### PR TITLE
Add garrison support for player-owned transports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -122,6 +122,9 @@ NEW:
 		Added IEffectiveOwner interface for traits/logic that temporarily alter an actor's apparent owner.
 		Renamed Spy trait to Disguise, SpyToolTip trait to DisguiseToolTip, and RenderSpy trait to RenderDisguise.
 		Overhauled the internal map management and preview generation code.
+		Muzzleflash definitions have moved from WithMuzzleFlash to each Armament. Only one WithMuzzleFlash is now required per actor.
+		Added an AttackGarrisoned trait that allows passengers to fire through a set of defined ports.
+		Maps can define initial cargo for actors by adding "Cargo: actora, actorb, ..." to the actor reference.
 	Server:
 		Message of the day is now shared between all mods and a default motd.txt gets created in the user directory.
 	Asset Browser:

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Graphics
 
 			// added for contrails
 			foreach (var a in world.ActorsWithTrait<IPostRender>())
-				if (!a.Actor.Destroyed)
+				if (a.Actor.IsInWorld && !a.Actor.Destroyed)
 					a.Trait.RenderAfterWorld(this, a.Actor);
 
 			if (world.OrderGenerator != null)

--- a/OpenRA.Mods.RA/Activities/Transform.cs
+++ b/OpenRA.Mods.RA/Activities/Transform.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.RA.Activities
 
 				var cargo = self.TraitOrDefault<Cargo>();
 				if (cargo != null)
-					init.Add( new CargoInit( cargo.Passengers.ToArray() ) );
+					init.Add( new RuntimeCargoInit( cargo.Passengers.ToArray() ) );
 
 				var a = w.CreateActor( ToActor, init );
 

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -58,6 +58,7 @@ namespace OpenRA.Mods.RA
 		public readonly ArmamentInfo Info;
 		public readonly WeaponInfo Weapon;
 		public readonly Barrel[] Barrels;
+		public readonly Actor self;
 		Lazy<Turreted> Turret;
 		Lazy<IBodyOrientation> Coords;
 		Lazy<LimitedAmmo> limitedAmmo;
@@ -69,6 +70,7 @@ namespace OpenRA.Mods.RA
 
 		public Armament(Actor self, ArmamentInfo info)
 		{
+			this.self = self;
 			Info = info;
 
 			// We can't resolve these until runtime
@@ -125,22 +127,22 @@ namespace OpenRA.Mods.RA
 
 		// Note: facing is only used by the legacy positioning code
 		// The world coordinate model uses Actor.Orientation
-		public void CheckFire(Actor self, IFacing facing, Target target)
+		public Barrel CheckFire(Actor self, IFacing facing, Target target)
 		{
 			if (FireDelay > 0)
-				return;
+				return null;
 
 			if (limitedAmmo.Value != null && !limitedAmmo.Value.HasAmmo())
-				return;
+				return null;
 
 			if (!target.IsInRange(self.CenterPosition, Weapon.Range))
-				return;
+				return null;
 
 			if (Weapon.MinRange != WRange.Zero && target.IsInRange(self.CenterPosition, Weapon.MinRange))
-				return;
+				return null;
 
 			if (!Weapon.IsValidAgainst(target, self.World))
-				return;
+				return null;
 
 			var barrel = Barrels[Burst % Barrels.Length];
 			var muzzlePosition = self.CenterPosition + MuzzleOffset(self, barrel);
@@ -185,6 +187,8 @@ namespace OpenRA.Mods.RA
 				FireDelay = Weapon.ROF;
 				Burst = Weapon.Burst;
 			}
+
+			return barrel;
 		}
 
 		public bool IsReloading { get { return FireDelay > 0; } }
@@ -211,5 +215,7 @@ namespace OpenRA.Mods.RA
 				orientation += Turret.Value.LocalOrientation(self);
 			return orientation;
 		}
+
+		public Actor Actor { get { return self; } }
 	}
 }

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -44,6 +44,12 @@ namespace OpenRA.Mods.RA
 		[Desc("Recoil recovery per-frame")]
 		public readonly WRange RecoilRecovery = new WRange(9);
 
+		[Desc("Muzzle flash sequence to render")]
+		public readonly string MuzzleSequence = null;
+
+		[Desc("Use multiple muzzle images if non-zero")]
+		public readonly int MuzzleSplitFacings = 0;
+
 		public object Create(ActorInitializer init) { return new Armament(init.self, this); }
 	}
 

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -135,7 +135,13 @@ namespace OpenRA.Mods.RA
 		public abstract Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove);
 
 		public bool HasAnyValidWeapons(Target t) { return Armaments.Any(a => a.Weapon.IsValidAgainst(t, self.World)); }
-		public WRange GetMaximumRange() { return Armaments.Max(a => a.Weapon.Range); }
+		public WRange GetMaximumRange()
+		{
+			if (!Armaments.Any())
+				return WRange.Zero;
+
+			return Armaments.Max(a => a.Weapon.Range);
+		}
 
 		public Armament ChooseArmamentForTarget(Target t) { return Armaments.FirstOrDefault(a => a.Weapon.IsValidAgainst(t, self.World)); }
 

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.Mods.RA.Buildings;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
@@ -35,6 +36,7 @@ namespace OpenRA.Mods.RA
 		protected Lazy<IFacing> facing;
 		Lazy<IEnumerable<Armament>> armaments;
 		protected IEnumerable<Armament> Armaments { get { return armaments.Value; } }
+		protected Lazy<Building> building;
 
 		public AttackBase(Actor self, AttackBaseInfo info)
 		{
@@ -43,11 +45,16 @@ namespace OpenRA.Mods.RA
 
 			armaments = Lazy.New(() => self.TraitsImplementing<Armament>());
 			facing = Lazy.New(() => self.TraitOrDefault<IFacing>());
+			building = Lazy.New(() => self.TraitOrDefault<Building>());
 		}
 
 		protected virtual bool CanAttack(Actor self, Target target)
 		{
 			if (!self.IsInWorld)
+				return false;
+
+			// Building is under construction or is being sold
+			if (building.Value != null && !building.Value.BuildComplete)
 				return false;
 
 			if (!target.IsValidFor(self))

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA
 		public abstract object Create(ActorInitializer init);
 	}
 
-	public abstract class AttackBase : IIssueOrder, IResolveOrder, ITick, IExplodeModifier, IOrderVoice, ISync
+	public abstract class AttackBase : IIssueOrder, IResolveOrder, IOrderVoice, ISync
 	{
 		[Sync] public bool IsAttacking { get; internal set; }
 
@@ -35,7 +35,6 @@ namespace OpenRA.Mods.RA
 		protected Lazy<IFacing> facing;
 		Lazy<IEnumerable<Armament>> armaments;
 		protected IEnumerable<Armament> Armaments { get { return armaments.Value; } }
-		List<Pair<int, Action>> delayedActions = new List<Pair<int, Action>>();
 
 		public AttackBase(Actor self, AttackBaseInfo info)
 		{
@@ -63,38 +62,13 @@ namespace OpenRA.Mods.RA
 			return true;
 		}
 
-		public bool ShouldExplode(Actor self) { return !IsReloading(); }
-
-		public bool IsReloading() { return Armaments.Any(a => a.IsReloading); }
-
-		public virtual void Tick(Actor self)
-		{
-			for (var i = 0; i < delayedActions.Count; i++)
-			{
-				var x = delayedActions[i];
-				if (--x.First <= 0)
-					x.Second();
-				delayedActions[i] = x;
-			}
-
-			delayedActions.RemoveAll(a => a.First <= 0);
-		}
-
-		internal void ScheduleDelayedAction(int t, Action a)
-		{
-			if (t > 0)
-				delayedActions.Add(Pair.New(t, a));
-			else
-				a();
-		}
-
 		public virtual void DoAttack(Actor self, Target target)
 		{
 			if (!CanAttack(self, target))
 				return;
 
 			foreach (var a in Armaments)
-				a.CheckFire(self, this, facing.Value, target);
+				a.CheckFire(self, facing.Value, target);
 		}
 
 		public IEnumerable<IOrderTargeter> Orders

--- a/OpenRA.Mods.RA/Attack/AttackCharge.cs
+++ b/OpenRA.Mods.RA/Attack/AttackCharge.cs
@@ -41,12 +41,10 @@ namespace OpenRA.Mods.RA
 			charges = aci.MaxCharges;
 		}
 
