### PR TITLE
Convert FindUnitsInCircle radius later from float to int

### DIFF
--- a/OpenRA.Game/PSubVec.cs
+++ b/OpenRA.Game/PSubVec.cs
@@ -29,8 +29,6 @@ namespace OpenRA
 		public static explicit operator PSubVec(int2 a) { return new PSubVec(a.X, a.Y); }
 		public static explicit operator PSubVec(float2 a) { return new PSubVec((int)a.X, (int)a.Y); }
 
-		public static PSubVec FromRadius(int r) { return new PSubVec(r, r); }
-
 		public static PSubVec operator +(PSubVec a, PSubVec b) { return new PSubVec(a.X + b.X, a.Y + b.Y); }
 		public static PSubVec operator -(PSubVec a, PSubVec b) { return new PSubVec(a.X - b.X, a.Y - b.Y); }
 		public static PSubVec operator *(int a, PSubVec b) { return new PSubVec(a * b.X, a * b.Y); }

--- a/OpenRA.Game/PVecInt.cs
+++ b/OpenRA.Game/PVecInt.cs
@@ -28,7 +28,7 @@ namespace OpenRA
 
 		public static explicit operator PVecInt(int2 a) { return new PVecInt(a.X, a.Y); }
 
-		public static PVecInt FromRadius(int r) { return new PVecInt(r, r); }
+		public static PVecInt FromRadius(float r) { return new PVecInt((int)(r*Game.CellSize), (int)(r*Game.CellSize)); }
 
 		public static PVecInt operator +(PVecInt a, PVecInt b) { return new PVecInt(a.X + b.X, a.Y + b.Y); }
 		public static PVecInt operator -(PVecInt a, PVecInt b) { return new PVecInt(a.X - b.X, a.Y - b.Y); }

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -39,7 +39,7 @@ namespace OpenRA
 			return actors.OrderBy( a => (a.CenterLocation - px).LengthSquared ).FirstOrDefault();
 		}
 
