### PR TITLE
Migrate speed, damage/armor and firepower modifiers to integer

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -23,7 +23,7 @@ namespace OpenRA.GameRules
 		public readonly WRange MaxSpread = new WRange(0);
 		[FieldLoader.LoadUsing("LoadVersus")]
 		[Desc("Damage vs each armortype. 0% = can't target.")]
-		public readonly Dictionary<string, float> Versus;
+		public readonly Dictionary<string, int> Versus;
 		[Desc("Can this damage resource patches?")]
 		public readonly bool DestroyResources = false;
 		[Desc("Will this splatter resources and which?")]
@@ -57,18 +57,18 @@ namespace OpenRA.GameRules
 		[Desc("By what percentage should damage be modified against prone infantry.")]
 		public readonly int ProneModifier = 50;
 
-		public float EffectivenessAgainst(ActorInfo ai)
+		public int EffectivenessAgainst(ActorInfo ai)
 		{
 			var health = ai.Traits.GetOrDefault<HealthInfo>();
 			if (health == null)
-				return 0f;
+				return 0;
 
 			var armor = ai.Traits.GetOrDefault<ArmorInfo>();
 			if (armor == null || armor.Type == null)
 				return 1;
 
-			float versus;
-			return Versus.TryGetValue(armor.Type, out versus) ? versus : 1;
+			int versus;
+			return Versus.TryGetValue(armor.Type, out versus) ? versus : 100;
 		}
 
 		public WarheadInfo(MiniYaml yaml)
@@ -80,8 +80,8 @@ namespace OpenRA.GameRules
 		{
 			var nd = y.ToDictionary();
 			return nd.ContainsKey("Versus")
-				? nd["Versus"].ToDictionary(my => FieldLoader.GetValue<float>("(value)", my.Value))
-				: new Dictionary<string, float>();
+				? nd["Versus"].ToDictionary(my => FieldLoader.GetValue<int>("(value)", my.Value))
+				: new Dictionary<string, int>();
 		}
 	}
 
@@ -95,7 +95,7 @@ namespace OpenRA.GameRules
 	public class ProjectileArgs
 	{
 		public WeaponInfo Weapon;
-		public float FirepowerModifier = 1.0f;
+		public int FirepowerModifier = 100;
 		public int Facing;
 		public WPos Source;
 		public Actor SourceActor;

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -106,10 +106,10 @@ namespace OpenRA.Traits
 			/* apply the damage modifiers, if we have any. */
 			var modifier = self.TraitsImplementing<IDamageModifier>()
 				.Concat(self.Owner.PlayerActor.TraitsImplementing<IDamageModifier>())
-				.Select(t => t.GetDamageModifier(attacker, warhead)).Product();
+				.Select(t => t.GetDamageModifier(attacker, warhead)).Sum();
 
 			if (!ignoreModifiers)
-				damage = damage > 0 ? (int)(damage * modifier) : damage;
+				damage = damage > 0 ? (int)((damage * modifier) / 100) : damage;
 
 			hp = Exts.Clamp(hp - damage, 0, MaxHP);
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Traits
 	}
 
 	public interface IRenderModifier { IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r); }
-	public interface IDamageModifier { float GetDamageModifier(Actor attacker, WarheadInfo warhead); }
+	public interface IDamageModifier { int GetDamageModifier(Actor attacker, WarheadInfo warhead); }
 	public interface ISpeedModifier { int GetSpeedModifier(); }
 	public interface IFirepowerModifier { float GetFirepowerModifier(); }
 	public interface ILoadsPalettes { void LoadPalettes(WorldRenderer wr); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Traits
 
 	public interface IRenderModifier { IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r); }
 	public interface IDamageModifier { float GetDamageModifier(Actor attacker, WarheadInfo warhead); }
-	public interface ISpeedModifier { decimal GetSpeedModifier(); }
+	public interface ISpeedModifier { int GetSpeedModifier(); }
 	public interface IFirepowerModifier { float GetFirepowerModifier(); }
 	public interface ILoadsPalettes { void LoadPalettes(WorldRenderer wr); }
 	public interface IPaletteModifier { void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> b); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Traits
 	public interface IRenderModifier { IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r); }
 	public interface IDamageModifier { int GetDamageModifier(Actor attacker, WarheadInfo warhead); }
 	public interface ISpeedModifier { int GetSpeedModifier(); }
-	public interface IFirepowerModifier { float GetFirepowerModifier(); }
+	public interface IFirepowerModifier { int GetFirepowerModifier(); }
 	public interface ILoadsPalettes { void LoadPalettes(WorldRenderer wr); }
 	public interface IPaletteModifier { void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> b); }
 	public interface IPips { IEnumerable<PipType> GetPips(Actor self); }

--- a/OpenRA.Mods.D2k/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.D2k/ThrowsShrapnel.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.D2k
 						Facing = self.World.SharedRandom.Next(-1, 255),
 						FirepowerModifier = self.TraitsImplementing<IFirepowerModifier>()
 							.Select(a => a.GetFirepowerModifier())
-							.Product(),
+							.Sum(),
 
 						Source = self.CenterPosition,
 						SourceActor = self,

--- a/OpenRA.Mods.RA/Activities/Demolish.cs
+++ b/OpenRA.Mods.RA/Activities/Demolish.cs
@@ -51,9 +51,9 @@ namespace OpenRA.Mods.RA.Activities
 						return;
 
 					// Invulnerable actors can't be demolished
-					var modifier = (float)target.Actor.TraitsImplementing<IDamageModifier>()
+					var modifier = (int)target.Actor.TraitsImplementing<IDamageModifier>()
 						.Concat(self.Owner.PlayerActor.TraitsImplementing<IDamageModifier>())
-						.Select(t => t.GetDamageModifier(self, null)).Product();
+						.Select(t => t.GetDamageModifier(self, null)).Sum();
 
 					var demolishable = target.Actor.TraitOrDefault<IDemolishable>();
 					if (demolishable == null || !demolishable.IsValidTarget(target.Actor, self))

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -200,10 +200,10 @@ namespace OpenRA.Mods.RA.Air
 		{
 			get
 			{
-				decimal ret = info.Speed;
+				int ret = info.Speed;
 				foreach (var t in self.TraitsImplementing<ISpeedModifier>())
-					ret *= t.GetSpeedModifier();
-				return (int)ret;
+					ret = (ret * t.GetSpeedModifier()) / 100;
+				return (int)(ret);
 			}
 		}
 

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.RA
 				Facing = legacyFacing,
 				FirepowerModifier = self.TraitsImplementing<IFirepowerModifier>()
 					.Select(a => a.GetFirepowerModifier())
-					.Product(),
+					.Sum(),
 
 				Source = muzzlePosition,
 				SourceActor = self,

--- a/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.RA/Attack/AttackPopupTurreted.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		[Desc("How many game ticks should pass before closing the actor's turret.")]
 		public int CloseDelay = 125;
 		public int DefaultFacing = 0;
-		public float ClosedDamageMultiplier = 0.5f;
+		public int ClosedDamageMultiplier = 50;
 
 		public override object Create(ActorInitializer init) { return new AttackPopupTurreted(init, this); }
 	}
@@ -103,9 +103,9 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public int GetDamageModifier(Actor attacker, WarheadInfo warhead)
 		{
-			return state == PopupState.Closed ? info.ClosedDamageMultiplier : 1f;
+			return state == PopupState.Closed ? info.ClosedDamageMultiplier : 100;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public readonly float[] CostThreshold = { 2, 4, 8, 16 };
 		public readonly float[] FirepowerModifier = { 1.1f, 1.15f, 1.2f, 1.5f };
 		public readonly float[] ArmorModifier = { 1.1f, 1.2f, 1.3f, 1.5f };
-		public readonly decimal[] SpeedModifier = { 1.1m, 1.15m, 1.2m, 1.5m };
+		public readonly int[] SpeedModifier = { 110, 115, 120, 150 };
 		public readonly string ChevronPalette = "effect";
 		public readonly string LevelUpPalette = "effect";
 		public object Create(ActorInitializer init) { return new GainsExperience(init, this); }
@@ -92,9 +92,9 @@ namespace OpenRA.Mods.RA
 			return Level > 0 ? info.FirepowerModifier[Level - 1] : 1;
 		}
 
-		public decimal GetSpeedModifier()
+		public int GetSpeedModifier()
 		{
-			return Level > 0 ? info.SpeedModifier[Level - 1] : 1m;
+			return Level > 0 ? info.SpeedModifier[Level - 1] : 100;
 		}
 	}
 

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA
 		[Desc("XP requirements for each level, as multiples of our own cost.")]
 		public readonly float[] CostThreshold = { 2, 4, 8, 16 };
 		public readonly float[] FirepowerModifier = { 1.1f, 1.15f, 1.2f, 1.5f };
