### PR TITLE
Display shroud by default again in Dune 2000

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ NEW:
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.
+		Display shroud by default again (disable it in the lobby settings).
 	Red Alert:
 		Tanya can now plant C4 on bridges.
 	Tiberian Dawn:

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -119,7 +119,7 @@ LobbyDefaults:
 	Crates: true
 	StartingUnitsClass: none
 	FragileAlliances: false
-	Shroud: false
+	Shroud: true
 	Fog: true
 
 ChromeMetrics:


### PR DESCRIPTION
As discussed in IRC. It looks cool now so show it by default again as in all the other mods.
