### PR TITLE
Sonic Tank offset

### DIFF
--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -723,6 +723,7 @@ SONIC:
 		Range: 7c0
 	Armament:
 		Weapon: SonicZap
+		LocalOffset: -50,0,410
 	AttackTurreted:
 	Turreted:
 		ROT: 5


### PR DESCRIPTION
Fixes the offset for the SonicZap weapon for the Disruptor tank.
