### PR TITLE
Remove the deprecation notice from the old Lua interface

### DIFF
--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -46,9 +46,6 @@ namespace OpenRA.Mods.RA.Scripting
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
-			Game.Debug("Warning: This map uses the deprecated scripting interface, which will be removed in a future release. " +
-				"If you are the map author, then please see the OpenRA wiki for instructions on how to migrate to the new API.");
-
 			world = w;
 			sma = world.WorldActor.Trait<SpawnMapActors>();
 


### PR DESCRIPTION
Fixes #5332.  The impending deprecation should probably still be
mentioned in the release notes.
