### PR TITLE
Attribute modifiers (Production time & Income)

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -34,6 +34,7 @@ namespace OpenRA
 		public bool? FragileAlliances;
 		public int? StartingCash;
 		public string TechLevel;
+		public bool AttributeModifiers = true;
 		public bool ConfigurableStartingUnits = true;
 		public string[] Difficulties = { };
 

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -112,6 +112,8 @@ namespace OpenRA.Network
 			public bool IsReady { get { return State == ClientState.Ready; } }
 			public bool IsInvalid { get { return State == ClientState.Invalid; } }
 			public bool IsObserver { get { return Slot == null; } }
+			public int ModifierProduction = 0;
+			public int ModifierIncome = 0;
 
 			public MiniYamlNode Serialize()
 			{

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -41,6 +41,8 @@ namespace OpenRA
 		public readonly PlayerReference PlayerReference;
 		public bool IsBot;
 		public int SpawnPoint;
+		public int ProductionModifier = 0;
+		public int IncomeModifier = 0;
 
 		public Shroud Shroud;
 		public World World { get; private set; }
@@ -70,6 +72,8 @@ namespace OpenRA
 				PlayerName = client.Name;
 				botType = client.Bot;
 				Country = ChooseCountry(world, client.Country);
+				ProductionModifier = client.ModifierProduction;
+				IncomeModifier = client.ModifierIncome;
 			}
 			else
 			{
@@ -82,6 +86,8 @@ namespace OpenRA
 				Spectating = pr.Spectating;
 				botType = pr.Bot;
 				Country = ChooseCountry(world, pr.Race);
+				ProductionModifier = 0;
+				IncomeModifier = 0;
 			}
 			PlayerActor = world.CreateActor("Player", new TypeDictionary { new OwnerInit(this) });
 			Shroud = PlayerActor.Trait<Shroud>();

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -75,6 +75,12 @@ namespace OpenRA.Traits
 			return true;
 		}
 
+		public int GetSpareCapacity()
+		{
+			// If we are overfull (somehow) then just return no spare capacity
+			return Math.Max(ResourceCapacity - Resources, 0);
+		}
+
 		public void GiveCash(int num)
 		{
 			Cash += num;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -185,6 +185,15 @@ namespace OpenRA.Traits
 		void SetVisualPosition(Actor self, WPos pos);
 	}
 
+	public enum ModifierType { Production, Income };
+	public interface IAttributeModManager
+	{
+		ModifierType ModType { get; }
+		int GetModifier(ModifierType modType, string Type);
+		void Register(ModifierType modType, string id, string[] types, int mod);
+		void Unregister(ModifierType modType, string id, int mod);
+	}
+
 	public interface IMoveInfo : ITraitInfo { }
 	public interface IMove
 	{

--- a/OpenRA.Mods.RA/AttributeModifier.cs
+++ b/OpenRA.Mods.RA/AttributeModifier.cs
@@ -1,0 +1,120 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("This provides a modifier to the player's production speed.", "This goes on a player or an actor.")]
+	public class AttributeModifierInfo : ITraitInfo
+	{
+		[Desc("What type of modifier this is.")]
+		public readonly ModifierType ModType = ModifierType.Production;
+
+		[Desc("The types this modifier applies to.")]
+		public readonly string[] Types = { "Any" };
+
+		[Desc("The amount of this modifier.", "0 = no adjustment", "-10 = 90% of normal", "10 = 110% of normal")]
+		public readonly int Modifier = 0;
+
+		[Desc("Only apply this modifier when these prerequisites are met.")]
+		public readonly string[] Prerequisites = { };
+
+		[Desc("Does this affect the player as opposed to just this actor", "true = Manager on PlayerActor is used.")]
+		public readonly bool IsGlobal = false;
+
+		[Desc("Is this attached to a player actor", "true = This is on a player")]
+		public readonly bool OnPlayerActor = false;
+
+		public object Create(ActorInitializer init) { return new AttributeModifier(init, this); }
+	}
+
+	public class AttributeModifier : INotifyAddedToWorld, INotifyRemovedFromWorld, ITechTreeElement
+	{
+		readonly Actor self;
+		public readonly AttributeModifierInfo Info;
+
+		IEnumerable<IAttributeModManager> managers;
+		TechTree techTree;
+
+		public AttributeModifier(ActorInitializer init, AttributeModifierInfo info)
+		{
+			self = init.self;
+			Info = info;
+		}
+
+		static string MakeKey(Actor self, AttributeModifierInfo info)
+		{
+			var key = self.ActorID.ToString() + ":" + info.Modifier.ToString();
+			if (info.Prerequisites.Any())
+				key += String.Join(",",info.Prerequisites);
+			return key;
+		}
+
+		public void RegisterSelf()
+		{
+			var key = MakeKey(self, Info);
+			foreach (var manager in managers)
+				manager.Register(Info.ModType, key, Info.Types, Info.Modifier);
+		}
+
+		public void UnregisterSelf()
+		{
+			var key = MakeKey(self, Info);
+			foreach (var manager in managers)
+				manager.Unregister(Info.ModType, key, Info.Modifier);
+		}
+
+		public void AddedToWorld(Actor self)
+		{
+			if (Info.OnPlayerActor)
+				techTree = self.Trait<TechTree>();
+			else
+				techTree = self.Owner.PlayerActor.Trait<TechTree>();
+
+			if (Info.IsGlobal && !Info.OnPlayerActor)
+				managers = self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>();
+			else
+				managers = self.TraitsImplementing<IAttributeModManager>();
+
+			if (Info.Prerequisites.Any())
+			{
+				techTree.Add(MakeKey(self, Info), Info.Prerequisites, 0, this);
+				techTree.Update();
+			}
+			else
+				RegisterSelf();
+		}
+
+		public void RemovedFromWorld(Actor self)
+		{
+			UnregisterSelf();
+		}
+
+		public void PrerequisitesAvailable(string key)
+		{
+			if (MakeKey(self, Info) == key)
+				RegisterSelf();
+		}
+
+		public void PrerequisitesUnavailable(string key)
+		{
+			if (MakeKey(self, Info) == key)
+				UnregisterSelf();
+		}
+
+		public void PrerequisitesItemHidden(string key) { }
+		public void PrerequisitesItemVisible(string key) { }
+	}
+}

