### PR TITLE
Add unit following/guarding

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -151,6 +151,7 @@ namespace OpenRA.GameRules
 		public string ScatterKey = "x";
 		public string DeployKey = "f";
 		public string StanceCycleKey = "z";
+		public string GuardKey = "d";
 
 		public string CycleTabsKey = "tab";
 	}

--- a/OpenRA.Mods.RA/Guard.cs
+++ b/OpenRA.Mods.RA/Guard.cs
@@ -1,0 +1,98 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.RA.Move;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	class GuardInfo : TraitInfo<Guard>, Requires<MobileInfo> { }
+
+	class Guard : IResolveOrder, IOrderVoice
+	{
+		public void ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString == "Guard")
+			{
+				var target = Target.FromActor(order.TargetActor);
+				self.SetTargetLine(target, Color.Yellow);
+				self.QueueActivity(false, new AttackMove.AttackMoveActivity(self,
+					new Follow(target, target.Actor.Info.Traits.Get<GuardableInfo>().Range)));
+			}
+		}
+
+		public string VoicePhraseForOrder(Actor self, Order order)
+		{
+			return order.OrderString == "Guard" ? "Move" : null;
+		}
+	}
+
+	class GuardOrderGenerator : IOrderGenerator
+	{
+		readonly IEnumerable<Actor> subjects;
+
+		public GuardOrderGenerator(IEnumerable<Actor> subjects)
+		{
+			this.subjects = subjects;
+		}
+
+		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
+		{
+			if (mi.Button == Game.mouseButtonPreference.Cancel)
+			{
+				world.CancelInputMode();
+				yield break;
+			}
+
+			var target = FriendlyGuardableUnitsAtMouse(world, mi).FirstOrDefault();
+
+			if (target == null || subjects.All(s => s.IsDead()))
+				yield break;
+
+			foreach (var actor in subjects)
+				yield return new Order("Guard", actor, false) { TargetActor = target };
+		}
+
+		public void Tick(World world)
+		{
+			if (subjects.All(s => s.IsDead() || !s.HasTrait<Guard>()))
+				world.CancelInputMode();
+		}
+
+		public void RenderBeforeWorld(WorldRenderer wr, World world) { }
+		public void RenderAfterWorld(WorldRenderer wr, World world) { }
+
+		public string GetCursor(World world, CPos xy, MouseInput mi)
+		{
+			return world.Map.IsInMap(xy)
+				&& FriendlyGuardableUnitsAtMouse(world, mi).Any()
+				? "guard"
+				: "move-blocked";
+		}
+
+		static IEnumerable<Actor> FriendlyGuardableUnitsAtMouse(World world, MouseInput mi)
+		{
+			return world.FindUnitsAtMouse(mi.Location)
+				.Where(a => !a.IsDead() && a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && a.HasTrait<Guardable>());
+		}
+	}
+
+	class GuardableInfo : TraitInfo<Guardable>
+	{
+		public readonly int Range = 2;
+	}
+
+	class Guardable { }
+}

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -229,6 +229,7 @@
     <Compile Include="GainsExperience.cs" />
     <Compile Include="GivesBounty.cs" />
     <Compile Include="GivesExperience.cs" />
+    <Compile Include="Guard.cs" />
     <Compile Include="Harvester.cs" />
     <Compile Include="HarvesterHuskModifier.cs" />
     <Compile Include="Husk.cs" />

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -208,6 +208,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			SetupKeyBinding(deployKey, "Deploy:", () => keyConfig.DeployKey, k => keyConfig.DeployKey = k);
 			unitCommandHotkeyList.AddChild(deployKey);
 
+			var guardKey = ScrollItemWidget.Setup(unitCommandHotkeyTemplate, () => false, () => { });
+			SetupKeyBinding(guardKey, "Guard: ", () => keyConfig.GuardKey, k => keyConfig.GuardKey = k);
+			unitCommandHotkeyList.AddChild(guardKey);
+
 			// Debug
 			var debug = bg.Get("DEBUG_PANE");
 

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -70,6 +70,9 @@ namespace OpenRA.Mods.RA.Widgets
 
 				if (e.KeyName == Game.Settings.Keys.StanceCycleKey)
 					return PerformStanceCycle();
+
+				if (e.KeyName == Game.Settings.Keys.GuardKey)
+					return PerformGuard();
 			}
 
 			return false;
