### PR TITLE
Improved ore rendering

### DIFF
--- a/OpenRA.Mods.RA/World/ResourceLayer.cs
+++ b/OpenRA.Mods.RA/World/ResourceLayer.cs
@@ -107,7 +107,8 @@ namespace OpenRA.Mods.RA
 			if (t.Density > 0)
 			{
 				var sprites = t.Type.Variants[t.Variant];
-				var frame = int2.Lerp(0, sprites.Length - 1, t.Density - 1, t.Type.Info.MaxDensity);
+				var frame = (int)Math.Round(
+					float2.Lerp(0, sprites.Length - 1, (float)t.Density / t.Type.Info.MaxDensity));
 				t.Sprite = sprites[frame];
 			}
 			else


### PR DESCRIPTION
Originally I wanted to fix #6278 but I can’t reproduce the bug. I set all ore to the lowest density and mining it worked flawlessly.

But I fixed some other problems with ore drawing:
• The sprite for the highest possible density was never used.
• Added rounding to the ore density linear interpolation (old: 4.9 => 4.0 new: 4.9 => 5.0)
