### PR TITLE
AttributeModifier and Manager added.

### DIFF
--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -75,6 +75,12 @@ namespace OpenRA.Traits
 			return true;
 		}
 
+		public int GetSpareCapacity()
+		{
+			// If we are overfull (somehow) then just return no spare capacity
+			return Math.Max(ResourceCapacity - Resources, 0);
+		}
+
 		public void GiveCash(int num)
 		{
 			Cash += num;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -167,6 +167,15 @@ namespace OpenRA.Traits
 		void SetVisualPosition(Actor self, WPos pos);
 	}
 
+	public enum ModifierType { Production, Income };
+	public interface IAttributeModManager
+	{
+		ModifierType ModType { get; }
+		int GetModifier(ModifierType modType, string Type);
+		void Register(ModifierType modType, string id, string[] types, int mod);
+		void Unregister(ModifierType modType, string id, int mod);
+	}
+
 	public interface IMoveInfo : ITraitInfo { }
 	public interface IMove
 	{

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -63,6 +63,18 @@ namespace OpenRA.Mods.RA.AI
 		[Desc("Radius in cells around the center of the base to expand.")]
 		public readonly int MaxBaseRadius = 20;
 
+		[Desc("The cheat modifier for the AI to its production time.", "-10 = 90% of normal production time", "10 = 110% of normal production time")]
+		public readonly int ProductionTimeModifier = 0;
+		
+		[Desc("The types of queues affected by the production time modifier.")]
+		public readonly string[] ProductionTimeModifierTypes = { "Building", "Defense", "Infantry", "Vehicle", "Ship", "Aircraft" };
+
+		[Desc("The cheat modifier for the AI to its income rate.", "-10 = 90% of normal income", "10 = 110% of normal income")]
+		public readonly int IncomeMultModifier = 0;
+		
+		[Desc("The types of income the income multiplier applies to.")]
+		public readonly string[] IncomeMultModifierTypes = { "Harvester", "CashTrickler", "Bounty" };
+
 		public readonly string[] UnitQueues = { "Vehicle", "Infantry", "Plane", "Ship", "Aircraft" };
 		public readonly bool ShouldRepairBuildings = true;
 
@@ -170,6 +182,14 @@ namespace OpenRA.Mods.RA.AI
 				Map.Rules.Actors["world"].Traits
 				.WithInterface<ResourceTypeInfo>()
 				.Select(t => world.TileSet.GetTerrainIndex(t.TerrainType)));
+
+			var managers = p.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production);
+			foreach (var manager in managers)
+				manager.Register(ModifierType.Production, p.PlayerActor.ActorID.ToString() + "AICheaty", Info.ProductionTimeModifierTypes, Info.ProductionTimeModifier);
+
+			var incomeManagers = p.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Income);
+			foreach (var manager in incomeManagers)
+				manager.Register(ModifierType.Income, p.PlayerActor.ActorID.ToString() + "AICheaty", Info.IncomeMultModifierTypes, Info.IncomeMultModifier);
 		}
 
 		ActorInfo ChooseRandomUnitToBuild(ProductionQueue queue)

