### PR TITLE
Replace Turret/Muzzle positioning code

### DIFF
--- a/OpenRA.FileFormats/FieldLoader.cs
+++ b/OpenRA.FileFormats/FieldLoader.cs
@@ -161,6 +161,61 @@ namespace OpenRA.FileFormats
 				return InvalidValueAction(x, fieldType, field);
 			}
 
+			else if (fieldType == typeof(WRange))
+			{
+				WRange res;
+				if (WRange.TryParse(x, out res))
+					return res;
+
+				return InvalidValueAction(x, fieldType, field);
+			}
+
+			else if (fieldType == typeof(WVec))
+			{
+				var parts = x.Split(',');
+				if (parts.Length == 3)
+				{
+					WRange rx, ry, rz;
+					if (WRange.TryParse(parts[0], out rx) && WRange.TryParse(parts[1], out ry) && WRange.TryParse(parts[2], out rz))
+						return new WVec(rx, ry, rz);
+				}
+
+				return InvalidValueAction(x, fieldType, field);
+			}
+
+			else if (fieldType == typeof(WPos))
+			{
+				var parts = x.Split(',');
+				if (parts.Length == 3)
+				{
+					WRange rx, ry, rz;
+					if (WRange.TryParse(parts[0], out rx) && WRange.TryParse(parts[1], out ry) && WRange.TryParse(parts[2], out rz))
+						return new WPos(rx, ry, rz);
+				}
+
+				return InvalidValueAction(x, fieldType, field);
+			}
+
+			else if (fieldType == typeof(WAngle))
+			{
+				int res;
+				if (int.TryParse(x, out res))
+					return new WAngle(res);
+				return InvalidValueAction(x, fieldType, field);
+			}
+
+			else if (fieldType == typeof(WRot))
+			{
+				var parts = x.Split(',');
+				if (parts.Length == 3)
+				{
+					int rr, rp, ry;
+					if (int.TryParse(x, out rr) && int.TryParse(x, out rp) && int.TryParse(x, out ry))
+						return new WRot(new WAngle(rr), new WAngle(rp), new WAngle(ry));
+				}
+				return InvalidValueAction(x, fieldType, field);
+			}
+
 			else if (fieldType.IsEnum)
 			{
 				if (!Enum.GetNames(fieldType).Select(a => a.ToLower()).Contains(x.ToLower()))

--- a/OpenRA.FileFormats/OpenRA.FileFormats.csproj
+++ b/OpenRA.FileFormats/OpenRA.FileFormats.csproj
@@ -132,6 +132,11 @@
     <Compile Include="Support\Timer.cs" />
     <Compile Include="Thirdparty\Random.cs" />
     <Compile Include="TypeDictionary.cs" />
+    <Compile Include="WPos.cs" />
+    <Compile Include="WVec.cs" />
+    <Compile Include="WAngle.cs" />
+    <Compile Include="WRot.cs" />
+    <Compile Include="WRange.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/OpenRA.FileFormats/WAngle.cs
+++ b/OpenRA.FileFormats/WAngle.cs
@@ -1,0 +1,123 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+
+namespace OpenRA
+{
+	/// <summary>
+	/// 1D angle - 1024 units = 360 degrees.
+	/// </summary>
+	public struct WAngle
+	{
+		public readonly int Angle;
+
+		public WAngle(int a)
+		{
+			Angle = a % 1024;
+			if (Angle < 0)
+				Angle += 1024;
+		}
+		public static readonly WAngle Zero = new WAngle(0);
+		public static WAngle FromFacing(int facing) { return new WAngle(facing*4); }
+		public static WAngle FromDegrees(int degrees) { return new WAngle(degrees*1024/360); }
+		public static WAngle operator +(WAngle a, WAngle b) { return new WAngle(a.Angle + b.Angle); }
+		public static WAngle operator -(WAngle a, WAngle b) { return new WAngle(a.Angle - b.Angle); }
+		public static WAngle operator -(WAngle a) { return new WAngle(-a.Angle); }
+
+		public static bool operator ==(WAngle me, WAngle other) { return (me.Angle == other.Angle); }
+		public static bool operator !=(WAngle me, WAngle other) { return !(me == other); }
+
+		public override int GetHashCode() { return Angle.GetHashCode(); }
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+				return false;
+
+			WAngle o = (WAngle)obj;
+			return o == this;
+		}
+
+		public int Sin() { return new WAngle(Angle - 256).Cos(); }
+
+		public int Cos()
+		{
+			if (Angle <= 256)
+				return CosineTable[Angle];
+			if (Angle <= 512)
+				return -CosineTable[512 - Angle];
+			return -new WAngle(Angle - 512).Cos();
+		}
+
+		public int Tan()
+		{
+			if (Angle <= 256)
+				return TanTable[Angle];
+			if (Angle <= 512)
+				return -TanTable[512 - Angle];
+			return new WAngle(Angle - 512).Tan();
+		}
+
+		// Must not be used outside rendering code
+		public float RendererRadians() { return (float)(Angle * Math.PI / 512f); }
+		public float RendererDegrees() { return Angle * 0.3515625f; }
+
+		public override string ToString() { return "{0}".F(Angle); }
+
+		static int[] CosineTable =
+		{
+			1024, 1023, 1023, 1023, 1023, 1023, 1023, 1023, 1022, 1022, 1022, 1021,
+			1021, 1020, 1020, 1019, 1019, 1018, 1017, 1017, 1016, 1015, 1014, 1013,
+			1012, 1011, 1010, 1009, 1008, 1007, 1006, 1005, 1004, 1003, 1001, 1000,
+			999, 997, 996, 994, 993, 991, 990, 988, 986, 985, 983, 981, 979, 978,
+			976, 974, 972, 970, 968, 966, 964, 962, 959, 957, 955, 953, 950, 948,
+			946, 943, 941, 938, 936, 933, 930, 928, 925, 922, 920, 917, 914, 911,
+			908, 906, 903, 900, 897, 894, 890, 887, 884, 881, 878, 875, 871, 868,
+			865, 861, 858, 854, 851, 847, 844, 840, 837, 833, 829, 826, 822, 818,
+			814, 811, 807, 803, 799, 795, 791, 787, 783, 779, 775, 771, 767, 762,
+			758, 754, 750, 745, 741, 737, 732, 728, 724, 719, 715, 710, 706, 701,
+			696, 692, 687, 683, 678, 673, 668, 664, 659, 654, 649, 644, 639, 634,
+			629, 625, 620, 615, 609, 604, 599, 594, 589, 584, 579, 574, 568, 563,
+			558, 553, 547, 542, 537, 531, 526, 521, 515, 510, 504, 499, 493, 488,
+			482, 477, 471, 466, 460, 454, 449, 443, 437, 432, 426, 420, 414, 409,
+			403, 397, 391, 386, 380, 374, 368, 362, 356, 350, 344, 339, 333, 327,
+			321, 315, 309, 303, 297, 291, 285, 279, 273, 267, 260, 254, 248, 242,
+			236, 230, 224, 218, 212, 205, 199, 193, 187, 181, 175, 168, 162, 156,
+			150, 144, 137, 131, 125, 119, 112, 106, 100, 94, 87, 81, 75, 69, 62,
+			56, 50, 43, 37, 31, 25, 18, 12, 6, 0
+		};
+
+		static int[] TanTable =
+		{
+			0, 6, 12, 18, 25, 31, 37, 44, 50, 56, 62, 69, 75, 81, 88, 94, 100, 107,
+			113, 119, 126, 132, 139, 145, 151, 158, 164, 171, 177, 184, 190, 197,
+			203, 210, 216, 223, 229, 236, 243, 249, 256, 263, 269, 276, 283, 290,
+			296, 303, 310, 317, 324, 331, 338, 345, 352, 359, 366, 373, 380, 387,
+			395, 402, 409, 416, 424, 431, 438, 446, 453, 461, 469, 476, 484, 492,
+			499, 507, 515, 523, 531, 539, 547, 555, 563, 571, 580, 588, 596, 605,
+			613, 622, 630, 639, 648, 657, 666, 675, 684, 693, 702, 711, 721, 730,
+			740, 749, 759, 769, 779, 789, 799, 809, 819, 829, 840, 850, 861, 872,
+			883, 894, 905, 916, 928, 939, 951, 963, 974, 986, 999, 1011, 1023, 1036,
+			1049, 1062, 1075, 1088, 1102, 1115, 1129, 1143, 1158, 1172, 1187, 1201,
+			1216, 1232, 1247, 1263, 1279, 1295, 1312, 1328, 1345, 1363, 1380, 1398,
+			1416, 1435, 1453, 1473, 1492, 1512, 1532, 1553, 1574, 1595, 1617, 1639,
+			1661, 1684, 1708, 1732, 1756, 1782, 1807, 1833, 1860, 1887, 1915, 1944,
+			1973, 2003, 2034, 2065, 2098, 2131, 2165, 2199, 2235, 2272, 2310, 2348,
+			2388, 2429, 2472, 2515, 2560, 2606, 2654, 2703, 2754, 2807, 2861, 2918,
+			2976, 3036, 3099, 3164, 3232, 3302, 3375, 3451, 3531, 3613, 3700, 3790,
+			3885, 3984, 4088, 4197, 4311, 4432, 4560, 4694, 4836, 4987, 5147, 5318,
+			5499, 5693, 5901, 6124, 6364, 6622, 6903, 7207, 7539, 7902, 8302, 8743,
+			9233, 9781, 10396, 11094, 11891, 12810, 13882, 15148, 16667, 18524, 20843,
+			23826, 27801, 33366, 41713, 55622, 83438, 166883, int.MaxValue
+		};
+	}
+}

--- a/OpenRA.FileFormats/WPos.cs
+++ b/OpenRA.FileFormats/WPos.cs
@@ -1,0 +1,50 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+
+namespace OpenRA
+{
+	/// <summary>
+	/// 3d World position - 1024 units = 1 cell.
+	/// </summary>
+	public struct WPos
+	{
+		public readonly int X, Y, Z;
+
+		public WPos(int x, int y, int z) { X = x; Y = y; Z = z; }
+		public WPos(WRange x, WRange y, WRange z) { X = x.Range; Y = y.Range; Z = z.Range; }
+
+		public static readonly WPos Zero = new WPos(0, 0, 0);
+
+		public static explicit operator WVec(WPos a) { return new WVec(a.X, a.Y, a.Z); }
+
+		public static WPos operator +(WPos a, WVec b) { return new WPos(a.X + b.X, a.Y + b.Y, a.Z + b.Z); }
+		public static WPos operator -(WPos a, WVec b) { return new WPos(a.X - b.X, a.Y - b.Y, a.Z - b.Z); }
+		public static WVec operator -(WPos a, WPos b) { return new WVec(a.X - b.X, a.Y - b.Y, a.Z - b.Z); }
+
+		public static bool operator ==(WPos me, WPos other) { return (me.X == other.X && me.Y == other.Y && me.Z == other.Z); }
+		public static bool operator !=(WPos me, WPos other) { return !(me == other); }
+
+		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+				return false;
+
+			WPos o = (WPos)obj;
+			return o == this;
+		}
+
+		public override string ToString() { return "{0},{1},{2}".F(X, Y, Z); }
+	}
+}

--- a/OpenRA.FileFormats/WRange.cs
+++ b/OpenRA.FileFormats/WRange.cs
@@ -1,0 +1,72 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+
+namespace OpenRA
+{
+	/// <summary>
+	/// 1d world distance - 1024 units = 1 cell.
+	/// </summary>
+	public struct WRange
+	{
+		public readonly int Range;
+
+		public WRange(int r) { Range = r; }
+		public static readonly WRange Zero = new WRange(0);
+
+		public static WRange operator +(WRange a, WRange b) { return new WRange(a.Range + b.Range); }
+		public static WRange operator -(WRange a, WRange b) { return new WRange(a.Range - b.Range); }
+		public static WRange operator -(WRange a) { return new WRange(-a.Range); }
+
+		public static bool operator ==(WRange me, WRange other) { return (me.Range == other.Range); }
+		public static bool operator !=(WRange me, WRange other) { return !(me == other); }
+
+		public static bool TryParse(string s, out WRange result)
+		{
+			s = s.ToLowerInvariant();
+			var components = s.Split('c');
+			int cell = 0;
+			int subcell = 0;
+			result = WRange.Zero;
+
+			switch (components.Length)
+			{
+			case 2:
+				if (!int.TryParse(components[0], out cell) ||
+				    !int.TryParse(components[1], out subcell))
+					return false;
+				break;
+			case 1:
+				if (!int.TryParse(components[0], out subcell))
+					return false;
+				break;
+			default: return false;
+			}
+
+			result = new WRange(1024*cell + subcell);
+			return true;
+		}
+
+		public override int GetHashCode() { return Range.GetHashCode(); }
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+				return false;
+
+			WRange o = (WRange)obj;
+			return o == this;
+		}
+
+		public override string ToString() { return "{0}".F(Range); }
+	}
+}

--- a/OpenRA.FileFormats/WRot.cs
+++ b/OpenRA.FileFormats/WRot.cs
@@ -1,0 +1,109 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+
+namespace OpenRA
+{
+	/// <summary>
+	/// 3d World rotation.
+	/// </summary>
+	public struct WRot
+	{
+		public readonly WAngle Roll, Pitch, Yaw;
+
+		public WRot(WAngle roll, WAngle pitch, WAngle yaw) { Roll = roll; Pitch = pitch; Yaw = yaw; }
+		public static readonly WRot Zero = new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero);
+
+		public static WRot FromFacing(int facing) { return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing)); }
+		public static WRot FromYaw(WAngle yaw) { return new WRot(WAngle.Zero, WAngle.Zero, yaw); }
+		public static WRot operator +(WRot a, WRot b) { return new WRot(a.Roll + b.Roll, a.Pitch + b.Pitch, a.Yaw + b.Yaw); }
+		public static WRot operator -(WRot a, WRot b) { return new WRot(a.Roll - b.Roll, a.Pitch - b.Pitch, a.Yaw - b.Yaw); }
+		public static WRot operator -(WRot a) { return new WRot(-a.Roll, -a.Pitch, -a.Yaw); }
+
+		public static bool operator ==(WRot me, WRot other) { return (me.Roll == other.Roll &&
+			me.Pitch == other.Pitch && me.Yaw == other.Yaw); }
+		public static bool operator !=(WRot me, WRot other) { return !(me == other); }
+
+		public WRot WithYaw(WAngle yaw)
+		{
+			return new WRot(Roll, Pitch, yaw);
+		}
+
+		public int[] AsQuarternion()
+		{
+			// Angles increase clockwise
+			var r = new WAngle(-Roll.Angle / 2);
+			var p = new WAngle(-Pitch.Angle / 2);
+			var y = new WAngle(-Yaw.Angle / 2);
+			var cr = (long)r.Cos();
+			var sr = (long)r.Sin();
+			var cp = (long)p.Cos();
+			var sp = (long)p.Sin();
+			var cy = (long)y.Cos();
+			var sy = (long)y.Sin();
+
+			// Normalized to 1024 == 1.0
+			return new int[4]
+			{
+				(int)((sr*cp*cy - cr*sp*sy) / 1048576), // x
+				(int)((cr*sp*cy + sr*cp*sy) / 1048576), // y
+				(int)((cr*cp*sy - sr*sp*cy) / 1048576), // z
+				(int)((cr*cp*cy + sr*sp*sy) / 1048576)  // w
+			};
+		}
+
+		public int[] AsMatrix()
+		{
+			var q = AsQuarternion();
+
+			// Theoretically 1024**2, but may differ slightly due to rounding
+			var lsq = q[0]*q[0] + q[1]*q[1] + q[2]*q[2] + q[3]*q[3];
+
+			// Quarternion components use 10 bits, so there's no risk of overflow
+			var mtx = new int[16];
+			mtx[0] = lsq - 2*(q[1]*q[1] + q[2]*q[2]);
+			mtx[1] = 2*(q[0]*q[1] + q[2]*q[3]);
+			mtx[2] = 2*(q[0]*q[2] - q[1]*q[3]);
+			mtx[3] = 0;
+
+			mtx[4] = 2*(q[0]*q[1] - q[2]*q[3]);
+			mtx[5] = lsq - 2*(q[0]*q[0] + q[2]*q[2]);
+			mtx[6] = 2*(q[1]*q[2] + q[0]*q[3]);
+			mtx[7] = 0;
+
+			mtx[8] = 2*(q[0]*q[2] + q[1]*q[3]);
+			mtx[9] = 2*(q[1]*q[2] - q[0]*q[3]);
+			mtx[10] = lsq - 2*(q[0]*q[0] + q[1]*q[1]);
+			mtx[11] = 0;
+
+			mtx[12] = 0;
+			mtx[13] = 0;
+			mtx[14] = 0;
+			mtx[15] = lsq;
+
+			return mtx;
+		}
+
+		public override int GetHashCode() { return Roll.GetHashCode() ^ Pitch.GetHashCode() ^ Yaw.GetHashCode(); }
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+				return false;
+
+			WRot o = (WRot)obj;
+			return o == this;
+		}
+
+		public override string ToString() { return "{0},{1},{2}".F(Roll, Pitch, Yaw); }
+	}
+}

--- a/OpenRA.FileFormats/WVec.cs
+++ b/OpenRA.FileFormats/WVec.cs
@@ -1,0 +1,64 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+
+namespace OpenRA
+{
+	/// <summary>
+	/// 3d World vector for describing offsets and distances - 1024 units = 1 cell.
+	/// </summary>
+	public struct WVec
+	{
+		public readonly int X, Y, Z;
+
+		public WVec(int x, int y, int z) { X = x; Y = y; Z = z; }
+		public WVec(WRange x, WRange y, WRange z) { X = x.Range; Y = y.Range; Z = z.Range; }
+
+		public static readonly WVec Zero = new WVec(0, 0, 0);
+
+		public static WVec operator +(WVec a, WVec b) { return new WVec(a.X + b.X, a.Y + b.Y, a.Z + b.Z); }
+		public static WVec operator -(WVec a, WVec b) { return new WVec(a.X - b.X, a.Y - b.Y, a.Y - b.Y); }
+		public static WVec operator -(WVec a) { return new WVec(-a.X, -a.Y, -a.Z); }
+
+		public static bool operator ==(WVec me, WVec other) { return (me.X == other.X && me.Y == other.Y && me.Z == other.Z); }
+		public static bool operator !=(WVec me, WVec other) { return !(me == other); }
+
+		public static int Dot(WVec a, WVec b) { return a.X * b.X + a.Y * b.Y + a.Z * b.Z; }
+		public int LengthSquared { get { return X * X + Y * Y + Z * Z; } }
+		public int Length { get { return (int)Math.Sqrt(LengthSquared); } }
+
+		public WVec Rotate(WRot rot)
+		{
+			var mtx = rot.AsMatrix();
+			var lx = (long)X;
+			var ly = (long)Y;
+			var lz = (long)Z;
+			return new WVec(
+				(int)((lx * mtx[0] + ly*mtx[4] + lz*mtx[8]) / mtx[15]),
+				(int)((lx * mtx[1] + ly*mtx[5] + lz*mtx[9]) / mtx[15]),
+				(int)((lx * mtx[2] + ly*mtx[6] + lz*mtx[10]) / mtx[15]));
+		}
+
+		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null)
+				return false;
+
+			WVec o = (WVec)obj;
+			return o == this;
+		}
+
+		public override string ToString() { return "{0},{1},{2}".F(X, Y, Z); }
+	}
+}

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -28,6 +28,8 @@ namespace OpenRA
 		Lazy<IOccupySpace> occupySpace;
 		IHasLocation HasLocation;
 		Lazy<IMove> Move;
