### PR TITLE
[TS] Fix Shroud revealing on Structures (PROC, GALIGHT)

### DIFF
--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -140,7 +140,7 @@ PROC:
 	Health:
 		HP: 900
 	RevealsShroud:
-		Range: 6
+		Range: 6c0
 	TiberianSunRefinery:
 		DockOffset: 3,1
 	StoresResources:
@@ -653,7 +653,7 @@ GALITE:
 	Armor:
 		Type: Wood
 	RevealsShroud:
-		Range: 0c0
+		Range: 2c0
 	Power:
 		Amount: 0
 #	WithIdleOverlay@LIGHTING:


### PR DESCRIPTION
- PROC doesnt reveal shroud enough:
  In my "research i had found that all Structures have "Xc0" style as Value but PROC has only "6" instead of "6c0" after chainging the Value to 6c0,
- GALIGHT: increase Shroud reveal value from "0c0" at least "2c0":
  Also i had noticed that GALIGHT is covered under the Shroud when it is placed on the map. 
  I gave it 2c0 instead of 0c0 -> so it is not covered by the shroud, when it is placed by the Player side 
