### PR TITLE
Minor TS cleanup

### DIFF
--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -993,14 +993,12 @@ GAVULC:
 	Armament@PRIMARY:
 		Weapon: VulcanTower
 		LocalOffset: 768,85,512
-		Recoil: 0
 		MuzzleSequence: muzzle
 		MuzzleSplitFacings: 8
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: VulcanTower
 		LocalOffset: 768,-85,512
-		Recoil: 0
 		MuzzleSequence: muzzle
 		MuzzleSplitFacings: 8
 	WithMuzzleFlash:
@@ -1054,7 +1052,6 @@ GAROCK:
 	Armament:
 		Weapon: RPGTower
 		LocalOffset: 512,-128,512
-		Recoil: 0
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	LineBuildNode:
@@ -1105,7 +1102,6 @@ GACSAM:
 	Armament:
 		Weapon: SAMTower
 		LocalOffset: 512,0,512
-		Recoil: 0
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	LineBuildNode:
@@ -1155,7 +1151,6 @@ NASAM:
 	Armament:
 		Weapon: SAMTower
 		LocalOffset: 512,0,512
-		Recoil: 0
 	Power:
 		Amount: -30
 

--- a/mods/ts/weapons.yaml
+++ b/mods/ts/weapons.yaml
@@ -685,7 +685,7 @@ FireballLauncher:
 	Projectile: Bullet
 		Speed: 64
 		Image: FLAMEALL
-		Inacuracy: 384
+		Inaccuracy: 384
 	Burst: 5
 	BurstDelay: 5
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
Fixes a typo and removes redundant armament recoil values (as Recoils is set to 'no' anyway).
