### PR TITLE
Restrict commando weapon to infantry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -125,6 +125,7 @@ NEW:
 		The Construction Yard fans now turn in the color picker preview.
 		The chance of artillery exploding on death has been reduced from 100% to 75%.
 		Fixed Chinook being unable to land on tiberium.
+		Commando will no longer shoot at vehicles or buildings.
 	Engine:
 		Converted Aircraft CruiseAltitude to world coordinates.
 		Converted Health Radius to world coordinates.

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -14,7 +14,7 @@
 	Selectable:
 		Voice: VehicleVoice
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Vehicle
 	Buildable:
 		Queue: Vehicle
 	Repairable:
@@ -59,7 +59,7 @@
 	Selectable:
 		Voice: VehicleVoice
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Vehicle
 	Buildable:
 		Queue: Vehicle
 	Repairable:
@@ -149,7 +149,7 @@
 	Selectable:
 		Voice: GenericVoice
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Infantry
 	Buildable:
 		Queue: Infantry
 	TakeCover:
@@ -243,7 +243,7 @@
 	Selectable:
 		Voice: DinoVoice
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Infantry
 	HiddenUnderFog:
 	GivesExperience:
 	RenderInfantry:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -133,11 +133,6 @@ IonCannon:
 		Damage: 900
 		Spread: 682
 		Ore: true
-		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 100%
-			Heavy: 100%
 		InfDeath: 5
 	Warhead@area:
 		DamageModel: PerCell

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -150,6 +150,7 @@ IonCannon:
 
 Sniper:
 	Report: RAMGUN2.AUD
+	ValidTargets: Infantry
 	ROF: 40
 	Range: 6c0
 	Projectile: Bullet
@@ -157,11 +158,6 @@ Sniper:
 	Warhead:
 		Damage: 100
 		Spread: 42
-		Versus:
-			None: 100%
-			Wood: 5%
-			Light: 5%
-			Heavy: 5%
 		InfDeath: 2
 
 HighV:


### PR DESCRIPTION
This matches the fix we did to Tanya a while back.
Supersedes #5060.
