### PR TITLE
Linux Standards Compliance

### DIFF
--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -23,7 +23,7 @@ cp -R $BUILTDIR/* "$ROOTDIR/usr/share/openra/" || exit 3
 
 # Desktop Icons
 mkdir -p $ROOTDIR/usr/share/applications/
-sed "s/{VERSION}/$VERSION/" openra.desktop > $ROOTDIR/usr/share/applications/openra.desktop
+desktop-file-install --dir $ROOTDIR/usr/share/applications/ openra.desktop
 
 mkdir -p $ROOTDIR/usr/share/icons/
 cp -r hicolor $ROOTDIR/usr/share/icons/

--- a/packaging/linux/deb/DEBIAN/control
+++ b/packaging/linux/deb/DEBIAN/control
@@ -2,7 +2,7 @@ Package: openra
 Version: {VERSION}
 Architecture: all
 Maintainer: Chris Forbes <chrisf@ijw.co.nz>
-Installed-Size: {SIZE}	
+Installed-Size: {SIZE}
 Depends: libopenal1, mono-runtime (>= 2.6.7), libmono-winforms2.0-cil, libfreetype6, libsdl1.2debian, libgl1-mesa-glx, libgl1-mesa-dri, libmono-i18n2.0-cil
 Section: games
 Priority: extra

--- a/packaging/linux/deb/copyright
+++ b/packaging/linux/deb/copyright
@@ -1,4 +1,4 @@
-Copyright 2007-2011 The OpenRA Developers (see /usr/share/openra/AUTHORS)
+Copyright 2007-2013 The OpenRA Developers (see /usr/share/openra/AUTHORS)
 
 OpenRA is free software. It is made available to you under the terms of
 the GNU General Public License as published by the Free Software Foundation

--- a/packaging/linux/openra.desktop
+++ b/packaging/linux/openra.desktop
@@ -1,9 +1,10 @@
 [Desktop Entry]
 Type=Application
-Version={VERSION}
+Version=1.0
 Name=OpenRA
-Comment=Reimagining of Red Alert and Command & Conquer
+GenericName=Real Time Strategy Game
+Comment=Reimagining of Red Alert and Tiberian Dawn
 Icon=openra
-Exec=/usr/bin/openra
+Exec=openra
 Terminal=false
-Categories=Game;
+Categories=Game;StrategyGame;

--- a/packaging/linux/rpm/openra.spec
+++ b/packaging/linux/rpm/openra.spec
@@ -5,7 +5,7 @@ Name: %{name}
 Version: %{version}
 Release: 1
 Summary: Open Source rebuild of the Red Alert game engine using Mono/OpenGL.
-License: GPL3
+License: GPL-3.0
 URL: http://open-ra.org
 Group: Amusements/Games
 Packager: Matthew Bowra-Dean <matthew@ijw.co.nz>
@@ -15,9 +15,9 @@ Source: %{name}-%{version}.tar.gz
 Buildroot: /tmp/openra
 
 %description
-A multiplayer reimplementation of the Command & Conquer: Red Alert game 
+A multiplayer reimplementation of the Command & Conquer: Red Alert game
 engine in .NET/Mono, OpenGL, OpenAL and SDL. Has extensive modding support
-and includes Command & Conquer as an official mod.
+and includes Command & Conquer: Tiberian Dawn as an official mod.
 
 %build
 


### PR DESCRIPTION
Just some fixes on minor problems I came across on http://build.opensuse.org which enforces strict standards compliance:
- http://standards.freedesktop.org/desktop-entry-spec/1.0/
- http://spdx.org/licenses/
