### PR TITLE
Persist custom map package contents on save. Fixes #4318.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -113,6 +113,8 @@ NEW:
 		Renamed Game.Mods launch argument to Game.Mod.
 		Linux packages now install to /usr/lib/openra for consistency with other Mono applications.
 		Added an optional map.yaml check to the OpenRA.Lint.exe command line tool.
+	Map Editor:
+		Fixed custom assets being removed when saving an oramap.
 	Mod / Custom map compatibility:
 		Mods can now include traits from TD and D2K in RA.
 		Mods can now customize UI text settings like font type/color/contrast for most widgets and set global defaults in metrics.yaml.

--- a/OpenRA.Game/Map.cs
+++ b/OpenRA.Game/Map.cs
@@ -284,6 +284,15 @@ namespace OpenRA
 			var s = root.WriteToString();
 			entries.Add("map.yaml", Encoding.UTF8.GetBytes(s));
 
+			// Add any custom assets
+			foreach (var file in Container.AllFileNames())
+			{
+				if (file == "map.bin" || file == "map.yaml")
+					continue;
+
+				entries.Add(file, Container.GetContent(file).ReadAllBytes());
+			}
+
 			// Saving the map to a new location
 			if (toPath != Path)
 			{


### PR DESCRIPTION
Should work in theory, but I haven't tested this -- the content site no longer hosts version 5 maps and SharpZipLib crashes when parsing archives compressed using `zip` on OSX.  This should also fix the editor destroying custom assets, but of course that doesn't work on OSX either...
