### PR TITLE
Lower BridgeHut Selectable Priority

### DIFF
--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -361,6 +361,7 @@ BRIDGEHUT:
 	Selectable:
 		Selectable: false
 		Bounds: 48,48
+		Priority: 2
 	BridgeHut:
 	TargetableBuilding:
 		TargetTypes: BridgeHut, C4

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -491,6 +491,7 @@ BRIDGEHUT:
 	Selectable:
 		Selectable: false
 		Bounds: 48,48
+		Priority: 2
 	BridgeHut:
 	TargetableBuilding:
 		TargetTypes: BridgeHut, C4
@@ -502,6 +503,7 @@ BRIDGEHUT.small:
 	Selectable:
 		Selectable: false
 		Bounds: 24,24
+		Priority: 2
 	BridgeHut:
 	TargetableBuilding:
 		TargetTypes: BridgeHut, C4


### PR DESCRIPTION
Fixes #4738 where player was unable unable to attack units/buildings that
are next to or on a bridge.

I didn't notice any regressions, it simply reorders the actor list so that the BridgeHut is no longer the first in the list, which caused the cursor/action evaluation to not consider enemy units that were on the bridge.  This only fixes the issue with attacking on or near the bridge and does not solve the issue where it shows the move-blocked cursor when trying to order units to move onto the bridge.
