### PR TITLE
Make repair animation pause if player has no money.

### DIFF
--- a/OpenRA.Mods.RA/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.RA/Buildings/RepairableBuilding.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.RA.Buildings
 
 		Health Health;
 		RepairableBuildingInfo Info;
+		public bool RepairActive = true;
 
 		public RepairableBuilding(Actor self, RepairableBuildingInfo info)
 		{
@@ -81,7 +82,8 @@ namespace OpenRA.Mods.RA.Buildings
 
 				var hpToRepair = Math.Min(Info.RepairStep, Health.MaxHP - Health.HP);
 				var cost = Math.Max(1, (hpToRepair * Info.RepairPercent * buildingValue) / (Health.MaxHP * 100));
-				if (!Repairer.PlayerActor.Trait<PlayerResources>().TakeCash(cost))
+				RepairActive = Repairer.PlayerActor.Trait<PlayerResources>().TakeCash(cost);
+				if (!RepairActive)
 				{
 					remainingTicks = 1;
 					return;

--- a/OpenRA.Mods.RA/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/RepairIndicator.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			rb = building.TraitOrDefault<RepairableBuilding>();
 			anim = new Animation(building.World, "allyrepair");
+			anim.Paused = () => !rb.RepairActive;
 			anim.PlayRepeating("repair");
 		}
 


### PR DESCRIPTION
This implements #5322. I tested it and seems to work. When player has no money, repair animation is paused and when he gets money again, repair animation continues from the paused frame.
