### PR TITLE
Fix broken objectives fine-tuning

### DIFF
--- a/OpenRA.Mods.RA/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.RA/Player/MissionObjectives.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.RA
 
 		public void MarkCompleted(Player player, int objectiveID)
 		{
-			if (objectiveID >= objectives.Count || objectives[objectiveID].State == ObjectiveState.Completed)
+			if (objectiveID >= objectives.Count || objectives[objectiveID].State != ObjectiveState.Incomplete)
 				return;
 
 			var inous = player.PlayerActor.TraitsImplementing<INotifyObjectivesUpdated>();
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.RA
 
 		public void MarkFailed(Player player, int objectiveID)
 		{
-			if (objectiveID >= objectives.Count || objectives[objectiveID].State != ObjectiveState.Incomplete)
+			if (objectiveID >= objectives.Count || objectives[objectiveID].State == ObjectiveState.Failed)
 				return;
 
 			var inous = player.PlayerActor.TraitsImplementing<INotifyObjectivesUpdated>();


### PR DESCRIPTION
As something in #6494 is broken.
Using

```
testobj = player.AddSecondaryObjective("xyz")
player.MarkCompletedObjective(testobj)
player.MarkFailedObjective(testobj)
```

(Objective should be failed)
gave me
![weirdobjectivesa](https://cloud.githubusercontent.com/assets/7704140/4442673/5ba89002-47e1-11e4-92fe-d0895bfce71c.png)
and using

```
testobj = player.AddSecondaryObjective("xyz")
player.MarkFailedObjective(testobj)
player.MarkCompletedObjective(testobj)
```

(Objective should stay failed)
as well.
