### PR TITLE
Orca nerf: reducing damage vs. heavy 20 dmg -> 15

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -129,11 +129,11 @@ ORCA:
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:
-		Ammo: 5
-		PipCount: 5
+		Ammo: 6
+		PipCount: 6
 	Reloads:
 		Count: 1
-		Period: 100
+		Period: 150
 	RenderUnit:
 	WithShadow:
 	FallsToEarth:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -123,8 +123,8 @@ PROC:
 		TickRate: 15
 	StoresOre:
 		PipColor: Green
-		PipCount: 18
-		Capacity: 1800
+		PipCount: 15
+		Capacity: 1500
 	Selectable:
 		Bounds: 73,72
 	CustomSellValue:
@@ -140,7 +140,7 @@ PROC:
 SILO:
 	Inherits: ^Building
 	Valued:
-		Cost: 150
+		Cost: 300
 	Tooltip:
 		Name: Tiberium Silo
 		Icon: siloicnh
@@ -156,16 +156,16 @@ SILO:
 		Dimensions: 2,1
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 400
 	RevealsShroud:
 		Range: 4
 	RenderBuildingSilo:
 	StoresOre:
-		PipCount: 12
+		PipCount: 24
 		PipColor: Green
-		Capacity: 1200
+		Capacity: 2400
 	Selectable:
-		Bounds: 49,24
+		Bounds: 49,30
 	-RenderBuilding:
 	-EmitInfantryOnSell:
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -563,7 +563,7 @@ SAM:
 	RevealsShroud:
 		Range: 5
 	Turreted:
-		ROT: 7
+		ROT: 10
 		InitialFacing: 0
 	RenderBuildingTurreted:
 	Armament:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -81,7 +81,7 @@ HARV:
 APC:
 	Inherits: ^Tank
 	Valued:
-		Cost: 700
+		Cost: 600
 	Tooltip:
 		Name: APC
 		Icon: apcicnh
@@ -475,7 +475,7 @@ MSAM:
 MLRS:
 	Inherits: ^Tank
 	Valued:
-		Cost: 750
+		Cost: 600
 	Tooltip:
 		Name: Mobile S.A.M.
 		Icon: mlrsicnh

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -485,7 +485,8 @@ MLRS:
 		Prerequisites: anyhq
 		Owner: nod
 	Mobile:
-		Speed: 6
+		Speed: 7
+		ROT: 7
 	Health:
 		HP: 120
 	Armor:
@@ -493,7 +494,7 @@ MLRS:
 	RevealsShroud:
 		Range: 10
 	Turreted:
-		ROT: 5
+		ROT: 8
 		Offset: -128,0,128
 		AlignWhenIdle: true
 	Armament:

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -350,6 +350,7 @@ sam:
 	closing:
 		Start: 50
 		Length: 14
+		Tick: 30
 	damaged-closed-idle:
 		Start:64
 	damaged-opening:
@@ -362,12 +363,13 @@ sam:
 	damaged-closing:
 		Start: 114
 		Length: 14
+		Tick: 30
 	dead:
 		Start: 128
 	make: sammake
 		Start: 0
 		Length: 20
-		Tick: 80
+		Tick: 30
 	muzzle: samfire
 		Start: 0
 		Length: 18

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -654,9 +654,9 @@ MachineGun:
 		Spread: 3
 		Versus: 
 			None: 100%
-			Wood: 30%
+			Wood: 25%
 			Light: 75%
-			Heavy: 30%
+			Heavy: 25%
 			Concrete: 10%
 		InfDeath: 2
 		Explosion: piffs

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -306,7 +306,7 @@ OrcaAGMissiles:
 		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 30
+		Damage: 25
 
 OrcaAAMissiles:
 	ROF: 15
@@ -337,7 +337,7 @@ OrcaAAMissiles:
 		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 30
+		Damage: 25
 
 Flamethrower:
 	ROF: 50

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -795,7 +795,7 @@ SAMMissile:
 		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 55
+		Damage: 60
 
 HonestJohn:
 	ROF: 200
@@ -866,11 +866,11 @@ APCGun.AA:
 		Damage: 30
 
 Patriot:
-	ROF: 100
+	ROF: 75
 	Range: 10
 	MinRange: 1
 	Burst: 2
-	BurstDelay: 35
+	BurstDelay: 25
 	Report:	ROCKET2
 	ValidTargets: Air
 	Projectile: Missile
@@ -883,7 +883,7 @@ Patriot:
 		RangeLimit: 35
 		Angle: .15
 	Warhead: AP
-		Spread: 14		
+		Spread: 16
 		Versus: 
 			None: 100%	
 			Wood: 100%
@@ -893,4 +893,4 @@ Patriot:
 		Explosion: poof
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 55
+		Damage: 60

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -299,14 +299,14 @@ OrcaAGMissiles:
 		Spread: 3
 		Versus: 
 			None: 50%
-			Wood: 75%
-			Light: 75%
+			Wood: 100%
+			Light: 100%
 			Heavy: 50%
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 40
+		Damage: 30
 
 OrcaAAMissiles:
 	ROF: 15
@@ -330,14 +330,14 @@ OrcaAAMissiles:
 		Spread: 3
 		Versus: 
 			None: 50%
-			Wood: 75%
-			Light: 75%
+			Wood: 100%
+			Light: 100%
 			Heavy: 50%
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 40
+		Damage: 30
 
 Flamethrower:
 	ROF: 50

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -506,24 +506,24 @@ Grenade:
 		Damage: 40
 
 TurretGun:
