### PR TITLE
Turrets now realign by default

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -265,7 +265,8 @@ namespace OpenRA
 			Uid = ComputeHash();
 
 			if (Container.Exists("map.png"))
-				CustomPreview = new Bitmap(Container.GetContent("map.png"));
+				using (var dataStream = Container.GetContent("map.png"))
+					CustomPreview = new Bitmap(dataStream);
 
 			PostInit();
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -645,6 +645,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20141002)
+				{
+					if (node.Key == "AlignWhenIdle" && parentKey == "Turreted")
+					{
+						node.Key = "RealignDelay";
+						node.Value.Value = "0";
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -493,7 +493,7 @@ MLRS:
 	Turreted:
 		ROT: 8
 		Offset: -128,0,128
-		AlignWhenIdle: true
+		RealignDelay: 0
 	Armament:
 		Weapon: Patriot
 		LocalOffset: 0,-171,0, 0,171,0

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -207,7 +207,7 @@ QUAD.starport:
 		Range: 7c0
 	Turreted:
 		ROT: 6
-		AlignWhenIdle: true
+		RealignDelay: 0
 	Armament:
 		Weapon: 90mm
 		Recoil: 128


### PR DESCRIPTION
After using vehicles to fire for the first time, their turret persistently stayed at the angle they fired at no matter which direction they navigate, you couldn't set up tanks to face a certain way because the turret would always face in the set direction and it plain looked weird.

Default AlignWhenIdle = true means:

When the unit destroys a target, it's turret remains facing so it's ready to fire on the next wave.
When ordered to move and the previous target was destroyed, the turret realigns.
When ordered the 'stop' command, the turret realigns - good visual feedback
Doesn't affect turreted structures
