### PR TITLE
AutoTarget ignores Building actors.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -59,6 +59,9 @@ namespace OpenRA.Traits
 		bool IsQueued { get; }
 	}
 
+	// Check `callingTrait is <type>`
+	public interface IConditionalTarget { bool TargetableBy(Actor self, Actor targeter, object callingTrait); }
+
 	public interface IResolveOrder { void ResolveOrder(Actor self, Order order); }
 	public interface IValidateOrder { bool OrderValidation(OrderManager orderManager, World world, int clientId, Order order); }
 	public interface IOrderVoice { string VoicePhraseForOrder(Actor self, Order order); }

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -151,13 +151,17 @@ namespace OpenRA.Mods.RA
 			nextScanTime = self.World.SharedRandom.Next(info.MinimumScanTimeInterval, info.MaximumScanTimeInterval);
 			var inRange = self.World.FindActorsInCircle(self.CenterPosition, range);
 
-			return inRange
-				.Where(a =>
-					a.AppearsHostileTo(self) &&
-					!a.HasTrait<AutoTargetIgnore>() &&
-					attack.HasAnyValidWeapons(Target.FromActor(a)) &&
-					self.Owner.Shroud.IsTargetable(a))
-				.ClosestTo(self);
+			return inRange.Where(a =>
+			{
+				foreach (var condition in a.TraitsImplementing<IConditionalTarget>())
+					if (!condition.TargetableBy(a, self, this))
+						return false;
+
+				return a.AppearsHostileTo(self) &&
+				!a.HasTrait<AutoTargetIgnore>() &&
+				attack.HasAnyValidWeapons(Target.FromActor(a)) &&
+				self.Owner.Shroud.IsTargetable(a);
+			}).ClosestTo(self);
 		}
 	}
 

--- a/OpenRA.Mods.RA/Buildings/Building.cs
+++ b/OpenRA.Mods.RA/Buildings/Building.cs
@@ -99,7 +99,9 @@ namespace OpenRA.Mods.RA.Buildings
 		}
 	}
 
-	public class Building : IOccupySpace, INotifySold, INotifyTransform, ISync, ITechTreePrerequisite, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
+	public class Building : IOccupySpace, INotifySold, INotifyTransform, ISync, ITechTreePrerequisite,
+							INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld,
+							IConditionalTarget
 	{
 		public readonly BuildingInfo Info;
 		public bool BuildComplete { get; private set; }
@@ -141,6 +143,11 @@ namespace OpenRA.Mods.RA.Buildings
 
 		Pair<CPos, SubCell>[] occupiedCells;
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return occupiedCells; }
+
+		public bool TargetableBy(Actor self, Actor targeter, object callingTrait)
+		{
+			return callingTrait is AutoTarget ? false : true;
+		}
 
 		public void Created(Actor self)
 		{


### PR DESCRIPTION
Closes #6170 and addresses:

```
[23:22:22]  <pchote> units should only auto-target units
[23:22:27]  <Phrohdoh> why?
[23:22:35]  <pchote> that is how the original games worked 
```

If there is a better way to check caller type let me know and I'll implement it.
