### PR TITLE
Fixed C&C build palette tooltip not taking low power slowdown into account

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -280,6 +280,7 @@ NEW:
 		Fixed helicopters falling down not revealing shroud.
 		Fixed effect (explosions, etc) saturation when the ingame menu is activated.
 		Added shadow to crate artwork.
+		Fixed build palette tooltip not taking low power slowdown into account when displaying the build time.
 	Dune 2000:
 		Added buildable concrete walls.
 		Fixed some cliffs being passable.

--- a/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -64,8 +64,12 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 					? Color.White : Color.Red;
 				powerLabel.IsVisible = () => power != 0;
 
-				var timeString = "T: {0}".F(WidgetUtils.FormatTime(palette.CurrentQueue.GetBuildTime(actor)));
+				var lowpower = pm.PowerState != PowerState.Normal;
+				var time = palette.CurrentQueue.GetBuildTime(actor)
+					* ((lowpower) ? palette.CurrentQueue.Info.LowPowerSlowdown : 1);
+				var timeString = "T: {0}".F(WidgetUtils.FormatTime(time));
 				timeLabel.GetText = () => timeString;
+				timeLabel.GetColor = () => lowpower ? Color.Red : Color.White;
 
 				var costString = "$: {0}".F(cost);
 				costLabel.GetText = () => costString;


### PR DESCRIPTION
as shown in #4840.
