### PR TITLE
[cnc] Infantry can now get into the hospital to seek medical care

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -132,6 +132,8 @@
 	SpawnViceroid:
 		Probability: 2
 	CrushableInfantry:
+	Repairable:
+		RepairBuildings: hosp
 
 ^CivInfantry:
 	Inherits: ^Infantry

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -29,6 +29,9 @@ HOSP:
 		Name: Hospital
 	LeavesHusk: 
 		HuskActor: HOSP.Husk
+	Reservable:
+	RepairsUnits:
+	RallyPoint:
 
 HOSP.Husk:
 	Inherits: ^CivBuildingHusk


### PR DESCRIPTION
Fixes #2228 without touching the source-code. It also makes sense that they have to visit the hospital and not enter some kind of magic heal zone. Well, they don't really enter as there is no "-BelowUnits:" nor "AboveUnits:", but this way you can see that they get healed.
