### PR TITLE
Remove custom build time for Tiberium refinery to fix desyncs

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -123,8 +123,6 @@ PROC:
 		Bounds: 73,72
 	CustomSellValue:
 		Value: 300
-	CustomBuildTimeValue:
-		Value: 80
 	FreeActor:
 		Actor: HARV
 		InitialActivity: FindResources


### PR DESCRIPTION
Fixes #2456
- this can be enabled again in cnc-classic
- needs an overhaul as it causes desyncs
