### PR TITLE
Rework aircraft destruction to use husks instead of the original actor

### DIFF
--- a/OpenRA.Mods.RA/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.RA/Air/FallsToEarth.cs
@@ -8,28 +8,26 @@
  */
 #endregion
 
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Air
 {
-	class FallsToEarthInfo : TraitInfo<FallsToEarth>
+	class FallsToEarthInfo : ITraitInfo
 	{
 		[WeaponReference]
-		public readonly string Explosion = null;
+		public readonly string Explosion = "UnitExplode";
 
 		public readonly bool Spins = true;
 		public readonly bool Moves = false;
+
+		public object Create(ActorInitializer init) { return new FallsToEarth(init.self, this); }
 	}
 
-	class FallsToEarth : INotifyKilled
+	class FallsToEarth
 	{
-		public void Killed(Actor self, AttackInfo e)
+		public FallsToEarth(Actor self, FallsToEarthInfo info)
 		{
-			self.Trait<Health>().RemoveOnDeath = false;
-
-			self.CancelActivity();
-			self.QueueActivity(new FallToEarth(self, self.Info.Traits.Get<FallsToEarthInfo>()));
+			self.QueueActivity(false, new FallToEarth(self, info));
 		}
 	}
 

--- a/OpenRA.Mods.RA/LeavesHusk.cs
+++ b/OpenRA.Mods.RA/LeavesHusk.cs
@@ -10,8 +10,9 @@
 
 using System.Linq;
 using OpenRA.FileFormats;
-using OpenRA.Traits;
+using OpenRA.Mods.RA.Air;
 using OpenRA.Mods.RA.Move;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
@@ -35,11 +36,11 @@ namespace OpenRA.Mods.RA
 		{
 			self.World.AddFrameEndTask(w =>
 			{
-				var td = new TypeDictionary()
+				var td = new TypeDictionary
 				{
-					new LocationInit( self.Location ),
+					new LocationInit(self.Location),
 					new CenterLocationInit(self.CenterLocation),
-					new OwnerInit( self.Owner ),
+					new OwnerInit(self.Owner),
 					new SkipMakeAnimsInit()
 				};
 
@@ -50,6 +51,10 @@ namespace OpenRA.Mods.RA
 					if (!mobile.CanEnterCell(self.Location, self, false)) return;
 					td.Add(new HuskSpeedInit(mobile.MovementSpeedForCell(self, self.Location)));
 				}
+
+				var aircraft = self.TraitOrDefault<Aircraft>();
+				if (aircraft != null)
+					td.Add(new AltitudeInit(aircraft.Altitude));
 
 				var facing = self.TraitOrDefault<IFacing>();
 				if (facing != null)

--- a/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.RA
 		public readonly WVec Offset = WVec.Zero;
 		public readonly int Interval = 3;
 		public readonly string Sprite = "smokey";
+		public readonly DamageState MinDamage = DamageState.Heavy;
 
 		public object Create(ActorInitializer init) { return new SmokeTrailWhenDamaged(init.self, this); }
 	}
@@ -41,7 +42,7 @@ namespace OpenRA.Mods.RA
 			if (--ticks <= 0)
 			{
 				var position = self.CenterPosition;
-				if (position.Z > 0 && self.GetDamageState() >= DamageState.Heavy &&
+				if (position.Z > 0 && self.GetDamageState() >= info.MinDamage &&
 				    !self.World.FogObscures(new CPos(position)))
 				{
 					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -36,8 +36,8 @@ TRAN:
 		Types: Infantry
 		MaxWeight: 10
 		PipCount: 10
-	FallsToEarth:
-		Explosion: HeliCrash
+	LeavesHusk:
+		HuskActor: TRAN.Husk
 	Explodes:
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode
@@ -86,8 +86,8 @@ HELI:
 		Offset: 0,0,85
 	WithMuzzleFlash:
 	WithShadow:
-	FallsToEarth:
-		Explosion: HeliCrash
+	LeavesHusk:
+		HuskActor: HELI.Husk
 	AutoTarget:
 	Explodes:
 		Weapon: HeliExplode
@@ -134,8 +134,8 @@ ORCA:
 		Period: 200
 	RenderUnit:
 	WithShadow:
-	FallsToEarth:
-		Explosion: HeliCrash
+	LeavesHusk:
+		HuskActor: ORCA.Husk
 	AutoTarget:
 	Explodes:
 		Weapon: HeliExplode
@@ -206,3 +206,42 @@ A10:
 	-GainsExperience:
 	FlyAwayOnIdle:
 
+TRAN.Husk:
+	Inherits: ^HelicopterHusk
+	Tooltip:
+		Name: Chinook Transport
+	Helicopter:
+		ROT: 5
+		Speed: 15
+	WithRotor@PRIMARY:
+		Offset: -597,0,171
+	WithRotor@SECONDARY:
+		Id: rotor_2
+		Offset: 597,0,85
+	RenderUnit:
+		Image: tran
+	WithShadow:
+
+HELI.Husk:
+	Inherits: ^HelicopterHusk
+	Tooltip:
+		Name: Apache Longbow
+	Helicopter:
+		ROT: 4
+		Speed: 20
+	WithRotor:
+		Offset: 0,0,85
+	RenderUnit:
+		Image: heli
+	WithShadow:
+
+ORCA.Husk:
+	Inherits: ^HelicopterHusk
+	Tooltip:
+		Name: Orca
+	Helicopter:
+		ROT: 4
+		Speed: 20
+	RenderUnit:
+		Image: orca
+	WithShadow:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -422,6 +422,18 @@
 #		AllowNeutral: true
 #		AllowEnemies: true
 
+^HelicopterHusk:
+	Inherits: ^Husk
+	-Husk:
+	-Burns:
+	FallsToEarth:
+		Spins: True
+		Moves: False
+		Explosion: HeliCrash
+	-BelowUnits:
+	-TransformOnCapture:
+	-TargetableUnit:
+
 ^Bridge:
 	Tooltip:
 		Name: Bridge

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -29,10 +29,8 @@
 		MaxWeight: 1
 		PipCount: 1
 		minimalUnloadAltitude: 25
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplodeScale
+	LeavesHusk:
+		HuskActor: CARRYALL.Husk
 
 FRIGATE:
 	ParaDrop:
@@ -92,10 +90,8 @@ ORNI:
 	WithShadow:
 	Selectable:
 		Bounds: 38,32,0,0
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplodeScale
+	LeavesHusk:
+		HuskActor: ORNI.Husk
 
 ORNI.bomber:
 	CarpetBomb:
@@ -122,10 +118,8 @@ ORNI.bomber:
 	-GainsExperience:
 	Tooltip:
 		Name: Ornithopter
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplodeScale
+	LeavesHusk:
+		HuskActor: ORNI.bomber.Husk
 
 CARRYALL.infantry:
 	ParaDrop:
@@ -153,10 +147,8 @@ CARRYALL.infantry:
 	-GainsExperience:
 	Tooltip:
 		Name: Carryall
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplodeScale
+	LeavesHusk:
+		HuskActor: CARRYALL.infantry.Husk
 
 BADR:
 	Inherits: CARRYALL.infantry
@@ -164,3 +156,70 @@ BADR:
 		LZRange: 4
 	Tooltip:
 		Name: Crate Carryall
+	LeavesHusk:
+		HuskActor: BADR.Husk
+
+CARRYALL.Husk:
+	Inherits: ^AircraftHusk
+	Tooltip:
+		Name: Carryall
+	Helicopter:
+		ROT: 4
+		Speed: 30
+		RepairBuildings: repair
+		RearmBuildings: starporta,starporto,starporth
+	RenderUnit:
+		Image: carryall
+	WithShadow:
+
+ORNI.Husk:
+	Inherits: ^AircraftHusk
+	Tooltip:
+		Name: Ornithopter
+	Helicopter:
+		ROT: 6
+		Speed: 40
+		RepairBuildings: repair
+		RearmBuildings: starporta,starporto,starporth
+	RenderUnit:
+		Image: orni
+	WithShadow:
+
+ORNI.bomber.Husk:
+	Inherits: ^AircraftHusk
+	Tooltip:
+		Name: Ornithopter
+	Plane:
+		ROT: 5
+		Speed: 50
+		RepairBuildings: repair
+		RearmBuildings: starporta,starporto,starporth
+	RenderUnit:
+		Image: orni
+	WithShadow:
+
+CARRYALL.infantry.Husk:
+	Inherits: ^AircraftHusk
+	Tooltip:
+		Name: Carryall
+	Plane:
+		ROT: 4
+		Speed: 40
+		RepairBuildings: repair
+		RearmBuildings: starporta,starporto,starporth
+	RenderUnit:
+		Image: carryall
+	WithShadow:
+
+BADR.Husk:
+	Inherits: ^AircraftHusk
+	Tooltip:
+		Name: Crate Carryall
+	Plane:
+		ROT: 4
+		Speed: 40
+		RepairBuildings: repair
+		RearmBuildings: starporta,starporto,starporth
+	RenderUnit:
+		Image: carryall
+	WithShadow:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -106,6 +106,15 @@
 		Types:Husk
 	BodyOrientation:
 
+^AircraftHusk:
+	Inherits: ^Husk
+	-Husk:
+	-Burns:
+	FallsToEarth:
+		Spins: False
+		Moves: True
+		Explosion: UnitExplodeScale
+
 ^Infantry:
 	AppearsOnRadar:
 	Health:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -23,10 +23,8 @@ BADR:
 		Offset: -469,469,0
 	Contrail@2:
 		Offset: -469,-469,0
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplode
+	LeavesHusk:
+		HuskActor: BADR.Husk
 	SmokeTrailWhenDamaged@0:
 		Offset: -469,469,0
 		Interval: 2
@@ -36,7 +34,7 @@ BADR:
 	-EjectOnDeath:
 	-GpsDot:
 
-BADR.bomber:
+BADR.Bomber:
 	CarpetBomb:
 		Range: 3
 		Weapon: ParaBomb
@@ -53,7 +51,7 @@ BADR.bomber:
 	RenderUnit:
 		Image: badr
 	WithShadow:
-	IronCurtainable:	
+	IronCurtainable:
 	-Selectable:
 	-GainsExperience:
 	Tooltip:
@@ -62,10 +60,8 @@ BADR.bomber:
 		Offset: 469,469,0
 	Contrail@2:
 		Offset: 469,-469,0
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplode
+	LeavesHusk:
+		HuskActor: BADR.Husk
 	SmokeTrailWhenDamaged@0:
 		Offset: -469,469,0
 		Interval: 2
@@ -119,10 +115,8 @@ MIG:
 		Offset: -598,-683,0
 	Contrail@2:
 		Offset: -598,683,0
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplode
+	LeavesHusk:
+		HuskActor: MIG.Husk
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,171
 		Interval: 2
@@ -172,14 +166,11 @@ YAK:
 	WithMuzzleFlash:
 	Contrail:
 		Offset: -853,0,0
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplode
+	LeavesHusk:
+		HuskActor: YAK.Husk
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,0
 		Interval: 2
-		
 
 TRAN:
 	Inherits: ^Helicopter
@@ -219,9 +210,9 @@ TRAN:
 		MaxWeight: 8
 		PipCount: 8
 	IronCurtainable:
-	FallsToEarth:
-		Explosion: UnitExplode
-		
+	LeavesHusk:
+		HuskActor: TRAN.Husk
+
 TRAN.Husk1:
 	Inherits: ^Husk
 	Tooltip:
@@ -277,8 +268,8 @@ HELI:
 	LimitedAmmo:
 		Ammo: 8
 	IronCurtainable:
-	FallsToEarth:
-		Explosion: UnitExplode
+	LeavesHusk:
+		HuskActor: HELI.Husk
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
 
@@ -327,8 +318,8 @@ HIND:
 	Selectable:
 		Bounds: 38,32,0,0
 	WithMuzzleFlash:
-	FallsToEarth:
-		Explosion: UnitExplode
+	LeavesHusk:
+		HuskActor: HIND.Husk
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
 
@@ -350,10 +341,129 @@ U2:
 		Offset: -725,683,0
 	Contrail@2:
 		Offset: -725,-683,0
-	FallsToEarth:
-		Spins: no
-		Moves: yes
-		Explosion: UnitExplode
+	LeavesHusk:
+		HuskActor: U2.Husk
 	SmokeTrailWhenDamaged:
 		Offset: -1c43,0,0
 		Interval: 2
+
+BADR.Husk:
+	Inherits: ^PlaneHusk
+	Tooltip:
+		Name: Badger
+	RenderUnit:
+		Image: badr
+	WithShadow:
+	Plane:
+		ROT: 5
+		Speed: 16
+	SmokeTrailWhenDamaged@0:
+		Offset: -469,469,0
+		Interval: 2
+		MinDamage: Undamaged
+	SmokeTrailWhenDamaged@1:
+		Offset: -469,-469,0
+		Interval: 2
+		MinDamage: Undamaged
+
+MIG.Husk:
+	Inherits: ^PlaneHusk
+	Tooltip:
+		Name: Mig Attack Plane
+	RenderUnit:
+		CameraPitch: 99
+		Image: mig
+	WithShadow:
+	Contrail@1:
+		Offset: -598,-683,0
+	Contrail@2:
+		Offset: -598,683,0
+	Plane:
+		ROT: 5
+		Speed: 20
+	SmokeTrailWhenDamaged:
+		Offset: -853,0,171
+		Interval: 2
+		MinDamage: Undamaged
+
+YAK.Husk:
+	Inherits: ^PlaneHusk
+	Tooltip:
+		Name: Yak Attack Plane
+	RenderUnit:
+		CameraPitch: 99
+		Image: yak
+	WithShadow:
+	Contrail:
+		Offset: -853,0,0
+	Plane:
+		ROT: 5
+		Speed: 16
+	SmokeTrailWhenDamaged:
+		Offset: -853,0,0
+		Interval: 2
+		MinDamage: Undamaged
+
+TRAN.Husk:
+	Inherits: ^HelicopterHusk
+	Tooltip:
+		Name: Transport Helicopter
+	RenderUnit:
+		Image: tran
+	WithShadow:
+	Helicopter:
+		ROT: 4
+		Speed: 16
+	WithRotor@PRIMARY:
+		Offset: -597,0,341
+	WithRotor@SECONDARY:
+		Id: rotor_2
+		Offset: 597,0,213
+
+HELI.Husk:
+	Inherits: ^HelicopterHusk
+	Tooltip:
+		Name: Longbow
+	RenderUnit:
+		Image: heli
+	WithShadow:
+	Helicopter:
+		ROT: 4
+		Speed: 16
+	WithRotor:
+		Offset: 0,0,85
+	SmokeTrailWhenDamaged:
+		Offset: -427,0,0
+		MinDamage: Undamaged
+
+HIND.Husk:
+	Inherits: ^HelicopterHusk
+	Tooltip:
+		Name: Hind
+	RenderUnit:
+		Image: hind
+	WithShadow:
+	Helicopter:
+		ROT: 4
+		Speed: 12
+	WithRotor:
+	SmokeTrailWhenDamaged:
+		Offset: -427,0,0
+		MinDamage: Undamaged
+
+U2.Husk:
+	Inherits: ^PlaneHusk
+	RenderUnit:
+		Image: u2
+	WithShadow:
+	Plane:
+		ROT: 7
+		Speed: 40
+	Contrail@1:
+		Offset: -725,683,0
+	Contrail@2:
+		Offset: -725,-683,0
+	SmokeTrailWhenDamaged:
+		Offset: -1c43,0,0
+		Interval: 2
+		MinDamage: Undamaged

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -368,6 +368,24 @@
 	BelowUnits:
 	BodyOrientation:
 
+^HelicopterHusk:
+	Inherits: ^Husk
+	-Husk:
+	-Burns:
+	FallsToEarth:
+		Spins: True
+		Moves: False
+	-BelowUnits:
+
+^PlaneHusk:
+	Inherits: ^Husk
+	-Husk:
+	-Burns:
+	FallsToEarth:
+		Spins: False
+		Moves: True
+	-BelowUnits:
+
 ^Bridge:
 	Tooltip:
 		Name: Bridge


### PR DESCRIPTION
This replaces dead aircraft with aircraft husks. The new aircraft husk runs the FallToEarth activity instead and the original aircraft is removed. This probably fixes the zombie aircraft bug and it fixes #3324. It causes the aircraft to flicker slightly when it's being swapped out but this is not a new problem
