### PR TITLE
[cnc] MachineGun, APCgun air/ground. Weapons tweaked

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -101,6 +101,9 @@ APC:
 		PrimaryWeapon: APCGun
 		PrimaryOffset: 0,0,0,0
 		PrimaryLocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
+		SecondaryWeapon: APCGun.AA
+		SecondaryOffset: 0,0,0,0
+		SecondaryLocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
 	WithMuzzleFlash:
 	RenderUnitTurreted:
 	AutoTarget:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -103,7 +103,7 @@ Sniper:
 
 HighV:
 	ROF: 40
-	Range: 5
+	Range: 6
 	Report: GUN8
 	Projectile: Bullet
 		Speed: 100
@@ -224,12 +224,12 @@ Rockets:
 		Damage: 40
 
 BikeRockets:
-	ROF: 60
-	Range: 7
+	ROF: 45
+	Range: 6
 	Report: BAZOOK1
 	ValidTargets: Ground, Air
 	Burst: 2
-	BurstDelay: 0
+	BurstDelay: 15
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -253,7 +253,7 @@ BikeRockets:
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 40
+		Damage: 25
 
 OrcaAGMissiles:
 	ROF: 10
@@ -327,7 +327,7 @@ Flamethrower:
 		Spread: 8
 		Versus: 
 			None: 90%
-			Wood: 200%
+			Wood: 150%
 			Light: 75%
 			Heavy: 25%
 		InfDeath: 5
@@ -380,7 +380,7 @@ Grenade:
 	ROF: 50
 	Range: 5
 	Projectile: Bullet
-		Speed: 8
+		Speed: 12
 		High: yes
 		Angle: .1
 		Inaccuracy: 5
@@ -494,7 +494,7 @@ TurretGun:
 		Spread: 3
 		Versus: 
 			None: 30%
-			Wood: 75%
+			Wood: 25%
 			Light: 75%
 			Heavy: 100%
 		InfDeath: 4
@@ -672,7 +672,7 @@ BoatMissile:
 
 TowerMissle:
 	ROF: 40
-	Range: 7.5
+	Range: 8
 	Report: ROCKET2
 	ValidTargets: Ground, Air
 	Burst: 2
@@ -691,10 +691,10 @@ TowerMissle:
 	Warhead:
 		Spread: 6
 		Versus: 
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 50%
+			Wood: 25%
+			Light: 100%
+			Heavy: 75%
 		InfDeath: 3
 		Explosion: med_frag
 		ImpactSound: xplos
@@ -744,6 +744,8 @@ Laser:
 		InfDeath: 5
 		SmudgeType: Scorch
 		Damage: 200
+		Versus:
+			Wood: 50%
 
 SAMMissile:
 	ROF: 50

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -842,3 +842,33 @@ APCGun.AA:
 			Heavy: 50%
 		Explosion: small_poof
 		Damage: 25
+
+Patriot:
+	ROF: 100
+	Range: 10
+	MinRange: 2
+	Burst: 2
+	BurstDelay: 35
+	Report:	ROCKET2
+	ValidTargets: Air
+	Projectile: Missile
+		High: yes
+		Shadow: no
+		Image: patriot
+		Trail: smokey
+		ROT: 20
+		Speed: 40
+		RangeLimit: 35
+		Angle: .15
+	Warhead: AP
+		Spread: 14		
+		Versus: 
+			None: 100%	
+			Wood: 100%
+			Light: 100%
+			Heavy: 75%
+		InfDeath: 4	
+		Explosion: poof
+		ImpactSound: xplos
+		SmudgeType: Crater
+		Damage: 55

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -114,8 +114,8 @@ HighV:
 		Versus: 
 			None: 100%
 			Wood: 50%
-			Light: 50%
-			Heavy: 25%
+			Light: 100%
+			Heavy: 50%
 		InfDeath: 2
 		Explosion: piffs
 
@@ -213,7 +213,7 @@ Rockets:
 		Spread: 3
 		Versus: 
 			None: 50%
