### PR TITLE
Fixed broken Install from CD code in RA.

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/RAInstallLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/RAInstallLogic.cs
@@ -23,7 +23,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var args = new WidgetArgs()
 			{
 				{ "afterInstall", () => { Ui.CloseWindow(); continueLoading(); } },
-				{ "installData", installData }
+				{ "installData", installData },
+				{ "continueLoading", continueLoading }
 			};
 
 			panel.Get<ButtonWidget>("DOWNLOAD_BUTTON").OnClick = () =>


### PR DESCRIPTION
RA Install from CD option was crashing due to `"continueLoading"` missing from `args`.
