### PR TITLE
Remove unused interface INotifyOtherCaptured

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -73,7 +73,6 @@ namespace OpenRA.Traits
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
 	public interface INotifyOwnerChanged { void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner); }
 	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner); }
-	public interface INotifyOtherCaptured { void OnActorCaptured(Actor self, Actor captured, Actor captor, Player oldOwner, Player newOwner); }
 	public interface INotifyHarvest { void Harvested(Actor self, ResourceType resource); }
 
 	public interface IAcceptInfiltrator { void OnInfiltrate(Actor self, Actor infiltrator); }

--- a/OpenRA.Mods.RA/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.RA/Activities/CaptureActor.cs
@@ -68,9 +68,6 @@ namespace OpenRA.Mods.RA.Activities
 						foreach (var t in target.Actor.TraitsImplementing<INotifyCapture>())
 							t.OnCapture(target.Actor, self, oldOwner, self.Owner);
 
-						foreach (var t in self.World.ActorsWithTrait<INotifyOtherCaptured>())
-							t.Trait.OnActorCaptured(t.Actor, target.Actor, self, oldOwner, self.Owner);
-
 						capturable.EndCapture();
 
 						if (capturesInfo != null && capturesInfo.ConsumeActor)

--- a/OpenRA.Mods.RA/Activities/LegacyCaptureActor.cs
+++ b/OpenRA.Mods.RA/Activities/LegacyCaptureActor.cs
@@ -49,9 +49,6 @@ namespace OpenRA.Mods.RA.Activities
 					foreach (var t in target.Actor.TraitsImplementing<INotifyCapture>())
 						t.OnCapture(target.Actor, self, oldOwner, self.Owner);
 
-					foreach (var t in target.Actor.World.ActorsWithTrait<INotifyOtherCaptured>())
-						t.Trait.OnActorCaptured(t.Actor, target.Actor, self, oldOwner, self.Owner);
-
 					if (b != null && b.Locked)
 						b.Unlock();
 				}


### PR DESCRIPTION
Nothing implements this interface. Also I can't even see why it existed in the first place
