### PR TITLE
Mud no longer crashes the sound engine: Bring it back in.

### DIFF
--- a/mods/ra/music.yaml
+++ b/mods/ra/music.yaml
@@ -10,7 +10,7 @@ fac1226m: Face to the Enemy 1
 fac2226m: Face to the Enemy 2
 fogger1a: Fogger
 hell226m: Hell March
-#mud1a: Mud # Crashes sound engine
+mud1a: Mud
 radio2: Radio 2
 rollout: Roll Out
 run1226m: Run for your Life


### PR DESCRIPTION
Tested this with the latest playtest. Mud no longer crashes the sound engine if brought back in by uncommenting it out and playing it ingame. So it should be brought back in.
