### PR TITLE
Fix visceroid health radius and name

### DIFF
--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -410,7 +410,7 @@ C10:
 VICE:
 	AppearsOnRadar:
 	Health:
-		Radius: 128
+		Radius: 427
 		HP: 400
 	Armor:
 		Type: Wood
@@ -438,7 +438,7 @@ VICE:
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: Viceroid
+		Name: Visceroid
 	Armament:
 		Weapon: Chemspray
 		LocalOffset: 384,0,0


### PR DESCRIPTION
Visceroids are vehicle-sized (in-game at least), so their health radius should reflect that.

And yes, I'm pretty sure it should be Visceroid and not Viceroid. The majority of Westwood documents and Tiberian Suns' rules.ini clearly spell it with an 's' added before the 'c'.
