### PR TITLE
Add supplimentary IO stream checks

### DIFF
--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -29,7 +29,7 @@ namespace OpenRA
 		public static void ReadBytes(this Stream s, byte[] buffer, int offset, int count)
 		{
 			if (s == null)
-			throw new IOException("Can not read from Stream");
+				throw new IOException("Can not read from Stream");
 			
 			while (s.CanRead && count > 0)
 			{

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -28,7 +28,10 @@ namespace OpenRA
 
 		public static void ReadBytes(this Stream s, byte[] buffer, int offset, int count)
 		{
-			while (count > 0)
+			if (s == null)
+			throw new IOException("Can not read from Stream");
+			
+			while (s.CanRead && count > 0)
 			{
 				int bytesRead;
 				if ((bytesRead = s.Read(buffer, offset, count)) == 0)


### PR DESCRIPTION
Someone has reported a crash in the IRC channel in relation with this function. while overviewing this function i had noticed, that there a no checks before the read progress starts ("canRead" and "is null") 

```
Red Alert Mod at Version release-20140722
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.34014
Exception of type `System.IO.EndOfStreamException`: Es wurde versucht, über das Ende des Datenstroms hinaus zu lesen.
   bei OpenRA.StreamExts.ReadBytes(Stream s, Byte[] buffer, Int32 offset, Int32 count)
   bei OpenRA.StreamExts.ReadBytes(Stream s, Int32 count)
   bei OpenRA.FileSystem.MixFile.ReadBlocks(Stream s, Int64 offset, Int32 count)
   bei OpenRA.FileSystem.MixFile.DecryptHeader(Stream s, Int64 offset, Int64& headerEnd)
   bei OpenRA.FileSystem.MixFile..ctor(String filename, PackageHashType type, Int32 priority)
   bei OpenRA.FileSystem.GlobalFileSystem.OpenPackage(String filename, String annotation, Int32 order)
   bei OpenRA.FileSystem.GlobalFileSystem.<Mount>c__AnonStorey36.<>m__5D()
   bei OpenRA.FileSystem.GlobalFileSystem.Mount(String name, String annotation)
   bei OpenRA.FileSystem.GlobalFileSystem.LoadFromManifest(Manifest manifest)
   bei OpenRA.ModData.PrepareMap(String uid)
   bei OpenRA.Game.StartGame(String mapUID, Boolean isShellmap)
   bei OpenRA.Game.LoadShellMap()
   bei OpenRA.Game.TestAndContinue()
   bei OpenRA.Mods.RA.DefaultLoadScreen.StartGame()
   bei OpenRA.Game.InitializeMod(String mod, Arguments args)
   bei OpenRA.Game.Initialize(Arguments args)
   bei OpenRA.Program.Run(String[] args)
   bei OpenRA.Program.Main(String[] args)
```

Added supplimentary IO stream checks
