### PR TITLE
included a spectator toggle in the server admin dropdown

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Also thanks to:
     * Maarten Meuris (Nyerguds)
     * Mark Olson (markolson)
     * Matthew Gatland (mgatland)
+    * Matthew Uzzell (MUzzell)
     * Max621
     * Max Ugrumov (katzsmile)
     * Nukem

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ NEW:
 		Fixed units staying selected and contributing to control groups when becoming cloaked or hidden in fog.
 		Swapped the cursors used for sabotaging and capturing buildings/units.
 		Added Ctrl+T shortcut for selection of all units matching the types of the currently selected ones across the screen and map.
+		Added a toggle spectators to multiplayer.
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -127,6 +127,7 @@ namespace OpenRA.Network
 			public int RandomSeed = 0;
 			public bool FragileAlliances = false; // Allow diplomatic stance changes after game start.
 			public bool AllowCheats = false;
+			public bool AllowSpectate = true;
 			public bool Dedicated;
 			public string Difficulty;
 			public bool Crates = true;

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Network
 			public int RandomSeed = 0;
 			public bool FragileAlliances = false; // Allow diplomatic stance changes after game start.
 			public bool AllowCheats = false;
-			public bool AllowSpectate = true;
+			public bool AllowSpectators = true;
 			public bool Dedicated;
 			public string Difficulty;
 			public bool Crates = true;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -276,7 +276,7 @@ namespace OpenRA.Server
 					IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin)
 				};
 
-				if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectate)
+				if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectators)
 				{
 					SendOrderTo(newConn, "ServerError", "The game is full");
 					DropClient(newConn);
@@ -324,7 +324,7 @@ namespace OpenRA.Server
 				LobbyInfo.Clients.Add(client);
 
 				Log.Write("server", "Client {0}: Accepted connection from {1}.",
-						  newConn.PlayerIndex, newConn.socket.RemoteEndPoint);
+				          newConn.PlayerIndex, newConn.socket.RemoteEndPoint);
 
 				foreach (var t in serverTraits.WithInterface<IClientJoined>())
 					t.ClientJoined(this, newConn);

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -276,6 +276,13 @@ namespace OpenRA.Server
 					IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin)
 				};
 
+				if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectate)
+				{
+					SendOrderTo(newConn, "ServerError", "The game is full");
+					DropClient(newConn);
+					return;
+				}
+
 				if (client.Slot != null)
 					SyncClientToPlayerReference(client, Map.Players[client.Slot]);
 				else
@@ -317,7 +324,7 @@ namespace OpenRA.Server
 				LobbyInfo.Clients.Add(client);
 
 				Log.Write("server", "Client {0}: Accepted connection from {1}.",
-				          newConn.PlayerIndex, newConn.socket.RemoteEndPoint);
+						  newConn.PlayerIndex, newConn.socket.RemoteEndPoint);
 
 				foreach (var t in serverTraits.WithInterface<IClientJoined>())
 					t.ClientJoined(this, newConn);

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -390,6 +390,7 @@
     <Compile Include="WaterPaletteRotation.cs" />
     <Compile Include="Widgets\BuildPaletteWidget.cs" />
     <Compile Include="Widgets\LogicTickerWidget.cs" />
+    <Compile Include="Widgets\Logic\KickSpectatorsLogic.cs" />
     <Compile Include="Widgets\Logic\IngameMenuLogic.cs" />
     <Compile Include="Widgets\Logic\IrcLogic.cs" />
     <Compile Include="Widgets\Logic\KickClientLogic.cs" />

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -132,14 +132,32 @@ namespace OpenRA.Mods.RA.Server
 
 						return true;
 					}},
