### PR TITLE
Offer user quick restart if settings change

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -14,8 +14,8 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net;
-using OpenRA.FileSystem;
 using MaxMind.GeoIP2;
+using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -464,7 +464,7 @@ namespace OpenRA
 			return shellmaps.Random(CosmeticRandom);
 		}
 
-		static bool quit;
+		static RunStatus state = RunStatus.Running;
 		public static event Action OnQuit = () => { };
 
 		static double idealFrameTime;
@@ -473,7 +473,7 @@ namespace OpenRA
 			idealFrameTime = 1.0 / fps;
 		}
 
-		internal static void Run()
+		internal static RunStatus Run()
 		{
 			if (Settings.Graphics.MaxFramerate < 1)
 			{
@@ -483,7 +483,7 @@ namespace OpenRA
 
 			SetIdealFrameTime(Settings.Graphics.MaxFramerate);
 
-			while (!quit)
+			while (state == RunStatus.Running)
 			{
 				if (Settings.Graphics.CapFramerate)
 				{
@@ -506,9 +506,19 @@ namespace OpenRA
 			Renderer.Device.Dispose();
 
 			OnQuit();
+
+			return state;
 		}
 
-		public static void Exit() { quit = true; }
+		public static void Exit()
+		{
+			state = RunStatus.Success;
+		}
+
+		public static void Restart()
+		{
+			state = RunStatus.Restart;
+		}
 
 		public static Action<Color, string, string> AddChatLine = (c, n, s) => { };
 

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -111,23 +111,13 @@ namespace OpenRA
 
 		static RunStatus Run(string[] args)
 		{
-			if (AppDomain.CurrentDomain.IsDefaultAppDomain())
-			{
-				var name = Assembly.GetEntryAssembly().GetName();
-				int retCode;
-				do
-				{
-					var domain = AppDomain.CreateDomain("Game");
-					retCode = domain.ExecuteAssemblyByName(name, args);
-					AppDomain.Unload(domain);
-				}
-				while (retCode == (int)RunStatus.Restart);
-				return RunStatus.Success;
-			}
-
 			Game.Initialize(new Arguments(args));
 			GC.Collect();
-			return Game.Run();
+			var status = Game.Run();
+			if (status == RunStatus.Restart)
+				using (var p = Process.GetCurrentProcess())
+					Process.Start(Assembly.GetEntryAssembly().Location, p.StartInfo.Arguments);
+			return status;
 		}
 	}
 }

--- a/OpenRA.Renderer.Sdl2/Sdl2Input.cs
+++ b/OpenRA.Renderer.Sdl2/Sdl2Input.cs
@@ -170,9 +170,7 @@ namespace OpenRA.Renderer.Sdl2
 						// Special case workaround for windows users
 						if (e.key.keysym.sym == SDL.SDL_Keycode.SDLK_F4 && mods.HasModifier(Modifiers.Alt) &&
 							Platform.CurrentPlatform == PlatformType.Windows)
-						{
 							Game.Exit();
-						}
 						else
 							inputHandler.OnKeyInput(keyEvent);
 


### PR DESCRIPTION
Ever been annoyed by those settings in the menu that require a restart? Well I haven't fixed those. But I have added a little dialog to save you some time! That's almost as good right?

![Restart Now?](http://imgur.com/HQJr5fT.png)

Hit the button and the game will be loading again within a second or two.

Doesn't check for mouse-lock in anticipation of #5597 landing.
