### PR TITLE
fix #2407; Character \# cannot be escaped in settings file

### DIFF
--- a/OpenRA.FileFormats/MiniYaml.cs
+++ b/OpenRA.FileFormats/MiniYaml.cs
@@ -120,6 +120,7 @@ namespace OpenRA.FileFormats
 						}
 					++charNo;
 				}
+				line = line.Replace("\\#","#");
 				var t = line.TrimStart(' ', '\t');
 				if (t.Length == 0)
 					continue;

--- a/OpenRA.FileFormats/MiniYaml.cs
+++ b/OpenRA.FileFormats/MiniYaml.cs
@@ -109,8 +109,17 @@ namespace OpenRA.FileFormats
 			{
 				var line = ll;
 				++lineNo;
-				if (line.Contains('#'))
-					line = line.Substring(0, line.IndexOf('#')).TrimEnd(' ', '\t');
+				var charNo = 0;
+				foreach (char character in line)
+				{
+					if (character == '#')
+						if (charNo == 0 || line[charNo-1] != '\\')
+						{
+							line = line.Substring(0, charNo).TrimEnd(' ', '\t');
+							break;
+						}
+					++charNo;
+				}
 				var t = line.TrimStart(' ', '\t');
 				if (t.Length == 0)
 					continue;


### PR DESCRIPTION
Another fix would be:

<pre>
if (line.Contains('#'))
{
    var commentIndex = line.IndexOf('#');
    var previousIndex = commentIndex - 1;
    if (commentIndex == 0 || line[previousIndex] != '\\')
        line = line.Substring(0, commentIndex).TrimEnd(' ', '\t');
}
</pre>


but this would ignore #bar in next line:
name\#foo#bar
