### PR TITLE
Fixed RepairBridgeOrderTargeter & hut logic - it now ignores dangling bridges

### DIFF
--- a/OpenRA.Mods.RA/BridgeHut.cs
+++ b/OpenRA.Mods.RA/BridgeHut.cs
@@ -23,18 +23,17 @@ namespace OpenRA.Mods.RA
 
 	class BridgeHut : IDemolishable
 	{
-		Lazy<Bridge> firstBridge;
-		int repairDirections = 0;
+		public readonly Bridge FirstBridge;
 		public readonly Bridge Bridge;
-		public Bridge FirstBridge { get { return firstBridge.Value; } }
 		public DamageState BridgeDamageState { get { return Bridge.AggregateDamageState(); } }
 		public bool Repairing { get { return repairDirections > 0; } }
+		int repairDirections = 0;
 
 		public BridgeHut(ActorInitializer init)
 		{
 			Bridge = init.Get<ParentActorInit>().value.Trait<Bridge>();
-			Bridge.Hut = this;
-			firstBridge = new Lazy<Bridge>(() => Bridge.Enumerate(0, true).Last());
+			Bridge.AddHut(this);
+			FirstBridge = Bridge.Enumerate(0, true).Last();
 		}
 
 		public void Repair(Actor repairer)

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2240,7 +2240,6 @@ Rules:
 		Inherits: E6
 		Buildable:
 			Prerequisites: ~barracks
-		-RepairsBridges:
 		Captures:
 			CaptureTypes: building
 			Sabotage: False


### PR DESCRIPTION
RepairBridgeOrderTargeter now ignores dangling bridges & rejects bridges under repair.
