### PR TITLE
D2K--QuadRockets and Bazooka are no longer "high"

### DIFF
--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -27,7 +27,6 @@ Bazooka:
 	Projectile: Missile
 		Speed: 25
 		Arm: 2
-		High: true
 		Shadow: yes
 		Proximity: true
 		ContrailLength: 10
@@ -175,7 +174,6 @@ QuadRockets:
 	ValidTargets: Ground, Air
 	Projectile: Missile
 		Arm: 0
-		High: yes
 		Shadow: yes
 		Proximity: yes
 		Inaccuracy: 3


### PR DESCRIPTION
Quad spam can be potentially very powerful. Gameplay-wise, one should be able to avoid their powerful missiles by hiding behind a building or a wall.
It doesn't necessarily make much sense that a vehicle low to the ground should be able to shoot over things perfectly. Same for infantry. 
The advantage of shooting high should be reserved for units like artillery, so you can put them behind walls or other obstacles. Makes gameplay more interesting and dynamic. 

TowerRockets will stay high.
