### PR TITLE
Added missing DomainIndex to Tiberian Sun

### DIFF
--- a/OpenRA.Mods.RA/World/DomainIndex.cs
+++ b/OpenRA.Mods.RA/World/DomainIndex.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	// Identify untraversable regions of the map for faster pathfinding, especially with AI
+	[Desc("Identify untraversable regions of the map for faster pathfinding, especially with AI.",
+		"This trait is required. Every mod needs it attached to the world actor.")]
 	class DomainIndexInfo : TraitInfo<DomainIndex> {}
 
 	public class DomainIndex : IWorldLoaded

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -85,6 +85,7 @@ World:
 	Country@1:
 		Name: Nod
 		Race: nod
+	DomainIndex:
 	ResourceLayer:
 	ResourceClaimLayer:
 	FixedColorPalette@GreenTiberium:


### PR DESCRIPTION
Fixes the crash

```
Exception of type `System.InvalidOperationException`: Actor does not have trait of type `OpenRA.Mods.RA.DomainIndex`
```

when building units.