+		Lazy<IFacing> Facing;
+
 		public Cached<Rectangle> Bounds;
 		public Cached<Rectangle> ExtendedBounds;
 
@@ -44,7 +46,26 @@ namespace OpenRA
 				return HasLocation.PxPosition;
 			}
 		}
-		
+
+		public WPos CenterPosition
+		{
+			get
+			{
+				var altitude = Move.Value != null ? Move.Value.Altitude : 0;
+				return CenterLocation.ToWPos(altitude);
+			}
+		}
+
+		public WRot Orientation
+		{
+			get
+			{
+				// TODO: Support non-zero pitch/roll in IFacing (IOrientation?)
+				var facing = Facing.Value != null ? Facing.Value.Facing : 0;
+				return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing));
+			}
+		}
+
 		public Shroud.ActorVisibility Sight;
 
 		[Sync] public Player Owner;
@@ -74,6 +95,7 @@ namespace OpenRA
 			}
 
 			Move = Lazy.New(() => TraitOrDefault<IMove>());
+			Facing = Lazy.New(() => TraitOrDefault<IFacing>());
 
 			Size = Lazy.New(() =>
 			{

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -211,5 +211,25 @@ namespace OpenRA.Graphics
 		{
 			palette.Update( world.WorldActor.TraitsImplementing<IPaletteModifier>() );
 		}
+
+		// Conversion between world and screen coordinates
+		public float2 ScreenPosition(WPos pos)
+		{
+			var c = Game.CellSize/1024f;
+			return new float2(c*pos.X, c*(pos.Y - pos.Z));
+		}
+
+		public int2 ScreenPxPosition(WPos pos)
+		{
+			var c = Game.CellSize/1024f;
+			return new int2((int)(c*pos.X), (int)(c*(pos.Y - pos.Z)));
+		}
+		public float ScreenZOffset(WPos pos) { return pos.Z*Game.CellSize/1024f; }
+
+		public float[] ScreenOffset(WVec vec)
+		{
+			var c = Game.CellSize/1024f;
+			return new float[] {c*vec.X, c*vec.Y, c*vec.Z};
+		}
 	}
 }

--- a/OpenRA.Game/PPos.cs
+++ b/OpenRA.Game/PPos.cs
@@ -23,6 +23,18 @@ namespace OpenRA
 		public PPos(int x, int y) { X = x; Y = y; }
 
 		public static readonly PPos Zero = new PPos(0, 0);
+		public static PPos FromWPos(WPos pos)
+		{
+			return new PPos(Game.CellSize*pos.X/1024, Game.CellSize*pos.Y/1024);
+		}
+
+		// Temporary hack for things that throw away altitude and
+		// cache screen positions directly. This can go once all
+		// the callers understand world coordinates
+		public static PPos FromWPosHackZ(WPos pos)
+		{
+			return new PPos(Game.CellSize*pos.X/1024, Game.CellSize*(pos.Y - pos.Z)/1024);
+		}
 
 		public static explicit operator PPos(int2 a) { return new PPos(a.X, a.Y); }
 
@@ -72,6 +84,13 @@ namespace OpenRA
 		{
 			return new PPos(Math.Min(r.Right, Math.Max(X, r.Left)),
 							Math.Min(r.Bottom, Math.Max(Y, r.Top)));
+		}
+
+		public WPos ToWPos(int z)
+		{
+			return new WPos(1024*X/Game.CellSize,
+			                1024*Y/Game.CellSize,
+			                1024*z/Game.CellSize);
 		}
 
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Traits
 		public bool PathDebug = false;
 		public bool UnlimitedPower;
 		public bool BuildAnywhere;
+		public bool ShowMuzzles;
 
 		public object Create (ActorInitializer init) { return new DeveloperMode(this); }
 	}
@@ -36,6 +37,9 @@ namespace OpenRA.Traits
 		[Sync] public bool UnlimitedPower;
 		[Sync] public bool BuildAnywhere;
 
+		// Client size only
+		public bool ShowMuzzles;
+
 		public DeveloperMode(DeveloperModeInfo info)
 		{
 			Info = info;
@@ -45,6 +49,7 @@ namespace OpenRA.Traits
 			PathDebug = info.PathDebug;
 			UnlimitedPower = info.UnlimitedPower;
 			BuildAnywhere = info.BuildAnywhere;
+			ShowMuzzles = info.ShowMuzzles;
 		}
 
 		public void ResolveOrder (Actor self, Order order)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -211,6 +211,11 @@ namespace OpenRA.Traits
 	public interface IPostRenderSelection { void RenderAfterWorld(WorldRenderer wr); }
 	public interface IPreRenderSelection { void RenderBeforeWorld(WorldRenderer wr, Actor self); }
 	public interface IRenderAsTerrain { IEnumerable<Renderable> RenderAsTerrain(WorldRenderer wr, Actor self); }
+	public interface ILocalCoordinatesModel
+	{
+		WVec LocalToWorld(WVec vec);
+		WRot QuantizeOrientation(Actor self, WRot orientation);
+	}
 
 	public interface ITargetable
 	{

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA
 		public readonly float LegacyRecoilRecovery = 0.2f;
 		public readonly int[] LegacyLocalOffset = { };
 
-		public readonly CoordinateModel OffsetModel = CoordinateModel.Legacy;
+		public CoordinateModel OffsetModel = CoordinateModel.Legacy;
 		[Desc("Muzzle position relative to turret or body. (forward, right, up) triples")]
 		public readonly WRange[] LocalOffset = {};
 		[Desc("Muzzle yaw relative to turret or body.")]
@@ -57,7 +57,14 @@ namespace OpenRA.Mods.RA
 		[Desc("Recoil recovery per-frame")]
 		public readonly WRange RecoilRecovery = new WRange(9);
 
-		public object Create(ActorInitializer init) { return new Armament(init.self, this); }
+		public object Create(ActorInitializer init)
+		{
+			// Auto-detect coordinate type
+			if (LocalOffset.Length > 0 && OffsetModel == CoordinateModel.Legacy)
+				OffsetModel = CoordinateModel.World;
+
+			return new Armament(init.self, this);
+		}
 	}
 
 	public class Armament : ITick

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -33,12 +33,12 @@ namespace OpenRA.Mods.RA
 		public readonly string Weapon = null;
 		public readonly string Turret = "primary";
 		[Desc("Move the turret backwards when firing.")] 
-		public readonly int Recoil = 0;
+		public readonly int LegacyRecoil = 0;
 		[Desc("Time (in frames) until the weapon can fire again.")] 
 		public readonly int FireDelay = 0;
 
-		public readonly float RecoilRecovery = 0.2f;
-		public readonly int[] LocalOffset = { };
+		public readonly float LegacyRecoilRecovery = 0.2f;
+		public readonly int[] LegacyLocalOffset = { };
 
 		public object Create(ActorInitializer init) { return new Armament(init.self, this); }
 	}
@@ -66,12 +66,12 @@ namespace OpenRA.Mods.RA
 			Burst = Weapon.Burst;
 
 			var barrels = new List<Barrel>();
-			for (var i = 0; i < info.LocalOffset.Length / 5; i++)
+			for (var i = 0; i < info.LegacyLocalOffset.Length / 5; i++)
 				barrels.Add(new Barrel
 				{
-					TurretSpaceOffset = new PVecInt(info.LocalOffset[5 * i], info.LocalOffset[5 * i + 1]),
-					ScreenSpaceOffset = new PVecInt(info.LocalOffset[5 * i + 2], info.LocalOffset[5 * i + 3]),
-					Facing = info.LocalOffset[5 * i + 4],
+					TurretSpaceOffset = new PVecInt(info.LegacyLocalOffset[5 * i], info.LegacyLocalOffset[5 * i + 1]),
+					ScreenSpaceOffset = new PVecInt(info.LegacyLocalOffset[5 * i + 2], info.LegacyLocalOffset[5 * i + 3]),
+					Facing = info.LegacyLocalOffset[5 * i + 4],
 				});
 
 			// if no barrels specified, the default is "turret position; turret facing".
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.RA
 		{
 			if (FireDelay > 0)
 				--FireDelay;
-			Recoil = Math.Max(0f, Recoil - Info.RecoilRecovery);
+			Recoil = Math.Max(0f, Recoil - Info.LegacyRecoilRecovery);
 		}
 
 		public void CheckFire(Actor self, AttackBase attack, IMove move, IFacing facing, Target target)
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.RA
 			foreach (var na in self.TraitsImplementing<INotifyAttack>())
 				na.Attacking(self, target);
 
-			Recoil = Info.Recoil;
+			Recoil = Info.LegacyRecoil;
 
 			if (--Burst > 0)
 				FireDelay = Weapon.BurstDelay;

--- a/OpenRA.Mods.RA/DebugMuzzlePositions.cs
+++ b/OpenRA.Mods.RA/DebugMuzzlePositions.cs
@@ -1,0 +1,62 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.FileFormats;
+using OpenRA.GameRules;
+using OpenRA.Graphics;
+using OpenRA.Mods.RA.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class DebugMuzzlePositionsInfo : ITraitInfo
+	{
+		public object Create(ActorInitializer init) { return new DebugFiringOffsets(init.self); }
+	}
+
+	public class DebugFiringOffsets : IPostRender
+	{
+		Lazy<IEnumerable<Armament>> armaments;
+
+		public DebugFiringOffsets(Actor self)
+		{
+			armaments = Lazy.New(() => self.TraitsImplementing<Armament>()
+				.Where(a => a.Info.OffsetModel == CoordinateModel.World));
+		}
+
+		public void RenderAfterWorld(WorldRenderer wr, Actor self)
+		{
+			if (self.World.LocalPlayer == null || !self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().ShowMuzzles)
+				return;
+
+			var wlr = Game.Renderer.WorldLineRenderer;
+			var c = Color.White;
+
+			foreach (var a in armaments.Value)
+				foreach (var b in a.Barrels)
+				{
+					var muzzle = self.CenterPosition + a.MuzzleOffset(self, b);
+					var dirOffset = new WVec(0,-224,0).Rotate(a.MuzzleOrientation(self, b));
+
+					var sm = wr.ScreenPosition(muzzle);
+					var sd = wr.ScreenPosition(muzzle + dirOffset);
+					wlr.DrawLine(sm, sd, c, c);
+					wlr.DrawLine(sm + new float2(-1, -1), sm + new float2(-1, 1), c, c);
+					wlr.DrawLine(sm + new float2(-1, 1), sm + new float2(1, 1), c, c);
+					wlr.DrawLine(sm + new float2(1, 1), sm + new float2(1, -1), c, c);
+					wlr.DrawLine(sm + new float2(1, -1), sm + new float2(-1, -1), c, c);
+				}
+		}
+	}
+}

--- a/OpenRA.Mods.RA/DebugMuzzlePositions.cs
+++ b/OpenRA.Mods.RA/DebugMuzzlePositions.cs
@@ -31,8 +31,7 @@ namespace OpenRA.Mods.RA
 
 		public DebugFiringOffsets(Actor self)
 		{
-			armaments = Lazy.New(() => self.TraitsImplementing<Armament>()
-				.Where(a => a.Info.OffsetModel == CoordinateModel.World));
+			armaments = Lazy.New(() => self.TraitsImplementing<Armament>());
 		}
 
 		public void RenderAfterWorld(WorldRenderer wr, Actor self)

--- a/OpenRA.Mods.RA/DebugMuzzlePositions.cs
+++ b/OpenRA.Mods.RA/DebugMuzzlePositions.cs
@@ -28,15 +28,19 @@ namespace OpenRA.Mods.RA
 	public class DebugFiringOffsets : IPostRender
 	{
 		Lazy<IEnumerable<Armament>> armaments;
+		DeveloperMode devMode;
 
 		public DebugFiringOffsets(Actor self)
 		{
 			armaments = Lazy.New(() => self.TraitsImplementing<Armament>());
+
+			var localPlayer = self.World.LocalPlayer;
+			devMode = localPlayer != null ? localPlayer.PlayerActor.Trait<DeveloperMode>() : null;
 		}
 
 		public void RenderAfterWorld(WorldRenderer wr, Actor self)
 		{
-			if (self.World.LocalPlayer == null || !self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().ShowMuzzles)
+			if (devMode == null || !devMode.ShowMuzzles)
 				return;
 
 			var wlr = Game.Renderer.WorldLineRenderer;

--- a/OpenRA.Mods.RA/Effects/LaserZap.cs
+++ b/OpenRA.Mods.RA/Effects/LaserZap.cs
@@ -87,9 +87,11 @@ namespace OpenRA.Mods.RA.Effects
 
 			var rc = Color.FromArgb((info.BeamDuration - ticks)*255/info.BeamDuration, color);
 
+			var src = new PPos(args.src.X, args.src.Y - args.srcAltitude);
+			var dest = new PPos(args.dest.X, args.dest.Y - args.destAltitude);
 			var wlr = Game.Renderer.WorldLineRenderer;
 			wlr.LineWidth = info.BeamRadius * 2;
-			wlr.DrawLine(args.src.ToFloat2(), args.dest.ToFloat2(), rc, rc);
+			wlr.DrawLine(src.ToFloat2(), dest.ToFloat2(), rc, rc);
 			wlr.Flush();
 			wlr.LineWidth = 1f;
 		}

--- a/OpenRA.Mods.RA/Effects/TeslaZap.cs
+++ b/OpenRA.Mods.RA/Effects/TeslaZap.cs
@@ -46,11 +46,13 @@ namespace OpenRA.Mods.RA.Effects
 			var bright = SequenceProvider.GetSequence(Info.Image, "bright");
 			var dim = SequenceProvider.GetSequence(Info.Image, "dim");
 
+			var src = new PPos(Args.src.X, Args.src.Y - Args.srcAltitude);
+			var dest = new PPos(Args.dest.X, Args.dest.Y - Args.destAltitude);
 			for (var n = 0; n < Info.DimZaps; n++)
-				foreach (var z in DrawZapWandering(wr, Args.src, Args.dest, dim))
+				foreach (var z in DrawZapWandering(wr, src, dest, dim))
 					yield return z;
 			for (var n = 0; n < Info.BrightZaps; n++)
-				foreach (var z in DrawZapWandering(wr, Args.src, Args.dest, bright))
+				foreach (var z in DrawZapWandering(wr, src, dest, bright))
 					yield return z;
 		}
 

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -420,6 +420,7 @@
     <Compile Include="FogPalette.cs" />
     <Compile Include="Infiltrates.cs" />
     <Compile Include="Armament.cs" />
+    <Compile Include="DebugMuzzlePositions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/Render/RenderBuildingSeparateTurret.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingSeparateTurret.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Render
 				anim.Play("turret");
 
 				anims.Add("turret_{0}".F(i++), new AnimationWithOffset(anim,
-					() => t.PxPosition(self, null).ToFloat2(), null));
+					() => PPos.FromWPosHackZ(WPos.Zero + t.Position(self)).ToFloat2(), null));
 			}
 		}
 	}

--- a/OpenRA.Mods.RA/Render/RenderUnitTurreted.cs
+++ b/OpenRA.Mods.RA/Render/RenderUnitTurreted.cs
@@ -43,26 +43,16 @@ namespace OpenRA.Mods.RA.Render
 
 		float2 TurretPosition(Actor self, Turreted t, IFacing facing)
 		{
-			if (t.CoordinateModel == CoordinateModel.Legacy)
-			{
-				var recoil = self.TraitsImplementing<Armament>()
-					.Where(w => w.Info.Turret == t.Name)
-					.Sum(w => w.LegacyRecoil);
-				return t.PxPosition(self, facing).ToFloat2() + Traits.Util.RotateVectorByFacing(new float2(0, recoil), t.turretFacing, .7f);
-			}
-			else
-			{
-				var recoil = self.TraitsImplementing<Armament>()
-					.Where(w => w.Info.Turret == t.Name)
-					.Aggregate(WRange.Zero, (a,b) => a + b.Recoil);
+			var recoil = self.TraitsImplementing<Armament>()
+				.Where(w => w.Info.Turret == t.Name)
+				.Aggregate(WRange.Zero, (a,b) => a + b.Recoil);
 
-				var localOffset = new WVec(-recoil, WRange.Zero, WRange.Zero);
-				var bodyOrientation = QuantizeOrientation(self, self.Orientation);
-				var turretOrientation = QuantizeOrientation(self, t.LocalOrientation(self));
-				var worldPos = WPos.Zero + t.Position(self) + LocalToWorld(localOffset.Rotate(turretOrientation).Rotate(bodyOrientation));
+			var localOffset = new WVec(-recoil, WRange.Zero, WRange.Zero);
+			var bodyOrientation = QuantizeOrientation(self, self.Orientation);
+			var turretOrientation = QuantizeOrientation(self, t.LocalOrientation(self));
+			var worldPos = WPos.Zero + t.Position(self) + LocalToWorld(localOffset.Rotate(turretOrientation).Rotate(bodyOrientation));
 
-				return PPos.FromWPosHackZ(worldPos).ToFloat2();
-			}
+			return PPos.FromWPosHackZ(worldPos).ToFloat2();
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Render/RenderUnitTurreted.cs
+++ b/OpenRA.Mods.RA/Render/RenderUnitTurreted.cs
@@ -37,19 +37,32 @@ namespace OpenRA.Mods.RA.Render
 				anim.Play("turret");
 
 				anims.Add("turret_{0}".F(i++), new AnimationWithOffset(anim,
-					() => turret.PxPosition(self, facing).ToFloat2() + RecoilOffset(self, turret), null));
+					() => TurretPosition(self, turret, facing), null));
 			}
 		}
 
