### PR TITLE
Bring the Diplomacy menu back to life...

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Network
 			public string[] Mods = { "ra" };	// mod names
 			public int OrderLatency = 3;
 			public int RandomSeed = 0;
-			public bool LockTeams = true;	// don't allow team changes after game start.
+			public bool FragileAlliances = false;	// Allow diplomatic stance changes after game start.
 			public bool AllowCheats = false;
 			public bool Dedicated;
 			public string Difficulty;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Network
 
 				case "SetStance":
 					{
-						if (Game.orderManager.LobbyInfo.GlobalSettings.LockTeams)
+						if (!Game.orderManager.LobbyInfo.GlobalSettings.FragileAlliances)
 							return;
 
 						var targetPlayer = order.Player.World.Players.FirstOrDefault(p => p.InternalName == order.TargetString);

--- a/OpenRA.Game/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Game/Widgets/CheckboxWidget.cs
@@ -56,7 +56,8 @@ namespace OpenRA.Widgets
 
 			var textSize = font.Measure(Text);
 			font.DrawText(Text,
-				new float2(rect.Left + rect.Height * 1.5f, RenderOrigin.Y - BaseLine + (Bounds.Height - textSize.Y)/2), Color.White);
+				new float2(rect.Left + rect.Height * 1.5f, RenderOrigin.Y - BaseLine + (Bounds.Height - textSize.Y)/2),
+				disabled ? Color.Gray : Color.White);
 
 			if (IsChecked() || (Depressed && HasPressedState && !disabled))
 			{

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -292,7 +292,7 @@ namespace OpenRA.Mods.RA.Server
 						server.SyncLobbyInfo();
 						return true;
 					}},
-				{ "lockteams",
+				{ "fragilealliance",
 					s =>
 					{
 						if (!client.IsAdmin)
@@ -301,7 +301,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						bool.TryParse(s, out server.lobbyInfo.GlobalSettings.LockTeams);
+						bool.TryParse(s, out server.lobbyInfo.GlobalSettings.FragileAlliances);
 						server.SyncLobbyInfo();
 						return true;
 					}},

--- a/OpenRA.Mods.RA/Widgets/Logic/DiplomacyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/DiplomacyLogic.cs
@@ -111,6 +111,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					GetText = () => world.LocalPlayer.Stances[ pp ].ToString(),
 				};
 
+				if (!p.World.LobbyInfo.GlobalSettings.FragileAlliances)
+					myStance.Disabled = true;
+
 				myStance.OnMouseDown = mi => ShowDropDown(pp, myStance);
 
 				bg.AddChild(myStance);
@@ -138,7 +141,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		void SetStance(ButtonWidget bw, Player p, Stance ss)
 		{
-			if (p.World.LobbyInfo.GlobalSettings.LockTeams)
+			if (!p.World.LobbyInfo.GlobalSettings.FragileAlliances)
 				return;	// team changes are banned
 
 			// NOTE(jsd): Abuse of the type system here with `CPos`

--- a/OpenRA.Mods.RA/Widgets/Logic/DiplomacyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/DiplomacyLogic.cs
@@ -41,6 +41,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			validPlayers = world.Players.Where(a => a != world.LocalPlayer && !a.NonCombatant).Count();
 			diplomacy.IsVisible = () => (validPlayers > 0);
+
+			diplomacyBG.Get<ButtonWidget>("CLOSE_DIPLOMACY").OnClick = () => { diplomacyBG.Visible = false; };
 		}
 
 		// This is shit

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -198,6 +198,14 @@ Container@INGAME_ROOT:
 					Text:Diplomacy
 					Align:Center
 					Font:Bold
+				Button@CLOSE_DIPLOMACY:
+					X:(PARENT_RIGHT - WIDTH)/2
+					Y:350
+					Width:160
+					Height:25
+					Text:Close
+					Font:Bold
+					Key:escape
 		ChatDisplay@CHAT_DISPLAY:
 			X:250
 			Y:WINDOW_BOTTOM - HEIGHT - 30

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -420,9 +420,15 @@ Background@SERVER_LOBBY:
 			Width: 80
 			Height: 20
 			Text: Crates
+		Checkbox@FRAGILEALLIANCES_CHECKBOX:
+			X: PARENT_RIGHT-154
+			Y: PARENT_BOTTOM-119
+			Width: 80
+			Height: 20
+			Text: Fragile Alliances
 		Button@DISCONNECT_BUTTON:
 			X:PARENT_RIGHT-154
-			Y:PARENT_BOTTOM-99
+			Y:PARENT_BOTTOM-94
 			Width:120
 			Height:25
 			Text:Disconnect


### PR DESCRIPTION
..., but
- rename LockTeams to FragileAlliances to avoid confusion
- only allow it in Free-For-All, not Team games or Missions
- grey out non-functional buttons and disabled checkboxes
