### PR TITLE
Update structures.yaml

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -980,7 +980,7 @@ SILO:
 	RenderBuildingSilo:
 	StoresOre:
 		PipCount: 5
-		Capacity: 1500
+		Capacity: 2000
 	IronCurtainable:
 	-RenderBuilding:
 	-EmitInfantryOnSell:


### PR DESCRIPTION
During mid/end game, it is often need to build Silo after Silo if cash is flowing faster than needs. Vocal warning 'silo is needed' is then very annoying if ones have no time to build those siloses, so - while it is not critical structure - imho it should have at least slight more capacity. I would give 2500 for both PROC and SILO, but 1500 -> 2000 for silo would be good start for test it (in private version I am using 2500 for both, and it is 100% adorable by me while not changing gameplay significantly).
