### PR TITLE
balance stick - infantry, mammoth

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -53,7 +53,7 @@ HELI:
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: hpad, hq
+		Prerequisites: hpad, anyhq
 		BuiltAt: hpad
 		Owner: nod
 	Selectable:
@@ -106,7 +106,7 @@ ORCA:
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry
 	Buildable:
 		BuildPaletteOrder: 20
-		Prerequisites: hpad, hq
+		Prerequisites: hpad, anyhq
 		BuiltAt: hpad
 		Owner: gdi
 	Selectable:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -113,7 +113,7 @@
 		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
-			Clear: 90
+			Clear: 100
 			Rough: 80
 			Road: 100
 			Tiberium: 70

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -405,7 +405,7 @@ HTNK:
 	RevealsShroud:
 		Range: 6
 	Turreted:
-		ROT: 2
+		ROT: 3
 	Armament@PRIMARY:
 		Weapon: 120mmDual
 		LocalOffset: 800, 180, 340, 800, -180, 340

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -834,7 +834,7 @@ Tiberium:
 		PreventProne: yes
 
 APCGun:
-	ROF: 20
+	ROF: 25
 	Range: 5
 	Report: gun20
 	ValidTargets: Ground
@@ -849,10 +849,10 @@ APCGun:
 			Light: 100%
 			Heavy: 50%
 		Explosion: small_poof
-		Damage: 25
+		Damage: 30
 		
 APCGun.AA:
-	ROF: 20
+	ROF: 25
 	Range: 7
 	Report: gun20
 	ValidTargets: Air
@@ -864,7 +864,7 @@ APCGun.AA:
 		Versus:
 			Heavy: 50%
 		Explosion: small_poof
-		Damage: 25
+		Damage: 30
 
 Patriot:
 	ROF: 100


### PR DESCRIPTION
During playtesting it seemed like having infantry go at full speed on clear terrain was a good addition.
If it seems inappropriate for some infantry, can change it individually later for some units that might be too fast (e.g. flamethrowers and grenadiers, who travel at speed=5).

Mammoth tank turret rotation speed increased to 3, matching its rotation speed. Seems like a good idea so that mammoth is more reliable as GDI's heavy anti-air unit. 
