### PR TITLE
Red Alert CashTicks

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -19,6 +19,9 @@ using OpenRA.Server;
 
 namespace OpenRA.GameRules
 {
+	public enum MouseScrollType { Disabled, Standard, Inverted }
+	public enum SoundCashTicks { Disabled, Normal, Extreme }
+
 	public class ServerSettings
 	{
 		public string Name = "OpenRA Game";
@@ -77,6 +80,8 @@ namespace OpenRA.GameRules
 		public bool Repeat = false;
 		public bool ShellmapMusic = true;
 		public string Engine = "AL";
+		
+		public SoundCashTicks SoundCashTickType = SoundCashTicks.Extreme;
 	}
 
 	public class PlayerSettings
@@ -85,8 +90,6 @@ namespace OpenRA.GameRules
 		public ColorRamp ColorRamp = new ColorRamp(75, 255, 180, 25);
 		public string LastServer = "localhost:1234";
 	}
-
-	public enum MouseScrollType { Disabled, Standard, Inverted }
 
 	public class GameSettings
 	{

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Linq;
+using OpenRA.GameRules;
 
 namespace OpenRA.Traits
 {
@@ -62,6 +63,8 @@ namespace OpenRA.Traits
 	{
 		readonly Player Owner;
 		int AdviceInterval;
+		
+		int tickermod = 0;
 
 		public PlayerResources(Actor self, PlayerResourcesInfo info)
 		{
@@ -134,7 +137,8 @@ namespace OpenRA.Traits
 		public void Tick(Actor self)
 		{
 			var eva = self.World.WorldActor.Info.Traits.Get<EvaAlertsInfo>();
-
+			tickermod = (tickermod + 1) % 3;
+			
 			OreCapacity = self.World.ActorsWithTrait<IStoreOre>()
 				.Where(a => a.Actor.Owner == Owner)
 				.Sum(a => a.Trait.Capacity);
@@ -158,12 +162,12 @@ namespace OpenRA.Traits
 			if (DisplayCash < Cash)
 			{
 				DisplayCash += move;
-				Sound.PlayToPlayer(self.Owner, eva.CashTickUp);
+				playCashTickUp(self);
 			}
 			else if (DisplayCash > Cash)
 			{
 				DisplayCash -= move;
-				Sound.PlayToPlayer(self.Owner, eva.CashTickDown);
+				playCashTickDown(self);
 			}
 
 			diff = Math.Abs(Ore - DisplayOre);
@@ -173,13 +177,35 @@ namespace OpenRA.Traits
 			if (DisplayOre < Ore)
 			{
 				DisplayOre += move;
-				Sound.PlayToPlayer(self.Owner, eva.CashTickUp);
+				playCashTickUp(self);
 			}
 			else if (DisplayOre > Ore)
 			{
 				DisplayOre -= move;
+				playCashTickDown(self);
+                        }
+		}
+		
+		
+		public void playCashTickUp(Actor self)
+		{
+			var eva = self.World.WorldActor.Info.Traits.Get<EvaAlertsInfo>();
+			if (Game.Settings.Sound.SoundCashTickType != SoundCashTicks.Disabled)
+			{
+				Sound.PlayToPlayer(self.Owner, eva.CashTickUp);
+			}
+		}
+		
+		public void playCashTickDown(Actor self)
+		{
+			var eva = self.World.WorldActor.Info.Traits.Get<EvaAlertsInfo>();
+			if (
+				Game.Settings.Sound.SoundCashTickType == SoundCashTicks.Extreme ||
+				(Game.Settings.Sound.SoundCashTickType == SoundCashTicks.Normal && tickermod == 0)
+			) {
 				Sound.PlayToPlayer(self.Owner, eva.CashTickDown);
 			}
+			
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -71,6 +71,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			// Audio
 			var audio = bg.Get("AUDIO_PANE");
+			var soundSettings = Game.Settings.Sound;
 
 			var soundslider = audio.Get<SliderWidget>("SOUND_VOLUME");
 			soundslider.OnChange += x => Sound.SoundVolume = x;
@@ -80,6 +81,12 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			musicslider.OnChange += x => Sound.MusicVolume = x;
 			musicslider.Value = Sound.MusicVolume;
 
+			var cashticksdropdown = audio.Get<DropDownButtonWidget>("CASH_TICK_TYPE");
+			cashticksdropdown.OnMouseDown = _ => ShowSoundTickDropdown(cashticksdropdown, soundSettings);
+			cashticksdropdown.GetText = () => soundSettings.SoundCashTickType == SoundCashTicks.Extreme ?
+				"Extreme" : soundSettings.SoundCashTickType == SoundCashTicks.Normal ? "Normal" : "Disabled";
+
+			
 			// Display
 			var display = bg.Get("DISPLAY_PANE");
 			var gs = Game.Settings.Graphics;
@@ -138,6 +145,29 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return true;
 		}
 
+		
+		public static bool ShowSoundTickDropdown(DropDownButtonWidget dropdown, SoundSettings audio)
+		{
+			var options = new Dictionary<string, SoundCashTicks>()
+			{
+				{ "Extreme", SoundCashTicks.Extreme },
+				{ "Normal", SoundCashTicks.Normal },
+				{ "Disabled", SoundCashTicks.Disabled },
+			};
+
+			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => audio.SoundCashTickType == options[o],
+					() => audio.SoundCashTickType = options[o]);
+				item.Get<LabelWidget>("LABEL").GetText = () => o;
+				return item;
+			};
+
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+			return true;
+		}
+		
 		public static bool ShowWindowModeDropdown(DropDownButtonWidget dropdown, GraphicSettings s)
 		{
 			var options = new Dictionary<string, WindowMode>()

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -136,6 +136,17 @@ Background@SETTINGS_MENU:
 					Width:250
 					Height:20
 					Ticks:5
+				Label@SOUND_TICK_TYPE_LABEL:
+					X:0
+					Y:70
+					Text: Cash ticks
+				DropDownButton@CASH_TICK_TYPE:
+					X:100
+					Y:60
+					Width:250
+					Height:20
+					Font:Regular
+					Text:Extreme
 		Container@DISPLAY_PANE:
 			X:37
 			Y:100


### PR DESCRIPTION
In the current OpenRA version every cash down tick is heared. Some people (including myself, my brother and brother-in-law) find this sound very annoying. Therefore I have written a patch.

This patch gives the player an option to decrease the number of heard ticks. This behavoir is more like the original game. There is also an option to disable the cash ticks at all.

Three options for cash ticks:
Extreme: current behavoir (every cash countdown tick is heard)
Normal: RedAlert countdown style (only one cash countdown tick every ~1 or 2 seconds)
Disabled: No cash tickdown or tickup is heard.

Thanks to Tirili for hints on the settings system.
