### PR TITLE
Add support for launching directly into games w/ dev cheats enabled

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -22,6 +22,7 @@ using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Widgets;
+using OpenRA.Traits;
 
 namespace OpenRA
 {
@@ -335,10 +336,87 @@ namespace OpenRA
 
 					Widgets.Ui.OpenWindow(window, new WidgetArgs());
 				}
+				else if (args.GetValue("Launch.Developer", "").ToLower() == "true")
+				{
+					// determine the cheats to use
+					var cheats = args.GetListValue("Launch.Developer.Cheats", DeveloperMode.DefaultCheats);
+
+					// determine the map to use
+					var mapUid = WidgetUtils.ChooseInitialMap(Game.Settings.Server.Map);
+					if (args.Contains("Launch.Developer.Map"))
+					{
+						var requestedMap = args.GetValue("Launch.Developer.Map", null);
+						foreach (var map in Game.modData.MapCache)
+							if (Path.GetFileName(map.Map.Path) == requestedMap)
+							{
+								mapUid = map.Uid;
+								break;
+							}
+					}
+
+					OrderManager om = null;
+
+					// add bots to the map
+					Action addBot = null;
+					addBot = () =>
+					{
+						Game.LobbyInfoChanged -= addBot;
+
+						// determine the bots to use
+						var defaultBot = Game.modData.DefaultRules.Actors["player"].Traits.WithInterface<IBotInfo>().Select(t => t.Name).FirstOrDefault();
+						var defaultBots = Enumerable.Repeat(defaultBot, 8).ToArray();
+						string[] bots = args.GetListValue("Launch.Developer.Bots", defaultBots);
+
+						var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
+
+						var currentBot = 0;
+						foreach (var slot in orderManager.LobbyInfo.Slots.Skip(1).Take(bots.Length))
+						{
+							// we will still fill the slot with a bot even if the map says no bots allowed (slot.Value.AllowBots)
+
+							if (slot.Value.Closed)
+								continue;
+
+							orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot.Key, botController.Index, bots[currentBot++])));
+						}
+
+					};
+					Game.LobbyInfoChanged += addBot;
+
+					// start the game
+					Action startGame = null;
+					startGame = () =>
+					{
+						om.IssueOrder(Order.Command("allowcheats true"));
+						om.IssueOrder(Order.Command("state {0}".F(Session.ClientState.Ready)));
+
+						// We need to issue the cheat commands but we need the world instance to get the
+						// appropriate subject. We just run this a little bit after the game has
+						// started (the recusive call is to ensure that the world has actually been
+						// initialized if, ie, the game is starting extremely slowly).
+						Action sendCheatCommands = null;
+						sendCheatCommands = () =>
+						{
+							if (om.world == null)
+								Game.RunAfterDelay(100, sendCheatCommands);
+							else
+								foreach (var cheat in cheats)
+									om.IssueOrder(new Order(cheat, om.world.LocalPlayer.PlayerActor, false));
+						};
+						sendCheatCommands();
+
+						Game.LobbyInfoChanged -= startGame;
+					};
+					Game.LobbyInfoChanged += startGame;
+
+					om = Game.JoinServer(IPAddress.Loopback.ToString(), Game.CreateLocalServer(mapUid), "", false);
+				}
+
 				else
 				{
 					modData.LoadScreen.StartGame();
 					Settings.Save();
+
 					var replay = args != null ? args.GetValue("Launch.Replay", null) : null;
 					if (!string.IsNullOrEmpty(replay))
 						Game.JoinReplay(replay);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -254,6 +254,9 @@ namespace OpenRA
 
 		public static void InitializeMod(string mod, Arguments args)
 		{
+			if (args == null)
+				throw new ArgumentNullException("args", "Use Arguments.Empty instead of null");
+
 			// Clear static state if we have switched mods
 			LobbyInfoChanged = () => { };
 			ConnectionStateChanged = om => { };
@@ -323,7 +326,7 @@ namespace OpenRA
 			}
 			else
 			{
-				var window = args != null ? args.GetValue("Launch.Window", null) : null;
+				var window = args.GetValue("Launch.Window", null);
 				if (!string.IsNullOrEmpty(window))
 				{
 					var installData = modData.Manifest.ContentInstaller;
@@ -351,7 +354,7 @@ namespace OpenRA
 			{
 				var args = new WidgetArgs()
 				{
-					{ "continueLoading", () => InitializeMod(Game.Settings.Game.Mod, null) },
+					{ "continueLoading", () => InitializeMod(Game.Settings.Game.Mod, Arguments.Empty) },
 				};
 
 				if (installData.InstallerBackgroundWidget != null)

--- a/OpenRA.Game/Support/Arguments.cs
+++ b/OpenRA.Game/Support/Arguments.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -34,5 +35,17 @@ namespace OpenRA
 
 		public bool Contains(string key) { return args.ContainsKey(key); }
 		public string GetValue(string key, string defaultValue) { return Contains(key) ? args[key] : defaultValue; }
+
+		public string[] GetListValue(string key, params string[] defaultValue)
+		{
+			if (Contains(key) == false)
+				return defaultValue;
+
+			var split = args[key].Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+			for (int i = 0; i < split.Length; ++i)
+				split[i] = split[i].Trim();
+
+			return split;
+		}
 	}
 }

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -29,6 +29,15 @@ namespace OpenRA.Traits
 
 	public class DeveloperMode : IResolveOrder, ISync
 	{
+		/// <summary>
+		/// The default cheats to enable when quick-starting the map via a command-line argument.
+		/// </summary>
+		public static string[] DefaultCheats = new[] {
+			"DevShroudDisable", "DevFastBuild", "DevBuildAnywhere",
+			"DevUnlimitedPower", "DevEnableTech", "DevFastCharge",
+			"DevGiveCash", "DevGiveCash", "DevGiveCash"
+		};
+
 		DeveloperModeInfo Info;
 		[Sync] public bool FastCharge;
 		[Sync] public bool AllTech;

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -161,7 +161,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.RunAfterTick(() =>
 			{
 				Ui.CloseWindow();
-				Game.InitializeMod(mod.Id, null);
+				Game.InitializeMod(mod.Id, Arguments.Empty);
 			});
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/Logic/InstallLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/InstallLogic.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
 			{
 				Game.Settings.Game.PreviousMod = Game.modData.Manifest.Mod.Id;
-				Game.InitializeMod("modchooser", null);
+				Game.InitializeMod("modchooser", Arguments.Empty);
 			};
 		}
 	}

--- a/OpenRA.Mods.RA/Widgets/Logic/InstallMusicLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/InstallMusicLogic.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var cancelButton = installMusicContainer.GetOrNull<ButtonWidget>("CANCEL_BUTTON");
 			if (cancelButton != null)
 			{
-				cancelButton.OnClick = () => Game.InitializeMod(Game.Settings.Game.Mod, null);
+				cancelButton.OnClick = () => Game.InitializeMod(Game.Settings.Game.Mod, Arguments.Empty);
 			}
 
 			var copyFromDiscButton = installMusicContainer.GetOrNull<ButtonWidget>("COPY_FROM_CD_BUTTON");
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				copyFromDiscButton.OnClick = () =>
 				{
 					Ui.OpenWindow("INSTALL_FROMCD_PANEL", new WidgetArgs() {
-						{ "continueLoading", () => Game.InitializeMod(Game.Settings.Game.Mod, null) },
+						{ "continueLoading", () => Game.InitializeMod(Game.Settings.Game.Mod, Arguments.Empty) },
 					});
 				};
 			}
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				downloadButton.OnClick = () =>
 				{
 					Ui.OpenWindow("INSTALL_DOWNLOAD_PANEL", new WidgetArgs() {
-						{ "afterInstall", () => Game.InitializeMod(Game.Settings.Game.Mod, null) },
+						{ "afterInstall", () => Game.InitializeMod(Game.Settings.Game.Mod, Arguments.Empty) },
 						{ "mirrorListUrl", mirrorListUrl },
 					});
 				};

