### PR TITLE
Fixes incorrect package name in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ Debian/Ubuntu
 -------------
 
 * mono-dmcs
-* libmono-winforms4.0-cil
+* libmono-system-windows-forms4.0-cil
 * cli-common-dev (>= 2.10)
 * libfreetype6
 * libopenal1


### PR DESCRIPTION
No package `libmono-winforms4.0-cil` exists in Debian or Ubuntu. The correct package name is `libmono-system-windows-forms4.0-cil`.
