### PR TITLE
Introduce CellLayer and CellRegion abstractions.

### DIFF
--- a/OpenRA.Editor/BrushTool.cs
+++ b/OpenRA.Editor/BrushTool.cs
@@ -75,9 +75,10 @@ namespace OpenRA.Editor
 
 			Action<int, int> maybeEnqueue = (x, y) =>
 			{
-				if (s.Map.IsInMap(x, y) && !touched[x, y])
+				var c = new CPos(x, y);
+				if (s.Map.IsInMap(c) && !touched[x, y])
 				{
-					queue.Enqueue(new CPos(x, y));
+					queue.Enqueue(c);
 					touched[x, y] = true;
 				}
 			};

--- a/OpenRA.Editor/BrushTool.cs
+++ b/OpenRA.Editor/BrushTool.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Editor
 				for (var v = 0; v < template.Size.Y; v++)
 				{
 					var cell = pos + new CVec(u, v);
-					if (surface.Map.IsInMap(cell))
+					if (surface.Map.Contains(cell))
 					{
 						var z = u + v * template.Size.X;
 						if (tile[z].Length > 0)
@@ -75,7 +75,7 @@ namespace OpenRA.Editor
 			Action<int, int> maybeEnqueue = (x, y) =>
 			{
 				var c = new CPos(x, y);
-				if (s.Map.IsInMap(c) && !touched[x, y])
+				if (s.Map.Contains(c) && !touched[x, y])
 				{
 					queue.Enqueue(c);
 					touched[x, y] = true;
@@ -112,7 +112,7 @@ namespace OpenRA.Editor
 			for (;;)
 			{
 				var q = p + d;
-				if (!s.Map.IsInMap(q)) return p;
+				if (!s.Map.Contains(q)) return p;
 				if (s.Map.MapTiles.Value[q].Type != replace.Type) return p;
 				p = q;
 			}

--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -657,7 +657,7 @@ namespace OpenRA.Editor
 				{
 					var cell = new CPos(x + u, y + v);
 
-					if (!surface1.Map.IsInMap(cell))
+					if (!surface1.Map.Contains(cell))
 						continue;
 
 					if (surface1.Map.MapResources.Value[cell].Type == resourceType)

--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -641,7 +641,8 @@ namespace OpenRA.Editor
 			for (var i = 0; i < surface1.Map.MapSize.X; i++)
 				for (var j = 0; j < surface1.Map.MapSize.Y; j++)
 				{
-					if (surface1.Map.MapResources.Value[i, j].Type != 0)
+					var cell = new CPos(i, j);
+					if (surface1.Map.MapResources.Value[cell].Type != 0)
 						totalResource += GetResourceValue(i, j);
 				}
 
@@ -654,9 +655,12 @@ namespace OpenRA.Editor
 			for (var u = -1; u < 2; u++)
 				for (var v = -1; v < 2; v++)
 				{
-					if (!surface1.Map.IsInMap(new CPos(x + u, y + v)))
+					var cell = new CPos(x + u, y + v);
+
+					if (!surface1.Map.IsInMap(cell))
 						continue;
-					if (surface1.Map.MapResources.Value[x + u, y + v].Type == resourceType)
+
+					if (surface1.Map.MapResources.Value[cell].Type == resourceType)
 						++sum;
 				}
 
@@ -666,7 +670,7 @@ namespace OpenRA.Editor
 		int GetResourceValue(int x, int y)
 		{
 			var imageLength = 0;
-			int type = surface1.Map.MapResources.Value[x, y].Type;
+			var type = surface1.Map.MapResources.Value[new CPos(x, y)].Type;
 			var template = surface1.ResourceTemplates.FirstOrDefault(a => a.Value.Info.ResourceType == type).Value;
 			if (type == 1)
 				imageLength = 12;

--- a/OpenRA.Editor/ResourceTool.cs
+++ b/OpenRA.Editor/ResourceTool.cs
@@ -21,12 +21,9 @@ namespace OpenRA.Editor
 
 		public void Apply(Surface surface)
 		{
-			surface.Map.MapResources.Value[surface.GetBrushLocation().X, surface.GetBrushLocation().Y]
-				= new TileReference<byte, byte>
-				{
-					Type = (byte)resourceTemplate.Info.ResourceType,
-					Index = (byte)random.Next(resourceTemplate.Info.MaxDensity)
-				};
+			var type = (byte)resourceTemplate.Info.ResourceType;
+			var index = (byte)random.Next(resourceTemplate.Info.MaxDensity);
+			surface.Map.MapResources.Value[surface.GetBrushLocation()] = new ResourceTile(type, index);
 
 			var ch = new int2(surface.GetBrushLocation().X / Surface.ChunkSize,
 				surface.GetBrushLocation().Y / Surface.ChunkSize);

--- a/OpenRA.Editor/Surface.cs
+++ b/OpenRA.Editor/Surface.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Editor
 		public bool ShowRuler;
 
 		public bool IsPaste { get { return TileSelection != null && ResourceSelection != null; } }
-		public TileReference<ushort, byte>[,] TileSelection;
+		public TerrainTile[,] TileSelection;
 		public ResourceTile[,] ResourceSelection;
 		public CPos SelectionStart;
 		public CPos SelectionEnd;
@@ -272,7 +272,7 @@ namespace OpenRA.Editor
 					for (var j = 0; j < ChunkSize; j++)
 					{
 						var cell = new CPos(u * ChunkSize + i, v * ChunkSize + j);
-						var tr = Map.MapTiles.Value[u * ChunkSize + i, v * ChunkSize + j];
+						var tr = Map.MapTiles.Value[cell];
 						var tile = TileSetRenderer.Data(tr.Type);
 						var index = (tr.Index < tile.Count) ? tr.Index : (byte)0;
 						var rawImage = tile[index];
@@ -509,7 +509,7 @@ namespace OpenRA.Editor
 			var width = Math.Abs((start - end).X);
 			var height = Math.Abs((start - end).Y);
 
-			TileSelection = new TileReference<ushort, byte>[width, height];
+			TileSelection = new TerrainTile[width, height];
 			ResourceSelection = new ResourceTile[width, height];
 
 			for (var x = 0; x < width; x++)
@@ -518,7 +518,7 @@ namespace OpenRA.Editor
 				{
 					// TODO: crash prevention
 					var cell = new CPos(start.X + x, start.Y + y);
-					TileSelection[x, y] = Map.MapTiles.Value[start.X + x, start.Y + y];
+					TileSelection[x, y] = Map.MapTiles.Value[cell];
 					ResourceSelection[x, y] = Map.MapResources.Value[cell];
 				}
 			}
@@ -539,7 +539,7 @@ namespace OpenRA.Editor
 					var cell = new CPos(mapX, mapY);
 
 					// TODO: crash prevention for outside of bounds
-					Map.MapTiles.Value[mapX, mapY] = TileSelection[x, y];
+					Map.MapTiles.Value[cell] = TileSelection[x, y];
 					Map.MapResources.Value[cell] = ResourceSelection[x, y];
 
 					var ch = new int2(mapX / ChunkSize, mapY / ChunkSize);

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -180,7 +180,7 @@ namespace OpenRA.GameRules
 			if (target.Type == TargetType.Terrain)
 			{
 				var cell = target.CenterPosition.ToCPos();
-				if (!world.Map.IsInMap(cell))
+				if (!world.Map.Contains(cell))
 					return false;
 
 				var cellInfo = world.Map.GetTerrainInfo(cell);

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Graphics
 
 					var color = t.Trait.RadarSignatureColor(t.Actor);
 					foreach (var cell in t.Trait.RadarSignatureCells(t.Actor))
-						if (world.Map.IsInMap(cell))
+						if (world.Map.Contains(cell))
 							*(c + ((cell.Y - world.Map.Bounds.Top) * bitmapData.Stride >> 2) + cell.X - world.Map.Bounds.Left) = color.ToArgb();
 				}
 			}

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -74,8 +74,9 @@ namespace OpenRA.Graphics
 							continue;
 
 						var res = resourceRules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>()
-								.Where(t => t.ResourceType == map.MapResources.Value[mapX, mapY].Type)
+							.Where(t => t.ResourceType == map.MapResources.Value[mapX, mapY].Type)
 								.Select(t => t.TerrainType).FirstOrDefault();
+
 						if (res == null)
 							continue;
 

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -46,9 +46,9 @@ namespace OpenRA.Graphics
 		public void Draw(WorldRenderer wr, Viewport viewport)
 		{
 			var verticesPerRow = 4*map.Bounds.Width;
-			var bounds = viewport.CellBounds;
-			var firstRow = bounds.Top - map.Bounds.Top;
-			var lastRow = bounds.Bottom - map.Bounds.Top;
+			var cells = viewport.VisibleCells;
+			var firstRow = cells.TopLeft.Y - map.Bounds.Top;
+			var lastRow = cells.BottomRight.Y - map.Bounds.Top + 1;
 
 			if (lastRow < 0 || firstRow > map.Bounds.Height)
 				return;

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -28,15 +28,12 @@ namespace OpenRA.Graphics
 			var vertices = new Vertex[4 * map.Bounds.Height * map.Bounds.Width];
 			var nv = 0;
 
-			for (var j = map.Bounds.Top; j < map.Bounds.Bottom; j++)
+			foreach (var cell in map.Cells)
 			{
-				for (var i = map.Bounds.Left; i < map.Bounds.Right; i++)
-				{
-					var tile = wr.Theater.TileSprite(map.MapTiles.Value[i, j]);
-					var pos = wr.ScreenPosition(new CPos(i, j).CenterPosition) - 0.5f * tile.size;
-					Util.FastCreateQuad(vertices, pos, tile, terrainPalette, nv, tile.size);
-					nv += 4;
-				}
+				var tile = wr.Theater.TileSprite(map.MapTiles.Value[cell]);
+				var pos = wr.ScreenPosition(cell.CenterPosition) - 0.5f * tile.size;
+				Util.FastCreateQuad(vertices, pos, tile, terrainPalette, nv, tile.size);
+				nv += 4;
 			}
 
 			vertexBuffer = Game.Renderer.Device.CreateVertexBuffer(vertices.Length);

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Graphics
 			missingTile = sheetBuilder.Add(new byte[1], new Size(1, 1));
 		}
 
-		public Sprite TileSprite(TileReference<ushort, byte> r)
+		public Sprite TileSprite(TerrainTile r)
 		{
 			Sprite[] template;
 			if (!templates.TryGetValue(r.Type, out template))

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -1,0 +1,105 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Graphics;
+
+namespace OpenRA
+{
+	// Represents a layer of "something" that covers the map
+	public class CellLayer<T> : IEnumerable<T>
+	{
+		public readonly Size Size;
+		T[] entries;
+
+		public CellLayer(Map map)
+			: this(new Size(map.MapSize.X, map.MapSize.Y)) { }
+
+		public CellLayer(Size size)
+		{
+			Size = size;
+			entries = new T[size.Width * size.Height];
+		}
+
+		// Resolve an array index from cell coordinates
+		int Index(CPos cell)
+		{
+			// This will eventually define a distinct case for diagonal cell grids
+			return cell.Y * Size.Width + cell.X;
+		}
+
+		/// <summary>Gets or sets the <see cref="OpenRA.CellLayer"/> using cell coordinates</summary>
+		public T this[CPos cell]
+		{
+			get
+			{
+				return entries[Index(cell)];
+			}
+
+			set
+			{
+				entries[Index(cell)] = value;
+			}
+		}
+
+		/// <summary>Gets or sets the layer contents using raw map coordinates (not CPos!)</summary>
+		public T this[int u, int v]
+		{
+			get
+			{
+				return entries[v * Size.Width + u];
+			}
+
+			set
+			{
+				entries[v * Size.Width + u] = value;
+			}
+		}
+
+		/// <summary>Clears the layer contents with a known value</summary>
+		public void Clear(T clearValue)
+		{
+			for (var i = 0; i < entries.Length; i++)
+				entries[i] = clearValue;
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			return (IEnumerator<T>)entries.GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+	}
+
+	// Helper functions
+	public static class CellLayer
+	{
+		/// <summary>Create a new layer by resizing another layer.  New cells are filled with defaultValue.</summary>
+		public static CellLayer<T> Resize<T>(CellLayer<T> layer, Size newSize, T defaultValue)
+		{
+			var result = new CellLayer<T>(newSize);
+			var width = Math.Min(layer.Size.Width, newSize.Width);
+			var height = Math.Min(layer.Size.Height, newSize.Height);
+
+			result.Clear(defaultValue);
+			for (var j = 0; j < height; j++)
+				for (var i = 0; i < width; i++)
+					result[i, j] = layer[i, j];
+
+			return result;
+		}
+	}
+}

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -1,0 +1,101 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Graphics;
+
+namespace OpenRA
+{
+	// Represents a (on-screen) rectangular collection of tiles.
+	// TopLeft and BottomRight are inclusive
+	public class CellRegion : IEnumerable<CPos>
+	{
+		// Corners of the region
+		public readonly CPos TopLeft;
+		public readonly CPos BottomRight;
+
+		// Corners in map coordinates
+		// Defined for forward compatibility with diagonal cell grids
+		readonly CPos mapTopLeft;
+		readonly CPos mapBottomRight;
+
+		public CellRegion(CPos topLeft, CPos bottomRight)
+		{
+			TopLeft = topLeft;
+			BottomRight = bottomRight;
+
+			mapTopLeft = TopLeft;
+			mapBottomRight = BottomRight;
+		}
+
+		public bool Contains(CPos cell)
+		{
+			// Defined for forward compatibility with diagonal cell grids
+			var uv = cell;
+			return uv.X >= mapTopLeft.X && uv.X <= mapBottomRight.X && uv.Y >= mapTopLeft.Y && uv.Y <= mapBottomRight.Y;
+		}
+
+		public IEnumerator<CPos> GetEnumerator()
+		{
+			return new CellRegionEnumerator(this);
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		class CellRegionEnumerator : IEnumerator<CPos>
+		{
+			readonly CellRegion r;
+
+			// Current position, in map coordinates
+			int u, v;
+
+			public CellRegionEnumerator(CellRegion region)
+			{
+				r = region;
+				Reset();
+			}
+
+			public bool MoveNext()
+			{
+				u += 1;
+
+				// Check for column overflow
+				if (u > r.mapBottomRight.X)
+				{
+					v += 1;
+					u = r.mapTopLeft.X;
+
+					// Check for row overflow
+					if (v > r.mapBottomRight.Y)
+						return false;
+				}
+
+				return true;
+			}
+
+			public void Reset()
+			{
+				// Enumerator starts *before* the first element in the sequence.
+				u = r.mapTopLeft.X - 1;
+				v = r.mapTopLeft.Y;
+			}
+
+			public CPos Current { get { return new CPos(u, v); } }
+			object IEnumerator.Current { get { return Current; } }
+			public void Dispose() { }
+		}
+	}
+}

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -461,8 +461,7 @@ namespace OpenRA
 			return dataStream.ToArray();
 		}
 
-		public bool IsInMap(CPos xy) { return IsInMap(xy.X, xy.Y); }
-		public bool IsInMap(int x, int y) { return Bounds.Contains(x, y); }
+		public bool IsInMap(CPos xy) { return Bounds.Contains(xy.X, xy.Y); }
 
 		public void Resize(int width, int height)		// editor magic.
 		{

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -461,7 +461,7 @@ namespace OpenRA
 			return dataStream.ToArray();
 		}
 
-		public bool IsInMap(CPos xy) { return Bounds.Contains(xy.X, xy.Y); }
+		public bool Contains(CPos xy) { return Bounds.Contains(xy.X, xy.Y); }
 
 		public void Resize(int width, int height)		// editor magic.
 		{
@@ -638,7 +638,7 @@ namespace OpenRA
 				foreach (var offset in TilesByDistance[i])
 				{
 					var t = offset + center;
-					if (IsInMap(t))
+					if (Contains(t))
 						yield return t;
 				}
 			}

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -113,7 +113,7 @@ namespace OpenRA
 
 		[FieldLoader.Ignore] public Lazy<TileReference<ushort, byte>[,]> MapTiles;
 		[FieldLoader.Ignore] public Lazy<TileReference<byte, byte>[,]> MapResources;
-		[FieldLoader.Ignore] public int[,] CustomTerrain;
+		[FieldLoader.Ignore] public CellLayer<int> CustomTerrain;
 
 		[FieldLoader.Ignore] Lazy<Ruleset> rules;
 		public Ruleset Rules { get { return rules != null ? rules.Value : null; } }
@@ -257,9 +257,9 @@ namespace OpenRA
 			var br = new CPos(Bounds.Right - 1, Bounds.Bottom - 1);
 			Cells = new CellRegion(tl, br);
 
-			CustomTerrain = new int[MapSize.X, MapSize.Y];
+			CustomTerrain = new CellLayer<int>(this);
 			foreach (var cell in Cells)
-				CustomTerrain[cell.X, cell.Y] = -1;
+				CustomTerrain[cell] = -1;
 		}
 
 		public Ruleset PreloadRules()
@@ -548,7 +548,7 @@ namespace OpenRA
 
 		public int GetTerrainIndex(CPos cell)
 		{
-			var custom = CustomTerrain[cell.X, cell.Y];
+			var custom = CustomTerrain[cell];
 			var tileSet = Rules.TileSets[Tileset];
 			return custom != -1 ? custom : tileSet.GetTerrainIndex(MapTiles.Value[cell.X, cell.Y]);
 		}

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -633,12 +633,12 @@ namespace OpenRA
 			if (range >= TilesByDistance.Length)
 				throw new InvalidOperationException("FindTilesInCircle supports queries for only <= {0}".F(MaxTilesInCircleRange));
 
-			for(var i = 0; i <= range; i++)
+			for (var i = 0; i <= range; i++)
 			{
-				foreach(var offset in TilesByDistance[i])
+				foreach (var offset in TilesByDistance[i])
 				{
 					var t = offset + center;
-					if (Bounds.Contains(t.X, t.Y))
+					if (IsInMap(t))
 						yield return t;
 				}
 			}

--- a/OpenRA.Game/Map/TileReference.cs
+++ b/OpenRA.Game/Map/TileReference.cs
@@ -23,4 +23,18 @@ namespace OpenRA
 
 		public override int GetHashCode() { return Type.GetHashCode() ^ Index.GetHashCode(); }
 	}
+
+	public struct ResourceTile
+	{
+		public readonly byte Type;
+		public readonly byte Index;
+
+		public ResourceTile(byte type, byte index)
+		{
+			Type = type;
+			Index = index;
+		}
+
+		public override int GetHashCode() { return Type.GetHashCode() ^ Index.GetHashCode(); }
+	}
 }

--- a/OpenRA.Game/Map/TileReference.cs
+++ b/OpenRA.Game/Map/TileReference.cs
@@ -10,15 +10,15 @@
 
 namespace OpenRA
 {
-	public struct TileReference<T, U>
+	public struct TerrainTile
 	{
-		public T Type;
-		public U Index;
+		public readonly ushort Type;
+		public readonly byte Index;
 
-		public TileReference(T t, U i)
+		public TerrainTile(ushort type, byte index)
 		{
-			Type = t;
-			Index = i;
+			Type = type;
+			Index = index;
 		}
 
 		public override int GetHashCode() { return Type.GetHashCode() ^ Index.GetHashCode(); }

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -223,7 +223,7 @@ namespace OpenRA
 			throw new InvalidDataException("Tileset '{0}' lacks terrain type '{1}'".F(Id, type));
 		}
 
-		public int GetTerrainIndex(TileReference<ushort, byte> r)
+		public int GetTerrainIndex(TerrainTile r)
 		{
 			var tpl = Templates[r.Type];
 
@@ -261,7 +261,7 @@ namespace OpenRA
 			root.WriteToFile(filepath);
 		}
 
-		public TerrainTypeInfo GetTerrainInfo(TileReference<ushort, byte> r)
+		public TerrainTypeInfo GetTerrainInfo(TerrainTile r)
 		{
 			return terrainInfo[GetTerrainIndex(r)];
 		}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -235,6 +235,8 @@
     <Compile Include="Support\MersenneTwister.cs" />
     <Compile Include="GameInformation.cs" />
     <Compile Include="Widgets\RootWidget.cs" />
+    <Compile Include="Map\CellLayer.cs" />
+    <Compile Include="Map\CellRegion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Game/Orders/GenericSelectTarget.cs
+++ b/OpenRA.Game/Orders/GenericSelectTarget.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Orders
 
 		IEnumerable<Order> OrderInner(World world, CPos xy, MouseInput mi)
 		{
-			if (mi.Button == expectedButton && world.Map.IsInMap(xy))
+			if (mi.Button == expectedButton && world.Map.Contains(xy))
 			{
 				world.CancelInputMode();
 				foreach (var subject in subjects)
@@ -66,6 +66,6 @@ namespace OpenRA.Orders
 		public virtual void Tick(World world) { }
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public void RenderAfterWorld(WorldRenderer wr, World world) { }
-		public string GetCursor(World world, CPos xy, MouseInput mi) { return world.Map.IsInMap(xy) ? cursor : "generic-blocked"; }
+		public string GetCursor(World world, CPos xy, MouseInput mi) { return world.Map.Contains(xy) ? cursor : "generic-blocked"; }
 	}
 }

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<Actor> GetUnitsAt(CPos a)
 		{
-			if (!map.IsInMap(a))
+			if (!map.Contains(a))
 				yield break;
 
 			for (var i = influence[a]; i != null; i = i.Next)
@@ -81,7 +81,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<Actor> GetUnitsAt(CPos a, SubCell sub)
 		{
-			if (!map.IsInMap(a))
+			if (!map.Contains(a))
 				yield break;
 
 			for (var i = influence[a]; i != null; i = i.Next)

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -206,5 +206,11 @@ namespace OpenRA.Traits
 				}
 			}
 		}
+
+		public IEnumerable<Actor> ActorsInWorld()
+		{
+			return actors.SelectMany(a => a.Where(b => b.IsInWorld))
+				.Distinct();
+		}
 	}
 }

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Traits
 
 		readonly ActorMapInfo info;
 		readonly Map map;
-		InfluenceNode[,] influence;
+		readonly CellLayer<InfluenceNode> influence;
 
 		List<Actor>[] actors;
 		int rows, cols;
@@ -56,7 +56,7 @@ namespace OpenRA.Traits
 		{
 			this.info = info;
 			map = world.Map;
-			influence = new InfluenceNode[world.Map.MapSize.X, world.Map.MapSize.Y];
+			influence = new CellLayer<InfluenceNode>(world.Map);
 
 			cols = world.Map.MapSize.X / info.BinSize + 1;
 			rows = world.Map.MapSize.Y / info.BinSize + 1;
@@ -74,7 +74,7 @@ namespace OpenRA.Traits
 			if (!map.IsInMap(a))
 				yield break;
 
-			for (var i = influence[a.X, a.Y]; i != null; i = i.Next)
+			for (var i = influence[a]; i != null; i = i.Next)
 				if (!i.Actor.Destroyed)
 					yield return i.Actor;
 		}
@@ -84,7 +84,7 @@ namespace OpenRA.Traits
 			if (!map.IsInMap(a))
 				yield break;
 
-			for (var i = influence[a.X, a.Y]; i != null; i = i.Next)
+			for (var i = influence[a]; i != null; i = i.Next)
 				if (!i.Actor.Destroyed && (i.SubCell == sub || i.SubCell == SubCell.FullCell))
 					yield return i.Actor;
 		}
@@ -107,12 +107,12 @@ namespace OpenRA.Traits
 
 		public bool AnyUnitsAt(CPos a)
 		{
-			return influence[a.X, a.Y] != null;
+			return influence[a] != null;
 		}
 
 		public bool AnyUnitsAt(CPos a, SubCell sub)
 		{
-			for (var i = influence[a.X, a.Y]; i != null; i = i.Next)
+			for (var i = influence[a]; i != null; i = i.Next)
 				if (i.SubCell == sub || i.SubCell == SubCell.FullCell)
 					return true;
 
@@ -122,20 +122,25 @@ namespace OpenRA.Traits
 		public void AddInfluence(Actor self, IOccupySpace ios)
 		{
 			foreach (var c in ios.OccupiedCells())
-				influence[c.First.X, c.First.Y] = new InfluenceNode { Next = influence[c.First.X, c.First.Y], SubCell = c.Second, Actor = self };
+				influence[c.First] = new InfluenceNode { Next = influence[c.First], SubCell = c.Second, Actor = self };
 		}
 
 		public void RemoveInfluence(Actor self, IOccupySpace ios)
 		{
 			foreach (var c in ios.OccupiedCells())
-				RemoveInfluenceInner(ref influence[c.First.X, c.First.Y], self);
+			{
+				var temp = influence[c.First];
+				RemoveInfluenceInner(ref temp, self);
+				influence[c.First] = temp;
+			}
 		}
 
 		void RemoveInfluenceInner(ref InfluenceNode influenceNode, Actor toRemove)
 		{
 			if (influenceNode == null)
 				return;
-			else if (influenceNode.Actor == toRemove)
+
+			if (influenceNode.Actor == toRemove)
 				influenceNode = influenceNode.Next;
 
 			if (influenceNode != null)

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Traits
 
 		public bool AllowResourceAt(ResourceType rt, CPos cell)
 		{
-			if (!world.Map.IsInMap(cell))
+			if (!world.Map.Contains(cell))
 				return false;
 
 			if (!rt.Info.AllowedTerrainTypes.Contains(world.Map.GetTerrainInfo(cell).Type))

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Traits
 
 		CellContents CreateResourceCell(ResourceType t, CPos cell)
 		{
-			world.Map.CustomTerrain[cell.X, cell.Y] = world.TileSet.GetTerrainIndex(t.Info.TerrainType);
+			world.Map.CustomTerrain[cell] = world.TileSet.GetTerrainIndex(t.Info.TerrainType);
 
 			return new CellContents
 			{
@@ -190,7 +190,7 @@ namespace OpenRA.Traits
 			if (--c.Density < 0)
 			{
 				content[cell] = EmptyCell;
-				world.Map.CustomTerrain[cell.X, cell.Y] = -1;
+				world.Map.CustomTerrain[cell] = -1;
 			}
 			else
 				content[cell] = c;
@@ -209,7 +209,7 @@ namespace OpenRA.Traits
 
 			// Clear cell
 			content[cell] = EmptyCell;
-			world.Map.CustomTerrain[cell.X, cell.Y] = -1;
+			world.Map.CustomTerrain[cell] = -1;
 
 			if (!dirty.Contains(cell))
 				dirty.Add(cell);

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Traits
 			foreach (var cell in w.Map.Cells)
 			{
 				ResourceType t;
-				if (!resources.TryGetValue(w.Map.MapResources.Value[cell.X, cell.Y].Type, out t))
+				if (!resources.TryGetValue(w.Map.MapResources.Value[cell].Type, out t))
 					continue;
 
 				if (!AllowResourceAt(t, cell))

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -217,7 +217,7 @@ namespace OpenRA.Traits
 
 		public bool IsExplored(CPos cell)
 		{
-			if (!map.IsInMap(cell))
+			if (!map.Contains(cell))
 				return false;
 
 			if (Disabled || !self.World.LobbyInfo.GlobalSettings.Shroud)
@@ -233,7 +233,7 @@ namespace OpenRA.Traits
 
 		public bool IsVisible(CPos cell)
 		{
-			if (!map.IsInMap(cell))
+			if (!map.Contains(cell))
 				return false;
 
 			if (Disabled || !self.World.LobbyInfo.GlobalSettings.Fog)

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -66,15 +66,12 @@ namespace OpenRA.Traits
 		static IEnumerable<CPos> FindVisibleTiles(World world, CPos position, WRange radius)
 		{
 			var r = (radius.Range + 1023) / 1024;
-			var min = (position - new CVec(r, r)).Clamp(world.Map.Bounds);
-			var max = (position + new CVec(r, r)).Clamp(world.Map.Bounds);
-
-			var circleArea = radius.Range * radius.Range;
+			var limit = radius.Range * radius.Range;
 			var pos = position.CenterPosition;
-			for (var j = min.Y; j <= max.Y; j++)
-				for (var i = min.X; i <= max.X; i++)
-					if (circleArea >= (new CPos(i, j).CenterPosition - pos).LengthSquared)
-						yield return new CPos(i, j);
+
+			foreach (var cell in world.Map.FindTilesInCircle(position, r))
+				if ((cell.CenterPosition - pos).HorizontalLengthSquared <= limit)
+					yield return cell;
 		}
 
 		void AddVisibility(Actor a)

--- a/OpenRA.Game/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportControllerWidget.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Widgets
 		{
 			TooltipType = WorldTooltipType.None;
 			var cell = worldRenderer.Position(worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
-			if (!world.Map.IsInMap(cell))
+			if (!world.Map.Contains(cell))
 				return;
 
 			if (world.ShroudObscures(cell))

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -209,18 +209,20 @@ namespace OpenRA.Widgets
 				}
 				else if (key == Game.Settings.Keys.SelectUnitsByTypeKey)
 				{
-					var selectedTypes = World.Selection.Actors.Where(
-						x => x.Owner == World.RenderPlayer).Select(a => a.Info);
+					var selectedTypes = World.Selection.Actors
+						.Where(x => x.Owner == World.RenderPlayer)
+						.Select(a => a.Info);
+
 					Func<Actor, bool> cond = a => a.Owner == World.RenderPlayer && selectedTypes.Contains(a.Info);
-					var newSelection = SelectActorsInBox(
-						World, worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.BottomRight, cond); 
+					var tl = worldRenderer.Viewport.TopLeft;
+					var br = worldRenderer.Viewport.BottomRight;
+					var newSelection = SelectActorsInBox(World, tl, br, cond);
+
 					if (newSelection.Count() > selectedTypes.Count())
 						Game.Debug("Selected across screen");
 					else
 					{
-						newSelection = World.ActorMap.ActorsInBox(
-							World.Map.Bounds.TopLeftAsCPos().TopLeft,
-							World.Map.Bounds.BottomRightAsCPos().BottomRight).Where(cond);
+						newSelection = World.ActorMap.ActorsInWorld().Where(cond);
 						Game.Debug("Selected across map");
 					}
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -55,17 +55,6 @@ namespace OpenRA
 		public bool ShroudObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(a); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
 
-		public Rectangle? VisibleBounds
-		{
-			get
-			{
-				if (RenderPlayer == null)
-					return null;
-
-				return RenderPlayer.Shroud.ExploredBounds;
-			}
-		}
-
 		public bool IsReplay
 		{
 			get { return orderManager.Connection is ReplayConnection; }

--- a/OpenRA.Mods.D2k/D2kResourceLayer.cs
+++ b/OpenRA.Mods.D2k/D2kResourceLayer.cs
@@ -97,28 +97,28 @@ namespace OpenRA.Traits
 		ClearSides FindClearSides(ResourceType t, CPos p)
 		{
 			var ret = ClearSides.None;
-			if (render[p.X, p.Y - 1].Type != t)
+			if (render[p + new CVec(0, -1)].Type != t)
 				ret |= ClearSides.Top | ClearSides.TopLeft | ClearSides.TopRight;
 
-			if (render[p.X - 1, p.Y].Type != t)
+			if (render[p + new CVec(-1, 0)].Type != t)
 				ret |= ClearSides.Left | ClearSides.TopLeft | ClearSides.BottomLeft;
 
-			if (render[p.X + 1, p.Y].Type != t)
+			if (render[p + new CVec(1, 0)].Type != t)
 				ret |= ClearSides.Right | ClearSides.TopRight | ClearSides.BottomRight;
 
-			if (render[p.X, p.Y + 1].Type != t)
+			if (render[p + new CVec(0, 1)].Type != t)
 				ret |= ClearSides.Bottom | ClearSides.BottomLeft | ClearSides.BottomRight;
 
-			if (render[p.X - 1, p.Y - 1].Type != t)
+			if (render[p + new CVec(-1, -1)].Type != t)
 				ret |= ClearSides.TopLeft;
 
-			if (render[p.X + 1, p.Y - 1].Type != t)
+			if (render[p + new CVec(1, -1)].Type != t)
 				ret |= ClearSides.TopRight;
 
-			if (render[p.X - 1, p.Y + 1].Type != t)
+			if (render[p + new CVec(-1, 1)].Type != t)
 				ret |= ClearSides.BottomLeft;
 
-			if (render[p.X + 1, p.Y + 1].Type != t)
+			if (render[p + new CVec(1, 1)].Type != t)
 				ret |= ClearSides.BottomRight;
 
 			return ret;
@@ -126,7 +126,7 @@ namespace OpenRA.Traits
 
 		void UpdateRenderedTileInner(CPos p)
 		{
-			var t = render[p.X, p.Y];
+			var t = render[p];
 			if (t.Density > 0)
 			{
 				var clear = FindClearSides(t.Type, p);
@@ -146,7 +146,7 @@ namespace OpenRA.Traits
 			else
 				t.Sprite = null;
 
-			render[p.X, p.Y] = t;
+			render[p] = t;
 		}
 
 		protected override void UpdateRenderedSprite(CPos p)

--- a/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			var path = pathFinder.FindBidiPath(
 				PathSearch.FromPoints(self.World, mobile.Info, self, searchCells, loc, true),
-				PathSearch.FromPoint(self.World, mobile.Info, self, loc, targetPosition, true).InReverse()
+				PathSearch.FromPoint(self.World, mobile.Info, self, loc, targetPosition, true).Reverse()
 			);
 
 			inner = mobile.MoveTo(() => path);

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.RA.Air
 
 		public bool CanLand(CPos cell)
 		{
-			if (!self.World.Map.IsInMap(cell))
+			if (!self.World.Map.Contains(cell))
 				return false;
 
 			if (self.World.ActorMap.AnyUnitsAt(cell))
@@ -246,7 +246,7 @@ namespace OpenRA.Mods.RA.Air
 				return false;
 
 			IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
-			cursor = self.World.Map.IsInMap(target.CenterPosition.ToCPos()) ? "move" : "move-blocked";
+			cursor = self.World.Map.Contains(target.CenterPosition.ToCPos()) ? "move" : "move-blocked";
 			return true;
 		}
 

--- a/OpenRA.Mods.RA/Air/FlyTimed.cs
+++ b/OpenRA.Mods.RA/Air/FlyTimed.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Air
 	{
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled || !self.World.Map.IsInMap(self.Location))
+			if (IsCanceled || !self.World.Map.Contains(self.Location))
 				return NextActivity;
 
 			var plane = self.Trait<Plane>();

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.RA
 
 			bool CanTargetLocation(Actor self, CPos location, List<Actor> actorsAtLocation, TargetModifiers modifiers, ref string cursor)
 			{
-				if (!self.World.Map.IsInMap(location))
+				if (!self.World.Map.Contains(location))
 					return false;
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);

--- a/OpenRA.Mods.RA/Bridge.cs
+++ b/OpenRA.Mods.RA/Bridge.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.RA
 
 			// Set the initial custom terrain types
 			foreach (var c in footprint.Keys)
-				self.World.Map.CustomTerrain[c.X, c.Y] = GetTerrainType(c);
+				self.World.Map.CustomTerrain[c] = GetTerrainType(c);
 		}
 
 		int GetTerrainType(CPos cell)
@@ -204,7 +204,7 @@ namespace OpenRA.Mods.RA
 
 			// Update map
 			foreach (var c in footprint.Keys)
-				self.World.Map.CustomTerrain[c.X, c.Y] = GetTerrainType(c);
+				self.World.Map.CustomTerrain[c] = GetTerrainType(c);
 
 			// If this bridge repair operation connects two pathfinding domains,
 			// update the domain index.

--- a/OpenRA.Mods.RA/Bridge.cs
+++ b/OpenRA.Mods.RA/Bridge.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.RA
 		{
 			var dx = cell - self.Location;
 			var index = dx.X + self.World.TileSet.Templates[template].Size.X * dx.Y;
-			return self.World.TileSet.GetTerrainIndex(new TileReference<ushort, byte>(template, (byte)index));
+			return self.World.TileSet.GetTerrainIndex(new TerrainTile(template, (byte)index));
 		}
 
 		public void LinkNeighbouringBridges(World world, BridgeLayer bridges)
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.RA
 		IRenderable[] TemplateRenderables(WorldRenderer wr, PaletteReference palette, ushort template)
 		{
 			return footprint.Select(c => (IRenderable)(new SpriteRenderable(
-				wr.Theater.TileSprite(new TileReference<ushort, byte>(template, c.Value)),
+				wr.Theater.TileSprite(new TerrainTile(template, c.Value)),
 				c.Key.CenterPosition, WVec.Zero, -512, palette, 1f, true))).ToArray();
 		}
 

--- a/OpenRA.Mods.RA/BridgeLayer.cs
+++ b/OpenRA.Mods.RA/BridgeLayer.cs
@@ -51,9 +51,14 @@ namespace OpenRA.Mods.RA
 
 			// Loop through the map looking for templates to overlay
 			for (var i = w.Map.Bounds.Left; i < w.Map.Bounds.Right; i++)
+			{
 				for (var j = w.Map.Bounds.Top; j < w.Map.Bounds.Bottom; j++)
-					if (bridgeTypes.Keys.Contains(w.Map.MapTiles.Value[i, j].Type))
-						ConvertBridgeToActor(w, new CPos(i, j));
+				{
+					var cell = new CPos(i, j);
+					if (bridgeTypes.Keys.Contains(w.Map.MapTiles.Value[cell].Type))
+						ConvertBridgeToActor(w, cell);
+				}
+			}
 
 			// Link adjacent (long)-bridges so that artwork is updated correctly
 			foreach (var b in w.Actors.SelectMany(a => a.TraitsImplementing<Bridge>()))
@@ -67,8 +72,8 @@ namespace OpenRA.Mods.RA
 				return;
 
 			// Correlate the tile "image" aka subtile with its position to find the template origin
-			var tile = w.Map.MapTiles.Value[cell.X, cell.Y].Type;
-			var index = w.Map.MapTiles.Value[cell.X, cell.Y].Index;
+			var tile = w.Map.MapTiles.Value[cell].Type;
+			var index = w.Map.MapTiles.Value[cell].Index;
 			var template = w.TileSet.Templates[tile];
 			var ni = cell.X - index % template.Size.X;
 			var nj = cell.Y - index / template.Size.X;
@@ -90,8 +95,8 @@ namespace OpenRA.Mods.RA
 				var subtile = new CPos(ni + ind % template.Size.X, nj + ind / template.Size.X);
 
 				// This isn't the bridge you're looking for
-				if (!w.Map.IsInMap(subtile) || w.Map.MapTiles.Value[subtile.X, subtile.Y].Type != tile ||
-					w.Map.MapTiles.Value[subtile.X, subtile.Y].Index != ind)
+				if (!w.Map.IsInMap(subtile) || w.Map.MapTiles.Value[subtile].Type != tile ||
+					w.Map.MapTiles.Value[subtile].Index != ind)
 					continue;
 
 				subTiles.Add(subtile, ind);

--- a/OpenRA.Mods.RA/BridgeLayer.cs
+++ b/OpenRA.Mods.RA/BridgeLayer.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.RA
 				var subtile = new CPos(ni + ind % template.Size.X, nj + ind / template.Size.X);
 
 				// This isn't the bridge you're looking for
-				if (!w.Map.IsInMap(subtile) || w.Map.MapTiles.Value[subtile].Type != tile ||
+				if (!w.Map.Contains(subtile) || w.Map.MapTiles.Value[subtile].Type != tile ||
 					w.Map.MapTiles.Value[subtile].Index != ind)
 					continue;
 
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.RA
 		// Used to check for neighbouring bridges
 		public Bridge GetBridge(CPos cell)
 		{
-			if (!world.Map.IsInMap(cell))
+			if (!world.Map.Contains(cell))
 				return null;
 
 			return bridges[cell];

--- a/OpenRA.Mods.RA/BridgeLayer.cs
+++ b/OpenRA.Mods.RA/BridgeLayer.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.RA
 				for (var j = w.Map.Bounds.Top; j < w.Map.Bounds.Bottom; j++)
 				{
 					var cell = new CPos(i, j);
-					if (bridgeTypes.Keys.Contains(w.Map.MapTiles.Value[cell].Type))
+					if (bridgeTypes.ContainsKey(w.Map.MapTiles.Value[cell].Type))
 						ConvertBridgeToActor(w, cell);
 				}
 			}

--- a/OpenRA.Mods.RA/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.RA/Buildings/BuildingInfluence.cs
@@ -19,14 +19,14 @@ namespace OpenRA.Mods.RA.Buildings
 
 	public class BuildingInfluence
 	{
-		Actor[,] influence;
+		CellLayer<Actor> influence;
 		Map map;
 
 		public BuildingInfluence(World world)
 		{
 			map = world.Map;
 
-			influence = new Actor[map.MapSize.X, map.MapSize.Y];
+			influence = new CellLayer<Actor>(map);
 
 			world.ActorAdded +=	a =>
 			{
@@ -35,8 +35,8 @@ namespace OpenRA.Mods.RA.Buildings
 					return;
 
 				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
-					if (map.IsInMap(u) && influence[u.X, u.Y] == null)
-						influence[u.X, u.Y] = a;
+					if (map.IsInMap(u) && influence[u] == null)
+						influence[u] = a;
 			};
 
 			world.ActorRemoved += a =>
@@ -46,8 +46,8 @@ namespace OpenRA.Mods.RA.Buildings
 					return;
 
 				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
-					if (map.IsInMap(u) && influence[u.X, u.Y] == a)
-						influence[u.X, u.Y] = null;
+					if (map.IsInMap(u) && influence[u] == a)
+						influence[u] = null;
 			};
 		}
 
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA.Buildings
 			if (!map.IsInMap(cell))
 				return null;
 
-			return influence[cell.X, cell.Y];
+			return influence[cell];
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.RA/Buildings/BuildingInfluence.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.RA.Buildings
 					return;
 
 				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
-					if (map.IsInMap(u) && influence[u] == null)
+					if (map.Contains(u) && influence[u] == null)
 						influence[u] = a;
 			};
 
@@ -46,14 +46,14 @@ namespace OpenRA.Mods.RA.Buildings
 					return;
 
 				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
-					if (map.IsInMap(u) && influence[u] == a)
+					if (map.Contains(u) && influence[u] == a)
 						influence[u] = null;
 			};
 		}
 
 		public Actor GetBuildingAt(CPos cell)
 		{
-			if (!map.IsInMap(cell))
+			if (!map.Contains(cell))
 				return null;
 
 			return influence[cell];

--- a/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Buildings
 						continue;
 
 					// Don't place under other buildings or custom terrain
-					if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c.X, c.Y] != -1)
+					if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != -1)
 						continue;
 
 					var index = Game.CosmeticRandom.Next(template.TilesCount);
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA.Buildings
 					continue;
 
 				// Don't place under other buildings or custom terrain
-				if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c.X, c.Y] != -1)
+				if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != -1)
 					continue;
 
 				layer.AddTile(c, new TileReference<ushort, byte>(template.Id, (byte)i));

--- a/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.RA.Buildings
 						continue;
 
 					var index = Game.CosmeticRandom.Next(template.TilesCount);
-					layer.AddTile(c, new TileReference<ushort, byte>(template.Id, (byte)index));
+					layer.AddTile(c, new TerrainTile(template.Id, (byte)index));
 				}
 
 				return;
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.RA.Buildings
 				if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != -1)
 					continue;
 
-				layer.AddTile(c, new TileReference<ushort, byte>(template.Id, (byte)i));
+				layer.AddTile(c, new TerrainTile(template.Id, (byte)i));
 			}
 		}
 	}

--- a/OpenRA.Mods.RA/Buildings/Util.cs
+++ b/OpenRA.Mods.RA/Buildings/Util.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Buildings
 
 			var res = world.WorldActor.Trait<ResourceLayer>();
 			return FootprintUtils.Tiles(world.Map.Rules, name, building, topLeft).All(
-				t => world.Map.IsInMap(t.X, t.Y) && res.GetResource(t) == null &&
+				t => world.Map.IsInMap(t) && res.GetResource(t) == null &&
 					world.IsCellBuildable(t, building, toIgnore));
 		}
 

--- a/OpenRA.Mods.RA/Buildings/Util.cs
+++ b/OpenRA.Mods.RA/Buildings/Util.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Buildings
 			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(a) != null) return false;
 			if (world.ActorMap.GetUnitsAt(a).Any(b => b != toIgnore)) return false;
 
