### PR TITLE
Fixed $TRAVIS_TAG being empty on release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ notifications:
     skip_join: true
 
 before_deploy:
- - env
  - echo $TRAVIS_TAG
  - cd packaging
  - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ script:
  - make all
  - make test
 
-# Only watch the development and release branches.
+# Only watch the development branch and tagged release.
 branches:
  only:
-   - master
-   - next
+   - /^release-.*$/
+   - /^playtest-.*$/
    - bleed
 
 # Notify developers when build passed/failed.


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/2373 I have to reg-ex white-list the name of the _tags_ not the release branches under `branches: only:` to trigger a build. Only then `$TRAVIS_TAG` won't be empty. That is counter-intuitive and I could not find that in the documentation. Hope other people find this via the GitHub search.
