### PR TITLE
infantry anims: running ticks corrected

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -38,7 +38,11 @@ TRAN:
 		MaxWeight: 10
 		PipCount: 10
 	FallsToEarth:
-
+		Explosion: HeliCrash
+	Explodes:
+		Weapon: HeliExplode
+		EmptyWeapon: HeliExplode
+		
 HELI:
 	Inherits: ^Helicopter
 	Valued:
@@ -84,7 +88,11 @@ HELI:
 	WithMuzzleFlash:
 	WithShadow:
 	FallsToEarth:
+		Explosion: HeliCrash
 	AutoTarget:
+	Explodes:
+		Weapon: HeliExplode
+		EmptyWeapon: HeliExplode
 
 ORCA:
 	Inherits: ^Helicopter
@@ -128,7 +136,11 @@ ORCA:
 	RenderUnit:
 	WithShadow:
 	FallsToEarth:
+		Explosion: HeliCrash
 	AutoTarget:
+	Explodes:
+		Weapon: HeliExplode
+		EmptyWeapon: HeliExplode
 
 C17:
 	ParaDrop:
@@ -164,7 +176,7 @@ A10:
 		ROT: 4
 		Speed: 40
 	Health:
-		HP: 60
+		HP: 150
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -90,6 +90,9 @@
 	DrawLineToTarget:
 	ActorLostNotification:
 		Notification: unitlost.aud
+	Explodes:
+		Weapon: HeliExplode
+		EmptyWeapon: HeliExplode
 
 ^Infantry:
 	AppearsOnRadar:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -178,8 +178,8 @@ FTNK:
 	AutoTarget:
 	WithMuzzleFlash:
 	Explodes:
-		Weapon: BigFlamer
-		EmptyWeapon: BigFlamer
+		Weapon: FlametankExplode
+		EmptyWeapon: FlametankExplode
 	LeavesHusk:
 		HuskActor: FTNK.Husk
 

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -25,6 +25,7 @@ e1:
 		Start: 16
 		Length: 6
 		Facings: 8
+		Tick: 100
 	shoot:
 		Start: 64
 		Length: 8
@@ -37,6 +38,7 @@ e1:
 		Start: 144
 		Length: 4
 		Facings: 8
+		Tick: 100
 	# stand -> prone transition
 	liedown:
 		Start: 128
@@ -119,6 +121,7 @@ e2:
 		Start: 16
 		Length: 6
 		Facings: 8
+		Tick: 100
 	shoot:
 		Start: 64
 		Length: 20
@@ -141,6 +144,7 @@ e2:
 		Start: 240
 		Length: 4
 		Facings: 8
+		Tick: 100
 	prone-shoot:
 		Start: 288
 		Length: 12
@@ -204,6 +208,7 @@ e3:
 		Start: 16
 		Length: 6
 		Facings: 8
+		Tick: 100
 	shoot:
 		Start: 64
 		Length: 8
@@ -226,6 +231,7 @@ e3:
 		Start: 144
 		Length: 4
 		Facings: 8
+		Tick: 100
 	prone-shoot:
 		Start: 192
 		Length: 10
@@ -289,6 +295,7 @@ e4:
 		Start: 16
 		Length: 6
 		Facings: 8
+		Tick: 100
 	shoot:
 		Start: 64
 		Length: 16
@@ -311,6 +318,7 @@ e4:
 		Start: 208
 		Length: 4
 		Facings: 8
+		Tick: 100
 	prone-shoot:
 		Start: 256
 		Length: 16
@@ -377,6 +385,7 @@ e5:
 		Start: 16
 		Length: 6
 		Facings: 8
+		Tick: 100
 	shoot:
 		Start: 64
 		Length: 16
@@ -399,6 +408,7 @@ e5:
 		Start: 208
 		Length: 4
 		Facings: 8
+		Tick: 100
 	prone-shoot:
 		Start: 256
 		Length: 16
@@ -465,6 +475,7 @@ e6:
 		Start: 16
 		Length: 6
 		Facings: 8
+		Tick: 100
 	# stand -> prone transition
 	liedown:
 		Start: 66
@@ -483,6 +494,7 @@ e6:
 		Start: 82
 		Length: 4
 		Facings: 8
+		Tick: 100
 	idle1:
 		Start: 114
 		Length: 6
@@ -541,6 +553,7 @@ rmbo:
 		Start: 16
 		Length: 6
 		Facings: 8
+		Tick: 100
 	shoot:
 		Start: 64
 		Length: 4
@@ -563,6 +576,7 @@ rmbo:
 		Start: 112
 		Length: 4
 		Facings: 8
+		Tick: 100
 	prone-shoot:
 		Start: 160
 		Length: 4

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -2,6 +2,7 @@ fact:
 	build:
 		Start: 4
 		Length: 20
+		Tick: 100
 	idle:
 		Start: 0
 		Length: 4
@@ -13,6 +14,7 @@ fact:
 	damaged-build:
 		Start: 28
 		Length: 20
+		Tick: 100
 	dead:
 		Start: 48
 	make: factmake

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -1,3 +1,32 @@
+
+
+FlametankExplode:
+	Warhead:
+		Damage: 100		
+		Spread: 24		
+		Explosion: big_napalm
+		InfDeath: 5
+		ImpactSound: xplobig6
+
+HeliExplode:
+	Warhead:
+		Explosion: small_building
+		InfDeath: 4
+		ImpactSound: xplos
+
+FlamethrowerExplode:
+	Warhead:
+		Damage: 10
+		Spread: 9
+		Versus:
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: small_napalm
+		InfDeath: 5
+		ImpactSound: flamer2
+		
 UnitExplode:
 	Warhead:
 		Damage: 500
@@ -20,7 +49,7 @@ UnitExplodeSmall:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: 8
+		Explosion: big_frag
 		InfDeath: 4
 		ImpactSound: xplobig4
 
@@ -33,9 +62,9 @@ GrenadierExplode:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: 8
+		Explosion: poof
 		InfDeath: 3
-		ImpactSound: xplos
+		ImpactSound: xplosml2
 
 Atomic:
 	Warhead@impact:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -1,5 +1,4 @@
 
-
 FlametankExplode:
 	Warhead:
 		Damage: 100		
@@ -7,6 +6,14 @@ FlametankExplode:
 		Explosion: big_napalm
 		InfDeath: 5
 		ImpactSound: xplobig6
+
+HeliCrash:
+	Warhead:
+		Damage: 40
+		Spread: 10
+		Explosion: poof
+		InfDeath: 4
+		ImpactSound: xplos
 
 HeliExplode:
 	Warhead:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -1,4 +1,3 @@
-
 FlametankExplode:
 	Warhead:
 		Damage: 100		
@@ -21,19 +20,6 @@ HeliExplode:
 		InfDeath: 4
 		ImpactSound: xplos
 
-FlamethrowerExplode:
-	Warhead:
-		Damage: 10
-		Spread: 9
-		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
-		Explosion: small_napalm
-		InfDeath: 5
-		ImpactSound: flamer2
-		
 UnitExplode:
 	Warhead:
 		Damage: 500


### PR DESCRIPTION
I guess nobody noticed, but in CNC and RA, the legs of infantry move way too fast. It should be ~100 Tick. 
