### PR TITLE
Fix TS offsets for good

### DIFF
--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -110,8 +110,8 @@ GAPILE:
 	RallyPoint:
 		RallyPoint: 2,3
 	Exit@1:
-		SpawnOffset: -256,1051,0
-		ExitCell: 2,3
+		SpawnOffset: -256,1024,0
+		ExitCell: 2,2
 	Production:
 		Produces: Infantry
 	PrimaryBuilding:
@@ -344,8 +344,8 @@ NAHAND:
 	RevealsShroud:
 		Range: 5c0
 	Exit@1:
-		SpawnOffset: 0,2048,0
-		ExitCell: 3,3
+		SpawnOffset: 384,768,0
+		ExitCell: 3,2
 	RallyPoint:
 		RallyPoint: 3,3
 	Production:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -138,7 +138,7 @@ PROC:
 		Prerequisites: anypower
 		Owner: gdi,nod
 	Building:
-		Footprint: xxx= xxx= xxx=
+		Footprint: xxx= xx== xxx=
 		Dimensions: 4,3
 	Selectable:
 		Bounds: 120, 60, -12, -12
@@ -147,7 +147,7 @@ PROC:
 	RevealsShroud:
 		Range: 6c0
 	TiberianSunRefinery:
-		DockOffset: 3,1
+		DockOffset: 2,1
 	StoresResources:
 		PipColor: Green
 		PipCount: 15
@@ -157,8 +157,8 @@ PROC:
 	FreeActor:
 		Actor: HARV
 		InitialActivity: FindResources
-		SpawnOffset: 3,4
-		Facing: 64
+		SpawnOffset: 3,1
+		Facing: 160
 	WithIdleOverlay@REDLIGHTS:
 		Sequence: idle-redlights
 	WithIdleOverlay@BIB:

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -43,7 +43,7 @@ GACNST:
 	Power:
 		Amount: 0
 	Selectable:
-		Bounds: 120, 90, 0, 20
+		Bounds: 144, 72, 0, -12
 
 GAPOWR:
 	Inherits: ^Building
@@ -72,7 +72,7 @@ GAPOWR:
 	WithIdleOverlay@PLUG:
 		Sequence: idle-plug
 	Selectable:
-		Bounds: 64, 64
+		Bounds: 96, 60, 0, -12
 	Power:
 		Amount: 100
 	InfiltrateForPowerOutage:
@@ -99,6 +99,8 @@ GAPILE:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Selectable:
+		Bounds: 96, 48, 0, -8
 	Health:
 		HP: 800
 	Armor:
@@ -138,6 +140,8 @@ PROC:
 	Building:
 		Footprint: xxx= xxx= xxx=
 		Dimensions: 4,3
+	Selectable:
+		Bounds: 120, 60, -12, -12
 	Health:
 		HP: 900
 	RevealsShroud:
@@ -177,6 +181,8 @@ GASILO:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2, 2
+	Selectable:
+		Bounds: 96, 48
 	-GivesBuildableArea:
 	Health:
 		HP: 300
@@ -213,6 +219,8 @@ GAWEAP:
 	Building:
 		Footprint: xxx= xxx= xxx=
 		Dimensions: 4,3
+	Selectable:
+		Bounds: 120, 60, 0, -12
 	Health:
 		HP: 1000
 	RevealsShroud:
@@ -220,10 +228,10 @@ GAWEAP:
 	-RenderBuilding:
 	RenderBuildingWarFactory:
 	RallyPoint:
-		RallyPoint: 6,5
+		RallyPoint: 6,1
 	Exit@1:
-		SpawnOffset: -170,0,0
-		ExitCell: 4,2
+		SpawnOffset: 0,0,0
+		ExitCell: 4,1
 	Production:
 		Produces: Vehicle
 	PrimaryBuilding:
@@ -255,6 +263,8 @@ NAPOWR:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Selectable:
+		Bounds: 96, 60, 0, -12
 	Health:
 		HP: 750
 	Armor:
@@ -289,6 +299,8 @@ NAAPWR:
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 2,3
+	Selectable:
+		Bounds: 120, 84, 0, -12
 	Health:
 		HP: 900
 	Armor:
@@ -323,6 +335,8 @@ NAHAND:
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
+	Selectable:
+		Bounds: 120, 60, 0, -8
 	Health:
 		HP: 800
 	Armor:
@@ -362,6 +376,8 @@ NAWEAP:
 	Building:
 		Footprint: xxx= xxx= xxx=
 		Dimensions: 4,3
+	Selectable:
+		Bounds: 144,72, 0,-12
 	Health:
 		HP: 1000
 	RevealsShroud:
@@ -369,10 +385,10 @@ NAWEAP:
 	-RenderBuilding:
 	RenderBuildingWarFactory:
 	RallyPoint:
-		RallyPoint: 6,5
+		RallyPoint: 6,1
 	Exit@1:
-		SpawnOffset: -170,0,0
-		ExitCell: 4,2
+		SpawnOffset: 0,0,0
+		ExitCell: 4,1
 	Production:
 		Produces: Vehicle
 	PrimaryBuilding:
@@ -471,9 +487,6 @@ GATICK:
 	-AcceptsSupplies:
 	Tooltip:
 		Name: Deployed Tick Tank
