### PR TITLE
Catch IOExceptions in Connection.cs.

### DIFF
--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -188,6 +188,7 @@ namespace OpenRA.Network
 			catch (SocketException) { /* drop this on the floor; we'll pick up the disconnect from the reader thread */ }
 			catch (ObjectDisposedException) { /* ditto */ }
 			catch (InvalidOperationException) { /* ditto */ }
+			catch (IOException) { /* ditto */ }
 		}
 
 		bool disposed = false;


### PR DESCRIPTION
A probable fix for #4083, #4423, #4501.
