### PR TITLE
Added in-game network stats

### DIFF
--- a/mods/cnc/chrome/ingame-infobriefing.yaml
+++ b/mods/cnc/chrome/ingame-infobriefing.yaml
@@ -1,5 +1,5 @@
 Container@MAP_PANEL:
-	Height:	PARENT_BOTTOM
+	Height: PARENT_BOTTOM
 	Width: PARENT_RIGHT
 	Logic: GameInfoBriefingLogic
 	Children:

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -77,8 +77,30 @@ Container@SKIRMISH_STATS:
 					X: 2
 					Y: 0
 					Children:
+						Image@ADMIN_INDICATOR:
+							ImageCollection: lobby-bits
+							ImageName: admin
+							X: 2
+							Visible: false
+						Container@LATENCY:
+							X: 0
+							Y: 6
+							Width: 11
+							Height: 14
+							Visible: false
+							Children:
+								ColorBlock@LATENCY_COLOR:
+									X: 2
+									Y: 2
+									Width: PARENT_RIGHT-4
+									Height: PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer: TOOLTIP_CONTAINER
+							Template: CLIENT_TOOLTIP
+							Width: 11
+							Height: 25
 						Label@NAME:
-							X: 10
+							X: 12
 							Width: 150
 							Height: 25
 						Image@FACTIONFLAG:
@@ -105,4 +127,5 @@ Container@SKIRMISH_STATS:
 							Width: 70
 							Height: 25
 							Align: Center
+		TooltipContainer@TOOLTIP_CONTAINER:
 

--- a/mods/cnc/chrome/ingame-leavemap.yaml
+++ b/mods/cnc/chrome/ingame-leavemap.yaml
@@ -18,7 +18,7 @@ Container@LEAVE_MAP_WIDGET:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			Background: shellmapborder
-		Container@LEAVE_MAP_SIMPLE
+		Container@LEAVE_MAP_SIMPLE:
 			X: (WINDOW_RIGHT - WIDTH) / 2
 			Y: (WINDOW_BOTTOM - HEIGHT) / 2
 			Width: 370

--- a/mods/ra/chrome/ingame-infostats.yaml
+++ b/mods/ra/chrome/ingame-infostats.yaml
@@ -77,8 +77,30 @@ Container@SKIRMISH_STATS:
 					X: 2
 					Y: 0
 					Children:
+						Image@ADMIN_INDICATOR:
+							ImageCollection: lobby-bits
+							ImageName: admin
+							X: 2
+							Visible: false
+						Container@LATENCY:
+							X: 0
+							Y: 6
+							Width: 11
+							Height: 14
+							Visible: false
+							Children:
+								ColorBlock@LATENCY_COLOR:
+									X: 2
+									Y: 2
+									Width: PARENT_RIGHT-4
+									Height: PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer: TOOLTIP_CONTAINER
+							Template: CLIENT_TOOLTIP
+							Width: 11
+							Height: 25
 						Label@NAME:
-							X: 10
+							X: 12
 							Width: 150
 							Height: 25
 						Image@FACTIONFLAG:
@@ -105,4 +127,5 @@ Container@SKIRMISH_STATS:
 							Width: 70
 							Height: 25
 							Align: Center
+		TooltipContainer@TOOLTIP_CONTAINER:
 

--- a/mods/ra/chrome/ingame-leavemap.yaml
+++ b/mods/ra/chrome/ingame-leavemap.yaml
@@ -20,7 +20,7 @@ Container@LEAVE_MAP_WIDGET:
 			Align: Center
 			Font: Regular
 			Contrast: True
-		Container@LEAVE_MAP_SIMPLE
+		Container@LEAVE_MAP_SIMPLE:
 			X: (WINDOW_RIGHT - WIDTH) / 2
 			Y: (WINDOW_BOTTOM - HEIGHT) / 2
 			Width: 370


### PR DESCRIPTION
As requested in #2281.

Also wired up the check if clients lag behind the current net frame (labeled as Delay). My plan is to expose the network stats tab to everyone and gameplay stats to allies not just spectators as requested in #2511 once #3135 is merged.

Note this is also useful for #2693 because it exposes the IP to everyone (not just the server and not just hidden in a log file) which can then be traced to identify trolls and get them banned for the next round.

Known limitations: the PlayerPinger server trait from #3158 does not update in-game, so latency and jitter do not show the live values, but the average calculated in the lobby.
