### PR TITLE
Added RAED tile ID 0 support

### DIFF
--- a/OpenRA.Game/Map.cs
+++ b/OpenRA.Game/Map.cs
@@ -485,6 +485,11 @@ namespace OpenRA
 				for (var i = Bounds.Left; i < Bounds.Right; i++)
 				{
 					var tr = MapTiles.Value[i, j];
+					if (!tileset.Templates.ContainsKey(tr.Type))
+					{
+						Console.WriteLine("Unknown Tile ID {0}".F(tr.Type));
+						continue;
+					}
 					var template = tileset.Templates[tr.Type];
 					if (!template.PickAny)
 						continue;

--- a/OpenRA.Utility/LegacyMapImporter.cs
+++ b/OpenRA.Utility/LegacyMapImporter.cs
@@ -240,7 +240,10 @@ namespace OpenRA.Utility
 
 			for (int j = 0; j < mapSize; j++)
 				for (int i = 0; i < mapSize; i++)
-					map.MapTiles.Value[i, j].Type = ms.ReadUInt16();
+				{
+					var tileID = ms.ReadUInt16();
+					map.MapTiles.Value[i, j].Type = tileID == (ushort)0 ? (ushort)255 : tileID; // RAED weirdness
+				}
 
 			for (int j = 0; j < mapSize; j++)
 				for (int i = 0; i < mapSize; i++)


### PR DESCRIPTION
The game will crash when loading/converting legacy maps created with http://cnc.wikia.com/wiki/RAED. See http://cnc-comm.com/community/index.php?topic=2727.0
