### PR TITLE
Fix to have units avoid projectile friendly fire.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -132,6 +132,7 @@ namespace OpenRA.Traits
 	}
 
 	public interface IMove : ITeleportable { int Altitude { get; set; } }
+	public interface INotifyIncomingProjectile { void OnNotifyIncomingProjectile(Actor self, Actor firedBy, int2 projectileDestination, int blastRadius); }
 
 	public interface IFacing
 	{

--- a/OpenRA.Mods.RA/Move/ScatterFromProjectiles.cs
+++ b/OpenRA.Mods.RA/Move/ScatterFromProjectiles.cs
@@ -1,0 +1,59 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using OpenRA.FileFormats;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA.Move
+{
+	class ScatterFromProjectilesInfo : ITraitInfo, Requires<MobileInfo>
+	{
+		public readonly Stance[] ScatterFrom = { Stance.Ally };
+
+		public object Create(ActorInitializer init) { return new ScatterFromProjectiles(init.self, this); }
+	}
+
+	class ScatterFromProjectiles : INotifyIncomingProjectile
+	{
+		private readonly ScatterFromProjectilesInfo Info;
+
+		public ScatterFromProjectiles(Actor self, ScatterFromProjectilesInfo info)
+		{
+			Info = info;
+		}
+
+		public void OnNotifyIncomingProjectile(Actor self, Actor firedBy, int2 projectileDestination, int blastRadius)
+		{
+			// Should we scatter from the projectile based on the attacker's stance from us?
+			Stance stanceAgainstFirer = self.Owner.Stances[firedBy.Owner];
+			if (!Info.ScatterFrom.Contains(stanceAgainstFirer)) return;
+
+			// Find the directional vector away from ground-zero for this unit:
+			var distVec = (self.CenterLocation - projectileDestination).ToFloat2();
+			// Create a vector that is a little less than `radius` distance from ground-zero:
+			var awayVec = distVec * (blastRadius * 0.75f / distVec.Length);
+
+			// Create the point to move to:
+			var moveTo = (self.CenterLocation + awayVec).ToInt2();
+			var moveToCell = Util.CellContaining(moveTo);
+			var moveToTarget = Target.FromPos(moveTo);
+
+			// Move the unit out of the way:
+			self.CancelActivity();
+			self.SetTargetLine(moveToTarget, System.Drawing.Color.Green, false);
+			self.QueueActivity(new Move(moveToCell, 0));
+		}
+	}
+}

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Move\Move.cs" />
     <Compile Include="Move\PathFinder.cs" />
     <Compile Include="Move\PathSearch.cs" />
+    <Compile Include="Move\ScatterFromProjectiles.cs" />
     <Compile Include="NukePaletteEffect.cs" />
     <Compile Include="NullLoadScreen.cs" />
     <Compile Include="OpenWidgetAtGameStart.cs" />

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -32,6 +32,7 @@
 	GpsDot:
 		String:Vehicle
 	WithSmoke:
+	ScatterFromProjectiles:
 
 ^Tank:
 	AppearsOnRadar:
@@ -67,6 +68,7 @@
 	GpsDot:
 		String:Vehicle
 	WithSmoke:
+	ScatterFromProjectiles:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -111,6 +113,7 @@
 		Offset: 0,-10
 	CrushableInfantry:
 		CrushSound: squishy2.aud
+	ScatterFromProjectiles:
 
 ^Ship:
 	AppearsOnRadar:


### PR DESCRIPTION
When I control one massive group comprising of both long-range artillery and short-range infantry, I find that the infantry is quite suicidal by default and is not interested in self-preservation against friendly-fire from the artillery who are all attacking the same target. This patch attempts to resolve that by having the friendly-firing unit notify other units near the destination point of the projectile. Their reaction is to move the shortest distance away from ground-zero to relative safety, depending on how large the blast radius of the projectile is.
