### PR TITLE
Add developer shortcut to reload chrome files

### DIFF
--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -27,6 +27,8 @@ namespace OpenRA.Graphics
 		static Dictionary<string, Sheet> cachedSheets;
 		static Dictionary<string, Dictionary<string, Sprite>> cachedSprites;
 
+		static string[] storedChromeFiles;
+
 		public static void Initialize(params string[] chromeFiles)
 		{
 			collections = new Dictionary<string, Collection>();
@@ -34,7 +36,13 @@ namespace OpenRA.Graphics
 			cachedSprites = new Dictionary<string, Dictionary<string, Sprite>>();
 
 			if (chromeFiles.Length == 0)
-				return;
+			{
+				chromeFiles = storedChromeFiles;
+				if (chromeFiles == null || chromeFiles.Length == 0)
+					return;
+			}
+			else
+				storedChromeFiles = chromeFiles;
 
 			var chrome = chromeFiles.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal);
 

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -250,6 +250,7 @@
     <Compile Include="GameRules\RulesetCache.cs" />
     <Compile Include="Support\MersenneTwister.cs" />
     <Compile Include="GameInformation.cs" />
+    <Compile Include="Widgets\RootWidget.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -176,6 +176,8 @@ namespace OpenRA
 		public Hotkey ObserverWorldView = new Hotkey(Keycode.EQUALS, Modifiers.None);
 
 		public Hotkey TogglePixelDoubleKey = new Hotkey(Keycode.PERIOD, Modifiers.None);
+
+		public Hotkey DevReloadChromeKey = new Hotkey(Keycode.C, Modifiers.Ctrl | Modifiers.Shift);
 	}
 
 	public class IrcSettings

