### PR TITLE
Implement IMA ADPCM WAV file support

### DIFF
--- a/OpenRA.Game/FileFormats/AdpcmLoader.cs
+++ b/OpenRA.Game/FileFormats/AdpcmLoader.cs
@@ -1,0 +1,99 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.IO;
+
+namespace OpenRA.FileFormats
+{
+	struct AdpcmChunk
+	{
+		public int CompressedSize;
+		public int OutputSize;
+
+		public static AdpcmChunk Read(Stream s)
+		{
+			AdpcmChunk c;
+			c.CompressedSize = s.ReadUInt16();
+			c.OutputSize = s.ReadUInt16();
+			if (s.ReadUInt32() != 0xdeaf)
+				throw new InvalidDataException("Chunk header is bogus");
+			return c;
+		}
+	}
+
+	public static class AdpcmLoader
+	{
+		static readonly int[] indexAdjust = { -1, -1, -1, -1, 2, 4, 6, 8 };
+		static readonly int[] stepTable = 
+		{	
+			7, 8, 9, 10, 11, 12, 13, 14, 16,
+			17, 19, 21, 23, 25, 28, 31, 34, 37,
+			41, 45, 50, 55, 60, 66, 73, 80, 88,
+			97, 107, 118, 130, 143, 157, 173, 190, 209,
+			230, 253, 279, 307, 337, 371, 408, 449, 494,
+			544, 598, 658, 724, 796, 876, 963, 1060, 1166,
+			1282, 1411, 1552, 1707, 1878, 2066, 2272, 2499, 2749,
+			3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484,
+			7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899, 15289,
+			16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767 
+		};
+
+		static short DecodeAdpcmSample(byte b, ref int index, ref int current)
+		{
+			var sb = (b & 8) != 0;
+			b &= 7;
+
+			var delta = (stepTable[index] * b) / 4 + stepTable[index] / 8;
+			if (sb) delta = -delta;
+
+			current += delta;
+			if (current > short.MaxValue) current = short.MaxValue;
+			if (current < short.MinValue) current = short.MinValue;
+
+			index += indexAdjust[b];
+			if (index < 0) index = 0;
+			if (index > 88) index = 88;
+
+			return (short)current;
+		}
+
+		public static byte[] LoadAdpcmSound(byte[] raw, ref int index)
+		{
+			var currentSample = 0;
+			return LoadAdpcmSound(raw, ref index, ref currentSample);
+		}
+
+		public static byte[] LoadAdpcmSound(byte[] raw, ref int index, ref int currentSample)
+		{
+			var s = new MemoryStream(raw);
+			var dataSize = raw.Length;
+			var outputSize = raw.Length * 4;
+
+			var output = new byte[outputSize];
+			var offset = 0;
+
+			while (dataSize-- > 0)
+			{
+				var b = s.ReadUInt8();
+
+				var t = DecodeAdpcmSample(b, ref index, ref currentSample);
+				output[offset++] = (byte)t;
+				output[offset++] = (byte)(t >> 8);
+
+				t = DecodeAdpcmSample((byte)(b >> 4), ref index, ref currentSample);
+				output[offset++] = (byte)t;
+				output[offset++] = (byte)(t >> 8);
+			}
+
+			return output;
+		}
+	}
+}

--- a/OpenRA.Game/FileFormats/WavLoader.cs
+++ b/OpenRA.Game/FileFormats/WavLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2013 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,
@@ -26,9 +26,13 @@ namespace OpenRA.FileFormats
 		public readonly int BlockAlign;
 		public readonly int BitsPerSample;
 
+		public readonly int UncompressedSize;
 		public readonly int DataSize;
 		public readonly byte[] RawOutput;
 
