### PR TITLE
Fixed replays showing all chat messages at second 0 instead of the time it was sent.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ NEW:
 		Added HitAnimPalette trait for LaserZap projectiles. Laser hit animations can now specify individual palettes. Defaults to effect palette.
 		Fixed performance issues with units pathing to naval transports.
 		Fixed unit moving to transports that have moved.
+		Fixed replays showing all chat messages at second 0 instead of the time it was sent.
 	Server:
 		Message of the day is now shared between all mods and a default motd.txt gets created in the user directory.
 	Asset Browser:

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -24,23 +24,23 @@ namespace OpenRA.Network
 		readonly Dictionary<int, int> clientQuitTimes = new Dictionary<int, int>();
 		readonly Dictionary<int, Dictionary<int, byte[]>> framePackets = new Dictionary<int, Dictionary<int, byte[]>>();
 
-		public IEnumerable<int> ClientsPlayingInFrame( int frame )
+		public IEnumerable<int> ClientsPlayingInFrame(int frame)
 		{
 			return clientQuitTimes
-				.Where( x => frame <= x.Value )
-				.Select( x => x.Key )
-				.OrderBy( x => x );
+				.Where(x => frame <= x.Value)
+				.Select(x => x.Key)
+				.OrderBy(x => x);
 		}
 
-		public void ClientQuit( int clientId, int lastClientFrame )
+		public void ClientQuit(int clientId, int lastClientFrame)
 		{
 			clientQuitTimes[clientId] = lastClientFrame;
 		}
 
-		public void AddFrameOrders( int clientId, int frame, byte[] orders )
+		public void AddFrameOrders(int clientId, int frame, byte[] orders)
 		{
-			var frameData = framePackets.GetOrAdd( frame );
-			frameData.Add( clientId, orders );
+			var frameData = framePackets.GetOrAdd(frame);
+			frameData.Add(clientId, orders);
 		}
 
 		public bool IsReadyForFrame(int frame)
@@ -55,16 +55,16 @@ namespace OpenRA.Network
 				.Where(client => !frameData.ContainsKey(client));
 		}
 
-		public IEnumerable<ClientOrder> OrdersForFrame( World world, int frame )
+		public IEnumerable<ClientOrder> OrdersForFrame(World world, int frame)
 		{
-			var frameData = framePackets[ frame ];
-			var clientData = ClientsPlayingInFrame( frame )
-				.ToDictionary( k => k, v => frameData[ v ] );
+			var frameData = framePackets[frame];
+			var clientData = ClientsPlayingInFrame(frame)
+				.ToDictionary(k => k, v => frameData[v]);
 
 			return clientData
-				.SelectMany( x => x.Value
-					.ToOrderList( world )
-					.Select( o => new ClientOrder { Client = x.Key, Order = o } ) );
+				.SelectMany(x => x.Value
+					.ToOrderList(world)
+					.Select(o => new ClientOrder { Client = x.Key, Order = o }));
 		}
 	}
 }

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -74,7 +74,7 @@ namespace OpenRA
 
 		public byte[] Serialize()
 		{
-			if (IsImmediate)		/* chat, whatever */
+			if (IsImmediate)
 			{
 				var ret = new MemoryStream();
 				var w = new BinaryWriter(ret);
@@ -197,9 +197,9 @@ namespace OpenRA
 		// Named constructors for Orders.
 		// Now that Orders are resolved by individual Actors, these are weird; you unpack orders manually, but not pack them.
 
-		public static Order Chat(bool team, string text)
+		public static Order Chat(bool team, string text, bool preGame)
 		{
-			return new Order(team ? "TeamChat" : "Chat", null, false) { IsImmediate = true, TargetString = text};
+			return new Order(team ? "TeamChat" : "Chat", null, false) { IsImmediate = preGame, TargetString = text};
 		}
 
 		public static Order HandshakeResponse(string text)

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -154,7 +154,7 @@ namespace OpenRA
 						var name = r.ReadString();
 						var data = r.ReadString();
 
-						return new Order( name, null, false ) { IsImmediate = true, TargetString = data };
+						return new Order(name, null, false) { IsImmediate = true, TargetString = data };
 					}
 
 				default:

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -75,15 +75,15 @@ namespace OpenRA.Network
 
 		public void TickImmediate()
 		{
-			var immediateOrders = localOrders.Where( o => o.IsImmediate ).ToList();
-			if( immediateOrders.Count != 0 )
-				Connection.SendImmediate( immediateOrders.Select( o => o.Serialize() ).ToList() );
-			localOrders.RemoveAll( o => o.IsImmediate );
+			var immediateOrders = localOrders.Where(o => o.IsImmediate).ToList();
+			if (immediateOrders.Count != 0)
+				Connection.SendImmediate(immediateOrders.Select(o => o.Serialize()).ToList());
+			localOrders.RemoveAll(o => o.IsImmediate);
 
 			var immediatePackets = new List<Pair<int, byte[]>>();
 
 			Connection.Receive(
-				( clientId, packet ) =>
+				(clientId, packet) =>
 				{
 					var frame = BitConverter.ToInt32(packet, 0);
 					if (packet.Length == 5 && packet[4] == 0xBF)
@@ -94,7 +94,7 @@ namespace OpenRA.Network
 						immediatePackets.Add(Pair.New(clientId, packet));
 					else
 						frameData.AddFrameOrders(clientId, frame, packet);
-				} );
+				});
 
 			foreach (var p in immediatePackets)
 				foreach (var o in p.Second.ToOrderList(world))
