### PR TITLE
Cleaned the TS TechTree #2

### DIFF
--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -70,6 +70,7 @@ Rules:
 	mods/ts/rules/aircraft.yaml
 	mods/ts/rules/defaults.yaml
 	mods/ts/rules/infantry.yaml
+	mods/ts/rules/civilian.yaml
 	mods/ts/rules/structures.yaml
 	mods/ts/rules/vehicles.yaml
 	mods/ts/rules/trees.yaml
@@ -78,6 +79,7 @@ Sequences:
 	mods/ts/sequences/aircraft.yaml
 	mods/ts/sequences/infantry.yaml
 	mods/ts/sequences/misc.yaml
+	mods/ts/sequences/civilian.yaml
 	mods/ts/sequences/structures.yaml
 	mods/ts/sequences/vehicles.yaml
 	mods/ts/sequences/trees.yaml

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -18,23 +18,36 @@ Player:
 			gapile: 1
 			nahand: 1
 			garadr: 1
+			naradr: 1
 			gaweap: 1
 			naweap: 1
+			gavulc: 9
+			garock: 9
+			gacsam: 9
+			nalasr: 9
+			nasam: 9
 		BuildingFractions:
 			proc: 30%
 			gapowr: 35%
 			napowr: 35%
+			garadr: 1%
+			naradr: 1%
 			gapile: 1%
 			nahand: 1%
 			gaweap: 1%
 			naweap: 1%
+			gavulc: 49%
+			garock: 49%
+			gacsam: 49%
+			nasam: 49%
+			nalasr: 49%
 		UnitsToBuild:
 			e1: 80%
 			e2: 8%
 			e3: 30%
 			medic: 2%
 			jumpjet: 15%
-			apc: 3%
+			mmch: 3%
 			smech: 25%
 			bike: 60%
 			bggy: 75%

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -4,10 +4,6 @@ DPOD:
 		Cost: 10
 	Tooltip:
 		Name: Drop Pod
-	Buildable:
-		Queue: Air
-		BuildPaletteOrder: 10
-		Owner: none
 	Helicopter:
 		LandWhenIdle: yes
 		ROT: 5
@@ -43,11 +39,6 @@ DSHP:
 		Cost: 1000
 	Tooltip:
 		Name: Dropship
-	Buildable:
-		Queue: Air
-		BuildPaletteOrder: 10
-		Owner: none
-		Prerequisites: gaweap
 	Helicopter:
 		LandWhenIdle: yes
 		ROT: 5

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -7,7 +7,7 @@ DPOD:
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 10
-		Owner: gdi
+		Owner: none
 	Helicopter:
 		LandWhenIdle: yes
 		ROT: 5
@@ -46,7 +46,7 @@ DSHP:
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 10
-		Owner: gdi
+		Owner: none
 		Prerequisites: gaweap
 	Helicopter:
 		LandWhenIdle: yes
@@ -277,4 +277,3 @@ APACHE:
 	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
-

--- a/mods/ts/rules/civilian.yaml
+++ b/mods/ts/rules/civilian.yaml
@@ -1,9 +1,5 @@
 GASPOT:
 	Inherits: ^Building
-	Buildable:
-		Queue: Defense
-		BuildPaletteOrder: 10
-		Owner: none
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -29,10 +25,6 @@ GASPOT:
 
 GALITE:
 	Inherits: ^LightPost
-	Buildable:
-		Queue: Defense
-		BuildPaletteOrder: 10
-		Owner: none
 	Valued:
 		Cost: 0
 	Building:

--- a/mods/ts/rules/civilian.yaml
+++ b/mods/ts/rules/civilian.yaml
@@ -1,0 +1,47 @@
+GASPOT:
+	Inherits: ^Building
+	Buildable:
+		Queue: Defense
+		BuildPaletteOrder: 10
+		Owner: none
+	Valued:
+		Cost: 300
+	Tooltip:
+		Name: Light Tower
+	Building:
+		Footprint: x
+		Dimensions: 1,1
+	Health:
+		HP: 400
+	Armor:
+		Type: Wood
+	RevealsShroud:
+		Range: 4c0
+	RenderDetectionCircle:
+	DetectCloaked:
+		Range: 3
+	WithIdleOverlay@LIGHTS:
+		Sequence: idle-lights
+	Power:
+		Amount: -10
+	Selectable:
+		Bounds: 34, 92, 0, -10
+
+GALITE:
+	Inherits: ^LightPost
+	Buildable:
+		Queue: Defense
+		BuildPaletteOrder: 10
+		Owner: none
+	Valued:
+		Cost: 0
+	Building:
+		Footprint: x
+		Dimensions: 1,1
+	-WithMakeAnimation:
+	Health:
+		HP: 600
+	Armor:
+		Type: Wood
+	RevealsShroud:
+		Range: 2c0

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -170,7 +170,7 @@
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 1000
-		Owner: gdi, nod
+		Owner: none
 	Health:
 		HP: 50
 	Mobile:
