### PR TITLE
fix #2193

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -175,7 +175,11 @@ namespace OpenRA.Server
 							var p = preConns.SingleOrDefault( c => c.socket == s );
 							if (p != null) p.ReadData( this );
 						}
-						else if (conns.Count > 0) conns.Single( c => c.socket == s ).ReadData( this );
+						else if (conns.Count > 0)
+						{
+							var conn = conns.SingleOrDefault( c => c.socket == s );
+							if (conn != null) conn.ReadData( this );
+						}
 
 					foreach (var t in ServerTraits.WithInterface<ITick>())
 						t.Tick(this);


### PR DESCRIPTION
the most common reason of "Operation is not valid due to the current state of the object"
