### PR TITLE
Faster replay browser loading

### DIFF
--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -78,7 +78,7 @@ namespace OpenRA
 
 			nodes.Add(new MiniYamlNode("Root", FieldSaver.Save(this)));
 
-			for (var i=0; i<Players.Count; i++)
+			for (var i = 0; i < Players.Count; i++)
 				nodes.Add(new MiniYamlNode("Player@{0}".F(i), FieldSaver.Save(Players[i])));
 
 			return nodes.WriteToString();

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -83,8 +83,8 @@ namespace OpenRA
 
 	public class MiniYaml
 	{
-		static Func<string, string> StringIdentity = s => s;
-		static Func<MiniYaml, MiniYaml> MiniYamlIdentity = my => my;
+		static readonly Func<string, string> StringIdentity = s => s;
+		static readonly Func<MiniYaml, MiniYaml> MiniYamlIdentity = my => my;
 		public string Value;
 		public List<MiniYamlNode> Nodes;
 
@@ -115,6 +115,7 @@ namespace OpenRA
 					throw new InvalidDataException("Duplicate key '{0}' in {1}".F(y.Key, y.Location), ex);
 				}
 			}
+
 			return ret;
 		}
 
@@ -268,10 +269,8 @@ namespace OpenRA
 				}
 			}
 
-			if (throwErrors)
-			if (noInherit.ContainsValue(false))
-				throw new YamlException("Bogus yaml removals: {0}".F(
-					noInherit.Where(x => !x.Value).JoinWith(", ")));
+			if (throwErrors && noInherit.ContainsValue(false))
+				throw new YamlException("Bogus yaml removals: {0}".F(noInherit.Where(x => !x.Value).JoinWith(", ")));
 
 			return ret;
 		}

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -142,7 +142,7 @@ namespace OpenRA
 			return nd.ContainsKey(s) ? nd[s].Nodes : new List<MiniYamlNode>();
 		}
 
-		static List<MiniYamlNode> FromLines(string[] lines, string filename)
+		static List<MiniYamlNode> FromLines(IEnumerable<string> lines, string filename)
 		{
 			var levels = new List<List<MiniYamlNode>>();
 			levels.Add(new List<MiniYamlNode>());
@@ -152,8 +152,9 @@ namespace OpenRA
 			{
 				var line = ll;
 				++lineNo;
-				if (line.Contains('#'))
-					line = line.Substring(0, line.IndexOf('#')).TrimEnd(' ', '\t');
+				var commentIndex = line.IndexOf('#');
+				if (commentIndex != -1)
+					line = line.Substring(0, commentIndex).TrimEnd(' ', '\t');
 				var t = line.TrimStart(' ', '\t');
 				if (t.Length == 0)
 					continue;
@@ -189,12 +190,8 @@ namespace OpenRA
 
 		public static List<MiniYamlNode> FromFileInPackage(string path)
 		{
-			var lines = new List<string>();
 			using (var stream = GlobalFileSystem.Open(path))
-			using (var reader = new StreamReader(stream))
-				while (!reader.EndOfStream)
-					lines.Add(reader.ReadLine());
-			return FromLines(lines.ToArray(), path);
+				return FromLines(stream.ReadAllLines(), path);
 		}
 
 		public static Dictionary<string, MiniYaml> DictFromFile(string path)

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -84,7 +84,6 @@ namespace OpenRA
 			if (!Manifest.Translations.Any())
 			{
 				Languages = new string[0];
-				FieldLoader.Translations = new Dictionary<string, string>();
 				return;
 			}
 
@@ -112,7 +111,7 @@ namespace OpenRA
 					translations.Add(tkv.Key, tkv.Value);
 			}
 
-			FieldLoader.Translations = translations;
+			FieldLoader.SetTranslations(translations);
 		}
 
 		public Map PrepareMap(string uid)

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Orders\IOrderGenerator.cs" />
     <Compile Include="Orders\UnitOrderGenerator.cs" />
     <Compile Include="Player.cs" />
+    <Compile Include="Primitives\ConcurrentCache.cs" />
     <Compile Include="Selection.cs" />
     <Compile Include="Server\Connection.cs" />
     <Compile Include="Server\Exts.cs" />

