### PR TITLE
Make user file locations configurable

### DIFF
--- a/OpenRA.CrashDialog/Program.cs
+++ b/OpenRA.CrashDialog/Program.cs
@@ -95,7 +95,8 @@ namespace OpenRA.CrashDialog
 		{
 			try
 			{
-				Process.Start(Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar);
+				Game.Settings = settings;
+				Process.Start(Platform.GetFolderPath(UserFolder.Logs));
 			}
 			catch { }
 		}

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -8,8 +8,10 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 
 namespace OpenRA.FileSystem
 {
@@ -77,6 +79,29 @@ namespace OpenRA.FileSystem
 				using (var dataStream = File.Create(Path.Combine(path, file.Key)))
 					using (var writer = new BinaryWriter(dataStream))
 					   writer.Write(file.Value);
+		}
+
+		static string GetTimestampedFilePath(string dir, string baseName, string ext)
+		{
+			return Path.Combine(dir, string.Concat(baseName, DateTime.UtcNow.ToString("yyyyMMdd-HHmmss-fff"), ext));
+		}
+
+		public static FileStream CreateTimestampedFile(string dir, string baseName, string ext)
+		{
+			Directory.CreateDirectory(dir);
+
+			while (true)
+			{
+				var name = GetTimestampedFilePath(dir, baseName, ext);
+				try
+				{
+					return File.Create(name);
+				}
+				catch (IOException)
+				{
+					Thread.Sleep(1);
+				}
+			}
 		}
 	}
 }

--- a/OpenRA.Game/FileSystem/GlobalFileSystem.cs
+++ b/OpenRA.Game/FileSystem/GlobalFileSystem.cs
@@ -105,13 +105,9 @@ namespace OpenRA.FileSystem
 
 		public static void Mount(string name, string annotation)
 		{
-			var optional = name.StartsWith("~");
-			if (optional)
-				name = name.Substring(1);
+			var optional = Platform.IsPathOptional(name);
 
-			// paths starting with ^ are relative to the support dir
-			if (name.StartsWith("^"))
-				name = Platform.SupportDir + name.Substring(1);
+			name = Platform.ResolvePath(name);
 
 			FolderPaths.Add(name);
 			Action a = () => MountInner(OpenPackage(name, annotation, order++));

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -29,6 +29,7 @@ namespace OpenRA
 		public static MouseButtonPreference mouseButtonPreference = new MouseButtonPreference();
 
 		public static ModData modData;
+		public static ModMetadata CurrentModMetadata;
 		public static Settings Settings;
 		static WorldRenderer worldRenderer;
 
@@ -45,14 +46,9 @@ namespace OpenRA
 		public static OrderManager JoinServer(string host, int port, string password)
 		{
 			var om = new OrderManager(host, port, password,
-				new ReplayRecorderConnection(new NetworkConnection(host, port), ChooseReplayFilename));
+				new ReplayRecorderConnection(new NetworkConnection(host, port)));
 			JoinInner(om);
 			return om;
-		}
-
-		static string ChooseReplayFilename()
-		{
-			return DateTime.UtcNow.ToString("OpenRA-yyyy-MM-ddTHHmmssZ");
 		}
 
 		static void JoinInner(OrderManager om)
@@ -295,7 +291,7 @@ namespace OpenRA
 
 			Settings = new Settings(Platform.SupportDir + "settings.yaml", args);
 
