### PR TITLE
Fixed a NullReferenceException in auto map download.

### DIFF
--- a/OpenRA.Game/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Game/Widgets/MapPreviewWidget.cs
@@ -132,7 +132,8 @@ namespace OpenRA.Widgets
 		public int2 ConvertToPreview(CPos cell)
 		{
 			var preview = Preview();
-			var point = Map.CellToMap(preview.Map.TileShape, cell);
+			var tileShape = Game.modData.Manifest.TileShape;
+			var point = Map.CellToMap(tileShape, cell);
 			var dx = (int)(previewScale * (point.X - preview.Bounds.Left));
 			var dy = (int)(previewScale * (point.Y - preview.Bounds.Top));
 			return new int2(mapRect.X + dx, mapRect.Y + dy);


### PR DESCRIPTION
Spotted while testing https://github.com/OpenRA/OpenRA/pull/5839. Introduced by https://github.com/OpenRA/OpenRA/commit/a30c8b53a7ed8735ec55688ec0769774af76fb4a#diff-7. This fix may create wrong spawn point preview positions for not yet downloaded isometric maps.