-	Building:
-		Footprint: x
-		Dimensions: 1,1
 	-GivesBuildableArea:
 	Health:
 		HP: 350
@@ -521,9 +534,6 @@ GAICBM:
 	-AcceptsSupplies:
 	Tooltip:
 		Name: Deployed ICBM
-	Building:
-		Footprint: _ x
-		Dimensions: 1,2
 	-GivesBuildableArea:
 	Health:
 		HP: 400
@@ -545,9 +555,6 @@ GADPSA:
 	-AcceptsSupplies:
 	Tooltip:
 		Name: Deployed Sensor Array
-	Building:
-		Footprint: _ x
-		Dimensions: 1,2
 	-GivesBuildableArea:
 	Health:
 		HP: 600
@@ -572,9 +579,6 @@ GAARTY:
 	-AcceptsSupplies:
 	Tooltip:
 		Name: Deployed Artillery
-	Building:
-		Footprint: x
-		Dimensions: 1,1
 	-GivesBuildableArea:
 	Health:
 		HP: 300
@@ -624,6 +628,8 @@ GASPOT:
 	Building:
 		Footprint: x
 		Dimensions: 1,1
+	Selectable:
+		Bounds: 48, 72
 	Health:
 		HP: 400
 	Armor:
@@ -648,9 +654,6 @@ GALITE:
 		Cost: 200
 	Tooltip:
 		Name: Light Post
-	Building:
-		Footprint: x
-		Dimensions: 1,1
 	RenderBuilding:
 		Palette: terrain
 	-WithMakeAnimation:
@@ -682,6 +685,8 @@ GARADR:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Selectable:
+		Bounds: 96, 96, 0, -12
 	Health:
 		HP: 800
 	Armor:
@@ -720,6 +725,8 @@ NARADR:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Selectable:
+		Bounds: 96, 72, 0, -12
 	Health:
 		HP: 800
 	Armor:
@@ -758,6 +765,8 @@ GATECH:
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
+	Selectable:
+		Bounds: 120, 60, 0, -12
 	Health:
 		HP: 500
 	Armor:
@@ -786,6 +795,8 @@ NATECH:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Selectable:
+		Bounds: 96, 48
 	Health:
 		HP: 500
 	Armor:
@@ -883,6 +894,8 @@ GADEPT:
 	Building:
 		Footprint: =x= xxx =x=
 		Dimensions: 3,3
+	Selectable:
+		Bounds: 120, 60, 12, -6
 	Health:
 		HP: 1100
 	RevealsShroud:
@@ -916,6 +929,8 @@ GAVULC:
 		BuildPaletteOrder: 30
 		Owner: gdi
 	Building:
+	Selectable:
+		Bounds: 48, 48, 0, -12
 	DisabledOverlay:
 	-GivesBuildableArea:
 	Health:
@@ -974,6 +989,8 @@ GAROCK:
 		BuildPaletteOrder: 40
 		Owner: gdi
 	Building:
+	Selectable:
+		Bounds: 48, 48, 0, -12
 	RequiresPower:
 	DisabledOverlay:
 	-GivesBuildableArea:
@@ -1023,6 +1040,8 @@ GACSAM:
 		BuildPaletteOrder: 60
 		Owner: gdi
 	Building:
+	Selectable:
+		Bounds: 48, 48, 0, -12
 	RequiresPower:
 	DisabledOverlay:
 	-GivesBuildableArea:
@@ -1071,6 +1090,8 @@ NASAM:
 		BuildPaletteOrder: 60
 		Owner: nod
 	Building:
+	Selectable:
+		Bounds: 48, 24
 	RequiresPower:
 	DisabledOverlay:
 	-GivesBuildableArea:
@@ -1112,6 +1133,8 @@ NALASR:
 		BuildPaletteOrder: 50
 		Owner: nod
 	Building:
+	Selectable:
+		Bounds: 48, 24
 	RequiresPower:
 	DisabledOverlay:
 	-GivesBuildableArea:
@@ -1128,7 +1151,7 @@ NALASR:
 	Turreted:
 		ROT: 10
 		InitialFacing: 300
-		Offset: 298,-171,256
+		Offset: 298,-171,0
 	AttackTurreted:
 	Armament:
 		Weapon: TurretLaser
@@ -1153,6 +1176,8 @@ NAOBEL:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Selectable:
+		Bounds: 96, 72, 0, -12
 	RequiresPower:
 	DisabledOverlay:
 	-GivesBuildableArea:
@@ -1196,6 +1221,8 @@ NAPULS:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Selectable:
+		Bounds: 96, 72, 0, -12
 	RequiresPower:
 	DisabledOverlay:
 	-GivesBuildableArea:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -1,34 +1,34 @@
 overlay:
 	build-valid-interior: place
 		Start: 0
-		Offset: 0, 12
+		Offset: 0, -12
 	build-valid-snow: place
 		Start: 0
-		Offset: 0, 12
+		Offset: 0, -12
 	build-valid-temperat: place
 		Start: 0
-		Offset: 0, 12
+		Offset: 0, -12
 	build-invalid: place
 		Start: 1
