### PR TITLE
Made torpedos not travel through land, but destroy bridges

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ NEW:
 		Added randomized tiles for Sand and Rock terrain.
 	Red Alert:
 		Tanya can now plant C4 on bridges.
+		Submarine torpedoes can now hit bridges when force fired.
+		Increased torpedo splash damage and raised multiplier vs. concrete.
 	Tiberian Dawn:
 		Commando can now plant C4 on bridges.
 	Engine:

--- a/OpenRA.FileFormats/Map/TileSet.cs
+++ b/OpenRA.FileFormats/Map/TileSet.cs
@@ -18,8 +18,9 @@ namespace OpenRA.FileFormats
 	public class TerrainTypeInfo
 	{
 		public string Type;
+		public string[] TargetTypes = { };
 		public string[] AcceptsSmudgeType = { };
-		public bool IsWater = false;
+		public bool IsWater = false; // TODO: Remove this
 		public Color Color;
 		public string CustomCursor;
 

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -179,13 +179,7 @@ namespace OpenRA.GameRules
 				if (!world.Map.IsInMap(cell))
 					return false;
 
-				if (ValidTargets.Contains("Ground") && world.GetTerrainType(cell) != "Water")
-					return true;
-
-				if (ValidTargets.Contains("Water") && world.GetTerrainType(cell) == "Water")
-					return true;
-
-				return false;
+				return true;
 			}
 
 			return false;

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -105,7 +105,7 @@ namespace OpenRA.GameRules
 		public readonly int ROF = 1;
 		public readonly int Burst = 1;
 		public readonly bool Charges = false;
-		public readonly bool Underwater = false;
+		public readonly string Palette = "effect";
 		public readonly string[] ValidTargets = { "Ground", "Water" };
 		public readonly string[] InvalidTargets = { };
 		public readonly int BurstDelay = 5;

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -179,6 +179,11 @@ namespace OpenRA.GameRules
 				if (!world.Map.IsInMap(cell))
 					return false;
 
+				var cellInfo = world.GetTerrainInfo(cell);
+				if (!ValidTargets.Intersect(cellInfo.TargetTypes).Any()
+				    || InvalidTargets.Intersect(cellInfo.TargetTypes).Any())
+					return false;
+
 				return true;
 			}
 

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Traits
 		public bool PathDebug = false;
 		public bool UnlimitedPower;
 		public bool BuildAnywhere;
-		public bool ShowMuzzles;
+		public bool ShowCombatGeometry;
 		public bool ShowDebugGeometry;
 
 		public object Create (ActorInitializer init) { return new DeveloperMode(this); }
@@ -37,7 +37,7 @@ namespace OpenRA.Traits
 		[Sync] public bool BuildAnywhere;
 
 		// Client size only
-		public bool ShowMuzzles;
+		public bool ShowCombatGeometry;
 		public bool ShowDebugGeometry;
 
 		public DeveloperMode(DeveloperModeInfo info)
@@ -49,7 +49,7 @@ namespace OpenRA.Traits
 			PathDebug = info.PathDebug;
 			UnlimitedPower = info.UnlimitedPower;
 			BuildAnywhere = info.BuildAnywhere;
-			ShowMuzzles = info.ShowMuzzles;
+			ShowCombatGeometry = info.ShowCombatGeometry;
 			ShowDebugGeometry = info.ShowDebugGeometry;
 		}
 

--- a/OpenRA.Mods.RA/BridgeHut.cs
+++ b/OpenRA.Mods.RA/BridgeHut.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA
 
 		public bool IsValidTarget(Actor self, Actor saboteur)
 		{
-			return BridgeDamageState == DamageState.Undamaged;
+			return BridgeDamageState != DamageState.Dead;
 		}
 
 		public DamageState BridgeDamageState { get { return bridge.AggregateDamageState(); } }

