### PR TITLE
fix artillery explode

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -153,7 +153,7 @@ ARTY:
 	RenderUnit:
 	Explodes:
 		Weapon: UnitExplode
-		Chance: 75	
+		EmptyWeapon: UnitExplode
 	AutoTarget:
 		InitialStance: Defend
 	DebugRetiliateAgainstAggressor:


### PR DESCRIPTION
For some reason artillery wasn't exploding. I had set it at 75% odds last time I edited it. Just making it explode again.
It really needs to explode. It only costs $600 and is pretty powerful. This is its drawback, to make it vulnerable if player bunches them up.
