### PR TITLE
Fixes #3216 zombie aircraft staying in the air

### DIFF
--- a/OpenRA.Mods.RA/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.RA/Air/ReturnOnIdle.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -23,6 +23,8 @@ namespace OpenRA.Mods.RA.Air
 	{
 		public void TickIdle(Actor self)
 		{
+			if (self.IsDead()) return;
+
 			var altitude = self.Trait<Aircraft>().Altitude;
 			if (altitude == 0) return;	// we're on the ground, let's stay there.
 


### PR DESCRIPTION
I think `ReturnOnIdle` was busted because this never happened with helicopters. Tested this with lot's of planes on Ice Woods against creep anti-air.
