### PR TITLE
Bug #2590 Long server names...

### DIFF
--- a/OpenRA.FileFormats/Exts.cs
+++ b/OpenRA.FileFormats/Exts.cs
@@ -19,21 +19,7 @@ namespace OpenRA
 {
 	public static class Exts
 	{
-		public static string LimitString(this string str,int lengthLimit)
-		{
-			if (!string.IsNullOrEmpty(str))
-			{
-				if (str.Length > lengthLimit)
-					return str.Substring(0, lengthLimit) + "...";
-				else
-					return str;
-			}
-			else
-			{
-				return "";
-			}
-		}
-
+		
 		public static string F(this string fmt, params object[] args)
 		{
 			return string.Format(fmt, args);

--- a/OpenRA.FileFormats/Exts.cs
+++ b/OpenRA.FileFormats/Exts.cs
@@ -19,6 +19,21 @@ namespace OpenRA
 {
 	public static class Exts
 	{
+		public static string LimitString(this string str,int lengthLimit)
+		{
+			if (!string.IsNullOrEmpty(str))
+			{
+				if (str.Length > lengthLimit)
+					return str.Substring(0, lengthLimit) + "...";
+				else
+					return str;
+			}
+			else
+			{
+				return "";
+			}
+		}
+
 		public static string F(this string fmt, params object[] args)
 		{
 			return string.Format(fmt, args);

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -209,6 +209,7 @@
     <Compile Include="Widgets\SliderWidget.cs" />
     <Compile Include="Widgets\TextFieldWidget.cs" />
     <Compile Include="Widgets\TimerWidget.cs" />
+    <Compile Include="Widgets\ToolTipWidget.cs" />
     <Compile Include="Widgets\ViewportScrollControllerWidget.cs" />
     <Compile Include="Widgets\VqaPlayerWidget.cs" />
     <Compile Include="Widgets\Widget.cs" />

--- a/OpenRA.Game/Widgets/LabelWidget.cs
+++ b/OpenRA.Game/Widgets/LabelWidget.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Widgets
 		public Func<string> GetText;
 		public Func<Color> GetColor;
 		public Func<Color> GetContrastColor;
+		public object Tag;
 
 		public LabelWidget()
 			: base()

--- a/OpenRA.Game/Widgets/LabelWidget.cs
+++ b/OpenRA.Game/Widgets/LabelWidget.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Widgets
 		public Func<Color> GetColor;
 		public Func<Color> GetContrastColor;
 		public object Tag;
+		public int2 Position;
 
 		public LabelWidget()
 			: base()
@@ -63,7 +64,7 @@ namespace OpenRA.Widgets
 				return;
 
 			int2 textSize = font.Measure(text);
-			int2 position = RenderOrigin;
+			int2 position = Position == new int2(0,0)?RenderOrigin:Position;
 
 			if (VAlign == TextVAlign.Middle)
 				position += new int2(0, (Bounds.Height - textSize.Y)/2);

--- a/OpenRA.Game/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Game/Widgets/ScrollItemWidget.cs
@@ -41,7 +41,6 @@ namespace OpenRA.Widgets
 			if (state != null)
 			{
 				WidgetUtils.DrawPanel(state, RenderBounds);
-				Depressed = true;
 			}
 		}
 

--- a/OpenRA.Game/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Game/Widgets/ScrollItemWidget.cs
@@ -39,7 +39,10 @@ namespace OpenRA.Widgets
 				null;
 
 			if (state != null)
+			{
 				WidgetUtils.DrawPanel(state, RenderBounds);
+				Depressed = true;
+			}
 		}
 
 		public override Widget Clone() { return new ScrollItemWidget(this); }

--- a/OpenRA.Game/Widgets/ToolTipWidget.cs
+++ b/OpenRA.Game/Widgets/ToolTipWidget.cs
@@ -8,31 +8,23 @@
  */
 #endregion
 
+using OpenRA.Graphics;
 using System;
 using System.Drawing;
-using OpenRA.Graphics;
 
 namespace OpenRA.Widgets
 {
 
 
-	public class ToolTipWidget : Widget
+	public class ToolTipWidget : LabelWidget
 	{
-		public string Text = null;
-		public TextAlign Align = TextAlign.Left;
-		public TextVAlign VAlign = TextVAlign.Middle;
-		public string Font = "Regular";
-		public Color Color = Color.Yellow;
-		public bool Contrast = false;
-		public Color ContrastColor = Color.Black;
-		public bool WordWrap = false;
-		public Func<string> GetText;
-		public Func<Color> GetColor;
-		public Func<Color> GetContrastColor;
+		public Widget RelatedControl;
+		public bool IsRendered = true;
 
 		public ToolTipWidget()
 			: base()
 		{
+			this.Color = Color.Yellow;
 			GetText = () => Text;
 			GetColor = () => Color;
 			GetContrastColor = () => ContrastColor;
@@ -53,37 +45,46 @@ namespace OpenRA.Widgets
 			GetContrastColor = other.GetContrastColor;
 		}
 
+	   
+
+
 		public override void Draw()
 		{
-			SpriteFont font = Game.Renderer.Fonts[Font];
-			var text = GetText();
-			if (text == null)
-				return;
 
-			int2 textSize = font.Measure(text);
-			int2 position = new int2(Viewport.LastMousePos.X-5,Viewport.LastMousePos.Y+15);
+			if (RelatedControl != null && Ui.MouseOverWidget != null && Ui.MouseOverWidget.GetType() == RelatedControl.GetType() && Ui.MouseOverWidget is ScrollItemWidget && ((ScrollItemWidget)Ui.MouseOverWidget).Depressed == true && Ui.MouseOverWidget.RenderBounds.Contains(Viewport.LastMousePos))
+			{
+				this.IsRendered = true;
+				SpriteFont font = Game.Renderer.Fonts[Font];
+				var text = GetText();
+				if (text == null)
+					return;
 
-			if (VAlign == TextVAlign.Middle)
-				position += new int2(0, (Bounds.Height - textSize.Y) / 2);
+				int2 textSize = font.Measure(text);
+				int2 position = new int2(Viewport.LastMousePos.X - 5, Viewport.LastMousePos.Y + 15);
 
-			if (VAlign == TextVAlign.Bottom)
-				position += new int2(0, Bounds.Height - textSize.Y);
+				if (VAlign == TextVAlign.Middle)
+					position += new int2(0, (Bounds.Height - textSize.Y) / 2);
 
-			if (Align == TextAlign.Center)
-				position += new int2((Bounds.Width - textSize.X) / 2, 0);
+				if (VAlign == TextVAlign.Bottom)
+					position += new int2(0, Bounds.Height - textSize.Y);
 
-			if (Align == TextAlign.Right)
-				position += new int2(Bounds.Width - textSize.X, 0);
+				if (Align == TextAlign.Center)
+					position += new int2((Bounds.Width - textSize.X) / 2, 0);
 
-			if (WordWrap)
-				text = WidgetUtils.WrapText(text, Bounds.Width, font);
+				if (Align == TextAlign.Right)
+					position += new int2(Bounds.Width - textSize.X, 0);
 
-			var color = GetColor();
-			var contrast = GetContrastColor();
-			if (Contrast)
-				font.DrawTextWithContrast(text, position, color, contrast, 2);
-			else
-				font.DrawText(text, position, color);
+				if (WordWrap)
+					text = WidgetUtils.WrapText(text, Bounds.Width, font);
+
+				var color = GetColor();
+				var contrast = GetContrastColor();
+				if (Contrast)
+					font.DrawTextWithContrast(text, position, color, contrast, 2);
+				else
+					font.DrawText(text, position, color);
+			}
+
 		}
 
 		public override Widget Clone() { return new ToolTipWidget(this); }

--- a/OpenRA.Game/Widgets/ToolTipWidget.cs
+++ b/OpenRA.Game/Widgets/ToolTipWidget.cs
@@ -15,8 +15,6 @@ using System.Timers;
 
 namespace OpenRA.Widgets
 {
-
-
 	public class ToolTipWidget : LabelWidget
 	{
 		public bool IsRendered = true;
@@ -46,9 +44,6 @@ namespace OpenRA.Widgets
 			GetContrastColor = other.GetContrastColor;
 		}
 
-
-
-
 		public override void Draw()
 		{
 			if (Ui.MouseOverWidget == null)
@@ -63,9 +58,6 @@ namespace OpenRA.Widgets
 			this.IsRendered = true;
 			base.Position = new int2(Viewport.LastMousePos.X, Viewport.LastMousePos.Y + 15);
 			base.Draw();
-		   
-			
-
 		}
 
 		public override Widget Clone() { return new ToolTipWidget(this); }

--- a/OpenRA.Game/Widgets/ToolTipWidget.cs
+++ b/OpenRA.Game/Widgets/ToolTipWidget.cs
@@ -1,0 +1,91 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using OpenRA.Graphics;
+
+namespace OpenRA.Widgets
+{
+
+
+	public class ToolTipWidget : Widget
+	{
+		public string Text = null;
+		public TextAlign Align = TextAlign.Left;
+		public TextVAlign VAlign = TextVAlign.Middle;
+		public string Font = "Regular";
+		public Color Color = Color.Yellow;
+		public bool Contrast = false;
+		public Color ContrastColor = Color.Black;
+		public bool WordWrap = false;
+		public Func<string> GetText;
+		public Func<Color> GetColor;
+		public Func<Color> GetContrastColor;
+
+		public ToolTipWidget()
+			: base()
+		{
+			GetText = () => Text;
+			GetColor = () => Color;
+			GetContrastColor = () => ContrastColor;
+		}
+
+		protected ToolTipWidget(ToolTipWidget other)
+			: base(other)
+		{
+			Text = other.Text;
+			Align = other.Align;
+			Font = other.Font;
+			Color = other.Color;
+			Contrast = other.Contrast;
+			ContrastColor = other.ContrastColor;
+			WordWrap = other.WordWrap;
+			GetText = other.GetText;
+			GetColor = other.GetColor;
+			GetContrastColor = other.GetContrastColor;
+		}
+
+		public override void Draw()
+		{
+			SpriteFont font = Game.Renderer.Fonts[Font];
+			var text = GetText();
+			if (text == null)
+				return;
+
+			int2 textSize = font.Measure(text);
+			int2 position = new int2(Viewport.LastMousePos.X-5,Viewport.LastMousePos.Y+15);
+
+			if (VAlign == TextVAlign.Middle)
+				position += new int2(0, (Bounds.Height - textSize.Y) / 2);
+
+			if (VAlign == TextVAlign.Bottom)
+				position += new int2(0, Bounds.Height - textSize.Y);
+
+			if (Align == TextAlign.Center)
+				position += new int2((Bounds.Width - textSize.X) / 2, 0);
+
+			if (Align == TextAlign.Right)
+				position += new int2(Bounds.Width - textSize.X, 0);
+
+			if (WordWrap)
+				text = WidgetUtils.WrapText(text, Bounds.Width, font);
+
+			var color = GetColor();
+			var contrast = GetContrastColor();
+			if (Contrast)
+				font.DrawTextWithContrast(text, position, color, contrast, 2);
+			else
+				font.DrawText(text, position, color);
+		}
+
+		public override Widget Clone() { return new ToolTipWidget(this); }
+	}
+}

--- a/OpenRA.Game/Widgets/ToolTipWidget.cs
+++ b/OpenRA.Game/Widgets/ToolTipWidget.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Widgets
 	public class ToolTipWidget : LabelWidget
 	{
 		public bool IsRendered = true;
-		int2 lastMousePosition = Viewport.LastMousePos;
+		public int TooltipDelay = 20;
 
 		public ToolTipWidget()
 			: base()
@@ -29,12 +29,6 @@ namespace OpenRA.Widgets
 			GetText = () => Text;
 			GetColor = () => Color;
 			GetContrastColor = () => ContrastColor;
-			Timer t = new Timer(3000);
-			t.Elapsed += (object s, ElapsedEventArgs arg) =>
-			{
-				lastMousePosition = Viewport.LastMousePos;
-			};
-			t.Start();
 		}
 
 		protected ToolTipWidget(ToolTipWidget other)
@@ -50,12 +44,6 @@ namespace OpenRA.Widgets
 			GetText = other.GetText;
 			GetColor = other.GetColor;
 			GetContrastColor = other.GetContrastColor;
-			Timer t = new Timer(3000);
-			t.Elapsed += (object s, ElapsedEventArgs arg) =>
-			{
-				lastMousePosition = Viewport.LastMousePos;
-			};
-			t.Start();
 		}
 
 
@@ -66,43 +54,17 @@ namespace OpenRA.Widgets
 			if (Ui.MouseOverWidget == null)
 				return;
 
-			if (Viewport.LastMousePos.X != lastMousePosition.X || Viewport.LastMousePos.Y != lastMousePosition.Y)
-				return;
+			if (Ui.MouseOverWidget != null && Ui.MouseOverWidget != this.Tag)
+			return;
 
-			if (Ui.MouseOverWidget != null && Ui.MouseOverWidget.Get<LabelWidget>("TITLE") != null && this.Tag != null && Ui.MouseOverWidget.Get<LabelWidget>("TITLE").Tag.ToString() != this.Tag.ToString())
+			if (Viewport.TicksSinceLastMove < TooltipDelay)
 				return;
 
 			this.IsRendered = true;
-			SpriteFont font = Game.Renderer.Fonts[Font];
-			var text = GetText();
-			if (text == null)
-				return;
-
-			int2 textSize = font.Measure(text);
-			int2 position = new int2(Viewport.LastMousePos.X - 5, Viewport.LastMousePos.Y + 15);
-
-			if (VAlign == TextVAlign.Middle)
-				position += new int2(0, (Bounds.Height - textSize.Y) / 2);
-
-			if (VAlign == TextVAlign.Bottom)
-				position += new int2(0, Bounds.Height - textSize.Y);
-
-			if (Align == TextAlign.Center)
-				position += new int2((Bounds.Width - textSize.X) / 2, 0);
-
-			if (Align == TextAlign.Right)
-				position += new int2(Bounds.Width - textSize.X, 0);
-
-			if (WordWrap)
-				text = WidgetUtils.WrapText(text, Bounds.Width, font);
-
-			var color = GetColor();
-			var contrast = GetContrastColor();
-			if (Contrast)
-				font.DrawTextWithContrast(text, position, color, contrast, 2);
-			else
-				font.DrawText(text, position, color);
-
+			base.Position = new int2(Viewport.LastMousePos.X, Viewport.LastMousePos.Y + 15);
+			base.Draw();
+		   
+			
 
 		}
 

--- a/OpenRA.Game/Widgets/ToolTipWidget.cs
+++ b/OpenRA.Game/Widgets/ToolTipWidget.cs
@@ -15,6 +15,8 @@ using System.Timers;
 
 namespace OpenRA.Widgets
 {
+
+
 	public class ToolTipWidget : LabelWidget
 	{
 		public bool IsRendered = true;
@@ -44,6 +46,9 @@ namespace OpenRA.Widgets
 			GetContrastColor = other.GetContrastColor;
 		}
 
+
+
+
 		public override void Draw()
 		{
 			if (Ui.MouseOverWidget == null)
@@ -58,6 +63,9 @@ namespace OpenRA.Widgets
 			this.IsRendered = true;
 			base.Position = new int2(Viewport.LastMousePos.X, Viewport.LastMousePos.Y + 15);
 			base.Draw();
+		   
+			
+
 		}
 
 		public override Widget Clone() { return new ToolTipWidget(this); }

--- a/OpenRA.Game/Widgets/ToolTipWidget.cs
+++ b/OpenRA.Game/Widgets/ToolTipWidget.cs
@@ -46,9 +46,6 @@ namespace OpenRA.Widgets
 			GetContrastColor = other.GetContrastColor;
 		}
 
-
-
-
 		public override void Draw()
 		{
 			if (Ui.MouseOverWidget == null)
@@ -63,9 +60,6 @@ namespace OpenRA.Widgets
 			this.IsRendered = true;
 			base.Position = new int2(Viewport.LastMousePos.X, Viewport.LastMousePos.Y + 15);
 			base.Draw();
-		   
-			
-
 		}
 
 		public override Widget Clone() { return new ToolTipWidget(this); }

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -15,6 +15,7 @@ using System.Drawing;
 using OpenRA.FileFormats;
 using OpenRA.Network;
 using OpenRA.Widgets;
+using System.Timers;
 
 namespace OpenRA.Mods.RA.Widgets.Logic
 {
@@ -159,9 +160,14 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						if (game.Name.Length > 29)
 						{
 							ToolTipWidget toolTip = new ToolTipWidget();
-							toolTip.RelatedControl = serverTemplate;
-							toolTip.Text = game.Name;
 							panel.AddChild(toolTip);
+							Timer t = new Timer(1000);
+							t.Elapsed += (object s, ElapsedEventArgs arg) =>
+								{
+									toolTip.Tag = toolTip.Text = game.Name;
+									t.Stop();
+								};
+							t.Start();
 						}
 					}
 				);
@@ -173,6 +179,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				var title = item.Get<LabelWidget>("TITLE");
 				title.GetText = () => game.Name.LimitString(29);
+				title.Tag = game.Name;
 
 				// TODO: Use game.MapTitle once the server supports it
 				var maptitle = item.Get<LabelWidget>("MAP");

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -124,6 +124,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		public void RefreshServerList(Widget panel, IEnumerable<GameServer> games)
 		{
 			var sl = panel.Get<ScrollPanelWidget>("SERVER_LIST");
+			
 
 			sl.RemoveChildren();
 			currentServer = null;
@@ -149,14 +150,27 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				var canJoin = game.CanJoin();
 
-				var item = ScrollItemWidget.Setup(serverTemplate, () => currentServer == game, () => currentServer = game);
 
+				var item = ScrollItemWidget.Setup(serverTemplate, () => currentServer == game, () =>
+					{
+						currentServer = game;
+						panel.Children.Remove(panel.Children.Where(c => c is ToolTipWidget).SingleOrDefault());
+						if (game.Name.Length > 29)
+						{
+							ToolTipWidget toolTip = new ToolTipWidget();
+							toolTip.Text = game.Name;
+							panel.AddChild(toolTip);
+						}
+					}
+				);
+
+			  
 				var preview = item.Get<MapPreviewWidget>("MAP_PREVIEW");
 				preview.Map = () => GetMapPreview(game);
 				preview.IsVisible = () => GetMapPreview(game) != null;
 
 				var title = item.Get<LabelWidget>("TITLE");
-				title.GetText = () => game.Name;
+				title.GetText = () => game.Name.LimitString(29);
 
 				// TODO: Use game.MapTitle once the server supports it
 				var maptitle = item.Get<LabelWidget>("MAP");

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -154,16 +154,18 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var item = ScrollItemWidget.Setup(serverTemplate, () => currentServer == game, () =>
 					{
 						currentServer = game;
+						
 						panel.Children.Remove(panel.Children.Where(c => c is ToolTipWidget).SingleOrDefault());
 						if (game.Name.Length > 29)
 						{
 							ToolTipWidget toolTip = new ToolTipWidget();
+							toolTip.RelatedControl = serverTemplate;
 							toolTip.Text = game.Name;
 							panel.AddChild(toolTip);
 						}
 					}
 				);
-
+			   
 			  
 				var preview = item.Get<MapPreviewWidget>("MAP_PREVIEW");
 				preview.Map = () => GetMapPreview(game);


### PR DESCRIPTION
![Capture](https://f.cloud.github.com/assets/3826953/262246/a8f4b622-8d22-11e2-9555-45029b0b3bd2.PNG)
This is fixed. From the code now on it puts ... on the long server
names. (Maximum server name limit is 29 characters. In plus, I added a
tooltipwidget, this widget when a server name exceeds the limit, renders
itself on the screen.
