### PR TITLE
Fix shroud glitches once and for all

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -66,8 +66,6 @@ namespace OpenRA
 			}
 		}
 
-		public Shroud.ActorVisibility Sight;
-
 		[Sync] public Player Owner;
 
 		Activity currentActivity;
@@ -107,15 +105,6 @@ namespace OpenRA
 				return TraitsImplementing<IAutoSelectionSize>().Select(x => x.SelectionSize(this)).FirstOrDefault();
 			});
 
-			if (this.HasTrait<RevealsShroud>())
-			{
-				Sight = new Shroud.ActorVisibility
-				{
-					range = this.Trait<RevealsShroud>().RevealRange,
-					vis = Shroud.GetVisOrigins(this).ToArray()
-				};
-			}
-
 			ApplyIRender = (x, wr) => x.Render(this, wr);
 			ApplyRenderModifier = (m, p, wr) => p.ModifyRender(this, wr, m);
 
@@ -129,11 +118,6 @@ namespace OpenRA
 			ExtendedBounds.Invalidate();
 
 			currentActivity = Traits.Util.RunActivity(this, currentActivity);
-		}
-
-		public void UpdateSight()
-		{
-			Sight.vis = Shroud.GetVisOrigins(this).ToArray();
 		}
 
 		public bool IsIdle

--- a/OpenRA.Game/Traits/CreatesShroud.cs
+++ b/OpenRA.Game/Traits/CreatesShroud.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Traits
 	public class CreatesShroud : ITick, ISync
 	{
 		CreatesShroudInfo Info;
-		[Sync] CPos previousLocation;
-		Shroud.ActorVisibility v;
+		[Sync] CPos cachedLocation;
+		[Sync] bool cachedDisabled;
 
 		public CreatesShroud(CreatesShroudInfo info)
 		{
@@ -31,29 +31,18 @@ namespace OpenRA.Traits
 
 		public void Tick(Actor self)
 		{
-	    	// TODO: don't tick all the time.
-			if (self.Owner == null)
-				return;
-
-			var shrouds = self.World.ActorsWithTrait<Shroud>().Select(s => s.Actor.Owner.Shroud);
-			if (previousLocation != self.Location && v != null)
+			var disabled = self.TraitsImplementing<IDisable>().Any(d => d.Disabled);
+			if (cachedLocation != self.Location || cachedDisabled != disabled)
 			{
-				previousLocation = self.Location;
+				cachedLocation = self.Location;
+				cachedDisabled = disabled;
 
-				foreach (var shroud in shrouds)
-					shroud.UnhideActor(self, v, Info.Range);
+				var shroud = self.World.Players.Select(p => p.Shroud);
+				foreach (var s in shroud)
+					s.UpdateShroudGeneration(self);
 			}
-
-			if (!self.TraitsImplementing<IDisable>().Any(d => d.Disabled))
-				foreach (var shroud in shrouds)
-					shroud.HideActor(self, Info.Range);
-			else
-				foreach (var shroud in shrouds)
-					shroud.UnhideActor(self, v, Info.Range);
-
-			v = new Shroud.ActorVisibility {
-				vis = Shroud.GetVisOrigins(self).ToArray()
-			};
 		}
+
+		public int Range { get { return cachedDisabled ? 0 : Info.Range; } }
 	}
 }

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -8,6 +8,8 @@
  */
 #endregion
 
+using System.Linq;
+
 namespace OpenRA.Traits
 {
 	public class RevealsShroudInfo : ITraitInfo
@@ -19,7 +21,7 @@ namespace OpenRA.Traits
 	public class RevealsShroud : ITick, ISync
 	{
 		RevealsShroudInfo Info;
-		[Sync] CPos previousLocation;
+		[Sync] CPos cachedLocation;
 
 		public RevealsShroud(RevealsShroudInfo info)
 		{
@@ -28,26 +30,15 @@ namespace OpenRA.Traits
 
 		public void Tick(Actor self)
 		{
-			// TODO: don't tick all the time.
-			World w = self.World;
-			if(self.Owner == null) return;
-			
-			if (previousLocation != self.Location)
+			if (cachedLocation != self.Location)
 			{
-				previousLocation = self.Location;
-				var actors = w.ActorsWithTrait<Shroud>();
+				cachedLocation = self.Location;
 
-				foreach( var s in actors )
-					s.Actor.Owner.Shroud.RemoveActor(self);
-					
-				self.UpdateSight();
-					
-				foreach( var s in actors )
-					s.Actor.Owner.Shroud.AddActor(self);
-				
+				foreach (var s in self.World.Players.Select(p => p.Shroud))
+					s.UpdateVisibility(self);
 			}
 		}
 
-		public int RevealRange { get { return Info.Range; } }
+		public int Range { get { return Info.Range; } }
 	}
 }

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -135,6 +135,10 @@ namespace OpenRA.Traits
 
 		public void UpdateVisibility(Actor a)
 		{
+			// Actors outside the world don't have any vis
+			if (!a.IsInWorld)
+				return;
+
 			RemoveVisibility(a);
 			AddVisibility(a);
 		}

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -113,6 +113,9 @@ namespace OpenRA.Traits
 				explored[c.X, c.Y] = true;
 			}
 
+			if (visibility.ContainsKey(a))
+				throw new InvalidOperationException("Attempting to add duplicate actor visibility");
+
 			visibility[a] = visible;
 			Invalidate();
 		}
@@ -146,6 +149,9 @@ namespace OpenRA.Traits
 				.Distinct().ToArray();
 			foreach (var c in shrouded)
 				generatedShroudCount[c.X, c.Y]++;
+
+			if (generation.ContainsKey(a))
+				throw new InvalidOperationException("Attempting to add duplicate shroud generation");
 
 			generation[a] = shrouded;
 			Invalidate();

--- a/OpenRA.Mods.RA/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.RA/InfiltrateForExploration.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.RA
 	{
 		public void OnInfiltrate(Actor self, Actor infiltrator)
 		{
-			infiltrator.Owner.Shroud.MergeShroud(self.Owner.Shroud);
+			// Steal and reset the owners exploration
+			infiltrator.Owner.Shroud.Explore(self.Owner.Shroud);
 			if (!self.Owner.HasFogVisibility())
 			    self.Owner.Shroud.ResetExploration();
 		}

--- a/OpenRA.Mods.RA/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.RA/Player/PlayerStatistics.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA
 			var total = (double)world.Map.Bounds.Width * world.Map.Bounds.Height;
 			MapControl = world.Actors
 				.Where(a => !a.IsDead() && a.IsInWorld && a.Owner == player && a.HasTrait<RevealsShroud>())
-				.SelectMany(a => world.FindTilesInCircle(a.Location, a.Trait<RevealsShroud>().RevealRange.Clamp(0, 50)))
+				.SelectMany(a => world.FindTilesInCircle(a.Location, a.Trait<RevealsShroud>().Range.Clamp(0, 50)))
 				.Distinct()
 				.Count() / total;
 		}


### PR DESCRIPTION
This removes the (now) unnecessary indirection introduced during the PPS transition, and restores Shroud's robustness against crazy trait code. Fixes the vis glitches with cargo, and in theory everywhere else (but these were untested).
