### PR TITLE
Fix HQ rules in nod03a and nod03b.

### DIFF
--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -581,6 +581,11 @@ Rules:
 			ShowOwnerRow: false
 	HARV:
 		-MustBeDestroyed:
+	HQ:
+		AirstrikePower:
+			Prerequisites: ~disabled
+		Tooltip:
+			Description: Provides an overview of the battlefield.\nRequires power to operate.
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled
@@ -620,9 +625,6 @@ Rules:
 	ATWR:
 		Buildable:
 			Prerequisites: ~disabled
-	HQ:
-		Buildable:
-			Prerequisites: ~disabled
 	E4:
 		Buildable:
 			Prerequisites: ~disabled
@@ -637,37 +639,6 @@ Rules:
 			Name: Prison
 		Capturable:
 			CaptureThreshold: 1
-	HQ.NOAIRSTRIKE:
-		RequiresPower:
-		CanPowerDown:
-		Inherits: ^Building
-		Valued:
-			Cost: 1000
-		Tooltip:
-			Name: Communications Center
-			Description: Provides an overview of the battlefield.\n  Requires power to operate.
-		ProvidesCustomPrerequisite:
-			Prerequisite: anyhq
-		Buildable:
-			BuildPaletteOrder: 70
-			Prerequisites: proc
-			Queue: Building.GDI, Building.Nod
-		Building:
-			Footprint: x_ xx
-			Dimensions: 2,2
-		Health:
-			HP: 750
-		RevealsShroud:
-			Range: 10c0
-		Bib:
-		ProvidesRadar:
-		RenderDetectionCircle:
-		DetectCloaked:
-			Range: 8
-		RenderBuilding:
-			Image: hq
-		Power:
-			Amount: -40
 
 Sequences:
 

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -626,6 +626,11 @@ Rules:
 			ShowOwnerRow: false
 	HARV:
 		-MustBeDestroyed:
+	HQ:
+		AirstrikePower:
+			Prerequisites: ~disabled
+		Tooltip:
+			Description: Provides an overview of the battlefield.\nRequires power to operate.
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled
@@ -665,9 +670,6 @@ Rules:
 	ATWR:
 		Buildable:
 			Prerequisites: ~disabled
-	HQ:
-		Buildable:
-			Prerequisites: ~disabled
 	E4:
 		Buildable:
 			Prerequisites: ~disabled
@@ -682,37 +684,6 @@ Rules:
 			Name: Prison
 		Capturable:
 			CaptureThreshold: 1
-	HQ.NOAIRSTRIKE:
-		RequiresPower:
-		CanPowerDown:
-		Inherits: ^Building
-		Valued:
-			Cost: 1000
-		Tooltip:
-			Name: Communications Center
-			Description: Provides an overview of the battlefield.\n  Requires power to operate.
-		ProvidesCustomPrerequisite:
-			Prerequisite: anyhq
-		Buildable:
-			BuildPaletteOrder: 70
-			Prerequisites: proc
-			Queue: Building.GDI, Building.Nod
-		Building:
-			Footprint: x_ xx
-			Dimensions: 2,2
-		Health:
-			HP: 750
-		RevealsShroud:
-			Range: 10c0
-		Bib:
-		ProvidesRadar:
-		RenderDetectionCircle:
-		DetectCloaked:
-			Range: 8
-		RenderBuilding:
-			Image: hq
-		Power:
-			Amount: -40
 
 Sequences:
 


### PR DESCRIPTION
Fixes a bug reported in the website comments:

> There's a bug in missions "sudanese prison break". you can build a comm center but you can't sell it. however you can sell any other building.

The `HQ.NOAIRSTRIKE` definitions did not inherit from the building default, and so they were missing some of the default traits.  This building duplication is no longer necessary, so I have changed this back to using the default HQ with overrides to disable the airstrike.
