### PR TITLE
Fix ChangeOwner bogosity.

### DIFF
--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA
 		public object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
 
-	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyKilled, INotifyCapture, INotifyAddedToWorld, ITick, INotifySold, IDisableMove
+	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyKilled, INotifyOwnerChanged, INotifyAddedToWorld, ITick, INotifySold, IDisableMove
 	{
 		public readonly CargoInfo Info;
 		readonly Actor self;
@@ -263,7 +263,7 @@ namespace OpenRA.Mods.RA
 			});
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (cargo == null)
 				return;

--- a/OpenRA.Mods.RA/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.RA/Infiltration/InfiltrateForPowerOutage.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA.Infiltration
 		public object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.self, this); }
 	}
 
-	class InfiltrateForPowerOutage : INotifyCapture, INotifyInfiltrated
+	class InfiltrateForPowerOutage : INotifyOwnerChanged, INotifyInfiltrated
 	{
 		readonly InfiltrateForPowerOutageInfo info;
 		PowerManager playerPower;
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Infiltration
 			playerPower.TriggerPowerOutage(info.Duration);
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerPower = self.Owner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.RA/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.RA/Power/AffectedByPowerOutage.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Power
 		public object Create(ActorInitializer init) { return new AffectedByPowerOutage(init.self); }
 	}
 
-	public class AffectedByPowerOutage : INotifyCapture, ISelectionBar, IPowerModifier, IDisable
+	public class AffectedByPowerOutage : INotifyOwnerChanged, ISelectionBar, IPowerModifier, IDisable
 	{
 		PowerManager playerPower;
 
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Power
 			get { return playerPower.PowerOutageRemainingTicks > 0; }
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerPower = newOwner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.RA/Power/Power.cs
+++ b/OpenRA.Mods.RA/Power/Power.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Power
 		public object Create(ActorInitializer init) { return new Power(init.self, this); }
 	}
 
-	public class Power : INotifyCapture
+	public class Power : INotifyOwnerChanged
 	{
 		readonly PowerInfo info;
 		readonly Lazy<IPowerModifier[]> powerModifiers;
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Power
 			powerModifiers = Exts.Lazy(() => self.TraitsImplementing<IPowerModifier>().ToArray());
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			PlayerPower = newOwner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.RA/Power/RequiresPower.cs
+++ b/OpenRA.Mods.RA/Power/RequiresPower.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA.Power
 		public object Create(ActorInitializer init) { return new RequiresPower(init.self); }
 	}
 
-	class RequiresPower : IDisable, INotifyCapture
+	class RequiresPower : IDisable, INotifyOwnerChanged
 	{
 		PowerManager playerPower;
 
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Power
 			get { return playerPower.PowerProvided < playerPower.PowerDrained; }
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerPower = newOwner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Render
 		}
 	}
 
-	class RenderBuildingSilo : RenderBuilding, INotifyBuildComplete, INotifyCapture
+	class RenderBuildingSilo : RenderBuilding, INotifyBuildComplete, INotifyOwnerChanged
 	{
 		PlayerResources playerResources;
 
@@ -49,9 +49,10 @@ namespace OpenRA.Mods.RA.Render
 					: 0);
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public override void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
+			base.OnOwnerChanged(self, oldOwner, newOwner);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Render/RenderSprites.cs
+++ b/OpenRA.Mods.RA/Render/RenderSprites.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.RA.Render
 				anim.OwnerChanged();
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) { UpdatePalette(); }
+		public virtual void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) { UpdatePalette(); }
 		public void OnEffectiveOwnerChanged(Actor self, Player oldEffectiveOwner, Player newEffectiveOwner) { UpdatePalette(); }
 
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.RA/Render/WithResources.cs
+++ b/OpenRA.Mods.RA/Render/WithResources.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Render
 		public object Create(ActorInitializer init) { return new WithResources(init.self, this); }
 	}
 
-	class WithResources : INotifyBuildComplete, INotifySold, INotifyCapture, INotifyDamageStateChanged
+	class WithResources : INotifyBuildComplete, INotifySold, INotifyOwnerChanged, INotifyDamageStateChanged
 	{
 		WithResourcesInfo info;
 		Animation anim;
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Render
 				anim.ReplaceAnim(rs.NormalizeSequence(self, info.Sequence));
 		}
 
-		public void OnCapture (Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
 		}

--- a/OpenRA.Mods.RA/Reservable.cs
+++ b/OpenRA.Mods.RA/Reservable.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA
 	[Desc("Reserve landing places for aircraft.")]
 	class ReservableInfo : TraitInfo<Reservable> { }
 
