### PR TITLE
Disable fontconfig in packaged OSX build. 

### DIFF
--- a/packaging/osx/template.app/Contents/MacOS/OpenRA
+++ b/packaging/osx/template.app/Contents/MacOS/OpenRA
@@ -30,4 +30,5 @@ then
 	exit 1
 fi
 
-cd "$RESOURCES" && mono --debug OpenRA.Game.exe Graphics.Renderer=Sdl2
+# Override fontconfig with our own dummy config that prevents long cache delays
+cd "$RESOURCES" && FONTCONFIG_PATH="." mono --debug OpenRA.Game.exe Graphics.Renderer=Sdl2

--- a/packaging/osx/template.app/Contents/Resources/fonts.conf
+++ b/packaging/osx/template.app/Contents/Resources/fonts.conf
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!-- dummy fonts.conf file that removed unwanted system overhead -->
+<fontconfig/>


### PR DESCRIPTION
Works around https://bugzilla.xamarin.com/show_bug.cgi?id=16517 by forcing mono to use a dummy fontconfig configuration where there is nothing to cache.  Fixes #4785.
