### PR TITLE
New/Improved lobby tooltips

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -53,6 +53,7 @@ namespace OpenRA.Network
 			public string Country;
 			public int SpawnPoint;
 			public string Name;
+			public string IpAddress;
 			public ClientState State;
 			public int Team;
 			public string Slot;	// slot ID, or null for observer

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -61,9 +61,9 @@ namespace OpenRA.Network
 			public bool IsAdmin;
 			public bool IsReady { get { return State == ClientState.Ready; } }
 			public bool IsObserver { get { return Slot == null; } }
-			public int Ping = -1;
-			public int PingJitter = -1;
-			public int[] PingHistory = {};
+			public int Latency = -1;
+			public int LatencyJitter = -1;
+			public int[] LatencyHistory = {};
 		}
 
 		public class Slot

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Widgets\TooltipContainerWidget.cs" />
     <Compile Include="Traits\DebugPauseState.cs" />
     <Compile Include="Network\UPnP.cs" />
+    <Compile Include="Widgets\ClientTooltipRegionWidget.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -469,16 +469,16 @@ namespace OpenRA.Server
 						break;
 					}
 
-					var history = fromClient.PingHistory.ToList();
+					var history = fromClient.LatencyHistory.ToList();
 					history.Add(Environment.TickCount - pingSent);
 
 					// Cap ping history at 5 values (25 seconds)
 					if (history.Count > 5)
 						history.RemoveRange(0, history.Count - 5);
 
-					fromClient.Ping = history.Sum() / history.Count;
-					fromClient.PingJitter = (history.Max() - history.Min())/2;
-					fromClient.PingHistory = history.ToArray();
+					fromClient.Latency = history.Sum() / history.Count;
+					fromClient.LatencyJitter = (history.Max() - history.Min())/2;
+					fromClient.LatencyHistory = history.ToArray();
 
 					if (State == ServerState.WaitingPlayers)
 						SyncLobbyInfo();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -263,11 +263,13 @@ namespace OpenRA.Server
 					return;
 				}
 
