### PR TITLE
Recursive OnCapture through ChangeOwner.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,6 +85,7 @@ Also thanks to:
     * Vladimir Komarov (VrKomarov)
     * Wuschel
     * Ian T. Jacobsen (Smilex)
+    * atlimit8
 
 Using Simple DirectMedia Layer distributed under
 the terms of the zlib license.

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -213,7 +213,7 @@ namespace OpenRA
 		}
 
 		// TODO: move elsewhere.
-		public void ChangeOwner(Player newOwner)
+		public void ChangeOwner(Player newOwner, Actor captor = null)
 		{
 			World.AddFrameEndTask(w =>
 			{
@@ -222,14 +222,23 @@ namespace OpenRA
 
 				var oldOwner = Owner;
 
-				// momentarily remove from world so the ownership queries don't get confused
-				w.Remove(this);
+				// momentarily remove from world if present so the ownership queries don't get confused
+				var inWorld = IsInWorld;
+				if (inWorld)
+					w.Remove(this);
 				Owner = newOwner;
 				Generation++;
-				w.Add(this);
+				if (inWorld)
+					w.Add(this);
 
 				foreach (var t in this.TraitsImplementing<INotifyOwnerChanged>())
 					t.OnOwnerChanged(this, oldOwner, newOwner);
+
+				if (captor != null)
+				{
+					foreach (var t in TraitsImplementing<INotifyCapture>())
+						t.OnCapture(this, captor, oldOwner, newOwner);
+				}
 			});
 		}
 

--- a/OpenRA.Mods.RA/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.RA/Activities/CaptureActor.cs
@@ -45,12 +45,7 @@ namespace OpenRA.Mods.RA.Activities
 				var lowEnoughHealth = health.HP <= capturableInfo.CaptureThreshold * health.MaxHP;
 				if (!capturesInfo.Sabotage || lowEnoughHealth || actor.Owner.NonCombatant)
 				{
-					var oldOwner = actor.Owner;
-
-					actor.ChangeOwner(self.Owner);
-
-					foreach (var t in actor.TraitsImplementing<INotifyCapture>())
-						t.OnCapture(actor, self, oldOwner, self.Owner);
+					actor.ChangeOwner(self.Owner, self);
 
 					if (b != null && b.Locked)
 						b.Unlock();

--- a/OpenRA.Mods.RA/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.RA/Activities/ExternalCaptureActor.cs
@@ -62,12 +62,7 @@ namespace OpenRA.Mods.RA.Activities
 						if (target.Actor.IsDead())
 							return;
 
-						var oldOwner = target.Actor.Owner;
-
-						target.Actor.ChangeOwner(self.Owner);
-
-						foreach (var t in target.Actor.TraitsImplementing<INotifyCapture>())
-							t.OnCapture(target.Actor, self, oldOwner, self.Owner);
+						target.Actor.ChangeOwner(self.Owner, self);
 
 						capturable.EndCapture();
 

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -217,11 +217,8 @@ namespace OpenRA.Mods.RA
 			if (cargo == null)
 				return;
 
-			self.World.AddFrameEndTask(w =>
-			{
-				foreach (var p in Passengers)
-					p.Owner = newOwner;
-			});
+			foreach (var p in Passengers)
+				p.ChangeOwner(newOwner, captor);
 		}
 
 		bool initialized;

--- a/OpenRA.Mods.RA/OreRefinery.cs
+++ b/OpenRA.Mods.RA/OreRefinery.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.RA
 		{
 			// Steal any docked harv too
 			if (dockedHarv != null)
-				dockedHarv.ChangeOwner(newOwner);
+				dockedHarv.ChangeOwner(newOwner, captor);
 
 			// Unlink any non-docked harvs
 			foreach (var harv in GetLinkedHarvesters())


### PR DESCRIPTION
Useful for nested transports. (ex: a loaded APC in a transport ship)
May be useful for detecting the loss of an important actor through transport theft.

of possible use:
    // for KillOnTransportCapture and EscapeTransportCapture (Not implemented yet)
    INotifyTransportCaptured { onTransportCaptured(Actor self, Actor transport. Actor captor); }