-		public override void Tick(Actor self)
+		public void Tick(Actor self)
 		{
 			if (--timeToRecharge <= 0)
 				charges = aci.MaxCharges;
-
-			base.Tick(self);
 		}
 
 		public void Attacking(Actor self, Target target, Armament a, Barrel barrel)

--- a/OpenRA.Mods.RA/Attack/AttackCharge.cs
+++ b/OpenRA.Mods.RA/Attack/AttackCharge.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA
 
 	class AttackCharge : AttackOmni, ITick, INotifyAttack, ISync
 	{
-		readonly AttackChargeInfo aci;
+		readonly AttackChargeInfo info;
 
 		[Sync] int charges;
 		[Sync] int timeToRecharge;
@@ -37,25 +37,25 @@ namespace OpenRA.Mods.RA
 		public AttackCharge(Actor self, AttackChargeInfo info)
 			: base(self, info)
 		{
-			aci = self.Info.Traits.Get<AttackChargeInfo>();
-			charges = aci.MaxCharges;
+			this.info = info;
+			charges = info.MaxCharges;
 		}
 
 		public void Tick(Actor self)
 		{
 			if (--timeToRecharge <= 0)
-				charges = aci.MaxCharges;
+				charges = info.MaxCharges;
 		}
 
 		public void Attacking(Actor self, Target target, Armament a, Barrel barrel)
 		{
 			--charges;
-			timeToRecharge = aci.ReloadTime;
+			timeToRecharge = info.ReloadTime;
 		}
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove)
 		{
-			return new ChargeAttack(newTarget);
+			return new ChargeAttack(this, newTarget);
 		}
 
 		public override void ResolveOrder(Actor self, Order order)
@@ -68,9 +68,12 @@ namespace OpenRA.Mods.RA
 
 		class ChargeAttack : Activity
 		{
+			readonly AttackCharge attack;
 			readonly Target target;
-			public ChargeAttack(Target target) 
+
+			public ChargeAttack(AttackCharge attack, Target target) 
 			{ 
+				this.attack = attack;
 				this.target = target; 
 			}
 
@@ -78,23 +81,22 @@ namespace OpenRA.Mods.RA
 			{
 				if (IsCanceled || !target.IsValidFor(self))
 					return NextActivity;
-				
-				var initDelay = self.Info.Traits.Get<AttackChargeInfo>().InitialChargeDelay;
-				
-				var attack = self.Trait<AttackCharge>();
+
 				if (attack.charges == 0 || !attack.CanAttack(self, target))
 					return this;
 
 				self.Trait<RenderBuildingCharge>().PlayCharge(self);
-				return Util.SequenceActivities(new Wait(initDelay), new ChargeFire(target), this);
+				return Util.SequenceActivities(new Wait(attack.info.InitialChargeDelay), new ChargeFire(attack, target), this);
 			}
 		}
 
 		class ChargeFire : Activity
 		{
+			readonly AttackCharge attack;
 			readonly Target target;
-			public ChargeFire(Target target) 
+			public ChargeFire(AttackCharge attack, Target target) 
 			{ 
+				this.attack = attack;
 				this.target = target; 
 			}
 
@@ -103,15 +105,12 @@ namespace OpenRA.Mods.RA
 				if (IsCanceled || !target.IsValidFor(self))
 					return NextActivity;
 
-				var chargeDelay = self.Info.Traits.Get<AttackChargeInfo>().ChargeDelay;
-
-				var attack = self.Trait<AttackCharge>();
 				if (attack.charges == 0)
 					return NextActivity;
 
 				attack.DoAttack(self, target);
 
-				return Util.SequenceActivities(new Wait(chargeDelay), this);
+				return Util.SequenceActivities(new Wait(attack.info.ChargeDelay), this);
 			}
 		}
 	}

