### PR TITLE
Removed inconstencies in alliance checks

### DIFF
--- a/OpenRA.Mods.RA/Activities/Sell.cs
+++ b/OpenRA.Mods.RA/Activities/Sell.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Activities
 			foreach (var ns in self.TraitsImplementing<INotifySold>())
 				ns.Sold(self);
 
-			if (refund > 0 && self.World.LocalPlayer != null && self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)
+			if (refund > 0 && self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				self.World.AddFrameEndTask(w => w.Add(new CashTick(refund, 30, 2, self.CenterLocation, self.Owner.Color.RGB)));
 
 			self.Destroy();
@@ -39,6 +39,6 @@ namespace OpenRA.Mods.RA.Activities
 		}
 
 		// Cannot be cancelled
-		public override void Cancel( Actor self ) { }
+		public override void Cancel(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.RA/Effects/CashTick.cs
+++ b/OpenRA.Mods.RA/Effects/CashTick.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Effects
 		static string FormatCashAmount(int x) { return "{0}${1}".F(x < 0 ? "-" : "+", x); }
 
 		public CashTick(int value, int lifetime, int velocity, PPos pos, Color color)
-			: this( FormatCashAmount(value), lifetime, velocity, pos, color ) { }
+			: this(FormatCashAmount(value), lifetime, velocity, pos, color) { }
 
 		public CashTick(string value, int lifetime, int velocity, PPos pos, Color color)
 		{

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -45,8 +45,6 @@ namespace OpenRA.Mods.RA.Effects
 			anim.PlayRepeating(info.String);
 
 			self.World.AddFrameEndTask(w => w.Add(this));
-			if (self.World.LocalPlayer != null)
-				watcher = self.World.LocalPlayer.PlayerActor.Trait<GpsWatcher>();
 		}
 
 		bool firstTick = true;
@@ -55,7 +53,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (self.Destroyed)
 				world.AddFrameEndTask(w => w.Remove(this));
 
-			if (world.LocalPlayer == null || !self.IsInWorld || self.Destroyed)
+			if (!self.IsInWorld || self.Destroyed)
 				return;
 
 			// Can be granted at runtime via a crate, so can't cache
@@ -67,6 +65,10 @@ namespace OpenRA.Mods.RA.Effects
 				spy = self.TraitOrDefault<Spy>();
 				firstTick = false;
 			}
+
+			// Can change with the Shroud selector for observers so don't cache.
+			if (self.World.RenderPlayer != null)
+				watcher = self.World.RenderPlayer.PlayerActor.Trait<GpsWatcher>();
 
 			var hasGps = (watcher != null && (watcher.Granted || watcher.GrantedAllies));
 			var hasDot = (huf != null && !huf.IsVisible(self, self.World.RenderPlayer));
@@ -84,7 +86,6 @@ namespace OpenRA.Mods.RA.Effects
 			var palette = wr.Palette(info.IndicatorPalettePrefix+self.Owner.InternalName);
 			yield return new Renderable(anim.Image, p.ToFloat2() - 0.5f * anim.Image.size, palette, p.Y)
 				.WithScale(1.5f);
