### PR TITLE
Fixed missing Requires: freetype2 for Fedora

### DIFF
--- a/packaging/linux/rpm/openra.spec
+++ b/packaging/linux/rpm/openra.spec
@@ -13,11 +13,9 @@ URL: http://open-ra.org
 Group: Amusements/Games
 Packager: Matthew Bowra-Dean <matthew@ijw.co.nz>
 Requires: mono-core mono-devel SDL openal
-%if 0%{?fedora}
-Requires: freetype
-%else
-Requires: freetype2
-%endif
+# TODO: make both Fedora and the rest of the RPM world happy
+#Requires: freetype
+#Requires: freetype2
 Prefix: /usr
 Source: %{name}-%{version}.tar.gz
 BuildRoot: /tmp/openra


### PR DESCRIPTION
This reverts https://github.com/OpenRA/OpenRA/pull/4305. While this works on clean VMs that build proper RPMs from source in the same environment where it will be installed later the `0%{?fedora}` or `0%{?suse}` RPM macros will always be zero on our Ubuntu build server which also feature a very old and hacked version of rpmbuild. I should have known that this will be a problem. Sorry.