--- a/OpenRA.Mods.RA/AttributeModifier.cs
+++ b/OpenRA.Mods.RA/AttributeModifier.cs
@@ -1,0 +1,120 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("This provides a modifier to the player's production speed.", "This goes on a player or an actor.")]
+	public class AttributeModifierInfo : ITraitInfo
+	{
+		[Desc("What type of modifier this is.")]
+		public readonly ModifierType ModType = ModifierType.Production;
+
+		[Desc("The types this modifier applies to.")]
+		public readonly string[] Types = { "Any" };
+
+		[Desc("The amount of this modifier.", "0 = no adjustment", "-10 = 90% of normal", "10 = 110% of normal")]
+		public readonly int Modifier = 0;
+
+		[Desc("Only apply this modifier when these prerequisites are met.")]
+		public readonly string[] Prerequisites = { };
+
+		[Desc("Does this affect the player as opposed to just this actor", "true = Manager on PlayerActor is used.")]
+		public readonly bool IsGlobal = false;
+
+		[Desc("Is this attached to a player actor", "true = This is on a player")]
+		public readonly bool OnPlayerActor = false;
+
+		public object Create(ActorInitializer init) { return new AttributeModifier(init, this); }
+	}
+
+	public class AttributeModifier : INotifyAddedToWorld, INotifyRemovedFromWorld, ITechTreeElement
+	{
+		readonly Actor self;
+		public readonly AttributeModifierInfo Info;
+
+		IEnumerable<IAttributeModManager> managers;
+		TechTree techTree;
+
+		public AttributeModifier(ActorInitializer init, AttributeModifierInfo info)
+		{
+			self = init.self;
+			Info = info;
+		}
+
+		static string MakeKey(Actor self, AttributeModifierInfo info)
+		{
+			var key = self.ActorID.ToString() + ":" + info.Modifier.ToString();
+			if (info.Prerequisites.Any())
+				key += String.Join(",",info.Prerequisites);
+			return key;
+		}
+
+		public void RegisterSelf()
+		{
+			var key = MakeKey(self, Info);
+			foreach (var manager in managers)
+				manager.Register(Info.ModType, key, Info.Types, Info.Modifier);
+		}
+
+		public void UnregisterSelf()
+		{
+			var key = MakeKey(self, Info);
+			foreach (var manager in managers)
+				manager.Unregister(Info.ModType, key, Info.Modifier);
+		}
+
+		public void AddedToWorld(Actor self)
+		{
+			if (Info.OnPlayerActor)
+				techTree = self.Trait<TechTree>();
+			else
+				techTree = self.Owner.PlayerActor.Trait<TechTree>();
+
+			if (Info.IsGlobal && !Info.OnPlayerActor)
+				managers = self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>();
+			else
+				managers = self.TraitsImplementing<IAttributeModManager>();
+
+			if (Info.Prerequisites.Any())
+			{
+				techTree.Add(MakeKey(self, Info), Info.Prerequisites, 0, this);
+				techTree.Update();
+			}
+			else
+				RegisterSelf();
+		}
+
+		public void RemovedFromWorld(Actor self)
+		{
+			UnregisterSelf();
+		}
+
+		public void PrerequisitesAvailable(string key)
+		{
+			if (MakeKey(self, Info) == key)
+				RegisterSelf();
+		}
+
+		public void PrerequisitesUnavailable(string key)
+		{
+			if (MakeKey(self, Info) == key)
+				UnregisterSelf();
+		}
+
+		public void PrerequisitesItemHidden(string key) { }
+		public void PrerequisitesItemVisible(string key) { }
+	}
+}

