### PR TITLE
fix - stealth tank, artillery; minor changes

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -46,7 +46,7 @@ FACT:
 	BaseBuilding:
 	ProductionBar:
 	BaseProvider:
-		Cooldown: 200
+		Cooldown: 125
 		Range: 14
 
 NUKE:
@@ -535,7 +535,7 @@ GUN:
 	RenderRangeCircle:
 	RenderDetectionCircle:
 	DetectCloaked:
-		Range: 4
+		Range: 5
 
 SAM:
 	Inherits: ^Building
@@ -654,7 +654,7 @@ GTWR:
 	DebugNextAutoTargetScanTime:
 	-AutoTargetIgnore:
 	DetectCloaked:
-		Range: 4
+		Range: 5
 	RenderDetectionCircle:
 	RenderRangeCircle:
 	WithMuzzleFlash:

--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -34,7 +34,7 @@ SPLITBLUE:
 		Palette: staticterrain
 	SeedsResource:
 		ResourceType:BlueTiberium
-		Interval: 95
+		Interval: 110
 	Tooltip:
 		Name: Blossom Tree (blue)
 	RadarColorFromTerrain:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -148,6 +148,8 @@ ARTY:
 	AttackFrontal:
 	RenderUnit:
 	Explodes:
+		Weapon: UnitExplode
+		Chance: 75	
 	AutoTarget:
 		InitialStance: Defend
 	DebugRetiliateAgainstAggressor:
@@ -539,9 +541,9 @@ STNK:
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
+		InitialStance: HoldFire
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
-		InitialStance: HoldFire
 	TargetableUnit:
 	LeavesHusk:
 		HuskActor: STNK.Husk

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -756,7 +756,7 @@ Napalm.Crate:
 
 Laser:
 	ROF: 90
-	Range: 7.5
+	Range: 8.5
 	Charges: true
 	Report: OBELRAY1
 	Projectile: LaserZap


### PR DESCRIPTION
Someone changed stealth tank and it did not have HoldFire as initial stance anymore.
Apparently Explodes: does not use UnitExplode by default anymore? Fixed.
