### PR TITLE
Fixes #4955 aircraft reservation crash

### DIFF
--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -80,8 +80,12 @@ namespace OpenRA.Mods.RA.Air
 				return;
 
 			var res = afld.Trait<Reservable>();
+
 			if (res != null)
+			{
+				UnReserve();
 				Reservation = res.Reserve(afld, self, this);
+			}
 		}
 
 		public void UnReserve()

--- a/OpenRA.Mods.RA/Air/HeliReturn.cs
+++ b/OpenRA.Mods.RA/Air/HeliReturn.cs
@@ -47,9 +47,12 @@ namespace OpenRA.Mods.RA.Air
 
 			var res = dest.TraitOrDefault<Reservable>();
 			var heli = self.Trait<Helicopter>();
-			if (res != null)
-				heli.Reservation = res.Reserve(dest, self, heli);
 
+			if (res != null)
+			{
+				heli.UnReserve();
+				heli.Reservation = res.Reserve(dest, self, heli);
+			}
 			var exit = dest.Info.Traits.WithInterface<ExitInfo>().FirstOrDefault();
 			var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
 


### PR DESCRIPTION
The unchecked reservation in HeliReturn.cs was the cause of the crash reported in #4955, and I added an additional UnReserve call when attempting to reserve the spawn point.  This may no longer be necessary due to more recent changes in how helicopters spawn, but since we are not attempting to clean up this code until after release I made sure to UnReserve before attempting any Reservation.
