### PR TITLE
Flamethrower range reduced to 2.5

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -345,7 +345,7 @@ OrcaAAMissiles:
 
 Flamethrower:
 	ROF: 50
-	Range: 3
+	Range: 2.5
 	Report: FLAMER2
 	Projectile: Bullet
 		Speed: 100


### PR DESCRIPTION
Flamethrower seems OP, and flamethrower spam can dominate early game without anything to counter it. Reduced range back to earlier levels (in C&C 95, range == 2).
