### PR TITLE
Add Angle and Shadow support to Missile projectiles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ NEW:
 		Added a new Launch.Replay=$FILEPATH parameter for OpenRA.Game.exe to instantly start watching a *.rep file.
 		Added HackyAI settings: ExcessPowerFactor, MinimumExcessPower, IdleBaseUnitsMaximum, RushAttackScanRadius, ProtectUnitScanRadius, RallyPointScanRadius. See the traits documentation for more information.
 		Added HitAnimPalette trait for LaserZap projectiles. Laser hit animations can now specify individual palettes. Defaults to effect palette.
+		Added support for Angle (ballistic flight curve) and Shadow to missile projectiles.
 		Fixed performance issues with units pathing to naval transports.
 		Fixed unit moving to transports that have moved.
 	Server:

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.RA.Effects
 		public readonly WRange Inaccuracy = WRange.Zero;
 		public readonly WAngle Angle = WAngle.Zero;
 		public readonly string Image = null;
+		public readonly bool Shadow = false;
 		[Desc("Rate of Turning")]
 		public readonly int ROT = 5;
 		[Desc("Explode when following the target longer than this.")]
@@ -206,6 +207,12 @@ namespace OpenRA.Mods.RA.Effects
 
 			if (!args.SourceActor.World.FogObscures(pos.ToCPos()))
 			{
+				if (info.Shadow)
+				{
+					var shadowPos = pos - new WVec(0, 0, pos.Z);
+					foreach (var r in anim.Render(shadowPos, wr.Palette("shadow")))
+						yield return r;
+				}
 				var palette = wr.Palette(args.Weapon.Palette);
 				foreach (var r in anim.Render(pos, palette))
 					yield return r;


### PR DESCRIPTION
Missiles can now be launched at an angle and follow targets in a big, lazy curve. 

Additionally, Shadow (code identical to Bullet) was added since missiles can now spend most of their flight above altitude 0 even when attacking ground units.

Solves #3680.
