### PR TITLE
Fix strategic map replay exception

### DIFF
--- a/OpenRA.Mods.RA/Widgets/StrategicProgressWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/StrategicProgressWidget.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA.Widgets
 			{
 				WidgetUtils.DrawRGBA(ChromeProvider.GetImage("strategic", "critical_unowned"), offset + new float2(rb.Left + curX, rb.Top));
 
-				if (WorldUtils.AreMutualAllies(a.Actor.Owner, world.LocalPlayer))
+				if (world.LocalPlayer != null && WorldUtils.AreMutualAllies(a.Actor.Owner, world.LocalPlayer))
 					WidgetUtils.DrawRGBA(ChromeProvider.GetImage("strategic", "player_owned"), offset + new float2(rb.Left + curX, rb.Top));
 				else if (!a.Actor.Owner.NonCombatant)
 					WidgetUtils.DrawRGBA(ChromeProvider.GetImage("strategic", "enemy_owned"), offset + new float2(rb.Left + curX, rb.Top));


### PR DESCRIPTION
The game crashes when trying to start a replay of the map Crossroads with two teams.

```
Exception of type `System.ArgumentNullException`: Argument cannot be null.
Parameter name: key
  at System.Collections.Generic.Dictionary`2[OpenRA.Player,OpenRA.Traits.Stance].get_Item (OpenRA.Player key) [0x000a2] in /build/mono/src/mono-3.2.8/mcs/class/corlib/System.Collections.Generic/Dictionary.cs:148 
  at OpenRA.WorldUtils.AreMutualAllies (OpenRA.Player a, OpenRA.Player b) [0x00008] in ~/openra/OpenRA.Game/WorldUtils.cs:191 
  at OpenRA.Mods.RA.Widgets.StrategicProgressWidget.Draw () [0x000e2] in ~/openra/OpenRA.Mods.RA/Widgets/StrategicProgressWidget.cs:49 
  at OpenRA.Widgets.Widget.DrawOuter () [0x00013] in ~/openra/OpenRA.Game/Widgets/Widget.cs:375 
  at OpenRA.Widgets.Widget.DrawOuter () [0x00033] in ~/openra/OpenRA.Game/Widgets/Widget.cs:377 
  at OpenRA.Widgets.Widget.DrawOuter () [0x00033] in ~/openra/OpenRA.Game/Widgets/Widget.cs:377 
  at OpenRA.Widgets.Ui.Draw () [0x00006] in ~/openra/OpenRA.Game/Widgets/Widget.cs:70 
  at OpenRA.Game.Tick (OpenRA.Network.OrderManager orderManager) [0x0010c] in ~/openra/OpenRA.Game/Game.cs:152 
  at OpenRA.Game.Run () [0x0007b] in ~/openra/OpenRA.Game/Game.cs:494 
  at OpenRA.Program.Run (System.String[] args) [0x00011] in ~/openra/OpenRA.Game/Support/Program.cs:110 
  at OpenRA.Program.Main (System.String[] args) [0x00050] in ~/openra/OpenRA.Game/Support/Program.cs:34 
```
