### PR TITLE
Fix RA MadTank chrono after activation/deployment.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -102,6 +102,8 @@ namespace OpenRA.Traits
 	public interface INotifyHarvest { void Harvested(Actor self, ResourceType resource); }
 	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }
 
+	public interface IConditionalTeleport { bool CanBeTeleported(Actor self); }
+
 	public interface IUpgradable
 	{
 		bool AcceptsUpgrade(string type);

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -46,6 +46,10 @@ namespace OpenRA.Mods.RA.Activities
 			if (pc != null && !pc.CanTeleport)
 				return NextActivity;
 
+			foreach (var conditional in self.TraitsImplementing<IConditionalTeleport>())
+				if (!conditional.CanBeTeleported(self))
+					return NextActivity;
+
 			var bestCell = ChooseBestDestinationCell(self, destination);
 			if (bestCell == null)
 				return NextActivity;

--- a/OpenRA.Mods.RA/MadTank.cs
+++ b/OpenRA.Mods.RA/MadTank.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.RA
 		public object Create(ActorInitializer init) { return new MadTank(init.self, this); }
 	}
 
-	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, ITick
+	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, ITick, IConditionalTeleport
 	{
 		readonly Actor self;
 		readonly MadTankInfo info;
@@ -61,6 +61,8 @@ namespace OpenRA.Mods.RA
 			renderUnit = self.Trait<RenderUnit>();
 			screenShaker = self.World.WorldActor.Trait<ScreenShaker>();
 		}
+
+		public bool CanBeTeleported(Actor self) { return !deployed; }
 
 		public void Tick(Actor self)
 		{

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {
@@ -59,7 +60,8 @@ namespace OpenRA.Mods.RA
 			foreach (var t in tiles)
 				units.AddRange(self.World.ActorMap.GetUnitsAt(t));
 
-			return units.Distinct().Where(a => a.HasTrait<Chronoshiftable>());
+			return units.Distinct().Where(a => a.HasTrait<Chronoshiftable>() &&
+				!a.TraitsImplementing<IConditionalTeleport>().Any(c => !c.CanBeTeleported(a)));
 		}
 
 		public bool SimilarTerrain(CPos xy, CPos sourceLocation)


### PR DESCRIPTION
Implement (new) `IChronoshiftableCondition` in `MadTank`.
Prevents MadTank from being chronoshifted after activating.
