### PR TITLE
Cloaked APCs are no longer unstoppable harrassment machines.

### DIFF
--- a/OpenRA.Mods.RA/Cloak.cs
+++ b/OpenRA.Mods.RA/Cloak.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.RA
 
 		public readonly bool UncloakOnAttack = true;
 		public readonly bool UncloakOnMove = false;
-		public readonly bool UncloakOnUnload = false;
+		public readonly bool UncloakOnUnload = true;
 
 		[Desc("Enable only if this upgrade is enabled.")]
 		public readonly string RequiresUpgrade = null;

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -762,7 +762,6 @@ STNK:
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 250
-		UncloakOnUnload: True
 	DetectCloaked:
 		Range: 6
 	Explodes:


### PR DESCRIPTION
Grabbing a cloak upgrade crate enabled APCs to load and unload units without uncloaking. Especially within the first 5 minutes of a game, players can load up with engineers and appear and disappear without warning as much as they like. Imagine how bad it'd be with commandos.
