### PR TITLE
engine detection: fix order/redundancy

### DIFF
--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -83,7 +83,7 @@ namespace OpenRA.GameRules
 
 	public class GraphicSettings
 	{
-		public string Renderer = "Gl";
+		public string Renderer = "Sdl2";
 		public WindowMode Mode = WindowMode.PseudoFullscreen;
 		public int2 FullscreenSize = new int2(0,0);
 		public int2 WindowedSize = new int2(1024, 768);


### PR DESCRIPTION
The previous order was
Gl, Sdl2, Gl, Cg, null
which effectively excluded Sdl2 on every system that supported
Gl as well.
We also don't need to initialize Renderer anymore outside of the
detection loop.
