### PR TITLE
Remove TakeOff activity from ReturnToBase

### DIFF
--- a/OpenRA.Mods.RA/Air/Plane.cs
+++ b/OpenRA.Mods.RA/Air/Plane.cs
@@ -112,7 +112,6 @@ namespace OpenRA.Mods.RA.Air
 				self.SetTargetLine(Target.FromActor(airfield), Color.Green);
 				self.QueueActivity(new ReturnToBase(self, airfield));
 				self.QueueActivity(new ResupplyAircraft());
-				self.QueueActivity(new TakeOff());
 			}
 			else
 			{


### PR DESCRIPTION
Reverting a change made in #5470. Currently if you order the plane to land by mouse, it stays landed. Using `F` (`ReturnToBase`) also lands the plane, but after rearming it will `TakeOff` and circle around the rallypoint.
