### PR TITLE
Fixed Atreides Barracks Make Anim.

### DIFF
--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -397,11 +397,11 @@ barra:
 		Start: 2525
 		Offset: -32,64
 	make: DATA
-		Start: 4213
+		Start: 4176
 		Length: 8
 		Offset: -32,64
 	crumble-overlay: DATA
-		Start: 4221
+		Start: 4184
 		Length: 9
 		Offset: -32,64
 		Tick: 100


### PR DESCRIPTION
This fixes atreides barracks was using same build anim of orther. But normally it has a special build anim.
