### PR TITLE
Sub-cell co-path-finding with dynamic range

### DIFF
--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -61,14 +61,14 @@ namespace OpenRA
 
 		public static readonly CVec[] directions =
 		{
-			new CVec(-1, -1),
-			new CVec(-1,  0),
+			new CVec( 1,  0),
+			new CVec( 1,  1),
+			new CVec( 0,  1),
 			new CVec(-1,  1),
-			new CVec(0, -1),
-			new CVec(0,  1),
-			new CVec(1, -1),
-			new CVec(1,  0),
-			new CVec(1,  1),
+			new CVec(-1,  0),
+			new CVec(-1, -1),
+			new CVec( 0, -1),
+			new CVec( 1, -1),
 		};
 
 		#region Scripting interface

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -81,6 +81,7 @@ namespace OpenRA
 		public readonly WVec[] SubCellOffsets;
 		public readonly SubCell DefaultSubCell;
 		public readonly SubCell LastSubCell;
+		public readonly int SharedSubCellCount;
 
 		public WVec OffsetOfSubCell(SubCell subCell) { return SubCellOffsets[(int)subCell]; }
 
@@ -253,7 +254,8 @@ namespace OpenRA
 			MapResources = Exts.Lazy(() => LoadResourceTiles());
 			TileShape = Game.modData.Manifest.TileShape;
 			SubCellOffsets = Game.modData.Manifest.SubCellOffsets;
-			LastSubCell = (SubCell)(SubCellOffsets.Length - 1);
+			SharedSubCellCount = SubCellOffsets.Length - 1;
+			LastSubCell = (SubCell)SharedSubCellCount;
 			DefaultSubCell = (SubCell)Game.modData.Manifest.SubCellDefaultIndex;
 
 			// The Uid is calculated from the data on-disk, so

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -200,15 +200,32 @@ namespace OpenRA.Traits
 	public interface IMoveInfo : ITraitInfo { }
 	public interface IMove
 	{
-		Activity MoveTo(CPos cell, int nearEnough);
-		Activity MoveTo(CPos cell, Actor ignoredActor);
-		Activity MoveWithinRange(Target target, WRange range);
+		Activity MoveTo(CPos cell, SubCell subCell, WRange awayEnough, WRange nearEnough);
+		Activity MoveTo(CPos cell, SubCell subCell, Actor ignoredActor);
 		Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange);
 		Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange);
 		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		CPos NearestMoveableCell(CPos target);
 		bool IsMoving { get; set; }
+	}
+
+	public static class IMoveExts
+	{
+		public static Activity MoveTo(this IMove move, CPos cell, SubCell subCell = SubCell.Any, WRange nearEnough = default(WRange))
+		{
+			return move.MoveTo(cell, subCell, nearEnough, nearEnough);
+		}
+
+		public static Activity MoveTo(this IMove move, CPos cell, WRange nearEnough)
+		{
+			return move.MoveTo(cell, SubCell.Any, WRange.Zero, nearEnough);
+		}
+
+		public static Activity MoveWithinRange(this IMove move, Target target, WRange range)
+		{
+			return move.MoveWithinRange(target, range / 2, range);
+		}
 	}
 
 	public interface INotifyBlockingMove { void OnNotifyBlockingMove(Actor self, Actor blocking); }

--- a/OpenRA.Game/WRange.cs
+++ b/OpenRA.Game/WRange.cs
@@ -25,8 +25,10 @@ namespace OpenRA
 		public readonly int Range;
 
 		public WRange(int r) { Range = r; }
+		public WRange(double cells) { Range = (int)(1024.0 * cells); }
 		public static readonly WRange Zero = new WRange(0);
-		public static WRange FromCells(int cells) { return new WRange(1024*cells); }
+		public static readonly WRange OneCell = new WRange(1024);
+		public static WRange FromCells(int cells) { return new WRange(1024 * cells); }
 
 		public static WRange operator +(WRange a, WRange b) { return new WRange(a.Range + b.Range); }
 		public static WRange operator -(WRange a, WRange b) { return new WRange(a.Range - b.Range); }

--- a/OpenRA.Mods.RA/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.RA/Activities/DeliverResources.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			self.SetTargetLine(Target.FromActor(proc), Color.Green, false);
 			if (self.Location != proc.Location + iao.DeliverOffset)