-		Offset: 0, 12
+		Offset: 0, -12
 	target-select: place
 		Start: 1
-		Offset: 0, 12
+		Offset: 0, -12
 	target-valid-desert: place
 		Start: 1
-		Offset: 0, 12
+		Offset: 0, -12
 	target-valid-interior: place
 		Start: 1
-		Offset: 0, 12
+		Offset: 0, -12
 	target-valid-snow: place
 		Start: 1
-		Offset: 0, 12
+		Offset: 0, -12
 	target-valid-temperat: place
 		Start: 1
-		Offset: 0, 12
+		Offset: 0, -12
 	target-invalid: place
 		Start: 1
-		Offset: 0, 12
+		Offset: 0, -12
 
 poweroff:
 	offline: poweroff
@@ -327,82 +327,102 @@ resources:
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib02: tib02
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib03: tib03
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib04: tib04
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib05: tib05
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib06: tib06
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib07: tib07
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib08: tib08
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib09: tib09
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib10: tib10
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib11: tib11
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib12: tib12
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib13: tib13
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib14: tib14
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib15: tib15
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib16: tib16
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib17: tib17
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib18: tib18
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib19: tib19
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 	tib20: tib20
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Offset: 0, -12
 
 shroud:
 	shroud: shroud
@@ -413,27 +433,39 @@ shroud:
 scorches: #TODO: make use of 07-12 as well
 	sc1: burnt01
 		Length: *
+		Offset: 0, -12
 	sc2: burnt02
 		Length: *
+		Offset: 0, -12
 	sc3: burnt03
 		Length: *
+		Offset: 0, -12
 	sc4: burnt04
 		Length: *
+		Offset: 0, -12
 	sc5: burnt05
 		Length: *
+		Offset: 0, -12
 	sc6: burnt06
 		Length: *
+		Offset: 0, -12
 
 craters: #TODO: make use of 07-12 as well
 	cr1: crater01
 		Length: *
+		Offset: 0, -12
 	cr2: crater02
 		Length: *
+		Offset: 0, -12
 	cr3: crater03
 		Length: *
+		Offset: 0, -12
 	cr4: crater04
 		Length: *
+		Offset: 0, -12
 	cr5: crater05
 		Length: *
+		Offset: 0, -12
 	cr6: crater06
 		Length: *
+		Offset: 0, -12

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -2,53 +2,69 @@ gacnst:
 	idle: gtcnst
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -36
 	damaged-idle: gtcnst
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -36
 	critical-idle: gtcnst
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -36
 	make: gtcnstmk
 		Start: 0
 		Length: 24
 		ShadowStart: 24
+		Offset: 0, -36
 	crane-overlay: gtcnst_d
 		Start: 0
 		Length: 20
+		Offset: 0, -36
 	damaged-crane-overlay: gtcnst_d
 		Start: 0
 		Length: 20
+		Offset: 0, -36
 	critical-crane-overlay: gtcnst_d
 		Start: 20
 		Length: 20
+		Offset: 0, -36
 	idle-top: gtcnst_c
 		Start: 0
 		Length: 15
 		Tick: 200
+		Offset: 0, -36
 	damaged-idle-top: gtcnst_c
 		Start: 15
 		Length: 15
 		Tick: 200
+		Offset: 0, -36
 	critical-idle-top: gtcnst_c
 		Start: 30
+		Offset: 0, -36
 	idle-side: gtcnst_a
 		Start: 0
 		Length: 10
+		Offset: 0, -36
 	damaged-idle-side: gtcnst_a
 		Start: 10
 		Length: 10
+		Offset: 0, -36
 	critical-idle-side: gtcnst_a
 		Start: 20
 		Length: 10
+		Offset: 0, -36
 	idle-front: gtcnst_b
 		Start: 0
 		Length: 10
+		Offset: 0, -36
 	damaged-idle-front: gtcnst_b
 		Start: 0
 		Length: 10
+		Offset: 0, -36
 	critical-idle-front: gtcnst_b
 		Start: 0
 		Length: 10
+		Offset: 0, -36
 	icon: facticon
 		Start: 0
 
@@ -56,40 +72,50 @@ gapowr:
 	idle: gtpowr
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: gtpowr
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: gtpowr
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	idle-lights: gtpowr_a
 		Start: 0
 		Length: 12
 		Tick: 200
+		Offset: 0, -24
 	damaged-idle-lights: gtpowr_a
 		Start: 12
 		Length: 12
 		Tick: 200
+		Offset: 0, -24
 	critical-idle-lights: gtpowr_a
 		Start: 24
 		Length: 12
 		Tick: 200
+		Offset: 0, -24
 	idle-plug: gtpowr_b
 		Start: 0
 		Length: 12
 		Tick: 200
+		Offset: 0, -24
 	damaged-idle-plug: gtpowr_b
 		Start: 0
 		Length: 12
 		Tick: 200
+		Offset: 0, -24
 	critical-idle-plug: gtpowr_b
 		Start: 0
 		Length: 12
 		Tick: 200
+		Offset: 0, -24
 	make: gtpowrmk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
+		Offset: 0, -24
 	icon: powricon
 		Start: 0
 
