### PR TITLE
Fixed crash when the last production building was killed while the mouse was still hovering over the build palette

### DIFF
--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.RA
 					.Where(p => p.Trait.Info.Produces.Contains(unit.Traits.Get<BuildableInfo>().Queue))
 						.Where(p => p.Actor.Owner == self.Owner).ToArray();
 
-				var speedModifier = Math.Min(selfsameBuildings.Count(), Info.BuildTimeSpeedReduction.Length) - 1;
+				var speedModifier = selfsameBuildings.Count().Clamp(1, Info.BuildTimeSpeedReduction.Length) - 1;
 				time = (time * Info.BuildTimeSpeedReduction[speedModifier]) / 100;
 			}
 


### PR DESCRIPTION
#4137
