### PR TITLE
Small memory savings

### DIFF
--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -77,12 +77,12 @@ namespace OpenRA.Graphics
 				Flush();
 
 			vertices[nv++] = new Vertex(start + offset,
-				new float2(startColor.R / 255.0f, startColor.G / 255.0f),
-				new float2(startColor.B / 255.0f, startColor.A / 255.0f));
+				startColor.R / 255.0f, startColor.G / 255.0f,
+				startColor.B / 255.0f, startColor.A / 255.0f);
 
 			vertices[nv++] = new Vertex(end + offset,
-				new float2(endColor.R / 255.0f, endColor.G / 255.0f),
-				new float2(endColor.B / 255.0f, endColor.A / 255.0f));
+				endColor.R / 255.0f, endColor.G / 255.0f,
+				endColor.B / 255.0f, endColor.A / 255.0f);
 		}
 
 		public void FillRect(RectangleF r, Color color)

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Graphics
 						var mapX = x + b.Left;
 						var mapY = y + b.Top;
 						var custom = map.CustomTerrain[mapX, mapY];
-						if (custom == -1)
+						if (custom == byte.MaxValue)
 							continue;
 						colors[y * stride + x] = world.TileSet[custom].Color.ToArgb();
 					}

--- a/OpenRA.Game/Graphics/QuadRenderer.cs
+++ b/OpenRA.Game/Graphics/QuadRenderer.cs
@@ -43,17 +43,21 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public void FillRect(RectangleF r, Color color)
+		public void FillRect(RectangleF rect, Color color)
 		{
 			Renderer.CurrentBatchRenderer = this;
 
 			if (nv + 4 > Renderer.TempBufferSize)
 				Flush();
 
-			vertices[nv] = new Vertex(new float2(r.Left, r.Top), new float2(color.R / 255.0f, color.G / 255.0f), new float2(color.B / 255.0f, color.A / 255.0f));
-			vertices[nv + 1] = new Vertex(new float2(r.Right, r.Top), new float2(color.R / 255.0f, color.G / 255.0f), new float2(color.B / 255.0f, color.A / 255.0f));
-			vertices[nv + 2] = new Vertex(new float2(r.Right, r.Bottom), new float2(color.R / 255.0f, color.G / 255.0f), new float2(color.B / 255.0f, color.A / 255.0f));
-			vertices[nv + 3] = new Vertex(new float2(r.Left, r.Bottom), new float2(color.R / 255.0f, color.G / 255.0f), new float2(color.B / 255.0f, color.A / 255.0f));
+			var r = color.R / 255.0f;
+			var g = color.G / 255.0f;
+			var b = color.B / 255.0f;
+			var a = color.A / 255.0f;
+			vertices[nv] = new Vertex(new float2(rect.Left, rect.Top), r, g, b, a);
+			vertices[nv + 1] = new Vertex(new float2(rect.Right, rect.Top), r, g, b, a);
+			vertices[nv + 2] = new Vertex(new float2(rect.Right, rect.Bottom), r, g, b, a);
+			vertices[nv + 3] = new Vertex(new float2(rect.Left, rect.Bottom), r, g, b, a);
 
 			nv += 4;
 		}

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Graphics
 		public readonly float2 size;
 		public readonly float2 offset;
 		public readonly float2 fractionalOffset;
-		readonly float top, left, bottom, right;
+		public readonly float top, left, bottom, right;
 
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel)
 			: this(sheet, bounds, float2.Zero, channel, BlendMode.Alpha) {}
@@ -44,26 +44,6 @@ namespace OpenRA.Graphics
 			top = (float)(bounds.Top) / sheet.Size.Height;
 			right = (float)(bounds.Right) / sheet.Size.Width;
 			bottom = (float)(bounds.Bottom) / sheet.Size.Height;