@@ -369,3 +369,134 @@
 		Interval: 55
 	WithActiveAnimation:
 
+^ConstructionYard:
+	Inherits: ^Building
+	Production:
+		Produces: Building,Defense
+	BaseBuilding:
+	Transforms:
+		IntoActor: mcv
+		Offset: 1,1
+		Facing: 96
+	Tooltip:
+		Name: Construction Yard
+		Description: Builds base structures.
+	ProductionBar@Building:
+		ProductionType: Building
+	ProductionBar@Defense:
+		ProductionType: Defense
+
+^Barracks:
+	Inherits: ^Building
+	Tooltip:
+		Name: Barracks
+		Description: Produces infantry
+	ProvidesCustomPrerequisite:
+		Prerequisite: barracks
+	Production:
+		Produces: Infantry
+	PrimaryBuilding:
+	ProductionBar:
+
+^WeaponFactory:
+	Inherits: ^Building
+	Tooltip:
+		Name: War Factory
+		Description: Assembly point for\nvehicle reinforcements
+	ProvidesCustomPrerequisite:
+		Prerequisite: factory
+	Production:
+		Produces: Vehicle
+	PrimaryBuilding:
+	ProductionBar:
+	RenderBuildingWarFactory:
+
+^Radar:
+	Inherits: ^Building
+	Tooltip:
+		Name: Radar
+		Description: Provides radar screen
+	ProvidesCustomPrerequisite:
+		Prerequisite: radar
+	RequiresPower:
+	CanPowerDown:
+	ProvidesRadar:
+	InfiltrateForExploration:
+	DetectCloaked:
+		Range: 10
+	RenderDetectionCircle:
+
+^TechCenter:
+	Inherits: ^Building
+	Tooltip:
+		Name: Tech Center
+		Description: Required for high-\ntech research
+	ProvidesCustomPrerequisite:
+		Prerequisite: tech
+
+^HeliPad:
+	Inherits: ^Building
+	Production:
+		Produces: Air
+	Tooltip:
+		Name: Helipad
+		Description: Produces, rearms and\nrepairs helicopters
+	RallyPoint:
+	PrimaryBuilding:
+	BelowUnits:
+	Reservable:
+	RepairsUnits:
+	ProductionBar:
+
+^PowerPlant:
+	Inherits: ^Building
+	Tooltip:
+		Name: Power Plant
+		Description: Provides power for other structures
+	ProvidesCustomPrerequisite:
+		Prerequisite: anypower
+	Power:
+		Amount: 100
+	ScalePowerWithHealth:
+	InfiltrateForPowerOutage:
+	AffectedByPowerOutage:
+
+^Refinery:
+	Inherits: ^Building
+	Tooltip:
+		Name: Tiberium Refinery
+		Description: Processes raw Tiberium\ninto useable resources
+	TiberianSunRefinery:
+		DockOffset: 3,1
+	StoresResources:
+		PipColor: Green
+		PipCount: 15
+		Capacity: 3000
+	FreeActor:
+		Actor: HARV
+		InitialActivity: FindResources
+		SpawnOffset: 3,4
+		Facing: 64
+
+^TiberiumSilo:
+	Inherits: ^Building
+	Buildable:
+		Prerequisites: proc
+	Tooltip:
+		Name: Silo
+		Description: Stores excess Tiberium.
+	StoresResources:
+		PipCount: 5
+		Capacity: 1500
+
+# This is the Generic Template for the other 7 light posts!)
+^LightPost:
+	Inherits: ^Building
+		Tooltip:
+		Name: Light Post
+	Power:
+		Amount: 0
+	RenderBuilding:
+		Palette: terrain
+#	WithIdleOverlay@LIGHTING:
+#		Sequence: lighting

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -168,6 +168,8 @@
 		Bounds: 12,17,0,-9
 	Tooltip:
 		Name: Civilian
+	Valued:
+		Cost: 0
 	Health:
 		HP: 50
 	Mobile:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -4,6 +4,9 @@
 		Palette: pips
 	Selectable:
 		Priority: 3
+	Tooltip:
+		Name: Building
+		Description: Building
 	TargetableBuilding:
 		TargetTypes: Ground, C4
 	Building:
@@ -163,14 +166,8 @@
 	Selectable:
 		Voice: Civilian
 		Bounds: 12,17,0,-9
-	Valued:
-		Cost: 10
 	Tooltip:
 		Name: Civilian
