### PR TITLE
Generalize cell/world coordinate conversions.

### DIFF
--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -104,15 +104,4 @@ namespace OpenRA
 
 		#endregion
 	}
-
-	public static class RectangleExtensions
-	{
-		public static CPos TopLeftAsCPos(this Rectangle r) { return new CPos(r.Left, r.Top); }
-		public static CPos BottomRightAsCPos(this Rectangle r) { return new CPos(r.Right, r.Bottom); }
-	}
-
-	public static class WorldCoordinateExtensions
-	{
-		public static CPos ToCPos(this WPos a) { return new CPos(a.X / 1024, a.Y / 1024); }
-	}
 }

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -114,6 +114,5 @@ namespace OpenRA
 	public static class WorldCoordinateExtensions
 	{
 		public static CPos ToCPos(this WPos a) { return new CPos(a.X / 1024, a.Y / 1024); }
-		public static CVec ToCVec(this WVec a) { return new CVec(a.X / 1024, a.Y / 1024); }
 	}
 }

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -40,10 +40,6 @@ namespace OpenRA
 		public float2 ToFloat2() { return new float2(X, Y); }
 		public int2 ToInt2() { return new int2(X, Y); }
 
-		public WPos CenterPosition { get { return new WPos(1024 * X + 512, 1024 * Y + 512, 0); } }
-		public WPos TopLeft { get { return new WPos(1024 * X, 1024 * Y, 0); } }
-		public WPos BottomRight { get { return new WPos(1024 * X + 1023, 1024 * Y + 1023, 0); } }
-
 		public CPos Clamp(Rectangle r)
 		{
 			return new CPos(Math.Min(r.Right, Math.Max(X, r.Left)),

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -37,9 +37,6 @@ namespace OpenRA
 		public static CPos Max(CPos a, CPos b) { return new CPos(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)); }
 		public static CPos Min(CPos a, CPos b) { return new CPos(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y)); }
 
-		public float2 ToFloat2() { return new float2(X, Y); }
-		public int2 ToInt2() { return new int2(X, Y); }
-
 		public CPos Clamp(Rectangle r)
 		{
 			return new CPos(Math.Min(r.Right, Math.Max(X, r.Left)),

--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -21,12 +21,7 @@ namespace OpenRA
 		public readonly int X, Y;
 
 		public CVec(int x, int y) { X = x; Y = y; }
-		public CVec(Size p) { X = p.Width; Y = p.Height; }
-
 		public static readonly CVec Zero = new CVec(0, 0);
-
-		public static explicit operator CVec(int2 a) { return new CVec(a.X, a.Y); }
-		public static explicit operator CVec(float2 a) { return new CVec((int)a.X, (int)a.Y); }
 
 		public static CVec operator +(CVec a, CVec b) { return new CVec(a.X + b.X, a.Y + b.Y); }
 		public static CVec operator -(CVec a, CVec b) { return new CVec(a.X - b.X, a.Y - b.Y); }
@@ -49,8 +44,6 @@ namespace OpenRA
 		public int LengthSquared { get { return X * X + Y * Y; } }
 		public int Length { get { return (int)Math.Sqrt(LengthSquared); } }
 
-		public float2 ToFloat2() { return new float2(X, Y); }
-		public int2 ToInt2() { return new int2(X, Y); }
 		public WVec ToWVec() { return new WVec(X*1024, Y*1024, 0); }
 
 		public CVec Clamp(Rectangle r)

--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -44,8 +44,6 @@ namespace OpenRA
 		public int LengthSquared { get { return X * X + Y * Y; } }
 		public int Length { get { return (int)Math.Sqrt(LengthSquared); } }
 
-		public WVec ToWVec() { return new WVec(X*1024, Y*1024, 0); }
-
 		public CVec Clamp(Rectangle r)
 		{
 			return new CVec(
@@ -115,7 +113,6 @@ namespace OpenRA
 				{
 					case "X": return X;
 					case "Y": return Y;
-					case "Facing": return Traits.Util.GetFacing(this, 0);
 					default: throw new LuaException("CVec does not define a member '{0}'".F(key));
 				}
 			}

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -179,7 +179,7 @@ namespace OpenRA.GameRules
 
 			if (target.Type == TargetType.Terrain)
 			{
-				var cell = target.CenterPosition.ToCPos();
+				var cell = world.Map.CellContaining(target.CenterPosition);
 				if (!world.Map.Contains(cell))
 					return false;
 

--- a/OpenRA.Game/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Game/Graphics/ContrailRenderable.cs
@@ -67,13 +67,13 @@ namespace OpenRA.Graphics
 
 			// Start of the first line segment is the tail of the list - don't smooth it.
 			var curPos = trail[idx(next - skip - 1)];
-			var curCell = curPos.ToCPos();
+			var curCell = wr.world.Map.CellContaining(curPos);
 			var curColor = color;
 			for (var i = 0; i < length - skip - 4; i++)
 			{
 				var j = next - skip - i - 2;
 				var nextPos = Average(trail[idx(j)], trail[idx(j-1)], trail[idx(j-2)], trail[idx(j-3)]);
-				var nextCell = nextPos.ToCPos();
+				var nextCell = wr.world.Map.CellContaining(nextPos);
 				var nextColor = Exts.ColorLerp(i * 1f / (length - 4), color, Color.Transparent);
 
 				if (!world.FogObscures(curCell) && !world.FogObscures(nextCell))

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Graphics
 			foreach (var cell in map.Cells)
 			{
 				var tile = wr.Theater.TileSprite(map.MapTiles.Value[cell]);
-				var pos = wr.ScreenPosition(cell.CenterPosition) - 0.5f * tile.size;
+				var pos = wr.ScreenPosition(map.CenterOfCell(cell)) - 0.5f * tile.size;
 				Util.FastCreateQuad(vertices, pos, tile, terrainPalette, nv, tile.size);
 				nv += 4;
 			}

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -100,6 +100,11 @@ namespace OpenRA.Graphics
 			Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
 		}
 
+		public CPos ViewToWorld(int2 view)
+		{
+			return worldRenderer.world.Map.CellContaining(worldRenderer.Position(ViewToWorldPx(view)));
+		}
+
 		public int2 ViewToWorldPx(int2 view) { return (1f / Zoom * view.ToFloat2()).ToInt2() + TopLeft; }
 		public int2 WorldToViewPx(int2 world) { return (Zoom * (world - TopLeft).ToFloat2()).ToInt2(); }
 
@@ -149,8 +154,8 @@ namespace OpenRA.Graphics
 				{
 					// Calculate the intersection of the visible rectangle and the map.
 					var map = worldRenderer.world.Map;
-					var tl = map.Clamp(worldRenderer.Position(TopLeft).ToCPos() - new CVec(1, 1));
-					var br = map.Clamp(worldRenderer.Position(BottomRight).ToCPos());
+					var tl = map.Clamp(map.CellContaining(worldRenderer.Position(TopLeft)) - new CVec(1, 1));
+					var br = map.Clamp(map.CellContaining(worldRenderer.Position(BottomRight)));
 
 					cells = new CellRegion(tl, br);
 					cellsDirty = false;

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -90,8 +90,10 @@ namespace OpenRA.Graphics
 
 			// Calculate map bounds in world-px
 			var b = map.Bounds;
-			var tl = wr.ScreenPxPosition(new CPos(b.Left, b.Top).TopLeft);
-			var br = wr.ScreenPxPosition(new CPos(b.Right, b.Bottom).BottomRight);
+
+			// Expand to corners of cells
+			var tl = wr.ScreenPxPosition(map.CenterOfCell(new CPos(b.Left, b.Top)) - new WVec(512, 512, 0));
+			var br = wr.ScreenPxPosition(map.CenterOfCell(new CPos(b.Right, b.Bottom)) + new WVec(511, 511, 0));
 			mapBounds = Rectangle.FromLTRB(tl.X, tl.Y, br.X, br.Y);
 
 			CenterLocation = (tl + br) / 2;
@@ -131,8 +133,8 @@ namespace OpenRA.Graphics
 		{
 			get
 			{
-				var ctl = VisibleCells.TopLeft.TopLeft;
-				var cbr = VisibleCells.BottomRight.BottomRight;
+				var ctl = worldRenderer.world.Map.CenterOfCell(VisibleCells.TopLeft) - new WVec(512, 512, 0);
+				var cbr = worldRenderer.world.Map.CenterOfCell(VisibleCells.BottomRight) + new WVec(511, 511, 0);
 				var tl = WorldToViewPx(worldRenderer.ScreenPxPosition(ctl)).Clamp(ScreenClip);
 				var br = WorldToViewPx(worldRenderer.ScreenPxPosition(cbr)).Clamp(ScreenClip);
 				return Rectangle.FromLTRB(tl.X, tl.Y, br.X, br.Y);

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -57,10 +57,10 @@ namespace OpenRA
 
 	public class LocationInit : IActorInit<CPos>
 	{
-		[FieldFromYamlKey] public readonly int2 value = int2.Zero;
+		[FieldFromYamlKey] public readonly CPos value = CPos.Zero;
 		public LocationInit() { }
-		public LocationInit(CPos init) { value = init.ToInt2(); }
-		public CPos Value(World world) { return (CPos)value; }
+		public LocationInit(CPos init) { value = init; }
+		public CPos Value(World world) { return value; }
 	}
 
 	public class SubCellInit : IActorInit<SubCell>

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -461,7 +461,15 @@ namespace OpenRA
 			return dataStream.ToArray();
 		}
 
-		public bool Contains(CPos xy) { return Bounds.Contains(xy.X, xy.Y); }
+		public bool Contains(CPos cell)
+		{
+			return Bounds.Contains(cell.X, cell.Y);
+		}
+
+		public WPos CenterOfCell(CPos c)
+		{
+			return new WPos(1024 * c.X + 512, 1024 * c.Y + 512, 0);
+		}
 
 		public void Resize(int width, int height)		// editor magic.
 		{
@@ -604,8 +612,8 @@ namespace OpenRA
 
 		public WRange DistanceToEdge(WPos pos, WVec dir)
 		{
-			var tl = Bounds.TopLeftAsCPos().TopLeft;
-			var br = Bounds.BottomRightAsCPos().BottomRight;
+			var tl = CenterOfCell(new CPos(Bounds.Left, Bounds.Top)) - new WVec(512, 512, 0);
+			var br = CenterOfCell(new CPos(Bounds.Right, Bounds.Bottom)) + new WVec(511, 511, 0);
 			var x = dir.X == 0 ? int.MaxValue : ((dir.X < 0 ? tl.X : br.X) - pos.X) / dir.X;
 			var y = dir.Y == 0 ? int.MaxValue : ((dir.Y < 0 ? tl.Y : br.Y) - pos.Y) / dir.Y;
 			return new WRange(Math.Min(x, y) * dir.Length);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -476,6 +476,11 @@ namespace OpenRA
 			return new CPos(pos.X / 1024, pos.Y / 1024);
 		}
 
+		public int FacingBetween(CPos cell, CPos towards, int fallbackfacing)
+		{
+			return Traits.Util.GetFacing(CenterOfCell(towards) - CenterOfCell(cell), fallbackfacing);
+		}
+
 		public void Resize(int width, int height)		// editor magic.
 		{
 			var oldMapTiles = MapTiles.Value;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -471,6 +471,11 @@ namespace OpenRA
 			return new WPos(1024 * c.X + 512, 1024 * c.Y + 512, 0);
 		}
 
+		public CPos CellContaining(WPos pos)
+		{
+			return new CPos(pos.X / 1024, pos.Y / 1024);
+		}
+
 		public void Resize(int width, int height)		// editor magic.
 		{
 			var oldMapTiles = MapTiles.Value;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -113,11 +113,11 @@ namespace OpenRA
 						if (TargetActor != null)
 							w.Write(UIntFromActor(TargetActor));
 						if (TargetLocation != CPos.Zero)
-							w.Write(TargetLocation.ToInt2());
+							w.Write(TargetLocation);
 						if (TargetString != null)
 							w.Write(TargetString);
 						if (ExtraLocation != CPos.Zero)
-							w.Write(ExtraLocation.ToInt2());
+							w.Write(ExtraLocation);
 						if (ExtraData != 0)
 							w.Write(ExtraData);
 

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -58,5 +58,11 @@ namespace OpenRA.Network
 			w.Write(p.X);
 			w.Write(p.Y);
 		}
+
+		public static void Write(this BinaryWriter w, CPos cell)
+		{
+			w.Write(cell.X);
+			w.Write(cell.Y);
+		}
 	}
 }

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Orders
 						.Select(x => new { Trait = trait, Order = x }))
 					.OrderByDescending(x => x.Order.OrderPriority))
 				{
-					var actorsAt = self.World.ActorMap.GetUnitsAt(target.CenterPosition.ToCPos()).ToList();
+					var actorsAt = self.World.ActorMap.GetUnitsAt(self.World.Map.CellContaining(target.CenterPosition)).ToList();
 
 					var modifiers = TargetModifiers.None;
 					if (mi.Modifiers.HasModifier(Modifiers.Ctrl))

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Orders
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
 					.Where(a => a.Info.Traits.Contains<ITargetableInfo>())
 					.WithHighestSelectionPriority();
-				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(xy);
+				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}
 
 			var orders = world.Selection.Actors
@@ -76,7 +76,7 @@ namespace OpenRA.Orders
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
 					.Where(a => a.Info.Traits.Contains<ITargetableInfo>())
 					.WithHighestSelectionPriority();
-				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(xy);
+				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}
 
 			var orders = world.Selection.Actors

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Traits
 		int generation;
 
 		public static Target FromPos(WPos p) { return new Target { pos = p, type = TargetType.Terrain }; }
-		public static Target FromCell(World w, CPos c) { return new Target { pos = c.CenterPosition, type = TargetType.Terrain }; }
+		public static Target FromCell(World w, CPos c) { return new Target { pos = w.Map.CenterOfCell(c), type = TargetType.Terrain }; }
 		public static Target FromOrder(World w, Order o)
 		{
 			return o.TargetActor != null

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Traits
 
 		public static Target FromPos(WPos p) { return new Target { pos = p, type = TargetType.Terrain }; }
 		public static Target FromCell(CPos c) { return new Target { pos = c.CenterPosition, type = TargetType.Terrain }; }
-		public static Target FromOrder(Order o)
+		public static Target FromOrder(World w, Order o)
 		{
 			return o.TargetActor != null
 				? FromActor(o.TargetActor)

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -28,12 +28,12 @@ namespace OpenRA.Traits
 		int generation;
 
 		public static Target FromPos(WPos p) { return new Target { pos = p, type = TargetType.Terrain }; }
-		public static Target FromCell(CPos c) { return new Target { pos = c.CenterPosition, type = TargetType.Terrain }; }
+		public static Target FromCell(World w, CPos c) { return new Target { pos = c.CenterPosition, type = TargetType.Terrain }; }
 		public static Target FromOrder(World w, Order o)
 		{
 			return o.TargetActor != null
 				? FromActor(o.TargetActor)
-				: FromCell(o.TargetLocation);
+				: FromCell(w, o.TargetLocation);
 		}
 
 		public static Target FromActor(Actor a)

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -42,11 +42,6 @@ namespace OpenRA.Traits
 			return (angle / 4 - 0x40) & 0xFF;
 		}
 
-		public static int GetFacing(CVec d, int currentFacing)
-		{
-			return GetFacing(d.ToWVec(), currentFacing);
-		}
-
 		public static int GetNearestFacing(int facing, int desiredFacing)
 		{
 			var turn = desiredFacing - facing;

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Traits
 			return a / step;
 		}
 
-		public static WPos BetweenCells(CPos from, CPos to)
+		public static WPos BetweenCells(World w, CPos from, CPos to)
 		{
 			return WPos.Lerp(from.CenterPosition, to.CenterPosition, 1, 2);
 		}

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Traits
 
 		public static WPos BetweenCells(World w, CPos from, CPos to)
 		{
-			return WPos.Lerp(from.CenterPosition, to.CenterPosition, 1, 2);
+			return WPos.Lerp(w.Map.CenterOfCell(from), w.Map.CenterOfCell(to), 1, 2);
 		}
 
 		public static Activity SequenceActivities(params Activity[] acts)

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -138,9 +138,9 @@ namespace OpenRA.Traits
 			return result.Keys;
 		}
 
-		public static IEnumerable<CPos> AdjacentCells(Target target)
+		public static IEnumerable<CPos> AdjacentCells(World w, Target target)
 		{
-			var cells = target.Positions.Select(p => p.ToCPos()).Distinct();
+			var cells = target.Positions.Select(p => w.Map.CellContaining(p)).Distinct();
 			return ExpandFootprint(cells, true);
 		}
 	}

--- a/OpenRA.Game/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Game/Traits/World/ResourceLayer.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Traits
 
 				var c = render[cell];
 				if (c.Sprite != null)
-					new SpriteRenderable(c.Sprite, cell.CenterPosition,
+					new SpriteRenderable(c.Sprite, wr.world.Map.CenterOfCell(cell),
 						WVec.Zero, -511, c.Type.Palette, 1f, true).Render(wr);
 			}
 		}

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Traits
 					return cells.Select(c => c.First);
 			}
 