-		}
-
-		public float2 TopLeftTextureCoords
-		{
-			get { return new float2(left, top); }
-		}
-
-		public float2 TopRightTextureCoords
-		{
-			get { return new float2(right, top); }
-		}
-
-		public float2 BottomLeftTextureCoords
-		{
-			get { return new float2(left, bottom); }
-		}
-
-		public float2 BottomRightTextureCoords
-		{
-			get { return new float2(right, bottom); }
 		}
 	}
 

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Graphics
 		public readonly float2 size;
 		public readonly float2 offset;
 		public readonly float2 fractionalOffset;
-		readonly float2[] textureCoords;
+		readonly float top, left, bottom, right;
 
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel)
 			: this(sheet, bounds, float2.Zero, channel, BlendMode.Alpha) {}
@@ -40,22 +40,30 @@ namespace OpenRA.Graphics
 
 			this.fractionalOffset = offset / this.size;
 
-			var left = (float)(bounds.Left) / sheet.Size.Width;
-			var top = (float)(bounds.Top) / sheet.Size.Height;
-			var right = (float)(bounds.Right) / sheet.Size.Width;
-			var bottom = (float)(bounds.Bottom) / sheet.Size.Height;
-			textureCoords = new float2[]
-			{
-				new float2(left, top),
-				new float2(right, top),
-				new float2(left, bottom),
-				new float2(right, bottom),
-			};
+			left = (float)(bounds.Left) / sheet.Size.Width;
+			top = (float)(bounds.Top) / sheet.Size.Height;
+			right = (float)(bounds.Right) / sheet.Size.Width;
+			bottom = (float)(bounds.Bottom) / sheet.Size.Height;
 		}
 
-		public float2 FastMapTextureCoords(int k)
+		public float2 TopLeftTextureCoords
 		{
-			return textureCoords[k];
+			get { return new float2(left, top); }
+		}
+
+		public float2 TopRightTextureCoords
+		{
+			get { return new float2(right, top); }
+		}
+
+		public float2 BottomLeftTextureCoords
+		{
+			get { return new float2(left, bottom); }
+		}
+
+		public float2 BottomRightTextureCoords
+		{
+			get { return new float2(right, bottom); }
 		}
 	}
 

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -29,12 +29,13 @@ namespace OpenRA.Graphics
 
 		public static void FastCreateQuad(Vertex[] vertices, float2 a, float2 b, float2 c, float2 d, Sprite r, int palette, int nv)
 		{
-			var attrib = new float2(palette / (float)HardwarePalette.MaxPalettes, channelSelect[(int)r.channel]);
+			var attribP = palette / (float)HardwarePalette.MaxPalettes;
+			var attribC = channelSelect[(int)r.channel];
 
-			vertices[nv] = new Vertex(a, r.TopLeftTextureCoords, attrib);
-			vertices[nv + 1] = new Vertex(b, r.TopRightTextureCoords, attrib);
-			vertices[nv + 2] = new Vertex(c, r.BottomRightTextureCoords, attrib);
-			vertices[nv + 3] = new Vertex(d, r.BottomLeftTextureCoords, attrib);
+			vertices[nv] = new Vertex(a, r.left, r.top, attribP, attribC);
+			vertices[nv + 1] = new Vertex(b, r.right, r.top, attribP, attribC);
+			vertices[nv + 2] = new Vertex(c, r.right, r.bottom, attribP, attribC);
+			vertices[nv + 3] = new Vertex(d, r.left, r.bottom, attribP, attribC);
 		}
 
 		static readonly int[] channelMasks = { 2, 1, 0, 3 };	// yes, our channel order is nuts.

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -31,10 +31,10 @@ namespace OpenRA.Graphics
 		{
 			var attrib = new float2(palette / (float)HardwarePalette.MaxPalettes, channelSelect[(int)r.channel]);
 
-			vertices[nv] = new Vertex(a, r.FastMapTextureCoords(0), attrib);
-			vertices[nv + 1] = new Vertex(b, r.FastMapTextureCoords(1), attrib);
-			vertices[nv + 2] = new Vertex(c, r.FastMapTextureCoords(3), attrib);
-			vertices[nv + 3] = new Vertex(d, r.FastMapTextureCoords(2), attrib);
+			vertices[nv] = new Vertex(a, r.TopLeftTextureCoords, attrib);
+			vertices[nv + 1] = new Vertex(b, r.TopRightTextureCoords, attrib);
+			vertices[nv + 2] = new Vertex(c, r.BottomRightTextureCoords, attrib);
+			vertices[nv + 3] = new Vertex(d, r.BottomLeftTextureCoords, attrib);
 		}
 
 		static readonly int[] channelMasks = { 2, 1, 0, 3 };	// yes, our channel order is nuts.

