### PR TITLE
More speeches polishing

### DIFF
--- a/OpenRA.Mods.Cnc/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Cnc/Widgets/SupportPowersWidget.cs
@@ -168,7 +168,11 @@ namespace OpenRA.Mods.Cnc.Widgets
 				.Select(i => i.Value).FirstOrDefault();
 
 			if (clicked != null)
+			{
+				if (!clicked.Power.Active)
+					Sound.PlayToPlayer(spm.self.Owner, clicked.Power.Info.InsufficientPowerSound);
 				spm.Target(clicked.Power.Info.OrderName);
+			}
 
 			return true;
 		}

--- a/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.RA
 		public readonly string BeginChargeSound = null;
 		public readonly string EndChargeSound = null;
 		public readonly string SelectTargetSound = null;
+		public readonly string InsufficientPowerSound = null;
 		public readonly string LaunchSound = null;
 		public readonly string IncomingSound = null;
 

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -370,8 +370,9 @@ namespace OpenRA.Mods.RA.Widgets
 					// Check if the item's build-limit has already been reached
 					var queued = CurrentQueue.AllQueued().Count(a => a.Item == unit.Name);
 					var inWorld = world.ActorsWithTrait<Buildable>().Count(a => a.Actor.Info.Name == unit.Name && a.Actor.Owner == world.LocalPlayer);
+					var buildLimit = unit.Traits.Get<BuildableInfo>().BuildLimit;
 
-					if (!((unit.Traits.Get<BuildableInfo>().BuildLimit != 0) && (inWorld + queued >= unit.Traits.Get<BuildableInfo>().BuildLimit)))
+					if (!((buildLimit != 0) && (inWorld + queued >= buildLimit)))
 						Sound.PlayNotification(world.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, world.LocalPlayer.Country.Race);
 					else
 						Sound.PlayNotification(world.LocalPlayer, "Speech", CurrentQueue.Info.BlockedAudio, world.LocalPlayer.Country.Race);

--- a/OpenRA.Mods.RA/Widgets/SupportPowerBinWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/SupportPowerBinWidget.cs
@@ -167,7 +167,15 @@ namespace OpenRA.Mods.RA.Widgets
 
 		Action<MouseInput> HandleSupportPower(string key, SupportPowerManager manager)
 		{
-			return mi => { if (mi.Button == MouseButton.Left) manager.Target(key); };
+			return mi =>
+			{
+				if (mi.Button == MouseButton.Left)
+				{
+					if (!manager.Powers[key].Active)
+						Sound.PlayToPlayer(manager.self.Owner, manager.Powers[key].Info.InsufficientPowerSound);
+					manager.Target(key);
+				}
+			};
 		}
 	}
 }

--- a/mods/cnc/notifications.yaml
+++ b/mods/cnc/notifications.yaml
@@ -9,7 +9,6 @@ Speech:
 		PrimaryBuildingSelected: pribldg1
 		BuildingCannotPlaceAudio: deploy1
 		NewOptions: newopt1
-		AbilityInsufficientPower: nopower1
 		Win: accom1
 		Lose: fail1
 		BaseAttack: baseatk1

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -379,6 +379,7 @@ HQ:
 		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
 		EndChargeSound: airredy1.aud
 		SelectTargetSound: select1.aud
+		InsufficientPowerSound: nopower1.aud
 		IncomingSound: enemya.aud
 		UnitType: a10
 	SupportPowerChargeBar:
@@ -443,6 +444,7 @@ EYE:
 		EndChargeSound: ionredy1.aud
 		LaunchSound: ion1.aud
 		SelectTargetSound: select1.aud
+		InsufficientPowerSound: nopower1.aud
 	SupportPowerChargeBar:
 
 TMPL:
@@ -477,6 +479,7 @@ TMPL:
 		BeginChargeSound:
 		EndChargeSound: nukavail.aud
 		SelectTargetSound: select1.aud
+		InsufficientPowerSound: nopower1.aud
 		LaunchSound: nuklnch1.aud
 		IncomingSound: nuke1.aud
 		MissileWeapon: atomic

--- a/mods/d2k/notifications.yaml
+++ b/mods/d2k/notifications.yaml
@@ -12,7 +12,6 @@ Speech:
 		LowPower: POWER
 		SilosNeeded: SILOS
 		PrimaryBuildingSelected: PRMRY
-		AbilityInsufficientPower:
 		NewOptions: NEWOP
 		Win: MWIN
 		Lose: MFAIL

--- a/mods/ra/notifications.yaml
+++ b/mods/ra/notifications.yaml
@@ -6,7 +6,6 @@ Speech:
 		PrimaryBuildingSelected: pribldg1
 		BuildingCannotPlaceAudio: nodeply1
 		NewOptions: newopt1
-		AbilityInsufficientPower: nopowr1
 		Win: misnwon1
 		Lose: misnlst1
 		BaseAttack: baseatk1

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -31,6 +31,7 @@ MSLO:
 		BeginChargeSound: aprep1.aud
 		EndChargeSound: aready1.aud
 		SelectTargetSound: slcttgt1.aud
+		InsufficientPowerSound: nopowr1.aud
 		IncomingSound: alaunch1.aud
 		LaunchSound:
 		MissileWeapon: atomic
@@ -220,6 +221,7 @@ IRON:
 		LongDesc: Makes a group of units invulnerable\nfor 20 seconds.
 		Duration: 20
 		SelectTargetSound: slcttgt1.aud
+		InsufficientPowerSound: nopowr1.aud
 		BeginChargeSound: ironchg1.aud
 		EndChargeSound: ironrdy1.aud
 	SupportPowerChargeBar:
@@ -257,6 +259,7 @@ PDOX:
 		Description: Chronoshift
 		LongDesc: Teleports a group of units across\nthe map for 20 seconds.
 		SelectTargetSound: slcttgt1.aud
+		InsufficientPowerSound: nopowr1.aud
 		BeginChargeSound: chrochr1.aud
 		EndChargeSound: chrordy1.aud
 		Duration: 20

--- a/mods/ts/notifications.yaml
+++ b/mods/ts/notifications.yaml
@@ -6,7 +6,6 @@ Speech:
 		PrimaryBuildingSelected: 00-i034
 		BuildingCannotPlaceAudio: 00-i016
 		NewOptions: 00-i032
-		AbilityInsufficientPower:
 		Win: 00-i284
 		Lose: 00-i286
 		BaseAttack: 00-i082


### PR DESCRIPTION
If you click in a supportpower-widget while it's providing building is powered down, nothing happens at all.
I changed this so the "insufficient power"-speeches are played in this case, for RA and C&C.
Also added the corresponding entry to the yaml files.

Pls review the code first.
