### PR TITLE
Issue4547

### DIFF
--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.RA
 
 	public class Harvester : IIssueOrder, IResolveOrder, IPips,
 		IExplodeModifier, IOrderVoice, ISpeedModifier, ISync,
-		INotifyResourceClaimLost, INotifyIdle, INotifyBlockingMove
+		INotifyResourceClaimLost, INotifyIdle/*, INotifyBlockingMove*/
 	{
 		Dictionary<ResourceTypeInfo, int> contents = new Dictionary<ResourceTypeInfo, int>();
 
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public void OnNotifyBlockingMove(Actor self, Actor blocking)
+		/*public void OnNotifyBlockingMove(Actor self, Actor blocking)
 		{
 			// I'm blocking someone else from moving to my location:
 			Activity act = self.GetCurrentActivity();
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.RA
 				// Find more resources but not at this location:
 				self.QueueActivity(new FindResources(cell));
 			}
-		}
+		}*/
 
 		public void TickIdle(Actor self)
 		{

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -489,9 +489,12 @@ namespace OpenRA.Mods.RA.Move
 
 			if (moveTo.HasValue)
 			{
+                var currAct = self.GetCurrentActivity();
 				self.CancelActivity();
 				self.SetTargetLine(Target.FromCell(moveTo.Value), Color.Green, false);
 				self.QueueActivity(new Move(moveTo.Value, 0));
+                if (currAct != null )
+                    self.QueueActivity(currAct);
 
 				Log.Write("debug", "OnNudge #{0} from {1} to {2}",
 					self.ActorID, self.Location, moveTo.Value);

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -545,7 +545,8 @@ namespace OpenRA.Mods.RA.Move
 
         public void OnNotifyBlockingMove(Actor self, Actor blocking)
         {
-            Nudge(self, blocking, true);
+            if (self.Owner == blocking.Owner || self.Owner.Stances[blocking.Owner] == Stance.Ally)
+                Nudge(self, blocking, true);
         }
     }
 }

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.RA.Move
 		public int GetInitialFacing() { return InitialFacing; }
 	}
 
-	public class Mobile : IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove, IFacing, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
+	public class Mobile : IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove, IFacing, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove
 	{
 		public readonly Actor self;
 		public readonly MobileInfo Info;
@@ -542,5 +542,10 @@ namespace OpenRA.Mods.RA.Move
 		public Activity MoveWithinRange(Target target, WRange range) { return new Move(target, range); }
 		public Activity MoveFollow(Actor self, Target target, WRange range) { return new Follow(self, target, range); }
 		public Activity MoveTo(Func<List<CPos>> pathFunc) { return new Move(pathFunc); }
-	}
+
+        public void OnNotifyBlockingMove(Actor self, Actor blocking)
+        {
+            Nudge(self, blocking, true);
+        }
+    }
 }

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -124,6 +124,17 @@ namespace OpenRA.Mods.RA
 		{
 			var mobileInfo = producee.Traits.GetOrDefault<MobileInfo>();
 
+            foreach (var blocker in self.World.ActorMap.GetUnitsAt(self.Location + s.ExitCell))
+            {
+                Log.Write("debug", "NotifyBlocker #{0} nudges #{1} at {2} from {3}",
+                    self.ActorID, blocker.ActorID, self.Location + s.ExitCell, self.Location);
+
+                // Notify the blocker that he's blocking our move:
+                var moveBlocked = blocker.TraitOrDefault<INotifyBlockingMove>();
+                if (moveBlocked != null)
+                    moveBlocked.OnNotifyBlockingMove(blocker, self);
+            } 
+
 			return mobileInfo == null ||
 				mobileInfo.CanEnterCell(self.World, self, self.Location + s.ExitCell, self, true, true);
 		}


### PR DESCRIPTION
First of, sorry for the spelling in the commit messages.
This is a fix for the issue #4547, and now a player's units and allied units will get notified when blocking a unit, and will be nudged. Both move commands and production buildings inform units of blocking.
