### PR TITLE
Fix end game window conflicting with ingame menu

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -417,8 +417,11 @@ namespace OpenRA.Widgets
 
 		public virtual void RemoveChild(Widget child)
 		{
-			Children.Remove(child);
-			child.Removed();
+			if (child != null)
+			{
+				Children.Remove(child);
+				child.Removed();
+			}
 		}
 
 		public virtual void RemoveChildren()

--- a/OpenRA.Mods.D2k/Widgets/Logic/IngameChromeLogic.cs
+++ b/OpenRA.Mods.D2k/Widgets/Logic/IngameChromeLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.D2k.Widgets.Logic
 
 			Action ShowLeaveRestartDialog = () =>
 			{
-				gameRoot.IsVisible = () => false;
+				gameRoot.RemoveChildren();
 				Game.LoadWidget(world, "LEAVE_RESTART_WIDGET", Ui.Root, new WidgetArgs());
 			};
 			world.GameOver += ShowLeaveRestartDialog;

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
@@ -32,9 +32,8 @@ namespace OpenRA.Mods.RA.Widgets
 				panelName = "LEAVE_RESTART_FULL";
 
 			var dialog = widget.Get<ContainerWidget>(panelName);
-			var fmvPlayer = Ui.Root.GetOrNull<BackgroundWidget>("FMVPLAYER");
 			dialog.IsVisible = () => true;
-			widget.IsVisible = () => fmvPlayer == null || fmvPlayer != Ui.CurrentWindow();
+			widget.IsVisible = () => Ui.CurrentWindow() == null;
 
 			var leaveButton = dialog.Get<ButtonWidget>("LEAVE_BUTTON");
 			leaveButton.OnClick = () =>

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			Action ShowLeaveRestartDialog = () =>
 			{
-				ingameRoot.IsVisible = () => false;
+				ingameRoot.RemoveChildren();
 				Game.LoadWidget(world, "LEAVE_RESTART_WIDGET", Ui.Root, new WidgetArgs());
 			};
 			world.GameOver += ShowLeaveRestartDialog;

--- a/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
@@ -21,12 +21,16 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		readonly World world;
 		readonly Widget ingameRoot;
 		bool disableSystemButtons;
+		Widget currentWidget;
 
 		[ObjectCreator.UseCtor]
 		public OrderButtonsChromeLogic(Widget widget, World world)
 		{
 			this.world = world;
 			ingameRoot = Ui.Root.Get("INGAME_ROOT");
+
+			Action removeCurrentWidget = () => Ui.Root.RemoveChild(currentWidget);
+			world.GameOver += removeCurrentWidget;
 
 			// Order Buttons
 			var sell = widget.GetOrNull<ButtonWidget>("SELL_BUTTON");
@@ -139,7 +143,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				disableSystemButtons = false;
 			});
 
-			Game.LoadWidget(world, button.MenuContainer, Ui.Root, widgetArgs);
+			currentWidget = Game.LoadWidget(world, button.MenuContainer, Ui.Root, widgetArgs);
 		}
 
 		static void BindOrderButton<T>(World world, ButtonWidget w, string icon)


### PR DESCRIPTION
This causes the menu to close itself when the game is over.

Fixes #6311.
