### PR TITLE
Improve new-lua error handling.

### DIFF
--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -118,6 +119,8 @@ namespace OpenRA.Scripting
 		{
 			runtime = new MemoryConstrainedLuaRuntime();
 
+			Log.AddChannel("lua", "lua.log");
+
 			World = world;
 			WorldRenderer = worldRenderer;
 			knownActorCommands = Game.modData.ObjectCreator
@@ -141,7 +144,7 @@ namespace OpenRA.Scripting
 
 			using (var registerGlobal = (LuaFunction)runtime.Globals["RegisterSandboxedGlobal"])
 			{
-				using (var fn = runtime.CreateFunctionFromDelegate((Action<string>)Console.WriteLine))
+				using (var fn = runtime.CreateFunctionFromDelegate((Action<string>)LogDebugMessage))
 					registerGlobal.Call("print", fn).Dispose();
 
 				// Register global tables
@@ -173,11 +176,22 @@ namespace OpenRA.Scripting
 			}
 		}
 
+		void LogDebugMessage(string message)
+		{
+			Console.WriteLine("Lua debug: {0}", message);
+			Log.Write("lua", message);
+		}
+
 		public bool FatalErrorOccurred { get; private set; }
 		public void FatalError(string message)
 		{
+			var stacktrace = new StackTrace().ToString();
 			Console.WriteLine("Fatal Lua Error: {0}", message);
-			Game.AddChatLine(Color.White, "Fatal Lua Error", message);
+			Console.WriteLine(stacktrace);
+
+			Log.Write("lua", "Fatal Lua Error: {0}", message);
+			Log.Write("lua", stacktrace);
+
 			FatalErrorOccurred = true;
 		}
 

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -193,6 +193,13 @@ namespace OpenRA.Scripting
 			Log.Write("lua", stacktrace);
 
 			FatalErrorOccurred = true;
+
+			World.AddFrameEndTask(w =>
+			{
+				World.EndGame();
+				World.SetPauseState(true);
+				World.PauseStateLocked = true;
+			});
 		}
 
 		public void RegisterMapActor(string name, Actor a)

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -173,12 +173,12 @@ namespace OpenRA.Scripting
 			}
 		}
 
-		bool error;
+		public bool FatalErrorOccurred { get; private set; }
 		public void FatalError(string message)
 		{
 			Console.WriteLine("Fatal Lua Error: {0}", message);
 			Game.AddChatLine(Color.White, "Fatal Lua Error", message);
-			error = true;
+			FatalErrorOccurred = true;
 		}
 
 		public void RegisterMapActor(string name, Actor a)
