### PR TITLE
Added LineBuildNode trait to filter which structure(s) a LineBuild actor can be attached to.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@ NEW:
 		Added the BLOXXMAS terrain tiles from the 1.06 patch.
 		Saboteur can now plant C4 on vehicles.
 		Added concrete plates and building weathering.
+		Walls will now extend themselves when placed in line with a turret.
 	Red Alert:
 		Engineers are now remapped to team colors.
 		Added some remap to the bottom edge of SAM sites.
@@ -138,6 +139,7 @@ NEW:
 		Maps can define initial cargo for actors by adding "Cargo: actora, actorb, ..." to the actor reference.
 		Modified Teleport activity to use the best/closest open cell to the target destination for teleports (for ChronoshiftPower this only applies on the return trip).
 		Renamed ChronoshiftDeploy trait to PortableChrono.
+		Added LineBuildNode trait to filter which structure(s) a LineBuild actor can be attached to.
 	Server:
 		Message of the day is now shared between all mods and a default motd.txt gets created in the user directory.
 	Asset Browser:

--- a/OpenRA.Mods.RA/Buildings/LineBuildNode.cs
+++ b/OpenRA.Mods.RA/Buildings/LineBuildNode.cs
@@ -13,15 +13,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Buildings
 {
-	[Desc("Place the second actor in line to build more of the same at once (used for walls).")]
-	public class LineBuildInfo : TraitInfo<LineBuild>
+	[Desc("LineBuild actors attach to LineBuildNodes.")]
+	public class LineBuildNodeInfo : TraitInfo<LineBuildNode>
 	{
-		[Desc("The maximum allowed length of the line.")]
-		public readonly int Range = 5;
-
-		[Desc("LineBuildNode 'Types' to attach to.")]
-		public readonly string[] NodeTypes = { "wall" };
+		[Desc("This actor is of LineBuild 'NodeType'...")]
+		public readonly string[] Types = { "wall" };
 	}
 
-	public class LineBuild {}
+	public class LineBuildNode {}
 }

