### PR TITLE
Added EditorConfig Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+; Top-most http://editorconfig.org/ file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+; 4-column tab indentation
+[*.cs]
+indent_style = tab
+indent_size = 4
+
+; 4-column tab indentation
+[*.yaml]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
http://editorconfig.org sounds like a good idea. We can then point newbies to the Visual Studio plugin download page when they contribute new code and can't find the button in the feature creeping IDE settings. This also helps for cases like #2310 because we don't follow the yaml standard by indenting with tabs. #3499
