### PR TITLE
Remove the MP tooltip row from campaign missions.

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Traits
 		public IRenderable[] Renderables { private get; set; }
 		public Player Owner;
 
-		public string TooltipName;
+		public ITooltipInfo TooltipInfo;
 		public Player TooltipOwner;
 
 		public int HP;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Traits
 	[Flags]
 	public enum Stance
 	{
+		None = 0,
 		Enemy = 1,
 		Neutral = 2,
 		Ally = 4,
@@ -125,10 +126,17 @@ namespace OpenRA.Traits
 		bool Disguised { get; }
 		Player Owner { get; }
 	}
+
 	public interface IToolTip
 	{
-		string Name();
-		Player Owner();
+		ITooltipInfo TooltipInfo { get; }
+		Player Owner { get; }
+	}
+
+	public interface ITooltipInfo
+	{
+		string TooltipForPlayerStance(Stance stance);
+		bool IsOwnerRowVisible { get; }
 	}
 
 	public interface IDisable { bool Disabled { get; } }

--- a/OpenRA.Game/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Game/Widgets/ViewportControllerWidget.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Widgets
 			}
 
 			var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos))
-				.Where(a => a.TooltipName != null && a.IsValid)
+				.Where(a => a.TooltipInfo != null && a.IsValid)
 				.WithHighestSelectionPriority();
 
 			if (frozen != null)

--- a/OpenRA.Mods.RA/Disguise.cs
+++ b/OpenRA.Mods.RA/Disguise.cs
@@ -36,28 +36,28 @@ namespace OpenRA.Mods.RA
 			disguise = self.Trait<Disguise>();
 		}
 
-		public string Name()
+		public ITooltipInfo TooltipInfo
 		{
-			if (disguise.Disguised)
+			get
 			{
-				if (self.Owner == self.World.LocalPlayer)
-					return "{0} ({1})".F(info.Name, disguise.AsName);
-
-				return disguise.AsName;
+				return disguise.Disguised ? disguise.AsTooltipInfo : info;
 			}
-			return info.Name;
 		}
 
-		public Player Owner()
+		public Player Owner
 		{
-			if (disguise.Disguised)
+			get
 			{
-				if (self.Owner == self.World.LocalPlayer)
-					return self.Owner;
+				if (disguise.Disguised)
+				{
+					if (self.Owner == self.World.LocalPlayer)
+						return self.Owner;
 
-				return disguise.AsPlayer;
+					return disguise.AsPlayer;
+				}
+
+				return self.Owner;
 			}
-			return self.Owner;
 		}
 	}
 
@@ -65,9 +65,9 @@ namespace OpenRA.Mods.RA
 
 	class Disguise : IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack
 	{
-		public Player AsPlayer;
-		public string AsSprite;
-		public string AsName;
+		public Player AsPlayer { get; private set; }
+		public string AsSprite { get; private set; }
+		public ITooltipInfo AsTooltipInfo { get; private set; }
 
 		public bool Disguised { get { return AsPlayer != null; } }
 		public Player Owner { get { return AsPlayer; } }
@@ -117,13 +117,13 @@ namespace OpenRA.Mods.RA
 			if (target != null)
 			{
 				var tooltip = target.TraitsImplementing<IToolTip>().FirstOrDefault();
-				AsName = tooltip.Name();
-				AsPlayer = tooltip.Owner();
+				AsTooltipInfo = tooltip.TooltipInfo;
+				AsPlayer = tooltip.Owner;
 				AsSprite = target.Trait<RenderSprites>().GetImage(target);
 			}
 			else
 			{
-				AsName = null;
+				AsTooltipInfo = null;
 				AsPlayer = null;
 				AsSprite = null;
 			}

--- a/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.RA/Modifiers/FrozenUnderFog.cs
@@ -101,8 +101,8 @@ namespace OpenRA.Mods.RA
 
 				if (tooltip.Value != null)
 				{
-					actor.TooltipName = tooltip.Value.Name();
-					actor.TooltipOwner = tooltip.Value.Owner();
+					actor.TooltipInfo = tooltip.Value.TooltipInfo;
+					actor.TooltipOwner = tooltip.Value.Owner;
 				}
 			}
 		}

