### PR TITLE
Added 2 new settings for unit health bars (fixes #3867)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,8 @@ NEW:
 		Improved the ingame chat interface and input, with it defaulting to Team Chat.
 		Redesigned the settings panel.
 		Re-added move flashes.
+		Added a setting to always display unit status bars (can also be toggled by hotkey).
+		Added a setting for team health bar colors.
 	Asset Browser:
 		Fixed crashes when trying to load invalid filenames or sprites with just 1 frame.
 		Added support for browsing the folders for R8 files.

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -133,6 +133,8 @@ namespace OpenRA.GameRules
 		public float ViewportEdgeScrollStep = 10f;
 
 		public bool UseClassicMouseStyle = false;
+		public bool AlwaysShowStatusBars = false;
+		public bool TeamHealthColors = false;
 
 		// Internal game settings
 		public int Timestep = 40;
@@ -146,6 +148,7 @@ namespace OpenRA.GameRules
 		public Hotkey CycleBaseKey = new Hotkey(Keycode.BACKSPACE, Modifiers.None);
 		public Hotkey ToLastEventKey = new Hotkey(Keycode.SPACE, Modifiers.None);
 		public Hotkey ToSelectionKey = new Hotkey(Keycode.HOME, Modifiers.None);
+		public Hotkey ToggleStatusBarsKey = new Hotkey(Keycode.INSERT, Modifiers.None);
 
 		public Hotkey PauseKey = new Hotkey(Keycode.F9, Modifiers.None);
 		public Hotkey SellKey = new Hotkey(Keycode.F10, Modifiers.None);

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -146,6 +146,16 @@ namespace OpenRA.Graphics
 				foreach (var t in g)
 					t.RenderAfterWorld(this);
 
+			if (!world.IsShellmap && Game.Settings.Game.AlwaysShowStatusBars)
+			{
+				foreach (var g in world.Actors.Where(a => !a.Destroyed
+					&& a.HasTrait<Selectable>()
+					&& !world.FogObscures(a)
+					&& !world.Selection.Actors.Contains(a)))
+
+					DrawRollover(g);
+			}
+
 			Game.Renderer.Flush();
 		}
 
@@ -177,7 +187,7 @@ namespace OpenRA.Graphics
 		{
 			var selectable = unit.TraitOrDefault<Selectable>();
 			if (selectable != null)
-				selectable.DrawRollover(this, unit);
+				selectable.DrawRollover(this);
 		}
 
 		public void DrawRangeCircle(Color c, float2 location, float range)

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -48,12 +48,12 @@ namespace OpenRA.Traits
 			var Xy = new float2(bounds.Right, bounds.Top);
 
 			wr.DrawSelectionBox(self, Color.White);
-			DrawHealthBar(wr, self, xy, Xy);
-			DrawExtraBars(wr, self, xy, Xy);
-			DrawUnitPath(wr, self);
+			DrawHealthBar(wr, xy, Xy);
+			DrawExtraBars(wr, xy, Xy);
+			DrawUnitPath(wr);
 		}
 
-		public void DrawRollover(WorldRenderer wr, Actor self)
+		public void DrawRollover(WorldRenderer wr)
 		{
 			if (!Info.Selectable)
 				return;
@@ -65,11 +65,11 @@ namespace OpenRA.Traits
 			var xy = new float2(bounds.Left, bounds.Top);
 			var Xy = new float2(bounds.Right, bounds.Top);
 
-			DrawHealthBar(wr, self, xy, Xy);
-			DrawExtraBars(wr, self, xy, Xy);
+			DrawHealthBar(wr, xy, Xy);
+			DrawExtraBars(wr, xy, Xy);
 		}
 
-		void DrawExtraBars(WorldRenderer wr, Actor self, float2 xy, float2 Xy)
+		void DrawExtraBars(WorldRenderer wr, float2 xy, float2 Xy)
 		{
 			foreach (var extraBar in self.TraitsImplementing<ISelectionBar>())
 			{
@@ -78,12 +78,12 @@ namespace OpenRA.Traits
 				{
 					xy.Y += (int)(4 / wr.Viewport.Zoom);
 					Xy.Y += (int)(4 / wr.Viewport.Zoom);
-					DrawSelectionBar(wr, self, xy, Xy, extraBar.GetValue(), extraBar.GetColor());
+					DrawSelectionBar(wr, xy, Xy, extraBar.GetValue(), extraBar.GetColor());
 				}
 			}
 		}
 
