### PR TITLE
Set unit/structure build time when building starts instead of when added to queue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ NEW:
 		Order lines are now shown on unit selection.
 		Fixed chat synchronization in replays.
 		Fixed the game sometimes crashing when deploying and activating the guard cursor at the same time.
+		Build time is now set when an item reaches the front of a queue, instead of immediately when queued.
 	Dune 2000:
 		Added the Atreides grenadier from the 1.06 patch.
 		Added randomized tiles for Sand and Rock terrain.


### PR DESCRIPTION
The build time for a unit/structure was previously set at the time that
item was added to a production queue. This meant modifiers of the
production time (multiple production facilities in ClassicProductionQueue
or "instant build" in debug) were not applied to items already in a queue.

This change modifies ProductionQueue so that build time is set at the
instant an item starts building (reaches the front of it's queue). This was
done primarily to make the production bonuses in ClassicProductionQueue
more apparent, though it also makes the "instant build" debug option more
responsive when items are queued prior to enabling.
