### PR TITLE
Debug the chosen target from AutoTarget for desync issues

### DIFF
--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Mods.RA
 		[Sync] public int stanceNumber { get { return (int)stance; } }
 		public UnitStance predictedStance;		/* NOT SYNCED: do not refer to this anywhere other than UI code */
 		[Sync] public int AggressorID;
+		[Sync] public int ChosenTargetID;
 
 		public AutoTarget(Actor self, AutoTargetInfo info)
 		{
@@ -107,7 +108,10 @@ namespace OpenRA.Mods.RA
 		{
 			var targetActor = ScanForTarget(self, null);
 			if (targetActor != null)
+			{
+				ChosenTargetID = (int)targetActor.ActorID;
 				attack.AttackTarget(Target.FromActor(targetActor), false, Info.AllowMovement && stance != UnitStance.Defend);
+			}
 		}
 
 		Actor ChooseTarget(Actor self, float range)
@@ -160,5 +164,17 @@ namespace OpenRA.Mods.RA
 		readonly AutoTarget a;
 		public DebugNextAutoTargetScanTime(Actor self){ a = self.Trait<AutoTarget>(); }
 		[Sync] public int NextAutoTargetScanTime { get { return a.nextScanTime; } }
+	}
+
+	public class DebugChosenAutoTargetInfo : ITraitInfo, Requires<AutoTargetInfo>
+	{
+		public object Create(ActorInitializer init) { return new DebugChosenAutoTarget(init.self); }
+	}
+	
+	public class DebugChosenAutoTarget : ISync
+	{
+		readonly AutoTarget a;
+		public DebugChosenAutoTarget(Actor self){ a = self.Trait<AutoTarget>(); }
+		[Sync] public int ChosenTarget { get { return a.ChosenTargetID; } }
 	}
 }

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -92,6 +92,7 @@ HELI:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode
@@ -142,6 +143,7 @@ ORCA:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -109,6 +109,7 @@
 		ScanRadius: 4
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Mobile:
 		Crushes: crate
 		SharesCell: true
@@ -154,6 +155,7 @@
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	-TakeCover:
 	-RenderInfantryProne:
 	AppearsOnRadar:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -171,6 +171,7 @@ E6:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 	RenderInfantryProne:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -28,6 +28,7 @@ BOAT:
 		AllowMovement: false
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	WithSmoke:
 
 LST:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -529,6 +529,7 @@ GUN:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	-AutoTargetIgnore:
 	-RenderBuilding:
 	-DeadBuildingState:
@@ -573,6 +574,7 @@ SAM:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	-RenderBuilding:
 	RenderRangeCircle:
 
@@ -615,6 +617,7 @@ OBLI:
 		QuantizedFacings: 8
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	-AutoTargetIgnore:
 	-RenderBuilding:
 	RenderRangeCircle:
@@ -652,6 +655,7 @@ GTWR:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	-AutoTargetIgnore:
 	DetectCloaked:
 		Range: 5
@@ -698,6 +702,7 @@ ATWR:
 		QuantizedFacings: 8
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	-AutoTargetIgnore:
 	RenderDetectionCircle:
 	DetectCloaked:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -113,6 +113,7 @@ APC:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
@@ -154,6 +155,7 @@ ARTY:
 		InitialStance: Defend
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	LeavesHusk:
 		HuskActor: ARTY.Husk
 
@@ -186,6 +188,7 @@ FTNK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	WithMuzzleFlash:
 	Explodes:
 		Weapon: FlametankExplode
@@ -225,6 +228,7 @@ BGGY:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	LeavesHusk:
 		HuskActor: BGGY.Husk
 
@@ -265,6 +269,7 @@ BIKE:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	LeavesHusk:
 		HuskActor: BIKE.Husk
 	
@@ -300,6 +305,7 @@ JEEP:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	LeavesHusk:
 		HuskActor: JEEP.Husk
 
@@ -336,6 +342,7 @@ LTNK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	LeavesHusk:
 		HuskActor: LTNK.Husk
 	Explodes:
@@ -374,6 +381,7 @@ MTNK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	LeavesHusk:
 		HuskActor: MTNK.Husk
 	Explodes:
@@ -421,6 +429,7 @@ HTNK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	SelfHealing:
 		Ticks: 10
 		HealIfBelow: 50%
@@ -465,6 +474,7 @@ MSAM:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	LeavesHusk:
 		HuskActor: MSAM.Husk
 
