### PR TITLE
Prevent MAD tanks executing multiple StartDetonationSequence activities

### DIFF
--- a/OpenRA.Mods.RA/MadTank.cs
+++ b/OpenRA.Mods.RA/MadTank.cs
@@ -123,6 +123,9 @@ namespace OpenRA.Mods.RA
 
 		void StartDetonationSequence()
 		{
+			if (deployed)
+				return;
+
 			self.World.AddFrameEndTask(w => EjectDriver());
 			if (info.ThumpSequence != null)
 				renderUnit.PlayCustomAnimRepeating(self, info.ThumpSequence);


### PR DESCRIPTION
Results in a bunch of E1 ejecting out if you spam deploy on the MAD.

Thanks to TerrorJaap for reporting this, with an [accompanied replay](https://www.youtube.com/watch?v=RhlWEvzfKH4&feature=youtu.be).
