### PR TITLE
restrict packet size to 4K in server

### DIFF
--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Server
 		public int ExpectLength = 8;
 		public int Frame = 0;
 		public int MostRecentFrame = 0;
+		public const int MaxOrderLength = 4096;
 
 		/* client data */
 		public int PlayerIndex;
@@ -65,7 +66,7 @@ namespace OpenRA.Server
 					if (e.SocketErrorCode == SocketError.WouldBlock) break;
 
 					server.DropClient(this);
-					Log.Write("server", "Dropping client {0} because reading the data failed: {1}", this.PlayerIndex.ToString(), e);
+					Log.Write("server", "Dropping client {0} because reading the data failed: {1}", PlayerIndex, e);
 					return false;
 				}
 			}
@@ -86,6 +87,13 @@ namespace OpenRA.Server
 								ExpectLength = BitConverter.ToInt32(bytes, 0) - 4;
 								Frame = BitConverter.ToInt32(bytes, 4);
 								State = ReceiveState.Data;
+
+								if (ExpectLength < 0 || ExpectLength > MaxOrderLength)
+								{
+									server.DropClient(this);
+									Log.Write("server", "Dropping client {0} for excessive order length = {1}", PlayerIndex, ExpectLength);
+									return;
+								}
 							} break;
 
 						case ReceiveState.Data:


### PR DESCRIPTION
- Sending a negative length no longer crashes the server
- Sending very large lengths can't force us to buffer stupid amounts of data

The offending client just gets kicked if they do this.
