### PR TITLE
Added OpenAL and SDL Windows dependency DLLs to mirrors

### DIFF
--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -160,17 +160,14 @@ SectionGroupEnd
 ;***************************
 Section "-OpenAl" OpenAl
 	AddSize 768
+	SetOutPath "$TEMP"
 	ClearErrors
 	${GetFileVersion} $SYSDIR\OpenAL32.dll $0
 	IfErrors installal 0
 	${VersionCompare} $0 "6.14.357.24" $1
 	IntCmp $1 1 done done installal
 	installal:
-		SetOutPath "$TEMP"
-		NSISdl::download http://connect.creativelabs.com/openal/Downloads/oalinst.zip oalinst.zip
-		Pop $R0
-		StrCmp $R0 "success" +2
-			Abort
+		!insertmacro DownloadDependency "openal" "oalinst.zip"
 		!insertmacro ZIPDLL_EXTRACT oalinst.zip OpenAL oalinst.exe
 		ExecWait "$TEMP\OpenAL\oalinst.exe"
 	done:
@@ -178,10 +175,10 @@ SectionEnd
 
 Section "-Sdl" SDL
 	AddSize 317
+	SetOutPath "$TEMP"
 	IfFileExists $INSTDIR\SDL.dll done installsdl
 	installsdl:
-		SetOutPath "$TEMP"
-		NSISdl::download http://www.libsdl.org/release/SDL-1.2.14-win32.zip sdl.zip
+		!insertmacro DownloadDependency "sdl" "sdl.zip"
 		!insertmacro ZIPDLL_EXTRACT sdl.zip $INSTDIR SDL.dll
 	done:
 SectionEnd


### PR DESCRIPTION
This fixes https://github.com/OpenRA/OpenRA/wiki/FAQ#the-downloads-during-windows-installation-and-first-game-start-dont-work as it is a common annoyance that the SDL/OpenAL webserver went down when somebody tried to run the OpenRA Setup.exe only this time it happened during the first minutes after the stable release announcement when I tried to prepare the patch for Desura which required a clean install so I noticed when a file got removed in my proposed patch there and could help people immediately. http://www.libsdl.org/ was online again after a short while so this is not urgent.
