### PR TITLE
Capture changes - Engis now capture from outside. Added classic (legacy)...

### DIFF
--- a/OpenRA.Mods.RA/Activities/LegacyCaptureActor.cs
+++ b/OpenRA.Mods.RA/Activities/LegacyCaptureActor.cs
@@ -1,0 +1,70 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+using OpenRA.Mods.RA.Move;
+using OpenRA.Mods.RA.Buildings;
+
+namespace OpenRA.Mods.RA.Activities
+{
+	class LegacyCaptureActor : Activity
+	{
+		Target target;
+
+		public LegacyCaptureActor(Target target) { this.target = target; }
+
+		public override Activity Tick(Actor self)
+		{
+			if (IsCanceled)
+				return NextActivity;
+			if (!target.IsValid)
+				return NextActivity;
+
+			var b = target.Actor.TraitOrDefault<Building>();
+			if (b != null && b.Locked)
+				return NextActivity;
+
+			var capturesInfo = self.Info.Traits.Get<LegacyCapturesInfo>();
+			var capturableInfo = target.Actor.Info.Traits.Get<LegacyCapturableInfo>();
+
+			var health = target.Actor.Trait<Health>();
+			var lowEnoughHealth = health.HP <= capturableInfo.CaptureThreshold * health.MaxHP;
+
+			self.World.AddFrameEndTask(w =>
+			{
+				if (!capturesInfo.Sabotage || lowEnoughHealth || target.Actor.Owner.NonCombatant)
+				{
+					var oldOwner = target.Actor.Owner;
+
+					target.Actor.ChangeOwner(self.Owner);
+
+					foreach (var t in self.TraitsImplementing<INotifyCapture>())
+						t.OnCapture(target.Actor, self, oldOwner, self.Owner);
+
+					foreach (var t in self.World.ActorsWithTrait<INotifyOtherCaptured>())
+						t.Trait.OnActorCaptured(t.Actor, target.Actor, self, oldOwner, self.Owner);
+
+					if (b != null && b.Locked)
+						b.Unlock();
+				}
+				else
+				{
+					int damage = (int)(health.MaxHP * capturesInfo.SabotageHPRemoval);
+					target.Actor.InflictDamage(self, damage, null);
+				}
+
+				self.Destroy();
+			});
+
+			return this;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Captures.cs
+++ b/OpenRA.Mods.RA/Captures.cs
@@ -16,14 +16,18 @@ using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
+using OpenRA.FileFormats;
 
 namespace OpenRA.Mods.RA
 {
+	[Desc("This actor can capture other actors which have the Capturable: trait.")]
 	class CapturesInfo : ITraitInfo
 	{
-		public string[] CaptureTypes = {"building"};
-		public bool WastedAfterwards = true;
-		public bool Sabotage = false;
+		[Desc("Types of actors that it can capture, as long as the type also exists in the Capturable Type: trait.")]
+		public readonly string[] CaptureTypes = { "building" };
+		[Desc("Destroy the unit after capturing.")]
+		public readonly bool ConsumeActor = false;
+
 		public object Create(ActorInitializer init) { return new Captures(init.self, this); }
 	}
 
@@ -42,11 +46,11 @@ namespace OpenRA.Mods.RA
 		{
 			get
 			{
-				yield return new CaptureOrderTargeter(Info.CaptureTypes, target => CanCapture(target));
+				yield return new CaptureOrderTargeter(CanCapture);
 			}
 		}
 
-		public Order IssueOrder( Actor self, IOrderTargeter order, Target target, bool queued )
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "CaptureActor")
 				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
@@ -56,8 +60,7 @@ namespace OpenRA.Mods.RA
 
 		public string VoicePhraseForOrder(Actor self, Order order)
 		{
-			return (order.OrderString == "CaptureActor"
-					&& CanCapture(order.TargetActor)) ? "Attack" : null;
+			return (order.OrderString == "CaptureActor" && CanCapture(order.TargetActor)) ? "Attack" : null;
 		}
 
 		public void ResolveOrder(Actor self, Order order)
@@ -70,27 +73,25 @@ namespace OpenRA.Mods.RA
 				self.SetTargetLine(Target.FromOrder(order), Color.Red);
 
 				self.CancelActivity();
-				self.QueueActivity(new CaptureActor(order.TargetActor));
+				self.QueueActivity(new CaptureActor(Target.FromOrder(order)));
 			}
 		}
 
 		bool CanCapture(Actor target)
 		{
 			var c = target.TraitOrDefault<Capturable>();
-			return c != null && (!c.CaptureInProgress || c.Captor.Owner.Stances[self.Owner] != Stance.Ally);
+			return c != null && c.CanBeTargetedBy(self);
 		}
 	}
 
 	class CaptureOrderTargeter : UnitOrderTargeter
 	{
-		readonly string[] captureTypes;
-		readonly Func<Actor, bool> useEnterCursor;
+		readonly Func<Actor, bool> useCaptureCursor;
 
-		public CaptureOrderTargeter(string[] captureTypes, Func<Actor, bool> useEnterCursor)
+		public CaptureOrderTargeter(Func<Actor, bool> useCaptureCursor)
 			: base("CaptureActor", 6, "enter", true, true)
 		{
-			this.captureTypes = captureTypes;
-			this.useEnterCursor = useEnterCursor;
+			this.useCaptureCursor = useCaptureCursor;
 		}
 
 		public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
@@ -98,26 +99,12 @@ namespace OpenRA.Mods.RA
 			if (!base.CanTargetActor(self, target, modifiers, ref cursor))
 				return false;
 
-			var ci = target.Info.Traits.GetOrDefault<CapturableInfo>();
-			if (ci == null)
-				return false;
+			var canTargetActor = useCaptureCursor(target);
+			cursor = canTargetActor ? "ability" : "move-blocked";
 
-			var playerRelationship = self.Owner.Stances[target.Owner];
-			if (playerRelationship == Stance.Ally && !ci.AllowAllies)
-				return false;
-
-			if (playerRelationship == Stance.Enemy && !ci.AllowEnemies)
-				return false;
-
-			if (playerRelationship == Stance.Neutral && !ci.AllowNeutral)
-				return false;
-
-			IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
-
-			var Info = self.Info.Traits.Get<CapturesInfo>();
-			if (captureTypes.Contains(ci.Type))
+			if (canTargetActor)
 			{
-				cursor = (Info.WastedAfterwards) ? (useEnterCursor(target) ? "enter" : "enter-blocked") : "attack";
+				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 				return true;
 			}
 

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA
 		public object Create( ActorInitializer init ) { return new Cargo( init, this ); }
 	}
 
