### PR TITLE
Fix an omission from #6303

### DIFF
--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -43,10 +43,10 @@ namespace OpenRA.Mods.RA
 			{
 				return new Dictionary<int, string[]>()
 				{
-					{ 200, new[] { "firepower", "armor", "speed", "reload", "inaccuracy" } },
-					{ 400, new[] { "firepower", "armor", "speed", "reload", "inaccuracy" } },
-					{ 800, new[] { "firepower", "armor", "speed", "reload", "inaccuracy" } },
-					{ 1600, new[] { "firepower", "armor", "speed", "reload", "inaccuracy" } }
+					{ 200, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } },
+					{ 400, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } },
+					{ 800, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } },
+					{ 1600, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } }
 				};
 			}
 

--- a/OpenRA.Utility/UpgradeRules.cs
+++ b/OpenRA.Utility/UpgradeRules.cs
@@ -459,6 +459,8 @@ namespace OpenRA.Utility
 						node.Value.Value = string.Join(", ", node.Value.Value.Split(',')
 							.Select(s => ((int)(100 * 100 / float.Parse(s))).ToString()));
 					}
+					if (depth == 3 && parentKey == "Upgrades")
+						node.Value.Value = node.Value.Value.Replace("armor", "damage");
 				}
 
 				// RenderInfantryProne and RenderInfantryPanic was merged into RenderInfantry

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -116,8 +116,8 @@
 	GainsExperience:
 		ChevronPalette: ra
 		Upgrades:
-			500: firepower, armor, speed, reload
-			1000: firepower, armor, speed, reload
+			500: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
@@ -205,8 +205,8 @@
 	GainsExperience:
 		ChevronPalette: ra
 		Upgrades:
-			500: firepower, armor, speed, reload
-			1000: firepower, armor, speed, reload
+			500: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
@@ -258,8 +258,8 @@
 	GainsExperience:
 		ChevronPalette: ra
 		Upgrades:
-			500: firepower, armor, speed, reload
-			1000: firepower, armor, speed, reload
+			500: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
@@ -305,8 +305,8 @@
 	GainsExperience:
 		ChevronPalette: ra
 		Upgrades:
-			500: firepower, armor, speed, reload
-			1000: firepower, armor, speed, reload
+			500: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66


### PR DESCRIPTION
PR #6303 neglected to rename the "armor" upgrade to "damage" in all
necessary places, as mentioned in https://github.com/OpenRA/OpenRA/pull/6303#issuecomment-53312209
