### PR TITLE
Improve cash ticks.

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -20,7 +20,6 @@ using OpenRA.Server;
 namespace OpenRA.GameRules
 {
 	public enum MouseScrollType { Disabled, Standard, Inverted }
-	public enum SoundCashTicks { Disabled, Normal, Extreme }
 
 	public class ServerSettings
 	{
@@ -116,7 +115,7 @@ namespace OpenRA.GameRules
 		public string Engine = "AL";
 		public string Device = null;
 
-		public SoundCashTicks SoundCashTickType = SoundCashTicks.Extreme;
+		public bool CashTicks = true;
 	}
 
 	public class PlayerSettings

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -27,8 +27,6 @@ namespace OpenRA.Traits
 	{
 		readonly Player Owner;
 		int AdviceInterval;
-		
-		int cashtickallowed = 0;
 
 		public PlayerResources(Actor self, PlayerResourcesInfo info)
 		{
@@ -103,13 +101,13 @@ namespace OpenRA.Traits
 		const float displayCashFracPerFrame = .07f;
 		const int displayCashDeltaPerFrame = 37;
 		int nextSiloAdviceTime = 0;
+		int nextCashTickTime = 0;
 
 		public void Tick(Actor self)
 		{
-			if(cashtickallowed > 0) {
-				cashtickallowed = cashtickallowed - 1;
-			}
-			
+			if (nextCashTickTime > 0)
+				nextCashTickTime--;
+
 			OreCapacity = self.World.ActorsWithTrait<IStoreOre>()
 				.Where(a => a.Actor.Owner == Owner)
 				.Sum(a => a.Trait.Capacity);
@@ -165,22 +163,17 @@ namespace OpenRA.Traits
 		
 		public void playCashTickUp(Actor self)
 		{
-			if (Game.Settings.Sound.SoundCashTickType != SoundCashTicks.Disabled)
-			{
+			if (Game.Settings.Sound.CashTicks)
 				Sound.PlayNotification(self.Owner, "Sounds", "CashTickUp", self.Owner.Country.Race);
-			}
 		}
 		
 		public void playCashTickDown(Actor self)
 		{
-			if (
-				Game.Settings.Sound.SoundCashTickType == SoundCashTicks.Extreme ||
-				(Game.Settings.Sound.SoundCashTickType == SoundCashTicks.Normal && cashtickallowed == 0)
-			) {
+			if (Game.Settings.Sound.CashTicks && nextCashTickTime == 0)
+			{
 				Sound.PlayNotification(self.Owner, "Sounds", "CashTickDown", self.Owner.Country.Race);
-				cashtickallowed = 3;
+				nextCashTickTime = 2;
 			}
-			
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsMenuLogic.cs
@@ -97,10 +97,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			videoslider.OnChange += x => Sound.VideoVolume = x;
 			videoslider.Value = Sound.VideoVolume;
 
-			var cashticksdropdown = audio.Get<DropDownButtonWidget>("CASH_TICK_TYPE");
-			cashticksdropdown.OnMouseDown = _ => ShowSoundTickDropdown(cashticksdropdown, soundSettings);
-			cashticksdropdown.GetText = () => soundSettings.SoundCashTickType == SoundCashTicks.Extreme ?
-				"Extreme" : soundSettings.SoundCashTickType == SoundCashTicks.Normal ? "Normal" : "Disabled";
+			var cashTicksCheckbox = audio.Get<CheckboxWidget>("CASHTICK_CHECKBOX");
+			cashTicksCheckbox.IsChecked = () => Game.Settings.Sound.CashTicks;
+			cashTicksCheckbox.OnClick = () => Game.Settings.Sound.CashTicks ^= true;
 
 			var mapMusicCheckbox = audio.Get<CheckboxWidget>("MAP_MUSIC_CHECKBOX");
 			mapMusicCheckbox.IsChecked = () => Game.Settings.Sound.MapMusic;
@@ -290,29 +289,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, Game.modData.Languages, setupItem);
 			return true;
 		}
-		
-		public static bool ShowSoundTickDropdown(DropDownButtonWidget dropdown, SoundSettings audio)
-		{
-			var options = new Dictionary<string, SoundCashTicks>()
-			{
-				{ "Extreme", SoundCashTicks.Extreme },
-				{ "Normal", SoundCashTicks.Normal },
-				{ "Disabled", SoundCashTicks.Disabled },
-			};
 
-			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
-			{
-				var item = ScrollItemWidget.Setup(itemTemplate,
-					() => audio.SoundCashTickType == options[o],
-					() => audio.SoundCashTickType = options[o]);
-				item.Get<LabelWidget>("LABEL").GetText = () => o;
-				return item;
-			};
-
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
-			return true;
-		}
-		
 		public static bool ShowWindowModeDropdown(DropDownButtonWidget dropdown, GraphicSettings s)
 		{
 			var options = new Dictionary<string, WindowMode>()

--- a/mods/cnc/notifications.yaml
+++ b/mods/cnc/notifications.yaml
@@ -34,8 +34,8 @@ Sounds:
 	Notifications:
 		RadarUp: comcntr1
 		RadarDown: powrdn1
-		CashTickUp:
-		CashTickDown:
+		CashTickUp:tone15
+		CashTickDown:tone16
 		LevelUp: text2
 		DisablePower: bleep11
 		EnablePower: bleep12

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -165,17 +165,12 @@ Background@SETTINGS_MENU:
 					Width:250
 					Height:20
 					Ticks:5
-				Label@SOUND_TICK_TYPE_LABEL:
+				Checkbox@CASHTICK_CHECKBOX:
 					X:0
-					Y:100
-					Text: Cash ticks
-				DropDownButton@CASH_TICK_TYPE:
-					X:100
 					Y:90
-					Width:250
-					Height:25
-					Font:Regular
-					Text:Extreme
+					Width:200
+					Height:20
+					Text:Cash Ticks
 				Checkbox@MAP_MUSIC_CHECKBOX:
 					X:0
 					Y:120


### PR DESCRIPTION
This replaces the Normal/Extreme/Disabled options with a checkbox, and tweaks the cash tick rate to more closely match the original games. It also enables cash ticks for C&C.
