### PR TITLE
Pathing improvements

### DIFF
--- a/OpenRA.Mods.RA/Activities/FindResources.cs
+++ b/OpenRA.Mods.RA/Activities/FindResources.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			// Find harvestable resources nearby:
 			var path = self.World.WorldActor.Trait<PathFinder>().FindPath(
-				PathSearch.Search(self.World, mobileInfo, self.Owner, true)
+				PathSearch.Search(self.World, mobileInfo, self, true)
 					.WithCustomCost(loc =>
 					{
 						// Avoid enemy territory:

--- a/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			var mobile = self.Trait<Mobile>();
 
-			var ps1 = new PathSearch( self.World, mobile.Info, self.Owner )
+			var ps1 = new PathSearch( self.World, mobile.Info, self )
 			{
 				checkForBlocked = true,
 				heuristic = location => 0,
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			ps1.heuristic = PathSearch.DefaultEstimator( mobile.toCell );
 
-			var ps2 = PathSearch.FromPoint( self.World, mobile.Info, self.Owner, mobile.toCell, target.CenterLocation.ToCPos(), true );
+			var ps2 = PathSearch.FromPoint( self.World, mobile.Info, self, mobile.toCell, target.CenterLocation.ToCPos(), true );
 			var ret = self.World.WorldActor.Trait<PathFinder>().FindBidiPath( ps1, ps2 );
 
 			return Util.SequenceActivities( mobile.MoveTo( () => ret ), this );

--- a/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.RA.Crates
 
 			for (var i = -1; i < 2; i++)
 				for (var j = -1; j < 2; j++)
-					if (mi.CanEnterCell(self.World, self.Owner, near + new CVec(i, j), null, true, true))
+					if (mi.CanEnterCell(self.World, self, near + new CVec(i, j), null, true, true))
 						yield return near + new CVec(i, j);
 		}
 

--- a/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.RA.Crates
 
 			for (var i = -1; i < 2; i++)
 				for (var j = -1; j < 2; j++)
-					if (mi.CanEnterCell(self.World, self.Owner, near + new CVec(i, j), null, true))
+					if (mi.CanEnterCell(self.World, self.Owner, near + new CVec(i, j), null, true, true))
 						yield return near + new CVec(i, j);
 		}
 

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.RA
 			// Start a search from each refinery's delivery location:
 			var mi = self.Info.Traits.Get<MobileInfo>();
 			var path = self.World.WorldActor.Trait<PathFinder>().FindPath(
-				PathSearch.FromPoints(self.World, mi, self.Owner, refs.Values.Select(r => r.Location), self.Location, false)
+				PathSearch.FromPoints(self.World, mi, self, refs.Values.Select(r => r.Location), self.Location, false)
 					.WithCustomCost((loc) =>
 					{
 						if (!refs.ContainsKey(loc)) return 0;
@@ -349,7 +349,7 @@ namespace OpenRA.Mods.RA
 
 			// Find any harvestable resources:
 			var path = self.World.WorldActor.Trait<PathFinder>().FindPath(
-				PathSearch.Search(self.World, mobileInfo, self.Owner, true)
+				PathSearch.Search(self.World, mobileInfo, self, true)
 					.WithHeuristic(loc =>
 					{
 						// Get the resource at this location:

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA.Move
 			{SubCell.FullCell, new PVecInt(0,0)},
 		};
 
-		public bool CanEnterCell(World world, Player owner, CPos cell, Actor ignoreActor, bool checkTransientActors)
+		public bool CanEnterCell(World world, Player owner, CPos cell, Actor ignoreActor, bool checkTransientActors, bool blockedByMovers)
 		{
 			if (MovementCostForCell(world, cell) == int.MaxValue)
 				return false;
@@ -85,7 +85,12 @@ namespace OpenRA.Mods.RA.Move
 			if (SharesCell && world.ActorMap.HasFreeSubCell(cell))
 				return true;
 
-			var blockingActors = world.ActorMap.GetUnitsAt(cell).Where(x => x != ignoreActor).ToList();
+			var blockingActors = world.ActorMap.GetUnitsAt(cell)
+				.Where(x => x != ignoreActor)
+				// Neutral/enemy units are blockers. Allied units that are moving are not blockers.
+				.Where(x => blockedByMovers || ((owner.Stances[x.Owner] != Stance.Ally) || !x.IsMoving()))
+				.ToList();
+
 			if (checkTransientActors && blockingActors.Count > 0)
 			{
 				// Non-sharable unit can enter a cell with shareable units only if it can crush all of them
@@ -93,7 +98,7 @@ namespace OpenRA.Mods.RA.Move
 					return false;
 
 				if (blockingActors.Any(a => !(a.HasTrait<ICrushable>() &&
-									         a.TraitsImplementing<ICrushable>().Any(b => b.CrushableBy(Crushes, owner)))))
+											 a.TraitsImplementing<ICrushable>().Any(b => b.CrushableBy(Crushes, owner)))))
 					return false;
 			}
 
@@ -342,7 +347,7 @@ namespace OpenRA.Mods.RA.Move
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor, bool checkTransientActors)
 		{
-			return Info.CanEnterCell(self.World, self.Owner, cell, ignoreActor, checkTransientActors);
+			return Info.CanEnterCell(self.World, self.Owner, cell, ignoreActor, checkTransientActors, true);
 		}
 
 		public void EnteringCell(Actor self)

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA.Move
 		{
 			this.getPath = (self,mobile) =>
 				self.World.WorldActor.Trait<PathFinder>().FindPath(
-					PathSearch.FromPoint( self.World, mobile.Info, self.Owner, mobile.toCell, destination, false )
+					PathSearch.FromPoint( self.World, mobile.Info, self, mobile.toCell, destination, false )
 					.WithoutLaneBias());
 			this.destination = destination;
 			this.nearEnough = 0;
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA.Move
 		{
 			this.getPath = (self,mobile) =>
 				self.World.WorldActor.Trait<PathFinder>().FindPath(
-					PathSearch.FromPoint( self.World, mobile.Info, self.Owner, mobile.toCell, destination, false )
+					PathSearch.FromPoint( self.World, mobile.Info, self, mobile.toCell, destination, false )
 					.WithIgnoredBuilding( ignoreBuilding ));
 
 			this.destination = destination;

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -388,4 +388,23 @@ namespace OpenRA.Mods.RA.Move
 			}
 		}
 	}
+
+	public static class ActorExtensionsForMove
+	{
+		public static bool IsMoving(this Actor self)
+		{
+			if (self.IsIdle) return false;
+
+			Activity a = self.GetCurrentActivity();
+			Debug.Assert(a != null);
+
+			// Dirty, but it suffices until we do something better:
+			if (a.GetType() == typeof(Move)) return true;
+			if (a.GetType() == typeof(MoveAdjacentTo)) return true;
+			if (a.GetType() == typeof(AttackMove)) return true;
+
+			// Not a move:
+			return false;
+		}
+	}
 }

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.RA.Move
 			{
 				var mi = self.Info.Traits.Get<MobileInfo>();
 				var tilesInRange = world.FindTilesInCircle(target, range)
-					.Where(t => mi.CanEnterCell(self.World, self.Owner, t, null, true));
+					.Where(t => mi.CanEnterCell(self.World, self.Owner, t, null, true, true));
 
 				var path = FindBidiPath(
 					PathSearch.FromPoints(world, mi, self.Owner, tilesInRange, src, true),

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -55,8 +55,8 @@ namespace OpenRA.Mods.RA.Move
 				var mi = self.Info.Traits.Get<MobileInfo>();
 
 				var pb = FindBidiPath(
-					PathSearch.FromPoint(world, mi, self.Owner, target, from, true),
-					PathSearch.FromPoint(world, mi, self.Owner, from, target, true).InReverse()
+					PathSearch.FromPoint(world, mi, self, target, from, true),
+					PathSearch.FromPoint(world, mi, self, from, target, true).InReverse()
 				);
 
 				CheckSanePath2(pb, from, target);
@@ -73,11 +73,11 @@ namespace OpenRA.Mods.RA.Move
 			{
 				var mi = self.Info.Traits.Get<MobileInfo>();
 				var tilesInRange = world.FindTilesInCircle(target, range)
-					.Where(t => mi.CanEnterCell(self.World, self.Owner, t, null, true, true));
+					.Where(t => mi.CanEnterCell(self.World, self, t, null, true, true));
 
 				var path = FindBidiPath(
-					PathSearch.FromPoints(world, mi, self.Owner, tilesInRange, src, true),
-					PathSearch.FromPoint(world, mi, self.Owner, src, target, true).InReverse()
+					PathSearch.FromPoints(world, mi, self, tilesInRange, src, true),
+					PathSearch.FromPoint(world, mi, self, src, target, true).InReverse()
 				);
 
 				return path;

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.RA.Move
 				if (costHere == int.MaxValue)
 					continue;
 
-				if (!mobileInfo.CanEnterCell(world, owner, newHere, ignoreBuilding, checkForBlocked))
+				if (!mobileInfo.CanEnterCell(world, owner, newHere, ignoreBuilding, checkForBlocked, false))
 					continue;
 
 				if (customBlock != null && customBlock(newHere))

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -28,14 +28,15 @@ namespace OpenRA.Mods.RA.Move
 		public bool inReverse;
 
 		MobileInfo mobileInfo;
-		Player owner;
+		Actor self;
+		public Player owner { get { return self.Owner; } }
 
-		public PathSearch(World world, MobileInfo mobileInfo, Player owner)
+		public PathSearch(World world, MobileInfo mobileInfo, Actor self)
 		{
 			this.world = world;
 			cellInfo = InitCellInfo();
 			this.mobileInfo = mobileInfo;
-			this.owner = owner;
+			this.self = self;
 			customCost = null;
 			queue = new PriorityQueue<PathDistance>();
 		}
@@ -120,7 +121,7 @@ namespace OpenRA.Mods.RA.Move
 				if (costHere == int.MaxValue)
 					continue;
 
-				if (!mobileInfo.CanEnterCell(world, owner, newHere, ignoreBuilding, checkForBlocked, false))
+				if (!mobileInfo.CanEnterCell(world, self, newHere, ignoreBuilding, checkForBlocked, false))
 					continue;
 
 				if (customBlock != null && customBlock(newHere))
@@ -182,18 +183,18 @@ namespace OpenRA.Mods.RA.Move
 			queue.Add(new PathDistance(heuristic(location), location));
 		}
 
-		public static PathSearch Search(World world, MobileInfo mi, Player owner, bool checkForBlocked)
+		public static PathSearch Search(World world, MobileInfo mi, Actor self, bool checkForBlocked)
 		{
-			var search = new PathSearch(world, mi, owner)
+			var search = new PathSearch(world, mi, self)
 			{
 				checkForBlocked = checkForBlocked
 			};
 			return search;
 		}
 
-		public static PathSearch FromPoint(World world, MobileInfo mi, Player owner, CPos from, CPos target, bool checkForBlocked)
+		public static PathSearch FromPoint(World world, MobileInfo mi, Actor self, CPos from, CPos target, bool checkForBlocked)
 		{
-			var search = new PathSearch(world, mi, owner)
+			var search = new PathSearch(world, mi, self)
 			{
 				heuristic = DefaultEstimator(target),
 				checkForBlocked = checkForBlocked
@@ -203,9 +204,9 @@ namespace OpenRA.Mods.RA.Move
 			return search;
 		}
 
-		public static PathSearch FromPoints(World world, MobileInfo mi, Player owner, IEnumerable<CPos> froms, CPos target, bool checkForBlocked)
+		public static PathSearch FromPoints(World world, MobileInfo mi, Actor self, IEnumerable<CPos> froms, CPos target, bool checkForBlocked)
 		{
-			var search = new PathSearch(world, mi, owner)
+			var search = new PathSearch(world, mi, self)
 			{
 				heuristic = DefaultEstimator(target),
 				checkForBlocked = checkForBlocked

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.RA
 			var mobileInfo = producee.Traits.GetOrDefault<MobileInfo>();
 
 			return mobileInfo == null ||
-				mobileInfo.CanEnterCell(self.World, self.Owner, self.Location + s.ExitCellVector, self, true);
+				mobileInfo.CanEnterCell(self.World, self.Owner, self.Location + s.ExitCellVector, self, true, true);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.RA
 			var mobileInfo = producee.Traits.GetOrDefault<MobileInfo>();
 
 			return mobileInfo == null ||
-				mobileInfo.CanEnterCell(self.World, self.Owner, self.Location + s.ExitCellVector, self, true, true);
+				mobileInfo.CanEnterCell(self.World, self, self.Location + s.ExitCellVector, self, true, true);
 		}
 	}
 }


### PR DESCRIPTION
Units no longer consider other moving units as obstacles. However, units moving in the opposite direction are considered as obstacles which helps avoid pathing deadlocks when two units are facing each other and are cell-adjacent.
