### PR TITLE
Remove X11 dependency from OSX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev
 game_SRCS := $(shell find OpenRA.Game/ -iname '*.cs')
 game_TARGET = OpenRA.Game.exe
 game_KIND = winexe
-game_LIBS = $(COMMON_LIBS) System.Windows.Forms.dll $(game_DEPS) thirdparty/Tao/Tao.OpenAl.dll thirdparty/SharpFont.dll
+game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/Tao/Tao.OpenAl.dll thirdparty/SharpFont.dll
 game_FLAGS = -win32icon:OpenRA.Game/OpenRA.ico
 PROGRAMS += game
 game: $(game_TARGET)
@@ -219,7 +219,7 @@ utility_SRCS := $(shell find OpenRA.Utility/ -iname '*.cs')
 utility_TARGET = OpenRA.Utility.exe
 utility_KIND = exe
 utility_DEPS = $(game_TARGET)
-utility_LIBS = $(COMMON_LIBS) $(utility_DEPS) thirdparty/ICSharpCode.SharpZipLib.dll System.Windows.Forms.dll
+utility_LIBS = $(COMMON_LIBS) $(utility_DEPS) thirdparty/ICSharpCode.SharpZipLib.dll
 PROGRAMS += utility
 utility: $(utility_TARGET)
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 
 # program targets
-CORE = rsdl2 rnull game utility irc
+CORE = rsdl2 rnull game utility irc crashdialog
 TOOLS = editor tsbuild ralint
 
 VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
@@ -107,7 +107,6 @@ rnull_DEPS = $(game_TARGET)
 rnull_LIBS = $(COMMON_LIBS) $(rnull_DEPS)
 PROGRAMS += rsdl2 rnull
 renderers: $(rsdl2_TARGET) $(rnull_TARGET)
-
 
 ##### Official Mods #####
 
@@ -206,6 +205,15 @@ tsbuild: OpenRA.TilesetBuilder.FormBuilder.resources OpenRA.TilesetBuilder.FormN
 
 ##### Launchers / Utilities #####
 
+crashdialog_SRCS := $(shell find OpenRA.CrashDialog/ -iname '*.cs')
+crashdialog_TARGET = OpenRA.CrashDialog.exe
+crashdialog_KIND = exe
+crashdialog_DEPS = $(game_TARGET)
+crashdialog_LIBS = $(COMMON_LIBS) $(crashdialog_DEPS) System.Windows.Forms.dll
+crashdialog_FLAGS = -win32icon:OpenRA.Game/OpenRA.ico
+PROGRAMS += crashdialog
+crashdialog: $(crashdialog_TARGET)
+
 # Backend for the launcher apps - queries game/mod info and applies actions to an install
 utility_SRCS := $(shell find OpenRA.Utility/ -iname '*.cs')
 utility_TARGET = OpenRA.Utility.exe
@@ -245,7 +253,7 @@ $(foreach prog,$(PROGRAMS),$(eval $(call BUILD_ASSEMBLY,$(prog))))
 #
 default: dependencies core
 
-core: game renderers mods utility
+core: game renderers mods utility crashdialog
 
 tools: editor tsbuild ralint
 

--- a/OpenRA.CrashDialog/OpenRA.CrashDialog.csproj
+++ b/OpenRA.CrashDialog/OpenRA.CrashDialog.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{47F1B0EE-EB35-47F2-93E4-273C70909157}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>OpenRA</RootNamespace>
+    <AssemblyName>OpenRA.CrashDialog</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Drawing" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">
+      <Project>{0DFB103F-2962-400F-8C6D-E2C28CCBA633}</Project>
+      <Name>OpenRA.Game</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/OpenRA.CrashDialog/Program.cs
+++ b/OpenRA.CrashDialog/Program.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -11,15 +11,21 @@
 using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Media;
+using System.Reflection;
 using System.Windows.Forms;
+using OpenRA;
 
