### PR TITLE
Removing requirement to restart game after applying changes to mouse focus option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Also thanks to:
     * Fahrradkette
     * Frank Razenberg (zzattack)
     * Gareth Needham (Ripley`)
+    * Gordon Martin (Happy0)
     * Igor Popov (ihptru)
     * Iran
     * James Dunne (jsd)

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -229,5 +229,15 @@ namespace OpenRA.Graphics
 			Flush();
 			Device.DisableDepthBuffer();
 		}
+
+		public void GrabWindowMouseFocus()
+		{
+			device.GrabWindowMouseFocus();
+		}
+
+		public void ReleaseWindowMouseFocus()
+		{
+			device.ReleaseWindowMouseFocus();
+		}
 	}
 }

--- a/OpenRA.Game/IGraphicsDevice.cs
+++ b/OpenRA.Game/IGraphicsDevice.cs
@@ -58,6 +58,9 @@ namespace OpenRA
 		void DisableDepthBuffer();
 
 		void SetBlendMode(BlendMode mode);
+
+		void GrabWindowMouseFocus();
+		void ReleaseWindowMouseFocus();
 	}
 
 	public interface IVertexBuffer<T>

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -129,7 +129,7 @@ namespace OpenRA
 		public bool ShowShellmap = true;
 
 		public bool ViewportEdgeScroll = true;
-		public bool LockMouseWindow = true;
+		public bool LockMouseWindow = false;
 		public MouseScrollType MouseScroll = MouseScrollType.Standard;
 		public float ViewportEdgeScrollStep = 10f;
 		public float UIScrollSpeed = 50f;

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -293,6 +293,18 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			BindSliderPref(panel, "SCROLLSPEED_SLIDER", gs, "ViewportEdgeScrollStep");
 			BindSliderPref(panel, "UI_SCROLLSPEED_SLIDER", gs, "UIScrollSpeed");
 
+			// Apply mouse focus preferences immediately
+			var lockMouseCheckbox = panel.Get<CheckboxWidget>("LOCKMOUSE_CHECKBOX");
+			var oldOnClick = lockMouseCheckbox.OnClick;
+			lockMouseCheckbox.OnClick = () =>
+			{
+				// Still perform the old behaviour for clicking the checkbox, before
+				// applying the changes live.
+				oldOnClick();
+
+				MakeMouseFocusSettingsLive();
+			};
+
 			var mouseScrollDropdown = panel.Get<DropDownButtonWidget>("MOUSE_SCROLL");
 			mouseScrollDropdown.OnMouseDown = _ => ShowMouseScrollDropdown(mouseScrollDropdown, gs);
 			mouseScrollDropdown.GetText = () => gs.MouseScroll.ToString();
@@ -362,6 +374,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				panel.Get<SliderWidget>("SCROLLSPEED_SLIDER").Value = gs.ViewportEdgeScrollStep;
 				panel.Get<SliderWidget>("UI_SCROLLSPEED_SLIDER").Value = gs.UIScrollSpeed;
+
+				MakeMouseFocusSettingsLive();
 			};
 		}
 
@@ -480,6 +494,16 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, Game.modData.Languages, setupItem);
 			return true;
+		}
+
+		void MakeMouseFocusSettingsLive()
+		{
+			var gameSettings = Game.Settings.Game;
+
+			if (gameSettings.LockMouseWindow)
+				Game.Renderer.GrabWindowMouseFocus();
+			else
+				Game.Renderer.ReleaseWindowMouseFocus();
 		}
 	}
 }

--- a/OpenRA.Renderer.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Renderer.Null/NullGraphicsDevice.cs
@@ -45,6 +45,9 @@ namespace OpenRA.Renderer.Null
 
 		public void SetBlendMode(BlendMode mode) { }
 
+		public void GrabWindowMouseFocus() { }
+		public void ReleaseWindowMouseFocus() { }
+
 		public void Clear() { }
 		public void Present() { }
 

--- a/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
@@ -63,8 +63,10 @@ namespace OpenRA.Renderer.Sdl2
 
 			window = SDL.SDL_CreateWindow("OpenRA", SDL.SDL_WINDOWPOS_CENTERED, SDL.SDL_WINDOWPOS_CENTERED, size.Width, size.Height, SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL);
 
-			var lockWindow = Game.Settings.Game.LockMouseWindow ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE;
-			SDL.SDL_SetWindowGrab(window, lockWindow);
+			if (Game.Settings.Game.LockMouseWindow)
+				GrabWindowMouseFocus();
+			else
+				ReleaseWindowMouseFocus();
 
 			if (windowMode == WindowMode.Fullscreen)
 				SDL.SDL_SetWindowFullscreen(window, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN);
@@ -197,6 +199,16 @@ namespace OpenRA.Renderer.Sdl2
 			}
 
 			ErrorHandler.CheckGlError();
+		}
+
+		public void GrabWindowMouseFocus() 
+		{
+			SDL.SDL_SetWindowGrab(window, SDL.SDL_bool.SDL_TRUE);
+		}
+
+		public void ReleaseWindowMouseFocus()
+		{ 
+			SDL.SDL_SetWindowGrab(window, SDL.SDL_bool.SDL_FALSE);
 		}
 
 		public void EnableScissor(int left, int top, int width, int height)

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -318,14 +318,6 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Lock mouse to window
-						Label@LOCKMOUSE_DESC:
-							X: 25
-							Y: 110
-							Width: 130
-							Height: 25
-							Font: Tiny
-							Align: Right
-							Text: (Requires restart)
 						Label@SCROLL_SPEED_LABEL:
 							X: PARENT_RIGHT - WIDTH - 270
 							Y: 67

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -322,14 +322,6 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Lock mouse to window
-				Label@LOCKMOUSE_DESC:
-					X: 25
-					Y: 110
-					Width: 130
-					Height: 25
-					Font: Tiny
-					Align: Right
-					Text: (Requires restart)
 				Label@SCROLL_SPEED_LABEL:
 					X: PARENT_RIGHT - WIDTH - 270
 					Y: 67


### PR DESCRIPTION
I have removed the requirement for the game to be restarted after applying changes to the 'lock mouse to window' option in the 'Input' tab of the settings menu. I had to add a bit of plumbing between IGraphicsDevice and SettingsLogic to achieve this.
