### PR TITLE
Add a symlink to libgdiplus in the OS X package.

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -26,7 +26,10 @@ rm OpenRA.app/Contents/Resources/OpenRA.CrashDialog.exe
 sed "s/{DEV_VERSION}/${1}/" OpenRA.app/Contents/Info.plist.template > OpenRA.app/Contents/Info.plist
 rm OpenRA.app/Contents/Info.plist.template
 
+# Add a symlink to libgdiplus.dylib to work around an issue in mono 3.8
+ln -s /Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib OpenRA.app/Contents/Resources/libgdiplus.dylib
+
 # Package app bundle into a zip and clean up
-zip OpenRA-$1 -r -9 OpenRA.app --quiet
+zip OpenRA-$1 -r -9 OpenRA.app --quiet --symlinks
 mv OpenRA-$1.zip $4
 rm -rf OpenRA.app


### PR DESCRIPTION
Closes #6413 for our packaged releases.
