### PR TITLE
TD remapable blue tiberium

### DIFF
--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -99,12 +99,17 @@ World:
 		PipColor: Green
 		AllowedTerrainTypes: Clear,Road
 		AllowUnderActors: false
+	FixedColorPalette@BlueTiberium:
+		Base: terrain
+		Name: bluetiberium
+		Color: 154, 201, 168
+		RemapIndex: 5, 4, 165, 166, 158, 156, 167, 157, 159, 160, 184, 185, 186, 187, 188, 189
 	ResourceType@blue-tib:
 		ResourceType: 2
-		Palette: staticterrain
+		Palette: bluetiberium
 		TerrainType: BlueTiberium
-		EditorSprite: bti1
-		Variants: bti1,bti2,bti3,bti4,bti5,bti6,bti7,bti8,bti9,bti10,bti11,bti12
+		EditorSprite: ti1
+		Variants: ti1,ti2,ti3,ti4,ti5,ti6,ti7,ti8,ti9,ti10,ti11,ti12
 		MaxDensity: 12
 		ValuePerUnit: 75
 		Name: BlueTiberium


### PR DESCRIPTION
Alternative approach to #5808.

This one would be a simpler approach, but it crashes for me:

```
Tiberian Dawn Mod at Version {DEV_VERSION}
Operating System: Windows (Microsoft Windows NT 6.1.7601 Service Pack 1)
Runtime Version: .NET CLR 4.0.30319.18444
Exception of type `System.ArgumentException`: Der Wert -881 ist fÃ¼r red ungÃ¼ltig. red muss grÃ¶ÃŸer als oder gleich 0 und kleiner als oder gleich 255 sein.
   bei System.Drawing.Color.CheckByte(Int32 value, String name)
   bei System.Drawing.Color.FromArgb(Int32 alpha, Int32 red, Int32 green, Int32 blue)
   bei OpenRA.Exts.ColorLerp(Single t, Color c1, Color c2) in e:\OpenRA_work2\OpenRA.Game\Exts.cs:Zeile 268.
   bei OpenRA.Graphics.PlayerColorRemap.<>c__DisplayClassb.<.ctor>b__2(Int32 x, Int32 i) in e:\OpenRA_work2\OpenRA.Game\Graphics\PlayerColorRemap.cs:Zeile 45.
   bei System.Linq.Enumerable.<SelectIterator>d__7`2.MoveNext()
   bei System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   bei System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   bei OpenRA.Graphics.PlayerColorRemap..ctor(Int32[] ramp, HSLColor c, Single rampFraction) in e:\OpenRA_work2\OpenRA.Game\Graphics\PlayerColorRemap.cs:Zeile 45.
   bei OpenRA.Traits.FixedColorPalette.LoadPalettes(WorldRenderer wr) in e:\OpenRA_work2\OpenRA.Game\Traits\Player\FixedColorPalette.cs:Zeile 45.
   bei OpenRA.Graphics.WorldRenderer..ctor(World world) in e:\OpenRA_work2\OpenRA.Game\Graphics\WorldRenderer.cs:Zeile 51.
   bei OpenRA.Game.StartGame(String mapUID, Boolean isShellmap) in e:\OpenRA_work2\OpenRA.Game\Game.cs:Zeile 260.
   bei OpenRA.Game.LoadShellMap() in e:\OpenRA_work2\OpenRA.Game\Game.cs:Zeile 452.
   bei OpenRA.Mods.Cnc.CncLoadScreen.TestAndContinue()
   bei OpenRA.Mods.Cnc.CncLoadScreen.StartGame()
   bei OpenRA.Game.InitializeWithMod(String mod, String replay) in e:\OpenRA_work2\OpenRA.Game\Game.cs:Zeile 440.
   bei OpenRA.Game.Initialize(Arguments args) in e:\OpenRA_work2\OpenRA.Game\Game.cs:Zeile 362.
   bei OpenRA.Program.Run(String[] args) in e:\OpenRA_work2\OpenRA.Game\Support\Program.cs:Zeile 114.
   bei OpenRA.Program.Main(String[] args) in e:\OpenRA_work2\OpenRA.Game\Support\Program.cs:Zeile 39.
```