@@ -501,6 +511,7 @@ MLRS:
 		InitialStance: Defend
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -544,6 +555,7 @@ STNK:
 		InitialStance: HoldFire
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	TargetableUnit:
 	LeavesHusk:
 		HuskActor: STNK.Husk

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -101,6 +101,7 @@
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	AttackMove:
 	Passenger:
 		CargoType: Infantry

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -172,6 +172,7 @@ E6:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 	-RenderInfantry:
@@ -209,6 +210,7 @@ SPY:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 	-RenderInfantry:
@@ -330,6 +332,7 @@ MEDI:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 	-RenderInfantry:
@@ -368,6 +371,7 @@ MECH:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 	-RenderInfantry:
@@ -392,6 +396,7 @@ EINSTEIN:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 	ProximityCaptor:
@@ -418,6 +423,7 @@ DELPHI:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 	ProximityCaptor:
@@ -460,6 +466,7 @@ THF:
 	-AutoTarget:
 	-DebugRetiliateAgainstAggressor:
 	-DebugNextAutoTargetScanTime:
+	-DebugChosenAutoTarget:
 	AttackMove:
 		JustMove: true
 

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -92,9 +92,10 @@ MSUB:
 	RepairableNear:
 	-DetectCloaked:
 	AutoTarget:
+		InitialStance: HoldFire
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
-		InitialStance: HoldFire
+	DebugChosenAutoTarget:
 	AttackMove:
 
 DD:
@@ -138,6 +139,7 @@ DD:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Chronoshiftable:
 	IronCurtainable:
 	RepairableNear:
@@ -195,6 +197,7 @@ CA:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Chronoshiftable:
 	IronCurtainable:
 	RepairableNear:
@@ -267,6 +270,7 @@ PT:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Chronoshiftable:
 	IronCurtainable:
 	RepairableNear:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -292,6 +292,7 @@ TSLA:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	IronCurtainable:
 	-RenderBuilding:
 	RenderRangeCircle:
@@ -453,6 +454,7 @@ PBOX.E1:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Vulcan
 		LocalOffset: 469,0,0
@@ -478,6 +480,7 @@ PBOX.E3:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Dragon
 		LocalOffset: 469,0,0
@@ -493,6 +496,7 @@ PBOX.E4:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Flamer
 		LocalOffset: 469,0,0
@@ -508,6 +512,7 @@ PBOX.E7:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Colt45
 		LocalOffset: 469,0,0
@@ -523,6 +528,7 @@ PBOX.SHOK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: PortaTesla
 		LocalOffset: 469,0,0
@@ -538,6 +544,7 @@ PBOX.SNIPER:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Sniper
 		LocalOffset: 469,0,0
@@ -630,6 +637,7 @@ HBOX.E1:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Vulcan
 		LocalOffset: 469,0,0
@@ -655,6 +663,7 @@ HBOX.E3:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Dragon
 		LocalOffset: 469,0,0
@@ -670,6 +679,7 @@ HBOX.E4:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Flamer
 		LocalOffset: 469,0,0
@@ -685,6 +695,7 @@ HBOX.E7:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Colt45
 		LocalOffset: 469,0,0
@@ -700,6 +711,7 @@ HBOX.SHOK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: PortaTesla
 		LocalOffset: 469,0,0
@@ -715,6 +727,7 @@ HBOX.SNIPER:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament:
 		Weapon: Sniper
 		LocalOffset: 469,0,0
@@ -752,6 +765,7 @@ GUN:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	IronCurtainable:
 	-RenderBuilding:
 	RenderRangeCircle:
@@ -792,6 +806,7 @@ FTUR:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	IronCurtainable:
 	RenderRangeCircle:
 	-AcceptsSupplies:
@@ -832,6 +847,7 @@ SAM:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	IronCurtainable:
 	-RenderBuilding:
 	RenderRangeCircle:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -26,6 +26,7 @@ V2RL:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: SCUD
 		EmptyWeapon:
@@ -61,6 +62,7 @@ V2RL:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -100,6 +102,7 @@ V2RL:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -142,6 +145,7 @@ V2RL:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -189,6 +193,7 @@ V2RL:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -234,6 +239,7 @@ ARTY:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 
 HARV:
 	Inherits: ^Vehicle
@@ -348,6 +354,7 @@ JEEP:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
@@ -383,6 +390,7 @@ APC:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
@@ -643,6 +651,7 @@ TTNK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 
 FTRK:
 	Inherits: ^Vehicle
@@ -676,6 +685,7 @@ FTRK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -741,6 +751,7 @@ CTNK:
 	AutoTarget:
 	DebugRetiliateAgainstAggressor:
 	DebugNextAutoTargetScanTime:
+	DebugChosenAutoTarget:
 	Armament@PRIMARY:
 		Weapon: ChronoTusk
 		LocalOffset: 0,-171,0


### PR DESCRIPTION
AutoTarget: is definitely still busted and responsible for #2843 but I don't know why. Is it wrong timing or does it pick the wrong actor? Is it just one edge case or is this broken in multiple ways? Did per-player-shrouds introduce this, is it a rounding error due to ranges in this strange coordinate system or problems with Mono vs .NET? Does cloaking not work properly with AutoTarget?
