### PR TITLE
Fix Eluant.dll reference in Common project. Requested in #6723.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <Reference Include="Eluant, Version=1.0.5229.27703, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
As requested in #6723, the reference fix has been moved to its own commit.