-
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/PowerdownIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/PowerdownIndicator.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<Renderable> Render(WorldRenderer wr)
 		{
-			if (!a.Destroyed && (a.World.LocalPlayer == null || a.Owner.Stances[a.Owner.World.LocalPlayer] == Stance.Ally))
+			if (!a.Destroyed && a.Owner.IsAlliedWith(a.World.RenderPlayer))
 				yield return new Renderable(anim.Image,	a.CenterLocation.ToFloat2() - .5f * anim.Image.size,
 					wr.Palette("chrome"), (int)a.CenterLocation.Y);
 		}

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.RA
 		public IEnumerable<Renderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<Renderable> r)
 		{
 			// TODO: Make this consistent with everything else that adds animations to RenderSimple.
-			if ((self.Owner == self.World.LocalPlayer || self.World.LocalPlayer == null) && Level > 0)
+			if (self.Owner.IsAlliedWith(self.World.RenderPlayer) && Level > 0)
 				return InnerModifyRender(self, wr, r);
 			else
 				return r;

--- a/OpenRA.Mods.RA/GivesBounty.cs
+++ b/OpenRA.Mods.RA/GivesBounty.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.RA
 			// 2 hundreds because of GetMultiplier and info.Percentage.
 			var bounty = cost * GetMultiplier(self) * info.Percentage / 10000;
 
-			if (bounty > 0 && e.Attacker.World.LocalPlayer != null && e.Attacker.Owner.Stances[e.Attacker.World.LocalPlayer] == Stance.Ally)
+			if (bounty > 0 && e.Attacker.Owner.IsAlliedWith(self.World.RenderPlayer))
 				e.Attacker.World.AddFrameEndTask(w => w.Add(new CashTick(bounty, 20, 1, self.CenterLocation, e.Attacker.Owner.Color.RGB)));
 
 			e.Attacker.Owner.PlayerActor.Trait<PlayerResources>().GiveCash(bounty);

--- a/OpenRA.Mods.RA/OreRefinery.cs
+++ b/OpenRA.Mods.RA/OreRefinery.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.RA
 			if (Info.ShowTicks && currentDisplayValue > 0 && --currentDisplayTick <= 0)
 			{
 				var temp = currentDisplayValue;
-				if (self.World.LocalPlayer != null && self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)
+				if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
 					self.World.AddFrameEndTask(w => w.Add(new CashTick(temp, Info.TickLifetime, Info.TickVelocity, self.CenterLocation, self.Owner.Color.RGB)));
 				currentDisplayTick = Info.TickRate;
 				currentDisplayValue = 0;

--- a/OpenRA.Mods.RA/Spy.cs
+++ b/OpenRA.Mods.RA/Spy.cs
@@ -115,8 +115,7 @@ namespace OpenRA.Mods.RA
 
 		public Color RadarColorOverride(Actor self)
 		{
-			if (!Disguised || self.World.LocalPlayer == null ||
-				self.Owner.Stances[self.World.LocalPlayer] == Stance.Ally)
+			if (!Disguised || self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				return self.Owner.Color.RGB;
 
 			return disguisedAsPlayer.Color.RGB;

--- a/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA
 
 		List<Actor> actors = new List<Actor> { };
 
-		public GpsWatcher( Player owner ) { this.owner = owner; }
+		public GpsWatcher(Player owner) { this.owner = owner; }
 
 		public void GpsRem(Actor atek)
 		{
@@ -62,16 +62,15 @@ namespace OpenRA.Mods.RA
 			foreach (TraitPair<GpsWatcher> i in atek.World.ActorsWithTrait<GpsWatcher>())
 				i.Trait.RefreshGranted();
 
-			if ((Granted || GrantedAllies) && atek.World.LocalPlayer != null && (atek.World.LocalPlayer.Stances[atek.Owner] == Stance.Ally))
+			if ((Granted || GrantedAllies) && atek.Owner.IsAlliedWith(atek.World.RenderPlayer))
 				atek.Owner.Shroud.ExploreAll(atek.World);
 		}
 
 		void RefreshGranted()
 		{
 			Granted = (actors.Count > 0 && Launched);
-			GrantedAllies = owner.World.ActorsWithTrait<GpsWatcher>().Any(p =>
-					p.Actor.Owner.Stances[owner] == Stance.Ally && p.Trait.Granted);
-					
+			GrantedAllies = owner.World.ActorsWithTrait<GpsWatcher>().Any(p => p.Actor.Owner.IsAlliedWith(owner) && p.Trait.Granted);
+
 			if (Granted || GrantedAllies)
 				owner.Shroud.ExploreAll(owner.World);
 		}

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerChargeBar.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA
 		public float GetValue()
 		{
 			// only people we like should see our charge status.
-			if (self.World.LocalPlayer != null && self.Owner.Stances[self.World.LocalPlayer] != Stance.Ally)
+			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				return 0;
 
 			var spm = self.Owner.PlayerActor.Trait<SupportPowerManager>();

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -229,6 +229,7 @@ World:
 		Name: effect
 		Filename: temperat.pal
 		ShadowIndex: 4
+		AllowModifiers: false
 	PaletteFromFile@colorpicker:
 		Name: colorpicker
 		Filename: temperat.pal


### PR DESCRIPTION
introduced by incomplete per-player shroud migration / observer detection hacks for
- various cash ticks (donate, bounty, ...)
- GPS dots #3181
- unit ranks
- support power charge bars #3178
- power down indicator
- spy disguise radar color override

which fixes various small bugs attached to it.