--- a/OpenRA.Mods.RA/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.RA/CombatDebugOverlay.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA
 
 		public void RenderAfterWorld(WorldRenderer wr, Actor self)
 		{
-			if (devMode == null || !devMode.ShowMuzzles)
+			if (devMode == null || !devMode.ShowCombatGeometry)
 				return;
 
 			if (health.Value != null)

--- a/OpenRA.Mods.RA/Effects/Bullet.cs
+++ b/OpenRA.Mods.RA/Effects/Bullet.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.RA.Effects
 						yield return r;
 				}
 
-				var palette = wr.Palette(args.Weapon.Underwater ? "shadow" : "effect");
+				var palette = wr.Palette(args.Weapon.Palette);
 				foreach (var r in anim.Render(pos, palette))
 					yield return r;
 			}

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			if (!args.SourceActor.World.FogObscures(pos.ToCPos()))
 			{
-				var palette = wr.Palette(args.Weapon.Underwater ? "shadow" : "effect");
+				var palette = wr.Palette(args.Weapon.Palette);
 				foreach (var r in anim.Render(pos, palette))
 					yield return r;
 			}

--- a/OpenRA.Mods.RA/Widgets/Logic/CheatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/CheatsLogic.cs
@@ -57,11 +57,11 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				fastChargeCheckbox.OnClick = () => Order(world, "DevFastCharge");
 			}
 
-			var showMuzzlesCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_MUZZLES");
-			if (showMuzzlesCheckbox != null)
+			var showCombatCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_COMBATOVERLAY");
+			if (showCombatCheckbox != null)
 			{
-				showMuzzlesCheckbox.IsChecked = () => devTrait.ShowMuzzles;
-				showMuzzlesCheckbox.OnClick = () => devTrait.ShowMuzzles ^= true;
+				showCombatCheckbox.IsChecked = () => devTrait.ShowCombatGeometry;
+				showCombatCheckbox.OnClick = () => devTrait.ShowCombatGeometry ^= true;
 			}
 
 			var showGeometryCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_GEOMETRY");

--- a/mods/cnc/chrome/cheats.yaml
+++ b/mods/cnc/chrome/cheats.yaml
@@ -101,7 +101,7 @@ Container@CHEATS_PANEL:
 					Width:200
 					Font:Regular
 					Text:Show A* Cost
-				Checkbox@SHOW_MUZZLES:
+				Checkbox@SHOW_COMBATOVERLAY:
 					X:290
 					Y:235
 					Height:20

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -10,47 +10,58 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 134, 95, 69
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		AcceptsSmudgeType:
 		Color: 93, 165, 206
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 168, 123, 83
+		TargetTypes: Ground
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
 		Color: 116, 90, 63
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		AcceptsSmudgeType:
 		Color: 111, 132, 139
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Tiberium:
 		Type: Tiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 161, 226, 28
+		TargetTypes: Ground
 	TerrainType@BlueTiberium:
 		Type: BlueTiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 84, 252, 252
+		TargetTypes: Ground
 
 Templates:
 	Template@255:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -10,47 +10,58 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 196, 196, 196
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		AcceptsSmudgeType:
 		Color: 92, 116, 164
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+		TargetTypes: Ground
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		AcceptsSmudgeType:
 		Color: 92, 140, 180
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Tiberium:
 		Type: Tiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 161, 226, 28
+		TargetTypes: Ground
 	TerrainType@BlueTiberium:
 		Type: BlueTiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 84, 252, 252
+		TargetTypes: Ground
 
 Templates:
 	Template@255:
@@ -1321,3 +1332,4 @@ Templates:
 			3: Water
 			4: River
 			6: Water
+

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -10,47 +10,58 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 40, 68, 40
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		AcceptsSmudgeType:
 		Color: 92, 116, 164
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+		TargetTypes: Ground
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		AcceptsSmudgeType:
 		Color: 92, 140, 180
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Tiberium:
 		Type: Tiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 161, 226, 28
+		TargetTypes: Ground
 	TerrainType@BlueTiberium:
 		Type: BlueTiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 84, 252, 252
+		TargetTypes: Ground
 
 Templates:
 	Template@255:
@@ -1333,3 +1344,4 @@ Templates:
 			3: Tree
 			2: Tree
 			4: Tree
