### PR TITLE
List files again to avoid owning standard dirs in RPM

### DIFF
--- a/packaging/linux/rpm/buildpackage.sh
+++ b/packaging/linux/rpm/buildpackage.sh
@@ -13,7 +13,7 @@ sed -i "s/{VERSION_FIELD}/$PKGVERSION/" openra.spec
 rootdir=`readlink -f $2`
 sed -i "s|{ROOT_DIR}|$rootdir|" openra.spec
 
-for x in `find $rootdir -type d`
+for x in `find $rootdir -type f`
 do
     y="${x#$rootdir}"
     sed -i "/%files/ a ${y}" openra.spec

--- a/packaging/linux/rpm/buildpackage.sh
+++ b/packaging/linux/rpm/buildpackage.sh
@@ -13,7 +13,27 @@ sed -i "s/{VERSION_FIELD}/$PKGVERSION/" openra.spec
 rootdir=`readlink -f $2`
 sed -i "s|{ROOT_DIR}|$rootdir|" openra.spec
 
-for x in `find $rootdir -type f`
+# List files to avoid owning standard dirs.
+for x in `find $rootdir/usr/bin -type f`
+do
+    y="${x#$rootdir}"
+    sed -i "/%files/ a ${y}" openra.spec
+done
+
+for x in `find $rootdir/usr/share/icons -type f`
+do
+    y="${x#$rootdir}"
+    sed -i "/%files/ a ${y}" openra.spec
+done
+
+for x in `find $rootdir/usr/share/applications -type f`
+do
+    y="${x#$rootdir}"
+    sed -i "/%files/ a ${y}" openra.spec
+done
+
+# List directories only to avoid spam and problems with files containing spaces.
+for x in `find $rootdir/usr/share/openra -type d`
 do
     y="${x#$rootdir}"
     sed -i "/%files/ a ${y}" openra.spec

--- a/packaging/linux/rpm/buildpackage.sh
+++ b/packaging/linux/rpm/buildpackage.sh
@@ -14,26 +14,28 @@ rootdir=`readlink -f $2`
 sed -i "s|{ROOT_DIR}|$rootdir|" openra.spec
 
 # List files to avoid owning standard dirs.
-for x in `find $rootdir/usr/bin -type f`
+find $rootdir/usr/bin -type f -print0 | xargs -0 -n 1 echo | while read x
 do
     y="${x#$rootdir}"
     sed -i "/%files/ a ${y}" openra.spec
 done
 
-for x in `find $rootdir/usr/share/icons -type f`
+find $rootdir/usr/share/icons -type f -print0 | xargs -0 -n 1 echo | while read x
 do
     y="${x#$rootdir}"
     sed -i "/%files/ a ${y}" openra.spec
 done
 
-for x in `find $rootdir/usr/share/applications -type f`
+find $rootdir/usr/share/applications -type f -print0 | \
+                                  xargs -0 -n 1 echo | \
+                                  while read x
 do
     y="${x#$rootdir}"
     sed -i "/%files/ a ${y}" openra.spec
 done
 
-# List directories only to avoid spam and problems with files containing spaces.
-for x in `find $rootdir/usr/share/openra -type d`
+# List directories only to avoid spam
+find $rootdir/usr/share/openra -type d -print0 | xargs -0 -n 1 echo | while read x
 do
     y="${x#$rootdir}"
     sed -i "/%files/ a ${y}" openra.spec

--- a/packaging/linux/rpm/buildpackage.sh
+++ b/packaging/linux/rpm/buildpackage.sh
@@ -14,31 +14,31 @@ rootdir=`readlink -f $2`
 sed -i "s|{ROOT_DIR}|$rootdir|" openra.spec
 
 # List files to avoid owning standard dirs.
-find $rootdir/usr/bin -type f -print0 | xargs -0 -n 1 echo | while read x
+`find $rootdir/usr/bin -type f -print0` | xargs -0 -n 1 echo | while read x
 do
     y="${x#$rootdir}"
-    sed -i "/%files/ a ${y}" openra.spec
+    sed -i "/%files/ a \"${y}\"" openra.spec
 done
 
-find $rootdir/usr/share/icons -type f -print0 | xargs -0 -n 1 echo | while read x
+`find $rootdir/usr/share/icons -type f -print0` | xargs -0 -n 1 echo | while read x
 do
     y="${x#$rootdir}"
-    sed -i "/%files/ a ${y}" openra.spec
+    sed -i "/%files/ a \"${y}\"" openra.spec
 done
 
-find $rootdir/usr/share/applications -type f -print0 | \
+`find $rootdir/usr/share/applications -type f -print0` | \
                                   xargs -0 -n 1 echo | \
                                   while read x
 do
     y="${x#$rootdir}"
-    sed -i "/%files/ a ${y}" openra.spec
+    sed -i "/%files/ a \"${y}\"" openra.spec
 done
 
 # List directories only to avoid spam
-find $rootdir/usr/share/openra -type d -print0 | xargs -0 -n 1 echo | while read x
+`find $rootdir/usr/share/openra -type d -print0` | xargs -0 -n 1 echo | while read x
 do
     y="${x#$rootdir}"
-    sed -i "/%files/ a ${y}" openra.spec
+    sed -i "/%files/ a \"${y}\"" openra.spec
 done
 
 cp openra.spec "$3/SPECS/"


### PR DESCRIPTION
reverts commit 9d256d93a59302c06d26f36c88125ce574d7e360

fixes file /usr/bin from install of openra-release.20130915-1.noarch
conflicts with file from package filesystem-3.2-13.fc19.x86_64

reported by @Samoi via IRC
