### PR TITLE
Allow multiple units in a crate

### DIFF
--- a/OpenRA.Mods.RA/CrateAction.cs
+++ b/OpenRA.Mods.RA/CrateAction.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA
 		public string Notification = null;
 		[ActorReference]
 		public string[] ExcludedActorTypes = { };
-
+		public readonly string[] GivenTo = { };
 		public virtual object Create(ActorInitializer init) { return new CrateAction(init.self, this); }
 	}
 
@@ -39,6 +39,9 @@ namespace OpenRA.Mods.RA
 		public int GetSelectionSharesOuter(Actor collector)
 		{
 			if (info.ExcludedActorTypes.Contains(collector.Info.Name))
+				return 0;
+
+			if (info.GivenTo.Any() && !info.GivenTo.Contains(collector.Owner.Country.Race))
 				return 0;
 
 			return GetSelectionShares(collector);

--- a/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Crates
 	class GiveUnitCrateActionInfo : CrateActionInfo
 	{
 		[ActorReference]
-		public readonly string Unit = null;
+		public readonly string[] Unit = null;
 		public readonly string Owner = null;
 
 		public override object Create(ActorInitializer init) { return new GiveUnitCrateAction(init.self, this); }
@@ -27,42 +27,52 @@ namespace OpenRA.Mods.RA.Crates
 
 	class GiveUnitCrateAction : CrateAction
 	{
-		GiveUnitCrateActionInfo Info;
+		readonly GiveUnitCrateActionInfo Info;
+		readonly List<CPos> usedCells = new List<CPos>();
 
 		public GiveUnitCrateAction(Actor self, GiveUnitCrateActionInfo info)
 			: base(self, info) { Info = info; }
 
 		public override int GetSelectionShares(Actor collector)
 		{
-			var bi = Rules.Info[Info.Unit].Traits.GetOrDefault<BuildableInfo>();
+			var unit = Info.Unit.First();
+			var bi = Rules.Info[unit].Traits.GetOrDefault<BuildableInfo>();
 
 			// this unit is not buildable by the collector's country, so
 			// don't give them free ones either.
 			if (Info.Owner == null && bi != null && !bi.Owner.Contains(collector.Owner.Country.Race)) return 0;
 
 			// avoid dumping tanks in the sea, and ships on dry land.
-			if (!GetSuitableCells(collector.Location).Any()) return 0;
+			if (!GetSuitableCells(collector.Location, unit).Any()) return 0;
 
 			return base.GetSelectionShares(collector);
 		}
 
 		public override void Activate(Actor collector)
 		{
-			var location = ChooseEmptyCellNear(collector);
-			if (location != null)
-				collector.World.AddFrameEndTask(
-					w => w.CreateActor(Info.Unit, new TypeDictionary
-					{
-						new LocationInit( location.Value ),
-						new OwnerInit( Info.Owner ?? collector.Owner.InternalName )
-					}));
+			foreach (var unit in Info.Unit)
+			{
+				var tmpUnit = unit; // avoiding access to modified closure
 
-			base.Activate(collector);
+				var location = ChooseEmptyCellNear(collector, unit);
+				if (location != null)
+				{
+					usedCells.Add(location.Value);
+					collector.World.AddFrameEndTask(
+					w => w.CreateActor(tmpUnit, new TypeDictionary
+						{
+							new LocationInit(location.Value),
+							new OwnerInit(Info.Owner ?? collector.Owner.InternalName)
+						}));
+				}
+			}
+
+		    base.Activate(collector);
 		}
 
-		IEnumerable<CPos> GetSuitableCells(CPos near)
+		IEnumerable<CPos> GetSuitableCells(CPos near, string unit)
 		{
-			var mi = Rules.Info[Info.Unit].Traits.Get<MobileInfo>();
+			var mi = Rules.Info[unit].Traits.Get<MobileInfo>();
 
 			for (var i = -1; i < 2; i++)
 				for (var j = -1; j < 2; j++)
@@ -70,9 +80,9 @@ namespace OpenRA.Mods.RA.Crates
 						yield return near + new CVec(i, j);
 		}
 
-		CPos? ChooseEmptyCellNear(Actor a)
+		CPos? ChooseEmptyCellNear(Actor a, string unit)
 		{
-			var possibleCells = GetSuitableCells(a.Location).ToArray();
+			var possibleCells = GetSuitableCells(a.Location, unit).Where(c => !usedCells.Contains(c)).ToArray();
 			if (possibleCells.Length == 0)
 				return null;
 

--- a/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Crates
 	class GiveUnitCrateActionInfo : CrateActionInfo
 	{
 		[ActorReference]
-		public readonly string[] Unit = null;
+		public readonly string[] Units = null;
 		public readonly string Owner = null;
 
 		public override object Create(ActorInitializer init) { return new GiveUnitCrateAction(init.self, this); }
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.RA.Crates
 
 		public override int GetSelectionShares(Actor collector)
 		{
-			var unit = Info.Unit.First();
+			var unit = Info.Units.First();
 			var bi = Rules.Info[unit].Traits.GetOrDefault<BuildableInfo>();
 
 			// this unit is not buildable by the collector's country, so
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Crates
 
 		public override void Activate(Actor collector)
 		{
-			foreach (var unit in Info.Unit)
+			foreach (var unit in Info.Units)
 			{
 				var tmpUnit = unit; // avoiding access to modified closure
 

--- a/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
@@ -36,11 +36,6 @@ namespace OpenRA.Mods.RA.Crates
 		public override int GetSelectionShares(Actor collector)
 		{
 			var unit = Info.Units.First();
-			var bi = Rules.Info[unit].Traits.GetOrDefault<BuildableInfo>();
-
-			// this unit is not buildable by the collector's country, so
-			// don't give them free ones either.
-			if (Info.Owner == null && bi != null && !bi.Owner.Contains(collector.Owner.Country.Race)) return 0;
 
 			// avoid dumping tanks in the sea, and ships on dry land.
 			if (!GetSuitableCells(collector.Location, unit).Any()) return 0;

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -375,25 +375,36 @@ CRATE:
 		Unit: mcv
 	GiveUnitCrateAction@jeep:
 		SelectionShares: 7
-		Unit: jeep
+		Units: jeep
 	GiveUnitCrateAction@arty:
 		SelectionShares: 6
-		Unit: arty
+		Units: arty
 	GiveUnitCrateAction@v2rl:
 		SelectionShares: 6
-		Unit: v2rl
+		Units: v2rl
 	GiveUnitCrateAction@1tnk:
 		SelectionShares: 5
-		Unit: 1tnk
+		Units: 1tnk
+	GiveUnitCrateAction@squad1:
+		SelectionShares: 5
+		Units: e1,e1,e3
 	GiveUnitCrateAction@2tnk:
 		SelectionShares: 4
-		Unit: 2tnk
+		Units: 2tnk
 	GiveUnitCrateAction@3tnk:
 		SelectionShares: 4
-		Unit: 3tnk
+		Units: 3tnk
 	GiveUnitCrateAction@4tnk:
 		SelectionShares: 3
-		Unit: 4tnk
+		Units: 4tnk
+	GiveUnitCrateAction@squad2:
+		SelectionShares: 2
+		Units: 1tnk,1tnk,2tnk
+		GivenTo: allies
+	GiveUnitCrateAction@squad3:
+		SelectionShares: 2
+		Units: 3tnk,3tnk
+		GivenTo: soviet
 	RenderSimple:
 	BelowUnits:
 	ProximityCaptor:

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -376,34 +376,37 @@ CRATE:
 	GiveUnitCrateAction@jeep:
 		SelectionShares: 7
 		Units: jeep
+		GivenTo: allies
 	GiveUnitCrateAction@arty:
 		SelectionShares: 6
 		Units: arty
+		GivenTo: allies
 	GiveUnitCrateAction@v2rl:
 		SelectionShares: 6
 		Units: v2rl
+		GivenTo: soviet
 	GiveUnitCrateAction@1tnk:
 		SelectionShares: 5
 		Units: 1tnk
+		GivenTo: allies
 	GiveUnitCrateAction@squad1:
 		SelectionShares: 5
 		Units: e1,e1,e3
+	GiveUnitCrateAction@squad2:
+		SelectionShares: 5
+		Units: e1,e3,e4
+		GivenTo: soviet
 	GiveUnitCrateAction@2tnk:
 		SelectionShares: 4
 		Units: 2tnk
+		GivenTo: allies
 	GiveUnitCrateAction@3tnk:
 		SelectionShares: 4
 		Units: 3tnk
+		GivenTo: soviet
 	GiveUnitCrateAction@4tnk:
 		SelectionShares: 3
 		Units: 4tnk
-	GiveUnitCrateAction@squad2:
-		SelectionShares: 2
-		Units: 1tnk,1tnk,2tnk
-		GivenTo: allies
-	GiveUnitCrateAction@squad3:
-		SelectionShares: 2
-		Units: 3tnk,3tnk
 		GivenTo: soviet
 	RenderSimple:
 	BelowUnits:


### PR DESCRIPTION
... (closes #2165)

By specifying multiple units in a crate, a squad can be given to the player, for example:

```
GiveUnitCrateAction@squad:
    SelectionShares: 20
    Unit: e1,e1,e3,e3
```

The first unit specified is used for determining whether the crate can be given to the user, so for example: 

```
    Unit: e1,e1,e3,e3
```

will be used for both sides (soviet and allies), while

```
    Unit: e2,e1,e3,e3
```

can be used to allow this type of crate for soviets only
