### PR TITLE
Map chooser polish & refactoring

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -190,7 +190,8 @@ namespace OpenRA
 						else
 							if (orderManager.NetFrameNumber == 0)
 								orderManager.LastTickTime = Environment.TickCount;
-					
+
+						world.TickRender(worldRenderer);
 						viewport.Tick();
 					}
 				}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -217,6 +217,7 @@
     <Compile Include="World.cs" />
     <Compile Include="WorldUtils.cs" />
     <Compile Include="Network\ReplayRecorderConnection.cs" />
+    <Compile Include="Widgets\TooltipContainerWidget.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Traits
 	}
 
 	public interface ITick { void Tick(Actor self); }
+	public interface ITickRender { void TickRender(WorldRenderer wr, Actor self); }
 	public interface IRender { IEnumerable<Renderable> Render(Actor self, WorldRenderer wr); }
 	public interface IAutoSelectionSize { int2 SelectionSize(Actor self); }
 

--- a/OpenRA.Game/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Game/Widgets/MapPreviewWidget.cs
@@ -155,6 +155,9 @@ namespace OpenRA.Widgets
 					Previews.Add(uid, bitmap);
 					cacheUids.Dequeue();
 				}
+
+				// Yuck... But this helps the UI Jank when opening the map selector significantly.
+				Thread.Sleep(50);
 			}
 		}
 
@@ -172,7 +175,6 @@ namespace OpenRA.Widgets
 			if (previewLoaderThread == null || !previewLoaderThread.IsAlive)
 			{
 				previewLoaderThread = new Thread(LoadAsyncInternal);
-				previewLoaderThread.Priority = ThreadPriority.Lowest;
 				previewLoaderThread.Start();
 			}
 		}

