### PR TITLE
Fixes crates getting collected by buildings or other crates

### DIFF
--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.RA.Buildings;
+using OpenRA.Mods.RA.Move;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -79,7 +80,11 @@ namespace OpenRA.Mods.RA
 				.FirstOrDefault(a => a != self);
 
 			if (landedOn != null)
-				OnCrush(landedOn);
+				if (landedOn.HasTrait<MobileInfo>() &&
+					CrushableBy(landedOn.TraitOrDefault<MobileInfo>().Crushes, landedOn.Owner))
+						OnCrush(landedOn);
+				else
+					self.Destroy();
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.RA/CrateAction.cs
+++ b/OpenRA.Mods.RA/CrateAction.cs
@@ -10,6 +10,7 @@
 
 using System.Linq;
 using OpenRA.Mods.RA.Effects;
+using OpenRA.Mods.RA.Move;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
@@ -37,6 +38,9 @@ namespace OpenRA.Mods.RA
 		[Desc("Actor types that this crate action will not occur for.")]
 		[ActorReference] public string[] ExcludedActorTypes = { };
 
+		[Desc("Must the collector be mobile?")]
+		public bool CollectorMustBeMobile = true;
+
 		public virtual object Create(ActorInitializer init) { return new CrateAction(init.self, this); }
 	}
 
@@ -58,6 +62,9 @@ namespace OpenRA.Mods.RA
 
 			if (info.ExcludedActorTypes.Contains(collector.Info.Name))
 				return 0;
+
+			if (info.CollectorMustBeMobile && !collector.HasTrait<Mobile>())
+					return 0;
 
 			if (info.Prerequisites.Any() && !collector.Owner.PlayerActor.Trait<TechTree>().HasPrerequisites(info.Prerequisites))
 				return 0;

--- a/OpenRA.Mods.RA/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Crates/DuplicateUnitCrateAction.cs
@@ -71,18 +71,18 @@ namespace OpenRA.Mods.RA.Crates
 
 		public override void Activate(Actor collector)
 		{
-			int AllowedWorthLeft = Info.MaxDuplicatesWorth;
-			int DupesMade = 0;
+			var allowedWorthLeft = Info.MaxDuplicatesWorth;
+			var dupesMade = 0;
 
-			while ((DupesMade < Info.MaxAmount) && (AllowedWorthLeft > 0) || (DupesMade < Info.MinAmount))
+			while ((dupesMade < Info.MaxAmount && allowedWorthLeft > 0) || dupesMade < Info.MinAmount)
 			{
 				//If the collector has a cost, and we have a max duplicate worth, then update how much dupe worth is left
 				var unitCost = collector.Info.Traits.Get<ValuedInfo>().Cost;
-				AllowedWorthLeft -= (Info.MaxDuplicatesWorth > 0) ? unitCost : 0;
-				if ((AllowedWorthLeft < 0) && (DupesMade >= Info.MinAmount))
+				allowedWorthLeft -= Info.MaxDuplicatesWorth > 0 ? unitCost : 0;
+				if (allowedWorthLeft < 0 && dupesMade >= Info.MinAmount)
 					break;
 
-				DupesMade++;
+				dupesMade++;
 
 				var location = ChooseEmptyCellNear(collector, collector.Info.Name);
 				if (location != null)


### PR DESCRIPTION
Long overdue fix for a regression I introduced.

Closes #5953. (Or should, it is very hard to test that specific case.)

Based on code from #6159.
(Tested NRE crash case reported in #6159. Buildings no longer collect crates dropped on them.)
