### PR TITLE
Make Ready text blink red and white

### DIFF
--- a/OpenRA.Mods.Cnc/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Cnc/Widgets/ProductionPaletteWidget.cs
@@ -253,6 +253,10 @@ namespace OpenRA.Mods.Cnc.Widgets
 							overlayFont.DrawTextWithContrast(ReadyText,
 															 icon.Pos + readyOffset,
 															 Color.White, Color.Black, 1);
+						else
+							overlayFont.DrawTextWithContrast(ReadyText,
+															 icon.Pos + readyOffset,
+															 Color.Red, Color.Black, 1);
 					}
 					else if (first.Paused)
 						overlayFont.DrawTextWithContrast(HoldText,

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA.Widgets
 		public int Columns = 3;
 		public int Rows = 5;
 
-		[Translate] public string ReadyText = "";
+		[Translate] public string ReadyText, ReadyText_alt = "";
 		[Translate] public string HoldText = "";
 		[Translate] public string RequiresText = "";
 
@@ -272,11 +272,22 @@ namespace OpenRA.Mods.RA.Widgets
 					WidgetUtils.DrawSHPCentered(ob.First, ob.Second + iconOffset, worldRenderer);
 
 				var font = Game.Renderer.Fonts["TinyBold"];
+				string textBit_temp;
 				foreach (var tb in textBits)
 				{
-					var size = font.Measure(tb.Second);
-					font.DrawTextWithContrast(tb.Second, tb.First - new float2(size.X / 2, 0),
-						Color.White, Color.Black, 1);
+					if(tb.Second.Contains("_"))
+					{	
+						textBit_temp = tb.Second.Substring(0, tb.Second.IndexOf("_"));
+						var size = font.Measure(textBit_temp);
+						font.DrawTextWithContrast(textBit_temp, tb.First - new float2(size.X / 2, 0),
+							Color.Red, Color.Black, 1);					
+					}
+					else
+					{
+						var size = font.Measure(tb.Second);
+						font.DrawTextWithContrast(tb.Second, tb.First - new float2(size.X / 2, 0),
+							Color.White, Color.Black, 1);
+					}
 				}
 
 				// Tooltip
@@ -305,7 +316,7 @@ namespace OpenRA.Mods.RA.Widgets
 				return HoldText;
 
 			if (item.Done)
-				return orderManager.LocalFrameNumber / 9 % 2 == 0 ? ReadyText : "";
+				return orderManager.LocalFrameNumber / 9 % 2 == 0 ? ReadyText : ReadyText + "_alt";
 
 			return WidgetUtils.FormatTime(item.RemainingTimeActual);
 		}

--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA.Widgets
 		public int Columns = 3;
 		public int Rows = 5;
 
-		[Translate] public string ReadyText, ReadyText_alt = "";
+		[Translate] public string ReadyText = "";
 		[Translate] public string HoldText = "";
 		[Translate] public string RequiresText = "";
 
@@ -272,14 +272,12 @@ namespace OpenRA.Mods.RA.Widgets
 					WidgetUtils.DrawSHPCentered(ob.First, ob.Second + iconOffset, worldRenderer);
 
 				var font = Game.Renderer.Fonts["TinyBold"];
-				string textBit_temp;
 				foreach (var tb in textBits)
 				{
 					if(tb.Second.Contains("_"))
 					{	
-						textBit_temp = tb.Second.Substring(0, tb.Second.IndexOf("_"));
-						var size = font.Measure(textBit_temp);
-						font.DrawTextWithContrast(textBit_temp, tb.First - new float2(size.X / 2, 0),
+						var size = font.Measure(tb.Second.Substring(1));
+						font.DrawTextWithContrast(tb.Second.Substring(1), tb.First - new float2(size.X / 2, 0),
 							Color.Red, Color.Black, 1);					
 					}
 					else
@@ -316,7 +314,7 @@ namespace OpenRA.Mods.RA.Widgets
 				return HoldText;
 
 			if (item.Done)
-				return orderManager.LocalFrameNumber / 9 % 2 == 0 ? ReadyText : ReadyText + "_alt";
+				return orderManager.LocalFrameNumber / 9 % 2 == 0 ? ReadyText : "_" + ReadyText;
 
 			return WidgetUtils.FormatTime(item.RemainingTimeActual);
 		}


### PR DESCRIPTION
The current blinking behavior as per #5178 is not optimal since the ready text may not be seen when taking a quick look at the production tab. This pull request makes the text alternate between red and white colors, instead of turning it on and off. This is for both Red Alert and Tiberian Dawn mods.
