### PR TITLE
Add support for TS/RA2 split-shadows.

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Graphics
 
 		public IEnumerable<IRenderable> Render(WPos pos, int zOffset, PaletteReference palette, float scale)
 		{
-			yield return new SpriteRenderable(Image, pos, zOffset, palette, scale);
+			yield return new SpriteRenderable(Image, pos, CurrentSequence.ZOffset + zOffset, palette, scale);
 		}
 
 		public IEnumerable<IRenderable> Render(WPos pos, PaletteReference palette)

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 
 namespace OpenRA.Graphics
 {
@@ -42,6 +43,16 @@ namespace OpenRA.Graphics
 					? CurrentSequence.GetSprite(CurrentSequence.End - frame - 1, facingFunc())
 					: CurrentSequence.GetSprite(frame, facingFunc());
 			}
+		}
+
+		public IEnumerable<IRenderable> Render(WPos pos, int zOffset, PaletteReference palette, float scale)
+		{
+			yield return new SpriteRenderable(Image, pos, zOffset, palette, scale);
+		}
+
+		public IEnumerable<IRenderable> Render(WPos pos, PaletteReference palette)
+		{
+			return Render(pos, 0, palette, 1f);
 		}
 
 		public void Play(string sequenceName)

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Graphics
 			get
 			{
 				return backwards
-					? CurrentSequence.GetSprite(CurrentSequence.End - frame - 1, facingFunc())
+					? CurrentSequence.GetSprite(CurrentSequence.Start + CurrentSequence.Length - frame - 1, facingFunc())
 					: CurrentSequence.GetSprite(frame, facingFunc());
 			}
 		}

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -35,18 +35,17 @@ namespace OpenRA.Graphics
 			this.facingFunc = facingFunc;
 		}
 
-		public Sprite Image
-		{
-			get
-			{
-				return backwards
-					? CurrentSequence.GetSprite(CurrentSequence.Start + CurrentSequence.Length - frame - 1, facingFunc())
-					: CurrentSequence.GetSprite(frame, facingFunc());
-			}
-		}
+		int CurrentFrame { get { return backwards ? CurrentSequence.Start + CurrentSequence.Length - frame - 1 : frame; } }
+		public Sprite Image { get { return CurrentSequence.GetSprite(CurrentFrame, facingFunc()); } }
 
 		public IEnumerable<IRenderable> Render(WPos pos, int zOffset, PaletteReference palette, float scale)
 		{
+			if (CurrentSequence.ShadowStart >= 0)
+			{
+				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
+				yield return new SpriteRenderable(shadow, pos, CurrentSequence.ShadowZOffset + zOffset, palette, scale);
+			}
+
 			yield return new SpriteRenderable(Image, pos, CurrentSequence.ZOffset + zOffset, palette, scale);
 		}
 

--- a/OpenRA.Game/Graphics/AnimationWithOffset.cs
+++ b/OpenRA.Game/Graphics/AnimationWithOffset.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Traits;
 
 namespace OpenRA.Graphics
@@ -34,19 +35,14 @@ namespace OpenRA.Graphics
 			this.ZOffset = zOffset;
 		}
 
-		public IRenderable Image(Actor self, WorldRenderer wr, PaletteReference pal)
-		{
-			return Image(self, wr, pal, 1f);
-		}
-
-		public IRenderable Image(Actor self, WorldRenderer wr, PaletteReference pal, float scale)
+		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr, PaletteReference pal, float scale)
 		{
 			var p = self.CenterPosition;
 			if (OffsetFunc != null)
 				p += OffsetFunc();
 
 			var z = (ZOffset != null) ? ZOffset(p) : 0;
-			return new SpriteRenderable(Animation.Image, p, z, pal, scale);
+			return Animation.Render(p, z, pal, scale);
 		}
 
 		public static implicit operator AnimationWithOffset(Animation a)