--- a/OpenRA.Mods.RA/Tooltip.cs
+++ b/OpenRA.Mods.RA/Tooltip.cs
@@ -13,29 +13,58 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA
 {
 	[Desc("Shown in the build palette widget.")]
-	public class TooltipInfo : ITraitInfo
+	public class TooltipInfo : ITraitInfo, ITooltipInfo
 	{
 		[Translate] public readonly string Description = "";
 		[Translate] public readonly string Name = "";
+
+		[Desc("An optional generic name (i.e. \"Soldier\" or \"Structure\")" +
+			"to be shown to chosen players.")]
+		[Translate] public readonly string GenericName = null;
+
+		[Desc("Prefix generic tooltip name with 'Enemy' or 'Allied'.")]
+		public readonly bool GenericStancePrefix = true;
+
+		[Desc("Player stances that the generic name should be shown to.")]
+		public readonly Stance GenericVisibility = Stance.None;
+
+		[Desc("Show the actor's owner and their faction flag")]
+		public readonly bool ShowOwnerRow = true;
 
 		[Desc("Sequence of the actor that contains the cameo.")]
 		public readonly string Icon = "icon";
 
 		public virtual object Create(ActorInitializer init) { return new Tooltip(init.self, this); }
+
+		public string TooltipForPlayerStance(Stance stance)
+		{
+			if (stance == Stance.None || !GenericVisibility.HasFlag(stance))
+				return Name;
+
+			if (GenericStancePrefix && stance == Stance.Ally)
+				return "Allied " + GenericName;
+
+			if (GenericStancePrefix && stance == Stance.Enemy)
+				return "Enemy " + GenericName;
+
+			return GenericName;
+		}
+
+		public bool IsOwnerRowVisible { get { return ShowOwnerRow; } }
 	}
 
 	public class Tooltip : IToolTip
 	{
-		Actor self;
-		TooltipInfo Info;
+		readonly Actor self;
+		readonly TooltipInfo info;
 
-		public string Name() { return Info.Name; }
-		public Player Owner() { return self.Owner; }
+		public ITooltipInfo TooltipInfo { get { return info; } }
+		public Player Owner { get { return self.Owner; } }
 
 		public Tooltip(Actor self, TooltipInfo info)
 		{
 			this.self = self;
-			Info = info;
+			this.info = info;
 		}
 	}
 }

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -465,10 +465,48 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	PROC:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -747,10 +747,48 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	PROC:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -908,8 +908,48 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+	^Vehicle:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
 	^Infantry:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	WEAP:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -553,12 +553,48 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
 	^Tank:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	CRATE:
 		Crate:
 			Lifetime: 9999

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -632,12 +632,48 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
 	^Tank:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	E3:
 		AutoTarget:
 			ScanRadius: 5

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -899,12 +899,48 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
 	^Tank:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	^CivInfantry:
 		Health:
 			HP: 125

--- a/mods/cnc/maps/nod01/map.yaml
+++ b/mods/cnc/maps/nod01/map.yaml
@@ -323,11 +323,48 @@ Rules:
 		MustBeDestroyed:
 	^CivInfantry:
 		MustBeDestroyed:
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
-
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 Sequences:
 
 VoxelSequences:

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -537,10 +537,48 @@ Rules:
 			Scripts: nod03a.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -582,10 +582,48 @@ Rules:
 			Scripts: nod03b.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
-	^Infantry:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+	HARV:
+		-MustBeDestroyed:
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -288,9 +288,9 @@ WOOD:
 	Inherits: ^Wall
 	Health:
 		HP: 100
-		Armor:
-			Type: Wood
-		Tooltip:
+	Armor:
+		Type: Wood
+	Tooltip:
 		Name: Wooden Fence
 		Icon: woodicnh
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -31,6 +31,8 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Vehicle
 	UpdatesPlayerStatistics:
 	Cloak:
 		RequiresUpgrade: cloak
@@ -85,6 +87,8 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Tank
 	UpdatesPlayerStatistics:
 	Cloak:
 		RequiresUpgrade: cloak
@@ -133,6 +137,8 @@
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
+	Tooltip:
+		GenericName: Helicopter
 	GainsStatUpgrades:
 	SelfHealing@ELITE:
 		Step: 2
@@ -190,6 +196,8 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Soldier
 	SelfHealing@HOSPITAL:
 		Step: 5
 		Ticks: 100
@@ -234,6 +242,7 @@
 		Cost: 70
 	Tooltip:
 		Name: Civilian
+		GenericVisibility: None
 	Mobile:
 		Speed: 56
 	Health:
@@ -396,6 +405,8 @@
 	Guardable:
 		Range: 3
 	BodyOrientation:
+	Tooltip:
+		GenericName: Structure
 	FrozenUnderFog:
 	UpdatesPlayerStatistics:
 	Huntable:
@@ -426,6 +437,7 @@
 	Building:
 	Tooltip:
 		Name: Civilian Building
