### PR TITLE
Shared MOTD between all mods and a default motd.txt

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ NEW:
 		Added GainsUnitUpgrades trait for leveling specific unit upgrades - firepower, armor, speed.
 		Added support for crates to level up specific unit upgrades.
 		Added a new Launch.Replay=$FILEPATH parameter for OpenRA.Game.exe to instantly start watching a *.rep file.
+	Server:
+		Message of the day is now shared between all mods and a default motd.txt gets created in the user directory.
 	Asset Browser:
 		Filenames are now listed in alphabetical order
 	Map Editor:

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -328,11 +328,14 @@ namespace OpenRA.Server
 				// Send initial ping
 				SendOrderTo(newConn, "Ping", Environment.TickCount.ToString());
 
-				var motdPath = Path.Combine(Platform.SupportDir, "motd_{0}.txt".F(ModData.Manifest.Mod.Id));
-				if (File.Exists(motdPath))
+				if (Settings.Dedicated)
 				{
-					var motd = System.IO.File.ReadAllText(motdPath);
-					SendOrderTo(newConn, "Message", motd);
+					var motdFile = Path.Combine(Platform.SupportDir, "motd.txt");
+					if (!File.Exists(motdFile))
+						System.IO.File.WriteAllText(motdFile, "Welcome, have fun and good luck!");
+					var motd = System.IO.File.ReadAllText(motdFile);
+					if (!string.IsNullOrEmpty(motd))
+						SendOrderTo(newConn, "Message", motd);
 				}
 
 				if (handshake.Mod == "{DEV_VERSION}")


### PR DESCRIPTION
to self-document how it works. I noticed that dedicated server admins like @xaionaro have one MOTD that is shared between all instances and contains no mod specific information. I also dislike underscores in filenames.
