### PR TITLE
Make lobby chat field have keyboard focus by default.

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -483,6 +483,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var chatLabel = lobby.Get<LabelWidget>("LABEL_CHATTYPE");
 			var chatTextField = lobby.Get<TextFieldWidget>("CHAT_TEXTFIELD");
 
+			chatTextField.TakeKeyboardFocus();
+
 			chatTextField.OnEnterKey = () =>
 			{
 				if (chatTextField.Text.Length == 0)


### PR DESCRIPTION
Fixes #4722. I could only test this in single player lobby. Do other mods also use the RA lobby logic?
