### PR TITLE
Change terrain type from string based dictionaries to arrays

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -32,6 +32,8 @@ namespace OpenRA.Graphics
 			var bitmapData = terrain.LockBits(terrain.Bounds(),
 				ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
 
+			var mapTiles = map.MapTiles.Value;
+
 			unsafe
 			{
 				int* c = (int*)bitmapData.Scan0;
@@ -41,11 +43,9 @@ namespace OpenRA.Graphics
 					{
 						var mapX = x + map.Bounds.Left;
 						var mapY = y + map.Bounds.Top;
-						var type = tileset.GetTerrainType(map.MapTiles.Value[mapX, mapY]);
-						if (!tileset.Terrain.ContainsKey(type))
-							throw new InvalidDataException("Tileset {0} lacks terraintype {1}".F(tileset.Id, type));
+						var type = tileset.GetTerrainInfo(mapTiles[mapX, mapY]);
 
-						*(c + (y * bitmapData.Stride >> 2) + x) = tileset.Terrain[type].Color.ToArgb();
+						*(c + (y * bitmapData.Stride >> 2) + x) = type.Color.ToArgb();
 					}
 			}
 
@@ -80,7 +80,7 @@ namespace OpenRA.Graphics
 						if (res == null)
 							continue;
 
-						*(c + (y * bitmapData.Stride >> 2) + x) = tileset.Terrain[res].Color.ToArgb();
+						*(c + (y * bitmapData.Stride >> 2) + x) = tileset[tileset.GetTerrainIndex(res)].Color.ToArgb();
 					}
 			}
 
@@ -107,9 +107,9 @@ namespace OpenRA.Graphics
 						var mapX = x + map.Bounds.Left;
 						var mapY = y + map.Bounds.Top;
 						var custom = map.CustomTerrain[mapX, mapY];
-						if (custom == null)
+						if (custom == -1)
 							continue;
-						*(c + (y * bitmapData.Stride >> 2) + x) = world.TileSet.Terrain[custom].Color.ToArgb();
+						*(c + (y * bitmapData.Stride >> 2) + x) = world.TileSet[custom].Color.ToArgb();
 					}
 			}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -111,7 +111,7 @@ namespace OpenRA
 
 		[FieldLoader.Ignore] public Lazy<TileReference<ushort, byte>[,]> MapTiles;
 		[FieldLoader.Ignore] public Lazy<TileReference<byte, byte>[,]> MapResources;
-		[FieldLoader.Ignore] public string[,] CustomTerrain;
+		[FieldLoader.Ignore] public int[,] CustomTerrain;
 
 		[FieldLoader.Ignore] Lazy<Ruleset> rules;
 		public Ruleset Rules { get { return rules != null ? rules.Value : null; } }
@@ -228,7 +228,10 @@ namespace OpenRA
 			NotificationDefinitions = MiniYaml.NodesOrEmpty(yaml, "Notifications");
 			TranslationDefinitions = MiniYaml.NodesOrEmpty(yaml, "Translations");
 
-			CustomTerrain = new string[MapSize.X, MapSize.Y];
+			CustomTerrain = new int[MapSize.X, MapSize.Y];
+			for (var x = 0; x < MapSize.X; x++)
+				for (var y = 0; y < MapSize.Y; y++)
+					CustomTerrain[x, y] = -1;
 
 			MapTiles = Exts.Lazy(() => LoadMapTiles());
 			MapResources = Exts.Lazy(() => LoadResourceTiles());
@@ -529,7 +532,7 @@ namespace OpenRA
 					var template = tileset.Templates[tr.Type];
 					if (!template.PickAny)
 						continue;
