### PR TITLE
Don't zoom UI lines when pixel doubling.

### DIFF
--- a/OpenRA.Game/Graphics/BeamRenderable.cs
+++ b/OpenRA.Game/Graphics/BeamRenderable.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 			var dest = wr.ScreenPosition(pos + length);
 
 			var oldWidth = wlr.LineWidth;
-			wlr.LineWidth = width;
+			wlr.LineWidth = wr.Viewport.Zoom * width;
 			wlr.DrawLine(src, dest, color, color);
 			wlr.LineWidth = oldWidth;
 		}

--- a/OpenRA.Game/Graphics/BeamRenderable.cs
+++ b/OpenRA.Game/Graphics/BeamRenderable.cs
@@ -49,20 +49,10 @@ namespace OpenRA.Graphics
 			var src = wr.ScreenPosition(pos);
 			var dest = wr.ScreenPosition(pos + length);
 
-			var lineWidth = wlr.LineWidth;
-			if (lineWidth != width)
-			{
-				wlr.Flush();
-				wlr.LineWidth = width;
-			}
-			
+			var oldWidth = wlr.LineWidth;
+			wlr.LineWidth = width;
 			wlr.DrawLine(src, dest, color, color);
-			
-			if (lineWidth != width)
-			{
-				wlr.Flush();
-				wlr.LineWidth = lineWidth;
-			}
+			wlr.LineWidth = oldWidth;
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) {}

--- a/OpenRA.Game/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Game/Graphics/ContrailRenderable.cs
@@ -58,8 +58,12 @@ namespace OpenRA.Graphics
 		public void Render(WorldRenderer wr)
 		{
 			// Need at least 4 points to smooth the contrail over
-			if (length - skip < 4 )
+			if (length - skip < 4)
 				return;
+
+			var wlr = Game.Renderer.WorldLineRenderer;
+			var oldWidth = wlr.LineWidth;
+			wlr.LineWidth = wr.Viewport.Zoom;
 
 			// Start of the first line segment is the tail of the list - don't smooth it.
 			var curPos = trail[idx(next - skip - 1)];
@@ -73,12 +77,14 @@ namespace OpenRA.Graphics
 				var nextColor = Exts.ColorLerp(i * 1f / (length - 4), color, Color.Transparent);
 
 				if (!world.FogObscures(curCell) && !world.FogObscures(nextCell))
-					Game.Renderer.WorldLineRenderer.DrawLine(wr.ScreenPosition(curPos), wr.ScreenPosition(nextPos), curColor, nextColor);
+					wlr.DrawLine(wr.ScreenPosition(curPos), wr.ScreenPosition(nextPos), curColor, nextColor);
 
 				curPos = nextPos;
 				curCell = nextCell;
 				curColor = nextColor;
 			}
+
+			wlr.LineWidth = oldWidth;
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) {}

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Graphics
 				{
 					var vb = renderer.GetTempVertexBuffer();
 					vb.SetData(vertices, nv);
-					renderer.SetLineWidth(LineWidth * Game.Zoom);
+					renderer.SetLineWidth(LineWidth);
 					renderer.DrawBatch(vb, 0, nv, PrimitiveType.LineList);
 				});
 				renderer.Device.SetBlendMode(BlendMode.None);

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -15,9 +15,8 @@ namespace OpenRA.Graphics
 {
 	public class LineRenderer : Renderer.IBatchRenderer
 	{
-		public float LineWidth = 1f;
-		static float2 offset = new float2(0.5f,0.5f);
-
+		static float2 offset = new float2(0.5f, 0.5f);
+		float lineWidth = 1f;
 		Renderer renderer;
 		IShader shader;
 
@@ -28,6 +27,19 @@ namespace OpenRA.Graphics
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+		}
+
+
+		public float LineWidth
+		{
+			get { return lineWidth; }
+			set
+			{
+				if (LineWidth != value)
+					Flush();
+
+				lineWidth = value;
+			}
 		}
 
 		public void Flush()

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -200,6 +200,20 @@ namespace OpenRA.Graphics
 			wlr.LineWidth = oldWidth;
 		}
 
