### PR TITLE
Fixed single resources being spawned at 0 density

### DIFF
--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Traits
 						// Adjacent includes the current cell, so is always >= 1
 						var adjacent = GetAdjacentCellsWith(type, x, y);
 						var density = int2.Lerp(0, type.Info.MaxDensity, adjacent, 9);
-						content[x, y].Density = density;
+						content[x, y].Density = Math.Max(density, 1);
 
 						render[x, y] = content[x, y];
 						UpdateRenderedSprite(new CPos(x, y));


### PR DESCRIPTION
and therefore not being rendered as described in https://github.com/OpenRA/OpenRA/issues/5565. Haos Ridges is a good test case (even without https://github.com/OpenRA/OpenRA/pull/4496) because it comes with spots showing few gems.

![image](https://cloud.githubusercontent.com/assets/756669/3208269/45a24510-ee26-11e3-9028-6a8ecf57e26f.png)
