### PR TITLE
Changes Weapon.Impact() to use Target (from WPos).

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -144,13 +144,14 @@ namespace OpenRA.GameRules
 			return true;
 		}
 
-		public void Impact(WPos pos, Actor firedBy, IEnumerable<int> damageModifiers)
+		///<summary>Applies all the weapon's warheads to the target.</summary>
+		public void Impact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
 			foreach (var wh in Warheads)
 			{
 				Action a;
 
-				a = () => wh.DoImpact(Target.FromPos(pos), firedBy, damageModifiers);
+				a = () => wh.DoImpact(target, firedBy, damageModifiers);
 				if (wh.Delay > 0)
 					firedBy.World.AddFrameEndTask(
 						w => w.Add(new DelayedAction(wh.Delay, a)));

--- a/OpenRA.Mods.Cnc/Effects/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Effects/IonCannon.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Cnc.Effects
 			if (!impacted && weaponDelay-- <= 0)
 			{
 				var weapon = world.Map.Rules.Weapons[this.weapon.ToLowerInvariant()];
-				weapon.Impact(target.CenterPosition, firedBy.PlayerActor, Enumerable.Empty<int>());
+				weapon.Impact(target, firedBy.PlayerActor, Enumerable.Empty<int>());
 				impacted = true;
 			}
 		}

--- a/OpenRA.Mods.Cnc/PoisonedByTiberium.cs
+++ b/OpenRA.Mods.Cnc/PoisonedByTiberium.cs
@@ -43,7 +43,8 @@ namespace OpenRA.Mods.Cnc
 			if (!info.Resources.Contains(r.Info.Name)) return;
 
 			var weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()];
-			weapon.Impact(self.CenterPosition, self.World.WorldActor, Enumerable.Empty<int>());
+
+			weapon.Impact(Target.FromActor(self), self.World.WorldActor, Enumerable.Empty<int>());
 			poisonTicks = weapon.ReloadDelay;
 		}
 	}

--- a/OpenRA.Mods.D2k/DamagedWithoutFoundation.cs
+++ b/OpenRA.Mods.D2k/DamagedWithoutFoundation.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.D2k
 			if (health.HP <= damageThreshold || --damageTicks > 0)
 				return;
 
-			weapon.Impact(self.CenterPosition, self.World.WorldActor, Enumerable.Empty<int>());
+			weapon.Impact(Target.FromActor(self), self.World.WorldActor, Enumerable.Empty<int>());
 			damageTicks = weapon.ReloadDelay;
 		}
 	}

--- a/OpenRA.Mods.RA/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.RA/Air/FallsToEarth.cs
@@ -55,7 +55,8 @@ namespace OpenRA.Mods.RA.Air
 				if (info.Explosion != null)
 				{
 					var weapon = self.World.Map.Rules.Weapons[info.Explosion.ToLowerInvariant()];
-					weapon.Impact(self.CenterPosition, self, Enumerable.Empty<int>());
+					// Use .FromPos since this actor is killed. Cannot use Target.FromActor
+					weapon.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
 				}
 
 				self.Destroy();

--- a/OpenRA.Mods.RA/Bridge.cs
+++ b/OpenRA.Mods.RA/Bridge.cs
@@ -299,7 +299,9 @@ namespace OpenRA.Mods.RA
 			self.World.AddFrameEndTask(w =>
 			{
 				var weapon = saboteur.World.Map.Rules.Weapons[Info.DemolishWeapon.ToLowerInvariant()];
-				weapon.Impact(self.CenterPosition, saboteur, Enumerable.Empty<int>());
+				// Use .FromPos since this actor is killed. Cannot use Target.FromActor
+				weapon.Impact(Target.FromPos(self.CenterPosition), saboteur, Enumerable.Empty<int>());
+
 				self.World.WorldActor.Trait<ScreenShaker>().AddEffect(15, self.CenterPosition, 6);
 				self.Kill(saboteur);
 			});

--- a/OpenRA.Mods.RA/Crates/ExplodeCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/ExplodeCrateAction.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA
 		public override void Activate(Actor collector)
 		{
 			var weapon = self.World.Map.Rules.Weapons[((ExplodeCrateActionInfo)info).Weapon.ToLowerInvariant()];
-			weapon.Impact(collector.CenterPosition, self, Enumerable.Empty<int>());
+			weapon.Impact(Target.FromPos(collector.CenterPosition), self, Enumerable.Empty<int>());
 			base.Activate(collector);
 		}
 	}

--- a/OpenRA.Mods.RA/Effects/Bullet.cs
+++ b/OpenRA.Mods.RA/Effects/Bullet.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			world.AddFrameEndTask(w => w.Remove(this));
 
