### PR TITLE
Fix crate actions assuming collector has Mobile.

### DIFF
--- a/OpenRA.Mods.RA/Crates/CloakCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/CloakCrateAction.cs
@@ -53,16 +53,15 @@ namespace OpenRA.Mods.RA.Crates
 				(a != collector) &&
 				(a.TraitOrDefault<Cloak>() != null) &&
 				(a.TraitOrDefault<Cloak>().AcceptsCloakCrate));
+
 			if (inRange.Any())
 			{
 				if (Info.MaxExtraCollectors > -1)
 					inRange = inRange.Take(Info.MaxExtraCollectors);
 
 				if (inRange.Any())
-					foreach (Actor actor in inRange)
-					{
+					foreach (var actor in inRange)
 						actor.Trait<Cloak>().ReceivedCloakCrate(actor);
-					}
 			}
 
 			base.Activate(collector);

--- a/OpenRA.Mods.RA/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/DuplicateUnitCrateAction.cs
@@ -71,18 +71,18 @@ namespace OpenRA.Mods.RA.Crates
 
 		public override void Activate(Actor collector)
 		{
-			int AllowedWorthLeft = Info.MaxDuplicatesWorth;
-			int DupesMade = 0;
+			int allowedWorthLeft = Info.MaxDuplicatesWorth;
+			int dupesMade = 0;
 
-			while ((DupesMade < Info.MaxAmount) && (AllowedWorthLeft > 0) || (DupesMade < Info.MinAmount))
+			while ((dupesMade < Info.MaxAmount) && (allowedWorthLeft > 0) || (dupesMade < Info.MinAmount))
 			{
 				//If the collector has a cost, and we have a max duplicate worth, then update how much dupe worth is left
 				var unitCost = collector.Info.Traits.Get<ValuedInfo>().Cost;
-				AllowedWorthLeft -= (Info.MaxDuplicatesWorth > 0) ? unitCost : 0;
-				if ((AllowedWorthLeft < 0) && (DupesMade >= Info.MinAmount))
+				allowedWorthLeft -= (Info.MaxDuplicatesWorth > 0) ? unitCost : 0;
+				if ((allowedWorthLeft < 0) && (dupesMade >= Info.MinAmount))
 					break;
 
-				DupesMade++;
+				dupesMade++;
 
 				var location = ChooseEmptyCellNear(collector, collector.Info.Name);
 				if (location != null)
@@ -101,7 +101,9 @@ namespace OpenRA.Mods.RA.Crates
 
 		IEnumerable<CPos> GetSuitableCells(CPos near, string unitName)
 		{
-			var mi = self.World.Map.Rules.Actors[unitName].Traits.Get<MobileInfo>();
+			var mi = self.World.Map.Rules.Actors[unitName].Traits.GetOrDefault<MobileInfo>();
+			if (mi == null)
+				yield break;
 
 			for (var i = -3; i < 4; i++)
 				for (var j = -3; j < 4; j++)

--- a/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
@@ -83,7 +83,9 @@ namespace OpenRA.Mods.RA.Crates
 
 		IEnumerable<CPos> GetSuitableCells(CPos near, string unitName)
 		{
-			var mi = self.World.Map.Rules.Actors[unitName].Traits.Get<MobileInfo>();
+			var mi = self.World.Map.Rules.Actors[unitName].Traits.GetOrDefault<MobileInfo>();
+			if (mi == null)
+				yield break;
 
 			for (var i = -1; i < 2; i++)
 				for (var j = -1; j < 2; j++)

--- a/OpenRA.Mods.RA/Crates/UnitUpgradeCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/UnitUpgradeCrateAction.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.RA.Crates
 					inRange = inRange.Take(Info.MaxExtraCollectors);
 
 				if (inRange.Any())
-					foreach (Actor actor in inRange)
+					foreach (var actor in inRange)
 					{
 						actor.World.AddFrameEndTask(w =>
 						{


### PR DESCRIPTION
A crate fell on a structure I had just built (cell was OK before paradrop).
This fixes the NRE from lack of `Mobile` but may have unintended side effects.

\+ a bit of code cleanup.
