### PR TITLE
Preload sequences

### DIFF
--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -58,6 +58,21 @@ namespace OpenRA.Graphics
 
 			return unitSeq.Value.Keys;
 		}
+
+		public void Preload()
+		{
+			foreach (var unitSeq in sequences.Value.Values)
+			{
+				try
+				{
+					foreach (var seq in unitSeq.Value.Values);
+				}
+				catch (FileNotFoundException ex)
+				{
+					Log.Write("debug", ex.Message);
+				}
+			}
+		}
 	}
 
 	public class SequenceCache
@@ -100,8 +115,11 @@ namespace OpenRA.Graphics
 				else
 				{
 					t = Exts.Lazy(() => (IReadOnlyDictionary<string, Sequence>)new ReadOnlyDictionary<string, Sequence>(
-						node.Value.NodesDict.ToDictionary(x => x.Key, x => 
-							new Sequence(spriteLoader.Value, node.Key, x.Key, x.Value))));
+						node.Value.NodesDict.ToDictionary(x => x.Key, x =>
+						{
+							using (new Support.PerfTimer("new Sequence(\"{0}\")".F(node.Key), 20))
+								return new Sequence(spriteLoader.Value, node.Key, x.Key, x.Value);
+						})));
 					sequenceCache.Add(key, t);
 					items.Add(node.Key, t);
 				}

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -134,8 +134,10 @@ namespace OpenRA
 			// Mount map package so custom assets can be used. TODO: check priority.
 			GlobalFileSystem.Mount(GlobalFileSystem.OpenPackage(map.Path, null, int.MaxValue));
 
-			using (new Support.PerfTimer("Map.LoadRules"))
+			using (new Support.PerfTimer("Map.PreloadRules"))
 				map.PreloadRules();
+			using (new Support.PerfTimer("Map.SequenceProvider.Preload"))
+				map.SequenceProvider.Preload();
 
 			VoxelProvider.Initialize(Manifest.VoxelSequences, map.VoxelSequenceDefinitions);
 

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -82,11 +82,8 @@ namespace OpenRA.Traits
 			{
 				var prev = act;
 
-				var sw = Stopwatch.StartNew();
-				act = act.Tick(self);
-				var dt = sw.Elapsed;
-				if (dt > Game.Settings.Debug.LongTickThreshold)
-					Log.Write("perf", "[{2}] Activity: {0} ({1:0.000} ms)", prev, dt.TotalMilliseconds, Game.LocalTick);
+				using (new PerfTimer("[{0}] Activity: {1}".F(Game.LocalTick, prev), (int)Game.Settings.Debug.LongTickThreshold.TotalMilliseconds))
+					act = act.Tick(self);
 
 				if (prev == act)
 					break;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -229,13 +229,9 @@ namespace OpenRA
 					foreach (var a in actors)
 						a.Tick();
 
-				ActorsWithTrait<ITick>().DoTimed(x => x.Trait.Tick(x.Actor),
-					"[{2}] Trait: {0} ({1:0.000} ms)",
-					Game.Settings.Debug.LongTickThreshold);
+				ActorsWithTrait<ITick>().DoTimed(x => x.Trait.Tick(x.Actor), "Trait", Game.Settings.Debug.LongTickThreshold);
 
-				effects.DoTimed(e => e.Tick(this),
-					"[{2}] Effect: {0} ({1:0.000} ms)",
-					Game.Settings.Debug.LongTickThreshold);
+				effects.DoTimed(e => e.Tick(this), "Effect", Game.Settings.Debug.LongTickThreshold);
 			}
 
 			while (frameEndActions.Count != 0)

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -174,15 +174,10 @@ namespace OpenRA
 
 		public static void DoTimed<T>(this IEnumerable<T> e, Action<T> a, string text, TimeSpan time)
 		{
-			var sw = Stopwatch.StartNew();
-
 			e.Do(x =>
 			{
-				var t = sw.Elapsed;
-				a(x);
-				var dt = sw.Elapsed - t;
-				if (dt > time)
-					Log.Write("perf", text, x, dt.TotalMilliseconds, Game.LocalTick);
+				using (new PerfTimer("[{0}] {1}: {2}".F(Game.LocalTick, text, x), (int)time.TotalMilliseconds))
+					a(x);
 			});
 		}
 


### PR DESCRIPTION
(Depends on #5384)

This forces all sequences to be preloaded on map start. It makes the initial map load longer (roughly 40%) but it prevents the loading freeze in-game.

Note: I initially tried to do it without relying on `OpenWithExts` throwing `FileNotFoundException` but it would require changing too many things or accept `null` values into the `sequences` dictionary, which would be worse long-term. This is why I added `TryOpenWithExts` but don't actually use it.
