### PR TITLE
Hide observer hud

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChromeLogic.cs
@@ -31,14 +31,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			r.GetWidget<ButtonWidget>("INGAME_OPTIONS_BUTTON").OnClick = () =>
 				optionsBG.Visible = !optionsBG.Visible;
 
-			optionsBG.GetWidget<ButtonWidget>("DISCONNECT").OnClick = () =>
-			{
-				optionsBG.Visible = false;
-				Game.Disconnect();
-				Game.LoadShellMap();
-				Widget.CloseWindow();
-				Widget.OpenWindow("MAINMENU_BG");
-			};
+			optionsBG.GetWidget<ButtonWidget>("DISCONNECT").OnClick = () => LeaveGame(optionsBG);
 
 			optionsBG.GetWidget<ButtonWidget>("SETTINGS").OnClick = () => Widget.OpenWindow("SETTINGS_MENU");
 			optionsBG.GetWidget<ButtonWidget>("MUSIC").OnClick = () => Widget.OpenWindow("MUSIC_MENU");

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChromeLogic.cs
@@ -44,16 +44,29 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			optionsBG.GetWidget<ButtonWidget>("MUSIC").OnClick = () => Widget.OpenWindow("MUSIC_MENU");
 			optionsBG.GetWidget<ButtonWidget>("RESUME").OnClick = () => optionsBG.Visible = false;
 
-			optionsBG.GetWidget<ButtonWidget>("SURRENDER").OnClick = () =>
+			optionsBG.GetWidget<ButtonWidget>("SURRENDER").OnClick = () => 
+			{
+				optionsBG.Visible = false;
 				world.IssueOrder(new Order("Surrender", world.LocalPlayer.PlayerActor, false));
+			};
+			
 			optionsBG.GetWidget("SURRENDER").IsVisible = () => (world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Undefined);
 
 			var postgameBG = gameRoot.GetWidget("POSTGAME_BG");
 			var postgameText = postgameBG.GetWidget<LabelWidget>("TEXT");
+			var postGameObserve = postgameBG.GetWidget<ButtonWidget>("POSTGAME_OBSERVE");
+
+			var postgameQuit = postgameBG.GetWidget<ButtonWidget>("POSTGAME_QUIT");
+			postgameQuit.OnClick = () => LeaveGame(postgameQuit);
+
+			postGameObserve.OnClick = () => postgameQuit.Visible = false;	
+			postGameObserve.IsVisible = () => world.LocalPlayer.WinState != WinState.Won;
+
 			postgameBG.IsVisible = () =>
 			{
-				return world.LocalPlayer != null && world.LocalPlayer.WinState != WinState.Undefined;
+				return postgameQuit.Visible && world.LocalPlayer != null && world.LocalPlayer.WinState != WinState.Undefined;
 			};
+
 
 			postgameText.GetText = () =>
 			{
@@ -61,6 +74,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				return state == WinState.Undefined ? "" :
 								(state == WinState.Lost ? "YOU ARE DEFEATED" : "YOU ARE VICTORIOUS");
 			};
+		}
+
+		void LeaveGame(Widget pane)
+		{
+			pane.Visible = false;
+			Game.Disconnect();
+			Game.LoadShellMap();
+			Widget.CloseWindow();
+			Widget.OpenWindow("MAINMENU_BG");
 		}
 
 		void UnregisterEvents()

--- a/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
@@ -23,7 +23,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var gameRoot = r.GetWidget("INGAME_ROOT");
 
 			var moneybin = gameRoot.GetWidget("INGAME_MONEY_BIN");