-		public readonly float[] ArmorModifier = { 1.1f, 1.2f, 1.3f, 1.5f };
+		public readonly int[] ArmorModifier = { 110, 115, 130, 150 };
 		public readonly int[] SpeedModifier = { 110, 115, 120, 150 };
 		public readonly string ChevronPalette = "effect";
 		public readonly string LevelUpPalette = "effect";
@@ -82,9 +82,9 @@ namespace OpenRA.Mods.RA
 			}
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public int GetDamageModifier(Actor attacker, WarheadInfo warhead)
 		{
-			return Level > 0 ? 1 / info.ArmorModifier[Level - 1] : 1;
+			return Level > 0 ? 100 - (info.ArmorModifier[Level - 1] - 100) : 100;
 		}
 
 		public float GetFirepowerModifier()

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 	{
 		[Desc("XP requirements for each level, as multiples of our own cost.")]
 		public readonly float[] CostThreshold = { 2, 4, 8, 16 };
-		public readonly float[] FirepowerModifier = { 1.1f, 1.15f, 1.2f, 1.5f };
+		public readonly int[] FirepowerModifier = { 110, 115, 120, 150 };
 		public readonly int[] ArmorModifier = { 110, 115, 130, 150 };
 		public readonly int[] SpeedModifier = { 110, 115, 120, 150 };
 		public readonly string ChevronPalette = "effect";
@@ -87,9 +87,9 @@ namespace OpenRA.Mods.RA
 			return Level > 0 ? 100 - (info.ArmorModifier[Level - 1] - 100) : 100;
 		}
 
-		public float GetFirepowerModifier()
+		public int GetFirepowerModifier()
 		{
-			return Level > 0 ? info.FirepowerModifier[Level - 1] : 1;
+			return Level > 0 ? info.FirepowerModifier[Level - 1] : 100;
 		}
 
 		public int GetSpeedModifier()

--- a/OpenRA.Mods.RA/GainsUnitUpgrades.cs
+++ b/OpenRA.Mods.RA/GainsUnitUpgrades.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA
 	public class GainsUnitUpgradesInfo : ITraitInfo
 	{
 		public readonly int FirepowerMaxLevel = 15;
-		public readonly float FirepowerModifier = .2f;
+		public readonly int FirepowerModifier = 20;
 		public readonly int ArmorMaxLevel = 8;
 		public readonly int ArmorModifier = 10;
 		public readonly int SpeedMaxLevel = 15;
@@ -62,9 +62,9 @@ namespace OpenRA.Mods.RA
 				SpeedLevel = Math.Min(SpeedLevel + numLevels, info.SpeedMaxLevel);
 		}
 
-		public float GetFirepowerModifier()
+		public int GetFirepowerModifier()
 		{
-			return FirepowerLevel > 0 ? (1 + FirepowerLevel * info.FirepowerModifier) : 1;
+			return FirepowerLevel > 0 ? FirepowerLevel * info.FirepowerModifier : 100;
 		}
 
 		public int GetDamageModifier(Actor attacker, WarheadInfo warhead)

--- a/OpenRA.Mods.RA/GainsUnitUpgrades.cs
+++ b/OpenRA.Mods.RA/GainsUnitUpgrades.cs
@@ -19,8 +19,8 @@ namespace OpenRA.Mods.RA
 	{
 		public readonly int FirepowerMaxLevel = 15;
 		public readonly float FirepowerModifier = .2f;
-		public readonly int ArmorMaxLevel = 15;
-		public readonly float ArmorModifier = .2f;
+		public readonly int ArmorMaxLevel = 8;
+		public readonly int ArmorModifier = 10;
 		public readonly int SpeedMaxLevel = 15;
 		public readonly int SpeedModifier = 20;
 		// TODO: weapon range, rate of fire modifiers. potentially a vision modifier.
@@ -67,9 +67,9 @@ namespace OpenRA.Mods.RA
 			return FirepowerLevel > 0 ? (1 + FirepowerLevel * info.FirepowerModifier) : 1;
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public int GetDamageModifier(Actor attacker, WarheadInfo warhead)
 		{
-			return ArmorLevel > 0 ? (1 / (1 + ArmorLevel * info.ArmorModifier)) : 1;
+			return ArmorLevel > 0 ? 100 - ArmorLevel * info.ArmorModifier : 100;
 		}
 
 		public int GetSpeedModifier()

--- a/OpenRA.Mods.RA/GainsUnitUpgrades.cs
+++ b/OpenRA.Mods.RA/GainsUnitUpgrades.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public readonly int ArmorMaxLevel = 15;
 		public readonly float ArmorModifier = .2f;
 		public readonly int SpeedMaxLevel = 15;
-		public readonly decimal SpeedModifier = .2m;
+		public readonly int SpeedModifier = 20;
 		// TODO: weapon range, rate of fire modifiers. potentially a vision modifier.
 
 		public object Create(ActorInitializer init) { return new GainsUnitUpgrades(this); }
@@ -72,9 +72,9 @@ namespace OpenRA.Mods.RA
 			return ArmorLevel > 0 ? (1 / (1 + ArmorLevel * info.ArmorModifier)) : 1;
 		}
 
-		public decimal GetSpeedModifier()
+		public int GetSpeedModifier()
 		{
-			return SpeedLevel > 0 ? (1m + SpeedLevel * info.SpeedModifier) : 1m;
+			return SpeedLevel > 0 ? (100 + SpeedLevel * info.SpeedModifier) : 100;
 		}
 	}
 

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -24,15 +24,15 @@ namespace OpenRA.Mods.RA
 		[Desc("How much resources it can carry.")]
 		public readonly int Capacity = 28;
 		public readonly int LoadTicksPerBale = 4;
-		[Desc("How fast it can dump it's carryage.")]
+		[Desc("How fast it can dump its carryage.")]
 		public readonly int UnloadTicksPerBale = 4;
 		[Desc("How many squares to show the fill level.")]
 		public readonly int PipCount = 7;
 		public readonly int HarvestFacings = 0;
 		[Desc("Which resources it can harvest.")]
 		public readonly string[] Resources = { };
-		[Desc("How much it is slowed down when returning to the refinery.")]
-		public readonly decimal FullyLoadedSpeed = .85m;
+		[Desc("Percentage of speed when fully loaded.")]
+		public readonly int FullyLoadedSpeed = 85;
 		[Desc("Initial search radius (in cells) from the refinery that created us.")]
 		public readonly int SearchFromProcRadius = 24;
 		[Desc("Search radius (in cells) from the last harvest order location to find more resources.")]
@@ -418,9 +418,9 @@ namespace OpenRA.Mods.RA
 
 		public bool ShouldExplode(Actor self) { return !IsEmpty; }
 
-		public decimal GetSpeedModifier()
+		public int GetSpeedModifier()
 		{
-			return 1m - (1m - Info.FullyLoadedSpeed) * contents.Values.Sum() / Info.Capacity;
+			return 100 - ((100 - Info.FullyLoadedSpeed) * Fullness / 100);
 		}
 
 		class HarvestOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.RA/Invulnerable.cs
+++ b/OpenRA.Mods.RA/Invulnerable.cs
@@ -18,6 +18,6 @@ namespace OpenRA.Mods.RA
 
 	class Invulnerable : IDamageModifier
 	{
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead) { return 0.0f; }
+		public int GetDamageModifier(Actor attacker, WarheadInfo warhead) { return 0; }
 	}
 }

--- a/OpenRA.Mods.RA/IronCurtainable.cs
+++ b/OpenRA.Mods.RA/IronCurtainable.cs
@@ -28,9 +28,9 @@ namespace OpenRA.Mods.RA
 				RemainingTicks--;
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public int GetDamageModifier(Actor attacker, WarheadInfo warhead)
 		{
-			return (RemainingTicks > 0) ? 0.0f : 1.0f;
+			return (RemainingTicks > 0) ? 0 : 100;
 		}
 
 		public void Activate(Actor self, int duration)

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Move
 		public readonly int InitialFacing = 128;
 		[Desc("Rate of Turning")]
 		public readonly int ROT = 255;
-		public readonly int Speed = 1;
+		public readonly int Speed = 43;
 		public readonly bool OnRails = false;
 		[Desc("Allow multiple (infantry) units in one cell.")]
 		public readonly bool SharesCell = false;
