### PR TITLE
Fixed crash in Fort Lonestar on map load

### DIFF
--- a/mods/ra/maps/Fort-Lonestar/map.yaml
+++ b/mods/ra/maps/Fort-Lonestar/map.yaml
@@ -532,7 +532,6 @@ Rules:
 		ExternalCapturable:
 		ExternalCapturableBar:
 		EngineerRepairable:
-		-MustBeDestroyed:
 		CashTrickler:
 			Period: 250
 			Amount: 50


### PR DESCRIPTION
```
Exception of type `OpenRA.FileFormats.YamlException`: Actor type oilb: Bogus yaml removals: [MustBeDestroyed, False]
```

Good use case for #4187.