-				return Util.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliverOffset, 0), this);
+				return Util.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliverOffset, SubCell.Any, WRange.Zero), this);
 
 			if (!isDocking)
 			{

--- a/OpenRA.Mods.RA/Activities/FindResources.cs
+++ b/OpenRA.Mods.RA/Activities/FindResources.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.RA.Activities
 				harv.LastOrderLocation = path[0];
 
 			self.SetTargetLine(Target.FromCell(self.World, path[0]), Color.Red, false);
-			return Util.SequenceActivities(mobile.MoveTo(path[0], 1), new HarvestResource(), new FindResources());
+			return Util.SequenceActivities(mobile.MoveTo(path[0], SubCell.Any, WRange.Zero, WRange.OneCell), new HarvestResource(), new FindResources());
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.RA/Activities/Hunt.cs
+++ b/OpenRA.Mods.RA/Activities/Hunt.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
+using OpenRA.Mods.RA.Move;
 
 namespace OpenRA.Mods.RA.Activities
 {
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.RA.Activities
 				return this;
 
 			return Util.SequenceActivities(
-				new AttackMove.AttackMoveActivity(self, new Move.Move(target.Location, WRange.FromCells(2))),
+				new AttackMove.AttackMoveActivity(self, new Move.Move(self, target.Location, SubCell.Any, WRange.Zero, WRange.FromCells(2))),
 				new Wait(25),
 				this);
 		}

--- a/OpenRA.Mods.RA/Activities/LayMines.cs
+++ b/OpenRA.Mods.RA/Activities/LayMines.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Activities
 
 				return Util.SequenceActivities(
 					new MoveAdjacentTo(self, Target.FromActor(rearmTarget)),
-					movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), rearmTarget),
+					movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), SubCell.Any, rearmTarget),
 					new Rearm(self),
 					new Repair(rearmTarget),
 					this);
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA.Activities
 				{
 					var p = ml.Minefield.Random(self.World.SharedRandom);
 					if (ShouldLayMine(self, p))
-						return Util.SequenceActivities( movement.MoveTo(p, 0), this );
+						return Util.SequenceActivities(movement.MoveTo(p, SubCell.Any, WRange.Zero), this);
 				}
 
 			// TODO: return somewhere likely to be safe (near fix) so we're not sitting out in the minefield.

--- a/OpenRA.Mods.RA/Air/Helicopter.cs
+++ b/OpenRA.Mods.RA/Air/Helicopter.cs
@@ -141,8 +141,8 @@ namespace OpenRA.Mods.RA.Air
 			Repulse();
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough) { return new HeliFly(self, Target.FromCell(self.World, cell)); }
-		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new HeliFly(self, Target.FromCell(self.World, cell)); }
+		public Activity MoveTo(CPos cell, SubCell subCell, WRange nearEnough, WRange awayEnough) { return new HeliFly(self, Target.FromCell(self.World, cell)); }
+		public Activity MoveTo(CPos cell, SubCell subCell, Actor ignoredActor) { return new HeliFly(self, Target.FromCell(self.World, cell)); }
 		public Activity MoveWithinRange(Target target, WRange range) { return new HeliFly(self, target, WRange.Zero, range); }
 		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return new HeliFly(self, target, minRange, maxRange); }
 		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new Follow(self, target, minRange, maxRange); }

--- a/OpenRA.Mods.RA/Air/Plane.cs
+++ b/OpenRA.Mods.RA/Air/Plane.cs
@@ -120,8 +120,8 @@ namespace OpenRA.Mods.RA.Air
 			}
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough) { return Util.SequenceActivities(new Fly(self, Target.FromCell(self.World, cell)), new FlyCircle()); }
-		public Activity MoveTo(CPos cell, Actor ignoredActor) { return Util.SequenceActivities(new Fly(self, Target.FromCell(self.World, cell)), new FlyCircle()); }
+		public Activity MoveTo(CPos cell, SubCell subCell, WRange nearEnough, WRange awayEnough) { return Util.SequenceActivities(new Fly(self, Target.FromCell(self.World, cell)), new FlyCircle()); }
+		public Activity MoveTo(CPos cell, SubCell subCell, Actor ignoredActor) { return Util.SequenceActivities(new Fly(self, Target.FromCell(self.World, cell)), new FlyCircle()); }
 		public Activity MoveWithinRange(Target target, WRange range) { return Util.SequenceActivities(new Fly(self, target, WRange.Zero, range), new FlyCircle()); }
 		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return Util.SequenceActivities(new Fly(self, target, minRange, maxRange), new FlyCircle()); }
 		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new FlyFollow(self, target, minRange, maxRange); }

