### PR TITLE
Airstrike improvements

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -173,7 +173,6 @@
     <Compile Include="Traits\TraitsInterfaces.cs" />
     <Compile Include="Traits\Util.cs" />
     <Compile Include="Traits\ValidateOrder.cs" />
-    <Compile Include="Traits\Waypoint.cs" />
     <Compile Include="Traits\World\Country.cs" />
     <Compile Include="Traits\World\ResourceLayer.cs" />
     <Compile Include="Traits\World\ResourceType.cs" />

--- a/OpenRA.Mods.Cnc/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/IonCannonPower.cs
@@ -28,8 +28,10 @@ namespace OpenRA.Mods.Cnc
 			return new SelectGenericPowerTarget(order, manager, "ioncannon", MouseButton.Left);
 		}
 
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			self.World.AddFrameEndTask(w =>
 			{
 				Sound.Play(Info.LaunchSound, order.TargetLocation.CenterPosition);

--- a/OpenRA.Mods.RA/AttackBomber.cs
+++ b/OpenRA.Mods.RA/AttackBomber.cs
@@ -23,48 +23,34 @@ namespace OpenRA.Mods.RA
 		[Desc("Armament name")]
 		public readonly string Guns = "secondary";
 		public readonly int FacingTolerance = 2;
-		public readonly WRange VisionRange = WRange.FromCells(10);
 
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.self, this); }
 	}
 
-	class AttackBomber : AttackBase, ISync, INotifyKilled
+	class AttackBomber : AttackBase, ISync, INotifyRemovedFromWorld
 	{
 		AttackBomberInfo info;
-		Actor camera;
 		[Sync] Target target;
+		[Sync] bool inAttackRange;
+
+		public event Action<Actor> OnRemovedFromWorld = self => { };
+		public event Action<Actor> OnEnteredAttackRange = self => { };
+		public event Action<Actor> OnExitedAttackRange = self => { };
 
 		public AttackBomber(Actor self, AttackBomberInfo info)
 			: base(self, info)
 		{
 			this.info = info;
-			this.camera = null;
 		}
 
 		public override void Tick(Actor self)
 		{
 			base.Tick(self);
 
-			var facing = self.TraitOrDefault<IFacing>();
 			var cp = self.CenterPosition;
 			var bombTarget = Target.FromPos(cp - new WVec(0, 0, cp.Z));
-
-			// Provide vision
-			if (this.camera == null &&
-				target.IsInRange(self.CenterPosition, this.info.VisionRange))
-			{
-				this.camera = self.World.CreateActor("camera", new TypeDictionary
-				{
-					new LocationInit(target.CenterPosition.ToCPos()),
-					new OwnerInit(self.Owner),
-				});
-			}
-			else if (this.camera != null &&
-				!target.IsInRange(self.CenterPosition, this.info.VisionRange))
-			{
-				self.World.Remove(this.camera);
-				this.camera = null;
-			}
+			var wasInAttackRange = inAttackRange;
+			inAttackRange = false;
 
 			// Bombs drop anywhere in range
 			foreach (var a in Armaments.Where(a => a.Info.Name == info.Bombs))
@@ -72,39 +58,43 @@ namespace OpenRA.Mods.RA
 				if (!target.IsInRange(self.CenterPosition, a.Weapon.Range))
 					continue;
 
-				a.CheckFire(self, this, facing, bombTarget);
+				inAttackRange = true;
+				a.CheckFire(self, this, facing.Value, bombTarget);
 			}
 
 			// Guns only fire when approaching the target
-			var facingToTarget = Util.GetFacing(target.CenterPosition - self.CenterPosition, facing.Facing);
-			if (Math.Abs(facingToTarget - facing.Facing) % 256 > info.FacingTolerance)
-				return;
-
-			foreach (var a in Armaments.Where(a => a.Info.Name == info.Guns))
+			var f = facing.Value.Facing;
+			var facingToTarget = Util.GetFacing(target.CenterPosition - self.CenterPosition, f);
+			if (Math.Abs(facingToTarget - f) % 256 <= info.FacingTolerance)
 			{
-				if (!target.IsInRange(self.CenterPosition, a.Weapon.Range))
-				    continue;
+				foreach (var a in Armaments.Where(a => a.Info.Name == info.Guns))
+				{
+					if (!target.IsInRange(self.CenterPosition, a.Weapon.Range))
+					    continue;
 
-				var t = Target.FromPos(cp - new WVec(0, a.Weapon.Range.Range / 2, cp.Z).Rotate(WRot.FromFacing(facing.Facing)));
-				a.CheckFire(self, this, facing, t);
+					var t = Target.FromPos(cp - new WVec(0, a.Weapon.Range.Range / 2, cp.Z).Rotate(WRot.FromFacing(f)));
+					inAttackRange = true;
+					a.CheckFire(self, this, facing.Value, t);
+				}
 			}
+
+			if (inAttackRange && !wasInAttackRange)
+				OnEnteredAttackRange(self);
+
+			if (!inAttackRange && wasInAttackRange)
+				OnExitedAttackRange(self);
 		}
 
 		public void SetTarget(WPos pos) { target = Target.FromPos(pos); }
 
