### PR TITLE
* Fixed Bug #5072: RenderLandingCraft doesn't do an IsInMap check

### DIFF
--- a/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
+++ b/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA.Render
 				return false;
 
 			return cargo.CurrentAdjacentCells
-				.Any(c => self.World.Map.IsInMap(c) && info.OpenTerrainTypes.Contains(self.World.GetTerrainType(c)) );
+				.Any(c => self.World.Map.IsInMap(c) && info.OpenTerrainTypes.Contains(self.World.GetTerrainType(c)));
 		}
 
 		void Open()

--- a/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
+++ b/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA.Render
 				return false;
 
 			return cargo.CurrentAdjacentCells
-				.Any(c => info.OpenTerrainTypes.Contains(self.World.GetTerrainType(c)));
+				.Any(c => self.World.Map.IsInMap(c) && info.OpenTerrainTypes.Contains(self.World.GetTerrainType(c)) );
 		}
 
 		void Open()


### PR DESCRIPTION
I fixed a small reported bug where landing crafts in Red Alert mod extend doors when adjacent to a map boundary:

https://github.com/OpenRA/OpenRA/issues/5072
