### PR TITLE
Prevent player name from becoming part of a formatting string.

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -241,8 +241,8 @@ namespace OpenRA.Network
 
 						SetPlayerStance(world, order.Player, targetPlayer, newStance);
 
-						Game.Debug("{0} has set diplomatic stance vs {1} to {2}".F(
-							order.Player.PlayerName, targetPlayer.PlayerName, newStance));
+						Game.Debug("{0} has set diplomatic stance vs {1} to {2}",
+							order.Player.PlayerName, targetPlayer.PlayerName, newStance);
 
 						// automatically declare war reciprocally
 						if (newStance == Stance.Enemy && targetPlayer.Stances[order.Player] == Stance.Ally)

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -140,7 +140,7 @@ namespace OpenRA.Traits
 					return;
 			}
 
-			Game.Debug("Cheat used: {0} by {1}".F(order.OrderString, self.Owner.PlayerName));
+			Game.Debug("Cheat used: {0} by {1}", order.OrderString, self.Owner.PlayerName);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.RA/ConquestVictoryConditions.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.RA
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.Debug("{0} is defeated.".F(player.PlayerName));
+			Game.Debug("{0} is defeated.", player.PlayerName);
 
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.RA
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.Debug("{0} is victorious.".F(player.PlayerName));
+			Game.Debug("{0} is victorious.", player.PlayerName);
 
 			if (player == player.World.LocalPlayer)
 				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Country.Race));

--- a/OpenRA.Mods.RA/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.RA/StrategicVictoryConditions.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.RA
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.Debug("{0} is defeated.".F(player.PlayerName));
+			Game.Debug("{0} is defeated.", player.PlayerName);
 
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.RA
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.Debug("{0} is victorious.".F(player.PlayerName));
+			Game.Debug("{0} is victorious.", player.PlayerName);
 
 			if (player == player.World.LocalPlayer)
 				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Country.Race));


### PR DESCRIPTION
This fixes #6524 

I've found 3 occasions where the player name was allowed to become part of the formatting string.
