### PR TITLE
Superweapon tweaks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@ NEW:
 		Added a warning dialog when force starting a match.
 		Added a new mod selection window, which now appears on the first game start.
 		Fixed walls not updating when neighboring sections were sold or destroyed.
+		Nuclear missile delay is now independent of map size, and reveals the target area immediately before detonation.
 	Dune 2000:
 		Engineers can now regain control over husks.
 		Added the Atreides grenadier from the 1.06 patch.
@@ -46,6 +47,7 @@ NEW:
 		Turrets now integrate with walls (visually, and as line building targets).
 		Fixed unclickable area on the right edge of the production palette.
 		Buildings now throw damaging shrapnel when they explode.
+		Airstrike will now reveal (only) the target area when it strikes.
 	Red Alert:
 		Mechanics can now regain control over husks.
 		Engineers are now remapped to team colors.
@@ -109,7 +111,7 @@ NEW:
 		Removed health bars and selection boxes from walls.
 		Changed Nod Obelisk HP to 600 from 400, same as Advanced Guard Tower
 		Fixed dinosaurs not being able to collect crates.
-		A10 air strike will only reveal the target area.
+		A10 air strike and the ion cannon will now reveal (only) the target area when they strike.
 		Reduced Guard Tower vision from 7 to 6.
 		Increased Guard Tower build time from 12 seconds to 24 seconds.
 		Reduced Gun Turret vision from 7 to 6.

--- a/OpenRA.Mods.Cnc/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/IonCannonPower.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -10,11 +10,21 @@
 
 using OpenRA.Mods.Cnc.Effects;
 using OpenRA.Mods.RA;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Primitives;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc
 {
 	class IonCannonPowerInfo : SupportPowerInfo
 	{
+		[ActorReference]
+		[Desc("Actor to spawn when the attack starts")]
+		public readonly string CameraActor = null;
+
+		[Desc("Amount of time to keep the camera alive")]
+		public readonly int CameraRemoveDelay = 25;
+
 		public override object Create(ActorInitializer init) { return new IonCannonPower(init.self, this); }
 	}
 
@@ -34,8 +44,21 @@ namespace OpenRA.Mods.Cnc
 
 			self.World.AddFrameEndTask(w =>
 			{
+				var info = Info as IonCannonPowerInfo;
 				Sound.Play(Info.LaunchSound, order.TargetLocation.CenterPosition);
 				w.Add(new IonCannon(self, w, order.TargetLocation));
+
+				if (info.CameraActor == null)
+					return;
+
+				var camera = w.CreateActor(info.CameraActor, new TypeDictionary
+				{
+					new LocationInit(order.TargetLocation),
+					new OwnerInit(self.Owner),
+				});
+
+				camera.QueueActivity(new Wait(info.CameraRemoveDelay));
+				camera.QueueActivity(new RemoveSelf());
 			});
 		}
 	}

--- a/OpenRA.Mods.RA/Effects/Beacon.cs
+++ b/OpenRA.Mods.RA/Effects/Beacon.cs
@@ -44,7 +44,8 @@ namespace OpenRA.Mods.RA.Effects
 				poster.Play(posterType);
 			}
 
-			owner.World.Add(new DelayedAction(duration, () => owner.World.Remove(this)));
+			if (duration > 0)
+				owner.World.Add(new DelayedAction(duration, () => owner.World.Remove(this)));
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -8,7 +8,11 @@
  */
 #endregion
 
+using System;
+using OpenRA.Effects;
+using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Effects;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
@@ -18,6 +22,15 @@ namespace OpenRA.Mods.RA
 		[WeaponReference]
 		public readonly string MissileWeapon = "";
 		public readonly WVec SpawnOffset = WVec.Zero;
+
+		[Desc("Travel time - split equally between ascent and descent")]
+		public readonly int FlightDelay = 400;
+
+		[Desc("Visual ascent velocity in WRange / tick")]
+		public readonly WRange FlightVelocity = new WRange(512);
+
+		[Desc("Descend immediately on the target, with half the FlightDelay")]
+		public readonly bool SkipAscent = false;
 
 		public override object Create(ActorInitializer init) { return new NukePower(init.self, this); }
 	}
@@ -50,8 +63,11 @@ namespace OpenRA.Mods.RA
 			var npi = Info as NukePowerInfo;
 			var rb = self.Trait<RenderSimple>();
 			rb.PlayCustomAnim(self, "active");
-			self.World.AddFrameEndTask(w => w.Add(
-				new NukeLaunch(self.Owner, self, npi.MissileWeapon, self.CenterPosition + body.LocalToWorld(npi.SpawnOffset), order.TargetLocation)));
+
+			self.World.AddFrameEndTask(w => w.Add(new NukeLaunch(self, npi.MissileWeapon,
+				self.CenterPosition + body.LocalToWorld(npi.SpawnOffset),
+				order.TargetLocation.CenterPosition,
+				npi.FlightVelocity, npi.FlightDelay, npi.SkipAscent)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -32,6 +32,9 @@ namespace OpenRA.Mods.RA
 		[Desc("Descend immediately on the target, with half the FlightDelay")]
 		public readonly bool SkipAscent = false;
 
+		[Desc("Amount of time before detonation to remove the beacon")]
+		public readonly int BeaconRemoveAdvance = 25;
+
 		[ActorReference]
 		[Desc("Actor to spawn before detonation")]
 		public readonly string CameraActor = null;
@@ -92,6 +95,17 @@ namespace OpenRA.Mods.RA
 
 				Action addCamera = () => self.World.AddFrameEndTask(w => w.Add(camera));
 				self.World.AddFrameEndTask(w => w.Add(new DelayedAction(npi.FlightDelay - npi.CameraSpawnAdvance, addCamera)));
+			}
+
+			if (beacon != null)
+			{
+				Action removeBeacon = () => self.World.AddFrameEndTask(w =>
+				{
+					w.Remove(beacon);
+					beacon = null;
+				});
+
+				self.World.AddFrameEndTask(w => w.Add(new DelayedAction(npi.FlightDelay - npi.BeaconRemoveAdvance, removeBeacon)));
 			}
 		}
 	}

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -972,6 +972,11 @@ Rules:
 			SelectTargetSound: select1.aud
 			IncomingSound: enemya.aud
 			UnitType: a10