+				client.IpAddress = ((IPEndPoint)newConn.socket.RemoteEndPoint).Address.ToString();
+
 				// Check if IP is banned
 				if (lobbyInfo.GlobalSettings.Ban != null)
 				{
-					var remote_addr = ((IPEndPoint)newConn.socket.RemoteEndPoint).Address.ToString();
-					if (lobbyInfo.GlobalSettings.Ban.Contains(remote_addr))
+
+					if (lobbyInfo.GlobalSettings.Ban.Contains(client.IpAddress))
 					{
 						Console.WriteLine("Rejected connection from "+client.Name+"("+newConn.socket.RemoteEndPoint+"); Banned.");
 						Log.Write("server", "Rejected connection from {0}; Banned.",

--- a/OpenRA.Game/Widgets/ClientTooltipRegionWidget.cs
+++ b/OpenRA.Game/Widgets/ClientTooltipRegionWidget.cs
@@ -1,0 +1,67 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Threading;
+using OpenRA.FileFormats;
+using OpenRA.Graphics;
+using OpenRA.Network;
+
+namespace OpenRA.Widgets
+{
+	public class ClientTooltipRegionWidget : Widget
+	{
+		public readonly string Template;
+		public readonly string TooltipContainer;
+		Lazy<TooltipContainerWidget> tooltipContainer;
+		OrderManager orderManager;
+		int clientIndex;
+
+		public ClientTooltipRegionWidget() : base()
+		{
+			tooltipContainer = Lazy.New(() => Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
+		}
+
+		protected ClientTooltipRegionWidget(ClientTooltipRegionWidget other)
+			: base(other)
+		{
+			Template = other.Template;
+			TooltipContainer = other.TooltipContainer;
+			tooltipContainer = Lazy.New(() => Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
+			orderManager = other.orderManager;
+			clientIndex = other.clientIndex;
+		}
+
+		public override Widget Clone() { return new ClientTooltipRegionWidget(this); }
+
+		public void Bind(OrderManager orderManager, int clientIndex)
+		{
+			this.orderManager = orderManager;
+			this.clientIndex = clientIndex;
+		}
+
+		public override void MouseEntered()
+		{
+			if (TooltipContainer == null)
+				return;
+			tooltipContainer.Value.SetTooltip(Template, new WidgetArgs() {{"orderManager", orderManager}, {"clientIndex", clientIndex}});
+		}
+
+		public override void MouseExited()
+		{
+			if (TooltipContainer == null)
+				return;
+			tooltipContainer.Value.RemoveTooltip();
+		}
+	}
+}

--- a/OpenRA.Game/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Game/Widgets/MapPreviewWidget.cs
@@ -24,7 +24,6 @@ namespace OpenRA.Widgets
 		public Func<Map> Map = () => null;
 		public Func<Dictionary<int2, Session.Client>> SpawnClients = () => new Dictionary<int2, Session.Client>();
 		public Action<MouseInput> OnMouseDown = _ => {};
-		public Action<int, int2> OnTooltip = (_, __) => { };
 		public bool IgnoreMouseInput = false;
 		public bool ShowSpawnPoints = true;
 
@@ -147,13 +146,7 @@ namespace OpenRA.Widgets
 					Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, pos + offset);
 
 					if ((pos - Viewport.LastMousePos).LengthSquared < 64)
-					{
 						TooltipSpawnIndex = spawnPoints.IndexOf(p) + 1;
-
-						// Legacy tooltip behavior
-						if (TooltipContainer == null)
-							OnTooltip(TooltipSpawnIndex, pos);
-					}
 				}
 			}
 		}

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -113,7 +113,6 @@
     <Compile Include="WithFire.cs" />
     <Compile Include="WithRoof.cs" />
     <Compile Include="Widgets\ResourceBarWidget.cs" />
-    <Compile Include="Widgets\Logic\SpawnSelectorTooltipLogic.cs" />
     <Compile Include="Widgets\Logic\ProductionTabsLogic.cs" />
     <Compile Include="Widgets\ProductionTypeButtonWidget.cs" />
   </ItemGroup>

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -430,6 +430,7 @@
     <Compile Include="BridgeHut.cs" />
     <Compile Include="Lint\CheckSequences.cs" />
     <Compile Include="ServerTraits\PlayerPinger.cs" />
+    <Compile Include="Widgets\Logic\SpawnSelectorTooltipLogic.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -431,6 +431,7 @@
     <Compile Include="Lint\CheckSequences.cs" />
     <Compile Include="ServerTraits\PlayerPinger.cs" />
     <Compile Include="Widgets\Logic\SpawnSelectorTooltipLogic.cs" />
+    <Compile Include="Widgets\Logic\ClientTooltipLogic.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/Widgets/Logic/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ClientTooltipLogic.cs
@@ -1,0 +1,64 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Widgets;
+using OpenRA.Network;
+
+namespace OpenRA.Mods.RA.Widgets.Logic
+{
+	public class ClientTooltipLogic
+	{
+		[ObjectCreator.UseCtor]
+		public ClientTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, OrderManager orderManager, int clientIndex)
+		{
+			var admin = widget.Get<LabelWidget>("ADMIN");
+			var adminFont = Game.Renderer.Fonts[admin.Font];
+
+			var latency = widget.Get<LabelWidget>("LATENCY");
+			var latencyFont = Game.Renderer.Fonts[latency.Font];
+
+			var ip = widget.Get<LabelWidget>("IP");
+			var ipFont = Game.Renderer.Fonts[ip.Font];
+
+			var ipOffset = ip.Bounds.Y;
+			var latencyOffset = latency.Bounds.Y;
+			var tooltipHeight = widget.Bounds.Height;
+
+			var margin = widget.Bounds.Width;
+			tooltipContainer.BeforeRender = () =>
+			{
+				var width = Math.Max(adminFont.Measure(admin.GetText()).X, Math.Max(ipFont.Measure(ip.GetText()).X, latencyFont.Measure(latency.GetText()).X));
+				widget.Bounds.Width = width + 2*margin;
+				latency.Bounds.Width = widget.Bounds.Width;
+				ip.Bounds.Width = widget.Bounds.Width;
+				admin.Bounds.Width = widget.Bounds.Width;
+
+				ip.Bounds.Y = ipOffset;
+				latency.Bounds.Y = latencyOffset;
+				widget.Bounds.Height = tooltipHeight;
+
+				if (admin.IsVisible())
+				{
+					ip.Bounds.Y += admin.Bounds.Height;
+					latency.Bounds.Y += admin.Bounds.Height;
+					widget.Bounds.Height += admin.Bounds.Height;
+				}
+			};
+
+			admin.IsVisible = () => orderManager.LobbyInfo.ClientWithIndex(clientIndex).IsAdmin;
+			latency.GetText = () => "Latency: {0}".F(LobbyUtils.LatencyDescription(orderManager.LobbyInfo.ClientWithIndex(clientIndex).Latency));
+			ip.GetText = () => orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
+		}
+	}
+}
+

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -112,7 +112,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			mapPreview.IsVisible = () => Map != null;
 			mapPreview.Map = () => Map;
 			mapPreview.OnMouseDown = mi => LobbyUtils.SelectSpawnPoint( orderManager, mapPreview, Map, mi );