--- a/OpenRA.Mods.RA/Buildings/Util.cs
+++ b/OpenRA.Mods.RA/Buildings/Util.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.RA.Buildings
 
 		public static IEnumerable<CPos> GetLineBuildCells(World world, CPos location, string name, BuildingInfo bi)
 		{
-			int range = Rules.Info[name].Traits.Get<LineBuildInfo>().Range;
+			var lbi = Rules.Info[name].Traits.Get<LineBuildInfo>();
 			var topLeft = location;	// 1x1 assumption!
 
 			if (world.IsCellBuildable(topLeft, bi))
@@ -54,17 +54,21 @@ namespace OpenRA.Mods.RA.Buildings
 			int[] dirs = { 0, 0, 0, 0 };
 			for (int d = 0; d < 4; d++)
 			{
-				for (int i = 1; i < range; i++)
+				for (int i = 1; i < lbi.Range; i++)
 				{
 					if (dirs[d] != 0)
 						continue;
 
-					CPos cell = topLeft + i * vecs[d];
+					var cell = topLeft + i * vecs[d];
 					if (world.IsCellBuildable(cell, bi))
 						continue; // Cell is empty; continue search
 
 					// Cell contains an actor. Is it the type we want?
-					if (world.ActorsWithTrait<LineBuild>().Any(a => (a.Actor.Info.Name == name && a.Actor.Location.X == cell.X && a.Actor.Location.Y == cell.Y)))
+					if (world.ActorsWithTrait<LineBuildNode>().Any(a =>
+					(
+						a.Actor.Location == cell &&
+						a.Actor.Info.Traits.Get<LineBuildNodeInfo>().Types.Intersect(lbi.NodeTypes).Any()
+					)))
 						dirs[d] = i; // Cell contains actor of correct type
 					else
 						dirs[d] = -1; // Cell is blocked by another actor type

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -490,6 +490,7 @@
     <Compile Include="Orders\BeaconOrderGenerator.cs" />
     <Compile Include="Widgets\LogicKeyListenerWidget.cs" />
     <Compile Include="Widgets\Logic\ControlGroupLogic.cs" />
+    <Compile Include="Buildings\LineBuildNode.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.FileFormats\OpenRA.FileFormats.csproj">

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -447,6 +447,9 @@
 		CrushSound: sandbag2.aud
 	LineBuild:
 		Range: 8
+		NodeTypes: wall
+	LineBuildNode:
+		Types: wall
 	RenderBuildingWall:
 		HasMakeAnimation: false
 		Palette: staticterrain

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -726,6 +726,11 @@ SBAG:
 		HP: 100
 	Armor:
 		Type: Light
+	LineBuild:
+		Range: 8
+		NodeTypes: sandbag
+	LineBuildNode:
+		Types: sandbag
 
 CYCL:
 	Inherits: ^Wall
@@ -745,6 +750,11 @@ CYCL:
 		HP: 100
 	Armor:
 		Type: Light
+	LineBuild:
+		Range: 8
+		NodeTypes: chain
+	LineBuildNode:
+		Types: chain
 
 BRIK:
 	Inherits: ^Wall
@@ -769,6 +779,11 @@ BRIK:
 		-CrushSound:
 	SoundOnDamageTransition:
 		DestroyedSound: crumble.aud
+	LineBuild:
+		Range: 8
+		NodeTypes: concrete
+	LineBuildNode:
+		Types: concrete
 
 BARRACKS:
 	Tooltip:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -412,6 +412,9 @@ CONCRETEB:
 		CrushClasses: Concretewall
 	LineBuild:
 		Range: 8
+		NodeTypes: wall, turret
+	LineBuildNode:
+		Types: wall
 	TargetableBuilding:
 		TargetTypes: Ground
 	RenderBuildingWall:
@@ -478,6 +481,8 @@ WALL:
 	DetectCloaked:
 		Range: 5
 	-WithCrumbleOverlay:
+	LineBuildNode:
+		Types: turret
 
 ^ROCKETTOWER:
 	Inherits: ^Building
@@ -527,6 +532,8 @@ WALL:
 	DetectCloaked:
 		Range: 6
 	-WithCrumbleOverlay:
+	LineBuildNode:
+		Types: turret
 
 ^REPAIR:
 	Inherits: ^Building

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -287,6 +287,9 @@
 		CrushClasses: wall
 	LineBuild:
 		Range: 8
+		NodeTypes: wall
+	LineBuildNode:
+		Types: wall
 	TargetableBuilding:
 		TargetTypes: Ground, DetonateAttack
 	RenderBuildingWall:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1355,6 +1355,11 @@ SBAG:
 		HP: 300
 	Armor:
 		Type: Wood
+	LineBuild:
+		Range: 8
+		NodeTypes: sandbag
+	LineBuildNode:
+		Types: sandbag
 
 FENC:
 	Inherits: ^Wall
@@ -1375,6 +1380,11 @@ FENC:
 		HP: 300
 	Armor:
 		Type: Wood
+	LineBuild:
+		Range: 8
+		NodeTypes: fence
+	LineBuildNode:
+		Types: fence
 
 BRIK:
 	Inherits: ^Wall
@@ -1400,6 +1410,11 @@ BRIK:
 		Type: Concrete
 	Wall:
 		CrushClasses: heavywall
+	LineBuild:
+		Range: 8
+		NodeTypes: concrete
+	LineBuildNode:
+		Types: concrete
 
 CYCL:
 	Inherits: ^Wall

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -159,6 +159,9 @@
 		CrushClasses: wall
 	LineBuild:
 		Range: 8
+		NodeTypes: wall
+	LineBuildNode:
+		Types: wall
 	SelectionDecorations:
 	Selectable:
 		Priority: 1


### PR DESCRIPTION
D2k walls now attach to turrets.
This has been requested and serves as an example for this trait pair.

In this example the Sandbag `SBAG` will LineBuild onto itself and the `SOMEDEF` actor definition.
You can see how this can be used for very generic or specific cases.

``` yaml
SBAG:
    LineBuild:
        NodeTypes: sbag, chicken
    LineBuildNode:
        Types: sbag

SOMEDEF:
    LineBuildNode:
        Types: chicken
```

Don't forget to include the `Range: <int>` property on the LineBuild trait!