--- a/OpenRA.Game/Graphics/Renderable.cs
+++ b/OpenRA.Game/Graphics/Renderable.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace OpenRA.Graphics
 {
@@ -47,6 +48,8 @@ namespace OpenRA.Graphics
 
 	public struct SpriteRenderable : IRenderable
 	{
+		public static readonly IEnumerable<IRenderable> None = new IRenderable[0].AsEnumerable();
+
 		readonly Sprite sprite;
 		readonly WPos pos;
 		readonly int zOffset;

--- a/OpenRA.Game/Graphics/Sequence.cs
+++ b/OpenRA.Game/Graphics/Sequence.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Graphics
 		public int Stride { get { return stride; } }
 		public int Facings { get { return facings; } }
 		public int Tick { get { return tick; } }
+		public readonly int ZOffset;
 
 		public Sequence(string unit, string name, MiniYaml info)
 		{
@@ -75,6 +76,9 @@ namespace OpenRA.Graphics
 
 			if (d.ContainsKey("Transpose"))
 			    transpose = bool.Parse(d["Transpose"].Value);
+
+			if (d.ContainsKey("ZOffset"))
+				ZOffset = int.Parse(d["ZOffset"].Value);
 
 			if (length > stride)
 				throw new InvalidOperationException(

--- a/OpenRA.Game/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Game/Traits/Render/RenderSimple.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Traits
 			var anim = new Animation(RenderSimple.GetImage(ai), () => 0);
 			anim.PlayRepeating("idle");
 
-			yield return new SpriteRenderable(anim.Image, WPos.Zero, 0, pr, 1f);
+			return anim.Render(WPos.Zero, pr);
 		}
 	}
 

--- a/OpenRA.Game/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Game/Traits/Render/RenderSprites.cs
@@ -90,8 +90,13 @@ namespace OpenRA.Traits
 			}
 
 			foreach (var a in anims.Values)
-				if (a.DisableFunc == null || !a.DisableFunc())
-					yield return a.Image(self, wr, palette, Info.Scale);
+			{
+				if (a.DisableFunc != null && a.DisableFunc())
+					continue;
+
+				foreach (var r in a.Render(self, wr, palette, Info.Scale))
+					yield return r;
+			}
 		}
 
 		public virtual void Tick(Actor self)

--- a/OpenRA.Mods.Cnc/Effects/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Effects/IonCannon.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return anim.Render(target.CenterPosition, 1, wr.Palette("effect"), 1.0f);
+			return anim.Render(target.CenterPosition, wr.Palette("effect"));
 		}
 
 		void Finish(World world)

--- a/OpenRA.Mods.Cnc/Effects/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Effects/IonCannon.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			yield return new SpriteRenderable(anim.Image, target.CenterPosition, 1, wr.Palette("effect"), 1.0f);
+			return anim.Render(target.CenterPosition, 1, wr.Palette("effect"), 1.0f);
 		}
 
 		void Finish(World world)

--- a/OpenRA.Mods.RA/Cloak.cs
+++ b/OpenRA.Mods.RA/Cloak.cs
@@ -66,8 +66,6 @@ namespace OpenRA.Mods.RA
 			if (!canCloak) Uncloak();
 		}
 
-		static readonly IRenderable[] Nothing = { };
-
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
 			if (remainingTime > 0)
@@ -79,7 +77,7 @@ namespace OpenRA.Mods.RA
 				else
 					return r.Select(a => a.WithPalette(wr.Palette(info.Palette)));
 			else
