### PR TITLE
Fixes #2753 ClassicProductionQueue related crashes

### DIFF
--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA
 		public readonly string Type = null;
 		public readonly string Group = null;
 
-		public float BuildSpeed = 0.4f;
+		public float BuildSpeedModifier = 0.4f;
 		public readonly int LowPowerSlowdown = 3;
 
 		public readonly string ReadyAudio = "UnitReady";
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.RA
 			if (self.World.LobbyInfo.GlobalSettings.AllowCheats && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
 				return 0;
 
-			var time = unit.GetBuildTime() * Info.BuildSpeed;
+			var time = unit.GetBuildTime() * Info.BuildSpeedModifier;
 
 			return (int) time;
 		}

--- a/mods/cnc-classic/rules/system.yaml
+++ b/mods/cnc-classic/rules/system.yaml
@@ -6,34 +6,39 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Defense:
 		Type: Defense
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	PlaceBuilding:
 	SupportPowerManager:
 	ConquestVictoryConditions:

--- a/mods/ra-classic/rules/structures.yaml
+++ b/mods/ra-classic/rules/structures.yaml
@@ -642,6 +642,10 @@ FACT:
 		Power: 0
 		Footprint: xxx xxx xxx
 		Dimensions: 3,3
+	Buildable:
+		Queue: Building
+		BuildPaletteOrder: 1000
+		Owner: None
 	Health:
 		HP: 1000
 	Armor:
@@ -651,11 +655,12 @@ FACT:
 	Bib:
 	Production:
 		Produces: Building,Defense
-	IronCurtainable: 
+	IronCurtainable:
 	Valued:
 		Cost: 2500
 	Tooltip:
 		Name: Construction Yard
+		Description: Builds base structures.
 	CustomSellValue:
 		Value: 2500
 	BaseBuilding:

--- a/mods/ra-classic/rules/system.yaml
+++ b/mods/ra-classic/rules/system.yaml
@@ -6,40 +6,46 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Defense:
 		Type: Defense
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Ship:
 		Type: Ship
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	ClassicProductionQueue@Plane:
 		Type: Plane
 		BuildSpeed: .4
 		LowPowerSlowdown: 3
-		SpeedUp: 0.25
-		MaxSpeedUp: 0.75
+		SpeedUp: yes
+		BuildTimeSpeedUpDivisor: 2
+		MaxBuildTimeReductionSteps: 6
 	PlaceBuilding:
 	SupportPowerManager:
 	ConquestVictoryConditions:


### PR DESCRIPTION
This should fix #2753 and increase performance slightly as well as emulate the legacy rules better according to the measurements at https://github.com/OpenRA/OpenRA/pull/9#issuecomment-5841512.
