### PR TITLE
Repairable building by upgrade

### DIFF
--- a/OpenRA.Mods.RA/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.RA/Buildings/RepairableBuilding.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.RA.Buildings
 		public readonly int RepairInterval = 24;
 		public readonly int RepairStep = 7;
 		public readonly int[] RepairBonuses = { 100, 150, 175, 200, 220, 240, 260, 280, 300 };
+		public readonly bool CancelWhenDisabled = false;
 
 		public readonly string IndicatorPalettePrefix = "player";
 
@@ -70,7 +71,15 @@ namespace OpenRA.Mods.RA.Buildings
 		public void Tick(Actor self)
 		{
 			if (IsTraitDisabled)
+			{
+				if (RepairActive && Info.CancelWhenDisabled)
+				{
+					Repairers.Clear();
+					RepairActive = false;
+				}
+
 				return;
+			}
 
 			if (remainingTicks == 0)
 			{

--- a/OpenRA.Mods.RA/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/RepairIndicator.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			rb = building.TraitOrDefault<RepairableBuilding>();
 			anim = new Animation(building.World, "allyrepair");
-			anim.Paused = () => !rb.RepairActive;
+			anim.Paused = () => !rb.RepairActive || rb.IsTraitDisabled;
 
 			CycleRepairer();
 		}

--- a/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
@@ -31,7 +31,8 @@ namespace OpenRA.Mods.RA.Orders
 			if (mi.Button == MouseButton.Left)
 			{
 				var underCursor = world.ScreenMap.ActorsAt(mi)
-					.FirstOrDefault(a => !world.FogObscures(a) && a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) && a.HasTrait<RepairableBuilding>());
+					.FirstOrDefault(a => !world.FogObscures(a) && a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor)
+						&& a.TraitsImplementing<RepairableBuilding>().Any(t => !t.IsTraitDisabled));
 
 				if (underCursor == null)
 					yield break;


### PR DESCRIPTION
A piece for adding DeploysToUpgrade and hopefully fixing WithMakeAnimation.
Requires #6750.

With UpgradeActorsNear, it can be used to require a deployed Construction Yard near by in order to repair.
