### PR TITLE
Re-implement Shadow support for Missiles

### DIFF
--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.RA.Effects
 		public readonly int Arm = 0;
 		[Desc("Check for whether an actor with Wall: trait blocks fire")]
 		public readonly bool High = false;
+		public readonly bool Shadow = false;
 		public readonly string Trail = null;
 		[Desc("Maximum offset at the maximum range")]
 		public readonly WRange Inaccuracy = WRange.Zero;
@@ -188,6 +189,13 @@ namespace OpenRA.Mods.RA.Effects
 
 			if (!args.SourceActor.World.FogObscures(wr.world.Map.CellContaining(pos)))
 			{
+				if (info.Shadow)
+				{
+					var shadowPos = new WPos(pos.X, pos.Y, 0);
+					foreach (var r in anim.Render(shadowPos, wr.Palette("shadow")))
+						yield return r;
+				}
+
 				var palette = wr.Palette(args.Weapon.Palette);
 				foreach (var r in anim.Render(pos, palette))
 					yield return r;

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -243,7 +243,6 @@ Rockets:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 15
@@ -275,7 +274,6 @@ BikeRockets:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 10
@@ -307,7 +305,6 @@ OrcaAGMissiles:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 20
@@ -338,7 +335,6 @@ OrcaAAMissiles:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 20
@@ -556,7 +552,6 @@ MammothMissiles:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 20
@@ -588,7 +583,7 @@ MammothMissiles:
 	Projectile: Bullet
 		Arm: 5
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 853
 		Angle: 62
 		Image: DRAGON
@@ -619,7 +614,6 @@ MammothMissiles:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: yes
 		Inaccuracy: 213
 		Image: DRAGON
 		ROT: 10
@@ -694,7 +688,6 @@ BoatMissile:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Inaccuracy: 213
 		Image: DRAGON
 		ROT: 10
@@ -723,7 +716,6 @@ TowerMissle:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 20
@@ -822,7 +814,6 @@ SAMMissile:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: no
 		Image: MISSILE
 		ROT: 20
 		Speed: 426
@@ -849,7 +840,7 @@ HonestJohn:
 	Projectile: Bullet
 		Arm: 10
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 213
 		Image: patriot
 		Trail: smokey
@@ -941,7 +932,6 @@ Patriot:
 	ValidTargets: Air
 	Projectile: Missile
 		High: yes
-		Shadow: no
 		Image: patriot
 		Trail: smokey
 		ContrailLength: 8

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -27,7 +27,6 @@ Bazooka:
 	Projectile: Missile
 		Speed: 160
 		Arm: 2
-		Shadow: yes
 		ContrailLength: 10
 		Inaccuracy: 96
 		Image: RPG
@@ -171,7 +170,6 @@ QuadRockets:
 	ValidTargets: Ground, Air
 	Projectile: Missile
 		Arm: 0
-		Shadow: yes
 		Inaccuracy: 96
 		Image: RPG
 		ROT: 10

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -127,7 +127,6 @@ Maverick:
 		Speed: 256
 		Arm: 2
 		High: true
-		Shadow: false
 		ContrailLength: 10
 		Inaccuracy: 512
 		Image: DRAGON
@@ -284,7 +283,6 @@ Dragon:
 		Speed: 213
 		Arm: 2
 		High: true
-		Shadow: false
 		Trail: smokey
 		ContrailLength: 10
 		Inaccuracy: 128
@@ -317,7 +315,6 @@ HellfireAG:
 		Speed: 256
 		Arm: 2
 		High: true
-		Shadow: false
 		ContrailLength: 10
 		Inaccuracy: 128
 		Image: DRAGON
@@ -349,7 +346,6 @@ HellfireAA:
 		Speed: 384
 		Arm: 2
 		High: true
-		Shadow: false
 		ContrailLength: 10
 		Inaccuracy: 128
 		Image: DRAGON
@@ -516,7 +512,6 @@ MammothTusk:
 		Speed: 341
 		Arm: 2
 		High: true
-		Shadow: false
 		ContrailLength: 10
 		Inaccuracy: 128
 		Image: DRAGON
@@ -686,7 +681,6 @@ Nike:
 	Projectile: Missile
 		Arm: 3
 		High: true
-		Shadow: false
 		ContrailLength: 10
 		Image: MISSILE
 		ROT: 25
@@ -714,7 +708,6 @@ RedEye:
 	Projectile: Missile
 		Arm: 3
 		High: true
-		Shadow: false
 		ContrailLength: 10
 		Image: MISSILE
 		ROT: 20
@@ -797,7 +790,6 @@ Stinger:
 	Projectile: Missile
 		Arm: 3
 		High: true
-		Shadow: false
 		ContrailLength: 10
 		Image: DRAGON
 		ROT: 20
@@ -1285,7 +1277,6 @@ APTusk:
 		Speed: 298
 		Arm: 2
 		High: true
-		Shadow: false
 		Trail: smokey
 		ContrailLength: 10
 		Inaccuracy: 128

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -127,9 +127,10 @@ HVR:
 		Range: 7c0
 	Armament:
 		Weapon: HoverMissile
+		LocalOffset: 0,171,384, 0,-171,384
 	Turreted:
 		ROT: 7
-		Offset: -128,0,0
+		Offset: -128,0,85
 	AttackTurreted:
 	AutoTarget:
 	RenderSprites:
@@ -605,8 +606,7 @@ BIKE:
 		Range: 5c0
 	Armament:
 		Weapon: BikeMissile
-		LocalOffset: -128, -170, 170, -128, 170, 170
-		LocalYaw: 100, -100
+		LocalOffset: -128,-170,213, -128,170,213
 	AttackFrontal:
 	AutoTarget:
 	RenderSprites:

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -47,7 +47,7 @@ Grenade:
 	Projectile: Bullet
 		Speed: 85
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Angle: 62
 		Inaccuracy: 554
 		Image: DISCUS
@@ -74,7 +74,7 @@ Bazooka:
 		Speed: 213
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 8
@@ -102,7 +102,7 @@ MultiCluster:
 		Speed: 170
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 8
@@ -198,7 +198,7 @@ CyCannon:
 	Projectile: Bullet
 		Speed: 192
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Image: TORPEDO
 	Warhead:
 		Spread: 256
@@ -275,7 +275,7 @@ FiendShard:
 	Projectile: Bullet
 		Speed: 213
 		Image: CRYSTAL4
-		Shadow: yes
+		Shadow: true
 		Angle: 88
 	Warhead:
 		Versus:
@@ -312,10 +312,10 @@ HoverMissile:
 	ValidTargets: Ground, Air
 	Palette: ra
 	Projectile: Missile
-		Speed: 256
+		Speed: 213
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 8
@@ -343,7 +343,7 @@ HoverMissile:
 	Projectile: Bullet
 		Speed: 682
 		Image: 120mm
-		Shadow: yes
+		Shadow: true
 		Angle: 62
 	Warhead:
 		Spread: 128
@@ -368,7 +368,7 @@ MammothTusk:
 	Projectile: Missile
 		Arm: 0
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 10
@@ -502,11 +502,11 @@ BikeMissile:
 	Projectile: Missile
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 8
-		Speed: 256
+		Speed: 213
 		RangeLimit: 35
 	Warhead:
 		Spread: 256
@@ -589,7 +589,7 @@ Dragon:
 		Speed: 213
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 8
@@ -615,7 +615,7 @@ Dragon:
 	Projectile: Bullet
 		Speed: 682
 		Image: 120mm
-		Shadow: yes
+		Shadow: true
 		Angle: 62
 	Warhead:
 		Spread: 128
@@ -639,7 +639,7 @@ Dragon:
 		Speed: 170
 		Image: 120mm
 		Angle: 165
-		Shadow: yes
+		Shadow: true
 		High: yes
 	MinRange: 5c0
 	Warhead:
@@ -666,7 +666,7 @@ Hellfire:
 		Speed: 256
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 8
@@ -691,7 +691,7 @@ Bomb:
 	Projectile: Bullet
 		Speed: 170
 		Image: canister
-		Shadow: yes
+		Shadow: true
 	Warhead:
 		Spread: 298
 		Versus:
@@ -715,7 +715,7 @@ Proton:
 		Speed: 256
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: TORPEDO
 		ROT: 1
@@ -815,10 +815,10 @@ RPGTower:
 	Palette: player
 	Projectile: Bullet
 		Speed: 384
-		Image: canister
-		Shadow: yes
-		Angle: 62
 		High: yes
+		Shadow: true
+		Angle: 62
+		Image: canister
 	Warhead:
 		Spread: 128
 		Versus:
@@ -842,7 +842,7 @@ SAMTower:
 		Speed: 298
 		Arm: 2
 		High: yes
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 128
 		Image: DRAGON
 		ROT: 5


### PR DESCRIPTION
Will be needed for TS, at least.

Also took this opportunity to remove lots of formerly bitrotted "Shadow: no/false" entries from the shipping mods. Shadow defaults to false as that's the wanted behaviour for all currently shipping mods, so these entries are obsolete anyway.

I intentionally left TS' weapons.yaml as-is, as a constant reminder that we need something like #3680 to make missile flight behaviour look good & realistic for TS/RA2 or similar projects which use isometric perspective.
