### PR TITLE
blossom trees: indestructible; blue slower

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -67,7 +67,7 @@ HELI:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 8
+		Range: 10
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
 		LocalOffset: -5,-3,0,2,0, 5,-3,0,2,0
@@ -120,7 +120,7 @@ ORCA:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 8
+		Range: 10
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
 		LocalOffset: -4,-10,0,5,0, 4,-10,0,5,0
@@ -130,10 +130,10 @@ ORCA:
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:
-		Ammo: 10
-		PipCount: 5
+		Ammo: 6
+		PipCount: 6
 	Reloads:
-		Count: 2
+		Count: 1
 		Period: 100
 	RenderUnit:
 	WithShadow:
@@ -184,7 +184,7 @@ A10:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 8
+		Range: 12
 	RenderUnit:
 	WithShadow:
 	LimitedAmmo:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -257,7 +257,7 @@ AFLD:
 		Footprint: xxxx xxxx
 		Dimensions: 4,2
 	Health:
-		HP: 1500
+		HP: 1000
 	RevealsShroud:
 		Range: 7
 	Bib:
@@ -296,7 +296,7 @@ WEAP:
 		Footprint: ___ xxx ===
 		Dimensions: 3,3
 	Health:
-		HP: 1750
+		HP: 1000
 	RevealsShroud:
 		Range: 4
 	Bib:
@@ -361,6 +361,8 @@ HQ:
 		Name: Communications Center
 		Icon: hqicnh
 		Description: Provides an overview of the battlefield.\n  Requires power to operate.
+	ProvidesCustomPrerequisite:
+		Prerequisite: anyhq
 	Buildable:
 		BuildPaletteOrder: 70
 		Prerequisites: proc
@@ -423,6 +425,8 @@ EYE:
 		Name: Advanced Communications Center
 		Icon: eyeicnh
 		Description: Provides access to the Ion Cannon.\n  Requires power to operate.
+	ProvidesCustomPrerequisite:
+		Prerequisite: anyhq
 	Buildable:
 		BuildPaletteOrder: 100
 		Prerequisites: hq
@@ -432,7 +436,7 @@ EYE:
 		Footprint: x_ xx
 		Dimensions: 2,2
 	Health:
-		HP: 1000
+		HP: 1200
 	RevealsShroud:
 		Range: 10
 	Bib:
@@ -461,6 +465,8 @@ TMPL:
 		Name: Temple of Nod
 		Icon: tmplicnh
 		Description: Place of worship and secret missile silo.\n  Requires power to operate.
+	ProvidesCustomPrerequisite:
+		Prerequisite: anyhq
 	Buildable:
 		BuildPaletteOrder: 100
 		Prerequisites: hq
@@ -765,3 +771,8 @@ ANYPOWER:
 	Tooltip:
 		Name: Power Plant
 		Description: Power Plant
+
+ANYHQ:
+	Tooltip:
+		Name: a communications center
+		Description: a communications center

--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -9,7 +9,12 @@ SPLIT2:
 		Name: Blossom Tree
 	RadarColorFromTerrain:
 		Terrain: Tiberium
-
+	-Health:
+	-DeadBuildingState:
+	-Armor:
+	-TargetableBuilding:
+	-AutoTargetIgnore:
+	
 SPLIT3:
 	Inherits: ^Tree
 	RenderBuilding:
@@ -21,19 +26,29 @@ SPLIT3:
 		Name: Blossom Tree
 	RadarColorFromTerrain:
 		Terrain: Tiberium
-
+	-Health:
+	-DeadBuildingState:
+	-Armor:
+	-TargetableBuilding:
+	-AutoTargetIgnore:
+	
 SPLITBLUE:
 	Inherits: ^Tree
 	RenderBuilding:
 		Palette: staticterrain
 	SeedsResource:
 		ResourceType:BlueTiberium
-		Interval: 55
+		Interval: 95
 	Tooltip:
 		Name: Blossom Tree (blue)
 	RadarColorFromTerrain:
 		Terrain: BlueTiberium
-
+	-Health:
+	-DeadBuildingState:
+	-Armor:
+	-TargetableBuilding:
+	-AutoTargetIgnore:
+	
 ROCK1:
 	Inherits: ^Rock
 ROCK2:

--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -12,9 +12,7 @@ SPLIT2:
 	-Health:
 	-DeadBuildingState:
 	-Armor:
-	-TargetableBuilding:
-	-AutoTargetIgnore:
-	
+
 SPLIT3:
 	Inherits: ^Tree
 	RenderBuilding:
@@ -29,9 +27,7 @@ SPLIT3:
 	-Health:
 	-DeadBuildingState:
 	-Armor:
-	-TargetableBuilding:
-	-AutoTargetIgnore:
-	
+
 SPLITBLUE:
 	Inherits: ^Tree
 	RenderBuilding:
@@ -46,9 +42,7 @@ SPLITBLUE:
 	-Health:
 	-DeadBuildingState:
 	-Armor:
-	-TargetableBuilding:
-	-AutoTargetIgnore:
-	
+
 ROCK1:
 	Inherits: ^Rock
 ROCK2:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -393,9 +393,10 @@ HTNK:
 		Owner: gdi
 	Mobile:
 		Crushes: wall, heavywall, crate, infantry
-		Speed: 3
+		Speed: 4
+		ROT: 3
 	Health:
-		HP: 600
+		HP: 800
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -441,9 +442,9 @@ MSAM:
 		Prerequisites: hq
 		Owner: gdi
 	Mobile:
-		Speed: 8
+		Speed: 7
 	Health:
-		HP: 120
+		HP: 115
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -495,6 +496,7 @@ MLRS:
 	AttackTurreted:
 	RenderUnitTurretedAim:
 	AutoTarget:
+		InitialStance: Defend
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
 	Explodes:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -56,8 +56,9 @@ HARV:
 		Bounds: 36,36
 	Harvester:
 		Resources: Tiberium, BlueTiberium
-		PipCount: 5
-		Capacity: 15
+		PipCount: 7
+		Capacity: 20
+		UnloadTicksPerBale: 12		# hardcoded default is 4
 		# How far away from our linked proc (refinery) to find resources (in cells):
 		SearchFromProcRadius: 24
 		# How far away from last harvest order location to find more resources (in cells):

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -88,27 +88,23 @@ Atomic:
 		ImpactSound: xplobig4
 
 IonCannon:
+	ValidTargets: Ground, Air
 	Warhead@impact:
-		Damage: 500
-		Spread: 6
+		Damage: 900
+		Spread: 16
 		Ore: true
 		Versus: 
 			None: 100%
 			Wood: 100%
-			Light: 60%
-			Heavy: 45%
+			Light: 100%
+			Heavy: 100%
 		InfDeath: 5
 	Warhead@area:
 		DamageModel: PerCell
-		Damage: 200
+		Damage: 0
 		SmudgeType: Scorch
 		Size: 2,1
 		Ore: true
-		Versus: 
-			None: 90%
-			Wood: 60%
-			Light: 60%
-			Heavy: 25%
 		Delay: 3
 		InfDeath: 5
 

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -283,7 +283,7 @@ BikeRockets:
 
 OrcaAGMissiles:
 	ROF: 10
-	Burst: 2
+	Burst: 1
 	BurstDelay: 0
 	Range: 5
 	Report: BAZOOK1
@@ -310,11 +310,11 @@ OrcaAGMissiles:
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 20
+		Damage: 40
 
 OrcaAAMissiles:
 	ROF: 10
-	Burst: 2
+	Burst: 1
 	BurstDelay: 0
 	Range: 5
 	Report: BAZOOK1
@@ -341,7 +341,7 @@ OrcaAAMissiles:
 		Explosion: 4
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 20
+		Damage: 40
 
 Flamethrower:
 	ROF: 50

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -135,7 +135,7 @@ HighV:
 	Projectile: Bullet
 		Speed: 100
 	Warhead:
-		Damage: 40
+		Damage: 45
 		Spread: 3
 		Versus: 
 			None: 100%
@@ -234,7 +234,7 @@ Rockets:
 		ROT: 15
 		Trail: smokey
 		Speed: 35
-		RangeLimit: 40
+		RangeLimit: 30
 	Warhead:
 		Spread: 3
 		Versus: 
@@ -613,7 +613,7 @@ MammothMissiles:
 		Spread: 3
 		Versus:
 			None: 35%
-			Wood: 90%
+			Wood: 50%
 			Light: 100%
 			Heavy: 90%
 		InfDeath: 4

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -68,7 +68,7 @@ Atomic:
 			None: 90%
 			Wood: 60%
 			Light: 60%
-			Heavy: 25%
+			Heavy: 50%
 		Explosion: 6
 		InfDeath: 5
 		ImpactSound: nukexplo
@@ -82,7 +82,7 @@ Atomic:
 			None: 90%
 			Wood: 60%
 			Light: 60%
-			Heavy: 25%
+			Heavy: 50%
 		Delay: 3
 		InfDeath: 5
 		ImpactSound: xplobig4

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -129,13 +129,13 @@ Sniper:
 		InfDeath: 2
 
 HighV:
-	ROF: 40
+	ROF: 30
 	Range: 6
 	Report: GUN8
 	Projectile: Bullet
 		Speed: 100
 	Warhead:
-		Damage: 45
+		Damage: 50
 		Spread: 3
 		Versus: 
 			None: 100%


### PR DESCRIPTION
Trees were made destructible; now they are indestructible.
Blue tiberium blossom trees regenerate slower than green tiberium. This keeps the green ones relevant in maps with both kinds of trees.
The blue ones produce at slightly over half speed, and slightly over 2x value, giving them a slight advantage. Blue's total value production rate is ~1.25x faster than green tib. blossom tree. 
