### PR TITLE
Aircraft defence balance changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,9 @@ NEW:
 		Tanya can now plant C4 on vehicles.
 		Parachute bomb air strike will reveal the whole target area.
 		Adjusted AA Guns to fire their guns alternately at a high fire rate, and added contrails to their bullets.
+		Decreased AA Gun ZSU-23 damage from 25 to 12.
+		Increased SAM Site power cost from -20 to -40.
+		Decreased SAM Site Nike damage from 100 to 50.
 	Tiberian Dawn:
 		Commando can now plant C4 on bridges.
 		Added the Asset Browser to the Extras menu.

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -769,7 +769,7 @@ SAM:
 		Name: SAM Site
 		Description: Anti-Air base defense.\n  Strong vs Aircraft\n  Weak vs Infantry, Tanks
 	Building:
-		Power: -20
+		Power: -40
 		Footprint: xx
 		Dimensions: 2,1
 	-GivesBuildableArea:

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -37,7 +37,7 @@ ZSU-23:
 			Light: 75%
 			Concrete: 50%
 		Explosion: small_explosion_air
-		Damage: 25
+		Damage: 12
 
 Vulcan:
 	ROF: 30
@@ -704,7 +704,7 @@ Nike:
 		ImpactSound: kaboom25.aud
 		InfDeath: 3
 		SmudgeType: Crater
-		Damage: 100
+		Damage: 50
 
 RedEye:
 	ROF: 50


### PR DESCRIPTION
I believe these changes make anti-air defenses less insta-win on placement and not so "one defense solves everything" anymore. Aircraft are given a chance to escape when they're placed now (SAM Sites used to 1-shot MiGs or level clumped aircraft quite quickly, so if you accidentally got in range you'd be hurting). If you still try to take defenses head on with aircraft, the aircraft can lose, which leads me to think the current defense damage was already too much.
