### PR TITLE
add Valkirie to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Also thanks to:
 	* Krishnakanth Mallik
 	* Kyrre Soerensen	(zypres)
 	* Lawrence Wang
+	* Lesueur Benjamin	(Valkirie)
 	* Mark Olson		(markolson)
 	* Matthew Gatland	(mgatland)
 	* Matthias Mailänder	(Mailaender)


### PR DESCRIPTION
@Iran mentioned that the latest HackyAI files reminded him of code he already saw when BetaAI was introduced. It seems that @VrKomarov built upon https://github.com/Valkirie/OpenRA/blob/bleed/OpenRA.Mods.RA/AI/HackyAI.cs and did a massive cleanup. Did not notice that at first sight. To comply with GNU GPL copyright notice requirements and for polite manners I hereby credit @Valkirie afterwards.

There are still some experimental features from that repository which could be merged back in without the hard-coding on the Red Alert actors, compiler warnings and unhandled exceptions. Discussion took place on http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=15984 but development was halted.
