### PR TITLE
Removed hard-coded squishy sounds to avoid confusion

### DIFF
--- a/OpenRA.Mods.RA/CrushableInfantry.cs
+++ b/OpenRA.Mods.RA/CrushableInfantry.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA
 {
 	class CrushableInfantryInfo : ITraitInfo, Requires<MobileInfo>, Requires<RenderInfantryInfo>
 	{
-		public readonly string CrushSound = "squish2.aud";
+		public readonly string CrushSound = null;
 		public readonly string CorpseSequence = "die-crushed";
 		public readonly string[] CrushClasses = { "infantry" };
 		public readonly int WarnProbability = 75;

--- a/OpenRA.Mods.RA/Parachutable.cs
+++ b/OpenRA.Mods.RA/Parachutable.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.RA
 		[Desc("If we land on invalid terrain for my actor type should we be killed?")]
 		public readonly bool KilledOnImpassableTerrain = true;
 
-		public readonly string GroundImpactSound = "squish2.aud";
+		public readonly string GroundImpactSound = null;
 		public readonly string GroundCorpseSequence = "corpse";
 		public readonly string GroundCorpsePalette = "effect";
 
-		public readonly string WaterImpactSound = "splash9.aud";
+		public readonly string WaterImpactSound = null;
 		public readonly string WaterCorpseSequence = "small_splash";
 		public readonly string WaterCorpsePalette = "effect";
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -166,6 +166,7 @@
 		Probability: 10
 	CrushableInfantry:
 		WarnProbability: 67
+		CrushSound: squish2.aud
 	CombatDebugOverlay:
 	Guard:
 	Guardable:
@@ -220,6 +221,7 @@
 		NotifyAll: true
 	ScaredyCat:
 	CrushableInfantry:
+		CrushSound: squish2.aud
 
 ^DINO:
 	AppearsOnRadar:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -182,6 +182,8 @@
 		KilledOnImpassableTerrain: true
 		ParachuteSequence: parach
 		ShadowSequence: parach-shadow
+		GroundImpactSound: squishy2.aud
+		WaterImpactSound: splash9.aud
 	Cloneable:
 		Types: Infantry
 	GainsStatUpgrades:


### PR DESCRIPTION
These file names differ slightly between Tiberian Dawn and Red Alert/Tiberian Sun. The defaults are historically grown and changed back and forth so we already lost an overview. This partly reverts https://github.com/OpenRA/OpenRA/pull/6366 to fix squishy sounds in the RA mod again.
