### PR TITLE
Fixed the sietch crashing the game when placed on a map

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -690,8 +690,6 @@ SIETCH:
 		Footprint: xx xx
 		Dimensions: 2,2
 		TerrainTypes: Cliff
-	Bib:
-		Sprite: bib2x
 	Health:
 		HP: 400
 	Armor:


### PR DESCRIPTION
Noticed during testing of https://github.com/OpenRA/OpenRA/pull/4496. It looks like bit rot as the `Sprite` field does not exist anymore on https://github.com/OpenRA/OpenRA/wiki/Traits#bib. Not sure why OpenRA.Lint did not pick this up. https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/GameRules/ActorInfo.cs#L81
