### PR TITLE
Renamed InfDeath to DeathType

### DIFF
--- a/OpenRA.Game/GameRules/DamageWarhead.cs
+++ b/OpenRA.Game/GameRules/DamageWarhead.cs
@@ -22,7 +22,7 @@ namespace OpenRA.GameRules
 		public readonly int Damage = 0;
 
 		[Desc("Infantry death animation to use")]
-		public readonly string InfDeath = "1";
+		public readonly string DeathType = "1";
 
 		[Desc("Whether we should prevent prone response for infantry.")]
 		public readonly bool PreventProne = false;

--- a/OpenRA.Mods.Cnc/SpawnViceroid.cs
+++ b/OpenRA.Mods.Cnc/SpawnViceroid.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc
 		[ActorReference] public readonly string ViceroidActor = "vice";
 		public readonly int Probability = 10;
 		public readonly string Owner = "Creeps";
-		public readonly string InfDeath = "6";
+		public readonly string DeathType = "6";
 
 		public object Create(ActorInitializer init) { return new SpawnViceroid(this); }
 	}
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Cnc
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			if (e.Warhead == null || e.Warhead.InfDeath != spawnViceroidInfo.InfDeath) return;
+			if (e.Warhead == null || e.Warhead.DeathType != spawnViceroidInfo.DeathType) return;
 			if (self.World.SharedRandom.Next(100) > spawnViceroidInfo.Probability) return;
 
 			self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.RA/DeathSounds.cs
+++ b/OpenRA.Mods.RA/DeathSounds.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Mods.RA
 		[Desc("Multiply volume with this factor.")]
 		public readonly float VolumeMultiplier = 1f;
 
-		[Desc("InfDeaths that this should be used for. If empty, this will be used as the default sound.")]
-		public readonly string[] InfDeaths = { };
+		[Desc("DeathTypes that this should be used for. If empty, this will be used as the default sound.")]
+		public readonly string[] DeathTypes = { };
 
 		public object Create(ActorInitializer init) { return new DeathSounds(this); }
 	}
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.RA
 
 			var cp = self.CenterPosition;
 
-			if (info.InfDeaths.Contains(e.Warhead.InfDeath) || (!info.InfDeaths.Any() && !self.Info.Traits.WithInterface<DeathSoundsInfo>().Any(dsi => dsi.InfDeaths.Contains(e.Warhead.InfDeath))))
+			if (info.DeathTypes.Contains(e.Warhead.DeathType) || (!info.DeathTypes.Any() && !self.Info.Traits.WithInterface<DeathSoundsInfo>().Any(dsi => dsi.DeathTypes.Contains(e.Warhead.DeathType))))
 				Sound.PlayVoiceLocal(info.DeathSound, self, self.Owner.Country.Race, cp, info.VolumeMultiplier);
 		}
 	}

--- a/OpenRA.Mods.RA/Explodes.cs
+++ b/OpenRA.Mods.RA/Explodes.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public readonly string EmptyWeapon = "UnitExplode";
 
 		public readonly int Chance = 100;
-		public readonly string[] InfDeath = null;
+		public readonly string[] DeathType = null;
 
 		public object Create(ActorInitializer init) { return new Explodes(this); }
 	}
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA
 			if (self.World.SharedRandom.Next(100) > explodesInfo.Chance)
 				return;
 
-			if (explodesInfo.InfDeath != null && e.Warhead != null && !explodesInfo.InfDeath.Contains(e.Warhead.InfDeath))
+			if (explodesInfo.DeathType != null && e.Warhead != null && !explodesInfo.DeathType.Contains(e.Warhead.DeathType))
 				return;
 
 			var weaponName = ChooseWeaponForExplosion(self);

--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.RA.Render
 
 			if (info.SpawnsCorpse)
 			{
-				SpawnCorpse(self, info.DeathAnimationPrefix + (e.Warhead.InfDeath));
+				SpawnCorpse(self, info.DeathAnimationPrefix + (e.Warhead.DeathType));
 			}	
 		}
 

--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -258,7 +258,7 @@ namespace OpenRA.Utility
 						node.Key = "StoresResources";
 				}
 
