### PR TITLE
Support for more weapons

### DIFF
--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -23,14 +23,56 @@ namespace OpenRA.Mods.RA
 		public readonly string PrimaryWeapon = null;
 		[WeaponReference]
 		public readonly string SecondaryWeapon = null;
+		[WeaponReference]
+		public readonly string TertiaryWeapon = null;
+		[WeaponReference]
+		public readonly string Weapon4Weapon = null;
+		[WeaponReference]
+		public readonly string Weapon5Weapon = null;
+		[WeaponReference]
+		public readonly string Weapon6Weapon = null;
+		[WeaponReference]
+		public readonly string Weapon7Weapon = null;
+		[WeaponReference]
+		public readonly string Weapon8Weapon = null;
+		[WeaponReference]
+		public readonly string Weapon9Weapon = null;
 		public readonly int PrimaryRecoil = 0;
 		public readonly int SecondaryRecoil = 0;
+		public readonly int TertiaryRecoil = 0;
+		public readonly int Weapon4Recoil = 0;
+		public readonly int Weapon5Recoil = 0;
+		public readonly int Weapon6Recoil = 0;
+		public readonly int Weapon7Recoil = 0;
+		public readonly int Weapon8Recoil = 0;
+		public readonly int Weapon9Recoil = 0;
 		public readonly float PrimaryRecoilRecovery = 0.2f;
 		public readonly float SecondaryRecoilRecovery = 0.2f;
+		public readonly float TertiaryRecoilRecovery = 0.2f;
+		public readonly float Weapon4RecoilRecovery = 0.2f;
+		public readonly float Weapon5RecoilRecovery = 0.2f;
+		public readonly float Weapon6RecoilRecovery = 0.2f;
+		public readonly float Weapon7RecoilRecovery = 0.2f;
+		public readonly float Weapon8RecoilRecovery = 0.2f;
+		public readonly float Weapon9RecoilRecovery = 0.2f;
 		public readonly int[] PrimaryLocalOffset = { };
 		public readonly int[] SecondaryLocalOffset = { };
+		public readonly int[] TertiaryLocalOffset = { };
+		public readonly int[] Weapon4LocalOffset = { };
+		public readonly int[] Weapon5LocalOffset = { };
+		public readonly int[] Weapon6LocalOffset = { };
+		public readonly int[] Weapon7LocalOffset = { };
+		public readonly int[] Weapon8LocalOffset = { };
+		public readonly int[] Weapon9LocalOffset = { };
 		public readonly int[] PrimaryOffset = { 0, 0 };
 		public readonly int[] SecondaryOffset = null;
+		public readonly int[] TertiaryOffset = null;
+		public readonly int[] Weapon4Offset = null;
+		public readonly int[] Weapon5Offset = null;
+		public readonly int[] Weapon6Offset = null;
+		public readonly int[] Weapon7Offset = null;
+		public readonly int[] Weapon8Offset = null;
+		public readonly int[] Weapon9Offset = null;
 		public readonly int FireDelay = 0;
 
 		public readonly bool AlignIdleTurrets = false;
@@ -45,8 +87,15 @@ namespace OpenRA.Mods.RA
 		{
 			var priRange = PrimaryWeapon != null ? Rules.Weapons[PrimaryWeapon.ToLowerInvariant()].Range : 0;
 			var secRange = SecondaryWeapon != null ? Rules.Weapons[SecondaryWeapon.ToLowerInvariant()].Range : 0;
+			var terRange = TertiaryWeapon != null ? Rules.Weapons[TertiaryWeapon.ToLowerInvariant()].Range : 0;
+			var wp4Range = Weapon4Weapon != null ? Rules.Weapons[Weapon4Weapon.ToLowerInvariant()].Range : 0;
+			var wp5Range = Weapon5Weapon != null ? Rules.Weapons[Weapon5Weapon.ToLowerInvariant()].Range : 0;
+			var wp6Range = Weapon6Weapon != null ? Rules.Weapons[Weapon6Weapon.ToLowerInvariant()].Range : 0;
+			var wp7Range = Weapon7Weapon != null ? Rules.Weapons[Weapon7Weapon.ToLowerInvariant()].Range : 0;
+			var wp8Range = Weapon8Weapon != null ? Rules.Weapons[Weapon8Weapon.ToLowerInvariant()].Range : 0;
+			var wp9Range = Weapon9Weapon != null ? Rules.Weapons[Weapon9Weapon.ToLowerInvariant()].Range : 0;
 
-			return Math.Max(priRange, secRange);
+			return Math.Max(priRange, wp9Range);
 		}
 	}
 
