### PR TITLE
Fixed broken FreeType 2 RPM dependency on Fedora

### DIFF
--- a/packaging/linux/rpm/openra.spec
+++ b/packaging/linux/rpm/openra.spec
@@ -12,7 +12,12 @@ License: GPL-3.0
 URL: http://open-ra.org
 Group: Amusements/Games
 Packager: Matthew Bowra-Dean <matthew@ijw.co.nz>
-Requires: mono-core mono-devel SDL openal freetype2
+Requires: mono-core mono-devel SDL openal
+%if 0%{?fedora}
+Requires: freetype
+%else
+Requires: freetype2
+%endif
 Prefix: /usr
 Source: %{name}-%{version}.tar.gz
 BuildRoot: /tmp/openra


### PR DESCRIPTION
reported via IRC http://logs.ihptru.net/?year=2013&month=12&day=13&update=Update
