### PR TITLE
[CNC]  Buff machine gun. APC can shoot at ground now.

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -1,167 +1,5 @@
-UnitExplode:
-	Warhead:
-		Damage: 500
-		Spread: 10
-		Versus: 
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
-		Explosion: 8
-		InfDeath: 4
-		ImpactSound: xplobig6
-
-UnitExplodeSmall:
-	Warhead:
-		Damage: 40
-		Spread: 10
-		Versus: 
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
-		Explosion: 8
-		InfDeath: 4
-		ImpactSound: xplos
-
-GrenadierExplode:
-	Warhead:
-		Damage: 10
-		Spread: 3
-		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
-		Explosion: 8
-		InfDeath: 3
-		ImpactSound: xplos
-
-Atomic:
-	Warhead@impact:
-		Damage: 1000
-		Spread: 6
-		Ore: true
-		Versus: 
-			None: 90%
-			Wood: 60%
-			Light: 60%
-			Heavy: 25%
-		Explosion: 6
-		InfDeath: 5
-		ImpactSound: nukexplo
-	Warhead@areanuke:
-		DamageModel: PerCell
-		Damage: 250
-		SmudgeType: Scorch
-		Size: 5
-		Ore: true
-		Versus: 
-			None: 90%
-			Wood: 60%
-			Light: 60%
-			Heavy: 25%
-		Delay: 3
-		InfDeath: 5
-		ImpactSound: xplobig4
-
-IonCannon:
-	Warhead@impact:
-		Damage: 500
-		Spread: 6
-		Ore: true
-		Versus: 
-			None: 90%
-			Wood: 60%
-			Light: 60%
-			Heavy: 25%
-		InfDeath: 5
-	Warhead@area:
-		DamageModel: PerCell
-		Damage: 200
-		SmudgeType: Scorch
-		Size: 2,1
-		Ore: true
-		Versus: 
-			None: 90%
-			Wood: 60%
-			Light: 60%
-			Heavy: 25%
-		Delay: 3
-		InfDeath: 5
-
-Sniper:
-	Report: RAMGUN2
-	ROF: 40
-	Range: 7
-	Projectile: Bullet
-		Speed: 100
-	Warhead: 
-		Damage: 100
-		Spread: 1
-		Versus: 
-			None: 100%
-			Wood: 5%
-			Light: 5%
-			Heavy: 5%
-		InfDeath: 2
-
-HighV:
-	ROF: 40
-	Range: 5
-	Report: GUN8
-	Projectile: Bullet
-		Speed: 100
-	Warhead:
-		Damage: 40
-		Spread: 3
-		Versus: 
-			None: 100%
-			Wood: 50%
-			Light: 50%
-			Heavy: 25%
-		InfDeath: 2
-		Explosion: 1
-
-HeliAGGun:
-	ROF: 20
-	Burst: 2
-	BurstDelay: 0
-	Range: 4
-	ValidTargets: Ground
-	Report: gun5
-	Projectile: Bullet
-		Speed: 100
-	Warhead:
-		Damage: 20
-		Spread: 3
-		Versus: 
-			None: 100%
-			Wood: 50%
-			Light: 50%
-			Heavy: 25%
-		InfDeath: 2
-		Explosion: 1
-
-HeliAAGun:
-	ROF: 20
-	Burst: 2
-	BurstDelay: 0
-	Range: 4
-	ValidTargets: Air
-	Report: gun5
-	Projectile: Bullet
-		Speed: 100
-	Warhead:
-		Damage: 20
-		Spread: 3
-		Versus: 
-			None: 100%
-			Wood: 50%
-			Light: 50%
-			Heavy: 25%
-		InfDeath: 2
-		Explosion: 1
+# Weapons are in order from basic to advanced units:
+# Infantry, Vehicles, Artillery, Tank Guns, Aircraft, Ships, Buildings, Superweapons, Misc.
 
 Pistol:
 	ROF: 7
@@ -226,6 +64,117 @@ Rockets:
 		SmudgeType: Crater
 		Damage: 40
 