--- a/OpenRA.Mods.RA/AttributeModifierManager.cs
+++ b/OpenRA.Mods.RA/AttributeModifierManager.cs
@@ -1,0 +1,79 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("This keeps track of player's modifier to production speed.", "This goes on a player or an actor.")]
+	public class AttributeModifierManagerInfo : ITraitInfo
+	{
+		[Desc("What type of modifiers this keeps track of.")]
+		public readonly ModifierType ModType = ModifierType.Production;
+
+		[Desc("The type of production this manager keeps track of.", "Adding 'Any' will apply this to all types.")]
+		public readonly string Type = "Any";
+
+		public object Create(ActorInitializer init) { return new AttributeModifierManager(init, this); }
+	}
+
+	public class AttributeModifierManager : IAttributeModManager, ISync
+	{
+		public readonly AttributeModifierManagerInfo Info;
+
+		public List<string> Modifiers = new List<string>();
+		[Sync] public int ModValue = 0;
+
+		public AttributeModifierManager(ActorInitializer init, AttributeModifierManagerInfo info)
+		{
+			Info = info;
+		}
+
+		public ModifierType ModType
+		{
+			get
+			{
+				return Info.ModType;
+			}
+		}
+
+		public int GetModifier(ModifierType modType, string Type)
+		{
+			if (Info.Type == Type && Info.ModType == modType)
+				return ModValue;
+
+			return 0;
+		}
+
+		public void Register(ModifierType modType, string id, string[] types, int mod)
+		{
+			if (Info.ModType == modType &&
+				(types.Contains("Any") || types.Contains(Info.Type)) &&
+				!Modifiers.Contains(id))
+			{
+				Modifiers.Add(id);
+				ModValue += mod;
+			}
+		}
+
+		public void Unregister(ModifierType modType, string id, int mod)
+		{
+			if (Info.ModType == modType && Modifiers.Contains(id))
+			{
+				Modifiers.Remove(id);
+				ModValue -= mod;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -117,6 +117,8 @@
     <Compile Include="Air\Aircraft.cs" />
     <Compile Include="Air\AttackHeli.cs" />
     <Compile Include="Air\AttackPlane.cs" />
+    <Compile Include="AttributeModifier.cs" />
+    <Compile Include="AttributeModifierManager.cs" />
     <Compile Include="Crates\DuplicateUnitCrateAction.cs" />
     <Compile Include="Power.cs" />
     <Compile Include="Effects\Beacon.cs" />

--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -115,7 +115,12 @@ namespace OpenRA.Mods.RA
 			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
 				return 0;
 
-			var time = (int)(ai.GetBuildTime() * Info.BuildSpeed);
+			var productionRateModifier = 0;
+			if (self.Owner != null && self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production).Any())
+				productionRateModifier += self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production)
+				.Select(t => t.GetModifier(ModifierType.Production, Info.Type)).Sum();
+
+			var time = (int)(ai.GetBuildTime() * Info.BuildSpeed * (100 + productionRateModifier) / 100);
 
 			if (info.SpeedUp)
 			{

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -327,7 +327,16 @@ namespace OpenRA.Mods.RA
 			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
 				return 0;
 
-			var time = unit.GetBuildTime() * Info.BuildSpeed;
+			var productionRateModifier = 0;
+			if (self.Owner != null && self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production).Any())
+				productionRateModifier += self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production)
+				.Select(t => t.GetModifier(ModifierType.Production, Info.Type)).Sum();
+
+			if (self.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production).Any())
+				productionRateModifier += self.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production)
+				.Select(t => t.GetModifier(ModifierType.Production, Info.Type)).Sum();
+
+			var time = unit.GetBuildTime() * Info.BuildSpeed * (100 + productionRateModifier) / 100;
 
 			return (int)time;
 		}

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -238,4 +238,370 @@ Player:
 			ca: 20%
 			pt: 10%
 		SquadSize: 1
