### PR TITLE
Transfer code from overused Mobile to IMove (and IMoveInfo)

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -148,6 +148,7 @@ namespace OpenRA.Traits
 		void SetVisualPosition(Actor self, WPos pos);
 	}
 
+	public interface IMoveInfo { }
 	public interface IMove
 	{
 		Activity MoveTo(CPos cell, int nearEnough);
@@ -155,6 +156,7 @@ namespace OpenRA.Traits
 		Activity MoveWithinRange(Target target, WRange range);
 		Activity MoveFollow(Actor self, Target target, WRange range);
 		CPos NearestMoveableCell(CPos target);
+		bool IsMoving { get; set; }
 	}
 
 	public interface INotifyBlockingMove { void OnNotifyBlockingMove(Actor self, Actor blocking); }

--- a/OpenRA.Mods.RA/Activities/Attack.cs
+++ b/OpenRA.Mods.RA/Activities/Attack.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Activities
 				nextPathTime = self.World.SharedRandom.Next(delayBetweenPathingAttempts - delaySpread,
 					delayBetweenPathingAttempts + delaySpread);
 
-				return (AllowMovement) ? Util.SequenceActivities(self.Trait<Mobile>().MoveWithinRange(Target, Range), this) : NextActivity;
+				return (AllowMovement) ? Util.SequenceActivities(self.Trait<IMove>().MoveWithinRange(Target, Range), this) : NextActivity;
 			}
 
 			var desiredFacing = Util.GetFacing(Target.CenterPosition - self.CenterPosition, 0);

--- a/OpenRA.Mods.RA/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.RA/Activities/DeliverResources.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Activities
 			if (NextActivity != null)
 				return NextActivity;
 
-			var mobile = self.Trait<Mobile>();
+			var movement = self.Trait<IMove>();
 			var harv = self.Trait<Harvester>();
 
 			// Find the nearest best refinery if not explicitly ordered to a specific refinery:
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			self.SetTargetLine(Target.FromActor(proc), Color.Green, false);
 			if (self.Location != proc.Location + iao.DeliverOffset)
