### PR TITLE
General Cleanup

### DIFF
--- a/OpenRA.CrashDialog/Program.cs
+++ b/OpenRA.CrashDialog/Program.cs
@@ -22,6 +22,7 @@ namespace OpenRA.CrashDialog
 	class FatalErrorDialog
 	{
 		static Settings settings;
+		[STAThread]
 		public static void Main(string[] args)
 		{
 			settings = new Settings(Platform.SupportDir + "settings.yaml", new Arguments());

--- a/OpenRA.Editor/ActorTool.cs
+++ b/OpenRA.Editor/ActorTool.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Editor
 			};
 		}
 
-		string NextActorName(Surface surface)
+		static string NextActorName(Surface surface)
 		{
 			var id = 0;
 			for (;;)

--- a/OpenRA.Editor/BrushTool.cs
+++ b/OpenRA.Editor/BrushTool.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Editor
 			s.Chunks.Clear();
 		}
 
-		CPos FindEdge(Surface s, CPos p, CVec d, TileReference<ushort, byte> replace)
+		static CPos FindEdge(Surface s, CPos p, CVec d, TileReference<ushort, byte> replace)
 		{
 			for (;;)
 			{

--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -307,7 +307,7 @@ namespace OpenRA.Editor
 			actorOwnerChooser.Items.Clear();
 			actorOwnerChooser.Items.AddRange(surface1.Map.Players.Values.ToArray());
 			actorOwnerChooser.SelectedIndex = 0;
-			surface1.NewActorOwner = (actorOwnerChooser.SelectedItem as PlayerReference).Name;
+			surface1.NewActorOwner = ((PlayerReference)actorOwnerChooser.SelectedItem).Name;
 		}
 
 		void ResizeClicked(object sender, EventArgs e)
@@ -381,7 +381,7 @@ namespace OpenRA.Editor
 				nms.ButtonOkay.Text = "Open";
 
 				if (DialogResult.OK == nms.ShowDialog())
-					LoadMap(nms.NewText.Tag as string);
+					LoadMap((string)nms.NewText.Tag);
 			}
 		}
 
@@ -507,7 +507,7 @@ namespace OpenRA.Editor
 		void DrawPlayerListItem(object sender, DrawItemEventArgs e)
 		{
 			// color block
-			var player = e.Index >= 0 ? (PlayerReference)(sender as ComboBox).Items[e.Index] : null;
+			var player = e.Index >= 0 ? (PlayerReference)((ComboBox)sender).Items[e.Index] : null;
 
 			e.DrawBackground();
 			e.DrawFocusRectangle();

--- a/OpenRA.Editor/MapSelect.cs
+++ b/OpenRA.Editor/MapSelect.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Editor
 				NewText.Text = MapList.SelectedItems[0].Text;
 				NewText.Tag = MapList.SelectedItems[0].Tag;
 
-				var map = new Map(NewText.Tag as string);
+				var map = new Map((string)NewText.Tag);
 				TitleText.Text = map.Title;
 				AuthorText.Text = map.Author;
 				TheaterText.Text = map.Tileset;

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -402,10 +402,10 @@ namespace OpenRA
 		}
 
 		[AttributeUsage(AttributeTargets.Field)]
-		public class IgnoreAttribute : Attribute { }
+		public sealed class IgnoreAttribute : Attribute { }
 
 		[AttributeUsage(AttributeTargets.Field)]
-		public class LoadUsingAttribute : Attribute
+		public sealed class LoadUsingAttribute : Attribute
 		{
 			Func<MiniYaml, object> loaderFuncCache;
 			public readonly string Loader;
@@ -440,12 +440,12 @@ namespace OpenRA
 	}
 
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-	public class TranslateAttribute : Attribute { }
+	public sealed class TranslateAttribute : Attribute { }
 
-	public class FieldFromYamlKeyAttribute : Attribute { }
+	public sealed class FieldFromYamlKeyAttribute : Attribute { }
 
 	// mirrors DescriptionAttribute from System.ComponentModel but we dont want to have to use that everywhere.
-	public class DescAttribute : Attribute
+	public sealed class DescAttribute : Attribute
 	{
 		public readonly string[] Lines;
 		public DescAttribute(params string[] lines) { Lines = lines; }

--- a/OpenRA.Game/FileFormats/Blowfish.cs
+++ b/OpenRA.Game/FileFormats/Blowfish.cs
@@ -47,7 +47,7 @@ namespace OpenRA.FileFormats
 
 		delegate void CipherFunc( ref uint a, ref uint b );
 
-		uint[] RunCipher(uint[] data, CipherFunc f)
+		static uint[] RunCipher(uint[] data, CipherFunc f)
 		{
 			uint[] result = new uint[data.Length];
 
@@ -120,7 +120,7 @@ namespace OpenRA.FileFormats
 			a ^= bf_f(b) ^ m_p[n];
 		}
 
-		uint SwapBytes(uint i)
+		static uint SwapBytes(uint i)
 		{
 			i = (i << 16) | (i >> 16);
 			i = ((i << 8) & 0xff00ff00) | ((i >> 8) & 0x00ff00ff);

--- a/OpenRA.Game/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Game/FileFormats/BlowfishKeyProvider.cs
@@ -35,13 +35,13 @@ namespace OpenRA.FileFormats
 		uint glob1_hi_bitlen;
 		uint glob1_hi_inv_lo, glob1_hi_inv_hi;
 
-		void init_bignum(uint[] n, uint val, uint len)
+		static void init_bignum(uint[] n, uint val, uint len)
 		{
 			for (int i = 0; i < len; i++) n[i] = 0;
 			n[0] = val;
 		}
 
-		void move_key_to_big(uint[] n, byte[] key, uint klen, uint blen)
+		static void move_key_to_big(uint[] n, byte[] key, uint klen, uint blen)
 		{
 			byte sign;
 
@@ -60,7 +60,7 @@ namespace OpenRA.FileFormats
 			}
 		}
 
-		void key_to_bignum(uint[] n, byte[] key, uint len)
+		static void key_to_bignum(uint[] n, byte[] key, uint len)
 		{
 			uint keylen;
 			int i;
@@ -85,7 +85,7 @@ namespace OpenRA.FileFormats
 				move_key_to_big(n, key.Skip(j).ToArray(), keylen, len);
 		}
 
-		uint len_bignum(uint[] n, uint len)
+		static uint len_bignum(uint[] n, uint len)
 		{
 			uint i;
 			i = len - 1;
@@ -93,7 +93,7 @@ namespace OpenRA.FileFormats
 			return i + 1;
 		}
 
-		uint bitlen_bignum(uint[] n, uint len)
+		static uint bitlen_bignum(uint[] n, uint len)
 		{
 			uint ddlen, bitlen, mask;
 			ddlen = len_bignum(n, len);
@@ -122,7 +122,7 @@ namespace OpenRA.FileFormats
 			return (55 / a + 1) * (a + 1);
 		}
 
-		int cmp_bignum(uint[] n1, uint[] n2, uint len)
+		static int cmp_bignum(uint[] n1, uint[] n2, uint len)
 		{
 
 			while (len > 0)
@@ -134,12 +134,12 @@ namespace OpenRA.FileFormats
 			return 0;
 		}
 
-		void mov_bignum(uint[] dest, uint[] src, uint len)
+		static void mov_bignum(uint[] dest, uint[] src, uint len)
 		{
 			Array.Copy(src, dest, len);
 		}
 
-		void shr_bignum(uint[] n, int bits, int len)
+		static void shr_bignum(uint[] n, int bits, int len)
 		{
 			int i; int i2 = bits / 32;
 
@@ -155,7 +155,7 @@ namespace OpenRA.FileFormats
 			n[i] = n[i] >> bits;
 		}
 
-		void shl_bignum(uint[] n, int bits, int len)
+		static void shl_bignum(uint[] n, int bits, int len)
 		{
 			int i, i2;
 
@@ -172,7 +172,7 @@ namespace OpenRA.FileFormats
 			n[0] <<= bits;
 		}
 
-		uint sub_bignum(uint[] dest, uint[] src1, uint[] src2, uint carry, int len)
+		static uint sub_bignum(uint[] dest, uint[] src1, uint[] src2, uint carry, int len)
 		{
 			uint i1, i2;
 
@@ -199,7 +199,7 @@ namespace OpenRA.FileFormats
 			return carry;
 		}
 
-		unsafe uint sub_bignum(uint* dest, uint* src1, uint* src2, uint carry, int len)
+		static unsafe uint sub_bignum(uint* dest, uint* src1, uint* src2, uint carry, int len)
 		{
 			uint i1, i2;
 
@@ -220,7 +220,7 @@ namespace OpenRA.FileFormats
 			return carry;
 		}
 
-		void inv_bignum(uint[] n1, uint[] n2, uint len)
+		static void inv_bignum(uint[] n1, uint[] n2, uint len)
 		{
 			uint[] n_tmp = new uint[64];
 			uint n2_bytelen, bit;
@@ -255,7 +255,7 @@ namespace OpenRA.FileFormats
 			init_bignum(n_tmp, 0, len);
 		}
 
-		void inc_bignum(uint[] n, uint len)
+		static void inc_bignum(uint[] n, uint len)
 		{
 			int i = 0;
 			while ((++n[i] == 0) && (--len > 0)) i++;
@@ -282,7 +282,7 @@ namespace OpenRA.FileFormats
 			glob1_hi_inv_hi = (ushort)(glob1_hi_inv[0] >> 16);
 		}
 
-		unsafe void mul_bignum_word(ushort *pn1, uint[] n2, uint mul, uint len)
+		static unsafe void mul_bignum_word(ushort* pn1, uint[] n2, uint mul, uint len)
 		{
 			uint i, tmp;
 			unsafe
@@ -305,7 +305,7 @@ namespace OpenRA.FileFormats
 			}
 		}
 