@@ -79,12 +82,11 @@ namespace OpenRA.Mods.RA.Widgets
 
 		bool PerformAttackMove()
 		{
-			var actors = World.Selection.Actors
-				.Where(a => a.Owner == World.LocalPlayer).ToArray();
+			var actors = World.Selection.Actors.Where(a => a.Owner == World.LocalPlayer).ToArray();
 
-			if (actors.Length > 0)
-				World.OrderGenerator = new GenericSelectTarget(actors, "AttackMove",
-				                                               "attackmove", Game.mouseButtonPreference.Action);
+			if (actors.Any())
+				World.OrderGenerator = new GenericSelectTarget(actors,
+					"AttackMove", "attackmove", Game.mouseButtonPreference.Action);
 
 			return true;
 		}
@@ -142,6 +144,16 @@ namespace OpenRA.Mods.RA.Widgets
 			});
 
 			Game.Debug( "Unit stance set to: {0}".F(nextStance) );
+
+			return true;
+		}
+
+		bool PerformGuard()
+		{
+			var actors = World.Selection.Actors.Where(a => a.Owner == World.LocalPlayer && a.HasTrait<Guard>());
+
+			if (actors.Any())
+				World.OrderGenerator = new GuardOrderGenerator(actors);
 
 			return true;
 		}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -31,6 +31,8 @@
 	AcceptsCloakCrate:
 	WithSmoke:
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Tank:
 	AppearsOnRadar:
@@ -68,6 +70,8 @@
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Helicopter:
 	AppearsOnRadar:
@@ -145,6 +149,8 @@
 		Buildings: hosp
 		CloseEnough: 1
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -176,7 +182,7 @@
 		Notification: CivilianKilled
 		NotifyAll: true
 	ScaredyCat:
-	RenderInfantryPanic:	
+	RenderInfantryPanic:
 	AttackMove:
 		JustMove: yes
 	CrushableInfantry:
@@ -214,6 +220,8 @@
 	ActorLostNotification:
 	AttackMove:
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Building:
 	AppearsOnRadar:
@@ -260,6 +268,8 @@
 	Capturable:
 	CapturableBar:
 	DebugMuzzlePositions:
+	Guardable:
+		Range: 3
 
 ^CivBuilding:
 	Inherits: ^Building
@@ -347,6 +357,7 @@
 		RelativeToTopLeft: yes
 	AutoTargetIgnore:
 	Sellable:
+	Guardable:
 
 ^Tree:
 	Tooltip:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -31,6 +31,8 @@
 	Repairable:
 		RepairBuildings: repair
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Tank:
 	AppearsOnRadar:
@@ -65,6 +67,8 @@
 	Repairable:
 		RepairBuildings: repair
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Husk:
 	Health:
@@ -145,6 +149,8 @@
 		Buildings: barra, barro
 		CloseEnough: 1
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Plane:
 	AppearsOnRadar:
@@ -200,7 +206,6 @@
 		ActorTypes: rifle,rifle,rifle,rifle,rifle,bazooka,bazooka,bazooka,engineer
 	MustBeDestroyed:
 	GivesExperience:
-
 	FrozenUnderFog:
 	CaptureNotification:
 	ActorLostNotification:
@@ -215,3 +220,5 @@
 	GivesBounty:
 	DebugMuzzlePositions:
 	Bib:
+	Guardable:
+		Range: 3

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -371,6 +371,7 @@ WALL:
 	ProximityCaptor:
 		Types:Wall
 	Sellable:
+	Guardable:
 
 GUNTOWER:
 	Inherits: ^Building

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -34,6 +34,8 @@
 	WithSmoke:
 	UpdatesPlayerStatistics:
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Tank:
 	AppearsOnRadar:
@@ -71,6 +73,8 @@
 	WithSmoke:
 	UpdatesPlayerStatistics:
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -122,6 +126,8 @@
 		CloseEnough: 1
 	UpdatesPlayerStatistics:
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Ship:
 	AppearsOnRadar:
@@ -151,6 +157,8 @@
 	WithSmoke:
 	UpdatesPlayerStatistics:
 	DebugMuzzlePositions:
+	Guard:
+	Guardable:
 
 ^Plane:
 	AppearsOnRadar:
@@ -224,6 +232,8 @@
 	GivesBounty:
 	UpdatesPlayerStatistics:
 	DebugMuzzlePositions:
+	Guardable:
+		Range: 3
 
 ^Wall:
 	AppearsOnRadar:
@@ -257,6 +267,7 @@
 		Types:Wall
 	Sellable:
 	UpdatesPlayerStatistics:
+	Guardable:
 
 ^TechBuilding:
 	Inherits: ^Building


### PR DESCRIPTION
Select a unit and then alt+click on another friendly unit to follow it. Includes a bunch of noise which adds a 'forceAlternate' field which indicates whether the alt key is pressed, for doing alt(ernative) order targeter things like guarding instead of moving.
