### PR TITLE
Restored PlaceBuilding order's ProductionQueue checks.

### DIFF
--- a/OpenRA.Mods.RA/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.RA/Player/PlaceBuilding.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA
 
 					var unit = self.World.Map.Rules.Actors[order.TargetString];
 					var queue = order.TargetActor.TraitsImplementing<ProductionQueue>()
-						.FirstOrDefault(q => q.CanBuild(unit));
+						.FirstOrDefault(q => q.CanBuild(unit) && q.CurrentItem() != null && q.CurrentItem().Item == order.TargetString && q.CurrentItem().RemainingTime == 0);
 
 					if (queue == null)
 						return;


### PR DESCRIPTION
Fixes regression in #5948 by restoring the currentItem
checks in the PlaceBuilding order to ensure that the production you are trying to deploy is still
valid at the time that you attempt to place the building.

I have tested and confirmed the fix, though I don't know what the original reasoning for removing the checks was in 4db2cf6.  It doesn't seem to have an effect on the capturable tech and race changes that were done.
