### PR TITLE
Added servername, mod and version to replay browser

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -91,11 +91,13 @@ namespace OpenRA.Network
 			public string Difficulty;
 			public bool Crates = true;
 			public bool AllowVersionMismatch;
+			public string Version;
 		}
 
 		public Session(string[] mods)
 		{
 			this.GlobalSettings.Mods = mods.ToArray();
+			this.GlobalSettings.Version = Mod.AllMods[mods[0]].Version;
 		}
 
 		public string Serialize()

--- a/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
@@ -11,6 +11,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using OpenRA.FileFormats;
 using OpenRA.Network;
 using OpenRA.Widgets;
 
@@ -43,7 +44,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 
 			var watch = panel.Get<ButtonWidget>("WATCH_BUTTON");
-			watch.IsDisabled = () => currentReplay == null || currentMap == null || currentReplay.Duration == 0;
+			watch.IsDisabled = () => currentReplay == null || currentMap == null || currentReplay.Duration == 0
+				|| currentReplay.LobbyInfo.GlobalSettings.Version != WidgetUtils.ActiveModVersion();
 			watch.OnClick = () =>
 			{
 				if (currentReplay != null)
@@ -70,8 +72,12 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				currentReplay = new Replay(filename);
 				currentMap = currentReplay.Map();
 
+				panel.Get<LabelWidget>("SERVER").GetText =
+					() => currentReplay.LobbyInfo.GlobalSettings.ServerName;
+
 				panel.Get<LabelWidget>("DURATION").GetText =
 					() => WidgetUtils.FormatTime(currentReplay.Duration * 3	/* TODO: 3:1 ratio isnt always true. */);
+
 				panel.Get<MapPreviewWidget>("MAP_PREVIEW").Map = () => currentMap;
 				panel.Get<LabelWidget>("MAP_TITLE").GetText =
 					() => currentMap != null ? currentMap.Title : "(Unknown Map)";
@@ -79,6 +85,12 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var players = currentReplay.LobbyInfo.Slots
 					.Count(s => currentReplay.LobbyInfo.ClientInSlot(s.Key) != null);
 				panel.Get<LabelWidget>("PLAYERS").GetText = () => players.ToString();
+
+				panel.Get<LabelWidget>("MOD").GetText =
+					() => currentReplay.LobbyInfo.GlobalSettings.Mods[0];
+
+				panel.Get<LabelWidget>("VERSION").GetText =
+					() => currentReplay.LobbyInfo.GlobalSettings.Version;
 			}
 			catch (Exception e)
 			{

--- a/mods/cnc/chrome/replaybrowser.yaml
+++ b/mods/cnc/chrome/replaybrowser.yaml
@@ -63,6 +63,18 @@ Container@REPLAYBROWSER_PANEL:
 							X:75
 							Width:70
 							Height:20
+						Label@SERVER_LABEL:
+							Align:Right
+							Width:70
+							Height:20
+							Text:Server:
+							Font:Bold
+							Visible: no
+						Label@SERVER:
+							Align:Left
+							Width:70
+							Height:20
+							Visible: no
 						Label@DURATION_LABEL:
 							Y:20
 							Align:Right
@@ -87,6 +99,30 @@ Container@REPLAYBROWSER_PANEL:
 							Y:40
 							Width:70
 							Height:20
+						Label@MOD_LABEL:
+							Align:Right
+							Width:70
+							Height:20
+							Text:Mod:
+							Font:Bold
+							Visible: no
+						Label@MOD:
+							Align:Left
+							Width:70
+							Height:20
+							Visible: no
+						Label@VERSION_LABEL:
+							Align:Right
+							Width:70
+							Height:20
+							Text:Version:
+							Font:Bold
+							Visible: no
+						Label@VERSION:
+							Align:Left
+							Width:70
+							Height:20
+							Visible: no
 				Button@CANCEL_BUTTON:
 					Key:escape
 					X:0

--- a/mods/ra/chrome/replaybrowser.yaml
+++ b/mods/ra/chrome/replaybrowser.yaml
@@ -42,6 +42,20 @@ Background@REPLAYBROWSER_BG:
 					Y:30
 					Width:192
 					Height:192
+				Label@SERVER_LABEL:
+					X:PARENT_RIGHT - 200 - WIDTH
+					Y:230
+					Align:Right
+					Width:70
+					Height:20
+					Text:Server:
+					Font:Bold
+				Label@SERVER:
+					X:PARENT_RIGHT - 195
+					Y:230
+					Align:Left
+					Width:70
+					Height:20
 				Label@MAP_TITLE_LABEL:
 					X:PARENT_RIGHT - 200 - WIDTH
 					Y:250
@@ -81,6 +95,34 @@ Background@REPLAYBROWSER_BG:
 				Label@PLAYERS:
 					X:PARENT_RIGHT - 195
 					Y:290
+					Align:Left
+					Width:70
+					Height:20
+				Label@MOD_LABEL:
+					X:PARENT_RIGHT - 200 - WIDTH
+					Y:310
+					Align:Right
+					Width:70
+					Height:20
+					Text:Mod:
+					Font:Bold
+				Label@MOD:
+					X:PARENT_RIGHT - 195
+					Y:310
+					Align:Left
+					Width:70
+					Height:20
+				Label@VERSION_LABEL:
+					X:PARENT_RIGHT - 200 - WIDTH
+					Y:330
+					Align:Right
+					Width:70
+					Height:20
+					Text:Version:
+					Font:Bold
+				Label@VERSION:
+					X:PARENT_RIGHT - 195
+					Y:330
 					Align:Left
 					Width:70
 					Height:20


### PR DESCRIPTION
I also disallowed watching replays of different versions so we don't get spammed with desync crash reports once the automated error reporting from #2854 is added. It also displays more information about the review to assist you in finding what match you are looking for. This was wished for in #2152 and #3002.
