### PR TITLE
Fix encoding problems with ZipFile

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using ICSharpCode.SharpZipLib.Zip;
 using SZipFile = ICSharpCode.SharpZipLib.Zip.ZipFile;
 
@@ -20,6 +21,11 @@ namespace OpenRA.FileSystem
 		string filename;
 		SZipFile pkg;
 		int priority;
+
+		static ZipFile()
+		{
+			ZipConstants.DefaultCodePage = Encoding.Default.CodePage;
+		}
 
 		public ZipFile(string filename, int priority)
 		{


### PR DESCRIPTION
SharpZipLib seems to use default "OEM" encoding for decoding the file names in the archive. This may cause problems if the default OEM encoding (as reported by mono) do not installed in the system.

Mono seems to select the OEM code page based on system locale. On Russian system it is 866, on Greek - 737 (as reported by #5261). On some system these "OEM" code pages are not installed and the game crashes.

I think it's sufficient to use the default encoding for file names (as we hopefully don't store some non-ASCII filenames there).

This patch should fix bug #5261.