+		GenericVisibility: None
 	FrozenUnderFog:
 		StartsRevealed: true
 
@@ -439,6 +451,7 @@
 		RelativeToTopLeft: yes
 	Tooltip:
 		Name: Civilian Building (Destroyed)
+		GenericVisibility: None
 	BodyOrientation:
 	FrozenUnderFog:
 		StartsRevealed: true
@@ -481,6 +494,7 @@
 		RelativeToTopLeft: yes
 	Tooltip:
 		Name: Field (Destroyed)
+		GenericVisibility: None
 	BelowUnits:
 	BodyOrientation:
 	RenderBuilding:
@@ -610,6 +624,8 @@
 		ForceHealthPercentage: 25
 	BelowUnits:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Destroyed Vehicle
 	LuaScriptEvents:
 	DisabledOverlay:
 	ScriptTriggers:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -43,6 +43,7 @@ HARV:
 		Cost: 1000
 	Tooltip:
 		Name: Harvester
+		GenericName: Harvester
 		Description: Collects Tiberium for processing.\n  Unarmed
 	Buildable:
 		BuildPaletteOrder: 10

--- a/mods/ra/maps/allies-01-classic/map.yaml
+++ b/mods/ra/maps/allies-01-classic/map.yaml
@@ -604,6 +604,42 @@ Rules:
 	EINSTEIN:
 		Passenger:
 			CargoType: Einstein
+	^Vehicle:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
 	^CivInfantry:
 		RevealsShroud:
 			Range: 0c0

--- a/mods/ra/maps/allies-02-classic/map.yaml
+++ b/mods/ra/maps/allies-02-classic/map.yaml
@@ -879,12 +879,45 @@ Rules:
 			LuaScripts: allies02.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
-	^Infantry:
-		MustBeDestroyed:
-	^Tank:
-		MustBeDestroyed:
 	^Vehicle:
 		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Tank:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Infantry:
+		MustBeDestroyed:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Ship:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Plane:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Helicopter:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Building:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+	^Wall:
+		Tooltip:
+			ShowOwnerRow: false
+	^Husk:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
 	APWR:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -38,6 +38,8 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Vehicle
 	EjectOnDeath:
 		PilotActor: e1
 		SuccessRate: 20
@@ -101,6 +103,8 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Tank
 	EjectOnDeath:
 		PilotActor: e1
 		SuccessRate: 20
@@ -171,6 +175,8 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Soldier
 	SelfHealing@HOSPITAL:
 		Step: 5
 		Ticks: 100
@@ -237,6 +243,8 @@
 	Guard:
 	Guardable:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Ship
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
@@ -280,6 +288,8 @@
 	UpdatesPlayerStatistics:
 	CombatDebugOverlay:
 	BodyOrientation:
+	Tooltip:
+		GenericName: Plane
 	Huntable:
 	LuaScriptEvents:
 	ScriptTriggers:
@@ -293,6 +303,8 @@
 
 ^Helicopter:
 	Inherits: ^Plane
+	Tooltip:
+		GenericName: Helicopter
 	GpsDot:
 		String: Helicopter
 
@@ -339,6 +351,8 @@
 		Range: 3
 	BodyOrientation:
 	FrozenUnderFog:
+	Tooltip:
+		GenericName: Structure
 	GpsDot:
 		String: Structure
 	Huntable:
@@ -400,6 +414,7 @@
 		Type: Wood
 	Tooltip:
 		Name: Civilian Building
+		GenericVisibility: None
 	ProximityCaptor:
 		Types: CivilianBuilding
 	-WithMakeAnimation:
@@ -438,6 +453,7 @@
 		Cost: 70
 	Tooltip:
 		Name: Civilian
+		GenericVisibility: None
 	Health:
 		HP: 20
 	Mobile:
@@ -517,6 +533,8 @@
 	TargetableUnit:
 		TargetTypes: Ground
 		RequiresForceFire: true
+	Tooltip:
+		GenericName: Destroyed Vehicle
 	AutoTargetIgnore:
 	Capturable:
 		Type: husk

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -245,6 +245,7 @@ HARV:
 		Cost: 1100
 	Tooltip:
 		Name: Ore Truck
+		GenericName: Harvester
 		Description: Collects Ore and Gems for processing.\n  Unarmed
 	Selectable:
 		Priority: 7


### PR DESCRIPTION
This is something that has always bugged me about the "recent" (2012 and later) singleplayer missions.  The player name and flag are not necessary in the sp missions (where each faction has a distinct color), and feel out of place.  Removing this row from the tooltip adds a bit of minor polish.
