### PR TITLE
MCV no longer loses controlgroup when transforming

### DIFF
--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -99,6 +99,12 @@ namespace OpenRA
 			Combine(world, groupActors, mods.HasModifier(Modifiers.Shift), false);
 		}
 
+		public void AddToControlGroup(Actor a, int group)
+		{
+			if (!controlGroups[group].Contains(a))
+				controlGroups[group].Add(a);
+		}
+
 		public int? GetControlGroupForActor(Actor a)
 		{
 			return controlGroups.Where(g => g.Value.Contains(a))

--- a/OpenRA.Mods.RA/Activities/Transform.cs
+++ b/OpenRA.Mods.RA/Activities/Transform.cs
@@ -43,6 +43,7 @@ namespace OpenRA.Mods.RA.Activities
 					nt.OnTransform(self);
 
 				var selected = w.Selection.Contains(self);
+				var controlgroup = w.Selection.GetControlGroupForActor(self);
 
 				self.Destroy();
 				foreach (var s in Sounds)
@@ -81,6 +82,8 @@ namespace OpenRA.Mods.RA.Activities
 
 				if (selected)
 					w.Selection.Add(w, a);
+				if (controlgroup.HasValue)
+					w.Selection.AddToControlGroup(a, controlgroup.Value);
 			});
 
 			return this;


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/6763
