### PR TITLE
Balancing: Reduced Commando HP

### DIFF
--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -189,7 +189,7 @@ RMBO:
 	Mobile:
 		Speed: 71
 	Health:
-		HP: 200
+		HP: 150
 	Passenger:
 		PipType: Red
 	RevealsShroud:


### PR DESCRIPTION
The general consensus from the online players of the CNC mod is that the Commandos have too much HP. The case is often a few Commandos are dropped in the base, gain instant experience level up by using a C4 on valuable structures and then becomes an unstoppable wave of destruction. Most of the time not even a direct hit from airstrike will kill one at base stats and now with flame tanks being nerfed they're more of a juggernaut than ever. More people are getting frustrated by the "[expletive deleted] Commandos" every day and even those who frequently use this unit agree that they're somewhat OP.

So easy change: 150HP is adequate. With the reduction, commandos can still take on a guard tower, they still get their instant-level up on destroying structures and surprise invasive attacks are an effective part of GDI's strategy; but this change should stop a 1000$ unit crawling through armies of tanks and soldiers to plant three more C4s than should be reasonable. For as things stand now, Commandos are more deadly than A-Bombs, and you can build as many as your income allows.
