### PR TITLE
Add engine support for D2K explosions

### DIFF
--- a/OpenRA.FileFormats/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.FileFormats/Graphics/IGraphicsDevice.cs
@@ -32,6 +32,8 @@ namespace OpenRA.FileFormats.Graphics
 		IGraphicsDevice Create( Size size, WindowMode windowMode );
 	}
 
+	public enum BlendMode { None, Alpha, Additive }
+
 	public interface IGraphicsDevice
 	{
 		IVertexBuffer<Vertex> CreateVertexBuffer( int length );
@@ -55,8 +57,7 @@ namespace OpenRA.FileFormats.Graphics
 		void EnableDepthBuffer();
 		void DisableDepthBuffer();
 
-		void EnableAlphaBlending();
-		void DisableAlphaBlending();
+		void SetBlendMode(BlendMode mode);
 	}
 
 	public interface IVertexBuffer<T>

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Graphics
 		{
 			if (nv > 0)
 			{
-				renderer.Device.EnableAlphaBlending();
+				renderer.Device.SetBlendMode(BlendMode.Alpha);
 				shader.Render(() =>
 				{
 					var vb = renderer.GetTempVertexBuffer();
@@ -42,7 +42,7 @@ namespace OpenRA.Graphics
 					renderer.SetLineWidth(LineWidth * Game.viewport.Zoom);
 					renderer.DrawBatch(vb, 0, nv, PrimitiveType.LineList);
 				});
-				renderer.Device.DisableAlphaBlending();
+				renderer.Device.SetBlendMode(BlendMode.None);
 				nv = 0;
 			}
 		}

