### PR TITLE
#6177: Fix for 6030 upgrade rules

### DIFF
--- a/OpenRA.Game/GameRules/Warhead.cs
+++ b/OpenRA.Game/GameRules/Warhead.cs
@@ -58,6 +58,10 @@ namespace OpenRA.GameRules
 
 		public bool IsValidAgainst(Actor victim, Actor firedBy)
 		{
+			// If this warhead is ineffective against the target, then it is not a valid target
+			if (EffectivenessAgainst(victim.Info) <= 0f)
+				return false;
+
 			// A target type is valid if it is in the valid targets list, and not in the invalid targets list.
 			return InTargetList(victim, firedBy, ValidTargets) &&
 				!InTargetList(victim, firedBy, InvalidTargets);
@@ -79,6 +83,10 @@ namespace OpenRA.GameRules
 
 		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
 		{
+			// If this warhead is ineffective against the target, then it is not a valid target
+			if (EffectivenessAgainst(victim.Info) <= 0f)
+				return false;
+
 			// A target type is valid if it is in the valid targets list, and not in the invalid targets list.
 			return InTargetList(victim, firedBy, ValidTargets) &&
 				!InTargetList(victim, firedBy, InvalidTargets);

--- a/OpenRA.Game/GameRules/Warhead.cs
+++ b/OpenRA.Game/GameRules/Warhead.cs
@@ -19,7 +19,7 @@ namespace OpenRA.GameRules
 	public abstract class Warhead
 	{
 		[Desc("What types of targets are affected.")]
-		public readonly string[] ValidTargets = { "Air", "Ground", "Water" };
+		public readonly string[] ValidTargets = { "Ground", "Water" };
 
 		[Desc("What types of targets are unaffected.", "Overrules ValidTargets.")]
 		public readonly string[] InvalidTargets = { };

--- a/OpenRA.Game/GameRules/Warhead.cs
+++ b/OpenRA.Game/GameRules/Warhead.cs
@@ -29,7 +29,7 @@ namespace OpenRA.GameRules
 
 		public abstract void DoImpact(Target target, Actor firedBy, float firepowerModifier);
 
-		public abstract float EffectivenessAgainst(ActorInfo ai);
+		public virtual float EffectivenessAgainst(ActorInfo ai) { return 0f; }
 
 		public bool IsValidAgainst(Target target, World world, Actor firedBy)
 		{

--- a/OpenRA.Mods.RA/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.RA/Warheads/CreateEffectWarhead.cs
@@ -95,8 +95,6 @@ namespace OpenRA.Mods.RA
 				Sound.Play(ImpactSound, pos);
 		}
 
-		public override float EffectivenessAgainst(ActorInfo ai) { return 1f; }
-
 		public bool IsValidImpact(WPos pos, Actor firedBy)
 		{
 			var world = firedBy.World;

--- a/OpenRA.Mods.RA/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.RA/Warheads/CreateResourceWarhead.cs
@@ -60,7 +60,5 @@ namespace OpenRA.Mods.RA
 				}
 			}
 		}
-
-		public override float EffectivenessAgainst(ActorInfo ai) { return 1f; }
 	}
 }

--- a/OpenRA.Mods.RA/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.RA/Warheads/DestroyResourceWarhead.cs
@@ -41,7 +41,5 @@ namespace OpenRA.Mods.RA
 			foreach (var cell in allCells)
 				resLayer.Destroy(cell);
 		}
-
-		public override float EffectivenessAgainst(ActorInfo ai) { return 1f; }
 	}
 }

--- a/OpenRA.Mods.RA/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.RA/Warheads/LeaveSmudgeWarhead.cs
@@ -52,7 +52,5 @@ namespace OpenRA.Mods.RA
 				smudgeLayer.AddSmudge(sc);
 			}
 		}
-
-		public override float EffectivenessAgainst(ActorInfo ai) { return 1f; }
 	}
 }

