### PR TITLE
dedicated fix: do not restart anymore with 1 client

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -390,7 +390,7 @@ namespace OpenRA
 					{
 						System.Threading.Thread.Sleep(100);
 
-						if (server.State == Server.ServerState.GameStarted && server.Conns.Count <= 1)
+						if (server.State == Server.ServerState.GameStarted && server.Conns.Count < 1)
 						{
 							Console.WriteLine("No one is playing, shutting down...");
 							server.Shutdown();


### PR DESCRIPTION
Noticed that it does not work in latest bleed anymore (client gets "Connection dropped" dialog once server is closed), seem it relied on wrong behavior which has been fixed recently.
