### PR TITLE
Nerfing guard towers & other balance changes

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -130,7 +130,7 @@ ORCA:
 		PipCount: 6
 	Reloads:
 		Count: 2
-		Period: 200
+		Period: 100
 	RenderUnit:
 	WithShadow:
 	LeavesHusk:

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -22,7 +22,7 @@ TRAN:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 8c0
+		Range: 10c0
 	RenderUnit:
 	WithRotor@PRIMARY:
 		Offset: -597,0,171

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -210,6 +210,7 @@ A10:
 		Weapon: Napalm
 		LocalOffset: 0,-256,-43, 0,256,-43
 	-Selectable:
+	-TargetableUnit:	
 	-GainsExperience:
 	FlyAwayOnIdle:
 	RejectsOrders:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -181,6 +181,8 @@
 	UpdatesPlayerStatistics:
 	Huntable:
 	LuaScriptEvents:
+	DetectCloaked:
+		Range: 1
 
 ^CivInfantry:
 	Inherits: ^Infantry

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -167,7 +167,7 @@
 	SpawnViceroid:
 		Probability: 10
 	CrushableInfantry:
-		WarnProbability: 60
+		WarnProbability: 67
 	CombatDebugOverlay:
 	Guard:
 	Guardable:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -137,7 +137,7 @@
 		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
-			Clear: 100
+			Clear: 90
 			Rough: 80
 			Road: 100
 			Tiberium: 70

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -141,9 +141,9 @@
 			Rough: 80
 			Road: 100
 			Tiberium: 70
-				PathingCost: 1000
+				PathingCost: 300
 			BlueTiberium: 70
-				PathingCost: 1000
+				PathingCost: 300
 			Beach: 80
 	SelectionDecorations:
 	Selectable:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -67,6 +67,8 @@ E3:
 		Speed: 42
 	Health:
 		HP: 45
+	AutoTarget:
+		ScanRadius: 5
 	Armament:
 		Weapon: Rockets
 		LocalOffset: 256,43,341

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -20,8 +20,6 @@ E1:
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2,idle3,idle4
 		StandAnimations: stand, stand2
-	DetectCloaked:
-		Range: 2
 
 E2:
 	Inherits: ^Infantry
@@ -52,8 +50,6 @@ E2:
 		Weapon: GrenadierExplode
 		EmptyWeapon: GrenadierExplode
 		Chance: 50
-	DetectCloaked:
-		Range: 2
 
 E3:
 	Inherits: ^Infantry
@@ -79,8 +75,6 @@ E3:
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
-	DetectCloaked:
-		Range: 2
 
 E4:
 	Inherits: ^Infantry
@@ -111,8 +105,6 @@ E4:
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
-	DetectCloaked:
-		Range: 2
 
 E5:
 	Inherits: ^Infantry
@@ -149,8 +141,6 @@ E5:
 	RenderInfantryProne:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
-	DetectCloaked:
-		Range: 2
 
 E6:
 	Inherits: ^Infantry
@@ -214,8 +204,6 @@ RMBO:
 		StandAnimations: stand, stand2
 	AnnounceOnBuild:
 	AnnounceOnKill:
-	DetectCloaked:
-		Range: 2
 
 PVICE:
 	Inherits: VICE

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -92,7 +92,7 @@ E4:
 	Selectable:
 		Bounds: 12,17,0,-6
 	Mobile:
-		Speed: 71
+		Speed: 56
 	Health:
 		HP: 90
 	Armament:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -124,10 +124,10 @@ E5:
 	Mobile:
 		Speed: 56
 		TerrainSpeeds:
-			Tiberium: 80
-				PathingCost: 80
-			BlueTiberium: 80
-				PathingCost: 80
+			Tiberium: 90
+				PathingCost: 90
+			BlueTiberium: 90
+				PathingCost: 90
 	Health:
 		HP: 90
 	Armament:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -571,7 +571,7 @@ SAM:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 5c0
+		Range: 8c0
 	Turreted:
 		ROT: 10
 		InitialFacing: 0

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -619,10 +619,10 @@ OBLI:
 	Armament:
 		Weapon: Laser
 		LocalOffset: 0,0,725
-		FireDelay: 25
+		FireDelay: 0
 	AttackCharge:
-		ReloadTime: 90
-		InitialChargeDelay: 25
+		ReloadTime: 40
+		InitialChargeDelay: 50
 	AutoTarget:
 	-RenderBuilding:
 	RenderRangeCircle:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -117,8 +117,8 @@ PROC:
 		TickRate: 15
 	StoresOre:
 		PipColor: Green
