### PR TITLE
Remove actors without counting deaths and kills

### DIFF
--- a/OpenRA.Mods.RA/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.RA/Player/PlayerStatistics.cs
@@ -116,6 +116,9 @@ namespace OpenRA.Mods.RA
 	{
 		public void Killed(Actor self, AttackInfo e)
 		{
+			if (self.Owner.WinState != WinState.Undefined)
+				return;
+
 			var attackerStats = e.Attacker.Owner.PlayerActor.Trait<PlayerStatistics>();
 			var defenderStats = self.Owner.PlayerActor.Trait<PlayerStatistics>();
 			if (self.HasTrait<Building>())


### PR DESCRIPTION
Would fix #6223.

But this fix will prevent husks and deathbuildingstates etc. from being shown.
