### PR TITLE
Fix unit attack pathing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -129,6 +129,8 @@ NEW:
 		Muzzleflash definitions have moved from WithMuzzleFlash to each Armament. Only one WithMuzzleFlash is now required per actor.
 		Added an AttackGarrisoned trait that allows passengers to fire through a set of defined ports.
 		Maps can define initial cargo for actors by adding "Cargo: actora, actorb, ..." to the actor reference.
+		Fixed unit behavior when moving into attack range.
+		Helicopters and Planes can now follow other actors.
 	Server:
 		Message of the day is now shared between all mods and a default motd.txt gets created in the user directory.
 	Asset Browser:

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -160,7 +160,8 @@ namespace OpenRA.Traits
 		Activity MoveTo(CPos cell, int nearEnough);
 		Activity MoveTo(CPos cell, Actor ignoredActor);
 		Activity MoveWithinRange(Target target, WRange range);
-		Activity MoveFollow(Actor self, Target target, WRange range);
+		Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange);
+		Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange);
 		Activity MoveIntoWorld(Actor self, CPos cell);
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		CPos NearestMoveableCell(CPos target);

--- a/OpenRA.Mods.RA/Activities/Attack.cs
+++ b/OpenRA.Mods.RA/Activities/Attack.cs
@@ -25,13 +25,10 @@ namespace OpenRA.Mods.RA.Activities
 		const int delayBetweenPathingAttempts = 20;
 		const int delaySpread = 5;
 
-		public Attack(Target target, WRange range)
-			: this(target, range, true) {}
-
-		public Attack(Target target, WRange range, bool allowMovement)
+		public Attack(Actor self, Target target, WRange minRange, WRange maxRange, bool allowMovement)
 		{
 			Target = target;
-			Range = range;
+			Range = maxRange;
 			AllowMovement = allowMovement;
 		}
 

