### PR TITLE
Tiberian Sun .vqa support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ Lua-API.md
 # SublimeText
 *.sublime-project
 *.sublime-workspace
+*.mix
+*.vqa

--- a/OpenRA.Game/FileFormats/Format80.cs
+++ b/OpenRA.Game/FileFormats/Format80.cs
@@ -60,11 +60,10 @@ namespace OpenRA.FileFormats
 			}
 		}
 
-		public static int DecodeInto(byte[] src, byte[] dest, int srcOffset = 0)
+		public static int DecodeInto(byte[] src, byte[] dest, int srcOffset = 0, bool reverse = false)
 		{
 			var ctx = new FastByteReader(src, srcOffset);
 			var destIndex = 0;
-
 			while (true)
 			{
 				var i = ctx.ReadByte();
@@ -104,7 +103,7 @@ namespace OpenRA.FileFormats
 					{
 						// case 5
 						var count = ctx.ReadWord();
-						var srcIndex = ctx.ReadWord();
+						var srcIndex = reverse ? destIndex - ctx.ReadWord() : ctx.ReadWord();
 						if (srcIndex >= destIndex)
 							throw new NotImplementedException("srcIndex >= destIndex {0} {1}".F(srcIndex, destIndex));
 
@@ -115,7 +114,7 @@ namespace OpenRA.FileFormats
 					{
 						// case 3
 						var count = count3 + 3;
-						var srcIndex = ctx.ReadWord();
+						var srcIndex = reverse ? destIndex - ctx.ReadWord() : ctx.ReadWord();
 						if (srcIndex >= destIndex)
 							throw new NotImplementedException("srcIndex >= destIndex {0} {1}".F(srcIndex, destIndex));
 
@@ -174,10 +173,13 @@ namespace OpenRA.FileFormats
 
 						// Command 4: Repeat byte n times
 						ms.WriteByte(0xFE);
+
 						// Low byte
 						ms.WriteByte((byte)(repeatCount & 0xFF));
+
 						// High byte
 						ms.WriteByte((byte)(repeatCount >> 8));
+
 						// Value to repeat
 						ms.WriteByte(src[offset]);
 

--- a/OpenRA.Game/FileFormats/VqaReader.cs
+++ b/OpenRA.Game/FileFormats/VqaReader.cs
@@ -493,7 +493,7 @@ namespace OpenRA.FileFormats
 			}
 		}
 
-		public bool IsHqVqa { get { return (videoFlags & 0x10) == 16; } }
+		bool IsHqVqa { get { return (videoFlags & 0x10) == 16; } }
 
 		void WriteBlock(int blockNumber, int count, ref int x, ref int y)
 		{

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -43,7 +43,7 @@ namespace OpenRA
 					return LoadWave(new WavLoader(s));
 
 			using (var s = GlobalFileSystem.Open(filename))
-				return LoadSoundRaw(AudLoader.LoadSound(s));
+				return LoadSoundRaw(AudLoader.LoadSound(s), 1, 16, 22050);
 		}
 
 		static ISoundSource LoadWave(WavLoader wave)
@@ -51,9 +51,9 @@ namespace OpenRA
 			return soundEngine.AddSoundSourceFromMemory(wave.RawOutput, wave.Channels, wave.BitsPerSample, wave.SampleRate);
 		}
 
-		static ISoundSource LoadSoundRaw(byte[] rawData)
+		static ISoundSource LoadSoundRaw(byte[] rawData, int channels, int sampleBits, int sampleRate)
 		{
-			return soundEngine.AddSoundSourceFromMemory(rawData, 1, 16, 22050);
+			return soundEngine.AddSoundSourceFromMemory(rawData, channels, sampleBits, sampleRate);
 		}
 
 		static ISoundEngine CreateEngine(string engine)
@@ -120,9 +120,9 @@ namespace OpenRA
 		public static ISound PlayToPlayer(Player player, string name) { return Play(player, name, true, WPos.Zero, 1); }
 		public static ISound PlayToPlayer(Player player, string name, WPos pos) { return Play(player, name, false, pos, 1); }
 
-		public static void PlayVideo(byte[] raw)
+		public static void PlayVideo(byte[] raw, int channels, int sampleBits, int sampleRate)
 		{
-			rawSource = LoadSoundRaw(raw);
+			rawSource = LoadSoundRaw(raw, channels, sampleBits, sampleRate);
 			video = soundEngine.Play2D(rawSource, false, true, WPos.Zero, InternalSoundVolume, false);
 		}
 
@@ -356,7 +356,7 @@ namespace OpenRA
 			if (!string.IsNullOrEmpty(name) && (p == null || p == p.World.LocalPlayer))
 				soundEngine.Play2D(sounds[name],
 					false, relative, pos,
-					(InternalSoundVolume * volumeModifier), attenuateVolume);
+					InternalSoundVolume * volumeModifier, attenuateVolume);
 
 			return true;
 		}

--- a/OpenRA.Game/Widgets/VqaPlayerWidget.cs
+++ b/OpenRA.Game/Widgets/VqaPlayerWidget.cs
@@ -73,12 +73,12 @@ namespace OpenRA.Widgets
 					video.Width,
 					video.Height), 
 				TextureChannel.Alpha);