--- a/OpenRA.Mods.RA/Air/TakeOff.cs
+++ b/OpenRA.Mods.RA/Air/TakeOff.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Air
 			var destination = rp != null ? rp.Location :
 				(hasHost ? self.World.Map.CellContaining(host.CenterPosition) : self.Location);
 
-			return new AttackMove.AttackMoveActivity(self, self.Trait<IMove>().MoveTo(destination, 1));
+			return new AttackMove.AttackMoveActivity(self, self.Trait<IMove>().MoveTo(destination, SubCell.Any, WRange.OneCell));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/AttackMove.cs
+++ b/OpenRA.Mods.RA/AttackMove.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.RA
 		void Activate(Actor self)
 		{
 			self.CancelActivity();
-			self.QueueActivity(new AttackMoveActivity(self, move.MoveTo(TargetLocation.Value, 1)));
+			self.QueueActivity(new AttackMoveActivity(self, move.MoveTo(TargetLocation.Value, SubCell.Any, WRange.OneCell)));
 		}
 
 		public void TickIdle(Actor self)

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.RA
 					var harv = self.Trait<Harvester>();
 
 					var moveTo = harv.LastHarvestedCell ?? (deliveryLoc + new CVec(0, 4));
-					self.QueueActivity(mobile.MoveTo(moveTo, 1));
+					self.QueueActivity(mobile.MoveTo(moveTo, SubCell.Any, WRange.OneCell));
 					self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
 
 					var territory = self.World.WorldActor.TraitOrDefault<ResourceClaimLayer>();
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.RA
 
 				var cell = self.Location;
 				var moveTo = mobile.NearestMoveableCell(cell, 2, 5);
-				self.QueueActivity(mobile.MoveTo(moveTo, 0));
+				self.QueueActivity(mobile.MoveTo(moveTo, SubCell.Any, WRange.Zero));
 				self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
 
 				// Find more resources but not at this location:
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.RA
 						loc = mobile.NearestCell(loc, p => mobile.CanEnterCell(p) && taken.Add(p), 1, 6);
 					}
 
-					self.QueueActivity(mobile.MoveTo(loc, 0));
+					self.QueueActivity(mobile.MoveTo(loc, SubCell.Any, WRange.Zero));
 					self.SetTargetLine(Target.FromCell(self.World, loc), Color.Red);
 
 					LastOrderLocation = loc;
@@ -311,7 +311,7 @@ namespace OpenRA.Mods.RA
 					if (!loc.HasValue)
 						return;
 
-					self.QueueActivity(mobile.MoveTo(loc.Value, 0));
+					self.QueueActivity(mobile.MoveTo(loc.Value, SubCell.Any, WRange.Zero));
 					self.SetTargetLine(Target.FromCell(self.World, loc.Value), Color.Red);
 
 					LastOrderLocation = loc;

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.RA
 					{
 						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
 						newUnit.QueueActivity(new AttackMove.AttackMoveActivity(
-							newUnit, move.MoveTo(exitLocation, 1)));
+							newUnit, move.MoveTo(exitLocation, SubCell.Any, WRange.Zero, WRange.FromCells(2))));
 					}
 				}
 

--- a/OpenRA.Mods.RA/RallyPoint.cs
+++ b/OpenRA.Mods.RA/RallyPoint.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.RA
 	[Desc("Used to waypoint units after production or repair is finished.")]
 	public class RallyPointInfo : ITraitInfo
 	{
-		public readonly CVec RallyPoint = new CVec(1, 3);
+		public readonly CVec RallyPoint = new CVec(1, 4);
 		public readonly string IndicatorPalettePrefix = "player";
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.self, this); }

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.RA
 
 				self.CancelActivity();
 				self.QueueActivity(new MoveAdjacentTo(self, target));
