### PR TITLE
Yaml to html

### DIFF
--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -347,5 +347,20 @@ namespace OpenRA.Utility
 			map.Save(dest);
 			Console.WriteLine(dest + " saved.");
 		}
+
+		[Desc("MOD", "OUTPUT DIR", "Output game rules for visual representation.")]
+		public static void GenerateStats(string[] args)
+		{
+			var mod = args[1];
+
+			var outputDir = "html";
+			if (args.Length > 2)
+				outputDir = args[2];
+
+			var modFolder = "mods\\" + mod;
+
+			YamlToHtml yth = new YamlToHtml();
+			yth.Run(modFolder, outputDir + "\\" + mod);
+		}
 	}
 }

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -351,16 +351,33 @@ namespace OpenRA.Utility
 		[Desc("MOD", "OUTPUT DIR", "Output game rules for visual representation.")]
 		public static void GenerateStats(string[] args)
 		{
-			var mod = args[1];
+			try
+			{
+				var mod = args[1];
 
-			var outputDir = "html";
-			if (args.Length > 2)
-				outputDir = args[2];
+				var outputDir = "html";
+				if (args.Length > 2)
+					outputDir = args[2];
 
-			var modFolder = "mods\\" + mod;
-
-			YamlToHtml yth = new YamlToHtml();
-			yth.Run(modFolder, outputDir + "\\" + mod);
+				YamlToHtml yth = new YamlToHtml();
+				if (mod == "all")
+				{
+					string[] dirs = Directory.GetDirectories("mods");
+					foreach (var dir in dirs)
+					{
+						yth.Run(dir, outputDir + "\\" + dir.Substring(dir.LastIndexOf('\\') + 1));
+					}
+				}
+				else
+				{
+					var modFolder = "mods\\" + mod;
+					yth.Run(modFolder, outputDir + "\\" + mod);
+				}
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e.Message);
+			}
 		}
 	}
 }

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -365,13 +365,13 @@ namespace OpenRA.Utility
 					string[] dirs = Directory.GetDirectories("mods");
 					foreach (var dir in dirs)
 					{
-						yth.Run(dir, outputDir + "\\" + dir.Substring(dir.LastIndexOf('\\') + 1));
+						yth.Run(dir, outputDir);
 					}
 				}
 				else
 				{
 					var modFolder = "mods\\" + mod;
-					yth.Run(modFolder, outputDir + "\\" + mod);
+					yth.Run(modFolder, outputDir);
 				}
 			}
 			catch (Exception e)

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -348,7 +348,7 @@ namespace OpenRA.Utility
 			Console.WriteLine(dest + " saved.");
 		}
 
-		[Desc("MOD", "OUTPUT DIR", "Output game rules for visual representation.")]
+		[Desc("MOD", "OUTPUTDIR", "Output game rules for visual representation.")]
 		public static void GenerateStats(string[] args)
 		{
 			try

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -376,7 +376,8 @@ namespace OpenRA.Utility
 			}
 			catch (Exception e)
 			{
-				Console.WriteLine(e.Message);
+				Console.WriteLine("Error: {0}", e.Message);
+				Console.WriteLine("Usage: --stats MOD [output directory]");
 			}
 		}
 	}

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -370,7 +370,7 @@ namespace OpenRA.Utility
 				}
 				else
 				{
-					var modFolder = "mods\\" + mod;
+					var modFolder = Path.Combine("mods", mod);
 					yth.Run(modFolder, outputDir);
 				}
 			}

--- a/OpenRA.Utility/Command.cs
+++ b/OpenRA.Utility/Command.cs
@@ -365,13 +365,13 @@ namespace OpenRA.Utility
 					string[] dirs = Directory.GetDirectories("mods");
 					foreach (var dir in dirs)
 					{
-						yth.Run(dir, outputDir);
+						yth.Run(dir, outputDir, true);
 					}
 				}
 				else
 				{
 					var modFolder = Path.Combine("mods", mod);
-					yth.Run(modFolder, outputDir);
+					yth.Run(modFolder, outputDir, true);
 				}
 			}
 			catch (Exception e)

--- a/OpenRA.Utility/OpenRA.Utility.csproj
+++ b/OpenRA.Utility/OpenRA.Utility.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="UpgradeRules.cs" />
     <Compile Include="LegacyMapImporter.cs" />
