### PR TITLE
RA: Harvester logic improvements

### DIFF
--- a/OpenRA.Mods.RA/Activities/FindResources.cs
+++ b/OpenRA.Mods.RA/Activities/FindResources.cs
@@ -24,19 +24,48 @@ namespace OpenRA.Mods.RA.Activities
 			if (IsCanceled || NextActivity != null) return NextActivity;
 
 			var harv = self.Trait<Harvester>();
+
 			if (harv.IsFull)
 				return Util.SequenceActivities(new DeliverResources(), NextActivity);
 
 			var harvInfo = self.Info.Traits.Get<HarvesterInfo>();
 			var mobile = self.Trait<Mobile>();
 			var mobileInfo = self.Info.Traits.Get<MobileInfo>();
-			var res = self.World.WorldActor.Trait<ResourceLayer>();
-			var path = self.World.WorldActor.Trait<PathFinder>().FindPath(PathSearch.Search(self.World, mobileInfo, self.Owner, true)
-						.WithHeuristic(loc => (res.GetResource(loc) != null && harvInfo.Resources.Contains(res.GetResource(loc).info.Name)) ? 0 : 1)
-						.FromPoint(self.Location));
+			var resLayer = self.World.WorldActor.Trait<ResourceLayer>();
+
+			// Find harvestable resources nearby:
+			var path = self.World.WorldActor.Trait<PathFinder>().FindPath(
+				PathSearch.Search(self.World, mobileInfo, self.Owner, true)
+						  .WithHeuristic(loc =>
+							{
+								// Get the resource at this location:
+								var resType = resLayer.GetResource(loc);
+
+								if (resType == null) return 1;
+								// Harvester can only collect resources of one type at a time:
+								if (!harvInfo.Resources.Contains(resType.info.Name)) return 1;
+								// Another harvester has claimed this resource:
+								if (resLayer.IsClaimedBy(harv, loc)) return 1;
+
+								//// Avoid less dense resources:
+								//if (resLayer.GetResourceDensity(loc) < 1) return 1;
+
+								return 0;
+							})
+				// Start searching either from the last harvested cell or our current position:
+						  .FromPoint(harv.LastHarvestedCell ?? self.Location)
+			);
 
 			if (path.Count == 0)
 				return NextActivity;
+
+			// NOTE(jsd): do not iterate through path[n] because the current location
+			// may be included in the list and moving to the current location will
+			// cause the activity code to go into an infinite loop.
+
+			// Attempt to claim a resource as ours:
+			if (!harv.ClaimResource(self, path[0]))
+				return this;
 
 			self.SetTargetLine(Target.FromCell(path[0]), Color.Red, false);
 			return Util.SequenceActivities(mobile.MoveTo(path[0], 1), new HarvestResource(), this);