-					tr.Index = (byte)r.Next(0, template.Tiles.Count);
+					tr.Index = (byte)r.Next(0, template.TilesCount);
 					MapTiles.Value[i, j] = tr;
 				}
 			}

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Traits
 
 		CellContents CreateResourceCell(ResourceType t, CPos p)
 		{
-			world.Map.CustomTerrain[p.X, p.Y] = t.Info.TerrainType;
+			world.Map.CustomTerrain[p.X, p.Y] = world.TileSet.GetTerrainIndex(t.Info.TerrainType);
 			return new CellContents
 			{
 				Type = t,
@@ -194,7 +194,7 @@ namespace OpenRA.Traits
 			if (--content[p.X, p.Y].Density < 0)
 			{
 				content[p.X, p.Y] = EmptyCell;
-				world.Map.CustomTerrain[p.X, p.Y] = null;
+				world.Map.CustomTerrain[p.X, p.Y] = -1;
 			}
 
 			if (!dirty.Contains(p))
@@ -211,7 +211,7 @@ namespace OpenRA.Traits
 
 			// Clear cell
 			content[p.X, p.Y] = EmptyCell;
-			world.Map.CustomTerrain[p.X, p.Y] = null;
+			world.Map.CustomTerrain[p.X, p.Y] = -1;
 
 			if (!dirty.Contains(p))
 				dirty.Add(p);

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -88,15 +88,15 @@ namespace OpenRA
 		public const int MaxRange = 50;
 		static List<CVec>[] TilesByDistance = InitTilesByDistance(MaxRange);
 
-		public static string GetTerrainType(this World world, CPos cell)
+		public static int GetTerrainIndex(this World world, CPos cell)
 		{
 			var custom = world.Map.CustomTerrain[cell.X, cell.Y];
-			return custom ?? world.TileSet.GetTerrainType(world.Map.MapTiles.Value[cell.X, cell.Y]);
+			return custom != -1 ? custom : world.TileSet.GetTerrainIndex(world.Map.MapTiles.Value[cell.X, cell.Y]);
 		}
 
 		public static TerrainTypeInfo GetTerrainInfo(this World world, CPos cell)
 		{
-			return world.TileSet.Terrain[world.GetTerrainType(cell)];
+			return world.TileSet[world.GetTerrainIndex(cell)];
 		}
 
 		public static CPos ClampToWorld(this World world, CPos xy)

--- a/OpenRA.Mods.D2k/DamagedWithoutFoundation.cs
+++ b/OpenRA.Mods.D2k/DamagedWithoutFoundation.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Cnc
 			foreach (var kv in self.OccupiesSpace.OccupiedCells())
 			{
 				totalTiles++;
-				if (info.SafeTerrain.Contains(self.World.GetTerrainType(kv.First)))
+				if (info.SafeTerrain.Contains(self.World.GetTerrainInfo(kv.First).Type))
 					safeTiles++;
 			}
 

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.RA.AI
 		BuildingInfo rallypointTestBuilding;
 		internal readonly HackyAIInfo Info;
 
-		string[] resourceTypes;
+		HashSet<int> resourceTypeIndices;
 
 		RushFuzzy rushFuzzy = new RushFuzzy();
 
@@ -152,8 +152,10 @@ namespace OpenRA.Mods.RA.AI
 
 			random = new MersenneTwister((int)p.PlayerActor.ActorID);
 
-			resourceTypes = Map.Rules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>()
-				.Select(t => t.TerrainType).ToArray();
+			resourceTypeIndices = new HashSet<int>(
+				Map.Rules.Actors["world"].Traits
+				.WithInterface<ResourceTypeInfo>()
+				.Select(t => world.TileSet.GetTerrainIndex(t.TerrainType)));
 		}
 
 		static int GetPowerProvidedBy(ActorInfo building)
@@ -364,7 +366,7 @@ namespace OpenRA.Mods.RA.AI
 
 				case BuildingType.Refinery:
 					var tilesPos = world.FindTilesInCircle(baseCenter, MaxBaseDistance)
-						.Where(a => resourceTypes.Contains(world.GetTerrainType(new CPos(a.X, a.Y))));
+						.Where(a => resourceTypeIndices.Contains(world.GetTerrainIndex(new CPos(a.X, a.Y))));
 					if (tilesPos.Any())
 					{
 						var pos = tilesPos.MinBy(a => (a.CenterPosition - baseCenter.CenterPosition).LengthSquared);

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.RA.Air
 			if (self.World.ActorMap.AnyUnitsAt(cell))
 				return false;
 
-			var type = self.World.GetTerrainType(cell);
+			var type = self.World.GetTerrainInfo(cell).Type;
 			return info.LandableTerrainTypes.Contains(type);
 		}
 

--- a/OpenRA.Mods.RA/Bridge.cs
+++ b/OpenRA.Mods.RA/Bridge.cs
@@ -94,11 +94,11 @@ namespace OpenRA.Mods.RA
 				self.World.Map.CustomTerrain[c.X, c.Y] = GetTerrainType(c);
 		}
 
