### PR TITLE
Separate wiki update into it's own script

### DIFF
--- a/packaging/checkout-and-build.sh
+++ b/packaging/checkout-and-build.sh
@@ -63,6 +63,8 @@ fi
 
 ./upload-all.sh $TAG ~/openra-package/packages
 
+./update-wiki.sh
+
 popd &> /dev/null # packaging
 popd &> /dev/null # $_gitname-build
 popd &> /dev/null # ~/openra-package/

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -1,0 +1,8 @@
+echo "Updating https://github.com/OpenRA/OpenRA/wiki/Traits"
+rm -rf openra-wiki
+git clone git@github.com:OpenRA/OpenRA.wiki.git openra-wiki
+cp -fr ../DOCUMENTATION.md openra-wiki/Traits.md
+cd openra-wiki
+git add Traits.md
+git commit -m "Update trait documentation"
+git push origin master

--- a/packaging/upload-all.sh
+++ b/packaging/upload-all.sh
@@ -22,12 +22,3 @@ upload linux/rpm openra-${LINUXVERSION}-1.noarch.rpm
 upload linux/arch openra-${LINUXVERSION}-1-any.pkg.tar.xz
 
 curl http://${SERVER}/home/syncdownloads
-
-echo "Updating https://github.com/OpenRA/OpenRA/wiki/Traits"
-rm -rf openra-wiki
-git clone git@github.com:OpenRA/OpenRA.wiki.git openra-wiki
-cp -fr ../DOCUMENTATION.md openra-wiki/Traits.md
-cd openra-wiki
-git add Traits.md
-git commit -m "Update trait documentation"
-git push origin master


### PR DESCRIPTION
Last time the update operation failed because I got the paths wrong. I can't really simulate the build server paths on my home machine, but I still hope this just fixes it.

```
cp: cannot stat `../DOCUMENTATION.md': No such file or directory
build@build:~/openra-package$ dir
checkout-and-build.sh  OpenRA  OpenRA-build  packages
```