-			return new[] { a.CenterPosition.ToCPos() };
+			return new[] { a.World.Map.CellContaining(a.CenterPosition) };
 		}
 
 		public void Explore(World world, CPos center, WRange range)

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -65,12 +65,13 @@ namespace OpenRA.Traits
 
 		static IEnumerable<CPos> FindVisibleTiles(World world, CPos position, WRange radius)
 		{
+			var map = world.Map;
 			var r = (radius.Range + 1023) / 1024;
 			var limit = radius.Range * radius.Range;
-			var pos = position.CenterPosition;
+			var pos = map.CenterOfCell(position);
 
-			foreach (var cell in world.Map.FindTilesInCircle(position, r))
-				if ((cell.CenterPosition - pos).HorizontalLengthSquared <= limit)
+			foreach (var cell in map.FindTilesInCircle(position, r))
+				if ((map.CenterOfCell(cell) - pos).HorizontalLengthSquared <= limit)
 					yield return cell;
 		}
 

--- a/OpenRA.Game/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportControllerWidget.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Widgets
 		public void UpdateMouseover()
 		{
 			TooltipType = WorldTooltipType.None;
-			var cell = worldRenderer.Position(worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
+			var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
 			if (!world.Map.Contains(cell))
 				return;
 

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -141,8 +141,7 @@ namespace OpenRA.Widgets
 				return;
 
 			var pos = worldRenderer.Position(xy);
-			var orders = world.OrderGenerator.Order(world, pos.ToCPos(), mi).ToArray();
-
+			var orders = world.OrderGenerator.Order(world, world.Map.CellContaining(pos), mi).ToArray();
 			world.PlayVoiceForOrders(orders);
 
 			var flashed = false;
@@ -180,7 +179,7 @@ namespace OpenRA.Widgets
 
 				var xy = worldRenderer.Viewport.ViewToWorldPx(screenPos);
 				var pos = worldRenderer.Position(xy);
-				var cell = pos.ToCPos();
+				var cell = World.Map.CellContaining(pos);
 
 				var mi = new MouseInput
 				{

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -20,17 +20,6 @@ namespace OpenRA
 {
 	public static class WorldUtils
 	{
-		public static IEnumerable<Actor> FindActorsInBox(this World world, CPos tl, CPos br)
-		{
-			// TODO: Support diamond boxes for isometric maps?
-			return world.FindActorsInBox(tl.TopLeft, br.BottomRight);
-		}
-
-		public static IEnumerable<Actor> FindActorsInBox(this World world, WPos tl, WPos br)
-		{
-			return world.ActorMap.ActorsInBox(tl, br);
-		}
-
 		public static Actor ClosestTo(this IEnumerable<Actor> actors, Actor a)
 		{
 			return actors.ClosestTo(a.CenterPosition);
@@ -48,7 +37,7 @@ namespace OpenRA
 				// Target ranges are calculated in 2D, so ignore height differences
 				var vec = new WVec(r, r, WRange.Zero);
 				var rSq = r.Range*r.Range;
-				return world.FindActorsInBox(origin - vec, origin + vec).Where(
+				return world.ActorMap.ActorsInBox(origin - vec, origin + vec).Where(
 					a => (a.CenterPosition - origin).HorizontalLengthSquared <= rSq);
 			}
 		}

--- a/OpenRA.Mods.Cnc/Effects/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Effects/IonCannon.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Effects
 			this.firedBy = firedBy;
 			this.weapon = weapon;
 			this.palette = palette;
-			target = Target.FromCell(location);
+			target = Target.FromCell(world, location);
 			anim = new Animation(world, effect);
 			anim.PlayThen("idle", () => Finish(world));
 		}

--- a/OpenRA.Mods.Cnc/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/IonCannonPower.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Cnc
 			self.World.AddFrameEndTask(w =>
 			{
 				var info = Info as IonCannonPowerInfo;
-				Sound.Play(Info.LaunchSound, order.TargetLocation.CenterPosition);
+				Sound.Play(Info.LaunchSound, self.World.Map.CenterOfCell(order.TargetLocation));
 				w.Add(new IonCannon(self.Owner, info.Weapon, w, order.TargetLocation, info.Effect, info.EffectPalette));
 
 				if (info.CameraActor == null)

--- a/OpenRA.Mods.Cnc/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/ProductionAirdrop.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Cnc
 					new FacingInit(64)
 				});
 
-				a.QueueActivity(new Fly(a, Target.FromCell(self.Location + new CVec(9, 0))));
+				a.QueueActivity(new Fly(a, Target.FromCell(w, self.Location + new CVec(9, 0))));
 				a.QueueActivity(new Land(Target.FromActor(self)));
 				a.QueueActivity(new CallFunc(() =>
 				{
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc
 					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Country.Race);
 				}));
 
-				a.QueueActivity(new Fly(a, Target.FromCell(endPos)));
+				a.QueueActivity(new Fly(a, Target.FromCell(w, endPos)));
 				a.QueueActivity(new RemoveSelf());
 			});
 

--- a/OpenRA.Mods.Cnc/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/ProductionAirdrop.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Cnc
 				var altitude = self.World.Map.Rules.Actors[actorType].Traits.Get<PlaneInfo>().CruiseAltitude;
 				var a = w.CreateActor(actorType, new TypeDictionary
 				{
-					new CenterPositionInit(startPos.CenterPosition + new WVec(WRange.Zero, WRange.Zero, altitude)),
+					new CenterPositionInit(w.Map.CenterOfCell(startPos) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 					new OwnerInit(owner),
 					new FacingInit(64)
 				});

--- a/OpenRA.Mods.RA/AI/States/AirStates.cs
+++ b/OpenRA.Mods.RA/AI/States/AirStates.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.RA.AI
 				for (var j = 0; j < y; j += DangerRadius * 2)
 				{
 					var pos = new CPos(i, j);
-					if (NearToPosSafely(owner, pos.CenterPosition, out detectedEnemyTarget))
+					if (NearToPosSafely(owner, owner.world.Map.CenterOfCell(pos), out detectedEnemyTarget))
 					{
 						if (needTarget && detectedEnemyTarget == null)
 							continue;

--- a/OpenRA.Mods.RA/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.RA/AI/States/GroundStates.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.RA.AI
 				if (owner.attackOrFleeFuzzy.CanAttack(owner.units, enemyUnits))
 				{
 					foreach (var u in owner.units)
-						owner.world.IssueOrder(new Order("AttackMove", u, false) { TargetLocation = owner.Target.CenterPosition.ToCPos() });
+						owner.world.IssueOrder(new Order("AttackMove", u, false) { TargetLocation = owner.Target.Location });
 
 					// We have gathered sufficient units. Attack the nearest enemy unit.
 					owner.fsm.ChangeState(owner, new GroundUnitsAttackMoveState(), true);
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.RA.AI
 			{
 				owner.world.IssueOrder(new Order("Stop", leader, false));
 				foreach (var unit in owner.units.Where(a => !ownUnits.Contains(a)))
-					owner.world.IssueOrder(new Order("AttackMove", unit, false) { TargetLocation = leader.CenterPosition.ToCPos() });
+					owner.world.IssueOrder(new Order("AttackMove", unit, false) { TargetLocation = leader.Location });
 			}
 			else
 			{

--- a/OpenRA.Mods.RA/Activities/Enter.cs
+++ b/OpenRA.Mods.RA/Activities/Enter.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA.Activities
 			if (target.Type != TargetType.Actor)
 				return NextActivity;
 
-			if (!Util.AdjacentCells(target).Any(c => c == self.Location))
+			if (!Util.AdjacentCells(self.World, target).Any(c => c == self.Location))
 				return Util.SequenceActivities(new MoveAdjacentTo(self, target), this);
 
 			// Move to the middle of the target, ignoring impassable tiles

--- a/OpenRA.Mods.RA/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.RA/Activities/EnterTransport.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			// TODO: Queue a move order to the transport? need to be
 			// careful about units that can't path to the transport
-			var cells = Util.AdjacentCells(Target.FromActor(transport));
+			var cells = Util.AdjacentCells(self.World, Target.FromActor(transport));
 			if (!cells.Contains(self.Location))
 				return NextActivity;
 

--- a/OpenRA.Mods.RA/Activities/FindResources.cs
+++ b/OpenRA.Mods.RA/Activities/FindResources.cs
@@ -114,13 +114,13 @@ namespace OpenRA.Mods.RA.Activities
 			if (harv.LastOrderLocation == null)
 				harv.LastOrderLocation = path[0];
 
-			self.SetTargetLine(Target.FromCell(path[0]), Color.Red, false);
+			self.SetTargetLine(Target.FromCell(self.World, path[0]), Color.Red, false);
 			return Util.SequenceActivities(mobile.MoveTo(path[0], 1), new HarvestResource(), new FindResources());
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)
 		{
-			yield return Target.FromCell(self.Location);
+			yield return Target.FromCell(self.World, self.Location);
 		}
 	}
 

--- a/OpenRA.Mods.RA/Activities/FindResources.cs
+++ b/OpenRA.Mods.RA/Activities/FindResources.cs
@@ -55,8 +55,8 @@ namespace OpenRA.Mods.RA.Activities
 			// TODO: calculate weapons ranges of units and factor those in instead of hard-coding 8.
 			var path = self.World.WorldActor.Trait<PathFinder>().FindPath(
 				PathSearch.Search(self.World, mobileInfo, self, true)
-					.WithCustomCost(loc => self.World.FindActorsInCircle(loc.CenterPosition, WRange.FromCells(8))
-						.Where (u => !u.Destroyed && self.Owner.Stances[u.Owner] == Stance.Enemy)
+						.WithCustomCost(loc => self.World.FindActorsInCircle(self.World.Map.CenterOfCell(loc), WRange.FromCells(8))
+						.Where(u => !u.Destroyed && self.Owner.Stances[u.Owner] == Stance.Enemy)
 						.Sum(u => Math.Max(0, 64 - (loc - u.Location).LengthSquared)))
 					.WithHeuristic(loc =>
 					{

--- a/OpenRA.Mods.RA/Activities/LayMines.cs
+++ b/OpenRA.Mods.RA/Activities/LayMines.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Activities
 
 				return Util.SequenceActivities(
 					new MoveAdjacentTo(self, Target.FromActor(rearmTarget)),
-					movement.MoveTo(rearmTarget.CenterPosition.ToCPos(), rearmTarget),
+					movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), rearmTarget),
 					new Rearm(self),
 					new Repair(rearmTarget),
 					this);

--- a/OpenRA.Mods.RA/Activities/Leap.cs
+++ b/OpenRA.Mods.RA/Activities/Leap.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Activities
 			mobile.IsMoving = true;
 
 			from = self.CenterPosition;
-			to = targetMobile.fromCell.CenterPosition + MobileInfo.SubCellOffsets[targetMobile.fromSubCell];
+			to = self.World.Map.CenterOfCell(targetMobile.fromCell) + MobileInfo.SubCellOffsets[targetMobile.fromSubCell];
 			length = Math.Max((to - from).Length / speed.Range, 1);
 
 			self.Trait<RenderInfantry>().Attacking(self, Target.FromActor(target));

--- a/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.RA/Activities/MoveAdjacentTo.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Activities
 			movementClass = (uint)mobile.Info.GetMovementClass(self.World.TileSet);
 
 			if (target.IsValidFor(self))
-				targetPosition = target.CenterPosition.ToCPos();
+				targetPosition = self.World.Map.CellContaining(target.CenterPosition);
 
 			repath = true;
 		}
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.RA.Activities
 			{
 				// Check if the target has moved
 				var oldTargetPosition = targetPosition;
-				targetPosition = target.CenterPosition.ToCPos();
+				targetPosition = self.World.Map.CellContaining(target.CenterPosition);
 
 				var shroudStop = ShouldStop(self, oldTargetPosition);
 				if (shroudStop || (!repath && ShouldRepath(self, oldTargetPosition)))
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.RA.Activities
 
 		protected virtual IEnumerable<CPos> CandidateMovementCells(Actor self)
 		{
-			return Util.AdjacentCells(target);
+			return Util.AdjacentCells(self.World, target);
 		}
 
 		void UpdateInnerPath(Actor self)

--- a/OpenRA.Mods.RA/Activities/MoveWithinRange.cs
+++ b/OpenRA.Mods.RA/Activities/MoveWithinRange.cs
@@ -43,11 +43,12 @@ namespace OpenRA.Mods.RA.Activities
 
 		protected override IEnumerable<CPos> CandidateMovementCells(Actor self)
 		{
+			var map = self.World.Map;
 			var maxCells = (maxRange.Range + 1023) / 1024;
-			var outerCells = self.World.Map.FindTilesInCircle(targetPosition, maxCells);
+			var outerCells = map.FindTilesInCircle(targetPosition, maxCells);
 
 			var minCells = minRange.Range / 1024;
-			var innerCells = self.World.Map.FindTilesInCircle(targetPosition, minCells);
+			var innerCells = map.FindTilesInCircle(targetPosition, minCells);
 
 			var outerSq = maxRange.Range * maxRange.Range;
 			var innerSq = minRange.Range * minRange.Range;
@@ -55,7 +56,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			return outerCells.Except(innerCells).Where(c =>
 			{
-				var dxSq = (c.CenterPosition - center).HorizontalLengthSquared;
+				var dxSq = (map.CenterOfCell(c) - center).HorizontalLengthSquared;
 				return dxSq >= innerSq && dxSq <= outerSq;
 			});
 		}

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.RA.Activities
 			destination = bestCell.Value;
 
 			Sound.Play(sound, self.CenterPosition);
-			Sound.Play(sound, destination.CenterPosition);
+			Sound.Play(sound, self.World.Map.CenterOfCell(destination));
 
 			self.Trait<IPositionable>().SetPosition(self, destination);
 			self.Generation++;

--- a/OpenRA.Mods.RA/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.RA/Activities/UnloadCargo.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.RA.Activities
 				actor.CancelActivity();
 				pos.SetVisualPosition(actor, spawn);
 				actor.QueueActivity(move.MoveIntoWorld(actor, exitCell.Value));
-				actor.SetTargetLine(Target.FromCell(exitCell.Value), Color.Green, false);
+				actor.SetTargetLine(Target.FromCell(w, exitCell.Value), Color.Green, false);
 			});
 
 			if (!unloadAll || cargo.IsEmpty(self))

--- a/OpenRA.Mods.RA/ActorExts.cs
+++ b/OpenRA.Mods.RA/ActorExts.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA
 		{
 			// Not targeting a frozen actor
 			if (order.ExtraData == 0)
-				return Target.FromOrder(order);
+				return Target.FromOrder(self.World, order);
 
 			// Targeted an actor under the fog
 			var frozenLayer = self.Owner.PlayerActor.TraitOrDefault<FrozenActorLayer>();

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.RA.Air
 
 		[Sync] public int Facing { get; set; }
 		[Sync] public WPos CenterPosition { get; private set; }
-		public CPos TopLeft { get { return CenterPosition.ToCPos(); } }
+		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
 		public IDisposable Reservation;
 		public int ROT { get { return info.ROT; } }
 
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.RA.Air
 				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
 
 			if (order.OrderID == "Move")
-				return new Order(order.OrderID, self, queued) { TargetLocation = target.CenterPosition.ToCPos() };
+				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
 
 			return null;
 		}
@@ -246,7 +246,7 @@ namespace OpenRA.Mods.RA.Air
 				return false;
 
 			IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
-			cursor = self.World.Map.Contains(target.CenterPosition.ToCPos()) ? "move" : "move-blocked";
+			cursor = self.World.Map.Contains(self.World.Map.CellContaining(target.CenterPosition)) ? "move" : "move-blocked";
 			return true;
 		}
 

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.RA.Air
 		}
 
 		// Changes position, but not altitude
-		public void SetPosition(Actor self, CPos cell) { SetPosition(self, cell.CenterPosition + new WVec(0, 0, CenterPosition.Z)); }
+		public void SetPosition(Actor self, CPos cell) { SetPosition(self, self.World.Map.CenterOfCell(cell) + new WVec(0, 0, CenterPosition.Z)); }
 		public void SetVisualPosition(Actor self, WPos pos) { SetPosition(self, pos); }
 
 		public void AddedToWorld(Actor self)

--- a/OpenRA.Mods.RA/Air/Helicopter.cs
+++ b/OpenRA.Mods.RA/Air/Helicopter.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.RA.Air
 			if (order.OrderString == "Move")
 			{
 				var cell = self.World.Map.Clamp(order.TargetLocation);
-				var t = Target.FromCell(cell);
+				var t = Target.FromCell(self.World, cell);
 
 				self.SetTargetLine(t, Color.Green);
 				self.CancelActivity();
@@ -161,8 +161,8 @@ namespace OpenRA.Mods.RA.Air
 			return (d * 1024 * 8) / (int)distSq;
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough) { return new HeliFly(self, Target.FromCell(cell)); }
-		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new HeliFly(self, Target.FromCell(cell)); }
+		public Activity MoveTo(CPos cell, int nearEnough) { return new HeliFly(self, Target.FromCell(self.World, cell)); }
+		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new HeliFly(self, Target.FromCell(self.World, cell)); }
 		public Activity MoveWithinRange(Target target, WRange range) { return new HeliFly(self, target, WRange.Zero, range); }
 		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return new HeliFly(self, target, minRange, maxRange); }
 		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new Follow(self, target, minRange, maxRange); }
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.RA.Air
 
 		public Activity MoveIntoWorld(Actor self, CPos cell)
 		{
-			return new HeliFly(self, Target.FromCell(cell));
+			return new HeliFly(self, Target.FromCell(self.World, cell));
 		}
 
 		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos)

