### PR TITLE
Fixed NullReferenceException for unknown IPs in Lobby Tooltip

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ClientTooltipLogic.cs
@@ -35,6 +35,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var tooltipHeight = widget.Bounds.Height;
 
 			var margin = widget.Bounds.Width;
+
+			tooltipContainer.IsVisible = () => (orderManager.LobbyInfo.ClientWithIndex(clientIndex) != null);
 			tooltipContainer.BeforeRender = () =>
 			{
 				var width = Math.Max(adminFont.Measure(admin.GetText()).X, Math.Max(ipFont.Measure(ip.GetText()).X, latencyFont.Measure(latency.GetText()).X));
@@ -57,7 +59,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			admin.IsVisible = () => orderManager.LobbyInfo.ClientWithIndex(clientIndex).IsAdmin;
 			latency.GetText = () => "Latency: {0}".F(LobbyUtils.LatencyDescription(orderManager.LobbyInfo.ClientWithIndex(clientIndex).Latency));
-			ip.GetText = () => orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
+			ip.GetText = () => LobbyUtils.DescriptiveIpAddress(orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -182,6 +182,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return "Poor";
 		}
 
+		public static string DescriptiveIpAddress(string ip)
+		{
+			if (ip == null)
+				return "Unknown Host";
+			if (ip == "127.0.0.1")
+				return "Local Host";
+			return ip;
+		}
+
 		public static void SetupClientWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, bool visible)
 		{
 			parent.Get("ADMIN_INDICATOR").IsVisible = () => c.IsAdmin;


### PR DESCRIPTION
This fixes #3167.

The lobby client tooltip can now handle not yet known IPs, too. It was not the Ping because that is initialized with -1.
