### PR TITLE
Select units by type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ NEW:
 		Added cheat button to grow map resources.
 		Fixed units staying selected and contributing to control groups when becoming cloaked or hidden in fog.
 		Swapped the cursors used for sabotaging and capturing buildings/units.
+		Added Ctrl+T shortcut for selection of all units matching the types of the currently selected ones across the screen and map.
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -148,6 +148,7 @@ namespace OpenRA.GameRules
 		public Hotkey ToLastEventKey = new Hotkey(Keycode.SPACE, Modifiers.None);
 		public Hotkey ToSelectionKey = new Hotkey(Keycode.HOME, Modifiers.None);
 		public Hotkey SelectAllUnitsKey = new Hotkey(Keycode.A, Modifiers.Ctrl);
+		public Hotkey SelectUnitsByTypeKey = new Hotkey(Keycode.T, Modifiers.Ctrl);
 
 		public Hotkey PauseKey = new Hotkey(Keycode.F9, Modifiers.None);
 		public Hotkey SellKey = new Hotkey(Keycode.F10, Modifiers.None);

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -208,9 +208,27 @@ namespace OpenRA.Widgets
 					World.SetPauseState(!World.Paused);
 				else if (Hotkey.FromKeyInput(e) == Game.Settings.Keys.SelectAllUnitsKey)
 				{
-					var ownUnitsOnScreen = SelectActorsInBox(World, worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.BottomRight, 
+					var ownUnitsOnScreen = SelectActorsInBox(World, worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.BottomRight,
 						a => a.Owner == World.RenderPlayer);
 					World.Selection.Combine(World, ownUnitsOnScreen, false, false);
+				}
+				else if (Hotkey.FromKeyInput(e) == Game.Settings.Keys.SelectUnitsByTypeKey)
+				{
+					var selectedTypes = World.Selection.Actors.Where(
+						x => x.Owner == World.RenderPlayer).Select(a => a.Info);
+					Func<Actor, bool> cond = a => a.Owner == World.RenderPlayer && selectedTypes.Contains(a.Info);
+					IEnumerable<Actor> newSelection = SelectActorsInBox(
+						World, worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.BottomRight, cond); 
+					if (newSelection.Count() > selectedTypes.Count())
+						Game.Debug("Selected across screen");
+					else
+					{
+						newSelection = World.ActorMap.ActorsInBox(
+							World.Map.Bounds.TopLeftAsCPos().TopLeft,
+							World.Map.Bounds.BottomRightAsCPos().BottomRight).Where(cond);
+						Game.Debug("Selected across map");
+					}
+					World.Selection.Combine(World, newSelection, true, false);
 				}
 			}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -253,6 +253,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				{ "ToLastEventKey", "Jump to last radar event" },
 				{ "ToSelectionKey", "Jump to selection" },
 				{ "SelectAllUnitsKey", "Select all units on screen" },
+				{ "SelectUnitsByTypeKey", "Select units by type" },
 
 				{ "PauseKey", "Pause / Unpause" },
 				{ "SellKey", "Sell mode" },


### PR DESCRIPTION
Adds #4551: Selecting of all units matching the current type across the screen or map using Ctrl + T.
