### PR TITLE
Attempt to parse unexpected key events as text.

### DIFF
--- a/OpenRA.FileFormats/Exts.cs
+++ b/OpenRA.FileFormats/Exts.cs
@@ -82,12 +82,6 @@ namespace OpenRA
 			return (k & mod) == mod;
 		}
 
-		public static bool IsValidInput(this KeyInput key)
-		{
-			return char.IsLetter(key.UnicodeChar) || char.IsDigit(key.UnicodeChar) ||
-					char.IsSymbol(key.UnicodeChar) || char.IsSeparator(key.UnicodeChar) ||
-					char.IsPunctuation(key.UnicodeChar);
-		}
 
 		public static V GetOrAdd<K, V>(this Dictionary<K, V> d, K k)
 			where V : new()

--- a/OpenRA.Renderer.SdlCommon/SdlInput.cs
+++ b/OpenRA.Renderer.SdlCommon/SdlInput.cs
@@ -151,7 +151,15 @@ namespace OpenRA.Renderer.SdlCommon
 			{ Sdl.SDLK_UNDO, Keycode.UNDO },
 		};
 
+
 		MouseButton lastButtonBits = (MouseButton)0;
+
+		static bool IsValidInput(char c)
+		{
+			return char.IsLetter(c) || char.IsDigit(c) ||
+				char.IsSymbol(c) || char.IsSeparator(c) ||
+					char.IsPunctuation(c);
+		}
 
 		MouseButton MakeButton(byte b)
 		{
@@ -242,7 +250,14 @@ namespace OpenRA.Renderer.SdlCommon
 						// Drop unknown keys
 						Keycode keyCode;
 						if (!KeyRemap.TryGetValue(e.key.keysym.sym, out keyCode))
+						{
+							// Try parsing it as text
+							var c = (char)e.key.keysym.unicode;
+							if (IsValidInput(c))
+								inputHandler.OnTextInput(c.ToString());
+
 							break;
+						}
 
 						var type = e.type == Sdl.SDL_KEYDOWN ?
 							KeyInputEvent.Down : KeyInputEvent.Up;
@@ -269,7 +284,7 @@ namespace OpenRA.Renderer.SdlCommon
 						else
 							inputHandler.OnKeyInput(keyEvent);
 
-						if (keyEvent.IsValidInput())
+						if (IsValidInput(keyEvent.UnicodeChar))
 							inputHandler.OnTextInput(keyEvent.UnicodeChar.ToString());
 
 						break;


### PR DESCRIPTION
Fixes #4232. Hotkeys still can't be bound to these foreign keys, but the fix there is less clear (SDL2 doesn't define a specific code to map them to).