--- a/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			mainMenu.Get<ButtonWidget>("MODS_BUTTON").OnClick = () =>
 			{
 				Game.Settings.Game.PreviousMod = Game.modData.Manifest.Mod.Id;
-				Game.InitializeMod("modchooser", null);
+				Game.InitializeMod("modchooser", Arguments.Empty);
 			};
 
 			mainMenu.Get<ButtonWidget>("SETTINGS_BUTTON").OnClick = () =>


### PR DESCRIPTION
Allow launching directly into games w/ dev cheats.

Usage is simple; just pass `Launch.Developer=true` into the command line arguments.

Launching can further be customized with:

  `Launch.Developer.Map`: Select the map to launch
  `Launch.Developer.Cheats`: Specify which cheats to enable
  `Launch.Developer.Bots`: Specify which bots to use. This also limits the maximum number of bots that will be used in the map. For example, to use no bots specify `Launch.Developer.Bots=""`

A reasonable default is selected for each `Launch.Developer.*` argument. if `Launch.Developer=true` is not present, then OpenRA will start normally.

An example launch is as follows:

```
OpenRA.Game.exe \
  Launch.Developer=true \
  Launch.Developer.Map=texas-sea \
  Launch.Developer.Cheats="DevShroudDisable, DevFastBuild" \
  Launch.Developer.Bots="Rush AI, Turtle AI"
```

This will launch a game directly into the texas-sea map with the shroud disabled and fast build enabled. Further, there will be two AI opponents, one using the Rush AI and the other using the Turtle AI.
