### PR TITLE
Properly save replay even when the game crashes (fixes #5610)

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -483,25 +483,30 @@ namespace OpenRA
 
 			SetIdealFrameTime(Settings.Graphics.MaxFramerate);
 
-			while (state == RunStatus.Running)
+			try
 			{
-				if (Settings.Graphics.CapFramerate)
+				while (state == RunStatus.Running)
 				{
-					var sw = Stopwatch.StartNew();
+					if (Settings.Graphics.CapFramerate)
+					{
+						var sw = Stopwatch.StartNew();
 
-					Tick(orderManager);
+						Tick(orderManager);
 
-					var waitTime = Math.Min(idealFrameTime - sw.Elapsed.TotalSeconds, 1);
-					if (waitTime > 0)
-						System.Threading.Thread.Sleep(TimeSpan.FromSeconds(waitTime));
+						var waitTime = Math.Min(idealFrameTime - sw.Elapsed.TotalSeconds, 1);
+						if (waitTime > 0)
+							System.Threading.Thread.Sleep(TimeSpan.FromSeconds(waitTime));
+					}
+					else
+						Tick(orderManager);
 				}
-				else
-					Tick(orderManager);
 			}
-
-			// Ensure that the active replay is properly saved
-			if (orderManager != null)
-				orderManager.Dispose();
+			finally
+			{
+				// Ensure that the active replay is properly saved
+				if (orderManager != null)
+					orderManager.Dispose();
+			}
 				
 			Renderer.Device.Dispose();
 


### PR DESCRIPTION
I simply wrapped the run loop and the orderManager disposal in a try/finally block. The rest is whitespace changes; [add ?w=1 to the url to ignore whitespace](https://github.com/pavlos256/OpenRA/commit/e19dae8eeca66d72a5d1efbab6803bcdb70b9377?w=1).

I tested it before and after using the new /crash command.