--- a/OpenRA.Game/Graphics/Vertex.cs
+++ b/OpenRA.Game/Graphics/Vertex.cs
@@ -18,18 +18,18 @@ namespace OpenRA.Graphics
 		public float x, y, z, u, v;
 		public float p, c;
 
-		public Vertex(float2 xy, float2 uv, float2 pc)
+		public Vertex(float2 xy, float u, float v, float p, float c)
 		{
 			this.x = xy.X; this.y = xy.Y; this.z = 0;
-			this.u = uv.X; this.v = uv.Y;
-			this.p = pc.X; this.c = pc.Y;
+			this.u = u; this.v = v;
+			this.p = p; this.c = c;
 		}
 
-		public Vertex(float[] xyz, float2 uv, float2 pc)
+		public Vertex(float[] xyz, float u, float v, float p, float c)
 		{
 			this.x = xyz[0]; this.y = xyz[1]; this.z = xyz[2];
-			this.u = uv.X; this.v = uv.Y;
-			this.p = pc.X; this.c = pc.Y;
+			this.u = u; this.v = v;
+			this.p = p; this.c = c;
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -87,13 +87,14 @@ namespace OpenRA.Graphics
 			Util.FastCopyIntoChannel(s, 1, normals);
 			s.sheet.CommitData();
 
-			var channels = new float2(channelSelect[(int)s.channel], channelSelect[(int)s.channel + 1]);
+			var channelP =channelSelect[(int)s.channel];
+			var channelC = channelSelect[(int)s.channel + 1];
 			return new Vertex[4]
 			{
-				new Vertex(coord(0, 0), s.TopLeftTextureCoords, channels),
-				new Vertex(coord(su, 0), s.TopRightTextureCoords, channels),
-				new Vertex(coord(su, sv), s.BottomRightTextureCoords, channels),
-				new Vertex(coord(0, sv), s.BottomLeftTextureCoords, channels)
+				new Vertex(coord(0, 0), s.left, s.top, channelP, channelC),
+				new Vertex(coord(su, 0),s.right, s.top, channelP, channelC),
+				new Vertex(coord(su, sv), s.right, s.bottom, channelP, channelC),
+				new Vertex(coord(0, sv), s.left, s.bottom, channelP, channelC)
 			};
 		}
 

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -90,10 +90,10 @@ namespace OpenRA.Graphics
 			var channels = new float2(channelSelect[(int)s.channel], channelSelect[(int)s.channel + 1]);
 			return new Vertex[4]
 			{
-				new Vertex(coord(0, 0), s.FastMapTextureCoords(0), channels),
-				new Vertex(coord(su, 0), s.FastMapTextureCoords(1), channels),
-				new Vertex(coord(su, sv), s.FastMapTextureCoords(3), channels),
-				new Vertex(coord(0, sv), s.FastMapTextureCoords(2), channels)
+				new Vertex(coord(0, 0), s.TopLeftTextureCoords, channels),
+				new Vertex(coord(su, 0), s.TopRightTextureCoords, channels),
+				new Vertex(coord(su, sv), s.BottomRightTextureCoords, channels),
+				new Vertex(coord(0, sv), s.BottomLeftTextureCoords, channels)
 			};
 		}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -121,7 +121,7 @@ namespace OpenRA
 
 		[FieldLoader.Ignore] public Lazy<CellLayer<TerrainTile>> MapTiles;
 		[FieldLoader.Ignore] public Lazy<CellLayer<ResourceTile>> MapResources;