-				// make animation is now it's own trait
+				// make animation is now its own trait
 				if (engineVersion < 20140621)
 				{
 					if (depth == 1 && (node.Key.StartsWith("RenderBuilding")))
@@ -470,6 +470,22 @@ namespace OpenRA.Utility
 
 					if (depth == 1 && (node.Key == "RenderInfantryProne" || node.Key == "RenderInfantryPanic"))
 						node.Key = "RenderInfantry";
+				}
+
+				// InfDeath was renamed to DeathType
+				if (engineVersion < 20140830)
+				{
+					if (depth == 1 && parentKey.StartsWith("DeathSounds"))
+					{
+						if (depth == 2 && node.Key == "InfDeaths")
+							node.Key = "DeathTypes";
+					}
+
+					if (depth == 2 && parentKey == "SpawnsViceroid" && node.Key == "InfDeath")
+						node.Key = "DeathType";
+
+					if (depth == 2 && parentKey == "Explodes" && node.Key == "InfDeath")
+						node.Key = "DeathType";
 				}
 
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
@@ -782,6 +798,15 @@ namespace OpenRA.Utility
 					// Converted versus definitions to integers
 					if (depth == 3 && parentKey == "Versus")
 						ConvertFloatArrayToPercentArray(ref node.Value.Value);
+				}
+
+				if (engineVersion < 20140830)
+				{
+					if (depth == 2)
+					{
+						if (node.Key == "InfDeath")
+							node.Key = "DeathType";
+					}
 				}
 
 				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1);

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -184,13 +184,13 @@
 		Range: 1
 	ScriptTriggers:
 	DeathSounds@NORMAL:
-		InfDeaths: 1, 2, 3, 4
+		DeathTypes: 1, 2, 3, 4
 	DeathSounds@BURNED:
 		DeathSound: Burned
-		InfDeaths: 5
+		DeathTypes: 5
 	DeathSounds@POISONED:
 		DeathSound: Poisoned
-		InfDeaths: 6
+		DeathTypes: 6
 	GainsStatUpgrades:
 
 ^CivInfantry:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -2,7 +2,7 @@ FlametankExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
 		Damage: 100
-		InfDeath: 5
+		DeathType: 5
 	Warhead@2Eff: CreateEffect
 		Explosion: big_napalm
 		ImpactSound: xplobig6.aud
@@ -11,14 +11,14 @@ HeliCrash:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 	Warhead@2Eff: CreateEffect
 		Explosion: poof
 		ImpactSound: xplos.aud
 
 HeliExplode:
 	Warhead@1Dam: SpreadDamage
-		InfDeath: 4
+		DeathType: 4
 	Warhead@2Eff: CreateEffect
 		Explosion: small_building
 		ImpactSound: xplos.aud
@@ -28,7 +28,7 @@ UnitExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -42,7 +42,7 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -56,7 +56,7 @@ GrenadierExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 10
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
@@ -73,7 +73,7 @@ Atomic:
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		ValidTargets: Ground, Air
 		Versus:
 			None: 100
@@ -87,7 +87,7 @@ Atomic:
 		Spread: 2c512
 		Damage: 100
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 3
 		ValidTargets: Ground, Air
 		Versus:
@@ -109,7 +109,7 @@ Atomic:
 		Spread: 3c768
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 6
 		ValidTargets: Ground, Air
 		Versus:
@@ -128,7 +128,7 @@ Atomic:
 		Spread: 5c0
 		Damage: 20
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 9
 		ValidTargets: Ground, Air
 		Versus:
@@ -150,7 +150,7 @@ IonCannon:
 		Range: 0, 1c1, 2c1, 2c512
 		Damage: 100
 		Falloff: 1000, 1000, 250, 100
-		InfDeath: 5
+		DeathType: 5
 		ValidTargets: Ground, Air
 	Warhead@2Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
@@ -176,7 +176,7 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Infantry
 
 HighV:
@@ -188,7 +188,7 @@ HighV:
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
 		Damage: 30
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 50
@@ -210,7 +210,7 @@ HeliAGGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 20
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground
 		Versus:
 			None: 100
@@ -233,7 +233,7 @@ HeliAAGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 20
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Air
 		Versus:
 			None: 100
