### PR TITLE
cnc - changed various unit speeds; gave increased sight to MCV and MSAM....

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -19,7 +19,7 @@ MCV:
 	Armor: 
 		Type: Light
 	RevealsShroud:
-		Range: 4
+		Range: 8
 	Transforms:
 		IntoActor: fact
 		Offset:-1,-1
@@ -84,7 +84,7 @@ APC:
 		Owner: gdi
 	Mobile:
 		ROT: 5
-		Speed: 11
+		Speed: 10
 	Health:
 		HP: 200
 	Armor:
@@ -186,7 +186,7 @@ BGGY:
 		Owner: nod
 	Mobile:
 		ROT: 10
-		Speed: 12
+		Speed: 16
 	Health:
 		HP: 140
 	Armor:
@@ -218,7 +218,14 @@ BIKE:
 		Owner: nod
 	Mobile:
 		ROT: 10
-		Speed: 13
+		Speed: 20
+		TerrainSpeeds:
+			Clear: 42
+			Rough: 25
+			Road: 100
+			Tiberium: 25
+			BlueTiberium: 25
+			Beach: 25
 	Health:
 		HP: 120
 	Armor: 
@@ -248,7 +255,7 @@ JEEP:
 		Owner: gdi
 	Mobile:
 		ROT: 10
-		Speed: 10
+		Speed: 14
 	Health:
 		HP: 150
 	Armor:
@@ -314,7 +321,7 @@ MTNK:
 		Prerequisites: hq
 		Owner: gdi
 	Mobile:
-		Speed: 9
+		Speed: 7
 	Health:
 		HP: 400
 	Armor:
@@ -384,7 +391,7 @@ HTNK:
 MSAM:
 	Inherits: ^Tank
 	Valued:
-		Cost: 800
+		Cost: 1200
 	Tooltip:
 		Name: Rocket Launcher
 		Icon: msamicnh
@@ -400,7 +407,7 @@ MSAM:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 6
+		Range: 10
 	Turreted:
 		ROT: 255
 	AttackFrontal:


### PR DESCRIPTION
MCV and MSAM vision improved to 7 and 10, respectively. MCV for early tiberium spotting and MSAM because it's artilllery with range 14.
Speed changes:  I will explain in converted speed values on "clear" terrain, since speed numbers are confusing (vehicles take a big penalty on terrain while tanks don't)
Buggy - from 7.2 to 9.6. Now the fastest unit, to encourage hit and runs behind enemy lines on lightly armored units (e.g. artillery), infantry and wood buildings. 
Bike - from 7.8 to 8.4. Bikes aren't uber fast, but they're now designed to zoom at ultra speed, way faster than anything else, once they get a road. 
Hum-vee - from 6 to 8.4 A bit slower than the buggy, with slightly more hitpoints. 
Med. Tank - from 7.2 to 5.6. I've tried differentiating the light tank and medium from one another; making medium slower is one way (they were set at identical speeds). Medium is still fast enough to break through places. Light tank has slightly less firepower (damage per second), but shoots fare more often, increasing odds of a hit. 