-				self.QueueActivity(movement.MoveTo(self.World.Map.CellContaining(order.TargetActor.CenterPosition), order.TargetActor));
+				self.QueueActivity(movement.MoveTo(self.World.Map.CellContaining(order.TargetActor.CenterPosition), SubCell.Any, order.TargetActor));
 				self.QueueActivity(new Rearm(self));
 				self.QueueActivity(new Repair(order.TargetActor));
 
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.RA
 					self.QueueActivity(new CallFunc(() =>
 					{
 						self.SetTargetLine(Target.FromCell(self.World, rp.Location), Color.Green);
-						self.QueueActivity(movement.MoveTo(rp.Location, order.TargetActor));
+						self.QueueActivity(movement.MoveTo(rp.Location, SubCell.Any, order.TargetActor));
 					}));
 			}
 		}

--- a/OpenRA.Mods.RA/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.RA/Scripting/Global/ReinforcementsGlobal.cs
@@ -19,6 +19,7 @@ using OpenRA.Scripting;
 using OpenRA.Effects;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Air;
+using OpenRA.Mods.RA.Move;
 
 namespace OpenRA.Mods.RA.Scripting
 {
@@ -63,7 +64,7 @@ namespace OpenRA.Mods.RA.Scripting
 			}
 			else
 			{
-				actor.QueueActivity(new Move.Move(dest, 2));
+				actor.QueueActivity(new Move.Move(actor, dest, SubCell.Any, WRange.Zero, WRange.FromCells(2)));
 			}
 		}
 

--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -17,6 +17,7 @@ using OpenRA.Effects;
 using OpenRA.FileSystem;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Air;
+using OpenRA.Mods.RA.Move;
 using OpenRA.Network;
 using OpenRA.Scripting;
 using OpenRA.Support;
@@ -324,9 +325,9 @@ namespace OpenRA.Mods.RA.Scripting
 		public void AttackMove(Actor actor, CPos location, double nearEnough)
 		{
 			if (actor.HasTrait<AttackMove>())
-				actor.QueueActivity(new AttackMove.AttackMoveActivity(actor, new Move.Move(location, (int)nearEnough)));
+				actor.QueueActivity(new AttackMove.AttackMoveActivity(actor, new Move.Move(actor, location, SubCell.Any, new WRange(nearEnough))));
 			else
-				actor.QueueActivity(new Move.Move(location, (int)nearEnough));
+				actor.QueueActivity(new Move.Move(actor, location, SubCell.Any, new WRange(nearEnough)));
 		}
 
 		[LuaGlobal]

--- a/OpenRA.Mods.RA/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/CombatProperties.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.RA.Move;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 
@@ -31,9 +32,9 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Move to a cell, but stop and attack anything within range on the way. " +
 			"closeEnough defines an optional range (in cells) that will be considered " +
 			"close enough to complete the activity.")]
-		public void AttackMove(CPos cell, int closeEnough = 0)
+		public void AttackMove(CPos cell, double closeEnough = 0.0)
 		{
-			self.QueueActivity(new AttackMove.AttackMoveActivity(self, new Move.Move(cell, WRange.FromCells(closeEnough))));
+			self.QueueActivity(new AttackMove.AttackMoveActivity(self, new Move.Move(self, cell, SubCell.Any, WRange.Zero, new WRange(closeEnough))));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/MobileProperties.cs
@@ -23,16 +23,16 @@ namespace OpenRA.Mods.RA.Scripting
 		[ScriptActorPropertyActivity]
 		[Desc("Moves within the cell grid. closeEnough defines an optional range " +
 			"(in cells) that will be considered close enough to complete the activity.")]
-		public void Move(CPos cell, int closeEnough = 0)
+		public void Move(CPos cell, double closeEnough = 0.0)
 		{
-			self.QueueActivity(new Move.Move(cell, WRange.FromCells(closeEnough)));
+			self.QueueActivity(new Move.Move(self, cell, SubCell.Any, WRange.Zero, new WRange(closeEnough)));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Moves within the cell grid, ignoring lane biases.")]
 		public void ScriptedMove(CPos cell)
 		{
-			self.QueueActivity(new Move.Move(cell));
+			self.QueueActivity(new Move.Move(self, cell, SubCell.Any));
 		}
 	}
 }


### PR DESCRIPTION
NOTE: continues work from #6208.
Sub-cell aware co-path-finding with dynamic range

Continued changes from #6208 to IMove.
- Removed non-sub-cell constructors from Move
- Enhanced path-finder
- Sub-cell aware co-path-finding - tries to use the same path for actors from the same cell.
- Forward adjacent co-path-finding - tries to use a cached path from a forward adjacent cell.
