### PR TITLE
Server Shutdown Doesn't Remove Game from Master List

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -313,7 +313,8 @@ namespace OpenRA
 					{
 						System.Threading.Thread.Sleep(100);
 
-						if((server.GameStarted)&&(server.conns.Count<=1))
+						if( (server.State == Server.ServerState.ShuttingDown)
+						   && (server.conns.Count<=1) )
 						{
 							Console.WriteLine("No one is playing, shutting down...");
 							server.Shutdown();

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -313,8 +313,8 @@ namespace OpenRA
 					{
 						System.Threading.Thread.Sleep(100);
 
-						if( (server.State == Server.ServerState.ShuttingDown)
-						   && (server.conns.Count<=1) )
+						if((server.State == Server.ServerState.GameStarted)
+						    && (server.conns.Count<=1))
 						{
 							Console.WriteLine("No one is playing, shutting down...");
 							server.Shutdown();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -51,15 +51,15 @@ namespace OpenRA.Server
 		public Map Map;
 		XTimer gameTimeout;
 
-		volatile bool _shutdown = false;
+		volatile bool shutdown = false;
 		public bool ShuttingDown
 		{
-			get { return this._shutdown; }
+			get { return this.shutdown; }
 		}
 
 		public void Shutdown()
 		{
-			_shutdown = true;
+			shutdown = true;
 		}
 
 		public void EndGame()
@@ -154,7 +154,7 @@ namespace OpenRA.Server
 					foreach( var c in preConns ) checkRead.Add( c.socket );
 
 					Socket.Select( checkRead, null, null, timeout );
-					if (_shutdown)
+					if (shutdown)
 					{
 						this.EndGame();
 						break;
@@ -172,7 +172,7 @@ namespace OpenRA.Server
 					foreach (var t in ServerTraits.WithInterface<ITick>())
 						t.Tick(this);
 
-					if (_shutdown)
+					if (shutdown)
 					{
 						this.EndGame();
 						break;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Server
 		public Map Map;
 		XTimer gameTimeout;
 
-		protected ServerState pState = new ServerState();
+		protected volatile ServerState pState = new ServerState();
 		public ServerState State
 		{
 			get { return pState; }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -26,6 +26,13 @@ using XTimer = System.Timers.Timer;
 
 namespace OpenRA.Server
 {
+	public enum ServerState : int
+	{
+	       WaitingPlayers = 1,
+	       GameStarted = 2,
+	       ShuttingDown = 3
+	}
+
 	public class Server
 	{
 		// Valid player connections
@@ -40,7 +47,7 @@ namespace OpenRA.Server
 
 		TypeDictionary ServerTraits = new TypeDictionary();
 		public Session lobbyInfo;
-		public bool GameStarted = false;
+
 		public readonly IPAddress Ip;
 		public readonly int Port;
 		int randomSeed;
@@ -51,15 +58,16 @@ namespace OpenRA.Server
 		public Map Map;
 		XTimer gameTimeout;
 
-		volatile bool shutdown = false;
-		public bool ShuttingDown
+		protected ServerState pState = new ServerState();
+		public ServerState State
 		{
-			get { return this.shutdown; }
+			get { return pState; }
+			protected set { pState = value; }
 		}
 
 		public void Shutdown()
 		{
-			shutdown = true;
+			State = ServerState.ShuttingDown;
 		}
 
 		public void EndGame()
@@ -74,6 +82,7 @@ namespace OpenRA.Server
 		{
 			Log.AddChannel("server", "server.log");
 
+			pState = ServerState.WaitingPlayers;
 			listener = new TcpListener(endpoint);
 			listener.Start();
 			var localEndpoint = (IPEndPoint)listener.LocalEndpoint;
@@ -154,7 +163,7 @@ namespace OpenRA.Server
 					foreach( var c in preConns ) checkRead.Add( c.socket );
 
 					Socket.Select( checkRead, null, null, timeout );
-					if (shutdown)
+					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();
 						break;
@@ -172,14 +181,13 @@ namespace OpenRA.Server
 					foreach (var t in ServerTraits.WithInterface<ITick>())
 						t.Tick(this);
 
-					if (shutdown)
+					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();
 						break;
 					}
 				}
 
-				GameStarted = false;
 				foreach (var t in ServerTraits.WithInterface<INotifyServerShutdown>())
 					t.ServerShutdown(this);
 
@@ -257,7 +265,7 @@ namespace OpenRA.Server
 		{
 			try
 			{
-				if (GameStarted)
+				if (State == ServerState.GameStarted)
 				{
 					Log.Write("server", "Rejected connection from {0}; game is already started.",
 						newConn.socket.RemoteEndPoint);
@@ -506,13 +514,13 @@ namespace OpenRA.Server
 				
 				OpenRA.Network.Session.Client dropClient = lobbyInfo.Clients.Where(c1 => c1.Index == toDrop.PlayerIndex).Single();
 				
-				if (GameStarted)
+				if (State == ServerState.GameStarted)
 					SendDisconnected(toDrop); /* Report disconnection */
 
 				lobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
 
 				// reassign admin if necessary
-				if ( lobbyInfo.GlobalSettings.Dedicated && dropClient.IsAdmin && !GameStarted)
+				if ( lobbyInfo.GlobalSettings.Dedicated && dropClient.IsAdmin && State == ServerState.WaitingPlayers)
 				{
 					if (lobbyInfo.Clients.Count() > 0)
 					{
@@ -538,7 +546,7 @@ namespace OpenRA.Server
 
 		public void SyncLobbyInfo()
 		{
-			if (!GameStarted)	/* don't do this while the game is running, it breaks things. */
+			if (State != ServerState.GameStarted)	/* don't do this while the game is running, it breaks things. */
 				DispatchOrders(null, 0,
 					new ServerOrder("SyncInfo", lobbyInfo.Serialize()).Serialize());
 
@@ -548,7 +556,7 @@ namespace OpenRA.Server
 
 		public void StartGame()
 		{
-			GameStarted = true;
+			State = ServerState.GameStarted;
 			listener.Stop();
 
 			Console.WriteLine("Game started");

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Server
 					Socket.Select( checkRead, null, null, timeout );
 					if (shutdown)
 					{
-						this.EndGame();
+						EndGame();
 						break;
 					}
 
@@ -174,7 +174,7 @@ namespace OpenRA.Server
 
 					if (shutdown)
 					{
-						this.EndGame();
+						EndGame();
 						break;
 					}
 				}

--- a/OpenRA.Game/Server/TraitInterfaces.cs
+++ b/OpenRA.Game/Server/TraitInterfaces.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Server
 	public interface INotifyServerShutdown { void ServerShutdown(Server server); }
 	public interface IStartGame { void GameStarted(Server server); }
 	public interface IClientJoined { void ClientJoined(Server server, Connection conn); }
+	public interface IEndGame { void GameEnded(Server server); }
 	public interface ITick
 	{
 		void Tick(Server server);
@@ -28,7 +29,7 @@ namespace OpenRA.Server
 
 	public abstract class ServerTrait {}
 
-	public class DebugServerTrait : ServerTrait, IInterpretCommand, IStartGame, INotifySyncLobbyInfo, INotifyServerStart, INotifyServerShutdown
+	public class DebugServerTrait : ServerTrait, IInterpretCommand, IStartGame, INotifySyncLobbyInfo, INotifyServerStart, INotifyServerShutdown, IEndGame
 	{
 		public bool InterpretCommand(Server server, Connection conn, Session.Client client, string cmd)
 		{
@@ -54,6 +55,11 @@ namespace OpenRA.Server
 		public void ServerShutdown(Server server)
 		{
 			Console.WriteLine("ServerShutdown()");
+		}
+
+		public void GameEnded(Server server)
+		{
+			Console.WriteLine("GameEnded()");
 		}
 	}
 }

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Server
 
 		public static bool ValidateCommand(S server, Connection conn, Session.Client client, string cmd)
 		{
-			if (server.GameStarted)
+			if (server.State == ServerState.GameStarted)
 			{
 				server.SendChatTo(conn, "Cannot change state when game started. ({0})".F(cmd));
 				return false;

--- a/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
@@ -19,13 +19,6 @@ namespace OpenRA.Mods.RA.Server
 {
 	public class MasterServerPinger : ServerTrait, ITick, INotifySyncLobbyInfo, IStartGame, IEndGame
 	{
-		protected enum ServerState : int
-		{
-			WaitingPlayers = 1,
-			GameStarted = 2,
-			ShuttingDown = 3
-		}
-
 		const int MasterPingInterval = 60 * 3;	// 3 minutes. server has a 5 minute TTL for games, so give ourselves a bit
 												// of leeway.
 		public int TickTimeout { get { return MasterPingInterval * 10000; } }
@@ -68,17 +61,11 @@ namespace OpenRA.Mods.RA.Server
 						using (var wc = new WebClient())
 						{
 							wc.Proxy = null;
-							ServerState state = new ServerState();
-
-							if (server.ShuttingDown)
-								state = ServerState.ShuttingDown;
-							else
-								state = server.GameStarted ? ServerState.GameStarted : ServerState.WaitingPlayers;
 
 							 wc.DownloadData(
 								server.Settings.MasterServer + url.F(
 								server.Settings.ExternalPort, Uri.EscapeUriString(server.Settings.Name),
-								(int) state,
+								(int) server.State,
 								server.lobbyInfo.Clients.Count,
 								Game.CurrentMods.Select(f => "{0}@{1}".F(f.Key, f.Value.Version)).JoinWith(","),
 								server.lobbyInfo.GlobalSettings.Map,

--- a/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
@@ -61,10 +61,14 @@ namespace OpenRA.Mods.RA.Server
 						using (var wc = new WebClient())
 						{
 							wc.Proxy = null;
+							int state = server.GameStarted ? 2 : 1;
+							if (server.ShuttingDown)
+								state = 3;
+
 							 wc.DownloadData(
 								server.Settings.MasterServer + url.F(
 								server.Settings.ExternalPort, Uri.EscapeUriString(server.Settings.Name),
-								(server.ShuttingDown ? 3 : (server.GameStarted ? 2 : 1)),	// todo: post-game states, etc.
+								state,
 								server.lobbyInfo.Clients.Count,
 								Game.CurrentMods.Select(f => "{0}@{1}".F(f.Key, f.Value.Version)).JoinWith(","),
 								server.lobbyInfo.GlobalSettings.Map,

--- a/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Server
 {
 	public class MasterServerPinger : ServerTrait, ITick, INotifySyncLobbyInfo, IStartGame, IEndGame
 	{
-		protected enum State : int
+		protected enum ServerState : int
 		{
 			WaitingPlayers = 1,
 			GameStarted = 2,
@@ -68,12 +68,12 @@ namespace OpenRA.Mods.RA.Server
 						using (var wc = new WebClient())
 						{
 							wc.Proxy = null;
-							State state = new State();
+							ServerState state = new ServerState();
 
 							if (server.ShuttingDown)
-								state = State.ShuttingDown;
+								state = ServerState.ShuttingDown;
 							else
-								state = server.GameStarted ? State.GameStarted : State.WaitingPlayers;
+								state = server.GameStarted ? ServerState.GameStarted : ServerState.WaitingPlayers;
 
 							 wc.DownloadData(
 								server.Settings.MasterServer + url.F(

--- a/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
@@ -17,7 +17,7 @@ using S = OpenRA.Server.Server;
 
 namespace OpenRA.Mods.RA.Server
 {
-	public class MasterServerPinger : ServerTrait, ITick, INotifySyncLobbyInfo, IStartGame
+	public class MasterServerPinger : ServerTrait, ITick, INotifySyncLobbyInfo, IStartGame, IEndGame
 	{
 		const int MasterPingInterval = 60 * 3;	// 3 minutes. server has a 5 minute TTL for games, so give ourselves a bit
 												// of leeway.
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.RA.Server
 
 		public void LobbyInfoSynced(S server) { PingMasterServer(server); }
 		public void GameStarted(S server) { PingMasterServer(server); }
+		public void GameEnded(S server) { PingMasterServer(server); }
 
 		int lastPing = 0;
 		bool isInitialPing = true;
@@ -63,7 +64,7 @@ namespace OpenRA.Mods.RA.Server
 							 wc.DownloadData(
 								server.Settings.MasterServer + url.F(
 								server.Settings.ExternalPort, Uri.EscapeUriString(server.Settings.Name),
-								server.GameStarted ? 2 : 1,	// todo: post-game states, etc.
+								(server.ShuttingDown ? 3 : (server.GameStarted ? 2 : 1)),	// todo: post-game states, etc.
 								server.lobbyInfo.Clients.Count,
 								Game.CurrentMods.Select(f => "{0}@{1}".F(f.Key, f.Value.Version)).JoinWith(","),
 								server.lobbyInfo.GlobalSettings.Map,


### PR DESCRIPTION
When the server is shutdown the master server should pinged with a state that
causes the server to be removed from the list. 

This means that if a server shuts down correctly it will be removed from the server list right away. Some changes have been made to the MasterServer to go with this.
