### PR TITLE
tweaks to balance: artillery min. range & more

### DIFF
--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -113,8 +113,8 @@ E5:
 	Valued:
 		Cost: 300
 	Tooltip:
-		Name: Chem Warrior
-		Description: Weaponized-tiberium infantry.\n  Strong vs all Ground units
+		Name: Chemical Warrior
+		Description: Advanced general-purpose infantry.\n  Strong vs all Ground units
 	Buildable:
 		BuildPaletteOrder: 50
 		Owner: nod

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -68,7 +68,7 @@ E3:
 	Health:
 		HP: 45
 	AutoTarget:
-		ScanRadius: 5
+		ScanRadius: 6
 	Armament:
 		Weapon: Rockets
 		LocalOffset: 256,43,341
@@ -195,7 +195,7 @@ RMBO:
 	RevealsShroud:
 		Range: 6c0
 	AutoTarget:
-		ScanRadius: 5
+		ScanRadius: 6
 	C4Demolition:
 		C4Delay: 45
 	Armament:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -27,7 +27,7 @@ E2:
 		Cost: 160
 	Tooltip:
 		Name: Grenadier
-		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
+		Description: Fast infantry armed with grenades. \n  Strong vs Buildings, slow-moving targets
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq
@@ -84,7 +84,7 @@ E4:
 		Cost: 200
 	Tooltip:
 		Name: Flamethrower
-		Description: Advanced Anti-infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
+		Description: Advanced Anti-infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Tanks
 	Buildable:
 		BuildPaletteOrder: 40
 		Owner: nod
@@ -114,7 +114,7 @@ E5:
 		Cost: 300
 	Tooltip:
 		Name: Chem Warrior
-		Description: Advanced Anti-infantry unit.\n  Strong vs Infantry\n  Weak vs Vehicles
+		Description: Weaponized-tiberium infantry.\n  Strong vs all Ground units
 	Buildable:
 		BuildPaletteOrder: 50
 		Owner: nod

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -283,7 +283,7 @@ WEAP:
 		Cost: 2000
 	Tooltip:
 		Name: Weapons Factory
-		Description: Assembly point for\nvehicle reinforcements
+		Description: Produces vehicles
 	ProvidesCustomPrerequisite:
 		Prerequisite: vehicleproduction
 	Buildable:
@@ -354,7 +354,7 @@ HQ:
 		Cost: 1000
 	Tooltip:
 		Name: Communications Center
-		Description: Provides an overview of the battlefield.\n  Requires power to operate.
+		Description: Provides radar & Air Strike support power. \nUnlocks higher-tech units & buildings.  \nRequires power to operate.
 	ProvidesCustomPrerequisite:
 		Prerequisite: anyhq
 	Buildable:
@@ -429,7 +429,7 @@ EYE:
 		Cost: 1800
 	Tooltip:
 		Name: Advanced Communications Center
-		Description: Provides access to the Ion Cannon.\n  Requires power to operate.
+		Description: Provides radar & Orbital Ion Cannon support power. \nUnlocks Mammoth Tank & Commando.  \nRequires power to operate.
 	ProvidesCustomPrerequisite:
 		Prerequisite: anyhq
 	Buildable:
@@ -474,7 +474,7 @@ TMPL:
 		Cost: 2000
 	Tooltip:
 		Name: Temple of Nod
-		Description: Place of worship and secret missile silo.\n  Requires power to operate.
+		Description: Provides Nuclear Strike support power. \nUnlocks Stealth Tank, Chem. Warrior & Obelisk of Light.  \nRequires power to operate.
 	ProvidesCustomPrerequisite:
 		Prerequisite: anyhq
 	Buildable:
@@ -520,7 +520,7 @@ GUN:
 		Value: 1440
 	Tooltip:
 		Name: Turret
-		Description: Anti-Armor base defense.\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
+		Description: Basic Anti-Tank base defense.\n  Strong vs Tanks, vehicles\n  Weak vs Infantry
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 45
@@ -563,7 +563,7 @@ SAM:
 		Value: 2160
 	Tooltip:
 		Name: SAM Site
