### PR TITLE
Added a new Launch.Replay=$FILEPATH parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ NEW:
 		Added initial support for Tmp(TS) sprites.
 		Added GainsUnitUpgrades trait for leveling specific unit upgrades - firepower, armor, speed.
 		Added support for crates to level up specific unit upgrades.
+		Added a new Launch.Replay=$FILEPATH parameter for OpenRA.Game.exe to instantly start watching a *.rep file.
 	Asset Browser:
 		Filenames are now listed in alphabetical order
 	Map Editor:

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -318,13 +318,13 @@ namespace OpenRA
 			foreach (var mod in Mod.AllMods)
 				Console.WriteLine("\t{0}: {1} ({2})", mod.Key, mod.Value.Title, mod.Value.Version);
 
-			InitializeWithMod(Settings.Game.Mod);
+			InitializeWithMod(Settings.Game.Mod, args.GetValue("Launch.Replay", null));
 
 			if (Settings.Server.DiscoverNatDevices)
 				RunAfterDelay(Settings.Server.NatDiscoveryTimeout, UPnP.TryStoppingNatDiscovery);
 		}
 
-		public static void InitializeWithMod(string mod)
+		public static void InitializeWithMod(string mod, string replay)
 		{
 			// Clear static state if we have switched mods
 			LobbyInfoChanged = () => { };
@@ -396,6 +396,8 @@ namespace OpenRA
 			{
 				modData.LoadScreen.StartGame();
 				Settings.Save();
+				if (!string.IsNullOrEmpty(replay))
+					Game.JoinReplay(replay);
 			}
 		}
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -339,9 +339,9 @@ namespace OpenRA
 			if (orderManager != null)
 				orderManager.Dispose();
 
-			// Fall back to RA if the mod doesn't exist
+			// Fall back to default if the mod doesn't exist
 			if (!Mod.AllMods.ContainsKey(mod))
-				mod = "ra";
+				mod = new GameSettings().Mod;
 
 			Console.WriteLine("Loading mod: {0}", mod);
 			Settings.Game.Mod = mod;

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -85,7 +85,7 @@ namespace OpenRA.GameRules
 	{
 		public string Renderer = "Gl";
 		public WindowMode Mode = WindowMode.PseudoFullscreen;
-		public int2 FullscreenSize = new int2(0,0);
+		public int2 FullscreenSize = new int2(0, 0);
 		public int2 WindowedSize = new int2(1024, 768);
 		public bool PixelDouble = false;
 		public bool CapFramerate = true;
@@ -187,7 +187,7 @@ namespace OpenRA.GameRules
 
 	public class Settings
 	{
-		string SettingsFile;
+		string settingsFile;
 
 		public PlayerSettings Player = new PlayerSettings();
 		public GameSettings Game = new GameSettings();
@@ -202,31 +202,31 @@ namespace OpenRA.GameRules
 
 		public Settings(string file, Arguments args)
 		{
-			SettingsFile = file;
+			settingsFile = file;
 			Sections = new Dictionary<string, object>()
 			{
-				{"Player", Player},
-				{"Game", Game},
-				{"Sound", Sound},
-				{"Graphics", Graphics},
-				{"Server", Server},
-				{"Debug", Debug},
-				{"Keys", Keys},
-				{"Irc", Irc}
+				{ "Player", Player },
+				{ "Game", Game },
+				{ "Sound", Sound },
+				{ "Graphics", Graphics },
+				{ "Server", Server },
+				{ "Debug", Debug },
+				{ "Keys", Keys },
+				{ "Irc", Irc }
 			};
 
 			// Override fieldloader to ignore invalid entries
 			var err1 = FieldLoader.UnknownFieldAction;
 			var err2 = FieldLoader.InvalidValueAction;
 
-			FieldLoader.UnknownFieldAction = (s,f) =>
+			FieldLoader.UnknownFieldAction = (s, f) =>
 			{
-				Console.WriteLine( "Ignoring unknown field `{0}` on `{1}`".F( s, f.Name ) );
+				Console.WriteLine("Ignoring unknown field `{0}` on `{1}`".F(s, f.Name));
 			};
 
-			if (File.Exists(SettingsFile))
+			if (File.Exists(settingsFile))
 			{
-				var yaml = MiniYaml.DictFromFile(SettingsFile);
+				var yaml = MiniYaml.DictFromFile(settingsFile);
 
 				foreach (var kv in Sections)
 					if (yaml.ContainsKey(kv.Key))
@@ -236,8 +236,8 @@ namespace OpenRA.GameRules
 			// Override with commandline args
 			foreach (var kv in Sections)
 				foreach (var f in kv.Value.GetType().GetFields())
-					if (args.Contains(kv.Key+"."+f.Name))
-						FieldLoader.LoadField( kv.Value, f.Name, args.GetValue(kv.Key+"."+f.Name, "") );
+					if (args.Contains(kv.Key + "." + f.Name))
+						FieldLoader.LoadField(kv.Value, f.Name, args.GetValue(kv.Key + "." + f.Name, ""));
 
 			FieldLoader.UnknownFieldAction = err1;
 			FieldLoader.InvalidValueAction = err2;
@@ -246,19 +246,19 @@ namespace OpenRA.GameRules
 		public void Save()
 		{
 			var root = new List<MiniYamlNode>();
-			foreach( var kv in Sections )
-				root.Add( new MiniYamlNode( kv.Key, FieldSaver.SaveDifferences(kv.Value, Activator.CreateInstance(kv.Value.GetType())) ) );
+			foreach (var kv in Sections)
+				root.Add(new MiniYamlNode(kv.Key, FieldSaver.SaveDifferences(kv.Value, Activator.CreateInstance(kv.Value.GetType()))));
 
-			root.WriteToFile(SettingsFile);
+			root.WriteToFile(settingsFile);
 		}
 
 		void LoadSectionYaml(MiniYaml yaml, object section)
 		{
 			var defaults = Activator.CreateInstance(section.GetType());
-			FieldLoader.InvalidValueAction = (s,t,f) =>
+			FieldLoader.InvalidValueAction = (s, t, f) =>
 			{
 				var ret = defaults.GetType().GetField(f).GetValue(defaults);
-				Console.WriteLine("FieldLoader: Cannot parse `{0}` into `{2}:{1}`; substituting default `{3}`".F(s,t.Name,f,ret) );
+				Console.WriteLine("FieldLoader: Cannot parse `{0}` into `{2}:{1}`; substituting default `{3}`".F(s, t.Name, f, ret));
 				return ret;
 			};
 

--- a/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				Ui.CloseWindow();
 				onSwitch();
-				Game.InitializeWithMod(mod);
+				Game.InitializeWithMod(mod, null);
 			});
 		}
 	}

--- a/launch-replay.sh
+++ b/launch-replay.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd ${0%/*}
+exec mono OpenRA.Game.exe Launch.Replay="$@"


### PR DESCRIPTION
for OpenRA.Game.exe to instantly start watching a *.rep file. Use cases are automated testing and double-clicking .rep files in the future.
