### PR TITLE
Diagonal scrolling area in viewport corners are too small

### DIFF
--- a/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
@@ -95,58 +95,54 @@ namespace OpenRA.Widgets
             Edge = ScrollDirection.None;
             if (Game.Settings.Game.ViewportEdgeScroll && Game.HasInputFocus)
             {
-                CheckForDirections();
+                Edge = CheckForDirections();
                 Scroll();
             }
 
 
         }
 
-        private ScrollDirection CheckForDirections()
+        ScrollDirection CheckForDirections()
         {
             // First let's check if the mouse is on the corners:
             if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
                 Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Right
             {
-                Edge = Edge.Set(ScrollDirection.Right | ScrollDirection.Down, true);
-                return Edge;
+                return ScrollDirection.Right | ScrollDirection.Down;
             }
             else if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
                Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Left
             {
-                Edge = Edge.Set(ScrollDirection.Down | ScrollDirection.Left, true);
-                return Edge;
+                return ScrollDirection.Down | ScrollDirection.Left;
             }
 
             else if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
                 Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Right
             {
-                Edge = Edge.Set(ScrollDirection.Right | ScrollDirection.Up, true);
-                return Edge;
+                return ScrollDirection.Right | ScrollDirection.Up;
             }
 
             else if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
                 Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Left
             {
-                Edge = Edge.Set(ScrollDirection.Left | ScrollDirection.Up, true);
-                return Edge;
+                return ScrollDirection.Left | ScrollDirection.Up;
             }
 
             //Check for corner ends here now let's check the edges:
 
             // Check for edge-scroll
             if (Viewport.LastMousePos.X < EdgeScrollThreshold)
-                Edge = Edge.Set(ScrollDirection.Left, true);
+                return ScrollDirection.Left;
             if (Viewport.LastMousePos.Y < EdgeScrollThreshold)
-                Edge = Edge.Set(ScrollDirection.Up, true);
+                return ScrollDirection.Up;
             if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeScrollThreshold)
-                Edge = Edge.Set(ScrollDirection.Right, true);
+                return ScrollDirection.Right;
             if (Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeScrollThreshold)
-                Edge = Edge.Set(ScrollDirection.Down, true);
+                return ScrollDirection.Down;
 
 
-            //Check for edge-scroll ends here.
-            return Edge;
+            //Check for edge-scroll ends here.If none of above then return none.
+            return ScrollDirection.None;
         }
 
 

--- a/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Widgets
         }
 
 
-        public void Scroll()
+        void Scroll()
         {
             if (Keyboard != ScrollDirection.None || Edge != ScrollDirection.None)
             {

--- a/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
@@ -95,65 +95,60 @@ namespace OpenRA.Widgets
             Edge = ScrollDirection.None;
             if (Game.Settings.Game.ViewportEdgeScroll && Game.HasInputFocus)
             {
-                // First let's check if the mouse is on the corners:
-                if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
-                    Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Right
-                {
-                    Edge = Edge.Set(ScrollDirection.Right, true);
-                    Scroll();
-                    Edge = Edge.Set(ScrollDirection.Down, true);
-                    Scroll();
-                    return;
-                }
-                if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
-                   Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Left
-                {
-                    Edge = Edge.Set(ScrollDirection.Left, true);
-                    Scroll();
-                    Edge = Edge.Set(ScrollDirection.Down, true);
-                    Scroll();
-                    return;
-                }
-
-                if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
-                   Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Right
-                {
-                    Edge = Edge.Set(ScrollDirection.Right, true);
-                    Scroll();
-                    Edge = Edge.Set(ScrollDirection.Up, true);
-                    Scroll();
-                    return;
-                }
-
-                if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
-                    Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Left
-                {
-                    Edge = Edge.Set(ScrollDirection.Left, true);
-                    Scroll();
-                    Edge = Edge.Set(ScrollDirection.Up, true);
-                    Scroll();
-                    return;
-                }
-
-
-                //Check for corner ends here now let's check the edges:
-
-                // Check for edge-scroll
-                if (Viewport.LastMousePos.X < EdgeScrollThreshold)
-                    Edge = Edge.Set(ScrollDirection.Left, true);
-                if (Viewport.LastMousePos.Y < EdgeScrollThreshold)
-                    Edge = Edge.Set(ScrollDirection.Up, true);
-                if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeScrollThreshold)
-                    Edge = Edge.Set(ScrollDirection.Right, true);
-                if (Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeScrollThreshold)
-                    Edge = Edge.Set(ScrollDirection.Down, true);
-
+                CheckForDirections();
                 Scroll();
-                //Check for edge-scroll ends here.
             }
 
 
         }
