### PR TITLE
Fixed broken drop-zone maps

### DIFF
--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -309,18 +309,32 @@ Rules:
 		GiveUnitCrateAction@ttnk:
 			SelectionShares: 4
 			Unit: ttnk
+			Owner: soviet
 		GiveUnitCrateAction@ftrk:
 			SelectionShares: 6
 			Unit: ftrk
+			Owner: soviet
 		GiveUnitCrateAction@harv:
 			SelectionShares: 1
 			Unit: harv
+			Owner: soviet
 		GiveUnitCrateAction@shok:
 			SelectionShares: 1
 			Unit: shok
+			Owner: soviet
 		GiveUnitCrateAction@dog:
 			SelectionShares: 1
 			Unit: dog
+			Owner: soviet
+	^Infantry:
+		GivesBounty:
+			Percentage: 0
+	^Tank:
+		GivesBounty:
+			Percentage: 0
+	^Vehicle:
+		GivesBounty:
+			Percentage: 0
 	APC:
 		Health:
 			HP: 1000
@@ -328,10 +342,7 @@ Rules:
 			Range: 40c0
 		MustBeDestroyed:
 		-AttackMove:
-		-GivesBounty:
 	HARV:
-		Buildable:
-			Owner: soviet
 		Tooltip:
 			Name: Bomb Truck
 			Description: Explodes like a damn nuke!
@@ -341,29 +352,14 @@ Rules:
 			Weapon: CrateNuke
 			EmptyWeapon: CrateNuke
 		DemoTruck:
-		-GivesBounty:
 	SHOK:
-		Buildable:
-			Owner: soviet
 		Health:
 			HP: 800
-		-GivesBounty:
 	DOG:
-		Buildable:
-			Owner: soviet
 		Health:
 			HP: 120
 		Mobile:
 			Speed: 99
-		-GivesBounty:
-	FTRK:
-		Buildable:
-			Owner: soviet
-		-GivesBounty:
-	TTNK:
-		Buildable:
-			Owner: soviet
-		-GivesBounty:
 
 Sequences:
 

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -328,23 +328,42 @@ Rules:
 			Range: 40c0
 		MustBeDestroyed:
 		-AttackMove:
+		-GivesBounty:
 	HARV:
+		Buildable:
+			Owner: soviet
 		Tooltip:
 			Name: Bomb Truck
 			Description: Explodes like a damn nuke!
 		Health:
 			HP: 100
-			Explodes:
-				Weapon: CrateNuke
-				EmptyWeapon:
+		Explodes:
+			Weapon: CrateNuke
+			EmptyWeapon: CrateNuke
+		DemoTruck:
+		-GivesBounty:
 	SHOK:
+		Buildable:
+			Owner: soviet
 		Health:
 			HP: 800
+		-GivesBounty:
 	DOG:
+		Buildable:
+			Owner: soviet
 		Health:
 			HP: 120
 		Mobile:
 			Speed: 99
+		-GivesBounty:
+	FTRK:
+		Buildable:
+			Owner: soviet
+		-GivesBounty:
+	TTNK:
+		Buildable:
+			Owner: soviet
+		-GivesBounty:
 
 Sequences:
 

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -204,18 +204,32 @@ Rules:
 		GiveUnitCrateAction@ttnk:
 			SelectionShares: 4
 			Unit: ttnk
+			Owner: soviet
 		GiveUnitCrateAction@ftrk:
 			SelectionShares: 6
 			Unit: ftrk
+			Owner: soviet
 		GiveUnitCrateAction@harv:
 			SelectionShares: 1
 			Unit: harv
+			Owner: soviet
 		GiveUnitCrateAction@shok:
 			SelectionShares: 1
 			Unit: shok
+			Owner: soviet
 		GiveUnitCrateAction@dog:
 			SelectionShares: 1
 			Unit: dog
+			Owner: soviet
+	^Infantry:
+		GivesBounty:
+			Percentage: 0
+	^Tank:
+		GivesBounty:
+			Percentage: 0
+	^Vehicle:
+		GivesBounty:
+			Percentage: 0
 	APC:
 		Health:
 			HP: 1000
@@ -223,10 +237,7 @@ Rules:
 			Range: 40c0
 		MustBeDestroyed:
 		-AttackMove:
-		-GivesBounty:
 	HARV:
-		Buildable:
-			Owner: soviet
 		Tooltip:
 			Name: Bomb Truck
 			Description: Explodes like a damn nuke!
@@ -236,29 +247,14 @@ Rules:
 			Weapon: CrateNuke
 			EmptyWeapon: CrateNuke
 		DemoTruck:
-		-GivesBounty:
 	SHOK:
-		Buildable:
-			Owner: soviet
 		Health:
 			HP: 800
-		-GivesBounty:
 	DOG:
-		Buildable:
-			Owner: soviet
 		Health:
 			HP: 120
 		Mobile:
 			Speed: 99
-		-GivesBounty:
-	FTRK:
-		Buildable:
-			Owner: soviet
-		-GivesBounty:
-	TTNK:
-		Buildable:
-			Owner: soviet
-		-GivesBounty:
 
 Sequences:
 

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -223,23 +223,42 @@ Rules:
 			Range: 40c0
 		MustBeDestroyed:
 		-AttackMove:
+		-GivesBounty:
 	HARV:
+		Buildable:
+			Owner: soviet
 		Tooltip:
 			Name: Bomb Truck
 			Description: Explodes like a damn nuke!
 		Health:
 			HP: 100
-			Explodes:
-				Weapon: CrateNuke
-				EmptyWeapon:
+		Explodes:
+			Weapon: CrateNuke
+			EmptyWeapon: CrateNuke
+		DemoTruck:
+		-GivesBounty:
 	SHOK:
+		Buildable:
+			Owner: soviet
 		Health:
 			HP: 800
+		-GivesBounty:
 	DOG:
+		Buildable:
+			Owner: soviet
 		Health:
 			HP: 120
 		Mobile:
 			Speed: 99
+		-GivesBounty:
+	FTRK:
+		Buildable:
+			Owner: soviet
+		-GivesBounty:
+	TTNK:
+		Buildable:
+			Owner: soviet
+		-GivesBounty:
 
 Sequences:
 


### PR DESCRIPTION
Before you only got this "heal-action" from crates,
now the units are also available and the harv-bomber works.

But the terrian is still broken, I'll fix that later in another PR.
