### PR TITLE
Friendly fire modifier

### DIFF
--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -134,13 +134,13 @@ namespace OpenRA.Mods.RA
 
 		public abstract Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove);
 
-		public bool HasAnyValidWeapons(Target t) { return Armaments.Any(a => a.Weapon.IsValidAgainst(t, self.World)); }
+		public bool HasAnyValidWeapons(Target t) { return Armaments.Any(a => a.Weapon.IsValidAgainst(t, self.World, self)); }
 		public WRange GetMaximumRange()
 		{
 			return Armaments.Select(a => a.Weapon.Range).Append(WRange.Zero).Max();
 		}
 
-		public Armament ChooseArmamentForTarget(Target t) { return Armaments.FirstOrDefault(a => a.Weapon.IsValidAgainst(t, self.World)); }
+		public Armament ChooseArmamentForTarget(Target t) { return Armaments.FirstOrDefault(a => a.Weapon.IsValidAgainst(t, self.World, self)); }
 
 		public void AttackTarget(Target target, bool queued, bool allowMove)
 		{

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -127,8 +127,11 @@ namespace OpenRA.Mods.RA
 
 						foreach (var victim in hitActors)
 						{
-							var damage = (int)GetDamageToInflict(pos, victim, warhead, weapon, firepowerModifier, true);
-							victim.InflictDamage(firedBy, damage, warhead);
+							if (warhead.IsValidAgainst(victim, firedBy))
+							{
+								var damage = (int)GetDamageToInflict(pos, victim, warhead, weapon, firepowerModifier, true);
+								victim.InflictDamage(firedBy, damage, warhead);
+							}
 						}
 					}
 					break;
@@ -137,10 +140,13 @@ namespace OpenRA.Mods.RA
 					{
 						foreach (var t in world.Map.FindTilesInCircle(targetTile, warhead.Size[0]))
 						{
-							foreach (var unit in world.ActorMap.GetUnitsAt(t))
+							foreach (var victim in world.ActorMap.GetUnitsAt(t))
 							{
-								var damage = (int)GetDamageToInflict(pos, unit, warhead, weapon, firepowerModifier, false);
-								unit.InflictDamage(firedBy, damage, warhead);
+								if (warhead.IsValidAgainst(victim, firedBy))
+								{
+									var damage = (int)GetDamageToInflict(pos, victim, warhead, weapon, firepowerModifier, false);
+									victim.InflictDamage(firedBy, damage, warhead);
+								}
 							}
 						}
 					}
@@ -153,14 +159,17 @@ namespace OpenRA.Mods.RA
 
 						foreach (var victim in hitActors)
 						{
-							var damage = GetDamageToInflict(pos, victim, warhead, weapon, firepowerModifier, false);
-							if (damage != 0) // will be 0 if the target doesn't have HealthInfo
+							if (warhead.IsValidAgainst(victim, firedBy))
 							{
-								var healthInfo = victim.Info.Traits.Get<HealthInfo>();
-								damage = (float)(damage / 100 * healthInfo.HP);
-							}
+								var damage = GetDamageToInflict(pos, victim, warhead, weapon, firepowerModifier, false);
+								if (damage != 0) // will be 0 if the target doesn't have HealthInfo
+								{
+									var healthInfo = victim.Info.Traits.Get<HealthInfo>();
+									damage = (float)(damage / 100 * healthInfo.HP);
+								}
 
-							victim.InflictDamage(firedBy, (int)damage, warhead);
+								victim.InflictDamage(firedBy, (int)damage, warhead);
+							}
 						}
 					}
 					break;

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -60,7 +60,7 @@ GrenadierExplode:
 		ImpactSound: xplosml2.aud
 
 Atomic:
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Report: nukemisl.aud
 	Warhead@impact:
 		Damage: 1500	#1000
@@ -115,7 +115,7 @@ Atomic:
 		InfDeath: 5
 
 IonCannon:
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Warhead@impact:
 		Damage: 900
 		Spread: 853
@@ -132,7 +132,7 @@ IonCannon:
 
 Sniper:
 	Report: RAMGUN2.AUD
-	ValidTargets: Infantry
+	ValidTargets: Infantry, Enemy, Neutral, Ally
 	ROF: 40
 	Range: 6c0
 	Projectile: Bullet
@@ -164,7 +164,7 @@ HeliAGGun:
 	Burst: 2
 	BurstDelay: 0
 	Range: 4c0
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Report: gun5.aud
 	Projectile: Bullet
 		Speed: 1c682
@@ -184,7 +184,7 @@ HeliAAGun:
 	Burst: 2
 	BurstDelay: 0
 	Range: 4c0
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Report: gun5.aud
 	Projectile: Bullet
 		Speed: 1c682
@@ -239,7 +239,7 @@ Rockets:
 	ROF: 50
 	Range: 6c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -268,7 +268,7 @@ BikeRockets:
 	ROF: 50
 	Range: 6c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Burst: 2
 	BurstDelay: 10
 	Projectile: Missile
