### PR TITLE
Avoid redundancy in BeginFrame.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Also thanks to:
     * Teemu Nieminen (Temeez)
     * Tim Mylemans (gecko)
     * Tirili
+    * Tom Roostan (RoosterDragon)
     * Tristan Keating (Kilkakon)
     * Tristan Mühlbacher (MicroBit)
     * Vladimir Komarov (VrKomarov)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -141,12 +141,12 @@ namespace OpenRA
 				// worldRenderer is null during the initial install/download screen
 				if (worldRenderer != null)
 				{
-					Renderer.BeginFrame(worldRenderer.Viewport.TopLeft.ToFloat2(), worldRenderer.Viewport.Zoom);
+					Renderer.BeginFrame(worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.Zoom);
 					Sound.SetListenerPosition(worldRenderer.Position(worldRenderer.Viewport.CenterLocation));
 					worldRenderer.Draw();
 				}
 				else
-					Renderer.BeginFrame(float2.Zero, 1f);
+					Renderer.BeginFrame(int2.Zero, 1f);
 
 				using (new PerfSample("render_widgets"))
 				{

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -103,9 +103,9 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public void SetViewportParams(Size screen, float zoom, float2 scroll)
+		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
-			shader.SetVec("Scroll", (int)scroll.X, (int)scroll.Y);
+			shader.SetVec("Scroll", scroll.X, scroll.Y);
 			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}

--- a/OpenRA.Game/Graphics/QuadRenderer.cs
+++ b/OpenRA.Game/Graphics/QuadRenderer.cs
@@ -58,9 +58,9 @@ namespace OpenRA.Graphics
 			nv += 4;
 		}
 
-		public void SetViewportParams(Size screen, float zoom, float2 scroll)
+		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
-			shader.SetVec("Scroll", (int)scroll.X, (int)scroll.Y);
+			shader.SetVec("Scroll", scroll.X, scroll.Y);
 			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -65,17 +65,34 @@ namespace OpenRA.Graphics
 
 		internal IGraphicsDevice Device { get { return device; } }
 
-		public void BeginFrame(float2 scroll, float zoom)
+		Size? lastResolution;
+		int2? lastScroll;
+		float? lastZoom;
+
+		public void BeginFrame(int2 scroll, float zoom)
 		{
 			device.Clear();
-			WorldSpriteRenderer.SetViewportParams(Resolution, zoom, scroll);
-			WorldRgbaSpriteRenderer.SetViewportParams(Resolution, zoom, scroll);
-			SpriteRenderer.SetViewportParams(Resolution, 1f, float2.Zero);
-			RgbaSpriteRenderer.SetViewportParams(Resolution, 1f, float2.Zero);
-			WorldLineRenderer.SetViewportParams(Resolution, zoom, scroll);
-			WorldQuadRenderer.SetViewportParams(Resolution, zoom, scroll);
-			LineRenderer.SetViewportParams(Resolution, 1f, float2.Zero);
-			WorldVoxelRenderer.SetViewportParams(Resolution, zoom, scroll);
+
+			var resolutionChanged = lastResolution != Resolution;
+			if (resolutionChanged)
+			{
+				lastResolution = Resolution;
+				RgbaSpriteRenderer.SetViewportParams(Resolution, 1f, int2.Zero);
+				SpriteRenderer.SetViewportParams(Resolution, 1f, int2.Zero);
+				LineRenderer.SetViewportParams(Resolution, 1f, int2.Zero);
+			}
+
+			// If zoom evaluates as different due to floating point weirdness that's OK, setting the parameters again is harmless.
+			if (resolutionChanged || lastScroll != scroll || lastZoom != zoom)
+			{
+				lastScroll = scroll;
+				lastZoom = zoom;
+				WorldRgbaSpriteRenderer.SetViewportParams(Resolution, zoom, scroll);
+				WorldSpriteRenderer.SetViewportParams(Resolution, zoom, scroll);
+				WorldVoxelRenderer.SetViewportParams(Resolution, zoom, scroll);
+				WorldLineRenderer.SetViewportParams(Resolution, zoom, scroll);
+				WorldQuadRenderer.SetViewportParams(Resolution, zoom, scroll);
+			}
 		}
 
 		ITexture currentPaletteTexture;

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -120,9 +120,9 @@ namespace OpenRA.Graphics
 			shader.SetTexture("Palette", palette);
 		}
 
-		public void SetViewportParams(Size screen, float zoom, float2 scroll)
+		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
-			shader.SetVec("Scroll", (int)scroll.X, (int)scroll.Y);
+			shader.SetVec("Scroll", scroll.X, scroll.Y);
 			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}

--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Graphics
 			shader.SetTexture("Palette", palette);
 		}
 
-		public void SetViewportParams(Size screen, float zoom, float2 scroll)
+		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
 			var a = 2f / Renderer.SheetSize;
 			var view = new float[]

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Cnc
 			loadTimer.Restart();
 
 			loadTick = ++loadTick % 8;
-			r.BeginFrame(float2.Zero, 1f);
+			r.BeginFrame(int2.Zero, 1f);
 			r.RgbaSpriteRenderer.DrawSprite(gdiLogo, gdiPos);
 			r.RgbaSpriteRenderer.DrawSprite(nodLogo, nodPos);
 			r.RgbaSpriteRenderer.DrawSprite(evaLogo, evaPos);

--- a/OpenRA.Mods.RA/DefaultLoadScreen.cs
+++ b/OpenRA.Mods.RA/DefaultLoadScreen.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.RA
 			var text = messages.Random(Game.CosmeticRandom);
 			var textSize = r.Fonts["Bold"].Measure(text);
 
-			r.BeginFrame(float2.Zero, 1f);
+			r.BeginFrame(int2.Zero, 1f);
 			WidgetUtils.FillRectWithSprite(stripeRect, stripe);
 			r.RgbaSpriteRenderer.DrawSprite(logo, logoPos);
 			r.Fonts["Bold"].DrawText(text, new float2(r.Resolution.Width - textSize.X - 20, r.Resolution.Height - textSize.Y - 20), Color.White);

--- a/OpenRA.Mods.RA/ModChooserLoadScreen.cs
+++ b/OpenRA.Mods.RA/ModChooserLoadScreen.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Cnc
 			if (r == null)
 				return;
 
-			r.BeginFrame(float2.Zero, 1f);
+			r.BeginFrame(int2.Zero, 1f);
 			WidgetUtils.FillRectWithSprite(bounds, sprite);
 			r.EndFrame(new NullInputHandler());
 		}

--- a/OpenRA.Mods.RA/NullLoadScreen.cs
+++ b/OpenRA.Mods.RA/NullLoadScreen.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA
 				return;
 
 			// Draw a black screen
-			Game.Renderer.BeginFrame(float2.Zero, 1f);
+			Game.Renderer.BeginFrame(int2.Zero, 1f);
 			Game.Renderer.EndFrame( new NullInputHandler() );
 		}
 


### PR DESCRIPTION
- Cache the old resolution, scroll and zoom in BeginFrame, and don't bother updating the viewport parameters again until they change.
- Pass around scroll as an int2 to reduce the number of back-and-forth casts.