@@ -253,7 +253,7 @@ Pistol:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 1
-		InfDeath: 2
+		DeathType: 2
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -273,7 +273,7 @@ M16:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		InfDeath: 2
+		DeathType: 2
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -301,7 +301,7 @@ Rockets:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
@@ -335,7 +335,7 @@ BikeRockets:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -369,7 +369,7 @@ OrcaAGMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			None: 50
@@ -402,7 +402,7 @@ OrcaAAMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Air
 		Versus:
 			Light: 75
@@ -423,7 +423,7 @@ Flamethrower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 40
-		InfDeath: 5
+		DeathType: 5
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -448,7 +448,7 @@ BigFlamer:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 75
-		InfDeath: 5
+		DeathType: 5
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -470,7 +470,7 @@ Chemspray:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 80
-		InfDeath: 6
+		DeathType: 6
 		Versus:
 			None: 100
 			Wood: 35
@@ -495,7 +495,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 50
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 50
@@ -517,7 +517,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 25
 			Wood: 75
@@ -540,7 +540,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 75
@@ -562,7 +562,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 25
 			Wood: 100
@@ -587,7 +587,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 25
 			Wood: 100
@@ -610,7 +610,7 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 25
@@ -642,7 +642,7 @@ MammothMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
 		Damage: 45
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
@@ -682,7 +682,7 @@ MammothMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
 		Damage: 25
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			None: 35
@@ -715,7 +715,7 @@ MammothMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -743,7 +743,7 @@ ArtilleryShell:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 150
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 80
@@ -766,7 +766,7 @@ MachineGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		InfDeath: 2
+		DeathType: 2
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -796,7 +796,7 @@ BoatMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 60
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
@@ -831,7 +831,7 @@ TowerMissle:
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
 		Damage: 25
-		InfDeath: 3
+		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 50
@@ -854,7 +854,7 @@ Vulcan:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 100
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground, Water
 		Versus:
 			None: 100
@@ -876,7 +876,7 @@ Napalm:
 		Spread: 341
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		ValidTargets: Ground, Water
 		Versus:
 			None: 100
@@ -894,7 +894,7 @@ Napalm.Crate:
 		Spread: 170
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 90
 			Wood: 100
@@ -917,7 +917,7 @@ Laser:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 360
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			Wood: 50
 	Warhead@2Smu: LeaveSmudge
@@ -945,7 +945,7 @@ SAMMissile:
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		InfDeath: 4
+		DeathType: 4
 		Damage: 30
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -970,7 +970,7 @@ HonestJohn:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 100
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
@@ -987,14 +987,14 @@ Tiberium:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 2
-		InfDeath: 6
+		DeathType: 6
 		PreventProne: yes
 
 TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
@@ -1073,7 +1073,7 @@ Patriot:
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		InfDeath: 4
+		DeathType: 4
 		Damage: 32
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -1089,7 +1089,7 @@ Tail:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 180
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
@@ -1105,7 +1105,7 @@ Horn:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 120
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
@@ -1121,7 +1121,7 @@ Teeth:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 180
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
@@ -1137,7 +1137,7 @@ Claw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 60
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -11,7 +11,7 @@ LMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 15
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 25
 			Light: 40
@@ -36,7 +36,7 @@ Bazooka:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 50
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			None: 10
@@ -63,7 +63,7 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 32
 		Damage: 60
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 0
@@ -85,7 +85,7 @@ Vulcan:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 30
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			Wood: 0
@@ -111,7 +111,7 @@ Slung:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Damage: 30
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			None: 0
@@ -138,7 +138,7 @@ HMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 30
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 15
 			Light: 45
@@ -162,7 +162,7 @@ HMGo:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 40
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 15
 			Light: 45
@@ -188,7 +188,7 @@ QuadRockets:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 25
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 35
@@ -215,7 +215,7 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 55
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 50
 			Wood: 75
@@ -248,7 +248,7 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Damage: 50
-		InfDeath: 3
+		DeathType: 3
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
@@ -273,7 +273,7 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 50
 			Wood: 50
@@ -296,7 +296,7 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 50
 			Wood: 50
