### PR TITLE
LaserZap improvements rev.2

### DIFF
--- a/OpenRA.Mods.RA/Effects/LaserZap.cs
+++ b/OpenRA.Mods.RA/Effects/LaserZap.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA.Effects
 	[Desc("Not a sprite, but an engine effect.")]
 	class LaserZapInfo : IProjectileInfo
 	{
-		public readonly int BeamRadius = 1;
+		public readonly int BeamWidth = 2;
 		public readonly int BeamDuration = 10;
 		public readonly bool UsePlayerColor = false;
 		public readonly Color Color = Color.Red;
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.RA.Effects
 			var src = new PPos(args.src.X, args.src.Y - args.srcAltitude);
 			var dest = new PPos(args.dest.X, args.dest.Y - args.destAltitude);
 			var wlr = Game.Renderer.WorldLineRenderer;
-			wlr.LineWidth = info.BeamRadius * 2;
+			wlr.LineWidth = info.BeamWidth;
 			wlr.DrawLine(src.ToFloat2(), dest.ToFloat2(), rc, rc);
 			wlr.Flush();
 			wlr.LineWidth = 1f;

--- a/OpenRA.Mods.RA/Effects/LaserZap.cs
+++ b/OpenRA.Mods.RA/Effects/LaserZap.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Effects
 		public readonly int BeamDuration = 10;
 		public readonly bool UsePlayerColor = false;
 		public readonly Color Color = Color.Red;
-		public readonly string Explosion = "laserfire";
+		public readonly string HitAnim = null;
 
 		public IEffect Create(ProjectileArgs args)
 		{
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Effects
 		int ticks = 0;
 		Color color;
 		bool doneDamage;
-		Animation explosion;
+		Animation hitanim;
 
 		public LaserZap(ProjectileArgs args, LaserZapInfo info, Color color)
 		{
@@ -49,8 +49,8 @@ namespace OpenRA.Mods.RA.Effects
 			this.info = info;
 			this.color = color;
 
-			if (info.Explosion != null)
-				this.explosion = new Animation(info.Explosion);
+			if (info.HitAnim != null)
+				this.hitanim = new Animation(info.HitAnim);
 		}
 
 		public void Tick(World world)
@@ -61,16 +61,16 @@ namespace OpenRA.Mods.RA.Effects
 
 			if (!doneDamage)
 			{
-				if (explosion != null)
-					explosion.PlayThen("idle",
+				if (hitanim != null)
+					hitanim.PlayThen("idle",
 						() => world.AddFrameEndTask(w => w.Remove(this)));
 				Combat.DoImpacts(args);
 				doneDamage = true;
 			}
 			++ticks;
 
-			if (explosion != null)
-				explosion.Tick();
+			if (hitanim != null)
+				hitanim.Tick();
 			else
 				if (ticks >= info.BeamDuration)
 					world.AddFrameEndTask(w => w.Remove(this));
@@ -78,8 +78,8 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (explosion != null)
-				yield return new SpriteRenderable(explosion.Image, args.dest.ToFloat2(),
+			if (hitanim != null)
+				yield return new SpriteRenderable(hitanim.Image, args.dest.ToFloat2(),
 				                                  wr.Palette("effect"), (int)args.dest.Y);
 
 			if (ticks >= info.BeamDuration)

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -761,6 +761,7 @@ Laser:
 	Report: OBELRAY1
 	Projectile: LaserZap
 		BeamWidth: 2
+		HitAnim: laserfire
 	Warhead:
 		Spread: 1
 		Versus:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -760,7 +760,7 @@ Laser:
 	Charges: true
 	Report: OBELRAY1
 	Projectile: LaserZap
-		BeamRadius: 1
+		BeamWidth: 2
 	Warhead:
 		Spread: 1
 		Versus:


### PR DESCRIPTION
-LaserZap Explosion trait renamed to HitAnim
-HitAnim defaults to null instead of laserfire
-BeamRadius replaced with BeamWidth
