### PR TITLE
Gave medic and mechanic lower selection priorities

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -278,6 +278,7 @@ MEDI:
 		Name: Medic
 		Description: Heals nearby infantry.\n  Strong vs Nothing\n  Weak vs Everything
 	Selectable:
+		Priority: 5
 		Voice: MedicVoice
 		Bounds: 12,17,0,-9
 	Health:
@@ -313,6 +314,7 @@ MECH:
 		Name: Mechanic
 		Description: Repairs nearby vehicles and restores\nhusks to working condition.\n  Strong vs Nothing\n  Weak vs Everything
 	Selectable:
+		Priority: 6
 		Voice: MechanicVoice
 		Bounds: 12,17,0,-9
 	Health:


### PR DESCRIPTION
It is currently quite hard to micro manage them in huge infantry crowds. They won't stay behind your front-line on their own and I usually waste them when attack moving everything towards the enemy. Now they will stay behind, which is a good default in those cases.