--- a/OpenRA.Mods.RA/AttributeModifierManager.cs
+++ b/OpenRA.Mods.RA/AttributeModifierManager.cs
@@ -1,0 +1,79 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("This keeps track of player's modifier to production speed.", "This goes on a player or an actor.")]
+	public class AttributeModifierManagerInfo : ITraitInfo
+	{
+		[Desc("What type of modifiers this keeps track of.")]
+		public readonly ModifierType ModType = ModifierType.Production;
+
+		[Desc("The type of production this manager keeps track of.", "Adding 'Any' will apply this to all types.")]
+		public readonly string Type = "Any";
+
+		public object Create(ActorInitializer init) { return new AttributeModifierManager(init, this); }
+	}
+
+	public class AttributeModifierManager : IAttributeModManager, ISync
+	{
+		public readonly AttributeModifierManagerInfo Info;
+
+		public List<string> Modifiers = new List<string>();
+		[Sync] public int ModValue = 0;
+
+		public AttributeModifierManager(ActorInitializer init, AttributeModifierManagerInfo info)
+		{
+			Info = info;
+		}
+
+		public ModifierType ModType
+		{
+			get
+			{
+				return Info.ModType;
+			}
+		}
+
+		public int GetModifier(ModifierType modType, string Type)
+		{
+			if (Info.Type == Type && Info.ModType == modType)
+				return ModValue;
+
+			return 0;
+		}
+
+		public void Register(ModifierType modType, string id, string[] types, int mod)
+		{
+			if (Info.ModType == modType &&
+				(types.Contains("Any") || types.Contains(Info.Type)) &&
+				!Modifiers.Contains(id))
+			{
+				Modifiers.Add(id);
+				ModValue += mod;
+			}
+		}
+
+		public void Unregister(ModifierType modType, string id, int mod)
+		{
+			if (Info.ModType == modType && Modifiers.Contains(id))
+			{
+				Modifiers.Remove(id);
+				ModValue -= mod;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.RA/CreateMPPlayers.cs
+++ b/OpenRA.Mods.RA/CreateMPPlayers.cs
@@ -42,6 +42,14 @@ namespace OpenRA.Mods.RA
 
 				if (client.Index == Game.LocalClientId)
 					w.SetLocalPlayer(player.InternalName);
+
+				var managers = player.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production);
+				foreach (var manager in managers)
+					manager.Register(ModifierType.Production, player.PlayerActor.ActorID.ToString() + "PlayerMod", new string[] { "Any" }, player.ProductionModifier);
+	
+				var incomeManagers = player.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Income);
+				foreach (var manager in incomeManagers)
+					manager.Register(ModifierType.Income, player.PlayerActor.ActorID.ToString() + "PlayerMod", new string[] { "Any" }, player.IncomeModifier);
 			}
 
 			// create a player that is allied with everyone for shared observer shroud

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -117,6 +117,8 @@
     <Compile Include="Air\Aircraft.cs" />
     <Compile Include="Air\AttackHeli.cs" />
     <Compile Include="Air\AttackPlane.cs" />
