### PR TITLE
Let tech tree account for units that are not in the world

### DIFF
--- a/OpenRA.Mods.RA/Player/TechTree.cs
+++ b/OpenRA.Mods.RA/Player/TechTree.cs
@@ -83,11 +83,11 @@ namespace OpenRA.Mods.RA
 				}
 			}
 
-			// Add buildables that have a build limit set and are not already in the list
+			//Add units (Anything that does not have the ITechTreePrerequisite trait) that have a build limit and are not already in the list, including those not in the world.
 			player.World.ActorsWithTrait<Buildable>()
 				  .Where(a =>
+					  !a.Actor.HasTrait<ITechTreePrerequisite>() &&
 					  a.Actor.Owner == player &&
-					  a.Actor.IsInWorld &&
 					  !a.Actor.IsDead() &&
 					  !ret.ContainsKey(a.Actor.Info.Name) &&
 					  a.Actor.Info.Traits.Get<BuildableInfo>().BuildLimit > 0)


### PR DESCRIPTION
This fixes #5872 by accounting for units that are not in the world.  However, one thing that needed to be considered was that by removing the isInWorld check, we would then add a regression back to where buildings with a build limit would incorrectly update the tech tree when sold or destroyed (Refer to #5233 for why the isInWorld check was added)

So, now I've taken it a step further by also filtering out any actor that has the ITechTreePrerequisite trait, for two reasons.  1) All buildings have this trait so it avoids the regression, and 2) any actor that has the ITechTreePrerequisite trait is already properly updated on lines 71 through 84, so there is no reason to do the check again.

This however creates the assumption:

Anything with ITechTreePrerequisite can only provide a prerequisite if it is in the world.  So for example, if someone creates a mod where a tank provides a prerequisite to a different unit, and that tank is placed in a transport, it will no longer provide the prerequisite, which is a limitation of the current tech system, and a side effect of removing a unit in order to "place" it in a transport or structure (pillbox).

I'm fine with this being rejected in favor of doing something different, I just couldn't find another good solution.  One thing I would like to see in the future is a way to "remove" units from the gameplay layer (placing in transport or burrowing underground) without having to remove them from the world, but I don't know how that will effect the engine.
