### PR TITLE
fixes #2128: cancel attacks when units get chrono-teleported

### DIFF
--- a/OpenRA.Mods.RA/Activities/Attack.cs
+++ b/OpenRA.Mods.RA/Activities/Attack.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA.Activities
 	/* non-turreted attack */
 	public class Attack : Activity
 	{
-		protected Target Target;
+		public Target Target;
 		ITargetable targetable;
 		int Range;
 		bool AllowMovement;

--- a/OpenRA.Mods.RA/Air/FlyAttack.cs
+++ b/OpenRA.Mods.RA/Air/FlyAttack.cs
@@ -14,7 +14,7 @@ namespace OpenRA.Mods.RA.Air
 {
 	public class FlyAttack : Activity
 	{
-		readonly Target Target;
+		public readonly Target Target;
 		Activity inner;
 
 		public FlyAttack(Target target) { Target = target; }

--- a/OpenRA.Mods.RA/Air/HeliAttack.cs
+++ b/OpenRA.Mods.RA/Air/HeliAttack.cs
@@ -16,13 +16,13 @@ namespace OpenRA.Mods.RA.Air
 {
 	public class HeliAttack : Activity
 	{
-		Target target;
-		public HeliAttack( Target target ) { this.target = target; }
+		public Target Target;
+		public HeliAttack( Target target ) { this.Target = target; }
 
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceled) return NextActivity;
-			if (!target.IsValid) return NextActivity;
+			if (!Target.IsValid) return NextActivity;
 
 			var limitedAmmo = self.TraitOrDefault<LimitedAmmo>();
 			var reloads = self.TraitOrDefault<Reloads>();
@@ -38,15 +38,15 @@ namespace OpenRA.Mods.RA.Air
 			}
 
 			var attack = self.Trait<AttackHeli>();
-			var dist = target.CenterLocation - self.CenterLocation;
+			var dist = Target.CenterLocation - self.CenterLocation;
 
 			var desiredFacing = Util.GetFacing(dist, aircraft.Facing);
 			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.ROT);
 
-			if (!Combat.IsInRange(self.CenterLocation, attack.GetMaximumRange(), target))
+			if (!Combat.IsInRange(self.CenterLocation, attack.GetMaximumRange(), Target))
 				aircraft.TickMove(PSubPos.PerPx * aircraft.MovementSpeed, desiredFacing);
 
-			attack.DoAttack( self, target );
+			attack.DoAttack( self, Target );
 
 			return this;
 		}

--- a/OpenRA.Mods.RA/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Chronoshiftable.cs
@@ -52,21 +52,22 @@ namespace OpenRA.Mods.RA
 		{
 			foreach (Actor a in self.World.Actors)
 			{
-				if (a.GetCurrentActivity() is Attack)
+				Activity activity = a.GetCurrentActivity();
+				if (activity is Attack)
 				{
-					var attack = (Attack) a.GetCurrentActivity();
+					var attack = (Attack) activity;
 					if (attack.Target.IsActor && attack.Target.Actor == self)
 						attack.Cancel(a);
 				}
-				else if (a.GetCurrentActivity() is FlyAttack)
+				else if (activity is FlyAttack)
 				{
-					var attack = (FlyAttack) a.GetCurrentActivity();
+					var attack = (FlyAttack) activity;
 					if (attack.Target.IsActor && attack.Target.Actor == self)
 						attack.Cancel(a);
 				}
-				else if (a.GetCurrentActivity() is HeliAttack)
+				else if (activity is HeliAttack)
 				{
-					var attack = (HeliAttack) a.GetCurrentActivity();
+					var attack = (HeliAttack) activity;
 					if (attack.Target.IsActor && attack.Target.Actor == self)
 						attack.Cancel(a);
 				}

--- a/OpenRA.Mods.RA/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Chronoshiftable.cs
@@ -6,9 +6,13 @@
  * as published by the Free Software Foundation. For more information,
  * see COPYING.
  */
+
+
+
 #endregion
 
 using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.RA.Air;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
@@ -38,8 +42,34 @@ namespace OpenRA.Mods.RA
 			if (chronoshiftReturnTicks == 0)
 			{
 				self.CancelActivity();
+				stopAttackers(self);
 				// Todo: need a new Teleport method that will move to the closest available cell
 				self.QueueActivity(new Teleport(chronosphere, chronoshiftOrigin, killCargo));
+			}
+		}
+
+		protected void stopAttackers(Actor self)
+		{
+			foreach (Actor a in self.World.Actors)
+			{
+				if (a.GetCurrentActivity() is Attack)
+				{
+					var attack = (Attack) a.GetCurrentActivity();
+					if (attack.Target.IsActor && attack.Target.Actor == self)
+						attack.Cancel(a);
+				}
+				else if (a.GetCurrentActivity() is FlyAttack)
+				{
+					var attack = (FlyAttack) a.GetCurrentActivity();
+					if (attack.Target.IsActor && attack.Target.Actor == self)
+						attack.Cancel(a);
+				}
+				else if (a.GetCurrentActivity() is HeliAttack)
+				{
+					var attack = (HeliAttack) a.GetCurrentActivity();
+					if (attack.Target.IsActor && attack.Target.Actor == self)
+						attack.Cancel(a);
+				}
 			}
 		}
 
@@ -62,6 +92,8 @@ namespace OpenRA.Mods.RA
 				});
 				return true;
 			}
+
+			stopAttackers(self);
 
 			/// Set up return-to-sender info
 			chronoshiftOrigin = self.Location;


### PR DESCRIPTION
Please review and discuss. This is just my first guess - not sure if it's the right way.
meant to fix #2128

BTW:
Why does Activity.Cancel( Actor self ) have this parameter? IMHO it's never used.
