### PR TITLE
Added switchable ruler markings to editor

### DIFF
--- a/OpenRA.Editor/Form1.Designer.cs
+++ b/OpenRA.Editor/Form1.Designer.cs
@@ -69,6 +69,7 @@ namespace OpenRA.Editor
 			this.zoomIntoolStripButton = new System.Windows.Forms.ToolStripButton();
 			this.zoomOutToolStripButton = new System.Windows.Forms.ToolStripButton();
 			this.panToolStripButton = new System.Windows.Forms.ToolStripButton();
+			this.showRulerToolStripItem = new System.Windows.Forms.ToolStripButton();
 			this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
 			this.toolStripMenuItemFixOpenAreas = new System.Windows.Forms.ToolStripButton();
 			this.toolStripMenuItemSetupDefaultPlayers = new System.Windows.Forms.ToolStripButton();
@@ -97,6 +98,7 @@ namespace OpenRA.Editor
 			this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
 			this.showActorNamesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.showGridToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.showRulerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
 			this.fixOpenAreasToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.setupDefaultPlayersMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -345,6 +347,7 @@ namespace OpenRA.Editor
 			this.zoomIntoolStripButton,
 			this.zoomOutToolStripButton,
 			this.panToolStripButton,
+			this.showRulerToolStripItem,
 			this.toolStripSeparator10,
 			this.toolStripMenuItemFixOpenAreas,
 			this.toolStripMenuItemSetupDefaultPlayers,
@@ -477,6 +480,15 @@ namespace OpenRA.Editor
 			this.panToolStripButton.Size = new System.Drawing.Size(23, 22);
 			this.panToolStripButton.Text = "Pan view";
 			this.panToolStripButton.Click += new System.EventHandler(this.panToolStripButtonClick);
+			//
+			// showRulerToolStripItem
+			// 
+			this.showRulerToolStripItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+			this.showRulerToolStripItem.Image = ((System.Drawing.Image)(resources.GetObject("showRulerToolStripItem.Image")));
+			this.showRulerToolStripItem.Name = "showRulerToolStripItem";
+			this.showRulerToolStripItem.Size = new System.Drawing.Size(23, 22);
+			this.showRulerToolStripItem.Text = "Show Ruler";
+			this.showRulerToolStripItem.Click += new System.EventHandler(this.showRulerToolStripItemClick);
 			// 
 			// toolStripSeparator10
 			// 
@@ -687,6 +699,7 @@ namespace OpenRA.Editor
 			this.toolStripSeparator9,
 			this.showActorNamesToolStripMenuItem,
 			this.showGridToolStripMenuItem,
+			this.showRulerToolStripMenuItem,
 			this.toolStripSeparator5,
 			this.fixOpenAreasToolStripMenuItem,
 			this.setupDefaultPlayersMenuItem,
@@ -738,6 +751,14 @@ namespace OpenRA.Editor
 			this.showGridToolStripMenuItem.Text = "Show &Grid";
 			this.showGridToolStripMenuItem.ToolTipText = "Enable a grid overlay for better orientation.";
 			this.showGridToolStripMenuItem.Click += new System.EventHandler(this.ShowGridClicked);
+			// 
+			// showRulerToolStripMenuItem
+			// 
+			this.showRulerToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("showRulerToolStripMenuItem.Image")));
+			this.showRulerToolStripMenuItem.Name = "showRulerToolStripMenuItem";
+			this.showRulerToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+			this.showRulerToolStripMenuItem.Text = "Show Ruler";
+			this.showRulerToolStripMenuItem.Click += new System.EventHandler(this.showRulerToolStripMenuItemClick);
 			// 
 			// toolStripSeparator5
 			// 
@@ -1036,6 +1057,8 @@ namespace OpenRA.Editor
 		private System.Windows.Forms.ToolStripButton zoomOutToolStripButton;
 		private System.Windows.Forms.ToolStripButton zoomIntoolStripButton;
 		private System.Windows.Forms.ToolStripSeparator toolStripSeparator12;
+		private System.Windows.Forms.ToolStripButton showRulerToolStripItem;
+		private System.Windows.Forms.ToolStripMenuItem showRulerToolStripMenuItem;
 
 		#endregion
 

--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -718,7 +718,7 @@ namespace OpenRA.Editor
 		{
 			if (surface1.Map == null) return;
 
-			surface1.Zoom *= 4.0f / 3.0f;
+			surface1.Zoom /= .75f;
 
 			surface1.Invalidate();
 		}
@@ -736,6 +736,19 @@ namespace OpenRA.Editor
 		{
 			panToolStripButton.Checked ^= true;
 			surface1.IsPanning = panToolStripButton.Checked;
+		}
+
+		void showRulerToolStripMenuItemClick(object sender, EventArgs e)
+		{
+			showRulerToolStripMenuItem.Checked ^= true;
+			showRulerToolStripItem.Checked ^= true;
+			surface1.ShowRuler = showRulerToolStripMenuItem.Checked;
+			surface1.Chunks.Clear();
+		}
+
+		void showRulerToolStripItemClick(object sender, System.EventArgs e)
+		{
+			showRulerToolStripMenuItemClick(sender, e);
 		}
 	}
 }