--- a/OpenRA.Mods.RA/Air/Plane.cs
+++ b/OpenRA.Mods.RA/Air/Plane.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.RA.Air
 
 				UnReserve();
 
-				self.SetTargetLine(Target.FromOrder(order), Color.Green);
+				self.SetTargetLine(Target.FromOrder(self.World, order), Color.Green);
 
 				self.CancelActivity();
 				self.QueueActivity(new ReturnToBase(self, order.TargetActor));

--- a/OpenRA.Mods.RA/Air/Plane.cs
+++ b/OpenRA.Mods.RA/Air/Plane.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.RA.Air
 				UnReserve();
 
 				var cell = self.World.Map.Clamp(order.TargetLocation);
-				var t = Target.FromCell(cell);
+				var t = Target.FromCell(self.World, cell);
 				self.SetTargetLine(t, Color.Green);
 				self.CancelActivity();
 				self.QueueActivity(new Fly(self, t));
@@ -101,14 +101,14 @@ namespace OpenRA.Mods.RA.Air
 			}
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough) { return Util.SequenceActivities(new Fly(self, Target.FromCell(cell)), new FlyCircle()); }
-		public Activity MoveTo(CPos cell, Actor ignoredActor) { return Util.SequenceActivities(new Fly(self, Target.FromCell(cell)), new FlyCircle()); }
+		public Activity MoveTo(CPos cell, int nearEnough) { return Util.SequenceActivities(new Fly(self, Target.FromCell(self.World, cell)), new FlyCircle()); }
+		public Activity MoveTo(CPos cell, Actor ignoredActor) { return Util.SequenceActivities(new Fly(self, Target.FromCell(self.World, cell)), new FlyCircle()); }
 		public Activity MoveWithinRange(Target target, WRange range) { return Util.SequenceActivities(new Fly(self, target, WRange.Zero, range), new FlyCircle()); }
 		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return Util.SequenceActivities(new Fly(self, target, minRange, maxRange), new FlyCircle()); }
 		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new FlyFollow(self, target, minRange, maxRange); }
 		public CPos NearestMoveableCell(CPos cell) { return cell; }
 
-		public Activity MoveIntoWorld(Actor self, CPos cell) { return new Fly(self, Target.FromCell(cell)); }
+		public Activity MoveIntoWorld(Actor self, CPos cell) { return new Fly(self, Target.FromCell(self.World, cell)); }
 		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos) { return Util.SequenceActivities(new CallFunc(() => SetVisualPosition(self, fromPos)), new Fly(self, Target.FromPos(toPos))); }
 	}
 }

--- a/OpenRA.Mods.RA/Air/TakeOff.cs
+++ b/OpenRA.Mods.RA/Air/TakeOff.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA.Air
 			var rp = hasHost ? host.TraitOrDefault<RallyPoint>() : null;
 
 			var destination = rp != null ? rp.rallyPoint :
-				(hasHost ? host.CenterPosition.ToCPos() : self.CenterPosition.ToCPos());
+				(hasHost ? self.World.Map.CellContaining(host.CenterPosition) : self.Location);
 
 			return new AttackMove.AttackMoveActivity(self, self.Trait<IMove>().MoveTo(destination, 1));
 		}

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.RA
 				case TargetType.FrozenActor:
 					return new Order("Attack", self, queued) { ExtraData = target.FrozenActor.ID };
 				case TargetType.Terrain:
-					return new Order("Attack", self, queued) { TargetLocation = target.CenterPosition.ToCPos() };
+					return new Order("Attack", self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
 				}
 			}
 
@@ -241,7 +241,7 @@ namespace OpenRA.Mods.RA
 				case TargetType.FrozenActor:
 					return CanTargetActor(self, target, modifiers, ref cursor);
 				case TargetType.Terrain:
-					return CanTargetLocation(self, target.CenterPosition.ToCPos(), othersAtTarget, modifiers, ref cursor);
+					return CanTargetLocation(self, self.World.Map.CellContaining(target.CenterPosition), othersAtTarget, modifiers, ref cursor);
 				default:
 					return false;
 				}

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.RA
 				if (modifiers.HasModifier(TargetModifiers.ForceAttack))
 				{
 					var maxRange = ab.GetMaximumRange().Range;
-					var targetRange = (location.CenterPosition - self.CenterPosition).HorizontalLengthSquared;
+					var targetRange = (self.World.Map.CenterOfCell(location) - self.CenterPosition).HorizontalLengthSquared;
 					if (targetRange > maxRange * maxRange)
 						cursor = ab.info.OutsideRangeCursor;
 

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -217,7 +217,7 @@ namespace OpenRA.Mods.RA
 				if (negativeDamage)
 					return false;
 
-				if (!ab.HasAnyValidWeapons(Target.FromCell(location)))
+				if (!ab.HasAnyValidWeapons(Target.FromCell(self.World, location)))
 					return false;
 
 				if (modifiers.HasModifier(TargetModifiers.ForceAttack))

--- a/OpenRA.Mods.RA/Attack/AttackWander.cs
+++ b/OpenRA.Mods.RA/Attack/AttackWander.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA
 		public void TickIdle(Actor self)
 		{
 			var target = self.CenterPosition + new WVec(0, -1024*Info.MoveRadius, 0).Rotate(WRot.FromFacing(self.World.SharedRandom.Next(255)));
-			self.Trait<AttackMove>().ResolveOrder(self, new Order("AttackMove", self, false) { TargetLocation = target.ToCPos() });
+			self.Trait<AttackMove>().ResolveOrder(self, new Order("AttackMove", self, false) { TargetLocation = self.World.Map.CellContaining(target) });
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Attack/AttackWander.cs
+++ b/OpenRA.Mods.RA/Attack/AttackWander.cs
@@ -31,8 +31,8 @@ namespace OpenRA.Mods.RA
 
 		public void TickIdle(Actor self)
 		{
-			var offset = new WVec(0, -1024*Info.MoveRadius, 0).Rotate(WRot.FromFacing(self.World.SharedRandom.Next(255))).ToCVec();
-			self.Trait<AttackMove>().ResolveOrder(self, new Order("AttackMove", self, false) { TargetLocation = self.Location + offset });
+			var target = self.CenterPosition + new WVec(0, -1024*Info.MoveRadius, 0).Rotate(WRot.FromFacing(self.World.SharedRandom.Next(255)));
+			self.Trait<AttackMove>().ResolveOrder(self, new Order("AttackMove", self, false) { TargetLocation = target.ToCPos() });
 		}
 	}
 }

