### PR TITLE
[TS] Add Nod Stealth Generator and GDI TechCenter to the AI 

### DIFF
--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -20,6 +20,9 @@ Player:
 			garadr: 1
 			gaweap: 1
 			naweap: 1
+			nastlh: 1
+			naradr: 1
+			natech: 1
 		BuildingFractions:
 			proc: 30%
 			gapowr: 35%
@@ -28,13 +31,18 @@ Player:
 			nahand: 1%
 			gaweap: 1%
 			naweap: 1%
+			gatech: 1%
+			naradr: 1%
+			garadr: 1%
+			natech: 1%
+			nastlh: 1%
 		UnitsToBuild:
 			e1: 80%
 			e2: 8%
 			e3: 30%
 			medic: 2%
 			jumpjet: 15%
-			apc: 3%
+			mmch: 3%
 			smech: 25%
 			bike: 60%
 			bggy: 75%

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -17,12 +17,13 @@ Player:
 			napowr: 8
 			gapile: 1
 			nahand: 1
-			garadr: 1
 			gaweap: 1
 			naweap: 1
-			nastlh: 1
+			garadr: 1
 			naradr: 1
+			gatech: 1
 			natech: 1
+			nastlh: 1
 		BuildingFractions:
 			proc: 30%
 			gapowr: 35%
@@ -31,9 +32,9 @@ Player:
 			nahand: 1%
 			gaweap: 1%
 			naweap: 1%
-			gatech: 1%
-			naradr: 1%
 			garadr: 1%
+			naradr: 1%
+			gatech: 1%
 			natech: 1%
 			nastlh: 1%
 		UnitsToBuild:
@@ -42,7 +43,7 @@ Player:
 			e3: 30%
 			medic: 2%
 			jumpjet: 15%
-			mmch: 3%
+			mmch: 15%
 			smech: 25%
 			bike: 60%
 			bggy: 75%


### PR DESCRIPTION
The AI can now build:
- Nod Stealth Generator (Nod)
- Tech Center (Nod & GDI)
- Radar (Nod & GDI)
- Replaced GDI Transport (apc) with GDI Titan (mmch)

![untitled](https://cloud.githubusercontent.com/assets/2057932/4539383/5b747fb2-4dfc-11e4-8311-1bee2f0e8fa8.jpg)