-				return Util.SequenceActivities(mobile.MoveTo(proc.Location + iao.DeliverOffset, 0), this);
+				return Util.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliverOffset, 0), this);
 
 			if (!isDocking)
 			{

--- a/OpenRA.Mods.RA/Activities/LayMines.cs
+++ b/OpenRA.Mods.RA/Activities/LayMines.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.Activities
 		{
 			if (IsCanceled) return NextActivity;
 
-			var mobile = self.Trait<Mobile>();
+			var movement = self.Trait<IMove>();
 			var limitedAmmo = self.TraitOrDefault<LimitedAmmo>();
 			if (!limitedAmmo.HasAmmo())
 			{
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA.Activities
 
 				return Util.SequenceActivities(
 					new MoveAdjacentTo(self, Target.FromActor(rearmTarget)),
-					mobile.MoveTo(rearmTarget.CenterPosition.ToCPos(), rearmTarget),
+					movement.MoveTo(rearmTarget.CenterPosition.ToCPos(), rearmTarget),
 					new Rearm(self),
 					new Repair(rearmTarget),
 					this );
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Activities
 				{
 					var p = ml.minefield.Random(self.World.SharedRandom);
 					if (ShouldLayMine(self, p))
-						return Util.SequenceActivities( mobile.MoveTo(p, 0), this );
+						return Util.SequenceActivities( movement.MoveTo(p, 0), this );
 				}
 
 			// TODO: return somewhere likely to be safe (near fix) so we're not sitting out in the minefield.

--- a/OpenRA.Mods.RA/Air/Helicopter.cs
+++ b/OpenRA.Mods.RA/Air/Helicopter.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Air
 {
-	class HelicopterInfo : AircraftInfo
+	class HelicopterInfo : AircraftInfo, IMoveInfo
 	{
 		public readonly WRange IdealSeparation = new WRange(1706);
 		public readonly bool LandWhenIdle = true;
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.RA.Air
 		public HelicopterInfo Info;
 		Actor self;
 		bool firstTick = true;
+		public bool IsMoving { get { return self.CenterPosition.Z > 0; } set { } }
 
 		public Helicopter(ActorInitializer init, HelicopterInfo info)
 			: base(init, info)

--- a/OpenRA.Mods.RA/Air/Plane.cs
+++ b/OpenRA.Mods.RA/Air/Plane.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Air
 {
-	public class PlaneInfo : AircraftInfo
+	public class PlaneInfo : AircraftInfo, IMoveInfo
 	{
 		public readonly WAngle MaximumPitch = WAngle.FromDegrees(10);
 
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.RA.Air
 		public readonly PlaneInfo Info;
 		[Sync] public WPos RTBPathHash;
 		Actor self;
+		public bool IsMoving { get { return self.CenterPosition.Z > 0; } set { } }
 
 		public Plane(ActorInitializer init, PlaneInfo info)
 			: base(init, info)

--- a/OpenRA.Mods.RA/Move/Drag.cs
+++ b/OpenRA.Mods.RA/Move/Drag.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Move
 		public override Activity Tick(Actor self)
 		{
 			var positionable = self.Trait<IPositionable>();
-			var mobile = positionable as Mobile;
+			var movement = self.Trait<IMove>();
 
 			var pos = length > 1
 				? WPos.Lerp(start, end, ticks, length - 1)
@@ -38,14 +38,14 @@ namespace OpenRA.Mods.RA.Move
 			positionable.SetVisualPosition(self, pos);
 			if (++ticks >= length)
 			{
-				if (mobile != null)
-					mobile.IsMoving = false;
+				if (movement != null)
+					movement.IsMoving = false;
 
 				return NextActivity;
 			}
 
-			if (mobile != null)
-				mobile.IsMoving = true;
+			if (movement != null)
+				movement.IsMoving = true;
 
 			return this;
 		}

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA.Move
 {
 	[Desc("Unit is able to move.")]
-	public class MobileInfo : ITraitInfo, IOccupySpaceInfo, IFacingInfo, UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>
+	public class MobileInfo : ITraitInfo, IOccupySpaceInfo, IFacingInfo, IMoveInfo, UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>
 	{
 		[FieldLoader.LoadUsing("LoadSpeeds")]
 		[Desc("Set Water: 0 for ground units and lower the value on rough terrain.")]
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.RA.Move
 	{
 		public readonly Actor self;
 		public readonly MobileInfo Info;
-		public bool IsMoving { get; internal set; }
+		public bool IsMoving { get; set; }
 
 		int __facing;
 		CPos __fromCell, __toCell;

--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -35,12 +35,12 @@ namespace OpenRA.Mods.RA.Render
 			IdleAnimating
 		}
 
-		protected bool dirty = false;
-
+		Mobile mobile;
 		RenderInfantryInfo info;
+		public bool IsMoving { get; set; }
+		protected bool dirty = false;
 		string idleSequence;
 		int idleDelay;
-		Mobile mobile;
 
 		protected virtual string NormalizeInfantrySequence(Actor self, string baseSequence)
 		{

--- a/OpenRA.Mods.RA/Render/WithRotor.cs
+++ b/OpenRA.Mods.RA/Render/WithRotor.cs
@@ -34,12 +34,14 @@ namespace OpenRA.Mods.RA.Render
 	{
 		WithRotorInfo info;
 		Animation rotorAnim;
+		IMove movement;
 
 		public WithRotor(Actor self, WithRotorInfo info)
 		{
 			this.info = info;
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<IBodyOrientation>();
+			movement = self.Trait<IMove>();
 
 			rotorAnim = new Animation(rs.GetImage(self));
 			rotorAnim.PlayRepeating(info.Sequence);
@@ -50,7 +52,7 @@ namespace OpenRA.Mods.RA.Render
 
 		public void Tick(Actor self)
 		{
-			var isFlying = self.CenterPosition.Z > 0 && !self.IsDead();
+			var isFlying = movement.IsMoving && !self.IsDead();
 			if (isFlying ^ (rotorAnim.CurrentSequence.Name != info.Sequence))
 				return;
 

--- a/OpenRA.Mods.RA/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.RA/Render/WithVoxelWalkerBody.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	public class WithVoxelWalkerBodyInfo : ITraitInfo, Requires<RenderVoxelsInfo>, Requires<MobileInfo>
+	public class WithVoxelWalkerBodyInfo : ITraitInfo, Requires<RenderVoxelsInfo>, Requires<IMoveInfo>
 	{
 		public readonly int TickRate = 5;
 		public object Create(ActorInitializer init) { return new WithVoxelWalkerBody(init.self, this); }
@@ -25,14 +25,14 @@ namespace OpenRA.Mods.RA.Render
 	public class WithVoxelWalkerBody : IAutoSelectionSize, ITick
 	{
 		WithVoxelWalkerBodyInfo info;
-		Mobile mobile;
+		IMove movement;
 		int2 size;
 		uint tick, frame, frames;
 
 		public WithVoxelWalkerBody(Actor self, WithVoxelWalkerBodyInfo info)
 		{
 			this.info = info;
-			mobile = self.Trait<Mobile>();
+			movement = self.Trait<IMove>();
 
 			var body = self.Trait<IBodyOrientation>();
 			var rv = self.Trait<RenderVoxels>();
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.RA.Render
 
 		public void Tick(Actor self)
 		{
-			if (mobile.IsMoving)
+			if (movement.IsMoving)
 				tick++;
 
 			if (tick < info.TickRate)

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -73,13 +73,13 @@ namespace OpenRA.Mods.RA
 				if( !CanRepairAt( order.TargetActor ) || !CanRepair() )
 					return;
 
-				var mobile = self.Trait<Mobile>();
+				var movement = self.Trait<IMove>();
 				var target = Target.FromOrder(order);
 				self.SetTargetLine(target, Color.Green);
 
 				self.CancelActivity();
 				self.QueueActivity(new MoveAdjacentTo(self, target));
-				self.QueueActivity(mobile.MoveTo(order.TargetActor.CenterPosition.ToCPos(), order.TargetActor));
+				self.QueueActivity(movement.MoveTo(order.TargetActor.CenterPosition.ToCPos(), order.TargetActor));
 				self.QueueActivity(new Rearm(self));
 				self.QueueActivity(new Repair(order.TargetActor));
 
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.RA
 					self.QueueActivity(new CallFunc(() =>
 					{
 						self.SetTargetLine(Target.FromCell(rp.rallyPoint), Color.Green);
-						self.QueueActivity(mobile.MoveTo(rp.rallyPoint, order.TargetActor));
+						self.QueueActivity(movement.MoveTo(rp.rallyPoint, order.TargetActor));
 					}));
 			}
 		}

--- a/OpenRA.Mods.RA/RepairableNear.cs
+++ b/OpenRA.Mods.RA/RepairableNear.cs
@@ -65,11 +65,11 @@ namespace OpenRA.Mods.RA
 		{
 			if (order.OrderString == "RepairNear" && CanRepairAt(order.TargetActor) && ShouldRepair())
 			{
-				var mobile = self.Trait<Mobile>();
+				var movement = self.Trait<IMove>();
 				var target = Target.FromOrder(order);
 
 				self.CancelActivity();
-				self.QueueActivity(mobile.MoveWithinRange(target, new WRange(1024*info.CloseEnough)));
+				self.QueueActivity(movement.MoveWithinRange(target, new WRange(1024*info.CloseEnough)));
 				self.QueueActivity(new Repair(order.TargetActor));
 
 				self.SetTargetLine(target, Color.Green, false);


### PR DESCRIPTION
Changed most references of trait Mobile -> IMove.
In Mobile.cs IsMoving now has a public set as opposed to the initial internal.
Added IMoveInfo interface to go with *Info classes that use IMove.
WithRotor now uses IMove.IsMoving instead of (self.CenterPosition.Z > 0) as part of a check.
