### PR TITLE
Fix #4350 - Spy not disappearing

### DIFF
--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Activities
 			foreach (var t in target.Actor.TraitsImplementing<IAcceptInfiltrator>())
 				t.OnInfiltrate(target.Actor, self);
 
-			self.World.AddFrameEndTask(w => { if (!self.Destroyed) w.Remove(self); });
+			self.Destroy();
 
 			if (target.Actor.HasTrait<Building>())
 				Sound.PlayToPlayer(self.Owner, "bldginf1.aud");


### PR DESCRIPTION
Spy now calls .Destroy() and is removed from minimap upon infiltration