@@ -318,7 +318,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 100
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 100
 			Wood: 50
@@ -351,7 +351,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Damage: 60
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			None: 20
@@ -408,7 +408,7 @@ FakeMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Damage: 100
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 80
@@ -433,7 +433,7 @@ Sound:
 	Warhead@1Dam: SpreadDamage
 		Spread: 32
 		Damage: 150
-		InfDeath: 6
+		DeathType: 6
 		Versus:
 			None: 60
 			Wood: 85
@@ -451,7 +451,7 @@ ChainGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 20
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 50
 			Light: 60
@@ -469,7 +469,7 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Damage: -50
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			Wood: 0
 			Light: 0
@@ -497,7 +497,7 @@ ParaBomb:
 		Spread: 192
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 75
@@ -518,7 +518,7 @@ Napalm:
 		Spread: 640
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 100
@@ -548,7 +548,7 @@ Atomic:
 		Spread: 2c0
 		Damage: 180
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 100
 			Wood: 100
@@ -564,7 +564,7 @@ CrateNuke:
 		Spread: 1c576
 		Damage: 80
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 20
 			Wood: 75
@@ -580,7 +580,7 @@ CrateExplosion:
 		Spread: 320
 		Damage: 40
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -595,7 +595,7 @@ UnitExplode:
 		Spread: 320
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -609,7 +609,7 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Damage: 60
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -623,7 +623,7 @@ UnitExplodeTiny:
 	Warhead@1Dam: SpreadDamage
 		Spread: 224
 		Damage: 30
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -637,7 +637,7 @@ UnitExplodeScale:
 	Warhead@1Dam: SpreadDamage
 		Spread: 416
 		Damage: 90
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -660,7 +660,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Damage: 60
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 50
 			Wood: 100
@@ -690,7 +690,7 @@ Shrapnel:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Damage: 60
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 50
 			Wood: 100
@@ -706,7 +706,7 @@ SpiceExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -371,7 +371,7 @@ Weapons:
 		Range: 10c0
 		Warhead: SpreadDamage
 			Spread: 42
-			InfDeath: 5
+			DeathType: 5
 			Damage: 80
 
 Voices:

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -305,7 +305,7 @@ Weapons:
 				Wood: 75
 				Light: 60
 				Heavy: 25
-			InfDeath: 2
+			DeathType: 2
 			Damage: 250
 		Warhead@1Eff: CreateEffect
 			Explosion: large_explosion
@@ -333,7 +333,7 @@ Weapons:
 				None: 40
 				Light: 30
 				Heavy: 30
-			InfDeath: blownaway
+			DeathType: blownaway
 			Damage: 400
 		Warhead@1Eff: CreateEffect
 			Explosion: large_explosion

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -266,7 +266,7 @@ Weapons:
 		Range: 10c0
 		Warhead: SpreadDamage
 			Spread: 42
-			InfDeath: 5
+			DeathType: 5
 			Damage: 80
 
 Voices:

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -778,7 +778,7 @@ Weapons:
 				Wood: 75
 				Light: 75
 				Concrete: 100
-			InfDeath: 4
+			DeathType: 4
 			Damage: 150
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
@@ -812,7 +812,7 @@ Weapons:
 				Light: 110
 				Heavy: 100
 				Concrete: 200
-			InfDeath: 3
+			DeathType: 3
 			Damage: 250
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
@@ -841,7 +841,7 @@ Weapons:
 				Light: 100
 				Heavy: 100
 				Concrete: 100
-			InfDeath: 4
+			DeathType: 4
 			Damage: 15
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
@@ -862,7 +862,7 @@ Weapons:
 				Wood: 100
 				Light: 60
 				Concrete: 25
-			InfDeath: 5
+			DeathType: 5
 			Damage: 200
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
@@ -892,7 +892,7 @@ Weapons:
 				Light: 60
 				Heavy: 75
 				Concrete: 35
-			InfDeath: 5
+			DeathType: 5
 			Damage: 10
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
@@ -944,7 +944,7 @@ Weapons:
 				Wood: 90
 				Light: 80
 				Heavy: 70
