### PR TITLE
Per-Player shrouds

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -43,6 +43,8 @@ namespace OpenRA
 				return HasLocation.PxPosition;
 			}
 		}
+		
+		public Shroud.ActorVisibility Sight;
 
 		[Sync]
 		public Player Owner;
@@ -85,6 +87,16 @@ namespace OpenRA
 				return (firstSprite.Sprite.size * firstSprite.Scale).ToInt2();
 			});
 
+			if(this.HasTrait<RevealsShroud>())
+			{
+				Sight = new Shroud.ActorVisibility
+				{
+					range = this.Trait<RevealsShroud>().RevealRange,
+					vis = Shroud.GetVisOrigins(this).ToArray()
+				};
+					
+			}
+			
 			ApplyIRender = x => x.Render(this);
 			ApplyRenderModifier = (m, p) => p.ModifyRender(this, m);
 
@@ -98,6 +110,11 @@ namespace OpenRA
 			ExtendedBounds.Invalidate();
 
 			currentActivity = Util.RunActivity( this, currentActivity );
+		}
+		
+		public void UpdateSight()
+		{
+			Sight.vis = Shroud.GetVisOrigins(this).ToArray();
 		}
 
 		public bool IsIdle

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -175,7 +175,6 @@ namespace OpenRA
 						{
 							++orderManager.LocalFrameNumber;
 
-							Log.Write("debug", "--Tick: {0} ({1})", LocalTick, isNetTick ? "net" : "local");
 
 							if (isNetTick) orderManager.Tick();
 

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Graphics
 
 				foreach (var t in world.ActorsWithTrait<IRadarSignature>())
 				{
-					if (!world.LocalShroud.IsVisible(t.Actor))
+					if (!world.RenderedShroud.IsVisible(t.Actor))
 						continue;
 
 					var color = t.Trait.RadarSignatureColor(t.Actor);
@@ -160,7 +160,7 @@ namespace OpenRA.Graphics
 			var map = world.Map;
 			var size = Exts.NextPowerOf2(Math.Max(map.Bounds.Width, map.Bounds.Height));
 			var bitmap = new Bitmap(size, size);
-			if (world.LocalShroud.Disabled)
+			if (world.RenderedShroud.Disabled)
 				return bitmap;
 
 			var bitmapData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height),
@@ -178,9 +178,9 @@ namespace OpenRA.Graphics
 					{
 						var mapX = x + map.Bounds.Left;
 						var mapY = y + map.Bounds.Top;
-						if (!world.LocalShroud.IsExplored(mapX, mapY))
+						if (!world.RenderedShroud.IsExplored(mapX, mapY))
 							*(c + (y * bitmapData.Stride >> 2) + x) = shroud;
-						else if (!world.LocalShroud.IsVisible(mapX,mapY))
+						else if (!world.RenderedShroud.IsVisible(mapX,mapY))
 							*(c + (y * bitmapData.Stride >> 2) + x) = fog;
 					}
 			}

--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -35,11 +35,6 @@ namespace OpenRA.Graphics
 
 			sprites = new Sprite[map.MapSize.X, map.MapSize.Y];
 			fogSprites = new Sprite[map.MapSize.X, map.MapSize.Y];
-			// this sets dirty whenever any player dirties it. 
-			// Obviously not what we want right now.
-			foreach(var x in world.ActorsWithTrait<Shroud>()){ 
-				x.Actor.Owner.Shroud.Dirty += () => dirty = true;
-			}
 		}
 
 		static readonly byte[][] SpecialShroudTiles =
