### PR TITLE
Revert "build with latest Mono from @Xamarin"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ language: c
 
 # Make sure build dependencies are installed.
 install:
- - wget http://download.mono-project.com/repo/xamarin.gpg -O /tmp/mono.gpg
- - sudo apt-key add /tmp/mono.gpg
- - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo apt-get update -qq
- - sudo apt-get install -qq mono-gmcs cli-common-dev libgl1-mesa-glx libopenal1 libfreetype6 libgdiplus=2.10-3
+ - sudo apt-get install -qq mono-gmcs cli-common-dev libgl1-mesa-glx libopenal1 libfreetype6
 cache: apt
 
 # Run the build script


### PR DESCRIPTION
Mono 3.10 appears to ship a broken compiler that chokes on ternary statements.  This is causing our travis tests to fail.