+				{ "allow_spectate",
+					s =>
+					{
+						s = s.Trim();
+						if(s.Equals("True") || s.Equals("False")){
+							bool.TryParse(s, out server.LobbyInfo.GlobalSettings.AllowSpectate);
+
+							server.SyncLobbyInfo();
+							return true;
+						}else{
+							server.SendOrderTo(conn, "Message", "Malformed allow_spectate command");
+							return true;
+						}
+					}},
 				{ "spectate",
 					s =>
 					{
-						client.Slot = null;
-						client.SpawnPoint = 0;
-						client.Color = HSLColor.FromRGB(255, 255, 255);
-						server.SyncLobbyInfo();
-						return true;
+						if(server.LobbyInfo.GlobalSettings.AllowSpectate){
+							client.Slot = null;
+							client.SpawnPoint = 0;
+							client.Color = HSLColor.FromRGB(255, 255, 255);
+							server.SyncLobbyInfo();
+							return true;
+						}else{
+							return false;
+						}
 					}},
 				{ "slot_close",
 					s =>

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -132,16 +132,16 @@ namespace OpenRA.Mods.RA.Server
 
 						return true;
 					}},
-				{ "allow_spectate",
+				{ "allow_spectators",
 					s =>
 					{
-						s = s.Trim();
-						if(s.Equals("True") || s.Equals("False")){
-							bool.TryParse(s, out server.LobbyInfo.GlobalSettings.AllowSpectate);
-
+						if (bool.TryParse(s, out server.LobbyInfo.GlobalSettings.AllowSpectators))
+						{
 							server.SyncLobbyInfo();
 							return true;
-						}else{
+						}
+						else
+						{
 							server.SendOrderTo(conn, "Message", "Malformed allow_spectate command");
 							return true;
 						}
@@ -149,15 +149,16 @@ namespace OpenRA.Mods.RA.Server
 				{ "spectate",
 					s =>
 					{
-						if(server.LobbyInfo.GlobalSettings.AllowSpectate){
+						if (server.LobbyInfo.GlobalSettings.AllowSpectators || client.IsAdmin)
+						{
 							client.Slot = null;
 							client.SpawnPoint = 0;
 							client.Color = HSLColor.FromRGB(255, 255, 255);
 							server.SyncLobbyInfo();
 							return true;
-						}else{
-							return false;
 						}
+						else
+							return false;
 					}},
 				{ "slot_close",
 					s =>

--- a/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
@@ -75,7 +75,8 @@ namespace OpenRA.Mods.RA.Server
 								numBots,
 								"{0}@{1}".F(mod.Id, mod.Version),
 								server.LobbyInfo.GlobalSettings.Map,
-								server.Map.PlayerCount));
+								server.Map.PlayerCount,
+								server.LobbyInfo.GlobalSettings.AllowSpectate));
 
 							if (isInitialPing)
 							{

--- a/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.RA/ServerTraits/MasterServerPinger.cs
@@ -75,8 +75,7 @@ namespace OpenRA.Mods.RA.Server
 								numBots,
 								"{0}@{1}".F(mod.Id, mod.Version),
 								server.LobbyInfo.GlobalSettings.Map,
-								server.Map.PlayerCount,
-								server.LobbyInfo.GlobalSettings.AllowSpectate));
+								server.Map.PlayerCount));
 
 							if (isInitialPing)
 							{

--- a/OpenRA.Mods.RA/Widgets/Logic/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/KickSpectatorsLogic.cs
@@ -1,0 +1,36 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.RA.Widgets.Logic
+{
+	class KickSpectatorsLogic
+	{
+		[ObjectCreator.UseCtor]
+		public KickSpectatorsLogic(Widget widget, string clientCount, Action okPressed, Action cancelPressed)
+		{
+			widget.Get<LabelWidget>("TEXT").GetText = () => "Are you sure you want to kick {0} spectators?".F(clientCount);
+
+			widget.Get<ButtonWidget>("OK_BUTTON").OnClick = () =>
+			{
+				widget.Parent.RemoveChild(widget);
+				okPressed();
+			};
+
+			widget.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () =>
+			{
+				widget.Parent.RemoveChild(widget);
+				cancelPressed();
+			};
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				{ "onExit", () => { Game.Disconnect(); menuType = MenuType.Main; } },
 				{ "onStart", RemoveShellmapUI },
-				{ "addBots", true }
+				{ "skirmishMode", true }
 			});
 		}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				{ "onExit", Game.Disconnect },
 				{ "onStart", onStart },
-				{ "addBots", false }
+				{ "skirmishMode", false }
 			});
 		}
 

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -199,6 +199,44 @@ Background@KICK_CLIENT_DIALOG:
 			Height:25
 			Text:Cancel
 			Font:Bold