-			InfDeath: 3
+			DeathType: 3
 			Damage: 500
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
@@ -966,7 +966,7 @@ Weapons:
 				Light: 0
 				Heavy: 50
 				Concrete: 0
-			InfDeath: 2
+			DeathType: 2
 			Damage: 150
 		Warhead@2Eff: CreateEffect
 			Explosion: piffs

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -1085,7 +1085,7 @@ Weapons:
 				Heavy: 25
 				Concrete: 50
 			Delay: 12
-			InfDeath: 4
+			DeathType: 4
 		Warhead@areanuke2Smu: LeaveSmudge
 			SmudgeType: Scorch
 			Size: 4,3
@@ -1106,7 +1106,7 @@ Weapons:
 				Heavy: 25
 				Concrete: 50
 			Delay: 24
-			InfDeath: 4
+			DeathType: 4
 		Warhead@areanuke3Smu: LeaveSmudge
 			SmudgeType: Scorch
 			Size: 3,2
@@ -1126,7 +1126,7 @@ Weapons:
 				Heavy: 25
 				Concrete: 50
 			Delay: 36
-			InfDeath: 4
+			DeathType: 4
 		Warhead@areanuke4Smu: LeaveSmudge
 			SmudgeType: Scorch
 			Size: 2,1

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -170,13 +170,13 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	DeathSounds@NORMAL:
-		InfDeaths: 1, 2, 3, 4
+		DeathTypes: 1, 2, 3, 4
 	DeathSounds@BURNED:
 		DeathSound: Burned
-		InfDeaths: 5
+		DeathTypes: 5
 	DeathSounds@ZAPPED:
 		DeathSound: Zapped
-		InfDeaths: 6
+		DeathTypes: 6
 	Parachutable:
 		ParachuteOffset: 0,0,427
 		KilledOnImpassableTerrain: true

--- a/mods/ra/weapons.yaml
+++ b/mods/ra/weapons.yaml
@@ -7,7 +7,7 @@ Colt45:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 50
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 0
@@ -52,7 +52,7 @@ Vulcan:
 	Warhead@1Dam_1: SpreadDamage
 		Spread: 128
 		Damage: 10
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 50
 			Light: 60
@@ -67,7 +67,7 @@ Vulcan:
 	Warhead@3Dam_2: SpreadDamage
 		Spread: 128
 		Damage: 10
-		InfDeath: 2
+		DeathType: 2
 		Delay: 2
 		Versus:
 			Wood: 50
@@ -85,7 +85,7 @@ Vulcan:
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
 		Damage: 10
-		InfDeath: 2
+		DeathType: 2
 		Delay: 4
 		Versus:
 			Wood: 50
@@ -103,7 +103,7 @@ Vulcan:
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
 		Damage: 10
-		InfDeath: 2
+		DeathType: 2
 		Delay: 6
 		Versus:
 			Wood: 50
@@ -121,7 +121,7 @@ Vulcan:
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
 		Damage: 10
-		InfDeath: 2
+		DeathType: 2
 		Delay: 8
 		Versus:
 			Wood: 50
@@ -139,7 +139,7 @@ Vulcan:
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
 		Damage: 10
-		InfDeath: 2
+		DeathType: 2
 		Delay: 10
 		Versus:
 			Wood: 50
@@ -175,7 +175,7 @@ Maverick:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 70
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 30
@@ -205,7 +205,7 @@ FireballLauncher:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 150
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 90
 			Wood: 50
@@ -232,7 +232,7 @@ Flamer:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 8
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 90
 			Wood: 100
@@ -256,7 +256,7 @@ ChainGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 120
 			Wood: 50
@@ -281,7 +281,7 @@ ChainGun.Yak:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 50
 			Light: 60
@@ -303,7 +303,7 @@ Pistol:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 1
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 50
 			Light: 60
@@ -325,7 +325,7 @@ M1Carbine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 25
 			Light: 30
@@ -356,7 +356,7 @@ Dragon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 10
@@ -393,7 +393,7 @@ HellfireAG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 30
@@ -430,7 +430,7 @@ HellfireAA:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Air
 		Versus:
 			None: 30
@@ -461,7 +461,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 60
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 50
 			Wood: 100