-		void mul_bignum(uint[] dest, uint[] src1, uint[] src2, uint len)
+		static void mul_bignum(uint[] dest, uint[] src1, uint[] src2, uint len)
 		{
 		  uint i;
 
@@ -324,13 +324,13 @@ namespace OpenRA.FileFormats
 		  }
 		}
 
-		void not_bignum(uint[] n, uint len)
+		static void not_bignum(uint[] n, uint len)
 		{
 		  uint i;
 		  for (i = 0; i < len; i++) n[i] = ~n[i];
 		}
 
-		void neg_bignum(uint[] n, uint len)
+		static void neg_bignum(uint[] n, uint len)
 		{
 		  not_bignum(n, len);
 		  inc_bignum(n, len);
@@ -348,7 +348,7 @@ namespace OpenRA.FileFormats
 			return i & 0xffff;
 		}
 
-		void dec_bignum(uint[] n, uint len)
+		static void dec_bignum(uint[] n, uint len)
 		{
 			int i = 0;
 			while ((--n[i] == 0xffffffff) && (--len > 0))
@@ -450,7 +450,7 @@ namespace OpenRA.FileFormats
 			}
 		}
 
-		unsafe void memcpy(byte* dest, byte* src, int len)
+		static unsafe void memcpy(byte* dest, byte* src, int len)
 		{
 			while (len-- != 0) *dest++ = *src++;
 		}

--- a/OpenRA.Game/FileFormats/IniFile.cs
+++ b/OpenRA.Game/FileFormats/IniFile.cs
@@ -66,7 +66,7 @@ namespace OpenRA.FileFormats
 			return ret;
 		}
 
