### PR TITLE
Fixed missing un-l10n of C&C Requires: production tooltip

### DIFF
--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -60,7 +60,7 @@ Background@PRODUCTION_TOOLTIP:
 			Y: 19
 			Height: 23
 			Font: TinyBold
-			Text: @requires@
+			Text: Requires {0}
 		Label@DESC:
 			X: 5
 			Y: 39


### PR DESCRIPTION
followup of #5162 as described in #5209.