@@ -160,7 +160,7 @@ namespace OpenRA.Network
 			get { return NetFrameNumber >= 1 && frameData.IsReadyForFrame(NetFrameNumber); }
 		}
 
-		static readonly IEnumerable<Session.Client> NoClients = new Session.Client[] {};
+		static readonly IEnumerable<Session.Client> NoClients = new Session.Client[] { };
 		public IEnumerable<Session.Client> GetClientsNotReadyForNextFrame
 		{
 			get

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -19,41 +19,41 @@ namespace OpenRA.Network
 		FileStream replayStream;
 		List<byte[]> sync = new List<byte[]>();
 
-		public ReplayConnection( string replayFilename ) { replayStream = File.OpenRead( replayFilename ); }
+		public ReplayConnection(string replayFilename) { replayStream = File.OpenRead(replayFilename); }
 
 		public int LocalClientId { get { return 0; } }
 		public ConnectionState ConnectionState { get { return ConnectionState.Connected; } }
 
 		// do nothing; ignore locally generated orders
-		public void Send( int frame, List<byte[]> orders ) { }
-		public void SendImmediate( List<byte[]> orders ) { }
+		public void Send(int frame, List<byte[]> orders) { }
+		public void SendImmediate(List<byte[]> orders) { }
 
-		public void SendSync( int frame, byte[] syncData )
+		public void SendSync(int frame, byte[] syncData)
 		{
 			var ms = new MemoryStream();
-			ms.Write( BitConverter.GetBytes( frame ) );
-			ms.Write( syncData );
-			sync.Add( ms.ToArray() );
+			ms.Write(BitConverter.GetBytes(frame));
+			ms.Write(syncData);
+			sync.Add(ms.ToArray());
 		}
 
-		public void Receive( Action<int, byte[]> packetFn )
+		public void Receive(Action<int, byte[]> packetFn)
 		{
-			while( sync.Count != 0 )
+			while (sync.Count != 0)
 			{
-				packetFn( LocalClientId, sync[ 0 ] );
-				sync.RemoveAt( 0 );
+				packetFn(LocalClientId, sync[0]);
+				sync.RemoveAt(0);
 			}
 
-			if( replayStream == null ) return;
+			if (replayStream == null) return;
 
-			var reader = new BinaryReader( replayStream );
+			var reader = new BinaryReader(replayStream);
 
-			while( replayStream.Position < replayStream.Length )
+			while (replayStream.Position < replayStream.Length)
 			{
 				var client = reader.ReadInt32();
 				var packetLen = reader.ReadInt32();
-				var packet = reader.ReadBytes( packetLen );
-				packetFn( client, packet );
+				var packet = reader.ReadBytes(packetLen);
+				packetFn(client, packet);
 			}
 
 			replayStream = null;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -454,7 +454,7 @@ namespace OpenRA.Server
 				case "Chat":
 				case "TeamChat":
 				case "PauseGame":
-					DispatchOrdersToClients(conn, 0, so.Serialize());
+					DispatchOrdersToClients(conn, conn.Frame, so.Serialize());
 					break;
 				case "Pong":
 				{

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				var team = teamChat && !disableTeamChat;
 				if (chatText.Text != "")
-					orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim()));
+					orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim(), false));
 
 				CloseChat();
 				return true;

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -448,7 +448,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				if (chatTextField.Text.Length == 0)
 					return true;
 
-				orderManager.IssueOrder(Order.Chat(teamChat, chatTextField.Text));
+				orderManager.IssueOrder(Order.Chat(teamChat, chatTextField.Text, true));
 				chatTextField.Text = "";
 				return true;
 			};


### PR DESCRIPTION
as wished in https://github.com/OpenRA/OpenRA/issues/4608.

This should help casters keep the tention and avoid spoilers: http://www.youtube.com/watch?v=Qe94i0ppurU
