### PR TITLE
Added a new OpenRA.Lint check for invalid player definitions

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -48,7 +48,7 @@ namespace OpenRA
 		static CountryInfo ChooseCountry(World world, string name)
 		{
 			var selectableCountries = world.Map.Rules.Actors["world"].Traits
-				.WithInterface<CountryInfo>().Where( c => c.Selectable )
+				.WithInterface<CountryInfo>().Where(c => c.Selectable)
 				.ToArray();
 
 			return selectableCountries.FirstOrDefault(c => c.Race == name)

--- a/OpenRA.Mods.RA/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.RA/Lint/CheckPlayers.cs
@@ -1,0 +1,39 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class CheckPlayers : ILintPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		{
+			var playerNames = map.Players.Values.Select(p => p.Name);
+			foreach (var player in map.Players)
+				foreach (var ally in player.Value.Allies)
+					if (!playerNames.Contains(ally))
+						emitError("Allies contains player {0} that is not in list.".F(ally));
+
+			foreach (var player in map.Players)
+				foreach (var enemy in player.Value.Enemies)
+					if (!playerNames.Contains(enemy))
+						emitError("Enemies contains player {0} that is not in list.".F(enemy));
+
+			var races = map.Rules.Actors["world"].Traits.WithInterface<CountryInfo>().Select(c => c.Race);
+			foreach (var player in map.Players)
+				if (!string.IsNullOrWhiteSpace(player.Value.Race) && player.Value.Race != "Random" && !races.Contains(player.Value.Race))
+					emitError("Invalid race {0} chosen for player {1}.".F(player.Value.Race, player.Value.Name));
+		}
+	}
+}
+

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -516,6 +516,7 @@
     <Compile Include="Render\WithRepairAnimation.cs" />
     <Compile Include="Render\WithRepairOverlay.cs" />
     <Compile Include="Activities\MoveWithinRange.cs" />
+    <Compile Include="Lint\CheckPlayers.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -26,7 +26,7 @@ Players:
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
-		Race: allies
+		Race: atreides
 
 Actors:
 	Actor0: spicebloom

--- a/mods/ra/maps/allies-02-classic/map.yaml
+++ b/mods/ra/maps/allies-02-classic/map.yaml
@@ -35,25 +35,25 @@ Players:
 		Race: soviet
 		ColorRamp: 3,255,127
 		Allies: BadGuy
-		Enemies: England,Greece
+		Enemies: Greece
 	PlayerReference@France:
 		Name: France
 		Race: allies
 		ColorRamp: 115,115,143
-		Allies: England,Greece
+		Allies: Greece
 		Enemies: USSR,BadGuy
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
 		NonCombatant: True
 		Race: allies
-		Enemies: England,Greece
+		Enemies: Greece
 	PlayerReference@BadGuy:
 		Name: BadGuy
 		Race: soviet
 		ColorRamp: 3,255,127
 		Allies: USSR
-		Enemies: England,Greece
+		Enemies: Greece
 	PlayerReference@Greece:
 		Name: Greece
 		Playable: True
@@ -65,7 +65,7 @@ Players:
 		ColorRamp: 161,134,200
 		LockSpawn: True
 		LockTeam: True
-		Allies: France,England
+		Allies: France
 		Enemies: USSR,BadGuy
 
 Actors:


### PR DESCRIPTION
Inspired by the findings of https://github.com/OpenRA/OpenRA/pull/5674 and https://github.com/OpenRA/OpenRA/pull/5703. 