--- a/OpenRA.Mods.RA/AttackBomber.cs
+++ b/OpenRA.Mods.RA/AttackBomber.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.RA
 				OnExitedAttackRange(self);
 		}
 
-		public void SetTarget(WPos pos) { target = Target.FromPos(pos); }
+		public void SetTarget(World w, WPos pos) { target = Target.FromPos(pos); }
 
 		public void RemovedFromWorld(Actor self)
 		{

--- a/OpenRA.Mods.RA/AttackMove.cs
+++ b/OpenRA.Mods.RA/AttackMove.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA
 			if (order.OrderString == "AttackMove")
 			{
 				TargetLocation = move.NearestMoveableCell(order.TargetLocation);
-				self.SetTargetLine(Target.FromCell(TargetLocation.Value), Color.Red);
+				self.SetTargetLine(Target.FromCell(self.World, TargetLocation.Value), Color.Red);
 				Activate(self);
 			}
 		}

--- a/OpenRA.Mods.RA/BelowUnits.cs
+++ b/OpenRA.Mods.RA/BelowUnits.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA
 		{
 			// Offset effective position to the top of the northernmost occupied cell
 			var bi = self.Info.Traits.GetOrDefault<BuildingInfo>();
-			offset = ((bi != null) ? -FootprintUtils.CenterOffset(bi).Y : 0) - 512;
+			offset = ((bi != null) ? -FootprintUtils.CenterOffset(self.World, bi).Y : 0) - 512;
 		}
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)

--- a/OpenRA.Mods.RA/Bridge.cs
+++ b/OpenRA.Mods.RA/Bridge.cs
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.RA
 		{
 			return footprint.Select(c => (IRenderable)(new SpriteRenderable(
 				wr.Theater.TileSprite(new TerrainTile(template, c.Value)),
-				c.Key.CenterPosition, WVec.Zero, -512, palette, 1f, true))).ToArray();
+				wr.world.Map.CenterOfCell(c.Key), WVec.Zero, -512, palette, 1f, true))).ToArray();
 		}
 
 		bool initialized;

--- a/OpenRA.Mods.RA/Buildings/Bib.cs
+++ b/OpenRA.Mods.RA/Buildings/Bib.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Buildings
 		{
 			var width = bi.Dimensions.X;
 			var bibOffset = bi.Dimensions.Y - 1;
-			var centerOffset = FootprintUtils.CenterOffset(bi);
+			var centerOffset = FootprintUtils.CenterOffset(self.World, bi);
 			var location = self.Location;
 			var rows = info.HasMinibib ? 1 : 2;
 			var map = self.World.Map;
@@ -49,16 +49,17 @@ namespace OpenRA.Mods.RA.Buildings
 				var index = i;
 				var anim = new Animation(self.World, rs.GetImage(self));
 				var cellOffset = new CVec(i % width, i / width + bibOffset);
+				var cell = location + cellOffset;
 
 				// Some mods may define terrain-specific bibs
-				var terrain = map.GetTerrainInfo(location + cellOffset).Type;
+				var terrain = map.GetTerrainInfo(cell).Type;
 				var testSequence = info.Sequence + "-" + terrain;
 				var sequence = anim.HasSequence(testSequence) ? testSequence : info.Sequence;
 				anim.PlayFetchIndex(sequence, () => index);
 				anim.IsDecoration = true;
 
 				// Z-order is one set to the top of the footprint
-				var offset = cellOffset.ToWVec() - centerOffset;
+				var offset = self.World.Map.CenterOfCell(cell) - self.World.Map.CenterOfCell(location) - centerOffset;
 				var awo = new AnimationWithOffset(anim, () => offset, null, -(offset.Y + centerOffset.Y + 512));
 				rs.Add("bib_{0}".F(i), awo, info.Palette);
 			}

--- a/OpenRA.Mods.RA/Buildings/Building.cs
+++ b/OpenRA.Mods.RA/Buildings/Building.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA.Buildings
 		public readonly int Adjacent = 2;
 		[Desc("x means space it blocks, _ is a part that is passable by actors.")]
 		public readonly string Footprint = "x";
-		public readonly int2 Dimensions = new int2(1, 1);
+		public readonly CVec Dimensions = new CVec(1, 1);
 		public readonly bool RequiresBaseProvider = false;
 		public readonly bool AllowInvalidPlacement = false;
 
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Buildings
 			if (RequiresBaseProvider && FindBaseProvider(world, p, topLeft) == null)
 				return false;
 
-			var buildingMaxBounds = (CVec)Dimensions;
+			var buildingMaxBounds = Dimensions;
 			var buildingTraits = world.Map.Rules.Actors[buildingName].Traits;
 			if (buildingTraits.Contains<BibInfo>() && !(buildingTraits.Get<BibInfo>().HasMinibib))
 				buildingMaxBounds += new CVec(0, 1);

--- a/OpenRA.Mods.RA/Buildings/Building.cs
+++ b/OpenRA.Mods.RA/Buildings/Building.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Buildings
 
 		public Actor FindBaseProvider(World world, Player p, CPos topLeft)
 		{
-			var center = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(this);
+			var center = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(world, this);
 			foreach (var bp in world.ActorsWithTrait<BaseProvider>())
 			{
 				var validOwner = bp.Actor.Owner == p || (world.LobbyInfo.GlobalSettings.AllyBuildRadius && bp.Actor.Owner.Stances[p] == Stance.Ally);
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.RA.Buildings
 			occupiedCells = FootprintUtils.UnpathableTiles( self.Info.Name, Info, TopLeft )
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
 
-			CenterPosition = init.world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(Info);
+			CenterPosition = init.world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(init.world, Info);
 			BuildComplete = init.Contains<SkipMakeAnimsInit>();
 		}
 

--- a/OpenRA.Mods.RA/Buildings/Building.cs
+++ b/OpenRA.Mods.RA/Buildings/Building.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Buildings
 
 		public Actor FindBaseProvider(World world, Player p, CPos topLeft)
 		{
-			var center = topLeft.CenterPosition + FootprintUtils.CenterOffset(this);
+			var center = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(this);
 			foreach (var bp in world.ActorsWithTrait<BaseProvider>())
 			{
 				var validOwner = bp.Actor.Owner == p || (world.LobbyInfo.GlobalSettings.AllyBuildRadius && bp.Actor.Owner.Stances[p] == Stance.Ally);
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.RA.Buildings
 			occupiedCells = FootprintUtils.UnpathableTiles( self.Info.Name, Info, TopLeft )
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
 
-			CenterPosition = topLeft.CenterPosition + FootprintUtils.CenterOffset(Info);
+			CenterPosition = init.world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(Info);
 			BuildComplete = init.Contains<SkipMakeAnimsInit>();
 		}
 

--- a/OpenRA.Mods.RA/Buildings/FootprintUtils.cs
+++ b/OpenRA.Mods.RA/Buildings/FootprintUtils.cs
@@ -62,11 +62,10 @@ namespace OpenRA.Mods.RA.Buildings
 			return new CVec(dim.X / 2, dim.Y > 1 ? (dim.Y + 1) / 2 : 0);
 		}
 
-		public static WVec CenterOffset(BuildingInfo buildingInfo)
+		public static WVec CenterOffset(World w, BuildingInfo buildingInfo)
 		{
 			var dim = buildingInfo.Dimensions;
-			// Offset is measured relative to the center of the cell, so need to subtract an additional half cell.
-			return new CVec(dim.X, dim.Y).ToWVec() / 2 - new WVec(512, 512, 0);
+			return (w.Map.CenterOfCell(CPos.Zero + new CVec(dim.X, dim.Y)) - w.Map.CenterOfCell(new CPos(1, 1))) / 2;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.RA
 
 		IEnumerable<CPos> GetAdjacentCells()
 		{
-			return Util.AdjacentCells(Target.FromActor(self)).Where(c => self.Location != c);
+			return Util.AdjacentCells(self.World, Target.FromActor(self)).Where(c => self.Location != c);
 		}
 
 		bool CanUnload()
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.RA
 				initialized = true;
 			}
 
-			var cell = self.CenterPosition.ToCPos();
+			var cell = self.World.Map.CellContaining(self.CenterPosition);
 			if (currentCell != cell)
 			{
 				currentCell = cell;

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.RA
 		public static void DoImpact(WPos pos, WarheadInfo warhead, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
 		{
 			var world = firedBy.World;
-			var targetTile = pos.ToCPos();
+			var targetTile = world.Map.CellContaining(pos);
 
 			if (!world.Map.Contains(targetTile))
 				return;

--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -85,8 +85,8 @@ namespace OpenRA.Mods.RA
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { yield return Pair.New(Location, SubCell.FullCell); }
 
 		public WPos CenterPosition { get; private set; }
-		public void SetPosition(Actor self, WPos pos) { SetPosition(self, pos.ToCPos()); }
-		public void SetVisualPosition(Actor self, WPos pos) { SetPosition(self, pos.ToCPos()); }
+		public void SetPosition(Actor self, WPos pos) { SetPosition(self, self.World.Map.CellContaining(pos)); }
+		public void SetVisualPosition(Actor self, WPos pos) { SetPosition(self, self.World.Map.CellContaining(pos)); }
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor, bool checkTransientActors)
 		{

--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.RA
 		{
 			self.World.ActorMap.RemoveInfluence(self, this);
 			Location = cell;
-			CenterPosition = cell.CenterPosition;
+			CenterPosition = self.World.Map.CenterOfCell(cell);
 
 			if (self.IsInWorld)
 			{

--- a/OpenRA.Mods.RA/CrateSpawner.cs
+++ b/OpenRA.Mods.RA/CrateSpawner.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.RA
 					});
 
 					plane.CancelActivity();
-					plane.QueueActivity(new FlyAttack(Target.FromCell(p)));
+					plane.QueueActivity(new FlyAttack(Target.FromCell(w, p)));
 					plane.Trait<ParaDrop>().SetLZ(p);
 					plane.Trait<Cargo>().Load(plane, crate);
 				}

--- a/OpenRA.Mods.RA/CrateSpawner.cs
+++ b/OpenRA.Mods.RA/CrateSpawner.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.RA
 					var altitude = w.Map.Rules.Actors[info.DeliveryAircraft].Traits.Get<PlaneInfo>().CruiseAltitude;
 					var plane = w.CreateActor(info.DeliveryAircraft, new TypeDictionary
 					{
-						new CenterPositionInit(startPos.CenterPosition + new WVec(WRange.Zero, WRange.Zero, altitude)),
+						new CenterPositionInit(w.Map.CenterOfCell(startPos) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 						new OwnerInit(w.WorldActor.Owner),
 						new FacingInit(Util.GetFacing(p - startPos, 0))
 					});

--- a/OpenRA.Mods.RA/CrateSpawner.cs
+++ b/OpenRA.Mods.RA/CrateSpawner.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.RA
 					{
 						new CenterPositionInit(w.Map.CenterOfCell(startPos) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 						new OwnerInit(w.WorldActor.Owner),
-						new FacingInit(Util.GetFacing(p - startPos, 0))
+						new FacingInit(w.Map.FacingBetween(startPos, p, 0))
 					});
 
 					plane.CancelActivity();

--- a/OpenRA.Mods.RA/Effects/Bullet.cs
+++ b/OpenRA.Mods.RA/Effects/Bullet.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.RA.Effects
 				trail.Update(pos);
 
 			if (ticks++ >= length || (!info.High && world.ActorMap
-				.GetUnitsAt(pos.ToCPos()).Any(a => a.HasTrait<IBlocksBullets>())))
+				.GetUnitsAt(world.Map.CellContaining(pos)).Any(a => a.HasTrait<IBlocksBullets>())))
 			{
 				Explode(world);
 			}
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (anim == null || ticks >= length)
 				yield break;
 
-			var cell = pos.ToCPos();
+			var cell = wr.world.Map.CellContaining(pos);
 			if (!args.SourceActor.World.FogObscures(cell))
 			{
 				if (info.Shadow)

--- a/OpenRA.Mods.RA/Effects/CashTick.cs
+++ b/OpenRA.Mods.RA/Effects/CashTick.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (wr.world.FogObscures(pos.ToCPos()))
+			if (wr.world.FogObscures(wr.world.Map.CellContaining(pos)))
 				yield break;
 
 			yield return new TextRenderable(font, pos, 0, color, text);

--- a/OpenRA.Mods.RA/Effects/Corpse.cs
+++ b/OpenRA.Mods.RA/Effects/Corpse.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Effects
 		{
 			this.world = world;
 			this.pos = pos;
-			this.cell = pos.ToCPos();
+			this.cell = world.Map.CellContaining(pos);
 			this.paletteName = paletteName;
 			anim = new Animation(world, image);
 			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));

--- a/OpenRA.Mods.RA/Effects/Explosion.cs
+++ b/OpenRA.Mods.RA/Effects/Explosion.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Effects
 		{
 			this.world = world;
 			this.pos = pos;
-			this.cell = pos.ToCPos();
+			this.cell = world.Map.CellContaining(pos);
 			this.palette = palette;
 			anim = new Animation(world, "explosion");
 			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));

--- a/OpenRA.Mods.RA/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.RA/Effects/GravityBomb.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			var cell = pos.ToCPos();
+			var cell = wr.world.Map.CellContaining(pos);
 			if (!args.SourceActor.World.FogObscures(cell))
 			{
 				if (info.Shadow)

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (info.ContrailLength > 0)
 				trail.Update(pos);
 
-			var cell = pos.ToCPos();
+			var cell = world.Map.CellContaining(pos);
 
 			var shouldExplode = (pos.Z < 0) // Hit the ground
 				|| (dist.LengthSquared < MissileCloseEnough.Range * MissileCloseEnough.Range) // Within range
@@ -186,7 +186,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (info.ContrailLength > 0)
 				yield return trail;
 
-			if (!args.SourceActor.World.FogObscures(pos.ToCPos()))
+			if (!args.SourceActor.World.FogObscures(wr.world.Map.CellContaining(pos)))
 			{
 				var palette = wr.Palette(args.Weapon.Palette);
 				foreach (var r in anim.Render(pos, palette))

--- a/OpenRA.Mods.RA/Effects/Parachute.cs
+++ b/OpenRA.Mods.RA/Effects/Parachute.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Effects
 				parachuteOffset = pai.Offset;
 
 			// Adjust x,y to match the target subcell
-			cargo.Trait<IPositionable>().SetPosition(cargo, dropPosition.ToCPos());
+			cargo.Trait<IPositionable>().SetPosition(cargo, cargo.World.Map.CellContaining(dropPosition));
 			var cp = cargo.CenterPosition;
 			pos = new WPos(cp.X, cp.Y, dropPosition.Z);
 		}

--- a/OpenRA.Mods.RA/Effects/RallyPoint.cs
+++ b/OpenRA.Mods.RA/Effects/RallyPoint.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (!building.IsInWorld || !building.World.Selection.Actors.Contains(building))
 				return SpriteRenderable.None;
 
-			var pos = cachedLocation.CenterPosition;
+			var pos = wr.world.Map.CenterOfCell(cachedLocation);
 			var palette = wr.Palette(palettePrefix+building.Owner.InternalName);
 			return circles.Render(pos, palette).Concat(flag.Render(pos, palette));
 		}

--- a/OpenRA.Mods.RA/Effects/Smoke.cs
+++ b/OpenRA.Mods.RA/Effects/Smoke.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Effects
 		{
 			this.world = world;
 			this.pos = pos;
-			this.cell = pos.ToCPos();
+			this.cell = world.Map.CellContaining(pos);
 
 			anim = new Animation(world, trail);
 			anim.PlayThen("idle",

--- a/OpenRA.Mods.RA/FreeActor.cs
+++ b/OpenRA.Mods.RA/FreeActor.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA
 		[Desc("What the unit should start doing. Warning: If this is not a harvester", "it will break if you use FindResources.")]
 		public readonly string InitialActivity = null;
 		[Desc("Offset relative to structure-center in 2D (e.g. 1, 2)")]
-		public readonly int2 SpawnOffset = int2.Zero;
+		public readonly CVec SpawnOffset = CVec.Zero;
 		[Desc("Which direction the unit should face.")]
 		public readonly int Facing = 0;
 
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.RA
 				var a = w.CreateActor(info.Actor, new TypeDictionary
 				{
 					new ParentActorInit(init.self),
-					new LocationInit(init.self.Location + (CVec)info.SpawnOffset),
+					new LocationInit(init.self.Location + info.SpawnOffset),
 					new OwnerInit(init.self.Owner),
 					new FacingInit(info.Facing),
 				});

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.RA
 
 					var moveTo = harv.LastHarvestedCell ?? (deliveryLoc + new CVec(0, 4));
 					self.QueueActivity(mobile.MoveTo(moveTo, 1));
-					self.SetTargetLine(Target.FromCell(moveTo), Color.Gray, false);
+					self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
 
 					var territory = self.World.WorldActor.TraitOrDefault<ResourceClaimLayer>();
 					if (territory != null) territory.ClaimResource(self, moveTo);
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.RA
 				var cell = self.Location;
 				var moveTo = mobile.NearestMoveableCell(cell, 2, 5);
 				self.QueueActivity(mobile.MoveTo(moveTo, 0));
-				self.SetTargetLine(Target.FromCell(moveTo), Color.Gray, false);
+				self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
 
 				// Find more resources but not at this location:
 				self.QueueActivity(new FindResources(cell));
@@ -299,7 +299,7 @@ namespace OpenRA.Mods.RA
 					}
 
 					self.QueueActivity(mobile.MoveTo(loc, 0));
-					self.SetTargetLine(Target.FromCell(loc), Color.Red);
+					self.SetTargetLine(Target.FromCell(self.World, loc), Color.Red);
 
 					LastOrderLocation = loc;
 				}
@@ -312,7 +312,7 @@ namespace OpenRA.Mods.RA
 						return;
 
 					self.QueueActivity(mobile.MoveTo(loc.Value, 0));
-					self.SetTargetLine(Target.FromCell(loc.Value), Color.Red);
+					self.SetTargetLine(Target.FromCell(self.World, loc.Value), Color.Red);
 
 					LastOrderLocation = loc;
 				}

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -260,7 +260,7 @@ namespace OpenRA.Mods.RA
 				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
 
 			if (order.OrderID == "Harvest")
