### PR TITLE
Fix missing ZOffset in FIX's damaged-idle sequence. Fixes #4954

### DIFF
--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -270,6 +270,7 @@ fix:
 		ZOffset: -1c511
 	damaged-idle:
 		Start: 7
+		ZOffset: -1c511
 	active:
 		Start: 0
 		Length: 7


### PR DESCRIPTION
As the title says.  I tested that it works as advertised and also looked at my replay, where the issue did not show up again either.
