### PR TITLE
cnc - made helicopter selection bounds a bit smaller

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -11,6 +11,8 @@ TRAN:
 		Prerequisites: hpad
 		BuiltAt: hpad
 		Owner: gdi,nod
+	Selectable:
+		Bounds: 41,41
 	Helicopter:
 		LandWhenIdle: true
 		ROT: 5
@@ -49,6 +51,8 @@ HELI:
 		Prerequisites: hpad, hq
 		BuiltAt: hpad
 		Owner: nod
+	Selectable:
+		Bounds: 30,24
 	Helicopter:
 		ROT: 4
 		Speed: 20
@@ -93,6 +97,8 @@ ORCA:
 		Prerequisites: hpad, hq
 		BuiltAt: hpad
 		Owner: gdi
+	Selectable:
+		Bounds: 30,24
 	Helicopter:
 		ROT: 4
 		Speed: 20


### PR DESCRIPTION
Made smaller since they're so huge. So they interfere less with selection of other units next to them. 
http://i.imgur.com/3hTKt.jpg for example (orca and chinook selection bounds have been reduced in size. ignore the pip error for the chinook, it's been corrected.)