--- a/OpenRA.Editor/Form1.resx
+++ b/OpenRA.Editor/Form1.resx
@@ -266,6 +266,17 @@
         5wrrvlLxhgAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="showRulerToolStripItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAEiSURBVDhPvVO7TgJBFN2fovAHNDb+gLGywsbCxoTOxF/wgaLGRPGJNUEeglBaaKExWhF8E1kh
+        Cwsyxzl3d83Gip3Ck5zMvTtzz97cOWPtnFVBbmcusXVaEaZOytg8vsDGUUmYPCxi/aCAtXReuLp/jpW9
+        HCyCxWHML6X8yEP/G2i7wEcHqH8C96/AdQOITc56AvxzAMdxMD696GfAYAgeQlMXN1rAw5uX5+9CAmyZ
+        YDE5NhWXnAffW11Zb1+GstYeve/ZvwILy7uYmEno4jnZGJUiwIGF8bsxKjjtADqNLsBrCmDbjrmADs06
+        oEmUUuj19T033egCdJg7UPjqGc6A1gycdvOkzAToNB2adcCH8WwDV3WI0yIL8FWxKEx/6z9gWT/PHGlW
+        lc2EywAAAABJRU5ErkJggg==
+</value>
+  </data>
   <data name="toolStripMenuItemFixOpenAreas.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -579,6 +590,17 @@
         /02TVv03jF/x3yB6KaZByKEN8jOUieJskGYoExMEITkbObSRA0wvBpvNcGfvBycSkJ8doKFtDtRskrQa
         7Gy96GX/daIW/9eKWAjGUO0IgBLa2QhnG8Uvh7OxaoQBZGdbpCJCG9nZeA0gHTAwAACOffGU2o3WzAAA
         AABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="showRulerToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAEiSURBVDhPvVO7TgJBFN2fovAHNDb+gLGywsbCxoTOxF/wgaLGRPGJNUEeglBaaKExWhF8E1kh
+        Cwsyxzl3d83Gip3Ck5zMvTtzz97cOWPtnFVBbmcusXVaEaZOytg8vsDGUUmYPCxi/aCAtXReuLp/jpW9
+        HCyCxWHML6X8yEP/G2i7wEcHqH8C96/AdQOITc56AvxzAMdxMD696GfAYAgeQlMXN1rAw5uX5+9CAmyZ
+        YDE5NhWXnAffW11Zb1+GstYeve/ZvwILy7uYmEno4jnZGJUiwIGF8bsxKjjtADqNLsBrCmDbjrmADs06
+        oEmUUuj19T033egCdJg7UPjqGc6A1gycdvOkzAToNB2adcCH8WwDV3WI0yIL8FWxKEx/6z9gWT/PHGlW
+        lc2EywAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="fixOpenAreasToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/OpenRA.Editor/Surface.cs
+++ b/OpenRA.Editor/Surface.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Editor
 		public bool IsPanning;
 		public bool ShowActorNames;
 		public bool ShowGrid;
+		public bool ShowRuler;
 
 		public bool IsPaste { get { return TileSelection != null && ResourceSelection != null; } }
 		public TileReference<ushort, byte>[,] TileSelection;
@@ -53,6 +54,9 @@ namespace OpenRA.Editor
 
 		Dictionary<string, ActorTemplate> ActorTemplates = new Dictionary<string, ActorTemplate>();
 		public Dictionary<int, ResourceTemplate> ResourceTemplates = new Dictionary<int, ResourceTemplate>();
+
+		static readonly Font MarkerFont = new Font(FontFamily.GenericSansSerif, 12.0f, FontStyle.Regular);
+		static readonly SolidBrush TextBrush = new SolidBrush(Color.Red);
 
 		public Keys GetModifiers() { return ModifierKeys; }
 
@@ -437,6 +441,27 @@ namespace OpenRA.Editor
 							(int)(ar.Value.Location().Y * TileSet.TileSize * Zoom + Offset.Y),
 							Brushes.White,
 							Brushes.Black);
+
+			if (ShowRuler && Zoom > 0.2)
+			{
+				for (int i = Map.Bounds.Left; i <= Map.Bounds.Right; i+=8)
+				{
+					if( i % 8 == 0)
+					{
+						PointF point = new PointF(i * TileSet.TileSize * Zoom + Offset.X, (Map.Bounds.Top - 8) * TileSet.TileSize * Zoom + Offset.Y);
+						e.Graphics.DrawString((i - Map.Bounds.Left).ToString(), MarkerFont, TextBrush, point);
+					}
+				}
+
+				for (int i = Map.Bounds.Top; i <= Map.Bounds.Bottom; i+=8)
+				{
+					if (i % 8 == 0)
+					{
+						PointF point = new PointF((Map.Bounds.Left - 8) * TileSet.TileSize * Zoom + Offset.X, i * TileSet.TileSize * Zoom + Offset.Y);
+						e.Graphics.DrawString((i - Map.Bounds.Left).ToString(), MarkerFont, TextBrush, point);
+					}
+				}
+			}
 
 			if (Tool != null)
 				Tool.Preview(this, e.Graphics);


### PR DESCRIPTION
Useful when trying to create symmetrical maps.

Again doing with https://github.com/TM-PD/FirstDance/ what they did with us. This is mostly the work of @SNce. I just made it switchable with a toolbar-button and tweaked some values so it does not look crappy when I zoom out a lot on Windows.
