### PR TITLE
Minor balance tweaks for TD

### DIFF
--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -279,8 +279,8 @@ BikeRockets:
 		ROT: 10
 		Trail: smokey
 		ContrailLength: 8
-		Speed: 298
-		RangeLimit: 20
+		Speed: 213
+		RangeLimit: 30
 	Warhead:
 		Spread: 128
 		Versus:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -620,7 +620,7 @@ MammothMissiles:
 		Trail: smokey
 		ContrailLength: 8
 		Speed: 213
-		RangeLimit: 55
+		RangeLimit: 40
 	Warhead:
 		Spread: 128
 		Versus:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -624,7 +624,7 @@ MammothMissiles:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 35%
+			None: 25%
 			Wood: 75%
 			Light: 100%
 			Heavy: 90%

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -923,11 +923,9 @@ APCGun.AA:
 		Damage: 25
 
 Patriot:
-	ROF: 30
+	ROF: 25
 	Range: 9c0
 	MinRange: 1c0
-	Burst: 2
-	BurstDelay: 15
 	Report: ROCKET2.AUD
 	ValidTargets: Air
 	Projectile: Missile
@@ -936,7 +934,7 @@ Patriot:
 		Trail: smokey
 		ContrailLength: 8
 		ROT: 20
-		Speed: 426
+		Speed: 341
 		RangeLimit: 30
 		Angle: 88
 	Warhead: AP
@@ -950,7 +948,7 @@ Patriot:
 		Explosion: poof
 		ImpactSound: xplos.aud
 		SmudgeType: Crater
-		Damage: 40
+		Damage: 32
 
 Tail:
 	ROF: 30


### PR DESCRIPTION
Playtesting has shown that the Stealth Tank is a little bit too good against infantry, which are supposed to be its (soft) natural counter. They are the only units which can detect the stealth tanks, so it's important that they not die too easily. Right now it seems that stealth tanks are able to sit and fight infantry very easily, especially since they outrange them. This change will discourage stealth tanks from engaging infantry without care.
