### PR TITLE
Fix voxel angle of TS units

### DIFF
--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -196,6 +196,7 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+		CameraPitch: 90
 	Huntable:
 	LuaScriptEvents:
 
@@ -228,6 +229,7 @@
 	ActorLostNotification:
 	CombatDebugOverlay:
 	BodyOrientation:
+		CameraPitch: 90
 	Huntable:
 	LuaScriptEvents:
 


### PR DESCRIPTION
The default CameraPitch is geared towards RA, TS needs a different CameraPitch to match the isometric perspective.
