### PR TITLE
Fix build of Debian package

### DIFF
--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # OpenRA packaging script for Debian based distributions
 
+LINUX_BUILD_ROOT="$(readlink -f "$2")"
+DEB_BUILD_ROOT=./root
+
+LIBDIR=/usr/lib/openra
+DOCDIR=/usr/share/doc/openra
+
 E_BADARGS=85
 if [ $# -ne "3" ]
 then
@@ -11,39 +17,40 @@ DATE=`echo $1 | grep -o "[0-9]\\+-\\?[0-9]\\?"`
 TYPE=`echo $1 | grep -o "^[a-z]*"`
 VERSION=$DATE.$TYPE
 
-rootdir=`readlink -f $2`
-PACKAGE_SIZE=`du --apparent-size -c $rootdir/usr | grep "total" | awk '{print $1}'`
-
 # Copy template files into a clean build directory (required)
-mkdir root
-cp -R DEBIAN root
-cp -R $rootdir/usr root
+mkdir "$DEB_BUILD_ROOT"
+cp -R DEBIAN "$DEB_BUILD_ROOT"
+cp -R "$LINUX_BUILD_ROOT"/usr "$DEB_BUILD_ROOT"
 
 # Binaries go in /usr/games
-mv root/usr/bin/ root/usr/games/
-sed "s|/usr/bin|/usr/games|g" root/usr/games/openra > temp
-mv temp root/usr/games/openra
-chmod +x root/usr/games/openra
-sed "s|/usr/bin|/usr/games|g" root/usr/games/openra-editor > temp
-mv temp root/usr/games/openra-editor
-chmod +x root/usr/games/openra-editor
+mv "$DEB_BUILD_ROOT"/usr/bin/ "$DEB_BUILD_ROOT"/usr/games/
+sed "s|/usr/bin|/usr/games|g" "$DEB_BUILD_ROOT"/usr/games/openra > temp
+mv -f temp "$DEB_BUILD_ROOT"/usr/games/openra
+chmod +x "$DEB_BUILD_ROOT"/usr/games/openra
+sed "s|/usr/bin|/usr/games|g" "$DEB_BUILD_ROOT"/usr/games/openra-editor > temp
+mv -f temp "$DEB_BUILD_ROOT"/usr/games/openra-editor
+chmod +x "$DEB_BUILD_ROOT"/usr/games/openra-editor
 
 # Put the copyright and changelog in /usr/share/doc/openra/
-mkdir -p root/usr/share/doc/openra/
-cp copyright root/usr/share/doc/openra/copyright
-CHANGES=`cat ./root/usr/share/openra/CHANGELOG`
+mkdir -p "$DEB_BUILD_ROOT"/usr/share/doc/openra/
+cp copyright "$DEB_BUILD_ROOT"/usr/share/doc/openra/copyright
+mv "$DEB_BUILD_ROOT"/usr/lib/openra/AUTHORS "$DEB_BUILD_ROOT"/usr/share/doc/openra
+gzip -9 "$DEB_BUILD_ROOT"/usr/share/doc/openra/AUTHORS
 DATE=`date -R`
 
-echo -e "openra (${VERSION}) unstable; urgency=low\n" > root/usr/share/doc/openra/changelog
-cat ./root/usr/share/openra/CHANGELOG >> root/usr/share/doc/openra/changelog
+echo -e "openra (${VERSION}) unstable; urgency=low\n" > "$DEB_BUILD_ROOT"/usr/share/doc/openra/changelog
+cat "$DEB_BUILD_ROOT"/usr/lib/openra/CHANGELOG >> "$DEB_BUILD_ROOT"/usr/share/doc/openra/changelog
 echo -e "\n\n-- Paul Chote <sleipnir@sleipnirstuff.com> ${DATE}" >> root/usr/share/doc/openra/changelog
-gzip -9 root/usr/share/doc/openra/changelog
+gzip -9 "$DEB_BUILD_ROOT"/usr/share/doc/openra/changelog
+rm "$DEB_BUILD_ROOT"/usr/lib/openra/CHANGELOG
+rm "$DEB_BUILD_ROOT"/usr/lib/openra/COPYING
 
 # Create the control file
-sed "s/{VERSION}/$VERSION/" DEBIAN/control | sed "s/{SIZE}/$PACKAGE_SIZE/" > root/DEBIAN/control
+PACKAGE_SIZE=`du --apparent-size -c "$DEB_BUILD_ROOT"/usr | grep "total" | awk '{print $1}'`
+sed "s/{VERSION}/$VERSION/" DEBIAN/control | sed "s/{SIZE}/$PACKAGE_SIZE/" > "$DEB_BUILD_ROOT"/DEBIAN/control
 
 # Build it in the temp directory, but place the finished deb in our starting directory
-pushd root
+pushd "$DEB_BUILD_ROOT"
 
 # Calculate md5sums and clean up the ./usr/ part of them
 find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 md5sum | sed 's|\./usr/|/usr/|' > DEBIAN/md5sums
@@ -57,5 +64,5 @@ fakeroot dpkg-deb -b . $3/openra_${PKGVERSION}_all.deb
 
 # Clean up
 popd
-rm -rf root
+rm -rf "$DEB_BUILD_ROOT"
 

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -15,42 +15,42 @@ then
 fi
 DATE=`echo $1 | grep -o "[0-9]\\+-\\?[0-9]\\?"`
 TYPE=`echo $1 | grep -o "^[a-z]*"`
-VERSION=$DATE.$TYPE
+VERSION="$DATE.$TYPE"
 
 # Copy template files into a clean build directory (required)
-mkdir "$DEB_BUILD_ROOT"
-cp -R DEBIAN "$DEB_BUILD_ROOT"
-cp -R "$LINUX_BUILD_ROOT"/usr "$DEB_BUILD_ROOT"
+mkdir "${DEB_BUILD_ROOT}"
+cp -R DEBIAN "${DEB_BUILD_ROOT}"
+cp -R "${LINUX_BUILD_ROOT}/usr" "${DEB_BUILD_ROOT}"
 
 # Binaries go in /usr/games
-mv "$DEB_BUILD_ROOT"/usr/bin/ "$DEB_BUILD_ROOT"/usr/games/
-sed "s|/usr/bin|/usr/games|g" "$DEB_BUILD_ROOT"/usr/games/openra > temp
-mv -f temp "$DEB_BUILD_ROOT"/usr/games/openra
-chmod +x "$DEB_BUILD_ROOT"/usr/games/openra
-sed "s|/usr/bin|/usr/games|g" "$DEB_BUILD_ROOT"/usr/games/openra-editor > temp
-mv -f temp "$DEB_BUILD_ROOT"/usr/games/openra-editor
-chmod +x "$DEB_BUILD_ROOT"/usr/games/openra-editor
+mv "${DEB_BUILD_ROOT}/usr/bin/" "${DEB_BUILD_ROOT}/usr/games/"
+sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra" > temp
+mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra"
+chmod +x "${DEB_BUILD_ROOT}/usr/games/openra"
+sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra-editor" > temp
+mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra-editor"
+chmod +x "${DEB_BUILD_ROOT}/usr/games/openra-editor"
 
 # Put the copyright and changelog in /usr/share/doc/openra/
-mkdir -p "$DEB_BUILD_ROOT"/usr/share/doc/openra/
-cp copyright "$DEB_BUILD_ROOT"/usr/share/doc/openra/copyright
-mv "$DEB_BUILD_ROOT"/usr/lib/openra/AUTHORS "$DEB_BUILD_ROOT"/usr/share/doc/openra
-gzip -9 "$DEB_BUILD_ROOT"/usr/share/doc/openra/AUTHORS
+mkdir -p "${DEB_BUILD_ROOT}/${DOCDIR}"
+cp copyright "${DEB_BUILD_ROOT}/${DOCDIR}/copyright"
+cp "${DEB_BUILD_ROOT}/${LIBDIR}/AUTHORS" "${DEB_BUILD_ROOT}/${DOCDIR}"
+gzip -9 "${DEB_BUILD_ROOT}/${DOCDIR}/AUTHORS"
 DATE=`date -R`
 
-echo -e "openra (${VERSION}) unstable; urgency=low\n" > "$DEB_BUILD_ROOT"/usr/share/doc/openra/changelog
-cat "$DEB_BUILD_ROOT"/usr/lib/openra/CHANGELOG >> "$DEB_BUILD_ROOT"/usr/share/doc/openra/changelog
-echo -e "\n\n-- Paul Chote <sleipnir@sleipnirstuff.com> ${DATE}" >> root/usr/share/doc/openra/changelog
-gzip -9 "$DEB_BUILD_ROOT"/usr/share/doc/openra/changelog
-rm "$DEB_BUILD_ROOT"/usr/lib/openra/CHANGELOG
-rm "$DEB_BUILD_ROOT"/usr/lib/openra/COPYING
+echo -e "openra (${VERSION}) unstable; urgency=low\n" > "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
+cat "${DEB_BUILD_ROOT}/${LIBDIR}/CHANGELOG" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
+echo -e "\n\n-- Paul Chote <sleipnir@sleipnirstuff.com> ${DATE}" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
+gzip -9 "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
+rm "${DEB_BUILD_ROOT}/${LIBDIR}/CHANGELOG"
+rm "${DEB_BUILD_ROOT}/${LIBDIR}/COPYING"
 
 # Create the control file
-PACKAGE_SIZE=`du --apparent-size -c "$DEB_BUILD_ROOT"/usr | grep "total" | awk '{print $1}'`
-sed "s/{VERSION}/$VERSION/" DEBIAN/control | sed "s/{SIZE}/$PACKAGE_SIZE/" > "$DEB_BUILD_ROOT"/DEBIAN/control
+PACKAGE_SIZE=`du --apparent-size -c "${DEB_BUILD_ROOT}/usr" | grep "total" | awk '{print $1}'`
+sed "s/{VERSION}/$VERSION/" DEBIAN/control | sed "s/{SIZE}/$PACKAGE_SIZE/" > "${DEB_BUILD_ROOT}/DEBIAN/control"
 
 # Build it in the temp directory, but place the finished deb in our starting directory
-pushd "$DEB_BUILD_ROOT"
+pushd "${DEB_BUILD_ROOT}"
 
 # Calculate md5sums and clean up the ./usr/ part of them
 find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 md5sum | sed 's|\./usr/|/usr/|' > DEBIAN/md5sums
@@ -60,9 +60,9 @@ chmod 0644 DEBIAN/md5sums
 PKGVERSION=`echo $1 | sed "s/-/\\./g"`
 
 # Start building, the file should appear in the output directory
-fakeroot dpkg-deb -b . $3/openra_${PKGVERSION}_all.deb
+fakeroot dpkg-deb -b . "$3/openra_${PKGVERSION}_all.deb"
 
 # Clean up
 popd
-rm -rf "$DEB_BUILD_ROOT"
+rm -rf "${DEB_BUILD_ROOT}"
 


### PR DESCRIPTION
I'm new to the whole github thing, so I want to start of with something small and simple:

The build of the Debian package had some issues:
- AUTHORS, CHANGELOG and COPYRIGHT files were placed in /usr/lib/openra
- /usr/share/doc/openra/changelog.gz did not contain the changelog, because the script contained the wrong path to the CHANGELOG file
- Due to the above, the build failed on my system and I was not able to build a .deb

I fixed that by placing AUTHORS and CHANGELOG in /usr/share/doc/openra and removing the COPYRIGHT file (the license texts are located in /usr/share/common-licences on Debian-based systems).  The build now also finishes successfully on my system.
