### PR TITLE
Fix tanya chrono bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@ NEW:
 		Increased torpedo splash damage and raised multiplier vs. concrete.
 		Fixed transparency glitches in the sniper icon.
 		Removed health bars and selection boxes from walls.
+		Fixed build-limited units such as Tanya being unavailable after using the Chronosphere on a vehicle she is in.
 	Tiberian Dawn:
 		Commando can now plant C4 on bridges.
 		Added the Asset Browser to the Extras menu.

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -39,14 +39,15 @@ namespace OpenRA.Mods.RA.Activities
 			if (killCargo && self.HasTrait<Cargo>())
 			{
 				var cargo = self.Trait<Cargo>();
-				while (!cargo.IsEmpty(self))
+				if (chronosphere != null)
 				{
-					if (chronosphere != null && chronosphere.HasTrait<UpdatesPlayerStatistics>())
-						chronosphere.Owner.PlayerActor.Trait<PlayerStatistics>().UnitsKilled++;
-
-					var a = cargo.Unload(self);
-					if (a.HasTrait<UpdatesPlayerStatistics>())
-						a.Owner.PlayerActor.Trait<PlayerStatistics>().UnitsDead++;
+					while (!cargo.IsEmpty(self))
+					{
+						var a = cargo.Unload(self);
+						// Kill all the units that are unloaded into the void
+						// Kill() handles kill and death statistics
+						a.Kill(chronosphere);
+					}
 				}
 			}
 


### PR DESCRIPTION
Fix for #4569 issue. Instead of leaving infantry units alive in the void after chronosphere, they are killed.
