### PR TITLE
Fix TechTree prerequisite bug for buildings with a build limit.

### DIFF
--- a/OpenRA.Mods.RA/Player/TechTree.cs
+++ b/OpenRA.Mods.RA/Player/TechTree.cs
@@ -113,7 +113,11 @@ namespace OpenRA.Mods.RA
 
 			public void Update(Cache<string, List<Actor>> buildables)
 			{
-				var hasReachedBuildLimit = buildLimit > 0 && buildables[Key].Count >= buildLimit;
+				var hasReachedBuildLimit = false;
+				
+				if(buildables.Keys.Contains(Key))
+					hasReachedBuildLimit = buildLimit > 0 && buildables[Key].Count >= buildLimit;
+
 				var nowHasPrerequisites = HasPrerequisites(buildables) && !hasReachedBuildLimit;
 
 				if (nowHasPrerequisites && !hasPrerequisites)

--- a/OpenRA.Mods.RA/Player/TechTree.cs
+++ b/OpenRA.Mods.RA/Player/TechTree.cs
@@ -113,10 +113,7 @@ namespace OpenRA.Mods.RA
 
 			public void Update(Cache<string, List<Actor>> buildables)
 			{
-				var hasReachedBuildLimit = false;
-				
-				if(buildables.Keys.Contains(Key))
-					hasReachedBuildLimit = buildLimit > 0 && buildables[Key].Count >= buildLimit;
+				var hasReachedBuildLimit = buildLimit > 0 && buildables.Keys.Contains(Key) && buildables[Key].Count >= buildLimit;
 
 				var nowHasPrerequisites = HasPrerequisites(buildables) && !hasReachedBuildLimit;
 

--- a/OpenRA.Mods.RA/Player/TechTree.cs
+++ b/OpenRA.Mods.RA/Player/TechTree.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.RA
 
 			// Add buildables that have a build limit set and are not already in the list
 			player.World.ActorsWithTrait<Buildable>()
-				  .Where(a => a.Actor.Info.Traits.Get<BuildableInfo>().BuildLimit > 0 && !a.Actor.IsDead() && a.Actor.Owner == player && ret.Keys.All(k => k != a.Actor.Info.Name))
+				  .Where(a => a.Actor.Info.Traits.Get<BuildableInfo>().BuildLimit > 0 && !a.Actor.IsDead() && a.Actor.IsInWorld && a.Actor.Owner == player && ret.Keys.All(k => k != a.Actor.Info.Name))
 				  .ToList()
 				  .ForEach(b => ret[b.Actor.Info.Name].Add(b.Actor));
 
@@ -114,7 +114,6 @@ namespace OpenRA.Mods.RA
 			public void Update(Cache<string, List<Actor>> buildables)
 			{
 				var hasReachedBuildLimit = buildLimit > 0 && buildables.Keys.Contains(Key) && buildables[Key].Count >= buildLimit;
-
 				var nowHasPrerequisites = HasPrerequisites(buildables) && !hasReachedBuildLimit;
 
 				if (nowHasPrerequisites && !hasPrerequisites)


### PR DESCRIPTION
Fixes #5153 by preventing buildings with a BuildLimit value set always being added to the buildables cache, which is then used to determine prerequisites.