-		float2 RecoilOffset(Actor self, Turreted t)
+		float2 TurretPosition(Actor self, Turreted t, IFacing facing)
 		{
-			var a = self.TraitsImplementing<Armament>()
-					.OrderByDescending(w => w.Recoil)
-					.FirstOrDefault(w => w.Info.Turret == t.info.Turret);
-			if (a == null)
-				return float2.Zero;
+			if (t.CoordinateModel == CoordinateModel.Legacy)
+			{
+				var recoil = self.TraitsImplementing<Armament>()
+					.Where(w => w.Info.Turret == t.Name)
+					.Sum(w => w.LegacyRecoil);
+				return t.PxPosition(self, facing).ToFloat2() + Traits.Util.RotateVectorByFacing(new float2(0, recoil), t.turretFacing, .7f);
+			}
+			else
+			{
+				var recoil = self.TraitsImplementing<Armament>()
+					.Where(w => w.Info.Turret == t.Name)
+					.Aggregate(WRange.Zero, (a,b) => a + b.Recoil);
 
-			return a.RecoilPxOffset(self, t.turretFacing).ToFloat2();
+				var localOffset = new WVec(-recoil, WRange.Zero, WRange.Zero);
+				var bodyOrientation = QuantizeOrientation(self, self.Orientation);
+				var turretOrientation = QuantizeOrientation(self, t.LocalOrientation(self));
+				var worldPos = WPos.Zero + t.Position(self) + LocalToWorld(localOffset.Rotate(turretOrientation).Rotate(bodyOrientation));
+
+				return PPos.FromWPosHackZ(worldPos).ToFloat2();
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA.Render
 				{
 					var barrel = b;
 					var turreted = self.TraitsImplementing<Turreted>()
-						.FirstOrDefault(t => t.info.Turret ==  a.Info.Turret);
+						.FirstOrDefault(t => t.Name ==  a.Info.Turret);
 					var getFacing = turreted != null ? () => turreted.turretFacing :
 						facing != null ? (Func<int>)(() => facing.Facing) : () => 0;
 
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Render
 
 					muzzleFlashes.Add("muzzle{0}".F(muzzleFlashes.Count), new AnimationWithOffset(
 						muzzleFlash,
-						() => a.MuzzlePxPosition(self, facing, barrel).ToFloat2(),
+						() => a.MuzzlePxOffset(self, facing, barrel).ToFloat2(),
 						() => !isShowing));
 				}
 		}

--- a/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Render
 
 					muzzleFlashes.Add("muzzle{0}".F(muzzleFlashes.Count), new AnimationWithOffset(
 						muzzleFlash,
-						() => a.MuzzlePxOffset(self, facing, barrel).ToFloat2(),
+						() => PPos.FromWPosHackZ(WPos.Zero + a.MuzzleOffset(self, barrel)).ToFloat2(),
 						() => !isShowing));
 				}
 		}

--- a/OpenRA.Mods.RA/TakeCover.cs
+++ b/OpenRA.Mods.RA/TakeCover.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.RA
 		{
 			base.Tick(self);
 			if (IsProne && --remainingProneTime == 0)
-				turret = new Turret(Info.Offset);
+				turret = new Turret(Info.LegacyOffset);
 		}
 
 		public float GetDamageModifier(Actor attacker, WarheadInfo warhead )

--- a/OpenRA.Mods.RA/TakeCover.cs
+++ b/OpenRA.Mods.RA/TakeCover.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.RA
 		public readonly int ProneTime = 100;	/* ticks, =4s */
 		public readonly float ProneDamage = .5f;
 		public readonly decimal ProneSpeed = .5m;
-		public readonly int[] ProneOffset = {0,-2,0,4};
+		public readonly int[] LegacyProneOffset = {0,-2,0,4};
+		public readonly WVec ProneOffset = new WVec(85, 0, -171);
 
 		public override object Create(ActorInitializer init) { return new TakeCover(init, this); }
 	}
@@ -43,7 +44,10 @@ namespace OpenRA.Mods.RA
 			if (e.Damage > 0 && (e.Warhead == null || !e.Warhead.PreventProne)) /* Don't go prone when healed */
 			{
 				if (!IsProne)
-					turret = new Turret(Info.ProneOffset);
+				{
+					turret = new Turret(Info.LegacyProneOffset);
+					LocalOffset = Info.ProneOffset;
+				}
 				remainingProneTime = Info.ProneTime;
 			}
 		}
@@ -52,7 +56,10 @@ namespace OpenRA.Mods.RA
 		{
 			base.Tick(self);
 			if (IsProne && --remainingProneTime == 0)
+			{
 				turret = new Turret(Info.LegacyOffset);
+				LocalOffset = WVec.Zero;
+			}
 		}
 
 		public float GetDamageModifier(Actor attacker, WarheadInfo warhead )

--- a/OpenRA.Mods.RA/TakeCover.cs
+++ b/OpenRA.Mods.RA/TakeCover.cs
@@ -19,7 +19,6 @@ namespace OpenRA.Mods.RA
 		public readonly int ProneTime = 100;	/* ticks, =4s */
 		public readonly float ProneDamage = .5f;
 		public readonly decimal ProneSpeed = .5m;
-		public readonly int[] LegacyProneOffset = {0,-2,0,4};
 		public readonly WVec ProneOffset = new WVec(85, 0, -171);
 
 		public override object Create(ActorInitializer init) { return new TakeCover(init, this); }
@@ -44,10 +43,8 @@ namespace OpenRA.Mods.RA
 			if (e.Damage > 0 && (e.Warhead == null || !e.Warhead.PreventProne)) /* Don't go prone when healed */
 			{
 				if (!IsProne)
-				{
-					turret = new Turret(Info.LegacyProneOffset);
 					LocalOffset = Info.ProneOffset;
-				}
+
 				remainingProneTime = Info.ProneTime;
 			}
 		}
@@ -56,10 +53,7 @@ namespace OpenRA.Mods.RA
 		{
 			base.Tick(self);
 			if (IsProne && --remainingProneTime == 0)
-			{
-				turret = new Turret(Info.LegacyOffset);
 				LocalOffset = WVec.Zero;
-			}
 		}
 
 		public float GetDamageModifier(Actor attacker, WarheadInfo warhead )

--- a/OpenRA.Mods.RA/Turreted.cs
+++ b/OpenRA.Mods.RA/Turreted.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Mods.RA.Render;
 using OpenRA.FileFormats;
@@ -24,6 +25,10 @@ namespace OpenRA.Mods.RA
 		public readonly int[] LegacyOffset = {0,0};
 		public readonly bool AlignWhenIdle = false;
 
+		public readonly CoordinateModel OffsetModel = CoordinateModel.Legacy;
+		[Desc("Muzzle position relative to turret or body. (forward, right, up) triples")]
+		public readonly WVec Offset = WVec.Zero;
+
 		public virtual object Create(ActorInitializer init) { return new Turreted(init, this); }
 	}
 
@@ -31,9 +36,16 @@ namespace OpenRA.Mods.RA
 	{
 		[Sync] public int turretFacing = 0;
 		public int? desiredFacing;
-		public TurretedInfo info;
+		TurretedInfo info;
 		protected Turret turret;
 		IFacing facing;
+
+		// For subclasses that want to move the turret relative to the body
+		protected WVec LocalOffset = WVec.Zero;
+
+		public WVec Offset { get { return info.Offset + LocalOffset; } }
+		public string Name { get { return info.Turret; } }
+		public CoordinateModel CoordinateModel { get { return info.OffsetModel; } }
 
 		public static int GetInitialTurretFacing(ActorInitializer init, int def)
 		{
@@ -62,7 +74,7 @@ namespace OpenRA.Mods.RA
 
 		public bool FaceTarget(Actor self, Target target)
 		{
-			desiredFacing = Util.GetFacing( target.CenterLocation - self.CenterLocation, turretFacing );
+			desiredFacing = Util.GetFacing(target.CenterLocation - self.CenterLocation, turretFacing);
 			return turretFacing == desiredFacing;
 		}
 
@@ -74,7 +86,29 @@ namespace OpenRA.Mods.RA
 
 		public PVecFloat PxPosition(Actor self, IFacing facing)
 		{
+			// Hack for external code unaware of world coordinates
+			if (info.OffsetModel == CoordinateModel.World)
+				return (PVecFloat)PPos.FromWPosHackZ(WPos.Zero + Position(self)).ToFloat2();
+
 			return turret.PxPosition(self, facing);
+		}
+
+		// Turret offset in world-space
+		public WVec Position(Actor self)
+		{
+			if (info.OffsetModel != CoordinateModel.World)
+				throw new InvalidOperationException("Turreted.Position requires a world coordinate offset");
+
+			var coords = self.Trait<ILocalCoordinatesModel>();
+			var bodyOrientation = coords.QuantizeOrientation(self, self.Orientation);
+			return coords.LocalToWorld(Offset.Rotate(bodyOrientation));
+		}
+
+		// Orientation in unit-space
+		public WRot LocalOrientation(Actor self)
+		{
+			// Hack: turretFacing is relative to the world, so subtract the body yaw
+			return WRot.FromYaw(WAngle.FromFacing(turretFacing) - self.Orientation.Yaw);
 		}
 	}
 

--- a/OpenRA.Mods.RA/Turreted.cs
+++ b/OpenRA.Mods.RA/Turreted.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA
 		[Desc("Rate of Turning")]
 		public readonly int ROT = 255;
 		public readonly int InitialFacing = 128;
-		public readonly int[] Offset = {0,0};
+		public readonly int[] LegacyOffset = {0,0};
 		public readonly bool AlignWhenIdle = false;
 
 		public virtual object Create(ActorInitializer init) { return new Turreted(init, this); }
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.RA
 			this.info = info;
 			turretFacing = GetInitialTurretFacing(init, info.InitialFacing);
 			facing = init.self.TraitOrDefault<IFacing>();
-			turret = new Turret(info.Offset);
+			turret = new Turret(info.LegacyOffset);
 		}
 
 		public virtual void Tick(Actor self)

--- a/OpenRA.Mods.RA/Widgets/Logic/CheatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/CheatsLogic.cs
@@ -41,6 +41,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			fastChargeCheckbox.IsChecked = () => devTrait.FastCharge;
 			fastChargeCheckbox.OnClick = () => Order(world, "DevFastCharge");
 
+			var showMuzzlesCheckbox = widget.Get<CheckboxWidget>("SHOW_MUZZLES");
+			showMuzzlesCheckbox.IsChecked = () => devTrait.ShowMuzzles;
+			showMuzzlesCheckbox.OnClick = () => devTrait.ShowMuzzles ^= true;
+
 			var allTechCheckbox = widget.Get<CheckboxWidget>("ENABLE_TECH");
 			allTechCheckbox.IsChecked = () => devTrait.AllTech;
 			allTechCheckbox.OnClick = () => Order(world, "DevEnableTech");

--- a/mods/cnc-classic/rules/aircraft.yaml
+++ b/mods/cnc-classic/rules/aircraft.yaml
@@ -65,7 +65,7 @@ HELI:
 		Range: 8
 	Armament:
 		Weapon: HeliAGGun
-		LocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
+		LegacyLocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:
@@ -107,7 +107,7 @@ ORCA:
 		Range: 8
 	Armament:
 		Weapon: OrcaAGMissiles
-		LocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
+		LegacyLocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:

--- a/mods/cnc-classic/rules/aircraft.yaml
+++ b/mods/cnc-classic/rules/aircraft.yaml
@@ -65,7 +65,7 @@ HELI:
 		Range: 8
 	Armament:
 		Weapon: HeliAGGun
-		LegacyLocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
+		LocalOffset: 128,-213,-85, 128,213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:
@@ -107,7 +107,7 @@ ORCA:
 		Range: 8
 	Armament:
 		Weapon: OrcaAGMissiles
-		LegacyLocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
+		LocalOffset: 427,-171,-213, 427,171,-213
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:

--- a/mods/cnc-classic/rules/defaults.yaml
+++ b/mods/cnc-classic/rules/defaults.yaml
@@ -114,7 +114,7 @@
 	Buildable:
 		Queue: Infantry
 	TakeCover:
-		BarrelOffset: 0,-2,0,4
+		LegacyOffset: 0,-2,0,4
 	RenderInfantryProne:
 	AttackMove:
 	Passenger:

--- a/mods/cnc-classic/rules/defaults.yaml
+++ b/mods/cnc-classic/rules/defaults.yaml
@@ -117,7 +117,6 @@
 	Buildable:
 		Queue: Infantry
 	TakeCover:
-		LegacyOffset: 0,-2,0,4
 	RenderInfantryProne:
 	AttackMove:
 	Passenger:

--- a/mods/cnc-classic/rules/defaults.yaml
+++ b/mods/cnc-classic/rules/defaults.yaml
@@ -31,6 +31,7 @@
 	WithSmoke:
 	Explodes:
 		Weapon: UnitExplodeSmall
+	DebugMuzzlePositions:
 
 ^Tank:
 	AppearsOnRadar:
@@ -64,6 +65,7 @@
 	WithSmoke:
 	Explodes:
 		Weapon: UnitExplodeSmall
+	DebugMuzzlePositions:
 
 ^Helicopter:
 	AppearsOnRadar:
@@ -81,6 +83,7 @@
 		Queue: Aircraft
 	ActorLostNotification:
 		Notification: unitlost.aud
+	DebugMuzzlePositions:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -127,6 +130,7 @@
 	CrushableInfantry:
 	DetectCloaked:
 		Range: 1
+	DebugMuzzlePositions:
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -173,6 +177,7 @@
 		TargetTypes: Air
 	ActorLostNotification:
 		Notification: unitlost.aud
+	DebugMuzzlePositions:
 
 ^Ship:
 	AppearsOnRadar:
@@ -188,6 +193,7 @@
 	ActorLostNotification:
 		Notification: unitlost.aud
 	AttackMove:
+	DebugMuzzlePositions:
 
 ^Building:
 	AppearsOnRadar:
@@ -236,6 +242,7 @@
 	Capturable:
 		CaptureCompleteTime: 0
 	CapturableBar:
+	DebugMuzzlePositions:
 
 ^CivBuilding:
 	Inherits: ^Building

--- a/mods/cnc-classic/rules/infantry.yaml
+++ b/mods/cnc-classic/rules/infantry.yaml
@@ -41,7 +41,7 @@ E2:
 		HP: 50
 	Armament:
 		Weapon: Grenade
-		LegacyLocalOffset: 0,0,0,-10,0
+		LocalOffset: 0,0,427
 		FireDelay: 15
 	AttackFrontal:
 	RenderInfantryProne:
@@ -81,7 +81,7 @@ E3:
 	# range value is 1 in C&C, but OpenRA renders vision slightly differently
 	Armament:
 		Weapon: Rockets
-		LegacyLocalOffset: 1,-6,0,-8,0
+		LocalOffset: 256,43,341
 		FireDelay: 5
 	AttackFrontal:
 	RenderInfantryProne:
@@ -107,7 +107,7 @@ E4:
 		HP: 70
 	Armament:
 		Weapon: Flamethrower
-		LegacyLocalOffset: 0,-2,2,-4,0
+		LocalOffset: 85,0,171
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:
@@ -140,7 +140,7 @@ E5:
 		HP: 70
 	Armament:
 		Weapon: Chemspray
-		LegacyLocalOffset: 0,-2,2,-9
+		LocalOffset: 85,0,384
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:

--- a/mods/cnc-classic/rules/infantry.yaml
+++ b/mods/cnc-classic/rules/infantry.yaml
@@ -41,7 +41,7 @@ E2:
 		HP: 50
 	Armament:
 		Weapon: Grenade
-		LocalOffset: 0,0,0,-10,0
+		LegacyLocalOffset: 0,0,0,-10,0
 		FireDelay: 15
 	AttackFrontal:
 	RenderInfantryProne:
@@ -81,7 +81,7 @@ E3:
 	# range value is 1 in C&C, but OpenRA renders vision slightly differently
 	Armament:
 		Weapon: Rockets
-		LocalOffset: 1,-6,0,-8,0
+		LegacyLocalOffset: 1,-6,0,-8,0
 		FireDelay: 5
 	AttackFrontal:
 	RenderInfantryProne:
@@ -107,7 +107,7 @@ E4:
 		HP: 70
 	Armament:
 		Weapon: Flamethrower
-		LocalOffset: 0,-2,2,-4,0
+		LegacyLocalOffset: 0,-2,2,-4,0
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:
@@ -140,7 +140,7 @@ E5:
 		HP: 70
 	Armament:
 		Weapon: Chemspray
-		LocalOffset: 0,-2,2,-9
+		LegacyLocalOffset: 0,-2,2,-9
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:

--- a/mods/cnc-classic/rules/ships.yaml
+++ b/mods/cnc-classic/rules/ships.yaml
@@ -18,10 +18,10 @@ BOAT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		LegacyOffset: 0,-15,0,-4
+		Offset: 640,0,171
 	Armament:
 		Weapon: BoatMissile
-		LegacyLocalOffset: -3,-5,0,0,0, 3,-5,0,0,0, 0,-5,0,0,0
+		LocalOffset: 213,-180,0, 213,128,0, 213,0,0
 	AttackTurreted:
 	RenderGunboat:
 	AutoTarget:

--- a/mods/cnc-classic/rules/ships.yaml
+++ b/mods/cnc-classic/rules/ships.yaml
@@ -18,10 +18,10 @@ BOAT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		Offset: 0,-15,0,-4
+		LegacyOffset: 0,-15,0,-4
 	Armament:
 		Weapon: BoatMissile
-		LocalOffset: -3,-5,0,0,0, 3,-5,0,0,0, 0,-5,0,0,0
+		LegacyLocalOffset: -3,-5,0,0,0, 3,-5,0,0,0, 0,-5,0,0,0
 	AttackTurreted:
 	RenderGunboat:
 	AutoTarget:

--- a/mods/cnc-classic/rules/structures.yaml
+++ b/mods/cnc-classic/rules/structures.yaml
@@ -556,11 +556,12 @@ OBLI:
 	# (Range of Obelisk laser is 7.5)
 	RenderBuildingCharge:
 		ChargeAudio: obelpowr.aud