-			Log.LogPath = Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar;
+			Log.LogPath = Platform.GetFolderPath(UserFolder.Logs);
 			Log.AddChannel("perf", "perf.log");
 			Log.AddChannel("debug", "debug.log");
 			Log.AddChannel("sync", "syncreport.log");

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -110,13 +110,7 @@ namespace OpenRA
 		{
 			string[] noMaps = { };
 
-			// Ignore optional flag
-			if (dir.StartsWith("~"))
-				dir = dir.Substring(1);
-
-			// Paths starting with ^ are relative to the user directory
-			if (dir.StartsWith("^"))
-				dir = Platform.SupportDir + dir.Substring(1);
+			dir = Platform.ResolvePath(dir);
 
 			if (!Directory.Exists(dir))
 				return noMaps;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -170,7 +170,7 @@ namespace OpenRA
 				return;
 
 			Status = MapStatus.Downloading;
-			var baseMapPath = new[] { Platform.SupportDir, "maps", Game.modData.Manifest.Mod.Id }.Aggregate(Path.Combine);
+			var baseMapPath = Platform.GetFolderPath(UserFolder.ModMaps);
 
 			// Create the map directory if it doesn't exist
 			if (!Directory.Exists(baseMapPath))
@@ -183,7 +183,6 @@ namespace OpenRA
 				var mapUrl = Game.Settings.Game.MapRepository + Uid;
 				try
 				{
-
 					var request = WebRequest.Create(mapUrl);
 					request.Method = "HEAD";
 					var res = request.GetResponse();
@@ -195,7 +194,8 @@ namespace OpenRA
 						return;
 					}
 
-					var mapPath = Path.Combine(baseMapPath, res.Headers["Content-Disposition"].Replace("attachment; filename = ", ""));
+					var fileName = res.Headers["Content-Disposition"].Replace("attachment; filename = ", "");
+					var mapPath = Path.Combine(baseMapPath, Path.GetFileName(fileName));
 
 					Action<DownloadProgressChangedEventArgs> onDownloadProgress = i => { DownloadBytes = i.BytesReceived; DownloadPercentage = i.ProgressPercentage; };
 					Action<AsyncCompletedEventArgs, bool> onDownloadComplete = (i, cancelled) =>

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -46,6 +46,7 @@ namespace OpenRA
 			MapCache = new MapCache(this);
 
 			// HACK: Mount only local folders so we have a half-working environment for the asset installer
+			Game.CurrentModMetadata = Manifest.Mod;
 			GlobalFileSystem.UnmountAll();
 			foreach (var dir in Manifest.Folders)
 				GlobalFileSystem.Mount(dir);

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -62,37 +62,6 @@ namespace OpenRA
 			}
 		}
 
-		public static string SupportDir
-		{
-			get
-			{
-				// Use a local directory in the game root if it exists
-				if (Directory.Exists("Support"))
-					return "Support" + Path.DirectorySeparatorChar;
-
-				var dir = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-
-				switch (CurrentPlatform)
-				{
-				case PlatformType.Windows:
-					dir += Path.DirectorySeparatorChar + "OpenRA";
-					break;
-				case PlatformType.OSX:
-					dir += "/Library/Application Support/OpenRA";
-					break;
-				case PlatformType.Linux:
-				default:
-					dir += "/.openra";
-					break;
-				}
-
-				if (!Directory.Exists(dir))
-					Directory.CreateDirectory(dir);
-
-				return dir + Path.DirectorySeparatorChar;
-			}
-		}
-
 		public static void ShowFatalErrorDialog()
 		{
 			var process = "OpenRA.CrashDialog.exe";
@@ -109,7 +78,7 @@ namespace OpenRA
 				var message = "OpenRA has encountered a fatal error.\nRefer to the crash logs and FAQ for more information.";
 
 				var faqPath = Game.Settings.Debug.FatalErrorDialogFaq;
-				var logsPath = "file://" + Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar;
+				var logsPath = "file://" + Platform.GetFolderPath(UserFolder.Logs);
 
 				var iconPath = new [] { "./OpenRA.icns", "./packaging/osx/template.app/Contents/Resources/OpenRA.icns" }.FirstOrDefault(f => File.Exists(f));
 				var icon = iconPath != null ? "with icon alias (POSIX file \\\"file://{0}\\\")".F(Environment.CurrentDirectory + "/" + iconPath) : "";
@@ -136,5 +105,269 @@ namespace OpenRA
 			psi.CreateNoWindow = true;
 			Process.Start(psi);
 		}