@@ -113,9 +108,9 @@ namespace OpenRA.Graphics
 
 		internal void Draw( WorldRenderer wr )
 		{
-			if (dirty)
+			if (shroud != null && shroud.dirty)
 			{
-				dirty = false;
+				shroud.dirty = false;
 				for (int i = map.Bounds.Left; i < map.Bounds.Right; i++)
 					for (int j = map.Bounds.Top; j < map.Bounds.Bottom; j++)
 						sprites[i, j] = ChooseShroud(i, j);

--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -15,7 +15,13 @@ namespace OpenRA.Graphics
 {
 	public class ShroudRenderer
 	{
-		Traits.Shroud shroud;
+		World world;
+		Traits.Shroud shroud {
+			get {
+				return world.RenderedShroud;
+			}
+		}
+		
 		Sprite[] shadowBits = Game.modData.SpriteLoader.LoadAllSprites("shadow");
 		Sprite[,] sprites, fogSprites;
 
@@ -24,7 +30,7 @@ namespace OpenRA.Graphics
 
 		public ShroudRenderer(World world)
 		{
-			this.shroud = world.RenderedShroud;
+			this.world = world;
 			this.map = world.Map;
 
 			sprites = new Sprite[map.MapSize.X, map.MapSize.Y];

--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Graphics
 
 		public ShroudRenderer(World world)
 		{
-			this.shroud = world.LocalShroud;
+			this.shroud = world.RenderedShroud;
 			this.map = world.Map;
 
 			sprites = new Sprite[map.MapSize.X, map.MapSize.Y];

--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -35,7 +35,11 @@ namespace OpenRA.Graphics
 
 			sprites = new Sprite[map.MapSize.X, map.MapSize.Y];
 			fogSprites = new Sprite[map.MapSize.X, map.MapSize.Y];
-			shroud.Dirty += () => dirty = true;
+			// this sets dirty whenever any player dirties it. 
+			// Obviously not what we want right now.
+			foreach(var x in world.ActorsWithTrait<Shroud>()){ 
+				x.Actor.Owner.Shroud.Dirty += () => dirty = true;
+			}
 		}
 
 		static readonly byte[][] SpecialShroudTiles =

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -72,9 +72,9 @@ namespace OpenRA.Graphics
 			if (firstRow < 0) firstRow = 0;
 			if (lastRow > map.Bounds.Height) lastRow = map.Bounds.Height;
 
-			if (world.LocalPlayer != null && !world.LocalShroud.Disabled && world.LocalShroud.Bounds.HasValue)
+			if (world.LocalPlayer != null && !world.RenderedShroud.Disabled && world.RenderedShroud.Bounds.HasValue)
 			{
-				var r = world.LocalShroud.Bounds.Value;
+				var r = world.RenderedShroud.Bounds.Value;
 				if (firstRow < r.Top - map.Bounds.Top)
 					firstRow = r.Top - map.Bounds.Top;
 

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Graphics
 			if (firstRow < 0) firstRow = 0;
 			if (lastRow > map.Bounds.Height) lastRow = map.Bounds.Height;
 
-			if (world.LocalPlayer != null && !world.RenderedShroud.Disabled && world.RenderedShroud.Bounds.HasValue)
+			if (world.RenderedPlayer != null && !world.RenderedShroud.Disabled && world.RenderedShroud.Bounds.HasValue)
 			{
 				var r = world.RenderedShroud.Bounds.Value;
 				if (firstRow < r.Top - map.Bounds.Top)

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -202,7 +202,7 @@ namespace OpenRA.Graphics
 				cachedScroll = scrollPosition;
 			}
 
-			var b = world.LocalShroud.Bounds;
+			var b = world.RenderedShroud.Bounds;
 			return (b.HasValue) ? Rectangle.Intersect(cachedRect, b.Value) : cachedRect;
 		}
 	}

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -185,8 +185,7 @@ namespace OpenRA.Network
 		{
 			var oldStance = p.Stances[target];
 			p.Stances[target] = s;
-			if (target == w.LocalPlayer)
-				w.WorldActor.Trait<Shroud>().UpdatePlayerStance(w, p, oldStance, s);
+			target.Shroud.UpdatePlayerStance(w, p, oldStance, s);
 
 			foreach (var nsc in w.ActorsWithTrait<INotifyStanceChanged>())
 				nsc.Trait.StanceChanged(nsc.Actor, p, target, oldStance, s);

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -36,7 +36,7 @@ namespace OpenRA
 		public readonly PlayerReference PlayerReference;
 		public bool IsBot;
 
-		public Shroud Shroud { get { return World.LocalShroud; } }
+		public Shroud Shroud;
 		public World World { get; private set; }
 
 		static CountryInfo ChooseCountry(World world, string name)
@@ -76,7 +76,7 @@ namespace OpenRA
 				Country = ChooseCountry(world, pr.Race);
 			}
 			PlayerActor = world.CreateActor("Player", new TypeDictionary { new OwnerInit(this) });
-
+			Shroud = PlayerActor.Trait<Shroud>();
 			// Enable the bot logic on the host
 			IsBot = botType != null;
 			if (IsBot && Game.IsHost)

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -77,7 +77,7 @@ namespace OpenRA
 			}
 			PlayerActor = world.CreateActor("Player", new TypeDictionary { new OwnerInit(this) });
 			Shroud = PlayerActor.Trait<Shroud>();
-			Shroud.Owner = PlayerName;
+			Shroud.Owner = this;
 			// Enable the bot logic on the host
 			IsBot = botType != null;
 			if (IsBot && Game.IsHost)
@@ -89,6 +89,11 @@ namespace OpenRA
 				else
 					logic.Activate(this);
 			}
+		}
+
+		public override string ToString()
+		{
+			return PlayerName;
 		}
 
 		public void GiveAdvice(string advice)

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -68,7 +68,7 @@ namespace OpenRA
 			else
 			{
 				// Map player
-				ClientIndex = 0; // Owned by the host (todo: fix this)
+				ClientIndex = -1; // Owned by the host (todo: fix this)
 				ColorRamp = pr.ColorRamp;
 				PlayerName = pr.Name;
 				NonCombatant = pr.NonCombatant;

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -77,6 +77,7 @@ namespace OpenRA
 			}
 			PlayerActor = world.CreateActor("Player", new TypeDictionary { new OwnerInit(this) });
 			Shroud = PlayerActor.Trait<Shroud>();
+			Shroud.Owner = PlayerName;
 			// Enable the bot logic on the host
 			IsBot = botType != null;
 			if (IsBot && Game.IsHost)

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -118,7 +118,6 @@ namespace OpenRA.Traits
 				if( RemoveOnDeath )
 					self.Destroy();
 
-				Log.Write("debug", "{0} #{1} killed by {2} #{3}", self.Info.Name, self.ActorID, attacker.Info.Name, attacker.ActorID);
 			}
 		}
 

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Traits
 				case "DevGiveExploration":
 					{
 						if (self.World.LocalPlayer == self.Owner)
-							self.World.WorldActor.Trait<Shroud>().ExploreAll(self.World);
+							self.World.LocalPlayer.Shroud.ExploreAll(self.World);
 						break;
 					}
 				case "DevUnlimitedPower":

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Traits
 					{
 						DisableShroud ^= true;
 						if (self.World.LocalPlayer == self.Owner)
-							self.World.LocalShroud.Disabled = DisableShroud;
+							self.World.RenderedShroud.Disabled = DisableShroud;
 						break;
 					}
 				case "DevPathDebug":

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -30,11 +30,21 @@ namespace OpenRA.Traits
 		{
 			// todo: don't tick all the time.
 			World w = self.World;
+			if(self.Owner == null) return;
+			
 			if (previousLocation != self.Location)
 			{
 				previousLocation = self.Location;
-				foreach( var s in w.ActorsWithTrait<Shroud>() )
-					s.Actor.Owner.Shroud.UpdateActor(self);
+				var actors = w.ActorsWithTrait<Shroud>();
+
+				foreach( var s in actors )
+					s.Actor.Owner.Shroud.RemoveActor(self);
+					
+				self.UpdateSight();
+					
+				foreach( var s in actors )
+					s.Actor.Owner.Shroud.AddActor(self);
+				
 			}
 		}
 

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -29,11 +29,12 @@ namespace OpenRA.Traits
 		public void Tick(Actor self)
 		{
 			// todo: don't tick all the time.
-
+			World w = self.World;
 			if (previousLocation != self.Location)
 			{
 				previousLocation = self.Location;
-				self.World.WorldActor.Trait<Shroud>().UpdateActor(self);
+				foreach( var s in w.ActorsWithTrait<Shroud>() )
+					s.Actor.Owner.Shroud.UpdateActor(self);
 			}
 		}
 