--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -475,6 +475,9 @@ namespace OpenRA.Utility
 					// Split out the warheads to individual warhead types.
 					if (depth == 0)
 					{
+						var validTargets = node.Value.Nodes.FirstOrDefault(n => n.Key == "ValidTargets"); // Weapon's ValidTargets need to be copied to the warheads, so find it
+						var invalidTargets = node.Value.Nodes.FirstOrDefault(n => n.Key == "InvalidTargets"); // Weapon's InvalidTargets need to be copied to the warheads, so find it
+
 						var warheadCounter = 0;
 						foreach(var curNode in node.Value.Nodes.ToArray())
 						{
@@ -493,13 +496,26 @@ namespace OpenRA.Utility
 
 									var newYaml = new List<MiniYamlNode>();
 
-									var keywords = new List<String>{ "Size","Damage","InfDeath","PreventProne","ProneModifier","Delay","ValidTargets","InvalidTargets" };
+									var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == "Size"); // New PerCell warhead allows 2 sizes, as opposed to 1 size
+									if (temp != null)
+									{
+										var newValue = temp.Value.Value.Split(',').First();
+										newYaml.Add(new MiniYamlNode("Size", newValue));
+									}
+
+									var keywords = new List<string>{ "Damage", "InfDeath", "PreventProne", "ProneModifier", "Delay" };
+
 									foreach(var keyword in keywords)
 									{
-										var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
-										if (temp != null)
-											newYaml.Add(new MiniYamlNode(keyword, temp.Value.Value));
+										var temp2 = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
+										if (temp2 != null)
+											newYaml.Add(new MiniYamlNode(keyword, temp2.Value.Value));
 									}
+
+									if (validTargets != null)
+										newYaml.Add(validTargets);
+									if (invalidTargets != null)
+										newYaml.Add(invalidTargets);
 
 									var tempVersus = curNode.Value.Nodes.FirstOrDefault(n => n.Key == "Versus");
 									if (tempVersus != null)
@@ -516,23 +532,26 @@ namespace OpenRA.Utility
 
 									var newYaml = new List<MiniYamlNode>();
 
-									var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == "Size"); // New HealthPercentage warhead allows spreads, as opposed to size
+									var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == "Size"); // New HealthPercentage warhead allows 2 spreads, as opposed to 1 size
 									if (temp != null)
 									{
 										var newValue = temp.Value.Value.Split(',').First() + "c0";
-										if (temp.Value.Value.Contains(','))
-											newValue = newValue + "," + temp.Value.Value.Split(',')[1] + "c0"; ;
-
 										newYaml.Add(new MiniYamlNode("Spread", newValue));
 									}
 
-									var keywords = new List<String>{ "Damage","InfDeath","PreventProne","ProneModifier","Delay","ValidTargets","InvalidTargets" };
+									var keywords = new List<string>{ "Damage", "InfDeath", "PreventProne", "ProneModifier", "Delay" };
+
 									foreach(var keyword in keywords)
 									{
 										var temp2 = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
 										if (temp2 != null)
 											newYaml.Add(new MiniYamlNode(keyword, temp2.Value.Value));
 									}
+
+									if (validTargets != null)
+										newYaml.Add(validTargets);
+									if (invalidTargets != null)
+										newYaml.Add(invalidTargets);
 
 									var tempVersus = curNode.Value.Nodes.FirstOrDefault(n => n.Key == "Versus");
 									if (tempVersus != null)
@@ -547,13 +566,19 @@ namespace OpenRA.Utility
 
 									var newYaml = new List<MiniYamlNode>();
 
-									var keywords = new List<String>{ "Spread","Damage","InfDeath","PreventProne","ProneModifier","Delay","ValidTargets","InvalidTargets" };
+									var keywords = new List<string>{ "Spread", "Damage", "InfDeath", "PreventProne", "ProneModifier", "Delay" };
+
 									foreach(var keyword in keywords)
 									{
 										var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
 										if (temp != null)
 											newYaml.Add(new MiniYamlNode(keyword, temp.Value.Value));
 									}
+
+									if (validTargets != null)
+										newYaml.Add(validTargets);
+									if (invalidTargets != null)
+										newYaml.Add(invalidTargets);
 
 									var tempVersus = curNode.Value.Nodes.FirstOrDefault(n => n.Key == "Versus");
 									if (tempVersus != null)
@@ -570,7 +595,7 @@ namespace OpenRA.Utility
 
 									var newYaml = new List<MiniYamlNode>();
 
