### PR TITLE
Fixes issue #2256: zombie aircraft flying around beyond death

### DIFF
--- a/OpenRA.Mods.RA/Air/FlyAttack.cs
+++ b/OpenRA.Mods.RA/Air/FlyAttack.cs
@@ -50,9 +50,10 @@ namespace OpenRA.Mods.RA.Air
 			{
 				if( inner != null )
 					inner.Cancel( self );
-
-				base.Cancel( self );
 			}
+
+			// NextActivity must always be set to null:
+			base.Cancel(self);
 		}
 	}
 }


### PR DESCRIPTION
`FallsToEarth.NotifyKilled` calls `Cancel` method in `FlyAttack`, and that method was not nulling out `NextActivity` in the event of a double-cancel on a frame where the aircraft was killed by a missile. The `FallToEarth` activity queued up from `FallsToEarth.NotifyKilled` got pushed deep into the queue which then got canceled at some later point.
