### PR TITLE
Renamed RenderInfantry to RenderUnitAnimated

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -264,7 +264,7 @@ namespace OpenRA.Traits
 	public interface INotifyIdle { void TickIdle(Actor self); }
 
 	public interface IBlocksBullets { }
-	public interface IRenderInfantrySequenceModifier
+	public interface IRenderUnitAnimatedSequenceModifier
 	{
 		bool IsModifyingSequence { get; }
 		string SequencePrefix { get; }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -654,6 +654,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20141019)
+				{
+					// Rename RenderInfantry to RenderUnitAnimated
+					if (depth == 1)
+					{
+						if (node.Key == "RenderInfantry")
+							node.Key = "RenderUnitAnimated";
+
+						if (node.Key == "-RenderInfantry")
+							node.Key = "-RenderUnitAnimated";
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.RA/Activities/Leap.cs
+++ b/OpenRA.Mods.RA/Activities/Leap.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Activities
 			to = self.World.Map.CenterOfSubCell(targetMobile.fromCell, targetMobile.fromSubCell);
 			length = Math.Max((to - from).Length / speed.Range, 1);
 
-			self.Trait<RenderInfantry>().Attacking(self, Target.FromActor(target));
+			self.Trait<RenderUnitAnimated>().Attacking(self, Target.FromActor(target));
 
 			if (weapon.Report != null && weapon.Report.Any())
 				Sound.Play(weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -307,7 +307,7 @@
     <Compile Include="Render\RenderEditorOnly.cs" />
     <Compile Include="Render\RenderFlare.cs" />
     <Compile Include="Render\RenderHarvester.cs" />
-    <Compile Include="Render\RenderInfantry.cs" />
+    <Compile Include="Render\RenderUnitAnimated.cs" />
     <Compile Include="Render\RenderDisguise.cs" />
     <Compile Include="Render\RenderLandingCraft.cs" />
     <Compile Include="Render\RenderUnit.cs" />

--- a/OpenRA.Mods.RA/Render/RenderDisguise.cs
+++ b/OpenRA.Mods.RA/Render/RenderDisguise.cs
@@ -12,12 +12,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Render
 {
-	class RenderDisguiseInfo : RenderInfantryInfo, Requires<DisguiseInfo>
+	class RenderDisguiseInfo : RenderUnitAnimatedInfo, Requires<DisguiseInfo>
 	{
 		public override object Create(ActorInitializer init) { return new RenderDisguise(init.self, this); }
 	}
 
-	class RenderDisguise : RenderInfantry
+	class RenderDisguise : RenderUnitAnimated
 	{
 		RenderDisguiseInfo info;
 		string intendedSprite;

--- a/OpenRA.Mods.RA/ScaredyCat.cs
+++ b/OpenRA.Mods.RA/ScaredyCat.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.RA
 		public object Create(ActorInitializer init) { return new ScaredyCat(init.self, this); }
 	}
 
-	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync, IRenderInfantrySequenceModifier
+	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync, IRenderUnitAnimatedSequenceModifier
 	{
 		readonly ScaredyCatInfo info;
 		[Sync] readonly Actor self;

--- a/OpenRA.Mods.RA/TakeCover.cs
+++ b/OpenRA.Mods.RA/TakeCover.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA
 		public override object Create(ActorInitializer init) { return new TakeCover(init, this); }
 	}
 
-	public class TakeCover : Turreted, INotifyDamage, IDamageModifier, ISpeedModifier, ISync, IRenderInfantrySequenceModifier
+	public class TakeCover : Turreted, INotifyDamage, IDamageModifier, ISpeedModifier, ISync, IRenderUnitAnimatedSequenceModifier
 	{
 		readonly TakeCoverInfo info;
 		[Sync] int remainingProneTime = 0;

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -177,7 +177,7 @@
 		TargetTypes: Ground, Infantry
 	TakeCover:
 		SpeedModifier: 60
-	RenderInfantry:
+	RenderUnitAnimated:
 	WithDeathAnimation:
 	AttackMove:
 	Passenger:
@@ -293,7 +293,7 @@
 		TargetTypes: Ground, Infantry
 	HiddenUnderFog:
 	GivesExperience:
-	RenderInfantry:
+	RenderUnitAnimated:
 		Palette: terrain
 	WithDeathAnimation:
 		UseDeathTypeSuffix: false

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -17,7 +17,7 @@ E1:
 	Armament:
 		Weapon: M16
 	AttackFrontal:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2,idle3,idle4
 		StandAnimations: stand, stand2
 
@@ -43,7 +43,7 @@ E2:
 		LocalOffset: 0,0,427
 		FireDelay: 15
 	AttackFrontal:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
 	Explodes:
@@ -74,7 +74,7 @@ E3:
 		LocalOffset: 256,43,341
 		FireDelay: 5
 	AttackFrontal:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
 
@@ -104,7 +104,7 @@ E4:
 	AttackFrontal:
 	WithMuzzleFlash:
 		SplitFacings: true
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
 
@@ -140,7 +140,7 @@ E5:
 	WithMuzzleFlash:
 		SplitFacings: true
 	-PoisonedByTiberium:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
 
@@ -167,7 +167,7 @@ E6:
 	Captures:
 		CaptureTypes: building, husk
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand, stand2
 	-GainsExperience:
@@ -201,7 +201,7 @@ RMBO:
 	Armament:
 		Weapon: Sniper
 	AttackFrontal:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2,idle3
 		StandAnimations: stand, stand2
 	AnnounceOnBuild:

--- a/mods/d2k/rules/atreides.yaml
+++ b/mods/d2k/rules/atreides.yaml
@@ -262,7 +262,7 @@ GRENADIER:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle
 	Explodes:
 		Weapon: UnitExplodeSmall

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -184,7 +184,7 @@
 		Voice: InfantryVoice
 	TargetableUnit:
 		TargetTypes: Ground
-	RenderInfantry:
+	RenderUnitAnimated:
 	TakeCover:
 	WithDeathAnimation:
 	AutoTarget:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -94,7 +94,7 @@ MEDIC:
 	AttackMedic:
 		Cursor: ability
 		OutsideRangeCursor: ability
-	RenderInfantry:
+	RenderUnitAnimated:
 		AttackAnimation: heal
 	Passenger:
 		PipType: Blue

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2244,7 +2244,7 @@ Rules:
 		Captures:
 			CaptureTypes: building
 			Sabotage: False
-		RenderInfantry:
+		RenderUnitAnimated:
 			Image: e6
 	E6:
 		Buildable:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -13,43 +13,43 @@ C4:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	RenderUnitAnimated:
 		Image: C2
 
 C5:
 	Inherits: ^CivInfantry
-	RenderInfantry:
+	RenderUnitAnimated:
 		Image: C1
 
 C6:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	RenderUnitAnimated:
 		Image: C2
 
 C7:
 	Inherits: ^CivInfantry
-	RenderInfantry:
+	RenderUnitAnimated:
 		Image: C1
 
 C8:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	RenderUnitAnimated:
 		Image: C2
 
 C9:
 	Inherits: ^CivInfantry
-	RenderInfantry:
+	RenderUnitAnimated:
 		Image: C1
 
 C10:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	RenderUnitAnimated:
 		Image: C2
 
 FCOM:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -164,7 +164,7 @@
 		Voice: GenericVoice
 	TargetableUnit:
 		TargetTypes: Ground, Infantry, Disguise
-	RenderInfantry:
+	RenderUnitAnimated:
 	WithDeathAnimation:
 	AutoTarget:
 	AttackMove:
@@ -499,7 +499,7 @@
 	AttackFrontal:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	RenderUnitAnimated:
 	ScaredyCat:
 
 ^CivBuilding:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -22,7 +22,7 @@ DOG:
 	Armament:
 		Weapon: DogJaw
 	AttackLeap:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 	IgnoresDisguise:
 	DetectCloaked:
@@ -54,7 +54,7 @@ E1:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
 
@@ -86,7 +86,7 @@ E2:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
 	Explodes:
@@ -122,7 +122,7 @@ E3:
 		Weapon: Dragon
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
 
@@ -153,7 +153,7 @@ E4:
 		Weapon: Flamer
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
 
@@ -184,7 +184,7 @@ E6:
 		Type: building
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
 
@@ -218,7 +218,7 @@ SPY:
 	Infiltrates:
 		Types: SpyInfiltrate
 	-AutoTarget:
-	-RenderInfantry:
+	-RenderUnitAnimated:
 	RenderDisguise:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
@@ -262,7 +262,7 @@ E7:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 MEDI:
@@ -296,7 +296,7 @@ MEDI:
 		OutsideRangeCursor: heal
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		AttackAnimation: heal
 
@@ -333,7 +333,7 @@ MECH:
 		CaptureTypes: husk
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		AttackAnimation: heal
 
@@ -355,7 +355,7 @@ EINSTEIN:
 	-AutoTarget:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	RenderUnitAnimated:
 	ScaredyCat:
 
 DELPHI:
@@ -376,7 +376,7 @@ DELPHI:
 	-AutoTarget:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	RenderUnitAnimated:
 	ScaredyCat:
 
 CHAN:
@@ -470,7 +470,7 @@ SHOK:
 		Weapon: PortaTesla
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
 
@@ -506,7 +506,7 @@ SNIPER:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		StandAnimations: stand,stand2
 	Cloak:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -118,7 +118,7 @@
 		Voice: Infantry
 	TargetableUnit:
 		TargetTypes: Ground, Infantry
-	RenderInfantry:
+	RenderUnitAnimated:
 	WithDeathAnimation:
 	AutoTarget:
 	AttackMove:
@@ -198,7 +198,7 @@
 	AttackFrontal:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	RenderUnitAnimated:
 	ScaredyCat:
 
 ^Vehicle:

--- a/mods/ts/rules/infantry.yaml
+++ b/mods/ts/rules/infantry.yaml
@@ -23,7 +23,7 @@ E1:
 		RequiresUpgrade: eliteweapon
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 E2:
@@ -49,7 +49,7 @@ E2:
 		FireDelay: 5
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 E3:
@@ -75,7 +75,7 @@ E3:
 		LocalOffset: 128,0,640
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 WEEDGUY:
@@ -104,7 +104,7 @@ WEEDGUY:
 		Weapon: FireballLauncher
 		LocalOffset: 85,0,384
 	AttackFrontal:
-	RenderInfantry:
+	RenderUnitAnimated:
 	TakeCover:
 
 MEDIC:
@@ -132,7 +132,7 @@ MEDIC:
 		Weapon: Heal
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 		AttackAnimation: heal
 	SelfHealing:
@@ -165,7 +165,7 @@ ENGINEER:
 	Captures:
 		CaptureTypes: building
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 	TakeCover:
 	-GainsExperience:
@@ -198,7 +198,7 @@ UMAGON:
 		Weapon: Sniper
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 GHOST:
@@ -235,7 +235,7 @@ GHOST:
 	C4Demolition:
 		C4Delay: 45
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 JUMPJET:
@@ -267,7 +267,7 @@ JUMPJET:
 	-Crushable:
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 
 CHAMSPY:
 	Inherits: ^Infantry
@@ -296,7 +296,7 @@ CHAMSPY:
 	Infiltrates:
 		Types: SpyInfiltrate
 	-AutoTarget:
-	-RenderInfantry:
+	-RenderUnitAnimated:
 	RenderDisguise:
 		IdleAnimations: idle1,idle2
 
@@ -331,7 +331,7 @@ CYBORG:
 		Weapon: Vulcan3
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 CYC2:
@@ -366,7 +366,7 @@ CYC2:
 		LocalOffset: 170,85,683
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 MUTANT:
@@ -394,7 +394,7 @@ MUTANT:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 MWMN:
@@ -422,7 +422,7 @@ MWMN:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 MUTANT3:
@@ -450,7 +450,7 @@ MUTANT3:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 MHIJACK:
@@ -478,7 +478,7 @@ MHIJACK:
 		Range: 6c0
 	-AutoTarget:
 	TakeCover:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 TRATOS:
@@ -503,7 +503,7 @@ TRATOS:
 		Range: 4c0
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 OXANNA:
@@ -526,7 +526,7 @@ OXANNA:
 		Range: 4c0
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 SLAV:
@@ -549,7 +549,7 @@ SLAV:
 		Range: 4c0
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
+	RenderUnitAnimated:
 		IdleAnimations: idle1,idle2
 
 DOGGIE:
@@ -607,7 +607,7 @@ VISSML:
 	TargetableUnit:
 		TargetTypes: Ground
 	-AutoTarget:
-	-RenderInfantry:
+	-RenderUnitAnimated:
 	RenderUnit:
 	-WithDeathAnimation:
 
@@ -640,7 +640,7 @@ VISLRG:
 		Weapon: SlimeAttack
 	AttackFrontal:
 	AttackWander:
-	-RenderInfantry:
+	-RenderUnitAnimated:
 	RenderUnit:
 	-WithDeathAnimation:
 

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -520,7 +520,7 @@ MMCH:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
-	RenderInfantry:
+	RenderUnitAnimated:
 	Turreted:
 		ROT: 5
 	AttackTurreted:
@@ -593,7 +593,7 @@ SMECH:
 	AutoTarget:
 	Armament:
 		Weapon: AssaultCannon
-	RenderInfantry:
+	RenderUnitAnimated:
 	Selectable:
 		Voices: Mech
 		Bounds: 16, 32


### PR DESCRIPTION
All the problematic inf-only stuff (death animation, death sounds) has been moved out into separate traits, and this trait is already used by TS shp mechs, for example, so we might as well rename it to make clear that this can be used for any animated unit by now.