-		PipCount: 15
-		Capacity: 1500
+		PipCount: 10
+		Capacity: 2000
 	Selectable:
 		Bounds: 73,72
 	CustomSellValue:
@@ -157,7 +157,7 @@ SILO:
 	StoresOre:
 		PipCount: 10
 		PipColor: Green
-		Capacity: 2400
+		Capacity: 2000
 	Selectable:
 		Bounds: 49,30
 	-RenderBuilding:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -104,7 +104,7 @@ PROC:
 		Prerequisites: anypower
 		Owner: gdi,nod
 	Building:
-		Power: -30
+		Power: -50
 		Footprint: _x_ xxx ===
 		Dimensions: 3,3
 	Health:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -49,7 +49,7 @@ FACT:
 NUKE:
 	Inherits: ^Building
 	Valued:
-		Cost: 300
+		Cost: 500
 	Tooltip:
 		Name: Power Plant
 		Description: Generates power
@@ -72,7 +72,7 @@ NUKE:
 NUK2:
 	Inherits: ^Building
 	Valued:
-		Cost: 500
+		Cost: 800
 	Tooltip:
 		Name: Advanced Power Plant
 		Description: Provides more power, cheaper than the \nstandard Power Plant

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -634,7 +634,7 @@ OBLI:
 GTWR:
 	Inherits: ^Building
 	Valued:
-		Cost: 500
+		Cost: 600
 	CustomBuildTimeValue:
 		Value: 1440
 	Tooltip:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -122,7 +122,7 @@ PROC:
 	Selectable:
 		Bounds: 73,72
 	CustomSellValue:
-		Value: 300
+		Value: 500
 	FreeActor:
 		Actor: HARV
 		InitialActivity: FindResources

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -166,7 +166,7 @@ SILO:
 PYLE:
 	Inherits: ^Building
 	Valued:
-		Cost: 300
+		Cost: 500
 	Tooltip:
 		Name: Barracks
 		Description: Trains infantry
@@ -204,7 +204,7 @@ PYLE:
 HAND:
 	Inherits: ^Building
 	Valued:
-		Cost: 300
+		Cost: 500
 	Tooltip:
 		Name: Hand of Nod
 		Description: Trains infantry

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -372,7 +372,7 @@ HQ:
 	ProvidesRadar:
 	RenderDetectionCircle:
 	DetectCloaked:
-		Range: 8
+		Range: 5
 	AirstrikePower:
 		Icon: airstrike
 		ChargeTime: 180
@@ -445,7 +445,7 @@ EYE:
 	ProvidesRadar:
 	RenderDetectionCircle:
 	DetectCloaked:
-		Range: 8
+		Range: 5
 	IonCannonPower:
 		Icon: ioncannon
 		ChargeTime: 180
@@ -543,7 +543,7 @@ GUN:
 	RenderRangeCircle:
 	RenderDetectionCircle:
 	DetectCloaked:
-		Range: 5
+		Range: 3
 
 SAM:
 	Inherits: ^Building
@@ -629,7 +629,7 @@ OBLI:
 	-EmitInfantryOnSell:
 	RenderDetectionCircle:
 	DetectCloaked:
-		Range: 6
+		Range: 5
 
 GTWR:
 	Inherits: ^Building
@@ -663,7 +663,7 @@ GTWR:
 		QuantizedFacings: 8
 	AutoTarget:
 	DetectCloaked:
-		Range: 5
+		Range: 3
 	RenderDetectionCircle:
 	RenderRangeCircle:
 	WithMuzzleFlash:
@@ -712,7 +712,7 @@ ATWR:
 		QuantizedFacings: 8
 	RenderDetectionCircle:
 	DetectCloaked:
-		Range: 6
+		Range: 5
 	RenderRangeCircle:
 
 SBAG:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -64,7 +64,7 @@ NUKE:
 		Footprint: x_ xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 500
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -87,7 +87,7 @@ NUK2:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 650
+		HP: 700
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -327,7 +327,7 @@ HPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 500
 	RevealsShroud:
 		Range: 5c0
 	Exit@1:
@@ -365,7 +365,7 @@ HQ:
 	CanPowerDown:
 	DisabledOverlay:
 	Health:
-		HP: 750
+		HP: 700
 	RevealsShroud:
 		Range: 10c0
 	Bib:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -10,7 +10,7 @@ FACT:
 		Name: Construction Yard
 		Description: Builds structures
 	Building:
-		Power: 15
+		Power: 0
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -702,8 +702,12 @@ ATWR:
 	Turreted:
 		ROT: 255
 		Offset: 128,128,-85
-	Armament:
+	Armament@PRIMARY:
 		Weapon: TowerMissle
+		LocalOffset: 256,128,0, 256,-128,0
+		LocalYaw: -100,100
+	Armament@SECONDARY:
+		Weapon: SAMMissile
 		LocalOffset: 256,128,0, 256,-128,0
 		LocalYaw: -100,100
 	AttackTurreted:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -611,7 +611,7 @@ OBLI:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 7c0
+		Range: 8c0
 	Bib:
 		HasMinibib: Yes
 	RenderBuildingCharge:
@@ -651,7 +651,7 @@ GTWR:
 	Health:
 		HP: 400
 	RevealsShroud:
-		Range: 6c0
+		Range: 7c0
 	Bib:
 		HasMinibib: Yes
 	Armament:
@@ -696,7 +696,7 @@ ATWR:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 7c0
+		Range: 8c0
 	Bib:
 		HasMinibib: Yes
 	Turreted:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -30,7 +30,7 @@ FACT:
 		Type: Building
 		Group: Building
 		BuildSpeed: .4
-		LowPowerSlowdown: 3
+		LowPowerSlowdown: 2
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
 	ProductionQueue@Defense:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -320,7 +320,7 @@ HPAD:
 		Description: Produces, rearms and\nrepairs helicopters
 	Buildable:
 		BuildPaletteOrder: 60
-		Prerequisites: barracks
+		Prerequisites: proc
 		Owner: gdi,nod
 	Building:
 		Power: -10

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -137,7 +137,7 @@ ARTY:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 9c0
+		Range: 8c0
 	Armament:
 		Weapon: ArtilleryShell
 		LocalOffset: 624,0,208
@@ -209,7 +209,7 @@ BGGY:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 7c0
+		Range: 8c0
 	Turreted:
 		ROT: 10
 		Offset: -43,0,128
@@ -448,7 +448,7 @@ MSAM:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 10c0
+		Range: 8c0
 	Turreted:
 		ROT: 255
 		Offset: -256,0,128
@@ -485,7 +485,7 @@ MLRS:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 10c0
+		Range: 8c0
 	Turreted:
 		ROT: 8
 		Offset: -128,0,128

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -410,7 +410,7 @@ HTNK:
 		Weapon: MammothMissiles
 		LocalOffset: -85,384,340, -85,-384,340
 		LocalYaw: -100, 100
-		Recoil: 42
+		Recoil: 10
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -39,7 +39,7 @@ MCV:
 HARV:
 	Inherits: ^Tank
 	Valued:
-		Cost: 1200
+		Cost: 1000
 	Tooltip:
 		Name: Harvester
 		Description: Collects Tiberium for processing.\n  Unarmed

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -392,7 +392,7 @@ HTNK:
 		Speed: 56
 		ROT: 3
 	Health:
-		HP: 900
+		HP: 800
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -157,7 +157,7 @@ ARTY:
 FTNK:
 	Inherits: ^Tank
 	Valued:
-		Cost: 800
+		Cost: 600
 	Tooltip:
 		Name: Flame Tank
 		Description: Heavily armored flame-throwing vehicle.\n  Strong vs Infantry, Buildings, Vehicles\n  Weak vs Aircraft
@@ -169,9 +169,9 @@ FTNK:
 		ROT: 7
 		Speed: 113
 	Health:
-		HP: 350
+		HP: 300
 	Armor:
-		Type: Light
+		Type: Heavy
 	RevealsShroud:
 		Range: 5c0
 	Armament:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -54,8 +54,8 @@ HARV:
 		Resources: Tiberium, BlueTiberium
 		PipCount: 7
 		Capacity: 20
-		LoadTicksPerBale: 6
-		UnloadTicksPerBale: 12
+		LoadTicksPerBale: 12
+		UnloadTicksPerBale: 6
 		SearchFromProcRadius: 24
 		SearchFromOrderRadius: 12
 	Mobile:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -312,7 +312,7 @@ LTNK:
 		ROT: 7
 		Speed: 113
 	Health:
