### PR TITLE
Added a DisplayDebugMessages setting and checkbox

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -450,7 +450,8 @@ namespace OpenRA
 
 		public static void Debug(string s, params object[] args)
 		{
-			AddChatLine(Color.White, "Debug", string.Format(s, args));
+			if (Settings.Debug.DisplayDebugMessages)
+				AddChatLine(Color.White, "Debug", string.Format(s, args));
 		}
 
 		public static void Disconnect()

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -68,6 +68,7 @@ namespace OpenRA.GameRules
 
 	public class DebugSettings
 	{
+		public bool DisplayDebugMessages = true;
 		public bool BotDebug = false;
 		public bool PerfText = false;
 		public bool PerfGraph = false;

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -356,6 +356,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			BindCheckboxPref(panel, "BOTDEBUG_CHECKBOX", ds, "BotDebug");
 			BindCheckboxPref(panel, "DEVELOPER_MENU_CHECKBOX", ds, "DeveloperMenu");
 			BindCheckboxPref(panel, "CRASH_DIALOG_CHECKBOX", ds, "ShowFatalErrorDialog");
+			BindCheckboxPref(panel, "DEBUGMESSAGES_CHECKBOX", ds, "DisplayDebugMessages");
 
 			return () => { };
 		}
@@ -375,6 +376,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				ds.PerfGraph = dds.PerfGraph;
 				ds.SanityCheckUnsyncedCode = dds.SanityCheckUnsyncedCode;
 				ds.BotDebug = dds.BotDebug;
+				ds.DisplayDebugMessages = dds.DisplayDebugMessages;
 				ds.DeveloperMenu = dds.DeveloperMenu;
 				ds.ShowFatalErrorDialog = dds.ShowFatalErrorDialog;
 			};

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -449,3 +449,10 @@ Background@SETTINGS_PANEL:
 					Height:20
 					Font:Regular
 					Text:Check Sync around Unsynced Code
+				Checkbox@DEBUGMESSAGES_CHECKBOX:
+					X:310
+					Y:190
+					Width:300
+					Height:20
+					Font:Regular
+					Text:Show Engine Debug Messages


### PR DESCRIPTION
Not sure if everyone cares for in-game messages like `Debug: Order lag is now 3 frames.` Now you can turn it off by unticking a checkbox. We might be already at a state where this can be the default.
