### PR TITLE
TraitDictionary cleanup

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Graphics
 			palette = new HardwarePalette();
 
 			palettes = new Cache<string, PaletteReference>(CreatePaletteReference);
-			foreach (var pal in world.traitDict.ActorsWithTraitMultiple<IPalette>(world))
+			foreach (var pal in world.traitDict.ActorsWithTrait<IPalette>())
 				pal.Trait.InitPalette(this);
 
 			palette.Initialize();

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -25,17 +25,17 @@ namespace OpenRA
 {
 	public class World
 	{
-		internal TraitDictionary traitDict = new TraitDictionary();
-		HashSet<Actor> actors = new HashSet<Actor>();
-		List<IEffect> effects = new List<IEffect>();
-		Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
+		internal readonly TraitDictionary traitDict = new TraitDictionary();
+		readonly HashSet<Actor> actors = new HashSet<Actor>();
+		readonly List<IEffect> effects = new List<IEffect>();
+		readonly Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
 
 		public int Timestep;
 
 		internal readonly OrderManager orderManager;
 		public Session LobbyInfo { get { return orderManager.LobbyInfo; } }
 
-		public MersenneTwister SharedRandom;
+		public readonly MersenneTwister SharedRandom;
 
 		public readonly List<Player> Players = new List<Player>();
 
@@ -285,7 +285,7 @@ namespace OpenRA
 					ret += n++ * (int)(1 + a.ActorID) * Sync.CalculateSyncHash(a);
 
 				// hash all the traits that tick
-				foreach (var x in traitDict.ActorsWithTraitMultiple<ISync>(this))
+				foreach (var x in ActorsWithTrait<ISync>())
 					ret += n++ * (int)(1 + x.Actor.ActorID) * Sync.CalculateSyncHash(x.Trait);
 
 				// TODO: don't go over all effects
@@ -305,7 +305,7 @@ namespace OpenRA
 
 		public IEnumerable<TraitPair<T>> ActorsWithTrait<T>()
 		{
-			return traitDict.ActorsWithTraitMultiple<T>(this);
+			return traitDict.ActorsWithTrait<T>();
 		}
 
 		public void OnPlayerWinStateChanged(Player player)

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.RA.Effects
 			var dist = targetPosition + offset - pos;
 			var desiredFacing = Traits.Util.GetFacing(dist, facing);
 			var desiredAltitude = targetPosition.Z;
-			var jammed = info.Jammable && world.ActorsWithTrait<JamsMissiles>().Any(j => JammedBy(j));
+			var jammed = info.Jammable && world.ActorsWithTrait<JamsMissiles>().Any(JammedBy);
 
 			if (jammed)
 			{

--- a/OpenRA.Mods.RA/PrimaryBuilding.cs
+++ b/OpenRA.Mods.RA/PrimaryBuilding.cs
@@ -69,9 +69,10 @@ namespace OpenRA.Mods.RA
 			foreach (var p in self.Info.Traits.Get<ProductionInfo>().Produces)
 				foreach (var b in self.World
 					.ActorsWithTrait<PrimaryBuilding>()
-					.Where(a => a.Actor.Owner == self.Owner)
-					.Where(x => x.Trait.IsPrimary
-						&& x.Actor.Info.Traits.Get<ProductionInfo>().Produces.Contains(p)))
+					.Where(a =>
+						a.Actor.Owner == self.Owner &&
+						a.Trait.IsPrimary &&
+						a.Actor.Info.Traits.Get<ProductionInfo>().Produces.Contains(p)))
 					b.Trait.SetPrimaryProducer(b.Actor, false);
 
 			isPrimary = true;


### PR DESCRIPTION
Little bit of housekeeping for TraitDictionary in the first commit. Nothing worth calling out.

I discovered the All and GetMultiple methods for TraitContainer were being called enough to make a hand-rolled enumerator somewhat worthwhile.

For All, I saw CPU spent in enumeration drop by half from 1.90% to 0.94% of overall CPU time (measured on the RA shellmap for 30 seconds or so), and a more modest 1.25% to 1.00% change for GetMultiple. Not sure it's worth the extra code though so I'll let you chaps decide on that one.