-			mapPreview.OnTooltip = (spawnPoint, pos) => LobbyUtils.ShowSpawnPointTooltip(orderManager, spawnPoint, pos);
 			mapPreview.SpawnClients = () => LobbyUtils.GetSpawnClients(orderManager, Map);
 
 			var mapTitle = lobby.GetOrNull<LabelWidget>("MAP_TITLE");

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -388,7 +388,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					if (template == null || template.Id != EditablePlayerTemplate.Id)
 						template = EditablePlayerTemplate.Clone();
 
-					LobbyUtils.SetupAdminPingWidget(template, slot, client, orderManager, client.Bot == null);
+					LobbyUtils.SetupClientWidget(template, slot, client, orderManager, client.Bot == null);
 
 					if (client.Bot != null)
 						LobbyUtils.SetupEditableSlotWidget(template, slot, client, orderManager);
@@ -408,7 +408,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					if (template == null || template.Id != NonEditablePlayerTemplate.Id)
 						template = NonEditablePlayerTemplate.Clone();
 
-					LobbyUtils.SetupAdminPingWidget(template, slot, client, orderManager, client.Bot == null);
+					LobbyUtils.SetupClientWidget(template, slot, client, orderManager, client.Bot == null);
 					LobbyUtils.SetupNameWidget(template, slot, client);
 					LobbyUtils.SetupKickWidget(template, slot, client, orderManager);
 					LobbyUtils.SetupColorWidget(template, slot, client);
@@ -459,7 +459,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					LobbyUtils.SetupReadyWidget(template, null, client);
 				}
 
-				LobbyUtils.SetupAdminPingWidget(template, null, c, orderManager, true);
+				LobbyUtils.SetupClientWidget(template, null, c, orderManager, true);
 				template.IsVisible = () => true;
 
 				if (idx >= Players.Children.Count)

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -158,15 +158,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 		}
 
-		public static void ShowSpawnPointTooltip(OrderManager orderManager, int spawnPoint, int2 position)
-		{
-			var client = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.SpawnPoint == spawnPoint);
-			if (client != null)
-			{
-				Game.Renderer.Fonts["Bold"].DrawTextWithContrast(client.Name, position + new int2(5, 5), Color.White, Color.Black, 1);
-			}
-		}
-
 		static Color GetPingColor(Session.Client c)
 		{
 			if (c.Ping < 0) // Ping unknown

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -158,16 +158,28 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 		}
 
-		static Color GetLatencyColor(Session.Client c)
+		static Color LatencyColor(int latency)
 		{
-			if (c.Latency < 0) // Ping unknown
+			// Levels set relative to the default order lag of 3 net ticks (360ms)
+			// TODO: Adjust this once dynamic lag is implemented
+			if (latency < 0)
 				return Color.Gray;
-			if (c.Latency > 720) // OrderLag > 6
-				return Color.Red;
-			if (c.Latency > 360) // OrderLag > 3
+			if (latency < 300)
+				return Color.LimeGreen;
+			if (latency < 600)
 				return Color.Orange;
+			return Color.Red;
+		}
 
-			return Color.LimeGreen;
+		static string LatencyDescription(int latency)
+		{
+			if (latency < 0)
+				return "Unknown";
+			if (latency < 300)
+				return "Good";
+			if (latency < 600)
+				return "Moderate";
+			return "Poor";
 		}
 
 		public static void SetupClientWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, bool visible)
@@ -177,7 +189,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			block.IsVisible = () => visible;
 
 			if (visible)
