### PR TITLE
fix sniper hotkey conflict AGAIN

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -454,7 +454,7 @@ SNIPER:
 		BuildPaletteOrder: 80
 		Owner: soviet
 		Prerequisites: dome
-		Hotkey: s
+		Hotkey: h
 	Selectable:
 		Bounds: 12,17,0,-6
 	Mobile:


### PR DESCRIPTION
You can't use `s`, it's a combat hotkey.