+    <Compile Include="YamlToHtml.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -32,7 +32,8 @@ namespace OpenRA.Utility
 			{ "--map-upgrade-v5", Command.UpgradeV5Map },
 			{ "--upgrade-map", UpgradeRules.UpgradeMap },
 			{ "--upgrade-mod", UpgradeRules.UpgradeMod },
-			{ "--map-import", Command.ImportLegacyMap }
+			{ "--map-import", Command.ImportLegacyMap },
+			{ "--stats", Command.GenerateStats }
 		};
 
 		static void Main(string[] args)

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -47,8 +47,12 @@ namespace OpenRA.Utility
 
 		public void ProcessDirectory(string dir, string output, bool recursive = true)
 		{
-			//sw.WriteLine("<div class='directory {0}'>", dir.Substring(dir.LastIndexOf('\\') + 1));
-			Console.WriteLine(output + "\\" + dir.Substring(dir.LastIndexOf("\\") + 1) + ".html");
+			if (!Directory.Exists(dir))
+				throw new ArgumentException(dir + " doesn't exist.");
+
+			if (!Directory.Exists(output))
+				Directory.CreateDirectory(output);
+
 			using (StreamWriter sw = new StreamWriter(output + "\\" + dir.Substring(dir.LastIndexOf("\\") + 1) + ".html"))
 			{
 				string[] files = Directory.GetFiles(dir);
@@ -62,18 +66,14 @@ namespace OpenRA.Utility
 				string[] directories = Directory.GetDirectories(dir);
 				foreach (var d in directories)
 				{
-					ProcessDirectory(d, output, recursive);
+					ProcessDirectory(d, output + "\\" + d.Substring(d.LastIndexOf('\\') + 1), recursive);
 				}
 			}
-			//sw.WriteLine("</div>");
 		}
 
 		public void Run(string where, string output = "html", bool recursive = true)
 		{
-			if (!Directory.Exists(output))
-				Directory.CreateDirectory(output);
-
-				ProcessDirectory(where, output, recursive);
+			ProcessDirectory(where, output, recursive);
 		}
 	}
 }

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -35,14 +35,14 @@ namespace OpenRA.Utility
 
 		public void WriteYamlFile(StreamWriter sw, string file)
 		{
-			var fileOutput = file.Substring(file.LastIndexOf('\\') + 1);
-			fileOutput = fileOutput.Substring(0, fileOutput.IndexOf(".yaml"));
-			sw.WriteLine("<div class='file {0}'><div class='value'>{0}</div>", fileOutput);
+			//var fileOutput = file.Substring(file.LastIndexOf('\\') + 1);
+			//fileOutput = fileOutput.Substring(0, fileOutput.IndexOf(".yaml"));
+			//sw.WriteLine("<div class='file {0}'><div class='value'>{0}</div>", fileOutput);
 
 			List<MiniYamlNode> yamlFile = MiniYaml.FromFile(file);
 			WriteYamlNodeList(sw, yamlFile);
 
-			sw.WriteLine("</div>");
+			//sw.WriteLine("</div>");
 		}
 
 		public void ProcessDirectory(string dir, string output, bool recursive = true)

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -53,10 +53,13 @@ namespace OpenRA.Utility
 			if (!Directory.Exists(output))
 				Directory.CreateDirectory(output);
 