-									var keywords = new List<String>{ "Size","Delay","ValidTargets","InvalidTargets" };
+									var keywords = new List<string>{ "Size", "Delay", "ValidTargets", "InvalidTargets" };
 									foreach(var keyword in keywords)
 									{
 										var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
@@ -588,7 +613,8 @@ namespace OpenRA.Utility
 
 									var newYaml = new List<MiniYamlNode>();
 
-									var keywords = new List<String>{ "AddsResourceType","Size","Delay","ValidTargets","InvalidTargets" };
+									var keywords = new List<string>{ "AddsResourceType", "Size", "Delay", "ValidTargets", "InvalidTargets" };
+
 									foreach(var keyword in keywords)
 									{
 										var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
@@ -606,7 +632,8 @@ namespace OpenRA.Utility
 
 									var newYaml = new List<MiniYamlNode>();
 
-									var keywords = new List<String>{ "SmudgeType","Size","Delay","ValidTargets","InvalidTargets" };
+									var keywords = new List<string>{ "SmudgeType", "Size", "Delay", "ValidTargets", "InvalidTargets" };
+
 									foreach(var keyword in keywords)
 									{
 										var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
@@ -617,23 +644,50 @@ namespace OpenRA.Utility
 									newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Smu" + oldNodeAtName, "LeaveSmudge", newYaml));
 								}
 
-								// CreateEffect
+								// CreateEffect - Explosion
 								if (curNode.Value.Nodes.Where(n => n.Key.Contains("Explosion") ||
-										n.Key.Contains("WaterExplosion") ||
-										n.Key.Contains("ImpactSound") ||
-										n.Key.Contains("WaterImpactSound")).Any())
+										n.Key.Contains("ImpactSound")).Any())
 								{
 									warheadCounter++;
 
 									var newYaml = new List<MiniYamlNode>();
 
-									var keywords = new List<String>{ "Explosion","WaterExplosion","ImpactSound","WaterImpactSound","Delay","ValidTargets","InvalidTargets" };
+									var keywords = new List<string>{ "Explosion", "ImpactSound", "Delay", "ValidTargets", "InvalidTargets", "ValidImpactTypes", "InvalidImpactTypes" };
+
 									foreach(var keyword in keywords)
 									{
 										var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
 										if (temp != null)
 											newYaml.Add(new MiniYamlNode(keyword, temp.Value.Value));
 									}
+									newYaml.Add(new MiniYamlNode("InvalidImpactTypes", "Water"));
+
+									newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Eff" + oldNodeAtName, "CreateEffect", newYaml));
+								}
+
+								// CreateEffect - Water Explosion
+								if (curNode.Value.Nodes.Where(n => n.Key.Contains("WaterExplosion") ||
+										n.Key.Contains("WaterImpactSound")).Any())
+								{
+									warheadCounter++;
+
+									var newYaml = new List<MiniYamlNode>();
+
+									var keywords = new List<string>{ "WaterExplosion", "WaterImpactSound", "Delay", "ValidTargets", "InvalidTargets", "ValidImpactTypes", "InvalidImpactTypes" };
+
+									foreach(var keyword in keywords)
+									{
+										var temp = curNode.Value.Nodes.FirstOrDefault(n => n.Key == keyword);
+										if (temp != null)
+										{
+											if (temp.Key == "WaterExplosion")
+												temp.Key = "Explosion";
+											if (temp.Key == "WaterImpactSound")
+												temp.Key = "ImpactSound";
+											newYaml.Add(new MiniYamlNode(temp.Key, temp.Value.Value));
+										}
+									}
+									newYaml.Add(new MiniYamlNode("ValidImpactTypes", "Water"));
 
 									newNodes.Add(new MiniYamlNode("Warhead@" + warheadCounter.ToString() + "Eff" + oldNodeAtName, "CreateEffect", newYaml));
 								}

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -72,6 +72,7 @@ Atomic:
 		Spread: 1c0
 		Damage: 1500
 		InfDeath: 5
+		ValidTargets: Ground, Air
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -85,6 +86,7 @@ Atomic:
 		Damage: 1000
 		InfDeath: 5
 		Delay: 3