+

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -10,47 +10,58 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 40, 68, 40
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		AcceptsSmudgeType:
 		Color: 92, 116, 164
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+		TargetTypes: Ground
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		AcceptsSmudgeType:
 		Color: 92, 140, 180
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Tiberium:
 		Type: Tiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 161, 226, 28
+		TargetTypes: Ground
 	TerrainType@BlueTiberium:
 		Type: BlueTiberium
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 84, 252, 252
+		TargetTypes: Ground
 
 Templates:
 	Template@255:
@@ -1327,3 +1338,4 @@ Templates:
 			3: Water
 			4: River
 			6: Water
+

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -9,52 +9,62 @@ Terrain:
 	TerrainType@Clear: # TODO: workaround for the stupid WinForms editor
 		Type: Clear
 		Color: 0, 0, 0
+		TargetTypes: Ground
 	TerrainType@Sand:
 		Type: Sand
 		AcceptsSmudgeType: SandCrater
 		IsWater: False
 		Color: 255,208,192,160
+		TargetTypes: Ground
 	TerrainType@Transition:
 		Type: Transition
 		AcceptsSmudgeType:
 		IsWater: False
 		Color: 255,207,166,100
+		TargetTypes: Ground
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType: RockCrater
 		IsWater: False
 		Color: 255,206,140,66
+		TargetTypes: Ground
 	TerrainType@Cliff:
 		Type: Cliff
 		AcceptsSmudgeType:
 		IsWater: False
 		Color: 255,74,41,16
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType:
 		IsWater: False
 		Color: 255,88,116,116
 		CustomCursor: move-rough
+		TargetTypes: Ground
 	TerrainType@Concrete:
 		Type: Concrete
 		AcceptsSmudgeType:
 		IsWater: False
 		Color: 255,208,192,160
+		TargetTypes: Ground
 	TerrainType@Dune:
 		Type: Dune
 		AcceptsSmudgeType:
 		IsWater: False
 		Color: 255,239,222,140
+		TargetTypes: Ground
 	TerrainType@Spice:
 		Type: Spice
 		AcceptsSmudgeType:
 		IsWater: False
 		Color: 255,239,148,74
+		TargetTypes: Ground
 	TerrainType@Ice:
 		Type: Ice
 		AcceptsSmudgeType:
 		IsWater: True
 		Color: 255,255,255,255
+		TargetTypes: Ground
 
 Templates:
 	Template@0:

--- a/mods/ra/chrome/cheats.yaml
+++ b/mods/ra/chrome/cheats.yaml
@@ -81,7 +81,7 @@ Background@CHEATS_PANEL:
 			Width:PARENT_RIGHT - 30
 			Height:20
 			Text:Show A* Cost
-		Checkbox@SHOW_MUZZLES:
+		Checkbox@SHOW_COMBATOVERLAY:
 			X:30
 			Y:350
 			Height:20

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -416,7 +416,7 @@ BRIDGE2:
 		SpawnOffset: 2,1
 
 SBRIDGE1:
-	Inherits: ^SVBridge
+	Inherits: ^Bridge
 	Bridge:
 		Template: 520
 		DamagedTemplate: 521
@@ -432,7 +432,7 @@ SBRIDGE1:
 		SpawnOffset: 1,1
 
 SBRIDGE2:
-	Inherits: ^SHBridge
+	Inherits: ^Bridge
 	Bridge:
 		Template: 531
 		DamagedTemplate: 532
@@ -448,7 +448,7 @@ SBRIDGE2:
 		SpawnOffset: 1,1
 
 SBRIDGE3:
-	Inherits: ^STDBridge
+	Inherits: ^Bridge
 	Bridge:
 		Template: 523
 		DamagedTemplate: 524
@@ -464,7 +464,7 @@ SBRIDGE3:
 		SpawnOffset: 0,1
 
 SBRIDGE4:
-	Inherits: ^STDBridge
+	Inherits: ^Bridge
 	Bridge:
 		Template: 527
 		DamagedTemplate: 528

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -459,6 +459,8 @@
 		HP: 1000
 	ProximityCaptor:
 		Types: Bridge
