### PR TITLE
Fix server freeze on client absence.

### DIFF
--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -34,6 +34,11 @@ namespace OpenRA.Network
 
 		public void ClientQuit( int clientId, int lastClientFrame )
 		{
+			if (lastClientFrame == -1)
+				lastClientFrame = framePackets
+					.Where(x => x.Value.ContainsKey(clientId))
+					.Select(x => x.Key).OrderBy(x => x).LastOrDefault();
+
 			clientQuitTimes[clientId] = lastClientFrame;
 		}
 

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -25,6 +25,10 @@ namespace OpenRA.Server
 		public int MostRecentFrame = 0;
 		public const int MaxOrderLength = 131072;
 
+		public int TimeSinceLastResponse { get { return Game.RunTime - lastReceivedTime; } }
+		public bool TimeoutMessageShown = false;
+		int lastReceivedTime = 0;
+
 		/* client data */
 		public int PlayerIndex;
 
@@ -69,6 +73,9 @@ namespace OpenRA.Server
 				}
 			}
 
+			lastReceivedTime = Game.RunTime;
+			TimeoutMessageShown = false;
+
 			return true;
 		}
 
@@ -101,7 +108,6 @@ namespace OpenRA.Server
 								ExpectLength = 8;
 								State = ReceiveState.Header;
 
-								server.UpdateInFlightFrames(this);
 							} break;
 					}
 				}

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Server;
 using S = OpenRA.Server.Server;
 
@@ -17,20 +18,52 @@ namespace OpenRA.Mods.Common.Server
 	public class PlayerPinger : ServerTrait, ITick
 	{
 		int PingInterval = 5000; // Ping every 5 seconds
+		int ConnReportInterval = 20000; // Report every 20 seconds
+		int ConnTimeout = 90000; // Drop unresponsive clients after 90 seconds
 
 		// TickTimeout is in microseconds
 		public int TickTimeout { get { return PingInterval * 100; } }
 
 		int lastPing = 0;
+		int lastConnReport = 0;
 		bool isInitialPing = true;
+
 		public void Tick(S server)
 		{
 			if ((Game.RunTime - lastPing > PingInterval) || isInitialPing)
 			{
 				isInitialPing = false;
 				lastPing = Game.RunTime;
-				foreach (var p in server.Conns)
-					server.SendOrderTo(p, "Ping", Game.RunTime.ToString());
+				foreach (var c in server.Conns.ToList())
+				{
+					if (c.TimeSinceLastResponse < ConnTimeout)
+					{
+						server.SendOrderTo(c, "Ping", Game.RunTime.ToString());
+						if (!c.TimeoutMessageShown && c.TimeSinceLastResponse > PingInterval * 2)
+						{
+							server.SendMessage(server.GetClient(c).Name + " is experiencing connection problems.");
+							c.TimeoutMessageShown = true;
+						}
+					}
+					else
+					{
+						server.SendMessage(server.GetClient(c).Name + " has been dropped after timing out.");
+						server.DropClient(c, -1);
+					}
+				}
+			}
+
+			if (Game.RunTime - lastConnReport > ConnReportInterval)
+			{
+				lastConnReport = Game.RunTime;
+
+				var timeouts = server.Conns
+					.Where(c => c.TimeSinceLastResponse > ConnReportInterval && c.TimeSinceLastResponse < ConnTimeout)
+					.OrderBy(c => c.TimeSinceLastResponse);
+
+				foreach (var c in timeouts)
+					server.SendMessage("{0} will be dropped in {1} seconds.".F(
+						server.GetClient(c).Name, (ConnTimeout - c.TimeSinceLastResponse) / 1000));
 			}
 		}
 	}


### PR DESCRIPTION
The server has no concept of clients disconnecting due to networking faults or purposely pulling their internet connection. The current behavior is the server freezes forever waiting for the missing clients to respond until the game timeouts.

This is incredibly frustrating for free-for-all and to an extent, larger team games. More often than not players wish to continue. This fixes the bug by recognizing that clients aren't communicating and eventually drops them so the game can continue.

First the server responds to say it's still alive and waiting, then after a while it shows who isn't responding. Finally after 2 minutes it drops the players. I recommend at least 1.5 minutes before dropping players as often a router can be restarted within a minute and in the original games often found you'd missed the 60 second deadline only by a few seconds.

This is an important fix as the majority of games going down on hetzner, etc. are because of this.
