### PR TITLE
Game Server: handle the 'already in use' error

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerCreationLogic.cs
@@ -105,9 +105,22 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var settings = new ServerSettings(Game.Settings.Server);
 
 			// Create and join the server
-			Game.CreateServer(settings);
-			Ui.CloseWindow();
-			ConnectionLogic.Connect(IPAddress.Loopback.ToString(), Game.Settings.Server.ListenPort, password, onCreate, onExit);
+			bool serverSuccess = false;
+			try {
+				Game.CreateServer(settings);
+				serverSuccess = true;
+			}
+			catch (System.Net.Sockets.SocketException) {
+				panel.Get<TextFieldWidget>("LISTEN_PORT").Text = (listenPort+1).ToString();
+				// XXX: Much better solution would be something like this:
+				//   AlertBox("Unable to bind on port " + listenPort.ToString() + ": " + e.Message, AlertBox.Buttons.OK);
+			}
+			finally {
+				if (serverSuccess) {
+					Ui.CloseWindow();
+					ConnectionLogic.Connect(IPAddress.Loopback.ToString(), Game.Settings.Server.ListenPort, password, onCreate, onExit);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
The game crashed everytime when the network server
was unable to start listening on a specified port.
This happens mostly in the case when the port is
used by another application.

This commit fixes the game to catch SocketException
so that the game won't crash.

Notes:
- we expect that the SocketException means that
  we're not able to bind the port (which may not
  be true in all the cases)
- instead of showing a nice alert-dialog, we try
  to increment the port number by one and let the
  user to try it again. This is for simplicity.

The original exception follows:

```
Platform is Linux
Using SDL 1.2 with OpenGL renderer
Desktop resolution: 1920x1080
No custom resolution provided, using desktop resolution
Using resolution: 1920x1080
Using OpenAL sound engine
Using default device
Available mods:
        cnc: Tiberian Dawn (release-20131223)
        d2k: Dune 2000 (release-20131223)
        ra: Red Alert (release-20131223)
Loading mod: ra
Exception of type `System.Net.Sockets.SocketException`: Address already in use
  at System.Net.Sockets.Socket.Bind (System.Net.EndPoint local_end) [0x00000] in <filename unknown>:0
  at System.Net.Sockets.TcpListener.Start (Int32 backlog) [0x00000] in <filename unknown>:0
  at System.Net.Sockets.TcpListener.Start () [0x00000] in <filename unknown>:0
  at OpenRA.Server.Server..ctor (System.Net.IPEndPoint endpoint, OpenRA.GameRules.ServerSettings settings, OpenRA.ModData modData) [0x00000] in <filename unknown>:0
  at OpenRA.Game.CreateServer (OpenRA.GameRules.ServerSettings settings) [0x00000] in <filename unknown>:0
  at OpenRA.Mods.RA.Widgets.Logic.ServerCreationLogic.CreateAndJoin () [0x00000] in <filename unknown>:0
  at OpenRA.Widgets.ButtonWidget.<ButtonWidget>m__CE (MouseInput _) [0x00000] in <filename unknown>:0
  at OpenRA.Widgets.ButtonWidget.HandleMouseInput (MouseInput mi) [0x00000] in <filename unknown>:0
  at OpenRA.Widgets.Widget.HandleMouseInputOuter (MouseInput mi) [0x00000] in <filename unknown>:0
  at OpenRA.Widgets.Ui.HandleInput (MouseInput mi) [0x00000] in <filename unknown>:0
  at OpenRA.DefaultInputHandler+<OnMouseInput>c__AnonStorey24.<>m__24 () [0x00000] in <filename unknown>:0
  at OpenRA.Sync.CheckSyncUnchanged[Boolean] (OpenRA.World world, System.Func`1 fn) [0x00000] in <filename unknown>:0
  at OpenRA.DefaultInputHandler.OnMouseInput (MouseInput input) [0x00000] in <filename unknown>:0
  at OpenRA.Renderer.SdlCommon.SdlInput.PumpInput (IInputHandler inputHandler) [0x00000] in <filename unknown>:0
  at OpenRA.Renderer.SdlCommon.SdlGraphics.PumpInput (IInputHandler inputHandler) [0x00000] in <filename unknown>:0
  at OpenRA.Graphics.Renderer.EndFrame (IInputHandler inputHandler) [0x00000] in <filename unknown>:0
  at OpenRA.Game.Tick (OpenRA.Network.OrderManager orderManager) [0x00000] in <filename unknown>:0
  at OpenRA.Game.Run () [0x00000] in <filename unknown>:0
  at OpenRA.Program.Run (System.String[] args) [0x00000] in <filename unknown>:0
  at OpenRA.Program.Main (System.String[] args) [0x00000] in <filename unknown>:0
```
