### PR TITLE
Fixed one dead arty killing an endless chain of arty.

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -205,6 +205,8 @@ ARTY:
 		PrimaryWeapon: 155mm
 	RenderUnit:
 	Explodes:
+		Weapon: UnitExplode
+		Chance: 75  
 	AutoTarget:
 
 HARV:


### PR DESCRIPTION
When an arty in a group of them dies, each individual arty only has a 75% chance (down from 100%) of perpetuating the genocide of arty.... so usually, it'll stop before killing your whole line but not before seriously hurting it.
