### PR TITLE
Follow-up to #6396 (WithDeathAnimation)

### DIFF
--- a/OpenRA.Mods.RA/Crushable.cs
+++ b/OpenRA.Mods.RA/Crushable.cs
@@ -54,8 +54,8 @@ namespace OpenRA.Mods.RA
 			var wda = self.TraitOrDefault<WithDeathAnimation>();
 			if (wda != null)
 			{
-				var palette = wda.Info.DeathSequencePalette;
-				if (wda.Info.DeathPaletteIsPlayerPalette)
+				var palette = wda.Info.CrushedSequencePalette;
+				if (wda.Info.CrushedPaletteIsPlayerPalette)
 					palette += self.Owner.InternalName;
 
 				wda.SpawnDeathAnimation(self, wda.Info.CrushedSequence, palette);


### PR DESCRIPTION
Fixes a copy-paste error introduced with a last-minute change to #6396.
