### PR TITLE
Automated translation string extraction

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -20,6 +20,11 @@ namespace OpenRA
 {
 	public static class Exts
 	{
+		public static bool IsUppercase(this string str)
+		{
+			return string.Compare(str.ToUpperInvariant(), str, false) == 0;
+		}
+
 		public static string F(this string fmt, params object[] args)
 		{
 			return string.Format(fmt, args);

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -111,9 +111,13 @@ namespace OpenRA
 		public IEnumerable<Type> GetTypesImplementing<T>()
 		{
 			var it = typeof(T);
+			return GetTypes().Where(t => t != it && it.IsAssignableFrom(t));
+		}
+		
+		public IEnumerable<Type> GetTypes()
+		{
 			return assemblies.Select(ma => ma.First).Distinct()
-				.SelectMany(ma => ma.GetTypes()
-				.Where(t => t != it && it.IsAssignableFrom(t)));
+				.SelectMany(ma => ma.GetTypes());
 		}
 
 		[AttributeUsage(AttributeTargets.Constructor)]

--- a/OpenRA.Game/Widgets/ButtonWidget.cs
+++ b/OpenRA.Game/Widgets/ButtonWidget.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Widgets
 		Lazy<TooltipContainerWidget> tooltipContainer;
 		public readonly string TooltipContainer;
 		public readonly string TooltipTemplate = "BUTTON_TOOLTIP";
-		public string TooltipText;
+		[Translate] public string TooltipText;
 
 		// Equivalent to OnMouseUp, but without an input arg
 		public Action OnClick = () => {};

--- a/OpenRA.Utility/ExtractLanguageStrings.cs
+++ b/OpenRA.Utility/ExtractLanguageStrings.cs
@@ -1,0 +1,68 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Utility
+{
+	public class ExtractLanguageStrings
+	{
+		[Desc("MOD", "Extract translatable strings that are not yet localized and update chrome layout.")]
+		public static void FromMod(string[] args)
+		{
+			var mod = args[1];
+			Game.modData = new ModData(mod);
+			Game.modData.RulesetCache.LoadDefaultRules();
+
+			var types = Game.modData.ObjectCreator.GetTypes();
+			var translatableFields = types.SelectMany(t => t.GetFields())
+				.Where(f => f.HasAttribute<TranslateAttribute>()).Distinct();
+
+			foreach (var filename in Game.modData.Manifest.ChromeLayout)
+			{
+				Console.WriteLine("# {0}:", filename);
+				var yaml = MiniYaml.FromFile(filename);
+				ExtractLanguageStrings.FromChromeLayout(ref yaml, null,
+					translatableFields.Select(t => t.Name).Distinct(), null);
+				using (var file = new StreamWriter(filename))
+					file.WriteLine(yaml.WriteToString());
+			}
+
+			// TODO: Properties can also be translated.
+		}
+
+		public static void FromChromeLayout(ref List<MiniYamlNode> nodes, MiniYamlNode parent, IEnumerable<string> translatables, string container)
+		{
+			var parentNode = parent != null ? parent.Key.Split('@') : null;
+			var parentType = parent != null ? parentNode.First() : null;
+			var parentLabel = parent != null ? parentNode.Last() : null;
+
+			if ((parentType == "Background" || parentType == "Container") && parentLabel.IsUppercase())
+				container = parentLabel;
+
+			foreach (var node in nodes)
+			{
+				var alreadyTranslated = node.Value.Value != null && node.Value.Value.Contains('@');
+				if (translatables.Contains(node.Key) && !alreadyTranslated)
+				{
+					var translationKey = "{0}-{1}-{2}".F(container.Replace('_', '-'), parentLabel.Replace('_', '-'), node.Key.ToUpper());
+					Console.WriteLine("\t{0}: {1}", translationKey , node.Value.Value);
+					node.Value.Value = "@{0}@".F(translationKey);
+				}
+
+				FromChromeLayout(ref node.Value.Nodes, node, translatables, container);
+			}
+		}
+
+	}
+}

--- a/OpenRA.Utility/OpenRA.Utility.csproj
+++ b/OpenRA.Utility/OpenRA.Utility.csproj
@@ -80,6 +80,7 @@
     <Compile Include="UpgradeRules.cs" />
     <Compile Include="LegacyMapImporter.cs" />
     <Compile Include="Glob.cs" />
+    <Compile Include="ExtractLanguageStrings.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2012 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -33,7 +33,8 @@ namespace OpenRA.Utility
 			{ "--map-upgrade-v5", Command.UpgradeV5Map },
 			{ "--upgrade-map", UpgradeRules.UpgradeMap },
 			{ "--upgrade-mod", UpgradeRules.UpgradeMod },
-			{ "--map-import", Command.ImportLegacyMap }
+			{ "--map-import", Command.ImportLegacyMap },
+			{ "--extract-language-strings", ExtractLanguageStrings.FromMod }
 		};
 
 		static void Main(string[] args)

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -174,7 +174,7 @@ Container@SETTINGS_PANEL:
 							Height: 25
 							Font: Regular
 							Visible: false
-						Label@VIDEO_DESC_A:
+						Label@LANGUAGE_DESC_A:
 							Y: 265
 							Width: PARENT_RIGHT
 							Height: 25
@@ -182,7 +182,7 @@ Container@SETTINGS_PANEL:
 							Align: Center
 							Text: Language changes will be applied after the game is restarted
 							Visible: false
-						Label@VIDEO_DESC_B:
+						Label@LANGUAGE_DESC_B:
 							Y: 280
 							Width: PARENT_RIGHT
 							Height: 25

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -186,7 +186,7 @@ Background@SETTINGS_PANEL:
 					Width: 200
 					Height: 25
 					Visible: false
-				Label@VIDEO_DESC_A:
+				Label@LANGUAGE_DESC_A:
 					Y: 265
 					Width: PARENT_RIGHT
 					Height: 25
@@ -194,7 +194,7 @@ Background@SETTINGS_PANEL:
 					Align: Center
 					Text: Language changes will be applied after the game is restarted
 					Visible: false
-				Label@VIDEO_DESC_B:
+				Label@LANGUAGE_DESC_B:
 					Y: 280
 					Width: PARENT_RIGHT
 					Height: 25


### PR DESCRIPTION
To quickly create and update GUI localisation. Creating this took me longer than expected. It is at an experimental stage where this should not yet merged. I already stumbled on some problems that might need discussion:
- Pretty long translation keys to avoid duplicates: OK_BUTTON, CANCEL_BUTTON etc. get prefixed with the container/background widget label. I already tried line numbers, but those are variable later on therefore maybe confusing and they still generated duplicates like L9_TITLE_LABEL-Text. We can also try to eliminate the redundancy at one stage, however I tried solving it manually and that is too much manual labor. Also the suffix may seem redundant, but that is required to differentiate multiple translatable texts per widget like READY/ON HOLD.
- You will notice a lot of noise in https://github.com/Mailaender/OpenRA/commit/b083448ba4d8469000c26cdf25d151d45b9efda8 because for some reason we use `key: value` in rule YAML, but no space between `key:value` in chrome YAML. I can hack a workaround in here or we just auto-convert them to stay in line with YamlWriter.
