### PR TITLE
Custom Warheads refactor and DisabledByWarhead.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,6 +85,7 @@ Also thanks to:
     * Vladimir Komarov (VrKomarov)
     * Wuschel
     * Ian T. Jacobsen (Smilex)
+    * Shawn Collins (UberWaffe)
 
 Using Simple DirectMedia Layer distributed under
 the terms of the zlib license.

--- a/OpenRA.Game/GameRules/WarheadInfo.cs
+++ b/OpenRA.Game/GameRules/WarheadInfo.cs
@@ -27,12 +27,13 @@ namespace OpenRA.GameRules
 		int DelayTicks { get; }
 	}
 
+	[Desc("Base warhead class. This can be used to derive other warheads from.")]
 	public class BaseWarhead : IWarheadInfo
 	{
-		[Desc("What types of targets are affected.", "Diplomacy keywords: Ally, Neutral, Enemy")]
+		[Desc("What types of targets are affected.", "Diplomacy keywords: Ally, Neutral, Enemy","Actor keyword: Self")]
 		public readonly string[] ValidTargets = { "Air", "Ground", "Water", "Ally", "Neutral", "Enemy" };
 
-		[Desc("What types of targets are unaffected.", "Overrules ValidTargets.", "Diplomacy keywords: Ally, Neutral, Enemy")]
+		[Desc("What types of targets are unaffected.", "Overrules ValidTargets.", "Diplomacy keywords: Ally, Neutral, Enemy", "Actor keyword: Self")]
 		public readonly string[] InvalidTargets = { };
 
 		[Desc("Delay in ticks before applying the warhead effect.","0 = instant (old model).")]
@@ -100,12 +101,17 @@ namespace OpenRA.GameRules
 			if (!targetList.Intersect(targetable.GetTargetTypes()).Any())
 				return false;
 			
+			//Keywords checks
+			//Diplomacy
 			var stance = firedBy.Owner.Stances[victim.Owner];
 			if (targetList.Contains("Ally") && (stance == Stance.Ally))
 				return true;
 			if (targetList.Contains("Neutral") && (stance == Stance.Neutral))
 				return true;
 			if (targetList.Contains("Enemy") && (stance == Stance.Enemy))
+				return true;
+			//Check for self
+			if (targetList.Contains("Self") && (victim == firedBy))
 				return true;
 			return false;
 		}

--- a/OpenRA.Game/GameRules/WarheadInfo.cs
+++ b/OpenRA.Game/GameRules/WarheadInfo.cs
@@ -1,0 +1,121 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Effects;
+using OpenRA.Traits;
+
+namespace OpenRA.GameRules
+{
+	public interface IWarheadInfo
+	{
+		void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float modifier);
+		float EffectivenessAgainst(ActorInfo ai);
+		bool IsValidAgainst(Actor victim, Actor firedBy);
+		bool IsValidAgainst(FrozenActor victim, Actor firedBy);
+		bool IsValidAgainst(Target target, World world, Actor firedBy);
+		void LoadYaml(MiniYaml yaml);
+
+		int DelayTicks { get; }
+	}
+
+	public class BaseWarhead : IWarheadInfo
+	{
+		[Desc("What types of targets are affected.", "Diplomacy keywords: Ally, Neutral, Enemy")]
+		public readonly string[] ValidTargets = { "Air", "Ground", "Water", "Ally", "Neutral", "Enemy" };
+
+		[Desc("What types of targets are unaffected.", "Overrules ValidTargets.", "Diplomacy keywords: Ally, Neutral, Enemy")]
+		public readonly string[] InvalidTargets = { };
+
+		[Desc("Delay in ticks before applying the warhead effect.","0 = instant (old model).")]
+		public readonly int Delay = 0;
+
+		public BaseWarhead() { }
+
+		public void LoadYaml(MiniYaml yaml)
+		{
+			FieldLoader.Load(this, yaml);
+		}
+
+		public void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
+		{
+			Log.Write("debug", "A Warhead called the base warhead type. This shouldn't happen. Offending actor is {0}", firedBy.Info.Name);
+		}
+
+		public float EffectivenessAgainst(ActorInfo ai) { return 1f; }
+
+		public bool IsValidAgainst(Actor victim, Actor firedBy)
+		{
+			//A target type is valid if it is in the valid targets list, and not in the invalid targets list.
+			return CheckTargetList(victim, firedBy, this.ValidTargets) &&
+				!CheckTargetList(victim, firedBy, this.InvalidTargets);
+		}
+
+		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
+		{
+			return IsValidAgainst(victim.Actor, firedBy);
+		}
+
+		public bool IsValidAgainst(Target target, World world, Actor firedBy)
+		{
+			if (target.Type == TargetType.Actor)
+				return IsValidAgainst(target.Actor, firedBy);
+
+			if (target.Type == TargetType.FrozenActor)
+				return IsValidAgainst(target.FrozenActor, firedBy);
+
+			if (target.Type == TargetType.Terrain)
+			{
+				var cell = world.Map.CellContaining(target.CenterPosition);
+				if (!world.Map.Contains(cell))
+					return false;
+
+				var cellInfo = world.Map.GetTerrainInfo(cell);
+				if (!this.ValidTargets.Intersect(cellInfo.TargetTypes).Any()
+					|| this.InvalidTargets.Intersect(cellInfo.TargetTypes).Any())
+					return false;
+
+				return true;
+			}
+
+			return false;
+		}
+
+		public static bool CheckTargetList(Actor victim, Actor firedBy, string[] targetList)
+		{
+			if (targetList.Length < 1)
+				return false;
+
+			var targetable = victim.Info.Traits.GetOrDefault<ITargetableInfo>();
+			if (targetable == null)
+				return false;
+			if (!targetList.Intersect(targetable.GetTargetTypes()).Any())
+				return false;
+			
+			var stance = firedBy.Owner.Stances[victim.Owner];
+			if (targetList.Contains("Ally") && (stance == Stance.Ally))
+				return true;
+			if (targetList.Contains("Neutral") && (stance == Stance.Neutral))
+				return true;
+			if (targetList.Contains("Enemy") && (stance == Stance.Enemy))
+				return true;
+			return false;
+		}
+
+		public int DelayTicks
+		{
+			get
+			{
+				return this.Delay;
+			}
+		}
+   }
+}

--- a/OpenRA.Game/GameRules/Warheads/DamagerWarheadInfo.cs
+++ b/OpenRA.Game/GameRules/Warheads/DamagerWarheadInfo.cs
@@ -1,0 +1,207 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Effects;
+using OpenRA.Traits;
+
+namespace OpenRA.GameRules
+{
+	public enum DamageModel
+	{
+		Normal,								// classic RA damage model: point actors, distance-based falloff
+		PerCell,							// like RA's "nuke damage"
+		HealthPercentage,					// for MAD Tank
+		Absolute							// Specify absolute spread ranges with associated factors
+	}
+
+	public class DamagerWarheadInfo : BaseWarhead, IWarheadInfo
+	{
+		[Desc("For Normal DamageModel: Distance from the explosion center at which damage is 1/2.", "For Abolsute DamageModel: Maximum spread of the associated SpreadFactor.")]
+		public readonly WRange[] Spread = { new WRange(43) };
+
+		[Desc("What factor to multiply the Damage by for this spread range.", "Each factor specified must have an associated Spread defined.")]
+		public readonly float[] SpreadFactor = { 1f };
+
+		[Desc("Size of the area. Damage will be applied to this area.", "Used in PerCell and HealthPercentage damage models.")]
+		public readonly int Size = 0;
+
+		[FieldLoader.LoadUsing("LoadVersus")]
+		[Desc("Damage vs each armortype. 0% = can't target.")]
+		public readonly Dictionary<string, float> Versus;
+
+		[Desc("How much (raw) damage to deal")]
+		public readonly int Damage = 0;
+
+		[Desc("Which damage model to use.")]
+		public readonly DamageModel DamageModel = DamageModel.Normal;
+
+		[Desc("Infantry death animation to use")]
+		public readonly string InfDeath = "1";
+
+		[Desc("Whether we should prevent prone response for infantry.")]
+		public readonly bool PreventProne = false;
+
+		[Desc("By what percentage should damage be modified against prone infantry.")]
+		public readonly int ProneModifier = 50;
+
+		public DamagerWarheadInfo() : base() { }
+
+		static object LoadVersus(MiniYaml y)
+		{
+			var nd = y.ToDictionary();
+			return nd.ContainsKey("Versus")
+				? nd["Versus"].ToDictionary(my => FieldLoader.GetValue<float>("(value)", my.Value))
+				: new Dictionary<string, float>();
+		}
+
+		public new void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
+		{
+			var world = firedBy.World;
+			var targetTile = world.Map.CellContaining(pos);
+
+			switch (DamageModel)
+			{
+				case DamageModel.Normal:
+					{
+						var maxSpread = new WRange((int)(Spread[0].Range * (float)Math.Log(Math.Abs(Damage), 2)));
+						var hitActors = world.FindActorsInCircle(pos, maxSpread);
+
+						foreach (var victim in hitActors)
+						{
+							if (IsValidAgainst(victim, firedBy))
+							{
+								var damage = (int)GetDamageToInflict(pos, victim, firedBy, weapon, firepowerModifier, true);
+								victim.InflictDamage(firedBy, damage, this);
+							}
+						}
+					}
+					break;
+
+				case DamageModel.PerCell:
+					{
+						foreach (var t in world.Map.FindTilesInCircle(targetTile, Size))
+						{
+							foreach (var victim in world.ActorMap.GetUnitsAt(t))
+							{
+								if (IsValidAgainst(victim, firedBy))
+								{
+									var damage = (int)GetDamageToInflict(pos, victim, firedBy, weapon, firepowerModifier, false);
+									victim.InflictDamage(firedBy, damage, this);
+								}
+							}
+						}
+					}
+					break;
+
+				case DamageModel.HealthPercentage:
+					{
+						var range = new WRange(Size * 1024);
+						var hitActors = world.FindActorsInCircle(pos, range);
+
+						foreach (var victim in hitActors)
+						{
+							if (IsValidAgainst(victim, firedBy))
+							{
+								var damage = GetDamageToInflict(pos, victim, firedBy, weapon, firepowerModifier, false);
+								if (damage != 0) // will be 0 if the target doesn't have HealthInfo
+								{
+									var healthInfo = victim.Info.Traits.Get<HealthInfo>();
+									damage = (float)(damage / 100 * healthInfo.HP);
+								}
+
+								victim.InflictDamage(firedBy, (int)damage, this);
+							}
+						}
+					}
+					break;
+
+				case DamageModel.Absolute:
+					{
+						for (int i = 0; i < Spread.Length; i++)
+						{
+							var currentSpread = Spread[i];
+							var currentFactor = SpreadFactor[i];
+							var previousSpread = WRange.Zero;
+							if (i > 0)
+								previousSpread = Spread[i - 1];
+							if (currentFactor <= 0f)
+								continue;
+
+							var hitActors = world.FindActorsInCircle(pos, currentSpread);
+							if (previousSpread.Range > 0)
+								hitActors.Except(world.FindActorsInCircle(pos, previousSpread));
+
+							foreach (var victim in hitActors)
+							{
+								if (IsValidAgainst(victim, firedBy))
+								{
+									var damage = (int)GetDamageToInflict(pos, victim, firedBy, weapon, firepowerModifier * currentFactor, true);
+									victim.InflictDamage(firedBy, damage, this);
+								}
+							}
+						}
+					}
+					break;
+			}
+		}
+
+		public new float EffectivenessAgainst(ActorInfo ai)
+		{
+			var health = ai.Traits.GetOrDefault<HealthInfo>();
+			if (health == null)
+				return 0f;
+
+			var armor = ai.Traits.GetOrDefault<ArmorInfo>();
+			if (armor == null || armor.Type == null)
+				return 1;
+
+			float versus;
+			return Versus.TryGetValue(armor.Type, out versus) ? versus : 1;
+		}
+
+		public float GetDamageToInflict(WPos pos, Actor target, Actor firedBy, WeaponInfo weapon, float modifier, bool withFalloff)
+		{
+			// don't hit air units with splash from ground explosions, etc
+			if (!weapon.IsValidAgainst(target, firedBy))
+				return 0;
+
+			var healthInfo = target.Info.Traits.GetOrDefault<HealthInfo>();
+			if (healthInfo == null)
+				return 0;
+
+			var rawDamage = (float)Damage;
+			if (withFalloff)
+			{
+				var distance = Math.Max(0, (target.CenterPosition - pos).Length - healthInfo.Radius.Range);
+				var falloff = (float)GetDamageFalloff(distance * 1f / Spread[0].Range);
+				rawDamage = (float)(falloff * rawDamage);
+			}
+
+			return (float)(rawDamage * modifier * (float)EffectivenessAgainst(target.Info));
+		}
+
+		static readonly float[] falloff =
+		{
+			1f, 0.3678795f, 0.1353353f, 0.04978707f,
+			0.01831564f, 0.006737947f, 0.002478752f, 0.000911882f
+		};
+
+		static float GetDamageFalloff(float x)
+		{
+			var u = (int)x;
+			if (u >= falloff.Length - 1) return 0;
+			var t = x - u;
+			return (falloff[u] * (1 - t)) + (falloff[u + 1] * t);
+		}
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -75,6 +75,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Actor.cs" />
+    <Compile Include="GameRules\Warheads\DamagerWarheadInfo.cs" />
+    <Compile Include="GameRules\WarheadInfo.cs" />
     <Compile Include="Graphics\QuadRenderer.cs" />
     <Compile Include="Download.cs" />
     <Compile Include="Effects\DelayedAction.cs" />

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Traits
 					nd.AppliedDamage(repairer, self, ai);
 		}
 
-		public void InflictDamage(Actor self, Actor attacker, int damage, WarheadInfo warhead, bool ignoreModifiers)
+		public void InflictDamage(Actor self, Actor attacker, int damage, DamagerWarheadInfo warhead, bool ignoreModifiers)
 		{
 			if (IsDead) return;		/* overkill! don't count extra hits as more kills! */
 
@@ -177,7 +177,7 @@ namespace OpenRA.Traits
 			return (health == null) ? DamageState.Undamaged : health.DamageState;
 		}
 
-		public static void InflictDamage(this Actor self, Actor attacker, int damage, WarheadInfo warhead)
+		public static void InflictDamage(this Actor self, Actor attacker, int damage, DamagerWarheadInfo warhead)
 		{
 			if (self.Destroyed) return;
 			var health = self.TraitOrDefault<Health>();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Traits
 	public class AttackInfo
 	{
 		public Actor Attacker;
-		public WarheadInfo Warhead;
+		public DamagerWarheadInfo Warhead;
 		public int Damage;
 		public DamageState DamageState;
 		public DamageState PreviousDamageState;
@@ -147,7 +147,7 @@ namespace OpenRA.Traits
 	}
 
 	public interface IRenderModifier { IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r); }
-	public interface IDamageModifier { float GetDamageModifier(Actor attacker, WarheadInfo warhead); }
+	public interface IDamageModifier { float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead); }
 	public interface ISpeedModifier { decimal GetSpeedModifier(); }
 	public interface IFirepowerModifier { float GetFirepowerModifier(); }
 	public interface ILoadsPalettes { void LoadPalettes(WorldRenderer wr); }

--- a/OpenRA.Mods.Cnc/PoisonedByTiberium.cs
+++ b/OpenRA.Mods.Cnc/PoisonedByTiberium.cs
@@ -11,6 +11,7 @@
 using System.Linq;
 using OpenRA.Traits;
 using OpenRA.Mods.RA;
+using OpenRA.GameRules;
 
 namespace OpenRA.Mods.Cnc
 {
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Cnc
 
 			var weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()];
 
-			self.InflictDamage(self.World.WorldActor, weapon.Warheads[0].Damage, weapon.Warheads[0]);
+			self.InflictDamage(self.World.WorldActor, (weapon.Warheads.FirstOrDefault(w => (w is DamagerWarheadInfo)) as DamagerWarheadInfo).Damage, (weapon.Warheads.FirstOrDefault(w => (w is DamagerWarheadInfo)) as DamagerWarheadInfo));
 			poisonTicks = weapon.ROF;
 		}
 	}

--- a/OpenRA.Mods.D2k/DamagedWithoutFoundation.cs
+++ b/OpenRA.Mods.D2k/DamagedWithoutFoundation.cs
@@ -66,7 +66,8 @@ namespace OpenRA.Mods.D2k
 				return;
 
 			foreach (var w in weapon.Warheads)
-				health.InflictDamage(self, self.World.WorldActor, w.Damage, w, false);
+				if (w is DamagerWarheadInfo)
+					health.InflictDamage(self, self.World.WorldActor, (w as DamagerWarheadInfo).Damage, (w as DamagerWarheadInfo), false);
 
 			damageTicks = weapon.ROF;
 		}

--- a/OpenRA.Mods.RA/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.RA/AI/AttackOrFleeFuzzy.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AI.Fuzzy.Library;
 using OpenRA.Mods.RA.Move;
+using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.AI
@@ -195,8 +196,8 @@ namespace OpenRA.Mods.RA.AI
 				var sumOfDamage = 0;
 				var arms = a.TraitsImplementing<Armament>();
 				foreach (var arm in arms)
-					if (arm.Weapon.Warheads[0] != null)
-						sumOfDamage += arm.Weapon.Warheads[0].Damage;
+					if ((arm.Weapon.Warheads.FirstOrDefault(w => (w is DamagerWarheadInfo)) as DamagerWarheadInfo) != null)
+						sumOfDamage += (arm.Weapon.Warheads.FirstOrDefault(w => (w is DamagerWarheadInfo)) as DamagerWarheadInfo).Damage;
 				return sumOfDamage;
 			});
 		}

--- a/OpenRA.Mods.RA/Activities/Leap.cs
+++ b/OpenRA.Mods.RA/Activities/Leap.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.RA.Activities
 				mobile.IsMoving = false;
 
 				self.World.ActorMap.GetUnitsAt(mobile.toCell, mobile.toSubCell)
-					.Except(new []{self}).Where(t => weapon.IsValidAgainst(t))
+					.Except(new []{self}).Where(t => weapon.IsValidAgainst(t, self))
 					.Do(t => t.Kill(self));
 
 				return NextActivity;

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.RA
 			if (Weapon.MinRange != WRange.Zero && target.IsInRange(self.CenterPosition, Weapon.MinRange))
 				return null;
 
-			if (!Weapon.IsValidAgainst(target, self.World))
+			if (!Weapon.IsValidAgainst(target, self.World, self))
 				return null;
 
 			var barrel = Barrels[Burst % Barrels.Length];

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.GameRules;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Traits;
 
@@ -87,11 +88,11 @@ namespace OpenRA.Mods.RA
 		{
 			get
 			{
-				var armament = Armaments.FirstOrDefault();
+				var armament = Armaments.FirstOrDefault(a => a.Weapon.Warheads.Any(w => (w is DamagerWarheadInfo)));
 				if (armament == null)
 					yield break;
 
-				var negativeDamage = armament.Weapon.Warheads[0].Damage < 0;
+				var negativeDamage = (armament.Weapon.Warheads.FirstOrDefault(w => (w is DamagerWarheadInfo)) as DamagerWarheadInfo).Damage < 0;
 				yield return new AttackOrderTargeter(this, "Attack", 6, negativeDamage);
 			}
 		}
@@ -134,13 +135,13 @@ namespace OpenRA.Mods.RA
 
 		public abstract Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove);
 
