### PR TITLE
Old Lua: use the correct method to set the pause state

### DIFF
--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -216,12 +216,12 @@ namespace OpenRA
 				return;
 
 			IssueOrder(Order.PauseGame(paused));
-			PredictedPaused = paused ? PauseState.Paused : PauseState.Active;;
+			PredictedPaused = paused ? PauseState.Paused : PauseState.Active;
 		}
 
-		public void SetLocalPauseState(PauseState paused)
+		public void SetLocalPauseState(bool paused)
 		{
-			Paused = PredictedPaused = paused;
+			Paused = PredictedPaused = paused ? PauseState.Paused : PauseState.Active;
 		}
 
 		public void Tick()


### PR DESCRIPTION
#5640 changed the methods that pause the game. This fixes the old Lua API to account for that change.