+	Armor:
+		Type: Concrete
 	AutoTargetIgnore:
 	BodyOrientation:
 	LuaScriptEvents:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -6,6 +6,7 @@
 			Clear: 80
 			Rough: 40
 			Road: 100
+			Bridge: 100
 			Ore: 70
 			Gems: 70
 			Beach: 40
@@ -53,6 +54,7 @@
 			Clear: 80
 			Rough: 70
 			Road: 100
+			Bridge: 100
 			Ore: 70
 			Gems: 70
 			Beach: 70
@@ -107,6 +109,7 @@
 			Clear: 90
 			Rough: 80
 			Road: 100
+			Bridge: 100
 			Ore: 80
 			Gems: 80
 			Beach: 80

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -463,57 +463,6 @@
 	BodyOrientation:
 	LuaScriptEvents:
 
-^SVBridge:
-	Tooltip:
-		Name: Small Bridge
-	BelowUnits:
-	TargetableBuilding:
-		TargetTypes: Ground, Water
-	Building:
-		Footprint: ___ ___
-		Dimensions: 3,2
-	Health:
-		HP: 750
-	ProximityCaptor:
-		Types: Bridge
-	AutoTargetIgnore:
-	BodyOrientation:
-	LuaScriptEvents:
-
-^SHBridge:
-	Tooltip:
-		Name: Small Bridge
-	BelowUnits:
-	TargetableBuilding:
-		TargetTypes: Ground, Water
-	Building:
-		Footprint: __ __ __
-		Dimensions: 2,3
-	Health:
-		HP: 750
-	ProximityCaptor:
-		Types: Bridge
-	AutoTargetIgnore:
-	BodyOrientation:
-	LuaScriptEvents:
-
-^STDBridge:
-	Tooltip:
-		Name: Small Bridge
-	BelowUnits:
-	TargetableBuilding:
-		TargetTypes: Ground, Water
-	Building:
-		Footprint: ____ ____
-		Dimensions: 4,2
-	Health:
-		HP: 750
-	ProximityCaptor:
-		Types: Bridge
-	AutoTargetIgnore:
-	BodyOrientation:
-	LuaScriptEvents:
-
 ^Rock:
 	Tooltip:
 		Name: Rock

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -24,6 +24,10 @@ Terrain:
 		Buildable: True
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 168, 123, 83
+	TerrainType@Bridge:
+		Type: Bridge
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 96, 96, 96
 	TerrainType@Rock:
 		Type: Rock
 		Buildable: False
@@ -2816,11 +2820,11 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
-			4: Road
-			5: Road
+			4: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@621:
@@ -2830,11 +2834,11 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
-			4: Road
-			5: Road
+			4: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@622:
@@ -2879,13 +2883,13 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
 			4: Rock
 			5: Rock
-			6: Road
-			7: Road
+			6: Bridge
+			7: Bridge
 	Template@625:
 		Id: 625
 		Image: bridge2h
@@ -2893,13 +2897,13 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
 			4: Rock
 			5: Rock
-			6: Road
-			7: Road
+			6: Bridge
+			7: Bridge
 	Template@626:
 		Id: 626
 		Image: bridge2d
@@ -2942,10 +2946,10 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
-			5: Road
+			5: Bridge
 			6: Rock
 			7: River
 	Template@236:
@@ -2955,10 +2959,10 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
-			5: Road
+			5: Bridge
 			6: Rock
 			7: River
 	Template@237:
@@ -2981,9 +2985,9 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			4: Road
-			5: Road
+			1: Bridge
+			4: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@239:
@@ -2993,9 +2997,9 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			4: Road
-			5: Road
+			1: Bridge
+			4: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@240:
@@ -3017,8 +3021,8 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			5: Road
+			1: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@242:
@@ -3028,8 +3032,8 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			5: Road
+			1: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@243:

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -13,65 +13,78 @@ Terrain:
 		Buildable: True
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 134, 95, 69
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		Buildable: False
 		AcceptsSmudgeType:
 		Color: 93, 165, 206
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		Buildable: True
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 168, 123, 83
+		TargetTypes: Ground
 	TerrainType@Bridge:
 		Type: Bridge
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 96, 96, 96
+		TargetTypes: Ground, Bridge
 	TerrainType@Rock:
 		Type: Rock
 		Buildable: False
 		AcceptsSmudgeType:
 		Color: 116, 90, 63
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		Buildable: False
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@Brush:
 		Type: Brush
 		Buildable: False
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		Buildable: False
 		AcceptsSmudgeType:
 		Color: 111, 132, 139
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		Buildable: False
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		Buildable: False
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		Buildable: False
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Ore:
 		Type: Ore
 		Buildable: False
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 148, 128, 96
+		TargetTypes: Ground
 	TerrainType@Gems:
 		Type: Gems
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 132, 112, 255
+		TargetTypes: Ground
 
 Templates:
 	Template@255:
@@ -3105,3 +3118,4 @@ Templates:
 			12: Rock
 			13: Rock
 			14: Rock
+

--- a/mods/ra/tilesets/interior.yaml
+++ b/mods/ra/tilesets/interior.yaml
@@ -9,47 +9,58 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 0, 0, 0
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		AcceptsSmudgeType:
 		Color: 92, 116, 164
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+		TargetTypes: Ground
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		AcceptsSmudgeType:
 		Color: 92, 140, 180
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Ore:
 		Type: Ore
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 148, 128, 96
+		TargetTypes: Ground
 	TerrainType@Gems:
 		Type: Gems
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 132, 112, 255
+		TargetTypes: Ground
 
 Templates:
 	Template@255:

--- a/mods/ra/tilesets/interior.yaml
+++ b/mods/ra/tilesets/interior.yaml
@@ -10,46 +10,15 @@ Terrain:
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 0, 0, 0
 		TargetTypes: Ground
-	TerrainType@Water:
-		Type: Water
-		IsWater: true
-		AcceptsSmudgeType:
-		Color: 92, 116, 164
-		TargetTypes: Water
-	TerrainType@Road:
-		Type: Road
-		AcceptsSmudgeType: Crater, Scorch
-		Color: 88, 116, 116
-		TargetTypes: Ground
-	TerrainType@Rock:
-		Type: Rock
-		AcceptsSmudgeType:
-		Color: 68, 68, 60
-		TargetTypes: Ground
-	TerrainType@Tree:
+	TerrainType@Tree: # and Boxes
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
 		TargetTypes: Ground
-	TerrainType@River:
-		Type: River
-		AcceptsSmudgeType:
-		Color: 92, 140, 180
-		TargetTypes: Ground
-	TerrainType@Rough:
-		Type: Rough
-		AcceptsSmudgeType: Crater, Scorch
-		Color: 68, 68, 60
-		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
-		AcceptsSmudgeType: Crater, Scorch
-		Color: 208, 192, 160
-		TargetTypes: Ground
-	TerrainType@Beach:
-		Type: Beach
 		AcceptsSmudgeType:
-		Color: 176, 156, 120
+		Color: 208, 192, 160
 		TargetTypes: Ground
 	TerrainType@Ore:
 		Type: Ore

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -19,6 +19,10 @@ Terrain:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+	TerrainType@Bridge:
+		Type: Bridge
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 96, 96, 96
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
@@ -2487,12 +2491,12 @@ Templates:
 		Category: Bridge
 		Tiles:
 			1: Rock
-			2: Road
+			2: Bridge
 			4: Rock
-			5: Road
-			6: Road
+			5: Bridge
+			6: Bridge
 			7: Rock
-			9: Road
+			9: Bridge
 			10: Rock
 			11: Rock
 	Template@236:
@@ -2532,13 +2536,13 @@ Templates:
 		Category: Bridge
 		Tiles:
 			1: Rock
-			2: Road
+			2: Bridge
 			5: Rock
