### PR TITLE
Registered Linux MIME type to directly load replays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,13 @@ install-linux-desktop:
 	@$(INSTALL_DATA) packaging/linux/openra.desktop "$(DESTDIR)$(datadir)/applications"
 	@$(INSTALL_DATA) packaging/linux/openra-editor.desktop "$(DESTDIR)$(datadir)/applications"
 
+install-linux-mime:
+	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/mime/packages/"
+	@$(INSTALL_DATA) packaging/linux/openra-mimeinfo.xml "$(DESTDIR)$(datadir)/mime/packages/openra.xml"
+
+	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/applications"
+	@$(INSTALL_DATA) packaging/linux/openra-replays.desktop "$(DESTDIR)$(datadir)/applications"
+
 install-linux-scripts:
 	@echo "#!/bin/sh" > openra
 	@echo 'cd "$(gameinstalldir)"' >> openra
@@ -426,6 +433,7 @@ uninstall:
 	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra-editor.png"
 	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/openra.png"
 	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/openra.png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/mime/packages/openra.xml"
 
 help:
 	@echo to compile, run:

--- a/OpenRA.Game/FileFormats/ReplayMetadata.cs
+++ b/OpenRA.Game/FileFormats/ReplayMetadata.cs
@@ -71,7 +71,7 @@ namespace OpenRA.FileFormats
 
 		public void RenameFile(string newFilenameWithoutExtension)
 		{
-			var newPath = Path.Combine(Path.GetDirectoryName(FilePath), newFilenameWithoutExtension) + ".rep";
+			var newPath = Path.Combine(Path.GetDirectoryName(FilePath), newFilenameWithoutExtension) + ".orarep";
 			File.Move(FilePath, newPath);
 			FilePath = newPath;
 		}

--- a/OpenRA.Game/Network/ReplayRecorderConnection.cs
+++ b/OpenRA.Game/Network/ReplayRecorderConnection.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Network
 			var id = -1;
 			while (file == null)
 			{
-				var fullFilename = Path.Combine(dir, id < 0 ? "{0}.rep".F(filename) : "{0}-{1}.rep".F(filename, id));
+				var fullFilename = Path.Combine(dir, id < 0 ? "{0}.orarep".F(filename) : "{0}-{1}.orarep".F(filename, id));
 				id++;
 				try
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				using (new Support.PerfTimer("Load replays"))
 				{
 					replays = Directory
-						.GetFiles(dir, "*.rep")
+						.GetFiles(dir, "*.orarep")
 						.Select(ReplayMetadata.Read)
 						.Where(r => r != null)
 						.OrderByDescending(r => r.GameInfo.StartTimeUtc)

--- a/launch-replay.sh
+++ b/launch-replay.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# TODO choose the correct Game.Mod instead of crashing
 cd ${0%/*}
 exec mono OpenRA.Game.exe Launch.Replay="$@"

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -22,6 +22,7 @@ make install-all prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 
 # Install startup scripts, desktop files and icons
 make install-linux-shortcuts prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
+make install-linux-mime prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 
 # Documentation
 mkdir -p $PWD/packaging/linux/$ROOTDIR/usr/share/doc/openra/

--- a/packaging/linux/openra-mimeinfo.xml
+++ b/packaging/linux/openra-mimeinfo.xml
@@ -5,7 +5,7 @@
     <icon name="openra" />
     <generic-icon name="applications-games"/>
     <comment>OpenRA Replay</comment>
-    <glob weight="60" pattern="*.rep"/>
+    <glob weight="60" pattern="*.orarep"/>
   </mime-type>
 
 </mime-info>

--- a/packaging/linux/openra-mimeinfo.xml
+++ b/packaging/linux/openra-mimeinfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+
+  <mime-type type="application/x-openra-replay">
+    <icon name="openra" />
+    <generic-icon name="applications-games"/>
+    <comment>OpenRA Replay</comment>
+    <glob weight="60" pattern="*.rep"/>
+  </mime-type>
+
+</mime-info>

--- a/packaging/linux/openra-replays.desktop
+++ b/packaging/linux/openra-replays.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=OpenRA
+GenericName=Real Time Strategy Game
+Comment=Reimagining of early Westwood Games
+Icon=openra
+Exec=openra Launch.Replay=%f
+Terminal=false
+NoDisplay=true
+Categories=Game;StrategyGame;
+MimeType=application/x-openra-replay;


### PR DESCRIPTION
I adapted our RPM and tested it on @openSUSE with KDE.

![opensuse-kde-openra-mime](https://f.cloud.github.com/assets/756669/2051353/a50908fc-8a87-11e3-8586-606c26a0d4f0.png)

Maybe @obrakmann can help with the Debian package. It should be similar to the spec file changes.
