### PR TITLE
Reordered production palette according to prerequisites.

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -76,7 +76,7 @@ MIG:
 	Inherits: ^Plane
 	Buildable:
 		Queue: Plane
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 50
 		Prerequisites: afld, stek, ~techlevel.unrestricted
 		Hotkey: m
 	Valued:
@@ -128,7 +128,7 @@ YAK:
 	Inherits: ^Plane
 	Buildable:
 		Queue: Plane
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 30
 		Prerequisites: afld, ~techlevel.medium
 		Hotkey: y
 	Valued:
@@ -186,7 +186,7 @@ TRAN:
 	Inherits: ^Helicopter
 	Buildable:
 		Queue: Helicopter
-		BuildPaletteOrder: 80
+		BuildPaletteOrder: 10
 		Prerequisites: hpad, ~techlevel.medium
 		Hotkey: t
 	Valued:
@@ -228,7 +228,7 @@ HELI:
 	Inherits: ^Helicopter
 	Buildable:
 		Queue: Helicopter
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 40
 		Prerequisites: hpad, atek, ~techlevel.unrestricted
 		Hotkey: l
 	Valued:
@@ -278,7 +278,7 @@ HIND:
 	Inherits: ^Helicopter
 	Buildable:
 		Queue: Helicopter
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 20
 		Prerequisites: hpad, ~techlevel.medium
 		Hotkey: h
 	Valued:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -2,7 +2,7 @@ DOG:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 50
 		Prerequisites: ~barr, ~techlevel.infonly
 		Hotkey: o
 	Valued:
@@ -63,7 +63,7 @@ E2:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 20
 		Prerequisites: ~barr, ~techlevel.infonly
 		Hotkey: g
 	Valued:
@@ -99,7 +99,7 @@ E3:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 30
 		Prerequisites: ~techlevel.infonly
 		Hotkey: r
 	Valued:
@@ -133,7 +133,7 @@ E4:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 70
 		Prerequisites: ~barr, ftur, ~techlevel.low
 		Hotkey: t
 	Valued:
@@ -165,7 +165,7 @@ E6:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 60
 		Prerequisites: ~techlevel.infonly
 		Hotkey: e
 	Valued:
@@ -197,7 +197,7 @@ SPY:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 90
 		Prerequisites: dome, ~tent, ~techlevel.medium
 		Hotkey: p
 	Valued:
@@ -233,7 +233,7 @@ E7:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 110
+		BuildPaletteOrder: 120
 		Prerequisites: ~tent, atek, ~techlevel.unrestricted
 		Hotkey: y
 		BuildLimit: 1
@@ -273,7 +273,7 @@ MEDI:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 40
 		Prerequisites: ~tent, ~techlevel.infonly
 		Hotkey: m
 	Valued:
@@ -308,7 +308,7 @@ MECH:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 70
+		BuildPaletteOrder: 100
 		Prerequisites: ~tent, fix, ~techlevel.medium
 		Hotkey: c
 	Valued:
@@ -424,7 +424,7 @@ HIJACKER:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 110
 		Prerequisites: ~barr, fix, ~techlevel.medium
 		Hotkey: j
 	Valued:
@@ -451,7 +451,7 @@ SHOK:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 70
+		BuildPaletteOrder: 130
 		Prerequisites: ~barr, stek, tsla, ~techlevel.unrestricted
 		Hotkey: l
 	Valued:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -2,7 +2,7 @@ SS:
 	Inherits: ^Ship
 	Buildable:
 		Queue: Ship
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 30
 		Prerequisites: ~spen, ~techlevel.medium
 		Hotkey: u
 	Valued:
@@ -106,7 +106,7 @@ DD:
 	Inherits: ^Ship
 	Buildable:
 		Queue: Ship
-		BuildPaletteOrder: 70
+		BuildPaletteOrder: 40
 		Prerequisites: ~syrd, dome, ~techlevel.medium
 		Hotkey: r
 	Valued:
@@ -155,7 +155,7 @@ CA:
 	Inherits: ^Ship
 	Buildable:
 		Queue: Ship
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 50
 		Prerequisites: ~syrd, atek, ~techlevel.unrestricted
 		Hotkey: c
 	Valued:
@@ -216,7 +216,7 @@ LST:
 	Inherits: ^Ship
 	Buildable:
 		Queue: Ship
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 10
 		Prerequisites: ~techlevel.low
 		Hotkey: t
 	Valued:
@@ -249,7 +249,7 @@ PT:
 	Inherits: ^Ship
 	Buildable:
 		Queue: Ship
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 20
 		Prerequisites: ~syrd, ~techlevel.medium
 		Hotkey: b
 	Valued:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -7,7 +7,7 @@ MSLO:
 		Description: Provides an atomic bomb.\nSpecial Ability: Atom Bomb\n\nMaximum 1 can be built
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 130
+		BuildPaletteOrder: 140
 		Prerequisites: techcenter, ~techlevel.unrestricted
 		BuildLimit: 1
 		Hotkey: m
