### PR TITLE
Fix AI not repairing buildings if struck by support powers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ Also thanks to:
     * Rikhardur Bjarni Einarsson (WolfGaming)
     * Sascha Biedermann (bidifx)
     * Sebastien Kerguen (xanax)
+    * Shawn Collins (UberWaffe)
     * Simon Verbeke (Saticmotion)
     * Taryn Hill (Phrohdoh)
     * Teemu Nieminen (Temeez)

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -785,11 +785,7 @@ namespace OpenRA.Mods.RA.AI
 
 		public void Damaged(Actor self, AttackInfo e)
 		{
-			// TODO: Surely we want to do this even if their destroyer died?
-			if (!enabled || e.Attacker.Destroyed)
-				return;
-
-			if (!e.Attacker.HasTrait<ITargetable>())
+			if (!enabled)
 				return;
 
 			var rb = self.TraitOrDefault<RepairableBuilding>();
@@ -804,6 +800,12 @@ namespace OpenRA.Mods.RA.AI
 						{ TargetActor = self });
 				}
 			}
+
+			if (e.Attacker.Destroyed)
+				return;
+
+			if (!e.Attacker.HasTrait<ITargetable>())
+				return;
 
 			if (e.Attacker != null && e.Damage > 0)
 				aggro[e.Attacker.Owner].Aggro += e.Damage;


### PR DESCRIPTION
AI wasn't initiating repairs when struck by support powers.

Fixed by moving the "Is the attacker still alive" checks to after the initiate repairs code.
