### PR TITLE
Display Ping of joining Clients in Lobby and use it to calculate OrderLatency

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -61,6 +61,7 @@ namespace OpenRA.Network
 			public bool IsAdmin;
 			public bool IsReady { get { return State == ClientState.Ready; } }
 			public bool IsObserver { get { return Slot == null; } }
+			public int Ping = -1;
 		}
 
 		public class Slot
@@ -82,7 +83,7 @@ namespace OpenRA.Network
 			public string Map;
 			public string[] Ban;
 			public string[] Mods = { "ra" };	// mod names
-			public int OrderLatency = 3;		// x 40 = ms
+			public int OrderLatency = 3;		// net tick frames (x 120 = ms)
 			public int RandomSeed = 0;
 			public bool FragileAlliances = false;	// Allow diplomatic stance changes after game start.
 			public bool AllowCheats = false;

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Network
 			public string Map;
 			public string[] Ban;
 			public string[] Mods = { "ra" };	// mod names
-			public int OrderLatency = 3;
+			public int OrderLatency = 3;		// x 40 = ms
 			public int RandomSeed = 0;
 			public bool FragileAlliances = false;	// Allow diplomatic stance changes after game start.
 			public bool AllowCheats = false;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -164,8 +164,7 @@ namespace OpenRA.Network
 							&& !orderManager.GameStarted)
 						{
 							orderManager.FramesAhead = orderManager.LobbyInfo.GlobalSettings.OrderLatency;
-							Game.Debug(
-								"Order lag is now {0} frames.".F(orderManager.LobbyInfo.GlobalSettings.OrderLatency));
+							Game.Debug("Order lag is now {0} frames.".F(orderManager.LobbyInfo.GlobalSettings.OrderLatency));
 						}
 						Game.SyncLobbyInfo();
 						break;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -322,6 +322,8 @@ namespace OpenRA.Server
 				preConns.Remove(newConn);
 				conns.Add(newConn);
 
+				client.Ping = newConn.Latency;
+
 				// Enforce correct PlayerIndex and Slot
 				client.Index = newConn.PlayerIndex;
 				client.Slot = lobbyInfo.FirstEmptySlot();
@@ -565,7 +567,7 @@ namespace OpenRA.Server
 
 			Log.Write("server", "Measured {0} ms as the highest connection round trip time.".F(highestLatency));
 
-			lobbyInfo.GlobalSettings.OrderLatency = highestLatency / 40; // 1 frame is 40 ms
+			lobbyInfo.GlobalSettings.OrderLatency = highestLatency / 120;
 			if (lobbyInfo.GlobalSettings.OrderLatency < 1) // should never be 0
 				lobbyInfo.GlobalSettings.OrderLatency = 1;
 

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -477,6 +477,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					template.Get<LabelWidget>("NAME").GetText = () => client.Name;
 					if (client.IsAdmin)
 						template.Get<LabelWidget>("NAME").Font = "Bold";
+					if (client.Ping > -1)
+						template.Get<LabelWidget>("NAME").GetColor = () => LobbyUtils.GetPingColor(client.Ping);
+
 					var color = template.Get<ColorBlockWidget>("COLOR");
 					color.GetColor = () => client.ColorRamp.GetColor(0);
 

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -26,6 +26,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			if (c.IsAdmin)
 				name.Font = "Bold";
 			name.Text = c.Name;
+			if (c.Ping > -1)
+				name.TextColor = GetPingColor(c.Ping);
 			name.OnEnterKey = () =>
 			{
 				name.Text = name.Text.Trim();
@@ -188,6 +190,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				Game.Renderer.Fonts["Bold"].DrawTextWithContrast(client.Name, position + new int2(5, 5), Color.White, Color.Black, 1);
 			}
+		}
+
+		public static Color GetPingColor(int ping)
+		{
+			if (ping > 720) // OrderLag > 6
+				return Color.Red;
+			if (ping > 360) // OrderLag > 3
+				return Color.Orange;
+			return Color.LimeGreen;
 		}
 	}
 }


### PR DESCRIPTION
Addresses both #2124 and #2990. It will also result in Single-Player games being played with OrderLag = 1 instead of the hard-coded 3 now because pinging localhost results in << 120 ms round trip time.
