### PR TITLE
Sell non buildings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,9 +38,11 @@ Also thanks to:
     * Frank Razenberg (zzattack)
     * Gareth Needham (Ripley`)
     * Gordon Martin (Happy0)
+    * Ian T. Jacobsen (Smilex)
     * Igor Popov (ihptru)
     * Iran
     * James Dunne (jsd)
+    * Jason (atlimit8)
     * Jeff Harris (jeff_1amstudios)
     * Jes
     * Joakim Lindberg (booom3)
@@ -84,7 +86,6 @@ Also thanks to:
     * Tristan Mühlbacher (MicroBit)
     * Vladimir Komarov (VrKomarov)
     * Wuschel
-    * Ian T. Jacobsen (Smilex)
 
 Using Simple DirectMedia Layer distributed under
 the terms of the zlib license.

--- a/OpenRA.Mods.RA/Sellable.cs
+++ b/OpenRA.Mods.RA/Sellable.cs
@@ -31,7 +31,8 @@ namespace OpenRA.Mods.RA
 
 		public void Sell(Actor self)
 		{
-			if (!self.Trait<Building>().Lock())
+			var building = self.TraitOrDefault<Building>();
+			if (building != null && !building.Lock())
 				return;
 
 			self.CancelActivity();


### PR DESCRIPTION
Allow actors that are not buildings to be sold.

The more humane way to refund units (as opposed the grinding them).
