### PR TITLE
Add in-game latency indicators

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -19,7 +19,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public LoadIngamePlayerOrObserverUILogic(Widget widget, World world)
 		{
 			var ingameRoot = widget.Get("INGAME_ROOT");
-			var playerRoot = ingameRoot.Get("PLAYER_ROOT");
+			var worldRoot = ingameRoot.Get("WORLD_ROOT");
+			var menuRoot = ingameRoot.Get("MENU_ROOT");
+			var playerRoot = worldRoot.Get("PLAYER_ROOT");
 
 			if (world.LocalPlayer == null)
 				Game.LoadWidget(world, "OBSERVER_WIDGETS", playerRoot, new WidgetArgs());
@@ -40,14 +42,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 			}
 
-			Game.LoadWidget(world, "CHAT_PANEL", ingameRoot, new WidgetArgs());
+			Game.LoadWidget(world, "CHAT_PANEL", worldRoot, new WidgetArgs());
 
-			Action showLeaveMapWidget = () =>
+			world.GameOver += () =>
 			{
-				ingameRoot.RemoveChildren();
-				Game.LoadWidget(world, "LEAVE_MAP_WIDGET", Ui.Root, new WidgetArgs());
+				worldRoot.RemoveChildren();
+				menuRoot.RemoveChildren();
+				Game.LoadWidget(world, "LEAVE_MAP_WIDGET", menuRoot, new WidgetArgs());
 			};
-			world.GameOver += showLeaveMapWidget;
 		}
 	}
 }

