### PR TITLE
Hotkey changes

### DIFF
--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -153,9 +153,7 @@ namespace OpenRA.Mods.RA.Widgets
 				TabChange(e.Modifiers.HasModifier(Modifiers.Shift));
 				return true;
 			}
-			if (e.Modifiers == Modifiers.Alt)
-				return DoBuildingHotkey(e.KeyName, world);
-			return false;
+			return DoBuildingHotkey(e.KeyName, world);
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -458,7 +456,7 @@ namespace OpenRA.Mods.RA.Widgets
 			WidgetUtils.DrawPanel("dialog4", new Rectangle(Game.viewport.Width - 300, pos.Y, 300, longDescSize + 65));
 
 			Game.Renderer.Fonts["Bold"].DrawText(
-				tooltip.Name + ((buildable.Hotkey != null) ? " (ALT + {0})".F(buildable.Hotkey.ToUpper()) : ""),
+				tooltip.Name + ((buildable.Hotkey != null) ? " ({0})".F(buildable.Hotkey.ToUpper()) : ""),
 												   p.ToInt2() + new int2(5, 5), Color.White);
 
 			var resources = pl.PlayerActor.Trait<PlayerResources>();

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -468,6 +468,7 @@ SHOK:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
+		BuildPaletteOrder: 70
 		Prerequisites: stek,tsla
 		Owner: soviet
 		Hotkey: l
@@ -505,7 +506,7 @@ SNIPER:
 		Description: Elite sniper infantry unit.\n  Strong vs Infantry\n  Weak vs Vehicles
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 80
 		Owner: soviet
 		Prerequisites: dome
 		Hotkey: n

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -80,7 +80,7 @@ SPEN:
 		Description: Produces and repairs submarines and \ntransports
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 50
 		Prerequisites: anypower
 		Owner: soviet
 		Hotkey: y
@@ -130,7 +130,7 @@ SYRD:
 		Proxy: powerproxy.sonarpulse
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 50
 		Prerequisites: anypower
 		Owner: allies
 		Hotkey: y
@@ -347,7 +347,7 @@ DOME:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 80
 		Prerequisites: proc
 		Owner: allies,soviet
 		Hotkey: r
@@ -882,7 +882,7 @@ WEAP:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 70
 		Prerequisites: proc
 		Owner: soviet,allies
 		Hotkey: w
@@ -997,7 +997,7 @@ SILO:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 60
 		Prerequisites: proc
 		Owner: allies,soviet
 		Hotkey: o
@@ -1063,7 +1063,7 @@ AFLD:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 90
 		Prerequisites: dome
 		Owner: soviet
 		Hotkey: i
@@ -1171,7 +1171,7 @@ STEK:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 100
 		Prerequisites: weap,dome
 		Owner: soviet
 		Hotkey: t
@@ -1290,7 +1290,7 @@ FIX:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 40
 		Prerequisites: weap
 		Owner: allies,soviet
 		Hotkey: m

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -53,7 +53,7 @@ GAP:
 		BuildPaletteOrder: 100
 		Prerequisites: atek
 		Owner: allies
-		Hotkey: x
+		Hotkey: g
 	Building:
 		Power: -60
 		Footprint: _ x
@@ -619,7 +619,7 @@ HBOX.E1:
 		BuildPaletteOrder: 20
 		Prerequisites: tent
 		Owner: allies
-		Hotkey: p
+		Hotkey: l
 	Tooltip:
 		Name: Camo Pillbox (Guns)
 		Description: Hidden defensive structure.\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks, Aircraft
@@ -1293,7 +1293,7 @@ FIX:
 		BuildPaletteOrder: 30
 		Prerequisites: weap
 		Owner: allies,soviet
-		Hotkey: x
+		Hotkey: m
 	Valued:
 		Cost: 1200
 	Tooltip:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -74,7 +74,7 @@ V2RL:
 		BuildPaletteOrder: 60
 		Prerequisites: fix
 		Owner: allies
-		Hotkey: x
+		Hotkey: m
 	Valued:
 		Cost: 850
 	Tooltip:
@@ -543,7 +543,7 @@ MRJ:
 		BuildPaletteOrder: 150
 		Prerequisites: atek
 		Owner: allies
-		Hotkey: m
+		Hotkey: k
 	Health:
 		HP: 200
 	Armor:


### PR DESCRIPTION
- Removed the `ALT` modifier for buildings hotkeys
- Changed some unit and building hotkeys
- Soviet buildings `BuildPaletteOrder:` now matches the Allies buildings BPO
- Changed flamethrower and shock trooper's `BuildPaletteOrder:`
