### PR TITLE
Request a more general FBO depth format.

### DIFF
--- a/OpenRA.Renderer.SdlCommon/FrameBuffer.cs
+++ b/OpenRA.Renderer.SdlCommon/FrameBuffer.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Renderer.SdlCommon
 			Gl.glBindRenderbufferEXT(Gl.GL_RENDERBUFFER_EXT, depth);
 			ErrorHandler.CheckGlError();
 
-			Gl.glRenderbufferStorageEXT(Gl.GL_RENDERBUFFER_EXT, Gl.GL_DEPTH_COMPONENT16, size.Width, size.Height);
+			Gl.glRenderbufferStorageEXT(Gl.GL_RENDERBUFFER_EXT, Gl.GL_DEPTH_COMPONENT, size.Width, size.Height);
 			ErrorHandler.CheckGlError();
 
 			Gl.glFramebufferRenderbufferEXT(Gl.GL_FRAMEBUFFER_EXT, Gl.GL_DEPTH_ATTACHMENT_EXT, Gl.GL_RENDERBUFFER_EXT, depth);


### PR DESCRIPTION
Some drivers / GPUs don't like `GL_DEPTH_COMPONENT16`. This should provide a safe fix for #3753 we can take before the pending release.
