### PR TITLE
Load assets using absolute file paths

### DIFF
--- a/OpenRA.CrashDialog/Program.cs
+++ b/OpenRA.CrashDialog/Program.cs
@@ -24,7 +24,7 @@ namespace OpenRA.CrashDialog
 		[STAThread]
 		public static void Main(string[] args)
 		{
-			settings = new Settings(Platform.SupportDir + "settings.yaml", new Arguments());
+			settings = new Settings(Platform.ResolvePath("^", "settings.yaml"), new Arguments());
 
 			var form = new Form
 			{
@@ -95,7 +95,7 @@ namespace OpenRA.CrashDialog
 		{
 			try
 			{
-				Process.Start(Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar);
+				Process.Start(Platform.ResolvePath("^", "Logs"));
 			}
 			catch { }
 		}

--- a/OpenRA.Editor/MapSelect.cs
+++ b/OpenRA.Editor/MapSelect.cs
@@ -27,8 +27,7 @@ namespace OpenRA.Editor
 
 		public MapSelect(string currentMod)
 		{
-			MapFolderPath = new string[] { Platform.SupportDir, "maps", currentMod }
-				.Aggregate(Path.Combine);
+			MapFolderPath = Platform.ResolvePath("^", "maps", currentMod);
 
 			if (!Directory.Exists(MapFolderPath))
 				Directory.CreateDirectory(MapFolderPath);

--- a/OpenRA.Game/FileSystem/GlobalFileSystem.cs
+++ b/OpenRA.Game/FileSystem/GlobalFileSystem.cs
@@ -104,20 +104,13 @@ namespace OpenRA.FileSystem
 			return new Folder(filename, order);
 		}
 
-		public static void Mount(string name)
-		{
-			Mount(name, null);
-		}
-
-		public static void Mount(string name, string annotation)
+		public static void Mount(string name, string annotation = null)
 		{
 			var optional = name.StartsWith("~");
 			if (optional)
 				name = name.Substring(1);
 
-			// paths starting with ^ are relative to the support dir
-			if (name.StartsWith("^"))
-				name = Platform.SupportDir + name.Substring(1);
+			name = Platform.ResolvePath(name);
 
 			FolderPaths.Add(name);
 			Action a = () => MountInner(OpenPackage(name, annotation, order++));

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -180,9 +180,9 @@ namespace OpenRA
 
 			AppDomain.CurrentDomain.AssemblyResolve += GlobalFileSystem.ResolveAssembly;
 
-			Settings = new Settings(Platform.SupportDir + "settings.yaml", args);
+			Settings = new Settings(Platform.ResolvePath("^", "settings.yaml"), args);
 
-			Log.LogPath = Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar;
+			Log.LogPath = Platform.ResolvePath("^", "Logs");
 			Log.AddChannel("perf", "perf.log");
 			Log.AddChannel("debug", "debug.log");
 			Log.AddChannel("sync", "syncreport.log");
@@ -208,7 +208,7 @@ namespace OpenRA
 				Log.Write("geoip", "DatabaseReader failed: {0}", e);
 			}
 
-			GlobalFileSystem.Mount("."); // Needed to access shaders
+			GlobalFileSystem.Mount(Platform.GameDir); // Needed to access shaders
 			var renderers = new[] { Settings.Graphics.Renderer, "Sdl2", null };
 			foreach (var r in renderers)
 			{

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -25,22 +25,11 @@ namespace OpenRA.Graphics
 		static Dictionary<string, Sheet> cachedSheets;
 		static Dictionary<string, Dictionary<string, Sprite>> cachedSprites;
 
-		static string[] storedChromeFiles;
-
-		public static void Initialize(params string[] chromeFiles)
+		public static void Initialize(IEnumerable<string> chromeFiles)
 		{
 			collections = new Dictionary<string, Collection>();
 			cachedSheets = new Dictionary<string, Sheet>();
 			cachedSprites = new Dictionary<string, Dictionary<string, Sprite>>();
-
-			if (chromeFiles.Length == 0)
-			{
-				chromeFiles = storedChromeFiles;
-				if (chromeFiles == null || chromeFiles.Length == 0)
-					return;
-			}
-			else
-				storedChromeFiles = chromeFiles;
 
 			var chrome = chromeFiles.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal);
 

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Graphics
 
 		public void InitializeFonts(Manifest m)
 		{
-			Fonts = m.Fonts.ToDictionary(x => x.Key, x => new SpriteFont(x.Value.First, x.Value.Second));
+			Fonts = m.Fonts.ToDictionary(x => x.Key, x => new SpriteFont(Platform.ResolvePath(x.Value.First), x.Value.Second));
 		}
 
 		internal IGraphicsDevice Device { get { return device; } }
@@ -146,7 +146,7 @@ namespace OpenRA.Graphics
 			var resolution = GetResolution(windowMode);
 
 			var renderer = Game.Settings.Server.Dedicated ? "Null" : Game.Settings.Graphics.Renderer;
-			var rendererPath = Path.GetFullPath("OpenRA.Renderer.{0}.dll".F(renderer));
+			var rendererPath = Platform.ResolvePath(".", "OpenRA.Renderer." + renderer + ".dll");
 
 			device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, windowMode);
 		}

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -26,7 +26,7 @@ namespace OpenRA
 			Folders, Rules, ServerTraits,
 			Sequences, VoxelSequences, Cursors, Chrome, Assemblies, ChromeLayout,
 			Weapons, Voices, Notifications, Music, Movies, Translations, TileSets,
-			ChromeMetrics, PackageContents, LuaScripts, MapCompatibility, Missions;
+			ChromeMetrics, LuaScripts, MapCompatibility, Missions;
 
 		public readonly IReadOnlyDictionary<string, string> Packages;
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
@@ -81,7 +81,6 @@ namespace OpenRA
 			Translations = YamlList(yaml, "Translations");
 			TileSets = YamlList(yaml, "TileSets");
 			ChromeMetrics = YamlList(yaml, "ChromeMetrics");
-			PackageContents = YamlList(yaml, "PackageContents");
 			LuaScripts = YamlList(yaml, "LuaScripts");
 			Missions = YamlList(yaml, "Missions");
 

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -55,35 +56,35 @@ namespace OpenRA
 
 		public Manifest(string mod)
 		{
-			var path = new[] { "mods", mod, "mod.yaml" }.Aggregate(Path.Combine);
+			var path = Platform.ResolvePath(".", "mods", mod, "mod.yaml");
 			var yaml = new MiniYaml(null, MiniYaml.FromFile(path)).ToDictionary();
 
 			Mod = FieldLoader.Load<ModMetadata>(yaml["Metadata"]);
 			Mod.Id = mod;
 
 			// TODO: Use fieldloader
-			Folders = YamlList(yaml, "Folders");
-			MapFolders = YamlDictionary(yaml, "MapFolders");
-			Packages = YamlDictionary(yaml, "Packages");
-			Rules = YamlList(yaml, "Rules");
-			ServerTraits = YamlList(yaml, "ServerTraits");
-			Sequences = YamlList(yaml, "Sequences");
-			VoxelSequences = YamlList(yaml, "VoxelSequences");
-			Cursors = YamlList(yaml, "Cursors");
-			Chrome = YamlList(yaml, "Chrome");
-			Assemblies = YamlList(yaml, "Assemblies");
-			ChromeLayout = YamlList(yaml, "ChromeLayout");
-			Weapons = YamlList(yaml, "Weapons");
-			Voices = YamlList(yaml, "Voices");
-			Notifications = YamlList(yaml, "Notifications");
-			Music = YamlList(yaml, "Music");
-			Movies = YamlList(yaml, "Movies");
-			Translations = YamlList(yaml, "Translations");
-			TileSets = YamlList(yaml, "TileSets");
-			ChromeMetrics = YamlList(yaml, "ChromeMetrics");
-			LuaScripts = YamlList(yaml, "LuaScripts");
-			Missions = YamlList(yaml, "Missions");
+			Folders = YamlList(yaml, "Folders", true);
+			MapFolders = YamlDictionary(yaml, "MapFolders", true);
+			Packages = YamlDictionary(yaml, "Packages", true);
+			Rules = YamlList(yaml, "Rules", true);
+			Sequences = YamlList(yaml, "Sequences", true);
+			VoxelSequences = YamlList(yaml, "VoxelSequences", true);
+			Cursors = YamlList(yaml, "Cursors", true);
+			Chrome = YamlList(yaml, "Chrome", true);
+			Assemblies = YamlList(yaml, "Assemblies", true);
+			ChromeLayout = YamlList(yaml, "ChromeLayout", true);
+			Weapons = YamlList(yaml, "Weapons", true);
+			Voices = YamlList(yaml, "Voices", true);
+			Notifications = YamlList(yaml, "Notifications", true);
+			Music = YamlList(yaml, "Music", true);
+			Movies = YamlList(yaml, "Movies", true);
+			Translations = YamlList(yaml, "Translations", true);
+			TileSets = YamlList(yaml, "TileSets", true);
+			ChromeMetrics = YamlList(yaml, "ChromeMetrics", true);
+			LuaScripts = YamlList(yaml, "LuaScripts", true);
+			Missions = YamlList(yaml, "Missions", true);
 
+			ServerTraits = YamlList(yaml, "ServerTraits");
 			LoadScreen = yaml["LoadScreen"];
 			LobbyDefaults = yaml["LobbyDefaults"];
 
@@ -134,20 +135,23 @@ namespace OpenRA
 				SpriteFormats = FieldLoader.GetValue<string[]>("SpriteFormats", yaml["SpriteFormats"].Value);
 		}
 
-		static string[] YamlList(Dictionary<string, MiniYaml> yaml, string key)
+		static string[] YamlList(Dictionary<string, MiniYaml> yaml, string key, bool parsePaths = false)
 		{
 			if (!yaml.ContainsKey(key))
 				return new string[] { };
 
-			return yaml[key].ToDictionary().Keys.ToArray();
+			var list = yaml[key].ToDictionary().Keys.ToArray();
+			return parsePaths ? list.Select(Platform.ResolvePath).ToArray() : list;
 		}
 
-		static IReadOnlyDictionary<string, string> YamlDictionary(Dictionary<string, MiniYaml> yaml, string key)
+		static IReadOnlyDictionary<string, string> YamlDictionary(Dictionary<string, MiniYaml> yaml, string key, bool parsePaths = false)
 		{
 			if (!yaml.ContainsKey(key))
 				return new ReadOnlyDictionary<string, string>();
 
-			var inner = yaml[key].ToDictionary(my => my.Value);
+			Func<string, string> keySelector = parsePaths ? (Func<string, string>)Platform.ResolvePath : k => k;
+			var inner = yaml[key].ToDictionary(keySelector, my => my.Value);
+
 			return new ReadOnlyDictionary<string, string>(inner);
 		}
 	}

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -114,9 +114,7 @@ namespace OpenRA
 			if (dir.StartsWith("~"))
 				dir = dir.Substring(1);
 
