### PR TITLE
Reduce memory allocations in the main loop.

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -49,13 +49,16 @@ namespace OpenRA.Graphics
 
 		public IEnumerable<IRenderable> Render(WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale)
 		{
+			var imageRenderable = new SpriteRenderable(Image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, scale, IsDecoration);
+
 			if (CurrentSequence.ShadowStart >= 0)
 			{
 				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
-				yield return new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, scale, true);
+				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, scale, true);
+				return new IRenderable[] { shadowRenderable, imageRenderable };
 			}
 
-			yield return new SpriteRenderable(Image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, scale, IsDecoration);
+			return new IRenderable[] { imageRenderable };
 		}
 
 		public IEnumerable<IRenderable> Render(WPos pos, PaletteReference palette)

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Traits
 
 	public class FrozenActor
 	{
-		public readonly IEnumerable<CPos> Footprint;
+		public readonly CPos[] Footprint;
 		public readonly WPos CenterPosition;
 		public readonly Rectangle Bounds;
 		readonly Actor actor;
@@ -41,7 +41,7 @@ namespace OpenRA.Traits
 		public FrozenActor(Actor self, IEnumerable<CPos> footprint)
 		{
 			actor = self;
-			Footprint = footprint;
+			Footprint = footprint.ToArray();
 			CenterPosition = self.CenterPosition;
 			Bounds = self.Bounds.Value;
 		}
@@ -54,7 +54,13 @@ namespace OpenRA.Traits
 		int flashTicks;
 		public void Tick(World world, Shroud shroud)
 		{
-			Visible = !Footprint.Any(c => shroud.IsVisible(c));
+			Visible = false;
+			foreach (var pos in Footprint)
+				if (shroud.IsVisible(pos))
+				{
+					Visible = true;
+					break;
+				}
 
 			if (flashTicks > 0)
 				flashTicks--;

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -237,10 +237,11 @@ namespace OpenRA.Widgets
 
 		public virtual Rectangle GetEventBounds()
 		{
-			return Children
-				.Where(c => c.IsVisible())
-				.Select(c => c.GetEventBounds())
-				.Aggregate(EventBounds, Rectangle.Union);
+			var bounds = EventBounds;
+			foreach (var child in Children)
+				if (child.IsVisible())
+					bounds = Rectangle.Union(bounds, child.GetEventBounds());
+			return bounds;
 		}
 
 		public bool HasMouseFocus { get { return Ui.MouseFocusWidget == this; } }


### PR DESCRIPTION
# Memory

I targeted some methods allocating memory in the main loop and tweaked them. They function the same - just with less allocations.

Tested in RA for 2 ingame minutes on a 4 player map with 4 rush bots.
## Before

1218 MiB allocated in total

| Method | Allocated (MiB) |
| --- | --: |
| Actor.Render | 45 |
| FrozenUnderFog.Tick | 112 |
| FrozenActor.Tick | 112 |
| Widget.GetEventBounds | 31 |
| Animation.Render | 66 |
| MobileInfo.CanEnterCell | 2 |
| _HardwarePalette.ApplyModifiers_ | 86 |
| _PerfTimer overhead in DoTimed_ | 500 |

The latter two methods I didn't alter in this PR, but they're useful to include as a reference point.
## After

939 MiB allocated in total

| Method | Allocated (MiB) |
| --- | --: |
| Actor.Render | 0 |
| FrozenUnderFog.Tick | 0 |
| FrozenActor.Tick | 0 |
| Widget.GetEventBounds | 0 |
| Animation.Render | 31 |
| MobileInfo.CanEnterCell | 0 |
| _HardwarePalette.ApplyModifiers_ | 91 |
| _PerfTimer overhead in DoTimed_ | 474 |

Of the methods I targeted that's 368 MiB reduced to 31 MiB.
# CPU

As a pleasant side effect this also reduced the CPU time spent in some methods.

Tested in RA for 8 ingame minutes on a 4 player map with 4 rush bots.
## Before

| Method | Relative Time (%) |
| --- | --: |
| Actor.Render | 2.46 |
| FrozenUnderFog.Tick | 3.00 |
| FrozenActor.Tick | 2.24 |
| Widget.GetEventBounds | 0.82 |
| Animation.Render | 2.70 |
| MobileInfo.CanEnterCell | 1.11 |
| _HardwarePalette.ApplyModifiers_ | 5.23 |
| _PerfTimer overhead in DoTimed_ | 12.91 |
## After

| Method | Relative Time (%) |
| --- | --: |
| Actor.Render | 1.78 |
| FrozenUnderFog.Tick | 1.55 |
| FrozenActor.Tick | 0.51 |
| Widget.GetEventBounds | 0.09 |
| Animation.Render | 1.16 |
| MobileInfo.CanEnterCell | 0.77 |
| _HardwarePalette.ApplyModifiers_ | 4.43 |
| _PerfTimer overhead in DoTimed_ | 13.07 |

That's a reduction from 12.33% to 5.86%. There might also be some reduction in GC time since there's less garbage to collect - I have no numbers for that though.

As a quick aside, the PerfTimer change that resulted in its poor performance happened after I drafted up this set of changes hence why it's not in this PR. See #5408 for a change that should fix most of the allocation and some of the CPU time.
