### PR TITLE
Fixed the .NET version check failing

### DIFF
--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -136,11 +136,11 @@ SectionGroupEnd
 ;***************************
 Section "-DotNet" DotNet
 	ClearErrors
-	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5" "Install"
+	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client" "Install"
 	IfErrors error 0
 	IntCmp $0 1 0 error 0
 	ClearErrors
-	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4.0" "SP"
+	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" "Install"
 	IfErrors error 0
 	IntCmp $0 1 done error done
 	error:


### PR DESCRIPTION
As described in #5224 installing .NET 4.5.1 is not detected although 4.5 does not add a new versioned sub-folder in the registry, but rather just an additional key http://msdn.microsoft.com/en-us/library/hh925568.aspx. In fact even with .NET 4.0 this is probably broken, because since that version, Microsoft distinguishes between Full and Client. http://support.microsoft.com/kb/318785 We only need client, but full is also not bad so I added both.