-	public class Reservable : ITick, INotifyKilled, INotifyCapture, INotifySold
+	public class Reservable : ITick, INotifyKilled, INotifyOwnerChanged, INotifySold
 	{
 		Actor reservedFor;
 		Aircraft reservedForAircraft;
@@ -60,15 +60,15 @@ namespace OpenRA.Mods.RA
 				reservedForAircraft.UnReserve();
 		}
 
-		public void OnCapture (Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (reservedForAircraft != null)
 				reservedForAircraft.UnReserve();
 		}
 
-		public void Selling (Actor self) { Sold(self); }
+		public void Selling(Actor self) { Sold(self); }
 
-		public void Sold (Actor self)
+		public void Sold(Actor self)
 		{
 			if (reservedForAircraft != null)
 				reservedForAircraft.UnReserve();

--- a/OpenRA.Mods.RA/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/GeneralProperties.cs
@@ -48,7 +48,19 @@ namespace OpenRA.Mods.RA.Scripting
 		public bool IsIdle { get { return self.IsIdle; } }
 
 		[Desc("The player that owns the actor.")]
-		public Player Owner { get { return self.Owner; } }
+		public Player Owner
+		{
+			get
+			{
+				return self.Owner;
+			}
+
+			set
+			{
+				if (self.Owner != value)
+					self.ChangeOwner(value);
+			}
+		}
 
 		[Desc("The type of the actor (e.g. \"e1\").")]
 		public string Type { get { return self.Info.Name; } }

--- a/OpenRA.Mods.RA/StoresResources.cs
+++ b/OpenRA.Mods.RA/StoresResources.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA
 		public object Create(ActorInitializer init) { return new StoresResources(init.self, this); }
 	}
 
-	class StoresResources : IPips, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreResources, ISync
+	class StoresResources : IPips, INotifyOwnerChanged, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreResources, ISync
 	{
 		readonly StoresResourcesInfo Info;
 
@@ -38,12 +38,16 @@ namespace OpenRA.Mods.RA
 
 		public int Capacity { get { return Info.Capacity; } }
 
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			Player = newOwner.PlayerActor.Trait<PlayerResources>();
+		}
+
 		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
 		{
 			var resources = Stored;
-			Player.TakeResources(resources);
-			Player = newOwner.PlayerActor.Trait<PlayerResources>();
-			Player.GiveResources(resources);
+			oldOwner.PlayerActor.Trait<PlayerResources>().TakeResources(resources);
+			newOwner.PlayerActor.Trait<PlayerResources>().GiveResources(resources);
 		}
 
 		public void Killed(Actor self, AttackInfo e)

--- a/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/GpsPower.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.RA
 		public override object Create(ActorInitializer init) { return new GpsPower(init.self, this); }
 	}
 
-	class GpsPower : SupportPower, INotifyKilled, INotifyStanceChanged, INotifySold, INotifyCapture
+	class GpsPower : SupportPower, INotifyKilled, INotifyStanceChanged, INotifySold, INotifyOwnerChanged
 	{
 		GpsWatcher owner;
 
@@ -133,10 +133,10 @@ namespace OpenRA.Mods.RA
 			owner.RefreshGps(self);
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			RemoveGps(self);
-			owner = captor.Owner.PlayerActor.Trait<GpsWatcher>();
+			owner = newOwner.PlayerActor.Trait<GpsWatcher>();
 			owner.GpsAdd(self);
 		}
 	}


### PR DESCRIPTION
This adds support for changing owner from within map scripts, and fixes the traits that were incorrectly using `INotifyCapture` to update their internal references (pretty much all of them).

The need for these fixes can be demonstrated by adding the following to allies02:

``` lua
    proc = Actor.Create("proc", true, { Owner = ukraine, Location = DeployPoint.Location - CVec.New(10, 0)})
    pbox = Actor.Create("pbox", true, { Owner = ukraine, Location = DeployPoint.Location - CVec.New(12, 0)})
    Trigger.AfterDelay(50, function()
        proc.Owner = player
        pbox.Owner = player
        Actor.Create("harv", true, { Owner = player, Location = DeployPoint.Location - CVec.New(7, 0) })
    end)
```

Before 543abd3, ejecting the pillbox will produce a soviet soldier that will attack you, and your harvester will not be able to unload.

I have organized this so that changing the owner of refineries or resource storage will update the references, but not grant the capture bonuses (stealing the harvester / resources).