@@ -67,6 +116,20 @@ namespace OpenRA.Mods.RA
 			Turrets.Add(new Turret(info.PrimaryOffset, info.PrimaryRecoilRecovery));
 			if (info.SecondaryOffset != null)
 				Turrets.Add(new Turret(info.SecondaryOffset, info.SecondaryRecoilRecovery));
+			if (info.TertiaryOffset != null)
+				Turrets.Add(new Turret(info.TertiaryOffset, info.TertiaryRecoilRecovery));
+			if (info.Weapon4Offset != null)
+				Turrets.Add(new Turret(info.Weapon4Offset, info.Weapon4RecoilRecovery));
+			if (info.Weapon5Offset != null)
+				Turrets.Add(new Turret(info.Weapon5Offset, info.Weapon5RecoilRecovery));
+			if (info.Weapon6Offset != null)
+				Turrets.Add(new Turret(info.Weapon6Offset, info.Weapon6RecoilRecovery));
+			if (info.Weapon7Offset != null)
+				Turrets.Add(new Turret(info.Weapon7Offset, info.Weapon7RecoilRecovery));
+			if (info.Weapon8Offset != null)
+				Turrets.Add(new Turret(info.Weapon8Offset, info.Weapon8RecoilRecovery));
+			if (info.Weapon9Offset != null)
+				Turrets.Add(new Turret(info.Weapon9Offset, info.Weapon9RecoilRecovery));
 
 			if (info.PrimaryWeapon != null)
 				Weapons.Add(new Weapon(info.PrimaryWeapon,
@@ -75,6 +138,27 @@ namespace OpenRA.Mods.RA
 			if (info.SecondaryWeapon != null)
 				Weapons.Add(new Weapon(info.SecondaryWeapon,
 					info.SecondaryOffset != null ? Turrets[1] : Turrets[0], info.SecondaryLocalOffset, info.SecondaryRecoil));
+			if (info.TertiaryWeapon != null)
+				Weapons.Add(new Weapon(info.TertiaryWeapon,
+					info.TertiaryOffset != null ? Turrets[2] : Turrets[0], info.TertiaryLocalOffset, info.TertiaryRecoil));
+			if (info.Weapon4Weapon != null)
+				Weapons.Add(new Weapon(info.Weapon4Weapon,
+					info.Weapon4Offset != null ? Turrets[3] : Turrets[0], info.Weapon4LocalOffset, info.Weapon4Recoil));
+			if (info.Weapon5Weapon != null)
+				Weapons.Add(new Weapon(info.Weapon5Weapon,
+					info.Weapon5Offset != null ? Turrets[4] : Turrets[0], info.Weapon5LocalOffset, info.Weapon5Recoil));
+			if (info.Weapon6Weapon != null)
+				Weapons.Add(new Weapon(info.Weapon6Weapon,
+					info.Weapon6Offset != null ? Turrets[5] : Turrets[0], info.Weapon6LocalOffset, info.Weapon6Recoil));
+			if (info.Weapon7Weapon != null)
+				Weapons.Add(new Weapon(info.Weapon7Weapon,
+					info.Weapon7Offset != null ? Turrets[6] : Turrets[0], info.Weapon7LocalOffset, info.Weapon7Recoil));
+			if (info.Weapon8Weapon != null)
+				Weapons.Add(new Weapon(info.Weapon8Weapon,
+					info.Weapon8Offset != null ? Turrets[7] : Turrets[0], info.Weapon8LocalOffset, info.Weapon8Recoil));
+			if (info.Weapon9Weapon != null)
+				Weapons.Add(new Weapon(info.Weapon9Weapon,
+					info.Weapon9Offset != null ? Turrets[8] : Turrets[0], info.Weapon9LocalOffset, info.Weapon9Recoil));
 		}
 
 		protected virtual bool CanAttack(Actor self, Target target)


### PR DESCRIPTION
While the official mods shipping with OpenRA might not need it, more than two weapon slots could be useful for several other mods (including one I'm working on).

After Tertiary, I continued with Weapon4-9, as quaternary, quinary and so on are just asking for typos, much more difficult to remember and far less copy-paste-friendly.

NOTE: I did test this, and it seems to work fine, but I'm not a programmer, this was done by copy-pasting + trial & error. I'm particularly unsure about the MathMax part, I have no idea whether it really works as intended.

NOTE2: This feature would become more useful if someone could implement customizable per-turret graphics, so that Secondary and beyond can use different turret graphics instead of using copies of the first turret. That would allow a large ship to have a small machine gun turret, two large cannon turrets and a missile turret, for example. That's beyond my current abilities, though.
