### PR TITLE
Add WavSoundLength to show track length in music player

### DIFF
--- a/OpenRA.Game/FileFormats/WavLoader.cs
+++ b/OpenRA.Game/FileFormats/WavLoader.cs
@@ -90,6 +90,25 @@ namespace OpenRA.FileFormats
 				BitsPerSample = 16;
 			}
 		}
+		
+		public static float WaveLength(Stream s)
+		{
+			s.Position = 12;
+			var fmt = s.ReadASCII(4);
+
+			if (fmt != "fmt ")
+				return 0;
+
+			s.Position = 22;
+			var channels = s.ReadInt16();
+			var sampleRate = s.ReadInt32();
+
+			s.Position = 34;
+			var bitsPerSample = s.ReadInt16();
+			var length = s.Length * 8;
+
+			return length / (channels * sampleRate * bitsPerSample);
+		}
 
 		public byte[] DecodeAdpcmData()
 		{

--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -32,7 +32,10 @@ namespace OpenRA.GameRules
 
 			Exists = true;
 			using (var s = GlobalFileSystem.Open(Filename))
-				Length = (int)AudLoader.SoundLength(s);
+				if (Filename.ToLowerInvariant().EndsWith("wav"))
+					Length = (int)WavLoader.WaveLength(s);
+				else
+					Length = (int)AudLoader.SoundLength(s);
 		}
 
 		public void Reload()
@@ -42,7 +45,10 @@ namespace OpenRA.GameRules
 
 			Exists = true;
 			using (var s = GlobalFileSystem.Open(Filename))
-				Length = (int)AudLoader.SoundLength(s);
+				if (Filename.ToLowerInvariant().EndsWith("wav"))
+					Length = (int)WavLoader.WaveLength(s);
+				else
+					Length = (int)AudLoader.SoundLength(s);
 		}
 	}
 }


### PR DESCRIPTION
Adds WavSoundLength to WavLoader, adapts MusicInfo to use length function depending on extension.
