### PR TITLE
GDI01 and GDI02 fixes

### DIFF
--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -446,7 +446,7 @@ Actors:
 		Location: 54,61
 		Owner: Neutral
 	lstEnd: waypoint
-		Location: 54,56
+		Location: 54,57
 		Owner: Neutral
 
 Smudges:

--- a/mods/cnc/maps/gdi02/gdi02.lua
+++ b/mods/cnc/maps/gdi02/gdi02.lua
@@ -14,7 +14,7 @@ BridgeheadSecured = function()
 	Reinforce(MobileConstructionVehicle)
 	Trigger.AfterDelay(Utils.Seconds(15), NodAttack)
 	Trigger.AfterDelay(Utils.Seconds(30), function() Reinforce(EngineerReinforcements) end)
-	Trigger.AfterDelay(Utils.Seconds(60), function() Reinforce(VehicleReinforcements) end)
+	Trigger.AfterDelay(Utils.Seconds(120), function() Reinforce(VehicleReinforcements) end)
 end
 
 NodAttack = function()

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -728,7 +728,7 @@ Actors:
 		Location: 35,33
 		Owner: Neutral
 	lstEnd: waypoint
-		Location: 58,56
+		Location: 58,57
 		Owner: GDI
 	lstStart: waypoint
 		Location: 58,61
@@ -791,6 +791,9 @@ Rules:
 			ShowOwnerRow: false
 	HARV:
 		-MustBeDestroyed:
+		Harvester:
+			SearchFromProcRadius: 32
+			SearchFromOrderRadius: 20
 	PROC:
 		Buildable:
 			Prerequisites: ~disabled
@@ -822,6 +825,9 @@ Rules:
 		Buildable:
 			Prerequisites: ~disabled
 	ATWR:
+		Buildable:
+			Prerequisites: ~disabled
+	BRIK:
 		Buildable:
 			Prerequisites: ~disabled
 	E2:


### PR DESCRIPTION
- moved down the landing craft unload waypoint by 1 cell (on both missions), matching the original
- disable concrete wall on gdi02
- fix Nod harvester not harvesting by increasing scan radiuses on gdi02
- increased delay for jeep reinforcement in gdi02 to 2 minutes, there's no need to make it arrive this early and as far as I remember it took longer in the original as well.