-		public static IEnumerable<Actor> FindUnitsInCircle(this World world, PPos a, int r)
+		public static IEnumerable<Actor> FindUnitsInCircle(this World world, PPos a, float r)
 		{
 			using (new PerfSample("FindUnitsInCircle"))
 			{
@@ -52,7 +52,7 @@ namespace OpenRA
 
 				var inBox = actors.Where(x => x.ExtendedBounds.Value.IntersectsWith(rect));
 
-				return inBox.Where(x => (x.CenterLocation - a).LengthSquared < r * r);
+				return inBox.Where(x => (x.CenterLocation - a).LengthSquared < r * r * Game.CellSize * Game.CellSize);
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Missions/Nod01Script.cs
+++ b/OpenRA.Mods.Cnc/Missions/Nod01Script.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Cnc.Missions
 
         IEnumerable<Actor> UnitsNearActor(Actor actor, int range)
         {
-            return world.FindUnitsInCircle(actor.CenterLocation, Game.CellSize * range)
+            return world.FindUnitsInCircle(actor.CenterLocation, range)
                 .Where(a => a.IsInWorld && a != world.WorldActor && !a.Destroyed && a.HasTrait<IMove>() && !a.Owner.NonCombatant);
         }
 

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.RA.AI
 				if (owner.IsEmpty) return false;
 				var u = owner.units.Random(owner.random);
 
-				var units = owner.world.FindUnitsInCircle(u.CenterLocation, Game.CellSize * dangerRadius).ToList();
+				var units = owner.world.FindUnitsInCircle(u.CenterLocation, dangerRadius).ToList();
 				var ownBaseBuildingAround = units.Where(unit => unit.Owner == owner.bot.p && unit.HasTrait<Building>()).ToList();
 				if (ownBaseBuildingAround.Count > 0) return false;
 
@@ -325,7 +325,7 @@ namespace OpenRA.Mods.RA.AI
 			protected static bool NearToPosSafely(Squad owner, PPos loc, out Actor detectedEnemyTarget)
 			{
 				detectedEnemyTarget = null;
-				var unitsAroundPos = owner.world.FindUnitsInCircle(loc, Game.CellSize * dangerRadius)
+				var unitsAroundPos = owner.world.FindUnitsInCircle(loc, dangerRadius)
 					.Where(unit => owner.bot.p.Stances[unit.Owner] == Stance.Enemy).ToList();
 
 				int missileUnitsCount = 0;
@@ -509,7 +509,7 @@ namespace OpenRA.Mods.RA.AI
 					owner.Target = t;
 				}
 
-				var enemyUnits = owner.world.FindUnitsInCircle(owner.Target.CenterLocation, Game.CellSize * 10)
+				var enemyUnits = owner.world.FindUnitsInCircle(owner.Target.CenterLocation, 10)
 					.Where(unit => owner.bot.p.Stances[unit.Owner] == Stance.Enemy).ToList();
 				if (enemyUnits.Any())
 
@@ -554,7 +554,7 @@ namespace OpenRA.Mods.RA.AI
 				Actor leader = owner.units.ClosestTo(owner.Target.CenterLocation);
 				if (leader == null)
 					return;
-				var ownUnits = owner.world.FindUnitsInCircle(leader.CenterLocation, Game.CellSize * owner.units.Count/3)
+				var ownUnits = owner.world.FindUnitsInCircle(leader.CenterLocation, owner.units.Count/3)
 					.Where(a => a.Owner == owner.units.FirstOrDefault().Owner && owner.units.Contains(a)).ToList();
 				if (ownUnits.Count < owner.units.Count)
 				{
@@ -564,7 +564,7 @@ namespace OpenRA.Mods.RA.AI
 				}
 				else
 				{
-					var enemys = owner.world.FindUnitsInCircle(leader.CenterLocation, Game.CellSize * 12)
+					var enemys = owner.world.FindUnitsInCircle(leader.CenterLocation, 12)
 						.Where(a1 => !a1.Destroyed && !a1.IsDead()).ToList();
 					var enemynearby = enemys.Where(a1 => a1.HasTrait<ITargetable>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy).ToList();
 					if (enemynearby.Any())
@@ -1037,7 +1037,7 @@ namespace OpenRA.Mods.RA.AI
 
 		internal Actor FindClosestEnemy(PPos pos, int radius)
 		{
-			var enemyUnits = world.FindUnitsInCircle(pos, Game.CellSize * radius)
+			var enemyUnits = world.FindUnitsInCircle(pos, radius)
 								.Where(unit => p.Stances[unit.Owner] == Stance.Enemy &&
 									!unit.HasTrait<Husk>() && unit.HasTrait<ITargetable>()).ToList();
 
@@ -1194,7 +1194,7 @@ namespace OpenRA.Mods.RA.AI
 			if (!allEnemyBaseBuilder.Any() || (ownUnits.Count < Info.SquadSize)) return;
 			foreach (var b in allEnemyBaseBuilder)
 			{
-				var enemys = world.FindUnitsInCircle(b.CenterLocation, Game.CellSize * 15)
+				var enemys = world.FindUnitsInCircle(b.CenterLocation, 15)
 					.Where(unit => p.Stances[unit.Owner] == Stance.Enemy && unit.HasTrait<AttackBase>()).ToList();
 				
 				rushFuzzy.CalculateFuzzy(ownUnits, enemys);
@@ -1223,7 +1223,7 @@ namespace OpenRA.Mods.RA.AI
 				protectSq.Target = attacker;
 			if (protectSq.IsEmpty)
 			{
-				var ownUnits = world.FindUnitsInCircle(baseCenter.ToPPos(), Game.CellSize * 15)
+				var ownUnits = world.FindUnitsInCircle(baseCenter.ToPPos(), 15)
 									.Where(unit => unit.Owner == p && !unit.HasTrait<Building>()
 										&& unit.HasTrait<AttackBase>()).ToList();
 				foreach (var a in ownUnits)
@@ -1340,7 +1340,7 @@ namespace OpenRA.Mods.RA.AI
 				for (int j = 0; j < y; j += radiusOfPower * 2)
 				{
 					CPos pos = new CPos(i, j);
-					var targets = world.FindUnitsInCircle(pos.ToPPos(), Game.CellSize * radiusOfPower).ToList();
+					var targets = world.FindUnitsInCircle(pos.ToPPos(), radiusOfPower).ToList();
 					var enemys = targets.Where(unit => p.Stances[unit.Owner] == Stance.Enemy).ToList();
 					var ally = targets.Where(unit => p.Stances[unit.Owner] == Stance.Ally || unit.Owner == p).ToList();
 

--- a/OpenRA.Mods.RA/Activities/FindResources.cs
+++ b/OpenRA.Mods.RA/Activities/FindResources.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.RA.Activities
 						// Avoid enemy territory:
 						int safetycost = (
 							// TODO: calculate weapons ranges of units and factor those in instead of hard-coding 8.
-							from u in self.World.FindUnitsInCircle(loc.ToPPos(), Game.CellSize * 8)
+							from u in self.World.FindUnitsInCircle(loc.ToPPos(), 8)
 							where !u.Destroyed
 							where self.Owner.Stances[u.Owner] == Stance.Enemy
 							select Math.Max(0, 64 - (loc - u.Location).LengthSquared)

--- a/OpenRA.Mods.RA/Air/Helicopter.cs
+++ b/OpenRA.Mods.RA/Air/Helicopter.cs
@@ -112,7 +112,8 @@ namespace OpenRA.Mods.RA.Air
 			/* repulsion only applies when we're flying */
 			if (Altitude <= 0) return;
 
-			var otherHelis = self.World.FindUnitsInCircle(self.CenterLocation, Info.IdealSeparation)
+			var radius = Info.IdealSeparation / (float)Game.CellSize;
+			var otherHelis = self.World.FindUnitsInCircle(self.CenterLocation, radius)
 				.Where(a => a.HasTrait<Helicopter>());
 
 			var f = otherHelis

--- a/OpenRA.Mods.RA/AutoHeal.cs
+++ b/OpenRA.Mods.RA/AutoHeal.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public void TickIdle( Actor self )
 		{
 			var attack = self.Trait<AttackBase>();
-			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, (int)(Game.CellSize * attack.GetMaximumRange()));
+			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, attack.GetMaximumRange());
 
 			var target = inRange
 				.Where(a => a != self && a.AppearsFriendlyTo(self))

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.RA
 			var info = self.Info.Traits.Get<AttackBaseInfo>();
 			nextScanTime = self.World.SharedRandom.Next(info.MinimumScanTimeInterval, info.MaximumScanTimeInterval);
 
-			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, (int)(Game.CellSize * range));
+			var inRange = self.World.FindUnitsInCircle(self.CenterLocation, range);
 
 			if (self.Owner.HasFogVisibility()) {
 				return inRange

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -103,8 +103,8 @@ namespace OpenRA.Mods.RA
 			{
 				case DamageModel.Normal:
 					{
-						var maxSpread = warhead.Spread * (float)Math.Log(Math.Abs(warhead.Damage), 2);
-						var hitActors = world.FindUnitsInCircle(args.dest, (int)maxSpread);
+						var maxSpread = warhead.Spread * (float)Math.Log(Math.Abs(warhead.Damage), 2) / (float)Game.CellSize;
+						var hitActors = world.FindUnitsInCircle(args.dest, maxSpread);
 
 						foreach (var victim in hitActors)
 						{

--- a/OpenRA.Mods.RA/Missions/MissionUtils.cs
+++ b/OpenRA.Mods.RA/Missions/MissionUtils.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Missions
 	{
 		public static IEnumerable<Actor> FindAliveCombatantActorsInCircle(this World world, PPos location, int range)
 		{
-			return world.FindUnitsInCircle(location, Game.CellSize * range)
+			return world.FindUnitsInCircle(location, range)
 				.Where(u => u.IsInWorld && u != world.WorldActor && !u.IsDead() && !u.Owner.NonCombatant);
 		}
 
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Missions
 
 		public static IEnumerable<Actor> FindAliveNonCombatantActorsInCircle(this World world, PPos location, int range)
 		{
-			return world.FindUnitsInCircle(location, Game.CellSize * range)
+			return world.FindUnitsInCircle(location, range)
 				.Where(u => u.IsInWorld && u != world.WorldActor && !u.IsDead() && u.Owner.NonCombatant);
 		}
 

--- a/OpenRA.Mods.RA/ProximityCapturable.cs
+++ b/OpenRA.Mods.RA/ProximityCapturable.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.RA
 
 		IEnumerable<Actor> UnitsInRange()
 		{
-			return Self.World.FindUnitsInCircle(Self.CenterLocation, Game.CellSize * Info.Range)
+			return Self.World.FindUnitsInCircle(Self.CenterLocation, Info.Range)
 				.Where(a => a.IsInWorld && a != Self && !a.Destroyed)
 				.Where(a => !a.Owner.NonCombatant);
 		}


### PR DESCRIPTION
I tried to fix problems with AutoTarget: ranges and wanted to calculate it more precisely and deterministic. In the end nothing really worked out, but I kept this little cleanup. It does not change game behavior, but maybe makes PVecInt.FromRadius more useful. This change essentially lets the code of FindUnitsInCircle() look analogous to Combat.IsInRange().
