### PR TITLE
fixes #2866: allow Button.Key to be a delegate

### DIFF
--- a/OpenRA.Game/Widgets/ButtonWidget.cs
+++ b/OpenRA.Game/Widgets/ButtonWidget.cs
@@ -17,7 +17,13 @@ namespace OpenRA.Widgets
 {
 	public class ButtonWidget : Widget
 	{
-		public string Key = null;
+		public Func<ButtonWidget, string> GetKey = _ => null;
+		public string Key
+		{
+			get { return GetKey(this); }
+			set { GetKey = _ => value; }
+		}
+
 		public string Text = "";
 		public bool Depressed = false;
 		public int VisualHeight = ChromeMetrics.Get<int>("ButtonDepth");

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChromeLogic.cs
@@ -54,9 +54,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 
 			var moneybin = gameRoot.Get("INGAME_MONEY_BIN");
-			moneybin.Get<OrderButtonWidget>("SELL").Key = Game.Settings.Keys.SellKey;
-			moneybin.Get<OrderButtonWidget>("POWER_DOWN").Key = Game.Settings.Keys.PowerDownKey;
-			moneybin.Get<OrderButtonWidget>("REPAIR").Key = Game.Settings.Keys.RepairKey;
+			moneybin.Get<OrderButtonWidget>("SELL").GetKey = _ => Game.Settings.Keys.SellKey;
+			moneybin.Get<OrderButtonWidget>("POWER_DOWN").GetKey = _ => Game.Settings.Keys.PowerDownKey;
+			moneybin.Get<OrderButtonWidget>("REPAIR").GetKey = _ => Game.Settings.Keys.RepairKey;
 
 			optionsBG.Get<ButtonWidget>("DISCONNECT").OnClick = () => LeaveGame(optionsBG, world);
 


### PR DESCRIPTION
Works nicely.
But one thing remains unclear to me: 
How does the yaml loader know not to load KeyFunc from yaml? Or would he try to if there were a "KeyFunc:" entry in the yaml file? How to prevent this?

fixes #2866
