### PR TITLE
Fixes order lines not being shown after reselect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ NEW:
 		Added Ctrl+T shortcut for selection of all units matching the types of the currently selected ones across the screen and map.
 		Added a toggle spectators to multiplayer.
 		Removed the ability of commandos to plant C4 on walls.
+		Order lines are now shown on unit selection.
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -94,7 +94,11 @@ namespace OpenRA
 
 		public void Tick()
 		{
+			var wasIdle = IsIdle;
 			currentActivity = Traits.Util.RunActivity(this, currentActivity);
+			if (!wasIdle && IsIdle)
+				foreach (var n in TraitsImplementing<INotifyBecomingIdle>())
+					n.OnBecomingIdle(this);
 		}
 
 		public bool IsIdle

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -22,6 +22,8 @@ namespace OpenRA
 		public void Add(World w, Actor a)
 		{
 			actors.Add(a);
+			foreach (var sel in a.TraitsImplementing<INotifySelected>())
+				sel.Selected(a);
 			foreach (var ns in w.WorldActor.TraitsImplementing<INotifySelection>())
 				ns.SelectionChanged();
 		}
@@ -47,6 +49,9 @@ namespace OpenRA
 			if (voicedUnit != null)
 				Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
 
+			foreach (var a in newSelection)
+				foreach (var sel in a.TraitsImplementing<INotifySelected>())
+					sel.Selected(a);
 			foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
 				ns.SelectionChanged();
 		}

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Traits
 		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.self, this); }
 	}
 
-	public class DrawLineToTarget : IPostRenderSelection
+	public class DrawLineToTarget : IPostRenderSelection, INotifySelected, INotifyBecomingIdle
 	{
 		Actor self;
 		DrawLineToTargetInfo Info;
@@ -49,6 +49,12 @@ namespace OpenRA.Traits
 				lifetime = Info.Ticks;
 		}
 
+		public void Selected(Actor a)
+		{
+			// Reset the order line timeout.
+			lifetime = Info.Ticks;
+		}
+
 		public void RenderAfterWorld(WorldRenderer wr)
 		{
 			var force = Game.GetModifierKeys().HasModifier(Modifiers.Alt);
@@ -69,6 +75,12 @@ namespace OpenRA.Traits
 				wr.DrawTargetMarker(c, from);
 				wr.DrawTargetMarker(c, to);
 			}
+		}
+
+		public void OnBecomingIdle(Actor a)
+		{
+			if (a.IsIdle)
+				targets = null;
 		}
 	}
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -184,6 +184,7 @@ namespace OpenRA.Traits
 	public interface Requires<T> where T : class { }
 	public interface UsesInit<T> where T : IActorInit { }
 
+	public interface INotifySelected { void Selected(Actor self); }
 	public interface INotifySelection { void SelectionChanged(); }
 	public interface IWorldLoaded { void WorldLoaded(World w, WorldRenderer wr); }
 	public interface ICreatePlayers { void CreatePlayers(World w); }
@@ -196,6 +197,7 @@ namespace OpenRA.Traits
 	}
 
 	public interface IRenderOverlay { void Render(WorldRenderer wr); }
+	public interface INotifyBecomingIdle { void OnBecomingIdle(Actor self); } 
 	public interface INotifyIdle { void TickIdle(Actor self); }
 
 	public interface IBlocksBullets { }


### PR DESCRIPTION
This fixes order lines having a single timeout across multiple selections and deselections, which caused order lines not to be shown when a unit was selected until the timeout expired, deselected and then reselected.
