### PR TITLE
Improved automatic map selection.

### DIFF
--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncMenuLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncMenuLogic.cs
@@ -139,6 +139,8 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 		void StartSkirmishGame()
 		{
 			var map = WidgetUtils.ChooseInitialMap(Game.Settings.Server.Map);
+			Game.Settings.Server.Map = map;
+			Game.Settings.Save();
 
 			ConnectionLogic.Connect(IPAddress.Loopback.ToString(),
 				Game.CreateLocalServer(map),


### PR DESCRIPTION
The existing behavior tends to default to a custom map, which messes with the map options and is generally not expected behavior.  This changes the behavior to pick a random conquest map that is 128x128 or smaller and allows bots.
