### PR TITLE
Renderer refactoring - Traits

### DIFF
--- a/OpenRA.Editor/RenderUtils.cs
+++ b/OpenRA.Editor/RenderUtils.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Editor
 
 		public static ActorTemplate RenderActor(ActorInfo info, TileSet tileset, Palette p)
 		{
-			var image = RenderSimple.GetImage(info);
+			var image = RenderSprites.GetImage(info);
 
 			using (var s = FileSystem.OpenWithExts(image, tileset.Extensions))
 			{

--- a/OpenRA.Game/Graphics/Renderable.cs
+++ b/OpenRA.Game/Graphics/Renderable.cs
@@ -41,7 +41,6 @@ namespace OpenRA.Graphics
 		IRenderable WithZOffset(int newOffset);
 		IRenderable WithPos(WPos pos);
 		void Render(WorldRenderer wr);
-		WVec Size(WorldRenderer wr);
 	}
 
 	public struct SpriteRenderable : IRenderable
@@ -83,12 +82,6 @@ namespace OpenRA.Graphics
 		public void Render(WorldRenderer wr)
 		{
 			sprite.DrawAt(wr.ScreenPxPosition(pos) - pxCenter, palette.Index, scale);
-		}
-
-		public WVec Size(WorldRenderer wr)
-		{
-			var size = (scale*sprite.size).ToInt2();
-			return new WVec(size.X, size.Y, size.Y);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Sequence.cs
+++ b/OpenRA.Game/Graphics/Sequence.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Graphics
 	{
 		readonly Sprite[] sprites;
 		readonly int start, length, stride, facings, tick;
+		readonly bool reverseFacings, transpose;
 
 		public readonly string Name;
 		public int Start { get { return start; } }
@@ -49,15 +50,22 @@ namespace OpenRA.Graphics
 			else
 				stride = length;
 
-			if(d.ContainsKey("Facings"))
-				facings = int.Parse(d["Facings"].Value);
+			if (d.ContainsKey("Facings"))
+			{
+				var f = int.Parse(d["Facings"].Value);
+				facings = Math.Abs(f);
+				reverseFacings = f < 0;
+			}
 			else
 				facings = 1;
 
-			if(d.ContainsKey("Tick"))
+			if (d.ContainsKey("Tick"))
 				tick = int.Parse(d["Tick"].Value);
 			else
 				tick = 40;
+
+			if (d.ContainsKey("Transpose"))
+			    transpose = bool.Parse(d["Transpose"].Value);
 
 			if (length > stride)
 				throw new InvalidOperationException(
@@ -71,15 +79,22 @@ namespace OpenRA.Graphics
 					info.Nodes[0].Location));
 		}
 
-		public Sprite GetSprite( int frame )
+		public Sprite GetSprite(int frame)
 		{
-			return GetSprite( frame, 0 );
+			return GetSprite(frame, 0);
 		}
 
 		public Sprite GetSprite(int frame, int facing)
 		{
-			var f = Traits.Util.QuantizeFacing( facing, facings );
-			return sprites[ (f * stride) + ( frame % length ) + start ];
+			var f = Traits.Util.QuantizeFacing(facing, facings);
+
+			if (reverseFacings)
+				f = (facings - f) % facings;
+
+			int i = transpose ? (frame % length) * facings + f :
+				(f * stride) + (frame % length);
+
+			return sprites[start + i];
 		}
 	}
 }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Network\UPnP.cs" />
     <Compile Include="Widgets\ClientTooltipRegionWidget.cs" />
     <Compile Include="Graphics\Renderable.cs" />
+    <Compile Include="Traits\Render\RenderSprites.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Widgets\ClientTooltipRegionWidget.cs" />
     <Compile Include="Graphics\Renderable.cs" />
     <Compile Include="Traits\Render\RenderSprites.cs" />
+    <Compile Include="Traits\BodyOrientation.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Game/Traits/BodyOrientation.cs
+++ b/OpenRA.Game/Traits/BodyOrientation.cs
@@ -1,0 +1,58 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.FileFormats;
+
+namespace OpenRA.Traits
+{
+	public class BodyOrientationInfo : ITraitInfo, IBodyOrientationInfo
+	{
+		[Desc("Camera pitch for rotation calculations")]
+		public readonly WAngle CameraPitch = WAngle.FromDegrees(40);
+		public object Create(ActorInitializer init) { return new BodyOrientation(init.self, this); }
+	}
+
+	public class BodyOrientation : IBodyOrientation
+	{
+		[Sync] public int QuantizedFacings { get; set; }
+		BodyOrientationInfo Info;
+
+		public BodyOrientation(Actor self, BodyOrientationInfo info)
+		{
+			Info = info;
+		}
+
+		public WAngle CameraPitch { get { return Info.CameraPitch; } }
+
+		public WVec LocalToWorld(WVec vec)
+		{
+			// RA's 2d perspective doesn't correspond to an orthonormal 3D
+			// coordinate system, so fudge the y axis to make things look good
+			return new WVec(vec.Y, -Info.CameraPitch.Sin()*vec.X/1024, vec.Z);
+		}
+
+		public WRot QuantizeOrientation(Actor self, WRot orientation)
+		{
+			// Quantization disabled
+			if (QuantizedFacings == 0)
+				return orientation;
+
+			// Map yaw to the closest facing
+			var facing = Util.QuantizeFacing(orientation.Yaw.Angle / 4, QuantizedFacings) * (256 / QuantizedFacings);
+
+			// Roll and pitch are always zero if yaw is quantized
+			return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing));
+		}
+	}
+}

--- a/OpenRA.Game/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Game/Traits/Render/RenderSimple.cs
@@ -16,7 +16,7 @@ using OpenRA.FileFormats;
 
 namespace OpenRA.Traits
 {
-	public class RenderSimpleInfo : RenderSpritesInfo, LocalCoordinatesModelInfo
+	public class RenderSimpleInfo : RenderSpritesInfo, IBodyOrientationInfo
 	{
 		[Desc("Number of facings for gameplay calculations. -1 indiciates auto-detection from sequence")]
 		public readonly int QuantizedFacings = -1;
@@ -34,7 +34,7 @@ namespace OpenRA.Traits
 		}
 	}
 