--- a/OpenRA.Mods.RA/Activities/FlyFollow.cs
+++ b/OpenRA.Mods.RA/Activities/FlyFollow.cs
@@ -18,13 +18,15 @@ namespace OpenRA.Mods.RA.Activities
 	{
 		Target target;
 		Plane plane;
-		WRange range;
+		WRange minRange;
+		WRange maxRange;
 
-		public FlyFollow(Actor self, Target target, WRange range)
+		public FlyFollow(Actor self, Target target, WRange minRange, WRange maxRange)
 		{
 			this.target = target;
 			plane = self.Trait<Plane>();
-			this.range = range;
+			this.minRange = minRange;
+			this.maxRange = maxRange;
 		}
 
 		public override Activity Tick(Actor self)
@@ -32,13 +34,13 @@ namespace OpenRA.Mods.RA.Activities
 			if (IsCanceled || !target.IsValidFor(self))
 				return NextActivity;
 
-			if (target.IsInRange(self.CenterPosition, range))
+			if (target.IsInRange(self.CenterPosition, maxRange) && !target.IsInRange(self.CenterPosition, minRange))
 			{
 				Fly.FlyToward(self, plane, plane.Facing, plane.Info.CruiseAltitude);
 				return this;
 			}
 
-			return Util.SequenceActivities(new Fly(self, target, WRange.Zero, range), this);
+			return Util.SequenceActivities(new Fly(self, target, minRange, maxRange), this);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Activities/Follow.cs
+++ b/OpenRA.Mods.RA/Activities/Follow.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.RA.Activities
 		const int delayBetweenPathingAttempts = 20;
 		const int delaySpread = 5;
 
-		public Follow(Actor self, Target target, WRange range)
+		public Follow(Actor self, Target target, WRange minRange, WRange maxRange)
 		{
 			this.target = target;
 			move = self.Trait<IMove>();
-			this.range = range;
+			this.range = maxRange;
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.RA/Activities/Heal.cs
+++ b/OpenRA.Mods.RA/Activities/Heal.cs
@@ -12,11 +12,10 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Activities
 {
-	/* non-turreted attack */
 	public class Heal : Attack
 	{
-		public Heal(Target target, WRange range, bool allowMovement)
-			: base(target, range, allowMovement) { }
+		public Heal(Actor self, Target target, WRange minRange, WRange maxRange, bool allowMovement)
+			: base(self, target, minRange, maxRange, allowMovement) { }
 
 		protected override Activity InnerTick(Actor self, AttackBase attack)
 		{

--- a/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled || !target.IsValidFor(self))
+			if ((IsCanceled && inner == null) || !target.IsValidFor(self))
 				return NextActivity;
 
 			var targetPosition = target.CenterPosition.ToCPos();
@@ -134,6 +134,13 @@ namespace OpenRA.Mods.RA.Activities
 				return inner.GetTargets(self);
 
 			return Target.None;
+		}
+
+		public override void Cancel(Actor self)
+		{
+			if (inner != null)
+				inner.Cancel(self);
+			base.Cancel(self);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
@@ -20,8 +20,6 @@ namespace OpenRA.Mods.RA.Activities
 		readonly Target target;
 		readonly Mobile mobile;
 		readonly PathFinder pathFinder;
-		readonly DomainIndex domainIndex;
-		readonly int movementClass;
 		readonly WRange maxRange;
 		readonly WRange minRange;
 
@@ -36,8 +34,6 @@ namespace OpenRA.Mods.RA.Activities
 
 			mobile = self.Trait<Mobile>();
 			pathFinder = self.World.WorldActor.Trait<PathFinder>();
-			domainIndex = self.World.WorldActor.TraitOrDefault<DomainIndex>();
-			movementClass = mobile.Info.GetMovementClass(self.World.TileSet);
 
 			repath = true;
 		}
@@ -90,7 +86,7 @@ namespace OpenRA.Mods.RA.Activities
 				{
 					if (cell == loc)
 						return NextActivity;
-					else if (domainIndex == null || domainIndex.IsPassable(loc, cell, (uint)movementClass))
+					else if (mobile.CanEnterCell(cell))
 						searchCells.Add(cell);
 				}
 

--- a/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA.Activities
 		readonly WRange minRange;
 
 		Activity inner;
-		CPos cachedTargetPosition;
+		CPos targetPosition;
 		CPos[] targetCells;
 		bool repath;
 
@@ -47,85 +47,95 @@ namespace OpenRA.Mods.RA.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if ((IsCanceled && inner == null) || !target.IsValidFor(self))
-				return NextActivity;
-
-			var targetPosition = target.CenterPosition.ToCPos();
-
-			// Calculate path to target
-			if (inner == null && repath)
+			if (inner == null)
 			{
-				cachedTargetPosition = targetPosition;
-				repath = false;
-
-				if (maxRange != WRange.Zero)
+				// Inner move order has completed.
+				if (repath && !IsCanceled && target.IsValidFor(self))
 				{
-					// Move to a cell within the requested annulus
-					var maxCells = (maxRange.Range + 1023) / 1024;
-					var outerCells = self.World.FindTilesInCircle(targetPosition, maxCells);
-
-					var minCells = minRange.Range / 1024;
-					var innerCells = self.World.FindTilesInCircle(targetPosition, minCells);
-
-					var outerSq = maxRange.Range * maxRange.Range;
-					var innerSq = minRange.Range * minRange.Range;
-					var center = targetPosition.CenterPosition;
-					targetCells = outerCells.Except(innerCells).Where(c =>
-					{
-						var dxSq = (c.CenterPosition - center).HorizontalLengthSquared;
-						return dxSq >= innerSq || dxSq <= outerSq;
-					}).ToArray();
+					// Repath only if we cancelled inner because the target moved.
+					UpdateInnerPath(self);
+					repath = false;
 				}
 				else
-					targetCells = Util.AdjacentCells(target).ToArray();
-
-
-				var loc = self.Location;
-				var searchCells = new List<CPos>();
-				foreach (var cell in targetCells)
 				{
-					if (cell == loc)
-						return NextActivity;
-					else if (mobile.CanEnterCell(cell))
-						searchCells.Add(cell);
-				}
-
-				if (searchCells.Any())
-				{
-					var ps1 = new PathSearch(self.World, mobile.Info, self)
-					{
-						checkForBlocked = true,
-						heuristic = location => 0,
-						inReverse = true
-					};
-
-					foreach (var cell in searchCells)
-						ps1.AddInitialCell(cell);
-
-					ps1.heuristic = PathSearch.DefaultEstimator(mobile.toCell);
-					var ps2 = PathSearch.FromPoint(self.World, mobile.Info, self, mobile.toCell, target.CenterPosition.ToCPos(), true);
-					var ret = pathFinder.FindBidiPath(ps1, ps2);
-
-					inner = mobile.MoveTo(() => ret);
+					// Otherweise, we're done here.
+					return NextActivity;
 				}
 			}
 
-			// Force a repath once the actor reaches the next cell
-			if (!repath && cachedTargetPosition != targetPosition)
+			if (target.IsValidFor(self))
 			{
-				if (inner != null)
-					inner.Cancel(self);
-
-				repath = true;
+				// Check if the target has moved
+				var oldPosition = targetPosition;
+				targetPosition = target.CenterPosition.ToCPos();
+				if (!repath && targetPosition != oldPosition)
+				{
+					// Finish moving into the next cell and then repath.
+					if (inner != null)
+						inner.Cancel(self);
+					repath = true;
+				}
+			}
+			else
+			{
+				// Target became invalid. Cancel the inner order,
+				// and then wait for it to move into the next cell
+				// before finishing this order (handled above).
+				inner.Cancel(self);
 			}
 
+			// Ticks the inner move activity to actually move the actor.
 			inner = Util.RunActivity(self, inner);
 
-			// Move completed
-			if (inner == null && targetCells.Contains(self.Location))
-				return NextActivity;
-
 			return this;
+		}
+
+		void UpdateInnerPath(Actor self)
+		{
+			if (maxRange != WRange.Zero)
+			{
+				// Move to a cell within the requested annulus
+				var maxCells = (maxRange.Range + 1023) / 1024;
+				var outerCells = self.World.FindTilesInCircle(targetPosition, maxCells);
+
+				var minCells = minRange.Range / 1024;
+				var innerCells = self.World.FindTilesInCircle(targetPosition, minCells);
+
+				var outerSq = maxRange.Range * maxRange.Range;
+				var innerSq = minRange.Range * minRange.Range;
+				var center = targetPosition.CenterPosition;
+				targetCells = outerCells.Except(innerCells).Where(c =>
+				{
+					var dxSq = (c.CenterPosition - center).HorizontalLengthSquared;
+					return dxSq >= innerSq || dxSq <= outerSq;
+				}).OrderByDescending(c => (c.CenterPosition - center).HorizontalLengthSquared).ToArray();
+			}
+			else
+				targetCells = Util.AdjacentCells(target).ToArray();
+
+			var searchCells = new List<CPos>();
+			foreach (var cell in targetCells)
+				if (mobile.CanEnterCell(cell))
+					searchCells.Add(cell);
+
+			if (searchCells.Any())
+			{
+				var ps1 = new PathSearch(self.World, mobile.Info, self)
+				{
+					checkForBlocked = true,
+					heuristic = location => 0,
+					inReverse = true
+				};
+
+				foreach (var cell in searchCells)
+					ps1.AddInitialCell(cell);
+
+				ps1.heuristic = PathSearch.DefaultEstimator(mobile.toCell);
+				var ps2 = PathSearch.FromPoint(self.World, mobile.Info, self, mobile.toCell, targetPosition, true);
+				var ret = pathFinder.FindBidiPath(ps1, ps2);
+
+				inner = mobile.MoveTo(() => ret);
+			}
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)
@@ -140,6 +150,7 @@ namespace OpenRA.Mods.RA.Activities
 		{
 			if (inner != null)
 				inner.Cancel(self);
+
 			base.Cancel(self);
 		}
 	}

--- a/OpenRA.Mods.RA/Air/Helicopter.cs
+++ b/OpenRA.Mods.RA/Air/Helicopter.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA.Air
 		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new HeliFly(self, Target.FromCell(cell)); }
 		public Activity MoveWithinRange(Target target, WRange range) { return new HeliFly(self, target, WRange.Zero, range); }
 		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return new HeliFly(self, target, minRange, maxRange); }