-		public bool HasAnyValidWeapons(Target t) { return Armaments.Any(a => a.Weapon.IsValidAgainst(t, self.World)); }
+		public bool HasAnyValidWeapons(Target t) { return Armaments.Any(a => a.Weapon.IsValidAgainst(t, self.World, self)); }
 		public WRange GetMaximumRange()
 		{
 			return Armaments.Select(a => a.Weapon.Range).Append(WRange.Zero).Max();
 		}
 
-		public Armament ChooseArmamentForTarget(Target t) { return Armaments.FirstOrDefault(a => a.Weapon.IsValidAgainst(t, self.World)); }
+		public Armament ChooseArmamentForTarget(Target t) { return Armaments.FirstOrDefault(a => a.Weapon.IsValidAgainst(t, self.World, self)); }
 
 		public void AttackTarget(Target target, bool queued, bool allowMove)
 		{

--- a/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
@@ -22,12 +22,17 @@ namespace OpenRA.Mods.RA
 		[Desc("How many game ticks should pass before closing the actor's turret.")]
 		public int CloseDelay = 125;
 		public int DefaultFacing = 0;
+
+		[Desc("The factor damage received is multiplied by while this actor is closed.")]
 		public float ClosedDamageMultiplier = 0.5f;
+
+		[Desc("The factor disableticks is multiplied by while this actor is closed.")]
+		public float ClosedDisableTicksMultiplier = 1f;
 
 		public override object Create(ActorInitializer init) { return new AttackPopupTurreted(init, this); }
 	}
 
-	class AttackPopupTurreted : AttackTurreted, INotifyBuildComplete, INotifyIdle, IDamageModifier
+	class AttackPopupTurreted : AttackTurreted, INotifyBuildComplete, INotifyIdle, IDamageModifier, IDisableTicksModifier
 	{
 		enum PopupState { Open, Rotating, Transitioning, Closed }
 
@@ -103,9 +108,14 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead)
 		{
 			return state == PopupState.Closed ? info.ClosedDamageMultiplier : 1f;
+		}
+
+		public float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead)
+		{
+			return state == PopupState.Closed ? info.ClosedDisableTicksMultiplier : 1f;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Combat.cs
+++ b/OpenRA.Mods.RA/Combat.cs
@@ -13,170 +13,23 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
-using OpenRA.Mods.RA.Effects;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
 	// some utility bits that are shared between various things
+	// TODO: Investigate the impact of moving this to WeaponInfo. Currently some crate actions also call DoExplosion.
 	public static class Combat
 	{
-		static string GetImpactSound(WarheadInfo warhead, bool isWater)
-		{
-			if (isWater && warhead.WaterImpactSound != null)
-				return warhead.WaterImpactSound;
-
-			if (warhead.ImpactSound != null)
-				return warhead.ImpactSound;
-
-			return null;
-		}
-
-		public static void DoImpact(WPos pos, WarheadInfo warhead, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
-		{
-			var world = firedBy.World;
-			var targetTile = world.Map.CellContaining(pos);
-
-			if (!world.Map.Contains(targetTile))
-				return;
-
-			var isWater = pos.Z <= 0 && world.Map.GetTerrainInfo(targetTile).IsWater;
-			var explosionType = isWater ? warhead.WaterExplosion : warhead.Explosion;
-			var explosionTypePalette = isWater ? warhead.WaterExplosionPalette : warhead.ExplosionPalette;
-
-			if (explosionType != null)
-				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, explosionType, explosionTypePalette)));
-
-			Sound.Play(GetImpactSound(warhead, isWater), pos);
-
-			var smudgeLayers = world.WorldActor.TraitsImplementing<SmudgeLayer>().ToDictionary(x => x.Info.Type);
-			var resLayer = warhead.DestroyResources || !string.IsNullOrEmpty(warhead.AddsResourceType) ? world.WorldActor.Trait<ResourceLayer>() : null;
-
-			if (warhead.Size[0] > 0)
-			{
-				var allCells = world.Map.FindTilesInCircle(targetTile, warhead.Size[0]).ToList();
-
-				// `smudgeCells` might want to just be an outer shell of the cells:
-				IEnumerable<CPos> smudgeCells = allCells;
-				if (warhead.Size.Length == 2)
-					smudgeCells = smudgeCells.Except(world.Map.FindTilesInCircle(targetTile, warhead.Size[1]));
-
-				// Draw the smudges:
-				foreach (var sc in smudgeCells)
-				{
-					var smudgeType = world.Map.GetTerrainInfo(sc).AcceptsSmudgeType.FirstOrDefault(t => warhead.SmudgeType.Contains(t));
-					if (smudgeType == null) continue;
-
-					SmudgeLayer smudgeLayer;
-					if (!smudgeLayers.TryGetValue(smudgeType, out smudgeLayer))
-						throw new NotImplementedException("Unknown smudge type `{0}`".F(smudgeType));
-
-					smudgeLayer.AddSmudge(sc);
-					if (warhead.DestroyResources)
-						resLayer.Destroy(sc);
-				}
-
-				// Destroy all resources in range, not just the outer shell:
-				if (warhead.DestroyResources)
-					foreach (var cell in allCells)
-						resLayer.Destroy(cell);
-
-				// Splatter resources:
-				if (!string.IsNullOrEmpty(warhead.AddsResourceType))
-				{
-					var resourceType = world.WorldActor.TraitsImplementing<ResourceType>()
-						.FirstOrDefault(t => t.Info.Name == warhead.AddsResourceType);
-
-					if (resourceType == null)
-						Log.Write("debug", "Warhead defines an invalid resource type '{0}'".F(warhead.AddsResourceType));
-					else
-					{
-						foreach (var cell in allCells)
-						{
-							if (!resLayer.CanSpawnResourceAt(resourceType, cell))
-								continue;
-
-							var splash = world.SharedRandom.Next(1, resourceType.Info.MaxDensity - resLayer.GetResourceDensity(cell));
-							resLayer.AddResource(resourceType, cell, splash);
-						}
-					}
-				}
-			}
-			else
-			{
-				var smudgeType = world.Map.GetTerrainInfo(targetTile).AcceptsSmudgeType.FirstOrDefault(t => warhead.SmudgeType.Contains(t));
-				if (smudgeType != null)
-				{
-					SmudgeLayer smudgeLayer;
-					if (!smudgeLayers.TryGetValue(smudgeType, out smudgeLayer))
-						throw new NotImplementedException("Unknown smudge type `{0}`".F(smudgeType));
-
-					smudgeLayer.AddSmudge(targetTile);
-				}
-			}
-
-			if (warhead.DestroyResources)
-				world.WorldActor.Trait<ResourceLayer>().Destroy(targetTile);
-
-			switch (warhead.DamageModel)
-			{
-				case DamageModel.Normal:
-					{
-						var maxSpread = new WRange((int)(warhead.Spread.Range * (float)Math.Log(Math.Abs(warhead.Damage), 2)));
-						var hitActors = world.FindActorsInCircle(pos, maxSpread);
-
-						foreach (var victim in hitActors)
-						{
-							var damage = (int)GetDamageToInflict(pos, victim, warhead, weapon, firepowerModifier, true);
-							victim.InflictDamage(firedBy, damage, warhead);
-						}
-					}
-					break;
-
-				case DamageModel.PerCell:
-					{
-						foreach (var t in world.Map.FindTilesInCircle(targetTile, warhead.Size[0]))
-						{
-							foreach (var unit in world.ActorMap.GetUnitsAt(t))
-							{
-								var damage = (int)GetDamageToInflict(pos, unit, warhead, weapon, firepowerModifier, false);
-								unit.InflictDamage(firedBy, damage, warhead);
-							}
-						}
-					}
-					break;
-
-				case DamageModel.HealthPercentage:
-					{
-						var range = new WRange(warhead.Size[0] * 1024);
-						var hitActors = world.FindActorsInCircle(pos, range);
-
-						foreach (var victim in hitActors)
-						{
-							var damage = GetDamageToInflict(pos, victim, warhead, weapon, firepowerModifier, false);
-							if (damage != 0) // will be 0 if the target doesn't have HealthInfo
-							{
-								var healthInfo = victim.Info.Traits.Get<HealthInfo>();
-								damage = (float)(damage / 100 * healthInfo.HP);
-							}
-
-							victim.InflictDamage(firedBy, (int)damage, warhead);
-						}
-					}
-					break;
-			}
-		}
-
 		public static void DoImpacts(WPos pos, Actor firedBy, WeaponInfo weapon, float damageModifier)
 		{
 			foreach (var wh in weapon.Warheads)
 			{
-				var warhead = wh;
-				Action a = () => DoImpact(pos, warhead, weapon, firedBy, damageModifier);
+				Action a;
 
-				if (warhead.Delay > 0)
+				a = () => wh.DoImpact(pos, weapon, firedBy, damageModifier);
+				if (wh.DelayTicks > 0)
 					firedBy.World.AddFrameEndTask(
-						w => w.Add(new DelayedAction(warhead.Delay, a)));
+						w => w.Add(new DelayedAction(wh.DelayTicks, a)));
 				else
 					a();
 			}
@@ -189,41 +42,6 @@ namespace OpenRA.Mods.RA
 				Sound.Play(weapon.Report.Random(attacker.World.SharedRandom), pos);
 
 			DoImpacts(pos, attacker, weapon, 1f);
-		}
-
-		static readonly float[] falloff =
-		{
-			1f, 0.3678795f, 0.1353353f, 0.04978707f,
-			0.01831564f, 0.006737947f, 0.002478752f, 0.000911882f
-		};
-
-		static float GetDamageFalloff(float x)
-		{
-			var u = (int)x;
-			if (u >= falloff.Length - 1) return 0;
-			var t = x - u;
-			return (falloff[u] * (1 - t)) + (falloff[u + 1] * t);
-		}
-
-		static float GetDamageToInflict(WPos pos, Actor target, WarheadInfo warhead, WeaponInfo weapon, float modifier, bool withFalloff)
-		{
-			// don't hit air units with splash from ground explosions, etc
-			if (!weapon.IsValidAgainst(target))
-				return 0;
-
-			var healthInfo = target.Info.Traits.GetOrDefault<HealthInfo>();
-			if (healthInfo == null)
-				return 0;
-
-			var rawDamage = (float)warhead.Damage;
-			if (withFalloff)
-			{
-				var distance = Math.Max(0, (target.CenterPosition - pos).Length - healthInfo.Radius.Range);
-				var falloff = (float)GetDamageFalloff(distance * 1f / warhead.Spread.Range);
-				rawDamage = (float)(falloff * rawDamage);
-			}
-
-			return (float)(rawDamage * modifier * (float)warhead.EffectivenessAgainst(target.Info));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/DisableArmor.cs
+++ b/OpenRA.Mods.RA/DisableArmor.cs
@@ -8,17 +8,15 @@
  */
 #endregion
 
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	[Desc("This unit cannot be damaged.")]
-	class InvulnerableInfo : TraitInfo<Invulnerable> { }
-
-	class Invulnerable : IDamageModifier, IDisableTicksModifier
+	public class DisableArmorInfo : TraitInfo<DisableArmor>
 	{
-		public float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead) { return 0.0f; }
-		public float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead) { return 0.0f; }
+		public readonly string Type = null;
 	}
+
+	public class DisableArmor { }
 }
+

--- a/OpenRA.Mods.RA/DisabledByWarhead.cs
+++ b/OpenRA.Mods.RA/DisabledByWarhead.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using System.Drawing;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("Allows the actor to be temporarily disabled by certain warhead types.")]
+	class DisabledByWarheadInfo : ITraitInfo
+	{
+		[Desc("The hitbox radius of the actor. A DisablerWarhead impact must touch this hitbox in order to affect the actor.")]
+		public readonly WRange Radius = new WRange(426);
+
+		[Desc("What types does this actor count as.", "Diplomacy keywords: Ally, Neutral, Enemy")]
+		public readonly string[] TargetTypes = { "EMP", "Ally", "Neutral", "Enemy" };
+
+		public object Create(ActorInitializer init) { return new DisabledByWarhead(init.self, this); }
+	}
+
+
+	class DisabledByWarhead : BaseWarhead, IWarheadInfo, IDisable, ISelectionBar, ITick, ISync
+	{
+		[Sync] int remainingTicks;
+		[Sync] bool disabled = false;
+		public DisabledByWarheadInfo Info;
+
+		public DisabledByWarhead(Actor self, DisabledByWarheadInfo info)
+		{
+			Info = info;
+		}
+
+		public bool Disabled { get { return disabled; } }
+
+		public void Tick(Actor self)
+		{
+			if (disabled)
+			{
+				disabled = (--remainingTicks > 0);
+				if (!disabled)
+					foreach (var nd in self.TraitsImplementing<INotifyDisabledByWarheadState>())
+						nd.DisabledByWarheadStateChanged(self, false);
+			}
+		}
+
+		public void SufferDisableImpact(Actor self, Actor attacker, int ticksLength)
+		{
+			if ((ticksLength > 0) &&
+				(ticksLength > remainingTicks))
+			{
+				remainingTicks = ticksLength;
+				disabled = true;
+
+				foreach (var nd in self.TraitsImplementing<INotifyDisabledByWarheadState>())
+					nd.DisabledByWarheadStateChanged(self, true);
+			}
+		}
+
+		public Color GetColor() { return Color.Blue; }
+		public float GetValue() { return .0f; }
+	}
+}

--- a/OpenRA.Mods.RA/DisabledByWarhead.cs
+++ b/OpenRA.Mods.RA/DisabledByWarhead.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Mods.RA
 		[Desc("The hitbox radius of the actor. A DisablerWarhead impact must touch this hitbox in order to affect the actor.")]
 		public readonly WRange Radius = new WRange(426);
 
-		[Desc("What types does this actor count as.", "Diplomacy keywords: Ally, Neutral, Enemy")]
-		public readonly string[] TargetTypes = { "EMP", "Ally", "Neutral", "Enemy" };
+		[Desc("What types does this actor count as.")]
+		public readonly string[] TargetTypes = { "EMP" };
 
 		public object Create(ActorInitializer init) { return new DisabledByWarhead(init.self, this); }
 	}

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -20,15 +20,24 @@ namespace OpenRA.Mods.RA
 	{
 		[Desc("XP requirements for each level, as multiples of our own cost.")]
 		public readonly float[] CostThreshold = { 2, 4, 8, 16 };
+
+		[Desc("Effect of this actor's warheads is multiplied by these amounts, if level > 0.")]
 		public readonly float[] FirepowerModifier = { 1.1f, 1.15f, 1.2f, 1.5f };
+
+		[Desc("Damage received from DamagerWarheads is multiplied by these amounts, if level > 0.")]
 		public readonly float[] ArmorModifier = { 1.1f, 1.2f, 1.3f, 1.5f };
+
+		[Desc("DisableTicks received from DisablerWarheads is multiplied by these amounts, if level > 0.")]
+		public readonly float[] DisableTicksModifier = { 1.1f, 1.2f, 1.3f, 1.5f };
+
+		[Desc("This actor's movement speed is multiplied by these amounts, if level > 0.")]
 		public readonly decimal[] SpeedModifier = { 1.1m, 1.15m, 1.2m, 1.5m };
 		public readonly string ChevronPalette = "effect";
 		public readonly string LevelUpPalette = "effect";
 		public object Create(ActorInitializer init) { return new GainsExperience(init, this); }
 	}
 
-	public class GainsExperience : IFirepowerModifier, ISpeedModifier, IDamageModifier, ISync
+	public class GainsExperience : IFirepowerModifier, ISpeedModifier, IDamageModifier, ISync, IDisableTicksModifier
 	{
 		readonly Actor self;
 		readonly int[] levels;
@@ -82,9 +91,14 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead)
 		{
 			return Level > 0 ? 1 / info.ArmorModifier[Level - 1] : 1;
+		}
+
+		public float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead)
+		{
+			return Level > 0 ? 1 / info.DisableTicksModifier[Level - 1] : 1;
 		}
 
 		public float GetFirepowerModifier()

--- a/OpenRA.Mods.RA/GainsUnitUpgrades.cs
+++ b/OpenRA.Mods.RA/GainsUnitUpgrades.cs
@@ -17,23 +17,41 @@ namespace OpenRA.Mods.RA
 	[Desc("This actor has properties that upgrade when a specific criteria is met.")]
 	public class GainsUnitUpgradesInfo : ITraitInfo
 	{
+		[Desc("The maximum upgrade level for firepower.")]
 		public readonly int FirepowerMaxLevel = 15;
+
+		[Desc("The boost to firepower per upgrade level.")]
 		public readonly float FirepowerModifier = .2f;
+
+		[Desc("The maximum upgrade level for armor.")]
 		public readonly int ArmorMaxLevel = 15;
+
+		[Desc("The boost to armor per upgrade level.")]
 		public readonly float ArmorModifier = .2f;
+
+		[Desc("The maximum upgrade level for disable armor.")]
+		public readonly int DisableArmorMaxLevel = 15;
+
+		[Desc("The boost to disable armor per upgrade level.")]
+		public readonly float DisableArmorModifier = .2f;
+
+		[Desc("The maximum upgrade level for speed.")]
 		public readonly int SpeedMaxLevel = 15;
+
+		[Desc("The boost to speed per upgrade level.")]
 		public readonly decimal SpeedModifier = .2m;
 		// TODO: weapon range, rate of fire modifiers. potentially a vision modifier.
 
 		public object Create(ActorInitializer init) { return new GainsUnitUpgrades(this); }
 	}
 
-	public class GainsUnitUpgrades : IFirepowerModifier, IDamageModifier, ISpeedModifier
+	public class GainsUnitUpgrades : IFirepowerModifier, IDamageModifier, ISpeedModifier, IDisableTicksModifier
 	{
 		GainsUnitUpgradesInfo info;
 		[Sync] public int FirepowerLevel = 0;
 		[Sync] public int SpeedLevel = 0;
 		[Sync] public int ArmorLevel = 0;
+		[Sync] public int DisableArmorLevel = 0;
 
 		public GainsUnitUpgrades(GainsUnitUpgradesInfo info)
 		{
@@ -67,9 +85,14 @@ namespace OpenRA.Mods.RA
 			return FirepowerLevel > 0 ? (1 + FirepowerLevel * info.FirepowerModifier) : 1;
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead)
 		{
 			return ArmorLevel > 0 ? (1 / (1 + ArmorLevel * info.ArmorModifier)) : 1;
+		}
+
+		public float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead)
+		{
+			return DisableArmorLevel > 0 ? (1 / (1 + DisableArmorLevel * info.DisableArmorModifier)) : 1;
 		}
 
 		public decimal GetSpeedModifier()

--- a/OpenRA.Mods.RA/IronCurtainable.cs
+++ b/OpenRA.Mods.RA/IronCurtainable.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA
 {
 	class IronCurtainableInfo : TraitInfo<IronCurtainable> { }
 
-	class IronCurtainable : IDamageModifier, ITick, ISync, ISelectionBar
+	class IronCurtainable : IDamageModifier, ITick, ISync, ISelectionBar, IDisableTicksModifier
 	{
 		[Sync] int RemainingTicks = 0;
 		int TotalTicks;
@@ -28,7 +28,12 @@ namespace OpenRA.Mods.RA
 				RemainingTicks--;
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead)
+		{
+			return (RemainingTicks > 0) ? 0.0f : 1.0f;
+		}
+
+		public float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead)
 		{
 			return (RemainingTicks > 0) ? 0.0f : 1.0f;
 		}

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -478,6 +478,9 @@ namespace OpenRA.Mods.RA.Move
 				return 0;
 
 			speed *= Info.Speed;