-
+			moneybin.IsVisible = () => {
+				return world.LocalPlayer.WinState == WinState.Undefined;
+			};
+			
 			var sell = moneybin.GetWidget<OrderButtonWidget>("SELL");
 			if (sell != null)
 			{

--- a/OpenRA.Mods.RA/Widgets/MoneyBinWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/MoneyBinWidget.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.RA.Widgets
 		public override void Draw()
 		{
 			if( world.LocalPlayer == null ) return;
+			if( world.LocalPlayer.WinState != WinState.Undefined ) return;
 
 			var digitCollection = "digits-" + world.LocalPlayer.Country.Race;
 			var chromeCollection = "chrome-" + world.LocalPlayer.Country.Race;

--- a/OpenRA.Mods.RA/Widgets/PowerBinWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/PowerBinWidget.cs
@@ -51,6 +51,7 @@ namespace OpenRA.Mods.RA.Widgets
 		public override void Draw()
 		{
 			if( world.LocalPlayer == null ) return;
+			if( world.LocalPlayer.WinState != WinState.Undefined ) return;
 
 			var radarBin = Widget.RootWidget.GetWidget<RadarBinWidget>(RadarBin);
 

--- a/OpenRA.Mods.RA/Widgets/RadarBinWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/RadarBinWidget.cs
@@ -131,7 +131,8 @@ namespace OpenRA.Mods.RA.Widgets
 		public override void Draw()
 		{
 			if( world == null || world.LocalPlayer == null ) return;
-
+			if( world.LocalPlayer.WinState != WinState.Undefined ) return;
+			
 			radarCollection = "radar-" + world.LocalPlayer.Country.Race;
 			var rsr = Game.Renderer.RgbaSpriteRenderer;
 			rsr.DrawSprite(ChromeProvider.GetImage(radarCollection, "left"), radarOrigin);

--- a/OpenRA.Mods.RA/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/RadarWidget.cs
@@ -124,7 +124,8 @@ namespace OpenRA.Mods.RA.Widgets
 		public override void Draw()
 		{
 			if (world == null) return;
-
+			if( world.LocalPlayer.WinState != WinState.Undefined ) return;
+			
 			var o = new float2(mapRect.Location.X, mapRect.Location.Y + world.Map.Bounds.Height * previewScale * (1 - radarMinimapHeight)/2);
 			var s = new float2(mapRect.Size.Width, mapRect.Size.Height*radarMinimapHeight);
 			var rsr = Game.Renderer.RgbaSpriteRenderer;

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -38,11 +38,26 @@ Container@INGAME_ROOT:
 				Label@TEXT:
 					Id:TEXT
 					X:(PARENT_RIGHT - WIDTH)/2
-					Y:(PARENT_BOTTOM - HEIGHT)/2
+					Y:0
 					Width:200
-					Height:40
+					Height:80
 					Align:Center
+				Button@POSTGAME_OBSERVE:
+					Id:POSTGAME_OBSERVE
+					X:10
+					Y:(PARENT_BOTTOM - HEIGHT - 10)
+					Width:150
+					Height:25
 					Font:Bold
+					Text:Observe
+				Button@POSTGAME_QUIT:
+					Id:POSTGAME_QUIT
+					X:(PARENT_RIGHT - WIDTH - 10)
+					Y:(PARENT_BOTTOM - HEIGHT - 10)
+					Width:150
+					Height:25
+					Font:Bold
+					Text:Leave
 		SupportPowerBin@INGAME_POWERS_BIN:
 			Id:INGAME_POWERS_BIN
 			X:0
@@ -346,11 +361,26 @@ Container@OBSERVER_ROOT:
 				Label@TEXT:
 					Id:TEXT
 					X:(PARENT_RIGHT - WIDTH)/2
-					Y:(PARENT_BOTTOM - HEIGHT)/2
+					Y:0
 					Width:200
-					Height:40
+					Height:80
 					Align:Center
+				Button@POSTGAME_OBSERVE:
+					Id:POSTGAME_OBSERVE
+					X:10
+					Y:(PARENT_BOTTOM - HEIGHT - 10)
+					Width:150
+					Height:25
 					Font:Bold
+					Text:Observe
+				Button@POSTGAME_QUIT:
+					Id:POSTGAME_QUIT
+					X:(PARENT_RIGHT - WIDTH - 10)
+					Y:(PARENT_BOTTOM - HEIGHT - 10)
+					Width:150
+					Height:25
+					Font:Bold
+					Text:Leave
 		SupportPowerBin@INGAME_POWERS_BIN:
 			Id:INGAME_POWERS_BIN
 			X:0


### PR DESCRIPTION
These commits change a few things that have bothered me while playing skirmishes against more than 1 other person, where I'm interested in watching the rest of the game as it unfolds.

I began by adding a choice of what to do upon defeat or surrender: Observe or Leave. When the user wins, only Leave will show up underneath the text. Regardless of what they select, much of the HUD disappears, as they don't need to see how much money they have left, or have access to the Sell, Powerdown or Repair buttons.