-		public Activity MoveFollow(Actor self, Target target, WRange range) { return new Follow(self, target, range); }
+		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new Follow(self, target, minRange, maxRange); }
 		public CPos NearestMoveableCell(CPos cell) { return cell; }
 
 		public Activity MoveIntoWorld(Actor self, CPos cell)

--- a/OpenRA.Mods.RA/Air/Plane.cs
+++ b/OpenRA.Mods.RA/Air/Plane.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.RA.Air
 		public Activity MoveTo(CPos cell, Actor ignoredActor) { return Util.SequenceActivities(new Fly(self, Target.FromCell(cell)), new FlyCircle()); }
 		public Activity MoveWithinRange(Target target, WRange range) { return Util.SequenceActivities(new Fly(self, target, WRange.Zero, range), new FlyCircle()); }
 		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return Util.SequenceActivities(new Fly(self, target, minRange, maxRange), new FlyCircle()); }
-		public Activity MoveFollow(Actor self, Target target, WRange range) { return new FlyFollow(self, target, range); }
+		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new FlyFollow(self, target, minRange, maxRange); }
 		public CPos NearestMoveableCell(CPos cell) { return cell; }
 
 		public Activity MoveIntoWorld(Actor self, CPos cell) { return new Fly(self, Target.FromCell(cell)); }