@@ -43,11 +43,11 @@ namespace OpenRA.Mods.RA.Move
 			var ret = new Dictionary<string, TerrainInfo>();
 			foreach (var t in y.ToDictionary()["TerrainSpeeds"].Nodes)
 			{
-				var speed = FieldLoader.GetValue<decimal>("speed", t.Value.Value);
+				var speed = FieldLoader.GetValue<int>("speed", t.Value.Value);
 				var nodesDict = t.Value.ToDictionary();
 				var cost = nodesDict.ContainsKey("PathingCost")
 					? FieldLoader.GetValue<int>("cost", nodesDict["PathingCost"].Value)
-					: (int)(10000 / speed);
+					: (int)(100 / speed);
 				ret.Add(t.Key, new TerrainInfo(speed, cost));
 			}
 
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.RA.Move
 			public static readonly TerrainInfo Impassable = new TerrainInfo();
 
 			public readonly int Cost;
-			public readonly decimal Speed;
+			public readonly int Speed;
 
 			public TerrainInfo()
 			{
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.RA.Move
 				Speed = 0;
 			}
 
-			public TerrainInfo(decimal speed, int cost)
+			public TerrainInfo(int speed, int cost)
 			{
 				Speed = speed;
 				Cost = cost;
@@ -474,12 +474,12 @@ namespace OpenRA.Mods.RA.Move
 				return 0;
 
 			var speed = Info.TilesetTerrainInfo[self.World.TileSet][index].Speed;
-			if (speed == decimal.Zero)
+			if (speed == 0)
 				return 0;
 
 			speed *= Info.Speed;
 			foreach (var t in self.TraitsImplementing<ISpeedModifier>())
-				speed *= t.GetSpeedModifier();
+				speed = (speed * t.GetSpeedModifier()) / 100;
 			return (int)(speed / 100);
 		}
 

--- a/OpenRA.Mods.RA/ScaredyCat.cs
+++ b/OpenRA.Mods.RA/ScaredyCat.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA
 	class ScaredyCatInfo : ITraitInfo
 	{
 		public readonly int PanicLength = 25 * 10;
-		public readonly decimal PanicSpeedModifier = 2;
+		public readonly int PanicSpeedModifier = 200;
 		public readonly int AttackPanicChance = 20;
 
 		public object Create(ActorInitializer init) { return new ScaredyCat(init.self, this); }
@@ -74,9 +74,9 @@ namespace OpenRA.Mods.RA
 				Panic();
 		}
 
-		public decimal GetSpeedModifier()
+		public int GetSpeedModifier()
 		{
-			return Panicking ? Info.PanicSpeedModifier : 1;
+			return Panicking ? Info.PanicSpeedModifier : 100;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/ScriptInvulnerable.cs
+++ b/OpenRA.Mods.RA/Scripting/ScriptInvulnerable.cs
@@ -20,9 +20,9 @@ namespace OpenRA.Mods.RA
 	{
 		public bool Invulnerable = false;
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public int GetDamageModifier(Actor attacker, WarheadInfo warhead)
 		{
-			return Invulnerable ? 0.0f : 1.0f;
+			return Invulnerable ? 0 : 100;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/TakeCover.cs
+++ b/OpenRA.Mods.RA/TakeCover.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Mods.RA
 			"Measured in game ticks. Default is 4 seconds.")]
 		public readonly int ProneTime = 100;
 
-		[Desc("How quickly we should go from standing to prone.")]
-		public readonly decimal ProneSpeed = .5m;
+		[Desc("Percentage of moving speed while prone.")]
+		public readonly int ProneSpeed = 50;
 
 		public readonly WVec ProneOffset = new WVec(85, 0, -171);
 
@@ -66,9 +66,9 @@ namespace OpenRA.Mods.RA
 			return IsProne && warhead != null ? warhead.ProneModifier / 100f : 1f;
 		}
 
-		public decimal GetSpeedModifier()
+		public int GetSpeedModifier()
 		{
-			return IsProne ? Info.ProneSpeed : 1m;
+			return IsProne ? Info.ProneSpeed : 100;
 		}
 	}
 

--- a/OpenRA.Mods.RA/TakeCover.cs
+++ b/OpenRA.Mods.RA/TakeCover.cs
@@ -61,9 +61,9 @@ namespace OpenRA.Mods.RA
 				LocalOffset = WVec.Zero;
 		}
 
-		public float GetDamageModifier(Actor attacker, WarheadInfo warhead)
+		public int GetDamageModifier(Actor attacker, WarheadInfo warhead)
 		{
-			return IsProne && warhead != null ? warhead.ProneModifier / 100f : 1f;
+			return IsProne && warhead != null ? warhead.ProneModifier : 100;
 		}
 
 		public int GetSpeedModifier()

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -25,10 +25,10 @@ UnitExplode:
 		Damage: 500
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: poof
 		InfDeath: 4
 		ImpactSound: xplobig6.aud
@@ -38,10 +38,10 @@ UnitExplodeSmall:
 		Damage: 40
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: big_frag
 		InfDeath: 4
 		ImpactSound: xplobig4.aud
@@ -51,10 +51,10 @@ GrenadierExplode:
 		Damage: 10
 		Spread: 256
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: poof
 		InfDeath: 3
 		ImpactSound: xplosml2.aud
@@ -66,10 +66,10 @@ Atomic:
 		Damage: 1500	#1000
 		Spread: 1c0
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 60%
-			Heavy: 50%
+			None: 100
+			Wood: 100
+			Light: 60
+			Heavy: 50
 		Explosion: 6
 		InfDeath: 5
 		ImpactSound: nukexplo.aud
@@ -80,10 +80,10 @@ Atomic:
 		Size: 3
 		DestroyResources: true
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 60%
-			Heavy: 50%
+			None: 100
+			Wood: 100
+			Light: 60
+			Heavy: 50
 		Delay: 3
 		InfDeath: 5
 		ImpactSound: xplobig4.aud
@@ -94,10 +94,10 @@ Atomic:
 		Size: 4
 		DestroyResources: true
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 60%
-			Heavy: 50%
+			None: 100
+			Wood: 100
+			Light: 60
+			Heavy: 50
 		Delay: 6
 		InfDeath: 5
 	Warhead@areanukec:
@@ -107,10 +107,10 @@ Atomic:
 		Size: 5
 		DestroyResources: true
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 60%
-			Heavy: 50%
+			None: 100
+			Wood: 100
+			Light: 60
+			Heavy: 50
 		Delay: 9
 		InfDeath: 5
 
@@ -162,10 +162,10 @@ HighV:
 		Damage: 30
 		Spread: 683
 		Versus:
-			None: 100%
-			Wood: 50%
-			Light: 70%
-			Heavy: 35%
+			None: 100
+			Wood: 50
+			Light: 70
+			Heavy: 35
 		InfDeath: 2
 		Explosion: piffs
 
@@ -182,10 +182,10 @@ HeliAGGun:
 		Damage: 20
 		Spread: 256
 		Versus:
-			None: 100%
-			Wood: 50%
-			Light: 75%
-			Heavy: 25%
+			None: 100
+			Wood: 50
+			Light: 75
+			Heavy: 25
 		InfDeath: 2
 		Explosion: piffs
 
@@ -202,10 +202,10 @@ HeliAAGun:
 		Damage: 20
 		Spread: 128
 		Versus:
-			None: 100%
-			Wood: 50%
-			Light: 50%
-			Heavy: 25%
+			None: 100
+			Wood: 50
+			Light: 50
+			Heavy: 25
 		InfDeath: 2
 		Explosion: piffs
 
@@ -219,10 +219,10 @@ Pistol:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 100%
-			Wood: 50%
-			Light: 50%
-			Heavy: 25%
+			None: 100
+			Wood: 50
+			Light: 50
+			Heavy: 25
 		InfDeath: 2
 		Explosion: piff
 		Damage: 1
@@ -237,10 +237,10 @@ M16:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 100%
-			Wood: 25%
-			Light: 30%
-			Heavy: 10%
+			None: 100
+			Wood: 25
+			Light: 30
+			Heavy: 10
 		Explosion: piff
 		InfDeath: 2
 		Damage: 15
@@ -263,11 +263,11 @@ Rockets:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 50%
-			Wood: 85%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 25%
+			None: 50
+			Wood: 85
+			Light: 100
+			Heavy: 100
+			Concrete: 25
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -294,11 +294,11 @@ BikeRockets:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 75%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 50%
+			None: 25
+			Wood: 75
+			Light: 100
+			Heavy: 100
+			Concrete: 50
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -325,10 +325,10 @@ OrcaAGMissiles:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 50%
-			Wood: 100%
-			Light: 100%
-			Heavy: 75%
+			None: 50
+			Wood: 100
+			Light: 100
+			Heavy: 75
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -355,8 +355,8 @@ OrcaAAMissiles:
 	Warhead:
 		Spread: 128
 		Versus:
-			Light: 75%
-			Heavy: 50%
+			Light: 75
+			Heavy: 50
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -373,10 +373,10 @@ Flamethrower:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 100%
-			Heavy: 20%
+			None: 100
+			Wood: 100
+			Light: 100
+			Heavy: 20
 		Explosion: small_napalm
 		InfDeath: 5
 		ImpactSound: flamer2.aud
@@ -395,10 +395,10 @@ BigFlamer:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 67%
-			Heavy: 25%
+			None: 100
+			Wood: 100
+			Light: 67
+			Heavy: 25
 		InfDeath: 5
 		Explosion: med_napalm
 		ImpactSound: flamer2.aud
@@ -415,10 +415,10 @@ Chemspray:
 		Damage: 80
 		Spread: 256
 		Versus:
-			None: 100%
-			Wood: 35%
-			Light: 75%
-			Heavy: 50%
+			None: 100
+			Wood: 35
+			Light: 75
+			Heavy: 50
 		InfDeath: 6
 		Explosion: chemball
 		SmudgeType: Scorch
@@ -437,10 +437,10 @@ Grenade:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 100%
-			Wood: 50%
-			Light: 75%
-			Heavy: 35%
+			None: 100
+			Wood: 50
+			Light: 75
+			Heavy: 35
 		InfDeath: 3
 		Explosion: small_poof
 		ImpactSound: xplos.aud
@@ -457,11 +457,11 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 75%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 50%
+			None: 25
+			Wood: 75
+			Light: 100
+			Heavy: 100
+			Concrete: 50
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -478,10 +478,10 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Heavy: 100%
+			None: 30
+			Wood: 75
+			Light: 75
+			Heavy: 100
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -498,11 +498,11 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 100%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 50%
+			None: 25
+			Wood: 100
+			Light: 100
+			Heavy: 100
+			Concrete: 50
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -521,11 +521,11 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 100%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 100%
+			None: 25
+			Wood: 100
+			Light: 100
+			Heavy: 100
+			Concrete: 100
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -542,10 +542,10 @@ TurretGun:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 20%
-			Wood: 25%
-			Light: 100%
-			Heavy: 100%
+			None: 20
+			Wood: 25
+			Light: 100
+			Heavy: 100
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -572,10 +572,10 @@ MammothMissiles:
 	Warhead:
 		Spread: 298
 		Versus:
-			None: 50%
-			Wood: 75%
-			Light: 100%
-			Heavy: 50%
+			None: 50
+			Wood: 75
+			Light: 100
+			Heavy: 50
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -604,10 +604,10 @@ MammothMissiles:
 	Warhead:
 		Spread: 683
 		Versus:
-			None: 35%
-			Wood: 60%
-			Light: 100%
-			Heavy: 50%
+			None: 35
+			Wood: 60
+			Light: 100
+			Heavy: 50
 		InfDeath: 4
 		Explosion: med_frag
 		ImpactSound: xplos.aud
@@ -634,10 +634,10 @@ MammothMissiles:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 75%
-			Light: 100%
-			Heavy: 90%
+			None: 25
+			Wood: 75
+			Light: 100
+			Heavy: 90
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -660,10 +660,10 @@ ArtilleryShell:
 		Damage: 150
 		Spread: 341
 		Versus:
-			None: 100%
-			Wood: 80%
-			Light: 75%
-			Heavy: 50%
+			None: 100
+			Wood: 80
+			Light: 75
+			Heavy: 50
 		InfDeath: 3
 		Explosion: poof
 		SmudgeType: Crater
@@ -680,11 +680,11 @@ MachineGun:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 100%
-			Wood: 20%
-			Light: 50%
-			Heavy: 20%
-			Concrete: 10%
+			None: 100
+			Wood: 20
+			Light: 50
+			Heavy: 20
+			Concrete: 10
 		InfDeath: 2
 		Explosion: piffs
 		Damage: 15
@@ -708,10 +708,10 @@ BoatMissile:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		InfDeath: 3
 		Explosion: small_poof
 		ImpactSound: xplos.aud
@@ -736,10 +736,10 @@ TowerMissle:
 	Warhead:
 		Spread: 683
 		Versus:
-			None: 50%
-			Wood: 25%
-			Light: 100%
-			Heavy: 100%
+			None: 50
+			Wood: 25
+			Light: 100
+			Heavy: 100
 		InfDeath: 3
 		Explosion: med_frag
 		ImpactSound: xplos.aud
@@ -757,10 +757,10 @@ Vulcan:
 		Damage: 100
 		Spread: 426
 		Versus:
-			None: 100%
-			Wood: 25%
-			Light: 100%
-			Heavy: 35%
+			None: 100
+			Wood: 25
+			Light: 100
+			Heavy: 35
 		InfDeath: 2
 		Explosion: piffs
 
@@ -775,10 +775,10 @@ Napalm:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 100%
-			Heavy: 80%
+			None: 100
+			Wood: 100
+			Light: 100
+			Heavy: 80
 		InfDeath: 5
 		Explosion: med_napalm
 		WaterExplosion: med_napalm
@@ -790,10 +790,10 @@ Napalm.Crate:
 	Warhead:
 		Spread: 170
 		Versus:
-			None: 90%
-			Wood: 100%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 100
+			Light: 60
+			Heavy: 25
 		InfDeath: 5
 		Explosion: med_napalm
 		ImpactSound: flamer2.aud
@@ -811,7 +811,7 @@ Laser:
 	Warhead:
 		Spread: 42
 		Versus:
-			Wood: 50%
+			Wood: 50
 		InfDeath: 5
 		SmudgeType: Scorch
 		Damage: 360
@@ -833,10 +833,10 @@ SAMMissile:
 	Warhead: AP
 		Spread: 682
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 100%
-			Heavy: 75%
+			None: 100
+			Wood: 100
+			Light: 100
+			Heavy: 75
 		InfDeath: 4
 		Explosion: small_frag
 		ImpactSound: xplos.aud
@@ -860,10 +860,10 @@ HonestJohn:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		InfDeath: 3
 		Explosion: small_poof
 		ImpactSound: xplos.aud
@@ -884,10 +884,10 @@ TiberiumExplosion:
 		Spread: 9
 		Size: 1,1
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: chemball
 		InfDeath: 3
 		ImpactSound: xplosml2.aud
@@ -910,10 +910,10 @@ APCGun:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 50%
-			Wood: 50%
-			Light: 100%
-			Heavy: 50%
+			None: 50
+			Wood: 50
+			Light: 100
+			Heavy: 50
 		Explosion: small_poof
 		Damage: 15
 
@@ -928,7 +928,7 @@ APCGun.AA:
 	Warhead:
 		Spread: 128
 		Versus:
-			Heavy: 50%
+			Heavy: 50
 		Explosion: small_poof
 		Damage: 25
 
@@ -950,10 +950,10 @@ Patriot:
 	Warhead: AP
 		Spread: 682
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 100%
-			Heavy: 75%
+			None: 100
+			Wood: 100
+			Light: 100
+			Heavy: 75
 		InfDeath: 4
 		Explosion: poof
 		ImpactSound: xplos.aud
@@ -968,11 +968,11 @@ Tail:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 90%
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			None: 90
+			Wood: 10
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		InfDeath: 1
 		Damage: 180
 
@@ -984,11 +984,11 @@ Horn:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 90%
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			None: 90
+			Wood: 10
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		InfDeath: 1
 		Damage: 120
 
@@ -1000,11 +1000,11 @@ Teeth:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 90%
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			None: 90
+			Wood: 10
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		InfDeath: 1
 		Damage: 180
 
@@ -1016,11 +1016,11 @@ Claw:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 90%
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			None: 90
+			Wood: 10
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		InfDeath: 1
 		Damage: 60
 

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -11,10 +11,10 @@ LMG:
 	Warhead:
 		Spread: 96
 		Versus:
-			Wood: 25%
-			Light: 40%
-			Heavy: 10%
-			Concrete: 20%
+			Wood: 25
+			Light: 40
+			Heavy: 10
+			Concrete: 20
 		Explosion: piffs
 		InfDeath: 2
 		Damage: 15
@@ -35,11 +35,11 @@ Bazooka:
 	Warhead:
 		Spread: 96
 		Versus:
