### PR TITLE
Move output to the "./bin/" directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ INSTALL_DIR = $(INSTALL) -d
 INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 
+# build locations
+OUTPUT_DIR = bin
+ENSURE_OUTPUT_DIR = $(OUTPUT_DIR)/placeholder
+
 # program targets
 CORE = rsdl2 rnull game utility irc ralint
 TOOLS = editor tsbuild crashdialog
@@ -79,7 +83,7 @@ VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev
 # Core binaries
 
 game_SRCS := $(shell find OpenRA.Game/ -iname '*.cs')
-game_TARGET = OpenRA.Game.exe
+game_TARGET = $(OUTPUT_DIR)/OpenRA.Game.exe
 game_KIND = winexe
 game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/SDL2-CS.dll thirdparty/SharpFont.dll
 game_FLAGS = -win32icon:OpenRA.Game/OpenRA.ico
@@ -87,7 +91,7 @@ PROGRAMS += game
 game: $(game_TARGET)
 
 irc_SRCS := $(shell find OpenRA.Irc/ -iname '*.cs')
-irc_TARGET = OpenRA.Irc.dll
+irc_TARGET = $(OUTPUT_DIR)/OpenRA.Irc.dll
 irc_KIND = library
 irc_DEPS = $(game_TARGET)
 irc_LIBS = $(COMMON_LIBS) $(irc_DEPS)
@@ -96,13 +100,13 @@ irc: $(irc_TARGET)
 
 # Renderer dlls
 rsdl2_SRCS := $(shell find OpenRA.Renderer.Sdl2/ -iname '*.cs')
-rsdl2_TARGET = OpenRA.Renderer.Sdl2.dll
+rsdl2_TARGET = $(OUTPUT_DIR)/OpenRA.Renderer.Sdl2.dll
 rsdl2_KIND = library
 rsdl2_DEPS = $(game_TARGET)
 rsdl2_LIBS = $(COMMON_LIBS) thirdparty/SDL2-CS.dll $(rsdl2_DEPS)
 
 rnull_SRCS := $(shell find OpenRA.Renderer.Null/ -iname '*.cs')
-rnull_TARGET = OpenRA.Renderer.Null.dll
+rnull_TARGET = $(OUTPUT_DIR)/OpenRA.Renderer.Null.dll
 rnull_KIND = library
 rnull_DEPS = $(game_TARGET)
 rnull_LIBS = $(COMMON_LIBS) $(rnull_DEPS)
@@ -116,7 +120,7 @@ STD_MOD_DEPS	= $(STD_MOD_LIBS) $(ralint_TARGET)
 
 # Red Alert
 mod_ra_SRCS := $(shell find OpenRA.Mods.RA/ -iname '*.cs')
-mod_ra_TARGET = mods/ra/OpenRA.Mods.RA.dll
+mod_ra_TARGET = $(OUTPUT_DIR)/OpenRA.Mods.RA.dll
 mod_ra_KIND = library
 mod_ra_DEPS = $(STD_MOD_DEPS) $(irc_TARGET)
 mod_ra_LIBS = $(COMMON_LIBS) $(STD_MOD_LIBS) $(irc_TARGET)
@@ -125,7 +129,7 @@ mod_ra: $(mod_ra_TARGET)
 
 # Command and Conquer
 mod_cnc_SRCS := $(shell find OpenRA.Mods.Cnc/ -iname '*.cs')
-mod_cnc_TARGET = mods/cnc/OpenRA.Mods.Cnc.dll
+mod_cnc_TARGET = $(OUTPUT_DIR)/OpenRA.Mods.Cnc.dll
 mod_cnc_KIND = library
 mod_cnc_DEPS = $(STD_MOD_DEPS) $(mod_ra_TARGET)
 mod_cnc_LIBS = $(COMMON_LIBS) $(STD_MOD_LIBS) $(mod_ra_TARGET)
@@ -134,7 +138,7 @@ mod_cnc: $(mod_cnc_TARGET)
 
 # Dune 2000
 mod_d2k_SRCS := $(shell find OpenRA.Mods.D2k/ -iname '*.cs')
