### PR TITLE
Use proper tile ID for RA anthills

### DIFF
--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -3586,8 +3586,8 @@ Templates:
 			0: Rough
 			1: Rough
 		Category: Bridge
-	Template@592:
-		Id: 592
+	Template@400:
+		Id: 400
 		Image: hill01
 		Size: 4,3
 		Tiles:


### PR DESCRIPTION
This lets us import original maps that have used the RA anthills. 

If we ship any maps with anthills at this time, I suspect this would break those maps?

Fixes #3865
