### PR TITLE
Fixed TraitDictionary.Contains to use Any() rather than Count() != 0.

### DIFF
--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -85,7 +85,7 @@ namespace OpenRA
 		public bool Contains<T>(Actor actor)
 		{
 			CheckDestroyed(actor);
-			return ((TraitContainer<T>)InnerGet(typeof(T))).GetMultiple(actor.ActorID).Count() != 0;
+			return ((TraitContainer<T>)InnerGet(typeof(T))).GetMultiple(actor.ActorID).Any();
 		}
 
 		public T Get<T>(Actor actor)


### PR DESCRIPTION
This means it can bail early if a match is found.
