### PR TITLE
Hotfix: Don't Crash on First-Start when Game Assets are missing

### DIFF
--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -20,7 +20,6 @@ namespace OpenRA.Graphics
 {
 	public static class CursorProvider
 	{
-		public static Dictionary<string, Palette> Palettes { get; private set; }
 		public static HardwarePalette Palette;
 		static Dictionary<string, CursorSequence> cursors;
 
@@ -36,12 +35,12 @@ namespace OpenRA.Graphics
 				ShadowIndex[ShadowIndex.Length - 1] = Convert.ToInt32(sequences.NodesDict["ShadowIndex"].Value);
 			}
 
-			Palettes = new Dictionary<string, Palette>();
+			var palettes = new Dictionary<string, Palette>();
 			foreach (var s in sequences.NodesDict["Palettes"].Nodes)
-				Palettes.Add(s.Key, new Palette(FileSystem.Open(s.Value.Value), ShadowIndex));
+				palettes.Add(s.Key, new Palette(FileSystem.Open(s.Value.Value), ShadowIndex));
 
 			Palette = new HardwarePalette();
-			foreach (var p in CursorProvider.Palettes)
+			foreach (var p in palettes)
 				Palette.AddPalette(p.Key, p.Value, false);
 
 			// Generate initial palette texture

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -131,9 +131,13 @@ namespace OpenRA.Graphics
 				var cursorSequence = CursorProvider.GetCursorSequence(cursorName);
 				var cursorSprite = cursorSequence.GetSprite((int)cursorFrame);
 
+				var palette = new HardwarePalette();
+				foreach (var p in CursorProvider.Palettes)
+					palette.AddPalette(p.Key, p.Value, false);
+
 				renderer.SpriteRenderer.DrawSprite(cursorSprite,
 					Viewport.LastMousePos - cursorSequence.Hotspot,
-					wr.Palette(cursorSequence.Palette).Index,
+					palette.GetPaletteIndex(cursorSequence.Palette),
 					cursorSprite.size);
 			}
 

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -127,18 +127,9 @@ namespace OpenRA.Graphics
 			using( new PerfSample("render_widgets") )
 			{
 				Ui.Draw();
+
 				var cursorName = Ui.Root.GetCursorOuter(Viewport.LastMousePos) ?? "default";
-				var cursorSequence = CursorProvider.GetCursorSequence(cursorName);
-				var cursorSprite = cursorSequence.GetSprite((int)cursorFrame);
-
-				var palette = new HardwarePalette();
-				foreach (var p in CursorProvider.Palettes)
-					palette.AddPalette(p.Key, p.Value, false);
-
-				renderer.SpriteRenderer.DrawSprite(cursorSprite,
-					Viewport.LastMousePos - cursorSequence.Hotspot,
-					palette.GetPaletteIndex(cursorSequence.Palette),
-					cursorSprite.size);
+				CursorProvider.DrawCursor(renderer, cursorName, Viewport.LastMousePos, (int)cursorFrame);
 			}
 
 			using( new PerfSample("render_flip") )

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -41,16 +41,11 @@ namespace OpenRA.Graphics
 		internal WorldRenderer(World world)
 		{
 			this.world = world;
-			palette = new HardwarePalette();
-			foreach (var p in CursorProvider.Palettes)
-				palette.AddPalette(p.Key, p.Value, false);
+			palette = CursorProvider.Palette;
 
 			palettes = new Cache<string, PaletteReference>(CreatePaletteReference);
 			foreach (var pal in world.traitDict.ActorsWithTraitMultiple<IPalette>(world))
 				pal.Trait.InitPalette( this );
-
-			// Generate initial palette texture
-			palette.Update(new IPaletteModifier[] {});
 
 			terrainRenderer = new TerrainRenderer(world, this);
 			shroudRenderer = new ShroudRenderer(world);

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -41,11 +41,14 @@ namespace OpenRA.Graphics
 		internal WorldRenderer(World world)
 		{
 			this.world = world;
-			palette = CursorProvider.Palette;
+			palette = new HardwarePalette();
 
 			palettes = new Cache<string, PaletteReference>(CreatePaletteReference);
 			foreach (var pal in world.traitDict.ActorsWithTraitMultiple<IPalette>(world))
 				pal.Trait.InitPalette( this );
+
+			// Generate initial palette texture
+			palette.Update(new IPaletteModifier[] {});
 
 			terrainRenderer = new TerrainRenderer(world, this);
 			shroudRenderer = new ShroudRenderer(world);


### PR DESCRIPTION
This was introduced in commit 82426e0e458618783a30dc4f39cbe7600d196d13 by @pchote during #2699. I don't know how to fix this properly when WorldRenderer does not exist. Might need a refactor of the refactoring.
