### PR TITLE
Added in the ability to put prerequisites on support powers.

### DIFF
--- a/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.RA
 		public readonly string LongDesc = "";
 		public readonly bool AllowMultiple = false;
 		public readonly bool OneShot = false;
+		public readonly string[] Prerequisites = {};
 
 		public readonly string BeginChargeSound = null;
 		public readonly string EndChargeSound = null;


### PR DESCRIPTION
This is an extension to the tech system that would allow more control over when players are given support powers.
