### PR TITLE
Reduce memory allocation in the main loop

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -85,7 +85,8 @@ namespace OpenRA.Graphics
 
 		public int2 Measure(string text)
 		{
-			return new int2((int)text.Split('\n').Max(s => s.Sum(a => glyphs[Pair.New(a, Color.White)].Advance)), text.Split('\n').Count()*size);
+			var lines = text.Split('\n');
+			return new int2((int)Math.Ceiling(lines.Max(s => s.Sum(a => glyphs[Pair.New(a, Color.White)].Advance))), lines.Length * size);
 		}
 
 		Cache<Pair<char,Color>, GlyphInfo> glyphs;

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -189,21 +189,22 @@ namespace OpenRA.Traits
 			var j1 = (top / info.BinSize).Clamp(0, rows - 1);
 			var j2 = (bottom / info.BinSize).Clamp(0, rows - 1);
 
-			var actorsInBox = new List<Actor>();
+			var actorsChecked = new HashSet<Actor>();
 			for (var j = j1; j <= j2; j++)
 			{
 				for (var i = i1; i <= i2; i++)
 				{
 					foreach (var actor in actors[j * cols + i])
 					{
-						var c = actor.CenterPosition;
-						if (actor.IsInWorld && left <= c.X && c.X <= right && top <= c.Y && c.Y <= bottom)
-							actorsInBox.Add(actor);
+						if (actor.IsInWorld && actorsChecked.Add(actor))
+						{
+							var c = actor.CenterPosition;
+							if (left <= c.X && c.X <= right && top <= c.Y && c.Y <= bottom)
+								yield return actor;
+						}
 					}
 				}
 			}
-
-			return actorsInBox.Distinct();
 		}
 	}
 }

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -153,14 +153,15 @@ namespace OpenRA.Traits
 			var top = (r.Top / info.BinSize).Clamp(0, rows - 1);
 			var bottom = (r.Bottom / info.BinSize).Clamp(0, rows - 1);
 
-			var actorsInBox = new List<Actor>();
+			var actorsChecked = new HashSet<Actor>();
 			for (var j = top; j <= bottom; j++)
 				for (var i = left; i <= right; i++)
-					actorsInBox.AddRange(actors[j * cols + i]
-						.Where(kv => kv.Key.IsInWorld && kv.Value.IntersectsWith(r))
-						.Select(kv => kv.Key));
-
-			return actorsInBox.Distinct();
+					foreach (var kvp in actors[j * cols + i])
+					{
+						var actor = kvp.Key;
+						if (actor.IsInWorld && kvp.Value.IntersectsWith(r) && actorsChecked.Add(actor))
+							yield return actor;
+					}
 		}
 
 		public IEnumerable<FrozenActor> FrozenActorsInBox(Player p, int2 a, int2 b)

--- a/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
@@ -111,18 +111,13 @@ namespace OpenRA.Mods.RA
 
 		public void TickRender(WorldRenderer wr, Actor self)
 		{
-			if (self.Destroyed || !initialized || !visible.Any(v => v.Value))
+			if (self.Destroyed || !initialized || !visible.Values.Any(v => v))
 				return;
 
-			IRenderable[] renderables = null;
+			var renderables = self.Render(wr).ToArray();
 			foreach (var player in self.World.Players)
 				if (visible[player])
-				{
-					// Lazily generate a copy of the underlying data.
-					if (renderables == null)
-						renderables = self.Render(wr).ToArray();
 					frozen[player].Renderables = renderables;
-				}
 		}
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)

--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -45,10 +45,13 @@ namespace OpenRA.Mods.RA
 
 		public override void Tick(Actor self)
 		{
-			isActive = self.World.ActorsWithTrait<Production>()
-				.Any(x => x.Actor.Owner == self.Owner
-					 && x.Trait.Info.Produces.Contains(Info.Type));
-
+			isActive = false;
+			foreach (var x in self.World.ActorsWithTrait<Production>())
+				if (x.Actor.Owner == self.Owner && x.Trait.Info.Produces.Contains(Info.Type))
+				{
+					isActive = true;
+					break;
+				}
 			base.Tick(self);
 		}
 


### PR DESCRIPTION
A few final tweaks for reducing memory allocations in the main game loop. This is the last of the easy stuff on the memory side of things. I don't think there are any more particularly easy wins to be had just from tweaking individual functions sadly.

On the plus side, things have improved enough that the GC is doing a fairly light amount of work now, so that's nice.