+		QuantizedFacings: 8
 	Turreted:
 		ROT:255
-		LegacyOffset: 0,0,-2,-17
 	Armament:
 		Weapon: Laser
+		LocalOffset: 0,0,725
 		FireDelay: 8
 	AttackTurreted:
 	AutoTarget:
@@ -666,7 +667,7 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
-		LegacyLocalOffset: 0,4,0,-2,0
+		LocalOffset: -71,0,85
 	AttackTurreted:
 	AutoTarget:
 	-AutoTargetIgnore:
@@ -741,9 +742,11 @@ GTWR:
 	# RevealShroud range was set to equal 1 + its weapon range (due to possible rendering issues with shroud for OpenRA)
 	Armament:
 		Weapon: HighV
-		LegacyLocalOffset: 0,-6,0,0,0
+		LocalOffset: 256,0,256
 	AttackTurreted:
 	AutoTarget:
+	RenderBuilding:
+		QuantizedFacings: 8
 	-AutoTargetIgnore:
 	DetectCloaked:
 		Range: 3
@@ -752,7 +755,6 @@ GTWR:
 	WithMuzzleFlash:
 	Turreted:
 		ROT:255
-		LegacyOffset: 0,0,0,-6
 
 ATWR:
 	Inherits: ^Building
@@ -783,12 +785,14 @@ ATWR:
 	# RevealShroud range was set to equal its weapon range +1 (due to possible rendering issues with shroud for OpenRA)
 	Turreted:
 		ROT:255
-		LegacyOffset: 0,0,5,2
 	Armament:
 		Weapon: TowerMissle
-		LegacyLocalOffset: 7,-7,0,0,-25, -7,-7,0,0,25
+		LocalOffset: 299,299,-85, 299,-299,-85
+		LocalYaw: -100,100
 	AttackTurreted:
 	AutoTarget:
+	RenderBuilding:
+		QuantizedFacings: 8
 	-AutoTargetIgnore:
 	DetectCloaked:
 		Range: 4

--- a/mods/cnc-classic/rules/structures.yaml
+++ b/mods/cnc-classic/rules/structures.yaml
@@ -558,7 +558,7 @@ OBLI:
 		ChargeAudio: obelpowr.aud
 	Turreted:
 		ROT:255
-		Offset: 0,0,-2,-17
+		LegacyOffset: 0,0,-2,-17
 	Armament:
 		Weapon: Laser
 		FireDelay: 8
@@ -666,7 +666,7 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
-		LocalOffset: 0,4,0,-2,0
+		LegacyLocalOffset: 0,4,0,-2,0
 	AttackTurreted:
 	AutoTarget:
 	-AutoTargetIgnore:
@@ -741,7 +741,7 @@ GTWR:
 	# RevealShroud range was set to equal 1 + its weapon range (due to possible rendering issues with shroud for OpenRA)
 	Armament:
 		Weapon: HighV
-		LocalOffset: 0,-6,0,0,0
+		LegacyLocalOffset: 0,-6,0,0,0
 	AttackTurreted:
 	AutoTarget:
 	-AutoTargetIgnore:
@@ -752,7 +752,7 @@ GTWR:
 	WithMuzzleFlash:
 	Turreted:
 		ROT:255
-		Offset: 0,0,0,-6
+		LegacyOffset: 0,0,0,-6
 
 ATWR:
 	Inherits: ^Building
@@ -783,10 +783,10 @@ ATWR:
 	# RevealShroud range was set to equal its weapon range +1 (due to possible rendering issues with shroud for OpenRA)
 	Turreted:
 		ROT:255
-		Offset: 0,0,5,2
+		LegacyOffset: 0,0,5,2
 	Armament:
 		Weapon: TowerMissle
-		LocalOffset: 7,-7,0,0,-25, -7,-7,0,0,25
+		LegacyLocalOffset: 7,-7,0,0,-25, -7,-7,0,0,25
 	AttackTurreted:
 	AutoTarget:
 	-AutoTargetIgnore:

--- a/mods/cnc-classic/rules/vehicles.yaml
+++ b/mods/cnc-classic/rules/vehicles.yaml
@@ -102,7 +102,6 @@ JEEP:
 		Offset: -85,0,171
 	Armament:
 		Weapon: MachineGun
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -135,7 +134,6 @@ APC:
 		ROT: 10
 	Armament:
 		Weapon: MachineGun
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -174,7 +172,6 @@ BGGY:
 		Offset: -43,0,128
 	Armament:
 		Weapon: MachineGun
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:

--- a/mods/cnc-classic/rules/vehicles.yaml
+++ b/mods/cnc-classic/rules/vehicles.yaml
@@ -99,7 +99,7 @@ JEEP:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 10
-		Offset: 0,2,0,-4
+		LegacyOffset: 0,2,0,-4
 	Armament:
 		Weapon: MachineGun
 	AttackTurreted:
@@ -169,7 +169,7 @@ BGGY:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 10
-		Offset: 0,1,0,-3
+		LegacyOffset: 0,1,0,-3
 	Armament:
 		Weapon: MachineGun
 	AttackTurreted:
@@ -202,7 +202,7 @@ BIKE:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Armament:
 		Weapon: BikeRockets
-		LocalOffset: -4,0,0,-2,25, 4,0,0,-2,-25
+		LegacyLocalOffset: -4,0,0,-2,25, 4,0,0,-2,-25
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -232,7 +232,7 @@ ARTY:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Armament:
 		Weapon: ArtilleryShell
-		LocalOffset: 0,-7,0,-3,0
+		LegacyLocalOffset: 0,-7,0,-3,0
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -265,7 +265,7 @@ FTNK:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Armament:
 		Weapon: BigFlamer
-		LocalOffset: 2,-5,3,2,0, -2,-5,3,2,0
+		LegacyLocalOffset: 2,-5,3,2,0, -2,-5,3,2,0
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -300,9 +300,9 @@ LTNK:
 		ROT: 5
 	Armament:
 		Weapon: 70mm
-		Recoil: 2
-		RecoilRecovery: 0.4
-		LocalOffset: 0,3,0,-2,0
+		LegacyRecoil: 2
+		LegacyRecoilRecovery: 0.4
+		LegacyLocalOffset: 0,3,0,-2,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -334,9 +334,9 @@ MTNK:
 	Armament:
 	#	Weapon: 120mm
 		Weapon: 105mm
-		Recoil: 3
-		RecoilRecovery: 0.6
-		LocalOffset: 0,0,0,-1,0
+		LegacyRecoil: 3
+		LegacyRecoilRecovery: 0.6
+		LegacyLocalOffset: 0,0,0,-1,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -370,13 +370,13 @@ HTNK:
 		ROT: 2
 	Armament@PRIMARY:
 		Weapon: 120mmDual
-		LocalOffset: -5,-5,0,-10,0, 5,-5,0,-10,0
-		Recoil: 4
-		RecoilRecovery: 1
+		LegacyLocalOffset: -5,-5,0,-10,0, 5,-5,0,-10,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 1
 	Armament@SECONDARY:
 		Weapon: MammothMissiles
-		LocalOffset: -9,2,0,0,25, 9,2,0,0,-25
-		Recoil: 1
+		LegacyLocalOffset: -9,2,0,0,25, 9,2,0,0,-25
+		LegacyRecoil: 1
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -412,10 +412,10 @@ MSAM:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 255
-		Offset: 0,6,0,-3
+		LegacyOffset: 0,6,0,-3
 	Armament:
 		Weapon: 227mm
-		LocalOffset: 3,-5,0,0,0, -3,-5,0,0,0
+		LegacyLocalOffset: 3,-5,0,0,0, -3,-5,0,0,0
 	AttackFrontal:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -446,14 +446,14 @@ MLRS:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 5
-		Offset: 0,3,0,-3
+		LegacyOffset: 0,3,0,-3
 	#	AlignWhenIdle: true
 	Armament@PRIMARY:
 		Weapon: HonestJohn
-		LocalOffset: -4,0,0,0,0
+		LegacyLocalOffset: -4,0,0,0,0
 	Armament@SECONDARY:
 		Weapon: HonestJohn
-		LocalOffset: 4,0,0,0,0
+		LegacyLocalOffset: 4,0,0,0,0
 	AttackFrontal:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -490,7 +490,7 @@ STNK:
 		UncloakSound: appear1.aud
 	Armament:
 		Weapon: 227mm.stnk
-		LocalOffset: 1,-5,0,-3,0, -1,-5,0,-3,0
+		LegacyLocalOffset: 1,-5,0,-3,0, -1,-5,0,-3,0
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:

--- a/mods/cnc-classic/rules/vehicles.yaml
+++ b/mods/cnc-classic/rules/vehicles.yaml
@@ -99,9 +99,10 @@ JEEP:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 10
-		LegacyOffset: 0,2,0,-4
+		Offset: -85,0,171
 	Armament:
 		Weapon: MachineGun
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -134,6 +135,7 @@ APC:
 		ROT: 10
 	Armament:
 		Weapon: MachineGun
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -169,9 +171,10 @@ BGGY:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 10
-		LegacyOffset: 0,1,0,-3
+		Offset: -43,0,128
 	Armament:
 		Weapon: MachineGun
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -202,7 +205,8 @@ BIKE:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Armament:
 		Weapon: BikeRockets
-		LegacyLocalOffset: -4,0,0,-2,25, 4,0,0,-2,-25
+		LocalOffset: -128, -170, 170, -128, 170, 170
+		LocalYaw: 100, -100
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -232,7 +236,7 @@ ARTY:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Armament:
 		Weapon: ArtilleryShell
-		LegacyLocalOffset: 0,-7,0,-3,0
+		LocalOffset: 299, 0, 128
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -265,7 +269,7 @@ FTNK:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Armament:
 		Weapon: BigFlamer
-		LegacyLocalOffset: 2,-5,3,2,0, -2,-5,3,2,0
+		LocalOffset: 213,213,-85, 213,-213,-85
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -300,9 +304,9 @@ LTNK:
 		ROT: 5
 	Armament:
 		Weapon: 70mm
-		LegacyRecoil: 2
-		LegacyRecoilRecovery: 0.4
-		LegacyLocalOffset: 0,3,0,-2,0
+		Recoil: 85
+		RecoilRecovery: 17
+		LocalOffset: -128,0,85
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -334,9 +338,9 @@ MTNK:
 	Armament:
 	#	Weapon: 120mm
 		Weapon: 105mm
-		LegacyRecoil: 3
-		LegacyRecoilRecovery: 0.6
-		LegacyLocalOffset: 0,0,0,-1,0
+		Recoil: 128
+		RecoilRecovery: 26
+		LocalOffset: 0,0,43
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -370,13 +374,14 @@ HTNK:
 		ROT: 2
 	Armament@PRIMARY:
 		Weapon: 120mmDual
-		LegacyLocalOffset: -5,-5,0,-10,0, 5,-5,0,-10,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 1
+		LocalOffset: 800, 180, 340, 800, -180, 340
+		Recoil: 170
+		RecoilRecovery: 42
 	Armament@SECONDARY:
 		Weapon: MammothMissiles
-		LegacyLocalOffset: -9,2,0,0,25, 9,2,0,0,-25
-		LegacyRecoil: 1
+		LocalOffset: -85, 384, 340, -85, -384, 340
+		LocalYaw: -100, 100
+		Recoil: 42
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -412,10 +417,10 @@ MSAM:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 255
-		LegacyOffset: 0,6,0,-3
+		Offset: -256,0,128
 	Armament:
 		Weapon: 227mm
-		LegacyLocalOffset: 3,-5,0,0,0, -3,-5,0,0,0
+		LocalOffset: 213,128,0, 213,-128,0
 	AttackFrontal:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -446,14 +451,14 @@ MLRS:
 	# In practice, it seems that OpenRA renders vision range differently. Will set at +2 from C&C Gold values for now to properly emulate.
 	Turreted:
 		ROT: 5
-		LegacyOffset: 0,3,0,-3
+		Offset: -128,0,128
 	#	AlignWhenIdle: true
 	Armament@PRIMARY:
 		Weapon: HonestJohn
-		LegacyLocalOffset: -4,0,0,0,0
+		LocalOffset: 0,-171,0
 	Armament@SECONDARY:
 		Weapon: HonestJohn
-		LegacyLocalOffset: 4,0,0,0,0
+		LocalOffset:0,171,0
 	AttackFrontal:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -490,7 +495,7 @@ STNK:
 		UncloakSound: appear1.aud
 	Armament:
 		Weapon: 227mm.stnk
-		LegacyLocalOffset: 1,-5,0,-3,0, -1,-5,0,-3,0
+		LocalOffset: 213,43,128, 213,-43,128
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:

--- a/mods/cnc/chrome/cheats.yaml
+++ b/mods/cnc/chrome/cheats.yaml
@@ -46,7 +46,13 @@ Container@CHEATS_PANEL:
 					Y:45
 					Width:200
 					Height:20
-					Text:Instant Charge Time				
+					Text:Instant Charge Time
+				Checkbox@SHOW_MUZZLES:
+					X:200
+					Y:75
+					Height:20
+					Width:200
+					Text:Show Muzzle Positions
 				Checkbox@DISABLE_SHROUD:
 					X:400
 					Y:15

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -70,10 +70,10 @@ HELI:
 		Range: 8
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
-		LegacyLocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
+		LocalOffset: 128,-213,-85, 128,213,-85
 	Armament@SECONDARY:
 		Weapon: HeliAGGun
-		LegacyLocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
+		LocalOffset: 128,-213,-85, 128,213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:
@@ -123,10 +123,10 @@ ORCA:
 		Range: 8
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
-		LegacyLocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
+		LocalOffset: 427,-171,-213, 427,171,-213
 	Armament@SECONDARY:
 		Weapon: OrcaAAMissiles
-		LegacyLocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
+		LocalOffset: 427,-171,-213, 427,171,-213
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -70,10 +70,10 @@ HELI:
 		Range: 8
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
-		LocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
+		LegacyLocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
 	Armament@SECONDARY:
 		Weapon: HeliAGGun
-		LocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
+		LegacyLocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:
@@ -123,10 +123,10 @@ ORCA:
 		Range: 8
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
-		LocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
+		LegacyLocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
 	Armament@SECONDARY:
 		Weapon: OrcaAAMissiles
-		LocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
+		LegacyLocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -31,6 +31,7 @@
 	AttackMove:
 	AcceptsCloakCrate:
 	WithSmoke:
+	DebugMuzzlePositions:
 
 ^Tank:
 	AppearsOnRadar:
@@ -68,6 +69,7 @@
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
+	DebugMuzzlePositions:
 
 ^Helicopter:
 	AppearsOnRadar:
@@ -93,6 +95,7 @@
 	Explodes:
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode
+	DebugMuzzlePositions:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -143,6 +146,7 @@
 	RepairableNear:
 		Buildings: hosp
 		CloseEnough: 1
+	DebugMuzzlePositions:
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -193,6 +197,7 @@
 	DrawLineToTarget:
 	ActorLostNotification:
 		Notification: unitlost.aud
+	DebugMuzzlePositions:
 
 ^Ship:
 	AppearsOnRadar:
@@ -212,6 +217,7 @@
 	ActorLostNotification:
 		Notification: unitlost.aud
 	AttackMove:
+	DebugMuzzlePositions:
 
 ^Building:
 	AppearsOnRadar:
@@ -260,6 +266,7 @@
 	Capturable:
 	CapturableBar:
 	C4Demolishable:
+	DebugMuzzlePositions:
 
 ^CivBuilding:
 	Inherits: ^Building

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -126,7 +126,6 @@
 	Buildable:
 		Queue: Infantry
 	TakeCover:
-		ProneOffset: 0,-2,0,4
 	RenderInfantryProne:
 	AttackMove:
 	Passenger:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -43,7 +43,7 @@ E2:
 		HP: 50
 	Armament:
 		Weapon: Grenade
-		LocalOffset: 0,0,0,-10,0
+		LegacyLocalOffset: 0,0,0,-10,0
 		FireDelay: 15
 	AttackFrontal:
 	RenderInfantryProne:
@@ -74,7 +74,7 @@ E3:
 		HP: 45
 	Armament:
 		Weapon: Rockets
-		LocalOffset: 1,-6,0,-8,0
+		LegacyLocalOffset: 1,-6,0,-8,0
 		FireDelay: 5
 	AttackFrontal:
 	RenderInfantryProne:
@@ -102,7 +102,7 @@ E4:
 		HP: 90
 	Armament:
 		Weapon: Flamethrower
-		LocalOffset: 0,-2,2,-4,0
+		LegacyLocalOffset: 0,-2,2,-4,0
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:
@@ -136,7 +136,7 @@ E5:
 		HP: 90
 	Armament:
 		Weapon: Chemspray
-		LocalOffset: 0,-2,2,-9,0
+		LegacyLocalOffset: 0,-2,2,-9,0
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -43,7 +43,7 @@ E2:
 		HP: 50
 	Armament:
 		Weapon: Grenade
-		LegacyLocalOffset: 0,0,0,-10,0
+		LocalOffset: 0,0,427
 		FireDelay: 15
 	AttackFrontal:
 	RenderInfantryProne:
@@ -74,7 +74,7 @@ E3:
 		HP: 45
 	Armament:
 		Weapon: Rockets
-		LegacyLocalOffset: 1,-6,0,-8,0
+		LocalOffset: 256,43,341
 		FireDelay: 5
 	AttackFrontal:
 	RenderInfantryProne:
@@ -102,7 +102,7 @@ E4:
 		HP: 90
 	Armament:
 		Weapon: Flamethrower
-		LegacyLocalOffset: 0,-2,2,-4,0
+		LocalOffset: 85,0,171
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:
@@ -136,7 +136,7 @@ E5:
 		HP: 90
 	Armament:
 		Weapon: Chemspray
-		LegacyLocalOffset: 0,-2,2,-9,0
+		LocalOffset: 85,0,384
 		FireDelay: 3
 	AttackFrontal:
 	WithMuzzleFlash:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -18,10 +18,10 @@ BOAT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		Offset: 0,-15,0,-4
+		LocalOffset: 0,-15,0,-4
 	Armament:
 		Weapon: BoatMissile
-		LocalOffset: -3,-5,0,0,0, 3,-5,0,0,0, 0,-5,0,0,0
+		LegacyLocalOffset: -3,-5,0,0,0, 3,-5,0,0,0, 0,-5,0,0,0
 	AttackTurreted:
 	RenderGunboat:
 	AutoTarget:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -18,10 +18,10 @@ BOAT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		LocalOffset: 0,-15,0,-4
