### PR TITLE
Ignore damage from friendlies that is <= 0

### DIFF
--- a/OpenRA.Mods.RA/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.RA/Player/BaseAttackNotifier.cs
@@ -37,8 +37,13 @@ namespace OpenRA.Mods.RA
 			if (!self.HasTrait<Building>())
 				return;
 
-			// don't track self-damage
-			if (e.Attacker != null && e.Attacker.Owner == self.Owner)
+			if (e.Attacker == null)
+				return;
+
+			if (e.Attacker.Owner == self.Owner)
+				return;
+
+			if (e.Attacker.Owner.IsAlliedWith(self.Owner) && e.Damage <= 0)
 				return;
 
 			if (self.World.FrameNumber - lastAttackTime > info.NotifyInterval * 25)


### PR DESCRIPTION
Check to make sure Attacker is not null.
Ignores self-attacking.
Ignores friendly-fire that does <= 0 damage (repairs).

Fixes https://github.com/OpenRA/OpenRA/issues/3963
