### PR TITLE
Simplepause

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -188,6 +188,8 @@ namespace OpenRA
 						else
 							if (orderManager.NetFrameNumber == 0)
 								orderManager.LastTickTime = Environment.TickCount;
+					
+						viewport.Tick();
 					}
 				}
 		}

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -166,7 +166,7 @@ namespace OpenRA
 					{
 						var isNetTick = LocalTick % NetTickScale == 0;
 
-						if (!isNetTick || orderManager.IsReadyForNextFrame)
+						if ((!isNetTick || orderManager.IsReadyForNextFrame) && !orderManager.GamePaused )
 						{
 							++orderManager.LocalFrameNumber;
 

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -199,7 +199,18 @@ namespace OpenRA
 		{
 			return new Order("HandshakeResponse", null, false) { IsImmediate = true, TargetString = text };
 		}
+		
+		public static Order PauseRequest()
+		{
+			return new Order("PauseRequest", null, false) { IsImmediate = true, TargetString="" }; //TODO: targetbool?
+		}
+                
+		public static Order PauseGame()
+		{
+			return new Order("PauseGame", null, false) { IsImmediate = true, TargetString=""}; //TODO: targetbool?
+		}
 
+		
 		public static Order Command(string text)
 		{
 			return new Order("Command", null, false) { IsImmediate = true, TargetString = text };

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Network
 		public int LastTickTime = Environment.TickCount;
 
 		public bool GameStarted { get { return NetFrameNumber != 0; } }
+		public bool GamePaused {get; set;}
 		public IConnection Connection { get; private set; }
 
 		public readonly int SyncHeaderSize = 9;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -96,8 +96,21 @@ namespace OpenRA.Network
 					}
 				
 				case "PauseGame":
-					{
-						orderManager.GamePaused = !orderManager.GamePaused;
+					{	
+						if(clientId != null)
+						{
+							var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
+					
+							orderManager.GamePaused = !orderManager.GamePaused;
+							if(orderManager.GamePaused)
+							{
+								Game.AddChatLine(Color.White, "", "The game is paused by "+client.Name);
+							}
+							else
+							{
+								Game.AddChatLine(Color.White, "", "The game is un-paused by "+client.Name);
+							}
+						}
 						break;
 					}
 

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -94,6 +94,12 @@ namespace OpenRA.Network
 						Game.StartGame(orderManager.LobbyInfo.GlobalSettings.Map, false);
 						break;
 					}
+				
+				case "PauseGame":
+					{
+						orderManager.GamePaused = !orderManager.GamePaused;
+						break;
+					}
 
 				case "HandshakeRequest":
 					{

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -97,19 +97,13 @@ namespace OpenRA.Network
 				
 				case "PauseGame":
 					{	
-						if(clientId != null)
+						var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
+				
+						if(client != null)
 						{
-							var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
-					
 							orderManager.GamePaused = !orderManager.GamePaused;
-							if(orderManager.GamePaused)
-							{
-								Game.AddChatLine(Color.White, "", "The game is paused by "+client.Name);
-							}
-							else
-							{
-								Game.AddChatLine(Color.White, "", "The game is un-paused by "+client.Name);
-							}
+							var pausetext = "The game is {0} by {1}".F( orderManager.GamePaused ? "paused" : "un-paused", client.Name );
+							Game.AddChatLine(Color.White, "", pausetext);
 						}
 						break;
 					}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -332,6 +332,9 @@ namespace OpenRA.Server
 
 		void InterpretServerOrder(Connection conn, ServerOrder so)
 		{
+			var fromClient = GetClient(conn);
+			var fromIndex = fromClient != null ? fromClient.Index : 0;
+			
 			switch (so.Name)
 			{
 				case "Command":
@@ -347,17 +350,23 @@ namespace OpenRA.Server
 					}
 
 					break;
+				
 				case "HandshakeResponse":
 					ValidateClient(conn, so.Data);
 					break;
+				
 				case "Chat":
 				case "TeamChat":
-					var fromClient = GetClient(conn);
-					var fromIndex = fromClient != null ? fromClient.Index : 0;
-
 					foreach (var c in conns.Except(conn).ToArray())
 						DispatchOrdersToClient(c, fromIndex, 0, so.Serialize());
-				break;
+					break;
+				
+				case "PauseRequest":
+					foreach (var c in conns.ToArray())
+					{  var x = Order.PauseGame();
+						DispatchOrdersToClient(c, fromIndex, 0, x.Serialize());
+					}
+					break;
 			}
 		}
 

--- a/OpenRA.Game/Widgets/TimerWidget.cs
+++ b/OpenRA.Game/Widgets/TimerWidget.cs
@@ -16,12 +16,18 @@ namespace OpenRA.Widgets
 	{
 		public override void Draw()
 		{
-			var s = WidgetUtils.FormatTime(Game.LocalTick);
 			var font = Game.Renderer.Fonts["Title"];
 			var rb = RenderBounds;
+			
+			var s = WidgetUtils.FormatTime(Game.LocalTick);
 			var pos = new float2(rb.Left - font.Measure(s).X / 2, rb.Top);
 
+			var s_paused = (Game.orderManager.GamePaused ? "\n (paused)" : "");
+			var pos_paused = new float2(rb.Left - font.Measure(s_paused).X / 2, rb.Top+1);
+			
 			font.DrawTextWithContrast(s, pos, Color.White, Color.Black, 1);
+			font.DrawTextWithContrast(s_paused, pos_paused, Color.White, Color.Black, 1);
+
 		}
 	}
 }

--- a/OpenRA.Game/Widgets/TimerWidget.cs
+++ b/OpenRA.Game/Widgets/TimerWidget.cs
@@ -19,15 +19,9 @@ namespace OpenRA.Widgets
 			var font = Game.Renderer.Fonts["Title"];
 			var rb = RenderBounds;
 			
-			var s = WidgetUtils.FormatTime(Game.LocalTick);
+			var s = WidgetUtils.FormatTime(Game.LocalTick) + (Game.orderManager.GamePaused?" (paused)":"");
 			var pos = new float2(rb.Left - font.Measure(s).X / 2, rb.Top);
-
-			var s_paused = (Game.orderManager.GamePaused ? "\n (paused)" : "");
-			var pos_paused = new float2(rb.Left - font.Measure(s_paused).X / 2, rb.Top+1);
-			
 			font.DrawTextWithContrast(s, pos, Color.White, Color.Black, 1);
-			font.DrawTextWithContrast(s_paused, pos_paused, Color.White, Color.Black, 1);
-
 		}
 	}
 }

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -148,6 +148,10 @@ namespace OpenRA.Widgets
 					world.Selection.DoControlGroup(world, e.KeyName[0] - '0', e.Modifiers);
 					return true;
 				}
