### PR TITLE
Fixed double click sound on Tiberian Dawn production tabs

### DIFF
--- a/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTabsLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTabsLogic.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 				if (tabs.QueueGroup == button.ProductionGroup)
 					tabs.SelectNextTab(reverse);
 				else
-				tabs.QueueGroup = button.ProductionGroup;
+					tabs.QueueGroup = button.ProductionGroup;
 			};
 
 			button.IsDisabled = () => tabs.Groups[button.ProductionGroup].Tabs.Count == 0;

--- a/OpenRA.Mods.RA/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/ProductionTabsWidget.cs
@@ -97,8 +97,6 @@ namespace OpenRA.Mods.RA.Widgets
 			if (queueGroup == null)
 				return true;
 
-			Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
-
 			// Prioritize alerted queues
 			var queues = Groups[queueGroup].Tabs.Select(t => t.Queue)
 					.OrderByDescending(q => q.CurrentDone ? 1 : 0)

--- a/OpenRA.Mods.RA/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/ProductionTabsWidget.cs
@@ -279,9 +279,15 @@ namespace OpenRA.Mods.RA.Widgets
 			var hotkey = Hotkey.FromKeyInput(e);
 
 			if (hotkey == Game.Settings.Keys.NextProductionTabKey)
+			{
+				Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 				return SelectNextTab(false);
+			}
 			else if (hotkey == Game.Settings.Keys.PreviousProductionTabKey)
+			{
+				Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 				return SelectNextTab(true);
+			}
 
 			return false;
 		}

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -227,6 +227,8 @@ namespace OpenRA.Mods.RA.Widgets
 
 			world.Selection.Combine(world, new Actor[] { next }, false, true);
 
+			Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
+
 			return ToSelection();
 		}
 

--- a/mods/cnc/chrome/ingame-infoobjectives.yaml
+++ b/mods/cnc/chrome/ingame-infoobjectives.yaml
@@ -1,5 +1,5 @@
 Container@MISSION_OBJECTIVES:
-	Height:	PARENT_BOTTOM
+	Height: PARENT_BOTTOM
 	Width: PARENT_RIGHT
 	Logic: GameInfoObjectivesLogic
 	Children:


### PR DESCRIPTION
It always clicked twice. Once for the main group and second for the production building number. I think that is what #5863 is about. At least that is what disturbs me.
