### PR TITLE
Fixed country specific decimal separators in the traits documentation

### DIFF
--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -69,6 +69,8 @@ namespace OpenRA
 			// Don't save floats in settings.yaml using country-specific decimal separators which can be misunderstood as group seperators.
 			if (t == typeof(float))
 				return ((float)v).ToString(CultureInfo.InvariantCulture);
+			if (t == typeof(decimal))
+				return ((decimal)v).ToString(CultureInfo.InvariantCulture);
 
 			if (t == typeof(Rectangle))
 			{

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -66,11 +66,13 @@ namespace OpenRA
 					((int)c.B).Clamp(0, 255));
 			}
 
-			// Don't save floats in settings.yaml using country-specific decimal separators which can be misunderstood as group seperators.
+			// Don't save using country-specific decimal separators which can be misunderstood as group seperators.
 			if (t == typeof(float))
 				return ((float)v).ToString(CultureInfo.InvariantCulture);
 			if (t == typeof(decimal))
 				return ((decimal)v).ToString(CultureInfo.InvariantCulture);
+			if (t == typeof(double))
+				return ((double)v).ToString(CultureInfo.InvariantCulture);
 
 			if (t == typeof(Rectangle))
 			{


### PR DESCRIPTION
I updated https://github.com/OpenRA/OpenRA/wiki/Traits from my de_DE machine manually as we currently don't have automatiation https://github.com/OpenRA/OpenRA/issues/5900 and noticed the inconsistency. @x-a-n-a-x notified me of this issue few days ago and I did not believe him at first. https://github.com/OpenRA/OpenRA/wiki/Traits#harvester FullyLoadedSpeed is a good example of this problem.
