### PR TITLE
6066 Crate Prerequisites

### DIFF
--- a/OpenRA.Mods.RA/CrateAction.cs
+++ b/OpenRA.Mods.RA/CrateAction.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.RA
 
 		[Desc("The earliest time (in ticks) that this crate action can occur on.")]
 		public readonly int TimeDelay = 0;
+		
+		[Desc("Only allow this crate action when the collector has these prerequisites")]
+		public readonly string[] Prerequisites = { };
 
 		[Desc("Actor types that this crate action will not occur for.")]
 		[ActorReference] public string[] ExcludedActorTypes = { };
@@ -52,8 +55,11 @@ namespace OpenRA.Mods.RA
 		{
 			if (self.World.WorldTick < info.TimeDelay)
 				return 0;
-			
+
 			if (info.ExcludedActorTypes.Contains(collector.Info.Name))
+				return 0;
+
+			if (info.Prerequisites.Any() && !collector.Owner.PlayerActor.Trait<TechTree>().HasPrerequisites(info.Prerequisites))
 				return 0;
 
 			return GetSelectionShares(collector);

--- a/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/GiveUnitCrateAction.cs
@@ -38,7 +38,12 @@ namespace OpenRA.Mods.RA.Crates
 		readonly List<CPos> usedCells = new List<CPos>();
 
 		public GiveUnitCrateAction(Actor self, GiveUnitCrateActionInfo info)
-			: base(self, info) { Info = info; }
+			: base(self, info)
+		{
+			Info = info;
+			if (!Info.Units.Any())
+				throw new YamlException("A GiveUnitCrateAction does not specify any units to give. This might be because the yaml is referring to 'Unit' rather than 'Units'.");
+		}
 
 		public bool CanGiveTo(Actor collector)
 		{

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -21,59 +21,74 @@ CRATE:
 	GiveUnitCrateAction@Trike:
 		SelectionShares: 20
 		Units: trike
+		Prerequisites: techlevel.low, Light
 	GiveUnitCrateAction@Raider:
 		SelectionShares: 15
 		Units: raider
 		ValidRaces: ordos
+		Prerequisites: techlevel.low, Light
 	GiveUnitCrateAction@Quad:
 		SelectionShares: 40
 		Units: quad
+		Prerequisites: techlevel.medium, Light, Outpost
 	GiveUnitCrateAction@CombatA:
 		SelectionShares: 10
 		Units: combata
 		ValidRaces: atreides
+		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@CombatH:
 		SelectionShares: 10
 		Units: combath
 		ValidRaces: harkonnen
+		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@CombatO:
 		SelectionShares: 10
 		Units: combato
 		ValidRaces: ordos
+		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@SiegeTank:
 		SelectionShares: 10
 		Units: siegetank
+		Prerequisites: techlevel.medium, Heavy, Outpost
 	GiveUnitCrateAction@MissileTank:
 		SelectionShares: 10
 		Units: missiletank
+		Prerequisites: techlevel.high, Hitech
 	GiveUnitCrateAction@StealthRaider:
 		SelectionShares: 7
 		Units: stealthraider
 		ValidRaces: ordos
+		Prerequisites: techlevel.medium, Hitech
 	GiveUnitCrateAction@Fremen:
 		SelectionShares: 5
 		Units: fremen,fremen
 		ValidRaces: atreides
+		Prerequisites: techlevel.high, Palace
 	GiveUnitCrateAction@Sardaukar:
 		SelectionShares: 8
 		Units: sardaukar,sardaukar
 		ValidRaces: harkonnen
+		Prerequisites: techlevel.high, Palace
 	GiveUnitCrateAction@Saboteur:
 		SelectionShares: 3
 		Units: saboteur,saboteur
 		ValidRaces: ordos
+		Prerequisites: techlevel.high, Palace
 	GiveUnitCrateAction@SonicTank:
 		SelectionShares: 5
 		Units: sonictank
 		ValidRaces: atreides
+		Prerequisites: techlevel.high, Research
 	GiveUnitCrateAction@Devast:
 		SelectionShares: 2
 		Units: devast
 		ValidRaces: harkonnen
+		Prerequisites: techlevel.high, Research
 	GiveUnitCrateAction@DeviatorTank:
 		SelectionShares: 5
 		Units: deviatortank
 		ValidRaces: ordos
+		Prerequisites: techlevel.high, Research
 	GiveMcvCrateAction@Atreides:
 		SelectionShares: 0
 		NoBaseSelectionShares: 9001

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -102,37 +102,37 @@ CRATE:
 		SelectionShares: 7
 		Units: jeep
 		ValidRaces: allies
-		TimeDelay: 3000
+		Prerequisites: techlevel.low
 	GiveUnitCrateAction@arty:
 		SelectionShares: 6
 		Units: arty
 		ValidRaces: allies
-		TimeDelay: 4500
+		Prerequisites: techlevel.medium, dome
 	GiveUnitCrateAction@v2rl:
 		SelectionShares: 6
 		Units: v2rl
 		ValidRaces: soviet
-		TimeDelay: 4500
+		Prerequisites: techlevel.medium, dome
 	GiveUnitCrateAction@1tnk:
 		SelectionShares: 5
 		Units: 1tnk
 		ValidRaces: allies
-		TimeDelay: 3000
+		Prerequisites: techlevel.low
 	GiveUnitCrateAction@2tnk:
 		SelectionShares: 4
 		Units: 2tnk
 		ValidRaces: allies
-		TimeDelay: 4500
+		Prerequisites: techlevel.medium, fix
 	GiveUnitCrateAction@3tnk:
 		SelectionShares: 4
 		Units: 3tnk
 		ValidRaces: soviet
-		TimeDelay: 4500
+		Prerequisites: techlevel.medium, fix
 	GiveUnitCrateAction@4tnk:
 		SelectionShares: 3
 		Units: 4tnk
 		ValidRaces: soviet
-		TimeDelay: 9000
+		Prerequisites: techlevel.unrestricted, fix, techcenter
 	GiveUnitCrateAction@squadlight:
 		SelectionShares: 7
 		Units: e1,e1,e1,e3,e3


### PR DESCRIPTION
Closes  #6066, #2587.

Also updated crate yaml for affected mods (RA and D2K).

Also adds YamlException on a GiveUnitCrateAction if it does not define any units to give.