-		public void Killed(Actor self, AttackInfo e)
+		public void RemovedFromWorld(Actor self)
 		{
-			if (this.camera != null)
-			{
-				self.World.Remove(this.camera);
-				this.camera = null;
-			}
+			OnRemovedFromWorld(self);
 		}
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove)
 		{
-			// TODO: Player controlled units want this too!
-			throw new NotImplementedException("CarpetBomb requires a scripted target");
+			throw new NotImplementedException("AttackBomber requires a scripted target");
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.RA/Effects/GravityBomb.cs
@@ -63,6 +63,10 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
+			var cell = pos.ToCPos();
+			if (args.SourceActor.World.FogObscures(cell))
+				return SpriteRenderable.None;
+
 			return anim.Render(pos, wr.Palette("effect"));
 		}
 	}

--- a/OpenRA.Mods.RA/Immobile.cs
+++ b/OpenRA.Mods.RA/Immobile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -10,19 +10,20 @@
 
 using System.Collections.Generic;
 using OpenRA.FileFormats;
+using OpenRA.Traits;
 
-namespace OpenRA.Traits
+namespace OpenRA.Mods.RA
 {
-	class WaypointInfo : ITraitInfo, IOccupySpaceInfo
+	class ImmobileInfo : ITraitInfo, IOccupySpaceInfo
 	{
-		public object Create( ActorInitializer init ) { return new Waypoint( init ); }
+		public object Create(ActorInitializer init) { return new Immobile(init); }
 	}
 
-	class Waypoint : IOccupySpace, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
+	class Immobile : IOccupySpace, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		[Sync] readonly CPos location;
 
-		public Waypoint(ActorInitializer init)
+		public Immobile(ActorInitializer init)
 		{
 			this.location = init.Get<LocationInit, CPos>();
 		}

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -481,6 +481,7 @@
     <Compile Include="Modifiers\DisabledOverlay.cs" />
     <Compile Include="Widgets\Logic\ReplayControlBarLogic.cs" />
     <Compile Include="Widgets\Logic\GameTimerLogic.cs" />
+    <Compile Include="Immobile.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -34,8 +34,10 @@ namespace OpenRA.Mods.RA
 			return new SelectTarget(order, manager, this);
 		}
 
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			foreach (var target in UnitsInRange(order.ExtraLocation))
 			{
 				var cs = target.Trait<Chronoshiftable>();

--- a/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
@@ -97,8 +97,10 @@ namespace OpenRA.Mods.RA
 			self.Owner.PlayerActor.Trait<SupportPowerManager>().Powers[key].Activate(new Order());
 		}
 
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			self.World.AddFrameEndTask(w =>
 			{
 				Sound.PlayToPlayer(self.Owner, Info.LaunchSound);

--- a/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
@@ -34,8 +34,10 @@ namespace OpenRA.Mods.RA
 			return new SelectTarget(order, manager, this);
 		}
 
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			self.Trait<RenderBuilding>().PlayCustomAnim(self, "active");
 
 			Sound.Play("ironcur9.aud", order.TargetLocation.CenterPosition);

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -38,8 +38,10 @@ namespace OpenRA.Mods.RA
 			return new SelectGenericPowerTarget(order, manager, "nuke", MouseButton.Left);
 		}
 
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				Sound.Play(Info.LaunchSound);
 			else

