### PR TITLE
Disable movement of EMPd actors

### DIFF
--- a/OpenRA.Mods.RA/Activities/Hunt.cs
+++ b/OpenRA.Mods.RA/Activities/Hunt.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.RA.Activities
 				return this;
 
 			return Util.SequenceActivities(
-				new AttackMove.AttackMoveActivity(self, new Move.Move(target.Location, WRange.FromCells(2))),
+				new AttackMove.AttackMoveActivity(self, new Move.Move(self, target.Location, WRange.FromCells(2))),
 				new Wait(25),
 				this);
 		}

--- a/OpenRA.Mods.RA/DisableUpgrade.cs
+++ b/OpenRA.Mods.RA/DisableUpgrade.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public object Create(ActorInitializer init) { return new DisableUpgrade(this); }
 	}
 
-	public class DisableUpgrade : IUpgradable, IDisable
+	public class DisableUpgrade : IUpgradable, IDisable, IDisableMove
 	{
 		readonly DisableUpgradeInfo info;
 		bool enabled;
@@ -44,5 +44,7 @@ namespace OpenRA.Mods.RA
 		}
 
 		public bool Disabled { get { return enabled; } }
+
+		public bool MoveDisabled(Actor self) { return enabled; }
 	}
 }

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -432,7 +432,7 @@ namespace OpenRA.Mods.RA.Move
 
 			ticksBeforePathing = avgTicksBeforePathing + self.World.SharedRandom.Next(-spreadTicksBeforePathing, spreadTicksBeforePathing);
 
-			self.QueueActivity(new Move(currentLocation, 8));
+			self.QueueActivity(new Move(self, currentLocation, 8));
 
 			self.SetTargetLine(Target.FromCell(self.World, currentLocation), Color.Green);
 		}
@@ -585,7 +585,7 @@ namespace OpenRA.Mods.RA.Move
 			{
 				self.CancelActivity();
 				self.SetTargetLine(Target.FromCell(self.World, moveTo.Value), Color.Green, false);
-				self.QueueActivity(new Move(moveTo.Value, 0));
+				self.QueueActivity(new Move(self, moveTo.Value, 0));
 
 				Log.Write("debug", "OnNudge #{0} from {1} to {2}",
 					self.ActorID, self.Location, moveTo.Value);
@@ -631,13 +631,13 @@ namespace OpenRA.Mods.RA.Move
 			}
 		}
 
-		public Activity ScriptedMove(CPos cell) { return new Move(cell); }
-		public Activity MoveTo(CPos cell, int nearEnough) { return new Move(cell, nearEnough); }
-		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new Move(cell, ignoredActor); }
+		public Activity ScriptedMove(CPos cell) { return new Move(self, cell); }
+		public Activity MoveTo(CPos cell, int nearEnough) { return new Move(self, cell, nearEnough); }
+		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new Move(self, cell, ignoredActor); }
 		public Activity MoveWithinRange(Target target, WRange range) { return new MoveWithinRange(self, target, WRange.Zero, range); }
 		public Activity MoveWithinRange(Target target, WRange minRange, WRange maxRange) { return new MoveWithinRange(self, target, minRange, maxRange); }
 		public Activity MoveFollow(Actor self, Target target, WRange minRange, WRange maxRange) { return new Follow(self, target, minRange, maxRange); }