--- a/OpenRA.Game/Primitives/Cache.cs
+++ b/OpenRA.Game/Primitives/Cache.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace OpenRA.Primitives
@@ -32,13 +31,7 @@ namespace OpenRA.Primitives
 
 		public U this[T key]
 		{
-			get
-			{
-				U result;
-				if (!cache.TryGetValue(key, out result))
-					cache.Add(key, result = loader(key));
-				return result;
-			}
+			get { return cache.GetOrAdd(key, loader); }
 		}
 		public bool ContainsKey(T key) { return cache.ContainsKey(key); }
 		public bool TryGetValue(T key, out U value) { return cache.TryGetValue(key, out value); }
@@ -46,6 +39,6 @@ namespace OpenRA.Primitives
 		public ICollection<T> Keys { get { return cache.Keys; } }
 		public ICollection<U> Values { get { return cache.Values; } }
 		public IEnumerator<KeyValuePair<T, U>> GetEnumerator() { return cache.GetEnumerator(); }
-		IEnumerator IEnumerable.GetEnumerator() { return GetEnumerator(); }
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return GetEnumerator(); }
 	}
 }

--- a/OpenRA.Game/Primitives/ConcurrentCache.cs
+++ b/OpenRA.Game/Primitives/ConcurrentCache.cs
@@ -1,0 +1,45 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace OpenRA.Primitives
+{
+	public class ConcurrentCache<T, U> : IReadOnlyDictionary<T, U>
+	{
+		readonly ConcurrentDictionary<T, U> cache;
+		readonly Func<T, U> loader;
+
+		public ConcurrentCache(Func<T, U> loader, IEqualityComparer<T> c)
+		{
+			if (loader == null)
+				throw new ArgumentNullException("loader");
+			this.loader = loader;
+			cache = new ConcurrentDictionary<T, U>(c);
+		}
+
+		public ConcurrentCache(Func<T, U> loader)
+			: this(loader, EqualityComparer<T>.Default) { }
+
+		public U this[T key]
+		{
+			get { return cache.GetOrAdd(key, loader); }
+		}
+		public bool ContainsKey(T key) { return cache.ContainsKey(key); }
+		public bool TryGetValue(T key, out U value) { return cache.TryGetValue(key, out value); }
+		public int Count { get { return cache.Count; } }
+		public ICollection<T> Keys { get { return cache.Keys; } }
+		public ICollection<U> Values { get { return cache.Values; } }
+		public IEnumerator<KeyValuePair<T, U>> GetEnumerator() { return cache.GetEnumerator(); }
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return GetEnumerator(); }
+	}
+}

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -124,17 +124,10 @@ namespace OpenRA
 
 		public static IEnumerable<string> ReadAllLines(this Stream s)
 		{
+			string line;
 			using (var sr = new StreamReader(s))
-			{
-				for (;;)
-				{
-					var line = sr.ReadLine();
-					if (line == null)
-						yield break;
-					else
-						yield return line;
-				}
-			}
+				while ((line = sr.ReadLine()) != null)
+					yield return line;
 		}
 
 		// The string is assumed to be length-prefixed, as written by WriteString()

--- a/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
@@ -56,6 +56,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				{
 					replays = Directory
 						.GetFiles(dir, "*.rep")
+						.AsParallel()
 						.Select(ReplayMetadata.Read)
 						.Where(r => r != null)
 						.OrderByDescending(r => r.GameInfo.StartTimeUtc)


### PR DESCRIPTION
Partial fix to address the core issue (slow replay browser loading) behind the suggestion given in #5942.

This parallelizes the loading process and removes a few bottlenecks. An informal test with 1200 replays sees the "Load Replays" time reduced from 3527 ms to 1210 ms on my dual core machine. Machines with more cores might see even bigger improvements but eventually IO will take over as the bottleneck so things will plateau somewhere.

This doesn't actually implement any lazy or background loading as suggested in #5942. That would probably be worthwhile, particularly for when the replay files are not in the file cache and waiting on IO becomes the main issue.
