### PR TITLE
Update ViewportScrollControllerWidget.cs

### DIFF
--- a/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportScrollControllerWidget.cs
@@ -96,10 +96,8 @@ namespace OpenRA.Widgets
             if (Game.Settings.Game.ViewportEdgeScroll && Game.HasInputFocus)
             {
                 Edge = CheckForDirections();
-                Scroll();
             }
-
-
+	    Scroll();
         }
 
         ScrollDirection CheckForDirections()


### PR DESCRIPTION
Moved Scroll() out of the if statement checking to see if edge scrolling was enabled thereby fixing bug introduced that stops keyboard from working if edge scrolling is not enabled.