-				block.Get<ColorBlockWidget>("LATENCY_COLOR").GetColor = () => GetLatencyColor(c);
+				block.Get<ColorBlockWidget>("LATENCY_COLOR").GetColor = () => LatencyColor(c.Latency);
 		}
 
 		public static void SetupEditableNameWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager)

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 		}
 
-		static Color LatencyColor(int latency)
+		public static Color LatencyColor(int latency)
 		{
 			// Levels set relative to the default order lag of 3 net ticks (360ms)
 			// TODO: Adjust this once dynamic lag is implemented
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return Color.Red;
 		}
 
-		static string LatencyDescription(int latency)
+		public static string LatencyDescription(int latency)
 		{
 			if (latency < 0)
 				return "Unknown";
@@ -190,6 +190,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			if (visible)
 				block.Get<ColorBlockWidget>("LATENCY_COLOR").GetColor = () => LatencyColor(c.Latency);
+
+			var tooltip = parent.Get<ClientTooltipRegionWidget>("CLIENT_REGION");
+			tooltip.IsVisible = () => visible;
+			tooltip.Bind(orderManager, c.Index);
 		}
 
 		public static void SetupEditableNameWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager)

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -158,26 +158,26 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 		}
 
-		static Color GetPingColor(Session.Client c)
+		static Color GetLatencyColor(Session.Client c)
 		{
-			if (c.Ping < 0) // Ping unknown
+			if (c.Latency < 0) // Ping unknown
 				return Color.Gray;
-			if (c.Ping > 720) // OrderLag > 6
+			if (c.Latency > 720) // OrderLag > 6
 				return Color.Red;
-			if (c.Ping > 360) // OrderLag > 3
+			if (c.Latency > 360) // OrderLag > 3
 				return Color.Orange;
 
 			return Color.LimeGreen;
 		}
 
-		public static void SetupAdminPingWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, bool visible)
+		public static void SetupClientWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, bool visible)
 		{
 			parent.Get("ADMIN_INDICATOR").IsVisible = () => c.IsAdmin;
-			var block = parent.Get("PING_BLOCK");
+			var block = parent.Get("LATENCY");
 			block.IsVisible = () => visible;
 
 			if (visible)
-				block.Get<ColorBlockWidget>("PING_COLOR").GetColor = () => GetPingColor(c);
+				block.Get<ColorBlockWidget>("LATENCY_COLOR").GetColor = () => GetLatencyColor(c);
 		}
 
 		public static void SetupEditableNameWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager)

--- a/OpenRA.Mods.RA/Widgets/Logic/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SpawnSelectorTooltipLogic.cs
@@ -14,7 +14,7 @@ using System.Linq;
 using OpenRA.Widgets;
 using OpenRA.Network;
 
-namespace OpenRA.Mods.Cnc.Widgets.Logic
+namespace OpenRA.Mods.RA.Widgets.Logic
 {
 	public class SpawnSelectorTooltipLogic
 	{
@@ -25,9 +25,14 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			var label = widget.Get<LabelWidget>("LABEL");
 			var flag = widget.Get<ImageWidget>("FLAG");
 			var team = widget.Get<LabelWidget>("TEAM");
-
+			var singleHeight = widget.Get("SINGLE_HEIGHT").Bounds.Height;
+			var doubleHeight = widget.Get("DOUBLE_HEIGHT").Bounds.Height;
 			var ownerFont = Game.Renderer.Fonts[label.Font];
 			var teamFont = Game.Renderer.Fonts[team.Font];
+
+			// Width specified in YAML is used as the margin between flag / label and label / border
+			var labelMargin = widget.Bounds.Width;
+
 			var cachedWidth = 0;
 			var labelText = "";
 			string playerCountry = null;
@@ -43,18 +48,18 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 					labelText = "Available spawn";
 					playerCountry = null;
 					playerTeam = 0;
-					widget.Bounds.Height = 25;
+					widget.Bounds.Height = singleHeight;
 				}
 				else
 				{
 					labelText = client.Name;
 					playerCountry = client.Country;
 					playerTeam = client.Team;
-					widget.Bounds.Height = playerTeam > 0 ? 40 : 25;
+					widget.Bounds.Height = playerTeam > 0 ? doubleHeight : singleHeight;
 					teamWidth = teamFont.Measure(team.GetText()).X;
 				}
 
-				label.Bounds.X = playerCountry != null ? flag.Bounds.Right + 5 : 5;
+				label.Bounds.X = playerCountry != null ? flag.Bounds.Right + labelMargin : labelMargin;
 
 				var textWidth = ownerFont.Measure(labelText).X;
 				if (textWidth != cachedWidth)
@@ -63,7 +68,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 					widget.Bounds.Width = 2*label.Bounds.X + textWidth;
 				}
 
