### PR TITLE
Fixed bogus warning as error CS0067 The event is never used

### DIFF
--- a/OpenRA.Game/Primitives/ObservableCollection.cs
+++ b/OpenRA.Game/Primitives/ObservableCollection.cs
@@ -18,7 +18,10 @@ namespace OpenRA.Primitives
 	public class ObservableCollection<T> : Collection<T>, IObservableCollection
 	{
 		public event Action<object> OnAdd = k => { };
+		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
+		#pragma warning disable 67
 		public event Action<object> OnRemove = k => { };
+		#pragma warning restore
 		public event Action<int> OnRemoveAt = i => { };
 		public event Action<object, object> OnSet = (o, n) => { };
 		public event Action OnRefresh = () => { };

--- a/OpenRA.Game/Primitives/ObservableDictionary.cs
+++ b/OpenRA.Game/Primitives/ObservableDictionary.cs
@@ -34,8 +34,11 @@ namespace OpenRA.Primitives
 
 		public event Action<object> OnAdd = k => { };
 		public event Action<object> OnRemove = k => { };
+		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
+		#pragma warning disable 67
 		public event Action<int> OnRemoveAt = i => { };
 		public event Action<object, object> OnSet = (o, n) => { };
+		#pragma warning restore
 		public event Action OnRefresh = () => { };
 
 		protected void FireOnRefresh()


### PR DESCRIPTION
as this breaks `make all` on Mac and Linux on the latest @mono version. See #6101
