### PR TITLE
Fixes cloaked units invisible to spectators

### DIFF
--- a/OpenRA.Mods.RA/Cloak.cs
+++ b/OpenRA.Mods.RA/Cloak.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.RA
 			if (remainingTime > 0)
 				return r;
 
-			if (Cloaked && IsVisible(self))
+			if (Cloaked && IsVisible(self.World.RenderedShroud, self))
 				return r.Select(a => a.WithPalette(wr.Palette(info.Palette)));
 			else
 				return Nothing;
@@ -94,25 +94,23 @@ namespace OpenRA.Mods.RA
 			}
 		}
 		
-		public bool IsVisible(Actor self)
-		{
-			return IsVisible(null, self);
-		}
-
 		public bool IsVisible(Shroud s, Actor self)
-		{			
-		    if (self.World.LocalPlayer != null) {
-			    if (s == null) {
-    				if (!Cloaked || self.Owner == self.World.LocalPlayer ||
-    					self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)
-    					return true;
-    			}
-    			else {
-    				if (!Cloaked || self.Owner == s.Owner ||
-    					self.Owner.Stances[s.Owner] == Stance.Ally)
-    					return true;
-    			}
+		{
+			if (!Cloaked)
+				return true;
+
+			if (s != null)
+			{
+				if (s == self.World.LocalShroud && s.Observing)
+					return true;
+				if (s.Owner != null)
+					if (self.Owner == s.Owner || self.Owner.Stances[s.Owner] == Stance.Ally)
+						return true;
 			}
+
+			if (self.World.LocalPlayer != null)
+				if (self.Owner == self.World.LocalPlayer || self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)
+					return true;
 			
 			return self.World.ActorsWithTrait<DetectCloaked>().Any(a =>
 				a.Actor.Owner.Stances[self.Owner] != Stance.Ally &&

--- a/OpenRA.Mods.RA/InvisibleToEnemy.cs
+++ b/OpenRA.Mods.RA/InvisibleToEnemy.cs
@@ -21,8 +21,13 @@ namespace OpenRA.Mods.RA
 	{
 		public bool IsVisible(Shroud s, Actor self)
 		{
-			return self.World.LocalPlayer == null ||
-				self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally;
+			if (s != null && s.Observing)
+				return true;
+
+			if (self.World.LocalPlayer != null && self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)
+				return true;
+
+			return false;
 		}
 
 		public Color RadarColorOverride(Actor self)
@@ -35,7 +40,7 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<Renderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<Renderable> r)
 		{
-			return IsVisible(self.Owner.Shroud, self) ? r : Nothing;
+			return IsVisible(self.World.RenderedShroud, self) ? r : Nothing;
 		}
 	}
 }


### PR DESCRIPTION
Not sure when #2918 was introduced. The code was hard to understand for me, so I rewrote it during the bug fix. Also don't know where `InvisibleToEnemy:` trait is used.