+	HackyAI@VeryEasyAI:
+		Name: Very Easy AI
+		BuildingCommonNames:
+			ConstructionYard: fact
+			Refinery: proc
+			Power: powr,apwr
+			Barracks: barr,tent
+			VehiclesFactory: weap
+			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Silo: silo
+		UnitsCommonNames:
+			Mcv: mcv
+		BuildingLimits:
+			proc: 3
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 90%
+			powr: 1%
+			apwr: 30%
+			tent: 1%
+			barr: 1%
+			weap: 3%
+			spen: 1%
+			syrd: 1%
+			pbox: 7%
+			gun: 7%
+			ftur: 10%
+			tsla: 5%
+			fix: 0.1%
+			dome: 10%
+			agun: 5%
+			sam: 1%
+		UnitsToBuild:
+			e1: 20%
+			e3: 10%
+			e4: 20%
+			harv: 10%
+			apc: 5%
+			jeep: 10%
+			ftrk: 5%
+			1tnk: 70%
+			2tnk: 25%
+			3tnk: 50%
+			ttnk: 50%
+			ss: 10%
+			dd: 10%
+			pt: 10%
+		SquadSize: 10
+		ProductionTimeModifier: 100
+		ProductionTimeModifierTypes: Any
+		IncomeMultModifier: -50
+		IncomeMultModifierTypes: Any
+	HackyAI@EasyAI:
+		Name: Easy AI
+		BuildingCommonNames:
+			ConstructionYard: fact
+			Refinery: proc
+			Power: powr,apwr
+			Barracks: barr,tent
+			VehiclesFactory: weap
+			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Silo: silo
+		UnitsCommonNames:
+			Mcv: mcv
+		BuildingLimits:
+			proc: 3
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 90%
+			powr: 1%
+			apwr: 30%
+			tent: 1%
+			barr: 1%
+			weap: 3%
+			hpad: 2%
+			spen: 1%
+			syrd: 1%
+			pbox: 7%
+			afld: 4%
+			gun: 7%
+			ftur: 10%
+			tsla: 5%
+			fix: 0.1%
+			dome: 10%
+			agun: 5%
+			sam: 1%
+			atek: 1%
+			stek: 1%
+		UnitsToBuild:
+			e1: 20%
+			e3: 10%
+			e4: 20%
+			harv: 10%
+			apc: 5%
+			jeep: 10%
+			ftrk: 5%
+			1tnk: 70%
+			2tnk: 25%
+			3tnk: 50%
+			4tnk: 50%
+			ttnk: 50%
+			arty: 20%
+			v2rl: 40%
+			heli: 30%
+			hind: 30%
+			mig: 30%
+			yak: 30%
+			ss: 10%
+			msub: 10%
+			dd: 10%
+			ca: 10%
+			pt: 10%
+		SquadSize: 10
+		ProductionTimeModifier: 25
+		ProductionTimeModifierTypes: Any
+		IncomeMultModifier: -25
+		IncomeMultModifierTypes: Any
+	HackyAI@MediumAI:
+		Name: Medium AI
+		BuildingCommonNames:
+			ConstructionYard: fact
+			Refinery: proc
+			Power: powr,apwr
+			Barracks: barr,tent
+			VehiclesFactory: weap
+			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Silo: silo
+		UnitsCommonNames:
+			Mcv: mcv
+		BuildingLimits:
+			proc: 4
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 90%
+			powr: 1%
+			apwr: 30%
+			tent: 1%
+			barr: 1%
+			weap: 3%
+			hpad: 2%
+			spen: 1%
+			syrd: 1%
+			pbox: 7%
+			afld: 4%
+			gun: 7%
+			ftur: 10%
+			tsla: 5%
+			fix: 0.1%
+			dome: 10%
+			agun: 5%
+			sam: 1%
+			atek: 1%
+			stek: 1%
+			mslo: 1%
+		UnitsToBuild:
+			e1: 20%
+			e3: 10%
+			e4: 20%
+			harv: 10%
+			apc: 5%
+			jeep: 10%
+			ftrk: 5%
+			1tnk: 70%
+			2tnk: 25%
+			3tnk: 50%
+			4tnk: 50%
+			ttnk: 50%
+			arty: 20%
+			v2rl: 40%
+			heli: 30%
+			hind: 30%
+			mig: 30%
+			yak: 30%
+			ss: 10%
+			msub: 10%
+			dd: 10%
+			ca: 10%
+			pt: 10%
+		SquadSize: 10
+		ProductionTimeModifier: 0
+		ProductionTimeModifierTypes: Any
+		IncomeMultModifier: 0
+		IncomeMultModifierTypes: Any
+	HackyAI@HardAI:
+		Name: Hard AI
+		BuildingCommonNames:
+			ConstructionYard: fact
+			Refinery: proc
+			Power: powr,apwr
+			Barracks: barr,tent
+			VehiclesFactory: weap
+			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Silo: silo
+		UnitsCommonNames:
+			Mcv: mcv
+		BuildingLimits:
+			proc: 5
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 90%
+			powr: 1%
+			apwr: 30%
+			tent: 1%
+			barr: 1%
+			weap: 3%
+			hpad: 2%
+			spen: 1%
+			syrd: 1%
+			pbox: 7%
+			afld: 4%
+			gun: 7%
+			ftur: 10%
+			tsla: 5%
+			fix: 0.1%
+			dome: 10%
+			agun: 5%
+			sam: 1%
+			atek: 1%
+			stek: 1%
+			mslo: 1%
+		UnitsToBuild:
+			e1: 20%
+			e3: 10%
+			e4: 20%
+			harv: 10%
+			apc: 5%
+			jeep: 10%
+			ftrk: 5%
+			1tnk: 70%
+			2tnk: 25%
+			3tnk: 50%
+			4tnk: 50%
+			ttnk: 50%
+			arty: 20%
+			v2rl: 40%
+			heli: 30%
+			hind: 30%
+			mig: 30%
+			yak: 30%
+			ss: 10%
+			msub: 10%
+			dd: 10%
+			ca: 10%
+			pt: 10%
+		SquadSize: 20
+		ProductionTimeModifier: -25
+		ProductionTimeModifierTypes: Any
+		IncomeMultModifier: 50
+		IncomeMultModifierTypes: Any
+	HackyAI@InsaneAI:
+		Name: Insane AI
+		BuildingCommonNames:
+			ConstructionYard: fact
+			Refinery: proc
+			Power: powr,apwr
+			Barracks: barr,tent
+			VehiclesFactory: weap
+			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Silo: silo
+		UnitsCommonNames:
+			Mcv: mcv
+		BuildingLimits:
+			proc: 5
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 90%
+			powr: 1%
+			apwr: 30%
+			tent: 1%
+			barr: 1%
+			weap: 3%
+			hpad: 2%
+			spen: 1%
+			syrd: 1%
+			pbox: 7%
+			afld: 4%
+			gun: 7%
+			ftur: 10%
+			tsla: 5%
+			fix: 0.1%
+			dome: 10%
+			agun: 5%
+			sam: 1%
+			atek: 1%
+			stek: 1%
+			mslo: 1%
+		UnitsToBuild:
+			e1: 20%
+			e3: 10%
+			e4: 20%
+			harv: 10%
+			apc: 5%
+			jeep: 10%
+			ftrk: 5%
+			1tnk: 70%
+			2tnk: 25%
+			3tnk: 50%
+			4tnk: 50%
+			ttnk: 50%
+			arty: 20%
+			v2rl: 40%
+			heli: 30%
+			hind: 30%
+			mig: 30%
+			yak: 30%
+			ss: 10%
+			msub: 10%
+			dd: 10%
+			ca: 10%
+			pt: 10%
+			mcv: 1%
+		SquadSize: 30
+		ProductionTimeModifier: -50
+		ProductionTimeModifierTypes: Any
+		IncomeMultModifier: 100
+		IncomeMultModifierTypes: Any
 

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -70,3 +70,31 @@ Player:
 	ProvidesTechPrerequisite@unrestricted:
 		Name: Unrestricted
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.unrestricted
+	AttributeModifierManager@ProdBuilding:
+		Type: Building
+		ModType: Production
+	AttributeModifierManager@ProdDefense:
+		Type: Defense
+		ModType: Production
+	AttributeModifierManager@ProdInfantry:
+		Type: Infantry
+		ModType: Production
+	AttributeModifierManager@ProdVehicle:
+		Type: Vehicle
+		ModType: Production
+	AttributeModifierManager@ProdShip:
+		Type: Ship
+		ModType: Production
+	AttributeModifierManager@ProdAircraft:
+		Type: Aircraft
+		ModType: Production
+	AttributeModifierManager@IncHarvester:
+		Type: Harvester
+		ModType: Income
+	AttributeModifierManager@IncCashTrickler:
+		Type: CashTrickler
+		ModType: Income
+	AttributeModifierManager@IncBounty:
+		Type: Bounty
+		ModType: Income
+		


### PR DESCRIPTION
Allows modifiers to be defined per player and per actor.
Modifiers can define prerequisites.
Currently supports production and income.

Allows for tie-in from HackyAI. InsaneAI for RA included.

Pre-work for #6103.