--- a/OpenRA.Game/Traits/SelectionDecorations.cs
+++ b/OpenRA.Game/Traits/SelectionDecorations.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Traits
 
 		void DrawPips(WorldRenderer wr, Actor self, float2 basePosition)
 		{
-			if (self.Owner != self.World.LocalPlayer) return;
+			if (self.Owner != self.World.RenderedPlayer) return;
 
 			var pipSources = self.TraitsImplementing<IPips>();
 			if (pipSources.Count() == 0)
@@ -95,7 +95,7 @@ namespace OpenRA.Traits
 
 		void DrawTags(WorldRenderer wr, Actor self, float2 basePosition)
 		{
-			if (self.Owner != self.World.LocalPlayer) return;
+			if (self.Owner != self.World.RenderedPlayer) return;
 
 			// If a mod wants to implement a unit with multiple tags, then they are placed on multiple rows
 			var tagxyBase = basePosition + new float2(-16, 2); // Correct for the offset in the shp file

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Traits
 		Color RadarSignatureColor(Actor self);
 	}
 
-	public interface IVisibilityModifier { bool IsVisible(Actor self); }
+	public interface IVisibilityModifier { bool IsVisible(Shroud s, Actor self); }
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self); }
 	public interface IHasLocation { int2 PxPosition { get; } }
 

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Traits
 			for (int x = clip.Left; x < clip.Right; x++)
 				for (int y = clip.Top; y < clip.Bottom; y++)
 				{
-					if (!world.LocalShroud.IsExplored(new int2(x, y)))
+					if (!world.RenderedShroud.IsExplored(new int2(x, y)))
 						continue;
 
 					var c = content[x, y];

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Traits
 		Map map;
 		World world;
 
+		public string Owner;
 		public int[,] visibleCells;
 		public bool[,] exploredCells;
 		Rectangle? exploredBounds;

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -34,13 +34,13 @@ namespace OpenRA.Traits
 		public bool dirty = true;
 		public bool Disabled
 		{
-			get { return disabled || (world.LocalPlayer == null && Owner == null); }
+			get { return disabled; }
 			set { disabled = value; Dirty(); }
 		}
 
 		public bool Observing
 		{
-			get { return world.IsShellmap; }
+			get { return world.IsShellmap || (world.LocalPlayer == null && Owner == null);; }
 		}
 		
 		public Rectangle? Bounds

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -33,13 +33,13 @@ namespace OpenRA.Traits
 		bool observing = false;
 		public bool Disabled
 		{
-			get { return disabled; }
+			get { return disabled || (world.LocalPlayer == null && Owner == null); }
 			set { disabled = value; Dirty(); }
 		}
 
 		public bool Observing
 		{
-			get { return world.LocalPlayer == null; }
+			get { return world.LocalPlayer == null && Owner == null; }
 		}
 		
 		public Rectangle? Bounds

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -30,14 +30,18 @@ namespace OpenRA.Traits
 		public bool[,] exploredCells;
 		Rectangle? exploredBounds;
 		bool disabled = false;
+		bool observing = false;
 		public bool Disabled
 		{
-			get { return disabled || world.LocalPlayer == null; }
+			get { return disabled; }
 			set { disabled = value; Dirty(); }
 		}
-		
-		public bool dirty = false;
 
+		public bool Observing
+		{
+			get { return world.LocalPlayer == null; }
+		}
+		
 		public Rectangle? Bounds
 		{
 			get { return Disabled ? null : exploredBounds; }
@@ -85,7 +89,7 @@ namespace OpenRA.Traits
 		{
 			if (!a.HasTrait<RevealsShroud>())
 				return;
-			if (a.Owner == null || a.Owner.World.LocalPlayer == null) return;
+			if (a.Owner == null) return;
 
 			if(Owner != null && a.Owner != Owner && a.Owner.Stances[Owner] != Stance.Ally) return;
 
@@ -179,7 +183,7 @@ namespace OpenRA.Traits
 
 		public void UpdateActor(Actor a)
 		{
-			if (a.Owner == null || a.Owner.World.LocalPlayer == null) return;
+			if (a.Owner == null) return;
 
 			if(Owner != null && a.Owner != Owner && a.Owner.Stances[Owner] != Stance.Ally) return;
 
@@ -252,7 +256,7 @@ namespace OpenRA.Traits
 			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a)))
 				return false;
 
-			return Disabled || a.Owner == a.World.RenderedPlayer || GetVisOrigins(a).Any(o => IsExplored(o));
+			return Disabled || a.Owner == Owner || GetVisOrigins(a).Any(o => IsExplored(o));
 		}
 		
 		public bool IsTargetable(Actor a) {

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -254,5 +254,12 @@ namespace OpenRA.Traits
 
 			return Disabled || a.Owner == a.World.RenderedPlayer || GetVisOrigins(a).Any(o => IsExplored(o));
 		}
+		
+		public bool IsTargetable(Actor a) {
+			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a)))
+				return false;
+
+			return GetVisOrigins(a).Any(o => IsVisible(o));
+		}
 	}
 }

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Traits
 		Rectangle? exploredBounds;
 		bool disabled = false;
 		bool observing = false;
+		public bool dirty = true;
 		public bool Disabled
 		{
 			get { return disabled || (world.LocalPlayer == null && Owner == null); }
@@ -63,6 +64,7 @@ namespace OpenRA.Traits
 			exploredCells = new bool[map.MapSize.X, map.MapSize.Y];
 			world.ActorAdded += AddActor;
 			world.ActorRemoved += RemoveActor;
+			Dirty += () => dirty = true;
 		}
 
 		// cache of positions that were added, so no matter what crazy trait code does, it

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Traits
 
 		public bool Observing
 		{
-			get { return world.IsShellmap; }
+			get { return world.IsShellmap || world.RenderedPlayer == null; }
 		}
 		
 		public Rectangle? Bounds

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Traits
 			}
 
 			vis[a] = v;
-			Log.Write("debug", "Moved {1}'s {2} in Shroud {0} ({3})", Owner, a.Owner, a.Info.Name, Explored());
+			//Log.Write("debug", "Moved {1}'s {2} in Shroud {0} ({3})", Owner, a.Owner, a.Info.Name, Explored());
 			if (!Disabled)
 				Dirty();
 		}

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Traits
 
 		public bool Observing
 		{
-			get { return world.IsShellmap || world.RenderedPlayer == null; }
+			get { return world.IsShellmap; }
 		}
 		
 		public Rectangle? Bounds

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Traits
 		// cache of positions that were added, so no matter what crazy trait code does, it
 		// can't make us invalid.
 		class ActorVisibility { public int range; public int2[] vis; }
-		Dictionary<Actor, ActorVisibility> vis = new Dictionary<Actor, ActorVisibility>();
+		static Dictionary<Actor, ActorVisibility> vis = new Dictionary<Actor, ActorVisibility>();
 
 		static IEnumerable<int2> FindVisibleTiles(World world, int2 a, int r)
 		{
@@ -95,14 +95,15 @@ namespace OpenRA.Traits
 
 			if(Owner != null && a.Owner != Owner && a.Owner.Stances[Owner] != Stance.Ally) return;
 
-
+			ActorVisibility v = null;
 			if (vis.ContainsKey(a))
 			{
-				Game.Debug("Warning: Actor {0}:{1} at {2} bad vis".F(a.Info.Name, a.ActorID, a.Location));
-				RemoveActor(a);
+				v = vis[a];
+				//Game.Debug("Warning: Actor {0}:{1} at {2} bad vis".F(a.Info.Name, a.ActorID, a.Location));
+				//RemoveActor(a);
 			}
-
-			var v = new ActorVisibility
+			
+			v = new ActorVisibility
 			{
 				range = a.Trait<RevealsShroud>().RevealRange,
 				vis = GetVisOrigins(a).ToArray()
@@ -122,7 +123,7 @@ namespace OpenRA.Traits
 				exploredBounds = (exploredBounds.HasValue) ? Rectangle.Union(exploredBounds.Value, box) : box;
 			}
 
-			vis[a] = v;
+			if (!vis.ContainsKey(a)) vis[a] = v;
 			//Log.Write("debug", "Moved {1}'s {2} in Shroud {0} ({3})", Owner, a.Owner, a.Info.Name, Explored());
 			if (!Disabled)
 				Dirty();

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Widgets
 		IEnumerable<Actor> SelectActorsInBox(World world, int2 a, int2 b, Func<Actor, bool> cond)
 		{
 			return world.FindUnits(a, b)
-				.Where( x => x.HasTrait<Selectable>() && world.LocalShroud.IsVisible(x) && cond(x) )
+				.Where( x => x.HasTrait<Selectable>() && world.RenderedShroud.IsVisible(x) && cond(x) )
 				.GroupBy(x => x.GetSelectionPriority())
 				.OrderByDescending(g => g.Key)
 				.Select( g => g.AsEnumerable() )

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -54,8 +54,6 @@ namespace OpenRA
 			}
 		}
 		
