### PR TITLE
Added resource splattering for destroyed units and weapons

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -23,8 +23,10 @@ namespace OpenRA.GameRules
 		[FieldLoader.LoadUsing( "LoadVersus" )]
 		[Desc("Damage vs each armortype. 0% = can't target.")]
 		public readonly Dictionary<string, float> Versus;
-		[Desc("Can this damage ore?")]
-		public readonly bool Ore = false;
+		[Desc("Can this remove resource patches in vicinity?")]
+		public readonly bool DestroyResources = false;
+		[Desc("Will this create new resource patches and which?")]
+		public readonly string AddsResourceType = null;
 		[Desc("Explosion effect to use.")]
 		public readonly string Explosion = null;
 		[Desc("Explosion effect on hitting water (usually a splash).")]

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Traits
 	public class PlayerResourcesInfo : ITraitInfo
 	{
 		public readonly int InitialCash = 10000;
-		public readonly int InitialOre = 0;
+		public readonly int InitialResources = 0;
 		public readonly int AdviceInterval = 250;
 
 		public object Create(ActorInitializer init) { return new PlayerResources(init.self, this); }
@@ -35,45 +35,45 @@ namespace OpenRA.Traits
 			Owner = self.Owner;
 
 			Cash = info.InitialCash;
-			Ore = info.InitialOre;
+			Resources = info.InitialResources;
 			AdviceInterval = info.AdviceInterval;
 		}
 
 		[Sync] public int Cash;
 
-		[Sync] public int Ore;
-		[Sync] public int OreCapacity;
+		[Sync] public int Resources;
+		[Sync] public int Capacity;
 
 		public int DisplayCash;
-		public int DisplayOre;
+		public int DisplayResources;
 		public bool AlertSilo;
 
 		public int Earned;
 		public int Spent;
 
-		public bool CanGiveOre(int amount)
+		public bool CanGiveResources(int amount)
 		{
-			return Ore + amount <= OreCapacity;
+			return Resources + amount <= Capacity;
 		}
 
-		public void GiveOre(int num)
+		public void GiveResources(int num)
 		{
-			Ore += num;
+			Resources += num;
 			Earned += num;
 
-			if (Ore > OreCapacity)
+			if (Resources > Capacity)
 			{
 				nextSiloAdviceTime = 0;
 
-				Earned -= Ore - OreCapacity;
-				Ore = OreCapacity;
+				Earned -= Resources - Capacity;
+				Resources = Capacity;
 			}
 		}
 