-			Wood: 100%
+			Wood: 85%
 			Light: 100%
 			Heavy: 100%
 			Concrete: 25%
@@ -221,7 +221,7 @@ Rockets:
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 40
+		Damage: 30
 
 BikeRockets:
 	ROF: 45
@@ -327,7 +327,7 @@ Flamethrower:
 		Spread: 8
 		Versus: 
 			None: 90%
-			Wood: 150%
+			Wood: 100%
 			Light: 75%
 			Heavy: 25%
 		InfDeath: 5
@@ -622,9 +622,9 @@ ArtilleryShell:
 		ImpactSound: XPLOSML2
 
 MachineGun:
-	ROF: 30
+	ROF: 20
 	Range: 4
-	Burst: 5
+	Burst: 4
 	Report: MGUN11
 	Projectile: Bullet
 		Speed: 100
@@ -632,13 +632,13 @@ MachineGun:
 		Spread: 3
 		Versus: 
 			None: 100%
-			Wood: 20%
-			Light: 50%
-			Heavy: 20%
+			Wood: 30%
+			Light: 75%
+			Heavy: 30%
 			Concrete: 10%
 		InfDeath: 2
 		Explosion: piffs
-		Damage: 15
+		Damage: 10
 
 BoatMissile:
 	ROF: 35

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -534,11 +534,11 @@ MammothMissiles:
 		Damage: 75
 
 227mm: 
-	ROF: 150
+	ROF: 140
 	Range: 14
 	MinRange: 3
 	Burst: 2
-	BurstDelay: 10
+	BurstDelay: 20
 	Report: ROCKET1
 	ValidTargets: Ground
 	Projectile: Bullet

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -107,6 +107,7 @@ HighV:
 	Report: GUN8
 	Projectile: Bullet
 		Speed: 100
+		High: yes
 	Warhead:
 		Damage: 40
 		Spread: 3
@@ -116,7 +117,7 @@ HighV:
 			Light: 50%
 			Heavy: 25%
 		InfDeath: 2
-		Explosion: 1
+		Explosion: piffs
 
 HeliAGGun:
 	ROF: 20
@@ -129,14 +130,14 @@ HeliAGGun:
 		Speed: 100
 	Warhead:
 		Damage: 20
-		Spread: 3
+		Spread: 6
 		Versus: 
 			None: 100%
 			Wood: 50%
 			Light: 50%
 			Heavy: 25%
 		InfDeath: 2
-		Explosion: 1
+		Explosion: piffs
 
 HeliAAGun:
 	ROF: 20
@@ -156,7 +157,7 @@ HeliAAGun:
 			Light: 50%
 			Heavy: 25%
 		InfDeath: 2
-		Explosion: 1
+		Explosion: piffs
 
 Pistol:
 	ROF: 7
@@ -330,6 +331,7 @@ Flamethrower:
 			Light: 75%
 			Heavy: 25%
 		InfDeath: 5
+		Explosion: small_napalm
 		ImpactSound: flamer2
 		SmudgeType: Scorch
 		Damage: 35
@@ -350,7 +352,7 @@ BigFlamer:
 			Light: 50%
 			Heavy: 25%
 		InfDeath: 5
-		Explosion: 3
+		Explosion: med_napalm
 		ImpactSound: flamer2
 		SmudgeType: Scorch
 		Damage: 90
@@ -558,7 +560,7 @@ MammothMissiles:
 			Light: 100%
 			Heavy: 50%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: med_frag
 		ImpactSound: xplobig4
 		SmudgeType: Crater
 		Damage: 100
@@ -615,7 +617,7 @@ ArtilleryShell:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 3
-		Explosion: 8
+		Explosion: poof
 		SmudgeType: Crater
 		ImpactSound: XPLOSML2
 
@@ -635,7 +637,7 @@ MachineGun:
 			Heavy: 20%
 			Concrete: 10%
 		InfDeath: 2
-		Explosion: 2
+		Explosion: piffs
 		Damage: 15
 
 BoatMissile:
