### PR TITLE
Revert "fix infantry without idle anim staying in fire animation state"

### DIFF
--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -149,11 +149,6 @@ namespace OpenRA.Mods.RA.Render
 					});
 				}
 			}
-			else
-			{
-				DefaultAnimation.PlayRepeating(NormalizeInfantrySequence(self, info.StandAnimations.Random(Game.CosmeticRandom)));
-				state = AnimationState.Waiting;
-			}
 		}
 
 		// TODO: Possibly move this into a separate trait


### PR DESCRIPTION
Reverts part of #6331. Fixes #6416. Reopens #5884.
