### PR TITLE
Updated the release build servers to Mono 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ language: c
 
 # Make sure build dependencies are installed.
 install:
+ - wget http://download.mono-project.com/repo/xamarin.gpg -O /tmp/mono.gpg
+ - sudo apt-key add /tmp/mono.gpg
+ - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/3.8.0 main' >> /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo apt-get update -qq
- - sudo apt-get install -qq mono-gmcs cli-common-dev libgl1-mesa-glx libopenal1 libfreetype6
+ - sudo apt-get install -qq mono-gmcs cli-common-dev libgl1-mesa-glx libopenal1 libfreetype6 libgdiplus=2.10-3
 cache: apt
 
 # Run the build script


### PR DESCRIPTION
Reverts the reverts from https://github.com/OpenRA/OpenRA/issues/6672 but locks the version to 3.8 which worked fine https://github.com/OpenRA/OpenRA/pull/6605.