-			None: 10%
-			Wood: 75%
-			Light: 60%
-			Heavy: 90%
-			Concrete: 40%
+			None: 10
+			Wood: 75
+			Light: 60
+			Heavy: 90
+			Concrete: 40
 		Explosion: small_explosion
 		InfDeath: 4
 		SmudgeType: SandCrater, RockCrater
@@ -60,11 +60,11 @@ Sniper:
 		Damage: 60
 		Spread: 32
 		Versus:
-			None: 100%
-			Wood: 0%
-			Light: 1%
-			Heavy: 0%
-			Concrete: 0%
+			None: 100
+			Wood: 0
+			Light: 1
+			Heavy: 0
+			Concrete: 0
 		InfDeath: 2
 
 Vulcan:
@@ -81,10 +81,10 @@ Vulcan:
 	Warhead:
 		Spread: 96
 		Versus:
-			Wood: 0%
-			Light: 60%
-			Heavy: 10%
-			Concrete: 0%
+			Wood: 0
+			Light: 60
+			Heavy: 10
+			Concrete: 0
 		Explosion: piffs
 		InfDeath: 2
 		Damage: 30
@@ -105,11 +105,11 @@ Slung:
 	Warhead:
 		Spread: 192
 		Versus:
-			None: 0%
-			Wood: 75%
-			Light: 40%
-			Heavy: 90%
-			Concrete: 50%
+			None: 0
+			Wood: 75
+			Light: 40
+			Heavy: 90
+			Concrete: 50
 		Explosion: small_explosion
 		InfDeath: 4
 		Damage: 30
@@ -130,10 +130,10 @@ HMG:
 	Warhead:
 		Spread: 96
 		Versus:
-			Wood: 15%
-			Light: 45%
-			Heavy: 20%
-			Concrete: 20%
+			Wood: 15
+			Light: 45
+			Heavy: 20
+			Concrete: 20
 		Explosion: piffs
 		InfDeath: 2
 		Damage: 30
@@ -153,10 +153,10 @@ HMGo:
 	Warhead:
 		Spread: 96
 		Versus:
-			Wood: 15%
-			Light: 45%
-			Heavy: 25%
-			Concrete: 20%
+			Wood: 15
+			Light: 45
+			Heavy: 25
+			Concrete: 20
 		Explosion: piffs
 		InfDeath: 2
 		Damage: 40
@@ -178,11 +178,11 @@ QuadRockets:
 	Warhead:
 		Spread: 96
 		Versus:
-			None: 35%
-			Wood: 45%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 35%
+			None: 35
+			Wood: 45
+			Light: 100
+			Heavy: 100
+			Concrete: 35
 		InfDeath: 4
 		Explosion: med_explosion
 		ImpactSound: EXPLSML1.WAV
@@ -202,10 +202,10 @@ TurretGun:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 50%
-			Wood: 75%
-			Light: 100%
-			Concrete: 65%
+			None: 50
+			Wood: 75
+			Light: 100
+			Concrete: 65
 		Explosion: small_napalm
 		ImpactSound: EXPLSML4.WAV
 		InfDeath: 4
@@ -233,11 +233,11 @@ TowerMissile:
 	Warhead:
 		Spread: 384
 		Versus:
-			None: 50%
-			Wood: 45%
-			Light: 100%
-			Heavy: 50%
-			Concrete: 35%
+			None: 50
+			Wood: 45
+			Light: 100
+			Heavy: 50
+			Concrete: 35
 		InfDeath: 3
 		Explosion: small_explosion
 		ImpactSound: EXPLMD1.WAV
@@ -255,10 +255,10 @@ TowerMissile:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 50%
-			Wood: 50%
-			Light: 100%
-			Concrete: 50%
+			None: 50
+			Wood: 50
+			Light: 100
+			Concrete: 50
 		Explosion: small_napalm
 		ImpactSound: EXPLSML4.WAV
 		InfDeath: 4
@@ -276,10 +276,10 @@ TowerMissile:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 50%
-			Wood: 50%
-			Light: 100%
-			Concrete: 50%
+			None: 50
+			Wood: 50
+			Light: 100
+			Concrete: 50
 		Explosion: small_napalm
 		ImpactSound: EXPLSML4.WAV
 		InfDeath: 4
@@ -296,11 +296,11 @@ DevBullet:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 100%
-			Wood: 50%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 80%
+			None: 100
+			Wood: 50
+			Light: 100
+			Heavy: 100
+			Concrete: 80
 		Explosion: shockwave
 		InfDeath: 4
 		SmudgeType: SandCrater, RockCrater
@@ -327,11 +327,11 @@ DevBullet:
 	Warhead:
 		Spread: 384
 		Versus:
-			None: 20%
-			Wood: 50%
-			Light: 100%
-			Heavy: 50%
-			Concrete: 80%
+			None: 20
+			Wood: 50
+			Light: 100
+			Heavy: 50
+			Concrete: 80
 		InfDeath: 4
 		Explosion: mini_explosion
 		ImpactSound: EXPLMD3.WAV
@@ -355,9 +355,9 @@ FakeMissile:
 	Warhead:
 		Spread: 96
 		Versus:
-			None: 0%
-			Wood: 0%
-			Concrete: 0%
+			None: 0
+			Wood: 0
+			Concrete: 0
 		Explosion: deviator
 		SmudgeType: SandCrater, RockCrater
 		Damage: 10
@@ -379,11 +379,11 @@ FakeMissile:
 	Warhead:
 		Spread: 384
 		Versus:
-			None: 100%
-			Wood: 80%
-			Light: 75%
-			Heavy: 50%
-			Concrete: 100%
+			None: 100
+			Wood: 80
+			Light: 75
+			Heavy: 50
+			Concrete: 100
 		Explosion: large_explosion
 		ImpactSound: EXPLLG3.WAV
 		InfDeath: 3
@@ -402,10 +402,10 @@ Sound:
 	Warhead:
 		Spread: 32
 		Versus:
-			None: 60%
-			Wood: 85%
-			Light: 80%
-			Concrete: 75%
+			None: 60
+			Wood: 85
+			Light: 80
+			Concrete: 75
 		InfDeath: 6
 		Damage: 150
 
@@ -420,10 +420,10 @@ ChainGun:
 	Warhead:
 		Spread: 96
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		InfDeath: 2
 		Damage: 20
@@ -437,10 +437,10 @@ Heal:
 	Warhead:
 		Spread: 160
 		Versus:
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		InfDeath: 1
 		Damage: -50
 
@@ -451,8 +451,8 @@ WormJaw:
 	Warhead:
 		Spread: 160
 		Versus:
-			Wood: 0%
-			Concrete: 0%
+			Wood: 0
+			Concrete: 0
 		Damage: 100
 
 ParaBomb:
@@ -464,10 +464,10 @@ ParaBomb:
 	Warhead:
 		Spread: 192
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: self_destruct
 		InfDeath: 4
 		SmudgeType: Crater
@@ -482,11 +482,11 @@ Napalm:
 	Warhead:
 		Spread: 640
 		Versus:
-			None: 20%
-			Wood: 100%
-			Light: 30%
-			Heavy: 20%
-			Concrete: 70%
+			None: 20
+			Wood: 100
+			Light: 30
+			Heavy: 20
+			Concrete: 70
 		InfDeath: 4
 		Explosion: artillery
 		ImpactSound: NAPALM1.WAV
@@ -508,11 +508,11 @@ Atomic:
 		Damage: 1800
 		Spread: 2c0
 		Versus:
-			None: 100%
-			Wood: 100%
-			Light: 100%
-			Heavy: 50%
-			Concrete: 50%
+			None: 100
+			Wood: 100
+			Light: 100
+			Heavy: 50
+			Concrete: 50
 		Explosion: nuke
 		InfDeath: 5
 		ImpactSound: EXPLLG2.WAV
@@ -522,11 +522,11 @@ CrateNuke:
 		Damage: 800
 		Spread: 1c576
 		Versus:
-			None: 20%
-			Wood: 75%
-			Light: 25%
-			Heavy: 25%
-			Concrete: 50%
+			None: 20
+			Wood: 75
+			Light: 25
+			Heavy: 25
+			Concrete: 50
 		Explosion: nuke
 		InfDeath: 5
 		ImpactSound: EXPLLG2.WAV
@@ -536,10 +536,10 @@ CrateExplosion:
 		Damage: 400
 		Spread: 320
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: building
 		InfDeath: 4
 		ImpactSound: EXPLSML4.WAV
@@ -549,10 +549,10 @@ UnitExplode:
 		Damage: 500
 		Spread: 320
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: building
 		InfDeath: 4
 		ImpactSound: EXPLMD1.WAV
