### PR TITLE
Added ./update-wiki.sh to Travis CI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_deploy:
  - cd packaging
  - mkdir build
  - ./package-all.sh ${TRAVIS_TAG} ${PWD}/build/
+ - ./update-wiki.sh
 deploy:
   provider: releases
   api_key:

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -1,3 +1,6 @@
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "travis-ci"
+
 echo "Updating https://github.com/OpenRA/OpenRA/wiki/Traits"
 rm -rf openra-wiki
 git clone git@github.com:OpenRA/OpenRA.wiki.git openra-wiki

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -8,8 +8,9 @@ pushd .. &> /dev/null
 mono --debug OpenRA.Utility.exe --lua-docs d2k > packaging/openra-wiki/New-Lua-API.md
 popd &> /dev/null
 
-cd openra-wiki
+pushd openra-wiki
 git add Traits.md
 git add New-Lua-API.md
 git commit -m "Update trait and scripting documentation"
 git push origin master
+popd


### PR DESCRIPTION
As described in #5643 I simply forgot it. There probably have to be no encrypted Tokens or credentials as the wiki has public commit access. The build server was allowed to do so with just this script and his anonymous non-GitHub account.