+		public void DrawTargetMarker(Color c, float2 location)
+		{
+			var tl = new float2(-1, -1);
+			var br = new float2(1, 1);
+			var bl = new float2(tl.X, br.Y);
+			var tr = new float2(br.X, tl.Y);
+
+			var wlr = Game.Renderer.WorldLineRenderer;
+			wlr.DrawLine(location + tl, location + tr, c, c);
+			wlr.DrawLine(location + tr, location + br, c, c);
+			wlr.DrawLine(location + br, location + bl, c, c);
+			wlr.DrawLine(location + bl, location + tl, c, c);
+		}
+
 		public void RefreshPalette()
 		{
 			palette.ApplyModifiers(world.WorldActor.TraitsImplementing<IPaletteModifier>());

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -189,15 +189,15 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public void DrawRangeCircleWithContrast(Color fg, float2 location, float range, Color bg, int offset)
+		public void DrawRangeCircleWithContrast(Color fg, float2 location, float range, Color bg)
 		{
-			if (offset > 0)
-			{
-				DrawRangeCircle(bg, location, range + (float)offset / Game.CellSize);
-				DrawRangeCircle(bg, location, range - (float)offset / Game.CellSize);
-			}
-
+			var wlr = Game.Renderer.WorldLineRenderer;
+			var oldWidth = wlr.LineWidth;
+			wlr.LineWidth = 3;
+			DrawRangeCircle(bg, location, range);
+			wlr.LineWidth = 1;
 			DrawRangeCircle(fg, location, range);
+			wlr.LineWidth = oldWidth;
 		}
 
 		public void RefreshPalette()

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -155,20 +155,22 @@ namespace OpenRA.Graphics
 			var bounds = a.Bounds.Value;
 
 			var tl = pos + new float2(bounds.Left, bounds.Top);
-			var tr = pos + new float2(bounds.Right, bounds.Top);
-			var bl = pos + new float2(bounds.Left, bounds.Bottom);
 			var br = pos + new float2(bounds.Right, bounds.Bottom);
+			var tr = new float2(br.X, tl.Y);
+			var bl = new float2(tl.X, br.Y);
+			var u = new float2(4f, 0);
+			var v = new float2(0, 4f);
 
 			var wlr = Game.Renderer.WorldLineRenderer;
-			wlr.DrawLine(tl, tl + new float2(4, 0), c, c);
-			wlr.DrawLine(tl, tl + new float2(0, 4), c, c);
-			wlr.DrawLine(tr, tr + new float2(-4, 0), c, c);
-			wlr.DrawLine(tr, tr + new float2(0, 4), c, c);
+			wlr.DrawLine(tl + u, tl, c, c);
+			wlr.DrawLine(tl, tl + v, c, c);
+			wlr.DrawLine(tr, tr - u, c, c);
+			wlr.DrawLine(tr, tr + v, c, c);
 
-			wlr.DrawLine(bl, bl + new float2(4, 0), c, c);
-			wlr.DrawLine(bl, bl + new float2(0, -4), c, c);
-			wlr.DrawLine(br, br + new float2(-4, 0), c, c);
-			wlr.DrawLine(br, br + new float2(0, -4), c, c);
+			wlr.DrawLine(bl, bl + u, c, c);
+			wlr.DrawLine(bl, bl - v, c, c);
+			wlr.DrawLine(br, br - u, c, c);
+			wlr.DrawLine(br, br - v, c, c);
 		}
 
 		public void DrawRollover(Actor unit)

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -158,8 +158,8 @@ namespace OpenRA.Graphics
 			var br = pos + new float2(bounds.Right, bounds.Bottom);
 			var tr = new float2(br.X, tl.Y);
 			var bl = new float2(tl.X, br.Y);
