### PR TITLE
Fixed map.yaml sequences being ignored

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -232,10 +232,10 @@ namespace OpenRA.Traits
 			Stance oldStance, Stance newStance);
 	}
 
-	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning); }
+	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning, Map map); }
 
 	public interface IObjectivesPanel { string ObjectivesPanel { get; } }
-	
+
 	public static class DisableExts
 	{
 		public static bool IsDisabled(this Actor a)

--- a/OpenRA.Lint/YamlChecker.cs
+++ b/OpenRA.Lint/YamlChecker.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Lint
 						if (verbose)
 							Console.WriteLine("Pass: {0}".F(customPassType.ToString()));
 
-						customPass.Run(EmitError, EmitWarning);
+						customPass.Run(EmitError, EmitWarning, testMap);
 					}
 					catch (Exception e)
 					{

--- a/OpenRA.Mods.RA/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.RA/Lint/CheckActorReferences.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA
 	{
 		Action<string> EmitError;
 
-		public void Run(Action<string> emitError, Action<string> emitWarning)
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
 			EmitError = emitError;
 

--- a/OpenRA.Mods.RA/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.RA/Lint/CheckSequences.cs
@@ -17,10 +17,11 @@ namespace OpenRA.Mods.RA
 {
 	class CheckSequences : ILintPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning)
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			var sequences = Game.modData.Manifest.Sequences
-				.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal);
+			var sequences = MiniYaml.MergeLiberal(map.Sequences,
+				Game.modData.Manifest.Sequences.Select(s => MiniYaml.FromFile(s))
+				.Aggregate(MiniYaml.MergeLiberal));
 
 			foreach (var actorInfo in Rules.Info)
 				foreach (var renderInfo in actorInfo.Value.Traits.WithInterface<RenderSimpleInfo>())

--- a/OpenRA.Mods.RA/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.RA/Lint/CheckSyncAnnotations.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA
 {
 	class CheckSyncAnnotations : ILintPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning)
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
 			/* first, check all the types implementing ISync */
 			foreach (var t in Game.modData.ObjectCreator.GetTypesImplementing<ISync>())

--- a/OpenRA.Mods.RA/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.RA/Lint/CheckTraitPrerequisites.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.RA
 {
 	public class CheckTraitPrerequisites : ILintPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning)
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
 			foreach (var actorInfo in Rules.Info.Where(a => !a.Key.StartsWith("^")))
 				try

--- a/OpenRA.Mods.RA/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.RA/Lint/LintBuildablePrerequisites.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.RA
 {
 	class LintBuildablePrerequisites : ILintPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning)
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
 			var providedPrereqs = Rules.Info.Keys.Concat(
 				Rules.Info.SelectMany(a => a.Value.Traits


### PR DESCRIPTION
As described in #4765. Test case was `mono --debug OpenRA.Lint.exe ra mods/ra/maps/bomber-john`.