+				else if(e.KeyName == "pause")
+				{
+					world.IssueOrder(Order.PauseRequest());
+				}
 
 				bool handled = false;
 

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Widgets
 					world.Selection.DoControlGroup(world, e.KeyName[0] - '0', e.Modifiers);
 					return true;
 				}
-				else if(e.KeyName == "pause")
+				else if(e.KeyName == "pause" || e.KeyName == "f3")
 				{
 					world.IssueOrder(Order.PauseRequest());
 				}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -183,7 +183,7 @@ namespace OpenRA
 
 			while (frameEndActions.Count != 0)
 				frameEndActions.Dequeue()(this);
-			Game.viewport.Tick();
+			
 		}
 
 		public IEnumerable<Actor> Actors { get { return actors; } }


### PR DESCRIPTION
The what: This branch demonstrates the possibility of a pause function for the OpenRA game engine.

The why: when playing with a friend or family member, it is sometimes desired to pause the game. For instance to get a drink or something to eat, when the phone rings, etc. Pausing the game will not ruin your life then, and it also won't ruin your game.

The how: the usage is very simple now. During the game, one can press the PAUSE key on the keyboard, and the game will pause. The game can be un-paused by pressing the key again.

In the background the following is done to make this work:
- The client sends PAUSE GAME REQUEST to the server.
- The server replies with PAUSE GAME to all clients.
- From now on, the ordermanager.tick() will not be invoked
  Note: pause messages are immediate orders (so one can unpause).

Some remarks:
- Orders can be given, but are queued. The UI will not update these orders until the game un-pauses.
- It has been tested with 1vs1.

Possible future extentions:
- Adding a pause option in the game-menu (for keyboards without a pause-key)
- Freeze the game with a "pause screen", where the user can un-pause, resign, chat, and change settings
- By the game-creating adding a setting which enables/disables the pause-option.
