### PR TITLE
Changes track title of Afterlife to Await

### DIFF
--- a/mods/ra/music.yaml
+++ b/mods/ra/music.yaml
@@ -1,7 +1,7 @@
 intro: Intro
 map: Map
 score: Militant Force
-await_r: Afterlife
+await_r: Await
 bigf226m: Bigfoot
 credits: End Credits
 crus226m: Crush


### PR DESCRIPTION
The file is called await_r.aud and the ingame title in RA was Await, too. As far as I can tell, the title 'Afterlife' first came up in the old RAMIXer's database, and was copy-pasted to XCC Mixer's database. But there is no indication that Afterlife really is/was supposed to be the real in-game title of this track.
