### PR TITLE
Build limit

### DIFF
--- a/OpenRA.Mods.RA/Buildable.cs
+++ b/OpenRA.Mods.RA/Buildable.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.RA
 
 		public readonly string Queue;
 		public readonly bool Hidden = false;
+		public readonly int BuildLimit = 0;
 
 		// todo: UI fluff; doesn't belong here
 		public readonly int BuildPaletteOrder = 9999;

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -213,11 +213,12 @@ E7:
 		Prerequisites: techcenter
 		Owner: allies
 		Hotkey: y
+		BuildLimit: 1
 	Valued:
 		Cost: 1200
 	Tooltip:
 		Name: Tanya
-		Description: Elite commando infantry, armed with \ndual pistols and C4.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles\n  Special Ability: Destroy Building with C4
+		Description: Elite commando infantry, armed with \ndual pistols and C4.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles\n  Special Ability: Destroy Building with C4\n\nMaximum 1 can be trained
 	Selectable:
 		Voice: TanyaVoice
 		Bounds: 12,17,0,-9
@@ -247,11 +248,12 @@ E8:
 		Prerequisites: stek
 		Owner: soviet
 		Hotkey: v
+		BuildLimit: 1
 	Valued:
 		Cost: 1800
 	Tooltip:
 		Name: Volkov
-		Description: Elite commando cyborg, armed with \nmodular cannons and grenade launcher.\n  Strong vs Vehicles, Infantry\n  Weak vs Aircraft
+		Description: Elite commando cyborg, armed with \nmodular cannons and grenade launcher.\n  Strong vs Vehicles, Infantry\n  Weak vs Aircraft\n\nMaximum 1 can be trained
 	Selectable:
 		Voice: VolkovVoice
 		Bounds: 12,17,0,-9

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -4,13 +4,14 @@ MSLO:
 		Cost: 2500
 	Tooltip:
 		Name: Missile Silo
-		Description: Launches a devastating nuclear strike.\n  Strong vs Infantry, Buildings\n  Weak vs Tanks\n  Special Ability: Nuclear Missile
+		Description: Launches a devastating nuclear strike.\n  Strong vs Infantry, Buildings\n  Weak vs Tanks\n  Special Ability: Nuclear Missile\n\nMaximum 1 can be built
 		Icon: msloicon2
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 130
 		Prerequisites: techcenter
 		Owner: soviet,allies
+		BuildLimit: 1
 	Building:
 		Power: -100
 		Footprint: xx


### PR DESCRIPTION
Added the possibility of specifying the maximum number of units (closes #2529)

Maximum number of specific units the player is allowed to build/train can be set by setting the Buildable -> BuildLimit property, for example:

```
Buildable:
    BuildLimit: 1
```

The player is not allowed to build more units than specified. If they somehow receive additional units of the same type by other means (capturing a building, crates, ...), they can go over this limit, however they won't be able to build additional ones of course.

In this batch the limit is set for Volkov and Tanya, however it could be applied to any other units or building, such as Missile Siloe (issue #2515)
