### PR TITLE
Fix BinaryReader / stream inconsistencies.

### DIFF
--- a/OpenRA.FileFormats/Exts.cs
+++ b/OpenRA.FileFormats/Exts.cs
@@ -41,41 +41,6 @@ namespace OpenRA
 			return a.GetTypes().Select(t => t.Namespace).Distinct().Where(n => n != null);
 		}
 
-		public static string ReadAllText(this Stream s)
-		{
-			using (s)
-			using (var sr = new StreamReader(s))
-				return sr.ReadToEnd();
-		}
-
-		public static byte[] ReadAllBytes(this Stream s)
-		{
-			using (s)
-			{
-				var data = new byte[s.Length - s.Position];
-				s.Read(data, 0, data.Length);
-				return data;
-			}
-		}
-
-		public static void Write(this Stream s, byte[] data)
-		{
-			s.Write(data, 0, data.Length);
-		}
-
-		public static IEnumerable<string> ReadAllLines(this Stream s)
-		{
-			using (var sr = new StreamReader(s))
-				for (; ; )
-				{
-					var line = sr.ReadLine();
-					if (line == null)
-						yield break;
-					else
-						yield return line;
-				}
-		}
-
 		public static bool HasAttribute<T>(this MemberInfo mi)
 		{
 			return mi.GetCustomAttributes(typeof(T), true).Length != 0;

--- a/OpenRA.FileFormats/Graphics/ShpTSReader.cs
+++ b/OpenRA.FileFormats/Graphics/ShpTSReader.cs
@@ -84,7 +84,7 @@ namespace OpenRA.FileFormats
 
 		private readonly List<HeaderImage> headers = new List<HeaderImage>();
 
-		public ShpTSReader(Stream stream)
+		public ShpTSReader(Stream s)
 		{
 
 			SHP SHP = new SHP();
@@ -100,13 +100,12 @@ namespace OpenRA.FileFormats
 				byte cp;
 				byte[] Databuffer;
 
-				BinaryReader sReader = new BinaryReader(stream);
-				FileSize = (int)sReader.BaseStream.Length;
+				FileSize = (int)s.Length;
 				// Get Header
-				SHP.Header.A = sReader.ReadUInt16();
-				SHP.Header.Width = sReader.ReadUInt16();
-				SHP.Header.Height = sReader.ReadUInt16();
-				SHP.Header.NumImages = sReader.ReadUInt16();
+				SHP.Header.A = s.ReadUInt16();
+				SHP.Header.Width = s.ReadUInt16();
+				SHP.Header.Height = s.ReadUInt16();
+				SHP.Header.NumImages = s.ReadUInt16();
 
 				SHP.Data = new SHPData[SHP.Header.NumImages + 1];
 
@@ -116,18 +115,18 @@ namespace OpenRA.FileFormats
 				{
 					SHP.Data[x].HeaderImage = new HeaderImage();
  
-					SHP.Data[x].HeaderImage.x = sReader.ReadUInt16();
-					SHP.Data[x].HeaderImage.y = sReader.ReadUInt16();
-					SHP.Data[x].HeaderImage.cx = sReader.ReadUInt16();
-					SHP.Data[x].HeaderImage.cy = sReader.ReadUInt16();
+					SHP.Data[x].HeaderImage.x = s.ReadUInt16();
+					SHP.Data[x].HeaderImage.y = s.ReadUInt16();
+					SHP.Data[x].HeaderImage.cx = s.ReadUInt16();
+					SHP.Data[x].HeaderImage.cy = s.ReadUInt16();
 
-					SHP.Data[x].HeaderImage.compression = sReader.ReadByte();
-					SHP.Data[x].HeaderImage.align = sReader.ReadBytes(3);
-					sReader.ReadInt32();
-					SHP.Data[x].HeaderImage.zero = sReader.ReadByte();
-					SHP.Data[x].HeaderImage.transparent = sReader.ReadBytes(3);
+					SHP.Data[x].HeaderImage.compression = s.ReadUInt8();
+					SHP.Data[x].HeaderImage.align = s.ReadBytes(3);
+					s.ReadInt32();
+					SHP.Data[x].HeaderImage.zero = s.ReadUInt8();
+					SHP.Data[x].HeaderImage.transparent = s.ReadBytes(3);
 
-					SHP.Data[x].HeaderImage.offset = sReader.ReadInt32();
+					SHP.Data[x].HeaderImage.offset = s.ReadInt32();
 
 				}
 
@@ -166,8 +165,8 @@ namespace OpenRA.FileFormats
 								Databuffer = new byte[ImageSize];
 								for (int i = 0; i < ImageSize; i++)
 								{
-									sReader.BaseStream.Position = SHP.Data[x].HeaderImage.offset + i;
-									Databuffer[i] = sReader.ReadByte();
+									s.Seek(SHP.Data[x].HeaderImage.offset + i, SeekOrigin.Begin);
+									Databuffer[i] = s.ReadUInt8();
 								}
 								SHP.Data[x].Databuffer = new byte[(SHP.Data[x].HeaderImage.cx * SHP.Data[x].HeaderImage.cy)];
 								Decode3(Databuffer, ref SHP.Data[x].Databuffer, SHP.Data[x].HeaderImage.cx, SHP.Data[x].HeaderImage.cy, ref FileSize);
@@ -221,8 +220,8 @@ namespace OpenRA.FileFormats
 								Databuffer = new byte[ImageSize];
 								for (int i = 0; i < ImageSize; i++)
 								{
-									sReader.BaseStream.Position = SHP.Data[x].HeaderImage.offset + i;
-									Databuffer[i] = sReader.ReadByte();
+									s.Seek(SHP.Data[x].HeaderImage.offset + i, SeekOrigin.Begin);
+									Databuffer[i] = s.ReadUInt8();
 								}
 								SHP.Data[x].Databuffer = new byte[((SHP.Data[x].HeaderImage.cx * SHP.Data[x].HeaderImage.cy))];
 								
@@ -279,8 +278,8 @@ namespace OpenRA.FileFormats
 								Databuffer = new byte[ImageSize];
 								for (int i = 0; i < ImageSize; i++)
 								{
-									sReader.BaseStream.Position = SHP.Data[x].HeaderImage.offset + i;
-									Databuffer[i] = sReader.ReadByte();
+									s.Seek(SHP.Data[x].HeaderImage.offset + i, SeekOrigin.Begin);
+									Databuffer[i] = s.ReadUInt8();
 								}
 
 								Decode2(Databuffer, ref SHP.Data[x].Databuffer, SHP.Data[x].HeaderImage.cx, SHP.Data[x].HeaderImage.cy, ref ImageSize);
@@ -334,8 +333,8 @@ namespace OpenRA.FileFormats
 								Databuffer = new byte[ImageSize];
 								for (int i = 0; i < ImageSize; i++)
 								{
-									sReader.BaseStream.Position = SHP.Data[x].HeaderImage.offset + i;
-									Databuffer[i] = sReader.ReadByte();
+									s.Seek(SHP.Data[x].HeaderImage.offset + i, SeekOrigin.Begin);
+									Databuffer[i] = s.ReadUInt8();
 								}
 								SHP.Data[x].Databuffer = new byte[((SHP.Data[x].HeaderImage.cx * SHP.Data[x].HeaderImage.cy))];
 								Decode2(Databuffer, ref SHP.Data[x].Databuffer, SHP.Data[x].HeaderImage.cx, SHP.Data[x].HeaderImage.cy, ref ImageSize);
@@ -389,8 +388,8 @@ namespace OpenRA.FileFormats
 							Databuffer = new byte[ImageSize];
 							for (int i = 0; i < ImageSize; i++)
 							{
-								sReader.BaseStream.Position = SHP.Data[x].HeaderImage.offset + i;
-								Databuffer[i] = sReader.ReadByte();
+								s.Seek(SHP.Data[x].HeaderImage.offset + i, SeekOrigin.Begin);
+								Databuffer[i] = s.ReadUInt8();
 							}
 							SHP.Data[x].Databuffer = new byte[(SHP.Data[x].HeaderImage.cx * SHP.Data[x].HeaderImage.cy)];
 							SHP.Data[x].Databuffer = Databuffer;

--- a/OpenRA.FileFormats/OpenRA.FileFormats.csproj
+++ b/OpenRA.FileFormats/OpenRA.FileFormats.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Graphics\ShpTSReader.cs" />
     <Compile Include="FileFormats\XccLocalDatabase.cs" />
     <Compile Include="FileFormats\XccGlobalDatabase.cs" />
+    <Compile Include="StreamExts.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/OpenRA.FileFormats/PackageEntry.cs
+++ b/OpenRA.FileFormats/PackageEntry.cs
@@ -30,11 +30,11 @@ namespace OpenRA.FileFormats
 			Length = length;
 		}
 
-		public PackageEntry(BinaryReader r)
+		public PackageEntry(Stream s)
 		{
-			Hash = r.ReadUInt32();
-			Offset = r.ReadUInt32();
-			Length = r.ReadUInt32();
+			Hash = s.ReadUInt32();
+			Offset = s.ReadUInt32();
+			Length = s.ReadUInt32();
 		}
 
 		public void Write(BinaryWriter w)

--- a/OpenRA.FileFormats/StreamExts.cs
+++ b/OpenRA.FileFormats/StreamExts.cs
@@ -1,0 +1,56 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace OpenRA
+{
+	public static class StreamExts
+	{
+		public static string ReadAllText(this Stream s)
+		{
+			using (s)
+			using (var sr = new StreamReader(s))
+				return sr.ReadToEnd();
+		}
+
+		public static byte[] ReadAllBytes(this Stream s)
+		{
+			using (s)
+			{
+				var data = new byte[s.Length - s.Position];
+				s.Read(data, 0, data.Length);
+				return data;
+			}
+		}
+
+		public static void Write(this Stream s, byte[] data)
+		{
+			s.Write(data, 0, data.Length);
+		}
+
+		public static IEnumerable<string> ReadAllLines(this Stream s)
+		{
+			using (var sr = new StreamReader(s))
+			{
+				for (;;)
+				{
+					var line = sr.ReadLine();
+					if (line == null)
+						yield break;
+					else
+						yield return line;
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.FileFormats/StreamExts.cs
+++ b/OpenRA.FileFormats/StreamExts.cs
@@ -11,11 +11,74 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace OpenRA
 {
 	public static class StreamExts
 	{
+		public static byte[] ReadBytes(this Stream s, int count)
+		{
+			if (count < 0)
+				throw new ArgumentOutOfRangeException("count", "Non-negative number required.");
+
+			var buf = new byte[count];
+			if (s.Read(buf, 0, count) < count)
+				throw new EndOfStreamException();
+
+			return buf;
+		}
+
+		public static int Peek(this Stream s)
+		{
+			var buf = new byte[1];
+			if (s.Read(buf, 0, 1) == 0)
+				return -1;
+
+			s.Seek(s.Position - 1, SeekOrigin.Begin);
+			return buf[0];
+		}
+
+		public static byte ReadUInt8(this Stream s)
+		{
+			return s.ReadBytes(1)[0];
+		}
+
+		public static ushort ReadUInt16(this Stream s)
+		{
+			return BitConverter.ToUInt16(s.ReadBytes(2), 0);
+		}
+
+		public static short ReadInt16(this Stream s)
+		{
+			return BitConverter.ToInt16(s.ReadBytes(2), 0);
+		}
+
+		public static uint ReadUInt32(this Stream s)
+		{
+			return BitConverter.ToUInt32(s.ReadBytes(4), 0);
+		}
+
+		public static int ReadInt32(this Stream s)
+		{
+			return BitConverter.ToInt32(s.ReadBytes(4), 0);
+		}
+
+		public static float ReadFloat(this Stream s)
+		{
+			return BitConverter.ToSingle(s.ReadBytes(4), 0);
+		}
+
+		public static double ReadDouble(this Stream s)
+		{
+			return BitConverter.ToDouble(s.ReadBytes(8), 0);
+		}
+
+		public static string ReadASCII(this Stream s, int length)
+		{
+			return new string(Encoding.ASCII.GetChars(s.ReadBytes(length)));
+		}
+
 		public static string ReadAllText(this Stream s)
 		{
 			using (s)


### PR DESCRIPTION
BinaryReader internally buffers bytes, meaning that the underlying stream position may not reflect the assumed position.

This adds extension methods for directly reading basic types from a Stream, and removes BinaryReader from the format parsers that incorrectly used BinaryReader.BaseStream.

The R8Reader changes will need to be tested by someone with access to the appropriate assets before merging.
