### PR TITLE
Fixed Tiberian Sun shroud offsets.

### DIFF
--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -387,8 +387,10 @@ resources:
 shroud:
 	shroud: shroud
 		Length: *
+		Offset: 0, -1
 	fog: fog
 		Length: *
+		Offset: 0, -1
 
 scorches: #TODO: make use of 07-12 as well
 	sc1: burnt01


### PR DESCRIPTION
https://github.com/OpenRA/OpenRA/issues/5757 mentioned https://github.com/OpenRA/OpenRA/issues/4718, but I don't really believe that the problem lies in the parser.

This is the original OS SHP Builder output of Tiberian Sun shroud.shp

![shpviewer 0000](https://cloud.githubusercontent.com/assets/756669/3416674/4ff0e3f0-fe2f-11e3-9e0d-e59ddcf3811a.png)

This is our output from OpenRA.Utility.exe

![shroud-0000](https://cloud.githubusercontent.com/assets/756669/3416684/5d64ff94-fe2f-11e3-884c-dfc31f763375.png)

Turns out the shapes match. Our parser seem to work correctly or just like https://github.com/OpenRA/OpenRA/commit/20a6c75ba423a82ec030fdfe1e6f5fa4192fbee6 did before.
