### PR TITLE
Increase MCV selection priority

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -10,7 +10,7 @@ MCV:
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.GDI, Vehicle.Nod
 	Selectable:
-		Priority: 3
+		Priority: 4
 	Mobile:
 		Speed: 71
 		Crushes: crate, infantry

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -297,7 +297,7 @@ MCV:
 		Name: Mobile Construction Vehicle
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Selectable:
-		Priority: 3
+		Priority: 4
 		Bounds: 42,42
 	Health:
 		HP: 600


### PR DESCRIPTION
This prevents buildings to also be selected when a selection box contains MCV. Fixes #5205.