-	Buildable:
-		Queue: Infantry
-		BuildPaletteOrder: 1000
-		Owner: none
 	Health:
 		HP: 50
 	Mobile:
@@ -203,6 +200,8 @@
 		Voice: Vehicle
 	TargetableUnit:
 		TargetTypes: Ground
+	Tooltip:
+		Name: Vehicle
 	Repairable:
 		RepairBuildings: gadept
 	Passenger:
@@ -256,6 +255,8 @@
 			Tiberium: 80
 			BlueTiberium: 80
 		ROT: 5
+	Tooltip:
+		Name: Tank
 	SelectionDecorations:
 		Palette: pips
 	Selectable:
@@ -494,7 +495,6 @@
 	Inherits: ^Building
 	Tooltip:
 		Name: Light Post
-		Description: Light Post
 	Power:
 		Amount: 0
 	RenderBuilding:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -492,8 +492,9 @@
 # This is the Generic Template for the other 7 light posts!)
 ^LightPost:
 	Inherits: ^Building
-		Tooltip:
+	Tooltip:
 		Name: Light Post
+		Description: Light Post
 	Power:
 		Amount: 0
 	RenderBuilding:

--- a/mods/ts/rules/infantry.yaml
+++ b/mods/ts/rules/infantry.yaml
@@ -78,12 +78,12 @@ E3:
 	RenderInfantry:
 		IdleAnimations: idle1,idle2
 
-WEEDGUY:
+WEEDGUY: #Not Buildable by Default..
 	Inherits: ^Infantry
 	Valued:
 		Cost: 300
 	Tooltip:
-		Name: Chem Spray Infantry
+		Name: Flame Spray Infantry
 		Description: Advanced Anti-infantry unit.\n  Strong vs Infantry\n  Weak vs Vehicles
 	Buildable:
 		Queue: Infantry
@@ -562,7 +562,7 @@ DOGGIE:
 	PoisonedByTiberium:
 		Weapon: TiberiumHeal
 	Valued:
-		Cost: 100
+		Cost: 1
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/ts/rules/infantry.yaml
+++ b/mods/ts/rules/infantry.yaml
@@ -552,10 +552,6 @@ DOGGIE:
 	Inherits: ^Infantry
 	Tooltip:
 		Name: Tiberian Fiend
-	Buildable:
-		Queue: Infantry
-		BuildPaletteOrder: 100
-		Owner: None
 	Health:
 		Radius: 213
 		HP: 250
@@ -582,10 +578,6 @@ VISSML:
 	Inherits: ^Infantry
 	Tooltip:
 		Name: Baby Visceroid
-	Buildable:
-		Queue: Infantry
-		BuildPaletteOrder: 100
-		Owner: None
 	Health:
 		HP: 200
 	PoisonedByTiberium:
@@ -613,10 +605,6 @@ VISLRG:
 	Inherits: ^Infantry
 	Tooltip:
 		Name: Adult Visceroid
-	Buildable:
-		Queue: Infantry
-		BuildPaletteOrder: 100
-		Owner: None
 	Health:
 		HP: 500
 	PoisonedByTiberium:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -1,5 +1,5 @@
 GACNST:
-	Inherits: ^Building
+	Inherits: ^ConstructionYard
 	Building:
 		Footprint: xxx xxx xxx
 		BuildSounds: facbld1.aud
@@ -14,24 +14,10 @@ GACNST:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
-	Production:
-		Produces: Building,Defense
 	Valued:
 		Cost: 2500
-	Tooltip:
-		Name: Construction Yard
-		Description: Builds base structures.
 	CustomSellValue:
 		Value: 2500
-	BaseBuilding:
-	Transforms:
-		IntoActor: mcv
-		Offset: 1,1
-		Facing: 96
-	ProductionBar@Building:
-		ProductionType: Building
-	ProductionBar@Defense:
-		ProductionType: Defense
 	-Sellable:
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
@@ -46,7 +32,7 @@ GACNST:
 		Bounds: 120, 90, 0, 20
 
 GAPOWR:
-	Inherits: ^Building
+	Inherits: ^PowerPlant
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 0
@@ -55,9 +41,6 @@ GAPOWR:
 		Cost: 300
 	Tooltip:
 		Name: GDI Power Plant
-		Description: Provides power for other structures
-	ProvidesCustomPrerequisite:
-		Prerequisite: anypower
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -71,19 +54,14 @@ GAPOWR:
 		Sequence: idle-lights
 	WithIdleOverlay@PLUG:
 		Sequence: idle-plug
-	Selectable:
-		Bounds: 64, 64
-	Power:
-		Amount: 100
-	InfiltrateForPowerOutage:
-	AffectedByPowerOutage:
 	TargetableBuilding:
 		TargetTypes: Ground, C4, DetonateAttack, SpyInfiltrate