--- a/OpenRA.Game/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Game/Widgets/ScrollItemWidget.cs
@@ -14,6 +14,8 @@ namespace OpenRA.Widgets
 {
 	public class ScrollItemWidget : ButtonWidget
 	{
+		public string ItemKey;
+
 		public ScrollItemWidget()
 			: base()
 		{
@@ -28,6 +30,7 @@ namespace OpenRA.Widgets
 			IsVisible = () => false;
 			VisualHeight = 0;
 			IgnoreChildMouseOver = true;
+			Key = other.Key;
 		}
 
 		public Func<bool> IsSelected = () => false;
@@ -57,6 +60,13 @@ namespace OpenRA.Widgets
 		{
 			var w = Setup(template, isSelected, onClick);
 			w.OnDoubleClick = onDoubleClick;
+			return w;
+		}
+
+		public static ScrollItemWidget Setup(string key, ScrollItemWidget template, Func<bool> isSelected, Action onClick)
+		{
+			var w = Setup(template, isSelected, onClick);
+			w.ItemKey = key;
 			return w;
 		}
 	}

--- a/OpenRA.Game/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Game/Widgets/ScrollPanelWidget.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Drawing;
+using System.Linq;
 using OpenRA.Graphics;
 
 namespace OpenRA.Widgets
@@ -141,6 +142,25 @@ namespace OpenRA.Widgets
 		public void ScrollToTop()
 		{
 			ListOffset = 0;
+		}
+
+		public void ScrollToItem(string itemKey)
+		{
+			var item = Children.FirstOrDefault(c =>
+			{
+				var si = c as ScrollItemWidget;
+				return si != null && si.ItemKey == itemKey;
+			});
+
+			if (item == null)
+				return;
+
+			// Scroll the item to be visible
+			if (item.Bounds.Top + ListOffset < 0)
+				ListOffset = ItemSpacing - item.Bounds.Top;
+
+			if (item.Bounds.Bottom + ListOffset > RenderBounds.Height)
+				ListOffset = RenderBounds.Height - item.Bounds.Bottom - ItemSpacing;
 		}
 
 		public override void Tick ()

--- a/OpenRA.Game/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Game/Widgets/TooltipContainerWidget.cs
@@ -13,11 +13,10 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.RA;
 using OpenRA.Widgets;
 using System;
 
-namespace OpenRA.Mods.Cnc.Widgets
+namespace OpenRA.Widgets
 {
 	public class TooltipContainerWidget : Widget
 	{

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.FileFormats;
+using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Orders;
 using OpenRA.Support;
@@ -192,7 +193,12 @@ namespace OpenRA
 
 			while (frameEndActions.Count != 0)
 				frameEndActions.Dequeue()(this);
-			
+		}
+
+		// For things that want to update their render state once per tick, ignoring pause state
+		public void TickRender(WorldRenderer wr)
+		{
+			ActorsWithTrait<ITickRender>().Do(x => x.Trait.TickRender(wr, x.Actor));
 		}
 
 		public IEnumerable<Actor> Actors { get { return actors; } }

--- a/OpenRA.Mods.Cnc/CncMenuPaletteEffect.cs
+++ b/OpenRA.Mods.Cnc/CncMenuPaletteEffect.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.FileFormats;
+using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Cnc
 		public object Create(ActorInitializer init) { return new CncMenuPaletteEffect(this); }
 	}
 
-	public class CncMenuPaletteEffect : IPaletteModifier, ITick
+	public class CncMenuPaletteEffect : IPaletteModifier, ITickRender
 	{
 		public enum EffectType { None, Black, Desaturated }
 		public readonly CncMenuPaletteEffectInfo Info;
@@ -40,7 +41,7 @@ namespace OpenRA.Mods.Cnc
 			to = type;
 		}
 
-		public void Tick(Actor self)
+		public void TickRender(WorldRenderer wr, Actor self)
 		{
 			if (remainingFrames > 0)
 				remainingFrames--;

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -111,10 +111,10 @@
     <Compile Include="Widgets\ProductionTabsWidget.cs" />
     <Compile Include="Widgets\SupportPowersWidget.cs" />
     <Compile Include="Widgets\ToggleButtonWidget.cs" />
-    <Compile Include="Widgets\TooltipContainerWidget.cs" />
     <Compile Include="WithFire.cs" />
     <Compile Include="WithRoof.cs" />
     <Compile Include="Widgets\ResourceBarWidget.cs" />
+    <Compile Include="Widgets\Logic\SpawnSelectorTooltipLogic.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.Cnc/Widgets/Logic/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/SpawnSelectorTooltipLogic.cs
@@ -1,0 +1,79 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Widgets;
+using OpenRA.Network;
+
+namespace OpenRA.Mods.Cnc.Widgets.Logic
+{
+	public class SpawnSelectorTooltipLogic
+	{
+		[ObjectCreator.UseCtor]
+		public SpawnSelectorTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, MapPreviewWidget preview)
+		{
+			widget.IsVisible = () => preview.TooltipSpawnIndex != -1;
+			var label = widget.Get<LabelWidget>("LABEL");
+			var flag = widget.Get<ImageWidget>("FLAG");
+			var team = widget.Get<LabelWidget>("TEAM");
+
+			var ownerFont = Game.Renderer.Fonts[label.Font];
+			var teamFont = Game.Renderer.Fonts[team.Font];
+			var cachedWidth = 0;
+			var labelText = "";
+			string playerCountry = null;
+			var playerTeam = -1;
+
+			tooltipContainer.BeforeRender = () =>
+			{
+				var client = preview.SpawnClients().Values.FirstOrDefault(c => c.SpawnPoint == preview.TooltipSpawnIndex);
+
+				var teamWidth = 0;
+				if (client == null)
+				{
+					labelText = "Available spawn";
+					playerCountry = null;
+					playerTeam = 0;
+					widget.Bounds.Height = 25;
+				}
+				else
+				{
+					labelText = client.Name;
+					playerCountry = client.Country;
+					playerTeam = client.Team;
+					widget.Bounds.Height = playerTeam > 0 ? 40 : 25;
+					teamWidth = teamFont.Measure(team.GetText()).X;
+				}
+
+				label.Bounds.X = playerCountry != null ? flag.Bounds.Right + 5 : 5;
+
+				var textWidth = ownerFont.Measure(labelText).X;
+				if (textWidth != cachedWidth)
+				{
+					label.Bounds.Width = textWidth;
+					widget.Bounds.Width = 2*label.Bounds.X + textWidth;
+				}
+
+				widget.Bounds.Width = Math.Max(teamWidth + 10, label.Bounds.Right + 5);
+				team.Bounds.Width = widget.Bounds.Width;
+			};
+
+			label.GetText = () => labelText;
+			flag.IsVisible = () => playerCountry != null;
+			flag.GetImageCollection = () => "flags";
+			flag.GetImageName = () => playerCountry;
+			team.GetText = () => "Team {0}".F(playerTeam);
+			team.IsVisible = () => playerTeam > 0;
+		}
+	}
+}
+

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -122,6 +122,20 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				mapTitle.GetText = () => Map.Title;
 			}
 
