### PR TITLE
Set the default buffer size

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -198,8 +198,8 @@ namespace OpenRA.Server
 			{
 				newConn.socket.Blocking = false;
 				newConn.socket.NoDelay = true;
-				newConn.socket.SendBufferSize = 65536;
-				newConn.socket.ReceiveBufferSize = 65536;
+				newConn.socket.SendBufferSize = 524288;
+				newConn.socket.ReceiveBufferSize = 524288;
 
 				// assign the player number.
 				newConn.PlayerIndex = ChooseFreePlayerIndex();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -198,6 +198,8 @@ namespace OpenRA.Server
 			{
 				newConn.socket.Blocking = false;
 				newConn.socket.NoDelay = true;
+				newConn.socket.SendBufferSize = 65536;
+				newConn.socket.ReceiveBufferSize = 65536;
 
 				// assign the player number.
 				newConn.PlayerIndex = ChooseFreePlayerIndex();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -97,9 +97,9 @@ namespace OpenRA.Server
 				UPnP.ForwardPort();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
-				ServerTraits.Add( modData.ObjectCreator.CreateObject<ServerTrait>(trait) );
+				ServerTraits.Add(modData.ObjectCreator.CreateObject<ServerTrait>(trait));
 
-			lobbyInfo = new Session( mods );
+			lobbyInfo = new Session(mods);
 			lobbyInfo.GlobalSettings.RandomSeed = randomSeed;
 			lobbyInfo.GlobalSettings.Map = settings.Map;
 			lobbyInfo.GlobalSettings.ServerName = settings.Name;


### PR DESCRIPTION
to workaround #3455 because .NET/Mono uses either too few 8192 bytes by default or something set by the OS which seems to be problematic for some Windows users with weird network settings.
