### PR TITLE
adding ImpactSounds to many weapons + other changes

### DIFF
--- a/mods/ra/sequences.yaml
+++ b/mods/ra/sequences.yaml
@@ -1003,6 +1003,9 @@ explosion:
 	self_destruct: art-exp1
 		Start: 0
 		Length: *
+	artillery_explosion: art-exp1
+		Start: 0
+		Length: *
 	building: fball1
 		Start: 0
 		Length: *

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -132,7 +132,8 @@ Maverick:
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
-		Explosion: med_explosion
+		Explosion: large_explosion
+		ImpactSound: kaboom15
 		WaterExplosion: med_splash
 		InfDeath: 4
 		SmudgeType: Crater
@@ -273,7 +274,7 @@ Dragon:
 		High: true
 		Shadow: false
 		Proximity: true
-		Trail: smokey
+#		Trail: smokey
 		ContrailLength: 10
 		Inaccuracy: 3
 		Image: DRAGON
@@ -324,6 +325,7 @@ HellfireAG:
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 40
+		ImpactSound: kaboom12
 
 HellfireAA:
 	ROF: 60
@@ -420,6 +422,7 @@ Grenade:
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 40
+		ImpactSound: kaboom12
 
 105mm:
 	ROF: 70
@@ -442,6 +445,7 @@ Grenade:
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 40
+		ImpactSound: kaboom12
 
 120mm:
 	ROF: 90
@@ -463,6 +467,7 @@ Grenade:
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 60
+		ImpactSound: kaboom12
 
 TurretGun:
 	ROF: 30
@@ -483,6 +488,7 @@ TurretGun:
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 60
+		ImpactSound: kaboom12
 
 MammothTusk:
 	ROF: 60
@@ -514,6 +520,7 @@ MammothTusk:
 		InfDeath: 3
 		SmudgeType: Crater
 		Damage: 45
+		ImpactSound: kaboom15
 
 155mm:
 	ROF: 85
@@ -535,11 +542,12 @@ MammothTusk:
 			Light: 60%
 			Heavy: 25%
 			Concrete: 50%
-		Explosion: large_explosion
+		Explosion: artillery_explosion
 		WaterExplosion: med_splash
 		InfDeath: 3
 		SmudgeType: Crater
 		Damage: 220
+		ImpactSound: kaboom22
 
 M60mg:
 	ROF: 30
@@ -731,12 +739,12 @@ RedEye:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: large_explosion
+		Explosion: artillery_explosion
 		WaterExplosion: large_splash
 		InfDeath: 3
 		SmudgeType: Crater
 		Damage: 250
-		ImpactSound: kaboom12
+		ImpactSound: kaboom22
 		WaterImpactSound: splash9
 
 SubMissile:
@@ -759,12 +767,12 @@ SubMissile:
 			None: 40%
 			Light: 30%
 			Heavy: 30%
-		Explosion: large_explosion
+		Explosion: artillery_explosion
 		WaterExplosion: large_splash
 		InfDeath: 3
 		SmudgeType: Crater
 		Damage: 300
-		ImpactSound: kaboom12
+		ImpactSound: kaboom22
 		WaterImpactSound: splash9
 
 Stinger:
@@ -798,6 +806,7 @@ Stinger:
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 30
+		ImpactSound: kaboom12
 
 TorpTube:
 	ROF: 100
@@ -1245,7 +1254,7 @@ ChronoTusk:
 		High: true
 		Shadow: false
 		Proximity: true
-		Trail: smokey
+#		Trail: smokey
 		ContrailLength: 10
 		Inaccuracy: 3
 		Image: DRAGON
@@ -1263,3 +1272,4 @@ ChronoTusk:
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 30
+		ImpactSound: kaboom12


### PR DESCRIPTION
When I recently watched the new desert shellmap, I felt something was missing somehow. I soon realised there where sounds of guns firing and missiles launching, but barely any noticable explosion sounds. Not surprising, considering most weapons had no ImpactSound defined at all.
In addition, I felt not just the impact sound, but also the explosion animation of artillery and cruiser grenades was too unimpressive.

With these changes, most weapons using visible projectiles gain an impact sound, while artillery shells use the larger art-exp1 and use kaboom22 as impact sound.
