### PR TITLE
Swap cursors used for sabotaging and capturing buildings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ NEW:
 		A player's units, and allied units, now move out of the way when blocking production facilities.
 		Added cheat button to grow map resources.
 		Fixed units staying selected and contributing to control groups when becoming cloaked or hidden in fog.
+		Swapped the cursors used for sabotaging and capturing buildings/units.
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.

--- a/OpenRA.Mods.RA/Captures.cs
+++ b/OpenRA.Mods.RA/Captures.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.RA
 				var lowEnoughHealth = health.HP <= c.CaptureThreshold * health.MaxHP;
 
 				cursor = !sabotage || lowEnoughHealth || target.Owner.NonCombatant
-					? "capture" : "enter";
+					? "enter" : "capture";
 				return true;
 			}
 
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.RA
 				var lowEnoughHealth = target.HP <= c.CaptureThreshold * health.HP;
 
 				cursor = !sabotage || lowEnoughHealth || target.Owner.NonCombatant
-					? "capture" : "enter";
+					? "enter" : "capture";
 
 				return true;
 			}


### PR DESCRIPTION
Red = Sabotage
Green = Capture

Matches the original game cursors