-		public bool TakeOre(int num)
+		public bool TakeResources(int num)
 		{
-			if (Ore < num) return false;
-			Ore -= num;
+			if (Resources < num) return false;
+			Resources -= num;
 			Spent += num;
 
 			return true;
@@ -87,15 +87,15 @@ namespace OpenRA.Traits
 
 		public bool TakeCash(int num)
 		{
-			if (Cash + Ore < num) return false;
+			if (Cash + Resources < num) return false;
 
 			// Spend ore before cash
-			Ore -= num;
+			Resources -= num;
 			Spent += num;
-			if (Ore < 0)
+			if (Resources < 0)
 			{
-				Cash += Ore;
-				Ore = 0;
+				Cash += Resources;
+				Resources = 0;
 			}
 
 			return true;
@@ -110,17 +110,17 @@ namespace OpenRA.Traits
 			if(cashtickallowed > 0) {
 				cashtickallowed = cashtickallowed - 1;
 			}
-			
-			OreCapacity = self.World.ActorsWithTrait<IStoreOre>()
+
+			Capacity = self.World.ActorsWithTrait<IStoreResources>()
 				.Where(a => a.Actor.Owner == Owner)
 				.Sum(a => a.Trait.Capacity);
 
-			if (Ore > OreCapacity)
-				Ore = OreCapacity;
+			if (Resources > Capacity)
+				Resources = Capacity;
 
 			if (--nextSiloAdviceTime <= 0)
 			{
-				if (Ore > 0.8 * OreCapacity)
+				if (Resources > 0.8 * Capacity)
 				{
 					Sound.PlayNotification(Owner, "Speech", "SilosNeeded", Owner.Country.Race);
 					AlertSilo = true;
@@ -147,18 +147,18 @@ namespace OpenRA.Traits
 				playCashTickDown(self);
 			}
 
-			diff = Math.Abs(Ore - DisplayOre);
+			diff = Math.Abs(Resources - DisplayResources);
 			move = Math.Min(Math.Max((int)(diff * displayCashFracPerFrame),
 					displayCashDeltaPerFrame), diff);
 
-			if (DisplayOre < Ore)
+			if (DisplayResources < Resources)
 			{
-				DisplayOre += move;
+				DisplayResources += move;
 				playCashTickUp(self);
 			}
-			else if (DisplayOre > Ore)
+			else if (DisplayResources > Resources)
 			{
-				DisplayOre -= move;
+				DisplayResources -= move;
 				playCashTickDown(self);
 			}
 		}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Traits
 	public interface INotifyHarvest { void Harvested(Actor self, ResourceType resource); }
 
 	public interface IAcceptInfiltrator { void OnInfiltrate(Actor self, Actor infiltrator); }
-	public interface IStoreOre { int Capacity { get; } }
+	public interface IStoreResources { int Capacity { get; } }
 	public interface IToolTip
 	{
 		string Name();

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncIngameChromeLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncIngameChromeLogic.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			var powerManager = world.LocalPlayer.PlayerActor.Trait<PowerManager>();
 			var playerResources = world.LocalPlayer.PlayerActor.Trait<PlayerResources>();
 			sidebarRoot.Get<LabelWidget>("CASH").GetText = () =>
-				"${0}".F(playerResources.DisplayCash + playerResources.DisplayOre);
+				"${0}".F(playerResources.DisplayCash + playerResources.DisplayResources);
 
 			playerWidgets.Get<ButtonWidget>("OPTIONS_BUTTON").OnClick = OptionsClicked;
 
@@ -127,14 +127,14 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			};
 
 			var siloBar = playerWidgets.Get<ResourceBarWidget>("SILOBAR");
-			siloBar.GetProvided = () => playerResources.OreCapacity;
-			siloBar.GetUsed = () => playerResources.Ore;
+			siloBar.GetProvided = () => playerResources.Capacity;
+			siloBar.GetUsed = () => playerResources.Resources;
 			siloBar.TooltipFormat = "Silo Usage: {0}/{1}";
 			siloBar.GetBarColor = () => 
 			{
-				if (playerResources.Ore == playerResources.OreCapacity)
+				if (playerResources.Resources == playerResources.Capacity)
 					return Color.Red;
-				if (playerResources.Ore >= 0.8 * playerResources.OreCapacity)
+				if (playerResources.Resources >= 0.8 * playerResources.Capacity)
 					return Color.Orange;
 				return Color.LimeGreen;
 			};

--- a/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTooltipLogic.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 
 				var costString = "$: {0}".F(cost);
 				costLabel.GetText = () => costString;
-				costLabel.GetColor = () => pr.DisplayCash + pr.DisplayOre >= cost
+				costLabel.GetColor = () => pr.DisplayCash + pr.DisplayResources >= cost
 					? Color.White : Color.Red;
 
 				var descString = tooltip.Description.Replace("\\n", "\n");

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.FileFormats;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Move;
 using OpenRA.Mods.RA.Orders;
@@ -20,20 +21,21 @@ namespace OpenRA.Mods.RA
 {
 	public class HarvesterInfo : ITraitInfo
 	{
+		[Desc("How much resources it can carry.")]
 		public readonly int Capacity = 28;
 		public readonly int LoadTicksPerBale = 4;
+		[Desc("How fast it can dump it's carryage.")]
 		public readonly int UnloadTicksPerBale = 4;
+		[Desc("How many squares to show the fill level.")]
 		public readonly int PipCount = 7;
 		public readonly int HarvestFacings = 0;
+		[Desc("Which resources it can harvest.")]
 		public readonly string[] Resources = { };
+		[Desc("How much it is slowed down when returning to the refinery.")]
 		public readonly decimal FullyLoadedSpeed = .85m;
-		/// <summary>
-		/// Initial search radius (in cells) from the refinery (proc) that created us.
-		/// </summary>
+		[Desc("Initial search radius (in cells) from the refinery that created us.")]
 		public readonly int SearchFromProcRadius = 24;
-		/// <summary>
-		/// Search radius (in cells) from the last harvest order location to find more resources.
-		/// </summary>
+		[Desc("Search radius (in cells) from the last harvest order location to find more resources.")]
 		public readonly int SearchFromOrderRadius = 12;
 
 		public object Create(ActorInitializer init) { return new Harvester(init.self, this); }

--- a/OpenRA.Mods.RA/InfiltrateForCash.cs
+++ b/OpenRA.Mods.RA/InfiltrateForCash.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA
 			var targetResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 			var spyResources = infiltrator.Owner.PlayerActor.Trait<PlayerResources>();
 
-			var toTake = (targetResources.Cash + targetResources.Ore) * info.Percentage / 100;
+			var toTake = (targetResources.Cash + targetResources.Resources) * info.Percentage / 100;
 			var toGive = Math.Max(toTake, info.Minimum);
 			
 			targetResources.TakeCash(toTake);

--- a/OpenRA.Mods.RA/Missions/MissionUtils.cs
+++ b/OpenRA.Mods.RA/Missions/MissionUtils.cs
@@ -204,8 +204,8 @@ namespace OpenRA.Mods.RA.Missions
 		public static void CapOre(Player player)
 		{
 			var res = player.PlayerActor.Trait<PlayerResources>();
-			if (res.Ore > res.OreCapacity * 0.8)
-				res.Ore = (int)(res.OreCapacity * 0.8);
+			if (res.Resources > res.Capacity * 0.8)
+				res.Resources = (int)(res.Capacity * 0.8);
 		}
 
 		public static void AttackNearestLandActor(bool queued, Actor self, Player enemyPlayer)

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -350,7 +350,6 @@
     <Compile Include="SpawnMPUnits.cs" />
     <Compile Include="SpawnMapActors.cs" />
     <Compile Include="Spy.cs" />
-    <Compile Include="StoresOre.cs" />
     <Compile Include="StrategicVictoryConditions.cs" />
     <Compile Include="SupplyTruck.cs" />
     <Compile Include="SupportPowers\AirstrikePower.cs" />
@@ -463,6 +462,7 @@
     <Compile Include="Effects\FrozenActorProxy.cs" />
     <Compile Include="Widgets\Logic\WorldTooltipLogic.cs" />
     <Compile Include="TeslaZapRenderable.cs" />
+    <Compile Include="StoresResources.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/OreRefinery.cs
+++ b/OpenRA.Mods.RA/OreRefinery.cs
@@ -62,11 +62,11 @@ namespace OpenRA.Mods.RA
 				.Where(a => a.Trait.LinkedProc == self);
 		}
 
-		public bool CanGiveOre(int amount) { return PlayerResources.CanGiveOre(amount); }
+		public bool CanGiveOre(int amount) { return PlayerResources.CanGiveResources(amount); }
 
 		public void GiveOre(int amount)
 		{
-			PlayerResources.GiveOre(amount);
+			PlayerResources.GiveResources(amount);
 			if (Info.ShowTicks)
 				currentDisplayValue += amount;
 		}

--- a/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
@@ -31,9 +31,9 @@ namespace OpenRA.Mods.RA.Render
 		{
 			var animation = (self.GetDamageState() >= DamageState.Heavy) ? "damaged-idle" : "idle";
 			anim.PlayFetchIndex(animation,
-				() => playerResources.OreCapacity != 0
-					? ((10 * anim.CurrentSequence.Length - 1) * playerResources.Ore) / (10 * playerResources.OreCapacity)
-					: 0);
+				() => playerResources.Capacity != 0
+			                    ? ((10 * anim.CurrentSequence.Length - 1) * playerResources.Resources) / (10 * playerResources.Capacity)
+			                    : 0);
 		}
 
 		public void OnCapture (Actor self, Actor captor, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.RA/Render/WithResources.cs
+++ b/OpenRA.Mods.RA/Render/WithResources.cs
@@ -40,8 +40,8 @@ namespace OpenRA.Mods.RA.Render
 
 			anim = new Animation(rs.GetImage(self));
 			anim.PlayFetchIndex(info.Sequence,
-			                    () => playerResources.OreCapacity != 0
-			                    ? ((10 * anim.CurrentSequence.Length - 1) * playerResources.Ore) / (10 * playerResources.OreCapacity)
+			                    () => playerResources.Capacity != 0
+			                    ? ((10 * anim.CurrentSequence.Length - 1) * playerResources.Resources) / (10 * playerResources.Capacity)
 			                    : 0);
 
 			rs.anims.Add("resources_{0}".F(info.Sequence), new AnimationWithOffset(

--- a/OpenRA.Mods.RA/SeedsResource.cs
+++ b/OpenRA.Mods.RA/SeedsResource.cs
@@ -59,14 +59,15 @@ namespace OpenRA.Mods.RA
 			if (--animationTicks <= 0)
 			{
 				var info = self.Info.Traits.Get<SeedsResourceInfo>();
-				self.Trait<RenderBuilding>().PlayCustomAnim(self, "active");
+				if (self.HasTrait<RenderBuilding>())
+					self.Trait<RenderBuilding>().PlayCustomAnim(self, "active");
 				animationTicks = info.AnimationInterval;
 			}
 		}
 
 		static IEnumerable<CPos> RandomWalk(CPos p, Thirdparty.Random r)
 		{
-			for (; ; )
+			for (;;)
 			{
 				var dx = r.Next(-1, 2);
 				var dy = r.Next(-1, 2);

--- a/OpenRA.Mods.RA/StoresResources.cs
+++ b/OpenRA.Mods.RA/StoresResources.cs
@@ -14,23 +14,23 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class StoresOreInfo : ITraitInfo
+	class StoresResourcesInfo : ITraitInfo
 	{
 		[Desc("Number of little squares used to display how filled unit is.")]
 		public readonly int PipCount = 0;
 		public readonly PipType PipColor = PipType.Yellow;
 		public readonly int Capacity = 0;
-		public object Create(ActorInitializer init) { return new StoresOre(init.self, this); }
+		public object Create(ActorInitializer init) { return new StoresResources(init.self, this); }
 	}
 
-	class StoresOre : IPips, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreOre, ISync
+	class StoresResources : IPips, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreResources, ISync
 	{
-		readonly StoresOreInfo Info;
+		readonly StoresResourcesInfo Info;
 
-		[Sync] public int Stored { get { return Player.OreCapacity == 0 ? 0 : Info.Capacity * Player.Ore / Player.OreCapacity; } }
+		[Sync] public int Stored { get { return Player.Capacity == 0 ? 0 : Info.Capacity * Player.Resources / Player.Capacity; } }
 
 		PlayerResources Player;
-		public StoresOre(Actor self, StoresOreInfo info)
+		public StoresResources(Actor self, StoresResourcesInfo info)
 		{
 			Player = self.Owner.PlayerActor.Trait<PlayerResources>();
 			Info = info;
@@ -40,22 +40,22 @@ namespace OpenRA.Mods.RA
 
 		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
 		{
-			var ore = Stored;
-			Player.TakeOre(ore);
+			var storage = Stored;
+			Player.TakeResources(storage);
 			Player = newOwner.PlayerActor.Trait<PlayerResources>();
-			Player.GiveOre(ore);
+			Player.GiveResources(storage);
 		}
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			Player.TakeOre(Stored);	// Lose the stored ore
+			Player.TakeResources(Stored);	// Lose the stored resources
 		}
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			return Exts.MakeArray( Info.PipCount,
-				i => ( Player.Ore * Info.PipCount > i * Player.OreCapacity )
-					? Info.PipColor : PipType.Transparent );
+			return Exts.MakeArray(Info.PipCount,
+				i => (Player.Resources * Info.PipCount > i * Player.Capacity)
+					? Info.PipColor : PipType.Transparent);
 		}
 
 		public bool ShouldExplode(Actor self) { return Stored > 0; }

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -465,7 +465,7 @@ namespace OpenRA.Mods.RA.Widgets
 			var power = pl.PlayerActor.Trait<PowerManager>();
 
 			DrawRightAligned("${0}".F(cost), pos + new int2(-5, 5),
-				(resources.DisplayCash + resources.DisplayOre >= cost ? Color.White : Color.Red));
+				(resources.DisplayCash + resources.DisplayResources >= cost ? Color.White : Color.Red));
 
 			var lowpower = power.PowerState != PowerState.Normal;
 			var time = CurrentQueue.GetBuildTime(info.Name)

--- a/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
 			if (stats == null) return template;
 
-			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayOre);
+			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayResources);
 			template.Get<LabelWidget>("EARNED_MIN").GetText = () => AverageEarnedPerMinute(res.Earned);
 			template.Get<LabelWidget>("EARNED_THIS_MIN").GetText = () => "$" + stats.EarnedThisMinute;
 			template.Get<LabelWidget>("EARNED").GetText = () => "$" + res.Earned;
@@ -249,7 +249,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			AddPlayerFlagAndName(template, player);
 
 			var res = player.PlayerActor.Trait<PlayerResources>();
-			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayOre);
+			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayResources);
 			template.Get<LabelWidget>("EARNED_MIN").GetText = () => AverageEarnedPerMinute(res.Earned);
 
 			var powerRes = player.PlayerActor.Trait<PowerManager>();

--- a/OpenRA.Mods.RA/Widgets/MoneyBinWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/MoneyBinWidget.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.RA.Widgets
 				new float2(Bounds.Left, 0));
 
 			// Cash