+
+        private ScrollDirection CheckForDirections()
+        {
+            // First let's check if the mouse is on the corners:
+            if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
+                Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Right
+            {
+                Edge = Edge.Set(ScrollDirection.Right | ScrollDirection.Down, true);
+                return Edge;
+            }
+            else if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
+               Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Left
+            {
+                Edge = Edge.Set(ScrollDirection.Down | ScrollDirection.Left, true);
+                return Edge;
+            }
+
+            else if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
+                Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Right
+            {
+                Edge = Edge.Set(ScrollDirection.Right | ScrollDirection.Up, true);
+                return Edge;
+            }
+
+            else if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
+                Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Left
+            {
+                Edge = Edge.Set(ScrollDirection.Left | ScrollDirection.Up, true);
+                return Edge;
+            }
+
+            //Check for corner ends here now let's check the edges:
+
+            // Check for edge-scroll
+            if (Viewport.LastMousePos.X < EdgeScrollThreshold)
+                Edge = Edge.Set(ScrollDirection.Left, true);
+            if (Viewport.LastMousePos.Y < EdgeScrollThreshold)
+                Edge = Edge.Set(ScrollDirection.Up, true);
+            if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeScrollThreshold)
+                Edge = Edge.Set(ScrollDirection.Right, true);
+            if (Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeScrollThreshold)
+                Edge = Edge.Set(ScrollDirection.Down, true);
+
+
+            //Check for edge-scroll ends here.
+            return Edge;
+        }
+
 
         public void Scroll()
         {

--- a/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
@@ -15,35 +15,35 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Widgets
 {
-	public class ViewportScrollControllerWidget : Widget
-	{
-		public int EdgeScrollThreshold = 15;
+    public class ViewportScrollControllerWidget : Widget
+    {
+        public int EdgeScrollThreshold = 15;
         public int EdgeCornerScrollThreshold = 35;
 
-		ScrollDirection Keyboard;
-		ScrollDirection Edge;
+        ScrollDirection Keyboard;
+        ScrollDirection Edge;
 
-		public ViewportScrollControllerWidget() : base() {}
-		protected ViewportScrollControllerWidget(ViewportScrollControllerWidget widget)
-			: base(widget) {}
+        public ViewportScrollControllerWidget() : base() { }
+        protected ViewportScrollControllerWidget(ViewportScrollControllerWidget widget)
+            : base(widget) { }
 
-		public override bool HandleMouseInput(MouseInput mi)
-		{
-			var scrolltype = Game.Settings.Game.MouseScroll;
-			if (scrolltype == MouseScrollType.Disabled)
-				return false;
+        public override bool HandleMouseInput(MouseInput mi)
+        {
+            var scrolltype = Game.Settings.Game.MouseScroll;
+            if (scrolltype == MouseScrollType.Disabled)
+                return false;
 
-			if (mi.Event == MouseInputEvent.Move &&
-				(mi.Button == MouseButton.Middle || mi.Button == (MouseButton.Left | MouseButton.Right)))
-			{
-				var d = scrolltype == MouseScrollType.Inverted ? -1 : 1;
-				Game.viewport.Scroll((Viewport.LastMousePos - mi.Location) * d);
-				return true;
-			}
-			return false;
-		}
+            if (mi.Event == MouseInputEvent.Move &&
+                (mi.Button == MouseButton.Middle || mi.Button == (MouseButton.Left | MouseButton.Right)))
+            {
+                var d = scrolltype == MouseScrollType.Inverted ? -1 : 1;
+                Game.viewport.Scroll((Viewport.LastMousePos - mi.Location) * d);
+                return true;
+            }
+            return false;
+        }
 
-		static readonly Dictionary<ScrollDirection, string> directions = new Dictionary<ScrollDirection, string>
+        static readonly Dictionary<ScrollDirection, string> directions = new Dictionary<ScrollDirection, string>
 		{
 			{ ScrollDirection.Up | ScrollDirection.Left, "scroll-tl" },
 			{ ScrollDirection.Up | ScrollDirection.Right, "scroll-tr" },
@@ -56,45 +56,45 @@ namespace OpenRA.Widgets
 			{ ScrollDirection.Right, "scroll-r" },
 		};
 
-		public static string GetScrollCursor(Widget w, ScrollDirection edge, int2 pos)
-		{
-			if (!Game.Settings.Game.ViewportEdgeScroll || Ui.MouseOverWidget != w)
-				return null;
+        public static string GetScrollCursor(Widget w, ScrollDirection edge, int2 pos)
+        {
+            if (!Game.Settings.Game.ViewportEdgeScroll || Ui.MouseOverWidget != w)
+                return null;
 
-			var blockedDirections = Game.viewport.GetBlockedDirections();
+            var blockedDirections = Game.viewport.GetBlockedDirections();
 
-			foreach( var dir in directions )
-				if (edge.Includes( dir.Key ))
-					return dir.Value + (blockedDirections.Includes( dir.Key ) ? "-blocked" : "");
+            foreach (var dir in directions)
+                if (edge.Includes(dir.Key))
+                    return dir.Value + (blockedDirections.Includes(dir.Key) ? "-blocked" : "");
 
-			return null;
-		}
+            return null;
+        }
 
-		public override string GetCursor(int2 pos) { return GetScrollCursor(this, Edge, pos); }
+        public override string GetCursor(int2 pos) { return GetScrollCursor(this, Edge, pos); }
 
-		public override bool LoseFocus (MouseInput mi)
-		{
-			Keyboard = ScrollDirection.None;
-			return base.LoseFocus(mi);
-		}
+        public override bool LoseFocus(MouseInput mi)
+        {
+            Keyboard = ScrollDirection.None;
+            return base.LoseFocus(mi);
+        }
 
-		public override bool HandleKeyPress(KeyInput e)
-		{
-			switch (e.KeyName)
-			{
-				case "up": Keyboard = Keyboard.Set(ScrollDirection.Up, e.Event == KeyInputEvent.Down); return true;
-				case "down": Keyboard = Keyboard.Set(ScrollDirection.Down, e.Event == KeyInputEvent.Down); return true;
-				case "left": Keyboard = Keyboard.Set(ScrollDirection.Left, e.Event == KeyInputEvent.Down); return true;
-				case "right": Keyboard = Keyboard.Set(ScrollDirection.Right, e.Event == KeyInputEvent.Down); return true;
-			}
-			return false;
-		}
+        public override bool HandleKeyPress(KeyInput e)
+        {
+            switch (e.KeyName)
+            {
+                case "up": Keyboard = Keyboard.Set(ScrollDirection.Up, e.Event == KeyInputEvent.Down); return true;
+                case "down": Keyboard = Keyboard.Set(ScrollDirection.Down, e.Event == KeyInputEvent.Down); return true;
+                case "left": Keyboard = Keyboard.Set(ScrollDirection.Left, e.Event == KeyInputEvent.Down); return true;
+                case "right": Keyboard = Keyboard.Set(ScrollDirection.Right, e.Event == KeyInputEvent.Down); return true;
+            }
+            return false;
+        }
 
-		public override void Tick()
-		{
-			Edge = ScrollDirection.None;
-			if (Game.Settings.Game.ViewportEdgeScroll && Game.HasInputFocus)
-			{
+        public override void Tick()
+        {
+            Edge = ScrollDirection.None;
+            if (Game.Settings.Game.ViewportEdgeScroll && Game.HasInputFocus)
+            {
                 // First let's check if the mouse is on the corners:
                 if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
                     Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Right
@@ -125,7 +125,7 @@ namespace OpenRA.Widgets
                     return;
                 }
 
-                if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold  &&
+                if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
                     Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Left
                 {
                     Edge = Edge.Set(ScrollDirection.Left, true);
@@ -135,25 +135,25 @@ namespace OpenRA.Widgets
                     return;
                 }
 
-                
+
                 //Check for corner ends here now let's check the edges:
 
-				// Check for edge-scroll
-				if (Viewport.LastMousePos.X < EdgeScrollThreshold)
-					Edge = Edge.Set(ScrollDirection.Left, true);
-				if (Viewport.LastMousePos.Y < EdgeScrollThreshold)
-					Edge = Edge.Set(ScrollDirection.Up, true);
-				if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeScrollThreshold)
-					Edge = Edge.Set(ScrollDirection.Right, true);
-				if (Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeScrollThreshold)
-					Edge = Edge.Set(ScrollDirection.Down, true);
+                // Check for edge-scroll
+                if (Viewport.LastMousePos.X < EdgeScrollThreshold)
+                    Edge = Edge.Set(ScrollDirection.Left, true);
+                if (Viewport.LastMousePos.Y < EdgeScrollThreshold)
+                    Edge = Edge.Set(ScrollDirection.Up, true);
+                if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeScrollThreshold)
+                    Edge = Edge.Set(ScrollDirection.Right, true);
+                if (Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeScrollThreshold)
+                    Edge = Edge.Set(ScrollDirection.Down, true);
 
                 Scroll();
                 //Check for edge-scroll ends here.
-			}
+            }
 
-			
-		}
+
+        }
 
         public void Scroll()
         {
@@ -178,6 +178,6 @@ namespace OpenRA.Widgets
             }
         }
 
