### PR TITLE
Don’t display LaserZap if source and dest are hidden.

### DIFF
--- a/OpenRA.Mods.RA/Effects/LaserZap.cs
+++ b/OpenRA.Mods.RA/Effects/LaserZap.cs
@@ -82,6 +82,10 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
+			if (wr.world.FogObscures(wr.world.Map.CellContaining(target)) &&
+				wr.world.FogObscures(wr.world.Map.CellContaining(args.Source)))
+				yield break;
+
 			if (ticks < info.BeamDuration)
 			{
 				var rc = Color.FromArgb((info.BeamDuration - ticks) * 255 / info.BeamDuration, color);


### PR DESCRIPTION
Closes #6146.

Later, once we have code to find the intersection of a lines and cells (also needed for other fixes), we will be able to check all the cells along the path and only draw the parts of the beam that are actually visible.
