### PR TITLE
march_29.patch - blue blossom trees, ...

### DIFF
--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -9,6 +9,11 @@ SPLIT2:
 		Name: Blossom Tree
 	RadarColorFromTerrain:
 		Terrain: Tiberium
+	-Health:
+	-DeadBuildingState:
+	-Armor:
+	-TargetableBuilding:
+	-AutoTargetIgnore:
 
 SPLIT3:
 	Inherits: ^Tree
@@ -21,6 +26,11 @@ SPLIT3:
 		Name: Blossom Tree
 	RadarColorFromTerrain:
 		Terrain: Tiberium
+	-Health:
+	-DeadBuildingState:
+	-Armor:
+	-TargetableBuilding:
+	-AutoTargetIgnore:
 
 SPLITBLUE:
 	Inherits: ^Tree
@@ -28,11 +38,16 @@ SPLITBLUE:
 		Palette: staticterrain
 	SeedsResource:
 		ResourceType:BlueTiberium
-		Interval: 55
+		Interval: 95
 	Tooltip:
 		Name: Blossom Tree (blue)
 	RadarColorFromTerrain:
 		Terrain: BlueTiberium
+	-Health:
+	-DeadBuildingState:
+	-Armor:
+	-TargetableBuilding:
+	-AutoTargetIgnore:
 
 ROCK1:
 	Inherits: ^Rock


### PR DESCRIPTION
Trees were made destructible; now they are indestructible.
Blue tiberium blossom trees regenerate slower than green tiberium. This keeps the green ones relevant.
The blue ones produce at slightly over half speed, and slightly over 2x value, giving them a slight advantage. Blue's total value production rate is ~1.25x faster than green tib. blossom tree. 
