### PR TITLE
add Shroud, CreatesShroud and RevealsShroud to syncreport.log

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -47,8 +47,7 @@ namespace OpenRA
 		
 		public Shroud.ActorVisibility Sight;
 
-		[Sync]
-		public Player Owner;
+		[Sync] public Player Owner;
 
 		Activity currentActivity;
 		public Group Group;

--- a/OpenRA.Game/Traits/CreatesShroud.cs
+++ b/OpenRA.Game/Traits/CreatesShroud.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Traits
 		public object Create(ActorInitializer init) { return new CreatesShroud(this); }
 	}
 
-	public class CreatesShroud : ITick
+	public class CreatesShroud : ITick, ISync
 	{
 		CreatesShroudInfo Info;
-		CPos previousLocation;
+		[Sync] CPos previousLocation;
 		Shroud.ActorVisibility v;
 
 		public CreatesShroud(CreatesShroudInfo info)
@@ -37,20 +37,20 @@ namespace OpenRA.Traits
 			if (previousLocation != self.Location && v != null) {
 				previousLocation = self.Location;
 
-				var shrouds = self.World.ActorsWithTrait<Traits.Shroud>().Select(s => s.Actor.Owner.Shroud);
+				var shrouds = self.World.ActorsWithTrait<Shroud>().Select(s => s.Actor.Owner.Shroud);
 				foreach (var shroud in shrouds) {
 					shroud.UnhideActor(self, v, Info.Range);
 				}
 			}
 
 			if (!self.TraitsImplementing<IDisable>().Any(d => d.Disabled)) {
-				var shrouds = self.World.ActorsWithTrait<Traits.Shroud>().Select(s => s.Actor.Owner.Shroud);
+				var shrouds = self.World.ActorsWithTrait<Shroud>().Select(s => s.Actor.Owner.Shroud);
 				foreach (var shroud in shrouds) {
 					shroud.HideActor(self, Info.Range);
 				}
 			}
 			else {
-				var shrouds = self.World.ActorsWithTrait<Traits.Shroud>().Select(s => s.Actor.Owner.Shroud);
+				var shrouds = self.World.ActorsWithTrait<Shroud>().Select(s => s.Actor.Owner.Shroud);
 				foreach (var shroud in shrouds) {
 					shroud.UnhideActor(self, v, Info.Range);
 				}

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -75,13 +75,10 @@ namespace OpenRA.Traits
 			AdviceInterval = info.AdviceInterval;
 		}
 
-		[Sync]
-		public int Cash;
+		[Sync] public int Cash;
 
-		[Sync]
-		public int Ore;
-		[Sync]
-		public int OreCapacity;
+		[Sync] public int Ore;
+		[Sync] public int OreCapacity;
 
 		public int DisplayCash;
 		public int DisplayOre;

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -16,10 +16,10 @@ namespace OpenRA.Traits
 		public object Create(ActorInitializer init) { return new RevealsShroud(this); }
 	}
 
-	public class RevealsShroud : ITick
+	public class RevealsShroud : ITick, ISync
 	{
 		RevealsShroudInfo Info;
-		CPos previousLocation;
+		[Sync] CPos previousLocation;
 
 		public RevealsShroud(RevealsShroudInfo info)
 		{

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -20,19 +20,19 @@ namespace OpenRA.Traits
 		public object Create(ActorInitializer init) { return new Shroud(init.world); }
 	}
 
-	public class Shroud
+	public class Shroud : ISync
 	{
 		Map map;
 		World world;
 
-		public Player Owner;
+		[Sync] public Player Owner;
 		public int[,] visibleCells;
 		public bool[,] exploredCells;
 		public bool[,] foggedCells;
 		public Rectangle? exploredBounds;
 		bool disabled = false;
 		public bool dirty = true;
-		public bool Disabled
+		[Sync] public bool Disabled
 		{
 			get { return disabled; }
 			set { disabled = value; Dirty(); }
@@ -70,7 +70,7 @@ namespace OpenRA.Traits
 
 		// cache of positions that were added, so no matter what crazy trait code does, it
 		// can't make us invalid.
-		public class ActorVisibility { public int range; public CPos[] vis; }
+		public class ActorVisibility { [Sync] public int range; [Sync] public CPos[] vis; }
 		public Dictionary<Actor, ActorVisibility> vis = new Dictionary<Actor, ActorVisibility>();
 
 		static IEnumerable<CPos> FindVisibleTiles(World world, CPos a, int r)

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -102,12 +102,9 @@ namespace OpenRA.Mods.RA.Air
 
 
 		protected readonly Actor self;
-		[Sync]
-		public int Facing { get; set; }
-		[Sync]
-		public int Altitude { get; set; }
-		[Sync]
-		public PSubPos SubPxPosition;
+		[Sync] public int Facing { get; set; }
+		[Sync] public int Altitude { get; set; }
+		[Sync] public PSubPos SubPxPosition;
 		public PPos PxPosition { get { return SubPxPosition.ToPPos(); } }
 		public CPos TopLeft { get { return PxPosition.ToCPos(); } }
 

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -25,13 +25,14 @@ namespace OpenRA.Mods.RA
 
 	public enum UnitStance { HoldFire, ReturnFire, Defend, AttackAnything };
 
-	public class AutoTarget : INotifyIdle, INotifyDamage, ITick, IResolveOrder
+	public class AutoTarget : INotifyIdle, INotifyDamage, ITick, IResolveOrder, ISync
 	{
 		readonly AutoTargetInfo Info;
 		readonly AttackBase attack;
 
 		[Sync] int nextScanTime = 0;
-		[Sync] public UnitStance stance;
+		public UnitStance stance;
+		[Sync] public int stanceNumber { get { return (int)stance; } }
 		public UnitStance predictedStance;		/* NOT SYNCED: do not refer to this anywhere other than UI code */
 
 		public AutoTarget(Actor self, AutoTargetInfo info)

--- a/OpenRA.Mods.RA/ScaredyCat.cs
+++ b/OpenRA.Mods.RA/ScaredyCat.cs
@@ -22,13 +22,13 @@ namespace OpenRA.Mods.RA
 		public object Create(ActorInitializer init) { return new ScaredyCat(init.self, this); }
 	}
 
-	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier
+	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync
 	{
 		readonly ScaredyCatInfo Info;
-		readonly Actor Self;
+		[Sync] readonly Actor Self;
 
-		public int PanicStartedTick;
-		public bool Panicking { get { return PanicStartedTick > 0; } }
+		[Sync] public int PanicStartedTick;
+		[Sync] public bool Panicking { get { return PanicStartedTick > 0; } }
 
 		public ScaredyCat(Actor self, ScaredyCatInfo info)
 		{


### PR DESCRIPTION
To investigate recent desync problems that might be related to the introduction of per-player shroud and gap generators.
