### PR TITLE
Speed up shroud checks

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -180,12 +180,14 @@ namespace OpenRA.Graphics
 			{
 				var colors = (int*)bitmapData.Scan0;
 				var stride = bitmapData.Stride / 4;
+				var shroudObscured = world.ShroudObscuresTest(map.Cells);
+				var fogObscured = world.FogObscuresTest(map.Cells);
 				foreach (var cell in map.Cells)
 				{
 					var uv = Map.CellToMap(map.TileShape, cell) - offset;
-					if (world.ShroudObscures(cell))
+					if (shroudObscured(cell))
 						colors[uv.Y * stride + uv.X] = shroud;
-					else if (world.FogObscures(cell))
+					else if (fogObscured(cell))
 						colors[uv.Y * stride + uv.X] = fog;
 				}
 			}

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -36,17 +36,16 @@ namespace OpenRA.Graphics
 
 			unsafe
 			{
-				var c = (int*)bitmapData.Scan0;
-
-				for (var x = 0; x < b.Width; x++)
+				var colors = (int*)bitmapData.Scan0;
+				var stride = bitmapData.Stride / 4;
+				for (var y = 0; y < b.Height; y++)
 				{
-					for (var y = 0; y < b.Height; y++)
+					for (var x = 0; x < b.Width; x++)
 					{
 						var mapX = x + b.Left;
 						var mapY = y + b.Top;
 						var type = tileset.GetTerrainInfo(mapTiles[mapX, mapY]);
-
-						*(c + (y * bitmapData.Stride >> 2) + x) = type.Color.ToArgb();
+						colors[y * stride + x] = type.Color.ToArgb();
 					}
 				}
 			}
@@ -67,11 +66,11 @@ namespace OpenRA.Graphics
 
 			unsafe
 			{
-				var c = (int*)bitmapData.Scan0;
-
-				for (var x = 0; x < b.Width; x++)
+				var colors = (int*)bitmapData.Scan0;
+				var stride = bitmapData.Stride / 4;
+				for (var y = 0; y < b.Height; y++)
 				{
-					for (var y = 0; y < b.Height; y++)
+					for (var x = 0; x < b.Width; x++)
 					{
 						var mapX = x + b.Left;
 						var mapY = y + b.Top;
@@ -85,7 +84,7 @@ namespace OpenRA.Graphics
 						if (res == null)
 							continue;
 
-						*(c + (y * bitmapData.Stride >> 2) + x) = tileset[tileset.GetTerrainIndex(res)].Color.ToArgb();
+						colors[y * stride + x] = tileset[tileset.GetTerrainIndex(res)].Color.ToArgb();
 					}
 				}
 			}
@@ -107,19 +106,18 @@ namespace OpenRA.Graphics
 
 			unsafe
 			{
-				var c = (int*)bitmapData.Scan0;
-
-				for (var x = 0; x < b.Width; x++)
+				var colors = (int*)bitmapData.Scan0;
+				var stride = bitmapData.Stride / 4;
+				for (var y = 0; y < b.Height; y++)
 				{
-					for (var y = 0; y < b.Height; y++)
+					for (var x = 0; x < b.Width; x++)
 					{
 						var mapX = x + b.Left;
 						var mapY = y + b.Top;
 						var custom = map.CustomTerrain[mapX, mapY];
 						if (custom == -1)
 							continue;
-
-						*(c + (y * bitmapData.Stride >> 2) + x) = world.TileSet[custom].Color.ToArgb();
+						colors[y * stride + x] = world.TileSet[custom].Color.ToArgb();
 					}
 				}
 			}
@@ -140,8 +138,8 @@ namespace OpenRA.Graphics
 
 			unsafe
 			{
-				var c = (int*)bitmapData.Scan0;
-
+				var colors = (int*)bitmapData.Scan0;
+				var stride = bitmapData.Stride / 4;
 				foreach (var t in world.ActorsWithTrait<IRadarSignature>())
 				{
 					if (world.FogObscures(t.Actor))
@@ -152,7 +150,7 @@ namespace OpenRA.Graphics
 					{
 						var uv = Map.CellToMap(map.TileShape, cell);
 						if (b.Contains(uv.X, uv.Y))
-							*(c + ((uv.Y - b.Top) * bitmapData.Stride >> 2) + uv.X - b.Left) = color.ToArgb();
+							colors[(uv.Y - b.Top) * stride + uv.X - b.Left] = color.ToArgb();
 					}
 				}
 			}
