### PR TITLE
Fixes #2216 InstallShield .Z package decompression

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ The OpenRA developers are:
 Also thanks to:
 	* Akseli Virtanen       (RAGEQUIT)
 	* Andrew Riedi
+	* Andreas Beck		(baxtor)
 	* Barnaby Smith		(mvi)
 	* Bellator
 	* Bugra Cuhadaroglu (BugraC)


### PR DESCRIPTION
Reverse engineered pascal code from "STIX", adjusted only a few line of code.
The blast implementation of OpenRA works perfectly with it.
Filename hashing should be removed 'cause of duplicate filenames in nested folders.