-			6: Road
-			7: Road
+			6: Bridge
+			7: Bridge
 			8: Rock
 			9: Rock
-			11: Road
+			11: Bridge
 			12: Rock
 			13: Rock
 	Template@239:
@@ -2580,8 +2584,8 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			5: Road
+			1: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@242:
@@ -2591,8 +2595,8 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			5: Road
+			1: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@243:
@@ -2665,12 +2669,12 @@ Templates:
 		Category: Bridge
 		Tiles:
 			1: Rock
-			2: Road
-			3: Road
+			2: Bridge
+			3: Bridge
 			4: Rock
 			5: Rock
-			6: Road
-			7: Road
+			6: Bridge
+			7: Bridge
 			8: Rock
 			9: Rock
 			12: Rock
@@ -2727,13 +2731,13 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
 			5: Rock
 			6: Rock
-			7: Road
-			8: Road
+			7: Bridge
+			8: Bridge
 			9: Rock
 	Template@134:
 		Id: 134

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -10,51 +10,63 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 196, 196, 196
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		AcceptsSmudgeType:
 		Color: 92, 116, 164
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+		TargetTypes: Ground
 	TerrainType@Bridge:
 		Type: Bridge
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 96, 96, 96
+		TargetTypes: Ground, Bridge
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		AcceptsSmudgeType:
 		Color: 92, 140, 180
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Ore:
 		Type: Ore
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 148, 128, 96
+		TargetTypes: Ground
 	TerrainType@Gems:
 		Type: Gems
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 132, 112, 255
+		TargetTypes: Ground
 
 Templates:
 	Template@255:
@@ -3141,3 +3153,4 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Rock
+

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -19,6 +19,10 @@ Terrain:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+	TerrainType@Bridge:
+		Type: Bridge
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 96, 96, 96
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
@@ -2489,12 +2493,12 @@ Templates:
 		Category: Bridge
 		Tiles:
 			1: Rock
-			2: Road
+			2: Bridge
 			4: Rock
-			5: Road
-			6: Road
+			5: Bridge
+			6: Bridge
 			7: Rock
-			9: Road
+			9: Bridge
 			10: Rock
 			11: Rock
 	Template@236:
@@ -2534,13 +2538,13 @@ Templates:
 		Category: Bridge
 		Tiles:
 			1: Rock
-			2: Road
+			2: Bridge
 			5: Rock
-			6: Road
-			7: Road
+			6: Bridge
+			7: Bridge
 			8: Rock
 			9: Rock
-			11: Road
+			11: Bridge
 			12: Rock
 			13: Rock
 	Template@239:
@@ -2582,8 +2586,8 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			5: Road
+			1: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@242:
@@ -2593,8 +2597,8 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			5: Road
+			1: Bridge
+			5: Bridge
 			6: Rock
 			7: Rock
 	Template@243:
@@ -2667,12 +2671,12 @@ Templates:
 		Category: Bridge
 		Tiles:
 			1: Rock
-			2: Road
-			3: Road
+			2: Bridge
+			3: Bridge
 			4: Rock
 			5: Rock
-			6: Road
-			7: Road
+			6: Bridge
+			7: Bridge
 			8: Rock
 			9: Rock
 			12: Rock
@@ -2715,11 +2719,11 @@ Templates:
 		Category: Bridge
 		Tiles:
 			2: Clear
-			3: Road
-			4: Road
+			3: Bridge
+			4: Bridge
 			5: Rock
-			15: Road
-			16: Road
+			15: Bridge
+			16: Bridge
 			18: Rock
 			19: Rock
 	Template@133:
@@ -2729,13 +2733,13 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rock
-			1: Road
-			2: Road
+			1: Bridge
+			2: Bridge
 			3: Rock
 			5: Rock
 			6: Rock
-			7: Road
-			8: Road
+			7: Bridge
+			8: Bridge
 			9: Rock
 	Template@134:
 		Id: 134
@@ -2773,8 +2777,8 @@ Templates:
 		Size: 5,5
 		Category: Bridge
 		Tiles:
-			0: Road
-			1: Road
+			0: Bridge
+			1: Bridge
 			2: Rough
 			3: Clear
 			4: Rough
@@ -2782,10 +2786,10 @@ Templates:
 			15: Rock
 			16: Rock
 			17: Rough
-			18: Road
-			19: Road
-			23: Road
-			24: Road
+			18: Bridge
+			19: Bridge
+			23: Bridge
+			24: Bridge
 	Template@247:
 		Id: 247
 		Image: f01

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -20,7 +20,7 @@ Terrain:
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
-		Color: 88, 116, 116
+		Color: 94, 67, 13
 		TargetTypes: Ground
 	TerrainType@Bridge:
 		Type: Bridge

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -10,51 +10,63 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 40, 68, 40
+		TargetTypes: Ground
 	TerrainType@Water:
 		Type: Water
 		IsWater: true
 		AcceptsSmudgeType:
 		Color: 92, 116, 164
+		TargetTypes: Water
 	TerrainType@Road:
 		Type: Road
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 88, 116, 116
+		TargetTypes: Ground
 	TerrainType@Bridge:
 		Type: Bridge
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 96, 96, 96
+		TargetTypes: Ground, Bridge
 	TerrainType@Rock:
 		Type: Rock
 		AcceptsSmudgeType:
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree
 		AcceptsSmudgeType:
 		Color: 28, 32, 36
+		TargetTypes: Ground
 	TerrainType@River:
 		Type: River
 		AcceptsSmudgeType:
 		Color: 92, 140, 180
+		TargetTypes: Ground
 	TerrainType@Rough:
 		Type: Rough
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 68, 68, 60
+		TargetTypes: Ground
 	TerrainType@Wall:
 		Type: Wall
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 208, 192, 160
+		TargetTypes: Ground
 	TerrainType@Beach:
 		Type: Beach
 		AcceptsSmudgeType:
 		Color: 176, 156, 120
+		TargetTypes: Ground
 	TerrainType@Ore:
 		Type: Ore
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 148, 128, 96
+		TargetTypes: Ground
 	TerrainType@Gems:
 		Type: Gems
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 132, 112, 255
+		TargetTypes: Ground
 
 Templates:
 	Template@255:
@@ -3225,7 +3237,7 @@ Templates:
 			0: River
 			1: Road
 			2: River
-			3: River 
+			3: River
 			4: Road
 			5: River
 		Category: Bridge
@@ -3237,7 +3249,7 @@ Templates:
 			0: River
 			1: Road
 			2: River
-			3: River 
+			3: River
 			4: Road
 			5: River
 		Category: Bridge
@@ -3249,7 +3261,7 @@ Templates:
 			0: River
 			1: Rock
 			2: River
-			3: River 
+			3: River
 			4: Rock
 			5: River
 		Category: Bridge
@@ -3345,7 +3357,7 @@ Templates:
 			6: Rock
 			7: Rock
 		Category: Bridge
-	Template@530
+	Template@530:
 		Id: 530
 		Image: sbridge4x
 		Size: 5,5
@@ -3365,7 +3377,7 @@ Templates:
 			23: Clear
 			24: Road
 		Category: Bridge
-	Template@531
+	Template@531:
 		Id: 531
 		Image: sbridge2
 		Size: 2,3
@@ -3377,7 +3389,7 @@ Templates:
 			4: Rock
 			5: Rock
 		Category: Bridge
-	Template@532
+	Template@532:
 		Id: 532
 		Image: sbridge2h
 		Size: 2,3
@@ -3389,7 +3401,7 @@ Templates:
 			4: Rock
 			5: Rock
 		Category: Bridge
-	Template@533
+	Template@533:
 		Id: 533
 		Image: sbridge2d
 		Size: 2,3
@@ -3401,7 +3413,7 @@ Templates:
 			4: River
 			5: River
 		Category: Bridge
-	Template@534
+	Template@534:
 		Id: 534
 		Image: sbridge2x
 		Size: 4,4
@@ -3533,7 +3545,7 @@ Templates:
 		Size: 1,1
 		Tiles:
 			0: Rough