-		public class ActorVisibility { public int range; public int2[] vis; }
-		public Dictionary<Actor, ActorVisibility> vis = new Dictionary<Actor, ActorVisibility>();
 
 		public void SetLocalPlayer(string pr)
 		{
@@ -152,7 +150,6 @@ namespace OpenRA
 		{
 			a.IsInWorld = true;
 			actors.Add(a);
-			Update(a);
 			ActorAdded(a);
 		}
 
@@ -161,18 +158,7 @@ namespace OpenRA
 			a.IsInWorld = false;
 			actors.Remove(a);
 			ActorRemoved(a);
-			if(vis.ContainsKey(a)) vis.Remove(a);
-		}
-		
-		public void Update(Actor a)
-		{
-			if (!a.HasTrait<RevealsShroud>()) return;
 			
-			vis[a] = new ActorVisibility
-			{
-				range = a.Trait<RevealsShroud>().RevealRange,
-				vis = Shroud.GetVisOrigins(a).ToArray()
-			};
 		}
 
 		public void Add(IEffect b) { effects.Add(b); }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -42,10 +42,17 @@ namespace OpenRA
 		public Player LocalPlayer { get; private set; }
 		public readonly Shroud LocalShroud;
 
+		public Player RenderedPlayer;
+		public Shroud RenderedShroud {
+			get {
+				return LocalShroud;
+			}
+		}
+
 		public void SetLocalPlayer(string pr)
 		{
 			if (!(orderManager.Connection is ReplayConnection))
-				LocalPlayer = Players.FirstOrDefault(p => p.InternalName == pr);
+	 			LocalPlayer = Players.FirstOrDefault(p => p.InternalName == pr);
 		}
 
 		public readonly Actor WorldActor;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -111,6 +111,7 @@ namespace OpenRA
 
 			WorldActor = CreateActor( "World", new TypeDictionary() );
 			LocalShroud = WorldActor.Trait<Shroud>();
+			LocalShroud.Disabled = true;
 			ActorMap = new ActorMap(this);
 
 			// Add players

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -45,7 +45,12 @@ namespace OpenRA
 		public Player RenderedPlayer;
 		public Shroud RenderedShroud {
 			get {
-				return LocalShroud;
+				if(RenderedPlayer == null)
+				{
+					return LocalShroud;
+				}else{
+					return RenderedPlayer.Shroud;
+				}
 			}
 		}
 
@@ -53,6 +58,8 @@ namespace OpenRA
 		{
 			if (!(orderManager.Connection is ReplayConnection))
 	 			LocalPlayer = Players.FirstOrDefault(p => p.InternalName == pr);
+				RenderedPlayer = LocalPlayer;
+				
 		}
 
 		public readonly Actor WorldActor;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -60,6 +60,8 @@ namespace OpenRA
 			{
 	 			LocalPlayer = Players.FirstOrDefault(p => p.InternalName == pr);
 				RenderedPlayer = LocalPlayer;
+			}else{
+				
 			}
 				
 		}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -111,8 +111,6 @@ namespace OpenRA
 
 			WorldActor = CreateActor( "World", new TypeDictionary() );
 			LocalShroud = WorldActor.Trait<Shroud>();
-			LocalShroud.Owner = "world";
-			LocalShroud.Disabled = true;
 			ActorMap = new ActorMap(this);
 
 			// Add players

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -57,8 +57,10 @@ namespace OpenRA
 		public void SetLocalPlayer(string pr)
 		{
 			if (!(orderManager.Connection is ReplayConnection))
+			{
 	 			LocalPlayer = Players.FirstOrDefault(p => p.InternalName == pr);
 				RenderedPlayer = LocalPlayer;
+			}
 				
 		}
 
@@ -111,7 +113,6 @@ namespace OpenRA
 
 			WorldActor = CreateActor( "World", new TypeDictionary() );
 			LocalShroud = WorldActor.Trait<Shroud>();
-			LocalShroud.Disabled = true;
 			ActorMap = new ActorMap(this);
 
 			// Add players

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -111,6 +111,8 @@ namespace OpenRA
 
 			WorldActor = CreateActor( "World", new TypeDictionary() );
 			LocalShroud = WorldActor.Trait<Shroud>();
+			LocalShroud.Owner = "world";
+			LocalShroud.Disabled = true;
 			ActorMap = new ActorMap(this);
 
 			// Add players

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -53,6 +53,9 @@ namespace OpenRA
 				}
 			}
 		}
+		
+		public class ActorVisibility { public int range; public int2[] vis; }
+		public Dictionary<Actor, ActorVisibility> vis = new Dictionary<Actor, ActorVisibility>();
 
 		public void SetLocalPlayer(string pr)
 		{
@@ -149,6 +152,7 @@ namespace OpenRA
 		{
 			a.IsInWorld = true;
 			actors.Add(a);
+			Update(a);
 			ActorAdded(a);
 		}
 
@@ -157,6 +161,18 @@ namespace OpenRA
 			a.IsInWorld = false;
 			actors.Remove(a);
 			ActorRemoved(a);
+			if(vis.ContainsKey(a)) vis.Remove(a);
+		}
+		
+		public void Update(Actor a)
+		{
+			if (!a.HasTrait<RevealsShroud>()) return;
+			
+			vis[a] = new ActorVisibility
+			{
+				range = a.Trait<RevealsShroud>().RevealRange,
+				vis = Shroud.GetVisOrigins(a).ToArray()
+			};
 		}
 
 		public void Add(IEffect b) { effects.Add(b); }

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -24,7 +24,7 @@ namespace OpenRA
 		public static IEnumerable<Actor> FindUnitsAtMouse(this World world, int2 mouseLocation)
 		{
 			var loc = Game.viewport.ViewToWorldPx(mouseLocation);
-			return FindUnits(world, loc, loc).Where(a => world.LocalShroud.IsVisible(a));
+			return FindUnits(world, loc, loc).Where(a => world.RenderedShroud.IsVisible(a));
 		}
 
 		public static IEnumerable<Actor> FindUnits(this World world, int2 a, int2 b)

--- a/OpenRA.Mods.RA/Activities/Attack.cs
+++ b/OpenRA.Mods.RA/Activities/Attack.cs
@@ -54,6 +54,9 @@ namespace OpenRA.Mods.RA.Activities
 			var facing = self.Trait<IFacing>();
 			if (!Target.IsValid)
 				return NextActivity;
+				
+			if (!self.Owner.HasFogVisibility() && Target.Actor != null && !self.Owner.Shroud.IsTargetable(Target.Actor))
+				return NextActivity;
 
 			if (targetable != null && !targetable.TargetableBy(Target.Actor, self))
 				return NextActivity;

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -116,6 +116,7 @@ namespace OpenRA.Mods.RA
 				.Where(a => a.AppearsHostileTo(self))
 				.Where(a => !a.HasTrait<AutoTargetIgnore>())
 				.Where(a => attack.HasAnyValidWeapons(Target.FromActor(a)))
