### PR TITLE
Add a proximity upgrade source, and TS stealth generator

### DIFF
--- a/OpenRA.Mods.RA/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Buildings/ClonesProducedUnits.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA
 		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)
 		{
 			// No recursive cloning!
-			if (producer.HasTrait<ClonesProducedUnits>())
+			if (producer.Owner != self.Owner || producer.HasTrait<ClonesProducedUnits>())
 				return;
 
 			var ci = produced.Info.Traits.GetOrDefault<CloneableInfo>();

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -550,6 +550,7 @@
     <Compile Include="Warheads\GrantUpgradeWarhead.cs" />
     <Compile Include="Crates\GrantUpgradeCrateAction.cs" />
     <Compile Include="Scripting\Properties\UpgradeProperties.cs" />
+    <Compile Include="UpgradeActorsNear.cs" />
     <Compile Include="WithRangeCircle.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -550,6 +550,7 @@
     <Compile Include="Warheads\GrantUpgradeWarhead.cs" />
     <Compile Include="Crates\GrantUpgradeCrateAction.cs" />
     <Compile Include="Scripting\Properties\UpgradeProperties.cs" />
+    <Compile Include="WithRangeCircle.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -98,9 +98,7 @@ namespace OpenRA.Mods.RA
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())
 						t.UnitProduced(self, newUnit, exit);
 
-				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>()
-					.Where(a => a.Actor.Owner == self.Owner);
-
+				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
 				foreach (var notify in notifyOthers)
 					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
 

--- a/OpenRA.Mods.RA/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.RA/UpgradeActorsNear.cs
@@ -1,0 +1,117 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("Applies an upgrade to actors within a specified range.")]
+	public class UpgradeActorsNearInfo : ITraitInfo
+	{
+		[Desc("The upgrades to grant.")]
+		public readonly string[] Upgrades = { };
+
+		[Desc("The range to search for actors to upgrade.")]
+		public readonly WRange Range = WRange.FromCells(3);
+
+		[Desc("What diplomatic stances are affected.")]
+		public readonly Stance ValidStances = Stance.Ally;
+
+		[Desc("Grant the upgrades apply to this actor.")]
+		public readonly bool AffectsParent = false;
+
+		public readonly string EnableSound = null;
+		public readonly string DisableSound = null;
+
+		public object Create(ActorInitializer init) { return new UpgradeActorsNear(init.self, this); }
+	}
+
+	public class UpgradeActorsNear : ITick, INotifyAddedToWorld, INotifyRemovedFromWorld
+	{
+		readonly UpgradeActorsNearInfo info;
+		readonly Actor self;
+
+		int proximityTrigger;
+		WPos cachedPosition;
+		WRange cachedRange;
+		WRange desiredRange;
+
+		bool cachedDisabled = true;
+
+		public UpgradeActorsNear(Actor self, UpgradeActorsNearInfo info)
+		{
+			this.info = info;
+			this.self = self;
+			cachedRange = info.Range;
+		}
+
+		public void AddedToWorld(Actor self)
+		{
+			cachedPosition = self.CenterPosition;
+			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, ActorEntered, ActorExited);
+		}
+
+		public void RemovedFromWorld(Actor self)
+		{
+			self.World.ActorMap.RemoveProximityTrigger(proximityTrigger);
+		}
+
+		public void Tick(Actor self)
+		{
+			var disabled = self.IsDisabled();
+
+			if (cachedDisabled != disabled)
+			{
+				Sound.Play(disabled ? info.DisableSound : info.EnableSound, self.CenterPosition);
+				desiredRange = disabled ? WRange.Zero : info.Range;
+				cachedDisabled = disabled;
+			}
+
+			if (self.CenterPosition != cachedPosition || desiredRange != cachedRange)
+			{
+				cachedPosition = self.CenterPosition;
+				cachedRange = desiredRange;
+				self.World.ActorMap.UpdateProximityTrigger(proximityTrigger, cachedPosition, cachedRange);
+			}
+		}
+
+		void ActorEntered(Actor a)
+		{
+			if (a.Destroyed)
+				return;
+
+			if (a == self && !info.AffectsParent)
+				return;
+
+			var stance = self.Owner.Stances[a.Owner];
+			if (!info.ValidStances.HasFlag(stance))
+				return;
+
+			var um = a.TraitOrDefault<UpgradeManager>();
+			if (um != null)
+				foreach (var u in info.Upgrades)
+					um.GrantUpgrade(a, u, this);
+		}
+
+		void ActorExited(Actor a)
+		{
+			if (a == self || a.Destroyed)
+				return;
+
+			var um = a.TraitOrDefault<UpgradeManager>();
+			if (um != null)
+				foreach (var u in info.Upgrades)
+					um.RevokeUpgrade(a, u, this);
+		}
+	}
+}

