### PR TITLE
Attempt to unify versioning with downstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@ CSC         = gmcs
 CSFLAGS     = -nologo -warn:4 -debug:full -optimize- -codepage:utf8 -unsafe -warnaserror
 DEFINE      = DEBUG;TRACE
 COMMON_LIBS = System.dll System.Core.dll System.Drawing.dll System.Xml.dll thirdparty/ICSharpCode.SharpZipLib.dll thirdparty/FuzzyLogicLibrary.dll thirdparty/Mono.Nat.dll
-PHONY       = core tools package all mods clean distclean dependencies
+PHONY       = core tools package all mods clean distclean dependencies version
+VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
 
 .SUFFIXES:
 core: game renderers mods utility tsbuild
 tools: editor ralint tsbuild
-package: dependencies core editor docs
+package: dependencies core editor docs version
 mods: mod_ra mod_cnc mod_d2k
 all: dependencies core tools
 clean:
@@ -16,6 +17,11 @@ distclean: clean
 dependencies:
 	@ cp -r thirdparty/*.dl* .
 	@ cp -r thirdparty/Tao/* .
+version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml
+	@for i in $? ; do \
+		awk '{sub("Version:.*$$","Version: $(VERSION)"); print $0}' $${i} > $${i}.tmp && \
+		mv -f $${i}.tmp $${i} ; \
+	done
 default: dependencies core
 
 .DEFAULT_GOAL := default

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -56,11 +56,6 @@ cp thirdparty/Mono.Nat.dll packaging/built
 # Copy game icon for windows package
 cp OpenRA.Game/OpenRA.ico packaging/built
 
-# Update mod versions
-sed "s/{DEV_VERSION}/$TAG/" ./mods/ra/mod.yaml > ./packaging/built/mods/ra/mod.yaml
-sed "s/{DEV_VERSION}/$TAG/" ./mods/cnc/mod.yaml > ./packaging/built/mods/cnc/mod.yaml
-sed "s/{DEV_VERSION}/$TAG/" ./mods/d2k/mod.yaml > ./packaging/built/mods/d2k/mod.yaml
-
 # Remove demo.mix from cnc
 rm ./packaging/built/mods/cnc/bits/demo.mix
 


### PR DESCRIPTION
This an attempt to unify versioning between:
- http://software.opensuse.org/package/openra
- http://gentoo-portage.com/games-strategy/openra
- http://archlinux.org/packages/community/any/openra/
- http://openra.ipdx.ru/deb/
- http://www.playdeb.net/software/OpenRA
- and http://openra.res0l.net/download/

to make it more comfortable to package OpenRA for various Linux distributions as well as to join @xaionaro's auto-update development servers who require `Version: bleed-$HASH` to be set.
