### PR TITLE
Cargo IsFull and RenderLandingCraft use of IsFull.

### DIFF
--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -117,6 +117,7 @@ namespace OpenRA.Mods.RA
 
 		public bool HasSpace(int weight) { return totalWeight + weight <= Info.MaxWeight; }
 		public bool IsEmpty(Actor self) { return cargo.Count == 0; }
+		public bool IsFull(Actor self) { return totalWeight == Info.MaxWeight;}
 
 		public Actor Peek(Actor self) { return cargo[0]; }
 

--- a/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
+++ b/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
@@ -42,6 +42,9 @@ namespace OpenRA.Mods.RA.Render
 			if (self.CenterPosition.Z > 0)
 				return false;
 
+			if (cargo.IsFull(self))
+				return false;
+
 			return cargo.CurrentAdjacentCells
 				.Any(c => info.OpenTerrainTypes.Contains(self.World.GetTerrainType(c)));
 		}


### PR DESCRIPTION
I did this in two separate commits because the latter may not be desired but I thought it served as a nice indicator for the transport being unable to take more passengers.

I know we have HasSpace(int) already but I feel this is easier to read and makes a bit more sense than checking if (cargo.HasSpace(0)).

If this is not wanted please close to prevent clutter.
