### PR TITLE
Add a Fog: trait to enable fog of war in ShroudRenderer

### DIFF
--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Graphics
 			return shadowBits[SpecialShroudTiles[u ^ uSides][v]];
 		}
 
-		internal void Draw( WorldRenderer wr )
+		internal void Draw(WorldRenderer wr)
 		{
 			if (shroud != null && shroud.dirty)
 			{
@@ -120,11 +120,12 @@ namespace OpenRA.Graphics
 			}
 
 			var clipRect = Game.viewport.WorldBounds(wr.world);
-			DrawShroud( wr, clipRect, fogSprites, "fog" );
-			DrawShroud( wr, clipRect, sprites, "shroud" );
+			if (wr.world.WorldActor.HasTrait<Fog>())
+				DrawShroud(wr, clipRect, fogSprites, "fog");
+			DrawShroud(wr, clipRect, sprites, "shroud");
 		}
 
-		void DrawShroud( WorldRenderer wr, Rectangle clip, Sprite[,] s, string pal )
+		void DrawShroud(WorldRenderer wr, Rectangle clip, Sprite[,] s, string pal)
 		{
 			var shroudPalette = wr.GetPaletteIndex(pal);
 

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -178,6 +178,7 @@
     <Compile Include="Traits\ValidateOrder.cs" />
     <Compile Include="Traits\Waypoint.cs" />
     <Compile Include="Traits\World\Country.cs" />
+    <Compile Include="Traits\World\Fog.cs" />
     <Compile Include="Traits\World\PlayerColorPalette.cs" />
     <Compile Include="Traits\World\ResourceLayer.cs" />
     <Compile Include="Traits\World\ResourceType.cs" />

--- a/OpenRA.Game/Traits/World/Fog.cs
+++ b/OpenRA.Game/Traits/World/Fog.cs
@@ -1,0 +1,22 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Traits
+{
+	public class FogInfo : TraitInfo<Fog>
+	{
+		/*
+		 * This tag trait will enable fog of war in ShroudRenderer.
+		 * Don't forget about HiddenUnderFog and FrozenUnderFog.
+		 */
+	}
+
+	public class Fog { }
+}

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -156,6 +156,7 @@ World:
 	SpatialBins:
 		BinSize: 4
 	Shroud:
+	Fog:
 	CrateSpawner:
 		Minimum: 1
 		Maximum: 3

--- a/mods/d2k/rules/system.yaml
+++ b/mods/d2k/rules/system.yaml
@@ -351,6 +351,7 @@ World:
 	SpatialBins:
 		BinSize: 4
 	Shroud:
+	Fog:
 	PathFinder:
 	ValidateOrder:
 

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -192,7 +192,7 @@ Player:
 	BaseAttackNotifier:
 	PlayerStatistics:
 
-World:	
+World:
 	OpenWidgetAtGameStart:
 		Widget: INGAME_ROOT
 		ObserverWidget: OBSERVER_ROOT
@@ -302,6 +302,7 @@ World:
 	SpatialBins:
 		BinSize: 4
 	Shroud:
+	Fog:
 	PathFinder:
 	ValidateOrder:
 


### PR DESCRIPTION
This makes fog of war conditional for nostalgic mappers and classic mods. It was the reason https://github.com/Iran/ClassicRA forked us and has been requested multiple times by die-hard fans of the original:
- http://www.sleipnirstuff.com/forum/viewtopic.php?f=83&t=16023
- http://cnc-comm.com/community/index.php?topic=1619.msg12285#msg12285
- http://forum.dune2k.com/topic/24184-opend2k-cross-platform-reimplementation-of-dune-2000/?p=377815
