### PR TITLE
Prevent pixel doubling of group / pip / tag / chevron decorations.

### DIFF
--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -121,8 +121,9 @@ namespace OpenRA.Mods.RA
 			var bounds = self.Bounds.Value;
 			bounds.Offset(pos.X, pos.Y);
 
-			var effectPos = wr.Position(new int2(bounds.Right, bounds.Bottom - 2));
-			yield return new SpriteRenderable(RankAnim.Image, effectPos, WVec.Zero, 0, wr.Palette("effect"), 1f, true);
+			var offset = (int)(6 / wr.Viewport.Zoom);
+			var effectPos = wr.Position(new int2(bounds.Right - offset, bounds.Bottom - offset));
+			yield return new SpriteRenderable(RankAnim.Image, effectPos, WVec.Zero, 0, wr.Palette("effect"), 1f / wr.Viewport.Zoom, true);
 		}
 	}
 


### PR DESCRIPTION
Followup to #3933.