@@ -562,10 +562,10 @@ UnitExplodeSmall:
 		Damage: 60
 		Spread: 320
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: self_destruct
 		InfDeath: 4
 		ImpactSound: EXPLHG1.WAV, EXPLLG1.WAV, EXPLMD1.WAV, EXPLSML4.WAV
@@ -575,10 +575,10 @@ UnitExplodeTiny:
 		Damage: 30
 		Spread: 224
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: med_explosion
 		InfDeath: 4
 		ImpactSound: EXPLMD2.WAV, EXPLSML1.WAV, EXPLSML2.WAV, EXPLSML3.WAV
@@ -588,10 +588,10 @@ UnitExplodeScale:
 		Damage: 90
 		Spread: 416
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: building
 		InfDeath: 4
 		ImpactSound: EXPLLG2.WAV, EXPLLG3.WAV, EXPLLG5.WAV
@@ -609,10 +609,10 @@ Grenade:
 	Warhead:
 		Spread: 192
 		Versus:
-			None: 50%
-			Wood: 100%
-			Light: 25%
-			Heavy: 5%
+			None: 50
+			Wood: 100
+			Light: 25
+			Heavy: 5
 		Explosion: med_explosion
 		InfDeath: 3
 		SmudgeType: SandCrater
@@ -637,10 +637,10 @@ Shrapnel:
 	Warhead:
 		Spread: 192
 		Versus:
-			None: 50%
-			Wood: 100%
-			Light: 25%
-			Heavy: 5%
+			None: 50
+			Wood: 100
+			Light: 25
+			Heavy: 5
 		Explosion: med_explosion
 		InfDeath: 3
 		SmudgeType: SandCrater
@@ -653,10 +653,10 @@ SpiceExplosion:
 		Spread: 9
 		Size: 2,2
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: med_explosion
 		InfDeath: 3
 		ImpactSound: EXPLLG5.WAV

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -7,11 +7,11 @@ Colt45:
 	Warhead:
 		Spread: 42
 		Versus:
-			None: 100%
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			None: 100
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		Explosion: piff
 		WaterExplosion: water_piff
 		InfDeath: 2
@@ -30,10 +30,10 @@ ZSU-23:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: small_explosion_air
 		Damage: 12
 
@@ -46,10 +46,10 @@ Vulcan:
 	Warhead@1:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -57,10 +57,10 @@ Vulcan:
 	Warhead@2:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -69,10 +69,10 @@ Vulcan:
 	Warhead@3:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -81,10 +81,10 @@ Vulcan:
 	Warhead@4:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -93,10 +93,10 @@ Vulcan:
 	Warhead@5:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -105,10 +105,10 @@ Vulcan:
 	Warhead@6:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -135,10 +135,10 @@ Maverick:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
@@ -159,11 +159,11 @@ FireballLauncher:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 90%
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		Explosion: napalm
 		WaterExplosion: napalm
 		InfDeath: 5
@@ -185,11 +185,11 @@ Flamer:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 90%
-			Wood: 100%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Wood: 100
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		Explosion: small_napalm
 		WaterExplosion: small_napalm
 		InfDeath: 5
@@ -208,11 +208,11 @@ ChainGun:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 120%
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			None: 120
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -229,10 +229,10 @@ ChainGun.Yak:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -247,10 +247,10 @@ Pistol:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 50%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 25%
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 		Explosion: piff
 		WaterExplosion: water_piff
 		InfDeath: 2
@@ -265,10 +265,10 @@ M1Carbine:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 25%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			Wood: 25
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -292,10 +292,10 @@ Dragon:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 10%
-			Wood: 75%
-			Light: 35%
-			Concrete: 20%
+			None: 10
+			Wood: 75
+			Light: 35
+			Concrete: 20
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		InfDeath: 4
@@ -323,10 +323,10 @@ HellfireAG:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		InfDeath: 4
@@ -354,10 +354,10 @@ HellfireAA:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: med_explosion_air
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
@@ -378,10 +378,10 @@ Grenade:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 50%
-			Wood: 100%
-			Light: 25%
-			Heavy: 5%
+			None: 50
+			Wood: 100
+			Light: 25
+			Heavy: 5
 		Explosion: med_explosion
 		WaterExplosion: small_splash
 		InfDeath: 3
@@ -400,10 +400,10 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 40%
-			Heavy: 40%
-			Concrete: 30%
+			None: 30
+			Wood: 40
+			Heavy: 40
+			Concrete: 30
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		InfDeath: 4
@@ -420,10 +420,10 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 20%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 20
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
@@ -444,10 +444,10 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 20%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 20
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
@@ -468,10 +468,10 @@ Grenade:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 20%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 20
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
@@ -490,10 +490,10 @@ TurretGun:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 20%
-			Wood: 50%
-			Light: 75%
-			Concrete: 50%
+			None: 20
+			Wood: 50
+			Light: 75
+			Concrete: 50
 		Explosion: small_explosion
 		WaterExplosion: small_splash
 		ImpactSound: kaboom12.aud
@@ -520,10 +520,10 @@ MammothTusk:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 100%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 100
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: med_explosion_air
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
@@ -547,11 +547,11 @@ MammothTusk:
 	Warhead:
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		Explosion: artillery_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom15.aud
@@ -570,10 +570,10 @@ M60mg:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			Wood: 10
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -589,10 +589,10 @@ Napalm:
 	Warhead:
 		Spread: 170
 		Versus:
-			None: 90%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		Explosion: napalm
 		WaterExplosion: med_splash
 		InfDeath: 5
@@ -605,10 +605,10 @@ CrateNapalm:
 	Warhead:
 		Spread: 170
 		Versus:
-			None: 90%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		Explosion: napalm
 		WaterExplosion: napalm
 		InfDeath: 5
@@ -621,10 +621,10 @@ CrateExplosion:
 		Damage: 500
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: self_destruct
 		WaterExplosion: self_destruct
 		InfDeath: 4
@@ -636,10 +636,10 @@ CrateNuke:
 		Spread: 256
 		DestroyResources: true
 		Versus:
-			None: 90%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		Explosion: nuke
 		WaterExplosion: nuke
 		InfDeath: 5
@@ -651,10 +651,10 @@ CrateNuke:
 		Size: 5,4
 		DestroyResources: true
 		Versus:
-			None: 90%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		Delay: 4
 		InfDeath: 5
 		ImpactSound: kaboom22.aud
@@ -670,8 +670,8 @@ TeslaZap:
 		InfDeath: 6
 		Damage: 100
 		Versus:
-			None: 1000%
-			Wood: 60%
+			None: 1000
+			Wood: 60
 
 Nike:
 	ROF: 15
@@ -689,11 +689,11 @@ Nike:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 90%
-			Wood: 0%
-			Light: 90%
-			Heavy: 50%
-			Concrete: 0%
+			None: 90
+			Wood: 0
+			Light: 90
+			Heavy: 50
+			Concrete: 0
 		Explosion: med_explosion_air
 		ImpactSound: kaboom25.aud
 		InfDeath: 3
@@ -716,10 +716,10 @@ RedEye:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: med_explosion_air
 		ImpactSound: kaboom25.aud
 		InfDeath: 3
@@ -741,10 +741,10 @@ RedEye:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 60%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 60
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: artillery_explosion
 		WaterExplosion: large_splash
 		InfDeath: 3
@@ -769,9 +769,9 @@ SubMissile:
 	Warhead:
 		Spread: 426
 		Versus:
-			None: 40%
-			Light: 30%
-			Heavy: 30%
+			None: 40
+			Light: 30
+			Heavy: 30
 		Explosion: artillery_explosion
 		WaterExplosion: large_splash
 		InfDeath: 3
@@ -799,10 +799,10 @@ Stinger:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
@@ -830,10 +830,10 @@ TorpTube:
 	Warhead:
 		Spread: 426
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 500%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 500
 		WaterExplosion: large_splash
 		WaterImpactSound: splash9.aud
 		Explosion: large_explosion
@@ -852,10 +852,10 @@ TorpTube:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: small_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom12.aud
@@ -877,10 +877,10 @@ DepthCharge:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		WaterExplosion: large_splash
 		WaterImpactSound: splash9.aud
 		InfDeath: 4
@@ -898,10 +898,10 @@ ParaBomb:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 30
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: self_destruct
 		WaterExplosion: small_splash
 		InfDeath: 4
@@ -918,10 +918,10 @@ DogJaw:
 	Warhead:
 		Spread: 213
 		Versus:
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		InfDeath: 1
 		Damage: 100
 
@@ -934,10 +934,10 @@ Heal:
 	Warhead:
 		Spread: 213
 		Versus:
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		InfDeath: 1
 		Damage: -50
 