-	public class RenderSimple : RenderSprites, ILocalCoordinatesModel, IAutoSelectionSize
+	public class RenderSimple : RenderSprites, IBodyOrientation, IAutoSelectionSize
 	{
 		RenderSimpleInfo Info;
 

--- a/OpenRA.Game/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Game/Traits/Render/RenderSimple.cs
@@ -16,23 +16,14 @@ using OpenRA.FileFormats;
 
 namespace OpenRA.Traits
 {
-	public class RenderSimpleInfo : ITraitInfo, LocalCoordinatesModelInfo
+	public class RenderSimpleInfo : RenderSpritesInfo, LocalCoordinatesModelInfo
 	{
-		[Desc("Defaults to the actor name.")]
-		public readonly string Image = null;
-		[Desc("custom palette name")]
-		public readonly string Palette = null;
-		[Desc("custom PlayerColorPalette: BaseName")]
-		public readonly string PlayerPalette = "player";
-		[Desc("Change the sprite image size.")]
-		public readonly float Scale = 1f;
-
 		[Desc("Number of facings for gameplay calculations. -1 indiciates auto-detection from sequence")]
 		public readonly int QuantizedFacings = -1;
 
 		[Desc("Camera pitch the sprite was rendered with. Used to determine rotation ellipses")]
 		public readonly WAngle CameraPitch = WAngle.FromDegrees(40);
-		public virtual object Create(ActorInitializer init) { return new RenderSimple(init.self); }
+		public override object Create(ActorInitializer init) { return new RenderSimple(init.self); }
 
 		public virtual IEnumerable<IRenderable> RenderPreview(ActorInfo ai, PaletteReference pr)
 		{
@@ -43,73 +34,21 @@ namespace OpenRA.Traits
 		}
 	}
 
-	public class RenderSimple : IRender, ILocalCoordinatesModel, IAutoSelectionSize, ITick, INotifyOwnerChanged
+	public class RenderSimple : RenderSprites, ILocalCoordinatesModel, IAutoSelectionSize
 	{
-		public Dictionary<string, AnimationWithOffset> anims = new Dictionary<string, AnimationWithOffset>();
-
-		public static Func<int> MakeFacingFunc(Actor self)
-		{
-			var facing = self.TraitOrDefault<IFacing>();
-			if (facing == null) return () => 0;
-			return () => facing.Facing;
-		}
-
-		public Animation anim
-		{
-			get { return anims[""].Animation; }
-			protected set { anims[""] = new AnimationWithOffset(value,
-				anims[""].OffsetFunc, anims[""].DisableFunc, anims[""].ZOffset); }
-		}
-
-		public static string GetImage(ActorInfo actor)
-		{
-			var Info = actor.Traits.Get<RenderSimpleInfo>();
-			return Info.Image ?? actor.Name;
-		}
-
-		public string GetImage(Actor self)
-		{
-			if (cachedImage != null)
-				return cachedImage;
-
-			return cachedImage = GetImage(self.Info);
-		}
-
 		RenderSimpleInfo Info;
-		string cachedImage = null;
-		bool initializePalette = true;
-		protected PaletteReference palette;
 
 		public RenderSimple(Actor self, Func<int> baseFacing)
+			: base(self, baseFacing)
 		{
 			anims.Add("", new Animation(GetImage(self), baseFacing));
 			Info = self.Info.Traits.Get<RenderSimpleInfo>();
 		}
 
-		public RenderSimple(Actor self) : this( self, MakeFacingFunc(self) )
+		public RenderSimple(Actor self)
+			: this(self, MakeFacingFunc(self))
 		{
 			anim.PlayRepeating("idle");
-		}
-
-		protected virtual string PaletteName(Actor self)
-		{
-			return Info.Palette ?? Info.PlayerPalette + self.Owner.InternalName;
-		}
-
-		protected void UpdatePalette() { initializePalette = true; }
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) { UpdatePalette(); }
-
-		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
-		{
-			if (initializePalette)
-			{
-				palette = wr.Palette(PaletteName(self));
-				initializePalette = false;
-			}
-
-			foreach (var a in anims.Values)
-				if (a.DisableFunc == null || !a.DisableFunc())
-					yield return a.Image(self, wr, palette, Info.Scale);
 		}
 
 		public int2 SelectionSize(Actor self)
@@ -118,12 +57,6 @@ namespace OpenRA.Traits
 			                                && b.Animation.CurrentSequence != null)
 				.Select(a => (a.Animation.Image.size*Info.Scale).ToInt2())
 				.FirstOrDefault();
-		}
-
-		public virtual void Tick(Actor self)
-		{
-			foreach (var a in anims.Values)
-				a.Animation.Tick();
 		}
 
 		protected virtual string NormalizeSequence(Actor self, string baseSequence)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -187,12 +187,12 @@ namespace OpenRA.Traits
 	public interface IPostRenderSelection { void RenderAfterWorld(WorldRenderer wr); }
 	public interface IPreRenderSelection { void RenderBeforeWorld(WorldRenderer wr, Actor self); }
 	public interface IRenderAsTerrain { IEnumerable<IRenderable> RenderAsTerrain(WorldRenderer wr, Actor self); }
-	public interface ILocalCoordinatesModel
+	public interface IBodyOrientation
 	{
 		WVec LocalToWorld(WVec vec);
 		WRot QuantizeOrientation(Actor self, WRot orientation);
 	}
