### PR TITLE
Corrected d2k.sardaukar prone-shoot animation.

### DIFF
--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -412,7 +412,7 @@ sardaukar:
 	prone-shoot: DATA
 		Start: 1058
 		Length: 6
-		Facings: 8
+		Facings: -8
 		Transpose: true
 	die1: DATA
 		Start: 1106


### PR DESCRIPTION
Sardaukar prone-shoot facings where non-negative, causing the actor to face the opposite direction of its target when firing prone.

See issue #5816 
