### PR TITLE
[cnc] added names for explosions

### DIFF
--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -121,7 +121,7 @@ explosion:
 	small_poof: veh-hit2		#for Grenades; tower missiles; boat missiles; APC AA gun.
 		Start: 0
 		Length: *
-	big_poof: art-exp1		#For UnitExplode (artillery); artillery shell hit; GrenadierExplode, 
+	poof: art-exp1			#For UnitExplode (artillery); artillery shell hit; GrenadierExplode, 
 		Start: 0
 		Length: *
 	small_building: veh-hit1	#like "building' explosion, but much smaller. (Used for heli-explosion in C&C Gold?)

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -85,16 +85,49 @@ explosion:
 	8: art-exp1
 		Start: 0
 		Length: *
-	building: fball1
-		Start: 0
-		Length: *
 	6: atomsfx
 		Start: 0
 		Length: *
 	6w: atomsfx
 		Start: 0
 		Length: *
-	chemball: chemball
+	piff: piff
+		Start: 0
+		Length: *
+	piffs: piffpiff
+		Start: 0
+		Length: *
+	chemball: chemball		#same size as small_napalm, but bright green.
+		Start: 0
+		Length: *
+	small_napalm: napalm1		#not used by much. currently used for flamethrower.
+		Start: 0
+		Length: *
+	med_napalm: napalm2		#explosion for bomblets
+		Start: 0
+		Length: *
+	big_napalm: napalm3		#huge; not used. (SSM used this explosion in C&C Gold?)
+		Start: 0
+		Length: *
+	small_frag: veh-hit3		#the most common weapon-hit explosion. For rockets, tank shells, etc. 
+		Start: 0
+		Length: *
+	med_frag: frag1			#fragmentation-style; quite large. (MLRS used this explosion in C&C Gold?)
+		Start: 0
+		Length: *
+	big_frag: frag3			#Same as med_frag, except fire hangs around longer.
+		Start: 0
+		Length: *
+	small_poof: veh-hit2		#for Grenades; tower missiles; boat missiles; APC AA gun.
+		Start: 0
+		Length: *
+	big_poof: art-exp1		#For UnitExplode (artillery); artillery shell hit; GrenadierExplode, 
+		Start: 0
+		Length: *
+	small_building: veh-hit1	#like "building' explosion, but much smaller. (Used for heli-explosion in C&C Gold?)
+		Start: 0
+		Length: *
+	building: fball1		#Large explosion, for when a building explodes. 
 		Start: 0
 		Length: *
 


### PR DESCRIPTION
Easier-to-understand names for explosions, which can be used in the future. Can phase out old names/numbers slowly.
Also included some explosions from the C&C Content which were not in use and did not have names.
