### PR TITLE
Fixed KeyNotFoundException in ServerBrowser

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -93,10 +93,16 @@ namespace OpenRA
 				}
 
 				var data = Encoding.UTF8.GetString(i.Result);
-				var yaml = MiniYaml.FromString(data);
-
-				foreach (var kv in yaml)
-					maps[kv.Key].UpdateRemoteSearch(MapStatus.DownloadAvailable, kv.Value);
+				try
+				{
+					var yaml = MiniYaml.FromString(data);
+					foreach (var kv in yaml)
+						maps[kv.Key].UpdateRemoteSearch(MapStatus.DownloadAvailable, kv.Value);
+				}
+				catch
+				{
+					Log.Write("debug", "Can't parse remote map search data:\n{0}", data);
+				}
 			};
 
 			new Download(url, _ => { }, onInfoComplete);


### PR DESCRIPTION
As described in #5492. Happens when resource site is sending invalid data such as an error page. Therefore, dump the received data into debug.log for investigation.
