### PR TITLE
Moved RenderSprites.cs from Mods.RA to Common

### DIFF
--- a/OpenRA.Mods.Cnc/Render/RenderGunboat.cs
+++ b/OpenRA.Mods.Cnc/Render/RenderGunboat.cs
@@ -10,6 +10,7 @@
 
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.Cnc/Render/WithFire.cs
+++ b/OpenRA.Mods.Cnc/Render/WithFire.cs
@@ -9,7 +9,7 @@
 #endregion
 
 using OpenRA.Graphics;
-using OpenRA.Mods.RA.Render;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc

--- a/OpenRA.Mods.Cnc/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Render/WithRoof.cs
@@ -9,7 +9,7 @@
 #endregion
 
 using OpenRA.Graphics;
-using OpenRA.Mods.RA.Render;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc

--- a/OpenRA.Mods.Common/CommonTraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/CommonTraitsInterfaces.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common
@@ -19,4 +20,5 @@ namespace OpenRA.Mods.Common
 	}
 
 	public interface INotifyChat { bool OnChat(string from, string message); }
+	public interface IRenderActorPreviewInfo { IEnumerable<IActorPreview> RenderPreview (ActorPreviewInitializer init); }
 }

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ServerTraits\PlayerPinger.cs" />
     <Compile Include="Traits\JamsMissiles.cs" />
     <Compile Include="Traits\ProvidesRadar.cs" />
+    <Compile Include="Traits\Render\RenderSprites.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />
     <Compile Include="UtilityCommands\ExtractFilesCommand.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 using OpenRA.Primitives;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.Common.Traits.Render
 {
 	public interface IRenderActorPreviewSpritesInfo { IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p); }
 

--- a/OpenRA.Mods.D2k/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.D2k/Render/WithBuildingPlacedOverlay.cs
@@ -9,8 +9,8 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Render

--- a/OpenRA.Mods.D2k/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Render/WithCrumbleOverlay.cs
@@ -9,8 +9,8 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Render

--- a/OpenRA.Mods.D2k/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Render/WithDeliveryOverlay.cs
@@ -10,8 +10,8 @@
 
 using OpenRA.Effects;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Render

--- a/OpenRA.Mods.D2k/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.D2k/Render/WithDockingOverlay.cs
@@ -10,8 +10,8 @@
 
 using OpenRA.Effects;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Render

--- a/OpenRA.Mods.D2k/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.D2k/Render/WithProductionOverlay.cs
@@ -11,9 +11,9 @@
 using System;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA;
 using OpenRA.Mods.RA.Buildings;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Render

--- a/OpenRA.Mods.RA/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.RA/Attack/AttackGarrisoned.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Buildings/Bib.cs
+++ b/OpenRA.Mods.RA/Buildings/Bib.cs
@@ -9,7 +9,7 @@
 #endregion
 
 using OpenRA.Graphics;
-using OpenRA.Mods.RA.Render;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Buildings

--- a/OpenRA.Mods.RA/Burns.cs
+++ b/OpenRA.Mods.RA/Burns.cs
@@ -9,7 +9,7 @@
 #endregion
 
 using OpenRA.Graphics;
-using OpenRA.Mods.RA.Render;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Crate.cs
+++ b/OpenRA.Mods.RA/Crate.cs
@@ -10,9 +10,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.RA.Move;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Disguise.cs
+++ b/OpenRA.Mods.RA/Disguise.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.RA.Render;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -474,7 +474,6 @@
     <Compile Include="Render\WithActiveAnimation.cs" />
     <Compile Include="SupportPowers\SpawnActorPower.cs" />
     <Compile Include="Render\RenderSimple.cs" />
-    <Compile Include="Render\RenderSprites.cs" />
     <Compile Include="Air\FlyAwayOnIdle.cs" />
     <Compile Include="Buildings\ClonesProducedUnits.cs" />
     <Compile Include="Cloneable.cs" />

--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.RA.Render;

--- a/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 using OpenRA.Mods.Common.Graphics;
 

--- a/OpenRA.Mods.RA/Render/RenderBuildingTurreted.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingTurreted.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/RenderBuildingWall.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWall.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Effects;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.RA/Render/RenderSimple.cs
+++ b/OpenRA.Mods.RA/Render/RenderSimple.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.RA/Render/RenderVoxels.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common;
 using OpenRA.Traits;
 using OpenRA.Mods.Common.Graphics;
 

--- a/OpenRA.Mods.RA/Render/WithBarrel.cs
+++ b/OpenRA.Mods.RA/Render/WithBarrel.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.RA/Render/WithCrateBody.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithHarvestAnimation.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithRepairOverlay.cs
@@ -11,6 +11,7 @@
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Render/WithRotor.cs
+++ b/OpenRA.Mods.RA/Render/WithRotor.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/WithSmoke.cs
+++ b/OpenRA.Mods.RA/Render/WithSmoke.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/Render/WithTurret.cs
+++ b/OpenRA.Mods.RA/Render/WithTurret.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render

--- a/OpenRA.Mods.RA/TraitsInterfaces.cs
+++ b/OpenRA.Mods.RA/TraitsInterfaces.cs
@@ -45,5 +45,4 @@ namespace OpenRA.Mods.RA
 	public interface INotifyParachuteLanded { void OnLanded(); }
 	public interface INotifyTransform { void BeforeTransform(Actor self); void OnTransform(Actor self); void AfterTransform(Actor toActor); }
 	public interface INotifyAttack { void Attacking(Actor self, Target target, Armament a, Barrel barrel); }
-	public interface IRenderActorPreviewInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
 }


### PR DESCRIPTION
Moved file RenderSprites.cs.
Moved interface IRenderActorPreviewInfo  from OpenRA.Mods.RA/TraitsInterfaces.cs  to  OpenRA.Mods.Common/CommonTraitsInterfaces.cs.
Naturally, a lot of "using"s needed to be added.

Note: I intentionally left a ton of unused "using" statements to reduce the number of differences and facilitate reviewing. I will do a clean-up for these at some point. (when more files are moved perhaps).
