### PR TITLE
Dump some more values into the debug log to investigate desyncs

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -140,17 +140,17 @@ namespace OpenRA.Network
 			if (index >= orders.Count())
 				OutOfSync(frame);
 
-			throw new InvalidOperationException("Out of sync in frame {0}.\n {1}".F(frame, orders.ElementAt(index).Order.ToString()));
+			throw new InvalidOperationException("Out of sync in frame {0}.\n {1}\n Compare syncreport.log with other players.".F(frame, orders.ElementAt(index).Order.ToString()));
 		}
 
 		void OutOfSync(int frame)
 		{
-			throw new InvalidOperationException("Out of sync in frame {0}.\n".F(frame));
+			throw new InvalidOperationException("Out of sync in frame {0}.\n Compare syncreport.log with other players.".F(frame));
 		}
 
 		void OutOfSync(int frame, string blame)
 		{
-			throw new InvalidOperationException("Out of sync in frame {0}: Blame {1}.\n".F(frame, blame));
+			throw new InvalidOperationException("Out of sync in frame {0}: Blame {1}.\n Compare syncreport.log with other players.".F(frame, blame));
 		}
 
 		public bool IsReadyForNextFrame

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -108,6 +108,7 @@ namespace OpenRA.Mods.RA
 			var info = self.Info.Traits.Get<AttackBaseInfo>();
 			nextScanTime = (int)(25 * (info.ScanTimeAverage +
 				(self.World.SharedRandom.NextFloat() * 2 - 1) * info.ScanTimeSpread));
+			Log.Write("debug", "Actor {0}; nextScanTime: {1}", self.ActorID, nextScanTime);
 
 			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, (int)(Game.CellSize * range));
 

--- a/OpenRA.Mods.RA/Effects/Bullet.cs
+++ b/OpenRA.Mods.RA/Effects/Bullet.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			if (info.Inaccuracy > 0)
 			{
-				var factor = ((Args.dest - Args.src).Length / Game.CellSize) / (float)args.weapon.Range;
+				var factor = ((Args.dest - Args.src).ToCVec().Length) / args.weapon.Range;
 				Args.dest += (PVecInt) (info.Inaccuracy * factor * args.firedBy.World.SharedRandom.Gauss2D(2)).ToInt2();
 				Log.Write("debug", "Bullet with Inaccuracy; factor: #{0}; Projectile dest: {1}", factor, Args.dest);
 			}

--- a/OpenRA.Mods.RA/Effects/Bullet.cs
+++ b/OpenRA.Mods.RA/Effects/Bullet.cs
@@ -59,6 +59,7 @@ namespace OpenRA.Mods.RA.Effects
 			{
 				var factor = ((Args.dest - Args.src).Length / Game.CellSize) / (float)args.weapon.Range;
 				Args.dest += (PVecInt) (info.Inaccuracy * factor * args.firedBy.World.SharedRandom.Gauss2D(2)).ToInt2();
+				Log.Write("debug", "Bullet with Inaccuracy; factor: #{0}; Projectile dest: {1}", factor, Args.dest);
 			}
 
 			if (Info.Image != null)


### PR DESCRIPTION
I want to find out if the inaccuracy calculation from bullets is a source of common desync problems.
