### PR TITLE
Unhardcoded and self-documented more resource/smudge parameters

### DIFF
--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -17,8 +17,10 @@ namespace OpenRA.Traits
 	{
 		// HACK: The editor is getting really unmaintanable...
 		public readonly string EditorSprite;
+
 		public readonly string[] Variants = { };
 		public readonly string Palette = "terrain";
+		public readonly string Sequence = "resources";
 		public readonly int ResourceType = 1;
 
 		public readonly int ValuePerUnit = 0;
@@ -47,7 +49,7 @@ namespace OpenRA.Traits
 			Variants = new Dictionary<string, Sprite[]>();
 			foreach (var v in info.Variants)
 			{
-				var seq = world.Map.SequenceProvider.GetSequence("resources", v);
+				var seq = world.Map.SequenceProvider.GetSequence(Info.Sequence, v);
 				var sprites = Exts.MakeArray(seq.Length, x => seq.GetSprite(x));
 				Variants.Add(v, sprites);
 			}

--- a/OpenRA.Mods.RA/World/ResourceLayer.cs
+++ b/OpenRA.Mods.RA/World/ResourceLayer.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
-	[Desc("Attach this to the world actor.")]
+	[Desc("Attach this to the world actor.", "Order of the layers defines the Z sorting.")]
 	public class ResourceLayerInfo : TraitInfo<ResourceLayer>, Requires<ResourceTypeInfo> { }
 
 	public class ResourceLayer : IRenderOverlay, IWorldLoaded, ITickRender
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA
 				var c = render[cell];
 				if (c.Sprite != null)
 					new SpriteRenderable(c.Sprite, wr.world.Map.CenterOfCell(cell),
-						WVec.Zero, -511, c.Type.Palette, 1f, true).Render(wr);
+						WVec.Zero, -511, c.Type.Palette, 1f, true).Render(wr); // TODO ZOffset is ignored
 			}
 		}
 

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -19,10 +19,16 @@ namespace OpenRA.Mods.RA
 	public class SmudgeLayerInfo : ITraitInfo
 	{
 		public readonly string Type = "Scorch";
+
+		[Desc("Sprite sequence name")]
 		public readonly string Sequence = "scorch";
 
 		public readonly int SmokePercentage = 25;
+
+		[Desc("Sprite sequence name")]
 		public readonly string SmokeType = "smoke_m";
+
+		public readonly string Palette = "terrain";
 
 		public object Create(ActorInitializer init) { return new SmudgeLayer(this); }
 	}
@@ -120,7 +126,7 @@ namespace OpenRA.Mods.RA
 
 		public void Render(WorldRenderer wr)
 		{
-			var pal = wr.Palette("terrain");
+			var pal = wr.Palette(Info.Palette);
 
 			foreach (var kv in tiles)
 			{

--- a/OpenRA.Mods.RA/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.RA/World/SmudgeLayer.cs
@@ -16,6 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
+	[Desc("Attach this to the world actor.", "Order of the layers defines the Z sorting.")]
 	public class SmudgeLayerInfo : ITraitInfo
 	{
 		public readonly string Type = "Scorch";
@@ -137,7 +138,7 @@ namespace OpenRA.Mods.RA
 					continue;
 
 				new SpriteRenderable(kv.Value.Sprite, world.Map.CenterOfCell(kv.Key),
-					WVec.Zero, -511, pal, 1f, true).Render(wr);
+					WVec.Zero, -511, pal, 1f, true).Render(wr); // TODO ZOffset is ignored
 			}
 		}
 	}


### PR DESCRIPTION
Tried to fix #6270, but failed as all offsets are ignored. Hopefully the cleanup commit is still useful.
