### PR TITLE
Fixes inconsistency in reload times for Cnc Aircraft

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ Also thanks to:
     * Pavlos Touboulidis (pav)
     * Pizzaoverhead
     * Psydev
+    * Raymond Bedrossian (Squiggles211)
     * Raymond Martineau (mart0258)
     * Reaperrr
     * Riderr3

--- a/OpenRA.Mods.RA/LimitedAmmo.cs
+++ b/OpenRA.Mods.RA/LimitedAmmo.cs
@@ -58,6 +58,8 @@ namespace OpenRA.Mods.RA
 
 		public void Attacking(Actor self, Target target, Armament a, Barrel barrel) { TakeAmmo(); }
 
+		public int GetAmmoCount() { return ammo; }
+
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
 			var pips = Info.PipCount != 0 ? Info.PipCount : Info.Ammo;


### PR DESCRIPTION
Fixes the timing inconsistencies of #4755 but does not change the reload behavior of the Apache.  I will leave that to a later balance pr, but these changes provide the code necessary to facilitate the new behavior of making the reload counter reset when the actor fires a shot.  By default this behavior is turned off and it begins trying to reload once it no longer has max ammo, and does not reset the counter.
