### PR TITLE
Added MaxSpread for more control over maximum area of damage

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -19,6 +19,8 @@ namespace OpenRA.GameRules
 	{
 		[Desc("Distance from the explosion center at which damage is 1/2.")]
 		public readonly WRange Spread = new WRange(43);
+		[Desc("Maximum Spread. If a value >= Spread is set, this sets a fixed maximum area of damage.")]
+		public readonly WRange MaxSpread = new WRange(0);
 		[FieldLoader.LoadUsing("LoadVersus")]
 		[Desc("Damage vs each armortype. 0% = can't target.")]
 		public readonly Dictionary<string, float> Versus;

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -122,7 +122,10 @@ namespace OpenRA.Mods.RA
 			{
 				case DamageModel.Normal:
 					{
-						var maxSpread = new WRange((int)(warhead.Spread.Range * (float)Math.Log(Math.Abs(warhead.Damage), 2)));
+						var spreadMax = warhead.MaxSpread.Range;
+						var maxSpreadCalculation = spreadMax >= warhead.Spread.Range ? spreadMax : (warhead.Spread.Range * (float)Math.Log(Math.Abs(warhead.Damage), 2));
+
+						var maxSpread = new WRange((int)(maxSpreadCalculation));
 						var hitActors = world.FindActorsInCircle(pos, maxSpread);
 
 						foreach (var victim in hitActors)

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -117,8 +117,10 @@ Atomic:
 IonCannon:
 	ValidTargets: Ground, Air
 	Warhead@impact:
-		Damage: 900
-		Spread: 853
+		Damage: 1000
+		SmudgeType: Scorch
+		Spread: 1c0
+		MaxSpread: 3c640
 		DestroyResources: true
 		InfDeath: 5
 	Warhead@area:
@@ -126,6 +128,14 @@ IonCannon:
 		Damage: 0
 		SmudgeType: Scorch
 		Size: 2,1
+		DestroyResources: true
+		Delay: 3
+		InfDeath: 5
+	Warhead@area2:
+		DamageModel: PerCell
+		Damage: 0
+		SmudgeType: Scorch
+		Size: 1
 		DestroyResources: true
 		Delay: 3
 		InfDeath: 5


### PR DESCRIPTION
This implements the more important part of #5436.

So far, it's only used to make the Ion Cannon more powerful without increasing the area of effect.
