### PR TITLE
Made husks targetable with force fire only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ NEW:
 			Added an Extras submenu for miscellaneous game extras.
 		Engineers can now regain control over husks.
 		Husks are now rendered with a black overlay.
+		Allow force fire to destroy husks.
 		A player's units, and allied units, now move out of the way when blocking production facilities.
 		Added cheat button to grow map resources.
 		Fixed units staying selected and contributing to control groups when becoming cloaked or hidden in fog.

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -85,6 +85,11 @@ namespace OpenRA.Traits
 			return true;
 		}
 
+		public bool RequiresForceFire
+		{
+			get { return targetable != null && targetable.RequiresForceFire; }
+		}
+
 		// Representative position - see Positions for the full set of targetable positions.
 		public WPos CenterPosition
 		{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -233,6 +233,7 @@ namespace OpenRA.Traits
 		string[] TargetTypes { get; }
 		IEnumerable<WPos> TargetablePositions(Actor self);
 		bool TargetableBy(Actor self, Actor byActor);
+		bool RequiresForceFire { get; }
 	}
 
 	public interface INotifyStanceChanged

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -199,6 +199,9 @@ namespace OpenRA.Mods.RA
 				if (modifiers.HasModifier(TargetModifiers.ForceMove))
 					return false;
 
+				if (target.RequiresForceFire)
+					return false;
+
 				var targetableRelationship = negativeDamage ? Stance.Ally : Stance.Enemy;
 
 				var owner = target.Type == TargetType.FrozenActor ? target.FrozenActor.Owner : target.Actor.Owner;

--- a/OpenRA.Mods.RA/TargetableBuilding.cs
+++ b/OpenRA.Mods.RA/TargetableBuilding.cs
@@ -18,8 +18,10 @@ namespace OpenRA.Mods.RA
 	public class TargetableBuildingInfo : ITraitInfo, ITargetableInfo, Requires<BuildingInfo>
 	{
 		public readonly string[] TargetTypes = { };
-
 		public string[] GetTargetTypes() { return TargetTypes; }
+
+		public bool RequiresForceFire = false;
+
 		public object Create(ActorInitializer init) { return new TargetableBuilding(init.self, this); }
 	}
 
@@ -41,5 +43,7 @@ namespace OpenRA.Mods.RA
 		{
 			return building.OccupiedCells().Select(c => c.First.CenterPosition);
 		}
+
+		public bool RequiresForceFire { get { return info.RequiresForceFire; } }
 	}
 }

--- a/OpenRA.Mods.RA/TargetableUnit.cs
+++ b/OpenRA.Mods.RA/TargetableUnit.cs
@@ -16,8 +16,10 @@ namespace OpenRA.Mods.RA
 	public class TargetableUnitInfo : ITraitInfo, ITargetableInfo
 	{
 		public readonly string[] TargetTypes = { };
-
 		public string[] GetTargetTypes() { return TargetTypes; }
+
+		public bool RequiresForceFire = false;
+
 		public virtual object Create(ActorInitializer init) { return new TargetableUnit(init.self, this); }
 	}
 
@@ -46,5 +48,7 @@ namespace OpenRA.Mods.RA
 		{
 			yield return self.CenterPosition;
 		}
+
+		public bool RequiresForceFire { get { return info.RequiresForceFire; } }
 	}
 }

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -514,6 +514,9 @@
 	Burns:
 		Interval: 2
 	TargetableUnit:
+		RequiresForceFire: yes
+		TargetTypes: Ground
+	AutoTargetIgnore:
 	Capturable:
 		Type: husk
 		AllowAllies: yes
@@ -542,6 +545,7 @@
 	Tooltip:
 		Name: Bridge
 	TargetableBuilding:
+		RequiresForceFire: yes
 		TargetTypes: Ground, Water
 	BelowUnits:
 	Health:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -98,6 +98,9 @@
 	BodyOrientation:
 	LuaScriptEvents:
 	TargetableUnit:
+		TargetTypes: Ground
+		RequiresForceFire: yes
+	AutoTargetIgnore:
 	Capturable:
 		Type: husk
 		AllowAllies: yes

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -430,6 +430,9 @@
 	Chronoshiftable:
 	LuaScriptEvents:
 	TargetableUnit:
+		TargetTypes: Ground
+		RequiresForceFire: yes
+	AutoTargetIgnore:
 	Capturable:
 		Type: husk
 		AllowAllies: yes
@@ -468,6 +471,7 @@
 	BelowUnits:
 	TargetableBuilding:
 		TargetTypes: Ground, Water
+		RequiresForceFire: yes
 	Building:
 		Footprint: ____ ____
 		Dimensions: 4,2


### PR DESCRIPTION
This is a remake of #3955 which allows force fire to kill husks without making the AI go crazy or annoy players in the height of the battle.
