### PR TITLE
Removed the build radius restrictions for Dune 2000

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ NEW:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.
 		Display shroud by default again (disable it in the lobby settings).
+		Removed the build radius restrictions.
 	Red Alert:
 		Tanya can now plant C4 on bridges.
 		Submarine torpedoes can now hit bridges when force fired.

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -210,7 +210,6 @@
 	TargetableBuilding:
 		TargetTypes: Ground, C4
 	Building:
-		RequiresBaseProvider: true
 		Dimensions: 1,1
 		Footprint: x
 		TerrainTypes: Rock, Concrete

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -30,9 +30,6 @@
 	ProductionBar:
 	ProvidesCustomPrerequisite:
 		Prerequisite: Conyard
-	BaseProvider:
-		Cooldown: 25
-		Range: 30
 
 ^POWER:
 	Inherits: ^Building


### PR DESCRIPTION
It is controversial #4378 and unnecessary for this mod because of the terrain. All clumsy designed ARRAKIS maps that required it have been removed already.
