### PR TITLE
Un-hardcoded several HackyAI aspects

### DIFF
--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -30,6 +30,10 @@ namespace OpenRA.Mods.RA.AI
 		public readonly int RushInterval = 600;
 		public readonly int AttackForceInterval = 30;
 
+		[Desc("By what factor should power output exceed power consumption.")]
+		public readonly float ExcessPowerFactor = 1.2f;
+		[Desc("By what minimum amount should power output exceed power consumption.")]
+		public readonly int MinimumExcessPower = 50;
 		// Temporary hack to maintain previous rallypoint behavior.
 		public readonly string RallypointTestBuilding = "fact";
 		public readonly string[] UnitQueues = { "Vehicle", "Infantry", "Plane", "Ship", "Aircraft" };
@@ -223,8 +227,8 @@ namespace OpenRA.Mods.RA.AI
 		bool HasAdequatePower()
 		{
 			// note: CNC `fact` provides a small amount of power. don't get jammed because of that.
-			return playerPower.PowerProvided > 50 &&
-				playerPower.PowerProvided > playerPower.PowerDrained * 1.2;
+			return playerPower.PowerProvided > Info.MinimumExcessPower &&
+				playerPower.PowerProvided > playerPower.PowerDrained * Info.ExcessPowerFactor;
 		}
 
 		bool HasAdequateFact()


### PR DESCRIPTION
This un-hardcodes things like the excess power factor and its minimum, as well as some radiuses and a count limit.

Quite a few modding veterans like to fiddle with those settings themselves rather than being forced to live with hard-coded values.
