### PR TITLE
Reduce Grenadier dmg vs. heavy from 50% -> 35%

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -434,7 +434,7 @@ Grenade:
 			None: 100%
 			Wood: 50%
 			Light: 75%
-			Heavy: 50%
+			Heavy: 35%
 		InfDeath: 3
 		Explosion: small_poof
 		ImpactSound: xplos.aud


### PR DESCRIPTION
Grenadier is a wee bit too powerful vs. heavy. 
After this change, grenadier will still keep its value vs. heavy armor still very high, but not OP like it is for the cost. 
(Grenadier will still have highest DPS vs. heavy as a function of cost, after this nerf).
