### PR TITLE
Don’t queue rallypoint move if MoveIntoWorld:false.

### DIFF
--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -78,10 +78,12 @@ namespace OpenRA.Mods.RA
 				if (move != null)
 				{
 					if (exitinfo.MoveIntoWorld)
+					{
 						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
 
-					newUnit.QueueActivity(new AttackMove.AttackMoveActivity(
-						newUnit, move.MoveWithinRange(target, nearEnough)));
+						newUnit.QueueActivity(new AttackMove.AttackMoveActivity(
+							newUnit, move.MoveWithinRange(target, nearEnough)));
+					}
 				}
 
 				newUnit.SetTargetLine(target, Color.Green, false);


### PR DESCRIPTION
Fixes #5576.