-		HP: 300
+		HP: 360
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -350,7 +350,7 @@ MTNK:
 	Mobile:
 		Speed: 85
 	Health:
-		HP: 400
+		HP: 450
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -202,7 +202,7 @@ BGGY:
 		Prerequisites: afld
 		Owner: nod
 	Mobile:
-		ROT: 12
+		ROT: 10
 		Speed: 170
 	Health:
 		HP: 120
@@ -237,7 +237,7 @@ BIKE:
 		Prerequisites: afld
 		Owner: nod
 	Mobile:
-		ROT: 12
+		ROT: 10
 		Speed: 213
 		TerrainSpeeds:
 			Clear: 70
@@ -274,7 +274,7 @@ JEEP:
 		Prerequisites: weap
 		Owner: gdi
 	Mobile:
-		ROT: 11
+		ROT: 10
 		Speed: 156
 	Health:
 		HP: 160
@@ -318,7 +318,7 @@ LTNK:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		ROT: 5
+		ROT: 7
 	Armament:
 		Weapon: 70mm
 		Recoil: 85
@@ -518,7 +518,7 @@ STNK:
 		Prerequisites: tmpl
 		Owner: nod
 	Mobile:
-		ROT: 8
+		ROT: 10
 		Speed: 142
 		Crushes: crate, infantry
 	Health:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -807,7 +807,7 @@ Napalm.Crate:
 		Damage: 500
 
 Laser:
-	ROF: 90
+	ROF: 1
 	Range: 7c512
 	Charges: true
 	Report: OBELRAY1.AUD

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -156,19 +156,19 @@ Sniper:
 		InfDeath: 2
 
 HighV:
-	ROF: 30
+	ROF: 25
 	Range: 6c0
 	Report: GUN8.AUD
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead:
-		Damage: 50
-		Spread: 128
+		Damage: 30
+		Spread: 683
 		Versus:
 			None: 100%
 			Wood: 50%
-			Light: 100%
-			Heavy: 25%
+			Light: 70%
+			Heavy: 35%
 		InfDeath: 2
 		Explosion: piffs
 
@@ -538,7 +538,7 @@ Grenade:
 		Damage: 40
 
 TurretGun:
-	ROF: 25
+	ROF: 20
 	Range: 6c0
 	Report: TNKFIRE6.AUD
 	Projectile: Bullet
@@ -547,15 +547,15 @@ TurretGun:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
+			None: 20%
 			Wood: 25%
-			Light: 80%
+			Light: 100%
 			Heavy: 100%
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
 		SmudgeType: Crater
-		Damage: 50
+		Damage: 40
 
 MammothMissiles:
 	ROF: 100
@@ -725,12 +725,10 @@ BoatMissile:
 		Damage: 60
 
 TowerMissle:
-	ROF: 24
-	Range: 8c0
+	ROF: 20
+	Range: 7c0
 	Report: ROCKET2.AUD
 	ValidTargets: Ground, Air
-	Burst: 2
-	BurstDelay: 16
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -743,17 +741,17 @@ TowerMissle:
 		Speed: 298
 		RangeLimit: 40
 	Warhead:
-		Spread: 512
+		Spread: 683
 		Versus:
-			None: 25%
+			None: 50%
 			Wood: 25%
 			Light: 100%
-			Heavy: 80%
+			Heavy: 100%
 		InfDeath: 3
 		Explosion: med_frag
 		ImpactSound: xplos.aud
 		SmudgeType: Crater
-		Damage: 45
+		Damage: 30
 
 Vulcan:
 	ValidTargets: Ground, Water
@@ -811,7 +809,7 @@ Napalm.Crate:
 
 Laser:
 	ROF: 90
-	Range: 8c512
+	Range: 7c512
 	Charges: true
 	Report: OBELRAY1.AUD
 	Projectile: LaserZap
@@ -827,7 +825,7 @@ Laser:
 
 SAMMissile:
 	ROF: 15
-	Range: 10c0
+	Range: 8c0
 	Report: ROCKET2.AUD
 	ValidTargets: Air
 	Projectile: Missile

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -558,11 +558,12 @@ TurretGun:
 		Damage: 40
 
 MammothMissiles:
-	ROF: 100
+	ROF: 45
 	Range: 5c0
 	Report: ROCKET1.AUD
 	ValidTargets: Ground, Air
 	Burst: 2
+	BurstDelay: 15
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -572,20 +573,20 @@ MammothMissiles:
 		ROT: 10
 		Trail: smokey
 		ContrailLength: 8
