### PR TITLE
Don't auto-target the neutral badger that drops crates!

### DIFF
--- a/OpenRA.Mods.RA/CrateDrop.cs
+++ b/OpenRA.Mods.RA/CrateDrop.cs
@@ -95,6 +95,10 @@ namespace OpenRA.Mods.RA
 						new AltitudeInit( Rules.Info["badr"].Traits.Get<AircraftInfo>().CruiseAltitude ),
 					});
 
+
+					var autoTargetIgnore = new AutoTargetIgnore();
+					plane.AddTrait(autoTargetIgnore);
+
 					plane.CancelActivity();
 					plane.QueueActivity(new FlyAttack(Target.FromCell(p)));
 					plane.Trait<ParaDrop>().SetLZ(p);


### PR DESCRIPTION
Those crates are useful! We've noticed that the badger can get auto-targeted and shot down quite often... let's not do that.
