### PR TITLE
Make volkov vulnerable to Anti-Personnel mines, and immune to anti-tank mines

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -263,7 +263,7 @@ E8:
 		Type: Cybernetic
 	Mobile:
 		Speed: 5
-		Crushes: atmine, crate
+		Crushes: apmine, crate
 	RevealsShroud:
 		Range: 4
 	Passenger:

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -1216,7 +1216,7 @@ APMine:
 			Light: 0%
 			Heavy: 0%
 			Concrete: 0%
-			Cybernetic: 40%
+			Cybernetic: 80%
 		ImpactSound: mine1
 		InfDeath: 3
 		Explosion: napalm

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -1204,7 +1204,7 @@ ATMine:
 			None: 0%
 			Wood: 0%
 			Concrete: 0%
-			Cybernetic: 60%
+			Cybernetic: 0%
 		ImpactSound: mineblo1
 		Explosion: large_explosion
 
@@ -1216,7 +1216,7 @@ APMine:
 			Light: 0%
 			Heavy: 0%
 			Concrete: 0%
-			Cybernetic: 0%
+			Cybernetic: 40%
 		ImpactSound: mine1
 		InfDeath: 3
 		Explosion: napalm


### PR DESCRIPTION
Why is volkov immune to Anti-Personnel mines, but is killed by Anti-Tank mines? Reverted as this violates set principles and is un-realistic and un-RAlistic
