### PR TITLE
Clean up loose ends with fog and lobby options.

### DIFF
--- a/OpenRA.FileFormats/Manifest.cs
+++ b/OpenRA.FileFormats/Manifest.cs
@@ -26,6 +26,7 @@ namespace OpenRA.FileFormats
 
 		public readonly Dictionary<string, string> Packages;
 		public readonly MiniYaml LoadScreen;
+		public readonly MiniYaml LobbyDefaults;
 		public readonly Dictionary<string, Pair<string,int>> Fonts;
 		public readonly int TileSize = 24;
 
@@ -57,6 +58,7 @@ namespace OpenRA.FileFormats
 			PackageContents = YamlList(yaml, "PackageContents");
 
 			LoadScreen = yaml["LoadScreen"];
+			LobbyDefaults = yaml["LobbyDefaults"];
 			Fonts = yaml["Fonts"].NodesDict.ToDictionary(x => x.Key,
 				x => Pair.New(x.Value.NodesDict["Font"].Value,
 					int.Parse(x.Value.NodesDict["Size"].Value)));

--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -15,8 +15,8 @@ namespace OpenRA.Graphics
 {
 	public class ShroudRenderer
 	{
+		World world;
 		Map map;
-		ShroudInfo shroudInfo;
 		Sprite[] shadowBits = Game.modData.SpriteLoader.LoadAllSprites("shadow");
 		Sprite[,] sprites, fogSprites;
 		int shroudHash;
@@ -46,8 +46,8 @@ namespace OpenRA.Graphics
 
 		public ShroudRenderer(World world)
 		{
+			this.world = world;
 			this.map = world.Map;
-			shroudInfo = Rules.Info["player"].Traits.Get<ShroudInfo>();
 
 			sprites = new Sprite[map.MapSize.X, map.MapSize.Y];
 			fogSprites = new Sprite[map.MapSize.X, map.MapSize.Y];
@@ -152,9 +152,10 @@ namespace OpenRA.Graphics
 		{
 			if (initializePalettes)
 			{
-				if (shroudInfo.Fog)
+				if (world.LobbyInfo.GlobalSettings.Fog)
 					fogPalette = wr.Palette("fog");
-				shroudPalette = wr.Palette("shroud");
+
+				shroudPalette = world.LobbyInfo.GlobalSettings.Fog ? wr.Palette("shroud") : wr.Palette("shroudfog");
 				initializePalettes = false;
 			}
 
@@ -165,7 +166,7 @@ namespace OpenRA.Graphics
 			// We draw the shroud when disabled to hide the sharp map edges
 			DrawShroud(wr, clipRect, sprites, shroudPalette);
 
-			if (shroudInfo.Fog)
+			if (world.LobbyInfo.GlobalSettings.Fog)
 				DrawShroud(wr, clipRect, fogSprites, fogPalette);
 		}
 

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Network
 			public bool Crates = true;
 			public bool Shroud = true;
 			public bool Fog = true;
-			public string StartingUnitsClass = "default";
+			public string StartingUnitsClass = "none";
 			public bool AllowVersionMismatch;
 		}
 

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -92,6 +92,8 @@ namespace OpenRA.Network
 			public bool Dedicated;
 			public string Difficulty;
 			public bool Crates = true;
+			public bool Shroud = true;
+			public bool Fog = true;
 			public string StartingUnitsClass = "default";
 			public bool AllowVersionMismatch;
 		}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -527,7 +527,10 @@ namespace OpenRA.Server
 				DispatchOrders(toDrop, toDrop.MostRecentFrame, new byte[] {0xbf});
 
 				if (!conns.Any())
+				{
+					FieldLoader.Load(lobbyInfo.GlobalSettings, ModData.Manifest.LobbyDefaults);
 					TempBans.Clear();
+				}
 
 				if (conns.Any() || lobbyInfo.GlobalSettings.Dedicated)
 					SyncLobbyInfo();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -106,6 +106,7 @@ namespace OpenRA.Server
 			lobbyInfo.GlobalSettings.Map = settings.Map;
 			lobbyInfo.GlobalSettings.ServerName = settings.Name;
 			lobbyInfo.GlobalSettings.Dedicated = settings.Dedicated;
+			FieldLoader.Load(lobbyInfo.GlobalSettings, modData.Manifest.LobbyDefaults);
 
 			foreach (var t in ServerTraits.WithInterface<INotifyServerStart>())
 				t.ServerStarted(this);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -64,6 +64,8 @@ namespace OpenRA.Traits
 	public interface IValidateOrder { bool OrderValidation(OrderManager orderManager, World world, int clientId, Order order); }
 	public interface IOrderVoice { string VoicePhraseForOrder(Actor self, Order order); }
 	public interface INotify { void Play(Player p, string notification); }
+	public interface INotifyAddedToWorld { void AddedToWorld(Actor self); }
+	public interface INotifyRemovedFromWorld { void RemovedFromWorld(Actor self); }
 	public interface INotifySold { void Selling(Actor self); void Sold(Actor self); }
 	public interface INotifyDamage { void Damaged(Actor self, AttackInfo e); }
 	public interface INotifyDamageStateChanged { void DamageStateChanged(Actor self, AttackInfo e); }

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -18,14 +18,11 @@ namespace OpenRA.Traits
 {
 	public class ShroudInfo : ITraitInfo
 	{
-		public readonly bool Shroud = true;
-		public readonly bool Fog = true;
-		public object Create(ActorInitializer init) { return new Shroud(init.self, this); }
+		public object Create(ActorInitializer init) { return new Shroud(init.self); }
 	}
 
 	public class Shroud
 	{
-		public ShroudInfo Info;
 		Actor self;
 		Map map;
 
@@ -42,9 +39,8 @@ namespace OpenRA.Traits
 
 		public int Hash { get; private set; }
 
-		public Shroud(Actor self, ShroudInfo info)
+		public Shroud(Actor self)
 		{
-			Info = info;
 			this.self = self;
 			map = self.World.Map;
 
@@ -58,7 +54,7 @@ namespace OpenRA.Traits
 			self.World.ActorAdded += AddShroudGeneration;
 			self.World.ActorRemoved += RemoveShroudGeneration;
 
-			if (!info.Shroud)
+			if (!self.World.LobbyInfo.GlobalSettings.Shroud)
 				ExploredBounds = map.Bounds;
 		}
 
@@ -252,7 +248,7 @@ namespace OpenRA.Traits
 			if (!map.IsInMap(x, y))
 				return false;
 
-			if (!Info.Shroud)
+			if (!self.World.LobbyInfo.GlobalSettings.Shroud)
 				return true;
 
 			return explored[x, y] && (generatedShroudCount[x, y] == 0 || visibleCount[x, y] > 0);
@@ -271,7 +267,7 @@ namespace OpenRA.Traits
 			if (x < 0 || x >= map.MapSize.X || y < 0 || y >= map.MapSize.Y)
 				return false;
 
-			if (!Info.Fog)
+			if (!self.World.LobbyInfo.GlobalSettings.Fog)
 				return true;
 
 			return visibleCount[x, y] > 0;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -159,6 +159,9 @@ namespace OpenRA
 			a.IsInWorld = true;
 			actors.Add(a);
 			ActorAdded(a);
+
+			foreach (var t in a.TraitsImplementing<INotifyAddedToWorld>())
+				t.AddedToWorld(a);
 		}
 
 		public void Remove(Actor a)
@@ -166,7 +169,9 @@ namespace OpenRA
 			a.IsInWorld = false;
 			actors.Remove(a);
 			ActorRemoved(a);
-			
+
+			foreach (var t in a.TraitsImplementing<INotifyRemovedFromWorld>())
+				t.RemovedFromWorld(a);
 		}
 
 		public void Add(IEffect b) { effects.Add(b); }

--- a/OpenRA.Mods.RA/LeavesHusk.cs
+++ b/OpenRA.Mods.RA/LeavesHusk.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.RA
 			{
 				var td = new TypeDictionary
 				{
+					new ParentActorInit(self),
 					new LocationInit(self.Location),
 					new CenterLocationInit(self.CenterLocation),
 					new OwnerInit(self.Owner),

--- a/OpenRA.Mods.RA/MPStartUnits.cs
+++ b/OpenRA.Mods.RA/MPStartUnits.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.RA
 {
 	public class MPStartUnitsInfo : TraitInfo<MPStartUnits>
 	{
-		public readonly string Class = "default";
+		public readonly string Class = "none";
 		public readonly string[] Races = { };
 
 		public readonly string BaseActor = null;

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -326,6 +326,32 @@ namespace OpenRA.Mods.RA.Server
 						server.SyncLobbyInfo();
 						return true;
 					}},
+				{ "shroud",
+					s =>
+					{
+						if (!client.IsAdmin)
+						{
+							server.SendOrderTo(conn, "Message", "Only the host can set that option");
+							return true;
+						}
+
+						bool.TryParse(s, out server.lobbyInfo.GlobalSettings.Shroud);
+						server.SyncLobbyInfo();
+						return true;
+					}},
+				{ "fog",
+					s =>
+					{
+						if (!client.IsAdmin)
+						{
+							server.SendOrderTo(conn, "Message", "Only the host can set that option");
+							return true;
+						}
+
+						bool.TryParse(s, out server.lobbyInfo.GlobalSettings.Fog);
+						server.SyncLobbyInfo();
+						return true;
+					}},
 				{ "assignteams",
 					s =>
 					{

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -360,6 +360,24 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				optionsBin.Get<LabelWidget>("STARTINGUNITS_DESC").IsVisible = startingUnits.IsVisible;
 			}
 
+			var enableShroud = optionsBin.GetOrNull<CheckboxWidget>("SHROUD_CHECKBOX");
+			if (enableShroud != null)
+			{
+				enableShroud.IsChecked = () => orderManager.LobbyInfo.GlobalSettings.Shroud;
+				enableShroud.IsDisabled = configurationDisabled;
+				enableShroud.OnClick = () => orderManager.IssueOrder(Order.Command(
+					"shroud {0}".F(!orderManager.LobbyInfo.GlobalSettings.Shroud)));
+			};
+
+			var enableFog = optionsBin.GetOrNull<CheckboxWidget>("FOG_CHECKBOX");
+			if (enableFog != null)
+			{
+				enableFog.IsChecked = () => orderManager.LobbyInfo.GlobalSettings.Fog;
+				enableFog.IsDisabled = configurationDisabled;
+				enableFog.OnClick = () => orderManager.IssueOrder(Order.Command(
+					"fog {0}".F(!orderManager.LobbyInfo.GlobalSettings.Fog)));
+			};
+
 			var disconnectButton = lobby.Get<ButtonWidget>("DISCONNECT_BUTTON");
 			disconnectButton.OnClick = () => { CloseWindow(); onExit(); };
 

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -327,7 +327,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var classNames = new Dictionary<string,string>()
 				{
 					{"none", "MCV Only"},
-					{"default", "Light Support"},
+					{"light", "Light Support"},
 					{"heavy", "Heavy Support"},
 				};
 

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -206,45 +206,57 @@ Background@LOBBY_OPTIONS_BIN:
 	Children:
 		Label@TITLE:
 			X:0
-			Y:50
+			Y:40
 			Width:PARENT_RIGHT
 			Height:25
 			Font:Bold
 			Align:Center
 			Text: Map Options
 		Checkbox@ALLOWCHEATS_CHECKBOX:
-			X:150
-			Y:80
+			X:80
+			Y:75
 			Width:230
 			Height:20
-			Text:Enable Cheats / Debug Menu
+			Text:Cheats / Debug Menu
 		Checkbox@CRATES_CHECKBOX:
-			X:150
+			X:80
 			Y:110
 			Width:230
 			Height:20
-			Text:Enable Crates
+			Text:Crates
+		Checkbox@SHROUD_CHECKBOX:
+			X:310
+			Y:75
+			Width:230
+			Height:20
+			Text:Shroud
+		Checkbox@FOG_CHECKBOX:
+			X:310
+			Y:110
+			Width:230
+			Height:20
+			Text:Fog of War
 		Label@STARTINGUNITS_DESC:
-			X:150
-			Y:140
+			X:135
+			Y:142
 			Width:120
 			Height:25
 			Text:Starting Units:
 		DropDownButton@STARTINGUNITS_DROPDOWNBUTTON:
-			X:245
-			Y:140
+			X:230
+			Y:142
 			Width:140
 			Height:25
 			Font:Bold
 		Label@DIFFICULTY_DESC:
-			X:150
-			Y:170
+			X:125
+			Y:177
 			Width:120
 			Height:25
 			Text:Mission Difficulty:
 		DropDownButton@DIFFICULTY_DROPDOWNBUTTON:
-			X:265
-			Y:170
+			X:230
+			Y:177
 			Width:100
 			Height:25
 			Font:Bold

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -123,6 +123,8 @@ LobbyDefaults:
 	Crates: true
 	StartingUnitsClass: default
 	FragileAlliances: false
+	Shroud: true
+	Fog: true
 
 ChromeMetrics:
 	mods/cnc/metrics.yaml

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -52,6 +52,7 @@ Sequences:
 	mods/cnc/sequences/funpark.yaml
 	mods/cnc/sequences/civilian.yaml
 	mods/cnc/sequences/campaign.yaml
+
 Cursors:
 	mods/cnc/cursors.yaml
 
@@ -116,6 +117,8 @@ ServerTraits:
 	LobbyCommands
 	PlayerPinger
 	MasterServerPinger
+
+LobbyDefaults:
 
 ChromeMetrics:
 	mods/cnc/metrics.yaml

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -119,6 +119,10 @@ ServerTraits:
 	MasterServerPinger
 
 LobbyDefaults:
+	AllowCheats: false
+	Crates: true
+	StartingUnitsClass: default
+	FragileAlliances: false
 
 ChromeMetrics:
 	mods/cnc/metrics.yaml

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -121,7 +121,7 @@ ServerTraits:
 LobbyDefaults:
 	AllowCheats: false
 	Crates: true
-	StartingUnitsClass: default
+	StartingUnitsClass: light
 	FragileAlliances: false
 	Shroud: true
 	Fog: true

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -324,7 +324,6 @@
 	-DeadBuildingState:
 	-Buildable:
 	-GivesBuildableArea:
-	-FrozenUnderFog:
 	Health:
 		HP: 400
 	Armor: 
@@ -337,6 +336,8 @@
 	-Sellable:
 	Tooltip:
 		Name: Civilian Building
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^CivBuildingHusk:
 	AppearsOnRadar:
@@ -349,6 +350,8 @@
 	Tooltip:
 		Name: Civilian Building (Destroyed)
 	BodyOrientation:
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^TechBuilding:
 	Inherits: ^CivBuilding
@@ -379,6 +382,10 @@
 		Name: Field (Destroyed)
 	BelowUnits:
 	BodyOrientation:
+	RenderBuilding:
+		Palette: terrain
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^Wall:
 	AppearsOnRadar:
@@ -429,6 +436,8 @@
 		Type: Wood
 	AutoTargetIgnore:
 	BodyOrientation:
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^Rock:
 	Tooltip:
@@ -444,6 +453,8 @@
 	EditorAppearance:
 		RelativeToTopLeft: yes
 	BodyOrientation:
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^Husk:
 	Health:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -415,6 +415,7 @@
 	Sellable:
 	Guardable:
 	BodyOrientation:
+	FrozenUnderFog:
 
 ^Tree:
 	Tooltip:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -23,6 +23,7 @@ FACT:
 	RevealsShroud:
 		Range: 10
 	Bib:
+		Sprite: bib2
 	Production:
 		Produces: Building,Defense
 	Transforms:
@@ -72,6 +73,7 @@ NUKE:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib3
 
 NUK2:
 	Inherits: ^Building
@@ -96,6 +98,7 @@ NUK2:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib3
 
 PROC:
 	Inherits: ^Building
@@ -118,6 +121,7 @@ PROC:
 	RevealsShroud:
 		Range: 6
 	Bib:
+		Sprite: bib2
 	TiberiumRefinery:
 		DockOffset: 0,2
 		TickRate: 15
@@ -191,6 +195,7 @@ PYLE:
 	RevealsShroud:
 		Range: 5
 	Bib:
+		Sprite: bib3
 	RallyPoint:
 	Exit@1:
 		SpawnOffset: -10,2
@@ -230,6 +235,7 @@ HAND:
 	RevealsShroud:
 		Range: 5
 	Bib:
+		Sprite: bib3
 	RallyPoint:
 	Exit@1:
 		SpawnOffset: 12,24
@@ -266,6 +272,7 @@ AFLD:
 	RevealsShroud:
 		Range: 7
 	Bib:
+		Sprite: bib1
 	RallyPoint:
 		RallyPoint: 4,2
 	BelowUnits:
@@ -305,6 +312,7 @@ WEAP:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib2
 	-RenderBuilding:
 	RenderBuildingWarFactory:
 	RallyPoint:
@@ -381,6 +389,7 @@ HQ:
 	RevealsShroud:
 		Range: 10
 	Bib:
+		Sprite: bib3
 	ProvidesRadar:
 	RenderDetectionCircle:
 	DetectCloaked:
@@ -445,6 +454,7 @@ EYE:
 	RevealsShroud:
 		Range: 10
 	Bib:
+		Sprite: bib3
 	ProvidesRadar:
 	RenderDetectionCircle:
 	DetectCloaked:
@@ -485,6 +495,7 @@ TMPL:
 	RevealsShroud:
 		Range: 6
 	Bib:
+		Sprite: bib2
 	NukePower:
 		Image: atomicnh
 		ChargeTime: 300

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -276,7 +276,6 @@ World:
 	ProductionQueueFromSelection:
 		ProductionTabsWidget: PRODUCTION_TABS
 	BibLayer:
-		FrozenUnderFog: true
 	DomainIndex:
 	ResourceLayer:
 	ResourceClaimLayer:

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -318,22 +318,27 @@ World:
 		Races: gdi, nod
 		BaseActor: mcv
 	MPStartUnits@defaultgdia:
+		Class: light
 		Races: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e3,e3,jeep
 	MPStartUnits@defaultgdib:
+		Class: light
 		Races: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e1,e3,apc
 	MPStartUnits@defaultnoda:
+		Class: light
 		Races: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e3,bggy,bike
 	MPStartUnits@defaultnodb:
+		Class: light
 		Races: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e3,e3,e3,bggy
 	MPStartUnits@defaultnodc:
+		Class: light
 		Races: nod
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e1,e1,e3,bike

--- a/mods/cnc/rules/system.yaml
+++ b/mods/cnc/rules/system.yaml
@@ -264,6 +264,9 @@ World:
 	ShroudPalette@fog:
 		Name: fog
 		Type: Fog
+	ShroudPalette@combined:
+		Name: shroudfog
+		Type: Combined
 	Country@gdi:
 		Name: GDI
 		Race: gdi

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -105,6 +105,10 @@ ServerTraits:
 	MasterServerPinger
 
 LobbyDefaults:
+	AllowCheats: false
+	Crates: true
+	StartingUnitsClass: default
+	FragileAlliances: false
 
 ChromeMetrics:
 	mods/d2k/metrics.yaml

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -104,6 +104,8 @@ ServerTraits:
 	PlayerPinger
 	MasterServerPinger
 
+LobbyDefaults:
+
 ChromeMetrics:
 	mods/d2k/metrics.yaml
 

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -109,6 +109,8 @@ LobbyDefaults:
 	Crates: true
 	StartingUnitsClass: default
 	FragileAlliances: false
+	Shroud: false
+	Fog: true
 
 ChromeMetrics:
 	mods/d2k/metrics.yaml

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -107,7 +107,7 @@ ServerTraits:
 LobbyDefaults:
 	AllowCheats: false
 	Crates: true
-	StartingUnitsClass: default
+	StartingUnitsClass: none
 	FragileAlliances: false
 	Shroud: false
 	Fog: true

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -230,7 +230,6 @@
 	Sellable:
 	GivesBounty:
 	DebugMuzzlePositions:
-	Bib:
 	Guardable:
 		Range: 3
 	BodyOrientation:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -5,6 +5,8 @@
 		Footprint: xxx xxx
 		Dimensions: 3,2
 		Adjacent: 4
+	Bib:
+		Sprite: bib3x
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 1000
@@ -51,6 +53,8 @@
 		Power: 100
 		Footprint: xx xx
 		Dimensions: 2,2
+	Bib:
+		Sprite: bib2x
 	Health:
 		HP: 400
 	Armor:
@@ -78,6 +82,8 @@
 		Power: -20
 		Footprint: =x xx
 		Dimensions: 2,2
+	Bib:
+		Sprite: bib2x
 	Health:
 		HP: 800
 	Armor:
@@ -119,6 +125,8 @@
 		Power: -30
 		Footprint: xxx x==
 		Dimensions: 3,2
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 900
 	Armor:
@@ -173,7 +181,6 @@
 		PipCount: 5
 		Capacity: 2000
 	-EmitInfantryOnSell:
-	-Bib:
 
 ^LIGHT:
 	Inherits: ^Building
@@ -193,6 +200,8 @@
 		Power: -20
 		Footprint: xxx xx=
 		Dimensions: 3,2
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 750
 	Armor:
@@ -230,6 +239,8 @@
 		Power: -30
 		Footprint: _x_ xxx =xx
 		Dimensions: 3,3
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 1500
 	Armor:
@@ -269,6 +280,8 @@
 		Power: -40
 		Footprint: xxx xxx
 		Dimensions: 3,2
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 1000
 	Armor:
@@ -298,6 +311,8 @@
 		Power: -40
 		Footprint: xxx x=x =x=
 		Dimensions: 3,3
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 1000
 	Armor:
@@ -420,7 +435,6 @@ GUNTOWER:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 5
-	-Bib:
 
 GUNTOWER.Husk:
 	Inherits: ^TowerHusk
@@ -479,7 +493,6 @@ ROCKETTOWER:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 6
-	-Bib:
 
 ROCKETTOWER.Husk:
 	Inherits: ^TowerHusk
@@ -520,7 +533,6 @@ REPAIR:
 		ValuePercentage: 50
 	RallyPoint:
 		RallyPoint: 1,3
-	-Bib:
 
 ^HIGHTECH:
 	Inherits: ^Building
@@ -540,6 +552,8 @@ REPAIR:
 		Power: -40
 		Footprint: _x_ xxx xxx
 		Dimensions: 3,3
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 1500
 	Armor:
@@ -580,6 +594,8 @@ RESEARCH:
 		Power: -40
 		Footprint: xxx xxx
 		Dimensions: 3,2
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 1000
 	Armor:
@@ -607,6 +623,8 @@ RESEARCH:
 		Power: -50
 		Footprint: _x_ xxx =xx
 		Dimensions: 3,3
+	Bib:
+		Sprite: bib3x
 	Health:
 		HP: 2000
 	Armor:
@@ -628,6 +646,8 @@ SIETCH:
 		Footprint: xx xx
 		Dimensions: 2,2
 		TerrainTypes: Cliff
+	Bib:
+		Sprite: bib2x
 	Health:
 		HP: 400
 	Armor:
@@ -652,6 +672,8 @@ PALACEC:
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
+	Bib:
+		Sprite: bib3x
 	RenderBuilding:
 		HasMakeAnimation: false
 

--- a/mods/d2k/rules/system.yaml
+++ b/mods/d2k/rules/system.yaml
@@ -342,6 +342,9 @@ World:
 	ShroudPalette@fog:
 		Name: fog
 		Type: Fog
+	ShroudPalette@combined:
+		Name: shroudfog
+		Type: Combined
 	Country@Atreides:
 		Name: Atreides
 		Race: atreides

--- a/mods/d2k/rules/system.yaml
+++ b/mods/d2k/rules/system.yaml
@@ -355,9 +355,6 @@ World:
 		Name: Ordos
 		Race: ordos
 	BibLayer:
-		BibTypes: bib3x, bib2x
-		BibWidths: 3, 2
-		FrozenUnderFog: true
 	DomainIndex:
 	ResourceLayer:
 	ResourceClaimLayer:

--- a/mods/ra/chrome/lobby-dialogs.yaml
+++ b/mods/ra/chrome/lobby-dialogs.yaml
@@ -59,39 +59,63 @@ Background@LOBBY_OPTIONS_BIN:
 	Children:
 		Label@TITLE:
 			X:0
-			Y:50
+			Y:40
 			Width:PARENT_RIGHT
 			Height:25
 			Font:Bold
 			Align:Center
 			Text: Map Options
 		Checkbox@ALLOWCHEATS_CHECKBOX:
-			X:150
-			Y:80
-			Width:220
+			X:80
+			Y:75
+			Width:230
 			Height:20
-			Text:Enable Cheats / Debug Menu
-		Checkbox@CRATES_CHECKBOX:
-			X:150
+			Text:Cheats / Debug Menu
+		Checkbox@FRAGILEALLIANCES_CHECKBOX:
+			X:80
 			Y:110
 			Width:220
 			Height:20
-			Text:Enable Crates
-		Checkbox@FRAGILEALLIANCES_CHECKBOX:
-			X:150
-			Y:140
-			Width:220
-			Height:20
 			Text:Allow Team Changes
+		Checkbox@CRATES_CHECKBOX:
+			X:80
+			Y:145
+			Width:230
+			Height:20
+			Text:Crates
+		Checkbox@SHROUD_CHECKBOX:
+			X:310
+			Y:75
+			Width:230
+			Height:20
+			Text:Shroud
+		Checkbox@FOG_CHECKBOX:
+			X:310
+			Y:110
+			Width:230
+			Height:20
+			Text:Fog of War
+		Label@STARTINGUNITS_DESC:
+			X:215
+			Y:142
+			Width:120
+			Height:25
+			Text:Starting Units:
+		DropDownButton@STARTINGUNITS_DROPDOWNBUTTON:
+			X:310
+			Y:142
+			Width:140
+			Height:25
+			Font:Bold
 		Label@DIFFICULTY_DESC:
-			X:150
-			Y:170
+			X:195
+			Y:177
 			Width:120
 			Height:25
 			Text:Mission Difficulty:
 		DropDownButton@DIFFICULTY_DROPDOWNBUTTON:
-			X:265
-			Y:170
+			X:310
+			Y:177
 			Width:100
 			Height:25
 			Font:Bold

--- a/mods/ra/maps/Fort-Lonestar/map.yaml
+++ b/mods/ra/maps/Fort-Lonestar/map.yaml
@@ -521,6 +521,7 @@ Rules:
 		Armor:
 			Type: Wood
 		Bib:
+			Sprite: bib3
 		RevealsShroud:
 			Range: 3
 		Capturable:

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -121,6 +121,10 @@ ServerTraits:
 	MasterServerPinger
 
 LobbyDefaults:
+	AllowCheats: false
+	Crates: true
+	StartingUnitsClass: default
+	FragileAlliances: false
 
 ChromeMetrics:
 	mods/ra/metrics.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -125,6 +125,8 @@ LobbyDefaults:
 	Crates: true
 	StartingUnitsClass: default
 	FragileAlliances: false
+	Shroud: true
+	Fog: true
 
 ChromeMetrics:
 	mods/ra/metrics.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -123,7 +123,7 @@ ServerTraits:
 LobbyDefaults:
 	AllowCheats: false
 	Crates: true
-	StartingUnitsClass: default
+	StartingUnitsClass: none
 	FragileAlliances: false
 	Shroud: true
 	Fog: true

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -120,6 +120,8 @@ ServerTraits:
 	PlayerPinger
 	MasterServerPinger
 
+LobbyDefaults:
+
 ChromeMetrics:
 	mods/ra/metrics.yaml
 

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -69,6 +69,7 @@ FCOM:
 	RevealsShroud:
 		Range: 10
 	Bib:
+		Sprite: bib3
 
 HOSP:
 	Inherits: ^TechBuilding
@@ -300,6 +301,7 @@ MISS:
 	Tooltip:
 		Name: Technology Center
 	Bib:
+		Sprite: bib2
 
 BIO:
 	Inherits: ^TechBuilding
@@ -319,6 +321,7 @@ OILB:
 	Health:
 		HP: 1000
 	Bib:
+		Sprite: bib3
 	RevealsShroud:
 		Range: 3
 	Capturable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -290,6 +290,8 @@
 	-Sellable:
 	-Capturable:
 	-CapturableBar:
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^AmmoBox:
 	Inherits: ^TechBuilding
@@ -370,6 +372,8 @@
 		Type: Wood
 	AutoTargetIgnore:
 	BodyOrientation:
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^Husk:
 	Husk:
@@ -489,6 +493,8 @@
 	ProximityCaptor:
 		Types:Tree
 	BodyOrientation:
+	FrozenUnderFog:
+		StartsRevealed: true
 
 ^DesertCivBuilding:
 	Inherits: ^CivBuilding

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -272,6 +272,7 @@
 	UpdatesPlayerStatistics:
 	Guardable:
 	BodyOrientation:
+	FrozenUnderFog:
 
 ^TechBuilding:
 	Inherits: ^Building

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -372,6 +372,7 @@ DOME:
 	RevealsShroud:
 		Range: 10
 	Bib:
+		Sprite: bib3
 	ProvidesRadar:
 	IronCurtainable:
 	Infiltratable:
@@ -844,6 +845,7 @@ ATEK:
 	RevealsShroud:
 		Range: 10
 	Bib:
+		Sprite: bib3
 	IronCurtainable:
 	GpsPower:
 		Image: gpssicon
@@ -880,6 +882,7 @@ WEAP:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib2
 	-RenderBuilding:
 	RenderBuildingWarFactory:
 	RallyPoint:
@@ -909,6 +912,7 @@ FACT:
 	RevealsShroud:
 		Range: 5
 	Bib:
+		Sprite: bib2
 	Production:
 		Produces: Building,Defense
 	IronCurtainable: 
@@ -952,6 +956,7 @@ PROC:
 	RevealsShroud:
 		Range: 6
 	Bib:
+		Sprite: bib2
 	OreRefinery:
 	StoresOre:
 		PipCount: 17
@@ -1027,6 +1032,7 @@ HPAD:
 	RevealsShroud:
 		Range: 5
 	Bib:
+		Sprite: bib3
 	Exit@1:
 		SpawnOffset: 0,-6
 		ExitCell: 0,0
@@ -1114,6 +1120,7 @@ POWR:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib3
 	IronCurtainable:
 	DeadBuildingState:
 
@@ -1143,6 +1150,7 @@ APWR:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib2
 	IronCurtainable:
 	DeadBuildingState:
 
@@ -1172,6 +1180,7 @@ STEK:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib2
 	IronCurtainable:
 
 BARR:
@@ -1198,6 +1207,7 @@ BARR:
 	RevealsShroud:
 		Range: 5
 	Bib:
+		Sprite: bib3
 	RallyPoint:
 	Exit@1:
 		SpawnOffset: -4,19
@@ -1235,6 +1245,7 @@ TENT:
 	RevealsShroud:
 		Range: 5
 	Bib:
+		Sprite: bib3
 	RallyPoint:
 	Exit@1:
 		SpawnOffset: -1,19
@@ -1317,6 +1328,7 @@ FACF:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib2
 	RenderBuilding:
 		Image: FACT
 	Fake:
@@ -1346,6 +1358,7 @@ WEAF:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib2
 	-RenderBuilding:
 	RenderBuildingWarFactory:
 		Image: WEAP
@@ -1438,6 +1451,7 @@ DOMF:
 	RevealsShroud:
 		Range: 4
 	Bib:
+		Sprite: bib3
 	RenderBuilding:
 		Image: DOME
 	Fake:

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -611,7 +611,6 @@ World:
 		Name: Soviet
 		Race: soviet
 	BibLayer:
-		FrozenUnderFog: true
 	DomainIndex:
 	ResourceLayer:
 	ResourceClaimLayer:

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -601,6 +601,9 @@ World:
 	ShroudPalette@fog:
 		Name: fog
 		Type: Fog
+	ShroudPalette@combined:
+		Name: shroudfog
+		Type: Combined
 	Country@0:
 		Name: Allies
 		Race: allies

--- a/mods/ra/rules/system.yaml
+++ b/mods/ra/rules/system.yaml
@@ -647,9 +647,38 @@ World:
 	DebugOverlay:
 	SpawnMapActors:
 	CreateMPPlayers:
-	MPStartUnits:
+	MPStartUnits@mcvonly:
+		Class: none
 		Races: soviet, allies
 		BaseActor: mcv
+	MPStartUnits@lightallies:
+		Class: light
+		Races: allies
+		BaseActor: mcv
+		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk
+		InnerSupportRadius: 3
+		OuterSupportRadius: 5
+	MPStartUnits@lightsoviet:
+		Class: light
+		Races: soviet
+		BaseActor: mcv
+		SupportActors: e1,e1,e1,e3,e3,apc,ftrk
+		InnerSupportRadius: 3
+		OuterSupportRadius: 5
+	MPStartUnits@heavyallies:
+		Class: heavy
+		Races: allies
+		BaseActor: mcv
+		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk,2tnk,2tnk,2tnk
+		InnerSupportRadius: 3
+		OuterSupportRadius: 5
+	MPStartUnits@heavysoviet:
+		Class: heavy
+		Races: soviet
+		BaseActor: mcv
+		SupportActors: e1,e1,e1,e3,e3,apc,ftrk,3tnk,3tnk
+		InnerSupportRadius: 3
+		OuterSupportRadius: 5
 	MPStartLocations:
 	SpawnMPUnits:
 	SpatialBins:

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -144,6 +144,10 @@ ServerTraits:
 	MasterServerPinger
 
 LobbyDefaults:
+	AllowCheats: false
+	Crates: true
+	StartingUnitsClass: default
+	FragileAlliances: false
 
 ChromeMetrics:
 	mods/ra/metrics.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -143,6 +143,8 @@ ServerTraits:
 	PlayerPinger
 	MasterServerPinger
 
+LobbyDefaults:
+
 ChromeMetrics:
 	mods/ra/metrics.yaml
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -146,7 +146,7 @@ ServerTraits:
 LobbyDefaults:
 	AllowCheats: false
 	Crates: true
-	StartingUnitsClass: default
+	StartingUnitsClass: none
 	FragileAlliances: false
 	Shroud: true
 	Fog: true

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -148,6 +148,8 @@ LobbyDefaults:
 	Crates: true
 	StartingUnitsClass: default
 	FragileAlliances: false
+	Shroud: true
+	Fog: true
 
 ChromeMetrics:
 	mods/ra/metrics.yaml

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -14,7 +14,6 @@ GACNST:
 		Type: Wood
 	RevealsShroud:
 		Range: 5
-	Bib:
 	Production:
 		Produces: Building,Defense
 	Valued:
@@ -58,7 +57,6 @@ GAPOWR:
 		Type: Wood
 	RevealsShroud:
 		Range: 4
-	Bib:
 
 GAPILE:
 	Inherits: ^Building
@@ -84,7 +82,6 @@ GAPILE:
 		Type: Wood
 	RevealsShroud:
 		Range: 5
-	Bib:
 #	RallyPoint: #TODO: setup sequences
 	Exit@1:
 		SpawnOffset: -64,64,0
@@ -117,7 +114,6 @@ GAWEAP:
 		HP: 1000
 	RevealsShroud:
 		Range: 4
-	Bib:
 	-RenderBuilding:
 	RenderBuildingWarFactory:
 #	RallyPoint: # TODO: setup sequences
@@ -302,7 +298,6 @@ GASPOT: # TODO: has moving spotlights
 		Type: Wood
 	RevealsShroud:
 		Range: 4
-	Bib:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 3

--- a/mods/ts/rules/system.yaml
+++ b/mods/ts/rules/system.yaml
@@ -111,7 +111,6 @@ World:
 		Race: nod
 	ResourceLayer:
 	ResourceClaimLayer:
-#	BibLayer: # TODO: file not found: bib3
 	DebugOverlay:
 	SpawnMapActors:
 	CreateMPPlayers:


### PR DESCRIPTION
- Freeze civilian / map buildings under fog (#3614).
- Freeze walls under fog.
- Add lobby options for shroud & fog.
- Allow mods to specify default lobby settings.
- Reset default lobby options when a dedicated server clears.
- Add @ScottNZ's starting unit configuration for RA.
