### PR TITLE
Tiberian Sun CD Install Logic

### DIFF
--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="TSLoadScreen.cs" />
+    <Compile Include="Widgets\Logic\TSInstallFromCDLogic.cs" />
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/OpenRA.Mods.TS/Widgets/Logic/TSInstallFromCDLogic.cs
+++ b/OpenRA.Mods.TS/Widgets/Logic/TSInstallFromCDLogic.cs
@@ -1,0 +1,123 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using OpenRA.FileFormats;
+using OpenRA.FileFormats.Graphics;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.TS.Widgets.Logic
+{
+	public class TSInstallFromCDLogic
+	{
+		Widget panel;
+		ProgressBarWidget progressBar;
+		LabelWidget statusLabel;
+		Action continueLoading;
+		ButtonWidget retryButton, backButton;
+		Widget installingContainer, insertDiskContainer;
+
+		[ObjectCreator.UseCtor]
+		public TSInstallFromCDLogic(Widget widget, Action continueLoading)
+		{
+			this.continueLoading = continueLoading;
+			panel = widget.Get("INSTALL_FROMCD_PANEL");
+			progressBar = panel.Get<ProgressBarWidget>("PROGRESS_BAR");
+			statusLabel = panel.Get<LabelWidget>("STATUS_LABEL");
+
+			backButton = panel.Get<ButtonWidget>("BACK_BUTTON");
+			backButton.OnClick = Ui.CloseWindow;
+
+			retryButton = panel.Get<ButtonWidget>("RETRY_BUTTON");
+			retryButton.OnClick = CheckForDisk;
+
+			installingContainer = panel.Get("INSTALLING");
+			insertDiskContainer = panel.Get("INSERT_DISK");
+			CheckForDisk();
+		}
+
+		void CheckForDisk()
+		{
+			Func<string, bool> ValidDiskFilter = diskRoot => File.Exists(diskRoot+Path.DirectorySeparatorChar+"multi.mix") &&
+					File.Exists(new string[] { diskRoot, "install", "tibsun.mix" }.Aggregate(Path.Combine));
+
+			var path = InstallUtils.GetMountedDisk(ValidDiskFilter);
+
+			if (path != null)
+				Install(path);
+			else
+			{
+				insertDiskContainer.IsVisible = () => true;
+				installingContainer.IsVisible = () => false;
+			}
+		}
+
+		void Install(string source)
+		{
+			backButton.IsDisabled = () => true;
+			retryButton.IsDisabled = () => true;
+			insertDiskContainer.IsVisible = () => false;
+			installingContainer.IsVisible = () => true;
+
+			var dest = new string[] { Platform.SupportDir, "Content", "ts" }.Aggregate(Path.Combine);
+			var copyFiles = new string[] { "install/tibsun.mix", "scores.mix", "multi.mix"};
+
+			//tibsun.mix needs to be decrypted to be extracted
+			var extractPackage = "tibsun.mix";
+			var extractFiles = new string[] { "sidenc01.mix", "sidenc02.mix", "cache.mix", "conquer.mix",
+					"isosnow.mix", "isotemp.mix", "local.mix", "sidec01.mix", "sidec02.mix", "sno.mix", 
+					"snow.mix", "sounds.mix", "speech01.mix", "speech02.mix", "tem.mix", "temperat.mix"};
+
+			var installCounter = 0;
+			var installTotal = copyFiles.Count() + extractFiles.Count();
+			var onProgress = (Action<string>)(s => Game.RunAfterTick(() =>
+			{
+				progressBar.Percentage = installCounter*100/installTotal;
+				installCounter++;
+
+				statusLabel.GetText = () => s;
+			}));
+
+			var onError = (Action<string>)(s => Game.RunAfterTick(() =>
+			{
+				statusLabel.GetText = () => "Error: "+s;
+				backButton.IsDisabled = () => false;
+				retryButton.IsDisabled = () => false;
+			}));
+
+			var t = new Thread( _ =>
+			{
+				try
+				{
+					if (!InstallUtils.CopyFiles(source, copyFiles, dest, onProgress, onError))
+						return;
+
+					if (!InstallUtils.ExtractFromPackage(source, extractPackage, extractFiles, dest, onProgress, onError))
+						return;
+
+					Game.RunAfterTick(() =>
+					{
+						Ui.CloseWindow();
+						continueLoading();
+					});
+				}
+				catch
+				{
+					onError("Installation failed");
+				}
+			}) { IsBackground = true };
+			t.Start();
+		}
+	}
+}
+