-			var cashDigits = (playerResources.DisplayCash + playerResources.DisplayOre).ToString();
+			var cashDigits = (playerResources.DisplayCash + playerResources.DisplayResources).ToString();
 			var x = Bounds.Right - 65;
 
 			foreach (var d in cashDigits.Reverse())

--- a/mods/cnc/rules/husks.yaml
+++ b/mods/cnc/rules/husks.yaml
@@ -13,6 +13,9 @@ HARV.Husk:
 		Icon: harvicnh
 	RenderUnit:
 		Image: harv
+	SeedsResource:
+		ResourceType: Tiberium
+		Interval: 25
 
 APC.Husk:
 	Inherits: ^Husk

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -145,6 +145,10 @@ E5:
 		IdleAnimations: idle1,idle2
 	DetectCloaked:
 		Range: 2
+	Explodes:
+		Weapon: ChemsprayExplode
+		EmptyWeapon: ChemsprayExplode
+		Chance: 50
 
 E6:
 	Inherits: ^Infantry

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -121,7 +121,7 @@ PROC:
 	TiberiumRefinery:
 		DockOffset: 0,2
 		TickRate: 15
-	StoresOre:
+	StoresResources:
 		PipColor: Green
 		PipCount: 15
 		Capacity: 1500
@@ -159,7 +159,7 @@ SILO:
 	RevealsShroud:
 		Range: 4
 	RenderBuildingSilo:
-	StoresOre:
+	StoresResources:
 		PipCount: 10
 		PipColor: Green
 		Capacity: 2400

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -286,7 +286,7 @@ World:
 		Name: Tiberium
 		PipColor: Green
 		AllowedTerrainTypes: Clear,Road
-		AllowUnderActors: false
+		AllowUnderActors: true
 	ResourceType@blue-tib:
 		ResourceType: 2
 		Palette: staticterrain
@@ -296,7 +296,7 @@ World:
 		Name: BlueTiberium
 		PipColor: Blue
 		AllowedTerrainTypes: Clear,Road
-		AllowUnderActors: false
+		AllowUnderActors: true
 	SmudgeLayer@SCORCH:
 		Type:Scorch
 		SmokePercentage:50

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -59,11 +59,25 @@ GrenadierExplode:
 		InfDeath: 3
 		ImpactSound: xplosml2.aud
 
+ChemsprayExplode:
+	Warhead:
+		Damage: 10
+		Spread: 9
+		Versus:
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: chemball
+		InfDeath: 3
+		ImpactSound: xplosml2.aud
+		AddsResourceType: Tiberium
+
 Atomic:
 	Warhead@impact:
 		Damage: 1000
 		Spread: 6
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Wood: 60%
@@ -77,7 +91,7 @@ Atomic:
 		Damage: 250
 		SmudgeType: Scorch
 		Size: 5
