### PR TITLE
[Addition] Add the Snow  terrain to the Tiberian Sun Mod

### DIFF
--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -146,7 +146,7 @@ Notifications:
 
 TileSets:
 	mods/ts/tilesets/temperat.yaml
-
+	mods/ts/tilesets/snow.yaml
 TileSize: 48,24
 TileShape: Diamond
 SubCells:

--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -1,0 +1,32 @@
+General:
+	Name: Snow
+	Id: SNOW
+	Extensions: .sno, .shp
+	Palette: isosno.pal
+	EditorTemplateOrder: Placeholder
+
+Terrain:
+	TerrainType@Clear:
+		Type: Clear
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 204, 231, 245
+		TargetTypes: Ground
+	TerrainType@Tiberium:
+		Type: Tiberium
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 161, 226, 28
+		TargetTypes: Ground
+	TerrainType@BlueTiberium:
+		Type: BlueTiberium
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 28, 64, 248
+		TargetTypes: Ground
+
+Templates:
+	Template@255:
+		Id: 255
+		Image: clear01
+		Size: 1,1
+		Category: Placeholder
+		Tiles:
+			0: Clear


### PR DESCRIPTION
This Patch contains only the Definitions of the Snow Theatre an second Patch is needed to get the Ligthning and Colors on the Map!
- Define Snow terrain "SNOW"
- Define file extensions (.sno) for this terrain
- Assign the Palette "isosno.pal" to this terrain
- Set Radar and World colors for this terrain
