### PR TITLE
Made ore mines indestructible

### DIFF
--- a/mods/ra/rules/trees.yaml
+++ b/mods/ra/rules/trees.yaml
@@ -182,37 +182,37 @@ BOXES01:
 BOXES02:
 	Inherits: ^Tree
 	Tooltip:
-		Name: Boxes	
+		Name: Boxes
 
 BOXES03:
 	Inherits: ^Tree
 	Tooltip:
-		Name: Boxes	
+		Name: Boxes
 
 BOXES04:
 	Inherits: ^Tree
 	Tooltip:
-		Name: Boxes	
+		Name: Boxes
 
 BOXES05:
 	Inherits: ^Tree
 	Tooltip:
-		Name: Boxes	
+		Name: Boxes
 
 BOXES06:
 	Inherits: ^Tree
 	Tooltip:
-		Name: Boxes	
+		Name: Boxes
 
 BOXES07:
 	Inherits: ^Tree
 	Tooltip:
-		Name: Boxes	
+		Name: Boxes
 
 BOXES08:
 	Inherits: ^Tree
 	Tooltip:
-		Name: Boxes	
+		Name: Boxes
 
 BOXES09:
 	Inherits: ^Tree

--- a/mods/ra/rules/trees.yaml
+++ b/mods/ra/rules/trees.yaml
@@ -155,12 +155,22 @@ TC05:
 		ExcludeTilesets: DESERT
 
 MINE:
-	Inherits: ^Tree
 	Tooltip:
 		Name: Ore Mine
-	SeedsResource:
+	RenderBuilding:
+		Palette: terrain
+	Building:
+		Footprint: x
+		Dimensions: 1,1
+	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Ore
+	EditorAppearance:
+		RelativeToTopLeft: yes
+		UseTerrainPalette: true
+	AutoTargetIgnore:
+	BodyOrientation:
+	SeedsResource:
 	BelowUnits:
 
 BOXES01:


### PR DESCRIPTION
This was a game-breaking problem because it can cause no cash stale mates and that is boring. I consider this a regression/bug, but in fact the community discussed whether this is a feature which provides valid tactics or can be exploited too easily http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=16286 and our wise crowd decided for invulnerable ore mines.
