### PR TITLE
fully configurable version mismatch detection

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -37,6 +37,7 @@ namespace OpenRA.GameRules
 		public bool Dedicated = false;
 		public bool DedicatedLoop = true;
 		public bool LockBots = false;
+		public bool AllowVersionMismatch = false;
 
 		public ServerSettings() { }
 
@@ -55,6 +56,7 @@ namespace OpenRA.GameRules
 			Dedicated = other.Dedicated;
 			DedicatedLoop = other.DedicatedLoop;
 			LockBots = other.LockBots;
+			AllowVersionMismatch = other.AllowVersionMismatch;
 		}
 	}
 
@@ -66,6 +68,7 @@ namespace OpenRA.GameRules
 		public float LongTickThreshold = 0.001f;
 		public bool SanityCheckUnsyncedCode = false;
 		public int Samples = 25;
+		public bool IgnoreVersionMismatch = false;
 	}
 
 	public class GraphicSettings

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -36,10 +36,10 @@ namespace OpenRA.Network
 
 		static bool AreVersionsCompatible(string a, string b)
 		{
-			/* dev versions are assumed compatible; if you're using one,
-			 * we trust that you know what you're doing. */
+			if (Game.Settings.Debug.IgnoreVersionMismatch)
+				return true;
 
-			return a == "{DEV_VERSION}" || b == "{DEV_VERSION}" || a == b;
+			return a == b;
 		}
 
 		public bool CanJoin()

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -87,6 +87,7 @@ namespace OpenRA.Network
 			public bool Dedicated;
 			public string Difficulty;
 			public bool Crates = true;
+			public bool AllowVersionMismatch;
 		}
 
 		public Session(string[] mods)

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -230,6 +230,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			longTickThreshold.Value = Game.Settings.Debug.LongTickThreshold;
 			longTickThreshold.OnChange += x => Game.Settings.Debug.LongTickThreshold = x;
 
+			var ignoreVersionMismatchCheckbox = debug.Get<CheckboxWidget>("IGNOREVERSIONMISMATCH_CHECKBOX");
+			ignoreVersionMismatchCheckbox.IsChecked = () => Game.Settings.Debug.IgnoreVersionMismatch;
+			ignoreVersionMismatchCheckbox.OnClick = () => Game.Settings.Debug.IgnoreVersionMismatch ^= true;
+
 			bg.Get<ButtonWidget>("BUTTON_CLOSE").OnClick = () =>
 			{
 				int x, y;

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+Name="Dedicated-Server"
+Mod="ra"
+Dedicated="True"
+DedicatedLoop="True"
+ListenPort=1234
+ExternalPort=1234
+AdvertiseOnline="False"
+Map="ba403f6bcb4cae934335b78be42f714992b3a71a"
+
+while true; do
+     mono --debug OpenRA.Game.exe Game.Mods=$Mod Server.Dedicated=$Dedicated Server.DedicatedLoop=$DedicatedLoop \
+     Server.Name=$Name Server.ListenPort=$ListenPort Server.ExternalPort=$ExternalPort \
+     Server.AdvertiseOnline=$AdvertiseOnline Server.Map=$Map 
+done

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec mono OpenRA.Game.exe "$@"
+exec mono OpenRA.Game.exe Server.Dedicated=False Server.DedicatedLoop=False "$@"

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -392,3 +392,9 @@ Background@SETTINGS_MENU:
 					Ticks:25
 					MinimumValue: 0.0001
 					MaximumValue: 0.01
+				Checkbox@IGNOREVERSIONMISMATCH_CHECKBOX:
+					X:0
+					Y:210
+					Width:300
+					Height:20
+					Text:Don't check for compatible version in game server browser.


### PR DESCRIPTION
It is hard to fix the dedicated server because it blocks {DEV_VERSION} by default with some obscure hard-coded conditionals. There are also other annoyances:
- People can bomb in with their self-compiled {DEV_VERSION} if the server is not dedicated although we warn in the lobby about that.
- People bomb into @ScottNZ and mine {DEV_VERSION} test-games with their stable releases and we have to explain or rudely kick them over and over again.

This addresses everything by introducing two new variables:
1. Reject from connections different versions (also covers the case if people direct connect overriding the server browser GUI based check)
2. Add a new Debug options so you can join every game with every version (if the server allows it, which he does not by default)

Still warn about {DEV_VERSION} as we don't know which commit we are on.

I also decided to ship the launch script from https://github.com/OpenRA/OpenRA/wiki/Dedicated because it has sane defaults. Everyone should use it. Plus I can then just type `./lauch-dedicated.sh` and `./launch-game.sh` when doing extensive testing.