-		public override Widget Clone() { return new ViewportScrollControllerWidget(this); }
-	}
+        public override Widget Clone() { return new ViewportScrollControllerWidget(this); }
+    }
 }

--- a/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Widgets
 	public class ViewportScrollControllerWidget : Widget
 	{
 		public int EdgeScrollThreshold = 15;
+        public int EdgeCornerScrollThreshold = 35;
 
 		ScrollDirection Keyboard;
 		ScrollDirection Edge;
@@ -94,6 +95,49 @@ namespace OpenRA.Widgets
 			Edge = ScrollDirection.None;
 			if (Game.Settings.Game.ViewportEdgeScroll && Game.HasInputFocus)
 			{
+                // First let's check if the mouse is on the corners:
+                if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
+                    Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Right
+                {
+                    Edge = Edge.Set(ScrollDirection.Right, true);
+                    Scroll();
+                    Edge = Edge.Set(ScrollDirection.Down, true);
+                    Scroll();
+                    return;
+                }
+                if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold &&
+                   Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeCornerScrollThreshold) //Bottom Left
+                {
+                    Edge = Edge.Set(ScrollDirection.Left, true);
+                    Scroll();
+                    Edge = Edge.Set(ScrollDirection.Down, true);
+                    Scroll();
+                    return;
+                }
+
+                if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeCornerScrollThreshold &&
+                   Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Right
+                {
+                    Edge = Edge.Set(ScrollDirection.Right, true);
+                    Scroll();
+                    Edge = Edge.Set(ScrollDirection.Up, true);
+                    Scroll();
+                    return;
+                }
+
+                if (Viewport.LastMousePos.X < EdgeCornerScrollThreshold  &&
+                    Viewport.LastMousePos.Y < EdgeCornerScrollThreshold) //Top Left
+                {
+                    Edge = Edge.Set(ScrollDirection.Left, true);
+                    Scroll();
+                    Edge = Edge.Set(ScrollDirection.Up, true);
+                    Scroll();
+                    return;
+                }
+
+                
+                //Check for corner ends here now let's check the edges:
+
 				// Check for edge-scroll
 				if (Viewport.LastMousePos.X < EdgeScrollThreshold)
 					Edge = Edge.Set(ScrollDirection.Left, true);
@@ -103,28 +147,36 @@ namespace OpenRA.Widgets
 					Edge = Edge.Set(ScrollDirection.Right, true);
 				if (Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeScrollThreshold)
 					Edge = Edge.Set(ScrollDirection.Down, true);
+
+                Scroll();
+                //Check for edge-scroll ends here.
 			}
 
