### PR TITLE
[cnc] inftry detect cloaked in next tile(C&C orig)

### DIFF
--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -19,6 +19,8 @@ E1:
 		PrimaryWeapon: M16
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2,idle3,idle4
+	DetectCloaked:
+		Range: 2
 
 E2:
 	Inherits: ^Infantry
@@ -46,7 +48,10 @@ E2:
 		IdleAnimations: idle1,idle2
 	Explodes:
 		Weapon: GrenadierExplode
+		EmptyWeapon: GrenadierExplode
 		Chance: 50
+	DetectCloaked:
+		Range: 2
 	
 E3:
 	Inherits: ^Infantry
@@ -71,6 +76,8 @@ E3:
 		FireDelay: 5
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2
+	DetectCloaked:
+		Range: 2
 
 E4:
 	Inherits: ^Infantry
@@ -97,6 +104,8 @@ E4:
 	WithMuzzleFlash:
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2
+	DetectCloaked:
+		Range: 2
 
 E5:
 	Inherits: ^Infantry
@@ -129,6 +138,8 @@ E5:
 	-PoisonedByTiberium:
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2
+	DetectCloaked:
+		Range: 2
 
 E6:
 	Inherits: ^Infantry
@@ -192,6 +203,8 @@ RMBO:
 		IdleAnimations: idle1,idle2,idle3
 	AnnounceOnBuild:
 	AnnounceOnKill:
+	DetectCloaked:
+		Range: 2
 
 PVICE:
 	Inherits:VICE


### PR DESCRIPTION
Infantry can detect cloaked units in the next tile. This behaviour was in the original C&C Gold.
(Even though it says range=2, it is actually just in the next tile)

Fixed GrenadierExplode.
