### PR TITLE
Fix selection persistence for invisible units

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ NEW:
 		Engineers can now regain control over husks.
 		A player's units, and allied units, now move out of the way when blocking production facilities.
 		Added cheat button to grow map resources.
+		Fixed units staying selected and contributing to control groups when becoming cloaked or hidden in fog.
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -56,11 +56,11 @@ namespace OpenRA
 
 		public void Tick(World world)
 		{
-			actors.RemoveAll(a => !a.IsInWorld);
+			actors.RemoveAll(a => !a.IsInWorld || world.FogObscures(a));
 
 			foreach (var cg in controlGroups.Values)
-				cg.RemoveAll(a => a.Destroyed);		// note: NOT `!a.IsInWorld`, since that would remove things
-													// that are in transports.
+				// note: NOT `!a.IsInWorld`, since that would remove things that are in transports.
+				cg.RemoveAll(a => a.Destroyed);
 		}
 
 		Cache<int, List<Actor>> controlGroups = new Cache<int, List<Actor>>(_ => new List<Actor>());
@@ -83,14 +83,15 @@ namespace OpenRA
 				return;
 			}
 
+			var groupActors = controlGroups[group].Where(a => !a.IsDead() && !world.FogObscures(a));
+
 			if (mods.HasModifier(Modifiers.Alt) || MultiTapCount >= 2)
 			{
-				worldRenderer.Viewport.Center(controlGroups[group]);
+				worldRenderer.Viewport.Center(groupActors);
 				return;
 			}
 
-			Combine(world, controlGroups[group],
-				mods.HasModifier(Modifiers.Shift), false);
+			Combine(world, groupActors, mods.HasModifier(Modifiers.Shift), false);
 		}
 
 		public int? GetControlGroupForActor(Actor a)


### PR DESCRIPTION
FogObscures might need to be renamed, since it can potentially check more (and does check more: cloaking) than just fog visibility.

This patch should deselect units that enter the fog or activate their cloak, and also not count towards their control group (so no viewport jumping to their location) when in this state.