--- a/OpenRA.Mods.RA/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.RA/Attack/AttackFollow.cs
@@ -1,0 +1,103 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.FileFormats;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.RA.Move;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class AttackFollowInfo : AttackBaseInfo
+	{
+		public override object Create(ActorInitializer init) { return new AttackFollow(init.self, this); }
+	}
+
+	public class AttackFollow : AttackBase, ITick, ISync
+	{
+		public Target Target { get; protected set; }
+
+		public AttackFollow(Actor self, AttackFollowInfo info)
+			: base(self, info) { }
+
+		protected override bool CanAttack(Actor self, Target target)
+		{
+			if (!target.IsValidFor(self))
+				return false;
+
+			return base.CanAttack(self, target);
+		}
+
+		public void Tick(Actor self)
+		{
+			DoAttack(self, Target);
+			IsAttacking = Target.IsValidFor(self);
+		}
+
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove)
+		{
+			return new AttackActivity(self, newTarget, allowMove);
+		}
+
+		public override void ResolveOrder(Actor self, Order order)
+		{
+			base.ResolveOrder(self, order);
+
+			if (order.OrderString == "Stop")
+				Target = Target.Invalid;
+		}
+
+		class AttackActivity : Activity
+		{
+			readonly AttackFollow attack;
+			readonly IMove move;
+			readonly Target target;
+
+			public AttackActivity(Actor self, Target target, bool allowMove)
+			{
+				attack = self.Trait<AttackFollow>();
+				move = allowMove ? self.TraitOrDefault<IMove>() : null;
+
+				// HACK: Mobile.OnRails is horrible
+				var mobile = move as Mobile;
+				if (mobile != null && mobile.Info.OnRails)
+					move = null;
+
+				this.target = target;
+			}
+
+			public override Activity Tick(Actor self)
+			{
+				if (IsCanceled || !target.IsValidFor(self))
+					return NextActivity;
+
+				if (self.IsDisabled())
+					return this;
+
+				const int RangeTolerance = 1;	/* how far inside our maximum range we should try to sit */
+				var weapon = attack.ChooseArmamentForTarget(target);
+
+				if (weapon != null)
+				{
+					var range = WRange.FromCells(Math.Max(0, weapon.Weapon.Range.Range / 1024 - RangeTolerance));
+
+					attack.Target = target;
+
+					if (move != null)
+						return Util.SequenceActivities(move.MoveFollow(self, target, range), this);
+				}
+
+				return NextActivity;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.RA/Attack/AttackFollow.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA
 			return base.CanAttack(self, target);
 		}
 
-		public void Tick(Actor self)
+		public virtual void Tick(Actor self)
 		{
 			DoAttack(self, Target);
 			IsAttacking = Target.IsValidFor(self);

--- a/OpenRA.Mods.RA/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.RA/Attack/AttackGarrisoned.cs
@@ -1,0 +1,192 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.FileFormats;
+using OpenRA.Graphics;
+using OpenRA.Mods.RA.Buildings;
+using OpenRA.Mods.RA.Move;
+using OpenRA.Mods.RA.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class FirePort
+	{
+		public WVec Offset;
+		public WAngle Yaw;
+		public WAngle Cone;
+	}
+
+	public class AttackGarrisonedInfo : AttackFollowInfo, Requires<CargoInfo>
+	{
+		[Desc("Fire port offsets in local coordinates")]
+		public readonly WRange[] PortOffsets = {};
+
+		[Desc("Fire port yaw angles")]
+		public readonly WAngle[] PortYaws = {};
+
+		[Desc("Fire port yaw cone angle")]
+		public readonly WAngle[] PortCones = {};
+
+		public override object Create(ActorInitializer init) { return new AttackGarrisoned(init.self, this); }
+	}
+
+	public class AttackGarrisoned : AttackFollow, INotifyPassengerEntered, INotifyPassengerExited, IRender
+	{
+		public readonly FirePort[] Ports;
+
+		AttackGarrisonedInfo info;
+		Lazy<IBodyOrientation> coords;
+		List<Armament> armaments;
+		List<AnimationWithOffset> muzzles;
+		Dictionary<Actor, IFacing> paxFacing;
+		Dictionary<Actor, IPositionable> paxPos;
+		Dictionary<Actor, RenderSprites> paxRender;
+
+
+		public AttackGarrisoned(Actor self, AttackGarrisonedInfo info)
+			: base(self, info)
+		{
+			this.info = info;
+			coords = Lazy.New(() => self.Trait<IBodyOrientation>());
+			armaments = new List<Armament>();
+			muzzles = new List<AnimationWithOffset>();
+			paxFacing = new Dictionary<Actor, IFacing>();
+			paxPos = new Dictionary<Actor, IPositionable>();
+			paxRender = new Dictionary<Actor, RenderSprites>();
+
+			GetArmaments = () => armaments;
+
+
+			if (info.PortOffsets.Length % 3 != 0 || info.PortOffsets.Length == 0)
+				throw new InvalidOperationException("PortOffsets array length must be a multiple of three");
+
+			if (info.PortYaws.Length * 3 != info.PortOffsets.Length)
+				throw new InvalidOperationException("FireYaw must define an angle for each port");
+
+			if (info.PortCones.Length * 3 != info.PortOffsets.Length)
+				throw new InvalidOperationException("PortCones must define an angle for each port");
+
+			var p = new List<FirePort>();
+			for (var i = 0; i < info.PortOffsets.Length / 3; i++)
+			{
+				p.Add(new FirePort
+				{
+					Offset = new WVec(info.PortOffsets[3*i], info.PortOffsets[3*i + 1], info.PortOffsets[3*i + 2]),
+					Yaw = info.PortYaws[i],
+					Cone = info.PortCones[i],
+				});
+			}
+
+			Ports = p.ToArray();
+		}
+
+		public void PassengerEntered(Actor self, Actor passenger)
+		{
+			paxFacing.Add(passenger, passenger.Trait<IFacing>());
+			paxPos.Add(passenger, passenger.Trait<IPositionable>());
+			paxRender.Add(passenger, passenger.Trait<RenderSprites>());
+			armaments = armaments.Append(passenger.TraitsImplementing<Armament>()
+				.Where(a => info.Armaments.Contains(a.Info.Name))
+				.ToArray()).ToList();
+		}
+
+		public void PassengerExited(Actor self, Actor passenger)
+		{
+			paxFacing.Remove(passenger);
+			paxPos.Remove(passenger);
+			paxRender.Remove(passenger);
+			armaments.RemoveAll(a => a.Actor == passenger);
+		}
+
+
+		FirePort SelectFirePort(Actor self, WAngle targetYaw)
+		{
+			// Pick a random port that faces the target
+			var bodyYaw = facing.Value != null ? WAngle.FromFacing(facing.Value.Facing) : WAngle.Zero;
+			var indices = Exts.MakeArray(Ports.Length, i => i).Shuffle(self.World.SharedRandom);
+			foreach (var i in indices)
+			{
+				var yaw = bodyYaw + Ports[i].Yaw;
+				var leftTurn = (yaw - targetYaw).Angle;
+				var rightTurn = (targetYaw - yaw).Angle;
+				if (Math.Min(leftTurn, rightTurn) <= Ports[i].Cone.Angle)
+					return Ports[i];
+			}
+
+			return null;
+		}
+
+		WVec PortOffset(Actor self, FirePort p)
+		{
+			var bodyOrientation = coords.Value.QuantizeOrientation(self, self.Orientation);
+			return coords.Value.LocalToWorld(p.Offset.Rotate(bodyOrientation));
+		}
+
+		public override void DoAttack(Actor self, Target target)
+		{
+			if (!CanAttack(self, target))
+				return;
+
+			var pos = self.CenterPosition;
+			var targetYaw = WAngle.FromFacing(Traits.Util.GetFacing(target.CenterPosition - self.CenterPosition, 0));
+
+			foreach (var a in Armaments)
+			{
+				var port = SelectFirePort(self, targetYaw);
+				if (port == null)
+					return;
+
+				var muzzleFacing = targetYaw.Angle / 4;
+				paxFacing[a.Actor].Facing = muzzleFacing;
+				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
+
+				var barrel = a.CheckFire(a.Actor, facing.Value, target);
+				if (barrel != null && a.Info.MuzzleSequence != null)
+				{
+					// Muzzle facing is fixed once the firing starts
+					var muzzleAnim = new Animation(paxRender[a.Actor].GetImage(a.Actor), () => muzzleFacing);
+					var sequence = a.Info.MuzzleSequence;
+
+					if (a.Info.MuzzleSplitFacings > 0)
+						sequence += Traits.Util.QuantizeFacing(muzzleFacing, a.Info.MuzzleSplitFacings).ToString();
+
+					var muzzleFlash = new AnimationWithOffset(muzzleAnim,
+						() => PortOffset(self, port),
+						() => false,
+						p => WithTurret.ZOffsetFromCenter(self, p, 1024));
+
+					muzzles.Add(muzzleFlash);
+					muzzleAnim.PlayThen(sequence, () => muzzles.Remove(muzzleFlash));
+				}
+			}
+		}
+
+		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
+		{
+			// Display muzzle flashes
+			foreach (var m in muzzles)
+				foreach (var r in m.Render(self, wr, wr.Palette("effect"), 1f))
+					yield return r;
+		}
+
+		public override void Tick(Actor self)
+		{
+			base.Tick(self);
+
+			// Take a copy so that Tick() can remove animations
+			foreach (var m in muzzles.ToList())
+				m.Animation.Tick();
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Attack/AttackLoyalty.cs
+++ b/OpenRA.Mods.RA/Attack/AttackLoyalty.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.RA
 
 		public override void DoAttack(Actor self, Target target)
 		{
-			if (!CanAttack(self, target)) return;
+			if (!CanAttack(self, target))
+				return;
 
 			var arm = Armaments.FirstOrDefault();
 			if (arm == null)
@@ -34,9 +35,8 @@ namespace OpenRA.Mods.RA
 			if (!target.IsInRange(self.CenterPosition, arm.Weapon.Range))
 				return;
 
-			var facing = self.TraitOrDefault<IFacing>();
 			foreach (var a in Armaments)
-				a.CheckFire(self, facing, target);
+				a.CheckFire(self, facing.Value, target);
 
 			if (target.Actor != null)
 				target.Actor.ChangeOwner(self.Owner);

--- a/OpenRA.Mods.RA/Attack/AttackLoyalty.cs
+++ b/OpenRA.Mods.RA/Attack/AttackLoyalty.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA
 
 			var facing = self.TraitOrDefault<IFacing>();
 			foreach (var a in Armaments)
-				a.CheckFire(self, this, facing, target);
+				a.CheckFire(self, facing, target);
 
 			if (target.Actor != null)
 				target.Actor.ChangeOwner(self.Owner);

--- a/OpenRA.Mods.RA/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.RA/Attack/AttackOmni.cs
@@ -8,7 +8,7 @@
  */
 #endregion
 
-using OpenRA.Mods.RA.Buildings;
+using OpenRA.FileFormats;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
@@ -18,34 +18,25 @@ namespace OpenRA.Mods.RA
 		public override object Create(ActorInitializer init) { return new AttackOmni(init.self, this); }
 	}
 
-	class AttackOmni : AttackBase, INotifyBuildComplete, ISync
+	class AttackOmni : AttackBase, ISync
 	{
-		[Sync] bool buildComplete = false;
-		public void BuildingComplete(Actor self) { buildComplete = true; }
-
 		public AttackOmni(Actor self, AttackOmniInfo info)
 			: base(self, info) { }
 
-		protected override bool CanAttack(Actor self, Target target)
-		{
-			var isBuilding = self.HasTrait<Building>() && !buildComplete;
-			return base.CanAttack(self, target) && !isBuilding;
-		}
-
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove)
 		{
-			return new SetTarget(newTarget, this);
+			return new SetTarget(this, newTarget);
 		}
 
 		class SetTarget : Activity
 		{
 			readonly Target target;
-			readonly AttackOmni ao;
+			readonly AttackOmni attack;
 
-			public SetTarget(Target target, AttackOmni ao)
+			public SetTarget(AttackOmni attack, Target target)
 			{
 				this.target = target;
-				this.ao = ao;
+				this.attack = attack;
 			}
 
 			public override Activity Tick(Actor self)
@@ -53,7 +44,7 @@ namespace OpenRA.Mods.RA
 				if (IsCanceled || !target.IsValidFor(self))
 					return NextActivity;
 
-				ao.DoAttack(self, target);
+				attack.DoAttack(self, target);
 				return this;
 			}
 		}

--- a/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
@@ -35,19 +35,20 @@ namespace OpenRA.Mods.RA
 		int idleTicks = 0;
 		PopupState state = PopupState.Open;
 		Turreted turret;
+		bool skippedMakeAnimation;
 
 		public AttackPopupTurreted(ActorInitializer init, AttackPopupTurretedInfo info)
 			: base(init.self, info)
 		{
 			this.info = info;
-			buildComplete = init.Contains<SkipMakeAnimsInit>();
 			turret = turrets.FirstOrDefault();
 			rb = init.self.Trait<RenderBuilding>();
+			skippedMakeAnimation = init.Contains<SkipMakeAnimsInit>();
 		}
 
 		protected override bool CanAttack(Actor self, Target target)
 		{
-			if (state == PopupState.Transitioning || !buildComplete)
+			if (state == PopupState.Transitioning || !building.Value.BuildComplete)
 				return false;
 
 			if (!base.CanAttack(self, target))
@@ -90,17 +91,14 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public override void BuildingComplete(Actor self)
+		public void BuildingComplete(Actor self)
 		{
-			// Set true for SkipMakeAnimsInit
-			if (buildComplete)
+			if (!skippedMakeAnimation)
 			{
 				state = PopupState.Closed;
 				rb.PlayCustomAnimRepeating(self, "closed-idle");
 				turret.desiredFacing = null;
 			}
-
-			buildComplete = true;
 		}
 
 		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)

--- a/OpenRA.Mods.RA/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.RA/Attack/AttackTurreted.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public override object Create(ActorInitializer init) { return new AttackTurreted(init.self, this); }
 	}
 
-	class AttackTurreted : AttackBase, INotifyBuildComplete, ISync
+	class AttackTurreted : AttackBase, ITick, INotifyBuildComplete, ISync
 	{
 		public Target Target { get; protected set; }
 		protected IEnumerable<Turreted> turrets;
@@ -53,9 +53,8 @@ namespace OpenRA.Mods.RA
 			return base.CanAttack(self, target);
 		}
 
-		public override void Tick(Actor self)
+		public void Tick(Actor self)
 		{
-			base.Tick(self);
 			DoAttack(self, Target);
 			IsAttacking = Target.IsValidFor(self);
 		}

--- a/OpenRA.Mods.RA/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.RA/Attack/AttackTurreted.cs
@@ -10,23 +10,21 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.FileFormats;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.RA.Move;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class AttackTurretedInfo : AttackBaseInfo, Requires<TurretedInfo>
+	class AttackTurretedInfo : AttackFollowInfo, Requires<TurretedInfo>
 	{
 		public override object Create(ActorInitializer init) { return new AttackTurreted(init.self, this); }
 	}
 
-	class AttackTurreted : AttackBase, ITick, INotifyBuildComplete, ISync
+	class AttackTurreted : AttackFollow, ITick, ISync
 	{
-		public Target Target { get; protected set; }
 		protected IEnumerable<Turreted> turrets;
-		[Sync] protected bool buildComplete;
 
 		public AttackTurreted(Actor self, AttackTurretedInfo info)
 			: base(self, info)
@@ -36,10 +34,7 @@ namespace OpenRA.Mods.RA
 
 		protected override bool CanAttack(Actor self, Target target)
 		{
-			if (self.HasTrait<Building>() && !buildComplete)
-				return false;
-
-			if (!target.IsValidFor(self))
+			if (!base.CanAttack(self, target))
 				return false;
 
 			var canAttack = false;
@@ -47,69 +42,7 @@ namespace OpenRA.Mods.RA
 				if (t.FaceTarget(self, target))
 					canAttack = true;
 
-			if (!canAttack)
-				return false;
-
-			return base.CanAttack(self, target);
-		}
-
-		public void Tick(Actor self)
-		{
-			DoAttack(self, Target);
-			IsAttacking = Target.IsValidFor(self);
-		}
-
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove)
-		{
-			return new AttackActivity(newTarget, allowMove);
-		}
-
-		public override void ResolveOrder(Actor self, Order order)
-		{
-			base.ResolveOrder(self, order);
-
-			if (order.OrderString == "Stop")
-				Target = Target.Invalid;
-		}
-
-		public virtual void BuildingComplete(Actor self) { buildComplete = true; }
-
-		class AttackActivity : Activity
-		{
-			readonly Target target;
-			readonly bool allowMove;
-
-			public AttackActivity(Target newTarget, bool allowMove)
-			{
-				this.target = newTarget;
-				this.allowMove = allowMove;
-			}
-
-			public override Activity Tick(Actor self)
-			{
-				if (IsCanceled || !target.IsValidFor(self))
-					return NextActivity;
-
-				if (self.IsDisabled())
-					return this;
-
-				var attack = self.Trait<AttackTurreted>();
-				const int RangeTolerance = 1;	/* how far inside our maximum range we should try to sit */
-				var weapon = attack.ChooseArmamentForTarget(target);
-
-				if (weapon != null)
-				{
-					var range = WRange.FromCells(Math.Max(0, weapon.Weapon.Range.Range / 1024 - RangeTolerance));
-
-					attack.Target = target;
-					var mobile = self.TraitOrDefault<Mobile>();
-
-					if (allowMove && mobile != null && !mobile.Info.OnRails)
-						return Util.SequenceActivities(mobile.MoveFollow(self, target, range), this);
-				}
-
-				return NextActivity;
-			}
+			return canAttack;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/AttackBomber.cs
+++ b/OpenRA.Mods.RA/AttackBomber.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.self, this); }
 	}
 
