### PR TITLE
Fix breakage of the old Lua API due to recent changes

### DIFF
--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -461,5 +461,11 @@ namespace OpenRA.Mods.RA.Scripting
 		{
 			return Util.ExpandFootprint(cells.Values.Cast<CPos>(), allowDiagonal);
 		}
+
+		[LuaGlobal]
+		public WPos CenterOfCell(CPos position)
+		{
+			return world.Map.CenterOfCell(position);
+		}
 	}
 }

--- a/mods/cnc/maps/gdi03/gdi03.lua
+++ b/mods/cnc/maps/gdi03/gdi03.lua
@@ -11,7 +11,7 @@ end
 AttackPlayer = function()
 	if not Actor.IsDead(NodBarracks) then
 		Production.BuildWithPerFactoryQueue(NodBarracks, "e1", 5)
-		attackSquad = Team.New(Map.FindUnitsInCircle(enemy, NodBarracks.location, 3))
+		attackSquad = Team.New(Map.FindUnitsInCircle(enemy, NodBarracks, 3))
 		Team.Do(attackSquad, function(unit)
 			Actor.AttackMove(unit, waypoint9.location)
 			Actor.Hunt(unit)

--- a/mods/cnc/maps/gdi04a/gdi04a.lua
+++ b/mods/cnc/maps/gdi04a/gdi04a.lua
@@ -22,7 +22,7 @@ HeliAction = function(heliActor, team)
 	Actor.AfterMove(heliActor)
 	Actor.UnloadCargo(heliActor, true)
 	Actor.Wait(heliActor, Utils.Seconds(2))
-	Actor.ScriptedMove(heliActor, NodHeliEntry)
+	Actor.ScriptedMove(heliActor, NodHeliEntry.Location)
 	Actor.RemoveSelf(heliActor)
 
 	Team.Do(team, function(actor)

--- a/mods/cnc/maps/gdi04b/gdi04b.lua
+++ b/mods/cnc/maps/gdi04b/gdi04b.lua
@@ -18,7 +18,7 @@ HeliAction = function(heliActor, team)
 	Actor.AfterMove(heliActor)
 	Actor.UnloadCargo(heliActor, true)
 	Actor.Wait(heliActor, Utils.Seconds(2))
-	Actor.ScriptedMove(heliActor, HeliEntry)
+	Actor.ScriptedMove(heliActor, HeliEntry.Location)
 	Actor.RemoveSelf(heliActor)
 
 	Team.Do(team, function(actor)

--- a/mods/common/lua/actor.lua
+++ b/mods/common/lua/actor.lua
@@ -29,7 +29,7 @@ end
 
 Actor.ScriptedMove = function(actor, location)
 	if Actor.HasTrait(actor, "Helicopter") then
-		Internal.HeliFlyToPos(actor, location.CenterPosition)
+		Internal.HeliFlyToPos(actor, Map.CenterOfCell(location))
 	else
 		actor:QueueActivity(OpenRA.New("Move", { location }))
 	end

--- a/mods/common/lua/map.lua
+++ b/mods/common/lua/map.lua
@@ -70,6 +70,10 @@ Map.ExpandFootprint = function(cells, allowDiagonal)
 	return Utils.EnumerableToTable(Internal.ExpandFootprint(cells, allowDiagonal))
 end
 
+Map.CenterOfCell = function(position)
+	return Internal.CenterOfCell(position)
+end
+
 CPos.New = function(x, y)
 	return OpenRA.New("CPos", { { x, "Int32" }, { y, "Int32" } })
 end

--- a/mods/common/lua/reinforcements.lua
+++ b/mods/common/lua/reinforcements.lua
@@ -2,7 +2,7 @@ Reinforcements = { }
 
 Reinforcements.Insert = function(owner, transportName, passengerNames, enterPath, exitPath)
 	local facing = { Map.GetFacing(CPos.op_Subtraction(enterPath[2], enterPath[1]), 0), "Int32" }
-	local center = WPos.op_Addition(enterPath[1].CenterPosition, WVec.New(0, 0, Rules.InitialAltitude(transportName)))
+	local center = WPos.op_Addition(Map.CenterOfCell(enterPath[1]), WVec.New(0, 0, Rules.InitialAltitude(transportName)))
 	local transport = Actor.Create(transportName, { Owner = owner, Location = enterPath[1], CenterPosition = center, Facing = facing })
 	local cargo = Actor.Trait(transport, "Cargo")
 	local passengers = { }
@@ -24,7 +24,7 @@ end
 
 Reinforcements.Extract = function(owner, transportName, passengerNames, enterPath, exitPath)
 	local facing = { Map.GetFacing(CPos.op_Subtraction(enterPath[2], enterPath[1]), 0), "Int32" }
-	local center = WPos.op_Addition(enterPath[1].CenterPosition, WVec.New(0, 0, Rules.InitialAltitude(transportName)))
+	local center = WPos.op_Addition(Map.CenterOfCell(enterPath[1]), WVec.New(0, 0, Rules.InitialAltitude(transportName)))
 	local transport = Actor.Create(transportName, { Owner = owner, Location = enterPath[1], CenterPosition = center, Facing = facing })
 	local cargo = Actor.Trait(transport, "Cargo")
 

--- a/mods/common/lua/supportpowers.lua
+++ b/mods/common/lua/supportpowers.lua
@@ -2,10 +2,11 @@ SupportPowers = { }
 
 SupportPowers.Airstrike = function(owner, planeName, enterLocation, bombLocation)
 	local facing = { Map.GetFacing(CPos.op_Subtraction(bombLocation, enterLocation), 0), "Int32" }
-	local center = WPos.op_Addition(enterLocation.CenterPosition, WVec.New(0, 0, Rules.InitialAltitude(planeName)))
+	local center = WPos.op_Addition(Map.CenterOfCell(enterLocation), WVec.New(0, 0, Rules.InitialAltitude(planeName)))
 	local plane = Actor.Create(planeName, { Location = enterLocation, Owner = owner, Facing = facing, CenterPosition = center })
-	Actor.Trait(plane, "AttackBomber"):SetTarget(bombLocation.CenterPosition)
-	Actor.Fly(plane, bombLocation.CenterPosition)
+	local bombLoc = Map.CenterOfCell(bombLocation)
+	Actor.Trait(plane, "AttackBomber"):SetTarget(bombLoc)
+	Actor.Fly(plane, bombLoc)
 	Actor.FlyOffMap(plane)
 	Actor.RemoveSelf(plane)
 	return plane
@@ -13,10 +14,10 @@ end
 
 SupportPowers.Paradrop = function(owner, planeName, passengerNames, enterLocation, dropLocation)
 	local facing = { Map.GetFacing(CPos.op_Subtraction(dropLocation, enterLocation), 0), "Int32" }
-	local center = WPos.op_Addition(enterLocation.CenterPosition, WVec.New(0, 0, Rules.InitialAltitude(planeName)))
+	local center = WPos.op_Addition(Map.CenterOfCell(enterLocation), WVec.New(0, 0, Rules.InitialAltitude(planeName)))
 	local plane = Actor.Create(planeName, { Location = enterLocation, Owner = owner, Facing = facing, CenterPosition = center })
 	Actor.FlyAttackCell(plane, dropLocation)
-	Actor.Trait(plane, "ParaDrop"):SetLZ(dropLocation)
+	Actor.Trait(plane, "ParaDrop"):SetLZ(dropLocation, true)
 	local cargo = Actor.Trait(plane, "Cargo")
 	local passengers = { }
 	for i, passengerName in ipairs(passengerNames) do

--- a/mods/ra/maps/intervention/mission.lua
+++ b/mods/ra/maps/intervention/mission.lua
@@ -55,9 +55,8 @@ Reinforcements.ReinforceAir = function(owner, planeNames, entrypoint, rallypoint
 	local flight = { }
 
 	for i, planeName in ipairs(planeNames) do
-		local plane = Actor.Create(planeName, { AddToWorld = false, Location = entrypoint.Location, Owner = owner, Facing = facing })
-		local enterLocation = entrypoint.Location
 		local enterPosition = WPos.op_Addition(entrypoint.CenterPosition, WVec.New(0, 0, Rules.InitialAltitude(planeName)))
+		local plane = Actor.Create(planeName, { AddToWorld = false, Location = entrypoint.Location, CenterPosition = enterPosition, Owner = owner, Facing = facing })
 		flight[i] = plane
 		OpenRA.RunAfterDelay((i - 1) * interval, function()
 			World:Add(plane)


### PR DESCRIPTION
Specifically, the CPos::CenterPosition -> Map::CenterOfCell rename (#5758),
as well as the additional argument to Paradrop::SetLZ (#5695).