@@ -97,38 +123,48 @@ gapile:
 	idle: gtpile
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: gtpile
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: gtpile
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	production-lights: gtpile_a
 		Start: 0
 		Length: 7
 		Tick: 200
+		Offset: 0, -24
 	damaged-production-lights: gtpile_a
 		Start:7
 		Length: 7
 		Tick: 200
+		Offset: 0, -24
 	idle-light: gtpile_b
 		Start: 0
 		Length: 7
 		Tick: 200
+		Offset: 0, -24
 	damaged-idle-light: gtpile_b
 		Start:7
 		Length: 7
 		Tick: 200
+		Offset: 0, -24
 	idle-flag: gtpile_c
 		Start:0
 		Length: 7
+		Offset: 0, -24
 	damaged-idle-flag: gtpile_c
 		Start:7
 		Length: 7
+		Offset: 0, -24
 	make: gtpilemk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
+		Offset: 0, -24
 	icon: brrkicon
 		Start: 0
 
@@ -136,151 +172,158 @@ gaweap:
 	idle: gtweap
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-idle: gtweap
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, -12
+		Offset: -12, -42
 	dead: gtweap
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, -12
+		Offset: -12, -42
 	production-lights-white: gtweap_a
 		Start: 0
 		Length: 8
 		Tick: 100
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-production-lights-white: gtweap_a
 		Start: 8
 		Length: 8
 		Tick: 100
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	production-lights-red: gtweap_b
 		Start: 0
 		Length: 4
 		Tick: 120
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-production-lights-red: gtweap_b
 		Start: 4
 		Length: 4
 		Tick: 120
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	idle-turbines: gtweap_c
 		Start: 0
 		Length: 4
 		Tick: 80
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-idle-turbines: gtweap_c
 		Start: 0
 		Length: 4
 		Tick: 80
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	build-top: gtweap_d
 		Start: 0
 		Length: 9
 		ShadowStart: 9
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-build-top: gtweap_d
 		Start: 0
 		Length: 9
 		ShadowStart: 9
-		Offset: 0, -12
+		Offset: -12, -42
 	idle-top: gtweap_2
 		Start: 0
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-idle-top: gtweap_2
 		Start: 1
-		Offset: 0, -12
+		Offset: -12, -42
 	make: gtweapmk
 		Start: 0
 		Length: 20
 		Tick: 80
 		ShadowStart: 20
-		Offset: 0, -12
+		Offset: -12, -42
 	icon: weapicon
 		Start: 0
 	bib: gtweapbb
 		Start: 0
 		Length: 1
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-bib: gtweapbb
 		Start: 1
 		Length: 1
-		Offset: 0, -12
+		Offset: -12, -42
 	critical-bib: gtweapbb
 		Start: 2
 		Length: 1
-		Offset: 0, -12
+		Offset: -12, -42
 # TODO: gtweap_1 & gtweap_a & gtweap_b & gtweap_c are unused
 
 napowr:
 	idle: ntpowr
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: ntpowr
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: ntpowr
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	idle-lights: ntpowr_a
 		Start: 0
 		Length: 9
 		Tick: 200
+		Offset: 0, -24
 	damaged-idle-lights: ntpowr_a
 		Start: 9
 		Length: 9
 		Tick: 200
+		Offset: 0, -24
 	critical-idle-lights: ntpowr_a
 		Start: 9
 		Length: 9
 		Tick: 200
+		Offset: 0, -24
 	make: ntpowrmk
 		Start: 0
 		Length: 19
 		ShadowStart: 19
+		Offset: 0, -24
 	icon: npwricon
 		Start: 0
 
 naapwr:
 	idle: ntapwr
 		Start: 0
-		Offset: 12, -6
+		Offset: 12, -30
 		ShadowStart: 3
 	damaged-idle: ntapwr
 		Start: 1
 		ShadowStart: 4
-		Offset: 12, -6
+		Offset: 12, -30
 	critical-idle: ntapwr
 		Start: 2
 		ShadowStart: 5
-		Offset: 12, -6
+		Offset: 12, -30
 	idle-lights: ntapwr_a
 		Start: 0
 		Length: 9
 		Tick: 200
-		Offset: 12, -6
+		Offset: 12, -30
 	damaged-idle-lights: ntapwr_a
 		Start: 9
 		Length: 9
 		Tick: 200
-		Offset: 12, -6
+		Offset: 12, -30
 	critical-idle-lights: ntapwr_a
 		Start: 9
 		Length: 9
 		Tick: 200
-		Offset: 12, -6
+		Offset: 12, -30
 	make: ntapwrmk
 		Start: 0
 		Length: 19
 		ShadowStart: 19
-		Offset: 12, -6
+		Offset: 12, -30
 	icon: apwricon
 		Start: 0
 
@@ -288,40 +331,40 @@ nahand:
 	idle: nthand
 		Start: 0
 		ShadowStart: 3
-		Offset: -6, -6
+		Offset: -6, -30
 	damaged-idle: nthand
 		Start: 1
 		ShadowStart: 4
-		Offset: -6, -6
+		Offset: -6, -30
 	critical-idle: nthand
 		Start: 2
 		ShadowStart: 5
