### PR TITLE
Save Replays in per Mod and Version folders

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -28,14 +28,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
 
 			var rl = panel.Get<ScrollPanelWidget>("REPLAY_LIST");
-			var replayDir = Path.Combine(Platform.SupportDir, "Replays");
+
+			var dir = new[] { Platform.SupportDir, "Replays", WidgetUtils.ActiveModId(), WidgetUtils.ActiveModVersion() }.Aggregate(Path.Combine);
 
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
 			rl.RemoveChildren();
-			if (Directory.Exists(replayDir))
+			if (Directory.Exists(dir))
 			{
-				var files = Directory.GetFiles(replayDir, "*.rep").Reverse();
+				var files = Directory.GetFiles(dir, "*.rep").Reverse();
 				foreach (var replayFile in files)
 					AddReplay(rl, replayFile, template);
 


### PR DESCRIPTION
as discussed in #2152 this will save replays in $HOME/.openra/Replays/$mod/$version instead of putting it all into one folder. That has several advantages:
- No more https://github.com/OpenRA/OpenRA/wiki/FAQ#old-replays-crash-the-game reports.
- Faster loading in the replay browser because fewer files need to get parsed.
- Easier to clean up and maintain that folder as it can grow huge.
