### PR TITLE
Moved two more Orders from RA to Common

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -69,6 +69,8 @@
     <Compile Include="Graphics\VoxelRenderable.cs" />
     <Compile Include="ModChooserLoadScreen.cs" />
     <Compile Include="Orders\DeployOrderTargeter.cs" />
+    <Compile Include="Orders\EnterAlliedActorTargeter.cs" />
+    <Compile Include="Orders\UnitOrderTargeter.cs" />
     <Compile Include="PaletteFromFile.cs" />
     <Compile Include="RallyPoint.cs" />
     <Compile Include="ServerTraits\ColorValidator.cs" />

--- a/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
@@ -11,7 +11,7 @@
 using System;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Orders
+namespace OpenRA.Mods.Common.Orders
 {
 	public class EnterAlliedActorTargeter<T> : UnitOrderTargeter
 	{

--- a/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Orders
+namespace OpenRA.Mods.Common.Orders
 {
 	public abstract class UnitOrderTargeter : IOrderTargeter
 	{

--- a/OpenRA.Mods.RA/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Air/Aircraft.cs
@@ -11,9 +11,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/C4Demolition.cs
+++ b/OpenRA.Mods.RA/C4Demolition.cs
@@ -11,8 +11,8 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Captures.cs
+++ b/OpenRA.Mods.RA/Captures.cs
@@ -10,8 +10,8 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Disguise.cs
+++ b/OpenRA.Mods.RA/Disguise.cs
@@ -11,7 +11,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Mods.RA.Orders;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/EngineerRepair.cs
+++ b/OpenRA.Mods.RA/EngineerRepair.cs
@@ -10,8 +10,8 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/ExternalCaptures.cs
+++ b/OpenRA.Mods.RA/ExternalCaptures.cs
@@ -10,8 +10,8 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Harvester.cs
+++ b/OpenRA.Mods.RA/Harvester.cs
@@ -12,9 +12,9 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Move;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.RA/Infiltration/Infiltrates.cs
@@ -11,8 +11,8 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Infiltration

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -264,7 +264,6 @@
     <Compile Include="Orders\PlaceBuildingOrderGenerator.cs" />
     <Compile Include="Orders\PowerDownOrderGenerator.cs" />
     <Compile Include="Orders\RepairOrderGenerator.cs" />
-    <Compile Include="Orders\UnitOrderTargeter.cs" />
     <Compile Include="OreRefinery.cs" />
     <Compile Include="PlayerPaletteFromCurrentTileset.cs" />
     <Compile Include="PaletteFromCurrentTileset.cs" />
@@ -423,7 +422,6 @@
     <Compile Include="MPStartUnits.cs" />
     <Compile Include="Widgets\Logic\WorldTooltipLogic.cs" />
     <Compile Include="Buildings\Bib.cs" />
-    <Compile Include="Orders\EnterAlliedActorTargeter.cs" />
     <Compile Include="Render\WithIdleOverlay.cs" />
     <Compile Include="Tooltip.cs" />
     <Compile Include="AI\Squad.cs" />

--- a/OpenRA.Mods.RA/Passenger.cs
+++ b/OpenRA.Mods.RA/Passenger.cs
@@ -12,8 +12,8 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -11,9 +11,9 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 using OpenRA.Mods.Common;
 

--- a/OpenRA.Mods.RA/RepairableNear.cs
+++ b/OpenRA.Mods.RA/RepairableNear.cs
@@ -11,9 +11,9 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/RepairsBridges.cs
+++ b/OpenRA.Mods.RA/RepairsBridges.cs
@@ -10,8 +10,8 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/SupplyTruck.cs
+++ b/OpenRA.Mods.RA/SupplyTruck.cs
@@ -10,8 +10,8 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA


### PR DESCRIPTION
Moved  Orders\EnterAlliedActorTargeter.cs  and  Orders\UnitOrderTargeter.cs  from OpenRA.Mods.RA to OpenRA.Mods.Common.
Also made a fix to an uncommon build issue regarding Common's reference to Eluant.dll. Not so much a problem as for consistency with the same reference in the other projects as they all reference it this way.
