### PR TITLE
Move inaccuracy modifier queries outside the projectile ctors.

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -20,6 +20,7 @@ namespace OpenRA.GameRules
 	{
 		public WeaponInfo Weapon;
 		public IEnumerable<int> DamageModifiers;
+		public IEnumerable<int> InaccuracyModifiers;
 		public int Facing;
 		public WPos Source;
 		public Actor SourceActor;

--- a/OpenRA.Mods.D2k/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.D2k/ThrowsShrapnel.cs
@@ -52,6 +52,9 @@ namespace OpenRA.Mods.D2k
 						DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 							.Select(a => a.GetFirepowerModifier()),
 
+						InaccuracyModifiers = self.TraitsImplementing<IInaccuracyModifier>()
+							.Select(a => a.GetInaccuracyModifier()),
+
 						Source = self.CenterPosition,
 						SourceActor = self,
 						PassiveTarget = self.CenterPosition + new WVec(range, 0, 0).Rotate(rotation)

--- a/OpenRA.Mods.RA/Armament.cs
+++ b/OpenRA.Mods.RA/Armament.cs
@@ -157,6 +157,9 @@ namespace OpenRA.Mods.RA
 				DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 					.Select(a => a.GetFirepowerModifier()),
 
+				InaccuracyModifiers = self.TraitsImplementing<IInaccuracyModifier>()
+					.Select(a => a.GetInaccuracyModifier()),
+
 				Source = muzzlePosition,
 				SourceActor = self,
 				PassiveTarget = target.CenterPosition,

--- a/OpenRA.Mods.RA/Effects/Bullet.cs
+++ b/OpenRA.Mods.RA/Effects/Bullet.cs
@@ -82,9 +82,7 @@ namespace OpenRA.Mods.RA.Effects
 			target = args.PassiveTarget;
 			if (info.Inaccuracy.Range > 0)
 			{
-				var modifiers = args.SourceActor.TraitsImplementing<IInaccuracyModifier>()
-					.Select(m => m.GetInaccuracyModifier());
-				var inaccuracy = Traits.Util.ApplyPercentageModifiers(info.Inaccuracy.Range, modifiers);
+				var inaccuracy = Traits.Util.ApplyPercentageModifiers(info.Inaccuracy.Range, args.InaccuracyModifiers);
 				var maxOffset = inaccuracy * (target - pos).Length / args.Weapon.Range.Range;
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}

--- a/OpenRA.Mods.RA/Effects/Missile.cs
+++ b/OpenRA.Mods.RA/Effects/Missile.cs
@@ -96,9 +96,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			if (info.Inaccuracy.Range > 0)
 			{
-				var modifiers = args.SourceActor.TraitsImplementing<IInaccuracyModifier>()
-					.Select(m => m.GetInaccuracyModifier());
-				var inaccuracy = Traits.Util.ApplyPercentageModifiers(info.Inaccuracy.Range, modifiers);
+				var inaccuracy = Traits.Util.ApplyPercentageModifiers(info.Inaccuracy.Range, args.InaccuracyModifiers);
 				offset = WVec.FromPDF(world.SharedRandom, 2) * inaccuracy / 1024;
 			}
 


### PR DESCRIPTION
 Fixes #6449.
