### PR TITLE
add libmono-winforms2.0-cil dep for debian/ubuntu

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -36,6 +36,7 @@ Debian/Ubuntu
 -------------
 
 * mono-gmcs
+* libmono-winforms2.0-cil
 * cli-common-dev (>= 2.10)
 * freetype
 * openal


### PR DESCRIPTION
This is needed to compile on Ubuntu. Added to README
