### PR TITLE
Fix Guard OG crash #4821

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ NEW:
 		Removed the ability of commandos to plant C4 on walls.
 		Order lines are now shown on unit selection.
 		Fixed chat synchronization in replays.
+		Fixed the game sometimes crashing when deploying and activating the guard cursor at the same time.
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.

--- a/OpenRA.Mods.RA/Guard.cs
+++ b/OpenRA.Mods.RA/Guard.cs
@@ -84,6 +84,9 @@ namespace OpenRA.Mods.RA
 
 		public string GetCursor(World world, CPos xy, MouseInput mi)
 		{
+			if (!subjects.Any())
+				return null;
+
 			var multiple = subjects.Count() > 1;
 			var canGuard = FriendlyGuardableUnits(world, mi)
 				.Any(a => multiple || a != subjects.First());


### PR DESCRIPTION
Specifically adds back a valuable check that https://github.com/OpenRA/OpenRA/commit/dfd51c0caae05c525f71d7515ce83b3e6309d606#diff-d897b7e465afb3ac8dc229d7110c9b5bL85 removed, causing this crash.