+		Offset: 640,0,171
 	Armament:
 		Weapon: BoatMissile
-		LegacyLocalOffset: -3,-5,0,0,0, 3,-5,0,0,0, 0,-5,0,0,0
+		LocalOffset: 213,-180,0, 213,128,0, 213,0,0
 	AttackTurreted:
 	RenderGunboat:
 	AutoTarget:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -512,7 +512,7 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
-		LegacyLocalOffset: 0,4,0,-2,0
+		LocalOffset: -71,0,85
 	AttackTurreted:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
@@ -593,12 +593,14 @@ OBLI:
 		ChargeAudio: obelpowr.aud
 	Armament:
 		Weapon: Laser
-		LegacyLocalOffset: 0,0,-2,-17,0
+		LocalOffset: 0,0,725
 		FireDelay: 8
 	AttackTurreted:
 	Turreted:
 		ROT:255
 	AutoTarget:
+	RenderBuilding:
+		QuantizedFacings: 8
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
 	-AutoTargetIgnore:
@@ -631,8 +633,10 @@ GTWR:
 		Range: 7
 	Armament:
 		Weapon: HighV
-		LegacyLocalOffset: 0,-6,0,-6,0
+		LocalOffset: 256,0,256
 	AttackTurreted:
+	RenderBuilding:
+		QuantizedFacings: 8
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
@@ -670,13 +674,16 @@ ATWR:
 		Type: Heavy
 	RevealsShroud:
 		Range: 9
-	Armament:
-		Weapon: TowerMissle
-		LegacyLocalOffset: 7,-7,5,2,-25, -7,-7,5,2,25
-	AttackTurreted:
 	Turreted:
 		ROT:255
+	Armament:
+		Weapon: TowerMissle
+		LocalOffset: 299,299,-85, 299,-299,-85
+		LocalYaw: -100,100
+	AttackTurreted:
 	AutoTarget:
+	RenderBuilding:
+		QuantizedFacings: 8
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
 	-AutoTargetIgnore:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -512,7 +512,7 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
-		LocalOffset: 0,4,0,-2,0
+		LegacyLocalOffset: 0,4,0,-2,0
 	AttackTurreted:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
@@ -593,7 +593,7 @@ OBLI:
 		ChargeAudio: obelpowr.aud
 	Armament:
 		Weapon: Laser
-		LocalOffset: 0,0,-2,-17,0
+		LegacyLocalOffset: 0,0,-2,-17,0
 		FireDelay: 8
 	AttackTurreted:
 	Turreted:
@@ -631,7 +631,7 @@ GTWR:
 		Range: 7
 	Armament:
 		Weapon: HighV
-		LocalOffset: 0,-6,0,-6,0
+		LegacyLocalOffset: 0,-6,0,-6,0
 	AttackTurreted:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
@@ -672,7 +672,7 @@ ATWR:
 		Range: 9
 	Armament:
 		Weapon: TowerMissle
-		LocalOffset: 7,-7,5,2,-25, -7,-7,5,2,25
+		LegacyLocalOffset: 7,-7,5,2,-25, -7,-7,5,2,25
 	AttackTurreted:
 	Turreted:
 		ROT:255

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -233,6 +233,7 @@ World:
 		Type:Crater
 		Types:cr1,cr2,cr3,cr4,cr5,cr6
 		Depths:5,5,5,5,5,5
+	DebugOverlay:
 	SpawnMapActors:
 	CreateMPPlayers:
 	SpawnMPUnits:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -255,7 +255,8 @@ BIKE:
 		Range: 8
 	Armament:
 		Weapon: BikeRockets
-		LegacyLocalOffset: -4,0,0,-2,25, 4,0,0,-2,-25
+		LocalOffset: -128, -170, 170, -128, 170, 170
+		LocalYaw: 100, -100
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -403,13 +404,14 @@ HTNK:
 		ROT: 2
 	Armament@PRIMARY:
 		Weapon: 120mmDual
-		LegacyLocalOffset: -5,-5,0,-10,0, 5,-5,0,-10,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 1
+		LocalOffset: 800, 180, 340, 800, -180, 340
+		Recoil: 170
+		RecoilRecovery: 42
 	Armament@SECONDARY:
 		Weapon: MammothMissiles
-		LegacyLocalOffset: -9,2,0,0,25, 9,2,0,0,-25
-		LegacyRecoil: 1
+		LocalOffset: -85, 384, 340, -85, -384, 340
+		LocalYaw: -100, 100
+		Recoil: 42
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -102,10 +102,10 @@ APC:
 		ROT: 10
 	Armament@PRIMARY:
 		Weapon: APCGun
-		LegacyLocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
+		LocalOffset: 85,85,299, 85,-85,299
 	Armament@SECONDARY:
 		Weapon: APCGun.AA
-		LegacyLocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
+		LocalOffset: 85,85,299, 85,-85,299
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -143,7 +143,7 @@ ARTY:
 		Range: 9
 	Armament:
 		Weapon: ArtilleryShell
-		LegacyLocalOffset: 0,-7,0,-3,0
+		LocalOffset: 299, 0, 128
 	AttackFrontal:
 	RenderUnit:
 	Explodes:
@@ -177,7 +177,7 @@ FTNK:
 		Range: 5
 	Armament:
 		Weapon: BigFlamer
-		LegacyLocalOffset: 5,-5,3,2,0, -5,-5,3,2,0
+		LocalOffset: 213,213,-85, 213,-213,-85
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -213,9 +213,10 @@ BGGY:
 		Range: 7
 	Turreted:
 		ROT: 10
-		LegacyOffset: 0,1,0,-3
+		Offset: -43,0,128
 	Armament:
 		Weapon: MachineGun
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -288,9 +289,10 @@ JEEP:
 		Range: 8
 	Turreted:
 		ROT: 10
-		LegacyOffset: 0,2,0,-4
+		Offset: -85,0,171
 	Armament:
 		Weapon: MachineGun
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -325,9 +327,9 @@ LTNK:
 		ROT: 5
 	Armament:
 		Weapon: 70mm
-		LegacyRecoil: 2
-		LegacyRecoilRecovery: 0.4
-		LegacyLocalOffset: 0,3,0,-2,0
+		Recoil: 85
+		RecoilRecovery: 17
+		LocalOffset: -128,0,85
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -363,9 +365,9 @@ MTNK:
 		ROT: 5
 	Armament:
 		Weapon: 120mm
-		LegacyRecoil: 3
-		LegacyRecoilRecovery: 0.6
-		LegacyLocalOffset: 0,0,0,-1,0
+		Recoil: 128
+		RecoilRecovery: 26
+		LocalOffset: 0,0,43
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -451,10 +453,10 @@ MSAM:
 		Range: 10
 	Turreted:
 		ROT: 255
-		LegacyOffset: 0,6,0,-3
+		Offset: -256,0,128
 	Armament:
 		Weapon: 227mm
-		LegacyLocalOffset: 3,-5,0,0,0, -3,-5,0,0,0
+		LocalOffset: 213,128,0, 213,-128,0
 	AttackFrontal:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -485,14 +487,14 @@ MLRS:
 		Range: 10
 	Turreted:
 		ROT: 5
-		LegacyOffset: 0,3,0,-3
+		Offset: -128,0,128
 		AlignWhenIdle: true
 	Armament@PRIMARY:
 		Weapon: Patriot
-		LegacyLocalOffset: -4,0,0,0,0
+		LocalOffset: 0,-171,0
 	Armament@SECONDARY:
 		Weapon: Patriot
-		LegacyLocalOffset: 4,0,0,0,0
+		LocalOffset:0,171,0
 	AttackTurreted:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -534,7 +536,7 @@ STNK:
 		UncloakSound: trans1.aud
 	Armament:
 		Weapon: 227mm.stnk
-		LegacyLocalOffset: 1,-5,0,-3,0, -1,-5,0,-3,0
+		LocalOffset: 213,43,128, 213,-43,128
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -102,10 +102,10 @@ APC:
 		ROT: 10
 	Armament@PRIMARY:
 		Weapon: APCGun
-		LocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
+		LegacyLocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
 	Armament@SECONDARY:
 		Weapon: APCGun.AA
-		LocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
+		LegacyLocalOffset: 2,-2,0,-7,0, -2,-2,0,-7,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -143,7 +143,7 @@ ARTY:
 		Range: 9
 	Armament:
 		Weapon: ArtilleryShell
-		LocalOffset: 0,-7,0,-3,0
+		LegacyLocalOffset: 0,-7,0,-3,0
 	AttackFrontal:
 	RenderUnit:
 	Explodes:
@@ -177,7 +177,7 @@ FTNK:
 		Range: 5
 	Armament:
 		Weapon: BigFlamer
-		LocalOffset: 5,-5,3,2,0, -5,-5,3,2,0
+		LegacyLocalOffset: 5,-5,3,2,0, -5,-5,3,2,0
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -213,7 +213,7 @@ BGGY:
 		Range: 7
 	Turreted:
 		ROT: 10
-		Offset: 0,1,0,-3
+		LegacyOffset: 0,1,0,-3
 	Armament:
 		Weapon: MachineGun
 	AttackTurreted:
@@ -255,7 +255,7 @@ BIKE:
 		Range: 8
 	Armament:
 		Weapon: BikeRockets
-		LocalOffset: -4,0,0,-2,25, 4,0,0,-2,-25
+		LegacyLocalOffset: -4,0,0,-2,25, 4,0,0,-2,-25
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -287,7 +287,7 @@ JEEP:
 		Range: 8
 	Turreted:
 		ROT: 10
-		Offset: 0,2,0,-4
+		LegacyOffset: 0,2,0,-4
 	Armament:
 		Weapon: MachineGun
 	AttackTurreted:
@@ -324,9 +324,9 @@ LTNK:
 		ROT: 5
 	Armament:
 		Weapon: 70mm
-		Recoil: 2
-		RecoilRecovery: 0.4
-		LocalOffset: 0,3,0,-2,0
+		LegacyRecoil: 2
+		LegacyRecoilRecovery: 0.4
+		LegacyLocalOffset: 0,3,0,-2,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -362,9 +362,9 @@ MTNK:
 		ROT: 5
 	Armament:
 		Weapon: 120mm
-		Recoil: 3
-		RecoilRecovery: 0.6
-		LocalOffset: 0,0,0,-1,0
+		LegacyRecoil: 3
+		LegacyRecoilRecovery: 0.6
+		LegacyLocalOffset: 0,0,0,-1,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -403,13 +403,13 @@ HTNK:
 		ROT: 2
 	Armament@PRIMARY:
 		Weapon: 120mmDual
-		LocalOffset: -5,-5,0,-10,0, 5,-5,0,-10,0
-		Recoil: 4
-		RecoilRecovery: 1
+		LegacyLocalOffset: -5,-5,0,-10,0, 5,-5,0,-10,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 1
 	Armament@SECONDARY:
 		Weapon: MammothMissiles
-		LocalOffset: -9,2,0,0,25, 9,2,0,0,-25
-		Recoil: 1
+		LegacyLocalOffset: -9,2,0,0,25, 9,2,0,0,-25
+		LegacyRecoil: 1
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -449,10 +449,10 @@ MSAM:
 		Range: 10
 	Turreted:
 		ROT: 255
-		Offset: 0,6,0,-3
+		LegacyOffset: 0,6,0,-3
 	Armament:
 		Weapon: 227mm
-		LocalOffset: 3,-5,0,0,0, -3,-5,0,0,0
+		LegacyLocalOffset: 3,-5,0,0,0, -3,-5,0,0,0
 	AttackFrontal:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -483,14 +483,14 @@ MLRS:
 		Range: 10
 	Turreted:
 		ROT: 5
-		Offset: 0,3,0,-3
+		LegacyOffset: 0,3,0,-3
 		AlignWhenIdle: true
 	Armament@PRIMARY:
 		Weapon: Patriot
-		LocalOffset: -4,0,0,0,0
+		LegacyLocalOffset: -4,0,0,0,0
 	Armament@SECONDARY:
 		Weapon: Patriot
-		LocalOffset: 4,0,0,0,0
+		LegacyLocalOffset: 4,0,0,0,0
 	AttackTurreted:
 	RenderUnitTurretedAim:
 	AutoTarget:
@@ -532,7 +532,7 @@ STNK:
 		UncloakSound: trans1.aud
 	Armament:
 		Weapon: 227mm.stnk
-		LocalOffset: 1,-5,0,-3,0, -1,-5,0,-3,0
+		LegacyLocalOffset: 1,-5,0,-3,0, -1,-5,0,-3,0
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -216,7 +216,6 @@ BGGY:
 		Offset: -43,0,128
 	Armament:
 		Weapon: MachineGun
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -292,7 +291,6 @@ JEEP:
 		Offset: -85,0,171
 	Armament:
 		Weapon: MachineGun
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -84,7 +84,7 @@ ORNI:
 		Range: 10
 	Armament:
 		Weapon: ChainGun
-		LocalOffset: -5,-2,0,2,0
+		LegacyLocalOffset: -5,-2,0,2,0
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -84,7 +84,7 @@ ORNI:
 		Range: 10
 	Armament:
 		Weapon: ChainGun
-		LegacyLocalOffset: -5,-2,0,2,0
+		LocalOffset: 85,-213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -145,9 +145,9 @@ COMBATA:
 		BuiltAt: heavya
 	Armament:
 		Weapon: 90mma
-		Recoil: 4
-		RecoilRecovery: 0.8
-		LocalOffset: 0,-2,0,-3,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.8
+		LegacyLocalOffset: 0,-2,0,-3,0
 	AttackTurreted:
 	RenderUnitTurreted:
 		Image: COMBATA
@@ -199,7 +199,7 @@ SONICTANK:
 		Image: SONICTANK
 	Armament:
 		Weapon: TTankZap
-		LocalOffset: 0,-15,0,-10,0
+		LegacyLocalOffset: 0,-15,0,-10,0
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -145,9 +145,9 @@ COMBATA:
 		BuiltAt: heavya
 	Armament:
 		Weapon: 90mma
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.8
-		LegacyLocalOffset: 0,-2,0,-3,0
+		Recoil: 171
+		RecoilRecovery: 34
+		LocalOffset: 85,0,128
 	AttackTurreted:
 	RenderUnitTurreted:
 		Image: COMBATA
@@ -199,7 +199,7 @@ SONICTANK:
 		Image: SONICTANK
 	Armament:
 		Weapon: TTankZap
-		LegacyLocalOffset: 0,-15,0,-10,0
+		LocalOffset: 640,0,427
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -40,6 +40,7 @@
 		RepairBuildings: repair
 	DetectCloaked:
 		Range: 1
+	DebugMuzzlePositions:
 
 ^Tank:
 	AppearsOnRadar:
@@ -81,6 +82,7 @@
 	#WithSmoke:
 	Repairable:
 		RepairBuildings: repair
+	DebugMuzzlePositions:
 
 ^Husk:
 	Health:
@@ -171,6 +173,7 @@
 		CloseEnough: 1
 	DetectCloaked:
 		Range: 2
+	DebugMuzzlePositions:
 
 ^Plane:
 	AppearsOnRadar:
@@ -201,6 +204,7 @@
 	ProximityCaptor:
 		Types:Plane
 	GivesBounty:
+	DebugMuzzlePositions:
 
 ^Helicopter:
 	Inherits: ^Plane
@@ -260,3 +264,4 @@
 	Sellable:
 	GivesBounty:
 	C4Demolishable:
+	DebugMuzzlePositions:

--- a/mods/d2k/rules/harkonnen.yaml
+++ b/mods/d2k/rules/harkonnen.yaml
@@ -40,7 +40,7 @@ REFH:
 #		Speed: 11
 #	Armament:
 #		Weapon: M60mg
-#		LegacyLocalOffset: 0,-1,0,-3,0
+#		LocalOffset: 43,0,128
 #	AttackFrontal:
 #	RenderUnit:
 #		Image: QUAD
@@ -216,7 +216,7 @@ DEVAST:
 	RenderUnit:
 	Armament:
 		Weapon: 120mm
-		LegacyLocalOffset: 5,-16,0,-2,0, -4,-16,0,-2,0
+		LocalOffset: 683,213,85, 683,-171,85
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/d2k/rules/harkonnen.yaml
+++ b/mods/d2k/rules/harkonnen.yaml
@@ -40,7 +40,7 @@ REFH:
 #		Speed: 11
 #	Armament:
 #		Weapon: M60mg
-#		LocalOffset: 0,-1,0,-3,0
+#		LegacyLocalOffset: 0,-1,0,-3,0
 #	AttackFrontal:
 #	RenderUnit:
 #		Image: QUAD
@@ -216,7 +216,7 @@ DEVAST:
 	RenderUnit:
 	Armament:
 		Weapon: 120mm
-		LocalOffset: 5,-16,0,-2,0, -4,-16,0,-2,0
+		LegacyLocalOffset: 5,-16,0,-2,0, -4,-16,0,-2,0
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -74,10 +74,10 @@ BAZOOKA:
 		Speed: 4
 	Armament@PRIMARY:
 		Weapon: RedEye
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 	Armament@SECONDARY:
 		Weapon: Dragon
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -74,10 +74,10 @@ BAZOOKA:
 		Speed: 4
 	Armament@PRIMARY:
 		Weapon: RedEye
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 	Armament@SECONDARY:
 		Weapon: Dragon
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -160,7 +160,7 @@ TRIKEO:
 		Image: RAIDER
 	Armament:
 		Weapon: M60mgo
-		LegacyLocalOffset: 0,-6,0,-3,0
+		LocalOffset: 256,0,128
 	AttackFrontal:
 
 
@@ -214,7 +214,7 @@ DEVIATORTANK:
 	RenderUnit:
 	Armament:
 		Weapon: FakeMissile
-		LegacyLocalOffset: 0,7,0,-2,0 #7
+		LocalOffset: -299,0,85 #7
 	AttackLoyalty:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -160,7 +160,7 @@ TRIKEO:
 		Image: RAIDER
 	Armament:
 		Weapon: M60mgo
-		LocalOffset: 0,-6,0,-3,0
+		LegacyLocalOffset: 0,-6,0,-3,0
 	AttackFrontal:
 
 
@@ -214,7 +214,7 @@ DEVIATORTANK:
 	RenderUnit:
 	Armament:
 		Weapon: FakeMissile