-		Offset: -6, -6
+		Offset: -6, -30
 	production-light: nthand_a
 		Start: 0
 		Length: 5
 		Tick: 100
-		Offset: -6, -6
+		Offset: -6, -30
 	damaged-production-light: nthand_a
 		Start: 5
 		Length: 5
 		Tick: 100
-		Offset: -6, -6
+		Offset: -6, -30
 	idle-lights: nthand_b
 		Start: 0
 		Length: 8
 		Tick: 200
-		Offset: -6, -6
+		Offset: -6, -30
 	damaged-idle-lights: nthand_b
 		Start: 8
 		Length: 8
 		Tick: 200
-		Offset: -6, -6
+		Offset: -6, -30
 	make: nthandmk
 		Start: 0
 		Length: 15
 		ShadowStart: 15
-		Offset: -6, -6
+		Offset: -6, -30
 	icon: handicon
 		Start: 0
 
@@ -329,87 +372,93 @@ naweap:
 	idle: ntweap
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-idle: ntweap
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, -12
+		Offset: -12, -42
 	dead: ntweap
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, -12
+		Offset: -12, -42
 	production-lights: ntweap_a
 		Start: 0
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-production-lights: ntweap_a
 		Start: 16
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
-		Offset: 0, -12
+		Offset: -12, -42
 	build-top: ntweap_b
 		Start: 0
 		Length: 10
 		ShadowStart: 10
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-build-top: ntweap_b
 		Start: 10
 		Length: 10
 		ShadowStart: 20
-		Offset: 0, -12
+		Offset: -12, -42
 	idle-top: ntweap_2
 		Start: 0
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-idle-top: ntweap_2
 		Start: 1
-		Offset: 0, -12
+		Offset: -12, -42
 	make: ntweapmk
 		Start: 0
 		Length: 22
 		Tick: 80
 		ShadowStart: 22
-		Offset: 0, -12
+		Offset: -12, -42
 	icon: nwepicon
 		Start: 0
 	bib: ntweapbb
 		Start: 0
 		Length: 1
-		Offset: 0, -12
+		Offset: -12, -42
 	damaged-bib: ntweapbb
 		Start: 1
 		Length: 1
-		Offset: 0, -12
+		Offset: -12, -42
 	critical-bib: ntweapbb
 		Start: 2
 		Length: 1
-		Offset: 0, -12
+		Offset: -12, -42
 # TODO: ntweap_1 & ntweap_b & ntweap_c are unused
 
 naradr:
 	idle: ntradr
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: ntradr
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 #	critical-idle: ntradr	#shows a destroyed dish
 #		Start: 2
 #		ShadowStart: 5
+#		Offset: 0, -24
 	idle-dish: ntradr_a
 		Start: 0
 		Length: 24
 		Tick: 120
+		Offset: 0, -24
 	damaged-idle-dish: ntradr_a
 		Start: 24
 		Length: 24
 		Tick: 120
+		Offset: 0, -24
 	make: ntradrmk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
+		Offset: 0, -24
 	icon: nradicon
 		Start: 0
 
@@ -417,28 +466,35 @@ natech:
 	idle: nttech
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: nttech
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: nttech
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	idle-lights: nttech_a
 		Start: 0
 		Length: 9
 		Tick: 120
+		Offset: 0, -24
 	damaged-idle-lights: nttech_a
 		Start: 0
 		Length: 9
 		Tick: 120
+		Offset: 0, -24
 	critical-idle-lights: nttech_a
 		Start: 0
 		Length: 9
 		Tick: 120
+		Offset: 0, -24
 	make: nttechmk
 		Start: 0
 		Length: 18
 		ShadowStart: 18
+		Offset: 0, -24
 	icon: ntchicon
 		Start: 0
 
@@ -446,24 +502,30 @@ garadr:
 	idle: gtradr
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: gtradr
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 #	critical-idle: gtradr	#shows a destroyed radar dish
 #		Start: 2
 #		ShadowStart: 5
+#		Offset: 0, -24
 	idle-dish: gtradr_a
 		Frames: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
 		Length: 28
 		Tick: 200
+		Offset: 0, -24
 	damaged-idle-dish: gtradr_a
 		Frames: 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
 		Length: 28
 		Tick: 240
+		Offset: 0, -24
 	make: gtradrmk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
+		Offset: 0, -24
 	icon: radricon
 		Start: 0
 
@@ -471,35 +533,35 @@ gatech:
 	idle: gttech
 		Start: 0
 		ShadowStart: 3
-		Offset: -12, -6
+		Offset: -12, -30
 	damaged-idle: gttech
 		Start: 1
 		ShadowStart: 4
-		Offset: -12, -6
+		Offset: -12, -30
 	critical-idle: gttech
 		Start: 2
 		ShadowStart: 5
-		Offset: -12, -6
+		Offset: -12, -30
 	idle-lights: gttech_a
 		Start: 0
 		Length: 8
 		Tick: 200
-		Offset: -12, -6
+		Offset: -12, -30
 	damaged-idle-lights: gttech_a
 		Start: 8
 		Length: 8
 		Tick: 240
