### PR TITLE
Fixed the automatic wiki documentation update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ script:
  - make all
  - make test
 
+# Automatically update the trait documentation and Lua API
+after_success:
+ - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && make docs && cd packaging && ./update-wiki.sh
+
 # Only watch the development branch and tagged release.
 branches:
  only:

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -1,17 +1,18 @@
+#!/bin/bash
+
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "travis-ci"
 
 echo "Updating https://github.com/OpenRA/OpenRA/wiki/Traits"
-rm -rf openra-wiki
-git clone git@github.com:OpenRA/OpenRA.wiki.git openra-wiki
-cp -fr ../DOCUMENTATION.md openra-wiki/Traits.md
+rm -rf $HOME/openra-wiki
+git clone git@github.com:OpenRA/OpenRA.wiki.git $HOME/openra-wiki
+cp -fr ../DOCUMENTATION.md $HOME/openra-wiki/Traits.md
 
 pushd .. &> /dev/null
-# d2k depends on all mod libraries
-mono --debug OpenRA.Utility.exe --lua-docs d2k > packaging/openra-wiki/New-Lua-API.md
+mono --debug OpenRA.Utility.exe --lua-docs d2k > $HOME/openra-wiki/New-Lua-API.md
 popd &> /dev/null
 
-pushd openra-wiki
+pushd $HOME/openra-wiki
 git add Traits.md
 git add New-Lua-API.md
 git commit -m "Update trait and scripting documentation"

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-git config --global user.email "travis@travis-ci.org"
-git config --global user.name "travis-ci"
+git config --global user.email "orabot@users.noreply.github.com"
+git config --global user.name "orabot"
 
 echo "Updating https://github.com/OpenRA/OpenRA/wiki/Traits"
 rm -rf $HOME/openra-wiki


### PR DESCRIPTION
After lessons learned from https://github.com/OpenRA/OpenRAWeb/pull/135 I resolved by https://github.com/OpenRA/OpenRA/issues/5900 by git cloning into `$HOME` to avoid the git inside an existing git repository problem. When testing locally I suggest to remove the lines

```
git config --global user.email "travis@travis-ci.org"
git config --global user.name "travis-ci"
```
