### PR TITLE
Show the repair indicator only for friends

### DIFF
--- a/OpenRA.Mods.RA/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/RepairIndicator.cs
@@ -36,7 +36,8 @@ namespace OpenRA.Mods.RA.Effects
 		public void Tick(World world)
 		{
 			if (!building.IsInWorld || building.IsDead() ||
-				rb.Repairer == null || rb.Repairer != player)
+				rb.Repairer == null || rb.Repairer != player
+			    || !rb.Repairer.IsAlliedWith(player.World.RenderPlayer))
 				world.AddFrameEndTask(w => w.Remove(this));
 
 			anim.Tick();


### PR DESCRIPTION
fixes #3502 which reveals enemy stealthed structures otherwise.