+			var disabled = self.TraitsImplementing<IDisable>().Any(d => d.Disabled);
+			speed = disabled ? 0 : speed;
+
 			foreach (var t in self.TraitsImplementing<ISpeedModifier>())
 				speed *= t.GetSpeedModifier();
 			return (int)(speed / 100);

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -117,6 +117,8 @@
     <Compile Include="Air\Aircraft.cs" />
     <Compile Include="Air\AttackHeli.cs" />
     <Compile Include="Air\AttackPlane.cs" />
+    <Compile Include="DisableArmor.cs" />
+    <Compile Include="DisabledByWarhead.cs" />
     <Compile Include="Effects\Beacon.cs" />
     <Compile Include="Player\PlaceBeacon.cs" />
     <Compile Include="MenuPaletteEffect.cs" />
@@ -287,6 +289,11 @@
     <Compile Include="Player\ProductionQueue.cs" />
     <Compile Include="Player\ProvidesTechPrerequisite.cs" />
     <Compile Include="PortableChrono.cs" />
+    <Compile Include="Render\WithDisabledOverlay.cs" />
+    <Compile Include="Warheads\DisablerWarheadInfo.cs" />
+    <Compile Include="Warheads\EffectCreatorWarheadInfo.cs" />
+    <Compile Include="Warheads\ResourcerWarheadInfo.cs" />
+    <Compile Include="Warheads\SmudgerWarheadInfo.cs" />
     <Compile Include="World\RadarPings.cs" />
     <Compile Include="Player\TechTree.cs" />
     <Compile Include="PrimaryBuilding.cs" />

--- a/OpenRA.Mods.RA/Render/WithDisabledOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithDisabledOverlay.cs
@@ -1,0 +1,76 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using System.Collections.Generic;
+using OpenRA.Graphics;
+using OpenRA.Mods.RA.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("Use together with DisabledByWarhead to render an overlay.", "Ex: EMP Sparkle Overlay")]
+	public class WithDisabledOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	{
+		[Desc("The name of the sequence to play","Needs 2 sub-sequences. A \"loop\" and an \"end\" sub-sequence.")]
+		public readonly string Sequence = "smoke_m";
+
+		[Desc("Position relative to body")]
+		public readonly int zOffset = 10;
+
+		public object Create(ActorInitializer init) { return new WithDisabledOverlay(init.self, this); }
+	}
+
+	public class WithDisabledOverlay : IRenderModifier, INotifyDisabledByWarheadState
+	{
+		bool isShowingDisabled;
+		Animation anim;
+
+		public WithDisabledOverlay(Actor self, WithDisabledOverlayInfo info)
+		{
+			var rs = self.Trait<RenderSprites>();
+
+			anim = new Animation(self.World, info.Sequence);
+			rs.Add("sparks", new AnimationWithOffset(anim, null, () => !isShowingDisabled, info.zOffset));
+		}
+
+		public void DisabledByWarheadStateChanged(Actor self, bool isNowDisabled)
+		{
+			if (!isNowDisabled)
+			{
+				if (isShowingDisabled)
+					anim.PlayThen("end", () => isShowingDisabled = false);
+				return;
+			}
+
+			if (isShowingDisabled) return;
+
+			isShowingDisabled = true;
+			anim.PlayRepeating("loop");
+		}
+
+		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
+			var disablerTrait = self.TraitOrDefault<DisabledByWarhead>();
+			var disabled = disablerTrait.Disabled;
+
+			foreach (var a in r)
+			{
+				yield return a;
+				if (disabled && !a.IsDecoration)
+				{
+					yield return a.WithPalette(wr.Palette("disabled"))
+						.WithZOffset(a.ZOffset + 1)
+						.AsDecoration();
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Scripting/ScriptInvulnerable.cs
+++ b/OpenRA.Mods.RA/Scripting/ScriptInvulnerable.cs
@@ -16,11 +16,16 @@ namespace OpenRA.Mods.RA
 	[Desc("Allows map scripts to make this actor invulnerable via actor.Invulnerable = true.")]
 	class ScriptInvulnerableInfo : TraitInfo<ScriptInvulnerable> {}
 
-	class ScriptInvulnerable : IDamageModifier
+	class ScriptInvulnerable : IDamageModifier, IDisableTicksModifier
 	{
 		public bool Invulnerable = false;
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead)
+		{
+			return Invulnerable ? 0.0f : 1.0f;
+		}
+
+		public float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead)
 		{
 			return Invulnerable ? 0.0f : 1.0f;
 		}

--- a/OpenRA.Mods.RA/TakeCover.cs
+++ b/OpenRA.Mods.RA/TakeCover.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA
 	}
 
 	// Infantry prone behavior
-	public class TakeCover : Turreted, ITick, INotifyDamage, IDamageModifier, ISpeedModifier, ISync
+	public class TakeCover : Turreted, ITick, INotifyDamage, IDamageModifier, ISpeedModifier, ISync, IDisableTicksModifier
 	{
 		TakeCoverInfo Info;
 		[Sync] int remainingProneTime = 0;
@@ -61,7 +61,12 @@ namespace OpenRA.Mods.RA
 				LocalOffset = WVec.Zero;
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public float GetDamageModifier(Actor attacker, DamagerWarheadInfo warhead)
+		{
+			return IsProne && warhead != null ? warhead.ProneModifier / 100f : 1f;
+		}
+
+		public float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead)
 		{
 			return IsProne && warhead != null ? warhead.ProneModifier / 100f : 1f;
 		}

--- a/OpenRA.Mods.RA/TraitsInterfaces.cs
+++ b/OpenRA.Mods.RA/TraitsInterfaces.cs
@@ -50,4 +50,7 @@ namespace OpenRA.Mods.RA
 	public interface INotifyTransform { void BeforeTransform(Actor self); void OnTransform(Actor self); void AfterTransform(Actor toActor); }
 	public interface INotifyAttack { void Attacking(Actor self, Target target, Armament a, Barrel barrel); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
+
+	public interface IDisableTicksModifier { float GetDisableTicksModifier(Actor attacker, DisablerWarheadInfo warhead); }
+	public interface INotifyDisabledByWarheadState { void DisabledByWarheadStateChanged(Actor self, bool isNowDisabled); }
 }

--- a/OpenRA.Mods.RA/Warheads/DisablerWarheadInfo.cs
+++ b/OpenRA.Mods.RA/Warheads/DisablerWarheadInfo.cs
@@ -1,0 +1,129 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class DisablerWarheadInfo : BaseWarhead, IWarheadInfo
+	{
+		[Desc("Ranges from the point-of-impact within which actors will be affected by the warhead.","Each range specified must have an associated SpreadFactor defined.","Must be shortest range to longest.")]
+		public readonly WRange[] Spread = { new WRange(43) };
+
+		[Desc("What factor to multiply the DisableTicks by for this spread range.", "Each factor specified must have an associated Spread defined.")]
+		public readonly float[] SpreadFactor = { 1f };
+
+		[FieldLoader.LoadUsing("LoadVersus")]
+		[Desc("Damage vs each disablearmortype. 0% = can't target.")]
+		public readonly Dictionary<string, float> Versus;
+
+		[Desc("The raw number of ticks this warhead disabled targets for.")]
+		public readonly int DisableTicks = 25;
+
+		[Desc("By what percentage should disable ticks be modified against prone infantry.")]
+		public readonly int ProneModifier = 100;
+
+		public DisablerWarheadInfo() : base() { }
+
+		static object LoadVersus(MiniYaml y)
+		{
+			var nd = y.ToDictionary();
+			return nd.ContainsKey("Versus")
+				? nd["Versus"].ToDictionary(my => FieldLoader.GetValue<float>("(value)", my.Value))
+				: new Dictionary<string, float>();
+		}
+
+		public new void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
+		{
+			var world = firedBy.World;
+			var targetTile = world.Map.CellContaining(pos);
+
+			for (int i = 0; i < Spread.Length; i++)
+			{
+				var currentSpread = Spread[i];
+				var currentFactor = SpreadFactor[i];
+				var previousSpread = WRange.Zero;
+				if (i > 0)
+					previousSpread = Spread[i - 1];
+
+				var hitActors = world.FindActorsInCircle(pos, currentSpread);
+				if (previousSpread.Range > 0)
+					hitActors.Except(world.FindActorsInCircle(pos, previousSpread));
+
+				foreach (var victim in hitActors)
+				{
+					var disablerTrait = victim.TraitOrDefault<DisabledByWarhead>();
+					if (disablerTrait == null)
+						continue;
+
+					if (IsValidAgainst(victim, firedBy))
+					{
+						var modifier = victim.TraitsImplementing<IDisableTicksModifier>()
+							.Concat(victim.Owner.PlayerActor.TraitsImplementing<IDisableTicksModifier>())
+							.Select(t => t.GetDisableTicksModifier(firedBy, this)).Product();
+
+						var ticksLength = (int)((float)DisableTicks * modifier * (float)EffectivenessAgainst(victim.Info));
+						disablerTrait.SufferDisableImpact(victim, firedBy, ticksLength);
+					}
+				}
+			}
+		}
+
+		public new float EffectivenessAgainst(ActorInfo ai)
+		{
+			var disabledByTrait = ai.Traits.GetOrDefault<DisabledByWarheadInfo>();
+			if (disabledByTrait == null)
+				return 0f;
+
+			var armor = ai.Traits.GetOrDefault<DisableArmorInfo>();
+			if (armor == null || armor.Type == null)
+				return 1;
+
+			float versus;
+			return Versus.TryGetValue(armor.Type, out versus) ? versus : 1;
+		}
+
+		public new bool IsValidAgainst(Actor victim, Actor firedBy)
+		{
+			var disablerTrait = victim.TraitOrDefault<DisabledByWarhead>();
+			if (disablerTrait == null)
+				return false;
+
+			//A target type is valid if it is in the valid targets list, and not in the invalid targets list.
+			return CheckTargetList(victim, firedBy, this.ValidTargets) &&
+				!CheckTargetList(victim, firedBy, this.InvalidTargets);
+		}
+
+		public new static bool CheckTargetList(Actor victim, Actor firedBy, string[] targetList)
+		{
+			if (targetList.Length < 1)
+				return false;
+
+			var targetable = victim.Info.Traits.GetOrDefault<DisabledByWarheadInfo>();
+			if (targetable == null)
+				return false;
+			if (!targetList.Intersect(targetable.TargetTypes).Any())
+				return false;
+
+			var stance = firedBy.Owner.Stances[victim.Owner];
+			if (targetList.Contains("Ally") && (stance == Stance.Ally))
+				return true;
+			if (targetList.Contains("Neutral") && (stance == Stance.Neutral))
+				return true;
+			if (targetList.Contains("Enemy") && (stance == Stance.Enemy))
+				return true;
+			return false;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Warheads/DisablerWarheadInfo.cs
+++ b/OpenRA.Mods.RA/Warheads/DisablerWarheadInfo.cs
@@ -47,7 +47,6 @@ namespace OpenRA.Mods.RA
 		public new void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
 		{
 			var world = firedBy.World;
-			var targetTile = world.Map.CellContaining(pos);
 
 			for (int i = 0; i < Spread.Length; i++)
 			{
@@ -73,7 +72,7 @@ namespace OpenRA.Mods.RA
 							.Concat(victim.Owner.PlayerActor.TraitsImplementing<IDisableTicksModifier>())
 							.Select(t => t.GetDisableTicksModifier(firedBy, this)).Product();
 
-						var ticksLength = (int)((float)DisableTicks * modifier * (float)EffectivenessAgainst(victim.Info));
+						var ticksLength = (int)((float)DisableTicks * modifier * currentFactor * (float)EffectivenessAgainst(victim.Info));
 						disablerTrait.SufferDisableImpact(victim, firedBy, ticksLength);
 					}
 				}

--- a/OpenRA.Mods.RA/Warheads/EffectCreatorWarheadInfo.cs
+++ b/OpenRA.Mods.RA/Warheads/EffectCreatorWarheadInfo.cs
@@ -1,0 +1,95 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Effects;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+using OpenRA.Mods.RA.Effects;
+
+namespace OpenRA.Mods.RA
+{
+	public class EffectCreatorWarheadInfo : BaseWarhead, IWarheadInfo
+	{
+		[Desc("Size of the area. An explosion animation will be created in each tile.", "Provide 2 values for a ring effect (outer/inner).")]
+		public readonly int[] Size = { 0, 0 };
+
+		[Desc("Explosion effect to use.")]
+		public readonly string Explosion = null;
+
+		[Desc("Palette to use for explosion effect.")]
+		public readonly string ExplosionPalette = "effect";
+
+		[Desc("Explosion effect on hitting water (usually a splash).")]
+		public readonly string WaterExplosion = null;
+
+		[Desc("Palette to use for effect on hitting water (usually a splash).")]
+		public readonly string WaterExplosionPalette = "effect";
+
+		[Desc("Sound to play on impact.")]
+		public readonly string ImpactSound = null;
+
+		[Desc("Sound to play on impact with water")]
+		public readonly string WaterImpactSound = null;
+
+		public EffectCreatorWarheadInfo() : base() { }
+
+		public new void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
+		{
+			var world = firedBy.World;
+			var targetTile = world.Map.CellContaining(pos);
+
+			if (!world.Map.Contains(targetTile))
+				return;
+
+			if (Size[0] > 0)
+			{
+				var allCells = world.Map.FindTilesInCircle(targetTile, Size[0]).ToList();
+				// `deltaCells` might want to just be an outer shell of the cells:
+				IEnumerable<CPos> deltaCells = allCells;
+				if (Size.Length == 2)
+					deltaCells = deltaCells.Except(world.Map.FindTilesInCircle(targetTile, Size[1]));
+
+				// Draw the effects
+				foreach (var currentCell in deltaCells)
+				{
+					var currentPos = world.Map.CenterOfCell(currentCell);
+					var isWater = currentPos.Z <= 0 && world.Map.GetTerrainInfo(currentCell).IsWater;
+					var explosionType = isWater ? WaterExplosion : Explosion;
+					var explosionTypePalette = isWater ? WaterExplosionPalette : ExplosionPalette;
+
+					if (explosionType != null)
+						world.AddFrameEndTask(w => w.Add(new Explosion(w, currentPos, explosionType, explosionTypePalette)));
+				}
+			}
+			else
+			{
+				var isWater = pos.Z <= 0 && world.Map.GetTerrainInfo(targetTile).IsWater;
+				var explosionType = isWater ? WaterExplosion : Explosion;
+				var explosionTypePalette = isWater ? WaterExplosionPalette : ExplosionPalette;
+
+				if (explosionType != null)
+					world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, explosionType, explosionTypePalette)));
+			}
+
+			string sound = null;
+
+			var isTargetWater = pos.Z <= 0 && world.Map.GetTerrainInfo(targetTile).IsWater;
+			if (isTargetWater && WaterImpactSound != null)
+				sound = WaterImpactSound;
+
+			if (ImpactSound != null)
+				sound = ImpactSound;
+
+			Sound.Play(sound, pos);
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Warheads/ResourcerWarheadInfo.cs
+++ b/OpenRA.Mods.RA/Warheads/ResourcerWarheadInfo.cs
@@ -1,0 +1,76 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Effects;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class ResourcerWarheadInfo : BaseWarhead, IWarheadInfo
+	{
+		[Desc("Size of the area. The resources are seeded within this area.", "Provide 2 values for a ring effect (outer/inner).")]
+		public readonly int[] Size = { 0, 0 };
+
+		[Desc("Can this damage resource patches?")]
+		public readonly bool DestroyResources = false;
+
+		[Desc("Will this splatter resources and which?")]
+		public readonly string AddsResourceType = null;
+
+		//TODO: Allow maximum resource splatter to be defined. (Per tile, and in total).
+
+		public ResourcerWarheadInfo() : base() { }
+
+		public new void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
+		{
+			var world = firedBy.World;
+			var targetTile = world.Map.CellContaining(pos);
+
+			var resLayer = DestroyResources || !string.IsNullOrEmpty(AddsResourceType) ? world.WorldActor.Trait<ResourceLayer>() : null;
+
+			if (Size[0] > 0)
+			{
+				var allCells = world.Map.FindTilesInCircle(targetTile, Size[0]).ToList();
+
+				// Destroy all resources in range, not just the outer shell:
+				if (DestroyResources)
+					foreach (var cell in allCells)
+						resLayer.Destroy(cell);
+
+				// Splatter resources:
+				if (!string.IsNullOrEmpty(AddsResourceType))
+				{
+					var resourceType = world.WorldActor.TraitsImplementing<ResourceType>()
+						.FirstOrDefault(t => t.Info.Name == AddsResourceType);
+
+					if (resourceType == null)
+						Log.Write("debug", "Warhead defines an invalid resource type '{0}'".F(AddsResourceType));
+					else
+					{
+						foreach (var cell in allCells)
+						{
+							if (!resLayer.CanSpawnResourceAt(resourceType, cell))
+								continue;
+
+							var splash = world.SharedRandom.Next(1, resourceType.Info.MaxDensity - resLayer.GetResourceDensity(cell));
+							resLayer.AddResource(resourceType, cell, splash);
+						}
+					}
+				}
+			}
+
+			if (DestroyResources)
+				world.WorldActor.Trait<ResourceLayer>().Destroy(targetTile);
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Warheads/SmudgerWarheadInfo.cs
+++ b/OpenRA.Mods.RA/Warheads/SmudgerWarheadInfo.cs
@@ -1,0 +1,72 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Effects;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	public class SmudgerWarheadInfo : BaseWarhead, IWarheadInfo
+	{
+		[Desc("Size of the area. A smudge will be created in each tile.", "Provide 2 values for a ring effect (outer/inner).")]
+		public readonly int[] Size = { 0, 0 };
+
+		[Desc("Type of smudge to apply to terrain.")]
+		public readonly string[] SmudgeType = { };
+
+		public SmudgerWarheadInfo() : base() { }
+
+		public new void DoImpact(WPos pos, WeaponInfo weapon, Actor firedBy, float firepowerModifier)
+		{
+			var world = firedBy.World;
+			var targetTile = world.Map.CellContaining(pos);
+			var smudgeLayers = world.WorldActor.TraitsImplementing<SmudgeLayer>().ToDictionary(x => x.Info.Type);
+
+			if (Size[0] > 0)
+			{
+				var allCells = world.Map.FindTilesInCircle(targetTile, Size[0]).ToList();
+
+				// `smudgeCells` might want to just be an outer shell of the cells:
+				IEnumerable<CPos> smudgeCells = allCells;
+				if (Size.Length == 2)
+					smudgeCells = smudgeCells.Except(world.Map.FindTilesInCircle(targetTile, Size[1]));
+
+				// Draw the smudges:
+				foreach (var sc in smudgeCells)
+				{
+					var smudgeType = world.Map.GetTerrainInfo(sc).AcceptsSmudgeType.FirstOrDefault(t => SmudgeType.Contains(t));
+					if (smudgeType == null) continue;
+
+					SmudgeLayer smudgeLayer;
+					if (!smudgeLayers.TryGetValue(smudgeType, out smudgeLayer))
+						throw new NotImplementedException("Unknown smudge type `{0}`".F(smudgeType));
+
+					smudgeLayer.AddSmudge(sc);
+				}
+			}
+			else
+			{
+				var smudgeType = world.Map.GetTerrainInfo(targetTile).AcceptsSmudgeType.FirstOrDefault(t => SmudgeType.Contains(t));
+				if (smudgeType != null)
+				{
+					SmudgeLayer smudgeLayer;
+					if (!smudgeLayers.TryGetValue(smudgeType, out smudgeLayer))
+						throw new NotImplementedException("Unknown smudge type `{0}`".F(smudgeType));
+
+					smudgeLayer.AddSmudge(targetTile);
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -421,6 +421,10 @@ namespace OpenRA.Utility
 								if (temp != null)
 									newYaml.Add(new MiniYamlNode("Size",temp.Value));
 
+								temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Delay");
+								if (temp != null)
+									newYaml.Add(new MiniYamlNode("Delay", temp.Value));
+
 								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Res", "Resourcer", newYaml));
 							}
 							//Resourcer
@@ -436,6 +440,10 @@ namespace OpenRA.Utility
 								if (temp != null)
 									newYaml.Add(new MiniYamlNode("Size", temp.Value));
 
+								temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Delay");
+								if (temp != null)
+									newYaml.Add(new MiniYamlNode("Delay", temp.Value));
+
 								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Res", "Resourcer", newYaml));
 							}
 							//Smudger
@@ -450,6 +458,10 @@ namespace OpenRA.Utility
 								var temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Size");
 								if (temp != null)
 									newYaml.Add(new MiniYamlNode("Size", temp.Value));
+
+								temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Delay");
+								if (temp != null)
+									newYaml.Add(new MiniYamlNode("Delay", temp.Value));
 
 								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Smu", "Smudger", newYaml));
 							}
@@ -489,6 +501,10 @@ namespace OpenRA.Utility
 									temp.Key = "KILLME!";
 								}
 
+								temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Delay");
+								if (temp != null)
+									newYaml.Add(new MiniYamlNode("Delay", temp.Value));
+
 								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Eff", "EffectCreator", newYaml));
 							}
 						}
@@ -497,16 +513,17 @@ namespace OpenRA.Utility
 						if (temp2 != null)
 							temp2.Value.Value = temp2.Value.Value.Split(',')[0];
 					}
+
+					if (node.Key != "KILLME!")
+					{
+						newNodes.Add(node);
+					}
 				}
 
-				if (node.Key != "KILLME!")
-				{
-					newNodes.Add(node);
-				}
-
-				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1, warheadCounter);
+				warheadCounter = UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1, warheadCounter);
 			}