@@ -488,7 +488,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 16
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 40
@@ -513,7 +513,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 75
@@ -542,7 +542,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 75
@@ -571,7 +571,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		InfDeath: 4
+		DeathType: 4
 		InvalidTargets: Air, Infantry
 		Versus:
 			None: 20
@@ -599,7 +599,7 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 50
@@ -634,7 +634,7 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 50
-		InfDeath: 3
+		DeathType: 3
 		ValidTargets: Air, Infantry
 		Versus:
 			None: 100
@@ -671,7 +671,7 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 220
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
@@ -699,7 +699,7 @@ M60mg:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 10
 			Light: 30
@@ -722,7 +722,7 @@ Napalm:
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
 		Damage: 100
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 90
 			Light: 60
@@ -744,7 +744,7 @@ CrateNapalm:
 		Spread: 170
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 90
 			Light: 60
@@ -761,7 +761,7 @@ CrateExplosion:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -776,7 +776,7 @@ CrateNuke:
 		Spread: 256
 		Damage: 100
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 90
 			Light: 60
@@ -789,7 +789,7 @@ CrateNuke:
 	Warhead@4Dam_areanuke: PerCellDamage
 		Size: 5
 		Damage: 250
-		InfDeath: 5
+		DeathType: 5
 		Delay: 4
 		Versus:
 			None: 90
@@ -798,7 +798,7 @@ CrateNuke:
 			Concrete: 50
 	Warhead@5Dam_areanuke: SpreadDamage
 		Damage: 250
-		InfDeath: 5
+		DeathType: 5
 		Delay: 4
 		Versus:
 			None: 90
@@ -825,7 +825,7 @@ TeslaZap:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		InfDeath: 6
+		DeathType: 6
 		Versus:
 			None: 1000
 			Wood: 60
@@ -846,7 +846,7 @@ Nike:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		InfDeath: 3
+		DeathType: 3
 		ValidTargets: Air
 		Versus:
 			None: 90
@@ -876,7 +876,7 @@ RedEye:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 3
+		DeathType: 3
 		ValidTargets: Air
 		Versus:
 			None: 90
@@ -905,7 +905,7 @@ RedEye:
 		Spread: 213
 		Damage: 25
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 60
 			Wood: 75
@@ -939,7 +939,7 @@ SubMissile:
 		Spread: 426
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 40
 			Light: 30
@@ -974,7 +974,7 @@ Stinger:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 30
@@ -1015,7 +1015,7 @@ TorpTube:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 180
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Water, Underwater, Bridge
 		Versus:
 			None: 30
@@ -1047,7 +1047,7 @@ TorpTube:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 75
@@ -1077,7 +1077,7 @@ DepthCharge:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 80
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Underwater
 		Versus:
 			None: 30
@@ -1106,7 +1106,7 @@ ParaBomb:
 		Spread: 256
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 75
@@ -1131,7 +1131,7 @@ DogJaw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 100
-		InfDeath: 1
+		DeathType: 1
 		ValidTargets: Infantry
 		Versus:
 			Wood: 0
@@ -1148,7 +1148,7 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			Wood: 0
 			Light: 0
@@ -1165,7 +1165,7 @@ Repair:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -20
-		InfDeath: 1
+		DeathType: 1
 		ValidTargets: Repair
 		Versus:
 			None: 0
@@ -1183,7 +1183,7 @@ SilencedPPK:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 150
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			Wood: 0
 			Light: 0
@@ -1214,7 +1214,7 @@ SCUD:
 		Spread: 341
 		Damage: 45
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
@@ -1237,7 +1237,7 @@ Atomic:
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
@@ -1253,7 +1253,7 @@ Atomic:
 		Spread: 2c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -1272,7 +1272,7 @@ Atomic:
 		Spread: 3c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 10
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -1288,7 +1288,7 @@ Atomic:
 		Spread: 4c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 15
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -1304,7 +1304,7 @@ Atomic:
 		Spread: 5c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 20
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -1323,7 +1323,7 @@ MiniNuke:
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
@@ -1336,7 +1336,7 @@ MiniNuke:
 		Spread: 2c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -1351,7 +1351,7 @@ MiniNuke:
 		Spread: 3c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 10
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -1363,7 +1363,7 @@ MiniNuke:
 		Spread: 4c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		Delay: 15
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -1381,7 +1381,7 @@ UnitExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -1400,7 +1400,7 @@ UnitExplodeShip:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 50
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -1414,7 +1414,7 @@ UnitExplodeSubmarine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 50
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -1428,7 +1428,7 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		InfDeath: 4
+		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
@@ -1448,7 +1448,7 @@ BarrelExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 4
+		DeathType: 4
 		Delay: 5
 		Versus:
 			None: 120
