### PR TITLE
Added native Gtk+ crash dialogs on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,8 @@ install-core: default
 	@$(INSTALL_PROGRAM) thirdparty/Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) thirdparty/RestSharp.dll "$(DATA_INSTALL_DIR)"
 
+	@$(INSTALL_PROGRAM) -m +rx "error-dialog.sh" "$(DATA_INSTALL_DIR)"
+
 	@echo "#!/bin/sh" > openra
 	@echo 'BINDIR=$$(dirname $$(readlink -f $$0))' >> openra
 	@echo 'ROOTDIR="$${BINDIR%'"$(bindir)"'}"' >> openra

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,9 @@ install-core: default
 	@$(INSTALL_PROGRAM) thirdparty/Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) thirdparty/RestSharp.dll "$(DATA_INSTALL_DIR)"
 
-	@$(INSTALL_PROGRAM) -m +rx "error-dialog.sh" "$(DATA_INSTALL_DIR)"
+ifeq ($(shell uname),Linux)
+	@$(CP) *.sh "$(DATA_INSTALL_DIR)"
+endif
 
 	@echo "#!/bin/sh" > openra
 	@echo 'BINDIR=$$(dirname $$(readlink -f $$0))' >> openra

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,7 @@ install-core: default
 	@$(INSTALL_PROGRAM) thirdparty/MaxMind.GeoIP2.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) thirdparty/Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) thirdparty/RestSharp.dll "$(DATA_INSTALL_DIR)"
