### PR TITLE
Revert "Make Shift+<Hotkey> queue five units/buildings. Fixes #5544."

### DIFF
--- a/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/BuildPaletteWidget.cs
@@ -523,7 +523,7 @@ namespace OpenRA.Mods.RA.Widgets
 			if (!paletteOpen) return false;
 			if (CurrentQueue == null) return false;
 
-			var toBuild = CurrentQueue.BuildableItems().FirstOrDefault(b => b.Traits.Get<BuildableInfo>().Hotkey.Key == Hotkey.FromKeyInput(e).Key);
+			var toBuild = CurrentQueue.BuildableItems().FirstOrDefault(b => b.Traits.Get<BuildableInfo>().Hotkey == Hotkey.FromKeyInput(e));
 
 			if (toBuild != null)
 			{


### PR DESCRIPTION
Reverts OpenRA/OpenRA#5763

Fixes #6024, which is worse than the original #5544.
