### PR TITLE
Minor allocation tweaks

### DIFF
--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -51,6 +51,7 @@ namespace OpenRA.Traits
 		// to ensure consistency during a tick
 		readonly List<Actor> addActorPosition = new List<Actor>();
 		readonly HashSet<Actor> removeActorPosition = new HashSet<Actor>();
+		readonly Predicate<Actor> actorShouldBeRemoved;
 
 		public ActorMap(World world, ActorMapInfo info)
 		{
@@ -64,6 +65,9 @@ namespace OpenRA.Traits
 			for (var j = 0; j < rows; j++)
 				for (var i = 0; i < cols; i++)
 					actors[j * cols + i] = new List<Actor>();
+
+			// Cache this delegate so it does not have to be allocated repeatedly.
+			actorShouldBeRemoved = removeActorPosition.Contains;
 		}
 
 		public IEnumerable<Actor> GetUnitsAt(CPos a)
@@ -144,7 +148,7 @@ namespace OpenRA.Traits
 			// Position updates are done in one pass
 			// to ensure consistency during a tick
 			foreach (var bin in actors)
-				bin.RemoveAll(removeActorPosition.Contains);
+				bin.RemoveAll(actorShouldBeRemoved);
 
 			removeActorPosition.Clear();
 

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA
 		public bool IsReachableTarget(Target target, bool allowMove)
 		{
 			return HasAnyValidWeapons(target)
-				&& (target.IsInRange(self.CenterPosition, GetMaximumRange()) || (self.HasTrait<IMove>() && allowMove));
+				&& (target.IsInRange(self.CenterPosition, GetMaximumRange()) || (allowMove && self.HasTrait<IMove>()));
 		}
 
 		class AttackOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -119,10 +119,12 @@ namespace OpenRA.Mods.RA
 
 		public Actor ScanForTarget(Actor self, Actor currentTarget)
 		{
-			var range = info.ScanRadius > 0 ? WRange.FromCells(info.ScanRadius) : attack.GetMaximumRange();
-			if (self.IsIdle || currentTarget == null || !Target.FromActor(currentTarget).IsInRange(self.CenterPosition, range))
-				if (nextScanTime <= 0)
+			if (nextScanTime <= 0)
+			{
+				var range = info.ScanRadius > 0 ? WRange.FromCells(info.ScanRadius) : attack.GetMaximumRange();
+				if (self.IsIdle || currentTarget == null || !Target.FromActor(currentTarget).IsInRange(self.CenterPosition, range))
 					return ChooseTarget(self, range);
+			}
 
 			return currentTarget;
 		}
@@ -148,10 +150,11 @@ namespace OpenRA.Mods.RA
 			var inRange = self.World.FindActorsInCircle(self.CenterPosition, range);
 
 			return inRange
-				.Where(a => a.AppearsHostileTo(self))
-				.Where(a => !a.HasTrait<AutoTargetIgnore>())
-				.Where(a => attack.HasAnyValidWeapons(Target.FromActor(a)))
-				.Where(a => self.Owner.Shroud.IsTargetable(a))
+				.Where(a =>
+					a.AppearsHostileTo(self) &&
+					!a.HasTrait<AutoTargetIgnore>() &&
+					attack.HasAnyValidWeapons(Target.FromActor(a)) &&
+					self.Owner.Shroud.IsTargetable(a))
 				.ClosestTo(self);
 		}
 	}


### PR DESCRIPTION
A handful of small changes to reduce allocations in the main loop.

These were found via profiling, so whilst only small tweaks they should net a nice 2-3% saving in memory allocations each tick. Plus a little CPU too I should think.
