### PR TITLE
Add more options to settings GUI including game-speed slider

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -88,7 +88,7 @@ namespace OpenRA.GameRules
 		public float VideoVolume = 0.5f;
 		public bool Shuffle = false;
 		public bool Repeat = false;
-		public bool ShellmapMusic = true;
+		public bool MapMusic = true;
 		public string Engine = "AL";
 		
 		public SoundCashTicks SoundCashTickType = SoundCashTicks.Extreme;

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncSettingsLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncSettingsLogic.cs
@@ -107,8 +107,8 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			musicSlider.Value = soundSettings.MusicVolume;
 
 			var shellmapMusicCheckbox = generalPane.Get<CheckboxWidget>("SHELLMAP_MUSIC");
-			shellmapMusicCheckbox.IsChecked = () => soundSettings.ShellmapMusic;
-			shellmapMusicCheckbox.OnClick = () => soundSettings.ShellmapMusic ^= true;
+			shellmapMusicCheckbox.IsChecked = () => soundSettings.MapMusic;
+			shellmapMusicCheckbox.OnClick = () => soundSettings.MapMusic ^= true;
 
 			// Input pane
 			var inputPane = panel.Get("INPUT_CONTROLS");

--- a/OpenRA.Mods.RA/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/PerfDebugLogic.cs
@@ -23,11 +23,12 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			// Perf text
 			var perfText = perfRoot.Get<LabelWidget>("TEXT");
+			perfText.IsVisible = () => Game.Settings.Debug.PerfText;
 			perfText.GetText = () => "Render {0} ({5}={2:F1} ms)\nTick {4} ({3:F1} ms)".F(
 					Game.RenderFrame,
 					Game.NetFrameNumber,
-					PerfHistory.items["render"].LastValue,
-					PerfHistory.items["tick_time"].LastValue,
+					PerfHistory.items["render"].Average(Game.Settings.Debug.Samples),
+					PerfHistory.items["tick_time"].Average(Game.Settings.Debug.Samples),
 					Game.LocalTick,
 					PerfHistory.items["batches"].LastValue);
 		}

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -137,6 +137,13 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				Game.viewport.Zoom = gs.PixelDouble ? 2 : 1;
 			};
 
+			var capFrameRateCheckbox = display.Get<CheckboxWidget>("CAPFRAMERATE_CHECKBOX");
+			capFrameRateCheckbox.IsChecked = () => gs.CapFramerate;
+			capFrameRateCheckbox.OnClick = () => gs.CapFramerate ^= true;
+
+			var maxFrameRate = display.Get<TextFieldWidget>("MAX_FRAMERATE");
+			maxFrameRate.Text = gs.MaxFramerate.ToString();
+
 			// Debug
 			var debug = bg.Get("DEBUG_PANE");
 
@@ -170,6 +177,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				int.TryParse(windowWidth.Text, out x);
 				int.TryParse(windowHeight.Text, out y);
 				gs.WindowedSize = new int2(x,y);
+				int.TryParse(maxFrameRate.Text, out gs.MaxFramerate);
 				Game.Settings.Save();
 				Ui.CloseWindow();
 			};

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -73,6 +73,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			useClassicMouseStyleCheckbox.IsChecked = () => Game.Settings.Game.UseClassicMouseStyle;
 			useClassicMouseStyleCheckbox.OnClick = () => Game.Settings.Game.UseClassicMouseStyle ^= true;
 
+			var timeStepSlider = general.Get<SliderWidget>("GAME_SPEED_AMOUNT");
+			timeStepSlider.Value = timeStepSlider.MaximumValue-Game.Settings.Game.Timestep;
+			timeStepSlider.OnChange += x => Game.Settings.Game.Timestep = (int)timeStepSlider.MaximumValue-(int)Math.Round(x);
+
 			// Audio
 			var audio = bg.Get("AUDIO_PANE");
 			var soundSettings = Game.Settings.Sound;

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -140,13 +140,29 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			// Debug
 			var debug = bg.Get("DEBUG_PANE");
 
-			var perfgraphCheckbox = debug.Get<CheckboxWidget>("PERFDEBUG_CHECKBOX");
+			var perfgraphCheckbox = debug.Get<CheckboxWidget>("PERFGRAPH_CHECKBOX");
 			perfgraphCheckbox.IsChecked = () => Game.Settings.Debug.PerfGraph;
 			perfgraphCheckbox.OnClick = () => Game.Settings.Debug.PerfGraph ^= true;
