### PR TITLE
Allow Chinook to land in tiberium

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -16,7 +16,7 @@ TRAN:
 		ROT: 5
 		Speed: 140
 		InitialFacing: 0
-		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach
+		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Tiberium,BlueTiberium
 	Health:
 		HP: 90
 	Armor:


### PR DESCRIPTION
Seems to not make sense that it can't land in tiberium, especially since Chem Troopers can walk through it undamaged, and since tiberium is not quite as deadly in recent patches.
