### PR TITLE
Made GetSpawnOccupants more robust against invalid list queries

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -150,14 +150,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		{
 			var spawns = preview.SpawnPoints;
 			return lobbyInfo.Clients
-				.Where(c => c.SpawnPoint != 0)
+				.Where(c => c.SpawnPoint >= 1)
 				.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c));
 		}
+
 		public static Dictionary<CPos, SpawnOccupant> GetSpawnOccupants(IEnumerable<GameInformation.Player> players, MapPreview preview)
 		{
 			var spawns = preview.SpawnPoints;
 			return players
-					.Where(c => c.SpawnPoint != 0)
+					.Where(c => c.SpawnPoint >= 1)
 					.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c));
 		}
 


### PR DESCRIPTION
I hope this fixes #5588.

> Index was out of range. Must be non-negative and less than the size of the collection.
