### PR TITLE
Fixes paratroopers revealing shroud after death

### DIFF
--- a/OpenRA.Mods.RA/Effects/Parachute.cs
+++ b/OpenRA.Mods.RA/Effects/Parachute.cs
@@ -51,6 +51,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (altitude <= 0)
 				world.AddFrameEndTask(w =>
 					{
+						w.Remove(cargo);
 						w.Remove(this);
 						var loc = location.ToCPos();
 						cargo.CancelActivity();


### PR DESCRIPTION
Fixes the most common occurrence of #2726 because the others don't even come with a proper reproducible test case. So it might not catch all shroud related glitches introduced by per-player shrouds and mobile gap generators. Took me ridiculously long to hunt this one down.