-mod_d2k_TARGET = mods/d2k/OpenRA.Mods.D2k.dll
+mod_d2k_TARGET = $(OUTPUT_DIR)/OpenRA.Mods.D2k.dll
 mod_d2k_KIND = library
 mod_d2k_DEPS = $(STD_MOD_DEPS) $(mod_ra_TARGET) $(mod_cnc_TARGET)
 mod_d2k_LIBS = $(COMMON_LIBS) $(STD_MOD_LIBS) $(mod_ra_TARGET)
@@ -143,7 +147,7 @@ mod_d2k: $(mod_d2k_TARGET)
 
 # Tiberian Sun
 mod_ts_SRCS := $(shell find OpenRA.Mods.TS/ -iname '*.cs')
-mod_ts_TARGET = mods/ts/OpenRA.Mods.TS.dll
+mod_ts_TARGET = $(OUTPUT_DIR)/OpenRA.Mods.TS.dll
 mod_ts_KIND = library
 mod_ts_DEPS = $(STD_MOD_DEPS) $(mod_ra_TARGET)
 mod_ts_LIBS = $(COMMON_LIBS) $(STD_MOD_LIBS) $(mod_ra_TARGET)
@@ -154,23 +158,23 @@ mod_ts: $(mod_ts_TARGET)
 
 # Map Editor
 editor_SRCS := $(shell find OpenRA.Editor/ -iname '*.cs')
-editor_TARGET = OpenRA.Editor.exe
+editor_TARGET = $(OUTPUT_DIR)/OpenRA.Editor.exe
 editor_KIND = winexe
 editor_DEPS = $(game_TARGET)
 editor_LIBS = System.Windows.Forms.dll System.Data.dll System.Drawing.dll $(editor_DEPS) thirdparty/Eluant.dll
-editor_EXTRA = -resource:OpenRA.Editor.Form1.resources -resource:OpenRA.Editor.MapSelect.resources
+editor_EXTRA = -resource:$(OUTPUT_DIR)/OpenRA.Editor.Form1.resources -resource:$(OUTPUT_DIR)/OpenRA.Editor.MapSelect.resources
 editor_FLAGS = -win32icon:OpenRA.Editor/OpenRA.Editor.Icon.ico
 
 PROGRAMS += editor
-OpenRA.Editor.MapSelect.resources:
-	resgen2 OpenRA.Editor/MapSelect.resx OpenRA.Editor.MapSelect.resources 1> /dev/null
-OpenRA.Editor.Form1.resources:
-	resgen2 OpenRA.Editor/Form1.resx OpenRA.Editor.Form1.resources 1> /dev/null
-editor: OpenRA.Editor.MapSelect.resources OpenRA.Editor.Form1.resources $(editor_TARGET)
+$(OUTPUT_DIR)/OpenRA.Editor.MapSelect.resources:
+	resgen2 OpenRA.Editor/MapSelect.resx $(OUTPUT_DIR)/OpenRA.Editor.MapSelect.resources 1> /dev/null
+$(OUTPUT_DIR)/OpenRA.Editor.Form1.resources:
+	resgen2 OpenRA.Editor/Form1.resx $(OUTPUT_DIR)/OpenRA.Editor.Form1.resources 1> /dev/null
+editor: $(OUTPUT_DIR)/OpenRA.Editor.MapSelect.resources $(OUTPUT_DIR)/OpenRA.Editor.Form1.resources $(editor_TARGET)
 
 # Analyses mod yaml for easy to detect errors
 ralint_SRCS := $(shell find OpenRA.Lint/ -iname '*.cs')
-ralint_TARGET = OpenRA.Lint.exe
+ralint_TARGET = $(OUTPUT_DIR)/OpenRA.Lint.exe
 ralint_KIND = exe
 ralint_DEPS = $(game_TARGET)
 ralint_LIBS = $(COMMON_LIBS) $(ralint_DEPS)
