### PR TITLE
Distinguish System Messages between Player Chat, fixes #2079

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -385,7 +385,7 @@ namespace OpenRA
 
 		public static void Debug(string s, params object[] args)
 		{
-			AddChatLine(Color.White, "Debug", String.Format(s,args));
+			AddChatLine(Color.White, "", String.Format(s,args));
 		}
 
 		public static void Disconnect()

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Network
 
 				case "StartGame":
 					{
-						Game.AddChatLine(Color.White, "Server", "The game has started.");
+						Game.Debug("The game has started.");
 						Game.StartGame(orderManager.LobbyInfo.GlobalSettings.Map, false);
 						break;
 					}
@@ -103,7 +103,7 @@ namespace OpenRA.Network
 						{
 							orderManager.GamePaused = !orderManager.GamePaused;
 							var pausetext = "The game is {0} by {1}".F( orderManager.GamePaused ? "paused" : "un-paused", client.Name );
-							Game.AddChatLine(Color.White, "", pausetext);
+							Game.Debug(pausetext);
 						}
 						break;
 					}


### PR DESCRIPTION
- remove colons from system messages and don't call them Debug
- use Game.Debug() everywhere