-		Description: Anti-Air base defense.\n  Strong vs Aircraft\n  Weak vs Infantry, Tanks
+		Description: Anti-Aircraft base defense.\n  Strong vs Aircraft\n  Cannot target Ground units.
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 50
@@ -603,7 +603,7 @@ OBLI:
 		Value: 3120
 	Tooltip:
 		Name: Obelisk of Light
-		Description: Advanced base defense.\n  Requires power to operate.\n  Strong vs Tanks, Infantry\n  Weak vs Aircraft
+		Description: Advanced base defense. \nRequires power to operate.\n  Strong vs all Ground units\n  Cannot target Aircraft
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 60
@@ -649,7 +649,7 @@ GTWR:
 		Value: 1440
 	Tooltip:
 		Name: Guard Tower
-		Description: Basic defensive structure.\n  Strong vs Infantry\n  Weak vs Tanks, Aircraft
+		Description: Basic defensive structure.\n  Strong vs Infantry\n  Weak vs Tanks
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 40
@@ -688,7 +688,7 @@ ATWR:
 		Value: 2880
 	Tooltip:
 		Name: Advanced Guard Tower
-		Description: Anti-armor defensive structure.\n  Strong vs Light Vehicles, Tanks\n  Weak vs Infantry
+		Description: All-purpose defensive structure.\n  Strong vs Aircraft, Tanks\n  Weak vs Infantry
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 60
@@ -737,7 +737,7 @@ SBAG:
 		Value: 0
 	Tooltip:
 		Name: Sandbag Barrier
-		Description: Stops infantry and blocks enemy fire.\nCan be crushed by tanks.
+		Description: Stops infantry & light vehicles. \nCan be crushed by tanks.
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 20
@@ -761,7 +761,7 @@ CYCL:
 		Value: 0
 	Tooltip:
 		Name: Chain Link Barrier
-		Description: Stops infantry and blocks enemy fire.\nCan be crushed by tanks.
+		Description: Stops infantry & light vehicles. \nCan be crushed by tanks.
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 20
@@ -785,7 +785,7 @@ BRIK:
 		Value: 0
 	Tooltip:
 		Name: Concrete Barrier
-		Description: Stop units and blocks enemy fire.
+		Description: Stop units.
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 30

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -78,7 +78,7 @@ APC:
 		Cost: 600
 	Tooltip:
 		Name: APC
-		Description: Armored infantry transport and mobile AA\n  Strong vs Aircraft, Vehicles\n  Weak vs Infantry
+		Description: Armed infantry transport. \nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: pyle
@@ -125,7 +125,7 @@ ARTY:
 		Cost: 600
 	Tooltip:
 		Name: Artillery
-		Description: Long-range artillery.\n  Strong vs Infantry, Vehicles\n  Weak vs Tanks, Aircraft
+		Description: Long-range artillery.\n  Strong vs Infantry, Vehicles & Buildings
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: anyhq
@@ -161,7 +161,7 @@ FTNK:
 		Cost: 600
 	Tooltip:
 		Name: Flame Tank
-		Description: Heavily armored flame-throwing vehicle.\n  Strong vs Infantry, Buildings, Vehicles\n  Weak vs Aircraft
+		Description: Heavily armored flame-throwing vehicle.\n  Strong vs Infantry, Buildings & Vehicles\n  Weak vs Tanks
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: anyhq
@@ -197,7 +197,7 @@ BGGY:
 		Cost: 300
 	Tooltip:
 		Name: Nod Buggy
-		Description: Fast scout & anti-infantry vehicle.\n  Strong vs Infantry, Vehicles\n  Weak vs Tanks, Aircraft
+		Description: Fast scout & anti-infantry vehicle.\n  Strong vs Infantry\n  Weak vs Tanks
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: afld
@@ -232,7 +232,7 @@ BIKE:
 		Cost: 500
 	Tooltip:
 		Name: Recon Bike
