### PR TITLE
Moved mirror selection to the client

### DIFF
--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -130,7 +130,7 @@ LoadScreen: CncLoadScreen
 	FilesToExtract: speech.mix, tempicnh.mix, transit.mix
 	InstallerBackgroundWidget: INSTALL_BACKGROUND
 	TestFiles: conquer.mix, desert.mix, general.mix, sounds.mix, speech.mix, temperat.mix, tempicnh.mix, winter.mix
-	PackageURL: http://open-ra.org/download/content/cnc-packages
+	PackageMirrorList: http://open-ra.org/packages/cnc-mirrors.txt
 
 ServerTraits:
 	LobbyCommands

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -113,7 +113,7 @@ LoadScreen: DefaultLoadScreen
 	InstallerMenuWidget: INSTALL_PANEL
 # TODO: check if DATA.R8 is at 1.03 patch level with 4840 frames
 	TestFiles: BLOXBASE.R8, BLOXBAT.R8, BLOXBGBS.R8, BLOXICE.R8, BLOXTREE.R8, BLOXWAST.R8, DATA.R8, SOUND.RS
-	PackageURL: http://open-ra.org/download/content/d2k-103-packages
+	PackageMirrorList: http://open-ra.org/packages/d2k-103-mirrors.txt
 	Text: Filling Crates..., Breeding Sandworms...
 
 ServerTraits:

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -129,7 +129,7 @@ LoadScreen: DefaultLoadScreen
 	Image: mods/ra/uibits/loadscreen.png
 	InstallerMenuWidget: INSTALL_PANEL
 	TestFiles: allies.mix, conquer.mix, general.mix, interior.mix, redalert.mix, russian.mix, scores.mix, snow.mix, sounds.mix, temperat.mix
-	PackageURL: http://open-ra.org/download/content/ra-packages
+	PackageMirrorList: http://open-ra.org/packages/ra-mirrors.txt
 	Text: Filling Crates..., Charging Capacitors..., Reticulating Splines..., Planting Trees..., Building Bridges..., Aging Empires..., Compiling EVA..., Constructing Pylons..., Activating Skynet..., Splitting Atoms...
 
 ServerTraits:

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -151,7 +151,7 @@ LoadScreen: DefaultLoadScreen
 	Image: mods/ts/uibits/loadscreen.png
 	InstallerMenuWidget: INSTALL_PANEL
 	TestFiles: cache.mix, conquer.mix, isosnow.mix, isotemp.mix, local.mix, sidec01.mix, sidec02.mix, sno.mix, snow.mix, sounds.mix, speech01.mix, tem.mix, temperat.mix
-	PackageURL: http://open-ra.org/download/content/ts-packages
+	PackageMirrorList: http://open-ra.org/packages/ts-mirrors.txt
 	Text: Updating EVA installation..., Changing perspective...
 
 ServerTraits:


### PR DESCRIPTION
This eliminates our last bottleneck https://github.com/OpenRA/OpenRAWeb/blob/master/content/get-dependency.php and makes moving the then completely static website elsewhere possible. It also appreciates our bandwidth donors by displaying at least their domain name  #3904.