+Grenade:
+	ROF: 50
+	Range: 5
+	Projectile: Bullet
+		Speed: 5
+		High: yes
+		Angle: .1
+		Inaccuracy: 5
+		Image: BOMB
+	Warhead:
+		Spread: 6
+		Versus: 
+			None: 90%
+			Wood: 75%
+			Light: 75%
+			Heavy: 50%
+		InfDeath: 3
+		Explosion: 5
+		ImpactSound: xplos
+		SmudgeType: Crater
+		Damage: 50
+
+Flamethrower:
+	ROF: 50
+	Range: 3
+	Report: FLAMER2
+	Projectile: Bullet
+		Speed: 100
+	Warhead:
+		Spread: 8
+		Versus: 
+			None: 90%
+			Wood: 200%
+			Light: 75%
+			Heavy: 25%
+		InfDeath: 5
+		ImpactSound: flamer2
+		SmudgeType: Scorch
+		Damage: 35
+
+Chemspray:
+	ROF: 70
+	Range: 3
+	Report: FLAMER2
+	Projectile: Bullet
+		Speed: 100
+	Warhead:
+		Damage: 80
+		Spread: 6
+		Versus: 
+			None: 100%
+			Wood: 75%
+			Light: 75%
+			Heavy: 50%
+		InfDeath: 6
+		SmudgeType: Scorch
+		ImpactSound: xplos
+
+Sniper:
+	Report: RAMGUN2
+	ROF: 40
+	Range: 7
+	Projectile: Bullet
+		Speed: 100
+	Warhead: 
+		Damage: 100
+		Spread: 1
+		Versus: 
+			None: 100%
+			Wood: 5%
+			Light: 5%
+			Heavy: 5%
+		InfDeath: 2
+		
+MachineGun:
+	ROF: 30
+	Range: 4
+	Burst: 5
+	Report: MGUN11
+	Projectile: Bullet
+		Speed: 100
+	Warhead:
+		Spread: 3
+		Versus: 
+			None: 100%
+			Wood: 10%
+			Light: 30%
+			Heavy: 10%
+			Concrete: 10%
+		InfDeath: 2
+		Explosion: 2
+		Damage: 15
+
+APCGun:
+	ROF: 20
+	Range: 5
+	Report: gun20
+	ValidTargets: Air, Ground
+	Projectile: Bullet
+		Speed: 100
+		High: true
+	Warhead:
+		Spread: 5
+		Versus:
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: 5
+		Damage: 24
+
 BikeRockets:
 	ROF: 60
 	Range: 7
@@ -257,86 +206,6 @@ BikeRockets:
 		SmudgeType: Crater
 		Damage: 35
 
-OrcaAGMissiles:
-	ROF: 10
-	Burst: 2
-	BurstDelay: 0
-	Range: 5
-	Report: BAZOOK1
-	ValidTargets: Ground
-	Projectile: Missile
-		Arm: 0
-		High: yes
-		Shadow: no
-		Proximity: yes
-		Inaccuracy: 3
-		Image: DRAGON
-		ROT: 10
-		Trail: smokey
-		Speed: 25
-		RangeLimit: 30
-	Warhead:
-		Spread: 3
-		Versus: 
-			None: 50%
-			Wood: 75%
-			Light: 75%
-			Heavy: 50%
-		InfDeath: 4
-		Explosion: 4
-		ImpactSound: xplos
-		SmudgeType: Crater
-		Damage: 20
-
-OrcaAAMissiles:
-	ROF: 10
-	Burst: 2
-	BurstDelay: 0
-	Range: 5
-	Report: BAZOOK1
-	ValidTargets: Air
-	Projectile: Missile
-		Arm: 0
-		High: yes
-		Shadow: no
-		Proximity: yes
-		Inaccuracy: 3
-		Image: DRAGON
-		ROT: 10
-		Trail: smokey
-		Speed: 25
-		RangeLimit: 30
-	Warhead:
-		Spread: 3
-		Versus: 
-			None: 50%
-			Wood: 75%
-			Light: 75%
-			Heavy: 50%
-		InfDeath: 4
-		Explosion: 4
-		ImpactSound: xplos
-		SmudgeType: Crater
-		Damage: 20
-
-Flamethrower:
-	ROF: 50
-	Range: 3
-	Report: FLAMER2
-	Projectile: Bullet
-		Speed: 100
-	Warhead:
-		Spread: 8
-		Versus: 
-			None: 90%
-			Wood: 200%
-			Light: 75%
-			Heavy: 25%
-		InfDeath: 5
-		ImpactSound: flamer2
-		SmudgeType: Scorch
-		Damage: 35
-
 BigFlamer:
 	ROF: 50
 	Range: 3.5
@@ -358,45 +227,121 @@ BigFlamer:
 		SmudgeType: Scorch
 		Damage: 25
 