-			nodes = newNodes;
+			if (newNodes.Any())
+				nodes = newNodes;
 
 			return warheadCounter;
 		}

--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -320,9 +320,12 @@ namespace OpenRA.Utility
 			}
 		}
 
-		static void UpgradeWeaponRules(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		static int UpgradeWeaponRules(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth, int warheadCounter = 0)
 		{
 			var parentKey = parent != null ? parent.Key.Split('@').First() : null;
+			var newNodes = new List<MiniYamlNode>();
+
+			if (depth == 0) warheadCounter = 0;
 
 			foreach (var node in nodes)
 			{
@@ -384,8 +387,128 @@ namespace OpenRA.Utility
 						node.Key = "DestroyResources";
 				}
 
-				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				if (engineVersion < 20140720)
+				{
+					//Update diplomacy target rules
+					if (depth == 1 && node.Key.Contains("ValidTargets") &&
+						!node.Value.Value.Contains("Enemy") &&
+						!node.Value.Value.Contains("Neutral") &&
+						!node.Value.Value.Contains("Ally"))
+					{
+						node.Value.Value = node.Value.Value + ", Enemy, Neutral, Ally";
+					}
+
+					//Split out the warheads to Damager, Smudger, Resourcer, EffectCreator.
+					if (depth == 1 && node.Key.Contains("Warhead") && node.Value.Value == null)
+					{
+						node.Value.Value = "Damager";
+
+						for (int i = 0; i < node.Value.Nodes.Count; i++)
+						{
+							var currentNode = node.Value.Nodes[i];
+
+							//Resourcer
+							if (currentNode.Key.Contains("DestroyResources") ||
+								currentNode.Key.Contains("Ore"))
+							{
+								warheadCounter++;
+								currentNode.Key = "KILLME!";
+
+								var newYaml = new List<MiniYamlNode>();
+								newYaml.Add(new MiniYamlNode("DestroyResources", currentNode.Value.Value));
+
+								var temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Size");
+								if (temp != null)
+									newYaml.Add(new MiniYamlNode("Size",temp.Value));
+
+								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Res", "Resourcer", newYaml));
+							}
+							//Resourcer
+							if (currentNode.Key.Contains("AddsResourceType"))
+							{
+								warheadCounter++;
+								currentNode.Key = "KILLME!";
+
+								var newYaml = new List<MiniYamlNode>();
+								newYaml.Add(new MiniYamlNode("AddsResourceType", currentNode.Value.Value));
+
+								var temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Size");
+								if (temp != null)
+									newYaml.Add(new MiniYamlNode("Size", temp.Value));
+
+								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Res", "Resourcer", newYaml));
+							}
+							//Smudger
+							if (currentNode.Key.Contains("SmudgeType"))
+							{
+								warheadCounter++;
+								currentNode.Key = "KILLME!";
+
+								var newYaml = new List<MiniYamlNode>();
+								newYaml.Add(new MiniYamlNode("SmudgeType", currentNode.Value.Value));
+
+								var temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Size");
+								if (temp != null)
+									newYaml.Add(new MiniYamlNode("Size", temp.Value));
+
+								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Smu", "Smudger", newYaml));
+							}
+							//EffectCreator
+							if (currentNode.Key.Contains("Explosion") ||
+								currentNode.Key.Contains("WaterExplosion") ||
+								currentNode.Key.Contains("ImpactSound") ||
+								currentNode.Key.Contains("WaterImpactSound"))
+							{
+								warheadCounter++;
+
+								var newYaml = new List<MiniYamlNode>();
+
+								var temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "Explosion");
+								if (temp != null)
+								{
+									newYaml.Add(new MiniYamlNode("Explosion", temp.Value));
+									temp.Key = "KILLME!";
+								}
+								temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "WaterExplosion");
+								if (temp != null)
+								{
+									newYaml.Add(new MiniYamlNode("WaterExplosion", temp.Value));
+									temp.Key = "KILLME!";
+								}
+
+								temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "ImpactSound");
+								if (temp != null)
+								{
+									newYaml.Add(new MiniYamlNode("ImpactSound", temp.Value));
+									temp.Key = "KILLME!";
+								}
+								temp = node.Value.Nodes.FirstOrDefault(n => n.Key == "WaterImpactSound");
+								if (temp != null)
+								{
+									newYaml.Add(new MiniYamlNode("WaterImpactSound", temp.Value));
+									temp.Key = "KILLME!";
+								}
+
+								newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Eff", "EffectCreator", newYaml));
+							}
+						}
+
+						var temp2 = node.Value.Nodes.FirstOrDefault(n => n.Key == "Size");
+						if (temp2 != null)
+							temp2.Value.Value = temp2.Value.Value.Split(',')[0];
+					}
+				}
+
+				if (node.Key != "KILLME!")
+				{
+					newNodes.Add(node);
+				}
+
+				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1, warheadCounter);
 			}
