### PR TITLE
Dispose of graphics resources deterministically

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -215,7 +215,7 @@ namespace OpenRA
 				Settings.Graphics.Renderer = r;
 				try
 				{
-					Renderer.Initialize(Settings.Graphics.Mode);
+					Renderer = new Renderer(Settings.Graphics, Settings.Server);
 					break;
 				}
 				catch (Exception e)
@@ -224,8 +224,6 @@ namespace OpenRA
 					Console.WriteLine("Renderer initialization failed. Fallback in place. Check graphics.log for details.");
 				}
 			}
-
-			Renderer = new Renderer();
 
 			try
 			{
@@ -258,11 +256,17 @@ namespace OpenRA
 			BeforeGameStart = () => { };
 			Ui.ResetAll();
 
+			if (worldRenderer != null)
+				worldRenderer.Dispose();
 			worldRenderer = null;
 			if (server != null)
 				server.Shutdown();
 			if (orderManager != null)
 				orderManager.Dispose();
+
+			if (modData != null)
+				modData.Dispose();
+			modData = null;
 
 			// Fall back to default if the mod doesn't exist
 			if (!ModMetadata.AllMods.ContainsKey(mod))
@@ -275,7 +279,7 @@ namespace OpenRA
 			Sound.StopVideo();
 			Sound.Initialize();
 
-			modData = new ModData(mod);
+			modData = new ModData(mod, true);
 			Renderer.InitializeFonts(modData.Manifest);
 			modData.InitializeLoaders();
 			using (new PerfTimer("LoadMaps"))
@@ -631,8 +635,9 @@ namespace OpenRA
 				if (orderManager != null)
 					orderManager.Dispose();
 			}
-				
-			Renderer.Device.Dispose();
+
+			modData.Dispose();
+			Renderer.Dispose();
 
 			OnQuit();
 

--- a/OpenRA.Game/GameRules/RulesetCache.cs
+++ b/OpenRA.Game/GameRules/RulesetCache.cs
@@ -17,7 +17,7 @@ using OpenRA.Support;
 
 namespace OpenRA
 {
-	public class RulesetCache
+	public sealed class RulesetCache : IDisposable
 	{
 		readonly ModData modData;
 
@@ -136,6 +136,13 @@ namespace OpenRA
 			}
 
 			return items;
+		}
+
+		public void Dispose()
+		{
+			foreach (var cache in sequenceCaches.Values)
+				cache.Dispose();
+			sequenceCaches.Clear();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -17,8 +17,8 @@ namespace OpenRA.Graphics
 	{
 		struct Collection
 		{
-			public string src;
-			public Dictionary<string, MappedImage> regions;
+			public string Src;
+			public Dictionary<string, MappedImage> Regions;
 		}
 
 		static Dictionary<string, Collection> collections;
@@ -64,10 +64,10 @@ namespace OpenRA.Graphics
 		static MiniYaml SaveCollection(Collection collection)
 		{
 			var root = new List<MiniYamlNode>();
-			foreach (var kv in collection.regions)
-				root.Add(new MiniYamlNode(kv.Key, kv.Value.Save(collection.src)));
+			foreach (var kv in collection.Regions)
+				root.Add(new MiniYamlNode(kv.Key, kv.Value.Save(collection.Src)));
 
-			return new MiniYaml(collection.src, root);
+			return new MiniYaml(collection.Src, root);
 		}
 
 		static void LoadCollection(string name, MiniYaml yaml)
@@ -75,8 +75,8 @@ namespace OpenRA.Graphics
 			Game.modData.LoadScreen.Display();
 			var collection = new Collection()
 			{
-				src = yaml.Value,
-				regions = yaml.Nodes.ToDictionary(n => n.Key, n => new MappedImage(yaml.Value, n.Value))
+				Src = yaml.Value,
+				Regions = yaml.Nodes.ToDictionary(n => n.Key, n => new MappedImage(yaml.Value, n.Value))
 			};
 
 			collections.Add(name, collection);
@@ -98,7 +98,7 @@ namespace OpenRA.Graphics
 			}
 
 			MappedImage mi;
-			if (!collection.regions.TryGetValue(imageName, out mi))
+			if (!collection.Regions.TryGetValue(imageName, out mi))
 				return null;
 
 			// Cached sheet
@@ -117,6 +117,7 @@ namespace OpenRA.Graphics
 				cachedCollection = new Dictionary<string, Sprite>();
 				cachedSprites.Add(collectionName, cachedCollection);
 			}
