### PR TITLE
Added map revision property.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -72,6 +72,7 @@ namespace OpenRA
 		public string Type = "Conquest";
 		public string Description;
 		public string Author;
+		public int Revision = 0;
 		public string Tileset;
 		public bool AllowStartUnitConfig = true;
 		public Bitmap CustomPreview;
@@ -310,6 +311,7 @@ namespace OpenRA
 				"Title",
 				"Description",
 				"Author",
+				"Revision",
 				"Tileset",
 				"MapSize",
 				"Bounds",

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -34,6 +34,7 @@ namespace OpenRA
 		public readonly string title;
 		public readonly string author;
 		public readonly string map_type;
+		public readonly int revision;
 		public readonly int players;
 		public readonly Rectangle bounds;
 		public readonly int[] spawnpoints = {};
@@ -50,6 +51,7 @@ namespace OpenRA
 		public string Title { get; private set; }
 		public string Type { get; private set; }
 		public string Author { get; private set; }
+		public int Revision { get; private set; }
 		public int PlayerCount { get; private set; }
 		public List<CPos> SpawnPoints { get; private set; }
 		public Rectangle Bounds { get; private set; }
@@ -93,6 +95,7 @@ namespace OpenRA
 			Title = "Unknown Map";
 			Type = "Unknown";
 			Author = "Unknown Author";
+			Revision = 0;
 			PlayerCount = 0;
 			Bounds = Rectangle.Empty;
 			SpawnPoints = NoSpawns;
@@ -107,6 +110,7 @@ namespace OpenRA
 			Type = m.Type;
 			Type = m.Type;
 			Author = m.Author;
+			Revision = m.Revision;
 			PlayerCount = m.Players.Count(x => x.Value.Playable);
 			Bounds = m.Bounds;
 			SpawnPoints = m.GetSpawnPoints().ToList();
@@ -137,6 +141,7 @@ namespace OpenRA
 						Title = r.title;
 						Type = r.map_type;
 						Author = r.author;
+						Revision = r.revision;
 						PlayerCount = r.players;
 						Bounds = r.bounds;
 

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyMapPreviewLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyMapPreviewLogic.cs
@@ -38,7 +38,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				var author = available.GetOrNull<LabelWidget>("MAP_AUTHOR");
 				if (author != null)
-					author.GetText = () => "Created by {0}".F(lobby.Map.Author);
+					author.GetText = () => (lobby.Map.Revision > 0) ?
+						"Rev.{0} by {1}".F(lobby.Map.Revision, lobby.Map.Author) :
+						"Created by {0}".F(lobby.Map.Author);
 			}
 
 			var invalid = widget.GetOrNull("MAP_INVALID");
@@ -80,7 +82,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				var author = download.GetOrNull<LabelWidget>("MAP_AUTHOR");
 				if (author != null)
-					author.GetText = () => "Created by {0}".F(lobby.Map.Author);
+					author.GetText = () => (lobby.Map.Revision > 0) ?
+						"Rev.{0} by {1}".F(lobby.Map.Revision, lobby.Map.Author) :
+						"Created by {0}".F(lobby.Map.Author);
 
 				var install = download.GetOrNull<ButtonWidget>("MAP_INSTALL");
 				if (install != null)

--- a/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
@@ -90,7 +90,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				.Where(m => m.Status == MapStatus.Available && m.Map.Selectable)
 				.Where(m => m.Type == gameMode || gameMode == null)
 				.OrderBy(m => m.PlayerCount)
-				.ThenBy(m => m.Title);
+				.ThenBy(m => m.Title)
+				.ThenBy(m => m.Revision);
 
 			scrollpanel.RemoveChildren();
 			foreach (var loop in maps)
@@ -115,7 +116,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				var authorWidget = item.GetOrNull<LabelWidget>("AUTHOR");
 				if (authorWidget != null)
-					authorWidget.GetText = () => "Created by {0}".F(preview.Author);
+					authorWidget.GetText = () => (preview.Revision > 0) ?
+						"Rev.{0} by {1}".F(preview.Revision, preview.Author) :
+						"Created by {0}".F(preview.Author);
 
 				var sizeWidget = item.GetOrNull<LabelWidget>("SIZE");
 				if (sizeWidget != null)


### PR DESCRIPTION
Downloading multiple revisions make map choice confusing for host and players. This fixes the problem with an optional Revision property.
