### PR TITLE
Try to avoid a System.Collections.Generic.KeyNotFoundException

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -67,6 +67,9 @@ namespace OpenRA
 
 		public void QueryRemoteMapDetails(IEnumerable<string> uids)
 		{
+			if (!uids.Any())
+				return;
+
 			var maps = uids.Distinct()
 				.Select(uid => previews[uid])
 				.Where(p => p.Status == MapStatus.Unavailable)


### PR DESCRIPTION
When executing Game.modData.MapCache.QueryRemoteMapDetails from ServerBrowserLogic.