-		LocalOffset: 0,7,0,-2,0 #7
+		LegacyLocalOffset: 0,7,0,-2,0 #7
 	AttackLoyalty:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -476,7 +476,7 @@ GUNTOWER:
 		InitialFacing: 128
 	Armament:
 		Weapon: TurretGun
-		LegacyLocalOffset: 0,-11,0,-7,0
+		LocalOffset: 469,0,299
 	AttackTurreted:
 	AutoTarget:
 	LeavesHusk:
@@ -532,7 +532,7 @@ ROCKETTOWER:
 	#	HasMakeAnimation: false
 	Armament:
 		Weapon: TowerMissile
-		LegacyLocalOffset: 14,-2,0,-11,0, -14,-2,0,-11,0
+		LocalOffset: 85,597,469, 85,-597,469
 	AttackTurreted:
 	Turreted:
 		ROT: 8

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -476,7 +476,7 @@ GUNTOWER:
 		InitialFacing: 128
 	Armament:
 		Weapon: TurretGun
-		LocalOffset: 0,-11,0,-7,0
+		LegacyLocalOffset: 0,-11,0,-7,0
 	AttackTurreted:
 	AutoTarget:
 	LeavesHusk:
@@ -532,7 +532,7 @@ ROCKETTOWER:
 	#	HasMakeAnimation: false
 	Armament:
 		Weapon: TowerMissile
-		LocalOffset: 14,-2,0,-11,0, -14,-2,0,-11,0
+		LegacyLocalOffset: 14,-2,0,-11,0, -14,-2,0,-11,0
 	AttackTurreted:
 	Turreted:
 		ROT: 8

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -133,7 +133,7 @@ HARVESTER.starport:
 	WithMuzzleFlash:
 	Armament:
 		Weapon: M60mg
-		LocalOffset: 0,-6,0,-3, 0
+		LegacyLocalOffset: 0,-6,0,-3, 0
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend
@@ -176,7 +176,7 @@ QUAD:
 		Image: QUAD
 	Armament:
 		Weapon: QuadRockets
-		LocalOffset: 0,-3,0,-2,0 #-4
+		LegacyLocalOffset: 0,-3,0,-2,0 #-4
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend
@@ -221,9 +221,9 @@ QUAD.starport:
 		AlignWhenIdle: true
 	Armament:
 		Weapon: 90mm
-		Recoil: 4
-		RecoilRecovery: 0.8
-		LocalOffset: 0,-2,0,-3,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.8
+		LegacyLocalOffset: 0,-2,0,-3,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -275,9 +275,9 @@ SIEGETANK:
 		ROT: 3
 	Armament:
 		Weapon: 155mm
-		Recoil: 7
-		RecoilRecovery: 0.45
-		LocalOffset: 0,-4,0,-7,0
+		LegacyRecoil: 7
+		LegacyRecoilRecovery: 0.45
+		LegacyLocalOffset: 0,-4,0,-7,0
 	AttackFrontal:
 	RenderUnitTurreted:
 		Image: SIEGETANK
@@ -341,7 +341,7 @@ MISSILETANK:
 		Image: MISSILETANK
 	Armament:
 		Weapon: 227mm
-		LocalOffset: 3,5,0,-4,0, -6,5,0,-4,0
+		LegacyLocalOffset: 3,5,0,-4,0, -6,5,0,-4,0
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -133,7 +133,7 @@ HARVESTER.starport:
 	WithMuzzleFlash:
 	Armament:
 		Weapon: M60mg
-		LegacyLocalOffset: 0,-6,0,-3, 0
+		LocalOffset: 256,0,128
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend
@@ -176,7 +176,7 @@ QUAD:
 		Image: QUAD
 	Armament:
 		Weapon: QuadRockets
-		LegacyLocalOffset: 0,-3,0,-2,0 #-4
+		LocalOffset: 128,0,85#-4
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend
@@ -221,9 +221,9 @@ QUAD.starport:
 		AlignWhenIdle: true
 	Armament:
 		Weapon: 90mm
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.8
-		LegacyLocalOffset: 0,-2,0,-3,0
+		Recoil: 171
+		RecoilRecovery: 34
+		LocalOffset: 85,0,128
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -275,9 +275,9 @@ SIEGETANK:
 		ROT: 3
 	Armament:
 		Weapon: 155mm
-		LegacyRecoil: 7
-		LegacyRecoilRecovery: 0.45
-		LegacyLocalOffset: 0,-4,0,-7,0
+		Recoil: 299
+		RecoilRecovery: 19
+		LocalOffset: 171,0,299
 	AttackFrontal:
 	RenderUnitTurreted:
 		Image: SIEGETANK
@@ -341,7 +341,7 @@ MISSILETANK:
 		Image: MISSILETANK
 	Armament:
 		Weapon: 227mm
-		LegacyLocalOffset: 3,5,0,-4,0, -6,5,0,-4,0
+		LocalOffset: -213,128,171, -213,-256,171
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend

--- a/mods/ra-classic/rules/aircraft.yaml
+++ b/mods/ra-classic/rules/aircraft.yaml
@@ -85,7 +85,8 @@ MIG:
 		Range: 12
 	Armament:
 		Weapon: Maverick
-		LegacyLocalOffset: -15,0,0,0,-10, 15,0,0,0,6
+		LocalOffset: 0,-640,0, 0,640,0
+		LocalYaw: -40, 24
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -130,10 +131,10 @@ YAK:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LegacyLocalOffset: -5,-6,0,0,0
+		LocalOffset: 256,-213,0
 	Armament@SECONDARY:
 		Weapon: ChainGun
-		LegacyLocalOffset: 5,-6,0,0,0
+		LocalOffset: 256,213,0
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -220,7 +221,7 @@ HELI:
 		Range: 12
 	Armament:
 		Weapon: HellfireAG
-		LegacyLocalOffset: -5,0,0,2,0
+		LocalOffset: 0,-213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:
@@ -262,10 +263,10 @@ HIND:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LegacyLocalOffset: -5,-2,0,2,0
+		LocalOffset: 85,-213,-85
 	Armament@SECONDARY:
 		Weapon: ChainGun
-		LegacyLocalOffset: 5,-2,0,2,0
+		LocalOffset: 85,213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:

--- a/mods/ra-classic/rules/aircraft.yaml
+++ b/mods/ra-classic/rules/aircraft.yaml
@@ -85,7 +85,7 @@ MIG:
 		Range: 12
 	Armament:
 		Weapon: Maverick
-		LocalOffset: -15,0,0,0,-10, 15,0,0,0,6
+		LegacyLocalOffset: -15,0,0,0,-10, 15,0,0,0,6
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -130,10 +130,10 @@ YAK:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LocalOffset: -5,-6,0,0,0
+		LegacyLocalOffset: -5,-6,0,0,0
 	Armament@SECONDARY:
 		Weapon: ChainGun
-		LocalOffset: 5,-6,0,0,0
+		LegacyLocalOffset: 5,-6,0,0,0
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -220,7 +220,7 @@ HELI:
 		Range: 12
 	Armament:
 		Weapon: HellfireAG
-		LocalOffset: -5,0,0,2,0
+		LegacyLocalOffset: -5,0,0,2,0
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:
@@ -262,10 +262,10 @@ HIND:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LocalOffset: -5,-2,0,2,0
+		LegacyLocalOffset: -5,-2,0,2,0
 	Armament@SECONDARY:
 		Weapon: ChainGun
-		LocalOffset: 5,-2,0,2,0
+		LegacyLocalOffset: 5,-2,0,2,0
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:

--- a/mods/ra-classic/rules/defaults.yaml
+++ b/mods/ra-classic/rules/defaults.yaml
@@ -28,6 +28,7 @@
 		String:Vehicle
 	WithSmoke:
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Tank:
 	AppearsOnRadar:
@@ -59,6 +60,7 @@
 		String:Vehicle
 	WithSmoke:
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -99,6 +101,7 @@
 	CrushableInfantry:
 		CrushSound: squishy2.aud
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Ship:
 	AppearsOnRadar:
@@ -122,6 +125,7 @@
 		String:Ship
 	WithSmoke:
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Plane:
 	AppearsOnRadar:
@@ -147,6 +151,7 @@
 	GpsDot:
 		String:Plane
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Helicopter:
 	Inherits: ^Plane
@@ -186,6 +191,7 @@
 	ProximityCaptor:
 		Types:Building
 	Sellable:
+	DebugMuzzlePositions:
 
 ^Wall:
 	AppearsOnRadar:

--- a/mods/ra-classic/rules/infantry.yaml
+++ b/mods/ra-classic/rules/infantry.yaml
@@ -73,7 +73,7 @@ E2:
 		Speed: 5
 	Armament:
 		Weapon: Grenade
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
@@ -103,10 +103,10 @@ E3:
 		Speed: 3
 	Armament@PRIMARY:
 		Weapon: RedEye
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 	Armament@SECONDARY:
 		Weapon: Dragon
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -133,7 +133,7 @@ E4:
 		Speed: 3
 	Armament:
 		Weapon: Flamer
-		LegacyLocalOffset: 0,-10,0,-8,0
+		LocalOffset: 427,0,341
 		FireDelay: 8
 	AttackFrontal:
 	TakeCover:
@@ -384,7 +384,7 @@ SHOK:
 		Range: 4
 	Armament:
 		Weapon: PortaTesla
-		LegacyLocalOffset: 0,-10,0,-8,0
+		LocalOffset: 427,0,341
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:

--- a/mods/ra-classic/rules/infantry.yaml
+++ b/mods/ra-classic/rules/infantry.yaml
@@ -73,7 +73,7 @@ E2:
 		Speed: 5
 	Armament:
 		Weapon: Grenade
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
@@ -103,10 +103,10 @@ E3:
 		Speed: 3
 	Armament@PRIMARY:
 		Weapon: RedEye
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 	Armament@SECONDARY:
 		Weapon: Dragon
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -133,7 +133,7 @@ E4:
 		Speed: 3
 	Armament:
 		Weapon: Flamer
-		LocalOffset: 0,-10,0,-8,0
+		LegacyLocalOffset: 0,-10,0,-8,0
 		FireDelay: 8
 	AttackFrontal:
 	TakeCover:
@@ -384,7 +384,7 @@ SHOK:
 		Range: 4
 	Armament:
 		Weapon: PortaTesla
-		LocalOffset: 0,-10,0,-8,0
+		LegacyLocalOffset: 0,-10,0,-8,0
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:

--- a/mods/ra-classic/rules/ships.yaml
+++ b/mods/ra-classic/rules/ships.yaml
@@ -32,7 +32,7 @@ SS:
 		UncloakSound: subshow1.aud
 	Armament:
 		Weapon: TorpTube
-		LocalOffset: -4,0,0,0,0, 4,0,0,0,0
+		LegacyLocalOffset: -4,0,0,0,0, 4,0,0,0,0
 		FireDelay: 2
 	AttackFrontal:
 	Selectable:
@@ -115,13 +115,13 @@ DD:
 		Range: 6
 	Turreted:
 		ROT: 7
-		Offset: 0,-8,0,-3
+		LegacyOffset: 0,-8,0,-3
 	Armament@PRIMARY:
 		Weapon: Stinger
-		LocalOffset: -4,0,0,0,-20, 4,0,0,0,20
+		LegacyLocalOffset: -4,0,0,0,-20, 4,0,0,0,20
 	Armament@SECONDARY:
 		Weapon: DepthCharge
-		LocalOffset: -4,0,0,0,-20, 4,0,0,0,20
+		LegacyLocalOffset: -4,0,0,0,-20, 4,0,0,0,20
 	AttackTurreted:
 	Selectable:
 		Bounds: 38,38
@@ -158,24 +158,24 @@ CA:
 		Range: 7
 	Turreted@PRIMARY:
 		Turret: primary
-		Offset: 0,17,0,-2
+		LegacyOffset: 0,17,0,-2
 		ROT: 3
 	Turreted@SECONDARY:
 		Turret: secondary
-		Offset: 0,-17,0,-2
+		LegacyOffset: 0,-17,0,-2
 		ROT: 3
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: 8Inch
-		LocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		Recoil: 4
-		RecoilRecovery: 0.8
+		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.8
 	Armament@SECONDARY:
 		Turret: secondary
 		Weapon: 8Inch
-		LocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		Recoil: 4
-		RecoilRecovery: 0.8
+		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.8
 	AttackTurreted:
 	Selectable:
 		Bounds: 44,44
@@ -239,7 +239,7 @@ PT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		Offset: 0,-6,0,-1
+		LegacyOffset: 0,-6,0,-1
 	Armament@PRIMARY:
 		Weapon: 2Inch
 	Armament@SECONDARY:

--- a/mods/ra-classic/rules/ships.yaml
+++ b/mods/ra-classic/rules/ships.yaml
@@ -80,7 +80,6 @@ MSUB:
 	Armament:
 		Weapon: SubMissile
 		FireDelay: 2
-		OffsetModel: World
 	AttackFrontal:
 	Selectable:
 		Bounds: 44,44
@@ -245,10 +244,8 @@ PT:
 		Offset: 256,0,43
 	Armament@PRIMARY:
 		Weapon: 2Inch
-		OffsetModel: World
 	Armament@SECONDARY:
 		Weapon: DepthCharge
-		OffsetModel: World
 	AttackTurreted:
 	Selectable:
 		Bounds: 32,32

--- a/mods/ra-classic/rules/ships.yaml
+++ b/mods/ra-classic/rules/ships.yaml
@@ -32,7 +32,7 @@ SS:
 		UncloakSound: subshow1.aud
 	Armament:
 		Weapon: TorpTube
-		LegacyLocalOffset: -4,0,0,0,0, 4,0,0,0,0
+		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
 	Selectable:
@@ -80,6 +80,7 @@ MSUB:
 	Armament:
 		Weapon: SubMissile
 		FireDelay: 2
+		OffsetModel: World
 	AttackFrontal:
 	Selectable:
 		Bounds: 44,44
@@ -115,13 +116,15 @@ DD:
 		Range: 6
 	Turreted:
 		ROT: 7
-		LegacyOffset: 0,-8,0,-3
+		Offset: 341,0,128
 	Armament@PRIMARY:
 		Weapon: Stinger
-		LegacyLocalOffset: -4,0,0,0,-20, 4,0,0,0,20
+		LocalOffset: 0,-171,0, 0,171,0
+		LocalYaw: 80, -80
 	Armament@SECONDARY:
 		Weapon: DepthCharge
-		LegacyLocalOffset: -4,0,0,0,-20, 4,0,0,0,20
+		LocalOffset: 0,-171,0, 0,171,0
+		LocalYaw: 80, -80
 	AttackTurreted:
 	Selectable:
 		Bounds: 38,38
@@ -158,24 +161,24 @@ CA:
 		Range: 7
 	Turreted@PRIMARY:
 		Turret: primary
-		LegacyOffset: 0,17,0,-2
+		Offset: -725,0,85
 		ROT: 3
 	Turreted@SECONDARY:
 		Turret: secondary
-		LegacyOffset: 0,-17,0,-2
+		Offset: 725,0,85
 		ROT: 3
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: 8Inch
-		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.8
+		LocalOffset: 213,-171,0, 213,171,0
+		Recoil: 171
+		RecoilRecovery: 34
 	Armament@SECONDARY:
 		Turret: secondary
 		Weapon: 8Inch
-		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.8
+		LocalOffset: 213,-171,0, 213,171,0
+		Recoil: 171
+		RecoilRecovery: 34
 	AttackTurreted:
 	Selectable:
 		Bounds: 44,44
@@ -239,11 +242,13 @@ PT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		LegacyOffset: 0,-6,0,-1
+		Offset: 256,0,43
 	Armament@PRIMARY:
 		Weapon: 2Inch
+		OffsetModel: World
 	Armament@SECONDARY:
 		Weapon: DepthCharge
+		OffsetModel: World
 	AttackTurreted:
 	Selectable:
 		Bounds: 32,32

--- a/mods/ra-classic/rules/structures.yaml
+++ b/mods/ra-classic/rules/structures.yaml
@@ -496,7 +496,6 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
-		OffsetModel: World
 	AttackTurreted:
 	AutoTarget:
 	IronCurtainable:
@@ -568,7 +567,6 @@ SAM:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: Nike
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:

--- a/mods/ra-classic/rules/structures.yaml
+++ b/mods/ra-classic/rules/structures.yaml
@@ -317,7 +317,7 @@ TSLA:
 	RenderBuildingCharge:
 	Armament:
 		Weapon: TeslaZap
-		LocalOffset: 0,0,0,-10,0
+		LegacyLocalOffset: 0,0,0,-10,0
 	AttackTesla:
 		ReloadTime: 120
 	AutoTarget:
@@ -424,7 +424,7 @@ PBOX:
 	AutoTarget:
 	Armament:
 		Weapon: Vulcan
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Turreted:
@@ -458,7 +458,7 @@ HBOX:
 	AutoTarget:
 	Armament:
 		Weapon: Vulcan
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Turreted:
@@ -522,10 +522,10 @@ FTUR:
 		Range: 6
 	Turreted:
 		ROT: 255
-		Offset: 0,0,0,-2
+		LegacyOffset: 0,0,0,-2
 	Armament:
 		Weapon: FireballLauncher
-		LocalOffset: 0,-12,0,0,0
+		LegacyLocalOffset: 0,-12,0,0,0
 	AttackTurreted:
 	AutoTarget:
 	IronCurtainable:

--- a/mods/ra-classic/rules/structures.yaml
+++ b/mods/ra-classic/rules/structures.yaml
@@ -317,7 +317,7 @@ TSLA:
 	RenderBuildingCharge:
 	Armament:
 		Weapon: TeslaZap
-		LegacyLocalOffset: 0,0,0,-10,0
+		LocalOffset: 0,0,427
 	AttackTesla:
 		ReloadTime: 120
 	AutoTarget:
@@ -424,12 +424,14 @@ PBOX:
 	AutoTarget:
 	Armament:
 		Weapon: Vulcan
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Turreted:
 		ROT: 255
-	
+	RenderBuilding:
+		QuantizedFacings: 8
+
 HBOX:
 	Inherits: ^Building
 	Buildable:
@@ -458,11 +460,13 @@ HBOX:
 	AutoTarget:
 	Armament:
 		Weapon: Vulcan
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Turreted:
 		ROT: 255
+	RenderBuilding:
+		QuantizedFacings: 8
 
 GUN:
 	Inherits: ^Building
@@ -492,6 +496,7 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
+		OffsetModel: World
 	AttackTurreted:
 	AutoTarget:
 	IronCurtainable:
@@ -522,14 +527,16 @@ FTUR:
 		Range: 6
 	Turreted:
 		ROT: 255
-		LegacyOffset: 0,0,0,-2
+		Offset: 0,0,85
 	Armament:
 		Weapon: FireballLauncher
-		LegacyLocalOffset: 0,-12,0,0,0
+		LocalOffset: 512,0,0
 	AttackTurreted:
 	AutoTarget:
 	IronCurtainable:
 	RenderRangeCircle:
+	RenderBuilding:
+		QuantizedFacings: 8
 
 SAM:
 	Inherits: ^Building
@@ -561,6 +568,7 @@ SAM:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: Nike
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:

--- a/mods/ra-classic/rules/vehicles.yaml
+++ b/mods/ra-classic/rules/vehicles.yaml
@@ -20,7 +20,6 @@ V2RL:
 		Range: 5
 	Armament:
 		Weapon: SCUD
-		OffsetModel: World
 	AttackFrontal:
 	RenderUnitReload:
 	AutoTarget:
@@ -54,7 +53,6 @@ V2RL:
 		Weapon: 25mm
 		Recoil: 85
 		RecoilRecovery: 25
-		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -88,7 +86,6 @@ V2RL:
 		Weapon: 90mm
 		Recoil: 128
 		RecoilRecovery: 38
-		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -203,7 +200,6 @@ ARTY:
 		Range: 5
 	Armament:
 		Weapon: 155mm
-		OffsetModel: World
 	AttackFrontal:
 	RenderUnit:
 	Explodes:
@@ -314,7 +310,6 @@ JEEP:
 		Offset: 0,0,85
 	Armament:
 		Weapon: M60mg
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:

--- a/mods/ra-classic/rules/vehicles.yaml
+++ b/mods/ra-classic/rules/vehicles.yaml
@@ -51,8 +51,8 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 25mm
-		Recoil: 2
-		RecoilRecovery: 0.5
+		LegacyRecoil: 2
+		LegacyRecoilRecovery: 0.5
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -84,8 +84,8 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 90mm
-		Recoil: 3
-		RecoilRecovery: 0.9
+		LegacyRecoil: 3
+		LegacyRecoilRecovery: 0.9
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -119,9 +119,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 105mm
-		Recoil: 3
-		RecoilRecovery: 0.9
-		LocalOffset: 2,0,0,0,0, -2,0,0,0,0
+		LegacyRecoil: 3
+		LegacyRecoilRecovery: 0.9
+		LegacyLocalOffset: 2,0,0,0,0, -2,0,0,0,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -156,12 +156,12 @@ V2RL:
 		ROT: 2
 	Armament@PRIMARY:
 		Weapon: 120mm
-		LocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		Recoil: 4
-		RecoilRecovery: 0.7
+		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.7
 	Armament@SECONDARY:
 		Weapon: MammothTusk
-		LocalOffset: -7,2,0,0,25, 7,2,0,0,-25
+		LegacyLocalOffset: -7,2,0,0,25, 7,2,0,0,-25
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -305,7 +305,7 @@ JEEP:
 		Range: 6
 	Turreted:
 		ROT: 10
-		Offset: 0,0,0,-2
+		LegacyOffset: 0,0,0,-2
 	Armament:
 		Weapon: M60mg
 	AttackTurreted:
@@ -338,7 +338,7 @@ APC:
 		Range: 5
 	Armament:
 		Weapon: M60mg
-		LocalOffset: 0,0,0,-4,0
+		LegacyLocalOffset: 0,0,0,-4,0
 	AttackFrontal:
 	RenderUnit:
 	WithMuzzleFlash:
@@ -445,7 +445,7 @@ TTNK:
 		Range: 7
 	Armament:
 		Weapon: TTankZap
-		LocalOffset: 0,0,0,-5,0
+		LegacyLocalOffset: 0,0,0,-5,0
 	AttackFrontal:
 	RenderUnitSpinner:
 	Selectable:
@@ -512,10 +512,10 @@ CTNK:
 	AutoTarget:
 	Armament@PRIMARY:
 		Weapon: ChronoTusk
-		LocalOffset: -4,0,0,0,0, -4,0,0,0,0
+		LegacyLocalOffset: -4,0,0,0,0, -4,0,0,0,0
 	Armament@SECONDARY:
 		Weapon: ChronoTusk
-		LocalOffset: 4,0,0,0,25, 4,0,0,0,-25
+		LegacyLocalOffset: 4,0,0,0,25, 4,0,0,0,-25
 	AttackFrontal:
 	ChronoshiftDeploy:
 		EmptyWeapon: UnitExplodeSmall

--- a/mods/ra-classic/rules/vehicles.yaml
+++ b/mods/ra-classic/rules/vehicles.yaml
@@ -20,6 +20,7 @@ V2RL:
 		Range: 5
 	Armament:
 		Weapon: SCUD
+		OffsetModel: World
 	AttackFrontal:
 	RenderUnitReload:
 	AutoTarget:
@@ -51,8 +52,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 25mm
-		LegacyRecoil: 2
-		LegacyRecoilRecovery: 0.5
+		Recoil: 85
+		RecoilRecovery: 25
+		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -84,8 +86,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 90mm
-		LegacyRecoil: 3
-		LegacyRecoilRecovery: 0.9
+		Recoil: 128
+		RecoilRecovery: 38
+		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -119,9 +122,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 105mm
-		LegacyRecoil: 3
-		LegacyRecoilRecovery: 0.9
-		LegacyLocalOffset: 2,0,0,0,0, -2,0,0,0,0
+		Recoil: 128
+		RecoilRecovery: 38
+		LocalOffset: 0,85,0, 0,-85,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -156,12 +159,14 @@ V2RL:
 		ROT: 2
 	Armament@PRIMARY:
 		Weapon: 120mm
-		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.7
+		LocalOffset: 800,180,340, 800,-180,340
+		Recoil: 171
+		RecoilRecovery: 30
 	Armament@SECONDARY:
 		Weapon: MammothTusk
-		LegacyLocalOffset: -7,2,0,0,25, 7,2,0,0,-25
+		LocalOffset: -85, 384, 340, -85, -384, 340
+		LocalYaw: -100,100
+		Recoil: 43
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -198,6 +203,7 @@ ARTY:
 		Range: 5
 	Armament:
 		Weapon: 155mm
+		OffsetModel: World
 	AttackFrontal:
 	RenderUnit:
 	Explodes:
@@ -305,9 +311,10 @@ JEEP:
 		Range: 6
 	Turreted:
 		ROT: 10
-		LegacyOffset: 0,0,0,-2
+		Offset: 0,0,85
 	Armament:
 		Weapon: M60mg
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -338,7 +345,7 @@ APC:
 		Range: 5
 	Armament:
 		Weapon: M60mg
-		LegacyLocalOffset: 0,0,0,-4,0
+		LocalOffset: 0,0,171
 	AttackFrontal:
 	RenderUnit:
 	WithMuzzleFlash:
@@ -445,7 +452,7 @@ TTNK:
 		Range: 7
 	Armament:
 		Weapon: TTankZap
-		LegacyLocalOffset: 0,0,0,-5,0
+		LocalOffset: 0,0,213
 	AttackFrontal:
 	RenderUnitSpinner:
 	Selectable:
@@ -512,10 +519,12 @@ CTNK:
 	AutoTarget:
 	Armament@PRIMARY:
 		Weapon: ChronoTusk
-		LegacyLocalOffset: -4,0,0,0,0, -4,0,0,0,0
+		LocalOffset: 0,-171,0
+		LocalYaw: 100
 	Armament@SECONDARY:
 		Weapon: ChronoTusk
-		LegacyLocalOffset: 4,0,0,0,25, 4,0,0,0,-25
+		LocalOffset: 0,171,0
+		LocalYaw: -100
 	AttackFrontal:
 	ChronoshiftDeploy:
 		EmptyWeapon: UnitExplodeSmall

--- a/mods/ra/chrome/cheats.yaml
+++ b/mods/ra/chrome/cheats.yaml
@@ -81,9 +81,15 @@ Background@CHEATS_PANEL:
 			Width:PARENT_RIGHT - 30
 			Height:20
 			Text:Show A* Cost
+		Checkbox@SHOW_MUZZLES:
+			X:30
+			Y:350
+			Height:20
+			Width:200
+			Text:Show Muzzle Positions
 		Button@CLOSE:
 			X:30
-			Y:360
+			Y:390
 			Width:PARENT_RIGHT - 60
 			Height:25
 			Text:Close

--- a/mods/ra/maps/bomber-john/map.yaml
+++ b/mods/ra/maps/bomber-john/map.yaml
@@ -899,7 +899,7 @@ Rules:
 			DamageCooldown: 0
 		Armament:
 			Weapon: CrateNuke
-			LocalOffset: 0,0,0,-4,0
+			LegacyLocalOffset: 0,0,0,-4,0
 		AttackFrontal:
 		Explodes:
 		DemoTruck:

--- a/mods/ra/maps/bomber-john/map.yaml
+++ b/mods/ra/maps/bomber-john/map.yaml
@@ -899,7 +899,7 @@ Rules:
 			DamageCooldown: 0
 		Armament:
 			Weapon: CrateNuke
-			LegacyLocalOffset: 0,0,0,-4,0
+			LocalOffset: 0,0,171
 		AttackFrontal:
 		Explodes:
 		DemoTruck:

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2570,13 +2570,14 @@ Rules:
 			ROT: 1
 		Armament@PRIMARY:
 			Weapon: SuperTankPrimary
-			LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-			LegacyRecoil: 4
-			LegacyRecoilRecovery: 0.7
+			LocalOffset: 213,-171,0, 213,171,0
+			Recoil: 171
+			RecoilRecovery: 30
 		Armament@SECONDARY:
 			Weapon: MammothTusk
-			LegacyLocalOffset: -7,2,0,0,25, 7,2,0,0,-25
-			LegacyRecoil: 1
+			LocalOffset: -85,-299,0, -85,299,0
+			LocalYaw: -100,100
+			Recoil: 43
 		AttackTurreted:
 		RenderUnitTurreted:
 			Image: 4TNK

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2570,13 +2570,13 @@ Rules:
 			ROT: 1
 		Armament@PRIMARY:
 			Weapon: SuperTankPrimary
-			LocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-			Recoil: 4
-			RecoilRecovery: 0.7
+			LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
+			LegacyRecoil: 4
+			LegacyRecoilRecovery: 0.7
 		Armament@SECONDARY:
 			Weapon: MammothTusk
-			LocalOffset: -7,2,0,0,25, 7,2,0,0,-25
-			Recoil: 1
+			LegacyLocalOffset: -7,2,0,0,25, 7,2,0,0,-25
+			LegacyRecoil: 1
 		AttackTurreted:
 		RenderUnitTurreted:
 			Image: 4TNK

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -1066,7 +1066,7 @@ Rules:
 			Image: truk
 		Armament:
 			Weapon: CrateNuke
-			LocalOffset: 0,0,0,-4,0
+			LegacyLocalOffset: 0,0,0,-4,0
 		AttackFrontal:
 		AttackMove:
 			JustMove: yes

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -1066,7 +1066,7 @@ Rules:
 			Image: truk
 		Armament:
 			Weapon: CrateNuke
-			LegacyLocalOffset: 0,0,0,-4,0
+			LocalOffset: 0,0,171
 		AttackFrontal:
 		AttackMove:
 			JustMove: yes

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -97,7 +97,7 @@ MIG:
 		Range: 12
 	Armament:
 		Weapon: Maverick
-		LocalOffset: -15,0,0,0,-10, 15,0,0,0,6
+		LegacyLocalOffset: -15,0,0,0,-10, 15,0,0,0,6
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -147,10 +147,10 @@ YAK:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
-		LocalOffset: -5,-6,0,0,0
+		LegacyLocalOffset: -5,-6,0,0,0
 	Armament@SECONDARY:
 		Weapon: ChainGun.Yak
-		LocalOffset: 5,-6,0,0,0
+		LegacyLocalOffset: 5,-6,0,0,0
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -255,10 +255,10 @@ HELI:
 		Range: 12
 	Armament@PRIMARY:
 		Weapon: HellfireAA
-		LocalOffset: -5,0,0,2,0
+		LegacyLocalOffset: -5,0,0,2,0
 	Armament@SECONDARY:
 		Weapon: HellfireAG
-		Offset: 5,0,0,2,0
+		LegacyLocalOffset: 5,0,0,2,0
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:
@@ -301,10 +301,10 @@ HIND:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LocalOffset: -5,-2,0,2,0
+		LegacyLocalOffset: -5,-2,0,2,0
 	Armament@SECONDARY:
 		Weapon: ChainGun
-		LocalOffset: -5,-2,0,2,0
+		LegacyLocalOffset: -5,-2,0,2,0
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -97,7 +97,8 @@ MIG:
 		Range: 12
 	Armament:
 		Weapon: Maverick
-		LegacyLocalOffset: -15,0,0,0,-10, 15,0,0,0,6
+		LocalOffset: 0,-640,0, 0,640,0
+		LocalYaw: -40, 24
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -147,10 +148,10 @@ YAK:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
-		LegacyLocalOffset: -5,-6,0,0,0
+		LocalOffset: 256,-213,0
 	Armament@SECONDARY:
 		Weapon: ChainGun.Yak
-		LegacyLocalOffset: 5,-6,0,0,0
+		LocalOffset: 256,213,0
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -255,10 +256,10 @@ HELI:
 		Range: 12
 	Armament@PRIMARY:
 		Weapon: HellfireAA
-		LegacyLocalOffset: -5,0,0,2,0
+		LocalOffset: 0,-213,-85
 	Armament@SECONDARY:
 		Weapon: HellfireAG
-		LegacyLocalOffset: 5,0,0,2,0
+		LocalOffset: 0,213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:
@@ -301,10 +302,10 @@ HIND:
 		Range: 10
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LegacyLocalOffset: -5,-2,0,2,0
+		LocalOffset: 85,-213,-85
 	Armament@SECONDARY:
 		Weapon: ChainGun
-		LegacyLocalOffset: -5,-2,0,2,0
+		LocalOffset: 85,213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -105,7 +105,7 @@ V01.SNIPER:
 		ROT: 255
 	Armament:
 		Weapon: Sniper
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 	Cargo:
 		InitialUnits: sniper

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -105,7 +105,7 @@ V01.SNIPER:
 		ROT: 255
 	Armament:
 		Weapon: Sniper
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 	Cargo:
 		InitialUnits: sniper

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -34,6 +34,7 @@
 		String:Vehicle
 	WithSmoke:
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Tank:
 	AppearsOnRadar:
@@ -71,6 +72,7 @@
 		String:Vehicle
 	WithSmoke:
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -122,6 +124,7 @@
 		Buildings: hosp
 		CloseEnough: 1
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Ship:
 	AppearsOnRadar:
@@ -150,6 +153,7 @@
 		String:Ship
 	WithSmoke:
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Plane:
 	AppearsOnRadar:
@@ -179,6 +183,7 @@
 	GpsDot:
 		String:Plane
 	UpdatesPlayerStatistics:
+	DebugMuzzlePositions:
 
 ^Helicopter:
 	Inherits: ^Plane
@@ -223,6 +228,7 @@
 	GivesBounty:
 	UpdatesPlayerStatistics:
 	C4Demolishable:
+	DebugMuzzlePositions:
 
 ^Wall:
 	AppearsOnRadar:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -75,7 +75,7 @@ E2:
 		Speed: 5
 	Armament:
 		Weapon: Grenade
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
@@ -106,10 +106,10 @@ E3:
 		Speed: 3
 	Armament@PRIMARY:
 		Weapon: RedEye
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 	Armament@SECONDARY:
 		Weapon: Dragon
-		LegacyLocalOffset: 0,0,0,-13,0
+		LocalOffset: 0,0,555
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -137,7 +137,7 @@ E4:
 		Speed: 3
 	Armament:
 		Weapon: Flamer
-		LegacyLocalOffset: 0,-10,0,-8,0
+		LocalOffset: 427,0,341
 		FireDelay: 8
 	AttackFrontal:
 	TakeCover:
@@ -486,7 +486,7 @@ SHOK:
 		Range: 4
 	Armament:
 		Weapon: PortaTesla
-		LegacyLocalOffset: 0,-10,0,-8,0
+		LocalOffset: 427,0,341
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -75,7 +75,7 @@ E2:
 		Speed: 5
 	Armament:
 		Weapon: Grenade
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
@@ -106,10 +106,10 @@ E3:
 		Speed: 3
 	Armament@PRIMARY:
 		Weapon: RedEye
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 	Armament@SECONDARY:
 		Weapon: Dragon
-		LocalOffset: 0,0,0,-13,0
+		LegacyLocalOffset: 0,0,0,-13,0
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -137,7 +137,7 @@ E4:
 		Speed: 3
 	Armament:
 		Weapon: Flamer
-		LocalOffset: 0,-10,0,-8,0
+		LegacyLocalOffset: 0,-10,0,-8,0
 		FireDelay: 8
 	AttackFrontal:
 	TakeCover:
@@ -486,7 +486,7 @@ SHOK:
 		Range: 4
 	Armament:
 		Weapon: PortaTesla
-		LocalOffset: 0,-10,0,-8,0
+		LegacyLocalOffset: 0,-10,0,-8,0
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -84,7 +84,6 @@ MSUB:
 	Armament:
 		Weapon: SubMissile
 		FireDelay: 2
-		OffsetModel: World
 	AttackFrontal:
 	Selectable:
 		Bounds: 44,44
@@ -259,10 +258,8 @@ PT:
 		Offset: 256,0,43
 	Armament@PRIMARY:
 		Weapon: 2Inch
-		OffsetModel: World
 	Armament@SECONDARY:
 		Weapon: DepthCharge
-		OffsetModel: World
 	AttackTurreted:
 	Selectable:
 		Bounds: 32,32

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -33,7 +33,7 @@ SS:
 		UncloakSound: subshow1.aud
 	Armament:
 		Weapon: TorpTube
-		LegacyLocalOffset: -4,0,0,0,0, 4,0,0,0,0
+		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
 	Selectable:
@@ -84,6 +84,7 @@ MSUB:
 	Armament:
 		Weapon: SubMissile
 		FireDelay: 2
+		OffsetModel: World
 	AttackFrontal:
 	Selectable:
 		Bounds: 44,44
@@ -122,12 +123,15 @@ DD:
 		Range: 6
 	Turreted:
 		ROT: 7
