### PR TITLE
Hardened the new Rank effect against crashes

### DIFF
--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -170,7 +170,8 @@ namespace OpenRA.Traits
 	{
 		public static bool IsDead(this Actor self)
 		{
-			if (self.Destroyed)	return true;
+			if (self.Destroyed)
+				return true;
 
 			var health = self.TraitOrDefault<Health>();
 			return (health == null) ? false : health.IsDead;
@@ -178,7 +179,8 @@ namespace OpenRA.Traits
 
 		public static DamageState GetDamageState(this Actor self)
 		{
-			if (self.Destroyed) return DamageState.Dead;
+			if (self.Destroyed)
+				return DamageState.Dead;
 
 			var health = self.TraitOrDefault<Health>();
 			return (health == null) ? DamageState.Undamaged : health.DamageState;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -181,7 +181,7 @@ namespace OpenRA
 		public void Add(IEffect b) { effects.Add(b); }
 		public void Remove(IEffect b) { effects.Remove(b); }
 
-		public void AddFrameEndTask( Action<World> a ) { frameEndActions.Enqueue( a ); }
+		public void AddFrameEndTask(Action<World> a) { frameEndActions.Enqueue(a); }
 
 		public event Action<Actor> ActorAdded = _ => { };
 		public event Action<Actor> ActorRemoved = _ => { };

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -479,7 +479,7 @@ namespace OpenRA.Mods.RA.AI
 		{
 			squads.RemoveAll(s => !s.IsValid);
 			foreach (var s in squads)
-				s.units.RemoveAll(a => a.Destroyed || a.IsDead() || a.Owner != p);
+				s.units.RemoveAll(a => a.IsDead() || a.Owner != p);
 		}
 
 		// Use of this function requires that one squad of this type. Hence it is a piece of shit
@@ -506,8 +506,8 @@ namespace OpenRA.Mods.RA.AI
 		void AssignRolesToIdleUnits(Actor self)
 		{
 			CleanSquads();
-			activeUnits.RemoveAll(a => a.Destroyed || a.IsDead() || a.Owner != p); 
-			unitsHangingAroundTheBase.RemoveAll(a => a.Destroyed || a.IsDead() || a.Owner != p);
+			activeUnits.RemoveAll(a => a.IsDead() || a.Owner != p); 
+			unitsHangingAroundTheBase.RemoveAll(a => a.IsDead() || a.Owner != p);
 
 			if (--rushTicks <= 0)
 			{

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.RA.Effects
 				world.AddFrameEndTask(w => w.Remove(this));
 
 			show = false;
-			if (!self.IsInWorld || self.Destroyed || self.IsDead() || self.World.RenderPlayer == null)
+			if (!self.IsInWorld || self.IsDead() || self.World.RenderPlayer == null)
 				return;
 
 			var gps = watcher[self.World.RenderPlayer];

--- a/OpenRA.Mods.RA/Effects/InvulnEffect.cs
+++ b/OpenRA.Mods.RA/Effects/InvulnEffect.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public void Tick( World world )
 		{
-			if (a.Destroyed || a.IsDead() || b.GetDamageModifier(null, null) > 0)
+			if (a.IsDead() || b.GetDamageModifier(null, null) > 0)
 				world.AddFrameEndTask(w => w.Remove(this));
 		}
 

--- a/OpenRA.Mods.RA/Effects/Rank.cs
+++ b/OpenRA.Mods.RA/Effects/Rank.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using OpenRA.Effects;
 using OpenRA.Graphics;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Effects
 {
@@ -18,20 +19,19 @@ namespace OpenRA.Mods.RA.Effects
 	{
 		Actor self;
 		Animation anim = new Animation("rank");
-		GainsExperience xp;
 
 		public Rank(Actor self)
 		{
 			this.self = self;
-			xp = self.Trait<GainsExperience>();
+			var xp = self.Trait<GainsExperience>();
 
 			anim.PlayRepeating("rank");
-			anim.PlayFetchIndex("rank", () => xp.Level - 1);
+			anim.PlayFetchIndex("rank", () => xp.Level == 0 ? 0 : xp.Level - 1);
 		}
 
 		public void Tick(World world)
 		{
-			if (self.Destroyed)
+			if (self.IsDead())
 				world.AddFrameEndTask(w => w.Remove(this));
 			else
 				anim.Tick();
@@ -42,10 +42,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (!self.IsInWorld)
 				yield break;
 
-			if (self.Destroyed)
-				yield break;
-
-			if (xp.Level < 1)
+			if (self.IsDead())
 				yield break;
 
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -76,8 +76,12 @@ namespace OpenRA.Mods.RA
 
 				Sound.PlayNotification(self.Owner, "Sounds", "LevelUp", self.Owner.Country.Race);
 				self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup")));
-				if (Level == 1 && !self.Destroyed)
-					self.World.AddFrameEndTask(w => w.Add(new Rank(self)));
+				if (Level == 1)
+					self.World.AddFrameEndTask(w =>
+					{
+						if (!self.IsDead())
+							w.Add(new Rank(self));
+					});
 			}
 		}
 


### PR DESCRIPTION
#4134

The `anim.PlayFetchIndex` is probably the most important change. I had a temp level variable before which only got updated during ticks and when the actor is alive. @pchote suggested to remove it for cleaner code and I forgot to add something to avoid the trait lookup from dead actors.

This also adds `.IsDead()` checks everywhere. They may be redundant, but I found them together with `.IsDestroyed` in other effects that have a trait look-up in their constructor.
