### PR TITLE
Fixed units not moving to the RallyPoint

### DIFF
--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -674,7 +674,7 @@ namespace OpenRA.Mods.RA.AI
 		{
 			var buildings = self.World.ActorsWithTrait<RallyPoint>()
 				.Where(rp => rp.Actor.Owner == p &&
-					!IsRallyPointValid(rp.Trait.rallyPoint, rp.Actor.Info.Traits.GetOrDefault<BuildingInfo>())).ToArray();
+					!IsRallyPointValid(rp.Trait.Location, rp.Actor.Info.Traits.GetOrDefault<BuildingInfo>())).ToArray();
 
 			if (buildings.Length > 0)
 				BotDebug("Bot {0} needs to find rallypoints for {1} buildings.",

--- a/OpenRA.Mods.RA/Air/TakeOff.cs
+++ b/OpenRA.Mods.RA/Air/TakeOff.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Air
 			var hasHost = host != null;
 			var rp = hasHost ? host.TraitOrDefault<RallyPoint>() : null;
 
-			var destination = rp != null ? rp.rallyPoint :
+			var destination = rp != null ? rp.Location :
 				(hasHost ? self.World.Map.CellContaining(host.CenterPosition) : self.Location);
 
 			return new AttackMove.AttackMoveActivity(self, self.Trait<IMove>().MoveTo(destination, 1));

--- a/OpenRA.Mods.RA/Effects/RallyPoint.cs
+++ b/OpenRA.Mods.RA/Effects/RallyPoint.cs
@@ -42,9 +42,9 @@ namespace OpenRA.Mods.RA.Effects
 		{
 			flag.Tick();
 			circles.Tick();
-			if (cachedLocation != rp.rallyPoint)
+			if (cachedLocation != rp.Location)
 			{
-				cachedLocation = rp.rallyPoint;
+				cachedLocation = rp.Location;
 				circles.Play("circles");
 			}
 

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -64,7 +64,6 @@ namespace OpenRA.Mods.RA
 
 			var exitLocation = rp.Value != null ? rp.Value.rallyPoint : exit;
 			var target = Target.FromCell(self.World, exitLocation);
-			var nearEnough = rp.Value != null ? WRange.FromCells(rp.Value.nearEnough) : WRange.Zero;
 
 			self.World.AddFrameEndTask(w =>
 			{
@@ -88,7 +87,7 @@ namespace OpenRA.Mods.RA
 					{
 						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
 						newUnit.QueueActivity(new AttackMove.AttackMoveActivity(
-							newUnit, move.MoveWithinRange(target, nearEnough)));
+							newUnit, move.MoveTo(exitLocation, 1)));
 					}
 				}
 

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.RA
 			var fi = producee.Traits.Get<IFacingInfo>();
 			var initialFacing = exitinfo.Facing < 0 ? Util.GetFacing(to - spawn, fi.GetInitialFacing()) : exitinfo.Facing;
 
-			var exitLocation = rp.Value != null ? rp.Value.rallyPoint : exit;
+			var exitLocation = rp.Value != null ? rp.Value.Location : exit;
 			var target = Target.FromCell(self.World, exitLocation);
 
 			self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.RA/RallyPoint.cs
+++ b/OpenRA.Mods.RA/RallyPoint.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.RA
 	[Desc("Used to waypoint units after production or repair is finished.")]
 	public class RallyPointInfo : ITraitInfo
 	{
-		public readonly int[] RallyPoint = { 1, 3 };
+		public readonly CVec RallyPoint = new CVec(1, 3);
 		public readonly string IndicatorPalettePrefix = "player";
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.self, this); }
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA
 
 		public RallyPoint(Actor self, RallyPointInfo info)
 		{
-			rallyPoint = self.Location + new CVec(info.RallyPoint[0], info.RallyPoint[1]);
+			rallyPoint = self.Location + info.RallyPoint;
 			self.World.AddFrameEndTask(w => w.Add(new Effects.RallyPoint(self, info.IndicatorPalettePrefix)));
 		}
 