--- a/OpenRA.Mods.RA/WithRangeCircle.cs
+++ b/OpenRA.Mods.RA/WithRangeCircle.cs
@@ -1,0 +1,76 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("Renders an arbitrary circle when selected or placing a structure")]
+	class WithRangeCircleInfo : ITraitInfo, IPlaceBuildingDecoration
+	{
+		[Desc("Type of range circle. used to decide which circles to draw on other structures during building placement.")]
+		public readonly string Type = null;
+
+		[Desc("Color of the circle")]
+		public readonly Color Color = Color.FromArgb(128, Color.White);
+
+		[Desc("Range of the circle")]
+		public readonly WRange Range = WRange.Zero;
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		{
+			yield return new RangeCircleRenderable(
+				centerPosition,
+				Range,
+				0,
+				Color,
+				Color.FromArgb(96, Color.Black)
+			);
+
+			foreach (var a in w.ActorsWithTrait<WithRangeCircle>())
+				if (a.Actor.Owner == a.Actor.World.LocalPlayer && a.Trait.Info.Type == Type)
+					foreach (var r in a.Trait.RenderAfterWorld(wr))
+						yield return r;
+		}
+
+		public object Create(ActorInitializer init) { return new WithRangeCircle(init.self, this); }
+	}
+
+	class WithRangeCircle : IPostRenderSelection
+	{
+		public readonly WithRangeCircleInfo Info;
+		readonly Actor self;
+
+		public WithRangeCircle(Actor self, WithRangeCircleInfo info)
+		{
+			this.self = self;
+			Info = info;
+		}
+
+		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		{
+			if (self.Owner != self.World.LocalPlayer)
+				yield break;
+
+			yield return new RangeCircleRenderable(
+				self.CenterPosition,
+				Info.Range,
+				0,
+				Info.Color,
+				Color.FromArgb(96, Color.Black)
+			);
+		}
+	}
+}
+

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -44,6 +44,11 @@
 	Demolishable:
 	ScriptTriggers:
 	WithMakeAnimation:
+	UpgradeManager:
+	Cloak@CLOAKGENERATOR:
+		RequiresUpgrade: cloakgenerator
+		InitialDelay: 0
+		CloakDelay: 90
 
 ^Wall:
 	AppearsOnRadar:
@@ -82,6 +87,11 @@
 	LuaScriptEvents:
 	Demolishable:
 	ScriptTriggers:
+	UpgradeManager:
+	Cloak@CLOAKGENERATOR:
+		RequiresUpgrade: cloakgenerator
+		InitialDelay: 0
+		CloakDelay: 90
 
 ^Infantry:
 	AppearsOnRadar:
@@ -158,6 +168,10 @@
 		DeathSound: Zapped
 		DeathTypes: 6
 	UpgradeManager:
+	Cloak@CLOAKGENERATOR:
+		RequiresUpgrade: cloakgenerator
+		InitialDelay: 0
+		CloakDelay: 90
 
 ^CivilianInfantry:
 	Inherits: ^Infantry
@@ -253,6 +267,10 @@
 	TimedUpgradeBar@EMPDISABLE:
 		Upgrade: empdisable
 		Color: 255,255,255
+	Cloak@CLOAKGENERATOR:
+		RequiresUpgrade: cloakgenerator
+		InitialDelay: 0
+		CloakDelay: 90
 
 ^Tank:
 	AppearsOnRadar:
@@ -321,6 +339,10 @@
 	TimedUpgradeBar@EMPDISABLE:
 		Upgrade: empdisable
 		Color: 255,255,255
+	Cloak@CLOAKGENERATOR:
+		RequiresUpgrade: cloakgenerator
+		InitialDelay: 0
+		CloakDelay: 90
 
 ^Helicopter:
 	AppearsOnRadar:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -903,6 +903,44 @@ GADEPT:
 	Power:
 		Amount: -30
 
+NASTLH:
+	Inherits: ^Building
+	Valued:
+		Cost: 2500
+	Tooltip:
+		Name: Stealth Generator
+		Description: Generates a cloaking field
+	Buildable:
+		BuildPaletteOrder: 80
+		Prerequisites: proc,natech
+		Owner: nod
+		Queue: Building
+	Building:
+		Footprint: xxx xxx
+		Dimensions: 3,2
+	Health:
+		HP: 600
+	Armor:
+		Type: Wood
+	RevealsShroud:
+		Range: 6c0
+	WithIdleOverlay@pulse:
+		Sequence: pulse
+		PauseOnLowPower: true
+	WithRangeCircle:
+		Range: 12c0
+		Type: cloakgenerator
+	Power:
+		Amount: -350
+	RequiresPower:
+	CanPowerDown:
+	UpgradeActorsNear:
+		Upgrades: cloakgenerator
+		Range: 12c0
+		EnableSound: cloak5.aud
+		DisableSound: cloak5.aud
+		AffectsParent: true
+
 #TODO: Placeholder, replace with Component Tower + Vulcan Upgrade
 GAVULC:
 	Inherits: ^Building

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -718,6 +718,31 @@ napuls:
 	icon: pulsicon
 		Start: 0
 
+nastlh:
+	idle: ntstlh
+		Start: 0
+		ShadowStart: 3
+	damaged-idle: ntstlh
+		Start: 1
+		ShadowStart: 4
+	critical-idle: ntstlh
+		Start: 2
+		ShadowStart: 5
+	pulse: ntstlh_a
+		Start: 0
+		Length: 4
+		Tick: 480
+	damaged-pulse: ntstlh_a
+		Start: 4
+		Length: 4
+		Tick: 480
+	make: ntstlhmk
+		Start: 0
+		Length: 18
+		ShadowStart: 20
+	icon: clckicon
+		Start: 0
+
 gavulc:
 	idle: gtctwr
 		Start: 0


### PR DESCRIPTION
This introduces a proximity upgrade source and implements the stealth generator as a demonstration of its capabilities.  This will also be useful for area buffs (like the propaganda tower in C&C generals) or debuffs (see [gapgen-sight](https://github.com/pchote/OpenRA/commits/gapgen-sight) for a prototype of the gap generator sight restriction).

~~The way that our production code is set up means that the proximity bonus won't be granted until the newly produced actor's second tick in the world, which means that units produced in the stealth field will be visible for their first tick.  This will probably require some reworking of the production code to fix.~~