-				return new Order(order.OrderID, self, queued) { TargetLocation = target.CenterPosition.ToCPos() };
+				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
 
 			return null;
 		}
@@ -437,7 +437,7 @@ namespace OpenRA.Mods.RA
 				if (modifiers.HasModifier(TargetModifiers.ForceMove))
 					return false;
 
-				var location = target.CenterPosition.ToCPos();
+				var location = self.World.Map.CellContaining(target.CenterPosition);
 				// Don't leak info about resources under the shroud
 				if (!self.Owner.Shroud.IsExplored(location))
 					return false;

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -336,7 +336,7 @@ namespace OpenRA.Mods.RA
 
 				idleSmart = true;
 
-				self.SetTargetLine(Target.FromOrder(order), Color.Green);
+				self.SetTargetLine(Target.FromOrder(self.World, order), Color.Green);
 
 				self.CancelActivity();
 				self.QueueActivity(new DeliverResources());

--- a/OpenRA.Mods.RA/Husk.cs
+++ b/OpenRA.Mods.RA/Husk.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.RA
 		{
 			self.World.ActorMap.RemoveInfluence(self, this);
 			CenterPosition = pos;
-			TopLeft = pos.ToCPos();
+			TopLeft = self.World.Map.CellContaining(pos);
 			self.World.ActorMap.AddInfluence(self, this);
 			self.World.ActorMap.UpdatePosition(self, this);
 			self.World.ScreenMap.Update(self);

--- a/OpenRA.Mods.RA/Husk.cs
+++ b/OpenRA.Mods.RA/Husk.cs
@@ -42,13 +42,14 @@ namespace OpenRA.Mods.RA
 			this.self = init.self;
 
 			TopLeft = init.Get<LocationInit, CPos>();
-			CenterPosition = init.Contains<CenterPositionInit>() ? init.Get<CenterPositionInit, WPos>() : TopLeft.CenterPosition;
+			CenterPosition = init.Contains<CenterPositionInit>() ? init.Get<CenterPositionInit, WPos>() : init.world.Map.CenterOfCell(TopLeft);
 			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 128;
 
 			var speed = init.Contains<HuskSpeedInit>() ? init.Get<HuskSpeedInit, int>() : 0;
-			var distance = (TopLeft.CenterPosition - CenterPosition).Length;
+			var finalPos = init.world.Map.CenterOfCell(TopLeft);
+			var distance = (finalPos - CenterPosition).Length;
 			if (speed > 0 && distance > 0)
-				self.QueueActivity(new Drag(CenterPosition, TopLeft.CenterPosition, distance / speed));
+				self.QueueActivity(new Drag(CenterPosition, finalPos, distance / speed));
 		}
 
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { yield return Pair.New(TopLeft, SubCell.FullCell); }
@@ -69,8 +70,8 @@ namespace OpenRA.Mods.RA
 		}
 
 		public bool CanEnterCell(CPos cell) { return CanEnterCell(cell, null, true); }
+		public void SetPosition(Actor self, CPos cell) { SetPosition(self, self.World.Map.CenterOfCell(cell)); }
 
-		public void SetPosition(Actor self, CPos cell) { SetPosition(self, cell.CenterPosition); }
 		public void SetVisualPosition(Actor self, WPos pos)
 		{
 			CenterPosition = pos;

--- a/OpenRA.Mods.RA/Immobile.cs
+++ b/OpenRA.Mods.RA/Immobile.cs
@@ -23,11 +23,13 @@ namespace OpenRA.Mods.RA
 	class Immobile : IOccupySpace, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		[Sync] readonly CPos location;
+		[Sync] readonly WPos position;
 		readonly IEnumerable<Pair<CPos, SubCell>> occupied;
 
 		public Immobile(ActorInitializer init, ImmobileInfo info)
 		{
-			this.location = init.Get<LocationInit, CPos>();
+			location = init.Get<LocationInit, CPos>();
+			position = init.world.Map.CenterOfCell(location);
 
 			if (info.OccupiesSpace)
 				occupied = new [] { Pair.New(TopLeft, SubCell.FullCell) };
@@ -36,8 +38,8 @@ namespace OpenRA.Mods.RA
 		}
 
 		public CPos TopLeft { get { return location; } }
+		public WPos CenterPosition { get { return position; } }
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return occupied; }
-		public WPos CenterPosition { get { return location.CenterPosition; } }
 
 		public void AddedToWorld(Actor self)
 		{

--- a/OpenRA.Mods.RA/MPStartLocations.cs
+++ b/OpenRA.Mods.RA/MPStartLocations.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.RA
 
 			// Set viewport
 			if (world.LocalPlayer != null && Start.ContainsKey(world.LocalPlayer))
-				wr.Viewport.Center(Start[world.LocalPlayer].CenterPosition);
+				wr.Viewport.Center(world.Map.CenterOfCell(Start[world.LocalPlayer]));
 		}
 
 		static Player FindPlayerInSlot(World world, string pr)

--- a/OpenRA.Mods.RA/Minelayer.cs
+++ b/OpenRA.Mods.RA/Minelayer.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA
 			switch (order.OrderID)
 			{
 				case "BeginMinefield":
-					var start = target.CenterPosition.ToCPos();
+					var start = self.World.Map.CellContaining(target.CenterPosition);
 					self.World.OrderGenerator = new MinefieldOrderGenerator(self, start);
 					return new Order("BeginMinefield", self, false) { TargetLocation = start };
 				case "PlaceMine":
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.RA
 				if (target.Type != TargetType.Terrain)
 					return false;
 
-				var location = target.CenterPosition.ToCPos();
+				var location = self.World.Map.CellContaining(target.CenterPosition);
 				if (!self.World.Map.Contains(location))
 					return false;
 

--- a/OpenRA.Mods.RA/Minelayer.cs
+++ b/OpenRA.Mods.RA/Minelayer.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.RA
 
 			var pal = wr.Palette("terrain");
 			foreach (var c in Minefield)
-				new SpriteRenderable(tile, c.CenterPosition,
+				new SpriteRenderable(tile, self.World.Map.CenterOfCell(c),
 					WVec.Zero, -511, pal, 1f, true).Render(wr);
 		}
 
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.RA
 				foreach (var c in minefield)
 				{
 					var tile = movement.CanEnterCell(c) ? tileOk : tileBlocked;
-					new SpriteRenderable(tile, c.CenterPosition,
+					new SpriteRenderable(tile, world.Map.CenterOfCell(c),
 						WVec.Zero, -511, pal, 1f, true).Render(wr);
 				}
 			}

--- a/OpenRA.Mods.RA/Minelayer.cs
+++ b/OpenRA.Mods.RA/Minelayer.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.RA
 			var p = end - start;
 			var q = new float2(p.Y, -p.X);
 			q = (start != end) ? (1 / q.Length) * q : new float2(1, 0);
-			var c = -float2.Dot(q, start.ToInt2());
+			var c = -float2.Dot(q, new float2(start.X, start.Y));
 
 			/* return all points such that |ax + by + c| < depth */
 

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -375,7 +375,7 @@ namespace OpenRA.Mods.RA.Move
 
 			self.QueueActivity(new Move(currentLocation, 8));
 
-			self.SetTargetLine(Target.FromCell(currentLocation), Color.Green);
+			self.SetTargetLine(Target.FromCell(self.World, currentLocation), Color.Green);
 		}
 
 		protected void PerformMove(Actor self, CPos targetLocation, bool queued)