-	ScalePowerWithHealth:
 	DisabledOverlay:
+	Selectable:
+		Bounds: 64, 64
 
 GAPILE:
-	Inherits: ^Building
+	Inherits: ^Barracks
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 30
@@ -93,9 +71,6 @@ GAPILE:
 		Cost: 300
 	Tooltip:
 		Name: GDI Barracks
-		Description: Produces infantry
-	ProvidesCustomPrerequisite:
-		Prerequisite: barracks
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -110,11 +85,7 @@ GAPILE:
 	Exit@1:
 		SpawnOffset: -256,1051,0
 		ExitCell: 2,3
-	Production:
-		Produces: Infantry
-	PrimaryBuilding:
 	IronCurtainable:
-	ProductionBar:
 	WithProductionOverlay@LIGHTS:
 		Sequence: production-lights
 	WithIdleOverlay@LIGHT:
@@ -123,14 +94,13 @@ GAPILE:
 		Sequence: idle-flag
 	Power:
 		Amount: -20
+	Selectable:
+		Bounds: 64, 64
 
 PROC:
-	Inherits: ^Building
+	Inherits: ^Refinery
 	Valued:
 		Cost: 2000
-	Tooltip:
-		Name: Tiberium Refinery
-		Description: Processes raw Tiberium\ninto useable resources
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 20
@@ -143,19 +113,8 @@ PROC:
 		HP: 900
 	RevealsShroud:
 		Range: 6c0
-	TiberianSunRefinery:
-		DockOffset: 3,1
-	StoresResources:
-		PipColor: Green
-		PipCount: 15
-		Capacity: 3000
 	CustomSellValue:
 		Value: 600
-	FreeActor:
-		Actor: HARV
-		InitialActivity: FindResources
-		SpawnOffset: 3,4
-		Facing: 64
 	WithIdleOverlay@REDLIGHTS:
 		Sequence: idle-redlights
 	WithIdleOverlay@BIB:
@@ -164,17 +123,13 @@ PROC:
 		Amount: -30
 
 GASILO:
-	Inherits: ^Building
+	Inherits: ^TiberiumSilo
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 70
-		Prerequisites: proc
 		Owner: gdi, nod
 	Valued:
 		Cost: 150
-	Tooltip:
-		Name: Silo
-		Description: Stores excess Tiberium.
 	Building:
 		Footprint: xx xx
 		Dimensions: 2, 2
@@ -191,21 +146,17 @@ GASILO:
 		Sequence: idle-underlay
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
-	StoresResources:
-		PipCount: 5
-		Capacity: 1500
 	Power:
 		Amount: -10
+	Selectable:
+		Bounds: 64, 64, 0, 20
 
 GAWEAP:
-	Inherits: ^Building
+	Inherits: ^WeaponFactory
 	Valued:
 		Cost: 2000
 	Tooltip:
 		Name: GDI War Factory
-		Description: Assembly point for\nvehicle reinforcements
-	ProvidesCustomPrerequisite:
-		Prerequisite: factory
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 50
@@ -219,16 +170,11 @@ GAWEAP:
 	RevealsShroud:
 		Range: 4c0
 	-RenderBuilding:
-	RenderBuildingWarFactory:
 	RallyPoint:
 		RallyPoint: 6,5
 	Exit@1:
 		SpawnOffset: -170,0,0
 		ExitCell: 4,2
-	Production:
-		Produces: Vehicle
-	PrimaryBuilding:
-	ProductionBar:
 	WithProductionOverlay@WHITELIGHTS:
 		Sequence: production-lights-white
 	WithProductionOverlay@REDLIGHTS:
@@ -239,9 +185,11 @@ GAWEAP:
 		Sequence: bib
 	Power:
 		Amount: -30
+	Selectable:
+		Bounds: 96, 64, 0, 10
 
 NAPOWR:
-	Inherits: ^Building
+	Inherits: ^PowerPlant
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 0
@@ -250,9 +198,6 @@ NAPOWR:
 		Cost: 300
 	Tooltip:
 		Name: Nod Power Plant
-		Description: Provides power for other structures
-	ProvidesCustomPrerequisite:
-		Prerequisite: anypower
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -264,17 +209,14 @@ NAPOWR:
 		Range: 4c0
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
-	Power:
-		Amount: 100
-	InfiltrateForPowerOutage:
-	AffectedByPowerOutage:
 	TargetableBuilding:
 		TargetTypes: Ground, C4, DetonateAttack, SpyInfiltrate
-	ScalePowerWithHealth:
 	DisabledOverlay:
+	Selectable:
+		Bounds: 64, 64
 
 NAAPWR:
