### PR TITLE
Fixed Unresolved=InfiltrateForCashInfo Missing=InfiltratableInfo in Monster Tank Madness

### DIFF
--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2622,6 +2622,8 @@ Rules:
 		Health:
 			HP: 2000
 	SILO:
+		Infiltratable:
+			Type: Cash
 		InfiltrateForCash:
 	DOME.NoInfiltrate:
 		Inherits: DOME


### PR DESCRIPTION
could not test the whole mission as the V2 destroyed my sub pen after I captured it because I was too slow.
