### PR TITLE
fixes d2k mod Sound weapon

### DIFF
--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -401,7 +401,8 @@ Sound:
 	Range: 8.5
 	Report: SONIC1
 	Projectile: LaserZap
-		BeamRadius: 1
+		BeamWidth: 2
+		HitAnim: laserfire
 		BeamDuration: 8
 		UsePlayerColor: true
 	Warhead:


### PR DESCRIPTION
I hadn't noticed that the D2K mod's Sound weapon uses LaserZap as well. Added HitAnim and replaced BeamRadius with BeamWidth.
