### PR TITLE
Fixed SeedsResources messing with make animation

### DIFF
--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -520,6 +520,7 @@
     <Compile Include="Render\WithMakeAnimation.cs" />
     <Compile Include="Widgets\Logic\InstallFromCDLogic.cs" />
     <Compile Include="Widgets\Logic\InstallMusicLogic.cs" />
+    <Compile Include="Render\WithActiveAnimation.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
@@ -1,0 +1,65 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA.Render
+{
+	[Desc("Replaces the idle animation of a building.")]
+	public class WithActiveAnimationInfo : ITraitInfo, Requires<RenderBuildingInfo>
+	{
+		[Desc("Sequence name to use")]
+		public readonly string Sequence = "active";
+
+		public readonly int Interval = 750;
+
+		public readonly bool PauseOnLowPower = false;
+
+		public object Create(ActorInitializer init) { return new WithActiveAnimation(init.self, this); }
+	}
+
+	public class WithActiveAnimation : ITickRender, INotifyBuildComplete
+	{
+		readonly IEnumerable<IDisable> disabled;
+		readonly WithActiveAnimationInfo info;
+		readonly RenderBuilding renderBuilding;
+
+		public WithActiveAnimation(Actor self, WithActiveAnimationInfo info)
+		{
+			disabled = self.TraitsImplementing<IDisable>();
+			renderBuilding = self.Trait<RenderBuilding>();
+			this.info = info;
+		}
+
+		int ticks;
+		public void TickRender(WorldRenderer wr, Actor self)
+		{
+			if (!buildComplete)
+				return;
+
+			if (--ticks <= 0)
+			{
+				if (!(info.PauseOnLowPower && disabled.Any(d => d.Disabled)))
+					renderBuilding.PlayCustomAnim(self, info.Sequence);
+				ticks = info.Interval;
+			}
+		}
+
+		bool buildComplete = false;
+
+		public void BuildingComplete(Actor self)
+		{
+			buildComplete = true;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.RA.Render
 		public object Create(ActorInitializer init) { return new WithActiveAnimation(init.self, this); }
 	}
 
-	public class WithActiveAnimation : ITickRender, INotifyBuildComplete
+	public class WithActiveAnimation : ITickRender, INotifyBuildComplete, INotifySold
 	{
 		readonly IEnumerable<IDisable> disabled;
 		readonly WithActiveAnimationInfo info;
@@ -61,5 +61,11 @@ namespace OpenRA.Mods.RA.Render
 		{
 			buildComplete = true;
 		}
+
+		public void Selling(Actor self)
+		{
+			buildComplete = false;
+		}
+		public void Sold(Actor self) { }
 	}
 }

--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -3,6 +3,7 @@ SPLIT2:
 	SeedsResource:
 		ResourceType: Tiberium
 		Interval: 55
+	WithActiveAnimation:
 
 SPLIT3:
 	Inherits: ^TibTree
@@ -11,6 +12,7 @@ SPLIT3:
 	SeedsResource:
 		ResourceType: Tiberium
 		Interval: 55
+	WithActiveAnimation:
 
 SPLITBLUE:
 	Inherits: ^TibTree
@@ -19,6 +21,7 @@ SPLITBLUE:
 	SeedsResource:
 		ResourceType: BlueTiberium
 		Interval: 110
+	WithActiveAnimation:
 	Tooltip:
 		Name: Blossom Tree (blue)
 	RadarColorFromTerrain:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -113,6 +113,7 @@ SPICEBLOOM:
 	SeedsResource:
 		ResourceType: Spice
 		Interval: 75
+	WithActiveAnimation:
 	RadarColorFromTerrain:
 		Terrain: Spice
 	BodyOrientation:

--- a/mods/ra/sequences/decorations.yaml
+++ b/mods/ra/sequences/decorations.yaml
@@ -223,18 +223,6 @@ t01:
 		Length: 8
 		Tick: 80
 
-mine:
-	idle:
-		Start: 0
-	active:
-		Start: 0
-
-railmine:
-	idle:
-		Start: 0
-	active:
-		Start: 0
-
 v01:
 	idle:
 		Start: 0

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -608,3 +608,11 @@ craters:
 		Length: *
 	cr6: cr6
 		Length: *
+
+mine:
+	idle:
+		Start: 0
+
+railmine:
+	idle:
+		Start: 0


### PR DESCRIPTION
This fixes #5300, but actually it does a lot more than that. 
- The split of WithActiveAnimation from SeedsResource removes the rendering related stuff from logic Tick to TickRender like https://github.com/OpenRA/OpenRA/pull/5640 does for all other traits that did not hide their rendering abilities from me. It also removes the need to define fake active animations that are identical to idle (RA mines). It also gets feature parity with our recent building render traits such as allowing to disable it when it is on low power.
- I also found SeedsResources doing multiple expensive trait lookups every few ticks. This caches everything in the constructor to further improve performance.
