### PR TITLE
slowed down *make animations to 80-tick

### DIFF
--- a/mods/cnc/sequences/map.yaml
+++ b/mods/cnc/sequences/map.yaml
@@ -696,12 +696,14 @@ hosp:
 	idle:
 		Start: 0
 		Length: 4
+		Tick: 100
 	damaged-idle:
 		Start: 4
 		Length: 4
 	make: hospmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 hosp.husk:
 	idle: hosp
@@ -715,6 +717,7 @@ bio:
 	make: biomake
 		Start: 0
 		Length: *
+		Tick: 80
 
 bio.husk:
 	idle: bio
@@ -728,6 +731,7 @@ miss:
 	make: missmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 miss.husk:
 	idle: miss

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -20,6 +20,7 @@ fact:
 	make: factmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 nuke:
 	idle:
@@ -36,6 +37,7 @@ nuke:
 	make: nukemake
 		Start: 0
 		Length: *
+		Tick: 80
 
 proc:
 	idle:
@@ -51,6 +53,7 @@ proc:
 	make: procmake
 		Start: 0
 		Length: *
+		Tick: 80
 	lights: proctwr
 		Start: 0
 		Length: 6
@@ -70,6 +73,7 @@ silo:
 	make: silomake
 		Start: 0
 		Length: *
+		Tick: 80
 
 hand:
 	idle:
@@ -81,6 +85,7 @@ hand:
 	make: handmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 pyle:
 	idle:
@@ -97,6 +102,7 @@ pyle:
 	make: pylemake
 		Start: 0
 		Length: *
+		Tick: 80
 
 weap:
 	idle:
@@ -118,6 +124,7 @@ weap:
 	make: weapmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 afld:
 	idle:
@@ -139,6 +146,7 @@ afld:
 	make: afldmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 hq:
 	idle:
@@ -154,6 +162,7 @@ hq:
 	make: hqmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 nuk2:
 	idle:
@@ -169,6 +178,7 @@ nuk2:
 	make: nuk2make
 		Start: 0
 		Length: *
+		Tick: 80
 
 hpad:
 	idle:
@@ -188,6 +198,7 @@ hpad:
 	make: hpadmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 fix:
 	idle:
@@ -205,6 +216,7 @@ fix:
 	make: fixmake
 		Start: 0
 		Length: 14
+		Tick: 60
 
 eye:
 	idle:
@@ -220,6 +232,7 @@ eye:
 	make: eyemake
 		Start: 0
 		Length: *
+		Tick: 80
 
 tmpl:
 	idle:
@@ -237,6 +250,7 @@ tmpl:
 	make: tmplmake
 		Start: 0
 		Length: *
+		Tick: 60
 
 obli:
 	idle:
@@ -254,6 +268,7 @@ obli:
 	make: oblimake
 		Start: 0
 		Length: 13
+		Tick: 80
 
 brik:
 	idle:
@@ -320,6 +335,7 @@ gun:
 	make: gunmake
 		Start: 0
 		Length: *
+		Tick: 80
 
 sam:
 	closed-idle:
@@ -349,6 +365,7 @@ sam:
 	make: sammake
 		Start: 0
 		Length: 20
+		Tick: 80
 	muzzle: samfire
 		Start: 0
 		Length: 18
@@ -363,6 +380,7 @@ gtwr:
 	make: gtwrmake
 		Start: 0
 		Length: *
+		Tick: 80
 	muzzle: minigun
 		Start: 0
 		Length: 6
@@ -378,4 +396,5 @@ atwr:
 	make: atwrmake
 		Start: 0
 		Length: *
+		Tick: 80
 


### PR DESCRIPTION
Animations were faster than they should be. Reduced to 80 tick. They look appropriate now, and close to the original.
I made TMPL and FIX 60 because it looked more natural. TMPL is slow to begin with, but it would look ok at 80, too.