@@ -951,11 +951,11 @@ Repair:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 0%
-			Wood: 0%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 0%
+			None: 0
+			Wood: 0
+			Light: 100
+			Heavy: 100
+			Concrete: 0
 		InfDeath: 1
 		Damage: -20
 
@@ -968,10 +968,10 @@ SilencedPPK:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		Explosion: piffs
 		WaterExplosion: water_piffs
 		InfDeath: 2
@@ -994,10 +994,10 @@ SCUD:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 70%
-			Heavy: 40%
+			None: 90
+			Wood: 75
+			Light: 70
+			Heavy: 40
 		Explosion: napalm
 		WaterExplosion: large_splash
 		InfDeath: 3
@@ -1015,7 +1015,7 @@ Atomic:
 		Size: 1
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Explosion: nuke
 		WaterExplosion: nuke
 		InfDeath: 5
@@ -1027,7 +1027,7 @@ Atomic:
 		Size: 2
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Delay: 5
 		InfDeath: 5
 		ImpactSound: kaboom22.aud
@@ -1038,7 +1038,7 @@ Atomic:
 		Size: 3
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Delay: 10
 		InfDeath: 5
 	Warhead@areanuke3:
@@ -1048,7 +1048,7 @@ Atomic:
 		Size: 4
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Delay: 15
 		InfDeath: 5
 	Warhead@areanuke4:
@@ -1058,7 +1058,7 @@ Atomic:
 		Size: 5
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Delay: 20
 		InfDeath: 5
 
@@ -1070,7 +1070,7 @@ MiniNuke:
 		Size: 1
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Explosion: nuke
 		WaterExplosion: nuke
 		InfDeath: 5
@@ -1081,7 +1081,7 @@ MiniNuke:
 		Size: 2
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Delay: 5
 		InfDeath: 5
 		ImpactSound: kaboom22.aud
@@ -1091,7 +1091,7 @@ MiniNuke:
 		Size: 3
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Delay: 10
 		InfDeath: 5
 	Warhead@areanuke3:
@@ -1101,7 +1101,7 @@ MiniNuke:
 		SmudgeType: Scorch
 		DestroyResources: true
 		Versus:
-			Concrete: 25%
+			Concrete: 25
 		Delay: 15
 		InfDeath: 5
 
@@ -1110,10 +1110,10 @@ UnitExplode:
 		Damage: 500
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: self_destruct
 		WaterExplosion: large_splash
 		InfDeath: 4
@@ -1125,10 +1125,10 @@ UnitExplodeShip:
 		Damage: 50
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: building
 		WaterExplosion: building
 		InfDeath: 4
@@ -1140,10 +1140,10 @@ UnitExplodeSubmarine:
 		Damage: 50
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		WaterExplosion: large_splash
 		InfDeath: 4
 		WaterImpactSound: splash9.aud
@@ -1153,10 +1153,10 @@ UnitExplodeSmall:
 		Damage: 40
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: large_explosion
 		WaterExplosion: large_splash
 		InfDeath: 4
@@ -1168,11 +1168,11 @@ BarrelExplode:
 		Damage: 500
 		Spread: 426
 		Versus:
-			None: 120%
-			Wood: 200%
-			Light: 50%
-			Heavy: 25%
-			Concrete: 10%
+			None: 120
+			Wood: 200
+			Light: 50
+			Heavy: 25
+			Concrete: 10
 		Explosion: napalm
 		InfDeath: 4
 		ImpactSound: firebl3.aud
@@ -1216,7 +1216,7 @@ PortaTesla:
 		InfDeath: 6
 		Damage: 45
 		Versus:
-			None: 1000%
+			None: 1000
 
 TTankZap:
 	ROF: 120
@@ -1229,7 +1229,7 @@ TTankZap:
 		InfDeath: 6
 		Damage: 100
 		Versus:
-			None: 1000%
+			None: 1000
 
 FLAK-23:
 	ROF: 10
@@ -1242,11 +1242,11 @@ FLAK-23:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 40%
-			Wood: 10%
-			Light: 60%
-			Heavy: 10%
-			Concrete: 20%
+			None: 40
+			Wood: 10
+			Light: 60
+			Heavy: 10
+			Concrete: 20
 		Explosion: small_explosion_air
 		WaterExplosion: small_splash
 		Damage: 20
@@ -1261,11 +1261,11 @@ Sniper:
 		Damage: 140
 		Spread: 42
 		Versus:
-			None: 100%
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			None: 100
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		InfDeath: 2
 
 APTusk:
@@ -1286,10 +1286,10 @@ APTusk:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 75%
-			Light: 75%
-			Concrete: 50%
+			None: 25
+			Wood: 75
+			Light: 75
+			Concrete: 50
 		Explosion: med_explosion
 		WaterExplosion: med_splash
 		ImpactSound: kaboom25.aud
@@ -1306,11 +1306,11 @@ Claw:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 90%
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			None: 90
+			Wood: 10
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		InfDeath: 1
 		Damage: 33
 
@@ -1322,11 +1322,11 @@ Mandible:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 90%
-			Wood: 10%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			None: 90
+			Wood: 10
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		InfDeath: 1
 		Damage: 60
 
@@ -1336,7 +1336,7 @@ MADTankThump:
 		DamageModel: HealthPercentage
 		Damage: 1
 		Versus:
-			None: 0%
+			None: 0
 		Size: 7,6
 
 MADTankDetonate:
@@ -1345,7 +1345,7 @@ MADTankDetonate:
 		DamageModel: HealthPercentage
 		Damage: 19
 		Versus:
-			None: 0%
+			None: 0
 		Size: 7,6
 		Explosion: med_explosion
 		ImpactSound: mineblo1.aud
@@ -1357,10 +1357,10 @@ OreExplosion:
 		Spread: 9
 		Size: 1,1
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: med_explosion
 		InfDeath: 3
 		ImpactSound: kaboom25.aud

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -115,7 +115,7 @@
 		ChevronPalette: ra
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
-		ArmorModifier: 1.2, 1.5
+		ArmorModifier: 120, 150
 		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:
@@ -201,7 +201,7 @@
 		ChevronPalette: ra
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
-		ArmorModifier: 1.2, 1.5
+		ArmorModifier: 120, 150
 		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:
@@ -250,7 +250,7 @@
 		ChevronPalette: ra
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
-		ArmorModifier: 1.2, 1.5
+		ArmorModifier: 120, 150
 		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:
@@ -293,7 +293,7 @@
 		ChevronPalette: ra
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
-		ArmorModifier: 1.2, 1.5
+		ArmorModifier: 120, 150
 		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -116,7 +116,7 @@
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
 		ArmorModifier: 1.2, 1.5
-		SpeedModifier: 1.2, 1.5
+		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:
@@ -202,7 +202,7 @@
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
 		ArmorModifier: 1.2, 1.5
-		SpeedModifier: 1.2, 1.5
+		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:
@@ -251,7 +251,7 @@
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
 		ArmorModifier: 1.2, 1.5
-		SpeedModifier: 1.2, 1.5
+		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:
@@ -294,7 +294,7 @@
 		CostThreshold: 5, 10
 		FirepowerModifier: 1.2, 1.5
 		ArmorModifier: 1.2, 1.5
-		SpeedModifier: 1.2, 1.5
+		SpeedModifier: 120, 150
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -3,10 +3,10 @@ UnitExplode:
 		Damage: 500
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: large_twlt
 		InfDeath: 2
 		ImpactSound: expnew09.aud
@@ -16,10 +16,10 @@ UnitExplodeSmall:
 		Damage: 40
 		Spread: 426
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		Explosion: medium_brnl
 		InfDeath: 2
 		ImpactSound: expnew13.aud
@@ -33,10 +33,10 @@ Minigun:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 12
@@ -55,11 +55,11 @@ Grenade:
 	Warhead:
 		Spread: 171
 		Versus:
-			None: 100%
-			Wood: 85%
-			Light: 70%
-			Heavy: 35%
-			Concrete: 28%
+			None: 100
+			Wood: 85
+			Light: 70
+			Heavy: 35
+			Concrete: 28
 		InfDeath: 3
 		Damage: 40
 		ProneModifier: 70
@@ -84,11 +84,11 @@ Bazooka:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 2
 		Damage: 25
 		Explosion: small_clsn
@@ -112,11 +112,11 @@ MultiCluster:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 3
 		Damage: 65
 		Explosion: large_explosion
@@ -131,10 +131,10 @@ Heal:
 	Warhead:
 		Spread: 213
 		Versus:
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		InfDeath: 1
 		Damage: -50
 		ProneModifier: 100
