### PR TITLE
Changed A10's vision.

### DIFF
--- a/OpenRA.Mods.RA/AttackBomber.cs
+++ b/OpenRA.Mods.RA/AttackBomber.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.RA
 		[Desc("Armament name")]
 		public readonly string Guns = "secondary";
 		public readonly int FacingTolerance = 2;
+		public readonly WRange VisionRange = WRange.FromCells(10);
 
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.self, this); }
 	}
@@ -30,12 +31,14 @@ namespace OpenRA.Mods.RA
 	class AttackBomber : AttackBase, ISync
 	{
 		AttackBomberInfo info;
+		Actor camera;
 		[Sync] Target target;
 
 		public AttackBomber(Actor self, AttackBomberInfo info)
 			: base(self)
 		{
 			this.info = info;
+			this.camera = null;
 		}
 
 		public override void Tick(Actor self)
@@ -45,6 +48,23 @@ namespace OpenRA.Mods.RA
 			var facing = self.TraitOrDefault<IFacing>();
 			var cp = self.CenterPosition;
 			var bombTarget = Target.FromPos(cp - new WVec(0, 0, cp.Z));
+
+			// Provide vision
+			if (this.camera == null &&
+				target.IsInRange(self.CenterPosition, this.info.VisionRange))
+			{
+				this.camera = self.World.CreateActor("camera", new TypeDictionary
+				{
+					new LocationInit(target.CenterPosition.ToCPos()),
+					new OwnerInit(self.Owner),
+				});
+			}
+			else if (this.camera != null &&
+				!target.IsInRange(self.CenterPosition, this.info.VisionRange))
+			{
+				self.World.Remove(this.camera);
+				this.camera = null;
+			}
 
 			// Bombs drop anywhere in range
 			foreach (var a in Armaments.Where(a => a.Info.Name == info.Bombs))

--- a/OpenRA.Mods.RA/AttackBomber.cs
+++ b/OpenRA.Mods.RA/AttackBomber.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.RA
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.self, this); }
 	}
 
-	class AttackBomber : AttackBase, ISync
+	class AttackBomber : AttackBase, ISync, INotifyKilled
 	{
 		AttackBomberInfo info;
 		Actor camera;
@@ -91,6 +91,15 @@ namespace OpenRA.Mods.RA
 		}
 
 		public void SetTarget(WPos pos) { target = Target.FromPos(pos); }
+
+		public void Killed(Actor self, AttackInfo e)
+		{
+			if (this.camera != null)
+			{
+				self.World.Remove(this.camera);
+				this.camera = null;
+			}
+		}
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove)
 		{

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -192,8 +192,6 @@ A10:
 		HP: 150
 	Armor:
 		Type: Heavy
-	RevealsShroud:
-		Range: 12
 	RenderUnit:
 	WithShadow:
 	AttackBomber:

--- a/mods/cnc/rules/system-actors.yaml
+++ b/mods/cnc/rules/system-actors.yaml
@@ -39,4 +39,13 @@ waypoint:
 	Waypoint:
 	RenderEditorOnly:
 	BodyOrientation:
+CAMERA:
+	Aircraft:
+	Health:
+		HP: 1000
+	RevealsShroud:
+		Range: 10
+	ProximityCaptor:
+		Types: Camera
+	BodyOrientation:
 


### PR DESCRIPTION
This is a fix for issue #4696
This copies the camera logic from the spy planes, to the A10s.
Mention has been made that spy planes and A10s should share this logic, instead of copying it. However, spy planes spawn a camera for a certain time, while I decided to make camera visible only while A10s are in range.
