### PR TITLE
Added resource splattering to destroyed harvesters

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -22,8 +22,8 @@ namespace OpenRA.GameRules
 		[FieldLoader.LoadUsing("LoadVersus")]
 		[Desc("Damage vs each armortype. 0% = can't target.")]
 		public readonly Dictionary<string, float> Versus;
-		[Desc("Can this damage ore?")]
-		public readonly bool Ore = false;
+		[Desc("Can this damage resource patches?")]
+		public readonly bool DestroyResources = false;
 		[Desc("Explosion effect to use.")]
 		public readonly string Explosion = null;
 		[Desc("Palette to use for explosion effect.")]

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -24,6 +24,8 @@ namespace OpenRA.GameRules
 		public readonly Dictionary<string, float> Versus;
 		[Desc("Can this damage resource patches?")]
 		public readonly bool DestroyResources = false;
+		[Desc("Will this splatter resources and which?")]
+		public readonly string AddsResourceType = null;
 		[Desc("Explosion effect to use.")]
 		public readonly string Explosion = null;
 		[Desc("Palette to use for explosion effect.")]

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -37,39 +37,39 @@ namespace OpenRA.Traits
 
 		[Sync] public int Cash;
 
-		[Sync] public int Ore;
-		[Sync] public int OreCapacity;
+		[Sync] public int Resources;
+		[Sync] public int ResourceCapacity;
 
 		public int DisplayCash;
-		public int DisplayOre;
+		public int DisplayResources;
 		public bool AlertSilo;
 
 		public int Earned;
 		public int Spent;
 
-		public bool CanGiveOre(int amount)
+		public bool CanGiveResources(int amount)
 		{
-			return Ore + amount <= OreCapacity;
+			return Resources + amount <= ResourceCapacity;
 		}
 
-		public void GiveOre(int num)
+		public void GiveResources(int num)
 		{
-			Ore += num;
+			Resources += num;
 			Earned += num;
 
-			if (Ore > OreCapacity)
+			if (Resources > ResourceCapacity)
 			{
 				nextSiloAdviceTime = 0;
 
-				Earned -= Ore - OreCapacity;
-				Ore = OreCapacity;
+				Earned -= Resources - ResourceCapacity;
+				Resources = ResourceCapacity;
 			}
 		}
 
