### PR TITLE
Map preview generation

### DIFF
--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -79,9 +79,9 @@ namespace OpenRA.Graphics
 					dirty = true;
 				}
 
-				if (dirty)
+				lock (dirtyLock)
 				{
-					lock (dirtyLock)
+					if (dirty)
 					{
 						texture.SetData(data, Size.Width, Size.Height);
 						dirty = false;

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Graphics
 		ITexture texture;
 		bool dirty;
 		byte[] data;
+		readonly object dirtyLock = new object();
 
 		public readonly Size Size;
 		public byte[] Data { get { return data ?? texture.GetData(); } }
@@ -68,6 +69,8 @@ namespace OpenRA.Graphics
 
 		public ITexture Texture
 		{
+			// This is only called from the main thread but 'dirty'
+			// is set from other threads too via CommitData().
 			get
 			{
 				if (texture == null)
@@ -78,8 +81,11 @@ namespace OpenRA.Graphics
 
 				if (dirty)
 				{
-					texture.SetData(data, Size.Width, Size.Height);
-					dirty = false;
+					lock (dirtyLock)
+					{
+						texture.SetData(data, Size.Width, Size.Height);
+						dirty = false;
+					}
 				}
 
 				return texture;
@@ -140,7 +146,10 @@ namespace OpenRA.Graphics
 			if (data == null)
 				throw new InvalidOperationException("Texture-wrappers are read-only");
 
-			dirty = true;
+			lock (dirtyLock)
+			{
+				dirty = true;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes a thread synchronization problem with the sheetbuilder and the map preview generation. It was not apparent previously because of the 50ms delay. This also improves the speed of the preview generation.

See also: #5503 for an alternative.