--- a/OpenRA.Mods.RA/RallyPoint.cs
+++ b/OpenRA.Mods.RA/RallyPoint.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -24,11 +24,11 @@ namespace OpenRA.Mods.RA
 
 	public class RallyPoint : IIssueOrder, IResolveOrder, ISync
 	{
-		[Sync] public CPos rallyPoint;
+		[Sync] public CPos Location;
 
 		public RallyPoint(Actor self, RallyPointInfo info)
 		{
-			rallyPoint = self.Location + info.RallyPoint;
+			Location = self.Location + info.RallyPoint;
 			self.World.AddFrameEndTask(w => w.Add(new Effects.RallyPoint(self, info.IndicatorPalettePrefix)));
 		}
 
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA
 			get { yield return new RallyPointOrderTargeter(); }
 		}
 
-		public Order IssueOrder( Actor self, IOrderTargeter order, Target target, bool queued )
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "SetRallyPoint")
 				return new Order(order.OrderID, self, false) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition), SuppressVisualFeedback = true };
@@ -45,10 +45,10 @@ namespace OpenRA.Mods.RA
 			return null;
 		}
 
-		public void ResolveOrder( Actor self, Order order )
+		public void ResolveOrder(Actor self, Order order)
 		{
-			if( order.OrderString == "SetRallyPoint" )
-				rallyPoint = order.TargetLocation;
+			if (order.OrderString == "SetRallyPoint")
+				Location = order.TargetLocation;
 		}
 
 		class RallyPointOrderTargeter : IOrderTargeter
@@ -67,6 +67,7 @@ namespace OpenRA.Mods.RA
 					cursor = "ability";
 					return true;
 				}
+
 				return false;
 			}
 

--- a/OpenRA.Mods.RA/RallyPoint.cs
+++ b/OpenRA.Mods.RA/RallyPoint.cs
@@ -25,7 +25,6 @@ namespace OpenRA.Mods.RA
 	public class RallyPoint : IIssueOrder, IResolveOrder, ISync
 	{
 		[Sync] public CPos rallyPoint;
-		public int nearEnough = 1;
 
 		public RallyPoint(Actor self, RallyPointInfo info)
 		{

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -86,8 +86,8 @@ namespace OpenRA.Mods.RA
 				if (rp != null)
 					self.QueueActivity(new CallFunc(() =>
 					{
-						self.SetTargetLine(Target.FromCell(self.World, rp.rallyPoint), Color.Green);
-						self.QueueActivity(movement.MoveTo(rp.rallyPoint, order.TargetActor));
+						self.SetTargetLine(Target.FromCell(self.World, rp.Location), Color.Green);
+						self.QueueActivity(movement.MoveTo(rp.Location, order.TargetActor));
 					}));
 			}
 		}

--- a/mods/common/lua/production.lua
+++ b/mods/common/lua/production.lua
@@ -31,7 +31,7 @@ end
 Production.SetRallyPoint = function(factory, location)
 	local srp = Actor.Trait(factory, "RallyPoint")
 	if srp ~= nil then
-		srp.rallyPoint = location.Location
+		srp.Location = location.Location
 	end
 end
 


### PR DESCRIPTION
I played around and made some observations.
- `public int nearEnough = 1;` is the only value that makes sense as 0 crashes the game and 2 will be too far away for the default exit and rally point distance. Also the value is looked up somewhere else and not even configurable so why was this even a public field.
- MoveWithinRange seems to be a bad choice for rally point movement as units are allowed to give up too early. We want them to move directly to that point not stand somewhere near it blocking the exit. This fixes #5682.

The StyleCop violations and legacy int[] fields to parse a 2D vector coordinate make this look like code that has not been touched for years. Hope this removes some bit rot.