@@ -1483,7 +1483,7 @@ APMine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 400
-		InfDeath: 3
+		DeathType: 3
 	Warhead@2Eff: CreateEffect
 		Explosion: napalm
 		ImpactSound: mine1.aud
@@ -1503,7 +1503,7 @@ PortaTesla:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 45
-		InfDeath: 6
+		DeathType: 6
 		Versus:
 			None: 1000
 
@@ -1516,7 +1516,7 @@ TTankZap:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		InfDeath: 6
+		DeathType: 6
 		Versus:
 			None: 1000
 
@@ -1557,7 +1557,7 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 140
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 0
@@ -1583,7 +1583,7 @@ APTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 4
+		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 25
@@ -1609,7 +1609,7 @@ Claw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 33
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
@@ -1625,7 +1625,7 @@ Mandible:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 60
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
@@ -1661,7 +1661,7 @@ OreExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -141,13 +141,13 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	DeathSounds@NORMAL:
-		InfDeaths: 1, 2, 3
+		DeathTypes: 1, 2, 3
 	DeathSounds@BURNED:
 		DeathSound: Burned
-		InfDeaths: 5
+		DeathTypes: 5
 	DeathSounds@ZAPPED:
 		DeathSound: Zapped
-		InfDeaths: 6
+		DeathTypes: 6
 
 ^CivilianInfantry:
 	Inherits: ^Infantry

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -3,7 +3,7 @@ UnitExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 90
 			Wood: 75
@@ -17,7 +17,7 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 90
 			Wood: 75
@@ -36,7 +36,7 @@ Minigun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 12
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -63,7 +63,7 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
 		Damage: 40
-		InfDeath: 3
+		DeathType: 3
 		ProneModifier: 70
 		Versus:
 			None: 100
@@ -98,7 +98,7 @@ Bazooka:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -137,7 +137,7 @@ MultiCluster:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 65
-		InfDeath: 3
+		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -163,7 +163,7 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 100
 		Versus:
 			Wood: 0
@@ -180,7 +180,7 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 150
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 100
 		Versus:
 			None: 100
@@ -198,7 +198,7 @@ M1Carbine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -224,7 +224,7 @@ LtRail:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 150
-		InfDeath: 2
+		DeathType: 2
 		ProneModifier: 100
 		Versus:
 			None: 100
@@ -246,7 +246,7 @@ CyCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 120
-		InfDeath: 6
+		DeathType: 6
 		ProneModifier: 100
 		ValidTargets: Ground
 		Versus:
@@ -274,7 +274,7 @@ Vulcan3:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 10
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -298,7 +298,7 @@ Vulcan2:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			None: 100
@@ -322,7 +322,7 @@ Vulcan:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 20
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -350,7 +350,7 @@ FiendShard:
 		Angle: 88
 	Warhead@1Dam: SpreadDamage
 		Damage: 35
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 100
 		Versus:
 			Wood: 60
@@ -372,7 +372,7 @@ JumpCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -405,7 +405,7 @@ HoverMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -441,7 +441,7 @@ HoverMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 25
 			Wood: 65
@@ -476,7 +476,7 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
 		Damage: 40
-		InfDeath: 3
+		DeathType: 3
 		ProneModifier: 70
 		ValidTargets: Air
 		Versus:
@@ -503,7 +503,7 @@ Repair:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 100
 		Versus:
 			None: 0
@@ -521,7 +521,7 @@ SlimeAttack:
 		Speed: 426
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
-		InfDeath: 2
+		DeathType: 2
 		ProneModifier: 100
 		Versus:
 			Wood: 25
