### PR TITLE
Removed false damage states which caused invisible walls.  Fixes #5654

### DIFF
--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -378,18 +378,12 @@ brik:
 	damaged-idle:
 		Start: 32
 		Length: 16
-	critical-idle:
-		Start: 48
-		Length: 16
 	icon: brikicnh
 		Start: 0
 
 sbag:
 	idle:
 		Start: 0
-		Length: 16
-	damaged-idle:
-		Start: 16
 		Length: 16
 	icon: sbagicnh
 		Start: 0
@@ -400,9 +394,6 @@ cycl:
 		Length: 16
 	damaged-idle:
 		Start: 16
-		Length: 16
-	critical-idle:
-		Start: 32
 		Length: 16
 	icon: cyclicnh
 		Start: 0

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -644,9 +644,6 @@ brik:
 	damaged-idle:
 		Start: 32
 		Length: 16
-	critical-idle:
-		Start: 48
-		Length: 16
 	icon: brikicon
 		Start: 0
 
@@ -654,18 +651,12 @@ sbag:
 	idle:
 		Start: 0
 		Length: 16
-	damaged-idle:
-		Start: 16
-		Length: 16
 	icon: sbagicon
 		Start: 0
 
 fenc:
 	idle:
 		Start: 0
-		Length: 16
-	damaged-idle:
-		Start: 16
 		Length: 16
 	icon: fencicon
 		Start: 0
@@ -676,7 +667,4 @@ cycl:
 		Length: 16
 	damaged-idle:
 		Start: 16
-		Length: 16
-	critical-idle:
-		Start: 32
 		Length: 16


### PR DESCRIPTION
This removes the final set of 16 images for each of the wall types in both RA and TD.  One of the pieces in particular makes the wall completely invisible, which is annoying and the cause for #5654.  This fixes that by getting rid of those last set of images.

`Explanation of why they are false damage states for walls + lengthy post warning:`
I'm not 100% sure by any means, but the final set of 16 images appear to be end pieces for the wall segments so that they look more "full".  If you build a single wall, then build one right next to it, you will notice that the original wall segment almost looks like it gets cut in half on the side not connected to the new wall segment.  I believe this space is supposed to be filled with the end pieces so that it looks more "full" and complete.

See the comparison below which shows what it looks like without these end pieces and with them on the center area where the vertical and horizontal wall segments meet together.

without them..
![withoutendpieces](https://cloud.githubusercontent.com/assets/7218092/3488325/0ac4fc58-04dd-11e4-90bd-3226049fd0c2.png)

and with them..
![withendpieces](https://cloud.githubusercontent.com/assets/7218092/3488326/21a6ae80-04dd-11e4-8128-fe2fff536327.png)

without the end pieces looks odd, as if it's missing something, and its very noticable when trying to place a new wall segment there.  I took the "with" end pieces picture by using the bleed version's bug where the final damage state is not a proper damage state, here you can clearly see that it is probably an end piece and not a proper damage state for the wall.  The final fix to make use of these end pieces is probably not that difficult, but will likely only be compatible with TD and RA, and not TS, so I would hate to introduce an incompatibility into the wall code if we expect to be able to make use of it for TS as well.  But for now, this removes the bogus wall damage states!
