### PR TITLE
RA - Explosive Oil Derricks

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -326,6 +326,8 @@ OILB:
 		CaptureAmount: 100
 	Tooltip:
 		Name: Oil Derrick
+	Explodes:
+		Weapon: BarrelExplode
 
 BR1:
 	Inherits: ^Bridge


### PR DESCRIPTION
I added Barrel Explode death weapon to Oil Derricks. They damages nearby units on death like RA2.
