### PR TITLE
Avoid expensive path-finding when the transport already sailed away

### DIFF
--- a/OpenRA.Mods.Cnc/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/WithCargo.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Cnc
 					cargoFacing.Facing = facing.Facing;
 
 				var cargoPassenger = c.Trait<Passenger>();
-				if (cargoInfo.DisplayTypes.Contains(cargoPassenger.info.CargoType))
+				if (cargoInfo.DisplayTypes.Contains(cargoPassenger.Info.CargoType))
 				{
 					var offset = pos - c.CenterPosition + body.LocalToWorld(positions[i++ % positions.Length].Rotate(bodyOrientation));
 					foreach (var cr in c.Render(wr))

--- a/OpenRA.Mods.RA/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.RA/Activities/EnterTransport.cs
@@ -14,26 +14,26 @@ namespace OpenRA.Mods.RA.Activities
 {
 	class EnterTransport : Activity
 	{
-		public Actor transport;
+		public Actor Transport;
 
 		public EnterTransport(Actor self, Actor transport)
 		{
-			this.transport = transport;
+			Transport = transport;
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceled) return NextActivity;
-			if (transport == null || !transport.IsInWorld) return NextActivity;
+			if (Transport == null || !Transport.IsInWorld) return NextActivity;
 
-			var cargo = transport.Trait<Cargo>();
-			if (!cargo.CanLoad(transport, self))
+			var cargo = Transport.Trait<Cargo>();
+			if (!cargo.CanLoad(Transport, self))
 				return NextActivity;
 
-			if ((transport.Location - self.Location).LengthSquared > 2)
+			if ((Transport.Location - self.Location).LengthSquared > 2)
 				return NextActivity;
 
-			cargo.Load(transport, self);
+			cargo.Load(Transport, self);
 			self.World.AddFrameEndTask(w => w.Remove(self));
 
 			return this;

--- a/OpenRA.Mods.RA/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.RA/Activities/EnterTransport.cs
@@ -30,8 +30,6 @@ namespace OpenRA.Mods.RA.Activities
 			if (!cargo.CanLoad(transport, self))
 				return NextActivity;
 
-			// TODO: Queue a move order to the transport? need to be
-			// careful about units that can't path to the transport
 			if ((transport.Location - self.Location).LengthSquared > 2)
 				return NextActivity;
 

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA
 		public readonly string[] InitialUnits = { };
 		public readonly WRange MaximumUnloadAltitude = WRange.Zero;
 
-		public object Create( ActorInitializer init ) { return new Cargo( init, this ); }
+		public object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
 
 	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyKilled, INotifyCapture
@@ -35,6 +35,8 @@ namespace OpenRA.Mods.RA
 		readonly CargoInfo info;
 
 		int totalWeight = 0;
+		static int GetWeight(Actor a) { return a.Info.Traits.Get<PassengerInfo>().Weight; }
+
 		List<Actor> cargo = new List<Actor>();
 		public IEnumerable<Actor> Passengers { get { return cargo; } }
 
@@ -45,7 +47,7 @@ namespace OpenRA.Mods.RA
 
 			if (init.Contains<CargoInit>())
 			{
-				cargo = init.Get<CargoInit,Actor[]>().ToList();
+				cargo = init.Get<CargoInit, Actor[]>().ToList();
 				totalWeight = cargo.Sum(c => GetWeight(c));
 			}
 			else
@@ -126,8 +128,6 @@ namespace OpenRA.Mods.RA
 
 		public Actor Peek(Actor self) {	return cargo[0]; }
 
-		static int GetWeight(Actor a) { return a.Info.Traits.Get<PassengerInfo>().Weight; }
-
 		public Actor Unload(Actor self)
 		{
 			var a = cargo[0];
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.RA
 
 	public class CargoInit : IActorInit<Actor[]>
 	{
-		[FieldFromYamlKey] public readonly Actor[] value = {};
+		[FieldFromYamlKey] public readonly Actor[] value = { };
 		public CargoInit() { }
 		public CargoInit(Actor[] init) { value = init; }
 		public Actor[] Value(World world) { return value; }

--- a/OpenRA.Mods.RA/Passenger.cs
+++ b/OpenRA.Mods.RA/Passenger.cs
@@ -23,13 +23,17 @@ namespace OpenRA.Mods.RA
 		public readonly PipType PipType = PipType.Green;
 		public int Weight = 1;
 
-		public object Create( ActorInitializer init ) { return new Passenger( this ); }
+		public object Create(ActorInitializer init) { return new Passenger(init, this); }
 	}
 
 	public class Passenger : IIssueOrder, IResolveOrder, IOrderVoice
 	{
-		public readonly PassengerInfo info;
-		public Passenger( PassengerInfo info ) { this.info = info; }
+		public readonly PassengerInfo Info;
+
+		public Passenger(ActorInitializer init, PassengerInfo info)
+		{
+			Info = info;
+		}
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
@@ -40,24 +44,24 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public Order IssueOrder( Actor self, IOrderTargeter order, Target target, bool queued )
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
-			if( order.OrderID == "EnterTransport" )
+			if (order.OrderID == "EnterTransport")
 				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
 
 			return null;
 		}
 
-		bool IsCorrectCargoType( Actor target )
+		bool IsCorrectCargoType(Actor target)
 		{
 			var ci = target.Info.Traits.Get<CargoInfo>();
-			return ci.Types.Contains( info.CargoType );
+			return ci.Types.Contains(Info.CargoType);
 		}
 
-		bool CanEnter( Actor target )
+		bool CanEnter(Actor target)
 		{
 			var cargo = target.TraitOrDefault<Cargo>();
-			return cargo != null && cargo.HasSpace(info.Weight);
+			return cargo != null && cargo.HasSpace(Info.Weight);
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)


### PR DESCRIPTION
This aborts earlier on `EnterTransport` orders. I especially tried to avoid `MoveAdjacentTo` that will trigger `PathSearch` and `PathFinder` and are worse-case scenarios for impossible paths that happen regularly when trying to board ground units into water transport. I was assured in my guess when I found a forseeing TODO comment warning that this can happen and has to be avoided.

I believe this will drastically improve performance on @wuschel's giant island oil derrick capture maps where you are constantly micro-managing transporters and you tend to forget more and more soldiers that will try to path through the whole (giant) map and this stacks up while you are amassing your armies.
