### PR TITLE
Making bridges indestructible for now.

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -14,7 +14,6 @@ TRAN:
 	Selectable:
 		Bounds: 41,41
 	Helicopter:
-		RearmBuildings: hpad
 		LandWhenIdle: true
 		ROT: 5
 		Speed: 15

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -418,7 +418,7 @@
 		TargetTypes: Ground, Water
 	BelowUnits:
 	Health:
-		HP: 500
+#		HP: 500
 	SoundOnDamageTransition:
 		DamagedSound: xplos.aud
 		DestroyedSound: xplobig4.aud

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -134,7 +134,7 @@ ARTY:
 		Icon:artyicnh
 		Description: Long-range artillery.\n  Strong vs Infantry, Vehicles\n  Weak vs Tanks, Aircraft
 	Buildable:
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 50
 		Prerequisites: anyhq
 		Owner: nod
 	Mobile:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -134,7 +134,7 @@ ARTY:
 		Icon:artyicnh
 		Description: Long-range artillery.\n  Strong vs Infantry, Vehicles\n  Weak vs Tanks, Aircraft
 	Buildable:
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 60
 		Prerequisites: anyhq
 		Owner: nod
 	Mobile:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -29,7 +29,7 @@ UnitExplode:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: 8
+		Explosion: poof
 		InfDeath: 4
 		ImpactSound: xplobig6
 
@@ -195,7 +195,7 @@ Pistol:
 			Light: 50%
 			Heavy: 25%
 		InfDeath: 2
-		Explosion: 1
+		Explosion: piff
 		Damage: 1
 
 M16:
@@ -211,7 +211,7 @@ M16:
 			Wood: 25%
 			Light: 30%
 			Heavy: 10%
-		Explosion: 1
+		Explosion: piff
 		InfDeath: 2
 		Damage: 15
 
@@ -240,7 +240,7 @@ Rockets:
 			Heavy: 100%
 			Concrete: 25%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 30
@@ -272,7 +272,7 @@ BikeRockets:
 			Heavy: 100%
 			Concrete: 50%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 30
@@ -303,7 +303,7 @@ OrcaAGMissiles:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 40
@@ -334,7 +334,7 @@ OrcaAAMissiles:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 40
@@ -415,7 +415,7 @@ Grenade:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 3
-		Explosion: 5
+		Explosion: small_poof
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 50
@@ -436,7 +436,7 @@ Grenade:
 			Heavy: 100%
 			Concrete: 50%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 25
@@ -456,7 +456,7 @@ Grenade:
 			Light: 75%
 			Heavy: 100%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 30
@@ -477,7 +477,7 @@ Grenade:
 			Heavy: 100%
 			Concrete: 50%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 40
@@ -500,7 +500,7 @@ Grenade:
 			Heavy: 100%
 			Concrete: 100%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 40
@@ -520,7 +520,7 @@ TurretGun:
 			Light: 75%
 			Heavy: 100%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 60
@@ -550,7 +550,7 @@ MammothMissiles:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 75
@@ -613,7 +613,7 @@ MammothMissiles:
 			Light: 100%
 			Heavy: 90%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 60
@@ -687,7 +687,7 @@ BoatMissile:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 3
-		Explosion: 5
+		Explosion: small_poof
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 60
@@ -749,7 +749,7 @@ Napalm.Crate:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 5
-		Explosion: 3
+		Explosion: med_napalm
 		ImpactSound: flamer2
 		SmudgeType: Scorch
 		Damage: 500
@@ -792,7 +792,7 @@ SAMMissile:
 			Light: 100%
 			Heavy: 75%
 		InfDeath: 4
-		Explosion: 4
+		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 55
@@ -820,7 +820,7 @@ HonestJohn:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 3
-		Explosion: 5
+		Explosion: small_poof
 		ImpactSound: xplos
 		SmudgeType: Crater
 		Damage: 100

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -111,7 +111,7 @@ IonCannon:
 Sniper:
 	Report: RAMGUN2
 	ROF: 40
-	Range: 7
+	Range: 5.5
 	Projectile: Bullet
 		Speed: 100
 	Warhead: 


### PR DESCRIPTION
Making bridges indestructible.
Rationale: 
-many maps don't work when bridges are destructible (most or all of the crossings are bridges)
-bridges will be repairable in the future. At this point, an engi can come and re-open it, but in the meantime, they shouldn't be destroyed.
-if someone wants to make a map with destructible bridges, they still can, by editing the .yaml themselves. This should be the default, though.

(FWIW, bridges were not destructible in C&C 1.)