@@ -179,35 +183,35 @@ ralint: $(ralint_TARGET)
 
 test:
 	@echo "OpenRA.Lint: checking Red Alert mod MiniYAML..."
-	@mono --debug OpenRA.Lint.exe --verbose ra
+	@mono --debug $(OUTPUT_DIR)/OpenRA.Lint.exe --verbose ra
 	@echo "OpenRA.Lint: checking Tiberian Dawn mod MiniYAML..."
-	@mono --debug OpenRA.Lint.exe --verbose cnc
+	@mono --debug $(OUTPUT_DIR)/OpenRA.Lint.exe --verbose cnc
 	@echo "OpenRA.Lint: checking Dune 2000 mod MiniYAML..."
-	@mono --debug OpenRA.Lint.exe --verbose d2k
+	@mono --debug $(OUTPUT_DIR)/OpenRA.Lint.exe --verbose d2k
 	@echo "OpenRA.Lint: checking Tiberian Sun mod MiniYAML..."
-	@mono --debug OpenRA.Lint.exe --verbose ts
+	@mono --debug $(OUTPUT_DIR)/OpenRA.Lint.exe --verbose ts
 
 # Builds and exports tilesets from a bitmap
 tsbuild_SRCS := $(shell find OpenRA.TilesetBuilder/ -iname '*.cs')
-tsbuild_TARGET = OpenRA.TilesetBuilder.exe
+tsbuild_TARGET = $(OUTPUT_DIR)/OpenRA.TilesetBuilder.exe
 tsbuild_KIND = winexe
 tsbuild_DEPS = $(game_TARGET)
 tsbuild_LIBS = $(COMMON_LIBS) $(tsbuild_DEPS) System.Windows.Forms.dll
