### PR TITLE
Destructible trees for both CnC and RA mod

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -76,7 +76,6 @@
     <Compile Include="Activities\HarvesterDockSequence.cs" />
     <Compile Include="CncLoadScreen.cs" />
     <Compile Include="CncMenuPaletteEffect.cs" />
-    <Compile Include="DeadBuildingState.cs" />
     <Compile Include="Effects\IonCannon.cs" />
     <Compile Include="IonCannonPower.cs" />
     <Compile Include="Missions\CncShellmapScript.cs" />

--- a/OpenRA.Mods.RA/Buildings/DeadBuildingState.cs
+++ b/OpenRA.Mods.RA/Buildings/DeadBuildingState.cs
@@ -35,7 +35,12 @@ namespace OpenRA.Mods.Cnc
 		public void Killed(Actor self, AttackInfo e)
 		{
 			if (!rs.anim.HasSequence("dead")) return;
-			rs.anim.PlayRepeating("dead");
+			
+			if (rs.anim.GetSequence("dead").Length > 1)
+				rs.anim.Play("dead");
+			else
+				rs.anim.PlayRepeating("dead");
+			
 			self.World.AddFrameEndTask(
 				w => w.Add(
 					new DelayedAction(info.LingerTime,

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -155,6 +155,7 @@
     <Compile Include="Buildings\CanPowerDown.cs" />
     <Compile Include="Buildings\CustomSellValue.cs" />
     <Compile Include="Buildings\CustomBuildTimeValue.cs" />
+    <Compile Include="Buildings\DeadBuildingState.cs" />
     <Compile Include="Buildings\FootprintUtils.cs" />
     <Compile Include="Buildings\LineBuild.cs" />
     <Compile Include="Buildings\PowerManager.cs" />

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -355,7 +355,15 @@
 		Terrain: Tree
 	EditorAppearance:
 		RelativeToTopLeft: yes
-		
+	Health:
+		HP: 500
+	DeadBuildingState:
+	Armor:
+		Type: Wood
+	TargetableBuilding:
+		TargetTypes: Ground
+	AutoTargetIgnore:
+
 ^Rock:
 	Tooltip:
 		Name: Rock

--- a/mods/cnc/sequences/map.yaml
+++ b/mods/cnc/sequences/map.yaml
@@ -49,163 +49,232 @@ rock7:
 tc04:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc05:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc03:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc02:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc01:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t18:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t17:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t16:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t15:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t14:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t13:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t12:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t11:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t10:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t09:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t08:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t07:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t06:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t05:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t04:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t03:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t02:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t01:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 v01:
 	idle:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -329,6 +329,14 @@
 		UseTerrainPalette: true
 	ProximityCaptor:
 		Types:Tree
+	Health:
+		HP: 500
+	DeadBuildingState:
+	Armor:
+		Type: Wood
+	TargetableBuilding:
+		TargetTypes: Ground
+	AutoTargetIgnore:
 
 ^Husk:
 	Husk:

--- a/mods/ra/sequences.yaml
+++ b/mods/ra/sequences.yaml
@@ -1131,128 +1131,182 @@ smoke_m:
 tc04:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc05:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc03:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc02:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 tc01:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t17:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t16:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t15:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t14:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t13:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t12:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t11:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t10:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t08:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t07:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t06:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t05:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t03:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 ice01:
 	idle:
@@ -1282,16 +1336,22 @@ ice05:
 t02:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 t01:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 mine:
 	idle:
@@ -2605,9 +2665,12 @@ rock7:
 t04:
 	idle:
 		Start: 0
-	burn:
+	damaged-idle:
 		Start: 1
-		Length: 9
+	dead:
+		Start: 2
+		Length: 8
+		Tick: 80
 
 v20:
 	idle:


### PR DESCRIPTION
The branch name is misleading as the trees won't burn yet. Still it uses the nice death animation for the trees that were unused before. Already makes throwing napalm and nukes on the landscape a lot more plausible.

Moving the `DeadBuildingState` into OpenRA.Mods.RA.dll also helps Harisson with [Red Alert Building Husk](http://www.sleipnirstuff.com/forum/viewtopic.php?f=83&p=284337).

This might change game-play if mappers use trees not only for decoration, but also to block paths. They need to reverse my changes in map.yaml then.