+    <Compile Include="AttributeModifier.cs" />
+    <Compile Include="AttributeModifierManager.cs" />
     <Compile Include="Crates\DuplicateUnitCrateAction.cs" />
     <Compile Include="Power.cs" />
     <Compile Include="Effects\Beacon.cs" />

--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -115,7 +115,12 @@ namespace OpenRA.Mods.RA
 			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
 				return 0;
 
-			var time = (int)(ai.GetBuildTime() * Info.BuildSpeed);
+			var productionRateModifier = 0;
+			if (self.Owner != null && self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production).Any())
+				productionRateModifier += self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production)
+				.Select(t => t.GetModifier(ModifierType.Production, Info.Type)).Sum();
+
+			var time = (int)(ai.GetBuildTime() * Info.BuildSpeed * (100 + productionRateModifier) / 100);
 
 			if (info.SpeedUp)
 			{

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -327,7 +327,16 @@ namespace OpenRA.Mods.RA
 			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
 				return 0;
 
-			var time = unit.GetBuildTime() * Info.BuildSpeed;
+			var productionRateModifier = 0;
+			if (self.Owner != null && self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production).Any())
+				productionRateModifier += self.Owner.PlayerActor.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production)
+				.Select(t => t.GetModifier(ModifierType.Production, Info.Type)).Sum();
+
+			if (self.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production).Any())
+				productionRateModifier += self.TraitsImplementing<IAttributeModManager>().Where(man => man.ModType == ModifierType.Production)
+				.Select(t => t.GetModifier(ModifierType.Production, Info.Type)).Sum();
+
+			var time = unit.GetBuildTime() * Info.BuildSpeed * (100 + productionRateModifier) / 100;
 
 			return (int)time;
 		}

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -753,6 +753,29 @@ namespace OpenRA.Mods.RA.Server
 						targetClient.Color = targetClient.PreferredColor = new HSLColor((byte)ci[0], (byte)ci[1], (byte)ci[2]);
 						server.SyncLobbyClients();
 						return true;
+					}},
+				{ "changeattribute",
+					s =>
+					{
+						var parts = s.Split(' ');
+						var targetClient = server.LobbyInfo.ClientWithIndex(Exts.ParseIntegerInvariant(parts[0]));
+						var targetAttribute = parts[1];
+						var targetValue = Int32.Parse(parts[2]);
+
+						// Only the host can change other client's info
+						if (targetClient.Index != client.Index && !client.IsAdmin)
+							return true;
+
+						// Map has disabled player attribute modifiers
+						if (server.Map.Options.AttributeModifiers == false) // TODO Set this up on the map side
+							return true;
+
+						if (targetAttribute == "production")
+							targetClient.ModifierProduction = targetValue;
+						else if (targetAttribute == "income")
+							targetClient.ModifierIncome = targetValue;
+						server.SyncLobbyClients();
+						return true;
 					}}
 			};
 

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -457,5 +457,75 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			playerName.GetText = () => player.PlayerName + (player.WinState == WinState.Undefined ? "" : " (" + player.WinState + ")");
 			playerName.GetColor = () => player.Color.RGB;
 		}
