### PR TITLE
Be more verbose about missing sequences and files

### DIFF
--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -40,7 +40,11 @@ namespace OpenRA.Graphics
 				var seq = sequences.NodesDict.ToDictionary(x => x.Key, x => new Sequence(unit,x.Key,x.Value));
 				units.Add(unit, seq);
 			}
-			catch (FileNotFoundException) {} // Do nothing; we can crash later if we actually wanted art
+			catch (FileNotFoundException)
+			{
+				// Do nothing; we can crash later if we actually wanted art
+				Console.WriteLine("Can't find all files for unit {0}.".F(unit));
+			} 
 		}
 
 		public static Sequence GetSequence(string unitName, string sequenceName)
@@ -53,7 +57,7 @@ namespace OpenRA.Graphics
 						"Unit `{0}` does not have a sequence `{1}`".F(unitName, sequenceName));
 				else
 					throw new InvalidOperationException(
-						"Unit `{0}` does not have any sequences defined.".F(unitName));
+						"Unit `{0}` does not have all sequences defined.".F(unitName));
 			}
 		}
 
@@ -61,7 +65,7 @@ namespace OpenRA.Graphics
 		{
 			if (!units.ContainsKey(unit))
 				throw new InvalidOperationException(
-					"Unit `{0}` does not have any sequences defined.".F(unit));
+					"Unit `{0}` does not have sequence `{1}` defined.".F(unit, seq));
 
 			return units[unit].ContainsKey(seq);
 		}

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -73,7 +73,8 @@ namespace OpenRA
 			FileSystem.Mount(FileSystem.OpenPackage(map.Path, int.MaxValue));
 
 			Rules.LoadRules(Manifest, map);
-			SpriteLoader = new SpriteLoader( Rules.TileSets[map.Tileset].Extensions, SheetBuilder );
+			SpriteLoader = new SpriteLoader(Rules.TileSets[map.Tileset].Extensions, SheetBuilder);
+			// TODO: Don't load the sequences for assets that are not used in this tileset. Maybe use the existing EditorTilesetFilters.
 			SequenceProvider.Initialize(Manifest.Sequences, map.Sequences);
 
 			return map;


### PR DESCRIPTION
as requested in #3039 although it does not solve all problems. The design decision to keep sequence definitions separate from game rules might be appealing for mods which have them all set up correctly, but modders usually forget about them when adding new unit rules. Now they get a warning immediately on startup that something will go wrong when the asset is loaded so that you don't have to click through the build palette and test build every unit to check for related crashes.
