### PR TITLE
Removed mouse capture while composing text in chat (fixes #2486)

### DIFF
--- a/OpenRA.Game/Widgets/ChatEntryWidget.cs
+++ b/OpenRA.Game/Widgets/ChatEntryWidget.cs
@@ -45,11 +45,6 @@ namespace OpenRA.Widgets
 
 		public override Rectangle EventBounds { get { return Rectangle.Empty; } }
 
-		public override bool LoseFocus(MouseInput mi)
-		{
-			return composing ? false : base.LoseFocus(mi);
-		}
-
 		public override bool HandleKeyPress(KeyInput e)
 		{
 			if (e.Event == KeyInputEvent.Up) return false;


### PR DESCRIPTION
I have been using this for a while and found no side effects.

I checked the history of this file and it seems this override was there from the beginning. While it might seem obvious that the widget will not capture keyboard anymore if the (mouse) focus is lost, it does not behave that way.

By removing this override, mouse works completely normal while typing the chat message (before you could click _some_ things but not the other (e.g. you could build but not place buildings) and it seems all keyboard strokes are still received by the chat until pressing the enter/return key - even when for example going to Options, changing things there and returning the chat seems to continue working normally.

I think even the worst-case scenario (which would probably be that the text widget would lose all focus until again reactivated by the enter key and which does _not_ happen anyway) would still outweigh the now more commonly occurring scenario which causes confusion by the half-working mouse when the player needs to immediately react to a game situation while in the middle of typing a message.
