### PR TITLE
Don't spawn resources at maximum density.

### DIFF
--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -161,7 +161,6 @@ namespace OpenRA.Traits
 			{
 				Type = t,
 				Variant = ChooseRandomVariant(t),
-				Density = t.Info.MaxDensity,
 			};
 		}
 


### PR DESCRIPTION
Fixes #4278.
