### PR TITLE
Viewport cleanup

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -212,7 +212,7 @@ namespace OpenRA
 			BeforeGameStart();
 
 			var map = modData.PrepareMap(mapUID);
-			viewport = new Viewport(new int2(Renderer.Resolution), map.Bounds, Renderer);
+			viewport = new Viewport(map.Bounds);
 			orderManager.world = new World(modData.Manifest, map, orderManager, isShellmap);
 			worldRenderer = new WorldRenderer(orderManager.world);
 			orderManager.world.LoadComplete(worldRenderer);
@@ -328,7 +328,7 @@ namespace OpenRA
 			PerfHistory.items["render_flip"].hasNormalTick = false;
 
 			JoinLocal();
-			viewport = new Viewport(new int2(Renderer.Resolution), Rectangle.Empty, Renderer);
+			viewport = new Viewport(Rectangle.Empty);
 
 			if (Game.Settings.Server.Dedicated)
 			{

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -45,11 +45,6 @@ namespace OpenRA
 		public static Renderer Renderer;
 		public static bool HasInputFocus = false;
 
-		public static void MoveViewport(float2 loc)
-		{
-			viewport.Center(loc);
-		}
-
 		public static void JoinServer(string host, int port)
 		{
 			JoinInner(new OrderManager(host, port,

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -141,8 +141,8 @@ namespace OpenRA
 				// worldRenderer is null during the initial install/download screen
 				if (worldRenderer != null)
 				{
-					Game.Renderer.BeginFrame(worldRenderer.Viewport.Location, Zoom);
-					Sound.SetListenerPosition(worldRenderer.Position(worldRenderer.Viewport.CenterLocation.ToInt2()));
+					Game.Renderer.BeginFrame(worldRenderer.Viewport.TopLeft.ToFloat2(), Zoom);
+					Sound.SetListenerPosition(worldRenderer.Position(worldRenderer.Viewport.CenterLocation));
 					worldRenderer.Draw();
 				}
 				else

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -39,7 +39,6 @@ namespace OpenRA
 			set { worldRenderer.Viewport.Zoom = value; }
 		}
 
-		public static Viewport viewport;
 		public static Settings Settings;
 
 		internal static OrderManager orderManager;
@@ -122,7 +121,8 @@ namespace OpenRA
 		public static void RunAfterTick(Action a) { delayedActions.Add(a); }
 		public static void RunAfterDelay(int delay, Action a) { delayedActions.Add(a, delay); }
 
-		static void Tick(OrderManager orderManager, Viewport viewPort)
+		static float cursorFrame = 0f;
+		static void Tick(OrderManager orderManager)
 		{
 			if (orderManager.Connection.ConnectionState != lastConnectionState)
 			{
@@ -130,17 +130,35 @@ namespace OpenRA
 				ConnectionStateChanged(orderManager);
 			}
 
-			Tick(orderManager);
+			TickInner(orderManager);
 			if (worldRenderer != null && orderManager.world != worldRenderer.world)
-				Tick(worldRenderer.world.orderManager);
+				TickInner(worldRenderer.world.orderManager);
 
 			using (new PerfSample("render"))
 			{
 				++RenderFrame;
-				viewport.DrawRegions(worldRenderer, new DefaultInputHandler(orderManager.world));
 
+				// worldRenderer is null during the initial install/download screen
 				if (worldRenderer != null)
-					Sound.SetListenerPosition(worldRenderer.Position(viewport.CenterLocation.ToInt2()));
+				{
+					Game.Renderer.BeginFrame(worldRenderer.Viewport.Location, Zoom);
+					Sound.SetListenerPosition(worldRenderer.Position(worldRenderer.Viewport.CenterLocation.ToInt2()));
+					worldRenderer.Draw();
+				}
+				else
+					Game.Renderer.BeginFrame(float2.Zero, 1f);
+
+				using (new PerfSample("render_widgets"))
+				{
+					Ui.Draw();
+					var cursorName = Ui.Root.GetCursorOuter(Viewport.LastMousePos) ?? "default";
+					CursorProvider.DrawCursor(Game.Renderer, cursorName, Viewport.LastMousePos, (int)cursorFrame);
+				}
+
+				using (new PerfSample("render_flip"))
+				{
+					Game.Renderer.EndFrame(new DefaultInputHandler(orderManager.world));
+				}
 			}
 
 			PerfHistory.items["render"].Tick();
@@ -151,7 +169,7 @@ namespace OpenRA
 			delayedActions.PerformActions();
 		}
 
-		static void Tick(OrderManager orderManager)
+		static void TickInner(OrderManager orderManager)
 		{
 			int t = Environment.TickCount;
 			int dt = t - orderManager.LastTickTime;
@@ -163,6 +181,7 @@ namespace OpenRA
 					var world = orderManager.world;
 					if (orderManager.GameStarted)
 						++Viewport.TicksSinceLastMove;
+
 					Sound.Tick();
 					Sync.CheckSyncUnchanged(world, orderManager.TickImmediate);
 
@@ -194,7 +213,8 @@ namespace OpenRA
 								orderManager.LastTickTime = Environment.TickCount;
 
 						Sync.CheckSyncUnchanged(world, () => world.TickRender(worldRenderer));
-						viewport.Tick();
+
+						cursorFrame += 0.5f;
 					}
 				}
 		}
@@ -212,7 +232,6 @@ namespace OpenRA
 			BeforeGameStart();
 
 			var map = modData.PrepareMap(mapUID);
-			viewport = new Viewport(map.Bounds);
 			orderManager.world = new World(modData.Manifest, map, orderManager, isShellmap);
 			worldRenderer = new WorldRenderer(orderManager.world);
 			orderManager.world.LoadComplete(worldRenderer);
@@ -328,7 +347,6 @@ namespace OpenRA
 			PerfHistory.items["render_flip"].hasNormalTick = false;
 
 			JoinLocal();
-			viewport = new Viewport(Rectangle.Empty);
 
 			if (Game.Settings.Server.Dedicated)
 			{
@@ -392,7 +410,7 @@ namespace OpenRA
 				var idealFrameTime = 1.0 / Settings.Graphics.MaxFramerate;
 				var sw = new Stopwatch();
 
-				Tick( orderManager, viewport );
+				Tick(orderManager);
 
 				if (Settings.Graphics.CapFramerate)
 				{

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -33,6 +33,11 @@ namespace OpenRA
 
 		public static ModData modData;
 		static WorldRenderer worldRenderer;
+		public static float Zoom
+		{
+			get { return worldRenderer.Viewport.Zoom; }
+			set { worldRenderer.Viewport.Zoom = value; }
+		}
 
 		public static Viewport viewport;
 		public static Settings Settings;

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Graphics
 				{
 					var vb = renderer.GetTempVertexBuffer();
 					vb.SetData(vertices, nv);
-					renderer.SetLineWidth(LineWidth * Game.viewport.Zoom);
+					renderer.SetLineWidth(LineWidth * Game.Zoom);
 					renderer.DrawBatch(vb, 0, nv, PrimitiveType.LineList);
 				});
 				renderer.Device.SetBlendMode(BlendMode.None);

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Graphics
 
 		static IGraphicsDevice device;
 
-		public static Size Resolution { get { return device.WindowSize; } }
+		public Size Resolution { get { return device.WindowSize; } }
 
 		// Work around a bug in OSX 10.6.8 / mono 2.10.2 / SDL 1.2.14
 		// which makes the window non-interactive in Windowed/Pseudofullscreen mode.

--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -161,7 +161,7 @@ namespace OpenRA.Graphics
 
 			GenerateSprites(shroud);
 
-			var clipRect = Game.viewport.WorldBounds(wr.world);
+			var clipRect = wr.Viewport.WorldBounds(wr.world);
 
 			// We draw the shroud when disabled to hide the sharp map edges
 			DrawShroud(wr, clipRect, sprites, shroudPalette);

--- a/OpenRA.Game/Graphics/ShroudRenderer.cs
+++ b/OpenRA.Game/Graphics/ShroudRenderer.cs
@@ -161,9 +161,8 @@ namespace OpenRA.Graphics
 
 			GenerateSprites(shroud);
 
-			var clipRect = wr.Viewport.WorldBounds(wr.world);
-
 			// We draw the shroud when disabled to hide the sharp map edges
+			var clipRect = wr.Viewport.CellBounds;
 			DrawShroud(wr, clipRect, sprites, shroudPalette);
 
 			if (world.LobbyInfo.GlobalSettings.Fog)

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -46,35 +46,13 @@ namespace OpenRA.Graphics
 
 		public void Draw(WorldRenderer wr, Viewport viewport)
 		{
-			int verticesPerRow = 4*map.Bounds.Width;
-
-			int visibleRows = (int)(Game.Renderer.Resolution.Height * 1f / Game.CellSize / viewport.Zoom + 2);
-
-			int firstRow = (int)(viewport.Location.Y * 1f / Game.CellSize - map.Bounds.Top);
-			int lastRow = firstRow + visibleRows;
+			var verticesPerRow = 4*map.Bounds.Width;
+			var bounds = viewport.CellBounds;
+			var firstRow = bounds.Top - map.Bounds.Top;
+			var lastRow = bounds.Bottom - map.Bounds.Top;
 
 			if (lastRow < 0 || firstRow > map.Bounds.Height)
 				return;
-
-			if (world.VisibleBounds.HasValue)
-			{
-				var r = world.VisibleBounds.Value;
-				if (firstRow < r.Top - map.Bounds.Top)
-					firstRow = r.Top - map.Bounds.Top;
-
-				if (firstRow > r.Bottom - map.Bounds.Top)
-					firstRow = r.Bottom - map.Bounds.Top;
-			}
-
-			// Sanity checking
-			if (firstRow < 0)
-				firstRow = 0;
-
-			if (lastRow > map.Bounds.Height)
-				lastRow = map.Bounds.Height;
-
-			if (lastRow < firstRow)
-				lastRow = firstRow;
 
 			Game.Renderer.WorldSpriteRenderer.DrawVertexBuffer(
 				vertexBuffer, verticesPerRow * firstRow, verticesPerRow * (lastRow - firstRow),

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Graphics
 		{
 			int verticesPerRow = 4*map.Bounds.Width;
 
-			int visibleRows = (int)(viewport.Height * 1f / Game.CellSize / viewport.Zoom + 2);
+			int visibleRows = (int)(Game.Renderer.Resolution.Height * 1f / Game.CellSize / viewport.Zoom + 2);
 
 			int firstRow = (int)(viewport.Location.Y * 1f / Game.CellSize - map.Bounds.Top);
 			int lastRow = firstRow + visibleRows;

--- a/OpenRA.Game/Graphics/TextRenderable.cs
+++ b/OpenRA.Game/Graphics/TextRenderable.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Graphics
 		public void BeforeRender(WorldRenderer wr) {}
 		public void Render(WorldRenderer wr)
 		{
-			var screenPos = wr.Viewport.Zoom*(wr.ScreenPosition(pos) - wr.Viewport.Location) - 0.5f*font.Measure(text).ToFloat2();
+			var screenPos = wr.Viewport.Zoom*(wr.ScreenPosition(pos) - wr.Viewport.TopLeft.ToFloat2()) - 0.5f*font.Measure(text).ToFloat2();
 			var screenPxPos = new float2((float)Math.Round(screenPos.X), (float)Math.Round(screenPos.Y));
 			font.DrawTextWithContrast(text, screenPxPos, color, Color.Black, 1);
 		}

--- a/OpenRA.Game/Graphics/TextRenderable.cs
+++ b/OpenRA.Game/Graphics/TextRenderable.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Graphics
 		public void BeforeRender(WorldRenderer wr) {}
 		public void Render(WorldRenderer wr)
 		{
-			var screenPos = Game.viewport.Zoom*(wr.ScreenPosition(pos) - Game.viewport.Location) - 0.5f*font.Measure(text).ToFloat2();
+			var screenPos = wr.Viewport.Zoom*(wr.ScreenPosition(pos) - wr.Viewport.Location) - 0.5f*font.Measure(text).ToFloat2();
 			var screenPxPos = new float2((float)Math.Round(screenPos.X), (float)Math.Round(screenPos.Y));
 			font.DrawTextWithContrast(text, screenPxPos, color, Color.Black, 1);
 		}

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -150,12 +150,17 @@ namespace OpenRA.Graphics
 			scrollPosition = NormalizeScrollPosition((Game.CellSize * loc - 1f/(2*Zoom)*new float2(Game.Renderer.Resolution)).ToInt2());
 		}
 
+		public void Center(WPos pos)
+		{
+			Center(new float2(pos.X / 1024f, (pos.Y + pos.Z) / 1024f));
+		}
+
 		public void Center(IEnumerable<Actor> actors)
 		{
 			if (!actors.Any())
 				return;
 
-			Center(actors.Select(a => a.CenterPosition).Average().ToCPos().ToFloat2());
+			Center(actors.Select(a => a.CenterPosition).Average());
 		}
 
 		// Rectangle (in viewport coords) that contains things to be drawn

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -66,8 +66,6 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		float cursorFrame = 0f;
-
 		public static int TicksSinceLastMove = 0;
 		public static int2 LastMousePos;
 
@@ -109,30 +107,6 @@ namespace OpenRA.Graphics
 
 			Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
 			scrollPosition = new int2(scrollLimits.Location) + new int2(scrollLimits.Size)/2;
-		}
-
-		public void DrawRegions(WorldRenderer wr, IInputHandler inputHandler)
-		{
-			Game.Renderer.BeginFrame(scrollPosition, Zoom);
-			if (wr != null)
-				wr.Draw();
-
-			using (new PerfSample("render_widgets"))
-			{
-				Ui.Draw();
-				var cursorName = Ui.Root.GetCursorOuter(Viewport.LastMousePos) ?? "default";
-				CursorProvider.DrawCursor(Game.Renderer, cursorName, Viewport.LastMousePos, (int)cursorFrame);
-			}
-
-			using (new PerfSample("render_flip"))
-			{
-				Game.Renderer.EndFrame(inputHandler);
-			}
-		}
-
-		public void Tick()
-		{
-			cursorFrame += 0.5f;
 		}
 
 		// Convert from viewport coords to cell coords (not px)

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Graphics
 	{
 		public readonly World world;
 		public readonly Theater Theater;
-		public Viewport Viewport { get { return Game.viewport; } }
+		public Viewport Viewport { get; private set; }
 
 		internal readonly TerrainRenderer terrainRenderer;
 		internal readonly ShroudRenderer shroudRenderer;
@@ -45,6 +45,7 @@ namespace OpenRA.Graphics
 		internal WorldRenderer(World world)
 		{
 			this.world = world;
+			Viewport = new Viewport(world.Map.Bounds);
 			palette = new HardwarePalette();
 
 			palettes = new Cache<string, PaletteReference>(CreatePaletteReference);

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Graphics
 	{
 		public readonly World world;
 		public readonly Theater Theater;
+		public Viewport Viewport { get { return Game.viewport; } }
 
 		internal readonly TerrainRenderer terrainRenderer;
 		internal readonly ShroudRenderer shroudRenderer;

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -75,9 +75,9 @@ namespace OpenRA.Graphics
 		List<IRenderable> GenerateRenderables()
 		{
 			var comparer = new RenderableComparer(this);
-			var vb = Game.viewport.ViewBounds(world);
-			var tl = Game.viewport.ViewToWorldPx(new int2(vb.Left, vb.Top));
-			var br = Game.viewport.ViewToWorldPx(new int2(vb.Right, vb.Bottom));
+			var vb = Viewport.ViewBounds(world);
+			var tl = Viewport.ViewToWorldPx(new int2(vb.Left, vb.Top));
+			var br = Viewport.ViewToWorldPx(new int2(vb.Right, vb.Bottom));
 			var actors = world.ScreenMap.ActorsInBox(tl, br)
 				.Append(world.WorldActor)
 				.ToList();
@@ -116,10 +116,10 @@ namespace OpenRA.Graphics
 				return;
 
 			var renderables = GenerateRenderables();
-			var bounds = Game.viewport.ViewBounds(world);
+			var bounds = Viewport.ViewBounds(world);
 			Game.Renderer.EnableScissor(bounds.Left, bounds.Top, bounds.Width, bounds.Height);
 
-			terrainRenderer.Draw(this, Game.viewport);
+			terrainRenderer.Draw(this, Viewport);
 			Game.Renderer.Flush();
 
 			for (var i = 0; i < renderables.Count; i++)

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Graphics
 		internal WorldRenderer(World world)
 		{
 			this.world = world;
-			Viewport = new Viewport(world.Map.Bounds);
+			Viewport = new Viewport(this, world.Map);
 			palette = new HardwarePalette();
 
 			palettes = new Cache<string, PaletteReference>(CreatePaletteReference);
@@ -76,10 +76,7 @@ namespace OpenRA.Graphics
 		List<IRenderable> GenerateRenderables()
 		{
 			var comparer = new RenderableComparer(this);
-			var vb = Viewport.ViewBounds(world);
-			var tl = Viewport.ViewToWorldPx(new int2(vb.Left, vb.Top));
-			var br = Viewport.ViewToWorldPx(new int2(vb.Right, vb.Bottom));
-			var actors = world.ScreenMap.ActorsInBox(tl, br)
+			var actors = world.ScreenMap.ActorsInBox(Viewport.TopLeft, Viewport.BottomRight)
 				.Append(world.WorldActor)
 				.ToList();
 
@@ -117,7 +114,7 @@ namespace OpenRA.Graphics
 				return;
 
 			var renderables = GenerateRenderables();
-			var bounds = Viewport.ViewBounds(world);
+			var bounds = Viewport.ScissorBounds;
 			Game.Renderer.EnableScissor(bounds.Left, bounds.Top, bounds.Width, bounds.Height);
 
 			terrainRenderer.Draw(this, Viewport);

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Orders
 				target = Target.FromActor(underCursor);
 			else
 			{
-				var frozen = world.FindFrozenActorsAtMouse(mi.Location)
+				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi.Location)
 					.Where(a => a.Info.Traits.Contains<ITargetableInfo>())
 					.OrderByDescending(a => a.Info.SelectionPriority())
 					.FirstOrDefault();
@@ -77,7 +77,7 @@ namespace OpenRA.Orders
 				target = Target.FromActor(underCursor);
 			else
 			{
-				var frozen = world.FindFrozenActorsAtMouse(mi.Location)
+				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi.Location)
 					.Where(a => a.Info.Traits.Contains<ITargetableInfo>())
 					.OrderByDescending(a => a.Info.SelectionPriority())
 					.FirstOrDefault();

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Orders
 	{
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
-			var underCursor = world.ScreenMap.ActorsAt(Game.viewport.ViewToWorldPx(mi.Location))
+			var underCursor = world.ScreenMap.ActorsAt(mi)
 				.Where(a => !world.FogObscures(a) && a.HasTrait<ITargetable>())
 				.OrderByDescending(a => a.Info.SelectionPriority())
 				.FirstOrDefault();
@@ -60,7 +60,7 @@ namespace OpenRA.Orders
 		public string GetCursor(World world, CPos xy, MouseInput mi)
 		{
 			var useSelect = false;
-			var underCursor = world.ScreenMap.ActorsAt(Game.viewport.ViewToWorldPx(mi.Location))
+			var underCursor = world.ScreenMap.ActorsAt(mi)
 				.Where(a => !world.FogObscures(a) && a.HasTrait<ITargetable>())
 				.OrderByDescending(a => a.Info.SelectionPriority())
 				.FirstOrDefault();

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA
@@ -64,7 +65,7 @@ namespace OpenRA
 
 		Cache<int, List<Actor>> controlGroups = new Cache<int, List<Actor>>(_ => new List<Actor>());
 
-		public void DoControlGroup(World world, int group, Modifiers mods, int MultiTapCount)
+		public void DoControlGroup(World world, WorldRenderer worldRenderer, int group, Modifiers mods, int MultiTapCount)
 		{
 			var addModifier = Platform.CurrentPlatform == PlatformType.OSX ? Modifiers.Meta : Modifiers.Ctrl;
 			if (mods.HasModifier(addModifier))
@@ -84,7 +85,7 @@ namespace OpenRA
 
 			if (mods.HasModifier(Modifiers.Alt) || MultiTapCount >= 2)
 			{
-				Game.viewport.Center(controlGroups[group]);
+				worldRenderer.Viewport.Center(controlGroups[group]);
 				return;
 			}
 

--- a/OpenRA.Game/Sound.cs
+++ b/OpenRA.Game/Sound.cs
@@ -682,8 +682,9 @@ namespace OpenRA
 			Al.alSourcei(source, Al.AL_LOOPING, looping ? Al.AL_TRUE : Al.AL_FALSE);
 			Al.alSourcei(source, Al.AL_SOURCE_RELATIVE, relative ? 1 : 0);
 
-			Al.alSourcef(source, Al.AL_REFERENCE_DISTANCE, Game.viewport.WorldRect.Width / 8);
-			Al.alSourcef(source, Al.AL_MAX_DISTANCE, 2*Game.viewport.WorldRect.Width);
+			var width = Game.Renderer.Resolution.Width / (Game.Zoom * Game.CellSize);
+			Al.alSourcef(source, Al.AL_REFERENCE_DISTANCE, width / 8);
+			Al.alSourcef(source, Al.AL_MAX_DISTANCE, 2 * width);
 			Al.alSourcePlay(source);
 		}
 

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Traits
 					rt.info.PaletteRef = wr.Palette(rt.info.Palette);
 			}
 
-			var clip = wr.Viewport.WorldBounds(world);
+			var clip = wr.Viewport.CellBounds;
 			for (var x = clip.Left; x < clip.Right; x++)
 			{
 				for (var y = clip.Top; y < clip.Bottom; y++)

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Traits
 					rt.info.PaletteRef = wr.Palette(rt.info.Palette);
 			}
 
-			var clip = Game.viewport.WorldBounds(world);
+			var clip = wr.Viewport.WorldBounds(world);
 			for (var x = clip.Left; x < clip.Right; x++)
 			{
 				for (var y = clip.Top; y < clip.Bottom; y++)

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -127,6 +127,11 @@ namespace OpenRA.Traits
 				.Select(kv => kv.Key);
 		}
 
+		public IEnumerable<Actor> ActorsAt(MouseInput mi)
+		{
+			return ActorsAt(worldRenderer.Viewport.ViewToWorldPx(mi.Location));
+		}
+
 		public IEnumerable<Actor> ActorsInBox(int2 a, int2 b)
 		{
 			return ActorsInBox(Rectangle.FromLTRB(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y), Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)));

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -109,8 +109,12 @@ namespace OpenRA.Traits
 			Add(a);
 		}
 
+		public static readonly IEnumerable<FrozenActor> NoFrozenActors = new FrozenActor[0].AsEnumerable();
 		public IEnumerable<FrozenActor> FrozenActorsAt(Player viewer, int2 pxPos)
 		{
+			if (viewer == null)
+				return NoFrozenActors;
+
 			var i = (pxPos.X / info.BinSize).Clamp(0, cols - 1);
 			var j = (pxPos.Y / info.BinSize).Clamp(0, rows - 1);
 			return frozen[viewer][j*cols + i]

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Traits
 		{
 			if (shakeEffects.Any())
 			{
-				Game.viewport.Scroll(GetScrollOffset(), true);
+				worldRenderer.Viewport.Scroll(GetScrollOffset(), true);
 				shakeEffects.RemoveAll(t => t.ExpiryTime == ticks);
 			}
 
@@ -50,7 +50,7 @@ namespace OpenRA.Traits
 
 		float GetIntensity()
 		{
-			var cp = worldRenderer.Position(Game.viewport.CenterLocation.ToInt2());
+			var cp = worldRenderer.Position(worldRenderer.Viewport.CenterLocation.ToInt2());
 			var intensity = 100 * 1024 * 1024 * shakeEffects.Sum(
 				e => (float)e.Intensity / (e.Position - cp).LengthSquared);
 

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Traits
 
 		float GetIntensity()
 		{
-			var cp = worldRenderer.Position(worldRenderer.Viewport.CenterLocation.ToInt2());
+			var cp = worldRenderer.Position(worldRenderer.Viewport.CenterLocation);
 			var intensity = 100 * 1024 * 1024 * shakeEffects.Sum(
 				e => (float)e.Intensity / (e.Position - cp).LengthSquared);
 

--- a/OpenRA.Game/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Game/Widgets/DropDownButtonWidget.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Widgets
 
 			// Mask to prevent any clicks from being sent to other widgets
 			fullscreenMask = new MaskWidget();
-			fullscreenMask.Bounds = new Rectangle(0, 0, Game.viewport.Width, Game.viewport.Height);
+			fullscreenMask.Bounds = new Rectangle(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
 			fullscreenMask.OnMouseDown += mi => RemovePanel();
 			if (onCancel != null)
 				fullscreenMask.OnMouseDown += _ => onCancel();

--- a/OpenRA.Game/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Game/Widgets/TooltipContainerWidget.cs
@@ -54,8 +54,8 @@ namespace OpenRA.Widgets
 				var pos = Viewport.LastMousePos + CursorOffset;
 				if (tooltip != null)
 				{
-					if (pos.X + tooltip.Bounds.Right > Game.viewport.Width)
-						pos.X = Game.viewport.Width - tooltip.Bounds.Right;
+					if (pos.X + tooltip.Bounds.Right > Game.Renderer.Resolution.Width)
+						pos.X = Game.Renderer.Resolution.Width - tooltip.Bounds.Right;
 				}
 
 				return pos;

--- a/OpenRA.Game/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportControllerWidget.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Widgets
 				(mi.Button == MouseButton.Middle || mi.Button == (MouseButton.Left | MouseButton.Right)))
 			{
 				var d = scrolltype == MouseScrollType.Inverted ? -1 : 1;
-				worldRenderer.Viewport.Scroll((Viewport.LastMousePos - mi.Location) * d);
+				worldRenderer.Viewport.Scroll((Viewport.LastMousePos - mi.Location) * d, false);
 				return true;
 			}
 
@@ -195,7 +195,7 @@ namespace OpenRA.Widgets
 				var length = Math.Max(1, scroll.Length);
 				scroll *= (1f / length) * Game.Settings.Game.ViewportEdgeScrollStep;
 
-				worldRenderer.Viewport.Scroll(scroll);
+				worldRenderer.Viewport.Scroll(scroll, false);
 			}
 		}
 

--- a/OpenRA.Game/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportControllerWidget.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Widgets
 				return;
 			}
 
-			var frozen = world.FindFrozenActorsAtMouse(Viewport.LastMousePos)
+			var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, Viewport.LastMousePos)
 				.Where(a => a.TooltipName != null)
 				.OrderByDescending(a => a.Info.SelectionPriority())
 				.FirstOrDefault();

--- a/OpenRA.Game/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportControllerWidget.cs
@@ -206,9 +206,9 @@ namespace OpenRA.Widgets
 				directions |= ScrollDirection.Left;
 			if (Viewport.LastMousePos.Y < EdgeScrollThreshold)
 				directions |= ScrollDirection.Up;
-			if (Viewport.LastMousePos.X >= Game.viewport.Width - EdgeScrollThreshold)
+			if (Viewport.LastMousePos.X >= Game.Renderer.Resolution.Width - EdgeScrollThreshold)
 				directions |= ScrollDirection.Right;
-			if (Viewport.LastMousePos.Y >= Game.viewport.Height - EdgeScrollThreshold)
+			if (Viewport.LastMousePos.Y >= Game.Renderer.Resolution.Height - EdgeScrollThreshold)
 				directions |= ScrollDirection.Down;
 
 			return directions;

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -188,15 +188,15 @@ namespace OpenRA.Widgets
 		{
 			// Parse the YAML equations to find the widget bounds
 			var parentBounds = (Parent == null)
-				? new Rectangle(0, 0, Game.viewport.Width, Game.viewport.Height)
+				? new Rectangle(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height)
 				: Parent.Bounds;
 
 			var substitutions = args.ContainsKey("substitutions") ?
 				new Dictionary<string, int>((Dictionary<string, int>)args["substitutions"]) :
 				new Dictionary<string, int>();
 
-			substitutions.Add("WINDOW_RIGHT", Game.viewport.Width);
-			substitutions.Add("WINDOW_BOTTOM", Game.viewport.Height);
+			substitutions.Add("WINDOW_RIGHT", Game.Renderer.Resolution.Width);
+			substitutions.Add("WINDOW_BOTTOM", Game.Renderer.Resolution.Height);
 			substitutions.Add("PARENT_RIGHT", parentBounds.Width);
 			substitutions.Add("PARENT_LEFT", parentBounds.Left);
 			substitutions.Add("PARENT_TOP", parentBounds.Top);

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -90,12 +90,8 @@ namespace OpenRA.Widgets
 					if (MultiClick)
 					{
 						var unit = world.ScreenMap.ActorsAt(xy).FirstOrDefault();
-
-						var visibleWorld = worldRenderer.Viewport.ViewBounds(world);
-						var topLeft = worldRenderer.Viewport.ViewToWorldPx(new int2(visibleWorld.Left, visibleWorld.Top));
-						var bottomRight = worldRenderer.Viewport.ViewToWorldPx(new int2(visibleWorld.Right, visibleWorld.Bottom));
-						var newSelection2= SelectActorsInBox(world, topLeft, bottomRight, 
-						                                      a => unit != null && a.Info.Name == unit.Info.Name && a.Owner == unit.Owner);
+						var newSelection2 = SelectActorsInBox(world, worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.BottomRight, 
+							a => unit != null && a.Info.Name == unit.Info.Name && a.Owner == unit.Owner);
 							
 						world.Selection.Combine(world, newSelection2, true, false);
 					}

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -48,10 +48,9 @@ namespace OpenRA.Widgets
 				worldRenderer.DrawRollover(u);
 		}
 
-
 		public override bool HandleMouseInput(MouseInput mi)
 		{
-			var xy = Game.viewport.ViewToWorldPx(mi.Location);
+			var xy = worldRenderer.Viewport.ViewToWorldPx(mi.Location);
 
 			var UseClassicMouseStyle = Game.Settings.Game.UseClassicMouseStyle;
 
@@ -92,9 +91,9 @@ namespace OpenRA.Widgets
 					{
 						var unit = world.ScreenMap.ActorsAt(xy).FirstOrDefault();
 
-						var visibleWorld = Game.viewport.ViewBounds(world);
-						var topLeft = Game.viewport.ViewToWorldPx(new int2(visibleWorld.Left, visibleWorld.Top));
-						var bottomRight = Game.viewport.ViewToWorldPx(new int2(visibleWorld.Right, visibleWorld.Bottom));
+						var visibleWorld = worldRenderer.Viewport.ViewBounds(world);
+						var topLeft = worldRenderer.Viewport.ViewToWorldPx(new int2(visibleWorld.Left, visibleWorld.Top));
+						var bottomRight = worldRenderer.Viewport.ViewToWorldPx(new int2(visibleWorld.Right, visibleWorld.Bottom));
 						var newSelection2= SelectActorsInBox(world, topLeft, bottomRight, 
 						                                      a => unit != null && a.Info.Name == unit.Info.Name && a.Owner == unit.Owner);
 							
@@ -155,7 +154,7 @@ namespace OpenRA.Widgets
 				if (SelectionBox != null)
 					return null;
 
-				var xy = Game.viewport.ViewToWorldPx(screenPos);
+				var xy = worldRenderer.Viewport.ViewToWorldPx(screenPos);
 				var pos = worldRenderer.Position(xy);
 				var cell = pos.ToCPos();
 

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Widgets
 			{
 				if (e.KeyName.Length == 1 && char.IsDigit(e.KeyName[0]))
 				{
-					world.Selection.DoControlGroup(world, e.KeyName[0] - '0', e.Modifiers, e.MultiTapCount);
+					world.Selection.DoControlGroup(world, worldRenderer, e.KeyName[0] - '0', e.Modifiers, e.MultiTapCount);
 					return true;
 				}
 

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -21,15 +21,6 @@ namespace OpenRA
 {
 	public static class WorldUtils
 	{
-		public static readonly IEnumerable<FrozenActor> NoFrozenActors = new FrozenActor[0].AsEnumerable();
-		public static IEnumerable<FrozenActor> FindFrozenActorsAtMouse(this World world, int2 mouseLocation)
-		{
-			if (world.RenderPlayer == null)
-				return NoFrozenActors;
-
-			return world.ScreenMap.FrozenActorsAt(world.RenderPlayer, Game.viewport.ViewToWorldPx(mouseLocation));
-		}
-
 		public static IEnumerable<Actor> FindActorsInBox(this World world, CPos tl, CPos br)
 		{
 			// TODO: Support diamond boxes for isometric maps?

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc
 			if (r == null) return;
 
 			var s = new Sheet("mods/cnc/uibits/chrome.png");
-			var res = Renderer.Resolution;
+			var res = r.Resolution;
 			bounds = new Rectangle(0, 0, res.Width, res.Height);
 
 			ss = new[]

--- a/OpenRA.Mods.Cnc/Missions/CncShellmapScript.cs
+++ b/OpenRA.Mods.Cnc/Missions/CncShellmapScript.cs
@@ -22,14 +22,16 @@ namespace OpenRA.Mods.RA
 
 	class CncShellmapScript : IWorldLoaded, ITick
 	{
-		static CPos viewportOrigin;
+		WPos viewportOrigin;
 		Dictionary<string, Actor> actors;
+		WorldRenderer worldRenderer;
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
+			worldRenderer = wr;
 			var b = w.Map.Bounds;
-			viewportOrigin = new CPos(b.Left + b.Width / 2, b.Top + b.Height / 2);
-			Game.MoveViewport(viewportOrigin.ToFloat2());
+			viewportOrigin = new CPos(b.Left + b.Width / 2, b.Top + b.Height / 2).CenterPosition;
+			worldRenderer.Viewport.Center(viewportOrigin);
 
 			actors = w.WorldActor.Trait<SpawnMapActors>().Actors;
 
@@ -39,8 +41,8 @@ namespace OpenRA.Mods.RA
 		void SetViewport()
 		{
 			var t = (ticks + 45) % (360f * speed) * (Math.PI / 180) * 1f / speed;
-			var loc = viewportOrigin.ToFloat2() + (new float2(-15, 4) * float2.FromAngle((float)t));
-			Game.viewport.Center(loc);
+			var offset = new float2(-15360, 4096) * float2.FromAngle((float)t);
+			worldRenderer.Viewport.Center(viewportOrigin + new WVec((int)offset.X, (int)offset.Y, 0));
 		}
 
 		int ticks = 0;

--- a/OpenRA.Mods.Cnc/Missions/Gdi01Script.cs
+++ b/OpenRA.Mods.Cnc/Missions/Gdi01Script.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Missions
 			players = w.Players.ToDictionary(p => p.InternalName);
 			actors = w.WorldActor.Trait<SpawnMapActors>().Actors;
 			var b = w.Map.Bounds;
-			Game.MoveViewport(new CPos(b.Left + b.Width / 2, b.Top + b.Height / 2).ToFloat2());
+			wr.Viewport.Center(new CPos(b.Left + b.Width / 2, b.Top + b.Height / 2).CenterPosition);
 
 			Action afterFMV = () =>
 			{

--- a/OpenRA.Mods.Cnc/Missions/Nod01Script.cs
+++ b/OpenRA.Mods.Cnc/Missions/Nod01Script.cs
@@ -193,13 +193,10 @@ namespace OpenRA.Mods.Cnc.Missions
 			nr1 = actors["NODReinforceNthA"];
 			nr2 = actors["NODReinforceNthB"];
 			nr3 = actors["NODReinforceNWstA"];
-			Game.MoveViewport(nr1.Location.ToFloat2());
-			Action afterFMV = () =>
-			{
-				MissionUtils.PlayMissionMusic();
-			};
+
+			wr.Viewport.Center(nr1.Location.CenterPosition);
 			Game.RunAfterDelay(0, () => Media.PlayFMVFullscreen(w, "nod1pre.vqa", () =>
-										Media.PlayFMVFullscreen(w, "nod1.vqa", afterFMV)));
+										Media.PlayFMVFullscreen(w, "nod1.vqa", MissionUtils.PlayMissionMusic)));
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncSettingsLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncSettingsLogic.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			pixelDoubleCheckbox.OnClick = () =>
 			{
 				graphicsSettings.PixelDouble ^= true;
-				Game.viewport.Zoom = graphicsSettings.PixelDouble ? 2 : 1;
+				Game.Zoom = graphicsSettings.PixelDouble ? 2 : 1;
 			};
 
 			var showShellmapCheckbox = generalPane.Get<CheckboxWidget>("SHOW_SHELLMAP");

--- a/OpenRA.Mods.D2k/D2kLoadScreen.cs
+++ b/OpenRA.Mods.D2k/D2kLoadScreen.cs
@@ -41,8 +41,8 @@ namespace OpenRA.Mods.D2k
 			var s = new Sheet("mods/d2k/uibits/loadscreen.png");
 			Logo = new Sprite(s, new Rectangle(0, 0, 256, 256), TextureChannel.Alpha);
 			stripe = new Sprite(s, new Rectangle(256, 0, 256, 256), TextureChannel.Alpha);
-			stripeRect = new Rectangle(0, Renderer.Resolution.Height / 2 - 128, Renderer.Resolution.Width, 256);
-			logoPos = new float2(Renderer.Resolution.Width / 2 - 128, Renderer.Resolution.Height / 2 - 128);
+			stripeRect = new Rectangle(0, r.Resolution.Height / 2 - 128, r.Resolution.Width, 256);
+			logoPos = new float2(r.Resolution.Width / 2 - 128, r.Resolution.Height / 2 - 128);
 		}
 
 		public void Display()
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.D2k
 			r.BeginFrame(float2.Zero, 1f);
 			WidgetUtils.FillRectWithSprite(stripeRect, stripe);
 			r.RgbaSpriteRenderer.DrawSprite(Logo, logoPos);
-			r.Fonts["Bold"].DrawText(text, new float2(Renderer.Resolution.Width - textSize.X - 20, Renderer.Resolution.Height - textSize.Y - 20), Color.White);
+			r.Fonts["Bold"].DrawText(text, new float2(r.Resolution.Width - textSize.X - 20, r.Resolution.Height - textSize.Y - 20), Color.White);
 			r.EndFrame(new NullInputHandler());
 		}
 

--- a/OpenRA.Mods.RA/Guard.cs
+++ b/OpenRA.Mods.RA/Guard.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.RA
 
 		static IEnumerable<Actor> FriendlyGuardableUnits(World world, MouseInput mi)
 		{
-			return world.ScreenMap.ActorsAt(Game.viewport.ViewToWorldPx(mi.Location))
+			return world.ScreenMap.ActorsAt(mi)
 				.Where(a => !world.FogObscures(a) && !a.IsDead() &&
 					a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) &&
 					a.HasTrait<Guardable>());

--- a/OpenRA.Mods.RA/MPStartLocations.cs
+++ b/OpenRA.Mods.RA/MPStartLocations.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA
 
 			// Set viewport
 			if (world.LocalPlayer != null && Start.ContainsKey(world.LocalPlayer))
-				Game.viewport.Center(Start[world.LocalPlayer].ToFloat2());
+				wr.Viewport.Center(Start[world.LocalPlayer].CenterPosition);
 		}
 
 		static Player FindPlayerInSlot(World world, string pr)

--- a/OpenRA.Mods.RA/Minelayer.cs
+++ b/OpenRA.Mods.RA/Minelayer.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.RA
 					yield break;
 				}
 
-				var underCursor = world.ScreenMap.ActorsAt(Game.viewport.ViewToWorldPx(mi.Location))
+				var underCursor = world.ScreenMap.ActorsAt(mi)
 					.Where(a => !world.FogObscures(a))
 					.OrderByDescending(a => a.Info.Traits.Contains<SelectableInfo>()
 						? a.Info.Traits.Get<SelectableInfo>().Priority : int.MinValue)

--- a/OpenRA.Mods.RA/Missions/Allies01Script.cs
+++ b/OpenRA.Mods.RA/Missions/Allies01Script.cs
@@ -300,7 +300,7 @@ namespace OpenRA.Mods.RA.Missions
 			attackEntryPoint2 = actors["SovietAttackEntryPoint2"];
 			SetAlliedUnitsToDefensiveStance();
 
-			Game.MoveViewport(insertionLZ.Location.ToFloat2());
+			wr.Viewport.Center(insertionLZ.CenterPosition);
 
 			if (w.LobbyInfo.IsSinglePlayer)
 				Media.PlayFMVFullscreen(w, "ally1.vqa", () =>

--- a/OpenRA.Mods.RA/Missions/Allies02Script.cs
+++ b/OpenRA.Mods.RA/Missions/Allies02Script.cs
@@ -468,10 +468,9 @@ namespace OpenRA.Mods.RA.Missions
 			shroud.Explore(w, sam4.Location, 2);
 
 			if (w.LocalPlayer == null || w.LocalPlayer == allies1)
-				Game.MoveViewport(chinookHusk.Location.ToFloat2());
-
+				wr.Viewport.Center(chinookHusk.CenterPosition);
 			else
-				Game.MoveViewport(allies2BasePoint.Location.ToFloat2());
+				wr.Viewport.Center(allies2BasePoint.CenterPosition);
 
 			MissionUtils.PlayMissionMusic();
 		}

--- a/OpenRA.Mods.RA/Missions/Allies03Script.cs
+++ b/OpenRA.Mods.RA/Missions/Allies03Script.cs
@@ -448,10 +448,9 @@ namespace OpenRA.Mods.RA.Missions
 			paradropBox = new Rectangle(topLeft.Location.X, topLeft.Location.Y, bottomRight.Location.X - topLeft.Location.X, bottomRight.Location.Y - topLeft.Location.Y);
 
 			if (w.LocalPlayer == null || w.LocalPlayer == allies1)
-				Game.MoveViewport(allies1EntryPoint.Location.ToFloat2());
-
+				wr.Viewport.Center(allies1EntryPoint.CenterPosition);
 			else
-				Game.MoveViewport(allies2EntryPoint.Location.ToFloat2());
+				wr.Viewport.Center(allies2EntryPoint.CenterPosition);
 
 			OnObjectivesUpdated(false);
 			MissionUtils.PlayMissionMusic();

--- a/OpenRA.Mods.RA/Missions/Allies04Script.cs
+++ b/OpenRA.Mods.RA/Missions/Allies04Script.cs
@@ -60,6 +60,7 @@ namespace OpenRA.Mods.RA.Missions
 		Player soviets;
 		Player creeps;
 		World world;
+		WorldRenderer worldRenderer;
 
 		List<Patrol> patrols;
 		CPos[] patrolPoints1;
@@ -110,7 +111,7 @@ namespace OpenRA.Mods.RA.Missions
 				if (world.FrameNumber == frameInfiltrated + 100)
 				{
 					Sound.Play("aarrivs1.aud");
-					Game.MoveViewport(reinforcementsUnloadPoint.Location.ToFloat2());
+					worldRenderer.Viewport.Center(reinforcementsUnloadPoint.CenterPosition);
 					world.AddFrameEndTask(w => SendReinforcements());
 				}
 				if (world.FrameNumber == frameInfiltrated + 200)
@@ -354,6 +355,7 @@ namespace OpenRA.Mods.RA.Missions
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			world = w;
+			worldRenderer = wr;
 
 			difficulty = w.LobbyInfo.GlobalSettings.Difficulty;
 			Game.Debug("{0} difficulty selected".F(difficulty));
@@ -453,7 +455,7 @@ namespace OpenRA.Mods.RA.Missions
 			OnObjectivesUpdated(false);
 			SetupSubStances();
 
-			Game.MoveViewport(spyReinforcementsEntryPoint.Location.ToFloat2());
+			worldRenderer.Viewport.Center(spyReinforcementsEntryPoint.CenterPosition);
 			MissionUtils.PlayMissionMusic();
 		}
 	}

--- a/OpenRA.Mods.RA/Missions/DefaultShellmapScript.cs
+++ b/OpenRA.Mods.RA/Missions/DefaultShellmapScript.cs
@@ -22,13 +22,15 @@ namespace OpenRA.Mods.RA
 	class DefaultShellmapScript: IWorldLoaded, ITick
 	{
 		Dictionary<string, Actor> Actors;
-		static CPos ViewportOrigin;
+		static WPos ViewportOrigin;
+		WorldRenderer worldRenderer;
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
+			worldRenderer = wr;
 			var b = w.Map.Bounds;
-			ViewportOrigin = new CPos(b.Left + b.Width/2, b.Top + b.Height/2);
-			Game.MoveViewport(ViewportOrigin.ToFloat2());
+			ViewportOrigin = new CPos(b.Left + b.Width/2, b.Top + b.Height/2).CenterPosition;
+			worldRenderer.Viewport.Center(ViewportOrigin);
 
 			Actors = w.WorldActor.Trait<SpawnMapActors>().Actors;
 			Sound.SoundVolumeModifier = 0.25f;
@@ -38,12 +40,9 @@ namespace OpenRA.Mods.RA
 		float speed = 4f;
 		public void Tick(Actor self)
 		{
-			var loc = new float2(
-				(float)(System.Math.Sin((ticks + 45) % (360f * speed) * (Math.PI / 180) * 1f / speed) * 15f + ViewportOrigin.X),
-				(float)(System.Math.Cos((ticks + 45) % (360f * speed) * (Math.PI / 180) * 1f / speed) * 10f + ViewportOrigin.Y)
-			);
-
-			Game.MoveViewport(loc);
+			var t = (ticks + 45) % (360f * speed) * (Math.PI / 180) * 1f / speed;
+			var offset = new float2(15360, 10240) * float2.FromAngle((float)t);
+			worldRenderer.Viewport.Center(ViewportOrigin + new WVec((int)offset.X, (int)offset.Y, 0));
 
 			if (ticks == 50)
 			{
@@ -53,7 +52,6 @@ namespace OpenRA.Mods.RA
 					Pair.New(Actors["ca2"], new CPos(98, 72))
 				}, Actors["pdox"], -1, false);
 			}
-
 
 			if (ticks == 100)
 				Actors["mslo1"].Trait<NukePower>().Activate(Actors["mslo1"], new Order() { TargetLocation = new CPos(98, 52) });

--- a/OpenRA.Mods.RA/Missions/DesertShellmapScript.cs
+++ b/OpenRA.Mods.RA/Missions/DesertShellmapScript.cs
@@ -26,16 +26,17 @@ namespace OpenRA.Mods.RA.Missions
 	class DesertShellmapScript : ITick, IWorldLoaded
 	{
 		World world;
+		WorldRenderer worldRenderer;
 		Player allies;
 		Player soviets;
 		Player neutral;
 
-		List<int2> viewportTargets = new List<int2>();
-		int2 viewportTarget;
+		WPos[] viewportTargets;
+		WPos viewportTarget;
 		int viewportTargetNumber;
-		int2 viewportOrigin;
-		float mul;
-		float div = 400;
+		WPos viewportOrigin;
+		int mul;
+		int div = 400;
 		int waitTicks = 0;
 
 		int nextCivilianMove = 1;
@@ -138,12 +139,12 @@ namespace OpenRA.Mods.RA.Missions
 			if (--waitTicks <= 0)
 			{
 				if (++mul <= div)
-					Game.MoveViewport(float2.Lerp(viewportOrigin, viewportTarget, mul / div));
+					worldRenderer.Viewport.Center(WPos.Lerp(viewportOrigin, viewportTarget, mul, div));
 				else
 				{
 					mul = 0;
 					viewportOrigin = viewportTarget;
-					viewportTarget = viewportTargets[(viewportTargetNumber = (viewportTargetNumber + 1) % viewportTargets.Count)];
+					viewportTarget = viewportTargets[(viewportTargetNumber = (viewportTargetNumber + 1) % viewportTargets.Length)];
 					waitTicks = 100;
 
 					if (viewportTargetNumber == 0)
@@ -238,7 +239,7 @@ namespace OpenRA.Mods.RA.Missions
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			world = w;
-
+			worldRenderer = wr;
 			allies = w.Players.Single(p => p.InternalName == "Allies");
 			soviets = w.Players.Single(p => p.InternalName == "Soviets");
 			neutral = w.Players.Single(p => p.InternalName == "Neutral");
@@ -254,12 +255,12 @@ namespace OpenRA.Mods.RA.Missions
 			paradrop2LZ = actors["Paradrop2LZ"];
 			paradrop2Entry = actors["Paradrop2Entry"];
 
-			var t1 = actors["ViewportTarget1"];
-			var t2 = actors["ViewportTarget2"];
-			var t3 = actors["ViewportTarget3"];
-			var t4 = actors["ViewportTarget4"];
-			var t5 = actors["ViewportTarget5"];
-			viewportTargets = new[] { t1, t2, t3, t4, t5 }.Select(t => t.Location.ToInt2()).ToList();
+			var t1 = actors["ViewportTarget1"].CenterPosition;
+			var t2 = actors["ViewportTarget2"].CenterPosition;
+			var t3 = actors["ViewportTarget3"].CenterPosition;
+			var t4 = actors["ViewportTarget4"].CenterPosition;
+			var t5 = actors["ViewportTarget5"].CenterPosition;
+			viewportTargets = new[] { t1, t2, t3, t4, t5 };
 
 			offmapAttackerSpawn1 = actors["OffmapAttackerSpawn1"];
 			offmapAttackerSpawn2 = actors["OffmapAttackerSpawn2"];
@@ -298,7 +299,8 @@ namespace OpenRA.Mods.RA.Missions
 			viewportOrigin = viewportTargets[0];
 			viewportTargetNumber = 1;
 			viewportTarget = viewportTargets[1];
-			Game.viewport.Center(viewportOrigin);
+
+			wr.Viewport.Center(viewportOrigin);
 			Sound.SoundVolumeModifier = 0.1f;
 		}
 	}

--- a/OpenRA.Mods.RA/Missions/MissionWidgets.cs
+++ b/OpenRA.Mods.RA/Missions/MissionWidgets.cs
@@ -28,9 +28,10 @@ namespace OpenRA.Mods.RA.Missions
 		{
 			if (!IsVisible()) return;
 
+			// TODO: Don't hardcode the screen position
 			var font = Game.Renderer.Fonts["Bold"];
 			var text = Format.F(WidgetUtils.FormatTime(Timer.TicksLeft));
-			var pos = new float2(Game.viewport.Width * 0.5f - font.Measure(text).X / 2, Game.viewport.Height * 0.1f);
+			var pos = new float2(Game.Renderer.Resolution.Width * 0.5f - font.Measure(text).X / 2, Game.Renderer.Resolution.Height * 0.1f);
 			font.DrawTextWithContrast(text, pos, Timer.TicksLeft <= 25 * 60 && Game.LocalTick % 50 < 25 ? Color.Red : Color.White, Color.Black, 1);
 		}
 	}
@@ -45,8 +46,9 @@ namespace OpenRA.Mods.RA.Missions
 		{
 			if (!IsVisible()) return;
 
+			// TODO: Don't hardcode the screen position
 			var font = Game.Renderer.Fonts["Bold"];
-			var pos = new float2(Game.viewport.Width * 0.5f - font.Measure(Text).X / 2, Game.viewport.Height * 0.1f);
+			var pos = new float2(Game.Renderer.Resolution.Width * 0.5f - font.Measure(Text).X / 2, Game.Renderer.Resolution.Height * 0.1f);
 			font.DrawTextWithContrast(Text, pos, Color.White, Color.Black, 1);
 		}
 	}

--- a/OpenRA.Mods.RA/Missions/MonsterTankMadnessScript.cs
+++ b/OpenRA.Mods.RA/Missions/MonsterTankMadnessScript.cs
@@ -335,7 +335,7 @@ namespace OpenRA.Mods.RA.Missions
 			superTankDome.AddTrait(new InfiltrateAction(OnSuperTankDomeInfiltrated));
 			superTankDome.AddTrait(new TransformedAction(self => superTankDome = self));
 
-			Game.MoveViewport(startEntryPoint.Location.ToFloat2());
+			wr.Viewport.Center(startEntryPoint.CenterPosition);
 			MissionUtils.PlayMissionMusic();
 		}
 	}

--- a/OpenRA.Mods.RA/Missions/Soviet01ClassicScript.cs
+++ b/OpenRA.Mods.RA/Missions/Soviet01ClassicScript.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.RA.Missions
 			airfield3 = actors["Airfield3"];
 			airfields = new[] { airfield1, airfield2, airfield3 };
 
-			Game.MoveViewport(startJeep.Location.ToFloat2());
+			wr.Viewport.Center(startJeep.CenterPosition);
 
 			if (w.LobbyInfo.IsSinglePlayer)
 			{

--- a/OpenRA.Mods.RA/Missions/Survival01Script.cs
+++ b/OpenRA.Mods.RA/Missions/Survival01Script.cs
@@ -336,7 +336,7 @@ namespace OpenRA.Mods.RA.Missions
 			shroud.Explore(w, sam1.Location, 4);
 			shroud.Explore(w, sam2.Location, 4);
 
-			Game.MoveViewport(alliesbase.Location.ToFloat2());
+			wr.Viewport.Center(alliesbase.CenterPosition);
 			StartCountDownTimer();
 			SendSquad1();
 			SendSquad2();

--- a/OpenRA.Mods.RA/Missions/Survival02Script.cs
+++ b/OpenRA.Mods.RA/Missions/Survival02Script.cs
@@ -80,8 +80,8 @@ namespace OpenRA.Mods.RA.Missions
 		Actor FranceparaEntry2;
 		Actor FranceparaEntry3;
 
-
 		World world;
+		WorldRenderer worldRenderer;
 
 		CountdownTimer survivalTimer;
 		CountdownTimerWidget survivalTimerWidget;
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.RA.Missions
 
 		void FrenchReinforcements()
 		{
-			Game.MoveViewport(sovietrally1.Location.ToFloat2());
+			worldRenderer.Viewport.Center(sovietrally1.CenterPosition);
 			MissionUtils.Parabomb(world, allies, FranceparaEntry1.Location, drum3.Location);
 			MissionUtils.Parabomb(world, allies, FranceparaEntry3.Location, drum2.Location);
 			MissionUtils.Parabomb(world, allies, FranceparaEntry2.Location, drum1.Location);
@@ -355,6 +355,8 @@ namespace OpenRA.Mods.RA.Missions
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			world = w;
+			worldRenderer = wr;
+
 			allies = w.Players.SingleOrDefault(p => p.InternalName == "Allies");
 			if (allies != null)
 			{
@@ -395,7 +397,8 @@ namespace OpenRA.Mods.RA.Missions
 			FranceparaEntry3 = actors["FranceparaEntry3"];
 			newsovietentrypoints = new[] { sovietparadropEntry, sovietEntry3 }.Select(p => p.Location).ToArray();
 			newsovietrallypoints = new[] { sovietrally3, sovietrally4, sovietrally8 }.Select(p => p.Location).ToArray();
-			Game.MoveViewport(alliesbase.Location.ToFloat2());
+
+			worldRenderer.Viewport.Center(alliesbase.CenterPosition);
 			StartCountDownTimer();
 			SetSovietUnitsToDefensiveStance();
 			world.CreateActor(Camera, new TypeDictionary

--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.RA.Orders
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public void RenderAfterWorld(WorldRenderer wr, World world)
 		{
-			var position = Game.viewport.ViewToWorld(Viewport.LastMousePos);
+			var position = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 			var topLeft = position - FootprintUtils.AdjustForBuildingSize(BuildingInfo);
 
 			var actorInfo = Rules.Info[Building];

--- a/OpenRA.Mods.RA/Orders/PowerDownOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PowerDownOrderGenerator.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Orders
 		{
 			if (mi.Button == MouseButton.Left)
 			{
-				var underCursor = world.ScreenMap.ActorsAt(Game.viewport.ViewToWorldPx(mi.Location))
+				var underCursor = world.ScreenMap.ActorsAt(mi)
 					.Where(a => a.Owner == world.LocalPlayer && a.HasTrait<T>()).FirstOrDefault();
 
 				if (underCursor != null)

--- a/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA.Orders
 		{
 			if (mi.Button == MouseButton.Left)
 			{
-				var underCursor = world.ScreenMap.ActorsAt(Game.viewport.ViewToWorldPx(mi.Location))
+				var underCursor = world.ScreenMap.ActorsAt(mi)
 					.Where(a => !world.FogObscures(a) && a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && a.HasTrait<RepairableBuilding>()).FirstOrDefault();
 
 				if (underCursor == null)

--- a/OpenRA.Mods.RA/RALoadScreen.cs
+++ b/OpenRA.Mods.RA/RALoadScreen.cs
@@ -44,8 +44,8 @@ namespace OpenRA.Mods.RA
 			var s = new Sheet(Info["LoadScreenImage"]);
 			Logo = new Sprite(s, new Rectangle(0,0,256,256), TextureChannel.Alpha);
 			Stripe = new Sprite(s, new Rectangle(256,0,256,256), TextureChannel.Alpha);
-			StripeRect = new Rectangle(0, Renderer.Resolution.Height/2 - 128, Renderer.Resolution.Width, 256);
-			LogoPos =  new float2(Renderer.Resolution.Width/2 - 128, Renderer.Resolution.Height/2 - 128);
+			StripeRect = new Rectangle(0, r.Resolution.Height/2 - 128, r.Resolution.Width, 256);
+			LogoPos =  new float2(r.Resolution.Width/2 - 128, r.Resolution.Height/2 - 128);
 		}
 
 		public void Display()
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.RA
 			r.BeginFrame(float2.Zero, 1f);
 			WidgetUtils.FillRectWithSprite(StripeRect, Stripe);
 			r.RgbaSpriteRenderer.DrawSprite(Logo, LogoPos);
-			r.Fonts["Bold"].DrawText(text, new float2(Renderer.Resolution.Width - textSize.X - 20, Renderer.Resolution.Height - textSize.Y - 20), Color.White);
+			r.Fonts["Bold"].DrawText(text, new float2(r.Resolution.Width - textSize.X - 20, r.Resolution.Height - textSize.Y - 20), Color.White);
 			r.EndFrame( new NullInputHandler() );
 		}
 

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.RA
 
 			public void RenderAfterWorld(WorldRenderer wr, World world)
 			{
-				var xy = Game.viewport.ViewToWorld(Viewport.LastMousePos);
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var targetUnits = power.UnitsInRange(xy);
 				foreach (var unit in targetUnits)
 					if (manager.self.Owner.Shroud.IsTargetable(unit) || manager.self.Owner.HasFogVisibility())
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.RA
 
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
-				var xy = Game.viewport.ViewToWorld(Viewport.LastMousePos);
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var tiles = world.FindTilesInCircle(xy, range);
 				var pal = wr.Palette("terrain");
 				foreach (var t in tiles)
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.RA
 
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
-				var xy = Game.viewport.ViewToWorld(Viewport.LastMousePos);
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var pal = wr.Palette("terrain");
 
 				// Source tiles

--- a/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
@@ -90,14 +90,14 @@ namespace OpenRA.Mods.RA
 
 			public void RenderAfterWorld(WorldRenderer wr, World world)
 			{
-				var xy = Game.viewport.ViewToWorld(Viewport.LastMousePos);
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				foreach (var unit in power.UnitsInRange(xy))
 					wr.DrawSelectionBox(unit, Color.Red);
 			}
 
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
-				var xy = Game.viewport.ViewToWorld(Viewport.LastMousePos);
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var pal = wr.Palette("terrain");
 				foreach (var t in world.FindTilesInCircle(xy, range))
 					yield return new SpriteRenderable(tile, t.CenterPosition, WVec.Zero, -511, pal, 1f, true);

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -69,8 +69,8 @@ namespace OpenRA.Mods.RA.Widgets
 
 		public override void Initialize(WidgetArgs args)
 		{
-			paletteOpenOrigin = new float2(Game.viewport.Width - Columns*IconWidth - 23, 280);
-			paletteClosedOrigin = new float2(Game.viewport.Width - 16, 280);
+			paletteOpenOrigin = new float2(Game.Renderer.Resolution.Width - Columns*IconWidth - 23, 280);
+			paletteClosedOrigin = new float2(Game.Renderer.Resolution.Width - 16, 280);
 			paletteOrigin = paletteClosedOrigin;
 			base.Initialize(args);
 		}
@@ -280,19 +280,19 @@ namespace OpenRA.Mods.RA.Widgets
 				// Tooltip
 				if (tooltipItem != null && !paletteAnimating && paletteOpen)
 					DrawProductionTooltip(world, tooltipItem,
-						new float2(Game.viewport.Width, origin.Y + numActualRows * IconHeight + 9).ToInt2());
+						new float2(Game.Renderer.Resolution.Width, origin.Y + numActualRows * IconHeight + 9).ToInt2());
 			}
 
 			// Palette Dock
 			WidgetUtils.DrawRGBA(ChromeProvider.GetImage(paletteCollection, "dock-top"),
-				new float2(Game.viewport.Width - 14, origin.Y - 23));
+				new float2(Game.Renderer.Resolution.Width - 14, origin.Y - 23));
 
 			for (int i = 0; i < numActualRows; i++)
 				WidgetUtils.DrawRGBA(ChromeProvider.GetImage(paletteCollection, "dock-" + (i % 4).ToString()),
-					new float2(Game.viewport.Width - 14, origin.Y + IconHeight * i));
+					new float2(Game.Renderer.Resolution.Width - 14, origin.Y + IconHeight * i));
 
 			WidgetUtils.DrawRGBA(ChromeProvider.GetImage(paletteCollection, "dock-bottom"),
-				new float2(Game.viewport.Width - 14, origin.Y - 1 + IconHeight * numActualRows));
+				new float2(Game.Renderer.Resolution.Width - 14, origin.Y - 1 + IconHeight * numActualRows));
 
 			return IconHeight * y + 9;
 		}
@@ -456,7 +456,7 @@ namespace OpenRA.Mods.RA.Widgets
 			var longDescSize = Game.Renderer.Fonts["Regular"].Measure(tooltip.Description.Replace("\\n", "\n")).Y;
 			if (!canBuildThis) longDescSize += 8;
 
-			WidgetUtils.DrawPanel("dialog4", new Rectangle(Game.viewport.Width - 300, pos.Y, 300, longDescSize + 65));
+			WidgetUtils.DrawPanel("dialog4", new Rectangle(Game.Renderer.Resolution.Width - 300, pos.Y, 300, longDescSize + 65));
 
 			Game.Renderer.Fonts["Bold"].DrawText(
 				tooltip.Name + ((buildable.Hotkey != null) ? " ({0})".F(buildable.Hotkey.ToUpper()) : ""),

--- a/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.Graphics;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Network;
 using OpenRA.Traits;
@@ -37,11 +38,13 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		DropDownButtonWidget statsDropDown;
 		IEnumerable<Player> players;
 		World world;
+		WorldRenderer worldRenderer;
 
 		[ObjectCreator.UseCtor]
-		public ObserverStatsLogic(World world, Widget widget)
+		public ObserverStatsLogic(World world, WorldRenderer worldRenderer, Widget widget)
 		{
 			this.world = world;
+			this.worldRenderer = worldRenderer;
 			players = world.Players.Where(p => !p.NonCombatant);
 
 			basicStatsHeaders = widget.Get<ContainerWidget>("BASIC_STATS_HEADERS");
@@ -272,9 +275,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				var playerBase = world.Actors.FirstOrDefault(a => !a.IsDead() && a.HasTrait<BaseBuilding>() && a.Owner == player);
 				if (playerBase != null)
-				{
-					Game.MoveViewport(playerBase.Location.ToFloat2());
-				}
+					worldRenderer.Viewport.Center(playerBase.CenterPosition);
 			});
 		}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			pixelDoubleCheckbox.OnClick = () =>
 			{
 				gs.PixelDouble ^= true;
-				Game.viewport.Zoom = gs.PixelDouble ? 2 : 1;
+				Game.Zoom = gs.PixelDouble ? 2 : 1;
 			};
 
 			var capFrameRateCheckbox = display.Get<CheckboxWidget>("CAPFRAMERATE_CHECKBOX");

--- a/OpenRA.Mods.RA/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/RadarWidget.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.RA.Widgets
 			var cell = MinimapPixelToCell(mi.Location);
 			var pos = cell.CenterPosition;
 			if ((mi.Event == MouseInputEvent.Down || mi.Event == MouseInputEvent.Move) && mi.Button == MouseButton.Left)
-				worldRenderer.Viewport.Center(cell.ToFloat2());
+				worldRenderer.Viewport.Center(cell.CenterPosition);
 
 			if (mi.Event == MouseInputEvent.Down && mi.Button == MouseButton.Right)
 			{
@@ -153,10 +153,8 @@ namespace OpenRA.Mods.RA.Widgets
 			// Draw viewport rect
 			if (hasRadar)
 			{
-				var wr = worldRenderer.Viewport.WorldRect;
-				var wro = new CPos(wr.X, wr.Y);
-				var tl = CellToMinimapPixel(wro);
-				var br = CellToMinimapPixel(wro + new CVec(wr.Width, wr.Height));
+				var tl = CellToMinimapPixel(worldRenderer.Position(worldRenderer.Viewport.TopLeft).ToCPos());
+				var br = CellToMinimapPixel(worldRenderer.Position(worldRenderer.Viewport.BottomRight).ToCPos());
 
 				Game.Renderer.EnableScissor(mapRect.Left, mapRect.Top, mapRect.Width, mapRect.Height);
 				Game.Renderer.LineRenderer.DrawRect(tl, br, Color.White);

--- a/OpenRA.Mods.RA/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/RadarWidget.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.RA.Widgets
 				return null;
 
 			var cell = MinimapPixelToCell(pos);
-			var location = Game.viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(cell.CenterPosition));
+			var location = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(cell.CenterPosition));
 
 			var mi = new MouseInput
 			{
@@ -110,12 +110,12 @@ namespace OpenRA.Mods.RA.Widgets
 			var cell = MinimapPixelToCell(mi.Location);
 			var pos = cell.CenterPosition;
 			if ((mi.Event == MouseInputEvent.Down || mi.Event == MouseInputEvent.Move) && mi.Button == MouseButton.Left)
-				Game.viewport.Center(cell.ToFloat2());
+				worldRenderer.Viewport.Center(cell.ToFloat2());
 
 			if (mi.Event == MouseInputEvent.Down && mi.Button == MouseButton.Right)
 			{
 				// fake a mousedown/mouseup here
-				var location = Game.viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(pos));
+				var location = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(pos));
 				var fakemi = new MouseInput
 				{
 					Event = MouseInputEvent.Down,
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.RA.Widgets
 			// Draw viewport rect
 			if (hasRadar)
 			{
-				var wr = Game.viewport.WorldRect;
+				var wr = worldRenderer.Viewport.WorldRect;
 				var wro = new CPos(wr.X, wr.Y);
 				var tl = CellToMinimapPixel(wro);
 				var br = CellToMinimapPixel(wro + new CVec(wr.Width, wr.Height));

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -13,29 +13,30 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.FileFormats;
 using OpenRA.Graphics;
+using OpenRA.Mods.RA.Orders;
 using OpenRA.Network;
 using OpenRA.Orders;
 using OpenRA.Widgets;
-using OpenRA.Mods.RA.Orders;
 
 namespace OpenRA.Mods.RA.Widgets
 {
 	public class WorldCommandWidget : Widget
 	{
-		public World World { get { return OrderManager.world; } }
-
-		public readonly OrderManager OrderManager;
+		World world;
 
 		[ObjectCreator.UseCtor]
-		public WorldCommandWidget(OrderManager orderManager) { OrderManager = orderManager; }
+		public WorldCommandWidget(World world)
+		{
+			this.world = world;
+		}
 
 		public override string GetCursor(int2 pos) { return null; }
 		public override Rectangle GetEventBounds() { return Rectangle.Empty; }
 
 		public override bool HandleKeyPress(KeyInput e)
 		{
-			if (World == null) return false;
-			if (World.LocalPlayer == null) return false;
+			if (world == null || world.LocalPlayer == null)
+				return false;
 
 			return ProcessInput(e);
 		}
@@ -53,7 +54,8 @@ namespace OpenRA.Mods.RA.Widgets
 				if (e.KeyName == Game.Settings.Keys.ToSelectionKey)
 					return ToSelection();
 
-				if (!World.Selection.Actors.Any()) // Put all functions, that are no unit-functions, before this line!
+				// Put all functions that aren't unit-specific before this line!
+				if (!world.Selection.Actors.Any()) 
 					return false;
 
 				if (e.KeyName == Game.Settings.Keys.AttackMoveKey)
@@ -79,13 +81,14 @@ namespace OpenRA.Mods.RA.Widgets
 		}
 
 		// TODO: take ALL this garbage and route it through the OrderTargeter stuff.
-
 		bool PerformAttackMove()
 		{
-			var actors = World.Selection.Actors.Where(a => a.Owner == World.LocalPlayer).ToArray();
+			var actors = world.Selection.Actors
+				.Where(a => a.Owner == world.LocalPlayer)
+				.ToArray();
 
 			if (actors.Any())
-				World.OrderGenerator = new GenericSelectTarget(actors,
+				world.OrderGenerator = new GenericSelectTarget(actors,
 					"AttackMove", "attackmove", Game.mouseButtonPreference.Action);
 
 			return true;
@@ -93,10 +96,15 @@ namespace OpenRA.Mods.RA.Widgets
 
 		void PerformKeyboardOrderOnSelection(Func<Actor, Order> f)
 		{
-			var orders = World.Selection.Actors
-				.Where(a => a.Owner == World.LocalPlayer && !a.Destroyed).Select(f).ToArray();
-			foreach (var o in orders) World.IssueOrder(o);
-			World.PlayVoiceForOrders(orders);
+			var orders = world.Selection.Actors
+				.Where(a => a.Owner == world.LocalPlayer && !a.Destroyed)
+				.Select(f)
+				.ToArray();
+
+			foreach (var o in orders)
+				world.IssueOrder(o);
+
+			world.PlayVoiceForOrders(orders);
 		}
 
 		bool PerformStop()
@@ -123,67 +131,76 @@ namespace OpenRA.Mods.RA.Widgets
 
 		bool PerformStanceCycle()
 		{
-			var actor = World.Selection.Actors
-				.Where(a => a.Owner == World.LocalPlayer && !a.Destroyed)
-				.Select(a => Pair.New( a, a.TraitOrDefault<AutoTarget>() ))
-				.Where(a => a.Second != null).FirstOrDefault();
+			var actor = world.Selection.Actors
+				.Where(a => a.Owner == world.LocalPlayer && !a.Destroyed)
+				.Select(a => Pair.New(a, a.TraitOrDefault<AutoTarget>()))
+				.Where(a => a.Second != null)
+				.FirstOrDefault();
 
 			if (actor.First == null)
 				return true;
 
 			var stances = Enum<UnitStance>.GetValues();
-
-			var nextStance = stances.Concat(stances).SkipWhile(s => s != actor.Second.predictedStance).Skip(1).First();
+			var nextStance = stances.Concat(stances)
+				.SkipWhile(s => s != actor.Second.predictedStance)
+				.Skip(1)
+				.First();
 
 			PerformKeyboardOrderOnSelection(a =>
 			{
 				var at = a.TraitOrDefault<AutoTarget>();
-				if (at != null) at.predictedStance = nextStance;
-				// NOTE(jsd): Abuse of the type system here with `CPos`
+				if (at != null)
+					at.predictedStance = nextStance;
+
+				// FIXME: Abuse of the type system here with `CPos`
 				return new Order("SetUnitStance", a, false) { TargetLocation = new CPos((int)nextStance, 0) };
 			});
 
-			Game.Debug( "Unit stance set to: {0}".F(nextStance) );
+			Game.Debug("Unit stance set to: {0}".F(nextStance));
 
 			return true;
 		}
 
 		bool PerformGuard()
 		{
-			var actors = World.Selection.Actors.Where(a => !a.Destroyed && a.Owner == World.LocalPlayer && a.HasTrait<Guard>());
+			var actors = world.Selection.Actors
+				.Where(a => !a.Destroyed && a.Owner == world.LocalPlayer && a.HasTrait<Guard>());
 
 			if (actors.Any())
-				World.OrderGenerator = new GuardOrderGenerator(actors);
+				world.OrderGenerator = new GuardOrderGenerator(actors);
 
 			return true;
 		}
 
 		bool CycleBases()
 		{
-			var bases = World.ActorsWithTrait<BaseBuilding>()
-				.Where( a => a.Actor.Owner == World.LocalPlayer ).ToArray();
-			if (!bases.Any()) return true;
+			var bases = world.ActorsWithTrait<BaseBuilding>()
+				.Where(a => a.Actor.Owner == world.LocalPlayer)
+				.ToArray();
+
+			if (!bases.Any())
+				return true;
 
 			var next = bases
 				.Select(b => b.Actor)
-				.SkipWhile(b => !World.Selection.Actors.Contains(b))
+				.SkipWhile(b => !world.Selection.Actors.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 
 			if (next == null)
 				next = bases.Select(b => b.Actor).First();
 
-			World.Selection.Combine(World, new Actor[] { next }, false, true);
+			world.Selection.Combine(world, new Actor[] { next }, false, true);
 
 			return ToSelection();
 		}
 
 		bool ToLastEvent()
 		{
-			if (World.LocalPlayer == null)
+			if (world.LocalPlayer == null)
 				return true;
 
-			var eventNotifier = World.LocalPlayer.PlayerActor.TraitOrDefault<BaseAttackNotifier>();
+			var eventNotifier = world.LocalPlayer.PlayerActor.TraitOrDefault<BaseAttackNotifier>();
 			if (eventNotifier == null)
 				return true;
 
@@ -196,7 +213,7 @@ namespace OpenRA.Mods.RA.Widgets
 
 		bool ToSelection()
 		{
-			Game.viewport.Center(World.Selection.Actors);
+			Game.viewport.Center(world.Selection.Actors);
 			return true;
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -22,12 +22,14 @@ namespace OpenRA.Mods.RA.Widgets
 {
 	public class WorldCommandWidget : Widget
 	{
-		World world;
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
 
 		[ObjectCreator.UseCtor]
-		public WorldCommandWidget(World world)
+		public WorldCommandWidget(World world, WorldRenderer worldRenderer)
 		{
 			this.world = world;
+			this.worldRenderer = worldRenderer;
 		}
 
 		public override string GetCursor(int2 pos) { return null; }
@@ -207,13 +209,13 @@ namespace OpenRA.Mods.RA.Widgets
 			if (eventNotifier.lastAttackTime < 0)
 				return true;
 
-			Game.viewport.Center(eventNotifier.lastAttackLocation.ToFloat2());
+			worldRenderer.Viewport.Center(eventNotifier.lastAttackLocation.CenterPosition);
 			return true;
 		}
 
 		bool ToSelection()
 		{
-			Game.viewport.Center(world.Selection.Actors);
+			worldRenderer.Viewport.Center(world.Selection.Actors);
 			return true;
 		}
 	}

--- a/OpenRA.Mods.RA/World/DebugOverlay.cs
+++ b/OpenRA.Mods.RA/World/DebugOverlay.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.RA
 			var doDim = refreshTick - world.FrameNumber <= 0;
 			if (doDim) refreshTick = world.FrameNumber + 20;
 
-			var viewBounds = Game.viewport.WorldBounds(world);
+			var viewBounds = wr.Viewport.WorldBounds(world);
 
 			foreach (var pair in layers)
 			{

--- a/OpenRA.Mods.RA/World/DebugOverlay.cs
+++ b/OpenRA.Mods.RA/World/DebugOverlay.cs
@@ -53,8 +53,7 @@ namespace OpenRA.Mods.RA
 			var doDim = refreshTick - world.FrameNumber <= 0;
 			if (doDim) refreshTick = world.FrameNumber + 20;
 
-			var viewBounds = wr.Viewport.WorldBounds(world);
-
+			var viewBounds = wr.Viewport.CellBounds;
 			foreach (var pair in layers)
 			{
 				var c = (pair.Key != null) ? pair.Key.Color.RGB : Color.PaleTurquoise;

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.RA
 
 		public void Render(WorldRenderer wr)
 		{
-			var cliprect = Game.viewport.WorldBounds(world);
+			var cliprect = wr.Viewport.WorldBounds(world);
 			var pal = wr.Palette("terrain");
 
 			foreach (var kv in tiles)

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.RA
 
 		public void Render(WorldRenderer wr)
 		{
-			var cliprect = wr.Viewport.WorldBounds(world);
+			var cliprect = wr.Viewport.CellBounds;
 			var pal = wr.Palette("terrain");
 
 			foreach (var kv in tiles)

--- a/OpenRA.Mods.TS/TSLoadScreen.cs
+++ b/OpenRA.Mods.TS/TSLoadScreen.cs
@@ -40,8 +40,8 @@ namespace OpenRA.Mods.TS
 			var s = new Sheet(Info["LoadScreenImage"]);
 			Logo = new Sprite(s, new Rectangle(0,0,256,256), TextureChannel.Alpha);
 			Stripe = new Sprite(s, new Rectangle(256,0,256,256), TextureChannel.Alpha);
-			StripeRect = new Rectangle(0, Renderer.Resolution.Height/2 - 128, Renderer.Resolution.Width, 256);
-			LogoPos =  new float2(Renderer.Resolution.Width/2 - 128, Renderer.Resolution.Height/2 - 128);
+			StripeRect = new Rectangle(0, r.Resolution.Height/2 - 128, r.Resolution.Width, 256);
+			LogoPos =  new float2(r.Resolution.Width/2 - 128, r.Resolution.Height/2 - 128);
 		}
 
 		public void Display()
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.TS
 			r.BeginFrame(float2.Zero, 1f);
 			WidgetUtils.FillRectWithSprite(StripeRect, Stripe);
 			r.RgbaSpriteRenderer.DrawSprite(Logo, LogoPos);
-			r.Fonts["Bold"].DrawText(text, new float2(Renderer.Resolution.Width - textSize.X - 20, Renderer.Resolution.Height - textSize.Y - 20), Color.White);
+			r.Fonts["Bold"].DrawText(text, new float2(r.Resolution.Width - textSize.X - 20, r.Resolution.Height - textSize.Y - 20), Color.White);
 			r.EndFrame( new NullInputHandler() );
 		}
 


### PR DESCRIPTION
Part 3/N of cleanups in preparation for TS/RA2 terrain support.

This simplifies the viewport code and removes inherent assumptions about tile geometry.
The viewport object has been moved from Game into WorldRenderer.
