### PR TITLE
Fixed husk flames (modified)

### DIFF
--- a/OpenRA.Mods.RA/BelowUnits.cs
+++ b/OpenRA.Mods.RA/BelowUnits.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			return r.Select(a => a.WithZOffset(offset));
+			return r.Select(a => a.WithZOffset(a.ZOffset + offset));
 		}
 	}
 }

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -8,10 +8,12 @@ fire:
 		Start: 0
 		Length: *
 		Offset: 0,-3
+		ZOffset: 1023
 	2: fire2
 		Start: 0
 		Length: *
 		Offset: 0,-3
+		ZOffset: 1023
 
 120mm:
 	idle:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -126,12 +126,15 @@ smoke_m:
 	idle:
 		Start: 0
 		Length: *
+		ZOffset: 1023
 	loop:
 		Start: 49
 		Length: 42
+		ZOffset: 1023
 	end:
 		Start: 0
 		Length: 26
+		ZOffset: 1023
 
 dragon:
 	idle:
@@ -142,6 +145,7 @@ smokey:
 	idle:
 		Start: 0
 		Length: *
+		ZOffset: 1023
 
 bomb:
 	idle:
@@ -390,10 +394,12 @@ smokland:
 		Start: 0
 		Length: 60
 		Tick: 120
+		ZOffset: 1023
 	idle: playersmoke
 		Start: 60
 		Length: 32
 		Tick: 120
+		ZOffset: 1023
 
 fire:
 	1: fire1

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -400,18 +400,22 @@ fire:
 		Start: 0
 		Length: *
 		Offset: 0,-3
+		ZOffset: 1023
 	2: fire2
 		Start: 0
 		Length: *
 		Offset: 0,-3
+		ZOffset: 1023
 	3: fire3
 		Start: 0
 		Length: *
 		Offset: 0,-3
+		ZOffset: 1023
 	4: fire4
 		Start: 0
 		Length: *
 		Offset: 0,-3
+		ZOffset: 1023
 
 rank:
 	rank:

--- a/mods/ra/sequences/vehicles.yaml
+++ b/mods/ra/sequences/vehicles.yaml
@@ -9,6 +9,7 @@ mcvhusk:
 	idle:
 		Start: 0
 		Facings: 32
+		ZOffset: -1023
 
 truk:
 	idle:
@@ -68,11 +69,13 @@ hhusk:
 	idle:
 		Start: 0
 		Facings: 32
+		ZOffset: -1023
 
 hhusk2:
 	idle:
 		Start: 0
 		Facings: 32
+		ZOffset: -1023
 
 1tnk:
 	idle:


### PR DESCRIPTION
Modifies #4833 by fixing the issue in BelowUnits instead of removing it.  This should fix #4762 without breaking anything that relies on BelowUnits. :+1: from me for the two patches by @Mailaender.
