### PR TITLE
making FIX cheaper, since no one uses it. Lower HP

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -399,7 +399,7 @@ HQ:
 FIX:
 	Inherits: ^Building
 	Valued:
-		Cost: 1200
+		Cost: 600
 	Tooltip:
 		Name: Repair Facility
 		Icon: fixicnh
@@ -413,7 +413,7 @@ FIX:
 		Footprint: _x_ xxx _x_
 		Dimensions: 3,3
 	Health:
-		HP: 800
+		HP: 400
 	RevealsShroud:
 		Range: 5
 	BelowUnits:


### PR DESCRIPTION
Nobody uses repair bay, because it's not a pre-requisite for anything, and it's expensive. Reducing cost from $1200 to $600.
To compensate for its lower value, its HP are being lowered as well, from 800 to 400. Now it should be killable with an airstrike, which is about right. 

To anyone paying attention: there has been some discussion over whether repairs should be cheaper. I am agnostic on the issue for now. How about we see if people like the repair bay more now and consider using it, before making further balance changes? Open to discussion.
