### PR TITLE
Remove language selector and IRC chat from the visible game UI.

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				showIncompatibleCheckbox.OnClick = () => { showIncompatible ^= true; ServerList.Query(games => RefreshServerList(panel, games)); };
 			}
 
-			Game.LoadWidget(null, "SERVERBROWSER_IRC", panel.Get("IRC_ROOT"), new WidgetArgs());
+			// Game.LoadWidget(null, "SERVERBROWSER_IRC", panel.Get("IRC_ROOT"), new WidgetArgs());
 
 			ServerList.Query(games => RefreshServerList(panel, games));
 		}

--- a/mods/cnc/chrome/serverbrowser.yaml
+++ b/mods/cnc/chrome/serverbrowser.yaml
@@ -17,11 +17,42 @@ Container@SERVERBROWSER_PANEL:
 			Height:500
 			Background:panel-black
 			Children:
+				Label@SHOW_LABEL_TITLE:
+					X:20
+					Y:10
+					Width:20
+					Height:25
+					Text:Show:
+					Font:Bold
+				Checkbox@WAITING_FOR_PLAYERS:
+					X:80
+					Y:13
+					Width:100
+					Height:20
+					Text:Waiting
+				Checkbox@EMPTY:
+					X:180
+					Y:13
+					Width:100
+					Height:20
+					Text:Empty
+				Checkbox@ALREADY_STARTED:
+					X:280
+					Y:13
+					Width:100
+					Height:20
+					Text:Started
+				Checkbox@INCOMPATIBLE_VERSION:
+					X:380
+					Y:13
+					Width:100
+					Height:20
+					Text:Incompatible
 				ScrollPanel@SERVER_LIST:
 					X:15
-					Y:15
+					Y:45
 					Width:700
-					Height:470
+					Height:440
 					Children:
 						ScrollItem@SERVER_TEMPLATE:
 							Width:PARENT_RIGHT-27

--- a/mods/cnc/chrome/serverbrowser.yaml
+++ b/mods/cnc/chrome/serverbrowser.yaml
@@ -1,31 +1,27 @@
 Container@SERVERBROWSER_PANEL:
 	Logic:ServerBrowserLogic
 	X:(WINDOW_RIGHT - WIDTH)/2
-	Y:(WINDOW_BOTTOM - HEIGHT)/2
+	Y:(WINDOW_BOTTOM - 500)/2
 	Width:730
-	Height:645
+	Height:535
 	Children:
 		Label@TITLE:
 			Text:Find Server
 			Width:740
-			Y:0-10
+			Y:0-25
 			Font:BigBold
 			Contrast:true
 			Align:Center
 		Background@bg:
 			Width:730
-			Height:600
+			Height:500
 			Background:panel-black
-			Y:15
 			Children:
-				Container@IRC_ROOT:
-					X:15
-					Y:15
 				ScrollPanel@SERVER_LIST:
 					X:15
-					Y:280
+					Y:15
 					Width:700
-					Height:300
+					Height:470
 					Children:
 						ScrollItem@SERVER_TEMPLATE:
 							Width:PARENT_RIGHT-27
@@ -80,7 +76,7 @@ Container@SERVERBROWSER_PANEL:
 									Height:25
 				Label@PROGRESS_LABEL:
 					X:(PARENT_RIGHT - WIDTH) / 2
-					Y:PARENT_BOTTOM / 2 - HEIGHT + (280 / 2)
+					Y:PARENT_BOTTOM / 2 - HEIGHT
 					Width:710
 					Height:25
 					Font:Bold
@@ -89,20 +85,20 @@ Container@SERVERBROWSER_PANEL:
 		Button@BACK_BUTTON:
 			Key:escape
 			X:0
-			Y:614
+			Y:499
 			Width:140
 			Height:35
 			Text:Back
 		Button@REFRESH_BUTTON:
 			X:PARENT_RIGHT - 140 - 10 - 140
-			Y:614
+			Y:499
 			Width:140
 			Height:35
 			Text:Refresh
 		Button@JOIN_BUTTON:
 			Key:return
 			X:PARENT_RIGHT - 140
-			Y:614
+			Y:499
 			Width:140
 			Height:35
 			Text:Join

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -170,6 +170,7 @@ Container@SETTINGS_PANEL:
 							Font:Bold
 							Text:Localization
 							Align:Center
+							Visible:false
 						Label@LANGUAGE_LABEL:
 							X:230 - WIDTH - 5
 							Y:244
@@ -177,12 +178,14 @@ Container@SETTINGS_PANEL:
 							Height:25
 							Align:Right
 							Text:Language:
+							Visible:false
 						DropDownButton@LANGUAGE_DROPDOWNBUTTON:
 							X:230
 							Y:245
 							Width:200
 							Height:25
 							Font:Regular
+							Visible:false
 						Label@VIDEO_DESC_A:
 							Y:265
 							Width:PARENT_RIGHT
@@ -190,6 +193,7 @@ Container@SETTINGS_PANEL:
 							Font:Tiny
 							Align:Center
 							Text:Language changes will be applied after the game is restarted
+							Visible:false
 						Label@VIDEO_DESC_B:
 							Y:280
 							Width:PARENT_RIGHT
@@ -197,6 +201,7 @@ Container@SETTINGS_PANEL:
 							Font:Tiny
 							Align:Center
 							Text:Translations apply to text strings only; Speech and build icons will remain in English
+							Visible:false
 				Container@AUDIO_PANEL:
 					Width:PARENT_RIGHT
 					Height:PARENT_BOTTOM

--- a/mods/ra/chrome/serverbrowser.yaml
+++ b/mods/ra/chrome/serverbrowser.yaml
@@ -3,7 +3,7 @@ Background@JOINSERVER_BG:
 	X:(WINDOW_RIGHT - WIDTH)/2
 	Y:(WINDOW_BOTTOM - HEIGHT)/2
 	Width:740
-	Height:700
+	Height:505
 	Children:
 		Label@JOINSERVER_LABEL_TITLE:
 			X:0
@@ -48,7 +48,7 @@ Background@JOINSERVER_BG:
 			X:20
 			Y:80
 			Width:700
-			Height:305
+			Height:355
 			Children:
 				ScrollItem@SERVER_TEMPLATE:
 					Width:PARENT_RIGHT-27
@@ -103,21 +103,21 @@ Background@JOINSERVER_BG:
 							Height:25
 		Label@PROGRESS_LABEL:
 			X:(PARENT_RIGHT - WIDTH) / 2
-			Y:505 / 2 - HEIGHT
+			Y:PARENT_BOTTOM / 2 - HEIGHT
 			Width:150
 			Height:30
 			Text:Fetching games...
 			Align:Center
 		Button@REFRESH_BUTTON:
 			X:20
-			Y:395
+			Y:PARENT_BOTTOM - 45
 			Width:100
 			Height:25
 			Text:Refresh
 			Font:Bold
 		Button@JOIN_BUTTON:
 			X:PARENT_RIGHT - 120 - 120
-			Y:395
+			Y:PARENT_BOTTOM - 45
 			Width:100
 			Height:25
 			Text:Join
@@ -125,12 +125,9 @@ Background@JOINSERVER_BG:
 			Key:return
 		Button@BACK_BUTTON:
 			X:PARENT_RIGHT - 120
-			Y:395
+			Y:PARENT_BOTTOM - 45
 			Width:100
 			Height:25
 			Text:Cancel
 			Font:Bold
 			Key:escape
-		Container@IRC_ROOT:
-			X:20
-			Y:430

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -170,6 +170,7 @@ Background@SETTINGS_PANEL:
 					Font:Bold
 					Text:Localization
 					Align:Center
+					Visible:false
 				Label@LANGUAGE_LABEL:
 					X:230 - WIDTH - 5
 					Y:244
@@ -177,11 +178,13 @@ Background@SETTINGS_PANEL:
 					Height:25
 					Align:Right
 					Text:Language:
+					Visible:false
 				DropDownButton@LANGUAGE_DROPDOWNBUTTON:
 					X:230
 					Y:245
 					Width:200
 					Height:25
+					Visible:false
 				Label@VIDEO_DESC_A:
 					Y:265
 					Width:PARENT_RIGHT
@@ -189,6 +192,7 @@ Background@SETTINGS_PANEL:
 					Font:Tiny
 					Align:Center
 					Text:Language changes will be applied after the game is restarted
+					Visible:false
 				Label@VIDEO_DESC_B:
 					Y:280
 					Width:PARENT_RIGHT
@@ -196,6 +200,7 @@ Background@SETTINGS_PANEL:
 					Font:Tiny
 					Align:Center
 					Text:Translations apply to text strings only; Speech and build icons will remain in English
+					Visible:false
 		Container@AUDIO_PANEL:
 			X:5
 			Y:50


### PR DESCRIPTION
Both of these features need a significant amount of work before they are release-ready. These features are currently doing more harm than good by blocking the other fixes and improvements from making their way into a new release.

I have made a start on fixing IRC, but that will not be ready in the near future.

Of course, both of these features can be restored once they have seen more polishing.