@@ -670,7 +672,7 @@ BoatMissile:
 
 TowerMissle:
 	ROF: 40
-	Range: 7
+	Range: 7.5
 	Report: ROCKET2
 	ValidTargets: Ground, Air
 	Burst: 2
@@ -694,7 +696,7 @@ TowerMissle:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 3
-		Explosion: 5
+		Explosion: med_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 60
@@ -711,10 +713,10 @@ Napalm:
 			Light: 60%
 			Heavy: 50%
 		InfDeath: 5
-		Explosion: 3
+		Explosion: med_napalm
 		ImpactSound: flamer2
 		SmudgeType: Scorch
-		Damage: 120
+		Damage: 130
 
 Napalm.Crate:
 	Warhead:
@@ -761,15 +763,15 @@ SAMMissile:
 	Warhead: AP
 		Spread: 3
 		Versus: 
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Heavy: 50%
+			None: 100%
+			Wood: 100%
+			Light: 100%
+			Heavy: 75%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 50
+		Damage: 60
 
 HonestJohn:
 	ROF: 200
@@ -821,7 +823,7 @@ APCGun:
 			None: 50%	
 			Light: 100%	
 			Heavy: 50%	
-		Explosion: 5
+		Explosion: small_poof
 		Damage: 25
 
 APCGun.AA:
@@ -836,5 +838,5 @@ APCGun.AA:
 		Spread: 5
 		Versus:
 			Heavy: 50%
-		Explosion: 5
+		Explosion: small_poof
 		Damage: 25

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -69,7 +69,7 @@ IonCannon:
 			None: 100%
 			Wood: 100%
 			Light: 60%
-			Heavy: 25%
+			Heavy: 45%
 		InfDeath: 5
 	Warhead@area:
 		DamageModel: PerCell
@@ -193,7 +193,7 @@ M16:
 		Damage: 15
 
 Rockets:
-	ROF: 60
+	ROF: 50
 	Range: 6
 	Report: BAZOOK1
 	ValidTargets: Ground, Air
@@ -212,9 +212,10 @@ Rockets:
 		Spread: 3
 		Versus: 
 			None: 50%
-			Wood: 75%
+			Wood: 100%
 			Light: 75%
-			Heavy: 50%
+			Heavy: 100%
+			Concrete: 25%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
@@ -222,7 +223,7 @@ Rockets:
 		Damage: 40
 
 BikeRockets:
-	ROF: 60
+	ROF: 80
 	Range: 7
 	Report: BAZOOK1
 	ValidTargets: Ground, Air
@@ -242,15 +243,16 @@ BikeRockets:
 	Warhead:
 		Spread: 3
 		Versus: 
-			None: 50%
-			Wood: 30%
-			Light: 75%
-			Heavy: 30%
+			None: 25%
+			Wood: 75%
+			Light: 100%
+			Heavy: 75%
+			Concrete: 50%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 35
+		Damage: 40
 
 OrcaAGMissiles:
 	ROF: 10
@@ -395,19 +397,20 @@ Grenade:
 		Damage: 50
 
 70mm:
-	ROF: 60
+	ROF: 30
 	Range: 4
 	Report: TNKFIRE3
 	Projectile: Bullet
 		Image: 120MM
-		Speed: 40
+		Speed: 60
 	Warhead:
 		Spread: 3
 		Versus: 
 			None: 30%
 			Wood: 75%
-			Light: 75%
+			Light: 100%
 			Heavy: 100%
+			Concrete: 50%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
@@ -435,7 +438,7 @@ Grenade:
 		Damage: 30
 
 120mm:
-	ROF: 80
+	ROF: 40
 	Range: 4.75
 	Report: TNKFIRE6
 	Projectile: Bullet
@@ -446,8 +449,9 @@ Grenade:
 		Versus: 
 			None: 30%
 			Wood: 75%
-			Light: 75%
+			Light: 100%
 			Heavy: 100%
+			Concrete: 50%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
@@ -455,10 +459,11 @@ Grenade:
 		Damage: 40
 
 120mmDual:
-	ROF: 80
+	ROF: 40
 	Range: 4.75
 	Report: TNKFIRE6
 	Burst: 2
+	BurstDelay: 5
 	Projectile: Bullet
 		Image: 120MM
 		Speed: 40
@@ -467,8 +472,9 @@ Grenade:
 		Versus: 
 			None: 30%
 			Wood: 75%
-			Light: 75%
+			Light: 100%
 			Heavy: 100%
+			Concrete: 50%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
@@ -553,7 +559,7 @@ MammothMissiles:
 			Heavy: 50%
 		InfDeath: 4
 		Explosion: 4
-		ImpactSound: xplos
+		ImpactSound: xplobig4
 		SmudgeType: Crater
 		Damage: 100
 
@@ -703,7 +709,7 @@ Napalm:
 			None: 90%
 			Wood: 100%
 			Light: 60%
-			Heavy: 25%
+			Heavy: 50%
 		InfDeath: 5
 		Explosion: 3
 		ImpactSound: flamer2

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -620,6 +620,7 @@ ArtilleryShell:
 MachineGun:
 	ROF: 30
 	Range: 4
+	Burst: 5
 	Report: MGUN11
 	Projectile: Bullet
 		Speed: 100
@@ -627,11 +628,12 @@ MachineGun:
 		Spread: 3
 		Versus: 
 			None: 100%
-			Wood: 50%
-			Light: 50%
-			Heavy: 25%
+			Wood: 10%
+			Light: 30%
+			Heavy: 10%
+			Concrete: 10%
 		InfDeath: 2
-		Explosion: 1
+		Explosion: 2
 		Damage: 15
 
 BoatMissile:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -253,7 +253,7 @@ BikeRockets:
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 35
+		Damage: 40
 
 OrcaAGMissiles:
 	ROF: 10

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -204,7 +204,7 @@ Rockets:
 		Proximity: yes
 		Inaccuracy: 3
 		Image: DRAGON
-		ROT: 10
+		ROT: 15
 		Trail: smokey
 		Speed: 35
 		RangeLimit: 40
@@ -213,7 +213,7 @@ Rockets:
 		Versus: 
 			None: 50%
 			Wood: 100%
-			Light: 75%
+			Light: 100%
 			Heavy: 100%
 			Concrete: 25%
 		InfDeath: 4
@@ -223,7 +223,7 @@ Rockets:
 		Damage: 40
 
 BikeRockets:
-	ROF: 80
+	ROF: 60
 	Range: 7
 	Report: BAZOOK1
 	ValidTargets: Ground, Air
@@ -238,7 +238,7 @@ BikeRockets:
 		Image: DRAGON
 		ROT: 10
 		Trail: smokey
-		Speed: 35
+		Speed: 40
 		RangeLimit: 40
 	Warhead:
 		Spread: 3
@@ -246,13 +246,13 @@ BikeRockets:
 			None: 25%
 			Wood: 75%
 			Light: 100%
-			Heavy: 75%
+			Heavy: 100%
 			Concrete: 50%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 40
+		Damage: 35
 
 OrcaAGMissiles:
 	ROF: 10
@@ -340,20 +340,20 @@ BigFlamer:
 	Report: FLAMER2
 	Projectile: Bullet
 		Speed: 20
-	Burst:2
-	BurstDelay:0
+	Burst: 2
+	BurstDelay:25
 	Warhead:
 		Spread: 8
 		Versus: 
-			None: 90%
-			Wood: 200%
-			Light: 75%
+			None: 100%
+			Wood: 100%
+			Light: 50%
 			Heavy: 25%
 		InfDeath: 5
 		Explosion: 3
 		ImpactSound: flamer2
 		SmudgeType: Scorch
-		Damage: 25
+		Damage: 90
 
 Chemspray:
 	ROF: 70
@@ -378,7 +378,7 @@ Grenade:
 	ROF: 50
 	Range: 5
 	Projectile: Bullet
-		Speed: 5
+		Speed: 8
 		High: yes
 		Angle: .1
 		Inaccuracy: 5
