### PR TITLE
OpenRA.Thirdparty is now OpenRA.Support

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						if (!string.IsNullOrEmpty(line))
 							mirrorList.Add(line);
 				}
-				mirror = mirrorList.Random(new OpenRA.Thirdparty.Random());
+				mirror = mirrorList.Random(new OpenRA.Support.Random());
 
 				// Save the package to a temp file
 				var dl = new Download(mirror, file, onDownloadProgress, onDownloadComplete);


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/4843 to unbreak the build.
