### PR TITLE
Yet Another Desync Debug Pull Request

### DIFF
--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA
 		readonly AutoTargetInfo Info;
 		readonly AttackBase attack;
 
-		[Sync] int nextScanTime = 0;
+		[Sync] public int nextScanTime = 0;
 		public UnitStance stance;
 		[Sync] public int stanceNumber { get { return (int)stance; } }
 		public UnitStance predictedStance;		/* NOT SYNCED: do not refer to this anywhere other than UI code */
@@ -148,5 +148,17 @@ namespace OpenRA.Mods.RA
 		readonly AutoTarget a;
 		public DebugRetiliateAgainstAggressor(Actor self){ a = self.Trait<AutoTarget>(); }
 		[Sync] public int Aggressor { get { return a.AggressorID; } }
+	}
+
+	public class DebugNextAutoTargetScanTimeInfo : ITraitInfo, Requires<AutoTargetInfo>
+	{
+		public object Create(ActorInitializer init) { return new DebugNextAutoTargetScanTime(init.self); }
+	}
+	
+	public class DebugNextAutoTargetScanTime : ISync
+	{
+		readonly AutoTarget a;
+		public DebugNextAutoTargetScanTime(Actor self){ a = self.Trait<AutoTarget>(); }
+		[Sync] public int NextAutoTargetScanTime { get { return a.nextScanTime; } }
 	}
 }

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -37,6 +37,7 @@ namespace OpenRA.Mods.RA
 		public UnitStance stance;
 		[Sync] public int stanceNumber { get { return (int)stance; } }
 		public UnitStance predictedStance;		/* NOT SYNCED: do not refer to this anywhere other than UI code */
+		[Sync] public int AggressorID;
 
 		public AutoTarget(Actor self, AutoTargetInfo info)
 		{
@@ -67,6 +68,8 @@ namespace OpenRA.Mods.RA
 			if (e.Attacker.AppearsFriendlyTo(self)) return;
 
 			if (e.Damage < 0) return;	// don't retaliate against healers
+
+			AggressorID = (int)e.Attacker.ActorID;
 
 			attack.AttackTarget(Target.FromActor(e.Attacker), false, Info.AllowMovement && stance != UnitStance.Defend);
 		}
@@ -134,4 +137,16 @@ namespace OpenRA.Mods.RA
 	[Desc("Will not get automatically targeted by enemy (like walls)")]
 	class AutoTargetIgnoreInfo : TraitInfo<AutoTargetIgnore> { }
 	class AutoTargetIgnore { }
+
+	public class DebugRetiliateAgainstAggressorInfo : ITraitInfo, Requires<AutoTargetInfo>
+	{
+		public object Create(ActorInitializer init) { return new DebugRetiliateAgainstAggressor(init.self); }
+	}
+	
+	public class DebugRetiliateAgainstAggressor : ISync
+	{
+		readonly AutoTarget a;
+		public DebugRetiliateAgainstAggressor(Actor self){ a = self.Trait<AutoTarget>(); }
+		[Sync] public int Aggressor { get { return a.AggressorID; } }
+	}
 }

--- a/OpenRA.Mods.RA/CarpetBomb.cs
+++ b/OpenRA.Mods.RA/CarpetBomb.cs
@@ -21,10 +21,10 @@ namespace OpenRA.Mods.RA
 		public readonly int Range = 3;
 	}
 
-	class CarpetBomb : ITick			// todo: maybe integrate this better with the normal weapons system?
+	class CarpetBomb : ITick, ISync			// todo: maybe integrate this better with the normal weapons system?
 	{
-		CPos Target;
-		int dropDelay;
+		[Sync] CPos Target;
+		[Sync] int dropDelay;
 
 		public void SetTarget(CPos targetCell) { Target = targetCell; }
 


### PR DESCRIPTION
I am dumping more values that depend on floating point operation or random number calculation to the `syncreport.log` the hacky way @pchote described earlier in https://github.com/OpenRA/OpenRA/pull/2796#issuecomment-15209761.

Also decided that Explodes and CarpetBomb deserve an ISync tag as well as choosing which explosion sound to play does not justify a desync and should therefore CosmeticRandom instead.
