### PR TITLE
Fixed ProductionQueue freezing Transform

### DIFF
--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -55,6 +55,9 @@ namespace OpenRA.Mods.RA
 			{
 				if (x.Actor.Owner == self.Owner && x.Trait.Info.Produces.Contains(Info.Type))
 				{
+					var b = x.Actor.TraitOrDefault<Building>();
+					if (b != null && b.Locked)
+						continue;
 					isActive = true;
 					break;
 				}

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -145,12 +145,12 @@ namespace OpenRA.Mods.RA
 			newOwner.PlayerActor.Trait<TechTree>().Update();
 		}
 
-		public void Killed(Actor killed, AttackInfo e) { if (killed == self) ClearQueue(); }
-		public void Selling(Actor self) { }
-		public void Sold(Actor self) { ClearQueue(); }
+		public void Killed(Actor killed, AttackInfo e) { if (killed == self) { ClearQueue(); Enabled = false; } }
+		public void Selling(Actor self) { ClearQueue(); Enabled = false; }
+		public void Sold(Actor self) { }
 
-		public void BeforeTransform(Actor self) { }
-		public void OnTransform(Actor self) { ClearQueue(); }
+		public void BeforeTransform(Actor self) { ClearQueue(); Enabled = false; }
+		public void OnTransform(Actor self) { }
 		public void AfterTransform(Actor self) { }
 
 		void CacheProduceables(Actor playerActor)
@@ -225,6 +225,8 @@ namespace OpenRA.Mods.RA
 
 		public virtual IEnumerable<ActorInfo> BuildableItems()
 		{
+			if (!Enabled)
+				return Enumerable.Empty<ActorInfo>();
 			if (self.World.AllowDevCommands && developerMode.AllTech)
 				return produceable.Select(a => a.Key);
 


### PR DESCRIPTION
This fixes the following:

step 1) with construction yard, have a structure on queue ready to place
step 2) start the construction yard to mcv transform, or sell the construction yard
step 3) before the packing up sequence finishes, place your queued structure
Result) sequence interrupted, structure can no longer transform or sell
