### PR TITLE
fixed a issue with pinging Master-server

### DIFF
--- a/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Server
 
 		public void Tick(S server)
 		{
-			if (Environment.TickCount - lastPing > MasterPingInterval * 1000)
+			if ((Environment.TickCount - lastPing > MasterPingInterval * 1000) || isInitialPing)
 				PingMasterServer(server);
 			else
 				lock (masterServerMessages)


### PR DESCRIPTION
fixes #2564

Sometimes initial TickCount is less than zero, so (Environment.TickCount - lastPing) can be less than "MasterPingInterval \* 1000". That's why PingMasterServer() is not calling for a long time until somebody connected.