-		Offset: -12, -6
+		Offset: -12, -30
 	critical-idle-lights: gttech_a
 		Start: 8
 		Length: 8
 		Tick: 240
-		Offset: -12, -6
+		Offset: -12, -30
 	make: gttechmk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
-		Offset: -12, -6
+		Offset: -12, -30
 	icon: techicon
 		Start: 0
 
@@ -508,12 +570,12 @@ gasand:
 		Start: 0
 		Length: 16
 		ShadowStart: 32
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: gtsand
 		Start: 16
 		Length: 16
 		ShadowStart: 48
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: sbagicon
 		Start: 0
 
@@ -522,17 +584,17 @@ gawall:
 		Start: 0
 		Length: 16
 		ShadowStart: 48
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: gtwall
 		Start: 16
 		Length: 16
 		ShadowStart: 64
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle: gtwall
 		Start: 32
 		Length: 16
 		ShadowStart: 80
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: wallicon
 		Start: 0
 
@@ -541,17 +603,17 @@ nawall:
 		Start: 0
 		Length: 16
 		ShadowStart: 48
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: ntwall
 		Start: 16
 		Length: 16
 		ShadowStart: 64
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle: ntwall
 		Start: 32
 		Length: 16
 		ShadowStart: 80
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: nwalicon
 		Start: 0
 
@@ -580,28 +642,34 @@ gaicbm:
 		Start: 0
 		Facings: 1
 		ShadowStart: 3
+		Offset: 0,-12
 	damaged-idle:
 		Start: 1
 		Facings: 1
 		ShadowStart: 4
+		Offset: 0,-12
 	make: gaicbmmk
 		Start: 0
 		Length: 30
 		ShadowStart: 30
+		Offset: 0,-12
 
 gadpsa:
 	idle:
 		Start: 0
 		Facings: 1
 		ShadowStart: 3
+		Offset: 0,-12
 	damaged-idle:
 		Start: 1
 		Facings: 1
 		ShadowStart: 4
+		Offset: 0,-12
 	make: gadpsamk
 		Start: 0
 		Length: 36
 		ShadowStart: 36
+		Offset: 0,-12
 
 gaarty:
 	idle:
@@ -627,28 +695,35 @@ naobel:
 	idle: ntobel
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: ntobel
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: ntobel
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	active: ntobel #placeholder until Charge supports overlays
 		Start: 0
 		Length: 1
 		ShadowStart: 3
+		Offset: 0, -24
 #	active: ntobel_b
 #		Start: 0
 #		Length: 12
 #		Tick: 240
+#		Offset: 0, -24
 	idle-lights: ntobel_a
 		Start: 0
 		Length: 12
 		Tick: 80
+		Offset: 0, -24
 	make: ntobelmk
 		Start: 0
 		Length: 19
 		ShadowStart: 19
+		Offset: 0, -24
 	icon: obliicon
 		Start: 0
 
@@ -656,20 +731,20 @@ nalasr:
 	idle: ntlasr
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: ntlasr
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle: ntlasr
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, 12
+		Offset: 0, -12
 	make: ntlasrmk
 		Start: 0
 		Length: 21
 		ShadowStart: 21
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: plticon
 		Start: 0
 
@@ -677,24 +752,24 @@ nasam:
 	idle: ntsam
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: ntsam
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle: ntsam
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, 12
+		Offset: 0, -12
 	turret: gtctwr_d
 		Start: 0
 		Facings: 32
-		Offset: 0,10
+		Offset: -4, 0
 	make: ntsammk
 		Start: 0
 		Length: 8
 		ShadowStart: 8
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: samicon
 		Start: 0
 
@@ -702,19 +777,24 @@ napuls:
 	idle: ntpuls
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: ntpuls
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: ntpuls
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	turret: ntpuls_a
 		Start: 0
 		Facings: 32
+		Offset: 0, -24
 	make: ntpulsmk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
+		Offset: 0, -24
 	icon: pulsicon
 		Start: 0
 
@@ -722,71 +802,71 @@ gavulc:
 	idle: gtctwr
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: gtctwr
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle: gtctwr
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, 12
+		Offset: 0, -12
 	turret: gtctwr_b
 		Start: 0
 		Facings: 32
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle0: mgun-n
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle1: mgun-nw
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle2: mgun-w
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle3: mgun-sw
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle4: mgun-s
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle5: mgun-se
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle6: mgun-e
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	muzzle7: mgun-ne
 		Start: 0
 		Length: *
-		Offset: 0, 12
+		Offset: 0, -12
 	idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle-lights: gtctwr_a
 		Start: 6
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	make: gtctwrmk
 		Start: 0
 		Length: 11
 		ShadowStart: 11
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: twr1icon
 		Start: 0
 
@@ -794,39 +874,39 @@ garock:
 	idle: gtctwr
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: gtctwr
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle: gtctwr
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, 12
+		Offset: 0, -12
 	turret: gtctwr_c
 		Start: 0
 		Facings: 32
-		Offset: 0, 12
+		Offset: 0, -12
 	idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle-lights: gtctwr_a
 		Start: 6
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	make: gtctwrmk
 		Start: 0
 		Length: 11
 		ShadowStart: 11
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: twr2icon
 		Start: 0
 
