### PR TITLE
Fixed Cnc Production Queue Tab Numbering

### DIFF
--- a/OpenRA.Mods.Cnc/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Cnc/Widgets/ProductionTabsWidget.cs
@@ -37,15 +37,32 @@ namespace OpenRA.Mods.Cnc.Widgets
 			var queues = allQueues.Where(q => q.Info.Group == Group).ToList();
 			List<ProductionTab> tabs = new List<ProductionTab>();
 
+			//current tally of removed queues
+			var removed = 0;
+
 			// Remove stale queues
 			foreach (var t in Tabs)
 			{
 				if (!queues.Contains(t.Queue))
+				{
+					removed++;
 					continue;
+				}
+
+				//if there are any removed tabs so far, change the name to match new queue number
+				if (removed > 0)
+				{
+					var nameId = int.Parse(t.Name);
+					nameId -= removed;
+					t.Name = nameId.ToString();
+				}
 
 				tabs.Add(t);
 				queues.Remove(t.Queue);
 			}
+
+			//change next queue name based on removed tabs count
+			NextQueueName -= removed;
 
 			// Add new queues
 			foreach (var queue in queues)


### PR DESCRIPTION
Queue numbering now changes if a queue is removed for any reason so that the queues are
always cleanly numbered from 1 to the total number of queues.  Also lowered the NextQueueName value each time a queue is removed so that the next created queue's number is the next proper number in the sequence.
