### PR TITLE
Isolate gameplay map state from the map cache.

### DIFF
--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -103,9 +103,11 @@ namespace OpenRA
 		{
 			LoadScreen.Display();
 
-			var map = MapCache[uid].Map;
-			if (map == null)
+			if (MapCache[uid].Status != MapStatus.Available)
 				throw new InvalidDataException("Invalid map uid: {0}".F(uid));
+
+			// Operate on a copy of the map to avoid gameplay state leaking into the cache
+			var map = new Map(MapCache[uid].Map.Path);
 
 			LoadTranslations(map);
 


### PR DESCRIPTION
Fixes #4937.
