### PR TITLE
Fix smoke animation offset in TD and RA.

### DIFF
--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -23,12 +23,18 @@ smoke_m:
 	idle:
 		Start: 0
 		Length: *
+		Offset: 2, -5
+		ZOffset: 512
 	loop:
 		Start: 49
 		Length: 42
+		Offset: 2, -5
+		ZOffset: 512
 	end:
 		Start: 0
 		Length: 26
+		Offset: 2, -5
+		ZOffset: 512
 
 laserfire:
 	idle:veh-hit3

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -150,15 +150,18 @@ smoke_m:
 	idle:
 		Start: 0
 		Length: *
-		ZOffset: 1023
+		Offset: 2, -5
+		ZOffset: 512
 	loop:
 		Start: 49
 		Length: 42
-		ZOffset: 1023
+		Offset: 2, -5
+		ZOffset: 512
 	end:
 		Start: 0
 		Length: 26
-		ZOffset: 1023
+		Offset: 2, -5
+		ZOffset: 512
 
 dragon:
 	idle:


### PR DESCRIPTION
This moves the origin of the smoke to the center of the sprite.  A simple polish fix that we should have done years ago.