@@ -54,7 +54,7 @@ GAP:
 		Description: Obscures the enemy's view with shroud.
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 110
 		Prerequisites: atek, ~structures.allies, ~techlevel.unrestricted
 		Hotkey: g
 	Building:
@@ -143,7 +143,7 @@ SYRD:
 		Proxy: powerproxy.sonarpulse
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 40
 		Prerequisites: anypower, ~structures.allies, ~techlevel.low
 		Hotkey: y
 	Valued:
@@ -195,7 +195,7 @@ IRON:
 	Inherits: ^Building
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 120
+		BuildPaletteOrder: 130
 		Prerequisites: stek, ~structures.soviet, ~techlevel.unrestricted
 		BuildLimit: 1
 		Hotkey: c
@@ -283,7 +283,7 @@ TSLA:
 	Inherits: ^Building
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 80
 		Prerequisites: weap, ~structures.soviet, ~techlevel.medium
 		Hotkey: u
 	Valued:
@@ -326,7 +326,7 @@ AGUN:
 	Inherits: ^Building
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 90
 		Prerequisites: dome, ~structures.allies, ~techlevel.medium
 		Hotkey: y
 	Valued:
@@ -372,7 +372,7 @@ DOME:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 70
+		BuildPaletteOrder: 90
 		Prerequisites: proc, ~techlevel.medium
 		Hotkey: r
 	Valued:
@@ -412,7 +412,7 @@ PBOX:
 		Power: -15
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 40
 		Prerequisites: tent, ~structures.allies, ~techlevel.low
 		Hotkey: p
 	-GivesBuildableArea:
@@ -457,7 +457,7 @@ HBOX:
 		Power: -15
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 50
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
 		Hotkey: l
 	-GivesBuildableArea:
@@ -500,7 +500,7 @@ GUN:
 	Inherits: ^Building
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 70
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
 		Hotkey: t
 	Valued:
@@ -540,7 +540,7 @@ FTUR:
 	Inherits: ^Building
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 60
 		Prerequisites: barr, ~structures.soviet, ~techlevel.low
 		Hotkey: t
 	Valued:
@@ -578,7 +578,7 @@ SAM:
 	Inherits: ^Building
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 70
+		BuildPaletteOrder: 100
 		Prerequisites: dome, ~structures.soviet, ~techlevel.medium
 		Hotkey: y
 	Valued:
@@ -623,7 +623,7 @@ ATEK:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 140
 		Prerequisites: weap, dome, ~structures.allies, ~techlevel.unrestricted
 		Hotkey: t
 	Valued:
@@ -662,7 +662,7 @@ WEAP:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 80
 		Prerequisites: proc, ~techlevel.low
 		Hotkey: w
 	Valued:
@@ -756,7 +756,7 @@ PROC:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 60
 		Prerequisites: anypower, ~techlevel.infonly
 		Hotkey: e
 	Valued:
@@ -802,7 +802,7 @@ SILO:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 70
 		Prerequisites: proc, ~techlevel.infonly
 		Hotkey: o
 	Valued:
@@ -833,7 +833,7 @@ HPAD:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 120
 		Prerequisites: dome, ~structures.allies, ~techlevel.medium
 		Hotkey: i
 	Valued:
@@ -868,7 +868,7 @@ AFLD:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 130
 		Prerequisites: dome, ~structures.soviet, ~techlevel.medium
 		Hotkey: i
 	Valued:
@@ -929,7 +929,7 @@ POWR:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 0
+		BuildPaletteOrder: 10
 		Prerequisites: ~techlevel.infonly
 		Hotkey: p
 	Valued:
@@ -957,7 +957,7 @@ APWR:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 80
+		BuildPaletteOrder: 110
 		Prerequisites: dome, ~techlevel.medium
 		Hotkey: l
 	Valued:
@@ -985,7 +985,7 @@ STEK:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 150
 		Prerequisites: weap, dome, ~structures.soviet, ~techlevel.unrestricted
 		Hotkey: t
 	Valued:
@@ -1048,7 +1048,7 @@ TENT:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 20
 		Prerequisites: anypower, ~structures.allies, ~techlevel.infonly
 		Hotkey: b
 	Valued:
@@ -1101,7 +1101,7 @@ FIX:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 100
 		Prerequisites: weap, ~techlevel.medium
 		Hotkey: m
 	Valued:
@@ -1133,7 +1133,7 @@ FACF:
 	Valued:
 		Cost: 50
 	Buildable:
-		BuildPaletteOrder: 900
+		BuildPaletteOrder: 940
 		Queue: Defense
 		Prerequisites: ~disabled
 	Tooltip:
@@ -1161,7 +1161,7 @@ WEAF:
 	Valued:
 		Cost: 50
 	Buildable:
-		BuildPaletteOrder: 900
+		BuildPaletteOrder: 920
 		Prerequisites: ~disabled
 		Queue: Defense
 	Tooltip:
@@ -1222,7 +1222,7 @@ SPEF:
 	TargetableBuilding:
 		TargetTypes: Ground, Water
 	Buildable:
-		BuildPaletteOrder: 900
+		BuildPaletteOrder: 910
 		Queue: Defense
 		Prerequisites: ~disabled
 	Tooltip:
@@ -1254,7 +1254,7 @@ DOMF:
 		Name: Fake Radar Dome
 		Description: Looks like a Radar Dome.
 	Buildable:
-		BuildPaletteOrder: 900
+		BuildPaletteOrder: 930
 		Queue: Defense
 		Prerequisites: ~disabled
 	Building:
@@ -1276,7 +1276,7 @@ SBAG:
 	Inherits: ^Wall
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 0
+		BuildPaletteOrder: 10
 		Prerequisites: fact, ~structures.allies, ~techlevel.low
 		Hotkey: b
 	Valued:
@@ -1302,7 +1302,7 @@ FENC:
 	Inherits: ^Wall
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 0
+		BuildPaletteOrder: 20
 		Prerequisites: fact, ~structures.soviet, ~techlevel.low
 		Hotkey: n
 	Valued:
@@ -1328,7 +1328,7 @@ BRIK:
 	Inherits: ^Wall
 	Buildable:
 		Queue: Defense
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 30
 		Prerequisites: fact, ~techlevel.medium
 		Hotkey: w
 	Valued:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -2,7 +2,7 @@ V2RL:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 80
 		Prerequisites: dome, ~vehicles.soviet, ~techlevel.medium
 		Hotkey: v
 	Valued:
@@ -31,7 +31,7 @@ V2RL:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 50
 		Prerequisites: ~vehicles.allies, ~techlevel.low
 		Hotkey: l
 	Valued:
@@ -70,7 +70,7 @@ V2RL:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 120
 		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
 		Hotkey: m
 	Valued:
@@ -112,7 +112,7 @@ V2RL:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 130
 		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
 		Hotkey: h
 	Valued:
@@ -154,7 +154,7 @@ V2RL:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 190
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
 		Hotkey: m
 	Valued:
@@ -210,7 +210,7 @@ ARTY:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 80
+		BuildPaletteOrder: 70
 		Prerequisites: dome, ~vehicles.allies, ~techlevel.medium
 		Hotkey: r
 	Valued:
@@ -286,7 +286,7 @@ MCV:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 110
+		BuildPaletteOrder: 90
 		Prerequisites: fix, ~techlevel.medium
 		Hotkey: b
 	CustomBuildTimeValue:
@@ -367,7 +367,7 @@ APC:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 40
 		Hotkey: c
 		Prerequisites: ~vehicles.soviet, ~techlevel.low
 	Valued:
@@ -403,7 +403,7 @@ MNLY.AP:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 100
 		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
 		Hotkey: i
 	Valued:
@@ -437,7 +437,7 @@ MNLY.AT:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 110
 		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
 		Hotkey: i
 	Valued:
@@ -471,7 +471,7 @@ TRUK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 120
+		BuildPaletteOrder: 20
 		Prerequisites: weap, ~techlevel.low
 		Hotkey: u
 	Valued:
@@ -567,7 +567,7 @@ TTNK:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 130
+		BuildPaletteOrder: 180
 		Prerequisites: tsla, stek, ~vehicles.soviet, ~techlevel.unrestricted
 		Hotkey: t
 	Valued:
@@ -602,7 +602,7 @@ FTRK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 60
 		Hotkey: k
 		Prerequisites: ~vehicles.soviet, ~techlevel.low
 	Valued:
@@ -642,7 +642,7 @@ DTRK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 140
+		BuildPaletteOrder: 170
 		Prerequisites: stek, ~vehicles.soviet, ~techlevel.unrestricted
 		Hotkey: o
 	Valued:
@@ -671,7 +671,7 @@ CTNK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 140
+		BuildPaletteOrder: 210
 		Prerequisites: atek, pdox, ~vehicles.allies, ~techlevel.unrestricted
 		Hotkey: j
 	Valued:
@@ -710,7 +710,7 @@ QTNK:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 150
+		BuildPaletteOrder: 200
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
 		Hotkey: q
 	Valued:
@@ -741,7 +741,7 @@ STNK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 170
+		BuildPaletteOrder: 140
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.unrestricted
 		Hotkey: p
 	Valued:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -403,7 +403,7 @@ MNLY.AP:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 110
 		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
 		Hotkey: i
 	Valued:
@@ -437,7 +437,7 @@ MNLY.AT:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 110
+		BuildPaletteOrder: 100
 		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
 		Hotkey: i
 	Valued:


### PR DESCRIPTION
This is the continuation of #5927. I reordered all tabs according to build prerequisites. If there are two elements of the same type, I put the allies first, e.g. allied barracks before soviet barracks. I also removed ambiguities of multiple elements in the same tab having the same order number, taking into account both factions.
