### PR TITLE
SyncInfo is only valid during the initial lobby phase. Fixes #3973.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -558,7 +558,7 @@ namespace OpenRA.Server
 
 		public void SyncLobbyInfo()
 		{
-			if (State != ServerState.GameStarted)	/* don't do this while the game is running, it breaks things. */
+			if (State == ServerState.WaitingPlayers) // Don't do this while the game is running, it breaks things!
 				DispatchOrders(null, 0,
 					new ServerOrder("SyncInfo", lobbyInfo.Serialize()).Serialize());
 


### PR DESCRIPTION
Existing broken replays can be fixed manually by removing the SyncInfo order at the end of the file.