+		ValidTargets: Ground, Air
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -105,6 +107,7 @@ Atomic:
 		Damage: 500
 		InfDeath: 5
 		Delay: 6
+		ValidTargets: Ground, Air
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -122,6 +125,7 @@ Atomic:
 		Damage: 200
 		InfDeath: 5
 		Delay: 9
+		ValidTargets: Ground, Air
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -141,38 +145,21 @@ IonCannon:
 		Spread: 1c0
 		Damage: 1000
 		InfDeath: 5
+		ValidTargets: Ground, Air
 	Warhead@2Res_impact: DestroyResource
 	Warhead@3Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
-	Warhead@4Dam_area: PerCellDamage
-		Size: 2,1
-		Damage: 0
-		InfDeath: 5
-		Delay: 3
-	Warhead@5Dam_area: SpreadDamage
-		Damage: 0
-		InfDeath: 5
-		Delay: 3
-	Warhead@6Res_area: DestroyResource
+	Warhead@4Res_area: DestroyResource
 		Size: 2,1
 		Delay: 3
-	Warhead@7Smu_area: LeaveSmudge
+	Warhead@5Smu_area: LeaveSmudge
 		SmudgeType: Scorch
 		Size: 2,1
 		Delay: 3
-	Warhead@8Dam_area2: PerCellDamage
-		Size: 1
-		Damage: 0
-		InfDeath: 5
-		Delay: 3
-	Warhead@9Dam_area2: SpreadDamage
-		Damage: 0
-		InfDeath: 5
-		Delay: 3
-	Warhead@10Res_area2: DestroyResource
+	Warhead@6Res_area2: DestroyResource
 		Size: 1
 		Delay: 3
-	Warhead@11Smu_area2: LeaveSmudge
+	Warhead@7Smu_area2: LeaveSmudge
 		SmudgeType: Scorch
 		Size: 1
 		Delay: 3
@@ -188,6 +175,7 @@ Sniper:
 		Spread: 42
 		Damage: 100
 		InfDeath: 2
+		ValidTargets: Infantry
 
 HighV:
 	ROF: 25
@@ -221,6 +209,7 @@ HeliAGGun:
 		Spread: 256
 		Damage: 20
 		InfDeath: 2
+		ValidTargets: Ground
 		Versus:
 			None: 100%
 			Wood: 50%
@@ -243,6 +232,7 @@ HeliAAGun:
 		Spread: 128
 		Damage: 20
 		InfDeath: 2
+		ValidTargets: Air
 		Versus:
 			None: 100%
 			Wood: 50%
@@ -262,6 +252,7 @@ Pistol:
 		Spread: 128
 		Damage: 1
 		InfDeath: 2
+		InvalidTargets: Wall
 		Versus:
 			None: 100%
 			Wood: 50%
@@ -281,6 +272,7 @@ M16:
 		Spread: 128
 		Damage: 15
 		InfDeath: 2
+		InvalidTargets: Wall
 		Versus:
 			None: 100%
 			Wood: 25%
@@ -308,6 +300,7 @@ Rockets:
 		Spread: 128
 		Damage: 30
 		InfDeath: 4
+		ValidTargets: Ground, Air
 		Versus:
 			None: 50%
 			Wood: 85%
@@ -341,6 +334,7 @@ BikeRockets:
 		Spread: 128
 		Damage: 30
 		InfDeath: 4
+		ValidTargets: Ground, Air
 		Versus:
 			None: 25%
 			Wood: 75%
@@ -374,6 +368,7 @@ OrcaAGMissiles:
 		Spread: 128
 		Damage: 25
 		InfDeath: 4
+		ValidTargets: Ground
 		Versus:
 			None: 50%
 			Wood: 100%
@@ -406,6 +401,7 @@ OrcaAAMissiles:
 		Spread: 128
 		Damage: 25
 		InfDeath: 4
+		ValidTargets: Air
 		Versus:
 			Light: 75%
 			Heavy: 50%
@@ -426,6 +422,7 @@ Flamethrower:
 		Spread: 341
 		Damage: 40
 		InfDeath: 5
+		InvalidTargets: Wall
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -450,6 +447,7 @@ BigFlamer:
 		Spread: 341
 		Damage: 75
 		InfDeath: 5