-		void DrawSelectionBar(WorldRenderer wr, Actor self, float2 xy, float2 Xy, float value, Color barColor)
+		void DrawSelectionBar(WorldRenderer wr, float2 xy, float2 Xy, float value, Color barColor)
 		{
 			if (!self.IsInWorld)
 				return;
@@ -110,7 +110,7 @@ namespace OpenRA.Traits
 			wlr.DrawLine(xy + r, z + r, barColor2, barColor2);
 		}
 
-		void DrawHealthBar(WorldRenderer wr, Actor self, float2 xy, float2 Xy)
+		void DrawHealthBar(WorldRenderer wr, float2 xy, float2 Xy)
 		{
 			if (!self.IsInWorld) return;
 
@@ -123,9 +123,7 @@ namespace OpenRA.Traits
 			var q = new float2(0, -3 / wr.Viewport.Zoom);
 			var r = new float2(0, -2 / wr.Viewport.Zoom);
 
-			var healthColor = (health.DamageState == DamageState.Critical) ? Color.Red :
-							  (health.DamageState == DamageState.Heavy) ? Color.Yellow : Color.LimeGreen;
-
+			var healthColor = GetHealthColor(health);
 			var healthColor2 = Color.FromArgb(
 				255,
 				healthColor.R / 2,
@@ -159,7 +157,7 @@ namespace OpenRA.Traits
 			}
 		}
 
-		void DrawUnitPath(WorldRenderer wr, Actor self)
+		void DrawUnitPath(WorldRenderer wr)
 		{
 			if (self.World.LocalPlayer == null || !self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().PathDebug)
 				return;
@@ -180,5 +178,14 @@ namespace OpenRA.Traits
 			}
 		}
 
