### PR TITLE
Allow mods to define a list of compatible map sources.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,6 +117,7 @@ NEW:
 		Mods can now include traits from TD and D2K in RA.
 		Mods can now customize UI text settings like font type/color/contrast for most widgets and set global defaults in metrics.yaml.
 		New sections MapFolders and Translations added to mod.yaml.
+		Mods must now explicitly specify the mods that they can inherit maps from by defining `SupportsMapsFrom: parent_mod' in mod.yaml.
 		Renamed CarpetBomb trait to AttackBomber, and additional functionality added. An Armament trait is now required to specify the weapons.
 		Renamed Capture trait to ExternalCapture.
 		Renamed CapturableBar trait to ExternalCapturableBar.

--- a/OpenRA.FileFormats/Manifest.cs
+++ b/OpenRA.FileFormats/Manifest.cs
@@ -22,7 +22,7 @@ namespace OpenRA.FileFormats
 			Folders, MapFolders, Rules, ServerTraits,
 			Sequences, VoxelSequences, Cursors, Chrome, Assemblies, ChromeLayout,
 			Weapons, Voices, Notifications, Music, Movies, Translations, TileSets,
-			ChromeMetrics, PackageContents, LuaScripts;
+			ChromeMetrics, PackageContents, LuaScripts, MapCompatibility;
 
 		public readonly Dictionary<string, string> Packages;
 		public readonly MiniYaml LoadScreen;
@@ -69,6 +69,16 @@ namespace OpenRA.FileFormats
 
 			if (yaml.ContainsKey("TileSize"))
 				TileSize = int.Parse(yaml["TileSize"].Value);
+
+			// Allow inherited mods to import parent maps.
+			var compat = new List<string>();
+			compat.Add(mod);
+
+			if (yaml.ContainsKey("SupportsMapsFrom"))
+				foreach (var c in yaml["SupportsMapsFrom"].Value.Split(','))
+					compat.Add(c.Trim());
+
+			MapCompatibility = compat.ToArray();
 		}
 
 		static string[] YamlList(Dictionary<string, MiniYaml> yaml, string key)

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -155,7 +155,7 @@ namespace OpenRA
 				try
 				{
 					var map = new Map(path, Manifest.Mod.Id);
-					if (map.RequiresMod == Manifest.Mod.Id)
+					if (Manifest.MapCompatibility.Contains(map.RequiresMod))
 						ret.Add(map.Uid, map);
 				}
 				catch (Exception e)


### PR DESCRIPTION
Fixes #4319.

A worked example:

```
MapFolders:
    ./mods/cnc/maps
    ~^/maps/cnc
    ./mods/fgtn/maps

SupportsMapsFrom: cnc
```
