### PR TITLE
Increase Chinook landing speed and removed turn before landing.

### DIFF
--- a/OpenRA.Mods.RA/Air/Helicopter.cs
+++ b/OpenRA.Mods.RA/Air/Helicopter.cs
@@ -19,8 +19,15 @@ namespace OpenRA.Mods.RA.Air
 	class HelicopterInfo : AircraftInfo, IMoveInfo
 	{
 		public readonly WRange IdealSeparation = new WRange(1706);
+
+		[Desc("Allow the helicopter land after it has no more commands.")]
 		public readonly bool LandWhenIdle = true;
+
+		[Desc("Allow the helicopter turn before landing.")]
+		public readonly bool TurnToLand = false;
 		public readonly WRange LandAltitude = WRange.Zero;
+
+		[Desc("How fast the helicopter ascends or descends.")]
 		public readonly WRange AltitudeVelocity = new WRange(43);
 
 		public override object Create(ActorInitializer init) { return new Helicopter(init, this); }
@@ -59,7 +66,9 @@ namespace OpenRA.Mods.RA.Air
 
 				if (Info.LandWhenIdle)
 				{
-					self.QueueActivity(new Turn(Info.InitialFacing));
+					if (Info.TurnToLand)
+						self.QueueActivity(new Turn(Info.InitialFacing));
+
 					self.QueueActivity(new HeliLand(true));
 				}
 			}
@@ -103,7 +112,9 @@ namespace OpenRA.Mods.RA.Air
 
 				if (Info.LandWhenIdle)
 				{
-					self.QueueActivity(new Turn(Info.InitialFacing));
+					if (Info.TurnToLand)
+						self.QueueActivity(new Turn(Info.InitialFacing));
+
 					self.QueueActivity(new HeliLand(true));
 				}
 			}

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -17,6 +17,7 @@ TRAN:
 		Speed: 140
 		InitialFacing: 0
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Tiberium,BlueTiberium
+		AltitudeVelocity: 0c100
 	Health:
 		HP: 90
 	Armor:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -206,6 +206,7 @@ TRAN:
 		ROT: 5
 		Speed: 112
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach
+		AltitudeVelocity: 0c100
 	RenderUnit:
 	WithRotor@PRIMARY:
 		Offset: -597,0,341


### PR DESCRIPTION
Fixes #5054, Allows for any helicopter to choose to turn to the initial facing before landing, and sets the default to disable the turn since this only affects the chinook.  I kept the previous functionality as a property because I thought it might make sense for single player for visual effect (Allies01) or for some other mod.

Increases the chinook's ascend/descend speed for faster landing as well.

Also documents some of the helicopter trait properties, since you can never have too much documentation.
