### PR TITLE
Fix Desync when Bots fire Super Weapons

### DIFF
--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -1318,7 +1318,8 @@ namespace OpenRA.Mods.RA.AI
 				{
 					var attackLocation = FindAttackLocationToSupportPower(5);
 					if (attackLocation == null) return;
-					sp.Activate(new Order() { TargetLocation = attackLocation.Value });
+
+					world.IssueOrder(new Order(sp.Info.OrderName, supportPowerMngr.self, false) { TargetLocation = attackLocation.Value });
 				}
 			}
 		}

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -293,6 +293,56 @@ Player:
 			ca: 8%
 			pt: 8%
 		SquadSize: 10
+	HackyAI@IslandMapAI:
+		Name:Island Map AI
+		BuildingCommonNames:
+			ConstructionYard: fact
+			Refinery: proc
+			Power: powr,apwr
+			Silo: silo
+		UnitsCommonNames:
+			Mcv: mcv
+		BuildingLimits:
+			proc: 4
+			dome: 1
+			spen: 1
+			syrd: 1
+			hpad: 8
+			afld: 8
+			weap: 1
+			atek: 1
+			stek: 1
+		BuildingFractions:
+			proc: 29%
+			powr: 1%
+			apwr: 24%
+			dome: 1%
+			weap: 1%
+			hpad: 20%
+			afld: 20%
+			atek: 1%
+			stek: 1%
+			spen: 1%
+			syrd: 1%
+			pbox.e1: 12%
+			gun: 12%
+			ftur: 12%
+			tsla: 12%
+			agun: 5%
+			sam: 5%
+			mslo: 1%
+		UnitsToBuild:
+			harv: 1%
+			heli: 30%
+			hind: 30%
+			mig: 30%
+			yak: 30%
+			ss: 10%
+			msub: 30%
+			dd: 30%
+			ca: 20%
+			pt: 10%
+		SquadSize: 1
 	HackyAI@OptiAI:
 		Name:Eisenhower AI
 		BuildingCommonNames:


### PR DESCRIPTION
It was not going properly through the order generator and was only triggered on the host leading to a desync as evidenced at https://github.com/OpenRA/OpenRA/issues/2763#issuecomment-14889285 for RA and https://github.com/OpenRA/OpenRA/issues/2763#issuecomment-14826367 for CnC mod.

I also created an Airforce/Navy-only bot that is more suited for island maps for testing purposes.