-		LegacyOffset: 0,-8,0,-3
+		Offset: 341,0,128
 	Armament@PRIMARY:
 		Weapon: Stinger
-		LegacyLocalOffset: -4,0,0,0,-20, 4,0,0,0,20
+		LocalOffset: 0,-171,0, 0,171,0
+		LocalYaw: 80, -80
 	Armament@SECONDARY:
 		Weapon: DepthCharge
+		LocalOffset: 0,-171,0, 0,171,0
+		LocalYaw: 80, -80
 	AttackTurreted:
 	Selectable:
 		Bounds: 38,38
@@ -167,24 +171,24 @@ CA:
 		Range: 7
 	Turreted@PRIMARY:
 		Turret: primary
-		LegacyOffset: 0,17,0,-2
+		Offset: -725,0,85
 		ROT: 3
 	Turreted@SECONDARY:
 		Turret: secondary
-		LegacyOffset: 0,-17,0,-2
+		Offset: 725,0,85
 		ROT: 3
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: 8Inch
-		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.8
+		LocalOffset: 213,-171,0, 213,171,0
+		Recoil: 171
+		RecoilRecovery: 34
 	Armament@SECONDARY:
 		Turret: secondary
 		Weapon: 8Inch
-		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.8
+		LocalOffset: 213,-171,0, 213,171,0
+		Recoil: 171
+		RecoilRecovery: 34
 	AttackTurreted:
 	Selectable:
 		Bounds: 44,44
@@ -252,11 +256,13 @@ PT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		LegacyOffset: 0,-6,0,-1
+		Offset: 256,0,43
 	Armament@PRIMARY:
 		Weapon: 2Inch
+		OffsetModel: World
 	Armament@SECONDARY:
 		Weapon: DepthCharge
+		OffsetModel: World
 	AttackTurreted:
 	Selectable:
 		Bounds: 32,32

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -33,7 +33,7 @@ SS:
 		UncloakSound: subshow1.aud
 	Armament:
 		Weapon: TorpTube
-		LocalOffset: -4,0,0,0,0, 4,0,0,0,0
+		LegacyLocalOffset: -4,0,0,0,0, 4,0,0,0,0
 		FireDelay: 2
 	AttackFrontal:
 	Selectable:
@@ -122,10 +122,10 @@ DD:
 		Range: 6
 	Turreted:
 		ROT: 7
-		Offset: 0,-8,0,-3
+		LegacyOffset: 0,-8,0,-3
 	Armament@PRIMARY:
 		Weapon: Stinger
-		LocalOffset: -4,0,0,0,-20, 4,0,0,0,20
+		LegacyLocalOffset: -4,0,0,0,-20, 4,0,0,0,20
 	Armament@SECONDARY:
 		Weapon: DepthCharge
 	AttackTurreted:
@@ -167,24 +167,24 @@ CA:
 		Range: 7
 	Turreted@PRIMARY:
 		Turret: primary
-		Offset: 0,17,0,-2
+		LegacyOffset: 0,17,0,-2
 		ROT: 3
 	Turreted@SECONDARY:
 		Turret: secondary
-		Offset: 0,-17,0,-2
+		LegacyOffset: 0,-17,0,-2
 		ROT: 3
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: 8Inch
-		LocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		Recoil: 4
-		RecoilRecovery: 0.8
+		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.8
 	Armament@SECONDARY:
 		Turret: secondary
 		Weapon: 8Inch
-		LocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		Recoil: 4
-		RecoilRecovery: 0.8
+		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.8
 	AttackTurreted:
 	Selectable:
 		Bounds: 44,44
@@ -252,7 +252,7 @@ PT:
 		Range: 7
 	Turreted:
 		ROT: 7
-		Offset: 0,-6,0,-1
+		LegacyOffset: 0,-6,0,-1
 	Armament@PRIMARY:
 		Weapon: 2Inch
 	Armament@SECONDARY:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -284,7 +284,7 @@ TSLA:
 	RenderBuildingCharge:
 	Armament:
 		Weapon: TeslaZap
-		LocalOffset: 0,0,0,-10,0
+		LegacyLocalOffset: 0,0,0,-10,0
 	AttackTesla:
 		ReloadTime: 120
 	AutoTarget:
@@ -451,7 +451,7 @@ PBOX.E1:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Vulcan
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Cargo:
@@ -476,7 +476,7 @@ PBOX.E3:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Dragon
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 PBOX.E4:
@@ -491,7 +491,7 @@ PBOX.E4:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Flamer
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 PBOX.E7:
@@ -506,7 +506,7 @@ PBOX.E7:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Colt45
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 PBOX.SHOK:
@@ -521,7 +521,7 @@ PBOX.SHOK:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: PortaTesla
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 PBOX.SNIPER:
@@ -536,7 +536,7 @@ PBOX.SNIPER:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Sniper
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 HBOX:
@@ -626,7 +626,7 @@ HBOX.E1:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Vulcan
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Cargo:
@@ -651,7 +651,7 @@ HBOX.E3:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Dragon
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 HBOX.E4:
@@ -666,7 +666,7 @@ HBOX.E4:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Flamer
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 HBOX.E7:
@@ -681,7 +681,7 @@ HBOX.E7:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Colt45
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 HBOX.SHOK:
@@ -696,7 +696,7 @@ HBOX.SHOK:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: PortaTesla
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 HBOX.SNIPER:
@@ -711,7 +711,7 @@ HBOX.SNIPER:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Sniper
-		LocalOffset: 0,-11,0,0,0
+		LegacyLocalOffset: 0,-11,0,0,0
 	AttackTurreted:
 
 GUN:
@@ -776,10 +776,10 @@ FTUR:
 		Range: 6
 	Turreted:
 		ROT: 255
-		Offset: 0,0,0,-2
+		LegacyOffset: 0,0,0,-2
 	Armament:
 		Weapon: FireballLauncher
-		LocalOffset: 0,-12,0,0,0
+		LegacyLocalOffset: 0,-12,0,0,0
 	AttackTurreted:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -284,7 +284,7 @@ TSLA:
 	RenderBuildingCharge:
 	Armament:
 		Weapon: TeslaZap
-		LegacyLocalOffset: 0,0,0,-10,0
+		LocalOffset: 0,0,427
 	AttackTesla:
 		ReloadTime: 120
 	AutoTarget:
@@ -328,8 +328,10 @@ AGUN:
 	RenderBuildingTurreted:
 	Armament@PRIMARY:
 		Weapon: ZSU-23
+		OffsetModel: World
 	Armament@SECONDARY:
 		Weapon: ZSU-23
+		OffsetModel: World
 	AttackTurreted:
 	AutoTarget:
 	IronCurtainable:
@@ -388,6 +390,8 @@ PBOX:
 	-AcceptsSupplies:
 	Turreted:
 		ROT: 255
+	RenderBuilding:
+		QuantizedFacings: 8
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
@@ -451,7 +455,7 @@ PBOX.E1:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Vulcan
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Cargo:
@@ -476,7 +480,7 @@ PBOX.E3:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Dragon
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 PBOX.E4:
@@ -491,7 +495,7 @@ PBOX.E4:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Flamer
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 PBOX.E7:
@@ -506,7 +510,7 @@ PBOX.E7:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Colt45
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 PBOX.SHOK:
@@ -521,7 +525,7 @@ PBOX.SHOK:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: PortaTesla
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 PBOX.SNIPER:
@@ -536,7 +540,7 @@ PBOX.SNIPER:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Sniper
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 HBOX:
@@ -563,6 +567,8 @@ HBOX:
 	-AcceptsSupplies:
 	Turreted:
 		ROT: 255
+	RenderBuilding:
+		QuantizedFacings: 8
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
@@ -626,7 +632,7 @@ HBOX.E1:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Vulcan
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 	WithMuzzleFlash:
 	Cargo:
@@ -651,7 +657,7 @@ HBOX.E3:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Dragon
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 HBOX.E4:
@@ -666,7 +672,7 @@ HBOX.E4:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Flamer
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 HBOX.E7:
@@ -681,7 +687,7 @@ HBOX.E7:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Colt45
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 HBOX.SHOK:
@@ -696,7 +702,7 @@ HBOX.SHOK:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: PortaTesla
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 HBOX.SNIPER:
@@ -711,7 +717,7 @@ HBOX.SNIPER:
 	DebugNextAutoTargetScanTime:
 	Armament:
 		Weapon: Sniper
-		LegacyLocalOffset: 0,-11,0,0,0
+		LocalOffset: 469,0,0
 	AttackTurreted:
 
 GUN:
@@ -742,6 +748,7 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
+		OffsetModel: World
 	AttackTurreted:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
@@ -776,11 +783,13 @@ FTUR:
 		Range: 6
 	Turreted:
 		ROT: 255
-		LegacyOffset: 0,0,0,-2
+		Offset: 0,0,85
 	Armament:
 		Weapon: FireballLauncher
-		LegacyLocalOffset: 0,-12,0,0,0
+		LocalOffset: 512,0,0
 	AttackTurreted:
+	RenderBuilding:
+		QuantizedFacings: 8
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
@@ -819,6 +828,7 @@ SAM:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: Nike
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -328,10 +328,8 @@ AGUN:
 	RenderBuildingTurreted:
 	Armament@PRIMARY:
 		Weapon: ZSU-23
-		OffsetModel: World
 	Armament@SECONDARY:
 		Weapon: ZSU-23
-		OffsetModel: World
 	AttackTurreted:
 	AutoTarget:
 	IronCurtainable:
@@ -748,7 +746,6 @@ GUN:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: TurretGun
-		OffsetModel: World
 	AttackTurreted:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
@@ -828,7 +825,6 @@ SAM:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: Nike
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -54,8 +54,8 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 25mm
-		Recoil: 2
-		RecoilRecovery: 0.5
+		LegacyRecoil: 2
+		LegacyRecoilRecovery: 0.5
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -93,8 +93,8 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 90mm
-		Recoil: 3
-		RecoilRecovery: 0.9
+		LegacyRecoil: 3
+		LegacyRecoilRecovery: 0.9
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -134,9 +134,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 105mm
-		Recoil: 3
-		RecoilRecovery: 0.9
-		LocalOffset: 2,0,0,0,0, -2,0,0,0,0
+		LegacyRecoil: 3
+		LegacyRecoilRecovery: 0.9
+		LegacyLocalOffset: 2,0,0,0,0, -2,0,0,0,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -176,13 +176,13 @@ V2RL:
 		ROT: 1
 	Armament@PRIMARY:
 		Weapon: 120mm
-		LocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		Recoil: 4
-		RecoilRecovery: 0.7
+		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
+		LegacyRecoil: 4
+		LegacyRecoilRecovery: 0.7
 	Armament@SECONDARY:
 		Weapon: MammothTusk
-		LocalOffset: -7,2,0,0,25, 7,2,0,0,-25
-		Recoil: 1
+		LegacyLocalOffset: -7,2,0,0,25, 7,2,0,0,-25
+		LegacyRecoil: 1
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -338,7 +338,7 @@ JEEP:
 		Range: 8
 	Turreted:
 		ROT: 10
-		Offset: 0,0,0,-2
+		LegacyOffset: 0,0,0,-2
 	Armament:
 		Weapon: M60mg
 	AttackTurreted:
@@ -375,7 +375,7 @@ APC:
 		Range: 5
 	Armament:
 		Weapon: M60mg
-		LocalOffset: 0,0,0,-4,0
+		LegacyLocalOffset: 0,0,0,-4,0
 	AttackFrontal:
 	RenderUnit:
 	WithMuzzleFlash:
@@ -641,7 +641,7 @@ TTNK:
 		Range: 7
 	Armament:
 		Weapon: TTankZap
-		LocalOffset: 0,0,0,-5,0
+		LegacyLocalOffset: 0,0,0,-5,0
 	AttackFrontal:
 	RenderUnitSpinner:
 	Selectable:
@@ -673,10 +673,10 @@ FTRK:
 		Range: 4
 	Turreted:
 		ROT: 5
-		Offset: 0,5,0,-4
+		LegacyOffset: 0,5,0,-4
 	Armament:
 		Weapon: FLAK-23
-		Recoil: 2
+		LegacyRecoil: 2
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -749,9 +749,9 @@ CTNK:
 	DebugNextAutoTargetScanTime:
 	Armament@PRIMARY:
 		Weapon: ChronoTusk
-		LocalOffset: -4,0,0,0,0, -4,0,0,0,0
+		LegacyLocalOffset: -4,0,0,0,0, -4,0,0,0,0
 	Armament@SECONDARY:
 		Weapon: ChronoTusk
-		LocalOffset: 4,0,0,0,25, 4,0,0,0,-25
+		LegacyLocalOffset: 4,0,0,0,25, 4,0,0,0,-25
 	AttackFrontal:
 	ChronoshiftDeploy:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -21,7 +21,6 @@ V2RL:
 		Range: 5
 	Armament:
 		Weapon: SCUD
-		OffsetModel: World
 	AttackFrontal:
 	RenderUnitReload:
 	AutoTarget:
@@ -57,7 +56,6 @@ V2RL:
 		Weapon: 25mm
 		Recoil: 85
 		RecoilRecovery: 25
-		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -97,7 +95,6 @@ V2RL:
 		Weapon: 90mm
 		Recoil: 128
 		RecoilRecovery: 38
-		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -229,7 +226,6 @@ ARTY:
 		Range: 5
 	Armament:
 		Weapon: 155mm
-		OffsetModel: World
 	AttackFrontal:
 	RenderUnit:
 	Explodes:
@@ -346,7 +342,6 @@ JEEP:
 		Offset: 0,0,85
 	Armament:
 		Weapon: M60mg
-		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -683,7 +678,6 @@ FTRK:
 	Armament:
 		Weapon: FLAK-23
 		Recoil: 85
-		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -21,6 +21,7 @@ V2RL:
 		Range: 5
 	Armament:
 		Weapon: SCUD
+		OffsetModel: World
 	AttackFrontal:
 	RenderUnitReload:
 	AutoTarget:
@@ -54,8 +55,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 25mm
-		LegacyRecoil: 2
-		LegacyRecoilRecovery: 0.5
+		Recoil: 85
+		RecoilRecovery: 25
+		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -93,8 +95,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 90mm
-		LegacyRecoil: 3
-		LegacyRecoilRecovery: 0.9
+		Recoil: 128
+		RecoilRecovery: 38
+		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -134,9 +137,9 @@ V2RL:
 		ROT: 5
 	Armament:
 		Weapon: 105mm
-		LegacyRecoil: 3
-		LegacyRecoilRecovery: 0.9
-		LegacyLocalOffset: 2,0,0,0,0, -2,0,0,0,0
+		Recoil: 128
+		RecoilRecovery: 38
+		LocalOffset: 0,85,0, 0,-85,0
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -176,13 +179,14 @@ V2RL:
 		ROT: 1
 	Armament@PRIMARY:
 		Weapon: 120mm
-		LegacyLocalOffset: -4,-5,0,0,0, 4,-5,0,0,0
-		LegacyRecoil: 4
-		LegacyRecoilRecovery: 0.7
+		LocalOffset: 800,180,340, 800,-180,340
+		Recoil: 171
+		RecoilRecovery: 30
 	Armament@SECONDARY:
 		Weapon: MammothTusk
-		LegacyLocalOffset: -7,2,0,0,25, 7,2,0,0,-25
-		LegacyRecoil: 1
+		LocalOffset: -85,384,340, -85,-384,340
+		LocalYaw: -100,100
+		Recoil: 43
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -225,6 +229,7 @@ ARTY:
 		Range: 5
 	Armament:
 		Weapon: 155mm
+		OffsetModel: World
 	AttackFrontal:
 	RenderUnit:
 	Explodes:
@@ -338,9 +343,10 @@ JEEP:
 		Range: 8
 	Turreted:
 		ROT: 10
-		LegacyOffset: 0,0,0,-2
+		Offset: 0,0,85
 	Armament:
 		Weapon: M60mg
+		OffsetModel: World
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnitTurreted:
@@ -375,7 +381,7 @@ APC:
 		Range: 5
 	Armament:
 		Weapon: M60mg
-		LegacyLocalOffset: 0,0,0,-4,0
+		LocalOffset: 0,0,171
 	AttackFrontal:
 	RenderUnit:
 	WithMuzzleFlash:
@@ -641,7 +647,7 @@ TTNK:
 		Range: 7
 	Armament:
 		Weapon: TTankZap
-		LegacyLocalOffset: 0,0,0,-5,0
+		LocalOffset: 0,0,213
 	AttackFrontal:
 	RenderUnitSpinner:
 	Selectable:
@@ -673,10 +679,11 @@ FTRK:
 		Range: 4
 	Turreted:
 		ROT: 5
-		LegacyOffset: 0,5,0,-4
+		Offset: -300,0,300
 	Armament:
 		Weapon: FLAK-23
-		LegacyRecoil: 2
+		Recoil: 85
+		OffsetModel: World
 	AttackTurreted:
 	RenderUnitTurreted:
 	AutoTarget:
@@ -749,9 +756,11 @@ CTNK:
 	DebugNextAutoTargetScanTime:
 	Armament@PRIMARY:
 		Weapon: ChronoTusk
-		LegacyLocalOffset: -4,0,0,0,0, -4,0,0,0,0
+		LocalOffset: 0,-171,0
+		LocalYaw: 100
 	Armament@SECONDARY:
 		Weapon: ChronoTusk
-		LegacyLocalOffset: 4,0,0,0,25, 4,0,0,0,-25
+		LocalOffset: 0,171,0
+		LocalYaw: -100
 	AttackFrontal:
 	ChronoshiftDeploy:


### PR DESCRIPTION
These patches introduce a new set of coordinates for representing position and orientation, and uses them to implement a much better system for positioning turrets and muzzles.

Key changes:
- New types for representing 3d types and rotations without requiring any floating point math.
- Turrets and weapons understand arbitrary 3d rotations, not just facing.
- Muzzles are now affected by recoil.
- Clearer yaml definitions for positioning turrets/muzzles (forward,right,up relative to body).
- Includes a debug layer for displaying the muzzle positions (might finally encourage someone to set them properly).
- Lays the foundations for voxels and TS/RA2 support.

I've tested this with RA, C&C, and my voxel test mod and I'm pretty sure I've covered all the edge cases. I have left rotors/spinners/etc with the old positioning for now, as these are better solved as part of #2841.

It will be straightforward from here to start fixing the coordinate-system mess and the rest of the combat code, but that should wait until these changes have been proven stable.