-			using (StreamWriter sw = new StreamWriter(output + "\\" + dir.Substring(dir.LastIndexOf("\\") + 1) + ".html"))
+			
+			string[] files = Directory.GetFiles(dir);
+			foreach (var file in files.Where(f => f.EndsWith(".yaml")))
 			{
-				string[] files = Directory.GetFiles(dir);
-				foreach (var file in files.Where(f => f.EndsWith(".yaml")))
+				if (!Directory.Exists(output + '\\' + file.Substring(0, file.LastIndexOf('\\'))))
+					Directory.CreateDirectory(output + '\\' + file.Substring(0, file.LastIndexOf('\\')));
+				using (StreamWriter sw = new StreamWriter(output + '\\' + file.Substring(0, file.IndexOf(".yaml")) + ".html"))
 				{
 					WriteYamlFile(sw, file);
 				}
@@ -66,7 +69,7 @@ namespace OpenRA.Utility
 				string[] directories = Directory.GetDirectories(dir);
 				foreach (var d in directories)
 				{
-					ProcessDirectory(d, output + "\\" + d.Substring(d.LastIndexOf('\\') + 1), recursive);
+					ProcessDirectory(d, output, recursive);
 				}
 			}
 		}

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -35,14 +35,8 @@ namespace OpenRA.Utility
 
 		public void WriteYamlFile(StreamWriter sw, string file)
 		{
-			//var fileOutput = file.Substring(file.LastIndexOf('\\') + 1);
-			//fileOutput = fileOutput.Substring(0, fileOutput.IndexOf(".yaml"));
-			//sw.WriteLine("<div class='file {0}'><div class='value'>{0}</div>", fileOutput);
-
 			List<MiniYamlNode> yamlFile = MiniYaml.FromFile(file);
 			WriteYamlNodeList(sw, yamlFile);
-
-			//sw.WriteLine("</div>");
 		}
 
 		public void ProcessDirectory(string dir, string output, bool recursive = true)

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -51,9 +51,10 @@ namespace OpenRA.Utility
 			string[] files = Directory.GetFiles(dir);
 			foreach (var file in files.Where(f => f.EndsWith(".yaml")))
 			{
-				if (!Directory.Exists(output + '\\' + file.Substring(0, file.LastIndexOf('\\'))))
-					Directory.CreateDirectory(output + '\\' + file.Substring(0, file.LastIndexOf('\\')));
-				using (StreamWriter sw = new StreamWriter(output + '\\' + file.Substring(0, file.IndexOf(".yaml")) + ".html"))
+
+				if (!Directory.Exists(Path.Combine(output,file.Substring(0, file.LastIndexOf(Path.DirectorySeparatorChar)))))
+					Directory.CreateDirectory(Path.Combine(output, file.Substring(0, file.LastIndexOf(Path.DirectorySeparatorChar))));
+				using (StreamWriter sw = new StreamWriter(Path.Combine(output, file.Substring(0, file.IndexOf(".yaml"))) + ".html"))
 				{
 					WriteYamlFile(sw, file);
 				}

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using OpenRA.FileFormats;
+
+namespace OpenRA.Utility
+{
+	class YamlToHtml
+	{
+		public void WriteYamlNode(StreamWriter sw, MiniYamlNode node)
+		{
+			sw.WriteLine("<div class='node {0}'><div class='key'>{0}</div>", node.Key);
+
+			WriteYaml(sw, node.Value);
+
+			sw.WriteLine("</div>");
+		}
+
+		public void WriteYamlNodeList(StreamWriter sw, List<MiniYamlNode> nodes)
+		{
+			foreach (var node in nodes)
+			{
+				WriteYamlNode(sw, node);
+			}
+		}
+
+		public void WriteYaml(StreamWriter sw, MiniYaml yaml)
+		{
+			sw.WriteLine("<div class='value'>{0}</div>", yaml.Value);
+
+			WriteYamlNodeList(sw, yaml.Nodes);
+		}
+
+		public void WriteYamlFile(StreamWriter sw, string file)
+		{
+			var fileOutput = file.Substring(file.LastIndexOf('\\') + 1);
+			fileOutput = fileOutput.Substring(0, fileOutput.IndexOf(".yaml"));
+			sw.WriteLine("<div class='file {0}'><div class='value'>{0}</div>", fileOutput);
+
+			List<MiniYamlNode> yamlFile = MiniYaml.FromFile(file);
+			WriteYamlNodeList(sw, yamlFile);
+
+			sw.WriteLine("</div>");
+		}
+
+		public void ProcessDirectory(string dir, string output, bool recursive = true)
+		{
+			//sw.WriteLine("<div class='directory {0}'>", dir.Substring(dir.LastIndexOf('\\') + 1));
+			Console.WriteLine(output + "\\" + dir.Substring(dir.LastIndexOf("\\") + 1) + ".html");
+			using (StreamWriter sw = new StreamWriter(output + "\\" + dir.Substring(dir.LastIndexOf("\\") + 1) + ".html"))
+			{
+				string[] files = Directory.GetFiles(dir);
+				foreach (var file in files.Where(f => f.EndsWith(".yaml")))
+				{
+					WriteYamlFile(sw, file);
+				}
+			}
+			if (recursive)
+			{
+				string[] directories = Directory.GetDirectories(dir);
+				foreach (var d in directories)
+				{
+					ProcessDirectory(d, output, recursive);
+				}
+			}
+			//sw.WriteLine("</div>");
+		}
+
+		public void Run(string where, string output = "html", bool recursive = true)
+		{
+			if (!Directory.Exists(output))
+				Directory.CreateDirectory(output);
+
+				ProcessDirectory(where, output, recursive);
+		}
+	}
+}

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Utility
 			}
 		}
 
