### PR TITLE
Decrease Orca reload time

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -129,8 +129,8 @@ ORCA:
 		Ammo: 6
 		PipCount: 6
 	Reloads:
-		Count: 2
-		Period: 200
+		Count: 1
+		Period: 50
 	RenderUnit:
 	WithShadow:
 	LeavesHusk:


### PR DESCRIPTION
Orca was over-nerfed in a previous update. The amount of time needed to reload armament is currently extremely high. Brought it back down to reasonable level.
