### PR TITLE
Use INotifyBuildComplete for Production & AnnounceOnBuild

### DIFF
--- a/OpenRA.Mods.RA/AnnounceOnBuild.cs
+++ b/OpenRA.Mods.RA/AnnounceOnBuild.cs
@@ -13,14 +13,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA
 {
 	[Desc("Play the Build voice of this actor when trained.")]
-	public class AnnounceOnBuildInfo : ITraitInfo
-	{
-		public object Create(ActorInitializer init) { return new AnnounceOnBuild(init.self); }
-	}
+	public class AnnounceOnBuildInfo : TraitInfo<AnnounceOnBuild> { }
 
-	public class AnnounceOnBuild
+	public class AnnounceOnBuild : INotifyBuildComplete
 	{
-		public AnnounceOnBuild(Actor self)
+		public void BuildingComplete(Actor self)
 		{
 			Sound.PlayVoice("Build", self, self.Owner.Country.Race);
 		}

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -105,6 +105,9 @@ namespace OpenRA.Mods.RA
 				var bi = newUnit.Info.Traits.GetOrDefault<BuildableInfo>();
 				if (bi != null && bi.InitialActivity != null)
 					newUnit.QueueActivity(Game.CreateObject<Activity>(bi.InitialActivity));
+
+				foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
+					t.BuildingComplete(newUnit);
 			});
 		}
 


### PR DESCRIPTION
Extend using INotifyBuildComplete to Production and have AnnounceOnBuild implement INotifyBuildComplete.

This gives AnnounceOnBuild correct behavior according to its name.