+
+		public static void SetupEditableProdModWidget(Widget parent, Session.Client c, OrderManager orderManager)
+		{
+			var dropdown = parent.Get<DropDownButtonWidget>("PRODMOD");
+			// Equal in both directions. Negatives = 100 - (100 / Postive)
+			var choices = new int[] { -90, -80, -75, -71, -67, -60, -50, -43, -33, -20, -9, 0, 10, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500 };
+			dropdown.IsDisabled = () => !Game.IsHost;
+			dropdown.OnMouseDown = _ => ShowProdModDropDown(dropdown, c, orderManager, choices.AsEnumerable());
+			dropdown.GetText = () => (c.ModifierProduction < 0) ? c.ModifierProduction.ToString() + "%" : "+" + c.ModifierProduction.ToString() + "%";
+		}
+
+		public static void ShowProdModDropDown(DropDownButtonWidget dropdown, Session.Client client,
+			OrderManager orderManager, IEnumerable<int> choices)
+		{
+			Func<int, ScrollItemWidget, ScrollItemWidget> setupItem = (ii, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => client.ModifierProduction == ii,
+					() => SetProdMod(orderManager, client, ii));
+				item.Get<LabelWidget>("LABEL").GetText = () => (ii < 0) ? ii.ToString() + "%" : "+" + ii.ToString() + "%";
+				return item;
+			};
+
+			dropdown.ShowDropDown("MOD_DROPDOWN_TEMPLATE", 150, choices, setupItem);
+		}
+
+		private static void SetProdMod(OrderManager orderManager, Session.Client c, int modValue)
+		{
+			orderManager.IssueOrder(Order.Command("changeattribute {0} {1} {2}".F(c.Index, "production", modValue)));
+		}
+
+		public static void SetupProdModWidget(Widget parent, Session.Client c)
+		{
+			parent.Get<LabelWidget>("PRODMOD").GetText = () => (c.ModifierIncome < 0) ? c.ModifierIncome.ToString() + "%" : "+" + c.ModifierIncome.ToString() + "%";
+		}
+
+		public static void SetupEditableIncModWidget(Widget parent, Session.Client c, OrderManager orderManager)
+		{
+			var dropdown = parent.Get<DropDownButtonWidget>("INCMOD");
+			// Equal in both directions. Negatives = 100 - (100 / Postive)
+			var choices = new int[] { -90, -80, -75, -71, -67, -60, -50, -43, -33, -20, -9, 0, 10, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500 };
+			dropdown.IsDisabled = () => !Game.IsHost;
+			dropdown.OnMouseDown = _ => ShowIncModDropDown(dropdown, c, orderManager, choices.AsEnumerable());
+			dropdown.GetText = () => (c.ModifierIncome < 0) ? c.ModifierIncome.ToString() + "%" : "+" + c.ModifierIncome.ToString() + "%";
+		}
+
+		public static void ShowIncModDropDown(DropDownButtonWidget dropdown, Session.Client client,
+			OrderManager orderManager, IEnumerable<int> choices)
+		{
+			Func<int, ScrollItemWidget, ScrollItemWidget> setupItem = (ii, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => client.ModifierIncome == ii,
+					() => SetIncMod(orderManager, client, ii));
+				item.Get<LabelWidget>("LABEL").GetText = () => (ii < 0) ? ii.ToString() + "%" : "+" + ii.ToString() + "%";
+				return item;
+			};
+
+			dropdown.ShowDropDown("MOD_DROPDOWN_TEMPLATE", 150, choices, setupItem);
+		}
+
+		private static void SetIncMod(OrderManager orderManager, Session.Client c, int modValue)
+		{
+			orderManager.IssueOrder(Order.Command("changeattribute {0} {1} {2}".F(c.Index, "income", modValue)));
+		}
+
+		public static void SetupIncModWidget(Widget parent, Session.Client c)
+		{
+			parent.Get<LabelWidget>("INCMOD").GetText = () => (c.ModifierIncome < 0) ? c.ModifierIncome.ToString() + "%" : "+" + c.ModifierIncome.ToString() + "%";
+		}
 	}
 }

--- a/mods/cnc/chrome/lobby-playerbin.yaml
+++ b/mods/cnc/chrome/lobby-playerbin.yaml
@@ -333,3 +333,71 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 					X: 210
 					Y: 0
 
