### PR TITLE
AutoTarget unarmed buildings again to help AI crush it's enemy

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -264,7 +264,6 @@
 		Notification: BuildingLost
 	EditorAppearance:
 		RelativeToTopLeft: yes
-	AutoTargetIgnore:
 	ShakeOnDeath:
 	Sellable:
 	LegacyCapturable:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -526,7 +526,6 @@ GUN:
 		LocalOffset: -71,0,85
 	AttackTurreted:
 	AutoTarget:
-	-AutoTargetIgnore:
 	-RenderBuilding:
 	-DeadBuildingState:
 	RenderRangeCircle:
@@ -608,7 +607,6 @@ OBLI:
 	AutoTarget:
 	RenderBuilding:
 		QuantizedFacings: 8
-	-AutoTargetIgnore:
 	-RenderBuilding:
 	RenderRangeCircle:
 	-EmitInfantryOnSell:
@@ -643,7 +641,6 @@ GTWR:
 	RenderBuilding:
 		QuantizedFacings: 8
 	AutoTarget:
-	-AutoTargetIgnore:
 	DetectCloaked:
 		Range: 5
 	RenderDetectionCircle:
@@ -687,7 +684,6 @@ ATWR:
 	AutoTarget:
 	RenderBuilding:
 		QuantizedFacings: 8
-	-AutoTargetIgnore:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 6

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -219,7 +219,6 @@
 		Notification: BuildingLost
 	EditorAppearance:
 		RelativeToTopLeft: yes
-	AutoTargetIgnore:
 	ShakeOnDeath:
 	ProximityCaptor:
 		Types:Building

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -403,7 +403,6 @@ GUNTOWER:
 	RevealsShroud:
 		Range: 8
 	RenderRangeCircle:
-	-AutoTargetIgnore:
 	RenderBuilding:
 		HasMakeAnimation: false
 		Image: guntowera
@@ -461,7 +460,6 @@ ROCKETTOWER:
 	RevealsShroud:
 		Range: 10
 	RenderRangeCircle:
-	-AutoTargetIgnore:
 	RenderBuilding:
 		HasMakeAnimation: false
 		Image: rockettowera

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -233,7 +233,6 @@
 	DebugMuzzlePositions:
 	Guardable:
 		Range: 3
-	AutoTargetIgnore:
 	BodyOrientation:
 
 ^Wall:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -299,7 +299,6 @@ TSLA:
 	RenderRangeCircle:
 	-AcceptsSupplies:
 	DrawLineToTarget:
-	-AutoTargetIgnore:
 
 AGUN:
 	Inherits: ^Building
@@ -343,7 +342,6 @@ AGUN:
 		RangeCircleType: aa
 	-AcceptsSupplies:
 	DrawLineToTarget:
-	-AutoTargetIgnore:
 
 DOME:
 	RequiresPower:
@@ -464,7 +462,6 @@ PBOX.E1:
 	WithMuzzleFlash:
 	Cargo:
 		InitialUnits: e1
-	-AutoTargetIgnore:
 
 #PBOX.E2:
 #	Inherits: PBOX
@@ -485,7 +482,6 @@ PBOX.E3:
 		Weapon: Dragon
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 PBOX.E4:
 	Inherits: PBOX
@@ -499,7 +495,6 @@ PBOX.E4:
 		Weapon: Flamer
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 PBOX.E7:
 	Inherits: PBOX
@@ -513,7 +508,6 @@ PBOX.E7:
 		Weapon: Colt45
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 PBOX.SHOK:
 	Inherits: PBOX
@@ -527,7 +521,6 @@ PBOX.SHOK:
 		Weapon: PortaTesla
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 PBOX.SNIPER:
 	Inherits: PBOX
@@ -541,7 +534,6 @@ PBOX.SNIPER:
 		Weapon: Sniper
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 HBOX:
 	Inherits: ^Building
@@ -635,7 +627,6 @@ HBOX.E1:
 	WithMuzzleFlash:
 	Cargo:
 		InitialUnits: e1
-	-AutoTargetIgnore:
 
 #HBOX.E2:
 #	Inherits: HBOX
@@ -656,7 +647,6 @@ HBOX.E3:
 		Weapon: Dragon
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 HBOX.E4:
 	Inherits: HBOX
@@ -670,7 +660,6 @@ HBOX.E4:
 		Weapon: Flamer
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 HBOX.E7:
 	Inherits: HBOX
@@ -684,7 +673,6 @@ HBOX.E7:
 		Weapon: Colt45
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 HBOX.SHOK:
 	Inherits: HBOX
@@ -698,7 +686,6 @@ HBOX.SHOK:
 		Weapon: PortaTesla
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 HBOX.SNIPER:
 	Inherits: HBOX
@@ -712,7 +699,6 @@ HBOX.SNIPER:
 		Weapon: Sniper
 		LocalOffset: 469,0,0
 	AttackTurreted:
-	-AutoTargetIgnore:
 
 GUN:
 	Inherits: ^Building
@@ -749,7 +735,6 @@ GUN:
 	RenderRangeCircle:
 	-AcceptsSupplies:
 	DrawLineToTarget:
-	-AutoTargetIgnore:
 
 FTUR:
 	Inherits: ^Building
@@ -787,7 +772,6 @@ FTUR:
 	RenderRangeCircle:
 	-AcceptsSupplies:
 	DrawLineToTarget:
-	-AutoTargetIgnore:
 
 SAM:
 	Inherits: ^Building
@@ -830,7 +814,6 @@ SAM:
 	CanPowerDown:
 	-AcceptsSupplies:
 	DrawLineToTarget:
-	-AutoTargetIgnore:
 
 ATEK:
 	Inherits: ^Building


### PR DESCRIPTION
This reverts #3337 for ra and the changes introduced by @psydev for d2k/cnc in that regard. The AI needs AutoTarget because it solely uses AttackMove to fight it's enemies.
