### PR TITLE
Avoid misleading "No sync report available!" messages

### DIFF
--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -196,11 +196,12 @@ namespace OpenRA.Network
 						foreach (var f in e.Fields)
 							Log.Write("sync", "\t\t {0}: {1}".F(f.Key, f.Value));
 					}
+
 					return;
 				}
-
-				Log.Write("sync", "No sync report available!");
 			}
+
+			Log.Write("sync", "No sync report available!");
 		}
 
 		class Report


### PR DESCRIPTION
introduced in #3741 seen in many current reports like #3845 and #3879.
