### PR TITLE
Cache tileset lookup in Map

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -115,6 +115,7 @@ namespace OpenRA
 		[FieldLoader.Ignore] public Lazy<CellLayer<ResourceTile>> MapResources;
 		[FieldLoader.Ignore] public CellLayer<int> CustomTerrain;
 
+		[FieldLoader.Ignore] Lazy<TileSet> cachedTileSet;
 		[FieldLoader.Ignore] Lazy<Ruleset> rules;
 		public Ruleset Rules { get { return rules != null ? rules.Value : null; } }
 		public SequenceProvider SequenceProvider { get { return Rules.Sequences[Tileset]; } }
@@ -259,6 +260,7 @@ namespace OpenRA
 		void PostInit()
 		{
 			rules = Exts.Lazy(() => Game.modData.RulesetCache.LoadMapRules(this));
+			cachedTileSet = Exts.Lazy(() => Rules.TileSets[Tileset]);
 
 			var tl = new CPos(Bounds.Left, Bounds.Top);
 			var br = new CPos(Bounds.Right - 1, Bounds.Bottom - 1);
@@ -569,14 +571,12 @@ namespace OpenRA
 		public int GetTerrainIndex(CPos cell)
 		{
 			var custom = CustomTerrain[cell];
-			var tileSet = Rules.TileSets[Tileset];
-			return custom != -1 ? custom : tileSet.GetTerrainIndex(MapTiles.Value[cell]);
+			return custom != -1 ? custom : cachedTileSet.Value.GetTerrainIndex(MapTiles.Value[cell]);
 		}
 
 		public TerrainTypeInfo GetTerrainInfo(CPos cell)
 		{
-			var tileSet = Rules.TileSets[Tileset];
-			return tileSet[GetTerrainIndex(cell)];
+			return cachedTileSet.Value[GetTerrainIndex(cell)];
 		}
 
 		public CPos Clamp(CPos xy)


### PR DESCRIPTION
The lookup accounts for ~50-60% of the time spent in GetTerrainIndex and GetTerrainInfo, and these methods themselves can account for up to 1.3% of total CPU used (during a replay, so admittedly this would be higher than otherwise since there's not as much other work going on during replays). Overall this is a small but measurable win.

This is slightly dangerous since Tileset is a mutable public field but it's used by FieldLoader so I can't safely wrap this up in a property or anything.
