### PR TITLE
Audio device swapper

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -258,6 +258,7 @@ namespace OpenRA
 			Log.AddChannel("debug", "debug.log");
 			Log.AddChannel("sync", "syncreport.log");
 			Log.AddChannel("server", "server.log");
+			Log.AddChannel("sound", "sound.log");
 
 			if (Settings.Server.DiscoverNatDevices)
 				UPnP.TryNatDiscovery();

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -104,7 +104,8 @@ namespace OpenRA.GameRules
 		public bool Repeat = false;
 		public bool MapMusic = true;
 		public string Engine = "AL";
-		
+		public string Device = null; //that means it will pick the default device.
+
 		public SoundCashTicks SoundCashTickType = SoundCashTicks.Extreme;
 	}
 

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncSettingsLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncSettingsLogic.cs
@@ -112,6 +112,16 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			shellmapMusicCheckbox.IsChecked = () => soundSettings.MapMusic;
 			shellmapMusicCheckbox.OnClick = () => soundSettings.MapMusic ^= true;
 
+			var audioDeviceDropdown = generalPane.Get<DropDownButtonWidget>("AUDIO_DEVICE");
+			audioDeviceDropdown.OnMouseDown = _ => ShowAudioDeviceDropdown(audioDeviceDropdown, soundSettings);
+			audioDeviceDropdown.GetText = () =>
+			{
+				var devicename = soundSettings.Device == null ? "Default Device" : soundSettings.Device;
+				if (devicename.Length > 32)
+					devicename = "..." + devicename.Substring(devicename.Length - 32);
+				return devicename;
+			};
+
 			// Input pane
 			var inputPane = panel.Get("INPUT_CONTROLS");
 			inputPane.IsVisible = () => Settings == PanelType.Input;
@@ -187,6 +197,30 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => s.MouseScroll == options[o],
 					() => s.MouseScroll = options[o]);
+				item.Get<LabelWidget>("LABEL").GetText = () => o;
+				return item;
+			};
+
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+			return true;
+		}
+
+		public static bool ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundSettings s)
+		{
+			var options = new Dictionary<string, string>();
+			options.Add("Default Device", null);
+			string[] deviceList = Sound.OpenAlGetDeviceList();
+			if (deviceList != null)
+			{
+				foreach(string device in deviceList)
+					options.Add(device, device);
+			}
+
+			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => s.Device == options[o],
+					() => s.Device = options[o]);
 				item.Get<LabelWidget>("LABEL").GetText = () => o;
 				return item;
 			};

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -109,7 +109,16 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			soundEngineDropdown.GetText = () => soundSettings.Engine == "AL" ?
 				"OpenAL" : soundSettings.Engine == "Null" ? "None" : "OpenAL";
 
-			
+			var audioDeviceDropdown = audio.Get<DropDownButtonWidget>("AUDIO_DEVICE");
+			audioDeviceDropdown.OnMouseDown = _ => ShowAudioDeviceDropdown(audioDeviceDropdown, soundSettings);
+			audioDeviceDropdown.GetText = () =>
+			{
+				var devicename = soundSettings.Device == null ? "Default Device" : soundSettings.Device;
+				if (devicename.Length > 32)
+					devicename = "..." + devicename.Substring(devicename.Length - 32);
+				return devicename;
+			};
+
 			// Display
 			var display = bg.Get("DISPLAY_PANE");
 			var gs = Game.Settings.Graphics;
@@ -362,6 +371,30 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => s.Engine == options[o],
 					() => s.Engine = options[o]);
+				item.Get<LabelWidget>("LABEL").GetText = () => o;
+				return item;
+			};
+
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+			return true;
+		}
+
+		public static bool ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundSettings s)
+		{
+			var options = new Dictionary<string, string>();
+			options.Add("Default Device", null);
+			string[] deviceList = Sound.OpenAlGetDeviceList();
+			if (deviceList != null)
+			{
+				foreach(string device in deviceList)
+					options.Add(device, device);
+			}
+
+			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => s.Device == options[o],
+					() => s.Device = options[o]);
 				item.Get<LabelWidget>("LABEL").GetText = () => o;
 				return item;
 			};

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -78,6 +78,13 @@ Container@SETTINGS_PANEL:
 					Height:20
 					Font:Regular
 					Text:Check Sync around Unsynced Code
+				Checkbox@SHELLMAP_MUSIC:
+					X:15
+					Y:210
+					Width:200
+					Height:20
+					Font:Regular
+					Text:Shellmap Music
 				Label@VIDEO_TITLE:
 					Y:20
 					X:375
@@ -183,13 +190,26 @@ Container@SETTINGS_PANEL:
 					Width:240
 					Height:20
 					Ticks:5
-				Checkbox@SHELLMAP_MUSIC:
+				Label@AUDIO_DEVICE_LABEL:
 					X:375
 					Y:240
-					Width:200
+					Width:75
+					Height:20
+					Text:Audio Device:
+				DropDownButton@AUDIO_DEVICE:
+					X:475
+					Y:240
+					Width:240
 					Height:20
 					Font:Regular
-					Text:Shellmap Music
+					Text:Default Device
+				Label@AUDIO_DESC
+					X:400
+					Y:262
+					Width:200
+					Height:25
+					Font:Tiny
+					Text:Device changes will be applied after the game is restarted.
 		Background@INPUT_CONTROLS:
 			Width:740
 			Height:290

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -195,6 +195,26 @@ Background@SETTINGS_MENU:
 					Height:25
 					Font:Regular
 					Text:OpenAL
+				Label@AUDIO_DEVICE_LABEL:
+					X:0
+					Y:185
+					Width:75
+					Height:25
+					Text:Audio Device:
+				DropDownButton@AUDIO_DEVICE:
+					X:100
+					Y:185
+					Width:250
+					Height:25
+					Font:Regular
+					Text:Default Device
+				Label@AUDIO_DESC
+					X:0
+					Y:210
+					Width:200
+					Height:25
+					Font:Tiny
+					Text:Device changes will be applied after the game is restarted.
 		Container@DISPLAY_PANE:
 			X:37
 			Y:100


### PR DESCRIPTION
Allows the user to pick an other device then the default one from a list of devices available to the OpenRA framework. Game needs to be restarted in order to apply this change.
