### PR TITLE
Overhaul production hotkeys

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -147,13 +147,13 @@ namespace OpenRA
 
 	public class KeySettings
 	{
-		public Hotkey CycleBaseKey = new Hotkey(Keycode.BACKSPACE, Modifiers.None);
+		public Hotkey CycleBaseKey = new Hotkey(Keycode.H, Modifiers.None);
 		public Hotkey ToLastEventKey = new Hotkey(Keycode.SPACE, Modifiers.None);
 		public Hotkey ToSelectionKey = new Hotkey(Keycode.HOME, Modifiers.None);
 		public Hotkey SelectAllUnitsKey = new Hotkey(Keycode.Q, Modifiers.None);
 		public Hotkey SelectUnitsByTypeKey = new Hotkey(Keycode.W, Modifiers.None);
 
-		public Hotkey PauseKey = new Hotkey(Keycode.F8, Modifiers.None);
+		public Hotkey PauseKey = new Hotkey(Keycode.PAUSE, Modifiers.None);
 		public Hotkey PlaceBeaconKey = new Hotkey(Keycode.B, Modifiers.None);
 		public Hotkey SellKey = new Hotkey(Keycode.Z, Modifiers.None);
 		public Hotkey PowerDownKey = new Hotkey(Keycode.X, Modifiers.None);
@@ -163,18 +163,17 @@ namespace OpenRA
 		public Hotkey PreviousProductionTabKey = new Hotkey(Keycode.PAGEUP, Modifiers.None);
 		public Hotkey CycleProductionBuildingsKey = new Hotkey(Keycode.TAB, Modifiers.None);
 
-		public Hotkey ToggleStatusBarsKey = new Hotkey(Keycode.BACKQUOTE, Modifiers.Ctrl | Modifiers.Shift);
-
 		public Hotkey AttackMoveKey = new Hotkey(Keycode.A, Modifiers.None);
 		public Hotkey StopKey = new Hotkey(Keycode.S, Modifiers.None);
-		public Hotkey ScatterKey = new Hotkey(Keycode.X, Modifiers.None);
+		public Hotkey ScatterKey = new Hotkey(Keycode.X, Modifiers.Ctrl);
 		public Hotkey DeployKey = new Hotkey(Keycode.F, Modifiers.None);
-		public Hotkey StanceCycleKey = new Hotkey(Keycode.Z, Modifiers.None);
+		public Hotkey StanceCycleKey = new Hotkey(Keycode.Z, Modifiers.Ctrl);
 		public Hotkey GuardKey = new Hotkey(Keycode.D, Modifiers.None);
 
 		public Hotkey ObserverCombinedView = new Hotkey(Keycode.MINUS, Modifiers.None);
 		public Hotkey ObserverWorldView = new Hotkey(Keycode.EQUALS, Modifiers.None);
 
+		public Hotkey ToggleStatusBarsKey = new Hotkey(Keycode.COMMA, Modifiers.None);
 		public Hotkey TogglePixelDoubleKey = new Hotkey(Keycode.PERIOD, Modifiers.None);
 
 		public Hotkey DevReloadChromeKey = new Hotkey(Keycode.C, Modifiers.Ctrl | Modifiers.Shift);

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -163,7 +163,7 @@ namespace OpenRA
 		public Hotkey PreviousProductionTabKey = new Hotkey(Keycode.PAGEUP, Modifiers.None);
 		public Hotkey CycleProductionBuildingsKey = new Hotkey(Keycode.TAB, Modifiers.None);
 
-		public Hotkey ToggleStatusBarsKey = new Hotkey(Keycode.INSERT, Modifiers.None);
+		public Hotkey ToggleStatusBarsKey = new Hotkey(Keycode.BACKQUOTE, Modifiers.Ctrl | Modifiers.Shift);
 
 		public Hotkey AttackMoveKey = new Hotkey(Keycode.A, Modifiers.None);
 		public Hotkey StopKey = new Hotkey(Keycode.S, Modifiers.None);

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -154,10 +154,10 @@ namespace OpenRA
 		public Hotkey SelectUnitsByTypeKey = new Hotkey(Keycode.T, Modifiers.Ctrl);
 
 		public Hotkey PauseKey = new Hotkey(Keycode.F8, Modifiers.None);
-		public Hotkey PlaceBeaconKey = new Hotkey(Keycode.F9, Modifiers.None);
-		public Hotkey SellKey = new Hotkey(Keycode.F10, Modifiers.None);
-		public Hotkey PowerDownKey = new Hotkey(Keycode.F11, Modifiers.None);
-		public Hotkey RepairKey = new Hotkey(Keycode.F12, Modifiers.None);
+		public Hotkey PlaceBeaconKey = new Hotkey(Keycode.B, Modifiers.None);
+		public Hotkey SellKey = new Hotkey(Keycode.Z, Modifiers.None);
+		public Hotkey PowerDownKey = new Hotkey(Keycode.X, Modifiers.None);
+		public Hotkey RepairKey = new Hotkey(Keycode.C, Modifiers.None);
 
 		public Hotkey NextProductionTabKey = new Hotkey(Keycode.PAGEDOWN, Modifiers.None);
 		public Hotkey PreviousProductionTabKey = new Hotkey(Keycode.PAGEUP, Modifiers.None);

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -178,6 +178,42 @@ namespace OpenRA
 		public Hotkey TogglePixelDoubleKey = new Hotkey(Keycode.PERIOD, Modifiers.None);
 
 		public Hotkey DevReloadChromeKey = new Hotkey(Keycode.C, Modifiers.Ctrl | Modifiers.Shift);
+
+		public Hotkey Production01Key = new Hotkey(Keycode.F1, Modifiers.None);
+		public Hotkey Production02Key = new Hotkey(Keycode.F2, Modifiers.None);
+		public Hotkey Production03Key = new Hotkey(Keycode.F3, Modifiers.None);
+		public Hotkey Production04Key = new Hotkey(Keycode.F4, Modifiers.None);
+		public Hotkey Production05Key = new Hotkey(Keycode.F5, Modifiers.None);
+		public Hotkey Production06Key = new Hotkey(Keycode.F6, Modifiers.None);
+		public Hotkey Production07Key = new Hotkey(Keycode.F7, Modifiers.None);
+		public Hotkey Production08Key = new Hotkey(Keycode.F8, Modifiers.None);
+		public Hotkey Production09Key = new Hotkey(Keycode.F9, Modifiers.None);
+		public Hotkey Production10Key = new Hotkey(Keycode.F10, Modifiers.None);
+		public Hotkey Production11Key = new Hotkey(Keycode.F11, Modifiers.None);
+		public Hotkey Production12Key = new Hotkey(Keycode.F12, Modifiers.None);
+
+		public Hotkey Production13Key = new Hotkey(Keycode.F1, Modifiers.Ctrl);
+		public Hotkey Production14Key = new Hotkey(Keycode.F2, Modifiers.Ctrl);
+		public Hotkey Production15Key = new Hotkey(Keycode.F3, Modifiers.Ctrl);
+		public Hotkey Production16Key = new Hotkey(Keycode.F4, Modifiers.Ctrl);
+		public Hotkey Production17Key = new Hotkey(Keycode.F5, Modifiers.Ctrl);
+		public Hotkey Production18Key = new Hotkey(Keycode.F6, Modifiers.Ctrl);
+		public Hotkey Production19Key = new Hotkey(Keycode.F7, Modifiers.Ctrl);
+		public Hotkey Production20Key = new Hotkey(Keycode.F8, Modifiers.Ctrl);
+		public Hotkey Production21Key = new Hotkey(Keycode.F9, Modifiers.Ctrl);
+		public Hotkey Production22Key = new Hotkey(Keycode.F10, Modifiers.Ctrl);
+		public Hotkey Production23Key = new Hotkey(Keycode.F11, Modifiers.Ctrl);
+		public Hotkey Production24Key = new Hotkey(Keycode.F12, Modifiers.Ctrl);
+
+
+		public Hotkey GetProductionHotkey(int index)
+		{
+			var field = GetType().GetField("Production{0:D2}Key".F(index + 1));
+			if (field == null)
+				return Hotkey.Invalid;
+
+			return (Hotkey)field.GetValue(this);
+		}
 	}
 
 	public class IrcSettings

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -150,8 +150,8 @@ namespace OpenRA
 		public Hotkey CycleBaseKey = new Hotkey(Keycode.BACKSPACE, Modifiers.None);
 		public Hotkey ToLastEventKey = new Hotkey(Keycode.SPACE, Modifiers.None);
 		public Hotkey ToSelectionKey = new Hotkey(Keycode.HOME, Modifiers.None);