-			var u = new float2(4f, 0);
-			var v = new float2(0, 4f);
+			var u = new float2(4f / Viewport.Zoom, 0);
+			var v = new float2(0, 4f / Viewport.Zoom);
 
 			var wlr = Game.Renderer.WorldLineRenderer;
 			wlr.DrawLine(tl + u, tl, c, c);
@@ -204,8 +204,8 @@ namespace OpenRA.Graphics
 
 		public void DrawTargetMarker(Color c, float2 location)
 		{
-			var tl = new float2(-1, -1);
-			var br = new float2(1, 1);
+			var tl = new float2(-1 / Viewport.Zoom, -1 / Viewport.Zoom);
+			var br = new float2(1 / Viewport.Zoom, 1 / Viewport.Zoom);
 			var bl = new float2(tl.X, br.Y);
 			var tr = new float2(br.X, tl.Y);
 

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -60,26 +60,16 @@ namespace OpenRA.Traits
 				return;
 
 			var from = wr.ScreenPxPosition(self.CenterPosition);
-			var wlr = Game.Renderer.WorldLineRenderer;
-
 			foreach (var target in targets)
 			{
 				if (target.Type == TargetType.Invalid)
 					continue;
 
 				var to = wr.ScreenPxPosition(target.CenterPosition);
-				wlr.DrawLine(from, to, c, c);
-				DrawTargetMarker(wlr, from);
-				DrawTargetMarker(wlr, to);
+				Game.Renderer.WorldLineRenderer.DrawLine(from, to, c, c);
+				wr.DrawTargetMarker(c, from);
+				wr.DrawTargetMarker(c, to);
 			}
-		}
-
-		void DrawTargetMarker(LineRenderer wlr, float2 p)
-		{
-			wlr.DrawLine(p + new float2(-1, -1), p + new float2(-1, 1), c, c);
-			wlr.DrawLine(p + new float2(-1, 1), p + new float2(1, 1), c, c);
-			wlr.DrawLine(p + new float2(1, 1), p + new float2(1, -1), c, c);
-			wlr.DrawLine(p + new float2(1, -1), p + new float2(-1, -1), c, c);
 		}
 	}
 
@@ -89,12 +79,7 @@ namespace OpenRA.Traits
 		{
 			var line = self.TraitOrDefault<DrawLineToTarget>();
 			if (line != null)
-			{
-				self.World.AddFrameEndTask(w =>
-				{
-					line.SetTargets(self, targets, color, false);
-				});
-			}
+				self.World.AddFrameEndTask(w => line.SetTargets(self, targets, color, false));
 		}
 
 		public static void SetTargetLine(this Actor self, Target target, Color color)

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -154,7 +154,8 @@ namespace OpenRA.Traits
 
 		void DrawUnitPath(WorldRenderer wr, Actor self)
 		{
-			if (self.World.LocalPlayer == null ||!self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().PathDebug) return;
+			if (self.World.LocalPlayer == null || !self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().PathDebug)
+				return;
 
 			var activity = self.GetCurrentActivity();
 			if (activity != null)
@@ -163,15 +164,10 @@ namespace OpenRA.Traits
 				var start = wr.ScreenPxPosition(self.CenterPosition);
 
 				var c = Color.Green;
-
-				var wlr = Game.Renderer.WorldLineRenderer;
-				foreach (var stp in targets.Where(t => t.Type != TargetType.Invalid).Select(p => wr.ScreenPxPosition(p.CenterPosition)))
+				foreach (var stp in targets.Where(t => t.Type != TargetType.Invalid).Select(pos => wr.ScreenPxPosition(pos.CenterPosition)))
 				{
-					wlr.DrawLine(stp + new float2(-1, -1), stp + new float2(-1, 1), c, c);
-					wlr.DrawLine(stp + new float2(-1, 1), stp + new float2(1, 1), c, c);
-					wlr.DrawLine(stp + new float2(1, 1), stp + new float2(1, -1), c, c);
-					wlr.DrawLine(stp + new float2(1, -1), stp + new float2(-1, -1), c, c);
-					wlr.DrawLine(start, stp, c, c);
+					Game.Renderer.WorldLineRenderer.DrawLine(start, stp, c, c);
+					wr.DrawTargetMarker(c, stp);
 					start = stp;
 				}
 			}

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -85,25 +85,29 @@ namespace OpenRA.Traits
 
 		void DrawSelectionBar(WorldRenderer wr, Actor self, float2 xy, float2 Xy, float value, Color barColor)
 		{
-			if (!self.IsInWorld) return;
+			if (!self.IsInWorld)
+				return;
 
 			var health = self.TraitOrDefault<Health>();
 			if (health == null || health.IsDead) return;
 
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);
+			var p = new float2(0, -4);
+			var q = new float2(0, -3);
+			var r = new float2(0, -2);
 
 			var barColor2 = Color.FromArgb(255, barColor.R / 2, barColor.G / 2, barColor.B / 2);
 
 			var z = float2.Lerp(xy, Xy, value);
 			var wlr = Game.Renderer.WorldLineRenderer;
