### PR TITLE
Additions to Makefile for cleaning up OpenRA.Game/*.dll left-overs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ mods: mod_ra mod_cnc mod_d2k mod_ts
 all: dependencies core tools
 
 clean:
-	@-$(RM_F) *.exe *.dll *.mdb mods/**/*.dll mods/**/*.mdb *.resources
+	@-$(RM_F) *.exe *.dll ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
 	@-$(RM_R) ./*/obj ./*/bin
 
 distclean: clean


### PR DESCRIPTION
followup of https://github.com/OpenRA/OpenRA/pull/5089 after `git status` detected these:

```
        OpenRA.Game/ICSharpCode.SharpZipLib.dll
        OpenRA.Game/OpenRA.FileFormats.dll
        OpenRA.Game/OpenRA.FileFormats.dll.mdb
        OpenRA.Game/SharpFont.dll
        OpenRA.Game/Tao.OpenAl.dll
```