+			var mapType = lobby.GetOrNull<LabelWidget>("MAP_TYPE");
+			if (mapType != null)
+			{
+				mapType.IsVisible = () => Map != null;
+				mapType.GetText = () => Map.Type;
+			}
+
+			var mapAuthor = lobby.GetOrNull<LabelWidget>("MAP_AUTHOR");
+			if (mapAuthor != null)
+			{
+				mapAuthor.IsVisible = () => Map != null;
+				mapAuthor.GetText = () => "Created by {0}".F(Map.Author);
+			}
+
 			CountryNames = Rules.Info["world"].Traits.WithInterface<CountryInfo>()
 				.Where(c => c.Selectable)
 				.ToDictionary(a => a.Race, a => a.Name);

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			mapPreview.Map = () => Map;
 			mapPreview.OnMouseDown = mi => LobbyUtils.SelectSpawnPoint( orderManager, mapPreview, Map, mi );
 			mapPreview.OnTooltip = (spawnPoint, pos) => LobbyUtils.ShowSpawnPointTooltip(orderManager, spawnPoint, pos);
-			mapPreview.SpawnColors = () => LobbyUtils.GetSpawnColors(orderManager, Map);
+			mapPreview.SpawnClients = () => LobbyUtils.GetSpawnClients(orderManager, Map);
 
 			var mapTitle = lobby.GetOrNull<LabelWidget>("MAP_TITLE");
 			if (mapTitle != null)

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -149,14 +149,14 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			color.AttachPanel(colorChooser);
 		}
 
-		public static Dictionary<int2, Color> GetSpawnColors(OrderManager orderManager, Map map)
+		public static Dictionary<int2, Session.Client> GetSpawnClients(OrderManager orderManager, Map map)
 		{
 			var spawns = map.GetSpawnPoints();
 			return orderManager.LobbyInfo.Clients
-				.Where( c => c.SpawnPoint != 0)
-				.ToDictionary(
-					c => spawns[c.SpawnPoint - 1],
-					c => c.ColorRamp.GetColor(0));
+				.Where(c => c.SpawnPoint != 0)
+					.ToDictionary(
+						c => spawns[c.SpawnPoint - 1],
+						c => c);
 		}
 
 		public static void SelectSpawnPoint(OrderManager orderManager, MapPreviewWidget mapPreview, Map map, MouseInput mi)

--- a/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
@@ -107,6 +107,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				previewWidget.IgnoreMouseOver = true;
 				previewWidget.IgnoreMouseInput = true;
 				previewWidget.Map = () => m;
+				previewWidget.IsVisible = () => previewWidget.RenderBounds.IntersectsWith(scrollpanel.RenderBounds);
 
 				var previewLoadingWidget = item.GetOrNull<BackgroundWidget>("PREVIEW_PLACEHOLDER");
 				if (previewLoadingWidget != null)

--- a/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
@@ -114,11 +114,11 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				var detailsWidget = item.GetOrNull<LabelWidget>("DETAILS");
 				if (detailsWidget != null)
-					detailsWidget.GetText = () => "{0} ({1})".F(m.Type, m.PlayerCount);
+					detailsWidget.GetText = () => "{0} ({1} players)".F(m.Type, m.PlayerCount);
 
 				var authorWidget = item.GetOrNull<LabelWidget>("AUTHOR");
 				if (authorWidget != null)
-					authorWidget.GetText = () => m.Author;
+					authorWidget.GetText = () => "Created by {0}".F(m.Author);
 
 				var sizeWidget = item.GetOrNull<LabelWidget>("SIZE");
 				if (sizeWidget != null)

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -32,6 +32,7 @@ Container@SERVER_LOBBY:
 							Y:1
 							Width:192
 							Height:192
+							TooltipContainer:TOOLTIP_CONTAINER
 				Label@MAP_TITLE:
 					X:PARENT_RIGHT-15-WIDTH
 					Y:227
@@ -403,6 +404,7 @@ Container@SERVER_LOBBY:
 							Height:25
 							Align:Right
 							Text:Chat:
+		TooltipContainer@TOOLTIP_CONTAINER:
 		Button@DISCONNECT_BUTTON:
 			X:0
 			Y:499

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -48,7 +48,7 @@ Container@SERVER_LOBBY:
 					Align:Center
 				Label@MAP_AUTHOR:
 					X:PARENT_RIGHT-15-WIDTH
-					Y:254
+					Y:255
 					Width:194
 					Height:25
 					Font:Tiny
@@ -343,13 +343,13 @@ Container@SERVER_LOBBY:
 							Font:Bold
 				Checkbox@ALLOWCHEATS_CHECKBOX:
 					X:15
-					Y:255
+					Y:257
 					Width:130
 					Height:20
 					Text: Allow Cheats
 				Checkbox@CRATES_CHECKBOX:
 					X:160
-					Y:255
+					Y:257
 					Width:80
 					Height:20
 					Text: Crates

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -34,10 +34,24 @@ Container@SERVER_LOBBY:
 							Height:192
 				Label@MAP_TITLE:
 					X:PARENT_RIGHT-15-WIDTH
-					Y:225
+					Y:227
 					Width:194
 					Height:25
 					Font:Bold
+					Align:Center
+				Label@MAP_TYPE:
+					X:PARENT_RIGHT-15-WIDTH
+					Y:242
+					Width:194
+					Height:25
+					Font:TinyBold
+					Align:Center
+				Label@MAP_AUTHOR:
+					X:PARENT_RIGHT-15-WIDTH
+					Y:254
+					Width:194
+					Height:25
+					Font:Tiny
 					Align:Center
 				ScrollPanel@PLAYERS:
 					X:15

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -347,13 +347,6 @@ Container@SERVER_LOBBY:
 					Font:Bold
 					Visible:false
 					Text:Assign
-				Button@RANDOMMAP_BUTTON:
-					X:PARENT_RIGHT-120-15-40
-					Y:255
-					Width:120
-					Height:25
-					Text:Random Map
-					Font:Bold
 				ScrollPanel@CHAT_DISPLAY:
 					X:15
 					Y:285

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -2,18 +2,18 @@ Container@MAPCHOOSER_PANEL:
 	Logic:MapChooserLogic
 	X:(WINDOW_RIGHT - WIDTH)/2
 	Y:(WINDOW_BOTTOM - 500)/2
-	Width:790
+	Width:740
 	Height:535
 	Children:
 		Label@TITLE:
-			Width:790
+			Width:PARENT_RIGHT
 			Y:0-25
 			Font:BigBold
 			Contrast:true
 			Align:Center
 			Text: Select Map
 		Background@bg:
-			Width:790
+			Width:PARENT_RIGHT
 			Height:500
 			Background:panel-black
 			Children:
@@ -37,44 +37,40 @@ Container@MAPCHOOSER_PANEL:
 					Height:440
 					Children:
 						ScrollItem@MAP_TEMPLATE:
-							Width:180
-							Height:208
+							Width:168
+							Height:215
 							X:2
 							Y:0
 							Visible:false
 							Children:
+								MapPreview@PREVIEW:
+									X:(PARENT_RIGHT - WIDTH)/2
+									Y:4
+									Width:158
+									Height:158
 								Label@TITLE:
 									X:2
-									Y:PARENT_BOTTOM-47
+									Y:PARENT_BOTTOM-45
 									Width:PARENT_RIGHT-4
-									Height:25
 									Align:Center
 								Label@DETAILS:
 									Width:PARENT_RIGHT-4
 									X:2
-									Y:PARENT_BOTTOM-35
+									Y:PARENT_BOTTOM-30
 									Align:Center
-									Height:25
 									Font:Tiny
 								Label@AUTHOR:
 									Width:PARENT_RIGHT-4
 									X:2
-									Y:PARENT_BOTTOM-26
+									Y:PARENT_BOTTOM-20
 									Align:Center
-									Height:25
 									Font:Tiny
 								Label@SIZE:
 									Width:PARENT_RIGHT-4
 									X:2
-									Y:PARENT_BOTTOM-17
+									Y:PARENT_BOTTOM-10
 									Align:Center
-									Height:25
 									Font:Tiny
