### PR TITLE
Added "AutoTargetIgnore:" to ^Building:

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -209,6 +209,7 @@
 		Notification: OI_BLOST.AUD
 	EditorAppearance:
 		RelativeToTopLeft: yes
+	AutoTargetIgnore:
 	ShakeOnDeath:
 	ProximityCaptor:
 		Types:Building


### PR DESCRIPTION
Added "AutoTargetIgnore:" to ^Building:

This will make units not attack them, to solve the problem of units attacking buildings that don't matter instead of units and guard towers. 
I will edit the guard towers so that they are still auto-targeted.
