### PR TITLE
Balance adjust: Return LTNK dmg. vs. wood to 75%

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -432,7 +432,7 @@ Grenade:
 		Spread: 341
 		Versus:
 			None: 100%
-			Wood: 75%
+			Wood: 50%
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 3

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -452,7 +452,7 @@ Grenade:
 		Spread: 128
 		Versus:
 			None: 25%
-			Wood: 100%
+			Wood: 75%
 			Light: 100%
 			Heavy: 100%
 			Concrete: 50%


### PR DESCRIPTION
It seemed that the tanks were inept at hurting buildings and needed a boost. However, after playtesting, it's clear that Nod's flame tank is already exceptional at destroying buildings, and the recon bikes are quite decent at it, too. Thus, the light tank's effectiveness at killing buildings is overlapping with the flame tank (same tech level & cost), making most Nod units effective at hurting buildings. So, I think this is in order to preserve distinct roles among the vehicles.
