### PR TITLE
Dispose of graphics resources deterministically

### DIFF
--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -46,6 +46,7 @@ namespace OpenRA.Editor
 				miniMapBox.Image = null;
 				currentMod = toolStripComboBox1.SelectedItem as string;
 
+				Game.InitializeSettings(Arguments.Empty);
 				Game.modData = new ModData(currentMod);
 				GlobalFileSystem.LoadFromManifest(Game.modData.Manifest);
 				Program.Rules = Game.modData.RulesetCache.LoadDefaultRules();
@@ -203,10 +204,10 @@ namespace OpenRA.Editor
 							Height = bitmap.Height / 2,
 							SizeMode = PictureBoxSizeMode.StretchImage
 						};
-	
+
 						var brushTemplate = new BrushTemplate { Bitmap = bitmap, N = t.Key };
 						ibox.Click += (_, e) => surface1.SetTool(new BrushTool(brushTemplate));
-	
+
 						var template = t.Value;
 						tilePalette.Controls.Add(ibox);
 						tt.SetToolTip(ibox, "{1}:{0} ({2}x{3})".F(template.Image, template.Id, template.Size.X, template.Size.Y));
@@ -463,7 +464,7 @@ namespace OpenRA.Editor
 		void ExportMinimap(object sender, EventArgs e)
 		{
 			using (var sfd = new SaveFileDialog()
-			{ 
+			{
 				InitialDirectory = Path.Combine(Environment.CurrentDirectory, "maps"),
 				DefaultExt = "*.png",
 				Filter = "PNG Image (*.png)|*.png",
@@ -471,9 +472,8 @@ namespace OpenRA.Editor
 				FileName = Path.ChangeExtension(loadedMapName, ".png"),
 				RestoreDirectory = true
 			})
-
-			if (DialogResult.OK == sfd.ShowDialog())
-				miniMapBox.Image.Save(sfd.FileName);
+				if (DialogResult.OK == sfd.ShowDialog())
+					miniMapBox.Image.Save(sfd.FileName);
 		}
 
 		void ShowActorNamesClicked(object sender, EventArgs e)
@@ -637,7 +637,7 @@ namespace OpenRA.Editor
 		{
 			ShowGridClicked(sender, e);
 		}
-		
+
 		public int CalculateTotalResource()
 		{
 			var totalResource = 0;
@@ -651,7 +651,7 @@ namespace OpenRA.Editor
 
 			return totalResource;
 		}
-		
+
 		int GetAdjecentCellsWith(int resourceType, int x, int y)
 		{
 			var sum = 0;

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -175,13 +175,18 @@ namespace OpenRA
 		public static Modifiers GetModifierKeys() { return modifiers; }
 		internal static void HandleModifierKeys(Modifiers mods) { modifiers = mods; }
 
+		public static void InitializeSettings(Arguments args)
+		{
+			Settings = new Settings(Platform.ResolvePath("^", "settings.yaml"), args);
+		}
+
 		internal static void Initialize(Arguments args)
 		{
 			Console.WriteLine("Platform is {0}", Platform.CurrentPlatform);
 
 			AppDomain.CurrentDomain.AssemblyResolve += GlobalFileSystem.ResolveAssembly;
 
-			Settings = new Settings(Platform.ResolvePath("^", "settings.yaml"), args);
+			InitializeSettings(args);
 
 			Log.AddChannel("perf", "perf.log");
 			Log.AddChannel("debug", "debug.log");

--- a/OpenRA.Game/GameRules/RulesetCache.cs
+++ b/OpenRA.Game/GameRules/RulesetCache.cs
@@ -17,7 +17,7 @@ using OpenRA.Support;
 
 namespace OpenRA
 {
-	public class RulesetCache
+	public sealed class RulesetCache : IDisposable
 	{
 		readonly ModData modData;
 
@@ -136,6 +136,13 @@ namespace OpenRA
 			}
 
 			return items;
+		}
+
+		public void Dispose()
+		{
+			foreach (var cache in sequenceCaches.Values)
+				cache.Dispose();
+			sequenceCaches.Clear();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -27,6 +27,8 @@ namespace OpenRA.Graphics
 
 		public static void Initialize(IEnumerable<string> chromeFiles)
 		{
+			Deinitialize();
+
 			collections = new Dictionary<string, Collection>();
 			cachedSheets = new Dictionary<string, Sheet>();
 			cachedSprites = new Dictionary<string, Dictionary<string, Sprite>>();
@@ -35,6 +37,17 @@ namespace OpenRA.Graphics
 
 			foreach (var c in chrome)
 				LoadCollection(c.Key, c.Value);
+		}
+
+		public static void Deinitialize()
+		{
+			if (cachedSheets != null)
+				foreach (var sheet in cachedSheets.Values)
+					sheet.Dispose();
+
+			collections = null;
+			cachedSheets = null;
+			cachedSprites = null;
 		}
 
 		public static void Save(string file)

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -17,8 +17,8 @@ namespace OpenRA.Graphics
 	{
 		struct Collection
 		{
-			public string src;
-			public Dictionary<string, MappedImage> regions;
+			public string Src;
+			public Dictionary<string, MappedImage> Regions;
 		}
 
 		static Dictionary<string, Collection> collections;
@@ -62,10 +62,10 @@ namespace OpenRA.Graphics
 		static MiniYaml SaveCollection(Collection collection)
 		{
 			var root = new List<MiniYamlNode>();
-			foreach (var kv in collection.regions)
-				root.Add(new MiniYamlNode(kv.Key, kv.Value.Save(collection.src)));
+			foreach (var kv in collection.Regions)
+				root.Add(new MiniYamlNode(kv.Key, kv.Value.Save(collection.Src)));
 
-			return new MiniYaml(collection.src, root);
+			return new MiniYaml(collection.Src, root);
 		}
 
 		static void LoadCollection(string name, MiniYaml yaml)
@@ -73,8 +73,8 @@ namespace OpenRA.Graphics
 			Game.modData.LoadScreen.Display();
 			var collection = new Collection()
 			{
-				src = yaml.Value,
-				regions = yaml.Nodes.ToDictionary(n => n.Key, n => new MappedImage(yaml.Value, n.Value))
+				Src = yaml.Value,
+				Regions = yaml.Nodes.ToDictionary(n => n.Key, n => new MappedImage(yaml.Value, n.Value))
 			};
 
 			collections.Add(name, collection);
@@ -96,7 +96,7 @@ namespace OpenRA.Graphics
 			}
 
 			MappedImage mi;
-			if (!collection.regions.TryGetValue(imageName, out mi))
+			if (!collection.Regions.TryGetValue(imageName, out mi))
 				return null;
 
 			// Cached sheet
@@ -115,6 +115,7 @@ namespace OpenRA.Graphics
 				cachedCollection = new Dictionary<string, Sprite>();
 				cachedSprites.Add(collectionName, cachedCollection);
 			}
+
 			var image = mi.GetImage(sheet);
 			cachedCollection.Add(imageName, image);
 

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -18,9 +18,9 @@ namespace OpenRA.Graphics
 {
 	public sealed class CursorProvider : IDisposable
 	{
-		HardwarePalette palette;
-		Dictionary<string, CursorSequence> cursors;
-		Cache<string, PaletteReference> palettes;
+		readonly HardwarePalette palette = new HardwarePalette();
+		readonly Dictionary<string, CursorSequence> cursors = new Dictionary<string, CursorSequence>();
+		readonly Cache<string, PaletteReference> palettes;
 		readonly SheetBuilder sheetBuilder;
 
 		public static bool CursorViewportZoomed { get { return Game.Settings.Graphics.CursorDouble && Game.Settings.Graphics.PixelDouble; } }
@@ -29,7 +29,6 @@ namespace OpenRA.Graphics
 		{
 			var sequenceFiles = modData.Manifest.Cursors;
 
-			cursors = new Dictionary<string, CursorSequence>();
 			palettes = new Cache<string, PaletteReference>(CreatePaletteReference);
 			var sequences = new MiniYaml(null, sequenceFiles.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal));
 			var shadowIndex = new int[] { };
@@ -42,7 +41,6 @@ namespace OpenRA.Graphics
 					out shadowIndex[shadowIndex.Length - 1]);
 			}
 
-			palette = new HardwarePalette();
 			foreach (var p in nodesDict["Palettes"].Nodes)
 				palette.AddPalette(p.Key, new ImmutablePalette(GlobalFileSystem.Open(p.Value.Value), shadowIndex), false);
 

--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {
-	public class HardwarePalette
+	public sealed class HardwarePalette : IDisposable
 	{
 		public const int MaxPalettes = 256;
 
@@ -110,6 +110,11 @@ namespace OpenRA.Graphics
 				var modifiedPalette = kvp.Value;
 				modifiedPalette.SetFromPalette(originalPalette);
 			}
+		}
+
+		public void Dispose()
+		{
+			Texture.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -63,7 +63,7 @@ namespace OpenRA
 		void ReleaseWindowMouseFocus();
 	}
 
-	public interface IVertexBuffer<T>
+	public interface IVertexBuffer<T> : IDisposable
 	{
 		void Bind();
 		void SetData(T[] vertices, int length);
@@ -80,7 +80,8 @@ namespace OpenRA
 	}
 
 	public enum TextureScaleFilter { Nearest, Linear }
-	public interface ITexture
+	
+	public interface ITexture : IDisposable
 	{
 		void SetData(Bitmap bitmap);
 		void SetData(uint[,] colors);
@@ -90,7 +91,7 @@ namespace OpenRA
 		TextureScaleFilter ScaleFilter { get; set; }
 	}
 
-	public interface IFrameBuffer
+	public interface IFrameBuffer : IDisposable
 	{
 		void Bind();
 		void Unbind();

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -20,13 +20,14 @@ namespace OpenRA.Graphics
 		Renderer renderer;
 		IShader shader;
 
-		Vertex[] vertices = new Vertex[Renderer.TempBufferSize];
+		readonly Vertex[] vertices;
 		int nv = 0;
 
 		public LineRenderer(Renderer renderer, IShader shader)
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
 
@@ -71,9 +72,9 @@ namespace OpenRA.Graphics
 
 		public void DrawLine(float2 start, float2 end, Color startColor, Color endColor)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
-			if (nv + 2 > Renderer.TempBufferSize)
+			if (nv + 2 > renderer.TempBufferSize)
 				Flush();
 
 			vertices[nv++] = new Vertex(start + offset,

--- a/OpenRA.Game/Graphics/LineRenderer.cs
+++ b/OpenRA.Game/Graphics/LineRenderer.cs
@@ -15,13 +15,15 @@ namespace OpenRA.Graphics
 {
 	public class LineRenderer : Renderer.IBatchRenderer
 	{
-		static float2 offset = new float2(0.5f, 0.5f);
-		float lineWidth = 1f;
-		Renderer renderer;
-		IShader shader;
+		static readonly float2 Offset = new float2(0.5f, 0.5f);
+
+		readonly Renderer renderer;
+		readonly IShader shader;
 
 		readonly Vertex[] vertices;
 		int nv = 0;
+
+		float lineWidth = 1f;
 
 		public LineRenderer(Renderer renderer, IShader shader)
 		{
@@ -30,10 +32,12 @@ namespace OpenRA.Graphics
 			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
-
 		public float LineWidth
 		{
-			get { return lineWidth; }
+			get
+			{
+				return lineWidth;
+			}
 			set
 			{
 				if (LineWidth != value)
@@ -77,11 +81,11 @@ namespace OpenRA.Graphics
 			if (nv + 2 > renderer.TempBufferSize)
 				Flush();
 
-			vertices[nv++] = new Vertex(start + offset,
+			vertices[nv++] = new Vertex(start + Offset,
 				startColor.R / 255.0f, startColor.G / 255.0f,
 				startColor.B / 255.0f, startColor.A / 255.0f);
 
-			vertices[nv++] = new Vertex(end + offset,
+			vertices[nv++] = new Vertex(end + Offset,
 				endColor.R / 255.0f, endColor.G / 255.0f,
 				endColor.B / 255.0f, endColor.A / 255.0f);
 		}
@@ -100,7 +104,7 @@ namespace OpenRA.Graphics
 			var yc = (r.Bottom + r.Top) / 2;
 			for (var y = r.Top; y <= r.Bottom; y++)
 			{
-				var dx = a * (float)(Math.Sqrt(1 - (y - yc) * (y - yc) / b / b));
+				var dx = a * (float)Math.Sqrt(1 - (y - yc) * (y - yc) / b / b);
 				DrawLine(new float2(xc - dx, y), new float2(xc + dx, y), color, color);
 			}
 		}
@@ -108,7 +112,7 @@ namespace OpenRA.Graphics
 		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
 			shader.SetVec("Scroll", scroll.X, scroll.Y);
-			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
+			shader.SetVec("r1", zoom * 2f / screen.Width, -zoom * 2f / screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}
 	}

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -203,8 +203,8 @@ namespace OpenRA.Graphics
 
 		public static Bitmap RenderMapPreview(TileSet tileset, Map map, Ruleset resourceRules, bool actualSize)
 		{
-			var terrain = TerrainBitmap(tileset, map, actualSize);
-			return AddStaticResources(tileset, map, resourceRules, terrain);
+			using (var terrain = TerrainBitmap(tileset, map, actualSize))
+				return AddStaticResources(tileset, map, resourceRules, terrain);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/QuadRenderer.cs
+++ b/OpenRA.Game/Graphics/QuadRenderer.cs
@@ -14,8 +14,8 @@ namespace OpenRA.Graphics
 {
 	public class QuadRenderer : Renderer.IBatchRenderer
 	{
-		Renderer renderer;
-		IShader shader;
+		readonly Renderer renderer;
+		readonly IShader shader;
 
 		readonly Vertex[] vertices;
 		int nv = 0;
@@ -66,7 +66,7 @@ namespace OpenRA.Graphics
 		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
 			shader.SetVec("Scroll", scroll.X, scroll.Y);
-			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
+			shader.SetVec("r1", zoom * 2f / screen.Width, -zoom * 2f / screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}
 	}

--- a/OpenRA.Game/Graphics/QuadRenderer.cs
+++ b/OpenRA.Game/Graphics/QuadRenderer.cs
@@ -17,13 +17,14 @@ namespace OpenRA.Graphics
 		Renderer renderer;
 		IShader shader;
 
-		Vertex[] vertices = new Vertex[Renderer.TempBufferSize];
+		readonly Vertex[] vertices;
 		int nv = 0;
 
 		public QuadRenderer(Renderer renderer, IShader shader)
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
 		public void Flush()
@@ -45,9 +46,9 @@ namespace OpenRA.Graphics
 
 		public void FillRect(RectangleF rect, Color color)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
-			if (nv + 4 > Renderer.TempBufferSize)
+			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
 			var r = color.R / 255.0f;

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	public class SequenceCache
+	public sealed class SequenceCache : IDisposable
 	{
 		readonly ModData modData;
 		readonly Lazy<SpriteCache> spriteCache;
@@ -140,6 +140,12 @@ namespace OpenRA.Graphics
 			}
 
 			return new ReadOnlyDictionary<string, Sequence>(unitSequences);
+		}
+
+		public void Dispose()
+		{
+			if (spriteCache.IsValueCreated)
+				spriteCache.Value.SheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -16,7 +16,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Graphics
 {
-	public class Sheet
+	public sealed class Sheet : IDisposable
 	{
 		readonly object textureLock = new object();
 		bool dirty;
@@ -177,6 +177,12 @@ namespace OpenRA.Graphics
 				if (releaseBuffer)
 					releaseBufferOnCommit = true;
 			}
+		}
+
+		public void Dispose()
+		{
+			if (texture != null)
+				texture.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -32,12 +32,13 @@ namespace OpenRA.Graphics
 	public sealed class SheetBuilder : IDisposable
 	{
 		readonly List<Sheet> sheets = new List<Sheet>();
+		readonly SheetType type;
+		readonly Func<Sheet> allocateSheet;
+
 		Sheet current;
 		TextureChannel channel;
-		SheetType type;
 		int rowHeight = 0;
 		Point p;
-		Func<Sheet> allocateSheet;
 
 		public static Sheet AllocateSheet(int sheetSize)
 		{

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Graphics
 		}
 
 		public SheetBuilder(SheetType t)
-			: this(t, Game.Renderer.SheetSize) { }
+			: this(t, Game.Settings.Graphics.SheetSize) { }
 
 		public SheetBuilder(SheetType t, int sheetSize)
 			: this(t, () => AllocateSheet(sheetSize)) { }

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -9,7 +9,9 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace OpenRA.Graphics
 {
@@ -27,8 +29,9 @@ namespace OpenRA.Graphics
 		BGRA = 4,
 	}
 
-	public class SheetBuilder
+	public sealed class SheetBuilder : IDisposable
 	{
+		readonly List<Sheet> sheets = new List<Sheet>();
 		Sheet current;
 		TextureChannel channel;
 		SheetType type;
@@ -36,19 +39,23 @@ namespace OpenRA.Graphics
 		Point p;
 		Func<Sheet> allocateSheet;
 
-		public static Sheet AllocateSheet()
+		public static Sheet AllocateSheet(int sheetSize)
 		{
-			return new Sheet(new Size(Renderer.SheetSize, Renderer.SheetSize));
+			return new Sheet(new Size(sheetSize, sheetSize));
 		}
 
 		public SheetBuilder(SheetType t)
-			: this(t, AllocateSheet) { }
+			: this(t, Game.Renderer.SheetSize) { }
+
+		public SheetBuilder(SheetType t, int sheetSize)
+			: this(t, () => AllocateSheet(sheetSize)) { }
 
 		public SheetBuilder(SheetType t, Func<Sheet> allocateSheet)
 		{
 			channel = TextureChannel.Red;
 			type = t;
 			current = allocateSheet();
+			sheets.Add(current);
 			this.allocateSheet = allocateSheet;
 		}
 
@@ -111,6 +118,7 @@ namespace OpenRA.Graphics
 				{
 					current.ReleaseBuffer();
 					current = allocateSheet();
+					sheets.Add(current);
 					channel = TextureChannel.Red;
 				}
 				else
@@ -127,5 +135,12 @@ namespace OpenRA.Graphics
 		}
 
 		public Sheet Current { get { return current; } }
+
+		public void Dispose()
+		{
+			foreach (var sheet in sheets)
+				sheet.Dispose();
+			sheets.Clear();
+		}
 	}
 }

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Graphics
 		static Library library = new Library();
 		static SheetBuilder builder;
 
-		int size;
+		readonly int size;
 		string name;
 
 		public SpriteFont(string name, int size)
@@ -114,7 +114,6 @@ namespace OpenRA.Graphics
 
 			// A new bitmap is generated each time this property is accessed, so we do need to dispose it.
 			using (var bitmap = face.Glyph.Bitmap)
-			{
 				unsafe
 				{
 					var p = (byte*)bitmap.Buffer;
@@ -136,7 +135,7 @@ namespace OpenRA.Graphics
 						p += bitmap.Pitch;
 					}
 				}
-			}
+
 
 			s.sheet.CommitData();
 

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -17,8 +17,8 @@ namespace OpenRA.Graphics
 		Renderer renderer;
 		IShader shader;
 
-		Vertex[] vertices = new Vertex[Renderer.TempBufferSize];
-		Sheet currentSheet = null;
+		readonly Vertex[] vertices;
+		Sheet currentSheet;
 		BlendMode currentBlend = BlendMode.Alpha;
 		int nv = 0;
 
@@ -26,6 +26,7 @@ namespace OpenRA.Graphics
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+			vertices = new Vertex[renderer.TempBufferSize];
 		}
 
 		public void Flush()
@@ -60,7 +61,7 @@ namespace OpenRA.Graphics
 
 		void DrawSprite(Sprite s, float2 location, int paletteIndex, float2 size)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
 			if (s.sheet != currentSheet)
 				Flush();
@@ -68,7 +69,7 @@ namespace OpenRA.Graphics
 			if (s.blendMode != currentBlend)
 				Flush();
 
-			if (nv + 4 > Renderer.TempBufferSize)
+			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
 			currentBlend = s.blendMode;
@@ -90,7 +91,7 @@ namespace OpenRA.Graphics
 
 		public void DrawSprite(Sprite s, float2 a, float2 b, float2 c, float2 d)
 		{
-			Renderer.CurrentBatchRenderer = this;
+			renderer.CurrentBatchRenderer = this;
 
 			if (s.sheet != currentSheet)
 				Flush();
@@ -98,7 +99,7 @@ namespace OpenRA.Graphics
 			if (s.blendMode != currentBlend)
 				Flush();
 
-			if (nv + 4 > Renderer.TempBufferSize)
+			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
 			currentSheet = s.sheet;

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -14,8 +14,8 @@ namespace OpenRA.Graphics
 {
 	public class SpriteRenderer : Renderer.IBatchRenderer
 	{
-		Renderer renderer;
-		IShader shader;
+		readonly Renderer renderer;
+		readonly IShader shader;
 
 		readonly Vertex[] vertices;
 		Sheet currentSheet;
@@ -124,7 +124,7 @@ namespace OpenRA.Graphics
 		public void SetViewportParams(Size screen, float zoom, int2 scroll)
 		{
 			shader.SetVec("Scroll", scroll.X, scroll.Y);
-			shader.SetVec("r1", zoom*2f/screen.Width, -zoom*2f/screen.Height);
+			shader.SetVec("r1", zoom * 2f / screen.Width, -zoom * 2f / screen.Height);
 			shader.SetVec("r2", -1, 1);
 		}
 	}

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -8,11 +8,12 @@
  */
 #endregion
 
+using System;
 using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {
-	class TerrainRenderer
+	sealed class TerrainRenderer : IDisposable
 	{
 		IVertexBuffer<Vertex> vertexBuffer;
 
@@ -57,6 +58,11 @@ namespace OpenRA.Graphics
 
 			foreach (var r in world.WorldActor.TraitsImplementing<IRenderOverlay>())
 				r.Render(wr);
+		}
+
+		public void Dispose()
+		{
+			vertexBuffer.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -15,10 +15,9 @@ namespace OpenRA.Graphics
 {
 	sealed class TerrainRenderer : IDisposable
 	{
-		IVertexBuffer<Vertex> vertexBuffer;
-
-		World world;
-		Map map;
+		readonly IVertexBuffer<Vertex> vertexBuffer;
+		readonly World world;
+		readonly Map map;
 
 		public TerrainRenderer(World world, WorldRenderer wr)
 		{
@@ -43,7 +42,7 @@ namespace OpenRA.Graphics
 
 		public void Draw(WorldRenderer wr, Viewport viewport)
 		{
-			var verticesPerRow = 4*map.Bounds.Width;
+			var verticesPerRow = 4 * map.Bounds.Width;
 			var cells = viewport.VisibleCells;
 			var shape = wr.world.Map.TileShape;
 

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -18,9 +18,9 @@ namespace OpenRA.Graphics
 {
 	public sealed class Theater : IDisposable
 	{
-		SheetBuilder sheetBuilder;
-		Dictionary<ushort, Sprite[]> templates;
-		Sprite missingTile;
+		readonly Dictionary<ushort, Sprite[]> templates = new Dictionary<ushort, Sprite[]>();
+		readonly SheetBuilder sheetBuilder;
+		readonly Sprite missingTile;
 		TileSet tileset;
 
 		public Theater(TileSet tileset)

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -16,7 +16,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA.Graphics
 {
-	public class Theater
+	public sealed class Theater : IDisposable
 	{
 		SheetBuilder sheetBuilder;
 		Dictionary<ushort, Sprite[]> templates;
@@ -101,5 +101,10 @@ namespace OpenRA.Graphics
 		}
 
 		public Sheet Sheet { get { return sheetBuilder.Current; } }
+
+		public void Dispose()
+		{
+			sheetBuilder.Dispose();
+		}
 	}
 }

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	public class VoxelLoader
+	public sealed class VoxelLoader : IDisposable
 	{
 		SheetBuilder sheetBuilder;
 
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 				if (allocated)
 					throw new SheetOverflowException("");
 				allocated = true;
-				return SheetBuilder.AllocateSheet();
+				return SheetBuilder.AllocateSheet(Game.Renderer.SheetSize);
 			};
 
 			return new SheetBuilder(SheetType.DualIndexed, allocate);
@@ -195,6 +195,8 @@ namespace OpenRA.Graphics
 
 		public void RefreshBuffer()
 		{
+			if (vertexBuffer != null)
+				vertexBuffer.Dispose();
 			vertexBuffer = Game.Renderer.Device.CreateVertexBuffer(totalVertexCount);
 			vertexBuffer.SetData(vertices.SelectMany(v => v).ToArray(), totalVertexCount);
 			cachedVertexCount = totalVertexCount;
@@ -229,6 +231,13 @@ namespace OpenRA.Graphics
 		public void Finish()
 		{
 			sheetBuilder.Current.ReleaseBuffer();
+		}
+
+		public void Dispose()
+		{
+			if (vertexBuffer != null)
+				vertexBuffer.Dispose();
+			sheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -34,13 +34,15 @@ namespace OpenRA.Graphics
 
 	public sealed class VoxelLoader : IDisposable
 	{
-		SheetBuilder sheetBuilder;
+		static readonly float[] ChannelSelect = { 0.75f, 0.25f, -0.25f, -0.75f };
 
-		Cache<Pair<string,string>, Voxel> voxels;
+		readonly List<Vertex[]> vertices = new List<Vertex[]>();
+		readonly Cache<Pair<string, string>, Voxel> voxels;
 		IVertexBuffer<Vertex> vertexBuffer;
-		List<Vertex[]> vertices;
 		int totalVertexCount;
 		int cachedVertexCount;
+
+		SheetBuilder sheetBuilder;
 
 		static SheetBuilder CreateSheetBuilder()
 		{
@@ -58,7 +60,7 @@ namespace OpenRA.Graphics
 
 		public VoxelLoader()
 		{
-			voxels = new Cache<Pair<string,string>, Voxel>(LoadFile);
+			voxels = new Cache<Pair<string, string>, Voxel>(LoadFile);
 			vertices = new List<Vertex[]>();
 			totalVertexCount = 0;
 			cachedVertexCount = 0;
@@ -66,29 +68,28 @@ namespace OpenRA.Graphics
 			sheetBuilder = CreateSheetBuilder();
 		}
 
-		static float[] channelSelect = { 0.75f, 0.25f, -0.25f, -0.75f };
-		Vertex[] GenerateSlicePlane(int su, int sv, Func<int,int,VxlElement> first, Func<int,int,VxlElement> second, Func<int, int, float[]> coord)
+		Vertex[] GenerateSlicePlane(int su, int sv, Func<int, int, VxlElement> first, Func<int, int, VxlElement> second, Func<int, int, float[]> coord)
 		{
-			var colors = new byte[su*sv];
-			var normals = new byte[su*sv];
+			var colors = new byte[su * sv];
+			var normals = new byte[su * sv];
 
 			var c = 0;
 			for (var v = 0; v < sv; v++)
 				for (var u = 0; u < su; u++)
-			{
-				var voxel = first(u,v) ?? second(u,v);
-				colors[c] = voxel == null ? (byte)0 : voxel.Color;
-				normals[c] = voxel == null ? (byte)0 : voxel.Normal;
-				c++;
-			}
+				{
+					var voxel = first(u, v) ?? second(u, v);
+					colors[c] = voxel == null ? (byte)0 : voxel.Color;
+					normals[c] = voxel == null ? (byte)0 : voxel.Normal;
+					c++;
+				}
 
 			var s = sheetBuilder.Allocate(new Size(su, sv));
 			Util.FastCopyIntoChannel(s, 0, colors);
 			Util.FastCopyIntoChannel(s, 1, normals);
 			s.sheet.CommitData();
 
-			var channelP =channelSelect[(int)s.channel];
-			var channelC = channelSelect[(int)s.channel + 1];
+			var channelP = ChannelSelect[(int)s.channel];
+			var channelC = ChannelSelect[(int)s.channel + 1];
 			return new Vertex[4]
 			{
 				new Vertex(coord(0, 0), s.left, s.top, channelP, channelC),
@@ -100,7 +101,7 @@ namespace OpenRA.Graphics
 
 		IEnumerable<Vertex[]> GenerateSlicePlanes(VxlLimb l)
 		{
-			Func<int,int,int,VxlElement> get = (x,y,z) =>
+			Func<int, int, int, VxlElement> get = (x, y, z) =>
 			{
 				if (x < 0 || y < 0 || z < 0)
 					return null;
@@ -108,41 +109,41 @@ namespace OpenRA.Graphics
 				if (x >= l.Size[0] || y >= l.Size[1] || z >= l.Size[2])
 					return null;
 
-				var v = l.VoxelMap[(byte)x,(byte)y];
+				var v = l.VoxelMap[(byte)x, (byte)y];
 				if (v == null || !v.ContainsKey((byte)z))
 					return null;
 
-				return l.VoxelMap[(byte)x,(byte)y][(byte)z];
+				return l.VoxelMap[(byte)x, (byte)y][(byte)z];
 			};
 
 			// Cull slices without any visible faces
-			var xPlanes = new bool[l.Size[0]+1];
-			var yPlanes = new bool[l.Size[1]+1];
-			var zPlanes = new bool[l.Size[2]+1];
+			var xPlanes = new bool[l.Size[0] + 1];
+			var yPlanes = new bool[l.Size[1] + 1];
+			var zPlanes = new bool[l.Size[2] + 1];
 			for (var x = 0; x < l.Size[0]; x++)
 			{
 				for (var y = 0; y < l.Size[1]; y++)
 				{
 					for (var z = 0; z < l.Size[2]; z++)
 					{
-						if (get(x,y,z) == null)
+						if (get(x, y, z) == null)
 							continue;
 
 						// Only generate a plane if it is actually visible
-						if (!xPlanes[x] && get(x-1,y,z) == null)
+						if (!xPlanes[x] && get(x - 1, y, z) == null)
 							xPlanes[x] = true;
-						if (!xPlanes[x+1] && get(x+1,y,z) == null)
-							xPlanes[x+1] = true;
+						if (!xPlanes[x + 1] && get(x + 1, y, z) == null)
+							xPlanes[x + 1] = true;
 
-						if (!yPlanes[y] && get(x,y-1,z) == null)
+						if (!yPlanes[y] && get(x, y - 1, z) == null)
 							yPlanes[y] = true;
-						if (!yPlanes[y+1] && get(x,y+1,z) == null)
-							yPlanes[y+1] = true;
+						if (!yPlanes[y + 1] && get(x, y + 1, z) == null)
+							yPlanes[y + 1] = true;
 
-						if (!zPlanes[z] && get(x,y,z-1) == null)
+						if (!zPlanes[z] && get(x, y, z - 1) == null)
 							zPlanes[z] = true;
-						if (!zPlanes[z+1] && get(x,y,z+1) == null)
-							zPlanes[z+1] = true;
+						if (!zPlanes[z + 1] && get(x, y, z + 1) == null)
+							zPlanes[z + 1] = true;
 					}
 				}
 			}
@@ -150,23 +151,23 @@ namespace OpenRA.Graphics
 			for (var x = 0; x <= l.Size[0]; x++)
 				if (xPlanes[x])
 					yield return GenerateSlicePlane(l.Size[1], l.Size[2],
-						(u,v) => get(x, u, v),
-						(u,v) => get(x - 1, u, v),
-						(u,v) => new float[] {x, u, v});
+						(u, v) => get(x, u, v),
+						(u, v) => get(x - 1, u, v),
+						(u, v) => new float[] { x, u, v });
 
 			for (var y = 0; y <= l.Size[1]; y++)
 				if (yPlanes[y])
 					yield return GenerateSlicePlane(l.Size[0], l.Size[2],
-						(u,v) => get(u, y, v),
-						(u,v) => get(u, y - 1, v),
-						(u,v) => new float[] {u, y, v});
+						(u, v) => get(u, y, v),
+						(u, v) => get(u, y - 1, v),
+						(u, v) => new float[] { u, y, v });
 
 			for (var z = 0; z <= l.Size[2]; z++)
 				if (zPlanes[z])
 					yield return GenerateSlicePlane(l.Size[0], l.Size[1],
-						(u,v) => get(u, v, z),
-						(u,v) => get(u, v, z - 1),
-						(u,v) => new float[] {u, v, z});
+						(u, v) => get(u, v, z),
+						(u, v) => get(u, v, z - 1),
+						(u, v) => new float[] { u, v, z });
 		}
 
 		public VoxelRenderData GenerateRenderData(VxlLimb l)
@@ -212,7 +213,7 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		Voxel LoadFile(Pair<string,string> files)
+		Voxel LoadFile(Pair<string, string> files)
 		{
 			VxlReader vxl;
 			HvaReader hva;

--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -34,31 +34,28 @@ namespace OpenRA.Graphics
 
 	public sealed class VoxelRenderer : IDisposable
 	{
-		Renderer renderer;
-		IShader shader;
+		// Static constants
+		static readonly float[] ShadowDiffuse = new float[] { 0, 0, 0 };
+		static readonly float[] ShadowAmbient = new float[] { 1, 1, 1 };
+		static readonly float2 SpritePadding = new float2(2, 2);
+		static readonly float[] ZeroVector = new float[] { 0, 0, 0, 1 };
+		static readonly float[] ZVector = new float[] { 0, 0, 1, 1 };
+		static readonly float[] FlipMtx = Util.ScaleMatrix(1, -1, 1);
+		static readonly float[] ShadowScaleFlipMtx = Util.ScaleMatrix(2, -2, 2);
+
+		readonly Renderer renderer;
+		readonly IShader shader;
+
+		readonly Dictionary<Sheet, IFrameBuffer> mappedBuffers = new Dictionary<Sheet, IFrameBuffer>();
+		readonly Stack<KeyValuePair<Sheet, IFrameBuffer>> unmappedBuffers = new Stack<KeyValuePair<Sheet, IFrameBuffer>>();
+		readonly List<Pair<Sheet, Action>> doRender = new List<Pair<Sheet, Action>>();
 
 		SheetBuilder sheetBuilder;
-		Dictionary<Sheet, IFrameBuffer> mappedBuffers;
-		Stack<KeyValuePair<Sheet, IFrameBuffer>> unmappedBuffers;
-		List<Pair<Sheet, Action>> doRender;
-
-		// Static constants
-		static readonly float[] shadowDiffuse = new float[] {0,0,0};
-		static readonly float[] shadowAmbient = new float[] {1,1,1};
-		static readonly float2 spritePadding = new float2(2, 2);
-		static readonly float[] zeroVector = new float[] {0,0,0,1};
-		static readonly float[] zVector = new float[] {0,0,1,1};
-		static readonly float[] flipMtx = Util.ScaleMatrix(1, -1, 1);
-		static readonly float[] shadowScaleFlipMtx = Util.ScaleMatrix(2, -2, 2);
 
 		public VoxelRenderer(Renderer renderer, IShader shader)
 		{
 			this.renderer = renderer;
 			this.shader = shader;
-
-			mappedBuffers = new Dictionary<Sheet, IFrameBuffer>();
-			unmappedBuffers = new Stack<KeyValuePair<Sheet, IFrameBuffer>>();
-			doRender = new List<Pair<Sheet, Action>>();
 		}
 
 		public void SetPalette(ITexture palette)
@@ -73,7 +70,7 @@ namespace OpenRA.Graphics
 			{
 				a, 0, 0, 0,
 				0, -a, 0, 0,
-				0, 0, -2*a, 0,
+				0, 0, -2 * a, 0,
 				-1, 1, 0, 1
 			};
 
@@ -111,7 +108,7 @@ namespace OpenRA.Graphics
 				var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
 
 				var worldTransform = v.RotationFunc().Aggregate(Util.IdentityMatrix(),
-					(x,y) => Util.MatrixMultiply(Util.MakeFloatMatrix(y.AsMatrix()), x));
+					(x, y) => Util.MatrixMultiply(Util.MakeFloatMatrix(y.AsMatrix()), x));
 				worldTransform = Util.MatrixMultiply(scaleTransform, worldTransform);
 				worldTransform = Util.MatrixMultiply(offsetTransform, worldTransform);
 
@@ -128,18 +125,18 @@ namespace OpenRA.Graphics
 			}
 
 			// Inflate rects to ensure rendering is within bounds
-			tl -= spritePadding;
-			br += spritePadding;
-			stl -= spritePadding;
-			sbr += spritePadding;
+			tl -= SpritePadding;
+			br += SpritePadding;
+			stl -= SpritePadding;
+			sbr += SpritePadding;
 
 			// Corners of the shadow quad, in shadow-space
 			var corners = new float[][]
 			{
-				new float[] {stl.X, stl.Y, 0, 1},
-				new float[] {sbr.X, sbr.Y, 0, 1},
-				new float[] {sbr.X, stl.Y, 0, 1},
-				new float[] {stl.X, sbr.Y, 0, 1}
+				new[] { stl.X, stl.Y, 0, 1 },
+				new[] { sbr.X, sbr.Y, 0, 1 },
+				new[] { sbr.X, stl.Y, 0, 1 },
+				new[] { stl.X, sbr.Y, 0, 1 }
 			};
 
 			var shadowScreenTransform = Util.MatrixMultiply(cameraTransform, invShadowTransform);
@@ -148,8 +145,8 @@ namespace OpenRA.Graphics
 			for (var j = 0; j < 4; j++)
 			{
 				// Project to ground plane
-				corners[j][2] = -(corners[j][1]*shadowGroundNormal[1]/shadowGroundNormal[2] +
-								  corners[j][0]*shadowGroundNormal[0]/shadowGroundNormal[2]);
+				corners[j][2] = -(corners[j][1] * shadowGroundNormal[1] / shadowGroundNormal[2] +
+								  corners[j][0] * shadowGroundNormal[0] / shadowGroundNormal[2]);
 
 				// Rotate to camera-space
 				corners[j] = Util.MatrixVectorMultiply(shadowScreenTransform, corners[j]);
@@ -171,8 +168,8 @@ namespace OpenRA.Graphics
 
 			var translateMtx = Util.TranslationMatrix(spriteCenter.X - spriteOffset.X, renderer.SheetSize - (spriteCenter.Y - spriteOffset.Y), 0);
 			var shadowTranslateMtx = Util.TranslationMatrix(shadowCenter.X - shadowSpriteOffset.X, renderer.SheetSize - (shadowCenter.Y - shadowSpriteOffset.Y), 0);
-			var correctionTransform = Util.MatrixMultiply(translateMtx, flipMtx);
-			var shadowCorrectionTransform = Util.MatrixMultiply(shadowTranslateMtx, shadowScaleFlipMtx);
+			var correctionTransform = Util.MatrixMultiply(translateMtx, FlipMtx);
+			var shadowCorrectionTransform = Util.MatrixMultiply(shadowTranslateMtx, ShadowScaleFlipMtx);
 
 			doRender.Add(Pair.New<Sheet, Action>(sprite.sheet, () =>
 			{
@@ -183,7 +180,7 @@ namespace OpenRA.Graphics
 					var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
 
 					var rotations = v.RotationFunc().Aggregate(Util.IdentityMatrix(),
-						(x,y) => Util.MatrixMultiply(Util.MakeFloatMatrix(y.AsMatrix()), x));
+						(x, y) => Util.MatrixMultiply(Util.MakeFloatMatrix(y.AsMatrix()), x));
 					var worldTransform = Util.MatrixMultiply(scaleTransform, rotations);
 					worldTransform = Util.MatrixMultiply(offsetTransform, worldTransform);
 
@@ -209,21 +206,21 @@ namespace OpenRA.Graphics
 
 						// Disable shadow normals by forcing zero diffuse and identity ambient light
 						Render(rd, Util.MatrixMultiply(shadow, t), lightDirection,
-						       shadowAmbient, shadowDiffuse, shadowPalette.Index, normals.Index);
+							ShadowAmbient, ShadowDiffuse, shadowPalette.Index, normals.Index);
 					}
 				}
 			}));
 
-			var screenLightVector = Util.MatrixVectorMultiply(invShadowTransform, zVector);
+			var screenLightVector = Util.MatrixVectorMultiply(invShadowTransform, ZVector);
 			screenLightVector = Util.MatrixVectorMultiply(cameraTransform, screenLightVector);
-			return new VoxelRenderProxy(sprite, shadowSprite, screenCorners, -screenLightVector[2]/screenLightVector[1]);
+			return new VoxelRenderProxy(sprite, shadowSprite, screenCorners, -screenLightVector[2] / screenLightVector[1]);
 		}
 
 		static void CalculateSpriteGeometry(float2 tl, float2 br, float scale, out Size size, out int2 offset)
 		{
-			var width = (int)(scale*(br.X - tl.X));
-			var height = (int)(scale*(br.Y - tl.Y));
-			offset = (0.5f*scale*(br + tl)).ToInt2();
+			var width = (int)(scale * (br.X - tl.X));
+			var height = (int)(scale * (br.Y - tl.Y));
+			offset = (0.5f * scale * (br + tl)).ToInt2();
 
 			// Width and height must be even to avoid rendering glitches
 			if ((width & 1) == 1)
@@ -236,14 +233,14 @@ namespace OpenRA.Graphics
 
 		static float[] ExtractRotationVector(float[] mtx)
 		{
-			var tVec = Util.MatrixVectorMultiply(mtx, zVector);
-			var tOrigin = Util.MatrixVectorMultiply(mtx, zeroVector);
-			tVec[0] -= tOrigin[0]*tVec[3]/tOrigin[3];
-			tVec[1] -= tOrigin[1]*tVec[3]/tOrigin[3];
-			tVec[2] -= tOrigin[2]*tVec[3]/tOrigin[3];
+			var tVec = Util.MatrixVectorMultiply(mtx, ZVector);
+			var tOrigin = Util.MatrixVectorMultiply(mtx, ZeroVector);
+			tVec[0] -= tOrigin[0] * tVec[3] / tOrigin[3];
+			tVec[1] -= tOrigin[1] * tVec[3] / tOrigin[3];
+			tVec[2] -= tOrigin[2] * tVec[3] / tOrigin[3];
 
 			// Renormalize
-			var w = (float)Math.Sqrt(tVec[0]*tVec[0] + tVec[1]*tVec[1] + tVec[2]*tVec[2]);
+			var w = (float)Math.Sqrt(tVec[0] * tVec[0] + tVec[1] * tVec[1] + tVec[2] * tVec[2]);
 			tVec[0] /= w;
 			tVec[1] /= w;
 			tVec[2] /= w;

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	public class WorldRenderer
+	public sealed class WorldRenderer : IDisposable
 	{
 		public readonly World world;
 		public readonly Theater Theater;
@@ -250,6 +250,13 @@ namespace OpenRA.Graphics
 		{
 			var ts = Game.modData.Manifest.TileSize;
 			return new WPos(1024 * screenPx.X / ts.Width, 1024 * screenPx.Y / ts.Height, 0);
+		}
+
+		public void Dispose()
+		{
+			palette.Dispose();
+			Theater.Dispose();
+			terrainRenderer.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -35,18 +35,16 @@ namespace OpenRA.Graphics
 		public readonly Theater Theater;
 		public Viewport Viewport { get; private set; }
 
+		readonly HardwarePalette palette = new HardwarePalette();
+		readonly Dictionary<string, PaletteReference> palettes = new Dictionary<string, PaletteReference>();
 		readonly TerrainRenderer terrainRenderer;
-		readonly HardwarePalette palette;
-		readonly Dictionary<string, PaletteReference> palettes;
 		readonly Lazy<DeveloperMode> devTrait;
 
 		internal WorldRenderer(World world)
 		{
 			this.world = world;
 			Viewport = new Viewport(this, world.Map);
-			palette = new HardwarePalette();
 
-			palettes = new Dictionary<string, PaletteReference>();
 			foreach (var pal in world.traitDict.ActorsWithTrait<ILoadsPalettes>())
 				pal.Trait.LoadPalettes(this);
 

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -21,7 +21,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA
 {
-	public class MapCache : IEnumerable<MapPreview>
+	public sealed class MapCache : IEnumerable<MapPreview>, IDisposable
 	{
 		public static readonly MapPreview UnknownMap = new MapPreview(null, null);
 		readonly Cache<string, MapPreview> previews;
@@ -163,7 +163,13 @@ namespace OpenRA
 				foreach (var p in todo)
 				{
 					// The rendering is thread safe because it only reads from the passed instances and writes to a new bitmap
-					var bitmap = p.CustomPreview ?? Minimap.RenderMapPreview(modData.DefaultRules.TileSets[p.Map.Tileset], p.Map, modData.DefaultRules, true);
+					var createdPreview = false;
+					var bitmap = p.CustomPreview;
+					if (bitmap == null)
+					{
+						createdPreview = true;
+						bitmap = Minimap.RenderMapPreview(modData.DefaultRules.TileSets[p.Map.Tileset], p.Map, modData.DefaultRules, true);
+					}
 					// Note: this is not generally thread-safe, but it works here because:
 					//   (a) This worker is the only thread writing to this sheet
 					//   (b) The main thread is the only thread reading this sheet
@@ -172,7 +178,15 @@ namespace OpenRA
 					//       the next render cycle.
 					//   (d) Any partially written bytes from the next minimap is in an
 					//       unallocated area, and will be committed in the next cycle.
-					p.SetMinimap(sheetBuilder.Add(bitmap));
+					try
+					{
+						p.SetMinimap(sheetBuilder.Add(bitmap));
+					}
+					finally
+					{
+						if (createdPreview)
+							bitmap.Dispose();
+					}
 
 					// Yuck... But this helps the UI Jank when opening the map selector significantly.
 					Thread.Sleep(Environment.ProcessorCount == 1 ? 25 : 5);
@@ -225,6 +239,11 @@ namespace OpenRA
 		IEnumerator IEnumerable.GetEnumerator()
 		{
 			return GetEnumerator();
+		}
+
+		public void Dispose()
+		{
+			sheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA
 {
-	public class ModData
+	public sealed class ModData : IDisposable
 	{
 		public readonly Manifest Manifest;
 		public readonly ObjectCreator ObjectCreator;
@@ -33,14 +33,17 @@ namespace OpenRA
 		Lazy<Ruleset> defaultRules;
 		public Ruleset DefaultRules { get { return defaultRules.Value; } }
 
-		public ModData(string mod)
+		public ModData(string mod, bool useLoadScreen = false)
 		{
 			Languages = new string[0];
 			Manifest = new Manifest(mod);
 			ObjectCreator = new ObjectCreator(Manifest);
-			LoadScreen = ObjectCreator.CreateObject<ILoadScreen>(Manifest.LoadScreen.Value);
-			LoadScreen.Init(Manifest, Manifest.LoadScreen.ToDictionary(my => my.Value));
-			LoadScreen.Display();
+			if (useLoadScreen)
+			{
+				LoadScreen = ObjectCreator.CreateObject<ILoadScreen>(Manifest.LoadScreen.Value);
+				LoadScreen.Init(Manifest, Manifest.LoadScreen.ToDictionary(my => my.Value));
+				LoadScreen.Display();
+			}
 			WidgetLoader = new WidgetLoader(this);
 			RulesetCache = new RulesetCache(this);
 			RulesetCache.LoadingProgress += HandleLoadingProgress;
@@ -82,8 +85,13 @@ namespace OpenRA
 			// horribly when you use ModData in unexpected ways.
 			ChromeMetrics.Initialize(Manifest.ChromeMetrics);
 			ChromeProvider.Initialize(Manifest.Chrome);
+
+			if (VoxelLoader != null)
+				VoxelLoader.Dispose();
 			VoxelLoader = new VoxelLoader();
 
+			if (CursorProvider != null)
+				CursorProvider.Dispose();
 			CursorProvider = new CursorProvider(this);
 		}
 
@@ -130,7 +138,8 @@ namespace OpenRA
 
 		public Map PrepareMap(string uid)
 		{
-			LoadScreen.Display();
+			if (LoadScreen != null)
+				LoadScreen.Display();
 
 			if (MapCache[uid].Status != MapStatus.Available)
 				throw new InvalidDataException("Invalid map uid: {0}".F(uid));
@@ -157,9 +166,21 @@ namespace OpenRA
 
 			return map;
 		}
+
+		public void Dispose()
+		{
+			if (LoadScreen != null)
+				LoadScreen.Dispose();
+			RulesetCache.Dispose();
+			MapCache.Dispose();
+			if (VoxelLoader != null)
+				VoxelLoader.Dispose();
+			if (CursorProvider != null)
+				CursorProvider.Dispose();
+		}
 	}
 
-	public interface ILoadScreen
+	public interface ILoadScreen : IDisposable
 	{
 		void Init(Manifest m, Dictionary<string, string> info);
 		void Display();

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -25,9 +25,9 @@ namespace OpenRA
 		public readonly WidgetLoader WidgetLoader;
 		public readonly MapCache MapCache;
 		public readonly ISpriteLoader[] SpriteLoaders;
-		public ILoadScreen LoadScreen = null;
-		public VoxelLoader VoxelLoader;
 		public readonly RulesetCache RulesetCache;
+		public ILoadScreen LoadScreen { get; private set; }
+		public VoxelLoader VoxelLoader { get; private set; }
 		public CursorProvider CursorProvider { get; private set; }
 
 		Lazy<Ruleset> defaultRules;

--- a/OpenRA.Lint/YamlChecker.cs
+++ b/OpenRA.Lint/YamlChecker.cs
@@ -55,9 +55,7 @@ namespace OpenRA.Lint
 				FieldLoader.UnknownFieldAction = (s, f) => EmitError("FieldLoader: Missing field `{0}` on `{1}`".F(s, f.Name));
 
 				AppDomain.CurrentDomain.AssemblyResolve += GlobalFileSystem.ResolveAssembly;
-				Game.Renderer = new Graphics.Renderer(
-					new GraphicSettings() { Renderer = "Null", NumTempBuffers = 0, SheetSize = 0 },
-					new ServerSettings());
+				Game.InitializeSettings(Arguments.Empty);
 				Game.modData = new ModData(mod);
 
 				IEnumerable<Map> maps;

--- a/OpenRA.Lint/YamlChecker.cs
+++ b/OpenRA.Lint/YamlChecker.cs
@@ -55,6 +55,9 @@ namespace OpenRA.Lint
 				FieldLoader.UnknownFieldAction = (s, f) => EmitError("FieldLoader: Missing field `{0}` on `{1}`".F(s, f.Name));
 
 				AppDomain.CurrentDomain.AssemblyResolve += GlobalFileSystem.ResolveAssembly;
+				Game.Renderer = new Graphics.Renderer(
+					new GraphicSettings() { Renderer = "Null", NumTempBuffers = 0, SheetSize = 0 },
+					new ServerSettings());
 				Game.modData = new ModData(mod);
 
 				IEnumerable<Map> maps;

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -11,8 +11,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
-using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 
@@ -29,7 +27,7 @@ namespace OpenRA.Mods.Cnc
 		Sprite nodLogo, gdiLogo, evaLogo, brightBlock, dimBlock;
 		Rectangle bounds;
 		Renderer r;
-		NullInputHandler nih = new NullInputHandler();
+		readonly NullInputHandler nih = new NullInputHandler();
 
 		public void Init(Manifest m, Dictionary<string, string> info)
 		{

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -18,10 +18,11 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Cnc
 {
-	public class CncLoadScreen : ILoadScreen
+	public sealed class CncLoadScreen : ILoadScreen
 	{
 		Dictionary<string, string> loadInfo;
 		Stopwatch loadTimer = Stopwatch.StartNew();
+		Sheet sheet;
 		Sprite[] ss;
 		int loadTick;
 		float2 nodPos, gdiPos, evaPos;
@@ -39,31 +40,31 @@ namespace OpenRA.Mods.Cnc
 			r = Game.Renderer;
 			if (r == null) return;
 
-			var s = new Sheet(Platform.ResolvePath(loadInfo["Image"]));
+			sheet = new Sheet(Platform.ResolvePath(loadInfo["Image"]));
 			var res = r.Resolution;
 			bounds = new Rectangle(0, 0, res.Width, res.Height);
 
 			ss = new[]
 			{
-				new Sprite(s, new Rectangle(161, 128, 62, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(161, 223, 62, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(128, 161, 33, 62), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(223, 161, 33, 62), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(128, 128, 33, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(223, 128, 33, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(128, 223, 33, 33), TextureChannel.Alpha),
-				new Sprite(s, new Rectangle(223, 223, 33, 33), TextureChannel.Alpha)
+				new Sprite(sheet, new Rectangle(161, 128, 62, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(161, 223, 62, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(128, 161, 33, 62), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(223, 161, 33, 62), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(128, 128, 33, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(223, 128, 33, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(128, 223, 33, 33), TextureChannel.Alpha),
+				new Sprite(sheet, new Rectangle(223, 223, 33, 33), TextureChannel.Alpha)
 			};
 
-			nodLogo = new Sprite(s, new Rectangle(0, 256, 256, 256), TextureChannel.Alpha);
-			gdiLogo = new Sprite(s, new Rectangle(256, 256, 256, 256), TextureChannel.Alpha);
-			evaLogo = new Sprite(s, new Rectangle(256, 64, 128, 64), TextureChannel.Alpha);
+			nodLogo = new Sprite(sheet, new Rectangle(0, 256, 256, 256), TextureChannel.Alpha);
+			gdiLogo = new Sprite(sheet, new Rectangle(256, 256, 256, 256), TextureChannel.Alpha);
+			evaLogo = new Sprite(sheet, new Rectangle(256, 64, 128, 64), TextureChannel.Alpha);
 			nodPos = new float2(bounds.Width / 2 - 384, bounds.Height / 2 - 128);
 			gdiPos = new float2(bounds.Width / 2 + 128, bounds.Height / 2 - 128);
 			evaPos = new float2(bounds.Width - 43 - 128, 43);
 
-			brightBlock = new Sprite(s, new Rectangle(320, 0, 16, 35), TextureChannel.Alpha);
-			dimBlock = new Sprite(s, new Rectangle(336, 0, 16, 35), TextureChannel.Alpha);
+			brightBlock = new Sprite(sheet, new Rectangle(320, 0, 16, 35), TextureChannel.Alpha);
+			dimBlock = new Sprite(sheet, new Rectangle(336, 0, 16, 35), TextureChannel.Alpha);
 
 			versionText = m.Mod.Version;
 		}
@@ -122,6 +123,12 @@ namespace OpenRA.Mods.Cnc
 		public void StartGame()
 		{
 			Game.TestAndContinue();
+		}
+
+		public void Dispose()
+		{
+			if (sheet != null)
+				sheet.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/LoadScreens/DefaultLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/DefaultLoadScreen.cs
@@ -11,8 +11,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
-using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/LoadScreens/DefaultLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/DefaultLoadScreen.cs
@@ -18,13 +18,14 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.LoadScreens
 {
-	public class DefaultLoadScreen : ILoadScreen
+	public sealed class DefaultLoadScreen : ILoadScreen
 	{
 		Stopwatch lastUpdate = Stopwatch.StartNew();
 		Renderer r;
 
 		Rectangle stripeRect;
 		float2 logoPos;
+		Sheet sheet;
 		Sprite stripe, logo;
 		string[] messages;
 
@@ -37,9 +38,9 @@ namespace OpenRA.Mods.Common.LoadScreens
 				return;
 
 			messages = info["Text"].Split(',');
-			var s = new Sheet(Platform.ResolvePath(info["Image"]));
-			logo = new Sprite(s, new Rectangle(0, 0, 256, 256), TextureChannel.Alpha);
-			stripe = new Sprite(s, new Rectangle(256, 0, 256, 256), TextureChannel.Alpha);
+			sheet = new Sheet(Platform.ResolvePath(info["Image"]));
+			logo = new Sprite(sheet, new Rectangle(0, 0, 256, 256), TextureChannel.Alpha);
+			stripe = new Sprite(sheet, new Rectangle(256, 0, 256, 256), TextureChannel.Alpha);
 			stripeRect = new Rectangle(0, r.Resolution.Height / 2 - 128, r.Resolution.Width, 256);
 			logoPos = new float2(r.Resolution.Width / 2 - 128, r.Resolution.Height / 2 - 128);
 		}
@@ -70,6 +71,12 @@ namespace OpenRA.Mods.Common.LoadScreens
 		public void StartGame()
 		{
 			Game.TestAndContinue();
+		}
+
+		public void Dispose()
+		{
+			if (sheet != null)
+				sheet.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/LoadScreens/ModChooserLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModChooserLoadScreen.cs
@@ -15,7 +15,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.LoadScreens
 {
-	public class ModChooserLoadScreen : ILoadScreen
+	public sealed class ModChooserLoadScreen : ILoadScreen
 	{
 		Sprite sprite;
 		Rectangle bounds;
@@ -42,6 +42,12 @@ namespace OpenRA.Mods.Common.LoadScreens
 		public void StartGame()
 		{
 			Ui.LoadWidget("MODCHOOSER", Ui.Root, new WidgetArgs());
+		}
+
+		public void Dispose()
+		{
+			if (sprite != null)
+				sprite.sheet.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/LoadScreens/NullLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/NullLoadScreen.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.LoadScreens
 {
-	public class NullLoadScreen : ILoadScreen
+	public sealed class NullLoadScreen : ILoadScreen
 	{
 		public void Init(Manifest m, Dictionary<string, string> info) { }
 
@@ -30,6 +30,10 @@ namespace OpenRA.Mods.Common.LoadScreens
 		public void StartGame()
 		{
 			Ui.ResetAll();
+		}
+
+		public void Dispose()
+		{
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Widget modList;
 		ButtonWidget modTemplate;
 		ModMetadata[] allMods;
+		readonly SheetBuilder sheetBuilder;
 		ModMetadata selectedMod;
 		string selectedAuthor;
 		string selectedDescription;
@@ -63,7 +64,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return ret;
 			};
 
-			var sheetBuilder = new SheetBuilder(SheetType.BGRA);
+			sheetBuilder = new SheetBuilder(SheetType.BGRA);
 			previews = new Dictionary<string, Sprite>();
 			logos = new Dictionary<string, Sprite>();
 			allMods = ModMetadata.AllMods.Values.Where(m => m.Id != "modchooser")
@@ -75,21 +76,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				try
 				{
-					var preview = new Bitmap(Platform.ResolvePath(".", "mods", mod.Id, "preview.png"));
-					if (preview.Width != 296 || preview.Height != 196)
-						continue;
-
-					previews.Add(mod.Id, sheetBuilder.Add(preview));
+					using (var preview = new Bitmap(Platform.ResolvePath(".", "mods", mod.Id, "preview.png")))
+						if (preview.Width == 296 && preview.Height == 196)
+							previews.Add(mod.Id, sheetBuilder.Add(preview));
 				}
 				catch (Exception) { }
 
 				try
 				{
-					var logo = new Bitmap(Platform.ResolvePath(".", "mods", mod.Id, "logo.png"));
-					if (logo.Width != 96 || logo.Height != 96)
-						continue;
-
-					logos.Add(mod.Id, sheetBuilder.Add(logo));
+					using (var logo = new Bitmap(Platform.ResolvePath(".", "mods", mod.Id, "logo.png")))
+						if (logo.Width == 96 && logo.Height == 96)
+							logos.Add(mod.Id, sheetBuilder.Add(logo));
 				}
 				catch (Exception) { }
 			}
@@ -155,11 +152,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				modOffset = selectedIndex - 4;
 		}
 
-		static void LoadMod(ModMetadata mod)
+		void LoadMod(ModMetadata mod)
 		{
 			Game.RunAfterTick(() =>
 			{
 				Ui.CloseWindow();
+				sheetBuilder.Dispose();
 				Game.InitializeMod(mod.Id, null);
 			});
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -20,16 +20,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ModBrowserLogic
 	{
-		Widget modList;
-		ButtonWidget modTemplate;
-		ModMetadata[] allMods;
+		readonly Widget modList;
+		readonly ButtonWidget modTemplate;
+		readonly ModMetadata[] allMods;
+		readonly Dictionary<string, Sprite> previews = new Dictionary<string, Sprite>();
+		readonly Dictionary<string, Sprite> logos = new Dictionary<string, Sprite>();
 		readonly SheetBuilder sheetBuilder;
 		ModMetadata selectedMod;
 		string selectedAuthor;
 		string selectedDescription;
 		int modOffset = 0;
-		Dictionary<string, Sprite> previews;
-		Dictionary<string, Sprite> logos;
 
 		[ObjectCreator.UseCtor]
 		public ModBrowserLogic(Widget widget)
@@ -65,8 +65,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			sheetBuilder = new SheetBuilder(SheetType.BGRA);
-			previews = new Dictionary<string, Sprite>();
-			logos = new Dictionary<string, Sprite>();
 			allMods = ModMetadata.AllMods.Values.Where(m => m.Id != "modchooser")
 				.OrderBy(m => m.Title)
 				.ToArray();

--- a/OpenRA.Renderer.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Renderer.Null/NullGraphicsDevice.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Renderer.Null
 		public void Render(Action a) { }
 	}
 
-	public class NullTexture : ITexture
+	public sealed class NullTexture : ITexture
 	{
 		public TextureScaleFilter ScaleFilter { get { return TextureScaleFilter.Nearest; } set { } }
 		public void SetData(Bitmap bitmap) { }
@@ -86,18 +86,21 @@ namespace OpenRA.Renderer.Null
 		public void SetData(byte[] colors, int width, int height) { }
 		public byte[] GetData() { return new byte[0]; }
 		public Size Size { get { return new Size(0, 0); } }
+		public void Dispose() { }
 	}
 
-	public class NullFrameBuffer : IFrameBuffer
+	public sealed class NullFrameBuffer : IFrameBuffer
 	{
 		public void Bind() { }
 		public void Unbind() { }
 		public ITexture Texture { get { return new NullTexture(); } }
+		public void Dispose() { }
 	}
 
-	class NullVertexBuffer<T> : IVertexBuffer<T>
+	sealed class NullVertexBuffer<T> : IVertexBuffer<T>
 	{
 		public void Bind() { }
 		public void SetData(T[] vertices, int length) { }
+		public void Dispose() { }
 	}
 }

--- a/OpenRA.Renderer.Sdl2/Texture.cs
+++ b/OpenRA.Renderer.Sdl2/Texture.cs
@@ -130,6 +130,7 @@ namespace OpenRA.Renderer.Sdl2
 				bitmap = new Bitmap(bitmap, bitmap.Size.NextPowerOf2());
 				allocatedBitmap = true;
 			}
+
 			try
 			{
 				size = new Size(bitmap.Width, bitmap.Height);

--- a/OpenRA.Renderer.Sdl2/VertexBuffer.cs
+++ b/OpenRA.Renderer.Sdl2/VertexBuffer.cs
@@ -14,11 +14,12 @@ using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Renderer.Sdl2
 {
-	public class VertexBuffer<T> : IVertexBuffer<T>
+	public sealed class VertexBuffer<T> : IVertexBuffer<T>
 			where T : struct
 	{
 		static readonly int VertexSize = Marshal.SizeOf(typeof(T));
 		int buffer;
+		bool disposed;
 
 		public VertexBuffer(int size)
 		{
@@ -52,7 +53,23 @@ namespace OpenRA.Renderer.Sdl2
 			ErrorHandler.CheckGlError();
 		}
 
-		void FinalizeInner() { GL.DeleteBuffers(1, ref buffer); }
-		~VertexBuffer() { Game.RunAfterTick(FinalizeInner); }
+		~VertexBuffer()
+		{
+			Game.RunAfterTick(() => Dispose(false));
+		}
+
+		public void Dispose()
+		{
+			Game.RunAfterTick(() => Dispose(true));
+			GC.SuppressFinalize(this);
+		}
+
+		void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+			disposed = true;
+			GL.DeleteBuffers(1, ref buffer);
+		}
 	}
 }

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Utility
 				return;
 			}
 
+			Game.InitializeSettings(Arguments.Empty);
 			var modData = new ModData(modName);
 			args = args.Skip(1).ToArray();
 			var actions = new Dictionary<string, Action<ModData, string[]>>();


### PR DESCRIPTION
#5923 is back.

Speculative fix for #5116 by implementing IDisposable on Texture, FrameBuffer and VertexBuffer rather than relying on the finalizer to do the work since the non-determinism of finalization means these resources could be hanging around for an unbounded length of time before being released. I don't have any particular proof that this will fix the out-of-memory issue, it just seems like it could be a possible cause.

To verify, you can stick some console logging in the finalizers for these methods. On bleed you should notice a lot of activity as you load assets (loading, switching mods, choosing maps, starting & ending a game). This PR fixes all but one inconsequential leak as far as I can tell (the leak is the static SheetBuilder in SprintFont, but since the textures are needed forever it hardly matters).
