### PR TITLE
Removed Mud track from RA playlist because crash reports came in

### DIFF
--- a/mods/ra/music.yaml
+++ b/mods/ra/music.yaml
@@ -10,7 +10,7 @@ fac1226m: Face to the Enemy 1
 fac2226m: Face to the Enemy 2
 fogger1a: Fogger
 hell226m: Hell March
-mud1a: Mud
+#mud1a: Mud # reports of AudLoader crashes
 radio2: Radio 2
 rollout: Roll Out
 run1226m: Run for your Life


### PR DESCRIPTION
Reverted #2562 because #2176 was never fixed. It just seems to crash slightly randomly making the problem hard to track down.
