### PR TITLE
Added tab completion to in-game and lobby chat.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Previous developers included:
 Also thanks to:
     * Adam Valy (Tschokky)
     * Akseli Virtanen (RAGEQUIT)
+    * Alexander Fast (mizipzor)
     * Allen262
     * Andrew Aldridge (i80and)
     * Andrew Perkins

--- a/OpenRA.Game/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Game/Widgets/TextFieldWidget.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Widgets
 		public Func<bool> OnEnterKey = () => false;
 		public Func<bool> OnTabKey = () => false;
 		public Func<bool> OnEscKey = () => false;
+		public Func<bool> OnAltKey = () => false;
 		public Action OnLoseFocus = () => { };
 		public Action OnTextEdited = () => { };
 		public int CursorPosition { get; set; }
@@ -119,6 +120,9 @@ namespace OpenRA.Widgets
 				return true;
 
 			if (e.Key == Keycode.ESCAPE && OnEscKey())
+				return true;
+
+			if (e.Key == Keycode.LALT && OnAltKey())
 				return true;
 
 			if (e.Key == Keycode.LEFT)

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
@@ -184,6 +184,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			if (string.IsNullOrEmpty(chatText.Text))
 				return false;
 
+			if (chatText.Text.LastOrDefault() == ' ')
+				return false;
+
 			var suggestion = "";
 
 			if (chatText.Text.StartsWith("/"))

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
@@ -190,10 +190,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 			else
 			{
-				var oneWord = chatText.Text.Contains(' ');
+				var oneWord = !chatText.Text.Contains(' ');
 				var toComplete = oneWord
-					? chatText.Text.Substring(chatText.Text.LastIndexOf(' ') + 1)
-					: chatText.Text;
+					? chatText.Text
+					: chatText.Text.Substring(chatText.Text.LastIndexOf(' ') + 1);
 
 				suggestion = playerNames.FirstOrDefault(x => x.StartsWith(toComplete, StringComparison.InvariantCultureIgnoreCase));
 				if (suggestion == null)

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
@@ -43,12 +43,12 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			chatTraits = world.WorldActor.TraitsImplementing<INotifyChat>().ToList();
 
-			var players = world.Players.Where(p => p != world.LocalPlayer && !p.NonCombatant && !p.IsBot).ToList();
+			var players = world.Players.Where(p => p != world.LocalPlayer && !p.NonCombatant && !p.IsBot);
 			var disableTeamChat = world.LocalPlayer == null || world.LobbyInfo.IsSinglePlayer || !players.Any(p => p.IsAlliedWith(world.LocalPlayer));
 			teamChat = !disableTeamChat;
 
 			commandNames = chatTraits.OfType<ChatCommands>().SelectMany(x => x.Commands.Keys).Select(x => "/" + x).ToList();
-			playerNames = players.Select(x => x.PlayerName).ToList();
+			playerNames = orderManager.LobbyInfo.Clients.Select(c => c.Name).ToList();
 
 			var chatPanel = (ContainerWidget)widget;
 			chatOverlay = chatPanel.Get<ContainerWidget>("CHAT_OVERLAY");

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
@@ -78,7 +78,11 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim()));
 					else
 						if (chatTraits != null)
-							chatTraits.ForEach(x => x.OnChat(orderManager.LocalClient.Name, chatText.Text.Trim()));
+						{
+							var text = chatText.Text.Trim();
+							foreach (var trait in chatTraits)
+								trait.OnChat(orderManager.LocalClient.Name, text);
+						}
 
 				CloseChat();
 				return true;

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -785,6 +785,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			if (chatText == null || string.IsNullOrEmpty(chatText.Text))
 				return false;
 
+			if (chatText.Text.LastOrDefault() == ' ')
+				return false;
+
 			var suggestion = "";
 			var oneWord = !chatText.Text.Contains(' ');
 			var toComplete = oneWord

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -770,34 +770,13 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			while (players.Children.Count > idx)
 				players.RemoveChild(players.Children[idx]);
 
-			playerNames = GetPlayerNames().ToList();
+			playerNames = orderManager.LobbyInfo.Clients.Select(c => c.Name).ToList();
 		}
 
 		void OnGameStart()
 		{
 			CloseWindow();
 			onStart();
-		}
-
-		IEnumerable<string> GetPlayerNames()
-		{
-			foreach (var container in players.Children)
-			{
-				if (container.Id == "TEMPLATE_EDITABLE_PLAYER")
-				{
-					var textWidget = container.Children.FirstOrDefault(x => x.Id == "NAME") as TextFieldWidget;
-					if (textWidget == null)
-						continue;
-					yield return textWidget.Text;
-				}
-				else if (container.Id == "TEMPLATE_NONEDITABLE_PLAYER")
-				{
-					var labelWidget = container.Children.FirstOrDefault(x => x.Id == "NAME") as LabelWidget;
-					if (labelWidget == null)
-						continue;
-					yield return labelWidget.GetText();
-				}
-			}
 		}
 
 		bool AutoCompleteText()


### PR DESCRIPTION
- Both player names and chat commands can be completed.
- ~~Names of local players and bots are not candidates for completion.~~
- If a completed name is the first word ": " is appended to the end.
- The hotkey for toggling team/all chat has been moved to left Alt.
