### PR TITLE
Made CrateEffect color palette customizable

### DIFF
--- a/OpenRA.Mods.RA/CrateAction.cs
+++ b/OpenRA.Mods.RA/CrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -21,6 +21,8 @@ namespace OpenRA.Mods.RA
 		public int SelectionShares = 10;
 		[Desc("An animation defined in sequence yaml(s) to draw.")]
 		public string Effect = null;
+		[Desc("Palette to draw the animation in.")]
+		public string Palette = "effect";
 		[Desc("Audio clip to play when the crate is collected.")]
 		public string Notification = null;
 		[ActorReference]
@@ -59,7 +61,7 @@ namespace OpenRA.Mods.RA
 
 			if (info.Effect != null)
 				collector.World.AddFrameEndTask(
-					w => w.Add(new CrateEffect(collector, info.Effect)));
+					w => w.Add(new CrateEffect(collector, info.Effect, info.Palette)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/CrateEffect.cs
+++ b/OpenRA.Mods.RA/Effects/CrateEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -16,12 +16,14 @@ namespace OpenRA.Mods.RA.Effects
 {
 	class CrateEffect : IEffect
 	{
+		readonly string palette;
 		Actor a;
 		Animation anim = new Animation("crate-effects");
 
-		public CrateEffect(Actor a, string seq)
+		public CrateEffect(Actor a, string seq, string palette)
 		{
 			this.a = a;
+			this.palette = palette;
 			anim.PlayThen(seq, () => a.World.AddFrameEndTask(w => w.Remove(this)));
 		}
 
@@ -35,7 +37,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (!a.IsInWorld || a.World.FogObscures(a.Location))
 				return SpriteRenderable.None;
 
-			return anim.Render(a.CenterPosition, wr.Palette("effect"));
+			return anim.Render(a.CenterPosition, wr.Palette(palette));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.RA
 				Level++;
 
 				Sound.PlayNotification(self.Owner, "Sounds", "LevelUp", self.Owner.Country.Race);
-				self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup")));
+				self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup", info.ChevronPalette)));
 				if (Level == 1)
 					self.World.AddFrameEndTask(w =>
 					{


### PR DESCRIPTION
Basically a follow-up of #5185.
CrateAction can now define a custom Palette, levelup effect of GainsExperience now uses ChevronPalette.

Automatically fixes TS mod "+1 rank" anim palette.
