### PR TITLE
Added return values for "Timeout" and "DNS" Errors

### DIFF
--- a/OpenRA.Game/Download.cs
+++ b/OpenRA.Game/Download.cs
@@ -28,7 +28,9 @@ namespace OpenRA
 			switch (ex.Status)
 			{
 				case WebExceptionStatus.NameResolutionFailure:
+					return "DNS lookup failed";
 				case WebExceptionStatus.Timeout:
+					return "Connection timeout";
 				case WebExceptionStatus.ConnectFailure:
 					return "Cannot connect to remote server";
 				case WebExceptionStatus.ProtocolError:


### PR DESCRIPTION
Added Return value for:
- WebExceptionStatus.NameResolutionFailure: "DNS lookup failed"
- WebExceptionStatus.Timeout: "Connection timeout"
