### PR TITLE
[CNC] Chinook price reduced to $750

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -1,7 +1,7 @@
 TRAN:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 1500
+		Cost: 750
 	Tooltip:
 		Name: Chinook Transport
 		Icon:tranicnh


### PR DESCRIPTION
Halved Chinook price, $1500 to $750.
Infantry should be a more feasible strategy, and transporting them quickly will make them more usable.
This should be good for Nod especially since they don't have APCs.
