### PR TITLE
Use Markdown for Readme and Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# OpenRA Contributing Guidelines
+
+## Bug reports
+
+* Have you read the [FAQ](https://github.com/OpenRA/OpenRA/wiki/FAQ)?
+* Add the appropriate log files on crashes.
+* Please be specific on how to reproduce the problem.
+
+## Patches
+
+* [Coding standard](https://github.com/OpenRA/OpenRA/wiki/Coding-Standard)
+* [Branches and Releases](https://github.com/OpenRA/OpenRA/wiki/Branches-and-Releases)
+* [Licensing](http://www.gnu.org/licenses/quick-guide-gplv3.html)
+
+Please `git rebase` to the latest revision of the bleed branch.
+
+Don't forget to add youself to [AUTHORS](https://github.com/OpenRA/OpenRA/blob/bleed/AUTHORS).
+
+While your pull-request is in review it will be helpful if you join [IRC](irc://chat.freenode.net/openra) to discuss the changes.

--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-OpenRA is a Libre/Free Real Time Strategy game engine supporting early Westwood games like Command & Conquer and Command & Conquer: Red Alert.
-
-Distributed mods include a reimagining and updating of both the Red Alert and Command & Conquer multiplayer games.
-
-Please read INSTALL on how to install an OpenRA development environment and HACKING for an overview of the engine.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# OpenRA
+
+A Libre/Free Real Time Strategy game engine supporting early Westwood classics.
+
+* Website: [http://www.open-ra.org](http://www.open-ra.org)
+* IRC: \#openra on irc.freenode.net
+* Repository: [https://github.com/openra/openra](https://github.com/openra/openra)
+
+Please read the [FAQ](https://github.com/OpenRA/OpenRA/wiki/FAQ) in our [Wiki](https://github.com/OpenRA/OpenRA/wiki) and report problems at [http://bugs.open-ra.org](http://bugs.open-ra.org).
+
+Join the [Forums](http://www.sleipnirstuff.com/forum/viewforum.php?f=80) for discussion.
+
+## Play
+
+Distributed mods include a reimagining of
+* Command & Conquer: Red Alert
+* Command & Conquer: Tiberian Dawn
+* Dune 2000 (experimental)
+
+Check our [Playing the Game](https://github.com/OpenRA/OpenRA/wiki/Playing-the-game) Guide to win multiplayer matches.
+
+## Contribute
+
+* Please read [INSTALL](https://github.com/OpenRA/OpenRA/blob/bleed/INSTALL) and [Compiling](https://github.com/OpenRA/OpenRA/wiki/Compiling) on how to set up an OpenRA development environment.
+* Read [HACKING](https://github.com/OpenRA/OpenRA/blob/bleed/HACKING) for an overview of the engine.
+* To get your patches merged please adhere to the [Contributing](https://github.com/OpenRA/OpenRA/blob/bleed/CONTRIBUTING.md) guidelines.
+* Some insights on the upcoming [Translation](https://github.com/OpenRA/OpenRA/wiki/Translation) framework.
+
+## Mapping
+
+* We offer a [Mapping](https://github.com/OpenRA/OpenRA/wiki/Mapping) Tutorial as you can change gameplay drastically with custom maps.
+* If you want to share custom maps, mini-games and units with the community upload them at [http://content.open-ra.org](http://content.open-ra.org)
+
+## Modding
+
+* There exists an incomplete [Trait documentation](https://github.com/OpenRA/OpenRA/wiki/Trait-Documentation) to get started with yaml files.
+* Check the [Modding Guide](https://github.com/OpenRA/OpenRA/wiki/Modding%20Guide) to create your own classic RTS.
+* Some hints on to create new OpenRA compatible [Pixelart](https://github.com/OpenRA/OpenRA/wiki/Pixelart).
+* Upload total conversions at [our ModDB profile](http://www.moddb.com/games/openra/mods)
+
+## Support
+
+* Sponsor a mirror server if you have some bandwidth to spare (ask in IRC).
+* You can immediately set up a [Dedicated](https://github.com/OpenRA/OpenRA/wiki/Dedicated) Game Server.
+* Fund development by creating [Bounties](https://www.bountysource.com/#repos/OpenRA/OpenRA) on specific tasks.


### PR DESCRIPTION
This will use https://github.com/github/markup for the Readme and add a boiler plate pointing to https://github.com/blog/1184-contributing-guidelines when someone adds a new bug report or pull request.
