### PR TITLE
MIG Improvements

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -96,13 +96,15 @@ MIG:
 	RevealsShroud:
 		Range: 12
 	AttackPlane:
-		PrimaryWeapon: Maverick
+		PrimaryWeapon: MaverickAG
 		PrimaryLocalOffset: -15,0,0,0,-10, 15,0,0,0,6
+		SecondaryWeapon: MaverickAA
+		SecondaryLocalOffset: -15,0,0,0,-10, 15,0,0,0,6
 		FacingTolerance: 20
 	Plane:
 		InitialFacing: 192
 		ROT: 5
-		Speed: 20
+		Speed: 25
 		RearmBuildings: afld
 	RenderUnit:
 	WithShadow:
@@ -261,7 +263,7 @@ HELI:
 		LandWhenIdle: false
 		InitialFacing: 20
 		ROT: 4
-		Speed: 16
+		Speed: 18
 	RenderUnit:
 	WithRotor:
 		Offset: 0,0,0,-2

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -105,16 +105,16 @@ Vulcan:
 		Damage: 10
 		Delay: 10
 		
-Maverick:
+MaverickAG:
 	ROF: 30
 	Range: 9
 	MinRange: 3
 	Report: MISSILE7
-	Burst: 2
+	Burst: 4
 	BurstDelay: 7
 	ValidTargets: Ground
 	Projectile: Missile
-		Speed: 30
+		Speed: 45
 		Arm: 2
 		High: true
 		Shadow: false
@@ -135,6 +135,39 @@ Maverick:
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		InfDeath: 4
+		SmudgeType: Crater
+		Damage: 70
+		
+MaverickAA:
+	ROF: 30
+	Range: 9
+	MinRange: 3
+	Report: MISSILE7
+	Burst: 2
+	BurstDelay: 1
+	ValidTargets: Air
+	Projectile: Missile
+		Speed: 60
+		Arm: 2
+		High: true
+		Shadow: false
+		Proximity: true
+#		Trail: smokey
+		ContrailLength: 10
+		Inaccuracy: 3
+		Image: DRAGON
+		ROT: 5
+		RangeLimit: 60
+	Warhead:
+		Spread: 3
+		Versus: 
+			None: 30%
+			Wood: 75%
+			Light: 75%
+			Concrete: 50%
+		Explosion: med_explosion
+		WaterExplosion: med_splash
+		InfDeath: 3
 		SmudgeType: Crater
 		Damage: 70
 		


### PR DESCRIPTION
The MIG is pretty darn expensive and carries a lot of risk in that cost. We found ourselves never building the plane, because Yaks were just as effective for the vast majority of use cases. This patch gives MIGs back the base strike ability they once had, with the added bonus that they are excellent in air-to-air combat (which they should be).
- MIG is now faster
- Longbow is now slightly faster
- MIG carries more firepower
- MIG missiles are faster
- MIG can fire anti-air
