### PR TITLE
Don't remap civilian buildings/fields in-game.

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -294,6 +294,10 @@
 	Tooltip:
 		Name: Field
 	-WithBuildingExplosion:
+	RenderBuilding:
+		Palette: terrain
+	EditorAppearance:
+		UseTerrainPalette: true
 
 ^CivFieldHusk:
 	AppearsOnRadar:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -262,6 +262,8 @@
 
 ^CivBuilding:
 	Inherits: ^TechBuilding
+	RenderBuilding:
+		Palette: terrain
 	EditorAppearance:
 		UseTerrainPalette: true
 


### PR DESCRIPTION
V16 field was affected most because it consists nearly only of remapped colors. This was already fixed in the editor, but apparently not in the game itself.
