### PR TITLE
Do not pass nonexisting requested Files!

### DIFF
--- a/OpenRA.Game/FileSystem/GlobalFileSystem.cs
+++ b/OpenRA.Game/FileSystem/GlobalFileSystem.cs
@@ -175,10 +175,12 @@ namespace OpenRA.FileSystem
 		public static Stream OpenWithExts(string filename, params string[] exts)
 		{
 			Stream s;
-			if (!TryOpenWithExts(filename, exts, out s))
-				throw new FileNotFoundException("File not found: {0}".F(filename), filename);
+			bool _tmp = TryOpenWithExts(filename, exts, out s);
 
-			return s;
+			if (_tmp && s != null)
+				return s;
+			else
+				throw new FileNotFoundException("File not found: {0}".F(filename), filename);
 		}
 
 		public static bool TryOpenWithExts(string filename, string[] exts, out Stream s)


### PR DESCRIPTION
I tried to create a new Testmap for TS by Converting a CNC-TD map and started the MapEditor which crashed because the RedAlert Mod worse not Installed GobleFileSystem passed a FileName over the "File-Exist" test which worse returning True but the Stream worse null... The File  does not exist in the Contents Mod Folder (redalert.mix) 
