### PR TITLE
Make the hidden pillboxes actually hidden.

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -416,6 +416,11 @@ HBOX:
 		Type: Wood
 	RevealsShroud:
 		Range: 6
+	Cloak:
+		InitialDelay: 125
+		CloakDelay: 125
+		CloakSound: appear1.aud
+		UncloakSound: appear1.aud
 	AttackTurreted:
 		PrimaryWeapon: Vulcan
 		PrimaryLocalOffset: 0,-11,0,0,0


### PR DESCRIPTION
Make ra "hidden pillbox" have the same "stealthed until firing" ability as the cnc Stealth Tank... Now there's a reason for them to be 50% more expensive.