-	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyKilled
+	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyKilled, INotifyCapture
 	{
 		readonly Actor self;
 		readonly CargoInfo info;
@@ -179,6 +179,18 @@ namespace OpenRA.Mods.RA
 			foreach( var c in cargo )
 				c.Destroy();
 			cargo.Clear();
+		}
+
+		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		{
+			if (cargo == null)
+				return;
+
+			self.World.AddFrameEndTask(w =>
+			{
+				foreach (var p in Passengers)
+					p.Owner = newOwner;
+			});
 		}
 	}
 

--- a/OpenRA.Mods.RA/LegacyCapturable.cs
+++ b/OpenRA.Mods.RA/LegacyCapturable.cs
@@ -1,0 +1,64 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+using OpenRA.FileFormats;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("This actor can be captured by a unit with LegacyCaptures: trait.")]
+	class LegacyCapturableInfo : ITraitInfo
+	{
+		[Desc("Type of actor (the LegacyCaptures: trait defines what Types it can capture).")]
+		public readonly string Type = "building";
+		public readonly bool AllowAllies = false;
+		public readonly bool AllowNeutral = true;
+		public readonly bool AllowEnemies = true;
+		[Desc("Health percentage the target must be at (or below) before it can be captured.")]
+		public readonly double CaptureThreshold = 0.5;
+
+		public object Create(ActorInitializer init) { return new LegacyCapturable(init.self, this); }
+	}
+
+	class LegacyCapturable
+	{
+		[Sync] Actor self;
+		public LegacyCapturableInfo Info;
+
+		public LegacyCapturable(Actor self, LegacyCapturableInfo info)
+		{
+			this.self = self;
+			Info = info;
+		}
+
+		public bool CanBeTargetedBy(Actor captor)
+		{
+			var c = captor.TraitOrDefault<LegacyCaptures>();
+			if (c == null)
+				return false;
+
+			var playerRelationship = self.Owner.Stances[captor.Owner];
+			if (playerRelationship == Stance.Ally && !Info.AllowAllies)
+				return false;
+
+			if (playerRelationship == Stance.Enemy && !Info.AllowEnemies)
+				return false;
+
+			if (playerRelationship == Stance.Neutral && !Info.AllowNeutral)
+				return false;
+
+			if (!c.Info.CaptureTypes.Contains(Info.Type))
+				return false;
+
+			return true;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/LegacyCaptures.cs
+++ b/OpenRA.Mods.RA/LegacyCaptures.cs
@@ -1,0 +1,118 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.RA.Buildings;
+using OpenRA.Mods.RA.Orders;
+using OpenRA.Traits;
+using OpenRA.FileFormats;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("This actor can capture other actors which have the LegacyCapturable: trait.")]
+	class LegacyCapturesInfo : ITraitInfo
+	{
+		[Desc("Types of actors that it can capture, as long as the type also exists in the LegacyCapturable Type: trait.")]
+		public readonly string[] CaptureTypes = { "building" };
+		[Desc("Unit will do damage to the actor instead of capturing it. Unit is destroyed when sabotaging.")]
+		public readonly bool Sabotage = true;
+		[Desc("Only used if Sabotage=true. Sabotage damage expressed as a percentage of enemy health removed.")]
+		public readonly double SabotageHPRemoval = 0.5;
+
+		public object Create(ActorInitializer init) { return new LegacyCaptures(init.self, this); }
+	}
+
+	class LegacyCaptures : IIssueOrder, IResolveOrder, IOrderVoice
+	{
+		public readonly LegacyCapturesInfo Info;
+		readonly Actor self;
+
+		public LegacyCaptures(Actor self, LegacyCapturesInfo info)
+		{
+			this.self = self;
+			Info = info;
+		}
+
+		public IEnumerable<IOrderTargeter> Orders
+		{
+			get
+			{
+				yield return new LegacyCaptureOrderTargeter(CanCapture);
+			}
+		}
+
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		{
+			if (order.OrderID == "LegacyCaptureActor")
+				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+
+			return null;
+		}
+
+		public string VoicePhraseForOrder(Actor self, Order order)
+		{
+			return (order.OrderString == "LegacyCaptureActor") ? "Attack" : null;
+		}
+
+		public void ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString == "LegacyCaptureActor")
+			{
+				self.SetTargetLine(Target.FromOrder(order), Color.Red);
+
+				self.CancelActivity();
+				self.QueueActivity(new Enter(order.TargetActor, new LegacyCaptureActor(Target.FromOrder(order))));
+			}
+		}
+
+		bool CanCapture(Actor target)
+		{
+			var c = target.TraitOrDefault<LegacyCapturable>();
+			return c != null && c.CanBeTargetedBy(self);
+		}
+
+		class LegacyCaptureOrderTargeter : UnitOrderTargeter
+		{
+			readonly Func<Actor, bool> useCaptureCursor;
+
+			public LegacyCaptureOrderTargeter(Func<Actor, bool> useCaptureCursor)
+				: base("LegacyCaptureActor", 6, "enter", true, true)
+			{
+				this.useCaptureCursor = useCaptureCursor;
+			}
+
+			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
+			{
+				if (!base.CanTargetActor(self, target, modifiers, ref cursor)) return false;
+
+				var canTargetActor = useCaptureCursor(target);
+
+				if (canTargetActor)
+				{
+					var c = target.Trait<LegacyCapturable>();
+					var health = target.Trait<Health>();
+					var lowEnoughHealth = health.HP <= c.Info.CaptureThreshold * health.MaxHP;
+
+					cursor = lowEnoughHealth ? "enter" : "capture";
+
+					IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
+					return true;
+				}
+
+				cursor = "enter-blocked";
+				return false;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Missions/Allies02Script.cs
+++ b/OpenRA.Mods.RA/Missions/Allies02Script.cs
@@ -322,7 +322,6 @@ namespace OpenRA.Mods.RA.Missions
 			foreach (var actor in world.Actors.Where(a => a.Owner == allies && a != allies.PlayerActor))
 			{
 				actor.ChangeOwner(allies2);
-				Capturable.ChangeCargoOwner(actor, allies2);
 				if (actor.Info.Name == "proc")
 					actor.QueueActivity(new Transform(actor, "proc") { SkipMakeAnims = true }); // for harv spawn
 				foreach (var c in actor.TraitsImplementing<INotifyCapture>())

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -75,6 +75,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Activities\LegacyCaptureActor.cs" />
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />
     <Compile Include="AI\BaseBuilder.cs" />
     <Compile Include="AI\HackyAI.cs" />
@@ -171,6 +172,7 @@
     <Compile Include="C4Demolition.cs" />
     <Compile Include="Capturable.cs" />
     <Compile Include="CapturableBar.cs" />
+    <Compile Include="LegacyCapturable.cs" />
     <Compile Include="Captures.cs" />
     <Compile Include="Cargo.cs" />
     <Compile Include="CarpetBomb.cs" />
@@ -238,6 +240,7 @@
     <Compile Include="IronCurtainable.cs" />
     <Compile Include="JamsMissiles.cs" />
     <Compile Include="LeavesHusk.cs" />
+    <Compile Include="LegacyCaptures.cs" />
     <Compile Include="LightPaletteRotator.cs" />
     <Compile Include="LimitedAmmo.cs" />
     <Compile Include="Lint\CheckActorReferences.cs" />

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -267,8 +267,7 @@
 	AutoTargetIgnore:
 	ShakeOnDeath:
 	Sellable:
-	Capturable:
-	CapturableBar:
+	LegacyCapturable:
 	DebugMuzzlePositions:
 	Guardable:
 		Range: 3
@@ -287,8 +286,7 @@
 	RenderBuilding:
 	WithBuildingExplosion:
 	-RepairableBuilding:
-	-Capturable:
-	-CapturableBar:
+	-LegacyCapturable:
 	-Sellable:
 	Tooltip:
 		Name: Civilian Building
@@ -307,8 +305,7 @@
 
 ^TechBuilding:
 	Inherits: ^CivBuilding
-	Capturable:
-	CapturableBar:
+	LegacyCapturable:
 	RepairableBuilding:
 	RevealsShroud:
 		Range: 3

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -167,7 +167,7 @@ E6:
 		PipType: Yellow
 	EngineerRepair:
 	RepairsBridges:
-	Captures:
+	LegacyCaptures:
 		CaptureTypes: building, husk
 	-AutoTarget:
 	AttackMove:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -91,9 +91,8 @@ V01:
 	TransformOnCapture:
 		IntoActor: v01.sniper
 		SkipMakeAnims: true
-	Capturable:
+	LegacyCapturable:
 		Type: civilianbuilding
-		CaptureCompleteTime: 0
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
 
@@ -119,7 +118,7 @@ V01.SNIPER:
 		OnExit: v01
 		SkipMakeAnims: true
 		BecomeNeutral: true
-	-Capturable:
+	-LegacyCapturable:
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
 


### PR DESCRIPTION
... capturable traits.

Changes made are:
- Capture classes no longer require the Building trait.
- Removed "change owner to neutral" when capturing, and split the current Capturable logic into two pieces: Capturable and LegacyCapturable.
- RA Engineers use Capturable (RA Sniper uses LegacyCapturable on Church)
- Cnc Engineers use LegacyCapturable

Capturable
- Engineers take 15 seconds to capture buildings, and do so from the outside. Engi and the building will flash while capturing, and the progress bar is shown.

LegacyCapturable
- Engineers will sabotage or enter a building, if it has low enough health, to capture it
- In Cnc, sending two engineers to one building will result in the building being dropped to 50% health, then captured. Neutral buildings require no sabotage (ever).

YAML (Capturable)
- Capture duration (attached to building)
- Destroy engi after cap (attached to engi)

YAML (LegacyCapturable)
- Capture HP threshold (attached to building)
- Sabotage damage (attached to engi)

YAML (Both)
- Capture types=building,vehicle,etc
- AllowAllies/AllowNeutral/AllowEnemies