-tsbuild_EXTRA = -resource:OpenRA.TilesetBuilder.FormBuilder.resources -resource:OpenRA.TilesetBuilder.FormNew.resources -resource:OpenRA.TilesetBuilder.Surface.resources
+tsbuild_EXTRA = -resource:$(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormBuilder.resources -resource:$(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormNew.resources -resource:$(OUTPUT_DIR)/OpenRA.TilesetBuilder.Surface.resources
 PROGRAMS += tsbuild
-OpenRA.TilesetBuilder.FormBuilder.resources:
-	resgen2 OpenRA.TilesetBuilder/FormBuilder.resx OpenRA.TilesetBuilder.FormBuilder.resources 1> /dev/null
-OpenRA.TilesetBuilder.FormNew.resources:
-	resgen2 OpenRA.TilesetBuilder/frmNew.resx OpenRA.TilesetBuilder.FormNew.resources 1> /dev/null
-OpenRA.TilesetBuilder.Surface.resources:
-	resgen2 OpenRA.TilesetBuilder/Surface.resx OpenRA.TilesetBuilder.Surface.resources 1> /dev/null
-tsbuild: OpenRA.TilesetBuilder.FormBuilder.resources OpenRA.TilesetBuilder.FormNew.resources OpenRA.TilesetBuilder.Surface.resources $(tsbuild_TARGET)
+$(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormBuilder.resources:
+	resgen2 OpenRA.TilesetBuilder/FormBuilder.resx $(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormBuilder.resources 1> /dev/null
+$(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormNew.resources:
+	resgen2 OpenRA.TilesetBuilder/frmNew.resx $(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormNew.resources 1> /dev/null
+$(OUTPUT_DIR)/OpenRA.TilesetBuilder.Surface.resources:
+	resgen2 OpenRA.TilesetBuilder/Surface.resx $(OUTPUT_DIR)/OpenRA.TilesetBuilder.Surface.resources 1> /dev/null
+tsbuild: $(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormBuilder.resources $(OUTPUT_DIR)/OpenRA.TilesetBuilder.FormNew.resources $(OUTPUT_DIR)/OpenRA.TilesetBuilder.Surface.resources $(tsbuild_TARGET)
 
 
 ##### Launchers / Utilities #####
 
 crashdialog_SRCS := $(shell find OpenRA.CrashDialog/ -iname '*.cs')
-crashdialog_TARGET = OpenRA.CrashDialog.exe
+crashdialog_TARGET = $(OUTPUT_DIR)/OpenRA.CrashDialog.exe
 crashdialog_KIND = exe
 crashdialog_DEPS = $(game_TARGET)
 crashdialog_LIBS = $(COMMON_LIBS) $(crashdialog_DEPS) System.Windows.Forms.dll
@@ -217,24 +221,23 @@ crashdialog: $(crashdialog_TARGET)
 
 # Backend for the launcher apps - queries game/mod info and applies actions to an install
 utility_SRCS := $(shell find OpenRA.Utility/ -iname '*.cs')
-utility_TARGET = OpenRA.Utility.exe
+utility_TARGET = $(OUTPUT_DIR)/OpenRA.Utility.exe
 utility_KIND = exe
 utility_DEPS = $(game_TARGET) $(mod_ra_TARGET)
 utility_LIBS = $(COMMON_LIBS) $(utility_DEPS) thirdparty/ICSharpCode.SharpZipLib.dll
 PROGRAMS += utility
 utility: $(utility_TARGET)
-	@$(CP) $(mod_ra_TARGET) .
 
 
 # Patches binary headers to work around a mono bug
-fixheader.exe: packaging/fixheader.cs
-	@echo CSC fixheader.exe
-	@$(CSC) packaging/fixheader.cs $(CSFLAGS) -out:fixheader.exe -t:exe $(COMMON_LIBS:%=-r:%)
+$(OUTPUT_DIR)/fixheader.exe: $(ENSURE_OUTPUT_DIR) packaging/fixheader.cs
+	@echo CSC $(OUTPUT_DIR)/fixheader.exe
+	@$(CSC) packaging/fixheader.cs $(CSFLAGS) -out:$(OUTPUT_DIR)/fixheader.exe -t:exe $(COMMON_LIBS:%=-r:%)
 
 # Generate build rules for each target defined above in PROGRAMS
 define BUILD_ASSEMBLY
 
-$$($(1)_TARGET): $$($(1)_SRCS) Makefile $$($(1)_DEPS) fixheader.exe
+$$($(1)_TARGET): $$($(1)_SRCS) Makefile $$($(1)_DEPS) $(ENSURE_OUTPUT_DIR) $(OUTPUT_DIR)/fixheader.exe
 	@echo CSC $$(@)
 	@$(CSC) $$($(1)_LIBS:%=-r:%) \
 		-out:$$(@) $(CSFLAGS) $$($(1)_FLAGS) \
@@ -242,7 +245,7 @@ $$($(1)_TARGET): $$($(1)_SRCS) Makefile $$($(1)_DEPS) fixheader.exe
 		-t:"$$($(1)_KIND)" \
 		$$($(1)_EXTRA) \
 		$$($(1)_SRCS)
-	@mono fixheader.exe $$(@) > /dev/null
+	@mono $(OUTPUT_DIR)/fixheader.exe $$(@) > /dev/null
 	@test `echo $$(@) | sed 's/^.*\.//'` = "dll" && chmod a-x $$(@) || ``
 	@$$($(1)_EXTRA_CMDS)
 endef
@@ -266,7 +269,7 @@ mods: mod_ra mod_cnc mod_d2k mod_ts
 all: cli-dependencies core tools
 
 clean:
-	@-$(RM_F) *.exe *.dll ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
+	@-$(RM_F) $(OUTPUT_DIR)/* ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
 	@-$(RM_RF) ./*/bin ./*/obj
 
 distclean: clean
@@ -278,12 +281,16 @@ endif
 
 dependencies: cli-dependencies native-dependencies
 
-cli-dependencies:
-	@ $(CP_R) thirdparty/*.dll .
-	@ $(CP_R) thirdparty/*.dll.config .
+$(ENSURE_OUTPUT_DIR):
+	@mkdir -p $(OUTPUT_DIR)
+	@touch $(ENSURE_OUTPUT_DIR)
 
-native-dependencies:
-	@ $(CP_R) thirdparty/${platformdeps}/* .
+cli-dependencies: $(ENSURE_OUTPUT_DIR)
+	@ $(CP_R) thirdparty/*.dll $(OUTPUT_DIR)/
+	@ $(CP_R) thirdparty/*.dll.config $(OUTPUT_DIR)/
+
+native-dependencies: $(ENSURE_OUTPUT_DIR)
+	@ $(CP_R) thirdparty/${platformdeps}/*.dll.config $(OUTPUT_DIR)/
 
 version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/modchooser/mod.yaml
 	@for i in $? ; do \
@@ -293,8 +300,8 @@ version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/modchooser/mo
 
 # Documentation (d2k depends on all mod libraries)
 docs: utility
-	@mono --debug OpenRA.Utility.exe --docs d2k > DOCUMENTATION.md
-	@mono --debug OpenRA.Utility.exe --lua-docs ra > Lua-API.md
+	@mono --debug $(OUTPUT_DIR)/OpenRA.Utility.exe --docs d2k > DOCUMENTATION.md
+	@mono --debug $(OUTPUT_DIR)/OpenRA.Utility.exe --lua-docs ra > Lua-API.md
 
 install: install-core
 
@@ -324,19 +331,19 @@ install-core: default
 	@$(CP_R) glsl "$(DATA_INSTALL_DIR)"
 	@$(CP_R) lua "$(DATA_INSTALL_DIR)"
 	@$(CP) *.ttf "$(DATA_INSTALL_DIR)"
-	@$(CP) SDL2-CS* "$(DATA_INSTALL_DIR)"
-	@$(CP) Eluant* "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) ICSharpCode.SharpZipLib.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) FuzzyLogicLibrary.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) SharpFont.dll "$(DATA_INSTALL_DIR)"
-	@$(CP) SharpFont.dll.config "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) Mono.Nat.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) KopiLua.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) NLua.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) MaxMind.Db.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) MaxMind.GeoIP2.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) RestSharp.dll "$(DATA_INSTALL_DIR)"
+	@$(CP) $(OUTPUT_DIR)/SDL2-CS* "$(DATA_INSTALL_DIR)"
+	@$(CP) $(OUTPUT_DIR)/Eluant* "$(DATA_INSTALL_DIR)"
+	@$(CP) $(OUTPUT_DIR)/SharpFont.dll.config "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/ICSharpCode.SharpZipLib.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/FuzzyLogicLibrary.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/SharpFont.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/Mono.Nat.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/KopiLua.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/NLua.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/MaxMind.Db.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/MaxMind.GeoIP2.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) $(OUTPUT_DIR)/RestSharp.dll "$(DATA_INSTALL_DIR)"
 
 ifeq ($(shell uname),Linux)
 	@$(CP) *.sh "$(DATA_INSTALL_DIR)"

--- a/OpenRA.CrashDialog/OpenRA.CrashDialog.csproj
+++ b/OpenRA.CrashDialog/OpenRA.CrashDialog.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{47F1B0EE-EB35-47F2-93E4-273C70909157}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>OpenRA</RootNamespace>
@@ -11,7 +11,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>x86</PlatformTarget>

--- a/OpenRA.Editor/OpenRA.Editor.csproj
+++ b/OpenRA.Editor/OpenRA.Editor.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{00038B75-405B-44F5-8691-BD2546DBE224}</ProjectGuid>
@@ -35,7 +35,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Graphics
 			var resolution = GetResolution(windowMode);
 
 			var renderer = Game.Settings.Server.Dedicated ? "Null" : Game.Settings.Graphics.Renderer;
-			var rendererPath = Path.GetFullPath("OpenRA.Renderer.{0}.dll".F(renderer));
+			var rendererPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "OpenRA.Renderer.{0}.dll".F(renderer));
 
 			device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, windowMode);
 		}

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -36,7 +36,11 @@ namespace OpenRA
 			// Namespaces from each mod assembly
 			foreach (var a in manifest.Assemblies)
 			{
-				var asm = Assembly.LoadFile(Path.GetFullPath(a));
+				var path = Path.GetFullPath(a);
+				if (!File.Exists(path))
+					path = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), Path.GetFileName(a));
+
+				var asm = Assembly.LoadFile(path);
 				asms.AddRange(asm.GetNamespaces().Select(ns => Pair.New(asm, ns)));
 			}
 

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -36,6 +36,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>

--- a/OpenRA.Irc/OpenRA.Irc.csproj
+++ b/OpenRA.Irc/OpenRA.Irc.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{85B48234-8B31-4BE6-AF9C-665CC6866841}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/OpenRA.Lint/OpenRA.Lint.csproj
+++ b/OpenRA.Lint/OpenRA.Lint.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{F9FA4D9F-2302-470A-8A07-6E37F488C124}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -32,7 +32,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>x86</PlatformTarget>

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{2881135D-4D62-493E-8F83-5EEE92CCC6BE}</ProjectGuid>
@@ -37,12 +37,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <OutputPath>bin\Debug\</OutputPath>
-    <CustomCommands>
-      <CustomCommands>
-        <Command type="AfterBuild" command="cp ${TargetFile} ../mods/cnc" workingdir="${ProjectDir}" />
-      </CustomCommands>
-    </CustomCommands>
+    <OutputPath>..\bin</OutputPath>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>9.0.21022</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C0B0465C-6BE2-409C-8770-3A9BF64C4344}</ProjectGuid>
@@ -37,12 +37,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <OutputPath>bin\Debug\</OutputPath>
-    <CustomCommands>
-      <CustomCommands>
-        <Command type="AfterBuild" command="cp ${TargetFile} ../mods/d2k" workingdir="${ProjectDir}" />
-      </CustomCommands>
-    </CustomCommands>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>TRACE;DEBUG;</DefineConstants>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{4A8A43B5-A9EF-4ED0-99DD-4BAB10A0DB6E}</ProjectGuid>
@@ -34,16 +34,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CustomCommands>
-      <CustomCommands>
-        <Command type="AfterBuild" command="cp ../thirdparty/FuzzyLogicLibrary.dll ../" workingdir="${ProjectDir}" />
-        <Command type="AfterBuild" command="cp ${TargetFile} ../mods/ra" workingdir="${ProjectDir}" />
-      </CustomCommands>
-    </CustomCommands>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>10.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{5457CBF5-4CE4-421E-A8BF-9FD6C9732E1D}</ProjectGuid>
@@ -12,15 +12,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>TRACE;DEBUG;</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CustomCommands>
-      <CustomCommands>
-        <Command type="AfterBuild" command="cp ${TargetFile} ../mods/ts" workingdir="${ProjectDir}" />
-      </CustomCommands>
-    </CustomCommands>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DebugType>full</DebugType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/OpenRA.Renderer.Null/OpenRA.Renderer.Null.csproj
+++ b/OpenRA.Renderer.Null/OpenRA.Renderer.Null.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{0C4AEC1A-E7D5-4114-8CCD-3EEC82872981}</ProjectGuid>
@@ -34,7 +34,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/OpenRA.Renderer.Sdl2/OpenRA.Renderer.Sdl2.csproj
+++ b/OpenRA.Renderer.Sdl2/OpenRA.Renderer.Sdl2.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>10.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{33D03738-C154-4028-8EA8-63A3C488A651}</ProjectGuid>
@@ -13,7 +13,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>TRACE;DEBUG;</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/OpenRA.TilesetBuilder/OpenRA.TilesetBuilder.csproj
+++ b/OpenRA.TilesetBuilder/OpenRA.TilesetBuilder.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{1A8E50CC-EE32-4E57-8842-0C39C8EA7541}</ProjectGuid>
@@ -35,7 +35,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>x86</PlatformTarget>

--- a/OpenRA.Utility/OpenRA.Utility.csproj
+++ b/OpenRA.Utility/OpenRA.Utility.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{F33337BE-CB69-4B24-850F-07D23E408DDF}</ProjectGuid>
@@ -34,7 +34,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>..\bin</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <UseVSHostingProcess>false</UseVSHostingProcess>

--- a/configure
+++ b/configure
@@ -18,7 +18,7 @@ if [ "$os" == 'Linux' ]; then
 		echo "Lua 5.1 library detection failed."
 		exit 1
 	else
-		sed "s/@LIBLUA51@/${liblua51}/" thirdparty/Eluant.dll.config.in > Eluant.dll.config
+		sed "s/@LIBLUA51@/${liblua51}/" thirdparty/Eluant.dll.config.in > bin/Eluant.dll.config
 		echo "Eluant.dll.config has been created successfully."
 	fi
 fi

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -9,7 +9,7 @@ ExternalPort=1234
 AdvertiseOnline="False"
 
 while true; do
-     mono --debug OpenRA.Game.exe Game.Mod=$Mod Server.Dedicated=$Dedicated Server.DedicatedLoop=$DedicatedLoop \
+     mono --debug bin/OpenRA.Game.exe Game.Mod=$Mod Server.Dedicated=$Dedicated Server.DedicatedLoop=$DedicatedLoop \
      Server.Name=$Name Server.ListenPort=$ListenPort Server.ExternalPort=$ExternalPort \
      Server.AdvertiseOnline=$AdvertiseOnline
 done

--- a/launch-editor.sh
+++ b/launch-editor.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # launch script (executed by Desura)
-exec mono OpenRA.Editor.exe "$@"
+exec mono bin/OpenRA.Editor.exe "$@"

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # launch script (executed by Desura)
-exec mono OpenRA.Game.exe Server.Dedicated=False Server.DedicatedLoop=False "$@"
+exec mono bin/OpenRA.Game.exe Server.Dedicated=False Server.DedicatedLoop=False "$@"

--- a/launch-replay.sh
+++ b/launch-replay.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # TODO choose the correct Game.Mod instead of crashing
 cd ${0%/*}
-exec mono OpenRA.Game.exe Launch.Replay="$@"
+exec mono bin/OpenRA.Game.exe Launch.Replay="$@"

--- a/make.ps1
+++ b/make.ps1
@@ -67,8 +67,7 @@ elseif ($command -eq "clean")
 	else
 	{
 		$proc = Start-Process $msBuild /t:Clean -NoNewWindow -PassThru -Wait
-		rm *.dll # delete third party dependencies
-		rm *.config
+		rm bin/*
 		rm mods/*/*.dll
 		echo "Clean complete."
 	}
@@ -90,21 +89,22 @@ elseif ($command -eq "version")
 }
 elseif ($command -eq "dependencies")
 {
-	cp thirdparty/*.dll .
-	cp thirdparty/windows/*.dll .
+	New-Item -ItemType Directory -Force -Path bin
+	cp thirdparty/*.dll bin/
+	cp thirdparty/windows/*.dll bin/
 	echo "Dependencies copied."
 }
 elseif ($command -eq "test")
 {
 	echo "Testing mods..."
 	echo "OpenRA.Lint: checking Red Alert mod MiniYAML..."
-	./OpenRA.Lint.exe --verbose ra
+	./bin/OpenRA.Lint.exe --verbose ra
 	echo "OpenRA.Lint: checking Tiberian Dawn mod MiniYAML..."
-	./OpenRA.Lint.exe --verbose cnc
+	./bin/OpenRA.Lint.exe --verbose cnc
 	echo "OpenRA.Lint: checking Dune 2000 mod MiniYAML..."
-	./OpenRA.Lint.exe --verbose d2k
+	./bin/OpenRA.Lint.exe --verbose d2k
 	echo "OpenRA.Lint: checking Tiberian Sun mod MiniYAML..."
-	./OpenRA.Lint.exe --verbose ts
+	./bin/OpenRA.Lint.exe --verbose ts
 }
 else
 {

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -30,8 +30,8 @@ markdown DOCUMENTATION.md > DOCUMENTATION.html
 markdown Lua-API.md > Lua-API.html
 
 # List of files that are packaged on all platforms
-FILES=('OpenRA.Game.exe' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' 'OpenRA.CrashDialog.exe' \
-'OpenRA.Renderer.Sdl2.dll' 'OpenRA.Renderer.Null.dll' 'OpenRA.Irc.dll' \
+FILES=('bin/OpenRA.Game.exe' 'bin/OpenRA.Editor.exe' 'bin/OpenRA.Utility.exe' 'bin/OpenRA.CrashDialog.exe' \
+'bin/OpenRA.Renderer.Sdl2.dll' 'bin/OpenRA.Renderer.Null.dll' 'bin/OpenRA.Irc.dll' \
 'FreeSans.ttf' 'FreeSansBold.ttf' 'lua' \
 'glsl' 'mods/common' 'mods/ra' 'mods/cnc' 'mods/d2k' 'mods/modchooser' \
 'AUTHORS' 'COPYING' \
@@ -42,6 +42,11 @@ echo "Copying files..."
 for i in "${FILES[@]}"; do
 	cp -R "${i}" "packaging/built/${i}" || exit 3
 done
+
+# Mod binaries
+cp bin/OpenRA.Mods.RA.dll packaging/built/mods/ra
+cp bin/OpenRA.Mods.Cnc.dll packaging/built/mods/cnc
+cp bin/OpenRA.Mods.D2k.dll packaging/built/mods/d2k
 
 # SharpZipLib for zip file support
 cp thirdparty/ICSharpCode.SharpZipLib.dll packaging/built

--- a/thirdparty/linux/Eluant.dll.config
+++ b/thirdparty/linux/Eluant.dll.config
@@ -1,4 +1,4 @@
 <configuration>
-  <dllmap os="linux" dll="lua51.dll" cpu="x86" target="liblua32.5.1.5.so" />
-  <dllmap os="linux" dll="lua51.dll" cpu="x86-64" target="liblua64.5.1.5.so" />
+  <dllmap os="linux" dll="lua51.dll" cpu="x86" target="thirdparty/linux/liblua32.5.1.5.so" />
+  <dllmap os="linux" dll="lua51.dll" cpu="x86-64" target="thirdparty/linux/liblua64.5.1.5.so" />
 </configuration>

--- a/thirdparty/linux/SDL2-CS.dll.config
+++ b/thirdparty/linux/SDL2-CS.dll.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <dllmap os="linux" dll="SDL2.dll" cpu="x86" target="libSDL232.2.0.2.so" />
-  <dllmap os="linux" dll="SDL2.dll" cpu="x86-64" target="libSDL264.2.0.2.so" />
+  <dllmap os="linux" dll="SDL2.dll" cpu="x86" target="thirdparty/linux/libSDL232.2.0.2.so" />
+  <dllmap os="linux" dll="SDL2.dll" cpu="x86-64" target="thirdparty/linux/libSDL264.2.0.2.so" />
 
   <dllmap dll="soft_oal.dll" os="linux" target="libopenal.so.1"/>
 

--- a/thirdparty/osx/Eluant.dll.config
+++ b/thirdparty/osx/Eluant.dll.config
@@ -1,3 +1,3 @@
 <configuration>
-  <dllmap os="osx" dll="lua51.dll" target="liblua.5.1.dylib" />
+  <dllmap os="osx" dll="lua51.dll" target="thirdparty/osx/liblua.5.1.dylib" />
 </configuration>


### PR DESCRIPTION
This changes the project files and the build scripts output directory to a new "bin" directory instead of the tree root.

Notes:
- Needs testing on platforms other than Linux
- Needs testing with packaging and installation on all platforms
- I'd like to make a few more changes, like creating a "data" directory and moving the .ttf and GeoIP files there.
- Maybe create a "scripts" directory for the Linux launch scripts
- Maybe do the same for the generated docs (make docs)

See also #5457 
