### PR TITLE
interim fix for turreted units moving in too close to target

### DIFF
--- a/OpenRA.Mods.RA/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.RA/Attack/AttackTurreted.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.RA
 				if (self.IsDisabled()) return this;
 
 				var attack = self.Trait<AttackTurreted>();
-				const int RangeTolerance = 1;	/* how far inside our maximum range we should try to sit */
+				const int RangeTolerance = 0;	/* how far inside our maximum range we should try to sit */
 				var weapon = attack.ChooseArmamentForTarget(target);
 
 				if (weapon != null)

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -383,7 +383,7 @@ Grenade:
 
 25mm:
 	ROF: 13
-	Range: 4
+	Range: 5
 	Report: CANNON2
 	Projectile: Bullet
 		Speed: 50
@@ -403,7 +403,7 @@ Grenade:
 
 90mm:
 	ROF: 50
-	Range: 4.75
+	Range: 5.75
 	Report: CANNON1
 	Projectile: Bullet
 		Speed: 40
@@ -423,7 +423,7 @@ Grenade:
 
 105mm:
 	ROF: 70
-	Range: 4.75
+	Range: 5.75
 	Report: CANNON1
 	Burst: 2
 	BurstDelay: 4
@@ -445,7 +445,7 @@ Grenade:
 
 120mm:
 	ROF: 90
-	Range: 4.75
+	Range: 5.75
 	Report: CANNON1
 	Burst: 2
 	Projectile: Bullet
@@ -543,7 +543,7 @@ MammothTusk:
 
 M60mg:
 	ROF: 30
-	Range: 4
+	Range: 5
 	Report: PILLBOX1
 	Burst: 5
 	Projectile: Bullet


### PR DESCRIPTION
Sets RangeTolerance to 0 as an interim solution.
Increases weapon range of jeep and all 4 tanks with cannons in RA mod by 1 cell.

This reduces the annoying behavior of turreted units moving close to their target, exposing themselves to friendly fire and reducing their effective attack range. (issue #2104)

I'm aware this might make it more difficult to attack fleeing targets, but that is already the case for none-turreted units anyway. I didn't notice much of a problem during testing, but more testing from others may be needed to verify this.

If disabling the RangeTolerance is considered too problematic, maybe settle for only increasing the weapon range of the turreted units for now as a little band aid.
