### PR TITLE
Fix old Lua breakage

### DIFF
--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2337,7 +2337,7 @@ Weapons:
 	Nike:
 		Range: 9c0
 	Maverick:
-		Warhead: SpreadDamage
+		Warhead@1Dam: SpreadDamage
 			Damage: 175
 
 Voices:

--- a/mods/ra/maps/intervention/mission.lua
+++ b/mods/ra/maps/intervention/mission.lua
@@ -194,7 +194,7 @@ SetupWorld = function()
 		end
 	end)
 
-	Production.SetRallyPoint(WarFactory, Rallypoint)
+--	Production.SetRallyPoint(WarFactory, Rallypoint)
 	Production.EventHandlers.Setup(soviets)
 
 	-- RunAfterDelay is used so that the 'Building captured' and 'Mission accomplished' sounds don't play at the same time


### PR DESCRIPTION
Works around a problem in the old Lua API where a trait lookup would
not find the correct class and make the script crash.

In this instance, `Game.modData.ObjectCreator.FindType("RallyPoint")`
returns `OpenRA.Mods.Common.Effects.RallyPoint` instead of the expected
`OpenRA.Mods.Common.RallyPoint`.

I only commented that line instead of removing it so that I won't forget about it when I port the mission to the new API.

The other change is an oversight from the recent warhead rewrites.

Fixes #6728.
