### PR TITLE
Disable replay saving for campaign missions.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -43,10 +43,13 @@ namespace OpenRA
 
 		public static DatabaseReader GeoIpDatabase;
 
-		public static OrderManager JoinServer(string host, int port, string password)
+		public static OrderManager JoinServer(string host, int port, string password, bool recordReplay = true)
 		{
-			var om = new OrderManager(host, port, password,
-				new ReplayRecorderConnection(new NetworkConnection(host, port), ChooseReplayFilename));
+			IConnection connection = new NetworkConnection(host, port);
+			if (recordReplay)
+				connection = new ReplayRecorderConnection(connection, ChooseReplayFilename);
+
+			var om = new OrderManager(host, port, password, connection);
 			JoinInner(om);
 			return om;
 		}

--- a/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			};
 			Game.LobbyInfoChanged += lobbyReady;
 
-			om = Game.JoinServer(IPAddress.Loopback.ToString(), Game.CreateLocalServer(selectedMapPreview.Uid), "");
+			om = Game.JoinServer(IPAddress.Loopback.ToString(), Game.CreateLocalServer(selectedMapPreview.Uid), "", false);
 		}
 	}
 }


### PR DESCRIPTION
Allowing players to view replays of campaign missions introduces two significant issues:
1. Desyncs and other issues due to the current implementation of FMVs (see #6210).
2. Players can easily cheat or accidentally spoil themselves by loading a replay and spying on the map layout and enemy forces.

In an ideal world (1) would be solved by moving the FMVs outside the world state (briefings integrated with the campaign menu and pause-menu briefing tab, end-game FMVs integrated with the post-game screen) and (2) would be solved by special-casing these missions to lock the shroud selector to the player view.  Both of these will require a fair amount of effort.

I propose that as a short-term solution we just disable replays for these missions.  The downside of this specific approach (as opposed to filtering them in the replay browser) is that we lose a debug tool that is (very) occasionally useful (e.g. #6076).
