### PR TITLE
Increasing the Capacity from Silo and Refinery in TS

### DIFF
--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -151,7 +151,7 @@ PROC:
 	StoresResources:
 		PipColor: Green
 		PipCount: 15
-		Capacity: 3000
+		Capacity: 6000
 	CustomSellValue:
 		Value: 600
 	FreeActor:
@@ -197,8 +197,8 @@ GASILO:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	StoresResources:
-		PipCount: 5
-		Capacity: 1500
+		PipCount: 10
+		Capacity: 10000
 	Power:
 		Amount: -10
 


### PR DESCRIPTION
This PR increases the Capacity from Silos and refinerys which should fixing the following:
- Stops EVA from Spaming "Silos needed" right after more than 3 silos...
- Silos should have more capacity as an Refinery
- AI stops blowing up the base with Tiberium Silos which causes a "never ends up process" and wasting the Buildable Space whith Silos: see screen:

![untitled](https://cloud.githubusercontent.com/assets/2057932/4539383/5b747fb2-4dfc-11e4-8311-1bee2f0e8fa8.jpg)

It makes no sense to let the AI Building 3 Refinerys which is causing a never ending Tiberium Overload :(
