### PR TITLE
More TS fixes & tuning

### DIFF
--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -221,6 +221,55 @@
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
 
+^Tank:
+	AppearsOnRadar:
+	Mobile:
+		Crushes: wall, crate
+		TerrainSpeeds:
+			Clear: 90
+			Rough: 70
+			Road: 100
+			Beach: 80
+			Tiberium: 80
+			BlueTiberium: 80
+		ROT: 5
+	SelectionDecorations:
+		Palette: pips
+	Selectable:
+		Voice: Vehicle
+	TargetableUnit:
+		TargetTypes: Ground
+	Repairable:
+		RepairBuildings: gadept
+	Passenger:
+		CargoType: Vehicle
+	AttackMove:
+	HiddenUnderFog:
+	GainsExperience:
+		ChevronPalette: ra
+		CostThreshold: 5, 10
+		FirepowerModifier: 1.2, 1.5
+		ArmorModifier: 1.2, 1.5
+		SpeedModifier: 1.2, 1.5
+	GivesExperience:
+	DrawLineToTarget:
+	ActorLostNotification:
+	ProximityCaptor:
+		Types: Vehicle
+	GivesBounty:
+	UpdatesPlayerStatistics:
+	CombatDebugOverlay:
+	Guard:
+	Guardable:
+	BodyOrientation:
+		CameraPitch: 90
+	Huntable:
+	LuaScriptEvents:
+	ScriptTriggers:
+	Explodes:
+		Weapon: UnitExplodeSmall
+		EmptyWeapon: UnitExplodeSmall
+
 ^Helicopter:
 	AppearsOnRadar:
 		UseLocation: yes

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -571,14 +571,14 @@ GALITE:
 	Valued:
 		Cost: 200
 	Tooltip:
-		Name: Lamp
+		Name: Light Post
 	Building:
 		Power: 0
 		Footprint: x
 		Dimensions: 1,1
 	RenderBuilding:
-		HasMakeAnimation: no
 		Palette: terrain
+	-WithMakeAnimation:
 	Health:
 		HP: 600
 	Armor:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -138,7 +138,7 @@ PROC:
 	StoresResources:
 		PipColor: Green
 		PipCount: 15
-		Capacity: 1500
+		Capacity: 3000
 	CustomSellValue:
 		Value: 600
 	FreeActor:

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -88,6 +88,14 @@ HARV:
 		SearchFromOrderRadius: 12
 	Mobile:
 		Speed: 71
+		Crushes: wall, crate
+		TerrainSpeeds:
+			Clear: 90
+			Rough: 70
+			Road: 100
+			Beach: 70
+			Tiberium: 80
+			BlueTiberium: 80
 	Health:
 		HP: 1000
 	SelfHealing:
@@ -119,6 +127,13 @@ HVR:
 		Hothey: v
 	Mobile:
 		Speed: 99
+		TerrainSpeeds:
+			Clear: 100
+			Rough: 100
+			Road: 100
+			Beach: 100
+			Tiberium: 100
+			BlueTiberium: 100
 	Health:
 		HP: 230
 	Armor:
@@ -139,7 +154,7 @@ HVR:
 	WithVoxelTurret:
 
 4TNK:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 1700
 	Tooltip:
@@ -268,7 +283,7 @@ ICBM:
 		NoTransformSounds:
 
 REPAIR:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 70
@@ -296,7 +311,7 @@ REPAIR:
 	WithVoxelBody:
 
 ART2:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 975
 	Tooltip:
@@ -485,7 +500,7 @@ WINI:
 	WithVoxelBody:
 
 MMCH:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -521,7 +536,7 @@ MMCH:
 	AutoTarget:
 
 HMEC:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 3000
 	Tooltip:
@@ -554,7 +569,7 @@ HMEC:
 	WithVoxelWalkerBody:
 
 SMECH:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -647,7 +662,7 @@ BGGY:
 	WithMuzzleFlash:
 
 SAPC:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -676,7 +691,7 @@ SAPC:
 	WithVoxelBody:
 
 SUBTANK:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -705,7 +720,7 @@ SUBTANK:
 	WithVoxelBody:
 
 SONIC:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 1300
 	Tooltip:
@@ -737,7 +752,7 @@ SONIC:
 	WithVoxelTurret:
 
 TTNK:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -767,7 +782,7 @@ TTNK:
 		NoTransformSounds:
 
 STNK:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Valued:
 		Cost: 1100
 	Tooltip:

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -7,23 +7,23 @@ e1:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -84,23 +84,23 @@ e2:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -161,23 +161,23 @@ e3:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -238,7 +238,7 @@ weedguy:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 210
 	shoot: weed
 		Start: 56
@@ -259,7 +259,7 @@ weedguy:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 288
 	prone-stand: weed
 		Start: 86
@@ -308,23 +308,23 @@ medic:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 315
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 378
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -388,23 +388,23 @@ engineer:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -454,23 +454,23 @@ umagon:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -532,23 +532,23 @@ ghost: # TODO unused GUNFIRE.SHP
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -610,23 +610,23 @@ jumpjet: # TODO: ShadowStart:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 459
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 507
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 523
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 538
 	prone-stand:
 		Start: 0
@@ -686,23 +686,23 @@ mhijack:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -764,23 +764,23 @@ chamspy:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -842,23 +842,23 @@ cyc2:
 		Start: 8
 		Length: 9
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 316
 	idle1:
 		Start: 80
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 388
 	idle2:
 		Start: 95
 		Length: 15
-		Tick: 120
-		ShadowStart: 413
+		Tick: 80
+		ShadowStart: 403
 	prone-run:
 		Start: 110
 		Length: 9
 		Facings: 8
-		Tick: 100
+		Tick: 80
 		ShadowStart: 418
 	prone-stand:
 		Start: 110
@@ -924,12 +924,12 @@ cyborg:
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 426
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 441
 	prone-run:
 		Start: 86
@@ -1002,12 +1002,12 @@ mutant:
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
@@ -1080,12 +1080,12 @@ mwmn:
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
@@ -1158,12 +1158,12 @@ mutant3: # TODO unused MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
@@ -1236,12 +1236,12 @@ tratos:
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
@@ -1314,12 +1314,12 @@ oxanna:
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86
@@ -1392,12 +1392,12 @@ slav:
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 120
+		Tick: 80
 		ShadowStart: 363
 	prone-run:
 		Start: 86

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -876,10 +876,10 @@ proc: # TODO: unused narefn_a, narefn_b
 		Start: 0
 
 galite:
-	idle:
+	idle: gtlite
 		Start: 0
 		ShadowStart: 2
-	damaged-idle:
+	damaged-idle: gtlite
 		Start: 1
 		ShadowStart: 3
 #	lighting: alphatst


### PR DESCRIPTION
Fixes #5903 (light post crash), also fixes palette and name.
Reduces infantry sequence Tick values (animations were a little too slow).
Fixes ShadowStart of one Cyborg Commando idle sequence.
Adds ^Tank default and uses it for tracked vehicles.
Sets movement speed for Hover MLRS to 100% on all terrain.
Increases speed of harvesters on tiberium.
Doubles Refinery storage capacity to 3000 to make testing a bit more convenient.
