### PR TITLE
Fix build palette showing too many queued items when BuildLimit is reached

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -224,17 +224,17 @@ namespace OpenRA
 
 		public static Order StartProduction(Actor subject, string item, int count)
 		{
-			return new Order("StartProduction", subject, false) { TargetLocation = new CPos(count, 0), TargetString = item };
+			return new Order("StartProduction", subject, false) { ExtraData = (uint)count, TargetString = item };
 		}
 
 		public static Order PauseProduction(Actor subject, string item, bool pause)
 		{
-			return new Order("PauseProduction", subject, false) { TargetLocation = new CPos(pause ? 1 : 0, 0), TargetString = item };
+			return new Order("PauseProduction", subject, false) { ExtraData = pause ? 1u : 0u, TargetString = item };
 		}
 
 		public static Order CancelProduction(Actor subject, string item, int count)
 		{
-			return new Order("CancelProduction", subject, false) { TargetLocation = new CPos(count, 0), TargetString = item };
+			return new Order("CancelProduction", subject, false) { ExtraData = (uint)count, TargetString = item };
 		}
 	}
 }


### PR DESCRIPTION
When a BuildLimit on an actor type is set and nearly reached, you could
shift-click the build palette and it would show it had five more units
queued when really less are allowed to be built. This fixes the text
overlay so that it shows the correct number of items that will be built.
