### PR TITLE
Make the TS Construction Yard selectable

### DIFF
--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -42,6 +42,8 @@ GACNST:
 	WithBuildingPlacedOverlay:
 	Power:
 		Amount: 0
+	Selectable:
+		Bounds: 120, 90, 0, 20
 
 GAPOWR:
 	Inherits: ^Building


### PR DESCRIPTION
Increasing the size of the selection box to make the Construction Yard selectable.
