### PR TITLE
shortened conyard cooldown 5 -> 4 secs

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -46,7 +46,7 @@ FACT:
 	BaseBuilding:
 	ProductionBar:
 	BaseProvider:
-		Cooldown: 125
+		Cooldown: 100
 		Range: 14
 
 NUKE:


### PR DESCRIPTION
The cooldown on the construction yard building is too damn long.