--- a/OpenRA.Mods.TS/Widgets/Logic/TSInstallFromCDLogic.cs
+++ b/OpenRA.Mods.TS/Widgets/Logic/TSInstallFromCDLogic.cs
@@ -72,14 +72,8 @@ namespace OpenRA.Mods.TS.Widgets.Logic
 			var dest = new string[] { Platform.SupportDir, "Content", "ts" }.Aggregate(Path.Combine);
 			var copyFiles = new string[] { "install/tibsun.mix", "scores.mix", "multi.mix"};
 
-			//tibsun.mix needs to be decrypted to be extracted
-			var extractPackage = "tibsun.mix";
-			var extractFiles = new string[] { "sidenc01.mix", "sidenc02.mix", "cache.mix", "conquer.mix",
-					"isosnow.mix", "isotemp.mix", "local.mix", "sidec01.mix", "sidec02.mix", "sno.mix", 
-					"snow.mix", "sounds.mix", "speech01.mix", "speech02.mix", "tem.mix", "temperat.mix"};
-
 			var installCounter = 0;
-			var installTotal = copyFiles.Count() + extractFiles.Count();
+			var installTotal = copyFiles.Count();
 			var onProgress = (Action<string>)(s => Game.RunAfterTick(() =>
 			{
 				progressBar.Percentage = installCounter*100/installTotal;
@@ -100,9 +94,6 @@ namespace OpenRA.Mods.TS.Widgets.Logic
 				try
 				{
 					if (!InstallUtils.CopyFiles(source, copyFiles, dest, onProgress, onError))
-						return;
-
-					if (!InstallUtils.ExtractFromPackage(source, extractPackage, extractFiles, dest, onProgress, onError))
 						return;
 
 					Game.RunAfterTick(() =>

--- a/mods/ts/chrome/gameinit.yaml
+++ b/mods/ts/chrome/gameinit.yaml
@@ -1,0 +1,165 @@
+Background@INSTALL_PANEL:
+	Logic:RAInstallLogic
+	X:(WINDOW_RIGHT - WIDTH)/2
+	Y:(WINDOW_BOTTOM - HEIGHT)/2
+	Width:510
+	Height:160
+	Children:
+		Label@TITLE:
+			X:0
+			Y:20
+			Width:PARENT_RIGHT
+			Height:25
+			Text:Install Required
+			Align:Center
+			Font:Bold
+		Label@DESC1:
+			X:0
+			Y:50
+			Width:PARENT_RIGHT
+			Height:25
+			Text:OpenRA requires the original Tiberian Sun game content.
+			Align:Center
+		Label@DESC2:
+			X:0
+			Y:70
+			Width:PARENT_RIGHT
+			Height:25
+			Text:Content can be downloaded, or copied from the install CD.
+			Align:Center
+		Button@DOWNLOAD_BUTTON:
+			X:20
+			Y:PARENT_BOTTOM - 45
+			Width:110
+			Height:25
+			Text:Download
+			Font:Bold
+		Button@INSTALL_BUTTON:
+			X:140
+			Y:PARENT_BOTTOM - 45
+			Width:110
+			Height:25
+			Text:Use CD
+			Font:Bold
+		Button@MODS_BUTTON:
+			X:PARENT_RIGHT - 250
+			Y:PARENT_BOTTOM - 45
+			Width:110
+			Height:25
+			Text:Change Mod
+			Font:Bold
+		Button@QUIT_BUTTON:
+			X:PARENT_RIGHT - 130
+			Y:PARENT_BOTTOM - 45
+			Width:110
+			Height:25
+			Text:Quit
+			Font:Bold
+
+Background@INSTALL_DOWNLOAD_PANEL:
+	Logic:DownloadPackagesLogic
+	X:(WINDOW_RIGHT - WIDTH)/2
+	Y:(WINDOW_BOTTOM - HEIGHT)/2
+	Width:500
+	Height:160
+	Children:
+		Label@TITLE:
+			X:0
+			Y:20
+			Width:PARENT_RIGHT
+			Height:25
+			Text:Downloading Tiberian Sun Content
+			Align:Center
+			Font:Bold
+		ProgressBar@PROGRESS_BAR:
+			X:50
+			Y:55
+			Width:PARENT_RIGHT - 100
+			Height:25
+		Label@STATUS_LABEL:
+			X:50
+			Y:80
+			Width:PARENT_RIGHT - 100
+			Height:25
+			Align:Left
+		Button@RETRY_BUTTON:
+			X:PARENT_RIGHT - 280
+			Y:PARENT_BOTTOM - 45
+			Width:120
+			Height:25
+			Visible: false
+			Text:Retry
+			Font:Bold
+			Key:return
+		Button@CANCEL_BUTTON:
+			X:PARENT_RIGHT - 140
+			Y:PARENT_BOTTOM - 45
+			Width:120
+			Height:25
+			Text:Cancel
+			Font:Bold
+			Key:escape
+Background@INSTALL_FROMCD_PANEL:
+	Logic:TSInstallFromCDLogic
+	X:(WINDOW_RIGHT - WIDTH)/2
+	Y:(WINDOW_BOTTOM - HEIGHT)/2
+	Width:500
+	Height:160
+	Children:
+		Label@TITLE:
+			X:0
+			Y:20
+			Width:PARENT_RIGHT
+			Height:25
+			Text:Installing from CD
+			Align:Center
+			Font:Bold
+		Container@INSTALLING:
+			Width:PARENT_RIGHT
+			Height:PARENT_BOTTOM
+			Visible: false
+			Children:
+				ProgressBar@PROGRESS_BAR:
+					X:50
+					Y:55
+					Width:PARENT_RIGHT - 100
+					Height:25
+				Label@STATUS_LABEL:
+					X:50
+					Y:80
+					Width:PARENT_RIGHT - 100
+					Height:25
+					Align:Left
+		Container@INSERT_DISK:
+			Width:PARENT_RIGHT
+			Height:PARENT_BOTTOM
+			Visible: false
+			Children:
+				Label@INFO:
+					Y:50
+					Width:PARENT_RIGHT
+					Height:25
+					Text:Disk not found.
+					Align:Center
+				Label@INFO2:
+					Y:70
+					Width:PARENT_RIGHT
+					Height:25
+					Text:Please insert one of the Tiberian Sun install CDs then click Retry.
+					Align:Center
+		Button@RETRY_BUTTON:
+			X:PARENT_RIGHT - 280
+			Y:PARENT_BOTTOM - 45
+			Width:120
+			Height:25
+			Text:Retry
+			Font:Bold
+			Key:return
+		Button@BACK_BUTTON:
+			X:PARENT_RIGHT - 140
+			Y:PARENT_BOTTOM - 45
+			Width:120
+			Height:25
+			Text:Cancel
+			Font:Bold
+			Key:escape

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -89,7 +89,7 @@ Assemblies:
 	mods/ts/OpenRA.Mods.TS.dll
 
 ChromeLayout:
-	mods/ra/chrome/gameinit.yaml
+	mods/ts/chrome/gameinit.yaml
 	mods/ra/chrome/ingame.yaml
 	mods/ra/chrome/ingame-chat.yaml
 	mods/ra/chrome/ingame-diplomacy.yaml


### PR DESCRIPTION
Basic install logic which will copy the required files from a Tiberian Sun CD. It will not copy firestorm content which at this point in time is required by the mod.