-		Speed: 213
+		Speed: 341
 		RangeLimit: 35
 	Warhead:
-		Spread: 256
+		Spread: 298
 		Versus:
-			None: 40%
+			None: 50%
 			Wood: 75%
-			Light: 75%
+			Light: 100%
 			Heavy: 50%
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
 		SmudgeType: Crater
-		Damage: 75
+		Damage: 45
 
 227mm:
 	ROF: 140

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -894,7 +894,7 @@ Heal:
 		PreventProne: yes
 
 APCGun:
-	ROF: 12
+	ROF: 18
 	Range: 5c0
 	Report: gun20.aud
 	ValidTargets: Ground
@@ -903,15 +903,15 @@ APCGun:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 35%
+			None: 50%
 			Wood: 50%
 			Light: 100%
-			Heavy: 20%
+			Heavy: 50%
 		Explosion: small_poof
 		Damage: 15
 
 APCGun.AA:
-	ROF: 12
+	ROF: 18
 	Range: 7c0
 	Report: gun20.aud
 	ValidTargets: Air

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -406,7 +406,7 @@ Chemspray:
 		Spread: 256
 		Versus:
 			None: 100%
-			Wood: 75%
+			Wood: 50%
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 6

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -309,9 +309,9 @@ BikeRockets:
 		Damage: 30
 
 OrcaAGMissiles:
-	ROF: 15
+	ROF: 12
 	Burst: 2
-	BurstDelay: 15
+	BurstDelay: 12
 	Range: 5c0
 	Report: BAZOOK1.AUD
 	ValidTargets: Ground
@@ -332,7 +332,7 @@ OrcaAGMissiles:
 			None: 50%
 			Wood: 100%
 			Light: 100%
-			Heavy: 50%
+			Heavy: 75%
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -340,9 +340,9 @@ OrcaAGMissiles:
 		Damage: 25
 
 OrcaAAMissiles:
-	ROF: 15
+	ROF: 12
 	Burst: 2
-	BurstDelay: 15
+	BurstDelay: 12
 	Range: 5c0
 	Report: BAZOOK1.AUD
 	ValidTargets: Air
@@ -360,9 +360,7 @@ OrcaAAMissiles:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 50%
-			Wood: 100%
-			Light: 100%
+			Light: 75%
 			Heavy: 50%
 		InfDeath: 4
 		Explosion: small_frag

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -686,13 +686,13 @@ MachineGun:
 		Spread: 128
 		Versus:
 			None: 100%
-			Wood: 25%
-			Light: 75%
-			Heavy: 25%
+			Wood: 20%
+			Light: 50%
+			Heavy: 20%
 			Concrete: 10%
 		InfDeath: 2
 		Explosion: piffs
-		Damage: 10
+		Damage: 15
 
 BoatMissile:
 	ROF: 35

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -416,16 +416,16 @@ Chemspray:
 
 Grenade:
 	ROF: 50
-	Range: 5c0
+	Range: 4c0
 	Report: toss1.aud
 	Projectile: Bullet
-		Speed: 204
+		Speed: 85
 		High: yes
 		Angle: 62
 		Inaccuracy: 213
 		Image: BOMB
 	Warhead:
-		Spread: 256
+		Spread: 341
 		Versus:
 			None: 90%
 			Wood: 75%

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -640,7 +640,7 @@ MammothMissiles:
 		Spread: 128
 		Versus:
 			None: 35%
-			Wood: 50%
+			Wood: 75%
 			Light: 100%
 			Heavy: 90%
 		InfDeath: 4

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -311,7 +311,7 @@ OrcaAGMissiles:
 		ROT: 20
 		Trail: smokey
 		ContrailLength: 8
-		Speed: 213
+		Speed: 298
 		RangeLimit: 30
 	Warhead:
 		Spread: 128
@@ -342,7 +342,7 @@ OrcaAAMissiles:
 		ROT: 20
 		Trail: smokey
 		ContrailLength: 8
-		Speed: 213
+		Speed: 298
 		RangeLimit: 30
 	Warhead:
 		Spread: 128

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -878,11 +878,11 @@ HonestJohn:
 		Damage: 100
 
 Tiberium:
-	ROF: 12
+	ROF: 16
 	Warhead:
 		Spread: 42
 		InfDeath: 6
