### PR TITLE
Reduced the verbosity of the packaging build

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -23,6 +23,6 @@ rm OpenRA.app/Contents/Resources/OpenRA.Editor.exe
 rm OpenRA.app/Contents/Resources/OpenRA.CrashDialog.exe
 
 # Package app bundle into a zip and clean up
-zip OpenRA-$1 -r -9 OpenRA.app
+zip OpenRA-$1 -r -9 OpenRA.app --quiet
 mv OpenRA-$1.zip $4
 rm -rf OpenRA.app

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -79,7 +79,7 @@ echo "Creating packages..."
 
 pushd windows
 echo "Building Windows setup.exe"
-makensis -DSRCDIR="$BUILTDIR" -DDEPSDIR="${SRCDIR}/thirdparty/windows" OpenRA.nsi
+makensis -V2 -DSRCDIR="$BUILTDIR" -DDEPSDIR="${SRCDIR}/thirdparty/windows" OpenRA.nsi
 if [ $? -eq 0 ]; then
     mv OpenRA.exe "$OUTPUTDIR"/OpenRA-$TAG.exe
 else


### PR DESCRIPTION
"This log is too long to be displayed. Please reduce the verbosity of your build or download the the raw log."