-		bool ProcessEntry(string line, IniSection currentSection)
+		static bool ProcessEntry(string line, IniSection currentSection)
 		{
 			var comment = line.IndexOf(';');
 			if (comment >= 0)

--- a/OpenRA.Game/FileFormats/VqaReader.cs
+++ b/OpenRA.Game/FileFormats/VqaReader.cs
@@ -257,7 +257,7 @@ namespace OpenRA.FileFormats
 
 		int cachedFrame = -1;
 
-		void DecodeFrameData( int frame )
+		void DecodeFrameData()
 		{
 			cachedFrame = currentFrame;
 			for (var y = 0; y < blocks.Y; y++)
@@ -280,7 +280,7 @@ namespace OpenRA.FileFormats
 			get
 			{
 				if (cachedFrame != currentFrame)
-					DecodeFrameData(currentFrame);
+					DecodeFrameData();
 
 				return frameData;
 			}

--- a/OpenRA.Game/FileFormats/VxlReader.cs
+++ b/OpenRA.Game/FileFormats/VxlReader.cs
@@ -40,7 +40,7 @@ namespace OpenRA.FileFormats
 
 		uint BodySize;
 
-		void ReadVoxelData(Stream s, VxlLimb l)
+		static void ReadVoxelData(Stream s, VxlLimb l)
 		{
 			var baseSize = l.Size[0]*l.Size[1];
 			var colStart = new int[baseSize];

--- a/OpenRA.Game/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldPackage.cs
@@ -62,7 +62,7 @@ namespace OpenRA.FileSystem
 
 		}
 
-		uint ParseDirectory(BinaryReader reader)
+		static uint ParseDirectory(BinaryReader reader)
 		{
 			// Parse directory header
 			var FileCount = reader.ReadUInt16();

--- a/OpenRA.Game/FileSystem/MixFile.cs
+++ b/OpenRA.Game/FileSystem/MixFile.cs
@@ -73,7 +73,7 @@ namespace OpenRA.FileSystem
 			);
 		}
 
-		List<PackageEntry> ParseHeader(Stream s, long offset, out long headerEnd)
+		static List<PackageEntry> ParseHeader(Stream s, long offset, out long headerEnd)
 		{
 			s.Seek(offset, SeekOrigin.Begin);
 			var numFiles = s.ReadUInt16();
@@ -87,7 +87,7 @@ namespace OpenRA.FileSystem
 			return items;
 		}
 
-		MemoryStream DecryptHeader(Stream s, long offset, out long headerEnd)
+		static MemoryStream DecryptHeader(Stream s, long offset, out long headerEnd)
 		{
 			s.Seek(offset, SeekOrigin.Begin);
 
@@ -121,7 +121,7 @@ namespace OpenRA.FileSystem
 			return ms;
 		}
 
-		uint[] ReadBlocks(Stream s, long offset, int count)
+		static uint[] ReadBlocks(Stream s, long offset, int count)
 		{
 			s.Seek(offset, SeekOrigin.Begin);
 

--- a/OpenRA.Game/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Game/Graphics/ContrailRenderable.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Graphics
 			return j < 0 ? j + trail.Length : j;
 		}
 
-		WPos Average(params WPos[] list)
+		static WPos Average(params WPos[] list)
 		{
 			return list.Average();
 		}

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {
-	public class Minimap
+	public static class Minimap
 	{
 		public static Bitmap TerrainBitmap(TileSet tileset, Map map, bool actualSize = false)
 		{

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -14,6 +14,7 @@ using OpenRA.FileFormats;
 
 namespace OpenRA.Graphics
 {
+	[Serializable]
 	public class SheetOverflowException : Exception
 	{
 		public SheetOverflowException(string message)

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -134,12 +134,7 @@ namespace OpenRA.Graphics
 			return g;
 		}
 
-		static SpriteFont()
-		{
-			library = new Library();  
-		}
-
-		static Library library;
+		static Library library = new Library();  
 		static SheetBuilder builder;
 	}
 

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Graphics
 		int totalVertexCount;
 		int cachedVertexCount;
 
-		SheetBuilder CreateSheetBuilder()
+		static SheetBuilder CreateSheetBuilder()
 		{
 			var allocated = false;
 			Func<Sheet> allocate = () =>

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Graphics
 			Theater = new Theater(world.TileSet);
 			terrainRenderer = new TerrainRenderer(world, this);
 
-			devTrait = new Lazy<DeveloperMode>(() => world.LocalPlayer != null ? world.LocalPlayer.PlayerActor.Trait<DeveloperMode>() : null);
+			devTrait = Exts.Lazy(() => world.LocalPlayer != null ? world.LocalPlayer.PlayerActor.Trait<DeveloperMode>() : null);
 		}
 
 		PaletteReference CreatePaletteReference(string name)

--- a/OpenRA.Game/IGraphicsDevice.cs
+++ b/OpenRA.Game/IGraphicsDevice.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 namespace OpenRA
 {
 	[AttributeUsage(AttributeTargets.Assembly)]
-	public class RendererAttribute : Attribute
+	public sealed class RendererAttribute : Attribute
 	{
 		public readonly Type Type;
 

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -293,6 +293,7 @@ namespace OpenRA
 		}
 	}
 
+	[Serializable]
 	public class YamlException : Exception
 	{
 		public YamlException(string s) : base(s) { }

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -145,12 +145,12 @@ namespace OpenRA.Network
 			throw new InvalidOperationException("Out of sync in frame {0}.\n {1}\n Compare syncreport.log with other players.".F(frame, orders.ElementAt(index).Order.ToString()));
 		}
 
-		void OutOfSync(int frame)
+		static void OutOfSync(int frame)
 		{
 			throw new InvalidOperationException("Out of sync in frame {0}.\n Compare syncreport.log with other players.".F(frame));
 		}
 
-		void OutOfSync(int frame, string blame)
+		static void OutOfSync(int frame, string blame)
 		{
 			throw new InvalidOperationException("Out of sync in frame {0}: Blame {1}.\n Compare syncreport.log with other players.".F(frame, blame));
 		}

--- a/OpenRA.Game/Network/ReplayRecorderConnection.cs
+++ b/OpenRA.Game/Network/ReplayRecorderConnection.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Network
 				});
 		}
 
-		bool IsGameStart(byte[] data)
+		static bool IsGameStart(byte[] data)
 		{
 			if (data.Length == 5 && data[4] == 0xbf)
 				return false;

--- a/OpenRA.Game/Network/UPnP.cs
+++ b/OpenRA.Game/Network/UPnP.cs
@@ -14,7 +14,7 @@ using Mono.Nat;
 
 namespace OpenRA.Network
 {
-	public class UPnP
+	public static class UPnP
 	{
 		public static INatDevice NatDevice;
 

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -102,6 +102,6 @@ namespace OpenRA
 		}
 
 		[AttributeUsage(AttributeTargets.Constructor)]
-		public class UseCtorAttribute : Attribute { }
+		public sealed class UseCtorAttribute : Attribute { }
 	}
 }

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -23,7 +23,7 @@ namespace OpenRA
 	{
 		public static PlatformType CurrentPlatform { get { return currentPlatform.Value; } }
 
-		static Lazy<PlatformType> currentPlatform = new Lazy<PlatformType>(GetCurrentPlatform);
+		static Lazy<PlatformType> currentPlatform = Exts.Lazy(GetCurrentPlatform);
 
 		static PlatformType GetCurrentPlatform()
 		{

--- a/OpenRA.Game/Primitives/Bits.cs
+++ b/OpenRA.Game/Primitives/Bits.cs
@@ -17,9 +17,7 @@ namespace OpenRA.Primitives
 	static class BitAllocator<T> where T : struct
 	{
 		static int nextVal = 1;
-		static Cache<string,int> bits;
-
-		static BitAllocator() {	bits = new Cache<string, int>( _ => Allocate() ); }
+		static Cache<string, int> bits = new Cache<string, int>(_ => Allocate());
 
 		static int Allocate()
 		{

--- a/OpenRA.Game/Primitives/Cache.cs
+++ b/OpenRA.Game/Primitives/Cache.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Primitives
 		{
 			hax = new Dictionary<T, U>(c);
 			if (loader == null)
-				throw new ArgumentNullException();
+				throw new ArgumentNullException("loader");
 
 			this.loader = loader;
 		}

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -34,13 +34,13 @@ namespace OpenRA.Scripting
 	}
 
 	// For traitinfos that provide actor / player commands
-	public class ScriptPropertyGroupAttribute : Attribute
+	public sealed class ScriptPropertyGroupAttribute : Attribute
 	{
 		public readonly string Category;
 		public ScriptPropertyGroupAttribute(string category) { Category = category; }
 	}
 
-	public class ScriptActorPropertyActivityAttribute : Attribute { }
+	public sealed class ScriptActorPropertyActivityAttribute : Attribute { }
 
 	public abstract class ScriptActorProperties
 	{
@@ -75,7 +75,7 @@ namespace OpenRA.Scripting
 		}
 	}
 
-	public class ScriptGlobalAttribute : Attribute
+	public sealed class ScriptGlobalAttribute : Attribute
 	{
 		public readonly string Name;
 		public ScriptGlobalAttribute(string name) { Name = name; }

--- a/OpenRA.Game/Scripting/ScriptMemberExts.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberExts.cs
@@ -49,23 +49,23 @@ namespace OpenRA.Scripting
 
 		public static string LuaDocString(this MemberInfo mi)
 		{
-			if (mi is MethodInfo)
+			var methodInfo = mi as MethodInfo;
+			if (methodInfo != null)
 			{
-				var methodInfo = mi as MethodInfo;
 				var parameters = methodInfo.GetParameters().Select(pi => pi.LuaDocString());
 				return "{0} {1}({2})".F(methodInfo.ReturnType.LuaDocString(), mi.Name, parameters.JoinWith(", "));
 			}
 
-			if (mi is PropertyInfo)
+			var propertyInfo = mi as PropertyInfo;
+			if (propertyInfo != null)
 			{
-				var pi = mi as PropertyInfo;
 				var types = new List<string>();
-				if (pi.GetGetMethod() != null)
+				if (propertyInfo.GetGetMethod() != null)
 					types.Add("get;");
-				if (pi.GetSetMethod() != null)
+				if (propertyInfo.GetSetMethod() != null)
 					types.Add("set;");
 
-				return "{0} {1} {{ {2} }}".F(pi.PropertyType.LuaDocString(), mi.Name, types.JoinWith(" "));
+				return "{0} {1} {{ {2} }}".F(propertyInfo.PropertyType.LuaDocString(), mi.Name, types.JoinWith(" "));
 			}
 
 			return "Unknown field: {0}".F(mi.Name);

--- a/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Scripting
 			if (!IsMethod)
 				throw new LuaException("Trying to invoke a ScriptMemberWrapper that isn't a method!");
 
-			var mi = Member as MethodInfo;
+			var mi = (MethodInfo)Member;
 			var pi = mi.GetParameters();
 
 			object[] clrArgs = new object[pi.Length];
@@ -71,7 +71,7 @@ namespace OpenRA.Scripting
 					throw new LuaException("Unable to convert parameter {0} to {1}".F(i, pi[i].ParameterType.Name));
 			}
 
-			var ret = (Member as MethodInfo).Invoke(Target, clrArgs);
+			var ret = (mi.Invoke(Target, clrArgs));
 			return ret.ToLuaValue(context);
 		}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -687,7 +687,7 @@ namespace OpenRA.Server
 			}
 		}
 
-		void SendData(Socket s, byte[] data)
+		static void SendData(Socket s, byte[] data)
 		{
 			var start = 0;
 			var length = data.Length;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -260,7 +260,7 @@ namespace OpenRA
 			root.WriteToFile(settingsFile);
 		}
 
-		void LoadSectionYaml(MiniYaml yaml, object section)
+		static void LoadSectionYaml(MiniYaml yaml, object section)
 		{
 			var defaults = Activator.CreateInstance(section.GetType());
 			FieldLoader.InvalidValueAction = (s, t, f) =>

--- a/OpenRA.Game/Sound.cs
+++ b/OpenRA.Game/Sound.cs
@@ -607,7 +607,7 @@ namespace OpenRA
 			slot.FrameStarted = currFrame;
 			slot.Sound = sound;
 			slot.IsRelative = relative;
-			return new OpenAlSound(source, (sound as OpenAlSoundSource).Buffer, loop, relative, pos, volume * atten);
+			return new OpenAlSound(source, ((OpenAlSoundSource)sound).Buffer, loop, relative, pos, volume * atten);
 		}
 
 		public float Volume

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -79,9 +79,9 @@ namespace OpenRA
 
 			sb.AppendFormat("Exception of type `{0}`: {1}", e.GetType().FullName, e.Message);
 
-			if (e is TypeLoadException)
+			var tle = e as TypeLoadException;
+			if (tle != null)
 			{
-				var tle = (TypeLoadException)e;
 				sb.AppendLine();
 				Indent(sb, d);
 				sb.AppendFormat("TypeName=`{0}`", tle.TypeName);

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -19,7 +19,7 @@ using OpenRA.Primitives;
 namespace OpenRA
 {
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-	public class SyncAttribute : Attribute { }
+	public sealed class SyncAttribute : Attribute { }
 	public interface ISync { }	/* marker interface */
 
 	public static class Sync

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -76,7 +76,7 @@ namespace OpenRA
 			InnerGet(t).Add(actor, val);
 		}
 
-		void CheckDestroyed(Actor actor)
+		static void CheckDestroyed(Actor actor)
 		{
 			if (actor.Destroyed)
 				throw new InvalidOperationException("Attempted to get trait from destroyed object ({0})".F(actor));

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -15,11 +15,11 @@ namespace OpenRA.Traits
 	/* attributes used by RALint to understand the rules */
 
 	[AttributeUsage(AttributeTargets.Field)]
-	public class ActorReferenceAttribute : Attribute { }
+	public sealed class ActorReferenceAttribute : Attribute { }
 
 	[AttributeUsage(AttributeTargets.Field)]
-	public class WeaponReferenceAttribute : Attribute { }
+	public sealed class WeaponReferenceAttribute : Attribute { }
 
 	[AttributeUsage(AttributeTargets.Field)]
-	public class VoiceReferenceAttribute : Attribute { }
+	public sealed class VoiceReferenceAttribute : Attribute { }
 }

--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -71,7 +71,7 @@ namespace OpenRA
 			return widget;
 		}
 
-		Widget NewWidget(string widgetType, WidgetArgs args)
+		static Widget NewWidget(string widgetType, WidgetArgs args)
 		{
 			widgetType = widgetType.Split('@')[0];
 			return Game.modData.ObjectCreator.CreateObject<Widget>(widgetType + "Widget", args);

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Widgets
 			return false;
 		}
 
-		IEnumerable<Actor> SelectActorsInBox(World world, int2 a, int2 b, Func<Actor, bool> cond)
+		static IEnumerable<Actor> SelectActorsInBox(World world, int2 a, int2 b, Func<Actor, bool> cond)
 		{
 			return world.ScreenMap.ActorsInBox(a, b)
 				.Where(x => x.HasTrait<Selectable>() && x.Trait<Selectable>().Info.Selectable && !world.FogObscures(x) && cond(x))

--- a/OpenRA.Irc/User.cs
+++ b/OpenRA.Irc/User.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Irc
 		public User(string prefix)
 		{
 			if (string.IsNullOrEmpty(prefix))
-				throw new ArgumentException();
+				throw new ArgumentException("prefix");
 
 			var ex = prefix.IndexOf('!');
 			var at = prefix.IndexOf('@');

--- a/OpenRA.Mods.Cnc/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/ProductionAirdrop.cs
@@ -48,7 +48,8 @@ namespace OpenRA.Mods.Cnc
 			foreach (var tower in self.TraitsImplementing<INotifyDelivery>())
 				tower.IncomingDelivery(self);
 
-			var actorType = (Info as ProductionAirdropInfo).ActorType;
+			var info = (ProductionAirdropInfo)Info;
+			var actorType = info.ActorType;
 
 			owner.World.AddFrameEndTask(w =>
 			{
@@ -70,7 +71,7 @@ namespace OpenRA.Mods.Cnc
 					foreach (var cargo in self.TraitsImplementing<INotifyDelivery>())
 						cargo.Delivered(self);
 					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit));
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", (Info as ProductionAirdropInfo).ReadyAudio, self.Owner.Country.Race);
+					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Country.Race);
 				}));
 
 				a.QueueActivity(new Fly(a, Target.FromCell(endPos)));

