### PR TITLE
Update civilian.yaml

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -318,7 +318,6 @@ OILB:
 		Dimensions: 2,2
 	Health:
 		HP: 1000
-	Bib:
 	RevealsShroud:
 		Range: 3
 	Capturable:


### PR DESCRIPTION
Remove bib from Oil Derrick as it caused graphical errors on some maps where it was placed near terrain obstacles. (The bib being on top of a river for example)
