### PR TITLE
Renamed some project files for IP clearance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,9 +71,5 @@ distributed under the CC BY-SA 3.0 license.
 
 Finally, special thanks goes to the original teams
 at Westwood Studios and EA for creating the classic
-games that inspired the creation of OpenRA.
-
-Red Alert, Command and Conquer, and related
-trademarks belong to Electronic Arts Inc. and are
-used without permission.
+games which OpenRA aims to reimagine.
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -1,5 +1,5 @@
 Metadata:
-	Title: C&C
+	Title: Tiberian Dawn
 	Description: OpenRA Reimagining of the classic game
 	Version: {DEV_VERSION}
 	Author: The OpenRA Developers

--- a/packaging/linux/deb/DEBIAN/control
+++ b/packaging/linux/deb/DEBIAN/control
@@ -7,7 +7,7 @@ Depends: libopenal1, mono-runtime (>= 2.10), libmono-winforms2.0-cil, libfreetyp
 Section: games
 Priority: extra
 Homepage: http://www.open-ra.org/
-Description: A multiplayer re-envisioning of Westwood Studios' C&C and C&C: Red Alert
+Description: A multiplayer re-envisioning of early RTS games by Westwood Studios
  .
  OpenRA is a Libre/Free Real Time Strategy game engine supporting early
  Westwood games like Command & Conquer and Command & Conquer: Red Alert.

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -258,7 +258,7 @@ SectionEnd
 LangString DESC_CLIENT ${LANG_ENGLISH} "OpenRA game and dependencies"
 LangString DESC_EDITOR ${LANG_ENGLISH} "OpenRA map editor"
 LangString DESC_RA ${LANG_ENGLISH} "Base Red Alert mod"
-LangString DESC_CNC ${LANG_ENGLISH} "Base Command and Conquer mod"
+LangString DESC_CNC ${LANG_ENGLISH} "Base Tiberian Dawn mod"
 LangString DESC_D2K ${LANG_ENGLISH} "Base Dune 2000 mod"
 LangString DESC_PORTABLE ${LANG_ENGLISH} "Store support files in the install directory."
 


### PR DESCRIPTION
to avoid unnecessary "Command & Conquer" trademarks that are used for that free to play game currently in the making which builds heavily on it's branding. "Tiberian Dawn" and "Red Alert" itself are not registered by EA without the C&C prefix.
