### PR TITLE
Add Ctrl+right-click cancelling to the production panel.

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-// new build
-
 using System;
 using System.IO;
 using System.Linq;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -8,6 +8,8 @@
  */
 #endregion
 
+// new build
+
 using System;
 using System.IO;
 using System.Linq;
@@ -237,5 +239,10 @@ namespace OpenRA
 		{
 			return new Order("CancelProduction", subject, false) { ExtraData = (uint)count, TargetString = item };
 		}
+
+        public static Order ClearProduction(Actor subject, string item, int count)
+        {
+            return new Order("ClearProduction", subject, false) { ExtraData = 0, TargetString = item };
+        }
 	}
 }

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-// New Build
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -8,6 +8,8 @@
  */
 #endregion
 
+// New Build
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -315,6 +317,14 @@ namespace OpenRA.Mods.RA
 					CancelProduction(order.TargetString, order.ExtraData);
 					break;
 				}
+
+            case "ClearProduction":
+                {
+                    List<ProductionItem> PausedItems = queue.FindAll(a => a.Item == order.TargetString);
+                    CancelProduction(order.TargetString, (uint)PausedItems.Count);           // There won't be more than 255 of the same item. Should be fine
+
+                    break;
+                }
 			}
 		}
 

--- a/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
@@ -8,6 +8,8 @@
  */
 #endregion
 
+// new
+
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -41,6 +43,7 @@ namespace OpenRA.Mods.RA.Widgets
 		public readonly int2 IconSize = new int2(64, 48);
 		public readonly int2 IconMargin = int2.Zero;
 		public readonly int2 IconSpriteOffset = int2.Zero;
+        public bool holdCtrl = false;
 
 		public readonly string TabClick = null;
 		public readonly string DisabledTabClick = null;
@@ -164,26 +167,31 @@ namespace OpenRA.Mods.RA.Widgets
 			}
 			else
 			{
-				// Hold/Cancel an existing item
-				if (first != null)
-				{
-					Sound.Play(TabClick);
+                // Hold/Cancel/Clear an existing item
+                if (first != null)
+                {
+                    Sound.Play(TabClick);
 
-					// instant cancel of things we havent started yet and things that are finished
-					if (first.Paused || first.Done || first.TotalCost == first.RemainingCost)
-					{
-						Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Country.Race);
-						World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name,
-							Game.GetModifierKeys().HasModifier(Modifiers.Shift) ? 5 : 1));
-					}
-					else
-					{
-						Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.OnHoldAudio, World.LocalPlayer.Country.Race);
-						World.IssueOrder(Order.PauseProduction(CurrentQueue.Actor, icon.Name, true));
-					}
-				}
-				else
-					Sound.Play(DisabledTabClick);
+                    // instant cancel of things we havent started yet and things that are finished
+                    if (first.Paused || first.Done || first.TotalCost == first.RemainingCost)
+                    {
+                        Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Country.Race);
+
+                        if (holdCtrl == false)
+                            World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name,          // Cancel single item
+                                Game.GetModifierKeys().HasModifier(Modifiers.Shift) ? 5 : 1));
+                        else
+                            World.IssueOrder(Order.ClearProduction(CurrentQueue.Actor, icon.Name,           // Clear all queued production
+                                Game.GetModifierKeys().HasModifier(Modifiers.Shift) ? 5 : 1));
+                    }
+                    else
+                    {
+                        Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.OnHoldAudio, World.LocalPlayer.Country.Race);
+                        World.IssueOrder(Order.PauseProduction(CurrentQueue.Actor, icon.Name, true));
+                    }
+                }
+                else
+                    Sound.Play(DisabledTabClick);
 			}
 
 			return true;
@@ -191,12 +199,21 @@ namespace OpenRA.Mods.RA.Widgets
 
 		public override bool HandleKeyPress(KeyInput e)
 		{
-			if (e.Event == KeyInputEvent.Up || CurrentQueue == null)
-				return false;
+            if (CurrentQueue == null)
+                return false;
 
-			var hotkey = Hotkey.FromKeyInput(e);
-			var toBuild = icons.Values.FirstOrDefault(i => i.Hotkey == hotkey);
-			return toBuild != null ? HandleEvent(toBuild, true) : false;
+            var hotkey = Hotkey.FromKeyInput(e);
+            var toBuild = icons.Values.FirstOrDefault(i => i.Hotkey == hotkey);
+
+            if (e.Key == Keycode.LCTRL)
+            {
+                if (e.Event == KeyInputEvent.Down)
+                    holdCtrl = true;
+                else
+                    holdCtrl = false;
+            }
+
+            return toBuild != null ? HandleEvent(toBuild, true) : false;
 		}
 
 		public void RefreshIcons()

--- a/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/ProductionPaletteWidget.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-// new
-
 using System;
 using System.Collections.Generic;
 using System.Drawing;


### PR DESCRIPTION
Feature: https://github.com/OpenRA/OpenRA/issues/6082
Regression tested - From what I can see no bugs or performance issues.

Order.cs : Line 241: 
- Function ClearProduction() inputs new order to the ProductionQueue

ProductionQueue.cs: Line 323: 
- Case statement "ClearProduction" counts number of items paused for item
- Deletes all paused items for that icon and returns appropriate fees if applicable

ProductionPaletteWidget.cs: HandleKeyPress(KeyInput e) && bool HandleEvent(ProductionIcon icon, bool isLeftClick)
- Former to remember Control is key up or down with bool (hold/release)
- Latter to call new production order "ClearProduction" for item LCtrl + Click on
