### PR TITLE
Fix enemy spies showing an enemy health bar when disguised as an ally - closes #4780

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,7 @@ NEW:
 		Removed the submarine detection ability from Cruiser and Transport.
 		Added the submarine detection ability to Submarines and Missile Subs.
 		Increased the submarine detection range of Gunboat from 3 to 4.
+		Fixed Spies having an enemy color health bar when disguised as a friendly unit (occurred using the Team Health Colors setting).
 	Tiberian Dawn:
 		Chinook rotors now counter-rotate.
 		Commando can now plant C4 on bridges.

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -228,6 +228,11 @@ namespace OpenRA
 			return (health.Value == null) ? false : health.Value.IsDead;
 		}
 
+		public bool IsDisguised()
+		{
+			return effectiveOwner.Value != null && effectiveOwner.Value.Disguised;
+		}
+
 		public void Kill(Actor attacker)
 		{
 			if (health.Value == null)

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -181,8 +181,11 @@ namespace OpenRA.Traits
 		Color GetHealthColor(Health health)
 		{
 			if (Game.Settings.Game.TeamHealthColors)
-				return self.Owner.IsAlliedWith(self.World.LocalPlayer) ? Color.LimeGreen :
-						self.Owner.NonCombatant ? Color.Tan : Color.Red;
+			{
+				var isAlly = self.Owner.IsAlliedWith(self.World.LocalPlayer)
+					|| (self.IsDisguised() && self.World.LocalPlayer.IsAlliedWith(self.EffectiveOwner.Owner));
+				return isAlly ?	Color.LimeGreen : self.Owner.NonCombatant ? Color.Tan : Color.Red;
+			}
 			else
 				return health.DamageState == DamageState.Critical ? Color.Red :
 						health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;

--- a/OpenRA.Mods.RA/ActorExts.cs
+++ b/OpenRA.Mods.RA/ActorExts.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA
 			if (stance == Stance.Ally)
 				return true;
 
-			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.HasTrait<IgnoresDisguise>())
+			if (self.IsDisguised() && !toActor.HasTrait<IgnoresDisguise>())
 				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Ally;
 
 			return stance == Stance.Ally;
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA
 			if (stance == Stance.Ally)
 				return false;		/* otherwise, we'll hate friendly disguised spies */
 
-			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.HasTrait<IgnoresDisguise>())
+			if (self.IsDisguised() && !toActor.HasTrait<IgnoresDisguise>())
 				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Enemy;
 
 			return stance == Stance.Enemy;


### PR DESCRIPTION
Happened when using the team health color setting