--- a/OpenRA.Game/Graphics/QuadRenderer.cs
+++ b/OpenRA.Game/Graphics/QuadRenderer.cs
@@ -31,14 +31,14 @@ namespace OpenRA.Graphics
 		{
 			if (nv > 0)
 			{
-				renderer.Device.EnableAlphaBlending();
+				renderer.Device.SetBlendMode(BlendMode.Alpha);
 				shader.Render(() =>
 				{
 					var vb = renderer.GetTempVertexBuffer();
 					vb.SetData(vertices, nv);
 					renderer.DrawBatch(vb, 0, nv, PrimitiveType.QuadList);
 				});
-				renderer.Device.DisableAlphaBlending();
+				renderer.Device.SetBlendMode(BlendMode.None);
 
 				nv = 0;
 			}

--- a/OpenRA.Game/Graphics/Sequence.cs
+++ b/OpenRA.Game/Graphics/Sequence.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.FileFormats.Graphics;
 
 namespace OpenRA.Graphics
 {
@@ -36,16 +37,20 @@ namespace OpenRA.Graphics
 			Name = name;
 			var d = info.NodesDict;
 			var offset = float2.Zero;
+			var blendMode = BlendMode.Alpha;
 
 			Start = int.Parse(d["Start"].Value);
 
 			if (d.ContainsKey("Offset"))
 				offset = FieldLoader.GetValue<float2>("Offset", d["Offset"].Value);
 
+			if (d.ContainsKey("BlendMode"))
+				blendMode = FieldLoader.GetValue<BlendMode>("BlendMode", d["BlendMode"].Value);
+
 			// Apply offset to each sprite in the sequence
 			// Different sequences may apply different offsets to the same frame
 			sprites = Game.modData.SpriteLoader.LoadAllSprites(srcOverride ?? unit).Select(
-				s => new Sprite(s.sheet, s.bounds, s.offset + offset, s.channel)).ToArray();
+				s => new Sprite(s.sheet, s.bounds, s.offset + offset, s.channel, blendMode)).ToArray();
 
 			if (!d.ContainsKey("Length"))
 				Length = 1;

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Drawing;
+using OpenRA.FileFormats.Graphics;
 
 namespace OpenRA.Graphics
 {
@@ -105,7 +106,7 @@ namespace OpenRA.Graphics
 				p = new Point(0,0);
 			}
 
-			var rect = new Sprite(current, new Rectangle(p, imageSize), spriteOffset, channel);
+			var rect = new Sprite(current, new Rectangle(p, imageSize), spriteOffset, channel, BlendMode.Alpha);
 			p.X += imageSize.Width;
 
 			return rect;

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Drawing;
+using OpenRA.FileFormats.Graphics;
 
 namespace OpenRA.Graphics
 {
@@ -16,21 +17,26 @@ namespace OpenRA.Graphics
 	{
 		public readonly Rectangle bounds;
 		public readonly Sheet sheet;
+		public readonly BlendMode blendMode;
 		public readonly TextureChannel channel;
 		public readonly float2 size;
 		public readonly float2 offset;
 		readonly float2[] textureCoords;
 
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel)
-			: this(sheet, bounds, float2.Zero, channel) {}
+			: this(sheet, bounds, float2.Zero, channel, BlendMode.Alpha) {}
 
-		public Sprite(Sheet sheet, Rectangle bounds, float2 offset, TextureChannel channel)
+		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel, BlendMode blendMode)
+			: this(sheet, bounds, float2.Zero, channel, blendMode) {}
+
+		public Sprite(Sheet sheet, Rectangle bounds, float2 offset, TextureChannel channel, BlendMode blendMode)
 		{
 			this.sheet = sheet;
 			this.bounds = bounds;
 			this.offset = offset;
 			this.channel = channel;
 			this.size = new float2(bounds.Size);
+			this.blendMode = blendMode;
 
 			var left = (float)(bounds.Left) / sheet.Size.Width;
 			var top = (float)(bounds.Top) / sheet.Size.Height;

--- a/OpenRA.Renderer.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Renderer.Null/NullGraphicsDevice.cs
@@ -41,8 +41,7 @@ namespace OpenRA.Renderer.Null
 		public void EnableDepthBuffer() { }
 		public void DisableDepthBuffer() { }
 
-		public void EnableAlphaBlending() { }
-		public void DisableAlphaBlending() { }
+		public void SetBlendMode(BlendMode mode) { }
 
 		public void Clear() { }
 		public void Present() { }

--- a/OpenRA.Renderer.SdlCommon/SdlGraphics.cs
+++ b/OpenRA.Renderer.SdlCommon/SdlGraphics.cs
@@ -147,17 +147,24 @@ namespace OpenRA.Renderer.SdlCommon
 			ErrorHandler.CheckGlError();
 		}
 
-		public void EnableAlphaBlending()
+		public void SetBlendMode(BlendMode mode)
 		{
-			Gl.glEnable(Gl.GL_BLEND);
-			ErrorHandler.CheckGlError();
-			Gl.glBlendFunc(Gl.GL_SRC_ALPHA, Gl.GL_ONE_MINUS_SRC_ALPHA);
-			ErrorHandler.CheckGlError();
-		}
-
-		public void DisableAlphaBlending()
-		{
-			Gl.glDisable(Gl.GL_BLEND);
+			switch (mode)
+			{
+				case BlendMode.None:
+					Gl.glDisable(Gl.GL_BLEND);
+					break;
+				case BlendMode.Alpha:
+					Gl.glEnable(Gl.GL_BLEND);
+					ErrorHandler.CheckGlError();
+					Gl.glBlendFunc(Gl.GL_SRC_ALPHA, Gl.GL_ONE_MINUS_SRC_ALPHA);
+					break;
+				case BlendMode.Additive:
+					Gl.glEnable(Gl.GL_BLEND);
+					ErrorHandler.CheckGlError();
+					Gl.glBlendFunc(Gl.GL_ONE, Gl.GL_ONE);
+					break;
+			}
 			ErrorHandler.CheckGlError();
 		}
 


### PR DESCRIPTION
This exposes a BlendMode sequence property, which will allow #3676 to properly render the D2K explosions.

![explosions](https://f.cloud.github.com/assets/167819/959932/3cafbfd0-049f-11e3-8800-a42814b9c0af.png)
