### PR TITLE
Makes newest production-building the primary building

### DIFF
--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -39,6 +39,8 @@ namespace OpenRA.Mods.RA.Orders
 
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
+			PlaceBuildingInfo.shiftWasPressed = Game.GetModifierKeys().HasModifier(Modifiers.Shift);
+
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
 


### PR DESCRIPTION
This is something that has troubled me a lot:

If you have a production-building and then build a new one of this type, the units will come out of the newest.
But if you made one of these a primary building in the past and then build a new building of this type, the units will still come out of the primary building - and not out of the newest.

It is better to always have the newest building be the primary building as soon as you place it.
I will explain why and i hope you guys agree - especially the players with a lot of experience.

Both ways have a problem.

The way it was until now has the problem: The behavior of having units always come of the newest building changes as soon as you made one of those a primary building earlier.
In this case, you have the trouble of having to make the newest building the primary building first, if you want units to come out of this one.

My way has the problem: The behavior of units always come out of the explicitly made primary building changes when you build a new building of this type.
In this case, you have the trouble of having to make your desired building the primary building again, if you for whatever reason do not want em to come of the new production building that you just built.

If you read the last line, you can already see that it is better the way i propose, as in 99% of the cases you want the units to come out of the newest building (but you can still make another building primary at any time) - this is the main reason you build a second building in the first place!
Plus, in the heat of battle - expecially in situations like chronoshifting your mcv and quickly place barracs/war fact behind the enemy's lines, or quickly dropping a barracks and spilling out E3s to defend against incoming mammoths you just saw - when every second counts, you dont want to have to select and right click a building first - or even think about it: "Gnah, now i forgot to make it primary, so the units came out in the other building at the other side of the map! :(".

So, both ways have problems, but i think the way i propose works better in practise!
