### PR TITLE
making bridges indestructible for now

### DIFF
--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -106,13 +106,13 @@ namespace OpenRA.Mods.RA.Widgets
 		bool PerformScatter()
 		{
 			PerformKeyboardOrderOnSelection(a => new Order("Scatter", a, false));
+			PerformKeyboardOrderOnSelection(a => new Order("ReturnToBase", a, false));
 			return true;
 		}
 
 		bool PerformDeploy()
 		{
 			/* hack: multiple orders here */
-			PerformKeyboardOrderOnSelection(a => new Order("ReturnToBase", a, false));
 			PerformKeyboardOrderOnSelection(a => new Order("DeployTransform", a, false));
 			PerformKeyboardOrderOnSelection(a => new Order("Unload", a, false));
 			PerformKeyboardOrderOnSelection(a => new Order("DemoDeploy", a, false));

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -418,7 +418,7 @@
 		TargetTypes: Ground, Water
 	BelowUnits:
 	Health:
-		HP: 500
+#		HP: 500
 	SoundOnDamageTransition:
 		DamagedSound: xplos.aud
 		DestroyedSound: xplobig4.aud


### PR DESCRIPTION
Making bridges indestructible.
Rationale: 
-many maps don't work when bridges are destructible (most or all of the crossings are bridges)
-bridges will be repairable in the future. At this point, an engi can come and re-open it, but in the meantime, they shouldn't be destroyed.
-if someone wants to make a map with destructible bridges, they still can, by editing the .yaml themselves. This should be the default, though.

(FWIW, bridges were not destructible in C&C 1.)
