### PR TITLE
Implemented Saving and Loading

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -40,6 +40,7 @@ namespace OpenRA
 
 		public static Renderer Renderer;
 		public static bool HasInputFocus = false;
+		public static bool IsSimulating = false;
 
 		public static DatabaseReader GeoIpDatabase;
 
@@ -590,8 +591,8 @@ namespace OpenRA
 					var haveSomeTimeUntilNextLogic = now < nextLogic;
 					var isTimeToRender = now >= nextRender;
 					var forceRender = now >= forcedNextRender;
-
-					if ((isTimeToRender && haveSomeTimeUntilNextLogic) || forceRender)
+					
+					if (((isTimeToRender && haveSomeTimeUntilNextLogic) || forceRender) && !IsSimulating)
 					{
 						nextRender = now + renderInterval;
 

--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -22,6 +22,7 @@ namespace OpenRA
 		public bool Spectating = false;
 		public string Bot = null;
 		public string StartingUnitsClass = null;
+		public bool AllowPlayers = true;
 		public bool AllowBots = true;
 		public bool Required = false;
 

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -21,13 +21,14 @@ namespace OpenRA.Network
 			public Order Order;
 		}
 
+		public readonly List<int> ObserverIDs = new List<int>();
 		readonly Dictionary<int, int> clientQuitTimes = new Dictionary<int, int>();
 		readonly Dictionary<int, Dictionary<int, byte[]>> framePackets = new Dictionary<int, Dictionary<int, byte[]>>();
 
 		public IEnumerable<int> ClientsPlayingInFrame( int frame )
 		{
 			return clientQuitTimes
-				.Where( x => frame <= x.Value )
+				.Where(x => !ObserverIDs.Contains(x.Key) && frame <= x.Value)
 				.Select( x => x.Key )
 				.OrderBy( x => x );
 		}
@@ -52,7 +53,7 @@ namespace OpenRA.Network
 		{
 			var frameData = framePackets.GetOrAdd(frame);
 			return ClientsPlayingInFrame(frame)
-				.Where(client => !frameData.ContainsKey(client));
+				.Where(client =>!frameData.ContainsKey(client));
 		}
 
 		public IEnumerable<ClientOrder> OrdersForFrame( World world, int frame )

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -191,6 +191,7 @@ namespace OpenRA.Network
 			public bool AllowVersionMismatch;
 			public string GameUid;
 			public int WaitFrames = -1;