+		InvalidTargets: Wall
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -643,6 +641,7 @@ MammothMissiles:
 		Spread: 298
 		Damage: 45
 		InfDeath: 4
+		ValidTargets: Ground, Air
 		Versus:
 			None: 50%
 			Wood: 75%
@@ -682,6 +681,7 @@ MammothMissiles:
 		Spread: 683
 		Damage: 25
 		InfDeath: 4
+		ValidTargets: Ground
 		Versus:
 			None: 35%
 			Wood: 60%
@@ -714,6 +714,7 @@ MammothMissiles:
 		Spread: 128
 		Damage: 60
 		InfDeath: 4
+		ValidTargets: Ground, Air
 		Versus:
 			None: 25%
 			Wood: 75%
@@ -764,6 +765,7 @@ MachineGun:
 		Spread: 128
 		Damage: 15
 		InfDeath: 2
+		InvalidTargets: Wall
 		Versus:
 			None: 100%
 			Wood: 20%
@@ -828,6 +830,7 @@ TowerMissle:
 		Spread: 683
 		Damage: 25
 		InfDeath: 3
+		ValidTargets: Ground
 		Versus:
 			None: 50%
 			Wood: 25%
@@ -850,6 +853,7 @@ Vulcan:
 		Spread: 426
 		Damage: 100
 		InfDeath: 2
+		ValidTargets: Ground, Water
 		Versus:
 			None: 100%
 			Wood: 25%
@@ -870,6 +874,7 @@ Napalm:
 		Spread: 341
 		Damage: 300
 		InfDeath: 5
+		ValidTargets: Ground, Water
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -930,6 +935,7 @@ SAMMissile:
 		ContrailLength: 8
 	Warhead@1Dam: SpreadDamage
 		Spread: 682
+		ValidTargets: Air
 		Versus:
 			None: 100%
 			Wood: 100%
@@ -1014,6 +1020,7 @@ APCGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
+		ValidTargets: Ground
 		Versus:
 			None: 50%
 			Wood: 50%
@@ -1033,6 +1040,7 @@ APCGun.AA:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
+		ValidTargets: Air
 		Versus:
 			Heavy: 50%
 	Warhead@2Eff: CreateEffect
@@ -1055,6 +1063,7 @@ Patriot:
 		Angle: 88
 	Warhead@1Dam: SpreadDamage
 		Spread: 682
+		ValidTargets: Air
 		Versus:
 			None: 100%
 			Wood: 100%

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -37,6 +37,7 @@ Bazooka:
 		Spread: 96
 		Damage: 50
 		InfDeath: 4
+		ValidTargets: Ground
 		Versus:
 			None: 10%
 			Wood: 75%
@@ -85,6 +86,7 @@ Vulcan:
 		Spread: 96
 		Damage: 30
 		InfDeath: 2
+		ValidTargets: Ground, Air
 		Versus:
 			Wood: 0%
 			Light: 60%
@@ -110,6 +112,7 @@ Slung:
 		Spread: 192
 		Damage: 30
 		InfDeath: 4
+		ValidTargets: Ground
 		Versus:
 			None: 0%
 			Wood: 75%
@@ -186,6 +189,7 @@ QuadRockets:
 		Spread: 96
 		Damage: 25
 		InfDeath: 4
+		ValidTargets: Ground, Air
 		Versus:
 			None: 35%
 			Wood: 45%
@@ -245,6 +249,7 @@ TowerMissile:
 		Spread: 384
 		Damage: 50
 		InfDeath: 3
+		ValidTargets: Ground, Air
 		Versus:
 			None: 50%
 			Wood: 45%
@@ -347,6 +352,7 @@ DevBullet:
 		Spread: 384
 		Damage: 60
 		InfDeath: 4
+		ValidTargets: Ground
 		Versus:
 			None: 20%
 			Wood: 50%

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -790,7 +790,7 @@ Weapons:
 		Range: 10c0
 		Report: MISSILE6.AUD
 		Burst: 2
-		ValidTargets: Ground, Air, Enemy, Neutral, Ally
+		ValidTargets: Ground, Air
 		Projectile: Missile
 			Speed: 128
 			Arm: 2
