### PR TITLE
Fixed repairing landed airplanes

### DIFF
--- a/OpenRA.Mods.RA/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.RA/Air/ReturnToBase.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.RA.Air
 
 			var speed = .2f * aircraft.MovementSpeed;
 
-            /* if the aircraft is on the ground, it will take off to the cruise altitude first before approaching */
+			/* if the aircraft is on the ground, it will take off to the cruise altitude first before approaching */
 			var altitude = aircraft.Altitude;
 			if (altitude == 0) altitude = self.Info.Traits.Get<PlaneInfo>().CruiseAltitude;
 

--- a/OpenRA.Mods.RA/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.RA/Air/ReturnToBase.cs
@@ -53,8 +53,8 @@ namespace OpenRA.Mods.RA.Air
 			var speed = .2f * aircraft.MovementSpeed;
 
             /* if the aircraft is on the ground, it will take off to the cruise altitude first before approaching */
-            var altitude = aircraft.Altitude;
-            if (altitude == 0) altitude = self.Info.Traits.Get<PlaneInfo>().CruiseAltitude;
+			var altitude = aircraft.Altitude;
+			if (altitude == 0) altitude = self.Info.Traits.Get<PlaneInfo>().CruiseAltitude;
 
 			var approachStart = landPos.ToFloat2() - new float2(altitude * speed, 0);
 			var turnRadius = (128f / self.Info.Traits.Get<AircraftInfo>().ROT) * speed / (float)Math.PI;

--- a/OpenRA.Mods.RA/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.RA/Air/ReturnToBase.cs
@@ -52,7 +52,11 @@ namespace OpenRA.Mods.RA.Air
 
 			var speed = .2f * aircraft.MovementSpeed;
 
-			var approachStart = landPos.ToFloat2() - new float2(aircraft.Altitude * speed, 0);
+            /* if the aircraft is on the ground, it will take off to the cruise altitude first before approaching */
+            var altitude = aircraft.Altitude;
+            if (altitude == 0) altitude = self.Info.Traits.Get<PlaneInfo>().CruiseAltitude;
+
+			var approachStart = landPos.ToFloat2() - new float2(altitude * speed, 0);
 			var turnRadius = (128f / self.Info.Traits.Get<AircraftInfo>().ROT) * speed / (float)Math.PI;
 
 			/* work out the center points */


### PR DESCRIPTION
This is most likely issue #2365

When an airplane was landed and ordered to another airport or service depot, the approach distance was not properly calculated since it was not taken into effect that its current altitude is zero. The result was that the plane was unable to land and returned to the airport.