+				//somethingsomethingvisible
 				.ClosestTo( self.CenterLocation );
 		}
 	}

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -112,12 +112,21 @@ namespace OpenRA.Mods.RA
 
 			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, (int)(Game.CellSize * range));
 
-			return inRange
-				.Where(a => a.AppearsHostileTo(self))
-				.Where(a => !a.HasTrait<AutoTargetIgnore>())
-				.Where(a => attack.HasAnyValidWeapons(Target.FromActor(a)))
-				.Where(a => self.Owner.Shroud.IsTargetable(a))
-				.ClosestTo( self.CenterLocation );
+			if (self.Owner.HasFogVisibility()) {
+				return inRange
+					.Where(a => a.AppearsHostileTo(self))
+					.Where(a => !a.HasTrait<AutoTargetIgnore>())
+					.Where(a => attack.HasAnyValidWeapons(Target.FromActor(a)))
+					.ClosestTo( self.CenterLocation );
+			}
+			else {
+				return inRange
+					.Where(a => a.AppearsHostileTo(self))
+					.Where(a => !a.HasTrait<AutoTargetIgnore>())
+					.Where(a => attack.HasAnyValidWeapons(Target.FromActor(a)))
+					.Where(a => self.Owner.Shroud.IsTargetable(a))
+					.ClosestTo( self.CenterLocation );
+			}
 		}
 	}
 

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.RA
 				.Where(a => a.AppearsHostileTo(self))
 				.Where(a => !a.HasTrait<AutoTargetIgnore>())
 				.Where(a => attack.HasAnyValidWeapons(Target.FromActor(a)))
-				//somethingsomethingvisible
+				.Where(a => self.Owner.Shroud.IsTargetable(a))
 				.ClosestTo( self.CenterLocation );
 		}
 	}

--- a/OpenRA.Mods.RA/Buildings/BibLayer.cs
+++ b/OpenRA.Mods.RA/Buildings/BibLayer.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.RA.Buildings
 			{
 				if (!cliprect.Contains(kv.Key.X, kv.Key.Y))
 					continue;
-				if (!world.LocalShroud.IsExplored(kv.Key))
+				if (!world.RenderedShroud.IsExplored(kv.Key))
 					continue;
 
 				bibSprites[kv.Value.type - 1][kv.Value.index].DrawAt( wr,

--- a/OpenRA.Mods.RA/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Chronoshiftable.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA
 			// Todo: Allow enemy units to be chronoshifted into bad terrain to kill them
 			return self.HasTrait<ITeleportable>() &&
 				self.Trait<ITeleportable>().CanEnterCell(targetLocation) &&
-				(ignoreVis || self.World.RenderedShroud.IsExplored(targetLocation));
+				(ignoreVis || self.Owner.Shroud.IsExplored(targetLocation));
 		}
 
 		public virtual bool Teleport(Actor self, int2 targetLocation, int duration, bool killCargo, Actor chronosphere)

--- a/OpenRA.Mods.RA/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Chronoshiftable.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA
 			// Todo: Allow enemy units to be chronoshifted into bad terrain to kill them
 			return self.HasTrait<ITeleportable>() &&
 				self.Trait<ITeleportable>().CanEnterCell(targetLocation) &&
-				(ignoreVis || self.World.LocalShroud.IsExplored(targetLocation));
+				(ignoreVis || self.World.RenderedShroud.IsExplored(targetLocation));
 		}
 
 		public virtual bool Teleport(Actor self, int2 targetLocation, int duration, bool killCargo, Actor chronosphere)

--- a/OpenRA.Mods.RA/Cloak.cs
+++ b/OpenRA.Mods.RA/Cloak.cs
@@ -85,7 +85,6 @@ namespace OpenRA.Mods.RA
 		public bool IsVisible(Actor self)
 		{
 			if (!Cloaked || self.Owner == self.World.LocalPlayer ||
-				self.World.LocalPlayer == null ||
 				self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)
 				return true;
 

--- a/OpenRA.Mods.RA/Cloak.cs
+++ b/OpenRA.Mods.RA/Cloak.cs
@@ -81,8 +81,13 @@ namespace OpenRA.Mods.RA
 				if (--remainingTime <= 0)
 					Sound.Play(info.CloakSound, self.CenterLocation);
 		}
-
+		
 		public bool IsVisible(Actor self)