+
+		#region Paths
+		public static string SupportDir
+		{
+			get
+			{
+				// Use a local directory in the game root if it exists
+				if (Directory.Exists("Support"))
+					return "Support" + Path.DirectorySeparatorChar;
+
+				var dir = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+
+				switch (CurrentPlatform)
+				{
+					case PlatformType.Windows:
+						dir += Path.DirectorySeparatorChar + "OpenRA";
+						break;
+					case PlatformType.OSX:
+						dir += "/Library/Application Support/OpenRA";
+						break;
+					case PlatformType.Linux:
+					default:
+						dir += "/.openra";
+						break;
+				}
+
+				if (!Directory.Exists(dir))
+					Directory.CreateDirectory(dir);
+
+				return dir + Path.DirectorySeparatorChar;
+			}
+		}
+
+		static ModMetadata GetCurrentModMetadata()
+		{
+			if (Game.CurrentModMetadata != null)
+				return Game.CurrentModMetadata;
+
+			throw new InvalidOperationException("No mod has been initialized yet.");
+		}
+
+		static PathSettings GetPathSettings()
+		{
+			if (Game.Settings != null && Game.Settings.Paths != null)
+				return Game.Settings.Paths;
+
+			return new PathSettings();
+		}
+
+		static string GetBasePath(PathSettings paths)
+		{
+			if (!UpgradeFileSystemDone)
+			{
+				UpgradeFileSystemDone = true;
+				UpgradeFileSystem();
+			}
+
+			if (paths == null)
+				throw new ArgumentNullException("paths");
+
+			if (!string.IsNullOrWhiteSpace(paths.Base))
+				return paths.Base.Trim();
+
+			return Platform.SupportDir;
+		}
+
+		static string GetModPath(PathSettings paths)
+		{
+			if (paths == null)
+				throw new ArgumentNullException("paths");
+
+			if (!string.IsNullOrEmpty(paths.Mods) && paths.Mods[0] == '$')
+				throw new InvalidDataException("The path for the mods cannot be resolved (it is not allowed to be relative to the current mod).");
+
+			var modsPath = ResolvePath(paths.Mods, paths);
+
+			return Path.Combine(modsPath, GetCurrentModMetadata().Id);
+		}
+
+		public static bool IsPathOptional(string path)
+		{
+			if (path == null)
+				throw new ArgumentNullException("path");
+
+			return path.Length > 0 && path[0] == '~';
+		}
+
+		// Translates arbitrary paths to filesystem paths.
+		// Example: ^logs => "userdir/logs"
+		//          @replays => "userdir/mods/mod/replays/version"
+		//          $ModCache/news.yaml => "userdir/mods/mod/cache/news.yaml"
+		public static string ResolvePath(string path, PathSettings paths = null)
+		{
+			if (path == null)
+				throw new ArgumentNullException("path");
+
+			if (paths == null)
+				paths = GetPathSettings();
+
+			path = path.Trim();
+
+			// Ignore optional flag
+			if (path.Length > 0 && path[0] == '~')
+				path = path.Substring(1);
+
+			if (path.Length == 0)
+				return GetBasePath(paths);
+
+			var prefix = path[0];
+
+			// ^ : relative to the base path
+			if (prefix == '^')
+				return Path.Combine(GetBasePath(paths), path.Substring(1));
+
+			// @ : relative to the current mod
+			if (prefix == '@')
+				return Path.Combine(GetModPath(paths), path.Substring(1));
+
+			// $ : predefined folder
+			if (prefix == '$')
+			{
+				path = path.Substring(1);
+				var parts = path.Split(new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, 2);
+				var predefinedName = parts[0];
+				var folder = Enum<UserFolder>.Parse(predefinedName);
+
+				parts[0] = GetFolderPath(folder);
+				return Path.Combine(parts);
+			}
+
+			return path;
+		}
+
+		public static string GetFolderPath(UserFolder folder, bool createFolder = false)
+		{
+			var paths = GetPathSettings();
+			string path;
+
+			switch (folder)
+			{
+				case UserFolder.Base:
+					path = GetBasePath(paths);
+					break;
+
+				case UserFolder.Logs:
+					path = ResolvePath(paths.Logs, paths);
+					break;
+
+				case UserFolder.ModContent:
+					path = ResolvePath(paths.ModContent, paths);
+					break;
+
+				case UserFolder.ModReplays:
+					path = Path.Combine(ResolvePath(paths.ModReplays, paths), GetCurrentModMetadata().Version);
+					break;
+
+				case UserFolder.ModMaps:
+					path = ResolvePath(paths.ModMaps, paths);
+					break;
+
+				case UserFolder.ModCache:
+					path = ResolvePath(paths.ModCache, paths);
+					break;
+
+				default:
+					throw new ArgumentException("Unhandled " + folder.GetType().Name + " value.", "folder");
+			}
+
+			if (createFolder)
+				Directory.CreateDirectory(path);
+
+			return path;
+		}
+
+		public static string GetFilePath(UserFile file, bool createFolder = false)
+		{
+			var paths = GetPathSettings();
+			string path;
+
+			switch (file)
+			{
+				case UserFile.Motd:
+					path = ResolvePath(paths.Motd, paths);
+					break;
+
+				case UserFile.ModMirrors:
+					path = ResolvePath(paths.ModMirrors, paths);
+					break;
+
+				case UserFile.ModNews:
+					path = ResolvePath(paths.ModNews, paths);
+					break;
+
+				default:
+					throw new ArgumentException("Unhandled " + file.GetType().Name + " value.", "folder");
+			}
+
+			if (createFolder)
+				Directory.CreateDirectory(Path.GetDirectoryName(path));
+
+			return path;
+		}
+
+		static bool UpgradeFileSystemDone;
+		static void UpgradeFileSystem()
+		{
+			if (!Directory.Exists(Path.Combine(SupportDir, "Content")))
+				return;
+
+			Directory.Move(Path.Combine(SupportDir, "Content"), Path.Combine(SupportDir, "old_content_dir"));
+
+			var paths = GetPathSettings();
+			var mods = new string[] { "ra", "cnc", "ts", "d2k" };
+
+			try { Directory.Move(Path.Combine(SupportDir, "Logs"), GetFolderPath(UserFolder.Logs)); } catch {} 
+			try
+			{
+				var modsDir = Directory.CreateDirectory(ResolvePath(paths.Mods));
+
+				foreach (var mod in mods)
+				{
+					try
+					{
+						var modDir = modsDir.CreateSubdirectory(mod);
+						try { Directory.Move(Path.Combine(SupportDir, "old_content_dir", mod), Path.Combine(modDir.FullName, "content")); } catch {} 
+						try { Directory.Move(Path.Combine(SupportDir, "Cache", mod), Path.Combine(modDir.FullName, "cache")); } catch {} 
+						try { Directory.Move(Path.Combine(SupportDir, "maps", mod), Path.Combine(modDir.FullName, "maps")); } catch {} 
+
+						var repDir = new DirectoryInfo(Path.Combine(SupportDir, "Replays", mod));
+						if (repDir.Exists)
+						{
+							foreach (var repsForModVer in repDir.EnumerateDirectories())
+							{
+								var newRepDir = modDir.CreateSubdirectory("replays");
+								repsForModVer.MoveTo(Path.Combine(newRepDir.FullName, repsForModVer.Name));
+							}
+						}
+					}
+					catch {}
+				}
+			}
+			catch {}
+			try { Directory.Move(Path.Combine(SupportDir, "Replays"), Path.Combine(SupportDir, "old_replays_dir")); } catch {} 
+			try { Directory.Move(Path.Combine(SupportDir, "Cache"), Path.Combine(SupportDir, "old_cache_dir")); } catch {} 
+			try { Directory.Move(Path.Combine(SupportDir, "maps"), Path.Combine(SupportDir, "old_maps_dir")); } catch {} 
+		}
+		#endregion
+	}
+
+	public enum UserFolder
+	{
+		Base,
+		Logs,
+		ModContent,
+		ModReplays,
+		ModMaps,
+		ModCache
+	}
+
+	public enum UserFile
+	{
+		Motd,
+		ModMirrors,
+		ModNews
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -338,7 +338,7 @@ namespace OpenRA.Server
 
 				if (Settings.Dedicated)
 				{
-					var motdFile = Path.Combine(Platform.SupportDir, "motd.txt");
+					var motdFile = Platform.GetFilePath(UserFile.Motd, createFolder: true);
 					if (!File.Exists(motdFile))
 						System.IO.File.WriteAllText(motdFile, "Welcome, have fun and good luck!");
 					var motd = System.IO.File.ReadAllText(motdFile);

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -195,6 +195,23 @@ namespace OpenRA
 		public bool ConnectAutomatically = false;
 	}
 
+	public class PathSettings
+	{
+		// Directories
+		public string Base = "";
+		public string Logs = "^logs";
+		public string Mods = "^mods";
+		public string ModContent = "@content";
+		public string ModReplays = "@replays";
+		public string ModMaps = "@maps";
+		public string ModCache = "@cache";
+
+		// Files
+		public string Motd = "^motd.txt";
+		public string ModMirrors = "@mirrors.txt";
+		public string ModNews = "$ModCache/news.yaml";
+	}
+
 	public class Settings
 	{
 		string settingsFile;
@@ -207,6 +224,7 @@ namespace OpenRA
 		public DebugSettings Debug = new DebugSettings();
 		public KeySettings Keys = new KeySettings();
 		public IrcSettings Irc = new IrcSettings();
+		public PathSettings Paths = new PathSettings();
 
 		public Dictionary<string, object> Sections;
 
@@ -222,7 +240,8 @@ namespace OpenRA
 				{ "Server", Server },
 				{ "Debug", Debug },
 				{ "Keys", Keys },
-				{ "Irc", Irc }
+				{ "Irc", Irc },
+				{ "Paths", Paths }
 			};
 
 			// Override fieldloader to ignore invalid entries

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncInstallFromCDLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncInstallFromCDLogic.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
 
-			var dest = new string[] { Platform.SupportDir, "Content", "cnc" }.Aggregate(Path.Combine);
+			var dest = Platform.GetFolderPath(UserFolder.ModContent);
 			var extractPackage = "INSTALL/SETUP.Z";
 
 			var installCounter = 0;

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncInstallMusicLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncInstallMusicLogic.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 				{
 					try
 					{
-						var path = new string[] { Platform.SupportDir, "Content", Game.modData.Manifest.Mod.Id }.Aggregate(Path.Combine);
+						var path = Platform.GetFolderPath(UserFolder.ModContent);
 						GlobalFileSystem.Mount(Path.Combine(path, "scores.mix"));
 						GlobalFileSystem.Mount(Path.Combine(path, "transit.mix"));
 

--- a/OpenRA.Mods.D2k/Widgets/Logic/D2kInstallFromCDLogic.cs
+++ b/OpenRA.Mods.D2k/Widgets/Logic/D2kInstallFromCDLogic.cs
@@ -75,9 +75,9 @@ namespace OpenRA.Mods.D2k.Widgets.Logic
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
 
-			var destMusic = new string[] { Platform.SupportDir, "Content", "d2k", "Music" }.Aggregate(Path.Combine);
-			var destData = new[] { Platform.SupportDir, "Content", "d2k" }.Aggregate(Path.Combine);
-			var destSound = new[] { destData, "GAMESFX" }.Aggregate(Path.Combine);
+			var destDir = Platform.GetFolderPath(UserFolder.ModContent);
+			var destMusic = Path.Combine(destDir, "Music");
+			var destSound = Path.Combine(destDir, "GAMESFX");
 			var copyFiles = new string[] { "music/ambush.aud", "music/arakatak.aud", "music/atregain.aud", "music/entordos.aud", "music/fightpwr.aud", "music/fremen.aud", "music/hark_bat.aud", "music/landsand.aud", "music/options.aud", "music/plotting.aud", "music/risehark.aud", "music/robotix.aud", "music/score.aud", "music/soldappr.aud", "music/spicesct.aud", "music/undercon.aud", "music/waitgame.aud" };
 
 			var extractPackage = "setup/setup.z";
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.D2k.Widgets.Logic
 					if (!InstallUtils.CopyFiles(source, copyFiles, destMusic, onProgress, onError))
 						return;
 
-					if (!InstallUtils.ExtractFromPackage(source, extractPackage, extractFiles, destData, onProgress, onError))
+					if (!InstallUtils.ExtractFromPackage(source, extractPackage, extractFiles, destDir, onProgress, onError))
 						return;
 
 					if (!InstallUtils.ExtractFromPackage(source, extractPackage, extractAudio, destSound, onProgress, onError))

--- a/OpenRA.Mods.RA/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/AssetBrowserLogic.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				sourceDropdown.OnMouseDown = _ => ShowSourceDropdown(sourceDropdown);
 				sourceDropdown.GetText = () =>
 				{
-					var name = assetSource != null ? assetSource.Name.Replace(Platform.SupportDir, "^") : "All Packages";
+					var name = assetSource != null ? assetSource.Name.Replace(Platform.GetFolderPath(UserFolder.Base), "^") : "All Packages";
 					if (name.Length > 15)
 						name = "..." + name.Substring(name.Length - 15);
 
@@ -210,7 +210,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var item = ScrollItemWidget.Setup(itemTemplate,
 				                                  () => assetSource == source,
 				                                  () => { assetSource = source;	PopulateAssetList(); });
-				item.Get<LabelWidget>("LABEL").GetText = () => source != null ? source.Name.Replace(Platform.SupportDir, "^") : "All Packages";
+				item.Get<LabelWidget>("LABEL").GetText = () => source != null ? source.Name.Replace(Platform.GetFolderPath(UserFolder.Base), "^") : "All Packages";
 				return item;
 			};
 

--- a/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
@@ -51,9 +51,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			var cancelButton = panel.Get<ButtonWidget>("CANCEL_BUTTON");
 
-			var mirrorsFile = new string[] { Platform.SupportDir, "Content", Game.modData.Manifest.Mod.Id, "mirrors.txt" }.Aggregate(Path.Combine);
+			var mirrorsFile = Platform.GetFilePath(UserFile.ModMirrors, createFolder: true);
 			var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-			var dest = new string[] { Platform.SupportDir, "Content", Game.modData.Manifest.Mod.Id }.Aggregate(Path.Combine);
+			var dest = Platform.GetFolderPath(UserFolder.ModContent);
 
 			Action<DownloadProgressChangedEventArgs> onDownloadProgress = i =>
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				if (Game.modData.Manifest.NewsUrl != null)
 				{
-					var cacheFile = GetNewsCacheFile();
+					var cacheFile = Platform.GetFilePath(UserFile.ModNews, createFolder: true);
 					var cacheValid = File.Exists(cacheFile) && DateTime.Today.ToUniversalTime() <= Game.Settings.Game.NewsFetchedDate;
 
 					if (cacheValid)
@@ -167,13 +167,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				newsButton.IsHighlighted = () => newsHighlighted && Game.LocalTick % 50 < 25;
 			}
-		}
-
-		static string GetNewsCacheFile()
-		{
-			var cacheDir = Path.Combine(Platform.SupportDir, "Cache", Game.modData.Manifest.Mod.Id);
-			Directory.CreateDirectory(cacheDir);
-			return Path.Combine(cacheDir, "news.yaml");
 		}
 
 		void SetNewsStatus(string message)
@@ -262,7 +255,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				Game.Settings.Game.NewsFetchedDate = DateTime.Today.ToUniversalTime();
 				Game.Settings.Save();
 
-				var cacheFile = GetNewsCacheFile();
+				var cacheFile = Platform.GetFilePath(UserFile.ModNews, createFolder: true);
 				if (File.Exists(cacheFile))
 				{
 					var oldNews = ReadNews(File.ReadAllBytes(cacheFile));

--- a/OpenRA.Mods.RA/Widgets/Logic/RAInstallFromCDLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/RAInstallFromCDLogic.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
 
-			var dest = new string[] { Platform.SupportDir, "Content", "ra" }.Aggregate(Path.Combine);
+			var dest = Platform.GetFolderPath(UserFolder.ModContent);
 			var copyFiles = new string[] { "INSTALL/REDALERT.MIX" };
 
 			var extractPackage = "MAIN.MIX";

--- a/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
@@ -46,8 +46,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			replayList = panel.Get<ScrollPanelWidget>("REPLAY_LIST");
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
-			var mod = Game.modData.Manifest.Mod;
-			var dir = new[] { Platform.SupportDir, "Replays", mod.Id, mod.Version }.Aggregate(Path.Combine);
+			var dir = Platform.GetFolderPath(UserFolder.ModReplays);
 
 			replayList.RemoveChildren();
 			if (Directory.Exists(dir))

--- a/OpenRA.Mods.TS/Widgets/Logic/TSInstallFromCDLogic.cs
+++ b/OpenRA.Mods.TS/Widgets/Logic/TSInstallFromCDLogic.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.TS.Widgets.Logic
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
 
-			var dest = new string[] { Platform.SupportDir, "Content", "ts" }.Aggregate(Path.Combine);
+			var dest = Platform.GetFolderPath(UserFolder.ModContent);
 			var copyFiles = new string[] { "install/tibsun.mix", "scores.mix", "multi.mix" };
 
 			var installCounter = 0;

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -43,7 +43,6 @@ namespace OpenRA.Utility
 
 			AppDomain.CurrentDomain.AssemblyResolve += GlobalFileSystem.ResolveAssembly;
 
-			Log.LogPath = Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar;
 			Log.AddChannel("perf", null);
 
 			try

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -11,11 +11,11 @@ Folders:
 	./mods/cnc/bits/jungle
 	./mods/cnc/bits/ss
 	./mods/cnc/uibits
-	~^Content/cnc
+	~$ModContent
 
 MapFolders:
 	./mods/cnc/maps: System
-	~^maps/cnc: User
+	~$ModMaps: User
 
 Packages:
 	bluetib.mix

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -12,13 +12,13 @@ Folders:
 	./mods/d2k/bits/xmas
 	./mods/d2k/uibits
 	./mods/ra/uibits
-	~^Content/d2k
-	~^Content/d2k/GAMESFX
-	~^Content/d2k/Music
+	~$ModContent
+	~$ModContent/GAMESFX
+	~$ModContent/Music
 
 MapFolders:
 	./mods/d2k/maps: System
-	~^maps/d2k: User
+	~$ModMaps: User
 
 Packages:
 	SOUND.RS

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -10,11 +10,11 @@ Folders:
 	./mods/ra/bits
 	./mods/ra/bits/desert
 	./mods/ra/uibits
-	~^Content/ra
+	~$ModContent
 
 MapFolders:
 	./mods/ra/maps: System
-	~^maps/ra: User
+	~$ModMaps: User
 
 Packages:
 	~main.mix

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -10,13 +10,13 @@ Folders:
 	./mods/ts
 	./mods/ts/bits
 	./mods/ts/uibits
-	~^Content/ts
+	~$ModContent
 # Red Alert
 	./mods/ra/uibits
 
 MapFolders:
 	./mods/ts/maps: System
-	~^maps/ts: User
+	~$ModMaps: User
 
 Packages:
 # Tiberian Sun


### PR DESCRIPTION
This allows the user to change the location of the game files
that typically go under `Platform.SupportDir`.

While one can change the whole `Platform.SupportDir` location,
its primary purpose it to be able to change the location of
runtime generated files, like logs, replays, screenshots (TODO).
