### PR TITLE
Move death voices from RenderInfantry into a separate trait

### DIFF
--- a/OpenRA.Game/Sound.cs
+++ b/OpenRA.Game/Sound.cs
@@ -367,6 +367,19 @@ namespace OpenRA
 			var type = mi.Voice.ToLowerInvariant();
 			return PlayPredefined(null, voicedUnit, type, phrase, variant, true);
 		}
+		
+		public static bool PlayVoiceLocal(string phrase, Actor voicedUnit, string variant, WPos pos)
+		{
+			if (voicedUnit == null || phrase == null)
+				return false;
+
+			var mi = voicedUnit.Info.Traits.GetOrDefault<SelectableInfo>();
+			if (mi == null || mi.Voice == null)
+				return false;
+
+			var type = mi.Voice.ToLowerInvariant();
+			return PlayPredefined(null, voicedUnit, type, phrase, variant, true);
+		}
 
 		public static bool PlayNotification(Player player, string type, string notification, string variant)
 		{

--- a/OpenRA.Mods.RA/DeathSounds.cs
+++ b/OpenRA.Mods.RA/DeathSounds.cs
@@ -1,0 +1,53 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.RA.Move;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class DeathSoundsInfo : ITraitInfo
+	{
+		public readonly string DeathVoice = "Die";
+		public readonly string Burned = null;
+		public readonly string Zapped = null;
+
+		public object Create(ActorInitializer init) { return new DeathSounds(this); }
+	}
+
+	public class DeathSounds : INotifyKilled
+	{
+		DeathSoundsInfo info;
+
+		public DeathSounds(DeathSoundsInfo info) { this.info = info; }
+
+		public void Killed(Actor self, AttackInfo e)
+		{
+			// Killed by some non-standard means
+			if (e.Warhead == null)
+				return;
+
+			var cp = self.CenterPosition;
+
+			// Killed by fire
+			if (info.Burned != null && e.Warhead.InfDeath == 5)
+				Sound.Play(info.Burned, cp);
+
+			// Killed by Tesla/Laser zap
+			if (info.Zapped != null && e.Warhead.InfDeath == 6)
+				Sound.Play(info.Zapped, cp);
+
+			if ((e.Warhead.InfDeath < 5) || (info.Burned == null && info.Zapped == null))
+				Sound.PlayVoiceLocal(info.DeathVoice, self, self.Owner.Country.Race, cp);
+		}
+	}
+}

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Crates\SupportPowerCrateAction.cs" />
     <Compile Include="CreateMPPlayers.cs" />
     <Compile Include="CrushableInfantry.cs" />
+    <Compile Include="DeathSounds.cs" />
     <Compile Include="DemoTruck.cs" />
     <Compile Include="DetectCloaked.cs" />
     <Compile Include="Effects\Bullet.cs" />

--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Render
 	{
 		public readonly int MinIdleWaitTicks = 30;
 		public readonly int MaxIdleWaitTicks = 110;
-		public readonly bool UseInfantryDeath = true;
+		public readonly bool SpawnsCorpse = true;
 		public readonly string[] IdleAnimations = { };
 		public readonly string[] StandAnimations = { "stand" };
 
@@ -125,19 +125,17 @@ namespace OpenRA.Mods.RA.Render
 			}
 		}
 
+		// TODO: Possibly move this into a separate trait
 		public void Killed(Actor self, AttackInfo e)
 		{
 			// Killed by some non-standard means
 			if (e.Warhead == null)
 				return;
 
-			// TODO: Possibly move Die sound out of this Render trait entirely
-			if (info.UseInfantryDeath == true)
+			if (info.SpawnsCorpse)
 			{
-				Sound.PlayVoice("Die", self, self.Owner.Country.Race);
 				SpawnCorpse(self, "die{0}".F(e.Warhead.InfDeath));
-			}
-			
+			}	
 		}
 
 		public void SpawnCorpse(Actor self, string sequence)

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -187,6 +187,8 @@
 	DetectCloaked:
 		Range: 1
 	ScriptTriggers:
+	DeathSounds:
+		Burned: yell1.aud
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -266,6 +268,7 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DeathSounds:
 
 ^Plane:
 	AppearsOnRadar:
@@ -588,4 +591,3 @@
 	BodyOrientation:
 	LuaScriptEvents:
 	ScriptTriggers:
-

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -195,6 +195,7 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DeathSounds:
 
 ^Plane:
 	AppearsOnRadar:

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -1321,6 +1321,11 @@ Rules:
 		ScriptInvulnerable:
 		GivesBounty:
 			Percentage: 0
+		GainsExperience:
+			CostThreshold:
+			FirepowerModifier:
+			ArmorModifier:
+			SpeedModifier:
 	^Plane:
 		ScriptInvulnerable:
 		GivesBounty:

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -1308,7 +1308,8 @@ Rules:
 			SpeedModifier:
 	^Infantry:
 		ScriptInvulnerable:
-		-Selectable: # short-term hack to make infantry not play die sounds until we fix RenderInfantry
+		DeathSounds:
+			DeathVoice:
 		GivesBounty:
 			Percentage: 0
 		GainsExperience:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -168,6 +168,7 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DeathSounds:
 
 ^Ship:
 	AppearsOnRadar:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -132,6 +132,8 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DeathSounds:
+		Zapped: electro1.aud
 
 ^CivilianInfantry:
 	Inherits: ^Infantry

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -480,7 +480,7 @@ MMCH:
 	RevealsShroud:
 		Range: 8c0
 	RenderInfantry:
-		UseInfantryDeath: false
+		SpawnsCorpse: false
 	Turreted:
 	AttackTurreted:
 	WithTurret:
@@ -550,7 +550,7 @@ SMECH:
 	Armament:
 		Weapon: AssaultCannon
 	RenderInfantry:
-		UseInfantryDeath: false
+		SpawnsCorpse: false
 	Selectable:
 		Voices: Mech
 


### PR DESCRIPTION
...named DeathSounds.

Note: I have some trouble moving SpawnCorpse into a separate trait as well (my attempt didn't even compile), but I consider the sounds far more important so I'm doing those first.

Infantry DeathSounds cannot be disabled with '-' on the desert shellmap since the ants' inheritance causes a bogus yaml removal crash in that case, so I had to set them to null instead.