-			// Paths starting with ^ are relative to the user directory
-			if (dir.StartsWith("^"))
-				dir = Platform.SupportDir + dir.Substring(1);
+			dir = Platform.ResolvePath(dir);
 
 			if (!Directory.Exists(dir))
 				return noMaps;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -164,7 +164,7 @@ namespace OpenRA
 				return;
 
 			Status = MapStatus.Downloading;
-			var baseMapPath = new[] { Platform.SupportDir, "maps", Game.modData.Manifest.Mod.Id }.Aggregate(Path.Combine);
+			var baseMapPath = Platform.ResolvePath("^", "maps", Game.modData.Manifest.Mod.Id);
 
 			// Create the map directory if it doesn't exist
 			if (!Directory.Exists(baseMapPath))

--- a/OpenRA.Game/ModMetadata.cs
+++ b/OpenRA.Game/ModMetadata.cs
@@ -16,7 +16,7 @@ namespace OpenRA
 {
 	public class ModMetadata
 	{
-		public static readonly Dictionary<string, ModMetadata> AllMods = ValidateMods(Directory.GetDirectories("mods").Select(x => x.Substring(5)).ToArray());
+		public static readonly Dictionary<string, ModMetadata> AllMods = ValidateMods();
 
 		public string Id;
 		public string Title;
@@ -24,12 +24,16 @@ namespace OpenRA
 		public string Version;
 		public string Author;
 
-		public static Dictionary<string, ModMetadata> ValidateMods(string[] mods)
+		static Dictionary<string, ModMetadata> ValidateMods()
 		{
+			var basePath = Platform.ResolvePath(".", "mods");
+			var mods = Directory.GetDirectories(basePath)
+				.Select(x => x.Substring(basePath.Length + 1));
+
 			var ret = new Dictionary<string, ModMetadata>();
 			foreach (var m in mods)
 			{
-				var yamlPath = new[] { "mods", m, "mod.yaml" }.Aggregate(Path.Combine);
+				var yamlPath = Platform.ResolvePath(".", "mods", m, "mod.yaml");
 				if (!File.Exists(yamlPath))
 					continue;
 

--- a/OpenRA.Game/Network/ReplayRecorderConnection.cs
+++ b/OpenRA.Game/Network/ReplayRecorderConnection.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Network
 		{
 			var filename = chooseFilename();
 			var mod = Game.modData.Manifest.Mod;
-			var dir = new[] { Platform.SupportDir, "Replays", mod.Id, mod.Version }.Aggregate(Path.Combine);
+			var dir = Platform.ResolvePath("^", "Replays", mod.Id, mod.Version);
 
 			if (!Directory.Exists(dir))
 				Directory.CreateDirectory(dir);

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -36,7 +36,7 @@ namespace OpenRA
 			// Namespaces from each mod assembly
 			foreach (var a in manifest.Assemblies)
 			{
-				var asm = Assembly.LoadFile(Path.GetFullPath(a));
+				var asm = Assembly.LoadFile(Platform.ResolvePath(a));
 				asms.AddRange(asm.GetNamespaces().Select(ns => Pair.New(asm, ns)));
 			}
 

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -62,35 +62,35 @@ namespace OpenRA
 			}
 		}
 
-		public static string SupportDir
+		public static string SupportDir { get { return supportDir.Value; } }
+		static Lazy<string> supportDir = Exts.Lazy(GetSupportDir);
+
+		static string GetSupportDir()
 		{
-			get
+			// Use a local directory in the game root if it exists
+			if (Directory.Exists("Support"))
+				return "Support" + Path.DirectorySeparatorChar;
+
+			var dir = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+
+			switch (CurrentPlatform)
 			{
-				// Use a local directory in the game root if it exists
-				if (Directory.Exists("Support"))
-					return "Support" + Path.DirectorySeparatorChar;
-
-				var dir = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-
-				switch (CurrentPlatform)
-				{
-				case PlatformType.Windows:
-					dir += Path.DirectorySeparatorChar + "OpenRA";
-					break;
-				case PlatformType.OSX:
-					dir += "/Library/Application Support/OpenRA";
-					break;
-				case PlatformType.Linux:
-				default:
-					dir += "/.openra";
-					break;
-				}
-
-				if (!Directory.Exists(dir))
-					Directory.CreateDirectory(dir);
-
-				return dir + Path.DirectorySeparatorChar;
+			case PlatformType.Windows:
+				dir += Path.DirectorySeparatorChar + "OpenRA";
+				break;
+			case PlatformType.OSX:
+				dir += "/Library/Application Support/OpenRA";
+				break;
+			case PlatformType.Linux:
+			default:
+				dir += "/.openra";
+				break;
 			}
+
+			if (!Directory.Exists(dir))
+				Directory.CreateDirectory(dir);
+
+			return dir + Path.DirectorySeparatorChar;
 		}
 
 		public static string GameDir { get { return AppDomain.CurrentDomain.BaseDirectory; } }

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -93,6 +93,40 @@ namespace OpenRA
 			}
 		}
 
+		public static string GameDir { get { return AppDomain.CurrentDomain.BaseDirectory; } }
+
+		/// <summary>Replace special character prefixes with full paths</summary>
+		public static string ResolvePath(string path)
+		{
+			// paths starting with ^ are relative to the support dir
+			if (path.StartsWith("^"))
+				path = SupportDir + path.Substring(1);
+
+			// paths starting with . are relative to the game dir
+			if (path.StartsWith("./") || path.StartsWith(".\\"))
+				path = GameDir + path.Substring(2);
+
+			return path;
+		}
+
+		/// <summary>Replace special character prefixes with full paths</summary>
+		public static string ResolvePath(params string[] path)
+		{
+			return ResolvePath(path.Aggregate(Path.Combine));
+		}
+
+		/// <summary>Replace the full path prefix with the special notation characters ^ or .</summary>
+		public static string UnresolvePath(string path)
+		{
+			if (path.StartsWith(SupportDir))
+				path = "^" + path.Substring(SupportDir.Length);
+
+			if (path.StartsWith(GameDir))
+				path = "." + path.Substring(GameDir.Length);
+
+			return path;
+		}
+
 		public static void ShowFatalErrorDialog()
 		{
 			var process = "OpenRA.CrashDialog.exe";

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -129,7 +129,8 @@ namespace OpenRA.Scripting
 				.GetTypesImplementing<ScriptPlayerProperties>()
 				.ToArray();
 
-			runtime.DoBuffer(GlobalFileSystem.Open(Path.Combine("lua", "scriptwrapper.lua")).ReadAllText(), "scriptwrapper.lua").Dispose();
+			runtime.Globals["GameDir"] = Platform.GameDir;
+			runtime.DoBuffer(GlobalFileSystem.Open(Platform.ResolvePath(".", "lua", "scriptwrapper.lua")).ReadAllText(), "scriptwrapper.lua").Dispose();
 			tick = (LuaFunction)runtime.Globals["Tick"];
 
 			// Register globals

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -360,7 +360,7 @@ namespace OpenRA.Server
 
 				if (Settings.Dedicated)
 				{
-					var motdFile = Path.Combine(Platform.SupportDir, "motd.txt");
+					var motdFile = Platform.ResolvePath("^", "motd.txt");
 					if (!File.Exists(motdFile))
 						System.IO.File.WriteAllText(motdFile, "Welcome, have fun and good luck!");
 					var motd = System.IO.File.ReadAllText(motdFile);

--- a/OpenRA.Game/Support/Log.cs
+++ b/OpenRA.Game/Support/Log.cs
@@ -22,7 +22,7 @@ namespace OpenRA
 
 	public static class Log
 	{
-		static string LogPathPrefix = Environment.GetFolderPath(Environment.SpecialFolder.Personal) + Path.DirectorySeparatorChar;
+		static string LogPathPrefix = ".";
 		public static readonly Dictionary<string, ChannelInfo> Channels = new Dictionary<string, ChannelInfo>();
 
 		public static string LogPath

--- a/OpenRA.Game/Widgets/ChromeMetrics.cs
+++ b/OpenRA.Game/Widgets/ChromeMetrics.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Widgets
 	{
 		static Dictionary<string, string> data = new Dictionary<string, string>();
 
-		public static void Initialize(string[] yaml)
+		public static void Initialize(IEnumerable<string> yaml)
 		{
 			data = new Dictionary<string, string>();
 			var metrics = yaml.Select(y => MiniYaml.FromFile(y))

--- a/OpenRA.Game/Widgets/RootWidget.cs
+++ b/OpenRA.Game/Widgets/RootWidget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Widgets
 
 				if (hk == Game.Settings.Keys.DevReloadChromeKey)
 				{
-					ChromeProvider.Initialize();
+					ChromeProvider.Initialize(Game.modData.Manifest.Chrome);
 					return true;
 				}
 			}

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc
 			r = Game.Renderer;
 			if (r == null) return;
 
-			var s = new Sheet(loadInfo["Image"]);
+			var s = new Sheet(Platform.ResolvePath(loadInfo["Image"]));
 			var res = r.Resolution;
 			bounds = new Rectangle(0, 0, res.Width, res.Height);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				sourceDropdown.OnMouseDown = _ => ShowSourceDropdown(sourceDropdown);
 				sourceDropdown.GetText = () =>
 				{
-					var name = assetSource != null ? assetSource.Name.Replace(Platform.SupportDir, "^") : "All Packages";
+					var name = assetSource != null ? Platform.UnresolvePath(assetSource.Name) : "All Packages";
 					if (name.Length > 15)
 						name = "..." + name.Substring(name.Length - 15);
 
@@ -324,7 +324,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var item = ScrollItemWidget.Setup(itemTemplate,
 				                                  () => assetSource == source,
 				                                  () => { assetSource = source;	PopulateAssetList(); });
-				item.Get<LabelWidget>("LABEL").GetText = () => source != null ? source.Name.Replace(Platform.SupportDir, "^") : "All Packages";
+				item.Get<LabelWidget>("LABEL").GetText = () => source != null ? Platform.UnresolvePath(source.Name) : "All Packages";
 				return item;
 			};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				try
 				{
-					var preview = new Bitmap(new[] { "mods", mod.Id, "preview.png" }.Aggregate(Path.Combine));
+					var preview = new Bitmap(Platform.ResolvePath(".", "mods", mod.Id, "preview.png"));
 					if (preview.Width != 296 || preview.Height != 196)
 						continue;
 
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				try
 				{
-					var logo = new Bitmap(new[] { "mods", mod.Id, "logo.png" }.Aggregate(Path.Combine));
+					var logo = new Bitmap(Platform.ResolvePath(".", "mods", mod.Id, "logo.png"));
 					if (logo.Width != 96 || logo.Height != 96)
 						continue;
 

--- a/OpenRA.Mods.RA/DefaultLoadScreen.cs
+++ b/OpenRA.Mods.RA/DefaultLoadScreen.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA
 				return;
 
 			messages = info["Text"].Split(',');
-			var s = new Sheet(info["Image"]);
+			var s = new Sheet(Platform.ResolvePath(info["Image"]));
 			logo = new Sprite(s, new Rectangle(0, 0, 256, 256), TextureChannel.Alpha);
 			stripe = new Sprite(s, new Rectangle(256, 0, 256, 256), TextureChannel.Alpha);
 			stripeRect = new Rectangle(0, r.Resolution.Height / 2 - 128, r.Resolution.Width, 256);

--- a/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
@@ -52,9 +52,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			var cancelButton = panel.Get<ButtonWidget>("CANCEL_BUTTON");
 
-			var mirrorsFile = new string[] { Platform.SupportDir, "Content", Game.modData.Manifest.Mod.Id, "mirrors.txt" }.Aggregate(Path.Combine);
+			var mirrorsFile = Platform.ResolvePath("^", "Content", Game.modData.Manifest.Mod.Id, "mirrors.txt");
 			var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-			var dest = new string[] { Platform.SupportDir, "Content", Game.modData.Manifest.Mod.Id }.Aggregate(Path.Combine);
+			var dest = Platform.ResolvePath("^", "Content", Game.modData.Manifest.Mod.Id);
 
 			Action<DownloadProgressChangedEventArgs> onDownloadProgress = i =>
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/InstallFromCDLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/InstallFromCDLogic.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
 
-			var dest = new string[] { Platform.SupportDir, "Content", Game.modData.Manifest.Mod.Id }.Aggregate(Path.Combine);
+			var dest = Platform.ResolvePath("^", "Content", Game.modData.Manifest.Mod.Id);
 			var copyFiles = Game.modData.Manifest.ContentInstaller.CopyFilesFromCD;
 
 			var packageToExtract = Game.modData.Manifest.ContentInstaller.PackageToExtractFromCD.Split(':');

--- a/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				newsStatus = newsPanel.Get<LabelWidget>("NEWS_STATUS");
 				SetNewsStatus("Loading news");
 
-				var cacheFile = Path.Combine(Platform.SupportDir, "news.yaml");
+				var cacheFile = Platform.ResolvePath("^", "news.yaml");
 				var currentNews = ParseNews(cacheFile);
 				if (currentNews != null)
 					DisplayNews(currentNews);

--- a/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			var yaml = new MiniYaml(null, Game.modData.Manifest.Missions.Select(MiniYaml.FromFile).Aggregate(MiniYaml.MergeLiberal)).ToDictionary();
 
-			var missionMapPaths = yaml["Missions"].Nodes.Select(n => Path.GetFullPath(n.Key));
+			var missionMapPaths = yaml["Missions"].Nodes.Select(n => Platform.ResolvePath(n.Key));
 
 			var maps = Game.modData.MapCache
 				.Where(p => p.Status == MapStatus.Available && missionMapPaths.Contains(Path.GetFullPath(p.Map.Path)))

--- a/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
 			var mod = Game.modData.Manifest.Mod;
-			var dir = new[] { Platform.SupportDir, "Replays", mod.Id, mod.Version }.Aggregate(Path.Combine);
+			var dir = Platform.ResolvePath("^", "Replays", mod.Id, mod.Version);
 
 			replayList.RemoveChildren();
 			if (Directory.Exists(dir))

--- a/OpenRA.TilesetBuilder/FormBuilder.cs
+++ b/OpenRA.TilesetBuilder/FormBuilder.cs
@@ -341,7 +341,7 @@ namespace OpenRA.TilesetBuilder
 
 		public void Export(string outputDir)
 		{
-			var dir = Path.Combine(Path.GetDirectoryName(srcfile), Platform.SupportDir + outputDir);
+			var dir = Platform.ResolvePath("^", outputDir);
 			Directory.CreateDirectory(dir);
 			var tilesetName = txtTilesetName.Text;
 			var tilesetID = txtID.Text;

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Utility
 
 			AppDomain.CurrentDomain.AssemblyResolve += GlobalFileSystem.ResolveAssembly;
 
-			Log.LogPath = Platform.SupportDir + "Logs" + Path.DirectorySeparatorChar;
+			Log.LogPath = Platform.ResolvePath("^", "Logs");
 			Log.AddChannel("perf", null);
 
 			var modName = args[0];

--- a/lua/scriptwrapper.lua
+++ b/lua/scriptwrapper.lua
@@ -1,7 +1,7 @@
 environment = {}
 
 -- Reset package path
-package.path = "./lua/?.lua;./mods/common/lua/?.lua"
+package.path = GameDir .. "/lua/?.lua"
 
 -- Note: sandbox has been customized to remove math.random
 local sandbox = require('sandbox')

--- a/mods/cnc/missions.yaml
+++ b/mods/cnc/missions.yaml
@@ -1,10 +1,10 @@
 Missions:
-	mods/cnc/maps/gdi01
-	mods/cnc/maps/gdi02
-	mods/cnc/maps/gdi03
-	mods/cnc/maps/gdi04a
-	mods/cnc/maps/gdi04b
-	mods/cnc/maps/gdi04c
-	mods/cnc/maps/nod01
-	mods/cnc/maps/nod03a
-	mods/cnc/maps/nod03b
+	./mods/cnc/maps/gdi01
+	./mods/cnc/maps/gdi02
+	./mods/cnc/maps/gdi03
+	./mods/cnc/maps/gdi04a
+	./mods/cnc/maps/gdi04b
+	./mods/cnc/maps/gdi04c
+	./mods/cnc/maps/nod01
+	./mods/cnc/maps/nod03a
+	./mods/cnc/maps/nod03b

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -34,106 +34,106 @@ Packages:
 	~transit.mix
 
 Rules:
-	mods/cnc/rules/misc.yaml
-	mods/cnc/rules/ai.yaml
-	mods/cnc/rules/player.yaml
-	mods/cnc/rules/world.yaml
-	mods/cnc/rules/defaults.yaml
-	mods/cnc/rules/structures.yaml
-	mods/cnc/rules/infantry.yaml
-	mods/cnc/rules/vehicles.yaml
-	mods/cnc/rules/trees.yaml
-	mods/cnc/rules/civilian.yaml
-	mods/cnc/rules/civilian-desert.yaml
-	mods/cnc/rules/tech.yaml
-	mods/cnc/rules/ships.yaml
-	mods/cnc/rules/aircraft.yaml
-	mods/cnc/rules/husks.yaml
+	./mods/cnc/rules/misc.yaml
+	./mods/cnc/rules/ai.yaml
+	./mods/cnc/rules/player.yaml
+	./mods/cnc/rules/world.yaml
+	./mods/cnc/rules/defaults.yaml
+	./mods/cnc/rules/structures.yaml
+	./mods/cnc/rules/infantry.yaml
+	./mods/cnc/rules/vehicles.yaml
+	./mods/cnc/rules/trees.yaml
+	./mods/cnc/rules/civilian.yaml
+	./mods/cnc/rules/civilian-desert.yaml
+	./mods/cnc/rules/tech.yaml
+	./mods/cnc/rules/ships.yaml
+	./mods/cnc/rules/aircraft.yaml
+	./mods/cnc/rules/husks.yaml
 
 Sequences:
-	mods/cnc/sequences/structures.yaml
-	mods/cnc/sequences/vehicles.yaml
-	mods/cnc/sequences/infantry.yaml
-	mods/cnc/sequences/aircraft.yaml
-	mods/cnc/sequences/decorations.yaml
-	mods/cnc/sequences/misc.yaml
-	mods/cnc/sequences/funpark.yaml
-	mods/cnc/sequences/civilian.yaml
-	mods/cnc/sequences/campaign.yaml
+	./mods/cnc/sequences/structures.yaml
+	./mods/cnc/sequences/vehicles.yaml
+	./mods/cnc/sequences/infantry.yaml
+	./mods/cnc/sequences/aircraft.yaml
+	./mods/cnc/sequences/decorations.yaml
+	./mods/cnc/sequences/misc.yaml
+	./mods/cnc/sequences/funpark.yaml
+	./mods/cnc/sequences/civilian.yaml
+	./mods/cnc/sequences/campaign.yaml
 
 Cursors:
-	mods/cnc/cursors.yaml
+	./mods/cnc/cursors.yaml
 
 Chrome:
-	mods/cnc/chrome.yaml
+	./mods/cnc/chrome.yaml
 
 Assemblies:
-	mods/common/OpenRA.Mods.Common.dll
-	mods/ra/OpenRA.Mods.RA.dll
-	mods/cnc/OpenRA.Mods.Cnc.dll
-	mods/d2k/OpenRA.Mods.D2k.dll
+	./mods/common/OpenRA.Mods.Common.dll
+	./mods/ra/OpenRA.Mods.RA.dll
+	./mods/cnc/OpenRA.Mods.Cnc.dll
+	./mods/d2k/OpenRA.Mods.D2k.dll
 
 ChromeLayout:
-	mods/cnc/chrome/install.yaml
-	mods/cnc/chrome/mainmenu.yaml
-	mods/cnc/chrome/serverbrowser.yaml
-	mods/cnc/chrome/createserver.yaml
-	mods/cnc/chrome/directconnect.yaml
-	mods/cnc/chrome/lobby.yaml
-	mods/cnc/chrome/lobby-mappreview.yaml
-	mods/cnc/chrome/lobby-playerbin.yaml
-	mods/cnc/chrome/lobby-dialogs.yaml
-	mods/cnc/chrome/connection.yaml
-	mods/cnc/chrome/color-picker.yaml
-	mods/cnc/chrome/mapchooser.yaml
-	mods/cnc/chrome/replaybrowser.yaml
-	mods/cnc/chrome/ingame.yaml
-	mods/cnc/chrome/ingame-chat.yaml
-	mods/cnc/chrome/ingame-menu.yaml
-	mods/cnc/chrome/ingame-debug.yaml
-	mods/cnc/chrome/ingame-info.yaml
-	mods/cnc/chrome/ingame-infobriefing.yaml
-	mods/cnc/chrome/ingame-infoobjectives.yaml
-	mods/cnc/chrome/ingame-infostats.yaml
-	mods/cnc/chrome/ingame-leavemap.yaml
-	mods/cnc/chrome/ingame-observerstats.yaml
-	mods/cnc/chrome/music.yaml
-	mods/cnc/chrome/settings.yaml
-	mods/cnc/chrome/credits.yaml
-	mods/cnc/chrome/dialogs.yaml
-	mods/cnc/chrome/tooltips.yaml
-	mods/cnc/chrome/irc.yaml
-	mods/cnc/chrome/assetbrowser.yaml
-	mods/cnc/chrome/missionbrowser.yaml
+	./mods/cnc/chrome/install.yaml
+	./mods/cnc/chrome/mainmenu.yaml
+	./mods/cnc/chrome/serverbrowser.yaml
+	./mods/cnc/chrome/createserver.yaml
+	./mods/cnc/chrome/directconnect.yaml
+	./mods/cnc/chrome/lobby.yaml
+	./mods/cnc/chrome/lobby-mappreview.yaml
+	./mods/cnc/chrome/lobby-playerbin.yaml
+	./mods/cnc/chrome/lobby-dialogs.yaml
+	./mods/cnc/chrome/connection.yaml
+	./mods/cnc/chrome/color-picker.yaml
+	./mods/cnc/chrome/mapchooser.yaml
+	./mods/cnc/chrome/replaybrowser.yaml
+	./mods/cnc/chrome/ingame.yaml
+	./mods/cnc/chrome/ingame-chat.yaml
+	./mods/cnc/chrome/ingame-menu.yaml
+	./mods/cnc/chrome/ingame-debug.yaml
+	./mods/cnc/chrome/ingame-info.yaml
+	./mods/cnc/chrome/ingame-infobriefing.yaml
+	./mods/cnc/chrome/ingame-infoobjectives.yaml
+	./mods/cnc/chrome/ingame-infostats.yaml
+	./mods/cnc/chrome/ingame-leavemap.yaml
+	./mods/cnc/chrome/ingame-observerstats.yaml
+	./mods/cnc/chrome/music.yaml
+	./mods/cnc/chrome/settings.yaml
+	./mods/cnc/chrome/credits.yaml
+	./mods/cnc/chrome/dialogs.yaml
+	./mods/cnc/chrome/tooltips.yaml
+	./mods/cnc/chrome/irc.yaml
+	./mods/cnc/chrome/assetbrowser.yaml
+	./mods/cnc/chrome/missionbrowser.yaml
 
 Weapons:
-	mods/cnc/weapons.yaml
+	./mods/cnc/weapons.yaml
 
 Movies:
-	mods/cnc/movies-gdi.yaml
-	mods/cnc/movies-nod.yaml
+	./mods/cnc/movies-gdi.yaml
+	./mods/cnc/movies-nod.yaml
 	
 Translations:
-	mods/cnc/languages/english.yaml
+	./mods/cnc/languages/english.yaml
 
 Voices:
-	mods/cnc/voices.yaml
+	./mods/cnc/voices.yaml
 
 Notifications:
-	mods/cnc/notifications.yaml
+	./mods/cnc/notifications.yaml
 
 Music:
-	mods/cnc/music.yaml
+	./mods/cnc/music.yaml
 
 TileSets:
-	mods/cnc/tilesets/desert.yaml
-	mods/cnc/tilesets/winter.yaml
-	mods/cnc/tilesets/snow.yaml
-	mods/cnc/tilesets/temperat.yaml
-	mods/cnc/tilesets/jungle.yaml
+	./mods/cnc/tilesets/desert.yaml
+	./mods/cnc/tilesets/winter.yaml
+	./mods/cnc/tilesets/snow.yaml
+	./mods/cnc/tilesets/temperat.yaml
+	./mods/cnc/tilesets/jungle.yaml
 
 LoadScreen: CncLoadScreen
-	Image: mods/cnc/uibits/chrome.png
+	Image: ./mods/cnc/uibits/chrome.png
 	Text: Loading
 
 ContentInstaller:
@@ -167,47 +167,47 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
-	mods/cnc/metrics.yaml
+	./mods/cnc/metrics.yaml
 
 Fonts:
 	Regular:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:14
 	Bold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:32
 	MediumBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:18
 	BigBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:24
 	Tiny:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:10
 
 LuaScripts:
-	mods/common/lua/utils.lua
-	mods/common/lua/openra.lua
-	mods/common/lua/map.lua
-	mods/common/lua/actor.lua
-	mods/common/lua/team.lua
-	mods/common/lua/media.lua
-	mods/common/lua/mission.lua
-	mods/common/lua/reinforcements.lua
-	mods/common/lua/supportpowers.lua
-	mods/common/lua/rules.lua
-	mods/common/lua/production.lua
-	mods/common/lua/facing.lua
+	./mods/common/lua/utils.lua
+	./mods/common/lua/openra.lua
+	./mods/common/lua/map.lua
+	./mods/common/lua/actor.lua
+	./mods/common/lua/team.lua
+	./mods/common/lua/media.lua
+	./mods/common/lua/mission.lua
+	./mods/common/lua/reinforcements.lua
+	./mods/common/lua/supportpowers.lua
+	./mods/common/lua/rules.lua
+	./mods/common/lua/production.lua
+	./mods/common/lua/facing.lua
 
 Missions:
-	mods/cnc/missions.yaml
+	./mods/cnc/missions.yaml
 
 SupportsMapsFrom: cnc
 

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -24,100 +24,100 @@ Packages:
 	SOUND.RS
 
 Rules:
-	mods/d2k/rules/misc.yaml
-	mods/d2k/rules/ai.yaml
-	mods/d2k/rules/player.yaml
-	mods/d2k/rules/world.yaml
-	mods/d2k/rules/defaults.yaml
-	mods/d2k/rules/vehicles.yaml
-	mods/d2k/rules/structures.yaml
-	mods/d2k/rules/aircraft.yaml
-	mods/d2k/rules/infantry.yaml
-	mods/d2k/rules/atreides.yaml
-	mods/d2k/rules/harkonnen.yaml
-	mods/d2k/rules/ordos.yaml
+	./mods/d2k/rules/misc.yaml
+	./mods/d2k/rules/ai.yaml
+	./mods/d2k/rules/player.yaml
+	./mods/d2k/rules/world.yaml
+	./mods/d2k/rules/defaults.yaml
+	./mods/d2k/rules/vehicles.yaml
+	./mods/d2k/rules/structures.yaml
+	./mods/d2k/rules/aircraft.yaml
+	./mods/d2k/rules/infantry.yaml
+	./mods/d2k/rules/atreides.yaml
+	./mods/d2k/rules/harkonnen.yaml
+	./mods/d2k/rules/ordos.yaml
 
 Sequences:
-	mods/d2k/sequences/aircraft.yaml
-	mods/d2k/sequences/vehicles.yaml
-	mods/d2k/sequences/infantry.yaml
-	mods/d2k/sequences/structures.yaml
-	mods/d2k/sequences/misc.yaml
+	./mods/d2k/sequences/aircraft.yaml
+	./mods/d2k/sequences/vehicles.yaml
+	./mods/d2k/sequences/infantry.yaml
+	./mods/d2k/sequences/structures.yaml
+	./mods/d2k/sequences/misc.yaml
 
 Cursors:
-	mods/d2k/cursors.yaml
+	./mods/d2k/cursors.yaml
 
 Chrome:
-	mods/d2k/chrome.yaml
+	./mods/d2k/chrome.yaml
 
 Assemblies:
-	mods/common/OpenRA.Mods.Common.dll
-	mods/ra/OpenRA.Mods.RA.dll
-	mods/cnc/OpenRA.Mods.Cnc.dll
-	mods/d2k/OpenRA.Mods.D2k.dll
+	./mods/common/OpenRA.Mods.Common.dll
+	./mods/ra/OpenRA.Mods.RA.dll
+	./mods/cnc/OpenRA.Mods.Cnc.dll
+	./mods/d2k/OpenRA.Mods.D2k.dll
 
 ChromeLayout:
-	mods/d2k/chrome/install.yaml
-	mods/d2k/chrome/ingame.yaml
-	mods/ra/chrome/ingame-chat.yaml
-	mods/ra/chrome/ingame-diplomacy.yaml
-	mods/ra/chrome/ingame-fmvplayer.yaml
-	mods/d2k/chrome/ingame-menu.yaml
-	mods/ra/chrome/ingame-info.yaml
-	mods/ra/chrome/ingame-infobriefing.yaml
-	mods/ra/chrome/ingame-infoobjectives.yaml
-	mods/ra/chrome/ingame-infostats.yaml
-	mods/d2k/chrome/ingame-observer.yaml
-	mods/ra/chrome/ingame-observerstats.yaml
-	mods/d2k/chrome/ingame-player.yaml
-	mods/ra/chrome/ingame-debug.yaml
-	mods/d2k/chrome/ingame-leavemap.yaml
-	mods/d2k/chrome/mainmenu.yaml
-	mods/ra/chrome/settings.yaml
-	mods/ra/chrome/credits.yaml
-	mods/ra/chrome/lobby.yaml
-	mods/ra/chrome/lobby-mappreview.yaml
-	mods/d2k/chrome/lobby-playerbin.yaml
-	mods/ra/chrome/lobby-dialogs.yaml
-	mods/d2k/chrome/color-picker.yaml
-	mods/ra/chrome/map-chooser.yaml
-	mods/ra/chrome/create-server.yaml
-	mods/ra/chrome/serverbrowser.yaml
-	mods/ra/chrome/connection.yaml
-	mods/ra/chrome/directconnect.yaml
-	mods/ra/chrome/replaybrowser.yaml
-	mods/d2k/chrome/dropdowns.yaml
-	mods/ra/chrome/musicplayer.yaml
-	mods/d2k/chrome/tooltips.yaml
-	mods/ra/chrome/assetbrowser.yaml
-	mods/ra/chrome/irc.yaml
-	mods/ra/chrome/missionbrowser.yaml
-	mods/ra/chrome/confirmation-dialogs.yaml
+	./mods/d2k/chrome/install.yaml
+	./mods/d2k/chrome/ingame.yaml
+	./mods/ra/chrome/ingame-chat.yaml
+	./mods/ra/chrome/ingame-diplomacy.yaml
+	./mods/ra/chrome/ingame-fmvplayer.yaml
+	./mods/d2k/chrome/ingame-menu.yaml
+	./mods/ra/chrome/ingame-info.yaml
+	./mods/ra/chrome/ingame-infobriefing.yaml
+	./mods/ra/chrome/ingame-infoobjectives.yaml
+	./mods/ra/chrome/ingame-infostats.yaml
+	./mods/d2k/chrome/ingame-observer.yaml
+	./mods/ra/chrome/ingame-observerstats.yaml
+	./mods/d2k/chrome/ingame-player.yaml
+	./mods/ra/chrome/ingame-debug.yaml
+	./mods/d2k/chrome/ingame-leavemap.yaml
+	./mods/d2k/chrome/mainmenu.yaml
+	./mods/ra/chrome/settings.yaml
+	./mods/ra/chrome/credits.yaml
+	./mods/ra/chrome/lobby.yaml
+	./mods/ra/chrome/lobby-mappreview.yaml
+	./mods/d2k/chrome/lobby-playerbin.yaml
+	./mods/ra/chrome/lobby-dialogs.yaml
+	./mods/d2k/chrome/color-picker.yaml
+	./mods/ra/chrome/map-chooser.yaml
+	./mods/ra/chrome/create-server.yaml
+	./mods/ra/chrome/serverbrowser.yaml
+	./mods/ra/chrome/connection.yaml
+	./mods/ra/chrome/directconnect.yaml
+	./mods/ra/chrome/replaybrowser.yaml
+	./mods/d2k/chrome/dropdowns.yaml
+	./mods/ra/chrome/musicplayer.yaml
+	./mods/d2k/chrome/tooltips.yaml
+	./mods/ra/chrome/assetbrowser.yaml
+	./mods/ra/chrome/irc.yaml
+	./mods/ra/chrome/missionbrowser.yaml
+	./mods/ra/chrome/confirmation-dialogs.yaml
 
 Weapons:
-	mods/d2k/weapons.yaml
+	./mods/d2k/weapons.yaml
 
 Voices:
-	mods/d2k/voices.yaml
+	./mods/d2k/voices.yaml
 
 Notifications:
-	mods/d2k/notifications.yaml
+	./mods/d2k/notifications.yaml
 
 TileSets:
-	mods/d2k/tilesets/arrakis.yaml
+	./mods/d2k/tilesets/arrakis.yaml
 
 TileSize: 32,32
 
 Music:
-	mods/d2k/music.yaml
+	./mods/d2k/music.yaml
 
 Movies:
 
 Translations:
-	mods/d2k/languages/english.yaml
+	./mods/d2k/languages/english.yaml
 
 LoadScreen: DefaultLoadScreen
-	Image: mods/d2k/uibits/loadscreen.png
+	Image: ./mods/d2k/uibits/loadscreen.png
 	Text: Filling Crates..., Breeding Sandworms...
 
 ContentInstaller:
@@ -148,44 +148,44 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
-	mods/d2k/metrics.yaml
+	./mods/d2k/metrics.yaml
 
 Fonts:
 	Regular:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:14
 	Bold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:mods/d2k/Dune2k.ttf
+		Font:./mods/d2k/Dune2k.ttf
 		Size:32
 	MediumBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:18
 	BigBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:24
 	Tiny:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:10
 
 LuaScripts:
-	mods/common/lua/utils.lua
-	mods/common/lua/openra.lua
-	mods/common/lua/map.lua
-	mods/common/lua/actor.lua
-	mods/common/lua/team.lua
-	mods/common/lua/media.lua
-	mods/common/lua/mission.lua
-	mods/common/lua/reinforcements.lua
-	mods/common/lua/supportpowers.lua
-	mods/common/lua/rules.lua
-	mods/common/lua/production.lua
-	mods/common/lua/facing.lua
+	./mods/common/lua/utils.lua
+	./mods/common/lua/openra.lua
+	./mods/common/lua/map.lua
+	./mods/common/lua/actor.lua
+	./mods/common/lua/team.lua
+	./mods/common/lua/media.lua
+	./mods/common/lua/mission.lua
+	./mods/common/lua/reinforcements.lua
+	./mods/common/lua/supportpowers.lua
+	./mods/common/lua/rules.lua
+	./mods/common/lua/production.lua
+	./mods/common/lua/facing.lua
 
 SupportsMapsFrom: d2k
 

--- a/mods/modchooser/mod.yaml
+++ b/mods/modchooser/mod.yaml
@@ -9,44 +9,44 @@ Folders:
 
 
 Cursors:
-	mods/modchooser/cursors.yaml
+	./mods/modchooser/cursors.yaml
 
 Chrome:
-	mods/modchooser/chrome.yaml
+	./mods/modchooser/chrome.yaml
 
 Assemblies:
-	mods/common/OpenRA.Mods.Common.dll
+	./mods/common/OpenRA.Mods.Common.dll
 
 ChromeLayout:
-	mods/modchooser/modchooser.yaml
+	./mods/modchooser/modchooser.yaml
 
 Notifications:
-	mods/modchooser/notifications.yaml
+	./mods/modchooser/notifications.yaml
 
 LoadScreen: ModChooserLoadScreen
 	Image: mods/modchooser/chrome.png
 
 ChromeMetrics:
-	mods/modchooser/metrics.yaml
+	./mods/modchooser/metrics.yaml
 
 Fonts:
 	Regular:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:14
 	Bold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:14
 	BigBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:24
 	MediumBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:18
 	Tiny:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:10
 
 LobbyDefaults:

--- a/mods/ra/missions.yaml
+++ b/mods/ra/missions.yaml
@@ -1,4 +1,4 @@
 Missions:
-	mods/ra/maps/allies-01-classic
-	mods/ra/maps/allies-02-classic
-	mods/ra/maps/intervention
+	./mods/ra/maps/allies-01-classic
+	./mods/ra/maps/allies-02-classic
+	./mods/ra/maps/intervention

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -34,106 +34,106 @@ Packages:
 	~movies2.mix
 
 Rules:
-	mods/ra/rules/misc.yaml
-	mods/ra/rules/ai.yaml
-	mods/ra/rules/player.yaml
-	mods/ra/rules/world.yaml
-	mods/ra/rules/defaults.yaml
-	mods/ra/rules/vehicles.yaml
-	mods/ra/rules/husks.yaml
-	mods/ra/rules/structures.yaml
-	mods/ra/rules/infantry.yaml
-	mods/ra/rules/civilian.yaml
-	mods/ra/rules/decoration.yaml
-	mods/ra/rules/aircraft.yaml
-	mods/ra/rules/ships.yaml
+	./mods/ra/rules/misc.yaml
+	./mods/ra/rules/ai.yaml
+	./mods/ra/rules/player.yaml
+	./mods/ra/rules/world.yaml
+	./mods/ra/rules/defaults.yaml
+	./mods/ra/rules/vehicles.yaml
+	./mods/ra/rules/husks.yaml
+	./mods/ra/rules/structures.yaml
+	./mods/ra/rules/infantry.yaml
+	./mods/ra/rules/civilian.yaml
+	./mods/ra/rules/decoration.yaml
+	./mods/ra/rules/aircraft.yaml
+	./mods/ra/rules/ships.yaml
 
 Sequences:
-	mods/ra/sequences/ships.yaml
-	mods/ra/sequences/vehicles.yaml
-	mods/ra/sequences/structures.yaml
-	mods/ra/sequences/infantry.yaml
-	mods/ra/sequences/aircraft.yaml
-	mods/ra/sequences/misc.yaml
-	mods/ra/sequences/decorations.yaml
+	./mods/ra/sequences/ships.yaml
+	./mods/ra/sequences/vehicles.yaml
+	./mods/ra/sequences/structures.yaml
+	./mods/ra/sequences/infantry.yaml
+	./mods/ra/sequences/aircraft.yaml
+	./mods/ra/sequences/misc.yaml
+	./mods/ra/sequences/decorations.yaml
 
 Cursors:
-	mods/ra/cursors.yaml
+	./mods/ra/cursors.yaml
 
 Chrome:
-	mods/ra/chrome.yaml
+	./mods/ra/chrome.yaml
 
 Assemblies:
-	mods/common/OpenRA.Mods.Common.dll
-	mods/ra/OpenRA.Mods.RA.dll
-	mods/cnc/OpenRA.Mods.Cnc.dll
-	mods/d2k/OpenRA.Mods.D2k.dll
+	./mods/common/OpenRA.Mods.Common.dll
+	./mods/ra/OpenRA.Mods.RA.dll
+	./mods/cnc/OpenRA.Mods.Cnc.dll
+	./mods/d2k/OpenRA.Mods.D2k.dll
 
 ChromeLayout:
-	mods/ra/chrome/install.yaml
-	mods/ra/chrome/ingame.yaml
-	mods/ra/chrome/ingame-chat.yaml
-	mods/ra/chrome/ingame-diplomacy.yaml
-	mods/ra/chrome/ingame-fmvplayer.yaml
-	mods/ra/chrome/ingame-info.yaml
-	mods/ra/chrome/ingame-infobriefing.yaml
-	mods/ra/chrome/ingame-infoobjectives.yaml
-	mods/ra/chrome/ingame-infostats.yaml
-	mods/ra/chrome/ingame-leavemap.yaml
-	mods/ra/chrome/ingame-menu.yaml
-	mods/ra/chrome/ingame-observer.yaml
-	mods/ra/chrome/ingame-observerstats.yaml
-	mods/ra/chrome/ingame-player.yaml
-	mods/ra/chrome/ingame-debug.yaml
-	mods/ra/chrome/mainmenu.yaml
-	mods/ra/chrome/settings.yaml
-	mods/ra/chrome/credits.yaml
-	mods/ra/chrome/lobby.yaml
-	mods/ra/chrome/lobby-mappreview.yaml
-	mods/ra/chrome/lobby-playerbin.yaml
-	mods/ra/chrome/lobby-dialogs.yaml
-	mods/ra/chrome/color-picker.yaml
-	mods/ra/chrome/map-chooser.yaml
-	mods/ra/chrome/create-server.yaml
-	mods/ra/chrome/serverbrowser.yaml
-	mods/ra/chrome/connection.yaml
-	mods/ra/chrome/directconnect.yaml
-	mods/ra/chrome/replaybrowser.yaml
-	mods/ra/chrome/dropdowns.yaml
-	mods/ra/chrome/musicplayer.yaml
-	mods/ra/chrome/tooltips.yaml
-	mods/ra/chrome/assetbrowser.yaml
-	mods/ra/chrome/irc.yaml
-	mods/ra/chrome/missionbrowser.yaml
-	mods/ra/chrome/confirmation-dialogs.yaml
+	./mods/ra/chrome/install.yaml
+	./mods/ra/chrome/ingame.yaml
+	./mods/ra/chrome/ingame-chat.yaml
+	./mods/ra/chrome/ingame-diplomacy.yaml
+	./mods/ra/chrome/ingame-fmvplayer.yaml
+	./mods/ra/chrome/ingame-info.yaml
+	./mods/ra/chrome/ingame-infobriefing.yaml
+	./mods/ra/chrome/ingame-infoobjectives.yaml
+	./mods/ra/chrome/ingame-infostats.yaml
+	./mods/ra/chrome/ingame-leavemap.yaml
+	./mods/ra/chrome/ingame-menu.yaml
+	./mods/ra/chrome/ingame-observer.yaml
+	./mods/ra/chrome/ingame-observerstats.yaml
+	./mods/ra/chrome/ingame-player.yaml
+	./mods/ra/chrome/ingame-debug.yaml
+	./mods/ra/chrome/mainmenu.yaml
+	./mods/ra/chrome/settings.yaml
+	./mods/ra/chrome/credits.yaml
+	./mods/ra/chrome/lobby.yaml
+	./mods/ra/chrome/lobby-mappreview.yaml
+	./mods/ra/chrome/lobby-playerbin.yaml
+	./mods/ra/chrome/lobby-dialogs.yaml
+	./mods/ra/chrome/color-picker.yaml
+	./mods/ra/chrome/map-chooser.yaml
+	./mods/ra/chrome/create-server.yaml
+	./mods/ra/chrome/serverbrowser.yaml
+	./mods/ra/chrome/connection.yaml
+	./mods/ra/chrome/directconnect.yaml
+	./mods/ra/chrome/replaybrowser.yaml
+	./mods/ra/chrome/dropdowns.yaml
+	./mods/ra/chrome/musicplayer.yaml
+	./mods/ra/chrome/tooltips.yaml
+	./mods/ra/chrome/assetbrowser.yaml
+	./mods/ra/chrome/irc.yaml
+	./mods/ra/chrome/missionbrowser.yaml
+	./mods/ra/chrome/confirmation-dialogs.yaml
 
 Weapons:
-	mods/ra/weapons.yaml
+	./mods/ra/weapons.yaml
 	
 Voices:
-	mods/ra/voices.yaml
+	./mods/ra/voices.yaml
 
 Notifications:
-	mods/ra/notifications.yaml
+	./mods/ra/notifications.yaml
 	
 TileSets:
-	mods/ra/tilesets/snow.yaml
-	mods/ra/tilesets/interior.yaml
-	mods/ra/tilesets/temperat.yaml
-	mods/ra/tilesets/desert.yaml
+	./mods/ra/tilesets/snow.yaml
+	./mods/ra/tilesets/interior.yaml
+	./mods/ra/tilesets/temperat.yaml
+	./mods/ra/tilesets/desert.yaml
 
 Music:
-	mods/ra/music.yaml
+	./mods/ra/music.yaml
 
 Movies:
-	mods/ra/movies1.yaml
-	mods/ra/movies2.yaml
+	./mods/ra/movies1.yaml
+	./mods/ra/movies2.yaml
 
 Translations:
-	mods/ra/languages/english.yaml
+	./mods/ra/languages/english.yaml
 
 LoadScreen: DefaultLoadScreen
-	Image: mods/ra/uibits/loadscreen.png
+	Image: ./mods/ra/uibits/loadscreen.png
 	Text: Filling Crates..., Charging Capacitors..., Reticulating Splines..., Planting Trees..., Building Bridges..., Aging Empires..., Compiling EVA..., Constructing Pylons..., Activating Skynet..., Splitting Atoms...
 
 ContentInstaller:
@@ -164,47 +164,47 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
-	mods/ra/metrics.yaml
+	./mods/ra/metrics.yaml
 
 Fonts:
 	Regular:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:14
 	Bold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:mods/ra/ZoodRangmah.ttf
+		Font:./mods/ra/ZoodRangmah.ttf
 		Size:48
 	MediumBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:18
 	BigBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:24
 	Tiny:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:10
 
 LuaScripts:
-	mods/common/lua/utils.lua
-	mods/common/lua/openra.lua
-	mods/common/lua/map.lua
-	mods/common/lua/actor.lua
-	mods/common/lua/team.lua
-	mods/common/lua/media.lua
-	mods/common/lua/mission.lua
-	mods/common/lua/reinforcements.lua
-	mods/common/lua/supportpowers.lua
-	mods/common/lua/rules.lua
-	mods/common/lua/production.lua
-	mods/common/lua/facing.lua
+	./mods/common/lua/utils.lua
+	./mods/common/lua/openra.lua
+	./mods/common/lua/map.lua
+	./mods/common/lua/actor.lua
+	./mods/common/lua/team.lua
+	./mods/common/lua/media.lua
+	./mods/common/lua/mission.lua
+	./mods/common/lua/reinforcements.lua
+	./mods/common/lua/supportpowers.lua
+	./mods/common/lua/rules.lua
+	./mods/common/lua/production.lua
+	./mods/common/lua/facing.lua
 
 Missions:
-	mods/ra/missions.yaml
+	./mods/ra/missions.yaml
 
 SupportsMapsFrom: ra
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -63,90 +63,90 @@ Packages:
 PackageContents:
 
 Rules:
-	mods/ts/rules/misc.yaml
-	mods/ts/rules/ai.yaml
-	mods/ts/rules/player.yaml
-	mods/ts/rules/world.yaml
-	mods/ts/rules/aircraft.yaml
-	mods/ts/rules/defaults.yaml
-	mods/ts/rules/infantry.yaml
-	mods/ts/rules/structures.yaml
-	mods/ts/rules/vehicles.yaml
-	mods/ts/rules/trees.yaml
+	./mods/ts/rules/misc.yaml
+	./mods/ts/rules/ai.yaml
+	./mods/ts/rules/player.yaml
+	./mods/ts/rules/world.yaml
+	./mods/ts/rules/aircraft.yaml
+	./mods/ts/rules/defaults.yaml
+	./mods/ts/rules/infantry.yaml
+	./mods/ts/rules/structures.yaml
+	./mods/ts/rules/vehicles.yaml
+	./mods/ts/rules/trees.yaml
 
 Sequences:
-	mods/ts/sequences/aircraft.yaml
-	mods/ts/sequences/infantry.yaml
-	mods/ts/sequences/misc.yaml
-	mods/ts/sequences/structures.yaml
-	mods/ts/sequences/vehicles.yaml
-	mods/ts/sequences/trees.yaml
+	./mods/ts/sequences/aircraft.yaml
+	./mods/ts/sequences/infantry.yaml
+	./mods/ts/sequences/misc.yaml
+	./mods/ts/sequences/structures.yaml
+	./mods/ts/sequences/vehicles.yaml
+	./mods/ts/sequences/trees.yaml
 
 VoxelSequences:
-	mods/ts/sequences/voxels.yaml
+	./mods/ts/sequences/voxels.yaml
 
 Cursors:
-	mods/ts/cursors.yaml
+	./mods/ts/cursors.yaml
 
 Chrome:
-	mods/ts/chrome.yaml
+	./mods/ts/chrome.yaml
 
 Assemblies:
-	mods/common/OpenRA.Mods.Common.dll
-	mods/ra/OpenRA.Mods.RA.dll
-	mods/d2k/OpenRA.Mods.D2k.dll
-	mods/cnc/OpenRA.Mods.Cnc.dll
-	mods/ts/OpenRA.Mods.TS.dll
+	./mods/common/OpenRA.Mods.Common.dll
+	./mods/ra/OpenRA.Mods.RA.dll
+	./mods/d2k/OpenRA.Mods.D2k.dll
+	./mods/cnc/OpenRA.Mods.Cnc.dll
+	./mods/ts/OpenRA.Mods.TS.dll
 
 ChromeLayout:
-	mods/ts/chrome/install.yaml
-	mods/ts/chrome/ingame.yaml
-	mods/ra/chrome/ingame-chat.yaml
-	mods/ra/chrome/ingame-diplomacy.yaml
-	mods/ra/chrome/ingame-fmvplayer.yaml
-	mods/ra/chrome/ingame-menu.yaml
-	mods/ra/chrome/ingame-info.yaml
-	mods/ra/chrome/ingame-infobriefing.yaml
-	mods/ra/chrome/ingame-infoobjectives.yaml
-	mods/ra/chrome/ingame-infostats.yaml
-	mods/ra/chrome/ingame-observer.yaml
-	mods/ra/chrome/ingame-observerstats.yaml
-	mods/ts/chrome/ingame-player.yaml
-	mods/ra/chrome/ingame-debug.yaml
-	mods/ra/chrome/ingame-leavemap.yaml
-	mods/ra/chrome/mainmenu.yaml
-	mods/ra/chrome/settings.yaml
-	mods/ra/chrome/credits.yaml
-	mods/ra/chrome/lobby.yaml
-	mods/ra/chrome/lobby-mappreview.yaml
-	mods/ra/chrome/lobby-playerbin.yaml
-	mods/ra/chrome/lobby-dialogs.yaml
-	mods/ts/chrome/color-picker.yaml
-	mods/ra/chrome/map-chooser.yaml
-	mods/ra/chrome/create-server.yaml
-	mods/ra/chrome/serverbrowser.yaml
-	mods/ra/chrome/connection.yaml
-	mods/ra/chrome/directconnect.yaml
-	mods/ra/chrome/replaybrowser.yaml
-	mods/ra/chrome/dropdowns.yaml
-	mods/ra/chrome/musicplayer.yaml
-	mods/ra/chrome/tooltips.yaml
-	mods/ra/chrome/assetbrowser.yaml
-	mods/ra/chrome/irc.yaml
-	mods/ra/chrome/missionbrowser.yaml
-	mods/ra/chrome/confirmation-dialogs.yaml
+	./mods/ts/chrome/install.yaml
+	./mods/ts/chrome/ingame.yaml
+	./mods/ra/chrome/ingame-chat.yaml
+	./mods/ra/chrome/ingame-diplomacy.yaml
+	./mods/ra/chrome/ingame-fmvplayer.yaml
+	./mods/ra/chrome/ingame-menu.yaml
+	./mods/ra/chrome/ingame-info.yaml
+	./mods/ra/chrome/ingame-infobriefing.yaml
+	./mods/ra/chrome/ingame-infoobjectives.yaml
+	./mods/ra/chrome/ingame-infostats.yaml
+	./mods/ra/chrome/ingame-observer.yaml
+	./mods/ra/chrome/ingame-observerstats.yaml
+	./mods/ts/chrome/ingame-player.yaml
+	./mods/ra/chrome/ingame-debug.yaml
+	./mods/ra/chrome/ingame-leavemap.yaml
+	./mods/ra/chrome/mainmenu.yaml
+	./mods/ra/chrome/settings.yaml
+	./mods/ra/chrome/credits.yaml
+	./mods/ra/chrome/lobby.yaml
+	./mods/ra/chrome/lobby-mappreview.yaml
+	./mods/ra/chrome/lobby-playerbin.yaml
+	./mods/ra/chrome/lobby-dialogs.yaml
+	./mods/ts/chrome/color-picker.yaml
+	./mods/ra/chrome/map-chooser.yaml
+	./mods/ra/chrome/create-server.yaml
+	./mods/ra/chrome/serverbrowser.yaml
+	./mods/ra/chrome/connection.yaml
+	./mods/ra/chrome/directconnect.yaml
+	./mods/ra/chrome/replaybrowser.yaml
+	./mods/ra/chrome/dropdowns.yaml
+	./mods/ra/chrome/musicplayer.yaml
+	./mods/ra/chrome/tooltips.yaml
+	./mods/ra/chrome/assetbrowser.yaml
+	./mods/ra/chrome/irc.yaml
+	./mods/ra/chrome/missionbrowser.yaml
+	./mods/ra/chrome/confirmation-dialogs.yaml
 
 Weapons:
-	mods/ts/weapons.yaml
+	./mods/ts/weapons.yaml
 
 Voices:
-	mods/ts/voices.yaml
+	./mods/ts/voices.yaml
 
 Notifications:
-	mods/ts/notifications.yaml
+	./mods/ts/notifications.yaml
 
 TileSets:
-	mods/ts/tilesets/temperat.yaml
+	./mods/ts/tilesets/temperat.yaml
 
 TileSize: 48,24
 TileShape: Diamond
@@ -155,15 +155,15 @@ SubCells:
 	DefaultIndex: 2
 
 Music:
-	mods/ts/music.yaml
+	./mods/ts/music.yaml
 
 Movies:
 
 Translations:
-	mods/ts/languages/english.yaml
+	./mods/ts/languages/english.yaml
 
 LoadScreen: DefaultLoadScreen
-	Image: mods/ts/uibits/loadscreen.png
+	Image: ./mods/ts/uibits/loadscreen.png
 	Text: Updating EVA installation..., Changing perspective...
 
 ContentInstaller:
@@ -192,41 +192,41 @@ LobbyDefaults:
 	Fog: true
 
 ChromeMetrics:
-	mods/ts/metrics.yaml
+	./mods/ts/metrics.yaml
 
 Fonts:
 	Regular:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:14
 	Bold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:32
 	BigBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:24
 	Tiny:
-		Font:FreeSans.ttf
+		Font:./FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:FreeSansBold.ttf
+		Font:./FreeSansBold.ttf
 		Size:10
 
 LuaScripts:
-	mods/common/lua/utils.lua
-	mods/common/lua/openra.lua
-	mods/common/lua/map.lua
-	mods/common/lua/actor.lua
-	mods/common/lua/team.lua
-	mods/common/lua/media.lua
-	mods/common/lua/mission.lua
-	mods/common/lua/reinforcements.lua
-	mods/common/lua/supportpowers.lua
-	mods/common/lua/rules.lua
-	mods/common/lua/production.lua
-	mods/common/lua/facing.lua
+	./mods/common/lua/utils.lua
+	./mods/common/lua/openra.lua
+	./mods/common/lua/map.lua
+	./mods/common/lua/actor.lua
+	./mods/common/lua/team.lua
+	./mods/common/lua/media.lua
+	./mods/common/lua/mission.lua
+	./mods/common/lua/reinforcements.lua
+	./mods/common/lua/supportpowers.lua
+	./mods/common/lua/rules.lua
+	./mods/common/lua/production.lua
+	./mods/common/lua/facing.lua
 
 SupportsMapsFrom: ts
 


### PR DESCRIPTION
This should allow any utility command and the game itself to be run from any directory.

Fixes #6717 and other frustrations caused by utility commands that previously only worked in the root directory.
