### PR TITLE
Build releases with latest Mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ language: c
 
 # Make sure build dependencies are installed.
 install:
+ - wget http://download.mono-project.com/repo/xamarin.gpg -O /tmp/mono.gpg
+ - sudo apt-key add /tmp/mono.gpg
+ - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo apt-get update -qq
- - sudo apt-get install -qq mono-gmcs cli-common-dev libgl1-mesa-glx libopenal1 libfreetype6
+ - sudo apt-get install -qq mono-gmcs cli-common-dev libgl1-mesa-glx libopenal1 libfreetype6 libgdiplus=2.10-3
 cache: apt
 
 # Run the build script


### PR DESCRIPTION
Stolen from https://github.com/travis-ci/travis-build/pull/294 which will probably need to bake a little longer, but we can't wait till then. This will fix https://github.com/OpenRA/OpenRA/issues/6597 and  https://github.com/OpenRA/OpenRA/issues/6599 whose root may be a miscompile. Mono 2.10 is ancient and unsupported. We should stop using it to build releases. This will also improve performance on the generated IL code.