@@ -834,39 +914,39 @@ gacsam:
 	idle: gtctwr
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: gtctwr
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle: gtctwr
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, 12
+		Offset: 0, -12
 	turret: gtctwr_d
 		Start: 0
 		Facings: 32
-		Offset: 0, 12
+		Offset: 0, -12
 	idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle-lights: gtctwr_a
 		Start: 6
 		Length: 6
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	make: gtctwrmk
 		Start: 0
 		Length: 11
 		ShadowStart: 11
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: twr3icon
 		Start: 0
 
@@ -874,35 +954,35 @@ gaspot:
 	idle:
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, 12
+		Offset: 0, -12
 	idle-lights: gaspot_a
 		Start: 0
 		Length: 8
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle-lights: gaspot_a
 		Start: 8
 		Length: 8
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	critical-idle-lights: gaspot_a
 		Start: 16
 		Length: 8
 		Tick: 200
-		Offset: 0, 12
+		Offset: 0, -12
 	make: gaspotmk
 		Start: 0
 		Length: 14
 		ShadowStart: 14
-		Offset: 0, 12
+		Offset: 0, -12
 	icon: spoticon
 		Start: 0
 
@@ -910,40 +990,47 @@ gahpad:
 	idle: gthpad
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: gthpad
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: gthpad
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	idle-platform: gthpadbb
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle-platform: gthpadbb
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle-platform: gthpadbb
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	idle-lights: gthpad_a
 		Start: 0
 		Length: 8
 		Tick: 200
-		Offset:0, -12
+		Offset: 0, -36
 	damaged-idle-lights: gthpad_a
 		Start: 8
 		Length: 8
 		Tick: 200
-		Offset:0, -12
+		Offset: 0, -36
 	critical-idle-lights: gthpad_a
 		Start: 16
 		Length: 8
 		Tick: 200
-		Offset:0, -12
+		Offset: 0, -36
 	make: gthpadmk
 		Start: 0
 		Length: 18
 		ShadowStart: 18
+		Offset: 0, -24
 	icon: heliicon
 		Start: 0
 
@@ -951,40 +1038,50 @@ nahpad:
 	idle: nthpad
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle: nthpad
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle: nthpad
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	idle-platform: nthpadbb
 		Start: 0
 		ShadowStart: 3
+		Offset: 0, -24
 	damaged-idle-platform: nthpadbb
 		Start: 1
 		ShadowStart: 4
+		Offset: 0, -24
 	critical-idle-platform: nthpadbb
 		Start: 2
 		ShadowStart: 5
+		Offset: 0, -24
 	idle-lights: nthpad_a
 		Start: 0
 		Length: 46
 #		Offset: 2,-12
+		Offset: 0, -24
 		Tick: 120
 	damaged-idle-lights: nthpad_a
 		Start: 46
 		Length: 46
 #		Offset: 16,-16
 		Tick: 120
+		Offset: 0, -24
 	critical-idle-lights: nthpad_a
 		Start: 46
 		Length: 46
 #		Offset: 24,-24
 		Tick: 200
+		Offset: 0, -24
 	make: nthpadmk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
+		Offset: 0, -24
 	icon: nhpdicon
 		Start: 0
 
@@ -992,47 +1089,47 @@ proc: # TODO: unused narefn_a, narefn_b
 	idle: ntrefn
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, -24
+		Offset: -12, -42
 	damaged-idle: ntrefn
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, -24
+		Offset: -12, -42
 	critical-idle: ntrefn
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, -24
+		Offset: -12, -42
 	make: ntrefnmk
 		Start: 0
 		Length: 20
 		ShadowStart: 20
-		Offset: 0, -24
+		Offset: -12, -42
 	idle-redlights: ntrefn_c
 		Start: 0
 		Length: 16
 		Tick: 120
-		Offset: 0, -24
+		Offset: -12, -42
 	damaged-idle-redlights: ntrefn_c
 		Start: 0
 		Length: 16
 		Tick: 120
-		Offset: 0, -24
+		Offset: -12, -42
 	critical-idle-redlights: ntrefn_c
 		Start: 16
 		Length: 16
 		Tick: 200
-		Offset: 0, -24
+		Offset: -12, -42
 	bib: ntrefnbb
 		Start: 0
 		Length: 1
-		Offset: 0, -24
+		Offset: -12, -42
 	damaged-bib: ntrefnbb
 		Start: 1
 		Length: 1
-		Offset: 0, -24
+		Offset: -12, -42
 	critical-bib: ntrefnbb
 		Start: 2
 		Length: 1
-		Offset: 0, -24
+		Offset: -12, -42
 	icon: reficon
 		Start: 0
 
@@ -1040,49 +1137,58 @@ gasilo:
 	idle: gtsilo_a
 		Start: 0
 		Length: 4
+		Offset: 0, -24
 	damaged-idle: gtsilo_a
 		Start: 4
 		Length: 4
+		Offset: 0, -24
 	idle-underlay: gtsilo
 		Start: 0
 		ShadowStart: 3
 		ZOffset: -512
+		Offset: 0, -24
 	damaged-idle-underlay: gtsilo
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -512
+		Offset: 0, -24
 	critical-idle-underlay: gtsilo
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -512
+		Offset: 0, -24
 	idle-lights: gtsilo_b
 		Start: 0
 		Length: 16
 		Tick: 120
