### PR TITLE
Fix for stealth tanks needing cloak upgrade

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -531,7 +531,7 @@ STNK:
 	RevealsShroud:
 		Range: 7c0
 	Cloak:
-		RequiresUpgrade: cloak
+		-RequiresUpgrade:
 		InitialDelay: 90
 		CloakDelay: 90
 		CloakSound: trans1.aud


### PR DESCRIPTION
This fixes https://github.com/OpenRA/OpenRA/issues/6448 by making it so that stealth tanks don't require a crate pickup to be able to cloak.
