### PR TITLE
Fixed #5664

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
@@ -87,6 +87,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			text = WidgetUtils.WrapText(text, description.Bounds.Width, descriptionFont);
 			description.Text = text;
 			description.Bounds.Height = descriptionFont.Measure(text).Y;
+            descriptionPanel.ScrollToTop();
 			descriptionPanel.Layout.AdjustChildren();
 		}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			text = WidgetUtils.WrapText(text, description.Bounds.Width, descriptionFont);
 			description.Text = text;
 			description.Bounds.Height = descriptionFont.Measure(text).Y;
-            descriptionPanel.ScrollToTop();
+			descriptionPanel.ScrollToTop();
 			descriptionPanel.Layout.AdjustChildren();
 		}
 


### PR DESCRIPTION
Mission description scrolls to the top whenever a new mission is
selected to avoid out-of-bounds scroll bar.