+		public enum WaveType { Pcm = 0x1, Adpcm = 0x11 };
+		public static WaveType Type { get; private set; }
+		
 		public WavLoader(Stream s)
 		{
 			while (s.Position < s.Length)
@@ -47,16 +51,24 @@ namespace OpenRA.FileFormats
 						break;
 					case "fmt ":
 						FmtChunkSize = s.ReadInt32();
-						if (FmtChunkSize != 16)
-							throw new NotSupportedException("{0} fmt chunk size is not a supported encoding scheme.".F(FmtChunkSize));
 						AudioFormat = s.ReadInt16();
-						if (AudioFormat != 1)
-							throw new NotSupportedException("Non-PCM compression is not supported.");
+						Type = (WaveType)AudioFormat;
+						if (Type != WaveType.Pcm && Type != WaveType.Adpcm)
+							throw new NotSupportedException("Compression type is not supported.");
 						Channels = s.ReadInt16();
 						SampleRate = s.ReadInt32();
 						ByteRate = s.ReadInt32();
 						BlockAlign = s.ReadInt16();
 						BitsPerSample = s.ReadInt16();
+
+						s.ReadBytes(FmtChunkSize - 16);
+						break;
+					case "fact":
+						{
+							var chunkSize = s.ReadInt32();
+							UncompressedSize = s.ReadInt32();
+							s.ReadBytes(chunkSize - 4);
+						}
 						break;
 					case "data":
 						DataSize = s.ReadInt32();
@@ -64,11 +76,84 @@ namespace OpenRA.FileFormats
 						break;
 					default:
 						// Ignore unknown chunks
-						var chunkSize = s.ReadInt32();
-						s.ReadBytes(chunkSize);
+						{
+							var chunkSize = s.ReadInt32();
+							s.ReadBytes(chunkSize);
+						}
 						break;
 				}
 			}
+
+			if (Type == WaveType.Adpcm)
+			{
+				RawOutput = DecodeAdpcmData();
+				BitsPerSample = 16;
+			}
+		}
+
+		public byte[] DecodeAdpcmData()
+		{
+			var s = new MemoryStream(RawOutput);
+
+			var numBlocks = DataSize / BlockAlign;
+			var blockDataSize = BlockAlign - (Channels * 4);
+			var outputSize = UncompressedSize * Channels * 2;
+
+			var outOffset = 0;
+			var output = new byte[outputSize];
+
+			var predictor = new int[Channels];
+			var index = new int[Channels];
+
+			// Decode each block of ADPCM data in RawOutput
+			for (var block = 0; block < numBlocks; block++)
+			{
+				// Each block starts with a initial state per-channel 
+				for (var c = 0; c < Channels; c++)
+				{
+					predictor[c] = s.ReadInt16();
+					index[c] = s.ReadUInt8();
+					/* unknown/reserved */ s.ReadUInt8();
+
+					// Output first sample from input
+					output[outOffset++] = (byte)predictor[c];
+					output[outOffset++] = (byte)(predictor[c] >> 8);
+
+					if (outOffset >= outputSize)
+						return output;
+				}
+
+				// Decode and output remaining data in this block
+				var blockOffset = 0;
+				while (blockOffset < blockDataSize)
+				{
+					for (var c = 0; c < Channels; c++)
+					{
+						// Decode 4 bytes (to 16 bytes of output) per channel
+						var chunk = s.ReadBytes(4);
+						var decoded = AdpcmLoader.LoadAdpcmSound(chunk, ref index[c], ref predictor[c]);
+
+						// Interleave output, one sample per channel
+						var outOffsetChannel = outOffset + (2 * c);
+						for (var i = 0; i < decoded.Length; i += 2)
+						{
+							var outOffsetSample = outOffsetChannel + i;
+							if (outOffsetSample >= outputSize)
+								return output;
+
+							output[outOffsetSample] = decoded[i];
+							output[outOffsetSample + 1] = decoded[i + 1];
+							outOffsetChannel += 2 * (Channels - 1);
+						}
+
+						blockOffset += 4;
+					}
+
+					outOffset += 16 * Channels;
+				}
+			}
+
+			return output;
 		}
 	}
 }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -264,6 +264,7 @@
     <Compile Include="InstallUtils.cs" />
     <Compile Include="Manifest.cs" />
     <Compile Include="Graphics\Vertex.cs" />
+    <Compile Include="FileFormats\AdpcmLoader.cs" />
     <Compile Include="FileFormats\AudLoader.cs" />
     <Compile Include="FileFormats\Blast.cs" />
     <Compile Include="FileFormats\Blowfish.cs" />


### PR DESCRIPTION
Fixes #4628.

Unfortunately it seems @jamslater lost interest or is otherwise not able to continue working on it at the moment, so I'm trying to bring this into a "good enough" state so we finally have an alternative to AUD with both compression and stereo support.

Code is pretty much @jamslater's work, I just rebased and tried to adress at least a few of @ScottNZ's style nits.
I'll need more specific examples for further improvements in that regard.
