### PR TITLE
Let the AI not command stolen units and brought back the Deviator tank

### DIFF
--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -485,7 +485,7 @@ namespace OpenRA.Mods.RA.AI
 		{
 			squads.RemoveAll(s => !s.IsValid);
 			foreach (var s in squads)
-				s.units.RemoveAll(a => a.Destroyed || a.IsDead());
+				s.units.RemoveAll(a => a.Destroyed || a.IsDead() || a.Owner != p);
 		}
 
 		// Use of this function requires that one squad of this type. Hence it is a piece of shit
@@ -508,8 +508,8 @@ namespace OpenRA.Mods.RA.AI
 		void AssignRolesToIdleUnits(Actor self)
 		{
 			CleanSquads();
-			activeUnits.RemoveAll(a => a.Destroyed || a.IsDead());
-			unitsHangingAroundTheBase.RemoveAll(a => a.Destroyed || a.IsDead());
+			activeUnits.RemoveAll(a => a.Destroyed || a.IsDead() || a.Owner != p); 
+			unitsHangingAroundTheBase.RemoveAll(a => a.Destroyed || a.IsDead() || a.Owner != p);
 
 			if (--rushTicks <= 0)
 			{

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -232,7 +232,7 @@ DEVIATORTANK:
 		Queue: Armor
 		BuildPaletteOrder: 50
 		Prerequisites: heavyo, researcho
-#		Owner: ordos
+		Owner: ordos
 		Hotkey: d
 	Mobile:
 		ROT: 3


### PR DESCRIPTION
extracted from #3691, fixes #2347 properly.
