### PR TITLE
balance tweak - make turret armor heavy

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -531,6 +531,8 @@ GUN:
 	-GivesBuildableArea:
 	Health:
 		HP: 400
+	Armor:
+		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
 	Bib:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -753,7 +753,7 @@ Vulcan:
 			None: 100%
 			Wood: 25%
 			Light: 100%
-			Heavy: 75%
+			Heavy: 35%
 		InfDeath: 2
 		Explosion: piffs
 
@@ -770,8 +770,8 @@ Napalm:
 		Versus:
 			None: 100%
 			Wood: 100%
-			Light: 75%
-			Heavy: 25%
+			Light: 100%
+			Heavy: 80%
 		InfDeath: 5
 		Explosion: med_napalm
 		WaterExplosion: med_napalm


### PR DESCRIPTION
Since turrets have wood armor, they can get killed by flame tanks uber fast. It might be best if turrets are a counter to flame tanks, rather than their prey. If they have heavy armor, they will take far less damage, and not die instantly to a flame tank rush, making them able to contribute to some defense.
