### PR TITLE
Revert removing TakeCover from Shock Trooper and make them Crushable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -64,8 +64,8 @@ NEW:
 		Tanya can now plant C4 on vehicles.
 		Decreased the cost of Mobile Radar Jammer from 1000 to 800.
 		Increased the hitpoints of Shock Trooper from 80 to 100.
+		Made Shock Trooper crushable by tanks/heavy vehicles.
 		Fixed Shock Trooper tooltip having the incorrect unit name.
-		Removed the TakeCover trait from Shock Trooper.
 		Parachute bomb air strike will reveal the whole target area.
 		Adjusted AA Guns to fire their guns alternately at a high fire rate, and added contrails to their bullets.
 		Decreased AA Gun ZSU-23 damage from 25 to 12.

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -484,10 +484,11 @@ SHOK:
 		Name: garrisoned
 		Weapon: PortaTesla
 	AttackFrontal:
-	RenderInfantry:
+	TakeCover:
+	-RenderInfantry:
+	RenderInfantryProne:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
-	-CrushableInfantry:
 
 SNIPER:
 	Inherits: ^Infantry


### PR DESCRIPTION
SHOK are too strong with this experimental change.