@@ -805,6 +805,7 @@ Weapons:
 			RangeLimit: 80
 		Warhead: SpreadDamage
 			Spread: 640
+			ValidTargets: Ground, Air
 			Versus:
 				None: 125%
 				Wood: 110%
@@ -822,7 +823,7 @@ Weapons:
 		ROF: 40
 		Range: 8c0
 		Report: AACANON3.AUD
-		ValidTargets: Ground, Enemy, Neutral, Ally
+		ValidTargets: Ground
 		Burst: 6
 		BurstDelay: 1
 		Projectile: Bullet
@@ -833,6 +834,7 @@ Weapons:
 			ContrailLength: 2
 		Warhead: SpreadDamage
 			Spread: 341
+			ValidTargets: Ground
 			Versus:
 				None: 90%
 				Wood: 170%
@@ -902,12 +904,13 @@ Weapons:
 		ROF: 10
 		Range: 8c0
 		Report: AACANON3.AUD
-		ValidTargets: Air, Ground, Enemy, Neutral, Ally
+		ValidTargets: Air, Ground
 		Projectile: Bullet
 			Speed: 1c682
 			High: true
 		Warhead: SpreadDamage
 			Spread: 213
+			ValidTargets: Air, Ground
 			Versus:
 				None: 35%
 				Wood: 30%

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -1076,8 +1076,7 @@ VoxelSequences:
 
 Weapons:
 	CrateNuke:
-		Warhead@areanuke2: SpreadDamage
-			DamageModel: PerCell
+		Warhead@areanuke2: PerCellDamage
 			Damage: 250
 			Size: 4
 			Versus:
@@ -1098,8 +1097,7 @@ Weapons:
 		Warhead@areanuke2Eff: CreateEffect
 			ImpactSound: kaboom22
 			Delay: 12
-		Warhead@areanuke3: SpreadDamage
-			DamageModel: PerCell
+		Warhead@areanuke3: PerCellDamage
 			Damage: 250
 			Size: 3
 			Versus:
@@ -1120,8 +1118,7 @@ Weapons:
 		Warhead@areanuke3Eff: CreateEffect
 			ImpactSound: kaboom22
 			Delay: 24
-		Warhead@areanuke4: SpreadDamage
-			DamageModel: PerCell
+		Warhead@areanuke4: PerCellDamage
 			Damage: 250
 			Versus:
 				None: 90%

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -34,6 +34,7 @@ ZSU-23:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 12
+		ValidTargets: Air
 		Versus:
 			None: 30%
 			Wood: 75%
@@ -175,6 +176,7 @@ Maverick:
 		Spread: 128
 		Damage: 70
 		InfDeath: 4
+		ValidTargets: Ground, Water
 		Versus:
 			None: 30%
 			Wood: 75%
@@ -355,6 +357,7 @@ Dragon:
 		Spread: 128
 		Damage: 50
 		InfDeath: 4
+		ValidTargets: Ground, Water
 		Versus:
 			None: 10%
 			Wood: 75%
@@ -391,6 +394,7 @@ HellfireAG:
 		Spread: 128
 		Damage: 60
 		InfDeath: 4
+		ValidTargets: Ground, Water
 		Versus:
 			None: 30%
 			Wood: 75%
@@ -427,6 +431,7 @@ HellfireAA:
 		Spread: 128
 		Damage: 40
 		InfDeath: 4
+		ValidTargets: Air
 		Versus:
 			None: 30%
 			Wood: 75%
@@ -567,6 +572,7 @@ Grenade:
 		Spread: 128
 		Damage: 60
 		InfDeath: 4
+		InvalidTargets: Air, Infantry
 		Versus:
 			None: 20%
 			Wood: 75%
@@ -629,6 +635,7 @@ MammothTusk:
 		Spread: 256
 		Damage: 50
 		InfDeath: 3
+		ValidTargets: Air, Infantry
 		Versus:
 			None: 100%
 			Wood: 75%
@@ -777,7 +784,7 @@ CrateNuke:
 		Explosion: nuke
 		ImpactSound: kaboom1.aud
 	Warhead@4Dam_areanuke: PerCellDamage
-		Size: 5,4
+		Size: 5
 		Damage: 250
 		InfDeath: 5
 		Delay: 4