-			if(Keyboard != ScrollDirection.None || Edge != ScrollDirection.None)
-			{
-				var scroll = new float2(0, 0);
-
-				if (Keyboard.Includes(ScrollDirection.Up) || Edge.Includes(ScrollDirection.Up))
-					scroll += new float2(0, -1);
-				if (Keyboard.Includes(ScrollDirection.Right) || Edge.Includes(ScrollDirection.Right))
-					scroll += new float2(1, 0);
-				if (Keyboard.Includes(ScrollDirection.Down) || Edge.Includes(ScrollDirection.Down))
-					scroll += new float2(0, 1);
-				if (Keyboard.Includes(ScrollDirection.Left) || Edge.Includes(ScrollDirection.Left))
-					scroll += new float2(-1, 0);
-
-				float length = Math.Max(1, scroll.Length);
-				scroll.X = (scroll.X / length) * Game.Settings.Game.ViewportEdgeScrollStep;
-				scroll.Y = (scroll.Y / length) * Game.Settings.Game.ViewportEdgeScrollStep;
-
-				Game.viewport.Scroll(scroll);
-			}
+			
 		}
+
+        public void Scroll()
+        {
+            if (Keyboard != ScrollDirection.None || Edge != ScrollDirection.None)
+            {
+                var scroll = new float2(0, 0);
+
+                if (Keyboard.Includes(ScrollDirection.Up) || Edge.Includes(ScrollDirection.Up))
+                    scroll += new float2(0, -1);
+                if (Keyboard.Includes(ScrollDirection.Right) || Edge.Includes(ScrollDirection.Right))
+                    scroll += new float2(1, 0);
+                if (Keyboard.Includes(ScrollDirection.Down) || Edge.Includes(ScrollDirection.Down))
+                    scroll += new float2(0, 1);
+                if (Keyboard.Includes(ScrollDirection.Left) || Edge.Includes(ScrollDirection.Left))
+                    scroll += new float2(-1, 0);
+
+                float length = Math.Max(1, scroll.Length);
+                scroll.X = (scroll.X / length) * Game.Settings.Game.ViewportEdgeScrollStep;
+                scroll.Y = (scroll.Y / length) * Game.Settings.Game.ViewportEdgeScrollStep;
+
+                Game.viewport.Scroll(scroll);
+            }
+        }
 
 		public override Widget Clone() { return new ViewportScrollControllerWidget(this); }
 	}


### PR DESCRIPTION
I added two options, one is for EdgeScrollTreshold and the other one is
EdgeCornerScrollThreshold. You can modify these threshold as much as you
want.

Note: This code is related with the 2720 numbered issue.
URL:https://github.com/OpenRA/OpenRA/issues/2720
