### PR TITLE
Fix Lua script filename typo in OpenRA.sln

### DIFF
--- a/OpenRA.sln
+++ b/OpenRA.sln
@@ -62,7 +62,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tiberian Dawn Lua scripts",
 		mods\cnc\maps\gdi02\gdi02.lua = mods\cnc\maps\gdi02\gdi02.lua
 		mods\cnc\maps\nod01\nod01.lua = mods\cnc\maps\nod01\nod01.lua
 		mods\cnc\maps\nod03a\nod03a.lua = mods\cnc\maps\nod03a\nod03a.lua
-		mods\cnc\maps\nod03b\nod03b.lua = mods\cnc\maps\nod01\nod03b.lua
+		mods\cnc\maps\nod03b\nod03b.lua = mods\cnc\maps\nod03b\nod03b.lua
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
Fixes my complaint in #4474
