### PR TITLE
Fixed the AI choosing rallypoints on land for shipyards

### DIFF
--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -2,7 +2,6 @@ Player:
 	HackyAI@Omnius:
 		Name: Omnius
 		UnitQueues: Infantry, Vehicle, Armor, Starport
-		RallypointTestBuilding: conyarda
 		BuildingCommonNames:
 			ConstructionYard: conyarda,conyardh,conyardo
 			Refinery: refa,refh,refo
@@ -104,7 +103,6 @@ Player:
 	HackyAI@Vidius:
 		Name: Vidious
 		UnitQueues: Infantry, Vehicle, Armor, Starport
-		RallypointTestBuilding: conyarda
 		BuildingCommonNames:
 			ConstructionYard: conyarda,conyardh,conyardo
 			Refinery: refa,refh,refo
@@ -207,7 +205,6 @@ Player:
 	HackyAI@Gladius:
 		Name: Gladius
 		UnitQueues: Infantry, Vehicle, Armor, Starport
-		RallypointTestBuilding: conyarda
 		BuildingCommonNames:
 			ConstructionYard: conyarda,conyardh,conyardo
 			Refinery: refa,refh,refo


### PR DESCRIPTION
I hope this improves Naval AI and performance as it avoids impossible pathings. It should also help prevent problems when people create mods and get confused because the AI crashes as it relies on a `fact` actor somewhere in the rules although it is listed in no production queues.
