### PR TITLE
#6128. Minor fixes for IonCannonPower and Bridge.

### DIFF
--- a/OpenRA.Mods.Cnc/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/IonCannonPower.cs
@@ -21,13 +21,19 @@ namespace OpenRA.Mods.Cnc
 		[ActorReference]
 		[Desc("Actor to spawn when the attack starts")]
 		public readonly string CameraActor = null;
+		
 		[Desc("Amount of time to keep the camera alive")]
 		public readonly int CameraRemoveDelay = 25;
+		
 		[Desc("Effect sequence to display")]
 		public readonly string Effect = "ionsfx";
 		public readonly string EffectPalette = "effect";
+		
 		[Desc("Which weapon to fire")]
 		public readonly string Weapon = "IonCannon";
+		
+		[Desc("Apply the weapon impact this many ticks into the effect")]
+		public readonly int WeaponDelay = 7;
 
 		public override object Create(ActorInitializer init) { return new IonCannonPower(init.self, this); }
 	}
@@ -50,7 +56,7 @@ namespace OpenRA.Mods.Cnc
 			{
 				var info = Info as IonCannonPowerInfo;
 				Sound.Play(Info.LaunchSound, self.World.Map.CenterOfCell(order.TargetLocation));
-				w.Add(new IonCannon(self.Owner, info.Weapon, w, order.TargetLocation, info.Effect, info.EffectPalette));
+				w.Add(new IonCannon(self.Owner, info.Weapon, w, order.TargetLocation, info.Effect, info.EffectPalette, info.WeaponDelay));
 
 				if (info.CameraActor == null)
 					return;

--- a/OpenRA.Mods.RA/Bridge.cs
+++ b/OpenRA.Mods.RA/Bridge.cs
@@ -37,6 +37,9 @@ namespace OpenRA.Mods.RA
 		public readonly string[] ShorePieces = {"br1", "br2"};
 		public readonly int[] NorthOffset = null;
 		public readonly int[] SouthOffset = null;
+		
+		[Desc("The name of the weapon to use when demolishing the bridge")]
+		public readonly string DemolishWeapon = "Demolish";
 
 		public object Create(ActorInitializer init) { return new Bridge(init.self, this); }
 
@@ -295,7 +298,7 @@ namespace OpenRA.Mods.RA
 			var initialDamage = Health.DamageState;
 			self.World.AddFrameEndTask(w =>
 			{
-				var weapon = saboteur.World.Map.Rules.Weapons["demolish"];
+				var weapon = saboteur.World.Map.Rules.Weapons[Info.DemolishWeapon.ToLowerInvariant()];
 				weapon.Impact(self.CenterPosition, saboteur, 1f);
 				self.World.WorldActor.Trait<ScreenShaker>().AddEffect(15, self.CenterPosition, 6);
 				self.Kill(saboteur);


### PR DESCRIPTION
Minor fixes. IonCannonPower can now define how many ticks into animation the weapon impact happens (as opposed to at the end of the animation. Bridge can now define weapon used for demolition, default = "Demolish" as previous.

Closes #6128.
