### PR TITLE
Restore blinking ready label in RA.

### DIFF
--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Widgets
 	class BuildPaletteWidget : Widget
 	{
 		public enum ReadyTextStyleOptions { Solid, AlternatingColor, Blinking }
-		public readonly ReadyTextStyleOptions ReadyTextStyle = ReadyTextStyleOptions.AlternatingColor;
+		public readonly ReadyTextStyleOptions ReadyTextStyle = ReadyTextStyleOptions.Blinking;
 		public readonly Color ReadyTextAltColor = Color.LimeGreen;
 		public int Columns = 3;
 		public int Rows = 5;

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -110,8 +110,6 @@ Container@PLAYER_WIDGETS:
 			Width: 250
 			Height: 500
 			ReadyText: READY
-			ReadyTextStyle: AlternatingColor
-			ReadyTextAltColor: 50,205,50
 			HoldText: ON HOLD
 			RequiresText: Requires {0}
 


### PR DESCRIPTION
This change has been controversial, and our "hardcore" ra players are a conservative bunch who don't like change.  This restores the old blinking behaviour in RA, but keeps the alternating colour in D2K.