-		string GetTerrainType(CPos cell)
+		int GetTerrainType(CPos cell)
 		{
 			var dx = cell - self.Location;
 			var index = dx.X + self.World.TileSet.Templates[template].Size.X * dx.Y;
-			return self.World.TileSet.GetTerrainType(new TileReference<ushort, byte>(template, (byte)index));
+			return self.World.TileSet.GetTerrainIndex(new TileReference<ushort, byte>(template, (byte)index));
 		}
 
 		public void LinkNeighbouringBridges(World world, BridgeLayer bridges)

--- a/OpenRA.Mods.RA/Buildings/Bib.cs
+++ b/OpenRA.Mods.RA/Buildings/Bib.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.RA.Buildings
 				var cellOffset = new CVec(i % width, i / width + bibOffset);
 
 				// Some mods may define terrain-specific bibs
-				var terrain = self.World.GetTerrainType(location + cellOffset);
+				var terrain = self.World.GetTerrainInfo(location + cellOffset).Type;
 				var testSequence = info.Sequence + "-" + terrain;
 				var sequence = anim.HasSequence(testSequence) ? testSequence : info.Sequence;
 				anim.PlayFetchIndex(sequence, () => index);

--- a/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
@@ -54,34 +54,34 @@ namespace OpenRA.Mods.RA.Buildings
 				foreach (var c in FootprintUtils.Tiles(self))
 				{
 					// Only place on allowed terrain types
-					if (!info.TerrainTypes.Contains(self.World.GetTerrainType(c)))
+					if (!info.TerrainTypes.Contains(self.World.GetTerrainInfo(c).Type))
 						continue;
 
 					// Don't place under other buildings or custom terrain
-					if (bi.GetBuildingAt(c) != self || self.World.Map.CustomTerrain[c.X, c.Y] != null)
+					if (bi.GetBuildingAt(c) != self || self.World.Map.CustomTerrain[c.X, c.Y] != -1)
 						continue;
 
-					var index = template.Tiles.Keys.Random(Game.CosmeticRandom);
-					layer.AddTile(c, new TileReference<ushort, byte>(template.Id, index));
+					var index = Game.CosmeticRandom.Next(template.TilesCount);
+					layer.AddTile(c, new TileReference<ushort, byte>(template.Id, (byte)index));
 				}
 
 				return;
 			}
 
 			var origin = self.Location + info.Offset;
-			foreach (var i in template.Tiles.Keys)
+			for (var i = 0; i < template.TilesCount; i++)
 			{
 				var c = origin + new CVec(i % template.Size.X, i / template.Size.X);
 
 				// Only place on allowed terrain types
-				if (!info.TerrainTypes.Contains(self.World.GetTerrainType(c)))
+				if (!info.TerrainTypes.Contains(self.World.GetTerrainInfo(c).Type))
 					continue;
 
 				// Don't place under other buildings or custom terrain
-				if (bi.GetBuildingAt(c) != self || self.World.Map.CustomTerrain[c.X, c.Y] != null)
+				if (bi.GetBuildingAt(c) != self || self.World.Map.CustomTerrain[c.X, c.Y] != -1)
 					continue;
 
-				layer.AddTile(c, new TileReference<ushort, byte>(template.Id, i));
+				layer.AddTile(c, new TileReference<ushort, byte>(template.Id, (byte)i));
 			}
 		}
 	}

--- a/OpenRA.Mods.RA/Buildings/Util.cs
+++ b/OpenRA.Mods.RA/Buildings/Util.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Buildings
 			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(a) != null) return false;
 			if (world.ActorMap.GetUnitsAt(a).Any(b => b != toIgnore)) return false;
 
-			return world.Map.IsInMap(a) && bi.TerrainTypes.Contains(world.GetTerrainType(a));
+			return world.Map.IsInMap(a) && bi.TerrainTypes.Contains(world.GetTerrainInfo(a).Type);
 		}
 
 		public static bool CanPlaceBuilding(this World world, string name, BuildingInfo building, CPos topLeft, Actor toIgnore)

