### PR TITLE
Release more sheet buffers

### DIFF
--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -62,8 +62,10 @@ namespace OpenRA.Graphics
 
 		public void Preload()
 		{
+			SpriteCache.SheetBuilder.Current.CreateBuffer();
 			foreach (var unitSeq in sequences.Value.Values)
 				foreach (var seq in unitSeq.Value.Values) { }
+			SpriteCache.SheetBuilder.Current.ReleaseBuffer();
 		}
 	}
 

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -27,13 +27,7 @@ namespace OpenRA.Graphics
 		public readonly Size Size;
 		public byte[] GetData()
 		{
-				if (data != null)
-					return data;
-				if (texture == null)
-					data = new byte[4 * Size.Width * Size.Height];
-				else
-					data = texture.GetData();
-				releaseBufferOnCommit = false;
+			CreateBuffer();
 			return data;
 		}
 		public bool Buffered { get { return data != null || texture == null; } }
@@ -142,6 +136,17 @@ namespace OpenRA.Graphics
 			bitmap.UnlockBits(bd);
 
 			return bitmap;
+		}
+
+		public void CreateBuffer()
+		{
+			if (data != null)
+				return;
+			if (texture == null)
+				data = new byte[4 * Size.Width * Size.Height];
+			else
+				data = texture.GetData();
+			releaseBufferOnCommit = false;
 		}
 
 		public void CommitData()

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -73,16 +73,17 @@ namespace OpenRA.Graphics
 
 		void GenerateTexture()
 		{
-			if (texture == null)
+			lock (textureLock)
 			{
-				texture = Game.Renderer.Device.CreateTexture();
-				dirty = true;
-			}
-
-			if (data != null)
-			{
-				lock (textureLock)
+				if (texture == null)
 				{
+					texture = Game.Renderer.Device.CreateTexture();
+					dirty = true;
+				}
+
+				if (data != null)
+				{
+
 					if (dirty)
 					{
 						texture.SetData(data, Size.Width, Size.Height);
@@ -140,13 +141,16 @@ namespace OpenRA.Graphics
 
 		public void CreateBuffer()
 		{
-			if (data != null)
-				return;
-			if (texture == null)
-				data = new byte[4 * Size.Width * Size.Height];
-			else
-				data = texture.GetData();
-			releaseBufferOnCommit = false;
+			lock (textureLock)
+			{
+				if (data != null)
+					return;
+				if (texture == null)
+					data = new byte[4 * Size.Width * Size.Height];
+				else
+					data = texture.GetData();
+				releaseBufferOnCommit = false;
+			}
 		}
 
 		public void CommitData()

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -25,10 +25,8 @@ namespace OpenRA.Graphics
 		byte[] data;
 
 		public readonly Size Size;
-		public byte[] Data
+		public byte[] GetData()
 		{
-			get
-			{
 				if (data != null)
 					return data;
 				if (texture == null)
@@ -36,8 +34,7 @@ namespace OpenRA.Graphics
 				else
 					data = texture.GetData();
 				releaseBufferOnCommit = false;
-				return data;
-			}
+			return data;
 		}
 		public bool Buffered { get { return data != null || texture == null; } }
 
@@ -72,15 +69,12 @@ namespace OpenRA.Graphics
 			ReleaseBuffer();
 		}
 
-		public ITexture Texture
+		public ITexture GetTexture()
 		{
 			// This is only called from the main thread but 'dirty'
 			// is set from other threads too via CommitData().
-			get
-			{
-				GenerateTexture();
-				return texture;
-			}
+			GenerateTexture();
+			return texture;
 		}
 
 		void GenerateTexture()
@@ -108,7 +102,7 @@ namespace OpenRA.Graphics
 
 		public Bitmap AsBitmap()
 		{
-			var d = Data;
+			var d = GetData();
 			var dataStride = 4 * Size.Width;
 			var bitmap = new Bitmap(Size.Width, Size.Height);
 
@@ -123,7 +117,7 @@ namespace OpenRA.Graphics
 
 		public Bitmap AsBitmap(TextureChannel channel, IPalette pal)
 		{
-			var d = Data;
+			var d = GetData();
 			var dataStride = 4 * Size.Width;
 			var bitmap = new Bitmap(Size.Width, Size.Height);
 			var channelOffset = (int)channel;

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Graphics
 
 		public static Sheet AllocateSheet()
 		{
-			return new Sheet(new Size(Renderer.SheetSize, Renderer.SheetSize), true);
+			return new Sheet(new Size(Renderer.SheetSize, Renderer.SheetSize));
 		}
 
 		public SheetBuilder(SheetType t)

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Graphics
 				unsafe
 				{
 					var p = (byte*)bitmap.Buffer;
-					var dest = s.sheet.Data;
+					var dest = s.sheet.GetData();
 					var destStride = s.sheet.Size.Width * 4;
 
 					for (var j = 0; j < s.size.Y; j++)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Graphics
 		{
 			if (nv > 0)
 			{
-				shader.SetTexture("DiffuseTexture", currentSheet.Texture);
+				shader.SetTexture("DiffuseTexture", currentSheet.GetTexture());
 
 				renderer.Device.SetBlendMode(currentBlend);
 				shader.Render(() =>
@@ -109,7 +109,7 @@ namespace OpenRA.Graphics
 
 		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, Sheet sheet)
 		{
-			shader.SetTexture("DiffuseTexture", sheet.Texture);
+			shader.SetTexture("DiffuseTexture", sheet.GetTexture());
 			renderer.Device.SetBlendMode(BlendMode.Alpha);
 			shader.Render(() => renderer.DrawBatch(buffer, start, length, type));
 			renderer.Device.SetBlendMode(BlendMode.None);

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Graphics
 					throw new SheetOverflowException("Terrain sheet overflow. Try increasing the tileset SheetSize parameter.");
 				allocated = true;
 
-				return new Sheet(new Size(tileset.SheetSize, tileset.SheetSize), true);
+				return new Sheet(new Size(tileset.SheetSize, tileset.SheetSize));
 			};
 
 			sheetBuilder = new SheetBuilder(SheetType.Indexed, allocate);

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Graphics
 		public static void FastCopyIntoChannel(Sprite dest, byte[] src) { FastCopyIntoChannel(dest, 0, src); }
 		public static void FastCopyIntoChannel(Sprite dest, int channelOffset, byte[] src)
 		{
-			var data = dest.sheet.Data;
+			var data = dest.sheet.GetData();
 			var srcStride = dest.bounds.Width;
 			var destStride = dest.sheet.Size.Width * 4;
 			var destOffset = destStride * dest.bounds.Top + dest.bounds.Left * 4 + channelMasks[(int)dest.channel + channelOffset];
@@ -64,7 +64,7 @@ namespace OpenRA.Graphics
 
 		public static void FastCopyIntoSprite(Sprite dest, Bitmap src)
 		{
-			var data = dest.sheet.Data;
+			var data = dest.sheet.GetData();
 			var dataStride = dest.sheet.Size.Width * 4;
 			var x = dest.bounds.Left * 4;
 			var width = dest.bounds.Width * 4;

--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -257,7 +257,7 @@ namespace OpenRA.Graphics
 		            float[] ambientLight, float[] diffuseLight,
 		            int colorPalette, int normalsPalette)
 		{
-			shader.SetTexture("DiffuseTexture", renderData.Sheet.Texture);
+			shader.SetTexture("DiffuseTexture", renderData.Sheet.GetTexture());
 			shader.SetVec("PaletteRows", (colorPalette + 0.5f) / HardwarePalette.MaxPalettes,
 			              				 (normalsPalette + 0.5f) / HardwarePalette.MaxPalettes);
 			shader.SetMatrix("TransformMatrix", t);

--- a/OpenRA.Game/Widgets/VqaPlayerWidget.cs
+++ b/OpenRA.Game/Widgets/VqaPlayerWidget.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Widgets
 
 			var size = Math.Max(video.Width, video.Height);
 			var textureSize = Exts.NextPowerOf2(size);
-			var videoSheet = new Sheet(new Size(textureSize, textureSize), false);
+			var videoSheet = new Sheet(new Size(textureSize, textureSize));
 
 			videoSheet.Texture.ScaleFilter = TextureScaleFilter.Linear;
 			videoSheet.Texture.SetData(video.FrameData);
@@ -89,7 +89,7 @@ namespace OpenRA.Widgets
 			for (var y = 0; y < scaledHeight; y += 2)
 				overlay[y, 0] = black;
 
-			var overlaySheet = new Sheet(new Size(1, Exts.NextPowerOf2(scaledHeight)), false);
+			var overlaySheet = new Sheet(new Size(1, Exts.NextPowerOf2(scaledHeight)));
 			overlaySheet.Texture.SetData(overlay);
 			overlaySprite = new Sprite(overlaySheet, new Rectangle(0, 0, 1, scaledHeight), TextureChannel.Alpha);
 		}

--- a/OpenRA.Game/Widgets/VqaPlayerWidget.cs
+++ b/OpenRA.Game/Widgets/VqaPlayerWidget.cs
@@ -63,8 +63,8 @@ namespace OpenRA.Widgets
 			var textureSize = Exts.NextPowerOf2(size);
 			var videoSheet = new Sheet(new Size(textureSize, textureSize));
 
-			videoSheet.Texture.ScaleFilter = TextureScaleFilter.Linear;
-			videoSheet.Texture.SetData(video.FrameData);
+			videoSheet.GetTexture().ScaleFilter = TextureScaleFilter.Linear;
+			videoSheet.GetTexture().SetData(video.FrameData);
 
 			videoSprite = new Sprite(videoSheet,
 				new Rectangle(
@@ -90,7 +90,7 @@ namespace OpenRA.Widgets
 				overlay[y, 0] = black;
 
 			var overlaySheet = new Sheet(new Size(1, Exts.NextPowerOf2(scaledHeight)));
-			overlaySheet.Texture.SetData(overlay);
+			overlaySheet.GetTexture().SetData(overlay);
 			overlaySprite = new Sprite(overlaySheet, new Rectangle(0, 0, 1, scaledHeight), TextureChannel.Alpha);
 		}
 
@@ -117,7 +117,7 @@ namespace OpenRA.Widgets
 				while (nextFrame > video.CurrentFrame)
 				{
 					video.AdvanceFrame();
-					videoSprite.sheet.Texture.SetData(video.FrameData);
+					videoSprite.sheet.GetTexture().SetData(video.FrameData);
 					skippedFrames++;
 				}
 
@@ -185,7 +185,7 @@ namespace OpenRA.Widgets
 			paused = true;
 			Sound.StopVideo();
 			video.Reset();
-			videoSprite.sheet.Texture.SetData(video.FrameData);
+			videoSprite.sheet.GetTexture().SetData(video.FrameData);
 			world.AddFrameEndTask(_ => onComplete());
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Widgets
 			back = new byte[4*256*256];
 
 			var rect = new Rectangle((int)(255*SRange[0]), (int)(255*(1 - VRange[1])), (int)(255*(SRange[1] - SRange[0]))+1, (int)(255*(VRange[1] - VRange[0])) + 1);
-			var mixerSheet = new Sheet(new Size(256, 256), false);
+			var mixerSheet = new Sheet(new Size(256, 256));
 			mixerSheet.Texture.SetData(front, 256, 256);
 			mixerSprite = new Sprite(mixerSheet, rect, TextureChannel.Alpha);
 		}

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var rect = new Rectangle((int)(255*SRange[0]), (int)(255*(1 - VRange[1])), (int)(255*(SRange[1] - SRange[0]))+1, (int)(255*(VRange[1] - VRange[0])) + 1);
 			var mixerSheet = new Sheet(new Size(256, 256));
-			mixerSheet.Texture.SetData(front, 256, 256);
+			mixerSheet.GetTexture().SetData(front, 256, 256);
 			mixerSprite = new Sprite(mixerSheet, rect, TextureChannel.Alpha);
 		}
 
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				try
 				{
-					mixerSprite.sheet.Texture.SetData(front, 256, 256);
+					mixerSprite.sheet.GetTexture().SetData(front, 256, 256);
 				}
 				finally
 				{

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			using (var hueBitmap = new Bitmap(256, 256))
 			{
-				var hueSheet = new Sheet(new Size(256, 256), false);
+				var hueSheet = new Sheet(new Size(256, 256));
 				hueSprite = new Sprite(hueSheet, new Rectangle(0, 0, 256, 1), TextureChannel.Alpha);
 
 				var bitmapData = hueBitmap.LockBits(hueBitmap.Bounds(),

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 						*(c + h) = HSLColor.FromHSV(h / 255f, 1, 1).RGB.ToArgb();
 				}
 				hueBitmap.UnlockBits(bitmapData);
-				hueSheet.Texture.SetData(hueBitmap);
+				hueSheet.GetTexture().SetData(hueBitmap);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -73,14 +73,14 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var r = new Rectangle(0, 0, width, height);
 				var s = new Size(terrainBitmap.Width, terrainBitmap.Height);
-				var terrainSheet = new Sheet(s, false);
+				var terrainSheet = new Sheet(s);
 				terrainSheet.Texture.SetData(terrainBitmap);
 				terrainSprite = new Sprite(terrainSheet, r, TextureChannel.Alpha);
 
 				// Data is set in Tick()
-				customTerrainSprite = new Sprite(new Sheet(s, false), r, TextureChannel.Alpha);
-				actorSprite = new Sprite(new Sheet(s, false), r, TextureChannel.Alpha);
-				shroudSprite = new Sprite(new Sheet(s, false), r, TextureChannel.Alpha);
+				customTerrainSprite = new Sprite(new Sheet(s), r, TextureChannel.Alpha);
+				actorSprite = new Sprite(new Sheet(s), r, TextureChannel.Alpha);
+				shroudSprite = new Sprite(new Sheet(s), r, TextureChannel.Alpha);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var r = new Rectangle(0, 0, width, height);
 				var s = new Size(terrainBitmap.Width, terrainBitmap.Height);
 				var terrainSheet = new Sheet(s);
-				terrainSheet.Texture.SetData(terrainBitmap);
+				terrainSheet.GetTexture().SetData(terrainBitmap);
 				terrainSprite = new Sprite(terrainSheet, r, TextureChannel.Alpha);
 
 				// Data is set in Tick()
@@ -203,16 +203,16 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				updateTicks = 12;
 				using (var bitmap = Minimap.CustomTerrainBitmap(world))
-					customTerrainSprite.sheet.Texture.SetData(bitmap);
+					customTerrainSprite.sheet.GetTexture().SetData(bitmap);
 			}
 
 			if (updateTicks == 8)
 				using (var bitmap = Minimap.ActorsBitmap(world))
-					actorSprite.sheet.Texture.SetData(bitmap);
+					actorSprite.sheet.GetTexture().SetData(bitmap);
 
 			if (updateTicks == 4)
 				using (var bitmap = Minimap.ShroudBitmap(world))
-					shroudSprite.sheet.Texture.SetData(bitmap);
+					shroudSprite.sheet.GetTexture().SetData(bitmap);
 
 			// Enable/Disable the radar
 			var enabled = IsEnabled();


### PR DESCRIPTION
Followup to #5712 - releases more sheet buffers allowing 96 MiB of memory to be freed.

Some background for anybody unfamiliar: prior to #5712, the Sheet class would permanently hold a reference to a managed copy of the texture it was representing. This is for performance as making small incremental updates was faster than getting and setting texture data from the texture itself all the time. Instead the changes were batched up in the managed buffer and committed on demand to the texture.
#5712 introduced a method to allow this buffer to be marked for release once committed to the texture. If no more incremental updates are planned this allows the buffer memory to be reclaimed. This is important because these buffers can be very large.

Even after #5712 there were still some sheets with buffers that stuck around, allocated by:
MapCache (16m)
SpriteFont (16m)
VoxelLoader (16m)
SequenceCache \* 4 (16m) (one per tileset)

This PR address 6 of those 7 sheets, freeing an additional 96 MiB.

The data buffer is now generated lazily, which solves the problem for VoxelLoader.
The 4 SequenceCache sheets are released as part of preloading the sequences - when preloading everything we know we won't be needing the buffer again later.
The MapCache sheet is now released when the map generation thread dies. In this particular case the texture may not get rendered for a while, so we make a manual call to force the buffer to be written to the texture after which it can be freed.

This only leaves a buffer for the SpriteFont sheet. When text is drawn the glyphs are lazily generated and so we can't easily get rid of the buffer without impacting either performance or flexibility.