@@ -195,7 +195,7 @@ namespace OpenRA.Scripting
 
 		public void WorldLoaded()
 		{
-			if (error)
+			if (FatalErrorOccurred)
 				return;
 
 			using (var worldLoaded = (LuaFunction)runtime.Globals["WorldLoaded"])
@@ -204,7 +204,7 @@ namespace OpenRA.Scripting
 
 		public void Tick(Actor self)
 		{
-			if (error || disposed)
+			if (FatalErrorOccurred || disposed)
 				return;
 
 			using (new PerfSample("tick_lua"))
@@ -215,6 +215,7 @@ namespace OpenRA.Scripting
 		{
 			if (disposed)
 				return;
+
 			disposed = true;
 			if (runtime != null)
 				runtime.Dispose();

--- a/OpenRA.Mods.RA/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.RA/Scripting/Global/TriggerGlobal.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA.Scripting
 					using (f)
 						f.Call();
 				}
-				catch (LuaException e)
+				catch (Exception e)
 				{
 					context.FatalError(e.Message);
 				}
@@ -81,11 +81,18 @@ namespace OpenRA.Mods.RA.Scripting
 			var copy = (LuaFunction)func.CopyReference();
 			Action<Actor> OnMemberKilled = m =>
 			{
-				group.Remove(m);
-				if (!group.Any())
+				try
 				{
-					copy.Call();
-					copy.Dispose();
+					group.Remove(m);
+					if (!group.Any())
+					{
+						copy.Call();
+						copy.Dispose();
+					}
+				}
+				catch (Exception e)
+				{
+					context.FatalError(e.Message);
 				}
 			};
 
@@ -101,14 +108,21 @@ namespace OpenRA.Mods.RA.Scripting
 			var copy = (LuaFunction)func.CopyReference();
 			Action<Actor> OnMemberKilled = m =>
 			{
-				if (called)
-					return;
+				try
+				{
+					if (called)
+						return;
 
-				using (var killed = m.ToLuaValue(context))
-					copy.Call(killed).Dispose();
+					using (var killed = m.ToLuaValue(context))
+						copy.Call(killed).Dispose();
 
-				copy.Dispose();
-				called = true;
+					copy.Dispose();
+					called = true;
+				}
+				catch (Exception e)
+				{
+					context.FatalError(e.Message);
+				}
 			};
 
 			foreach (var a in actors)
@@ -180,11 +194,18 @@ namespace OpenRA.Mods.RA.Scripting
 			var copy = (LuaFunction)func.CopyReference();
 			Action<Actor> OnMemberRemoved = m =>
 			{
-				group.Remove(m);
-				if (!group.Any())
+				try
 				{
-					copy.Call().Dispose();
-					copy.Dispose();
+					group.Remove(m);
+					if (!group.Any())
+					{
+						copy.Call().Dispose();
+						copy.Dispose();
+					}
+				}
+				catch (Exception e)
+				{
+					context.FatalError(e.Message);
 				}
 			};
 
@@ -208,9 +229,16 @@ namespace OpenRA.Mods.RA.Scripting
 			var onEntry = (LuaFunction)func.CopyReference();
 			Action<Actor> invokeEntry = a =>
 			{
-				using (var luaActor = a.ToLuaValue(context))
-				using (var id = triggerId.ToLuaValue(context))
-					onEntry.Call(luaActor, id).Dispose();
+				try
+				{
+					using (var luaActor = a.ToLuaValue(context))
+					using (var id = triggerId.ToLuaValue(context))
+						onEntry.Call(luaActor, id).Dispose();
+				}
+				catch (Exception e)
+				{
+					context.FatalError(e.Message);
+				}
 			};
 
 			triggerId = context.World.ActorMap.AddCellTrigger(cells, invokeEntry, null);
@@ -227,9 +255,16 @@ namespace OpenRA.Mods.RA.Scripting
 			var onExit = (LuaFunction)func.CopyReference();
 			Action<Actor> invokeExit = a =>
 			{
-				using (var luaActor = a.ToLuaValue(context))
-				using (var id = triggerId.ToLuaValue(context))
-					onExit.Call(luaActor, id).Dispose();
+				try
+				{
+					using (var luaActor = a.ToLuaValue(context))
+					using (var id = triggerId.ToLuaValue(context))
+						onExit.Call(luaActor, id).Dispose();
+				}
+				catch (Exception e)
+				{
+					context.FatalError(e.Message);
+				}
 			};
 
 			triggerId = context.World.ActorMap.AddCellTrigger(cells, null, invokeExit);

--- a/OpenRA.Mods.RA/Scripting/LuaScript.cs
+++ b/OpenRA.Mods.RA/Scripting/LuaScript.cs
@@ -50,5 +50,7 @@ namespace OpenRA.Mods.RA.Scripting
 			if (context != null)
 				context.Dispose();
 		}
+
+		public bool FatalErrorOccurred { get { return context.FatalErrorOccurred; } }
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.RA/Scripting/ScriptTriggers.cs
@@ -45,25 +45,55 @@ namespace OpenRA.Mods.RA.Scripting
 		public void TickIdle(Actor self)
 		{
 			foreach (var f in Triggers[Trigger.OnIdle])
-				using (var a = self.ToLuaValue(f.Second))
-					f.First.Call(a).Dispose();
+			{
+				try
+				{
+					using (var a = self.ToLuaValue(f.Second))
+						f.First.Call(a).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void Damaged(Actor self, AttackInfo e)
 		{
 			foreach (var f in Triggers[Trigger.OnDamaged])
-				using (var a = self.ToLuaValue(f.Second))
-				using (var b = e.Attacker.ToLuaValue(f.Second))
-					f.First.Call(a, b).Dispose();
+			{
+				try
+				{
+					using (var a = self.ToLuaValue(f.Second))
+					using (var b = e.Attacker.ToLuaValue(f.Second))
+						f.First.Call(a, b).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void Killed(Actor self, AttackInfo e)
 		{
 			// Run Lua callbacks
 			foreach (var f in Triggers[Trigger.OnKilled])
-				using (var a = self.ToLuaValue(f.Second))
-				using (var b = e.Attacker.ToLuaValue(f.Second))
-					f.First.Call(a, b).Dispose();
+			{
+				try
+				{
+					using (var a = self.ToLuaValue(f.Second))
+					using (var b = e.Attacker.ToLuaValue(f.Second))
+						f.First.Call(a, b).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 
 			// Run any internally bound callbacks
 			OnKilledInternal(self);
@@ -72,72 +102,162 @@ namespace OpenRA.Mods.RA.Scripting
 		public void UnitProduced(Actor self, Actor other, CPos exit)
 		{
 			foreach (var f in Triggers[Trigger.OnProduction])
-				using (var a = self.ToLuaValue(f.Second))
-				using (var b = other.ToLuaValue(f.Second))
-					f.First.Call(a, b).Dispose();
+			{
+				try
+				{
+					using (var a = self.ToLuaValue(f.Second))
+					using (var b = other.ToLuaValue(f.Second))
+						f.First.Call(a, b).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void OnPlayerWon(Player player)
 		{
 			foreach (var f in Triggers[Trigger.OnPlayerWon])
-				using (var a = player.ToLuaValue(f.Second))
-					f.First.Call(a).Dispose();
+			{
+				try
+				{
+					using (var a = player.ToLuaValue(f.Second))
+						f.First.Call(a).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void OnPlayerLost(Player player)
 		{
 			foreach (var f in Triggers[Trigger.OnPlayerLost])
-				using (var a = player.ToLuaValue(f.Second))
-					f.First.Call(a).Dispose();
+			{
+				try
+				{
+					using (var a = player.ToLuaValue(f.Second))
+						f.First.Call(a).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void OnObjectiveAdded(Player player, int id)
 		{
 			foreach (var f in Triggers[Trigger.OnObjectiveAdded])
-				using (var a = player.ToLuaValue(f.Second))
-				using (var b = id.ToLuaValue(f.Second))
-					f.First.Call(a, b).Dispose();
+			{
+				try
+				{
+					using (var a = player.ToLuaValue(f.Second))
+					using (var b = id.ToLuaValue(f.Second))
+						f.First.Call(a, b).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void OnObjectiveCompleted(Player player, int id)
 		{
 			foreach (var f in Triggers[Trigger.OnObjectiveCompleted])
-				using (var a = player.ToLuaValue(f.Second))
-				using (var b = id.ToLuaValue(f.Second))
-					f.First.Call(a, b).Dispose();
+			{
+				try
+				{
+					using (var a = player.ToLuaValue(f.Second))
+					using (var b = id.ToLuaValue(f.Second))
+						f.First.Call(a, b).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void OnObjectiveFailed(Player player, int id)
 		{
 			foreach (var f in Triggers[Trigger.OnObjectiveFailed])
-				using (var a = player.ToLuaValue(f.Second))
-				using (var b = id.ToLuaValue(f.Second))
-					f.First.Call(a, b).Dispose();
+			{
+				try
+				{
+					using (var a = player.ToLuaValue(f.Second))
+					using (var b = id.ToLuaValue(f.Second))
+						f.First.Call(a, b).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
 		{
 			foreach (var f in Triggers[Trigger.OnCapture])
-				using (var a = self.ToLuaValue(f.Second))
-				using (var b = captor.ToLuaValue(f.Second))
-				using (var c = oldOwner.ToLuaValue(f.Second))
-				using (var d = newOwner.ToLuaValue(f.Second))
-					f.First.Call(a, b, c, d).Dispose();
+			{
+				try
+				{
+					using (var a = self.ToLuaValue(f.Second))
+					using (var b = captor.ToLuaValue(f.Second))
+					using (var c = oldOwner.ToLuaValue(f.Second))
+					using (var d = newOwner.ToLuaValue(f.Second))
+						f.First.Call(a, b, c, d).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void AddedToWorld(Actor self)
 		{
 			foreach (var f in Triggers[Trigger.OnAddedToWorld])
-				using (var a = self.ToLuaValue(f.Second))
-					f.First.Call(a).Dispose();
+			{
+				try
+				{
+					using (var a = self.ToLuaValue(f.Second))
+						f.First.Call(a).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 		}
 
 		public void RemovedFromWorld(Actor self)
 		{
 			// Run Lua callbacks
 			foreach (var f in Triggers[Trigger.OnRemovedFromWorld])
-				using (var a = self.ToLuaValue(f.Second))
-					f.First.Call(a).Dispose();
+			{
+				try
+				{
+					using (var a = self.ToLuaValue(f.Second))
+						f.First.Call(a).Dispose();
+				}
+				catch (Exception ex)
+				{
+					f.Second.FatalError(ex.Message);
+					return;
+				}
+			}
 
 			// Run any internally bound callbacks
 			OnRemovedInternal(self);

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.RA.Scripting;
 using OpenRA.Network;
 using OpenRA.Traits;
 using OpenRA.Widgets;
@@ -34,9 +35,11 @@ namespace OpenRA.Mods.RA.Widgets
 
 			var showStats = false;
 
+			var scriptContext = world.WorldActor.TraitOrDefault<LuaScript>();
 			var iop = world.WorldActor.TraitsImplementing<IObjectivesPanel>().FirstOrDefault();
 			var isMultiplayer = !world.LobbyInfo.IsSinglePlayer && !world.IsReplay;
-			var hasObjectives = iop != null && iop.PanelName != null && world.LocalPlayer != null;
+			var hasError = scriptContext != null && scriptContext.FatalErrorOccurred;
+			var hasObjectives = hasError || (iop != null && iop.PanelName != null && world.LocalPlayer != null);
 			var showTabs = hasObjectives && isMultiplayer;
 			currentTab = hasObjectives ? Tab.Objectives : Tab.Chat;
 
@@ -114,8 +117,9 @@ namespace OpenRA.Mods.RA.Widgets
 
 			if (hasObjectives)
 			{
+				var panel = hasError ? "SCRIPT_ERROR_PANEL" : iop.PanelName;
 				var objectivesContainer = dialog.Get<ContainerWidget>("OBJECTIVES_PANEL");
-				Game.LoadWidget(world, iop.PanelName, objectivesContainer, new WidgetArgs());
+				Game.LoadWidget(world, panel, objectivesContainer, new WidgetArgs());
 				objectivesContainer.IsVisible = () => currentTab == Tab.Objectives;
 			}
 

--- a/mods/cnc/chrome/ingame-infoscripterror.yaml
+++ b/mods/cnc/chrome/ingame-infoscripterror.yaml
@@ -1,0 +1,27 @@
+Container@SCRIPT_ERROR_PANEL:
+	Height: PARENT_BOTTOM
+	Width: PARENT_RIGHT
+	Children:
+		Label@DESCA:
+			X: 15
+			Y: 15
+			Width: PARENT_RIGHT-30
+			Height: 20
+			Font: Bold
+			Align:Center
+			Text: The map script has encountered a fatal error
+		Label@DESCB:
+			X: 15
+			Y: 45
+			Width: PARENT_RIGHT-30
+			Height: 20
+			Font: Regular
+			WordWrap: true
+			Text: The details of the error have been saved to lua.log in the logs directory.
+		Label@DESCC:
+			X: 15
+			Y: 65
+			Width: PARENT_RIGHT-30
+			Height: 20
+			Font: Regular
+			Text: Please send this file to the map author so that they can fix this issue.

--- a/mods/cnc/chrome/ingame-leavemap.yaml
+++ b/mods/cnc/chrome/ingame-leavemap.yaml
@@ -116,6 +116,8 @@ Container@LEAVE_MAP_WIDGET:
 					Font: Bold
 					Text: Statistics
 				Container@OBJECTIVES_PANEL:
+					Width: PARENT_RIGHT
+					Height: 365
 				Container@DIALOG_CHAT_PANEL:
 					X: 15
 					Y: 15

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -93,6 +93,7 @@ ChromeLayout:
 	./mods/cnc/chrome/ingame-debug.yaml
 	./mods/cnc/chrome/ingame-info.yaml
 	./mods/cnc/chrome/ingame-infobriefing.yaml
+	./mods/cnc/chrome/ingame-infoscripterror.yaml
 	./mods/cnc/chrome/ingame-infoobjectives.yaml
 	./mods/cnc/chrome/ingame-infostats.yaml
 	./mods/cnc/chrome/ingame-leavemap.yaml

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -64,6 +64,7 @@ ChromeLayout:
 	./mods/ra/chrome/ingame-fmvplayer.yaml
 	./mods/d2k/chrome/ingame-menu.yaml
 	./mods/ra/chrome/ingame-info.yaml
+	./mods/ra/chrome/ingame-infoscripterror.yaml
 	./mods/ra/chrome/ingame-infobriefing.yaml
 	./mods/ra/chrome/ingame-infoobjectives.yaml
 	./mods/ra/chrome/ingame-infostats.yaml

--- a/mods/ra/chrome/ingame-infoscripterror.yaml
+++ b/mods/ra/chrome/ingame-infoscripterror.yaml
@@ -1,0 +1,27 @@
+Container@SCRIPT_ERROR_PANEL:
+	Height: PARENT_BOTTOM
+	Width: PARENT_RIGHT
+	Children:
+		Label@DESCA:
+			X: 15
+			Y: 15
+			Width: PARENT_RIGHT-30
+			Height: 20
+			Font: Bold
+			Align:Center
+			Text: The map script has encountered a fatal error
+		Label@DESCB:
+			X: 15
+			Y: 45
+			Width: PARENT_RIGHT-30
+			Height: 20
+			Font: Regular
+			WordWrap: true
+			Text: The details of the error have been saved to lua.log in the logs directory.
+		Label@DESCC:
+			X: 15
+			Y: 65
+			Width: PARENT_RIGHT-30
+			Height: 20
+			Font: Regular
+			Text: Please send this file to the map author so that they can fix this issue.

--- a/mods/ra/chrome/ingame-leavemap.yaml
+++ b/mods/ra/chrome/ingame-leavemap.yaml
@@ -126,6 +126,7 @@ Container@LEAVE_MAP_WIDGET:
 					Text: Leave
 				Container@OBJECTIVES_PANEL:
 					Y: 65
+					Width: PARENT_RIGHT
 				Container@DIALOG_CHAT_PANEL:
 					X: 20
 					Y: 65

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -76,6 +76,7 @@ ChromeLayout:
 	./mods/ra/chrome/ingame-diplomacy.yaml
 	./mods/ra/chrome/ingame-fmvplayer.yaml
 	./mods/ra/chrome/ingame-info.yaml
+	./mods/ra/chrome/ingame-infoscripterror.yaml
 	./mods/ra/chrome/ingame-infobriefing.yaml
 	./mods/ra/chrome/ingame-infoobjectives.yaml
 	./mods/ra/chrome/ingame-infostats.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -106,6 +106,7 @@ ChromeLayout:
 	./mods/ra/chrome/ingame-fmvplayer.yaml
 	./mods/ra/chrome/ingame-menu.yaml
 	./mods/ra/chrome/ingame-info.yaml
+	./mods/ra/chrome/ingame-infoscripterror.yaml
 	./mods/ra/chrome/ingame-infobriefing.yaml
 	./mods/ra/chrome/ingame-infoobjectives.yaml
 	./mods/ra/chrome/ingame-infostats.yaml


### PR DESCRIPTION
This improves our handling of lua errors by
1. not crashing inside most of our recent triggers
2. writing the error details (and also print statements) to lua.log
3. halting the game on error with a (rudimentary) dialog.

The error dialog UI isn't great, but this will be difficult to improve without completely rewriting our info-panel implementation.  That is something that needs to be done, but I would prefer to leave that until after the pending release so that it can also include #2850.

Note that #6552 and #6762 include new triggers that will also need to be updated with these fixes.