-		Damage: 1
+		Damage: 2
 		PreventProne: yes
 
 Heal:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -371,7 +371,7 @@ OrcaAAMissiles:
 		Damage: 25
 
 Flamethrower:
-	ROF: 50
+	ROF: 55
 	Range: 2c512
 	Report: FLAMER2.AUD
 	Projectile: Bullet
@@ -379,15 +379,15 @@ Flamethrower:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 90%
+			None: 100%
 			Wood: 100%
-			Light: 75%
-			Heavy: 25%
+			Light: 100%
+			Heavy: 20%
 		Explosion: small_napalm
 		InfDeath: 5
 		ImpactSound: flamer2
 		SmudgeType: Scorch
-		Damage: 35
+		Damage: 40
 
 BigFlamer:
 	ROF: 50

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -118,7 +118,7 @@ IonCannon:
 	ValidTargets: Ground, Air
 	Warhead@impact:
 		Damage: 900
-		Spread: 682
+		Spread: 853
 		Ore: true
 		InfDeath: 5
 	Warhead@area:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -438,17 +438,17 @@ Grenade:
 		Damage: 50
 
 70mm:
-	ROF: 38
+	ROF: 30
 	Range: 4c0
 	Report: TNKFIRE3.AUD
 	Projectile: Bullet
 		Image: 120MM
-		Speed: 1c0
+		Speed: 853
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
+			None: 25%
+			Wood: 100%
 			Light: 100%
 			Heavy: 100%
 			Concrete: 50%
@@ -479,7 +479,7 @@ Grenade:
 		Damage: 30
 
 120mm:
-	ROF: 50
+	ROF: 40
 	Range: 4c768
 	Report: TNKFIRE6.AUD
 	Projectile: Bullet
@@ -488,8 +488,8 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
+			None: 25%
+			Wood: 100%
 			Light: 100%
 			Heavy: 100%
 			Concrete: 50%
@@ -500,19 +500,19 @@ Grenade:
 		Damage: 40
 
 120mmDual:
-	ROF: 60
+	ROF: 40
 	Range: 4c768
 	Report: TNKFIRE6.AUD
 	Burst: 2
-	BurstDelay: 5
+	BurstDelay: 8
 	Projectile: Bullet
 		Image: 120MM
 		Speed: 682
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
+			None: 25%
+			Wood: 100%
 			Light: 100%
 			Heavy: 100%
 			Concrete: 100%

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -402,7 +402,7 @@ BigFlamer:
 		Versus:
 			None: 100%
 			Wood: 100%
-			Light: 50%
+			Light: 67%
 			Heavy: 25%
 		InfDeath: 5
 		Explosion: med_napalm

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -747,13 +747,13 @@ Vulcan:
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead:
-		Damage: 75
+		Damage: 100
 		Spread: 426
 		Versus:
 			None: 100%
-			Wood: 50%
+			Wood: 25%
 			Light: 100%
-			Heavy: 25%
+			Heavy: 75%
 		InfDeath: 2
 		Explosion: piffs
 
@@ -766,18 +766,18 @@ Napalm:
 	Projectile: GravityBomb
 		Image: BOMBLET
 	Warhead:
-		Spread: 853
+		Spread: 341
 		Versus:
-			None: 90%
+			None: 100%
 			Wood: 100%
-			Light: 60%
-			Heavy: 55%
+			Light: 75%
+			Heavy: 25%
 		InfDeath: 5
 		Explosion: med_napalm
 		WaterExplosion: med_napalm
 		ImpactSound: flamer2.aud
 		SmudgeType: Scorch
-		Damage: 50
+		Damage: 300
 
 Napalm.Crate:
 	Warhead:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -927,7 +927,7 @@ APCGun.AA:
 
 Patriot:
 	ROF: 30
-	Range: 10c0
+	Range: 9c0
 	MinRange: 1c0
 	Burst: 2
 	BurstDelay: 15
@@ -954,7 +954,7 @@ Patriot:
 		Explosion: poof
 		ImpactSound: xplos.aud
 		SmudgeType: Crater
-		Damage: 30
+		Damage: 40
 
 Tail:
 	ROF: 30

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -666,10 +666,10 @@ ArtilleryShell:
 		Damage: 150
 		Spread: 256
 		Versus:
-			None: 90%
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
+			None: 100%
+			Wood: 80%
+			Light: 75%
+			Heavy: 50%
 		InfDeath: 3
 		Explosion: poof
 		SmudgeType: Crater

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -711,10 +711,10 @@ BoatMissile:
 		Damage: 60
 
 TowerMissle:
