### PR TITLE
Fixed a crash when there are no actors to reveal shroud on the map.

### DIFF
--- a/OpenRA.Mods.RA/ShroudRenderer.cs
+++ b/OpenRA.Mods.RA/ShroudRenderer.cs
@@ -231,7 +231,7 @@ namespace OpenRA.Mods.RA
 			if (shroud != null)
 			{
 				// If the current shroud hasn't changed and we have already updated the specified area, we don't need to do anything.
-				if (lastShroudHash == shroud.Hash && !clearedForNullShroud && updatedRegion.Contains(region))
+				if (lastShroudHash == shroud.Hash && !clearedForNullShroud && updatedRegion != null && updatedRegion.Contains(region))
 					return;
 
 				lastShroudHash = shroud.Hash;


### PR DESCRIPTION
as described in https://github.com/OpenRA/OpenRA/issues/6166. This does not fix https://github.com/OpenRA/OpenRA/issues/6097 although I tried several alternatives.