+			public bool Simulate = false;
 
 			public MiniYamlNode Serialize()
 			{

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -190,6 +190,7 @@ namespace OpenRA.Network
 			public string StartingUnitsClass = "none";
 			public bool AllowVersionMismatch;
 			public string GameUid;
+			public int WaitFrames = -1;
 
 			public MiniYamlNode Serialize()
 			{

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Network
 
 		public string FirstEmptySlot()
 		{
-			return Slots.FirstOrDefault(s => !s.Value.Closed && ClientInSlot(s.Key) == null).Key;
+			return Slots.FirstOrDefault(s => !s.Value.Closed && ClientInSlot(s.Key) == null && s.Value.AllowPlayers).Key;
 		}
 
 		public string FirstEmptyBotSlot()
@@ -152,6 +152,7 @@ namespace OpenRA.Network
 			public string PlayerReference;	// playerReference to bind against.
 			public bool Closed;	// host has explicitly closed this slot.
 
+			public bool AllowPlayers;
 			public bool AllowBots;
 			public bool LockRace;
 			public bool LockColor;
@@ -190,6 +191,7 @@ namespace OpenRA.Network
 			public string StartingUnitsClass = "none";
 			public bool AllowVersionMismatch;
 			public string GameUid;
+			public bool AllowConfiguration = true;
 			public int WaitFrames = -1;
 			public bool Simulate = false;
 

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -115,6 +115,15 @@ namespace OpenRA.Network
 						break;
 					}
 
+				case "Simulate":
+					{
+						if (order.TargetString == "Enable")
+							Game.IsSimulating = true;
+						else
+							Game.IsSimulating = false;
+						break;
+					}
+
 				case "HandshakeRequest":
 					{
 						// TODO: Switch to the server's mod if we have it

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Server\Connection.cs" />
     <Compile Include="Server\Exts.cs" />
     <Compile Include="Server\ProtocolVersion.cs" />
+    <Compile Include="Server\ReplayParser.cs" />
     <Compile Include="Server\Server.cs" />
     <Compile Include="Server\ServerOrder.cs" />
     <Compile Include="Server\TraitInterfaces.cs" />

--- a/OpenRA.Game/Server/ReplayParser.cs
+++ b/OpenRA.Game/Server/ReplayParser.cs
@@ -109,8 +109,13 @@ namespace OpenRA.Server
 
 			if (Resume)
 			{
-				//Remove last ping of replay since it is unneeded
-				Packets.Remove(Packets.Last());
+				//Remove last frame of replay since it is unneeded
+				for ( var i = Packets.Count - 1; i >= 0; i-- )
+				{
+					if (BitConverter.ToInt32(Packets[i].Second, 0) != TickCount)
+						break;
+					Packets.Remove(Packets[i]);
+				}
 
 				var newPackets = new List<Pair<int, byte[]>>();
 

--- a/OpenRA.Game/Server/ReplayParser.cs
+++ b/OpenRA.Game/Server/ReplayParser.cs
@@ -1,0 +1,184 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenRA.FileFormats;
+using OpenRA.Network;
+using OpenRA.Primitives;
+
+namespace OpenRA.Server
+{
+	public class ReplayParser
+	{
+		public List<Pair<int, byte[]>> Packets = new List<Pair<int, byte[]>>();
+
+		public bool ReplayDone { get { return Packets.Count == 0 && IsValid; } }
+		public ConnectionState ConnectionState { get { return ConnectionState.Connected; } }
+
+		public readonly int TickCount;
+		public readonly bool IsValid;
+		public readonly ReplayMetadata Info;
+		public readonly Dictionary<int, int> IndexConverter;
+		public readonly bool Resume;
+
+		public ReplayParser(string replayFilename, bool resume)
+		{
+			Info = ReplayMetadata.Read(replayFilename);
+			IndexConverter = new Dictionary<int, int>();
+			Info.GameInfo.Players.Do(p => IndexConverter.Add(p.ClientIndex, p.ClientIndex));
+			Resume = resume;
+
+			var ignore = new List<byte[]> {
+				new ServerOrder("Simulate", "Enable").Serialize(),
+				new ServerOrder("Simulate", "Disable").Serialize() };
+
+			var clients = new List<int>();
+			var skip = false;
+
+			using (var rs = File.OpenRead(replayFilename))
+			{
+				while (rs.Position < rs.Length)
+				{
+					var client = rs.ReadInt32();
+					if (client == ReplayMetadata.MetaStartMarker)
+						break;
+					if (!clients.Contains(client))
+						clients.Add(client);
+					var packetLen = rs.ReadInt32();
+					var packet = rs.ReadBytes(packetLen);
+					var frame = BitConverter.ToInt32(packet, 0);
+					
+					if (packet.Length == 5 && packet[4] == 0xBF)
+						continue; // disconnect
+					else if (packet.Length >= 5 && packet[4] == 0x65)
+						continue; // sync
+					else if (frame == 0)
+					{
+						var orders = packet.ToOrderList(null);
+						foreach (var o in orders)
+						{
+							if (o.IsImmediate)
+							{
+								skip = true;
+								if (o.OrderString == "StartGame")
+									IsValid = true;
+							}
+						}
+
+						if (skip)
+						{
+							skip = false;
+							continue;
+						}
+					}
+
+					foreach (var i in ignore)
+						packet = CheckIgnore(i, packet);
+
+					if (frame != 0 && Packets.Any(p2 => p2.First == client))
+					{
+						var packet2 = Packets.First(p2 => p2.First == client);
+
+						if (BitConverter.ToInt32(packet2.Second, 0) == frame)
+						{
+							byte[] newpacket = new byte[packet.Length - 4];
+							Buffer.BlockCopy(packet, 4, newpacket, 0, newpacket.Length);
+
+							Packets.Remove(packet2);
+							Packets.Add(Pair.New(client, sumArrays(packet2.Second, newpacket)));
+							continue;
+						}
+					}
+
+					TickCount = Math.Max(TickCount, frame);
+					Packets.Add(Pair.New(client, packet));
+				}
+			}
+
+			Packets = Packets.OrderBy(p => BitConverter.ToInt32(p.Second, 0)).ToList();
+
+			if (Resume)
+			{
+				//Remove last ping of replay since it is unneeded
+				Packets.Remove(Packets.Last());
+
+				var newPackets = new List<Pair<int, byte[]>>();
+
+				var startOrders = BitConverter.GetBytes(0);
+				startOrders = sumArrays(startOrders, new ServerOrder("Simulate", "Enable").Serialize());
+				newPackets.Add(new Pair<int, byte[]>(0, startOrders));
+
+				var endOrders = BitConverter.GetBytes(TickCount);
+				endOrders = sumArrays(endOrders, new ServerOrder("Simulate", "Disable").Serialize());
+				endOrders = sumArrays(endOrders, new ServerOrder("PauseGame", "UnPause").Serialize());
+
+				clients.Do(c =>
+				{
+					newPackets.Add(new Pair<int, byte[]>(c, endOrders));
+				});
+
+				newPackets.Do(p => Packets.Add(p));
+			}
+
+			Packets = Packets.OrderBy(p => BitConverter.ToInt32(p.Second, 0)).ToList();
+		}
+
+		byte[] CheckIgnore(byte[] ignore, byte[] packet)
+		{
+			var check = false;
+			var startingIndex = 0;
+			var x = 0;
+
+			if (ignore.Length <= packet.Length - 4)
+				for (var i = 4; i < packet.Length; i++)
+				{
+					if (x < ignore.Length && i < packet.Length)
+					{
+						if (!check && ignore[x] == packet[i])
+						{
+							startingIndex = i;
+							check = true;
+						}
+						else if (check && ignore[x] != packet[i])
+						{
+							x = 0;
+							check = false;
+						}
+					}
+
+					if (check)
+						x++;
+				}
+
+			if (check)
+			{
+				var newPacket = new byte[packet.Length - ignore.Length];
+				Buffer.BlockCopy(packet, 0, newPacket, 0, startingIndex);
+				Buffer.BlockCopy(packet, startingIndex + ignore.Length, newPacket, startingIndex, packet.Length - (startingIndex + ignore.Length));
+				return newPacket;
+			}
+			else
+				return packet;
+		}
+
+		byte[] sumArrays(byte[] array1, byte[] array2)
+		{
+			var array = new byte[array1.Length + array2.Length];
+			Buffer.BlockCopy(array1, 0, array, 0, array1.Length);
+			Buffer.BlockCopy(array2, 0, array, array1.Length, array2.Length);
+			return array;
+		}
+
+		internal List<Pair<int, byte[]>> GetData() { return Packets; }
+	}
+}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using OpenRA.Graphics;
+using OpenRA.Server;
 
 namespace OpenRA
 {
@@ -32,6 +33,7 @@ namespace OpenRA
 		public bool VerboseNatDiscovery = false; // print very detailed logs for debugging
 		public bool AllowCheats = false;
 		public string Map = null;
+		public ReplayParser Replay = null;
 		public string[] Ban = { };
 		public int TimeOut = 0;
 		public bool Dedicated = false;

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -247,7 +247,7 @@ namespace OpenRA
 		{
 			get
 			{
-				return Game.Settings.Sound.SoundVolume;
+				return Game.IsSimulating ? 0f : Game.Settings.Sound.SoundVolume;
 			}
 
 			set
@@ -261,7 +261,7 @@ namespace OpenRA
 		{
 			get
 			{
-				return Game.Settings.Sound.MusicVolume;
+				return Game.IsSimulating ? 0f : Game.Settings.Sound.MusicVolume;
 			}
 
 			set
@@ -276,7 +276,7 @@ namespace OpenRA
 		{
 			get
 			{
-				return Game.Settings.Sound.VideoVolume;
+				return Game.IsSimulating ? 0f : Game.Settings.Sound.VideoVolume;
 			}
 
 			set

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -89,6 +89,16 @@ namespace OpenRA
 			get { return orderManager.Connection is ReplayConnection; }
 		}
 
+		public bool CanSave()
+		{
+			return orderManager.Connection is ReplayRecorderConnection;
+		}
+
+		public void Save(string directory, string filename)
+		{
+			this.AddFrameEndTask((w) => ((ReplayRecorderConnection)orderManager.Connection).SaveToFile(directory, filename));
+		}
+
 		public bool AllowDevCommands
 		{
 			get { return LobbyInfo.GlobalSettings.AllowCheats || LobbyInfo.IsSinglePlayer; }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -30,7 +30,12 @@ namespace OpenRA
 		readonly List<IEffect> effects = new List<IEffect>();
 		readonly Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
 
-		public int Timestep;
+		int timestep;
+		public int Timestep
+		{
+			get { return Game.IsSimulating ? 1 : timestep; }
+			set { timestep = value; }
+		}
 
 		internal readonly OrderManager orderManager;
 		public Session LobbyInfo { get { return orderManager.LobbyInfo; } }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -96,7 +96,7 @@ namespace OpenRA
 
 		public bool CanSave()
 		{
-			return orderManager.Connection is ReplayRecorderConnection;
+			return orderManager.Connection is ReplayRecorderConnection && orderManager.NetFrameNumber != 0;
 		}
 
 		public void Save(string directory, string filename)

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -292,6 +292,7 @@
     <Compile Include="Warheads\CreateEffectWarhead.cs" />
     <Compile Include="Warheads\CreateResourceWarhead.cs" />
     <Compile Include="Warheads\LeaveSmudgeWarhead.cs" />
+    <Compile Include="Widgets\Logic\SaveBrowserLogic.cs" />
     <Compile Include="World\RadarPings.cs" />
     <Compile Include="Player\TechTree.cs" />
     <Compile Include="PrimaryBuilding.cs" />

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -481,7 +481,7 @@ namespace OpenRA.Mods.RA.Server
 								// Create a new bot from replay reference
 								var bot = new Session.Client()
 								{
-									Index = players[id].ClientIndex,
+									Index = server.ChooseFreePlayerIndex(),
 									Name = players[id].Name,
 									Bot = players[id].Name,
 									Slot = slot,
@@ -495,6 +495,7 @@ namespace OpenRA.Mods.RA.Server
 								// Set the color of the bot according to replay
 								bot.Color = bot.PreferredColor = players[id].Color;
 
+								server.Settings.Replay.IndexConverter[players[id].ClientIndex] = bot.Index;
 								server.LobbyInfo.Clients.Add(bot);
 
 								S.SyncClientToPlayerReference(bot, server.Map.Players[slot]);

--- a/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.RA/ServerTraits/LobbyCommands.cs
@@ -11,10 +11,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Server;
 using S = OpenRA.Server.Server;
+using System.IO;
 
 namespace OpenRA.Mods.RA.Server
 {
@@ -128,6 +130,30 @@ namespace OpenRA.Mods.RA.Server
 							return false;
 
 						client.Slot = s;
+
+						if (server.Settings.Replay != null)
+						{
+							var index = 0;
+							foreach (var sl in server.LobbyInfo.Slots.Keys)
+							{
+								if (sl == s)
+									break;
+								index++;
+							}
+
+							var playerinfo = server.Settings.Replay.Info.GameInfo.Players[index];
+							if (playerinfo == null)
+							{
+								server.SendOrderTo(conn, "Message", "You can't use a slot that wasnt in the replay");
+								return true;
+							}
+
+							server.Settings.Replay.IndexConverter[playerinfo.ClientIndex] = client.Index;
+							client.Country = playerinfo.FactionId;
+							client.Team = playerinfo.Team;
+							client.SpawnPoint = playerinfo.SpawnPoint;
+						}
+
 						S.SyncClientToPlayerReference(client, server.Map.Players[s]);
 						server.SyncLobbyClients();
 						CheckAutoStart(server);
@@ -167,6 +193,12 @@ namespace OpenRA.Mods.RA.Server
 					{
 						if (!ValidateSlotCommand(server, conn, client, s, true))
 							return false;
+
+						if (server.Settings.Replay != null)
+						{
+							server.SendOrderTo(conn, "Message", "You can't close a slot which is required for the save to load");
+							return true;
+						}
 
 						// kick any player that's in the slot
 						var occupant = server.LobbyInfo.ClientInSlot(s);
@@ -279,6 +311,29 @@ namespace OpenRA.Mods.RA.Server
 							bot.Name = botType;
 							bot.Bot = botType;
 						}
+						
+						if (server.Settings.Replay != null)
+						{
+							var index = 0;
+							foreach (var sl in server.LobbyInfo.Slots.Keys)
+							{
+								if (sl == parts[0])
+									break;
+								index++;
+							}
+
+							var playerinfo = server.Settings.Replay.Info.GameInfo.Players[index];
+							if (playerinfo == null)
+							{
+								server.SendOrderTo(conn, "Message", "You can't use a slot that wasnt in the replay");
+								return true;
+							}
+
+							server.Settings.Replay.IndexConverter[playerinfo.ClientIndex] = bot.Index;
+							bot.Country = playerinfo.FactionId;
+							bot.Team = playerinfo.Team;
+							bot.SpawnPoint = playerinfo.SpawnPoint;
+						}
 
 						S.SyncClientToPlayerReference(bot, server.Map.Players[parts[0]]);
 						server.SyncLobbyClients();
@@ -301,6 +356,8 @@ namespace OpenRA.Mods.RA.Server
 						}
 
 						server.LobbyInfo.GlobalSettings.Map = s;
+						server.LobbyInfo.GlobalSettings.AllowConfiguration = true;
+						server.Settings.Replay = null;
 
 						var oldSlots = server.LobbyInfo.Slots.Keys.ToArray();
 						LoadMap(server);
@@ -341,6 +398,126 @@ namespace OpenRA.Mods.RA.Server
 
 						return true;
 					}},
+				{ "load",
+					s =>
+					{
+						if (!client.IsAdmin)
+						{
+							server.SendOrderTo(conn, "Message", "Only the host can load a save");
+							return true;
+						}
+
+						var save = ReplayMetadata.Read(s);
+
+						if (server.ModData.MapCache[save.GameInfo.MapUid].Status != MapStatus.Available)
+						{
+							server.SendOrderTo(conn, "Message", "Map for save was not found on server");
+							return true;
+						}
+
+						var oldSlots = server.LobbyInfo.Slots.Keys.ToArray();
+						server.LobbyInfo.GlobalSettings.Map = save.GameInfo.MapUid;
+						server.Settings.Replay = Game.Settings.Server.Replay;
+
+						server.Map = save.GameInfo.MapPreview.Map;
+						server.LobbyInfo.Slots = server.Map.Players
+							.Select(p => MakeSlotFromPlayerReference(p.Value))
+							.Where(sl => sl != null)
+							.ToDictionary(sl => sl.PlayerReference, sl => sl);
+						server.Map.Options.UpdateServerSettings(server.LobbyInfo.GlobalSettings);
+						server.LobbyInfo.GlobalSettings.AllowConfiguration = false;
+
+						SetDefaultDifficulty(server);
+
+						// Reset client states
+						foreach (var c in server.LobbyInfo.Clients)
+							c.State = Session.ClientState.Invalid;
+
+						// Reassign players into new slots based on their old slots:
+						//  - Observers & Players are made observers
+						//  - Bots are dropped
+						var slots = server.LobbyInfo.Slots.Keys.ToArray();
+						var i = 0;
+						foreach (var os in oldSlots)
+						{
+							var c = server.LobbyInfo.ClientInSlot(os);
+							if (c == null)
+								continue;
+
+							c.Slot = i < slots.Length ? slots[i++] : null;
+							if (c.Slot != null && c.Bot == null)
+							{
+								c.Slot = null;
+								c.SpawnPoint = 0;
+							}
+
+							if (c.Bot != null)
+							{
+								server.LobbyInfo.Clients.Remove(c);
+								S.SyncClientToPlayerReference(c, server.Map.Players[c.Slot]);
+							}
+						}
+
+						var id = 0;
+						var players = save.GameInfo.Players.ToArray();
+						foreach (var slot in slots)
+						{
+							if (players.Count() <= id)
+							{
+								server.LobbyInfo.Slots.Remove(slot);
+								continue;
+							}
+
+							server.LobbyInfo.Slots[slot].Required = true;
+							server.LobbyInfo.Slots[slot].LockRace = true;
+							server.LobbyInfo.Slots[slot].LockTeam = true;
+							server.LobbyInfo.Slots[slot].LockSpawn = true;
+
+							if (players[id].IsBot)
+							{
+								server.LobbyInfo.Slots[slot].Closed = false;
+								server.LobbyInfo.Slots[slot].AllowPlayers = false;
+									
+								// Create a new bot from replay reference
+								var bot = new Session.Client()
+								{
+									Index = players[id].ClientIndex,
+									Name = players[id].Name,
+									Bot = players[id].Name,
+									Slot = slot,
+									Country = players[id].FactionId,
+									SpawnPoint = players[id].SpawnPoint,
+									Team = players[id].Team,
+									State = Session.ClientState.NotReady,
+									BotControllerClientIndex = 0
+								};
+
+								// Set the color of the bot according to replay
+								bot.Color = bot.PreferredColor = players[id].Color;
+
+								server.LobbyInfo.Clients.Add(bot);
+
+								S.SyncClientToPlayerReference(bot, server.Map.Players[slot]);
+							}
+							else
+								server.LobbyInfo.Slots[slot].AllowBots = false;
+
+							id++;
+						}
+
+						//var opt = save.GameInfo.MapPreview.Map.Options;
+						//server.LobbyInfo.GlobalSettings.AllowCheats =  opt.Cheats.Value;
+						//ve.GameInfo.MapPreview.Map.Options;
+
+						
+						server.SyncLobbyClients();
+						server.SyncLobbySlots();
+						server.SyncLobbyInfo();
+
+						server.SendMessage("{0} changed the map to {1}.".F(client.Name, server.Map.Title));
+
+						return true;
+					}},
 				{ "fragilealliance",
 					s =>
 					{
@@ -350,7 +527,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.FragileAlliances.HasValue)
+						if (server.Map.Options.FragileAlliances.HasValue && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled alliance configuration");
 							return true;
@@ -372,7 +549,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.Cheats.HasValue)
+						if (server.Map.Options.Cheats.HasValue && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled cheat configuration");
 							return true;
@@ -394,7 +571,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.Shroud.HasValue)
+						if (server.Map.Options.Shroud.HasValue && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled shroud configuration");
 							return true;
@@ -416,7 +593,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.Fog.HasValue)
+						if (server.Map.Options.Fog.HasValue && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled fog configuration");
 							return true;
@@ -480,7 +657,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.Crates.HasValue)
+						if (server.Map.Options.Crates.HasValue && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled crate configuration");
 							return true;
@@ -502,7 +679,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.AllyBuildRadius.HasValue)
+						if (server.Map.Options.AllyBuildRadius.HasValue && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled ally build radius configuration");
 							return true;
@@ -546,7 +723,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (!server.Map.Options.ConfigurableStartingUnits)
+						if (!server.Map.Options.ConfigurableStartingUnits && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled start unit configuration");
 							return true;
@@ -571,7 +748,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.StartingCash.HasValue)
+						if (server.Map.Options.StartingCash.HasValue && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled cash configuration");
 							return true;
@@ -592,7 +769,7 @@ namespace OpenRA.Mods.RA.Server
 							return true;
 						}
 
-						if (server.Map.Options.TechLevel != null)
+						if (server.Map.Options.TechLevel != null && server.LobbyInfo.GlobalSettings.AllowConfiguration)
 						{
 							server.SendOrderTo(conn, "Message", "Map has disabled Tech configuration");
 							return true;
@@ -785,6 +962,7 @@ namespace OpenRA.Mods.RA.Server
 			{
 				PlayerReference = pr.Name,
 				Closed = false,
+				AllowPlayers = pr.AllowPlayers,
 				AllowBots = pr.AllowBots,
 				LockRace = pr.LockRace,
 				LockColor = pr.LockColor,

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -39,11 +39,16 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		public static void ShowSlotDropDown(Ruleset rules, DropDownButtonWidget dropdown, Session.Slot slot,
 			Session.Client client, OrderManager orderManager)
 		{
-			var options = new Dictionary<string, IEnumerable<SlotDropDownOption>>() {{"Slot", new List<SlotDropDownOption>()
-			{
-				new SlotDropDownOption("Open", "slot_open "+slot.PlayerReference, () => (!slot.Closed && client == null)),
-				new SlotDropDownOption("Closed", "slot_close "+slot.PlayerReference, () => slot.Closed)
-			}}};
+			var slots = new List<SlotDropDownOption>();
+
+			if (!slot.Required)
+				slots.Add(new SlotDropDownOption("Closed", "slot_close " + slot.PlayerReference, () => slot.Closed));
+			
+			if (slot.AllowPlayers)
+				slots.Add(new SlotDropDownOption("Open", "slot_open " + slot.PlayerReference, () => (!slot.Closed && client == null)));
+
+			var options = new Dictionary<string, IEnumerable<SlotDropDownOption>>();
+			options.Add(slots.Any() ? "Slots" : "Slots Disabled", slots);
 
 			var bots = new List<SlotDropDownOption>();
 			if (slot.AllowBots)

--- a/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/SaveBrowserLogic.cs
@@ -1,0 +1,366 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using OpenRA.FileFormats;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Network;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.RA.Widgets.Logic
+{
+	public class SaveBrowserLogic
+	{
+		Widget panel;
+		ScrollPanelWidget saveList, playerList;
+		ScrollItemWidget playerTemplate, playerHeader;
+		List<ReplayMetadata> saves;
+		Dictionary<ReplayMetadata, SaveState> saveState = new Dictionary<ReplayMetadata, SaveState>();
+		ScrollPanelWidget descriptionPanel;
+		Action<ReplayMetadata> onLoad;
+		LabelWidget descriptionLabel;
+		SpriteFont descriptionFont;
+
+		Dictionary<CPos, SpawnOccupant> selectedSpawns;
+		ReplayMetadata selectedSave;
+
+		[ObjectCreator.UseCtor]
+		public SaveBrowserLogic(Widget widget, Action onExit, Action<ReplayMetadata> onLoad)
+		{
+			this.onLoad = onLoad;
+			panel = widget;
+
+			playerList = panel.Get<ScrollPanelWidget>("PLAYER_LIST");
+			playerHeader = playerList.Get<ScrollItemWidget>("HEADER");
+			playerTemplate = playerList.Get<ScrollItemWidget>("TEMPLATE");
+			playerList.RemoveChildren();
+
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
+
+			saveList = panel.Get<ScrollPanelWidget>("SAVE_LIST");
+			var template = panel.Get<ScrollItemWidget>("SAVE_TEMPLATE");
+			descriptionPanel = panel.Get<ScrollPanelWidget>("SAVE_DESCRIPTION_PANEL");
+			descriptionLabel = descriptionPanel.Get<LabelWidget>("SAVE_DESCRIPTION");
+			descriptionFont = Game.Renderer.Fonts[descriptionLabel.Font];
+
+			var mod = Game.modData.Manifest.Mod;
+			var dir = new[] { Platform.SupportDir, "Saves", mod.Id, mod.Version }.Aggregate(Path.Combine);
+
+			saveList.RemoveChildren();
+			if (Directory.Exists(dir))
+			{
+				using (new Support.PerfTimer("Load saves"))
+				{
+					saves = Directory
+						.GetFiles(dir, "*.orasave")
+						.Select(ReplayMetadata.Read)
+						.Where(r => r != null)
+						.OrderByDescending(r => r.GameInfo.StartTimeUtc)
+						.ToList();
+				}
+
+				foreach (var save in saves)
+					AddSave(save, template);
+
+				SelectFirstVisibleSave();
+			}
+			else
+				saves = new List<ReplayMetadata>();
+
+			var load = panel.Get<ButtonWidget>("LOAD_BUTTON");
+			load.IsDisabled = () => selectedSave == null || selectedSave.GameInfo.MapPreview.Status != MapStatus.Available;
+			load.OnClick = () => { Ui.CloseWindow(); onLoad(selectedSave); };
+
+			panel.Get("SAVE_INFO").IsVisible = () => selectedSave != null;
+
+			var preview = panel.Get<MapPreviewWidget>("MAP_PREVIEW");
+			preview.SpawnOccupants = () => selectedSpawns;
+			preview.Preview = () => selectedSave != null ? selectedSave.GameInfo.MapPreview : null;
+
+			var title = panel.GetOrNull<LabelWidget>("MAP_TITLE");
+			if (title != null)
+				title.GetText = () => selectedSave != null ? selectedSave.GameInfo.MapPreview.Title : null;
+
+			var type = panel.GetOrNull<LabelWidget>("MAP_TYPE");
+			if (type != null)
+				type.GetText = () => selectedSave.GameInfo.MapPreview.Type;
+
+			panel.Get<LabelWidget>("DURATION").GetText = () => WidgetUtils.FormatTimeSeconds((int)selectedSave.GameInfo.Duration.TotalSeconds);
+
+			SetupManagement();
+		}
+
+		void ApplyFilter(GameType type)
+		{
+			foreach (var save in saves)
+				saveState[save].Visible = EvaluateSaveVisibility(save, type);
+
+			if (selectedSave == null || saveState[selectedSave].Visible == false)
+				SelectFirstVisibleSave();
+
+			saveList.Layout.AdjustChildren();
+		}
+
+		bool EvaluateSaveVisibility(ReplayMetadata replay, GameType type)
+		{
+			// Game type
+			if ((type == GameType.Multiplayer && replay.GameInfo.IsSinglePlayer) || (type == GameType.Singleplayer && !replay.GameInfo.IsSinglePlayer))
+				return false;
+			return true;
+		}
+
+		void SetupManagement()
+		{
+			{
+				var button = panel.Get<ButtonWidget>("MNG_RENSEL_BUTTON");
+				button.IsDisabled = () => selectedSave == null;
+				button.OnClick = () =>
+				{
+					var r = selectedSave;
+					var initialName = Path.GetFileNameWithoutExtension(r.FilePath);
+					var directoryName = Path.GetDirectoryName(r.FilePath);
+					var invalidChars = Path.GetInvalidFileNameChars();
+
+					ConfirmationDialogs.TextInputPrompt(
+						"Rename Save",
+						"Enter a new file name:",
+						initialName,
+						onAccept: newName => RenameSave(r, newName),
+						onCancel: null,
+						acceptText: "Rename",
+						cancelText: null,
+						inputValidator: newName =>
+						{
+							if (newName == initialName)
+								return false;
+
+							if (string.IsNullOrWhiteSpace(newName))
+								return false;
+
+							if (newName.IndexOfAny(invalidChars) >= 0)
+								return false;
+
+							if (File.Exists(Path.Combine(directoryName, newName)))
+								return false;
+
+							return true;
+						});
+				};
+			}
+
+			Action<ReplayMetadata, Action> onDeleteSave = (r, after) =>
+			{
+				ConfirmationDialogs.PromptConfirmAction(
+					"Delete selected save?",
+					"Delete save '{0}'?".F(Path.GetFileNameWithoutExtension(r.FilePath)),
+					() =>
+					{
+						DeleteSave(r);
+						if (after != null)
+							after.Invoke();
+					},
+					null,
+					"Delete");
+			};
+
+			{
+				var button = panel.Get<ButtonWidget>("MNG_DELSEL_BUTTON");
+				button.IsDisabled = () => selectedSave == null;
+				button.OnClick = () =>
+				{
+					onDeleteSave(selectedSave, () =>
+					{
+						if (selectedSave == null)
+							SelectFirstVisibleSave();
+					});
+				};
+			}
+
+			{
+				var button = panel.Get<ButtonWidget>("MNG_DELALL_BUTTON");
+				button.IsDisabled = () => saveState.Count(kvp => kvp.Value.Visible) == 0;
+				button.OnClick = () =>
+				{
+					var list = saveState.Where(kvp => kvp.Value.Visible).Select(kvp => kvp.Key).ToList();
+					if (list.Count == 0)
+						return;
+
+					if (list.Count == 1)
+					{
+						onDeleteSave(list[0], () => { if (selectedSave == null) SelectFirstVisibleSave(); });
+						return;
+					}
+
+					ConfirmationDialogs.PromptConfirmAction(
+						"Delete all selected saves?",
+						"Delete {0} saves?".F(list.Count),
+						() =>
+						{
+							list.ForEach(DeleteSave);
+							if (selectedSave == null)
+								SelectFirstVisibleSave();
+						},
+						null,
+						"Delete All");
+				};
+			}
+		}
+
+		void RenameSave(ReplayMetadata save, string newFilenameWithoutExtension)
+		{
+			try
+			{
+				save.RenameFile(newFilenameWithoutExtension);
+				saveState[save].Item.Text = newFilenameWithoutExtension;
+			}
+			catch (Exception ex)
+			{
+				Log.Write("debug", ex.ToString());
+				return;
+			}
+		}
+
+		void DeleteSave(ReplayMetadata save)
+		{
+			try
+			{
+				File.Delete(save.FilePath);
+			}
+			catch (Exception ex)
+			{
+				Game.Debug("Failed to delete save file '{0}'. See the logs for details.", save.FilePath);
+				Log.Write("debug", ex.ToString());
+				return;
+			}
+
+			if (save == selectedSave)
+				SelectSave(null);
+
+			saveList.RemoveChild(saveState[save].Item);
+			saves.Remove(save);
+			saveState.Remove(save);
+		}
+
+		void SelectFirstVisibleSave()
+		{
+			SelectSave(saves.FirstOrDefault(s => saveState[s].Visible));
+		}
+
+		void SelectSave(ReplayMetadata save)
+		{
+			selectedSave = save;
+			selectedSpawns = (selectedSave != null)
+				? LobbyUtils.GetSpawnOccupants(selectedSave.GameInfo.Players, selectedSave.GameInfo.MapPreview)
+				: new Dictionary<CPos, SpawnOccupant>();
+
+			if (save == null)
+				return;
+
+			try
+			{
+				var players = save.GameInfo.Players
+					.GroupBy(p => p.Team)
+					.OrderBy(g => g.Key);
+
+				var teams = new Dictionary<string, IEnumerable<GameInformation.Player>>();
+				var noTeams = players.Count() == 1;
+				foreach (var p in players)
+				{
+					var label = noTeams ? "Players" : p.Key == 0 ? "No Team" : "Team {0}".F(p.Key);
+					teams.Add(label, p);
+				}
+
+				playerList.RemoveChildren();
+
+				foreach (var kv in teams)
+				{
+					var group = kv.Key;
+					if (group.Length > 0)
+					{
+						var header = ScrollItemWidget.Setup(playerHeader, () => true, () => { });
+						header.Get<LabelWidget>("LABEL").GetText = () => group;
+						playerList.AddChild(header);
+					}
+
+					foreach (var option in kv.Value)
+					{
+						var o = option;
+
+						var color = o.Color.RGB;
+
+						var item = ScrollItemWidget.Setup(playerTemplate, () => false, () => { });
+
+						var label = item.Get<LabelWidget>("LABEL");
+						label.GetText = () => o.Name;
+						label.GetColor = () => color;
+
+						var flag = item.Get<ImageWidget>("FLAG");
+						flag.GetImageCollection = () => "flags";
+						flag.GetImageName = () => o.FactionId;
+
+						playerList.AddChild(item);
+					}
+				}
+
+				if (selectedSave.GameInfo.MapPreview.Status == MapStatus.Available)
+				{
+					var text = selectedSave.GameInfo.MapPreview.Map.Description != null ? selectedSave.GameInfo.MapPreview.Map.Description.Replace("\\n", "\n") : "";
+					text = WidgetUtils.WrapText(text, descriptionLabel.Bounds.Width, descriptionFont);
+					descriptionLabel.Text = text;
+					descriptionLabel.Bounds.Height = descriptionFont.Measure(text).Y;
+					descriptionPanel.ScrollToTop();
+					descriptionPanel.Layout.AdjustChildren();
+				}
+			}
+			catch (Exception e)
+			{
+				Log.Write("debug", "Exception while parsing save: {0}", e);
+				SelectSave(null);
+			}
+		}
+
+		void AddSave(ReplayMetadata save, ScrollItemWidget template)
+		{
+			var item = ScrollItemWidget.Setup(template,
+				() => selectedSave == save,
+				() => SelectSave(save),
+				() => { Ui.CloseWindow(); onLoad(save); });
+
+			saveState[save] = new SaveState
+			{
+				Item = item,
+				Visible = true
+			};
+
+			item.Text = Path.GetFileNameWithoutExtension(save.FilePath);
+			item.Get<LabelWidget>("TITLE").GetText = () => item.Text;
+			item.IsVisible = () => saveState[save].Visible;
+			saveList.AddChild(item);
+		}
+
+		class SaveState
+		{
+			public bool Visible;
+			public ScrollItemWidget Item;
+		}
+
+		public enum GameType
+		{
+			Any,
+			Singleplayer,
+			Multiplayer
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame-menu.yaml
+++ b/mods/cnc/chrome/ingame-menu.yaml
@@ -23,7 +23,7 @@ Container@INGAME_MENU:
 		Container@MENU_BUTTONS:
 			X: (WINDOW_RIGHT-WIDTH)/2
 			Y: WINDOW_BOTTOM-33-HEIGHT-10
-			Width: 740
+			Width: 890
 			Height: 35
 			Children:
 				Button@ABORT_MISSION:
@@ -50,9 +50,15 @@ Container@INGAME_MENU:
 					Width: 140
 					Height: 35
 					Text: Settings
+				Button@SAVE:
+					X: 600
+					Y: 0
+					Width: 140
+					Height: 35
+					Text: Save
 				Button@RESUME:
 					Key: escape
-					X: 600
+					X: 750
 					Y: 0
 					Width: 140
 					Height: 35

--- a/mods/cnc/chrome/savebrowser.yaml
+++ b/mods/cnc/chrome/savebrowser.yaml
@@ -1,0 +1,201 @@
+Background@SAVEBROWSER_PANEL:
+	Logic: SaveBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - HEIGHT)/2
+	Width: 780
+	Height: 500
+	Children:
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				Container@SAVE_LIST_CONTAINER:
+					X: 20
+					Y: 20
+					Width: 245
+					Height: PARENT_BOTTOM - 20 - 55
+					Children:
+						Label@SAVEBROWSER_LABEL_TITLE:
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Choose Save
+							Align: Center
+							Font: Bold
+						ScrollPanel@SAVE_LIST:
+							X: 0
+							Y: 30
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM - 110
+							CollapseHiddenChildren: True
+							Children:
+								ScrollItem@SAVE_TEMPLATE:
+									Width: PARENT_RIGHT-27
+									Height: 25
+									X: 2
+									Visible: false
+									Children:
+										Label@TITLE:
+											X: 10
+											Width: PARENT_RIGHT-20
+											Height: 25
+						Container@MANAGEMENT:
+							X: PARENT_RIGHT / 4
+							Y: PARENT_BOTTOM - 80
+							Width: PARENT_RIGHT / 2
+							Height: 115
+							Children:
+								Label@MANAGE_TITLE:
+									Width: PARENT_RIGHT
+									Height: 25
+									Font: Bold
+									Align: Center
+									Text: Manage
+								Button@MNG_RENSEL_BUTTON:
+									Y: 30
+									Width: PARENT_RIGHT
+									Height: 25
+									Text: Rename
+									Font: Bold
+									Key: F2
+								Button@MNG_DELSEL_BUTTON:
+									Y: 60
+									Width: PARENT_RIGHT
+									Height: 25
+									Text: Delete
+									Font: Bold
+									Key: Delete
+								Button@MNG_DELALL_BUTTON:
+									Y: 90
+									Width: PARENT_RIGHT
+									Height: 25
+									Text: Delete All
+									Font: Bold
+		Container@MAP_BG_CONTAINER:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20
+			Width: 194
+			Height: 30 + 194
+			Children:
+				Label@MAP_BG_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Preview
+					Align: Center
+					Font: Bold
+				Background@MAP_BG:
+					Y: 30
+					Width: 194
+					Height: 194
+					Background: panel-gray
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: 192
+							Height: 192
+							TooltipContainer: TOOLTIP_CONTAINER
+		Container@SAVE_DESCRIPTION:
+			X: PARENT_RIGHT - 224 - WIDTH
+			Y: 20
+			Width: 280
+			Height: PARENT_BOTTOM - 45
+			Children:
+				Label@SAVE_DESCRIPTION_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Description
+					Align: Center
+					Font: Bold
+				ScrollPanel@SAVE_DESCRIPTION_PANEL:
+					X: 0
+					Y: 30
+					Width: 280
+					Height: PARENT_BOTTOM - 25
+					Children:
+						Label@SAVE_DESCRIPTION:
+							X: 5
+							Y: 5
+							Width: 265
+							VAlign: Top
+		Container@SAVE_INFO:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20 + 30+194 + 10
+			Width: 194
+			Height: PARENT_BOTTOM - 20 - 30-194 - 10 - 55
+			Children:
+				Label@MAP_TITLE:
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Bold
+					Align: Center
+				Label@MAP_TYPE:
+					Y: 15
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: TinyBold
+					Align: Center
+				Label@DURATION:
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Tiny
+					Align: Center
+				ScrollPanel@PLAYER_LIST:
+					Y: 50
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 50
+					IgnoreChildMouseOver: true
+					Children:
+						ScrollItem@HEADER:
+							BaseName: scrollheader
+							Width: PARENT_RIGHT-27
+							Height: 13
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+						ScrollItem@TEMPLATE:
+							Width: PARENT_RIGHT-27
+							Height: 25
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Image@FLAG:
+									X: 4
+									Y: 6
+									Width: 32
+									Height: 16
+								Label@LABEL:
+									X: 40
+									Width: 60
+									Height: 25
+								Label@NOFLAG_LABEL:
+									X: 5
+									Width: PARENT_RIGHT
+									Height: 25
+		Button@LOAD_BUTTON:
+			Key: return
+			X: PARENT_RIGHT - 110 - 105
+			Y: PARENT_BOTTOM - 55
+			Width: 100
+			Height: 35
+			Text: Load
+			Font: Bold
+		Button@CANCEL_BUTTON:
+			Key: escape
+			X: PARENT_RIGHT - 110 - 10
+			Y: PARENT_BOTTOM - 55
+			Width: 100
+			Height: 35
+			Text: Cancel
+			Font: Bold
+		TooltipContainer@TOOLTIP_CONTAINER:
+

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -86,6 +86,7 @@ ChromeLayout:
 	mods/cnc/chrome/color-picker.yaml
 	mods/cnc/chrome/mapchooser.yaml
 	mods/cnc/chrome/replaybrowser.yaml
+	mods/cnc/chrome/savebrowser.yaml
 	mods/cnc/chrome/ingame.yaml
 	mods/cnc/chrome/ingame-chat.yaml
 	mods/cnc/chrome/ingame-menu.yaml

--- a/mods/d2k/chrome/ingame-menu.yaml
+++ b/mods/d2k/chrome/ingame-menu.yaml
@@ -13,7 +13,7 @@ Container@INGAME_MENU:
 			X: 100
 			Y: (WINDOW_BOTTOM - HEIGHT)/2
 			Width: 200
-			Height: 295
+			Height: 335
 			Children:
 				Label@LABEL_TITLE:
 					X: (PARENT_RIGHT - WIDTH)/2
@@ -31,30 +31,37 @@ Container@INGAME_MENU:
 					Text: Resume
 					Font: Bold
 					Key: escape
-				Button@SETTINGS:
+				Button@SAVE:
 					X: (PARENT_RIGHT - WIDTH)/2
 					Y: 100
+					Width: 140
+					Height: 30
+					Text: Save
+					Font: Bold
+				Button@SETTINGS:
+					X: (PARENT_RIGHT - WIDTH)/2
+					Y: 140
 					Width: 140
 					Height: 30
 					Text: Settings
 					Font: Bold
 				Button@MUSIC:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 140
+					Y: 180
 					Width: 140
 					Height: 30
 					Text: Music
 					Font: Bold
 				Button@SURRENDER:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 180
+					Y: 220
 					Width: 140
 					Height: 30
 					Text: Surrender
 					Font: Bold
 				Button@ABORT_MISSION:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 220
+					Y: 260
 					Width: 140
 					Height: 30
 					Text: Abort Mission

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -85,6 +85,7 @@ ChromeLayout:
 	mods/ra/chrome/connection.yaml
 	mods/ra/chrome/directconnect.yaml
 	mods/ra/chrome/replaybrowser.yaml
+	mods/ra/chrome/savebrowser.yaml
 	mods/d2k/chrome/dropdowns.yaml
 	mods/ra/chrome/musicplayer.yaml
 	mods/d2k/chrome/tooltips.yaml

--- a/mods/ra/chrome/ingame-menu.yaml
+++ b/mods/ra/chrome/ingame-menu.yaml
@@ -26,7 +26,7 @@ Container@INGAME_MENU:
 			X: 100
 			Y: (WINDOW_BOTTOM - HEIGHT)/2
 			Width: 200
-			Height: 295
+			Height: 335
 			Children:
 				Label@LABEL_TITLE:
 					X: (PARENT_RIGHT - WIDTH)/2
@@ -44,30 +44,37 @@ Container@INGAME_MENU:
 					Text: Resume
 					Font: Bold
 					Key: escape
-				Button@SETTINGS:
+				Button@SAVE:
 					X: (PARENT_RIGHT - WIDTH)/2
 					Y: 100
+					Width: 140
+					Height: 30
+					Text: Save
+					Font: Bold
+				Button@SETTINGS:
+					X: (PARENT_RIGHT - WIDTH)/2
+					Y: 140
 					Width: 140
 					Height: 30
 					Text: Settings
 					Font: Bold
 				Button@MUSIC:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 140
+					Y: 180
 					Width: 140
 					Height: 30
 					Text: Music
 					Font: Bold
 				Button@SURRENDER:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 180
+					Y: 220
 					Width: 140
 					Height: 30
 					Text: Surrender
 					Font: Bold
 				Button@ABORT_MISSION:
 					X: (PARENT_RIGHT - WIDTH)/2
-					Y: 220
+					Y: 260
 					Width: 140
 					Height: 30
 					Text: Abort Mission

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -77,6 +77,13 @@ Background@SERVER_LOBBY:
 			Height: 25
 			Font: Bold
 			Text: Game Options
+		Button@LOAD_BUTTON:
+			X: 194
+			Y: PARENT_BOTTOM - 281
+			Width: 135
+			Height: 25
+			Text: Load
+			Font: Bold
 		Button@CHANGEMAP_BUTTON:
 			X: 336
 			Y: PARENT_BOTTOM - 291

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -73,28 +73,28 @@ Background@SERVER_LOBBY:
 		Button@OPTIONS_BUTTON:
 			X: 194
 			Y: PARENT_BOTTOM - 291
-			Width: 135
+			Width: 93
 			Height: 25
 			Font: Bold
 			Text: Game Options
 		Button@LOAD_BUTTON:
-			X: 194
-			Y: PARENT_BOTTOM - 281
-			Width: 135
+			X: 294
+			Y: PARENT_BOTTOM - 291
+			Width: 85
 			Height: 25
 			Text: Load
 			Font: Bold
 		Button@CHANGEMAP_BUTTON:
-			X: 336
+			X: 386
 			Y: PARENT_BOTTOM - 291
-			Width: 135
+			Width: 115
 			Height: 25
 			Text: Change Map
 			Font: Bold
 		Button@START_GAME_BUTTON:
-			X: 478
+			X: 508
 			Y: PARENT_BOTTOM - 291
-			Width: 135
+			Width: 105
 			Height: 25
 			Text: Start Game
 			Font: Bold

--- a/mods/ra/chrome/savebrowser.yaml
+++ b/mods/ra/chrome/savebrowser.yaml
@@ -1,0 +1,196 @@
+Background@SAVEBROWSER_PANEL:
+	Logic: SaveBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - HEIGHT)/2
+	Width: 780
+	Height: 535
+	Children:
+		Container@SAVE_LIST_CONTAINER:
+			X: 20
+			Y: 20
+			Width: 245
+			Height: PARENT_BOTTOM - 20 - 55
+			Children:
+				Label@SAVEBROWSER_LABEL_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Choose Save
+					Align: Center
+					Font: Bold
+				ScrollPanel@SAVE_LIST:
+					X: 0
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 110
+					CollapseHiddenChildren: True
+					Children:
+						ScrollItem@SAVE_TEMPLATE:
+							Width: PARENT_RIGHT-27
+							Height: 25
+							X: 2
+							Visible: false
+							Children:
+								Label@TITLE:
+									X: 10
+									Width: PARENT_RIGHT-20
+									Height: 25
+				Container@MANAGEMENT:
+					X: 0
+					Y: PARENT_BOTTOM - 80
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Label@MANAGE_TITLE:
+							Width: PARENT_RIGHT
+							Height: 25
+							Font: Bold
+							Align: Center
+							Text: Manage
+						Button@MNG_RENSEL_BUTTON:
+							Y: 30
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Rename
+							Font: Bold
+							Key: F2
+						Button@MNG_DELSEL_BUTTON:
+							Y: 60
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Delete
+							Font: Bold
+							Key: Delete
+						Button@MNG_DELALL_BUTTON:
+							Y: 90
+							Width: PARENT_RIGHT
+							Height: 25
+							Text: Delete All
+							Font: Bold
+		Container@MAP_BG_CONTAINER:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20
+			Width: 194
+			Height: 30 + 194
+			Children:
+				Label@MAP_BG_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Preview
+					Align: Center
+					Font: Bold
+				Background@MAP_BG:
+					Y: 30
+					Width: 194
+					Height: 194
+					Background: dialog3
+					Children:
+						MapPreview@MAP_PREVIEW:
+							X: 1
+							Y: 1
+							Width: 192
+							Height: 192
+							TooltipContainer: TOOLTIP_CONTAINER
+		Container@SAVE_DESCRIPTION:
+			X: PARENT_RIGHT - 224 - WIDTH
+			Y: 20
+			Width: 280
+			Height: PARENT_BOTTOM - 45
+			Children:
+				Label@SAVE_DESCRIPTION_TITLE:
+					Width: PARENT_RIGHT
+					Height: 25
+					Text: Description
+					Align: Center
+					Font: Bold
+				ScrollPanel@SAVE_DESCRIPTION_PANEL:
+					X: 0
+					Y: 30
+					Width: 280
+					Height: PARENT_BOTTOM - 25
+					Children:
+						Label@SAVE_DESCRIPTION:
+							X: 5
+							Y: 5
+							Width: 265
+							VAlign: Top
+		Container@SAVE_INFO:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: 20 + 30+194 + 10
+			Width: 194
+			Height: PARENT_BOTTOM - 20 - 30-194 - 10 - 55
+			Children:
+				Label@MAP_TITLE:
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Bold
+					Align: Center
+				Label@MAP_TYPE:
+					Y: 15
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: TinyBold
+					Align: Center
+				Label@DURATION:
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Tiny
+					Align: Center
+				ScrollPanel@PLAYER_LIST:
+					Y: 50
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 50
+					IgnoreChildMouseOver: true
+					Children:
+						ScrollItem@HEADER:
+							BaseName: scrollheader
+							Width: PARENT_RIGHT-27
+							Height: 13
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+						ScrollItem@TEMPLATE:
+							Width: PARENT_RIGHT-27
+							Height: 25
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Image@FLAG:
+									X: 4
+									Y: 6
+									Width: 32
+									Height: 16
+								Label@LABEL:
+									X: 40
+									Width: 60
+									Height: 25
+								Label@NOFLAG_LABEL:
+									X: 5
+									Width: PARENT_RIGHT
+									Height: 25
+		Button@LOAD_BUTTON:
+			X: PARENT_RIGHT - 110 - 105
+			Y: PARENT_BOTTOM - 45
+			Width: 90
+			Height: 25
+			Text: Load
+			Font: Bold
+			Key: p
+		Button@CANCEL_BUTTON:
+			X: PARENT_RIGHT - 110
+			Y: PARENT_BOTTOM - 45
+			Width: 90
+			Height: 25
+			Text: Cancel
+			Font: Bold
+			Key: escape
+		TooltipContainer@TOOLTIP_CONTAINER:
+

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -98,6 +98,7 @@ ChromeLayout:
 	mods/ra/chrome/connection.yaml
 	mods/ra/chrome/directconnect.yaml
 	mods/ra/chrome/replaybrowser.yaml
+	mods/ra/chrome/savebrowser.yaml
 	mods/ra/chrome/dropdowns.yaml
 	mods/ra/chrome/musicplayer.yaml
 	mods/ra/chrome/tooltips.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -127,6 +127,7 @@ ChromeLayout:
 	mods/ra/chrome/connection.yaml
 	mods/ra/chrome/directconnect.yaml
 	mods/ra/chrome/replaybrowser.yaml
+	mods/ra/chrome/savebrowser.yaml
 	mods/ra/chrome/dropdowns.yaml
 	mods/ra/chrome/musicplayer.yaml
 	mods/ra/chrome/tooltips.yaml


### PR DESCRIPTION
This is the combined results of my discussion with pchote, #6280 and #6238.

This supports loading in multiplayer and singleplayer, you can take over another human player when you load.
You can watch replays in this branch as normal, both loaded and original.

Only the host needs to have the replays for them to load,
not sure how Dedicated servers would work with this.

 ^ Needs testing on multiple computers.

Problems that might or might not be addressed:
- UI is needed, 3f6c17e is a prototype (pchote doesnt like this so looking for a better way)
            http://imgur.com/a/QgqmE#0
- Doesnt support taking over AI (this would need a rewrite on how the AI gets orders)
- Start button is broken when loading, to load everyone has to hit ready.
- If the save was made after a player disconnected it will freeze when trying to load.
- When you save a game where the admin is a spectator and load, if the admin is a spectator (in the loading lobby) it kicks the admin and freezes the game.
- If you join a lobby where a save game was loaded it doesnt force your faction/team/spawnpoint on join, have to switch slots to load the settings

This PR also makes observers independant of the game, this means they no longer lag the game for other players, but they can still chat even if they somehow fall behind (because of lag).

You can have as many observers as you want when loading/playing a game, they dont affect the game (unless one of the spectators is the admin, he is the only one who works like the old observers since he needs to give orders to bots).
