### PR TITLE
[cnc] Obelisk AutoTargeted, airstrike cooldown, +misc.

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -259,7 +259,7 @@ AFLD:
 		Footprint: xxxx xxxx
 		Dimensions: 4,2
 	Health:
-		HP: 1750
+		HP: 1500
 	RevealsShroud:
 		Range: 7
 	Bib:
@@ -372,7 +372,7 @@ HQ:
 		Footprint: x_ xx
 		Dimensions: 2,2
 	Health:
-		HP: 1000
+		HP: 750
 	RevealsShroud:
 		Range: 10
 	Bib:
@@ -382,7 +382,7 @@ HQ:
 		Range: 8
 	AirstrikePower:
 		Image: bombicnh
-		ChargeTime: 240
+		ChargeTime: 180
 		Description: Air Strike
 		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
 		EndChargeSound: airredy1.aud

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -594,6 +594,7 @@ OBLI:
 	Turreted:
 		ROT:255
 	AutoTarget:
+	-AutoTargetIgnore:
 	-RenderBuilding:
 	RenderRangeCircle:
 	-EmitInfantryOnSell:


### PR DESCRIPTION
Obelisk of light was missing "-AutoTargetIgnore". All the guard towers have it, but for some reason the Obelisk didn't. 