-	public interface LocalCoordinatesModelInfo {}
+	public interface IBodyOrientationInfo {}
 
 	public interface ITargetable
 	{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -189,6 +189,8 @@ namespace OpenRA.Traits
 	public interface IRenderAsTerrain { IEnumerable<IRenderable> RenderAsTerrain(WorldRenderer wr, Actor self); }
 	public interface IBodyOrientation
 	{
+		WAngle CameraPitch { get; }
+		int QuantizedFacings { get; set; }
 		WVec LocalToWorld(WVec vec);
 		WRot QuantizeOrientation(Actor self, WRot orientation);
 	}

--- a/OpenRA.Mods.Cnc/RenderGunboat.cs
+++ b/OpenRA.Mods.Cnc/RenderGunboat.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	class RenderGunboatInfo : RenderUnitInfo
+	class RenderGunboatInfo : RenderSimpleInfo
 	{
 		public override object Create(ActorInitializer init) { return new RenderGunboat(init.self); }
 	}
@@ -26,8 +26,13 @@ namespace OpenRA.Mods.RA.Render
 		string lastDir = "left";
 		string lastDamage = "";
 
+		static Func<int> TurretFacingFunc(Actor self)
+		{
+			return () => self.HasTrait<Turreted>() ? self.TraitsImplementing<Turreted>().First().turretFacing : 0;
+		}
+
 		public RenderGunboat(Actor self)
-			: base(self, () => self.HasTrait<Turreted>() ? self.TraitsImplementing<Turreted>().First().turretFacing : 0)
+			: base(self, TurretFacingFunc(self))
 		{
 			facing = self.Trait<IFacing>();
 			anim.Play("left");

--- a/OpenRA.Mods.Cnc/RenderGunboat.cs
+++ b/OpenRA.Mods.Cnc/RenderGunboat.cs
@@ -45,6 +45,8 @@ namespace OpenRA.Mods.RA.Render
 			anims.Add("wake", new AnimationWithOffset(wake,
 				() => anims["wake"].Animation.CurrentSequence.Name == "left-wake" ? leftOffset : rightOffset,
 			    () => false, -87));
+
+			self.Trait<IBodyOrientation>().QuantizedFacings = anim.CurrentSequence.Facings;
 		}
 
 		public override void Tick(Actor self)

--- a/OpenRA.Mods.Cnc/WithFire.cs
+++ b/OpenRA.Mods.Cnc/WithFire.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc
 {
-	class WithFireInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	class WithFireInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
 		public readonly WVec Offset = new WVec(299,-640,0);
 
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Cnc
 	{
 		public WithFire(Actor self, WithFireInfo info)
 		{
-			var rs = self.Trait<RenderSimple>();
+			var rs = self.Trait<RenderSprites>();
 			var roof = new Animation(rs.GetImage(self));
 			roof.PlayThen("fire-start", () => roof.PlayRepeating("fire-loop"));
 

--- a/OpenRA.Mods.Cnc/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/WithRoof.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc
 {
-	public class WithRoofInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	public class WithRoofInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
 		public object Create(ActorInitializer init) { return new WithRoof(init.self); }
 	}
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc
 	{
 		public WithRoof(Actor self)
 		{
-			var rs = self.Trait<RenderSimple>();
+			var rs = self.Trait<RenderSprites>();
 			var roof = new Animation(rs.GetImage(self), () => self.Trait<IFacing>().Facing);
 			roof.Play("roof");
 			rs.anims.Add("roof", new AnimationWithOffset(roof, null, null, 1024));

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA
 		public readonly WeaponInfo Weapon;
 		public readonly Barrel[] Barrels;
 		Lazy<Turreted> Turret;
-		Lazy<ILocalCoordinatesModel> Coords;
+		Lazy<IBodyOrientation> Coords;
 
 		public WRange Recoil;
 		public int FireDelay { get; private set; }
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.RA
 
 			// We can't resolve these until runtime
 			Turret = Lazy.New(() => self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == info.Turret));
-			Coords = Lazy.New(() => self.Trait<ILocalCoordinatesModel>());
+			Coords = Lazy.New(() => self.Trait<IBodyOrientation>());
 
 			Weapon = Rules.Weapons[info.Weapon.ToLowerInvariant()];
 			Burst = Weapon.Burst;

--- a/OpenRA.Mods.RA/BelowUnits.cs
+++ b/OpenRA.Mods.RA/BelowUnits.cs
@@ -11,17 +11,30 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.RA.Buildings;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class BelowUnitsInfo : TraitInfo<BelowUnits> { }
+	class BelowUnitsInfo : ITraitInfo
+	{
+		public object Create(ActorInitializer init) { return new BelowUnits(init.self); }
+	}
 
 	class BelowUnits : IRenderModifier
 	{
+		int offset;
+
+		public BelowUnits(Actor self)
+		{
+			// Offset effective position to the top of the northernmost occupied cell
+			var bi = self.Info.Traits.GetOrDefault<BuildingInfo>();
+			offset = (bi != null) ? -FootprintUtils.CenterOffset(bi).Y : -512;
+		}
+
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			return r.Select(a => a.WithZOffset(-a.Size(wr).Z));
+			return r.Select(a => a.WithZOffset(offset));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Buildings/DeadBuildingState.cs
+++ b/OpenRA.Mods.RA/Buildings/DeadBuildingState.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc
 {
-	class DeadBuildingStateInfo : ITraitInfo, Requires<HealthInfo>, Requires<RenderSimpleInfo>
+	class DeadBuildingStateInfo : ITraitInfo, Requires<HealthInfo>, Requires<RenderSpritesInfo>
 	{
 		public readonly int LingerTime = 20;
 
@@ -23,12 +23,12 @@ namespace OpenRA.Mods.Cnc
 	class DeadBuildingState : INotifyKilled
 	{
 		DeadBuildingStateInfo info;
-		RenderSimple rs;
+		RenderSprites rs;
 
 		public DeadBuildingState(Actor self, DeadBuildingStateInfo info)
 		{
 			this.info = info;
-			rs = self.Trait<RenderSimple>();
+			rs = self.Trait<RenderSprites>();
 			self.Trait<Health>().RemoveOnDeath = !rs.anim.HasSequence("dead");
 		}
 

--- a/OpenRA.Mods.RA/Burns.cs
+++ b/OpenRA.Mods.RA/Burns.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class BurnsInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	class BurnsInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
 		public readonly string Anim = "1";
 		public readonly int Damage = 1;
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA
 
 			var anim = new Animation("fire", () => 0);
 			anim.PlayRepeating(Info.Anim);
-			self.Trait<RenderSimple>().anims.Add("fire",
+			self.Trait<RenderSprites>().anims.Add("fire",
 				new AnimationWithOffset(anim, () => info.Offset, null));
 		}
 

--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.RA.Buildings;
 
 namespace OpenRA.Mods.RA
 {
-	class CrateInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	class CrateInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
 		public readonly int Lifetime = 5; // Seconds
 		public readonly string[] TerrainTypes = { };
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.RA
 			PxPosition = Util.CenterOfCell(cell);
 
 			var seq = self.World.GetTerrainInfo(cell).IsWater ? "water" : "land";
-			var rs = self.Trait<RenderSimple>();
+			var rs = self.Trait<RenderSprites>();
 			if (seq != rs.anim.CurrentSequence.Name)
 				rs.anim.PlayRepeating(seq);
 

--- a/OpenRA.Mods.RA/Effects/Contrail.cs
+++ b/OpenRA.Mods.RA/Effects/Contrail.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class ContrailInfo : ITraitInfo, Requires<LocalCoordinatesModelInfo>
+	class ContrailInfo : ITraitInfo, Requires<IBodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA
 	{
 		ContrailInfo info;
 		ContrailHistory history;
-		ILocalCoordinatesModel coords;
+		IBodyOrientation body;
 
 		public Contrail(Actor self, ContrailInfo info)
 		{
@@ -40,13 +40,13 @@ namespace OpenRA.Mods.RA
 			history = new ContrailHistory(info.TrailLength,
 				info.UsePlayerColor ? ContrailHistory.ChooseColor(self) : info.Color);
 
-			coords = self.Trait<ILocalCoordinatesModel>();
+			body = self.Trait<IBodyOrientation>();
 		}
 
 		public void Tick(Actor self)
 		{
-			var local = info.Offset.Rotate(coords.QuantizeOrientation(self, self.Orientation));
-			history.Tick(self.CenterPosition + coords.LocalToWorld(local));
+			var local = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
+			history.Tick(self.CenterPosition + body.LocalToWorld(local));
 		}
 
 		public void RenderAfterWorld(WorldRenderer wr, Actor self) { history.Render(wr, self); }

--- a/OpenRA.Mods.RA/Render/RenderBuilding.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuilding.cs
@@ -57,6 +57,7 @@ namespace OpenRA.Mods.RA.Render
 			var self = init.self;
 			// Work around a bogus crash
 			anim.PlayRepeating( NormalizeSequence(self, "idle") );
+			self.Trait<IBodyOrientation>().QuantizedFacings = anim.CurrentSequence.Facings;
 
 			// Can't call Complete() directly from ctor because other traits haven't been inited yet
 			if (self.Info.Traits.Get<RenderBuildingInfo>().HasMakeAnimation && !init.Contains<SkipMakeAnimsInit>())

--- a/OpenRA.Mods.RA/Render/RenderBuildingTurreted.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingTurreted.cs
@@ -22,14 +22,26 @@ namespace OpenRA.Mods.RA.Render
 
 	class RenderBuildingTurreted : RenderBuilding
 	{
-		public RenderBuildingTurreted( ActorInitializer init, RenderBuildingInfo info )
-			: base(init, info, MakeTurretFacingFunc(init.self)) { }
+		Turreted t;
 
 		static Func<int> MakeTurretFacingFunc(Actor self)
 		{
 			// Turret artwork is baked into the sprite, so only the first turret makes sense.
 			var turreted = self.TraitsImplementing<Turreted>().FirstOrDefault();
 			return () => turreted.turretFacing;
+		}
+
+		public RenderBuildingTurreted(ActorInitializer init, RenderBuildingInfo info)
+			: base(init, info, MakeTurretFacingFunc(init.self))
+		{
+			t = init.self.TraitsImplementing<Turreted>().FirstOrDefault();
+			t.QuantizedFacings = anim.CurrentSequence.Facings;
+		}
+
+		public override void DamageStateChanged(Actor self, AttackInfo e)
+		{
+			base.DamageStateChanged(self, e);
+			t.QuantizedFacings = anim.CurrentSequence.Facings;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA.Render
 			foreach (var r in p)
 				yield return r;
 
-			var anim = new Animation(RenderSimple.GetImage(building), () => 0);
+			var anim = new Animation(RenderSprites.GetImage(building), () => 0);
 			anim.PlayRepeating("idle-top");
 			yield return new SpriteRenderable(anim.Image, WPos.Zero + Origin, 0, pr, 1f);
 		}

--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -61,6 +61,8 @@ namespace OpenRA.Mods.RA.Render
 			anim.PlayFetchIndex(NormalizeInfantrySequence(self, "stand"), () => 0);
 			State = AnimationState.Waiting;
 			mobile = self.Trait<Mobile>();
+
+			self.Trait<IBodyOrientation>().QuantizedFacings = anim.CurrentSequence.Facings;
 		}
 
 		public void Attacking(Actor self, Target target)

--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.RA.Render
 		public AnimationState State { get; private set; }
 
 		public RenderInfantry(Actor self, RenderInfantryInfo info)
-			: base(self, RenderSimple.MakeFacingFunc(self))
+			: base(self, MakeFacingFunc(self))
 		{
 			Info = info;
 			anim.PlayFetchIndex(NormalizeInfantrySequence(self, "stand"), () => 0);

--- a/OpenRA.Mods.RA/Render/RenderUnit.cs
+++ b/OpenRA.Mods.RA/Render/RenderUnit.cs
@@ -22,10 +22,7 @@ namespace OpenRA.Mods.RA.Render
 	public class RenderUnit : RenderSimple
 	{
 		public RenderUnit(Actor self)
-			: base(self, RenderSimple.MakeFacingFunc(self))
-		{
-			anim.PlayRepeating("idle");
-		}
+			: base(self) { }
 
 		public void PlayCustomAnimation(Actor self, string newAnim, Action after)
 		{

--- a/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
@@ -17,7 +17,7 @@ using OpenRA.Mods.RA;
 
 namespace OpenRA.Mods.RA.Render
 {
-	class WithMuzzleFlashInfo : ITraitInfo, Requires<RenderSimpleInfo>, Requires<AttackBaseInfo>
+	class WithMuzzleFlashInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<AttackBaseInfo>
 	{
 		public object Create(ActorInitializer init) { return new WithMuzzleFlash(init.self); }
 	}
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Render
 
 		public WithMuzzleFlash(Actor self)
 		{
-			var render = self.Trait<RenderSimple>();
+			var render = self.Trait<RenderSprites>();
 			var facing = self.TraitOrDefault<IFacing>();
 
 			var arms = self.TraitsImplementing<Armament>();

--- a/OpenRA.Mods.RA/Render/WithRotor.cs
+++ b/OpenRA.Mods.RA/Render/WithRotor.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	public class WithRotorInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	public class WithRotorInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<LocalCoordinatesModelInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -28,12 +28,13 @@ namespace OpenRA.Mods.RA.Render
 		public Animation rotorAnim;
 		public WithRotor(Actor self, WithRotorInfo info)
 		{
-			var rs = self.Trait<RenderSimple>();
+			var rs = self.Trait<RenderSprites>();
+			var coords = self.Trait<ILocalCoordinatesModel>();
 
 			rotorAnim = new Animation(rs.GetImage(self));
 			rotorAnim.PlayRepeating("rotor");
 			rs.anims.Add(info.Id, new AnimationWithOffset(rotorAnim,
-				() => rs.LocalToWorld(info.Offset.Rotate(rs.QuantizeOrientation(self, self.Orientation))),
+				() => coords.LocalToWorld(info.Offset.Rotate(coords.QuantizeOrientation(self, self.Orientation))),
 				null, p => WithTurret.ZOffsetFromCenter(self, p, 1)));
 		}
 

--- a/OpenRA.Mods.RA/Render/WithRotor.cs
+++ b/OpenRA.Mods.RA/Render/WithRotor.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	public class WithRotorInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<LocalCoordinatesModelInfo>
+	public class WithRotorInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -29,12 +29,12 @@ namespace OpenRA.Mods.RA.Render
 		public WithRotor(Actor self, WithRotorInfo info)
 		{
 			var rs = self.Trait<RenderSprites>();
-			var coords = self.Trait<ILocalCoordinatesModel>();
+			var body = self.Trait<IBodyOrientation>();
 
 			rotorAnim = new Animation(rs.GetImage(self));
 			rotorAnim.PlayRepeating("rotor");
 			rs.anims.Add(info.Id, new AnimationWithOffset(rotorAnim,
-				() => coords.LocalToWorld(info.Offset.Rotate(coords.QuantizeOrientation(self, self.Orientation))),
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				null, p => WithTurret.ZOffsetFromCenter(self, p, 1)));
 		}
 

--- a/OpenRA.Mods.RA/Render/WithSmoke.cs
+++ b/OpenRA.Mods.RA/Render/WithSmoke.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	public class WithSmokeInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	public class WithSmokeInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
 		public object Create(ActorInitializer init) { return new WithSmoke(init.self); }
 	}
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Render
 
 		public WithSmoke(Actor self)
 		{
-			var rs = self.Trait<RenderSimple>();
+			var rs = self.Trait<RenderSprites>();
 
 			anim = new Animation("smoke_m");
 			rs.anims.Add("smoke", new AnimationWithOffset(anim, null, () => !isSmoking));

--- a/OpenRA.Mods.RA/Render/WithSpinner.cs
+++ b/OpenRA.Mods.RA/Render/WithSpinner.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	class WithSpinnerInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<LocalCoordinatesModelInfo>
+	class WithSpinnerInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "spinner";
@@ -30,12 +30,12 @@ namespace OpenRA.Mods.RA.Render
 		public WithSpinner(Actor self, WithSpinnerInfo info)
 		{
 			var rs = self.Trait<RenderSprites>();
-			var coords = self.Trait<ILocalCoordinatesModel>();
+			var body = self.Trait<IBodyOrientation>();
 
 			var spinner = new Animation(rs.GetImage(self));
 			spinner.PlayRepeating(info.Sequence);
 			rs.anims.Add("spinner_{0}".F(info.Sequence), new AnimationWithOffset(spinner,
-				() => coords.LocalToWorld(info.Offset.Rotate(coords.QuantizeOrientation(self, self.Orientation))),
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				null, p => WithTurret.ZOffsetFromCenter(self, p, 1)));
 		}
 	}

--- a/OpenRA.Mods.RA/Render/WithSpinner.cs
+++ b/OpenRA.Mods.RA/Render/WithSpinner.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	class WithSpinnerInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	class WithSpinnerInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<LocalCoordinatesModelInfo>
 	{
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "spinner";
@@ -29,11 +29,13 @@ namespace OpenRA.Mods.RA.Render
 	{
 		public WithSpinner(Actor self, WithSpinnerInfo info)
 		{
-			var rs = self.Trait<RenderSimple>();
+			var rs = self.Trait<RenderSprites>();
+			var coords = self.Trait<ILocalCoordinatesModel>();
+
 			var spinner = new Animation(rs.GetImage(self));
 			spinner.PlayRepeating(info.Sequence);
 			rs.anims.Add("spinner_{0}".F(info.Sequence), new AnimationWithOffset(spinner,
-				() => rs.LocalToWorld(info.Offset.Rotate(rs.QuantizeOrientation(self, self.Orientation))),
+				() => coords.LocalToWorld(info.Offset.Rotate(coords.QuantizeOrientation(self, self.Orientation))),
 				null, p => WithTurret.ZOffsetFromCenter(self, p, 1)));
 		}
 	}

--- a/OpenRA.Mods.RA/Render/WithTurret.cs
+++ b/OpenRA.Mods.RA/Render/WithTurret.cs
@@ -54,6 +54,9 @@ namespace OpenRA.Mods.RA.Render
 			anim.Play(info.Sequence);
 			rs.anims.Add("turret_{0}".F(info.Turret), new AnimationWithOffset(
 				anim, () => TurretOffset(self), null, p => ZOffsetFromCenter(self, p, 1)));
+
+			// Restrict turret facings to match the sprite
+			t.QuantizedFacings = anim.CurrentSequence.Facings;
 		}
 
 		WVec TurretOffset(Actor self)

--- a/OpenRA.Mods.RA/Render/WithTurret.cs
+++ b/OpenRA.Mods.RA/Render/WithTurret.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	class WithTurretInfo : ITraitInfo, Requires<RenderSimpleInfo>, Requires<TurretedInfo>
+	class WithTurretInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<LocalCoordinatesModelInfo>
 	{
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "turret";
@@ -37,7 +37,8 @@ namespace OpenRA.Mods.RA.Render
 	class WithTurret : ITick
 	{
 		WithTurretInfo info;
-		RenderSimple rs;
+		RenderSprites rs;
+		ILocalCoordinatesModel coords;
 		AttackBase ab;
 		Turreted t;
 		IEnumerable<Armament> arms;
@@ -46,7 +47,9 @@ namespace OpenRA.Mods.RA.Render
 		public WithTurret(Actor self, WithTurretInfo info)
 		{
 			this.info = info;
-			rs = self.Trait<RenderSimple>();
+			rs = self.Trait<RenderSprites>();
+			coords = self.Trait<ILocalCoordinatesModel>();
+
 			ab = self.TraitOrDefault<AttackBase>();
 			t = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == info.Turret);
@@ -69,9 +72,9 @@ namespace OpenRA.Mods.RA.Render
 
 			var recoil = arms.Aggregate(WRange.Zero, (a,b) => a + b.Recoil);
 			var localOffset = new WVec(-recoil, WRange.Zero, WRange.Zero);
-			var bodyOrientation = rs.QuantizeOrientation(self, self.Orientation);
-			var turretOrientation = rs.QuantizeOrientation(self, t.LocalOrientation(self));
-			return t.Position(self) + rs.LocalToWorld(localOffset.Rotate(turretOrientation).Rotate(bodyOrientation));
+			var bodyOrientation = coords.QuantizeOrientation(self, self.Orientation);
+			var turretOrientation = coords.QuantizeOrientation(self, t.LocalOrientation(self));
+			return t.Position(self) + coords.LocalToWorld(localOffset.Rotate(turretOrientation).Rotate(bodyOrientation));
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.RA/Render/WithTurret.cs
+++ b/OpenRA.Mods.RA/Render/WithTurret.cs
@@ -28,6 +28,9 @@ namespace OpenRA.Mods.RA.Render
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";
 
+		[Desc("Render recoil")]
+		public readonly bool Recoils = true;
+
 		public object Create(ActorInitializer init) { return new WithTurret(init.self, this); }
 	}
 
@@ -61,6 +64,9 @@ namespace OpenRA.Mods.RA.Render
 
 		WVec TurretOffset(Actor self)
 		{
+			if (!info.Recoils)
+				return t.Position(self);
+
 			var recoil = arms.Aggregate(WRange.Zero, (a,b) => a + b.Recoil);
 			var localOffset = new WVec(-recoil, WRange.Zero, WRange.Zero);
 			var bodyOrientation = rs.QuantizeOrientation(self, self.Orientation);

--- a/OpenRA.Mods.RA/Render/WithTurret.cs
+++ b/OpenRA.Mods.RA/Render/WithTurret.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	class WithTurretInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<LocalCoordinatesModelInfo>
+	class WithTurretInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "turret";
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA.Render
 	{
 		WithTurretInfo info;
 		RenderSprites rs;
-		ILocalCoordinatesModel coords;
+		IBodyOrientation body;
 		AttackBase ab;
 		Turreted t;
 		IEnumerable<Armament> arms;
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.RA.Render
 		{
 			this.info = info;
 			rs = self.Trait<RenderSprites>();
-			coords = self.Trait<ILocalCoordinatesModel>();
+			body = self.Trait<IBodyOrientation>();
 
 			ab = self.TraitOrDefault<AttackBase>();
 			t = self.TraitsImplementing<Turreted>()
@@ -72,9 +72,9 @@ namespace OpenRA.Mods.RA.Render
 
 			var recoil = arms.Aggregate(WRange.Zero, (a,b) => a + b.Recoil);
 			var localOffset = new WVec(-recoil, WRange.Zero, WRange.Zero);
-			var bodyOrientation = coords.QuantizeOrientation(self, self.Orientation);
-			var turretOrientation = coords.QuantizeOrientation(self, t.LocalOrientation(self));
-			return t.Position(self) + coords.LocalToWorld(localOffset.Rotate(turretOrientation).Rotate(bodyOrientation));
+			var bodyOrientation = body.QuantizeOrientation(self, self.Orientation);
+			var turretOrientation = body.QuantizeOrientation(self, t.LocalOrientation(self));
+			return t.Position(self) + body.LocalToWorld(localOffset.Rotate(turretOrientation).Rotate(bodyOrientation));
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<LocalCoordinatesModelInfo>
+	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<IBodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -26,14 +26,14 @@ namespace OpenRA.Mods.RA
 
 	class SmokeTrailWhenDamaged : ITick
 	{
-		ILocalCoordinatesModel coords;
+		IBodyOrientation body;
 		SmokeTrailWhenDamagedInfo info;
 		int ticks;
 
 		public SmokeTrailWhenDamaged(Actor self, SmokeTrailWhenDamagedInfo info)
 		{
 			this.info = info;
-			coords = self.Trait<ILocalCoordinatesModel>();
+			body = self.Trait<IBodyOrientation>();
 		}
 
 		public void Tick(Actor self)
@@ -44,8 +44,8 @@ namespace OpenRA.Mods.RA
 				if (position.Z > 0 && self.GetDamageState() >= DamageState.Heavy &&
 				    !self.World.FogObscures(new CPos(position)))
 				{
-					var offset = info.Offset.Rotate(coords.QuantizeOrientation(self, self.Orientation));
-					var pos = position + coords.LocalToWorld(offset);
+					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
+					var pos = position + body.LocalToWorld(offset);
 					self.World.AddFrameEndTask(w => w.Add(new Smoke(w, pos, info.Sprite)));
 				}
 

--- a/OpenRA.Mods.RA/Spy.cs
+++ b/OpenRA.Mods.RA/Spy.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.RA
 			var tooltip = target.TraitsImplementing<IToolTip>().FirstOrDefault();
 			disguisedAsName = tooltip.Name();
 			disguisedAsPlayer = tooltip.Owner();
-			disguisedAsSprite = target.Trait<RenderSimple>().GetImage(target);
+			disguisedAsSprite = target.Trait<RenderSprites>().GetImage(target);
 		}
 
 		void DropDisguise()

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class NukePowerInfo : SupportPowerInfo
+	class NukePowerInfo : SupportPowerInfo, Requires<LocalCoordinatesModelInfo>
 	{
 		[WeaponReference]
 		public readonly string MissileWeapon = "";
@@ -25,7 +25,14 @@ namespace OpenRA.Mods.RA
 
 	class NukePower : SupportPower
 	{
-		public NukePower(Actor self, NukePowerInfo info) : base(self, info) { }
+		ILocalCoordinatesModel coords;
+
+		public NukePower(Actor self, NukePowerInfo info)
+			: base(self, info)
+		{
+			coords = self.Trait<ILocalCoordinatesModel>();
+		}
+
 		public override IOrderGenerator OrderGenerator(string order, SupportPowerManager manager)
 		{
 			Sound.PlayToPlayer(manager.self.Owner, Info.SelectTargetSound);
@@ -42,7 +49,7 @@ namespace OpenRA.Mods.RA
 			var rb = self.Trait<RenderSimple>();
 			rb.PlayCustomAnim(self, "active");
 			self.World.AddFrameEndTask(w => w.Add(
-				new NukeLaunch(self.Owner, self, npi.MissileWeapon, self.CenterPosition + rb.LocalToWorld(npi.SpawnOffset), order.TargetLocation)));
+				new NukeLaunch(self.Owner, self, npi.MissileWeapon, self.CenterPosition + coords.LocalToWorld(npi.SpawnOffset), order.TargetLocation)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class NukePowerInfo : SupportPowerInfo, Requires<LocalCoordinatesModelInfo>
+	class NukePowerInfo : SupportPowerInfo, Requires<IBodyOrientationInfo>
 	{
 		[WeaponReference]
 		public readonly string MissileWeapon = "";
@@ -25,12 +25,12 @@ namespace OpenRA.Mods.RA
 
 	class NukePower : SupportPower
 	{
-		ILocalCoordinatesModel coords;
+		IBodyOrientation body;
 
 		public NukePower(Actor self, NukePowerInfo info)
 			: base(self, info)
 		{
-			coords = self.Trait<ILocalCoordinatesModel>();
+			body = self.Trait<IBodyOrientation>();
 		}
 
 		public override IOrderGenerator OrderGenerator(string order, SupportPowerManager manager)
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA
 			var rb = self.Trait<RenderSimple>();
 			rb.PlayCustomAnim(self, "active");
 			self.World.AddFrameEndTask(w => w.Add(
-				new NukeLaunch(self.Owner, self, npi.MissileWeapon, self.CenterPosition + coords.LocalToWorld(npi.SpawnOffset), order.TargetLocation)));
+				new NukeLaunch(self.Owner, self, npi.MissileWeapon, self.CenterPosition + body.LocalToWorld(npi.SpawnOffset), order.TargetLocation)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/ThrowsParticle.cs
+++ b/OpenRA.Mods.RA/ThrowsParticle.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class ThrowsParticleInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	class ThrowsParticleInfo : ITraitInfo, Requires<RenderSimpleInfo>, Requires<LocalCoordinatesModelInfo>
 	{
 		public readonly string Anim = null;
 
@@ -54,6 +54,7 @@ namespace OpenRA.Mods.RA
 
 			var self = init.self;
 			var rs = self.Trait<RenderSimple>();
+			var coords = self.Trait<ILocalCoordinatesModel>();
 
 			// TODO: Carry orientation over from the parent instead of just facing
 			var bodyFacing = init.Contains<FacingInit>() ? init.Get<FacingInit,int>() : 0;
@@ -63,7 +64,7 @@ namespace OpenRA.Mods.RA
 			var throwRotation = WRot.FromFacing(Game.CosmeticRandom.Next(1024));
 			var throwOffset = new WVec((int)(Game.CosmeticRandom.Gauss1D(1)*info.ThrowRange.Range), 0, 0).Rotate(throwRotation);
 
-			initialPos = pos = info.Offset.Rotate(rs.QuantizeOrientation(self, WRot.FromFacing(bodyFacing)));
+			initialPos = pos = info.Offset.Rotate(coords.QuantizeOrientation(self, WRot.FromFacing(bodyFacing)));
 			finalPos = initialPos + throwOffset;
 
 			// Facing rotation

--- a/OpenRA.Mods.RA/ThrowsParticle.cs
+++ b/OpenRA.Mods.RA/ThrowsParticle.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class ThrowsParticleInfo : ITraitInfo, Requires<RenderSimpleInfo>, Requires<LocalCoordinatesModelInfo>
+	class ThrowsParticleInfo : ITraitInfo, Requires<RenderSimpleInfo>, Requires<IBodyOrientationInfo>
 	{
 		public readonly string Anim = null;
 
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA
 
 			var self = init.self;
 			var rs = self.Trait<RenderSimple>();
-			var coords = self.Trait<ILocalCoordinatesModel>();
+			var body = self.Trait<IBodyOrientation>();
 
 			// TODO: Carry orientation over from the parent instead of just facing
 			var bodyFacing = init.Contains<FacingInit>() ? init.Get<FacingInit,int>() : 0;
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA
 			var throwRotation = WRot.FromFacing(Game.CosmeticRandom.Next(1024));
 			var throwOffset = new WVec((int)(Game.CosmeticRandom.Gauss1D(1)*info.ThrowRange.Range), 0, 0).Rotate(throwRotation);
 
-			initialPos = pos = info.Offset.Rotate(coords.QuantizeOrientation(self, WRot.FromFacing(bodyFacing)));
+			initialPos = pos = info.Offset.Rotate(body.QuantizeOrientation(self, WRot.FromFacing(bodyFacing)));
 			finalPos = initialPos + throwOffset;
 
 			// Facing rotation

--- a/OpenRA.Mods.RA/Turreted.cs
+++ b/OpenRA.Mods.RA/Turreted.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA
 
 	public class Turreted : ITick, ISync, IResolveOrder
 	{
-		[Sync] public int QuantizedFacings = -1;
+		[Sync] public int QuantizedFacings = 0;
 		[Sync] public int turretFacing = 0;
 		public int? desiredFacing;
 		TurretedInfo info;
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.RA
 			// Hack: turretFacing is relative to the world, so subtract the body yaw
 			var local = WRot.FromYaw(WAngle.FromFacing(turretFacing) - self.Orientation.Yaw);
 
-			if (QuantizedFacings == -1)
+			if (QuantizedFacings == 0)
 				return local;
 
 			// Quantize orientation to match a rendered sprite

--- a/OpenRA.Mods.RA/Turreted.cs
+++ b/OpenRA.Mods.RA/Turreted.cs
@@ -84,9 +84,9 @@ namespace OpenRA.Mods.RA
 		// Turret offset in world-space
 		public WVec Position(Actor self)
 		{
-			var coords = self.Trait<ILocalCoordinatesModel>();
-			var bodyOrientation = coords.QuantizeOrientation(self, self.Orientation);
-			return coords.LocalToWorld(Offset.Rotate(bodyOrientation));
+			var body = self.Trait<IBodyOrientation>();
+			var bodyOrientation = body.QuantizeOrientation(self, self.Orientation);
+			return body.LocalToWorld(Offset.Rotate(bodyOrientation));
 		}
 
 		// Orientation in unit-space

--- a/OpenRA.Mods.RA/Turreted.cs
+++ b/OpenRA.Mods.RA/Turreted.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.RA
 
 	public class Turreted : ITick, ISync, IResolveOrder
 	{
+		[Sync] public int QuantizedFacings = -1;
 		[Sync] public int turretFacing = 0;
 		public int? desiredFacing;
 		TurretedInfo info;
@@ -91,8 +92,17 @@ namespace OpenRA.Mods.RA
 		// Orientation in unit-space
 		public WRot LocalOrientation(Actor self)
 		{
+
 			// Hack: turretFacing is relative to the world, so subtract the body yaw
-			return WRot.FromYaw(WAngle.FromFacing(turretFacing) - self.Orientation.Yaw);
+			var local = WRot.FromYaw(WAngle.FromFacing(turretFacing) - self.Orientation.Yaw);
+
+			if (QuantizedFacings == -1)
+				return local;
+
+			// Quantize orientation to match a rendered sprite
+			// Implies no pitch or yaw
+			var facing = Traits.Util.QuantizeFacing(local.Yaw.Angle / 4, QuantizedFacings) * (256 / QuantizedFacings);
+			return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing));
 		}
 	}
 }

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -445,3 +445,4 @@ VICE:
 	AttackWander:
 	RenderUnit:
 	WithMuzzleFlash:
+	BodyOrientation:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -33,6 +33,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Tank:
 	AppearsOnRadar:
@@ -72,6 +73,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Helicopter:
 	AppearsOnRadar:
@@ -97,6 +99,7 @@
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode
 	DebugMuzzlePositions:
+	BodyOrientation:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -149,6 +152,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -197,6 +201,7 @@
 	DrawLineToTarget:
 	ActorLostNotification:
 	DebugMuzzlePositions:
+	BodyOrientation:
 
 ^Ship:
 	AppearsOnRadar:
@@ -218,6 +223,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Building:
 	AppearsOnRadar:
@@ -266,6 +272,7 @@
 	DebugMuzzlePositions:
 	Guardable:
 		Range: 3
+	BodyOrientation:
 
 ^CivBuilding:
 	Inherits: ^Building
@@ -296,6 +303,7 @@
 		RelativeToTopLeft: yes
 	Tooltip:
 		Name: Civilian Building (Destroyed)
+	BodyOrientation:
 
 ^TechBuilding:
 	Inherits: ^CivBuilding
@@ -326,6 +334,7 @@
 	Tooltip:
 		Name: Field (Destroyed)
 	BelowUnits:
+	BodyOrientation:
 
 ^Wall:
 	AppearsOnRadar:
@@ -354,6 +363,7 @@
 	AutoTargetIgnore:
 	Sellable:
 	Guardable:
+	BodyOrientation:
 
 ^Tree:
 	Tooltip:
@@ -374,6 +384,7 @@
 	Armor:
 		Type: Wood
 	AutoTargetIgnore:
+	BodyOrientation:
 
 ^Rock:
 	Tooltip:
@@ -388,6 +399,7 @@
 		Terrain: Tree
 	EditorAppearance:
 		RelativeToTopLeft: yes
+	BodyOrientation:
 
 ^Husk:
 	Health:
@@ -403,6 +415,7 @@
 	TransformOnCapture:
 		ForceHealthPercentage: 25
 	BelowUnits:
+	BodyOrientation:
 #	Capturable:
 #		Type: husk
 #		AllowAllies: true
@@ -420,3 +433,4 @@
 	SoundOnDamageTransition:
 		DamagedSound: xplos.aud
 		DestroyedSound: xplobig4.aud
+	BodyOrientation:

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -351,11 +351,14 @@ CRATE:
 		Unit: mcv
 	RenderSimple:
 	BelowUnits:
+	BodyOrientation:
 
 mpspawn:
 	Waypoint:
 	RenderEditorOnly:
+	BodyOrientation:
 
 waypoint:
 	Waypoint:
 	RenderEditorOnly:
+	BodyOrientation:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -33,6 +33,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Tank:
 	AppearsOnRadar:
@@ -69,6 +70,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Husk:
 	Health:
@@ -84,6 +86,7 @@
 		Types:Husk
 	Tooltip:
 		Name: Destroyed Tank
+	BodyOrientation:
 
 ^TowerHusk:
 	Health:
@@ -101,6 +104,7 @@
 		Name: Destroyed Tower
 	ProximityCaptor:
 		Types:Husk
+	BodyOrientation:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -149,6 +153,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Plane:
 	AppearsOnRadar:
@@ -168,6 +173,7 @@
 		Types:Plane
 	GivesBounty:
 	DebugMuzzlePositions:
+	BodyOrientation:
 
 ^Helicopter:
 	Inherits: ^Plane
@@ -216,3 +222,4 @@
 	Bib:
 	Guardable:
 		Range: 3
+	BodyOrientation:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -372,6 +372,7 @@ WALL:
 		Types:Wall
 	Sellable:
 	Guardable:
+	BodyOrientation:
 
 GUNTOWER:
 	Inherits: ^Building

--- a/mods/d2k/rules/system.yaml
+++ b/mods/d2k/rules/system.yaml
@@ -481,14 +481,17 @@ CRATE:
 	ProximityCaptor:
 		Types:Crate
 	Passenger:
+	BodyOrientation:
 
 mpspawn:
 	Waypoint:
 	RenderEditorOnly:
+	BodyOrientation:
 
 waypoint:
 	Waypoint:
 	RenderEditorOnly:
+	BodyOrientation:
 
 SPICEBLOOM:
 	RenderBuilding:
@@ -508,6 +511,7 @@ SPICEBLOOM:
 		Interval: 75
 	RadarColorFromTerrain:
 		Terrain: Spice
+	BodyOrientation:
 
 #SANDWORM:
 #	Buildable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -36,6 +36,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Tank:
 	AppearsOnRadar:
@@ -75,6 +76,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -126,6 +128,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Ship:
 	AppearsOnRadar:
@@ -157,6 +160,7 @@
 	DebugMuzzlePositions:
 	Guard:
 	Guardable:
+	BodyOrientation:
 
 ^Plane:
 	AppearsOnRadar:
@@ -183,6 +187,7 @@
 		String:Plane
 	UpdatesPlayerStatistics:
 	DebugMuzzlePositions:
+	BodyOrientation:
 
 ^Helicopter:
 	Inherits: ^Plane
@@ -229,6 +234,7 @@
 	Guardable:
 		Range: 3
 	AutoTargetIgnore:
+	BodyOrientation:
 
 ^Wall:
 	AppearsOnRadar:
@@ -263,6 +269,7 @@
 	Sellable:
 	UpdatesPlayerStatistics:
 	Guardable:
+	BodyOrientation:
 
 ^TechBuilding:
 	Inherits: ^Building
@@ -344,6 +351,7 @@
 	Armor:
 		Type: Wood
 	AutoTargetIgnore:
+	BodyOrientation:
 
 ^Husk:
 	Husk:
@@ -358,6 +366,7 @@
 	ProximityCaptor:
 		Types:Husk
 	BelowUnits:
+	BodyOrientation:
 
 ^Bridge:
 	Tooltip:
@@ -373,6 +382,7 @@
 	ProximityCaptor:
 		Types:Bridge
 	AutoTargetIgnore:
+	BodyOrientation:
 
 #Temperate Terrain Expansion
 ^SVBridge:
@@ -389,6 +399,7 @@
 	ProximityCaptor:
 		Types:Bridge
 	AutoTargetIgnore:
+	BodyOrientation:
 
 ^SHBridge:
 	Tooltip:
@@ -404,6 +415,7 @@
 	ProximityCaptor:
 		Types:Bridge
 	AutoTargetIgnore:
+	BodyOrientation:
 
 ^STDBridge:
 	Tooltip:
@@ -419,6 +431,7 @@
 	ProximityCaptor:
 		Types:Bridge
 	AutoTargetIgnore:
+	BodyOrientation:
 
 #Desert Terrain Expansion:
 ^Rock:
@@ -437,6 +450,7 @@
 		UseTerrainPalette: true
 	ProximityCaptor:
 		Types:Tree
+	BodyOrientation:
 
 ^DesertCivBuilding:
 	Inherits: ^CivBuilding

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -670,6 +670,7 @@ MINP:
 		Types: Mine
 	TargetableUnit:
 		TargetTypes: Ground
+	BodyOrientation:
 
 MINV:
 	Mine:
@@ -695,6 +696,7 @@ MINV:
 		Types: Mine
 	TargetableUnit:
 		TargetTypes: Ground
+	BodyOrientation:
 
 CRATE:
 	Tooltip:
@@ -757,6 +759,7 @@ CRATE:
 	ProximityCaptor:
 		Types:Crate
 	Passenger:
+	BodyOrientation:
 
 CAMERA:
 	Aircraft:
@@ -766,6 +769,7 @@ CAMERA:
 		Range: 10
 	ProximityCaptor:
 		Types:Camera
+	BodyOrientation:
 
 FLARE:
 	Aircraft:
@@ -780,6 +784,7 @@ FLARE:
 		Name: Flare
 	ProximityCaptor:
 		Types: Flare
+	BodyOrientation:
 
 powerproxy.parabombs:
 	AirstrikePower:
@@ -805,7 +810,9 @@ powerproxy.sonarpulse:
 mpspawn:
 	Waypoint:
 	RenderEditorOnly:
+	BodyOrientation:
 
 waypoint:
 	Waypoint:
 	RenderEditorOnly:
+	BodyOrientation:


### PR DESCRIPTION
This should be the last of the major refactoring patches preparing for voxel units.
The RenderSimple trait is split into three (RenderSimple, RenderSprites, BodyOrientation) to support sprite additions (smoke, muzzleflash, etc) on voxel units, and voxel addons on sprite units (titan barrel).

The turret behavior and sequence definitions have been modified to support the giant walking edge-case that is the Titan (legs with 8 facings, turret with 32 facings, voxel barrel, clockwise sprite orientation).

There isn't much custom behavior left in RenderSimple/RenderUnit/RenderBuilding. A future patch should look into unifying these (WithBody:?) and clean up the mess of code relating to RenderSprites.anims.