+		Color GetHealthColor(Health health)
+		{
+			if (Game.Settings.Game.TeamHealthColors)
+				return self.Owner.IsAlliedWith(self.World.LocalPlayer) ? Color.LimeGreen :
+						self.Owner.NonCombatant ? Color.Tan : Color.Red;
+			else
+				return health.DamageState == DamageState.Critical ? Color.Red :
+						health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;
+		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -18,7 +18,7 @@ using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 
-namespace OpenRA.Mods.Ra.Widgets.Logic
+namespace OpenRA.Mods.RA.Widgets.Logic
 {
 	public class SettingsLogic
 	{
@@ -120,6 +120,8 @@ namespace OpenRA.Mods.Ra.Widgets.Logic
 			BindCheckboxPref(panel, "PIXELDOUBLE_CHECKBOX", ds, "PixelDouble");
 			BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
 			BindCheckboxPref(panel, "SHOW_SHELLMAP", gs, "ShowShellmap");
+			BindCheckboxPref(panel, "ALWAYS_SHOW_STATUS_BARS_CHECKBOX", gs, "AlwaysShowStatusBars");
+			BindCheckboxPref(panel, "TEAM_HEALTH_COLORS_CHECKBOX", gs, "TeamHealthColors");
 
 			var languageDropDownButton = panel.Get<DropDownButtonWidget>("LANGUAGE_DROPDOWNBUTTON");
 			languageDropDownButton.OnMouseDown = _ => ShowLanguageDropdown(languageDropDownButton);
@@ -244,7 +246,8 @@ namespace OpenRA.Mods.Ra.Widgets.Logic
 				{ "SellKey", "Sell mode" },
 				{ "PowerDownKey", "Power-down mode" },
 				{ "RepairKey", "Repair mode" },
-				{ "CycleTabsKey", "Cycle production tabs" }
+				{ "CycleTabsKey", "Cycle production tabs" },
+				{ "ToggleStatusBarsKey", "Toggle status bars" }
 			};
 
 			var unitHotkeys = new Dictionary<string, string>()

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -56,6 +56,9 @@ namespace OpenRA.Mods.RA.Widgets
 				if (key == ks.ToSelectionKey)
 					return ToSelection();
 
+				if (key == ks.ToggleStatusBarsKey)
+					return ToggleStatusBars();
+
 				// Put all functions that aren't unit-specific before this line!
 				if (!world.Selection.Actors.Any()) 
 					return false;
@@ -215,6 +218,12 @@ namespace OpenRA.Mods.RA.Widgets
 		bool ToSelection()
 		{
 			worldRenderer.Viewport.Center(world.Selection.Actors);
+			return true;
+		}
+
+		bool ToggleStatusBars()
+		{
+			Game.Settings.Game.AlwaysShowStatusBars ^= true;
 			return true;
 		}
 	}

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -3,7 +3,7 @@ Container@SETTINGS_PANEL:
 	X:(WINDOW_RIGHT - WIDTH)/2
 	Y:(WINDOW_BOTTOM - HEIGHT)/2
 	Width:590
-	Height:260+68
+	Height:310+68
 	Children:
 		Label@TITLE:
 			Width:590
@@ -34,21 +34,21 @@ Container@SETTINGS_PANEL:
 					Height:35
 					Text:Advanced
 		Button@RESET_BUTTON:
-			Y:293
+			Y:343
 			Width:140
 			Height:35
 			Text:Reset
 		Button@BACK_BUTTON:
 			Key:escape
 			X:PARENT_RIGHT-WIDTH
-			Y:293
+			Y:343
 			Width:140
 			Height:35
 			Text:Back
 		Background@bg:
 			Y:34
 			Width:590
-			Height:260
+			Height:310
 			Background:panel-black
 			Children:
 				Container@DISPLAY_PANEL:
@@ -120,7 +120,7 @@ Container@SETTINGS_PANEL:
 							Text:Enable Frame Limiter
 						Checkbox@PIXELDOUBLE_CHECKBOX:
 							X:310
-							Y:105
+							Y:100
 							Width:200
 							Height:20
 							Font:Regular
@@ -143,41 +143,55 @@ Container@SETTINGS_PANEL:
 							Y:132
 							Height:25
 							Text: FPS
-						Checkbox@SHOW_SHELLMAP:
+						Checkbox@TEAM_HEALTH_COLORS_CHECKBOX:
 							X:310
 							Y:135
 							Width:200
 							Height:20
 							Font:Regular
+							Text:Team Health Colors
+						Checkbox@SHOW_SHELLMAP:
+							X:15
+							Y:170
+							Width:200
+							Height:20
+							Font:Regular
 							Text:Show Shellmap
+						Checkbox@ALWAYS_SHOW_STATUS_BARS_CHECKBOX:
+							X:310
+							Y:170
+							Width:200
+							Height:20
+							Font:Regular
+							Text:Always Show Status Bars
 						Label@VIDEO_TITLE:
-							Y:175
+							Y:225
 							Width:PARENT_RIGHT
 							Font:Bold
 							Text:Localization
 							Align:Center
 						Label@LANGUAGE_LABEL:
 							X:230 - WIDTH - 5
-							Y:194
+							Y:244
 							Width:75
 							Height:25
 							Align:Right
 							Text:Language:
 						DropDownButton@LANGUAGE_DROPDOWNBUTTON:
 							X:230
-							Y:195
+							Y:245
 							Width:200
 							Height:25
 							Font:Regular
 						Label@VIDEO_DESC_A:
-							Y:215
+							Y:265
 							Width:PARENT_RIGHT
 							Height:25
 							Font:Tiny
 							Align:Center
 							Text:Language changes will be applied after the game is restarted
 						Label@VIDEO_DESC_B:
-							Y:230
+							Y:280
 							Width:PARENT_RIGHT
 							Height:25
 							Font:Tiny
@@ -248,18 +262,18 @@ Container@SETTINGS_PANEL:
 							Ticks:5
 						Label@AUDIO_DEVICE_LABEL:
 							X:190 - WIDTH - 5
-							Y:194
+							Y:244
 							Width:75
 							Height:25
 							Align:Right
 							Text:Audio Device:
 						DropDownButton@AUDIO_DEVICE:
 							X:190
-							Y:195
+							Y:245
 							Width:300
 							Height:25
 						Label@AUDIO_DEVICE_DESC:
-							Y:215
+							Y:265
 							Width:PARENT_RIGHT
 							Height:25
 							Font:Tiny
@@ -330,7 +344,7 @@ Container@SETTINGS_PANEL:
 							Y:135
 							Width:560
 							ItemSpacing:4
-							Height:110
+							Height:160
 							Children:
 								ScrollItem@HEADER:
 									Width:528

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -3,7 +3,7 @@ Background@SETTINGS_PANEL:
 	X:(WINDOW_RIGHT - WIDTH)/2
 	Y:(WINDOW_BOTTOM- HEIGHT)/2
 	Width:600
-	Height:351
+	Height:400
 	Children:
 		Label@SETTINGS_LABEL_TITLE:
 			Y:20
@@ -120,7 +120,7 @@ Background@SETTINGS_PANEL:
 					Text:Enable Frame Limiter
 				Checkbox@PIXELDOUBLE_CHECKBOX:
 					X:310
-					Y:105
+					Y:100
 					Width:200
 					Height:20
 					Font:Regular
@@ -143,40 +143,54 @@ Background@SETTINGS_PANEL:
 					Y:132
 					Height:25
 					Text: FPS
-				Checkbox@SHOW_SHELLMAP:
+				Checkbox@TEAM_HEALTH_COLORS_CHECKBOX:
 					X:310
 					Y:135
 					Width:200
 					Height:20
 					Font:Regular
+					Text:Team Health Colors
+				Checkbox@SHOW_SHELLMAP:
+					X:15
+					Y:170
+					Width:200
+					Height:20
+					Font:Regular
 					Text:Show Shellmap
+				Checkbox@ALWAYS_SHOW_STATUS_BARS_CHECKBOX:
+					X:310
+					Y:170
+					Width:200
+					Height:20
+					Font:Regular
+					Text:Always Show Status Bars
 				Label@VIDEO_TITLE:
-					Y:175
+					Y:225
 					Width:PARENT_RIGHT
 					Font:Bold
 					Text:Localization
 					Align:Center
 				Label@LANGUAGE_LABEL:
 					X:230 - WIDTH - 5
-					Y:194
+					Y:244
 					Width:75
 					Height:25
 					Align:Right
 					Text:Language:
 				DropDownButton@LANGUAGE_DROPDOWNBUTTON:
 					X:230
-					Y:195
+					Y:245
 					Width:200
 					Height:25
 				Label@VIDEO_DESC_A:
-					Y:215
+					Y:265
 					Width:PARENT_RIGHT
 					Height:25
 					Font:Tiny
 					Align:Center
 					Text:Language changes will be applied after the game is restarted
 				Label@VIDEO_DESC_B:
-					Y:230
+					Y:280
 					Width:PARENT_RIGHT
 					Height:25
 					Font:Tiny
@@ -243,18 +257,18 @@ Background@SETTINGS_PANEL:
 					Ticks:5
 				Label@AUDIO_DEVICE_LABEL:
 					X:190 - WIDTH - 5
-					Y:194
+					Y:244
 					Width:75
 					Height:25
 					Align:Right
 					Text:Audio Device:
 				DropDownButton@AUDIO_DEVICE:
 					X:190
-					Y:195
+					Y:245
 					Width:300
 					Height:25
 				Label@AUDIO_DEVICE_DESC:
-					Y:215
+					Y:265
 					Width:PARENT_RIGHT
 					Height:25
 					Font:Tiny
@@ -321,7 +335,7 @@ Background@SETTINGS_PANEL:
 					Y:135
 					Width:560
 					ItemSpacing:4
-					Height:110
+					Height:160
 					Children:
 						ScrollItem@HEADER:
 							BaseName:scrollheader


### PR DESCRIPTION
Added two new settings:
- Always show status bars (can also be toggled with the `insert` hotkey). Default is off.
- Team health colors (this is a dota-style coloring for health bars: green (friendly), tan (neutral), red (enemies)). Default is off.

Selectable.cs - removed 'self' parameter from the draw *bars functions, since self is already a property of the class. The parameter is a relic from when bars used to be drawn in the WCWidget.

Also made the settings UI a bit taller.
