### PR TITLE
Allow support powers to require tech prerequisites.

### DIFF
--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.RA
 			Produceable[self.World.Map.Rules.Actors[key]].Visible = false;
 		}
 
-		public void PrerequisitesItemVisable(string key)
+		public void PrerequisitesItemVisible(string key)
 		{
 			Produceable[self.World.Map.Rules.Actors[key]].Visible = true;
 		}

--- a/OpenRA.Mods.RA/Player/TechTree.cs
+++ b/OpenRA.Mods.RA/Player/TechTree.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.RA
 					watcher.PrerequisitesItemHidden(Key);
 
 				if (!nowHidden && hidden)
-					watcher.PrerequisitesItemVisable(Key);
+					watcher.PrerequisitesItemVisible(Key);
 
 				if (nowHasPrerequisites && !hasPrerequisites)
 					watcher.PrerequisitesAvailable(Key);

--- a/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.RA
 		public readonly string LongDesc = "";
 		public readonly bool AllowMultiple = false;
 		public readonly bool OneShot = false;
+		public readonly string[] Prerequisites = {};
 
 		public readonly string BeginChargeSound = null;
 		public readonly string EndChargeSound = null;

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.RA
 		}
 
 		public void PrerequisitesItemHidden(string key) { }
-		public void PrerequisitesItemVisable(string key) { }
+		public void PrerequisitesItemVisible(string key) { }
 	}
 
 	public class SupportPowerInstance

--- a/OpenRA.Mods.RA/TraitsInterfaces.cs
+++ b/OpenRA.Mods.RA/TraitsInterfaces.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA
 		void PrerequisitesAvailable(string key);
 		void PrerequisitesUnavailable(string key);
 		void PrerequisitesItemHidden(string key);
-		void PrerequisitesItemVisable(string key);
+		void PrerequisitesItemVisible(string key);
 	}
 
 	public interface ITechTreePrerequisite

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -985,7 +985,6 @@ AFLD:
 		ChargeTime: 360
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
-		Prerequisites: AFLD
 		DropItems: E1,E1,E1,E3,E3
 		SelectTargetSound: slcttgt1.aud
 	ProductionBar:


### PR DESCRIPTION
Rewritten version of #5374.  This allows us to specify multiple prerequisites for a support power, and is the first step towards moving the shared powers onto the player actor (simplifying the code and making it consistent with production).

Two simple testcases:
- Add `Prerequisites: dome` to `MSLO -> NukePower` in RA for a nuke that also requires radar to charge.
- Move `HQ -> AirstrikePower` to `player` in TD for shared powers.