-		public bool TakeOre(int num)
+		public bool TakeResources(int num)
 		{
-			if (Ore < num) return false;
-			Ore -= num;
+			if (Resources < num) return false;
+			Resources -= num;
 			Spent += num;
 
 			return true;
@@ -83,15 +83,15 @@ namespace OpenRA.Traits
 
 		public bool TakeCash(int num)
 		{
-			if (Cash + Ore < num) return false;
+			if (Cash + Resources < num) return false;
 
 			// Spend ore before cash
-			Ore -= num;
+			Resources -= num;
 			Spent += num;
-			if (Ore < 0)
+			if (Resources < 0)
 			{
-				Cash += Ore;
-				Ore = 0;
+				Cash += Resources;
+				Resources = 0;
 			}
 
 			return true;
@@ -107,16 +107,16 @@ namespace OpenRA.Traits
 			if (nextCashTickTime > 0)
 				nextCashTickTime--;
 
-			OreCapacity = self.World.ActorsWithTrait<IStoreOre>()
+			ResourceCapacity = self.World.ActorsWithTrait<IStoreResources>()
 				.Where(a => a.Actor.Owner == Owner)
 				.Sum(a => a.Trait.Capacity);
 
-			if (Ore > OreCapacity)
-				Ore = OreCapacity;
+			if (Resources > ResourceCapacity)
+				Resources = ResourceCapacity;
 
 			if (--nextSiloAdviceTime <= 0)
 			{
-				if (Ore > 0.8 * OreCapacity)
+				if (Resources > 0.8 * ResourceCapacity)
 				{
 					Sound.PlayNotification(self.World.Map.Rules, Owner, "Speech", "SilosNeeded", Owner.Country.Race);
 					AlertSilo = true;
@@ -143,18 +143,18 @@ namespace OpenRA.Traits
 				playCashTickDown(self);
 			}
 
-			diff = Math.Abs(Ore - DisplayOre);
+			diff = Math.Abs(Resources - DisplayResources);
 			move = Math.Min(Math.Max((int)(diff * displayCashFracPerFrame),
 					displayCashDeltaPerFrame), diff);
 
-			if (DisplayOre < Ore)
+			if (DisplayResources < Resources)
 			{
-				DisplayOre += move;
+				DisplayResources += move;
 				playCashTickUp(self);
 			}
-			else if (DisplayOre > Ore)
+			else if (DisplayResources > Resources)
 			{
-				DisplayOre -= move;
+				DisplayResources -= move;
 				playCashTickDown(self);
 			}
 		}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -90,8 +90,9 @@ namespace OpenRA.Traits
 		bool IsValidTarget(Actor self, Actor saboteur);
 	}
 
-	public interface IStoreOre { int Capacity { get; } }
+	public interface IStoreResources { int Capacity { get; } }
 	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
+
 	public interface IEffectiveOwner
 	{
 		bool Disguised { get; }

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -153,6 +153,13 @@ namespace OpenRA.Traits
 			return true;
 		}
 
+		public bool CanSpawnResourceAt(ResourceType newResourceType, CPos cell)
+		{
+			var currentResourceType = GetResource(cell);
+			return currentResourceType == newResourceType
+				|| (currentResourceType == null && AllowResourceAt(newResourceType, cell));
+		}
+
 		CellContents CreateResourceCell(ResourceType t, CPos p)
 		{
 			world.Map.CustomTerrain[p.X, p.Y] = world.TileSet.GetTerrainIndex(t.Info.TerrainType);

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncIngameChromeLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncIngameChromeLogic.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			var powerManager = world.LocalPlayer.PlayerActor.Trait<PowerManager>();
 			var playerResources = world.LocalPlayer.PlayerActor.Trait<PlayerResources>();
 			sidebarRoot.Get<LabelWidget>("CASH").GetText = () =>
-				"${0}".F(playerResources.DisplayCash + playerResources.DisplayOre);
+				"${0}".F(playerResources.DisplayCash + playerResources.DisplayResources);
 
 			playerWidgets.Get<ButtonWidget>("OPTIONS_BUTTON").OnClick = OptionsClicked;
 
@@ -104,14 +104,14 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			};
 
 			var siloBar = playerWidgets.Get<ResourceBarWidget>("SILOBAR");
-			siloBar.GetProvided = () => playerResources.OreCapacity;
-			siloBar.GetUsed = () => playerResources.Ore;
+			siloBar.GetProvided = () => playerResources.ResourceCapacity;
+			siloBar.GetUsed = () => playerResources.Resources;
 			siloBar.TooltipFormat = "Silo Usage: {0}/{1}";
-			siloBar.GetBarColor = () => 
+			siloBar.GetBarColor = () =>
 			{
-				if (playerResources.Ore == playerResources.OreCapacity)
+				if (playerResources.Resources == playerResources.ResourceCapacity)
 					return Color.Red;
-				if (playerResources.Ore >= 0.8 * playerResources.OreCapacity)
+				if (playerResources.Resources >= 0.8 * playerResources.ResourceCapacity)
 					return Color.Orange;
 				return Color.LimeGreen;
 			};

--- a/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTooltipLogic.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 
 				var costString = "$: {0}".F(cost);
 				costLabel.GetText = () => costString;
-				costLabel.GetColor = () => pr.DisplayCash + pr.DisplayOre >= cost
+				costLabel.GetColor = () => pr.DisplayCash + pr.DisplayResources >= cost
 					? Color.White : Color.Red;
 
 				var descString = tooltip.Description.Replace("\\n", "\n");

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -71,14 +71,14 @@ namespace OpenRA.Mods.RA
 						throw new NotImplementedException("Unknown smudge type `{0}`".F(smudgeType));
 
 					smudgeLayer.AddSmudge(sc);
-					if (warhead.Ore)
+					if (warhead.DestroyResources)
 						resLayer.Destroy(sc);
 				}
 
 				// Destroy all resources in range, not just the outer shell:
 				foreach (var cell in allCells)
 				{
-					if (warhead.Ore)
+					if (warhead.DestroyResources)
 						resLayer.Destroy(cell);
 				}
 			}
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.RA
 				}
 			}
 
-			if (warhead.Ore)
+			if (warhead.DestroyResources)
 				world.WorldActor.Trait<ResourceLayer>().Destroy(targetTile);
 
 			switch (warhead.DamageModel)

