### PR TITLE
Don't render empty remaining tick bars for iron curtain / chrono

### DIFF
--- a/OpenRA.Mods.RA/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Chronoshiftable.cs
@@ -82,9 +82,11 @@ namespace OpenRA.Mods.RA
 		// Show the remaining time as a bar
 		public float GetValue()
 		{
+			if (chronoshiftReturnTicks == 0) // otherwise an empty bar is rendered all the time
+				return 0f;
+
 			return (float)chronoshiftReturnTicks / TotalTicks;
 		}
-		
 		public Color GetColor() { return Color.White; }
 	}
 }

--- a/OpenRA.Mods.RA/IronCurtainable.cs
+++ b/OpenRA.Mods.RA/IronCurtainable.cs
@@ -45,9 +45,11 @@ namespace OpenRA.Mods.RA
 		// Show the remaining time as a bar
 		public float GetValue()
 		{
+			if (RemainingTicks == 0) // otherwise an empty bar is rendered all the time
+				return 0f;
+
 			return (float)RemainingTicks / TotalTicks;
 		}
-
 		public Color GetColor() { return Color.Red; }
 	}
 }


### PR DESCRIPTION
For some reason in C# float = 0 / value is not 0f? Anyway this fixes it. @ScottNZ complained about in IRC and it was ugly because it greyed out the top selection edges.
