### PR TITLE
Better name for automatic port forwarding and enabled by default if all pre-checks end well.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -281,13 +281,13 @@ namespace OpenRA
 				{
 					Log.Write("server", "Can't discover UPnP-enabled device: {0}", e);
 					Settings.Server.NatDeviceAvailable = false;
-					Settings.Server.AllowUPnP = false;
+					Settings.Server.AllowPortForward = false;
 				}
 			}
 			else
 			{
 				Settings.Server.NatDeviceAvailable = false;
-				Settings.Server.AllowUPnP = false;
+				Settings.Server.AllowPortForward = false;
 			}
 
 			FileSystem.Mount("."); // Needed to access shaders
@@ -315,14 +315,14 @@ namespace OpenRA
 					{
 						Log.Write("server", "Failed to stop NAT device discovery: {0}", e);
 						Settings.Server.NatDeviceAvailable = false;
-						Settings.Server.AllowUPnP = false;
+						Settings.Server.AllowPortForward = false;
 					}
 
 					if (natDevice == null)
 					{
 						Log.Write("server", "No NAT devices with UPnP enabled found within {0} ms deadline. Disabling automatic port forwarding.".F(Settings.Server.NatDiscoveryTimeout));
 						Settings.Server.NatDeviceAvailable = false;
-						Settings.Server.AllowUPnP = false;
+						Settings.Server.AllowPortForward = false;
 					}
 				});
 			}
@@ -336,7 +336,7 @@ namespace OpenRA
 			Log.Write("server", "NAT device discovered.");
 
 			Settings.Server.NatDeviceAvailable = true;
-			Settings.Server.AllowUPnP = true;
+			Settings.Server.AllowPortForward = true;
 
 			try
 			{
@@ -353,7 +353,7 @@ namespace OpenRA
 				Log.Write("server", "Can't fetch information from NAT device: {0}", e);
 
 				Settings.Server.NatDeviceAvailable = false;
-				Settings.Server.AllowUPnP = false;
+				Settings.Server.AllowPortForward = false;
 			}
 		}
 
@@ -375,7 +375,7 @@ namespace OpenRA
 			}
 
 			Settings.Server.NatDeviceAvailable = false;
-			Settings.Server.AllowUPnP = false;
+			Settings.Server.AllowPortForward = false;
 		}
 
 		public static void InitializeWithMods(string[] mods)
@@ -538,7 +538,7 @@ namespace OpenRA
 			// Work around a miscompile in mono 2.6.7:
 			// booleans that default to true cannot be set false by an initializer
 			settings.AdvertiseOnline = false;
-			settings.AllowUPnP = false;
+			settings.AllowPortForward = false;
 
 			server = new Server.Server(new IPEndPoint(IPAddress.Loopback, 0),
 			                           Game.Settings.Game.Mods, settings, modData, natDevice);

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -30,7 +30,7 @@ namespace OpenRA.GameRules
 		public bool AdvertiseOnline = true;
 		public string MasterServer = "http://master.open-ra.org/";
 		public bool DiscoverNatDevices = true; // Allow users to disable NAT discovery if problems occur
-		public bool AllowUPnP = true; // let the user disable it even if compatible devices are found
+		public bool AllowPortForward = true; // let the user disable it even if compatible devices are found
 		public bool NatDeviceAvailable = false; // internal check if discovery succeeded
 		public int NatDiscoveryTimeout = 1000; // ms to search for UPnP enabled NATs
 		public bool VerboseNatDiscovery = false; // print very detailed logs for debugging
@@ -53,7 +53,7 @@ namespace OpenRA.GameRules
 			AdvertiseOnline = other.AdvertiseOnline;
 			MasterServer = other.MasterServer;
 			DiscoverNatDevices = other.DiscoverNatDevices;
-			AllowUPnP = other.AllowUPnP;
+			AllowPortForward = other.AllowPortForward;
 			NatDeviceAvailable = other.NatDeviceAvailable;
 			NatDiscoveryTimeout = other.NatDiscoveryTimeout;
 			VerboseNatDiscovery = other.VerboseNatDiscovery;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Server
 
 			randomSeed = (int)DateTime.Now.ToBinary();
 
-			if (Settings.AllowUPnP)
+			if (Settings.AllowPortForward)
 				ForwardPort();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
@@ -157,7 +157,7 @@ namespace OpenRA.Server
 					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();
-						if (Settings.AllowUPnP)
+						if (Settings.AllowPortForward)
 							RemovePortforward();
 						break;
 					}
@@ -185,7 +185,7 @@ namespace OpenRA.Server
 			catch (Exception e)
 			{
 				Log.Write("server", "Can not forward ports via UPnP: {0}", e);
-				Settings.AllowUPnP = false;
+				Settings.AllowPortForward = false;
 			}
 		}
 
@@ -200,7 +200,7 @@ namespace OpenRA.Server
 			catch (Exception e)
 			{
 				Log.Write("server", "Can not remove UPnP portforwarding rules: {0}", e);
-				Settings.AllowUPnP = false;
+				Settings.AllowPortForward = false;
 			}
 		}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerCreationLogic.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		Action onExit;
 		Map map;
 		bool advertiseOnline;
-		bool allowUPnP;
+		bool allowPortForward;
 
 		[ObjectCreator.UseCtor]
 		public ServerCreationLogic(Widget widget, Action onExit, Action openLobby)
@@ -66,9 +66,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			advertiseCheckbox.IsChecked = () => advertiseOnline;
 			advertiseCheckbox.OnClick = () => advertiseOnline ^= true;
 
+			allowPortForward = Game.Settings.Server.AllowPortForward;
 			var UPnPCheckbox = panel.Get<CheckboxWidget>("UPNP_CHECKBOX");
-			UPnPCheckbox.IsChecked = () => allowUPnP;
-			UPnPCheckbox.OnClick = () => allowUPnP ^= true;
+			UPnPCheckbox.IsChecked = () => allowPortForward;
+			UPnPCheckbox.OnClick = () => allowPortForward ^= true;
 			UPnPCheckbox.IsDisabled = () => !Game.Settings.Server.NatDeviceAvailable;
 		}
 
@@ -87,7 +88,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			Game.Settings.Server.ListenPort = listenPort;
 			Game.Settings.Server.ExternalPort = externalPort;
 			Game.Settings.Server.AdvertiseOnline = advertiseOnline;
-			Game.Settings.Server.AllowUPnP = allowUPnP;
+			Game.Settings.Server.AllowPortForward = allowPortForward;
 			Game.Settings.Server.Map = map.Uid;
 			Game.Settings.Save();
 


### PR DESCRIPTION
No need to ignore the suggestion after all those try catch monsters checked if it is going to work. `Server.AllowPortForward` should make it easier to understand what the variable does now that there are more to control the default Nat behavior.
