### PR TITLE
Added ExplosionPalette and WaterExplosionPalette traits to Warheads

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -147,6 +147,7 @@ NEW:
 		Added HackyAI settings: ExcessPowerFactor, MinimumExcessPower, IdleBaseUnitsMaximum, RushAttackScanRadius, ProtectUnitScanRadius, RallyPointScanRadius. See the traits documentation for more information.
 		Added HitAnimPalette trait for LaserZap projectiles. Laser hit animations can now specify individual palettes. Defaults to effect palette.
 		Added RenderNameTag trait to show the player's name above an actor.
+		Added ExplosionPalette and WaterExplosionPalette traits to Warheads to allow custom explosion palettes. Defaults to effect palette.
 		Fixed performance issues with units pathing to naval transports.
 		Fixed unit moving to transports that have moved.
 		Updated shroud-based traits to use world units.

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -27,8 +27,12 @@ namespace OpenRA.GameRules
 		public readonly bool Ore = false;
 		[Desc("Explosion effect to use.")]
 		public readonly string Explosion = null;
+		[Desc("Palette to use for explosion effect.")]
+		public readonly string ExplosionPalette = "effect";
 		[Desc("Explosion effect on hitting water (usually a splash).")]
 		public readonly string WaterExplosion = null;
+		[Desc("Palette to use for effect on hitting water (usually a splash).")]
+		public readonly string WaterExplosionPalette = "effect";
 		[Desc("Type of smudge to apply to terrain.")]
 		public readonly string[] SmudgeType = { };
 		[Desc("Size of the explosion. provide 2 values for a ring effect (outer/inner).")]

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -41,9 +41,10 @@ namespace OpenRA.Mods.RA
 
 			var isWater = pos.Z == 0 && world.GetTerrainInfo(targetTile).IsWater;
 			var explosionType = isWater ? warhead.WaterExplosion : warhead.Explosion;
+			var explosionTypePalette = isWater ? warhead.WaterExplosionPalette : warhead.ExplosionPalette;
 
 			if (explosionType != null)
-				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, explosionType)));
+				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, explosionType, explosionTypePalette)));
 
 			Sound.Play(GetImpactSound(warhead, isWater), pos);
 

--- a/OpenRA.Mods.RA/Effects/Explosion.cs
+++ b/OpenRA.Mods.RA/Effects/Explosion.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -19,15 +19,17 @@ namespace OpenRA.Mods.RA.Effects
 		World world;
 		WPos pos;
 		CPos cell;
+		string palette;
 		Animation anim;
 
-		public Explosion(World world, WPos pos, string style)
+		public Explosion(World world, WPos pos, string sequence, string palette)
 		{
 			this.world = world;
 			this.pos = pos;
 			this.cell = pos.ToCPos();
+			this.palette = palette;
 			anim = new Animation("explosion");
-			anim.PlayThen(style, () => world.AddFrameEndTask(w => w.Remove(this)));
+			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
 		}
 
 		public void Tick(World world) { anim.Tick(); }
@@ -37,7 +39,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (world.FogObscures(cell))
 				return SpriteRenderable.None;
 
-			return anim.Render(pos, wr.Palette("effect"));
+			return anim.Render(pos, wr.Palette(palette));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Render/WithBuildingExplosion.cs
+++ b/OpenRA.Mods.RA/Render/WithBuildingExplosion.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -19,10 +19,11 @@ namespace OpenRA.Mods.RA.Render
 	{
 		public void Killed(Actor self, AttackInfo e)
 		{
+			//TODO: Make palette for this customizable as well
 			var bi = self.Info.Traits.Get<BuildingInfo>();
 			FootprintUtils.UnpathableTiles(self.Info.Name, bi, self.Location).Do(
 				t => self.World.AddFrameEndTask(
-					w => w.Add(new Explosion(w, t.CenterPosition, "building"))));
+					w => w.Add(new Explosion(w, t.CenterPosition, "building", "effect"))));
 		}
 	}
 }


### PR DESCRIPTION
This is needed for TS water splashes, for example (they use unit*.pal instead of anim.pal, converting them to anim.pal results in significant quality regression due to lack of compatible colors in anim.pal).

Defaults to "effect".

Currently there aren't any test cases in the shipping mods, but I tested this with custom versions of the RA and TS mods and it worked as intended.