@@ -180,15 +178,15 @@ namespace OpenRA.Graphics
 
 			unsafe
 			{
-				var c = (int*)bitmapData.Scan0;
-
+				var colors = (int*)bitmapData.Scan0;
+				var stride = bitmapData.Stride / 4;
 				foreach (var cell in map.Cells)
 				{
 					var uv = Map.CellToMap(map.TileShape, cell) - offset;
 					if (world.ShroudObscures(cell))
-						*(c + (uv.Y * bitmapData.Stride >> 2) + uv.X) = shroud;
+						colors[uv.Y * stride + uv.X] = shroud;
 					else if (world.FogObscures(cell))
-						*(c + (uv.Y * bitmapData.Stride >> 2) + uv.X) = fog;
+						colors[uv.Y * stride + uv.X] = fog;
 				}
 			}
 

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
-using OpenRA.Graphics;
 
 namespace OpenRA
 {
@@ -21,7 +20,7 @@ namespace OpenRA
 	{
 		public readonly Size Size;
 		public readonly TileShape Shape;
-		T[] entries;
+		readonly T[] entries;
 
 		public CellLayer(Map map)
 			: this(map.TileShape, new Size(map.MapSize.X, map.MapSize.Y)) { }
@@ -37,35 +36,27 @@ namespace OpenRA
 		int Index(CPos cell)
 		{
 			var uv = Map.CellToMap(Shape, cell);
-			return uv.Y * Size.Width + uv.X;
+			return Index(uv.X, uv.Y);
+		}
+
+		// Resolve an array index from map coordinates
+		int Index(int u, int v)
+		{
+			return v * Size.Width + u;
 		}
 
 		/// <summary>Gets or sets the <see cref="OpenRA.CellLayer"/> using cell coordinates</summary>
 		public T this[CPos cell]
 		{
-			get
-			{
-				return entries[Index(cell)];
-			}
-
-			set
-			{
-				entries[Index(cell)] = value;
-			}
+			get { return entries[Index(cell)]; }
+			set { entries[Index(cell)] = value; }
 		}
 
 		/// <summary>Gets or sets the layer contents using raw map coordinates (not CPos!)</summary>
 		public T this[int u, int v]
 		{
-			get
-			{
-				return entries[v * Size.Width + u];
-			}
-
-			set
-			{
-				entries[v * Size.Width + u] = value;
-			}
+			get { return entries[Index(u, v)]; }
+			set { entries[Index(u, v)] = value; }
 		}
 
 		/// <summary>Clears the layer contents with a known value</summary>

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -8,11 +8,8 @@
  */
 #endregion
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Drawing;
-using OpenRA.Graphics;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Traits
 	public class FrozenActor
 	{
 		public readonly CPos[] Footprint;
+		public readonly CellRegion FootprintRegion;
 		public readonly WPos CenterPosition;
 		public readonly Rectangle Bounds;
 		readonly Actor actor;
@@ -38,10 +39,12 @@ namespace OpenRA.Traits
 
 		public bool Visible;
 
-		public FrozenActor(Actor self, IEnumerable<CPos> footprint)
+		public FrozenActor(Actor self, CPos[] footprint, CellRegion footprintRegion)
 		{
 			actor = self;
-			Footprint = footprint.ToArray();
+			Footprint = footprint;
+			FootprintRegion = footprintRegion;
+
 			CenterPosition = self.CenterPosition;
 			Bounds = self.Bounds.Value;
 		}
@@ -54,16 +57,7 @@ namespace OpenRA.Traits
 		int flashTicks;
 		public void Tick(World world, Shroud shroud)
 		{
-			Visible = true;
-			foreach (var pos in Footprint)
-			{
-				if (shroud.IsVisible(pos))
-				{
-					Visible = false;
-					break;
-				}
-			}
-
+			Visible = !Footprint.Any(shroud.IsVisibleTest(FootprintRegion));
 			if (flashTicks > 0)
 				flashTicks--;
 		}

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -27,7 +27,7 @@ namespace OpenRA.Traits
 		public readonly Rectangle Bounds;
 		readonly Actor actor;
 
-		public IRenderable[] Renderables { set; private get; }
+		public IRenderable[] Renderables { private get; set; }
 		public Player Owner;
 
 		public string TooltipName;
@@ -84,6 +84,7 @@ namespace OpenRA.Traits
 				return Renderables.Concat(Renderables.Where(r => !r.IsDecoration)
 					.Select(r => r.WithPalette(highlight)));
 			}
+
 			return Renderables;
 		}
 

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 
 namespace OpenRA.Traits
@@ -22,21 +21,21 @@ namespace OpenRA.Traits
 
 	public class Shroud
 	{
-		[Sync] public bool Disabled = false;
+		[Sync] public bool Disabled;
 
-		Actor self;
-		Map map;
+		readonly Actor self;
+		readonly Map map;
 
-		CellLayer<int> visibleCount;
-		CellLayer<int> generatedShroudCount;
-		CellLayer<bool> explored;
+		readonly CellLayer<int> visibleCount;
+		readonly CellLayer<int> generatedShroudCount;
+		readonly CellLayer<bool> explored;
 
 		readonly Lazy<IFogVisibilityModifier[]> fogVisibilities;
 
 		// Cache of visibility that was added, so no matter what crazy trait code does, it
 		// can't make us invalid.
-		Dictionary<Actor, CPos[]> visibility = new Dictionary<Actor, CPos[]>();
-		Dictionary<Actor, CPos[]> generation = new Dictionary<Actor, CPos[]>();
+		readonly Dictionary<Actor, CPos[]> visibility = new Dictionary<Actor, CPos[]>();
+		readonly Dictionary<Actor, CPos[]> generation = new Dictionary<Actor, CPos[]>();
 
 		public int Hash { get; private set; }
 
@@ -186,14 +185,17 @@ namespace OpenRA.Traits
 
 		public void Explore(World world, CPos center, WRange range)
 		{
-			foreach (var q in FindVisibleTiles(world, center, range))
-				explored[q] = true;
+			foreach (var c in FindVisibleTiles(world, center, range))
+				explored[c] = true;
 
 			Invalidate();
 		}
 
 		public void Explore(Shroud s)
 		{
+			if (map.Bounds != s.map.Bounds)
+				throw new ArgumentException("The map bounds of these shrouds do not match.", "s");
+
 			foreach (var cell in map.Cells)
 				if (s.explored[cell])
 					explored[cell] = true;

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -26,8 +26,8 @@ namespace OpenRA.Traits
 		readonly Actor self;
 		readonly Map map;
 
-		readonly CellLayer<int> visibleCount;
-		readonly CellLayer<int> generatedShroudCount;
+		readonly CellLayer<short> visibleCount;
+		readonly CellLayer<short> generatedShroudCount;
 		readonly CellLayer<bool> explored;
 
 		readonly Lazy<IFogVisibilityModifier[]> fogVisibilities;
@@ -39,13 +39,19 @@ namespace OpenRA.Traits
 
 		public int Hash { get; private set; }
 
+		static readonly Func<CPos, bool> TruthPredicate = cell => true;
+		readonly Func<CPos, bool> fastExploredTest;
+		readonly Func<CPos, bool> slowExploredTest;
+		readonly Func<CPos, bool> fastVisibleTest;
+		readonly Func<CPos, bool> slowVisibleTest;
+
 		public Shroud(Actor self)
 		{
 			this.self = self;
 			map = self.World.Map;
 
-			visibleCount = new CellLayer<int>(map);
-			generatedShroudCount = new CellLayer<int>(map);
+			visibleCount = new CellLayer<short>(map);
+			generatedShroudCount = new CellLayer<short>(map);
 			explored = new CellLayer<bool>(map);
 
 			self.World.ActorAdded += AddVisibility;
@@ -55,6 +61,11 @@ namespace OpenRA.Traits
 			self.World.ActorRemoved += RemoveShroudGeneration;
 
 			fogVisibilities = Exts.Lazy(() => self.TraitsImplementing<IFogVisibilityModifier>().ToArray());
+
+			fastExploredTest = IsExploredCore;
+			slowExploredTest = IsExplored;
+			fastVisibleTest = IsVisibleCore;
+			slowVisibleTest = IsVisible;
 		}
 
 		void Invalidate()
@@ -223,10 +234,32 @@ namespace OpenRA.Traits
 			if (!map.Contains(cell))
 				return false;
 
-			if (Disabled || !self.World.LobbyInfo.GlobalSettings.Shroud)
+			if (!ShroudEnabled)
 				return true;
 
-			return explored[cell] && (generatedShroudCount[cell] == 0 || visibleCount[cell] > 0);
+			return IsExploredCore(cell);
+		}
+
+		bool ShroudEnabled { get { return !Disabled && self.World.LobbyInfo.GlobalSettings.Shroud; } }
+
+		bool IsExploredCore(CPos cell)
+		{
+			var uv = Map.CellToMap(map.TileShape, cell);
+			return explored[uv.X, uv.Y] && (generatedShroudCount[uv.X, uv.Y] == 0 || visibleCount[uv.X, uv.Y] > 0);
+		}
+
+		public Func<CPos, bool> IsExploredTest(CellRegion region)
+		{
+			// If the region to test extends outside the map we must use the slow test that checks the map boundary every time.
+			if (!map.Cells.Contains(region))
+				return slowExploredTest;
+
+			// If shroud isn't enabled, then we can see everything.
+			if (!ShroudEnabled)
+				return TruthPredicate;
+
+			// If shroud is enabled, we can use the fast test that just does the core check.
+			return fastExploredTest;
 		}
 
 		public bool IsExplored(Actor a)
@@ -239,10 +272,31 @@ namespace OpenRA.Traits
 			if (!map.Contains(cell))
 				return false;
 
-			if (Disabled || !self.World.LobbyInfo.GlobalSettings.Fog)
+			if (!FogEnabled)
 				return true;
 
+			return IsVisibleCore(cell);
+		}
+
+		bool FogEnabled { get { return !Disabled && self.World.LobbyInfo.GlobalSettings.Fog; } }
+
+		bool IsVisibleCore(CPos cell)
+		{
 			return visibleCount[cell] > 0;
+		}
+
+		public Func<CPos, bool> IsVisibleTest(CellRegion region)
+		{
+			// If the region to test extends outside the map we must use the slow test that checks the map boundary every time.
+			if (!map.Cells.Contains(region))
+				return slowVisibleTest;
+
+			// If fog isn't enabled, then we can see everything.
+			if (!FogEnabled)
+				return TruthPredicate;
+
+			// If fog is enabled, we can use the fast test that just does the core check.
+			return fastVisibleTest;
 		}
 
 		// Actors are hidden under shroud, but not under fog by default

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -24,6 +24,7 @@ namespace OpenRA
 {
 	public class World
 	{
+		static readonly Func<CPos, bool> FalsePredicate = cell => false;
 		internal readonly TraitDictionary traitDict = new TraitDictionary();
 		readonly HashSet<Actor> actors = new HashSet<Actor>();
 		readonly List<IEffect> effects = new List<IEffect>();
@@ -53,6 +54,24 @@ namespace OpenRA
 		public bool FogObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(p); }
 		public bool ShroudObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(a); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
+		
+		public Func<CPos, bool> FogObscuresTest(CellRegion region)
+		{
+			var rp = RenderPlayer;
+			if (rp == null)
+				return FalsePredicate;
+			var predicate = rp.Shroud.IsVisibleTest(region);
+			return cell => !predicate(cell);
+		}
+
+		public Func<CPos, bool> ShroudObscuresTest(CellRegion region)
+		{
+			var rp = RenderPlayer;
+			if (rp == null)
+				return FalsePredicate;
+			var predicate = rp.Shroud.IsExploredTest(region);
+			return cell => !predicate(cell);
+		}
 
 		public bool IsReplay
 		{

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.FileFormats;

--- a/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -28,13 +28,16 @@ namespace OpenRA.Mods.RA
 	{
 		[Sync] public int VisibilityHash;
 
-		bool initialized, startsRevealed;
+		readonly bool startsRevealed;
 		readonly CPos[] footprint;
-		Lazy<IToolTip> tooltip;
-		Lazy<Health> health;
 
-		Dictionary<Player, bool> visible;
-		Dictionary<Player, FrozenActor> frozen;
+		readonly Lazy<IToolTip> tooltip;
+		readonly Lazy<Health> health;
+
+		readonly Dictionary<Player, bool> visible;
+		readonly Dictionary<Player, FrozenActor> frozen;
+
+		bool initialized;
 
 		public FrozenUnderFog(ActorInitializer init, FrozenUnderFogInfo info)
 		{

--- a/OpenRA.Mods.RA/World/ResourceLayer.cs
+++ b/OpenRA.Mods.RA/World/ResourceLayer.cs
@@ -34,9 +34,10 @@ namespace OpenRA.Mods.RA
 
 		public void Render(WorldRenderer wr)
 		{
+			var shroudObscured = world.ShroudObscuresTest(wr.Viewport.VisibleCells);
 			foreach (var cell in wr.Viewport.VisibleCells)
 			{
-				if (world.ShroudObscures(cell))
+				if (shroudObscured(cell))
 					continue;
 
 				var c = render[cell];


### PR DESCRIPTION
This improves shroud-related performance.

There are two key changes in this PR:
- Carried over from #5542, shroud is only updated within the visible screen region. When scrolling on large maps this prevents a lot of wasted work being performed to update the whole shroud to prep it for rendering since most of it will be thrown away when the shroud changes before it can be used anyway.
- The refactored `GetEdges` method accepts a delegate for the visibility function. This removes the duplicate code between `FoggedEdges` and `ShroudedEdges` but also allows an optimization by allowing the delegate to be specialized. About 50% of the work done in calls to `IsVisible` or `IsExplored` are the initial checks that the cell is within the map boundary and if the shroud or fog is even enabled. We can avoid repeating these checks by providing a delegate valid over certain cell regions. We can check the map bounds and shroud/fog visibility once upfront and then a faster delegate that just does the core work can be used. In the common scenario where all the cells are in bounds and shroud/fog is enabled the fast core work only delegate is about twice as fast. Since it gets called in loops this makes shroud-related checks about twice as fast. In practise, scrolling around a fair amount on a medium-sized map at the start of a game with a bunch of AI saw the `RenderShroud` method take up 28% of CPU time, with 11% being the `Update` method. This PR reduced that to 21% with 5% being the `Update` method.
