### PR TITLE
Added checks for valid targets to C4 demolition

### DIFF
--- a/OpenRA.Mods.RA/C4Demolition.cs
+++ b/OpenRA.Mods.RA/C4Demolition.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.RA
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
 				// TODO: Bridges don't yet support FrozenUnderFog.
-				if (target.Actor.HasTrait<BridgeHut>())
+				if (target.Actor != null && target.Actor.HasTrait<BridgeHut>())
 					return false;
 
 				return true;


### PR DESCRIPTION
Try to catch `target == null` cases as described in https://github.com/OpenRA/OpenRA/issues/4975#issuecomment-39081921
