### PR TITLE
Anti-basewalk balance adjustments

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -17,9 +17,9 @@ MSLO:
 		Footprint: xx
 		Dimensions: 2,1
 	Health:
-		HP: 400
+		HP: 1000
 	Armor:
-		Type: Heavy
+		Type: Wood
 	RevealsShroud:
 		Range: 5
 	IronCurtainable:
@@ -197,7 +197,7 @@ IRON:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 1000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -235,7 +235,7 @@ PDOX:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 1000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -376,7 +376,7 @@ PBOX:
 	Health:
 		HP: 400
 	Armor:
-		Type: Wood
+		Type: Heavy
 	RevealsShroud:
 		Range: 6
 	IronCurtainable:
@@ -528,7 +528,7 @@ HBOX:
 	Health:
 		HP: 600
 	Armor:
-		Type: Wood
+		Type: Heavy
 	RevealsShroud:
 		Range: 6
 	Cloak:
@@ -863,9 +863,9 @@ FACT:
 		Footprint: xxx xxx xxx
 		Dimensions: 3,3
 	Health:
-		HP: 1000
+		HP: 1500
 	Armor:
-		Type: Heavy
+		Type: Wood
 	RevealsShroud:
 		Range: 5
 	Bib:

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -159,6 +159,7 @@ FireballLauncher:
 		Spread: 5
 		Versus: 
 			None: 90%
+			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Cybernetic: 30%
@@ -495,7 +496,7 @@ TurretGun:
 		Spread: 3
 		Versus: 
 			None: 20%
-			Wood: 75%
+			Wood: 50%
 			Light: 75%
 			Cybernetic: 50%
 			Concrete: 50%
@@ -679,6 +680,8 @@ TeslaZap:
 		Spread: 1
 		InfDeath: 6
 		Damage: 100
+		Versus:
+			Wood: 60%
 
 Nike:
 	ROF: 15


### PR DESCRIPTION
Making this a pull request because I would like some opinions on these changes and some testing done. They generally make defenses bad against wooden structures which will discourage basewalking and make basewalking more difficult. Because some structures like `fact` and the superweapons are heavy I have moved them over to wood and given them a health boost. pbox and hbox have been moved over to heavy from wood. I have left the pillbox weapons unchanged.