-			wlr.DrawLine(xy + new float2(0, -4), Xy + new float2(0, -4), c, c);
-			wlr.DrawLine(xy + new float2(0, -3), Xy + new float2(0, -3), c2, c2);
-			wlr.DrawLine(xy + new float2(0, -2), Xy + new float2(0, -2), c, c);
+			wlr.DrawLine(xy + p, Xy + p, c, c);
+			wlr.DrawLine(xy + q, Xy + q, c2, c2);
+			wlr.DrawLine(xy + r, Xy + r, c, c);
 
-			wlr.DrawLine(xy + new float2(0, -3), z + new float2(0, -3), barColor, barColor);
-			wlr.DrawLine(xy + new float2(0, -2), z + new float2(0, -2), barColor2, barColor2);
-			wlr.DrawLine(xy + new float2(0, -4), z + new float2(0, -4), barColor2, barColor2);
+			wlr.DrawLine(xy + p, z + p, barColor2, barColor2);
+			wlr.DrawLine(xy + q, z + q, barColor, barColor);
+			wlr.DrawLine(xy + r, z + r, barColor2, barColor2);
 		}
 
 		void DrawHealthBar(WorldRenderer wr, Actor self, float2 xy, float2 Xy)
@@ -115,6 +119,9 @@ namespace OpenRA.Traits
 
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);
+			var p = new float2(0, -4);
+			var q = new float2(0, -3);
+			var r = new float2(0, -2);
 
 			var healthColor = (health.DamageState == DamageState.Critical) ? Color.Red :
 							  (health.DamageState == DamageState.Heavy) ? Color.Yellow : Color.LimeGreen;
@@ -128,13 +135,13 @@ namespace OpenRA.Traits
 			var z = float2.Lerp(xy, Xy, (float)health.HP / health.MaxHP);
 
 			var wlr = Game.Renderer.WorldLineRenderer;
-			wlr.DrawLine(xy + new float2(0, -4), Xy + new float2(0, -4), c, c);
-			wlr.DrawLine(xy + new float2(0, -3), Xy + new float2(0, -3), c2, c2);
-			wlr.DrawLine(xy + new float2(0, -2), Xy + new float2(0, -2), c, c);
+			wlr.DrawLine(xy + p, Xy + p, c, c);
+			wlr.DrawLine(xy + q, Xy + q, c2, c2);
+			wlr.DrawLine(xy + r, Xy + r, c, c);
 
