### PR TITLE
Fix Gem Mine footprint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -96,6 +96,7 @@ NEW:
 		Added Minibibs for bibless buildings.
 		Fixed Small portion of Production tab on Right side was unresponsive
 		Fixed unclickable area on the right edge of the production palette.
+		Fixed Gem Mines having an incorrect land footprint.
 	Tiberian Dawn:
 		Engineers can now regain control over husks.
 		Chinook rotors now counter-rotate.

--- a/mods/ra/rules/trees.yaml
+++ b/mods/ra/rules/trees.yaml
@@ -179,8 +179,8 @@ RAILMINE:
 	RenderBuilding:
 		Palette: terrain
 	Building:
-		Footprint: _x
-		Dimensions: 1,2
+		Footprint: xx
+		Dimensions: 2,1
 	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Gems


### PR DESCRIPTION
Fixes the gem mine's footprint.

1st pic - how it appears in editor
2nd pic - before patch
3rd pic - after patch
![footprints](https://cloud.githubusercontent.com/assets/566742/2623281/cb6e9b30-bce4-11e3-81e7-0a2f16aeabec.png)

Also looks like trees might not be right either.