-		Ore: true
+		DestroyResources: true
 		Versus: 
 			None: 90%
 			Wood: 60%
@@ -92,7 +106,7 @@ IonCannon:
 	Warhead@impact:
 		Damage: 900
 		Spread: 16
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -104,7 +118,7 @@ IonCannon:
 		Damage: 0
 		SmudgeType: Scorch
 		Size: 2,1
-		Ore: true
+		DestroyResources: true
 		Delay: 3
 		InfDeath: 5
 

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -130,7 +130,7 @@
 		DockOffset: 2,1
 		DockAngle: 160
 		TickRate: 20
-	StoresOre:
+	StoresResources:
 		PipColor: green
 		PipCount: 10
 		Capacity: 2000
@@ -168,7 +168,7 @@
 		Range: 4
 	-RenderBuilding:
 	RenderBuildingSilo:
-	StoresOre:
+	StoresResources:
 		PipColor: green
 		PipCount: 5
 		Capacity: 2000

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -67,9 +67,7 @@ HARVESTER:
 		HarvestFacings: 8
 		Resources: Spice
 		UnloadTicksPerBale: 5
-		# How far away from our linked refinery to find resources (in cells):
 		SearchFromProcRadius: 24
-		# How far away from last harvest order location to find more resources (in cells):
 		SearchFromOrderRadius: 12
 	Health:
 		HP: 1000

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -953,7 +953,7 @@ PROC:
 		Range: 6
 	Bib:
 	OreRefinery:
-	StoresOre:
+	StoresResources:
 		PipCount: 17
 		Capacity: 2000
 	IronCurtainable:
@@ -996,7 +996,7 @@ SILO:
 	RevealsShroud:
 		Range: 4
 	RenderBuildingSilo:
-	StoresOre:
+	StoresResources:
 		PipCount: 5
 		Capacity: 1500
 	IronCurtainable:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -249,9 +249,7 @@ HARV:
 		Capacity: 20
 		Resources: Ore,Gems
 		UnloadTicksPerBale: 1
-		# How far away from our linked proc (refinery) to find resources (in cells):
 		SearchFromProcRadius: 24
-		# How far away from last harvest order location to find more resources (in cells):
 		SearchFromOrderRadius: 12
 	Health:
 		HP: 600

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -610,7 +610,7 @@ CrateNuke:
 	Warhead@impact:
 		Damage: 1000
 		Spread: 6
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -625,7 +625,7 @@ CrateNuke:
 		Damage: 250
 		SmudgeType: Scorch
 		Size: 5,4
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -976,7 +976,7 @@ Atomic:
 	Warhead@impact:
 		Damage: 1000
 		Spread: 6
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -990,7 +990,7 @@ Atomic:
 		DamageModel: PerCell
 		Damage: 180
 		Size: 2,1
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1003,7 +1003,7 @@ Atomic:
 		DamageModel: PerCell
 		Damage: 180
 		Size: 3,2
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1015,7 +1015,7 @@ Atomic:
 		DamageModel: PerCell
 		Damage: 180
 		Size: 4,3
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1028,7 +1028,7 @@ Atomic:
 		Damage: 180
 		SmudgeType: Scorch
 		Size: 5,4
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1041,7 +1041,7 @@ MiniNuke:
 	Warhead@impact:
 		Damage: 800
 		Spread: 6
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1055,7 +1055,7 @@ MiniNuke:
 		DamageModel: PerCell
 		Damage: 180
 		Size: 2,1
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1068,7 +1068,7 @@ MiniNuke:
 		DamageModel: PerCell
 		Damage: 180
 		Size: 3,2
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1081,7 +1081,7 @@ MiniNuke:
 		Damage: 180
 		Size: 4,3
 		SmudgeType: Scorch
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%


### PR DESCRIPTION
You now have 2 methods to achieve #2346:
- Attach it to a husk spawned from a unit (`SeedsResources` is not limited to buildings anymore)
- Attach it to a building which has a `DeadBuildingState` with some lingering time and use the new `SplatterUponDestruction` boolean in `SeedsResources`.