--- a/OpenRA.Mods.RA/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.RA/AI/AttackOrFleeFuzzy.cs
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.RA.AI
 			return !double.IsNaN(attackChance) && attackChance < 30.0;
 		}
 
-		protected float NormalizedHealth(IEnumerable<Actor> actors, float normalizeByValue)
+		protected static float NormalizedHealth(IEnumerable<Actor> actors, float normalizeByValue)
 		{
 			var sumOfMaxHp = 0;
 			var sumOfHp = 0;
@@ -206,7 +206,7 @@ namespace OpenRA.Mods.RA.AI
 			return RelativeValue(own, enemy, 100, Average<Mobile>, (Actor a) => a.Trait<Mobile>().Info.Speed);
 		}
 
-		protected float RelativeValue(IEnumerable<Actor> own, IEnumerable<Actor> enemy, float normalizeByValue, 
+		protected static float RelativeValue(IEnumerable<Actor> own, IEnumerable<Actor> enemy, float normalizeByValue, 
 					Func<IEnumerable<Actor>, Func<Actor, int>, float> relativeFunc, Func<Actor, int> getValue)
 		{
 			if (!enemy.Any())

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -22,7 +22,7 @@ using OpenRA.Support;
 
 namespace OpenRA.Mods.RA.AI
 {
-	public class HackyAIInfo : IBotInfo, ITraitInfo
+	public sealed class HackyAIInfo : IBotInfo, ITraitInfo
 	{
 		public readonly string Name = "Unnamed Bot";
 		public readonly int SquadSize = 8;
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.RA.AI
 
 	public enum BuildingType { Building, Defense, Refinery }
 
-	public class HackyAI : ITick, IBot, INotifyDamage
+	public sealed class HackyAI : ITick, IBot, INotifyDamage
 	{
 		bool enabled;
 		public int ticks;
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA.AI
 				.Select(t => t.TerrainType).ToArray();
 		}
 
-		int GetPowerProvidedBy(ActorInfo building)
+		static int GetPowerProvidedBy(ActorInfo building)
 		{
 			var bi = building.Traits.GetOrDefault<BuildingInfo>();
 			return bi != null ? bi.Power : 0;

--- a/OpenRA.Mods.RA/Activities/LayMines.cs
+++ b/OpenRA.Mods.RA/Activities/LayMines.cs
@@ -65,13 +65,13 @@ namespace OpenRA.Mods.RA.Activities
 			return new Wait(20);	// nothing to do here
 		}
 
-		bool ShouldLayMine(Actor self, CPos p)
+		static bool ShouldLayMine(Actor self, CPos p)
 		{
 			// if there is no unit (other than me) here, we want to place a mine here
 			return !self.World.ActorMap.GetUnitsAt(p).Any(a => a != self);
 		}
 
-		void LayMine(Actor self)
+		static void LayMine(Actor self)
 		{
 			var limitedAmmo = self.TraitOrDefault<LimitedAmmo>();
 			if (limitedAmmo != null)

--- a/OpenRA.Mods.RA/Console/DevCommands.cs
+++ b/OpenRA.Mods.RA/Console/DevCommands.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		void IssueDevCommand(World world, string command)
+		static void IssueDevCommand(World world, string command)
 		{
 			world.IssueOrder(new Order(command, world.LocalPlayer.PlayerActor, false));
 		}

--- a/OpenRA.Mods.RA/Crates/ExplodeCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/ExplodeCrateAction.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA
 
 		public override void Activate(Actor collector)
 		{
-			Combat.DoExplosion(self, (info as ExplodeCrateActionInfo).Weapon, collector.CenterPosition);
+			Combat.DoExplosion(self, ((ExplodeCrateActionInfo)info).Weapon, collector.CenterPosition);
 			base.Activate(collector);
 		}
 	}

--- a/OpenRA.Mods.RA/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveCashCrateAction.cs
@@ -30,10 +30,11 @@ namespace OpenRA.Mods.RA
 		{
 			collector.World.AddFrameEndTask(w =>
 			{
-				var amount = (info as GiveCashCrateActionInfo).Amount;
+				var crateInfo = (GiveCashCrateActionInfo)info;
+				var amount = crateInfo.Amount;
 				collector.Owner.PlayerActor.Trait<PlayerResources>().GiveCash(amount);
 
-				if ((info as GiveCashCrateActionInfo).UseCashTick)
+				if (crateInfo.UseCashTick)
 					w.Add(new CashTick(collector.CenterPosition, collector.Owner.Color.RGB, amount));
 			});
 

--- a/OpenRA.Mods.RA/Crates/GiveMcvCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveMcvCrateAction.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA.Crates
 				.Any(a => a.Actor.Owner == collector.Owner);
 
 			return hasBase ? info.SelectionShares :
-				(info as GiveMcvCrateActionInfo).NoBaseSelectionShares;
+				((GiveMcvCrateActionInfo)info).NoBaseSelectionShares;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Crates/LevelUpCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/LevelUpCrateAction.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA
 			{
 				var gainsExperience = collector.TraitOrDefault<GainsExperience>();
 				if (gainsExperience != null)
-					gainsExperience.GiveLevels((info as LevelUpCrateActionInfo).Levels);
+					gainsExperience.GiveLevels(((LevelUpCrateActionInfo)info).Levels);
 			});
 
 			base.Activate(collector);

--- a/OpenRA.Mods.RA/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/RevealMapCrateAction.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA
 
 		bool ShouldReveal(Player collectingPlayer)
 		{
-			if ((info as RevealMapCrateActionInfo).IncludeAllies)
+			if (((RevealMapCrateActionInfo)info).IncludeAllies)
 				return collectingPlayer.World.LocalPlayer != null &&
 					collectingPlayer.Stances[collectingPlayer.World.LocalPlayer] == Stance.Ally;
 

--- a/OpenRA.Mods.RA/DemoTruck.cs
+++ b/OpenRA.Mods.RA/DemoTruck.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 
 	class DemoTruck : IIssueOrder, IResolveOrder, IOrderVoice
 	{
-		void Explode(Actor self)
+		static void Explode(Actor self)
 		{
 			self.World.AddFrameEndTask(w =>
 			{

--- a/OpenRA.Mods.RA/EjectOnDeath.cs
+++ b/OpenRA.Mods.RA/EjectOnDeath.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA
 				new TypeDictionary { new OwnerInit(self.Owner), new LocationInit(self.Location) });
 
 
-			if (IsSuitableCell(self, pilot, self.Location))
+			if (IsSuitableCell(self, pilot))
 			{
 				if (cp.Z > 0)
 				{
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.RA
 				pilot.Destroy();
 		}
 
-		bool IsSuitableCell(Actor self, Actor actorToDrop, CPos p)
+		static bool IsSuitableCell(Actor self, Actor actorToDrop)
 		{
 			return actorToDrop.Trait<IPositionable>().CanEnterCell(self.Location, self, true);
 		}

--- a/OpenRA.Mods.RA/EmitCargoOnSell.cs
+++ b/OpenRA.Mods.RA/EmitCargoOnSell.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA
 
 	class EmitCargoOnSell : INotifySold
 	{
-		void Emit(Actor self)
+		static void Emit(Actor self)
 		{
 			// TODO: would like to spill all actors out similar to how we call Unload
 		}

--- a/OpenRA.Mods.RA/EmitInfantryOnSell.cs
+++ b/OpenRA.Mods.RA/EmitInfantryOnSell.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.RA
 	{
 		public void Selling(Actor self) { }
 
-		void Emit(Actor self)
+		static void Emit(Actor self)
 		{
 			var info = self.Info.Traits.Get<EmitInfantryOnSellInfo>();
 			var csv = self.Info.Traits.GetOrDefault<CustomSellValueInfo>();

--- a/OpenRA.Mods.RA/EngineerRepair.cs
+++ b/OpenRA.Mods.RA/EngineerRepair.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA
 			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
 		}
 
-		bool IsValidOrder(Actor self, Order order)
+		static bool IsValidOrder(Actor self, Order order)
 		{
 			// Not targeting a frozen actor
 			if (order.ExtraData == 0 && order.TargetActor == null)

--- a/OpenRA.Mods.RA/ExternalCaptures.cs
+++ b/OpenRA.Mods.RA/ExternalCaptures.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA
 			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
 		}
 
-		bool IsValidOrder(Actor self, Order order)
+		static bool IsValidOrder(Actor self, Order order)
 		{
 			// Not targeting an actor
 			if (order.ExtraData == 0 && order.TargetActor == null)

--- a/OpenRA.Mods.RA/GivesBounty.cs
+++ b/OpenRA.Mods.RA/GivesBounty.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA
 
 	class GivesBounty : INotifyKilled
 	{
-		int GetMultiplier(Actor self)
+		static int GetMultiplier(Actor self)
 		{
 			// returns 100's as 1, so as to keep accuracy for longer.
 			var info = self.Info.Traits.Get<GivesBountyInfo>();

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -349,7 +349,7 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		CPos? FindNextResourceForBot(Actor self)
+		static CPos? FindNextResourceForBot(Actor self)
 		{
 			// NOTE: This is only used for the AI to find the next available resource to harvest.
 			var harvInfo = self.Info.Traits.Get<HarvesterInfo>();

--- a/OpenRA.Mods.RA/MenuPaletteEffect.cs
+++ b/OpenRA.Mods.RA/MenuPaletteEffect.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.RA
 				remainingFrames--;
 		}
 
-		Color ColorForEffect(EffectType t, Color orig)
+		static Color ColorForEffect(EffectType t, Color orig)
 		{
 			switch (t)
 			{

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.RA.Move
 				throw new InvalidOperationException("(Move) Sanity check failed");
 		}
 
-		void NotifyBlocker(Actor self, CPos nextCell)
+		static void NotifyBlocker(Actor self, CPos nextCell)
 		{
 			foreach (var blocker in self.World.ActorMap.GetUnitsAt(nextCell))
 			{

--- a/OpenRA.Mods.RA/Orders/PowerDownOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PowerDownOrderGenerator.cs
@@ -31,10 +31,10 @@ namespace OpenRA.Mods.RA.Orders
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
 
-			return OrderInner(world, xy, mi);
+			return OrderInner(world, mi);
 		}
 
-		IEnumerable<Order> OrderInner(World world, CPos xy, MouseInput mi)
+		IEnumerable<Order> OrderInner(World world, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Left)
 			{
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.RA.Orders
 		public string GetCursor(World world, CPos xy, MouseInput mi)
 		{
 			mi.Button = MouseButton.Left;
-			return cursor + (OrderInner(world, xy, mi).Any()	? "" : "-blocked");
+			return cursor + (OrderInner(world, mi).Any()	? "" : "-blocked");
 		}
 	}
 

--- a/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
@@ -23,10 +23,10 @@ namespace OpenRA.Mods.RA.Orders
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
 
-			return OrderInner(world, xy, mi);
+			return OrderInner(world, mi);
 		}
 
-		IEnumerable<Order> OrderInner(World world, CPos xy, MouseInput mi)
+		IEnumerable<Order> OrderInner(World world, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Left)
 			{
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.RA.Orders
 		public string GetCursor(World world, CPos xy, MouseInput mi)
 		{
 			mi.Button = MouseButton.Left;
-			return OrderInner(world, xy, mi).Any()
+			return OrderInner(world, mi).Any()
 				? "repair" : "repair-blocked";
 		}
 	}

--- a/OpenRA.Mods.RA/ParaDrop.cs
+++ b/OpenRA.Mods.RA/ParaDrop.cs
@@ -58,12 +58,12 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		bool IsSuitableCell(Actor actorToDrop, CPos p)
+		static bool IsSuitableCell(Actor actorToDrop, CPos p)
 		{
 			return actorToDrop.Trait<IPositionable>().CanEnterCell(p);
 		}
 
-		void FinishedDropping(Actor self)
+		static void FinishedDropping(Actor self)
 		{
 			self.CancelActivity();
 			self.QueueActivity(new FlyOffMap());

--- a/OpenRA.Mods.RA/ProvidesRadar.cs
+++ b/OpenRA.Mods.RA/ProvidesRadar.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA
 
 		public void Tick(Actor self) { IsActive = UpdateActive(self); }
 
-		bool UpdateActive(Actor self)
+		static bool UpdateActive(Actor self)
 		{
 			// Check if powered
 			if (self.IsDisabled()) return false;

--- a/OpenRA.Mods.RA/ProximityCapturable.cs
+++ b/OpenRA.Mods.RA/ProximityCapturable.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		void ChangeOwnership(Actor self, Actor captor)
+		static void ChangeOwnership(Actor self, Actor captor)
 		{
 			self.World.AddFrameEndTask(w =>
 			{

--- a/OpenRA.Mods.RA/Render/RenderBuildingWall.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWall.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA.Render
 			dirty = false;
 		}
 
-		void UpdateNeighbours(Actor self)
+		static void UpdateNeighbours(Actor self)
 		{
 			var vec = new CVec(1, 1);
 			var neighbours = self.World.FindActorsInBox(self.Location - vec, self.Location + vec)

--- a/OpenRA.Mods.RA/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.RA/Scripting/Global/TriggerGlobal.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Scripting
 	{
 		public TriggerGlobal(ScriptContext context) : base(context) { }
 
-		ScriptTriggers GetScriptTriggers(Actor a)
+		static ScriptTriggers GetScriptTriggers(Actor a)
 		{
 			var events = a.TraitOrDefault<ScriptTriggers>();
 			if (events == null)

--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.RA.Scripting
 			return Activator.CreateInstance(type, argsArray);
 		}
 
-		object[] ConvertArgs(LuaTable args)
+		static object[] ConvertArgs(LuaTable args)
 		{
 			var argsArray = new object[args.Keys.Count];
 			for (var i = 1; i <= args.Keys.Count; i++)

--- a/OpenRA.Mods.RA/Scripting/Media.cs
+++ b/OpenRA.Mods.RA/Scripting/Media.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Scripting
 {
-	public class Media
+	public static class Media
 	{
 		public static void PlayFMVFullscreen(World w, string movie, Action onComplete)
 		{

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA.Server
 			return true;
 		}
 
-		void CheckAutoStart(S server, Connection conn, Session.Client client)
+		static void CheckAutoStart(S server)
 		{
 			var playerClients = server.LobbyInfo.Clients.Where(c => c.Bot == null && c.Slot != null);
 
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.RA.Server
 
 						server.SyncLobbyClients();
 
-						CheckAutoStart(server, conn, client);
+						CheckAutoStart(server);
 
 						return true;
 					}},
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.RA.Server
 						client.Slot = s;
 						S.SyncClientToPlayerReference(client, server.Map.Players[s]);
 						server.SyncLobbyClients();
-						CheckAutoStart(server, conn, client);
+						CheckAutoStart(server);
 
 						return true;
 					}},

--- a/OpenRA.Mods.RA/SpawnMPUnits.cs
+++ b/OpenRA.Mods.RA/SpawnMPUnits.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA
 				SpawnUnitsForPlayer(world, s.Key, s.Value);
 		}
 
-		void SpawnUnitsForPlayer(World w, Player p, CPos sp)
+		static void SpawnUnitsForPlayer(World w, Player p, CPos sp)
 		{
 			var spawnClass = p.PlayerReference.StartingUnitsClass ?? w.LobbyInfo.GlobalSettings.StartingUnitsClass;
 			var unitGroup = w.Map.Rules.Actors["world"].Traits.WithInterface<MPStartUnitsInfo>()

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<Actor> UnitsInRange(CPos xy)
 		{
-			var range = (Info as ChronoshiftPowerInfo).Range;
+			var range = ((ChronoshiftPowerInfo)Info).Range;
 			var tiles = self.World.FindTilesInCircle(xy, range);
 			var units = new List<Actor>();
 			foreach (var t in tiles)
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.RA
 			if (!self.Owner.Shroud.IsExplored(xy))
 				return false;
 
-			var range = (Info as ChronoshiftPowerInfo).Range;
+			var range = ((ChronoshiftPowerInfo)Info).Range;
 			var sourceTiles = self.World.FindTilesInCircle(xy, range);
 			var destTiles = self.World.FindTilesInCircle(sourceLocation, range);
 			var sourceTerrain = new List<string>();
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.RA
 				this.manager = manager;
 				this.order = order;
 				this.power = power;
-				this.range = (power.Info as ChronoshiftPowerInfo).Range;
+				this.range = ((ChronoshiftPowerInfo)power.Info).Range;
 				tile = world.Map.SequenceProvider.GetSequence("overlay", "target-select").GetSprite(0);
 			}
 
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.RA
 				this.order = order;
 				this.power = power;
 				this.sourceLocation = sourceLocation;
-				this.range = (power.Info as ChronoshiftPowerInfo).Range;
+				this.range = ((ChronoshiftPowerInfo)power.Info).Range;
 
 				var tileset = manager.self.World.TileSet.Id.ToLower();
 				validTile = world.Map.SequenceProvider.GetSequence("overlay", "target-valid-{0}".F(tileset)).GetSprite(0);
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.RA
 					yield break;
 				}
 
-				var ret = OrderInner( world, xy, mi ).FirstOrDefault();
+				var ret = OrderInner(xy).FirstOrDefault();
 				if (ret == null)
 					yield break;
 
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.RA
 				yield return ret;
 			}
 
-			IEnumerable<Order> OrderInner(World world, CPos xy, MouseInput mi)
+			IEnumerable<Order> OrderInner(CPos xy)
 			{
 				// Cannot chronoshift into unexplored location
 				if (IsValidTarget(xy))

--- a/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA
 
 		public void Launch(Actor atek, SupportPowerInfo info)
 		{
-			atek.World.Add(new DelayedAction((info as GpsPowerInfo).RevealDelay * 25,
+			atek.World.Add(new DelayedAction(((GpsPowerInfo)info).RevealDelay * 25,
 					() =>
 					{
 						Launched = true;

--- a/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
@@ -54,12 +54,12 @@ namespace OpenRA.Mods.RA
 
 			foreach (var target in UnitsInRange(order.TargetLocation)
 				.Where(a => a.Owner.Stances[self.Owner] == Stance.Ally))
-				target.Trait<IronCurtainable>().Activate(target, (Info as IronCurtainPowerInfo).Duration * 25);
+				target.Trait<IronCurtainable>().Activate(target, ((IronCurtainPowerInfo)Info).Duration * 25);
 		}
 
 		public IEnumerable<Actor> UnitsInRange(CPos xy)
 		{
-			int range = (Info as IronCurtainPowerInfo).Range;
+			int range = ((IronCurtainPowerInfo)Info).Range;
 			var tiles = self.World.FindTilesInCircle(xy, range);
 			var units = new List<Actor>();
 			foreach (var t in tiles)
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.RA
 				this.manager = manager;
 				this.order = order;
 				this.power = power;
-				this.range = (power.Info as IronCurtainPowerInfo).Range;
+				this.range = ((IronCurtainPowerInfo)power.Info).Range;
 				tile = world.Map.SequenceProvider.GetSequence("overlay", "target-select").GetSprite(0);
 			}
 

--- a/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
@@ -37,12 +37,12 @@ namespace OpenRA.Mods.RA
 		{
 			base.Activate(self, order, manager);
 
-			var items = (Info as ParatroopersPowerInfo).DropItems;
+			var info = (ParatroopersPowerInfo)Info;
+			var items = info.DropItems;
 			var startPos = self.World.ChooseRandomEdgeCell();
 
 			self.World.AddFrameEndTask(w =>
 			{
-				var info = (Info as ParatroopersPowerInfo);
 				var flare = info.FlareType != null ? w.CreateActor(info.FlareType, new TypeDictionary
 				{
 					new LocationInit( order.TargetLocation ),

--- a/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA
 						new OwnerInit( self.Owner ),
 					});
 
-					camera.QueueActivity(new Wait(25 * (Info as SpyPlanePowerInfo).RevealTime));
+					camera.QueueActivity(new Wait(25 * ((SpyPlanePowerInfo)Info).RevealTime));
 					camera.QueueActivity(new RemoveSelf());
 				})));
 			plane.QueueActivity(new FlyOffMap());

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -191,8 +191,8 @@ namespace OpenRA.Mods.RA.Widgets
 			if (!IsVisible()) return;
 			// TODO: fix
 
-			int paletteHeight = DrawPalette(CurrentQueue);
-			DrawBuildTabs(world, paletteHeight);
+			DrawPalette(CurrentQueue);
+			DrawBuildTabs(world);
 		}
 
 		int numActualRows = 5;
@@ -413,7 +413,7 @@ namespace OpenRA.Mods.RA.Widgets
 				Game.GetModifierKeys().HasModifier(Modifiers.Shift) ? 5 : 1));
 		}
 
-		void DrawBuildTabs(World world, int paletteHeight)
+		void DrawBuildTabs(World world)
 		{
 			const int tabWidth = 24;
 			const int tabHeight = 40;
@@ -450,7 +450,7 @@ namespace OpenRA.Mods.RA.Widgets
 			}
 		}
 
-		void DrawRightAligned(string text, int2 pos, Color c)
+		static void DrawRightAligned(string text, int2 pos, Color c)
 		{
 			var font = Game.Renderer.Fonts["Bold"];
 			font.DrawText(text, pos - new int2(font.Measure(text).X, 0), c);

--- a/OpenRA.Mods.RA/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/AssetBrowserLogic.cs
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return true;
 		}
 
-		void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
+		static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
 		{
 			Action onExit = () =>
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/IrcLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IrcLogic.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			};
 		}
 
-		string ChooseNickname(string nickname)
+		static string ChooseNickname(string nickname)
 		{
 			if (!IrcUtils.IsNickname(nickname))
 			{
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			IrcClient.Instance.Connect(s.Hostname, s.Port, s.ConnectionTimeout, nickname, s.Username ?? nickname, s.Realname ?? nickname);
 		}
 
-		Widget MakeLabelWidget(LabelWidget template, object item)
+		static Widget MakeLabelWidget(LabelWidget template, object item)
 		{
 			var itemString = item.ToString();
 			var widget = (LabelWidget)template.Clone();

--- a/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 		}
 
-		string GetNewsCacheFile()
+		static string GetNewsCacheFile()
 		{
 			var cacheDir = Path.Combine(Platform.SupportDir, "cache", Game.modData.Manifest.Mod.Id);
 			Directory.CreateDirectory(cacheDir);
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			public string Content;
 		}
 
-		IEnumerable<NewsItem> ReadNews(byte[] bytes)
+		static IEnumerable<NewsItem> ReadNews(byte[] bytes)
 		{
 			var str = Encoding.UTF8.GetString(bytes);
 			return MiniYaml.FromString(str).Select(node => new NewsItem

--- a/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				modOffset = selectedIndex - 4;
 		}
 
-		void LoadMod(ModMetadata mod)
+		static void LoadMod(ModMetadata mod)
 		{
 			Game.RunAfterTick(() =>
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MusicPlayerLogic.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			});
 		}
 
-		string SongLengthLabel(MusicInfo song)
+		static string SongLengthLabel(MusicInfo song)
 		{
 			return "{0:D1}:{1:D2}".F(song.Length / 60, song.Length % 60);
 		}

--- a/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ObserverStatsLogic.cs
@@ -278,7 +278,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			});
 		}
 
-		string MapControl(double control)
+		static string MapControl(double control)
 		{
 			return (control * 100).ToString("F1") + "%";
 		}

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -289,7 +289,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			ConnectionLogic.Connect(host, port, "", OpenLobby, DoNothing);
 		}
 
-		string GetPlayersLabel(GameServer game)
+		static string GetPlayersLabel(GameServer game)
 		{
 			if (game == null || game.Players == 0)
 				return "";
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return "{0} / {1}".F(game.Players, map.PlayerCount == 0 ? "?" : map.PlayerCount.ToString());
 		}
 
-		string GetStateLabel(GameServer game)
+		static string GetStateLabel(GameServer game)
 		{
 			if (game == null)
 				return "";

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			soundDevice = devices.FirstOrDefault(d => d.Engine == ss.Engine && d.Device == ss.Device) ?? devices.First();
 
 			var audioDeviceDropdown = panel.Get<DropDownButtonWidget>("AUDIO_DEVICE");
-			audioDeviceDropdown.OnMouseDown = _ => ShowAudioDeviceDropdown(audioDeviceDropdown, ss, devices);
+			audioDeviceDropdown.OnMouseDown = _ => ShowAudioDeviceDropdown(audioDeviceDropdown, devices);
 			audioDeviceDropdown.GetText = () => soundDevice.Label;
 
 			return () =>
@@ -400,7 +400,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			};
 		}
 
-		bool ShowMouseScrollDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		static bool ShowMouseScrollDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, MouseScrollType>()
 			{
@@ -422,7 +422,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return true;
 		}
 
-		bool ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundSettings s, SoundDevice[] devices)
+		bool ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundDevice[] devices)
 		{
 			var i = 0;
 			var options = devices.ToDictionary(d => (i++).ToString(), d => d);
@@ -441,7 +441,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return true;
 		}
 
-		bool ShowWindowModeDropdown(DropDownButtonWidget dropdown, GraphicSettings s)
+		static bool ShowWindowModeDropdown(DropDownButtonWidget dropdown, GraphicSettings s)
 		{
 			var options = new Dictionary<string, WindowMode>()
 			{
@@ -464,7 +464,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			return true;
 		}
 
-		bool ShowLanguageDropdown(DropDownButtonWidget dropdown)
+		static bool ShowLanguageDropdown(DropDownButtonWidget dropdown)
 		{
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{

--- a/OpenRA.Mods.RA/Widgets/SupportPowerBinWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/SupportPowerBinWidget.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.RA.Widgets
 			}
 		}
 
-		Action<MouseInput> HandleSupportPower(string key, SupportPowerManager manager)
+		static Action<MouseInput> HandleSupportPower(string key, SupportPowerManager manager)
 		{
 			return mi =>
 			{

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -251,7 +251,7 @@ namespace OpenRA.Mods.RA.Widgets
 			return true;
 		}
 
-		bool ToggleStatusBars()
+		static bool ToggleStatusBars()
 		{
 			Game.Settings.Game.AlwaysShowStatusBars ^= true;
 			return true;

--- a/OpenRA.Renderer.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Renderer.Null/NullGraphicsDevice.cs
@@ -71,7 +71,6 @@ namespace OpenRA.Renderer.Null
 		public void SetVec(string name, float[] vec, int length) { }
 		public void SetTexture(string param, ITexture texture) { }
 		public void SetMatrix(string param, float[] mtx) { }
-		public void Commit() { }
 		public void Render(Action a) { }
 	}
 

--- a/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Renderer.Sdl2
 			SDL.SDL_Quit();
 		}
 
-		BeginMode ModeFromPrimitiveType(PrimitiveType pt)
+		static BeginMode ModeFromPrimitiveType(PrimitiveType pt)
 		{
 			switch (pt)
 			{

--- a/OpenRA.Renderer.Sdl2/Sdl2Input.cs
+++ b/OpenRA.Renderer.Sdl2/Sdl2Input.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Renderer.Sdl2
 	{
 		MouseButton lastButtonBits = (MouseButton)0;
 
-		MouseButton MakeButton(byte b)
+		static MouseButton MakeButton(byte b)
 		{
 			return b == SDL.SDL_BUTTON_LEFT ? MouseButton.Left
 				: b == SDL.SDL_BUTTON_RIGHT ? MouseButton.Right
@@ -25,7 +25,7 @@ namespace OpenRA.Renderer.Sdl2
 				: 0;
 		}
 
-		Modifiers MakeModifiers(int raw)
+		static Modifiers MakeModifiers(int raw)
 		{
 			return ((raw & (int)SDL.SDL_Keymod.KMOD_ALT) != 0 ? Modifiers.Alt : 0)
 				 | ((raw & (int)SDL.SDL_Keymod.KMOD_CTRL) != 0 ? Modifiers.Ctrl : 0)

--- a/OpenRA.TilesetBuilder/FormBuilder.cs
+++ b/OpenRA.TilesetBuilder/FormBuilder.cs
@@ -31,10 +31,10 @@ namespace OpenRA.TilesetBuilder
 		public string ImageFile = "";
 		public int TileSize = 24;
 
-	private int ColorDiff(Color color, Color curr)
-	{
-		return Math.Abs(color.R - curr.R) + Math.Abs(color.G - curr.G) + Math.Abs(color.B - curr.B);
-	}
+		private static int ColorDiff(Color color, Color curr)
+		{
+			return Math.Abs(color.R - curr.R) + Math.Abs(color.G - curr.G) + Math.Abs(color.B - curr.B);
+		}
 
 	public void CreateNewTileset()
 	{
@@ -220,16 +220,17 @@ namespace OpenRA.TilesetBuilder
 
 		void TerrainTypeSelectorClicked(object sender, EventArgs e)
 		{
-			surface1.InputMode = (sender as ToolStripButton).Tag as string;
-			foreach (var tsb in (sender as ToolStripButton).Owner.Items.OfType<ToolStripButton>())
-				tsb.Checked = false;
-			(sender as ToolStripButton).Checked = true;
+			var tsb = (ToolStripButton)sender;
+			surface1.InputMode = tsb.Tag as string;
+			foreach (var innerTsb in tsb.Owner.Items.OfType<ToolStripButton>())
+				innerTsb.Checked = false;
+			tsb.Checked = true;
 		}
 		
 		void SaveClicked(object sender, EventArgs e) { Save(); }
 		void ShowOverlaysClicked(object sender, EventArgs e) 
 		{
-			surface1.ShowTerrainTypes = (sender as ToolStripButton).Checked;
+			surface1.ShowTerrainTypes = ((ToolStripButton)sender).Checked;
 			surface1.Invalidate();
 		}
 
@@ -243,7 +244,7 @@ namespace OpenRA.TilesetBuilder
 			ExportTemplateToTileNumberMapping();
 		}
 
-		string ExportPalette(List<Color> p, string file)
+		static string ExportPalette(List<Color> p, string file)
 		{
 			while (p.Count < 256) p.Add(Color.Black); // pad the palette out with extra blacks
 			var paletteData = p.Take(256).SelectMany(


### PR DESCRIPTION
General cleanup of hopefully uncontroversial things:
- Made private methods static where possible (runtime can elide checking the object for null).
- Declared attribute classes as sealed (allows reflection on attributes to complete faster).
- Moved some static cctor's into field initializers (static cctor's are slower than static field initializers).
- Made classes static if they contained only static methods (can't create instances of useless objects).
- Use inferable Exts.Lazy and not new Lazy<T>().
- Added required STAThread attribute to CrashDialog.
- Removed unused parameters in private methods.
- Added Serializable attribute to exceptions.
- Added parameter name in calls to ArgumentNullException.
- Use of as operator instead of is + cast.
- Changed (x as Foo).Bar anti-pattern into ((Foo)x).Bar. Results in sensible cast exceptions on error rather than null dereferences.
- Removed unused method in NullShader.
