### PR TITLE
Invalidate FrozenActors that don’t have any sprites.

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Traits
 		}
 
 		public uint ID { get { return actor.ActorID; } }
-		public bool IsValid { get { return Owner != null; } }
+		public bool IsValid { get { return Owner != null && HasRenderables; } }
 		public ActorInfo Info { get { return actor.Info; } }
 		public Actor Actor { get { return !actor.IsDead() ? actor : null; } }
 
@@ -87,7 +87,7 @@ namespace OpenRA.Traits
 			return Renderables;
 		}
 
-		public bool HasRenderables { get { return Renderables != null; } }
+		public bool HasRenderables { get { return Renderables != null && Renderables.Any(); } }
 
 		public override string ToString()
 		{

--- a/OpenRA.Game/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportControllerWidget.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Widgets
 			}
 
 			var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos))
-				.Where(a => a.TooltipName != null)
+				.Where(a => a.TooltipName != null && a.IsValid)
 				.WithHighestSelectionPriority();
 
 			if (frozen != null)


### PR DESCRIPTION
Fixes #4809.