@@ -301,7 +301,7 @@ OrcaAGMissiles:
 	BurstDelay: 12
 	Range: 5c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -331,7 +331,7 @@ OrcaAAMissiles:
 	BurstDelay: 12
 	Range: 5c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -546,7 +546,7 @@ MammothMissiles:
 	ROF: 45
 	Range: 5c0
 	Report: ROCKET1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Burst: 2
 	BurstDelay: 15
 	Projectile: Missile
@@ -579,7 +579,7 @@ MammothMissiles:
 	Burst: 4
 	BurstDelay: 4
 	Report: ROCKET1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Arm: 5
 		High: yes
@@ -610,7 +610,7 @@ MammothMissiles:
 	Report: ROCKET1.AUD
 	Burst: 2
 	BurstDelay: 10
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -712,7 +712,7 @@ TowerMissle:
 	ROF: 15
 	Range: 7c0
 	Report: ROCKET2.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -737,7 +737,7 @@ TowerMissle:
 		Damage: 25
 
 Vulcan:
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	ROF: 2
 	Range: 6c0
 	Report: gun5.aud
@@ -755,7 +755,7 @@ Vulcan:
 		Explosion: piffs
 
 Napalm:
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	ROF: 4
 	Range: 2c0
 	Burst: 2
@@ -810,7 +810,7 @@ SAMMissile:
 	ROF: 15
 	Range: 8c0
 	Report: ROCKET2.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -894,7 +894,7 @@ APCGun:
 	ROF: 18
 	Range: 5c0
 	Report: gun20.aud
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead:
@@ -911,7 +911,7 @@ APCGun.AA:
 	ROF: 18
 	Range: 7c0
 	Report: gun20.aud
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
@@ -929,7 +929,7 @@ Patriot:
 	Burst: 2
 	BurstDelay: 15
 	Report: ROCKET2.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		High: yes
 		Image: patriot

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -23,7 +23,7 @@ Bazooka:
 	ROF: 50
 	Range: 5c0
 	Report: BAZOOK1.WAV
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 160
 		Arm: 2
@@ -71,7 +71,7 @@ Vulcan:
 	ROF: 30
 	Range: 5c768
 	Report: VULCAN.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c256
 		ContrailLength: 3
@@ -94,7 +94,7 @@ Slung:
 	Delay: 5
 	Range: 5c512
 	Report: BAZOOK2.WAV
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 320
 		High: true
@@ -167,7 +167,7 @@ QuadRockets:
 	BurstDelay: 25
 	Range: 7c0
 	Report: ROCKET1.WAV
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		Inaccuracy: 96
@@ -217,7 +217,7 @@ TowerMissile:
 	Range: 7c768
 	MinRange: 1c0
 	Report: ROCKET1.WAV
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Burst: 2
 	BurstDelay: 15
 	Projectile: Bullet
@@ -313,7 +313,7 @@ DevBullet:
 	Burst: 4
 	BurstDelay: 15
 	Report: MISSLE1.WAV
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 358
 		Arm: 5

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -23,7 +23,7 @@ ZSU-23:
 	ROF: 0
 	Range: 10c0
 	Report: AACANON3.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
@@ -122,7 +122,7 @@ Maverick:
 	Report: MISSILE7.AUD
 	Burst: 2
 	BurstDelay: 7
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -278,7 +278,7 @@ Dragon:
 	ROF: 50
 	Range: 5c0
 	Report: MISSILE6.AUD
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 213
 		Arm: 2
@@ -310,7 +310,7 @@ HellfireAG:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 10
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -341,7 +341,7 @@ HellfireAA:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 10
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 384
 		Arm: 2
@@ -461,7 +461,7 @@ Grenade:
 	Range: 4c768
 	Report: CANNON1.AUD
 	Burst: 2
-	InvalidTargets: Air, Infantry
+	InvalidTargets: Air, Infantry, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 682
 		Image: 120MM
@@ -507,7 +507,7 @@ MammothTusk:
 	Range: 8c0
 	Report: MISSILE6.AUD
 	Burst: 2
-	ValidTargets: Air, Infantry
+	ValidTargets: Air, Infantry, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 341
 		Arm: 2
@@ -677,7 +677,7 @@ Nike:
 	ROF: 15
 	Range: 7c512
 	Report: MISSILE1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 3
 		High: true
@@ -704,7 +704,7 @@ RedEye:
 	ROF: 50
 	Range: 7c512
 	Report: MISSILE1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 3
 		High: true
@@ -786,7 +786,7 @@ Stinger:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 0
-	ValidTargets: Air, Ground, Water
+	ValidTargets: Air, Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 3
 		High: true
@@ -815,7 +815,7 @@ TorpTube:
 	ROF: 100
 	Range: 9c0
 	Report: TORPEDO1.AUD
