### PR TITLE
Csproj BuildEvents problem in both Linux and Windows

### DIFF
--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -460,7 +460,8 @@
   <PropertyGroup>
     <PostBuildEvent>mkdir "$(SolutionDir)mods/ra/"
 copy "$(TargetPath)" "$(SolutionDir)mods/ra/"
-copy "thirdparty/FuzzyLogicLibrary.dll" "$(SolutionDir)"
+cd "$(SolutionDir)thirdparty/"
+copy "FuzzyLogicLibrary.dll" "$(SolutionDir)"
 cd "$(SolutionDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I have found this error with the OpenRa.Mods.RA csproj: copy
"thirdparty/FuzzyLogicLibrary.dll" "$(SolutionDir)", this should be: cd
"$(SolutionDir)thirdparty/"
copy "FuzzyLogicLibrary.dll" "$(SolutionDir)" in two seperated codes,
this FuzzyLogicLibrary.dll copy error can be fixed in both Windows and
Linux environment
