### PR TITLE
Fix D2K paratroopers.

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -634,7 +634,6 @@ WALL:
 		ChargeTime: 180
 		Description: Paratroopers
 		LongDesc: A Carryall drops a squad of Infantry \nanywhere on the map
-		Prerequisites: HIGHTECHO
 		DropItems: RIFLE, RIFLE, BAZOOKA, BAZOOKA, ENGINEER, BAZOOKA, RIFLE, RIFLE
 		SelectTargetSound:
 		FlareType:


### PR DESCRIPTION
#5634 combined with legacy cruft broke the carryall drops in D2K.
