### PR TITLE
Overhaul observer shroud selector.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,8 @@ NEW:
 		Order lines are now shown on unit selection.
 		Fixed chat synchronization in replays.
 		Added a combined shroud view of every player to the replay viewer and spectator mode.
-		Added pause, slowdown, play and fastforward buttons for replays.
+		Improved the observer/replay view selector with teams, factions, player colors, and hotkeys.
+		Added playback speed controls to replays.
 		Fixed the game sometimes crashing when deploying and activating the guard cursor at the same time.
 		Build time is now set when an item reaches the front of a queue, instead of immediately when queued.
 		The attack cursor now changes if the target is out of range.

--- a/OpenRA.Game/GameRules/Settings.cs
+++ b/OpenRA.Game/GameRules/Settings.cs
@@ -165,6 +165,9 @@ namespace OpenRA.GameRules
 		public Hotkey DeployKey = new Hotkey(Keycode.F, Modifiers.None);
 		public Hotkey StanceCycleKey = new Hotkey(Keycode.Z, Modifiers.None);
 		public Hotkey GuardKey = new Hotkey(Keycode.D, Modifiers.None);
+
+		public Hotkey ObserverCombinedView = new Hotkey(Keycode.MINUS, Modifiers.None);
+		public Hotkey ObserverWorldView = new Hotkey(Keycode.EQUALS, Modifiers.None);
 	}
 
 	public class IrcSettings

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -198,13 +198,7 @@ namespace OpenRA.Widgets
 		{
 			if (e.Event == KeyInputEvent.Down)
 			{
-				if (e.Key >= Keycode.NUMBER_0 && e.Key <= Keycode.NUMBER_9)
-				{
-					var group = (int)e.Key - (int)Keycode.NUMBER_0;
-					World.Selection.DoControlGroup(World, worldRenderer, group, e.Modifiers, e.MultiTapCount);
-					return true;
-				}
-				else if (Hotkey.FromKeyInput(e) == Game.Settings.Keys.PauseKey && World.LocalPlayer != null) // Disable pausing for spectators
+				if (Hotkey.FromKeyInput(e) == Game.Settings.Keys.PauseKey && World.LocalPlayer != null) // Disable pausing for spectators
 					World.SetPauseState(!World.Paused);
 				else if (Hotkey.FromKeyInput(e) == Game.Settings.Keys.SelectAllUnitsKey)
 				{

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -489,6 +489,7 @@
     <Compile Include="Widgets\Logic\LobbyMapPreviewLogic.cs" />
     <Compile Include="Widgets\Logic\ButtonTooltipLogic.cs" />
     <Compile Include="Orders\BeaconOrderGenerator.cs" />
+    <Compile Include="Widgets\LogicKeyListenerWidget.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -490,6 +490,7 @@
     <Compile Include="Widgets\Logic\ButtonTooltipLogic.cs" />
     <Compile Include="Orders\BeaconOrderGenerator.cs" />
     <Compile Include="Widgets\LogicKeyListenerWidget.cs" />
+    <Compile Include="Widgets\Logic\ControlGroupLogic.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/OpenRA.Mods.RA/Widgets/Logic/ControlGroupLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ControlGroupLogic.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.RA.Widgets.Logic
+{
+	public class ControlGroupLogic
+	{
+		[ObjectCreator.UseCtor]
+		public ControlGroupLogic(Widget widget, World world, WorldRenderer worldRenderer)
+		{
+			var keyhandler = widget.Get<LogicKeyListenerWidget>("CONTROLGROUP_KEYHANDLER");
+			keyhandler.OnKeyPress = e =>
+			{
+				if (e.Key >= Keycode.NUMBER_0 && e.Key <= Keycode.NUMBER_9)
+				{
+					var group = (int)e.Key - (int)Keycode.NUMBER_0;
+					world.Selection.DoControlGroup(world, worldRenderer, group, e.Modifiers, e.MultiTapCount);
+					return true;
+				}
+
+				return false;
+			};
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Widgets/Logic/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ObserverShroudSelectorLogic.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Network;
 using OpenRA.Widgets;
@@ -18,29 +19,33 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 {
 	public class ObserverShroudSelectorLogic
 	{
+		CameraOption selected;
+
 		class CameraOption
 		{
-			public string Label;
-			public Func<bool> IsSelected;
-			public Action OnClick;
+			public readonly string Label;
+			public readonly Color Color;
+			public readonly string Race;
+			public readonly Func<bool> IsSelected;
+			public readonly Action OnClick;
 
-			public CameraOption(string label, Func<bool> isSelected, Action onClick)
+			public CameraOption(ObserverShroudSelectorLogic logic, Player p)
+			{
+				Label = p.PlayerName;
+				Color = p.Color.RGB;
+				Race = p.Country.Race;
+				IsSelected = () => p.World.RenderPlayer == p;
+				OnClick = () => { p.World.RenderPlayer = p; logic.selected = this; };
+			}
+
+			public CameraOption(ObserverShroudSelectorLogic logic, World w, string label, Player p)
 			{
 				Label = label;
-				IsSelected = isSelected;
-				OnClick = onClick;
+				Color = Color.White;
+				Race = null;
+				IsSelected = () => w.RenderPlayer == p;
+				OnClick = () => { w.RenderPlayer = p; logic.selected = this; };
 			}
-		}
-
-		static string LabelForPlayer(Player p)
-		{
-			if (p == null)
-				return "Disable shroud";
-
-			if (p.InternalName == "Everyone")
-				return "Combined view";
-
-			return p.PlayerName;
 		}
 
 		[ObjectCreator.UseCtor]
@@ -54,33 +59,63 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			foreach (var t in teams)
 			{
-				var team = t.Select(p => new CameraOption(LabelForPlayer(p),
-					() => world.RenderPlayer == p,
-					() => world.RenderPlayer = p));
-
 				var label = noTeams ? "Players" : t.Key == 0 ? "No Team" : "Team {0}".F(t.Key);
-				groups.Add(label, team);
+				groups.Add(label, t.Select(p => new CameraOption(this, p)));
 			}
 
 			var combined = world.Players.First(p => p.InternalName == "Everyone");
+			var disableShroud = new CameraOption(this, world, "Disable Shroud", null);
 			groups.Add("Other", new List<CameraOption>()
 			{
-				new CameraOption(LabelForPlayer(combined), () => world.RenderPlayer == combined, () => world.RenderPlayer = combined),
-				new CameraOption(LabelForPlayer(null), () => world.RenderPlayer == null, () => world.RenderPlayer = null)
+				new CameraOption(this, world, "All Players", combined),
+				disableShroud
 			});
 
 			var shroudSelector = widget.Get<DropDownButtonWidget>("SHROUD_SELECTOR");
-			shroudSelector.GetText = () => LabelForPlayer(world.RenderPlayer);
 			shroudSelector.OnMouseDown = _ =>
 			{
 				Func<CameraOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
 				{
 					var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
-					item.Get<LabelWidget>("LABEL").GetText = () => option.Label;
+					var showFlag = option.Race != null;
+
+					var label = item.Get<LabelWidget>("LABEL");
+					label.IsVisible = () => showFlag;
+					label.GetText = () => option.Label;
+					label.GetColor = () => option.Color;
+
+					var flag = item.Get<ImageWidget>("FLAG");
+					flag.IsVisible = () => showFlag;
+					flag.GetImageCollection = () => "flags";
+					flag.GetImageName = () => option.Race;
+
+					var labelAlt = item.Get<LabelWidget>("NOFLAG_LABEL");
+					labelAlt.IsVisible = () => !showFlag;
+					labelAlt.GetText = () => option.Label;
+					labelAlt.GetColor = () => option.Color;
+
 					return item;
 				};
-				shroudSelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 400, groups, setupItem);
+
+				shroudSelector.ShowDropDown("SPECTATOR_DROPDOWN_TEMPLATE", 400, groups, setupItem);
 			};
+
+			var shroudLabel = shroudSelector.Get<LabelWidget>("LABEL");
+			shroudLabel.IsVisible = () => selected.Race != null;
+			shroudLabel.GetText = () => selected.Label;
+			shroudLabel.GetColor = () => selected.Color;
+
+			var shroudFlag = shroudSelector.Get<ImageWidget>("FLAG");
+			shroudFlag.IsVisible = () => selected.Race != null;
+			shroudFlag.GetImageCollection = () => "flags";
+			shroudFlag.GetImageName = () => selected.Race;
+
+			var shroudLabelAlt = shroudSelector.Get<LabelWidget>("NOFLAG_LABEL");
+			shroudLabelAlt.IsVisible = () => selected.Race == null;
+			shroudLabelAlt.GetText = () => selected.Label;
+			shroudLabelAlt.GetColor = () => selected.Color;
+
+			selected = disableShroud;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/Logic/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ObserverShroudSelectorLogic.cs
@@ -9,7 +9,9 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Network;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.RA.Widgets.Logic
@@ -32,18 +34,40 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		static string LabelForPlayer(Player p)
 		{
-			return p != null ? p.PlayerName == "Everyone" ? "Combined view" : "{0}'s view".F(p.PlayerName) : "World view";
+			if (p == null)
+				return "Disable shroud";
+
+			if (p.InternalName == "Everyone")
+				return "Combined view";
+
+			return p.PlayerName;
 		}
 
 		[ObjectCreator.UseCtor]
 		public ObserverShroudSelectorLogic(Widget widget, World world)
 		{
-			var views = world.Players.Where(p => (p.NonCombatant && p.Spectating)
-				|| !p.NonCombatant).Concat(new[] { (Player)null }).Select(
-					p => new CameraOption(LabelForPlayer(p),
-						() => world.RenderPlayer == p,
-						() => world.RenderPlayer = p
-				)).ToArray();
+			var groups = new Dictionary<string, IEnumerable<CameraOption>>();
+
+			var teams = world.Players.Where(p => !p.NonCombatant)
+				.GroupBy(p => (world.LobbyInfo.ClientWithIndex(p.ClientIndex) ?? new Session.Client()).Team).OrderBy(g => g.Key);
+			var noTeams = teams.Count() == 1;
+
+			foreach (var t in teams)
+			{
+				var team = t.Select(p => new CameraOption(LabelForPlayer(p),
+					() => world.RenderPlayer == p,
+					() => world.RenderPlayer = p));
+
+				var label = noTeams ? "Players" : t.Key == 0 ? "No Team" : "Team {0}".F(t.Key);
+				groups.Add(label, team);
+			}
+
+			var combined = world.Players.First(p => p.InternalName == "Everyone");
+			groups.Add("Other", new List<CameraOption>()
+			{
+				new CameraOption(LabelForPlayer(combined), () => world.RenderPlayer == combined, () => world.RenderPlayer = combined),
+				new CameraOption(LabelForPlayer(null), () => world.RenderPlayer == null, () => world.RenderPlayer = null)
+			});
 
 			var shroudSelector = widget.Get<DropDownButtonWidget>("SHROUD_SELECTOR");
 			shroudSelector.GetText = () => LabelForPlayer(world.RenderPlayer);
@@ -55,7 +79,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					item.Get<LabelWidget>("LABEL").GetText = () => option.Label;
 					return item;
 				};
-				shroudSelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", views.Length * 30, views, setupItem);
+				shroudSelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 400, groups, setupItem);
 			};
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -279,6 +279,12 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				{ "GuardKey", "Guard" }
 			};
 
+			var observerHotkeys = new Dictionary<string, string>()
+			{
+				{ "ObserverCombinedView", "All Players" },
+				{ "ObserverWorldView", "Disable Shroud" }
+			};
+
 			var gs = Game.Settings.Game;
 			var ks = Game.Settings.Keys;
 
@@ -302,6 +308,13 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			hotkeyList.AddChild(globalHeader);
 
 			foreach (var kv in specialHotkeys)
+				BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
+
+			var observerHeader = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
+			observerHeader.Get<LabelWidget>("LABEL").GetText = () => "Observer Commands";
+			hotkeyList.AddChild(observerHeader);
+
+			foreach (var kv in observerHotkeys)
 				BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
 
 			var unitHeader = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});

--- a/OpenRA.Mods.RA/Widgets/LogicKeyListenerWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/LogicKeyListenerWidget.cs
@@ -1,0 +1,25 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.RA.Widgets
+{
+	public class LogicKeyListenerWidget : Widget
+	{
+		public Func<KeyInput, bool> OnKeyPress = _ => false;
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			return OnKeyPress(e);
+		}
+	}
+}

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -64,6 +64,43 @@ ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 					Height:25
 					Align:Center
 
+ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
+	Width:DROPDOWN_WIDTH
+	Background:panel-black
+	Children:
+		ScrollItem@HEADER:
+			Width:PARENT_RIGHT-27
+			Height:13
+			X:2
+			Y:0
+			Visible:false
+			Children:
+				Label@LABEL:
+					Font:TinyBold
+					Width:PARENT_RIGHT
+					Height:10
+					Align:Center
+		ScrollItem@TEMPLATE:
+			Width:PARENT_RIGHT-27
+			Height:25
+			X:2
+			Y:0
+			Visible:false
+			Children:
+				Image@FLAG:
+					X:4
+					Y:4
+					Width:32
+					Height:16
+				Label@LABEL:
+					X:40
+					Width:60
+					Height:25
+				Label@NOFLAG_LABEL:
+					X:5
+					Width:PARENT_RIGHT
+					Height:25
+
 Container@CONFIRM_PROMPT:
 	X:(WINDOW_RIGHT - WIDTH)/2
 	Y:(WINDOW_BOTTOM - 90)/2

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -158,6 +158,20 @@ Container@OBSERVER_WIDGETS:
 			Width:168
 			Height:25
 			Font:Bold
+			Children:
+				Image@FLAG:
+					X:4
+					Y:4
+					Width:32
+					Height:16
+				Label@LABEL:
+					X:40
+					Width:60
+					Height:25
+				Label@NOFLAG_LABEL:
+					X:5
+					Width:PARENT_RIGHT
+					Height:25
 
 Container@PLAYER_WIDGETS:
 	Children:

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -175,6 +175,8 @@ Container@OBSERVER_WIDGETS:
 
 Container@PLAYER_WIDGETS:
 	Children:
+		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
+			Logic:ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:
 		WorldCommand:
 			Width:WINDOW_RIGHT

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -159,6 +159,7 @@ Container@OBSERVER_WIDGETS:
 			Height:25
 			Font:Bold
 			Children:
+				LogicKeyListener@SHROUD_KEYHANDLER:
 				Image@FLAG:
 					X:4
 					Y:4

--- a/mods/d2k/chrome/dropdowns.yaml
+++ b/mods/d2k/chrome/dropdowns.yaml
@@ -66,12 +66,12 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 			Visible:false
 			Children:
 				Image@FLAG:
+					Width:23
+					Height:23
 					X:4
-					Y:4
-					Width:32
-					Height:16
+					Y:2
 				Label@LABEL:
-					X:40
+					X:34
 					Width:60
 					Height:25
 				Label@NOFLAG_LABEL:

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -35,12 +35,12 @@ Container@OBSERVER_WIDGETS:
 					Font:Bold
 					Children:
 						Image@FLAG:
+							Width:23
+							Height:23
 							X:4
-							Y:4
-							Width:32
-							Height:16
+							Y:2
 						Label@LABEL:
-							X:40
+							X:34
 							Width:60
 							Height:25
 						Label@NOFLAG_LABEL:

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -34,6 +34,7 @@ Container@OBSERVER_WIDGETS:
 					Height:25
 					Font:Bold
 					Children:
+						LogicKeyListener@SHROUD_KEYHANDLER:
 						Image@FLAG:
 							Width:23
 							Height:23

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -1,5 +1,7 @@
 Container@PLAYER_WIDGETS:
 	Children:
+		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
+			Logic:ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:
 		Button@INGAME_DIPLOMACY_BUTTON:
 			X:162

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -62,7 +62,7 @@ ChromeLayout:
 	mods/ra/chrome/ingame-diplomacy.yaml
 	mods/ra/chrome/ingame-fmvplayer.yaml
 	mods/ra/chrome/ingame-menu.yaml
-	mods/ra/chrome/ingame-observer.yaml
+	mods/d2k/chrome/ingame-observer.yaml
 	mods/ra/chrome/ingame-observerstats.yaml
 	mods/d2k/chrome/ingame-player.yaml
 	mods/d2k/chrome/mainmenu.yaml
@@ -79,7 +79,7 @@ ChromeLayout:
 	mods/ra/chrome/connection.yaml
 	mods/ra/chrome/directconnect.yaml
 	mods/ra/chrome/replaybrowser.yaml
-	mods/ra/chrome/dropdowns.yaml
+	mods/d2k/chrome/dropdowns.yaml
 	mods/ra/chrome/modchooser.yaml
 	mods/ra/chrome/cheats.yaml
 	mods/ra/chrome/musicplayer.yaml

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -34,6 +34,7 @@ Container@OBSERVER_WIDGETS:
 					Height:25
 					Font:Bold
 					Children:
+						LogicKeyListener@SHROUD_KEYHANDLER:
 						Image@FLAG:
 							X:4
 							Y:4

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -1,5 +1,7 @@
 Container@PLAYER_WIDGETS:
 	Children:
+		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
+			Logic:ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:
 		Button@INGAME_DIPLOMACY_BUTTON:
 			X:162


### PR DESCRIPTION
The list is now divided into teams, and includes faction and color.
This adds hotkeys (replacing control groups for observers) of 0-9 to cycle teams (+shift to cycle in reverse), and -/= for combined/no shroud (these are configurable in the options).

![shroudview](https://f.cloud.github.com/assets/167819/2490406/a54e82aa-b1a7-11e3-95ab-798115334255.png)