-		public Activity MoveTo(Func<List<CPos>> pathFunc) { return new Move(pathFunc); }
+		public Activity MoveTo(Func<List<CPos>> pathFunc) { return new Move(self, pathFunc); }
 
 		public void OnNotifyBlockingMove(Actor self, Actor blocking)
 		{

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -22,11 +22,13 @@ namespace OpenRA.Mods.RA.Move
 	{
 		static readonly List<CPos> NoPath = new List<CPos>();
 
-		CPos? destination;
-		WRange nearEnough;
+		readonly Mobile mobile;
+		readonly WRange nearEnough;
+		readonly Func<List<CPos>> getPath;
+		readonly Actor ignoreBuilding;
+
 		List<CPos> path;
-		Func<Actor, Mobile, List<CPos>> getPath;
-		Actor ignoreBuilding;
+		CPos? destination;
 
 		// For dealing with blockers
 		bool hasWaited;
@@ -35,9 +37,11 @@ namespace OpenRA.Mods.RA.Move
 
 		// Scriptable move order
 		// Ignores lane bias and nearby units
-		public Move(CPos destination)
+		public Move(Actor self, CPos destination)
 		{
-			this.getPath = (self, mobile) =>
+			mobile = self.Trait<Mobile>();
+
+			getPath = () =>
 				self.World.WorldActor.Trait<PathFinder>().FindPath(
 					PathSearch.FromPoint(self.World, mobile.Info, self, mobile.toCell, destination, false)
 					.WithoutLaneBias());
@@ -46,28 +50,34 @@ namespace OpenRA.Mods.RA.Move
 		}
 
 		// HACK: for legacy code
-		public Move(CPos destination, int nearEnough)
-			: this(destination, WRange.FromCells(nearEnough)) { }
+		public Move(Actor self, CPos destination, int nearEnough)
+			: this(self, destination, WRange.FromCells(nearEnough)) { }
 
-		public Move(CPos destination, WRange nearEnough)
+		public Move(Actor self, CPos destination, WRange nearEnough)
 		{
-			this.getPath = (self, mobile) => self.World.WorldActor.Trait<PathFinder>()
+			mobile = self.Trait<Mobile>();
+
+			getPath = () => self.World.WorldActor.Trait<PathFinder>()
 				.FindUnitPath(mobile.toCell, destination, self);
 			this.destination = destination;
 			this.nearEnough = nearEnough;
 		}
 
-		public Move(CPos destination, SubCell subCell, WRange nearEnough)
+		public Move(Actor self, CPos destination, SubCell subCell, WRange nearEnough)
 		{
-			this.getPath = (self, mobile) => self.World.WorldActor.Trait<PathFinder>()
+			mobile = self.Trait<Mobile>();
+
+			getPath = () => self.World.WorldActor.Trait<PathFinder>()
 				.FindUnitPathToRange(mobile.fromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self);
 			this.destination = destination;
 			this.nearEnough = nearEnough;
 		}
 
-		public Move(CPos destination, Actor ignoreBuilding)
+		public Move(Actor self, CPos destination, Actor ignoreBuilding)
 		{
-			this.getPath = (self, mobile) =>
+			mobile = self.Trait<Mobile>();
+
+			getPath = () =>
 				self.World.WorldActor.Trait<PathFinder>().FindPath(
 					PathSearch.FromPoint(self.World, mobile.Info, self, mobile.toCell, destination, false)
 					.WithIgnoredBuilding(ignoreBuilding));
@@ -77,9 +87,11 @@ namespace OpenRA.Mods.RA.Move
 			this.ignoreBuilding = ignoreBuilding;
 		}
 
-		public Move(Target target, WRange range)
+		public Move(Actor self, Target target, WRange range)
 		{
-			this.getPath = (self, mobile) =>
+			mobile = self.Trait<Mobile>();
+
+			getPath = () =>
 			{
 				if (!target.IsValidFor(self))
 					return NoPath;
@@ -88,15 +100,18 @@ namespace OpenRA.Mods.RA.Move
 					mobile.toCell, mobile.toSubCell, target.CenterPosition, range, self);
 			};
 
-			this.destination = null;
-			this.nearEnough = range;
+			destination = null;
+			nearEnough = range;
 		}
 
-		public Move(Func<List<CPos>> getPath)
+		public Move(Actor self, Func<List<CPos>> getPath)
 		{
-			this.getPath = (_1, _2) => getPath();
-			this.destination = null;
-			this.nearEnough = WRange.Zero;
+			mobile = self.Trait<Mobile>();
+
+			this.getPath = getPath;
+
+			destination = null;
+			nearEnough = WRange.Zero;
 		}
 
 		static int HashList<T>(List<T> xs)
@@ -111,14 +126,13 @@ namespace OpenRA.Mods.RA.Move
 
 		List<CPos> EvalPath(Actor self, Mobile mobile)
 		{
-			var path = getPath(self, mobile).TakeWhile(a => a != mobile.toCell).ToList();
+			var path = getPath().TakeWhile(a => a != mobile.toCell).ToList();
 			mobile.PathHash = HashList(path);
 			return path;
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			var mobile = self.Trait<Mobile>();
 
 			if (destination == mobile.toCell)
 				return NextActivity;
@@ -297,7 +311,7 @@ namespace OpenRA.Mods.RA.Move
 			public override Activity Tick(Actor self)
 			{
 				var mobile = self.Trait<Mobile>();
-				var ret = InnerTick(self, mobile);
+				var ret = InnerTick(self, move.mobile);
 				mobile.IsMoving = ret is MovePart;
 
 				if (moveFraction > moveFractionTotal)

--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.RA.Move
 		static readonly List<CPos> NoPath = new List<CPos>();
 
 		readonly Mobile mobile;
+		readonly IEnumerable<IDisableMove> moveDisablers;
 		readonly WRange nearEnough;
 		readonly Func<List<CPos>> getPath;
 		readonly Actor ignoreBuilding;
@@ -40,6 +41,7 @@ namespace OpenRA.Mods.RA.Move
 		public Move(Actor self, CPos destination)
 		{
 			mobile = self.Trait<Mobile>();
+			moveDisablers = self.TraitsImplementing<IDisableMove>();
 
 			getPath = () =>
 				self.World.WorldActor.Trait<PathFinder>().FindPath(
@@ -56,6 +58,7 @@ namespace OpenRA.Mods.RA.Move
 		public Move(Actor self, CPos destination, WRange nearEnough)
 		{
 			mobile = self.Trait<Mobile>();
+			moveDisablers = self.TraitsImplementing<IDisableMove>();
 
 			getPath = () => self.World.WorldActor.Trait<PathFinder>()
 				.FindUnitPath(mobile.toCell, destination, self);
@@ -66,6 +69,7 @@ namespace OpenRA.Mods.RA.Move
 		public Move(Actor self, CPos destination, SubCell subCell, WRange nearEnough)
 		{
 			mobile = self.Trait<Mobile>();
+			moveDisablers = self.TraitsImplementing<IDisableMove>();
 
 			getPath = () => self.World.WorldActor.Trait<PathFinder>()
 				.FindUnitPathToRange(mobile.fromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self);
@@ -76,6 +80,7 @@ namespace OpenRA.Mods.RA.Move
 		public Move(Actor self, CPos destination, Actor ignoreBuilding)
 		{
 			mobile = self.Trait<Mobile>();
+			moveDisablers = self.TraitsImplementing<IDisableMove>();
 
 			getPath = () =>
 				self.World.WorldActor.Trait<PathFinder>().FindPath(
@@ -90,6 +95,7 @@ namespace OpenRA.Mods.RA.Move
 		public Move(Actor self, Target target, WRange range)
 		{
 			mobile = self.Trait<Mobile>();
+			moveDisablers = self.TraitsImplementing<IDisableMove>();
 
 			getPath = () =>
 			{
@@ -107,6 +113,7 @@ namespace OpenRA.Mods.RA.Move
 		public Move(Actor self, Func<List<CPos>> getPath)
 		{
 			mobile = self.Trait<Mobile>();
+			moveDisablers = self.TraitsImplementing<IDisableMove>();
 
 			this.getPath = getPath;
 
@@ -133,6 +140,8 @@ namespace OpenRA.Mods.RA.Move
 
 		public override Activity Tick(Actor self)
 		{
+			if (moveDisablers.Any(d => d.MoveDisabled(self)))
+				return this;
 
 			if (destination == mobile.toCell)
 				return NextActivity;

--- a/OpenRA.Mods.RA/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.RA/Scripting/Global/ReinforcementsGlobal.cs
@@ -54,17 +54,11 @@ namespace OpenRA.Mods.RA.Scripting
 
 		void Move(Actor actor, CPos dest)
 		{
-			if (actor.HasTrait<Aircraft>())
-			{
-				if (actor.HasTrait<Helicopter>())
-					actor.QueueActivity(new HeliFly(actor, Target.FromCell(actor.World, dest)));
-				else
-					actor.QueueActivity(new Fly(actor, Target.FromCell(actor.World, dest)));
-			}
-			else
-			{
-				actor.QueueActivity(new Move.Move(dest, 2));
-			}
+			var move = actor.TraitOrDefault<IMove>();
+			if (move == null)
+				return;
+
+			actor.QueueActivity(move.MoveTo(dest, 2));
 		}
 
 		[Desc("Send reinforcements consisting of multiple units. Supports ground-based, naval and air units. " +

--- a/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScriptInterface.cs
@@ -324,9 +324,9 @@ namespace OpenRA.Mods.RA.Scripting
 		public void AttackMove(Actor actor, CPos location, double nearEnough)
 		{
 			if (actor.HasTrait<AttackMove>())
-				actor.QueueActivity(new AttackMove.AttackMoveActivity(actor, new Move.Move(location, (int)nearEnough)));
+				actor.QueueActivity(new AttackMove.AttackMoveActivity(actor, new Move.Move(actor, location, (int)nearEnough)));
 			else
-				actor.QueueActivity(new Move.Move(location, (int)nearEnough));
+				actor.QueueActivity(new Move.Move(actor, location, (int)nearEnough));
 		}
 
 		[LuaGlobal]

--- a/OpenRA.Mods.RA/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/CombatProperties.cs
@@ -33,7 +33,11 @@ namespace OpenRA.Mods.RA.Scripting
 			"close enough to complete the activity.")]
 		public void AttackMove(CPos cell, int closeEnough = 0)
 		{
-			self.QueueActivity(new AttackMove.AttackMoveActivity(self, new Move.Move(cell, WRange.FromCells(closeEnough))));
+			var move = self.TraitOrDefault<IMove>();
+			if (move == null)
+				return;
+
+			self.QueueActivity(new AttackMove.AttackMoveActivity(self, move.MoveTo(cell, closeEnough)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/MobileProperties.cs
@@ -25,14 +25,14 @@ namespace OpenRA.Mods.RA.Scripting
 			"(in cells) that will be considered close enough to complete the activity.")]
 		public void Move(CPos cell, int closeEnough = 0)
 		{
-			self.QueueActivity(new Move.Move(cell, WRange.FromCells(closeEnough)));
+			self.QueueActivity(new Move.Move(self, cell, WRange.FromCells(closeEnough)));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Moves within the cell grid, ignoring lane biases.")]
 		public void ScriptedMove(CPos cell)
 		{
-			self.QueueActivity(new Move.Move(cell));
+			self.QueueActivity(new Move.Move(self, cell));
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.RA/Warheads/GrantUpgradeWarhead.cs
+++ b/OpenRA.Mods.RA/Warheads/GrantUpgradeWarhead.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA
 			{
 				var um = a.TraitOrDefault<UpgradeManager>();
 				if (um == null)
-					return;
+					continue;
 
 				foreach (var u in Upgrades)
 				{

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -5,7 +5,7 @@
 	Selectable:
 		Priority: 3
 	TargetableBuilding:
-		TargetTypes: Ground, C4
+		TargetTypes: Ground, Building, C4
 	Building:
 		Dimensions: 1,1
 		Footprint: x
@@ -70,7 +70,7 @@
 	LineBuildNode:
 		Types: wall
 	TargetableBuilding:
-		TargetTypes: Ground, C4
+		TargetTypes: Ground, Wall, C4
 	RenderBuildingWall:
 		Type: wall
 	GivesExperience:
@@ -116,7 +116,7 @@
 	Selectable:
 		Voice: Infantry
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Infantry
 	RenderInfantry:
 	WithDeathAnimation:
 	AutoTarget:
@@ -217,7 +217,7 @@
 	Selectable:
 		Voice: Vehicle
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Vehicle
 	Repairable:
 		RepairBuildings: gadept
 	Passenger:
@@ -289,7 +289,7 @@
 	Selectable:
 		Voice: Vehicle
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Vehicle
 	Repairable:
 		RepairBuildings: gadept
 	Passenger:

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -1130,10 +1130,13 @@ EMPulseCannon:
 	Warhead@target: SpreadDamage
 		Spread: 0
 		Damage: 0
+		PreventProne: true
+		ValidTargets: Vehicle
 	Warhead@emp: GrantUpgrade
 		Range: 3c0
 		Duration: 250
 		Upgrades: empdisable
+		ValidTargets: Vehicle
 
 TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
This implements the a missing piece from #6528 and uses `IDisableMove` to improve the EMP effect.