-		[FieldLoader.Ignore] public CellLayer<int> CustomTerrain;
+		[FieldLoader.Ignore] public CellLayer<byte> CustomTerrain;
 
 		[FieldLoader.Ignore] Lazy<TileSet> cachedTileSet;
 		[FieldLoader.Ignore] Lazy<Ruleset> rules;
@@ -280,9 +280,9 @@ namespace OpenRA
 			var br = Map.MapToCell(TileShape, new CPos(Bounds.Right - 1, Bounds.Bottom - 1));
 			Cells = new CellRegion(TileShape, tl, br);
 
-			CustomTerrain = new CellLayer<int>(this);
+			CustomTerrain = new CellLayer<byte>(this);
 			foreach (var cell in Cells)
-				CustomTerrain[cell] = -1;
+				CustomTerrain[cell] = byte.MaxValue;
 		}
 
 		public Ruleset PreloadRules()
@@ -672,10 +672,10 @@ namespace OpenRA
 			}
 		}
 
-		public int GetTerrainIndex(CPos cell)
+		public byte GetTerrainIndex(CPos cell)
 		{
 			var custom = CustomTerrain[cell];
-			return custom != -1 ? custom : cachedTileSet.Value.GetTerrainIndex(MapTiles.Value[cell]);
+			return custom != byte.MaxValue ? custom : cachedTileSet.Value.GetTerrainIndex(MapTiles.Value[cell]);
 		}
 
 		public TerrainTypeInfo GetTerrainInfo(CPos cell)

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common;
@@ -158,7 +159,7 @@ namespace OpenRA.Mods.RA.AI
 		bool enabled;
 		int ticks;
 
-		HashSet<byte> resourceTypeIndices;
+		BitArray resourceTypeIndices;
 
 		RushFuzzy rushFuzzy = new RushFuzzy();
 
@@ -208,10 +209,9 @@ namespace OpenRA.Mods.RA.AI
 
 			random = new MersenneTwister((int)p.PlayerActor.ActorID);
 
-			resourceTypeIndices = new HashSet<byte>(
-				Map.Rules.Actors["world"].Traits
-				.WithInterface<ResourceTypeInfo>()
-				.Select(t => world.TileSet.GetTerrainIndex(t.TerrainType)));
+			resourceTypeIndices = new BitArray(world.TileSet.TerrainInfo.Length); // Big enough
+			foreach (var t in Map.Rules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>())
+				resourceTypeIndices.Set(world.TileSet.GetTerrainIndex(t.TerrainType), true);
 		}
 
 		ActorInfo ChooseRandomUnitToBuild(ProductionQueue queue)
@@ -371,7 +371,7 @@ namespace OpenRA.Mods.RA.AI
 
 					// Try and place the refinery near a resource field
 					var nearbyResources = Map.FindTilesInCircle(baseCenter, Info.MaxBaseRadius)
-						.Where(a => resourceTypeIndices.Contains(Map.GetTerrainIndex(a)))
+						.Where(a => resourceTypeIndices.Get(Map.GetTerrainIndex(a)))
 						.Shuffle(random);
 
 					foreach (var c in nearbyResources)

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.RA.AI
 		bool enabled;
 		int ticks;
 
-		HashSet<int> resourceTypeIndices;
+		HashSet<byte> resourceTypeIndices;
 
 		RushFuzzy rushFuzzy = new RushFuzzy();
 
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.RA.AI
 
 			random = new MersenneTwister((int)p.PlayerActor.ActorID);
 