+
+			var perftextCheckbox = debug.Get<CheckboxWidget>("PERFTEXT_CHECKBOX");
+			perftextCheckbox.IsChecked = () => Game.Settings.Debug.PerfText;
+			perftextCheckbox.OnClick = () => Game.Settings.Debug.PerfText ^= true;
+
+			var sampleSlider = debug.Get<SliderWidget>("PERFTEXT_SAMPLE_AMOUNT");
+			sampleSlider.Value = sampleSlider.MaximumValue-Game.Settings.Debug.Samples;
+			sampleSlider.OnChange += x => Game.Settings.Debug.Samples = (int)sampleSlider.MaximumValue-(int)Math.Round(x);
 
 			var checkunsyncedCheckbox = debug.Get<CheckboxWidget>("CHECKUNSYNCED_CHECKBOX");
 			checkunsyncedCheckbox.IsChecked = () => Game.Settings.Debug.SanityCheckUnsyncedCode;
 			checkunsyncedCheckbox.OnClick = () => Game.Settings.Debug.SanityCheckUnsyncedCode ^= true;
+
+			var botdebugCheckbox = debug.Get<CheckboxWidget>("BOTDEBUG_CHECKBOX");
+			botdebugCheckbox.IsChecked = () => Game.Settings.Debug.BotDebug;
+			botdebugCheckbox.OnClick = () => Game.Settings.Debug.BotDebug ^= true;
+
+			var longTickThreshold = debug.Get<SliderWidget>("LONG_TICK_THRESHOLD");
+			longTickThreshold.Value = Game.Settings.Debug.LongTickThreshold;
+			longTickThreshold.OnChange += x => Game.Settings.Debug.LongTickThreshold = x;
 
 			bg.Get<ButtonWidget>("BUTTON_CLOSE").OnClick = () =>
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -89,10 +89,23 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			musicslider.OnChange += x => Sound.MusicVolume = x;
 			musicslider.Value = Sound.MusicVolume;
 
+			var videoslider = audio.Get<SliderWidget>("VIDEO_VOLUME");
+			videoslider.OnChange += x => Sound.VideoVolume = x;
+			videoslider.Value = Sound.VideoVolume;
+
 			var cashticksdropdown = audio.Get<DropDownButtonWidget>("CASH_TICK_TYPE");
 			cashticksdropdown.OnMouseDown = _ => ShowSoundTickDropdown(cashticksdropdown, soundSettings);
 			cashticksdropdown.GetText = () => soundSettings.SoundCashTickType == SoundCashTicks.Extreme ?
 				"Extreme" : soundSettings.SoundCashTickType == SoundCashTicks.Normal ? "Normal" : "Disabled";
+
+			var mapMusicCheckbox = audio.Get<CheckboxWidget>("MAP_MUSIC_CHECKBOX");
+			mapMusicCheckbox.IsChecked = () => Game.Settings.Sound.MapMusic;
+			mapMusicCheckbox.OnClick = () => Game.Settings.Sound.MapMusic ^= true;
+
+			var soundEngineDropdown = audio.Get<DropDownButtonWidget>("SOUND_ENGINE");
+			soundEngineDropdown.OnMouseDown = _ => ShowSoundEngineDropdown(soundEngineDropdown, soundSettings);
+			soundEngineDropdown.GetText = () => soundSettings.Engine == "AL" ?
+				"OpenAL" : soundSettings.Engine == "Null" ? "None" : "OpenAL";
 
 			
 			// Display
@@ -216,6 +229,27 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => s.Renderer == options[o],
 					() => s.Renderer = options[o]);
+				item.Get<LabelWidget>("LABEL").GetText = () => o;
+				return item;
+			};
+
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+			return true;
+		}
+
+		public static bool ShowSoundEngineDropdown(DropDownButtonWidget dropdown, SoundSettings s)
+		{
+			var options = new Dictionary<string, string>()
+			{
+				{ "OpenAL", "AL" },
+				{ "None", "Null" },
+			};
+
+			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => s.Engine == options[o],
+					() => s.Engine = options[o]);
 				item.Get<LabelWidget>("LABEL").GetText = () => o;
 				return item;
 			};