-	class AttackBomber : AttackBase, ISync, INotifyRemovedFromWorld
+	class AttackBomber : AttackBase, ITick, ISync, INotifyRemovedFromWorld
 	{
 		AttackBomberInfo info;
 		[Sync] Target target;
@@ -43,10 +43,8 @@ namespace OpenRA.Mods.RA
 			this.info = info;
 		}
 
-		public override void Tick(Actor self)
+		public void Tick(Actor self)
 		{
-			base.Tick(self);
-
 			var cp = self.CenterPosition;
 			var bombTarget = Target.FromPos(cp - new WVec(0, 0, cp.Z));
 			var wasInAttackRange = inAttackRange;
@@ -59,7 +57,7 @@ namespace OpenRA.Mods.RA
 					continue;
 
 				inAttackRange = true;
-				a.CheckFire(self, this, facing.Value, bombTarget);
+				a.CheckFire(self, facing.Value, bombTarget);
 			}
 
 			// Guns only fire when approaching the target
@@ -74,7 +72,7 @@ namespace OpenRA.Mods.RA
 
 					var t = Target.FromPos(cp - new WVec(0, a.Weapon.Range.Range / 2, cp.Z).Rotate(WRot.FromFacing(f)));
 					inAttackRange = true;
-					a.CheckFire(self, this, facing.Value, t);
+					a.CheckFire(self, facing.Value, t);
 				}
 			}
 

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -44,9 +44,21 @@ namespace OpenRA.Mods.RA
 			self = init.self;
 			Info = info;
 