-			wlr.DrawLine(xy + new float2(0, -3), z + new float2(0, -3), healthColor, healthColor);
-			wlr.DrawLine(xy + new float2(0, -2), z + new float2(0, -2), healthColor2, healthColor2);
-			wlr.DrawLine(xy + new float2(0, -4), z + new float2(0, -4), healthColor2, healthColor2);
+			wlr.DrawLine(xy + p, z + p, healthColor2, healthColor2);
+			wlr.DrawLine(xy + q, z + q, healthColor, healthColor);
+			wlr.DrawLine(xy + r, z + r, healthColor2, healthColor2);
 
 			if (health.DisplayHp != health.HP)
 			{
@@ -146,9 +153,9 @@ namespace OpenRA.Traits
 					deltaColor.B / 2);
 				var zz = float2.Lerp(xy, Xy, (float)health.DisplayHp / health.MaxHP);
 
-				wlr.DrawLine(z + new float2(0, -3), zz + new float2(0, -3), deltaColor, deltaColor);
-				wlr.DrawLine(z + new float2(0, -2), zz + new float2(0, -2), deltaColor2, deltaColor2);
-				wlr.DrawLine(z + new float2(0, -4), zz + new float2(0, -4), deltaColor2, deltaColor2);
+				wlr.DrawLine(z + p, zz + p, deltaColor2, deltaColor2);
+				wlr.DrawLine(z + q, zz + q, deltaColor, deltaColor);
+				wlr.DrawLine(z + r, zz + r, deltaColor2, deltaColor2);
 			}
 		}
 

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -76,8 +76,8 @@ namespace OpenRA.Traits
 				var value = extraBar.GetValue();
 				if (value != 0)
 				{
-					xy.Y += 4;
-					Xy.Y += 4;
+					xy.Y += (int)(4 / wr.Viewport.Zoom);
+					Xy.Y += (int)(4 / wr.Viewport.Zoom);
 					DrawSelectionBar(wr, self, xy, Xy, extraBar.GetValue(), extraBar.GetColor());
 				}
 			}
@@ -93,9 +93,9 @@ namespace OpenRA.Traits
 
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);
-			var p = new float2(0, -4);
-			var q = new float2(0, -3);
-			var r = new float2(0, -2);
+			var p = new float2(0, -4 / wr.Viewport.Zoom);
+			var q = new float2(0, -3 / wr.Viewport.Zoom);
+			var r = new float2(0, -2 / wr.Viewport.Zoom);
 
 			var barColor2 = Color.FromArgb(255, barColor.R / 2, barColor.G / 2, barColor.B / 2);
 
@@ -119,9 +119,9 @@ namespace OpenRA.Traits
 
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);
-			var p = new float2(0, -4);
-			var q = new float2(0, -3);
-			var r = new float2(0, -2);
+			var p = new float2(0, -4 / wr.Viewport.Zoom);
+			var q = new float2(0, -3 / wr.Viewport.Zoom);
+			var r = new float2(0, -2 / wr.Viewport.Zoom);
 
 			var healthColor = (health.DamageState == DamageState.Critical) ? Color.Red :
 							  (health.DamageState == DamageState.Heavy) ? Color.Yellow : Color.LimeGreen;

--- a/OpenRA.Mods.RA/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.RA/Buildings/BaseProvider.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.RA.Buildings
 			wr.DrawRangeCircleWithContrast(
 				Color.FromArgb(128, Ready() ? Color.White : Color.Red),
 				wr.ScreenPxPosition(self.CenterPosition), Info.Range,
-				Color.FromArgb(96, Color.Black), 1);
+				Color.FromArgb(96, Color.Black));
 		}
 
 		// Selection bar

--- a/OpenRA.Mods.RA/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.RA/CombatDebugOverlay.cs
@@ -52,6 +52,7 @@ namespace OpenRA.Mods.RA
 			var c = Color.White;
 
 			foreach (var a in armaments.Value)
