### PR TITLE
cnc - made selection bounds of helicopters a bit smaller

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -11,6 +11,8 @@ TRAN:
 		Prerequisites: hpad
 		BuiltAt: hpad
 		Owner: gdi,nod
+	Selectable:
+		Bounds: 40,40
 	Helicopter:
 		LandWhenIdle: true
 		ROT: 5
@@ -49,6 +51,8 @@ HELI:
 		Prerequisites: hpad, hq
 		BuiltAt: hpad
 		Owner: nod
+	Selectable:
+		Bounds: 30,24
 	Helicopter:
 		ROT: 4
 		Speed: 20
@@ -93,6 +97,8 @@ ORCA:
 		Prerequisites: hpad, hq
 		BuiltAt: hpad
 		Owner: gdi
+	Selectable:
+		Bounds: 30,24
 	Helicopter:
 		ROT: 4
 		Speed: 20


### PR DESCRIPTION
made selection bounds of Chinook, Apache and Orca a bit smaller since they extend quite far beyond their typical size, and it can be problematic to select units next to them without also selecting the chopper. I reduced the size of the selection bounds just enough to make it easier to select units right beside them, but not so that they're too small for the size of the unit.
Chinook can't really go below 40 px, since that's the size required to display its 10 passenger pips.
