### PR TITLE
Reduce range of Recon Bikes, Bazookas

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -257,7 +257,7 @@ M16:
 
 Rockets:
 	ROF: 50
-	Range: 6c0
+	Range: 5c0
 	Report: BAZOOK1.AUD
 	ValidTargets: Ground, Air
 	Projectile: Missile
@@ -287,7 +287,7 @@ Rockets:
 
 BikeRockets:
 	ROF: 50
-	Range: 6c0
+	Range: 5c0
 	Report: BAZOOK1.AUD
 	ValidTargets: Ground, Air
 	Burst: 2


### PR DESCRIPTION
Guard tower had its range reduced from 6 -> 5. I decreased range of Rockets and BikeRockets to match, to prevent Recon Bikes and E3s from easily outranging them and unbalancing the early game. 

I imagine that without this change, Bike rush will be too good and Nod strategy will mostly focus around it, making for repetitive gameplay.
