### PR TITLE
Renamed OpenRA.Support.Random aka XRandom to MersenneTwister

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using OpenRA.Support;
 
 namespace OpenRA
 {
@@ -100,13 +101,13 @@ namespace OpenRA
 			return ret;
 		}
 
-		public static T Random<T>(this IEnumerable<T> ts, Support.Random r)
+		public static T Random<T>(this IEnumerable<T> ts, MersenneTwister r)
 		{
 			var xs = ts.ToArray();
 			return xs[r.Next(xs.Length)];
 		}
 
-		public static T RandomOrDefault<T>(this IEnumerable<T> ts, Support.Random r)
+		public static T RandomOrDefault<T>(this IEnumerable<T> ts, MersenneTwister r)
 		{
 			if (!ts.Any())
 				return default(T);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -24,8 +24,6 @@ using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Widgets;
 
-using XRandom = OpenRA.Support.Random;
-
 namespace OpenRA
 {
 	public static class Game
@@ -39,7 +37,7 @@ namespace OpenRA
 		internal static OrderManager orderManager;
 		static Server.Server server;
 
-		public static XRandom CosmeticRandom = new XRandom();	// not synced
+		public static MersenneTwister CosmeticRandom = new MersenneTwister(); // not synced
 
 		public static Renderer Renderer;
 		public static bool HasInputFocus = false;

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -247,6 +247,7 @@
     <Compile Include="ModMetadata.cs" />
     <Compile Include="GameRules\Ruleset.cs" />
     <Compile Include="GameRules\RulesetCache.cs" />
+    <Compile Include="Support\MersenneTwister.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />
@@ -321,7 +322,6 @@
     <Compile Include="WRot.cs" />
     <Compile Include="WVec.cs" />
     <Compile Include="Primitives\TypeDictionary.cs" />
-    <Compile Include="Support\Random.cs" />
     <Compile Include="Map\ActorInitializer.cs" />
     <Compile Include="Map\ActorReference.cs" />
     <Compile Include="Support\Evaluator.cs" />

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -21,6 +21,7 @@ using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
+using OpenRA.Support;
 
 using XTimer = System.Timers.Timer;
 
@@ -39,7 +40,7 @@ namespace OpenRA.Server
 		public readonly int Port;
 
 		int randomSeed;
-		public readonly Support.Random Random = new Support.Random();
+		public readonly MersenneTwister Random = new MersenneTwister();
 
 		// Valid player connections
 		public List<Connection> Conns = new List<Connection>();

--- a/OpenRA.Game/Support/MersenneTwister.cs
+++ b/OpenRA.Game/Support/MersenneTwister.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -13,8 +13,7 @@ using System;
 namespace OpenRA.Support
 {
 	// quick & dirty Mersenne Twister [MT19937] implementation
-
-	public class Random
+	public class MersenneTwister
 	{
 		uint[] mt = new uint[624];
 		int index = 0;
@@ -22,9 +21,9 @@ namespace OpenRA.Support
 		public int Last;
 		public int TotalCount = 0;
 
-		public Random() : this(Environment.TickCount) { }
+		public MersenneTwister() : this(Environment.TickCount) { }
 
-		public Random(int seed)
+		public MersenneTwister(int seed)
 		{
 			mt[0] = (uint)seed;
 			for (var i = 1u; i < mt.Length; i++)

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Traits
 		}
 
 		/* pretty crap */
-		public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> ts, Support.Random random)
+		public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> ts, MersenneTwister random)
 		{
 			var items = ts.ToList();
 			while (items.Count > 0)

--- a/OpenRA.Game/WRange.cs
+++ b/OpenRA.Game/WRange.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Linq;
+using OpenRA.Support;
 
 namespace OpenRA
 {
@@ -39,7 +40,7 @@ namespace OpenRA
 		// 2 samples produces a triangular probability
 		// ...
 		// N samples approximates a true gaussian
-		public static WRange FromPDF(Support.Random r, int samples)
+		public static WRange FromPDF(MersenneTwister r, int samples)
 		{
 			return new WRange(Exts.MakeArray(samples, _ => r.Next(-1024, 1024))
 				.Sum() / samples);

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -12,6 +12,7 @@ using System;
 using Eluant;
 using Eluant.ObjectBinding;
 using OpenRA.Scripting;
+using OpenRA.Support;
 
 namespace OpenRA
 {
@@ -73,7 +74,7 @@ namespace OpenRA
 		// 2 samples produces a triangular probability
 		// ...
 		// N samples approximates a true gaussian
-		public static WVec FromPDF(Support.Random r, int samples)
+		public static WVec FromPDF(MersenneTwister r, int samples)
 		{
 			return new WVec(WRange.FromPDF(r, samples), WRange.FromPDF(r, samples), WRange.Zero);
 		}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -20,7 +20,6 @@ using OpenRA.Orders;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
-using XRandom = OpenRA.Support.Random;
 
 namespace OpenRA
 {
@@ -36,7 +35,7 @@ namespace OpenRA
 		internal readonly OrderManager orderManager;
 		public Session LobbyInfo { get { return orderManager.LobbyInfo; } }
 
-		public XRandom SharedRandom;
+		public MersenneTwister SharedRandom;
 
 		public readonly List<Player> Players = new List<Player>();
 
@@ -126,7 +125,7 @@ namespace OpenRA
 			Map = map;
 
 			TileSet = map.Rules.TileSets[Map.Tileset];
-			SharedRandom = new XRandom(orderManager.LobbyInfo.GlobalSettings.RandomSeed);
+			SharedRandom = new MersenneTwister(orderManager.LobbyInfo.GlobalSettings.RandomSeed);
 
 			WorldActor = CreateActor("World", new TypeDictionary());
 			ActorMap = WorldActor.Trait<ActorMap>();

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -118,7 +118,7 @@ namespace OpenRA
 					: (edge ? w.Map.Bounds.Top : w.Map.Bounds.Bottom));
 		}
 
-		public static CPos ChooseRandomCell(this World w, Support.Random r)
+		public static CPos ChooseRandomCell(this World w, MersenneTwister r)
 		{
 			return new CPos(
 				r.Next(w.Map.Bounds.Left, w.Map.Bounds.Right),

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -18,7 +18,7 @@ using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.RA.Move;
 using OpenRA.Traits;
 using OpenRA.Primitives;
-using XRandom = OpenRA.Support.Random;
+using OpenRA.Support;
 
 namespace OpenRA.Mods.RA.AI
 {
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.RA.AI
 		bool enabled;
 		public int ticks;
 		public Player p;
-		public XRandom random;
+		public MersenneTwister random;
 		public CPos baseCenter;
 		PowerManager playerPower;
 		SupportPowerManager supportPowerMngr;
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.RA.AI
 				new BaseBuilder(this, "Defense", q => ChooseBuildingToBuild(q, true))
 			};
 
-			random = new XRandom((int)p.PlayerActor.ActorID);
+			random = new MersenneTwister((int)p.PlayerActor.ActorID);
 
 			resourceTypes = Map.Rules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>()
 				.Select(t => t.TerrainType).ToArray();

--- a/OpenRA.Mods.RA/AI/Squad.cs
+++ b/OpenRA.Mods.RA/AI/Squad.cs
@@ -10,8 +10,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Support;
 using OpenRA.Traits;
-using XRandom = OpenRA.Support.Random;
 
 namespace OpenRA.Mods.RA.AI
 {
@@ -24,12 +24,11 @@ namespace OpenRA.Mods.RA.AI
 
 		internal World world;
 		internal HackyAI bot;
-		internal XRandom random;
+		internal MersenneTwister random;
 
 		internal Target target;
 		internal StateMachine fsm;
 
-		//fuzzy
 		internal AttackOrFleeFuzzy attackOrFleeFuzzy = new AttackOrFleeFuzzy();
 
 		public Squad(HackyAI bot, SquadType type) : this(bot, type, null) { }

--- a/OpenRA.Mods.RA/SeedsResource.cs
+++ b/OpenRA.Mods.RA/SeedsResource.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
+using OpenRA.Support;
 
 namespace OpenRA.Mods.RA
 {
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.RA
 
 		}
 
-		static IEnumerable<CPos> RandomWalk(CPos p, Support.Random r)
+		static IEnumerable<CPos> RandomWalk(CPos p, MersenneTwister r)
 		{
 			for (; ; )
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/CheatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/CheatsLogic.cs
@@ -11,13 +11,13 @@
 using System;
 using OpenRA.Traits;
 using OpenRA.Widgets;
-using XRandom = OpenRA.Support.Random;
+using OpenRA.Support;
 
 namespace OpenRA.Mods.RA.Widgets.Logic
 {
 	public class CheatsLogic
 	{
-		public static XRandom CosmeticRandom = new XRandom();
+		public static MersenneTwister CosmeticRandom = new MersenneTwister();
 
 		[ObjectCreator.UseCtor]
 		public CheatsLogic(Widget widget, Action onExit, World world)

--- a/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using OpenRA.FileFormats;
+using OpenRA.Support;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.RA.Widgets.Logic
@@ -127,7 +128,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						if (!string.IsNullOrEmpty(line))
 							mirrorList.Add(line);
 				}
-				mirror = mirrorList.Random(new OpenRA.Support.Random());
+				mirror = mirrorList.Random(new MersenneTwister());
 
 				// Save the package to a temp file
 				var dl = new Download(mirror, file, onDownloadProgress, onDownloadComplete);


### PR DESCRIPTION
So that our own pseudo random number generator does not collide with the ones provided by Mono/.NET.
