### PR TITLE
Fix FlyAttack discarding the activity queue upon completion

### DIFF
--- a/OpenRA.Mods.RA/Air/FlyAttack.cs
+++ b/OpenRA.Mods.RA/Air/FlyAttack.cs
@@ -22,11 +22,11 @@ namespace OpenRA.Mods.RA.Air
 		public override Activity Tick(Actor self)
 		{
 			if (!target.IsValidFor(self))
-				Cancel(self);
+				return NextActivity;
 
 			var limitedAmmo = self.TraitOrDefault<LimitedAmmo>();
 			if (limitedAmmo != null && !limitedAmmo.HasAmmo())
-				Cancel(self);
+				return NextActivity;
 
 			var attack = self.TraitOrDefault<AttackPlane>();
 			if (attack != null)

--- a/mods/ra/maps/intervention/mission.lua
+++ b/mods/ra/maps/intervention/mission.lua
@@ -77,7 +77,6 @@ FollowWaypoints = function(team, waypoints)
 end
 
 PlaneExitMap = function(actor, exitPoint)
-	Actor.Stop(actor)
 	Actor.Fly(actor, exitPoint.CenterPosition)
 	Actor.FlyOffMap(actor)
 	Actor.RemoveSelf(actor)
@@ -94,15 +93,9 @@ BaseRaid = function()
 	local flight = Team.New(Reinforcements.ReinforceAir(soviets, BaseRaidAircraft, BaseRaidEntrypoint, BaseRaidWpts[1], Utils.Seconds(1)))
 	FollowWaypoints(flight, BaseRaidWpts)
 
-	-- this is a workaround for bug #4482
-	Actor.OnDamaged(target, function()
-		Team.Do(flight, function(plane)
-			PlaneExitMap(plane, VillageRaidEntrypoint)
-		end)
-	end)
-
 	Team.Do(flight, function(plane)
 		Actor.FlyAttackActor(plane, target)
+		PlaneExitMap(plane, VillageRaidEntrypoint)
 	end)
 
 	OpenRA.RunAfterDelay(BaseRaidInterval, BaseRaid)
@@ -124,15 +117,9 @@ VillageRaid = function()
 	local flight = Team.New(Reinforcements.ReinforceAir(soviets, VillageRaidAircraft, VillageRaidEntrypoint, VillageRaidWpts[1], Utils.Seconds(1)))
 	FollowWaypoints(flight, VillageRaidWpts)
 
-	-- this is a workaround for bug #4482
-	Actor.OnDamaged(target, function()
-		Team.Do(flight, function(actor)
-			PlaneExitMap(actor, BaseRaidEntrypoint)
-		end)
-	end)
-
 	Team.Do(flight, function(plane)
 		Actor.FlyAttackActor(plane, target)
+		PlaneExitMap(plane, BaseRaidEntrypoint)
 	end)
 
 	OpenRA.RunAfterDelay(VillageRaidInterval, VillageRaid)

--- a/mods/ra/maps/intervention/mission.lua
+++ b/mods/ra/maps/intervention/mission.lua
@@ -188,7 +188,9 @@ SetupWorld = function()
 	Utils.Do(Actor.ActorsWithTrait("RepairableBuilding"), function(building)
 		if Actor.Owner(building) == soviets then
 			Actor.OnDamaged(building, function(b)
-				Actor.RepairBuilding(b)
+				if Actor.Owner(b) == soviets then
+					Actor.RepairBuilding(b)
+				end
 			end)
 		end
 	end)


### PR DESCRIPTION
This fixes a long-standing pet peeve of mine and makes aircraft finally fully scriptable without workarounds.

This pr also removes said workaround from the intervention mission, and also fixes another small issue the map had, which doesn't really deserve its own pr.
