### PR TITLE
Fix NullReferenceException in UnHideActor

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -137,6 +137,9 @@ namespace OpenRA.Traits
 	 		if (a.Owner.World.LocalPlayer == null
 				|| a.Owner.Stances[a.Owner.World.LocalPlayer] == Stance.Ally) return;
 
+			if (v == null)
+				return;
+
 	 		foreach (var p in v.vis)
 				foreach (var q in FindVisibleTiles(a.World, p, range))
 					foggedCells[q.X, q.Y] = exploredCells[q.X, q.Y];


### PR DESCRIPTION
Fixes #2664 which crashes the game if gap generators are on low power.
