### PR TITLE
Fix strange d2k loading slowness

### DIFF
--- a/OpenRA.Game/FileFormats/R8Reader.cs
+++ b/OpenRA.Game/FileFormats/R8Reader.cs
@@ -62,8 +62,8 @@ namespace OpenRA.FileFormats
 
 	public class R8Reader : ISpriteSource
 	{
-		readonly List<R8Image> frames = new List<R8Image>();
-		public IEnumerable<ISpriteFrame> Frames { get { return frames.Cast<ISpriteFrame>(); } }
+		readonly List<ISpriteFrame> frames = new List<ISpriteFrame>();
+		public IEnumerable<ISpriteFrame> Frames { get { return frames; } }
 		public bool CacheWhenLoadingTileset { get { return true; } }
 
 		public readonly int ImageCount;

--- a/OpenRA.Game/FileFormats/ShpD2Reader.cs
+++ b/OpenRA.Game/FileFormats/ShpD2Reader.cs
@@ -86,8 +86,8 @@ namespace OpenRA.FileFormats
 
 	public class ShpD2Reader : ISpriteSource
 	{
-		List<Frame> headers = new List<Frame>();
-		public IEnumerable<ISpriteFrame> Frames { get { return headers.Cast<ISpriteFrame>(); } }
+		readonly List<ISpriteFrame> frames = new List<ISpriteFrame>();
+		public IEnumerable<ISpriteFrame> Frames { get { return frames; } }
 		public bool CacheWhenLoadingTileset { get { return false; } }
 
 		public ShpD2Reader(Stream s)
@@ -108,7 +108,7 @@ namespace OpenRA.FileFormats
 			for (var i = 0; i < imageCount; i++)
 			{
 				s.Position = offsets[i];
-				headers.Add(new Frame(s));
+				frames.Add(new Frame(s));
 			}
 		}
 	}

--- a/OpenRA.Game/FileFormats/ShpReader.cs
+++ b/OpenRA.Game/FileFormats/ShpReader.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -58,7 +59,8 @@ namespace OpenRA.FileFormats
 	public class ShpReader : ISpriteSource
 	{
 		readonly List<ImageHeader> headers = new List<ImageHeader>();
-		public IEnumerable<ISpriteFrame> Frames { get { return headers.Cast<ISpriteFrame>(); } }
+		Lazy<IEnumerable<ISpriteFrame>> spriteFrames;
+		public IEnumerable<ISpriteFrame> Frames { get { return spriteFrames.Value; } }
 		public bool CacheWhenLoadingTileset { get { return false; } }
 		public readonly Size Size;
 
@@ -93,6 +95,8 @@ namespace OpenRA.FileFormats
 
 			foreach (var h in headers)
 				Decompress(stream, h);
+
+			spriteFrames = Exts.Lazy(() => headers.Cast<ISpriteFrame>());
 		}
 
 		static byte[] ReadCompressedData(Stream stream, ImageHeader h)

--- a/OpenRA.Game/FileFormats/ShpTSReader.cs
+++ b/OpenRA.Game/FileFormats/ShpTSReader.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -46,7 +47,8 @@ namespace OpenRA.FileFormats
 	public class ShpTSReader : ISpriteSource
 	{
 		readonly List<FrameHeader> frames = new List<FrameHeader>();
-		public IEnumerable<ISpriteFrame> Frames { get { return frames.Cast<ISpriteFrame>(); } }
+		Lazy<IEnumerable<ISpriteFrame>> spriteFrames;
+		public IEnumerable<ISpriteFrame> Frames { get { return spriteFrames.Value; } }
 		public bool CacheWhenLoadingTileset { get { return false; } }
 
 		public ShpTSReader(Stream stream)
@@ -95,6 +97,8 @@ namespace OpenRA.FileFormats
 					}
 				}
 			}
+
+			spriteFrames = Exts.Lazy(() => frames.Cast<ISpriteFrame>());
 		}
 	}
 }

--- a/OpenRA.Game/FileFormats/TmpRAReader.cs
+++ b/OpenRA.Game/FileFormats/TmpRAReader.cs
@@ -18,8 +18,8 @@ namespace OpenRA.FileFormats
 {
 	public class TmpRAReader : ISpriteSource
 	{
-		readonly List<TmpTile> tiles = new List<TmpTile>();
-		public IEnumerable<ISpriteFrame> Frames { get { return tiles.Cast<ISpriteFrame>(); } }
+		readonly List<ISpriteFrame> tiles = new List<ISpriteFrame>();
+		public IEnumerable<ISpriteFrame> Frames { get { return tiles; } }
 		public bool CacheWhenLoadingTileset { get { return false; } }
 
 		public TmpRAReader(Stream s)

--- a/OpenRA.Game/FileFormats/TmpTDReader.cs
+++ b/OpenRA.Game/FileFormats/TmpTDReader.cs
@@ -37,8 +37,8 @@ namespace OpenRA.FileFormats
 
 	public class TmpTDReader : ISpriteSource
 	{
-		readonly List<TmpTile> tiles = new List<TmpTile>();
-		public IEnumerable<ISpriteFrame> Frames { get { return tiles.Cast<ISpriteFrame>(); } }
+		readonly List<ISpriteFrame> tiles = new List<ISpriteFrame>();
+		public IEnumerable<ISpriteFrame> Frames { get { return tiles; } }
 		public bool CacheWhenLoadingTileset { get { return false; } }
 
 		public TmpTDReader(Stream s)

--- a/OpenRA.Game/FileFormats/TmpTSReader.cs
+++ b/OpenRA.Game/FileFormats/TmpTSReader.cs
@@ -51,8 +51,8 @@ namespace OpenRA.FileFormats
 
 	public class TmpTSReader : ISpriteSource
 	{
-		readonly List<TmpTSTile> tiles = new List<TmpTSTile>();
-		public IEnumerable<ISpriteFrame> Frames { get { return tiles.Cast<ISpriteFrame>(); } }
+		readonly List<ISpriteFrame> tiles = new List<ISpriteFrame>();
+		public IEnumerable<ISpriteFrame> Frames { get { return tiles; } }
 		public bool CacheWhenLoadingTileset { get { return false; } }
 
 		public TmpTSReader(Stream s)

--- a/OpenRA.Game/Graphics/SpriteSource.cs
+++ b/OpenRA.Game/Graphics/SpriteSource.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Graphics
 
 	public interface ISpriteSource
 	{
+		// TODO: Change this to IReadOnlyList so users don't need to call .ToArray()
 		IEnumerable<ISpriteFrame> Frames { get; }
 		bool CacheWhenLoadingTileset { get; }
 	}


### PR DESCRIPTION
Note: I tracked this down to being a Mono bug that was fixed somewhere between  3.2.8 and 3.4.0. I don't know if you want this merged or not.

There is a strange issue that appears when Theater calls
ISpriteFrame.Frames on the R8Reader. The R8Reader uses
IEnumerable.Cast<> which behaves slower and slower, which
makes map loading become 10+ times slower.

The changes here simply avoid the casting.
