### PR TITLE
Move Zombie up in the RA infantry tab build palette order

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -503,7 +503,7 @@ Zombie:
 		Description: Slow undead. Attacks in close combat.
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 28
+		BuildPaletteOrder: 200
 		Owner: Umbrella
 		Prerequisites: bio
 	Selectable:


### PR DESCRIPTION
It's in the middle of the build palette right now
