### PR TITLE
Remove Nod01Script.cs reference from csproj

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -77,7 +77,6 @@
     <Compile Include="CncMenuPaletteEffect.cs" />
     <Compile Include="Effects\IonCannon.cs" />
     <Compile Include="IonCannonPower.cs" />
-    <Compile Include="Missions\Nod01Script.cs" />
     <Compile Include="PoisonedByTiberium.cs" />
     <Compile Include="ProductionAirdrop.cs" />
     <Compile Include="ProductionQueueFromSelection.cs" />


### PR DESCRIPTION
Lets OpenRA build on Windows again