-	ValidTargets: Water, Underwater, Bridge
+	ValidTargets: Water, Underwater, Bridge, Enemy, Neutral, Ally
 	Palette: shadow
 	Burst: 2
 	BurstDelay: 20
@@ -867,7 +867,7 @@ TorpTube:
 DepthCharge:
 	ROF: 60
 	Range: 5c0
-	ValidTargets: Underwater
+	ValidTargets: Underwater, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 85
 		Image: BOMB
@@ -911,7 +911,7 @@ ParaBomb:
 		WaterImpactSound: splash9.aud
 
 DogJaw:
-	ValidTargets: Infantry
+	ValidTargets: Infantry, Enemy, Neutral, Ally
 	ROF: 10
 	Range: 3c0
 	Report: DOGG5P.AUD
@@ -945,7 +945,7 @@ Repair:
 	ROF: 80
 	Range: 4c0
 	Report: FIXIT1.AUD
-	ValidTargets: Repair
+	ValidTargets: Repair, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead:
@@ -1007,7 +1007,7 @@ SCUD:
 		WaterImpactSound: splash9.aud
 
 Atomic:
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water, Air, Enemy, Neutral, Ally
 	Warhead@impact:
 		Damage: 1500
 		Spread: 1c0
@@ -1063,7 +1063,7 @@ Atomic:
 		InfDeath: 5
 
 MiniNuke:
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water, Air, Enemy, Neutral, Ally
 	Warhead@impact:
 		Damage: 1500
 		Spread: 1c0
@@ -1235,7 +1235,7 @@ FLAK-23:
 	ROF: 10
 	Range: 8c0
 	Report: AACANON3.AUD
-	ValidTargets: Air, Ground, Water
+	ValidTargets: Air, Ground, Water, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
@@ -1272,7 +1272,7 @@ APTusk:
 	ROF: 60
 	Range: 6c0
 	Report: MISSILE6.AUD
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 298
 		Arm: 2
@@ -1331,7 +1331,7 @@ Mandible:
 		Damage: 60
 
 MADTankThump:
-	InvalidTargets: MADTank
+	InvalidTargets: MADTank, Enemy, Neutral, Ally
 	Warhead:
 		DamageModel: HealthPercentage
 		Damage: 1
@@ -1340,7 +1340,7 @@ MADTankThump:
 		Size: 7,6
 
 MADTankDetonate:
-	InvalidTargets: MADTank
+	InvalidTargets: MADTank, Enemy, Neutral, Ally
 	Warhead:
 		DamageModel: HealthPercentage
 		Damage: 19

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -70,7 +70,7 @@ Bazooka:
 	ROF: 60
 	Range: 6c0
 	Report: RKETINF1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 213
@@ -98,7 +98,7 @@ MultiCluster:
 	ROF: 80
 	Range: 6c0
 	Report: MISL1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 170
@@ -200,7 +200,7 @@ CyCannon:
 	ROF: 50
 	Range: 7c0
 	Report: SCRIN5B.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 192
 		High: yes
@@ -323,7 +323,7 @@ HoverMissile:
 	Burst: 2
 	Range: 8c0
 	Report: HOVRMIS1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 213
@@ -376,7 +376,7 @@ MammothTusk:
 	ROF: 80
 	Range: 6c0
 	Report: MISL1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Burst: 2
 	Palette: ra
 	Projectile: Missile
@@ -516,7 +516,7 @@ BikeMissile:
 	BurstDelay: 60
 	Range: 5c0
 	Report: MISL1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Arm: 2
@@ -604,7 +604,7 @@ Dragon:
 	Range: 6c0
 	Burst: 2
 	Report: MISL1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 213
@@ -682,7 +682,7 @@ Hellfire:
 	Range: 6c0
 	Report: ORCAMIS1.AUD
 	Burst: 2
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 256
@@ -733,7 +733,7 @@ Proton:
 	Range: 5c0
 	Report: SCRIN5B.AUD
 	Burst: 2
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -762,7 +762,7 @@ HarpyClaw:
 	Report: CYGUN1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Warhead:
 		Spread: 128
 		Versus:
@@ -810,7 +810,7 @@ TiberiumHeal:
 		PreventProne: yes
 
 IonCannon:
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Warhead@impact:
 		Damage: 1000
 		Spread: 1c0
@@ -871,7 +871,7 @@ SAMTower:
 	ROF: 55
 	Range: 15c0
 	Report: SAMSHOT1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 298


### PR DESCRIPTION
Implementation for #5618.

ValidTarget and InvalidTarget on weapon allows/prevents targeting. (<- Was an existing feature)
ValidTarget and InvalidTarget on warhead allows/prevents damage + spread damage. (New)
ValidTarget and InvalidTarget on both weapon and warheads now understand the following keywords related to stances/diplomacy: "Ally", "Neutral", "Enemy" (New)
