### PR TITLE
make sniper not target buildings, vehicles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -98,6 +98,7 @@ NEW:
 		Fixed unclickable area on the right edge of the production palette.
 		Fixed Gem Mines having an incorrect land footprint.
 	Tiberian Dawn:
+		Snipers can no longer shoot at vehicles and buildings.
 		Engineers can now regain control over husks.
 		Chinook rotors now counter-rotate.
 		Commando can now plant C4 on bridges.

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -159,9 +159,9 @@ Sniper:
 		Spread: 42
 		Versus:
 			None: 100%
-			Wood: 5%
-			Light: 5%
-			Heavy: 5%
+			Wood: 0%
+			Light: 0%
+			Heavy: 0%
 		InfDeath: 2
 
 HighV:


### PR DESCRIPTION
Sniper currently shoots at buildings when auto-attacking. This seems kind of wrong, given that he can blow them up with a C4 charge.

Sniper is probably also wasting his ammo by shooting at vehicles when the enemy is a mix of vehicles + infantry. Since the Sniper costs $1000, you would want him to kill some infantry before dying, to get your money's worth.

Part of the reason proposed change is that sniper is not useful when fighting a mix of vehicles + infantry (e.g. end-game light tanks + chem warriors). Sniper might be helpful in a mix, but currently wastes a lot of its ammo on vehicles, making it definitely not worth the money.