--- a/OpenRA.Game/Widgets/RootWidget.cs
+++ b/OpenRA.Game/Widgets/RootWidget.cs
@@ -1,0 +1,39 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Graphics;
+
+namespace OpenRA.Widgets
+{
+	public class RootWidget : ContainerWidget
+	{
+		public RootWidget()
+		{
+			IgnoreMouseOver = true;
+		}
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (e.Event == KeyInputEvent.Down)
+			{
+				var hk = Hotkey.FromKeyInput(e);
+
+				if (hk == Game.Settings.Keys.DevReloadChromeKey)
+				{
+					ChromeProvider.Initialize();
+					return true;
+				}
+			}
+
+			return base.HandleKeyPress(e);
+		}
+	}
+}

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Widgets
 {
 	public static class Ui
 	{
-		public static Widget Root = new ContainerWidget();
+		public static Widget Root = new RootWidget();
 
 		public static int LastTickTime = Environment.TickCount;
 

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -244,46 +244,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		Action InitInputPanel(Widget panel)
 		{
-			// TODO: Extract these to a yaml file
-			var specialHotkeys = new Dictionary<string, string>()
-			{
-				{ "CycleBaseKey", "Jump to base" },
-				{ "ToLastEventKey", "Jump to last radar event" },
-				{ "ToSelectionKey", "Jump to selection" },
-				{ "SelectAllUnitsKey", "Select all units on screen" },
-				{ "SelectUnitsByTypeKey", "Select units by type" },
-
-				{ "PlaceBeaconKey", "Place beacon" },
-
-				{ "PauseKey", "Pause / Unpause" },
-				{ "SellKey", "Sell mode" },
-				{ "PowerDownKey", "Power-down mode" },
-				{ "RepairKey", "Repair mode" },
-
-				{ "NextProductionTabKey", "Next production tab" },
-				{ "PreviousProductionTabKey", "Previous production tab" },
-				{ "CycleProductionBuildingsKey", "Cycle production facilities" },
-
-				{ "ToggleStatusBarsKey", "Toggle status bars" },
-				{ "TogglePixelDoubleKey", "Toggle pixel doubling" },
-			};
-
-			var unitHotkeys = new Dictionary<string, string>()
-			{
-				{ "AttackMoveKey", "Attack Move" },
-				{ "StopKey", "Stop" },
-				{ "ScatterKey", "Scatter" },
-				{ "StanceCycleKey", "Cycle Stance" },
-				{ "DeployKey", "Deploy" },
-				{ "GuardKey", "Guard" }
-			};
-
-			var observerHotkeys = new Dictionary<string, string>()
-			{
-				{ "ObserverCombinedView", "All Players" },
-				{ "ObserverWorldView", "Disable Shroud" }
-			};
-
 			var gs = Game.Settings.Game;
 			var ks = Game.Settings.Keys;
 
@@ -304,26 +264,89 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var unitTemplate = hotkeyList.Get("UNIT_TEMPLATE");
 			hotkeyList.RemoveChildren();
 
-			var globalHeader = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
-			globalHeader.Get<LabelWidget>("LABEL").GetText = () => "Global Commands";
-			hotkeyList.AddChild(globalHeader);
+			// Game
+			{
+				var hotkeys = new Dictionary<string, string>()
+				{
+					{ "CycleBaseKey", "Jump to base" },
+					{ "ToLastEventKey", "Jump to last radar event" },
+					{ "ToSelectionKey", "Jump to selection" },
+					{ "SelectAllUnitsKey", "Select all units on screen" },
+					{ "SelectUnitsByTypeKey", "Select units by type" },
 
-			foreach (var kv in specialHotkeys)
-				BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
+					{ "PlaceBeaconKey", "Place beacon" },
 
-			var observerHeader = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
-			observerHeader.Get<LabelWidget>("LABEL").GetText = () => "Observer Commands";
-			hotkeyList.AddChild(observerHeader);
+					{ "PauseKey", "Pause / Unpause" },
+					{ "SellKey", "Sell mode" },
+					{ "PowerDownKey", "Power-down mode" },
+					{ "RepairKey", "Repair mode" },
 
-			foreach (var kv in observerHotkeys)
-				BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
+					{ "NextProductionTabKey", "Next production tab" },
+					{ "PreviousProductionTabKey", "Previous production tab" },
+					{ "CycleProductionBuildingsKey", "Cycle production facilities" },
 
-			var unitHeader = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
-			unitHeader.Get<LabelWidget>("LABEL").GetText = () => "Unit Commands";
-			hotkeyList.AddChild(unitHeader);
+					{ "ToggleStatusBarsKey", "Toggle status bars" },
+					{ "TogglePixelDoubleKey", "Toggle pixel doubling" },
+				};
 
-			foreach (var kv in unitHotkeys)
-				BindHotkeyPref(kv, ks, unitTemplate, hotkeyList);
+				var header = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
+				header.Get<LabelWidget>("LABEL").GetText = () => "Game Commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
+			}
+
+			// Observer
+			{
+				var hotkeys = new Dictionary<string, string>()
+				{
+					{ "ObserverCombinedView", "All Players" },
+					{ "ObserverWorldView", "Disable Shroud" }
+				};
+
+				var header = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
+				header.Get<LabelWidget>("LABEL").GetText = () => "Observer Commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
+			}
+
+			// Unit
+			{
+				var hotkeys = new Dictionary<string, string>()
+				{
+					{ "AttackMoveKey", "Attack Move" },
+					{ "StopKey", "Stop" },
+					{ "ScatterKey", "Scatter" },
+					{ "StanceCycleKey", "Cycle Stance" },
+					{ "DeployKey", "Deploy" },
+					{ "GuardKey", "Guard" }
+				};
+
+				var header = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
+				header.Get<LabelWidget>("LABEL").GetText = () => "Unit Commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, unitTemplate, hotkeyList);
+			}
+
+			// Developer
+			{
+				var hotkeys = new Dictionary<string, string>()
+				{
+					{ "DevReloadChromeKey", "Reload Chrome" }
+				};
+
+				var header = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
+				header.Get<LabelWidget>("LABEL").GetText = () => "Developer commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
+			}
 
 			return () =>
 			{


### PR DESCRIPTION
Hitting Ctrl+Shift+C will re-initialize the chrome provider,
reloading all chrome files instantly. Useful when changing the
UI.

Note: A new "RootWidget" was created to trap top-level (global)
shortcuts instead of putting everything in Widget.
