### PR TITLE
Add support for mouse grabs.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -129,6 +129,7 @@ namespace OpenRA
 		public bool ShowShellmap = true;
 
 		public bool ViewportEdgeScroll = true;
+		public bool LockMouseWindow = true;
 		public MouseScrollType MouseScroll = MouseScrollType.Standard;
 		public float ViewportEdgeScrollStep = 10f;
 		public float UIScrollSpeed = 50f;

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -289,6 +289,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			BindCheckboxPref(panel, "CLASSICORDERS_CHECKBOX", gs, "UseClassicMouseStyle");
 			BindCheckboxPref(panel, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
+			BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gs, "LockMouseWindow");
 			BindSliderPref(panel, "SCROLLSPEED_SLIDER", gs, "ViewportEdgeScrollStep");
 			BindSliderPref(panel, "UI_SCROLLSPEED_SLIDER", gs, "UIScrollSpeed");
 
@@ -347,6 +348,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				gs.UseClassicMouseStyle = dgs.UseClassicMouseStyle;
 				gs.MouseScroll = dgs.MouseScroll;
+				gs.LockMouseWindow = dgs.LockMouseWindow;
 				gs.ViewportEdgeScroll = dgs.ViewportEdgeScroll;
 				gs.ViewportEdgeScrollStep = dgs.ViewportEdgeScrollStep;
 				gs.UIScrollSpeed = dgs.UIScrollSpeed;

--- a/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
@@ -62,6 +62,9 @@ namespace OpenRA.Renderer.Sdl2
 
 			window = SDL.SDL_CreateWindow("OpenRA", SDL.SDL_WINDOWPOS_CENTERED, SDL.SDL_WINDOWPOS_CENTERED, size.Width, size.Height, SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL);
 
+			var lockWindow = Game.Settings.Game.LockMouseWindow ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE;
+			SDL.SDL_SetWindowGrab(window, lockWindow);
+
 			if (windowMode == WindowMode.Fullscreen)
 				SDL.SDL_SetWindowFullscreen(window, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN);
 			else if (windowMode == WindowMode.PseudoFullscreen)

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -311,6 +311,21 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Edge Scrolling
+						Checkbox@LOCKMOUSE_CHECKBOX:
+							X: 15
+							Y: 100
+							Width: 130
+							Height: 20
+							Font: Regular
+							Text: Lock mouse to window
+						Label@LOCKMOUSE_DESC:
+							X: 25
+							Y: 110
+							Width: 130
+							Height: 25
+							Font: Tiny
+							Align: Right
+							Text: (Requires restart)
 						Label@SCROLL_SPEED_LABEL:
 							X: PARENT_RIGHT - WIDTH - 270
 							Y: 67

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -315,6 +315,21 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Edge Scrolling
+				Checkbox@LOCKMOUSE_CHECKBOX:
+					X: 15
+					Y: 100
+					Width: 130
+					Height: 20
+					Font: Regular
+					Text: Lock mouse to window
+				Label@LOCKMOUSE_DESC:
+					X: 25
+					Y: 110
+					Width: 130
+					Height: 25
+					Font: Tiny
+					Align: Right
+					Text: (Requires restart)
 				Label@SCROLL_SPEED_LABEL:
 					X: PARENT_RIGHT - WIDTH - 270
 					Y: 67


### PR DESCRIPTION
Added call to SDL_CreateWindow on game initialisation.

To allow for situations (such as development) where the user does not wish OpenRA to grab the window focus, this functionality is configurable in the 'Display' settings menu.