--- a/OpenRA.Mods.D2k/Widgets/Logic/IngameChromeLogic.cs
+++ b/OpenRA.Mods.D2k/Widgets/Logic/IngameChromeLogic.cs
@@ -25,7 +25,9 @@ namespace OpenRA.Mods.D2k.Widgets.Logic
 {
 	public class IngameChromeLogic
 	{
-		readonly Widget gameRoot;
+		readonly Widget ingameRoot;
+		readonly Widget worldRoot;
+		readonly Widget menuRoot;
 		readonly Widget playerRoot;
 		readonly World world;
 
@@ -33,8 +35,10 @@ namespace OpenRA.Mods.D2k.Widgets.Logic
 		public IngameChromeLogic(World world)
 		{
 			this.world = world;
-			gameRoot = Ui.Root.Get("INGAME_ROOT");
-			playerRoot = gameRoot.Get("PLAYER_ROOT");
+			ingameRoot = Ui.Root.Get("INGAME_ROOT");
+			worldRoot = ingameRoot.Get("WORLD_ROOT");
+			menuRoot = ingameRoot.Get("MENU_ROOT");
+			playerRoot = worldRoot.Get("PLAYER_ROOT");
 
 			InitRootWidgets();
 			if (world.LocalPlayer == null)
@@ -45,14 +49,14 @@ namespace OpenRA.Mods.D2k.Widgets.Logic
 
 		void InitRootWidgets()
 		{
-			Game.LoadWidget(world, "CHAT_PANEL", gameRoot, new WidgetArgs());
+			Game.LoadWidget(world, "CHAT_PANEL", ingameRoot, new WidgetArgs());
 
-			Action ShowLeaveMapWidget = () =>
+			world.GameOver += () =>
 			{
-				gameRoot.RemoveChildren();
-				Game.LoadWidget(world, "LEAVE_MAP_WIDGET", Ui.Root, new WidgetArgs());
+				worldRoot.RemoveChildren();
+				menuRoot.RemoveChildren();
+				Game.LoadWidget(world, "LEAVE_MAP_WIDGET", menuRoot, new WidgetArgs());
 			};
-			world.GameOver += ShowLeaveMapWidget;
 		}
 
 		void InitObserverWidgets()

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Network;
 using OpenRA.Widgets;
 using OpenRA.Traits;
 using OpenRA.Mods.RA;
@@ -20,7 +21,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 	class GameInfoStatsLogic
 	{
 		[ObjectCreator.UseCtor]
-		public GameInfoStatsLogic(Widget widget, World world)
+		public GameInfoStatsLogic(Widget widget, World world, OrderManager orderManager)
 		{
 			var lp = world.LocalPlayer;
 
@@ -45,6 +46,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var pp = p;
 				var client = world.LobbyInfo.ClientWithIndex(pp.ClientIndex);
 				var item = playerTemplate.Clone();
+
+				LobbyUtils.SetupClientWidget(item, client, orderManager, client.Bot == null);
+
 				var nameLabel = item.Get<LabelWidget>("NAME");
 				nameLabel.GetText = () =>
 				{

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
@@ -30,6 +30,10 @@ namespace OpenRA.Mods.RA.Widgets
 		{
 			this.orderManager = orderManager;
 
+			var mpe = world.WorldActor.TraitOrDefault<MenuPaletteEffect>();
+			if (mpe != null)
+				mpe.Fade(mpe.Info.MenuEffect);
+
 			widget.Get<LabelWidget>("VERSION_LABEL").Text = Game.modData.Manifest.Mod.Version;
 
 			var showStats = false;
@@ -92,7 +96,6 @@ namespace OpenRA.Mods.RA.Widgets
 			leaveButton.OnClick = () =>
 			{
 				leaveButton.Disabled = true;
-				var mpe = world.WorldActor.TraitOrDefault<MenuPaletteEffect>();
 
 				Sound.PlayNotification(world.Map.Rules, null, "Speech", "Leave",
 					world.LocalPlayer == null ? null : world.LocalPlayer.Country.Race);

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameMenuLogic.cs
@@ -56,7 +56,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			Action closeMenu = () =>
 			{
 				Ui.CloseWindow();
-				Ui.Root.RemoveChild(menu);
 				if (mpe != null)
 					mpe.Fade(MenuPaletteEffect.EffectType.None);
 				onExit();
@@ -110,12 +109,16 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			resumeButton.IsDisabled = () => resumeDisabled;
 			resumeButton.OnClick = closeMenu;
 
-			// Game info panel
-			var gameInfoPanel = Game.LoadWidget(world, "GAME_INFO_PANEL", menu, new WidgetArgs()
+			var panelRoot = widget.GetOrNull("PANEL_ROOT");
+			if (panelRoot != null)
 			{
-				{ "activePanel", activePanel }
-			});
-			gameInfoPanel.IsVisible = () => !hideMenu;
+				var gameInfoPanel = Game.LoadWidget(world, "GAME_INFO_PANEL", panelRoot, new WidgetArgs()
+				{
+					{ "activePanel", activePanel }
+				});
+
+				gameInfoPanel.IsVisible = () => !hideMenu;
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -665,7 +665,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					if (template == null || template.Id != editablePlayerTemplate.Id)
 						template = editablePlayerTemplate.Clone();
 
-					LobbyUtils.SetupClientWidget(template, slot, client, orderManager, client.Bot == null);
+					LobbyUtils.SetupClientWidget(template, client, orderManager, client.Bot == null);
 
 					if (client.Bot != null)
 						LobbyUtils.SetupEditableSlotWidget(template, slot, client, orderManager, modRules);
@@ -684,7 +684,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					if (template == null || template.Id != nonEditablePlayerTemplate.Id)
 						template = nonEditablePlayerTemplate.Clone();
 
-					LobbyUtils.SetupClientWidget(template, slot, client, orderManager, client.Bot == null);
+					LobbyUtils.SetupClientWidget(template, client, orderManager, client.Bot == null);
 					LobbyUtils.SetupNameWidget(template, slot, client);
 					LobbyUtils.SetupKickWidget(template, slot, client, orderManager, lobby,
 						() => panel = PanelType.Kick, () => panel = PanelType.Players);
@@ -734,7 +734,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						() => panel = PanelType.Kick, () => panel = PanelType.Players);
 				}
 
-				LobbyUtils.SetupClientWidget(template, null, c, orderManager, true);
+				LobbyUtils.SetupClientWidget(template, c, orderManager, true);
 				template.IsVisible = () => true;
 
 				if (idx >= players.Children.Count)

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -242,7 +242,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 		}
 
-		public static void SetupClientWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, bool visible)
+		public static void SetupClientWidget(Widget parent, Session.Client c, OrderManager orderManager, bool visible)
 		{
 			parent.Get("ADMIN_INDICATOR").IsVisible = () => c.IsAdmin;
 			var block = parent.Get("LATENCY");

--- a/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 	public class OrderButtonsChromeLogic
 	{
 		readonly World world;
-		readonly Widget ingameRoot;
+		readonly Widget worldRoot;
+		readonly Widget menuRoot;
 		bool disableSystemButtons;
 		Widget currentWidget;
 
@@ -28,9 +29,11 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		public OrderButtonsChromeLogic(Widget widget, World world)
 		{
 			this.world = world;
-			ingameRoot = Ui.Root.Get("INGAME_ROOT");
+			var ingameRoot = Ui.Root.Get("INGAME_ROOT");
+			worldRoot = ingameRoot.Get("WORLD_ROOT");
+			menuRoot = ingameRoot.Get("MENU_ROOT");
 
-			Action removeCurrentWidget = () => Ui.Root.RemoveChild(currentWidget);
+			Action removeCurrentWidget = () => menuRoot.RemoveChild(currentWidget);
 			world.GameOver += removeCurrentWidget;
 
 			// Order Buttons
@@ -127,7 +130,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var cachedPause = world.PredictedPaused;
 
 			if (button.HideIngameUI)
-				ingameRoot.IsVisible = () => false;
+				worldRoot.IsVisible = () => false;
 
 			if (button.Pause && world.LobbyInfo.IsSinglePlayer)
 				world.SetPauseState(true);
@@ -136,15 +139,16 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			widgetArgs.Add("onExit", () =>
 			{
 				if (button.HideIngameUI)
-					ingameRoot.IsVisible = () => true;
+					worldRoot.IsVisible = () => true;
 
 				if (button.Pause && world.LobbyInfo.IsSinglePlayer)
 					world.SetPauseState(cachedPause);
 
+				menuRoot.RemoveChild(currentWidget);
 				disableSystemButtons = false;
 			});
 
-			currentWidget = Game.LoadWidget(world, button.MenuContainer, Ui.Root, widgetArgs);
+			currentWidget = Game.LoadWidget(world, button.MenuContainer, menuRoot, widgetArgs);
 		}
 
 		static void BindOrderButton<T>(World world, ButtonWidget w, string icon)

--- a/mods/cnc/chrome/ingame-infobriefing.yaml
+++ b/mods/cnc/chrome/ingame-infobriefing.yaml
@@ -1,5 +1,5 @@
 Container@MAP_PANEL:
-	Height:	PARENT_BOTTOM
+	Height: PARENT_BOTTOM
 	Width: PARENT_RIGHT
 	Logic: GameInfoBriefingLogic
 	Children:

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -77,9 +77,34 @@ Container@SKIRMISH_STATS:
 					X: 2
 					Y: 0
 					Children:
+						Image@ADMIN_INDICATOR:
+							ImageCollection: lobby-bits
+							ImageName: admin
+							X: 5
+							Y: 1
+							Visible: false
+						Background@LATENCY:
+							Background: button
+							X: 3
+							Y: 7
+							Width: 11
+							Height: 14
+							Visible: false
+							Children:
+								ColorBlock@LATENCY_COLOR:
+									X: 2
+									Y: 2
+									Width: PARENT_RIGHT-4
+									Height: PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer: TOOLTIP_CONTAINER
+							Template: CLIENT_TOOLTIP
+							X: 5
+							Width: 11
+							Height: 25
 						Label@NAME:
-							X: 10
-							Width: 150
+							X: 17
+							Width: 143
 							Height: 25
 						Image@FACTIONFLAG:
 							X: 159

--- a/mods/cnc/chrome/ingame-leavemap.yaml
+++ b/mods/cnc/chrome/ingame-leavemap.yaml
@@ -18,7 +18,7 @@ Container@LEAVE_MAP_WIDGET:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			Background: shellmapborder
-		Container@LEAVE_MAP_SIMPLE
+		Container@LEAVE_MAP_SIMPLE:
 			X: (WINDOW_RIGHT - WIDTH) / 2
 			Y: (WINDOW_BOTTOM - HEIGHT) / 2
 			Width: 370

--- a/mods/cnc/chrome/ingame-menu.yaml
+++ b/mods/cnc/chrome/ingame-menu.yaml
@@ -20,6 +20,7 @@ Container@INGAME_MENU:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			Background: shellmapborder
+		Container@PANEL_ROOT:
 		Container@MENU_BUTTONS:
 			X: (WINDOW_RIGHT-WIDTH)/2
 			Y: WINDOW_BOTTOM-33-HEIGHT-10

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -1,60 +1,63 @@
 Container@INGAME_ROOT:
 	Logic: LoadIngamePlayerOrObserverUILogic
 	Children:
-		LogicTicker@DISCONNECT_WATCHER:
-			Logic: DisconnectWatcherLogic
-		Container@GAME_TIMER_BLOCK:
-			Logic: GameTimerLogic
-			X: WINDOW_RIGHT/2 - WIDTH
-			Width: 100
-			Height: 55
+		Container@WORLD_ROOT:
 			Children:
-				Label@GAME_TIMER:
-					Width: PARENT_RIGHT
-					Height: 30
-					Align: Center
-					Font: Title
-					Contrast: true
-				Label@GAME_TIMER_STATUS:
-					Y: 35
-					Width: PARENT_RIGHT
-					Height: 15
-					Align: Center
-					Font: Bold
-					Contrast: true
-		StrategicProgress@STRATEGIC_PROGRESS:
-			X: WINDOW_RIGHT/2
-			Y: 40
-		Container@PERFORMANCE_INFO:
-			Logic: PerfDebugLogic
-			Children:
-				Label@PERF_TEXT:
-					X: WINDOW_RIGHT - 200
-					Y: WINDOW_BOTTOM - 70
-					Width: 170
-					Height: 40
-					Contrast: true
-					VAlign: Top
-				Background@GRAPH_BG:
-					X: 10
-					Y: WINDOW_BOTTOM-HEIGHT-10
-					Width: 220
-					Height: 220
-					Background: panel-black
+				LogicTicker@DISCONNECT_WATCHER:
+					Logic: DisconnectWatcherLogic
+				Container@GAME_TIMER_BLOCK:
+					Logic: GameTimerLogic
+					X: WINDOW_RIGHT/2 - WIDTH
+					Width: 100
+					Height: 55
 					Children:
-						PerfGraph@GRAPH:
+						Label@GAME_TIMER:
+							Width: PARENT_RIGHT
+							Height: 30
+							Align: Center
+							Font: Title
+							Contrast: true
+						Label@GAME_TIMER_STATUS:
+							Y: 35
+							Width: PARENT_RIGHT
+							Height: 15
+							Align: Center
+							Font: Bold
+							Contrast: true
+				StrategicProgress@STRATEGIC_PROGRESS:
+					X: WINDOW_RIGHT/2
+					Y: 40
+				Container@PERFORMANCE_INFO:
+					Logic: PerfDebugLogic
+					Children:
+						Label@PERF_TEXT:
+							X: WINDOW_RIGHT - 200
+							Y: WINDOW_BOTTOM - 70
+							Width: 170
+							Height: 40
+							Contrast: true
+							VAlign: Top
+						Background@GRAPH_BG:
 							X: 10
-							Y: 10
-							Width: 200
-							Height: 200
-		WorldInteractionController@INTERACTION_CONTROLLER:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-		ViewportController:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-			TooltipContainer: TOOLTIP_CONTAINER
-		Container@PLAYER_ROOT:
+							Y: WINDOW_BOTTOM-HEIGHT-10
+							Width: 220
+							Height: 220
+							Background: panel-black
+							Children:
+								PerfGraph@GRAPH:
+									X: 10
+									Y: 10
+									Width: 200
+									Height: 200
+				WorldInteractionController@INTERACTION_CONTROLLER:
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+				ViewportController:
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+					TooltipContainer: TOOLTIP_CONTAINER
+				Container@PLAYER_ROOT:
+		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Container@OBSERVER_WIDGETS:

--- a/mods/d2k/chrome/ingame-menu.yaml
+++ b/mods/d2k/chrome/ingame-menu.yaml
@@ -9,6 +9,7 @@ Container@INGAME_MENU:
 			Align: Right
 			Font: Regular
 			Contrast: True
+		Container@PANEL_ROOT:
 		Background@MENU_BUTTONS:
 			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
 			Y: (WINDOW_BOTTOM - HEIGHT)/2

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -1,5 +1,14 @@
 Container@OBSERVER_WIDGETS:
 	Children:
+		MenuButton@OPTIONS_BUTTON:
+			Logic: OrderButtonsChromeLogic
+			X: 0
+			Y: 0
+			Width: 160
+			Height: 25
+			Text: Options (Esc)
+			Font: Bold
+			Key: escape
 		MenuButton@OBSERVER_STATS_BUTTON:
 			Logic: OrderButtonsChromeLogic
 			MenuContainer: INGAME_OBSERVERSTATS_BG

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -3,6 +3,15 @@ Container@PLAYER_WIDGETS:
 		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
 			Logic: ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:
+		MenuButton@OPTIONS_BUTTON:
+			Logic: OrderButtonsChromeLogic
+			X: 0
+			Y: 0
+			Width: 160
+			Height: 25
+			Text: Options (Esc)
+			Font: Bold
+			Key: escape
 		MenuButton@DIPLOMACY_BUTTON:
 			Logic: OrderButtonsChromeLogic
 			MenuContainer: INGAME_DIPLOMACY_BG

--- a/mods/d2k/chrome/ingame.yaml
+++ b/mods/d2k/chrome/ingame.yaml
@@ -1,81 +1,74 @@
 Container@INGAME_ROOT:
 	Logic: IngameChromeLogic
 	Children:
-		LogicTicker@DISCONNECT_WATCHER:
-			Logic: DisconnectWatcherLogic
-		WorldInteractionController@INTERACTION_CONTROLLER:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-		ViewportController:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-			TooltipContainer: TOOLTIP_CONTAINER
-		WorldCommand:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-		Container@GAME_TIMER_BLOCK:
-			Logic: GameTimerLogic
-			X: WINDOW_RIGHT/2 - WIDTH
-			Width: 100
-			Height: 55
+		Container@WORLD_ROOT:
 			Children:
-				Label@GAME_TIMER:
-					Width: PARENT_RIGHT
-					Height: 30
-					Align: Center
-					Font: Title
-					Contrast: true
-				Label@GAME_TIMER_STATUS:
-					Y: 32
-					Width: PARENT_RIGHT
-					Height: 15
-					Align: Center
-					Font: Bold
-					Contrast: true
-		StrategicProgress@STRATEGIC_PROGRESS:
-			X: WINDOW_RIGHT/2
-			Y: 40
-		SupportPowerTimer@SUPPORT_POWER_TIMER:
-			X: 80
-			Y: 34
-			Order: Descending
-		Container@PLAYER_ROOT:
-		MenuButton@OPTIONS_BUTTON:
-			Logic: OrderButtonsChromeLogic
-			X: 0
-			Y: 0
-			Width: 160
-			Height: 25
-			Text: Options (Esc)
-			Font: Bold
-			Key: escape
-		Container@PERFORMANCE_INFO:
-			Logic: PerfDebugLogic
-			Children:
-				Label@PERF_TEXT:
-					X: WINDOW_RIGHT - 200
-					Y: WINDOW_BOTTOM - 70
-					Width: 170
-					Height: 40
-					Contrast: true
-				Background@GRAPH_BG:
-					ClickThrough: true
-					Background: dialog4
-					X: 30
-					Y: WINDOW_BOTTOM - 240
-					Width: 210
-					Height: 210
+				LogicTicker@DISCONNECT_WATCHER:
+					Logic: DisconnectWatcherLogic
+				WorldInteractionController@INTERACTION_CONTROLLER:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+				ViewportController:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+					TooltipContainer: TOOLTIP_CONTAINER
+				WorldCommand:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+				StrategicProgress@STRATEGIC_PROGRESS:
+					X: WINDOW_RIGHT/2
+					Y: 40
+				SupportPowerTimer@SUPPORT_POWER_TIMER:
+					X: 80
+					Y: 34
+					Order: Descending
+				Container@PLAYER_ROOT:
+				Container@PERFORMANCE_INFO:
+					Logic: PerfDebugLogic
 					Children:
-						PerfGraph@GRAPH:
-							X: 5
-							Y: 5
-							Width: 200
-							Height: 200
+						Label@PERF_TEXT:
+							X: WINDOW_RIGHT - 200
+							Y: WINDOW_BOTTOM - 70
+							Width: 170
+							Height: 40
+							Contrast: true
+						Background@GRAPH_BG:
+							ClickThrough: true
+							Background: dialog4
+							X: 30
+							Y: WINDOW_BOTTOM - 240
+							Width: 210
+							Height: 210
+							Children:
+								PerfGraph@GRAPH:
+									X: 5
+									Y: 5
+									Width: 200
+									Height: 200
+				Container@GAME_TIMER_BLOCK:
+					Logic: GameTimerLogic
+					X: WINDOW_RIGHT/2 - WIDTH
+					Width: 100
+					Height: 55
+					Children:
+						Label@GAME_TIMER:
+							Width: PARENT_RIGHT
+							Height: 30
+							Align: Center
+							Font: Title
+							Contrast: true
+						Label@GAME_TIMER_STATUS:
+							Y: 32
+							Width: PARENT_RIGHT
+							Height: 15
+							Align: Center
+							Font: Bold
+							Contrast: true
+		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
-

--- a/mods/ra/chrome/ingame-infostats.yaml
+++ b/mods/ra/chrome/ingame-infostats.yaml
@@ -3,7 +3,7 @@ Container@SKIRMISH_STATS:
 	Width: PARENT_RIGHT
 	Logic: GameInfoStatsLogic
 	Children:
-		Label@MISSION:
+		Label@STATS_OBJECTIVE:
 			X: 20
 			Y: 20
 			Width: 482
@@ -77,9 +77,33 @@ Container@SKIRMISH_STATS:
 					X: 2
 					Y: 0
 					Children:
+						Image@ADMIN_INDICATOR:
+							ImageCollection: lobby-bits
+							ImageName: admin
+							X: 5
+							Y: 1
+							Visible: false
+						Container@LATENCY:
+							X: 3
+							Y: 7
+							Width: 11
+							Height: 14
+							Visible: false
+							Children:
+								ColorBlock@LATENCY_COLOR:
+									X: 2
+									Y: 2
+									Width: PARENT_RIGHT-4
+									Height: PARENT_BOTTOM-4
+						ClientTooltipRegion@CLIENT_REGION:
+							TooltipContainer: TOOLTIP_CONTAINER
+							Template: CLIENT_TOOLTIP
+							X: 3
+							Width: 11
+							Height: 25
 						Label@NAME:
-							X: 10
-							Width: 150
+							X: 17
+							Width: 143
 							Height: 25
 						Image@FACTIONFLAG:
 							X: 159

--- a/mods/ra/chrome/ingame-leavemap.yaml
+++ b/mods/ra/chrome/ingame-leavemap.yaml
@@ -20,7 +20,7 @@ Container@LEAVE_MAP_WIDGET:
 			Align: Center
 			Font: Regular
 			Contrast: True
-		Container@LEAVE_MAP_SIMPLE
+		Container@LEAVE_MAP_SIMPLE:
 			X: (WINDOW_RIGHT - WIDTH) / 2
 			Y: (WINDOW_BOTTOM - HEIGHT) / 2
 			Width: 370

--- a/mods/ra/chrome/ingame-menu.yaml
+++ b/mods/ra/chrome/ingame-menu.yaml
@@ -22,6 +22,7 @@ Container@INGAME_MENU:
 			Align: Center
 			Font: Regular
 			Contrast: True
+		Container@PANEL_ROOT:
 		Background@MENU_BUTTONS:
 			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
 			Y: (WINDOW_BOTTOM - HEIGHT)/2

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -1,53 +1,55 @@
 Container@INGAME_ROOT:
 	Logic: LoadIngamePlayerOrObserverUILogic
 	Children:
-		LogicTicker@DISCONNECT_WATCHER:
-			Logic: DisconnectWatcherLogic
-		WorldInteractionController@INTERACTION_CONTROLLER:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-		ViewportController:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-			TooltipContainer: TOOLTIP_CONTAINER
-		WorldCommand:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-		StrategicProgress@STRATEGIC_PROGRESS:
-			X: WINDOW_RIGHT/2
-			Y: 40
-		SupportPowerTimer@SUPPORT_POWER_TIMER:
-			X: 80
-			Y: 10
-			Order: Descending
-		Container@PLAYER_ROOT:
-		Container@PERFORMANCE_INFO:
-			Logic: PerfDebugLogic
+		Container@WORLD_ROOT:
 			Children:
-				Label@PERF_TEXT:
-					X: WINDOW_RIGHT - 200
-					Y: WINDOW_BOTTOM - 70
-					Width: 170
-					Height: 40
-					Contrast: true
-				Background@GRAPH_BG:
-					ClickThrough: true
-					Background: dialog4
-					X: 30
-					Y: WINDOW_BOTTOM - 240
-					Width: 210
-					Height: 210
+				LogicTicker@DISCONNECT_WATCHER:
+					Logic: DisconnectWatcherLogic
+				WorldInteractionController@INTERACTION_CONTROLLER:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+				ViewportController:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+					TooltipContainer: TOOLTIP_CONTAINER
+				WorldCommand:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+				StrategicProgress@STRATEGIC_PROGRESS:
+					X: WINDOW_RIGHT/2
+					Y: 40
+				SupportPowerTimer@SUPPORT_POWER_TIMER:
+					X: 80
+					Y: 10
+					Order: Descending
+				Container@PLAYER_ROOT:
+				Container@PERFORMANCE_INFO:
+					Logic: PerfDebugLogic
 					Children:
-						PerfGraph@GRAPH:
-							X: 5
-							Y: 5
-							Width: 200
-							Height: 200
+						Label@PERF_TEXT:
+							X: WINDOW_RIGHT - 200
+							Y: WINDOW_BOTTOM - 70
+							Width: 170
+							Height: 40
+							Contrast: true
+						Background@GRAPH_BG:
+							ClickThrough: true
+							Background: dialog4
+							X: 30
+							Y: WINDOW_BOTTOM - 240
+							Width: 210
+							Height: 210
+							Children:
+								PerfGraph@GRAPH:
+									X: 5
+									Y: 5
+									Width: 200
+									Height: 200
+		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
-

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -3,6 +3,16 @@ Container@PLAYER_WIDGETS:
 		LogicKeyListener@CONTROLGROUP_KEYHANDLER:
 			Logic: ControlGroupLogic
 		LogicTicker@SIDEBAR_TICKER:
+		MenuButton@OPTIONS_BUTTON:
+			Logic: OrderButtonsChromeLogic
+			MenuContainer: INGAME_MENU
+			X: 0
+			Y: 0
+			Width: 160
+			Height: 25
+			Text: Options (Esc)
+			Font: Bold
+			Key: escape
 		MenuButton@DIPLOMACY_BUTTON:
 			Logic: OrderButtonsChromeLogic
 			MenuContainer: INGAME_DIPLOMACY_BG

--- a/mods/ts/chrome/ingame.yaml
+++ b/mods/ts/chrome/ingame.yaml
@@ -1,82 +1,74 @@
 Container@INGAME_ROOT:
 	Logic: IngameChromeLogic
 	Children:
-		LogicTicker@DISCONNECT_WATCHER:
-			Logic: DisconnectWatcherLogic
-		WorldInteractionController@INTERACTION_CONTROLLER:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-		ViewportController:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-			TooltipContainer: TOOLTIP_CONTAINER
-		WorldCommand:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-		Container@GAME_TIMER_BLOCK:
-			Logic: GameTimerLogic
-			X: WINDOW_RIGHT/2 - WIDTH
-			Width: 100
-			Height: 55
+		Container@WORLD_ROOT:
 			Children:
-				Label@GAME_TIMER:
-					Width: PARENT_RIGHT
-					Height: 15
-					Align: Center
-					Font: Title
-					Contrast: true
-				Label@GAME_TIMER_STATUS:
-					Y: 35
-					Width: PARENT_RIGHT
-					Height: 15
-					Align: Center
-					Font: Bold
-					Contrast: true
-		StrategicProgress@STRATEGIC_PROGRESS:
-			X: WINDOW_RIGHT/2
-			Y: 40
-		SupportPowerTimer@SUPPORT_POWER_TIMER:
-			X: 80
-			Y: 34
-			Order: Descending
-		Container@PLAYER_ROOT:
-		MenuButton@OPTIONS_BUTTON:
-			Logic: OrderButtonsChromeLogic
-			MenuContainer: INGAME_MENU
-			X: 0
-			Y: 0
-			Width: 160
-			Height: 25
-			Text: Options (Esc)
-			Font: Bold
-			Key: escape
-		Container@PERFORMANCE_INFO:
-			Logic: PerfDebugLogic
-			Children:
-				Label@PERF_TEXT:
-					X: WINDOW_RIGHT - 200
-					Y: WINDOW_BOTTOM - 70
-					Width: 170
-					Height: 40
-					Contrast: true
-				Background@GRAPH_BG:
-					ClickThrough: true
-					Background: dialog4
-					X: 30
-					Y: WINDOW_BOTTOM - 240
-					Width: 210
-					Height: 210
+				LogicTicker@DISCONNECT_WATCHER:
+					Logic: DisconnectWatcherLogic
+				WorldInteractionController@INTERACTION_CONTROLLER:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+				ViewportController:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+					TooltipContainer: TOOLTIP_CONTAINER
+				WorldCommand:
+					X: 0
+					Y: 0
+					Width: WINDOW_RIGHT
+					Height: WINDOW_BOTTOM
+				StrategicProgress@STRATEGIC_PROGRESS:
+					X: WINDOW_RIGHT/2
+					Y: 40
+				SupportPowerTimer@SUPPORT_POWER_TIMER:
+					X: 80
+					Y: 34
+					Order: Descending
+				Container@PLAYER_ROOT:
+				Container@PERFORMANCE_INFO:
+					Logic: PerfDebugLogic
 					Children:
-						PerfGraph@GRAPH:
-							X: 5
-							Y: 5
-							Width: 200
-							Height: 200
+						Label@PERF_TEXT:
+							X: WINDOW_RIGHT - 200
+							Y: WINDOW_BOTTOM - 70
+							Width: 170
+							Height: 40
+							Contrast: true
+						Background@GRAPH_BG:
+							ClickThrough: true
+							Background: dialog4
+							X: 30
+							Y: WINDOW_BOTTOM - 240
+							Width: 210
+							Height: 210
+							Children:
+								PerfGraph@GRAPH:
+									X: 5
+									Y: 5
+									Width: 200
+									Height: 200
+				Container@GAME_TIMER_BLOCK:
+					Logic: GameTimerLogic
+					X: WINDOW_RIGHT/2 - WIDTH
+					Width: 100
+					Height: 55
+					Children:
+						Label@GAME_TIMER:
+							Width: PARENT_RIGHT
+							Height: 15
+							Align: Center
+							Font: Title
+							Contrast: true
+						Label@GAME_TIMER_STATUS:
+							Y: 35
+							Width: PARENT_RIGHT
+							Height: 15
+							Align: Center
+							Font: Bold
+							Contrast: true
+		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
-


### PR DESCRIPTION
This fixes a few issues with the in-game menu plumbing, and adds the latency indicators from the lobby to the in-game and end-game score panels.

Closes #2281, #4577.
