### PR TITLE
Sonic tank moved to end of build menu (100)

### DIFF
--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -267,7 +267,7 @@ SONICTANK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 15
+		BuildPaletteOrder: 100
 		Prerequisites: heavya,researcha
 		Owner: atreides
 		BuiltAt: heavya


### PR DESCRIPTION
Sonic tank moved to bottom of vehicle build menu (set palette order to 100)
