### PR TITLE
Unhardcoded productionbar colors

### DIFF
--- a/OpenRA.Mods.RA/ProductionBar.cs
+++ b/OpenRA.Mods.RA/ProductionBar.cs
@@ -21,6 +21,8 @@ namespace OpenRA.Mods.RA
 		[Desc("Production queue type, for actors with multiple queues.")]
 		public readonly string ProductionType = null;
 
+		public readonly Color Color = Color.SkyBlue;
+
 		public object Create(ActorInitializer init) { return new ProductionBar(init.self, this); }
 	}
 
@@ -72,6 +74,6 @@ namespace OpenRA.Mods.RA
 			return value;
 		}
 
-		public Color GetColor() { return Color.SkyBlue; }
+		public Color GetColor() { return info.Color; }
 	}
 }

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -758,6 +758,7 @@ FACT:
 		ProductionType: Building
 	ProductionBar@Defense:
 		ProductionType: Defense
+		Color: 138,138,138
 	DeadBuildingState:
 	BaseProvider:
 		Range: 16


### PR DESCRIPTION
Added an expample color to the defense production bar as well
(see https://github.com/OpenRA/OpenRA/issues/5454#issuecomment-44159648 ).