-Chemspray:
-	ROF: 70
-	Range: 3
-	Report: FLAMER2
+ArtilleryShell:
+	ROF: 65
+	Range: 12
+	MinRange: 2
+	Report: TNKFIRE2
 	Projectile: Bullet
-		Speed: 100
+		Speed: 12
+		High: yes
+		Angle: .09
+		Inaccuracy: 30
+		ContrailLength: 30
+		Image: 120MM
 	Warhead:
-		Damage: 80
+		Damage: 150
 		Spread: 6
 		Versus: 
-			None: 100%
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		InfDeath: 3
+		Explosion: 8
+		SmudgeType: Crater
+		ImpactSound: XPLOSML2
+
+227mm: 		
+	ROF: 150
+	Range: 14
+	MinRange: 3
+	Burst: 2
+	BurstDelay: 10
+	Report: ROCKET1
+	ValidTargets: Ground
+	Projectile: Bullet
+		Arm: 5
+		High: yes
+		Shadow: yes
+		Inaccuracy: 20
+		Angle: 0.1
+		Image: DRAGON
+		ROT: 2
+		ContrailLength: 10
+		Trail: smokey
+		Speed: 20
+	Warhead:
+		Spread: 15
+		Versus: 
+			None: 30%
+			Wood: 50%
+			Light: 100%
+			Heavy: 50%
+		InfDeath: 4
+		Explosion: 4
+		ImpactSound: xplos
+		SmudgeType: Crater
+		Damage: 100
+
+227mm.stnk:
+	ROF: 80
+	Range: 8
+	Report: ROCKET1
+	Burst: 2
+	BurstDelay: 0
+	ValidTargets: Ground, Air
+	Projectile: Missile
+		Arm: 0
+		High: yes
+		Shadow: yes
+		Proximity: yes
+		Inaccuracy: 5
+		Image: DRAGON
+		ROT: 10
+		Trail: smokey
+		Speed: 20
+		RangeLimit: 55
+	Warhead:
+		Spread: 3
+		Versus:
+			None: 30%
 			Wood: 75%
 			Light: 75%
 			Heavy: 50%
-		InfDeath: 6
-		SmudgeType: Scorch
+		InfDeath: 4
+		Explosion: 4
 		ImpactSound: xplos
+		SmudgeType: Crater
+		Damage: 75
 
-Grenade:
-	ROF: 50
-	Range: 5
+HonestJohn:
+	ROF: 200
+	Range: 10
+	Report: ROCKET1
 	Projectile: Bullet
-		Speed: 5
+		Arm: 10
 		High: yes
-		Angle: .1
+		Shadow: yes
+		Proximity: yes
 		Inaccuracy: 5
-		Image: BOMB
+		Image: patriot
+		Trail: smokey
+		Speed: 11
+		RangeLimit: 35
+		Angle: .15
 	Warhead:
 		Spread: 6
 		Versus: 
 			None: 90%
 			Wood: 75%
-			Light: 75%
-			Heavy: 50%
+			Light: 60%
+			Heavy: 25%
 		InfDeath: 3
 		Explosion: 5
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 50
+		Damage: 100
 
 70mm:
 	ROF: 60
@@ -529,101 +474,17 @@ MammothMissiles:
 		SmudgeType: Crater
 		Damage: 75
 
-227mm: 
-	ROF: 150
-	Range: 14
-	MinRange: 3
-	Burst: 2
-	BurstDelay: 10
-	Report: ROCKET1
-	ValidTargets: Ground
-	Projectile: Bullet
-		Arm: 5
-		High: yes
-		Shadow: yes
-		Inaccuracy: 20
-		Angle: 0.1
-		Image: DRAGON
-		ROT: 2
-		ContrailLength: 10
-		Trail: smokey
-		Speed: 20
-	Warhead:
-		Spread: 15
-		Versus: 
-			None: 30%
-			Wood: 50%
-			Light: 100%
-			Heavy: 50%
-		InfDeath: 4
-		Explosion: 4
-		ImpactSound: xplos
-		SmudgeType: Crater
-		Damage: 100
-
-227mm.stnk:
-	ROF: 80
-	Range: 8
-	Report: ROCKET1
+HeliAGGun:
+	ROF: 20
 	Burst: 2
 	BurstDelay: 0