@@ -564,11 +564,11 @@ MammothMissiles:
 		Damage: 100
 
 227mm.stnk:
-	ROF: 80
+	ROF: 70
 	Range: 8
 	Report: ROCKET1
 	Burst: 2
-	BurstDelay: 0
+	BurstDelay: 10
 	ValidTargets: Ground, Air
 	Projectile: Missile
 		Arm: 0
@@ -579,20 +579,20 @@ MammothMissiles:
 		Image: DRAGON
 		ROT: 10
 		Trail: smokey
-		Speed: 20
+		Speed: 25
 		RangeLimit: 55
 	Warhead:
 		Spread: 3
 		Versus:
 			None: 30%
-			Wood: 75%
-			Light: 75%
-			Heavy: 50%
+			Wood: 50%
+			Light: 100%
+			Heavy: 100%
 		InfDeath: 4
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 75
+		Damage: 60
 
 ArtilleryShell:
 	ROF: 65
@@ -630,9 +630,9 @@ MachineGun:
 		Spread: 3
 		Versus: 
 			None: 100%
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
+			Wood: 20%
+			Light: 50%
+			Heavy: 20%
 			Concrete: 10%
 		InfDeath: 2
 		Explosion: 2
@@ -819,8 +819,8 @@ APCGun:
 		Versus:
 			Wood: 50%	
 			None: 50%	
-			Light: 75%	
-			Heavy: 75%	
+			Light: 100%	
+			Heavy: 50%	
 		Explosion: 5
 		Damage: 25
 

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -22,17 +22,12 @@ UnitExplodeSmall:
 			Heavy: 25%
 		Explosion: 8
 		InfDeath: 4
-		ImpactSound: xplos
+		ImpactSound: xplobig4
 
 GrenadierExplode:
 	Warhead:
 		Damage: 10
-		Spread: 3
-		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+		Spread: 9
 		Explosion: 8
 		InfDeath: 3
 		ImpactSound: xplos
@@ -71,8 +66,8 @@ IonCannon:
 		Spread: 6
 		Ore: true
 		Versus: 
-			None: 90%
-			Wood: 60%
+			None: 100%
+			Wood: 100%
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 5
@@ -373,6 +368,7 @@ Chemspray:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 6
+		Explosion: chemball
 		SmudgeType: Scorch
 		ImpactSound: xplos
 
@@ -712,7 +708,7 @@ Napalm:
 		Explosion: 3
 		ImpactSound: flamer2
 		SmudgeType: Scorch
-		Damage: 100
+		Damage: 120
 
 Napalm.Crate:
 	Warhead:
@@ -806,7 +802,24 @@ Tiberium:
 		PreventProne: yes
 
 APCGun:
-	ROF: 10
+	ROF: 20
+	Range: 5
+	Report: gun20
+	ValidTargets: Ground
+	Projectile: Bullet
+		Speed: 100
+	Warhead:
+		Spread: 3
+		Versus:
+			Wood: 50%	
+			None: 50%	
+			Light: 75%	
+			Heavy: 75%	
+		Explosion: 5
+		Damage: 25
+
+APCGun.AA:
+	ROF: 20
 	Range: 7
 	Report: gun20
 	ValidTargets: Air
@@ -816,6 +829,6 @@ APCGun:
 	Warhead:
 		Spread: 5
 		Versus:
-			Light: 100%
+			Heavy: 50%
 		Explosion: 5
-		Damage: 12
+		Damage: 25


### PR DESCRIPTION
Buffed MachineGun for Jeeps. Now identical to RA. 
(Default Humvee and Buggy are quite weak vs. infantry. This is meant to allow them to be useful in an anti-infantry role. They still remain balanced by being vulnerable to E3, tanks and vehicles)

APC gun can now shoot at ground and air.

Minor changes:
Airstrike and IonCannon tweaked to one-shot certain buildings (barracks & adv. power plant, respectively).
GrenadierExplode fixed.
Minor Housekeeping for Chemspray, some explosion sounds. 