--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.RA
 		{
 			if (!self.World.Map.IsInMap(cell.X, cell.Y)) return false;
 
-			var type = self.World.GetTerrainType(cell);
+			var type = self.World.GetTerrainInfo(cell).Type;
 			if (!info.TerrainTypes.Contains(type))
 				return false;
 

--- a/OpenRA.Mods.RA/CrateSpawner.cs
+++ b/OpenRA.Mods.RA/CrateSpawner.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.RA
 				var p = self.World.ChooseRandomCell(self.World.SharedRandom);
 
 				// Is this valid terrain?
-				var terrainType = self.World.GetTerrainType(p);
+				var terrainType = self.World.GetTerrainInfo(p).Type;
 				if (!(inWater ? info.ValidWater : info.ValidGround).Contains(terrainType))
 					continue;
 

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.RA.Effects
 				|| (info.RangeLimit != 0 && ticks > info.RangeLimit) // Ran out of fuel
 				|| (!info.High && world.ActorMap.GetUnitsAt(cell)
 					.Any(a => a.HasTrait<IBlocksBullets>())) // Hit a wall
-				|| (!string.IsNullOrEmpty(info.BoundToTerrainType) && world.GetTerrainType(cell) != info.BoundToTerrainType); // Hit incompatible terrain
+				|| (!string.IsNullOrEmpty(info.BoundToTerrainType) && world.GetTerrainInfo(cell).Type != info.BoundToTerrainType); // Hit incompatible terrain
 
 			if (shouldExplode)
 				Explode(world);

--- a/OpenRA.Mods.RA/Husk.cs
+++ b/OpenRA.Mods.RA/Husk.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA
 			if (!self.World.Map.IsInMap(cell.X, cell.Y))
 				return false;
 
-			if (!info.AllowedTerrain.Contains(self.World.GetTerrainType(cell)))
+			if (!info.AllowedTerrain.Contains(self.World.GetTerrainInfo(cell).Type))
 				return false;
 
 			if (!checkTransientActors)

--- a/OpenRA.Mods.RA/RadarColorFromTerrain.cs
+++ b/OpenRA.Mods.RA/RadarColorFromTerrain.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA
 
 		public RadarColorFromTerrain(Actor self, string terrain)
 		{
-			c = self.World.TileSet.Terrain[terrain].Color;
+			c = self.World.TileSet[self.World.TileSet.GetTerrainIndex(terrain)].Color;
 		}
 
 		public bool VisibleOnRadar(Actor self) { return true; }

--- a/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
+++ b/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA.Render
 				return false;
 
 			return cargo.CurrentAdjacentCells
-				.Any(c => self.World.Map.IsInMap(c) && info.OpenTerrainTypes.Contains(self.World.GetTerrainType(c)));
+				.Any(c => self.World.Map.IsInMap(c) && info.OpenTerrainTypes.Contains(self.World.GetTerrainInfo(c).Type));
 		}
 
 		void Open()

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -71,36 +71,18 @@ namespace OpenRA.Mods.RA
 			var range = ((ChronoshiftPowerInfo)Info).Range;
 			var sourceTiles = self.World.FindTilesInCircle(xy, range);
 			var destTiles = self.World.FindTilesInCircle(sourceLocation, range);
-			var sourceTerrain = new List<string>();
-			var destTerrain = new List<string>();
 
-			int j = 0;
-			foreach (var t in sourceTiles)
+			using (var se = sourceTiles.GetEnumerator())
+			using (var de = destTiles.GetEnumerator())
+			while (se.MoveNext() && de.MoveNext())
 			{
-				j = j + 1;
-				if (!self.Owner.Shroud.IsExplored(t))
-					return false;
-				sourceTerrain.Add(self.World.GetTerrainType(t));
-			}
+				var a = se.Current;
+				var b = de.Current;
 
-			j = 0;
-			foreach (var t in destTiles)
-			{
-				j = j + 1;
-				if (!self.Owner.Shroud.IsExplored(t))
+				if (!self.Owner.Shroud.IsExplored(a) || !self.Owner.Shroud.IsExplored(b))
 					return false;
 
-				self.World.GetTerrainType(t);
-				destTerrain.Add(self.World.GetTerrainType(t));
-			}
-
-			// HACK but I don't want to write a comparison function
-			if (sourceTerrain.Count != destTerrain.Count)
-				return false;
-
-			for (int i = 0; i < sourceTerrain.Count; i++)
-			{
-				if (!sourceTerrain[i].Equals(destTerrain[i]))
+				if (self.World.GetTerrainIndex(a) != self.World.GetTerrainIndex(b))
 					return false;
 			}
 

