### PR TITLE
Static AutoTarget nextScanTime to combat desyncs

### DIFF
--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -36,8 +36,7 @@ namespace OpenRA.Mods.RA
 		public readonly bool AlignIdleTurrets = false;
 		public readonly bool CanAttackGround = true;
 
-		public readonly int MinimumScanTimeInterval = 30;
-		public readonly int MaximumScanTimeInterval = 60;
+		public readonly int ScanTimeInterval = 50;
 
 		public abstract object Create(ActorInitializer init);
 

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -107,7 +107,8 @@ namespace OpenRA.Mods.RA
 		Actor ChooseTarget(Actor self, float range)
 		{
 			var info = self.Info.Traits.Get<AttackBaseInfo>();
-			nextScanTime = self.World.SharedRandom.Next(info.MinimumScanTimeInterval, info.MaximumScanTimeInterval);
+
+			nextScanTime = info.ScanTimeInterval;
 
 			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, (int)(Game.CellSize * range));
 


### PR DESCRIPTION
This fix removes the random number generator, too and assumes actors won't scan for new targets all at once in non-scripted missions anyway because they start ticking upon placement into the world which is already fairly random. It seems that the auto-target desync problem persists in the last playtest releases https://github.com/OpenRA/OpenRA/issues/2763#issuecomment-14826367.
