### PR TITLE
Quicker unit production with multiple producers.

### DIFF
--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -256,8 +256,12 @@ namespace OpenRA.Mods.RA
 
 			if (self.World.LobbyInfo.GlobalSettings.AllowCheats && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild) return 0;
 			var cost = unit.Traits.Contains<ValuedInfo>() ? unit.Traits.Get<ValuedInfo>().Cost : 0;
+			
+			var selfsameBuildings = self.World.ActorsWithTrait<Production>().Where(p => p.Trait.Info.Produces.Contains(unit.Traits.Get<BuildableInfo>().Queue));
+			var speedUp = 1 - (selfsameBuildings.First().Trait.Info.SpeedUp  * (selfsameBuildings.Count() - 1)).Clamp(0, selfsameBuildings.First().Trait.Info.MaxSpeedUp);
+
 			var time = cost
-				* Info.BuildSpeed
+				* (Info.BuildSpeed * speedUp)
 				* (25 * 60) /* frames per min */				/* todo: build acceleration, if we do that */
 				 / 1000;
 			return (int) time;

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -257,12 +257,14 @@ namespace OpenRA.Mods.RA
 			if (self.World.LobbyInfo.GlobalSettings.AllowCheats && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild) return 0;
 			var cost = unit.Traits.Contains<ValuedInfo>() ? unit.Traits.Get<ValuedInfo>().Cost : 0;
 			
-			var selfsameBuildings = self.World.ActorsWithTrait<Production>().Where(p => p.Trait.Info.Produces.Contains(unit.Traits.Get<BuildableInfo>().Queue));
+			var selfsameBuildings = self.World.ActorsWithTrait<Production>()
+				.Where(p => p.Trait.Info.Produces.Contains(unit.Traits.Get<BuildableInfo>().Queue))
+				.Where(p => p.Actor.Owner == self.Owner);
 			var speedUp = 1 - (selfsameBuildings.First().Trait.Info.SpeedUp  * (selfsameBuildings.Count() - 1)).Clamp(0, selfsameBuildings.First().Trait.Info.MaxSpeedUp);
 
 			var time = cost
 				* (Info.BuildSpeed * speedUp)
-				* (25 * 60) /* frames per min */				/* todo: build acceleration, if we do that */
+				* (25 * 60) /* frames per min */
 				 / 1000;
 			return (int) time;
 		}

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -20,6 +20,8 @@ namespace OpenRA.Mods.RA
 	public class ProductionInfo : ITraitInfo
 	{
 		public readonly string[] Produces = { };
+		public readonly float SpeedUp = 0;
+		public readonly float MaxSpeedUp = 0;
 
 		public virtual object Create(ActorInitializer init) { return new Production(this); }
 	}

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -632,7 +632,6 @@ FACT:
 	CustomSellValue:
 		Value: 2500
 	BaseBuilding:
-	AllowsBuildingRepair:
 	Transforms:
 		IntoActor: mcv
 		Offset:1,1

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -111,6 +111,8 @@ SPEN:
 		ExitCell: 2,0
 	Production:
 		Produces: Ship
+		SpeedUp: 0.15
+		MaxSpeedUp: 0.45
 	PrimaryBuilding:
 	IronCurtainable:
 	-EmitInfantryOnSell:
@@ -166,6 +168,8 @@ SYRD:
 		ExitCell: 2,0
 	Production:
 		Produces: Ship
+		SpeedUp: 0.15
+		MaxSpeedUp: 0.45
 	PrimaryBuilding:
 	IronCurtainable:
 	-EmitInfantryOnSell:
@@ -599,6 +603,8 @@ WEAP:
 		ExitCell: 1,1
 	Production:
 		Produces: Vehicle
+		SpeedUp: 0.15
+		MaxSpeedUp: 0.45
 	PrimaryBuilding:
 	IronCurtainable:
 	ProductionBar:
@@ -626,6 +632,7 @@ FACT:
 	CustomSellValue:
 		Value: 2500
 	BaseBuilding:
+	AllowsBuildingRepair:
 	Transforms:
 		IntoActor: mcv
 		Offset:1,1
@@ -728,6 +735,8 @@ HPAD:
 		ExitCell: 0,0
 	Production:
 		Produces: Plane
+		SpeedUp: 0.15
+		MaxSpeedUp: 0.45
 	BelowUnits:
 	Reservable:
 	IronCurtainable:
@@ -762,6 +771,8 @@ AFLD:
 		Facing:192
 	Production:
 		Produces: Plane
+		SpeedUp: 0.15
+		MaxSpeedUp: 0.45
 	BelowUnits:
 	Reservable:
 	IronCurtainable:
@@ -879,6 +890,7 @@ BARR:
 	Tooltip:
 		Name: Soviet Barracks
 		Description: Produces infantry
+		
 	Building:
 		Power: -20
 		Footprint: xx xx
@@ -899,6 +911,8 @@ BARR:
 		ExitCell: 0,2
 	Production:
 		Produces: Infantry
+		SpeedUp: 0.15
+		MaxSpeedUp: 0.45
 	PrimaryBuilding:
 	IronCurtainable:
 	ProductionBar:
@@ -936,6 +950,8 @@ TENT:
 		ExitCell: 0,2
 	Production:
 		Produces: Infantry
+		SpeedUp: 0.15
+		MaxSpeedUp: 0.45
 	PrimaryBuilding:
 	IronCurtainable:
 	ProductionBar:


### PR DESCRIPTION
I am sure that the ActorsWithTrait call is wrong, but I couldn't dig up another way to do this. If applied, it will need lots of balancing, but my initial impression is that it will speed up cash rich endgames.
