### PR TITLE
Fixed chat commands crashing replays

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
@@ -67,7 +67,11 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				var team = teamChat && !disableTeamChat;
 				if (chatText.Text != "")
-					orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim()));
+					if (!chatText.Text.StartsWith("/"))
+						orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim()));
+					else
+						if (chatTraits != null)
+							chatTraits.All(x => x.OnChat(orderManager.LocalClient.Name, chatText.Text.Trim()));
 
 				CloseChat();
 				return true;
@@ -126,9 +130,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		public void AddChatLine(Color c, string from, string text)
 		{
-			if (chatTraits != null && !chatTraits.All(x => x.OnChat(from, text)))
-				return;
-			
 			chatOverlayDisplay.AddLine(c, from, text);
 
 			var template = chatTemplate.Clone();


### PR DESCRIPTION
This does not just fix #5755, but also the fact that chat commands were sent also via a regular chat order so they would be executed on _all_ clients who read the chat and watch them for strings starting with `/`. It just crashed because on replays the local client is null, but in fact this is a serious exploit especially in combination with https://github.com/OpenRA/OpenRA/pull/5701! We also don't need to send a new Order.Chat and hide the received output later, because all Chat/Player/DevCommands issue proper network orders themselves once invoked.
