### PR TITLE
buff HeliGun vs. light armor 50% -> 75%

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -174,7 +174,7 @@ HeliAGGun:
 		Versus:
 			None: 100%
 			Wood: 50%
-			Light: 50%
+			Light: 75%
 			Heavy: 25%
 		InfDeath: 2
 		Explosion: piffs


### PR DESCRIPTION
Apache, for all its greatness, doesn't do very well at one of the things it's supposed to do well, namely take out light vehicles quickly (humvee, artillery, MLRS, etc.). Apache is required for Nod as a reliable way to take out MLRS, but currently it doesn't do enough damage to take it out with its entire payload (which takes 4 seconds to unload, to boot). A single Apache should be able to destroy an MLRS, if it gets the chance.

If anyone thinks the Apache needs nerfing, I would suggest looking in other areas besides its damage vs. light armor. 

Also, does anyone object to removing the AG/AA distinctions for helicopters? They don't seem needed anymore.