--- a/OpenRA.Mods.RA/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.RA/Attack/AttackFollow.cs
@@ -86,8 +86,8 @@ namespace OpenRA.Mods.RA
 				var weapon = attack.ChooseArmamentForTarget(target);
 				if (weapon != null)
 				{
-					// Try and sit at least half a cell closer, in case the target starts moving.
-					var maxRange = new WRange(Math.Max(0, weapon.Weapon.Range.Range - 512));
+					// Try and sit at least one cell closer, in case the target starts moving.
+					var maxRange = new WRange(Math.Max(0, weapon.Weapon.Range.Range - 1024));
 
 					attack.Target = target;
 

--- a/OpenRA.Mods.RA/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.RA/Attack/AttackFollow.cs
@@ -83,17 +83,16 @@ namespace OpenRA.Mods.RA
 				if (self.IsDisabled())
 					return this;
 
-				const int RangeTolerance = 1;	/* how far inside our maximum range we should try to sit */
 				var weapon = attack.ChooseArmamentForTarget(target);
-
 				if (weapon != null)
 				{
-					var range = WRange.FromCells(Math.Max(0, weapon.Weapon.Range.Range / 1024 - RangeTolerance));
+					// Try and sit at least half a cell closer, in case the target starts moving.
+					var maxRange = new WRange(Math.Max(0, weapon.Weapon.Range.Range - 512));
 
 					attack.Target = target;
 
 					if (move != null)
-						return Util.SequenceActivities(move.MoveFollow(self, target, range), this);
+						return Util.SequenceActivities(move.MoveFollow(self, target, weapon.Weapon.MinRange, maxRange), this);
 				}
 
 				return NextActivity;

--- a/OpenRA.Mods.RA/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.RA/Attack/AttackFrontal.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.RA
 			if (a == null)
 				return null;
 
-			return new Activities.Attack(newTarget, a.Weapon.Range, allowMove);
+			return new Activities.Attack(self, newTarget, a.Weapon.MinRange, a.Weapon.Range, allowMove);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Attack/AttackMedic.cs
+++ b/OpenRA.Mods.RA/Attack/AttackMedic.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA
 			if (a == null)
 				return null;
 
-			return new Activities.Heal(newTarget, a.Weapon.Range, allowMove);
+			return new Activities.Heal(self, newTarget, a.Weapon.MinRange, a.Weapon.Range, allowMove);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Guard.cs
+++ b/OpenRA.Mods.RA/Guard.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA
 			self.SetTargetLine(target, Color.Yellow);
 
 			var range = WRange.FromCells(target.Actor.Info.Traits.Get<GuardableInfo>().Range);
-			self.QueueActivity(false, new AttackMove.AttackMoveActivity(self, self.Trait<IMove>().MoveFollow(self, target, range)));
+			self.QueueActivity(false, new AttackMove.AttackMoveActivity(self, self.Trait<IMove>().MoveFollow(self, target, WRange.Zero, range)));
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -540,7 +540,8 @@ namespace OpenRA.Mods.RA.Move
 		public Activity MoveTo(CPos cell, int nearEnough) { return new Move(cell, nearEnough); }
 		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new Move(cell, ignoredActor); }
 		public Activity MoveWithinRange(Target target, WRange range) { return new Move(target, range); }
-		public Activity MoveFollow(Actor self, Target target, WRange range) { return new Follow(self, target, range); }
+		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return new Move(target, maxRange); }
+		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new Follow(self, target, minRange, maxRange); }
 		public Activity MoveTo(Func<List<CPos>> pathFunc) { return new Move(pathFunc); }
 
 		public void OnNotifyBlockingMove(Actor self, Actor blocking)

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -539,8 +539,8 @@ namespace OpenRA.Mods.RA.Move
 		public Activity ScriptedMove(CPos cell) { return new Move(cell); }
 		public Activity MoveTo(CPos cell, int nearEnough) { return new Move(cell, nearEnough); }
 		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new Move(cell, ignoredActor); }
-		public Activity MoveWithinRange(Target target, WRange range) { return new Move(target, range); }
-		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return new Move(target, maxRange); }
+		public Activity MoveWithinRange(Target target, WRange range) { return new MoveAdjacentTo(self, target, WRange.Zero, range); }
+		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return new MoveAdjacentTo(self, target, minRange, maxRange); }
 		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new Follow(self, target, minRange, maxRange); }
 		public Activity MoveTo(Func<List<CPos>> pathFunc) { return new Move(pathFunc); }
 


### PR DESCRIPTION
This improves pathfinding in a bunch of cases relating to attacks: 
- Fixes #2104, #2923, #4449, #4455.
- Helicopters and planes can now Guard and Follow other actors (C&C only - requires AutoTargeting aircraft).
- Cleans up a bunch of crufty old code.

This will need a fair bit more testing, as it is fiddly code with a bunch of potential edge-cases.
