### PR TITLE
Fixes two cosmetical issues with RA mod

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -525,6 +525,7 @@ Ant:
 		Prerequisites: bio
 	Selectable:
 		Voice: AntVoice
+		Bounds: 30,30,0,-2
 	Health:
 		HP: 750
 	Mobile:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1085,7 +1085,7 @@ AFLD:
 		Icon: paratroopers
 		ChargeTime: 360
 		Description: Paratroopers
-		LongDesc: A Badger drops a squad of Riflemen \nanywhere on the map
+		LongDesc: A Badger drops a squad of infantry \nanywhere on the map
 		Prerequisites: AFLD
 		DropItems: E1,E1,E1,E3,E3
 		SelectTargetSound: slcttgt1.aud


### PR DESCRIPTION
Downsizes Ant selection box fixing #3885, and corrects Paradrop description which only says rifleman even though two Rocket Soldiers are dropped as well.
