### PR TITLE
Fixes #5278: SAM site on the TD shellmap starts open

### DIFF
--- a/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.RA
 
 		public void BuildingComplete(Actor self)
 		{
-			if (!skippedMakeAnimation)
+			if (skippedMakeAnimation)
 			{
 				state = PopupState.Closed;
 				rb.PlayCustomAnimRepeating(self, "closed-idle");


### PR DESCRIPTION
I think I got this.

Previously, not only it was starting open on the shellmap, when you build one in-game it would be built open and then close immediately, without animation.

Now the it starts closed on the shellmap and stays open (for a while) when you build it in-game.
