### PR TITLE
Repaired gdi03 mission. Fixes #5210.

### DIFF
--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -931,12 +931,14 @@ Rules:
 		-Buildable:
 	SAM:
 		-Buildable:
+		Building:
+			Power: -10
 	HQ:
 		-Buildable:
 	NOHQ:
 		RequiresPower:
 		CanPowerDown:
-		Inherits: ^Building
+		Inherits: ^BaseBuilding
 		Valued:
 			Cost: 1000
 		Tooltip:


### PR DESCRIPTION
I opted to lower the power consumption for SAM instead of restoring the
original power values for FACT and PROC since those two are available to
the player as well and they would behave slightly different in this
mission than in other ones.
