### PR TITLE
Add Bots button in Lobby

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Previous developers included:
 
 Also thanks to:
     * Akseli Virtanen (RAGEQUIT)
+    * Andrew Perkins
     * Andrew Riedi
     * Andreas Beck (baxtor)
     * Barnaby Smith (mvi)

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -335,7 +335,7 @@ namespace OpenRA.Mods.RA.Server
 							server.SendOrderTo(conn, "Message", "Number of teams could not be parsed: {0}".F(s));
 							return true;
 						}
-						teams = teams.Clamp(2, 8);
+						teams = teams.Clamp(1, 8);
 
 						var players = server.lobbyInfo.Slots
 							.Select(slot => server.lobbyInfo.Clients.SingleOrDefault(c => c.Slot == slot.Key))
@@ -366,6 +366,9 @@ namespace OpenRA.Mods.RA.Server
 								cl.Team = team;
 							}
 						}
+						// All vs Host
+						if (teams == 1)
+							client.Team = 2;
 						server.SyncLobbyInfo();
 						return true;
 					}},

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -448,6 +448,13 @@ Container@SERVER_LOBBY:
 					Width:80
 					Height:20
 					Text: Crates
+				Button@ADD_BOTS:
+					X:398-120-10
+					Y:255
+					Width:120
+					Height:25
+					Text:Add Bots
+					Font:Bold
 				DropDownButton@ASSIGNTEAMS_DROPDOWNBUTTON:
 					X:398
 					Y:255

--- a/mods/d2k/chrome/lobby.yaml
+++ b/mods/d2k/chrome/lobby.yaml
@@ -474,6 +474,13 @@ Background@SERVER_LOBBY:
 			Height:25
 			Text:Change Map
 			Font:Bold
+		Button@ADD_BOTS:
+			X:PARENT_RIGHT-154
+			Y:PARENT_BOTTOM-(289-25-5)
+			Width:120
+			Height:25
+			Text:Add Bots
+			Font:Bold
 		DropDownButton@ASSIGNTEAMS_DROPDOWNBUTTON:
 			X:PARENT_RIGHT-154
 			Y:PARENT_BOTTOM-229

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -474,6 +474,13 @@ Background@SERVER_LOBBY:
 			Height:25
 			Text:Change Map
 			Font:Bold
+		Button@ADD_BOTS:
+			X:PARENT_RIGHT-154
+			Y:PARENT_BOTTOM-(289-25-5)
+			Width:120
+			Height:25
+			Text:Add Bots
+			Font:Bold
 		DropDownButton@ASSIGNTEAMS_DROPDOWNBUTTON:
 			X:PARENT_RIGHT-154
 			Y:PARENT_BOTTOM-229


### PR DESCRIPTION
New 'Add Bots' button in the Lobby that adds the maximum number of bots with random AI for the selected map.
Added 'All vs Host' option to the Assign drop-down that assigns Host to Team 2, and all other slots to Team 1.
