### PR TITLE
Changed scroll velocity in the map chooser for better mouse scolling

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
@@ -31,6 +31,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			widget.Get<ButtonWidget>("BUTTON_CANCEL").OnClick = () => { Ui.CloseWindow(); onExit(); };
 
 			scrollpanel = widget.Get<ScrollPanelWidget>("MAP_LIST");
+			scrollpanel.ScrollVelocity = 40f;
+
 			itemTemplate = scrollpanel.Get<ScrollItemWidget>("MAP_TEMPLATE");
 
 			var gameModeDropdown = widget.GetOrNull<DropDownButtonWidget>("GAMEMODE_FILTER");


### PR DESCRIPTION
Scrolling with mouse in the map chooser dialog was much too slow to be useful. 

I changed the scrolling velocity for the map chooser instance to the default \* 10 so mouse can now normally be used to scroll down the list of maps