-		public Hotkey SelectAllUnitsKey = new Hotkey(Keycode.A, Modifiers.Ctrl);
-		public Hotkey SelectUnitsByTypeKey = new Hotkey(Keycode.T, Modifiers.Ctrl);
+		public Hotkey SelectAllUnitsKey = new Hotkey(Keycode.Q, Modifiers.None);
+		public Hotkey SelectUnitsByTypeKey = new Hotkey(Keycode.W, Modifiers.None);
 
 		public Hotkey PauseKey = new Hotkey(Keycode.F8, Modifiers.None);
 		public Hotkey PlaceBeaconKey = new Hotkey(Keycode.B, Modifiers.None);

--- a/OpenRA.Mods.RA/Buildable.cs
+++ b/OpenRA.Mods.RA/Buildable.cs
@@ -35,7 +35,6 @@ namespace OpenRA.Mods.RA
 
 		// TODO: UI fluff; doesn't belong here
 		public readonly int BuildPaletteOrder = 9999;
-		public readonly Hotkey Hotkey = Hotkey.Invalid;
 	}
 
 	public class Buildable { }

--- a/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SettingsLogic.cs
@@ -305,6 +305,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var hotkeyHeader = hotkeyList.Get<ScrollItemWidget>("HEADER");
 			var globalTemplate = hotkeyList.Get("GLOBAL_TEMPLATE");
 			var unitTemplate = hotkeyList.Get("UNIT_TEMPLATE");
+			var productionTemplate = hotkeyList.Get("PRODUCTION_TEMPLATE");
 			hotkeyList.RemoveChildren();
 
 			// Game
@@ -374,6 +375,20 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				foreach (var kv in hotkeys)
 					BindHotkeyPref(kv, ks, unitTemplate, hotkeyList);
+			}
+
+			// Production
+			{
+				var hotkeys = new Dictionary<string, string>();
+				for (var i = 1; i <= 24; i++)
+					hotkeys.Add("Production{0:D2}Key".F(i), "Slot {0}".F(i));
+
+				var header = ScrollItemWidget.Setup(hotkeyHeader, () => true, () => {});
+				header.Get<LabelWidget>("LABEL").GetText = () => "Production Commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, productionTemplate, hotkeyList);
 			}
 
 			// Developer

--- a/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
@@ -130,10 +130,10 @@ namespace OpenRA.Mods.RA.Widgets
 			if (mi.Event != MouseInputEvent.Down)
 				return true;
 
-			return HandleEvent(icon, mi.Button == MouseButton.Left);
+			return HandleEvent(icon, mi.Button == MouseButton.Left, mi.Modifiers.HasModifier(Modifiers.Shift));
 		}
 
-		bool HandleEvent(ProductionIcon icon, bool isLeftClick)
+		bool HandleEvent(ProductionIcon icon, bool isLeftClick, bool handleMultiple)
 		{
 			var actor = World.Map.Rules.Actors[icon.Name];
 			var first = icon.Queued.FirstOrDefault();
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.RA.Widgets
 					Sound.Play(TabClick);
 					Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, World.LocalPlayer.Country.Race);
 					World.IssueOrder(Order.StartProduction(CurrentQueue.Actor, icon.Name,
-						Game.GetModifierKeys().HasModifier(Modifiers.Shift) ? 5 : 1));
+						handleMultiple ? 5 : 1));
 				}
 				else
 					Sound.Play(DisabledTabClick);
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.RA.Widgets
 					{
 						Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Country.Race);
 						World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name,
-							Game.GetModifierKeys().HasModifier(Modifiers.Shift) ? 5 : 1));
+							handleMultiple ? 5 : 1));
 					}
 					else
 					{
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.RA.Widgets
 
 			var hotkey = Hotkey.FromKeyInput(e);
 			var toBuild = icons.Values.FirstOrDefault(i => i.Hotkey == hotkey);
-			return toBuild != null ? HandleEvent(toBuild, true) : false;
+			return toBuild != null ? HandleEvent(toBuild, true, false) : false;
 		}
 
 		public void RefreshIcons()

