### PR TITLE
Fixed typos in the Lua API intro again

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.modData = modData;
 
-			Console.WriteLine("This is an automatically generated lising of the new Lua map scripting API, generated for {0} of OpenRA.", Game.modData.Manifest.Mod.Version);
+			Console.WriteLine("This is an automatically generated listing of the new Lua map scripting API, generated for {0} of OpenRA.", Game.modData.Manifest.Mod.Version);
 			Console.WriteLine();
 			Console.WriteLine("OpenRA allows custom maps and missions to be scripted using Lua 5.1.\n" +
 				"These scripts run in a sandbox that prevents access to unsafe functions (e.g. OS or file access), " +
@@ -39,12 +39,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine("Map scripts can interact with the game engine in three ways:\n" +
 				"* Global tables provide functions for interacting with the global world state, or performing general helper tasks.\n" +
 				"They exist in the global namespace, and can be called directly using ```<table name>.<function name>```.\n" +
-				"* Individual actors expose a collection of properties and commands that query information of modify their state.\n" +
+				"* Individual actors expose a collection of properties and commands that query information or modify their state.\n" +
 				"  * Some commands, marked as <em>queued activity</em>, are asynchronous.  Activities are queued on the actor, and will run in " +
 				"sequence until the queue is empty or the Stop command is called.  Actors that are not performing an activity are Idle " +
 				"(actor.IsIdle will return true).  The properties and commands available on each actor depends on the traits that the actor " +
 				"specifies in its rule definitions.\n" +
-				"* Individual players explose a collection of properties and commands that query information of modify their state.\n" +
+				"* Individual players expose a collection of properties and commands that query information or modify their state.\n" +
 				"The properties and commands available on each actor depends on the traits that the actor specifies in its rule definitions.\n");
 			Console.WriteLine();
 


### PR DESCRIPTION
While updating https://github.com/OpenRA/OpenRA/wiki/New-Lua-API/_compare/cc9ec6b4020a21794fc539c68fa00371bbcc6cf7...03299b312ead249e160ff8b78cc2c708b582fc6f I noticed a slight regression.
