### PR TITLE
Fixed a desync when the bot controlling client left a dedicated server

### DIFF
--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -690,6 +690,7 @@ namespace OpenRA.Mods.RA.AI
 		public Player p;
 		public XRandom random;
 		public CPos baseCenter;
+		int controllerId;
 		PowerManager playerPower;
 		SupportPowerManager supportPowerMngr;
 		PlayerResources playerResource;
@@ -727,6 +728,7 @@ namespace OpenRA.Mods.RA.AI
 		{
 			this.p = p;
 			enabled = true;
+			controllerId = p.ClientIndex;
 			playerPower = p.PlayerActor.Trait<PowerManager>();
 			supportPowerMngr = p.PlayerActor.Trait<SupportPowerManager>();
 			playerResource = p.PlayerActor.Trait<PlayerResources>();
@@ -963,6 +965,12 @@ namespace OpenRA.Mods.RA.AI
 		{
 			if (!enabled)
 				return;
+
+			if (world.LobbyInfo.ClientWithIndex(controllerId) == null)
+			{
+				enabled = false;
+				return;
+			}
 
 			ticks++;
 


### PR DESCRIPTION
See #3228

While I drop all bots in the lobby when the admin leaves for #2957 I did not think about the problems it could cause in-game when the bot controller leaves the game.