--- a/OpenRA.Mods.RA/InfiltrateForCash.cs
+++ b/OpenRA.Mods.RA/InfiltrateForCash.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA
 			var targetResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 			var spyResources = infiltrator.Owner.PlayerActor.Trait<PlayerResources>();
 
-			var toTake = (targetResources.Cash + targetResources.Ore) * info.Percentage / 100;
+			var toTake = (targetResources.Cash + targetResources.Resources) * info.Percentage / 100;
 			var toGive = Math.Max(toTake, info.Minimum);
 			
 			targetResources.TakeCash(toTake);

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -358,7 +358,7 @@
     <Compile Include="SpawnMPUnits.cs" />
     <Compile Include="SpawnMapActors.cs" />
     <Compile Include="Disguise.cs" />
-    <Compile Include="StoresOre.cs" />
+    <Compile Include="StoresResources.cs" />
     <Compile Include="StrategicVictoryConditions.cs" />
     <Compile Include="SupplyTruck.cs" />
     <Compile Include="SupportPowers\AirstrikePower.cs" />

--- a/OpenRA.Mods.RA/OreRefinery.cs
+++ b/OpenRA.Mods.RA/OreRefinery.cs
@@ -63,11 +63,11 @@ namespace OpenRA.Mods.RA
 				.Where(a => a.Trait.LinkedProc == self);
 		}
 
-		public bool CanGiveOre(int amount) { return PlayerResources.CanGiveOre(amount); }
+		public bool CanGiveOre(int amount) { return PlayerResources.CanGiveResources(amount); }
 
 		public void GiveOre(int amount)
 		{
-			PlayerResources.GiveOre(amount);
+			PlayerResources.GiveResources(amount);
 			if (Info.ShowTicks)
 				currentDisplayValue += amount;
 		}

--- a/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
@@ -30,9 +30,10 @@ namespace OpenRA.Mods.RA.Render
 		public void BuildingComplete(Actor self)
 		{
 			var animation = (self.GetDamageState() >= DamageState.Heavy) ? "damaged-idle" : "idle";
+
 			DefaultAnimation.PlayFetchIndex(animation,
-				() => playerResources.OreCapacity != 0
-				? ((10 * DefaultAnimation.CurrentSequence.Length - 1) * playerResources.Ore) / (10 * playerResources.OreCapacity)
+				() => playerResources.ResourceCapacity != 0
+				? ((10 * DefaultAnimation.CurrentSequence.Length - 1) * playerResources.Resources) / (10 * playerResources.ResourceCapacity)
 					: 0);
 		}
 

