### PR TITLE
Hotfix: Addresses Desync Issues in AutoTarget Trait

### DIFF
--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -36,8 +36,8 @@ namespace OpenRA.Mods.RA
 		public readonly bool AlignIdleTurrets = false;
 		public readonly bool CanAttackGround = true;
 
-		public readonly float ScanTimeAverage = 2f;
-		public readonly float ScanTimeSpread = .5f;
+		public readonly int MinimumScanTimeInterval = 30;
+		public readonly int MaximumScanTimeInterval = 60;
 
 		public abstract object Create(ActorInitializer init);
 

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -107,9 +107,7 @@ namespace OpenRA.Mods.RA
 		Actor ChooseTarget(Actor self, float range)
 		{
 			var info = self.Info.Traits.Get<AttackBaseInfo>();
-			nextScanTime = (int)(25 * (info.ScanTimeAverage +
-				(self.World.SharedRandom.NextFloat() * 2 - 1) * info.ScanTimeSpread));
-			Log.Write("debug", "Actor {0}; nextScanTime: {1}", self.ActorID, nextScanTime);
+			nextScanTime = self.World.SharedRandom.Next(info.MinimumScanTimeInterval, info.MaximumScanTimeInterval);
 
 			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, (int)(Game.CellSize * range));
 


### PR DESCRIPTION
Use integer math to calculate next auto-target scan-time to combat random desync problem because of rounding problems. This can lead to problems as evidenced at https://github.com/OpenRA/OpenRA/issues/2751#issuecomment-14704485.