-				widget.Bounds.Width = Math.Max(teamWidth + 10, label.Bounds.Right + 5);
+				widget.Bounds.Width = Math.Max(teamWidth + 2*labelMargin, label.Bounds.Right + labelMargin);
 				team.Bounds.Width = widget.Bounds.Width;
 			};
 

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -73,7 +73,7 @@ Container@SERVER_LOBBY:
 									ImageName:admin
 									X:2
 									Visible:false
-								Background@PING_BLOCK:
+								Background@LATENCY:
 									Background:button
 									X:0
 									Y:6
@@ -81,7 +81,7 @@ Container@SERVER_LOBBY:
 									Height:14
 									Visible:false
 									Children:
-										ColorBlock@PING_COLOR:
+										ColorBlock@LATENCY_COLOR:
 											X:2
 											Y:2
 											Width:PARENT_RIGHT-4
@@ -161,7 +161,7 @@ Container@SERVER_LOBBY:
 									ImageName:admin
 									X:2
 									Visible:false
-								Background@PING_BLOCK:
+								Background@LATENCY:
 									Background:button
 									X:0
 									Y:6
@@ -169,7 +169,7 @@ Container@SERVER_LOBBY:
 									Height:14
 									Visible:false
 									Children:
-										ColorBlock@PING_COLOR:
+										ColorBlock@LATENCY_COLOR:
 											X:2
 											Y:2
 											Width:PARENT_RIGHT-4
@@ -263,7 +263,7 @@ Container@SERVER_LOBBY:
 									ImageName:admin
 									X:2
 									Visible:false
-								Background@PING_BLOCK:
+								Background@LATENCY:
 									Background:button
 									X:0
 									Y:6
@@ -271,7 +271,7 @@ Container@SERVER_LOBBY:
 									Height:14
 									Visible:false
 									Children:
-										ColorBlock@PING_COLOR:
+										ColorBlock@LATENCY_COLOR:
 											X:2
 											Y:2
 											Width:PARENT_RIGHT-4
@@ -319,7 +319,7 @@ Container@SERVER_LOBBY:
 									ImageName:admin
 									X:2
 									Visible:false
-								Background@PING_BLOCK:
+								Background@LATENCY:
 									Background:button
 									X:0
 									Y:6
@@ -327,7 +327,7 @@ Container@SERVER_LOBBY:
 									Height:14
 									Visible:false
 									Children:
-										ColorBlock@PING_COLOR:
+										ColorBlock@LATENCY_COLOR:
 											X:2
 											Y:2
 											Width:PARENT_RIGHT-4

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -480,7 +480,6 @@ Container@SERVER_LOBBY:
 							Height:25
 							Align:Right
 							Text:Chat:
-		TooltipContainer@TOOLTIP_CONTAINER:
 		Button@DISCONNECT_BUTTON:
 			X:0
 			Y:499
@@ -505,3 +504,4 @@ Container@SERVER_LOBBY:
 			Width:140
 			Height:35
 			Text:Start Game
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -86,6 +86,11 @@ Container@SERVER_LOBBY:
 											Y:2
 											Width:PARENT_RIGHT-4
 											Height:PARENT_BOTTOM-4
+								ClientTooltipRegion@CLIENT_REGION:
+									TooltipContainer:TOOLTIP_CONTAINER
+									Template:CLIENT_TOOLTIP
+									Width:11
+									Height:25
 								TextField@NAME:
 									Text:Name
 									X:15
@@ -174,6 +179,11 @@ Container@SERVER_LOBBY:
 											Y:2
 											Width:PARENT_RIGHT-4
 											Height:PARENT_BOTTOM-4
+								ClientTooltipRegion@CLIENT_REGION:
+									TooltipContainer:TOOLTIP_CONTAINER
+									Template:CLIENT_TOOLTIP
+									Width:11
+									Height:25
 								Label@NAME:
 									Text:Name
 									Width:185
