### PR TITLE
Fixes Issue #2205 (turret A can hit turret B but not vice-versa)

### DIFF
--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.RA
 		{
 			if( !target.IsValid ) return false;
 			if( target.IsActor )
-				return IsInRange( attackOrigin, range, target.Actor );
+				return IsInRange( attackOrigin, range, target.CenterLocation );
 			else
 				return IsInRange( attackOrigin, range, target.CenterLocation );
 		}

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -226,8 +226,6 @@ namespace OpenRA.Mods.RA
 		public static bool IsInRange(PPos attackOrigin, float range, Target target)
 		{
 			if( !target.IsValid ) return false;
-			if( target.IsActor )
-				return IsInRange( attackOrigin, range, target.CenterLocation );
 			else
 				return IsInRange( attackOrigin, range, target.CenterLocation );
 		}


### PR DESCRIPTION
Fixes issue #2205 that if two turrets/units with the same weapon range are placed at the edge of their range, from certain angles one can hit the other but not vice-versa.

It's quite possible this just works around a deeper-rooted Actor-related issue.
