### PR TITLE
AI no longer calls support power on things it can't target

### DIFF
--- a/OpenRA.Mods.RA/AI/SupportPowerDecision.cs
+++ b/OpenRA.Mods.RA/AI/SupportPowerDecision.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.RA
 
 				var checkActors = world.FindActorsInCircle(pos, radiusToUse);
 				foreach (var scrutinized in checkActors)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.Stances[scrutinized.Owner]);
+					answer += consideration.GetAttractiveness(scrutinized, firedBy.Stances[scrutinized.Owner], firedBy);
 			}
 
 			return answer;
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.RA
 
 			foreach (var consideration in Considerations)
 				foreach (var scrutinized in actors)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.Stances[scrutinized.Owner]);
+					answer += consideration.GetAttractiveness(scrutinized, firedBy.Stances[scrutinized.Owner], firedBy);
 
 			return answer;
 		}
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.RA
 			}
 
 			///<summary>Evaluates a single actor according to the rules defined in this consideration</summary>
-			public int GetAttractiveness(Actor a, Stance stance)
+			public int GetAttractiveness(Actor a, Stance stance, Player firedBy)
 			{
 				if (stance != Against)
 					return 0;
@@ -130,6 +130,9 @@ namespace OpenRA.Mods.RA
 
 				var targetable = a.TraitOrDefault<ITargetable>();
 				if (targetable == null)
+					return 0;
+
+				if (!targetable.TargetableBy(a, firedBy.PlayerActor))
 					return 0;
 
 				if (Types.Intersect(targetable.TargetTypes).Any())


### PR DESCRIPTION
This makes the AI take into consideration whether or not it can target a unit when considering how attractive a target it is for its support power - if it can't be targetted then it's not considered.

I tested this change by creating a large number of stealth tanks and having them sat clumped together as bait - when cloaked the AI didn't air strike them and instead chose another target. When uncloaked (I made them force fire on a bit of terrain) it saw them and air striked them (as they were by far the most obvious target).

I think this will make it a bit more fun to use stealth tanks against the AI - it decimated my stealth tanks the other day and I was a little bit displeased (╯°□°)╯︵ ┻━┻
