### PR TITLE
Moving generic RTS code from OpenRA.Mods.RA to OpenRA.Mods.Common [Superseded]

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Graphics\VoxelActorPreview.cs" />
     <Compile Include="Graphics\VoxelRenderable.cs" />
     <Compile Include="ModChooserLoadScreen.cs" />
+    <Compile Include="Orders\DeployOrderTargeter.cs" />
     <Compile Include="PaletteFromFile.cs" />
     <Compile Include="RallyPoint.cs" />
     <Compile Include="ServerTraits\ColorValidator.cs" />

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -12,7 +12,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Orders
+namespace OpenRA.Mods.Common.Orders
 {
 	public class DeployOrderTargeter : IOrderTargeter
 	{

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -8,13 +8,13 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
-using OpenRA.Mods.RA.Air;
-using OpenRA.Primitives;
+using System.Collections.Generic;
 using OpenRA.Traits;
+using OpenRA.Primitives;
+using OpenRA.Mods.RA.Air;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.Common.Orders;
 
 namespace OpenRA.Mods.RA
 {

--- a/OpenRA.Mods.RA/DemoTruck.cs
+++ b/OpenRA.Mods.RA/DemoTruck.cs
@@ -8,11 +8,12 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
-using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
+using System.Collections.Generic;
 using OpenRA.Traits;
+using OpenRA.Mods.RA.Orders;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.Common.Orders;
 
 namespace OpenRA.Mods.RA
 {

--- a/OpenRA.Mods.RA/MadTank.cs
+++ b/OpenRA.Mods.RA/MadTank.cs
@@ -8,16 +8,16 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.GameRules;
-using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Move;
-using OpenRA.Mods.RA.Orders;
-using OpenRA.Mods.RA.Render;
-using OpenRA.Primitives;
+using System.Drawing;
+using System.Collections.Generic;
 using OpenRA.Traits;
+using OpenRA.Primitives;
+using OpenRA.Mods.RA.Move;
+using OpenRA.Mods.RA.Render;
+using OpenRA.Mods.RA.Orders;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.Common.Orders;
 
 namespace OpenRA.Mods.RA
 {

--- a/OpenRA.Mods.RA/Minelayer.cs
+++ b/OpenRA.Mods.RA/Minelayer.cs
@@ -9,12 +9,12 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+using OpenRA.Traits;
 using OpenRA.Graphics;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
-using OpenRA.Traits;
+using OpenRA.Mods.Common.Orders;
 
 namespace OpenRA.Mods.RA
 {

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -255,7 +255,6 @@
     <Compile Include="NukePaletteEffect.cs" />
     <Compile Include="NullLoadScreen.cs" />
     <Compile Include="LoadWidgetAtGameStart.cs" />
-    <Compile Include="Orders\DeployOrderTargeter.cs" />
     <Compile Include="Orders\PlaceBuildingOrderGenerator.cs" />
     <Compile Include="Orders\PowerDownOrderGenerator.cs" />
     <Compile Include="Orders\RepairOrderGenerator.cs" />

--- a/OpenRA.Mods.RA/PortableChrono.cs
+++ b/OpenRA.Mods.RA/PortableChrono.cs
@@ -8,13 +8,13 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
+using System.Collections.Generic;
+using OpenRA.Traits;
 using OpenRA.Graphics;
 using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Graphics;
-using OpenRA.Mods.RA.Orders;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA
 {

--- a/OpenRA.Mods.RA/PrimaryBuilding.cs
+++ b/OpenRA.Mods.RA/PrimaryBuilding.cs
@@ -8,10 +8,10 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.RA.Orders;
+using System.Collections.Generic;
 using OpenRA.Traits;
+using OpenRA.Mods.Common.Orders;
 
 namespace OpenRA.Mods.RA
 {

--- a/OpenRA.Mods.RA/Transforms.cs
+++ b/OpenRA.Mods.RA/Transforms.cs
@@ -9,11 +9,11 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Orders;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
+using OpenRA.Mods.RA.Render;
+using OpenRA.Mods.RA.Buildings;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.Common.Orders;
 
 namespace OpenRA.Mods.RA
 {


### PR DESCRIPTION
- Moved a sizeable chunk of the Traits, Activities and Orders from the RA mod project to Common
- Fixed classes in OpenRA.Mods.D2k project being declared in namespace OpenRA.Mods.RA
- Dune 2000 and Tiberian Sun mods no longer have ANY dependencies on OpenRA.Mods.RA
- Restructured refinery-related code

Yes, it is a big commit, but it should get the job done. Anything that is left to be moved should be transferable with simple editions to the using statements and the namespace.
