### PR TITLE
d2k-tanks get increased spread, 4 -> 6

### DIFF
--- a/mods/d2k/rules/system.yaml
+++ b/mods/d2k/rules/system.yaml
@@ -415,7 +415,7 @@ CRATE:
 		SelectionShares: 20
 		Unit: trikea
 	GiveUnitCrateAction@TrikeO:
-		SelectionShares: 20
+		SelectionShares: 15
 		Unit: trikeo
 	GiveUnitCrateAction@Quad:
 		SelectionShares: 40
@@ -435,6 +435,9 @@ CRATE:
 	GiveUnitCrateAction@MissileTank:
 		SelectionShares: 10
 		Unit: missiletank
+	GiveUnitCrateAction@StealthTrike:
+		SelectionShares: 7
+		Unit: stealthtrike
 	GiveUnitCrateAction@Fremen:
 		SelectionShares: 5
 		Unit: fremen
@@ -451,7 +454,7 @@ CRATE:
 		SelectionShares: 2
 		Unit: devast
 	GiveUnitCrateAction@DeviatorTank:
-		SelectionShares: 7
+		SelectionShares: 5
 		Unit: deviatortank
 	GiveMcvCrateAction@Atreides:
 		SelectionShares: 0

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -212,7 +212,7 @@ TurretGun:
 		Versus: 
 			None: 50%
 			Wood: 75%
-			Light: 75%
+			Light: 100%
 			Concrete: 65%
 		Explosion: med_explosion
 		ImpactSound: kaboom30
@@ -244,7 +244,7 @@ TowerMissile:
 			None: 80%
 			Wood: 45%
 			Light: 75%
-			Heavy: 40%
+			Heavy: 50%
 			Concrete: 35%
 		InfDeath: 3
 		Explosion: small_explosion

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -265,7 +265,7 @@ TowerMissile:
 		Versus: 
 			None: 30%
 			Wood: 50%
-			Light: 65%
+			Light: 80%
 			Concrete: 40%
 		Explosion: med_explosion
 		ImpactSound: kaboom30
@@ -286,7 +286,7 @@ TowerMissile:
 		Versus: 
 			None: 30%
 			Wood: 50%
-			Light: 65%
+			Light: 80%
 			Concrete: 40%
 		Explosion: med_explosion
 		ImpactSound: kaboom30

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -261,7 +261,7 @@ TowerMissile:
 		Inaccuracy: 12
 		Image: 90MM
 	Warhead:
-		Spread: 4
+		Spread: 6
 		Versus: 
 			None: 30%
 			Wood: 50%
@@ -282,7 +282,7 @@ TowerMissile:
 		Inaccuracy: 11
 		Image: 90MM
 	Warhead:
-		Spread: 4
+		Spread: 6
 		Versus: 
 			None: 30%
 			Wood: 50%


### PR DESCRIPTION
Tanks get chewed up pretty good by bazookas, and dont do much damage to infantry. This will help a bit to hurt infantry that are clumped up in the same cell.