-	ValidTargets: Ground, Air
-	Projectile: Missile
-		Arm: 0
-		High: yes
-		Shadow: yes
-		Proximity: yes
-		Inaccuracy: 5
-		Image: DRAGON
-		ROT: 10
-		Trail: smokey
-		Speed: 20
-		RangeLimit: 55
-	Warhead:
-		Spread: 3
-		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Heavy: 50%
-		InfDeath: 4
-		Explosion: 4
-		ImpactSound: xplos
-		SmudgeType: Crater
-		Damage: 75
-
-ArtilleryShell:
-	ROF: 65
-	Range: 12
-	MinRange: 2
-	Report: TNKFIRE2
-	Projectile: Bullet
-		Speed: 12
-		High: yes
-		Angle: .09
-		Inaccuracy: 30
-		ContrailLength: 30
-		Image: 120MM
-	Warhead:
-		Damage: 150
-		Spread: 6
-		Versus: 
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
-		InfDeath: 3
-		Explosion: 8
-		SmudgeType: Crater
-		ImpactSound: XPLOSML2
-
-MachineGun:
-	ROF: 30
 	Range: 4
-	Report: MGUN11
+	ValidTargets: Ground
+	Report: gun5
 	Projectile: Bullet
 		Speed: 100
 	Warhead:
+		Damage: 20
 		Spread: 3
 		Versus: 
 			None: 100%
@@ -632,7 +493,105 @@ MachineGun:
 			Heavy: 25%
 		InfDeath: 2
 		Explosion: 1
-		Damage: 15
+
+HeliAAGun:
+	ROF: 20
+	Burst: 2
+	BurstDelay: 0
+	Range: 4
+	ValidTargets: Air
+	Report: gun5
+	Projectile: Bullet
+		Speed: 100
+	Warhead:
+		Damage: 20
+		Spread: 3
+		Versus: 
+			None: 100%
+			Wood: 50%
+			Light: 50%
+			Heavy: 25%
+		InfDeath: 2
+		Explosion: 1
+
+OrcaAGMissiles:
+	ROF: 10
+	Burst: 2
+	BurstDelay: 0
+	Range: 5
+	Report: BAZOOK1
+	ValidTargets: Ground
+	Projectile: Missile
+		Arm: 0
+		High: yes
+		Shadow: no
+		Proximity: yes
+		Inaccuracy: 3
+		Image: DRAGON
+		ROT: 10
+		Trail: smokey
+		Speed: 25
+		RangeLimit: 30
+	Warhead:
+		Spread: 3
+		Versus: 
+			None: 50%
+			Wood: 75%
+			Light: 75%
+			Heavy: 50%
+		InfDeath: 4
+		Explosion: 4
+		ImpactSound: xplos
+		SmudgeType: Crater
+		Damage: 20
+
+OrcaAAMissiles:
+	ROF: 10
+	Burst: 2
+	BurstDelay: 0
+	Range: 5
+	Report: BAZOOK1
+	ValidTargets: Air
+	Projectile: Missile
+		Arm: 0
+		High: yes
+		Shadow: no
+		Proximity: yes
+		Inaccuracy: 3
+		Image: DRAGON
+		ROT: 10
+		Trail: smokey
+		Speed: 25
+		RangeLimit: 30
+	Warhead:
+		Spread: 3
+		Versus: 
+			None: 50%
+			Wood: 75%
+			Light: 75%
+			Heavy: 50%
+		InfDeath: 4
+		Explosion: 4
+		ImpactSound: xplos
+		SmudgeType: Crater
+		Damage: 20
+
+Napalm:
+	ROF: 2
+	Projectile: GravityBomb
+		Image: BOMBLET
+	Warhead:
+		Spread: 20
+		Versus: 
+			None: 90%
+			Wood: 100%
+			Light: 60%
+			Heavy: 25%
+		InfDeath: 5
+		Explosion: 3
+		ImpactSound: flamer2
+		SmudgeType: Scorch
+		Damage: 100
 
 BoatMissile:
 	ROF: 35
@@ -664,6 +623,23 @@ BoatMissile:
 		SmudgeType: Crater
 		Damage: 60
 
+HighV:
+	ROF: 40
+	Range: 5
+	Report: GUN8
+	Projectile: Bullet
+		Speed: 100
+	Warhead:
+		Damage: 40
+		Spread: 3
+		Versus: 
+			None: 100%
+			Wood: 50%
+			Light: 50%
+			Heavy: 25%
+		InfDeath: 2
+		Explosion: 1
+
 TowerMissle:
 	ROF: 40
 	Range: 7