@@ -837,6 +844,7 @@ Nike:
 		Spread: 128
 		Damage: 50
 		InfDeath: 3
+		ValidTargets: Air
 		Versus:
 			None: 90%
 			Wood: 0%
@@ -866,6 +874,7 @@ RedEye:
 		Spread: 128
 		Damage: 40
 		InfDeath: 3
+		ValidTargets: Air
 		Versus:
 			None: 90%
 			Wood: 75%
@@ -961,6 +970,7 @@ Stinger:
 		Spread: 128
 		Damage: 30
 		InfDeath: 4
+		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 30%
 			Wood: 75%
@@ -1001,6 +1011,7 @@ TorpTube:
 		Spread: 426
 		Damage: 180
 		InfDeath: 4
+		ValidTargets: Water, Underwater, Bridge
 		Versus:
 			None: 30%
 			Wood: 75%
@@ -1062,6 +1073,7 @@ DepthCharge:
 		Spread: 128
 		Damage: 80
 		InfDeath: 4
+		ValidTargets: Underwater
 		Versus:
 			None: 30%
 			Wood: 75%
@@ -1114,6 +1126,7 @@ DogJaw:
 		Spread: 213
 		Damage: 100
 		InfDeath: 1
+		ValidTargets: Infantry
 		Versus:
 			Wood: 0%
 			Light: 0%
@@ -1147,6 +1160,7 @@ Repair:
 		Spread: 213
 		Damage: -20
 		InfDeath: 1
+		ValidTargets: Repair
 		Versus:
 			None: 0%
 			Wood: 0%
@@ -1217,6 +1231,7 @@ Atomic:
 		Spread: 1c0
 		Damage: 1500
 		InfDeath: 5
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@2Res_impact: DestroyResource
@@ -1232,6 +1247,7 @@ Atomic:
 		Damage: 600
 		InfDeath: 5
 		Delay: 5
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@6Res_areanuke1: DestroyResource
@@ -1249,6 +1265,7 @@ Atomic:
 		Damage: 600
 		InfDeath: 5
 		Delay: 10
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@10Res_areanuke2: DestroyResource
@@ -1263,6 +1280,7 @@ Atomic:
 		Damage: 600
 		InfDeath: 5
 		Delay: 15
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@13Res_areanuke3: DestroyResource
@@ -1277,6 +1295,7 @@ Atomic:
 		Damage: 600
 		InfDeath: 5
 		Delay: 20
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@16Res_areanuke4: DestroyResource
@@ -1293,6 +1312,7 @@ MiniNuke:
 		Spread: 1c0
 		Damage: 1500
 		InfDeath: 5
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@2Res_impact: DestroyResource
@@ -1305,6 +1325,7 @@ MiniNuke:
 		Damage: 600
 		InfDeath: 5
 		Delay: 5
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@5Res_areanuke1: DestroyResource
@@ -1318,6 +1339,7 @@ MiniNuke:
 		Damage: 600
 		InfDeath: 5
 		Delay: 10
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@8Res_areanuke2: DestroyResource
@@ -1328,6 +1350,7 @@ MiniNuke:
 		Damage: 600
 		InfDeath: 5
 		Delay: 15
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25%
 	Warhead@10Res_areanuke3: DestroyResource
@@ -1491,6 +1514,7 @@ FLAK-23:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 20
+		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 40%
 			Wood: 10%
@@ -1543,6 +1567,7 @@ APTusk:
 		Spread: 128
 		Damage: 30
 		InfDeath: 4
+		ValidTargets: Ground, Water
 		Versus:
 			None: 25%
 			Wood: 75%
@@ -1594,30 +1619,24 @@ Mandible:
 MADTankThump:
 	InvalidTargets: MADTank
 	Warhead@1Dam: HealthPercentageDamage
-		Spread: 7c0,6c0
+		Spread: 7c0
 		Damage: 1
-		Versus:
-			None: 0%
-	Warhead@2Dam: SpreadDamage
-		Damage: 1
+		InvalidTargets: MADTank
 		Versus:
 			None: 0%
 
 MADTankDetonate:
 	InvalidTargets: MADTank
 	Warhead@1Dam: HealthPercentageDamage
