### PR TITLE
Fix the handling of maps with invalid rules.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -76,6 +76,7 @@ namespace OpenRA
 		public string Tileset;
 		public bool AllowStartUnitConfig = true;
 		public Bitmap CustomPreview;
+		public bool InvalidCustomRules { get; private set; }
 
 		public readonly TileShape TileShape;
 		[FieldLoader.Ignore]
@@ -274,7 +275,21 @@ namespace OpenRA
 
 		void PostInit()
 		{
-			rules = Exts.Lazy(() => Game.modData.RulesetCache.LoadMapRules(this));
+			rules = Exts.Lazy(() =>
+			{
+				try
+				{
+					return Game.modData.RulesetCache.LoadMapRules(this);
+				}
+				catch (Exception e)
+				{
+					InvalidCustomRules = true;
+					Log.Write("debug", "Failed to load rules for {0} with error {1}", Title, e.Message);
+				}
+
+				return Game.modData.DefaultRules;
+			});
+
 			cachedTileSet = Exts.Lazy(() => Rules.TileSets[Tileset]);
 
 			var tl = Map.MapToCell(TileShape, new CPos(Bounds.Left, Bounds.Top));

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -237,16 +237,8 @@ namespace OpenRA
 			if (RuleStatus != MapRuleStatus.Unknown)
 				return;
 
-			try
-			{
-				Map.PreloadRules();
-				RuleStatus = MapRuleStatus.Cached;
-			}
-			catch (Exception e)
-			{
-				Log.Write("debug", "Map {0} failed validation with an exception:\n{1}", Uid, e.Message);
-				RuleStatus = MapRuleStatus.Invalid;
-			}
+			Map.PreloadRules();
+			RuleStatus = Map.InvalidCustomRules ? MapRuleStatus.Invalid : MapRuleStatus.Cached;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #6787.  This appears to have been regressed by the color validator changes (which access the map rules directly).
