### PR TITLE
Added a minimap renderer to OpenRA.Utility.exe

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Graphics
 					{
 						var mapX = x + map.Bounds.Left;
 						var mapY = y + map.Bounds.Top;
-						var custom = map.CustomTerrain[mapX,mapY];
+						var custom = map.CustomTerrain[mapX, mapY];
 						if (custom == null)
 							continue;
 						*(c + (y * bitmapData.Stride >> 2) + x) = world.TileSet.Terrain[custom].Color.ToArgb();
@@ -187,7 +187,7 @@ namespace OpenRA.Graphics
 
 		public static Bitmap RenderMapPreview(Map map)
 		{
-			Bitmap terrain = TerrainBitmap(map);
+			Bitmap terrain = TerrainBitmap(map, true);
 			return AddStaticResources(map, terrain);
 		}
 	}

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -185,9 +185,9 @@ namespace OpenRA.Graphics
 			return bitmap;
 		}
 
-		public static Bitmap RenderMapPreview(Map map)
+		public static Bitmap RenderMapPreview(Map map, bool actualSize)
 		{
-			Bitmap terrain = TerrainBitmap(map, true);
+			Bitmap terrain = TerrainBitmap(map, actualSize);
 			return AddStaticResources(map, terrain);
 		}
 	}

--- a/OpenRA.Game/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Game/Widgets/MapPreviewWidget.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Widgets
 					uid = cacheUids.Peek();
 				}
 
-				var bitmap = Minimap.RenderMapPreview(Game.modData.AvailableMaps[uid]);
+				var bitmap = Minimap.RenderMapPreview(Game.modData.AvailableMaps[uid], false);
 				lock (syncRoot)
 				{
 					// TODO: We should add previews to a sheet here (with multiple previews per sheet)

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -297,8 +297,8 @@ namespace OpenRA.Utility
 		public static void GenerateMinimap(string[] args)
 		{
 			var map = new Map(args[1]);
-
-			Game.modData = new ModData(map.RequiresMod);
+			var mod = args.Length > 1 ? args[2] : map.RequiresMod;
+			Game.modData = new ModData(mod);
 
 			FileSystem.UnmountAll();
 			foreach (var dir in Game.modData.Manifest.Folders)

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -293,5 +293,24 @@ namespace OpenRA.Utility
 			var result = new Map(args[1]).Uid;
 			Console.WriteLine(result);
 		}
+
+		public static void GenerateMinimap(string[] args)
+		{
+			var map = new Map(args[1]);
+
+			Game.modData = new ModData(map.RequiresMod);
+
+			FileSystem.UnmountAll();
+			foreach (var dir in Game.modData.Manifest.Folders)
+				FileSystem.Mount(dir);
+
+			Rules.LoadRules(Game.modData.Manifest, map);
+
+			var minimap = Minimap.RenderMapPreview(map);
+
+			var dest = Path.GetFileNameWithoutExtension(args[1]) + ".png";
+			minimap.Save(dest);
+			Console.WriteLine(dest + " saved.");
+		}
 	}
 }

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -306,7 +306,7 @@ namespace OpenRA.Utility
 
 			Rules.LoadRules(Game.modData.Manifest, map);
 
-			var minimap = Minimap.RenderMapPreview(map);
+			var minimap = Minimap.RenderMapPreview(map, true);
 
 			var dest = Path.GetFileNameWithoutExtension(args[1]) + ".png";
 			minimap.Save(dest);

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2012 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Utility
 				{ "--transpose", Command.TransposeShp },
 				{ "--docs", Command.ExtractTraitDocs },
 				{ "--map-hash", Command.GetMapHash },
+				{ "--minimap", Command.GenerateMinimap },
 			};
 
 			if (args.Length == 0) { PrintUsage(); return; }
@@ -62,6 +63,7 @@ namespace OpenRA.Utility
 			Console.WriteLine("  --transpose SRCSHP DESTSHP START N M [START N M ...]     Transpose the N*M block of frames starting at START.");
 			Console.WriteLine("  --docs MOD     Generate trait documentation in MarkDown format.");
 			Console.WriteLine("  --map-hash MAPFILE     Generate hash of specified oramap file.");
+			Console.WriteLine("  --minimap MAPFILE     Render PNG minimap of specified oramap file.");
 		}
 
 		static string GetNamedArg(string[] args, string arg)

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Utility
 			Console.WriteLine("  --transpose SRCSHP DESTSHP START N M [START N M ...]     Transpose the N*M block of frames starting at START.");
 			Console.WriteLine("  --docs MOD     Generate trait documentation in MarkDown format.");
 			Console.WriteLine("  --map-hash MAPFILE     Generate hash of specified oramap file.");
-			Console.WriteLine("  --minimap MAPFILE     Render PNG minimap of specified oramap file.");
+			Console.WriteLine("  --minimap MAPFILE [MOD]     Render PNG minimap of specified oramap file.");
 		}
 
 		static string GetNamedArg(string[] args, string arg)

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2012 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made


### PR DESCRIPTION
#4195 for http://content.open-ra.org/ which should migrate to this tool. The indexed PNGs generated with it are 10x smaller than the uncompressed BMPs created by https://github.com/Holloweye/OpenRA-Content-Website/blob/master/python/minimap.py It should also fix wrong radar colors for the ARRAKIS tileset etc.

We also want to fade out the OpenRA.Editor.exe #3377.
