### PR TITLE
Fix D2K build overlay offsets

### DIFF
--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -107,19 +107,19 @@ rank:
 overlay:
 	build-valid-arrakis: DATA.R8
 		Start: 0
-		Offset: -20,-20
+		Offset: -16,-16
 	build-invalid: DATA.R8
 		Start: 1
-		Offset: -20,-20
+		Offset: -16,-16
 	target-select: DATA.R8
 		Start: 2
-		Offset: -20,-20
+		Offset: -16,-16
 	target-valid-arrakis: DATA.R8
 		Start: 0
-		Offset: -20,-20
+		Offset: -16,-16
 	target-invalid: DATA.R8
 		Start: 1
-		Offset: -20,-20
+		Offset: -16,-16
 
 rallypoint:
 	flag:flagfly


### PR DESCRIPTION
This probably doesn't fix everything in #2293 (somebody will need to compare against the original game), but it does fix the worst issue which is enough to remove it as a blocker from the next release.
