### PR TITLE
Fix for weird aircraft bug

### DIFF
--- a/OpenRA.Mods.RA/Air/FlyAttack.cs
+++ b/OpenRA.Mods.RA/Air/FlyAttack.cs
@@ -46,10 +46,12 @@ namespace OpenRA.Mods.RA.Air
 
 		public override void Cancel( Actor self )
 		{
-			if( inner != null )
-				inner.Cancel( self );
+            if( !IsCanceled ) {
+		        if( inner != null )
+		            inner.Cancel( self );
 
-			base.Cancel( self );
+			    base.Cancel( self );
+		    }
 		}
 	}
 }


### PR DESCRIPTION
This small commit fixes an odd aircraft issue I ran into during a recent game. One of the players was attacking a small ground force with a Yak. The Yak kills a V2 right before it is shot down by a rocket soldier. However, the plane gets stuck in the game world, is unplayable, and is auto-targeted by any hostile forces that go near it.

After running through the replays, the exact cause is as follows:

(1) In the first tick, the Yak destroys the V2
(2) In the very next tick, the Yak itself is killed. The `FallToEarth` kill observer queues up the `FallToEarth` activity on the `FlyAttack` activity.
(3) The `Tick` method for `FlyAttack` is called. The target is no longer valid (and in our instance, the Yak was out of ammo), so the `Cancel` method is called on the `FlyAttack` activity. This sets `NextActivity` to null, effectively canceling the crash animation for the plane.

By simply checking to see if the activity has already been canceled, this can be avoided.