-	Inherits: ^Building
+	Inherits: ^PowerPlant
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 5
@@ -285,8 +227,6 @@ NAAPWR:
 	Tooltip:
 		Name: Advanced Power Plant
 		Description: Provides more power for structures
-	ProvidesCustomPrerequisite:
-		Prerequisite: anypower
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 2,3
@@ -300,15 +240,14 @@ NAAPWR:
 		Sequence: idle-lights
 	Power:
 		Amount: 200
-	InfiltrateForPowerOutage:
-	AffectedByPowerOutage:
 	TargetableBuilding:
 		TargetTypes: Ground, C4, DetonateAttack, SpyInfiltrate
-	ScalePowerWithHealth:
 	DisabledOverlay:
+	Selectable:
+		Bounds: 110, 64, 0, 10
 
 NAHAND:
-	Inherits: ^Building
+	Inherits: ^Barracks
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 30
@@ -318,9 +257,6 @@ NAHAND:
 		Cost: 300
 	Tooltip:
 		Name: Hand of Nod
-		Description: Produces infantry
-	ProvidesCustomPrerequisite:
-		Prerequisite: barracks
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
@@ -335,27 +271,22 @@ NAHAND:
 		ExitCell: 3,3
 	RallyPoint:
 		RallyPoint: 3,3
-	Production:
-		Produces: Infantry
-	PrimaryBuilding:
 	IronCurtainable:
-	ProductionBar:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	WithProductionOverlay@LIGHT:
 		Sequence: production-light
 	Power:
 		Amount: -20
+	Selectable:
+		Bounds: 96, 64, 0, 10
 
 NAWEAP:
-	Inherits: ^Building
+	Inherits: ^WeaponFactory
 	Valued:
 		Cost: 2000
 	Tooltip:
 		Name: Nod War Factory
-		Description: Assembly point for\nvehicle reinforcements
-	ProvidesCustomPrerequisite:
-		Prerequisite: factory
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 50
@@ -369,22 +300,19 @@ NAWEAP:
 	RevealsShroud:
 		Range: 4c0
 	-RenderBuilding:
-	RenderBuildingWarFactory:
 	RallyPoint:
 		RallyPoint: 6,5
 	Exit@1:
 		SpawnOffset: -170,0,0
 		ExitCell: 4,2
-	Production:
-		Produces: Vehicle
-	PrimaryBuilding:
-	ProductionBar:
 	WithProductionOverlay@LIGHTS:
 		Sequence: production-lights
 	WithIdleOverlay@BIB:
 		Sequence: bib
 	Power:
 		Amount: -30
+	Selectable:
+		Bounds: 96, 64, 0, 10
 
 GASAND:
 	Inherits: ^Wall
@@ -613,62 +541,8 @@ GAARTY:
 		NoTransformSounds:
 	WithMuzzleFlash:
 
-GASPOT:
-	Inherits: ^Building
-	Buildable:
-		Queue: Defense
-		BuildPaletteOrder: 10
-		Owner: gdi, nod
-	Valued:
-		Cost: 300
-	Tooltip:
-		Name: Light Tower
-	Building:
-		Footprint: x
-		Dimensions: 1,1
-	Health:
-		HP: 400
-	Armor:
-		Type: Wood
-	RevealsShroud:
-		Range: 4c0
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 3
-	WithIdleOverlay@LIGHTS:
-		Sequence: idle-lights
-	Power:
-		Amount: -10
-
-GALITE:
-	Inherits: ^Building
-	Buildable:
-		Queue: Defense
-		BuildPaletteOrder: 10
-		Owner: gdi, nod
-	Valued:
-		Cost: 200
-	Tooltip:
-		Name: Light Post
-	Building:
-		Footprint: x
-		Dimensions: 1,1
-	RenderBuilding:
-		Palette: terrain
-	-WithMakeAnimation:
-	Health:
-		HP: 600
-	Armor:
-		Type: Wood
-	RevealsShroud:
-		Range: 2c0
-	Power:
-		Amount: 0
-#	WithIdleOverlay@LIGHTING:
-#		Sequence: lighting
-
 GARADR:
-	Inherits: ^Building
+	Inherits: ^Radar
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 90
@@ -678,9 +552,6 @@ GARADR:
 		Cost: 1000
 	Tooltip:
 		Name: GDI Radar
-		Description: Provides radar screen
-	ProvidesCustomPrerequisite:
-		Prerequisite: radar
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -688,13 +559,6 @@ GARADR:
 		HP: 800
 	Armor:
 		Type: Wood
-	RequiresPower:
-	CanPowerDown:
-	ProvidesRadar:
-	InfiltrateForExploration:
-	DetectCloaked:
-		Range: 10
-	RenderDetectionCircle:
 	RevealsShroud:
 		Range: 10c0
 	WithIdleOverlay@DISH:
@@ -704,9 +568,11 @@ GARADR:
 		TargetTypes: Ground, C4, SpyInfiltrate
 	Power:
 		Amount: -50
+	Selectable:
+		Bounds: 64, 110, 0, -10
 
 NARADR:
-	Inherits: ^Building
+	Inherits: ^Radar
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 90
@@ -717,8 +583,6 @@ NARADR:
 	Tooltip:
 		Name: Nod Radar
 		Description: Provides radar screen
-	ProvidesCustomPrerequisite:
-		Prerequisite: radar
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -726,13 +590,6 @@ NARADR:
 		HP: 800
 	Armor:
 		Type: Wood
-	RequiresPower:
-	CanPowerDown:
-	ProvidesRadar:
-	InfiltrateForExploration:
-	DetectCloaked:
-		Range: 10
-	RenderDetectionCircle:
 	RevealsShroud:
 		Range: 10c0
 	WithIdleOverlay@DISH:
@@ -742,21 +599,20 @@ NARADR:
 		TargetTypes: Ground, C4, SpyInfiltrate
 	Power:
 		Amount: -50
+	Selectable:
+		Bounds: 64, 64, 0, 0
 
 GATECH:
-	Inherits: ^Building
+	Inherits: ^TechCenter
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 100
 		Owner: gdi
-		Prerequisites: garadr
+		Prerequisites: radar
 	Valued:
 		Cost: 2000
 	Tooltip:
 		Name: GDI Tech Center
-		Description: Required for high-\ntech research
-	ProvidesCustomPrerequisite:
-		Prerequisite: tech
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
@@ -770,21 +626,20 @@ GATECH:
 		Sequence: idle-lights
 	Power:
 		Amount: -150
+	Selectable:
+		Bounds: 110, 64, 10, 20
 
 NATECH:
-	Inherits: ^Building
+	Inherits: ^TechCenter
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 100
 		Owner: nod
-		Prerequisites: naradr
+		Prerequisites: radar
 	Valued:
 		Cost: 2000
 	Tooltip:
 		Name: Nod Tech Center
-		Description: Required for high-\ntech research
-	ProvidesCustomPrerequisite:
-		Prerequisite: tech
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -798,19 +653,18 @@ NATECH:
 		Sequence: idle-lights
 	Power:
 		Amount: -150
+	Selectable:
+		Bounds: 64, 64, 0, 20
 
 GAHPAD:
-	Inherits: ^Building
+	Inherits: ^HeliPad
 	Valued:
 		Cost: 500
-	Tooltip:
-		Name: Helipad
-		Description: Produces, rearms and\nrepairs helicopters
 	Buildable:
 		BuildPaletteOrder: 60
 		Owner: gdi
 		Queue: Building
-		Prerequisites: garadr
+		Prerequisites: radar
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -820,32 +674,24 @@ GAHPAD:
 		Range: 5c0
 	Exit@1:
 		SpawnOffset: 0,-256,0
-	RallyPoint:
-	Production:
-		Produces: Air
-	PrimaryBuilding:
-	BelowUnits:
-	Reservable:
-	RepairsUnits:
-	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	Power:
 		Amount: -10
+	Selectable:
+		Bounds: 64, 64, 0, 10
 
 NAHPAD:
-	Inherits: ^Building
+	Inherits: ^HeliPad
 	Valued:
 		Cost: 500
-	Tooltip:
-		Name: Nod Helipad
-		Description: Produces, rearms and\nrepairs helicopters
 	Buildable:
 		BuildPaletteOrder: 60
 		Owner: nod
 		Queue: Building
+		Prerequisites: radar
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -855,20 +701,14 @@ NAHPAD:
 		Range: 5c0
 	Exit@1:
 		SpawnOffset: 0,-256,0
-	RallyPoint:
-	Production:
-		Produces: Air
-	PrimaryBuilding:
-	BelowUnits:
-	Reservable:
-	RepairsUnits:
-	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	Power:
 		Amount: -10
+	Selectable:
+		Bounds: 64, 64, 0, 10
 
 GADEPT:
 	Inherits: ^Building
@@ -904,6 +744,8 @@ GADEPT:
 		Sequence: platform
 	Power:
 		Amount: -30
+	Selectable:
+		Bounds: 96, 80, 0, 20
 
 #TODO: Placeholder, replace with Component Tower + Vulcan Upgrade
 GAVULC:
@@ -917,6 +759,7 @@ GAVULC:
 		Queue: Defense
 		BuildPaletteOrder: 30
 		Owner: gdi
+		Prerequisites: radar
 	Building:
 	DisabledOverlay:
 	-GivesBuildableArea:
