### PR TITLE
Categorized shellmaps

### DIFF
--- a/mods/cnc/maps/shellmap/map.yaml
+++ b/mods/cnc/maps/shellmap/map.yaml
@@ -18,7 +18,7 @@ Bounds: 8,1,80,45
 
 UseAsShellmap: True
 
-Type: Conquest
+Type: Shellmap
 
 Options:
 

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -18,7 +18,7 @@ Bounds: 16,16,80,80
 
 UseAsShellmap: True
 
-Type: Conquest
+Type: Shellmap
 
 Options:
 

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -18,7 +18,7 @@ Bounds: 1,1,126,126
 
 UseAsShellmap: True
 
-Type: Conquest
+Type: Shellmap
 
 Options:
 

--- a/mods/ts/maps/blank-shellmap/map.yaml
+++ b/mods/ts/maps/blank-shellmap/map.yaml
@@ -18,7 +18,7 @@ Bounds: 16,16,96,96
 
 UseAsShellmap: True
 
-Type: Conquest
+Type: Shellmap
 
 Options:
 


### PR DESCRIPTION
This is another uncontroversial commit from https://github.com/OpenRA/OpenRA/pull/4496 that was easy to split. I reuse the map load widget for my ingame editor which allows to browse by categories. This groups them in their own category which makes them easier to find or avoid.
