### PR TITLE
Make tiles sorting deterministic in all cases

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -716,7 +716,28 @@ namespace OpenRA
 
 			// Sort each integer-distance group by the actual distance
 			foreach (var list in ts)
-				list.Sort((a, b) => a.LengthSquared.CompareTo(b.LengthSquared));
+			{
+				list.Sort((a, b) =>
+				{
+					var result = a.LengthSquared.CompareTo(b.LengthSquared);
+					if (result != 0)
+						return result;
+
+					// If the lengths are equal, use other means to sort them.
+					// Try the hashcode first because it gives more
+					// random-appearing results than X or Y that would always
+					// prefer the leftmost/topmost position.
+					result = a.GetHashCode().CompareTo(b.GetHashCode());
+					if (result != 0)
+						return result;
+
+					result = a.X.CompareTo(b.X);
+					if (result != 0)
+						return result;
+
+					return a.Y.CompareTo(b.Y);
+				});
+			}
 
 			return ts.Select(list => list.ToArray()).ToArray();
 		}


### PR DESCRIPTION
This may fix issue #5916.

In any case, it's wanted because this kind of sort is "unstable".
According to the docs:

```
"This implementation performs an unstable sort; that is, if two
elements are equal, their order might not be preserved."
```