@@ -962,6 +805,8 @@ GAVULC:
 		Type: wall
 	Power:
 		Amount: -20
+	Selectable:
+		Bounds: 48, 48, 0, 10
 
 #TODO: Placeholder, replace with Component Tower + RPG Upgrade
 GAROCK:
@@ -975,6 +820,7 @@ GAROCK:
 		Queue: Defense
 		BuildPaletteOrder: 40
 		Owner: gdi
+		Prerequisites: radar
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -1011,6 +857,8 @@ GAROCK:
 		Type: wall
 	Power:
 		Amount: -50
+	Selectable:
+		Bounds: 48, 48, 0, 10
 
 #TODO: Placeholder, replace with Component Tower + SAM Upgrade
 GACSAM:
@@ -1024,6 +872,7 @@ GACSAM:
 		Queue: Defense
 		BuildPaletteOrder: 60
 		Owner: gdi
+		Prerequisites: radar
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -1060,6 +909,8 @@ GACSAM:
 		Type: wall
 	Power:
 		Amount: -30
+	Selectable:
+		Bounds: 48, 48, 0, 10
 
 NASAM:
 	Inherits: ^Building
@@ -1072,6 +923,7 @@ NASAM:
 		Queue: Defense
 		BuildPaletteOrder: 60
 		Owner: nod
+		Prerequisites: radar
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -1101,6 +953,8 @@ NASAM:
 		Recoil: 0
 	Power:
 		Amount: -30
+	Selectable:
+		Bounds: 48, 48, 0, 10
 
 NALASR:
 	Inherits: ^Building
@@ -1113,6 +967,7 @@ NALASR:
 		Queue: Defense
 		BuildPaletteOrder: 50
 		Owner: nod
+		Prerequisites: radar
 	Building:
 	RequiresPower:
 	DisabledOverlay:
@@ -1139,6 +994,8 @@ NALASR:
 	AutoTarget:
 	Power:
 		Amount: -40
+	Selectable:
+		Bounds: 48, 48, 0, 0
 
 NAOBEL:
 	Inherits: ^Building
@@ -1182,6 +1039,8 @@ NAOBEL:
 		Sequence: idle-lights
 	Power:
 		Amount: -150
+	Selectable:
+		Bounds: 64, 64, 0, 0
 
 ANYPOWER:
 	Tooltip:
@@ -1207,4 +1066,3 @@ TECH:
 	Tooltip:
 		Name: Tech Center
 		Description: Tech Center
-

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -4,10 +4,6 @@ GACNST:
 		Footprint: xxx xxx xxx
 		BuildSounds: facbld1.aud
 		Dimensions: 3,3
-	Buildable:
-		Queue: Building
-		BuildPaletteOrder: 1000
-		Owner: None
 	Health:
 		HP: 1500
 	Armor:

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -158,10 +158,6 @@ HVR:
 	Tooltip:
 		Name: Mammoth Tank
 		Description: Heavily armored GDI Tank.\n  Strong vs Everything
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 60
-		Owner: none
 	Mobile:
 		Speed: 56
 		ROT: 5
@@ -195,10 +191,6 @@ HVR:
 
 TRUCKB:
 	Inherits: ^Vehicle
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 120
-		Owner: none
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -254,10 +246,6 @@ ICBM:
 		Cost: 1400
 	Tooltip:
 		Name: Ballistic Missile Launcher
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 100
-		Owner: none
 	Health:
 		HP: 500
 	Armor:
@@ -364,10 +352,6 @@ BUS:
 		Cost: 800
 	Tooltip:
 		Name: School Bus
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 300
-		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -391,10 +375,6 @@ PICK:
 		Cost: 800
 	Tooltip:
 		Name: Pickup
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 300
-		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -418,10 +398,6 @@ CAR:
 		Cost: 800
 	Tooltip:
 		Name: Automobile
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 300
-		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -445,10 +421,6 @@ GGHUNT:
 		Cost: 1000
 	Tooltip:
 		Name: Hunter-Seeker Droid
-	Buildable:
-		BuildPaletteOrder: 20
-		Owner: none
-		Queue: Vehicle
 	Mobile:
 		ROT: 16
 		Speed: 355
@@ -470,10 +442,6 @@ WINI:
 		Cost: 800
 	Tooltip:
 		Name: Recreational Vehicle
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 300
-		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -150,6 +150,7 @@ HVR:
 	WithVoxelBody:
 	WithVoxelTurret:
 
+# Campaign unit... 
 4TNK:
 	Inherits: ^Tank
 	Valued:
@@ -160,7 +161,7 @@ HVR:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
-		Owner: gdi
+		Owner: none
 	Mobile:
 		Speed: 56
 		ROT: 5
