### PR TITLE
Don't try discover routers by default and expose setting to GUI

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -29,7 +29,7 @@ namespace OpenRA.GameRules
 		public int ExternalPort = 1234;
 		public bool AdvertiseOnline = true;
 		public string MasterServer = "http://master.open-ra.org/";
-		public bool DiscoverNatDevices = true; // Allow users to disable NAT discovery if problems occur
+		public bool DiscoverNatDevices = false; // Allow users to disable NAT discovery if problems occur
 		public bool AllowPortForward = true; // let the user disable it even if compatible devices are found
 		public bool NatDeviceAvailable = false; // internal check if discovery succeeded
 		public int NatDiscoveryTimeout = 1000; // ms to search for UPnP enabled NATs

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -74,6 +74,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			useClassicMouseStyleCheckbox.IsChecked = () => Game.Settings.Game.UseClassicMouseStyle;
 			useClassicMouseStyleCheckbox.OnClick = () => Game.Settings.Game.UseClassicMouseStyle ^= true;
 
+			var allowNatDiscoveryCheckbox = general.Get<CheckboxWidget>("ALLOW_NAT_DISCOVERY_CHECKBOX");
+			allowNatDiscoveryCheckbox.IsChecked = () => Game.Settings.Server.DiscoverNatDevices;
+			allowNatDiscoveryCheckbox.OnClick = () => Game.Settings.Server.DiscoverNatDevices ^= true;
+
 			// Audio
 			var audio = bg.Get("AUDIO_PANE");
 			var soundSettings = Game.Settings.Sound;
@@ -226,13 +230,13 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			botdebugCheckbox.IsChecked = () => Game.Settings.Debug.BotDebug;
 			botdebugCheckbox.OnClick = () => Game.Settings.Debug.BotDebug ^= true;
 
-			var longTickThreshold = debug.Get<SliderWidget>("LONG_TICK_THRESHOLD");
-			longTickThreshold.Value = Game.Settings.Debug.LongTickThreshold;
-			longTickThreshold.OnChange += x => Game.Settings.Debug.LongTickThreshold = x;
-
 			var ignoreVersionMismatchCheckbox = debug.Get<CheckboxWidget>("IGNOREVERSIONMISMATCH_CHECKBOX");
 			ignoreVersionMismatchCheckbox.IsChecked = () => Game.Settings.Debug.IgnoreVersionMismatch;
 			ignoreVersionMismatchCheckbox.OnClick = () => Game.Settings.Debug.IgnoreVersionMismatch ^= true;
+
+			var verboseNatDiscoveryCheckbox = debug.Get<CheckboxWidget>("VERBOSE_NAT_DISCOVERY_CHECKBOX");
+			verboseNatDiscoveryCheckbox.IsChecked = () => Game.Settings.Server.VerboseNatDiscovery;
+			verboseNatDiscoveryCheckbox.OnClick = () => Game.Settings.Server.VerboseNatDiscovery ^= true;
 
 			bg.Get<ButtonWidget>("BUTTON_CLOSE").OnClick = () =>
 			{

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -122,6 +122,12 @@ Background@SETTINGS_MENU:
 					Width:200
 					Height:20
 					Text: Left-Click Orders
+				Checkbox@ALLOW_NAT_DISCOVERY_CHECKBOX:
+					X:0
+					Y:210
+					Width:200
+					Height:20
+					Text: Try to discover routers suitable for automatic port-forwarding on startup.
 		Container@AUDIO_PANE:
 			X:37
 			Y:100
@@ -380,21 +386,15 @@ Background@SETTINGS_MENU:
 					Width:300
 					Height:20
 					Text:Show Bot Debug Messages
-				Label@PERFTEXT_SAMPLE_LABEL:
-					X:0
-					Y:160
-					Text:Slow Trait Report Threshold in (mili)seconds
-				Slider@LONG_TICK_THRESHOLD:
-					X:0
-					Y:170
-					Width:380
-					Height:20
-					Ticks:25
-					MinimumValue: 0.0001
-					MaximumValue: 0.01
 				Checkbox@IGNOREVERSIONMISMATCH_CHECKBOX:
 					X:0
-					Y:210
+					Y:150
 					Width:300
 					Height:20
 					Text:Don't check for compatible version in game server browser.
+				Checkbox@VERBOSE_NAT_DISCOVERY_CHECKBOX:
+					X:0
+					Y:180
+					Width:300
+					Height:20
+					Text:Print very detailed information to server.log about NAT devices.


### PR DESCRIPTION
@clemx and @TiriliPiitPiit reported problems with https://github.com/mono/Mono.Nat which I did not expect nor can resolve properly so I hearby give up. To workaround the feature is disabled by default, but the switch to enable it is exposed to the GUI now so people can hopefully find it easily.
