### PR TITLE
fix bogus shroud disable

### DIFF
--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -81,7 +81,8 @@ namespace OpenRA.Traits
 				case "DevShroudDisable":
 					{
 						DisableShroud ^= true;
-						self.World.RenderPlayer = DisableShroud ? null : self.Owner;
+						if (self.World.LocalPlayer == self.Owner)
+							self.World.RenderPlayer = DisableShroud ? null : self.Owner;
 						break;
 					}
 				case "DevPathDebug":


### PR DESCRIPTION
This code runs everywhere -- and so was clobbering every client's
RenderedPlayer to the player who was setting their cheat.