--- a/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.RA.Widgets
 {
 	public class ProductionIcon
 	{
+		public ActorInfo Actor;
 		public string Name;
 		public Hotkey Hotkey;
 		public Sprite Sprite;
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.RA.Widgets
 		public int IconCount { get; private set; }
 		public event Action<int, int> OnIconCountChanged = (a, b) => {};
 
-		public string TooltipActor { get; private set; }
+		public ProductionIcon TooltipIcon { get; private set; }
 		public readonly World World;
 		readonly OrderManager orderManager;
 
@@ -116,7 +117,7 @@ namespace OpenRA.Mods.RA.Widgets
 				.Select(i => i.Value).FirstOrDefault();
 
 			if (mi.Event == MouseInputEvent.Move)
-				TooltipActor = icon != null ? icon.Name : null;
+				TooltipIcon = icon;
 
 			if (icon == null)
 				return false;
@@ -218,6 +219,7 @@ namespace OpenRA.Mods.RA.Widgets
 			var oldIconCount = IconCount;
 			IconCount = 0;
 
+			var ks = Game.Settings.Keys;
 			var rb = RenderBounds;
 			foreach (var item in allBuildables)
 			{
@@ -229,8 +231,9 @@ namespace OpenRA.Mods.RA.Widgets
 
 				var pi = new ProductionIcon()
 				{
+					Actor = item,
 					Name = item.Name,
-					Hotkey = item.Traits.Get<BuildableInfo>().Hotkey,
+					Hotkey = ks.GetProductionHotkey(IconCount),
 					Sprite = icon.Image,
 					Pos = new float2(rect.Location),
 					Queued = CurrentQueue.AllQueued().Where(a => a.Item == item.Name).ToList(),

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -328,7 +328,7 @@ Container@PLAYER_WIDGETS:
 						ProductionTypeButton@BUILDING:
 							Width: 30
 							Height: 30
-							Key: q
+							Key: e
 							TooltipText: Buildings
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Building
@@ -341,7 +341,7 @@ Container@PLAYER_WIDGETS:
 							X: 35
 							Width: 30
 							Height: 30
-							Key: w
+							Key: r
 							TooltipText: Defence
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Defence
@@ -354,7 +354,7 @@ Container@PLAYER_WIDGETS:
 							X: 70
 							Width: 30
 							Height: 30
-							Key: e
+							Key: t
 							TooltipText: Infantry
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Infantry
@@ -367,7 +367,7 @@ Container@PLAYER_WIDGETS:
 							X: 105
 							Width: 30
 							Height: 30
-							Key: r
+							Key: y
 							TooltipText: Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
@@ -380,7 +380,7 @@ Container@PLAYER_WIDGETS:
 							X: 140
 							Width: 30
 							Height: 30
-							Key: t
+							Key: u
 							TooltipText: Aircraft
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Aircraft

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -399,6 +399,20 @@ Container@SETTINGS_PANEL:
 											X: PARENT_RIGHT-WIDTH+1
 											Width: 80
 											Height: 25
+								Container@PRODUCTION_TEMPLATE:
+									Width: 173
+									Height: 25
+									Visible: false
+									Children:
+										Label@FUNCTION:
+											Y: 0-1
+											Width: PARENT_RIGHT - 84
+											Height: 25
+											Align: Right
+										HotkeyEntry@HOTKEY:
+											X: PARENT_RIGHT-WIDTH+1
+											Width: 80
+											Height: 25
 				Container@ADVANCED_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -8,27 +8,27 @@ Container@PLAYER_WIDGETS:
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Diplomacy (F1)
+			Text: Diplomacy (P)
 			Font: Bold
-			Key: f1
+			Key: p
 		Button@INGAME_DEBUG_BUTTON:
 			X: 324
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Debug (F2)
+			Text: Debug (Shift + Esc)
 			Visible: false
 			Font: Bold
-			Key: f2
+			Key: escape Shift
 		Button@OBJECTIVES_BUTTON:
 			X: 486
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Objectives (F3)
+			Text: Objectives (O)
 			Visible: false
 			Font: Bold
-			Key: f3
+			Key: o
 		SlidingContainer@INGAME_RADAR_BIN:
 			X: WINDOW_RIGHT-215
 			Y: 0

--- a/mods/d2k/chrome/ingame.yaml
+++ b/mods/d2k/chrome/ingame.yaml
@@ -51,7 +51,7 @@ Container@INGAME_ROOT:
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Options (ESC)
+			Text: Options (Esc)
 			Font: Bold
 			Key: escape
 		Container@PERFORMANCE_INFO:

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -166,7 +166,6 @@ SONICTANK:
 		BuildPaletteOrder: 100
 		Prerequisites: heavya, researcha, ~techlevel.high
 		Owner: atreides
-		Hotkey: o
 	Valued:
 		Cost: 1250
 	Tooltip:
@@ -215,7 +214,6 @@ FREMEN:
 		BuildPaletteOrder: 85
 		Owner: atreides
 		Prerequisites: palacea, ~techlevel.high
-		Hotkey: f
 	Selectable:
 		Bounds: 12,17,0,0
 		Voice: FremenVoice
@@ -250,7 +248,6 @@ GRENADIER:
 		BuildPaletteOrder: 10
 		Owner: atreides
 		Prerequisites: ~techlevel.medium
-		Hotkey: g
 	Valued:
 		Cost: 160
 	Tooltip:

--- a/mods/d2k/rules/harkonnen.yaml
+++ b/mods/d2k/rules/harkonnen.yaml
@@ -172,7 +172,6 @@ DEVAST:
 		BuildPaletteOrder: 100
 		Prerequisites: Research, ~techlevel.high
 		Owner: harkonnen
-		Hotkey: d
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -220,7 +219,6 @@ SARDAUKAR:
 		BuildPaletteOrder: 80
 		Prerequisites: palaceh, ~techlevel.high
 		Owner: harkonnen
-		Hotkey: d
 	Valued:
 		Cost: 400
 	Tooltip:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -4,7 +4,6 @@ RIFLE:
 		Queue: Infantry
 		BuildPaletteOrder: 10
 		Owner: atreides,harkonnen,ordos
-		Hotkey: r
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -31,7 +30,6 @@ ENGINEER:
 		Queue: Infantry
 		BuildPaletteOrder: 50
 		Owner: atreides,harkonnen,ordos
-		Hotkey: e
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -60,7 +58,6 @@ BAZOOKA:
 		Queue: Infantry
 		BuildPaletteOrder: 20
 		Owner: atreides,harkonnen,ordos
-		Hotkey: t
 	Valued:
 		Cost: 250
 	Tooltip:
@@ -88,7 +85,6 @@ MEDIC:
 		BuildPaletteOrder: 60
 		Owner: atreides, ordos
 		Prerequisites: Research, ~techlevel.high
-		Hotkey: m
 	Valued:
 		Cost: 500
 	Tooltip:

--- a/mods/d2k/rules/ordos.yaml
+++ b/mods/d2k/rules/ordos.yaml
@@ -152,7 +152,6 @@ RAIDER:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
-		Hotkey: w
 		Owner: ordos
 	Valued:
 		Cost: 300
@@ -245,7 +244,6 @@ DEVIATORTANK:
 		BuildPaletteOrder: 50
 		Prerequisites: heavyo, researcho, ~techlevel.high
 		Owner: ordos
-		Hotkey: d
 	Mobile:
 		ROT: 3
 		Speed: 64
@@ -284,7 +282,6 @@ SABOTEUR:
 		BuildPaletteOrder: 100
 		Prerequisites: palaceo, ~techlevel.high
 		Owner: ordos
-		Hotkey: b
 	Valued:
 		Cost: 800
 	Tooltip:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -83,7 +83,6 @@ CONCRETEB:
 		Prerequisites: Conyard
 		Queue: Building
 		BuildPaletteOrder: 10
-		Hotkey: w
 	Selectable:
 		Bounds: 64,64
 	Valued:
@@ -115,7 +114,6 @@ CONCRETEB:
 		Prerequisites: Power
 		Queue: Building
 		BuildPaletteOrder: 40
-		Hotkey: b
 	Selectable:
 		Bounds: 64,64
 	Valued:
@@ -158,7 +156,6 @@ CONCRETEB:
 		Prerequisites: Power
 		Queue: Building
 		BuildPaletteOrder: 20
-		Hotkey: r
 	Selectable:
 		Bounds: 96,64
 	Valued:
@@ -205,7 +202,6 @@ CONCRETEB:
 		Prerequisites: Refinery
 		Queue: Building
 		BuildPaletteOrder: 30
-		Hotkey: i
 	Selectable:
 		Bounds: 32,32
 	Valued:
@@ -238,7 +234,6 @@ CONCRETEB:
 		Prerequisites: Refinery
 		Queue: Building
 		BuildPaletteOrder: 70
-		Hotkey: l
 	Selectable:
 		Bounds: 96,64
 	Valued:
@@ -279,7 +274,6 @@ CONCRETEB:
 		Prerequisites: Refinery
 		Queue: Building
 		BuildPaletteOrder: 100
-		Hotkey: h
 	Selectable:
 		Bounds: 96,96
 	Valued:
@@ -323,7 +317,6 @@ CONCRETEB:
 		Prerequisites: Barracks, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 50
-		Hotkey: o
 	Selectable:
 		Bounds: 96,64
 	Valued:
@@ -364,7 +357,6 @@ CONCRETEB:
 		Prerequisites: Outpost, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 80
-		Hotkey: c
 	Building:
 		Footprint: xxx x=x =x=
 		Dimensions: 3,3
@@ -415,7 +407,6 @@ CONCRETEB:
 	Tooltip:
 		Name: Concrete Wall
 		Description: Stop units and blocks enemy fire.
-		Hotkey: o
 	AppearsOnRadar:
 	Building:
 		BuildSounds: CHUNG.WAV
@@ -461,7 +452,6 @@ WALL:
 		Queue: Building
 		Prerequisites: Barracks
 		BuildPaletteOrder: 90
-		Hotkey: g
 	Valued:
 		Cost: 650
 	Tooltip:
@@ -514,7 +504,6 @@ WALL:
 		Queue: Building
 		Prerequisites: Outpost, ~techlevel.medium
 		BuildPaletteOrder: 120
-		Hotkey: m
 	Valued:
 		Cost: 850
 	Tooltip:
@@ -567,7 +556,6 @@ WALL:
 		Queue: Building
 		Prerequisites: Heavy, ~techlevel.medium
 		BuildPaletteOrder: 130
-		Hotkey: e
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -601,7 +589,6 @@ WALL:
 		Prerequisites: Outpost, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 110
-		Hotkey: t
 	Selectable:
 		Bounds: 96,96
 	Valued:
@@ -632,7 +619,6 @@ WALL:
 		Queue: Building
 		Prerequisites: Hitech, ~techlevel.high
 		BuildPaletteOrder: 140
-		Hotkey: v
 	Selectable:
 		Bounds: 96,64
 	Valued:
@@ -674,7 +660,6 @@ WALL:
 		Prerequisites: Research, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 150
-		Hotkey: p
 	Selectable:
 		Bounds: 96,96
 	Valued:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -4,7 +4,6 @@
 		Prerequisites: Repair, ~techlevel.medium
 		Queue: Armor
 		BuildPaletteOrder: 110
-		Hotkey: m
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -48,7 +47,6 @@ HARVESTER:
 		Prerequisites: Heavy,Refinery
 		Owner: atreides, harkonnen, ordos
 		BuildPaletteOrder: 10
-		Hotkey: h
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -107,7 +105,6 @@ TRIKE:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
-		Hotkey: w
 		Owner: atreides, harkonnen
 	Valued:
 		Cost: 250
@@ -154,7 +151,6 @@ QUAD:
 		Prerequisites: Light,Outpost, ~techlevel.medium
 		Owner: atreides, ordos, harkonnen
 		BuildPaletteOrder: 20
-		Hotkey: q
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -195,7 +191,6 @@ QUAD.starport:
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 40
-		Hotkey: c
 	Valued:
 		Cost: 700
 	Tooltip:
@@ -245,7 +240,6 @@ SIEGETANK:
 		Prerequisites: Outpost, ~techlevel.medium
 		Owner: atreides, harkonnen, ordos
 		BuildPaletteOrder: 50
-		Hotkey: t
 	Valued:
 		Cost: 850
 	Tooltip:
@@ -314,7 +308,6 @@ MISSILETANK:
 		Prerequisites: Hitech, ~techlevel.high
 		Owner: atreides, harkonnen, ordos
 		BuildPaletteOrder: 60
-		Hotkey: r
 	Mobile:
 		Speed: 64
 		ROT: 5

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -28,7 +28,7 @@ Container@OBSERVER_WIDGETS:
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Options (ESC)
+			Text: Options (Esc)
 			Font: Bold
 			Key: escape
 		MenuButton@OBSERVER_STATS_BUTTON:

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -8,10 +8,10 @@ Container@PLAYER_WIDGETS:
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Objectives (F3)
+			Text: Objectives (O)
 			Visible: false
 			Font: Bold
-			Key: f3
+			Key: o
 		Container@SUPPORT_POWERS:
 			Logic: SupportPowerBinLogic
 			X: 10
@@ -109,7 +109,7 @@ Container@PLAYER_WIDGETS:
 							MenuContainer: INGAME_DEBUG_BG
 							HideIngameUI: false
 							Pause: false
-							Key: f2
+							Key: escape Shift
 							X: 128
 							Width: 28
 							Height: 28
@@ -128,7 +128,7 @@ Container@PLAYER_WIDGETS:
 							MenuContainer: INGAME_DIPLOMACY_BG
 							HideIngameUI: false
 							Pause: false
-							Key: f1
+							Key: P
 							X: 160
 							Width: 28
 							Height: 28

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -255,6 +255,7 @@ Container@PLAYER_WIDGETS:
 					Children:
 						ProductionTypeButton@BUILDING:
 							Logic: AddRaceSuffixLogic
+							Key: e
 							Width: 28
 							Height: 28
 							VisualHeight: 0
@@ -269,6 +270,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@DEFENSE:
 							Logic: AddRaceSuffixLogic
+							Key: r
 							Y: 31
 							Width: 28
 							Height: 28
@@ -284,6 +286,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@INFANTRY:
 							Logic: AddRaceSuffixLogic
+							Key: t
 							Y: 62
 							Width: 28
 							Height: 28
@@ -299,6 +302,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@VEHICLE:
 							Logic: AddRaceSuffixLogic
+							Key: y
 							Y: 93
 							Width: 28
 							Height: 28
@@ -314,6 +318,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@AIRCRAFT:
 							Logic: AddRaceSuffixLogic
+							Key: u
 							Y: 124
 							Width: 28
 							Height: 28
@@ -327,8 +332,9 @@ Container@PLAYER_WIDGETS:
 									X: 6
 									Y: 6
 									ImageCollection: production-icons
-						ProductionTypeButton@AIRCRAFT:
+						ProductionTypeButton@NAVAL:
 							Logic: AddRaceSuffixLogic
+							Key: i
 							Y: 155
 							Width: 28
 							Height: 28

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -404,6 +404,20 @@ Background@SETTINGS_PANEL:
 									X: PARENT_RIGHT-WIDTH+1
 									Width: 80
 									Height: 25
+						Container@PRODUCTION_TEMPLATE:
+							Width: 173
+							Height: 25
+							Visible: false
+							Children:
+								Label@FUNCTION:
+									Y: 0-1
+									Width: PARENT_RIGHT - 84
+									Height: 25
+									Align: Right
+								HotkeyEntry@HOTKEY:
+									X: PARENT_RIGHT-WIDTH+1
+									Width: 80
+									Height: 25
 		Container@ADVANCED_PANEL:
 			X: 5
 			Y: 50

--- a/mods/ra/maps/bomber-john/map.yaml
+++ b/mods/ra/maps/bomber-john/map.yaml
@@ -884,7 +884,6 @@ Rules:
 			Queue: Building
 			BuildPaletteOrder: 30
 			Owner: allies, soviet
-			Hotkey: b
 		Valued:
 			Cost: 30
 		Health:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -81,7 +81,6 @@ MIG:
 		BuildAtProductionType: Plane
 		BuildPaletteOrder: 50
 		Prerequisites: ~afld, stek, ~techlevel.unrestricted
-		Hotkey: m
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -135,7 +134,6 @@ YAK:
 		BuildAtProductionType: Plane
 		BuildPaletteOrder: 30
 		Prerequisites: ~afld, ~techlevel.medium
-		Hotkey: y
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -195,7 +193,6 @@ TRAN:
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 10
 		Prerequisites: ~hpad, ~techlevel.medium
-		Hotkey: t
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -238,7 +235,6 @@ HELI:
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 40
 		Prerequisites: ~hpad, atek, ~techlevel.unrestricted
-		Hotkey: l
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -289,7 +285,6 @@ HIND:
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 20
 		Prerequisites: ~hpad, ~techlevel.medium
-		Hotkey: h
 	Valued:
 		Cost: 1000
 	Tooltip:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -5,7 +5,6 @@ DOG:
 		BuildAtProductionType: Dog
 		BuildPaletteOrder: 50
 		Prerequisites: ~kenn, ~techlevel.infonly
-		Hotkey: o
 	Valued:
 		Cost: 200
 	Tooltip:
@@ -36,7 +35,6 @@ E1:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 10
 		Prerequisites: ~barracks, ~techlevel.infonly
-		Hotkey: i
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -68,7 +66,6 @@ E2:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 20
 		Prerequisites: ~barr, ~techlevel.infonly
-		Hotkey: g
 	Valued:
 		Cost: 160
 	Tooltip:
@@ -105,7 +102,6 @@ E3:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 30
 		Prerequisites: ~barracks, ~techlevel.infonly
-		Hotkey: r
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -140,7 +136,6 @@ E4:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 70
 		Prerequisites: ~barr, ftur, ~techlevel.low
-		Hotkey: t
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -173,7 +168,6 @@ E6:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 60
 		Prerequisites: ~barracks, ~techlevel.infonly
-		Hotkey: e
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -206,7 +200,6 @@ SPY:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 90
 		Prerequisites: dome, ~tent, ~techlevel.medium
-		Hotkey: p
 	Valued:
 		Cost: 500
 	DisguiseToolTip:
@@ -243,7 +236,6 @@ E7:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 120
 		Prerequisites: ~tent, atek, ~techlevel.unrestricted
-		Hotkey: y
 		BuildLimit: 1
 	Valued:
 		Cost: 1200
@@ -284,7 +276,6 @@ MEDI:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 40
 		Prerequisites: ~tent, ~techlevel.infonly
-		Hotkey: m
 	Valued:
 		Cost: 200
 	Tooltip:
@@ -321,7 +312,6 @@ MECH:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 100
 		Prerequisites: ~tent, fix, ~techlevel.medium
-		Hotkey: c
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -439,7 +429,6 @@ HIJACKER:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 110
 		Prerequisites: ~barr, fix, ~techlevel.medium
-		Hotkey: j
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -467,7 +456,6 @@ SHOK:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 130
 		Prerequisites: ~barr, stek, tsla, ~techlevel.unrestricted
-		Hotkey: l
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -507,7 +495,6 @@ SNIPER:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 80
 		Prerequisites: ~barr, dome, ~techlevel.medium
-		Hotkey: h
 	Selectable:
 		Bounds: 12,17,0,-6
 	Mobile:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -5,7 +5,6 @@ SS:
 		BuildAtProductionType: Submarine
 		BuildPaletteOrder: 30
 		Prerequisites: ~spen, ~techlevel.medium
-		Hotkey: u
 	Valued:
 		Cost: 950
 	Tooltip:
@@ -58,7 +57,6 @@ MSUB:
 		BuildAtProductionType: Submarine
 		BuildPaletteOrder: 60
 		Prerequisites: ~spen, stek, ~techlevel.unrestricted
-		Hotkey: m
 	Valued:
 		Cost: 2400
 	Tooltip:
@@ -111,7 +109,6 @@ DD:
 		BuildAtProductionType: Boat
 		BuildPaletteOrder: 40
 		Prerequisites: ~syrd, dome, ~techlevel.medium
-		Hotkey: r
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -161,7 +158,6 @@ CA:
 		BuildAtProductionType: Boat
 		BuildPaletteOrder: 50
 		Prerequisites: ~syrd, atek, ~techlevel.unrestricted
-		Hotkey: c
 	Valued:
 		Cost: 2400
 	Tooltip:
@@ -222,7 +218,6 @@ LST:
 		Queue: Ship
 		BuildPaletteOrder: 10
 		Prerequisites: ~techlevel.low
-		Hotkey: t
 	Valued:
 		Cost: 700
 	Tooltip:
@@ -256,7 +251,6 @@ PT:
 		BuildAtProductionType: Boat
 		BuildPaletteOrder: 20
 		Prerequisites: ~syrd, ~techlevel.medium
-		Hotkey: b
 	Valued:
 		Cost: 500
 	Tooltip:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -10,7 +10,6 @@ MSLO:
 		BuildPaletteOrder: 140
 		Prerequisites: techcenter, ~techlevel.unrestricted
 		BuildLimit: 1
-		Hotkey: m
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
@@ -57,7 +56,6 @@ GAP:
 		Queue: Defense
 		BuildPaletteOrder: 110
 		Prerequisites: atek, ~structures.allies, ~techlevel.unrestricted
-		Hotkey: g
 	Building:
 		Footprint: _ x
 		Dimensions: 1,2
@@ -94,7 +92,6 @@ SPEN:
 		Queue: Building
 		BuildPaletteOrder: 50
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.low
-		Hotkey: y
 	TargetableBuilding:
 		TargetTypes: Ground, Water, C4, DetonateAttack, SpyInfiltrate
 	Building:
@@ -144,7 +141,6 @@ SYRD:
 		Queue: Building
 		BuildPaletteOrder: 40
 		Prerequisites: anypower, ~structures.allies, ~techlevel.low
-		Hotkey: y
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -198,7 +194,6 @@ IRON:
 		BuildPaletteOrder: 130
 		Prerequisites: stek, ~structures.soviet, ~techlevel.unrestricted
 		BuildLimit: 1
-		Hotkey: c
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -243,7 +238,6 @@ PDOX:
 		BuildPaletteOrder: 120
 		Prerequisites: atek, ~structures.allies, ~techlevel.unrestricted
 		BuildLimit: 1
-		Hotkey: o
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -287,7 +281,6 @@ TSLA:
 		Queue: Defense
 		BuildPaletteOrder: 80
 		Prerequisites: weap, ~structures.soviet, ~techlevel.medium
-		Hotkey: u
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -331,7 +324,6 @@ AGUN:
 		Queue: Defense
 		BuildPaletteOrder: 90
 		Prerequisites: dome, ~structures.allies, ~techlevel.medium
-		Hotkey: y
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -378,7 +370,6 @@ DOME:
 		Queue: Building
 		BuildPaletteOrder: 90
 		Prerequisites: proc, ~techlevel.medium
-		Hotkey: r
 	Valued:
 		Cost: 1800
 	Tooltip:
@@ -418,7 +409,6 @@ PBOX:
 		Queue: Defense
 		BuildPaletteOrder: 40
 		Prerequisites: tent, ~structures.allies, ~techlevel.low
-		Hotkey: p
 	-GivesBuildableArea:
 	Valued:
 		Cost: 400
@@ -464,7 +454,6 @@ HBOX:
 		Queue: Defense
 		BuildPaletteOrder: 50
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
-		Hotkey: l
 	-GivesBuildableArea:
 	Valued:
 		Cost: 600
@@ -509,7 +498,6 @@ GUN:
 		Queue: Defense
 		BuildPaletteOrder: 70
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
-		Hotkey: t
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -550,7 +538,6 @@ FTUR:
 		Queue: Defense
 		BuildPaletteOrder: 60
 		Prerequisites: barr, ~structures.soviet, ~techlevel.low
-		Hotkey: t
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -589,7 +576,6 @@ SAM:
 		Queue: Defense
 		BuildPaletteOrder: 100
 		Prerequisites: dome, ~structures.soviet, ~techlevel.medium
-		Hotkey: y
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -635,7 +621,6 @@ ATEK:
 		Queue: Building
 		BuildPaletteOrder: 140
 		Prerequisites: weap, dome, ~structures.allies, ~techlevel.unrestricted
-		Hotkey: t
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -675,7 +660,6 @@ WEAP:
 		Queue: Building
 		BuildPaletteOrder: 80
 		Prerequisites: proc, ~techlevel.low
-		Hotkey: w
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -771,7 +755,6 @@ PROC:
 		Queue: Building
 		BuildPaletteOrder: 60
 		Prerequisites: anypower, ~techlevel.infonly
-		Hotkey: e
 	Valued:
 		Cost: 1400
 	Tooltip:
@@ -818,7 +801,6 @@ SILO:
 		Queue: Building
 		BuildPaletteOrder: 70
 		Prerequisites: proc, ~techlevel.infonly
-		Hotkey: o
 	Valued:
 		Cost: 150
 	Tooltip:
@@ -850,7 +832,6 @@ HPAD:
 		Queue: Building
 		BuildPaletteOrder: 120
 		Prerequisites: dome, ~structures.allies, ~techlevel.medium
-		Hotkey: i
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -886,7 +867,6 @@ AFLD:
 		Queue: Building
 		BuildPaletteOrder: 130
 		Prerequisites: dome, ~structures.soviet, ~techlevel.medium
-		Hotkey: i
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -948,7 +928,6 @@ POWR:
 		Queue: Building
 		BuildPaletteOrder: 10
 		Prerequisites: ~techlevel.infonly
-		Hotkey: p
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -978,7 +957,6 @@ APWR:
 		Queue: Building
 		BuildPaletteOrder: 110
 		Prerequisites: dome, ~techlevel.medium
-		Hotkey: l
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -1008,7 +986,6 @@ STEK:
 		Queue: Building
 		BuildPaletteOrder: 150
 		Prerequisites: weap, dome, ~structures.soviet, ~techlevel.unrestricted
-		Hotkey: t
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -1036,7 +1013,6 @@ BARR:
 		Queue: Building
 		BuildPaletteOrder: 30
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.infonly
-		Hotkey: b
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -1075,7 +1051,6 @@ KENN:
 		Queue: Building
 		BuildPaletteOrder: 25
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.infonly
-		Hotkey: k
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -1111,7 +1086,6 @@ TENT:
 		Queue: Building
 		BuildPaletteOrder: 20
 		Prerequisites: anypower, ~structures.allies, ~techlevel.infonly
-		Hotkey: b
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -1150,7 +1124,6 @@ FIX:
 		Queue: Building
 		BuildPaletteOrder: 100
 		Prerequisites: weap, ~techlevel.medium
-		Hotkey: m
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -1331,7 +1304,6 @@ SBAG:
 		Queue: Defense
 		BuildPaletteOrder: 10
 		Prerequisites: fact, ~structures.allies, ~techlevel.low
-		Hotkey: b
 	Valued:
 		Cost: 25
 	CustomSellValue:
@@ -1357,7 +1329,6 @@ FENC:
 		Queue: Defense
 		BuildPaletteOrder: 20
 		Prerequisites: fact, ~structures.soviet, ~techlevel.low
-		Hotkey: n
 	Valued:
 		Cost: 25
 	CustomSellValue:
@@ -1383,7 +1354,6 @@ BRIK:
 		Queue: Defense
 		BuildPaletteOrder: 30
 		Prerequisites: fact, ~techlevel.medium
-		Hotkey: w
 	Valued:
 		Cost: 100
 	CustomSellValue:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -4,7 +4,6 @@ V2RL:
 		Queue: Vehicle
 		BuildPaletteOrder: 80
 		Prerequisites: dome, ~vehicles.soviet, ~techlevel.medium
-		Hotkey: v
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -33,7 +32,6 @@ V2RL:
 		Queue: Vehicle
 		BuildPaletteOrder: 50
 		Prerequisites: ~vehicles.allies, ~techlevel.low
-		Hotkey: l
 	Valued:
 		Cost: 700
 	Tooltip:
@@ -72,7 +70,6 @@ V2RL:
 		Queue: Vehicle
 		BuildPaletteOrder: 120
 		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
-		Hotkey: m
 	Valued:
 		Cost: 850
 	Tooltip:
@@ -114,7 +111,6 @@ V2RL:
 		Queue: Vehicle
 		BuildPaletteOrder: 130
 		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
-		Hotkey: h
 	Valued:
 		Cost: 1150
 	Tooltip:
@@ -156,7 +152,6 @@ V2RL:
 		Queue: Vehicle
 		BuildPaletteOrder: 190
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
-		Hotkey: m
 	Valued:
 		Cost: 2000
 	CustomBuildTimeValue:
@@ -212,7 +207,6 @@ ARTY:
 		Queue: Vehicle
 		BuildPaletteOrder: 70
 		Prerequisites: dome, ~vehicles.allies, ~techlevel.medium
-		Hotkey: r
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -245,7 +239,6 @@ HARV:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Prerequisites: proc, ~techlevel.infonly
-		Hotkey: e
 	Valued:
 		Cost: 1100
 	Tooltip:
@@ -288,7 +281,6 @@ MCV:
 		Queue: Vehicle
 		BuildPaletteOrder: 90
 		Prerequisites: fix, ~techlevel.medium
-		Hotkey: b
 	CustomBuildTimeValue:
 		Value: 2000
 	Valued:
@@ -329,7 +321,6 @@ JEEP:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
 		Prerequisites: ~vehicles.allies, ~techlevel.low
-		Hotkey: n
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -368,7 +359,6 @@ APC:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 40
-		Hotkey: c
 		Prerequisites: ~vehicles.soviet, ~techlevel.low
 	Valued:
 		Cost: 850
@@ -405,7 +395,6 @@ MNLY.AP:
 		Queue: Vehicle
 		BuildPaletteOrder: 110
 		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
-		Hotkey: i
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -439,7 +428,6 @@ MNLY.AT:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
 		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
-		Hotkey: i
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -473,7 +461,6 @@ TRUK:
 		Queue: Vehicle
 		BuildPaletteOrder: 20
 		Prerequisites: weap, ~techlevel.low
-		Hotkey: u
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -500,7 +487,6 @@ MGG:
 		Queue: Vehicle
 		BuildPaletteOrder: 160
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.unrestricted
-		Hotkey: y
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -538,7 +524,6 @@ MRJ:
 		Queue: Vehicle
 		BuildPaletteOrder: 150
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.unrestricted
-		Hotkey: k
 	Health:
 		HP: 220
 	Armor:
@@ -569,7 +554,6 @@ TTNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 180
 		Prerequisites: tsla, stek, ~vehicles.soviet, ~techlevel.unrestricted
-		Hotkey: t
 	Valued:
 		Cost: 1350
 	Tooltip:
@@ -603,7 +587,6 @@ FTRK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
-		Hotkey: k
 		Prerequisites: ~vehicles.soviet, ~techlevel.low
 	Valued:
 		Cost: 600
@@ -644,7 +627,6 @@ DTRK:
 		Queue: Vehicle
 		BuildPaletteOrder: 170
 		Prerequisites: stek, ~vehicles.soviet, ~techlevel.unrestricted
-		Hotkey: o
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -673,7 +655,6 @@ CTNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 210
 		Prerequisites: atek, pdox, ~vehicles.allies, ~techlevel.unrestricted
-		Hotkey: j
 	Valued:
 		Cost: 1350
 	Tooltip:
@@ -712,7 +693,6 @@ QTNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 200
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
-		Hotkey: q
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -743,7 +723,6 @@ STNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 140
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.unrestricted
-		Hotkey: p
 	Valued:
 		Cost: 1350
 	Tooltip:

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -8,27 +8,27 @@ Container@PLAYER_WIDGETS:
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Diplomacy (F1)
+			Text: Diplomacy (P)
 			Font: Bold
-			Key: f1
+			Key: p
 		Button@INGAME_DEBUG_BUTTON:
 			X: 324
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Cheats (F2)
+			Text: Debug (Shift + Esc)
 			Visible: false
 			Font: Bold
-			Key: f2
+			Key: escape Shift
 		Button@OBJECTIVES_BUTTON:
 			X: 486
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Objectives (F3)
+			Text: Objectives (O)
 			Visible: false
 			Font: Bold
-			Key: f3
+			Key: o
 		SlidingContainer@INGAME_RADAR_BIN:
 			X: WINDOW_RIGHT-215
 			Y: 0

--- a/mods/ts/chrome/ingame.yaml
+++ b/mods/ts/chrome/ingame.yaml
@@ -51,7 +51,7 @@ Container@INGAME_ROOT:
 			Y: 0
 			Width: 160
 			Height: 25
-			Text: Options (ESC)
+			Text: Options (Esc)
 			Font: Bold
 			Key: escape
 		Container@PERFORMANCE_INFO:

--- a/mods/ts/rules/infantry.yaml
+++ b/mods/ts/rules/infantry.yaml
@@ -4,7 +4,6 @@ E1:
 		Queue: Infantry
 		BuildPaletteOrder: 10
 		Owner: gdi,nod
-		Hotkey: i
 	Valued:
 		Cost: 120
 	Tooltip:
@@ -30,7 +29,6 @@ E2:
 		Queue: Infantry
 		BuildPaletteOrder: 10
 		Owner: gdi
-		Hotkey: d
 	Valued:
 		Cost: 200
 	Tooltip:
@@ -58,7 +56,6 @@ E3:
 		Queue: Infantry
 		BuildPaletteOrder: 20
 		Owner: nod
-		Hotkey: r
 	Valued:
 		Cost: 250
 	Tooltip:
@@ -120,7 +117,6 @@ MEDIC:
 		Queue: Infantry
 		BuildPaletteOrder: 60
 		Owner: gdi
-		Hotkey: m
 	Selectable:
 		Bounds: 12,17,0,-6
 		Voice: Medic
@@ -153,7 +149,6 @@ ENGINEER:
 		Queue: Infantry
 		BuildPaletteOrder: 30
 		Owner: gdi,nod
-		Hotkey: e
 	Selectable:
 		Bounds: 12,17,0,-6
 		Voice: Engineer
@@ -252,7 +247,6 @@ JUMPJET:
 		Queue: Infantry
 		BuildPaletteOrder: 50
 		Owner: gdi
-		Hotkey: j
 	Selectable:
 		Bounds: 12,17,0,-6
 		Voice: JumpJet
@@ -279,7 +273,6 @@ CHAMSPY:
 		Queue: Infantry
 		BuildPaletteOrder: 60
 		Owner: nod
-		Hotkey: s
 	Valued:
 		Cost: 700
 	DisguiseToolTip:
@@ -317,7 +310,6 @@ CYBORG:
 		Queue: Infantry
 		BuildPaletteOrder: 50
 		Owner: nod
-		Hotkey: n
 	-CrushableInfantry:
 		CrushSound: squish2.aud
 	Selectable:
@@ -353,7 +345,6 @@ CYC2:
 		Queue: Infantry
 		BuildPaletteOrder: 50
 		Owner: nod
-		Hotkey: o
 	-CrushableInfantry:
 		CrushSound: squish2.aud
 	Selectable:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -49,7 +49,6 @@ GAPOWR:
 		Queue: Building
 		BuildPaletteOrder: 0
 		Owner: gdi
-		Hotkey: p
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -81,7 +80,6 @@ GAPILE:
 		BuildPaletteOrder: 30
 		Prerequisites: anypower
 		Owner: gdi
-		Hotkey: b
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -127,7 +125,6 @@ PROC:
 		BuildPaletteOrder: 20
 		Prerequisites: anypower
 		Owner: gdi,nod
-		Hotkey: r
 	Building:
 		Footprint: xxx xxx x==
 		Dimensions: 3,3
@@ -168,7 +165,6 @@ GAWEAP:
 		Queue: Building
 		BuildPaletteOrder: 50
 		Owner: gdi
-		Hotkey: w
 	Building:
 		Footprint: ___ xxx ===
 		Dimensions: 3,3
@@ -204,7 +200,6 @@ NAPOWR:
 		Queue: Building
 		BuildPaletteOrder: 0
 		Owner: nod
-		Hotkey: q
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -234,7 +229,6 @@ NAAPWR:
 		BuildPaletteOrder: 5
 		Prerequisites: factory
 		Owner: nod
-		Hotkey: a
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -264,7 +258,6 @@ NAHAND:
 		BuildPaletteOrder: 30
 		Prerequisites: anypower
 		Owner: nod
-		Hotkey: h
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -309,7 +302,6 @@ NAWEAP:
 		Queue: Building
 		BuildPaletteOrder: 50
 		Owner: nod
-		Hotkey: f
 	Building:
 		Footprint: ___ xxx ===
 		Dimensions: 3,3
@@ -342,7 +334,6 @@ GASAND:
 		BuildPaletteOrder: 1000
 		Prerequisites: gacnst
 		Owner: gdi
-		Hotkey: b
 	SoundOnDamageTransition:
 		DamagedSound: sandbag1.aud
 		DestroyedSound: sandbag1.aud
@@ -371,7 +362,6 @@ GAWALL:
 		BuildPaletteOrder: 1001
 		Prerequisites: gacnst
 		Owner: gdi
-		Hotkey: w
 	SoundOnDamageTransition:
 		DamagedSound:
 		DestroyedSound:
@@ -396,7 +386,6 @@ NAWALL:
 		BuildPaletteOrder: 1001
 		Prerequisites: gacnst
 		Owner: nod
-		Hotkey: n
 	SoundOnDamageTransition:
 		DamagedSound:
 		DestroyedSound:
@@ -561,7 +550,6 @@ GASPOT:
 		Queue: Defense
 		BuildPaletteOrder: 10
 		Owner: gdi, nod
-		Hotkey: p
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -589,7 +577,6 @@ GALITE:
 		Queue: Defense
 		BuildPaletteOrder: 10
 		Owner: gdi, nod
-		Hotkey: m
 	Valued:
 		Cost: 200
 	Tooltip:
@@ -618,7 +605,6 @@ GARADR:
 		BuildPaletteOrder: 90
 		Owner: gdi
 		Prerequisites: anypower, factory
-		Hotkey: d
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -657,7 +643,6 @@ NARADR:
 		BuildPaletteOrder: 90
 		Owner: nod
 		Prerequisites: anypower, factory
-		Hotkey: e
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -696,7 +681,6 @@ GATECH:
 		BuildPaletteOrder: 100
 		Owner: gdi
 		Prerequisites: garadr
-		Hotkey: t
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -725,7 +709,6 @@ NATECH:
 		BuildPaletteOrder: 100
 		Owner: nod
 		Prerequisites: naradr
-		Hotkey: x
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -758,7 +741,6 @@ GAHPAD:
 		BuildPaletteOrder: 60
 		Owner: gdi
 		Queue: Building
-		Hotkey: i
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -793,7 +775,6 @@ NAHPAD:
 		BuildPaletteOrder: 60
 		Owner: nod
 		Queue: Building
-		Hotkey: j
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -829,7 +810,6 @@ GADEPT:
 		Prerequisites: factory
 		Owner: gdi
 		Queue: Building
-		Hotkey: v
 	Building:
 		Footprint: _x_ xxx _x_
 		Dimensions: 3,3
@@ -865,7 +845,6 @@ GAVULC:
 		Queue: Defense
 		BuildPaletteOrder: 30
 		Owner: gdi
-		Hotkey: v
 	Building:
 	DisabledOverlay:
 	-GivesBuildableArea:
@@ -924,7 +903,6 @@ GAROCK:
 		Queue: Defense
 		BuildPaletteOrder: 40
 		Owner: gdi
-		Hotkey: r
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -974,7 +952,6 @@ GACSAM:
 		Queue: Defense
 		BuildPaletteOrder: 60
 		Owner: gdi
-		Hotkey: a
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -1023,7 +1000,6 @@ NASAM:
 		Queue: Defense
 		BuildPaletteOrder: 60
 		Owner: nod
-		Hotkey: s
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -1065,7 +1041,6 @@ NALASR:
 		Queue: Defense
 		BuildPaletteOrder: 50
 		Owner: nod
-		Hotkey: l
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -1105,7 +1080,6 @@ NAOBEL:
 		BuildPaletteOrder: 90
 		Prerequisites: tech
 		Owner: nod
-		Hotkey: o
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -4,7 +4,6 @@ MCV:
 		Queue: Vehicle
 		BuildPaletteOrder: 110
 		Owner: gdi,nod
-		Hotkey: b
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -45,7 +44,6 @@ APC:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
 		Owner: gdi
-		Hotkey: a
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -76,7 +74,6 @@ HARV:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Owner: gdi,nod
-		Hotkey: h
 	Selectable:
 		Priority: 7
 		Bounds: 36,36
@@ -160,7 +157,6 @@ HVR:
 	Tooltip:
 		Name: Mammoth Tank
 		Description: Heavily armored GDI Tank.\n  Strong vs Everything
-		Hotkey: m
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
@@ -202,7 +198,6 @@ TRUCKB:
 		Queue: Vehicle
 		BuildPaletteOrder: 120
 		Owner: gdi, nod
-		Hotkey: t
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -232,7 +227,6 @@ LPST:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
 		Owner: gdi, nod
-		Hotkey: y
 	Health:
 		HP: 600
 	Armor:
@@ -262,7 +256,6 @@ ICBM:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
 		Owner: gdi
-		Hotkey: l
 	Health:
 		HP: 500
 	Armor:
@@ -288,7 +281,6 @@ REPAIR:
 		Queue: Vehicle
 		BuildPaletteOrder: 70
 		Owner: nod
-		Hotkey: r
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -320,7 +312,6 @@ ART2:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
 		Owner: nod
-		Hotkey: i
 	Health:
 		HP: 300
 	Armor:
@@ -351,7 +342,6 @@ WEED:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Owner: nod
-		Hotkey: w
 	Mobile:
 		Speed: 71
 		ROT: 5
@@ -509,7 +499,6 @@ MMCH:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
 		Owner: gdi
-		Hotkey: e
 	Mobile:
 		ROT: 5
 		Speed: 56
@@ -545,7 +534,6 @@ HMEC:
 		Queue: Vehicle
 		BuildPaletteOrder: 80
 		Owner: gdi
-		Hotkey: o
 	Mobile:
 		ROT: 3
 		Speed: 42
@@ -579,7 +567,6 @@ SMECH:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Owner: gdi
-		Hotkey: n
 	Mobile:
 		ROT: 5
 		Speed: 99
@@ -609,7 +596,6 @@ BIKE:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
 		Owner: nod
-		Hotkey: c
 	Mobile:
 		ROT: 8
 		Speed: 170
@@ -639,7 +625,6 @@ BGGY:
 		Queue: Vehicle
 		BuildPaletteOrder: 40
 		Owner: nod
-		Hotkey: g
 	Mobile:
 		ROT: 8
 		Speed: 142
@@ -672,7 +657,6 @@ SAPC:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
 		Owner: nod
-		Hotkey: s
 	Mobile:
 		ROT: 5
 		Speed: 71
@@ -701,7 +685,6 @@ SUBTANK:
 		Queue: Vehicle
 		BuildPaletteOrder: 40
 		Owner: nod
-		Hotkey: d
 	Mobile:
 		ROT: 6
 		Speed: 71
@@ -729,7 +712,6 @@ SONIC:
 		Queue: Vehicle
 		BuildPaletteOrder: 70
 		Owner: gdi
-		Hotkey: p
 	Mobile:
 		ROT: 4
 		Speed: 56
@@ -761,7 +743,6 @@ TTNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
 		Owner: nod
-		Hotkey: j
 	Mobile:
 		ROT: 5
 		Speed: 85
@@ -792,7 +773,6 @@ STNK:
 		BuildPaletteOrder: 90
 		Queue: Vehicle
 		Owner: nod
-		Hotkey: q
 	Mobile:
 		ROT: 5
 		Speed: 85


### PR DESCRIPTION
This changes the sidebar production hotkeys to a configurable slot-based assignment as used in C&C3 and RA3 (the earlier games didn't have production hotkeys).

The default hotkeys are set to the F-keys (as C&C3 and RA3 did), which is a safe but non-optimal choice.  Players can adjust them in the settings menu to whatever they wish.

Fixes #3915, #4142, #4181, #6031.