-			return world.Map.IsInMap(a) && bi.TerrainTypes.Contains(world.Map.GetTerrainInfo(a).Type);
+			return world.Map.Contains(a) && bi.TerrainTypes.Contains(world.Map.GetTerrainInfo(a).Type);
 		}
 
 		public static bool CanPlaceBuilding(this World world, string name, BuildingInfo building, CPos topLeft, Actor toIgnore)
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Buildings
 
 			var res = world.WorldActor.Trait<ResourceLayer>();
 			return FootprintUtils.Tiles(world.Map.Rules, name, building, topLeft).All(
-				t => world.Map.IsInMap(t) && res.GetResource(t) == null &&
+				t => world.Map.Contains(t) && res.GetResource(t) == null &&
 					world.IsCellBuildable(t, building, toIgnore));
 		}
 

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA
 			var world = firedBy.World;
 			var targetTile = pos.ToCPos();
 
-			if (!world.Map.IsInMap(targetTile))
+			if (!world.Map.Contains(targetTile))
 				return;
 
 			var isWater = pos.Z <= 0 && world.Map.GetTerrainInfo(targetTile).IsWater;

--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.RA
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor, bool checkTransientActors)
 		{
-			if (!self.World.Map.IsInMap(cell)) return false;
+			if (!self.World.Map.Contains(cell)) return false;
 
 			var type = self.World.Map.GetTerrainInfo(cell).Type;
 			if (!info.TerrainTypes.Contains(type))

--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.RA
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor, bool checkTransientActors)
 		{
-			if (!self.World.Map.IsInMap(cell.X, cell.Y)) return false;
+			if (!self.World.Map.IsInMap(cell)) return false;
 
 			var type = self.World.Map.GetTerrainInfo(cell).Type;
 			if (!info.TerrainTypes.Contains(type))

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.RA.Effects
 				|| (dist.LengthSquared < MissileCloseEnough.Range * MissileCloseEnough.Range) // Within range
 				|| (info.RangeLimit != 0 && ticks > info.RangeLimit) // Ran out of fuel
 				|| (!info.High && world.ActorMap.GetUnitsAt(cell).Any(a => a.HasTrait<IBlocksBullets>())) // Hit a wall
-				|| !world.Map.IsInMap(cell) // This also avoids an IndexOutOfRangeException in GetTerrainInfo below.
+				|| !world.Map.Contains(cell) // This also avoids an IndexOutOfRangeException in GetTerrainInfo below.
 				|| (!string.IsNullOrEmpty(info.BoundToTerrainType) && world.Map.GetTerrainInfo(cell).Type != info.BoundToTerrainType); // Hit incompatible terrain
 
 			if (shouldExplode)

--- a/OpenRA.Mods.RA/Husk.cs
+++ b/OpenRA.Mods.RA/Husk.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { yield return Pair.New(TopLeft, SubCell.FullCell); }
 		public bool CanEnterCell(CPos cell, Actor ignoreActor, bool checkTransientActors)
 		{
-			if (!self.World.Map.IsInMap(cell))
+			if (!self.World.Map.Contains(cell))
 				return false;
 
 			if (!info.AllowedTerrain.Contains(self.World.Map.GetTerrainInfo(cell).Type))

--- a/OpenRA.Mods.RA/Husk.cs
+++ b/OpenRA.Mods.RA/Husk.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { yield return Pair.New(TopLeft, SubCell.FullCell); }
 		public bool CanEnterCell(CPos cell, Actor ignoreActor, bool checkTransientActors)
 		{
-			if (!self.World.Map.IsInMap(cell.X, cell.Y))
+			if (!self.World.Map.IsInMap(cell))
 				return false;
 
 			if (!info.AllowedTerrain.Contains(self.World.Map.GetTerrainInfo(cell).Type))

--- a/OpenRA.Mods.RA/Minelayer.cs
+++ b/OpenRA.Mods.RA/Minelayer.cs
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.RA
 					return false;
 
 				var location = target.CenterPosition.ToCPos();
-				if (!self.World.Map.IsInMap(location))
+				if (!self.World.Map.Contains(location))
 					return false;
 
 				cursor = "ability";

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.RA.Move
 
 		public int MovementCostForCell(World world, CPos cell)
 		{
-			if (!world.Map.IsInMap(cell.X, cell.Y))
+			if (!world.Map.IsInMap(cell))
 				return int.MaxValue;
 
 			var index = world.Map.GetTerrainIndex(cell);

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.RA.Move
 
 		public int MovementCostForCell(World world, CPos cell)
 		{
-			if (!world.Map.IsInMap(cell))
+			if (!world.Map.Contains(cell))
 				return int.MaxValue;
 
 			var index = world.Map.GetTerrainIndex(cell);
@@ -580,7 +580,7 @@ namespace OpenRA.Mods.RA.Move
 				if (self.Owner.Shroud.IsExplored(location))
 					cursor = self.World.Map.GetTerrainInfo(location).CustomCursor ?? cursor;
 
-				if (!self.World.Map.IsInMap(location) || (self.Owner.Shroud.IsExplored(location) &&
+				if (!self.World.Map.Contains(location) || (self.Owner.Shroud.IsExplored(location) &&
 						unitType.MovementCostForCell(self.World, location) == int.MaxValue))
 					cursor = "move-blocked";
 

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using OpenRA;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
@@ -136,9 +137,7 @@ namespace OpenRA.Mods.RA.Move
 
 					var dbg = world.WorldActor.TraitOrDefault<PathfinderDebugOverlay>();
 					if (dbg != null)
-					{
-						dbg.AddLayer(search.Considered.Select(p => new Pair<CPos, int>(p, search.CellInfo[p.X, p.Y].MinCost)), search.MaxCost, search.Owner);
-					}
+						dbg.AddLayer(search.Considered.Select(p => new Pair<CPos, int>(p, search.CellInfo[p].MinCost)), search.MaxCost, search.Owner);
 
 					if (path != null)
 						return path;
@@ -149,15 +148,15 @@ namespace OpenRA.Mods.RA.Move
 			}
 		}
 
-		static List<CPos> MakePath(CellInfo[,] cellInfo, CPos destination)
+		static List<CPos> MakePath(CellLayer<CellInfo> cellInfo, CPos destination)
 		{
 			var ret = new List<CPos>();
 			var pathNode = destination;
 
-			while (cellInfo[pathNode.X, pathNode.Y].Path != pathNode)
+			while (cellInfo[pathNode].Path != pathNode)
 			{
 				ret.Add(pathNode);
-				pathNode = cellInfo[pathNode.X, pathNode.Y].Path;
+				pathNode = cellInfo[pathNode].Path;
 			}
 
 			ret.Add(pathNode);
@@ -165,9 +164,8 @@ namespace OpenRA.Mods.RA.Move
 			return ret;
 		}
 
-		public List<CPos> FindBidiPath(			/* searches from both ends toward each other */
-			PathSearch fromSrc,
-			PathSearch fromDest)
+		// Searches from both ends toward each other
+		public List<CPos> FindBidiPath(PathSearch fromSrc, PathSearch fromDest)
 		{
 			using (new PerfSample("Pathfinder"))
 			{
@@ -181,8 +179,8 @@ namespace OpenRA.Mods.RA.Move
 						/* make some progress on the first search */
 						var p = fromSrc.Expand(world);
 
-						if (fromDest.CellInfo[p.X, p.Y].Seen &&
-							fromDest.CellInfo[p.X, p.Y].MinCost < float.PositiveInfinity)
+						if (fromDest.CellInfo[p].Seen &&
+							fromDest.CellInfo[p].MinCost < float.PositiveInfinity)
 						{
 							path = MakeBidiPath(fromSrc, fromDest, p);
 							break;
@@ -191,8 +189,8 @@ namespace OpenRA.Mods.RA.Move
 						/* make some progress on the second search */
 						var q = fromDest.Expand(world);
 
-						if (fromSrc.CellInfo[q.X, q.Y].Seen &&
-							fromSrc.CellInfo[q.X, q.Y].MinCost < float.PositiveInfinity)
+						if (fromSrc.CellInfo[q].Seen &&
+							fromSrc.CellInfo[q].MinCost < float.PositiveInfinity)
 						{
 							path = MakeBidiPath(fromSrc, fromDest, q);
 							break;
@@ -202,8 +200,8 @@ namespace OpenRA.Mods.RA.Move
 					var dbg = world.WorldActor.TraitOrDefault<PathfinderDebugOverlay>();
 					if (dbg != null)
 					{
-						dbg.AddLayer(fromSrc.Considered.Select(p => new Pair<CPos, int>(p, fromSrc.CellInfo[p.X, p.Y].MinCost)), fromSrc.MaxCost, fromSrc.Owner);
-						dbg.AddLayer(fromDest.Considered.Select(p => new Pair<CPos, int>(p, fromDest.CellInfo[p.X, p.Y].MinCost)), fromDest.MaxCost, fromDest.Owner);
+						dbg.AddLayer(fromSrc.Considered.Select(p => new Pair<CPos, int>(p, fromSrc.CellInfo[p].MinCost)), fromSrc.MaxCost, fromSrc.Owner);
+						dbg.AddLayer(fromDest.Considered.Select(p => new Pair<CPos, int>(p, fromDest.CellInfo[p].MinCost)), fromDest.MaxCost, fromDest.Owner);
 					}
 
 					if (path != null)
@@ -222,19 +220,19 @@ namespace OpenRA.Mods.RA.Move
 			var ret = new List<CPos>();
 
 			var q = p;
-			while (ca[q.X, q.Y].Path != q)
+			while (ca[q].Path != q)
 			{
 				ret.Add(q);
-				q = ca[q.X, q.Y].Path;
+				q = ca[q].Path;
 			}
 			ret.Add(q);
 
 			ret.Reverse();
 
 			q = p;
-			while (cb[q.X, q.Y].Path != q)
+			while (cb[q].Path != q)
 			{
-				q = cb[q.X, q.Y].Path;
+				q = cb[q].Path;
 				ret.Add(q);
 			}
 

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -284,8 +284,8 @@ namespace OpenRA.Mods.RA.Move
 
 	public struct PathDistance : IComparable<PathDistance>
 	{
-		public int EstTotal;
-		public CPos Location;
+		public readonly int EstTotal;
+		public readonly CPos Location;
 
 		public PathDistance(int estTotal, CPos location)
 		{

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.RA.Move
 
 				var pb = FindBidiPath(
 					PathSearch.FromPoint(world, mi, self, target, from, true),
-					PathSearch.FromPoint(world, mi, self, from, target, true).InReverse()
+					PathSearch.FromPoint(world, mi, self, from, target, true).Reverse()
 				);
 
 				CheckSanePath2(pb, from, target);
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.RA.Move
 
 				var path = FindBidiPath(
 					PathSearch.FromPoints(world, mi, self, tilesInRange, src, true),
-					PathSearch.FromPoint(world, mi, self, src, targetCell, true).InReverse()
+					PathSearch.FromPoint(world, mi, self, src, targetCell, true).Reverse()
 				);
 
 				return path;
@@ -124,12 +124,12 @@ namespace OpenRA.Mods.RA.Move
 				{
 					List<CPos> path = null;
 
-					while (!search.queue.Empty)
+					while (!search.Queue.Empty)
 					{
 						var p = search.Expand(world);
-						if (search.heuristic(p) == 0)
+						if (search.Heuristic(p) == 0)
 						{
-							path = MakePath(search.cellInfo, p);
+							path = MakePath(search.CellInfo, p);
 							break;
 						}
 					}
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.RA.Move
 					var dbg = world.WorldActor.TraitOrDefault<PathfinderDebugOverlay>();
 					if (dbg != null)
 					{
-						dbg.AddLayer(search.considered.Select(p => new Pair<CPos, int>(p, search.cellInfo[p.X, p.Y].MinCost)), search.maxCost, search.owner);
+						dbg.AddLayer(search.Considered.Select(p => new Pair<CPos, int>(p, search.CellInfo[p.X, p.Y].MinCost)), search.MaxCost, search.Owner);
 					}
 
 					if (path != null)
@@ -176,13 +176,13 @@ namespace OpenRA.Mods.RA.Move
 				{
 					List<CPos> path = null;
 
-					while (!fromSrc.queue.Empty && !fromDest.queue.Empty)
+					while (!fromSrc.Queue.Empty && !fromDest.Queue.Empty)
 					{
 						/* make some progress on the first search */
 						var p = fromSrc.Expand(world);
 
-						if (fromDest.cellInfo[p.X, p.Y].Seen &&
-							fromDest.cellInfo[p.X, p.Y].MinCost < float.PositiveInfinity)
+						if (fromDest.CellInfo[p.X, p.Y].Seen &&
+							fromDest.CellInfo[p.X, p.Y].MinCost < float.PositiveInfinity)
 						{
 							path = MakeBidiPath(fromSrc, fromDest, p);
 							break;
@@ -191,8 +191,8 @@ namespace OpenRA.Mods.RA.Move
 						/* make some progress on the second search */
 						var q = fromDest.Expand(world);
 
-						if (fromSrc.cellInfo[q.X, q.Y].Seen &&
-							fromSrc.cellInfo[q.X, q.Y].MinCost < float.PositiveInfinity)
+						if (fromSrc.CellInfo[q.X, q.Y].Seen &&
+							fromSrc.CellInfo[q.X, q.Y].MinCost < float.PositiveInfinity)
 						{
 							path = MakeBidiPath(fromSrc, fromDest, q);
 							break;
@@ -202,8 +202,8 @@ namespace OpenRA.Mods.RA.Move
 					var dbg = world.WorldActor.TraitOrDefault<PathfinderDebugOverlay>();
 					if (dbg != null)
 					{
-						dbg.AddLayer(fromSrc.considered.Select(p => new Pair<CPos, int>(p, fromSrc.cellInfo[p.X, p.Y].MinCost)), fromSrc.maxCost, fromSrc.owner);
-						dbg.AddLayer(fromDest.considered.Select(p => new Pair<CPos, int>(p, fromDest.cellInfo[p.X, p.Y].MinCost)), fromDest.maxCost, fromDest.owner);
+						dbg.AddLayer(fromSrc.Considered.Select(p => new Pair<CPos, int>(p, fromSrc.CellInfo[p.X, p.Y].MinCost)), fromSrc.MaxCost, fromSrc.Owner);
+						dbg.AddLayer(fromDest.Considered.Select(p => new Pair<CPos, int>(p, fromDest.CellInfo[p.X, p.Y].MinCost)), fromDest.MaxCost, fromDest.Owner);
 					}
 
 					if (path != null)
@@ -216,8 +216,8 @@ namespace OpenRA.Mods.RA.Move
 
 		static List<CPos> MakeBidiPath(PathSearch a, PathSearch b, CPos p)
 		{
-			var ca = a.cellInfo;
-			var cb = b.cellInfo;
+			var ca = a.CellInfo;
+			var cb = b.CellInfo;
 
 			var ret = new List<CPos>();
 

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.RA.Move
 				var newHere = p.Location + d;
 
 				// Is this direction flat-out unusable or already seen?
-				if (!world.Map.IsInMap(newHere.X, newHere.Y))
+				if (!world.Map.IsInMap(newHere))
 					continue;
 				if (cellInfo[newHere.X, newHere.Y].Seen)
 					continue;
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.RA.Move
 
 		public void AddInitialCell(CPos location)
 		{
-			if (!world.Map.IsInMap(location.X, location.Y))
+			if (!world.Map.IsInMap(location))
 				return;
 
 			cellInfo[location.X, location.Y] = new CellInfo(0, location, false);

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -178,7 +178,7 @@ namespace OpenRA.Mods.RA.Move
 				var newHere = p.Location + d;
 
 				// Is this direction flat-out unusable or already seen?
-				if (!world.Map.IsInMap(newHere))
+				if (!world.Map.Contains(newHere))
 					continue;
 
 				if (CellInfo[newHere].Seen)
@@ -255,7 +255,7 @@ namespace OpenRA.Mods.RA.Move
 
 		public void AddInitialCell(CPos location)
 		{
-			if (!self.World.Map.IsInMap(location))
+			if (!self.World.Map.Contains(location))
 				return;
 
 			CellInfo[location] = new CellInfo(0, location, false);

--- a/OpenRA.Mods.RA/RallyPoint.cs
+++ b/OpenRA.Mods.RA/RallyPoint.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.RA
 					return false;
 
 				var location = target.CenterPosition.ToCPos();
-				if (self.World.Map.IsInMap(location))
+				if (self.World.Map.Contains(location))
 				{
 					cursor = "ability";
 					return true;

--- a/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
+++ b/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Render
 			if (self.CenterPosition.Z > 0 || move.IsMoving)
 				return false;
 
-			return cargo.CurrentAdjacentCells.Any(c => self.World.Map.IsInMap(c)
+			return cargo.CurrentAdjacentCells.Any(c => self.World.Map.Contains(c)
 				&& info.OpenTerrainTypes.Contains(self.World.Map.GetTerrainInfo(c).Type));
 		}
 

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.RA
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
 			world.CancelInputMode();
-			if (mi.Button == expectedButton && world.Map.IsInMap(xy))
+			if (mi.Button == expectedButton && world.Map.Contains(xy))
 				yield return new Order(order, manager.self, false) { TargetLocation = xy, SuppressVisualFeedback = true };
 		}
 
@@ -258,6 +258,6 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public void RenderAfterWorld(WorldRenderer wr, World world) { }
-		public string GetCursor(World world, CPos xy, MouseInput mi) { return world.Map.IsInMap(xy) ? cursor : "generic-blocked"; }
+		public string GetCursor(World world, CPos xy, MouseInput mi) { return world.Map.Contains(xy) ? cursor : "generic-blocked"; }
 	}
 }

--- a/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA
 			dirty = new Dictionary<CPos, Sprite>();
 		}
 
-		public void AddTile(CPos cell, TileReference<ushort, byte> tile)
+		public void AddTile(CPos cell, TerrainTile tile)
 		{
 			map.CustomTerrain[cell] = tileset.GetTerrainIndex(tile);
 

--- a/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA
 
 		public void AddTile(CPos cell, TileReference<ushort, byte> tile)
 		{
-			map.CustomTerrain[cell.X, cell.Y] = tileset.GetTerrainIndex(tile);
+			map.CustomTerrain[cell] = tileset.GetTerrainIndex(tile);
 
 			// Terrain tiles define their origin at the topleft
 			var s = theater.TileSprite(tile);

--- a/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
@@ -59,12 +59,11 @@ namespace OpenRA.Mods.RA
 
 		public void Render(WorldRenderer wr)
 		{
-			var cliprect = wr.Viewport.CellBounds;
 			var pal = wr.Palette("terrain");
 
 			foreach (var kv in tiles)
 			{
-				if (!cliprect.Contains(kv.Key.X, kv.Key.Y))
+				if (!wr.Viewport.VisibleCells.Contains(kv.Key))
 					continue;
 
 				if (wr.world.ShroudObscures(kv.Key))

--- a/OpenRA.Mods.RA/World/DomainIndex.cs
+++ b/OpenRA.Mods.RA/World/DomainIndex.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.RA
 
 		public bool IsPassable(CPos p1, CPos p2)
 		{
-			if (!map.IsInMap(p1) || !map.IsInMap(p2))
+			if (!map.Contains(p1) || !map.Contains(p2))
 				return false;
 
 			if (domains[p1] == domains[p2])
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.RA
 			{
 				// Select all neighbors inside the map boundries
 				var neighbors = CVec.directions.Select(d => d + cell)
-					.Where(c => map.IsInMap(c));
+					.Where(c => map.Contains(c));
 
 				var found = false;
 				foreach (var n in neighbors)
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.RA
 
 					// Don't crawl off the map, or add already-visited cells
 					var neighbors = CVec.directions.Select(d => n + d)
-						.Where(p => map.IsInMap(p) && !visited[p]);
+						.Where(p => map.Contains(p) && !visited[p]);
 
 					foreach (var neighbor in neighbors)
 						domainQueue.Enqueue(neighbor);

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -120,12 +120,11 @@ namespace OpenRA.Mods.RA
 
 		public void Render(WorldRenderer wr)
 		{
-			var cliprect = wr.Viewport.CellBounds;
 			var pal = wr.Palette("terrain");
 
 			foreach (var kv in tiles)
 			{
-				if (!cliprect.Contains(kv.Key.X, kv.Key.Y))
+				if (!wr.Viewport.VisibleCells.Contains(kv.Key))
 					continue;
 
 				if (world.ShroudObscures(kv.Key))

--- a/OpenRA.Utility/LegacyMapImporter.cs
+++ b/OpenRA.Utility/LegacyMapImporter.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Utility
 
 			map.Smudges = Exts.Lazy(() => new List<SmudgeReference>());
 			map.Actors = Exts.Lazy(() => new Dictionary<string, ActorReference>());
-			map.MapResources = Exts.Lazy(() => new TileReference<byte, byte>[mapSize, mapSize]);
+			map.MapResources = Exts.Lazy(() => new CellLayer<ResourceTile>(new Size(mapSize, mapSize)));
 			map.MapTiles = Exts.Lazy(() => new TileReference<ushort, byte>[mapSize, mapSize]);
 
 			map.Options = new MapOptions();
@@ -277,15 +277,16 @@ namespace OpenRA.Utility
 
 					if (o != 255 && overlayResourceMapping.ContainsKey(redAlertOverlayNames[o]))
 						res = overlayResourceMapping[redAlertOverlayNames[o]];
-
-					map.MapResources.Value[i, j] = new TileReference<byte, byte>(res.First, res.Second);
+					
+					var cell = new CPos(i, j);
+					map.MapResources.Value[cell] = new ResourceTile(res.First, res.Second);
 
 					if (o != 255 && overlayActorMapping.ContainsKey(redAlertOverlayNames[o]))
 					{
 						map.Actors.Value.Add("Actor" + actorCount++,
 							new ActorReference(overlayActorMapping[redAlertOverlayNames[o]])
 							{
-								new LocationInit(new CPos(i, j)),
+								new LocationInit(cell),
 								new OwnerInit("Neutral")
 							});
 					}
@@ -342,7 +343,7 @@ namespace OpenRA.Utility
 				if (overlayResourceMapping.ContainsKey(kv.Value.ToLower()))
 					res = overlayResourceMapping[kv.Value.ToLower()];
 
-				map.MapResources.Value[cell.X, cell.Y] = new TileReference<byte, byte>(res.First, res.Second);
+				map.MapResources.Value[cell] = new ResourceTile(res.First, res.Second);
 
 				if (overlayActorMapping.ContainsKey(kv.Value.ToLower()))
 					map.Actors.Value.Add("Actor" + actorCount++,


### PR DESCRIPTION
The next step towards TS/RA2 tileset support (#5350) is to remove the assumption that map coordinates == cell coordinates (the isometric games have cell axes rotated by 45 degrees to the map).

The existing code required each trait that stored something for each cell to roll its own storage, usually via an inefficient 2D array.  The CellLayer class replaces this duplication with a wrapper around a 1D array, and which can transparently convert between cell and map coordinates (see [pchote:isometric](https://github.com/pchote/OpenRA/commits/isometric) for a sneak-peek at where this is going).

The next problem is enumerating over a set of cells on the screen / in the map / etc.  Looping over the x and y axes won't work, as they are rotated relative to the screen for isometric maps.  The CellRegion class introduces a simpler way of enumerating regions that will work for both perspectives.
