### PR TITLE
Implemented IEquatable<T>

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
-	public class Actor : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
+	public class Actor : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding, IEquatable<Actor>
 	{
 		public readonly ActorInfo Info;
 
@@ -158,7 +158,12 @@ namespace OpenRA
 		public override bool Equals(object obj)
 		{
 			var o = obj as Actor;
-			return o != null && o.ActorID == ActorID;
+			return o != null && Equals(o);
+		}
+
+		public bool Equals(Actor other)
+		{
+			return ActorID == other.ActorID;
 		}
 
 		public override string ToString()

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -16,7 +16,7 @@ using OpenRA.Scripting;
 
 namespace OpenRA
 {
-	public struct CPos : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, ILuaTableBinding
+	public struct CPos : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<CPos>
 	{
 		public readonly int X, Y;
 
@@ -52,13 +52,10 @@ namespace OpenRA
 
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as CPos?;
-			return o != null && o == this;
-		}
+		public bool Equals(CPos other) { return other == this; }
+		public override bool Equals(object obj) { return obj is CPos && Equals((CPos)obj); }
 
-		public override string ToString() { return "{0},{1}".F(X, Y); }
+		public override string ToString() { return X + "," + Y; }
 
 		#region Scripting interface
 

--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -16,7 +16,7 @@ using OpenRA.Scripting;
 
 namespace OpenRA
 {
-	public struct CVec : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding
+	public struct CVec : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<CVec>
 	{
 		public readonly int X, Y;
 
@@ -63,13 +63,10 @@ namespace OpenRA
 
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as CVec?;
-			return o != null && o == this;
-		}
+		public bool Equals(CVec other) { return other == this; }
+		public override bool Equals(object obj) { return obj is CVec && Equals((CVec)obj); }
 
-		public override string ToString() { return "{0},{1}".F(X, Y); }
+		public override string ToString() { return X + "," + Y; }
 
 		public static readonly CVec[] directions =
 		{

--- a/OpenRA.Game/Primitives/Bits.cs
+++ b/OpenRA.Game/Primitives/Bits.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Primitives
 		}
 	}
 
-	public struct Bits<T> where T : struct
+	public struct Bits<T> : IEquatable<Bits<T>> where T : struct
 	{
 		public int Value;
 
@@ -60,6 +60,11 @@ namespace OpenRA.Primitives
 			return BitAllocator<T>.GetStrings(Value).JoinWith(",");
 		}
 
+		public static bool operator ==(Bits<T> me, Bits<T> other) { return (me.Value == other.Value); }
+		public static bool operator !=(Bits<T> me, Bits<T> other) { return !(me == other); }
+
+		public bool Equals(Bits<T> other) { return other == this; }
+		public override bool Equals(object obj) { return obj is Bits<T> && Equals((Bits<T>)obj); }
 		public override int GetHashCode() { return Value.GetHashCode(); }
 	}
 }

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -15,7 +15,7 @@ namespace OpenRA
 	/// <summary>
 	/// 1D angle - 1024 units = 360 degrees.
 	/// </summary>