-	ROF: 20
+	ROF: 15
 	Range: 7c0
 	Report: ROCKET2.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -737,7 +737,7 @@ TowerMissle:
 		Explosion: med_frag
 		ImpactSound: xplos.aud
 		SmudgeType: Crater
-		Damage: 30
+		Damage: 25
 
 Vulcan:
 	ValidTargets: Ground, Water

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -650,7 +650,7 @@ ArtilleryShell:
 		Image: 120MM
 	Warhead:
 		Damage: 150
-		Spread: 256
+		Spread: 341
 		Versus:
 			None: 100%
 			Wood: 80%

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -297,8 +297,8 @@ BikeRockets:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 65%
-			Wood: 50%
+			None: 25%
+			Wood: 75%
 			Light: 100%
 			Heavy: 100%
 			Concrete: 50%

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -63,39 +63,39 @@ Atomic:
 	ValidTargets: Ground, Air
 	Report: nukemisl.aud
 	Warhead@impact:
-		Damage: 1000
-		Spread: 640
+		Damage: 1500	#1000
+		Spread: 1c0
 		Versus:
-			None: 90%
-			Wood: 60%
+			None: 100%
+			Wood: 100%
 			Light: 60%
 			Heavy: 50%
 		Explosion: 6
 		InfDeath: 5
 		ImpactSound: nukexplo.aud
 	Warhead@areanukea:
-		Damage: 200
+		Damage: 1000	#200
 		SmudgeType: Scorch
 		Spread: 2c512
 		Size: 3
 		Ore: true
 		Versus:
-			None: 90%
-			Wood: 60%
+			None: 100%
+			Wood: 100%
 			Light: 60%
 			Heavy: 50%
 		Delay: 3
 		InfDeath: 5
 		ImpactSound: xplobig4.aud
 	Warhead@areanukeb:
-		Damage: 200
+		Damage: 500	#200
 		SmudgeType: Scorch
 		Spread: 3c768
 		Size: 4
 		Ore: true
 		Versus:
-			None: 90%
-			Wood: 60%
+			None: 100%
+			Wood: 100%
 			Light: 60%
 			Heavy: 50%
 		Delay: 6
@@ -107,24 +107,11 @@ Atomic:
 		Size: 5
 		Ore: true
 		Versus:
-			None: 90%
-			Wood: 60%
+			None: 100%
+			Wood: 100%
 			Light: 60%
 			Heavy: 50%
 		Delay: 9
-		InfDeath: 5
-	Warhead@areanuke:
-		Damage: 200
-		SmudgeType: Scorch
-		Spread: 6c256
-		Size: 6
-		Ore: true
-		Versus:
-			None: 90%
-			Wood: 60%
-			Light: 60%
-			Heavy: 50%
-		Delay: 12
 		InfDeath: 5
 
 IonCannon:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -607,10 +607,10 @@ MammothMissiles:
 		Trail: smokey
 		Speed: 341
 	Warhead:
-		Spread: 640
+		Spread: 683
 		Versus:
-			None: 25%
-			Wood: 30%
+			None: 35%
+			Wood: 60%
 			Light: 100%
 			Heavy: 50%
 		InfDeath: 4

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -308,7 +308,7 @@ OrcaAGMissiles:
 		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
-		ROT: 10
+		ROT: 20
 		Trail: smokey
 		ContrailLength: 8
 		Speed: 213
@@ -339,7 +339,7 @@ OrcaAAMissiles:
 		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
-		ROT: 10
+		ROT: 20
 		Trail: smokey
 		ContrailLength: 8
 		Speed: 213
@@ -555,7 +555,7 @@ MammothMissiles:
 		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
-		ROT: 10
+		ROT: 20
 		Trail: smokey
 		ContrailLength: 8
 		Speed: 341


### PR DESCRIPTION
- Range of obelisk, Adv. Guard Tower and SAM site reduced.
- Damage of Guard Tower reduced vs. infantry and light vehicles; spread increased to compensate a bit.
- Damage of Advanced Guard Tower nerfed, especially against light vehicles. Damage vs. infantry increased (though it's still low DPS). Spread also increased to compensate for its lack of power vs. infantry.
- Turret damage mostly unchanged, but does less damage per shot. Damage vs. light vehicles increased to match its damage vs. heavy armor. Damage vs. infantry slightly reduced.
