### PR TITLE
closes #4779 Deploy hotkey F not repairing orcas/apaches in cnc/td

### DIFF
--- a/OpenRA.Mods.RA/Air/HeliReturn.cs
+++ b/OpenRA.Mods.RA/Air/HeliReturn.cs
@@ -57,8 +57,7 @@ namespace OpenRA.Mods.RA.Air
 				new HeliFly(self, Target.FromPos(dest.CenterPosition + offset)),
 				new Turn(initialFacing),
 				new HeliLand(false),
-				new Rearm(self),
-				NextActivity);
+				new ResupplyAircraft());
 		}
 	}
 }


### PR DESCRIPTION
As per  #4779, the HeliReturn activity was lacking any call to the Repair activity. Using ResupplyAircraft instead allows for rearm, and repair if applicable.
