### PR TITLE
Fix breakage of --upgrade-map in OpenRA.Utility

### DIFF
--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -628,13 +628,13 @@ namespace OpenRA.Utility
 			nodes.AddRange(addNodes);
 		}
 
-		[Desc("MAP", "CURRENTENGINE", "Upgrade map rules to the latest engine version.")]
+		[Desc("MAP", "CURRENTENGINE", "MOD", "Upgrade map rules to the latest engine version.")]
 		public static void UpgradeMap(string[] args)
 		{
+			Game.modData = new ModData(args[3]);
 			var map = new Map(args[1]);
 			var engineDate = Exts.ParseIntegerInvariant(args[2]);
 
-			Game.modData = new ModData(map.RequiresMod);
 			UpgradeWeaponRules(engineDate, ref map.WeaponDefinitions, null, 0);
 			UpgradeActorRules(engineDate, ref map.RuleDefinitions, null, 0);
 			map.Save(args[1]);


### PR DESCRIPTION
Closes #6045.

Note that --upgrade-map now needs a third argument that specifies the mod.
