### PR TITLE
CrashReporting

### DIFF
--- a/OpenRA.FileFormats/FieldLoader.cs
+++ b/OpenRA.FileFormats/FieldLoader.cs
@@ -325,6 +325,11 @@ namespace OpenRA.FileFormats
 					((int)c.B).Clamp(0, 255));
 			}
 
+			if (t == typeof(DateTime))
+			{
+				return ((DateTime) v).ToString("yyyy-MM-dd HH:mm:ss");
+			}
+
 			// Don't save floats in settings.yaml using country-specific decimal separators which can be misunderstood as group seperators.
 			if (t == typeof(float))
 				return ((float)v).ToString(CultureInfo.InvariantCulture);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -237,7 +237,7 @@ namespace OpenRA
 
 		public static Dictionary<String, Mod> CurrentMods
 		{
-			get { return Mod.AllMods.Where( k => modData.Manifest.Mods.Contains( k.Key )).ToDictionary( k => k.Key, k => k.Value ); }
+			get { return modData==null ? null : Mod.AllMods.Where( k => modData.Manifest.Mods.Contains( k.Key )).ToDictionary( k => k.Key, k => k.Value ); }
 		}
 
 		static Modifiers modifiers;

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -29,6 +29,7 @@ namespace OpenRA.GameRules
 		public int ExternalPort = 1234;
 		public bool AdvertiseOnline = true;
 		public string MasterServer = "http://master.open-ra.org/";
+		public string CrashReportServer = "http://localhost:8080/crs/";
 		public bool AllowUPnP = false;
 		public bool AllowCheats = false;
 		public string Map = null;

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -6,6 +6,7 @@
  * as published by the Free Software Foundation. For more information,
  * see COPYING.
  */
+
 #endregion
 
 using System;
@@ -13,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.Exceptions;
 
 namespace OpenRA.Network
 {
@@ -140,17 +142,17 @@ namespace OpenRA.Network
 			if (index >= orders.Count())
 				OutOfSync(frame);
 
-			throw new InvalidOperationException("Out of sync in frame {0}.\n {1}\n Compare syncreport.log with other players.".F(frame, orders.ElementAt(index).Order.ToString()));
+			throw new OutOfSyncException("Out of sync in frame {0}.\n {1}".F(frame, orders.ElementAt(index).Order.ToString()), syncReport.GetReport(frame));
 		}
 
 		void OutOfSync(int frame)
 		{
-			throw new InvalidOperationException("Out of sync in frame {0}.\n Compare syncreport.log with other players.".F(frame));
+			throw new OutOfSyncException("Out of sync in frame {0}.".F(frame), syncReport.GetReport(frame));
 		}
 
 		void OutOfSync(int frame, string blame)
 		{
-			throw new InvalidOperationException("Out of sync in frame {0}: Blame {1}.\n Compare syncreport.log with other players.".F(frame, blame));
+			throw new OutOfSyncException("Out of sync in frame {0}: Blame {1}.".F(frame, blame), syncReport.GetReport(frame));
 		}
 
 		public bool IsReadyForNextFrame

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -87,11 +87,13 @@ namespace OpenRA.Network
 			public bool Dedicated;
 			public string Difficulty;
 			public bool Crates = true;
+			public string GameUid;
 		}
 
 		public Session(string[] mods)
 		{
 			this.GlobalSettings.Mods = mods.ToArray();
+			this.GlobalSettings.GameUid = System.Guid.NewGuid().ToString();
 		}
 
 		public string Serialize()

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace OpenRA.Network
 {
-	class SyncReport
+	public class SyncReport
 	{
 		readonly OrderManager orderManager;
 		const int numSyncReports = 5;
@@ -74,7 +74,14 @@ namespace OpenRA.Network
 			Log.Write("sync", "No sync report available!");
 		}
 
-		class Report
+		public Report GetReport(int frame)
+		{
+			foreach (var r in syncReports)
+				if (r.Frame == frame) return r;
+			return null;
+		}
+
+		public class Report
 		{
 			public int Frame;
 			public int SyncedRandom;
@@ -82,7 +89,7 @@ namespace OpenRA.Network
 			public List<TraitReport> Traits = new List<TraitReport>();
 		}
 
-		struct TraitReport
+		public struct TraitReport
 		{
 			public uint ActorID;
 			public string Type;
@@ -90,6 +97,5 @@ namespace OpenRA.Network
 			public string Trait;
 			public int Hash;
 		}
-
 	}
 }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -157,6 +157,9 @@
     <Compile Include="Support\Arguments.cs" />
     <Compile Include="Support\PerfHistory.cs" />
     <Compile Include="Support\Program.cs" />
