### PR TITLE
Add support for Nyergud's Music Upgrade pack

### DIFF
--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -26,6 +26,7 @@ Packages:
 	~movies-nod.mix
 	~movies.mix
 	~scores.mix
+	~scores2.mix
 	~transit.mix
 
 Rules:


### PR DESCRIPTION
This adds support for nyergud's music upgrade pack, which can be downloaded at http://nyerguds.arsaneus-design.com/cnc95upd/cc95p106/

This will help the people who don't have covert ops music, but want it in.
