### PR TITLE
Line build segment type

### DIFF
--- a/OpenRA.Mods.RA/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.RA/Buildings/LineBuild.cs
@@ -20,6 +20,9 @@ namespace OpenRA.Mods.RA.Buildings
 
 		[Desc("LineBuildNode 'Types' to attach to.")]
 		public readonly string[] NodeTypes = { "wall" };
+
+		[Desc("Type of actor to use as segments between nodes (empty means same as this).")]
+		public readonly string SegmentType = null;
 	}
 
 	public class LineBuild {}

--- a/OpenRA.Mods.RA/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.RA/Player/PlaceBuilding.cs
@@ -44,9 +44,12 @@ namespace OpenRA.Mods.RA
 					if (order.OrderString == "LineBuild")
 					{
 						var playSounds = true;
+						var segmentType = unit.Traits.Get<LineBuildInfo>().SegmentType;
+						if (segmentType == null || segmentType.Length == 0)
+							segmentType = order.TargetString;
 						foreach (var t in BuildingUtils.GetLineBuildCells(w, order.TargetLocation, order.TargetString, buildingInfo))
 						{
-							var building = w.CreateActor(order.TargetString, new TypeDictionary
+							var building = w.CreateActor(t == order.TargetLocation ? order.TargetString : segmentType, new TypeDictionary
 							{
 								new LocationInit(t),
 								new OwnerInit(order.Player),

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -429,6 +429,8 @@ NAPOST:
 		SegmentType: nafnce
 	LineBuildNode:
 		Types: laserfence
+	RenderBuildingWall:
+		Type: laserfence
 
 NAFNCE:
 	Inherits: ^Wall
@@ -449,6 +451,8 @@ NAFNCE:
 		NodeTypes: laserfence
 	LineBuildNode:
 		Types: laserfence
+	RenderBuildingWall:
+		Type: laserfence
 
 FSNODE:
 	Inherits: ^Wall
@@ -476,6 +480,8 @@ FSNODE:
 		SegmentType: fsseg
 	LineBuildNode:
 		Types: firestorm
+	RenderBuildingWall:
+		Type: firestorm
 
 FSSEG:
 	Inherits: ^Wall
@@ -496,6 +502,8 @@ FSSEG:
 		NodeTypes: firestorm
 	LineBuildNode:
 		Types: firestorm
+	RenderBuildingWall:
+		Type: firestorm
 
 
 GATICK:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -403,6 +403,101 @@ NAWALL:
 	LineBuild:
 		NodeTypes: wall, turret
 
+NAPOST:
+	Inherits: ^Wall
+	Buildable:
+		Queue: Defense
+		BuildPaletteOrder: 1001
+		Prerequisites: naapwr
+		Owner: nod
+	SoundOnDamageTransition:
+		DamagedSound:
+		DestroyedSound:
+	Valued:
+		Cost: 200
+	CustomSellValue:
+		Value: 0
+	Tooltip:
+		Name: Laser Fence
+		Description: Laser barrier.
+	Health:
+		HP: 300
+	Armor:
+		Type: Concrete
+	LineBuild:
+		NodeTypes: laserfence
+		SegmentType: nafnce
+	LineBuildNode:
+		Types: laserfence
+
+NAFNCE:
+	Inherits: ^Wall
+	Building:
+		Footprint: x
+	Valued:
+		Cost: 50
+	CustomSellValue:
+		Value: 0
+	Tooltip:
+		Name: Laser Fence
+		Description: Laser barrier.
+	Health:
+		HP: 300
+	Armor:
+		Type: Concrete
+	LineBuild:
+		NodeTypes: laserfence
+	LineBuildNode:
+		Types: laserfence
+
+FSNODE:
+	Inherits: ^Wall
+	Buildable:
+		Queue: Defense
+		BuildPaletteOrder: 1001
+		Prerequisites: gacnst
+		Owner: gdi
+	SoundOnDamageTransition:
+		DamagedSound:
+		DestroyedSound:
+	Valued:
+		Cost: 50
+	CustomSellValue:
+		Value: 0
+	Tooltip:
+		Name: Firestorm Wall
+		Description: Stops almost everything when the Firestorm generator is active.
+	Health:
+		HP: 200
+	Armor:
+		Type: Concrete
+	LineBuild:
+		NodeTypes: firestorm
+		SegmentType: fsseg
+	LineBuildNode:
+		Types: firestorm
+
+FSSEG:
+	Inherits: ^Wall
+	Building:
+		Footprint: x
+	Valued:
+		Cost: 50
+	CustomSellValue:
+		Value: 0
+	Tooltip:
+		Name: Firestorm Wall
+		Description: Stops almost everything when the Firestorm generator is active.
+	Health:
+		HP: 200
+	Armor:
+		Type: Concrete
+	LineBuild:
+		NodeTypes: firestorm
+	LineBuildNode:
+		Types: firestorm
+
+
 GATICK:
 	Inherits: ^Building
 	Valued:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -449,8 +449,6 @@ NAFNCE:
 		Type: Concrete
 	LineBuild:
 		NodeTypes: laserfence
-	LineBuildNode:
-		Types: laserfence
 	RenderBuildingWall:
 		Type: laserfence
 
@@ -500,8 +498,6 @@ FSSEG:
 		Type: Concrete
 	LineBuild:
 		NodeTypes: firestorm
-	LineBuildNode:
-		Types: firestorm
 	RenderBuildingWall:
 		Type: firestorm
 

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -495,6 +495,47 @@ nawall:
 	icon: nwalicon
 		Start: 0
 
+napost:
+	idle:
+		Start: 0
+		ShadowStart: 3
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+	critical-idle:
+		Start: 2
+		ShadowStart: 5
+	make: napostmk
+		Start: 0
+		Length: 12
+		ShadowStart: 12
+	icon: lasricon
+		Start: 0
+
+nafnce:
+	idle:
+		Frames: 0, 4
+		Length: 2
+	damaged-idle:
+		Frames: 11, 15
+		Length: 2
+
+fsnode:
+	idle: gtfsdf
+		Frames: 32,33,34,35,36,47,38,39,40,41,47,43,44,45,46,47
+		Length: 16
+	icon: fspicon
+		Start: 0
+
+fsseg:
+	idle: gtfsdf
+		Frames: 42,37
+		Length: 2
+	icon: fspicon
+		Start: 0
+
+
+
 gatick:
 	idle:
 		Start: 0


### PR DESCRIPTION
Specifies another actor type as the type for segments between nodes if LineBuildInfo.SegmentType is not empty.