@@ -542,7 +542,7 @@ namespace OpenRA.Mods.RA.Move
 			if (moveTo.HasValue)
 			{
 				self.CancelActivity();
-				self.SetTargetLine(Target.FromCell(moveTo.Value), Color.Green, false);
+				self.SetTargetLine(Target.FromCell(self.World, moveTo.Value), Color.Green, false);
 				self.QueueActivity(new Move(moveTo.Value, 0));
 
 				Log.Write("debug", "OnNudge #{0} from {1} to {2}",

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -266,7 +266,7 @@ namespace OpenRA.Mods.RA.Move
 
 		public void SetPosition(Actor self, WPos pos)
 		{
-			var cell = pos.ToCPos();
+			var cell = self.World.Map.CellContaining(pos);
 			SetLocation(cell, fromSubCell, cell, fromSubCell);
 			SetVisualPosition(self, pos);
 			FinishedMoving(self);
@@ -306,7 +306,7 @@ namespace OpenRA.Mods.RA.Move
 				if (Info.OnRails)
 					return null;
 
-				return new Order("Move", self, queued) { TargetLocation = target.CenterPosition.ToCPos() };
+				return new Order("Move", self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
 			}
 			return null;
 		}
@@ -573,7 +573,7 @@ namespace OpenRA.Mods.RA.Move
 				if (rejectMove || !target.IsValidFor(self))
 					return false;
 
-				var location = target.CenterPosition.ToCPos();
+				var location = self.World.Map.CellContaining(target.CenterPosition);
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 				cursor = "move";
 

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -246,7 +246,7 @@ namespace OpenRA.Mods.RA.Move
 			if (init.Contains<LocationInit>())
 			{
 				this.__fromCell = this.__toCell = init.Get<LocationInit, CPos>();
-				SetVisualPosition(self, fromCell.CenterPosition + MobileInfo.SubCellOffsets[fromSubCell]);
+				SetVisualPosition(self, init.world.Map.CenterOfCell(fromCell) + MobileInfo.SubCellOffsets[fromSubCell]);
 			}
 
 			this.Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : info.InitialFacing;
@@ -260,7 +260,7 @@ namespace OpenRA.Mods.RA.Move
 		public void SetPosition(Actor self, CPos cell)
 		{
 			SetLocation(cell, fromSubCell, cell, fromSubCell);
-			SetVisualPosition(self, fromCell.CenterPosition + MobileInfo.SubCellOffsets[fromSubCell]);
+			SetVisualPosition(self, self.World.Map.CenterOfCell(fromCell) + MobileInfo.SubCellOffsets[fromSubCell]);
 			FinishedMoving(self);
 		}
 
@@ -611,7 +611,7 @@ namespace OpenRA.Mods.RA.Move
 			SetVisualPosition(self, pos);
 
 			// Animate transition
-			var to = cell.CenterPosition;
+			var to = self.World.Map.CenterOfCell(cell);
 			var speed = MovementSpeedForCell(self, cell);
 			var length = speed > 0 ? (to - pos).Length / speed : 0;
 

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.RA.Move
 				mobile.SetLocation(mobile.fromCell, mobile.fromSubCell, nextCell.Value.First, nextCell.Value.Second);
 				var move = new MoveFirstHalf(
 					this,
-					mobile.fromCell.CenterPosition + MobileInfo.SubCellOffsets[mobile.fromSubCell],
+					self.World.Map.CenterOfCell(mobile.fromCell) + MobileInfo.SubCellOffsets[mobile.fromSubCell],
 					Util.BetweenCells(self.World, mobile.fromCell, mobile.toCell) + (MobileInfo.SubCellOffsets[mobile.fromSubCell] + MobileInfo.SubCellOffsets[mobile.toSubCell]) / 2,
 					mobile.Facing,
 					mobile.Facing,
@@ -375,7 +375,7 @@ namespace OpenRA.Mods.RA.Move
 				var ret2 = new MoveSecondHalf(
 					move,
 					Util.BetweenCells(self.World, mobile.fromCell, mobile.toCell) + (fromSubcellOffset + toSubcellOffset) / 2,
-					mobile.toCell.CenterPosition + toSubcellOffset,
+					self.World.Map.CenterOfCell(mobile.toCell) + toSubcellOffset,
 					mobile.Facing,
 					mobile.Facing,
 					moveFraction - moveFractionTotal);

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -251,9 +251,9 @@ namespace OpenRA.Mods.RA.Move
 		public override IEnumerable<Target> GetTargets(Actor self)
 		{
 			if (path != null)
-				return Enumerable.Reverse(path).Select(c => Target.FromCell(c));
+				return Enumerable.Reverse(path).Select(c => Target.FromCell(self.World, c));
 			if (destination != null)
-				return new Target[] { Target.FromCell(destination.Value) };
+				return new Target[] { Target.FromCell(self.World, destination.Value) };
 			return Target.None;
 		}
 

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -139,8 +139,7 @@ namespace OpenRA.Mods.RA.Move
 			if (nextCell == null)
 				return this;
 
-			var dir = nextCell.Value.First - mobile.fromCell;
-			var firstFacing = Util.GetFacing(dir, mobile.Facing);
+			var firstFacing = self.World.Map.FacingBetween(mobile.fromCell, nextCell.Value.First, mobile.Facing);
 			if (firstFacing != mobile.Facing)
 			{
 				path.Add(nextCell.Value.First);
@@ -362,7 +361,7 @@ namespace OpenRA.Mods.RA.Move
 							Util.BetweenCells(self.World, mobile.fromCell, mobile.toCell) + (fromSubcellOffset + toSubcellOffset) / 2,
 							Util.BetweenCells(self.World, mobile.toCell, nextCell.Value.First) + (toSubcellOffset + nextSubcellOffset) / 2,
 							mobile.Facing,
-							Util.GetNearestFacing(mobile.Facing, Util.GetFacing(nextCell.Value.First - mobile.toCell, mobile.Facing)),
+							Util.GetNearestFacing(mobile.Facing, self.World.Map.FacingBetween(mobile.toCell, nextCell.Value.First, mobile.Facing)),
 							moveFraction - moveFractionTotal);
 
 						mobile.SetLocation(mobile.toCell, mobile.toSubCell, nextCell.Value.First, nextCell.Value.Second);

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.RA.Move
 				var move = new MoveFirstHalf(
 					this,
 					mobile.fromCell.CenterPosition + MobileInfo.SubCellOffsets[mobile.fromSubCell],
-					Util.BetweenCells(mobile.fromCell, mobile.toCell) + (MobileInfo.SubCellOffsets[mobile.fromSubCell] + MobileInfo.SubCellOffsets[mobile.toSubCell]) / 2,
+					Util.BetweenCells(self.World, mobile.fromCell, mobile.toCell) + (MobileInfo.SubCellOffsets[mobile.fromSubCell] + MobileInfo.SubCellOffsets[mobile.toSubCell]) / 2,
 					mobile.Facing,
 					mobile.Facing,
 					0);
@@ -359,8 +359,8 @@ namespace OpenRA.Mods.RA.Move
 						var nextSubcellOffset = MobileInfo.SubCellOffsets[nextCell.Value.Second];
 						var ret = new MoveFirstHalf(
 							move,
-							Util.BetweenCells(mobile.fromCell, mobile.toCell) + (fromSubcellOffset + toSubcellOffset) / 2,
-							Util.BetweenCells(mobile.toCell, nextCell.Value.First) + (toSubcellOffset + nextSubcellOffset) / 2,
+							Util.BetweenCells(self.World, mobile.fromCell, mobile.toCell) + (fromSubcellOffset + toSubcellOffset) / 2,
+							Util.BetweenCells(self.World, mobile.toCell, nextCell.Value.First) + (toSubcellOffset + nextSubcellOffset) / 2,
 							mobile.Facing,
 							Util.GetNearestFacing(mobile.Facing, Util.GetFacing(nextCell.Value.First - mobile.toCell, mobile.Facing)),
 							moveFraction - moveFractionTotal);
@@ -374,7 +374,7 @@ namespace OpenRA.Mods.RA.Move
 
 				var ret2 = new MoveSecondHalf(
 					move,
-					Util.BetweenCells(mobile.fromCell, mobile.toCell) + (fromSubcellOffset + toSubcellOffset) / 2,
+					Util.BetweenCells(self.World, mobile.fromCell, mobile.toCell) + (fromSubcellOffset + toSubcellOffset) / 2,
 					mobile.toCell.CenterPosition + toSubcellOffset,
 					mobile.Facing,
 					mobile.Facing,

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.RA.Move
 			using (new PerfSample("Pathfinder"))
 			{
 				var mi = self.Info.Traits.Get<MobileInfo>();
-				var targetCell = target.ToCPos();
+				var targetCell = self.World.Map.CellContaining(target);
 				var rangeSquared = range.Range*range.Range;
 
 				// Correct for SubCell offset

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.RA.Move
 				// Select only the tiles that are within range from the requested SubCell
 				// This assumes that the SubCell does not change during the path traversal
 				var tilesInRange = world.Map.FindTilesInCircle(targetCell, range.Range / 1024 + 1)
-					.Where(t => (t.CenterPosition - target).LengthSquared <= rangeSquared
+					.Where(t => (world.Map.CenterOfCell(t) - target).LengthSquared <= rangeSquared
 					       && mi.CanEnterCell(self.World, self, t, null, true, true));
 
 				// See if there is any cell within range that does not involve a cross-domain request

--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -79,14 +79,14 @@ namespace OpenRA.Mods.RA.Orders
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public void RenderAfterWorld(WorldRenderer wr, World world)
 		{
-			var position = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
-			var topLeft = position - FootprintUtils.AdjustForBuildingSize(BuildingInfo);
+			var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
+			var topLeft = xy - FootprintUtils.AdjustForBuildingSize(BuildingInfo);
 
 			var rules = world.Map.Rules;
 
 			var actorInfo = rules.Actors[Building];
 			foreach (var dec in actorInfo.Traits.WithInterface<IPlaceBuildingDecoration>())
-				dec.Render(wr, world, actorInfo, world.Map.CenterOfCell(position));
+				dec.Render(wr, world, actorInfo, world.Map.CenterOfCell(xy));
 
 			var cells = new Dictionary<CPos, bool>();
 			// Linebuild for walls.

--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.RA.Orders
 					initialized = true;
 				}
 
-				var offset = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(BuildingInfo) - WPos.Zero;
+				var offset = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(world, BuildingInfo) - WPos.Zero;
 				foreach (var r in preview)
 					r.OffsetBy(offset).Render(wr);
 

--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.RA.Orders
 
 			var actorInfo = rules.Actors[Building];
 			foreach (var dec in actorInfo.Traits.WithInterface<IPlaceBuildingDecoration>())
-				dec.Render(wr, world, actorInfo, position.CenterPosition);	/* hack hack */
+				dec.Render(wr, world, actorInfo, world.Map.CenterOfCell(position));
 
 			var cells = new Dictionary<CPos, bool>();
 			// Linebuild for walls.
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.RA.Orders
 					initialized = true;
 				}
 
-				var offset = topLeft.CenterPosition + FootprintUtils.CenterOffset(BuildingInfo) - WPos.Zero;
+				var offset = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(BuildingInfo) - WPos.Zero;
 				foreach (var r in preview)
 					r.OffsetBy(offset).Render(wr);
 
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.RA.Orders
 			foreach (var c in cells)
 			{
 				var tile = c.Value ? buildOk : buildBlocked;
-				new SpriteRenderable(tile, c.Key.CenterPosition,
+				new SpriteRenderable(tile, world.Map.CenterOfCell(c.Key),
 					WVec.Zero, -511, pal, 1f, true).Render(wr);
 			}
 		}

--- a/OpenRA.Mods.RA/OreRefinery.cs
+++ b/OpenRA.Mods.RA/OreRefinery.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA
 {
 	public class OreRefineryInfo : ITraitInfo
 	{
-		public readonly int2 DockOffset = new int2(1, 2);
+		public readonly CVec DockOffset = new CVec(1, 2);
 
 		public readonly bool ShowTicks = true;
 		public readonly int TickLifetime = 30;
@@ -44,8 +44,7 @@ namespace OpenRA.Mods.RA
 		[Sync] bool preventDock = false;
 
 		public bool AllowDocking { get { return !preventDock; } }
-
-		public CVec DeliverOffset { get { return (CVec)Info.DockOffset; } }
+		public CVec DeliverOffset { get { return Info.DockOffset; } }
 
 		public virtual Activity DockSequence(Actor harv, Actor self) { return new RAHarvesterDockSequence(harv, self, Info.DockAngle); }
 

--- a/OpenRA.Mods.RA/Passenger.cs
+++ b/OpenRA.Mods.RA/Passenger.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.RA
 				if (!CanEnter(order.TargetActor)) return;
 				if (!IsCorrectCargoType(order.TargetActor)) return;
 
-				var target = Target.FromOrder(order);
+				var target = Target.FromOrder(self.World, order);
 				self.SetTargetLine(target, Color.Green);
 
 				self.CancelActivity();

--- a/OpenRA.Mods.RA/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.RA/Player/PlaceBeacon.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.RA
 			if (order.OrderString != "PlaceBeacon")
 				return;
 
-			var pos = order.TargetLocation.CenterPosition;
+			var pos = self.World.Map.CenterOfCell(order.TargetLocation);
 
 			self.World.AddFrameEndTask(w =>
 			{

--- a/OpenRA.Mods.RA/PortableChrono.cs
+++ b/OpenRA.Mods.RA/PortableChrono.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.RA
 				self.World.OrderGenerator = new PortableChronoOrderGenerator(self);
 
 			if (order.OrderID == "PortableChronoTeleport")
-				return new Order(order.OrderID, self, queued) { TargetLocation = target.CenterPosition.ToCPos() };
+				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
 
 			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
 		}
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.RA
 			// TODO: When target modifiers are configurable this needs to be revisited
 			if (modifiers.HasModifier(TargetModifiers.ForceMove) || modifiers.HasModifier(TargetModifiers.ForceQueue))
 			{
-				var xy = target.CenterPosition.ToCPos();
+				var xy = self.World.Map.CellContaining(target.CenterPosition);
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.RA
 				yield break;
 			}
 
-			if (self.IsInWorld && self.CenterPosition.ToCPos() != xy
+			if (self.IsInWorld && self.Location != xy
 				&& self.Trait<PortableChrono>().CanTeleport && self.Owner.Shroud.IsExplored(xy))
 			{
 				world.CancelInputMode();
@@ -190,7 +190,7 @@ namespace OpenRA.Mods.RA
 
 		public string GetCursor(World world, CPos xy, MouseInput mi)
 		{
-			if (self.IsInWorld && self.CenterPosition.ToCPos() != xy
+			if (self.IsInWorld && self.Location != xy
 				&& self.Trait<PortableChrono>().CanTeleport && self.Owner.Shroud.IsExplored(xy))
 				return "chrono-target";
 			else

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA
 		{
 			var exit = self.Location + exitinfo.ExitCell;
 			var spawn = self.CenterPosition + exitinfo.SpawnOffset;
-			var to = exit.CenterPosition;
+			var to = self.World.Map.CenterOfCell(exit);
 
 			var fi = producee.Traits.Get<IFacingInfo>();
 			var initialFacing = exitinfo.Facing < 0 ? Util.GetFacing(to - spawn, fi.GetInitialFacing()) : exitinfo.Facing;

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.RA
 			var initialFacing = exitinfo.Facing < 0 ? Util.GetFacing(to - spawn, fi.GetInitialFacing()) : exitinfo.Facing;
 
 			var exitLocation = rp.Value != null ? rp.Value.rallyPoint : exit;
-			var target = Target.FromCell(exitLocation);
+			var target = Target.FromCell(self.World, exitLocation);
 			var nearEnough = rp.Value != null ? WRange.FromCells(rp.Value.nearEnough) : WRange.Zero;
 
 			self.World.AddFrameEndTask(w =>
@@ -87,7 +87,6 @@ namespace OpenRA.Mods.RA
 					if (exitinfo.MoveIntoWorld)
 					{
 						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
-
 						newUnit.QueueActivity(new AttackMove.AttackMoveActivity(
 							newUnit, move.MoveWithinRange(target, nearEnough)));
 					}

--- a/OpenRA.Mods.RA/RallyPoint.cs
+++ b/OpenRA.Mods.RA/RallyPoint.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA
 		public Order IssueOrder( Actor self, IOrderTargeter order, Target target, bool queued )
 		{
 			if (order.OrderID == "SetRallyPoint")
-				return new Order(order.OrderID, self, false) { TargetLocation = target.CenterPosition.ToCPos(), SuppressVisualFeedback = true };
+				return new Order(order.OrderID, self, false) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition), SuppressVisualFeedback = true };
 
 			return null;
 		}
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.RA
 				if (target.Type != TargetType.Terrain)
 					return false;
 
-				var location = target.CenterPosition.ToCPos();
+				var location = self.World.Map.CellContaining(target.CenterPosition);
 				if (self.World.Map.Contains(location))
 				{
 					cursor = "ability";

--- a/OpenRA.Mods.RA/Render/RenderBuildingWall.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWall.cs
@@ -51,8 +51,8 @@ namespace OpenRA.Mods.RA.Render
 				return;
 
 			// Update connection to neighbours
-			var vec = new CVec(1, 1);
-			var adjacentActors = self.World.FindActorsInBox(self.Location - vec, self.Location + vec);
+			var adjacentActors = CVec.directions.SelectMany(dir =>
+				self.World.ActorMap.GetUnitsAt(self.Location + dir));
 
 			adjacent = 0;
 			foreach (var a in adjacentActors)
@@ -79,12 +79,12 @@ namespace OpenRA.Mods.RA.Render
 
 		static void UpdateNeighbours(Actor self)
 		{
-			var vec = new CVec(1, 1);
-			var neighbours = self.World.FindActorsInBox(self.Location - vec, self.Location + vec)
+			var adjacentActors = CVec.directions.SelectMany(dir =>
+					self.World.ActorMap.GetUnitsAt(self.Location + dir))
 				.Select(a => a.TraitOrDefault<RenderBuildingWall>())
 				.Where(a => a != null);
 
-			foreach (var rb in neighbours)
+			foreach (var rb in adjacentActors)
 				rb.dirty = true;
 		}
 

--- a/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Render
 			var bi = init.self.Info.Traits.Get<BuildingInfo>();
 
 			// Additional 512 units move from center -> top of cell
-			var offset = FootprintUtils.CenterOffset(bi).Y + 512;
+			var offset = FootprintUtils.CenterOffset(init.world, bi).Y + 512;
 			Add("roof", new AnimationWithOffset(roof, null,
 				() => !buildComplete, offset));
 		}

--- a/OpenRA.Mods.RA/Render/WithBuildingExplosion.cs
+++ b/OpenRA.Mods.RA/Render/WithBuildingExplosion.cs
@@ -22,8 +22,7 @@ namespace OpenRA.Mods.RA.Render
 			//TODO: Make palette for this customizable as well
 			var bi = self.Info.Traits.Get<BuildingInfo>();
 			FootprintUtils.UnpathableTiles(self.Info.Name, bi, self.Location).Do(
-				t => self.World.AddFrameEndTask(
-					w => w.Add(new Explosion(w, t.CenterPosition, "building", "effect"))));
+				t => self.World.AddFrameEndTask(w => w.Add(new Explosion(w, w.Map.CenterOfCell(t), "building", "effect"))));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -69,11 +69,11 @@ namespace OpenRA.Mods.RA
 		{
 			if (order.OrderString == "Repair")
 			{
-				if( !CanRepairAt( order.TargetActor ) || !CanRepair() )
+				if (!CanRepairAt(order.TargetActor) || !CanRepair())
 					return;
 
 				var movement = self.Trait<IMove>();
-				var target = Target.FromOrder(order);
+				var target = Target.FromOrder(self.World, order);
 				self.SetTargetLine(target, Color.Green);
 
 				self.CancelActivity();

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.RA
 
 				self.CancelActivity();
 				self.QueueActivity(new MoveAdjacentTo(self, target));
-				self.QueueActivity(movement.MoveTo(order.TargetActor.CenterPosition.ToCPos(), order.TargetActor));
+				self.QueueActivity(movement.MoveTo(self.World.Map.CellContaining(order.TargetActor.CenterPosition), order.TargetActor));
 				self.QueueActivity(new Rearm(self));
 				self.QueueActivity(new Repair(order.TargetActor));
 

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.RA
 				if (rp != null)
 					self.QueueActivity(new CallFunc(() =>
 					{
-						self.SetTargetLine(Target.FromCell(rp.rallyPoint), Color.Green);
+						self.SetTargetLine(Target.FromCell(self.World, rp.rallyPoint), Color.Green);
 						self.QueueActivity(movement.MoveTo(rp.rallyPoint, order.TargetActor));
 					}));
 			}

--- a/OpenRA.Mods.RA/RepairableNear.cs
+++ b/OpenRA.Mods.RA/RepairableNear.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.RA
 			if (order.OrderString == "RepairNear" && CanRepairAt(order.TargetActor) && ShouldRepair())
 			{
 				var movement = self.Trait<IMove>();
-				var target = Target.FromOrder(order);
+				var target = Target.FromOrder(self.World, order);
 
 				self.CancelActivity();
 				self.QueueActivity(movement.MoveWithinRange(target, new WRange(1024*info.CloseEnough)));

--- a/OpenRA.Mods.RA/RepairsBridges.cs
+++ b/OpenRA.Mods.RA/RepairsBridges.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA
 				if (bridge.BridgeDamageState == DamageState.Undamaged)
 					return;
 
-				self.SetTargetLine(Target.FromOrder(order), Color.Yellow);
+				self.SetTargetLine(Target.FromOrder(self.World, order), Color.Yellow);
 
 				self.CancelActivity();
 				self.QueueActivity(new Enter(order.TargetActor, new RepairBridge(order.TargetActor)));

--- a/OpenRA.Mods.RA/Scripting/Global/UtilsGlobal.cs
+++ b/OpenRA.Mods.RA/Scripting/Global/UtilsGlobal.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Returns the center of a cell in world coordinates.")]
 		public WPos CenterOfCell(CPos cell)
 		{
-			return cell.CenterPosition;
+			return context.World.Map.CenterOfCell(cell);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.RA.Scripting
 		[LuaGlobal]
 		public void FlyAttackCell(Actor actor, CPos location)
 		{
-			actor.QueueActivity(new FlyAttack(Target.FromCell(location)));
+			actor.QueueActivity(new FlyAttack(Target.FromCell(actor.World, location)));
 		}
 
 		[LuaGlobal]

--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -369,7 +369,7 @@ namespace OpenRA.Mods.RA.Scripting
 		[LuaGlobal]
 		public Actor[] FindActorsInBox(WPos topLeft, WPos bottomRight)
 		{
-			return world.FindActorsInBox(topLeft, bottomRight).ToArray();
+			return world.ActorMap.ActorsInBox(topLeft, bottomRight).ToArray();
 		}
 
 		[LuaGlobal]

--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.RA.Scripting
 		public int GetFacing(object vec, double currentFacing)
 		{
 			if (vec is CVec)
-				return Util.GetFacing((CVec)vec, (int)currentFacing);
+				return world.Map.FacingBetween(CPos.Zero, CPos.Zero + (CVec)vec, (int)currentFacing);
 			if (vec is WVec)
 				return Util.GetFacing((WVec)vec, (int)currentFacing);
 			throw new ArgumentException("Unsupported vector type: {0}".F(vec.GetType()));

--- a/OpenRA.Mods.RA/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/TransportProperties.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Scripting
 		public void Paradrop(CPos cell)
 		{
 			paradrop.SetLZ(cell);
-			self.QueueActivity(new FlyAttack(Target.FromCell(cell)));
+			self.QueueActivity(new FlyAttack(Target.FromCell(self.World, cell)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/ShroudRenderer.cs
+++ b/OpenRA.Mods.RA/ShroudRenderer.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.RA
 			// Initialize tile cache
 			foreach (var cell in map.Cells)
 			{
-				var screen = wr.ScreenPosition(cell.CenterPosition);
+				var screen = wr.ScreenPosition(w.Map.CenterOfCell(cell));
 				var variant = Game.CosmeticRandom.Next(info.ShroudVariants.Length);
 				tiles[cell] = new ShroudTile(cell, screen, variant);
 			}

--- a/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.RA/SmokeTrailWhenDamaged.cs
@@ -41,8 +41,7 @@ namespace OpenRA.Mods.RA
 			if (--ticks <= 0)
 			{
 				var position = self.CenterPosition;
-				if (position.Z > 0 && self.GetDamageState() >= info.MinDamage &&
-					!self.World.FogObscures(position.ToCPos()))
+				if (position.Z > 0 && self.GetDamageState() >= info.MinDamage && !self.World.FogObscures(self))
 				{
 					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 					var pos = position + body.LocalToWorld(offset);

--- a/OpenRA.Mods.RA/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/AirstrikePower.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA
 			var delta = new WVec(0, -1024, 0).Rotate(attackRotation);
 
 			var altitude = self.World.Map.Rules.Actors[info.UnitType].Traits.Get<PlaneInfo>().CruiseAltitude.Range;
-			var target = order.TargetLocation.CenterPosition + new WVec(0, 0, altitude);
+			var target = self.World.Map.CenterOfCell(order.TargetLocation) + new WVec(0, 0, altitude);
 			var startEdge = target - (self.World.Map.DistanceToEdge(target, -delta) + info.Cordon).Range * delta / 1024;
 			var finishEdge = target + (self.World.Map.DistanceToEdge(target, delta) + info.Cordon).Range * delta / 1024;
 
@@ -174,7 +174,7 @@ namespace OpenRA.Mods.RA
 
 					beacon = new Beacon(
 						order.Player,
-						order.TargetLocation.CenterPosition,
+						self.World.Map.CenterOfCell(order.TargetLocation),
 						Info.BeaconPalettePrefix,
 						Info.BeaconPoster,
 						Info.BeaconPosterPalette,

--- a/OpenRA.Mods.RA/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/AirstrikePower.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA
 					});
 
 					var attack = a.Trait<AttackBomber>();
-					attack.SetTarget(target + targetOffset);
+					attack.SetTarget(w, target + targetOffset);
 					attack.OnEnteredAttackRange += onEnterRange;
 					attack.OnExitedAttackRange += onExitRange;
 					attack.OnRemovedFromWorld += onExitRange;

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.RA
 				// Unit previews
 				foreach (var unit in power.UnitsInRange(sourceLocation))
 				{
-					var offset = (xy - sourceLocation).ToWVec();
+					var offset = world.Map.CenterOfCell(xy) - world.Map.CenterOfCell(sourceLocation);
 					if (manager.self.Owner.Shroud.IsTargetable(unit))
 						foreach (var r in unit.Render(wr))
 							yield return r.OffsetBy(offset);

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.RA
 				var tiles = world.Map.FindTilesInCircle(xy, range);
 				var pal = wr.Palette("terrain");
 				foreach (var t in tiles)
-					yield return new SpriteRenderable(tile, t.CenterPosition, WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(tile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 			}
 
 			public string GetCursor(World world, CPos xy, MouseInput mi)
@@ -217,11 +217,11 @@ namespace OpenRA.Mods.RA
 
 				// Source tiles
 				foreach (var t in world.Map.FindTilesInCircle(sourceLocation, range))
-					yield return new SpriteRenderable(sourceTile, t.CenterPosition, WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(sourceTile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 
 				// Destination tiles
 				foreach (var t in world.Map.FindTilesInCircle(xy, range))
-					yield return new SpriteRenderable(sourceTile, t.CenterPosition, WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(sourceTile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 
 				// Unit previews
 				foreach (var unit in power.UnitsInRange(sourceLocation))
@@ -241,7 +241,7 @@ namespace OpenRA.Mods.RA
 						var canEnter = manager.self.Owner.Shroud.IsExplored(targetCell) &&
 						                unit.Trait<Chronoshiftable>().CanChronoshiftTo(unit, targetCell);
 						var tile = canEnter ? validTile : invalidTile;
-						yield return new SpriteRenderable(tile, targetCell.CenterPosition, WVec.Zero, -511, pal, 1f, true);
+						yield return new SpriteRenderable(tile, wr.world.Map.CenterOfCell(targetCell), WVec.Zero, -511, pal, 1f, true);
 					}
 				}
 			}

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.RA
 
 			public void RenderAfterWorld(WorldRenderer wr, World world)
 			{
-				var xy = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var targetUnits = power.UnitsInRange(xy);
 				foreach (var unit in targetUnits)
 					if (manager.self.Owner.Shroud.IsTargetable(unit))
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.RA
 
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
-				var xy = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var tiles = world.Map.FindTilesInCircle(xy, range);
 				var pal = wr.Palette("terrain");
 				foreach (var t in tiles)
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.RA
 
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
-				var xy = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var pal = wr.Palette("terrain");
 
 				// Source tiles

--- a/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
@@ -100,14 +100,14 @@ namespace OpenRA.Mods.RA
 
 			public void RenderAfterWorld(WorldRenderer wr, World world)
 			{
-				var xy = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				foreach (var unit in power.UnitsInRange(xy))
 					wr.DrawSelectionBox(unit, Color.Red);
 			}
 
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
-				var xy = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
+				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var pal = wr.Palette("terrain");
 
 				foreach (var t in world.Map.FindTilesInCircle(xy, range))

--- a/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/IronCurtainPower.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA
 
 			self.Trait<RenderBuilding>().PlayCustomAnim(self, "active");
 
-			Sound.Play(info.IronCurtainSound, order.TargetLocation.CenterPosition);
+			Sound.Play(info.IronCurtainSound, self.World.Map.CenterOfCell(order.TargetLocation));
 
 			foreach (var target in UnitsInRange(order.TargetLocation)
 				.Where(a => a.Owner.Stances[self.Owner] == Stance.Ally))
@@ -109,8 +109,9 @@ namespace OpenRA.Mods.RA
 			{
 				var xy = wr.Position(wr.Viewport.ViewToWorldPx(Viewport.LastMousePos)).ToCPos();
 				var pal = wr.Palette("terrain");
+
 				foreach (var t in world.Map.FindTilesInCircle(xy, range))
-					yield return new SpriteRenderable(tile, t.CenterPosition, WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(tile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 			}
 
 			public string GetCursor(World world, CPos xy, MouseInput mi)

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -77,9 +77,10 @@ namespace OpenRA.Mods.RA
 			var rb = self.Trait<RenderSimple>();
 			rb.PlayCustomAnim(self, "active");
 
+			var targetPosition = self.World.Map.CenterOfCell(order.TargetLocation);
 			var missile = new NukeLaunch(self.Owner, npi.MissileWeapon,
 				self.CenterPosition + body.LocalToWorld(npi.SpawnOffset),
-				order.TargetLocation.CenterPosition,
+				targetPosition,
 				npi.FlightVelocity, npi.FlightDelay, npi.SkipAscent);
 
 			self.World.AddFrameEndTask(w => w.Add(missile));
@@ -103,7 +104,7 @@ namespace OpenRA.Mods.RA
 			{
 				var beacon = new Beacon(
 					order.Player,
-					order.TargetLocation.CenterPosition,
+					targetPosition,
 					Info.BeaconPalettePrefix,
 					Info.BeaconPoster,
 					Info.BeaconPosterPalette,

--- a/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.RA
 				{
 					new CenterPositionInit(w.Map.CenterOfCell(startPos) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 					new OwnerInit(self.Owner),
-					new FacingInit(Util.GetFacing(order.TargetLocation - startPos, 0))
+					new FacingInit(w.Map.FacingBetween(startPos, order.TargetLocation, 0))
 				});
 
 				a.CancelActivity();

--- a/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA
 				});
 
 				a.CancelActivity();
-				a.QueueActivity(new FlyAttack(Target.FromOrder(order)));
+				a.QueueActivity(new FlyAttack(Target.FromOrder(self.World, order)));
 				a.Trait<ParaDrop>().SetLZ(order.TargetLocation);
 
 				var cargo = a.Trait<Cargo>();

--- a/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA
 				var altitude = self.World.Map.Rules.Actors[info.UnitType].Traits.Get<PlaneInfo>().CruiseAltitude;
 				var a = w.CreateActor(info.UnitType, new TypeDictionary
 				{
-					new CenterPositionInit(startPos.CenterPosition + new WVec(WRange.Zero, WRange.Zero, altitude)),
+					new CenterPositionInit(w.Map.CenterOfCell(startPos) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 					new OwnerInit(self.Owner),
 					new FacingInit(Util.GetFacing(order.TargetLocation - startPos, 0))
 				});

--- a/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA
 
 			var plane = self.World.CreateActor("u2", new TypeDictionary
 			{
-				new CenterPositionInit(enterCell.CenterPosition + new WVec(WRange.Zero, WRange.Zero, altitude)),
+				new CenterPositionInit(self.World.Map.CenterOfCell(enterCell) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 				new OwnerInit(self.Owner),
 				new FacingInit(Util.GetFacing(order.TargetLocation - enterCell, 0))
 			});

--- a/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA
 			{
 				new CenterPositionInit(self.World.Map.CenterOfCell(enterCell) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 				new OwnerInit(self.Owner),
-				new FacingInit(Util.GetFacing(order.TargetLocation - enterCell, 0))
+				new FacingInit(self.World.Map.FacingBetween(enterCell, order.TargetLocation, 0))
 			});
 
 			plane.CancelActivity();

--- a/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SpyPlanePower.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.RA
 			});
 
 			plane.CancelActivity();
-			plane.QueueActivity(new Fly(plane, Target.FromCell(order.TargetLocation)));
+			plane.QueueActivity(new Fly(plane, Target.FromCell(self.World, order.TargetLocation)));
 			plane.QueueActivity(new CallFunc(() => plane.World.AddFrameEndTask( w =>
 				{
 					var camera = w.CreateActor("camera", new TypeDictionary

--- a/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPower.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.RA
 			{
 				ping = manager.RadarPings.Value.Add(
 					() => order.Player.IsAlliedWith(self.World.RenderPlayer),
-					order.TargetLocation.CenterPosition,
+					self.World.Map.CenterOfCell(order.TargetLocation),
 					order.Player.Color.RGB,
 					Info.RadarPingDuration);
 			}

--- a/OpenRA.Mods.RA/TargetableBuilding.cs
+++ b/OpenRA.Mods.RA/TargetableBuilding.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<WPos> TargetablePositions(Actor self)
 		{
-			return building.OccupiedCells().Select(c => c.First.CenterPosition);
+			return building.OccupiedCells().Select(c => self.World.Map.CenterOfCell(c.First));
 		}
 
 		public bool RequiresForceFire { get { return info.RequiresForceFire; } }

--- a/OpenRA.Mods.RA/Transforms.cs
+++ b/OpenRA.Mods.RA/Transforms.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 	class TransformsInfo : ITraitInfo
 	{
 		[ActorReference] public readonly string IntoActor = null;
-		public readonly int2 Offset = int2.Zero;
+		public readonly CVec Offset = CVec.Zero;
 		public readonly int Facing = 96;
 		public readonly string[] TransformSounds = { };
 		public readonly string[] NoTransformSounds = { };
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA
 			if (b != null && b.Locked)
 				return false;
 
-			return bi == null || self.World.CanPlaceBuilding(info.IntoActor, bi, self.Location + (CVec)info.Offset, self);
+			return bi == null || self.World.CanPlaceBuilding(info.IntoActor, bi, self.Location + info.Offset, self);
 		}
 
 		public IEnumerable<IOrderTargeter> Orders
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.RA
 			if (rb != null && self.Info.Traits.Get<RenderBuildingInfo>().HasMakeAnimation)
 				self.QueueActivity(new MakeAnimation(self, true, () => rb.PlayCustomAnim(self, "make")));
 
-			self.QueueActivity(new Transform(self, info.IntoActor) { Offset = (CVec)info.Offset, Facing = info.Facing, Sounds = info.TransformSounds, Race = race });
+			self.QueueActivity(new Transform(self, info.IntoActor) { Offset = info.Offset, Facing = info.Facing, Sounds = info.TransformSounds, Race = race });
 		}
 
 		public void ResolveOrder(Actor self, Order order)

--- a/OpenRA.Mods.RA/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/RadarWidget.cs
@@ -158,8 +158,8 @@ namespace OpenRA.Mods.RA.Widgets
 			// Draw viewport rect
 			if (hasRadar)
 			{
-				var tl = CellToMinimapPixel(worldRenderer.Position(worldRenderer.Viewport.TopLeft).ToCPos());
-				var br = CellToMinimapPixel(worldRenderer.Position(worldRenderer.Viewport.BottomRight).ToCPos());
+				var tl = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.Position(worldRenderer.Viewport.TopLeft)));
+				var br = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.Position(worldRenderer.Viewport.BottomRight)));
 
 				Game.Renderer.EnableScissor(mapRect);
 				DrawRadarPings();
@@ -180,7 +180,8 @@ namespace OpenRA.Mods.RA.Widgets
 			foreach (var radarPing in radarPings.Pings.Where(e => e.IsVisible()))
 			{
 				var c = radarPing.Color;
-				var points = radarPing.Points(CellToMinimapPixel(radarPing.Position.ToCPos())).ToArray();
+				var pingCell = world.Map.CellContaining(radarPing.Position);
+				var points = radarPing.Points(CellToMinimapPixel(pingCell)).ToArray();
 
 				lr.DrawLine(points[0], points[1], c, c);
 				lr.DrawLine(points[1], points[2], c, c);

--- a/OpenRA.Mods.RA/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/RadarWidget.cs
@@ -242,18 +242,18 @@ namespace OpenRA.Mods.RA.Widgets
 
 		int2 CellToMinimapPixel(CPos p)
 		{
-			var viewOrigin = new float2(mapRect.X, mapRect.Y);
 			var mapOrigin = new CPos(world.Map.Bounds.Left, world.Map.Bounds.Top);
+			var mapOffset = p - mapOrigin;
 
-			return (viewOrigin + previewScale * (p - mapOrigin).ToFloat2()).ToInt2();
+			return new int2(mapRect.X, mapRect.Y) + (previewScale * new float2(mapOffset.X, mapOffset.Y)).ToInt2();
 		}
 
 		CPos MinimapPixelToCell(int2 p)
 		{
 			var viewOrigin = new float2(mapRect.X, mapRect.Y);
-			var mapOrigin = new CPos(world.Map.Bounds.Left, world.Map.Bounds.Top);
-
-			return (CPos)(mapOrigin.ToFloat2() + (1f / previewScale) * (p - viewOrigin)).ToInt2();
+			var mapOrigin = new float2(world.Map.Bounds.Left, world.Map.Bounds.Top);
+			var fcell = mapOrigin + (1f / previewScale) * (p - viewOrigin);
+			return new CPos((int)fcell.X, (int)fcell.Y);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/RadarWidget.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.RA.Widgets
 				return null;
 
 			var cell = MinimapPixelToCell(pos);
-			var location = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(cell.CenterPosition));
+			var location = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(world.Map.CenterOfCell(cell)));
 
 			var mi = new MouseInput
 			{
@@ -113,9 +113,9 @@ namespace OpenRA.Mods.RA.Widgets
 				return true;
 
 			var cell = MinimapPixelToCell(mi.Location);
-			var pos = cell.CenterPosition;
+			var pos = world.Map.CenterOfCell(cell);
 			if ((mi.Event == MouseInputEvent.Down || mi.Event == MouseInputEvent.Move) && mi.Button == MouseButton.Left)
-				worldRenderer.Viewport.Center(cell.CenterPosition);
+				worldRenderer.Viewport.Center(world.Map.CenterOfCell(cell));
 
 			if (mi.Event == MouseInputEvent.Down && mi.Button == MouseButton.Right)
 			{

--- a/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.RA/World/BuildableTerrainLayer.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.RA
 				if (wr.world.ShroudObscures(kv.Key))
 					continue;
 
-				new SpriteRenderable(kv.Value, kv.Key.CenterPosition,
+				new SpriteRenderable(kv.Value, wr.world.Map.CenterOfCell(kv.Key),
 					WVec.Zero, -511, pal, 1f, true).Render(wr);
 			}
 		}

--- a/OpenRA.Mods.RA/World/PathfinderDebugOverlay.cs
+++ b/OpenRA.Mods.RA/World/PathfinderDebugOverlay.cs
@@ -76,8 +76,9 @@ namespace OpenRA.Mods.RA
 						layer[cell] = layer[cell] * 5 / 6;
 
 					// TODO: This doesn't make sense for isometric terrain
-					var tl = wr.ScreenPxPosition(cell.TopLeft);
-					var br = wr.ScreenPxPosition(cell.BottomRight);
+					var pos = wr.world.Map.CenterOfCell(cell);
+					var tl = wr.ScreenPxPosition(pos - new WVec(512, 512, 0));
+					var br = wr.ScreenPxPosition(pos + new WVec(511, 511, 0));
 					qr.FillRect(RectangleF.FromLTRB(tl.X, tl.Y, br.X, br.Y), Color.FromArgb(w, c));
 				}
 			}

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.RA
 		public void AddSmudge(CPos loc)
 		{
 			if (Game.CosmeticRandom.Next(0, 100) <= Info.SmokePercentage)
-				world.AddFrameEndTask(w => w.Add(new Smoke(w, loc.CenterPosition, Info.SmokeType)));
+				world.AddFrameEndTask(w => w.Add(new Smoke(w, world.Map.CenterOfCell(loc), Info.SmokeType)));
 
 			if (!dirty.ContainsKey(loc) && !tiles.ContainsKey(loc))
 			{
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.RA
 				if (world.ShroudObscures(kv.Key))
 					continue;
 
-				new SpriteRenderable(kv.Value.Sprite, kv.Key.CenterPosition,
+				new SpriteRenderable(kv.Value.Sprite, world.Map.CenterOfCell(kv.Key),
 					WVec.Zero, -511, pal, 1f, true).Render(wr);
 			}
 		}


### PR DESCRIPTION
Part 3 / 5 of the isometric terrain implementation.
- CPos.CenterPosition has been replaced with Map.CenterOfCell.
- WPos.ToCPos has been replaced with Map.CellContaining.
- A bunch of plumbing changes so that a Map is available where it is needed.
- Cleaned up some more legacy code.

Moving the conversions into Map will allow these checks to be extended in future PRs to account for rectangular vs isometric cell grids, and use heightmap data.