-			args.Weapon.Impact(pos, args.SourceActor, args.DamageModifiers);
+			args.Weapon.Impact(Target.FromPos(pos), args.SourceActor, args.DamageModifiers);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.RA/Effects/GravityBomb.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Effects
 {
@@ -56,7 +57,7 @@ namespace OpenRA.Mods.RA.Effects
 			{
 				pos += new WVec(0, 0, args.PassiveTarget.Z - pos.Z);
 				world.AddFrameEndTask(w => w.Remove(this));
-				args.Weapon.Impact(pos, args.SourceActor, args.DamageModifiers);
+				args.Weapon.Impact(Target.FromPos(pos), args.SourceActor, args.DamageModifiers);
 			}
 
 			anim.Tick();

--- a/OpenRA.Mods.RA/Effects/LaserZap.cs
+++ b/OpenRA.Mods.RA/Effects/LaserZap.cs
@@ -13,6 +13,7 @@ using System.Drawing;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
+using OpenRA.Traits;
 using OpenRA.Mods.RA.Graphics;
 
 namespace OpenRA.Mods.RA.Effects
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.RA.Effects
 				if (hitanim != null)
 					hitanim.PlayThen("idle", () => animationComplete = true);
 
-				args.Weapon.Impact(target, args.SourceActor, args.DamageModifiers);
+				args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);
 				doneDamage = true;
 			}
 

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (ticks <= info.Arm)
 				return;
 
-			args.Weapon.Impact(pos, args.SourceActor, args.DamageModifiers);
+			args.Weapon.Impact(Target.FromPos(pos), args.SourceActor, args.DamageModifiers);
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)

--- a/OpenRA.Mods.RA/Effects/NukeLaunch.cs
+++ b/OpenRA.Mods.RA/Effects/NukeLaunch.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.RA.Effects
 		{
 			world.AddFrameEndTask(w => w.Remove(this));
 			var weapon = world.Map.Rules.Weapons[this.weapon.ToLowerInvariant()];
-			weapon.Impact(pos, firedBy.PlayerActor, Enumerable.Empty<int>());
+			weapon.Impact(Target.FromPos(pos), firedBy.PlayerActor, Enumerable.Empty<int>());
 			world.WorldActor.Trait<ScreenShaker>().AddEffect(20, pos, 5);
 
 			foreach (var a in world.ActorsWithTrait<NukePaletteEffect>())

--- a/OpenRA.Mods.RA/Effects/TeslaZap.cs
+++ b/OpenRA.Mods.RA/Effects/TeslaZap.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Effects
 {
@@ -47,7 +48,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (!doneDamage)
 			{
 				var pos = Args.GuidedTarget.IsValidFor(Args.SourceActor) ? Args.GuidedTarget.CenterPosition : Args.PassiveTarget;
-				Args.Weapon.Impact(pos, Args.SourceActor, Args.DamageModifiers);
+				Args.Weapon.Impact(Target.FromPos(pos), Args.SourceActor, Args.DamageModifiers);
 				doneDamage = true;
 			}
 		}

--- a/OpenRA.Mods.RA/Explodes.cs
+++ b/OpenRA.Mods.RA/Explodes.cs
@@ -51,7 +51,8 @@ namespace OpenRA.Mods.RA
 				if (weapon.Report != null && weapon.Report.Any())
 					Sound.Play(weapon.Report.Random(e.Attacker.World.SharedRandom), self.CenterPosition);
 	
-				weapon.Impact(self.CenterPosition, e.Attacker, Enumerable.Empty<int>());
+				// Use .FromPos since this actor is killed. Cannot use Target.FromActor
+				weapon.Impact(Target.FromPos(self.CenterPosition), e.Attacker, Enumerable.Empty<int>());
 			}
 		}
 

--- a/OpenRA.Mods.RA/MadTank.cs
+++ b/OpenRA.Mods.RA/MadTank.cs
@@ -72,7 +72,8 @@ namespace OpenRA.Mods.RA
 				if (info.ThumpDamageWeapon != null)
 				{
 					var weapon = self.World.Map.Rules.Weapons[info.ThumpDamageWeapon.ToLowerInvariant()];
-					weapon.Impact(self.CenterPosition, self, Enumerable.Empty<int>());
+					// Use .FromPos since this weapon needs to affect more than just the MadTank actor
+					weapon.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
 				}
 				screenShaker.AddEffect(info.ThumpShakeTime, self.CenterPosition, info.ThumpShakeIntensity, info.ThumpShakeMultiplier);
 				tick = 0;
@@ -111,7 +112,8 @@ namespace OpenRA.Mods.RA
 				if (info.DetonationWeapon != null)
 				{
 					var weapon = self.World.Map.Rules.Weapons[info.DetonationWeapon.ToLowerInvariant()];
-					weapon.Impact(self.CenterPosition, self, Enumerable.Empty<int>());
+					// Use .FromPos since this actor is killed. Cannot use Target.FromActor
+					weapon.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
 				}
 				self.Kill(self);
 			});


### PR DESCRIPTION
Requires #6265.

Split out from original overloaded PR #6162.

Improvement requested by @Phrohdoh, and allows calls to Weapon.Impact to specify a target, as opposed to just a position. Allowing much more flexible use of the Target parameter on the Warhead.DoImpact
