### PR TITLE
Nuke/Ion Cannon actor targeting fix

### DIFF
--- a/OpenRA.Mods.Cnc/Effects/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Effects/IonCannon.cs
@@ -20,13 +20,17 @@ namespace OpenRA.Mods.Cnc.Effects
 	{
 		Target target;
 		Animation anim;
-		Actor firedBy;
+		Player firedBy;
+		string palette;
+		string weapon;
 
-		public IonCannon(Actor firedBy, World world, CPos location)
+		public IonCannon(Player firedBy, string weapon, World world, CPos location, string effect, string palette)
 		{
 			this.firedBy = firedBy;
+			this.weapon = weapon;
+			this.palette = palette;
 			target = Target.FromCell(location);
-			anim = new Animation("ionsfx");
+			anim = new Animation(effect);
 			anim.PlayThen("idle", () => Finish(world));
 		}
 
@@ -34,13 +38,13 @@ namespace OpenRA.Mods.Cnc.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return anim.Render(target.CenterPosition, wr.Palette("effect"));
+			return anim.Render(target.CenterPosition, wr.Palette(palette));
 		}
 
 		void Finish(World world)
 		{
 			world.AddFrameEndTask(w => w.Remove(this));
-			Combat.DoExplosion(firedBy, "IonCannon", target.CenterPosition);
+			Combat.DoExplosion(firedBy.PlayerActor, weapon, target.CenterPosition);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/IonCannonPower.cs
@@ -21,9 +21,13 @@ namespace OpenRA.Mods.Cnc
 		[ActorReference]
 		[Desc("Actor to spawn when the attack starts")]
 		public readonly string CameraActor = null;
-
 		[Desc("Amount of time to keep the camera alive")]
 		public readonly int CameraRemoveDelay = 25;
+		[Desc("Effect sequence to display")]
+		public readonly string Effect = "ionsfx";
+		public readonly string EffectPalette = "effect";
+		[Desc("Which weapon to fire")]
+		public readonly string Weapon = "IonCannon";
 
 		public override object Create(ActorInitializer init) { return new IonCannonPower(init.self, this); }
 	}
@@ -46,7 +50,7 @@ namespace OpenRA.Mods.Cnc
 			{
 				var info = Info as IonCannonPowerInfo;
 				Sound.Play(Info.LaunchSound, order.TargetLocation.CenterPosition);
-				w.Add(new IonCannon(self, w, order.TargetLocation));
+				w.Add(new IonCannon(self.Owner, info.Weapon, w, order.TargetLocation, info.Effect, info.EffectPalette));
 
 				if (info.CameraActor == null)
 					return;

--- a/OpenRA.Mods.RA/Effects/NukeLaunch.cs
+++ b/OpenRA.Mods.RA/Effects/NukeLaunch.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Effects
 {
 	public class NukeLaunch : IEffect
 	{
-		readonly Actor firedBy;
+		readonly Player firedBy;
 		readonly Animation anim;
 		readonly string weapon;
 
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA.Effects
 		WPos pos;
 		int ticks;
 
-		public NukeLaunch(Actor firedBy, string weapon, WPos launchPos, WPos targetPos, WRange velocity, int delay, bool skipAscent)
+		public NukeLaunch(Player firedBy, string weapon, WPos launchPos, WPos targetPos, WRange velocity, int delay, bool skipAscent)
 		{
 			this.firedBy = firedBy;
 			this.weapon = weapon;
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.RA.Effects
 		void Explode(World world)
 		{
 			world.AddFrameEndTask(w => w.Remove(this));
-			Combat.DoExplosion(firedBy, weapon, pos);
+			Combat.DoExplosion(firedBy.PlayerActor, weapon, pos);
 			world.WorldActor.Trait<ScreenShaker>().AddEffect(20, pos, 5);
 
 			foreach (var a in world.ActorsWithTrait<NukePaletteEffect>())

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA
 			var rb = self.Trait<RenderSimple>();
 			rb.PlayCustomAnim(self, "active");
 
-			self.World.AddFrameEndTask(w => w.Add(new NukeLaunch(self, npi.MissileWeapon,
+			self.World.AddFrameEndTask(w => w.Add(new NukeLaunch(self.Owner, npi.MissileWeapon,
 				self.CenterPosition + body.LocalToWorld(npi.SpawnOffset),
 				order.TargetLocation.CenterPosition,
 				npi.FlightVelocity, npi.FlightDelay, npi.SkipAscent)));


### PR DESCRIPTION
Fixes #5239 (at least it should).

The added customizability of the IonCannon support power was something I had already done about a week ago, it caused no problems during my tests and it shouldn't cause any regressions since all it does is un-hardcode some things.