-	public struct WAngle
+	public struct WAngle : IEquatable<WAngle>
 	{
 		public readonly int Angle;
 
@@ -37,11 +37,8 @@ namespace OpenRA
 
 		public override int GetHashCode() { return Angle.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as WAngle?;
-			return o != null && o == this;
-		}
+		public bool Equals(WAngle other) { return other == this; }
+		public override bool Equals(object obj) { return obj is WAngle && Equals((WAngle)obj); }
 
 		public int Sin() { return new WAngle(Angle - 256).Cos(); }
 
@@ -103,7 +100,7 @@ namespace OpenRA
 		public float RendererRadians() { return (float)(Angle * Math.PI / 512f); }
 		public float RendererDegrees() { return Angle * 0.3515625f; }
 
-		public override string ToString() { return "{0}".F(Angle); }
+		public override string ToString() { return Angle.ToString(); }
 
 		static int[] CosineTable =
 		{

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Eluant;
@@ -16,7 +17,7 @@ using OpenRA.Scripting;
 
 namespace OpenRA
 {
-	public struct WPos : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, ILuaTableBinding
+	public struct WPos : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<WPos>
 	{
 		public readonly int X, Y, Z;
 
@@ -52,13 +53,10 @@ namespace OpenRA
 
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as WPos?;
-			return o != null && o == this;
-		}
+		public bool Equals(WPos other) { return other == this; }
+		public override bool Equals(object obj) { return obj is WPos && Equals((WPos)obj); }
 
-		public override string ToString() { return "{0},{1},{2}".F(X, Y, Z); }
+		public override string ToString() { return X + "," + Y + "," + Z; }
 
 		#region Scripting interface
 

--- a/OpenRA.Game/WRange.cs
+++ b/OpenRA.Game/WRange.cs
@@ -17,7 +17,7 @@ namespace OpenRA
 	/// <summary>
 	/// 1d world distance - 1024 units = 1 cell.
 	/// </summary>
-	public struct WRange : IComparable, IComparable<WRange>
+	public struct WRange : IComparable, IComparable<WRange>, IEquatable<WRange>
 	{
 		public readonly int Range;
 
@@ -31,6 +31,10 @@ namespace OpenRA
 		public static WRange operator /(WRange a, int b) { return new WRange(a.Range / b); }
 		public static WRange operator *(WRange a, int b) { return new WRange(a.Range * b); }
 		public static WRange operator *(int a, WRange b) { return new WRange(a * b.Range); }
+		public static bool operator <(WRange a, WRange b) { return a.Range < b.Range; }
+		public static bool operator >(WRange a, WRange b) { return a.Range > b.Range; }
+		public static bool operator <=(WRange a, WRange b) { return a.Range <= b.Range; }
+		public static bool operator >=(WRange a, WRange b) { return a.Range >= b.Range; }
 
 		public static bool operator ==(WRange me, WRange other) { return (me.Range == other.Range); }
 		public static bool operator !=(WRange me, WRange other) { return !(me == other); }
@@ -78,23 +82,17 @@ namespace OpenRA
 
 		public override int GetHashCode() { return Range.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as WRange?;
-			return o != null && o == this;
-		}
+		public bool Equals(WRange other) { return other == this; }
+		public override bool Equals(object obj) { return obj is WRange && Equals((WRange)obj); }
 
 		public int CompareTo(object obj)
 		{
-			var o = obj as WRange?;
-			if (o == null)
+			if (!(obj is WRange))
 				return 1;
-
-			return Range.CompareTo(o.Value.Range);
+			return Range.CompareTo(((WRange)obj).Range);
 		}
-
 		public int CompareTo(WRange other) { return Range.CompareTo(other.Range); }
 
-		public override string ToString() { return "{0}".F(Range); }
+		public override string ToString() { return Range.ToString(); }
 	}
 }

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -8,12 +8,14 @@
  */
 #endregion
 
+using System;
+
 namespace OpenRA
 {
 	/// <summary>
 	/// 3d World rotation.
 	/// </summary>
-	public struct WRot
+	public struct WRot : IEquatable<WRot>
 	{
 		public readonly WAngle Roll, Pitch, Yaw;
 
@@ -92,12 +94,9 @@ namespace OpenRA
 
 		public override int GetHashCode() { return Roll.GetHashCode() ^ Pitch.GetHashCode() ^ Yaw.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as WRot?;
-			return o != null && o == this;
-		}
+		public bool Equals(WRot other) { return other == this; }
+		public override bool Equals(object obj) { return obj is WRot && Equals((WRot)obj); }
 
-		public override string ToString() { return "{0},{1},{2}".F(Roll, Pitch, Yaw); }
+		public override string ToString() { return Roll + "," + Pitch + "," + Yaw; }
 	}
 }

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -16,7 +16,7 @@ using OpenRA.Support;
 
 namespace OpenRA
 {
-	public struct WVec : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding
+	public struct WVec : IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaUnaryMinusBinding, ILuaEqualityBinding, ILuaTableBinding, IEquatable<WVec>
 	{
 		public readonly int X, Y, Z;
 
@@ -81,13 +81,10 @@ namespace OpenRA
 
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as WVec?;
-			return o != null && o == this;
-		}
+		public bool Equals(WVec other) { return other == this; }
+		public override bool Equals(object obj) { return obj is WVec && Equals((WVec)obj); }
 
-		public override string ToString() { return "{0},{1},{2}".F(X, Y, Z); }
+		public override string ToString() { return X + "," + Y + "," + Z; }
 
 		#region Scripting interface
 


### PR DESCRIPTION
Actor, CPos, CVec, WAngle, WPos, WRange, WRot and WVec structs now implement IEquatable<T> which means unboxing/casting costs can be eliminated.

Also simplified the ToString method by concatenating components directly rather than using a format string since the overhead is a bit high for simple cases like this.
