### PR TITLE
Fixed idle overlays being displayed during actor transformations

### DIFF
--- a/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA.Render
 		}
 	}
 
-	public class WithIdleOverlay : INotifyDamageStateChanged, INotifyBuildComplete, INotifySold
+	public class WithIdleOverlay : INotifyDamageStateChanged, INotifyBuildComplete, INotifySold, INotifyTransform
 	{
 		Animation overlay;
 		bool buildComplete;
@@ -82,6 +82,13 @@ namespace OpenRA.Mods.RA.Render
 		{
 			buildComplete = false;
 		}
+
+		public void BeforeTransform(Actor self)
+		{
+			buildComplete = false;
+		}
+		public void OnTransform(Actor self) { }
+		public void AfterTransform(Actor self) { }
 
 		public void DamageStateChanged(Actor self, AttackInfo e)
 		{


### PR DESCRIPTION
as described in #6018. Tiberian Sun construction yard is the only test case at the moment.