@@ -150,11 +150,11 @@ Sniper:
 		ProneModifier: 100
 		Spread: 42
 		Versus:
-			None: 100%
-			Wood: 0%
-			Light: 0%
-			Heavy: 0%
-			Concrete: 0%
+			None: 100
+			Wood: 0
+			Light: 0
+			Heavy: 0
+			Concrete: 0
 		InfDeath: 1
 
 M1Carbine:
@@ -166,10 +166,10 @@ M1Carbine:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 15
@@ -189,11 +189,11 @@ LtRail:
 		ProneModifier: 100
 		Spread: 42
 		Versus:
-			None: 100%
-			Wood: 130%
-			Light: 150%
-			Heavy: 110%
-			Concrete: 5%
+			None: 100
+			Wood: 130
+			Light: 150
+			Heavy: 110
+			Concrete: 5
 		InfDeath: 2
 
 CyCannon:
@@ -209,11 +209,11 @@ CyCannon:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 100%
-			Wood: 65%
-			Light: 75%
-			Heavy: 50%
-			Concrete: 40%
+			None: 100
+			Wood: 65
+			Light: 75
+			Heavy: 50
+			Concrete: 40
 		InfDeath: 6
 		Damage: 120
 		ProneModifier: 100
@@ -230,10 +230,10 @@ Vulcan3:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 10
@@ -249,11 +249,11 @@ Vulcan2:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 100%
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			None: 100
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 50
@@ -268,10 +268,10 @@ Vulcan:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 20
@@ -291,10 +291,10 @@ FiendShard:
 		Angle: 88
 	Warhead:
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		InfDeath: 1
 		Damage: 35
 		ProneModifier: 100
@@ -309,10 +309,10 @@ JumpCannon:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 15
@@ -337,11 +337,11 @@ HoverMissile:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 2
 		Damage: 30
 		Explosion: small_clsn
@@ -362,11 +362,11 @@ HoverMissile:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 2
 		Damage: 50
 		Explosion: medium_clsn
@@ -391,11 +391,11 @@ MammothTusk:
 	Warhead:
 		Spread: 171
 		Versus:
-			None: 100%
-			Wood: 85%
-			Light: 70%
-			Heavy: 35%
-			Concrete: 28%
+			None: 100
+			Wood: 85
+			Light: 70
+			Heavy: 35
+			Concrete: 28
 		InfDeath: 3
 		Damage: 40
 		ProneModifier: 70
@@ -411,11 +411,11 @@ Repair:
 	Warhead:
 		Spread: 213
 		Versus:
-			None: 0%
-			Wood: 0%
-			Light: 100%
-			Heavy: 100%
-			Concrete: 0%
+			None: 0
+			Wood: 0
+			Light: 100
+			Heavy: 100
+			Concrete: 0
 		InfDeath: 1
 		Damage: -50
 		ProneModifier: 100
@@ -429,10 +429,10 @@ SlimeAttack:
 		Speed: 426
 	Warhead:
 		Versus:
-			Wood: 25%
-			Light: 30%
-			Heavy: 10%
-			Concrete: 10%
+			Wood: 25
+			Light: 30
+			Heavy: 10
+			Concrete: 10
 		InfDeath: 2
 		Damage: 100
 		ProneModifier: 100
@@ -446,10 +446,10 @@ SuicideBomb:
 		Spread: 256
 		DestroyResources: true
 		Versus:
-			None: 90%
-			Light: 60%
-			Heavy: 25%
-			Concrete: 50%
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		InfDeath: 5
 
 120mm:
@@ -461,11 +461,11 @@ SuicideBomb:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 2
 		Damage: 70
 		Explosion: large_clsn
@@ -483,11 +483,11 @@ MechRailgun:
 	Warhead:
 		Spread: 42
 		Versus:
-			None: 200%
-			Wood: 175%
-			Light: 160%
-			Heavy: 100%
-			Concrete: 25%
+			None: 200
+			Wood: 175
+			Light: 160
+			Heavy: 100
+			Concrete: 25
 		InfDeath: 5
 		Damage: 200
 		ProneModifier: 100
@@ -501,10 +501,10 @@ AssaultCannon:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 40
@@ -530,11 +530,11 @@ BikeMissile:
 	Warhead:
 		Spread: 256
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 2
 		Damage: 40
 		Explosion: small_clsn
@@ -551,10 +551,10 @@ RaiderCannon:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 40
@@ -573,11 +573,11 @@ FireballLauncher:
 	Warhead:
 		Spread: 341
 		Versus:
-			None: 600%
-			Wood: 148%
-			Light: 59%
-			Heavy: 6%
-			Concrete: 2%
+			None: 600
+			Wood: 148
+			Light: 59
+			Heavy: 6
+			Concrete: 2
 		InfDeath: 5
 		Damage: 25
 		ProneModifier: 100
@@ -594,8 +594,8 @@ SonicZap:
 	Warhead:
 		Spread: 42
 		Versus:
-			Heavy: 80%
-			Concrete: 60%
+			Heavy: 80
+			Concrete: 60
 		InfDeath: 5
 		Damage: 100
 
@@ -618,11 +618,11 @@ Dragon:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 2
 		Damage: 30
 		Explosion: small_clsn
@@ -641,11 +641,11 @@ Dragon:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 2
 		Damage: 36
 		Explosion: medium_clsn
@@ -666,11 +666,11 @@ Dragon:
 	Warhead:
 		Spread: 298
 		Versus:
-			None: 100%
-			Wood: 85%
-			Light: 68%
-			Heavy: 35%
-			Concrete: 35%
+			None: 100
+			Wood: 85
+			Light: 68
+			Heavy: 35
+			Concrete: 35
 		InfDeath: 3
 		Damage: 150
 		ProneModifier: 100
@@ -696,11 +696,11 @@ Hellfire:
 	Warhead:
 		Spread: 85
 		Versus:
-			None: 30%
-			Wood: 65%
-			Light: 150%
-			Heavy: 100%
-			Concrete: 30%
+			None: 30
+			Wood: 65
+			Light: 150
+			Heavy: 100
+			Concrete: 30
 		InfDeath: 2
 		Damage: 30
 		Explosion: small_bang
@@ -717,11 +717,11 @@ Bomb:
 	Warhead:
 		Spread: 298
 		Versus:
-			None: 200%
-			Wood: 90%
-			Light: 75%
-			Heavy: 32%
-			Concrete: 100%
+			None: 200
+			Wood: 90
+			Light: 75
+			Heavy: 32
+			Concrete: 100
 		InfDeath: 3
 		Damage: 160
 		ProneModifier: 100
@@ -746,11 +746,11 @@ Proton:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 25%
-			Wood: 65%
-			Light: 75%
-			Heavy: 100%
-			Concrete: 60%
+			None: 25
+			Wood: 65
+			Light: 75
+			Heavy: 100
+			Concrete: 60
 		InfDeath: 3
 		Damage: 20
 		Explosion: small_bang
@@ -766,10 +766,10 @@ HarpyClaw:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 60
@@ -784,10 +784,10 @@ Pistola:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piff
 		InfDeath: 1
 		Damage: 2
@@ -834,10 +834,10 @@ VulcanTower:
 	Warhead:
 		Spread: 128
 		Versus:
-			Wood: 60%
-			Light: 40%
-			Heavy: 25%
-			Concrete: 10%
+			Wood: 60
+			Light: 40
+			Heavy: 25
+			Concrete: 10
 		Explosion: piffpiff
 		InfDeath: 1
 		Damage: 18
@@ -856,11 +856,11 @@ RPGTower:
 	Warhead:
 		Spread: 128
 		Versus:
-			None: 30%
-			Wood: 75%
-			Light: 90%
-			Heavy: 100%
-			Concrete: 70%
+			None: 30
+			Wood: 75
+			Light: 90
+			Heavy: 100
+			Concrete: 70
 		InfDeath: 2
 		Damage: 110
 		ProneModifier: 70
@@ -923,10 +923,10 @@ TiberiumExplosion:
 		Spread: 9
 		Size: 1,1
 		Versus:
-			None: 90%
-			Wood: 75%
-			Light: 60%
-			Heavy: 25%
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 		InfDeath: 3
 		Explosion: large_explosion
 		ImpactSound: expnew09.aud


### PR DESCRIPTION
Current state:
SpeedModifier seems to work fine.

DamageModifier currently does about twice as much damage as it should, probably a misplaced division op, haven't found the error yet.

FirepowerModifier leads to zero damage of tanks vs. infantry for example, so there's probably a misplaced division op as well.
