### PR TITLE
Target generations

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -273,6 +273,7 @@ namespace OpenRA
 				// momentarily remove from world so the ownership queries don't get confused
 				w.Remove(this);
 				Owner = newOwner;
+				Generation++;
 				w.Add(this);
 
 				foreach (var t in this.TraitsImplementing<INotifyOwnerChanged>())

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -72,6 +72,7 @@ namespace OpenRA
 
 		Activity currentActivity;
 		public Group Group;
+		public int Generation;
 
 		internal Actor(World world, string name, TypeDictionary initDict )
 		{

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Traits
 		Player owner;
 		PPos pos;
 		bool valid;
+		int generation;
 
 		public static Target FromActor(Actor a)
 		{
@@ -25,7 +26,8 @@ namespace OpenRA.Traits
 			{
 				actor = a,
 				valid = (a != null),
-				owner = (a != null) ? a.Owner : null
+				owner = (a != null) ? a.Owner : null,
+				generation = a.Generation,
 			};
 		}
 		public static Target FromPos(PPos p) { return new Target { pos = p, valid = true }; }
@@ -39,7 +41,7 @@ namespace OpenRA.Traits
 
 		public static readonly Target None = new Target();
 
-		public bool IsValid { get { return valid && (actor == null || (actor.IsInWorld && !actor.IsDead() && actor.Owner == owner)); } }
+		public bool IsValid { get { return valid && (actor == null || (actor.IsInWorld && !actor.IsDead() && actor.Owner == owner && actor.Generation == generation)); } }
 		public PPos PxPosition { get { return IsActor ? actor.Trait<IHasLocation>().PxPosition : pos; } }
 		public PPos CenterLocation { get { return PxPosition; } }
 

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -15,7 +15,6 @@ namespace OpenRA.Traits
 		public static Target[] NoTargets = {};
 
 		Actor actor;
-		Player owner;
 		PPos pos;
 		bool valid;
 		int generation;
@@ -26,7 +25,6 @@ namespace OpenRA.Traits
 			{
 				actor = a,
 				valid = (a != null),
-				owner = (a != null) ? a.Owner : null,
 				generation = a.Generation,
 			};
 		}
@@ -41,7 +39,7 @@ namespace OpenRA.Traits
 
 		public static readonly Target None = new Target();
 
-		public bool IsValid { get { return valid && (actor == null || (actor.IsInWorld && !actor.IsDead() && actor.Owner == owner && actor.Generation == generation)); } }
+		public bool IsValid { get { return valid && (actor == null || (actor.IsInWorld && !actor.IsDead() && actor.Generation == generation)); } }
 		public PPos PxPosition { get { return IsActor ? actor.Trait<IHasLocation>().PxPosition : pos; } }
 		public PPos CenterLocation { get { return PxPosition; } }
 

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.RA.Activities
 			Sound.Play("chrono2.aud", destination.ToPPos());
 
 			self.Trait<ITeleportable>().SetPosition(self, destination);
+			self.Generation++;
 
 			if (killCargo && self.HasTrait<Cargo>())
 			{
@@ -66,6 +67,7 @@ namespace OpenRA.Mods.RA.Activities
 		public override Activity Tick(Actor self)
 		{
 			self.Trait<ITeleportable>().SetPosition(self, destination);
+			self.Generation++;
 			return NextActivity;
 		}
 	}


### PR DESCRIPTION
This series reworks how we invalidate targets on ownership change, and adds new invalidation when the targeted unit is chronoshifted.
