### PR TITLE
Removed unneccessary build-top sequences from Dune 2000

### DIFF
--- a/OpenRA.Game/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Game/Traits/Render/RenderSimple.cs
@@ -14,16 +14,18 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Traits
 {
-	public class RenderSimpleInfo : RenderSpritesInfo, Requires<IBodyOrientationInfo>
+	public class RenderSimpleInfo : RenderSpritesInfo, IRenderPlaceBuildingPreviewInfo, Requires<IBodyOrientationInfo>
 	{
 		public override object Create(ActorInitializer init) { return new RenderSimple(init.self); }
 
-		public virtual IEnumerable<IRenderable> RenderPreview(World world, ActorInfo ai, PaletteReference pr)
+		public virtual IEnumerable<IRenderable> RenderPreview(WorldRenderer wr, ActorInfo ai, Player owner)
 		{
-			var anim = new Animation(world, RenderSimple.GetImage(ai), () => 0);
+			var palette = Palette ?? (owner != null ? PlayerPalette + owner.InternalName : null);
+
+			var anim = new Animation(wr.world, RenderSimple.GetImage(ai), () => 0);
 			anim.PlayRepeating("idle");
 
-			return anim.Render(WPos.Zero, WVec.Zero, 0, pr, Scale);
+			return anim.Render(WPos.Zero, WVec.Zero, 0, wr.Palette(palette), Scale);
 		}
 	}
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -146,6 +146,7 @@ namespace OpenRA.Traits
 		}
 	}
 
+	public interface IRenderPlaceBuildingPreviewInfo { IEnumerable<IRenderable> RenderPreview(WorldRenderer wr, ActorInfo ai, Player owner); }
 	public interface IRenderModifier { IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r); }
 	public interface IDamageModifier { float GetDamageModifier(Actor attacker, WarheadInfo warhead); }
 	public interface ISpeedModifier { decimal GetSpeedModifier(); }

--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.Orders
 		readonly string Building;
 		readonly BuildingInfo BuildingInfo;
 
-		IEnumerable<IRenderable> preview;
+		IRenderable[] preview;
 		Sprite buildOk, buildBlocked;
 		bool initialized = false;
 
@@ -103,16 +103,9 @@ namespace OpenRA.Mods.RA.Orders
 			{
 				if (!initialized)
 				{
-					var rbi = rules.Actors[Building].Traits.GetOrDefault<RenderBuildingInfo>();
-					if (rbi == null)
-						preview = new IRenderable[0];
-					else
-					{
-						var palette = rbi.Palette ?? (Producer.Owner != null ?
-							rbi.PlayerPalette + Producer.Owner.InternalName : null);
-
-						preview = rbi.RenderPreview(world, rules.Actors[Building], wr.Palette(palette));
-					}
+					preview = rules.Actors[Building].Traits.WithInterface<IRenderPlaceBuildingPreviewInfo>()
+						.SelectMany(rpi => rpi.RenderPreview(wr, rules.Actors[Building], Producer.Owner))
+						.ToArray();
 
 					initialized = true;
 				}

--- a/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
@@ -21,18 +21,20 @@ namespace OpenRA.Mods.RA.Render
 		public override object Create(ActorInitializer init) { return new RenderBuildingWarFactory( init, this ); }
 
 		/* get around unverifiability */
-		IEnumerable<IRenderable> BaseBuildingPreview(World world, ActorInfo building, PaletteReference pr)
+		IEnumerable<IRenderable> BaseBuildingPreview(WorldRenderer wr, ActorInfo ai, Player owner)
 		{
-			return base.RenderPreview(world, building, pr);
+			return base.RenderPreview(wr, ai, owner);
 		}
 
-		public override IEnumerable<IRenderable> RenderPreview(World world, ActorInfo building, PaletteReference pr)
+		public override IEnumerable<IRenderable> RenderPreview(WorldRenderer wr, ActorInfo ai, Player owner)
 		{
-			var p = BaseBuildingPreview(world, building, pr);
-			var anim = new Animation(world, RenderSprites.GetImage(building), () => 0);
+			var p = BaseBuildingPreview(wr, ai, owner);
+
+			var palette = Palette ?? (owner != null ? PlayerPalette + owner.InternalName : null);
+			var anim = new Animation(wr.world, RenderSprites.GetImage(ai), () => 0);
 			anim.PlayRepeating("idle-top");
 
-			return p.Concat(anim.Render(WPos.Zero, WVec.Zero, 0, pr, Scale));
+			return p.Concat(anim.Render(WPos.Zero, WVec.Zero, 0, wr.Palette(palette), Scale));
 		}
 	}
 