-			if (init.Contains<CargoInit>())
+			if (init.Contains<RuntimeCargoInit>())
 			{
-				cargo = init.Get<CargoInit, Actor[]>().ToList();
+				cargo = init.Get<RuntimeCargoInit, Actor[]>().ToList();
+				totalWeight = cargo.Sum(c => GetWeight(c));
+			}
+			else if (init.Contains<CargoInit>())
+			{
+				foreach (var u in init.Get<CargoInit, string[]>())
+				{
+					var unit = self.World.CreateActor(false, u.ToLowerInvariant(),
+						new TypeDictionary { new OwnerInit(self.Owner) });
+
+					cargo.Add(unit);
+				}
+
 				totalWeight = cargo.Sum(c => GetWeight(c));
 			}
 			else
@@ -56,9 +68,10 @@ namespace OpenRA.Mods.RA
 					var unit = self.World.CreateActor(false, u.ToLowerInvariant(),
 						new TypeDictionary { new OwnerInit(self.Owner) });
 
-					if (CanLoad(self, unit))
-						Load(self, unit);
+					cargo.Add(unit);
 				}
+
+				totalWeight = cargo.Sum(c => GetWeight(c));
 			}
 		}
 
@@ -186,8 +199,19 @@ namespace OpenRA.Mods.RA
 			});
 		}
 
+		bool initialized;
 		public void Tick(Actor self)
 		{
+			// Notify initial cargo load
+			if (!initialized)
+			{
+				foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
+					foreach (var c in cargo)
+						npe.PassengerEntered(self, c);
+
+				initialized = true;
+			}
+
 			var cell = self.CenterPosition.ToCPos();
 			if (currentCell != cell)
 			{
@@ -200,12 +224,21 @@ namespace OpenRA.Mods.RA
 	public interface INotifyPassengerEntered { void PassengerEntered(Actor self, Actor passenger); }
 	public interface INotifyPassengerExited { void PassengerExited(Actor self, Actor passenger); }
 
-	public class CargoInit : IActorInit<Actor[]>
+	public class RuntimeCargoInit : IActorInit<Actor[]>
 	{
 		[FieldFromYamlKey]
 		public readonly Actor[] value = { };
-		public CargoInit() { }
-		public CargoInit(Actor[] init) { value = init; }
+		public RuntimeCargoInit() { }
+		public RuntimeCargoInit(Actor[] init) { value = init; }
 		public Actor[] Value(World world) { return value; }
+	}
+
+	public class CargoInit : IActorInit<string[]>
+	{
+		[FieldFromYamlKey]
+		public readonly string[] value = { };
+		public CargoInit() { }
+		public CargoInit(string[] init) { value = init; }
+		public string[] Value(World world) { return value; }
 	}
 }

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -144,6 +144,7 @@ namespace OpenRA.Mods.RA
 			foreach (var npe in self.TraitsImplementing<INotifyPassengerExited>())
 				npe.PassengerExited(self, a);
 
+			a.Trait<Passenger>().Transport = null;
 			return a;
 		}
 
@@ -178,6 +179,8 @@ namespace OpenRA.Mods.RA
 
 			foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
 				npe.PassengerEntered(self, a);
+
+			a.Trait<Passenger>().Transport = self;
 		}
 
 		public void Killed(Actor self, AttackInfo e)
@@ -205,10 +208,13 @@ namespace OpenRA.Mods.RA
 			// Notify initial cargo load
 			if (!initialized)
 			{
-				foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
-					foreach (var c in cargo)
-						npe.PassengerEntered(self, c);
+				foreach (var c in cargo)
+				{
+					c.Trait<Passenger>().Transport = self;
 
+					foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
+						npe.PassengerEntered(self, c);
+				}
 				initialized = true;
 			}
 

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -486,6 +486,7 @@
     <Compile Include="Buildings\LaysTerrain.cs" />
     <Compile Include="RemoveImmediately.cs" />
     <Compile Include="Attack\AttackFollow.cs" />
+    <Compile Include="Attack\AttackGarrisoned.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -485,6 +485,7 @@
     <Compile Include="World\BuildableTerrainLayer.cs" />
     <Compile Include="Buildings\LaysTerrain.cs" />
     <Compile Include="RemoveImmediately.cs" />
