### PR TITLE
Changed logging in DoTimed/RunActivity to create less overhead

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -71,7 +71,7 @@ namespace OpenRA
 		public bool BotDebug = false;
 		public bool PerfText = false;
 		public bool PerfGraph = false;
-		public TimeSpan LongTickThreshold = TimeSpan.FromMilliseconds(1d);
+		public float LongTickThresholdMs = 1;
 		public bool SanityCheckUnsyncedCode = false;
 		public int Samples = 25;
 		public bool IgnoreVersionMismatch = false;

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -244,9 +244,9 @@ namespace OpenRA
 					foreach (var a in actors)
 						a.Tick();
 
-				ActorsWithTrait<ITick>().DoTimed(x => x.Trait.Tick(x.Actor), "Trait", Game.Settings.Debug.LongTickThreshold);
+				ActorsWithTrait<ITick>().DoTimed(x => x.Trait.Tick(x.Actor), "Trait");
 
-				effects.DoTimed(e => e.Tick(this), "Effect", Game.Settings.Debug.LongTickThreshold);
+				effects.DoTimed(e => e.Tick(this), "Effect");
 			}
 
 			while (frameEndActions.Count != 0)


### PR DESCRIPTION
Added a specific method for calling the PerfTimer with the long tick threshold as the limit, and outputting in the tick format. This is carefully designed to delay creating the output string until it is needed and avoid allocations. The class itself has been refactored slightly to reduce its memory footprint since so many are created.
