### PR TITLE
Fog visibility freezing

### DIFF
--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -213,6 +213,7 @@ namespace OpenRA.Traits
 		}
 
 		public ResourceType GetResource(CPos p) { return content[p.X, p.Y].Type; }
+		public ResourceType GetRenderedResource(CPos p) { return render[p.X, p.Y].Type; }
 		public int GetResourceDensity(CPos p) { return content[p.X, p.Y].Density; }
 		public int GetMaxResourceDensity(CPos p)
 		{

--- a/OpenRA.Mods.RA/Buildings/BibLayer.cs
+++ b/OpenRA.Mods.RA/Buildings/BibLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -19,12 +19,12 @@ namespace OpenRA.Mods.RA.Buildings
 {
 	class BibLayerInfo : ITraitInfo
 	{
-		public readonly string[] BibTypes = {"bib3", "bib2", "bib1"};
-		public readonly int[] BibWidths = {2,3,4};
+		public readonly string[] BibTypes = { "bib3", "bib2", "bib1" };
+		public readonly int[] BibWidths = { 2, 3, 4 };
 		public object Create(ActorInitializer init) { return new BibLayer(init.self, this); }
 	}
 
-	class BibLayer: IRenderOverlay, IWorldLoaded
+	class BibLayer : IRenderOverlay, IWorldLoaded
 	{
 		World world;
 		BibLayerInfo info;
@@ -36,10 +36,8 @@ namespace OpenRA.Mods.RA.Buildings
 			this.info = info;
 			bibSprites = info.BibTypes.Select(x => Game.modData.SpriteLoader.LoadAllSprites(x)).ToArray();
 
-			self.World.ActorAdded +=
-				a => { if (a.HasTrait<Bib>()) DoBib(a,true); };
-			self.World.ActorRemoved +=
-				a => { if (a.HasTrait<Bib>()) DoBib(a,false); };
+			self.World.ActorAdded += a => DoBib(a, true);
+			self.World.ActorRemoved += a => DoBib(a, false);
 		}
 
 		public void WorldLoaded(World w)
@@ -50,18 +48,21 @@ namespace OpenRA.Mods.RA.Buildings
 
 		public void DoBib(Actor b, bool isAdd)
 		{
+			if (!b.HasTrait<Bib>())
+				return;
+
 			var buildingInfo = b.Info.Traits.Get<BuildingInfo>();
 			var size = buildingInfo.Dimensions.X;
 			var bibOffset = buildingInfo.Dimensions.Y - 1;
 
-			int bib = Array.IndexOf(info.BibWidths,size);
+			int bib = Array.IndexOf(info.BibWidths, size);
 			if (bib < 0)
 			{
 				Log.Write("debug", "Cannot bib {0}-wide building {1}", size, b.Info.Name);
 				return;
 			}
 
-			for (int i = 0; i < 2 * size; i++)
+			for (var i = 0; i < 2 * size; i++)
 			{
 				var p = b.Location + new CVec(i % size, i / size + bibOffset);
 				if (isAdd)
@@ -71,10 +72,11 @@ namespace OpenRA.Mods.RA.Buildings
 			}
 		}
 
-		public void Render( WorldRenderer wr )
+		public void Render(WorldRenderer wr)
 		{
 			var pal = wr.Palette("terrain");
 			var cliprect = Game.viewport.WorldBounds(world);
+
 			foreach (var kv in tiles)
 			{
 				if (!cliprect.Contains(kv.Key.X, kv.Key.Y))

--- a/OpenRA.Mods.RA/Buildings/BibLayer.cs
+++ b/OpenRA.Mods.RA/Buildings/BibLayer.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.FileFormats;
 using OpenRA.Graphics;
@@ -21,14 +22,23 @@ namespace OpenRA.Mods.RA.Buildings
 	{
 		public readonly string[] BibTypes = { "bib3", "bib2", "bib1" };
 		public readonly int[] BibWidths = { 2, 3, 4 };
+		public readonly bool FrozenUnderFog = false;
 		public object Create(ActorInitializer init) { return new BibLayer(init.self, this); }
 	}
 
-	class BibLayer : IRenderOverlay, IWorldLoaded
+	struct CachedBib
+	{
+		public Dictionary<CPos, TileReference<byte, byte>> Tiles;
+		public IEnumerable<CPos> Footprint;
+		public bool Visible;
+	}
+
+	class BibLayer : IRenderOverlay, IWorldLoaded, ITickRender
 	{
 		World world;
 		BibLayerInfo info;
-		Dictionary<CPos, TileReference<byte, byte>> tiles;
+		Dictionary<Actor, CachedBib> visible;
+		Dictionary<Actor, CachedBib> dirty;
 		Sprite[][] bibSprites;
 
 		public BibLayer(Actor self, BibLayerInfo info)
@@ -43,7 +53,8 @@ namespace OpenRA.Mods.RA.Buildings
 		public void WorldLoaded(World w)
 		{
 			world = w;
-			tiles = new Dictionary<CPos, TileReference<byte, byte>>();
+			visible = new Dictionary<Actor, CachedBib>();
+			dirty = new Dictionary<Actor, CachedBib>();
 		}
 
 		public void DoBib(Actor b, bool isAdd)
@@ -55,21 +66,46 @@ namespace OpenRA.Mods.RA.Buildings
 			var size = buildingInfo.Dimensions.X;
 			var bibOffset = buildingInfo.Dimensions.Y - 1;
 
-			int bib = Array.IndexOf(info.BibWidths, size);
+			var bib = Array.IndexOf(info.BibWidths, size);
 			if (bib < 0)
 			{
 				Log.Write("debug", "Cannot bib {0}-wide building {1}", size, b.Info.Name);
 				return;
 			}
 
+			dirty[b] = new CachedBib()
+			{
+				Footprint = FootprintUtils.Tiles(b),
+				Tiles = new Dictionary<CPos, TileReference<byte, byte>>(),
+				Visible = isAdd
+			};
+
 			for (var i = 0; i < 2 * size; i++)
 			{
-				var p = b.Location + new CVec(i % size, i / size + bibOffset);
-				if (isAdd)
-					tiles[p] = new TileReference<byte, byte>((byte)(bib + 1), (byte)i);
-				else
-					tiles.Remove(p);
+				var cell = b.Location + new CVec(i % size, i / size + bibOffset);
+				var tile = new TileReference<byte, byte>((byte)(bib + 1), (byte) i);
+				dirty[b].Tiles.Add(cell, tile);
 			}
+		}
+
+		public void TickRender(WorldRenderer wr, Actor self)
+		{
+			var remove = new List<Actor>();
+			foreach (var kv in dirty)
+			{
+				if (!info.FrozenUnderFog || kv.Value.Footprint.Any(c => !self.World.FogObscures(c)))
+				{
+					if (kv.Value.Visible)
+						visible[kv.Key] = kv.Value;
+					else
+						visible.Remove(kv.Key);
+
+					remove.Add(kv.Key);
+				}
+			}
+
+			foreach (var r in remove)
+				dirty.Remove(r);
 		}
 
 		public void Render(WorldRenderer wr)
@@ -77,18 +113,22 @@ namespace OpenRA.Mods.RA.Buildings
 			var pal = wr.Palette("terrain");
 			var cliprect = Game.viewport.WorldBounds(world);
 
-			foreach (var kv in tiles)
+			foreach (var bib in visible.Values)
 			{
-				if (!cliprect.Contains(kv.Key.X, kv.Key.Y))
-					continue;
-				if (world.ShroudObscures(kv.Key))
-					continue;
+				foreach (var kv in bib.Tiles)
+				{
+					if (!cliprect.Contains(kv.Key.X, kv.Key.Y))
+						continue;
+					if (world.ShroudObscures(kv.Key))
+						continue;
 
-				bibSprites[kv.Value.type - 1][kv.Value.index].DrawAt(kv.Key.ToPPos().ToFloat2(), pal);
+					var tile = bibSprites[kv.Value.type - 1][kv.Value.index];
+					tile.DrawAt(wr.ScreenPxPosition(kv.Key.CenterPosition) - 0.5f * tile.size, pal);
+				}
 			}
 		}
 	}
 
-	public class BibInfo : TraitInfo<Bib> { }
+	public class BibInfo : TraitInfo<Bib>, Requires<BuildingInfo> { }
 	public class Bib { }
 }

--- a/OpenRA.Mods.RA/Effects/Corpse.cs
+++ b/OpenRA.Mods.RA/Effects/Corpse.cs
@@ -17,23 +17,30 @@ namespace OpenRA.Mods.RA.Effects
 {
 	public class Corpse : IEffect
 	{
-		readonly Animation Anim;
-		readonly WPos Pos;
-		readonly string PaletteName;
+		readonly World world;
+		readonly WPos pos;
+		readonly CPos cell;
+		readonly string paletteName;
+		readonly Animation anim;
 
 		public Corpse(World world, WPos pos, string image, string sequence, string paletteName)
 		{
-			Pos = pos;
-			PaletteName = paletteName;
-			Anim = new Animation(image);
-			Anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
+			this.world = world;
+			this.pos = pos;
+			this.cell = pos.ToCPos();
+			this.paletteName = paletteName;
+			anim = new Animation(image);
+			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
 		}
 
-		public void Tick(World world) { Anim.Tick(); }
+		public void Tick(World world) { anim.Tick(); }
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return Anim.Render(Pos, wr.Palette(PaletteName));
+			if (world.FogObscures(cell))
+				return SpriteRenderable.None;
+
+			return anim.Render(pos, wr.Palette(paletteName));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/CrateEffect.cs
+++ b/OpenRA.Mods.RA/Effects/CrateEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -23,18 +23,17 @@ namespace OpenRA.Mods.RA.Effects
 		public CrateEffect(Actor a, string seq)
 		{
 			this.a = a;
-			anim.PlayThen(seq,
-				() => a.World.AddFrameEndTask(w => w.Remove(this)));
+			anim.PlayThen(seq, () => a.World.AddFrameEndTask(w => w.Remove(this)));
 		}
 
-		public void Tick( World world )
+		public void Tick(World world)
 		{
 			anim.Tick();
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (!a.IsInWorld)
+			if (!a.IsInWorld || a.World.FogObscures(a.Location))
 				return SpriteRenderable.None;
 
 			return anim.Render(a.CenterPosition, wr.Palette("effect"));

--- a/OpenRA.Mods.RA/Effects/Explosion.cs
+++ b/OpenRA.Mods.RA/Effects/Explosion.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -17,20 +17,27 @@ namespace OpenRA.Mods.RA.Effects
 {
 	public class Explosion : IEffect
 	{
-		Animation anim;
+		World world;
 		WPos pos;
+		CPos cell;
+		Animation anim;
 
 		public Explosion(World world, WPos pos, string style)
 		{
+			this.world = world;
 			this.pos = pos;
+			this.cell = pos.ToCPos();
 			anim = new Animation("explosion");
 			anim.PlayThen(style, () => world.AddFrameEndTask(w => w.Remove(this)));
 		}
 
-		public void Tick( World world ) { anim.Tick(); }
+		public void Tick(World world) { anim.Tick(); }
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
+			if (world.FogObscures(cell))
+				return SpriteRenderable.None;
+
 			return anim.Render(pos, wr.Palette("effect"));
 		}
 	}

--- a/OpenRA.Mods.RA/Effects/FrozenActorProxy.cs
+++ b/OpenRA.Mods.RA/Effects/FrozenActorProxy.cs
@@ -1,0 +1,53 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Effects;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA.Effects
+{
+	public class FrozenActorProxy : IEffect
+	{
+		readonly Actor self;
+		readonly IEnumerable<CPos> footprint;
+		IRenderable[] renderables;
+
+		public FrozenActorProxy(Actor self, IEnumerable<CPos> footprint)
+		{
+			this.self = self;
+			this.footprint = footprint;
+		}
+
+		public void Tick(World world) { }
+		public void SetRenderables(IEnumerable<IRenderable> r)
+		{
+			renderables = r.Select(rr => rr).ToArray();
+		}
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		{
+			if (renderables == null)
+				return SpriteRenderable.None;
+
+			if (footprint.Any(c => !wr.world.FogObscures(c)))
+			{
+				if (self.Destroyed)
+					self.World.AddFrameEndTask(w => w.Remove(this));
+
+				return SpriteRenderable.None;
+			}
+
+			return renderables;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Effects/PowerdownIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/PowerdownIndicator.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (a.Destroyed || a.Owner.IsAlliedWith(a.World.RenderPlayer))
+			if (a.Destroyed || wr.world.FogObscures(a))
 				return SpriteRenderable.None;
 
 			return anim.Render(a.CenterPosition, wr.Palette("chrome"));

--- a/OpenRA.Mods.RA/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/RepairIndicator.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (building.Destroyed)
+			if (building.Destroyed || wr.world.FogObscures(building))
 				return SpriteRenderable.None;
 
 			return anim.Render(building.CenterPosition,

--- a/OpenRA.Mods.RA/Effects/Smoke.cs
+++ b/OpenRA.Mods.RA/Effects/Smoke.cs
@@ -17,25 +17,29 @@ namespace OpenRA.Mods.RA.Effects
 {
 	public class Smoke : IEffect
 	{
-		readonly WPos Pos;
-		readonly Animation Anim;
+		readonly World world;
+		readonly WPos pos;
+		readonly CPos cell;
+		readonly Animation anim;
 
 		public Smoke(World world, WPos pos, string trail)
 		{
-			Pos = pos;
-			Anim = new Animation(trail);
-			Anim.PlayThen("idle",
+			this.world = world;
+			this.pos = pos;
+			this.cell = pos.ToCPos();
+			anim = new Animation(trail);
+			anim.PlayThen("idle",
 				() => world.AddFrameEndTask(w => w.Remove(this)));
 		}
 
-		public void Tick(World world)
-		{
-			Anim.Tick();
-		}
+		public void Tick(World world) { anim.Tick(); }
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return Anim.Render(Pos, wr.Palette("effect"));
+			if (world.FogObscures(cell))
+				return SpriteRenderable.None;
+
+			return anim.Render(pos, wr.Palette("effect"));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -433,7 +433,7 @@ namespace OpenRA.Mods.RA
 				if (!self.Owner.Shroud.IsExplored(location))
 					return false;
 
-				var res = self.World.WorldActor.Trait<ResourceLayer>().GetResource(location);
+				var res = self.World.WorldActor.Trait<ResourceLayer>().GetRenderedResource(location);
 				var info = self.Info.Traits.Get<HarvesterInfo>();
 
 				if (res == null || !info.Resources.Contains(res.info.Name))

--- a/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -11,25 +11,48 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.RA.Buildings;
+using OpenRA.Mods.RA.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class FrozenUnderFogInfo : TraitInfo<FrozenUnderFog> {}
-
-	class FrozenUnderFog : IRenderModifier, IVisibilityModifier
+	public class FrozenUnderFogInfo : ITraitInfo, Requires<BuildingInfo>, Requires<RenderSpritesInfo>
 	{
-		public bool IsVisible(Actor self, Player byPlayer)
+		public object Create(ActorInitializer init) { return new FrozenUnderFog(init.self); }
+	}
+
+	public class FrozenUnderFog : IRenderModifier, IVisibilityModifier, ITickRender
+	{
+		FrozenActorProxy proxy;
+		IEnumerable<CPos> footprint;
+		bool visible;
+
+		public FrozenUnderFog(Actor self)
 		{
-			return byPlayer == null || Shroud.GetVisOrigins(self).Any(o => byPlayer.Shroud.IsVisible(o));
+			footprint = FootprintUtils.Tiles(self);
+			proxy = new FrozenActorProxy(self, footprint);
+			self.World.AddFrameEndTask(w => w.Add(proxy));
 		}
 
-		IRenderable[] cache = { };
+		public bool IsVisible(Actor self, Player byPlayer)
+		{
+			return byPlayer == null || footprint.Any(c => byPlayer.Shroud.IsVisible(c));
+		}
+
+		public void TickRender(WorldRenderer wr, Actor self)
+		{
+			if (self.Destroyed)
+				return;
+
+			visible = IsVisible(self, self.World.RenderPlayer);
+			if (visible)
+				proxy.SetRenderables(self.Render(wr));
+		}
+
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			if (IsVisible(self, self.World.RenderPlayer))
-				cache = r.ToArray();
-			return cache;
+			return visible ? r : SpriteRenderable.None;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/HiddenUnderFog.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -15,19 +15,18 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class HiddenUnderFogInfo : TraitInfo<HiddenUnderFog> {}
+	public class HiddenUnderFogInfo : TraitInfo<HiddenUnderFog> { }
 
-	class HiddenUnderFog : IRenderModifier, IVisibilityModifier
+	public class HiddenUnderFog : IRenderModifier, IVisibilityModifier
 	{
 		public bool IsVisible(Actor self, Player byPlayer)
 		{
 			return byPlayer == null || Shroud.GetVisOrigins(self).Any(o => byPlayer.Shroud.IsVisible(o));
 		}
 
-		static IRenderable[] Nothing = { };
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			return IsVisible(self, self.World.RenderPlayer) ? r : Nothing;
+			return IsVisible(self, self.World.RenderPlayer) ? r : SpriteRenderable.None;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -461,6 +461,7 @@
     <Compile Include="World\DomainIndex.cs" />
     <Compile Include="MPStartUnits.cs" />
     <Compile Include="Orders\SetChronoTankDestination.cs" />
+    <Compile Include="Effects\FrozenActorProxy.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -14,22 +14,22 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Traits;
 using OpenRA.Mods.RA.Effects;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
 	public class SmudgeLayerInfo : ITraitInfo
 	{
 		public readonly string Type = "Scorch";
-		public readonly string[] Types = {"sc1", "sc2", "sc3", "sc4", "sc5", "sc6"};
-		public readonly int[] Depths = {1,1,1,1,1,1};
+		public readonly string[] Types = { "sc1", "sc2", "sc3", "sc4", "sc5", "sc6" };
+		public readonly int[] Depths = { 1, 1, 1, 1, 1, 1 };
 		public readonly int SmokePercentage = 25;
 		public readonly string SmokeType = "smoke_m";
 		public object Create(ActorInitializer init) { return new SmudgeLayer(this); }
 	}
 
-	public class SmudgeLayer: IRenderOverlay, IWorldLoaded
+	public class SmudgeLayer : IRenderOverlay, IWorldLoaded
 	{
 		public SmudgeLayerInfo Info;
 		Dictionary<CPos, TileReference<byte, byte>> tiles;
@@ -48,26 +48,27 @@ namespace OpenRA.Mods.RA
 			tiles = new Dictionary<CPos, TileReference<byte, byte>>();
 
 			// Add map smudges
-			foreach (var s in w.Map.Smudges.Value.Where( s => Info.Types.Contains(s.Type )))
+			foreach (var s in w.Map.Smudges.Value.Where(s => Info.Types.Contains(s.Type)))
 				tiles.Add((CPos)s.Location, new TileReference<byte, byte>((byte)Array.IndexOf(Info.Types, s.Type), (byte)s.Depth));
 		}
 
 		public void AddSmudge(CPos loc)
 		{
-			if (Game.CosmeticRandom.Next(0,100) <= Info.SmokePercentage)
+			if (Game.CosmeticRandom.Next(0, 100) <= Info.SmokePercentage)
 				world.AddFrameEndTask(w => w.Add(new Smoke(w, loc.CenterPosition, Info.SmokeType)));
 
 			// No smudge; create a new one
 			if (!tiles.ContainsKey(loc))
 			{
 				byte st = (byte)(1 + world.SharedRandom.Next(Info.Types.Length - 1));
-				tiles.Add(loc, new TileReference<byte,byte>(st,(byte)0));
+				tiles.Add(loc, new TileReference<byte, byte>(st, (byte)0));
 				return;
 			}
 
 			var tile = tiles[loc];
+
 			// Existing smudge; make it deeper
-			int depth = Info.Depths[tile.type-1];
+			var depth = Info.Depths[tile.type - 1];
 			if (tile.index < depth - 1)
 			{
 				tile.index++;
@@ -75,20 +76,20 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public void Render( WorldRenderer wr )
+		public void Render(WorldRenderer wr)
 		{
 			var cliprect = Game.viewport.WorldBounds(world);
 			var pal = wr.Palette("terrain");
 
 			foreach (var kv in tiles)
 			{
-				if (!cliprect.Contains(kv.Key.X,kv.Key.Y))
+				if (!cliprect.Contains(kv.Key.X, kv.Key.Y))
 					continue;
 
 				if (world.ShroudObscures(kv.Key))
 					continue;
 
-				smudgeSprites[kv.Value.type- 1][kv.Value.index].DrawAt(kv.Key.ToPPos().ToFloat2(), pal);
+				smudgeSprites[kv.Value.type - 1][kv.Value.index].DrawAt(kv.Key.ToPPos().ToFloat2(), pal);
 			}
 		}
 	}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -317,12 +317,14 @@
 	Guardable:
 		Range: 3
 	BodyOrientation:
+	FrozenUnderFog:
 
 ^CivBuilding:
 	Inherits: ^Building
 	-DeadBuildingState:
 	-Buildable:
 	-GivesBuildableArea:
+	-FrozenUnderFog:
 	Health:
 		HP: 400
 	Armor: 

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -273,6 +273,7 @@ World:
 	ProductionQueueFromSelection:
 		ProductionTabsWidget: PRODUCTION_TABS
 	BibLayer:
+		FrozenUnderFog: true
 	DomainIndex:
 	ResourceLayer:
 	ResourceClaimLayer:

--- a/mods/d2k/rules/system.yaml
+++ b/mods/d2k/rules/system.yaml
@@ -354,6 +354,7 @@ World:
 	BibLayer:
 		BibTypes: bib3x, bib2x
 		BibWidths: 3, 2
+		FrozenUnderFog: true
 	DomainIndex:
 	ResourceLayer:
 	ResourceClaimLayer:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -222,7 +222,6 @@
 		ActorTypes: e1,e1,e1,e1,e1,e1,e1,e1,e1,e1,e1,e1,e1,e1,e1,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,e6,e6,e6,e6,e6
 	MustBeDestroyed:
 	GivesExperience:
-#	FrozenUnderFog:
 	CaptureNotification:
 	EditorAppearance:
 		RelativeToTopLeft: yes
@@ -237,6 +236,7 @@
 	Guardable:
 		Range: 3
 	BodyOrientation:
+	FrozenUnderFog:
 
 ^Wall:
 	AppearsOnRadar:

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -604,6 +604,7 @@ World:
 		Name: Soviet
 		Race: soviet
 	BibLayer:
+		FrozenUnderFog: true
 	DomainIndex:
 	ResourceLayer:
 	ResourceClaimLayer:


### PR DESCRIPTION
This hides a few effects that shouldn't be visible behind the fog:
- Explosions / gunfire
- Infantry death animations
- Smoke

The state of resource fields, smudges, and bibs (if enabled) are frozen as they were last seen.

The repair and powerdown icons are hidden for cloaked units (or any other IVisibilityModifier, including HiddenUnderFog if enabled).

I have dropped the FrozenUnderFog improvements for now, as this will need some low level changes for faking the order targeters against frozen buildings where the backing actor was destroyed.