-		Description: Fast scout vehicle, armed with \nrockets.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
+		Description: Fast scout vehicle, armed with \nrockets. \nCan attack Aircraft.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: afld
@@ -269,7 +269,7 @@ JEEP:
 		Cost: 400
 	Tooltip:
 		Name: Hum-Vee
-		Description: Fast scout & anti-infantry vehicle.\n  Strong vs Infantry, Vehicles\n  Weak vs Tanks, Aircraft
+		Description: Fast scout & anti-infantry vehicle.\n  Strong vs Infantry\n  Weak vs Tanks
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: weap
@@ -304,7 +304,7 @@ LTNK:
 		Cost: 600
 	Tooltip:
 		Name: Light Tank
-		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry, Aircraft
+		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq
@@ -343,7 +343,7 @@ MTNK:
 		Cost: 800
 	Tooltip:
 		Name: Medium Tank
-		Description: General-Purpose GDI Tank.\n  Strong vs Tanks, Vehicles\n  Weak vs Infantry, Aircraft
+		Description: General-Purpose GDI Tank.\n  Strong vs Tanks, Vehicles\n  Weak vs Infantry
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq
@@ -383,7 +383,7 @@ HTNK:
 		Cost: 1500
 	Tooltip:
 		Name: Mammoth Tank
-		Description: Heavily armored GDI Tank.\n  Strong vs Everything
+		Description: Heavily armored GDI Tank. \nCan attack Aircraft.\n  Strong vs Everything
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: eye
@@ -436,7 +436,7 @@ MSAM:
 		Cost: 1200
 	Tooltip:
 		Name: Rocket Launcher
-		Description: Long range rocket artillery.\n  Strong vs all ground units.
+		Description: Long range rocket artillery.\n  Strong vs all Ground units.
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: anyhq
@@ -473,7 +473,7 @@ MLRS:
 		Cost: 600
 	Tooltip:
 		Name: Mobile S.A.M.
-		Description: Powerful anti-air unit.\nCannot attack ground units.
+		Description: Powerful anti-air unit. \nCannot attack Ground units.
 	Buildable:
 		BuildPaletteOrder: 70
 		Prerequisites: anyhq
@@ -513,7 +513,7 @@ STNK:
 		Cost: 900
 	Tooltip:
 		Name: Stealth Tank
-		Description: Long-range missile tank that can cloak.\nHas weak armor. Can be spotted by infantry.\n  Strong vs Vehicles, Tanks, Aircraft\n  Weak vs Infantry.
+		Description: Long-range missile tank that can cloak. \nCan attack Aircraft. \nHas weak armor. Can be spotted by infantry.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry.
 	Buildable:
 		BuildPaletteOrder: 90
 		Prerequisites: tmpl

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -410,7 +410,7 @@ Chemspray:
 		Spread: 256
 		Versus:
 			None: 100%
-			Wood: 50%
+			Wood: 35%
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 6

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -250,7 +250,7 @@ Rockets:
 		Trail: smokey
 		ContrailLength: 8
 		Speed: 298
-		RangeLimit: 30
+		RangeLimit: 20
 	Warhead:
 		Spread: 128
 		Versus:
@@ -282,7 +282,7 @@ BikeRockets:
 		Trail: smokey
 		ContrailLength: 8
 		Speed: 298
-		RangeLimit: 40
+		RangeLimit: 20
 	Warhead:
 		Spread: 128
 		Versus:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -643,7 +643,7 @@ MammothMissiles:
 ArtilleryShell:
 	ROF: 65
 	Range: 11c0
-	MinRange: 2c0
+	MinRange: 2c896
 	Report: TNKFIRE2.AUD
 	Projectile: Bullet
 		Speed: 204


### PR DESCRIPTION
Artillery was recently buffed, but I think this makes the fact that they can currently fire at close range is not appropriate. I think artillery should be vulnerable to units that are able to get quite close, instead of being able to fire at them and do massive damage.

The reason min. range of 2c896 was picked is that when you set min. range to 3c0, it is not able to fire exactly 3 cells away. Perhaps the behaviour should change so that 3c0 = 3 cells away. 

(For comparison, MLRS has minimum range of 3).