+
 			var image = mi.GetImage(sheet);
 			cachedCollection.Add(imageName, image);
 

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -29,6 +29,10 @@ namespace OpenRA.Graphics
 
 		public static void Initialize(params string[] chromeFiles)
 		{
+			if (cachedSheets != null)
+				foreach (var sheet in cachedSheets.Values)
+					sheet.Dispose();
+
 			collections = new Dictionary<string, Collection>();
 			cachedSheets = new Dictionary<string, Sheet>();
 			cachedSprites = new Dictionary<string, Dictionary<string, Sprite>>();

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -16,11 +16,12 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
 {
-	public class CursorProvider
+	public sealed class CursorProvider : IDisposable
 	{
 		HardwarePalette palette;
 		Dictionary<string, CursorSequence> cursors;
 		Cache<string, PaletteReference> palettes;
+		readonly SheetBuilder sheetBuilder;
 
 		public CursorProvider(ModData modData)
 		{
@@ -43,10 +44,11 @@ namespace OpenRA.Graphics
 			foreach (var p in nodesDict["Palettes"].Nodes)
 				palette.AddPalette(p.Key, new ImmutablePalette(GlobalFileSystem.Open(p.Value.Value), shadowIndex), false);
 
-			var spriteLoader = new SpriteLoader(new string[0], new SheetBuilder(SheetType.Indexed));
+			sheetBuilder = new SheetBuilder(SheetType.Indexed);
+			var spriteLoader = new SpriteLoader(new string[0], sheetBuilder);
 			foreach (var s in nodesDict["Cursors"].Nodes)
 				LoadSequencesForCursor(spriteLoader, s.Key, s.Value);
-			spriteLoader.SheetBuilder.Current.ReleaseBuffer();
+			sheetBuilder.Current.ReleaseBuffer();
 
 			palette.Initialize();
 		}
@@ -87,6 +89,12 @@ namespace OpenRA.Graphics
 			{
 				throw new InvalidOperationException("Cursor does not have a sequence `{0}`".F(cursor));
 			}
+		}
+
+		public void Dispose()
+		{
+			palette.Dispose();
+			sheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -18,16 +18,15 @@ namespace OpenRA.Graphics
 {
 	public sealed class CursorProvider : IDisposable
 	{
-		HardwarePalette palette;
-		Dictionary<string, CursorSequence> cursors;
-		Cache<string, PaletteReference> palettes;
+		readonly HardwarePalette palette = new HardwarePalette();
+		readonly Dictionary<string, CursorSequence> cursors = new Dictionary<string, CursorSequence>();
+		readonly Cache<string, PaletteReference> palettes;
 		readonly SheetBuilder sheetBuilder;
 
 		public CursorProvider(ModData modData)
 		{
 			var sequenceFiles = modData.Manifest.Cursors;
 
-			cursors = new Dictionary<string, CursorSequence>();
 			palettes = new Cache<string, PaletteReference>(CreatePaletteReference);
 			var sequences = new MiniYaml(null, sequenceFiles.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal));
 			var shadowIndex = new int[] { };
@@ -40,7 +39,6 @@ namespace OpenRA.Graphics
 					out shadowIndex[shadowIndex.Length - 1]);
 			}
 
-			palette = new HardwarePalette();
 			foreach (var p in nodesDict["Palettes"].Nodes)
 				palette.AddPalette(p.Key, new ImmutablePalette(GlobalFileSystem.Open(p.Value.Value), shadowIndex), false);
 

--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {
-	public class HardwarePalette
+	public sealed class HardwarePalette : IDisposable
 	{
 		public const int MaxPalettes = 256;
 
@@ -112,6 +112,11 @@ namespace OpenRA.Graphics
 				for (var i = 0; i < Palette.Size; i++)
 					modifiedPalette[i] = originalPalette[i];
 			}
+		}
+
+		public void Dispose()
+		{
+			Texture.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -63,7 +63,7 @@ namespace OpenRA
 		void ReleaseWindowMouseFocus();
 	}
 
-	public interface IVertexBuffer<T>
+	public interface IVertexBuffer<T> : IDisposable
 	{
 		void Bind();
 		void SetData(T[] vertices, int length);
@@ -79,7 +79,7 @@ namespace OpenRA
 		void Render(Action a);
 	}
 
-	public interface ITexture
+	public interface ITexture : IDisposable
 	{
 		void SetData(Bitmap bitmap);
 		void SetData(uint[,] colors);
@@ -88,7 +88,7 @@ namespace OpenRA
 		Size Size { get; }
 	}
 
-	public interface IFrameBuffer
+	public interface IFrameBuffer : IDisposable
 	{
 		void Bind();
 		void Unbind();

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -20,13 +20,14 @@ namespace OpenRA.Graphics
 		Renderer renderer;
 		IShader shader;
 
-		Vertex[] vertices = new Vertex[Renderer.TempBufferSize];
+		readonly Vertex[] vertices;
 		int nv = 0;
 
 		public LineRenderer(Renderer renderer, IShader shader)
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
 
@@ -71,9 +72,9 @@ namespace OpenRA.Graphics
 
 		public void DrawLine(float2 start, float2 end, Color startColor, Color endColor)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
-			if (nv + 2 > Renderer.TempBufferSize)
+			if (nv + 2 > renderer.TempBufferSize)
 				Flush();
 
 			vertices[nv++] = new Vertex(start + offset,

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -15,13 +15,15 @@ namespace OpenRA.Graphics
 {
 	public class LineRenderer : Renderer.IBatchRenderer
 	{
-		static float2 offset = new float2(0.5f, 0.5f);
-		float lineWidth = 1f;
-		Renderer renderer;
-		IShader shader;
+		static readonly float2 Offset = new float2(0.5f, 0.5f);
+
+		readonly Renderer renderer;
+		readonly IShader shader;
 
 		readonly Vertex[] vertices;
 		int nv = 0;
+
+		float lineWidth = 1f;
 
 		public LineRenderer(Renderer renderer, IShader shader)
 		{
@@ -30,10 +32,12 @@ namespace OpenRA.Graphics
 			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
-
 		public float LineWidth
 		{
-			get { return lineWidth; }
+			get
+			{
+				return lineWidth;
+			}
 			set
 			{
 				if (LineWidth != value)
@@ -77,11 +81,11 @@ namespace OpenRA.Graphics
 			if (nv + 2 > renderer.TempBufferSize)
 				Flush();
 
-			vertices[nv++] = new Vertex(start + offset,
+			vertices[nv++] = new Vertex(start + Offset,
 				new float2(startColor.R / 255.0f, startColor.G / 255.0f),
 				new float2(startColor.B / 255.0f, startColor.A / 255.0f));
 
-			vertices[nv++] = new Vertex(end + offset,
+			vertices[nv++] = new Vertex(end + Offset,
 				new float2(endColor.R / 255.0f, endColor.G / 255.0f),
 				new float2(endColor.B / 255.0f, endColor.A / 255.0f));
 		}
@@ -100,7 +104,7 @@ namespace OpenRA.Graphics
 			var yc = (r.Bottom + r.Top) / 2;
 			for (var y = r.Top; y <= r.Bottom; y++)
 			{
-				var dx = a * (float)(Math.Sqrt(1 - (y - yc) * (y - yc) / b / b));
+				var dx = a * (float)Math.Sqrt(1 - (y - yc) * (y - yc) / b / b);
 				DrawLine(new float2(xc - dx, y), new float2(xc + dx, y), color, color);
 			}
 		}
@@ -108,7 +112,7 @@ namespace OpenRA.Graphics
 		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
 			shader.SetVec("Scroll", scroll.X, scroll.Y);
-			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
+			shader.SetVec("r1", zoom * 2f / screen.Width, -zoom * 2f / screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}
 	}

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -203,8 +203,8 @@ namespace OpenRA.Graphics
 
 		public static Bitmap RenderMapPreview(TileSet tileset, Map map, Ruleset resourceRules, bool actualSize)
 		{
-			var terrain = TerrainBitmap(tileset, map, actualSize);
-			return AddStaticResources(tileset, map, resourceRules, terrain);
+			using (var terrain = TerrainBitmap(tileset, map, actualSize))
+				return AddStaticResources(tileset, map, resourceRules, terrain);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/QuadRenderer.cs
+++ b/OpenRA.Game/Graphics/QuadRenderer.cs
@@ -17,13 +17,14 @@ namespace OpenRA.Graphics
 		Renderer renderer;
 		IShader shader;
 
-		Vertex[] vertices = new Vertex[Renderer.TempBufferSize];
+		readonly Vertex[] vertices;
 		int nv = 0;
 
 		public QuadRenderer(Renderer renderer, IShader shader)
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
 		public void Flush()
@@ -45,9 +46,9 @@ namespace OpenRA.Graphics
 
 		public void FillRect(RectangleF r, Color color)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
-			if (nv + 4 > Renderer.TempBufferSize)
+			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
 			vertices[nv] = new Vertex(new float2(r.Left, r.Top), new float2(color.R / 255.0f, color.G / 255.0f), new float2(color.B / 255.0f, color.A / 255.0f));

--- a/OpenRA.Game/Graphics/QuadRenderer.cs
+++ b/OpenRA.Game/Graphics/QuadRenderer.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -14,8 +14,8 @@ namespace OpenRA.Graphics
 {
 	public class QuadRenderer : Renderer.IBatchRenderer
 	{
-		Renderer renderer;
-		IShader shader;
+		readonly Renderer renderer;
+		readonly IShader shader;
 
 		readonly Vertex[] vertices;
 		int nv = 0;
@@ -62,7 +62,7 @@ namespace OpenRA.Graphics
 		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
 			shader.SetVec("Scroll", scroll.X, scroll.Y);
-			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
+			shader.SetVec("r1", zoom * 2f / screen.Width, -zoom * 2f / screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}
 	}

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -178,7 +178,8 @@ namespace OpenRA.Graphics
 			}
 			set
 			{
-				if (currentBatchRenderer == value) return;
+				if (currentBatchRenderer == value)
+					return;
 				if (currentBatchRenderer != null)
 					currentBatchRenderer.Flush();
 				currentBatchRenderer = value;

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -18,12 +18,8 @@ using OpenRA.Support;
 
 namespace OpenRA.Graphics
 {
-	public class Renderer
+	public sealed class Renderer : IDisposable
 	{
-		internal static int SheetSize;
-		internal static int TempBufferSize;
-		internal static int TempBufferCount;
-
 		public SpriteRenderer WorldSpriteRenderer { get; private set; }
 		public SpriteRenderer WorldRgbaSpriteRenderer { get; private set; }
 		public QuadRenderer WorldQuadRenderer { get; private set; }
@@ -32,46 +28,75 @@ namespace OpenRA.Graphics
 		public LineRenderer LineRenderer { get; private set; }
 		public SpriteRenderer RgbaSpriteRenderer { get; private set; }
 		public SpriteRenderer SpriteRenderer { get; private set; }
+		public IReadOnlyDictionary<string, SpriteFont> Fonts;
 
-		Queue<IVertexBuffer<Vertex>> tempBuffers = new Queue<IVertexBuffer<Vertex>>();
+		internal IGraphicsDevice Device { get; private set; }
+		internal int SheetSize { get; private set; }
+		internal int TempBufferSize { get; private set; }
+		internal int TempBufferCount { get; private set; }
 
-		public Dictionary<string, SpriteFont> Fonts;
-		Stack<Rectangle> scissorState;
-
-		public Renderer()
-		{
-			TempBufferSize = Game.Settings.Graphics.BatchSize;
-			TempBufferCount = Game.Settings.Graphics.NumTempBuffers;
-			SheetSize = Game.Settings.Graphics.SheetSize;
-			scissorState = new Stack<Rectangle>();
-
-			WorldSpriteRenderer = new SpriteRenderer(this, device.CreateShader("shp"));
-			WorldRgbaSpriteRenderer = new SpriteRenderer(this, device.CreateShader("rgba"));
-			WorldLineRenderer = new LineRenderer(this, device.CreateShader("line"));
-			WorldVoxelRenderer = new VoxelRenderer(this, device.CreateShader("vxl"));
-			LineRenderer = new LineRenderer(this, device.CreateShader("line"));
-			WorldQuadRenderer = new QuadRenderer(this, device.CreateShader("line"));
-			RgbaSpriteRenderer = new SpriteRenderer(this, device.CreateShader("rgba"));
-			SpriteRenderer = new SpriteRenderer(this, device.CreateShader("shp"));
-
-			for (var i = 0; i < TempBufferCount; i++)
-				tempBuffers.Enqueue(device.CreateVertexBuffer(TempBufferSize));
-		}
-
-		public void InitializeFonts(Manifest m)
-		{
-			Fonts = m.Fonts.ToDictionary(x => x.Key, x => new SpriteFont(x.Value.First, x.Value.Second));
-		}
-
-		internal IGraphicsDevice Device { get { return device; } }
+		readonly Queue<IVertexBuffer<Vertex>> tempBuffers = new Queue<IVertexBuffer<Vertex>>();
+		readonly Stack<Rectangle> scissorState = new Stack<Rectangle>();
 
 		Size? lastResolution;
 		int2? lastScroll;
 		float? lastZoom;
+		ITexture currentPaletteTexture;
+		IBatchRenderer currentBatchRenderer;
+
+		public Renderer(GraphicSettings graphicSettings, ServerSettings serverSettings)
+		{
+			var resolution = GetResolution(graphicSettings);
+
+			var rendererName = serverSettings.Dedicated ? "Null" : graphicSettings.Renderer;
+			var rendererPath = Path.GetFullPath("OpenRA.Renderer.{0}.dll".F(rendererName));
+
+			Device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, graphicSettings.Mode);
+
+			TempBufferSize = graphicSettings.BatchSize;
+			TempBufferCount = graphicSettings.NumTempBuffers;
+			SheetSize = graphicSettings.SheetSize;
+
+			WorldSpriteRenderer = new SpriteRenderer(this, Device.CreateShader("shp"));
+			WorldRgbaSpriteRenderer = new SpriteRenderer(this, Device.CreateShader("rgba"));
+			WorldLineRenderer = new LineRenderer(this, Device.CreateShader("line"));
+			WorldVoxelRenderer = new VoxelRenderer(this, Device.CreateShader("vxl"));
+			LineRenderer = new LineRenderer(this, Device.CreateShader("line"));
+			WorldQuadRenderer = new QuadRenderer(this, Device.CreateShader("line"));
+			RgbaSpriteRenderer = new SpriteRenderer(this, Device.CreateShader("rgba"));
+			SpriteRenderer = new SpriteRenderer(this, Device.CreateShader("shp"));
+
+			for (var i = 0; i < TempBufferCount; i++)
+				tempBuffers.Enqueue(Device.CreateVertexBuffer(TempBufferSize));
+		}
+
+		static Size GetResolution(GraphicSettings graphicsSettings)
+		{
+			var size = (graphicsSettings.Mode == WindowMode.Windowed)
+				? graphicsSettings.WindowedSize
+				: graphicsSettings.FullscreenSize;
+			return new Size(size.X, size.Y);
+		}
+
+		static IGraphicsDevice CreateDevice(Assembly rendererDll, int width, int height, WindowMode window)
+		{
+			foreach (RendererAttribute r in rendererDll.GetCustomAttributes(typeof(RendererAttribute), false))
+			{
+				var factory = (IDeviceFactory)r.Type.GetConstructor(Type.EmptyTypes).Invoke(null);
+				return factory.Create(new Size(width, height), window);
+			}
+
+			throw new InvalidOperationException("Renderer DLL is missing RendererAttribute to tell us what type to use!");
+		}
+
+		public void InitializeFonts(Manifest m)
+		{
+			Fonts = m.Fonts.ToDictionary(x => x.Key, x => new SpriteFont(x.Value.First, x.Value.Second)).AsReadOnly();
+		}
 
 		public void BeginFrame(int2 scroll, float zoom)
 		{
-			device.Clear();
+			Device.Clear();
 
 			var resolutionChanged = lastResolution != Resolution;
 			if (resolutionChanged)
@@ -95,7 +120,6 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		ITexture currentPaletteTexture;
 		public void SetPalette(HardwarePalette palette)
 		{
 			if (palette.Texture == currentPaletteTexture)
@@ -114,8 +138,8 @@ namespace OpenRA.Graphics
 		public void EndFrame(IInputHandler inputHandler)
 		{
 			Flush();
-			device.PumpInput(inputHandler);
-			device.Present();
+			Device.PumpInput(inputHandler);
+			Device.Present();
 		}
 
 		public void DrawBatch<T>(IVertexBuffer<T> vertices,
@@ -123,7 +147,7 @@ namespace OpenRA.Graphics
 			where T : struct
 		{
 			vertices.Bind();
-			device.DrawPrimitives(type, firstVertex, numVertices);
+			Device.DrawPrimitives(type, firstVertex, numVertices);
 			PerfHistory.Increment("batches", 1);
 		}
 
@@ -134,55 +158,24 @@ namespace OpenRA.Graphics
 
 		public void SetLineWidth(float width)
 		{
-			device.SetLineWidth(width);
+			Device.SetLineWidth(width);
 		}
 
-		static IGraphicsDevice device;
-
-		public Size Resolution { get { return device.WindowSize; } }
-
-		internal static void Initialize(WindowMode windowMode)
-		{
-			var resolution = GetResolution(windowMode);
-
-			var renderer = Game.Settings.Server.Dedicated ? "Null" : Game.Settings.Graphics.Renderer;
-			var rendererPath = Path.GetFullPath("OpenRA.Renderer.{0}.dll".F(renderer));
-
-			device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, windowMode);
-		}
-
-		static Size GetResolution(WindowMode windowmode)
-		{
-			var size = (windowmode == WindowMode.Windowed)
-				? Game.Settings.Graphics.WindowedSize
-				: Game.Settings.Graphics.FullscreenSize;
-			return new Size(size.X, size.Y);
-		}
-
-		static IGraphicsDevice CreateDevice(Assembly rendererDll, int width, int height, WindowMode window)
-		{
-			foreach (RendererAttribute r in rendererDll.GetCustomAttributes(typeof(RendererAttribute), false))
-			{
-				var factory = (IDeviceFactory)r.Type.GetConstructor(Type.EmptyTypes).Invoke(null);
-				return factory.Create(new Size(width, height), window);
-			}
-
-			throw new InvalidOperationException("Renderer DLL is missing RendererAttribute to tell us what type to use!");
-		}
+		public Size Resolution { get { return Device.WindowSize; } }
 
 		internal IVertexBuffer<Vertex> GetTempVertexBuffer()
 		{
-			var ret = tempBuffers.Dequeue();
-			tempBuffers.Enqueue(ret);
-			return ret;
+			return tempBuffers.Peek();
 		}
 
-		public interface IBatchRenderer	{ void Flush();	}
+		public interface IBatchRenderer { void Flush();	}
 
-		static IBatchRenderer currentBatchRenderer;
-		public static IBatchRenderer CurrentBatchRenderer
+		public IBatchRenderer CurrentBatchRenderer
 		{
-			get { return currentBatchRenderer; }
+			get
+			{
+				return currentBatchRenderer;
+			}
 			set
 			{
 				if (currentBatchRenderer == value) return;
@@ -232,12 +225,21 @@ namespace OpenRA.Graphics
 
 		public void GrabWindowMouseFocus()
 		{
-			device.GrabWindowMouseFocus();
+			Device.GrabWindowMouseFocus();
 		}
 
 		public void ReleaseWindowMouseFocus()
 		{
-			device.ReleaseWindowMouseFocus();
+			Device.ReleaseWindowMouseFocus();
+		}
+
+		public void Dispose()
+		{
+			Device.Dispose();
+			WorldVoxelRenderer.Dispose();
+			foreach (var buffer in tempBuffers)
+				buffer.Dispose();
+			tempBuffers.Clear();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	public class SequenceCache
+	public sealed class SequenceCache : IDisposable
 	{
 		readonly ModData modData;
 		readonly Lazy<SpriteLoader> spriteLoader;
@@ -138,6 +138,12 @@ namespace OpenRA.Graphics
 			}
 
 			return new ReadOnlyDictionary<string, Sequence>(unitSequences);
+		}
+
+		public void Dispose()
+		{
+			if (spriteLoader.IsValueCreated)
+				spriteLoader.Value.SheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -16,7 +16,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Graphics
 {
-	public class Sheet
+	public sealed class Sheet : IDisposable
 	{
 		readonly object textureLock = new object();
 		bool dirty;
@@ -155,6 +155,12 @@ namespace OpenRA.Graphics
 		{
 			lock (textureLock)
 				releaseBufferOnCommit = true;
+		}
+
+		public void Dispose()
+		{
+			if (texture != null)
+				texture.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -32,12 +32,13 @@ namespace OpenRA.Graphics
 	public sealed class SheetBuilder : IDisposable
 	{
 		readonly List<Sheet> sheets = new List<Sheet>();
+		readonly SheetType type;
+		readonly Func<Sheet> allocateSheet;
+
 		Sheet current;
 		TextureChannel channel;
-		SheetType type;
 		int rowHeight = 0;
 		Point p;
-		Func<Sheet> allocateSheet;
 
 		public static Sheet AllocateSheet(int sheetSize)
 		{

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2012 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -18,7 +18,10 @@ namespace OpenRA.Graphics
 {
 	public class SpriteFont
 	{
-		int size;
+		static Library library = new Library();
+		static SheetBuilder builder;
+
+		readonly int size;
 
 		public SpriteFont(string name, int size)
 		{
@@ -27,8 +30,7 @@ namespace OpenRA.Graphics
 			face = library.NewFace(name, 0);
 			face.SetPixelSizes((uint)size, (uint)size);
 
-			glyphs = new Cache<Pair<char, Color>, GlyphInfo>(CreateGlyph, 
-			         Pair<char,Color>.EqualityComparer);
+			glyphs = new Cache<Pair<char, Color>, GlyphInfo>(CreateGlyph, Pair<char, Color>.EqualityComparer);
 
 			// setup a SheetBuilder for our private use
 			// TODO: SheetBuilder state is leaked between mod switches
@@ -89,7 +91,7 @@ namespace OpenRA.Graphics
 			return new int2((int)Math.Ceiling(lines.Max(s => s.Sum(a => glyphs[Pair.New(a, Color.White)].Advance))), lines.Length * size);
 		}
 
-		Cache<Pair<char,Color>, GlyphInfo> glyphs;
+		Cache<Pair<char, Color>, GlyphInfo> glyphs;
 		Face face;
 
 		GlyphInfo CreateGlyph(Pair<char, Color> c)
@@ -131,13 +133,11 @@ namespace OpenRA.Graphics
 						p += bitmap.Pitch;
 					}
 				}
+
 			s.sheet.CommitData();
 
 			return g;
 		}
-
-		static Library library = new Library();  
-		static SheetBuilder builder;
 	}
 
 	class GlyphInfo

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -17,8 +17,8 @@ namespace OpenRA.Graphics
 		Renderer renderer;
 		IShader shader;
 
-		Vertex[] vertices = new Vertex[Renderer.TempBufferSize];
-		Sheet currentSheet = null;
+		readonly Vertex[] vertices;
+		Sheet currentSheet;
 		BlendMode currentBlend = BlendMode.Alpha;
 		int nv = 0;
 
@@ -26,6 +26,7 @@ namespace OpenRA.Graphics
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
 		public void Flush()
@@ -60,7 +61,7 @@ namespace OpenRA.Graphics
 
 		void DrawSprite(Sprite s, float2 location, int paletteIndex, float2 size)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
 			if (s.sheet != currentSheet)
 				Flush();
@@ -68,7 +69,7 @@ namespace OpenRA.Graphics
 			if (s.blendMode != currentBlend)
 				Flush();
 
-			if (nv + 4 > Renderer.TempBufferSize)
+			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
 			currentBlend = s.blendMode;
@@ -90,7 +91,7 @@ namespace OpenRA.Graphics
 
 		public void DrawSprite(Sprite s, float2 a, float2 b, float2 c, float2 d)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
 			if (s.sheet != currentSheet)
 				Flush();
@@ -98,7 +99,7 @@ namespace OpenRA.Graphics
 			if (s.blendMode != currentBlend)
 				Flush();
 
-			if (nv + 4 > Renderer.TempBufferSize)
+			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
 			currentSheet = s.sheet;

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -14,8 +14,8 @@ namespace OpenRA.Graphics
 {
 	public class SpriteRenderer : Renderer.IBatchRenderer
 	{
-		Renderer renderer;
-		IShader shader;
+		readonly Renderer renderer;
+		readonly IShader shader;
 
 		readonly Vertex[] vertices;
 		Sheet currentSheet;
@@ -124,7 +124,7 @@ namespace OpenRA.Graphics
 		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
 			shader.SetVec("Scroll", scroll.X, scroll.Y);
-			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
+			shader.SetVec("r1", zoom * 2f / screen.Width, -zoom * 2f / screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}
 	}

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -15,10 +15,9 @@ namespace OpenRA.Graphics
 {
 	sealed class TerrainRenderer : IDisposable
 	{
-		IVertexBuffer<Vertex> vertexBuffer;
-
-		World world;
-		Map map;
+		readonly IVertexBuffer<Vertex> vertexBuffer;
+		readonly World world;
+		readonly Map map;
 
 		public TerrainRenderer(World world, WorldRenderer wr)
 		{
@@ -43,7 +42,7 @@ namespace OpenRA.Graphics
 
 		public void Draw(WorldRenderer wr, Viewport viewport)
 		{
-			var verticesPerRow = 4*map.Bounds.Width;
+			var verticesPerRow = 4 * map.Bounds.Width;
 			var cells = viewport.VisibleCells;
 			var shape = wr.world.Map.TileShape;
 

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -8,11 +8,12 @@
  */
 #endregion
 
+using System;
 using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {
-	class TerrainRenderer
+	sealed class TerrainRenderer : IDisposable
 	{
 		IVertexBuffer<Vertex> vertexBuffer;
 
@@ -57,6 +58,11 @@ namespace OpenRA.Graphics
 
 			foreach (var r in world.WorldActor.TraitsImplementing<IRenderOverlay>())
 				r.Render(wr);
+		}
+
+		public void Dispose()
+		{
+			vertexBuffer.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -18,9 +18,9 @@ namespace OpenRA.Graphics
 {
 	public sealed class Theater : IDisposable
 	{
-		SheetBuilder sheetBuilder;
-		Dictionary<ushort, Sprite[]> templates;
-		Sprite missingTile;
+		readonly Dictionary<ushort, Sprite[]> templates = new Dictionary<ushort, Sprite[]>();
+		readonly SheetBuilder sheetBuilder;
+		readonly Sprite missingTile;
 
 		Sprite[] LoadTemplate(string filename, string[] exts, Dictionary<string, ISpriteSource> sourceCache, int[] frames)
 		{
@@ -62,7 +62,6 @@ namespace OpenRA.Graphics
 			};
 
 			var sourceCache = new Dictionary<string, ISpriteSource>();
-			templates = new Dictionary<ushort, Sprite[]>();
 			sheetBuilder = new SheetBuilder(SheetType.Indexed, allocate);
 			foreach (var t in tileset.Templates)
 				templates.Add(t.Value.Id, LoadTemplate(t.Value.Image, tileset.Extensions, sourceCache, t.Value.Frames));

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -16,7 +16,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Graphics
 {
-	public class Theater
+	public sealed class Theater : IDisposable
 	{
 		SheetBuilder sheetBuilder;
 		Dictionary<ushort, Sprite[]> templates;
@@ -86,5 +86,10 @@ namespace OpenRA.Graphics
 		}
 
 		public Sheet Sheet { get { return sheetBuilder.Current; } }
+
+		public void Dispose()
+		{
+			sheetBuilder.Dispose();
+		}
 	}
 }

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -34,13 +34,15 @@ namespace OpenRA.Graphics
 
 	public sealed class VoxelLoader : IDisposable
 	{
-		SheetBuilder sheetBuilder;
+		static readonly float[] ChannelSelect = { 0.75f, 0.25f, -0.25f, -0.75f };
 
-		Cache<Pair<string,string>, Voxel> voxels;
+		readonly List<Vertex[]> vertices = new List<Vertex[]>();
+		readonly Cache<Pair<string, string>, Voxel> voxels;
 		IVertexBuffer<Vertex> vertexBuffer;
-		List<Vertex[]> vertices;
 		int totalVertexCount;
 		int cachedVertexCount;
+
+		SheetBuilder sheetBuilder;
 
 		static SheetBuilder CreateSheetBuilder()
 		{
@@ -58,7 +60,7 @@ namespace OpenRA.Graphics
 
 		public VoxelLoader()
 		{
-			voxels = new Cache<Pair<string,string>, Voxel>(LoadFile);
+			voxels = new Cache<Pair<string, string>, Voxel>(LoadFile);
 			vertices = new List<Vertex[]>();
 			totalVertexCount = 0;
 			cachedVertexCount = 0;
@@ -66,28 +68,27 @@ namespace OpenRA.Graphics
 			sheetBuilder = CreateSheetBuilder();
 		}
 
-		static float[] channelSelect = { 0.75f, 0.25f, -0.25f, -0.75f };
-		Vertex[] GenerateSlicePlane(int su, int sv, Func<int,int,VxlElement> first, Func<int,int,VxlElement> second, Func<int, int, float[]> coord)
+		Vertex[] GenerateSlicePlane(int su, int sv, Func<int, int, VxlElement> first, Func<int, int, VxlElement> second, Func<int, int, float[]> coord)
 		{
-			var colors = new byte[su*sv];
-			var normals = new byte[su*sv];
+			var colors = new byte[su * sv];
+			var normals = new byte[su * sv];
 
 			var c = 0;
 			for (var v = 0; v < sv; v++)
 				for (var u = 0; u < su; u++)
-			{
-				var voxel = first(u,v) ?? second(u,v);
-				colors[c] = voxel == null ? (byte)0 : voxel.Color;
-				normals[c] = voxel == null ? (byte)0 : voxel.Normal;
-				c++;
-			}
+				{
+					var voxel = first(u, v) ?? second(u, v);
+					colors[c] = voxel == null ? (byte)0 : voxel.Color;
+					normals[c] = voxel == null ? (byte)0 : voxel.Normal;
+					c++;
+				}
 
 			var s = sheetBuilder.Allocate(new Size(su, sv));
 			Util.FastCopyIntoChannel(s, 0, colors);
 			Util.FastCopyIntoChannel(s, 1, normals);
 			s.sheet.CommitData();
 
-			var channels = new float2(channelSelect[(int)s.channel], channelSelect[(int)s.channel + 1]);
+			var channels = new float2(ChannelSelect[(int)s.channel], ChannelSelect[(int)s.channel + 1]);
 			return new Vertex[4]
 			{
 				new Vertex(coord(0, 0), s.FastMapTextureCoords(0), channels),
@@ -99,7 +100,7 @@ namespace OpenRA.Graphics
 
 		IEnumerable<Vertex[]> GenerateSlicePlanes(VxlLimb l)
 		{
-			Func<int,int,int,VxlElement> get = (x,y,z) =>
+			Func<int, int, int, VxlElement> get = (x, y, z) =>
 			{
 				if (x < 0 || y < 0 || z < 0)
 					return null;
@@ -107,41 +108,41 @@ namespace OpenRA.Graphics
 				if (x >= l.Size[0] || y >= l.Size[1] || z >= l.Size[2])
 					return null;
 
-				var v = l.VoxelMap[(byte)x,(byte)y];
+				var v = l.VoxelMap[(byte)x, (byte)y];
 				if (v == null || !v.ContainsKey((byte)z))
 					return null;
 
-				return l.VoxelMap[(byte)x,(byte)y][(byte)z];
+				return l.VoxelMap[(byte)x, (byte)y][(byte)z];
 			};
 
 			// Cull slices without any visible faces
-			var xPlanes = new bool[l.Size[0]+1];
-			var yPlanes = new bool[l.Size[1]+1];
-			var zPlanes = new bool[l.Size[2]+1];
+			var xPlanes = new bool[l.Size[0] + 1];
+			var yPlanes = new bool[l.Size[1] + 1];
+			var zPlanes = new bool[l.Size[2] + 1];
 			for (var x = 0; x < l.Size[0]; x++)
 			{
 				for (var y = 0; y < l.Size[1]; y++)
 				{
 					for (var z = 0; z < l.Size[2]; z++)
 					{
-						if (get(x,y,z) == null)
+						if (get(x, y, z) == null)
 							continue;
 
 						// Only generate a plane if it is actually visible
-						if (!xPlanes[x] && get(x-1,y,z) == null)
+						if (!xPlanes[x] && get(x - 1, y, z) == null)
 							xPlanes[x] = true;
-						if (!xPlanes[x+1] && get(x+1,y,z) == null)
-							xPlanes[x+1] = true;
+						if (!xPlanes[x + 1] && get(x + 1, y, z) == null)
+							xPlanes[x + 1] = true;
 
-						if (!yPlanes[y] && get(x,y-1,z) == null)
+						if (!yPlanes[y] && get(x, y - 1, z) == null)
 							yPlanes[y] = true;
-						if (!yPlanes[y+1] && get(x,y+1,z) == null)
-							yPlanes[y+1] = true;
+						if (!yPlanes[y + 1] && get(x, y + 1, z) == null)
+							yPlanes[y + 1] = true;
 
-						if (!zPlanes[z] && get(x,y,z-1) == null)
+						if (!zPlanes[z] && get(x, y, z - 1) == null)
 							zPlanes[z] = true;
-						if (!zPlanes[z+1] && get(x,y,z+1) == null)
-							zPlanes[z+1] = true;
+						if (!zPlanes[z + 1] && get(x, y, z + 1) == null)
+							zPlanes[z + 1] = true;
 					}
 				}
 			}
@@ -149,23 +150,23 @@ namespace OpenRA.Graphics
 			for (var x = 0; x <= l.Size[0]; x++)
 				if (xPlanes[x])
 					yield return GenerateSlicePlane(l.Size[1], l.Size[2],
-						(u,v) => get(x, u, v),
-						(u,v) => get(x - 1, u, v),
-						(u,v) => new float[] {x, u, v});
+						(u, v) => get(x, u, v),
+						(u, v) => get(x - 1, u, v),
+						(u, v) => new float[] { x, u, v });
 
 			for (var y = 0; y <= l.Size[1]; y++)
 				if (yPlanes[y])
 					yield return GenerateSlicePlane(l.Size[0], l.Size[2],
-						(u,v) => get(u, y, v),
-						(u,v) => get(u, y - 1, v),
-						(u,v) => new float[] {u, y, v});
+						(u, v) => get(u, y, v),
+						(u, v) => get(u, y - 1, v),
+						(u, v) => new float[] { u, y, v });
 
 			for (var z = 0; z <= l.Size[2]; z++)
 				if (zPlanes[z])
 					yield return GenerateSlicePlane(l.Size[0], l.Size[1],
-						(u,v) => get(u, v, z),
-						(u,v) => get(u, v, z - 1),
-						(u,v) => new float[] {u, v, z});
+						(u, v) => get(u, v, z),
+						(u, v) => get(u, v, z - 1),
+						(u, v) => new float[] { u, v, z });
 		}
 
 		public VoxelRenderData GenerateRenderData(VxlLimb l)
@@ -211,7 +212,7 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		Voxel LoadFile(Pair<string,string> files)
+		Voxel LoadFile(Pair<string, string> files)
 		{
 			VxlReader vxl;
 			HvaReader hva;

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	public class VoxelLoader
+	public sealed class VoxelLoader : IDisposable
 	{
 		SheetBuilder sheetBuilder;
 
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 				if (allocated)
 					throw new SheetOverflowException("");
 				allocated = true;
-				return SheetBuilder.AllocateSheet();
+				return SheetBuilder.AllocateSheet(Game.Renderer.SheetSize);
 			};
 
 			return new SheetBuilder(SheetType.DualIndexed, allocate);
@@ -194,6 +194,8 @@ namespace OpenRA.Graphics
 
 		public void RefreshBuffer()
 		{
+			if (vertexBuffer != null)
+				vertexBuffer.Dispose();
 			vertexBuffer = Game.Renderer.Device.CreateVertexBuffer(totalVertexCount);
 			vertexBuffer.SetData(vertices.SelectMany(v => v).ToArray(), totalVertexCount);
 			cachedVertexCount = totalVertexCount;
@@ -228,6 +230,13 @@ namespace OpenRA.Graphics
 		public void Finish()
 		{
 			sheetBuilder.Current.ReleaseBuffer();
+		}
+
+		public void Dispose()
+		{
+			if (vertexBuffer != null)
+				vertexBuffer.Dispose();
+			sheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	public class WorldRenderer
+	public sealed class WorldRenderer : IDisposable
 	{
 		public readonly World world;
 		public readonly Theater Theater;
@@ -250,6 +250,13 @@ namespace OpenRA.Graphics
 		{
 			var ts = Game.modData.Manifest.TileSize;
 			return new WPos(1024 * screenPx.X / ts.Width, 1024 * screenPx.Y / ts.Height, 0);
+		}
+
+		public void Dispose()
+		{
+			palette.Dispose();
+			Theater.Dispose();
+			terrainRenderer.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -35,18 +35,16 @@ namespace OpenRA.Graphics
 		public readonly Theater Theater;
 		public Viewport Viewport { get; private set; }
 
+		readonly HardwarePalette palette = new HardwarePalette();
+		readonly Dictionary<string, PaletteReference> palettes = new Dictionary<string, PaletteReference>();
 		readonly TerrainRenderer terrainRenderer;
-		readonly HardwarePalette palette;
-		readonly Dictionary<string, PaletteReference> palettes;
 		readonly Lazy<DeveloperMode> devTrait;
 
 		internal WorldRenderer(World world)
 		{
 			this.world = world;
 			Viewport = new Viewport(this, world.Map);
-			palette = new HardwarePalette();
 
-			palettes = new Dictionary<string, PaletteReference>();
 			foreach (var pal in world.traitDict.ActorsWithTrait<ILoadsPalettes>())
 				pal.Trait.LoadPalettes(this);
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -256,7 +256,8 @@ namespace OpenRA
 			Uid = ComputeHash();
 
 			if (Container.Exists("map.png"))
-				CustomPreview = new Bitmap(Container.GetContent("map.png"));
+				using (var s = Container.GetContent("map.png"))
+					CustomPreview = new Bitmap(s);
 
 			PostInit();
 		}

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -24,9 +24,9 @@ namespace OpenRA
 		public readonly ObjectCreator ObjectCreator;
 		public readonly WidgetLoader WidgetLoader;
 		public readonly MapCache MapCache;
-		public ILoadScreen LoadScreen = null;
-		public VoxelLoader VoxelLoader;
 		public readonly RulesetCache RulesetCache;
+		public ILoadScreen LoadScreen { get; private set; }
+		public VoxelLoader VoxelLoader { get; private set; }
 		public CursorProvider CursorProvider { get; private set; }
 
 		Lazy<Ruleset> defaultRules;

--- a/OpenRA.Lint/YamlChecker.cs
+++ b/OpenRA.Lint/YamlChecker.cs
@@ -54,6 +54,9 @@ namespace OpenRA.Lint
 				FieldLoader.UnknownFieldAction = (s, f) => EmitError("FieldLoader: Missing field `{0}` on `{1}`".F(s, f.Name));
 
 				AppDomain.CurrentDomain.AssemblyResolve += GlobalFileSystem.ResolveAssembly;
+				Game.Renderer = new Graphics.Renderer(
+					new GraphicSettings() { Renderer = "Null", NumTempBuffers = 0, SheetSize = 0 },
+					new ServerSettings());
 				Game.modData = new ModData(mod);
 
 				IEnumerable<Map> maps;

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -11,8 +11,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
-using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 
@@ -29,7 +27,7 @@ namespace OpenRA.Mods.Cnc
 		Sprite nodLogo, gdiLogo, evaLogo, brightBlock, dimBlock;
 		Rectangle bounds;
 		Renderer r;
-		NullInputHandler nih = new NullInputHandler();
+		readonly NullInputHandler nih = new NullInputHandler();
 
 		public void Init(Manifest m, Dictionary<string, string> info)
 		{

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -18,10 +18,11 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Cnc
 {
-	public class CncLoadScreen : ILoadScreen
+	public sealed class CncLoadScreen : ILoadScreen
 	{
 		Dictionary<string, string> loadInfo;
 		Stopwatch loadTimer = Stopwatch.StartNew();
+		Sheet sheet;
 		Sprite[] ss;
 		int loadTick;
 		float2 nodPos, gdiPos, evaPos;
@@ -39,31 +40,31 @@ namespace OpenRA.Mods.Cnc
 			r = Game.Renderer;
 			if (r == null) return;
 
-			var s = new Sheet(loadInfo["Image"]);
+			sheet = new Sheet(loadInfo["Image"]);
 			var res = r.Resolution;
 			bounds = new Rectangle(0, 0, res.Width, res.Height);
 
 			ss = new[]
 			{
-				new Sprite(s, new Rectangle(161, 128, 62, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(161, 223, 62, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(128, 161, 33, 62), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(223, 161, 33, 62), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(128, 128, 33, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(223, 128, 33, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(128, 223, 33, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(223, 223, 33, 33), TextureChannel.Alpha)
+				new Sprite(sheet, new Rectangle(161, 128, 62, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(161, 223, 62, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(128, 161, 33, 62), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(223, 161, 33, 62), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(128, 128, 33, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(223, 128, 33, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(128, 223, 33, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(223, 223, 33, 33), TextureChannel.Alpha)
 			};
 
-			nodLogo = new Sprite(s, new Rectangle(0, 256, 256, 256), TextureChannel.Alpha);
-			gdiLogo = new Sprite(s, new Rectangle(256, 256, 256, 256), TextureChannel.Alpha);
-			evaLogo = new Sprite(s, new Rectangle(256, 64, 128, 64), TextureChannel.Alpha);
+			nodLogo = new Sprite(sheet, new Rectangle(0, 256, 256, 256), TextureChannel.Alpha);
+			gdiLogo = new Sprite(sheet, new Rectangle(256, 256, 256, 256), TextureChannel.Alpha);
+			evaLogo = new Sprite(sheet, new Rectangle(256, 64, 128, 64), TextureChannel.Alpha);
 			nodPos = new float2(bounds.Width / 2 - 384, bounds.Height / 2 - 128);
 			gdiPos = new float2(bounds.Width / 2 + 128, bounds.Height / 2 - 128);
 			evaPos = new float2(bounds.Width - 43 - 128, 43);
 
-			brightBlock = new Sprite(s, new Rectangle(320, 0, 16, 35), TextureChannel.Alpha);
-			dimBlock = new Sprite(s, new Rectangle(336, 0, 16, 35), TextureChannel.Alpha);
+			brightBlock = new Sprite(sheet, new Rectangle(320, 0, 16, 35), TextureChannel.Alpha);
+			dimBlock = new Sprite(sheet, new Rectangle(336, 0, 16, 35), TextureChannel.Alpha);
 
 			versionText = m.Mod.Version;
 		}
@@ -122,6 +123,12 @@ namespace OpenRA.Mods.Cnc
 		public void StartGame()
 		{
 			Game.TestAndContinue();
+		}
+
+		public void Dispose()
+		{
+			if (sheet != null)
+				sheet.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.RA/DefaultLoadScreen.cs
+++ b/OpenRA.Mods.RA/DefaultLoadScreen.cs
@@ -11,8 +11,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
-using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.RA/DefaultLoadScreen.cs
+++ b/OpenRA.Mods.RA/DefaultLoadScreen.cs
@@ -18,13 +18,14 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.RA
 {
-	public class DefaultLoadScreen : ILoadScreen
+	public sealed class DefaultLoadScreen : ILoadScreen
 	{
 		Stopwatch lastUpdate = Stopwatch.StartNew();
 		Renderer r;
 
 		Rectangle stripeRect;
 		float2 logoPos;
+		Sheet sheet;
 		Sprite stripe, logo;
 		string[] messages;
 
@@ -37,9 +38,9 @@ namespace OpenRA.Mods.RA
 				return;
 
 			messages = info["Text"].Split(',');
-			var s = new Sheet(info["Image"]);
-			logo = new Sprite(s, new Rectangle(0, 0, 256, 256), TextureChannel.Alpha);
-			stripe = new Sprite(s, new Rectangle(256, 0, 256, 256), TextureChannel.Alpha);
+			sheet = new Sheet(info["Image"]);
+			logo = new Sprite(sheet, new Rectangle(0, 0, 256, 256), TextureChannel.Alpha);
+			stripe = new Sprite(sheet, new Rectangle(256, 0, 256, 256), TextureChannel.Alpha);
 			stripeRect = new Rectangle(0, r.Resolution.Height / 2 - 128, r.Resolution.Width, 256);
 			logoPos = new float2(r.Resolution.Width / 2 - 128, r.Resolution.Height / 2 - 128);
 		}
@@ -70,6 +71,12 @@ namespace OpenRA.Mods.RA
 		public void StartGame()
 		{
 			Game.TestAndContinue();
+		}
+
+		public void Dispose()
+		{
+			if (sheet != null)
+				sheet.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.RA/ModChooserLoadScreen.cs
+++ b/OpenRA.Mods.RA/ModChooserLoadScreen.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc
 			var sheet = new Sheet(info["Image"]);
 			var res = Game.Renderer.Resolution;
 			bounds = new Rectangle(0, 0, res.Width, res.Height);
-			sprite = new Sprite(sheet, new Rectangle(0,0,1024,480), TextureChannel.Alpha);
+			sprite = new Sprite(sheet, new Rectangle(0, 0, 1024, 480), TextureChannel.Alpha);
 		}
 
 		public void Display()

--- a/OpenRA.Mods.RA/ModChooserLoadScreen.cs
+++ b/OpenRA.Mods.RA/ModChooserLoadScreen.cs
@@ -15,7 +15,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Cnc
 {
-	public class ModChooserLoadScreen : ILoadScreen
+	public sealed class ModChooserLoadScreen : ILoadScreen
 	{
 		Sprite sprite;
 		Rectangle bounds;
@@ -42,6 +42,12 @@ namespace OpenRA.Mods.Cnc
 		public void StartGame()
 		{
 			Ui.LoadWidget("MODCHOOSER", Ui.Root, new WidgetArgs());
+		}
+
+		public void Dispose()
+		{
+			if (sprite != null)
+				sprite.sheet.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.RA/NullLoadScreen.cs
+++ b/OpenRA.Mods.RA/NullLoadScreen.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.RA
 {
-	public class NullLoadScreen : ILoadScreen
+	public sealed class NullLoadScreen : ILoadScreen
 	{
 		public void Init(Manifest m, Dictionary<string, string> info) {}
 
@@ -30,6 +30,10 @@ namespace OpenRA.Mods.RA
 		public void StartGame()
 		{
 			Ui.ResetAll();
+		}
+
+		public void Dispose()
+		{
 		}
 	}
 }

--- a/OpenRA.Mods.RA/NullLoadScreen.cs
+++ b/OpenRA.Mods.RA/NullLoadScreen.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.RA
 {
 	public sealed class NullLoadScreen : ILoadScreen
 	{
-		public void Init(Manifest m, Dictionary<string, string> info) {}
+		public void Init(Manifest m, Dictionary<string, string> info) { }
 
 		public void Display()
 		{
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA
 
 			// Draw a black screen
 			Game.Renderer.BeginFrame(int2.Zero, 1f);
-			Game.Renderer.EndFrame( new NullInputHandler() );
+			Game.Renderer.EndFrame(new NullInputHandler());
 		}
 
 		public void StartGame()
@@ -37,4 +37,3 @@ namespace OpenRA.Mods.RA
 		}
 	}
 }
-

--- a/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
@@ -20,15 +20,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 {
 	public class ModBrowserLogic
 	{
-		Widget modList;
-		ButtonWidget modTemplate;
-		ModMetadata[] allMods;
+		readonly Widget modList;
+		readonly ButtonWidget modTemplate;
+		readonly ModMetadata[] allMods;
+		readonly Dictionary<string, Sprite> previews = new Dictionary<string, Sprite>();
+		readonly Dictionary<string, Sprite> logos = new Dictionary<string, Sprite>();
 		ModMetadata selectedMod;
 		string selectedAuthor;
 		string selectedDescription;
 		int modOffset = 0;
-		Dictionary<string, Sprite> previews;
-		Dictionary<string, Sprite> logos;
 
 		[ObjectCreator.UseCtor]
 		public ModBrowserLogic(Widget widget)
@@ -64,8 +64,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			};
 
 			var sheetBuilder = new SheetBuilder(SheetType.BGRA);
-			previews = new Dictionary<string, Sprite>();
-			logos = new Dictionary<string, Sprite>();
 			allMods = ModMetadata.AllMods.Values.Where(m => m.Id != "modchooser")
 				.OrderBy(m => m.Title)
 				.ToArray();
@@ -90,12 +88,20 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				catch (Exception) { }
 			}
 
-
 			ModMetadata initialMod = null;
 			ModMetadata.AllMods.TryGetValue(Game.Settings.Game.PreviousMod, out initialMod);
 			SelectMod(initialMod ?? ModMetadata.AllMods["ra"]);
 
 			RebuildModList();
+		}
+
+		static void LoadMod(ModMetadata mod)
+		{
+			Game.RunAfterTick(() =>
+			{
+				Ui.CloseWindow();
+				Game.InitializeMod(mod.Id, null);
+			});
 		}
 
 		void RebuildModList()
@@ -150,15 +156,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var selectedIndex = Array.IndexOf(allMods, mod);
 			if (selectedIndex - modOffset > 4)
 				modOffset = selectedIndex - 4;
-		}
-
-		static void LoadMod(ModMetadata mod)
-		{
-			Game.RunAfterTick(() =>
-			{
-				Ui.CloseWindow();
-				Game.InitializeMod(mod.Id, null);
-			});
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ModBrowserLogic.cs
@@ -75,21 +75,17 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			{
 				try
 				{
-					var preview = new Bitmap(new[] { "mods", mod.Id, "preview.png" }.Aggregate(Path.Combine));
-					if (preview.Width != 296 || preview.Height != 196)
-						continue;
-
-					previews.Add(mod.Id, sheetBuilder.Add(preview));
+					using (var preview = new Bitmap(new[] { "mods", mod.Id, "preview.png" }.Aggregate(Path.Combine)))
+						if (preview.Width == 296 && preview.Height == 196)
+							previews.Add(mod.Id, sheetBuilder.Add(preview));
 				}
 				catch (Exception) { }
 
 				try
 				{
-					var logo = new Bitmap(new[] { "mods", mod.Id, "logo.png" }.Aggregate(Path.Combine));
-					if (logo.Width != 96 || logo.Height != 96)
-						continue;
-
-					logos.Add(mod.Id, sheetBuilder.Add(logo));
+					using (var logo = new Bitmap(new[] { "mods", mod.Id, "logo.png" }.Aggregate(Path.Combine)))
+						if (logo.Width == 96 && logo.Height == 96)
+							logos.Add(mod.Id, sheetBuilder.Add(logo));
 				}
 				catch (Exception) { }
 			}

--- a/OpenRA.Renderer.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Renderer.Null/NullGraphicsDevice.cs
@@ -77,25 +77,28 @@ namespace OpenRA.Renderer.Null
 		public void Render(Action a) { }
 	}
 
-	public class NullTexture : ITexture
+	public sealed class NullTexture : ITexture
 	{
 		public void SetData(Bitmap bitmap) { }
 		public void SetData(uint[,] colors) { }
 		public void SetData(byte[] colors, int width, int height) { }
 		public byte[] GetData() { return new byte[0]; }
 		public Size Size { get { return new Size(0, 0); } }
+		public void Dispose() { }
 	}
 
-	public class NullFrameBuffer : IFrameBuffer
+	public sealed class NullFrameBuffer : IFrameBuffer
 	{
 		public void Bind() { }
 		public void Unbind() { }
 		public ITexture Texture { get { return new NullTexture(); } }
+		public void Dispose() { }
 	}
 
-	class NullVertexBuffer<T> : IVertexBuffer<T>
+	sealed class NullVertexBuffer<T> : IVertexBuffer<T>
 	{
 		public void Bind() { }
 		public void SetData(T[] vertices, int length) { }
+		public void Dispose() { }
 	}
 }

--- a/OpenRA.Renderer.Sdl2/Texture.cs
+++ b/OpenRA.Renderer.Sdl2/Texture.cs
@@ -110,6 +110,7 @@ namespace OpenRA.Renderer.Sdl2
 				bitmap = new Bitmap(bitmap, bitmap.Size.NextPowerOf2());
 				allocatedBitmap = true;
 			}
+
 			try
 			{
 				size = new Size(bitmap.Width, bitmap.Height);

--- a/OpenRA.Renderer.Sdl2/Texture.cs
+++ b/OpenRA.Renderer.Sdl2/Texture.cs
@@ -16,13 +16,15 @@ using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Renderer.Sdl2
 {
-	public class Texture : ITexture
+	public sealed class Texture : ITexture
 	{
 		int texture;
 		public int ID { get { return texture; } }
 
 		Size size;
 		public Size Size { get { return size; } }
+
+		bool disposed;
 
 		public Texture()
 		{
@@ -36,9 +38,6 @@ namespace OpenRA.Renderer.Sdl2
 			ErrorHandler.CheckGlError();
 			SetData(bitmap);
 		}
-
-		void FinalizeInner() { GL.DeleteTextures(1, ref texture); }
-		~Texture() { Game.RunAfterTick(FinalizeInner); }
 
 		void PrepareTexture()
 		{
@@ -159,6 +158,25 @@ namespace OpenRA.Renderer.Sdl2
 			GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, width, height,
 				0, OpenTK.Graphics.OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, IntPtr.Zero);
 			ErrorHandler.CheckGlError();
+		}
+
+		~Texture()
+		{
+			Game.RunAfterTick(() => Dispose(false));
+		}
+
+		public void Dispose()
+		{
+			Game.RunAfterTick(() => Dispose(true));
+			GC.SuppressFinalize(this);
+		}
+
+		void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+			disposed = true;
+			GL.DeleteTextures(1, ref texture);
 		}
 	}
 }

--- a/OpenRA.Renderer.Sdl2/VertexBuffer.cs
+++ b/OpenRA.Renderer.Sdl2/VertexBuffer.cs
@@ -14,11 +14,12 @@ using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Renderer.Sdl2
 {
-	public class VertexBuffer<T> : IVertexBuffer<T>
+	public sealed class VertexBuffer<T> : IVertexBuffer<T>
 			where T : struct
 	{
 		static readonly int VertexSize = Marshal.SizeOf(typeof(T));
 		int buffer;
+		bool disposed;
 
 		public VertexBuffer(int size)
 		{
@@ -52,7 +53,23 @@ namespace OpenRA.Renderer.Sdl2
 			ErrorHandler.CheckGlError();
 		}
 
-		void FinalizeInner() { GL.DeleteBuffers(1, ref buffer); }
-		~VertexBuffer() { Game.RunAfterTick(FinalizeInner); }
+		~VertexBuffer()
+		{
+			Game.RunAfterTick(() => Dispose(false));
+		}
+
+		public void Dispose()
+		{
+			Game.RunAfterTick(() => Dispose(true));
+			GC.SuppressFinalize(this);
+		}
+
+		void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+			disposed = true;
+			GL.DeleteBuffers(1, ref buffer);
+		}
 	}
 }


### PR DESCRIPTION
Speculative fix for #5116 by implementing IDisposable on Texture, FrameBuffer and VertexBuffer rather than relying on the finalizer to do the work since the non-determinism of finalization means these resources could be hanging around for an unbounded length of time before being released.

This PR ensures almost all of these resources are released deterministically via Dispose (a few stragglers still get finalized since some lifetimes are non-trivial, particularly with textures for sheets allocated by sheet builders, which makes tracking them down difficult).

I don't have any particular proof that this will fix the out-of-memory issue, it just seems like it could be a possible cause.