@@ -197,7 +198,7 @@ TRUCKB:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 120
-		Owner: gdi, nod
+		Owner: none
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -246,6 +247,7 @@ LPST:
 		TransformSounds:
 		NoTransformSounds:
 
+# Campaign unit... 
 ICBM:
 	Inherits: ^Vehicle
 	Valued:
@@ -255,7 +257,7 @@ ICBM:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
-		Owner: gdi
+		Owner: none
 	Health:
 		HP: 500
 	Armor:
@@ -365,7 +367,7 @@ BUS:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 300
-		Owner: gdi
+		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -392,7 +394,7 @@ PICK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 300
-		Owner: gdi
+		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -419,7 +421,7 @@ CAR:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 300
-		Owner: gdi
+		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -445,7 +447,7 @@ GGHUNT:
 		Name: Hunter-Seeker Droid
 	Buildable:
 		BuildPaletteOrder: 20
-		Owner: gdi, nod
+		Owner: none
 		Queue: Vehicle
 	Mobile:
 		ROT: 16
@@ -471,7 +473,7 @@ WINI:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 300
-		Owner: gdi
+		Owner: none
 	Mobile:
 		ROT: 5
 		Speed: 113
@@ -813,4 +815,3 @@ STNK:
 	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
-

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -1,0 +1,51 @@
+gaspot:
+	idle:
+		Start: 0
+		ShadowStart: 3
+		Offset: 0, 12
+	damaged-idle:
+		Start: 1
+		ShadowStart: 4
+		Offset: 0, 12
+	critical-idle:
+		Start: 2
+		ShadowStart: 5
+		Offset: 0, 12
+	idle-lights: gaspot_a
+		Start: 0
+		Length: 8
+		Tick: 200
+		Offset: 0, 12
+	damaged-idle-lights: gaspot_a
+		Start: 8
+		Length: 8
+		Tick: 200
+		Offset: 0, 12
+	critical-idle-lights: gaspot_a
+		Start: 16
+		Length: 8
+		Tick: 200
+		Offset: 0, 12
+	make: gaspotmk
+		Start: 0
+		Length: 14
+		ShadowStart: 14
+		Offset: 0, 12
+	icon: spoticon
+		Start: 0
+
+galite:
+	idle: gtlite
+		Start: 0
+		ShadowStart: 2
+		Offset: 0, 12
+	damaged-idle: gtlite
+		Start: 1
+		ShadowStart: 3
+		Offset: 0, 12
+#	lighting: alphatst
+#		Start: 0
+#		ZOffset: -1c511
+#		BlendMode: Alpha
+	icon: liteicon
+		Start: 0

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -850,42 +850,6 @@ gacsam:
 	icon: twr3icon
 		Start: 0
 
-gaspot:
-	idle:
-		Start: 0
-		ShadowStart: 3
-		Offset: 0, 12
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-		Offset: 0, 12
-	critical-idle:
-		Start: 2
-		ShadowStart: 5
-		Offset: 0, 12
-	idle-lights: gaspot_a
-		Start: 0
-		Length: 8
-		Tick: 200
-		Offset: 0, 12
-	damaged-idle-lights: gaspot_a
-		Start: 8
-		Length: 8
-		Tick: 200
-		Offset: 0, 12
-	critical-idle-lights: gaspot_a
-		Start: 16
-		Length: 8
-		Tick: 200
-		Offset: 0, 12
-	make: gaspotmk
-		Start: 0
-		Length: 14
-		ShadowStart: 14
-		Offset: 0, 12
-	icon: spoticon
-		Start: 0
-
 gahpad:
 	idle: gthpad
 		Start: 0
@@ -1053,22 +1017,6 @@ gasilo:
 		Start: 0
 		Length: 18
 		ShadowStart: 20
-
-galite:
-	idle: gtlite
-		Start: 0
-		ShadowStart: 2
-		Offset: 0, 12
-	damaged-idle: gtlite
-		Start: 1
-		ShadowStart: 3
-		Offset: 0, 12
-#	lighting: alphatst
-#		Start: 0
-#		ZOffset: -1c511
-#		BlendMode: Alpha
-	icon: liteicon
-		Start: 0
 
 gadept:
 	idle: gtdept


### PR DESCRIPTION
- Cleaned some Buildings by Creating Factory Templates
- created Civilian.yaml files which contains tge gaspot and lightpost
- By default in TS "not buildable units" are flagged with "owner: none"
  because some units are only available  for campaign missions, they will
  be uncommented when we have Icons for them :)
- The "WeedGuy" has now a sensefull name"
- The AI got some Defence Buildings... playtests are otherwise very
  lonely :(
- This PR should also fix the last point of #2187 (Mailaender noticed me about this issue) 
