### PR TITLE
Fixing Helis taking off after rearmed but before repaired

### DIFF
--- a/OpenRA.Mods.RA/Activities/Rearm.cs
+++ b/OpenRA.Mods.RA/Activities/Rearm.cs
@@ -42,8 +42,17 @@ namespace OpenRA.Mods.RA.Activities
 				{
 					var helicopter = self.TraitOrDefault<Helicopter>();
 					if (helicopter != null)
+					{
+						if (helicopter.Info.RepairBuildings.Contains(hostBuilding.Info.Name) && self.HasTrait<Health>())
+						{
+							if (self.Trait<Health>().DamageState != DamageState.Undamaged)
+								return NextActivity;
+						}
+
 						return helicopter.TakeOff(hostBuilding);
-					else return NextActivity;
+					}
+
+					return NextActivity;
 				}
 
 				if (hostBuilding != null)

--- a/OpenRA.Mods.RA/Activities/Repair.cs
+++ b/OpenRA.Mods.RA/Activities/Repair.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Mods.RA.Air;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
@@ -34,7 +35,15 @@ namespace OpenRA.Mods.RA.Activities
 			{
 				var helicopter = self.TraitOrDefault<Helicopter>();
 				if (helicopter != null)
+				{
+					if (helicopter.Info.RearmBuildings.Contains(host.Info.Name) && self.HasTrait<LimitedAmmo>())
+					{
+						if (self.Trait<LimitedAmmo>().FullAmmo() == false)
+							return NextActivity;
+					}
+
 					return helicopter.TakeOff(host);
+				}
 
 				return NextActivity;
 			}


### PR DESCRIPTION
Fixing an issue that I just created, in that Helis would land, and take off as soon as either they were reloaded, or repaired. Now, if it finds that it's on a building that does both(Specifically Cnc/Td), it will wait until both are finished.