+			
+Background@KICK_SPECTATORS_DIALOG:
+	X:15
+	Y:30
+	Width:501
+	Height:219
+	Logic:KickSpectatorsLogic
+	Background:scrollpanel-bg
+	Children:
+		Label@TITLE:
+			X:0
+			Y:40
+			Width:PARENT_RIGHT
+			Height:25
+			Font:Bold
+			Align:Center
+			Text:Kick Spectators
+		Label@TEXT:
+			X:0
+			Y:85
+			Width:PARENT_RIGHT
+			Height:25
+			Font:Regular
+			Align:Center
+		Button@OK_BUTTON:
+			X:(PARENT_RIGHT - WIDTH)/2 + 75
+			Y:155
+			Width:120
+			Height:25
+			Text:Ok
+			Font:Bold
+		Button@CANCEL_BUTTON:
+			X:(PARENT_RIGHT - WIDTH)/2 - 75
+			Y:155
+			Width:120
+			Height:25
+			Text:Cancel
+			Font:Bold
 
 Background@LOBBY_OPTIONS_BIN:
 	X:15

--- a/mods/cnc/chrome/lobby-playerbin.yaml
+++ b/mods/cnc/chrome/lobby-playerbin.yaml
@@ -307,20 +307,13 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 			Height:25
 			Visible:false
 			Children:
-				Button@ALLOW_SPECTATE:
-					Text:Allow Spectators
+				Checkbox@TOGGLE_SPECTATORS:
 					Font:Regular
 					Width:190
-					Height:25
-					Y:0
+					Height:20
 					X:15
-				Button@BLOCK_SPECTATE:
-					Text:Block Spectators
-					Font:Regular
-					Width:190
-					Height:25
 					Y:0
-					X:15
+					Text:Allow Spectators?
 				Button@SPECTATE:
 					Text:Spectate
 					Font:Regular

--- a/mods/cnc/chrome/lobby-playerbin.yaml
+++ b/mods/cnc/chrome/lobby-playerbin.yaml
@@ -307,10 +307,24 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 			Height:25
 			Visible:false
 			Children:
+				Button@ALLOW_SPECTATE:
+					Text:Allow Spectators
+					Font:Regular
+					Width:190
+					Height:25
+					Y:0
+					X:15
+				Button@BLOCK_SPECTATE:
+					Text:Block Spectators
+					Font:Regular
+					Width:190
+					Height:25
+					Y:0
+					X:15
 				Button@SPECTATE:
 					Text:Spectate
 					Font:Regular
-					Width:453
+					Width:257
 					Height:25
-					X:15
+					X:210
 					Y:0

--- a/mods/d2k/chrome/lobby-playerbin.yaml
+++ b/mods/d2k/chrome/lobby-playerbin.yaml
@@ -298,6 +298,20 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 			Height:25
 			Visible:false
 			Children:
+				Button@ALLOW_SPECTATE:
+					Text:Allow Spectators
+					Font:Regular
+					Width:165
+					Height:25
+					X:15
+					Y:0
+				Button@BLOCK_SPECTATE:
+					Text:Block Spectators
+					Font:Regular
+					Width:165
+					Height:25
+					X:15
+					Y:0
 				Button@SPECTATE:
 					Text:Spectate
 					Font:Regular

--- a/mods/d2k/chrome/lobby-playerbin.yaml
+++ b/mods/d2k/chrome/lobby-playerbin.yaml
@@ -298,20 +298,13 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 			Height:25
 			Visible:false
 			Children:
-				Button@ALLOW_SPECTATE:
-					Text:Allow Spectators
+				Checkbox@TOGGLE_SPECTATORS:
 					Font:Regular
 					Width:165
-					Height:25
+					Height:20
 					X:15
 					Y:0
-				Button@BLOCK_SPECTATE:
-					Text:Block Spectators
-					Font:Regular
-					Width:165
-					Height:25
-					X:15
-					Y:0
+					Text:Allow Spectators?
 				Button@SPECTATE:
 					Text:Spectate
 					Font:Regular

--- a/mods/ra/chrome/lobby-dialogs.yaml
+++ b/mods/ra/chrome/lobby-dialogs.yaml
@@ -50,6 +50,44 @@ Background@KICK_CLIENT_DIALOG:
 			Text:Cancel
 			Font:Bold
 
+Background@KICK_SPECTATORS_DIALOG:
+	X:20
+	Y:67
+	Width:535
+	Height:235
+	Logic:KickSpectatorsLogic
+	Background:dialog3
+	Children:
+		Label@TITLE:
+			X:0
+			Y:40
+			Width:PARENT_RIGHT
+			Height:25
+			Font:Bold
+			Align:Center
+			Text:Kick Spectators
+		Label@TEXT:
+			X:0
+			Y:85
+			Width:PARENT_RIGHT
+			Height:25
+			Font:Regular
+			Align:Center
+		Button@OK_BUTTON:
+			X:(PARENT_RIGHT - WIDTH)/2 + 75
+			Y:155
+			Width:120
+			Height:25
+			Text:Ok
+			Font:Bold
+		Button@CANCEL_BUTTON:
+			X:(PARENT_RIGHT - WIDTH)/2 - 75
+			Y:155
+			Width:120
+			Height:25
+			Text:Cancel
+			Font:Bold
+
 Background@LOBBY_OPTIONS_BIN:
 	X:20
 	Y:67

--- a/mods/ra/chrome/lobby-playerbin.yaml
+++ b/mods/ra/chrome/lobby-playerbin.yaml
@@ -298,6 +298,20 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 			Height:25
 			Visible:false
 			Children:
+				Button@ALLOW_SPECTATE:
+					Text:Allow Spectators
+					Font:Regular
+					Width:165
+					Height:25
+					X:15
+					Y:0
+				Button@BLOCK_SPECTATE:
+					Text:Block Spectators
+					Font:Regular
+					Width:165
+					Height:25
+					X:15
+					Y:0
 				Button@SPECTATE:
 					Text:Spectate
 					Font:Regular

--- a/mods/ra/chrome/lobby-playerbin.yaml
+++ b/mods/ra/chrome/lobby-playerbin.yaml
@@ -298,20 +298,13 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 			Height:25
 			Visible:false
 			Children:
-				Button@ALLOW_SPECTATE:
-					Text:Allow Spectators
+				Checkbox@TOGGLE_SPECTATORS:
 					Font:Regular
 					Width:165
-					Height:25
+					Height:20
 					X:15
 					Y:0
-				Button@BLOCK_SPECTATE:
-					Text:Block Spectators
-					Font:Regular
-					Width:165
-					Height:25
-					X:15
-					Y:0
+					Text:Allow Spectators?
 				Button@SPECTATE:
 					Text:Spectate
 					Font:Regular


### PR DESCRIPTION
I have added into LobbyWidgets an action to the server admin dropdown where it acts as a toggle. 

![spectators_1](https://f.cloud.github.com/assets/2963387/2179004/cd1bb342-9687-11e3-900c-41baae5f236f.jpg)

when it is toggled (default) the game allows spectators as normal. when not toggled, all current spectators are kicked and the add spectator button dissapears.

![spectators_2](https://f.cloud.github.com/assets/2963387/2179006/ff2c13e0-9687-11e3-97ca-6d36bf27f7b5.jpg)

The exception however is the admin, who can still be a spectator at this point (if he was already when it was toggled). Figured it might be good if the admin still could.

Let me know what you guys think, its not in CnC yet as I would like your opinion on placement, logic etc.
