### PR TITLE
Fixed 0,0 shroud reveal when producing units on maps with tiny cordons

### DIFF
--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -59,6 +59,7 @@ namespace OpenRA.Mods.RA
 			var newUnit = self.World.CreateActor(producee.Name, new TypeDictionary
 			{
 				new OwnerInit(self.Owner),
+				new LocationInit(exit),
 				new CenterPositionInit(spawn),
 				new FacingInit(initialFacing)
 			});


### PR DESCRIPTION
as described in #5076.
