### PR TITLE
Don't misinterpret AI orders as an exploit on dedicated servers anymore.

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -57,6 +57,7 @@ namespace OpenRA.Network
 			public int Team;
 			public string Slot;	// slot ID, or null for observer
 			public string Bot; // Bot type, null for real clients
+			public int BotControllerClientIndex; // who added the bot to the slot
 			public bool IsAdmin;
 			public bool IsReady { get { return State == ClientState.Ready; } }
 			public bool IsObserver { get { return Slot == null; } }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -528,9 +528,11 @@ namespace OpenRA.Server
 					SendDisconnected(toDrop); /* Report disconnection */
 
 				lobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
+				// remove the bots he added
+				lobbyInfo.Clients.RemoveAll(c => c.BotControllerClientIndex == toDrop.PlayerIndex);
 
 				// reassign admin if necessary
-				if ( lobbyInfo.GlobalSettings.Dedicated && dropClient.IsAdmin && State == ServerState.WaitingPlayers)
+				if (lobbyInfo.GlobalSettings.Dedicated && dropClient.IsAdmin && State == ServerState.WaitingPlayers)
 				{
 					if (lobbyInfo.Clients.Where(c1 => c1.Bot == null).Count() > 0)
 					{
@@ -545,7 +547,7 @@ namespace OpenRA.Server
 
 				if (conns.Count != 0 || lobbyInfo.GlobalSettings.Dedicated)
 					SyncLobbyInfo();
-				if ( !lobbyInfo.GlobalSettings.Dedicated && dropClient.IsAdmin )
+				if (!lobbyInfo.GlobalSettings.Dedicated && dropClient.IsAdmin)
 					Shutdown();
 			}
 

--- a/OpenRA.Game/Traits/ValidateOrder.cs
+++ b/OpenRA.Game/Traits/ValidateOrder.cs
@@ -31,8 +31,7 @@ namespace OpenRA.Traits
 				return false;
 			}
 
-			// Hack: Assumes bots always run on clientId 0.
-			var isBotOrder = subjectClient.Bot != null && clientId == 0;
+			var isBotOrder = subjectClient.Bot != null && clientId == subjectClient.BotControllerClientIndex;
 
 			// Drop exploiting orders
 			if (subjectClientId != clientId && !isBotOrder)

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -287,8 +287,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				{
 					var slot = orderManager.LobbyInfo.FirstEmptySlot();
 					var bot = Rules.Info["player"].Traits.WithInterface<IBotInfo>().Select(t => t.Name).FirstOrDefault();
+					var botController = orderManager.LobbyInfo.Clients.Where(c => c.IsAdmin).FirstOrDefault();
 					if (slot != null && bot != null)
-						orderManager.IssueOrder(Order.Command("slot_bot {0} {1}".F(slot, bot)));
+						orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot, botController.Index, bot)));
 				});
 		}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -71,8 +71,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				foreach (var b in Rules.Info["player"].Traits.WithInterface<IBotInfo>().Select(t => t.Name))
 				{
 					var bot = b;
+					var botController = orderManager.LobbyInfo.Clients.Where(c => c.IsAdmin).FirstOrDefault();
 					options.Add(new SlotDropDownOption("Bot: {0}".F(bot),
-						"slot_bot {0} {1}".F(slot.PlayerReference, bot),
+						"slot_bot {0} {1} {2}".F(slot.PlayerReference, botController.Index, bot),
 						() => client != null && client.Bot == bot));
 				}
 


### PR DESCRIPTION
Fixes #2540 and also cleans up bot slots when admins leave to prevent them becoming uncontrollable from the next client who joins.