+			{
 				foreach (var b in a.Barrels)
 				{
 					var muzzle = self.CenterPosition + a.MuzzleOffset(self, b);
@@ -60,11 +61,9 @@ namespace OpenRA.Mods.RA
 					var sm = wr.ScreenPosition(muzzle);
 					var sd = wr.ScreenPosition(muzzle + dirOffset);
 					wlr.DrawLine(sm, sd, c, c);
-					wlr.DrawLine(sm + new float2(-1, -1), sm + new float2(-1, 1), c, c);
-					wlr.DrawLine(sm + new float2(-1, 1), sm + new float2(1, 1), c, c);
-					wlr.DrawLine(sm + new float2(1, 1), sm + new float2(1, -1), c, c);
-					wlr.DrawLine(sm + new float2(1, -1), sm + new float2(-1, -1), c, c);
+					wr.DrawTargetMarker(c, sm);
 				}
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.RA/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.RA/RenderDetectionCircle.cs
@@ -33,8 +33,7 @@ namespace OpenRA.Mods.RA
 			wr.DrawRangeCircleWithContrast(
 				Color.FromArgb(128, Color.LimeGreen),
 				wr.ScreenPxPosition(self.CenterPosition), self.Info.Traits.Get<DetectCloakedInfo>().Range,
-				Color.FromArgb(96, Color.Black),
-				1);
+				Color.FromArgb(96, Color.Black));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/RenderJammerCircle.cs
+++ b/OpenRA.Mods.RA/RenderJammerCircle.cs
@@ -61,8 +61,7 @@ namespace OpenRA.Mods.RA
 				Color.FromArgb(128, color),
 				wr.ScreenPxPosition(pos),
 				range,
-				Color.FromArgb(96, Color.Black),
-				1);
+				Color.FromArgb(96, Color.Black));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/RenderRangeCircle.cs
+++ b/OpenRA.Mods.RA/RenderRangeCircle.cs
@@ -30,8 +30,7 @@ namespace OpenRA.Mods.RA
 				Color.FromArgb(128, Color.Yellow), wr.ScreenPxPosition(centerPosition),
 				ai.Traits.WithInterface<ArmamentInfo>()
 					.Select(a => Rules.Weapons[a.Weapon.ToLowerInvariant()].Range).Max(),
-				Color.FromArgb(96, Color.Black), 1
-			);
+				Color.FromArgb(96, Color.Black));
 
 			foreach (var a in w.ActorsWithTrait<RenderRangeCircle>())
 				if (a.Actor.Owner == a.Actor.World.LocalPlayer)
@@ -58,8 +57,7 @@ namespace OpenRA.Mods.RA
 			wr.DrawRangeCircleWithContrast(
 				Color.FromArgb(128, Color.Yellow),
 				wr.ScreenPxPosition(self.CenterPosition), pxRange,
-				Color.FromArgb(96, Color.Black),
-				1);
+				Color.FromArgb(96, Color.Black));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/RenderShroudCircle.cs
+++ b/OpenRA.Mods.RA/RenderShroudCircle.cs
@@ -22,8 +22,7 @@ namespace OpenRA.Mods.RA
 				Color.FromArgb(128, Color.Cyan),
 				wr.ScreenPxPosition(centerPosition),
 				ai.Traits.Get<CreatesShroudInfo>().Range,
-				Color.FromArgb(96, Color.Black),
-				1);
+				Color.FromArgb(96, Color.Black));
 
 			foreach (var a in w.ActorsWithTrait<RenderShroudCircle>())
 				if (a.Actor.Owner == a.Actor.World.LocalPlayer)
@@ -47,8 +46,7 @@ namespace OpenRA.Mods.RA
 			wr.DrawRangeCircleWithContrast(
 				Color.FromArgb(128, Color.Cyan),
 				wr.ScreenPxPosition(self.CenterPosition), self.Info.Traits.Get<CreatesShroudInfo>().Range,
-				Color.FromArgb(96, Color.Black),
-				1);
+				Color.FromArgb(96, Color.Black));
 		}
 	}
 }


### PR DESCRIPTION
These changes keep the line width of the selection boxes / selection bars / range circles / target constant when zooming, which makes pixel doubling much more useable.