+    <Compile Include="Support\CrashReporter.cs" />
+    <Compile Include="Support\CrashReport.cs" />
+    <Compile Include="Support\Exceptions.cs" />
     <Compile Include="Sync.cs" />
     <Compile Include="TraitDictionary.cs" />
     <Compile Include="Traits\Activity.cs" />

--- a/OpenRA.Game/Support/CrashReport.cs
+++ b/OpenRA.Game/Support/CrashReport.cs
@@ -1,0 +1,225 @@
+#region Copyright & License Information
+/*
+ * Copyright 2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Net;
+using System.Collections.Generic;
+using System.IO;
+using System.Diagnostics;
+using System.Threading;
+using System.ComponentModel;
+using System.Text;
+using System.Reflection;
+using OpenRA.FileFormats;
+using OpenRA.Exceptions;
+using OpenRA.Network;
+using OpenRA.GameRules;
+
+namespace OpenRA.Support
+{
+	public class CrashReport
+	{
+		static string ReportPath = Platform.SupportDir + "Crash Reports" + Path.DirectorySeparatorChar;
+
+		static readonly string[] Fields = { "ReportUid", "ReportVersion", "Created", "OSPlatform", "OSVersion", "GameUID"};
+		public static readonly int ReportVersion = 1;
+
+		public DateTime Created = DateTime.UtcNow;
+		public string Error { get { return exception == null ? null : exception.GetType().FullName; }}
+		public string Message { get { return exception == null ? null : exception.Message; }}
+		public static readonly string OSVersion = Environment.OSVersion.Version.ToString();
+		public static readonly string OSPlatform = Environment.OSVersion.Platform.ToString();
+		public readonly string ReportUid;
+		public Session LobbyInfo;
+		public Mod[] Mods;
+
+		Exception exception;
+
+		public CrashReport(Exception e)
+		{
+			ReportUid = System.Guid.NewGuid().ToString();
+			exception = e;
+		}
+
+		public static void OpenReportsFolder()
+		{
+			Process.Start(ReportPath);
+		}
+
+		private struct WorkData
+		{
+			public string url;
+			public string yaml;
+		}
+
+		private void doWork(object sender, DoWorkEventArgs e)
+		{
+			BackgroundWorker bw = sender as BackgroundWorker;
+			WorkData data = (WorkData) e.Argument;
+
+			HttpWebRequest request = (HttpWebRequest) WebRequest.Create(data.url);
+
+			request.UserAgent = "OpenRA";
+			request.Method = "POST";
+			request.AllowWriteStreamBuffering = false;
+			request.ContentType = "text/x-yaml";
+
+
+			var enc = new System.Text.UTF8Encoding();
+			byte[] ba = enc.GetBytes(data.yaml);
+
+			request.ContentLength = ba.Length;
+
+			Stream dataStream = request.GetRequestStream();
+
+			for (var i = 0; i < ba.Length; i+=1024)
+			{
+				dataStream.Write(ba,i,Math.Min(1024, ba.Length-i));
+
+				bw.ReportProgress((int)(i/(float)ba.Length*100));
+			}
+
+			dataStream.Close();
+			HttpWebResponse response = (HttpWebResponse) request.GetResponse();
+
+			e.Result = response.GetResponseStream().ReadAllText();
+			response.Close();
+		}
+
+		public void Submit(Action<int> onProgress, Action onComplete, Action<WebException> onError)
+		{
+			BackgroundWorker bw = new BackgroundWorker();
+
+			bw.WorkerReportsProgress = true;
+			bw.DoWork += this.doWork;
+			bw.ProgressChanged += (sender, e) => { onProgress(e.ProgressPercentage); };
+			bw.RunWorkerCompleted += (sender, e) =>
+			{
+				if (e.Error != null)
+				{
+					Console.WriteLine(e.Error.ToString());
+					if (e.Error is WebException)
+						onError(e.Error as WebException);
+					onError(null);
+				}
+				else
+				{
+					Console.WriteLine(e.Result as String);
+					onProgress(100);
+					onComplete();
+				}
+			};
+
+			var data = new WorkData();
+			data.yaml = Serialize().WriteToString();
+
+			if (Game.Settings != null)
+				data.url = Game.Settings.Server.CrashReportServer;
+			else
+				data.url = new ServerSettings().CrashReportServer;
+
+			data.url += "submit/";
+
+
+			onProgress(0);
+			bw.RunWorkerAsync(data);
+		}
+
+		public void Save()
+		{
+			Directory.CreateDirectory(ReportPath);
+			var filename = ReportPath + Created.ToString("yyyy-MM-dd HHmmss ")+ReportUid+".yaml";
+			Serialize().WriteToFile(filename);
+		}
+
+		public List<MiniYamlNode> Serialize()
+		{
+			var root = new List<MiniYamlNode>();
+			List<MiniYamlNode> nodes;
+
+			foreach (var field in Fields)
+			{
+				FieldInfo f = this.GetType().GetField(field);
+				if (f == null || f.GetValue(this) == null) continue;
+				root.Add( new MiniYamlNode( field, FieldSaver.FormatValue( this, f ) ) );
+			}
+
+			// Exception-Stack
+			var inner = exception;
+			var parent = root;
+			while (inner != null)
+			{
+				nodes = new List<MiniYamlNode>();
+				nodes.Add(new MiniYamlNode("Type", inner.GetType().FullName));
+				nodes.Add(new MiniYamlNode("Message", inner.Message));
+
+				// Stack-Trace
+				var stack = new List<MiniYamlNode>();
+				var i = 0;
+				foreach (var frame in inner.StackTrace.Split('\n'))
+				{
+					var line = frame.Trim();
+					line = line.StartsWith("at ") ? line.Substring(3) : line;
+					stack.Add(new MiniYamlNode(i++.ToString(), line));
+				}
+				nodes.Add(new MiniYamlNode("StackTrace", new MiniYaml(null, stack)));
+
+				parent.Add(new MiniYamlNode (parent == root ? "Exception" : "InnerException", new MiniYaml(null, nodes)));
+				parent = nodes;
+				inner = inner.InnerException;
+			}
+
+			// SyncReport
+			if (exception is OutOfSyncException)
+			{
+				var e = (OutOfSyncException) exception;
+				nodes = new List<MiniYamlNode>();
+				nodes.Add(new MiniYamlNode("Frame", e.SyncReport.Frame.ToString()));
+				nodes.Add(new MiniYamlNode("SharedRandom", e.SyncReport.SyncedRandom.ToString()));
+				nodes.Add(new MiniYamlNode("TotalCount", e.SyncReport.TotalCount.ToString()));
+
+				var i = 0;
+				foreach (var a in e.SyncReport.Traits)
+					nodes.Add(new MiniYamlNode("Trait@{0}".F(i++), FieldSaver.Save(a)));
+
+				root.Add(new MiniYamlNode ("SyncReport", new MiniYaml(null, nodes)));
+			}
+
+			// Mods
+			if (Mods != null && Mods.Length > 0)
+			{
+				nodes = new List<MiniYamlNode>();
+				var i = 0;
+				foreach (var mod in Mods)
+				{
+					nodes.Add(new MiniYamlNode("Mod@{0}".F(i++), FieldSaver.Save(mod)));
+				}
+				root.Add(new MiniYamlNode("Mods", new MiniYaml(null, nodes)));
+			}
+
+			// LobbyInfo (Session)
+			if (LobbyInfo != null)
+			{
+				nodes = new List<MiniYamlNode>();
+				foreach (var client in LobbyInfo.Clients)
+					nodes.Add(new MiniYamlNode("Client@{0}".F(client.Index), FieldSaver.Save(client)));
+
+				foreach (var slot in LobbyInfo.Slots)
+					nodes.Add(new MiniYamlNode("Slot@{0}".F(slot.Key), FieldSaver.Save(slot.Value)));
+
+				nodes.Add(new MiniYamlNode("GlobalSettings", FieldSaver.Save(LobbyInfo.GlobalSettings)));
+				root.Add(new MiniYamlNode("LobbyInfo", new MiniYaml(null, nodes)));
+			}
+
+			return root;
+		}
+	}
+}
+

--- a/OpenRA.Game/Support/CrashReporter.cs
+++ b/OpenRA.Game/Support/CrashReporter.cs
@@ -1,0 +1,139 @@
+#region Copyright & License Information
+/*
+ * Copyright 2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Windows.Forms;
+using System.Drawing;
+using System.Diagnostics;
+using System.Net;
+using OpenRA.FileFormats;
+
+namespace OpenRA.Support
+{
+	public class CrashReporter : Form
+	{
+		private CrashReport Report;
+		private Button BtnSubmit;
+		ProgressBar PBar;
+
+		public static void Run(CrashReport report)
+		{
+			var cr = new CrashReporter(report);
+			Application.Run(cr);
+		}
+
+		public CrashReporter(CrashReport report)
+		{
+			Report = report;
+			Text = "OpenRA: Crash Report";
+			Size = new Size(550, 400);
+			MinimizeBox = false;
+			MaximizeBox = false;
+			Font = new Font("Sans", 12);
+			FormBorderStyle = FormBorderStyle.FixedDialog;
+			CenterToScreen();
+
+			Label lblTitle = new Label();
+			lblTitle.Text = "We're sorry, OpenRA crashed...";
+			lblTitle.Font = new Font("Sans", 14, FontStyle.Bold);
+			lblTitle.TextAlign = ContentAlignment.MiddleCenter;
+			lblTitle.Width = Size.Width;
+			lblTitle.Height = 30;
+			lblTitle.Location = new Point(0, 25);
+			Controls.Add(lblTitle);
+
+			Label lblText = new Label();
+			lblText.Text = @"This should've never happened. You can help us fix this by submitting the generated crash report.";
+			lblText.Location = new Point(25, lblTitle.Bottom+25);
+			Controls.Add(lblText);
+
+			Label lblTeam = new Label();
+			lblTeam.Text = "The OpenRA Development Team";
+			lblTeam.Size = new Size(Width-50, 25);
+			lblTeam.Location = new Point(0, lblText.Bottom);
+			lblTeam.TextAlign = ContentAlignment.TopRight;
+			Controls.Add(lblTeam);
+
+			Label lblError = new Label();
+			lblError.AutoSize = true;
+			lblError.Text = Report.Error;
+			lblError.Location = new Point(40, lblTeam.Bottom + 25);
+			Controls.Add(lblError);
+
+			Label lblMessage = new Label();
+			lblMessage.Size = new Size(Width-80, 50);
+			lblMessage.Text = Report.Message;
+			lblMessage.Location = new Point(lblError.Left, lblError.Bottom);
+			Controls.Add(lblMessage);
+
+			LinkLabel lnkFaq = new LinkLabel();
+			lnkFaq.Font = new Font("Sans", 10);
+			lnkFaq.AutoSize = true;
+			lnkFaq.Text = "Consult the FAQ";
+			lnkFaq.LinkArea = new LinkArea(0, lnkFaq.Text.Length);
+			lnkFaq.LinkClicked += (sender, e) => {Process.Start("https://github.com/OpenRA/OpenRA/wiki/FAQ");};
+			lnkFaq.Dock = DockStyle.Bottom;
+			Controls.Add(lnkFaq);
+
+			LinkLabel lnkReport = new LinkLabel();
+			lnkReport.Font = new Font("Sans", 10);
+			lnkReport.AutoSize = true;
+			lnkReport.Text = "Show the Crash Report";
+			lnkReport.LinkArea = new LinkArea(0, lnkReport.Text.Length);
+			lnkReport.LinkClicked += (sender, e) => {CrashReport.OpenReportsFolder();};
+			lnkReport.Dock = DockStyle.Bottom;
+			Controls.Add(lnkReport);
+
+			PBar = new ProgressBar();
+			PBar.Size = new Size(400, 25);
+			PBar.Location = new Point(75, lblMessage.Bottom+20);
+			PBar.Minimum = 0;
+			PBar.Maximum = 100;
+			PBar.Value = 0;
+			Controls.Add(PBar);
+
+			BtnSubmit = new Button();
+			BtnSubmit.Text = "Submit";
+			BtnSubmit.Size = new Size(100, 32);
+			BtnSubmit.Location = new Point((Width-BtnSubmit.Width)/2, PBar.Bottom+10);
+			BtnSubmit.Click += (sender, e) => { Submit(); };
+			Controls.Add(BtnSubmit);
+		}
+
+		private void Submit()
+		{
+			BtnSubmit.Enabled = false;
+			Report.Submit(
+				(p) => {PBar.Value = p;},
+				() =>
+				{
+					MessageBox.Show("The crash report has been submitted. Thank you for your support!", "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
+					Close();
+				},
+				(e) =>
+				{
+					var message = "The crash report could not be submitted.";
+					if (e != null)
+					{
+						var we = e as WebException;
+						var resp = (HttpWebResponse) we.Response;
+						message += "\n" + we.Message;
+						if (resp != null)
+							message += "\n {0} - {1}".F(resp.StatusCode, resp.StatusDescription);
+					}
+					MessageBox.Show(message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+					Close();
+				}
+			);
+		}
+
+	}
+}
+

--- a/OpenRA.Game/Support/Exceptions.cs
+++ b/OpenRA.Game/Support/Exceptions.cs
@@ -1,0 +1,25 @@
+#region Copyright & License Information
+/*
+ * Copyright 2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Network;
+
+namespace OpenRA.Exceptions
+{
+	public class OutOfSyncException : System.ApplicationException
+	{
+		public SyncReport.Report SyncReport;
+		public OutOfSyncException(string message, SyncReport.Report syncreport) : base(message)
+		{
+			SyncReport = syncreport;
+		}
+	}
+}
+

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using OpenRA.Support;
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -30,7 +31,6 @@ namespace OpenRA
 				Run(args);
 				return;
 			}
-
 			try
 			{
 				Run(args);
@@ -41,6 +41,20 @@ namespace OpenRA
 				var rpt = BuildExceptionReport(e).ToString();
 				Log.Write("exception", "{0}", rpt);
 				Console.Error.WriteLine(rpt);
+
+				var report = new CrashReport(e);
+				var om = Game.orderManager;
+				if (om != null)
+				{
+					report.LobbyInfo = om.LobbyInfo;
+				}
+
+				if (Game.CurrentMods != null)
+					report.Mods = Game.CurrentMods.Values.ToArray();
+
+				report.Save();
+				// disabled until OpenRACrashReport Server is up and running
+				//CrashReporter.Run(report);
 			}
 		}
 


### PR DESCRIPTION
Please review and discuss.

I think some refactoring needs to be done. I don't know much about the namespace structure of the project. I also think we need to use more custom exceptions. This will later allow a better filtering of the reports. I therefore introduced a OutOfSyncException. (also to pass the SyncReport to the CrashReport, or whatever catches...)
- added unique game id: fixes #2570
- fixes #2571 (kind of)

There is a CrashReporter class (WinForms) which is a GUI for uploading CrashReports. It can be used for fatal exceptions which crashes the game.
Other GUIs (In-Game) can be added for non-fatal exceptions. (see #2850)

Uploading crash reports is disabled until the crash report server is ready and running. For now reports are only written to file "~/.openra/Crash Reports".
Merging this will allow others to improve/extend the functionality while I can work on the Server.

:)

A CrashReport looks like this:
https://gist.github.com/bidifx/a7a92bbfcea76378bcea