+    <Compile Include="Attack\AttackFollow.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/Passenger.cs
+++ b/OpenRA.Mods.RA/Passenger.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.RA
 	{
 		public readonly PassengerInfo info;
 		public Passenger( PassengerInfo info ) { this.info = info; }
+		public Actor Transport;
 
 		public IEnumerable<IOrderTargeter> Orders
 		{

--- a/OpenRA.Mods.RA/Render/RenderUnitReload.cs
+++ b/OpenRA.Mods.RA/Render/RenderUnitReload.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -8,25 +8,39 @@
  */
 #endregion
 
+using System.Linq;
+using OpenRA.FileFormats;
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.RA.Render
 {
-	class RenderUnitReloadInfo : RenderUnitInfo
+	class RenderUnitReloadInfo : RenderUnitInfo, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
 	{
-		public override object Create(ActorInitializer init) { return new RenderUnitReload(init.self); }
+		[Desc("Armament name")]
+		public readonly string Armament = "primary";
+
+		public override object Create(ActorInitializer init) { return new RenderUnitReload(init.self, this); }
 	}
 
 	class RenderUnitReload : RenderUnit
 	{
-		public RenderUnitReload(Actor self)
-			: base(self) { }
+		readonly AttackBase attack;
+		readonly Armament armament;
+
+		public RenderUnitReload(Actor self, RenderUnitReloadInfo info)
+			: base(self)
+		{
+			attack = self.Trait<AttackBase>();
+			armament = self.TraitsImplementing<Armament>()
+				.Single(a => a.Info.Name == info.Armament);
+		}
 
 		public override void Tick(Actor self)
 		{
-			var attack = self.TraitOrDefault<AttackBase>();
+			var sequence = (armament.IsReloading ? "empty-" : "") + (attack.IsAttacking ? "aim" : "idle");
+			if (sequence != anim.CurrentSequence.Name)
+				anim.ReplaceAnim(sequence);
 
-			if (attack != null)
-				anim.ReplaceAnim((attack.IsReloading() ? "empty-" : "")
-					+ (attack.IsAttacking ? "aim" : "idle"));
 			base.Tick(self);
 		}
 	}

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -68,10 +68,12 @@ HELI:
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
 		LocalOffset: 128,-213,-85, 128,213,-85
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: HeliAAGun
 		LocalOffset: 128,-213,-85, 128,213,-85
+		MuzzleSequence: muzzle
 	AttackHeli:
 		FacingTolerance: 20
 	LimitedAmmo:
@@ -83,9 +85,7 @@ HELI:
 	RenderUnit:
 	WithRotor:
 		Offset: 0,0,85
-	WithMuzzleFlash@PRIMARY:
-	WithMuzzleFlash@SECONDARY:
-		Armament: secondary
+	WithMuzzleFlash:
 	WithShadow:
 	LeavesHusk:
 		HuskActor: HELI.Husk
@@ -204,8 +204,7 @@ A10:
 		Name: gun
 		Weapon: Vulcan
 		LocalOffset: 1024,0,-85
-	WithMuzzleFlash@SECONDARY:
-		Armament: gun
+	WithMuzzleFlash:
 	Armament@BOMBS:
 		Name: bombs
 		Weapon: Napalm

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -197,6 +197,7 @@ A10:
 	RenderUnit:
 	WithShadow:
 	AttackBomber:
+		Armaments: gun, bombs
 		Guns: gun
 		Bombs: bombs
 	Armament@GUNS:

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -441,6 +441,8 @@ VICE:
 	Armament:
 		Weapon: Chemspray
 		LocalOffset: 384,0,0
+		MuzzleSequence: muzzle
+		MuzzleSplitFacings: 8
 	AttackFrontal:
 	AttackWander:
 	RenderUnit:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -103,6 +103,8 @@ E4:
 		Weapon: Flamethrower
 		LocalOffset: 341,0,256
 		FireDelay: 3
+		MuzzleSequence: muzzle
+		MuzzleSplitFacings: 8
 	AttackFrontal:
 	WithMuzzleFlash:
 		SplitFacings: true
@@ -138,6 +140,8 @@ E5:
 		Weapon: Chemspray
 		LocalOffset: 341,0,256
 		FireDelay: 3
+		MuzzleSequence: muzzle
+		MuzzleSplitFacings: 8
 	AttackFrontal:
 	WithMuzzleFlash:
 		SplitFacings: true

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -524,6 +524,7 @@ GUN:
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:
@@ -566,6 +567,7 @@ SAM:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: SAMMissile
+		MuzzleSequence: muzzle
 	AttackPopupTurreted:
 	WithMuzzleFlash:
 	AutoTarget:
@@ -639,6 +641,7 @@ GTWR:
 	Armament:
 		Weapon: HighV
 		LocalOffset: 256,0,256
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	BodyOrientation:
 		QuantizedFacings: 8

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -98,16 +98,16 @@ APC:
 		Recoil: 96
 		RecoilRecovery: 18
 		LocalOffset: 85,85,299, 85,-85,299
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: APCGun.AA
 		Recoil: 96
 		RecoilRecovery: 18
 		LocalOffset: 85,85,299, 85,-85,299
+		MuzzleSequence: muzzle
 	AttackTurreted:
-	WithMuzzleFlash@PRIMARY:
-	WithMuzzleFlash@SECONDARY:
-		Armament: secondary
+	WithMuzzleFlash:
 	RenderUnit:
 	WithTurret:
 	AutoTarget:
@@ -141,6 +141,7 @@ ARTY:
 	Armament:
 		Weapon: ArtilleryShell
 		LocalOffset: 624,0,208
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -175,6 +176,8 @@ FTNK:
 	Armament:
 		Weapon: BigFlamer
 		LocalOffset: 512,128,42, 512,-128,42
+		MuzzleSequence: muzzle
+		MuzzleSplitFacings: 8
 	AttackFrontal:
 	RenderUnit:
 	AutoTarget:
@@ -212,6 +215,7 @@ BGGY:
 	Armament:
 		Weapon: MachineGun
 		LocalOffset: 171,0,43
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -283,6 +287,7 @@ JEEP:
 	Armament:
 		Weapon: MachineGun
 		LocalOffset: 171,0,85
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -318,6 +323,7 @@ LTNK:
 		Recoil: 85
 		RecoilRecovery: 17
 		LocalOffset: 720,0,90
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -355,6 +361,7 @@ MTNK:
 		Recoil: 128
 		RecoilRecovery: 26
 		LocalOffset: 768,0,90
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -396,14 +403,16 @@ HTNK:
 		LocalOffset: 900,180,340, 900,-180,340
 		Recoil: 170
 		RecoilRecovery: 42
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: MammothMissiles
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -100, 100
 		Recoil: 42
+		MuzzleSequence: muzzle
 	AttackTurreted:
-	WithMuzzleFlash@PRIMARY:
+	WithMuzzleFlash:
 	RenderUnit:
 	WithTurret:
 	AutoTarget:

--- a/mods/d2k/rules/harkonnen.yaml
+++ b/mods/d2k/rules/harkonnen.yaml
@@ -190,6 +190,7 @@ DEVAST:
 	Armament:
 		Weapon: DevBullet
 		LocalOffset: 256,0,32
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleFlash:
 	AutoTarget:

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -172,6 +172,7 @@ RAIDER:
 	Armament:
 		Weapon: HMGo
 		LocalOffset: 256,0,128
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	AutoTarget:
 	Explodes:
@@ -206,6 +207,7 @@ STEALTHRAIDER:
 	Armament:
 		Weapon: HMGo
 		LocalOffset: 256,0,128
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	Explodes:
 		Weapon: UnitExplodeTiny

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -471,6 +471,7 @@ WALL:
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 448,0,128
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	AutoTarget:
 	RenderDetectionCircle:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -130,6 +130,7 @@ TRIKE:
 	Armament:
 		Weapon: HMG
 		LocalOffset: -416,0,0
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	AutoTarget:
 	Explodes:
@@ -218,6 +219,7 @@ QUAD.starport:
 		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -267,6 +269,7 @@ SIEGETANK:
 		Recoil: 150
 		RecoilRecovery: 19
 		LocalOffset: 512,0,320
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleFlash:
 	RenderUnit:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -147,10 +147,12 @@ YAK:
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
 		LocalOffset: 256,-213,0
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun.Yak
 		LocalOffset: 256,213,0
+		MuzzleSequence: muzzle
 	AttackPlane:
 		FacingTolerance: 20
 	Plane:
@@ -171,9 +173,7 @@ YAK:
 		ReloadTicks: 11
 	IronCurtainable:
 	ReturnOnIdle:
-	WithMuzzleFlash@PRIMARY:
-	WithMuzzleFlash@SECONDARY:
-		Armament: secondary
+	WithMuzzleFlash:
 	Contrail:
 		Offset: -853,0,0
 	LeavesHusk:
@@ -295,10 +295,12 @@ HIND:
 	Armament@PRIMARY:
 		Weapon: ChainGun
 		LocalOffset: 85,-213,-85
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun
 		LocalOffset: 85,213,-85
+		MuzzleSequence: muzzle
 	AttackHeli:
 		FacingTolerance: 20
 	Helicopter:
@@ -321,9 +323,7 @@ HIND:
 	IronCurtainable:
 	Selectable:
 		Bounds: 38,32,0,0
-	WithMuzzleFlash@PRIMARY:
-	WithMuzzleFlash@SECONDARY:
-		Armament: secondary
+	WithMuzzleFlash:
 	LeavesHusk:
 		HuskActor: HIND.Husk
 	SmokeTrailWhenDamaged:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -47,8 +47,12 @@ E1:
 		HP: 50
 	Mobile:
 		Speed: 56
-	Armament:
+	Armament@PRIMARY:
 		Weapon: M1Carbine
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: Vulcan
+		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -75,9 +79,13 @@ E2:
 		HP: 50
 	Mobile:
 		Speed: 71
-	Armament:
+	Armament@PRIMARY:
 		Weapon: Grenade
 		LocalOffset: 0,0,555
+		FireDelay: 15
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: Grenade
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
@@ -113,6 +121,9 @@ E3:
 	Armament@SECONDARY:
 		Weapon: Dragon
 		LocalOffset: 0,0,555
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: Dragon
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -139,10 +150,13 @@ E4:
 		HP: 40
 	Mobile:
 		Speed: 56
-	Armament:
+	Armament@PRIMARY:
 		Weapon: Flamer
 		LocalOffset: 427,0,341
 		FireDelay: 8
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: Flamer
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -252,6 +266,10 @@ E7:
 		Weapon: Colt45
 	Armament@SECONDARY:
 		Weapon: Colt45
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: Colt45
+		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -429,9 +447,12 @@ SHOK:
 		Speed: 56
 	RevealsShroud:
 		Range: 4c0
-	Armament:
+	Armament@PRIMARY:
 		Weapon: PortaTesla
 		LocalOffset: 427,0,341
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: PortaTesla
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:
@@ -465,8 +486,12 @@ SNIPER:
 		Range: 6c0
 	AutoTarget:
 		InitialStance: ReturnFire
-	Armament:
+	Armament@PRIMARY:
 		Weapon: Sniper
+	Armament@GARRISONED:
+		Name: garrisoned
+		Weapon: Sniper
+		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
 	-RenderInfantry:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -181,6 +181,7 @@ CA:
 		LocalOffset: 480,-100,40, 480,100,40
 		Recoil: 171
 		RecoilRecovery: 34
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Turret: secondary
@@ -188,10 +189,9 @@ CA:
 		LocalOffset: 480,-100,40, 480,100,40
 		Recoil: 171
 		RecoilRecovery: 34
+		MuzzleSequence: muzzle
 	AttackTurreted:
-	WithMuzzleFlash@PRIMARY:
-	WithMuzzleFlash@SECONDARY:
-		Armament: secondary
+	WithMuzzleFlash:
 	Selectable:
 		Bounds: 44,44
 	RenderUnit:
@@ -262,11 +262,13 @@ PT:
 	Armament@PRIMARY:
 		Weapon: 2Inch
 		LocalOffset: 208,0,48
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: DepthCharge
+		MuzzleSequence: muzzle
 	AttackTurreted:
-	WithMuzzleFlash@PRIMARY:
+	WithMuzzleFlash:
 	Selectable:
 		Bounds: 32,32
 	RenderUnit:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -351,6 +351,7 @@ AGUN:
 	Armament:
 		Weapon: ZSU-23
 		LocalOffset: 432,150,-30, 432,-150,-30
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:
@@ -624,6 +625,7 @@ HBOX.E1:
 	Armament:
 		Weapon: Vulcan
 		LocalOffset: 400,0,48
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	Cargo:
@@ -723,6 +725,7 @@ GUN:
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:
@@ -802,6 +805,7 @@ SAM:
 	RenderBuildingTurreted:
 	Armament:
 		Weapon: Nike
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	AutoTarget:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -401,9 +401,15 @@ DOME:
 PBOX:
 	Inherits: ^Building
 	Tooltip:
-		Name: Pillbox (Unarmed)
+		Name: Pillbox
 	Building:
 		Power: -15
+	Buildable:
+		Queue: Defense
+		BuildPaletteOrder: 20
+		Prerequisites: tent
+		Owner: allies
+		Hotkey: p
 	-GivesBuildableArea:
 	Valued:
 		Cost: 400
@@ -423,133 +429,67 @@ PBOX:
 		Types: Infantry
 		MaxWeight: 1
 		PipCount: 1
+		InitialUnits: e1
 	-EmitInfantryOnSell:
 	DrawLineToTarget:
-	TransformOnPassenger@e1:
-		PassengerTypes: e1
-		OnEnter: pbox.e1
-		OnExit: pbox
-		SkipMakeAnims: true
-	TransformOnPassenger@e3:
-		PassengerTypes: e3
-		OnEnter: pbox.e3
-		OnExit: pbox
-		SkipMakeAnims: true
-	TransformOnPassenger@e4:
-		PassengerTypes: e4
-		OnEnter: pbox.e4
-		OnExit: pbox
-		SkipMakeAnims: true
-	TransformOnPassenger@e7:
-		PassengerTypes: e7
-		OnEnter: pbox.e7
-		OnExit: pbox
-		SkipMakeAnims: true
-	TransformOnPassenger@SHOK:
-		PassengerTypes: shok
-		OnEnter: pbox.shok
-		OnExit: pbox
-		SkipMakeAnims: true
-	TransformOnPassenger@Sniper:
-		PassengerTypes: sniper
-		OnEnter: pbox.sniper
-		OnExit: pbox
-		SkipMakeAnims: true
+	AttackGarrisoned:
+		Armaments: garrisoned
+		PortOffsets: 384,0,128, 224,-341,128, -224,-341,128, -384,0,128, -224,341,128, 224,341,128
+		PortYaws: 0, 176, 341, 512, 682, 853
+		PortCones: 86, 86, 86, 86, 86, 86
+	RenderRangeCircle:
+		FallbackRange: 6c0
+	AutoTarget:
 
+# Legacy definitions to keep compatibility with outdated maps
 PBOX.E1:
 	Inherits: PBOX
+	-Buildable:
+	RenderBuilding:
+		Image: PBOX
+
+PBOX.E3:
+	Inherits: PBOX
+	-Buildable:
+	RenderBuilding:
+		Image: PBOX
+
+PBOX.E4:
+	Inherits: PBOX
+	-Buildable:
+	RenderBuilding:
+		Image: PBOX
+
+PBOX.E7:
+	Inherits: PBOX
+	-Buildable:
+	RenderBuilding:
+		Image: PBOX
+
+PBOX.SHOK:
+	Inherits: PBOX
+	-Buildable:
+	RenderBuilding:
+		Image: PBOX
+
+PBOX.SNIPER:
+	Inherits: PBOX
+	-Buildable:
+	RenderBuilding:
+		Image: PBOX
+
+HBOX:
+	Inherits: ^Building
+	Tooltip:
+		Name: Camo Pillbox
+	Building:
+		Power: -15
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 20
 		Prerequisites: tent
 		Owner: allies
-		Hotkey: p
-	Tooltip:
-		Name: Pillbox (Guns)
-		Description: Basic defensive structure.\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks, Aircraft
-	RenderBuilding:
-		Image: PBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Vulcan
-		LocalOffset: 384,0,88
-	AttackTurreted:
-	WithMuzzleFlash:
-	Cargo:
-		InitialUnits: e1
-
-PBOX.E3:
-	Inherits: PBOX
-	Tooltip:
-		Name: Pillbox (Rockets)
-	RenderBuilding:
-		Image: PBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Dragon
-		LocalOffset: 384,0,88
-	AttackTurreted:
-
-PBOX.E4:
-	Inherits: PBOX
-	Tooltip:
-		Name: Pillbox (Flamethrower)
-	RenderBuilding:
-		Image: PBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Flamer
-		LocalOffset: 384,0,88
-	AttackTurreted:
-
-PBOX.E7:
-	Inherits: PBOX
-	Tooltip:
-		Name: Pillbox (Tanya)
-	RenderBuilding:
-		Image: PBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Colt45
-		LocalOffset: 384,0,88
-	AttackTurreted:
-
-PBOX.SHOK:
-	Inherits: PBOX
-	Tooltip:
-		Name: Pillbox (Tesla)
-	RenderBuilding:
-		Image: PBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: PortaTesla
-		LocalOffset: 384,0,88
-	AttackTurreted:
-
-PBOX.SNIPER:
-	Inherits: PBOX
-	Tooltip:
-		Name: Pillbox (Sniper)
-	RenderBuilding:
-		Image: PBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Sniper
-		LocalOffset: 384,0,88
-	AttackTurreted:
-
-HBOX:
-	Inherits: ^Building
-	Tooltip:
-		Name: Camo Pillbox (Unarmed)
-	Building:
-		Power: -15
+		Hotkey: l
 	-GivesBuildableArea:
 	Valued:
 		Cost: 600
@@ -572,129 +512,56 @@ HBOX:
 		Types: Infantry
 		MaxWeight: 1
 		PipCount: 1
+		InitialUnits: e1
 	-EmitInfantryOnSell:
 	DrawLineToTarget:
-	TransformOnPassenger@e1:
-		PassengerTypes: e1
-		OnEnter: HBOX.e1
-		OnExit: HBOX
-		SkipMakeAnims: true
-	TransformOnPassenger@e3:
-		PassengerTypes: e3
-		OnEnter: HBOX.e3
-		OnExit: HBOX
-		SkipMakeAnims: true
-	TransformOnPassenger@e4:
-		PassengerTypes: e4
-		OnEnter: HBOX.e4
-		OnExit: HBOX
-		SkipMakeAnims: true
-	TransformOnPassenger@e7:
-		PassengerTypes: e7
-		OnEnter: HBOX.e7
-		OnExit: HBOX
-		SkipMakeAnims: true
-	TransformOnPassenger@SHOK:
-		PassengerTypes: shok
-		OnEnter: HBOX.shok
-		OnExit: HBOX
-		SkipMakeAnims: true
-	TransformOnPassenger@Sniper:
-		PassengerTypes: sniper
-		OnEnter: HBOX.sniper
-		OnExit: HBOX
-		SkipMakeAnims: true
 	DetectCloaked:
 		Range: 6
+	RenderRangeCircle:
+		FallbackRange: 6c0
+	AutoTarget:
+	AttackGarrisoned:
+		Armaments: garrisoned
+		PortOffsets: 384,0,128, 224,-341,128, -224,-341,128, -384,0,128, -224,341,128, 224,341,128
+		PortYaws: 0, 176, 341, 512, 682, 853
+		PortCones: 86, 86, 86, 86, 86, 86
 
+# Legacy definitions to keep compatibility with outdated maps
 HBOX.E1:
 	Inherits: HBOX
-	Buildable:
-		Queue: Defense
-		BuildPaletteOrder: 20
-		Prerequisites: tent
-		Owner: allies
-		Hotkey: l
-	Tooltip:
-		Name: Camo Pillbox (Guns)
-		Description: Hidden defensive structure.\nCan detect cloaked units.\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks, Aircraft
+	-Buildable:
 	RenderBuilding:
 		Image: HBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Vulcan
-		LocalOffset: 400,0,48
-		MuzzleSequence: muzzle
-	AttackTurreted:
-	WithMuzzleFlash:
-	Cargo:
-		InitialUnits: e1
 
 HBOX.E3:
 	Inherits: HBOX
-	Tooltip:
-		Name: Camo Pillbox (Rockets)
+	-Buildable:
 	RenderBuilding:
 		Image: HBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Dragon
-		LocalOffset: 400,0,48
-	AttackTurreted:
 
 HBOX.E4:
 	Inherits: HBOX
-	Tooltip:
-		Name: Camo Pillbox (Flamethrower)
+	-Buildable:
 	RenderBuilding:
 		Image: HBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Flamer
-		LocalOffset: 400,0,48
-	AttackTurreted:
 
 HBOX.E7:
 	Inherits: HBOX
-	Tooltip:
-		Name: Camo Pillbox (Tanya)
+	-Buildable:
 	RenderBuilding:
 		Image: HBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Colt45
-		LocalOffset: 400,0,48
-	AttackTurreted:
 
 HBOX.SHOK:
 	Inherits: HBOX
-	Tooltip:
-		Name: Camo Pillbox (Tesla)
+	-Buildable:
 	RenderBuilding:
 		Image: HBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: PortaTesla
-		LocalOffset: 400,0,48
-	AttackTurreted:
 
 HBOX.SNIPER:
 	Inherits: HBOX
-	Tooltip:
-		Name: Camo Pillbox (Sniper)
+	-Buildable:
 	RenderBuilding:
 		Image: HBOX
-	RenderRangeCircle:
-	AutoTarget:
-	Armament:
-		Weapon: Sniper
-		LocalOffset: 400,0,48
-	AttackTurreted:
 
 GUN:
 	Inherits: ^Building

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -55,6 +55,7 @@ V2RL:
 		Recoil: 85
 		RecoilRecovery: 25
 		LocalOffset: 768,0,90
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -95,6 +96,7 @@ V2RL:
 		Recoil: 128
 		RecoilRecovery: 38
 		LocalOffset: 720,0,80
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -137,6 +139,7 @@ V2RL:
 		Recoil: 128
 		RecoilRecovery: 38
 		LocalOffset: 768,85,90, 768,-85,90
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -181,14 +184,16 @@ V2RL:
 		LocalOffset: 900,180,340, 900,-180,340
 		Recoil: 171
 		RecoilRecovery: 30
+		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: MammothTusk
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -100,100
 		Recoil: 43
+		MuzzleSequence: muzzle
 	AttackTurreted:
-	WithMuzzleFlash@PRIMARY:
+	WithMuzzleFlash:
 	RenderUnit:
 	WithTurret:
 	AutoTarget:
@@ -230,6 +235,7 @@ ARTY:
 	Armament:
 		Weapon: 155mm
 		LocalOffset: 624,0,208
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -344,6 +350,7 @@ JEEP:
 		Offset: 0,0,85
 	Armament:
 		Weapon: M60mg
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -377,6 +384,7 @@ APC:
 	Armament:
 		Weapon: M60mg
 		LocalOffset: 0,0,171
+		MuzzleSequence: muzzle
 	AttackFrontal:
 	RenderUnit:
 	WithMuzzleFlash:
@@ -608,6 +616,7 @@ FTRK:
 		Weapon: FLAK-23
 		Recoil: 85
 		LocalOffset: 512,0,192
+		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
 	RenderUnit:
@@ -717,6 +726,7 @@ QTNK:
 	-EjectOnDeath:
 	TargetableUnit:
 		TargetTypes: Ground, MADTank
+
 STNK:
 	Inherits: ^Vehicle
 	Buildable:
@@ -761,3 +771,4 @@ STNK:
 		UncloakOnUnload: True
 	DetectCloaked:
 		Range: 6
+

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -64,6 +64,10 @@ e1:
 		Start: 0
 		Length: 6
 		Tick: 1600
+	garrison-muzzle: minigun
+		Start: 0
+		Length: 6
+		Facings: 8
 	icon: e1icon
 		Start: 0
 
@@ -132,6 +136,11 @@ sniper:
 		Start: 0
 		Length: 6
 		Tick: 1600
+	garrison-muzzle: minigun
+		Start: 0
+		Length: 3
+		Stride: 6
+		Facings: 8
 	icon: snipericon
 		Start: 0
 
@@ -643,6 +652,11 @@ e7:
 	prone-shoot:
 		Start: 176
 		Length: 7
+		Facings: 8
+	garrison-muzzle: minigun
+		Start: 0
+		Length: 3
+		Stride: 6
 		Facings: 8
 	icon: e7icon
 		Start: 0


### PR DESCRIPTION
This cleans up the Attack\* and muzzle flash code, and adds support for transports (including buildings) that let their passengers shoot through defined firing ports.

The RA pillboxes have been migrated to this new system.
Support for garrisoning civilian structures will be done in a future pr, as this will first need EffectiveOwner to be implemented uniformly through the engine.
