### PR TITLE
Disallow glitchy overbright player color remaps everywhere

### DIFF
--- a/OpenRA.FileFormats/FieldLoader.cs
+++ b/OpenRA.FileFormats/FieldLoader.cs
@@ -156,7 +156,8 @@ namespace OpenRA.FileFormats
 						(byte)int.Parse(parts[0]).Clamp(0, 255),
 						(byte)int.Parse(parts[1]).Clamp(0, 255),
 						(byte)int.Parse(parts[2]).Clamp(0, 255),
-						(byte)int.Parse(parts[3]).Clamp(0, 255));
+						(byte)int.Parse(parts[3]).Clamp(0, 10)
+					);
 
 				return InvalidValueAction(x, fieldType, field);
 			}

--- a/OpenRA.FileFormats/Map/PlayerReference.cs
+++ b/OpenRA.FileFormats/Map/PlayerReference.cs
@@ -29,7 +29,7 @@ namespace OpenRA.FileFormats
 		public string Race;
 
 		public bool LockColor = false;
-		public ColorRamp ColorRamp = new ColorRamp(0,0,238,34);
+		public ColorRamp ColorRamp = new ColorRamp(0,0,238,10);
 
 		public bool LockSpawn = false;
 		public int Spawn = 0;

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -110,7 +110,7 @@ namespace OpenRA.GameRules
 	public class PlayerSettings
 	{
 		public string Name = "Newbie";
-		public ColorRamp ColorRamp = new ColorRamp(75, 255, 180, 25);
+		public ColorRamp ColorRamp = new ColorRamp(75, 255, 180, 10);
 		public string LastServer = "localhost:1234";
 	}
 


### PR DESCRIPTION
The first impression is that this is a bug in the engine because it just looks messed up. See picture and comment at http://www.moddb.com/games/openra/images/fort-lonestar#imagebox
