### PR TITLE
Production queue - change BuildTimeSpeedUpDivisor

### DIFF
--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -26,10 +26,8 @@ namespace OpenRA.Mods.RA
 		public readonly bool SpeedUp = false;
 		[Desc("Every time another production building of the same queue is", 
 			"contructed, the build times of all actors in the queue", 
-			"are divided by this value.")]
-		public readonly int BuildTimeSpeedUpDivisor = 2;
-		[Desc("You can still build more production buildings", "than this value, but the build time won't increase further.")]
-		public readonly int MaxBuildTimeReductionSteps = 6;
+			"decreased by a percentage of the original time.")]
+		public readonly int[] BuildTimeSpeedReduction = {100,85,75,65,60,55,50};
 
 		public override object Create(ActorInitializer init) { return new ClassicProductionQueue(init.self, this); }
 	}
@@ -108,10 +106,8 @@ namespace OpenRA.Mods.RA
 					.Where(p => p.Trait.Info.Produces.Contains(unit.Traits.Get<BuildableInfo>().Queue))
 						.Where(p => p.Actor.Owner == self.Owner).ToArray();
 
-				var BuildTimeReductionSteps = Math.Min(selfsameBuildings.Count(), Info.MaxBuildTimeReductionSteps);
-
-				for (int i = 1; i < BuildTimeReductionSteps; i++)
-					time /= Info.BuildTimeSpeedUpDivisor;
+				var speedModifier = Math.Min(selfsameBuildings.Count(), Info.BuildTimeSpeedReduction.Length - 1);
+				time = (time * Info.BuildTimeSpeedReduction[speedModifier]) / 100;
 			}
 
 			return time;


### PR DESCRIPTION
This is needed. The current integer parameter was limited - we could never have less than a 50% build speed reduction.

I `grep`ed for mods using this yaml setting and found none.

**Note: This does not enable it for any mods**
- Now is a yaml setting where you can set the decay in %, e.g. 100, 85, 75, 65, etc. So the second production building reduces time to 85% of original time, third 75% of original time, etc.