-		Spread: 7c0,6c0
+		Spread: 7c0
 		Damage: 19
+		InvalidTargets: MADTank
 		Versus:
 			None: 0%
-	Warhead@2Dam: SpreadDamage
-		Damage: 19
-		Versus:
-			None: 0%
-	Warhead@3Smu: LeaveSmudge
+	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		Size: 7,6
-	Warhead@4Eff: CreateEffect
+	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: mineblo1.aud
 

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -98,6 +98,7 @@ Bazooka:
 		Spread: 128
 		Damage: 25
 		InfDeath: 2
+		ValidTargets: Ground, Air
 		Versus:
 			None: 25%
 			Wood: 65%
@@ -136,6 +137,7 @@ MultiCluster:
 		Spread: 128
 		Damage: 65
 		InfDeath: 3
+		ValidTargets: Ground
 		Versus:
 			None: 25%
 			Wood: 65%
@@ -245,6 +247,7 @@ CyCannon:
 		Damage: 120
 		InfDeath: 6
 		ProneModifier: 100
+		ValidTargets: Ground
 		Versus:
 			None: 100%
 			Wood: 65%
@@ -402,6 +405,7 @@ HoverMissile:
 		Spread: 128
 		Damage: 30
 		InfDeath: 2
+		ValidTargets: Ground, Air
 		Versus:
 			None: 25%
 			Wood: 65%
@@ -473,6 +477,7 @@ MammothTusk:
 		Damage: 40
 		InfDeath: 3
 		ProneModifier: 70
+		ValidTargets: Air
 		Versus:
 			None: 100%
 			Wood: 85%
@@ -628,6 +633,7 @@ BikeMissile:
 		Spread: 256
 		Damage: 40
 		InfDeath: 2
+		ValidTargets: Ground
 		Versus:
 			None: 25%
 			Wood: 65%
@@ -727,6 +733,7 @@ Dragon:
 		Spread: 128
 		Damage: 30
 		InfDeath: 2
+		ValidTargets: Ground, Air
 		Versus:
 			None: 25%
 			Wood: 65%
@@ -827,6 +834,7 @@ Hellfire:
 		Spread: 85
 		Damage: 30
 		InfDeath: 2
+		ValidTargets: Ground, Air
 		Versus:
 			None: 30%
 			Wood: 65%
@@ -893,6 +901,7 @@ Proton:
 		Spread: 128
 		Damage: 20
 		InfDeath: 3
+		ValidTargets: Ground, Air
 		Versus:
 			None: 25%
 			Wood: 65%
@@ -920,6 +929,7 @@ HarpyClaw:
 		Damage: 60
 		InfDeath: 1
 		ProneModifier: 70
+		ValidTargets: Ground, Air
 		Versus:
 			Wood: 60%
 			Light: 40%
@@ -978,18 +988,16 @@ IonCannon:
 		Damage: 1000
 		InfDeath: 5
 		ProneModifier: 100
+		ValidTargets: Ground, Air
 	Warhead@2Eff_impact: CreateEffect
 		Explosion: ring1
 	Warhead@3Dam_area: PerCellDamage
-		Size: 2,1
+		Size: 2
 		Damage: 250
 		InfDeath: 5
 		Delay: 3
-	Warhead@4Dam_area: SpreadDamage
-		Damage: 250
-		InfDeath: 5
-		Delay: 3
-	Warhead@5Smu_area: LeaveSmudge
+		ValidTargets: Ground, Air
+	Warhead@4Smu_area: LeaveSmudge
 		SmudgeType: Scorch
 		Size: 2,1
 		Delay: 3
@@ -1066,6 +1074,7 @@ SAMTower:
 		Spread: 128
 		Damage: 33
 		InfDeath: 2
+		ValidTargets: Air
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud


### PR DESCRIPTION
Updated UpgradeRules to correct regressions caused in yaml.
- Fixed the incorrect double entry size for HealthPercentage and PerCell warheads.
- Fixed ValidTargets and InvalidTargets not being propagated from Weapon to Warheads. (Causing most weapons to damage passing airplanes and such nonsense).

Closes #6177.
Closes #6222.
Closes #6240.
Closes #6245.
