### PR TITLE
Added a new Lint check for invalid map cordons

### DIFF
--- a/OpenRA.Mods.RA/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.RA/Lint/CheckMapCordon.cs
@@ -1,0 +1,29 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class CheckMapCordon : ILintPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		{
+			if (map.Bounds.Left == 0 || map.Bounds.Top == 0
+				|| map.Bounds.Right == map.MapSize.X || map.Bounds.Bottom == map.MapSize.Y)
+					emitError("This map does not define a valid cordon.\n"
+						+"A one cell (or greater) border is required on all four sides "
+						+"between the playable bounds and the map edges");
+		}
+	}
+}
+

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -519,6 +519,7 @@
     <Compile Include="Lint\CheckPlayers.cs" />
     <Compile Include="Player\ProvidesCustomPrerequisite.cs" />
     <Compile Include="Lint\CheckActors.cs" />
+    <Compile Include="Lint\CheckMapCordon.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">


### PR DESCRIPTION
This will protect both this repository and http://resource.openra.net from invalid submissions that crash the game. It is also documented at https://github.com/OpenRA/OpenRA/wiki/Mapping#file-format but no one reads manuals.