-		Category: Debris		
+		Category: Debris
 	Template@583:
 		Id: 583
 		Image: decc
@@ -3604,3 +3616,4 @@ Templates:
 			4: Rough
 			5: Clear
 		Category: Debris
+

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -820,7 +820,7 @@ TorpTube:
 	Range: 9c0
 	Report: TORPEDO1.AUD
 	ValidTargets: Water, Underwater
-	Underwater: yes
+	Palette: shadow
 	Burst: 2
 	BurstDelay: 20
 	Projectile: Missile

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -508,7 +508,7 @@ MammothTusk:
 	Range: 8c0
 	Report: MISSILE6.AUD
 	Burst: 2
-	ValidTargets: Ground, Air
+	ValidTargets: Air, Ground, Water
 	Projectile: Missile
 		Speed: 341
 		Arm: 2
@@ -789,7 +789,7 @@ Stinger:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 0
-	ValidTargets: Ground, Air
+	ValidTargets: Air, Ground, Water
 	Projectile: Missile
 		Arm: 3
 		High: true
@@ -830,15 +830,18 @@ TorpTube:
 		Trail: bubbles
 		ROT: 1
 		RangeLimit: 160
+		BoundToTerrainType: Water
 	Warhead:
-		Spread: 128
+		Spread: 426
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
-			Concrete: 50%
+			Concrete: 500%
 		WaterExplosion: large_splash
 		WaterImpactSound: splash9.aud
+		Explosion: large_explosion
+		ImpactSound: kaboom12.aud
 		InfDeath: 4
 		SmudgeType: Crater
 		Damage: 180
@@ -1207,7 +1210,7 @@ FLAK-23:
 	ROF: 10
 	Range: 8c0
 	Report: AACANON3.AUD
-	ValidTargets: Air,Ground
+	ValidTargets: Air, Ground, Water
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
@@ -1220,6 +1223,7 @@ FLAK-23:
 			Heavy: 10%
 			Concrete: 20%
 		Explosion: small_explosion_air
+		WaterExplosion: small_splash
 		Damage: 20
 
 Sniper:

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -120,7 +120,7 @@ Maverick:
 	Report: MISSILE7.AUD
 	Burst: 2
 	BurstDelay: 7
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -277,7 +277,7 @@ Dragon:
 	ROF: 50
 	Range: 5c0
 	Report: MISSILE6.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Projectile: Missile
 		Speed: 213
 		Arm: 2
@@ -310,7 +310,7 @@ HellfireAG:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 10
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -819,7 +819,7 @@ TorpTube:
 	ROF: 100
 	Range: 9c0
 	Report: TORPEDO1.AUD
-	ValidTargets: Water, Underwater
+	ValidTargets: Water, Underwater, Bridge
 	Palette: shadow
 	Burst: 2
 	BurstDelay: 20
@@ -1247,7 +1247,7 @@ ChronoTusk:
 	ROF: 60
 	Range: 6c0
 	Report: MISSILE6.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Water
 	Projectile: Missile
 		Speed: 298
 		Arm: 2

--- a/mods/ts/tilesets/interior.yaml
+++ b/mods/ts/tilesets/interior.yaml
@@ -9,6 +9,7 @@ Terrain:
 		Type: Clear
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 0, 0, 0
+		TargetTypes: Ground
 
 Templates:
 	Template@255:
@@ -17,3 +18,4 @@ Templates:
 		Size: 1,1
 		Tiles:
 			0: Clear
+


### PR DESCRIPTION
as this is legacy RA95 behavior I would like to see here for consistency and balancing reasons. #2097 Allies have many ways to destroy long bridges with ships. I cleaned up the hard-coded target code (Water == Water, Ground == !Water)  which gets rid of unwanted inconsistencies like flak truck and rocket troopers being unable to target water and bridges just because they defined `ValidTargets: Air, Ground` although no `InvalidTargets` were set and torpedos travelling through land when the target was missed #3252 which was not catched by just making the target cursor invalid.