+	@$(CP) thirdparty/${platformdeps}/* "$(DATA_INSTALL_DIR)"
 
 ifeq ($(shell uname),Linux)
 	@$(CP) *.sh "$(DATA_INSTALL_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 
 # program targets
-CORE = rsdl2 rnull game utility irc crashdialog
+CORE = rsdl2 rnull game utility irc
 TOOLS = editor tsbuild ralint
 
 VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
@@ -253,11 +253,11 @@ $(foreach prog,$(PROGRAMS),$(eval $(call BUILD_ASSEMBLY,$(prog))))
 #
 default: dependencies core
 
-core: game renderers mods utility crashdialog
+core: game renderers mods utility ralint
 
-tools: editor tsbuild ralint
+tools: editor tsbuild crashdialog
 
-package: dependencies core editor docs version
+package: dependencies core editor crashdialog docs version
 
 mods: mod_ra mod_cnc mod_d2k mod_ts
 

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -129,7 +129,7 @@ namespace OpenRA
 				).F(title, message, icon, logsButton, logsPath, faqButton, faqPath, quitButton);
 			}
 
-			if (CurrentPlatform == PlatformType.Linux && File.Exists("/usr/bin/zenity") && File.Exists("/usr/bin/xdg-open"))
+			if (CurrentPlatform == PlatformType.Linux)
 				process = "error-dialog.sh";
 
 			var psi = new ProcessStartInfo(process, args);

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -129,6 +129,9 @@ namespace OpenRA
 				).F(title, message, icon, logsButton, logsPath, faqButton, faqPath, quitButton);
 			}
 
+			if (CurrentPlatform == PlatformType.Linux && File.Exists("/usr/bin/zenity") && File.Exists("/usr/bin/xdg-open"))
+				process = "error-dialog.sh";
+
 			var psi = new ProcessStartInfo(process, args);
 			psi.UseShellExecute = false;
 			psi.CreateNoWindow = true;

--- a/error-dialog.sh
+++ b/error-dialog.sh
@@ -1,11 +1,3 @@
 #!/bin/sh
-
-zenity --error --title "OpenRA" --text "OpenRA has encountered a fatal error."
-
-zenity --question --title "OpenRA" --text="Would you like have a look at the crash log files?" || exit
-
-xdg-open ~/.openra/Logs
-
-zenity --question --title "OpenRA" --text="Would you like to read the FAQ?" || exit
-
-xdg-open https://github.com/OpenRA/OpenRA/wiki/FAQ
+ZENITY=`which zenity` || echo "OpenRA needs zenity installed to display a graphical error dialog. See ~/.openra. for log files."
+$ZENITY --question --title "OpenRA" --text "OpenRA has encountered a fatal error.\nLog Files are available in ~/.openra." --ok-label "Quit" --cancel-label "View FAQ" || xdg-open https://github.com/OpenRA/OpenRA/wiki/FAQ

--- a/error-dialog.sh
+++ b/error-dialog.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+zenity --error --title "OpenRA" --text "OpenRA has encountered a fatal error."
+
+zenity --question --title "OpenRA" --text="Would you like have a look at the crash log files?" || exit
+
+xdg-open ~/.openra/Logs
+
+zenity --question --title "OpenRA" --text="Would you like to read the FAQ?" || exit
+
+xdg-open https://github.com/OpenRA/OpenRA/wiki/FAQ

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# example launch script, see https://github.com/OpenRA/OpenRA/wiki/Dedicated for details
 Name="Dedicated-Server"
 Mod="ra"
 Dedicated="True"

--- a/launch-editor.sh
+++ b/launch-editor.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+# launch script (executed by Desura)
 exec mono OpenRA.Editor.exe "$@"

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+# launch script (executed by Desura)
 exec mono OpenRA.Game.exe Server.Dedicated=False Server.DedicatedLoop=False "$@"

--- a/launch-replay.sh
+++ b/launch-replay.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# TODO choose the correct Game.Mod instead of crashing
 cd ${0%/*}
 exec mono OpenRA.Game.exe Launch.Replay="$@"

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -24,9 +24,6 @@ make install-all prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 # Native library dependencies
 cp "$DEPSDIR"/* "$PWD/packaging/linux/$ROOTDIR/usr/lib/openra/" || exit 3
 
-# Launch scripts (executed by Desura)
-cp *.sh "$PWD/packaging/linux/$ROOTDIR/usr/lib/openra/" || exit 3
-
 # Icons and .desktop files
 make install-shortcuts prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -24,6 +24,9 @@ make install-all prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 # Icons and .desktop files
 make install-shortcuts prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 
+# Remove the WinForms dialog which is replaced with a native one provided by zenity
+rm $PWD/packaging/linux/$ROOTDIR/usr/lib/openra/OpenRA.CrashDialog.exe
+
 # Documentation
 mkdir -p $PWD/packaging/linux/$ROOTDIR/usr/share/doc/openra/
 cp *.html $PWD/packaging/linux/$ROOTDIR/usr/share/doc/openra/

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -21,9 +21,6 @@ cd ../..
 # Copy files for OpenRA.Game.exe and OpenRA.Editor.exe as well as all dependencies.
 make install-all prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 
-# Native library dependencies
-cp "$DEPSDIR"/* "$PWD/packaging/linux/$ROOTDIR/usr/lib/openra/" || exit 3
-
 # Icons and .desktop files
 make install-shortcuts prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 

--- a/packaging/linux/deb/DEBIAN/control
+++ b/packaging/linux/deb/DEBIAN/control
@@ -3,7 +3,7 @@ Version: {VERSION}
 Architecture: all
 Maintainer: Chris Forbes <chrisf@ijw.co.nz>
 Installed-Size: {SIZE}
-Depends: libopenal1, mono-runtime (>= 2.10), libmono-system-core4.0-cil, libmono-system-drawing4.0-cil, libmono-system-windows-forms4.0-cil, libfreetype6, libc6, libasound2, libgl1-mesa-glx, libgl1-mesa-dri
+Depends: libopenal1, mono-runtime (>= 2.10), libmono-system-core4.0-cil, libmono-system-drawing4.0-cil, libmono-system-windows-forms4.0-cil, libfreetype6, libc6, libasound2, libgl1-mesa-glx, libgl1-mesa-dri, xdg-utils, zenity
 Section: games
 Priority: extra
 Homepage: http://www.open-ra.org/

--- a/packaging/linux/pkgbuild/PKGBUILD
+++ b/packaging/linux/pkgbuild/PKGBUILD
@@ -7,7 +7,7 @@ arch=('any')
 url="http://open-ra.org"
 license=('GPL3')
 groups=()
-depends=('mono' 'openal' 'mesa' 'freetype2' 'glibc' 'alsa-lib')
+depends=('mono' 'openal' 'mesa' 'freetype2' 'glibc' 'alsa-lib' 'xdg-utils' 'zenity')
 makedepends=('git' 'unzip' 'wget')
 optdepends=('gksu: Elevation for installing game packages on Gnome platforms'
 'kdesudo: Elevation for installing game packages on KDE platforms')

--- a/packaging/linux/rpm/openra.spec
+++ b/packaging/linux/rpm/openra.spec
@@ -22,6 +22,8 @@ Requires: libdl.so.2
 Requires: libm.so.6
 Requires: libpthread.so.0
 Requires: librt.so.1
+Requires: xdg-utils
+Requires: zenity
 
 Prefix: /usr
 Source: %{name}-%{version}.tar.gz

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -16,9 +16,11 @@ fi
 cp -rv template.app OpenRA.app
 cp -rv $2/* $3/* "OpenRA.app/Contents/Resources/" || exit 3
 
-# Icon isn't used, and editor doesn't work.
+# Remove unused icon
 rm OpenRA.app/Contents/Resources/OpenRA.ico
+# Remove broken WinForms applications
 rm OpenRA.app/Contents/Resources/OpenRA.Editor.exe
+rm OpenRA.app/Contents/Resources/OpenRA.CrashDialog.exe
 
 # Package app bundle into a zip and clean up
 zip OpenRA-$1 -r -9 OpenRA.app

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -21,7 +21,7 @@ make package
 # Remove the mdb files that are created during `make`
 find . -path "*.mdb" -delete
 
-wget https://raw.github.com/wiki/OpenRA/OpenRA/Changelog.md
+wget https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md
 markdown Changelog.md > CHANGELOG.html
 markdown README.md > README.html
 markdown CONTRIBUTING.md > CONTRIBUTING.html

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -21,6 +21,7 @@ make package
 # Remove the mdb files that are created during `make`
 find . -path "*.mdb" -delete
 
+rm Changelog.md
 wget https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md
 markdown Changelog.md > CHANGELOG.html
 markdown README.md > README.html


### PR DESCRIPTION
A followup of #5244 that addresses the annoyances of the WinForms crash dialog on Linux like #3872 and #3849 using https://help.gnome.org/users/zenity/stable/message.html which is a little limited, but available everywhere http://pkgs.org/download/zenity.
