### PR TITLE
Allied Paratanks

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -939,7 +939,7 @@ HPAD:
 	IronCurtainable:
 	ParatroopersPower:
 		Icon: paratroopers
-		ChargeTime: 480
+		ChargeTime: 440
 		Description: Paratanks
 		LongDesc: A Badger drops some tank\nanywhere on the map.
 		DropItems: 1tnk, jeep, jeep
@@ -989,7 +989,7 @@ AFLD:
 		EndChargeSound: spypln1.aud
 	ParatroopersPower:
 		Icon: paratroopers
-		ChargeTime: 360
+		ChargeTime: 440
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
 		DropItems: E1,E1,E2,E3,E3,E3,E6

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -942,7 +942,7 @@ HPAD:
 		ChargeTime: 480
 		Description: Paratanks
 		LongDesc: A Badger drops some tank\nanywhere on the map.
-		DropItems: 1tnk, 1tnk, jeep
+		DropItems: 1tnk, jeep, jeep
 		SelectTargetSound: slcttgt1.aud
 	ProductionBar:
 	PrimaryBuilding:
@@ -992,7 +992,7 @@ AFLD:
 		ChargeTime: 360
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
-		DropItems: E1,E1,E2,E3,E3,E6
+		DropItems: E1,E1,E2,E3,E3,E3,E6
 		SelectTargetSound: slcttgt1.aud
 	ProductionBar:
 	SupportPowerChargeBar:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -916,7 +916,7 @@ HPAD:
 		Cost: 500
 	Tooltip:
 		Name: Helipad
-		Description: Produces and reloads helicopters.
+		Description: Produces and reloads helicopters. \n  Special Ability: Parabombs
 	Building:
 		Power: -10
 		Footprint: xx xx
@@ -937,6 +937,13 @@ HPAD:
 		Produces: Helicopter
 	Reservable:
 	IronCurtainable:
+	ParatroopersPower:
+		Icon: parabomb
+		ChargeTime: 400
+		Description: Parabomb
+		LongDesc: A Badger drops some bombs\nanywhere on the map.
+		DropItems: Bomb, Bomb, Bomb, Bomb, Bomb
+		SelectTargetSound: slcttgt1.aud
 	ProductionBar:
 	PrimaryBuilding:
 

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -942,7 +942,7 @@ HPAD:
 		ChargeTime: 480
 		Description: Paratanks
 		LongDesc: A Badger drops some tank\nanywhere on the map.
-		DropItems: 1tnk, 1tnk, apc
+		DropItems: 1tnk, 1tnk, jeep
 		SelectTargetSound: slcttgt1.aud
 	ProductionBar:
 	PrimaryBuilding:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -992,7 +992,7 @@ AFLD:
 		ChargeTime: 360
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
-		DropItems: E1,E1,E1,E3,E3
+		DropItems: E1,E1,E2,E3,E3,E6
 		SelectTargetSound: slcttgt1.aud
 	ProductionBar:
 	SupportPowerChargeBar:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -916,7 +916,7 @@ HPAD:
 		Cost: 500
 	Tooltip:
 		Name: Helipad
-		Description: Produces and reloads helicopters.
+		Description: Produces and reloads helicopters. \n  Special Ability: Paratanks
 	Building:
 		Power: -10
 		Footprint: xx xx
@@ -939,8 +939,8 @@ HPAD:
 	IronCurtainable:
 	ParatroopersPower:
 		Icon: paratroopers
-		ChargeTime: 400
-		Description: Paratank
+		ChargeTime: 480
+		Description: Paratanks
 		LongDesc: A Badger drops some tank\nanywhere on the map.
 		DropItems: 1tnk, 1tnk, apc
 		SelectTargetSound: slcttgt1.aud

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -916,7 +916,7 @@ HPAD:
 		Cost: 500
 	Tooltip:
 		Name: Helipad
-		Description: Produces and reloads helicopters. \n  Special Ability: Parabombs
+		Description: Produces and reloads helicopters.
 	Building:
 		Power: -10
 		Footprint: xx xx
@@ -938,11 +938,11 @@ HPAD:
 	Reservable:
 	IronCurtainable:
 	ParatroopersPower:
-		Icon: parabomb
+		Icon: paratroopers
 		ChargeTime: 400
-		Description: Parabomb
-		LongDesc: A Badger drops some bombs\nanywhere on the map.
-		DropItems: Bomb, Bomb, Bomb, Bomb, Bomb
+		Description: Paratank
+		LongDesc: A Badger drops some tank\nanywhere on the map.
+		DropItems: 1tnk, 1tnk, apc
 		SelectTargetSound: slcttgt1.aud
 	ProductionBar:
 	PrimaryBuilding:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -800,25 +800,3 @@ STNK:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
-
-BOMB:
-	Inherits: ^Vehicle
-	Tooltip:
-		Name: Bomb
-	Health:
-		HP: 50
-	Armor:
-		Type: Light
-	Mobile:
-		Speed: 0
-	RevealsShroud:
-		Range: 2c0
-	RenderUnit:
-	Explodes:
-		Weapon: BarrelExplode
-		EmptyWeapon: BarrelExplode
-	DemoTruck:
-	-IronCurtainable:
-	Chronoshiftable:
-		ExplodeInstead: yes
-

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -801,3 +801,24 @@ STNK:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
 
+BOMB:
+	Inherits: ^Vehicle
+	Tooltip:
+		Name: Bomb
+	Health:
+		HP: 50
+	Armor:
+		Type: Light
+	Mobile:
+		Speed: 0
+	RevealsShroud:
+		Range: 2c0
+	RenderUnit:
+	Explodes:
+		Weapon: BarrelExplode
+		EmptyWeapon: BarrelExplode
+	DemoTruck:
+	-IronCurtainable:
+	Chronoshiftable:
+		ExplodeInstead: yes
+

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -800,3 +800,4 @@ STNK:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
+


### PR DESCRIPTION
I think there is a balance problem in special weapons. Soviets have 2(Spy Plane, Paratrooper,) Allieds have 1(GPS) special weapons. I added Paratanks to allieds. But icon is missing(same as paratrooper) also soviet paratroopers are now more powerful.
