### PR TITLE
Modular + UpgradeModule

### DIFF
--- a/OpenRA.Mods.RA/Activities/Sell.cs
+++ b/OpenRA.Mods.RA/Activities/Sell.cs
@@ -8,23 +8,60 @@
  */
 #endregion
 
+using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Traits;
 using OpenRA.Mods.RA.Effects;
 using OpenRA.Mods.RA.Buildings;
+using OpenRA.Mods.RA.Render;
 
 namespace OpenRA.Mods.RA.Activities
 {
 	class Sell : Activity
 	{
+		public bool PlayAnim;
+
+		public Sell() { PlayAnim = true; }
+		public Sell(bool playAnim) { PlayAnim = playAnim; }
+
 		public override Activity Tick(Actor self)
 		{
+			if (PlayAnim)
+			{
+				var rb = self.TraitOrDefault<RenderBuilding>();
+				if (rb != null && self.Info.Traits.Get<RenderBuildingInfo>().HasMakeAnimation)
+					self.QueueActivity(new MakeAnimation(self, true, () => rb.PlayCustomAnim(self, "make")));
+			}
+
 			var h = self.TraitOrDefault<Health>();
 			var si = self.Info.Traits.Get<SellableInfo>();
 			var pr = self.Owner.PlayerActor.Trait<PlayerResources>();
-
 			var cost = self.GetSellValue();
 
 			var refund = (cost * si.RefundPercent * (h == null ? 1 : h.HP)) / (100 * (h == null ? 1 : h.MaxHP));
+
+			var mods = self.TraitsImplementing<Modular>().Where(p => p.IsUpgraded);
+			foreach (var mod in mods)
+			{
+				var umi = mod.UpgradeActor.Info.Traits.Get<UpgradeModuleInfo>();
+				if (umi.DestroyOrSell == DestroyOrSell.Sell)
+				{
+					var umh = mod.UpgradeActor.TraitOrDefault<Health>();
+					var umsi = mod.UpgradeActor.Info.Traits.GetOrDefault<SellableInfo>();
+					var umc = mod.UpgradeActor.GetSellValue();
+
+					var cashBack = umsi == null ? 50 : umsi.RefundPercent;
+					var hasHealth = umh != null;
+
+					refund += (umc * cashBack * (hasHealth ? 1 : umh.MaxHP)) / (100 * (hasHealth ? 1 : h.MaxHP));
+
+					foreach (var ns in mod.UpgradeActor.TraitsImplementing<INotifySold>())
+						ns.Sold(mod.UpgradeActor);
+				}
+
+				mod.UpgradeActor.Destroy();
+			}
+
 			pr.GiveCash(refund);
 
 			foreach (var ns in self.TraitsImplementing<INotifySold>())

--- a/OpenRA.Mods.RA/Buildings/Modular.cs
+++ b/OpenRA.Mods.RA/Buildings/Modular.cs
@@ -1,0 +1,54 @@
+#region Copyright & License Information
+/*
+  * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+  * This file is part of OpenRA, which is free software. It is made
+  * available to you under the terms of the GNU General Public License
+  * as published by the Free Software Foundation. For more information,
+  * see COPYING.
+  */
+#endregion
+
+using System;
+using OpenRA.Traits;
+using OpenRA.FileFormats;
+
+namespace OpenRA.Mods.RA.Buildings
+{
+	public class ModularInfo : ITraitInfo
+	{
+		public readonly CVec CellOffset = CVec.Zero;
+		public readonly string[] Types = { };
+
+		public object Create(ActorInitializer init) { return new Modular(this); }
+	}
+
+	public class Modular : INotifySold, INotifyKilled, INotifyCapture
+	{
+		[Sync] public Actor UpgradeActor;
+		public ModularInfo Info;
+		public bool IsUpgraded { get { return UpgradeActor != null; } }
+
+		public Modular(ModularInfo info) { Info = info; }
+
+		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		{
+			if (!IsUpgraded)
+				return;
+
+			UpgradeActor.ChangeOwner(newOwner);
+		}
+
+		public void Selling(Actor self) { }
+		public void Sold(Actor self) { RemoveModule(); }
+		public void Killed(Actor self, AttackInfo e) { RemoveModule(); }
+
+		void RemoveModule()
+		{
+			if (!IsUpgraded)
+				return;
+
+			UpgradeActor.Destroy();
+			UpgradeActor = null;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Buildings/RequiresPower.cs
+++ b/OpenRA.Mods.RA/Buildings/RequiresPower.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA.Buildings
 	{
 		PowerManager power;
 
-		public RequiresPower( Actor self )
+		public RequiresPower(Actor self)
 		{
 			power = self.Owner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.RA/Buildings/UpgradeModule.cs
+++ b/OpenRA.Mods.RA/Buildings/UpgradeModule.cs
@@ -1,0 +1,30 @@
+#region Copyright & License Information
+/*
+  * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+  * This file is part of OpenRA, which is free software. It is made
+  * available to you under the terms of the GNU General Public License
+  * as published by the Free Software Foundation. For more information,
+  * see COPYING.
+  */
+#endregion
+
+using System;
+using OpenRA.Traits;
+using OpenRA.FileFormats;
+
+namespace OpenRA.Mods.RA.Buildings
+{
+	public class UpgradeModuleInfo : TraitInfo<UpgradeModule>
+	{
+		public readonly string Type = null;
+		public readonly DestroyOrSell DestroyOrSell = DestroyOrSell.Destroy;
+	}
+
+	public class UpgradeModule { }
+
+	public enum DestroyOrSell
+	{
+		Destroy = 1,
+		Sell = 2,
+	}
+}

--- a/OpenRA.Mods.RA/Buildings/Util.cs
+++ b/OpenRA.Mods.RA/Buildings/Util.cs
@@ -29,6 +29,29 @@ namespace OpenRA.Mods.RA.Buildings
 			return world.Map.IsInMap(a) && bi.TerrainTypes.Contains(world.GetTerrainType(a));
 		}
 
+		public static bool CanPlaceModule(this World world, Actor existing, ActorInfo toPlaceInfo, CPos placeLocation)
+		{
+			if (existing == null)
+				return false;
+
+			var existingMods = existing.TraitsImplementing<Modular>();
+			if (!existingMods.Any())
+				return false;
+
+			var toPlaceMod = toPlaceInfo.Traits.GetOrDefault<UpgradeModuleInfo>();
+			if (toPlaceMod == null)
+				return false;
+
+			var topleft = existing.Location;
+			var existingMIs = existing.Info.Traits.WithInterface<ModularInfo>();
+			var freeSpace = existingMods.Where(p => !p.IsUpgraded);
+
+			if (!freeSpace.Any(fs => placeLocation == topleft + fs.Info.CellOffset))
+				return false;
+
+			return existingMIs.Any(api => placeLocation == topleft + api.CellOffset && api.Types.Contains(toPlaceMod.Type));
+		}
+
 		public static bool CanPlaceBuilding(this World world, string name, BuildingInfo building, CPos topLeft, Actor toIgnore)
 		{
 			if (building.AllowInvalidPlacement)

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -528,6 +528,9 @@
     <Compile Include="Console\PlayerCommands.cs" />
     <Compile Include="Render\WithRepairAnimation.cs" />
     <Compile Include="Render\WithRepairOverlay.cs" />
+    <Compile Include="Buildings\UpgradeModule.cs" />
+    <Compile Include="Buildings\Modular.cs" />
+    <Compile Include="Orders\PlaceModuleOrderGenerator.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.RA/Orders/PlaceModuleOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceModuleOrderGenerator.cs
@@ -1,0 +1,79 @@
+﻿#region Copyright & License Information
+ /*
+  * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+  * This file is part of OpenRA, which is free software. It is made
+  * available to you under the terms of the GNU General Public License
+  * as published by the Free Software Foundation. For more information,
+  * see COPYING.
+  */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.RA.Buildings;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.RA
+{
+	public class PlaceModuleOrderGenerator : IOrderGenerator
+	{
+		readonly Actor producer;
+		readonly string buildingName;
+		readonly BuildingInfo bi;
+		Sprite buildOk, buildBlocked;
+
+		public PlaceModuleOrderGenerator(Actor producer, string name)
+		{
+			this.producer = producer;
+			buildingName = name;
+			var tileset = producer.World.TileSet.Id.ToLower();
+			bi = producer.World.Map.Rules.Actors[buildingName].Traits.Get<BuildingInfo>();
+			buildOk = producer.World.Map.SequenceProvider.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
+			buildBlocked = producer.World.Map.SequenceProvider.GetSequence("overlay", "build-invalid").GetSprite(0);
+		}
+
+		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Right)
+				world.CancelInputMode();
+
+			if (mi.Button == MouseButton.Left)
+			{
+				if (world.CanPlaceModule(world.ActorMap.GetUnitsAt(xy).FirstOrDefault(), world.Map.Rules.Actors[buildingName], xy))
+				{
+					yield return new Order("PlaceModule", producer, false) { TargetLocation = xy, TargetString = buildingName };
+					world.CancelInputMode();
+				}
+				else
+				{
+					Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Country.Race);
+					yield break;
+				}
+			}
+		}
+
+		public void RenderAfterWorld(WorldRenderer wr, World world)
+		{
+			var cells = new Dictionary<CPos, bool>();
+			var position = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
+			var topLeft = position - FootprintUtils.AdjustForBuildingSize(bi);
+			var toPlaceInfo = world.Map.Rules.Actors[buildingName.ToLowerInvariant()];
+
+			foreach (var t in FootprintUtils.Tiles(world.Map.Rules, buildingName, bi, topLeft))
+				cells.Add(t, world.CanPlaceModule(world.ActorMap.GetUnitsAt(topLeft).FirstOrDefault(), toPlaceInfo, topLeft));
+
+			var pal = wr.Palette("terrain");
+			foreach (var c in cells)
+			{
+				var tile = c.Value ? buildOk : buildBlocked;
+				new SpriteRenderable(tile, c.Key.CenterPosition,
+					WVec.Zero, -511, pal, 1f, true).Render(wr);
+			}
+		}
+
+		public void Tick(World world) {	}
+		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) {	yield break; }
+		public string GetCursor(World world, CPos xy, MouseInput mi) { return "default"; }
+	}
+}

--- a/OpenRA.Mods.RA/Orders/PowerDownOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PowerDownOrderGenerator.cs
@@ -31,10 +31,10 @@ namespace OpenRA.Mods.RA.Orders
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
 
-			return OrderInner(world, mi);
+			return OrderInner(world, xy, mi);
 		}
 
-		IEnumerable<Order> OrderInner(World world, MouseInput mi)
+		IEnumerable<Order> OrderInner(World world, CPos xy, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Left)
 			{
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.RA.Orders
 		public string GetCursor(World world, CPos xy, MouseInput mi)
 		{
 			mi.Button = MouseButton.Left;
-			return cursor + (OrderInner(world, mi).Any()	? "" : "-blocked");
+			return cursor + (OrderInner(world, xy, mi).Any() ? "" : "-blocked");
 		}
 	}
 

--- a/OpenRA.Mods.RA/Sellable.cs
+++ b/OpenRA.Mods.RA/Sellable.cs
@@ -39,10 +39,6 @@ namespace OpenRA.Mods.RA
 				ns.Selling(self);
 
 			self.CancelActivity();
-
-			var rb = self.TraitOrDefault<RenderBuilding>();
-			if (rb != null && self.Info.Traits.Get<RenderBuildingInfo>().HasMakeAnimation)
-				self.QueueActivity(new MakeAnimation(self, true, () => rb.PlayCustomAnim(self, "make")));
 			self.QueueActivity(new Sell());
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -358,7 +358,9 @@ namespace OpenRA.Mods.RA.Widgets
 				{
 					if (producing.Done)
 					{
-						if (unit.Traits.Contains<BuildingInfo>())
+						if (unit.Traits.Contains<UpgradeModuleInfo>())
+							world.OrderGenerator = new PlaceModuleOrderGenerator(CurrentQueue.self, item);
+						else if (unit.Traits.Contains<BuildingInfo>())
 							world.OrderGenerator = new PlaceBuildingOrderGenerator(CurrentQueue.self, item);
 						else
 							StartProduction(world, item);

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -1,3 +1,20 @@
+^UpgradeModule:
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+		BuildSounds: place2.aud
+		TerrainTypes: Clear, Road
+	RenderBuilding:
+	EditorAppearance:
+		RelativeToTopLeft: yes
+	Sellable:
+	BodyOrientation:
+	ScriptTriggers:
+	LuaScriptEvents:
+	Module:
+		Type: generic
+		DestroyOrSell: Destroy	
+
 ^Building:
 	AppearsOnRadar:
 	SelectionDecorations:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -70,6 +70,37 @@ GAPOWR:
 		Sequence: idle-lights
 	WithIdleOverlay@PLUG:
 		Sequence: idle-plug
+	Modular@1:
+		Types: powrturb
+		CellOffset: 1,1
+	Modular@2:
+		Types: powrturb
+		CellOffset: 0,1
+
+GAPOWRUP:
+	Inherits: ^UpgradeModule
+	Buildable:
+		Queue: Building
+		BuildPaletteOrder: 10
+		Prerequisites: gapowr
+		Owner: gdi
+		Hotkey: t
+	Valued:
+		Cost: 100
+	Tooltip:
+		Name: Power Turbine
+		Description: Increases power output
+	Building:
+		Power: 50
+	Health:
+		HP: 100
+	Armor:
+		Type: Wood
+	UpgradeModule:
+		Type: powrturb
+		DestroyOrSell: Sell
+	RenderBuilding:
+		Image: gapowr_b
 
 GAPILE:
 	Inherits: ^Building

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -93,6 +93,22 @@ gapowr:
 	icon: powricon
 		Start: 0
 
+gapowr_b:
+	icon: turbicon
+		Start: 0
+	idle: gapowr_b
+		Start: 0
+		Length: 12
+		Tick: 200
+		ShadowStart: 12
+	damaged-idle: gapowr_b
+		Start: 0
+		ShadowStart: 12
+	make: gtpowr_b
+		Start: 0
+		Length: 1
+		ShadowStart: 12
+
 gapile:
 	idle: gtpile
 		Start: 0


### PR DESCRIPTION
Added TS’s GDI Power Turbine.
Currently this doesn't support selling (or selecting, etc.) plugs independently.

Possibly fixes #3211 (in one of two ways).

I should note there is an example ingame with TS but it does not work due to cell layout, I assume.
If you test this in RA/TD/D2k you will see that it works as expected.

This responds oddly with plugs that are not 1x1 due to our numerous topleft assumptions (which is not too surprising).
