### PR TITLE
Change replay to serverside

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -40,6 +40,7 @@ namespace OpenRA
 
 		public static Renderer Renderer;
 		public static bool HasInputFocus = false;
+		public static bool IsSimulating = false;
 
 		public static DatabaseReader GeoIpDatabase;
 
@@ -592,8 +593,8 @@ namespace OpenRA
 					var haveSomeTimeUntilNextLogic = now < nextLogic;
 					var isTimeToRender = now >= nextRender;
 					var forceRender = now >= forcedNextRender;
-
-					if ((isTimeToRender && haveSomeTimeUntilNextLogic) || forceRender)
+					
+					if (((isTimeToRender && haveSomeTimeUntilNextLogic) || forceRender) && !IsSimulating)
 					{
 						nextRender = now + renderInterval;
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -580,6 +580,8 @@ namespace OpenRA
 				var nextUpdate = Math.Min(nextLogic, nextRender);
 				if (now >= nextUpdate)
 				{
+					if (IsHost && server != null)
+						server.Tick(NetFrameNumber);
 					if (now >= nextLogic)
 					{
 						nextLogic += logicInterval;

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Network
 
 	public interface IConnection : IDisposable
 	{
+		bool DisableSend { get; set; }
 		int LocalClientId { get; }
 		ConnectionState ConnectionState { get; }
 		void Send(int frame, List<byte[]> orders);
@@ -38,6 +39,8 @@ namespace OpenRA.Network
 
 	class EchoConnection : IConnection
 	{
+		public bool DisableSend { get; set; }
+
 		protected struct ReceivedPacket
 		{
 			public int FromClient;
@@ -57,6 +60,9 @@ namespace OpenRA.Network
 
 		public virtual void Send(int frame, List<byte[]> orders)
 		{
+			//Ignore local orders when DisableSend is true
+			if (DisableSend)
+				return;
 			var ms = new MemoryStream();
 			ms.Write(BitConverter.GetBytes(frame));
 			foreach (var o in orders)
@@ -66,6 +72,9 @@ namespace OpenRA.Network
 
 		public virtual void SendImmediate(List<byte[]> orders)
 		{
+			//Ignore local orders when DisableSend is true
+			if (DisableSend)
+				return;
 			var ms = new MemoryStream();
 			ms.Write(BitConverter.GetBytes((int)0));
 			foreach (var o in orders)

--- a/OpenRA.Game/Network/ReplayRecorderConnection.cs
+++ b/OpenRA.Game/Network/ReplayRecorderConnection.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Network
 		}
 
 		IConnection inner;
+		FileStream file;
 		BinaryWriter writer;
 		Func<string> chooseFilename;
 		MemoryStream preStartBuffer = new MemoryStream();
@@ -67,7 +68,8 @@ namespace OpenRA.Network
 			}
 
 			file.Write(initialContent);
-			this.writer = new BinaryWriter(file);
+			this.file = file;
+			this.writer = new BinaryWriter(this.file);
 		}
 
 		public int LocalClientId { get { return inner.LocalClientId; } }
@@ -105,6 +107,38 @@ namespace OpenRA.Network
 
 			var frame = BitConverter.ToInt32(data, 0);
 			return frame == 0 && data.ToOrderList(null).Any(o => o.OrderString == "StartGame");
+		}
+
+		public void SaveToFile(string path, string filename)
+		{
+			if (!Directory.Exists(path))
+				Directory.CreateDirectory(path);
+
+			FileStream file = null;
+			var id = -1;
+			while (file == null)
+			{
+				var fullFilename = Path.Combine(path, id < 0 ? "{0}.orasave".F(filename) : "{0}-{1}.orasave".F(filename, id));
+				id++;
+				try
+				{
+					file = File.Create(fullFilename);
+				}
+				catch (IOException) { }
+			}
+
+			this.file.Position = 0;
+			this.file.CopyTo(file);
+			var writer = new BinaryWriter(file);
+
+			if (Metadata != null)
+			{
+				if (Metadata.GameInfo != null)
+					Metadata.GameInfo.EndTimeUtc = DateTime.UtcNow;
+				Metadata.Write(writer);
+			}
+
+			writer.Close();
 		}
 
 		bool disposed;

--- a/OpenRA.Game/Network/ReplayRecorderConnection.cs
+++ b/OpenRA.Game/Network/ReplayRecorderConnection.cs
@@ -19,6 +19,17 @@ namespace OpenRA.Network
 	sealed class ReplayRecorderConnection : IConnection
 	{
 		public ReplayMetadata Metadata;
+		public bool DisableSend
+		{
+			get
+			{
+				return inner.DisableSend;
+			}
+			set
+			{
+				inner.DisableSend = value;
+			}
+		}
 
 		IConnection inner;
 		BinaryWriter writer;

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -190,6 +190,7 @@ namespace OpenRA.Network
 			public string StartingUnitsClass = "none";
 			public bool AllowVersionMismatch;
 			public string GameUid;
+			public bool AllowConfiguration = true;
 
 			public MiniYamlNode Serialize()
 			{

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -127,11 +127,6 @@ namespace OpenRA.Network
 						else
 						{
 							orderManager.Connection.DisableSend = false;
-							if (orderManager.world != null)
-							{
-								orderManager.world.Paused = false;
-								orderManager.world.PredictedPaused = false;
-							}
 							Game.IsSimulating = false;
 						}
 						break;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -118,9 +118,22 @@ namespace OpenRA.Network
 				case "SendPermission":
 					{
 						if (order.TargetString == "Disable")
+						{
 							orderManager.Connection.DisableSend = true;
+							//Disabled for testing
+							//Game.IsSimulating = true;
+							break;
+						}
 						else
+						{
 							orderManager.Connection.DisableSend = false;
+							if (orderManager.world != null)
+							{
+								orderManager.world.Paused = false;
+								orderManager.world.PredictedPaused = false;
+							}
+							Game.IsSimulating = false;
+						}
 						break;
 					}
 

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -115,6 +115,15 @@ namespace OpenRA.Network
 						break;
 					}
 
+				case "SendPermission":
+					{
+						if (order.TargetString == "Disable")
+							orderManager.Connection.DisableSend = true;
+						else
+							orderManager.Connection.DisableSend = false;
+						break;
+					}
+
 				case "HandshakeRequest":
 					{
 						// TODO: Switch to the server's mod if we have it

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -117,12 +117,14 @@ namespace OpenRA.Network
 
 				case "SendPermission":
 					{
-						if (order.TargetString == "Disable")
+						if (order.TargetString == "DisableNoSim")
 						{
 							orderManager.Connection.DisableSend = true;
-							//Disabled for testing
-							//Game.IsSimulating = true;
-							break;
+						}
+						else if (order.TargetString == "DisableSim")
+						{
+							orderManager.Connection.DisableSend = true;
+							Game.IsSimulating = true;
 						}
 						else
 						{

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Server\Connection.cs" />
     <Compile Include="Server\Exts.cs" />
     <Compile Include="Server\ProtocolVersion.cs" />
+    <Compile Include="Server\ReplayViewer.cs" />
     <Compile Include="Server\Server.cs" />
     <Compile Include="Server\ServerOrder.cs" />
     <Compile Include="Server\TraitInterfaces.cs" />

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -93,8 +93,12 @@ namespace OpenRA.Server
 						DispatchReplayOrdersToClient(c, r.First, r.Second);
 
 				if (Settings.Replay.ReplayDone)
+				{
 					foreach (var c in Conns.ToArray())
 						SendOrderTo(c, "SendPermission", "Enable");
+					Settings.Replay = null;
+					return;
+				}
 
 				/*var from = conn != null ? conn.PlayerIndex : 0;
 				foreach (var c in Conns.Except(conn).ToArray())

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -95,7 +95,10 @@ namespace OpenRA.Server
 				if (Settings.Replay.ReplayDone)
 				{
 					foreach (var c in Conns.ToArray())
+					{
 						SendOrderTo(c, "SendPermission", "Enable");
+						SendOrderTo(c, "PauseGame", "UnPause");
+					}
 					Settings.Replay = null;
 					return;
 				}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -82,6 +82,26 @@ namespace OpenRA.Server
 
 		public List<string> TempBans = new List<string>();
 
+		public void Tick(int frame)
+		{
+			if (Settings.Replay != null && State == ServerState.GameStarted)
+			{
+				var replayData = Settings.Replay.GetNextData(frame + LobbyInfo.GlobalSettings.OrderLatency);
+
+				foreach (var r in replayData)
+					foreach (var c in Conns.ToArray())
+						DispatchReplayOrdersToClient(c, r.First, r.Second);
+
+				if (Settings.Replay.ReplayDone)
+					foreach (var c in Conns.ToArray())
+						SendOrderTo(c, "SendPermission", "Enable");
+
+				/*var from = conn != null ? conn.PlayerIndex : 0;
+				foreach (var c in Conns.Except(conn).ToArray())
+					DispatchOrdersToClient(c, from, frame, data);*/
+			}
+		}
+
 		public void Shutdown()
 		{
 			State = ServerState.ShuttingDown;
@@ -379,6 +399,21 @@ namespace OpenRA.Server
 				inFlightFrames.Remove(conn.Frame);
 		}
 
+		void DispatchReplayOrdersToClient(Connection c, int client, byte[] data)
+		{
+			try
+			{
+				SendData(c.socket, BitConverter.GetBytes(data.Length));
+				SendData(c.socket, BitConverter.GetBytes(client));
+				SendData(c.socket, data);
+			}
+			catch (Exception e)
+			{
+				DropClient(c);
+				Log.Write("server", "Dropping client {0} because dispatching orders failed: {1}", client.ToString(), e);
+			}
+		}
+
 		void DispatchOrdersToClient(Connection c, int client, int frame, byte[] data)
 		{
 			try
@@ -662,8 +697,12 @@ namespace OpenRA.Server
 			State = ServerState.GameStarted;
 
 			foreach (var c in Conns)
+			{
 				foreach (var d in Conns)
 					DispatchOrdersToClient(c, d.PlayerIndex, 0x7FFFFFFF, new byte[] { 0xBF });
+				if (Settings.Replay != null && !Settings.Replay.ReplayDone)
+					SendOrderTo(c, "SendPermission", "Disable");
+			}
 
 			DispatchOrders(null, 0,
 				new ServerOrder("StartGame", "").Serialize());

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -94,18 +94,8 @@ namespace OpenRA.Server
 
 				if (Settings.Replay.ReplayDone)
 				{
-					foreach (var c in Conns.ToArray())
-					{
-						SendOrderTo(c, "SendPermission", "Enable");
-						SendOrderTo(c, "PauseGame", "UnPause");
-					}
 					Settings.Replay = null;
-					return;
 				}
-
-				/*var from = conn != null ? conn.PlayerIndex : 0;
-				foreach (var c in Conns.Except(conn).ToArray())
-					DispatchOrdersToClient(c, from, frame, data);*/
 			}
 		}
 
@@ -708,7 +698,12 @@ namespace OpenRA.Server
 				foreach (var d in Conns)
 					DispatchOrdersToClient(c, d.PlayerIndex, 0x7FFFFFFF, new byte[] { 0xBF });
 				if (Settings.Replay != null && !Settings.Replay.ReplayDone)
-					SendOrderTo(c, "SendPermission", "Disable");
+				{
+					if (Settings.Replay.Resume)
+						SendOrderTo(c, "SendPermission", "DisableSim");
+					else
+						SendOrderTo(c, "SendPermission", "DisableNoSim");
+				}
 			}
 
 			DispatchOrders(null, 0,

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using OpenRA.Graphics;
+using OpenRA.Server;
 
 namespace OpenRA
 {
@@ -32,6 +33,7 @@ namespace OpenRA
 		public bool VerboseNatDiscovery = false; // print very detailed logs for debugging
 		public bool AllowCheats = false;
 		public string Map = null;
+		public ReplayViewer Replay = null;
 		public string[] Ban = { };
 		public int TimeOut = 0;
 		public bool Dedicated = false;

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -247,7 +247,7 @@ namespace OpenRA
 		{
 			get
 			{
-				return Game.Settings.Sound.SoundVolume;
+				return Game.IsSimulating ? 0f : Game.Settings.Sound.SoundVolume;
 			}
 
 			set
@@ -261,7 +261,7 @@ namespace OpenRA
 		{
 			get
 			{
-				return Game.Settings.Sound.MusicVolume;
+				return Game.IsSimulating ? 0f : Game.Settings.Sound.MusicVolume;
 			}
 
 			set
@@ -276,7 +276,7 @@ namespace OpenRA
 		{
 			get
 			{
-				return Game.Settings.Sound.VideoVolume;
+				return Game.IsSimulating ? 0f : Game.Settings.Sound.VideoVolume;
 			}
 
 			set

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -94,6 +94,16 @@ namespace OpenRA
 			get { return orderManager.Connection is ReplayConnection; }
 		}
 
+		public bool CanSave()
+		{
+			return orderManager.Connection is ReplayRecorderConnection;
+		}
+
+		public void Save(string directory, string filename)
+		{
+			this.AddFrameEndTask((w) => ((ReplayRecorderConnection)orderManager.Connection).SaveToFile(directory, filename));
+		}
+
 		public bool AllowDevCommands
 		{
 			get { return LobbyInfo.GlobalSettings.AllowCheats || LobbyInfo.IsSinglePlayer; }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -30,7 +30,12 @@ namespace OpenRA
 		readonly List<IEffect> effects = new List<IEffect>();
 		readonly Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
 
-		public int Timestep;
+		int timestep;
+		public int Timestep
+		{
+			get { return Game.IsSimulating ? 1 : timestep; }
+			set { timestep = value; }
+		}
 
 		internal readonly OrderManager orderManager;
 		public Session LobbyInfo { get { return orderManager.LobbyInfo; } }

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -292,6 +292,7 @@
     <Compile Include="Warheads\CreateEffectWarhead.cs" />
     <Compile Include="Warheads\CreateResourceWarhead.cs" />
     <Compile Include="Warheads\LeaveSmudgeWarhead.cs" />
+    <Compile Include="Widgets\Logic\SaveBrowserLogic.cs" />
     <Compile Include="World\RadarPings.cs" />
     <Compile Include="Player\TechTree.cs" />
     <Compile Include="PrimaryBuilding.cs" />

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -328,6 +328,7 @@ namespace OpenRA.Mods.RA.Server
 						}
 
 						server.LobbyInfo.GlobalSettings.Map = s;
+						server.Settings.Replay = null;
 
 						var oldSlots = server.LobbyInfo.Slots.Keys.ToArray();
 						LoadMap(server);

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				orderManager.LocalClient == null || orderManager.LocalClient.IsReady;
 
 			var mapButton = lobby.GetOrNull<ButtonWidget>("CHANGEMAP_BUTTON");
-			/*if (mapButton != null)
+			if (mapButton != null)
 			{
 				mapButton.IsDisabled = configurationDisabled; 
 				mapButton.OnClick = () =>
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 						orderManager.IssueOrder(Order.Command("map " + uid));
 						Game.Settings.Server.Map = uid;
-						Game.Settings.Server.Save = null;
+						Game.Settings.Server.Replay = null;
 						Game.Settings.Save();
 					});
 
@@ -168,18 +168,17 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						{ "onSelect", onSelect }
 					});
 				};
-			}*/
+			}
 
 			var loadButton = lobby.GetOrNull<ButtonWidget>("LOAD_BUTTON");
-			if (mapButton != null)
+			if (loadButton != null)
 			{
-				mapButton.IsDisabled = configurationDisabled;
-				mapButton.OnClick = () =>
+				loadButton.IsDisabled = configurationDisabled;
+				loadButton.OnClick = () =>
 				{
 					var onLoad = new Action<ReplayMetadata>(save =>
 					{
 						orderManager.IssueOrder(Order.Command("load " + save.FilePath));
-						//orderManager.IssueOrder(Order.Command("save " + save.FilePath));
 						Game.Settings.Server.Map = save.GameInfo.MapUid;
 						Game.Settings.Server.Replay = new OpenRA.Server.ReplayViewer(save.FilePath);
 						Game.Settings.Save();

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					{
 						orderManager.IssueOrder(Order.Command("load " + save.FilePath));
 						Game.Settings.Server.Map = save.GameInfo.MapUid;
-						Game.Settings.Server.Replay = new OpenRA.Server.ReplayViewer(save.FilePath);
+						Game.Settings.Server.Replay = new OpenRA.Server.ReplayViewer(save.FilePath, true);
 						Game.Settings.Save();
 					});
 

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Threading;
+using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Traits;
@@ -143,7 +144,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				orderManager.LocalClient == null || orderManager.LocalClient.IsReady;
 
 			var mapButton = lobby.GetOrNull<ButtonWidget>("CHANGEMAP_BUTTON");
-			if (mapButton != null)
+			/*if (mapButton != null)
 			{
 				mapButton.IsDisabled = configurationDisabled; 
 				mapButton.OnClick = () =>
@@ -156,6 +157,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 						orderManager.IssueOrder(Order.Command("map " + uid));
 						Game.Settings.Server.Map = uid;
+						Game.Settings.Server.Save = null;
 						Game.Settings.Save();
 					});
 
@@ -164,6 +166,30 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						{ "initialMap", Map.Uid },
 						{ "onExit", DoNothing },
 						{ "onSelect", onSelect }
+					});
+				};
+			}*/
+
+			var loadButton = lobby.GetOrNull<ButtonWidget>("LOAD_BUTTON");
+			if (mapButton != null)
+			{
+				mapButton.IsDisabled = configurationDisabled;
+				mapButton.OnClick = () =>
+				{
+					var onLoad = new Action<ReplayMetadata>(save =>
+					{
+						orderManager.IssueOrder(Order.Command("load " + save.FilePath));
+						//orderManager.IssueOrder(Order.Command("save " + save.FilePath));
+						Game.Settings.Server.Map = save.GameInfo.MapUid;
+						Game.Settings.Server.Replay = new OpenRA.Server.ReplayViewer(save.FilePath);
+						Game.Settings.Save();
+					});
+
+					Ui.OpenWindow("SAVEBROWSER_PANEL", new WidgetArgs
+					{
+						{ "onLoad",  onLoad},
+						{ "onExit",  DoNothing},
+						{ "filter", SaveBrowserLogic.GameType.Any }
 					});
 				};
 			}

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -23,6 +23,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 {
 	public class LobbyLogic
 	{
+		public enum LobbyType { All, Server, Load };
+
 		static readonly Action DoNothing = () => { };
 
 		public MapPreview Map = MapCache.UnknownMap;
@@ -91,7 +93,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		[ObjectCreator.UseCtor]
 		internal LobbyLogic(Widget widget, WorldRenderer worldRenderer, OrderManager orderManager,
-			Action onExit, Action onStart, bool skirmishMode, Ruleset modRules)
+			Action onExit, Action onStart, LobbyType lobbyType, bool skirmishMode, Ruleset modRules)
 		{
 			lobby = widget;
 			this.orderManager = orderManager;
@@ -146,6 +148,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var mapButton = lobby.GetOrNull<ButtonWidget>("CHANGEMAP_BUTTON");
 			if (mapButton != null)
 			{
+				mapButton.IsVisible = () => lobbyType == LobbyType.Server || lobbyType == LobbyType.All;
 				mapButton.IsDisabled = configurationDisabled; 
 				mapButton.OnClick = () =>
 				{
@@ -173,6 +176,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var loadButton = lobby.GetOrNull<ButtonWidget>("LOAD_BUTTON");
 			if (loadButton != null)
 			{
+				loadButton.IsVisible = () => lobbyType == LobbyType.Load || lobbyType == LobbyType.All;
 				loadButton.IsDisabled = configurationDisabled;
 				loadButton.OnClick = () =>
 				{
@@ -188,7 +192,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					{
 						{ "onLoad",  onLoad},
 						{ "onExit",  DoNothing},
-						{ "filter", SaveBrowserLogic.GameType.Any }
+						{ "filter", skirmishMode ? SaveBrowserLogic.GameType.Singleplayer : SaveBrowserLogic.GameType.Multiplayer }
 					});
 				};
 			}
@@ -564,6 +568,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					if (slot != null && bot != null)
 						orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot, botController.Index, bot)));
 				});
+			}
+
+			if (lobbyType == LobbyType.Load)
+			{
+				/* 
+				 * Needs a way to display an unknown map on startup so we
+				 * dont load a normal game each time, would also like to have
+				 * only spectator slots availible until a save has been chosen.
+				 */
 			}
 		}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		ReplayMetadata selectedSave;
 
 		[ObjectCreator.UseCtor]
-		public SaveBrowserLogic(Widget widget, Action onExit, Action<ReplayMetadata> onLoad)
+		public SaveBrowserLogic(Widget widget, Action onExit, Action<ReplayMetadata> onLoad, GameType filter)
 		{
 			this.onLoad = onLoad;
 			panel = widget;
@@ -98,6 +98,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				type.GetText = () => selectedSave.GameInfo.MapPreview.Type;
 
 			panel.Get<LabelWidget>("DURATION").GetText = () => WidgetUtils.FormatTimeSeconds((int)selectedSave.GameInfo.Duration.TotalSeconds);
+
+			ApplyFilter(filter);
 
 			SetupManagement();
 		}

--- a/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
@@ -1,0 +1,366 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using OpenRA.FileFormats;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Network;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.RA.Widgets.Logic
+{
+	public class SaveBrowserLogic
+	{
+		Widget panel;
+		ScrollPanelWidget saveList, playerList;
+		ScrollItemWidget playerTemplate, playerHeader;
+		List<ReplayMetadata> saves;
+		Dictionary<ReplayMetadata, SaveState> saveState = new Dictionary<ReplayMetadata, SaveState>();
+		Action<ReplayMetadata> onLoad;
+		ScrollPanelWidget descriptionPanel;
+		LabelWidget descriptionLabel;
+		SpriteFont descriptionFont;
+
+		Dictionary<CPos, SpawnOccupant> selectedSpawns;
+		ReplayMetadata selectedSave;
+
+		[ObjectCreator.UseCtor]
+		public SaveBrowserLogic(Widget widget, Action onExit, Action<ReplayMetadata> onLoad, GameType filter)
+		{
+			this.onLoad = onLoad;
+			panel = widget;
+
+			playerList = panel.Get<ScrollPanelWidget>("PLAYER_LIST");
+			playerHeader = playerList.Get<ScrollItemWidget>("HEADER");
+			playerTemplate = playerList.Get<ScrollItemWidget>("TEMPLATE");
+			playerList.RemoveChildren();
+
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
+
+			saveList = panel.Get<ScrollPanelWidget>("SAVE_LIST");
+			var template = panel.Get<ScrollItemWidget>("SAVE_TEMPLATE");
+			descriptionPanel = panel.Get<ScrollPanelWidget>("SAVE_DESCRIPTION_PANEL");
+			descriptionLabel = descriptionPanel.Get<LabelWidget>("SAVE_DESCRIPTION");
+			descriptionFont = Game.Renderer.Fonts[descriptionLabel.Font];
+
+			var mod = Game.modData.Manifest.Mod;
+			var dir = new[] { Platform.SupportDir, "Saves", mod.Id, mod.Version }.Aggregate(Path.Combine);
+
+			saveList.RemoveChildren();
+			if (Directory.Exists(dir))
+			{
+				using (new Support.PerfTimer("Load saves"))
+				{
+					saves = Directory
+						.GetFiles(dir, "*.orasave")
+						.Select(ReplayMetadata.Read)
+						.Where(r => r != null)
+						.OrderByDescending(r => r.GameInfo.StartTimeUtc)
+						.ToList();
+				}
+
+				foreach (var save in saves)
+					AddSave(save, template);
+
+				SelectFirstVisibleSave();
+			}
+			else
+				saves = new List<ReplayMetadata>();
+
+			var load = panel.Get<ButtonWidget>("LOAD_BUTTON");
+			load.IsDisabled = () => selectedSave == null || selectedSave.GameInfo.MapPreview.Status != MapStatus.Available;
+			load.OnClick = () => { Ui.CloseWindow(); onLoad(selectedSave); };
+
+			panel.Get("SAVE_INFO").IsVisible = () => selectedSave != null;
+
+			var preview = panel.Get<MapPreviewWidget>("MAP_PREVIEW");
+			preview.SpawnOccupants = () => selectedSpawns;
+			preview.Preview = () => selectedSave != null ? selectedSave.GameInfo.MapPreview : null;
+
+			var title = panel.GetOrNull<LabelWidget>("MAP_TITLE");
+			if (title != null)
+				title.GetText = () => selectedSave != null ? selectedSave.GameInfo.MapPreview.Title : null;
+
+			var type = panel.GetOrNull<LabelWidget>("MAP_TYPE");
+			if (type != null)
+				type.GetText = () => selectedSave.GameInfo.MapPreview.Type;
+
+			panel.Get<LabelWidget>("DURATION").GetText = () => WidgetUtils.FormatTimeSeconds((int)selectedSave.GameInfo.Duration.TotalSeconds);
+
+			SetupManagement();
+		}
+
+		void ApplyFilter(GameType type)
+		{
+			foreach (var save in saves)
+				saveState[save].Visible = EvaluateSaveVisibility(save, type);
+
+			if (selectedSave == null || saveState[selectedSave].Visible == false)
+				SelectFirstVisibleSave();
+
+			saveList.Layout.AdjustChildren();
+		}
+
+		bool EvaluateSaveVisibility(ReplayMetadata replay, GameType type)
+		{
+			// Game type
+			if ((type == GameType.Multiplayer && replay.GameInfo.IsSinglePlayer) || (type == GameType.Singleplayer && !replay.GameInfo.IsSinglePlayer))
+				return false;
+			return true;
+		}
+
+		void SetupManagement()
+		{
+			{
+				var button = panel.Get<ButtonWidget>("MNG_RENSEL_BUTTON");
+				button.IsDisabled = () => selectedSave == null;
+				button.OnClick = () =>
+				{
+					var r = selectedSave;
+					var initialName = Path.GetFileNameWithoutExtension(r.FilePath);
+					var directoryName = Path.GetDirectoryName(r.FilePath);
+					var invalidChars = Path.GetInvalidFileNameChars();
+
+					ConfirmationDialogs.TextInputPrompt(
+						"Rename Save",
+						"Enter a new file name:",
+						initialName,
+						onAccept: newName => RenameSave(r, newName),
+						onCancel: null,
+						acceptText: "Rename",
+						cancelText: null,
+						inputValidator: newName =>
+						{
+							if (newName == initialName)
+								return false;
+
+							if (string.IsNullOrWhiteSpace(newName))
+								return false;
+
+							if (newName.IndexOfAny(invalidChars) >= 0)
+								return false;
+
+							if (File.Exists(Path.Combine(directoryName, newName)))
+								return false;
+
+							return true;
+						});
+				};
+			}
+
+			Action<ReplayMetadata, Action> onDeleteSave = (r, after) =>
+			{
+				ConfirmationDialogs.PromptConfirmAction(
+					"Delete selected save?",
+					"Delete save '{0}'?".F(Path.GetFileNameWithoutExtension(r.FilePath)),
+					() =>
+					{
+						DeleteSave(r);
+						if (after != null)
+							after.Invoke();
+					},
+					null,
+					"Delete");
+			};
+
+			{
+				var button = panel.Get<ButtonWidget>("MNG_DELSEL_BUTTON");
+				button.IsDisabled = () => selectedSave == null;
+				button.OnClick = () =>
+				{
+					onDeleteSave(selectedSave, () =>
+					{
+						if (selectedSave == null)
+							SelectFirstVisibleSave();
+					});
+				};
+			}
+
+			{
+				var button = panel.Get<ButtonWidget>("MNG_DELALL_BUTTON");
+				button.IsDisabled = () => saveState.Count(kvp => kvp.Value.Visible) == 0;
+				button.OnClick = () =>
+				{
+					var list = saveState.Where(kvp => kvp.Value.Visible).Select(kvp => kvp.Key).ToList();
+					if (list.Count == 0)
+						return;
+
+					if (list.Count == 1)
+					{
+						onDeleteSave(list[0], () => { if (selectedSave == null) SelectFirstVisibleSave(); });
+						return;
+					}
+
+					ConfirmationDialogs.PromptConfirmAction(
+						"Delete all selected saves?",
+						"Delete {0} saves?".F(list.Count),
+						() =>
+						{
+							list.ForEach(DeleteSave);
+							if (selectedSave == null)
+								SelectFirstVisibleSave();
+						},
+						null,
+						"Delete All");
+				};
+			}
+		}
+
+		void RenameSave(ReplayMetadata save, string newFilenameWithoutExtension)
+		{
+			try
+			{
+				save.RenameFile(newFilenameWithoutExtension);
+				saveState[save].Item.Text = newFilenameWithoutExtension;
+			}
+			catch (Exception ex)
+			{
+				Log.Write("debug", ex.ToString());
+				return;
+			}
+		}
+
+		void DeleteSave(ReplayMetadata save)
+		{
+			try
+			{
+				File.Delete(save.FilePath);
+			}
+			catch (Exception ex)
+			{
+				Game.Debug("Failed to delete save file '{0}'. See the logs for details.", save.FilePath);
+				Log.Write("debug", ex.ToString());
+				return;
+			}
+
+			if (save == selectedSave)
+				SelectSave(null);
+
+			saveList.RemoveChild(saveState[save].Item);
+			saves.Remove(save);
+			saveState.Remove(save);
+		}
+
+		void SelectFirstVisibleSave()
+		{
+			SelectSave(saves.FirstOrDefault(s => saveState[s].Visible));
+		}
+
+		void SelectSave(ReplayMetadata save)
+		{
+			selectedSave = save;
+			selectedSpawns = (selectedSave != null)
+				? LobbyUtils.GetSpawnOccupants(selectedSave.GameInfo.Players, selectedSave.GameInfo.MapPreview)
+				: new Dictionary<CPos, SpawnOccupant>();
+
+			if (save == null)
+				return;
+
+			try
+			{
+				var players = save.GameInfo.Players
+					.GroupBy(p => p.Team)
+					.OrderBy(g => g.Key);
+
+				var teams = new Dictionary<string, IEnumerable<GameInformation.Player>>();
+				var noTeams = players.Count() == 1;
+				foreach (var p in players)
+				{
+					var label = noTeams ? "Players" : p.Key == 0 ? "No Team" : "Team {0}".F(p.Key);
+					teams.Add(label, p);
+				}
+
+				playerList.RemoveChildren();
+
+				foreach (var kv in teams)
+				{
+					var group = kv.Key;
+					if (group.Length > 0)
+					{
+						var header = ScrollItemWidget.Setup(playerHeader, () => true, () => { });
+						header.Get<LabelWidget>("LABEL").GetText = () => group;
+						playerList.AddChild(header);
+					}
+
+					foreach (var option in kv.Value)
+					{
+						var o = option;
+
+						var color = o.Color.RGB;
+
+						var item = ScrollItemWidget.Setup(playerTemplate, () => false, () => { });
+
+						var label = item.Get<LabelWidget>("LABEL");
+						label.GetText = () => o.Name;
+						label.GetColor = () => color;
+
+						var flag = item.Get<ImageWidget>("FLAG");
+						flag.GetImageCollection = () => "flags";
+						flag.GetImageName = () => o.FactionId;
+
+						playerList.AddChild(item);
+					}
+				}
+
+				if (selectedSave.GameInfo.MapPreview.Status == MapStatus.Available)
+				{
+					var text = selectedSave.GameInfo.MapPreview.Map.Description != null ? selectedSave.GameInfo.MapPreview.Map.Description.Replace("\\n", "\n") : "";
+					text = WidgetUtils.WrapText(text, descriptionLabel.Bounds.Width, descriptionFont);
+					descriptionLabel.Text = text;
+					descriptionLabel.Bounds.Height = descriptionFont.Measure(text).Y;
+					descriptionPanel.ScrollToTop();
+					descriptionPanel.Layout.AdjustChildren();
+				}
+			}
+			catch (Exception e)
+			{
+				Log.Write("debug", "Exception while parsing save: {0}", e);
+				SelectSave(null);
+			}
+		}
+
+		void AddSave(ReplayMetadata save, ScrollItemWidget template)
+		{
+			var item = ScrollItemWidget.Setup(template,
+				() => selectedSave == save,
+				() => SelectSave(save),
+				() => { onLoad(save); Ui.CloseWindow(); });
+
+			saveState[save] = new SaveState
+			{
+				Item = item,
+				Visible = true
+			};
+
+			item.Text = Path.GetFileNameWithoutExtension(save.FilePath);
+			item.Get<LabelWidget>("TITLE").GetText = () => item.Text;
+			item.IsVisible = () => saveState[save].Visible;
+			saveList.AddChild(item);
+		}
+
+		class SaveState
+		{
+			public bool Visible;
+			public ScrollItemWidget Item;
+		}
+
+		public enum GameType
+		{
+			Any,
+			Singleplayer,
+			Multiplayer
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
@@ -28,8 +28,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		ScrollItemWidget playerTemplate, playerHeader;
 		List<ReplayMetadata> saves;
 		Dictionary<ReplayMetadata, SaveState> saveState = new Dictionary<ReplayMetadata, SaveState>();
-		Action<ReplayMetadata> onLoad;
 		ScrollPanelWidget descriptionPanel;
+		Action<ReplayMetadata> onLoad;
 		LabelWidget descriptionLabel;
 		SpriteFont descriptionFont;
 
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		ReplayMetadata selectedSave;
 
 		[ObjectCreator.UseCtor]
-		public SaveBrowserLogic(Widget widget, Action onExit, Action<ReplayMetadata> onLoad, GameType filter)
+		public SaveBrowserLogic(Widget widget, Action onExit, Action<ReplayMetadata> onLoad)
 		{
 			this.onLoad = onLoad;
 			panel = widget;
@@ -336,7 +336,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var item = ScrollItemWidget.Setup(template,
 				() => selectedSave == save,
 				() => SelectSave(save),
-				() => { onLoad(save); Ui.CloseWindow(); });
+				() => { Ui.CloseWindow(); onLoad(save); });
 
 			saveState[save] = new SaveState
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -64,9 +64,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			refreshButton.GetText = () => searchStatus == SearchStatus.Fetching ? "Refreshing..." : "Refresh";
 			refreshButton.OnClick = RefreshServerList;
 
-			panel.Get<ButtonWidget>("DIRECTCONNECT_BUTTON").OnClick = OpenDirectConnectPanel;
-			panel.Get<ButtonWidget>("CREATE_BUTTON").OnClick = OpenCreateServerPanel;
-
 			var join = panel.Get<ButtonWidget>("JOIN_BUTTON");
 			join.IsDisabled = () => currentServer == null || !currentServer.CanJoin();
 			join.OnClick = () => Join(currentServer);
@@ -256,24 +253,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				{ "onExit", Game.Disconnect },
 				{ "onStart", onStart },
 				{ "skirmishMode", false }
-			});
-		}
-
-		void OpenDirectConnectPanel()
-		{
-			Ui.OpenWindow("DIRECTCONNECT_PANEL", new WidgetArgs
-			{
-				{ "openLobby", OpenLobby },
-				{ "onExit", DoNothing }
-			});
-		}
-
-		void OpenCreateServerPanel()
-		{
-			Ui.OpenWindow("CREATESERVER_PANEL", new WidgetArgs
-			{
-				{ "openLobby", OpenLobby },
-				{ "onExit", DoNothing }
 			});
 		}
 

--- a/mods/cnc/chrome/ingame-menu.yaml
+++ b/mods/cnc/chrome/ingame-menu.yaml
@@ -23,7 +23,7 @@ Container@INGAME_MENU:
 		Container@MENU_BUTTONS:
 			X: (WINDOW_RIGHT-WIDTH)/2
 			Y: WINDOW_BOTTOM-33-HEIGHT-10
-			Width: 740
+			Width: 890
 			Height: 35
 			Children:
 				Button@ABORT_MISSION:
@@ -50,9 +50,15 @@ Container@INGAME_MENU:
 					Width: 140
 					Height: 35
 					Text: Settings
+				Button@SAVE:
+					X: 600
+					Y: 0
+					Width: 140
+					Height: 35
+					Text: Save
 				Button@RESUME:
 					Key: escape
-					X: 600
+					X: 750
 					Y: 0
 					Width: 140
 					Height: 35

--- a/mods/cnc/chrome/savebrowser.yaml
+++ b/mods/cnc/chrome/savebrowser.yaml
@@ -1,0 +1,201 @@
+Background@SAVEBROWSER_PANEL:
+	Logic: SaveBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - HEIGHT)/2
+	Width: 780
+	Height: 500
+	Children:
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				Container@SAVE_LIST_CONTAINER:
+					X: 20
+					Y: 20
+					Width: 245
+					Height: PARENT_BOTTOM - 20 - 55
+					Children:
+						Label@SAVEBROWSER_LABEL_TITLE:
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Choose Save
+							Align: Center
+							Font: Bold
+						ScrollPanel@SAVE_LIST:
+							X: 0
+							Y: 30
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM - 110
+							CollapseHiddenChildren: True
+							Children:
+								ScrollItem@SAVE_TEMPLATE:
+									Width: PARENT_RIGHT-27
+									Height: 25
+									X: 2
+									Visible: false
+									Children:
+										Label@TITLE:
+											X: 10
+											Width: PARENT_RIGHT-20
+											Height: 25
+						Container@MANAGEMENT:
+							X: PARENT_RIGHT / 4
+							Y: PARENT_BOTTOM - 80
+							Width: PARENT_RIGHT / 2
+							Height: 115
+							Children:
+								Label@MANAGE_TITLE:
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Bold
+									Align: Center
+									Text: Manage
+								Button@MNG_RENSEL_BUTTON:
+									Y: 30
+									Width: PARENT_RIGHT
+									Height: 25
+									Text: Rename
+									Font: Bold
+									Key: F2
+								Button@MNG_DELSEL_BUTTON:
+									Y: 60
+									Width: PARENT_RIGHT
+									Height: 25
+									Text: Delete
+									Font: Bold
+									Key: Delete
+								Button@MNG_DELALL_BUTTON:
+									Y: 90
+									Width: PARENT_RIGHT
+									Height: 25
+									Text: Delete All
+									Font: Bold
+		Container@MAP_BG_CONTAINER:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20
+			Width: 194
+			Height: 30 + 194
+			Children:
+				Label@MAP_BG_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Preview
+					Align: Center
+					Font: Bold
+				Background@MAP_BG:
+					Y: 30
+					Width: 194
+					Height: 194
+					Background: panel-gray
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: 192
+							Height: 192
+							TooltipContainer: TOOLTIP_CONTAINER
+		Container@SAVE_DESCRIPTION:
+			X: PARENT_RIGHT - 224 - WIDTH
+			Y: 20
+			Width: 280
+			Height: PARENT_BOTTOM - 45
+			Children:
+				Label@SAVE_DESCRIPTION_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Description
+					Align: Center
+					Font: Bold
+				ScrollPanel@SAVE_DESCRIPTION_PANEL:
+					X: 0
+					Y: 30
+					Width: 280
+					Height: PARENT_BOTTOM - 25
+					Children:
+						Label@SAVE_DESCRIPTION:
+							X: 5
+							Y: 5
+							Width: 265
+							VAlign: Top
+		Container@SAVE_INFO:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20 + 30+194 + 10
+			Width: 194
+			Height: PARENT_BOTTOM - 20 - 30-194 - 10 - 55
+			Children:
+				Label@MAP_TITLE:
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Bold
+					Align: Center
+				Label@MAP_TYPE:
+					Y: 15
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: TinyBold
+					Align: Center
+				Label@DURATION:
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Tiny
+					Align: Center
+				ScrollPanel@PLAYER_LIST:
+					Y: 50
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 50
+					IgnoreChildMouseOver: true
+					Children:
+						ScrollItem@HEADER:
+							BaseName: scrollheader
+							Width: PARENT_RIGHT-27
+							Height: 13
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+						ScrollItem@TEMPLATE:
+							Width: PARENT_RIGHT-27
+							Height: 25
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Image@FLAG:
+									X: 4
+									Y: 6
+									Width: 32
+									Height: 16
+								Label@LABEL:
+									X: 40
+									Width: 60
+									Height: 25
+								Label@NOFLAG_LABEL:
+									X: 5
+									Width: PARENT_RIGHT
+									Height: 25
+		Button@LOAD_BUTTON:
+			Key: return
+			X: PARENT_RIGHT - 110 - 105
+			Y: PARENT_BOTTOM - 55
+			Width: 100
+			Height: 35
+			Text: Load
+			Font: Bold
+		Button@CANCEL_BUTTON:
+			Key: escape
+			X: PARENT_RIGHT - 110 - 10
+			Y: PARENT_BOTTOM - 55
+			Width: 100
+			Height: 35
+			Text: Cancel
+			Font: Bold
+		TooltipContainer@TOOLTIP_CONTAINER:
+

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -86,6 +86,7 @@ ChromeLayout:
 	mods/cnc/chrome/color-picker.yaml
 	mods/cnc/chrome/mapchooser.yaml
 	mods/cnc/chrome/replaybrowser.yaml
+	mods/cnc/chrome/savebrowser.yaml
 	mods/cnc/chrome/ingame.yaml
 	mods/cnc/chrome/ingame-chat.yaml
 	mods/cnc/chrome/ingame-menu.yaml

--- a/mods/d2k/chrome/ingame-menu.yaml
+++ b/mods/d2k/chrome/ingame-menu.yaml
@@ -13,7 +13,7 @@ Container@INGAME_MENU:
 			X: 100
 			Y: (WINDOW_BOTTOM - HEIGHT)/2
 			Width: 200
-			Height: 295
+			Height: 335
 			Children:
 				Label@LABEL_TITLE:
 					X: (PARENT_RIGHT - WIDTH)/2
@@ -31,30 +31,37 @@ Container@INGAME_MENU:
 					Text: Resume
 					Font: Bold
 					Key: escape
-				Button@SETTINGS:
+				Button@SAVE:
 					X: (PARENT_RIGHT - WIDTH)/2
 					Y: 100
+					Width: 140
+					Height: 30
+					Text: Save
+					Font: Bold
+				Button@SETTINGS:
+					X: (PARENT_RIGHT - WIDTH)/2
+					Y: 140
 					Width: 140
 					Height: 30
 					Text: Settings
 					Font: Bold
 				Button@MUSIC:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 140
+					Y: 180
 					Width: 140
 					Height: 30
 					Text: Music
 					Font: Bold
 				Button@SURRENDER:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 180
+					Y: 220
 					Width: 140
 					Height: 30
 					Text: Surrender
 					Font: Bold
 				Button@ABORT_MISSION:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 220
+					Y: 260
 					Width: 140
 					Height: 30
 					Text: Abort Mission

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -85,6 +85,7 @@ ChromeLayout:
 	mods/ra/chrome/connection.yaml
 	mods/ra/chrome/directconnect.yaml
 	mods/ra/chrome/replaybrowser.yaml
+	mods/ra/chrome/savebrowser.yaml
 	mods/d2k/chrome/dropdowns.yaml
 	mods/ra/chrome/musicplayer.yaml
 	mods/d2k/chrome/tooltips.yaml

--- a/mods/ra/chrome/create-server.yaml
+++ b/mods/ra/chrome/create-server.yaml
@@ -103,3 +103,107 @@ Background@CREATESERVER_PANEL:
 			Font: Bold
 			Key: escape
 
+Background@LOADSERVER_PANEL:
+	Logic: ServerCreationLogic
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - HEIGHT)/2
+	Width: 400
+	Height: 300
+	Children:
+		Label@LABEL_TITLE:
+			X: 0
+			Y: 20
+			Width: 400
+			Height: 25
+			Text: Load Server
+			Align: Center
+			Font: Bold
+		Label@SERVER_NAME_LABEL:
+			X: 50
+			Y: 59
+			Width: 95
+			Height: 25
+			Align: Right
+			Text: Game Title:
+		TextField@SERVER_NAME:
+			X: 150
+			Y: 60
+			Width: 210
+			MaxLength: 50
+			Height: 25
+			Text: OpenRA Game
+		Label@PASSWORD_LABEL:
+			X: 50
+			Y: 94
+			Width: 95
+			Height: 25
+			Align: Right
+			Text: Password:
+		PasswordField@PASSWORD:
+			X: 150
+			Y: 95
+			Width: 145
+			MaxLength: 20
+			Height: 25
+		Label@AFTER_PASSWORD_LABEL:
+			X: 300
+			Y: 94
+			Width: 95
+			Height: 25
+			Align: Left
+			Text: (optional)
+		Label@EXTERNAL_PORT_LABEL:
+			X: 50
+			Y: 129
+			Width: 95
+			Height: 25
+			Align: Right
+			Text: External Port:
+		TextField@EXTERNAL_PORT:
+			X: 150
+			Y: 130
+			Width: 50
+			MaxLength: 5
+			Height: 25
+			Text: OpenRA Game
+		Label@LISTEN_PORT_LABEL:
+			X: 210
+			Y: 129
+			Width: 95
+			Height: 25
+			Align: Right
+			Text: Listen Port:
+		TextField@LISTEN_PORT:
+			X: 310
+			Y: 130
+			Width: 50
+			MaxLength: 5
+			Height: 25
+		Checkbox@UPNP_CHECKBOX:
+			X: 150
+			Y: 165
+			Width: 300
+			Height: 20
+			Text: Automatic port forwarding
+		Checkbox@ADVERTISE_CHECKBOX:
+			X: 150
+			Y: 200
+			Width: 300
+			Height: 20
+			Text: Advertise game Online
+		Button@CREATE_BUTTON:
+			X: 130
+			Y: PARENT_BOTTOM - 45
+			Width: 120
+			Height: 25
+			Text: Create
+			Font: Bold
+			Key: return
+		Button@BACK_BUTTON:
+			X: 260
+			Y: PARENT_BOTTOM - 45
+			Width: 120
+			Height: 25
+			Text: Cancel
+			Font: Bold
+			Key: escape

--- a/mods/ra/chrome/ingame-menu.yaml
+++ b/mods/ra/chrome/ingame-menu.yaml
@@ -26,7 +26,7 @@ Container@INGAME_MENU:
 			X: 100
 			Y: (WINDOW_BOTTOM - HEIGHT)/2
 			Width: 200
-			Height: 295
+			Height: 335
 			Children:
 				Label@LABEL_TITLE:
 					X: (PARENT_RIGHT - WIDTH)/2
@@ -44,30 +44,37 @@ Container@INGAME_MENU:
 					Text: Resume
 					Font: Bold
 					Key: escape
-				Button@SETTINGS:
+				Button@SAVE:
 					X: (PARENT_RIGHT - WIDTH)/2
 					Y: 100
+					Width: 140
+					Height: 30
+					Text: Save
+					Font: Bold
+				Button@SETTINGS:
+					X: (PARENT_RIGHT - WIDTH)/2
+					Y: 140
 					Width: 140
 					Height: 30
 					Text: Settings
 					Font: Bold
 				Button@MUSIC:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 140
+					Y: 180
 					Width: 140
 					Height: 30
 					Text: Music
 					Font: Bold
 				Button@SURRENDER:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 180
+					Y: 220
 					Width: 140
 					Height: 30
 					Text: Surrender
 					Font: Bold
 				Button@ABORT_MISSION:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 220
+					Y: 260
 					Width: 140
 					Height: 30
 					Text: Abort Mission

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -77,6 +77,13 @@ Background@SERVER_LOBBY:
 			Height: 25
 			Font: Bold
 			Text: Game Options
+		Button@LOAD_BUTTON:
+			X: 194
+			Y: PARENT_BOTTOM - 291
+			Width: 135
+			Height: 25
+			Text: Load
+			Font: Bold
 		Button@CHANGEMAP_BUTTON:
 			X: 336
 			Y: PARENT_BOTTOM - 291

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -78,7 +78,7 @@ Background@SERVER_LOBBY:
 			Font: Bold
 			Text: Game Options
 		Button@LOAD_BUTTON:
-			X: 194
+			X: 336
 			Y: PARENT_BOTTOM - 291
 			Width: 135
 			Height: 25

--- a/mods/ra/chrome/mainmenu.yaml
+++ b/mods/ra/chrome/mainmenu.yaml
@@ -106,6 +106,61 @@ Container@MAINMENU:
 							Height: 30
 							Text: Missions
 							Font: Bold
+						Button@LOAD_BUTTON:
+							X: PARENT_RIGHT/2-WIDTH/2
+							Y: 140
+							Width: 140
+							Height: 30
+							Text: Load
+							Font: Bold
+						Button@BACK_BUTTON:
+							X: PARENT_RIGHT/2-WIDTH/2
+							Key: escape
+							Y: 260
+							Width: 140
+							Height: 30
+							Text: Back
+							Font: Bold
+				Background@MULTIPLAYER_MENU:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Label@MULTIPLAYER_MENU_TITLE:
+							X: 0
+							Y: 20
+							Width: 200
+							Height: 30
+							Text: Multiplayer
+							Align: Center
+							Font: Bold
+						Button@CREATE_BUTTON:
+							X: PARENT_RIGHT/2-WIDTH/2
+							Y: 60
+							Width: 140
+							Height: 30
+							Text: Create
+							Font: Bold
+						Button@JOIN_BUTTON:
+							X: PARENT_RIGHT/2-WIDTH/2
+							Y: 100
+							Width: 140
+							Height: 30
+							Text: Join
+							Font: Bold
+						Button@LOAD_BUTTON:
+							X: PARENT_RIGHT/2-WIDTH/2
+							Y: 140
+							Width: 140
+							Height: 30
+							Text: Load
+							Font: Bold
+						Button@DIRECTCONNECT_BUTTON:
+							X: PARENT_RIGHT/2-WIDTH/2
+							Y: 180
+							Width: 140
+							Height: 30
+							Text: Direct Connect
+							Font: Bold
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT/2-WIDTH/2
 							Key: escape

--- a/mods/ra/chrome/savebrowser.yaml
+++ b/mods/ra/chrome/savebrowser.yaml
@@ -1,0 +1,196 @@
+Background@SAVEBROWSER_PANEL:
+	Logic: SaveBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - HEIGHT)/2
+	Width: 780
+	Height: 535
+	Children:
+		Container@SAVE_LIST_CONTAINER:
+			X: 20
+			Y: 20
+			Width: 245
+			Height: PARENT_BOTTOM - 20 - 55
+			Children:
+				Label@SAVEBROWSER_LABEL_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Choose Save
+					Align: Center
+					Font: Bold
+				ScrollPanel@SAVE_LIST:
+					X: 0
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 110
+					CollapseHiddenChildren: True
+					Children:
+						ScrollItem@SAVE_TEMPLATE:
+							Width: PARENT_RIGHT-27
+							Height: 25
+							X: 2
+							Visible: false
+							Children:
+								Label@TITLE:
+									X: 10
+									Width: PARENT_RIGHT-20
+									Height: 25
+				Container@MANAGEMENT:
+					X: 0
+					Y: PARENT_BOTTOM - 80
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Label@MANAGE_TITLE:
+							Width: PARENT_RIGHT
+							Height: 25
+							Font: Bold
+							Align: Center
+							Text: Manage
+						Button@MNG_RENSEL_BUTTON:
+							Y: 30
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Rename
+							Font: Bold
+							Key: F2
+						Button@MNG_DELSEL_BUTTON:
+							Y: 60
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Delete
+							Font: Bold
+							Key: Delete
+						Button@MNG_DELALL_BUTTON:
+							Y: 90
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Delete All
+							Font: Bold
+		Container@MAP_BG_CONTAINER:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20
+			Width: 194
+			Height: 30 + 194
+			Children:
+				Label@MAP_BG_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Preview
+					Align: Center
+					Font: Bold
+				Background@MAP_BG:
+					Y: 30
+					Width: 194
+					Height: 194
+					Background: dialog3
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: 192
+							Height: 192
+							TooltipContainer: TOOLTIP_CONTAINER
+		Container@SAVE_DESCRIPTION:
+			X: PARENT_RIGHT - 224 - WIDTH
+			Y: 20
+			Width: 280
+			Height: PARENT_BOTTOM - 45
+			Children:
+				Label@SAVE_DESCRIPTION_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Description
+					Align: Center
+					Font: Bold
+				ScrollPanel@SAVE_DESCRIPTION_PANEL:
+					X: 0
+					Y: 30
+					Width: 280
+					Height: PARENT_BOTTOM - 25
+					Children:
+						Label@SAVE_DESCRIPTION:
+							X: 5
+							Y: 5
+							Width: 265
+							VAlign: Top
+		Container@SAVE_INFO:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20 + 30+194 + 10
+			Width: 194
+			Height: PARENT_BOTTOM - 20 - 30-194 - 10 - 55
+			Children:
+				Label@MAP_TITLE:
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Bold
+					Align: Center
+				Label@MAP_TYPE:
+					Y: 15
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: TinyBold
+					Align: Center
+				Label@DURATION:
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Tiny
+					Align: Center
+				ScrollPanel@PLAYER_LIST:
+					Y: 50
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 50
+					IgnoreChildMouseOver: true
+					Children:
+						ScrollItem@HEADER:
+							BaseName: scrollheader
+							Width: PARENT_RIGHT-27
+							Height: 13
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+						ScrollItem@TEMPLATE:
+							Width: PARENT_RIGHT-27
+							Height: 25
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Image@FLAG:
+									X: 4
+									Y: 6
+									Width: 32
+									Height: 16
+								Label@LABEL:
+									X: 40
+									Width: 60
+									Height: 25
+								Label@NOFLAG_LABEL:
+									X: 5
+									Width: PARENT_RIGHT
+									Height: 25
+		Button@LOAD_BUTTON:
+			X: PARENT_RIGHT - 110 - 105
+			Y: PARENT_BOTTOM - 45
+			Width: 90
+			Height: 25
+			Text: Load
+			Font: Bold
+			Key: p
+		Button@CANCEL_BUTTON:
+			X: PARENT_RIGHT - 110
+			Y: PARENT_BOTTOM - 45
+			Width: 90
+			Height: 25
+			Text: Cancel
+			Font: Bold
+			Key: escape
+		TooltipContainer@TOOLTIP_CONTAINER:
+

--- a/mods/ra/chrome/serverbrowser.yaml
+++ b/mods/ra/chrome/serverbrowser.yaml
@@ -115,20 +115,6 @@ Background@SERVERBROWSER_PANEL:
 			Height: 25
 			Text: Refresh
 			Font: Bold
-		Button@CREATE_BUTTON:
-			X: PARENT_RIGHT - 120 - 120 - 120 - 120
-			Y: PARENT_BOTTOM - 45
-			Width: 100
-			Height: 25
-			Text: Create
-			Font: Bold
-		Button@DIRECTCONNECT_BUTTON:
-			X: PARENT_RIGHT - 120 - 120 - 120
-			Y: PARENT_BOTTOM - 45
-			Width: 100
-			Height: 25
-			Text: Direct IP
-			Font: Bold
 		Button@JOIN_BUTTON:
 			X: PARENT_RIGHT - 120 - 120
 			Y: PARENT_BOTTOM - 45

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -98,6 +98,7 @@ ChromeLayout:
 	mods/ra/chrome/connection.yaml
 	mods/ra/chrome/directconnect.yaml
 	mods/ra/chrome/replaybrowser.yaml
+	mods/ra/chrome/savebrowser.yaml
 	mods/ra/chrome/dropdowns.yaml
 	mods/ra/chrome/musicplayer.yaml
 	mods/ra/chrome/tooltips.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -127,6 +127,7 @@ ChromeLayout:
 	mods/ra/chrome/connection.yaml
 	mods/ra/chrome/directconnect.yaml
 	mods/ra/chrome/replaybrowser.yaml
+	mods/ra/chrome/savebrowser.yaml
 	mods/ra/chrome/dropdowns.yaml
 	mods/ra/chrome/musicplayer.yaml
 	mods/ra/chrome/tooltips.yaml


### PR DESCRIPTION
This moves the replay playing code serverside, also allows loading from replay.

TODO:
- Support Multiplayer loading
- Change Replay browser to use the server system
- Allow to change players between saves.
- ~~Move the load button in the lobby so it doesnt cover the options button.~~

This superseeds #6238 completly except you currently cant watch replays of loaded games,
this will be fixed as soon as I move the replay watching to the new system.
