### PR TITLE
Avoid sending the map change order when selecting the same map.  

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -150,6 +150,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				{
 					var onSelect = new Action<string>(uid =>
 					{
+						// Don't select the same map again
+						if (uid == Map.Uid)
+							return;
+
 						orderManager.IssueOrder(Order.Command("map " + uid));
 						Game.Settings.Server.Map = uid;
 						Game.Settings.Save();


### PR DESCRIPTION
Fixes #6206.

Switching the map causes the client state to be changed to `Invalid`.  `UpdateCurrentMap` would normally verify that the map exists and then change the client state back to `NotReady`, but this check is skipped when switching to the same map.  If the game is then started with the force-start button, the server will notice that all of the players have an `Invalid` state and kick them as if they did not have the map.

Preventing the initial map order from being issued avoids this.