-			resourceTypeIndices = new HashSet<int>(
+			resourceTypeIndices = new HashSet<byte>(
 				Map.Rules.Actors["world"].Traits
 				.WithInterface<ResourceTypeInfo>()
 				.Select(t => world.TileSet.GetTerrainIndex(t.TerrainType)));

--- a/OpenRA.Mods.RA/Bridge.cs
+++ b/OpenRA.Mods.RA/Bridge.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.RA
 				self.World.Map.CustomTerrain[c] = GetTerrainType(c);
 		}
 
-		int GetTerrainType(CPos cell)
+		byte GetTerrainType(CPos cell)
 		{
 			var dx = cell - self.Location;
 			var index = dx.X + self.World.TileSet.Templates[template].Size.X * dx.Y;

--- a/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Buildings
 						continue;
 
 					// Don't place under other buildings or custom terrain
-					if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != -1)
+					if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != byte.MaxValue)
 						continue;
 
 					var index = Game.CosmeticRandom.Next(template.TilesCount);
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA.Buildings
 					continue;
 
 				// Don't place under other buildings or custom terrain
-				if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != -1)
+				if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != byte.MaxValue)
 					continue;
 
 				layer.AddTile(c, new TerrainTile(template.Id, (byte)i));

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.RA.Move
 
 			foreach (var kvp in TerrainSpeeds)
 			{
-				int index;
+				byte index;
 				if (tileSet.TryGetTerrainIndex(kvp.Key, out index))
 					info[index] = kvp.Value;
 			}
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.RA.Move
 				return int.MaxValue;
 
 			var index = world.Map.GetTerrainIndex(cell);
-			if (index == -1)
+			if (index == byte.MaxValue)
 				return int.MaxValue;
 
 			return TilesetTerrainInfo[world.TileSet][index].Cost;
@@ -526,7 +526,7 @@ namespace OpenRA.Mods.RA.Move
 		public int MovementSpeedForCell(Actor self, CPos cell)
 		{
 			var index = self.World.Map.GetTerrainIndex(cell);
-			if (index == -1)
+			if (index == byte.MaxValue)
 				return 0;
 
 			// TODO: Convert to integers

--- a/OpenRA.Mods.RA/World/ResourceLayer.cs
+++ b/OpenRA.Mods.RA/World/ResourceLayer.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.RA
 			if (--c.Density < 0)
 			{
 				content[cell] = EmptyCell;
-				world.Map.CustomTerrain[cell] = -1;
+				world.Map.CustomTerrain[cell] = byte.MaxValue;
 			}
 			else
 				content[cell] = c;
@@ -222,7 +222,7 @@ namespace OpenRA.Mods.RA
 
 			// Clear cell
 			content[cell] = EmptyCell;
-			world.Map.CustomTerrain[cell] = -1;
+			world.Map.CustomTerrain[cell] = byte.MaxValue;
 
 			if (!dirty.Contains(cell))
 				dirty.Add(cell);

--- a/OpenRA.TilesetBuilder/FormBuilder.cs
+++ b/OpenRA.TilesetBuilder/FormBuilder.cs
@@ -385,7 +385,7 @@ namespace OpenRA.TilesetBuilder
 			ushort cur = 0;
 			foreach (var tp in surface1.Templates)
 			{
-				var tiles = new int[tp.Width * tp.Height];
+				var tiles = new byte[tp.Width * tp.Height];
 				foreach (var t in tp.Cells)
 				{
 					var ttype = TerrainType[surface1.TerrainTypes[t.Key.X, t.Key.Y]].Type;


### PR DESCRIPTION
Two small changes which save some memory:
- Indexes into tile arrays are now stored as bytes instead of ints, since the only need to represent very small numbers. The CustomTerrain field in the Map class means this gains us about 5MiB back for medium sized maps.
- We don't store pre-calculated textures coordinate pairs in Sprite, preferring to store pre-calculated values for each corner and return pairs on demand. This allows us to store texture co-ords for sprites using only 4 floats instead of 8. We also remove the array as well. This saved about 5MiB in my tests.
