### PR TITLE
Remove sequence warnings for the stable release.

### DIFF
--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -43,7 +43,6 @@ namespace OpenRA.Graphics
 			catch (FileNotFoundException)
 			{
 				// Do nothing; we can crash later if we actually wanted art
-				Console.WriteLine("Can't find all files for unit {0}.".F(unit));
 			} 
 		}
 


### PR DESCRIPTION
As discussed in #3201 - a temporary fix for #3142 until we can fix the sequence loading mess properly.
