### PR TITLE
Added UseInfantryDeath option to RenderInfantry trait

### DIFF
--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.RA.Render
 	{
 		public readonly int MinIdleWaitTicks = 30;
 		public readonly int MaxIdleWaitTicks = 110;
+		public readonly bool UseInfantryDeath = true;
 		public readonly string[] IdleAnimations = { };
 		public readonly string[] StandAnimations = { "stand" };
 
@@ -130,8 +131,13 @@ namespace OpenRA.Mods.RA.Render
 			if (e.Warhead == null)
 				return;
 
-			Sound.PlayVoice("Die", self, self.Owner.Country.Race);
-			SpawnCorpse(self, "die{0}".F(e.Warhead.InfDeath));
+			// TODO: Possibly move Die sound out of this Render trait entirely
+			if (info.UseInfantryDeath == true)
+			{
+				Sound.PlayVoice("Die", self, self.Owner.Country.Race);
+				SpawnCorpse(self, "die{0}".F(e.Warhead.InfDeath));
+			}
+			
 		}
 
 		public void SpawnCorpse(Actor self, string sequence)

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -480,6 +480,7 @@ MMCH:
 	RevealsShroud:
 		Range: 8c0
 	RenderInfantry:
+		UseInfantryDeath: false
 	Turreted:
 	AttackTurreted:
 	WithTurret:
@@ -549,6 +550,7 @@ SMECH:
 	Armament:
 		Weapon: AssaultCannon
 	RenderInfantry:
+		UseInfantryDeath: false
 	Selectable:
 		Voices: Mech
 

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -117,19 +117,20 @@ gghunt:
 		Start: 0
 
 smech:
-	stand: # TODO: slightly glitchy
-		Start: 0
-		Facings: 8
-		ShadowStart: 136
+	stand:
+		Start: 96
+		Facings: -8
+		ShadowStart: 232
 	run:
 		Start: 0
 		Facings: -8
 		Length: 12
 		ShadowStart: 136
-	shoot: # TODO: played somehow too fast
+	shoot:
 		Start: 104
 		Length: 4
 		Facings: -8
 		ShadowStart: 240
+		Tick: 100
 	icon: smchicon
 		Start: 0


### PR DESCRIPTION
This allows the use of RenderInfantry for units that do not have a Die voice or die(0) sequences.
Fixes crash upon destruction of Titan/Wolverine in TS mod.

Might come in handy for cyborg destruction logic as well.

Additionally fixed Wolverine stand and shoot sequences.
