### PR TITLE
Resolve hotkey conflicts between build palette and world command widget once and for all

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -146,9 +146,9 @@ namespace OpenRA.GameRules
 
 		public string AttackMoveKey = "a";
 		public string StopKey = "s";
-		public string ScatterKey = "d";
+		public string ScatterKey = "x";
 		public string DeployKey = "f";
-		public string StanceCycleKey = "g";
+		public string StanceCycleKey = "z";
 
 		public string CycleTabsKey = "tab";
 	}

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -150,8 +150,9 @@ namespace OpenRA.Mods.RA.Widgets
 				TabChange(e.Modifiers.HasModifier(Modifiers.Shift));
 				return true;
 			}
-
-			return DoBuildingHotkey(e.KeyName, world);
+			if (e.Modifiers == Modifiers.Alt)
+				return DoBuildingHotkey(e.KeyName, world);
+			return false;
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -454,7 +455,7 @@ namespace OpenRA.Mods.RA.Widgets
 			WidgetUtils.DrawPanel("dialog4", new Rectangle(Game.viewport.Width - 300, pos.Y, 300, longDescSize + 65));
 
 			Game.Renderer.Fonts["Bold"].DrawText(
-				tooltip.Name + ((buildable.Hotkey != null) ? " ({0})".F(buildable.Hotkey.ToUpper()) : ""),
+				tooltip.Name + ((buildable.Hotkey != null) ? " (ALT + {0})".F(buildable.Hotkey.ToUpper()) : ""),
 												   p.ToInt2() + new int2(5, 5), Color.White);
 
 			var resources = pl.PlayerActor.Trait<PlayerResources>();


### PR DESCRIPTION
Build palette hotkeys require the ALT modifier now to avoid conflicts. This allows to change back the unit action hotkeys scatter / stance cycle to what they were before.
