### PR TITLE
Disables "building"-speech when nothing more can be built

### DIFF
--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -225,11 +225,8 @@ namespace OpenRA.Mods.RA
 					{
 						var inQueue = Queue.Count(pi => pi.Item == order.TargetString);
 						var owned = self.Owner.World.ActorsWithTrait<Buildable>().Count(a => a.Actor.Info.Name == order.TargetString && a.Actor.Owner == self.Owner);
-						if (inQueue + owned >= bi.BuildLimit)
-						{
-							Sound.PlayNotification(self.Owner, "Speech", Info.BlockedAudio, self.Owner.Country.Race);
-							return;
-						}
+						if (inQueue + owned >= bi.BuildLimit)						
+							return;						
 					}
 
 					for (var n = 0; n < order.TargetLocation.X; n++)	// repeat count

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -366,7 +366,16 @@ namespace OpenRA.Mods.RA.Widgets
 					}
 				}
 				else
-					Sound.PlayNotification(world.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, world.LocalPlayer.Country.Race);
+				{
+					// Check if the item's build-limit has already been reached
+					var queued = CurrentQueue.AllQueued().Count(a => a.Item == unit.Name);
+					var inWorld = world.ActorsWithTrait<Buildable>().Count(a => a.Actor.Info.Name == unit.Name && a.Actor.Owner == world.LocalPlayer);
+
+					if (!((unit.Traits.Get<BuildableInfo>().BuildLimit != 0) && (inWorld + queued >= unit.Traits.Get<BuildableInfo>().BuildLimit)))
+						Sound.PlayNotification(world.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, world.LocalPlayer.Country.Race);
+					else
+						Sound.PlayNotification(world.LocalPlayer, "Speech", CurrentQueue.Info.BlockedAudio, world.LocalPlayer.Country.Race);
+				}
 
 				StartProduction(world, item);
 			}


### PR DESCRIPTION
Small polishing:

When you try to buid something and it's build-limit has already been reached (like 2nd tanya ore nuke silo), it plays both the "building"- and the "unable to build more"-speeches.

It should only play the latter speech in this case.
