### PR TITLE
Reduced range and increased build time of static defense

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -489,6 +489,8 @@ GUN:
 	Inherits: ^Building
 	Valued:
 		Cost: 600
+	CustomBuildTimeValue:
+		Value: 1440
 	Tooltip:
 		Name: Turret
 		Description: Anti-Armor base defense.\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
@@ -503,7 +505,7 @@ GUN:
 	Health:
 		HP: 400
 	RevealsShroud:
-		Range: 7
+		Range: 6
 	Turreted:
 		ROT: 12
 		InitialFacing: 50
@@ -526,6 +528,8 @@ SAM:
 	RequiresPower:
 	Valued:
 		Cost: 750
+	CustomBuildTimeValue:
+		Value: 2160
 	Tooltip:
 		Name: SAM Site
 		Description: Anti-Air base defense.\n  Strong vs Aircraft\n  Weak vs Infantry, Tanks
@@ -562,6 +566,8 @@ OBLI:
 	Inherits: ^Building
 	Valued:
 		Cost: 1500
+	CustomBuildTimeValue:
+		Value: 3120
 	Tooltip:
 		Name: Obelisk of Light
 		Description: Advanced base defense.\n  Requires power to operate.\n  Strong vs Tanks, Infantry\n  Weak vs Aircraft
@@ -580,7 +586,7 @@ OBLI:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 8
+		Range: 7
 	RenderBuildingCharge:
 		ChargeAudio: obelpowr.aud
 	Armament:
@@ -602,6 +608,8 @@ GTWR:
 	Inherits: ^Building
 	Valued:
 		Cost: 500
+	CustomBuildTimeValue:
+		Value: 1440
 	Tooltip:
 		Name: Guard Tower
 		Description: Basic defensive structure.\n  Strong vs Infantry\n  Weak vs Tanks, Aircraft
@@ -616,7 +624,7 @@ GTWR:
 	Health:
 		HP: 400
 	RevealsShroud:
-		Range: 7
+		Range: 6
 	Armament:
 		Weapon: HighV
 		LocalOffset: 256,0,256
@@ -637,6 +645,8 @@ ATWR:
 	RequiresPower:
 	Valued:
 		Cost: 1000
+	CustomBuildTimeValue:
+		Value: 2880
 	Tooltip:
 		Name: Advanced Guard Tower
 		Description: Anti-armor defensive structure.\n  Strong vs Light Vehicles, Tanks\n  Weak vs Infantry
@@ -655,7 +665,7 @@ ATWR:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 9
+		Range: 7
 	Turreted:
 		ROT: 255
 		Offset: 128,128,-85

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -166,7 +166,7 @@ Sniper:
 
 HighV:
 	ROF: 30
-	Range: 6c0
+	Range: 5c0
 	Report: GUN8.AUD
 	Projectile: Bullet
 		Speed: 1c682
@@ -548,7 +548,7 @@ Grenade:
 
 TurretGun:
 	ROF: 25
-	Range: 6c0
+	Range: 5c0
 	Report: TNKFIRE6.AUD
 	Projectile: Bullet
 		Image: 120MM
@@ -735,7 +735,7 @@ BoatMissile:
 
 TowerMissle:
 	ROF: 24
-	Range: 8c0
+	Range: 6c0
 	Report: ROCKET2.AUD
 	ValidTargets: Ground, Air
 	Burst: 2
@@ -820,7 +820,7 @@ Napalm.Crate:
 
 Laser:
 	ROF: 90
-	Range: 8c512
+	Range: 6c512
 	Charges: true
 	Report: OBELRAY1.AUD
 	Projectile: LaserZap
@@ -836,7 +836,7 @@ Laser:
 
 SAMMissile:
 	ROF: 15
-	Range: 10c0
+	Range: 7c0
 	Report: ROCKET2.AUD
 	ValidTargets: Air
 	Projectile: Missile


### PR DESCRIPTION
As described in #4723 - this is my first attempt at a Pull Request for those changes.

Guard Tower
- Reduced range from 6 to 5
- Reduced vision from 7 to 6
- Increased buildtime from 12s to 24s

Gun Turret
- Reduced range from 6 to 5
- Reduced vision from 7 to 6
- Increased buildtime from 15s to 30s

SAM Site
- Reduced range from 10 to 7
- Increased buildtime from 18s to 36s

Advanced Guard Tower
- Reduced range from 8 to 6
- Reduced vision from 9 to 7
- Increased buildtime from 24s to 48s

Obelisk of Light
- Reduced range from 8.5 to 6.5
- Reduced vision from 8 to 7
- Increased buildtime from 36s to 52s