+		Offset: 0, -24
 	damaged-idle-lights: gtsilo_b
 		Start: 16
 		Length: 16
 		Tick: 120
+		Offset: 0, -24
 	critical-idle-lights: gtsilo_b
 		Start: 32
 		Length: 16
 		Tick: 200
+		Offset: 0, -24
 	icon: siloicon
 		Start: 0
 	make: gtsilomk
 		Start: 0
 		Length: 18
 		ShadowStart: 20
+		Offset: 0, -24
 
 galite:
 	idle: gtlite
 		Start: 0
 		ShadowStart: 2
-		Offset: 0, 12
+		Offset: 0, -12
 	damaged-idle: gtlite
 		Start: 1
 		ShadowStart: 3
-		Offset: 0, 12
+		Offset: 0, -12
 #	lighting: alphatst
 #		Start: 0
 #		ZOffset: -1c511
@@ -1094,69 +1200,69 @@ gadept:
 	idle: gtdept
 		Start: 0
 		ShadowStart: 3
-		Offset: 0, -12
+		Offset: 0, -36
 	damaged-idle: gtdept
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, -12
+		Offset: 0, -36
 	critical-idle: gtdept
 		Start: 2
 		ShadowStart: 5
-		Offset: 0, -12
+		Offset: 0, -36
 	ground: gtdeptbb
 		Start: 0
 		ShadowStart: 3
 		ZOffset: -1c611
-		Offset: 0, -12
+		Offset: 0, -36
 	damaged-ground: gtdeptbb
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -1c611
-		Offset: 0, -12
+		Offset: 0, -36
 	critical-ground: gtdeptbb
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -1c611
-		Offset: 0, -12
+		Offset: 0, -36
 	idle-light: gtdept_b
 		Start: 0
 		Length: 7
 		Tick: 120
-		Offset: 0, -12
+		Offset: 0, -36
 	damaged-idle-light: gtdept_b
 		Start: 7
 		Length: 7
 		Tick: 120
-		Offset: 0, -12
+		Offset: 0, -36
 	circuits: gtdept_a
 		Start: 0
 		Length: 5
 		ZOffset: -1c511
-		Offset: 0, -12
+		Offset: 0, -36
 	damaged-circuits: gtdept_a
 		Start: 5
 		Length: 5
 		ZOffset: -1c511
-		Offset: 0, -12
+		Offset: 0, -36
 	crane: gtdept_c
 		Start: 0
 		Length: 16
-		Offset: 0, -12
+		Offset: 0, -36
 	platform: gtdept_d
 		Start: 0
 		Length: 7
 		ZOffset: -1c511
-		Offset: 0, -12
+		Offset: 0, -36
 	damaged-platform: gtdept_d
 		Start: 7
 		Length: 7
 		ZOffset: -1c511
-		Offset: 0, -12
+		Offset: 0, -36
 	make: gtdeptmk
 		Start: 0
 		Length: 10
 		Tick: 60
 		ShadowStart: 10
-		Offset: 0, -12
+		Offset: 0, -36
 	icon: fixicon
 		Start: 0

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -3,41 +3,49 @@ tibtre01:
 		Start: 0
 		Length: 1
 		ShadowStart: 11
+		Offset: 0, -12
 	active:
 		Start: 1
 		Length: 10
 		ShadowStart: 12
 		Tick: 160
+		Offset: 0, -12
 
 tibtre02:
 	idle:
 		Start: 0
 		Length: 1
 		ShadowStart: 11
+		Offset: 0, -12
 	active:
 		Start: 1
 		Length: 10
 		ShadowStart: 12
 		Tick: 160
+		Offset: 0, -12
 
 tibtre03:
 	idle:
 		Start: 0
 		Length: 1
 		ShadowStart: 11
+		Offset: 0, -12
 	active:
 		Start: 1
 		Length: 10
 		ShadowStart: 12
 		Tick: 160
+		Offset: 0, -12
 
 bigblue:
 	idle:
 		Start: 0
 		Length: 1
 		ShadowStart: 10
+		Offset: 0, -12
 	active:
 		Start: 1
 		Length: 9
 		ShadowStart: 11
 		Tick: 160
+		Offset: 0, -12

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -154,19 +154,16 @@ smech:
 		Start: 96
 		Facings: -8
 		ShadowStart: 232
-		Offset: 0, 8
 	run:
 		Start: 0
 		Facings: -8
 		Length: 12
 		ShadowStart: 136
-		Offset: 0, 8
 	shoot:
 		Start: 104
 		Length: 4
 		Facings: -8
 		ShadowStart: 240
 		Tick: 100
-		Offset: 0, 8
 	icon: smchicon
 		Start: 0


### PR DESCRIPTION
I had suspected that the offsets were still wrong, but didn't have time to look at them properly until now.

Turns out they were a mess. I used TS' own blank01 tile as test grid and whipped the offsets into shape.
Additionally, I set okayish selection bounds for structures as temporary solution until we have proper isometric selection boxes.
Finally, the fixed offsets allowed to fix the factory exits as well.
