### PR TITLE
Fix a crash when double-clicking a replay with an unknown map.

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
@@ -624,7 +624,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		void WatchReplay()
 		{
-			if (selectedReplay != null)
+			if (selectedReplay != null && selectedReplay.GameInfo.MapPreview.Status == MapStatus.Available)
 			{
 				Game.JoinReplay(selectedReplay.FilePath);
 				Ui.CloseWindow();


### PR DESCRIPTION
Reproducible with any replay created before #6783 was merged.