+ScrollPanel@LOBBY_PLAYERMODIFIERS_BIN:
+	X: 20
+	Y: 67
+	ItemSpacing: 5
+	Width: 593
+	Height: 235
+	Children:
+		Container@TEMPLATE_EDITABLE_PLAYER_MODIFIERS:
+			X: 5
+			Y: 0
+			Width: 475
+			Height: 25
+			Visible: false
+			Children:
+				Label@NAME:
+					Text: Name
+					X: 15
+					Width: 165
+					Height: 25
+				DropDownButton@PRODMOD:
+					X: 185
+					Width: 85
+					Height: 25
+					Text: Production
+				DropDownButton@INCMOD:
+					X: 275
+					Width: 85
+					Height: 25
+					Text: Income
+		Container@TEMPLATE_NONEDITABLE_PLAYER_MODIFIERS:
+			X: 5
+			Y: 0
+			Width: 475
+			Height: 25
+			Visible: false
+			Children:
+				Label@NAME:
+					Text: Name
+					X: 15
+					Width: 165
+					Height: 25
+				Label@PRODMOD:
+					X: 185
+					Width: 55
+					Height: 25
+					Text: Production
+				Label@INCMOD:
+					Align: Center
+					X: 245
+					Width: 55
+					Height: 25
+					Text: Income
+
+ScrollPanel@MOD_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT-27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 5
+					Width: 60
+					Height: 25
+

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -65,6 +65,31 @@ Container@SERVER_LOBBY:
 							Text: Ready
 							Align: Left
 							Font: Bold
+				Container@MODIFIERS_LABEL_CONTAINER:
+					X: 25
+					Y: 40
+					Children:
+						Label@LABEL_LOBBY_NAME:
+							X: 0
+							Width: 180
+							Height: 25
+							Text: Name
+							Align: Center
+							Font: Bold
+						Label@LABEL_LOBBY_PROD:
+							X: 180
+							Width: 130
+							Height: 25
+							Text: ProductionTime
+							Align: Center
+							Font: Bold
+						Label@LABEL_LOBBY_INC:
+							X: 380
+							Width: 130
+							Height: 25
+							Text: Income
+							Align: Center
+							Font: Bold
 				Container@PLAYER_BIN_ROOT:
 				DropDownButton@SLOTS_DROPDOWNBUTTON:
 					X: 15
@@ -75,8 +100,15 @@ Container@SERVER_LOBBY:
 				Button@OPTIONS_BUTTON:
 					X: 186
 					Y: 254
-					Width: 125
+					Width: 100
 					Height: 25
+				Button@MODIFIERS_BUTTON:
+					X: 291
+					Y: PARENT_BOTTOM - 291
+					Width: 20
+					Height: 25
+					Font: Bold
+					Text: ...
 				Button@CHANGEMAP_BUTTON:
 					X: 316
 					Y: 254

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -31,3 +31,42 @@ Player:
 	ProvidesTechPrerequisite@all:
 		Name: Unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
+	AttributeModifierManager@ProdBuildingGDI:
+		Type: Building.GDI
+		ModType: Production
+	AttributeModifierManager@ProdBuildingNod:
+		Type: Buildings.Nod
+		ModType: Production
+	AttributeModifierManager@ProdDefenceGDI:
+		Type: Defence.GDI
+		ModType: Production
+	AttributeModifierManager@ProdDefenceNod:
+		Type: Defence.Nod
+		ModType: Production
+	AttributeModifierManager@ProdInfantryGDI:
+		Type: Infantry.GDI
+		ModType: Production
+	AttributeModifierManager@ProdInfantryNod:
+		Type: Infantry.Nod
+		ModType: Production
+	AttributeModifierManager@ProdVehicleGDI:
+		Type: Vehicle.GDI
+		ModType: Production
+	AttributeModifierManager@ProdVehicleNod:
+		Type: Vehicle.Nod
+		ModType: Production
+	AttributeModifierManager@ProdAircraftGDI:
+		Type: Aircraft.GDI
+		ModType: Production
+	AttributeModifierManager@ProdAircraftNod:
+		Type: Aircraft.Nod
+		ModType: Production
+	AttributeModifierManager@IncHarvester:
+		Type: Harvester
+		ModType: Income
+	AttributeModifierManager@IncCashTrickler:
+		Type: CashTrickler
+		ModType: Income
+	AttributeModifierManager@IncBounty:
+		Type: Bounty
+		ModType: Income

--- a/mods/d2k/chrome/dropdowns.yaml
+++ b/mods/d2k/chrome/dropdowns.yaml
@@ -128,3 +128,18 @@ ScrollPanel@NEWS_PANEL:
 			Height: PARENT_BOTTOM
 			Align: Center
 			VAlign: Middle
+
+ScrollPanel@MOD_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT-27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 5
+					Width: 60
+					Height: 25

