### PR TITLE
Fixed rpmbuild warning: File listed twice

### DIFF
--- a/packaging/linux/rpm/buildpackage.sh
+++ b/packaging/linux/rpm/buildpackage.sh
@@ -16,17 +16,11 @@ sed -i "s/{VERSION_FIELD}/$PKGVERSION/" openra.spec
 rootdir=`readlink -f $2`
 sed -i "s|{ROOT_DIR}|$rootdir|" openra.spec
 
-for x in `find $rootdir/usr/lib/openra -type d`
-do
-    y="${x#$rootdir}"
-    sed -i "/%files/ a ${y}" openra.spec
-done
-
 cp openra.spec "$3/SPECS/"
 
 cd "$3"
 
-rpmbuild --target noarch --buildroot /tmp/openra/ -bb SPECS/openra.spec --quiet
+rpmbuild --target noarch --buildroot /tmp/openra/ -bb SPECS/openra.spec
 if [ $? -ne 0 ]; then
   exit 1
 fi

--- a/packaging/linux/rpm/openra.spec
+++ b/packaging/linux/rpm/openra.spec
@@ -47,6 +47,7 @@ rm -rf %{buildroot}
 %files
 /usr/bin/openra
 /usr/bin/openra-editor
+/usr/lib/openra/
 /usr/share/applications/*.desktop
 /usr/share/doc/openra/*
 /usr/share/icons/hicolor/*/apps/*.png


### PR DESCRIPTION
We were doing a recursive directory listing that RPM does itself. I tested it on build.open-ra.org and it also works on Ubuntu rpmbuild. Not sure why we added this.
