### PR TITLE
Make Shift+<Hotkey> queue five units/buildings. Fixes #5544.

### DIFF
--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -523,7 +523,7 @@ namespace OpenRA.Mods.RA.Widgets
 			if (!paletteOpen) return false;
 			if (CurrentQueue == null) return false;
 
-			var toBuild = CurrentQueue.BuildableItems().FirstOrDefault(b => b.Traits.Get<BuildableInfo>().Hotkey == Hotkey.FromKeyInput(e));
+			var toBuild = CurrentQueue.BuildableItems().FirstOrDefault(b => b.Traits.Get<BuildableInfo>().Hotkey.Key == Hotkey.FromKeyInput(e).Key);
 
 			if (toBuild != null)
 			{


### PR DESCRIPTION
I had a commit ready (as in, another one-liner :) that also made the CTRL key cancel builds, but that obviously conflicts with the CTRL+A and CTRL+T selection shortcuts. Let me know if you want that in anyhow, and if you have any preference how to fix the conflicts.
