### PR TITLE
Non-targetable Trees

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -364,8 +364,6 @@
 	DeadBuildingState:
 	Armor:
 		Type: Wood
-	TargetableBuilding:
-		TargetTypes: Ground
 	AutoTargetIgnore:
 
 ^Rock:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -335,8 +335,6 @@
 	DeadBuildingState:
 	Armor:
 		Type: Wood
-	TargetableBuilding:
-		TargetTypes: Ground
 	AutoTargetIgnore:
 
 ^Husk:


### PR DESCRIPTION
Rebalancing of #2612, fixes #2875 and related regressions. Makes forest indestructable again except for area damaging super-weapons (nukes and ion cannon).
