### PR TITLE
Fixed airfield name.

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1002,7 +1002,7 @@ AFLD:
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Airstrip
+		Name: Airfield
 		Description: Provides radar and off-map support\n  Special Ability: Paratroopers\n  Special Ability: Spy Plane
 	Building:
 		Power: -20


### PR DESCRIPTION
The name of the airfield was airstrip... which is wrong since the icon says airfield whilte the building is called airstrip... its even called AFLD in the code so... just a simple fix :)
