### PR TITLE
Fixes to StreamExts.

### DIFF
--- a/OpenRA.Game/FileFormats/ShpReader.cs
+++ b/OpenRA.Game/FileFormats/ShpReader.cs
@@ -105,10 +105,7 @@ namespace OpenRA.FileFormats
 
 			// Actually, far too big. There's no length field with the correct length though :(
 			var compressedLength = (int)(stream.Length - stream.Position);
-			var compressedBytes = new byte[compressedLength];
-			stream.Read(compressedBytes, 0, compressedLength);
-
-			return compressedBytes;
+			return stream.ReadBytes(compressedLength);
 		}
 
 		void Decompress(Stream stream, ImageHeader h)

--- a/OpenRA.Game/FileFormats/ShpTSReader.cs
+++ b/OpenRA.Game/FileFormats/ShpTSReader.cs
@@ -81,7 +81,8 @@ namespace OpenRA.FileFormats
 					for (var j = 0; j < f.Size.Height; j++)
 					{
 						var length = stream.ReadUInt16() - 2;
-						stream.Read(f.Data, f.Size.Width * j, length);
+						var offset = f.Size.Width * j;
+						stream.ReadBytes(f.Data, offset, length);
 					}
 				}
 

--- a/OpenRA.Game/FileSystem/D2kSoundResources.cs
+++ b/OpenRA.Game/FileSystem/D2kSoundResources.cs
@@ -56,10 +56,7 @@ namespace OpenRA.FileSystem
 				return null;
 
 			s.Seek(e.Offset, SeekOrigin.Begin);
-			var data = new byte[e.Length];
-			s.Read(data, 0, (int)e.Length);
-
-			return new MemoryStream(data);
+			return new MemoryStream(s.ReadBytes((int)e.Length));
 		}
 
 		public Stream GetContent(string filename)

--- a/OpenRA.Game/FileSystem/GlobalFileSystem.cs
+++ b/OpenRA.Game/FileSystem/GlobalFileSystem.cs
@@ -230,8 +230,7 @@ namespace OpenRA.FileSystem
 			if (Exists(filename))
 				using (var s = Open(filename))
 				{
-					var buf = new byte[s.Length];
-					s.Read(buf, 0, buf.Length);
+					var buf = s.ReadBytes((int)s.Length);
 					a = Assembly.Load(buf);
 					assemblyCache.Add(filename, a);
 					return a;

--- a/OpenRA.Game/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldPackage.cs
@@ -103,8 +103,7 @@ namespace OpenRA.FileSystem
 				return null;
 
 			s.Seek(dataStart + e.Offset, SeekOrigin.Begin);
-			var data = new byte[e.Length];
-			s.Read(data, 0, (int)e.Length);
+			var data = s.ReadBytes((int)e.Length);
 
 			return new MemoryStream(Blast.Decompress(data));
 		}

--- a/OpenRA.Game/FileSystem/MixFile.cs
+++ b/OpenRA.Game/FileSystem/MixFile.cs
@@ -157,8 +157,7 @@ namespace OpenRA.FileSystem
 				return null;
 
 			s.Seek(dataStart + e.Offset, SeekOrigin.Begin);
-			var data = new byte[e.Length];
-			s.Read(data, 0, (int)e.Length);
+			var data = s.ReadBytes((int)e.Length);
 			return new MemoryStream(data);
 		}
 

--- a/OpenRA.Game/FileSystem/Pak.cs
+++ b/OpenRA.Game/FileSystem/Pak.cs
@@ -59,8 +59,7 @@ namespace OpenRA.FileSystem
 				return null;
 
 			stream.Seek(entry.Offset, SeekOrigin.Begin);
-			var data = new byte[entry.Length];
-			stream.Read(data, 0, (int)entry.Length);
+			var data = stream.ReadBytes((int)entry.Length);
 			return new MemoryStream(data);
 		}
 

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -60,11 +60,7 @@ namespace OpenRA.FileSystem
 			using (var z = pkg.GetInputStream(pkg.GetEntry(filename)))
 			{
 				var ms = new MemoryStream();
-				int bufSize = 2048;
-				byte[] buf = new byte[bufSize];
-				while ((bufSize = z.Read(buf, 0, buf.Length)) > 0)
-					ms.Write(buf, 0, bufSize);
-
+				z.CopyTo(ms);
 				ms.Seek(0, SeekOrigin.Begin);
 				return ms;
 			}

--- a/OpenRA.Game/InstallUtils.cs
+++ b/OpenRA.Game/InstallUtils.cs
@@ -122,12 +122,7 @@ namespace OpenRA
 				extracted.Add(path);
 
 				using (var f = File.Create(path))
-				{
-					int bufSize = 2048;
-					byte[] buf = new byte[bufSize];
-					while ((bufSize = z.Read(buf, 0, buf.Length)) > 0)
-					f.Write(buf, 0, bufSize);
-				}
+					z.CopyTo(f);
 			}
 
 			z.Close();


### PR DESCRIPTION
Separated out from #5503 and built upon.

Fixes #2441, Fixes #4135, Fixes #4357, Fixes #5520, Fixes #5580, maybe others.

Lots of code was using Stream.Read without checking the return result. This is a fatal error as Stream.Read is allowed to return less than the requested data. If you don't check the return result your array will only be partially filled and bad things happen.

ReadBytes was broken and would throw an EndOfStreamException if the count was anything less than the requested number. If the count was non-zero then this is a bogus exception and results in traces like in #5520, #5580.

ReadAllBytes was broken and wouldn't even do you the good graces of throwing an exception. Instead it'd hand you back a partially filled array and let you choke later on all the zeros at the end of the array you weren't expecting. PrepareMap called this method so you would get traces like in #2441, #4135, #4357.

Personally I didn't know file streams did this (I never checked but I assumed this was something more intended for network streams and stuff) but today I learned that they do. This explains why it only occurred occasionally - most of the time you would actually get all the bytes you requested.