--- a/mods/d2k/chrome/lobby-playerbin.yaml
+++ b/mods/d2k/chrome/lobby-playerbin.yaml
@@ -343,3 +343,56 @@ ScrollPanel@RACE_DROPDOWN_TEMPLATE:
 					Width: 70
 					Height: 25
 
+ScrollPanel@LOBBY_PLAYERMODIFIERS_BIN:
+	X: 20
+	Y: 67
+	ItemSpacing: 5
+	Width: 593
+	Height: 235
+	Children:
+		Container@TEMPLATE_EDITABLE_PLAYER_MODIFIERS:
+			X: 5
+			Y: 0
+			Width: 475
+			Height: 25
+			Visible: false
+			Children:
+				Label@NAME:
+					Text: Name
+					X: 15
+					Width: 165
+					Height: 25
+				DropDownButton@PRODMOD:
+					X: 185
+					Width: 85
+					Height: 25
+					Text: Production
+				DropDownButton@INCMOD:
+					X: 275
+					Width: 85
+					Height: 25
+					Text: Income
+		Container@TEMPLATE_NONEDITABLE_PLAYER_MODIFIERS:
+			X: 5
+			Y: 0
+			Width: 475
+			Height: 25
+			Visible: false
+			Children:
+				Label@NAME:
+					Text: Name
+					X: 15
+					Width: 165
+					Height: 25
+				Label@PRODMOD:
+					X: 185
+					Width: 55
+					Height: 25
+					Text: Production
+				Label@INCMOD:
+					Align: Center
+					X: 245
+					Width: 55
+					Height: 25
+					Text: Income
+

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -66,3 +66,30 @@ Player:
 	ProvidesTechPrerequisite@all:
 		Name: Unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
+	AttributeModifierManager@ProdBuilding:
+		Type: Building
+		ModType: Production
+	AttributeModifierManager@ProdArmor:
+		Type: Armor
+		ModType: Production
+	AttributeModifierManager@ProdInfantry:
+		Type: Infantry
+		ModType: Production
+	AttributeModifierManager@ProdVehicle:
+		Type: Vehicle
+		ModType: Production
+	AttributeModifierManager@ProdStarport:
+		Type: Starport
+		ModType: Production
+	AttributeModifierManager@ProdAircraft:
+		Type: Aircraft
+		ModType: Production
+	AttributeModifierManager@IncHarvester:
+		Type: Harvester
+		ModType: Income
+	AttributeModifierManager@IncCashTrickler:
+		Type: CashTrickler
+		ModType: Income
+	AttributeModifierManager@IncBounty:
+		Type: Bounty
+		ModType: Income

--- a/mods/ra/chrome/dropdowns.yaml
+++ b/mods/ra/chrome/dropdowns.yaml
@@ -128,3 +128,18 @@ ScrollPanel@NEWS_PANEL:
 			Height: PARENT_BOTTOM
 			Align: Center
 			VAlign: Middle
+
+ScrollPanel@MOD_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT-27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 5
+					Width: 60
+					Height: 25

--- a/mods/ra/chrome/lobby-playerbin.yaml
+++ b/mods/ra/chrome/lobby-playerbin.yaml
@@ -343,3 +343,56 @@ ScrollPanel@RACE_DROPDOWN_TEMPLATE:
 					Width: 60
 					Height: 25
 
+
+ScrollPanel@LOBBY_PLAYERMODIFIERS_BIN:
+	X: 20
+	Y: 67
+	ItemSpacing: 5
+	Width: 593
+	Height: 235
+	Children:
+		Container@TEMPLATE_EDITABLE_PLAYER_MODIFIERS:
+			X: 5
+			Y: 0
+			Width: 475
+			Height: 25
+			Visible: false
+			Children:
+				Label@NAME:
+					Text: Name
+					X: 15
+					Width: 165
+					Height: 25
+				DropDownButton@PRODMOD:
+					X: 185
+					Width: 85
+					Height: 25
+					Text: Production
+				DropDownButton@INCMOD:
+					X: 275
+					Width: 85
+					Height: 25
+					Text: Income
+		Container@TEMPLATE_NONEDITABLE_PLAYER_MODIFIERS:
+			X: 5
+			Y: 0
+			Width: 475
+			Height: 25
+			Visible: false
+			Children:
+				Label@NAME:
+					Text: Name
+					X: 15
+					Width: 165
+					Height: 25
+				Label@PRODMOD:
+					X: 185
+					Width: 55
+					Height: 25
+					Text: Production
+				Label@INCMOD:
+					Align: Center
+					X: 245
+					Width: 55
+					Height: 25
+					Text: Income

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -62,6 +62,31 @@ Background@SERVER_LOBBY:
 					Text: Ready
 					Align: Left
 					Font: Bold
