### PR TITLE
Give PerfTimer the ability to write only slow operations to the log

### DIFF
--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -82,11 +82,8 @@ namespace OpenRA.Traits
 			{
 				var prev = act;
 
-				var sw = Stopwatch.StartNew();
-				act = act.Tick(self);
-				var dt = sw.Elapsed;
-				if (dt > Game.Settings.Debug.LongTickThreshold)
-					Log.Write("perf", "[{2}] Activity: {0} ({1:0.000} ms)", prev, dt.TotalMilliseconds, Game.LocalTick);
+				using (new PerfTimer("[{0}] Activity: {1}".F(Game.LocalTick, prev), (int)Game.Settings.Debug.LongTickThreshold.TotalMilliseconds))
+					act = act.Tick(self);
 
 				if (prev == act)
 					break;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -229,13 +229,9 @@ namespace OpenRA
 					foreach (var a in actors)
 						a.Tick();
 
-				ActorsWithTrait<ITick>().DoTimed(x => x.Trait.Tick(x.Actor),
-					"[{2}] Trait: {0} ({1:0.000} ms)",
-					Game.Settings.Debug.LongTickThreshold);
+				ActorsWithTrait<ITick>().DoTimed(x => x.Trait.Tick(x.Actor), "Trait", Game.Settings.Debug.LongTickThreshold);
 
-				effects.DoTimed(e => e.Tick(this),
-					"[{2}] Effect: {0} ({1:0.000} ms)",
-					Game.Settings.Debug.LongTickThreshold);
+				effects.DoTimed(e => e.Tick(this), "Effect", Game.Settings.Debug.LongTickThreshold);
 			}
 
 			while (frameEndActions.Count != 0)

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -174,15 +174,10 @@ namespace OpenRA
 
 		public static void DoTimed<T>(this IEnumerable<T> e, Action<T> a, string text, TimeSpan time)
 		{
-			var sw = Stopwatch.StartNew();
-
 			e.Do(x =>
 			{
-				var t = sw.Elapsed;
-				a(x);
-				var dt = sw.Elapsed - t;
-				if (dt > time)
-					Log.Write("perf", text, x, dt.TotalMilliseconds, Game.LocalTick);
+				using (new PerfTimer("[{0}] {1}: {2}".F(Game.LocalTick, text, x), (int)time.TotalMilliseconds))
+					a(x);
 			});
 		}
 


### PR DESCRIPTION
This is useful to ignore fast operations that just spam the log
