### PR TITLE
Fix a NRE in the exception handler.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -257,7 +257,14 @@ namespace OpenRA
 
 		public static Dictionary<String, Mod> CurrentMods
 		{
-			get { return Mod.AllMods.Where(k => modData.Manifest.Mods.Contains(k.Key)).ToDictionary(k => k.Key, k => k.Value); }
+			get
+			{
+				// Initialization hasn't completed yet
+				if (Mod.AllMods == null || modData == null)
+					return null;
+
+				return Mod.AllMods.Where(k => modData.Manifest.Mods.Contains(k.Key)).ToDictionary(k => k.Key, k => k.Value);
+			}
 		}
 
 		static Modifiers modifiers;

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -46,8 +46,13 @@ namespace OpenRA
 		static void FatalError(Exception e)
 		{
 			Log.AddChannel("exception", "exception.log");
-			var mod = Game.CurrentMods.First().Value;
-			Log.Write("exception", "{0} Mod at Version {1}", mod.Title, mod.Version);
+
+			if (Game.CurrentMods != null)
+			{
+				var mod = Game.CurrentMods.First().Value;
+				Log.Write("exception", "{0} Mod at Version {1}", mod.Title, mod.Version);
+			}
+
 			Log.Write("exception", "Operating System: {0} ({1})", Platform.CurrentPlatform, Environment.OSVersion);
 			Log.Write("exception", "Runtime Version: {0}", Platform.RuntimeVersion);
 			var rpt = BuildExceptionReport(e).ToString();


### PR DESCRIPTION
The exception handler would die if an error occurred before modData was initialized.