--- a/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
@@ -33,8 +33,10 @@ namespace OpenRA.Mods.RA
 	{
 		public ParatroopersPower(Actor self, ParatroopersPowerInfo info) : base(self, info) { }
 
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			var items = (Info as ParatroopersPowerInfo).DropItems;
 			var startPos = self.World.ChooseRandomEdgeCell();
 

--- a/OpenRA.Mods.RA/SupportPowers/SonarPulsePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SonarPulsePower.cs
@@ -18,8 +18,10 @@ namespace OpenRA.Mods.RA
 	public class SonarPulsePower : SupportPower
 	{
 		public SonarPulsePower(Actor self, SonarPulsePowerInfo info) : base(self, info) { }
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			// TODO: Reveal submarines
 
 			// Should this play for all players?

--- a/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
@@ -25,8 +25,10 @@ namespace OpenRA.Mods.RA
 	{
 		public SpyPlanePower(Actor self, SpyPlanePowerInfo info) : base(self, info) { }
 
-		public override void Activate(Actor self, Order order)
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
+			base.Activate(self, order, manager);
+
 			var enterCell = self.World.ChooseRandomEdgeCell();
 			var altitude = Rules.Info["u2"].Traits.Get<PlaneInfo>().CruiseAltitude;
 

--- a/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using OpenRA.Mods.RA.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
@@ -45,6 +46,7 @@ namespace OpenRA.Mods.RA
 	{
 		public readonly Actor self;
 		public readonly SupportPowerInfo Info;
+		protected Beacon beacon;
 
 		public SupportPower(Actor self, SupportPowerInfo info)
 		{
@@ -62,7 +64,26 @@ namespace OpenRA.Mods.RA
 			Sound.PlayToPlayer(self.Owner, Info.EndChargeSound);
 		}
 
-		public virtual void Activate(Actor self, Order order) { }
+		public virtual void Activate(Actor self, Order order, SupportPowerManager manager)
+		{
+			if (Info.DisplayBeacon)
+			{
+				beacon = new Beacon(
+					order.Player,
+					order.TargetLocation.CenterPosition,
+					Info.BeaconDuration,
+					Info.BeaconPalettePrefix);
+
+				self.World.Add(beacon);
+			}
+
+			if (Info.DisplayRadarPing && manager.RadarPings != null)
+				manager.RadarPings.Value.Add(
+					() => order.Player.IsAlliedWith(self.World.RenderPlayer),
+					order.TargetLocation.CenterPosition,
+					order.Player.Color.RGB,
+					Info.BeaconDuration);
+		}
 
 		public virtual IOrderGenerator OrderGenerator(string order, SupportPowerManager manager)
 		{

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
@@ -188,23 +188,9 @@ namespace OpenRA.Mods.RA
 			var power = Instances.First(i => !InstanceDisabled(i));
 
 			// Note: order.Subject is the *player* actor
-			power.Activate(power.self, order);
+			power.Activate(power.self, order, Manager);
 			RemainingTime = TotalTime;
 			notifiedCharging = notifiedReady = false;
-
-			if (power.Info.DisplayBeacon)
-				power.self.World.Add(new Beacon(
-					order.Player,
-					order.TargetLocation.CenterPosition,
-					power.Info.BeaconDuration,
-					power.Info.BeaconPalettePrefix));
-
-			if (power.Info.DisplayRadarPing && Manager.RadarPings != null)
-				Manager.RadarPings.Value.Add(
-					() => order.Player.IsAlliedWith(power.self.World.RenderPlayer),
-					order.TargetLocation.CenterPosition,
-					order.Player.Color.RGB,
-					power.Info.BeaconDuration);
 
 			if (Info.OneShot)
 				Disabled = true;

--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -143,6 +143,13 @@ namespace OpenRA.Utility
 						ConvertFloatToRange(ref node.Value.Value);
 				}
 
+				// Waypoint was renamed to Immobile
+				if (engineVersion < 20140312)
+				{
+					if (depth == 1 && node.Key == "Waypoint")
+						node.Key = "Immobile";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -385,6 +385,7 @@ HQ:
 		UnitType: a10
 		DisplayBeacon: True
 		DisplayRadarPing: True
+		CameraActor: camera
 	SupportPowerChargeBar:
 
 FIX:

--- a/mods/cnc/rules/system-actors.yaml
+++ b/mods/cnc/rules/system-actors.yaml
@@ -31,12 +31,12 @@ CRATE:
 	BodyOrientation:
 
 mpspawn:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 
 waypoint:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 

--- a/mods/cnc/rules/system-actors.yaml
+++ b/mods/cnc/rules/system-actors.yaml
@@ -41,7 +41,7 @@ waypoint:
 	BodyOrientation:
 
 CAMERA:
-	Aircraft:
+	Immobile:
 	Health:
 		HP: 1000
 	RevealsShroud:

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -59,7 +59,6 @@ PALACEA:
 		LongDesc: Ornithopter drops a load of parachuted\nbombs on your target
 		UnitType: orni.bomber
 		SelectTargetSound:
-		FlareType:
 	CanPowerDown:
 	DisabledOverlay:
 	RequiresPower:

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -88,7 +88,6 @@ PALACEO:
 		LongDesc: Ornithopter drops a load of parachuted\nbombs on your target
 		UnitType: orni.bomber
 		SelectTargetSound:
-		FlareType:
 	CanPowerDown:
 	DisabledOverlay:
 	RequiresPower:

--- a/mods/d2k/rules/system-actors.yaml
+++ b/mods/d2k/rules/system-actors.yaml
@@ -85,12 +85,12 @@ CRATE:
 	BodyOrientation:
 
 mpspawn:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 
 waypoint:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 

--- a/mods/ra/rules/system-actors.yaml
+++ b/mods/ra/rules/system-actors.yaml
@@ -165,12 +165,12 @@ powerproxy.sonarpulse:
 		SelectTargetSound: slcttgt1.aud
 
 mpspawn:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 
 waypoint:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 

--- a/mods/ra/rules/system-actors.yaml
+++ b/mods/ra/rules/system-actors.yaml
@@ -152,7 +152,7 @@ powerproxy.parabombs:
 		AllowMultiple: yes
 		UnitType: badr.bomber
 		SelectTargetSound: slcttgt1.aud
-		FlareType: flare
+		FlareActor: flare
 
 powerproxy.sonarpulse:
 	SonarPulsePower:

--- a/mods/ra/rules/system-actors.yaml
+++ b/mods/ra/rules/system-actors.yaml
@@ -119,7 +119,7 @@ CRATE:
 	BodyOrientation:
 
 CAMERA:
-	Aircraft:
+	Immobile:
 	Health:
 		HP: 1000
 	RevealsShroud:
@@ -129,7 +129,7 @@ CAMERA:
 	BodyOrientation:
 
 FLARE:
-	Aircraft:
+	Immobile:
 	Health:
 		HP: 1000
 	RevealsShroud:

--- a/mods/ts/rules/system-actors.yaml
+++ b/mods/ts/rules/system-actors.yaml
@@ -1,10 +1,10 @@
 mpspawn:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 
 waypoint:
-	Waypoint:
+	Immobile:
 	RenderEditorOnly:
 	BodyOrientation:
 


### PR DESCRIPTION
This adjusts the way in which flares, cameras, and beacons work:
- Flares spawn when the attack is ordered, and removed 1 second (configurable) after the attack completes.
- Cameras spawn when the attack begins, and removed 1 second (configurable) after it completes.
- Beacons spawn when the attack is ordered, and removed when the attack begins.

It also fixes bombs being rendered through the fog, and fixes flares and cameras being treated as aircraft.
