### PR TITLE
Changes to Tiberium and Viceroids

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -58,6 +58,9 @@ NEW:
 		Reduced Obelisk range from 8.5 to 6.5.
 		Reduced Obelisk vision from 8 to 7.
 		Increased Obelisk build time from 36 seconds to 52 seconds.
+		Decreased Tiberium damage rate by a factor of 3.
+		Decreased Visceroid health by 25% and removed their ability to gain experience.
+		Increased the chance of Tiberium or chemical deaths spawning a Visceroid from 2% to 10%.
 	Engine:
 		Converted Aircraft CruiseAltitude to world coordinates.
 		Converted Health Radius to world coordinates.

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -411,7 +411,7 @@ VICE:
 	AppearsOnRadar:
 	Health:
 		Radius: 427
-		HP: 400
+		HP: 300
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -433,7 +433,6 @@ VICE:
 		ScanRadius: 5
 	AttackMove:
 	HiddenUnderFog:
-	GainsExperience:
 	GivesExperience:
 	Valued:
 		Cost: 1000

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -165,7 +165,7 @@
 	DrawLineToTarget:
 	ActorLostNotification:
 	SpawnViceroid:
-		Probability: 2
+		Probability: 10
 	CrushableInfantry:
 		WarnProbability: 60
 	CombatDebugOverlay:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -890,7 +890,7 @@ HonestJohn:
 		Damage: 100
 
 Tiberium:
-	ROF: 4
+	ROF: 12
 	Warhead:
 		Spread: 42
 		InfDeath: 6


### PR DESCRIPTION
Tiberium Poisoning caused by walking on Tiberium with infantry is
nerfed.

W/O nerf: 16 seconds to kill Minigunner
W/ nerf: 31 seconds to kill Minigunner

Chance of viceroid spawning has been buffed.

W/O buff: with about 40-50 minigunners, only 1 will viceroid from just
standing on tiberium, other factors not counted.
W/ buff: with about 40-50 minigunners, 3 or more will viceroid from just
standing on tiberium, other factors not counted.

Viceroids have 100 less HP.

I don't need to explain this one.

Viceroids can no longer gain experience. They still give experience on
death though.

W/O buff/nerf/whateverthisis: Viceroids can gain experience and become
veterans, getting more health and doing more damage. Killing them gives
experience.
W/ buff/nerf/whatever: Viceroids cannot rank up and become veterans
anymore. Killing them gives experience.