--- a/OpenRA.Mods.RA/World/PlayMusicOnMapLoad.cs
+++ b/OpenRA.Mods.RA/World/PlayMusicOnMapLoad.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA
 		{
 			var onComplete = Info.Loop ? (Action)PlayMusic : () => {};
 
-			if (Game.Settings.Sound.ShellmapMusic &&
+			if (Game.Settings.Sound.MapMusic &&
 				Rules.Music.ContainsKey(Info.Music))
 				Sound.PlayMusicThen(Rules.Music[Info.Music], onComplete);
 		}

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -327,11 +327,11 @@ Background@SETTINGS_MENU:
 				Label@PERFTEXT_SAMPLE_LABEL:
 					X:0
 					Y:160
-					Text:Trait Report Threshold in Ticks:
+					Text:Slow Trait Report Threshold in Seconds:
 				Slider@LONG_TICK_THRESHOLD:
 					X:0
 					Y:170
-					Width:350
+					Width:370
 					Height:20
 					Ticks:5
 					MinimumValue: 0.0001

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -3,7 +3,7 @@ Background@SETTINGS_MENU:
 	X:(WINDOW_RIGHT - WIDTH)/2
 	Y:(WINDOW_BOTTOM- HEIGHT)/2
 	Width: 450
-	Height: 350
+	Height: 450
 	Children:
 		Label@SETTINGS_LABEL_TITLE:
 			X:0
@@ -115,6 +115,18 @@ Background@SETTINGS_MENU:
 					Width:200
 					Height:20
 					Text: Left-Click Orders
+				Label@GAME_SPEED_AMOUNT_LABEL:
+					X:0
+					Y:220
+					Text: Game Speed
+				Slider@GAME_SPEED_AMOUNT:
+					X:130
+					Y:210
+					Width:250
+					Height:20
+					Ticks:5
+					MinimumValue: 1
+					MaximumValue: 80
 		Container@AUDIO_PANE:
 			X:37
 			Y:100

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -276,15 +276,51 @@ Background@SETTINGS_MENU:
 			Height:PARENT_BOTTOM - 100
 			Visible: false
 			Children:
-				Checkbox@PERFDEBUG_CHECKBOX:
+				Checkbox@PERFGRAPH_CHECKBOX:
 					X:0
 					Y:0
 					Width:300
 					Height:20
-					Text:Show Performance Information
-				Checkbox@CHECKUNSYNCED_CHECKBOX:
+					Text:Show Performance Graph
+				Checkbox@PERFTEXT_CHECKBOX:
 					X:0
 					Y:30
 					Width:300
 					Height:20
+					Text:Show Performance Text
+				Label@PERFTEXT_SAMPLE_LABEL:
+					X:30
+					Y:70
+					Text:Update Rate
+				Slider@PERFTEXT_SAMPLE_AMOUNT:
+					X:130
+					Y:60
+					Width:250
+					Height:20
+					Ticks:5
+					MinimumValue: 1
+					MaximumValue: 50
+				Checkbox@CHECKUNSYNCED_CHECKBOX:
+					X:0
+					Y:90
+					Width:300
+					Height:20
 					Text:Check Sync around Unsynced Code
+				Checkbox@BOTDEBUG_CHECKBOX:
+					X:0
+					Y:120
+					Width:300
+					Height:20
+					Text:Show Bot Debug Messages
+				Label@PERFTEXT_SAMPLE_LABEL:
+					X:0
+					Y:160
+					Text:Trait Report Threshold in Ticks:
+				Slider@LONG_TICK_THRESHOLD:
+					X:0
+					Y:170
+					Width:350
+					Height:20
+					Ticks:5
+					MinimumValue: 0.0001
+					MaximumValue: 0.01

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -269,6 +269,18 @@ Background@SETTINGS_MENU:
 					Height:20
 					Font:Regular
 					Text:Enable Pixel Doubling
+				Checkbox@CAPFRAMERATE_CHECKBOX:
+					Y:120
+					Width:200
+					Height:20
+					Font:Regular
+					Text:Cap Framerate @ 
+				TextField@MAX_FRAMERATE:
+					X:150
+					Y:120
+					Width:45
+					Height:25
+					MaxLength:3
 		Container@DEBUG_PANE:
 			X:37
 			Y:100

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -154,17 +154,46 @@ Background@SETTINGS_MENU:
 					Width:250
 					Height:20
 					Ticks:5
-				Label@SOUND_TICK_TYPE_LABEL:
+				Label@VIDEO_VOLUME_LABEL:
 					X:0
 					Y:70
+					Text: Video Volume
+				Slider@VIDEO_VOLUME:
+					X:100
+					Y:60
+					Width:250
+					Height:20
+					Ticks:5
+				Label@SOUND_TICK_TYPE_LABEL:
+					X:0
+					Y:100
 					Text: Cash ticks
 				DropDownButton@CASH_TICK_TYPE:
 					X:100
-					Y:60
+					Y:90
 					Width:250
 					Height:25
 					Font:Regular
 					Text:Extreme
+				Checkbox@MAP_MUSIC_CHECKBOX:
+					X:0
+					Y:120
+					Width:200
+					Height:20
+					Text: Autoplay Music After Map Load
+				Label@SOUND_ENGINE_LABEL:
+					X:0
+					Y:150
+					Width:75
+					Height:25
+					Text:Sound Engine:
+				DropDownButton@SOUND_ENGINE:
+					X:100
+					Y:150
+					Width:120
+					Height:25
+					Font:Regular
+					Text:OpenAL
 		Container@DISPLAY_PANE:
 			X:37
 			Y:100


### PR DESCRIPTION
This adds several new hidden settings to the Red Alert and Dune 2000 settings menu including the anticipated game-speed slider from #2058.

![game-speed-slider](https://f.cloud.github.com/assets/756669/158193/daa61f4a-76dd-11e2-92bf-efb69cda9330.png)

![cap-fps](https://f.cloud.github.com/assets/756669/158195/de367b14-76dd-11e2-99e7-1576f82df149.png)

![new-sound-options](https://f.cloud.github.com/assets/756669/158197/e543b340-76dd-11e2-967b-7e9ca0e871e2.png)

![debug](https://f.cloud.github.com/assets/756669/158198/e955c518-76dd-11e2-8e72-cf06b1ba07c8.png)