--- a/OpenRA.Mods.RA/Render/WithResources.cs
+++ b/OpenRA.Mods.RA/Render/WithResources.cs
@@ -37,8 +37,8 @@ namespace OpenRA.Mods.RA.Render
 
 			anim = new Animation(self.World, rs.GetImage(self));
 			anim.PlayFetchIndex(info.Sequence,
-			                    () => playerResources.OreCapacity != 0
-			                    ? ((10 * anim.CurrentSequence.Length - 1) * playerResources.Ore) / (10 * playerResources.OreCapacity)
+			                    () => playerResources.ResourceCapacity != 0
+			                    ? ((10 * anim.CurrentSequence.Length - 1) * playerResources.Resources) / (10 * playerResources.ResourceCapacity)
 			                    : 0);
 
 			rs.Add("resources_{0}".F(info.Sequence), new AnimationWithOffset(

--- a/OpenRA.Mods.RA/Scripting/Properties/ResourceProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ResourceProperties.cs
@@ -28,12 +28,12 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("The amount of harvestable resources held by the player.")]
 		public int Resources
 		{
-			get { return pr.Ore; }
-			set { pr.Ore = value.Clamp(0, pr.OreCapacity); }
+			get { return pr.Resources; }
+			set { pr.Resources = value.Clamp(0, pr.ResourceCapacity); }
 		}
 
 		[Desc("The maximum resource storage of the player.")]
-		public int ResourceCapacity { get { return pr.OreCapacity; } }
+		public int ResourceCapacity { get { return pr.ResourceCapacity; } }
 
 		[Desc("The amount of cash held by the player.")]
 		public int Cash

--- a/OpenRA.Mods.RA/SeedsResource.cs
+++ b/OpenRA.Mods.RA/SeedsResource.cs
@@ -63,16 +63,13 @@ namespace OpenRA.Mods.RA
 				.SkipWhile(p => resLayer.GetResource(p) == resourceType && resLayer.IsFull(p.X, p.Y))
 				.Cast<CPos?>().FirstOrDefault();
 
-			if (cell != null && self.World.Map.IsInMap(cell.Value) &&
-				(resLayer.GetResource(cell.Value) == resourceType
-				|| (resLayer.GetResource(cell.Value) == null && resLayer.AllowResourceAt(resourceType, cell.Value))))
+			if (cell != null && resLayer.CanSpawnResourceAt(resourceType, cell.Value))
 				resLayer.AddResource(resourceType, cell.Value, 1);
-
 		}
 
 		static IEnumerable<CPos> RandomWalk(CPos p, MersenneTwister r)
 		{
-			for (; ; )
+			for (;;)
 			{
 				var dx = r.Next(-1, 2);
 				var dy = r.Next(-1, 2);

--- a/OpenRA.Mods.RA/StoresResources.cs
+++ b/OpenRA.Mods.RA/StoresResources.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -13,23 +13,23 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	class StoresOreInfo : ITraitInfo
+	class StoresResourcesInfo : ITraitInfo
 	{
 		[Desc("Number of little squares used to display how filled unit is.")]
 		public readonly int PipCount = 0;
 		public readonly PipType PipColor = PipType.Yellow;
 		public readonly int Capacity = 0;
-		public object Create(ActorInitializer init) { return new StoresOre(init.self, this); }
+		public object Create(ActorInitializer init) { return new StoresResources(init.self, this); }
 	}
 
-	class StoresOre : IPips, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreOre, ISync
+	class StoresResources : IPips, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreResources, ISync
 	{
-		readonly StoresOreInfo Info;
+		readonly StoresResourcesInfo Info;
 
-		[Sync] public int Stored { get { return Player.OreCapacity == 0 ? 0 : Info.Capacity * Player.Ore / Player.OreCapacity; } }
+		[Sync] public int Stored { get { return Player.ResourceCapacity == 0 ? 0 : Info.Capacity * Player.Resources / Player.ResourceCapacity; } }
 
 		PlayerResources Player;
-		public StoresOre(Actor self, StoresOreInfo info)
+		public StoresResources(Actor self, StoresResourcesInfo info)
 		{
 			Player = self.Owner.PlayerActor.Trait<PlayerResources>();
 			Info = info;
@@ -39,22 +39,22 @@ namespace OpenRA.Mods.RA
 
 		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
 		{
-			var ore = Stored;
-			Player.TakeOre(ore);
+			var resources = Stored;
+			Player.TakeResources(resources);
 			Player = newOwner.PlayerActor.Trait<PlayerResources>();
-			Player.GiveOre(ore);
+			Player.GiveResources(resources);
 		}
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			Player.TakeOre(Stored);	// Lose the stored ore
+			Player.TakeResources(Stored); // lose the stored resources
 		}
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			return Exts.MakeArray( Info.PipCount,
-				i => ( Player.Ore * Info.PipCount > i * Player.OreCapacity )
-					? Info.PipColor : PipType.Transparent );
+			return Exts.MakeArray(Info.PipCount,
+				i => (Player.Resources * Info.PipCount > i * Player.ResourceCapacity)
+					? Info.PipColor : PipType.Transparent);
 		}
 
 		public bool ShouldExplode(Actor self) { return Stored > 0; }

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -489,7 +489,7 @@ namespace OpenRA.Mods.RA.Widgets
 			var power = pl.PlayerActor.Trait<PowerManager>();
 
 			DrawRightAligned("${0}".F(cost), pos + new int2(-5, 5),
-				(resources.DisplayCash + resources.DisplayOre >= cost ? Color.White : Color.Red));
+				(resources.DisplayCash + resources.DisplayResources >= cost ? Color.White : Color.Red));
 
 			var lowpower = power.PowerState != PowerState.Normal;
 			var time = CurrentQueue.GetBuildTime(info.Name)

--- a/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
 			if (stats == null) return template;
 
-			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayOre);
+			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayResources);
 			template.Get<LabelWidget>("EARNED_MIN").GetText = () => AverageEarnedPerMinute(res.Earned);
 			template.Get<LabelWidget>("EARNED_THIS_MIN").GetText = () => "$" + stats.EarnedThisMinute;
 			template.Get<LabelWidget>("EARNED").GetText = () => "$" + res.Earned;
