### PR TITLE
Added player name and color selection to Settings menu

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -121,6 +121,7 @@
     <Compile Include="SpriteLoaders\TmpRALoader.cs" />
     <Compile Include="SpriteLoaders\TmpTDLoader.cs" />
     <Compile Include="SpriteLoaders\ShpD2Loader.cs" />
+    <Compile Include="Widgets\Logic\SettingsLogic.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (colorDropdown != null)
 			{
 				colorDropdown.IsDisabled = () => currentPalette != colorPreview.PaletteName;
-				colorDropdown.OnMouseDown = _ => ShowColorDropDown(colorDropdown, colorPreview, world);
+				colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorPreview, world);
 				panel.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => Game.Settings.Player.Color.RGB;
 			}
 
@@ -375,27 +375,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var palettes = world.WorldActor.TraitsImplementing<PaletteFromFile>();
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 280, palettes, setupItem);
 			return true;
-		}
-
-		static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
-		{
-			Action onExit = () =>
-			{
-				Game.Settings.Player.Color = preview.Color;
-				Game.Settings.Save();
-			};
-
-			color.RemovePanel();
-
-			Action<HSLColor> onChange = c => preview.Color = c;
-
-			var colorChooser = Game.LoadWidget(world, "COLOR_CHOOSER", null, new WidgetArgs()
-			{
-				{ "onChange", onChange },
-				{ "initialColor", Game.Settings.Player.Color }
-			});
-
-			color.AttachPanel(colorChooser, onExit);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -52,6 +52,27 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			hueSlider.Value = initialColor.H / 255f;
 			onChange(mixer.Color);
 		}
+
+		public static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
+		{
+			Action onExit = () =>
+			{
+				Game.Settings.Player.Color = preview.Color;
+				Game.Settings.Save();
+			};
+
+			color.RemovePanel();
+
+			Action<HSLColor> onChange = c => preview.Color = c;
+
+			var colorChooser = Game.LoadWidget(world, "COLOR_CHOOSER", null, new WidgetArgs()
+			{
+				{ "onChange", onChange },
+				{ "initialColor", Game.Settings.Player.Color }
+			});
+
+			color.AttachPanel(colorChooser, onExit);
+		}
 	}
 }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -13,10 +13,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Widgets;
 
-namespace OpenRA.Mods.RA.Widgets.Logic
+namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class SettingsLogic
 	{
@@ -196,6 +195,21 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			frameLimitTextfield.OnEnterKey = () => { frameLimitTextfield.YieldKeyboardFocus(); return true; };
 			frameLimitTextfield.IsDisabled = () => !ds.CapFramerate;
 
+			// Player profile
+			var ps = Game.Settings.Player;
+
+			var nameTextfield = panel.Get<TextFieldWidget>("PLAYERNAME");
+			nameTextfield.Text = ps.Name;
+			nameTextfield.OnEnterKey = () => { nameTextfield.YieldKeyboardFocus(); return true; };
+			nameTextfield.OnLoseFocus = () => { ps.Name = nameTextfield.Text; };
+
+			var colorPreview = panel.Get<ColorPreviewManagerWidget>("COLOR_MANAGER");
+			colorPreview.Color = ps.Color;
+
+			var colorDropdown = panel.Get<DropDownButtonWidget>("PLAYERCOLOR");
+			colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorPreview, worldRenderer.world);
+			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => ps.Color.RGB;
+
 			return () =>
 			{
 				int x, y;
@@ -203,6 +217,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				Exts.TryParseIntegerInvariant(windowHeight.Text, out y);
 				ds.WindowedSize = new int2(x, y);
 				frameLimitTextfield.YieldKeyboardFocus();
+				nameTextfield.YieldKeyboardFocus();
 			};
 		}
 
@@ -210,8 +225,10 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		{
 			var ds = Game.Settings.Graphics;
 			var gs = Game.Settings.Game;
+			var ps = Game.Settings.Player;
 			var dds = new GraphicSettings();
 			var dgs = new GameSettings();
+			var dps = new PlayerSettings();
 			return () =>
 			{
 				gs.ShowShellmap = dgs.ShowShellmap;
@@ -225,6 +242,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				ds.PixelDouble = dds.PixelDouble;
 				ds.CursorDouble = dds.CursorDouble;
 				worldRenderer.Viewport.Zoom = ds.PixelDouble ? 2 : 1;
+
+				ps.Color = dps.Color;
+				ps.Name = dps.Name;
 			};
 		}
 

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -420,7 +420,6 @@
     <Compile Include="Widgets\Logic\InstallLogic.cs" />
     <Compile Include="CombatDebugOverlay.cs" />
     <Compile Include="World\PathfinderDebugOverlay.cs" />
-    <Compile Include="Widgets\Logic\SettingsLogic.cs" />
     <Compile Include="AttackBomber.cs" />
     <Compile Include="ShroudRenderer.cs" />
     <Compile Include="Render\WithCrateBody.cs" />

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -47,7 +47,7 @@ Container@SETTINGS_PANEL:
 							Y: 20
 							Width: PARENT_RIGHT
 							Font: Bold
-							Text: Graphics
+							Text: Display
 							Align: Center
 						Label@MODE_LABEL:
 							X: 120

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -152,6 +152,29 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Show Shellmap
+						Label@PLAYER:
+							Text: Player:
+							X: 15
+							Y: 215
+						TextField@PLAYERNAME:
+							Text: Name
+							X: 65
+							Y: 205
+							Width: 145
+							Height: 25
+							MaxLength: 16
+						ColorPreviewManager@COLOR_MANAGER:
+						DropDownButton@PLAYERCOLOR:
+							X: 215
+							Y: 205
+							Width: 70
+							Height: 25
+							Children:
+								ColorBlock@COLORBLOCK:
+									X: 5
+									Y: 6
+									Width: PARENT_RIGHT-35
+									Height: PARENT_BOTTOM-12
 						Checkbox@ALWAYS_SHOW_STATUS_BARS_CHECKBOX:
 							X: 310
 							Y: 205

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -165,6 +165,29 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Show Shellmap
+				Label@PLAYER:
+					Text: Player:
+					X: 15
+					Y: 215
+				TextField@PLAYERNAME:
+					Text: Name
+					X: 65
+					Y: 205
+					Width: 145
+					Height: 25
+					MaxLength: 16
+				ColorPreviewManager@COLOR_MANAGER:
+				DropDownButton@PLAYERCOLOR:
+					X: 215
+					Y: 205
+					Width: 70
+					Height: 25
+					Children:
+						ColorBlock@COLORBLOCK:
+							X: 5
+							Y: 6
+							Width: PARENT_RIGHT-35
+							Height: PARENT_BOTTOM-12
 				Checkbox@ALWAYS_SHOW_STATUS_BARS_CHECKBOX:
 					X: 310
 					Y: 205


### PR DESCRIPTION
The player settings had not been ported from the Tiberian Dawn UI in https://github.com/OpenRA/OpenRA/pull/3991. This brings them back as outlined in https://github.com/OpenRA/OpenRA/issues/6380 to serve as an alternative to the troubled lobby when it is not empty. https://github.com/OpenRA/OpenRA/issues/5802
