### PR TITLE
More OSX launcher tweaks

### DIFF
--- a/packaging/osx/template.app/Contents/MacOS/OpenRA
+++ b/packaging/osx/template.app/Contents/MacOS/OpenRA
@@ -3,17 +3,21 @@
 # Checks for a sufficiently recent mono version, then launches the game from the resources directory.
 # Based on code from the monodevelop project
 
-REQUIRED_MAJOR=2
-REQUIRED_MINOR=10
+REQUIRED_MAJOR=3
+REQUIRED_MINOR=2
+
+# Require a framework build of mono.
+# The game files assume that mono-installed libraries are present in /Library/Frameworks/Mono.framework/Libraries
+MONO_BIN="/Library/Frameworks/Mono.framework/Commands/mono"
 
 TITLE="Cannot launch OpenRA"
-MESSAGE="OpenRA requires the Mono Framework version $REQUIRED_MAJOR.$REQUIRED_MINOR or later."
-MONO_URL="http://www.go-mono.com/mono-downloads/download.html"
+MESSAGE="OpenRA requires Mono $REQUIRED_MAJOR.$REQUIRED_MINOR or later. Please install the Mono MRE package and try again."
+MONO_URL="http://www.mono-project.com/download/"
 
 DIR=$(cd "$(dirname "$0")"; pwd)
 RESOURCES="$DIR/../Resources"
 
-MONO_VERSION="$(mono --version | grep 'Mono JIT compiler version ' |  cut -f5 -d\ )"
+MONO_VERSION="$($MONO_BIN --version | grep 'Mono JIT compiler version ' |  cut -f5 -d\ )"
 MONO_VERSION_MAJOR="$(echo $MONO_VERSION | cut -f1 -d.)"
 MONO_VERSION_MINOR="$(echo $MONO_VERSION | cut -f2 -d.)"
 
@@ -23,12 +27,12 @@ if [ -z "$MONO_VERSION" ] \
 then
 	osascript \
 	-e "tell application \"Finder\"" \
-	-e "	set question to display dialog \"$MESSAGE\" with title \"$TITLE\" with icon alias (POSIX file \"$RESOURCES/OpenRA.icns\") buttons {\"Cancel\", \"Download...\"} default button 2" \
-	-e "	if button returned of question is equal to \"Download...\" then open location \"$MONO_URL\"" \
+	-e "	set question to display dialog \"$MESSAGE\" with title \"$TITLE\" with icon alias (POSIX file \"$RESOURCES/OpenRA.icns\") buttons {\"Quit\", \"Download Mono\"} default button 2" \
+	-e "	if button returned of question is equal to \"Download Mono\" then open location \"$MONO_URL\"" \
 	-e "	activate" \
 	-e "end tell"
 	exit 1
 fi
 
 # Override fontconfig with our own dummy config that prevents long cache delays
-cd "$RESOURCES" && FONTCONFIG_PATH="." mono --debug OpenRA.Game.exe Graphics.Renderer=Sdl2
+cd "$RESOURCES" && FONTCONFIG_PATH="." $MONO_BIN --debug OpenRA.Game.exe Graphics.Renderer=Sdl2


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/167819/4262202/207d1b60-3b93-11e4-91e9-f17630f7a889.png)
- Require a framework install of Mono, as our .config files reference dylibs installed to the frameworks dir.
- Bump the minimum Mono version to 3.2, which included the SGen GC.
- Update download link for the new Mono website.
- Reference the MRE package to reduce potential confusion.

After this has been merged I will manually backport this, #6300, #6307, and #6438 to our release-20140722 OSX package to solve the current crash and startup perf issues.
