### PR TITLE
Add elite self-healing bonus

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -204,9 +204,12 @@ namespace OpenRA
 		{
 			World.AddFrameEndTask(w =>
 			{
-				if (Destroyed) return;
+				if (Destroyed)
+					return;
 
-				World.Remove(this);
+				if (IsInWorld)
+					World.Remove(this);
+
 				World.traitDict.RemoveActor(this);
 				Destroyed = true;
 			});

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -563,6 +563,18 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20140927)
+				{
+					if (depth == 0)
+						node.Value.Nodes.RemoveAll(n => n.Key == "SelfHealingTech");
+
+					if (depth == 2 && node.Key == "RequiresTech" && parentKey.StartsWith("SelfHealing"))
+					{
+						node.Key = "RequiresUpgrade";
+						node.Value.Value = "selfhealing-needs-reconfiguration";
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.RA/GainsExperience.cs
+++ b/OpenRA.Mods.RA/GainsExperience.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA
 					{ 200, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } },
 					{ 400, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } },
 					{ 800, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } },
-					{ 1600, new[] { "firepower", "damage", "speed", "reload", "inaccuracy" } }
+					{ 1600, new[] { "firepower", "damage", "speed", "reload", "inaccuracy", "selfheal" } }
 				};
 			}
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -42,6 +42,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Tank:
 	AppearsOnRadar:
@@ -90,6 +96,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Helicopter:
 	AppearsOnRadar:
@@ -122,6 +134,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Infantry:
 	AppearsOnRadar:
@@ -172,7 +190,7 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
-	SelfHealing:
+	SelfHealing@HOSPITAL:
 		Step: 5
 		Ticks: 100
 		HealIfBelow: 1
@@ -196,6 +214,12 @@
 		DeathSound: Poisoned
 		DeathTypes: 6
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^CivInfantry:
 	Inherits: ^Infantry
@@ -296,6 +320,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Ship:
 	AppearsOnRadar:
@@ -323,6 +353,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Building:
 	AppearsOnRadar:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -177,7 +177,10 @@
 		Ticks: 100
 		HealIfBelow: 1
 		DamageCooldown: 125
-		RequiresTech: InfantryHealing
+		RequiresUpgrade: hospitalheal
+	GlobalUpgradable:
+		Upgrades: hospitalheal
+		Prerequisites: hosp
 	UpdatesPlayerStatistics:
 	Huntable:
 	LuaScriptEvents:

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -31,3 +31,5 @@ Player:
 	ProvidesTechPrerequisite@all:
 		Name: Unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
+	GlobalUpgradeManager:
+

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -27,8 +27,6 @@ HOSP:
 		Dimensions: 2,2
 	Health:
 		HP: 1000
-	SelfHealingTech:
-		Type: InfantryHealing
 	Tooltip:
 		Name: Hospital
 	LeavesHusk:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -40,6 +40,12 @@
 	Demolishable:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Tank:
 	AppearsOnRadar:
@@ -83,6 +89,12 @@
 	Demolishable:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Husk:
 	Health:
@@ -203,6 +215,12 @@
 	Parachutable:
 		FallRate: 130
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Plane:
 	AppearsOnRadar:
@@ -229,6 +247,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -83,8 +83,6 @@ HOSP:
 	ExternalCapturable:
 	ExternalCapturableBar:
 	EngineerRepairable:
-	SelfHealingTech:
-		Type: InfantryHealing
 	Tooltip:
 		Name: Hospital
 	RevealsShroud:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -166,7 +166,10 @@
 		Ticks: 100
 		HealIfBelow: 1
 		DamageCooldown: 125
-		RequiresTech: InfantryHealing
+		RequiresUpgrade: hospitalheal
+	GlobalUpgradable:
+		Upgrades: hospitalheal
+		Prerequisites: hosp
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -55,6 +55,12 @@
 		Notification: UnitStolen
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Tank:
 	AppearsOnRadar:
@@ -113,6 +119,12 @@
 		Notification: UnitStolen
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Infantry:
 	AppearsOnRadar:
@@ -161,7 +173,7 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
-	SelfHealing:
+	SelfHealing@HOSPITAL:
 		Step: 5
 		Ticks: 100
 		HealIfBelow: 1
@@ -191,6 +203,12 @@
 	Cloneable:
 		Types: Infantry
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Ship:
 	AppearsOnRadar:
@@ -225,6 +243,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Plane:
 	AppearsOnRadar:
@@ -262,6 +286,12 @@
 	LuaScriptEvents:
 	ScriptTriggers:
 	GainsStatUpgrades:
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -72,3 +72,4 @@ Player:
 	ProvidesTechPrerequisite@unrestricted:
 		Name: Unrestricted
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.unrestricted
+	GlobalUpgradeManager:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -118,12 +118,18 @@
 		ChevronPalette: ra
 		Upgrades:
 			500: firepower, damage, speed, reload
-			1000: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload, selfheal
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
 		SpeedModifier: 120, 150
 		ReloadModifier: 90, 75
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:
@@ -207,12 +213,18 @@
 		ChevronPalette: ra
 		Upgrades:
 			500: firepower, damage, speed, reload
-			1000: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload, selfheal
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
 		SpeedModifier: 120, 150
 		ReloadModifier: 90, 75
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:
@@ -260,12 +272,18 @@
 		ChevronPalette: ra
 		Upgrades:
 			500: firepower, damage, speed, reload
-			1000: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload, selfheal
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
 		SpeedModifier: 120, 150
 		ReloadModifier: 90, 75
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:
@@ -307,12 +325,18 @@
 		ChevronPalette: ra
 		Upgrades:
 			500: firepower, damage, speed, reload
-			1000: firepower, damage, speed, reload
+			1000: firepower, damage, speed, reload, selfheal
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
 		SpeedModifier: 120, 150
 		ReloadModifier: 90, 75
+	SelfHealing@ELITE:
+		Step: 2
+		Ticks: 100
+		HealIfBelow: 1
+		DamageCooldown: 125
+		RequiresUpgrade: selfheal
 	GivesExperience:
 	DrawLineToTarget:
 	ActorLostNotification:


### PR DESCRIPTION
Split from #6556, this ports SelfHealing to the new upgrade system and adds it as an elite unit bonus.

This doesn't include an upgrade rule for the `RequiresTech` &rarr; `RequiresUpgrade` change because it crosses multiple actors, which makes it a difficult thing to do for such a minor feature.