--- a/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA
 
 		public void AddTile(CPos cell, TileReference<ushort, byte> tile)
 		{
-			map.CustomTerrain[cell.X, cell.Y] = tileset.GetTerrainType(tile);
+			map.CustomTerrain[cell.X, cell.Y] = tileset.GetTerrainIndex(tile);
 
 			// Terrain tiles define their origin at the topleft
 			var s = theater.TileSprite(tile);

--- a/OpenRA.Mods.RA/World/DomainIndex.cs
+++ b/OpenRA.Mods.RA/World/DomainIndex.cs
@@ -59,24 +59,12 @@ namespace OpenRA.Mods.RA
 		int[,] domains;
 		Dictionary<int, HashSet<int>> transientConnections;
 
-		// Each terrain has an offset corresponding to its location in a
-		// movement class bitmask.  This caches each offset.
-		Dictionary<string, int> terrainOffsets;
-
 		public MovementClassDomainIndex(World world, uint movementClass)
 		{
 			bounds = world.Map.Bounds;
 			this.movementClass = movementClass;
 			domains = new int[(bounds.Width + bounds.X), (bounds.Height + bounds.Y)];
 			transientConnections = new Dictionary<int, HashSet<int>>();
-
-			terrainOffsets = new Dictionary<string, int>();
-			var terrains = world.TileSet.Terrain.OrderBy(t => t.Key).ToList();
-			foreach (var terrain in terrains)
-			{
-				var terrainOffset = terrains.FindIndex(x => x.Key == terrain.Key);
-				terrainOffsets[terrain.Key] = terrainOffset;
-			}
 
 			BuildDomains(world);
 		}
@@ -181,8 +169,7 @@ namespace OpenRA.Mods.RA
 
 		bool CanTraverseTile(World world, CPos p)
 		{
-			var currentTileType = WorldUtils.GetTerrainType(world, p);
-			var terrainOffset = terrainOffsets[currentTileType];
+			var terrainOffset = world.GetTerrainIndex(p);
 			return (movementClass & (1 << terrainOffset)) > 0;
 		}
 

--- a/OpenRA.TilesetBuilder/FormBuilder.cs
+++ b/OpenRA.TilesetBuilder/FormBuilder.cs
@@ -367,7 +367,8 @@ namespace OpenRA.TilesetBuilder
 				name: tilesetName,
 				id: tilesetID.ToUpper(),
 				palette: tilesetPalette.ToLower(),
-				extensions: new string[] { ext[0], ext[1] }
+				extensions: new string[] { ext[0], ext[1] },
+				terrainInfo: TerrainType
 			);
 
 			// List of files to add to the mix file
@@ -381,29 +382,24 @@ namespace OpenRA.TilesetBuilder
 			foreach (var t in surface1.Templates)
 				fileList.Add(ExportTemplate(t, surface1.Templates.IndexOf(t), tileset.Extensions.First(), dir));
 
-			// Add the terraintypes
-			foreach (var tt in TerrainType)
-			{
-				tileset.Terrain.Add(tt.Type, tt);
-			}
-
 			// Add the templates
 			ushort cur = 0;
 			foreach (var tp in surface1.Templates)
 			{
+				var tiles = new int[tp.Width * tp.Height];
+				foreach (var t in tp.Cells)
+				{
+					string ttype = TerrainType[surface1.TerrainTypes[t.Key.X, t.Key.Y]].Type;
+					var idx = (t.Key.X - tp.Left) + tp.Width * (t.Key.Y - tp.Top);
+					tiles[idx] = tileset.GetTerrainIndex(ttype);
+				}
+
 				var template = new TileTemplate(
 					id: cur,
 					image: "{0}{1:00}".F(txtTilesetName.Text, cur),
-					size: new int2(tp.Width, tp.Height)
+					size: new int2(tp.Width, tp.Height),
+					tiles: tiles
 				);
-
-				foreach (var t in tp.Cells)
-				{
-					string ttype = "Clear";
-					ttype = TerrainType[surface1.TerrainTypes[t.Key.X, t.Key.Y]].Type;
-					var idx = (t.Key.X - tp.Left) + tp.Width * (t.Key.Y - tp.Top);
-					template.Tiles.Add((byte)idx, ttype);
-				}
 
 				tileset.Templates.Add(cur, template);
 				cur++;


### PR DESCRIPTION
This replaces the string based dictionary lookups with arrays that are accessed by index. It partially follows the suggestions in #4596. The main difference being that it doesn't create bit fields, mainly because we want more info per terrain type than a boolean pass/can't pass (we store movement cost and speed).

It's difficult to test exactly how this performs but I see a 10+% speedup in movement/pathfinding related activities, on average.

I've tested several replays recorded on the current bleed with this and they don't desync, crash, or anything else strange so it seems this doesn't break anything obvious.

~~It requires #5447 or it will complain about invalid terrain templates and abort.~~ (edit: merged)

Please test & discuss. I plan to look for more cases that can be optimized and build on this PR so I'd like to know if the changes here are in the right direction.