-				return Nothing;
+				return SpriteRenderable.None;
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.RA/Effects/Corpse.cs
+++ b/OpenRA.Mods.RA/Effects/Corpse.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			yield return new SpriteRenderable(Anim.Image, Pos, 0, wr.Palette(PaletteName), 1f);
+			return Anim.Render(Pos, wr.Palette(PaletteName));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/CrateEffect.cs
+++ b/OpenRA.Mods.RA/Effects/CrateEffect.cs
@@ -34,9 +34,10 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (a.IsInWorld)
-				yield return new SpriteRenderable(anim.Image,
-					a.CenterPosition, 0, wr.Palette("effect"), 1f);
+			if (!a.IsInWorld)
+				return SpriteRenderable.None;
+
+			return anim.Render(a.CenterPosition, wr.Palette("effect"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/Explosion.cs
+++ b/OpenRA.Mods.RA/Effects/Explosion.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			yield return new SpriteRenderable(anim.Image, pos, 0, wr.Palette("effect"), 1f);
+			return anim.Render(pos, wr.Palette("effect"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -80,10 +80,10 @@ namespace OpenRA.Mods.RA.Effects
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
 			if (!show || self.Destroyed)
-				yield break;
+				return SpriteRenderable.None;
 
 			var palette = wr.Palette(info.IndicatorPalettePrefix+self.Owner.InternalName);
-			yield return new SpriteRenderable(anim.Image, self.CenterPosition, 0, palette, 1f);
+			return anim.Render(self.CenterPosition, palette);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/GpsSatellite.cs
+++ b/OpenRA.Mods.RA/Effects/GpsSatellite.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			yield return new SpriteRenderable(Anim.Image, Pos, 0, wr.Palette("effect"), 1f);
+			return Anim.Render(Pos, wr.Palette("effect"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/NukeLaunch.cs
+++ b/OpenRA.Mods.RA/Effects/NukeLaunch.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			yield return new SpriteRenderable(anim.Image, pos, 0, wr.Palette("effect"), 1f);
+			return anim.Render(pos, wr.Palette("effect"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/Parachute.cs
+++ b/OpenRA.Mods.RA/Effects/Parachute.cs
@@ -76,7 +76,8 @@ namespace OpenRA.Mods.RA.Effects
 				yield return c.WithPos(pos);
 			}
 
-			yield return new SpriteRenderable(paraAnim.Image, pos + parachuteOffset, 1, rc.First().Palette, 1f);
+			foreach (var r in paraAnim.Render(pos + parachuteOffset, 1, rc.First().Palette, 1f))
+				yield return r;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/PowerdownIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/PowerdownIndicator.cs
@@ -36,9 +36,10 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (!a.Destroyed && a.Owner.IsAlliedWith(a.World.RenderPlayer))
-				yield return new SpriteRenderable(anim.Image, a.CenterPosition, 0,
-					wr.Palette("chrome"), 1f);
+			if (a.Destroyed || a.Owner.IsAlliedWith(a.World.RenderPlayer))
+				return SpriteRenderable.None;
+
+			return anim.Render(a.CenterPosition, wr.Palette("chrome"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/RallyPoint.cs
+++ b/OpenRA.Mods.RA/Effects/RallyPoint.cs
@@ -50,14 +50,15 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (building.IsInWorld && building.Owner == building.World.LocalPlayer
-				&& building.World.Selection.Actors.Contains(building))
-			{
-				var pos = cachedLocation.CenterPosition;
-				var palette = wr.Palette(palettePrefix+building.Owner.InternalName);
-				yield return new SpriteRenderable(circles.Image, pos, 0, palette, 1f);
-				yield return new SpriteRenderable(flag.Image, pos, 0, palette, 1f);
-			}
+			if (building.Owner != building.World.LocalPlayer)
+				return SpriteRenderable.None;
+
+			if (!building.IsInWorld || !building.World.Selection.Actors.Contains(building))
+				return SpriteRenderable.None;
+
+			var pos = cachedLocation.CenterPosition;
+			var palette = wr.Palette(palettePrefix+building.Owner.InternalName);
+			return circles.Render(pos, palette).Concat(flag.Render(pos, palette));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/RepairIndicator.cs
@@ -44,11 +44,11 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (!building.Destroyed)
-			{
-				yield return new SpriteRenderable(anim.Image, building.CenterPosition, 0,
-					wr.Palette(palettePrefix+player.InternalName), 1f);
-			}
+			if (building.Destroyed)
+				return SpriteRenderable.None;
+
+			return anim.Render(building.CenterPosition,
+					wr.Palette(palettePrefix+player.InternalName));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/SatelliteLaunch.cs
+++ b/OpenRA.Mods.RA/Effects/SatelliteLaunch.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			yield return new SpriteRenderable(doors.Image, pos, 0, wr.Palette("effect"), 1f);
+			return doors.Render(pos, wr.Palette("effect"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/Smoke.cs
+++ b/OpenRA.Mods.RA/Effects/Smoke.cs
@@ -28,14 +28,14 @@ namespace OpenRA.Mods.RA.Effects
 				() => world.AddFrameEndTask(w => w.Remove(this)));
 		}
 
-		public void Tick( World world )
+		public void Tick(World world)
 		{
 			Anim.Tick();
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			yield return new SpriteRenderable(Anim.Image, Pos, 0, wr.Palette("effect"), 1f);
+			return Anim.Render(Pos, wr.Palette("effect"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
@@ -29,12 +29,10 @@ namespace OpenRA.Mods.RA.Render
 		public override IEnumerable<IRenderable> RenderPreview(ActorInfo building, PaletteReference pr)
 		{
 			var p = BaseBuildingPreview(building, pr);
-			foreach (var r in p)
-				yield return r;
-
 			var anim = new Animation(RenderSprites.GetImage(building), () => 0);
 			anim.PlayRepeating("idle-top");
-			yield return new SpriteRenderable(anim.Image, WPos.Zero, 0, pr, 1f);
+
+			return p.Concat(anim.Render(WPos.Zero, pr));
 		}
 	}
 

--- a/OpenRA.Mods.RA/Render/RenderEditorOnly.cs
+++ b/OpenRA.Mods.RA/Render/RenderEditorOnly.cs
@@ -23,7 +23,6 @@ namespace OpenRA.Mods.RA.Render
 	{
 		public RenderEditorOnly(Actor self) : base(self, () => 0) { }
 
-		static readonly IRenderable[] Nothing = { };
-		public override IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr) { return Nothing; }
+		public override IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr) { return SpriteRenderable.None; }
 	}
 }

--- a/OpenRA.Mods.RA/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithHarvestAnimation.cs
@@ -24,9 +24,6 @@ namespace OpenRA.Mods.RA.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[Desc("Additional draw-order offset")]
-		public readonly int ZOffset = 0;
-
 		public object Create(ActorInitializer init) { return new WithHarvestAnimation(init.self, this); }
 	}
 
@@ -47,7 +44,7 @@ namespace OpenRA.Mods.RA.Render
 			rs.anims.Add("harvest_{0}".F(info.Sequence), new AnimationWithOffset(anim,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => !visible,
-			    p => WithTurret.ZOffsetFromCenter(self, p, info.ZOffset)));
+			    p => WithTurret.ZOffsetFromCenter(self, p, 0)));
 		}
 
 		public void Harvested(Actor self, ResourceType resource)

--- a/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
@@ -62,8 +62,13 @@ namespace OpenRA.Mods.RA.Render
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
 			foreach (var a in muzzleFlashes.Values)
-				if (a.DisableFunc == null || !a.DisableFunc())
-					yield return a.Image(self, wr, wr.Palette("effect"));
+			{
+				if (a.DisableFunc != null && a.DisableFunc())
+					continue;
+
+				foreach (var r in a.Render(self, wr, wr.Palette("effect"), 1f))
+					yield return r;
+			}
 		}
 
 		public void Tick(Actor self)

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -224,6 +224,7 @@ ionsfx:
 		Start: 0
 		Length: *
 		Offset: 0, -78
+		ZOffset: 1
 
 bomblet:
 	idle:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -89,7 +89,6 @@ HARVESTER:
 	LeavesHusk:
 		HuskActor: Harvester.Husk
 	WithHarvestAnimation:
-		ZOffset: 1
 
 HARVESTER.Husk:
 	Inherits: ^Husk

--- a/mods/d2k/sequences.yaml
+++ b/mods/d2k/sequences.yaml
@@ -72,6 +72,7 @@ harvester:
 		Length: 6
 		Facings: 8
 		Tick: 80
+		ZOffset: 1
 	dock: unload2
 		Start: 0
 		Length: 10


### PR DESCRIPTION
This adds 3 new fields to sequences:
- **ShadowStart** sets the start index of the shadow frames for the sequence (defaults to -1, i.e no shadow).
- **ZOffset** sets a relative z-offset for the sequence (to be used for overlays; defaults to 0).
- **ShadowZOffset** sets a relative z-offset for the shadow sequence (defaults to -5).