@@ -55,23 +84,38 @@ namespace OpenRA.Mods.RA.Activities
 		public override Activity Tick(Actor self)
 		{
 			if (isHarvesting) return this;
-			if (IsCanceled) return NextActivity;
+
 			var harv = self.Trait<Harvester>();
+			if (IsCanceled)
+			{
+				harv.UnclaimResource(self);
+				return NextActivity;
+			}
+
 			harv.LastHarvestedCell = self.Location;
 
+			var resLayer = self.World.WorldActor.Trait<ResourceLayer>();
+
 			if (harv.IsFull)
+			{
+				harv.UnclaimResource(self);
 				return NextActivity;
+			}
 
 			var renderUnit = self.Trait<RenderUnit>();	/* better have one of these! */
-			var resource = self.World.WorldActor.Trait<ResourceLayer>().Harvest(self.Location);
+			var resource = resLayer.Harvest(self.Location);
 			if (resource == null)
+			{
+				harv.UnclaimResource(self);
 				return NextActivity;
+			}
 
 			if (renderUnit.anim.CurrentSequence.Name != "harvest")
 			{
 				isHarvesting = true;
 				renderUnit.PlayCustomAnimation(self, "harvest", () => isHarvesting = false);
 			}
+
 			harv.AcceptResource(resource);
 			return this;
 		}

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -19,13 +19,13 @@ namespace OpenRA.Mods.RA.Move
 {
 	public class PathFinderInfo : ITraitInfo
 	{
-		public object Create( ActorInitializer init ) { return new PathFinder( init.world ); }
+		public object Create(ActorInitializer init) { return new PathFinder(init.world); }
 	}
 
 	public class PathFinder
 	{
 		readonly World world;
-		public PathFinder( World world ) { this.world = world; }
+		public PathFinder(World world) { this.world = world; }
 
 		class CachedPath
 		{
@@ -66,13 +66,13 @@ namespace OpenRA.Mods.RA.Move
 			}
 		}
 
-		public List<int2> FindUnitPathToRange( int2 src, int2 target, int range, Actor self )
+		public List<int2> FindUnitPathToRange(int2 src, int2 target, int range, Actor self)
 		{
-			using( new PerfSample( "Pathfinder" ) )
+			using (new PerfSample("Pathfinder"))
 			{
 				var mi = self.Info.Traits.Get<MobileInfo>();
 				var tilesInRange = world.FindTilesInCircle(target, range)
-					.Where( t => mi.CanEnterCell(self.World, self.Owner, t, null, true));
+					.Where(t => mi.CanEnterCell(self.World, self.Owner, t, null, true));
 
 				var path = FindBidiPath(
 					PathSearch.FromPoints(world, mi, self.Owner, tilesInRange, src, true),
@@ -83,11 +83,11 @@ namespace OpenRA.Mods.RA.Move
 			}
 		}
 
-		public List<int2> FindPath( PathSearch search )
+		public List<int2> FindPath(PathSearch search)
 		{
 			using (new PerfSample("Pathfinder"))
 			{
-				using(search)
+				using (search)
 					while (!search.queue.Empty)
 					{
 						var p = search.Expand(world);
@@ -100,15 +100,15 @@ namespace OpenRA.Mods.RA.Move
 			}
 		}
 
-		static List<int2> MakePath( CellInfo[ , ] cellInfo, int2 destination )
+		static List<int2> MakePath(CellInfo[,] cellInfo, int2 destination)
 		{
 			List<int2> ret = new List<int2>();
 			int2 pathNode = destination;
 
-			while( cellInfo[ pathNode.X, pathNode.Y ].Path != pathNode )
+			while (cellInfo[pathNode.X, pathNode.Y].Path != pathNode)
 			{
-				ret.Add( pathNode );
-				pathNode = cellInfo[ pathNode.X, pathNode.Y ].Path;
+				ret.Add(pathNode);
+				pathNode = cellInfo[pathNode.X, pathNode.Y].Path;
 			}
 
 			ret.Add(pathNode);
@@ -155,8 +155,8 @@ namespace OpenRA.Mods.RA.Move
 			var q = p;
 			while (ca[q.X, q.Y].Path != q)
 			{
-				ret.Add( q );
-				q = ca[ q.X, q.Y ].Path;
+				ret.Add(q);
+				q = ca[q.X, q.Y].Path;
 			}
 			ret.Add(q);
 
@@ -169,22 +169,22 @@ namespace OpenRA.Mods.RA.Move
 				ret.Add(q);
 			}
 
-			CheckSanePath( ret );
+			CheckSanePath(ret);
 			return ret;
 		}
 
-		[Conditional( "SANITY_CHECKS" )]
-		static void CheckSanePath( List<int2> path )
+		[Conditional("SANITY_CHECKS")]
+		static void CheckSanePath(List<int2> path)
 		{
-			if( path.Count == 0 )
+			if (path.Count == 0)
 				return;
-			var prev = path[ 0 ];
-			for( int i = 0 ; i < path.Count ; i++ )
+			var prev = path[0];
+			for (int i = 0; i < path.Count; i++)
 			{
-				var d = path[ i ] - prev;
-				if( Math.Abs( d.X ) > 1 || Math.Abs( d.Y ) > 1 )
-					throw new InvalidOperationException( "(PathFinder) path sanity check failed" );
-				prev = path[ i ];
+				var d = path[i] - prev;
+				if (Math.Abs(d.X) > 1 || Math.Abs(d.Y) > 1)
+					throw new InvalidOperationException("(PathFinder) path sanity check failed");
+				prev = path[i];
 			}
 		}
 
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.RA.Move
 		public int2 Path;
 		public bool Seen;
 
-		public CellInfo( int minCost, int2 path, bool seen )
+		public CellInfo(int minCost, int2 path, bool seen)
 		{
 			MinCost = minCost;
 			Path = path;

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Move
 	public class PathSearch : IDisposable
 	{
 		World world;
-		public CellInfo[ , ] cellInfo;
+		public CellInfo[,] cellInfo;
 		public PriorityQueue<PathDistance> queue;
 		public Func<int2, int> heuristic;
 		Func<int2, bool> customBlock;
@@ -70,13 +70,13 @@ namespace OpenRA.Mods.RA.Move
 
 		public PathSearch FromPoint(int2 from)
 		{
-			AddInitialCell( from );
+			AddInitialCell(from);
 			return this;
 		}
 
 		int LaneBias = 1;
 
-		public int2 Expand( World world )
+		public int2 Expand(World world)
 		{
 			var p = queue.Pop();
 			while (cellInfo[p.Location.X, p.Location.Y].Seen)
@@ -92,12 +92,12 @@ namespace OpenRA.Mods.RA.Move
 			if (thisCost == int.MaxValue)
 				return p.Location;
 
-			foreach( int2 d in directions )
+			foreach (int2 d in directions)
 			{
 				int2 newHere = p.Location + d;
 
 				if (!world.Map.IsInMap(newHere.X, newHere.Y)) continue;
-				if( cellInfo[ newHere.X, newHere.Y ].Seen )
+				if (cellInfo[newHere.X, newHere.Y].Seen)
 					continue;
 
 				var costHere = mobileInfo.MovementCostForCell(world, newHere);
@@ -111,31 +111,34 @@ namespace OpenRA.Mods.RA.Move
 				if (customBlock != null && customBlock(newHere))
 					continue;
 
-				var est = heuristic( newHere );
-				if( est == int.MaxValue )
+				var est = heuristic(newHere);
+				if (est == int.MaxValue)
 					continue;
 
 				int cellCost = costHere;
-				if( d.X * d.Y != 0 ) cellCost = ( cellCost * 34 ) / 24;
+				if (d.X * d.Y != 0) cellCost = (cellCost * 34) / 24;
 
 				// directional bonuses for smoother flow!
-				var ux = (newHere.X + (inReverse ? 1 : 0) & 1);
-				var uy = (newHere.Y + (inReverse ? 1 : 0) & 1);
+				if (LaneBias != 0)
+				{
+					var ux = (newHere.X + (inReverse ? 1 : 0) & 1);
+					var uy = (newHere.Y + (inReverse ? 1 : 0) & 1);
 
-				if (ux == 0 && d.Y < 0) cellCost += LaneBias;
-				else if (ux == 1 && d.Y > 0) cellCost += LaneBias;
-				if (uy == 0 && d.X < 0) cellCost += LaneBias;
-				else if (uy == 1 && d.X > 0) cellCost += LaneBias;
+					if (ux == 0 && d.Y < 0) cellCost += LaneBias;
+					else if (ux == 1 && d.Y > 0) cellCost += LaneBias;
+					if (uy == 0 && d.X < 0) cellCost += LaneBias;
+					else if (uy == 1 && d.X > 0) cellCost += LaneBias;
+				}
 
-				int newCost = cellInfo[ p.Location.X, p.Location.Y ].MinCost + cellCost;
+				int newCost = cellInfo[p.Location.X, p.Location.Y].MinCost + cellCost;
 
-				if( newCost >= cellInfo[ newHere.X, newHere.Y ].MinCost )
+				if (newCost >= cellInfo[newHere.X, newHere.Y].MinCost)
 					continue;
 
-				cellInfo[ newHere.X, newHere.Y ].Path = p.Location;
-				cellInfo[ newHere.X, newHere.Y ].MinCost = newCost;
+				cellInfo[newHere.X, newHere.Y].Path = p.Location;
+				cellInfo[newHere.X, newHere.Y].MinCost = newCost;
 
-				queue.Add( new PathDistance( newCost + est, newHere ) );
+				queue.Add(new PathDistance(newCost + est, newHere));
 
 			}
 			return p.Location;
@@ -153,29 +156,33 @@ namespace OpenRA.Mods.RA.Move
 			new int2(  1,  1 ),
 		};
 
-		public void AddInitialCell( int2 location )
+		public void AddInitialCell(int2 location)
 		{
 			if (!world.Map.IsInMap(location.X, location.Y))
 				return;
 
-			cellInfo[ location.X, location.Y ] = new CellInfo( 0, location, false );
-			queue.Add( new PathDistance( heuristic( location ), location ) );
+			cellInfo[location.X, location.Y] = new CellInfo(0, location, false);
+			queue.Add(new PathDistance(heuristic(location), location));
 		}
 
-		public static PathSearch Search( World world, MobileInfo mi, Player owner, bool checkForBlocked )
+		public static PathSearch Search(World world, MobileInfo mi, Player owner, bool checkForBlocked)
 		{
-			var search = new PathSearch(world, mi, owner) {
-				checkForBlocked = checkForBlocked };
+			var search = new PathSearch(world, mi, owner)
+			{
+				checkForBlocked = checkForBlocked
+			};
 			return search;
 		}
 
-		public static PathSearch FromPoint( World world, MobileInfo mi, Player owner, int2 from, int2 target, bool checkForBlocked )
+		public static PathSearch FromPoint(World world, MobileInfo mi, Player owner, int2 from, int2 target, bool checkForBlocked)
 		{
-			var search = new PathSearch(world, mi, owner) {
-				heuristic = DefaultEstimator( target ),
-				checkForBlocked = checkForBlocked };
+			var search = new PathSearch(world, mi, owner)
+			{
+				heuristic = DefaultEstimator(target),
+				checkForBlocked = checkForBlocked
+			};
 
-			search.AddInitialCell( from );
+			search.AddInitialCell(from);
 			return search;
 		}
 
@@ -187,8 +194,8 @@ namespace OpenRA.Mods.RA.Move
 				checkForBlocked = checkForBlocked
 			};
 
-			foreach( var sl in froms )
-				search.AddInitialCell( sl );
+			foreach (var sl in froms)
+				search.AddInitialCell(sl);
 
 			return search;
 		}
@@ -207,7 +214,7 @@ namespace OpenRA.Mods.RA.Move
 				cellInfoPool.Enqueue(ci);
 		}
 
-		CellInfo[ , ] InitCellInfo()
+		CellInfo[,] InitCellInfo()
 		{
 			CellInfo[,] result = null;
 			while (cellInfoPool.Count > 0)
@@ -225,22 +232,22 @@ namespace OpenRA.Mods.RA.Move
 			}
 
 			if (result == null)
-				result  = new CellInfo[ world.Map.MapSize.X, world.Map.MapSize.Y ];
+				result = new CellInfo[world.Map.MapSize.X, world.Map.MapSize.Y];
 
-			for( int x = 0 ; x < world.Map.MapSize.X ; x++ )
-				for( int y = 0 ; y < world.Map.MapSize.Y ; y++ )
-					result[ x, y ] = new CellInfo( int.MaxValue, new int2( x, y ), false );
+			for (int x = 0; x < world.Map.MapSize.X; x++)
+				for (int y = 0; y < world.Map.MapSize.Y; y++)
+					result[x, y] = new CellInfo(int.MaxValue, new int2(x, y), false);
 
 			return result;
 		}
 
-		public static Func<int2, int> DefaultEstimator( int2 destination )
+		public static Func<int2, int> DefaultEstimator(int2 destination)
 		{
 			return here =>
 			{
-				int2 d = ( here - destination ).Abs();
-				int diag = Math.Min( d.X, d.Y );
-				int straight = Math.Abs( d.X - d.Y );
+				int2 d = (here - destination).Abs();
+				int diag = Math.Min(d.X, d.Y);
+				int straight = Math.Abs(d.X - d.Y);
 				return (3400 * diag / 24) + (100 * straight);
 			};
 		}


### PR DESCRIPTION
A harvester will now claim a resource on the map it has decided to harvest so that other harvesters do not attempt to harvest it.
A harvester will now search for resources near the last harvested cell instead of blindly moving there first (and potentially discovering that there is nothing there to collect).
