### PR TITLE
Always show primary tag

### DIFF
--- a/OpenRA.Game/Traits/SelectionDecorations.cs
+++ b/OpenRA.Game/Traits/SelectionDecorations.cs
@@ -24,7 +24,6 @@ namespace OpenRA.Traits
 	{
 		// depends on the order of pips in TraitsInterfaces.cs!
 		static readonly string[] pipStrings = { "pip-empty", "pip-green", "pip-yellow", "pip-red", "pip-gray", "pip-blue", "pip-ammo", "pip-ammoempty" };
-		static readonly string[] tagStrings = { "", "tag-fake", "tag-primary" };
 
 		public SelectionDecorationsInfo Info;
 		Actor self;
@@ -49,7 +48,6 @@ namespace OpenRA.Traits
 
 			DrawControlGroup(wr, self, xy);
 			DrawPips(wr, self, xY);
-			DrawTags(wr, self, new int2((bounds.Left + bounds.Right) / 2, bounds.Top));
 		}
 
 		void DrawControlGroup(WorldRenderer wr, Actor self, int2 basePosition)
@@ -109,34 +107,6 @@ namespace OpenRA.Traits
 				pipxyOffset.Y -= pipSize.Y + 1;
 			}
 		}
-
-		void DrawTags(WorldRenderer wr, Actor self, int2 basePosition)
-		{
-			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				return;
-
-			var tagImages = new Animation(self.World, "pips");
-			var pal = wr.Palette(Info.Palette);
-			var tagxyOffset = new int2(0, 6);
-			var tagBase = wr.Viewport.WorldToViewPx(basePosition);
-
-			foreach (var tags in self.TraitsImplementing<ITags>())
-			{
-				foreach (var tag in tags.GetTags())
-				{
-					if (tag == TagType.None)
-						continue;
-
-					tagImages.PlayRepeating(tagStrings[(int)tag]);
-					var pos = tagBase + tagxyOffset - (0.5f * tagImages.Image.size).ToInt2();
-					Game.Renderer.SpriteRenderer.DrawSprite(tagImages.Image, pos, pal);
-
-					// Increment row
-					tagxyOffset.Y += 8;
-				}
-			}
-		}
-
 	}
 }
 

--- a/OpenRA.Mods.RA/PrimaryBuilding.cs
+++ b/OpenRA.Mods.RA/PrimaryBuilding.cs
@@ -27,20 +27,25 @@ namespace OpenRA.Mods.RA
 	}
 
 	[Desc("Used together with ClassicProductionQueue.")]
-	class PrimaryBuildingInfo : TraitInfo<PrimaryBuilding>
+	class PrimaryBuildingInfo : ITraitInfo
 	{
+		public readonly string Palette = "chrome";
+		
 		public readonly int OffsetX = 0;
 		public readonly int OffsetY = 7;
 		public readonly int OffsetAirfieldX = -16;
 		public readonly int OffsetAirfieldY = 15;
 		public readonly int OffsetAirfieldDoubleX = 35;
 		public readonly int OffsetAirfieldDoubleY = 72;
+		
+		public object Create(ActorInitializer init) { return new PrimaryBuilding(this); }
 	}
 
 	class PrimaryBuilding : IIssueOrder, IResolveOrder, ITags, IPostRender
 	{
 		bool isPrimary = false;
 		public bool IsPrimary { get { return isPrimary; } }
+		PrimaryBuildingInfo info;
 
 		public IEnumerable<TagType> GetTags()
 		{
@@ -50,6 +55,11 @@ namespace OpenRA.Mods.RA
 		public IEnumerable<IOrderTargeter> Orders
 		{
 			get { yield return new DeployOrderTargeter("PrimaryProducer", 1); }
+		}
+
+		public PrimaryBuilding(PrimaryBuildingInfo info)
+		{
+			this.info = info;
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
@@ -101,21 +111,21 @@ namespace OpenRA.Mods.RA
 				int2 basePosition = new int2((bounds.Left + bounds.Right) / 2, bounds.Top);
 
 				var tagImages = new Animation(self.World, "pips");
-				var pal = wr.Palette("chrome");
-				var tagxyOffset = new int2(self.Trait<PrimaryBuildingInfo>().OffsetX, self.Trait<PrimaryBuildingInfo>().OffsetY);
+				var pal = wr.Palette(info.Palette);
+				var tagxyOffset = new int2(info.OffsetX, info.OffsetY);
 
 				// Special tag position for airfield
 				if (self.Info.Name == "afld")
 				{
 					if (Game.Settings.Graphics.PixelDouble)
 					{
-						tagxyOffset.X = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldDoubleX;
-						tagxyOffset.Y = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldDoubleY;
-					} 
+						tagxyOffset.X = info.OffsetAirfieldDoubleX;
+						tagxyOffset.Y = info.OffsetAirfieldDoubleY;
+					}
 					else
 					{
-						tagxyOffset.X = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldX;
-						tagxyOffset.Y = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldY;
+						tagxyOffset.X = info.OffsetAirfieldX;
+						tagxyOffset.Y = info.OffsetAirfieldY;
 					}
 				}
 

--- a/OpenRA.Mods.RA/PrimaryBuilding.cs
+++ b/OpenRA.Mods.RA/PrimaryBuilding.cs
@@ -102,20 +102,20 @@ namespace OpenRA.Mods.RA
 
 				var tagImages = new Animation(self.World, "pips");
 				var pal = wr.Palette("chrome");
-				var tagxyOffset = new int2(OffsetX, OffsetY);
+				var tagxyOffset = new int2(self.Trait<PrimaryBuildingInfo>().OffsetX, self.Trait<PrimaryBuildingInfo>().OffsetY);
 
 				// Special tag position for airfield
 				if (self.Info.Name == "afld")
 				{
 					if (Game.Settings.Graphics.PixelDouble)
 					{
-						tagxyOffset.X = OffsetAirfieldDoubleX;
-						tagxyOffset.Y = OffsetAirfieldDoubleY;
+						tagxyOffset.X = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldDoubleX;
+						tagxyOffset.Y = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldDoubleY;
 					} 
 					else
 					{
-						tagxyOffset.X = OffsetAirfieldX;
-						tagxyOffset.Y = OffsetAirfieldY;
+						tagxyOffset.X = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldX;
+						tagxyOffset.Y = self.Trait<PrimaryBuildingInfo>().OffsetAirfieldY;
 					}
 				}
 

--- a/OpenRA.Mods.RA/PrimaryBuilding.cs
+++ b/OpenRA.Mods.RA/PrimaryBuilding.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.RA
 
 				var tagImages = new Animation(self.World, "pips");
 				var pal = wr.Palette("chrome");
-				var tagxyOffset = new int2(0, 0);
+				var tagxyOffset = new int2(0, 7);
 
 				// Special tag position for airfield
 				if (self.Info.Name == "afld")
@@ -110,16 +110,14 @@ namespace OpenRA.Mods.RA
 						tagxyOffset.Y = 15;
 					}
 				}
