### PR TITLE
Adds RallyPoint to Airfield

### DIFF
--- a/OpenRA.Mods.RA/Activities/Rearm.cs
+++ b/OpenRA.Mods.RA/Activities/Rearm.cs
@@ -39,21 +39,7 @@ namespace OpenRA.Mods.RA.Activities
 					.FirstOrDefault(a => a.HasTrait<RenderBuilding>());
 
 				if (!limitedAmmo.GiveAmmo())
-				{
-					var helicopter = self.TraitOrDefault<Helicopter>();
-					if (helicopter != null)
-					{
-						if (helicopter.Info.RepairBuildings.Contains(hostBuilding.Info.Name) && self.HasTrait<Health>())
-						{
-							if (self.Trait<Health>().DamageState != DamageState.Undamaged)
-								return NextActivity;
-						}
-
-						return helicopter.TakeOff(hostBuilding);
-					}
-
 					return NextActivity;
-				}
 
 				if (hostBuilding != null)
 					hostBuilding.Trait<RenderBuilding>().PlayCustomAnim(hostBuilding, "active");

--- a/OpenRA.Mods.RA/Activities/Repair.cs
+++ b/OpenRA.Mods.RA/Activities/Repair.cs
@@ -31,22 +31,9 @@ namespace OpenRA.Mods.RA.Activities
 
 			health = self.TraitOrDefault<Health>();
 			if (health == null) return NextActivity;
+
 			if (health.DamageState == DamageState.Undamaged)
-			{
-				var helicopter = self.TraitOrDefault<Helicopter>();
-				if (helicopter != null)
-				{
-					if (helicopter.Info.RearmBuildings.Contains(host.Info.Name) && self.HasTrait<LimitedAmmo>())
-					{
-						if (self.Trait<LimitedAmmo>().FullAmmo() == false)
-							return NextActivity;
-					}
-
-					return helicopter.TakeOff(host);
-				}
-
 				return NextActivity;
-			}
 
 			if (remainingTicks == 0)
 			{

--- a/OpenRA.Mods.RA/Air/Helicopter.cs
+++ b/OpenRA.Mods.RA/Air/Helicopter.cs
@@ -87,6 +87,7 @@ namespace OpenRA.Mods.RA.Air
 					self.QueueActivity(new Turn(Info.InitialFacing));
 					self.QueueActivity(new HeliLand(false));
 					self.QueueActivity(new ResupplyAircraft());
+					self.QueueActivity(new TakeOff());
 				}
 			}
 
@@ -116,11 +117,11 @@ namespace OpenRA.Mods.RA.Air
 				if (!self.HasTrait<FallsToEarth>()) // TODO: Aircraft husks don't properly unreserve.
 					ReserveSpawnBuilding();
 
-				var afld = GetActorBelow();
-				if (afld == null)
+				var host = GetActorBelow();
+				if (host == null)
 					return;
 
-				self.QueueActivity(TakeOff(afld));
+				self.QueueActivity(new TakeOff());
 			}
 
 			// Repulsion only applies when we're flying!
@@ -182,26 +183,6 @@ namespace OpenRA.Mods.RA.Air
 		{
 			foreach (var b in base.GetResupplyActivities(a))
 				yield return b;
-		}
-
-		public Activity TakeOff(Actor a)
-		{
-			self.CancelActivity();
-			if (Reservation != null)
-			{
-				Reservation.Dispose();
-				Reservation = null;
-			}
-
-			if (a != null)
-			{
-				if (a.HasTrait<RallyPoint>())
-					return new HeliFly(self, Target.FromCell(a.Trait<RallyPoint>().rallyPoint));
-
-				return new HeliFly(self, Target.FromPos(a.CenterPosition));
-			}
-
-			return new HeliFly(self, Target.FromPos(self.CenterPosition));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Air/Plane.cs
+++ b/OpenRA.Mods.RA/Air/Plane.cs
@@ -43,6 +43,12 @@ namespace OpenRA.Mods.RA.Air
 				firstTick = false;
 				if (!self.HasTrait<FallsToEarth>()) // TODO: Aircraft husks don't properly unreserve.
 					ReserveSpawnBuilding();
+
+				var host = GetActorBelow();
+				if (host == null)
+					return;
+
+				self.QueueActivity(new TakeOff());
 			}
 		}
 
@@ -86,6 +92,7 @@ namespace OpenRA.Mods.RA.Air
 				self.SetTargetLine(Target.FromActor(airfield), Color.Green);
 				self.QueueActivity(new ReturnToBase(self, airfield));
 				self.QueueActivity(new ResupplyAircraft());
+				self.QueueActivity(new TakeOff());
 			}
 			else
 			{

--- a/OpenRA.Mods.RA/Air/TakeOff.cs
+++ b/OpenRA.Mods.RA/Air/TakeOff.cs
@@ -1,0 +1,40 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA.Air
+{
+	public class TakeOff : Activity
+	{
+		public override Activity Tick(Actor self)
+		{
+			var aircraft = self.Trait<Aircraft>();
+
+			self.CancelActivity();
+
+			var reservation = aircraft.Reservation;
+			if (reservation != null)
+			{
+				reservation.Dispose();
+				reservation = null;
+			}
+
+			var host = aircraft.GetActorBelow();
+			var hasHost = host != null;
+			var rp = hasHost ? host.TraitOrDefault<RallyPoint>() : null;
+
+			var destination = rp != null ? rp.rallyPoint :
+				(hasHost ? host.CenterPosition.ToCPos() : self.CenterPosition.ToCPos());
+
+			return new AttackMove.AttackMoveActivity(self, self.Trait<IMove>().MoveTo(destination, 1));
+		}
+	}
+}

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -94,6 +94,7 @@
   <ItemGroup>
     <Compile Include="Activities\CaptureActor.cs" />
     <Compile Include="Activities\Hunt.cs" />
+    <Compile Include="Air\TakeOff.cs" />
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />
     <Compile Include="AI\BaseBuilder.cs" />
     <Compile Include="AI\HackyAI.cs" />

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.RA
 					}
 				}
 
-				newUnit.SetTargetLine(target, Color.Green, false);
+				newUnit.SetTargetLine(target, rp.Value != null ? Color.Red : Color.Green, false);
 
 				if (!self.IsDead())
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -968,6 +968,7 @@ AFLD:
 		ExitCell: 1,1
 		Facing: 192
 		MoveIntoWorld: false
+	RallyPoint:
 	Production:
 		Produces: Plane
 	Reservable:


### PR DESCRIPTION
I see no reason why the Airfield should not have a RP. Perhaps it was just forgotten to update the yaml.
Definitely makes sense to have it.

Only one of many examples where this is useful: U got only one airfield and want to build several yaks. With the RP, you dont have to send each yak somewhere else on its own, just that another one can be build - the airfield is not blocked anymore.

Regards.
