### PR TITLE
More aircraft/shroud interaction fixes

### DIFF
--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -61,7 +61,7 @@ namespace OpenRA
 
 		public void Tick(World world)
 		{
-			actors.RemoveAll(a => !a.IsInWorld || (a.Owner != world.LocalPlayer && world.FogObscures(a)));
+			actors.RemoveAll(a => !a.IsInWorld || (!a.Owner.IsAlliedWith(world.LocalPlayer) && world.FogObscures(a)));
 
 			foreach (var cg in controlGroups.Values)
 				// note: NOT `!a.IsInWorld`, since that would remove things that are in transports.

--- a/OpenRA.Game/Traits/SelectionDecorations.cs
+++ b/OpenRA.Game/Traits/SelectionDecorations.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
 		{
-			if (self.World.FogObscures(self))
+			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer) && self.World.FogObscures(self))
 				yield break;
 
 			var b = self.Bounds.Value;
@@ -74,9 +74,6 @@ namespace OpenRA.Traits
 
 		IEnumerable<IRenderable> DrawPips(WorldRenderer wr, Actor self, int2 basePosition)
 		{
-			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				yield break;
-
 			var pipSources = self.TraitsImplementing<IPips>();
 			if (!pipSources.Any())
 				yield break;
@@ -118,9 +115,6 @@ namespace OpenRA.Traits
 
 		IEnumerable<IRenderable> DrawTags(WorldRenderer wr, Actor self, int2 basePosition)
 		{
-			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				yield break;
-
 			var tagImages = new Animation(self.World, "pips");
 			var pal = wr.Palette(Info.Palette);
 			var tagxyOffset = new int2(0, 6);

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -239,7 +239,7 @@ namespace OpenRA.Widgets
 		static IEnumerable<Actor> SelectActorsInBox(World world, int2 a, int2 b, Func<Actor, bool> cond)
 		{
 			return world.ScreenMap.ActorsInBox(a, b)
-				.Where(x => x.HasTrait<Selectable>() && x.Trait<Selectable>().Info.Selectable && !world.FogObscures(x) && cond(x))
+				.Where(x => x.HasTrait<Selectable>() && x.Trait<Selectable>().Info.Selectable && (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)) && cond(x))
 				.GroupBy(x => x.GetSelectionPriority())
 				.OrderByDescending(g => g.Key)
 				.Select(g => g.AsEnumerable())

--- a/OpenRA.Mods.RA/Air/AttackPlane.cs
+++ b/OpenRA.Mods.RA/Air/AttackPlane.cs
@@ -29,8 +29,8 @@ namespace OpenRA.Mods.RA.Air
 
 		protected override bool CanAttack(Actor self, Target target)
 		{
-			// dont fire while landed
-			return base.CanAttack(self, target) && self.CenterPosition.Z > 0;
+			// dont fire while landed or when outside the map
+			return base.CanAttack(self, target) && self.CenterPosition.Z > 0 && self.World.Map.Contains(self.Location);
 		}
 	}
 }


### PR DESCRIPTION
This is a continuation of #5967, which only made planes not lose their selection when they strayed
outside the map border. This PR makes it possible to select them when they already are outside the map.

Fixes #5651 for real, then.

Also fixes #6001 by making aircraft not attack when they are outside the map. The change will affect both Yaks and Migs, even though Yaks did not have the original problem.