-namespace OpenRA
+namespace OpenRA.CrashDialog
 {
-	public static class FatalErrorDialog
+	class FatalErrorDialog
 	{
-		public static void Show()
+		static Settings settings;
+		public static void Main(string[] args)
 		{
+			settings = new Settings(Platform.SupportDir + "settings.yaml", new Arguments());
+
 			var form = new Form
 			{
 				Size = new Size(315, 140),
@@ -27,7 +33,8 @@ namespace OpenRA
 				MinimizeBox = false,
 				MaximizeBox = false,
 				FormBorderStyle = FormBorderStyle.FixedDialog,
-				StartPosition = FormStartPosition.CenterScreen
+				StartPosition = FormStartPosition.CenterScreen,
+				Icon = Icon.ExtractAssociatedIcon(Assembly.GetExecutingAssembly().Location)
 			};
 
 			var notice = new Label
@@ -76,8 +83,8 @@ namespace OpenRA
 
 			form.FormClosed += (sender, e) =>
 			{
-				Game.Settings.Debug.ShowFatalErrorDialog = !dontShowAgain.Checked;
-				Game.Settings.Save();
+				settings.Debug.ShowFatalErrorDialog = !dontShowAgain.Checked;
+				settings.Save();
 			};
 
 			SystemSounds.Exclamation.Play();
@@ -88,7 +95,7 @@ namespace OpenRA
 		{
 			try
 			{
-				Process.Start(Log.LogPath);
+				Process.Start(Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar);
 			}
 			catch { }
 		}
@@ -97,7 +104,7 @@ namespace OpenRA
 		{
 			try
 			{
-				Process.Start(Game.Settings.Debug.FatalErrorDialogFaq);
+				Process.Start(settings.Debug.FatalErrorDialogFaq);
 			}
 			catch { }
 		}

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -14,7 +14,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Windows.Forms;
 using OpenRA.Support;
 
 namespace OpenRA.Graphics
@@ -125,15 +124,8 @@ namespace OpenRA.Graphics
 
 		public Size Resolution { get { return device.WindowSize; } }
 
-		// Work around a bug in OSX 10.6.8 / mono 2.10.2 / SDL 1.2.14
-		// which makes the window non-interactive in Windowed/Pseudofullscreen mode.
-		static Screen FixOSX() { return Screen.PrimaryScreen; }
-
 		internal static void Initialize(WindowMode windowMode)
 		{
-			if (Platform.CurrentPlatform == PlatformType.OSX)
-				FixOSX();
-
 			var resolution = GetResolution(windowMode);
 
 			var renderer = Game.Settings.Server.Dedicated ? "Null" : Game.Settings.Graphics.Renderer;

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -154,7 +154,6 @@
     <Compile Include="Server\TraitInterfaces.cs" />
     <Compile Include="Sound.cs" />
     <Compile Include="Support\Arguments.cs" />
-    <Compile Include="Support\FatalErrorDialog.cs" />
     <Compile Include="Support\PerfHistory.cs" />
     <Compile Include="Support\Program.cs" />
     <Compile Include="Sync.cs" />

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -62,7 +62,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="SharpFont">
       <SpecificVersion>False</SpecificVersion>

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -92,5 +92,16 @@ namespace OpenRA
 				return dir + Path.DirectorySeparatorChar;
 			}
 		}
+
+		public static void ShowFatalErrorDialog()
+		{
+			var process = "OpenRA.CrashDialog.exe";
+			var args = "";
+
+			var psi = new ProcessStartInfo(process, args);
+			psi.UseShellExecute = false;
+			psi.CreateNoWindow = true;
+			Process.Start(psi);
+		}
 	}
 }

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -13,7 +13,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Windows.Forms;
 
 namespace OpenRA
 {
@@ -22,9 +21,6 @@ namespace OpenRA
 		[STAThread]
 		static void Main(string[] args)
 		{
-			// brutal hack
-			Application.CurrentCulture = CultureInfo.InvariantCulture;
-
 			if (Debugger.IsAttached || args.Contains("--just-die"))
 			{
 				Run(args);

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -62,7 +62,7 @@ namespace OpenRA
 			if (Game.Settings.Debug.ShowFatalErrorDialog && !Game.Settings.Server.Dedicated)
 			{
 				Game.Renderer.Device.Quit();
-				FatalErrorDialog.Show();
+				Platform.ShowFatalErrorDialog();
 			}
 		}
 

--- a/OpenRA.Utility/OpenRA.Utility.csproj
+++ b/OpenRA.Utility/OpenRA.Utility.csproj
@@ -58,7 +58,6 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/OpenRA.sln
+++ b/OpenRA.sln
@@ -50,6 +50,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tiberian Dawn Lua scripts",
 		mods\cnc\maps\gdi03\gdi03.lua = mods\cnc\maps\gdi03\gdi03.lua
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.CrashDialog", "OpenRA.CrashDialog\OpenRA.CrashDialog.csproj", "{47F1B0EE-EB35-47F2-93E4-273C70909157}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +107,14 @@ Global
 		{33D03738-C154-4028-8EA8-63A3C488A651}.Release|Any CPU.Build.0 = Release|Any CPU
 		{33D03738-C154-4028-8EA8-63A3C488A651}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{33D03738-C154-4028-8EA8-63A3C488A651}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{47F1B0EE-EB35-47F2-93E4-273C70909157}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{4A8A43B5-A9EF-4ED0-99DD-4BAB10A0DB6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4A8A43B5-A9EF-4ED0-99DD-4BAB10A0DB6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A8A43B5-A9EF-4ED0-99DD-4BAB10A0DB6E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -28,7 +28,7 @@ markdown CONTRIBUTING.md > CONTRIBUTING.html
 markdown DOCUMENTATION.md > DOCUMENTATION.html
 
 # List of files that are packaged on all platforms
-FILES=('OpenRA.Game.exe' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' \
+FILES=('OpenRA.Game.exe' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' 'OpenRA.CrashDialog.exe' \
 'OpenRA.Renderer.Sdl2.dll' 'OpenRA.Renderer.Null.dll' 'OpenRA.Irc.dll' \
 'FreeSans.ttf' 'FreeSansBold.ttf' 'lua' \
 'glsl' 'mods/common' 'mods/ra' 'mods/cnc' 'mods/d2k' 'mods/modchooser' \

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -66,6 +66,7 @@ Section "Game" GAME
 	SetOutPath "$INSTDIR"
 	File "${SRCDIR}\OpenRA.Game.exe"
 	File "${SRCDIR}\OpenRA.Utility.exe"
+	File "${SRCDIR}\OpenRA.CrashDialog.exe"
 	File "${SRCDIR}\OpenRA.Renderer.Null.dll"
 	File "${SRCDIR}\OpenRA.Renderer.Sdl2.dll"
 	File "${SRCDIR}\OpenRA.Irc.dll"
@@ -186,6 +187,7 @@ Function ${UN}Clean
 	Delete $INSTDIR\OpenRA.Launcher.exe
 	Delete $INSTDIR\OpenRA.Game.exe
 	Delete $INSTDIR\OpenRA.Utility.exe
+	Delete $INSTDIR\OpenRA.CrashDialog.exe
 	Delete $INSTDIR\OpenRA.Editor.exe
 	Delete $INSTDIR\OpenRA.Renderer.Null.dll
 	Delete $INSTDIR\OpenRA.Renderer.Sdl2.dll

--- a/thirdparty/SharpFont.dll.config
+++ b/thirdparty/SharpFont.dll.config
@@ -2,6 +2,6 @@
 <configuration>
 	<dllmap dll="freetype6.dll">
 		<dllentry os="linux" dll="libfreetype.so.6" />
-		<dllentry os="osx" dll="/usr/X11/lib/libfreetype.6.dylib" />
+		<dllentry os="osx" dll="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
 	</dllmap>
 </configuration>


### PR DESCRIPTION
This removes Windows.Forms from the game and utility, which combine with the custom libSDL2.dylib in #5190 to remove our dependency on X11/XQuartz under OSX.

This fixes the excessive font-caching delay (#4785) and looks much nicer:

![dialogs](https://cloud.githubusercontent.com/assets/167819/2871519/de7d8d42-d311-11e3-94d2-3e2dbfc87932.png)

Test packages (osxtest-20140504) are sitting on the build server, and I have verified that the OSX/Windows/Ubuntu packages work.
