### PR TITLE
Fixed building animations staying paused when disabled due to low power during sell causing glitches

### DIFF
--- a/OpenRA.Game/Traits/CreatesShroud.cs
+++ b/OpenRA.Game/Traits/CreatesShroud.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Traits
 
 		public void Tick(Actor self)
 		{
-			var disabled = self.TraitsImplementing<IDisable>().Any(d => d.Disabled);
+			var disabled = self.IsDisabled();
 			if (cachedLocation != self.Location || cachedDisabled != disabled)
 			{
 				cachedLocation = self.Location;

--- a/OpenRA.Mods.RA/Render/RenderBuilding.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuilding.cs
@@ -57,8 +57,7 @@ namespace OpenRA.Mods.RA.Render
 
 			if (info.PauseOnLowPower)
 			{
-				var disabled = self.TraitsImplementing<IDisable>();
-				DefaultAnimation.Paused = () => disabled.Any(d => d.Disabled)
+				DefaultAnimation.Paused = () => self.IsDisabled()
 					&& self.Trait<Building>().BuildComplete
 					&& DefaultAnimation.CurrentSequence.Name == NormalizeSequence(self, "idle");
 			}

--- a/OpenRA.Mods.RA/Render/RenderBuilding.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuilding.cs
@@ -59,6 +59,7 @@ namespace OpenRA.Mods.RA.Render
 			{
 				var disabled = self.TraitsImplementing<IDisable>();
 				DefaultAnimation.Paused = () => disabled.Any(d => d.Disabled)
+					&& self.Trait<Building>().BuildComplete
 					&& DefaultAnimation.CurrentSequence.Name == NormalizeSequence(self, "idle");
 			}
 		}

--- a/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
@@ -30,13 +30,11 @@ namespace OpenRA.Mods.RA.Render
 
 	public class WithActiveAnimation : ITick, INotifyBuildComplete, INotifySold
 	{
-		readonly IEnumerable<IDisable> disabled;
 		readonly WithActiveAnimationInfo info;
 		readonly RenderBuilding renderBuilding;
 
 		public WithActiveAnimation(Actor self, WithActiveAnimationInfo info)
 		{
-			disabled = self.TraitsImplementing<IDisable>();
 			renderBuilding = self.Trait<RenderBuilding>();
 			this.info = info;
 		}
@@ -49,7 +47,7 @@ namespace OpenRA.Mods.RA.Render
 
 			if (--ticks <= 0)
 			{
-				if (!(info.PauseOnLowPower && disabled.Any(d => d.Disabled)))
+				if (!(info.PauseOnLowPower && self.IsDisabled()))
 					renderBuilding.PlayCustomAnim(self, info.Sequence);
 				ticks = info.Interval;
 			}

--- a/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
@@ -58,7 +58,6 @@ namespace OpenRA.Mods.RA.Render
 		{
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<IBodyOrientation>();
-			var disabled = self.TraitsImplementing<IDisable>();
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
@@ -67,7 +66,7 @@ namespace OpenRA.Mods.RA.Render
 				new AnimationWithOffset(overlay,
 					() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 					() => !buildComplete,
-					() => info.PauseOnLowPower && disabled.Any(d => d.Disabled),
+					() => info.PauseOnLowPower && self.IsDisabled(),
 					p => WithTurret.ZOffsetFromCenter(self, p, 1)),
 				info.Palette, info.IsPlayerPalette);
 		}

--- a/OpenRA.Mods.RA/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithRepairAnimation.cs
@@ -27,19 +27,17 @@ namespace OpenRA.Mods.RA.Render
 
 	public class WithRepairAnimation : INotifyRepair
 	{
-		IEnumerable<IDisable> disabled;
 		WithRepairAnimationInfo info;
 
 		public WithRepairAnimation(Actor self, WithRepairAnimationInfo info)
 		{
-			disabled = self.TraitsImplementing<IDisable>();
 			this.info = info;
 		}
 
 		public void Repairing(Actor self, Actor host)
 		{
 			var building = host.TraitOrDefault<RenderBuilding>();
-			if (building != null && !(info.PauseOnLowPower && disabled.Any(d => d.Disabled)))
+			if (building != null && !(info.PauseOnLowPower && self.IsDisabled()))
 				building.PlayCustomAnim(host, info.Sequence);
 		}
 	}

--- a/OpenRA.Mods.RA/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithRepairOverlay.cs
@@ -45,7 +45,6 @@ namespace OpenRA.Mods.RA.Render
 		{
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<IBodyOrientation>();
-			var disabled = self.TraitsImplementing<IDisable>();
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
@@ -54,7 +53,7 @@ namespace OpenRA.Mods.RA.Render
 				new AnimationWithOffset(overlay,
 					() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 					() => !buildComplete,
-					() => info.PauseOnLowPower && disabled.Any(d => d.Disabled),
+					() => info.PauseOnLowPower && self.IsDisabled(),
 					p => WithTurret.ZOffsetFromCenter(self, p, 1)),
 				info.Palette, info.IsPlayerPalette);
 		}

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.RA
 
 		static bool InstanceDisabled(SupportPower sp)
 		{
-			return sp.self.TraitsImplementing<IDisable>().Any(d => d.Disabled);
+			return sp.self.IsDisabled();
 		}
 
 		bool notifiedCharging;


### PR DESCRIPTION
Both #6076 and #6275 are duplicates. Probably introduced by myself in https://github.com/OpenRA/OpenRA/pull/5138.