-	ROF: 30
+	ROF: 25
 	Range: 6
 	Report: TNKFIRE6
 	Projectile: Bullet
 		Image: 120MM
-		Speed: 40
+		Speed: 50
 	Warhead:
 		Spread: 3
 		Versus: 
 			None: 25%
 			Wood: 25%
-			Light: 75%
+			Light: 80%
 			Heavy: 100%
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 60
+		Damage: 50
 
 MammothMissiles:
 	ROF: 100

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -770,7 +770,7 @@ Laser:
 		Damage: 200
 
 SAMMissile:
-	ROF: 50
+	ROF: 15
 	Range: 10
 	Report: ROCKET2
 	ValidTargets: Air
@@ -781,8 +781,8 @@ SAMMissile:
 		Proximity: yes
 		Image: MISSILE
 		ROT: 20
-		Speed: 40
-		RangeLimit: 50
+		Speed: 50
+		RangeLimit: 35
 		Trail: smokey
 	Warhead: AP
 		Spread: 3
@@ -795,7 +795,7 @@ SAMMissile:
 		Explosion: small_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 60
+		Damage: 30
 
 HonestJohn:
 	ROF: 200

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -693,35 +693,35 @@ BoatMissile:
 		Damage: 60
 
 TowerMissle:
-	ROF: 30
+	ROF: 24
 	Range: 8
 	Report: ROCKET2
 	ValidTargets: Ground, Air
 	Burst: 2
-	BurstDelay: 20
+	BurstDelay: 16
 	Projectile: Missile
 		Arm: 0
 		High: yes
 		Shadow: no
 		Proximity: yes
-		Inaccuracy: 5
+		Inaccuracy: 3
 		Image: DRAGON
-		ROT: 10
+		ROT: 20
 		Trail: smokey
 		Speed: 35
-		RangeLimit: 30
+		RangeLimit: 40
 	Warhead:
-		Spread: 6
+		Spread: 12
 		Versus: 
 			None: 25%
 			Wood: 25%
 			Light: 100%
-			Heavy: 75%
+			Heavy: 80%
 		InfDeath: 3
 		Explosion: med_frag
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 60
+		Damage: 45
 
 Napalm:
 	ROF: 2

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -866,11 +866,11 @@ APCGun.AA:
 		Damage: 30
 
 Patriot:
-	ROF: 75
+	ROF: 30
 	Range: 10
 	MinRange: 1
 	Burst: 2
-	BurstDelay: 25
+	BurstDelay: 15
 	Report:	ROCKET2
 	ValidTargets: Air
 	Projectile: Missile
@@ -879,8 +879,8 @@ Patriot:
 		Image: patriot
 		Trail: smokey
 		ROT: 20
-		Speed: 40
-		RangeLimit: 35
+		Speed: 50
+		RangeLimit: 30
 		Angle: .15
 	Warhead: AP
 		Spread: 16
@@ -893,4 +893,4 @@ Patriot:
 		Explosion: poof
 		ImpactSound: xplos
 		SmudgeType: Crater
-		Damage: 60
+		Damage: 30

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -834,7 +834,7 @@ Tiberium:
 		PreventProne: yes
 
 APCGun:
-	ROF: 25
+	ROF: 12
 	Range: 5
 	Report: gun20
 	ValidTargets: Ground
@@ -843,15 +843,15 @@ APCGun:
 	Warhead:
 		Spread: 3
 		Versus:
-			None: 30%
+			None: 35%
 			Wood: 50%
 			Light: 100%
 			Heavy: 20%
 		Explosion: small_poof
-		Damage: 30
+		Damage: 15
 		
 APCGun.AA:
-	ROF: 25
+	ROF: 12
 	Range: 7
 	Report: gun20
 	ValidTargets: Air
@@ -863,7 +863,7 @@ APCGun.AA:
 		Versus:
 			Heavy: 50%
 		Explosion: small_poof
-		Damage: 30
+		Damage: 25
 
 Patriot:
 	ROF: 30

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -840,14 +840,13 @@ APCGun:
 	ValidTargets: Ground
 	Projectile: Bullet
 		Speed: 100
-		High: true
 	Warhead:
 		Spread: 3
 		Versus:
-			None: 50%
+			None: 30%
 			Wood: 50%
 			Light: 100%
-			Heavy: 30%
+			Heavy: 20%
 		Explosion: small_poof
 		Damage: 30
 		


### PR DESCRIPTION
Orca rockets will do 15 damage vs. heavy. Hopefully this will take some edge off orca spam. This will:
-Give anti-air APC more lasting power vs. orca, ensuring it can at least down some of them and get their money's worth.
-Mammoth tank will bet better able to survive a mass assault and return fire with its rockets to down some of them (and get better money's worth).
-Give advanced guard towers better ability to defend themselves against air assault. (ATWR has heavy armor and does good damage, but can die quickly against a large group of orcas).
-Give armored units in general more resilience vs. orcas so they aren't completely helpless and quickly annihilated. Maybe then they can reach their target better (e.g. a couple tanks charging an artillery position that is being defended by some orcas).

Damage vs. infantry also slightly reduced as as result (also 20 -> 15 dmg).
Orcas generally aren't a threat to infantry, but E3s should be able to do some credible damage, even if they are in a small group. Enough orca spam will kill a small group of infantry, unfortunately. Since Orca has no business attacking infantry anyway, this slight nerf won't hurt orcas.

(Note: The damage model was simplified a bit, so that it does 100% of 30 dmg instead of 75% of 40 damage, vs. light & wood.)