+		Container@MODIFIERS_LABEL_CONTAINER:
+			X: 25
+			Y: 40
+			Children:
+				Label@LABEL_LOBBY_NAME:
+					X: 0
+					Width: 180
+					Height: 25
+					Text: Name
+					Align: Center
+					Font: Bold
+				Label@LABEL_LOBBY_PROD:
+					X: 180
+					Width: 130
+					Height: 25
+					Text: ProductionTime
+					Align: Center
+					Font: Bold
+				Label@LABEL_LOBBY_INC:
+					X: 380
+					Width: 130
+					Height: 25
+					Text: Income
+					Align: Center
+					Font: Bold
 		Container@PLAYER_BIN_ROOT:
 		DropDownButton@SLOTS_DROPDOWNBUTTON:
 			X: 20
@@ -73,10 +98,17 @@ Background@SERVER_LOBBY:
 		Button@OPTIONS_BUTTON:
 			X: 194
 			Y: PARENT_BOTTOM - 291
-			Width: 135
+			Width: 100
 			Height: 25
 			Font: Bold
 			Text: Game Options
+		Button@MODIFIERS_BUTTON:
+			X: 299
+			Y: PARENT_BOTTOM - 291
+			Width: 32
+			Height: 25
+			Font: Bold
+			Text: ...
 		Button@CHANGEMAP_BUTTON:
 			X: 336
 			Y: PARENT_BOTTOM - 291

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -72,3 +72,31 @@ Player:
 	ProvidesTechPrerequisite@unrestricted:
 		Name: Unrestricted
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.unrestricted
+	AttributeModifierManager@ProdBuilding:
+		Type: Building
+		ModType: Production
+	AttributeModifierManager@ProdDefense:
+		Type: Defense
+		ModType: Production
+	AttributeModifierManager@ProdInfantry:
+		Type: Infantry
+		ModType: Production
+	AttributeModifierManager@ProdVehicle:
+		Type: Vehicle
+		ModType: Production
+	AttributeModifierManager@ProdShip:
+		Type: Ship
+		ModType: Production
+	AttributeModifierManager@ProdAircraft:
+		Type: Aircraft
+		ModType: Production
+	AttributeModifierManager@IncHarvester:
+		Type: Harvester
+		ModType: Income
+	AttributeModifierManager@IncCashTrickler:
+		Type: CashTrickler
+		ModType: Income
+	AttributeModifierManager@IncBounty:
+		Type: Bounty
+		ModType: Income
+		

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -44,4 +44,28 @@ Player:
 	BaseAttackNotifier:
 	PlayerStatistics:
 	PlaceBeacon:
+	AttributeModifierManager@ProdBuilding:
+		Type: Building
+		ModType: Production
+	AttributeModifierManager@ProdDefense:
+		Type: Defense
+		ModType: Production
+	AttributeModifierManager@ProdInfantry:
+		Type: Infantry
+		ModType: Production
+	AttributeModifierManager@ProdVehicle:
+		Type: Vehicle
+		ModType: Production
+	AttributeModifierManager@ProdShip:
+		Type: Air
+		ModType: Production
+	AttributeModifierManager@IncHarvester:
+		Type: Harvester
+		ModType: Income
+	AttributeModifierManager@IncCashTrickler:
+		Type: CashTrickler
+		ModType: Income
+	AttributeModifierManager@IncBounty:
+		Type: Bounty
+		ModType: Income
 


### PR DESCRIPTION
Meant to close #6103.

This functional (but sickly) PR allows you to select production time and income modifiers per player in the lobby.

But the chrome work I did for it is an **ugly abomination**, and I need input into what would be the best way to lay it out and display it.

It is, however, somewhat functional. Classic production queues work for all mods, and income modifiers work for all mods.

But C&C:TD style production queues do not currently seem to like fetching the production time modifier from the player actor. Busy looking into this.

I did do a "multiplayer" test between two clients on my machine and did not get any desyncs, so that at least is a good start.
Skirmish tests also worked fine.