-								MapPreview@PREVIEW:
-									X:(PARENT_RIGHT - WIDTH)/2
-									Y:4
-									Width:160
-									Height:160
 				Button@BUTTON_CANCEL:
 					Key:escape
 					X:0

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -2,7 +2,7 @@ Container@MAPCHOOSER_PANEL:
 	Logic:MapChooserLogic
 	X:(WINDOW_RIGHT - WIDTH)/2
 	Y:(WINDOW_BOTTOM - 500)/2
-	Width:740
+	Width:790
 	Height:535
 	Children:
 		Label@TITLE:

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -17,11 +17,24 @@ Container@MAPCHOOSER_PANEL:
 			Height:500
 			Background:panel-black
 			Children:
+				Label@GAMEMODE_DESC:
+					X:PARENT_RIGHT - WIDTH - 220
+					Y:10
+					Width:200
+					Height:25
+					Font: Bold
+					Align: Right
+					Text:Filter:
+				DropDownButton@GAMEMODE_FILTER:
+					X:PARENT_RIGHT - WIDTH - 15
+					Y:10
+					Width:200
+					Height:25
 				ScrollPanel@MAP_LIST:
 					X:15
-					Y:30
+					Y:45
 					Width:PARENT_RIGHT - 30
-					Height:455
+					Height:440
 					Children:
 						ScrollItem@MAP_TEMPLATE:
 							Width:180

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -43,6 +43,13 @@ Container@MAPCHOOSER_PANEL:
 							Y:0
 							Visible:false
 							Children:
+								Background@PREVIEW_PLACEHOLDER:
+									X:(PARENT_RIGHT - WIDTH)/2
+									Y:4
+									Width:158
+									Height:158
+									Background:panel-black
+									ClickThrough: false
 								MapPreview@PREVIEW:
 									X:(PARENT_RIGHT - WIDTH)/2
 									Y:4

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -69,9 +69,16 @@ Container@MAPCHOOSER_PANEL:
 					Width:140
 					Height:35
 					Text:Cancel
+				Button@RANDOMMAP_BUTTON:
+					Key:space
+					X:PARENT_RIGHT - 150 - WIDTH
+					Y:499
+					Width:140
+					Height:35
+					Text:Random
 				Button@BUTTON_OK:
 					Key:return
-					X:790 - WIDTH
+					X:PARENT_RIGHT - WIDTH
 					Y:499
 					Width:140
 					Height:35

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -38,7 +38,7 @@ Container@MAPCHOOSER_PANEL:
 					Children:
 						ScrollItem@MAP_TEMPLATE:
 							Width:168
-							Height:215
+							Height:217
 							X:2
 							Y:0
 							Visible:false
@@ -57,19 +57,19 @@ Container@MAPCHOOSER_PANEL:
 									Height:158
 								Label@TITLE:
 									X:2
-									Y:PARENT_BOTTOM-45
+									Y:PARENT_BOTTOM-48
 									Width:PARENT_RIGHT-4
 									Align:Center
 								Label@DETAILS:
 									Width:PARENT_RIGHT-4
 									X:2
-									Y:PARENT_BOTTOM-30
+									Y:PARENT_BOTTOM-34
 									Align:Center
 									Font:Tiny
 								Label@AUTHOR:
 									Width:PARENT_RIGHT-4
 									X:2
-									Y:PARENT_BOTTOM-20
+									Y:PARENT_BOTTOM-22
 									Align:Center
 									Font:Tiny
 								Label@SIZE:

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -99,3 +99,23 @@ Background@SUPPORT_POWER_TOOLTIP:
 			Y:20
 			Font:TinyBold
 			VAlign:Top
+
+Background@SPAWN_TOOLTIP:
+	Logic:SpawnSelectorTooltipLogic
+	Background:panel-black
+	Width:141
+	Children:
+		Label@LABEL:
+			X:5
+			Height:23
+			Font:Bold
+		Image@FLAG:
+			X:5
+			Y:5
+			Width:32
+			Height:16
+		Label@TEAM:
+			Y:21
+			Height:15
+			Font:TinyBold
+			Align:center

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -230,5 +230,6 @@ PVICE:
 	DrawLineToTarget:
 	Selectable:
 		Voice: DinoVoice
+	SelectionDecorations:
 	ActorLostNotification:
 		Notification: unitlost.aud


### PR DESCRIPTION
These changes add some much needed polish to the map chooser in C&C, and removes some of the issues associated with the map chooser logic.

The map list is now generated synchronously, but the previews generation is async within the MapPreviewWidget.
