### PR TITLE
Fixed Session.Deserialize exceptions not throwing properly

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -59,10 +59,9 @@ namespace OpenRA.Network
 
 				return session;
 			}
-			catch (InvalidOperationException)
+			catch (InvalidOperationException e)
 			{
-				Log.Write("exception", "Session deserialized invalid MiniYaml:\n{0}".F(data));
-				throw;
+				throw new InvalidOperationException("Session deserialized invalid MiniYaml:\n{0}".F(data), e);
 			}
 		}
 


### PR DESCRIPTION
as described in #6168 we don't get enough data to fix the crash, because the crash itself crashed. This makes everything go through Program.FatalError for complete logs and end user instructions what to do.
