### PR TITLE
Balancing: Increased BIKE cost to 600

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -233,7 +233,7 @@ BGGY:
 BIKE:
 	Inherits: ^Vehicle
 	Valued:
-		Cost: 500
+		Cost: 600
 	Tooltip:
 		Name: Recon Bike
 		Description: Fast scout vehicle, armed with \nrockets. \nCan attack Aircraft.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry


### PR DESCRIPTION
Hoping to squeeze this into this release.

Recon bikes are not overpowered, but given what they bring to the battlefield - dealing very similar damage to bazooka infantry and being the fastest unit in the game - for only $500 a unit at tier 1, some players only strategy now is spamming huge recon bike armies, which devolves the game into a boring starcraft-zerg-rush style mess. Newbies get mopped the floor with these bikes and it certainly doesn't help with the latency.

$600 is fair; it doesn't nerf the bikes and puts them on par with the cost of other units. Players can still spam them if that's what they want to spend their cash on, but are no longer rewarded for doing so.