+			nodes = newNodes;
+
+			return warheadCounter;
 		}
 
 		static void UpgradeTileset(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -535,7 +535,7 @@ VoxelSequences:
 
 Weapons:
 	BoatMissile:
-		Warhead:
+		Warhead: Damager
 			Versus:
 				Heavy: 50%
 		Damage: 50

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -572,7 +572,7 @@ VoxelSequences:
 
 Weapons:
 	Tiberium:
-		Warhead:
+		Warhead: Damager
 			Damage: 6
 
 Voices:

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -653,7 +653,7 @@ VoxelSequences:
 
 Weapons:
 	Tiberium:
-		Warhead:
+		Warhead: Damager
 			Damage: 4
 
 Voices:

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -913,7 +913,7 @@ VoxelSequences:
 
 Weapons:
 	Rockets:
-		Warhead:
+		Warhead: Damager
 			Versus:
 				None: 20%
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -41,6 +41,8 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
 
 ^Tank:
 	AppearsOnRadar:
@@ -88,6 +90,8 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
 
 ^Helicopter:
 	AppearsOnRadar:
@@ -119,6 +123,8 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
 
 ^Infantry:
 	AppearsOnRadar:
@@ -187,6 +193,8 @@
 	DeathSounds@POISONED:
 		DeathSound: Poisoned
 		InfDeaths: 6
+	DisabledByWarhead:
+		TargetTypes: Paralyze
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -285,6 +293,8 @@
 	AttackMove:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
 
 ^Ship:
 	AppearsOnRadar:
@@ -311,6 +321,8 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
 
 ^Building:
 	AppearsOnRadar:
@@ -356,6 +368,8 @@
 	Demolishable:
 	ScriptTriggers:
 	WithMakeAnimation:
+	DisabledByWarhead:
+		TargetTypes: EMP
 
 ^BaseBuilding:
 	Inherits: ^Building

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -1,27 +1,33 @@
 FlametankExplode:
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: big_napalm
+		ImpactSound: xplobig6.aud
+	Warhead: Damager
 		Damage: 100
 		Spread: 1c0
-		Explosion: big_napalm
 		InfDeath: 5
-		ImpactSound: xplobig6.aud
 
 HeliCrash:
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: poof
+		ImpactSound: xplos.aud
+	Warhead: Damager
 		Damage: 40
 		Spread: 426
-		Explosion: poof
 		InfDeath: 4
-		ImpactSound: xplos.aud
 
 HeliExplode:
-	Warhead:
+	Warhead@1Eff: EffectCreator
 		Explosion: small_building
-		InfDeath: 4
 		ImpactSound: xplos.aud
+	Warhead: Damager
+		InfDeath: 4
 
 UnitExplode:
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: poof
+		ImpactSound: xplobig6.aud
+	Warhead: Damager
 		Damage: 500
 		Spread: 426
 		Versus:
@@ -29,12 +35,13 @@ UnitExplode:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: poof
 		InfDeath: 4
-		ImpactSound: xplobig6.aud
 
 UnitExplodeSmall:
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: big_frag
+		ImpactSound: xplobig4.aud
+	Warhead: Damager
 		Damage: 40
 		Spread: 426
 		Versus:
@@ -42,12 +49,13 @@ UnitExplodeSmall:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: big_frag
 		InfDeath: 4
-		ImpactSound: xplobig4.aud
 
 GrenadierExplode:
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: poof
+		ImpactSound: xplosml2.aud
+	Warhead: Damager
 		Damage: 10
 		Spread: 256
 		Versus:
@@ -55,30 +63,35 @@ GrenadierExplode:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: poof
 		InfDeath: 3
-		ImpactSound: xplosml2.aud
 
 Atomic:
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Report: nukemisl.aud
-	Warhead@impact:
-		Damage: 1500	#1000
+	Warhead@1Eff: EffectCreator
+		Explosion: 6
+		ImpactSound: nukexplo.aud
+	Warhead@impact: Damager
+		Damage: 1500
 		Spread: 1c0
 		Versus:
 			None: 100%
 			Wood: 100%
 			Light: 60%
 			Heavy: 50%
-		Explosion: 6
 		InfDeath: 5
-		ImpactSound: nukexplo.aud
-	Warhead@areanukea:
-		Damage: 1000	#200
+	Warhead@2Smu: Smudger
 		SmudgeType: Scorch
+		Size: 3
+	Warhead@3Res: Resourcer
+		DestroyResources: true
+		Size: 3
+	Warhead@4Eff: EffectCreator
+		ImpactSound: xplobig4.aud
+	Warhead@areanukea: Damager
+		Damage: 1000
 		Spread: 2c512
 		Size: 3
-		DestroyResources: true
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -86,13 +99,16 @@ Atomic:
 			Heavy: 50%
 		Delay: 3
 		InfDeath: 5
-		ImpactSound: xplobig4.aud
-	Warhead@areanukeb:
-		Damage: 500	#200
+	Warhead@5Smu: Smudger
 		SmudgeType: Scorch
+		Size: 4
+	Warhead@6Res: Resourcer
+		DestroyResources: true
+		Size: 4
+	Warhead@areanukeb: Damager
+		Damage: 500
 		Spread: 3c768
 		Size: 4
-		DestroyResources: true
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -100,12 +116,16 @@ Atomic:
 			Heavy: 50%
 		Delay: 6
 		InfDeath: 5
-	Warhead@areanukec:
-		Damage: 200
+	Warhead@7Smu: Smudger
 		SmudgeType: Scorch
+		Size: 5
+	Warhead@8Res: Resourcer
+		DestroyResources: true
+		Size: 5
+	Warhead@areanukec: Damager
+		Damage: 200
 		Spread: 5c0
 		Size: 5
-		DestroyResources: true
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -115,29 +135,39 @@ Atomic:
 		InfDeath: 5
 
 IonCannon:
-	ValidTargets: Ground, Air
-	Warhead@impact:
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
+	Warhead@impact: Damager
 		Damage: 900
 		Spread: 853
-		DestroyResources: true
 		InfDeath: 5
-	Warhead@area:
-		DamageModel: PerCell
-		Damage: 0
+	Warhead@impactDis: Disabler
+		ValidTargets: EMP, Enemy, Neutral
+		Spread: 1c0
+		SpreadFactor: 100%
+		DisableTicks: 1500
+	Warhead@areaSmu: Smudger
 		SmudgeType: Scorch
-		Size: 2,1
-		DestroyResources: true
+		Size: 2
 		Delay: 3
-		InfDeath: 5
+	Warhead@areaRes: Resourcer
+		DestroyResources: true
+		Size: 2
+		Delay: 3
+	Warhead@areaDis: Disabler
+		ValidTargets: EMP, Enemy, Neutral
+		Spread: 1c0, 2c0
+		SpreadFactor: 0%, 100%
+		DisableTicks: 250
+		Delay: 3
 
 Sniper:
 	Report: RAMGUN2.AUD
-	ValidTargets: Infantry
+	ValidTargets: Infantry, Enemy, Neutral, Ally
 	ROF: 40
 	Range: 6c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Damage: 100
 		Spread: 42
 		InfDeath: 2
@@ -148,7 +178,9 @@ HighV:
 	Report: GUN8.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: piffs
+	Warhead: Damager
 		Damage: 30
 		Spread: 683
 		Versus:
@@ -157,18 +189,19 @@ HighV:
 			Light: 70%
 			Heavy: 35%
 		InfDeath: 2
-		Explosion: piffs
 
 HeliAGGun:
 	ROF: 20
 	Burst: 2
 	BurstDelay: 0
 	Range: 4c0
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Report: gun5.aud
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: piffs
+	Warhead: Damager
 		Damage: 20
 		Spread: 256
 		Versus:
@@ -177,18 +210,19 @@ HeliAGGun:
 			Light: 75%
 			Heavy: 25%
 		InfDeath: 2
-		Explosion: piffs
 
 HeliAAGun:
 	ROF: 20
 	Burst: 2
 	BurstDelay: 0
 	Range: 4c0
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Report: gun5.aud
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: piffs
+	Warhead: Damager
 		Damage: 20
 		Spread: 128
 		Versus:
@@ -197,7 +231,6 @@ HeliAAGun:
 			Light: 50%
 			Heavy: 25%
 		InfDeath: 2
-		Explosion: piffs
 
 Pistol:
 	ROF: 7
@@ -206,7 +239,9 @@ Pistol:
 	Report: GUN18.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: piff
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 100%
@@ -214,7 +249,6 @@ Pistol:
 			Light: 50%
 			Heavy: 25%
 		InfDeath: 2
-		Explosion: piff
 		Damage: 1
 
 M16:
@@ -224,14 +258,15 @@ M16:
 	Report: MGUN2.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: piff
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 100%
 			Wood: 25%
 			Light: 30%
 			Heavy: 10%
-		Explosion: piff
 		InfDeath: 2
 		Damage: 15
 
@@ -239,7 +274,7 @@ Rockets:
 	ROF: 50
 	Range: 6c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -250,7 +285,12 @@ Rockets:
 		ContrailLength: 8
 		Speed: 298
 		RangeLimit: 20
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 50%
@@ -259,16 +299,13 @@ Rockets:
 			Heavy: 100%
 			Concrete: 25%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 30
 
 BikeRockets:
 	ROF: 50
 	Range: 6c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Burst: 2
 	BurstDelay: 10
 	Projectile: Missile
@@ -281,7 +318,12 @@ BikeRockets:
 		ContrailLength: 8
 		Speed: 298
 		RangeLimit: 20
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -290,9 +332,6 @@ BikeRockets:
 			Heavy: 100%
 			Concrete: 50%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 30
 
 OrcaAGMissiles:
@@ -301,7 +340,7 @@ OrcaAGMissiles:
 	BurstDelay: 12
 	Range: 5c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -312,7 +351,12 @@ OrcaAGMissiles:
 		ContrailLength: 8
 		Speed: 298
 		RangeLimit: 30
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 50%
@@ -320,9 +364,6 @@ OrcaAGMissiles:
 			Light: 100%
 			Heavy: 75%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 25
 
 OrcaAAMissiles:
@@ -331,7 +372,7 @@ OrcaAAMissiles:
 	BurstDelay: 12
 	Range: 5c0
 	Report: BAZOOK1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -342,15 +383,17 @@ OrcaAAMissiles:
 		ContrailLength: 8
 		Speed: 298
 		RangeLimit: 30
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 25
 
 Flamethrower:
@@ -360,17 +403,19 @@ Flamethrower:
 	Report: FLAMER2.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_napalm
+		ImpactSound: flamer2.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Scorch
+	Warhead: Damager
 		Spread: 341
 		Versus:
 			None: 100%
 			Wood: 100%
 			Light: 100%
 			Heavy: 20%
-		Explosion: small_napalm
 		InfDeath: 5
-		ImpactSound: flamer2.aud
-		SmudgeType: Scorch
 		Damage: 40
 
 BigFlamer:
@@ -382,7 +427,12 @@ BigFlamer:
 		Speed: 341
 	Burst: 2
 	BurstDelay: 25
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: med_napalm
+		ImpactSound: flamer2.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Scorch
+	Warhead: Damager
 		Spread: 341
 		Versus:
 			None: 100%
@@ -390,9 +440,6 @@ BigFlamer:
 			Light: 67%
 			Heavy: 25%
 		InfDeath: 5
-		Explosion: med_napalm
-		ImpactSound: flamer2.aud
-		SmudgeType: Scorch
 		Damage: 90
 
 Chemspray:
@@ -401,7 +448,12 @@ Chemspray:
 	Report: FLAMER2.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: chemball
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Scorch
+	Warhead: Damager
 		Damage: 80
 		Spread: 256
 		Versus:
@@ -410,9 +462,6 @@ Chemspray:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 6
-		Explosion: chemball
-		SmudgeType: Scorch
-		ImpactSound: xplos.aud
 
 Grenade:
 	ROF: 50
@@ -424,7 +473,12 @@ Grenade:
 		Angle: 62
 		Inaccuracy: 213
 		Image: BOMB
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_poof
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 341
 		Versus:
 			None: 100%
@@ -432,9 +486,6 @@ Grenade:
 			Light: 75%
 			Heavy: 35%
 		InfDeath: 3
-		Explosion: small_poof
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 50
 
 70mm:
@@ -444,7 +495,12 @@ Grenade:
 	Projectile: Bullet
 		Image: 120MM
 		Speed: 853
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -453,9 +509,6 @@ Grenade:
 			Heavy: 100%
 			Concrete: 50%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 25
 
 105mm:
@@ -465,7 +518,12 @@ Grenade:
 	Projectile: Bullet
 		Image: 120MM
 		Speed: 682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 30%
@@ -473,9 +531,6 @@ Grenade:
 			Light: 75%
 			Heavy: 100%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 30
 
 120mm:
@@ -485,7 +540,12 @@ Grenade:
 	Projectile: Bullet
 		Image: 120MM
 		Speed: 682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -494,9 +554,6 @@ Grenade:
 			Heavy: 100%
 			Concrete: 50%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 40
 
 120mmDual:
@@ -508,7 +565,12 @@ Grenade:
 	Projectile: Bullet
 		Image: 120MM
 		Speed: 682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -517,9 +579,6 @@ Grenade:
 			Heavy: 100%
 			Concrete: 100%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 40
 
 TurretGun:
@@ -529,7 +588,12 @@ TurretGun:
 	Projectile: Bullet
 		Image: 120MM
 		Speed: 853
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 20%
@@ -537,16 +601,13 @@ TurretGun:
 			Light: 100%
 			Heavy: 100%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 40
 
 MammothMissiles:
 	ROF: 45
 	Range: 5c0
 	Report: ROCKET1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Burst: 2
 	BurstDelay: 15
 	Projectile: Missile
@@ -559,7 +620,12 @@ MammothMissiles:
 		ContrailLength: 8
 		Speed: 341
 		RangeLimit: 35
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 298
 		Versus:
 			None: 50%
@@ -567,9 +633,6 @@ MammothMissiles:
 			Light: 100%
 			Heavy: 50%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 45
 
 227mm:
@@ -579,7 +642,7 @@ MammothMissiles:
 	Burst: 4
 	BurstDelay: 4
 	Report: ROCKET1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Arm: 5
 		High: yes
@@ -591,7 +654,12 @@ MammothMissiles:
 		ContrailLength: 10
 		Trail: smokey
 		Speed: 341
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: med_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 683
 		Versus:
 			None: 35%
@@ -599,9 +667,6 @@ MammothMissiles:
 			Light: 100%
 			Heavy: 50%
 		InfDeath: 4
-		Explosion: med_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 25
 
 227mm.stnk:
@@ -610,7 +675,7 @@ MammothMissiles:
 	Report: ROCKET1.AUD
 	Burst: 2
 	BurstDelay: 10
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -621,7 +686,12 @@ MammothMissiles:
 		ContrailLength: 8
 		Speed: 213
 		RangeLimit: 55
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 35%
@@ -629,9 +699,6 @@ MammothMissiles:
 			Light: 100%
 			Heavy: 90%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 60
 
 ArtilleryShell:
@@ -646,7 +713,12 @@ ArtilleryShell:
 		Inaccuracy: 1c256
 		ContrailLength: 30
 		Image: 120MM
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: poof
+		ImpactSound: XPLOSML2.AUD
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Damage: 150
 		Spread: 341
 		Versus:
@@ -655,9 +727,6 @@ ArtilleryShell:
 			Light: 75%
 			Heavy: 50%
 		InfDeath: 3
-		Explosion: poof
-		SmudgeType: Crater
-		ImpactSound: XPLOSML2.AUD
 
 MachineGun:
 	ROF: 20
@@ -667,7 +736,9 @@ MachineGun:
 	Report: MGUN11.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: piffs
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 100%
@@ -676,7 +747,6 @@ MachineGun:
 			Heavy: 20%
 			Concrete: 10%
 		InfDeath: 2
-		Explosion: piffs
 		Damage: 15
 
 BoatMissile:
@@ -695,7 +765,12 @@ BoatMissile:
 		ContrailLength: 8
 		Speed: 170
 		RangeLimit: 60
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_poof
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 90%
@@ -703,16 +778,13 @@ BoatMissile:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 3
-		Explosion: small_poof
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 60
 
 TowerMissle:
 	ROF: 15
 	Range: 7c0
 	Report: ROCKET2.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -723,7 +795,12 @@ TowerMissle:
 		ContrailLength: 8
 		Speed: 298
 		RangeLimit: 40
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: med_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 683
 		Versus:
 			None: 50%
@@ -731,19 +808,18 @@ TowerMissle:
 			Light: 100%
 			Heavy: 100%
 		InfDeath: 3
-		Explosion: med_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 25
 
 Vulcan:
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	ROF: 2
 	Range: 6c0
 	Report: gun5.aud
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: piffs
+	Warhead: Damager
 		Damage: 100
 		Spread: 426
 		Versus:
@@ -752,17 +828,22 @@ Vulcan:
 			Light: 100%
 			Heavy: 35%
 		InfDeath: 2
-		Explosion: piffs
 
 Napalm:
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	ROF: 4
 	Range: 2c0
 	Burst: 2
 	BurstDelay: 2
 	Projectile: GravityBomb
 		Image: BOMBLET
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: med_napalm
+		WaterExplosion: med_napalm
+		ImpactSound: flamer2.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Scorch
+	Warhead: Damager
 		Spread: 341
 		Versus:
 			None: 100%
@@ -770,14 +851,15 @@ Napalm:
 			Light: 100%
 			Heavy: 80%
 		InfDeath: 5
-		Explosion: med_napalm
-		WaterExplosion: med_napalm
-		ImpactSound: flamer2.aud
-		SmudgeType: Scorch
 		Damage: 300
 
 Napalm.Crate:
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: med_napalm
+		ImpactSound: flamer2.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Scorch
+	Warhead: Damager
 		Spread: 170
 		Versus:
 			None: 90%
@@ -785,9 +867,6 @@ Napalm.Crate:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 5
-		Explosion: med_napalm
-		ImpactSound: flamer2.aud
-		SmudgeType: Scorch
 		Damage: 500
 
 Laser:
@@ -798,19 +877,20 @@ Laser:
 	Projectile: LaserZap
 		BeamWidth: 2
 		HitAnim: laserfire
-	Warhead:
+	Warhead@1Smu: Smudger
+		SmudgeType: Scorch
+	Warhead: Damager
 		Spread: 42
 		Versus:
 			Wood: 50%
 		InfDeath: 5
-		SmudgeType: Scorch
 		Damage: 360
 
 SAMMissile:
 	ROF: 15
 	Range: 8c0
 	Report: ROCKET2.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		High: yes
@@ -820,7 +900,12 @@ SAMMissile:
 		RangeLimit: 35
 		Trail: smokey
 		ContrailLength: 8
-	Warhead: AP
+	Warhead@1Eff: EffectCreator
+		Explosion: small_frag
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 682
 		Versus:
 			None: 100%
@@ -828,9 +913,6 @@ SAMMissile:
 			Light: 100%
 			Heavy: 75%
 		InfDeath: 4
-		Explosion: small_frag
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 30
 
 HonestJohn:
@@ -847,7 +929,12 @@ HonestJohn:
 		Speed: 187
 		RangeLimit: 35
 		Angle: 88
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_poof
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 90%
@@ -855,37 +942,37 @@ HonestJohn:
 			Light: 60%
 			Heavy: 25%
 		InfDeath: 3
-		Explosion: small_poof
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 100
 
 Tiberium:
 	ROF: 16
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		InfDeath: 6
 		Damage: 2
 		PreventProne: yes
 
 TiberiumExplosion:
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: chemball
+		ImpactSound: xplosml2.aud
+	Warhead@2Res: Resourcer
+		AddsResourceType: Tiberium
+		Size: 1
+	Warhead: Damager
 		Damage: 10
 		Spread: 9
-		Size: 1,1
+		Size: 1
 		Versus:
 			None: 90%
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: chemball
 		InfDeath: 3
-		ImpactSound: xplosml2.aud
-		AddsResourceType: Tiberium
 
 Heal:
 	ROF: 4
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		Damage: -1
 		PreventProne: yes
@@ -894,32 +981,34 @@ APCGun:
 	ROF: 18
 	Range: 5c0
 	Report: gun20.aud
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_poof
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 50%
 			Wood: 50%
 			Light: 100%
 			Heavy: 50%
-		Explosion: small_poof
 		Damage: 15
 
 APCGun.AA:
 	ROF: 18
 	Range: 7c0
 	Report: gun20.aud
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
-	Warhead:
+	Warhead@1Eff: EffectCreator
+		Explosion: small_poof
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Heavy: 50%
-		Explosion: small_poof
 		Damage: 25
 
 Patriot:
@@ -929,7 +1018,7 @@ Patriot:
 	Burst: 2
 	BurstDelay: 15
 	Report: ROCKET2.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		High: yes
 		Image: patriot
@@ -939,7 +1028,12 @@ Patriot:
 		Speed: 426
 		RangeLimit: 30
 		Angle: 88
-	Warhead: AP
+	Warhead@1Eff: EffectCreator
+		Explosion: poof
+		ImpactSound: xplos.aud
+	Warhead@2Smu: Smudger
+		SmudgeType: Crater
+	Warhead: Damager
 		Spread: 682
 		Versus:
 			None: 100%
@@ -947,9 +1041,6 @@ Patriot:
 			Light: 100%
 			Heavy: 75%
 		InfDeath: 4
-		Explosion: poof
-		ImpactSound: xplos.aud
-		SmudgeType: Crater
 		Damage: 40
 
 Tail:
@@ -957,7 +1048,7 @@ Tail:
 	Range: 1c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			None: 90%
@@ -973,7 +1064,7 @@ Horn:
 	Range: 1c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			None: 90%
@@ -989,7 +1080,7 @@ Teeth:
 	Range: 1c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			None: 90%
@@ -1005,7 +1096,7 @@ Claw:
 	Range: 1c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			None: 90%
@@ -1017,7 +1108,8 @@ Claw:
 		Damage: 60
 
 Demolish:
-	Warhead:
-		ImpactSound: xplobig6.aud
+	Warhead@1Eff: EffectCreator
 		Explosion: building
+		ImpactSound: xplobig6.aud
+	Warhead: Damager
 

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -8,7 +8,7 @@ LMG:
 		TrailInterval: 1
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			Wood: 25%
@@ -23,7 +23,7 @@ Bazooka:
 	ROF: 50
 	Range: 5c0
 	Report: BAZOOK1.WAV
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 160
 		Arm: 2
@@ -32,7 +32,7 @@ Bazooka:
 		Image: RPG
 		ROT: 5
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			None: 10%
@@ -56,7 +56,7 @@ Sniper:
 		TrailInterval: 1
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
-	Warhead:
+	Warhead: Damager
 		Damage: 60
 		Spread: 32
 		Versus:
@@ -71,14 +71,14 @@ Vulcan:
 	ROF: 30
 	Range: 5c768
 	Report: VULCAN.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c256
 		ContrailLength: 3
 		TrailInterval: 1
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			Wood: 0%
@@ -94,7 +94,7 @@ Slung:
 	Delay: 5
 	Range: 5c512
 	Report: BAZOOK2.WAV
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 320
 		High: true
@@ -102,7 +102,7 @@ Slung:
 		Angle: 88
 		Inaccuracy: 384
 		Image: MISSILE
-	Warhead:
+	Warhead: Damager
 		Spread: 192
 		Versus:
 			None: 0%
@@ -127,7 +127,7 @@ HMG:
 		TrailInterval: 1
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			Wood: 15%
@@ -150,7 +150,7 @@ HMGo:
 		TrailInterval: 1
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			Wood: 15%
@@ -167,7 +167,7 @@ QuadRockets:
 	BurstDelay: 25
 	Range: 7c0
 	Report: ROCKET1.WAV
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 0
 		Inaccuracy: 96
@@ -175,7 +175,7 @@ QuadRockets:
 		ROT: 10
 		Speed: 256
 		RangeLimit: 40
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			None: 35%
@@ -199,7 +199,7 @@ TurretGun:
 		Shadow: no
 		Inaccuracy: 288
 		Image: 120mm
-	Warhead:
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 50%
@@ -217,7 +217,7 @@ TowerMissile:
 	Range: 7c768
 	MinRange: 1c0
 	Report: ROCKET1.WAV
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Burst: 2
 	BurstDelay: 15
 	Projectile: Bullet
@@ -230,7 +230,7 @@ TowerMissile:
 		Speed: 256
 		RangeLimit: 50
 		Angle: 110
-	Warhead:
+	Warhead: Damager
 		Spread: 384
 		Versus:
 			None: 50%
@@ -252,7 +252,7 @@ TowerMissile:
 		Speed: 640
 		Inaccuracy: 384
 		Image: 120mm
-	Warhead:
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 50%
@@ -273,7 +273,7 @@ TowerMissile:
 		Speed: 704
 		Inaccuracy: 352
 		Image: 120mm
-	Warhead:
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 50%
@@ -293,7 +293,7 @@ DevBullet:
 	Projectile: Bullet
 		Speed: 640
 		Image: doubleblastbullet
-	Warhead:
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 100%
@@ -313,7 +313,7 @@ DevBullet:
 	Burst: 4
 	BurstDelay: 15
 	Report: MISSLE1.WAV
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 358
 		Arm: 5
@@ -324,7 +324,7 @@ DevBullet:
 		Image: MISSILE2
 		ROT: 5
 		ContrailLength: 5
-	Warhead:
+	Warhead: Damager
 		Spread: 384
 		Versus:
 			None: 20%
@@ -352,7 +352,7 @@ FakeMissile:
 		Image: MISSILE
 		ContrailLength: 15
 		ContrailUsePlayerColor: True
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			None: 0%
@@ -376,7 +376,7 @@ FakeMissile:
 		Inaccuracy: 1c256
 		ContrailLength: 20
 		Image: 155mm
-	Warhead:
+	Warhead: Damager
 		Spread: 384
 		Versus:
 			None: 100%
@@ -399,7 +399,7 @@ Sound:
 		HitAnim: laserfire
 		BeamDuration: 8
 		UsePlayerColor: true
-	Warhead:
+	Warhead: Damager
 		Spread: 32
 		Versus:
 			None: 60%
@@ -417,7 +417,7 @@ ChainGun:
 	Projectile: Bullet
 		Speed: 1c256
 		High: true
-	Warhead:
+	Warhead: Damager
 		Spread: 96
 		Versus:
 			Wood: 50%
@@ -434,7 +434,7 @@ Heal:
 	Report:
 	Projectile: Bullet
 		Speed: 1c256
-	Warhead:
+	Warhead: Damager
 		Spread: 160
 		Versus:
 			Wood: 0%
@@ -448,7 +448,7 @@ WormJaw:
 	ROF: 10
 	Range: 3c0
 	Report: WORM.WAV
-	Warhead:
+	Warhead: Damager
 		Spread: 160
 		Versus:
 			Wood: 0%
@@ -461,7 +461,7 @@ ParaBomb:
 	Report:
 	Projectile: GravityBomb
 		Image: BOMBS
-	Warhead:
+	Warhead: Damager
 		Spread: 192
 		Versus:
 			None: 30%
@@ -479,7 +479,7 @@ Napalm:
 	Range: 3c0
 	Projectile: GravityBomb
 		Image: BOMBS
-	Warhead:
+	Warhead: Damager
 		Spread: 640
 		Versus:
 			None: 20%
@@ -494,17 +494,17 @@ Napalm:
 		Damage: 300
 
 Crush:
-	Warhead:
+	Warhead: Damager
 		ImpactSound: CRUSH1.WAV
 		Damage: 100
 
 Demolish:
-	Warhead:
+	Warhead: Damager
 		ImpactSound: EXPLLG2.WAV
 		Explosion: building
 
 Atomic:
-	Warhead:
+	Warhead: Damager
 		Damage: 1800
 		Spread: 2c0
 		Versus:
@@ -518,7 +518,7 @@ Atomic:
 		ImpactSound: EXPLLG2.WAV
 
 CrateNuke:
-	Warhead:
+	Warhead: Damager
 		Damage: 800
 		Spread: 1c576
 		Versus:
@@ -532,7 +532,7 @@ CrateNuke:
 		ImpactSound: EXPLLG2.WAV
 
 CrateExplosion:
-	Warhead:
+	Warhead: Damager
 		Damage: 400
 		Spread: 320
 		Versus:
@@ -545,7 +545,7 @@ CrateExplosion:
 		ImpactSound: EXPLSML4.WAV
 
 UnitExplode:
-	Warhead:
+	Warhead: Damager
 		Damage: 500
 		Spread: 320
 		Versus:
@@ -558,7 +558,7 @@ UnitExplode:
 		ImpactSound: EXPLMD1.WAV
 
 UnitExplodeSmall:
-	Warhead:
+	Warhead: Damager
 		Damage: 60
 		Spread: 320
 		Versus:
@@ -571,7 +571,7 @@ UnitExplodeSmall:
 		ImpactSound: EXPLHG1.WAV, EXPLLG1.WAV, EXPLMD1.WAV, EXPLSML4.WAV
 
 UnitExplodeTiny:
-	Warhead:
+	Warhead: Damager
 		Damage: 30
 		Spread: 224
 		Versus:
@@ -584,7 +584,7 @@ UnitExplodeTiny:
 		ImpactSound: EXPLMD2.WAV, EXPLSML1.WAV, EXPLSML2.WAV, EXPLSML3.WAV
 
 UnitExplodeScale:
-	Warhead:
+	Warhead: Damager
 		Damage: 90
 		Spread: 416
 		Versus:
@@ -606,7 +606,7 @@ Grenade:
 		Angle: 62
 		Inaccuracy: 416
 		Image: BOMBS
-	Warhead:
+	Warhead: Damager
 		Spread: 192
 		Versus:
 			None: 50%
@@ -621,7 +621,7 @@ Grenade:
 
 Weathering:
 	ROF: 100
-	Warhead:
+	Warhead: Damager
 		Damage: 5
 
 Shrapnel:
@@ -634,7 +634,7 @@ Shrapnel:
 		Angle: 91, 264
 		Inaccuracy: 416
 		Image: bombs
-	Warhead:
+	Warhead: Damager
 		Spread: 192
 		Versus:
 			None: 50%
@@ -648,10 +648,10 @@ Shrapnel:
 		ImpactSound: EXPLLG5.WAV
 
 SpiceExplosion:
-	Warhead:
+	Warhead: Damager
 		Damage: 10
 		Spread: 9
-		Size: 2,2
+		Size: 2
 		Versus:
 			None: 90%
 			Wood: 75%

--- a/mods/ra/maps/allies-01-classic/map.yaml
+++ b/mods/ra/maps/allies-01-classic/map.yaml
@@ -615,7 +615,7 @@ Weapons:
 		Range: 5c0
 		ROF: 20
 		Burst: 1
-		Warhead:
+		Warhead: Damager
 			Damage: 20
 
 Voices:

--- a/mods/ra/maps/allies-02-classic/map.yaml
+++ b/mods/ra/maps/allies-02-classic/map.yaml
@@ -951,7 +951,7 @@ Weapons:
 		Range: 5c0
 		ROF: 20
 		Burst: 1
-		Warhead:
+		Warhead: Damager
 			Damage: 20
 
 Voices:

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -364,7 +364,7 @@ Weapons:
 	PortaTesla:
 		ROF: 20
 		Range: 10c0
-		Warhead:
+		Warhead: Damager
 			Spread: 42
 			InfDeath: 5
 			Damage: 80

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -313,20 +313,22 @@ Weapons:
 			Inaccuracy: 3c341
 			Image: 120MM
 			ContrailLength: 30
-		Warhead:
+		Warhead: Damager
 			Spread: 128
 			Versus:
 				None: 60%
 				Wood: 75%
 				Light: 60%
 				Heavy: 25%
+			InfDeath: 2
+			Damage: 250
+		Warhead@1Eff: EffectCreator
 			Explosion: large_explosion
 			WaterExplosion: large_splash
-			InfDeath: 2
-			SmudgeType: Crater
-			Damage: 250
 			ImpactSound: kaboom12.aud
 			WaterImpactSound: splash9.aud
+		Warhead@2Smu: Smudger
+			SmudgeType: Crater
 	SubMissile:
 		ROF: 250
 		Range: 32c0
@@ -346,13 +348,15 @@ Weapons:
 				None: 40%
 				Light: 30%
 				Heavy: 30%
+			InfDeath: blownaway
+			Damage: 400
+		Warhead@1Eff: EffectCreator
 			Explosion: large_explosion
 			WaterExplosion: large_splash
-			InfDeath: blownaway
-			SmudgeType: Crater
-			Damage: 400
 			ImpactSound: kaboom12.aud
 			WaterImpactSound: splash9.aud
+		Warhead@2Smu: Smudger
+			SmudgeType: Crater
 
 Voices:
 

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -342,7 +342,7 @@ Weapons:
 			Image: MISSILE
 			Trail: smokey
 			ContrailLength: 30
-		Warhead:
+		Warhead: Damager
 			Spread: 426
 			Versus:
 				None: 40%

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -259,7 +259,7 @@ Weapons:
 	PortaTesla:
 		ROF: 20
 		Range: 10c0
-		Warhead:
+		Warhead: Damager
 			Spread: 42
 			InfDeath: 5
 			Damage: 80

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -771,24 +771,26 @@ Weapons:
 			Inaccuracy: 1c682
 			Image: 120MM
 			ContrailLength: 50
-		Warhead:
+		Warhead: Damager
 			Spread: 256
 			Versus:
 				None: 75%
 				Wood: 75%
 				Light: 75%
 				Concrete: 100%
+			InfDeath: 4
+			Damage: 150
+		Warhead@2Smu: Smudger
+			SmudgeType: Crater
+		Warhead@3Eff: EffectCreator
 			Explosion: self_destruct
 			WaterExplosion: self_destruct
-			InfDeath: 4
-			SmudgeType: Crater
-			Damage: 150
 	MammothTusk:
 		ROF: 300
 		Range: 10c0
 		Report: MISSILE6.AUD
 		Burst: 2
-		ValidTargets: Ground, Air
+		ValidTargets: Ground, Air, Enemy, Neutral, Ally
 		Projectile: Missile
 			Speed: 128
 			Arm: 2
@@ -801,7 +803,7 @@ Weapons:
 			Image: DRAGON
 			ROT: 10
 			RangeLimit: 80
-		Warhead:
+		Warhead: Damager
 			Spread: 640
 			Versus:
 				None: 125%
@@ -809,16 +811,18 @@ Weapons:
 				Light: 110%
 				Heavy: 100%
 				Concrete: 200%
+			InfDeath: 3
+			Damage: 250
+		Warhead@2Smu: Smudger
+			SmudgeType: Crater
+		Warhead@3Eff: EffectCreator
 			Explosion: nuke
 			WaterExplosion: nuke
-			InfDeath: 3
-			SmudgeType: Crater
-			Damage: 250
 	TankNapalm:
 		ROF: 40
 		Range: 8c0
 		Report: AACANON3.AUD
-		ValidTargets: Ground
+		ValidTargets: Ground, Enemy, Neutral, Ally
 		Burst: 6
 		BurstDelay: 1
 		Projectile: Bullet
@@ -827,7 +831,7 @@ Weapons:
 			Inaccuracy: 2c512
 			Trail: smokey
 			ContrailLength: 2
-		Warhead:
+		Warhead: Damager
 			Spread: 341
 			Versus:
 				None: 90%
@@ -835,31 +839,35 @@ Weapons:
 				Light: 100%
 				Heavy: 100%
 				Concrete: 100%
+			InfDeath: 4
+			Damage: 15
+		Warhead@2Smu: Smudger
+			SmudgeType: Scorch
+		Warhead@3Eff: EffectCreator
 			Explosion: small_explosion
 			WaterExplosion: small_explosion
-			InfDeath: 4
-			SmudgeType: Scorch
 			ImpactSound: firebl3.aud
-			Damage: 15
 	ParaBomb:
 		ROF: 5
 		Range: 5c0
 		Report: CHUTE1.AUD
 		Projectile: GravityBomb
 			Image: BOMBLET
-		Warhead:
+		Warhead: Damager
 			Spread: 426
 			Versus:
 				None: 125%
 				Wood: 100%
 				Light: 60%
 				Concrete: 25%
+			InfDeath: 5
+			Damage: 200
+		Warhead@2Smu: Smudger
+			SmudgeType: Crater
+		Warhead@3Eff: EffectCreator
 			Explosion: napalm
 			ImpactSound: firebl3.aud
 			WaterExplosion: napalm
-			InfDeath: 5
-			SmudgeType: Crater
-			Damage: 200
 	155mm:
 		ROF: 10
 		Range: 7c5
@@ -874,7 +882,7 @@ Weapons:
 			Angle: 30
 			Inaccuracy: 1c682
 			ContrailLength: 2
-		Warhead:
+		Warhead: Damager
 			Spread: 426
 			Versus:
 				None: 80%
@@ -882,21 +890,23 @@ Weapons:
 				Light: 60%
 				Heavy: 75%
 				Concrete: 35%
+			InfDeath: 5
+			Damage: 10
+		Warhead@2Smu: Smudger
+			SmudgeType: Scorch
+		Warhead@3Eff: EffectCreator
 			Explosion: small_napalm
 			WaterExplosion: small_napalm
-			InfDeath: 5
-			SmudgeType: Scorch
 			ImpactSound: firebl3.aud
-			Damage: 10
 	FLAK-23:
 		ROF: 10
 		Range: 8c0
 		Report: AACANON3.AUD
-		ValidTargets: Air,Ground
+		ValidTargets: Air, Ground, Enemy, Neutral, Ally
 		Projectile: Bullet
 			Speed: 1c682
 			High: true
-		Warhead:
+		Warhead: Damager
 			Spread: 213
 			Versus:
 				None: 35%
@@ -904,8 +914,11 @@ Weapons:
 				Light: 30%
 				Heavy: 40%
 				Concrete: 30%
-			Explosion: med_explosion
 			Damage: 25
+		Warhead@2Smu: Smudger
+			SmudgeType: Scorch
+		Warhead@3Eff: EffectCreator
+			Explosion: med_explosion
 	SCUD:
 		ROF: 280
 		Range: 7c0
@@ -921,18 +934,20 @@ Weapons:
 			Inaccuracy: 426
 			Image: V2
 			Angle: 216
-		Warhead:
+		Warhead: Damager
 			Spread: 853
 			Versus:
 				None: 100%
 				Wood: 90%
 				Light: 80%
 				Heavy: 70%
+			InfDeath: 3
+			Damage: 500
+		Warhead@2Smu: Smudger
+			SmudgeType: Crater
+		Warhead@3Eff: EffectCreator
 			Explosion: nuke
 			WaterExplosion: large_splash
-			InfDeath: 3
-			SmudgeType: Crater
-			Damage: 500
 			ImpactSound: kaboom1.aud
 			WaterImpactSound: kaboom1.aud
 	SilencedPPK:
@@ -941,16 +956,17 @@ Weapons:
 		Report: silppk.aud
 		Projectile: Bullet
 			Speed: 1c682
-		Warhead:
+		Warhead: Damager
 			Spread: 128
 			Versus:
 				Wood: 0%
 				Light: 0%
 				Heavy: 50%
 				Concrete: 0%
-			Explosion: piffs
 			InfDeath: 2
 			Damage: 150
+		Warhead@2Eff: EffectCreator
+			Explosion: piffs
 
 Voices:
 

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2333,7 +2333,7 @@ Weapons:
 	Nike:
 		Range: 9c0
 	Maverick:
-		Warhead:
+		Warhead: Damager
 			Damage: 175
 
 Voices:

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -1130,15 +1130,15 @@ Weapons:
 				Concrete: 50%
 			Delay: 36
 			InfDeath: 4
-		Warhead@areanuke3Smu: Smudger
+		Warhead@areanuke4Smu: Smudger
 			SmudgeType: Scorch
 			Size: 2,1
 			Delay: 36
-		Warhead@areanuke3Res: Resourcer
+		Warhead@areanuke4Res: Resourcer
 			DestroyResources: true
 			Size: 2,1
 			Delay: 36
-		Warhead@areanuke3Eff: EffectCreator
+		Warhead@areanuke4Eff: EffectCreator
 			ImpactSound: kaboom22
 			Delay: 36
 

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -1079,9 +1079,7 @@ Weapons:
 		Warhead@areanuke2:
 			DamageModel: PerCell
 			Damage: 250
-			SmudgeType: Scorch
-			Size: 4,3
-			Ore: true
+			Size: 4
 			Versus:
 				None: 90%
 				Light: 60%
@@ -1089,13 +1087,21 @@ Weapons:
 				Concrete: 50%
 			Delay: 12
 			InfDeath: 4
+		Warhead@areanuke2Smu: Smudger
+			SmudgeType: Scorch
+			Size: 4,3
+			Delay: 12
+		Warhead@areanuke2Res: Resourcer
+			DestroyResources: true
+			Size: 4,3
+			Delay: 12
+		Warhead@areanuke2Eff: EffectCreator
 			ImpactSound: kaboom22
+			Delay: 12
 		Warhead@areanuke3:
 			DamageModel: PerCell
 			Damage: 250
-			SmudgeType: Scorch
-			Size: 3,2
-			Ore: true
+			Size: 3
 			Versus:
 				None: 90%
 				Light: 60%
@@ -1103,13 +1109,20 @@ Weapons:
 				Concrete: 50%
 			Delay: 24
 			InfDeath: 4
+		Warhead@areanuke3Smu: Smudger
+			SmudgeType: Scorch
+			Size: 3,2
+			Delay: 24
+		Warhead@areanuke3Res: Resourcer
+			DestroyResources: true
+			Size: 3,2
+			Delay: 24
+		Warhead@areanuke3Eff: EffectCreator
 			ImpactSound: kaboom22
+			Delay: 24
 		Warhead@areanuke4:
 			DamageModel: PerCell
 			Damage: 250
-			SmudgeType: Scorch
-			Size: 2,1
-			Ore: true
 			Versus:
 				None: 90%
 				Light: 60%
@@ -1117,7 +1130,17 @@ Weapons:
 				Concrete: 50%
 			Delay: 36
 			InfDeath: 4
+		Warhead@areanuke3Smu: Smudger
+			SmudgeType: Scorch
+			Size: 2,1
+			Delay: 36
+		Warhead@areanuke3Res: Resourcer
+			DestroyResources: true
+			Size: 2,1
+			Delay: 36
+		Warhead@areanuke3Eff: EffectCreator
 			ImpactSound: kaboom22
+			Delay: 36
 
 Voices:
 

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -1076,7 +1076,7 @@ VoxelSequences:
 
 Weapons:
 	CrateNuke:
-		Warhead@areanuke2:
+		Warhead@areanuke2: Damager
 			DamageModel: PerCell
 			Damage: 250
 			Size: 4
@@ -1098,7 +1098,7 @@ Weapons:
 		Warhead@areanuke2Eff: EffectCreator
 			ImpactSound: kaboom22
 			Delay: 12
-		Warhead@areanuke3:
+		Warhead@areanuke3: Damager
 			DamageModel: PerCell
 			Damage: 250
 			Size: 3
@@ -1120,7 +1120,7 @@ Weapons:
 		Warhead@areanuke3Eff: EffectCreator
 			ImpactSound: kaboom22
 			Delay: 24
-		Warhead@areanuke4:
+		Warhead@areanuke4: Damager
 			DamageModel: PerCell
 			Damage: 250
 			Versus:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -54,6 +54,9 @@
 	CaptureNotification:
 		Notification: UnitStolen
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
+	WithDisabledOverlay:
 
 ^Tank:
 	AppearsOnRadar:
@@ -111,6 +114,9 @@
 	CaptureNotification:
 		Notification: UnitStolen
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
+	WithDisabledOverlay:
 
 ^Infantry:
 	AppearsOnRadar:
@@ -180,6 +186,8 @@
 		KilledOnImpassableTerrain: true
 		ParachuteSequence: parach
 		ShadowSequence: parach-shadow
+	DisabledByWarhead:
+		TargetTypes: Paralyze
 
 ^Ship:
 	AppearsOnRadar:
@@ -213,6 +221,9 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
+	WithDisabledOverlay:
 
 ^Plane:
 	AppearsOnRadar:
@@ -249,6 +260,9 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
+	WithDisabledOverlay:
 
 ^Helicopter:
 	Inherits: ^Plane
@@ -303,6 +317,9 @@
 	LuaScriptEvents:
 	Demolishable:
 	ScriptTriggers:
+	DisabledByWarhead:
+		TargetTypes: EMP
+	WithDisabledOverlay:
 
 ^Wall:
 	AppearsOnRadar:

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -4,7 +4,7 @@ Colt45:
 	Report: GUN5.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 42
 		Versus:
 			None: 100%
@@ -12,10 +12,11 @@ Colt45:
 			Light: 0%
 			Heavy: 0%
 			Concrete: 0%
-		Explosion: piff
-		WaterExplosion: water_piff
 		InfDeath: 2
 		Damage: 50
+	Warhead@Eff: EffectCreator
+		Explosion: piff
+		WaterExplosion: water_piff
 
 ZSU-23:
 	Burst: 2
@@ -23,19 +24,20 @@ ZSU-23:
 	ROF: 0
 	Range: 10c0
 	Report: AACANON3.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 213
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
-		Explosion: small_explosion_air
 		Damage: 12
+	Warhead@Eff: EffectCreator
+		Explosion: small_explosion_air
 
 Vulcan:
 	ROF: 30
@@ -43,76 +45,87 @@ Vulcan:
 	Report: GUN13.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead@1:
+	Warhead@1: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 10
-	Warhead@2:
+	Warhead@Eff1: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
+	Warhead@2: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 10
 		Delay: 2
-	Warhead@3:
+	Warhead@Eff2: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
+		Delay: 2
+	Warhead@3: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 10
 		Delay: 4
-	Warhead@4:
+	Warhead@Eff3: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
+		Delay: 4
+	Warhead@4: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 10
 		Delay: 6
-	Warhead@5:
+	Warhead@Eff4: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
+		Delay: 6
+	Warhead@5: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 10
 		Delay: 8
-	Warhead@6:
+	Warhead@Eff5: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
+		Delay: 8
+	Warhead@6: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 10
+		Delay: 10
+	Warhead@Eff6: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
 		Delay: 10
 
 Maverick:
@@ -122,7 +135,7 @@ Maverick:
 	Report: MISSILE7.AUD
 	Burst: 2
 	BurstDelay: 7
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -132,20 +145,22 @@ Maverick:
 		Image: DRAGON
 		ROT: 5
 		RangeLimit: 60
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 70
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 70
 
 FireballLauncher:
 	ROF: 65
@@ -156,7 +171,7 @@ FireballLauncher:
 		Speed: 204
 		Trail: fb2
 		Image: FB1
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 213
 		Versus:
 			None: 90%
@@ -164,12 +179,14 @@ FireballLauncher:
 			Light: 60%
 			Heavy: 25%
 			Concrete: 50%
+		InfDeath: 5
+		Damage: 150
+	Warhead@Eff: EffectCreator
 		Explosion: napalm
 		WaterExplosion: napalm
-		InfDeath: 5
-		SmudgeType: Scorch
 		ImpactSound: firebl3.aud
-		Damage: 150
+	Warhead@Smu: Smudger
+		SmudgeType: Scorch
 
 Flamer:
 	ROF: 50
@@ -182,7 +199,7 @@ Flamer:
 		Image: fb3
 		Angle: 62
 		Inaccuracy: 853
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 341
 		Versus:
 			None: 90%
@@ -190,12 +207,14 @@ Flamer:
 			Light: 60%
 			Heavy: 25%
 			Concrete: 50%
+		InfDeath: 5
+		Damage: 8
+	Warhead@Eff: EffectCreator
 		Explosion: small_napalm
 		WaterExplosion: small_napalm
-		InfDeath: 5
-		SmudgeType: Scorch
 		ImpactSound: firebl3.aud
-		Damage: 8
+	Warhead@Smu: Smudger
+		SmudgeType: Scorch
 
 ChainGun:
 	ROF: 10
@@ -205,7 +224,7 @@ ChainGun:
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 120%
@@ -213,10 +232,11 @@ ChainGun:
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 30
+	Warhead@Eff: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
 
 ChainGun.Yak:
 	ROF: 3
@@ -226,17 +246,18 @@ ChainGun.Yak:
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 40
+	Warhead@Eff: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
 
 Pistol:
 	ROF: 7
@@ -244,17 +265,18 @@ Pistol:
 	Report: GUN27.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			Wood: 50%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 25%
-		Explosion: piff
-		WaterExplosion: water_piff
 		InfDeath: 2
 		Damage: 1
+	Warhead@Eff: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
 
 M1Carbine:
 	ROF: 20
@@ -262,23 +284,24 @@ M1Carbine:
 	Report: GUN11.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			Wood: 25%
 			Light: 30%
 			Heavy: 10%
 			Concrete: 10%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 15
+	Warhead@Eff: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
 
 Dragon:
 	ROF: 50
 	Range: 5c0
 	Report: MISSILE6.AUD
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 213
 		Arm: 2
@@ -289,20 +312,22 @@ Dragon:
 		Image: DRAGON
 		ROT: 5
 		RangeLimit: 35
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 10%
 			Wood: 75%
 			Light: 35%
 			Concrete: 20%
+		InfDeath: 4
+		Damage: 50
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion
 		WaterExplosion: med_splash
-		InfDeath: 4
-		SmudgeType: Crater
-		Damage: 50
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Crater
 
 HellfireAG:
 	ROF: 60
@@ -310,7 +335,7 @@ HellfireAG:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 10
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -320,20 +345,22 @@ HellfireAG:
 		Image: DRAGON
 		ROT: 10
 		RangeLimit: 20
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 60
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion
 		WaterExplosion: med_splash
-		InfDeath: 4
-		SmudgeType: Crater
-		Damage: 60
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Crater
 
 HellfireAA:
 	ROF: 60
@@ -341,7 +368,7 @@ HellfireAA:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 10
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 384
 		Arm: 2
@@ -351,19 +378,22 @@ HellfireAA:
 		Image: DRAGON
 		ROT: 10
 		RangeLimit: 20
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 40
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion_air
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
-		InfDeath: 4
+		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 40
 
 Grenade:
 	ROF: 60
@@ -375,20 +405,22 @@ Grenade:
 		Angle: 62
 		Inaccuracy: 554
 		Image: BOMB
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 256
 		Versus:
 			None: 50%
 			Wood: 100%
 			Light: 25%
 			Heavy: 5%
+		InfDeath: 3
+		Damage: 60
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion
 		WaterExplosion: small_splash
-		InfDeath: 3
-		SmudgeType: Crater
-		Damage: 60
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Crater
 
 25mm:
 	ROF: 13
@@ -397,18 +429,20 @@ Grenade:
 	Projectile: Bullet
 		Speed: 853
 		Image: 50CAL
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 30%
 			Wood: 40%
 			Heavy: 40%
 			Concrete: 30%
+		InfDeath: 4
+		Damage: 16
+	Warhead@Eff: EffectCreator
 		Explosion: small_explosion
 		WaterExplosion: small_splash
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 16
 
 90mm:
 	ROF: 50
@@ -417,20 +451,22 @@ Grenade:
 	Projectile: Bullet
 		Speed: 682
 		Image: 120MM
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 20%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 40
+	Warhead@Eff: EffectCreator
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 40
 
 105mm:
 	ROF: 70
@@ -441,44 +477,48 @@ Grenade:
 	Projectile: Bullet
 		Speed: 682
 		Image: 120MM
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 20%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 40
+	Warhead@Eff: EffectCreator
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 40
 
 120mm:
 	ROF: 90
 	Range: 4c768
 	Report: CANNON1.AUD
 	Burst: 2
-	InvalidTargets: Air, Infantry
+	InvalidTargets: Air, Infantry, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 682
 		Image: 120MM
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 20%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 60
+	Warhead@Eff: EffectCreator
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 60
 
 TurretGun:
 	ROF: 30
@@ -487,27 +527,29 @@ TurretGun:
 	Projectile: Bullet
 		Speed: 682
 		Image: 120MM
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 20%
 			Wood: 50%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 60
+	Warhead@Eff: EffectCreator
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 60
 
 MammothTusk:
 	ROF: 60
 	Range: 8c0
 	Report: MISSILE6.AUD
 	Burst: 2
-	ValidTargets: Air, Infantry
+	ValidTargets: Air, Infantry, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 341
 		Arm: 2
@@ -517,20 +559,22 @@ MammothTusk:
 		Image: DRAGON
 		ROT: 15
 		RangeLimit: 40
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 256
 		Versus:
 			None: 100%
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
+		InfDeath: 3
+		Damage: 50
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion_air
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 3
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 50
 
 155mm:
 	ROF: 85
@@ -544,7 +588,7 @@ MammothTusk:
 		Inaccuracy: 1c682
 		Image: 120MM
 		ContrailLength: 30
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 426
 		Versus:
 			None: 90%
@@ -552,13 +596,15 @@ MammothTusk:
 			Light: 60%
 			Heavy: 25%
 			Concrete: 50%
+		InfDeath: 3
+		Damage: 220
+	Warhead@Eff: EffectCreator
 		Explosion: artillery_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom15.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 3
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 220
 
 M60mg:
 	ROF: 30
@@ -567,17 +613,18 @@ M60mg:
 	Burst: 5
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			Wood: 10%
 			Light: 30%
 			Heavy: 10%
 			Concrete: 10%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 15
+	Warhead@Eff: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
 
 Napalm:
 	ROF: 20
@@ -586,38 +633,42 @@ Napalm:
 		Image: BOMBLET
 		Speed: 85
 		High: yes
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 170
 		Versus:
 			None: 90%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 50%
+		InfDeath: 5
+		Damage: 100
+	Warhead@Eff: EffectCreator
 		Explosion: napalm
 		WaterExplosion: med_splash
-		InfDeath: 5
-		SmudgeType: Scorch
 		ImpactSound: firebl3.aud
 		WaterImpactSound: splash9.aud
-		Damage: 100
+	Warhead@Smu: Smudger
+		SmudgeType: Scorch
 
 CrateNapalm:
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 170
 		Versus:
 			None: 90%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 50%
+		InfDeath: 5
+		Damage: 600
+	Warhead@Eff: EffectCreator
 		Explosion: napalm
 		WaterExplosion: napalm
-		InfDeath: 5
-		SmudgeType: Scorch
 		ImpactSound: firebl3.aud
-		Damage: 600
+	Warhead@Smu: Smudger
+		SmudgeType: Scorch
 
 CrateExplosion:
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 500
 		Spread: 426
 		Versus:
@@ -625,31 +676,32 @@ CrateExplosion:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
+		InfDeath: 4
+	Warhead@Eff: EffectCreator
 		Explosion: self_destruct
 		WaterExplosion: self_destruct
-		InfDeath: 4
 		ImpactSound: kaboom15.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Scorch
 
 CrateNuke:
-	Warhead@impact:
+	Warhead@impact: Damager
 		Damage: 1000
 		Spread: 256
-		DestroyResources: true
 		Versus:
 			None: 90%
 			Light: 60%
 			Heavy: 25%
 			Concrete: 50%
+		InfDeath: 5
+	Warhead@impactEff: EffectCreator
 		Explosion: nuke
 		WaterExplosion: nuke
-		InfDeath: 5
 		ImpactSound: kaboom1.aud
-	Warhead@areanuke:
+	Warhead@areanuke: Damager
 		DamageModel: PerCell
 		Damage: 250
-		SmudgeType: Scorch
-		Size: 5,4
-		DestroyResources: true
+		Size: 5
 		Versus:
 			None: 90%
 			Light: 60%
@@ -657,7 +709,19 @@ CrateNuke:
 			Concrete: 50%
 		Delay: 4
 		InfDeath: 5
+	Warhead@areanukeEff: EffectCreator
+		Explosion: nuke
+		WaterExplosion: nuke
 		ImpactSound: kaboom22.aud
+		Delay: 4
+	Warhead@areanukeSmu: Smudger
+		SmudgeType: Scorch
+		Delay: 4
+		Size: 5
+	Warhead@areanukeRes: Resourcer
+		Delay: 4
+		Size: 5
+		DestroyResources: true
 
 TeslaZap:
 	ROF: 3
@@ -665,19 +729,26 @@ TeslaZap:
 	Range: 8c512
 	Report: TESLA1.AUD
 	Projectile: TeslaZap
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		InfDeath: 6
 		Damage: 100
 		Versus:
 			None: 1000%
 			Wood: 60%
+	Warhead@Dis: Disabler
+		ValidTargets: EMP, Enemy, Neutral
+		Spread: 42
+		SpreadFactor: 100%
+		DisableTicks: 25
+		Versus:
+			Wood: 30%
 
 Nike:
 	ROF: 15
 	Range: 7c512
 	Report: MISSILE1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 3
 		High: true
@@ -686,7 +757,7 @@ Nike:
 		ROT: 25
 		RangeLimit: 50
 		Speed: 341
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 90%
@@ -694,17 +765,19 @@ Nike:
 			Light: 90%
 			Heavy: 50%
 			Concrete: 0%
+		InfDeath: 3
+		Damage: 50
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion_air
 		ImpactSound: kaboom25.aud
-		InfDeath: 3
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 50
 
 RedEye:
 	ROF: 50
 	Range: 7c512
 	Report: MISSILE1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 3
 		High: true
@@ -713,18 +786,20 @@ RedEye:
 		ROT: 20
 		RangeLimit: 30
 		Speed: 298
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 90%
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
+		InfDeath: 3
+		Damage: 40
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion_air
 		ImpactSound: kaboom25.aud
-		InfDeath: 3
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 40
 
 8Inch:
 	ROF: 250
@@ -738,20 +813,22 @@ RedEye:
 		Inaccuracy: 2c938
 		Image: 120MM
 		ContrailLength: 30
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 213
 		Versus:
 			None: 60%
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
+		InfDeath: 3
+		Damage: 250
+	Warhead@Eff: EffectCreator
 		Explosion: artillery_explosion
 		WaterExplosion: large_splash
-		InfDeath: 3
-		SmudgeType: Crater
-		Damage: 250
 		ImpactSound: kaboom15.aud
 		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Crater
 
 SubMissile:
 	ROF: 300
@@ -766,19 +843,21 @@ SubMissile:
 		Image: MISSILE
 		Trail: smokey
 		ContrailLength: 30
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 426
 		Versus:
 			None: 40%
 			Light: 30%
 			Heavy: 30%
+		InfDeath: 3
+		Damage: 300
+	Warhead@Eff: EffectCreator
 		Explosion: artillery_explosion
 		WaterExplosion: large_splash
-		InfDeath: 3
-		SmudgeType: Crater
-		Damage: 300
 		ImpactSound: kaboom15.aud
 		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Crater
 
 Stinger:
 	ROF: 60
@@ -786,7 +865,7 @@ Stinger:
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 0
-	ValidTargets: Air, Ground, Water
+	ValidTargets: Air, Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Arm: 3
 		High: true
@@ -796,26 +875,28 @@ Stinger:
 		RangeLimit: 50
 		TurboBoost: true
 		Speed: 170
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 30
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 30
 
 TorpTube:
 	ROF: 100
 	Range: 9c0
 	Report: TORPEDO1.AUD
-	ValidTargets: Water, Underwater, Bridge
+	ValidTargets: Water, Underwater, Bridge, Enemy, Neutral, Ally
 	Palette: shadow
 	Burst: 2
 	BurstDelay: 20
@@ -827,20 +908,22 @@ TorpTube:
 		ROT: 1
 		RangeLimit: 160
 		BoundToTerrainType: Water
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 426
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 500%
+		InfDeath: 4
+		Damage: 180
+	Warhead@Eff: EffectCreator
 		WaterExplosion: large_splash
 		WaterImpactSound: splash9.aud
 		Explosion: large_explosion
 		ImpactSound: kaboom12.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 180
 
 2Inch:
 	ROF: 60
@@ -849,43 +932,47 @@ TorpTube:
 	Projectile: Bullet
 		Speed: 426
 		Image: 120MM
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 25
+	Warhead@Eff: EffectCreator
 		Explosion: small_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom12.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 25
 
 DepthCharge:
 	ROF: 60
 	Range: 5c0
-	ValidTargets: Underwater
+	ValidTargets: Underwater, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 85
 		Image: BOMB
 		Angle: 62
 		High: true
 		Inaccuracy: 128
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 80
+	Warhead@Eff: EffectCreator
 		WaterExplosion: large_splash
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 80
 
 ParaBomb:
 	ROF: 10
@@ -895,27 +982,29 @@ ParaBomb:
 		Image: PARABOMB
 		Velocity: 43
 		Acceleration: 0
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 256
 		Versus:
 			None: 30%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 500
+	Warhead@Eff: EffectCreator
 		Explosion: self_destruct
 		WaterExplosion: small_splash
-		InfDeath: 4
-		SmudgeType: Crater
-		Damage: 500
 		ImpactSound: kaboom15.aud
 		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Crater
 
 DogJaw:
-	ValidTargets: Infantry
+	ValidTargets: Infantry, Enemy, Neutral, Ally
 	ROF: 10
 	Range: 3c0
 	Report: DOGG5P.AUD
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			Wood: 0%
@@ -931,7 +1020,7 @@ Heal:
 	Report: HEAL2.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			Wood: 0%
@@ -945,10 +1034,10 @@ Repair:
 	ROF: 80
 	Range: 4c0
 	Report: FIXIT1.AUD
-	ValidTargets: Repair
+	ValidTargets: Repair, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			None: 0%
@@ -965,17 +1054,18 @@ SilencedPPK:
 	Report: silppk.aud
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			Wood: 0%
 			Light: 0%
 			Heavy: 0%
 			Concrete: 0%
-		Explosion: piffs
-		WaterExplosion: water_piffs
 		InfDeath: 2
 		Damage: 150
+	Warhead@Eff: EffectCreator
+		Explosion: piffs
+		WaterExplosion: water_piffs
 
 SCUD:
 	ROF: 240
@@ -991,122 +1081,288 @@ SCUD:
 		Inaccuracy: 213
 		Image: V2
 		Angle: 62
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 341
 		Versus:
 			None: 90%
 			Wood: 75%
 			Light: 70%
 			Heavy: 40%
+		InfDeath: 3
+		Damage: 450
+	Warhead@Eff: EffectCreator
 		Explosion: napalm
 		WaterExplosion: large_splash
-		InfDeath: 3
-		SmudgeType: Crater
-		Damage: 450
 		ImpactSound: firebl3.aud
 		WaterImpactSound: splash9.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Crater
 
 Atomic:
-	ValidTargets: Ground, Water, Air
-	Warhead@impact:
+	ValidTargets: Ground, Water, Air, Enemy, Neutral, Ally
+	Warhead@impact: Damager
+		DamageModel: Absolute
 		Damage: 1500
 		Spread: 1c0
-		SmudgeType: Scorch
-		Size: 1
-		DestroyResources: true
 		Versus:
 			Concrete: 25%
+		InfDeath: 5
+	Warhead@impactEff: EffectCreator
 		Explosion: nuke
 		WaterExplosion: nuke
-		InfDeath: 5
 		ImpactSound: kaboom1.aud
-	Warhead@areanuke1:
-		Damage: 600
-		Spread: 2c0
+	Warhead@impactSmu: Smudger
 		SmudgeType: Scorch
-		Size: 2
+		Size: 1
+	Warhead@impactRes: Resourcer
 		DestroyResources: true
+		Size: 1
+	Warhead@areanuke1: Damager
+		DamageModel: Absolute
+		Damage: 600
+		Spread: 1c0, 2c0
+		SpreadFactor: 0%, 100%
 		Versus:
 			Concrete: 25%
 		Delay: 5
 		InfDeath: 5
+	Warhead@areanuke1Eff: EffectCreator
+		Explosion: napalm
+		WaterExplosion: napalm
 		ImpactSound: kaboom22.aud
-	Warhead@areanuke2:
-		Damage: 600
-		Spread: 3c0
+		Size: 2,1
+		Delay: 5
+	Warhead@areanuke1Smu: Smudger
 		SmudgeType: Scorch
-		Size: 3
+		Size: 2,1
+		Delay: 5
+	Warhead@areanuke1Res: Resourcer
 		DestroyResources: true
+		Size: 2,1
+		Delay: 5
+	Warhead@areanuke2: Damager
+		DamageModel: Absolute
+		Damage: 600
+		Spread: 2c0, 3c0
+		SpreadFactor: 0%, 100%
 		Versus:
 			Concrete: 25%
 		Delay: 10
 		InfDeath: 5
-	Warhead@areanuke3:
-		Damage: 600
-		Spread: 4c0
+	Warhead@areanuke2Eff: EffectCreator
+		Explosion: napalm
+		WaterExplosion: napalm
+		ImpactSound: kaboom22.aud
+		Size: 3,2
+		Delay: 10
+	Warhead@areanuke2Smu: Smudger
 		SmudgeType: Scorch
-		Size: 4
+		Size: 3,2
+		Delay: 10
+	Warhead@areanuke2Res: Resourcer
 		DestroyResources: true
+		Size: 3,2
+		Delay: 10
+	Warhead@areanuke3: Damager
+		DamageModel: Absolute
+		Damage: 600
+		Spread: 3c0, 4c0
+		SpreadFactor: 0%, 100%
 		Versus:
 			Concrete: 25%
 		Delay: 15
 		InfDeath: 5
-	Warhead@areanuke4:
-		Damage: 600
-		Spread: 5c0
+	Warhead@areanuke3Eff: EffectCreator
+		Explosion: napalm
+		WaterExplosion: napalm
+		ImpactSound: kaboom22.aud
+		Size: 4,3
+		Delay: 15
+	Warhead@areanuke3Smu: Smudger
 		SmudgeType: Scorch
-		Size: 5
+		Size: 4,3
+		Delay: 15
+	Warhead@areanuke3Res: Resourcer
 		DestroyResources: true
+		Size: 4,3
+		Delay: 15
+	Warhead@areanuke4: Damager
+		DamageModel: Absolute
+		Damage: 150
+		Spread: 4c0, 5c0
+		SpreadFactor: 0%, 100%
 		Versus:
 			Concrete: 25%
 		Delay: 20
 		InfDeath: 5
+	Warhead@areanuke4Eff: EffectCreator
+		Explosion: small_napalm
+		WaterExplosion: small_napalm
+		ImpactSound: kaboom22.aud
+		Size: 5,4
+		Delay: 20
+	Warhead@areanuke4Smu: Smudger
+		SmudgeType: Scorch
+		Size: 5,4
+		Delay: 20
+	Warhead@areanuke4Res: Resourcer
+		DestroyResources: true
+		Size: 5,4
+		Delay: 20
+	Warhead@areanuke5: Damager
+		DamageModel: Absolute
+		Damage: 150
+		Spread: 5c0, 6c0
+		SpreadFactor: 0%, 100%
+		Versus:
+			Concrete: 25%
+		Delay: 25
+		InfDeath: 5
+	Warhead@areanuke5Eff: EffectCreator
+		Explosion: small_napalm
+		WaterExplosion: small_napalm
+		ImpactSound: kaboom22.aud
+		Size: 6,5
+		Delay: 25
+	Warhead@areanuke5Smu: Smudger
+		SmudgeType: Scorch
+		Size: 6,5
+		Delay: 25
+	Warhead@areanuke5Res: Resourcer
+		DestroyResources: true
+		Size: 6,5
+		Delay: 25
+	Warhead@areanuke6: Damager
+		DamageModel: Absolute
+		Damage: 150
+		Spread: 6c0, 7c0
+		SpreadFactor: 0%, 100%
+		Versus:
+			Concrete: 25%
+		Delay: 30
+		InfDeath: 5
+	Warhead@areanuke6Eff: EffectCreator
+		Explosion: small_napalm
+		WaterExplosion: small_napalm
+		ImpactSound: kaboom22.aud
+		Size: 7,6
+		Delay: 30
+	Warhead@areanuke6Smu: Smudger
+		SmudgeType: Scorch
+		Size: 7,6
+		Delay: 30
+	Warhead@areanuke6Res: Resourcer
+		DestroyResources: true
+		Size: 7,6
+		Delay: 30
+	Warhead@areanuke7: Damager
+		DamageModel: Absolute
+		Damage: 150
+		Spread: 7c0, 8c0, 9c0, 10c0
+		SpreadFactor: 0%, 100%, 50%, 25%
+		Versus:
+			Concrete: 25%
+		Delay: 35
+		InfDeath: 5
+	Warhead@areanuke7Eff: EffectCreator
+		Explosion: small_napalm
+		WaterExplosion: small_napalm
+		ImpactSound: kaboom22.aud
+		Size: 10,7
+		Delay: 35
+	Warhead@areanuke7Smu: Smudger
+		SmudgeType: Scorch
+		Size: 10,7
+		Delay: 35
 
 MiniNuke:
-	ValidTargets: Ground, Water, Air
-	Warhead@impact:
+	ValidTargets: Ground, Water, Air, Enemy, Neutral, Ally
+	Warhead@impact: Damager
 		Damage: 1500
 		Spread: 1c0
 		Size: 1
-		DestroyResources: true
 		Versus:
 			Concrete: 25%
+		InfDeath: 5
+	Warhead@impactEff: EffectCreator
 		Explosion: nuke
 		WaterExplosion: nuke
-		InfDeath: 5
 		ImpactSound: kaboom1.aud
-	Warhead@areanuke1:
+	Warhead@impactSmu: Smudger
+		SmudgeType: Scorch
+		Size: 1
+	Warhead@impactRes: Resourcer
+		DestroyResources: true
+		Size: 1
+	Warhead@areanuke1: Damager
 		Damage: 600
 		Spread: 2c0
 		Size: 2
-		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 5
 		InfDeath: 5
+	Warhead@areanuke1Eff: EffectCreator
+		Explosion: small_napalm
+		WaterExplosion: small_napalm
 		ImpactSound: kaboom22.aud
-	Warhead@areanuke2:
+		Size: 2,1
+		Delay: 5
+	Warhead@areanuke1Smu: Smudger
+		SmudgeType: Scorch
+		Size: 2,1
+		Delay: 5
+	Warhead@areanuke1Res: Resourcer
+		DestroyResources: true
+		Size: 2,1
+		Delay: 5
+	Warhead@areanuke2: Damager
 		Damage: 600
 		Spread: 3c0
 		Size: 3
-		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 10
 		InfDeath: 5
-	Warhead@areanuke3:
+	Warhead@areanuke2Eff: EffectCreator
+		Explosion: small_napalm
+		WaterExplosion: small_napalm
+		ImpactSound: kaboom22.aud
+		Size: 3,2
+		Delay: 10
+	Warhead@areanuke2Smu: Smudger
+		SmudgeType: Scorch
+		Size: 3,2
+		Delay: 10
+	Warhead@areanuke2Res: Resourcer
+		DestroyResources: true
+		Size: 3,2
+		Delay: 10
+	Warhead@areanuke3: Damager
 		Damage: 600
 		Spread: 4c0
 		Size: 4
-		SmudgeType: Scorch
-		DestroyResources: true
 		Versus:
 			Concrete: 25%
 		Delay: 15
 		InfDeath: 5
+	Warhead@areanuke3Eff: EffectCreator
+		Explosion: small_napalm
+		WaterExplosion: small_napalm
+		ImpactSound: kaboom22.aud
+		Size: 4,3
+		Delay: 15
+	Warhead@areanuke3Smu: Smudger
+		SmudgeType: Scorch
+		Size: 4,3
+		Delay: 15
+	Warhead@areanuke3Res: Resourcer
+		DestroyResources: true
+		Size: 4,3
+		Delay: 15
 
 UnitExplode:
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 500
 		Spread: 426
 		Versus:
@@ -1114,14 +1370,15 @@ UnitExplode:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
+		InfDeath: 4
+	Warhead@Eff: EffectCreator
 		Explosion: self_destruct
 		WaterExplosion: large_splash
-		InfDeath: 4
 		ImpactSound: kaboom22.aud
 		WaterImpactSound: splash9.aud
 
 UnitExplodeShip:
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 50
 		Spread: 426
 		Versus:
@@ -1129,14 +1386,15 @@ UnitExplodeShip:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
+		InfDeath: 4
+	Warhead@Eff: EffectCreator
 		Explosion: building
 		WaterExplosion: building
-		InfDeath: 4
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: kaboom25.aud
 
 UnitExplodeSubmarine:
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 50
 		Spread: 426
 		Versus:
@@ -1144,12 +1402,13 @@ UnitExplodeSubmarine:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		WaterExplosion: large_splash
 		InfDeath: 4
+	Warhead@Eff: EffectCreator
+		WaterExplosion: large_splash
 		WaterImpactSound: splash9.aud
 
 UnitExplodeSmall:
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 40
 		Spread: 426
 		Versus:
@@ -1157,14 +1416,15 @@ UnitExplodeSmall:
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
+		InfDeath: 4
+	Warhead@Eff: EffectCreator
 		Explosion: large_explosion
 		WaterExplosion: large_splash
-		InfDeath: 4
 		ImpactSound: kaboom15.aud
 		WaterImpactSound: splash9.aud
 
 BarrelExplode:
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 500
 		Spread: 426
 		Versus:
@@ -1173,35 +1433,42 @@ BarrelExplode:
 			Light: 50%
 			Heavy: 25%
 			Concrete: 10%
-		Explosion: napalm
 		InfDeath: 4
-		ImpactSound: firebl3.aud
-		SmudgeType: Scorch
 		Delay: 5
-		Size: 2,1
+		Size: 2
+	Warhead@Eff: EffectCreator
+		Explosion: napalm
+		ImpactSound: firebl3.aud
+	Warhead@Smu: Smudger
+		SmudgeType: Scorch
+		Size: 2
+		Delay: 5
 
 Crush:
-	Warhead:
-		ImpactSound: squishy2.aud
+	Warhead@Dam: Damager
 		Damage: 100
+	Warhead@Eff: EffectCreator
+		ImpactSound: squishy2.aud
 
 ATMine:
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 256
 		Damage: 400
+	Warhead@Eff: EffectCreator
 		ImpactSound: mineblo1.aud
 		Explosion: large_explosion
 
 APMine:
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 256
 		Damage: 400
-		ImpactSound: mine1.aud
 		InfDeath: 3
+	Warhead@Eff: EffectCreator
+		ImpactSound: mine1.aud
 		Explosion: napalm
 
 Demolish:
-	Warhead:
+	Warhead@Eff: EffectCreator
 		ImpactSound: kaboom25.aud
 		Explosion: building
 
@@ -1211,12 +1478,19 @@ PortaTesla:
 	Report: TESLA1.AUD
 	Charges: yes
 	Projectile: TeslaZap
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 42
 		InfDeath: 6
 		Damage: 45
 		Versus:
 			None: 1000%
+	Warhead@Dis: Disabler
+		ValidTargets: EMP, Enemy, Neutral
+		Spread: 42
+		SpreadFactor: 100%
+		DisableTicks: 25
+		Versus:
+			Wood: 50%
 
 TTankZap:
 	ROF: 120
@@ -1224,22 +1498,29 @@ TTankZap:
 	Report: TESLA1.AUD
 	Charges: yes
 	Projectile: TeslaZap
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 42
 		InfDeath: 6
 		Damage: 100
 		Versus:
 			None: 1000%
+	Warhead@Dis: Disabler
+		ValidTargets: EMP, Enemy, Neutral
+		Spread: 42
+		SpreadFactor: 100%
+		DisableTicks: 25
+		Versus:
+			Wood: 50%
 
 FLAK-23:
 	ROF: 10
 	Range: 8c0
 	Report: AACANON3.AUD
-	ValidTargets: Air, Ground, Water
+	ValidTargets: Air, Ground, Water, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 1c682
 		High: true
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 213
 		Versus:
 			None: 40%
@@ -1247,9 +1528,10 @@ FLAK-23:
 			Light: 60%
 			Heavy: 10%
 			Concrete: 20%
+		Damage: 20
+	Warhead@Eff: EffectCreator
 		Explosion: small_explosion_air
 		WaterExplosion: small_splash
-		Damage: 20
 
 Sniper:
 	Report: GUN5.AUD
@@ -1257,7 +1539,7 @@ Sniper:
 	Range: 10c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 140
 		Spread: 42
 		Versus:
@@ -1272,7 +1554,7 @@ APTusk:
 	ROF: 60
 	Range: 6c0
 	Report: MISSILE6.AUD
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 298
 		Arm: 2
@@ -1283,27 +1565,29 @@ APTusk:
 		Image: DRAGON
 		ROT: 10
 		RangeLimit: 22
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 128
 		Versus:
 			None: 25%
 			Wood: 75%
 			Light: 75%
 			Concrete: 50%
+		InfDeath: 4
+		Damage: 30
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
 		WaterImpactSound: splash9.aud
-		InfDeath: 4
+	Warhead@Smu: Smudger
 		SmudgeType: Crater
-		Damage: 30
 
 Claw:
 	ROF: 30
 	Range: 1c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 213
 		Versus:
 			None: 90%
@@ -1319,7 +1603,7 @@ Mandible:
 	Range: 1c0
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead@Dam: Damager
 		Spread: 213
 		Versus:
 			None: 90%
@@ -1332,37 +1616,48 @@ Mandible:
 
 MADTankThump:
 	InvalidTargets: MADTank
-	Warhead:
+	Warhead@Dam: Damager
 		DamageModel: HealthPercentage
 		Damage: 1
 		Versus:
 			None: 0%
-		Size: 7,6
+		Size: 7
 
 MADTankDetonate:
 	InvalidTargets: MADTank
-	Warhead:
+	Warhead: Damager
 		DamageModel: HealthPercentage
 		Damage: 19
 		Versus:
 			None: 0%
-		Size: 7,6
+		Size: 7
+	Warhead@Eff: EffectCreator
 		Explosion: med_explosion
 		ImpactSound: mineblo1.aud
+	Warhead@Smu1: Smudger
 		SmudgeType: Crater
+		Size: 2,1
+	Warhead@Smu2: Smudger
+		SmudgeType: Crater
+		Size: 4,3
+	Warhead@Smu3: Smudger
+		SmudgeType: Crater
+		Size: 7,6
 
 OreExplosion:
-	Warhead:
+	Warhead@Dam: Damager
 		Damage: 10
 		Spread: 9
-		Size: 1,1
 		Versus:
 			None: 90%
 			Wood: 75%
 			Light: 60%
 			Heavy: 25%
-		Explosion: med_explosion
 		InfDeath: 3
+	Warhead@Eff: EffectCreator
+		Explosion: med_explosion
 		ImpactSound: kaboom25.aud
+	Warhead@Res: Resourcer
+		Size: 1
 		AddsResourceType: Ore
 

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -811,16 +811,19 @@ TiberiumHeal:
 
 IonCannon:
 	ValidTargets: Ground, Air, Enemy, Neutral, Ally
-	Warhead@impact:
+	Warhead@1Eff: EffectCreator
+		Explosion: ring1
+	Warhead@impact: Damager
 		Damage: 1000
 		Spread: 1c0
 		InfDeath: 5
-		Explosion: ring1
 		ProneModifier: 100
-	Warhead@area:
+	Warhead@2Smu: Smudger
+		SmudgeType: Scorch
+		Size: 2
+	Warhead@area: Damager
 		DamageModel: PerCell
 		Damage: 250
-		SmudgeType: Scorch
 		Size: 2
 		Delay: 3
 		InfDeath: 5
@@ -931,3 +934,4 @@ TiberiumExplosion:
 		Explosion: large_explosion
 		ImpactSound: expnew09.aud
 		AddsResourceType: Tiberium
+

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -1,5 +1,5 @@
 UnitExplode:
-	Warhead:
+	Warhead: Damager
 		Damage: 500
 		Spread: 426
 		Versus:
@@ -12,7 +12,7 @@ UnitExplode:
 		ImpactSound: expnew09.aud
 
 UnitExplodeSmall:
-	Warhead:
+	Warhead: Damager
 		Damage: 40
 		Spread: 426
 		Versus:
@@ -30,7 +30,7 @@ Minigun:
 	Report: INFGUN3.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -52,7 +52,7 @@ Grenade:
 		Angle: 62
 		Inaccuracy: 554
 		Image: DISCUS
-	Warhead:
+	Warhead: Damager
 		Spread: 171
 		Versus:
 			None: 100%
@@ -70,7 +70,7 @@ Bazooka:
 	ROF: 60
 	Range: 6c0
 	Report: RKETINF1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 213
@@ -81,7 +81,7 @@ Bazooka:
 		Image: DRAGON
 		ROT: 8
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -98,7 +98,7 @@ MultiCluster:
 	ROF: 80
 	Range: 6c0
 	Report: MISL1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 170
@@ -109,7 +109,7 @@ MultiCluster:
 		Image: DRAGON
 		ROT: 8
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -128,7 +128,7 @@ Heal:
 	Report: HEALER1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			Wood: 0%
@@ -145,7 +145,7 @@ Sniper:
 	Report: SILENCER.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Damage: 150
 		ProneModifier: 100
 		Spread: 42
@@ -163,7 +163,7 @@ M1Carbine:
 	Report: INFGUN3.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -184,7 +184,7 @@ LtRail:
 		BeamWidth: 1
 		BeamDuration: 10
 		Color: 200,0,128,255
-	Warhead:
+	Warhead: Damager
 		Damage: 150
 		ProneModifier: 100
 		Spread: 42
@@ -200,13 +200,13 @@ CyCannon:
 	ROF: 50
 	Range: 7c0
 	Report: SCRIN5B.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Projectile: Bullet
 		Speed: 192
 		High: yes
 		Shadow: true
 		Image: TORPEDO
-	Warhead:
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 100%
@@ -227,7 +227,7 @@ Vulcan3:
 	Report: CYGUN1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -246,7 +246,7 @@ Vulcan2:
 	Report: TSGUN4.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 100%
@@ -265,7 +265,7 @@ Vulcan:
 	Report: CHAINGN1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -289,7 +289,7 @@ FiendShard:
 		Inaccuracy: 512
 		Shadow: true
 		Angle: 88
-	Warhead:
+	Warhead: Damager
 		Versus:
 			Wood: 60%
 			Light: 40%
@@ -306,7 +306,7 @@ JumpCannon:
 	Report: JUMPJET1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -323,7 +323,7 @@ HoverMissile:
 	Burst: 2
 	Range: 8c0
 	Report: HOVRMIS1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 213
@@ -334,7 +334,7 @@ HoverMissile:
 		Image: DRAGON
 		ROT: 8
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -359,7 +359,7 @@ HoverMissile:
 		Image: 120mm
 		Shadow: true
 		Angle: 62
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -376,7 +376,7 @@ MammothTusk:
 	ROF: 80
 	Range: 6c0
 	Report: MISL1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Burst: 2
 	Palette: ra
 	Projectile: Missile
@@ -388,7 +388,7 @@ MammothTusk:
 		ROT: 10
 		Speed: 170
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 171
 		Versus:
 			None: 100%
@@ -408,7 +408,7 @@ Repair:
 	Report: REPAIR11.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 213
 		Versus:
 			None: 0%
@@ -427,7 +427,7 @@ SlimeAttack:
 	Report: VICER1.AUD
 	Projectile: Bullet
 		Speed: 426
-	Warhead:
+	Warhead: Damager
 		Versus:
 			Wood: 25%
 			Light: 30%
@@ -441,7 +441,7 @@ SuicideBomb:
 	ROF: 1
 	Range: 0c512
 	Report: HUNTER2.AUD
-	Warhead:
+	Warhead: Damager
 		Damage: 11000
 		Spread: 256
 		DestroyResources: true
@@ -458,7 +458,7 @@ SuicideBomb:
 	Report: 120MMF.AUD
 	Projectile: Bullet
 		Speed: 1c512
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -480,7 +480,7 @@ MechRailgun:
 	Projectile: LaserZap
 		Color: 200,0,255,255
 		BeamWidth: 3
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		Versus:
 			None: 200%
@@ -498,7 +498,7 @@ AssaultCannon:
 	Report: TSGUN4.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -516,7 +516,7 @@ BikeMissile:
 	BurstDelay: 60
 	Range: 5c0
 	Report: MISL1.AUD
-	ValidTargets: Ground
+	ValidTargets: Ground, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Arm: 2
@@ -527,7 +527,7 @@ BikeMissile:
 		ROT: 8
 		Speed: 213
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 256
 		Versus:
 			None: 25%
@@ -548,7 +548,7 @@ RaiderCannon:
 	Report: CHAINGN1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -570,7 +570,7 @@ FireballLauncher:
 		Inacuracy: 384
 	Burst: 5
 	BurstDelay: 5
-	Warhead:
+	Warhead: Damager
 		Spread: 341
 		Versus:
 			None: 600%
@@ -591,7 +591,7 @@ SonicZap:
 		Color: 200,0,255,255
 		BeamWidth: 12
 		BeamDuration: 50
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		Versus:
 			Heavy: 80%
@@ -604,7 +604,7 @@ Dragon:
 	Range: 6c0
 	Burst: 2
 	Report: MISL1.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 213
@@ -615,7 +615,7 @@ Dragon:
 		Image: DRAGON
 		ROT: 8
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -638,7 +638,7 @@ Dragon:
 		Image: 120mm
 		Shadow: true
 		Angle: 62
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -663,7 +663,7 @@ Dragon:
 		Shadow: true
 		High: yes
 	MinRange: 5c0
-	Warhead:
+	Warhead: Damager
 		Spread: 298
 		Versus:
 			None: 100%
@@ -682,7 +682,7 @@ Hellfire:
 	Range: 6c0
 	Report: ORCAMIS1.AUD
 	Burst: 2
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 256
@@ -693,7 +693,7 @@ Hellfire:
 		Image: DRAGON
 		ROT: 8
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 85
 		Versus:
 			None: 30%
@@ -714,7 +714,7 @@ Bomb:
 		Speed: 170
 		Image: canister
 		Shadow: true
-	Warhead:
+	Warhead: Damager
 		Spread: 298
 		Versus:
 			None: 200%
@@ -733,7 +733,7 @@ Proton:
 	Range: 5c0
 	Report: SCRIN5B.AUD
 	Burst: 2
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Projectile: Missile
 		Speed: 256
 		Arm: 2
@@ -743,7 +743,7 @@ Proton:
 		Image: TORPEDO
 		ROT: 1
 		RangeLimit: 35
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 25%
@@ -762,8 +762,8 @@ HarpyClaw:
 	Report: CYGUN1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	ValidTargets: Ground, Air
-	Warhead:
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -781,7 +781,7 @@ Pistola:
 	Report: GUN18.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -795,7 +795,7 @@ Pistola:
 
 Tiberium:
 	ROF: 16
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		InfDeath: 6
 		Damage: 2
@@ -803,14 +803,14 @@ Tiberium:
 
 TiberiumHeal:
 	ROF: 16
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		InfDeath: 6
 		Damage: -2
 		PreventProne: yes
 
 IonCannon:
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Enemy, Neutral, Ally
 	Warhead@impact:
 		Damage: 1000
 		Spread: 1c0
@@ -821,7 +821,7 @@ IonCannon:
 		DamageModel: PerCell
 		Damage: 250
 		SmudgeType: Scorch
-		Size: 2,1
+		Size: 2
 		Delay: 3
 		InfDeath: 5
 
@@ -831,7 +831,7 @@ VulcanTower:
 	Report: CHAINGN1.AUD
 	Projectile: Bullet
 		Speed: 1c682
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			Wood: 60%
@@ -853,7 +853,7 @@ RPGTower:
 		Shadow: true
 		Angle: 62
 		Image: canister
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		Versus:
 			None: 30%
@@ -871,7 +871,7 @@ SAMTower:
 	ROF: 55
 	Range: 15c0
 	Report: SAMSHOT1.AUD
-	ValidTargets: Air
+	ValidTargets: Air, Enemy, Neutral, Ally
 	Palette: ra
 	Projectile: Missile
 		Speed: 298
@@ -882,7 +882,7 @@ SAMTower:
 		Image: DRAGON
 		ROT: 5
 		RangeLimit: 60
-	Warhead:
+	Warhead: Damager
 		Spread: 128
 		InfDeath: 2
 		Damage: 33
@@ -896,7 +896,7 @@ ObeliskLaser:
 	Report: OBELRAY1.AUD
 	Projectile: LaserZap
 		BeamWidth: 4
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		InfDeath: 5
 		SmudgeType: Scorch
@@ -910,7 +910,7 @@ TurretLaser:
 	Projectile: LaserZap
 		BeamWidth: 2
 		BeamDuration: 5
-	Warhead:
+	Warhead: Damager
 		Spread: 42
 		InfDeath: 5
 		SmudgeType: Scorch
@@ -918,10 +918,10 @@ TurretLaser:
 		ProneModifier: 60
 
 TiberiumExplosion:
-	Warhead:
+	Warhead: Damager
 		Damage: 10
 		Spread: 9
-		Size: 1,1
+		Size: 1
 		Versus:
 			None: 90%
 			Wood: 75%


### PR DESCRIPTION
Allright, so this is a big one, with a lot of code changes in the weapon and warhead code, along with their associated tie-in points.

As such, we probably need very thorough testing. I've done as many tests as I can over the course of doing this, but at some point we probably need more people chipping in on the testing effort.

I've tested all 4 mods after running the new UpgradeRules (engine version 20140720) on the mods (weapons.yaml update). So far I have only found one possible regression that I couldn't nail down. It is in D2K, but I cannot reliably reproduce it. See #2641.

This supersedes #5882.

A quick "How To" guide for making new custom warheads using this branch can be found here: http://pastebin.com/xUg2bfT5

This pull request includes some changes to the yaml (and thus balance) of RA and TD. We probably want to discard these before the pull request is finally accepted, and rerun the UpgradeRules code on a 'clean' set of yaml code for RA and TD.
