### PR TITLE
Log reason why a Lua script fails to parse

### DIFF
--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -162,6 +163,7 @@ namespace OpenRA.Scripting
 		public void FatalError(string message)
 		{
 			Console.WriteLine("Fatal Lua Error: {0}", message);
+			Game.AddChatLine(Color.White, "Fatal Lua Error", message);
 			error = true;
 		}
 

--- a/lua/scriptwrapper.lua
+++ b/lua/scriptwrapper.lua
@@ -31,9 +31,9 @@ Tick = function()
 end
 
 ExecuteSandboxedScript = function(file, contents)
-	local script = loadstring(contents, file)
+	local script, err = loadstring(contents, file)
 	if (script == nil) then
-		FatalError("Error parsing " .. file)
+		FatalError("Error parsing " .. file .. ". Reason: " .. err)
 	else
 		TryRunSandboxed(script)
 	end


### PR DESCRIPTION
Explains more why the script failed parsing. Also adds a `Game.AddChatLine` for why it fails.

![luaparseerror2](https://cloud.githubusercontent.com/assets/566742/3822375/9de3891a-1d23-11e4-9dd3-069e767ce7c0.png)
