### PR TITLE
Prevent a NullReferenceException in GameInfoStatsLogic

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var nameLabel = item.Get<LabelWidget>("NAME");
 				nameLabel.GetText = () =>
 				{
-					if (client.State == Network.Session.ClientState.Disconnected)
+					if (client != null && client.State == Network.Session.ClientState.Disconnected)
 						return pp.PlayerName + " (Gone)";
 					return pp.PlayerName + (pp.WinState == WinState.Undefined ? "" : " (" + pp.WinState + ")");
 				};

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -457,7 +457,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var client = player.World.LobbyInfo.ClientWithIndex(player.ClientIndex);
 			playerName.GetText = () =>
 			{
-				if (client.State == Network.Session.ClientState.Disconnected)
+				if (client != null && client.State == Network.Session.ClientState.Disconnected)
 					return player.PlayerName + " (Gone)";
 				return player.PlayerName + (player.WinState == WinState.Undefined ? "" : " (" + player.WinState + ")");
 			};


### PR DESCRIPTION
Fixes #6444.