@@ -694,37 +670,6 @@ TowerMissle:
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 60
-
-Napalm:
-	ROF: 2
-	Projectile: GravityBomb
-		Image: BOMBLET
-	Warhead:
-		Spread: 20
-		Versus: 
-			None: 90%
-			Wood: 100%
-			Light: 60%
-			Heavy: 25%
-		InfDeath: 5
-		Explosion: 3
-		ImpactSound: flamer2
-		SmudgeType: Scorch
-		Damage: 100
-
-Napalm.Crate:
-	Warhead:
-		Spread: 4
-		Versus: 
-			None: 90%
-			Wood: 100%
-			Light: 60%
-			Heavy: 25%
-		InfDeath: 5
-		Explosion: 3
-		ImpactSound: flamer2
-		SmudgeType: Scorch
-		Damage: 500
 
 Laser:
 	ROF: 90
@@ -767,33 +712,111 @@ SAMMissile:
 		SmudgeType: Crater
 		Damage: 50
 
-HonestJohn:
-	ROF: 200
-	Range: 10
-	Report: ROCKET1
-	Projectile: Bullet
-		Arm: 10
-		High: yes
-		Shadow: yes
-		Proximity: yes
-		Inaccuracy: 5
-		Image: patriot
-		Trail: smokey
-		Speed: 11
-		RangeLimit: 35
-		Angle: .15
-	Warhead:
+IonCannon:
+	Warhead@impact:
+		Damage: 500
 		Spread: 6
+		Ore: true
+		Versus: 
+			None: 90%
+			Wood: 60%
+			Light: 60%
+			Heavy: 25%
+		InfDeath: 5
+	Warhead@area:
+		DamageModel: PerCell
+		Damage: 200
+		SmudgeType: Scorch
+		Size: 2,1
+		Ore: true
+		Versus: 
+			None: 90%
+			Wood: 60%
+			Light: 60%
+			Heavy: 25%
+		Delay: 3
+		InfDeath: 5
+
+Atomic:
+	Warhead@impact:
+		Damage: 1000
+		Spread: 6
+		Ore: true
+		Versus: 
+			None: 90%
+			Wood: 60%
+			Light: 60%
+			Heavy: 25%
+		Explosion: 6
+		InfDeath: 5
+		ImpactSound: nukexplo
+	Warhead@areanuke:
+		DamageModel: PerCell
+		Damage: 250
+		SmudgeType: Scorch
+		Size: 5
+		Ore: true
+		Versus: 
+			None: 90%
+			Wood: 60%
+			Light: 60%
+			Heavy: 25%
+		Delay: 3
+		InfDeath: 5
+		ImpactSound: xplobig4
+
+UnitExplode:
+	Warhead:
+		Damage: 500
+		Spread: 10
 		Versus: 
 			None: 90%
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		InfDeath: 3
-		Explosion: 5
+		Explosion: 8
+		InfDeath: 4
+		ImpactSound: xplobig6
+
+UnitExplodeSmall:
+	Warhead:
+		Damage: 40
+		Spread: 10
+		Versus: 
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: 8
+		InfDeath: 4
 		ImpactSound: xplos
-		SmudgeType: Crater
-		Damage: 100
+
+GrenadierExplode:
+	Warhead:
+		Damage: 10
+		Spread: 3
+		Versus:
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: 8
+		InfDeath: 3
+		ImpactSound: xplos
+
+Napalm.Crate:
+	Warhead:
+		Spread: 4
+		Versus: 
+			None: 90%
+			Wood: 100%
+			Light: 60%
+			Heavy: 25%
+		InfDeath: 5
+		Explosion: 3
+		ImpactSound: flamer2
+		SmudgeType: Scorch
+		Damage: 500
 
 Tiberium:
 	ROF: 4
@@ -802,18 +825,3 @@ Tiberium:
 		InfDeath: 6
 		Damage: 1
 		PreventProne: yes
-
-APCGun:
-	ROF: 10
-	Range: 7
-	Report: gun20
-	ValidTargets: Air
-	Projectile: Bullet
-		Speed: 100
-		High: true
-	Warhead:
-		Spread: 5
-		Versus:
-			Light: 100%
-		Explosion: 5
-		Damage: 12


### PR DESCRIPTION
Humvee and Nod Buggy get buff to their machine gun--it's now the same power as Jeep's in ORA.

APC gun now shoots at ground instead of just air. Reduced range from 7 to 5 as a result.
This should give a soft counter to enemy vehicles if the player decides not to play with tanks in the early game. 
