### PR TITLE
Gives ant adequate health radius and fixes instant turn

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -528,8 +528,10 @@ Ant:
 		Bounds: 30,30,0,-2
 	Health:
 		HP: 750
+		Radius: 11
 	Mobile:
 		Speed: 7
+		ROT: 12
 		SharesCell: no
 	AutoTarget:
 		ScanRadius: 5


### PR DESCRIPTION
Ant was using the same tiny health radius as other infantry. Additionally, I gave it a ROT value so it no longer insta-turns up to 180° without the slightest delay.