-				else
-					tagxyOffset.Y = 7;
 
 				var tagBase = wr.Viewport.WorldToViewPx(basePosition);
 
 				if (this.GetTags().Contains(TagType.Primary))
 				{
 					tagImages.PlayRepeating("tag-primary");
-					var pos2 = tagBase + tagxyOffset - (0.5f * tagImages.Image.size).ToInt2();
-					Game.Renderer.SpriteRenderer.DrawSprite(tagImages.Image, pos2, pal);
+					var tagPos = tagBase + tagxyOffset - (0.5f * tagImages.Image.size).ToInt2();
+					Game.Renderer.SpriteRenderer.DrawSprite(tagImages.Image, tagPos, pal);
 				}
 			}
 		}

--- a/OpenRA.Mods.RA/PrimaryBuilding.cs
+++ b/OpenRA.Mods.RA/PrimaryBuilding.cs
@@ -33,10 +33,8 @@ namespace OpenRA.Mods.RA
 		
 		public readonly int OffsetX = 0;
 		public readonly int OffsetY = 7;
-		public readonly int OffsetAirfieldX = -16;
+		public readonly int OffsetAirfieldX = 16;
 		public readonly int OffsetAirfieldY = 15;
-		public readonly int OffsetAirfieldDoubleX = 35;
-		public readonly int OffsetAirfieldDoubleY = 72;
 		
 		public object Create(ActorInitializer init) { return new PrimaryBuilding(this); }
 	}
@@ -118,10 +116,7 @@ namespace OpenRA.Mods.RA
 				if (self.Info.Name == "afld")
 				{
 					if (Game.Settings.Graphics.PixelDouble)
-					{
-						tagxyOffset.X = info.OffsetAirfieldDoubleX;
-						tagxyOffset.Y = info.OffsetAirfieldDoubleY;
-					}
+						tagxyOffset.Y += 4;
 					else
 					{
 						tagxyOffset.X = info.OffsetAirfieldX;

--- a/OpenRA.Mods.RA/PrimaryBuilding.cs
+++ b/OpenRA.Mods.RA/PrimaryBuilding.cs
@@ -27,7 +27,15 @@ namespace OpenRA.Mods.RA
 	}
 
 	[Desc("Used together with ClassicProductionQueue.")]
-	class PrimaryBuildingInfo : TraitInfo<PrimaryBuilding> { }
+	class PrimaryBuildingInfo : TraitInfo<PrimaryBuilding>
+	{
+		public readonly int OffsetX = 0;
+		public readonly int OffsetY = 7;
+		public readonly int OffsetAirfieldX = -16;
+		public readonly int OffsetAirfieldY = 15;
+		public readonly int OffsetAirfieldDoubleX = 35;
+		public readonly int OffsetAirfieldDoubleY = 72;
+	}
 
 	class PrimaryBuilding : IIssueOrder, IResolveOrder, ITags, IPostRender
 	{
@@ -94,20 +102,20 @@ namespace OpenRA.Mods.RA
 
 				var tagImages = new Animation(self.World, "pips");
 				var pal = wr.Palette("chrome");
-				var tagxyOffset = new int2(0, 7);
+				var tagxyOffset = new int2(OffsetX, OffsetY);
 
 				// Special tag position for airfield
 				if (self.Info.Name == "afld")
 				{
 					if (Game.Settings.Graphics.PixelDouble)
 					{
-						tagxyOffset.X = 35;
-						tagxyOffset.Y = 72;
+						tagxyOffset.X = OffsetAirfieldDoubleX;
+						tagxyOffset.Y = OffsetAirfieldDoubleY;
 					} 
 					else
 					{
-						tagxyOffset.X = -16;
-						tagxyOffset.Y = 15;
+						tagxyOffset.X = OffsetAirfieldX;
+						tagxyOffset.Y = OffsetAirfieldY;
 					}
 				}
 


### PR DESCRIPTION
This implements #4935, although the wording in that issue is not correct. This commit shows primary tag on production buildings always if it is set, not only when the building is selected. Airfield has a separate tag position because of overlapping of progress bars. I experimented with different locations and I think this results in least overlapping. Airfield also has a different tag position if pixel doubling is enabled. I couldn't have done this commit without the help of WolfGaming in #openra. I tested the commit and seems to work.

I removed DrawTags method from SelectionDecorations.cs because its only purpose was to draw the primary tag which is now done in PrimaryBuilding.cs.