@@ -276,6 +286,11 @@ Container@SERVER_LOBBY:
 											Y:2
 											Width:PARENT_RIGHT-4
 											Height:PARENT_BOTTOM-4
+								ClientTooltipRegion@CLIENT_REGION:
+									TooltipContainer:TOOLTIP_CONTAINER
+									Template:CLIENT_TOOLTIP
+									Width:11
+									Height:25
 								TextField@NAME:
 									Text:Name
 									X:15
@@ -332,6 +347,11 @@ Container@SERVER_LOBBY:
 											Y:2
 											Width:PARENT_RIGHT-4
 											Height:PARENT_BOTTOM-4
+								ClientTooltipRegion@CLIENT_REGION:
+									TooltipContainer:TOOLTIP_CONTAINER
+									Template:CLIENT_TOOLTIP
+									Width:11
+									Height:25
 								Label@NAME:
 									Text:Name
 									Width:185

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -103,8 +103,12 @@ Background@SUPPORT_POWER_TOOLTIP:
 Background@SPAWN_TOOLTIP:
 	Logic:SpawnSelectorTooltipLogic
 	Background:panel-black
-	Width:141
+	Width:5
 	Children:
+		Container@SINGLE_HEIGHT:
+			Height:26
+		Container@DOUBLE_HEIGHT:
+			Height:40
 		Label@LABEL:
 			X:5
 			Height:23

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -123,3 +123,27 @@ Background@SPAWN_TOOLTIP:
 			Height:15
 			Font:TinyBold
 			Align:center
+
+Background@CLIENT_TOOLTIP:
+	Logic:ClientTooltipLogic
+	Background:panel-black
+	Height:35
+	Width:5
+	Children:
+		Label@ADMIN:
+			Y:2
+			Height:18
+			Font:Bold
+			Text:Game Admin
+			Align:Center
+		Label@IP:
+			Y:5
+			Width:5
+			Height:10
+			Font:TinyBold
+			Align:Center
+		Label@LATENCY:
+			Y:17
+			Height:10
+			Font:TinyBold
+			Align:Center

--- a/mods/d2k/chrome/lobby.yaml
+++ b/mods/d2k/chrome/lobby.yaml
@@ -34,6 +34,7 @@ Background@SERVER_LOBBY:
 					Y:4
 					Width:244
 					Height:244
+					TooltipContainer:TOOLTIP_CONTAINER
 		ScrollPanel@PLAYERS:
 			X:20
 			Y:67
@@ -494,3 +495,4 @@ Background@SERVER_LOBBY:
 			Height:25
 			Text:Start Game
 			Font:Bold
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/d2k/chrome/lobby.yaml
+++ b/mods/d2k/chrome/lobby.yaml
@@ -66,6 +66,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						TextField@NAME:
 							Text:Name
 							X:15
@@ -152,6 +157,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						Label@NAME:
 							Text:Name
 							Width:130
@@ -252,6 +262,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						TextField@NAME:
 							Text:Name
 							X:15
@@ -314,6 +329,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						Label@NAME:
 							Text:Name
 							Width:130

--- a/mods/d2k/chrome/lobby.yaml
+++ b/mods/d2k/chrome/lobby.yaml
@@ -54,14 +54,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4
@@ -140,14 +140,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4
@@ -240,14 +240,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4
@@ -302,14 +302,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -21,3 +21,27 @@ Background@SPAWN_TOOLTIP:
 			Height:15
 			Font:TinyBold
 			Align:center
+
+Background@CLIENT_TOOLTIP:
+	Logic:ClientTooltipLogic
+	Background:dialog3
+	Height:39
+	Width:7
+	Children:
+		Label@ADMIN:
+			Y:4
+			Height:18
+			Font:Bold
+			Text:Game Admin
+			Align:Center
+		Label@IP:
+			Y:7
+			Width:5
+			Height:10
+			Font:TinyBold
+			Align:Center
+		Label@LATENCY:
+			Y:19
+			Height:10
+			Font:TinyBold
+			Align:Center

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -1,0 +1,23 @@
+Background@SPAWN_TOOLTIP:
+	Logic:SpawnSelectorTooltipLogic
+	Background:dialog3
+	Width:7
+	Children:
+		Container@SINGLE_HEIGHT:
+			Height:31
+		Container@DOUBLE_HEIGHT:
+			Height:47
+		Label@LABEL:
+			Y:3
+			Height:23
+			Font:Bold
+		Image@FLAG:
+			X:5
+			Y:5
+			Width:23
+			Height:23
+		Label@TEAM:
+			Y:28
+			Height:15
+			Font:TinyBold
+			Align:center

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -60,6 +60,7 @@ ChromeLayout:
 	mods/ra/chrome/dropdowns.yaml
 	mods/ra/chrome/modchooser.yaml
 	mods/ra/chrome/cheats.yaml
