### PR TITLE
Dedicated server crashfix

### DIFF
--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -440,13 +440,6 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						var startUnits = Rules.Info["world"].Traits.WithInterface<MPStartUnitsInfo>();
-						if (!startUnits.Any(msu => msu.Class == s))
-						{
-							server.SendOrderTo(conn, "Message", "Unknown unit class: {0}".F(s));
-							return true;
-						}
-
 						server.lobbyInfo.GlobalSettings.StartingUnitsClass = s;
 						server.SyncLobbyInfo();
 						return true;


### PR DESCRIPTION
This fixes starting units by removing the bogus check. This makes it no worse than changing race, which also isn't validated, for the same reason.
