### PR TITLE
3091 Have Helis take off after repair/rearm

### DIFF
--- a/OpenRA.Mods.RA/Activities/Rearm.cs
+++ b/OpenRA.Mods.RA/Activities/Rearm.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.RA.Air;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
@@ -34,10 +35,16 @@ namespace OpenRA.Mods.RA.Activities
 
 			if (--remainingTicks == 0)
 			{
-				if (!limitedAmmo.GiveAmmo()) return NextActivity;
-
 				var hostBuilding = self.World.ActorMap.GetUnitsAt(self.Location)
 					.FirstOrDefault(a => a.HasTrait<RenderBuilding>());
+
+				if (!limitedAmmo.GiveAmmo())
+				{
+					var helicopter = self.TraitOrDefault<Helicopter>();
+					if (helicopter != null)
+						return helicopter.TakeOff(hostBuilding);
+					else return NextActivity;
+				}
 
 				if (hostBuilding != null)
 					hostBuilding.Trait<RenderBuilding>().PlayCustomAnim(hostBuilding, "active");

--- a/OpenRA.Mods.RA/Activities/Repair.cs
+++ b/OpenRA.Mods.RA/Activities/Repair.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using OpenRA.Mods.RA.Air;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
@@ -30,7 +31,13 @@ namespace OpenRA.Mods.RA.Activities
 			health = self.TraitOrDefault<Health>();
 			if (health == null) return NextActivity;
 			if (health.DamageState == DamageState.Undamaged)
+			{
+				var helicopter = self.TraitOrDefault<Helicopter>();
+				if (helicopter != null)
+					return helicopter.TakeOff(host);
+
 				return NextActivity;
+			}
 
 			if (remainingTicks == 0)
 			{
@@ -44,6 +51,7 @@ namespace OpenRA.Mods.RA.Activities
 					remainingTicks = 1;
 					return this;
 				}
+
 				self.InflictDamage(self, -hpToRepair, null);
 
 				if (host != null)

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.RA.Air
 			return info.LandableTerrainTypes.Contains(type);
 		}
 
-		public IEnumerable<Activity> GetResupplyActivities(Actor a)
+		public virtual IEnumerable<Activity> GetResupplyActivities(Actor a)
 		{
 			var name = a.Info.Name;
 			if (info.RearmBuildings.Contains(name))

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -928,6 +928,7 @@ HPAD:
 		SpawnOffset: 0,-256,0
 		ExitCell: 0,0
 		MoveIntoWorld: false
+	RallyPoint:
 	Production:
 		Produces: Helicopter
 	Reservable:


### PR DESCRIPTION
As per polish request:
https://github.com/OpenRA/OpenRA/issues/3091

Will run the Helicopter Activity TakeOff() whenever a helicopter is fully rearmed or repaired, or constructed.
TakeOff() attempts to find the rally point for the building below it. If it does not exist, it will simply hover over the building. If it can't, it will simply hover over its current position.