+		{
+			return IsVisible(null, self);
+		}
+
+		public bool IsVisible(Shroud s, Actor self)
 		{
 			if (!Cloaked || self.Owner == self.World.LocalPlayer ||
 				self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)

--- a/OpenRA.Mods.RA/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.RA/ConquestVictoryConditions.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.RA
 
 			if (self.Owner == self.World.LocalPlayer)
 			{
-				self.World.LocalShroud.Disabled = true;
+				self.World.RenderedShroud.Disabled = true;
 				Game.RunAfterDelay(Info.NotificationDelay, () =>
 				{
 					if (Game.IsCurrentWorld(self.World))
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.RA
 			Game.Debug("{0} is victorious.".F(self.Owner.PlayerName));
 			if (self.Owner == self.World.LocalPlayer)
 			{
-				self.World.LocalShroud.Disabled = true;
+				self.World.RenderedShroud.Disabled = true;
 				Game.RunAfterDelay(Info.NotificationDelay, () => Sound.Play(Info.WinNotification));
 			}
 		}

--- a/OpenRA.Mods.RA/Crates/HideMapCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/HideMapCrateAction.cs
@@ -25,8 +25,7 @@ namespace OpenRA.Mods.RA
 		public override int GetSelectionShares (Actor collector)
 		{
 			// don't ever hide the map for people who have GPS.
-			var gpsWatcher = collector.Owner.PlayerActor.TraitOrDefault<GpsWatcher>();
-			if (gpsWatcher != null && (gpsWatcher.Granted || gpsWatcher.GrantedAllies))
+			if (collector.Owner.HasFogVisibility())
 				return 0;
 
 			return base.GetSelectionShares (collector);

--- a/OpenRA.Mods.RA/Crates/HideMapCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/HideMapCrateAction.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA
 		{
 			base.Activate(collector);
 			if (collector.Owner == collector.World.LocalPlayer)
-				collector.World.WorldActor.Trait<Shroud>().ResetExploration();
+				collector.Owner.Shroud.ResetExploration();
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/RevealMapCrateAction.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA
 			base.Activate(collector);
 
 			if (ShouldReveal( collector.Owner ))
-				collector.World.WorldActor.Trait<Shroud>().ExploreAll(collector.World);
+				collector.Owner.Shroud.ExploreAll(collector.World);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/Bullet.cs
+++ b/OpenRA.Mods.RA/Effects/Bullet.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.RA.Effects
 				var altitude = float2.Lerp(Args.srcAltitude, Args.destAltitude, at);
 				var pos = float2.Lerp(Args.src, Args.dest, at) - new float2(0, altitude);
 
-				if (Args.firedBy.World.LocalShroud.IsVisible(OpenRA.Traits.Util.CellContaining(pos)))
+				if (Args.firedBy.World.RenderedShroud.IsVisible(OpenRA.Traits.Util.CellContaining(pos)))
 				{
 					if (Info.High || Info.Angle > 0)
 					{

--- a/OpenRA.Mods.RA/Effects/Contrail.cs
+++ b/OpenRA.Mods.RA/Effects/Contrail.cs
@@ -93,8 +93,8 @@ namespace OpenRA.Mods.RA
 				var conPos = positions[i];
 				var nextPos = positions[i - 1];
 
-				if (self.World.LocalShroud.IsVisible(OpenRA.Traits.Util.CellContaining(conPos)) ||
-					self.World.LocalShroud.IsVisible(OpenRA.Traits.Util.CellContaining(nextPos)))
+				if (self.World.RenderedShroud.IsVisible(OpenRA.Traits.Util.CellContaining(conPos)) ||
+					self.World.RenderedShroud.IsVisible(OpenRA.Traits.Util.CellContaining(nextPos)))
 				{
 					Game.Renderer.WorldLineRenderer.DrawLine(conPos, nextPos, trailStart, trailEnd);
 

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (
 				self.IsInWorld
 				&& (watcher.Granted || watcher.GrantedAllies)
-				&& !self.Trait<HiddenUnderFog>().IsVisible(self)
+				&& !self.Trait<HiddenUnderFog>().IsVisible(self.World.RenderedShroud, self) // WRONG
 				&& (!self.HasTrait<Cloak>() || !self.Trait<Cloak>().Cloaked)
 				)
 			{

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<Renderable> Render()
 		{
-			if (Args.firedBy.World.LocalShroud.IsVisible(OpenRA.Traits.Util.CellContaining(PxPosition.ToFloat2())))
+			if (Args.firedBy.World.RenderedShroud.IsVisible(OpenRA.Traits.Util.CellContaining(PxPosition.ToFloat2())))
 				yield return new Renderable(anim.Image,PxPosition.ToFloat2() - 0.5f * anim.Image.size - new float2(0, Altitude),
 					Args.weapon.Underwater ? "shadow" : "effect", PxPosition.Y);
 

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.RA
 			public bool CanTargetLocation(Actor self, int2 location, List<Actor> actorsAtLocation, bool forceAttack, bool forceQueued, ref string cursor)
 			{
 				// Don't leak info about resources under the shroud
-				if (!self.World.LocalShroud.IsExplored(location)) return false;
+				if (!self.World.RenderedShroud.IsExplored(location)) return false;
 
 				var res = self.World.WorldActor.Trait<ResourceLayer>().GetResource( location );
 				var info = self.Info.Traits.Get<HarvesterInfo>();

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.RA
 			public bool CanTargetLocation(Actor self, int2 location, List<Actor> actorsAtLocation, bool forceAttack, bool forceQueued, ref string cursor)
 			{
 				// Don't leak info about resources under the shroud
-				if (!self.World.RenderedShroud.IsExplored(location)) return false;
+				if (!self.Owner.Shroud.IsExplored(location)) return false;
 
 				var res = self.World.WorldActor.Trait<ResourceLayer>().GetResource( location );
 				var info = self.Info.Traits.Get<HarvesterInfo>();

--- a/OpenRA.Mods.RA/InvisibleToEnemy.cs
+++ b/OpenRA.Mods.RA/InvisibleToEnemy.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA
 
 	class InvisibleToEnemy : IRenderModifier, IVisibilityModifier, IRadarColorModifier
 	{
-		public bool IsVisible(Actor self)
+		public bool IsVisible(Shroud s, Actor self)
 		{
 			return self.Owner == self.World.LocalPlayer;
 		}

--- a/OpenRA.Mods.RA/InvisibleToEnemy.cs
+++ b/OpenRA.Mods.RA/InvisibleToEnemy.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 	{
 		public bool IsVisible(Actor self)
 		{
-			return self.World.LocalPlayer == null || self.Owner == self.World.LocalPlayer;
+			return self.Owner == self.World.LocalPlayer;
 		}
 
 		public Color RadarColorOverride(Actor self)

--- a/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
@@ -18,15 +18,15 @@ namespace OpenRA.Mods.RA
 
 	class FrozenUnderFog : IRenderModifier, IVisibilityModifier
 	{
-		public bool IsVisible(Actor self)
+		public bool IsVisible(Shroud s, Actor self)
 		{
-			return Shroud.GetVisOrigins(self).Any(o => self.Owner.Shroud.IsVisible(o));
+			return Shroud.GetVisOrigins(self).Any(o => s.IsVisible(o));
 		}
 
 		Renderable[] cache = { };
 		public IEnumerable<Renderable> ModifyRender(Actor self, IEnumerable<Renderable> r)
 		{
-			if (IsVisible(self))
+			if (IsVisible(self.World.RenderedShroud, self))
 				cache = r.ToArray();
 			return cache;
 		}

--- a/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 	{
 		public bool IsVisible(Actor self)
 		{
-			return Shroud.GetVisOrigins(self).Any(o => self.World.LocalShroud.IsVisible(o));
+			return Shroud.GetVisOrigins(self).Any(o => self.World.RenderedShroud.IsVisible(o));
 		}
 
 		Renderable[] cache = { };

--- a/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 	{
 		public bool IsVisible(Actor self)
 		{
-			return Shroud.GetVisOrigins(self).Any(o => self.World.RenderedShroud.IsVisible(o));
+			return Shroud.GetVisOrigins(self).Any(o => self.Owner.Shroud.IsVisible(o));
 		}
 
 		Renderable[] cache = { };

--- a/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
@@ -18,15 +18,15 @@ namespace OpenRA.Mods.RA
 
 	class HiddenUnderFog : IRenderModifier, IVisibilityModifier
 	{
-		public bool IsVisible(Actor self)
+		public bool IsVisible(Shroud s, Actor self)
 		{
-			return Shroud.GetVisOrigins(self).Any(o => self.Owner.Shroud.IsVisible(o));
+			return Shroud.GetVisOrigins(self).Any(o => s.IsVisible(o));
 		}
 
 		static Renderable[] Nothing = { };
 		public IEnumerable<Renderable> ModifyRender(Actor self, IEnumerable<Renderable> r)
 		{
-			return IsVisible(self) ? r : Nothing;
+			return IsVisible(self.World.RenderedShroud, self) ? r : Nothing;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 	{
 		public bool IsVisible(Actor self)
 		{
-			return Shroud.GetVisOrigins(self).Any(o => self.World.LocalShroud.IsVisible(o));
+			return Shroud.GetVisOrigins(self).Any(o => self.World.RenderedShroud.IsVisible(o));
 		}
 
 		static Renderable[] Nothing = { };

--- a/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 	{
 		public bool IsVisible(Actor self)
 		{
-			return Shroud.GetVisOrigins(self).Any(o => self.World.RenderedShroud.IsVisible(o));
+			return Shroud.GetVisOrigins(self).Any(o => self.Owner.Shroud.IsVisible(o));
 		}
 
 		static Renderable[] Nothing = { };

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -441,7 +441,7 @@ namespace OpenRA.Mods.RA.Move
 			{
 				IsQueued = forceQueued;
 				cursor = "move";
-				if (!self.World.Map.IsInMap(location) || (self.World.LocalPlayer.Shroud.IsExplored(location) &&
+				if (!self.World.Map.IsInMap(location) || (self.Owner.Shroud.IsExplored(location) &&
 						unitType.MovementCostForCell(self.World, location) == int.MaxValue))
 					cursor = "move-blocked";
 

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -87,8 +87,6 @@ namespace OpenRA.Mods.RA.Move
 		{
 			var path = getPath(self, mobile).TakeWhile(a => a != mobile.toCell).ToList();
 			mobile.PathHash = HashList(path);
-			Log.Write("debug", "EvalPathHash #{0} {1}",
-				self.ActorID, mobile.PathHash);
 			return path;
 		}
 

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Player\ProductionQueue.cs" />
     <Compile Include="Player\SurrenderOnDisconnect.cs" />
     <Compile Include="Player\TechTree.cs" />
+    <Compile Include="PlayerExts.cs" />
     <Compile Include="PrimaryBuilding.cs" />
     <Compile Include="Production.cs" />
     <Compile Include="ProductionBar.cs" />

--- a/OpenRA.Mods.RA/PlayerExts.cs
+++ b/OpenRA.Mods.RA/PlayerExts.cs
@@ -1,0 +1,25 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public static class PlayerExts
+	{
+		public static bool HasFogVisibility( this Player a )
+		{
+		    var gpsWatcher = a.PlayerActor.TraitOrDefault<GpsWatcher>();
+			return gpsWatcher != null && (gpsWatcher.Granted || gpsWatcher.GrantedAllies);
+		}
+
+	}
+}

--- a/OpenRA.Mods.RA/ProductionBar.cs
+++ b/OpenRA.Mods.RA/ProductionBar.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA
 		public float GetValue()
 		{
 			// only people we like should see our production status.
-			if (self.World.LocalPlayer != null && self.Owner.Stances[self.World.LocalPlayer] != Stance.Ally)
+			if (self.World.RenderedPlayer != null && self.Owner.Stances[self.World.RenderedPlayer] != Stance.Ally)
 				return 0;
 
 			var queue = self.TraitsImplementing<ProductionQueue>().FirstOrDefault(q => q.CurrentItem() != null);

--- a/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.RA
 					var altitude = new int2(0, move.Altitude);
 					position = (self.CenterLocation - Combat.GetTurretPosition(self, facing, smokeTurret)).ToInt2();
 
-					if (self.World.LocalShroud.IsVisible(Util.CellContaining(position)))
+					if (self.World.RenderedShroud.IsVisible(Util.CellContaining(position)))
 						self.World.AddFrameEndTask(
 							w => w.Add(new Smoke(w, position - altitude, "smokey")));
 				}

--- a/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
@@ -62,9 +62,6 @@ namespace OpenRA.Mods.RA
 			foreach (TraitPair<GpsWatcher> i in atek.World.ActorsWithTrait<GpsWatcher>())
 				i.Trait.RefreshGranted();
 
-			if (atek.World.LocalPlayer == null)
-				return;
-
 			if ((Granted || GrantedAllies) && (atek.World.LocalPlayer.Stances[atek.Owner] == Stance.Ally))
 				atek.Owner.Shroud.ExploreAll(atek.World);
 		}
@@ -74,6 +71,9 @@ namespace OpenRA.Mods.RA
 			Granted = (actors.Count > 0 && Launched);
 			GrantedAllies = owner.World.ActorsWithTrait<GpsWatcher>().Any(p =>
 					p.Actor.Owner.Stances[owner] == Stance.Ally && p.Trait.Granted);
+					
+			if (Granted || GrantedAllies)
+				owner.Shroud.ExploreAll(owner.World);
 		}
 	}
 

--- a/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA
 		public void RefreshGps(Actor atek)
 		{
 			RefreshGranted();
-
+			
 			foreach (TraitPair<GpsWatcher> i in atek.World.ActorsWithTrait<GpsWatcher>())
 				i.Trait.RefreshGranted();
 
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.RA
 				return;
 
 			if ((Granted || GrantedAllies) && (atek.World.LocalPlayer.Stances[atek.Owner] == Stance.Ally))
-				atek.World.WorldActor.Trait<Shroud>().ExploreAll(atek.World);
+				atek.Owner.Shroud.ExploreAll(atek.World);
 		}
 
 		void RefreshGranted()

--- a/OpenRA.Mods.RA/Widgets/Logic/ObserveAsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ObserveAsLogic.cs
@@ -1,0 +1,58 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.FileFormats.Graphics;
+using OpenRA.GameRules;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.RA.Widgets.Logic
+{
+	public class ObserveAsLogic
+	{
+		[ObjectCreator.UseCtor]
+		public ObserveAsLogic(World world)
+		{
+			var r = Widget.RootWidget;
+			var gameRoot = r.GetWidget("OBSERVER_ROOT");
+			if(gameRoot == null) { 
+				gameRoot = r.GetWidget("INGAME_ROOT");
+			}
+			var selector = gameRoot.GetWidget<DropDownButtonWidget>("OBSERVEAS_DROPDOWN");
+			
+			selector.OnMouseDown = _ => ShowWindowModeDropdown(selector, world);
+		}
+		
+		public static bool ShowWindowModeDropdown(DropDownButtonWidget selector, World world)
+		{
+			/**
+				Select all the 'active' players in this world and push them into a dictionary
+				using their name as a key.
+			**/
+			var options = world.Players.Where(a => !a.NonCombatant).ToDictionary(p => p.PlayerName);
+			options.Add("[Global View]", null);
+			
+			// This Func tells each option how to conduct itself: text & actions
+			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
+			{
+				// params: dropdown id, "selected", "onclick action"
+				var s = (options[o] == null) ? null : options[o];
+				var item = ScrollItemWidget.Setup(itemTemplate, () => world.RenderedPlayer == s, () => { world.RenderedPlayer = s; world.RenderedShroud.Jank(); } );
+				item.GetWidget<LabelWidget>("LABEL").GetText = () => o;
+				return item;
+			};
+			
+			selector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+			return true;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -169,15 +169,15 @@ namespace OpenRA.Mods.RA.Widgets
 		
 		bool PerformViewCycle()
 		{
-			var shrouds = World.ActorsWithTrait<Traits.Shroud>().Select(a => a.Actor.Owner).Distinct();
+			var shrouds = World.ActorsWithTrait<Traits.Shroud>().Select(a => a.Actor.Owner).Where(a => a.ClientIndex >= 0).Distinct();
 			var next = shrouds.SkipWhile( a => a.Shroud != World.RenderedShroud ).Skip(1).FirstOrDefault();
 			if(next == null) 
 			{
-				next = shrouds.First();
+				next = (World.RenderedPlayer == null) ? shrouds.First() : null;
 			}
 			World.RenderedPlayer = next;
 			World.RenderedShroud.Jank();
-			Game.Debug("Viewing through {0}".F(World.RenderedPlayer));
+			Game.Debug("Viewing through {0}".F( (World.RenderedPlayer == null) ? "Observer" : World.RenderedPlayer.ToString() ) );
 			return true;
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.RA.Widgets
 		
 		bool PerformViewCycle()
 		{
-			/**
+			if(World.LocalPlayer != null) return true;
 			var shrouds = World.ActorsWithTrait<Traits.Shroud>().Select(a => a.Actor.Owner).Where(a => a.ClientIndex >= 0).Distinct();
 			var next = shrouds.SkipWhile( a => a.Shroud != World.RenderedShroud ).Skip(1).FirstOrDefault();
 			if(next == null) 
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.RA.Widgets
 			World.RenderedPlayer = next;
 			World.RenderedShroud.Jank();
 			Game.Debug("Viewing through {0}".F( (World.RenderedPlayer == null) ? "Observer" : World.RenderedPlayer.ToString() ) );
-			**/
+			
 			return true;
 			
 		}

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.RA.Widgets
 		public string DeployKey = "f";
 		public string StanceCycleKey = "z";
 		public string BaseCycleKey = "backspace";
+		public string ViewCycleKey = "v";
 		public readonly OrderManager OrderManager;
 
 		[ObjectCreator.UseCtor]
@@ -51,6 +52,9 @@ namespace OpenRA.Mods.RA.Widgets
 			{
 				if (e.KeyName == BaseCycleKey)
 					return CycleBases();
+					
+				if (e.KeyName == ViewCycleKey)
+					return PerformViewCycle();
 
 				if (!World.Selection.Actors.Any())
 					return false;
@@ -160,6 +164,19 @@ namespace OpenRA.Mods.RA.Widgets
 
 			World.Selection.Combine(World, new Actor[] { next }, false, true);
 			Game.viewport.Center(World.Selection.Actors);
+			return true;
+		}
+		
+		bool PerformViewCycle()
+		{
+			var shrouds = World.ActorsWithTrait<Traits.Shroud>().Select(a => a.Actor.Owner).Distinct();
+			var next = shrouds.SkipWhile( a => a.Shroud != World.RenderedShroud ).Skip(1).FirstOrDefault();
+			if(next == null) 
+			{
+				next = shrouds.First();
+			}
+			World.RenderedPlayer = next;
+			Game.Debug("Viewing through {0}".F(World.RenderedPlayer.InternalName));
 			return true;
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -41,7 +41,6 @@ namespace OpenRA.Mods.RA.Widgets
 		public override bool HandleKeyPress(KeyInput e)
 		{
 			if (World == null) return false;
-			if (World.LocalPlayer == null) return false;
 
 			return ProcessInput(e);
 		}
@@ -169,6 +168,7 @@ namespace OpenRA.Mods.RA.Widgets
 		
 		bool PerformViewCycle()
 		{
+			/**
 			var shrouds = World.ActorsWithTrait<Traits.Shroud>().Select(a => a.Actor.Owner).Where(a => a.ClientIndex >= 0).Distinct();
 			var next = shrouds.SkipWhile( a => a.Shroud != World.RenderedShroud ).Skip(1).FirstOrDefault();
 			if(next == null) 
@@ -178,7 +178,9 @@ namespace OpenRA.Mods.RA.Widgets
 			World.RenderedPlayer = next;
 			World.RenderedShroud.Jank();
 			Game.Debug("Viewing through {0}".F( (World.RenderedPlayer == null) ? "Observer" : World.RenderedPlayer.ToString() ) );
+			**/
 			return true;
+			
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -176,7 +176,8 @@ namespace OpenRA.Mods.RA.Widgets
 				next = shrouds.First();
 			}
 			World.RenderedPlayer = next;
-			Game.Debug("Viewing through {0}".F(World.RenderedPlayer.InternalName));
+			World.RenderedShroud.Jank();
+			Game.Debug("Viewing through {0}".F(World.RenderedPlayer));
 			return true;
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/WorldTooltipWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldTooltipWidget.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Widgets
 			var cell = Game.viewport.ViewToWorld(Viewport.LastMousePos).ToInt2();
 			if (!world.Map.IsInMap(cell)) return;
 
-			if (world.LocalPlayer != null && !world.LocalPlayer.Shroud.IsExplored(cell))
+			if (world.LocalPlayer != null && !world.RenderedShroud.IsExplored(cell))
 			{
 				var utext = "Unexplored Terrain";
 				var usz = Game.Renderer.Fonts["Bold"].Measure(utext) + new int2(20, 24);

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.RA
 			{
 				if (!cliprect.Contains(kv.Key.X,kv.Key.Y))
 					continue;
-				if (localPlayer != null && !localPlayer.Shroud.IsExplored(kv.Key))
+				if (localPlayer != null && !world.RenderedShroud.IsExplored(kv.Key))
 					continue;
 
 				smudgeSprites[kv.Value.type- 1][kv.Value.index].DrawAt( wr,

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -354,6 +354,15 @@ Container@OBSERVER_ROOT:
 			Id:GAME_TIMER
 			X: WINDOW_RIGHT/2
 			Y: 0-10
+		DropDownButton@OBSERVEAS_DROPDOWN:
+			Id:OBSERVEAS_DROPDOWN
+			Logic:ObserveAsLogic
+			X:0
+			Y:27
+			Width:160
+			Height:25
+			Font:Regular
+			Text:Observer
 		Background@POSTGAME_BG:
 			Id:POSTGAME_BG
 			X:(WINDOW_RIGHT - WIDTH)/2

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -335,6 +335,11 @@ Container@OBSERVER_ROOT:
 	Visible:true
 	Logic:IngameObserverChromeLogic
 	Children:
+		WorldCommand:
+			X:0
+			Y:0
+			Width:WINDOW_RIGHT
+			Height:WINDOW_BOTTOM
 		WorldInteractionController:
 			X:0
 			Y:0

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -135,6 +135,7 @@ Player:
 	DebugResourceOre:
 	DebugResourceOreCapacity:
 	GpsWatcher:
+	Shroud:
 
 World:	
 	OpenWidgetAtGameStart:

--- a/mods/ra/sequences.yaml
+++ b/mods/ra/sequences.yaml
@@ -1026,7 +1026,7 @@ t15:
 		Start: 0
 	burn:
 		Start: 1
-		Length: 10
+		Length: 9
 
 t14:
 	idle:
@@ -1054,7 +1054,7 @@ t11:
 		Start: 0
 	burn:
 		Start: 1
-		Length: 10
+		Length: 9
 
 t10:
 	idle:


### PR DESCRIPTION
These commits should serve as a starting point for per-user shroud coverage and associated unit logic. 
First, it creates a distinction between the shroud that is being rendered, and the shroud that the local player is using, which will enable future work on observers and replays. 

Furthermore, it changes how unit targeting works by limiting units' ability to fire to only those things that they (or an Allied player) have vision of. This, in practice, greatly changes how V2s, Artillery, Cruisers and other long-range weapons work, as the targets a player wishes to attack will have to be scouted with units like Jeeps.

For debugging purposes, it adds a new hotkey during replays: "v" will cycle between players' views. Multiple games have been played with this patch with no sync errors or crashes while watching replays and cycling through views. 