+	mods/d2k/chrome/tooltips.yaml
 
 Weapons:
 	mods/d2k/weapons/defaults.yaml

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -66,6 +66,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						TextField@NAME:
 							Text:Name
 							X:15
@@ -152,6 +157,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						Label@NAME:
 							Text:Name
 							Width:130
@@ -252,6 +262,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						TextField@NAME:
 							Text:Name
 							X:15
@@ -314,6 +329,11 @@ Background@SERVER_LOBBY:
 									Y:2
 									Width:PARENT_RIGHT-4
 									Height:PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer:TOOLTIP_CONTAINER
+							Template:CLIENT_TOOLTIP
+							Width:11
+							Height:25
 						Label@NAME:
 							Text:Name
 							Width:130

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -54,14 +54,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4
@@ -140,14 +140,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4
@@ -240,14 +240,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4
@@ -302,14 +302,14 @@ Background@SERVER_LOBBY:
 							ImageName:admin
 							X:2
 							Visible:false
-						Container@PING_BLOCK:
+						Container@LATENCY:
 							X:0
 							Y:6
 							Width:11
 							Height:14
 							Visible:false
 							Children:
-								ColorBlock@PING_COLOR:
+								ColorBlock@LATENCY_COLOR:
 									X:2
 									Y:2
 									Width:PARENT_RIGHT-4

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -34,6 +34,7 @@ Background@SERVER_LOBBY:
 					Y:4
 					Width:244
 					Height:244
+					TooltipContainer:TOOLTIP_CONTAINER
 		ScrollPanel@PLAYERS:
 			X:20
 			Y:67
@@ -500,3 +501,4 @@ Background@SERVER_LOBBY:
 			Height:25
 			Text:Start Game
 			Font:Bold
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -21,3 +21,27 @@ Background@SPAWN_TOOLTIP:
 			Height:15
 			Font:TinyBold
 			Align:center
+
+Background@CLIENT_TOOLTIP:
+	Logic:ClientTooltipLogic
+	Background:dialog4
+	Height:39
+	Width:7
+	Children:
+		Label@ADMIN:
+			Y:4
+			Height:18
+			Font:Bold
+			Text:Game Admin
+			Align:Center
+		Label@IP:
+			Y:7
+			Width:5
+			Height:10
+			Font:TinyBold
+			Align:Center
+		Label@LATENCY:
+			Y:19
+			Height:10
+			Font:TinyBold
+			Align:Center

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -1,0 +1,23 @@
+Background@SPAWN_TOOLTIP:
+	Logic:SpawnSelectorTooltipLogic
+	Background:dialog4
+	Width:7
+	Children:
+		Container@SINGLE_HEIGHT:
+			Height:29
+		Container@DOUBLE_HEIGHT:
+			Height:44
+		Label@LABEL:
+			Y:2
+			Height:23
+			Font:Bold
+		Image@FLAG:
+			X:7
+			Y:7
+			Width:32
+			Height:16
+		Label@TEAM:
+			Y:23
+			Height:15
+			Font:TinyBold
+			Align:center

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -70,6 +70,7 @@ ChromeLayout:
 	mods/ra/chrome/modchooser.yaml
 	mods/ra/chrome/cheats.yaml
 	mods/ra/chrome/objectives.yaml
+	mods/ra/chrome/tooltips.yaml
 
 Weapons:
 	mods/ra/weapons.yaml


### PR DESCRIPTION
This implements the C&C spawn tooltips in RA and d2k, and adds a tooltip over the ping block showing the client IP, latency, and whether the client is the admin.

Latency thresholds have been tightened to give a more realistic picture of when to expect poor performance with the default order lag.
