### PR TITLE
Tanks' ROF increased

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -421,7 +421,7 @@ Grenade:
 		Damage: 50
 
 70mm:
-	ROF: 45
+	ROF: 38
 	Range: 4
 	Report: TNKFIRE3
 	Projectile: Bullet
@@ -462,7 +462,7 @@ Grenade:
 		Damage: 30
 
 120mm:
-	ROF: 60
+	ROF: 50
 	Range: 4.75
 	Report: TNKFIRE6
 	Projectile: Bullet


### PR DESCRIPTION
Increased ROF of tanks. The guns of Light & Medium Tanks are a bit weak
relative to their role as tanks. They do less damage than bike rockets,
and do less damage against light vehicles than even the hum-vee. Changing
ROF should mitigate this a bit, even though their gun is still not that
powerful (e.g. compared to stealth tank, and even flame tank matched light
tank). The fact that their rivals are often moving fasts also complicates
the slower ROF.

The same proportion of damage was kept between light & medium tanks.
Mammoth Tank was left unchanged.