-			var videoDisplayHeight = video.IsHqVqa ? video.Height : video.Height * AspectRatio;
-			var scale = Math.Min((float)RenderBounds.Width / video.Width, (float)RenderBounds.Height / videoDisplayHeight);
-			videoOrigin = new float2(RenderBounds.X + (RenderBounds.Width - scale * video.Width) / 2, RenderBounds.Y + (RenderBounds.Height - scale * videoDisplayHeight) / 2);
+
+			var scale = Math.Min((float)RenderBounds.Width / video.Width, (float)RenderBounds.Height / video.Height * AspectRatio);
+			videoOrigin = new float2(RenderBounds.X + (RenderBounds.Width - scale * video.Width) / 2, RenderBounds.Y + (RenderBounds.Height - scale * video.Height * AspectRatio) / 2);
 
 			// Round size to integer pixels. Round up to be consistent with the scale calcuation.
-			videoSize = new float2((int)Math.Ceiling(video.Width * scale), (int)Math.Ceiling(videoDisplayHeight * scale));
+			videoSize = new float2((int)Math.Ceiling(video.Width * scale), (int)Math.Ceiling(video.Height * AspectRatio * scale));
 
 			if (!DrawOverlay)
 				return;

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -21,6 +21,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class AssetBrowserLogic
 	{
+		static readonly string[] AllowedExtensions = { ".shp", ".r8", "tmp", ".tem", ".des", ".sno", ".int", ".jun", ".vqa" };
+
+		readonly World world;
+
 		Widget panel;
 
 		TextFieldWidget filenameInput;
@@ -38,10 +42,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		VqaPlayerWidget player = null;
 		bool isVideoLoaded = false;
 		int currentFrame;
-
-		readonly World world;
-
-		static readonly string[] AllowedExtensions = { ".shp", ".r8", "tmp", ".tem", ".des", ".sno", ".int", ".jun", ".vqa" };
 
 		[ObjectCreator.UseCtor]
 		public AssetBrowserLogic(Widget widget, Action onExit, World world)
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var frameContainer = panel.GetOrNull("FRAME_SELECTOR");
 			if (frameContainer != null)
-				frameContainer.IsVisible = () => (currentSprites != null && currentSprites.Length > 1) || (player != null && player.Video != null && player.Video.Frames > 1);
+				frameContainer.IsVisible = () => (currentSprites != null && currentSprites.Length > 1) || (isVideoLoaded && player != null && player.Video != null && player.Video.Frames > 1);
 
 			frameSlider = panel.Get<SliderWidget>("FRAME_SLIDER");
 			if (frameSlider != null)
@@ -301,9 +301,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				player = panel.Get<VqaPlayerWidget>("PLAYER");
 				currentFilename = filename;
 				player.Load(filename);
+				player.DrawOverlay = false;
 				isVideoLoaded = true;
 				frameSlider.MaximumValue = (float)player.Video.Frames - 1;
 				frameSlider.Ticks = 0;
+				return true;
 			}
 			else
 			{
@@ -330,7 +332,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// TODO: Re-enable "All Packages" once list generation is done in a background thread
 			// var sources = new[] { (IFolder)null }.Concat(GlobalFileSystem.MountedFolders);
-
 			var sources = GlobalFileSystem.MountedFolders;
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 280, sources, setupItem);
 			return true;
@@ -344,7 +345,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// TODO: This is too slow to run in the main thread
 			// var files = AssetSource != null ? AssetSource.AllFileNames() :
 			// GlobalFileSystem.MountedFolders.SelectMany(f => f.AllFileNames());
-
 			if (assetSource == null)
 				return;
 

--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -103,6 +103,7 @@ Container@ASSETBROWSER_PANEL:
 						VqaPlayer@PLAYER:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
+							AspectRatio: 1
 				Container@FRAME_SELECTOR:
 					X: 190
 					Y: 395

--- a/mods/ra/chrome/assetbrowser.yaml
+++ b/mods/ra/chrome/assetbrowser.yaml
@@ -98,6 +98,7 @@ Background@ASSETBROWSER_PANEL:
 				VqaPlayer@PLAYER:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
+					AspectRatio: 1
 		Container@FRAME_SELECTOR:
 			X: 190
 			Y: 425


### PR DESCRIPTION
Ref : #3363,#3226

This is very much WIP so it is even messier than usual.

Progress so far is:
Most videos load and play without crashing, but the audio is somewhere between stretched out and complete noise. The video only displays some shapes correctly (the spinning EVA logo is the easiest to see), but all colors are wrong and the image is flipped https://imgur.com/NG1yvFc.jpg ([Original video](https://www.youtube.com/watch?v=xuNN9ACgTFg)).
So still left to do is:
- [x] Fix image orientation
- [x] Fix colors
- [x] Fix audio playback
- [x] Performance improvements (Some videos have ~1 sec stutters) 
- [x] Fix crashes with certain videos (I'm not sure if diskdest.vqa is a proper video anyway)

The changes to gitignore and to the asset browser are just for testing so they can be removed once this is complete.

Also credit for reverse engineering goes to [olafvdspek's XCC Mixer](https://code.google.com/p/xcc/).