--- a/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Render
 {
 	class RenderBuildingWarFactoryInfo : RenderBuildingInfo
 	{
-		public override object Create(ActorInitializer init) { return new RenderBuildingWarFactory( init, this ); }
+		public override object Create(ActorInitializer init) { return new RenderBuildingWarFactory(init, this); }
 
 		/* get around unverifiability */
 		IEnumerable<IRenderable> BaseBuildingPreview(WorldRenderer wr, ActorInfo ai, Player owner)

--- a/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.RA.Buildings;
@@ -16,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA.Render
 {
 	[Desc("Renders a decorative animation on units and buildings.")]
-	public class WithIdleOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithIdleOverlayInfo : ITraitInfo, IRenderPlaceBuildingPreviewInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "idle-overlay";
@@ -31,6 +32,16 @@ namespace OpenRA.Mods.RA.Render
 		public readonly bool IsPlayerPalette = false;
 
 		public readonly bool PauseOnLowPower = false;
+
+		public IEnumerable<IRenderable> RenderPreview(WorldRenderer wr, ActorInfo ai, Player owner)
+		{
+			var rs = ai.Traits.Get<RenderSpritesInfo>();
+			var palette = rs.Palette ?? (owner != null ? rs.PlayerPalette + owner.InternalName : null);
+			var anim = new Animation(wr.world, RenderSprites.GetImage(ai), () => 0);
+			anim.PlayRepeating(Sequence);
+
+			return anim.Render(WPos.Zero, wr.Palette(palette));
+		}
 
 		public object Create(ActorInitializer init) { return new WithIdleOverlay(init.self, this); }
 	}

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -25,8 +25,6 @@ REFA:
 	Inherits: ^REFINERY
 	Buildable:
 		Owner: atreides
-	RenderBuildingWarFactory:
-		Image: REFA
 
 BARRA:
 	Inherits: ^BARRACKS
@@ -75,15 +73,11 @@ LIGHTA:
 	Inherits: ^LIGHT
 	Buildable:
 		Owner: atreides
-	RenderBuildingWarFactory:
-		Image: LIGHTA
 
 HEAVYA:
 	Inherits: ^HEAVY
 	Buildable:
 		Owner: atreides
-	RenderBuildingWarFactory:
-		Image: HEAVYA
 
 RADARA:
 	Inherits: ^RADAR

--- a/mods/d2k/rules/harkonnen.yaml
+++ b/mods/d2k/rules/harkonnen.yaml
@@ -25,8 +25,6 @@ REFH:
 	Inherits: ^REFINERY
 	Buildable:
 		Owner: harkonnen
-	RenderBuildingWarFactory:
-		Image: REFH
 
 BARRH:
 	Inherits: ^BARRACKS
@@ -53,15 +51,11 @@ LIGHTH:
 	Inherits: ^LIGHT
 	Buildable:
 		Owner: harkonnen
-	RenderBuildingWarFactory:
-		Image: LIGHTH
 
 HEAVYH:
 	Inherits: ^HEAVY
 	Buildable:
 		Owner: harkonnen
-	RenderBuildingWarFactory:
-		Image: HEAVYH
 
 RADARH:
 	Inherits: ^RADAR

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -25,8 +25,6 @@ REFO:
 	Inherits: ^REFINERY
 	Buildable:
 		Owner: ordos
-	RenderBuildingWarFactory:
-		Image: REFO
 
 BARRO:
 	Inherits: ^BARRACKS
@@ -52,15 +50,11 @@ LIGHTO:
 	Inherits: ^LIGHT
 	Buildable:
 		Owner: ordos
-	RenderBuildingWarFactory:
-		Image: LIGHTO
 
 HEAVYO:
 	Inherits: ^HEAVY
 	Buildable:
 		Owner: ordos
-	RenderBuildingWarFactory:
-		Image: HEAVYO
 
 RADARO:
 	Inherits: ^RADAR

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -173,7 +173,6 @@ CONCRETEB:
 		Type: Wood
 	RevealsShroud:
 		Range: 6c0
-	-RenderBuilding:
 	OreRefinery:
 		DockOffset: 2,1
 		DockAngle: 160
@@ -193,6 +192,8 @@ CONCRETEB:
 		Prerequisite: Refinery
 	WithDockingOverlay@SMOKE:
 		Sequence: smoke
+	WithIdleOverlay@TOP:
+		Sequence: idle-top
 
 ^SILO:
 	Inherits: ^Building
@@ -251,7 +252,6 @@ CONCRETEB:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	-RenderBuilding:
 	RallyPoint:
 		RallyPoint: 2,2
 	Exit@1:
@@ -265,6 +265,8 @@ CONCRETEB:
 		Prerequisite: Light
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
+	WithIdleOverlay@TOP:
+		Sequence: idle-top
 
 ^HEAVY:
 	Inherits: ^Building
@@ -291,7 +293,6 @@ CONCRETEB:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	-RenderBuilding:
 	RallyPoint:
 		RallyPoint: 0,3
 	Exit@1:
@@ -305,6 +306,8 @@ CONCRETEB:
 		Prerequisite: Heavy
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
+	WithIdleOverlay@TOP:
+		Sequence: idle-top
 
 ^RADAR:
 	Inherits: ^Building
@@ -719,8 +722,6 @@ PALACEC:
 HEAVYC:
 	Inherits: ^HEAVY
 	-Buildable:
-	RenderBuildingWarFactory:
-		Image: HEAVYC
 
 CONYARD:
 	Tooltip:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -693,14 +693,6 @@ lighta:
 	damaged-idle: DATA
 		Start: 2673
 		Offset: -48,64
-	build-top: DATA
-		Start: 2674
-		Length: 1
-		Offset: -48,64
-	damaged-build-top: DATA
-		Start: 2675
-		Length: 1
-		Offset: -48,64
 	idle-top: DATA
 		Start: 2674
 		Offset: -48,64
@@ -741,14 +733,6 @@ heavya:
 		Tick: 100
 	damaged-idle: DATA
 		Start: 2518
-		Offset: -48,80
-	build-top: DATA
-		Start: 2519
-		Length: 1
-		Offset: -48,80
-	damaged-build-top: DATA
-		Start: 2520
-		Length: 1
 		Offset: -48,80
 	idle-top: DATA
 		Start: 2519
@@ -1104,14 +1088,6 @@ lighth:
 	damaged-idle: DATA
 		Start: 2833
 		Offset: -48,64
-	build-top: DATA
-		Start: 2834
-		Length: 1
-		Offset: -48,64
-	damaged-build-top: DATA
-		Start: 2835
-		Length: 1
-		Offset: -48,64
 	idle-top: DATA
 		Start: 2834
 		Offset: -48,64
@@ -1152,14 +1128,6 @@ heavyh:
 		Tick: 100
 	damaged-idle: DATA
 		Start: 2678
-		Offset: -48,80
-	build-top: DATA
-		Start: 2679
-		Length: 1
-		Offset: -48,80
-	damaged-build-top: DATA
-		Start: 2680
-		Length: 1
 		Offset: -48,80
 	idle-top: DATA
 		Start: 2679
@@ -1508,14 +1476,6 @@ lighto:
 	damaged-idle: DATA
 		Start: 2993
 		Offset: -48,64
-	build-top: DATA
-		Start: 2994
-		Length: 1
-		Offset: -48,64
-	damaged-build-top: DATA
-		Start: 2995
-		Length: 1
-		Offset: -48,64
 	idle-top: DATA
 		Start: 2994
 		Offset: -48,64
@@ -1556,14 +1516,6 @@ heavyo:
 		Tick: 100
 	damaged-idle: DATA
 		Start: 2838
-		Offset: -48,80
-	build-top: DATA
-		Start: 2839
-		Length: 1
-		Offset: -48,80
-	damaged-build-top: DATA
-		Start: 2840
-		Length: 1
 		Offset: -48,80
 	idle-top: DATA
 		Start: 2839
@@ -1676,14 +1628,6 @@ heavyc: # TODO: unused
 		Tick: 100
 	damaged-idle: DATA
 		Start: 3001
-		Offset: -48,64
-	build-top: DATA
-		Start: 3002
-		Length: 1
-		Offset: -48,64
-	damaged-build-top: DATA
-		Start: 3003
-		Length: 1
 		Offset: -48,64
 	idle-top: DATA
 		Start: 3002


### PR DESCRIPTION
The factories don't have doors and the refinery does not produce any units. In the future this all wants to be replaced by a https://github.com/OpenRA/OpenRA/wiki/Traits#withroof that is included into RenderPreview.
