### PR TITLE
More palette un-hardcoding

### DIFF
--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -46,6 +46,9 @@ namespace OpenRA.Mods.RA
 
 		[Desc("Muzzle flash sequence to render")]
 		public readonly string MuzzleSequence = null;
+
+		[Desc("Palette to render Muzzle flash sequence in")]
+		public readonly string MuzzlePalette = "effect";
 
 		[Desc("Use multiple muzzle images if non-zero")]
 		public readonly int MuzzleSplitFacings = 0;

--- a/OpenRA.Mods.RA/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.RA/Attack/AttackGarrisoned.cs
@@ -38,6 +38,8 @@ namespace OpenRA.Mods.RA
 		[Desc("Fire port yaw cone angle")]
 		public readonly WAngle[] PortCones = {};
 
+		public readonly string MuzzlePalette = "effect";
+
 		public override object Create(ActorInitializer init) { return new AttackGarrisoned(init.self, this); }
 	}
 
@@ -175,9 +177,10 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
+			var pal = wr.Palette(info.MuzzlePalette);
 			// Display muzzle flashes
 			foreach (var m in muzzles)
-				foreach (var r in m.Render(self, wr, wr.Palette("effect"), 1f))
+				foreach (var r in m.Render(self, wr, pal, 1f))
 					yield return r;
 		}
 

--- a/OpenRA.Mods.RA/Effects/TeslaZap.cs
+++ b/OpenRA.Mods.RA/Effects/TeslaZap.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.RA.Effects
 	class TeslaZapInfo : IProjectileInfo
 	{
 		public readonly string Image = "litning";
+		public readonly string Palette = "effect";
 		public readonly int BrightZaps = 1;
 		public readonly int DimZaps = 2;
 		public IEffect Create(ProjectileArgs args) { return new TeslaZap( this, args ); }
@@ -56,7 +57,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (!initialized)
 			{
 				var pos = Args.GuidedTarget.IsValidFor(Args.SourceActor) ? Args.GuidedTarget.CenterPosition : Args.PassiveTarget;
-				zap = new TeslaZapRenderable(Args.Source, 0, pos - Args.Source, Info.Image, Info.BrightZaps, Info.DimZaps);
+				zap = new TeslaZapRenderable(Args.Source, 0, pos - Args.Source, Info.Image, Info.BrightZaps, Info.DimZaps, Info.Palette);
 			}
 			yield return zap;
 		}

--- a/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -78,16 +78,20 @@ namespace OpenRA.Mods.RA.Render
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
-			foreach (var kv in anims)
+			foreach (var arm in self.TraitsImplementing<Armament>())
 			{
-				if (!visible[kv.Key])
-					continue;
+				var palette = wr.Palette(arm.Info.MuzzlePalette);
+				foreach (var kv in anims)
+				{
+					if (!visible[kv.Key])
+						continue;
 
-				if (kv.Value.DisableFunc != null && kv.Value.DisableFunc())
-					continue;
+					if (kv.Value.DisableFunc != null && kv.Value.DisableFunc())
+						continue;
 
-				foreach (var r in kv.Value.Render(self, wr, wr.Palette("effect"), 1f))
-					yield return r;
+					foreach (var r in kv.Value.Render(self, wr, palette, 1f))
+						yield return r;
+				}
 			}
 		}
 


### PR DESCRIPTION
This time muzzle flashes and tesla zaps.

The muzzle flash customization is a bit limited because the palette is defined under WithMuzzleFlash which is no longer on a per-muzzle/weapon base, so all muzzles of a unit must use the same muzzle palette. Neither an issue for any of the mods currently shipping with OpenRA nor for the TS mod, though.
Similar situation with AttackGarrisoned, which defines only one muzzle palette.