@@ -537,7 +537,7 @@ SuicideBomb:
 		Spread: 256
 		Damage: 110
 		Falloff: 10000, 3680, 1350, 500, 180, 70, 0
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			None: 90
 			Light: 60
@@ -554,7 +554,7 @@ SuicideBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 70
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 25
 			Wood: 65
@@ -582,7 +582,7 @@ MechRailgun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 200
-		InfDeath: 5
+		DeathType: 5
 		ProneModifier: 100
 		Versus:
 			None: 200
@@ -600,7 +600,7 @@ AssaultCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -634,7 +634,7 @@ BikeMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -662,7 +662,7 @@ RaiderCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -689,7 +689,7 @@ FireballLauncher:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 25
-		InfDeath: 5
+		DeathType: 5
 		ProneModifier: 100
 		Versus:
 			None: 600
@@ -710,7 +710,7 @@ SonicZap:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		InfDeath: 5
+		DeathType: 5
 		Versus:
 			Heavy: 80
 			Concrete: 60
@@ -734,7 +734,7 @@ Dragon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -768,7 +768,7 @@ Dragon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 36
-		InfDeath: 2
+		DeathType: 2
 		Versus:
 			None: 25
 			Wood: 65
@@ -799,7 +799,7 @@ Dragon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
 		Damage: 150
-		InfDeath: 3
+		DeathType: 3
 		ProneModifier: 100
 		Versus:
 			None: 100
@@ -835,7 +835,7 @@ Hellfire:
 	Warhead@1Dam: SpreadDamage
 		Spread: 85
 		Damage: 30
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			None: 30
@@ -867,7 +867,7 @@ Bomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
 		Damage: 160
-		InfDeath: 3
+		DeathType: 3
 		ProneModifier: 100
 		Versus:
 			None: 200
@@ -902,7 +902,7 @@ Proton:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 20
-		InfDeath: 3
+		DeathType: 3
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -929,7 +929,7 @@ HarpyClaw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		ValidTargets: Ground, Air
 		Versus:
@@ -953,7 +953,7 @@ Pistola:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 2
-		InfDeath: 1
+		DeathType: 1
 		ProneModifier: 70
 		Versus:
 			Wood: 60
@@ -972,7 +972,7 @@ Tiberium:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 2
-		InfDeath: 6
+		DeathType: 6
 		PreventProne: yes
 
 TiberiumHeal:
@@ -980,7 +980,7 @@ TiberiumHeal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: -2
-		InfDeath: 6
+		DeathType: 6
 		PreventProne: yes
 
 IonCannon:
@@ -989,7 +989,7 @@ IonCannon:
 		Spread: 1c0
 		Damage: 100
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		InfDeath: 5
+		DeathType: 5
 		ProneModifier: 100
 		ValidTargets: Ground, Air
 	Warhead@2Eff_impact: CreateEffect
@@ -997,7 +997,7 @@ IonCannon:
 	Warhead@3Dam_area: PerCellDamage
 		Size: 2
 		Damage: 250
-		InfDeath: 5
+		DeathType: 5
 		Delay: 3
 		ValidTargets: Ground, Air
 	Warhead@4Smu_area: LeaveSmudge
@@ -1014,7 +1014,7 @@ VulcanTower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 18
-		InfDeath: 1
+		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
@@ -1041,7 +1041,7 @@ RPGTower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 110
-		InfDeath: 2
+		DeathType: 2
 		ProneModifier: 70
 		Versus:
 			None: 30
@@ -1076,7 +1076,7 @@ SAMTower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 33
-		InfDeath: 2
+		DeathType: 2
 		ValidTargets: Air
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
@@ -1092,7 +1092,7 @@ ObeliskLaser:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 250
-		InfDeath: 5
+		DeathType: 5
 		ProneModifier: 60
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -1107,7 +1107,7 @@ TurretLaser:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 30
-		InfDeath: 5
+		DeathType: 5
 		ProneModifier: 60
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -1116,7 +1116,7 @@ TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		InfDeath: 3
+		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75


### PR DESCRIPTION
Prerequisite for the upcoming replacement of RenderInfantry's SpawnsCorpse with an infantry-independent WithDeathAnimation trait.