+			DisplayBeacon: True
+			BeaconDuration: -1
+			BeaconPoster: airstrike
+			DisplayRadarPing: True
+			CameraActor: camera
 
 Sequences:
 

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -49,7 +49,14 @@ CAMERA:
 		HP: 1000
 	RevealsShroud:
 		Range: 10c0
-	ProximityCaptor:
-		Types: Camera
+	BodyOrientation:
+
+CAMERA.small:
+	Immobile:
+		OccupiesSpace: false
+	Health:
+		HP: 1000
+	RevealsShroud:
+		Range: 6c0
 	BodyOrientation:
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -499,6 +499,7 @@ TMPL:
 		DisplayBeacon: True
 		BeaconPoster: atomic
 		DisplayRadarPing: True
+		CameraActor: camera
 	SupportPowerChargeBar:
 
 GUN:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -498,6 +498,7 @@ TMPL:
 		IncomingSound: nuke1.aud
 		MissileWeapon: atomic
 		DisplayBeacon: True
+		BeaconDuration: -1
 		BeaconPoster: atomic
 		DisplayRadarPing: True
 		CameraActor: camera

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -456,6 +456,7 @@ EYE:
 		SelectTargetSound: select1.aud
 		InsufficientPowerSound: nopower1.aud
 		DisplayRadarPing: True
+		CameraActor: camera.small
 	SupportPowerChargeBar:
 
 TMPL:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -386,6 +386,7 @@ HQ:
 		IncomingSound: enemya.aud
 		UnitType: a10
 		DisplayBeacon: True
+		BeaconDuration: -1
 		BeaconPoster: airstrike
 		DisplayRadarPing: True
 		CameraActor: camera

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -101,8 +101,6 @@ ORNI.bomber:
 		HP: 100
 	Armor:
 		Type: Light
-	RevealsShroud:
-		Range: 10c0
 	Plane:
 		ROT: 5
 		Speed: 350

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -60,6 +60,7 @@ PALACEA:
 		UnitType: orni.bomber
 		SelectTargetSound:
 		DisplayBeacon: True
+		BeaconDuration: -1
 		CameraActor: camera
 	CanPowerDown:
 	DisabledOverlay:

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -59,6 +59,8 @@ PALACEA:
 		LongDesc: Ornithopter drops a load of parachuted\nbombs on your target
 		UnitType: orni.bomber
 		SelectTargetSound:
+		DisplayBeacon: True
+		CameraActor: camera
 	CanPowerDown:
 	DisabledOverlay:
 	RequiresPower:

--- a/mods/d2k/rules/harkonnen.yaml
+++ b/mods/d2k/rules/harkonnen.yaml
@@ -98,6 +98,7 @@ PALACEH:
 		SpawnOffset: -512,1c171,0
 		DisplayBeacon: True
 		DisplayRadarPing: True
+		CameraActor: camera
 	CanPowerDown:
 	DisabledOverlay:
 	RequiresPower:

--- a/mods/d2k/rules/harkonnen.yaml
+++ b/mods/d2k/rules/harkonnen.yaml
@@ -98,6 +98,7 @@ PALACEH:
 		SpawnOffset: -512,1c171,0
 		DisplayBeacon: True
 		DisplayRadarPing: True
+		BeaconDuration: -1
 		CameraActor: camera
 	CanPowerDown:
 	DisabledOverlay:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -115,3 +115,11 @@ SPICEBLOOM:
 		Terrain: Spice
 	BodyOrientation:
 
+CAMERA:
+	Immobile:
+		OccupiesSpace: false
+	Health:
+		HP: 1000
+	RevealsShroud:
+		Range: 8c0
+	BodyOrientation:

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -89,6 +89,7 @@ PALACEO:
 		UnitType: orni.bomber
 		SelectTargetSound:
 		DisplayBeacon: True
+		BeaconDuration: -1
 		CameraActor: camera
 	CanPowerDown:
 	DisabledOverlay:

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -88,6 +88,8 @@ PALACEO:
 		LongDesc: Ornithopter drops a load of parachuted\nbombs on your target
 		UnitType: orni.bomber
 		SelectTargetSound:
+		DisplayBeacon: True
+		CameraActor: camera
 	CanPowerDown:
 	DisabledOverlay:
 	RequiresPower:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -38,6 +38,7 @@ MSLO:
 		SpawnOffset: 0,427,0
 		DisplayTimer: True
 		DisplayBeacon: True
+		BeaconDuration: -1
 		DisplayRadarPing: True
 		BeaconPoster: atomicon
 		CameraActor: camera

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -40,6 +40,7 @@ MSLO:
 		DisplayBeacon: True
 		DisplayRadarPing: True
 		BeaconPoster: atomicon
+		CameraActor: camera
 	CanPowerDown:
 	RequiresPower:
 	DisabledOverlay:


### PR DESCRIPTION
- Ion cannon and nuke (TD+RA) will now reveal the shroud when they strike.
- Nuke launch -> detonate delay is now independent of map, and configurable by mods/maps.
- Nuke beacons now stick around until (just before) detonation.