@@ -251,7 +251,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			LobbyUtils.AddPlayerFlagAndName(template, player);
 
 			var res = player.PlayerActor.Trait<PlayerResources>();
-			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayOre);
+			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.DisplayCash + res.DisplayResources);
 			template.Get<LabelWidget>("EARNED_MIN").GetText = () => AverageEarnedPerMinute(res.Earned);
 
 			var powerRes = player.PlayerActor.Trait<PowerManager>();

--- a/OpenRA.Mods.RA/Widgets/MoneyBinWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/MoneyBinWidget.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.RA.Widgets
 				new float2(Bounds.Left, 0));
 
 			// Cash
-			var cashDigits = (playerResources.DisplayCash + playerResources.DisplayOre).ToString();
+			var cashDigits = (playerResources.DisplayCash + playerResources.DisplayResources).ToString();
 			var x = Bounds.Right - 65;
 
 			foreach (var d in cashDigits.Reverse())

--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -246,6 +246,12 @@ namespace OpenRA.Utility
 						node.Value.Nodes.RemoveAll(n => n.Key == "TeslaInstantKills");
 				}
 
+				if (engineVersion < 20140615)
+				{
+					if (depth == 1 && node.Key == "StoresOre")
+						node.Key = "StoresResources";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
@@ -306,6 +312,12 @@ namespace OpenRA.Utility
 								break;
 						}
 					}
+				}
+
+				if (engineVersion < 20140615)
+				{
+					if (depth == 2 && parentKey == "Warhead" && node.Key == "Ore" )
+						node.Key = "DestroyResources";
 				}
 
 				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1);

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -119,7 +119,7 @@ PROC:
 	TiberiumRefinery:
 		DockOffset: 0,2
 		TickRate: 15
-	StoresOre:
+	StoresResources:
 		PipColor: Green
 		PipCount: 10
 		Capacity: 2000
@@ -158,7 +158,7 @@ SILO:
 	Bib:
 		HasMinibib: Yes
 	RenderBuildingSilo:
-	StoresOre:
+	StoresResources:
 		PipCount: 10
 		PipColor: Green
 		Capacity: 2000

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -71,6 +71,8 @@ HARV:
 		HuskActor: HARV.Husk
 	-GainsExperience:
 	RenderHarvester:
+	Explodes:
+		Weapon: TiberiumExplosion
 
 APC:
 	Inherits: ^Tank

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -877,6 +877,21 @@ Tiberium:
 		Damage: 2
 		PreventProne: yes
 
+TiberiumExplosion:
+	Warhead:
+		Damage: 10
+		Spread: 9
+		Size: 1,1
+		Versus:
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: chemball
+		InfDeath: 3
+		ImpactSound: xplosml2.aud
+		AddsResourceType: Tiberium
+
 Heal:
 	ROF: 4
 	Warhead:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -78,7 +78,7 @@ Atomic:
 		SmudgeType: Scorch
 		Spread: 2c512
 		Size: 3
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -92,7 +92,7 @@ Atomic:
 		SmudgeType: Scorch
 		Spread: 3c768
 		Size: 4
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -105,7 +105,7 @@ Atomic:
 		SmudgeType: Scorch
 		Spread: 5c0
 		Size: 5
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -119,14 +119,14 @@ IonCannon:
 	Warhead@impact:
 		Damage: 900
 		Spread: 853
-		Ore: true
+		DestroyResources: true
 		InfDeath: 5
 	Warhead@area:
 		DamageModel: PerCell
 		Damage: 0
 		SmudgeType: Scorch
 		Size: 2,1
-		Ore: true
+		DestroyResources: true
 		Delay: 3
 		InfDeath: 5
 

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -178,7 +178,7 @@ CONCRETEB:
 		DockOffset: 2,1
 		DockAngle: 160
 		TickRate: 20
-	StoresOre:
+	StoresResources:
 		PipColor: green
 		PipCount: 10
 		Capacity: 2000
@@ -220,7 +220,7 @@ CONCRETEB:
 		Range: 4c0
 	-RenderBuilding:
 	RenderBuildingSilo:
-	StoresOre:
+	StoresResources:
 		PipColor: green
 		PipCount: 5
 		Capacity: 2000

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -77,7 +77,7 @@ HARVESTER:
 	RevealsShroud:
 		Range: 4c0
 	Explodes:
-		Weapon: UnitExplodeScale
+		Weapon: SpiceExplosion
 		EmptyWeapon: UnitExplodeScale
 	LeavesHusk:
 		HuskActor: Harvester.Husk

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -649,3 +649,18 @@ Shrapnel:
 		Damage: 60
 		ImpactSound: EXPLLG5.WAV
 
+SpiceExplosion:
+	Warhead:
+		Damage: 10
+		Spread: 9
+		Size: 2,2
+		Versus:
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: med_explosion
+		InfDeath: 3
+		ImpactSound: EXPLLG5.WAV
+		AddsResourceType: Spice
+

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -850,7 +850,7 @@ PROC:
 		Range: 6c0
 	Bib:
 	OreRefinery:
-	StoresOre:
+	StoresResources:
 		PipCount: 17
 		Capacity: 2000
 	IronCurtainable:
@@ -897,7 +897,7 @@ SILO:
 	Bib:
 		HasMinibib: Yes
 	RenderBuildingSilo:
-	StoresOre:
+	StoresResources:
 		PipCount: 5
 		Capacity: 1500
 	IronCurtainable:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -285,7 +285,7 @@ HARV:
 		FullHuskActor: HARV.FullHusk
 		FullnessThreshold: 50
 	Explodes:
-		Weapon: UnitExplodeSmall
+		Weapon: OreExplosion
 		EmptyWeapon: UnitExplodeSmall
 
 MCV:

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -639,7 +639,7 @@ CrateNuke:
 	Warhead@impact:
 		Damage: 1000
 		Spread: 256
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -654,7 +654,7 @@ CrateNuke:
 		Damage: 250
 		SmudgeType: Scorch
 		Size: 5,4
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
@@ -1021,7 +1021,7 @@ Atomic:
 		Spread: 1c0
 		SmudgeType: Scorch
 		Size: 1
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Explosion: nuke
@@ -1033,7 +1033,7 @@ Atomic:
 		Spread: 2c0
 		SmudgeType: Scorch
 		Size: 2
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 5
@@ -1044,7 +1044,7 @@ Atomic:
 		Spread: 3c0
 		SmudgeType: Scorch
 		Size: 3
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 10
@@ -1054,7 +1054,7 @@ Atomic:
 		Spread: 4c0
 		SmudgeType: Scorch
 		Size: 4
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 15
@@ -1064,7 +1064,7 @@ Atomic:
 		Spread: 5c0
 		SmudgeType: Scorch
 		Size: 5
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 20
@@ -1076,7 +1076,7 @@ MiniNuke:
 		Damage: 1500
 		Spread: 1c0
 		Size: 1
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Explosion: nuke
@@ -1087,7 +1087,7 @@ MiniNuke:
 		Damage: 600
 		Spread: 2c0
 		Size: 2
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 5
@@ -1097,7 +1097,7 @@ MiniNuke:
 		Damage: 600
 		Spread: 3c0
 		Size: 3
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 10
@@ -1107,7 +1107,7 @@ MiniNuke:
 		Spread: 4c0
 		Size: 4
 		SmudgeType: Scorch
-		Ore: true
+		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 15

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -1360,3 +1360,18 @@ MADTankDetonate:
 		ImpactSound: mineblo1.aud
 		SmudgeType: Crater
 
+OreExplosion:
+	Warhead:
+		Damage: 10
+		Spread: 9
+		Size: 1,1
+		Versus:
+			None: 90%
+			Wood: 75%
+			Light: 60%
+			Heavy: 25%
+		Explosion: med_explosion
+		InfDeath: 3
+		ImpactSound: kaboom25.aud
+		AddsResourceType: Ore
+

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -133,7 +133,7 @@ PROC:
 		Range: 6
 #	Bib:
 	TiberiumRefinery:
-	StoresOre:
+	StoresResources:
 		PipColor: Green
 		PipCount: 15
 		Capacity: 1500

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -427,7 +427,7 @@ SuicideBomb:
 	Warhead:
 		Damage: 11000
 		Spread: 256
-		Ore: true
+		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%


### PR DESCRIPTION
However, the mechanic introduced (weapons being able to create resource patches) is much more generic. https://github.com/OpenRA/OpenRA/issues/2346 This is just a default setup as suggested in #2074. You can now also create Tiberium missiles etc.