-		public void Run(string where, string output = "html", bool recursive = true)
+		public void Run(string where, string output, bool recursive)
 		{
 			ProcessDirectory(where, output, recursive);
 		}

--- a/OpenRA.Utility/YamlToHtml.cs
+++ b/OpenRA.Utility/YamlToHtml.cs
@@ -35,8 +35,10 @@ namespace OpenRA.Utility
 
 		public void WriteYamlFile(StreamWriter sw, string file)
 		{
+			sw.WriteLine("<div class='file'>");
 			List<MiniYamlNode> yamlFile = MiniYaml.FromFile(file);
 			WriteYamlNodeList(sw, yamlFile);
+			sw.WriteLine("</div>");
 		}
 
 		public void ProcessDirectory(string dir, string output, bool recursive = true)

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta HTTP-EQUIV="content-type" CONTENT="text/html; charset=utf-8">
+		<link rel="stylesheet" href="style.css" />
+		<script src="http://code.jquery.com/jquery-2.1.0.min.js"></script>
+		<script>
+			var gCurrentFile = "";
+
+			function reloadContent() {
+				gCurrentFile = "mods/" + $("#mod > option:selected").attr("value") + $("#file > option:selected").attr("value");
+				$("#content").load(gCurrentFile);
+			}
+
+			$(document).ready(function () {
+				reloadContent();
+				$("#mod").change(function () {
+					reloadContent();
+				});
+				$("#file").change(function () {
+					reloadContent();
+				});
+			});
+		</script>
+	</head>
+
+	<body>
+		<div id="container">
+			<div id="header">
+				<select id="mod">
+					<option value="ra/" selected>Red Alert</option>
+					<option value="cnc/">Tiberium Dawn</option>
+					<option value="d2k/">Dune 2000</option>
+					<option value="ts/">Tiberian Sun</option>
+				</select>
+				<select id="file">
+					<!-- Might want to insert options here by traversing filesystem -->
+					<option value="rules/infantry.html" selected>Infantry</option>
+					<option value="rules/vehicles.html" >Vehicles</option>
+					<option value="rules/aircraft.html" >Aircraft</option>
+					<option value="rules/ships.html" >Ships</option>
+					<option value="rules/structures.html" >Structures</option>
+					<option value="weapons.html" >Weapons</option>
+				</select>
+			</div>
+			<div id="content">
+			</div>
+		</div>
+	</body>
+</head>

--- a/html/style.css
+++ b/html/style.css
@@ -1,0 +1,10 @@
+.container > .node {
+	background-color: #CAA0A0;
+	margin-bottom: 20px;
+	margin-left: 10%;
+	margin-right: 10%;
+}
+
+.container > .node > .key:first-child {
+	font-size: 24px;
+}

--- a/html/style.css
+++ b/html/style.css
@@ -1,10 +1,32 @@
-.container > .node {
-	background-color: #CAA0A0;
+.file > .node {
+	background-color: #E44;
 	margin-bottom: 20px;
 	margin-left: 10%;
 	margin-right: 10%;
+
+	text-align: center;
 }
 
-.container > .node > .key:first-child {
+.file > .node > .key:first-child {
 	font-size: 24px;
+}
+
+.file > .node > .node {
+	display: inline-block;
+	background-color: #A44;
+}
+
+.file > .node > .node > .key:first-child {
+	font-size: 18px;
+	font-weight: bold;
+	text-decoration: underline;
+}
+
+.file > .node > .node > .node {
+	display: inline-block;
+	background-color: #44E;
+}
+
+.file > .node > .node > .node > .key:first-child {
+	font-weight: bold;
 }


### PR DESCRIPTION
Usage: OpenRA.Utility --stats MOD [output directory]

This adds a utility that converts the yaml files to html. This is intended to provide a website where people can see the current stats for units, etc. in release, and in bleed (to see what is coming).

A very simple example .css file is included in html/

I'm making this PR because the utility works, but also to get some feedback into features I should add and how I should do things.
