### PR TITLE
Add groundwork for heightmapped terrain.

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Graphics
 					{
 						var mapX = x + b.Left;
 						var mapY = y + b.Top;
-						var type = tileset.GetTerrainInfo(mapTiles[mapX, mapY]);
+						var type = tileset[tileset.GetTerrainIndex(mapTiles[mapX, mapY])];
 						colors[y * stride + x] = type.Color.ToArgb();
 					}
 				}

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Graphics
 			foreach (var cell in map.Cells)
 			{
 				var tile = wr.Theater.TileSprite(map.MapTiles.Value[cell]);
-				var pos = wr.ScreenPosition(map.CenterOfCell(cell)) - 0.5f * tile.size;
+				var pos = wr.ScreenPosition(map.CenterOfCell(cell)) + tile.offset - 0.5f * tile.size;
 				Util.FastCreateQuad(vertices, pos, tile, terrainPalette, nv, tile.size);
 				nv += 4;
 			}

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -42,7 +42,13 @@ namespace OpenRA.Graphics
 			{
 				var allFrames = frameCache[t.Value.Image];
 				var frames = t.Value.Frames != null ? t.Value.Frames.Select(f => allFrames[f]).ToArray() : allFrames;
-				templates.Add(t.Value.Id, frames.Select(f => sheetBuilder.Add(f)).ToArray());
+				var sprites = frames.Select(f => sheetBuilder.Add(f));
+
+				// Ignore the offsets baked into R8 sprites
+				if (tileset.IgnoreTileSpriteOffsets)
+					sprites = sprites.Select(s => new Sprite(s.sheet, s.bounds, float2.Zero, s.channel, s.blendMode));
+
+				templates.Add(t.Value.Id, sprites.ToArray());
 			}
 
 			// 1x1px transparent tile

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -21,9 +21,11 @@ namespace OpenRA.Graphics
 		SheetBuilder sheetBuilder;
 		Dictionary<ushort, Sprite[]> templates;
 		Sprite missingTile;
+		TileSet tileset;
 
 		public Theater(TileSet tileset)
 		{
+			this.tileset = tileset;
 			var allocated = false;
 			Func<Sheet> allocate = () =>
 			{
@@ -67,6 +69,35 @@ namespace OpenRA.Graphics
 				return missingTile;
 
 			return template[r.Index];
+		}
+
+		public Rectangle TemplateBounds(TerrainTemplateInfo template, Size tileSize, TileShape tileShape)
+		{
+			Rectangle? templateRect = null;
+
+			var i = 0;
+			for (var y = 0; y < template.Size.Y; y++)
+			{
+				for (var x = 0; x < template.Size.X; x++)
+				{
+					var tile = new TerrainTile(template.Id, (byte)(i++));
+					var tileInfo = tileset.GetTileInfo(tile);
+
+					// Empty tile
+					if (tileInfo == null)
+						continue;
+
+					var sprite = TileSprite(tile);
+					var u = tileShape == TileShape.Rectangle ? x : (x - y) / 2f;
+					var v = tileShape == TileShape.Rectangle ? y : (x + y) / 2f;
+
+					var tl = new float2(u * tileSize.Width, (v - 0.5f * tileInfo.Height) * tileSize.Height) - 0.5f * sprite.size;
+					var rect = new Rectangle((int)(tl.X + sprite.offset.X), (int)(tl.Y + sprite.offset.Y), (int)sprite.size.X, (int)sprite.size.Y);
+					templateRect = templateRect.HasValue ? Rectangle.Union(templateRect.Value, rect) : rect;
+				}
+			}
+
+			return templateRect.HasValue ? templateRect.Value : Rectangle.Empty;
 		}
 
 		public Sheet Sheet { get { return sheetBuilder.Current; } }

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -44,6 +44,8 @@ namespace OpenRA
 
 	public class TileTemplate
 	{
+		static readonly string[] Fields = { "Id", "Image", "Frames", "Size", "PickAny", "Category" };
+
 		public readonly ushort Id;
 		public readonly string Image;
 		public readonly int[] Frames;
@@ -113,8 +115,6 @@ namespace OpenRA
 			return tile;
 		}
 
-		static readonly string[] Fields = { "Id", "Image", "Frames", "Size", "PickAny" };
-
 		public TerrainTileInfo this[int index] { get { return tileInfo[index]; } }
 
 		public bool Contains(int index)
@@ -148,6 +148,8 @@ namespace OpenRA
 
 	public class TileSet
 	{
+		static readonly string[] Fields = { "Name", "Id", "SheetSize", "Palette", "PlayerPalette", "Extensions", "WaterPaletteRotationBase", "EditorTemplateOrder" };
+
 		public readonly string Name;
 		public readonly string Id;
 		public readonly int SheetSize = 512;
@@ -162,8 +164,6 @@ namespace OpenRA
 		readonly Dictionary<string, byte> terrainIndexByType = new Dictionary<string, byte>();
 		readonly byte defaultWalkableTerrainIndex;
 
-		static readonly string[] Fields = { "Name", "Id", "SheetSize", "Palette", "Extensions" };
-
 		public TileSet(ModData modData, string filepath)
 		{
 			var yaml = MiniYaml.DictFromFile(filepath);
@@ -176,8 +176,10 @@ namespace OpenRA
 				.Select(y => new TerrainTypeInfo(y))
 				.OrderBy(tt => tt.Type)
 				.ToArray();
+
 			if (TerrainInfo.Length >= byte.MaxValue)
 				throw new InvalidDataException("Too many terrain types.");
+
 			for (byte i = 0; i < TerrainInfo.Length; i++)
 			{
 				var tt = TerrainInfo[i].Type;
@@ -197,33 +199,30 @@ namespace OpenRA
 
 		public TileSet(string name, string id, string palette, string[] extensions, TerrainTypeInfo[] terrainInfo)
 		{
-			this.Name = name;
-			this.Id = id;
-			this.Palette = palette;
-			this.Extensions = extensions;
-			this.TerrainInfo = terrainInfo;
+			Name = name;
+			Id = id;
+			Palette = palette;
+			Extensions = extensions;
+			TerrainInfo = terrainInfo;
+
 			if (TerrainInfo.Length >= byte.MaxValue)
 				throw new InvalidDataException("Too many terrain types.");
+
 			for (byte i = 0; i < terrainInfo.Length; i++)
 			{
 				var tt = terrainInfo[i].Type;
-
 				if (terrainIndexByType.ContainsKey(tt))
 					throw new InvalidDataException("Duplicate terrain type '{0}'.".F(tt));
 
 				terrainIndexByType.Add(tt, i);
 			}
+
 			defaultWalkableTerrainIndex = GetTerrainIndex("Clear");
 		}
 
 		public TerrainTypeInfo this[byte index]
 		{
 			get { return TerrainInfo[index]; }
-		}
-
-		public int TerrainsCount
-		{
-			get { return TerrainInfo.Length; }
 		}
 
 		public bool TryGetTerrainIndex(string type, out byte index)
@@ -282,11 +281,6 @@ namespace OpenRA
 			root.Add(new MiniYamlNode("Templates", null,
 				Templates.Select(t => new MiniYamlNode("Template@{0}".F(t.Value.Id), t.Value.Save(this))).ToList()));
 			root.WriteToFile(filepath);
-		}
-
-		public TerrainTypeInfo GetTerrainInfo(TerrainTile r)
-		{
-			return this[GetTerrainIndex(r)];
 		}
 	}
 }

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -148,7 +148,7 @@ namespace OpenRA
 
 	public class TileSet
 	{
-		static readonly string[] Fields = { "Name", "Id", "SheetSize", "Palette", "PlayerPalette", "Extensions", "WaterPaletteRotationBase", "EditorTemplateOrder" };
+		static readonly string[] Fields = { "Name", "Id", "SheetSize", "Palette", "PlayerPalette", "Extensions", "WaterPaletteRotationBase", "EditorTemplateOrder", "IgnoreTileSpriteOffsets" };
 
 		public readonly string Name;
 		public readonly string Id;
@@ -159,6 +159,7 @@ namespace OpenRA
 		public readonly int WaterPaletteRotationBase = 0x60; 
 		public readonly Dictionary<ushort, TerrainTemplateInfo> Templates = new Dictionary<ushort, TerrainTemplateInfo>();
 		public readonly string[] EditorTemplateOrder;
+		public readonly bool IgnoreTileSpriteOffsets;
 
 		public readonly TerrainTypeInfo[] TerrainInfo;
 		readonly Dictionary<string, byte> terrainIndexByType = new Dictionary<string, byte>();

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -42,7 +42,7 @@ namespace OpenRA
 		public MiniYaml Save() { return FieldSaver.Save(this); }
 	}
 
-	public class TileTemplate
+	public class TerrainTemplateInfo
 	{
 		static readonly string[] Fields = { "Id", "Image", "Frames", "Size", "PickAny", "Category" };
 
@@ -55,14 +55,14 @@ namespace OpenRA
 
 		TerrainTileInfo[] tileInfo;
 
-		public TileTemplate(ushort id, string image, int2 size, byte[] tiles)
+		public TerrainTemplateInfo(ushort id, string image, int2 size, byte[] tiles)
 		{
 			this.Id = id;
 			this.Image = image;
 			this.Size = size;
 		}
 
-		public TileTemplate(TileSet tileSet, MiniYaml my)
+		public TerrainTemplateInfo(TileSet tileSet, MiniYaml my)
 		{
 			FieldLoader.Load(this, my);
 
@@ -157,7 +157,7 @@ namespace OpenRA
 		public readonly string PlayerPalette;
 		public readonly string[] Extensions;
 		public readonly int WaterPaletteRotationBase = 0x60; 
-		public readonly Dictionary<ushort, TileTemplate> Templates = new Dictionary<ushort, TileTemplate>();
+		public readonly Dictionary<ushort, TerrainTemplateInfo> Templates = new Dictionary<ushort, TerrainTemplateInfo>();
 		public readonly string[] EditorTemplateOrder;
 
 		public readonly TerrainTypeInfo[] TerrainInfo;
@@ -194,7 +194,7 @@ namespace OpenRA
 
 			// Templates
 			Templates = yaml["Templates"].ToDictionary().Values
-				.Select(y => new TileTemplate(this, y)).ToDictionary(t => t.Id);
+				.Select(y => new TerrainTemplateInfo(this, y)).ToDictionary(t => t.Id);
 		}
 
 		public TileSet(string name, string id, string palette, string[] extensions, TerrainTypeInfo[] terrainInfo)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -129,6 +129,7 @@
     <Compile Include="SpriteLoaders\TmpTDLoader.cs" />
     <Compile Include="SpriteLoaders\ShpD2Loader.cs" />
     <Compile Include="Widgets\Logic\SettingsLogic.cs" />
+    <Compile Include="Widgets\TerrainTemplatePreviewWidget.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -1,0 +1,103 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Linq;
+using OpenRA.FileFormats;
+using OpenRA.Graphics;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public class TerrainTemplatePreviewWidget : Widget
+	{
+		public Func<float> GetScale = () => 1f;
+		public string Palette = "terrain";
+
+		readonly WorldRenderer worldRenderer;
+		readonly TileSet tileset;
+
+		TerrainTemplateInfo template;
+		Rectangle bounds;
+
+		public TerrainTemplateInfo Template
+		{
+			get
+			{
+				return template;
+			}
+
+			set
+			{
+				template = value;
+				if (template == null)
+					return;
+
+				var ts = Game.modData.Manifest.TileSize;
+				var shape = Game.modData.Manifest.TileShape;
+				bounds = worldRenderer.Theater.TemplateBounds(template, ts, shape);
+			}
+		}
+
+		[ObjectCreator.UseCtor]
+		public TerrainTemplatePreviewWidget(WorldRenderer worldRenderer, World world)
+		{
+			this.worldRenderer = worldRenderer;
+			tileset = world.Map.Rules.TileSets[world.Map.Tileset];
+		}
+
+		protected TerrainTemplatePreviewWidget(TerrainTemplatePreviewWidget other)
+			: base(other)
+		{
+			worldRenderer = other.worldRenderer;
+			tileset = other.worldRenderer.world.Map.Rules.TileSets[other.worldRenderer.world.Map.Tileset];
+			Template = other.Template;
+			GetScale = other.GetScale;
+		}
+
+		public override Widget Clone() { return new TerrainTemplatePreviewWidget(this); }
+
+		public override void Draw()
+		{
+			if (template == null)
+				return;
+
+			var ts = Game.modData.Manifest.TileSize;
+			var shape = Game.modData.Manifest.TileShape;
+			var scale = GetScale();
+
+			var sb = new Rectangle((int)(scale * bounds.X), (int)(scale * bounds.Y), (int)(scale * bounds.Width), (int)(scale * bounds.Height));
+			var origin = RenderOrigin + new int2((RenderBounds.Size.Width - sb.Width) / 2 - sb.X, (RenderBounds.Size.Height - sb.Height) / 2 - sb.Y);
+
+			var i = 0;
+			for (var y = 0; y < Template.Size.Y; y++)
+			{
+				for (var x = 0; x < Template.Size.X; x++)
+				{
+					var tile = new TerrainTile(Template.Id, (byte)(i++));
+					var tileInfo = tileset.GetTileInfo(tile);
+
+					// Empty tile
+					if (tileInfo == null)
+						continue;
+
+					var sprite = worldRenderer.Theater.TileSprite(tile);
+					var size = new float2(sprite.size.X * scale, sprite.size.Y * scale);
+
+					var u = shape == TileShape.Rectangle ? x : (x - y) / 2f;
+					var v = shape == TileShape.Rectangle ? y : (x + y) / 2f;
+					var pos = origin + scale * (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.size);
+					Game.Renderer.SpriteRenderer.DrawSprite(sprite, pos, worldRenderer.Palette(Palette), size);
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.RA/Buildings/LaysTerrain.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Buildings
 		readonly LaysTerrainInfo info;
 		readonly BuildableTerrainLayer layer;
 		readonly BuildingInfluence bi;
-		readonly TileTemplate template;
+		readonly TerrainTemplateInfo template;
 
 		public LaysTerrain(Actor self, LaysTerrainInfo info)
 		{

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.RA.Move
 
 		TerrainInfo[] LoadTilesetSpeeds(TileSet tileSet)
 		{
-			var info = new TerrainInfo[tileSet.TerrainsCount];
+			var info = new TerrainInfo[tileSet.TerrainInfo.Length];
 			for (var i = 0; i < info.Length; i++)
 				info[i] = TerrainInfo.Impassable;
 

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -91,19 +91,22 @@ namespace OpenRA.Mods.TS.UtilityCommands
 									continue;
 
 								s.Position = offsets[j] + 40;
-								/* var height = */s.ReadUInt8();
+								var height = s.ReadUInt8();
 								var terrainType = s.ReadUInt8();
-								/* var rampType = */s.ReadUInt8();
-								/* var height = */s.ReadUInt8();
+								var rampType = s.ReadUInt8();
+
 								if (!terrainTypes.ContainsKey(terrainType))
 									throw new InvalidDataException("Unknown terrain type {0} in {1}".F(terrainType, templateFilename));
 
 								Console.WriteLine("\t\t\t{0}: {1}", j, terrainTypes[terrainType]);
-								// Console.WriteLine("\t\t\t\tHeight: {0}", height);
-								// Console.WriteLine("\t\t\t\tTerrainType: {0}", terrainType);
-								// Console.WriteLine("\t\t\t\tRampType: {0}", rampType);
-								// Console.WriteLine("\t\t\t\tLeftColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
-								// Console.WriteLine("\t\t\t\tRightColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
+								if (height != 0)
+									Console.WriteLine("\t\t\t\tHeight: {0}", height);
+
+								if (rampType != 0)
+									Console.WriteLine("\t\t\t\tRampType: {0}", rampType);
+
+								Console.WriteLine("\t\t\t\tMinimapLeftColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
+								Console.WriteLine("\t\t\t\tMinimapRightColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
 							}
 						}
 					}

--- a/OpenRA.TilesetBuilder/FormBuilder.cs
+++ b/OpenRA.TilesetBuilder/FormBuilder.cs
@@ -393,7 +393,7 @@ namespace OpenRA.TilesetBuilder
 					tiles[idx] = tileset.GetTerrainIndex(ttype);
 				}
 
-				var template = new TileTemplate(
+				var template = new TerrainTemplateInfo(
 					id: cur,
 					image: "{0}{1:00}".F(txtTilesetName.Text, cur),
 					size: new int2(tp.Width, tp.Height),

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -5,6 +5,7 @@ General:
 	Palette: d2k.pal
 	Extensions: .R8, .r8, .shp, .tmp
 	EditorTemplateOrder: Basic, Dune, Sand-Detail, Brick, Sand-Cliff, Sand-Smooth, Cliff-Type-Changer, Rock-Sand-Smooth, Rock-Detail, Rock-Cliff, Rock-Cliff-Rock, Rotten-Base, Dead-Worm, Ice, Ice-Detail, Rock-Cliff-Sand, Sand-Platform, Unidentified
+	IgnoreTileSpriteOffsets: true
 
 Terrain:
 	TerrainType@Clear: # TODO: workaround for the stupid WinForms editor

--- a/mods/ts/tilesets/temperat.yaml
+++ b/mods/ts/tilesets/temperat.yaml
@@ -60,6 +60,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 109,87,61
+				RightColor: 111,89,62
 	Template@1:
 		Category: Misc Buildings
 		Id: 1
@@ -67,6 +69,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 122,126,139
+				RightColor: 97,102,109
 	Template@2:
 		Category: Misc Buildings
 		Id: 2
@@ -74,9 +78,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Rough
+				LeftColor: 128,130,133
+				RightColor: 122,126,134
 			1: Rough
+				LeftColor: 110,113,118
+				RightColor: 131,135,154
 			2: Rough
+				LeftColor: 156,158,177
+				RightColor: 115,119,126
 			3: Rough
+				LeftColor: 146,151,173
+				RightColor: 145,149,172
 	Template@3:
 		Category: Misc Buildings
 		Id: 3
@@ -84,14 +96,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 103,110,118
+				RightColor: 112,118,124
 			1: Cliff
+				LeftColor: 80,84,88
+				RightColor: 95,99,109
 			2: Rough
+				LeftColor: 190,192,236
+				RightColor: 206,207,246
 			3: Cliff
+				LeftColor: 120,123,130
+				RightColor: 121,126,132
 			4: Cliff
+				LeftColor: 109,112,117
+				RightColor: 87,90,102
 			5: Rough
+				LeftColor: 199,200,246
+				RightColor: 198,200,248
 			6: Rough
+				LeftColor: 203,204,247
+				RightColor: 196,198,230
 			7: Rough
+				LeftColor: 194,196,230
+				RightColor: 173,176,206
 			8: Rough
+				LeftColor: 196,198,240
+				RightColor: 194,196,246
 	Template@4:
 		Category: Clear
 		Id: 4
@@ -99,6 +129,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 199,201,250
+				RightColor: 195,197,250
 	Template@5:
 		Category: Clear
 		Id: 5
@@ -106,6 +138,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 203,204,247
+				RightColor: 207,208,245
 	Template@6:
 		Category: Clear
 		Id: 6
@@ -113,6 +147,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 200,202,249
+				RightColor: 203,204,247
 	Template@7:
 		Category: Clear
 		Id: 7
@@ -120,6 +156,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 207,208,246
+				RightColor: 209,210,245
 	Template@8:
 		Category: Cliff Pieces
 		Id: 8
@@ -127,6 +165,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 207,208,246
+				RightColor: 209,210,245
 	Template@9:
 		Category: Cliff Pieces
 		Id: 9
@@ -134,6 +174,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 207,208,246
+				RightColor: 209,210,245
 	Template@10:
 		Category: Ice Flow
 		Id: 10
@@ -141,41 +183,113 @@ Templates:
 		Size: 9, 7
 		Tiles:
 			2: Rough
+				LeftColor: 129,130,141
+				RightColor: 165,166,190
 			3: Rough
+				LeftColor: 135,136,147
+				RightColor: 179,180,205
 			11: Rough
+				LeftColor: 151,152,170
+				RightColor: 143,145,158
 			12: Rough
+				LeftColor: 184,185,203
+				RightColor: 160,161,182
 			13: Rough
+				LeftColor: 164,164,184
+				RightColor: 175,176,206
 			18: Rough
+				LeftColor: 201,202,231
+				RightColor: 195,196,221
 			19: Rough
+				LeftColor: 115,117,130
+				RightColor: 163,164,187
 			20: Rough
+				LeftColor: 179,180,202
+				RightColor: 149,150,165
 			21: Rough
+				LeftColor: 167,168,192
+				RightColor: 133,134,153
 			22: Rough
+				LeftColor: 166,167,189
+				RightColor: 180,181,207
 			23: Rough
+				LeftColor: 176,177,203
+				RightColor: 196,197,228
 			24: Rough
+				LeftColor: 153,154,170
+				RightColor: 191,192,221
 			25: Rough
+				LeftColor: 150,151,168
+				RightColor: 193,195,243
 			26: Rough
+				LeftColor: 167,168,193
+				RightColor: 195,196,230
 			28: Rough
+				LeftColor: 191,193,227
+				RightColor: 145,146,164
 			29: Rough
+				LeftColor: 180,181,206
+				RightColor: 170,170,196
 			30: Rough
+				LeftColor: 130,131,143
+				RightColor: 150,151,162
 			31: Rough
+				LeftColor: 175,176,195
+				RightColor: 178,178,200
 			32: Rough
+				LeftColor: 189,189,210
+				RightColor: 179,179,205
 			33: Rough
+				LeftColor: 160,161,178
+				RightColor: 164,164,182
 			34: Rough
+				LeftColor: 169,170,193
+				RightColor: 150,150,169
 			35: Rough
+				LeftColor: 157,158,176
+				RightColor: 187,188,214
 			38: Rough
+				LeftColor: 154,155,176
+				RightColor: 166,166,185
 			39: Rough
+				LeftColor: 166,167,194
+				RightColor: 157,158,177
 			40: Rough
+				LeftColor: 161,161,181
+				RightColor: 175,175,197
 			41: Rough
+				LeftColor: 163,164,182
+				RightColor: 191,192,211
 			42: Rough
+				LeftColor: 192,193,226
+				RightColor: 203,204,243
 			43: Rough
+				LeftColor: 201,202,234
+				RightColor: 190,191,229
 			44: Rough
+				LeftColor: 166,168,198
+				RightColor: 184,185,208
 			49: Rough
+				LeftColor: 177,179,206
+				RightColor: 173,174,203
 			50: Rough
+				LeftColor: 187,187,211
+				RightColor: 168,169,186
 			51: Rough
+				LeftColor: 157,158,177
+				RightColor: 166,167,183
 			52: Rough
+				LeftColor: 167,167,181
+				RightColor: 172,173,189
 			53: Rough
+				LeftColor: 179,180,209
+				RightColor: 157,158,174
 			60: Rough
+				LeftColor: 193,194,228
+				RightColor: 161,162,181
 			61: Rough
+				LeftColor: 163,165,196
+				RightColor: 169,170,196
 	Template@11:
 		Category: House
 		Id: 11
@@ -183,9 +297,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 141,128,106
+				RightColor: 115,108,97
 			1: Cliff
+				LeftColor: 159,160,165
+				RightColor: 126,122,123
 			2: Cliff
+				LeftColor: 185,182,184
+				RightColor: 150,140,123
 			3: Cliff
+				LeftColor: 188,184,182
+				RightColor: 159,159,164
 	Template@12:
 		Category: Blank
 		Id: 12
@@ -193,6 +315,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 40,40,40
+				RightColor: 40,40,40
 	Template@40:
 		Category: Ice Ramps
 		Id: 40
@@ -200,6 +324,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 1
+				LeftColor: 116,96,70
+				RightColor: 111,93,68
 	Template@41:
 		Category: Ice Ramps
 		Id: 41
@@ -207,6 +334,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 2
+				LeftColor: 75,68,57
+				RightColor: 68,63,52
 	Template@42:
 		Category: Ice Ramps
 		Id: 42
@@ -214,6 +344,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 3
+				LeftColor: 88,77,62
+				RightColor: 88,77,62
 	Template@43:
 		Category: Ice Ramps
 		Id: 43
@@ -221,6 +354,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 4
+				LeftColor: 96,82,63
+				RightColor: 93,78,58
 	Template@44:
 		Category: Ice Ramps
 		Id: 44
@@ -228,6 +364,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 5
+				LeftColor: 113,93,68
+				RightColor: 71,63,51
 	Template@45:
 		Category: Ice Ramps
 		Id: 45
@@ -235,6 +374,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 6
+				LeftColor: 67,61,51
+				RightColor: 91,77,59
 	Template@46:
 		Category: Ice Ramps
 		Id: 46
@@ -242,6 +384,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 7
+				LeftColor: 101,86,67
+				RightColor: 91,78,61
 	Template@47:
 		Category: Ice Ramps
 		Id: 47
@@ -249,6 +394,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 8
+				LeftColor: 105,87,64
+				RightColor: 108,89,66
 	Template@48:
 		Category: Ice Ramps
 		Id: 48
@@ -256,6 +404,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 9
+				LeftColor: 101,86,65
+				RightColor: 101,87,69
 	Template@49:
 		Category: Ice Ramps
 		Id: 49
@@ -263,6 +414,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 10
+				LeftColor: 99,83,63
+				RightColor: 66,60,50
 	Template@50:
 		Category: Ice Ramps
 		Id: 50
@@ -270,6 +424,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 11
+				LeftColor: 93,79,60
+				RightColor: 95,80,60
 	Template@51:
 		Category: Ice Ramps
 		Id: 51
@@ -277,6 +434,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 12
+				LeftColor: 117,97,71
+				RightColor: 112,92,67
 	Template@52:
 		Category: Ice Ramps
 		Id: 52
@@ -284,6 +444,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 13
+				LeftColor: 88,72,56
+				RightColor: 88,72,56
 	Template@53:
 		Category: Ice Ramps
 		Id: 53
@@ -291,6 +454,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 14
+				LeftColor: 68,61,49
+				RightColor: 70,62,50
 	Template@54:
 		Category: Ice Ramps
 		Id: 54
@@ -298,6 +464,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 15
+				LeftColor: 100,85,64
+				RightColor: 89,75,55
 	Template@55:
 		Category: Ice Ramps
 		Id: 55
@@ -305,6 +474,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 16
+				LeftColor: 124,99,68
+				RightColor: 126,101,72
 	Template@56:
 		Category: Ice Ramps
 		Id: 56
@@ -312,6 +484,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				RampType: 17
+				LeftColor: 70,62,50
+				RightColor: 121,97,69
 	Template@57:
 		Category: Ice Ramps
 		Id: 57
@@ -319,6 +494,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				RampType: 18
+				LeftColor: 117,95,66
+				RightColor: 68,61,50
 	Template@58:
 		Category: Ice Ramps
 		Id: 58
@@ -326,6 +504,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				RampType: 19
+				LeftColor: 119,119,88
+				RightColor: 128,79,82
 	Template@59:
 		Category: Ice Ramps
 		Id: 59
@@ -333,6 +514,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				RampType: 20
+				LeftColor: 155,104,118
+				RightColor: 107,86,67
 	Template@60:
 		Category: Cliff Set
 		Id: 60
@@ -340,9 +524,19 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 63,59,52
+				RightColor: 80,69,55
 			2: Cliff
+				LeftColor: 81,70,56
+				RightColor: 65,61,54
 			3: Cliff
+				Height: 4
+				LeftColor: 45,43,39
+				RightColor: 65,60,53
 			5: Cliff
+				LeftColor: 103,83,59
+				RightColor: 72,62,48
 	Template@61:
 		Category: Cliff Set
 		Id: 61
@@ -350,7 +544,12 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 60,56,49
+				RightColor: 73,65,52
 			1: Cliff
+				LeftColor: 97,91,81
+				RightColor: 71,66,59
 	Template@62:
 		Category: Cliff Set
 		Id: 62
@@ -358,9 +557,19 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 67,61,52
+				RightColor: 72,62,50
 			2: Cliff
+				LeftColor: 95,81,62
+				RightColor: 63,59,52
 			3: Cliff
+				Height: 4
+				LeftColor: 45,44,40
+				RightColor: 55,50,43
 			5: Cliff
+				LeftColor: 104,89,69
+				RightColor: 74,65,52
 	Template@63:
 		Category: Cliff Set
 		Id: 63
@@ -368,9 +577,19 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 82,70,55
+				RightColor: 89,75,56
 			2: Cliff
+				LeftColor: 91,80,63
+				RightColor: 79,74,65
 			3: Cliff
+				Height: 4
+				LeftColor: 73,70,63
+				RightColor: 73,67,56
 			5: Cliff
+				LeftColor: 105,90,69
+				RightColor: 87,77,63
 	Template@64:
 		Category: Cliff Set
 		Id: 64
@@ -378,9 +597,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 77,70,58
+				RightColor: 76,66,52
 			1: Cliff
+				Height: 4
+				LeftColor: 74,66,53
+				RightColor: 79,68,54
 			2: Cliff
+				LeftColor: 105,91,73
+				RightColor: 72,67,57
 			3: Cliff
+				LeftColor: 91,79,62
+				RightColor: 83,76,64
 	Template@65:
 		Category: Cliff Set
 		Id: 65
@@ -388,9 +617,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 43,40,36
+				RightColor: 78,68,55
 			1: Cliff
+				Height: 4
+				LeftColor: 53,48,40
+				RightColor: 71,63,52
 			2: Cliff
+				LeftColor: 109,91,67
+				RightColor: 81,72,60
 			3: Cliff
+				LeftColor: 84,71,55
+				RightColor: 74,64,52
 	Template@66:
 		Category: Cliff Set
 		Id: 66
@@ -398,9 +637,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 74,67,56
+				RightColor: 79,68,54
 			1: Cliff
+				Height: 4
+				LeftColor: 72,65,54
+				RightColor: 77,66,51
 			2: Cliff
+				LeftColor: 97,84,67
+				RightColor: 71,68,61
 			3: Cliff
+				LeftColor: 90,77,60
+				RightColor: 78,71,61
 	Template@67:
 		Category: Cliff Set
 		Id: 67
@@ -408,7 +657,12 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 57,53,46
+				RightColor: 69,59,45
 			1: Cliff
+				LeftColor: 90,83,70
+				RightColor: 71,67,60
 	Template@68:
 		Category: Cliff Set
 		Id: 68
@@ -416,8 +670,15 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 73,64,52
+				RightColor: 78,68,54
 			1: Cliff
+				LeftColor: 90,79,63
+				RightColor: 82,76,66
 			2: Cliff
+				LeftColor: 84,76,63
+				RightColor: 78,71,60
 	Template@69:
 		Category: Cliff Set
 		Id: 69
@@ -425,8 +686,15 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 78,68,55
+				RightColor: 81,68,52
 			1: Cliff
+				LeftColor: 79,70,57
+				RightColor: 81,73,61
 			2: Cliff
+				LeftColor: 70,64,53
+				RightColor: 85,78,66
 	Template@70:
 		Category: Cliff Set
 		Id: 70
@@ -434,8 +702,15 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,67,52
+				RightColor: 73,65,53
 			1: Cliff
+				LeftColor: 86,77,63
+				RightColor: 72,68,59
 			2: Cliff
+				LeftColor: 85,80,70
+				RightColor: 94,86,74
 	Template@71:
 		Category: Cliff Set
 		Id: 71
@@ -443,6 +718,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 82,77,67
+				RightColor: 83,77,66
 	Template@72:
 		Category: Cliff Set
 		Id: 72
@@ -450,6 +727,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 68,63,55
+				RightColor: 82,75,63
 	Template@73:
 		Category: Cliff Set
 		Id: 73
@@ -457,6 +736,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 84,78,67
+				RightColor: 61,56,48
 	Template@74:
 		Category: Cliff Set
 		Id: 74
@@ -464,9 +745,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 69,60,48
+				RightColor: 66,57,45
 			1: Cliff
+				LeftColor: 75,65,53
+				RightColor: 62,57,49
 			2: Cliff
+				Height: 4
+				LeftColor: 77,67,52
+				RightColor: 64,58,49
 			3: Cliff
+				LeftColor: 92,79,63
+				RightColor: 61,57,49
 	Template@75:
 		Category: Cliff Set
 		Id: 75
@@ -474,9 +765,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 75,64,50
+				RightColor: 65,58,49
 			1: Cliff
+				LeftColor: 69,60,49
+				RightColor: 57,52,45
 			2: Cliff
+				Height: 4
+				LeftColor: 69,59,47
+				RightColor: 68,61,52
 			3: Cliff
+				LeftColor: 88,76,60
+				RightColor: 69,64,56
 	Template@76:
 		Category: Cliff Set
 		Id: 76
@@ -484,9 +785,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 68,60,48
+				RightColor: 69,60,48
 			1: Cliff
+				LeftColor: 54,50,44
+				RightColor: 58,55,49
 			2: Cliff
+				Height: 4
+				LeftColor: 79,66,49
+				RightColor: 68,61,52
 			3: Cliff
+				LeftColor: 75,67,56
+				RightColor: 63,60,55
 	Template@77:
 		Category: Cliff Set
 		Id: 77
@@ -494,7 +805,12 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 74,63,47
+				RightColor: 74,67,56
 			1: Cliff
+				LeftColor: 72,65,55
+				RightColor: 62,58,52
 	Template@78:
 		Category: Cliff Set
 		Id: 78
@@ -502,9 +818,19 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 75,64,49
+				RightColor: 64,60,51
 			1: Cliff
+				LeftColor: 50,50,48
+				RightColor: 70,65,58
 			4: Cliff
+				Height: 4
+				LeftColor: 74,66,54
+				RightColor: 43,42,39
 			5: Cliff
+				LeftColor: 94,84,70
+				RightColor: 78,69,56
 	Template@79:
 		Category: Cliff Set
 		Id: 79
@@ -512,9 +838,19 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 81,70,55
+				RightColor: 74,65,52
 			1: Cliff
+				LeftColor: 45,44,41
+				RightColor: 66,62,54
 			4: Cliff
+				Height: 4
+				LeftColor: 77,65,50
+				RightColor: 48,46,43
 			5: Cliff
+				LeftColor: 90,79,65
+				RightColor: 72,63,51
 	Template@80:
 		Category: Cliff Set
 		Id: 80
@@ -522,9 +858,19 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 66,57,44
+				RightColor: 59,54,46
 			1: Cliff
+				LeftColor: 42,40,38
+				RightColor: 55,52,46
 			4: Cliff
+				Height: 4
+				LeftColor: 72,64,52
+				RightColor: 42,41,38
 			5: Cliff
+				LeftColor: 87,78,65
+				RightColor: 74,66,55
 	Template@81:
 		Category: Cliff Set
 		Id: 81
@@ -532,7 +878,12 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 63,56,46
+				RightColor: 67,60,51
 			1: Cliff
+				LeftColor: 66,57,44
+				RightColor: 56,53,48
 	Template@82:
 		Category: Cliff Set
 		Id: 82
@@ -540,7 +891,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 80,67,50
+				RightColor: 73,64,51
 			1: Cliff
+				Height: 4
+				LeftColor: 74,63,49
+				RightColor: 61,56,48
 	Template@83:
 		Category: Cliff Set
 		Id: 83
@@ -548,7 +905,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,67,52
+				RightColor: 65,59,49
 			1: Cliff
+				Height: 4
+				LeftColor: 80,68,52
+				RightColor: 66,58,47
 	Template@84:
 		Category: Cliff Set
 		Id: 84
@@ -556,7 +919,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 77,66,52
+				RightColor: 66,61,53
 			1: Cliff
+				Height: 4
+				LeftColor: 67,60,50
+				RightColor: 74,68,59
 	Template@85:
 		Category: Cliff Set
 		Id: 85
@@ -564,6 +933,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 78,66,51
+				RightColor: 58,51,41
 	Template@86:
 		Category: Cliff Set
 		Id: 86
@@ -571,8 +943,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,71,59
+				RightColor: 68,63,54
 			1: Cliff
+				Height: 4
+				LeftColor: 78,66,50
+				RightColor: 70,63,53
 			2: Cliff
+				Height: 4
+				LeftColor: 64,59,51
+				RightColor: 80,71,58
 	Template@87:
 		Category: Cliff Set
 		Id: 87
@@ -580,8 +961,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 61,55,46
+				RightColor: 59,54,45
 			2: Cliff
+				Height: 4
+				LeftColor: 67,61,51
+				RightColor: 60,55,47
 			3: Cliff
+				Height: 4
+				LeftColor: 80,72,59
+				RightColor: 68,58,45
 	Template@88:
 		Category: Cliff Set
 		Id: 88
@@ -589,6 +979,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 65,59,50
+				RightColor: 71,65,54
 	Template@89:
 		Category: Cliff Set
 		Id: 89
@@ -596,6 +989,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 71,64,54
+				RightColor: 60,55,48
 	Template@90:
 		Category: Cliff Set
 		Id: 90
@@ -603,8 +999,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 49,48,43
+				RightColor: 57,53,47
 			1: Cliff
+				Height: 4
+				LeftColor: 77,69,58
+				RightColor: 76,67,55
 			2: Cliff
+				Height: 4
+				LeftColor: 76,66,53
+				RightColor: 71,63,50
 	Template@91:
 		Category: Cliff Set
 		Id: 91
@@ -612,8 +1017,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 69,64,56
+				RightColor: 63,57,49
 			2: Cliff
+				Height: 4
+				LeftColor: 78,67,52
+				RightColor: 60,55,48
 			3: Cliff
+				Height: 4
+				LeftColor: 84,74,60
+				RightColor: 78,67,53
 	Template@92:
 		Category: Cliff Set
 		Id: 92
@@ -621,6 +1035,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 76,66,52
+				RightColor: 69,62,51
 	Template@93:
 		Category: Cliff Set
 		Id: 93
@@ -628,6 +1045,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 74,64,50
+				RightColor: 79,66,49
 	Template@94:
 		Category: Cliff Set
 		Id: 94
@@ -635,7 +1055,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 75,69,58
+				RightColor: 71,63,52
 			1: Cliff
+				Height: 4
+				LeftColor: 68,64,57
+				RightColor: 82,72,59
 	Template@95:
 		Category: Cliff Set
 		Id: 95
@@ -643,7 +1069,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 73,68,59
+				RightColor: 75,64,50
 			1: Cliff
+				Height: 4
+				LeftColor: 70,65,58
+				RightColor: 80,70,56
 	Template@96:
 		Category: Cliff Set
 		Id: 96
@@ -651,7 +1083,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 71,65,56
+				RightColor: 71,64,54
 			1: Cliff
+				Height: 4
+				LeftColor: 72,66,57
+				RightColor: 89,80,66
 	Template@97:
 		Category: Cliff Set
 		Id: 97
@@ -659,6 +1097,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 53,50,44
+				RightColor: 57,51,43
 	Template@98:
 		Category: Cliff Set
 		Id: 98
@@ -666,6 +1107,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 75,67,55
+				RightColor: 75,64,48
 	Template@99:
 		Category: Cliff Set
 		Id: 99
@@ -673,6 +1117,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 77,66,51
+				RightColor: 69,62,52
 	Template@100:
 		Category: Civilian Buildings
 		Id: 100
@@ -680,14 +1127,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Impassable
+				LeftColor: 102,109,118
+				RightColor: 113,119,125
 			1: Impassable
+				LeftColor: 80,84,87
+				RightColor: 97,101,111
 			2: Clear
+				LeftColor: 191,192,237
+				RightColor: 206,207,246
 			3: Impassable
+				LeftColor: 121,123,130
+				RightColor: 123,127,134
 			4: Impassable
+				LeftColor: 109,111,116
+				RightColor: 88,90,102
 			5: Clear
+				LeftColor: 199,200,246
+				RightColor: 198,200,248
 			6: Clear
+				LeftColor: 203,204,247
+				RightColor: 197,198,230
 			7: Clear
+				LeftColor: 194,196,230
+				RightColor: 173,176,206
 			8: Clear
+				LeftColor: 196,198,240
+				RightColor: 194,196,246
 	Template@101:
 		Category: Civilian Buildings
 		Id: 101
@@ -695,7 +1160,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Impassable
+				LeftColor: 177,177,231
+				RightColor: 179,181,217
 			1: Impassable
+				LeftColor: 180,181,210
+				RightColor: 190,191,247
 	Template@102:
 		Category: Civilian Buildings
 		Id: 102
@@ -703,6 +1172,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Impassable
+				LeftColor: 157,158,160
+				RightColor: 137,139,143
 	Template@103:
 		Category: Civilian Buildings
 		Id: 103
@@ -710,7 +1181,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Impassable
+				LeftColor: 183,184,230
+				RightColor: 180,182,214
 			1: Impassable
+				LeftColor: 186,187,225
+				RightColor: 202,203,246
 	Template@104:
 		Category: Civilian Buildings
 		Id: 104
@@ -718,8 +1193,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: Impassable
+				LeftColor: 124,129,138
+				RightColor: 103,107,114
 			2: Impassable
+				LeftColor: 123,127,131
+				RightColor: 122,126,130
 			3: Impassable
+				LeftColor: 114,117,124
+				RightColor: 106,109,115
 	Template@105:
 		Category: Civilian Buildings
 		Id: 105
@@ -727,11 +1208,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: Impassable
+				LeftColor: 115,117,123
+				RightColor: 125,127,136
 			3: Impassable
+				LeftColor: 146,148,162
+				RightColor: 119,122,128
 			4: Impassable
+				LeftColor: 151,155,172
+				RightColor: 157,160,178
 			5: Rough
+				LeftColor: 179,179,189
+				RightColor: 189,189,215
 			7: Rough
+				LeftColor: 188,190,219
+				RightColor: 174,173,175
 			8: Rough
+				LeftColor: 189,191,216
+				RightColor: 176,178,202
 	Template@106:
 		Category: Civilian Buildings
 		Id: 106
@@ -739,6 +1232,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Impassable
+				LeftColor: 114,117,125
+				RightColor: 92,97,105
 	Template@107:
 		Category: Civilian Buildings
 		Id: 107
@@ -746,7 +1241,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Impassable
+				LeftColor: 104,107,110
+				RightColor: 114,118,129
 			1: Impassable
+				LeftColor: 121,127,141
+				RightColor: 94,102,120
 	Template@108:
 		Category: Shore Pieces
 		Id: 108
@@ -754,9 +1253,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 61,65,72
+				RightColor: 80,76,72
 			1: Water
+				LeftColor: 72,73,72
+				RightColor: 93,80,64
 			2: Water
+				LeftColor: 26,45,71
+				RightColor: 46,59,79
 			3: Water
+				LeftColor: 28,47,74
+				RightColor: 44,57,74
 	Template@109:
 		Category: Shore Pieces
 		Id: 109
@@ -764,9 +1271,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 65,68,71
+				RightColor: 83,77,70
 			1: Water
+				LeftColor: 62,67,71
+				RightColor: 94,83,71
 			2: Water
+				LeftColor: 24,40,58
+				RightColor: 35,47,60
 			3: Water
+				LeftColor: 23,43,72
+				RightColor: 37,56,84
 	Template@110:
 		Category: Shore Pieces
 		Id: 110
@@ -774,9 +1289,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 66,68,72
+				RightColor: 88,77,64
 			1: Water
+				LeftColor: 47,57,71
+				RightColor: 92,79,64
 			2: Water
+				LeftColor: 23,42,67
+				RightColor: 36,52,75
 			3: Water
+				LeftColor: 24,40,61
+				RightColor: 30,49,78
 	Template@111:
 		Category: Shore Pieces
 		Id: 111
@@ -784,7 +1307,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Water
+				LeftColor: 80,74,67
+				RightColor: 93,79,63
 			1: Water
+				LeftColor: 22,41,67
+				RightColor: 47,56,68
 	Template@112:
 		Category: Shore Pieces
 		Id: 112
@@ -792,11 +1319,23 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Water
+				LeftColor: 79,73,66
+				RightColor: 94,82,67
 			1: Water
+				LeftColor: 74,75,73
+				RightColor: 106,86,62
 			2: Water
+				LeftColor: 38,52,68
+				RightColor: 41,53,65
 			3: Water
+				LeftColor: 40,59,85
+				RightColor: 76,78,80
 			4: Water
+				LeftColor: 20,40,66
+				RightColor: 39,55,77
 			5: Water
+				LeftColor: 39,52,71
+				RightColor: 36,50,70
 	Template@113:
 		Category: Shore Pieces
 		Id: 113
@@ -804,11 +1343,23 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Water
+				LeftColor: 68,72,76
+				RightColor: 86,79,70
 			1: Water
+				LeftColor: 84,87,87
+				RightColor: 100,84,64
 			2: Water
+				LeftColor: 66,70,79
+				RightColor: 56,63,73
 			3: Water
+				LeftColor: 38,53,76
+				RightColor: 56,66,79
 			4: Water
+				LeftColor: 22,41,68
+				RightColor: 24,44,72
 			5: Water
+				LeftColor: 16,34,56
+				RightColor: 23,42,69
 	Template@114:
 		Category: Shore Pieces
 		Id: 114
@@ -816,9 +1367,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 60,67,79
+				RightColor: 70,71,71
 			1: Water
+				LeftColor: 37,54,78
+				RightColor: 24,42,67
 			2: Water
+				LeftColor: 22,41,67
+				RightColor: 32,52,82
 			3: Water
+				LeftColor: 18,37,63
+				RightColor: 26,46,75
 	Template@115:
 		Category: Shore Pieces
 		Id: 115
@@ -826,9 +1385,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 79,80,81
+				RightColor: 79,79,77
 			1: Water
+				LeftColor: 38,55,78
+				RightColor: 20,37,59
 			2: Water
+				LeftColor: 28,47,71
+				RightColor: 36,57,87
 			3: Water
+				LeftColor: 16,34,55
+				RightColor: 21,40,66
 	Template@116:
 		Category: Shore Pieces
 		Id: 116
@@ -836,9 +1403,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 84,78,72
+				RightColor: 81,77,72
 			1: Water
+				LeftColor: 53,65,83
+				RightColor: 31,47,70
 			2: Water
+				LeftColor: 93,78,59
+				RightColor: 47,59,77
 			3: Water
+				LeftColor: 34,53,81
+				RightColor: 26,45,74
 	Template@117:
 		Category: Shore Pieces
 		Id: 117
@@ -846,9 +1421,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 76,79,84
+				RightColor: 84,77,68
 			1: Water
+				LeftColor: 39,59,91
+				RightColor: 22,40,61
 			2: Water
+				LeftColor: 87,78,68
+				RightColor: 54,69,88
 			3: Water
+				LeftColor: 28,46,73
+				RightColor: 24,45,74
 	Template@118:
 		Category: Shore Pieces
 		Id: 118
@@ -856,9 +1439,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 67,72,80
+				RightColor: 90,84,77
 			1: Water
+				LeftColor: 40,60,89
+				RightColor: 22,42,65
 			2: Clear
+				LeftColor: 98,82,65
+				RightColor: 80,79,78
 			3: Water
+				LeftColor: 31,50,77
+				RightColor: 29,48,79
 	Template@119:
 		Category: Shore Pieces
 		Id: 119
@@ -866,7 +1457,11 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Water
+				LeftColor: 96,84,69
+				RightColor: 66,70,77
 			1: Water
+				LeftColor: 32,48,70
+				RightColor: 22,40,63
 	Template@120:
 		Category: Shore Pieces
 		Id: 120
@@ -874,11 +1469,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Clear
+				LeftColor: 96,85,73
+				RightColor: 100,86,69
 			1: Water
+				LeftColor: 63,73,88
+				RightColor: 75,74,74
 			2: Water
+				LeftColor: 40,56,80
+				RightColor: 20,39,61
 			3: Water
+				LeftColor: 82,80,77
+				RightColor: 59,71,89
 			4: Water
+				LeftColor: 39,53,72
+				RightColor: 29,45,70
 			5: Water
+				LeftColor: 26,47,77
+				RightColor: 22,42,69
 	Template@121:
 		Category: Shore Pieces
 		Id: 121
@@ -886,11 +1493,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Water
+				LeftColor: 85,77,67
+				RightColor: 85,79,72
 			1: Water
+				LeftColor: 51,65,85
+				RightColor: 26,43,64
 			2: Water
+				LeftColor: 35,53,77
+				RightColor: 38,54,77
 			3: Clear
+				LeftColor: 107,86,61
+				RightColor: 73,76,81
 			4: Water
+				LeftColor: 76,74,71
+				RightColor: 55,65,80
 			5: Water
+				LeftColor: 24,44,73
+				RightColor: 24,43,70
 	Template@122:
 		Category: Shore Pieces
 		Id: 122
@@ -898,9 +1517,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 32,49,72
+				RightColor: 21,41,67
 			1: Water
+				LeftColor: 22,42,70
+				RightColor: 14,33,54
 			2: Water
+				LeftColor: 99,85,69
+				RightColor: 67,71,73
 			3: Water
+				LeftColor: 35,52,73
+				RightColor: 25,44,71
 	Template@123:
 		Category: Shore Pieces
 		Id: 123
@@ -908,9 +1535,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 27,47,77
+				RightColor: 20,40,65
 			1: Water
+				LeftColor: 28,48,81
+				RightColor: 16,36,59
 			2: Water
+				LeftColor: 85,80,74
+				RightColor: 53,66,84
 			3: Water
+				LeftColor: 36,54,79
+				RightColor: 25,45,74
 	Template@124:
 		Category: Shore Pieces
 		Id: 124
@@ -918,9 +1553,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 38,53,75
+				RightColor: 32,49,69
 			1: Water
+				LeftColor: 44,59,80
+				RightColor: 16,36,59
 			2: Water
+				LeftColor: 90,82,71
+				RightColor: 61,69,78
 			3: Water
+				LeftColor: 69,72,77
+				RightColor: 73,74,74
 	Template@125:
 		Category: Shore Pieces
 		Id: 125
@@ -928,9 +1571,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 23,42,68
+				RightColor: 28,46,71
 			1: Water
+				LeftColor: 28,47,75
+				RightColor: 19,39,63
 			2: Water
+				LeftColor: 85,81,77
+				RightColor: 47,62,82
 			3: Water
+				LeftColor: 81,79,77
+				RightColor: 72,71,70
 	Template@126:
 		Category: Shore Pieces
 		Id: 126
@@ -938,9 +1589,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 36,53,75
+				RightColor: 30,47,70
 			1: Water
+				LeftColor: 27,47,76
+				RightColor: 20,40,66
 			2: Water
+				LeftColor: 97,82,65
+				RightColor: 65,71,81
 			3: Water
+				LeftColor: 78,78,78
+				RightColor: 60,68,81
 	Template@127:
 		Category: Shore Pieces
 		Id: 127
@@ -948,7 +1607,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Water
+				LeftColor: 31,49,73
+				RightColor: 22,42,70
 			1: Water
+				LeftColor: 93,81,66
+				RightColor: 83,76,69
 	Template@128:
 		Category: Shore Pieces
 		Id: 128
@@ -956,11 +1619,23 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Water
+				LeftColor: 21,40,65
+				RightColor: 21,40,64
 			1: Water
+				LeftColor: 37,51,72
+				RightColor: 17,37,61
 			2: Water
+				LeftColor: 36,50,69
+				RightColor: 53,60,68
 			3: Water
+				LeftColor: 58,63,70
+				RightColor: 78,75,72
 			4: Water
+				LeftColor: 96,82,66
+				RightColor: 72,72,71
 			5: Water
+				LeftColor: 91,81,68
+				RightColor: 82,78,75
 	Template@129:
 		Category: Shore Pieces
 		Id: 129
@@ -968,11 +1643,23 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Water
+				LeftColor: 50,58,67
+				RightColor: 27,45,70
 			1: Water
+				LeftColor: 40,51,64
+				RightColor: 17,35,57
 			2: Water
+				LeftColor: 76,78,82
+				RightColor: 48,58,71
 			3: Water
+				LeftColor: 40,52,70
+				RightColor: 32,50,78
 			4: Water
+				LeftColor: 100,83,62
+				RightColor: 78,78,76
 			5: Water
+				LeftColor: 90,81,69
+				RightColor: 86,77,66
 	Template@130:
 		Category: Shore Pieces
 		Id: 130
@@ -980,9 +1667,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 24,45,73
+				RightColor: 24,43,71
 			1: Water
+				LeftColor: 40,54,72
+				RightColor: 24,43,68
 			2: Water
+				LeftColor: 29,46,67
+				RightColor: 34,54,84
 			3: Water
+				LeftColor: 59,65,73
+				RightColor: 69,70,72
 	Template@131:
 		Category: Shore Pieces
 		Id: 131
@@ -990,9 +1685,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 37,51,70
+				RightColor: 30,45,65
 			1: Water
+				LeftColor: 48,58,69
+				RightColor: 30,49,77
 			2: Water
+				LeftColor: 38,50,65
+				RightColor: 61,67,74
 			3: Water
+				LeftColor: 91,80,67
+				RightColor: 82,78,75
 	Template@132:
 		Category: Shore Pieces
 		Id: 132
@@ -1000,9 +1703,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 31,49,74
+				RightColor: 42,53,69
 			1: Water
+				LeftColor: 75,74,73
+				RightColor: 93,82,68
 			2: Water
+				LeftColor: 33,49,69
+				RightColor: 40,55,73
 			3: Water
+				LeftColor: 80,80,77
+				RightColor: 85,82,76
 	Template@133:
 		Category: Shore Pieces
 		Id: 133
@@ -1010,9 +1721,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 29,48,70
+				RightColor: 53,63,72
 			1: Water
+				LeftColor: 74,75,73
+				RightColor: 97,85,70
 			2: Water
+				LeftColor: 30,46,65
+				RightColor: 55,62,71
 			3: Water
+				LeftColor: 82,76,69
+				RightColor: 93,81,65
 	Template@134:
 		Category: Shore Pieces
 		Id: 134
@@ -1020,9 +1739,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 42,57,76
+				RightColor: 57,66,78
 			1: Water
+				LeftColor: 71,73,75
+				RightColor: 92,82,72
 			2: Water
+				LeftColor: 33,47,64
+				RightColor: 38,55,80
 			3: Water
+				LeftColor: 83,77,68
+				RightColor: 89,80,68
 	Template@135:
 		Category: Shore Pieces
 		Id: 135
@@ -1030,7 +1757,11 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Water
+				LeftColor: 36,50,70
+				RightColor: 54,62,71
 			1: Water
+				LeftColor: 84,78,71
+				RightColor: 95,85,71
 	Template@136:
 		Category: Shore Pieces
 		Id: 136
@@ -1038,11 +1769,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Water
+				LeftColor: 21,39,62
+				RightColor: 64,68,75
 			1: Water
+				LeftColor: 73,76,80
+				RightColor: 78,76,75
 			2: Water
+				LeftColor: 78,70,59
+				RightColor: 102,84,62
 			3: Water
+				LeftColor: 14,32,54
+				RightColor: 17,35,58
 			4: Water
+				LeftColor: 33,48,66
+				RightColor: 59,68,78
 			5: Water
+				LeftColor: 82,78,70
+				RightColor: 88,80,67
 	Template@137:
 		Category: Shore Pieces
 		Id: 137
@@ -1050,11 +1793,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Water
+				LeftColor: 19,37,61
+				RightColor: 22,43,70
 			1: Water
+				LeftColor: 46,64,90
+				RightColor: 53,63,74
 			2: Water
+				LeftColor: 86,81,72
+				RightColor: 97,80,59
 			3: Water
+				LeftColor: 29,42,59
+				RightColor: 46,56,69
 			4: Water
+				LeftColor: 96,81,61
+				RightColor: 59,67,76
 			5: Water
+				LeftColor: 91,80,65
+				RightColor: 92,81,67
 	Template@138:
 		Category: Shore Pieces
 		Id: 138
@@ -1062,9 +1817,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 31,48,71
+				RightColor: 57,60,64
 			1: Water
+				LeftColor: 74,71,67
+				RightColor: 98,82,62
 			2: Water
+				LeftColor: 15,33,55
+				RightColor: 21,40,66
 			3: Water
+				LeftColor: 23,43,69
+				RightColor: 34,48,69
 	Template@139:
 		Category: Shore Pieces
 		Id: 139
@@ -1072,9 +1835,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 22,41,67
+				RightColor: 53,60,70
 			1: Water
+				LeftColor: 87,82,76
+				RightColor: 103,85,63
 			2: Water
+				LeftColor: 18,37,61
+				RightColor: 24,45,73
 			3: Water
+				LeftColor: 23,43,70
+				RightColor: 49,61,75
 	Template@140:
 		Category: Shore Pieces
 		Id: 140
@@ -1082,9 +1853,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Clear
+				LeftColor: 99,86,69
+				RightColor: 94,84,70
 			1: Water
+				LeftColor: 67,75,83
+				RightColor: 94,82,67
 			2: Water
+				LeftColor: 101,85,65
+				RightColor: 55,66,80
 			3: Water
+				LeftColor: 26,45,70
+				RightColor: 39,58,86
 	Template@141:
 		Category: Shore Pieces
 		Id: 141
@@ -1092,9 +1871,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Clear
+				LeftColor: 94,80,64
+				RightColor: 100,84,66
 			1: Water
+				LeftColor: 74,73,72
+				RightColor: 91,80,65
 			2: Water
+				LeftColor: 96,83,67
+				RightColor: 72,74,76
 			3: Water
+				LeftColor: 52,62,76
+				RightColor: 52,62,74
 	Template@142:
 		Category: Shore Pieces
 		Id: 142
@@ -1102,9 +1889,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 86,77,67
+				RightColor: 86,78,67
 			1: Water
+				LeftColor: 34,53,79
+				RightColor: 19,39,61
 			2: Clear
+				LeftColor: 110,88,62
+				RightColor: 88,83,78
 			3: Water
+				LeftColor: 74,73,73
+				RightColor: 76,75,73
 	Template@143:
 		Category: Shore Pieces
 		Id: 143
@@ -1112,9 +1907,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 81,78,73
+				RightColor: 83,78,74
 			1: Water
+				LeftColor: 40,56,77
+				RightColor: 21,41,65
 			2: Clear
+				LeftColor: 112,90,62
+				RightColor: 91,80,65
 			3: Water
+				LeftColor: 82,79,75
+				RightColor: 71,73,73
 	Template@144:
 		Category: Shore Pieces
 		Id: 144
@@ -1122,9 +1925,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 29,48,74
+				RightColor: 48,60,77
 			1: Water
+				LeftColor: 77,79,82
+				RightColor: 109,88,62
 			2: Water
+				LeftColor: 85,79,71
+				RightColor: 70,75,79
 			3: Clear
+				LeftColor: 95,84,71
+				RightColor: 102,85,65
 	Template@145:
 		Category: Shore Pieces
 		Id: 145
@@ -1132,9 +1943,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 34,52,77
+				RightColor: 48,58,71
 			1: Water
+				LeftColor: 73,77,83
+				RightColor: 101,84,64
 			2: Water
+				LeftColor: 94,82,68
+				RightColor: 68,71,75
 			3: Water
+				LeftColor: 93,82,69
+				RightColor: 93,81,67
 	Template@146:
 		Category: Shore Pieces
 		Id: 146
@@ -1142,9 +1961,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 83,79,73
+				RightColor: 91,82,72
 			1: Clear
+				LeftColor: 98,84,66
+				RightColor: 107,87,62
 			2: Water
+				LeftColor: 37,49,63
+				RightColor: 55,66,79
 			3: Water
+				LeftColor: 88,82,72
+				RightColor: 82,79,75
 	Template@147:
 		Category: Shore Pieces
 		Id: 147
@@ -1152,9 +1979,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 73,75,78
+				RightColor: 92,84,74
 			1: Water
+				LeftColor: 76,75,74
+				RightColor: 98,82,64
 			2: Water
+				LeftColor: 40,54,73
+				RightColor: 37,56,85
 			3: Water
+				LeftColor: 78,76,74
+				RightColor: 84,79,74
 	Template@148:
 		Category: Shore Pieces
 		Id: 148
@@ -1162,26 +1997,68 @@ Templates:
 		Size: 6, 4
 		Tiles:
 			1: Clear
+				LeftColor: 99,82,61
+				RightColor: 96,81,61
 			2: Clear
+				LeftColor: 93,80,63
+				RightColor: 99,82,62
 			3: Clear
+				LeftColor: 98,83,64
+				RightColor: 102,84,63
 			6: Clear
+				LeftColor: 100,84,64
+				RightColor: 96,81,61
 			7: Water
+				LeftColor: 72,68,63
+				RightColor: 85,73,59
 			8: Water
+				LeftColor: 67,65,61
+				RightColor: 69,66,60
 			9: Water
+				LeftColor: 68,64,59
+				RightColor: 81,71,57
 			10: Water
+				LeftColor: 57,61,64
+				RightColor: 83,74,63
 			11: Water
+				LeftColor: 39,46,56
+				RightColor: 27,40,57
 			12: Water
+				LeftColor: 85,77,66
+				RightColor: 77,70,60
 			13: Water
+				LeftColor: 69,72,74
+				RightColor: 52,62,74
 			14: Water
+				LeftColor: 58,64,69
+				RightColor: 61,64,65
 			15: Water
+				LeftColor: 35,47,61
+				RightColor: 43,52,61
 			16: Water
+				LeftColor: 31,48,72
+				RightColor: 30,48,72
 			17: Water
+				LeftColor: 30,52,86
+				RightColor: 21,40,66
 			18: Water
+				LeftColor: 88,76,62
+				RightColor: 68,66,62
 			19: Water
+				LeftColor: 31,48,74
+				RightColor: 34,53,82
 			20: Water
+				LeftColor: 22,42,70
+				RightColor: 27,45,69
 			21: Water
+				LeftColor: 16,34,56
+				RightColor: 25,46,75
 			22: Water
+				LeftColor: 24,44,73
+				RightColor: 31,53,87
 			23: Water
+				LeftColor: 17,36,60
+				RightColor: 18,37,62
 	Template@149:
 		Category: Shore Pieces
 		Id: 149
@@ -1189,35 +2066,95 @@ Templates:
 		Size: 9, 5
 		Tiles:
 			2: Water
+				LeftColor: 88,78,63
+				RightColor: 95,81,61
 			3: Water
+				LeftColor: 82,74,62
+				RightColor: 100,85,65
 			11: Water
+				LeftColor: 79,74,67
+				RightColor: 59,64,70
 			12: Water
+				LeftColor: 56,63,71
+				RightColor: 78,77,73
 			13: Clear
+				LeftColor: 101,84,63
+				RightColor: 110,92,68
 			18: Clear
+				LeftColor: 108,90,66
+				RightColor: 102,86,65
 			19: Water
+				LeftColor: 87,74,58
+				RightColor: 91,77,60
 			20: Water
+				LeftColor: 56,60,62
+				RightColor: 48,55,63
 			21: Water
+				LeftColor: 40,54,78
+				RightColor: 39,51,64
 			22: Water
+				LeftColor: 37,49,63
+				RightColor: 76,72,64
 			23: Water
+				LeftColor: 51,55,56
+				RightColor: 87,79,68
 			24: Water
+				LeftColor: 40,50,60
+				RightColor: 79,71,60
 			25: Water
+				LeftColor: 64,65,64
+				RightColor: 76,72,66
 			26: Water
+				LeftColor: 33,50,77
+				RightColor: 22,40,61
 			28: Water
+				LeftColor: 93,80,62
+				RightColor: 97,84,68
 			29: Water
+				LeftColor: 90,82,70
+				RightColor: 54,55,55
 			30: Water
+				LeftColor: 30,50,82
+				RightColor: 26,43,65
 			31: Water
+				LeftColor: 27,48,80
+				RightColor: 25,45,75
 			32: Water
+				LeftColor: 28,49,81
+				RightColor: 27,49,81
 			33: Water
+				LeftColor: 21,41,68
+				RightColor: 23,43,69
 			34: Water
+				LeftColor: 20,39,63
+				RightColor: 25,46,75
 			35: Water
+				LeftColor: 21,40,66
+				RightColor: 19,38,64
 			37: Water
+				LeftColor: 105,87,65
+				RightColor: 93,78,59
 			38: Water
+				LeftColor: 55,57,56
+				RightColor: 61,63,63
 			39: Water
+				LeftColor: 22,41,68
+				RightColor: 22,42,71
 			40: Water
+				LeftColor: 17,35,59
+				RightColor: 24,44,73
 			41: Water
+				LeftColor: 18,37,61
+				RightColor: 17,37,61
 			42: Water
+				LeftColor: 15,33,54
+				RightColor: 16,35,60
 			43: Water
+				LeftColor: 14,32,54
+				RightColor: 18,37,63
 			44: Water
+				LeftColor: 21,40,67
+				RightColor: 20,40,66
 	Template@150:
 		Category: Rough LAT tile
 		Id: 150
@@ -1225,6 +2162,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 70,64,54
+				RightColor: 71,65,55
 	Template@151:
 		Category: Clear/Rough LAT
 		Id: 151
@@ -1232,6 +2171,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 83,72,57
+				RightColor: 84,73,57
 	Template@152:
 		Category: Clear/Rough LAT
 		Id: 152
@@ -1239,6 +2180,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 74,68,57
+				RightColor: 88,74,56
 	Template@153:
 		Category: Clear/Rough LAT
 		Id: 153
@@ -1246,6 +2189,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 70,64,54
+				RightColor: 87,74,57
 	Template@154:
 		Category: Clear/Rough LAT
 		Id: 154
@@ -1253,6 +2198,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 76,70,59
+				RightColor: 94,79,60
 	Template@155:
 		Category: Clear/Rough LAT
 		Id: 155
@@ -1260,6 +2207,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 85,73,57
+				RightColor: 73,67,56
 	Template@156:
 		Category: Clear/Rough LAT
 		Id: 156
@@ -1267,6 +2216,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 85,73,56
+				RightColor: 87,74,58
 	Template@157:
 		Category: Clear/Rough LAT
 		Id: 157
@@ -1274,6 +2225,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 88,76,60
+				RightColor: 88,74,57
 	Template@158:
 		Category: Clear/Rough LAT
 		Id: 158
@@ -1281,6 +2234,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 86,75,59
+				RightColor: 97,82,63
 	Template@159:
 		Category: Clear/Rough LAT
 		Id: 159
@@ -1288,6 +2243,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 86,73,57
+				RightColor: 73,67,56
 	Template@160:
 		Category: Clear/Rough LAT
 		Id: 160
@@ -1295,6 +2252,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 84,73,57
+				RightColor: 86,73,55
 	Template@161:
 		Category: Clear/Rough LAT
 		Id: 161
@@ -1302,6 +2261,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 90,78,61
+				RightColor: 91,76,57
 	Template@162:
 		Category: Clear/Rough LAT
 		Id: 162
@@ -1309,6 +2270,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 87,76,60
+				RightColor: 96,80,61
 	Template@163:
 		Category: Clear/Rough LAT
 		Id: 163
@@ -1316,6 +2279,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 100,83,61
+				RightColor: 74,68,56
 	Template@164:
 		Category: Clear/Rough LAT
 		Id: 164
@@ -1323,6 +2288,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 103,83,59
+				RightColor: 88,75,58
 	Template@165:
 		Category: Clear/Rough LAT
 		Id: 165
@@ -1330,6 +2297,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 99,84,64
+				RightColor: 85,73,57
 	Template@166:
 		Category: Clear/Rough LAT
 		Id: 166
@@ -1337,6 +2306,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 91,77,58
+				RightColor: 93,79,61
 	Template@167:
 		Category: Cliff/Water pieces
 		Id: 167
@@ -1344,9 +2315,19 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 61,51,37
+				RightColor: 82,67,47
 			2: Cliff
+				LeftColor: 66,59,51
+				RightColor: 73,63,48
 			3: Cliff
+				Height: 4
+				LeftColor: 49,40,27
+				RightColor: 70,56,39
 			5: Cliff
+				LeftColor: 43,51,59
+				RightColor: 60,55,45
 	Template@168:
 		Category: Cliff/Water pieces
 		Id: 168
@@ -1354,7 +2335,12 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 70,63,51
+				RightColor: 82,71,56
 			1: Cliff
+				LeftColor: 70,65,56
+				RightColor: 62,56,46
 	Template@169:
 		Category: Cliff/Water pieces
 		Id: 169
@@ -1362,9 +2348,19 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 62,55,44
+				RightColor: 76,64,47
 			2: Cliff
+				LeftColor: 49,56,66
+				RightColor: 63,57,48
 			3: Cliff
+				Height: 4
+				LeftColor: 53,48,39
+				RightColor: 58,52,42
 			5: Cliff
+				LeftColor: 36,45,58
+				RightColor: 48,46,42
 	Template@170:
 		Category: Cliff/Water pieces
 		Id: 170
@@ -1372,9 +2368,19 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 80,70,55
+				RightColor: 81,68,51
 			2: Cliff
+				LeftColor: 38,49,63
+				RightColor: 77,68,54
 			3: Cliff
+				Height: 4
+				LeftColor: 64,58,45
+				RightColor: 76,66,52
 			5: Cliff
+				LeftColor: 45,53,63
+				RightColor: 69,63,51
 	Template@171:
 		Category: Cliff/Water pieces
 		Id: 171
@@ -1382,9 +2388,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 62,54,42
+				RightColor: 70,60,46
 			1: Cliff
+				Height: 4
+				LeftColor: 63,58,50
+				RightColor: 80,68,52
 			2: Cliff
+				LeftColor: 42,49,55
+				RightColor: 66,60,50
 			3: Cliff
+				LeftColor: 46,54,64
+				RightColor: 77,70,59
 	Template@172:
 		Category: Cliff/Water pieces
 		Id: 172
@@ -1392,9 +2408,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 65,57,45
+				RightColor: 77,67,52
 			1: Cliff
+				Height: 4
+				LeftColor: 58,52,41
+				RightColor: 74,62,46
 			2: Cliff
+				LeftColor: 54,55,55
+				RightColor: 77,69,56
 			3: Cliff
+				LeftColor: 50,52,54
+				RightColor: 77,68,54
 	Template@173:
 		Category: Cliff/Water pieces
 		Id: 173
@@ -1402,9 +2428,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 72,62,48
+				RightColor: 80,67,50
 			1: Cliff
+				Height: 4
+				LeftColor: 72,63,51
+				RightColor: 78,65,48
 			2: Cliff
+				LeftColor: 43,50,59
+				RightColor: 62,57,49
 			3: Cliff
+				LeftColor: 53,59,66
+				RightColor: 72,66,56
 	Template@174:
 		Category: Cliff/Water pieces
 		Id: 174
@@ -1412,7 +2448,12 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 62,54,44
+				RightColor: 77,66,51
 			1: Cliff
+				LeftColor: 72,71,68
+				RightColor: 68,64,56
 	Template@175:
 		Category: Cliff/Water pieces
 		Id: 175
@@ -1420,8 +2461,15 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 71,62,50
+				RightColor: 82,69,53
 			1: Cliff
+				LeftColor: 52,55,58
+				RightColor: 78,71,60
 			2: Cliff
+				LeftColor: 74,69,59
+				RightColor: 69,65,57
 	Template@176:
 		Category: Cliff/Water pieces
 		Id: 176
@@ -1429,9 +2477,18 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 73,64,50
+				RightColor: 76,64,50
 			1: Cliff
+				LeftColor: 33,41,50
+				RightColor: 73,67,57
 			2: Cliff
+				LeftColor: 62,59,53
+				RightColor: 72,66,55
 			3: Cliff
+				LeftColor: 49,55,64
+				RightColor: 30,43,60
 	Template@177:
 		Category: Cliff/Water pieces
 		Id: 177
@@ -1439,8 +2496,15 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 72,61,47
+				RightColor: 63,54,41
 			1: Cliff
+				LeftColor: 44,51,58
+				RightColor: 60,56,47
 			2: Cliff
+				LeftColor: 70,67,61
+				RightColor: 72,68,62
 	Template@178:
 		Category: Cliff/Water pieces
 		Id: 178
@@ -1448,6 +2512,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 71,67,60
+				RightColor: 62,60,55
 	Template@179:
 		Category: Cliff/Water pieces
 		Id: 179
@@ -1455,6 +2521,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 66,63,57
+				RightColor: 78,71,61
 	Template@180:
 		Category: Cliff/Water pieces
 		Id: 180
@@ -1462,6 +2530,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 74,69,60
+				RightColor: 59,55,47
 	Template@181:
 		Category: Cliff/Water pieces
 		Id: 181
@@ -1469,9 +2539,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 78,66,51
+				RightColor: 66,56,44
 			1: Cliff
+				LeftColor: 46,46,45
+				RightColor: 50,48,44
 			2: Cliff
+				Height: 4
+				LeftColor: 72,61,48
+				RightColor: 61,56,48
 			3: Cliff
+				LeftColor: 48,53,60
+				RightColor: 47,48,48
 	Template@182:
 		Category: Cliff/Water pieces
 		Id: 182
@@ -1479,9 +2559,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 68,62,52
+				RightColor: 66,59,48
 			1: Cliff
+				LeftColor: 54,53,49
+				RightColor: 39,41,42
 			2: Cliff
+				Height: 4
+				LeftColor: 71,63,51
+				RightColor: 48,46,41
 			3: Cliff
+				LeftColor: 56,56,55
+				RightColor: 55,54,50
 	Template@183:
 		Category: Cliff/Water pieces
 		Id: 183
@@ -1489,9 +2579,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 69,59,45
+				RightColor: 70,62,50
 			1: Cliff
+				LeftColor: 48,43,34
+				RightColor: 47,46,43
 			2: Cliff
+				Height: 4
+				LeftColor: 80,68,52
+				RightColor: 70,63,52
 			3: Cliff
+				LeftColor: 40,44,48
+				RightColor: 58,55,50
 	Template@184:
 		Category: Cliff/Water pieces
 		Id: 184
@@ -1499,7 +2599,12 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,65,47
+				RightColor: 74,64,51
 			1: Cliff
+				LeftColor: 44,46,45
+				RightColor: 54,53,49
 	Template@185:
 		Category: Cliff/Water pieces
 		Id: 185
@@ -1507,9 +2612,19 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 81,68,52
+				RightColor: 61,55,47
 			1: Cliff
+				LeftColor: 44,42,37
+				RightColor: 43,46,49
 			4: Cliff
+				Height: 4
+				LeftColor: 68,59,45
+				RightColor: 36,35,32
 			5: Cliff
+				LeftColor: 48,57,66
+				RightColor: 47,51,54
 	Template@186:
 		Category: Cliff/Water pieces
 		Id: 186
@@ -1517,9 +2632,19 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 78,66,50
+				RightColor: 69,62,50
 			1: Cliff
+				LeftColor: 45,44,42
+				RightColor: 35,39,45
 			4: Cliff
+				Height: 4
+				LeftColor: 81,66,49
+				RightColor: 43,41,37
 			5: Cliff
+				LeftColor: 41,49,58
+				RightColor: 37,44,52
 	Template@187:
 		Category: Cliff/Water pieces
 		Id: 187
@@ -1527,9 +2652,19 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 70,61,48
+				RightColor: 48,47,43
 			1: Cliff
+				LeftColor: 43,44,43
+				RightColor: 52,52,49
 			4: Cliff
+				Height: 4
+				LeftColor: 80,68,52
+				RightColor: 36,34,31
 			5: Cliff
+				LeftColor: 60,62,64
+				RightColor: 46,52,59
 	Template@188:
 		Category: Cliff/Water pieces
 		Id: 188
@@ -1537,7 +2672,12 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 74,62,47
+				RightColor: 68,64,56
 			1: Cliff
+				LeftColor: 43,45,47
+				RightColor: 48,48,46
 	Template@189:
 		Category: Cliff/Water pieces
 		Id: 189
@@ -1545,10 +2685,22 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 70,62,50
+				RightColor: 77,64,49
 			2: Cliff
+				LeftColor: 74,70,60
+				RightColor: 62,60,54
 			3: Cliff
+				Height: 4
+				LeftColor: 43,40,36
+				RightColor: 55,50,42
 			4: Cliff
+				LeftColor: 32,45,64
+				RightColor: 59,59,59
 			5: Cliff
+				LeftColor: 37,48,63
+				RightColor: 55,54,52
 	Template@190:
 		Category: Cliff/Water pieces
 		Id: 190
@@ -1556,7 +2708,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 71,66,57
+				RightColor: 63,59,53
 			1: Cliff
+				LeftColor: 32,44,59
+				RightColor: 55,60,65
 	Template@191:
 		Category: Cliff/Water pieces
 		Id: 191
@@ -1564,7 +2720,11 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 72,67,59
+				RightColor: 76,70,60
 			1: Cliff
+				LeftColor: 56,60,65
+				RightColor: 32,45,61
 	Template@192:
 		Category: Cliff/Water pieces
 		Id: 192
@@ -1572,7 +2732,11 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 64,60,51
+				RightColor: 78,71,59
 			1: Cliff
+				LeftColor: 45,53,64
+				RightColor: 68,63,59
 	Template@193:
 		Category: Cliff/Water pieces
 		Id: 193
@@ -1580,7 +2744,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 84,75,61
+				RightColor: 66,63,56
 			1: Cliff
+				LeftColor: 56,61,71
+				RightColor: 47,57,71
 	Template@194:
 		Category: Cliff/Water pieces
 		Id: 194
@@ -1588,10 +2756,22 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 75,63,46
+				RightColor: 66,59,49
 			1: Cliff
+				LeftColor: 49,47,43
+				RightColor: 53,51,46
 			2: Cliff
+				LeftColor: 66,65,63
+				RightColor: 22,40,62
 			4: Cliff
+				Height: 4
+				LeftColor: 78,65,50
+				RightColor: 40,39,36
 			5: Cliff
+				LeftColor: 49,55,62
+				RightColor: 48,52,57
 	Template@195:
 		Category: Bendy Dirt Roads
 		Id: 195
@@ -1599,10 +2779,20 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 112,89,62
+				RightColor: 136,105,70
 			1: DirtRoad
+				LeftColor: 144,111,73
+				RightColor: 142,110,73
 			2: DirtRoad
+				LeftColor: 146,112,74
+				RightColor: 154,117,74
 			4: DirtRoad
+				LeftColor: 112,89,62
+				RightColor: 133,103,69
 			5: DirtRoad
+				LeftColor: 127,100,68
+				RightColor: 139,109,72
 	Template@196:
 		Category: Bendy Dirt Roads
 		Id: 196
@@ -1610,9 +2800,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 124,98,67
+				RightColor: 141,108,70
 			1: DirtRoad
+				LeftColor: 145,110,71
+				RightColor: 143,110,72
 			2: DirtRoad
+				LeftColor: 111,88,61
+				RightColor: 122,97,67
 			3: DirtRoad
+				LeftColor: 122,97,67
+				RightColor: 146,112,72
 	Template@197:
 		Category: Bendy Dirt Roads
 		Id: 197
@@ -1620,9 +2818,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 124,99,69
+				RightColor: 146,112,73
 			1: DirtRoad
+				LeftColor: 151,116,75
+				RightColor: 128,101,69
 			2: DirtRoad
+				LeftColor: 111,88,61
+				RightColor: 129,102,70
 			3: DirtRoad
+				LeftColor: 139,108,72
+				RightColor: 138,108,73
 	Template@198:
 		Category: Bendy Dirt Roads
 		Id: 198
@@ -1630,8 +2836,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 137,106,71
+				RightColor: 142,109,71
 			1: DirtRoad
+				LeftColor: 138,105,67
+				RightColor: 127,100,67
 			3: DirtRoad
+				LeftColor: 129,101,68
+				RightColor: 126,99,66
 	Template@199:
 		Category: Bendy Dirt Roads
 		Id: 199
@@ -1639,9 +2851,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 143,110,71
+				RightColor: 138,106,69
 			1: DirtRoad
+				LeftColor: 139,106,69
+				RightColor: 125,99,68
 			2: DirtRoad
+				LeftColor: 130,101,67
+				RightColor: 134,103,67
 			3: DirtRoad
+				LeftColor: 118,94,66
+				RightColor: 118,94,64
 	Template@200:
 		Category: Bendy Dirt Roads
 		Id: 200
@@ -1649,10 +2869,20 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			1: DirtRoad
+				LeftColor: 149,115,75
+				RightColor: 149,114,73
 			2: DirtRoad
+				LeftColor: 147,112,72
+				RightColor: 124,97,65
 			3: DirtRoad
+				LeftColor: 109,88,62
+				RightColor: 124,98,66
 			4: DirtRoad
+				LeftColor: 126,99,67
+				RightColor: 148,113,73
 			5: DirtRoad
+				LeftColor: 137,106,70
+				RightColor: 132,103,68
 	Template@201:
 		Category: Bendy Dirt Roads
 		Id: 201
@@ -1660,10 +2890,20 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: DirtRoad
+				LeftColor: 123,98,67
+				RightColor: 125,99,68
 			1: DirtRoad
+				LeftColor: 143,109,70
+				RightColor: 153,116,74
 			2: DirtRoad
+				LeftColor: 109,86,60
+				RightColor: 124,97,66
 			3: DirtRoad
+				LeftColor: 156,119,77
+				RightColor: 145,110,70
 			5: DirtRoad
+				LeftColor: 113,89,62
+				RightColor: 138,107,70
 	Template@202:
 		Category: Bendy Dirt Roads
 		Id: 202
@@ -1671,9 +2911,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 117,93,65
+				RightColor: 127,100,68
 			1: DirtRoad
+				LeftColor: 149,114,73
+				RightColor: 157,119,76
 			2: DirtRoad
+				LeftColor: 114,93,66
+				RightColor: 126,100,69
 			3: DirtRoad
+				LeftColor: 144,110,73
+				RightColor: 143,110,73
 	Template@203:
 		Category: Bendy Dirt Roads
 		Id: 203
@@ -1681,9 +2929,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 118,95,67
+				RightColor: 125,99,68
 			1: DirtRoad
+				LeftColor: 155,118,75
+				RightColor: 157,120,77
 			2: DirtRoad
+				LeftColor: 127,100,68
+				RightColor: 136,106,70
 			3: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 135,105,70
 	Template@204:
 		Category: Bendy Dirt Roads
 		Id: 204
@@ -1691,9 +2947,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 153,117,75
+				RightColor: 132,103,69
 			1: DirtRoad
+				LeftColor: 160,122,77
+				RightColor: 158,120,77
 			2: DirtRoad
+				LeftColor: 132,103,68
+				RightColor: 146,112,73
 			3: DirtRoad
+				LeftColor: 122,98,68
+				RightColor: 136,106,70
 	Template@205:
 		Category: Bendy Dirt Roads
 		Id: 205
@@ -1701,10 +2965,20 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			1: DirtRoad
+				LeftColor: 142,109,71
+				RightColor: 131,101,66
 			2: DirtRoad
+				LeftColor: 159,120,76
+				RightColor: 158,120,77
 			3: DirtRoad
+				LeftColor: 118,95,67
+				RightColor: 131,100,64
 			4: DirtRoad
+				LeftColor: 123,95,63
+				RightColor: 145,110,70
 			5: DirtRoad
+				LeftColor: 131,102,68
+				RightColor: 136,105,68
 	Template@206:
 		Category: Bendy Dirt Roads
 		Id: 206
@@ -1712,10 +2986,20 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 113,90,62
+				RightColor: 137,107,72
 			1: DirtRoad
+				LeftColor: 141,109,73
+				RightColor: 158,120,77
 			2: DirtRoad
+				LeftColor: 158,121,78
+				RightColor: 157,119,76
 			4: DirtRoad
+				LeftColor: 112,89,63
+				RightColor: 134,106,72
 			5: DirtRoad
+				LeftColor: 126,99,69
+				RightColor: 127,101,71
 	Template@207:
 		Category: Bendy Dirt Roads
 		Id: 207
@@ -1723,11 +3007,23 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: DirtRoad
+				LeftColor: 126,100,69
+				RightColor: 119,94,65
 			1: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 129,100,67
 			2: DirtRoad
+				LeftColor: 124,97,66
+				RightColor: 142,109,71
 			3: DirtRoad
+				LeftColor: 142,111,75
+				RightColor: 152,117,75
 			4: DirtRoad
+				LeftColor: 112,90,64
+				RightColor: 126,99,67
 			5: DirtRoad
+				LeftColor: 149,115,75
+				RightColor: 142,110,73
 	Template@208:
 		Category: Bendy Dirt Roads
 		Id: 208
@@ -1735,9 +3031,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 125,99,67
+				RightColor: 120,95,64
 			1: DirtRoad
+				LeftColor: 140,108,71
+				RightColor: 129,100,67
 			2: DirtRoad
+				LeftColor: 130,102,68
+				RightColor: 139,107,69
 			3: DirtRoad
+				LeftColor: 146,111,72
+				RightColor: 149,114,74
 	Template@209:
 		Category: Bendy Dirt Roads
 		Id: 209
@@ -1745,8 +3049,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 137,106,71
+				RightColor: 122,95,64
 			1: DirtRoad
+				LeftColor: 147,112,72
+				RightColor: 129,101,67
 			3: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 147,112,73
 	Template@210:
 		Category: Bendy Dirt Roads
 		Id: 210
@@ -1754,8 +3064,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
+				LeftColor: 144,111,74
+				RightColor: 128,100,67
 			2: DirtRoad
+				LeftColor: 112,89,62
+				RightColor: 125,99,68
 			3: DirtRoad
+				LeftColor: 124,98,67
+				RightColor: 148,113,74
 	Template@211:
 		Category: Bendy Dirt Roads
 		Id: 211
@@ -1763,11 +3079,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 126,99,68
+				RightColor: 125,99,68
 			1: DirtRoad
+				LeftColor: 137,106,70
+				RightColor: 120,94,64
 			2: DirtRoad
+				LeftColor: 118,93,64
+				RightColor: 110,90,64
 			3: DirtRoad
+				LeftColor: 125,97,66
+				RightColor: 139,107,70
 			4: DirtRoad
+				LeftColor: 140,109,73
+				RightColor: 144,111,73
 			5: DirtRoad
+				LeftColor: 147,112,74
+				RightColor: 137,106,70
 	Template@212:
 		Category: Bendy Dirt Roads
 		Id: 212
@@ -1775,8 +3103,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 140,108,72
+				RightColor: 127,100,68
 			1: DirtRoad
+				LeftColor: 134,104,70
+				RightColor: 116,93,64
 			3: DirtRoad
+				LeftColor: 148,114,76
+				RightColor: 138,106,69
 	Template@213:
 		Category: Bendy Dirt Roads
 		Id: 213
@@ -1784,9 +3118,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 136,106,70
+				RightColor: 122,96,66
 			1: DirtRoad
+				LeftColor: 119,93,62
+				RightColor: 115,91,62
 			2: DirtRoad
+				LeftColor: 131,102,68
+				RightColor: 141,108,70
 			3: DirtRoad
+				LeftColor: 142,109,70
+				RightColor: 139,107,70
 	Template@214:
 		Category: Bendy Dirt Roads
 		Id: 214
@@ -1794,10 +3136,20 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 140,108,72
+				RightColor: 126,99,67
 			1: DirtRoad
+				LeftColor: 138,109,74
+				RightColor: 122,97,68
 			2: DirtRoad
+				LeftColor: 122,96,66
+				RightColor: 115,92,63
 			4: DirtRoad
+				LeftColor: 145,111,72
+				RightColor: 150,114,74
 			5: DirtRoad
+				LeftColor: 140,109,73
+				RightColor: 119,95,66
 	Template@215:
 		Category: Bendy Dirt Roads
 		Id: 215
@@ -1805,9 +3157,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 139,108,72
+				RightColor: 122,97,66
 			1: DirtRoad
+				LeftColor: 128,100,68
+				RightColor: 113,90,62
 			2: DirtRoad
+				LeftColor: 147,113,74
+				RightColor: 150,116,76
 			3: DirtRoad
+				LeftColor: 148,113,73
+				RightColor: 129,101,68
 	Template@216:
 		Category: Bendy Dirt Roads
 		Id: 216
@@ -1815,8 +3175,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
+				LeftColor: 141,110,74
+				RightColor: 112,91,65
 			2: DirtRoad
+				LeftColor: 125,99,67
+				RightColor: 142,109,71
 			3: DirtRoad
+				LeftColor: 143,111,73
+				RightColor: 135,106,71
 	Template@217:
 		Category: Bendy Dirt Roads
 		Id: 217
@@ -1824,9 +3190,17 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 133,104,71
+				RightColor: 112,90,63
 			2: DirtRoad
+				LeftColor: 138,108,71
+				RightColor: 141,109,71
 			3: DirtRoad
+				LeftColor: 139,106,68
+				RightColor: 129,100,66
 			5: DirtRoad
+				LeftColor: 129,101,68
+				RightColor: 124,98,66
 	Template@218:
 		Category: Bendy Dirt Roads
 		Id: 218
@@ -1834,10 +3208,20 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 125,99,67
+				RightColor: 110,90,64
 			2: DirtRoad
+				LeftColor: 152,116,75
+				RightColor: 158,120,77
 			3: DirtRoad
+				LeftColor: 149,115,74
+				RightColor: 130,102,68
 			4: DirtRoad
+				LeftColor: 132,102,68
+				RightColor: 147,114,75
 			5: DirtRoad
+				LeftColor: 123,98,67
+				RightColor: 130,102,68
 	Template@219:
 		Category: Dirt Road Junctions
 		Id: 219
@@ -1845,9 +3229,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 124,97,66
+				RightColor: 142,109,71
 			1: DirtRoad
+				LeftColor: 154,118,77
+				RightColor: 143,111,75
 			2: DirtRoad
+				LeftColor: 126,100,68
+				RightColor: 136,106,71
 			3: DirtRoad
+				LeftColor: 145,113,75
+				RightColor: 153,117,76
 	Template@220:
 		Category: Dirt Road Junctions
 		Id: 220
@@ -1855,9 +3247,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 128,100,68
 			1: DirtRoad
+				LeftColor: 143,110,73
+				RightColor: 129,100,67
 			2: DirtRoad
+				LeftColor: 148,113,73
+				RightColor: 145,111,72
 			3: DirtRoad
+				LeftColor: 146,112,73
+				RightColor: 154,117,76
 	Template@221:
 		Category: Dirt Road Junctions
 		Id: 221
@@ -1865,9 +3265,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 150,115,75
+				RightColor: 153,118,77
 			1: DirtRoad
+				LeftColor: 150,115,74
+				RightColor: 127,101,69
 			2: DirtRoad
+				LeftColor: 147,112,72
+				RightColor: 149,113,72
 			3: DirtRoad
+				LeftColor: 144,111,71
+				RightColor: 123,96,65
 	Template@222:
 		Category: Dirt Road Junctions
 		Id: 222
@@ -1875,9 +3283,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 142,110,73
+				RightColor: 137,107,72
 			1: DirtRoad
+				LeftColor: 156,119,77
+				RightColor: 144,112,75
 			2: DirtRoad
+				LeftColor: 134,104,69
+				RightColor: 141,109,72
 			3: DirtRoad
+				LeftColor: 138,107,71
+				RightColor: 154,118,76
 	Template@223:
 		Category: Dirt Road Junctions
 		Id: 223
@@ -1885,9 +3301,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 139,108,72
+				RightColor: 150,116,76
 			1: DirtRoad
+				LeftColor: 155,120,78
+				RightColor: 145,113,75
 			2: DirtRoad
+				LeftColor: 140,108,71
+				RightColor: 140,108,72
 			3: DirtRoad
+				LeftColor: 143,112,74
+				RightColor: 150,115,75
 	Template@224:
 		Category: Dirt Road Junctions
 		Id: 224
@@ -1895,12 +3319,26 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 138,110,76
+				RightColor: 131,103,70
 			2: DirtRoad
+				LeftColor: 159,121,77
+				RightColor: 158,120,76
 			3: DirtRoad
+				LeftColor: 143,110,73
+				RightColor: 136,105,70
 			4: DirtRoad
+				LeftColor: 150,116,77
+				RightColor: 164,126,82
 			5: DirtRoad
+				LeftColor: 145,112,74
+				RightColor: 140,109,71
 			7: DirtRoad
+				LeftColor: 133,103,69
+				RightColor: 145,112,75
 			8: DirtRoad
+				LeftColor: 151,116,76
+				RightColor: 142,110,73
 	Template@225:
 		Category: Dirt Road Junctions
 		Id: 225
@@ -1908,11 +3346,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 119,94,65
+				RightColor: 110,89,64
 			3: DirtRoad
+				LeftColor: 142,110,72
+				RightColor: 139,107,70
 			4: DirtRoad
+				LeftColor: 155,117,75
+				RightColor: 134,103,67
 			5: DirtRoad
+				LeftColor: 128,99,66
+				RightColor: 112,89,62
 			7: DirtRoad
+				LeftColor: 135,104,69
+				RightColor: 147,112,73
 			8: DirtRoad
+				LeftColor: 151,116,76
+				RightColor: 143,111,73
 	Template@226:
 		Category: Dirt Road Junctions
 		Id: 226
@@ -1920,11 +3370,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 145,112,74
+				RightColor: 127,99,67
 			2: DirtRoad
+				LeftColor: 153,116,74
+				RightColor: 157,120,76
 			3: DirtRoad
+				LeftColor: 141,109,72
+				RightColor: 150,115,74
 			4: DirtRoad
+				LeftColor: 141,109,71
+				RightColor: 149,114,74
 			5: DirtRoad
+				LeftColor: 129,102,70
+				RightColor: 132,103,69
 			7: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 129,101,69
 	Template@227:
 		Category: Dirt Road Junctions
 		Id: 227
@@ -1932,12 +3394,26 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 140,107,71
+				RightColor: 133,103,69
 			2: DirtRoad
+				LeftColor: 159,121,77
+				RightColor: 158,120,77
 			3: DirtRoad
+				LeftColor: 113,91,64
+				RightColor: 135,105,70
 			4: DirtRoad
+				LeftColor: 144,110,71
+				RightColor: 157,120,77
 			5: DirtRoad
+				LeftColor: 150,114,73
+				RightColor: 137,106,70
 			7: DirtRoad
+				LeftColor: 110,87,61
+				RightColor: 130,102,68
 			8: DirtRoad
+				LeftColor: 149,115,75
+				RightColor: 143,111,73
 	Template@228:
 		Category: Dirt Road Junctions
 		Id: 228
@@ -1945,12 +3421,26 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 138,108,74
+				RightColor: 133,103,69
 			2: DirtRoad
+				LeftColor: 160,122,78
+				RightColor: 158,121,77
 			3: DirtRoad
+				LeftColor: 141,109,72
+				RightColor: 148,113,73
 			4: DirtRoad
+				LeftColor: 145,110,71
+				RightColor: 153,117,75
 			5: DirtRoad
+				LeftColor: 147,113,72
+				RightColor: 137,106,70
 			7: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 143,109,71
 			8: DirtRoad
+				LeftColor: 152,116,75
+				RightColor: 144,111,73
 	Template@229:
 		Category: Dirt Road Junctions
 		Id: 229
@@ -1958,18 +3448,44 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
+				LeftColor: 135,108,75
+				RightColor: 137,106,70
 			3: DirtRoad
+				LeftColor: 156,119,75
+				RightColor: 159,120,76
 			5: DirtRoad
+				LeftColor: 127,100,70
+				RightColor: 123,97,67
 			6: DirtRoad
+				LeftColor: 156,120,78
+				RightColor: 157,121,79
 			7: DirtRoad
+				LeftColor: 133,102,68
+				RightColor: 128,100,67
 			8: DirtRoad
+				LeftColor: 152,116,75
+				RightColor: 127,100,68
 			9: DirtRoad
+				LeftColor: 146,113,75
+				RightColor: 158,121,79
 			10: DirtRoad
+				LeftColor: 152,120,83
+				RightColor: 151,119,81
 			11: DirtRoad
+				LeftColor: 150,117,78
+				RightColor: 135,105,70
 			12: DirtRoad
+				LeftColor: 137,106,70
+				RightColor: 153,117,76
 			13: DirtRoad
+				LeftColor: 132,105,73
+				RightColor: 150,116,77
 			14: DirtRoad
+				LeftColor: 138,107,72
+				RightColor: 145,114,79
 			15: DirtRoad
+				LeftColor: 134,104,69
+				RightColor: 149,115,76
 	Template@230:
 		Category: Straight Dirt Roads
 		Id: 230
@@ -1977,14 +3493,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
+				LeftColor: 135,107,75
+				RightColor: 129,101,68
 			3: DirtRoad
+				LeftColor: 160,122,77
+				RightColor: 158,120,77
 			5: DirtRoad
+				LeftColor: 126,101,72
+				RightColor: 123,97,67
 			6: DirtRoad
+				LeftColor: 161,123,78
+				RightColor: 159,122,78
 			7: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 136,106,70
 			8: DirtRoad
+				LeftColor: 141,109,72
+				RightColor: 134,103,68
 			9: DirtRoad
+				LeftColor: 135,104,69
+				RightColor: 147,113,74
 			10: DirtRoad
+				LeftColor: 128,101,69
+				RightColor: 134,103,67
 			13: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 129,101,68
 	Template@231:
 		Category: Straight Dirt Roads
 		Id: 231
@@ -1992,14 +3526,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
+				LeftColor: 133,106,74
+				RightColor: 135,104,69
 			3: DirtRoad
+				LeftColor: 155,118,75
+				RightColor: 159,120,76
 			5: DirtRoad
+				LeftColor: 126,100,70
+				RightColor: 122,96,66
 			6: DirtRoad
+				LeftColor: 155,120,79
+				RightColor: 153,118,78
 			7: DirtRoad
+				LeftColor: 121,95,64
+				RightColor: 127,100,67
 			8: DirtRoad
+				LeftColor: 134,105,72
+				RightColor: 127,101,70
 			9: DirtRoad
+				LeftColor: 148,112,72
+				RightColor: 153,118,76
 			10: DirtRoad
+				LeftColor: 135,107,74
+				RightColor: 133,106,75
 			13: DirtRoad
+				LeftColor: 138,106,69
+				RightColor: 137,107,71
 	Template@232:
 		Category: Straight Dirt Roads
 		Id: 232
@@ -2007,14 +3559,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
+				LeftColor: 129,100,67
+				RightColor: 130,100,65
 			3: DirtRoad
+				LeftColor: 143,109,71
+				RightColor: 150,114,72
 			5: DirtRoad
+				LeftColor: 121,94,63
+				RightColor: 114,91,63
 			6: DirtRoad
+				LeftColor: 124,99,70
+				RightColor: 133,104,69
 			7: DirtRoad
+				LeftColor: 131,101,66
+				RightColor: 121,94,63
 			8: DirtRoad
+				LeftColor: 135,105,71
+				RightColor: 135,105,70
 			9: DirtRoad
+				LeftColor: 148,113,72
+				RightColor: 137,103,65
 			10: DirtRoad
+				LeftColor: 124,97,65
+				RightColor: 122,97,66
 			13: DirtRoad
+				LeftColor: 139,107,70
+				RightColor: 134,104,70
 	Template@233:
 		Category: Straight Dirt Roads
 		Id: 233
@@ -2022,17 +3592,41 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			0: Clear
+				LeftColor: 119,94,64
+				RightColor: 117,92,63
 			1: Clear
+				LeftColor: 142,109,71
+				RightColor: 125,98,67
 			2: DirtRoad
+				LeftColor: 156,119,76
+				RightColor: 147,113,74
 			3: DirtRoad
+				LeftColor: 156,118,74
+				RightColor: 157,118,74
 			4: Clear
+				LeftColor: 124,99,68
+				RightColor: 136,105,69
 			5: DirtRoad
+				LeftColor: 158,120,77
+				RightColor: 162,124,79
 			6: DirtRoad
+				LeftColor: 133,102,67
+				RightColor: 140,107,68
 			7: DirtRoad
+				LeftColor: 118,93,65
+				RightColor: 122,95,63
 			8: DirtRoad
+				LeftColor: 142,110,74
+				RightColor: 145,111,72
 			9: DirtRoad
+				LeftColor: 157,119,75
+				RightColor: 145,111,72
 			10: DirtRoad
+				LeftColor: 117,93,64
+				RightColor: 111,89,61
 			13: DirtRoad
+				LeftColor: 138,107,70
+				RightColor: 136,106,70
 	Template@234:
 		Category: Straight Dirt Roads
 		Id: 234
@@ -2040,11 +3634,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 140,107,69
+				RightColor: 141,107,69
 			2: DirtRoad
+				LeftColor: 158,120,77
+				RightColor: 155,118,75
 			3: DirtRoad
+				LeftColor: 137,108,72
+				RightColor: 136,105,69
 			4: DirtRoad
+				LeftColor: 162,123,78
+				RightColor: 155,118,75
 			5: DirtRoad
+				LeftColor: 125,97,65
+				RightColor: 128,98,64
 			7: DirtRoad
+				LeftColor: 134,105,70
+				RightColor: 134,105,70
 	Template@235:
 		Category: Straight Dirt Roads
 		Id: 235
@@ -2052,8 +3658,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 135,107,75
+				RightColor: 144,112,73
 			1: DirtRoad
+				LeftColor: 160,122,78
+				RightColor: 159,121,77
 			3: DirtRoad
+				LeftColor: 143,108,68
+				RightColor: 139,107,70
 	Template@236:
 		Category: Straight Dirt Roads
 		Id: 236
@@ -2061,8 +3673,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 143,109,71
+				RightColor: 136,104,68
 			1: DirtRoad
+				LeftColor: 157,119,75
+				RightColor: 157,119,75
 			3: DirtRoad
+				LeftColor: 135,104,69
+				RightColor: 131,101,67
 	Template@237:
 		Category: Straight Dirt Roads
 		Id: 237
@@ -2070,13 +3688,29 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			2: Clear
+				LeftColor: 113,90,63
+				RightColor: 110,88,61
 			5: DirtRoad
+				LeftColor: 124,97,67
+				RightColor: 117,94,65
 			6: Clear
+				LeftColor: 121,97,68
+				RightColor: 116,93,67
 			7: Clear
+				LeftColor: 119,94,66
+				RightColor: 115,91,63
 			8: DirtRoad
+				LeftColor: 137,108,73
+				RightColor: 119,93,63
 			9: DirtRoad
+				LeftColor: 146,110,70
+				RightColor: 135,103,66
 			10: DirtRoad
+				LeftColor: 118,93,64
+				RightColor: 118,94,65
 			13: DirtRoad
+				LeftColor: 131,102,68
+				RightColor: 133,104,70
 	Template@238:
 		Category: Straight Dirt Roads
 		Id: 238
@@ -2084,14 +3718,32 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			1: Clear
+				LeftColor: 116,93,66
+				RightColor: 114,91,65
 			2: Clear
+				LeftColor: 123,99,69
+				RightColor: 121,97,68
 			3: Clear
+				LeftColor: 115,91,64
+				RightColor: 112,89,63
 			4: DirtRoad
+				LeftColor: 136,107,73
+				RightColor: 131,105,73
 			5: DirtRoad
+				LeftColor: 154,120,81
+				RightColor: 137,109,78
 			6: DirtRoad
+				LeftColor: 133,108,78
+				RightColor: 126,101,72
 			7: DirtRoad
+				LeftColor: 117,93,66
+				RightColor: 113,90,63
 			9: DirtRoad
+				LeftColor: 139,108,71
+				RightColor: 146,113,76
 			10: Clear
+				LeftColor: 118,96,70
+				RightColor: 118,95,68
 	Template@239:
 		Category: Straight Dirt Roads
 		Id: 239
@@ -2099,11 +3751,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: Clear
+				LeftColor: 123,98,68
+				RightColor: 119,95,67
 			2: Clear
+				LeftColor: 129,102,71
+				RightColor: 114,91,63
 			3: DirtRoad
+				LeftColor: 135,105,71
+				RightColor: 135,105,71
 			4: DirtRoad
+				LeftColor: 144,110,71
+				RightColor: 134,104,70
 			5: Clear
+				LeftColor: 117,93,65
+				RightColor: 119,94,64
 			7: DirtRoad
+				LeftColor: 138,106,69
+				RightColor: 132,103,69
 	Template@240:
 		Category: Straight Dirt Roads
 		Id: 240
@@ -2111,14 +3775,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
+				LeftColor: 128,99,65
+				RightColor: 132,102,67
 			3: DirtRoad
+				LeftColor: 142,109,71
+				RightColor: 145,111,71
 			5: DirtRoad
+				LeftColor: 115,91,62
+				RightColor: 116,91,62
 			6: DirtRoad
+				LeftColor: 123,97,66
+				RightColor: 138,105,67
 			7: DirtRoad
+				LeftColor: 132,101,65
+				RightColor: 131,101,66
 			8: Clear
+				LeftColor: 113,89,61
+				RightColor: 118,91,61
 			9: Clear
+				LeftColor: 126,97,64
+				RightColor: 130,99,63
 			10: DirtRoad
+				LeftColor: 122,94,62
+				RightColor: 119,93,62
 			13: Clear
+				LeftColor: 115,91,64
+				RightColor: 119,93,63
 	Template@241:
 		Category: Straight Dirt Roads
 		Id: 241
@@ -2126,14 +3808,32 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 121,95,63
+				RightColor: 133,102,67
 			2: DirtRoad
+				LeftColor: 126,97,65
+				RightColor: 149,114,73
 			3: Clear
+				LeftColor: 112,90,63
+				RightColor: 130,100,67
 			4: Clear
+				LeftColor: 147,112,72
+				RightColor: 140,106,67
 			5: DirtRoad
+				LeftColor: 119,93,64
+				RightColor: 126,98,64
 			6: Clear
+				LeftColor: 121,96,68
+				RightColor: 132,104,73
 			7: Clear
+				LeftColor: 134,103,67
+				RightColor: 131,101,67
 			9: Clear
+				LeftColor: 114,93,67
+				RightColor: 120,96,67
 			10: Clear
+				LeftColor: 115,92,65
+				RightColor: 122,96,65
 	Template@242:
 		Category: Straight Dirt Roads
 		Id: 242
@@ -2141,11 +3841,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 121,97,68
+				RightColor: 125,99,68
 			2: DirtRoad
+				LeftColor: 137,106,70
+				RightColor: 156,119,76
 			3: Clear
+				LeftColor: 118,96,69
+				RightColor: 116,93,65
 			4: DirtRoad
+				LeftColor: 129,101,69
+				RightColor: 137,107,71
 			5: DirtRoad
+				LeftColor: 129,100,67
+				RightColor: 127,100,67
 			7: Clear
+				LeftColor: 111,89,63
+				RightColor: 124,99,69
 	Template@243:
 		Category: Straight Dirt Roads
 		Id: 243
@@ -2153,15 +3865,35 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 125,98,66
+				RightColor: 122,97,66
 			2: DirtRoad
+				LeftColor: 151,115,73
+				RightColor: 133,101,65
 			3: DirtRoad
+				LeftColor: 160,121,77
+				RightColor: 150,114,74
 			4: DirtRoad
+				LeftColor: 161,123,79
+				RightColor: 163,124,79
 			5: DirtRoad
+				LeftColor: 133,104,69
+				RightColor: 131,102,67
 			6: DirtRoad
+				LeftColor: 157,119,75
+				RightColor: 153,116,73
 			7: DirtRoad
+				LeftColor: 138,107,70
+				RightColor: 151,115,73
 			8: DirtRoad
+				LeftColor: 132,102,68
+				RightColor: 141,109,71
 			9: DirtRoad
+				LeftColor: 117,93,64
+				RightColor: 125,99,67
 			11: DirtRoad
+				LeftColor: 138,107,71
+				RightColor: 134,103,68
 	Template@244:
 		Category: Straight Dirt Roads
 		Id: 244
@@ -2169,15 +3901,35 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			1: DirtRoad
+				LeftColor: 121,95,64
+				RightColor: 123,96,65
 			2: DirtRoad
+				LeftColor: 144,111,72
+				RightColor: 159,123,80
 			3: DirtRoad
+				LeftColor: 121,97,67
+				RightColor: 119,95,66
 			4: DirtRoad
+				LeftColor: 140,108,71
+				RightColor: 143,111,73
 			5: DirtRoad
+				LeftColor: 127,101,70
+				RightColor: 134,105,70
 			6: DirtRoad
+				LeftColor: 121,95,65
+				RightColor: 140,108,72
 			7: DirtRoad
+				LeftColor: 126,99,67
+				RightColor: 122,96,65
 			9: DirtRoad
+				LeftColor: 142,111,74
+				RightColor: 132,103,69
 			10: DirtRoad
+				LeftColor: 130,100,66
+				RightColor: 123,97,66
 			13: DirtRoad
+				LeftColor: 133,104,69
+				RightColor: 121,97,67
 	Template@245:
 		Category: Straight Dirt Roads
 		Id: 245
@@ -2185,11 +3937,23 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			1: Clear
+				LeftColor: 123,97,67
+				RightColor: 118,94,65
 			2: Clear
+				LeftColor: 120,97,68
+				RightColor: 122,98,67
 			3: Clear
+				LeftColor: 125,100,71
+				RightColor: 121,98,69
 			4: Clear
+				LeftColor: 130,103,71
+				RightColor: 132,104,71
 			5: Clear
+				LeftColor: 117,93,65
+				RightColor: 114,91,63
 			6: Clear
+				LeftColor: 113,89,62
+				RightColor: 119,95,66
 	Template@246:
 		Category: Straight Dirt Roads
 		Id: 246
@@ -2197,13 +3961,29 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 137,107,71
+				RightColor: 122,96,65
 			1: DirtRoad
+				LeftColor: 123,98,67
+				RightColor: 121,96,67
 			2: DirtRoad
+				LeftColor: 119,94,64
+				RightColor: 117,93,63
 			3: DirtRoad
+				LeftColor: 138,107,71
+				RightColor: 129,100,67
 			4: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 139,108,71
 			5: DirtRoad
+				LeftColor: 126,99,68
+				RightColor: 143,110,72
 			6: DirtRoad
+				LeftColor: 132,102,67
+				RightColor: 144,111,72
 			7: DirtRoad
+				LeftColor: 131,102,68
+				RightColor: 152,116,75
 	Template@247:
 		Category: Straight Dirt Roads
 		Id: 247
@@ -2211,13 +3991,29 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 126,98,66
 			1: DirtRoad
+				LeftColor: 146,112,74
+				RightColor: 142,110,73
 			2: DirtRoad
+				LeftColor: 145,112,73
+				RightColor: 133,104,70
 			3: DirtRoad
+				LeftColor: 150,115,74
+				RightColor: 128,100,68
 			4: DirtRoad
+				LeftColor: 129,101,68
+				RightColor: 137,106,69
 			5: DirtRoad
+				LeftColor: 121,97,67
+				RightColor: 137,107,71
 			6: DirtRoad
+				LeftColor: 118,95,67
+				RightColor: 133,105,71
 			7: DirtRoad
+				LeftColor: 120,94,65
+				RightColor: 148,114,74
 	Template@248:
 		Category: Straight Dirt Roads
 		Id: 248
@@ -2225,13 +4021,29 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 151,116,75
+				RightColor: 126,100,68
 			1: DirtRoad
+				LeftColor: 140,109,73
+				RightColor: 129,101,68
 			2: DirtRoad
+				LeftColor: 125,100,70
+				RightColor: 119,96,67
 			3: DirtRoad
+				LeftColor: 146,113,76
+				RightColor: 125,98,67
 			4: DirtRoad
+				LeftColor: 137,106,70
+				RightColor: 147,113,76
 			5: DirtRoad
+				LeftColor: 127,102,72
+				RightColor: 144,112,75
 			6: DirtRoad
+				LeftColor: 131,104,71
+				RightColor: 145,114,79
 			7: DirtRoad
+				LeftColor: 134,104,69
+				RightColor: 149,115,76
 	Template@249:
 		Category: Straight Dirt Roads
 		Id: 249
@@ -2239,13 +4051,29 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 140,106,68
+				RightColor: 126,97,64
 			1: DirtRoad
+				LeftColor: 139,107,70
+				RightColor: 137,105,68
 			2: DirtRoad
+				LeftColor: 146,112,73
+				RightColor: 126,99,67
 			3: DirtRoad
+				LeftColor: 139,107,70
+				RightColor: 126,99,67
 			4: DirtRoad
+				LeftColor: 126,100,69
+				RightColor: 148,112,70
 			5: DirtRoad
+				LeftColor: 128,100,68
+				RightColor: 142,110,72
 			6: DirtRoad
+				LeftColor: 124,97,64
+				RightColor: 146,112,72
 			7: DirtRoad
+				LeftColor: 124,97,65
+				RightColor: 145,111,71
 	Template@250:
 		Category: Straight Dirt Roads
 		Id: 250
@@ -2253,11 +4081,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 138,107,71
+				RightColor: 125,98,66
 			1: DirtRoad
+				LeftColor: 136,105,69
+				RightColor: 130,101,68
 			2: DirtRoad
+				LeftColor: 141,108,70
+				RightColor: 130,101,67
 			3: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 140,108,70
 			4: DirtRoad
+				LeftColor: 126,98,66
+				RightColor: 142,109,71
 			5: DirtRoad
+				LeftColor: 122,95,64
+				RightColor: 148,112,71
 	Template@251:
 		Category: Straight Dirt Roads
 		Id: 251
@@ -2265,9 +4105,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 124,97,67
 			1: DirtRoad
+				LeftColor: 134,105,73
+				RightColor: 126,99,68
 			2: DirtRoad
+				LeftColor: 127,99,66
+				RightColor: 142,110,73
 			3: DirtRoad
+				LeftColor: 133,105,71
+				RightColor: 144,112,74
 	Template@252:
 		Category: Straight Dirt Roads
 		Id: 252
@@ -2275,7 +4123,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 126,99,68
 			1: DirtRoad
+				LeftColor: 134,104,70
+				RightColor: 146,112,72
 	Template@253:
 		Category: Straight Dirt Roads
 		Id: 253
@@ -2283,7 +4135,11 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 143,109,71
+				RightColor: 124,97,66
 			1: DirtRoad
+				LeftColor: 127,98,64
+				RightColor: 139,107,70
 	Template@254:
 		Category: Straight Dirt Roads
 		Id: 254
@@ -2291,11 +4147,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 140,108,71
+				RightColor: 125,97,65
 			1: DirtRoad
+				LeftColor: 133,103,69
+				RightColor: 118,93,63
 			2: Clear
+				LeftColor: 120,95,65
+				RightColor: 111,90,64
 			3: DirtRoad
+				LeftColor: 129,101,68
+				RightColor: 145,111,72
 			4: DirtRoad
+				LeftColor: 128,100,67
+				RightColor: 133,102,66
 			5: Clear
+				LeftColor: 116,92,65
+				RightColor: 115,91,62
 	Template@255:
 		Category: Straight Dirt Roads
 		Id: 255
@@ -2303,9 +4171,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 151,116,75
+				RightColor: 113,91,63
 			1: Clear
+				LeftColor: 117,94,66
+				RightColor: 110,89,65
 			2: DirtRoad
+				LeftColor: 129,101,68
+				RightColor: 140,109,73
 			3: Clear
+				LeftColor: 116,93,66
+				RightColor: 116,93,66
 	Template@256:
 		Category: Straight Dirt Roads
 		Id: 256
@@ -2313,12 +4189,26 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: Clear
+				LeftColor: 113,92,66
+				RightColor: 111,90,66
 			2: Clear
+				LeftColor: 117,94,68
+				RightColor: 109,89,65
 			3: DirtRoad
+				LeftColor: 136,106,71
+				RightColor: 122,97,67
 			4: DirtRoad
+				LeftColor: 138,107,72
+				RightColor: 128,103,73
 			5: Clear
+				LeftColor: 115,93,68
+				RightColor: 117,95,68
 			6: DirtRoad
+				LeftColor: 132,104,71
+				RightColor: 135,106,72
 			7: DirtRoad
+				LeftColor: 117,94,67
+				RightColor: 119,95,66
 	Template@257:
 		Category: Straight Dirt Roads
 		Id: 257
@@ -2326,11 +4216,23 @@ Templates:
 		Size: 3, 2
 		Tiles:
 			0: Clear
+				LeftColor: 121,94,64
+				RightColor: 119,94,64
 			1: DirtRoad
+				LeftColor: 136,107,73
+				RightColor: 120,95,67
 			2: DirtRoad
+				LeftColor: 141,110,73
+				RightColor: 129,101,68
 			3: Clear
+				LeftColor: 117,93,65
+				RightColor: 131,102,67
 			4: DirtRoad
+				LeftColor: 121,97,67
+				RightColor: 139,107,71
 			5: DirtRoad
+				LeftColor: 132,104,71
+				RightColor: 154,118,75
 	Template@258:
 		Category: Straight Dirt Roads
 		Id: 258
@@ -2338,9 +4240,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Clear
+				LeftColor: 120,97,69
+				RightColor: 114,91,63
 			1: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 128,101,69
 			2: Clear
+				LeftColor: 119,95,67
+				RightColor: 126,98,66
 			3: DirtRoad
+				LeftColor: 113,90,63
+				RightColor: 141,110,73
 	Template@259:
 		Category: Straight Dirt Roads
 		Id: 259
@@ -2348,9 +4258,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Clear
+				LeftColor: 120,94,63
+				RightColor: 124,97,65
 			1: DirtRoad
+				LeftColor: 143,108,69
+				RightColor: 124,98,67
 			2: Clear
+				LeftColor: 119,95,65
+				RightColor: 120,95,65
 			3: DirtRoad
+				LeftColor: 123,97,66
+				RightColor: 146,112,73
 	Template@260:
 		Category: Straight Dirt Roads
 		Id: 260
@@ -2358,13 +4276,29 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: DirtRoad
+				LeftColor: 144,111,72
+				RightColor: 124,97,66
 			1: Clear
+				LeftColor: 132,104,71
+				RightColor: 115,93,64
 			4: DirtRoad
+				LeftColor: 127,100,68
+				RightColor: 138,105,68
 			5: DirtRoad
+				LeftColor: 129,99,65
+				RightColor: 150,114,73
 			6: DirtRoad
+				LeftColor: 136,105,70
+				RightColor: 122,96,65
 			7: DirtRoad
+				LeftColor: 137,107,72
+				RightColor: 126,99,68
 			10: Clear
+				LeftColor: 115,93,67
+				RightColor: 123,97,67
 			11: DirtRoad
+				LeftColor: 120,95,65
+				RightColor: 139,108,72
 	Template@261:
 		Category: Straight Dirt Roads
 		Id: 261
@@ -2372,13 +4306,29 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			2: Clear
+				LeftColor: 124,97,65
+				RightColor: 119,94,66
 			3: DirtRoad
+				LeftColor: 147,113,73
+				RightColor: 125,98,66
 			4: DirtRoad
+				LeftColor: 145,112,73
+				RightColor: 127,99,68
 			5: DirtRoad
+				LeftColor: 139,107,70
+				RightColor: 133,102,66
 			6: DirtRoad
+				LeftColor: 123,96,64
+				RightColor: 132,103,69
 			7: DirtRoad
+				LeftColor: 129,100,67
+				RightColor: 144,110,70
 			8: DirtRoad
+				LeftColor: 122,95,64
+				RightColor: 130,101,67
 			9: Clear
+				LeftColor: 118,94,65
+				RightColor: 121,96,66
 	Template@262:
 		Category: Straight Dirt Roads
 		Id: 262
@@ -2386,13 +4336,29 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: Clear
+				LeftColor: 117,93,64
+				RightColor: 120,94,63
 			1: Clear
+				LeftColor: 136,105,70
+				RightColor: 125,99,66
 			2: Clear
+				LeftColor: 134,103,69
+				RightColor: 115,93,65
 			3: Clear
+				LeftColor: 122,95,64
+				RightColor: 112,89,63
 			4: Clear
+				LeftColor: 112,90,64
+				RightColor: 118,93,64
 			5: Clear
+				LeftColor: 115,91,63
+				RightColor: 146,112,74
 			6: Clear
+				LeftColor: 132,102,67
+				RightColor: 137,104,67
 			7: Clear
+				LeftColor: 121,97,68
+				RightColor: 117,93,64
 	Template@263:
 		Category: Straight Dirt Roads
 		Id: 263
@@ -2400,14 +4366,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 119,95,65
+				RightColor: 110,90,64
 			4: DirtRoad
+				LeftColor: 113,91,64
+				RightColor: 135,105,70
 			5: DirtRoad
+				LeftColor: 144,110,72
+				RightColor: 133,104,70
 			6: DirtRoad
+				LeftColor: 123,98,67
+				RightColor: 108,88,64
 			9: DirtRoad
+				LeftColor: 114,92,65
+				RightColor: 134,104,69
 			10: DirtRoad
+				LeftColor: 145,111,72
+				RightColor: 141,109,71
 			11: DirtRoad
+				LeftColor: 129,100,67
+				RightColor: 112,89,62
 			14: DirtRoad
+				LeftColor: 110,87,61
+				RightColor: 130,102,68
 			15: DirtRoad
+				LeftColor: 149,115,75
+				RightColor: 142,110,73
 	Template@264:
 		Category: Straight Dirt Roads
 		Id: 264
@@ -2415,14 +4399,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 127,101,69
+				RightColor: 110,89,64
 			4: DirtRoad
+				LeftColor: 113,92,67
+				RightColor: 134,105,70
 			5: DirtRoad
+				LeftColor: 144,109,70
+				RightColor: 134,104,68
 			6: DirtRoad
+				LeftColor: 122,96,65
+				RightColor: 110,88,61
 			9: DirtRoad
+				LeftColor: 112,89,62
+				RightColor: 131,103,69
 			10: DirtRoad
+				LeftColor: 139,107,70
+				RightColor: 137,106,69
 			11: DirtRoad
+				LeftColor: 127,99,66
+				RightColor: 110,90,64
 			14: DirtRoad
+				LeftColor: 113,92,67
+				RightColor: 125,99,67
 			15: DirtRoad
+				LeftColor: 135,104,69
+				RightColor: 148,113,74
 	Template@265:
 		Category: Straight Dirt Roads
 		Id: 265
@@ -2430,14 +4432,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 136,107,71
+				RightColor: 114,91,63
 			4: DirtRoad
+				LeftColor: 115,94,68
+				RightColor: 134,105,71
 			5: DirtRoad
+				LeftColor: 133,105,71
+				RightColor: 135,105,70
 			6: DirtRoad
+				LeftColor: 132,105,71
+				RightColor: 120,96,66
 			9: DirtRoad
+				LeftColor: 114,90,62
+				RightColor: 134,105,69
 			10: DirtRoad
+				LeftColor: 140,109,73
+				RightColor: 132,104,71
 			11: DirtRoad
+				LeftColor: 130,102,69
+				RightColor: 113,90,62
 			14: DirtRoad
+				LeftColor: 114,91,64
+				RightColor: 129,102,69
 			15: DirtRoad
+				LeftColor: 139,108,72
+				RightColor: 134,104,69
 	Template@266:
 		Category: Straight Dirt Roads
 		Id: 266
@@ -2445,14 +4465,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 122,96,65
+				RightColor: 110,89,64
 			4: DirtRoad
+				LeftColor: 115,93,65
+				RightColor: 135,106,71
 			5: DirtRoad
+				LeftColor: 136,106,71
+				RightColor: 132,103,69
 			6: DirtRoad
+				LeftColor: 129,102,69
+				RightColor: 110,89,64
 			9: DirtRoad
+				LeftColor: 113,91,64
+				RightColor: 131,103,69
 			10: DirtRoad
+				LeftColor: 128,100,66
+				RightColor: 146,113,74
 			11: DirtRoad
+				LeftColor: 129,102,70
+				RightColor: 115,93,66
 			14: DirtRoad
+				LeftColor: 115,93,66
+				RightColor: 124,99,68
 			15: DirtRoad
+				LeftColor: 144,111,74
+				RightColor: 137,107,71
 	Template@267:
 		Category: Straight Dirt Roads
 		Id: 267
@@ -2460,11 +4498,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 129,101,68
+				RightColor: 112,89,62
 			3: DirtRoad
+				LeftColor: 113,90,62
+				RightColor: 129,101,68
 			4: DirtRoad
+				LeftColor: 138,107,71
+				RightColor: 138,107,71
 			5: DirtRoad
+				LeftColor: 135,106,71
+				RightColor: 118,94,65
 			7: DirtRoad
+				LeftColor: 114,91,63
+				RightColor: 129,100,67
 			8: DirtRoad
+				LeftColor: 147,113,74
+				RightColor: 145,112,74
 	Template@268:
 		Category: Straight Dirt Roads
 		Id: 268
@@ -2472,8 +4522,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
+				LeftColor: 130,102,68
+				RightColor: 112,89,62
 			2: DirtRoad
+				LeftColor: 115,92,64
+				RightColor: 134,105,71
 			3: DirtRoad
+				LeftColor: 142,109,72
+				RightColor: 145,113,75
 	Template@269:
 		Category: Straight Dirt Roads
 		Id: 269
@@ -2481,8 +4537,14 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
+				LeftColor: 123,96,64
+				RightColor: 110,88,61
 			2: DirtRoad
+				LeftColor: 114,91,63
+				RightColor: 133,104,70
 			3: DirtRoad
+				LeftColor: 139,108,71
+				RightColor: 140,108,72
 	Template@270:
 		Category: Straight Dirt Roads
 		Id: 270
@@ -2490,14 +4552,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 139,108,72
+				RightColor: 115,92,63
 			4: DirtRoad
+				LeftColor: 110,88,63
+				RightColor: 133,105,71
 			5: DirtRoad
+				LeftColor: 146,112,74
+				RightColor: 144,111,73
 			6: DirtRoad
+				LeftColor: 125,98,67
+				RightColor: 112,89,62
 			9: DirtRoad
+				LeftColor: 112,91,65
+				RightColor: 129,102,70
 			10: DirtRoad
+				LeftColor: 129,101,69
+				RightColor: 130,102,69
 			11: Clear
+				LeftColor: 117,92,64
+				RightColor: 112,89,62
 			14: Clear
+				LeftColor: 112,88,61
+				RightColor: 122,96,66
 			15: Clear
+				LeftColor: 117,94,66
+				RightColor: 119,95,66
 	Template@271:
 		Category: Straight Dirt Roads
 		Id: 271
@@ -2505,15 +4585,35 @@ Templates:
 		Size: 4, 5
 		Tiles:
 			1: DirtRoad
+				LeftColor: 148,114,75
+				RightColor: 116,92,65
 			4: DirtRoad
+				LeftColor: 110,88,63
+				RightColor: 134,106,72
 			5: DirtRoad
+				LeftColor: 146,113,75
+				RightColor: 145,112,74
 			6: Clear
+				LeftColor: 123,96,66
+				RightColor: 111,90,64
 			9: Clear
+				LeftColor: 121,96,67
+				RightColor: 129,101,69
 			10: Clear
+				LeftColor: 125,97,66
+				RightColor: 123,96,65
 			11: Clear
+				LeftColor: 114,90,62
+				RightColor: 113,90,63
 			13: Clear
+				LeftColor: 114,91,64
+				RightColor: 118,93,64
 			14: Clear
+				LeftColor: 115,91,63
+				RightColor: 115,91,63
 			18: Clear
+				LeftColor: 114,92,66
+				RightColor: 117,93,65
 	Template@272:
 		Category: Straight Dirt Roads
 		Id: 272
@@ -2521,11 +4621,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 128,100,68
+				RightColor: 111,89,62
 			3: DirtRoad
+				LeftColor: 112,91,65
+				RightColor: 134,105,72
 			4: DirtRoad
+				LeftColor: 139,107,71
+				RightColor: 131,102,69
 			5: DirtRoad
+				LeftColor: 117,93,64
+				RightColor: 112,89,62
 			7: DirtRoad
+				LeftColor: 110,87,61
+				RightColor: 122,96,66
 			8: DirtRoad
+				LeftColor: 121,97,68
+				RightColor: 123,97,67
 	Template@273:
 		Category: Straight Dirt Roads
 		Id: 273
@@ -2533,14 +4645,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: Clear
+				LeftColor: 118,95,66
+				RightColor: 118,94,65
 			4: Clear
+				LeftColor: 114,91,64
+				RightColor: 118,93,65
 			5: Clear
+				LeftColor: 120,94,65
+				RightColor: 125,98,67
 			6: Clear
+				LeftColor: 124,99,70
+				RightColor: 112,90,63
 			9: Clear
+				LeftColor: 114,92,65
+				RightColor: 127,100,68
 			10: DirtRoad
+				LeftColor: 137,108,74
+				RightColor: 128,101,70
 			11: DirtRoad
+				LeftColor: 131,103,69
+				RightColor: 114,92,65
 			14: DirtRoad
+				LeftColor: 115,92,63
+				RightColor: 126,99,67
 			15: DirtRoad
+				LeftColor: 136,105,69
+				RightColor: 141,109,72
 	Template@274:
 		Category: Straight Dirt Roads
 		Id: 274
@@ -2548,11 +4678,23 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Clear
+				LeftColor: 114,91,65
+				RightColor: 114,91,63
 			1: Clear
+				LeftColor: 116,92,63
+				RightColor: 110,88,61
 			2: Clear
+				LeftColor: 112,88,61
+				RightColor: 127,100,68
 			3: DirtRoad
+				LeftColor: 136,106,72
+				RightColor: 117,94,65
 			4: DirtRoad
+				LeftColor: 112,89,63
+				RightColor: 116,92,65
 			5: DirtRoad
+				LeftColor: 140,109,72
+				RightColor: 144,110,72
 	Template@275:
 		Category: Straight Dirt Roads
 		Id: 275
@@ -2560,11 +4702,23 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: Clear
+				LeftColor: 115,90,61
+				RightColor: 110,88,61
 			3: Clear
+				LeftColor: 110,87,61
+				RightColor: 111,88,60
 			4: Clear
+				LeftColor: 121,95,64
+				RightColor: 124,96,65
 			5: DirtRoad
+				LeftColor: 124,96,63
+				RightColor: 114,90,62
 			7: DirtRoad
+				LeftColor: 117,93,65
+				RightColor: 129,99,63
 			8: DirtRoad
+				LeftColor: 135,105,70
+				RightColor: 140,108,72
 	Template@276:
 		Category: Straight Dirt Roads
 		Id: 276
@@ -2572,16 +4726,38 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			1: DirtRoad
+				LeftColor: 141,109,71
+				RightColor: 120,94,65
 			2: Clear
+				LeftColor: 125,97,65
+				RightColor: 115,91,63
 			5: DirtRoad
+				LeftColor: 113,90,64
+				RightColor: 139,108,71
 			6: DirtRoad
+				LeftColor: 142,109,71
+				RightColor: 141,107,68
 			7: DirtRoad
+				LeftColor: 140,107,68
+				RightColor: 133,103,68
 			8: DirtRoad
+				LeftColor: 131,102,69
+				RightColor: 125,98,66
 			9: Clear
+				LeftColor: 130,102,70
+				RightColor: 111,90,64
 			11: Clear
+				LeftColor: 120,96,66
+				RightColor: 127,100,67
 			12: DirtRoad
+				LeftColor: 115,92,64
+				RightColor: 131,102,68
 			13: DirtRoad
+				LeftColor: 129,100,67
+				RightColor: 141,107,69
 			14: DirtRoad
+				LeftColor: 147,114,76
+				RightColor: 142,110,72
 	Template@277:
 		Category: Straight Dirt Roads
 		Id: 277
@@ -2589,15 +4765,35 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			1: DirtRoad
+				LeftColor: 120,95,65
+				RightColor: 115,91,62
 			3: DirtRoad
+				LeftColor: 121,96,67
+				RightColor: 139,108,71
 			4: DirtRoad
+				LeftColor: 143,112,76
+				RightColor: 126,99,67
 			6: Clear
+				LeftColor: 114,91,63
+				RightColor: 122,97,67
 			7: DirtRoad
+				LeftColor: 143,112,75
+				RightColor: 150,117,78
 			8: Clear
+				LeftColor: 127,102,71
+				RightColor: 111,90,63
 			10: DirtRoad
+				LeftColor: 125,100,71
+				RightColor: 139,109,73
 			11: DirtRoad
+				LeftColor: 146,113,74
+				RightColor: 119,94,65
 			13: Clear
+				LeftColor: 111,90,64
+				RightColor: 126,101,71
 			14: DirtRoad
+				LeftColor: 134,105,72
+				RightColor: 140,109,74
 	Template@278:
 		Category: Straight Dirt Roads
 		Id: 278
@@ -2605,14 +4801,32 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: Clear
+				LeftColor: 115,92,64
+				RightColor: 112,89,62
 			4: Clear
+				LeftColor: 112,89,63
+				RightColor: 113,91,64
 			5: DirtRoad
+				LeftColor: 129,103,71
+				RightColor: 127,100,68
 			6: Clear
+				LeftColor: 115,92,64
+				RightColor: 111,90,65
 			9: Clear
+				LeftColor: 111,90,64
+				RightColor: 118,95,68
 			10: DirtRoad
+				LeftColor: 128,101,69
+				RightColor: 127,100,69
 			11: Clear
+				LeftColor: 122,96,67
+				RightColor: 111,88,61
 			14: Clear
+				LeftColor: 110,87,61
+				RightColor: 119,95,65
 			15: Clear
+				LeftColor: 120,96,66
+				RightColor: 123,97,67
 	Template@279:
 		Category: Straight Dirt Roads
 		Id: 279
@@ -2620,13 +4834,29 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 125,98,67
+				RightColor: 145,111,72
 			1: DirtRoad
+				LeftColor: 150,115,74
+				RightColor: 127,101,69
 			2: DirtRoad
+				LeftColor: 125,101,71
+				RightColor: 137,107,72
 			3: DirtRoad
+				LeftColor: 143,112,75
+				RightColor: 131,103,69
 			4: DirtRoad
+				LeftColor: 122,97,66
+				RightColor: 137,107,72
 			5: DirtRoad
+				LeftColor: 134,106,72
+				RightColor: 121,97,68
 			6: DirtRoad
+				LeftColor: 127,100,68
+				RightColor: 135,105,70
 			7: DirtRoad
+				LeftColor: 143,111,72
+				RightColor: 119,94,64
 	Template@280:
 		Category: Straight Dirt Roads
 		Id: 280
@@ -2634,13 +4864,29 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 135,106,72
+				RightColor: 146,113,75
 			1: DirtRoad
+				LeftColor: 134,104,69
+				RightColor: 123,97,66
 			2: DirtRoad
+				LeftColor: 127,100,69
+				RightColor: 145,113,75
 			3: DirtRoad
+				LeftColor: 135,106,71
+				RightColor: 118,94,65
 			4: DirtRoad
+				LeftColor: 124,100,71
+				RightColor: 127,100,68
 			5: DirtRoad
+				LeftColor: 129,103,70
+				RightColor: 129,102,69
 			6: DirtRoad
+				LeftColor: 128,100,67
+				RightColor: 147,113,74
 			7: DirtRoad
+				LeftColor: 136,106,71
+				RightColor: 121,96,66
 	Template@281:
 		Category: Straight Dirt Roads
 		Id: 281
@@ -2648,13 +4894,29 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 124,98,67
+				RightColor: 149,113,72
 			1: DirtRoad
+				LeftColor: 143,111,73
+				RightColor: 123,97,65
 			2: DirtRoad
+				LeftColor: 127,100,68
+				RightColor: 142,111,74
 			3: DirtRoad
+				LeftColor: 144,113,76
+				RightColor: 120,96,66
 			4: DirtRoad
+				LeftColor: 128,101,69
+				RightColor: 138,109,73
 			5: DirtRoad
+				LeftColor: 145,113,75
+				RightColor: 120,97,68
 			6: DirtRoad
+				LeftColor: 129,102,69
+				RightColor: 144,111,72
 			7: DirtRoad
+				LeftColor: 146,112,74
+				RightColor: 124,98,66
 	Template@282:
 		Category: Straight Dirt Roads
 		Id: 282
@@ -2662,13 +4924,29 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 125,99,69
+				RightColor: 143,110,72
 			1: DirtRoad
+				LeftColor: 137,107,71
+				RightColor: 119,94,64
 			2: DirtRoad
+				LeftColor: 129,103,71
+				RightColor: 142,111,74
 			3: DirtRoad
+				LeftColor: 143,112,75
+				RightColor: 126,100,69
 			4: DirtRoad
+				LeftColor: 134,105,71
+				RightColor: 140,110,73
 			5: DirtRoad
+				LeftColor: 148,115,77
+				RightColor: 136,106,70
 			6: DirtRoad
+				LeftColor: 131,103,69
+				RightColor: 149,116,77
 			7: DirtRoad
+				LeftColor: 137,108,73
+				RightColor: 116,93,64
 	Template@283:
 		Category: Straight Dirt Roads
 		Id: 283
@@ -2676,11 +4954,23 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: DirtRoad
+				LeftColor: 123,97,67
+				RightColor: 146,113,75
 			1: DirtRoad
+				LeftColor: 143,110,72
+				RightColor: 125,98,66
 			2: DirtRoad
+				LeftColor: 126,101,72
+				RightColor: 137,107,72
 			3: DirtRoad
+				LeftColor: 142,110,73
+				RightColor: 128,101,69
 			4: DirtRoad
+				LeftColor: 129,101,67
+				RightColor: 149,114,73
 			5: DirtRoad
+				LeftColor: 138,107,71
+				RightColor: 122,98,68
 	Template@284:
 		Category: Straight Dirt Roads
 		Id: 284
@@ -2688,9 +4978,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 129,101,68
+				RightColor: 143,110,72
 			1: DirtRoad
+				LeftColor: 147,113,74
+				RightColor: 125,99,67
 			2: DirtRoad
+				LeftColor: 126,100,70
+				RightColor: 141,110,73
 			3: DirtRoad
+				LeftColor: 143,111,73
+				RightColor: 125,100,68
 	Template@285:
 		Category: Straight Dirt Roads
 		Id: 285
@@ -2698,7 +4996,11 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 126,100,68
+				RightColor: 148,113,74
 			1: DirtRoad
+				LeftColor: 136,106,70
+				RightColor: 116,93,65
 	Template@286:
 		Category: Straight Dirt Roads
 		Id: 286
@@ -2706,7 +5008,11 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 131,103,69
+				RightColor: 145,112,73
 			1: DirtRoad
+				LeftColor: 141,109,72
+				RightColor: 130,103,71
 	Template@287:
 		Category: Straight Dirt Roads
 		Id: 287
@@ -2714,13 +5020,29 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: Clear
+				LeftColor: 114,92,65
+				RightColor: 114,91,64
 			1: Clear
+				LeftColor: 112,89,63
+				RightColor: 111,89,62
 			2: Clear
+				LeftColor: 114,91,65
+				RightColor: 118,95,68
 			3: Clear
+				LeftColor: 122,100,74
+				RightColor: 111,91,66
 			4: DirtRoad
+				LeftColor: 132,106,76
+				RightColor: 132,106,75
 			5: DirtRoad
+				LeftColor: 139,111,78
+				RightColor: 120,96,68
 			6: DirtRoad
+				LeftColor: 128,100,68
+				RightColor: 150,116,76
 			7: DirtRoad
+				LeftColor: 141,111,75
+				RightColor: 129,103,72
 	Template@288:
 		Category: Straight Dirt Roads
 		Id: 288
@@ -2728,12 +5050,26 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Clear
+				LeftColor: 114,91,64
+				RightColor: 112,91,65
 			1: Clear
+				LeftColor: 112,89,62
+				RightColor: 111,89,62
 			3: DirtRoad
+				LeftColor: 118,93,64
+				RightColor: 132,102,68
 			4: DirtRoad
+				LeftColor: 125,100,71
+				RightColor: 112,90,63
 			5: Clear
+				LeftColor: 118,95,67
+				RightColor: 118,94,65
 			6: DirtRoad
+				LeftColor: 127,101,70
+				RightColor: 136,106,72
 			7: DirtRoad
+				LeftColor: 147,113,74
+				RightColor: 134,105,70
 	Template@289:
 		Category: Straight Dirt Roads
 		Id: 289
@@ -2741,10 +5077,20 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Clear
+				LeftColor: 115,91,63
+				RightColor: 112,89,62
 			2: Clear
+				LeftColor: 124,99,69
+				RightColor: 119,95,66
 			3: DirtRoad
+				LeftColor: 120,96,67
+				RightColor: 117,94,66
 			4: DirtRoad
+				LeftColor: 123,97,66
+				RightColor: 135,105,69
 			5: DirtRoad
+				LeftColor: 144,111,73
+				RightColor: 126,100,69
 	Template@290:
 		Category: Straight Dirt Roads
 		Id: 290
@@ -2752,12 +5098,26 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 129,102,70
+				RightColor: 147,112,72
 			1: DirtRoad
+				LeftColor: 142,111,74
+				RightColor: 128,102,70
 			2: DirtRoad
+				LeftColor: 126,101,71
+				RightColor: 139,109,76
 			3: DirtRoad
+				LeftColor: 134,104,69
+				RightColor: 128,100,68
 			4: Clear
+				LeftColor: 118,93,64
+				RightColor: 123,98,68
 			5: Clear
+				LeftColor: 118,94,66
+				RightColor: 119,94,65
 			6: Clear
+				LeftColor: 114,93,67
+				RightColor: 114,91,64
 	Template@291:
 		Category: Straight Dirt Roads
 		Id: 291
@@ -2765,13 +5125,29 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 122,97,67
+				RightColor: 146,113,74
 			1: DirtRoad
+				LeftColor: 146,112,73
+				RightColor: 126,99,66
 			2: DirtRoad
+				LeftColor: 120,94,64
+				RightColor: 141,108,71
 			3: DirtRoad
+				LeftColor: 143,110,73
+				RightColor: 127,100,68
 			4: DirtRoad
+				LeftColor: 124,100,71
+				RightColor: 135,104,70
 			5: Clear
+				LeftColor: 125,99,69
+				RightColor: 122,97,67
 			6: Clear
+				LeftColor: 111,89,61
+				RightColor: 122,97,67
 			7: Clear
+				LeftColor: 111,89,63
+				RightColor: 111,90,64
 	Template@292:
 		Category: Straight Dirt Roads
 		Id: 292
@@ -2779,9 +5155,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
+				LeftColor: 123,98,69
+				RightColor: 144,113,77
 			1: DirtRoad
+				LeftColor: 131,104,73
+				RightColor: 121,96,67
 			2: Clear
+				LeftColor: 114,93,65
+				RightColor: 125,100,69
 			3: Clear
+				LeftColor: 116,92,65
+				RightColor: 118,94,64
 	Template@293:
 		Category: Straight Dirt Roads
 		Id: 293
@@ -2789,13 +5173,29 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 122,97,67
+				RightColor: 143,109,71
 			2: DirtRoad
+				LeftColor: 145,111,72
+				RightColor: 124,97,66
 			4: DirtRoad
+				LeftColor: 136,106,71
+				RightColor: 143,111,74
 			5: DirtRoad
+				LeftColor: 123,97,66
+				RightColor: 116,94,67
 			6: Clear
+				LeftColor: 122,96,67
+				RightColor: 131,103,70
 			7: DirtRoad
+				LeftColor: 144,110,73
+				RightColor: 137,106,70
 			9: DirtRoad
+				LeftColor: 126,101,71
+				RightColor: 137,106,71
 			10: DirtRoad
+				LeftColor: 142,109,72
+				RightColor: 127,101,69
 	Template@294:
 		Category: Straight Dirt Roads
 		Id: 294
@@ -2803,13 +5203,29 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 119,94,65
+				RightColor: 144,111,74
 			1: DirtRoad
+				LeftColor: 144,113,77
+				RightColor: 122,97,68
 			3: Clear
+				LeftColor: 115,93,66
+				RightColor: 120,95,67
 			4: DirtRoad
+				LeftColor: 146,113,75
+				RightColor: 130,102,69
 			7: DirtRoad
+				LeftColor: 131,102,68
+				RightColor: 155,119,77
 			8: Clear
+				LeftColor: 128,101,70
+				RightColor: 113,90,62
 			10: DirtRoad
+				LeftColor: 130,103,71
+				RightColor: 144,112,74
 			11: DirtRoad
+				LeftColor: 137,107,72
+				RightColor: 120,96,66
 	Template@295:
 		Category: Straight Dirt Roads
 		Id: 295
@@ -2817,10 +5233,20 @@ Templates:
 		Size: 2, 3
 		Tiles:
 			0: Clear
+				LeftColor: 117,93,65
+				RightColor: 122,97,68
 			1: Clear
+				LeftColor: 134,106,75
+				RightColor: 114,92,65
 			2: Clear
+				LeftColor: 112,89,62
+				RightColor: 122,97,67
 			3: Clear
+				LeftColor: 138,108,73
+				RightColor: 126,100,69
 			5: Clear
+				LeftColor: 114,90,62
+				RightColor: 124,98,67
 	Template@296:
 		Category: Bridges
 		Id: 296
@@ -2828,20 +5254,58 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 111,107,102
+				RightColor: 85,79,70
 			1: Cliff
+				LeftColor: 110,106,97
+				RightColor: 99,94,87
 			2: Cliff
+				LeftColor: 110,90,65
+				RightColor: 108,88,64
 			3: Road
+				Height: 4
+				LeftColor: 51,49,47
+				RightColor: 75,74,72
 			4: Road
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 88,88,85
 			5: Cliff
+				LeftColor: 108,87,63
+				RightColor: 107,94,77
 			6: Road
+				Height: 4
+				LeftColor: 48,45,39
+				RightColor: 45,43,39
 			7: Road
+				Height: 4
+				LeftColor: 44,43,40
+				RightColor: 45,43,39
 			8: Cliff
+				LeftColor: 112,92,68
+				RightColor: 98,93,85
 			9: Road
+				Height: 4
+				LeftColor: 76,74,72
+				RightColor: 53,50,47
 			10: Road
+				Height: 4
+				LeftColor: 77,76,74
+				RightColor: 50,49,47
 			11: Cliff
+				LeftColor: 111,88,62
+				RightColor: 95,88,79
 			12: Cliff
+				Height: 4
+				LeftColor: 91,86,78
+				RightColor: 119,117,113
 			13: Cliff
+				LeftColor: 110,97,80
+				RightColor: 133,130,121
 			14: Cliff
+				LeftColor: 112,90,64
+				RightColor: 112,89,62
 	Template@297:
 		Category: Bridges
 		Id: 297
@@ -2849,20 +5313,58 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 111,107,102
+				RightColor: 85,79,71
 			1: Cliff
+				LeftColor: 111,108,102
+				RightColor: 94,92,88
 			2: Cliff
+				LeftColor: 21,39,59
+				RightColor: 15,35,57
 			3: Road
+				Height: 4
+				LeftColor: 51,49,47
+				RightColor: 75,74,72
 			4: Road
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 88,88,85
 			5: Cliff
+				LeftColor: 30,41,51
+				RightColor: 62,69,75
 			6: Road
+				Height: 4
+				LeftColor: 48,45,39
+				RightColor: 45,43,39
 			7: Road
+				Height: 4
+				LeftColor: 44,43,40
+				RightColor: 45,43,39
 			8: Cliff
+				LeftColor: 31,44,57
+				RightColor: 81,83,85
 			9: Road
+				Height: 4
+				LeftColor: 76,74,72
+				RightColor: 53,50,47
 			10: Road
+				Height: 4
+				LeftColor: 77,76,74
+				RightColor: 50,49,47
 			11: Cliff
+				LeftColor: 35,51,68
+				RightColor: 77,79,79
 			12: Cliff
+				Height: 4
+				LeftColor: 91,86,78
+				RightColor: 119,117,113
 			13: Cliff
+				LeftColor: 80,79,75
+				RightColor: 132,130,122
 			14: Cliff
+				LeftColor: 36,51,65
+				RightColor: 22,39,60
 	Template@298:
 		Category: Bridges
 		Id: 298
@@ -2870,15 +5372,43 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 0,0,0
+				RightColor: 0,0,0
 			1: Cliff
+				Height: 4
+				LeftColor: 114,111,106
+				RightColor: 88,81,71
 			2: Road
+				Height: 4
+				LeftColor: 51,49,47
+				RightColor: 96,94,90
 			3: Road
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 73,72,70
 			4: Road
+				Height: 4
+				LeftColor: 48,45,39
+				RightColor: 45,43,39
 			5: Road
+				Height: 4
+				LeftColor: 44,43,40
+				RightColor: 45,43,39
 			6: Road
+				Height: 4
+				LeftColor: 76,76,75
+				RightColor: 53,50,47
 			7: Road
+				Height: 4
+				LeftColor: 75,73,69
+				RightColor: 50,49,48
 			8: Cliff
+				LeftColor: 140,133,121
+				RightColor: 138,133,122
 			9: Cliff
+				Height: 4
+				LeftColor: 83,77,67
+				RightColor: 106,104,101
 	Template@299:
 		Category: Bridges
 		Id: 299
@@ -2886,20 +5416,58 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,73,64
+				RightColor: 99,96,91
 			1: Road
+				Height: 4
+				LeftColor: 75,74,72
+				RightColor: 51,49,47
 			2: Road
+				Height: 4
+				LeftColor: 45,43,39
+				RightColor: 48,45,39
 			3: Road
+				Height: 4
+				LeftColor: 52,50,47
+				RightColor: 73,72,68
 			4: Cliff
+				Height: 4
+				LeftColor: 91,89,85
+				RightColor: 86,77,66
 			5: Cliff
+				LeftColor: 153,142,125
+				RightColor: 152,149,141
 			6: Road
+				Height: 4
+				LeftColor: 73,72,69
+				RightColor: 72,71,69
 			7: Road
+				Height: 4
+				LeftColor: 45,43,40
+				RightColor: 45,44,42
 			8: Road
+				Height: 4
+				LeftColor: 50,49,46
+				RightColor: 75,73,69
 			9: Cliff
+				LeftColor: 100,90,76
+				RightColor: 106,101,91
 			10: Cliff
+				LeftColor: 109,87,61
+				RightColor: 111,89,62
 			11: Cliff
+				LeftColor: 110,88,61
+				RightColor: 136,122,104
 			12: Cliff
+				LeftColor: 114,92,65
+				RightColor: 141,134,122
 			13: Cliff
+				LeftColor: 111,90,64
+				RightColor: 139,132,120
 			14: Cliff
+				LeftColor: 112,92,67
+				RightColor: 108,87,62
 	Template@300:
 		Category: Bridges
 		Id: 300
@@ -2907,20 +5475,58 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,73,64
+				RightColor: 99,96,91
 			1: Road
+				Height: 4
+				LeftColor: 75,74,72
+				RightColor: 51,49,47
 			2: Road
+				Height: 4
+				LeftColor: 45,43,39
+				RightColor: 48,45,39
 			3: Road
+				Height: 4
+				LeftColor: 52,50,47
+				RightColor: 73,72,68
 			4: Cliff
+				Height: 4
+				LeftColor: 91,89,85
+				RightColor: 86,77,67
 			5: Cliff
+				LeftColor: 136,137,137
+				RightColor: 152,149,141
 			6: Road
+				Height: 4
+				LeftColor: 73,72,69
+				RightColor: 72,71,69
 			7: Road
+				Height: 4
+				LeftColor: 45,43,40
+				RightColor: 45,44,42
 			8: Road
+				Height: 4
+				LeftColor: 50,49,46
+				RightColor: 75,73,69
 			9: Cliff
+				LeftColor: 93,88,79
+				RightColor: 103,99,91
 			10: Cliff
+				LeftColor: 14,32,54
+				RightColor: 25,42,62
 			11: Cliff
+				LeftColor: 16,33,53
+				RightColor: 102,107,110
 			12: Cliff
+				LeftColor: 18,36,57
+				RightColor: 127,127,124
 			13: Cliff
+				LeftColor: 17,35,55
+				RightColor: 128,129,126
 			14: Cliff
+				LeftColor: 17,33,53
+				RightColor: 34,48,65
 	Template@301:
 		Category: Bridges
 		Id: 301
@@ -2928,15 +5534,43 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 0,0,0
+				RightColor: 0,0,0
 			1: Road
+				Height: 4
+				LeftColor: 76,76,76
+				RightColor: 76,75,74
 			2: Road
+				Height: 4
+				LeftColor: 45,43,39
+				RightColor: 48,45,39
 			3: Road
+				Height: 4
+				LeftColor: 53,51,47
+				RightColor: 77,76,75
 			4: Cliff
+				LeftColor: 104,95,85
+				RightColor: 107,102,95
 			5: Cliff
+				Height: 4
+				LeftColor: 86,77,64
+				RightColor: 96,94,91
 			6: Road
+				Height: 4
+				LeftColor: 77,77,76
+				RightColor: 51,50,48
 			7: Road
+				Height: 4
+				LeftColor: 45,43,39
+				RightColor: 44,43,40
 			8: Road
+				Height: 4
+				LeftColor: 49,49,48
+				RightColor: 75,76,76
 			9: Cliff
+				Height: 4
+				LeftColor: 94,91,87
+				RightColor: 86,83,78
 	Template@302:
 		Category: Bridges
 		Id: 302
@@ -2944,15 +5578,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 112,110,106
+				RightColor: 100,98,93
 			1: Cliff
+				LeftColor: 110,90,65
+				RightColor: 108,88,64
 			2: Road
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 98,98,98
 			3: Cliff
+				LeftColor: 108,87,63
+				RightColor: 107,95,80
 			4: Road
+				Height: 4
+				LeftColor: 44,43,40
+				RightColor: 45,43,39
 			5: Cliff
+				LeftColor: 112,92,68
+				RightColor: 98,93,86
 			6: Road
+				Height: 4
+				LeftColor: 78,77,75
+				RightColor: 50,49,48
 			7: Cliff
+				LeftColor: 111,88,62
+				RightColor: 95,90,82
 			8: Cliff
+				LeftColor: 155,149,139
+				RightColor: 145,143,138
 			9: Cliff
+				LeftColor: 112,90,64
+				RightColor: 112,89,62
 	Template@303:
 		Category: Bridges
 		Id: 303
@@ -2960,15 +5617,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 112,110,106
+				RightColor: 100,98,93
 			1: Cliff
+				LeftColor: 110,90,65
+				RightColor: 108,88,64
 			2: Road
+				Height: 4
+				LeftColor: 59,59,58
+				RightColor: 100,99,100
 			3: Cliff
+				LeftColor: 108,87,63
+				RightColor: 107,95,80
 			4: Road
+				Height: 4
+				LeftColor: 52,52,50
+				RightColor: 54,52,48
 			5: Cliff
+				LeftColor: 112,92,68
+				RightColor: 98,93,86
 			6: Road
+				Height: 4
+				LeftColor: 70,70,69
+				RightColor: 54,54,53
 			7: Cliff
+				LeftColor: 111,88,62
+				RightColor: 95,90,82
 			8: Cliff
+				LeftColor: 143,137,129
+				RightColor: 140,138,133
 			9: Cliff
+				LeftColor: 113,92,66
+				RightColor: 112,89,62
 	Template@304:
 		Category: Bridges
 		Id: 304
@@ -2976,15 +5656,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 113,112,108
+				RightColor: 100,98,94
 			1: Cliff
+				LeftColor: 116,101,82
+				RightColor: 107,87,64
 			2: Road
+				Height: 4
+				LeftColor: 51,50,48
+				RightColor: 101,101,101
 			3: Cliff
+				LeftColor: 108,99,87
+				RightColor: 111,101,89
 			4: Road
+				Height: 4
+				LeftColor: 51,50,48
+				RightColor: 52,51,48
 			5: Cliff
+				LeftColor: 102,86,67
+				RightColor: 95,91,84
 			6: Road
+				Height: 4
+				LeftColor: 82,82,82
+				RightColor: 58,58,58
 			7: Cliff
+				LeftColor: 107,88,64
+				RightColor: 90,85,78
 			8: Cliff
+				LeftColor: 152,146,137
+				RightColor: 138,136,132
 			9: Cliff
+				LeftColor: 112,90,64
+				RightColor: 112,90,62
 	Template@305:
 		Category: Bridges
 		Id: 305
@@ -2992,15 +5695,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 113,112,108
+				RightColor: 99,97,92
 			1: Cliff
+				LeftColor: 120,105,88
+				RightColor: 115,97,77
 			2: Rough
+				Height: 4
+				LeftColor: 59,59,59
+				RightColor: 91,91,92
 			3: Cliff
+				LeftColor: 108,99,87
+				RightColor: 111,101,89
 			4: Rough
+				Height: 4
+				LeftColor: 59,59,57
+				RightColor: 55,54,52
 			5: Cliff
+				LeftColor: 92,82,69
+				RightColor: 95,91,84
 			6: Rough
+				Height: 4
+				LeftColor: 75,75,75
+				RightColor: 60,60,60
 			7: Cliff
+				LeftColor: 107,88,64
+				RightColor: 89,84,78
 			8: Cliff
+				LeftColor: 143,137,129
+				RightColor: 139,136,132
 			9: Cliff
+				LeftColor: 113,92,66
+				RightColor: 112,90,62
 	Template@306:
 		Category: Bridges
 		Id: 306
@@ -3008,15 +5734,35 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 123,122,119
+				RightColor: 135,133,128
 			1: Cliff
+				LeftColor: 120,105,88
+				RightColor: 115,97,77
 			2: Cliff
+				LeftColor: 101,101,98
+				RightColor: 114,113,111
 			3: Cliff
+				LeftColor: 106,99,88
+				RightColor: 104,87,67
 			4: Cliff
+				LeftColor: 108,107,106
+				RightColor: 132,131,127
 			5: Cliff
+				LeftColor: 87,81,71
+				RightColor: 95,81,63
 			6: Cliff
+				LeftColor: 116,115,113
+				RightColor: 143,142,137
 			7: Cliff
+				LeftColor: 97,88,75
+				RightColor: 98,83,63
 			8: Cliff
+				LeftColor: 144,135,124
+				RightColor: 116,112,104
 			9: Cliff
+				LeftColor: 93,80,64
+				RightColor: 99,83,63
 	Template@307:
 		Category: Bridges
 		Id: 307
@@ -3024,14 +5770,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			1: Road
+				Height: 4
+				LeftColor: 76,76,76
+				RightColor: 76,75,74
 			2: Road
+				Height: 4
+				LeftColor: 45,43,40
+				RightColor: 45,44,42
 			3: Road
+				Height: 4
+				LeftColor: 50,49,47
+				RightColor: 78,77,76
 			4: Cliff
+				LeftColor: 117,109,99
+				RightColor: 128,125,120
 			5: Cliff
+				LeftColor: 109,87,61
+				RightColor: 152,143,131
 			6: Cliff
+				LeftColor: 110,88,61
+				RightColor: 146,140,131
 			7: Cliff
+				LeftColor: 114,92,65
+				RightColor: 145,138,128
 			8: Cliff
+				LeftColor: 111,90,64
+				RightColor: 144,138,129
 			9: Cliff
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 	Template@308:
 		Category: Bridges
 		Id: 308
@@ -3039,14 +5806,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			1: Road
+				Height: 4
+				LeftColor: 78,78,78
+				RightColor: 78,78,77
 			2: Road
+				Height: 4
+				LeftColor: 50,48,45
+				RightColor: 53,52,48
 			3: Road
+				Height: 4
+				LeftColor: 54,55,54
+				RightColor: 96,96,97
 			4: Cliff
+				LeftColor: 117,109,99
+				RightColor: 128,125,120
 			5: Cliff
+				LeftColor: 109,87,61
+				RightColor: 152,143,131
 			6: Cliff
+				LeftColor: 110,88,61
+				RightColor: 146,140,131
 			7: Cliff
+				LeftColor: 114,92,65
+				RightColor: 145,138,128
 			8: Cliff
+				LeftColor: 111,90,64
+				RightColor: 144,138,129
 			9: Cliff
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 	Template@309:
 		Category: Bridges
 		Id: 309
@@ -3054,14 +5842,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			1: Road
+				Height: 4
+				LeftColor: 84,84,84
+				RightColor: 75,74,73
 			2: Road
+				Height: 4
+				LeftColor: 58,56,51
+				RightColor: 49,46,41
 			3: Road
+				Height: 4
+				LeftColor: 51,50,49
+				RightColor: 77,76,76
 			4: Cliff
+				LeftColor: 117,110,99
+				RightColor: 127,124,119
 			5: Cliff
+				LeftColor: 109,87,62
+				RightColor: 144,136,125
 			6: Cliff
+				LeftColor: 110,89,63
+				RightColor: 130,125,117
 			7: Cliff
+				LeftColor: 112,94,72
+				RightColor: 135,129,120
 			8: Cliff
+				LeftColor: 109,89,64
+				RightColor: 135,132,125
 			9: Cliff
+				LeftColor: 112,93,70
+				RightColor: 106,86,62
 	Template@310:
 		Category: Bridges
 		Id: 310
@@ -3069,14 +5878,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			1: Rough
+				Height: 4
+				LeftColor: 65,65,66
+				RightColor: 76,76,76
 			2: Rough
+				Height: 4
+				LeftColor: 54,52,48
+				RightColor: 50,48,45
 			3: Rough
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 85,85,85
 			4: Cliff
+				LeftColor: 117,112,104
+				RightColor: 123,120,114
 			5: Cliff
+				LeftColor: 110,89,63
+				RightColor: 143,135,125
 			6: Cliff
+				LeftColor: 105,88,67
+				RightColor: 130,126,120
 			7: Cliff
+				LeftColor: 110,94,73
+				RightColor: 135,129,120
 			8: Cliff
+				LeftColor: 109,89,64
+				RightColor: 140,136,130
 			9: Cliff
+				LeftColor: 112,93,70
+				RightColor: 114,99,81
 	Template@311:
 		Category: Bridges
 		Id: 311
@@ -3084,14 +5914,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 0,0,0
+				RightColor: 0,0,0
 			2: Cliff
+				Height: 4
+				LeftColor: 0,0,0
+				RightColor: 0,0,0
 			3: Cliff
+				Height: 4
+				LeftColor: 0,0,0
+				RightColor: 0,0,0
 			4: Cliff
+				LeftColor: 117,112,104
+				RightColor: 118,114,109
 			5: Cliff
+				LeftColor: 110,90,66
+				RightColor: 129,117,103
 			6: Cliff
+				LeftColor: 105,88,67
+				RightColor: 130,125,118
 			7: Cliff
+				LeftColor: 110,94,73
+				RightColor: 143,139,132
 			8: Cliff
+				LeftColor: 97,88,76
+				RightColor: 133,131,125
 			9: Cliff
+				LeftColor: 117,108,98
+				RightColor: 112,99,83
 	Template@312:
 		Category: Paved Roads
 		Id: 312
@@ -3099,8 +5950,14 @@ Templates:
 		Size: 1, 3
 		Tiles:
 			0: Road
+				LeftColor: 66,64,60
+				RightColor: 77,77,75
 			1: Road
+				LeftColor: 64,60,52
+				RightColor: 60,57,52
 			2: Road
+				LeftColor: 77,75,70
+				RightColor: 68,65,60
 	Template@313:
 		Category: Paved Roads
 		Id: 313
@@ -3108,8 +5965,14 @@ Templates:
 		Size: 3, 1
 		Tiles:
 			0: Road
+				LeftColor: 77,77,75
+				RightColor: 66,64,60
 			1: Road
+				LeftColor: 60,57,52
+				RightColor: 64,60,52
 			2: Road
+				LeftColor: 68,65,60
+				RightColor: 77,75,70
 	Template@314:
 		Category: Paved Roads
 		Id: 314
@@ -3117,14 +5980,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Road
+				LeftColor: 62,62,60
+				RightColor: 62,62,60
 			1: Road
+				LeftColor: 56,56,56
+				RightColor: 58,59,59
 			2: Road
+				LeftColor: 56,56,56
+				RightColor: 68,68,67
 			3: Road
+				LeftColor: 59,59,59
+				RightColor: 58,58,58
 			4: Road
+				LeftColor: 54,54,54
+				RightColor: 56,56,56
 			5: Road
+				LeftColor: 58,58,58
+				RightColor: 59,59,59
 			6: Road
+				LeftColor: 69,68,67
+				RightColor: 57,57,57
 			7: Road
+				LeftColor: 59,60,60
+				RightColor: 57,57,57
 			8: Road
+				LeftColor: 63,62,61
+				RightColor: 63,62,60
 	Template@315:
 		Category: Paved Roads
 		Id: 315
@@ -3132,14 +6013,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Road
+				LeftColor: 63,63,61
+				RightColor: 66,64,61
 			1: Road
+				LeftColor: 60,57,52
+				RightColor: 64,60,52
 			2: Road
+				LeftColor: 62,60,57
+				RightColor: 66,66,64
 			3: Road
+				LeftColor: 59,59,59
+				RightColor: 62,61,58
 			4: Road
+				LeftColor: 60,58,53
+				RightColor: 59,57,53
 			5: Road
+				LeftColor: 60,59,59
+				RightColor: 58,58,58
 			6: Road
+				LeftColor: 66,66,65
+				RightColor: 61,60,57
 			7: Road
+				LeftColor: 60,58,54
+				RightColor: 60,59,56
 			8: Road
+				LeftColor: 65,64,61
+				RightColor: 63,62,59
 	Template@316:
 		Category: Paved Roads
 		Id: 316
@@ -3147,14 +6046,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Road
+				LeftColor: 67,64,61
+				RightColor: 64,63,61
 			1: Road
+				LeftColor: 62,60,58
+				RightColor: 60,61,60
 			2: Road
+				LeftColor: 61,61,61
+				RightColor: 66,66,65
 			3: Road
+				LeftColor: 59,57,53
+				RightColor: 60,58,53
 			4: Road
+				LeftColor: 64,60,52
+				RightColor: 60,57,52
 			5: Road
+				LeftColor: 59,58,53
+				RightColor: 60,57,52
 			6: Road
+				LeftColor: 66,66,66
+				RightColor: 60,60,59
 			7: Road
+				LeftColor: 60,60,60
+				RightColor: 62,61,59
 			8: Road
+				LeftColor: 63,62,59
+				RightColor: 65,63,60
 	Template@317:
 		Category: Paved Roads
 		Id: 317
@@ -3162,14 +6079,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Road
+				LeftColor: 66,64,60
+				RightColor: 77,77,75
 			1: Road
+				LeftColor: 65,64,61
+				RightColor: 76,75,72
 			2: Road
+				LeftColor: 64,64,64
+				RightColor: 76,76,74
 			3: Road
+				LeftColor: 60,58,54
+				RightColor: 60,58,52
 			4: Road
+				LeftColor: 63,60,53
+				RightColor: 60,57,52
 			5: Road
+				LeftColor: 59,58,53
+				RightColor: 60,57,52
 			6: Road
+				LeftColor: 66,66,66
+				RightColor: 60,60,59
 			7: Road
+				LeftColor: 60,60,60
+				RightColor: 62,61,59
 			8: Road
+				LeftColor: 63,62,59
+				RightColor: 65,63,60
 	Template@318:
 		Category: Paved Roads
 		Id: 318
@@ -3177,14 +6112,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Road
+				LeftColor: 63,63,61
+				RightColor: 66,64,61
 			1: Road
+				LeftColor: 60,58,54
+				RightColor: 61,59,55
 			2: Road
+				LeftColor: 65,63,61
+				RightColor: 80,79,75
 			3: Road
+				LeftColor: 59,59,59
+				RightColor: 62,61,58
 			4: Road
+				LeftColor: 60,58,53
+				RightColor: 59,57,53
 			5: Road
+				LeftColor: 64,63,62
+				RightColor: 79,77,74
 			6: Road
+				LeftColor: 66,66,65
+				RightColor: 61,60,57
 			7: Road
+				LeftColor: 60,57,52
+				RightColor: 60,58,54
 			8: Road
+				LeftColor: 64,63,61
+				RightColor: 76,77,76
 	Template@319:
 		Category: Paved Roads
 		Id: 319
@@ -3192,14 +6145,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Road
+				LeftColor: 67,64,61
+				RightColor: 64,63,61
 			1: Road
+				LeftColor: 62,60,58
+				RightColor: 60,61,60
 			2: Road
+				LeftColor: 61,61,61
+				RightColor: 66,66,65
 			3: Road
+				LeftColor: 59,57,53
+				RightColor: 60,58,53
 			4: Road
+				LeftColor: 60,58,54
+				RightColor: 60,58,52
 			5: Road
+				LeftColor: 60,59,55
+				RightColor: 59,58,53
 			6: Road
+				LeftColor: 79,77,74
+				RightColor: 64,63,62
 			7: Road
+				LeftColor: 76,77,76
+				RightColor: 64,63,61
 			8: Road
+				LeftColor: 80,79,75
+				RightColor: 65,63,61
 	Template@320:
 		Category: Paved Roads
 		Id: 320
@@ -3207,14 +6178,32 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Road
+				LeftColor: 76,75,72
+				RightColor: 65,64,61
 			1: Road
+				LeftColor: 60,57,52
+				RightColor: 63,60,53
 			2: Road
+				LeftColor: 62,60,57
+				RightColor: 66,66,64
 			3: Road
+				LeftColor: 78,77,74
+				RightColor: 66,65,62
 			4: Road
+				LeftColor: 60,58,53
+				RightColor: 59,57,53
 			5: Road
+				LeftColor: 60,59,59
+				RightColor: 58,58,58
 			6: Road
+				LeftColor: 77,77,75
+				RightColor: 66,64,60
 			7: Road
+				LeftColor: 60,58,54
+				RightColor: 61,59,55
 			8: Road
+				LeftColor: 65,64,61
+				RightColor: 63,62,59
 	Template@321:
 		Category: Paved Roads
 		Id: 321
@@ -3222,17 +6211,41 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Clear
+				LeftColor: 108,89,64
+				RightColor: 108,90,66
 			1: Clear
+				LeftColor: 76,68,57
+				RightColor: 83,77,68
 			2: Clear
+				LeftColor: 98,81,63
+				RightColor: 94,80,63
 			3: Road
+				LeftColor: 69,64,59
+				RightColor: 79,76,71
 			4: Clear
+				LeftColor: 104,84,60
+				RightColor: 94,79,61
 			5: DirtRoad
+				LeftColor: 105,87,65
+				RightColor: 100,82,61
 			6: DirtRoad
+				LeftColor: 93,78,60
+				RightColor: 80,71,61
 			7: Road
+				LeftColor: 69,63,53
+				RightColor: 61,58,52
 			8: Clear
+				LeftColor: 97,85,70
+				RightColor: 79,70,60
 			9: Clear
+				LeftColor: 101,87,70
+				RightColor: 103,85,63
 			10: DirtRoad
+				LeftColor: 101,85,68
+				RightColor: 98,81,62
 			11: Road
+				LeftColor: 85,75,63
+				RightColor: 69,65,60
 	Template@322:
 		Category: Paved Roads
 		Id: 322
@@ -3240,17 +6253,41 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Road
+				LeftColor: 66,64,60
+				RightColor: 84,76,67
 			1: DirtRoad
+				LeftColor: 75,69,60
+				RightColor: 99,82,61
 			2: Clear
+				LeftColor: 92,78,61
+				RightColor: 101,86,67
 			3: Clear
+				LeftColor: 99,80,59
+				RightColor: 110,87,61
 			4: Road
+				LeftColor: 64,60,52
+				RightColor: 60,57,52
 			5: DirtRoad
+				LeftColor: 69,64,56
+				RightColor: 64,60,53
 			6: DirtRoad
+				LeftColor: 68,63,54
+				RightColor: 82,71,57
 			7: DirtRoad
+				LeftColor: 84,74,62
+				RightColor: 109,87,61
 			8: Road
+				LeftColor: 78,74,68
+				RightColor: 72,66,59
 			9: DirtRoad
+				LeftColor: 97,80,61
+				RightColor: 93,80,64
 			10: Clear
+				LeftColor: 105,93,79
+				RightColor: 92,79,63
 			11: Clear
+				LeftColor: 101,84,63
+				RightColor: 104,85,62
 	Template@323:
 		Category: Paved Roads
 		Id: 323
@@ -3258,17 +6295,41 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: DirtRoad
+				LeftColor: 71,66,59
+				RightColor: 99,82,61
 			1: Rough
+				LeftColor: 66,62,55
+				RightColor: 84,74,61
 			2: Rough
+				LeftColor: 79,74,67
+				RightColor: 86,80,71
 			3: Clear
+				LeftColor: 83,77,69
+				RightColor: 86,78,67
 			4: Road
+				LeftColor: 66,60,52
+				RightColor: 65,59,50
 			5: Rough
+				LeftColor: 72,67,57
+				RightColor: 67,62,55
 			6: Rough
+				LeftColor: 73,69,61
+				RightColor: 68,67,63
 			7: Road
+				LeftColor: 79,72,63
+				RightColor: 69,65,59
 			8: DirtRoad
+				LeftColor: 80,75,67
+				RightColor: 83,73,60
 			9: Clear
+				LeftColor: 96,83,66
+				RightColor: 69,66,62
 			10: Rough
+				LeftColor: 84,77,69
+				RightColor: 76,72,67
 			11: Clear
+				LeftColor: 82,79,74
+				RightColor: 64,62,59
 	Template@324:
 		Category: Paved Roads
 		Id: 324
@@ -3276,17 +6337,41 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 78,77,74
+				RightColor: 66,65,62
 			1: Road
+				LeftColor: 64,60,52
+				RightColor: 60,58,53
 			2: DirtRoad
+				LeftColor: 64,63,61
+				RightColor: 76,77,76
 			3: Clear
+				LeftColor: 87,76,63
+				RightColor: 74,68,60
 			4: DirtRoad
+				LeftColor: 72,64,52
+				RightColor: 67,62,52
 			5: DirtRoad
+				LeftColor: 75,68,59
+				RightColor: 80,78,73
 			6: Clear
+				LeftColor: 108,89,66
+				RightColor: 99,81,62
 			7: DirtRoad
+				LeftColor: 94,79,60
+				RightColor: 81,72,61
 			8: Clear
+				LeftColor: 99,82,62
+				RightColor: 100,84,65
 			9: Clear
+				LeftColor: 109,88,62
+				RightColor: 109,89,64
 			10: Clear
+				LeftColor: 111,90,64
+				RightColor: 107,87,62
 			11: Clear
+				LeftColor: 112,91,65
+				RightColor: 103,85,62
 	Template@325:
 		Category: Paved Roads
 		Id: 325
@@ -3294,17 +6379,41 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Clear
+				LeftColor: 97,83,65
+				RightColor: 102,84,62
 			1: Clear
+				LeftColor: 103,83,60
+				RightColor: 109,88,62
 			2: Clear
+				LeftColor: 111,88,62
+				RightColor: 110,88,61
 			3: Clear
+				LeftColor: 93,80,64
+				RightColor: 98,82,63
 			4: DirtRoad
+				LeftColor: 80,71,61
+				RightColor: 92,78,61
 			5: Clear
+				LeftColor: 98,80,62
+				RightColor: 108,88,63
 			6: DirtRoad
+				LeftColor: 94,84,73
+				RightColor: 83,73,62
 			7: Road
+				LeftColor: 67,62,53
+				RightColor: 73,65,53
 			8: DirtRoad
+				LeftColor: 70,66,60
+				RightColor: 85,75,62
 			9: Road
+				LeftColor: 76,76,74
+				RightColor: 72,68,64
 			10: Road
+				LeftColor: 71,64,54
+				RightColor: 69,63,54
 			11: Road
+				LeftColor: 65,64,62
+				RightColor: 79,77,74
 	Template@326:
 		Category: Paved Roads
 		Id: 326
@@ -3312,17 +6421,41 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: DirtRoad
+				LeftColor: 77,76,74
+				RightColor: 64,64,64
 			1: Road
+				LeftColor: 55,54,49
+				RightColor: 55,53,49
 			2: DirtRoad
+				LeftColor: 62,58,51
+				RightColor: 77,76,73
 			3: Clear
+				LeftColor: 76,76,73
+				RightColor: 62,61,59
 			4: Rough
+				LeftColor: 45,44,42
+				RightColor: 47,44,38
 			5: DirtRoad
+				LeftColor: 79,67,54
+				RightColor: 94,83,69
 			6: Clear
+				LeftColor: 82,75,66
+				RightColor: 60,57,53
 			7: Rough
+				LeftColor: 54,53,50
+				RightColor: 54,51,46
 			8: Clear
+				LeftColor: 64,62,57
+				RightColor: 77,74,68
 			9: Road
+				LeftColor: 73,72,69
+				RightColor: 62,60,58
 			10: Road
+				LeftColor: 60,58,54
+				RightColor: 55,54,50
 			11: Road
+				LeftColor: 65,64,61
+				RightColor: 81,79,76
 	Template@327:
 		Category: Paved Roads
 		Id: 327
@@ -3330,21 +6463,53 @@ Templates:
 		Size: 4, 5
 		Tiles:
 			0: Road
+				LeftColor: 67,64,60
+				RightColor: 78,77,75
 			1: Road
+				LeftColor: 65,64,63
+				RightColor: 76,76,74
 			2: Road
+				LeftColor: 67,65,62
+				RightColor: 78,77,74
 			3: Road
+				LeftColor: 66,64,61
+				RightColor: 76,75,72
 			4: Road
+				LeftColor: 71,64,53
+				RightColor: 65,60,52
 			5: Road
+				LeftColor: 69,63,54
+				RightColor: 65,60,52
 			6: Road
+				LeftColor: 80,71,59
+				RightColor: 75,67,55
 			7: Road
+				LeftColor: 81,73,62
+				RightColor: 65,61,55
 			8: Road
+				LeftColor: 84,78,70
+				RightColor: 82,73,62
 			9: Road
+				LeftColor: 117,96,71
+				RightColor: 98,81,63
 			10: Road
+				LeftColor: 127,104,76
+				RightColor: 102,86,67
 			11: Road
+				LeftColor: 87,83,77
+				RightColor: 68,66,61
 			12: DirtRoad
+				LeftColor: 134,105,72
+				RightColor: 130,103,71
 			13: DirtRoad
+				LeftColor: 149,113,72
+				RightColor: 154,118,77
 			14: DirtRoad
+				LeftColor: 136,107,74
+				RightColor: 133,107,75
 			17: DirtRoad
+				LeftColor: 138,106,70
+				RightColor: 138,107,72
 	Template@328:
 		Category: Paved Roads
 		Id: 328
@@ -3352,19 +6517,47 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
+				LeftColor: 135,107,75
+				RightColor: 128,100,67
 			2: DirtRoad
+				LeftColor: 160,121,77
+				RightColor: 158,120,77
 			4: Road
+				LeftColor: 69,66,61
+				RightColor: 87,79,68
 			5: Road
+				LeftColor: 98,83,65
+				RightColor: 128,103,75
 			6: Road
+				LeftColor: 117,95,70
+				RightColor: 127,103,75
 			7: Road
+				LeftColor: 85,73,60
+				RightColor: 90,79,64
 			8: Road
+				LeftColor: 60,58,53
+				RightColor: 69,63,53
 			9: Road
+				LeftColor: 73,66,55
+				RightColor: 81,71,56
 			10: Road
+				LeftColor: 76,67,55
+				RightColor: 80,70,56
 			11: Road
+				LeftColor: 71,65,55
+				RightColor: 65,60,51
 			12: Road
+				LeftColor: 79,77,74
+				RightColor: 66,64,60
 			13: Road
+				LeftColor: 82,80,75
+				RightColor: 68,65,60
 			14: Road
+				LeftColor: 79,79,77
+				RightColor: 71,67,62
 			15: Road
+				LeftColor: 81,78,71
+				RightColor: 70,66,61
 	Template@329:
 		Category: Paved Roads
 		Id: 329
@@ -3372,21 +6565,53 @@ Templates:
 		Size: 4, 5
 		Tiles:
 			1: DirtRoad
+				LeftColor: 129,101,69
+				RightColor: 148,113,74
 			2: DirtRoad
+				LeftColor: 152,117,75
+				RightColor: 127,101,69
 			4: Road
+				LeftColor: 70,67,63
+				RightColor: 81,78,73
 			5: Road
+				LeftColor: 92,80,65
+				RightColor: 130,107,79
 			6: Road
+				LeftColor: 123,100,71
+				RightColor: 115,97,74
 			7: Road
+				LeftColor: 77,70,62
+				RightColor: 79,76,72
 			8: Road
+				LeftColor: 62,59,54
+				RightColor: 67,62,54
 			9: Road
+				LeftColor: 83,73,61
+				RightColor: 95,81,62
 			10: Road
+				LeftColor: 107,88,65
+				RightColor: 93,77,57
 			11: Road
+				LeftColor: 68,62,54
+				RightColor: 62,59,52
 			12: Road
+				LeftColor: 76,77,76
+				RightColor: 67,65,61
 			13: Road
+				LeftColor: 107,93,75
+				RightColor: 113,93,69
 			14: Road
+				LeftColor: 127,105,78
+				RightColor: 98,84,66
 			15: Road
+				LeftColor: 89,84,76
+				RightColor: 68,66,62
 			17: DirtRoad
+				LeftColor: 126,100,68
+				RightColor: 137,106,70
 			18: DirtRoad
+				LeftColor: 143,111,72
+				RightColor: 120,95,64
 	Template@330:
 		Category: Paved Roads
 		Id: 330
@@ -3394,21 +6619,53 @@ Templates:
 		Size: 5, 4
 		Tiles:
 			2: Road
+				LeftColor: 96,88,78
+				RightColor: 78,71,63
 			3: Road
+				LeftColor: 85,75,61
+				RightColor: 66,61,53
 			4: Road
+				LeftColor: 68,65,60
+				RightColor: 77,75,70
 			6: DirtRoad
+				LeftColor: 125,101,72
+				RightColor: 123,97,67
 			7: Road
+				LeftColor: 147,116,80
+				RightColor: 132,106,76
 			8: Road
+				LeftColor: 95,81,63
+				RightColor: 81,72,60
 			9: Road
+				LeftColor: 70,67,63
+				RightColor: 81,79,74
 			10: DirtRoad
+				LeftColor: 141,109,71
+				RightColor: 134,103,68
 			11: DirtRoad
+				LeftColor: 135,105,70
+				RightColor: 147,113,74
 			12: Road
+				LeftColor: 124,100,70
+				RightColor: 126,100,70
 			13: Road
+				LeftColor: 97,82,63
+				RightColor: 83,74,61
 			14: Road
+				LeftColor: 66,65,62
+				RightColor: 77,77,76
 			16: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 131,103,69
 			17: Road
+				LeftColor: 83,77,68
+				RightColor: 88,78,65
 			18: Road
+				LeftColor: 67,63,56
+				RightColor: 81,73,61
 			19: Road
+				LeftColor: 68,66,61
+				RightColor: 83,81,76
 	Template@331:
 		Category: Paved Roads
 		Id: 331
@@ -3416,19 +6673,47 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			0: Road
+				LeftColor: 78,77,74
+				RightColor: 66,66,64
 			1: Road
+				LeftColor: 64,60,53
+				RightColor: 61,59,54
 			2: Road
+				LeftColor: 76,70,63
+				RightColor: 87,77,64
 			4: Road
+				LeftColor: 76,75,72
+				RightColor: 67,65,62
 			5: Road
+				LeftColor: 66,62,55
+				RightColor: 72,68,60
 			6: Road
+				LeftColor: 120,99,74
+				RightColor: 118,98,73
 			7: DirtRoad
+				LeftColor: 156,118,75
+				RightColor: 157,119,76
 			8: Road
+				LeftColor: 79,78,75
+				RightColor: 68,65,62
 			9: Road
+				LeftColor: 75,68,57
+				RightColor: 93,80,62
 			10: Road
+				LeftColor: 132,106,76
+				RightColor: 138,111,79
 			11: DirtRoad
+				LeftColor: 121,95,64
+				RightColor: 127,99,67
 			12: Road
+				LeftColor: 77,77,75
+				RightColor: 68,65,61
 			13: Road
+				LeftColor: 62,59,53
+				RightColor: 85,74,60
 			14: Road
+				LeftColor: 87,78,66
+				RightColor: 101,91,76
 	Template@332:
 		Category: Paved Roads
 		Id: 332
@@ -3436,21 +6721,53 @@ Templates:
 		Size: 5, 4
 		Tiles:
 			1: Road
+				LeftColor: 77,77,75
+				RightColor: 66,64,60
 			2: Road
+				LeftColor: 60,58,53
+				RightColor: 64,60,52
 			3: Road
+				LeftColor: 69,65,60
+				RightColor: 77,75,70
 			5: DirtRoad
+				LeftColor: 139,108,72
+				RightColor: 128,101,69
 			6: Road
+				LeftColor: 118,101,80
+				RightColor: 87,78,68
 			7: Road
+				LeftColor: 87,76,61
+				RightColor: 81,71,59
 			8: Road
+				LeftColor: 95,82,67
+				RightColor: 99,87,71
 			9: DirtRoad
+				LeftColor: 139,108,72
+				RightColor: 129,100,67
 			10: DirtRoad
+				LeftColor: 132,103,69
+				RightColor: 141,109,72
 			11: Road
+				LeftColor: 119,97,72
+				RightColor: 132,106,77
 			12: Road
+				LeftColor: 107,90,69
+				RightColor: 111,92,71
 			13: Road
+				LeftColor: 114,96,74
+				RightColor: 127,104,77
 			14: DirtRoad
+				LeftColor: 131,102,68
+				RightColor: 153,117,75
 			16: Road
+				LeftColor: 77,75,72
+				RightColor: 71,67,62
 			17: Road
+				LeftColor: 60,58,52
+				RightColor: 75,68,58
 			18: Road
+				LeftColor: 73,68,63
+				RightColor: 95,86,75
 	Template@333:
 		Category: Water
 		Id: 333
@@ -3458,9 +6775,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 18,37,61
+				RightColor: 21,41,68
 			1: Water
+				LeftColor: 27,47,80
+				RightColor: 16,36,59
 			2: Water
+				LeftColor: 15,34,55
+				RightColor: 19,38,64
 			3: Water
+				LeftColor: 20,40,66
+				RightColor: 19,38,64
 	Template@334:
 		Category: Water
 		Id: 334
@@ -3468,9 +6793,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 13,31,51
+				RightColor: 14,32,53
 			1: Water
+				LeftColor: 15,33,55
+				RightColor: 15,35,56
 			2: Water
+				LeftColor: 14,33,54
+				RightColor: 11,27,46
 			3: Water
+				LeftColor: 15,34,56
+				RightColor: 15,33,55
 	Template@335:
 		Category: Water
 		Id: 335
@@ -3478,9 +6811,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 16,35,58
+				RightColor: 18,37,62
 			1: Water
+				LeftColor: 19,39,65
+				RightColor: 16,35,58
 			2: Water
+				LeftColor: 15,33,56
+				RightColor: 14,33,54
 			3: Water
+				LeftColor: 15,33,56
+				RightColor: 15,34,55
 	Template@336:
 		Category: Water
 		Id: 336
@@ -3488,9 +6829,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 14,33,54
+				RightColor: 15,33,55
 			1: Water
+				LeftColor: 17,35,59
+				RightColor: 17,35,57
 			2: Water
+				LeftColor: 19,38,63
+				RightColor: 17,35,56
 			3: Water
+				LeftColor: 20,39,66
+				RightColor: 20,40,67
 	Template@337:
 		Category: Water
 		Id: 337
@@ -3498,9 +6847,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 13,32,53
+				RightColor: 10,27,45
 			1: Water
+				LeftColor: 16,35,58
+				RightColor: 18,36,62
 			2: Water
+				LeftColor: 15,33,55
+				RightColor: 16,35,58
 			3: Water
+				LeftColor: 15,33,54
+				RightColor: 16,35,60
 	Template@338:
 		Category: Water
 		Id: 338
@@ -3508,9 +6865,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Water
+				LeftColor: 15,34,57
+				RightColor: 16,34,56
 			1: Water
+				LeftColor: 18,37,61
+				RightColor: 15,33,55
 			2: Water
+				LeftColor: 14,32,54
+				RightColor: 17,36,60
 			3: Water
+				LeftColor: 14,30,51
+				RightColor: 16,34,57
 	Template@339:
 		Category: Water
 		Id: 339
@@ -3518,9 +6883,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 48,55,62
+				RightColor: 41,51,64
 			1: Water
+				LeftColor: 31,51,82
+				RightColor: 18,36,60
 			2: Water
+				LeftColor: 16,35,57
+				RightColor: 18,36,58
 			3: Water
+				LeftColor: 17,36,59
+				RightColor: 20,40,66
 	Template@340:
 		Category: Water
 		Id: 340
@@ -3528,9 +6901,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 64,74,85
+				RightColor: 40,49,58
 			1: Water
+				LeftColor: 21,39,61
+				RightColor: 16,36,60
 			2: Cliff
+				LeftColor: 22,43,68
+				RightColor: 37,51,72
 			3: Cliff
+				LeftColor: 44,55,72
+				RightColor: 44,55,68
 	Template@341:
 		Category: Water
 		Id: 341
@@ -3538,6 +6919,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Water
+				LeftColor: 14,31,52
+				RightColor: 17,36,59
 	Template@342:
 		Category: Water
 		Id: 342
@@ -3545,6 +6928,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Water
+				LeftColor: 17,35,59
+				RightColor: 17,36,60
 	Template@343:
 		Category: Water
 		Id: 343
@@ -3552,6 +6937,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Water
+				LeftColor: 15,33,54
+				RightColor: 16,34,56
 	Template@344:
 		Category: Water
 		Id: 344
@@ -3559,6 +6946,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Water
+				LeftColor: 13,30,51
+				RightColor: 16,34,57
 	Template@345:
 		Category: Water
 		Id: 345
@@ -3566,6 +6955,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Water
+				LeftColor: 16,34,56
+				RightColor: 16,34,56
 	Template@346:
 		Category: Water
 		Id: 346
@@ -3573,6 +6964,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				LeftColor: 44,54,66
+				RightColor: 39,49,58
 	Template@387:
 		Category: Dirt Road Slopes
 		Id: 387
@@ -3580,7 +6973,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
+				RampType: 1
+				LeftColor: 140,108,71
+				RightColor: 124,99,69
 			1: DirtRoad
+				RampType: 1
+				LeftColor: 127,103,74
+				RightColor: 120,93,62
 	Template@388:
 		Category: Dirt Road Slopes
 		Id: 388
@@ -3588,7 +6987,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
+				RampType: 1
+				LeftColor: 151,115,73
+				RightColor: 130,105,74
 			1: DirtRoad
+				RampType: 1
+				LeftColor: 130,106,75
+				RightColor: 130,102,68
 	Template@389:
 		Category: Dirt Road Slopes
 		Id: 389
@@ -3596,7 +7001,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
+				RampType: 2
+				LeftColor: 108,88,64
+				RightColor: 142,108,70
 			1: DirtRoad
+				RampType: 2
+				LeftColor: 117,94,66
+				RightColor: 99,83,62
 	Template@390:
 		Category: Dirt Road Slopes
 		Id: 390
@@ -3604,7 +7015,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
+				RampType: 2
+				LeftColor: 109,89,65
+				RightColor: 144,109,71
 			1: DirtRoad
+				RampType: 2
+				LeftColor: 118,93,65
+				RightColor: 100,83,63
 	Template@391:
 		Category: Dirt Road Slopes
 		Id: 391
@@ -3612,7 +7029,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
+				RampType: 3
+				LeftColor: 128,101,68
+				RightColor: 110,91,67
 			1: DirtRoad
+				RampType: 3
+				LeftColor: 103,86,65
+				RightColor: 123,103,77
 	Template@392:
 		Category: Dirt Road Slopes
 		Id: 392
@@ -3620,7 +7043,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
+				RampType: 3
+				LeftColor: 124,97,65
+				RightColor: 107,88,66
 			1: DirtRoad
+				RampType: 3
+				LeftColor: 104,86,65
+				RightColor: 114,92,65
 	Template@393:
 		Category: Dirt Road Slopes
 		Id: 393
@@ -3628,7 +7057,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
+				RampType: 4
+				LeftColor: 122,97,68
+				RightColor: 148,114,74
 			1: DirtRoad
+				RampType: 4
+				LeftColor: 125,98,67
+				RightColor: 110,89,62
 	Template@394:
 		Category: Dirt Road Slopes
 		Id: 394
@@ -3636,7 +7071,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
+				RampType: 4
+				LeftColor: 117,92,63
+				RightColor: 140,108,70
 			1: DirtRoad
+				RampType: 4
+				LeftColor: 140,107,68
+				RightColor: 115,92,64
 	Template@403:
 		Category: Slope Set Pieces
 		Id: 403
@@ -3644,15 +7085,49 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			1: Clear
+				Height: 3
+				RampType: 11
+				LeftColor: 82,70,55
+				RightColor: 96,80,61
 			2: Clear
+				Height: 3
+				RampType: 4
+				LeftColor: 93,78,59
+				RightColor: 103,83,58
 			3: Cliff
+				Height: 4
+				LeftColor: 78,69,57
+				RightColor: 63,55,43
 			4: Cliff
+				Height: 3
+				RampType: 3
+				LeftColor: 81,70,54
+				RightColor: 87,76,61
 			5: Clear
+				Height: 2
+				RampType: 4
+				LeftColor: 85,73,56
+				RightColor: 95,81,62
 			6: Cliff
+				LeftColor: 105,87,66
+				RightColor: 80,72,60
 			7: Cliff
+				RampType: 1
+				LeftColor: 105,90,70
+				RightColor: 97,82,62
 			8: Clear
+				Height: 1
+				RampType: 4
+				LeftColor: 90,75,56
+				RightColor: 84,72,55
 			10: Clear
+				RampType: 8
+				LeftColor: 108,89,65
+				RightColor: 104,87,65
 			11: Clear
+				RampType: 4
+				LeftColor: 105,84,60
+				RightColor: 101,83,61
 	Template@404:
 		Category: Slope Set Pieces
 		Id: 404
@@ -3660,15 +7135,49 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Clear
+				Height: 3
+				RampType: 4
+				LeftColor: 87,75,58
+				RightColor: 95,81,63
 			1: Clear
+				Height: 3
+				RampType: 12
+				LeftColor: 106,92,72
+				RightColor: 104,85,62
 			3: Clear
+				Height: 2
+				RampType: 4
+				LeftColor: 90,77,60
+				RightColor: 87,76,61
 			4: Cliff
+				Height: 3
+				RampType: 1
+				LeftColor: 78,70,58
+				RightColor: 98,85,67
 			5: Cliff
+				Height: 4
+				LeftColor: 80,69,55
+				RightColor: 66,57,44
 			6: Clear
+				Height: 1
+				RampType: 4
+				LeftColor: 93,80,64
+				RightColor: 88,76,60
 			7: Cliff
+				RampType: 3
+				LeftColor: 86,77,65
+				RightColor: 77,68,56
 			8: Cliff
+				LeftColor: 103,88,69
+				RightColor: 63,58,49
 			9: Clear
+				RampType: 4
+				LeftColor: 106,86,62
+				RightColor: 92,78,58
 			10: Clear
+				RampType: 7
+				LeftColor: 102,86,64
+				RightColor: 89,76,59
 	Template@405:
 		Category: Slope Set Pieces
 		Id: 405
@@ -3676,15 +7185,49 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Clear
+				Height: 3
+				RampType: 3
+				LeftColor: 96,84,68
+				RightColor: 98,84,66
 			1: Clear
+				Height: 2
+				RampType: 3
+				LeftColor: 85,77,65
+				RightColor: 88,78,63
 			2: Clear
+				Height: 1
+				RampType: 3
+				LeftColor: 84,77,67
+				RightColor: 96,84,69
 			3: Clear
+				RampType: 3
+				LeftColor: 80,72,61
+				RightColor: 98,85,68
 			4: Clear
+				Height: 3
+				RampType: 10
+				LeftColor: 108,88,65
+				RightColor: 79,71,60
 			5: Cliff
+				Height: 3
+				RampType: 2
+				LeftColor: 78,69,55
+				RightColor: 77,70,58
 			6: Cliff
+				RampType: 4
+				LeftColor: 102,88,70
+				RightColor: 93,82,68
 			7: Clear
+				RampType: 7
+				LeftColor: 108,91,69
+				RightColor: 98,82,61
 			9: Cliff
+				Height: 4
+				LeftColor: 75,64,51
+				RightColor: 65,58,47
 			10: Cliff
+				LeftColor: 86,77,64
+				RightColor: 63,59,51
 	Template@406:
 		Category: Slope Set Pieces
 		Id: 406
@@ -3692,15 +7235,49 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 71,62,51
+				RightColor: 64,58,50
 			2: Cliff
+				LeftColor: 59,56,49
+				RightColor: 53,51,46
 			4: Clear
+				Height: 3
+				RampType: 11
+				LeftColor: 96,86,72
+				RightColor: 99,89,74
 			5: Cliff
+				Height: 3
+				RampType: 4
+				LeftColor: 101,91,75
+				RightColor: 93,84,71
 			6: Cliff
+				RampType: 2
+				LeftColor: 78,69,55
+				RightColor: 74,66,54
 			7: Clear
+				RampType: 6
+				LeftColor: 76,67,55
+				RightColor: 95,82,64
 			8: Clear
+				Height: 3
+				RampType: 3
+				LeftColor: 100,86,69
+				RightColor: 90,80,66
 			9: Clear
+				Height: 2
+				RampType: 3
+				LeftColor: 88,77,61
+				RightColor: 87,78,66
 			10: Clear
+				Height: 1
+				RampType: 3
+				LeftColor: 90,80,65
+				RightColor: 66,60,51
 			11: Clear
+				RampType: 3
+				LeftColor: 92,78,61
+				RightColor: 97,82,63
 	Template@407:
 		Category: Slope Set Pieces
 		Id: 407
@@ -3708,15 +7285,48 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			1: Clear
+				RampType: 5
+				LeftColor: 84,74,60
+				RightColor: 79,70,58
 			2: Clear
+				RampType: 2
+				LeftColor: 68,61,49
+				RightColor: 80,69,53
 			3: Cliff
+				LeftColor: 84,76,64
+				RightColor: 84,76,63
 			4: Cliff
+				LeftColor: 74,67,56
+				RightColor: 68,61,51
 			5: Clear
+				Height: 1
+				RampType: 2
+				LeftColor: 71,66,56
+				RightColor: 71,64,53
 			6: Cliff
+				Height: 4
+				LeftColor: 80,69,53
+				RightColor: 77,70,59
 			7: Cliff
+				Height: 3
+				RampType: 3
+				LeftColor: 78,74,65
+				RightColor: 85,78,66
 			8: Clear
+				Height: 2
+				RampType: 2
+				LeftColor: 74,67,56
+				RightColor: 80,71,58
 			10: Clear
+				Height: 3
+				RampType: 10
+				LeftColor: 102,89,71
+				RightColor: 78,71,59
 			11: Clear
+				Height: 3
+				RampType: 2
+				LeftColor: 90,83,72
+				RightColor: 74,68,58
 	Template@408:
 		Category: Slope Set Pieces
 		Id: 408
@@ -3724,12 +7334,35 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Clear
+				RampType: 2
+				LeftColor: 84,76,64
+				RightColor: 79,72,61
 			1: Clear
+				RampType: 6
+				LeftColor: 78,70,58
+				RightColor: 93,80,63
 			3: Clear
+				Height: 1
+				RampType: 2
+				LeftColor: 69,63,52
+				RightColor: 78,71,58
 			4: Cliff
+				RampType: 3
+				LeftColor: 90,79,63
+				RightColor: 96,86,71
 			5: Cliff
+				LeftColor: 107,90,69
+				RightColor: 109,90,65
 			6: Clear
+				Height: 2
+				RampType: 2
+				LeftColor: 65,60,50
+				RightColor: 72,65,55
 			9: Clear
+				Height: 3
+				RampType: 2
+				LeftColor: 69,62,50
+				RightColor: 67,62,52
 	Template@409:
 		Category: Slope Set Pieces
 		Id: 409
@@ -3737,8 +7370,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 3
+				RampType: 1
+				LeftColor: 116,99,77
+				RightColor: 116,101,79
 			1: Cliff
+				Height: 4
+				LeftColor: 82,70,54
+				RightColor: 73,64,52
 			2: Clear
+				Height: 3
+				RampType: 9
+				LeftColor: 98,85,68
+				RightColor: 106,88,66
 	Template@410:
 		Category: Slope Set Pieces
 		Id: 410
@@ -3746,15 +7390,48 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			1: Cliff
+				LeftColor: 104,92,75
+				RightColor: 100,91,76
 			2: Cliff
+				Height: 4
+				LeftColor: 76,69,58
+				RightColor: 76,66,52
 			4: Clear
+				RampType: 5
+				LeftColor: 112,96,74
+				RightColor: 97,85,69
 			5: Cliff
+				LeftColor: 116,97,73
+				RightColor: 112,96,73
 			6: Cliff
+				Height: 3
+				RampType: 4
+				LeftColor: 102,93,79
+				RightColor: 97,89,77
 			7: Clear
+				Height: 3
+				RampType: 12
+				LeftColor: 108,95,76
+				RightColor: 115,99,77
 			8: Clear
+				RampType: 1
+				LeftColor: 113,95,71
+				RightColor: 114,98,76
 			9: Clear
+				Height: 1
+				RampType: 1
+				LeftColor: 119,101,77
+				RightColor: 116,97,73
 			10: Clear
+				Height: 2
+				RampType: 1
+				LeftColor: 116,97,73
+				RightColor: 106,93,75
 			11: Clear
+				Height: 3
+				RampType: 1
+				LeftColor: 114,98,76
+				RightColor: 105,93,77
 	Template@411:
 		Category: Slope Set Pieces
 		Id: 411
@@ -3762,12 +7439,35 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Clear
+				RampType: 1
+				LeftColor: 106,92,73
+				RightColor: 109,99,83
 			1: Clear
+				Height: 1
+				RampType: 1
+				LeftColor: 105,95,79
+				RightColor: 111,97,76
 			2: Clear
+				Height: 2
+				RampType: 1
+				LeftColor: 115,98,75
+				RightColor: 113,96,73
 			3: Clear
+				Height: 3
+				RampType: 1
+				LeftColor: 117,98,73
+				RightColor: 113,95,72
 			4: Clear
+				RampType: 8
+				LeftColor: 107,89,67
+				RightColor: 101,89,71
 			5: Cliff
+				RampType: 4
+				LeftColor: 105,95,80
+				RightColor: 92,82,68
 			9: Cliff
+				LeftColor: 112,93,69
+				RightColor: 110,92,70
 	Template@412:
 		Category: Slope Set Pieces
 		Id: 412
@@ -3775,8 +7475,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 3
+				RampType: 2
+				LeftColor: 101,91,75
+				RightColor: 82,74,61
 			1: Clear
+				Height: 3
+				RampType: 9
+				LeftColor: 106,90,68
+				RightColor: 102,91,74
 			2: Cliff
+				Height: 4
+				LeftColor: 70,64,55
+				RightColor: 72,65,55
 	Template@423:
 		Category: Dead Oil Tanker
 		Id: 423
@@ -3784,30 +7495,83 @@ Templates:
 		Size: 5, 8
 		Tiles:
 			0: Cliff
+				LeftColor: 171,173,194
+				RightColor: 124,126,137
 			1: Cliff
+				LeftColor: 88,90,95
+				RightColor: 188,189,221
 			2: Water
+				RampType: 4
+				LeftColor: 176,178,200
+				RightColor: 196,197,226
 			3: Water
+				RampType: 12
+				LeftColor: 123,125,133
+				RightColor: 164,165,181
 			5: Cliff
+				LeftColor: 63,77,88
+				RightColor: 125,130,140
 			6: Cliff
+				LeftColor: 83,86,90
+				RightColor: 84,85,86
 			7: Water
+				LeftColor: 117,123,138
+				RightColor: 116,124,142
 			8: Water
+				RampType: 8
+				LeftColor: 81,88,98
+				RightColor: 151,154,168
 			10: Water
+				LeftColor: 41,56,64
+				RightColor: 50,64,73
 			11: Cliff
+				LeftColor: 60,72,80
+				RightColor: 83,85,87
 			12: Cliff
+				LeftColor: 69,77,81
+				RightColor: 103,112,125
 			13: Water
+				LeftColor: 56,68,76
+				RightColor: 53,66,76
 			16: Water
+				LeftColor: 41,56,64
+				RightColor: 44,58,66
 			17: Cliff
+				LeftColor: 53,66,73
+				RightColor: 60,73,81
 			18: Water
+				LeftColor: 48,61,68
+				RightColor: 42,56,64
 			22: Cliff
+				LeftColor: 48,60,67
+				RightColor: 58,68,76
 			23: Cliff
+				LeftColor: 64,72,78
+				RightColor: 59,72,82
 			27: Cliff
+				LeftColor: 56,68,77
+				RightColor: 50,62,68
 			28: Cliff
+				LeftColor: 75,76,77
+				RightColor: 67,70,73
 			29: Water
+				LeftColor: 42,55,62
+				RightColor: 40,55,63
 			32: Cliff
+				LeftColor: 41,56,64
+				RightColor: 78,88,100
 			33: Cliff
+				LeftColor: 69,77,83
+				RightColor: 81,81,82
 			34: Cliff
+				LeftColor: 52,55,58
+				RightColor: 39,51,59
 			38: Cliff
+				LeftColor: 41,56,64
+				RightColor: 70,77,80
 			39: Cliff
+				LeftColor: 49,53,56
+				RightColor: 49,54,58
 	Template@424:
 		Category: Ruins
 		Id: 424
@@ -3815,12 +7579,26 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			1: Cliff
+				LeftColor: 117,118,119
+				RightColor: 112,115,128
 			2: Cliff
+				LeftColor: 126,130,145
+				RightColor: 138,141,161
 			4: Cliff
+				LeftColor: 117,120,128
+				RightColor: 106,109,117
 			5: Cliff
+				LeftColor: 123,126,139
+				RightColor: 137,140,154
 			6: Cliff
+				LeftColor: 183,184,202
+				RightColor: 135,135,135
 			7: Cliff
+				LeftColor: 189,188,199
+				RightColor: 185,185,189
 			8: Cliff
+				LeftColor: 198,199,218
+				RightColor: 136,137,152
 	Template@435:
 		Category: Waterfalls
 		Id: 435
@@ -3828,13 +7606,33 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 63,54,42
+				RightColor: 66,58,47
 			1: Cliff
+				Height: 4
+				LeftColor: 23,34,49
+				RightColor: 16,28,43
 			2: Cliff
+				Height: 4
+				LeftColor: 67,60,49
+				RightColor: 69,62,52
 			3: Cliff
+				Height: 4
+				LeftColor: 65,67,74
+				RightColor: 49,61,81
 			4: Cliff
+				LeftColor: 102,84,60
+				RightColor: 76,70,59
 			5: Cliff
+				LeftColor: 71,82,97
+				RightColor: 98,103,105
 			6: Rough
+				LeftColor: 96,79,59
+				RightColor: 55,63,74
 			7: Cliff
+				LeftColor: 37,54,80
+				RightColor: 31,49,77
 	Template@436:
 		Category: Waterfalls
 		Id: 436
@@ -3842,9 +7640,19 @@ Templates:
 		Size: 1, 4
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 20,34,56
+				RightColor: 13,28,46
 			1: Cliff
+				Height: 4
+				LeftColor: 84,93,109
+				RightColor: 52,63,80
 			2: Cliff
+				LeftColor: 111,123,141
+				RightColor: 147,152,158
 			3: Cliff
+				LeftColor: 21,40,65
+				RightColor: 40,63,99
 	Template@437:
 		Category: Waterfalls
 		Id: 437
@@ -3852,13 +7660,33 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 12,26,44
+				RightColor: 13,27,44
 			1: Cliff
+				Height: 4
+				LeftColor: 24,35,49
+				RightColor: 14,27,44
 			2: Cliff
+				Height: 4
+				LeftColor: 86,94,106
+				RightColor: 39,54,78
 			3: Cliff
+				Height: 4
+				LeftColor: 77,88,109
+				RightColor: 46,57,76
 			4: Cliff
+				LeftColor: 97,109,125
+				RightColor: 164,168,173
 			5: Cliff
+				LeftColor: 142,149,162
+				RightColor: 182,184,191
 			6: Cliff
+				LeftColor: 21,41,67
+				RightColor: 35,57,92
 			7: Cliff
+				LeftColor: 24,44,73
+				RightColor: 53,74,111
 	Template@438:
 		Category: Waterfalls
 		Id: 438
@@ -3866,13 +7694,33 @@ Templates:
 		Size: 2, 4
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 21,31,42
+				RightColor: 31,37,45
 			1: Cliff
+				Height: 4
+				LeftColor: 68,59,47
+				RightColor: 80,65,47
 			2: Cliff
+				Height: 4
+				LeftColor: 82,90,104
+				RightColor: 50,54,60
 			3: Cliff
+				Height: 4
+				LeftColor: 82,70,53
+				RightColor: 72,62,49
 			4: Cliff
+				LeftColor: 127,134,144
+				RightColor: 160,158,158
 			5: Cliff
+				LeftColor: 84,75,61
+				RightColor: 79,70,56
 			6: Cliff
+				LeftColor: 42,54,71
+				RightColor: 71,74,78
 			7: Rough
+				LeftColor: 95,80,61
+				RightColor: 96,83,65
 	Template@439:
 		Category: Ground 01
 		Id: 439
@@ -3880,6 +7728,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 109,87,61
+				RightColor: 111,89,62
 	Template@440:
 		Category: Ground 01
 		Id: 440
@@ -3887,6 +7737,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 110,88,61
+				RightColor: 110,88,61
 	Template@441:
 		Category: Ground 01
 		Id: 441
@@ -3894,6 +7746,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 114,92,65
+				RightColor: 115,92,64
 	Template@442:
 		Category: Ground 01
 		Id: 442
@@ -3901,6 +7755,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 111,90,64
+				RightColor: 108,88,64
 	Template@443:
 		Category: Ground 01
 		Id: 443
@@ -3908,6 +7764,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 112,90,64
+				RightColor: 112,89,62
 	Template@444:
 		Category: Ground 01
 		Id: 444
@@ -3915,6 +7773,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 111,88,61
+				RightColor: 111,88,61
 	Template@445:
 		Category: Ground 01
 		Id: 445
@@ -3922,6 +7782,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 	Template@446:
 		Category: Ground 01
 		Id: 446
@@ -3929,6 +7791,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 	Template@447:
 		Category: Ground 01
 		Id: 447
@@ -3936,6 +7800,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 70,64,54
+				RightColor: 71,65,55
 	Template@448:
 		Category: Ground 01
 		Id: 448
@@ -3943,6 +7809,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 72,67,56
+				RightColor: 66,61,51
 	Template@449:
 		Category: Ground 01
 		Id: 449
@@ -3950,6 +7818,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 68,63,54
+				RightColor: 71,66,55
 	Template@450:
 		Category: Ground 01
 		Id: 450
@@ -3957,6 +7827,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 74,68,58
+				RightColor: 69,64,54
 	Template@451:
 		Category: Ground 01
 		Id: 451
@@ -3964,6 +7836,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 71,65,55
+				RightColor: 72,66,56
 	Template@452:
 		Category: Ground 01
 		Id: 452
@@ -3971,6 +7845,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 69,64,54
+				RightColor: 72,66,55
 	Template@453:
 		Category: Ground 01
 		Id: 453
@@ -3978,6 +7854,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 72,67,57
+				RightColor: 71,65,54
 	Template@454:
 		Category: Ground 01
 		Id: 454
@@ -3985,6 +7863,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 71,65,55
+				RightColor: 72,66,56
 	Template@455:
 		Category: Ground 01
 		Id: 455
@@ -3992,6 +7872,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 83,72,57
+				RightColor: 84,73,57
 	Template@456:
 		Category: Ground 01
 		Id: 456
@@ -3999,6 +7881,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 74,68,57
+				RightColor: 88,74,56
 	Template@457:
 		Category: Ground 01
 		Id: 457
@@ -4006,6 +7890,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 70,64,54
+				RightColor: 87,74,57
 	Template@458:
 		Category: Ground 01
 		Id: 458
@@ -4013,6 +7899,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 76,70,59
+				RightColor: 94,79,60
 	Template@459:
 		Category: Ground 01
 		Id: 459
@@ -4020,6 +7908,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 85,73,57
+				RightColor: 73,67,56
 	Template@460:
 		Category: Ground 01
 		Id: 460
@@ -4027,6 +7917,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 85,73,56
+				RightColor: 87,74,58
 	Template@461:
 		Category: Ground 01
 		Id: 461
@@ -4034,6 +7926,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 88,76,60
+				RightColor: 88,74,57
 	Template@462:
 		Category: Ground 01
 		Id: 462
@@ -4041,6 +7935,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 86,75,59
+				RightColor: 97,82,63
 	Template@463:
 		Category: Ground 01
 		Id: 463
@@ -4048,6 +7944,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 86,73,57
+				RightColor: 73,67,56
 	Template@464:
 		Category: Ground 01
 		Id: 464
@@ -4055,6 +7953,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 84,73,57
+				RightColor: 86,73,55
 	Template@465:
 		Category: Ground 01
 		Id: 465
@@ -4062,6 +7962,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 90,78,61
+				RightColor: 91,76,57
 	Template@466:
 		Category: Ground 01
 		Id: 466
@@ -4069,6 +7971,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 87,76,60
+				RightColor: 96,80,61
 	Template@467:
 		Category: Ground 01
 		Id: 467
@@ -4076,6 +7980,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 100,83,61
+				RightColor: 74,68,56
 	Template@468:
 		Category: Ground 01
 		Id: 468
@@ -4083,6 +7989,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 103,83,59
+				RightColor: 88,75,58
 	Template@469:
 		Category: Ground 01
 		Id: 469
@@ -4090,6 +7998,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 99,84,64
+				RightColor: 85,73,57
 	Template@470:
 		Category: Ground 01
 		Id: 470
@@ -4097,6 +8007,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 91,77,58
+				RightColor: 93,79,61
 	Template@471:
 		Category: Ground 01
 		Id: 471
@@ -4104,6 +8016,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 85,73,58
+				RightColor: 81,71,57
 	Template@472:
 		Category: Ground 01
 		Id: 472
@@ -4111,6 +8025,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 80,70,56
+				RightColor: 94,78,59
 	Template@473:
 		Category: Ground 01
 		Id: 473
@@ -4118,6 +8034,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 81,72,58
+				RightColor: 89,75,57
 	Template@474:
 		Category: Ground 01
 		Id: 474
@@ -4125,6 +8043,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 84,75,61
+				RightColor: 100,82,62
 	Template@475:
 		Category: Ground 01
 		Id: 475
@@ -4132,6 +8052,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 94,79,59
+				RightColor: 80,71,58
 	Template@476:
 		Category: Ground 01
 		Id: 476
@@ -4139,6 +8061,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 94,77,57
+				RightColor: 92,77,58
 	Template@477:
 		Category: Ground 01
 		Id: 477
@@ -4146,6 +8070,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 89,76,59
+				RightColor: 92,77,58
 	Template@478:
 		Category: Ground 01
 		Id: 478
@@ -4153,6 +8079,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 93,78,60
+				RightColor: 101,84,64
 	Template@479:
 		Category: Ground 01
 		Id: 479
@@ -4160,6 +8088,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 86,74,58
+				RightColor: 78,70,57
 	Template@480:
 		Category: Ground 01
 		Id: 480
@@ -4167,6 +8097,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 88,75,57
+				RightColor: 98,81,59
 	Template@481:
 		Category: Ground 01
 		Id: 481
@@ -4174,6 +8106,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 90,77,61
+				RightColor: 87,74,56
 	Template@482:
 		Category: Ground 01
 		Id: 482
@@ -4181,6 +8115,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 93,80,62
+				RightColor: 99,82,62
 	Template@483:
 		Category: Ground 01
 		Id: 483
@@ -4188,6 +8124,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 104,84,60
+				RightColor: 87,74,57
 	Template@484:
 		Category: Ground 01
 		Id: 484
@@ -4195,6 +8133,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 97,80,59
+				RightColor: 92,77,58
 	Template@485:
 		Category: Ground 01
 		Id: 485
@@ -4202,6 +8142,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 103,85,63
+				RightColor: 91,77,59
 	Template@486:
 		Category: Ground 01
 		Id: 486
@@ -4209,6 +8151,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 98,81,61
+				RightColor: 95,80,61
 	Template@487:
 		Category: Ground 02
 		Id: 487
@@ -4216,6 +8160,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 109,87,61
+				RightColor: 111,89,62
 	Template@488:
 		Category: Ground 02
 		Id: 488
@@ -4223,6 +8169,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 110,88,61
+				RightColor: 110,88,61
 	Template@489:
 		Category: Ground 02
 		Id: 489
@@ -4230,6 +8178,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 114,92,65
+				RightColor: 115,92,64
 	Template@490:
 		Category: Ground 02
 		Id: 490
@@ -4237,6 +8187,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 111,90,64
+				RightColor: 108,88,64
 	Template@491:
 		Category: Ground 02
 		Id: 491
@@ -4244,6 +8196,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 112,90,64
+				RightColor: 112,89,62
 	Template@492:
 		Category: Ground 02
 		Id: 492
@@ -4251,6 +8205,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 111,88,61
+				RightColor: 111,88,61
 	Template@493:
 		Category: Ground 02
 		Id: 493
@@ -4258,6 +8214,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 	Template@494:
 		Category: Ground 02
 		Id: 494
@@ -4265,6 +8223,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 	Template@495:
 		Category: Ground 02
 		Id: 495
@@ -4272,6 +8232,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 139,109,72
+				RightColor: 138,109,72
 	Template@496:
 		Category: Ground 02
 		Id: 496
@@ -4279,6 +8241,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 140,111,73
+				RightColor: 137,109,72
 	Template@497:
 		Category: Ground 02
 		Id: 497
@@ -4286,6 +8250,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 138,109,72
+				RightColor: 137,108,71
 	Template@498:
 		Category: Ground 02
 		Id: 498
@@ -4293,6 +8259,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 141,112,74
+				RightColor: 140,110,73
 	Template@499:
 		Category: Ground 02
 		Id: 499
@@ -4300,6 +8268,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 137,109,71
+				RightColor: 135,106,70
 	Template@500:
 		Category: Ground 02
 		Id: 500
@@ -4307,6 +8277,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 138,109,72
+				RightColor: 140,111,73
 	Template@501:
 		Category: Ground 02
 		Id: 501
@@ -4314,6 +8286,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 139,109,72
+				RightColor: 135,107,71
 	Template@502:
 		Category: Ground 02
 		Id: 502
@@ -4321,6 +8295,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 137,108,72
+				RightColor: 135,107,70
 	Template@503:
 		Category: Ground 02
 		Id: 503
@@ -4328,6 +8304,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 124,98,67
+				RightColor: 129,102,69
 	Template@504:
 		Category: Ground 02
 		Id: 504
@@ -4335,6 +8313,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 116,92,63
+				RightColor: 128,101,67
 	Template@505:
 		Category: Ground 02
 		Id: 505
@@ -4342,6 +8322,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 114,91,64
+				RightColor: 125,99,66
 	Template@506:
 		Category: Ground 02
 		Id: 506
@@ -4349,6 +8331,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 109,88,62
+				RightColor: 131,104,69
 	Template@507:
 		Category: Ground 02
 		Id: 507
@@ -4356,6 +8340,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 116,93,65
+				RightColor: 107,85,60
 	Template@508:
 		Category: Ground 02
 		Id: 508
@@ -4363,6 +8349,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 128,102,68
+				RightColor: 124,99,67
 	Template@509:
 		Category: Ground 02
 		Id: 509
@@ -4370,6 +8358,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 118,94,65
+				RightColor: 117,93,64
 	Template@510:
 		Category: Ground 02
 		Id: 510
@@ -4377,6 +8367,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 117,94,65
+				RightColor: 127,101,68
 	Template@511:
 		Category: Ground 02
 		Id: 511
@@ -4384,6 +8376,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 123,97,65
+				RightColor: 108,87,61
 	Template@512:
 		Category: Ground 02
 		Id: 512
@@ -4391,6 +8385,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 119,94,64
+				RightColor: 115,92,63
 	Template@513:
 		Category: Ground 02
 		Id: 513
@@ -4398,6 +8394,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 126,99,67
+				RightColor: 124,98,66
 	Template@514:
 		Category: Ground 02
 		Id: 514
@@ -4405,6 +8403,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 123,97,66
+				RightColor: 136,108,72
 	Template@515:
 		Category: Ground 02
 		Id: 515
@@ -4412,6 +8412,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 134,106,71
+				RightColor: 108,87,61
 	Template@516:
 		Category: Ground 02
 		Id: 516
@@ -4419,6 +8421,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 131,104,69
+				RightColor: 121,96,66
 	Template@517:
 		Category: Ground 02
 		Id: 517
@@ -4426,6 +8430,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 136,107,71
+				RightColor: 120,95,65
 	Template@518:
 		Category: Ground 02
 		Id: 518
@@ -4433,6 +8439,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 116,92,63
+				RightColor: 119,95,64
 	Template@519:
 		Category: Ground 02
 		Id: 519
@@ -4440,6 +8448,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 130,103,69
+				RightColor: 122,97,67
 	Template@520:
 		Category: Ground 02
 		Id: 520
@@ -4447,6 +8457,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 118,94,64
+				RightColor: 126,100,67
 	Template@521:
 		Category: Ground 02
 		Id: 521
@@ -4454,6 +8466,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 115,93,65
+				RightColor: 129,102,68
 	Template@522:
 		Category: Ground 02
 		Id: 522
@@ -4461,6 +8475,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 114,91,62
+				RightColor: 136,108,71
 	Template@523:
 		Category: Ground 02
 		Id: 523
@@ -4468,6 +8484,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 129,103,69
+				RightColor: 113,91,64
 	Template@524:
 		Category: Ground 02
 		Id: 524
@@ -4475,6 +8493,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 118,94,65
+				RightColor: 113,92,66
 	Template@525:
 		Category: Ground 02
 		Id: 525
@@ -4482,6 +8502,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 121,96,65
+				RightColor: 127,101,67
 	Template@526:
 		Category: Ground 02
 		Id: 526
@@ -4489,6 +8511,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 128,102,69
+				RightColor: 140,111,73
 	Template@527:
 		Category: Ground 02
 		Id: 527
@@ -4496,6 +8520,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 128,101,68
+				RightColor: 115,92,63
 	Template@528:
 		Category: Ground 02
 		Id: 528
@@ -4503,6 +8529,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 118,95,66
+				RightColor: 120,97,68
 	Template@529:
 		Category: Ground 02
 		Id: 529
@@ -4510,6 +8538,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 131,104,69
+				RightColor: 121,96,65
 	Template@530:
 		Category: Ground 02
 		Id: 530
@@ -4517,6 +8547,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 118,93,63
+				RightColor: 125,98,66
 	Template@531:
 		Category: Ground 02
 		Id: 531
@@ -4524,6 +8556,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 138,109,72
+				RightColor: 115,92,63
 	Template@532:
 		Category: Ground 02
 		Id: 532
@@ -4531,6 +8565,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 135,106,70
+				RightColor: 119,93,64
 	Template@533:
 		Category: Ground 02
 		Id: 533
@@ -4538,6 +8574,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 136,108,71
+				RightColor: 118,94,64
 	Template@534:
 		Category: Ground 02
 		Id: 534
@@ -4545,6 +8583,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 118,94,64
+				RightColor: 117,93,63
 	Template@535:
 		Category: Sand
 		Id: 535
@@ -4552,6 +8592,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 139,109,72
+				RightColor: 138,109,72
 	Template@536:
 		Category: Sand/Clear LAT
 		Id: 536
@@ -4559,6 +8601,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 124,98,67
+				RightColor: 129,102,69
 	Template@537:
 		Category: Sand/Clear LAT
 		Id: 537
@@ -4566,6 +8610,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 136,107,71
+				RightColor: 120,95,65
 	Template@538:
 		Category: Sand/Clear LAT
 		Id: 538
@@ -4573,6 +8619,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 131,104,69
+				RightColor: 121,96,66
 	Template@539:
 		Category: Sand/Clear LAT
 		Id: 539
@@ -4580,6 +8628,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 134,106,71
+				RightColor: 108,87,61
 	Template@540:
 		Category: Sand/Clear LAT
 		Id: 540
@@ -4587,6 +8637,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 123,97,66
+				RightColor: 136,108,72
 	Template@541:
 		Category: Sand/Clear LAT
 		Id: 541
@@ -4594,6 +8646,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 126,99,67
+				RightColor: 124,98,66
 	Template@542:
 		Category: Sand/Clear LAT
 		Id: 542
@@ -4601,6 +8655,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 119,94,64
+				RightColor: 115,92,63
 	Template@543:
 		Category: Sand/Clear LAT
 		Id: 543
@@ -4608,6 +8664,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 123,97,65
+				RightColor: 108,87,61
 	Template@544:
 		Category: Sand/Clear LAT
 		Id: 544
@@ -4615,6 +8673,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 117,94,65
+				RightColor: 127,101,68
 	Template@545:
 		Category: Sand/Clear LAT
 		Id: 545
@@ -4622,6 +8682,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 118,94,65
+				RightColor: 117,93,64
 	Template@546:
 		Category: Sand/Clear LAT
 		Id: 546
@@ -4629,6 +8691,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 128,102,68
+				RightColor: 124,99,67
 	Template@547:
 		Category: Sand/Clear LAT
 		Id: 547
@@ -4636,6 +8700,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 116,93,65
+				RightColor: 107,85,60
 	Template@548:
 		Category: Sand/Clear LAT
 		Id: 548
@@ -4643,6 +8709,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 109,88,62
+				RightColor: 131,104,69
 	Template@549:
 		Category: Sand/Clear LAT
 		Id: 549
@@ -4650,6 +8718,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 114,91,64
+				RightColor: 125,99,66
 	Template@550:
 		Category: Sand/Clear LAT
 		Id: 550
@@ -4657,6 +8727,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 116,92,63
+				RightColor: 128,101,67
 	Template@551:
 		Category: Sand/Clear LAT
 		Id: 551
@@ -4664,6 +8736,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 116,92,63
+				RightColor: 119,95,64
 	Template@552:
 		Category: Rough ground
 		Id: 552
@@ -4671,41 +8745,113 @@ Templates:
 		Size: 9, 7
 		Tiles:
 			2: Rough
+				LeftColor: 106,87,64
+				RightColor: 91,74,53
 			3: Rough
+				LeftColor: 78,66,49
+				RightColor: 100,82,60
 			11: Rough
+				LeftColor: 99,82,60
+				RightColor: 94,79,59
 			12: Rough
+				LeftColor: 82,70,54
+				RightColor: 75,61,43
 			13: Rough
+				LeftColor: 96,79,58
+				RightColor: 103,85,62
 			18: Rough
+				LeftColor: 109,90,67
+				RightColor: 104,86,63
 			19: Rough
+				LeftColor: 90,75,56
+				RightColor: 106,89,67
 			20: Rough
+				LeftColor: 93,77,55
+				RightColor: 93,78,57
 			21: Rough
+				LeftColor: 81,67,49
+				RightColor: 90,77,60
 			22: Rough
+				LeftColor: 62,52,39
+				RightColor: 93,76,56
 			23: Rough
+				LeftColor: 87,76,62
+				RightColor: 102,83,59
 			24: Rough
+				LeftColor: 98,81,60
+				RightColor: 96,79,58
 			25: Rough
+				LeftColor: 78,66,50
+				RightColor: 98,81,60
 			26: Rough
+				LeftColor: 106,90,69
+				RightColor: 102,83,60
 			28: Rough
+				LeftColor: 109,89,65
+				RightColor: 99,83,64
 			29: Rough
+				LeftColor: 93,77,57
+				RightColor: 96,82,63
 			30: Rough
+				LeftColor: 89,74,54
+				RightColor: 96,81,61
 			31: Rough
+				LeftColor: 86,73,56
+				RightColor: 87,72,53
 			32: Rough
+				LeftColor: 58,50,38
+				RightColor: 79,69,55
 			33: Rough
+				LeftColor: 87,75,59
+				RightColor: 91,78,61
 			34: Rough
+				LeftColor: 65,56,42
+				RightColor: 77,65,50
 			35: Rough
+				LeftColor: 80,68,52
+				RightColor: 97,81,60
 			38: Rough
+				LeftColor: 111,89,63
+				RightColor: 96,80,61
 			39: Rough
+				LeftColor: 106,86,62
+				RightColor: 102,84,62
 			40: Rough
+				LeftColor: 101,85,65
+				RightColor: 81,70,53
 			41: Rough
+				LeftColor: 60,51,36
+				RightColor: 70,60,46
 			42: Rough
+				LeftColor: 80,68,52
+				RightColor: 81,70,56
 			43: Rough
+				LeftColor: 84,76,64
+				RightColor: 86,74,58
 			44: Rough
+				LeftColor: 89,75,59
+				RightColor: 98,82,62
 			49: Rough
+				LeftColor: 110,91,68
+				RightColor: 97,83,65
 			50: Rough
+				LeftColor: 90,77,59
+				RightColor: 82,70,53
 			51: Rough
+				LeftColor: 89,76,58
+				RightColor: 87,75,59
 			52: Rough
+				LeftColor: 91,75,54
+				RightColor: 94,78,58
 			53: Rough
+				LeftColor: 105,88,65
+				RightColor: 98,81,61
 			60: Rough
+				LeftColor: 109,89,64
+				RightColor: 94,77,55
 			61: Rough
+				LeftColor: 108,88,64
+				RightColor: 99,84,64
 	Template@553:
 		Category: Rough ground
 		Id: 553
@@ -4713,15 +8859,35 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: Rough
+				LeftColor: 99,83,64
+				RightColor: 98,82,62
 			2: Rough
+				LeftColor: 83,69,51
+				RightColor: 104,87,66
 			4: Rough
+				LeftColor: 100,82,59
+				RightColor: 107,91,70
 			5: Rough
+				LeftColor: 95,83,66
+				RightColor: 85,74,57
 			6: Rough
+				LeftColor: 87,73,55
+				RightColor: 86,73,57
 			7: Rough
+				LeftColor: 90,74,54
+				RightColor: 100,81,59
 			8: Rough
+				LeftColor: 114,95,71
+				RightColor: 95,80,62
 			9: Rough
+				LeftColor: 96,82,63
+				RightColor: 91,78,59
 			10: Rough
+				LeftColor: 105,89,69
+				RightColor: 106,90,70
 			13: Rough
+				LeftColor: 107,88,65
+				RightColor: 96,81,60
 	Template@554:
 		Category: Rough ground
 		Id: 554
@@ -4729,16 +8895,38 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Rough
+				LeftColor: 107,89,66
+				RightColor: 97,82,63
 			1: Rough
+				LeftColor: 96,83,66
+				RightColor: 100,86,68
 			2: Rough
+				LeftColor: 91,79,63
+				RightColor: 107,90,67
 			3: Rough
+				LeftColor: 94,79,60
+				RightColor: 111,92,68
 			6: Rough
+				LeftColor: 105,88,68
+				RightColor: 84,73,58
 			7: Rough
+				LeftColor: 84,70,53
+				RightColor: 83,71,56
 			8: Rough
+				LeftColor: 80,71,58
+				RightColor: 92,77,58
 			9: Rough
+				LeftColor: 81,72,58
+				RightColor: 107,89,66
 			12: Rough
+				LeftColor: 105,87,63
+				RightColor: 93,80,63
 			13: Rough
+				LeftColor: 101,84,63
+				RightColor: 94,82,67
 			14: Rough
+				LeftColor: 99,83,65
+				RightColor: 85,72,54
 	Template@555:
 		Category: Rough ground
 		Id: 555
@@ -4746,13 +8934,29 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Rough
+				LeftColor: 108,89,68
+				RightColor: 95,80,60
 			1: Rough
+				LeftColor: 103,85,63
+				RightColor: 91,78,61
 			2: Rough
+				LeftColor: 73,63,48
+				RightColor: 107,89,66
 			5: Rough
+				LeftColor: 103,86,67
+				RightColor: 80,69,55
 			6: Rough
+				LeftColor: 63,59,51
+				RightColor: 62,53,41
 			7: Rough
+				LeftColor: 76,64,49
+				RightColor: 98,82,61
 			10: Rough
+				LeftColor: 100,84,63
+				RightColor: 75,67,54
 			11: Rough
+				LeftColor: 96,81,62
+				RightColor: 98,85,69
 	Template@556:
 		Category: Rough ground
 		Id: 556
@@ -4760,17 +8964,41 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			1: Rough
+				LeftColor: 98,82,62
+				RightColor: 108,91,69
 			3: Rough
+				LeftColor: 100,84,64
+				RightColor: 101,83,62
 			4: Rough
+				LeftColor: 86,79,69
+				RightColor: 80,68,52
 			5: Rough
+				LeftColor: 83,72,57
+				RightColor: 104,88,69
 			6: Rough
+				LeftColor: 96,83,67
+				RightColor: 92,78,59
 			7: Rough
+				LeftColor: 69,59,45
+				RightColor: 92,78,60
 			8: Rough
+				LeftColor: 93,79,63
+				RightColor: 98,83,65
 			9: Rough
+				LeftColor: 100,84,63
+				RightColor: 95,81,62
 			10: Rough
+				LeftColor: 74,65,52
+				RightColor: 72,65,54
 			11: Rough
+				LeftColor: 73,63,50
+				RightColor: 88,73,55
 			13: Rough
+				LeftColor: 108,89,65
+				RightColor: 96,81,61
 			14: Rough
+				LeftColor: 97,84,67
+				RightColor: 90,76,58
 	Template@557:
 		Category: Rough ground
 		Id: 557
@@ -4778,18 +9006,44 @@ Templates:
 		Size: 4, 4
 		Tiles:
 			1: Clear
+				LeftColor: 101,83,61
+				RightColor: 100,82,61
 			2: Clear
+				LeftColor: 104,88,70
+				RightColor: 107,87,63
 			4: Clear
+				LeftColor: 108,88,65
+				RightColor: 110,92,69
 			5: Rough
+				LeftColor: 77,68,53
+				RightColor: 91,77,59
 			6: Rough
+				LeftColor: 79,69,54
+				RightColor: 68,60,48
 			7: Rough
+				LeftColor: 85,73,58
+				RightColor: 110,88,63
 			8: Clear
+				LeftColor: 113,94,70
+				RightColor: 103,88,69
 			9: Rough
+				LeftColor: 81,71,56
+				RightColor: 73,65,52
 			10: Rough
+				LeftColor: 79,68,54
+				RightColor: 76,67,55
 			11: Rough
+				LeftColor: 85,73,57
+				RightColor: 99,84,64
 			13: Rough
+				LeftColor: 109,88,62
+				RightColor: 98,81,60
 			14: Rough
+				LeftColor: 99,83,63
+				RightColor: 98,83,64
 			15: Rough
+				LeftColor: 86,74,58
+				RightColor: 88,75,58
 	Template@558:
 		Category: Rough ground
 		Id: 558
@@ -4797,13 +9051,29 @@ Templates:
 		Size: 3, 3
 		Tiles:
 			0: Rough
+				LeftColor: 97,81,62
+				RightColor: 93,76,56
 			1: Rough
+				LeftColor: 85,74,57
+				RightColor: 100,83,61
 			2: Rough
+				LeftColor: 94,78,57
+				RightColor: 112,93,71
 			3: Rough
+				LeftColor: 109,92,71
+				RightColor: 95,82,66
 			4: Rough
+				LeftColor: 99,82,61
+				RightColor: 72,64,53
 			5: Rough
+				LeftColor: 85,73,57
+				RightColor: 102,85,65
 			7: Rough
+				LeftColor: 104,85,61
+				RightColor: 82,70,53
 			8: Rough
+				LeftColor: 98,83,63
+				RightColor: 85,71,53
 	Template@559:
 		Category: Rough ground
 		Id: 559
@@ -4811,27 +9081,71 @@ Templates:
 		Size: 6, 10
 		Tiles:
 			1: Rough
+				LeftColor: 104,85,62
+				RightColor: 101,84,64
 			6: Rough
+				LeftColor: 110,92,70
+				RightColor: 92,76,56
 			7: Rough
+				LeftColor: 91,77,58
+				RightColor: 93,81,66
 			12: Rough
+				LeftColor: 108,89,66
+				RightColor: 81,70,54
 			13: Rough
+				LeftColor: 84,72,56
+				RightColor: 90,76,58
 			14: Rough
+				LeftColor: 81,71,55
+				RightColor: 98,80,57
 			15: Rough
+				LeftColor: 91,77,57
+				RightColor: 107,87,64
 			20: Rough
+				LeftColor: 101,85,64
+				RightColor: 92,76,55
 			21: Rough
+				LeftColor: 77,65,49
+				RightColor: 96,79,56
 			22: Rough
+				LeftColor: 66,55,40
+				RightColor: 106,87,65
 			26: Rough
+				LeftColor: 104,86,63
+				RightColor: 99,83,62
 			27: Rough
+				LeftColor: 84,71,55
+				RightColor: 73,65,53
 			28: Rough
+				LeftColor: 77,63,45
+				RightColor: 84,69,49
 			33: Rough
+				LeftColor: 104,86,64
+				RightColor: 89,75,57
 			34: Rough
+				LeftColor: 86,74,58
+				RightColor: 87,72,52
 			35: Rough
+				LeftColor: 105,87,64
+				RightColor: 111,91,66
 			40: Rough
+				LeftColor: 98,85,70
+				RightColor: 95,81,63
 			45: Rough
+				LeftColor: 92,78,59
+				RightColor: 97,82,62
 			46: Rough
+				LeftColor: 103,85,63
+				RightColor: 97,81,61
 			51: Rough
+				LeftColor: 90,76,57
+				RightColor: 79,67,50
 			52: Rough
+				LeftColor: 101,82,60
+				RightColor: 103,84,61
 			57: Rough
+				LeftColor: 108,89,66
+				RightColor: 89,75,57
 	Template@560:
 		Category: Rough ground
 		Id: 560
@@ -4839,21 +9153,53 @@ Templates:
 		Size: 8, 3
 		Tiles:
 			0: Clear
+				LeftColor: 98,79,54
+				RightColor: 113,91,64
 			1: Rough
+				LeftColor: 92,78,59
+				RightColor: 95,79,58
 			2: Rough
+				LeftColor: 84,73,56
+				RightColor: 95,78,57
 			3: Rough
+				LeftColor: 77,65,49
+				RightColor: 108,88,63
 			4: Rough
+				LeftColor: 84,72,55
+				RightColor: 103,86,65
 			5: Clear
+				LeftColor: 95,82,65
+				RightColor: 107,88,65
 			8: Rough
+				LeftColor: 100,84,64
+				RightColor: 84,73,57
 			9: Clear
+				LeftColor: 111,91,66
+				RightColor: 111,93,71
 			10: Clear
+				LeftColor: 112,91,66
+				RightColor: 104,89,71
 			11: Clear
+				LeftColor: 112,93,69
+				RightColor: 95,82,64
 			12: Rough
+				LeftColor: 94,80,60
+				RightColor: 82,69,51
 			13: Rough
+				LeftColor: 82,70,54
+				RightColor: 83,72,58
 			14: Rough
+				LeftColor: 87,77,62
+				RightColor: 102,87,67
 			15: Rough
+				LeftColor: 96,82,63
+				RightColor: 101,85,65
 			21: Clear
+				LeftColor: 110,90,66
+				RightColor: 102,89,71
 			22: Clear
+				LeftColor: 102,85,64
+				RightColor: 114,93,68
 	Template@561:
 		Category: Rough ground
 		Id: 561
@@ -4861,13 +9207,29 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Rough
+				LeftColor: 101,83,61
+				RightColor: 95,78,57
 			1: Rough
+				LeftColor: 97,85,70
+				RightColor: 106,87,63
 			3: Rough
+				LeftColor: 96,81,62
+				RightColor: 85,75,62
 			4: Rough
+				LeftColor: 90,75,56
+				RightColor: 80,70,58
 			5: Rough
+				LeftColor: 94,79,59
+				RightColor: 105,88,66
 			7: Rough
+				LeftColor: 101,84,62
+				RightColor: 79,69,56
 			8: Rough
+				LeftColor: 90,74,54
+				RightColor: 96,81,60
 			10: Rough
+				LeftColor: 105,87,65
+				RightColor: 100,84,63
 	Template@562:
 		Category: Paved Road Ends
 		Id: 562
@@ -4875,8 +9237,14 @@ Templates:
 		Size: 1, 3
 		Tiles:
 			0: Rough
+				LeftColor: 57,55,52
+				RightColor: 77,72,63
 			1: Rough
+				LeftColor: 59,55,48
+				RightColor: 66,60,51
 			2: Rough
+				LeftColor: 77,74,69
+				RightColor: 69,63,54
 	Template@563:
 		Category: Paved Road Ends
 		Id: 563
@@ -4884,8 +9252,14 @@ Templates:
 		Size: 3, 1
 		Tiles:
 			0: Rough
+				LeftColor: 80,78,74
+				RightColor: 62,58,52
 			1: Rough
+				LeftColor: 62,59,52
+				RightColor: 64,59,54
 			2: Rough
+				LeftColor: 63,60,56
+				RightColor: 98,84,65
 	Template@564:
 		Category: Paved Road Ends
 		Id: 564
@@ -4893,8 +9267,14 @@ Templates:
 		Size: 1, 3
 		Tiles:
 			0: Rough
+				LeftColor: 63,58,51
+				RightColor: 74,70,65
 			1: Rough
+				LeftColor: 79,68,54
+				RightColor: 55,51,45
 			2: Rough
+				LeftColor: 74,67,57
+				RightColor: 66,60,51
 	Template@565:
 		Category: Paved Road Ends
 		Id: 565
@@ -4902,8 +9282,14 @@ Templates:
 		Size: 3, 1
 		Tiles:
 			0: Rough
+				LeftColor: 91,78,62
+				RightColor: 59,57,54
 			1: Rough
+				LeftColor: 70,61,47
+				RightColor: 62,59,52
 			2: Rough
+				LeftColor: 69,62,52
+				RightColor: 74,69,62
 	Template@566:
 		Category: TrainBridges
 		Id: 566
@@ -4911,20 +9297,58 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 111,107,102
+				RightColor: 85,79,70
 			1: Cliff
+				LeftColor: 110,106,97
+				RightColor: 99,94,87
 			2: Cliff
+				LeftColor: 110,90,65
+				RightColor: 108,88,64
 			3: Road
+				Height: 4
+				LeftColor: 51,49,47
+				RightColor: 75,74,72
 			4: Road
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 88,88,85
 			5: Cliff
+				LeftColor: 108,87,63
+				RightColor: 107,94,77
 			6: Rail
+				Height: 4
+				LeftColor: 54,55,57
+				RightColor: 57,58,60
 			7: Rail
+				Height: 4
+				LeftColor: 53,55,57
+				RightColor: 57,58,60
 			8: Cliff
+				LeftColor: 112,92,68
+				RightColor: 98,93,85
 			9: Road
+				Height: 4
+				LeftColor: 76,74,72
+				RightColor: 53,50,47
 			10: Road
+				Height: 4
+				LeftColor: 77,76,74
+				RightColor: 50,49,47
 			11: Cliff
+				LeftColor: 111,88,62
+				RightColor: 95,88,79
 			12: Cliff
+				Height: 4
+				LeftColor: 91,86,78
+				RightColor: 119,117,113
 			13: Cliff
+				LeftColor: 110,97,80
+				RightColor: 133,130,121
 			14: Cliff
+				LeftColor: 112,90,64
+				RightColor: 112,89,62
 	Template@567:
 		Category: TrainBridges
 		Id: 567
@@ -4932,20 +9356,58 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 111,107,102
+				RightColor: 85,79,70
 			1: Cliff
+				LeftColor: 111,108,102
+				RightColor: 94,92,88
 			2: Cliff
+				LeftColor: 21,39,59
+				RightColor: 15,35,57
 			3: Road
+				Height: 4
+				LeftColor: 51,49,47
+				RightColor: 75,74,72
 			4: Road
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 88,88,85
 			5: Cliff
+				LeftColor: 30,41,51
+				RightColor: 62,69,75
 			6: Rail
+				Height: 4
+				LeftColor: 54,55,57
+				RightColor: 57,58,60
 			7: Rail
+				Height: 4
+				LeftColor: 53,55,57
+				RightColor: 57,58,60
 			8: Cliff
+				LeftColor: 31,44,57
+				RightColor: 81,83,85
 			9: Road
+				Height: 4
+				LeftColor: 76,74,72
+				RightColor: 53,50,47
 			10: Road
+				Height: 4
+				LeftColor: 77,76,74
+				RightColor: 50,49,47
 			11: Cliff
+				LeftColor: 35,51,68
+				RightColor: 77,79,79
 			12: Cliff
+				Height: 4
+				LeftColor: 91,86,78
+				RightColor: 119,117,113
 			13: Cliff
+				LeftColor: 80,79,75
+				RightColor: 132,130,122
 			14: Cliff
+				LeftColor: 36,51,65
+				RightColor: 22,39,60
 	Template@568:
 		Category: TrainBridges
 		Id: 568
@@ -4953,15 +9415,43 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 0,0,0
+				RightColor: 0,0,0
 			1: Cliff
+				Height: 4
+				LeftColor: 114,111,106
+				RightColor: 88,81,71
 			2: Road
+				Height: 4
+				LeftColor: 51,49,47
+				RightColor: 96,94,90
 			3: Road
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 73,72,70
 			4: Rail
+				Height: 4
+				LeftColor: 54,55,57
+				RightColor: 57,58,60
 			5: Rail
+				Height: 4
+				LeftColor: 53,55,57
+				RightColor: 57,58,60
 			6: Road
+				Height: 4
+				LeftColor: 76,76,75
+				RightColor: 53,50,47
 			7: Road
+				Height: 4
+				LeftColor: 75,73,69
+				RightColor: 50,49,48
 			8: Cliff
+				LeftColor: 140,133,121
+				RightColor: 138,133,122
 			9: Cliff
+				Height: 4
+				LeftColor: 83,77,67
+				RightColor: 106,104,101
 	Template@569:
 		Category: TrainBridges
 		Id: 569
@@ -4969,20 +9459,58 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,73,64
+				RightColor: 99,96,91
 			1: Road
+				Height: 4
+				LeftColor: 75,74,72
+				RightColor: 51,49,47
 			2: Rail
+				Height: 4
+				LeftColor: 55,56,58
+				RightColor: 53,55,56
 			3: Road
+				Height: 4
+				LeftColor: 52,50,47
+				RightColor: 73,72,68
 			4: Cliff
+				Height: 4
+				LeftColor: 91,89,85
+				RightColor: 86,77,66
 			5: Cliff
+				LeftColor: 153,142,125
+				RightColor: 152,149,141
 			6: Road
+				Height: 4
+				LeftColor: 73,72,69
+				RightColor: 72,71,69
 			7: Rail
+				Height: 4
+				LeftColor: 55,56,58
+				RightColor: 53,54,57
 			8: Road
+				Height: 4
+				LeftColor: 50,49,46
+				RightColor: 75,73,69
 			9: Cliff
+				LeftColor: 100,90,76
+				RightColor: 106,101,91
 			10: Cliff
+				LeftColor: 109,87,61
+				RightColor: 111,89,62
 			11: Cliff
+				LeftColor: 110,88,61
+				RightColor: 136,122,104
 			12: Cliff
+				LeftColor: 114,92,65
+				RightColor: 141,134,122
 			13: Cliff
+				LeftColor: 111,90,64
+				RightColor: 139,132,120
 			14: Cliff
+				LeftColor: 112,92,67
+				RightColor: 108,87,62
 	Template@570:
 		Category: TrainBridges
 		Id: 570
@@ -4990,20 +9518,58 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 79,73,64
+				RightColor: 99,96,91
 			1: Road
+				Height: 4
+				LeftColor: 75,74,72
+				RightColor: 51,49,47
 			2: Rail
+				Height: 4
+				LeftColor: 55,56,58
+				RightColor: 53,55,56
 			3: Road
+				Height: 4
+				LeftColor: 52,50,47
+				RightColor: 73,72,68
 			4: Cliff
+				Height: 4
+				LeftColor: 91,89,85
+				RightColor: 86,77,66
 			5: Cliff
+				LeftColor: 136,137,137
+				RightColor: 152,149,141
 			6: Road
+				Height: 4
+				LeftColor: 73,72,69
+				RightColor: 72,71,69
 			7: Rail
+				Height: 4
+				LeftColor: 55,56,58
+				RightColor: 53,54,57
 			8: Road
+				Height: 4
+				LeftColor: 50,49,46
+				RightColor: 75,73,69
 			9: Cliff
+				LeftColor: 93,88,79
+				RightColor: 103,99,91
 			10: Cliff
+				LeftColor: 14,32,54
+				RightColor: 25,42,62
 			11: Cliff
+				LeftColor: 16,33,53
+				RightColor: 102,107,110
 			12: Cliff
+				LeftColor: 18,36,57
+				RightColor: 127,127,124
 			13: Cliff
+				LeftColor: 17,35,55
+				RightColor: 128,129,126
 			14: Cliff
+				LeftColor: 17,33,53
+				RightColor: 34,48,65
 	Template@571:
 		Category: TrainBridges
 		Id: 571
@@ -5011,15 +9577,43 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 0,0,0
+				RightColor: 0,0,0
 			1: Road
+				Height: 4
+				LeftColor: 76,76,76
+				RightColor: 76,75,74
 			2: Rail
+				Height: 4
+				LeftColor: 55,56,58
+				RightColor: 53,55,56
 			3: Road
+				Height: 4
+				LeftColor: 53,51,47
+				RightColor: 77,76,75
 			4: Cliff
+				LeftColor: 104,95,85
+				RightColor: 107,102,95
 			5: Cliff
+				Height: 4
+				LeftColor: 86,77,64
+				RightColor: 96,94,91
 			6: Road
+				Height: 4
+				LeftColor: 77,77,76
+				RightColor: 51,50,48
 			7: Rail
+				Height: 4
+				LeftColor: 55,56,57
+				RightColor: 53,54,57
 			8: Road
+				Height: 4
+				LeftColor: 49,49,48
+				RightColor: 75,76,76
 			9: Cliff
+				Height: 4
+				LeftColor: 94,91,87
+				RightColor: 86,83,78
 	Template@572:
 		Category: TrainBridges
 		Id: 572
@@ -5027,15 +9621,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 113,112,109
+				RightColor: 106,105,103
 			1: Cliff
+				LeftColor: 204,205,221
+				RightColor: 209,210,238
 			2: Road
+				Height: 4
+				LeftColor: 69,70,70
+				RightColor: 109,109,110
 			3: Cliff
+				LeftColor: 204,205,221
+				RightColor: 159,159,171
 			4: Rail
+				Height: 4
+				LeftColor: 55,54,51
+				RightColor: 55,54,50
 			5: Cliff
+				LeftColor: 200,202,222
+				RightColor: 116,116,120
 			6: Road
+				Height: 4
+				LeftColor: 98,98,98
+				RightColor: 70,70,70
 			7: Cliff
+				LeftColor: 200,202,223
+				RightColor: 115,115,121
 			8: Cliff
+				LeftColor: 181,181,185
+				RightColor: 153,152,150
 			9: Cliff
+				LeftColor: 200,203,230
+				RightColor: 195,197,247
 	Template@573:
 		Category: TrainBridges
 		Id: 573
@@ -5043,15 +9660,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 113,112,109
+				RightColor: 105,104,103
 			1: Cliff
+				LeftColor: 204,205,221
+				RightColor: 209,210,238
 			2: Road
+				Height: 4
+				LeftColor: 63,64,65
+				RightColor: 102,102,103
 			3: Cliff
+				LeftColor: 204,205,221
+				RightColor: 159,159,171
 			4: Rough
+				Height: 4
+				LeftColor: 52,51,49
+				RightColor: 56,55,52
 			5: Cliff
+				LeftColor: 200,202,222
+				RightColor: 116,116,120
 			6: Road
+				Height: 4
+				LeftColor: 74,74,74
+				RightColor: 65,65,65
 			7: Cliff
+				LeftColor: 200,202,223
+				RightColor: 115,115,121
 			8: Cliff
+				LeftColor: 166,166,170
+				RightColor: 147,146,144
 			9: Cliff
+				LeftColor: 198,200,227
+				RightColor: 195,197,247
 	Template@574:
 		Category: TrainBridges
 		Id: 574
@@ -5059,15 +9699,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 113,112,109
+				RightColor: 106,105,103
 			1: Cliff
+				LeftColor: 200,202,217
+				RightColor: 209,210,238
 			2: Road
+				Height: 4
+				LeftColor: 64,64,64
+				RightColor: 101,101,101
 			3: Cliff
+				LeftColor: 185,187,202
+				RightColor: 142,143,151
 			4: Rail
+				Height: 4
+				LeftColor: 54,53,51
+				RightColor: 49,49,47
 			5: Cliff
+				LeftColor: 184,187,203
+				RightColor: 114,114,118
 			6: Road
+				Height: 4
+				LeftColor: 91,91,91
+				RightColor: 64,64,64
 			7: Cliff
+				LeftColor: 191,192,206
+				RightColor: 110,110,115
 			8: Cliff
+				LeftColor: 179,178,182
+				RightColor: 145,144,143
 			9: Cliff
+				LeftColor: 198,200,227
+				RightColor: 177,179,218
 	Template@575:
 		Category: TrainBridges
 		Id: 575
@@ -5075,15 +9738,38 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 113,112,109
+				RightColor: 104,103,101
 			1: Cliff
+				LeftColor: 200,202,217
+				RightColor: 209,210,238
 			2: Rough
+				Height: 4
+				LeftColor: 60,60,61
+				RightColor: 91,91,91
 			3: Cliff
+				LeftColor: 185,187,202
+				RightColor: 142,143,151
 			4: Rough
+				Height: 4
+				LeftColor: 53,53,51
+				RightColor: 52,51,48
 			5: Cliff
+				LeftColor: 184,187,203
+				RightColor: 114,114,118
 			6: Rough
+				Height: 4
+				LeftColor: 75,75,75
+				RightColor: 61,61,61
 			7: Cliff
+				LeftColor: 191,192,206
+				RightColor: 110,110,115
 			8: Cliff
+				LeftColor: 166,166,170
+				RightColor: 145,145,143
 			9: Cliff
+				LeftColor: 198,200,227
+				RightColor: 177,179,218
 	Template@576:
 		Category: TrainBridges
 		Id: 576
@@ -5091,15 +9777,35 @@ Templates:
 		Size: 2, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 122,121,119
+				RightColor: 144,144,143
 			1: Cliff
+				LeftColor: 195,196,208
+				RightColor: 181,182,199
 			2: Cliff
+				LeftColor: 99,98,96
+				RightColor: 108,108,106
 			3: Cliff
+				LeftColor: 122,124,132
+				RightColor: 176,177,198
 			4: Cliff
+				LeftColor: 110,109,107
+				RightColor: 132,131,128
 			5: Cliff
+				LeftColor: 151,154,167
+				RightColor: 125,127,137
 			6: Cliff
+				LeftColor: 121,120,117
+				RightColor: 151,150,146
 			7: Cliff
+				LeftColor: 186,187,198
+				RightColor: 185,187,221
 			8: Cliff
+				LeftColor: 179,179,186
+				RightColor: 169,169,173
 			9: Cliff
+				LeftColor: 198,200,227
+				RightColor: 176,178,214
 	Template@577:
 		Category: TrainBridges
 		Id: 577
@@ -5107,15 +9813,38 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 189,189,197
+				RightColor: 157,156,152
 			1: Road
+				Height: 4
+				LeftColor: 97,97,97
+				RightColor: 86,86,87
 			2: Rail
+				Height: 4
+				LeftColor: 54,53,49
+				RightColor: 55,54,50
 			3: Road
+				Height: 4
+				LeftColor: 69,69,69
+				RightColor: 96,96,97
 			4: Cliff
+				LeftColor: 143,143,151
+				RightColor: 137,136,137
 			5: Cliff
+				LeftColor: 211,211,241
+				RightColor: 205,206,228
 			6: Cliff
+				LeftColor: 203,205,226
+				RightColor: 183,184,196
 			7: Cliff
+				LeftColor: 207,208,239
+				RightColor: 166,164,166
 			8: Cliff
+				LeftColor: 200,202,245
+				RightColor: 163,163,165
 			9: Cliff
+				LeftColor: 200,202,245
+				RightColor: 203,205,236
 	Template@578:
 		Category: TrainBridges
 		Id: 578
@@ -5123,14 +9852,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			1: Road
+				Height: 4
+				LeftColor: 88,88,88
+				RightColor: 78,78,78
 			2: Rail
+				Height: 4
+				LeftColor: 51,50,47
+				RightColor: 52,51,48
 			3: Road
+				Height: 4
+				LeftColor: 68,68,68
+				RightColor: 83,83,83
 			4: Cliff
+				LeftColor: 143,143,151
+				RightColor: 137,137,137
 			5: Cliff
+				LeftColor: 211,211,241
+				RightColor: 186,186,194
 			6: Cliff
+				LeftColor: 203,205,226
+				RightColor: 163,163,164
 			7: Cliff
+				LeftColor: 207,208,239
+				RightColor: 166,164,166
 			8: Cliff
+				LeftColor: 200,202,245
+				RightColor: 163,163,165
 			9: Cliff
+				LeftColor: 200,202,245
+				RightColor: 203,205,236
 	Template@579:
 		Category: TrainBridges
 		Id: 579
@@ -5138,15 +9888,38 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 163,163,170
+				RightColor: 142,141,137
 			1: Road
+				Height: 4
+				LeftColor: 86,86,86
+				RightColor: 81,81,81
 			2: Rail
+				Height: 4
+				LeftColor: 51,50,46
+				RightColor: 55,54,51
 			3: Road
+				Height: 4
+				LeftColor: 63,63,63
+				RightColor: 95,96,96
 			4: Cliff
+				LeftColor: 143,143,151
+				RightColor: 136,135,136
 			5: Cliff
+				LeftColor: 211,211,241
+				RightColor: 190,191,211
 			6: Cliff
+				LeftColor: 192,194,213
+				RightColor: 165,166,176
 			7: Cliff
+				LeftColor: 197,199,223
+				RightColor: 150,148,148
 			8: Cliff
+				LeftColor: 195,197,228
+				RightColor: 158,157,159
 			9: Cliff
+				LeftColor: 199,201,243
+				RightColor: 203,205,236
 	Template@580:
 		Category: TrainBridges
 		Id: 580
@@ -5154,14 +9927,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			1: Rough
+				Height: 4
+				LeftColor: 65,66,66
+				RightColor: 75,75,75
 			2: Rough
+				Height: 4
+				LeftColor: 46,45,43
+				RightColor: 45,43,40
 			3: Rough
+				Height: 4
+				LeftColor: 49,49,49
+				RightColor: 77,77,77
 			4: Cliff
+				LeftColor: 134,134,138
+				RightColor: 132,131,132
 			5: Cliff
+				LeftColor: 199,200,226
+				RightColor: 170,170,176
 			6: Cliff
+				LeftColor: 192,194,213
+				RightColor: 144,144,145
 			7: Cliff
+				LeftColor: 194,195,219
+				RightColor: 148,147,146
 			8: Cliff
+				LeftColor: 195,197,228
+				RightColor: 162,161,163
 			9: Cliff
+				LeftColor: 195,197,240
+				RightColor: 185,186,212
 	Template@581:
 		Category: TrainBridges
 		Id: 581
@@ -5169,15 +9963,35 @@ Templates:
 		Size: 5, 2
 		Tiles:
 			0: Cliff
+				LeftColor: 162,163,170
+				RightColor: 138,137,135
 			1: Cliff
+				LeftColor: 151,151,151
+				RightColor: 150,148,145
 			2: Cliff
+				LeftColor: 138,136,131
+				RightColor: 136,135,131
 			3: Cliff
+				LeftColor: 149,147,144
+				RightColor: 120,119,118
 			4: Cliff
+				LeftColor: 132,132,137
+				RightColor: 145,145,153
 			5: Cliff
+				LeftColor: 199,200,226
+				RightColor: 187,188,201
 			6: Cliff
+				LeftColor: 183,185,199
+				RightColor: 167,169,186
 			7: Cliff
+				LeftColor: 176,176,188
+				RightColor: 112,113,120
 			8: Cliff
+				LeftColor: 194,196,228
+				RightColor: 162,163,173
 			9: Cliff
+				LeftColor: 191,193,235
+				RightColor: 183,185,211
 	Template@582:
 		Category: Pavement
 		Id: 582
@@ -5185,6 +9999,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 86,85,83
+				RightColor: 83,82,80
 	Template@583:
 		Category: Pavement
 		Id: 583
@@ -5192,6 +10008,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 88,87,84
+				RightColor: 84,82,80
 	Template@584:
 		Category: Pavement
 		Id: 584
@@ -5199,6 +10017,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 84,83,80
+				RightColor: 82,82,81
 	Template@585:
 		Category: Pavement
 		Id: 585
@@ -5206,6 +10026,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 80,79,77
+				RightColor: 77,77,76
 	Template@586:
 		Category: Pavement
 		Id: 586
@@ -5213,9 +10035,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 87,83,78
+				RightColor: 85,82,78
 			1: Road
+				LeftColor: 85,81,77
+				RightColor: 84,82,79
 			2: Road
+				LeftColor: 82,81,79
+				RightColor: 84,81,76
 			3: Road
+				LeftColor: 83,82,79
+				RightColor: 89,84,79
 	Template@587:
 		Category: Pavement
 		Id: 587
@@ -5223,9 +10053,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 86,85,83
+				RightColor: 83,82,80
 			1: Road
+				LeftColor: 83,82,81
+				RightColor: 82,82,81
 			2: Road
+				LeftColor: 86,84,82
+				RightColor: 84,82,81
 			3: Road
+				LeftColor: 86,85,84
+				RightColor: 87,87,86
 	Template@588:
 		Category: Pavement
 		Id: 588
@@ -5233,9 +10071,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 82,81,79
+				RightColor: 78,77,77
 			1: Road
+				LeftColor: 84,83,82
+				RightColor: 86,85,82
 			2: Road
+				LeftColor: 86,85,83
+				RightColor: 86,85,82
 			3: Road
+				LeftColor: 79,78,76
+				RightColor: 81,80,78
 	Template@589:
 		Category: Pavement
 		Id: 589
@@ -5243,9 +10089,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 89,88,85
+				RightColor: 85,84,81
 			1: Road
+				LeftColor: 90,89,86
+				RightColor: 90,88,85
 			2: Road
+				LeftColor: 86,84,82
+				RightColor: 86,85,83
 			3: Road
+				LeftColor: 87,86,83
+				RightColor: 90,88,84
 	Template@590:
 		Category: Pavement
 		Id: 590
@@ -5253,9 +10107,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 91,90,88
+				RightColor: 91,88,85
 			1: Road
+				LeftColor: 91,91,88
+				RightColor: 89,88,85
 			2: Road
+				LeftColor: 83,82,79
+				RightColor: 84,83,81
 			3: Road
+				LeftColor: 85,83,80
+				RightColor: 88,86,84
 	Template@591:
 		Category: Pavement
 		Id: 591
@@ -5263,9 +10125,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 88,85,82
+				RightColor: 83,82,82
 			1: Road
+				LeftColor: 86,85,83
+				RightColor: 85,84,81
 			2: Road
+				LeftColor: 85,83,81
+				RightColor: 84,84,82
 			3: Road
+				LeftColor: 87,83,79
+				RightColor: 84,83,83
 	Template@592:
 		Category: Pavement
 		Id: 592
@@ -5273,9 +10143,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 87,83,77
+				RightColor: 91,86,81
 			1: Road
+				LeftColor: 93,89,82
+				RightColor: 90,87,83
 			2: Road
+				LeftColor: 85,82,79
+				RightColor: 91,85,77
 			3: Road
+				LeftColor: 91,87,81
+				RightColor: 91,89,85
 	Template@593:
 		Category: Pavement
 		Id: 593
@@ -5283,9 +10161,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 88,84,79
+				RightColor: 95,88,79
 			1: Road
+				LeftColor: 95,90,83
+				RightColor: 90,86,81
 			2: Road
+				LeftColor: 90,86,82
+				RightColor: 97,91,83
 			3: Road
+				LeftColor: 91,85,78
+				RightColor: 85,83,79
 	Template@594:
 		Category: Pavement
 		Id: 594
@@ -5293,9 +10179,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 86,83,78
+				RightColor: 89,85,79
 			1: Road
+				LeftColor: 92,87,80
+				RightColor: 87,85,81
 			2: Road
+				LeftColor: 86,84,80
+				RightColor: 90,86,80
 			3: Road
+				LeftColor: 92,87,80
+				RightColor: 85,84,82
 	Template@595:
 		Category: Pavement
 		Id: 595
@@ -5303,9 +10197,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Road
+				LeftColor: 86,83,78
+				RightColor: 89,85,79
 			1: Road
+				LeftColor: 92,87,80
+				RightColor: 87,85,81
 			2: Road
+				LeftColor: 86,84,80
+				RightColor: 90,86,80
 			3: Road
+				LeftColor: 92,87,80
+				RightColor: 85,84,82
 	Template@596:
 		Category: Pavement/Clear LAT
 		Id: 596
@@ -5313,6 +10215,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 94,85,74
+				RightColor: 97,85,72
 	Template@597:
 		Category: Pavement/Clear LAT
 		Id: 597
@@ -5320,6 +10224,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 88,84,76
+				RightColor: 97,85,70
 	Template@598:
 		Category: Pavement/Clear LAT
 		Id: 598
@@ -5327,6 +10233,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 88,84,78
+				RightColor: 99,87,71
 	Template@599:
 		Category: Pavement/Clear LAT
 		Id: 599
@@ -5334,6 +10242,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 95,87,77
+				RightColor: 112,90,62
 	Template@600:
 		Category: Pavement/Clear LAT
 		Id: 600
@@ -5341,6 +10251,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 98,85,70
+				RightColor: 86,82,77
 	Template@601:
 		Category: Pavement/Clear LAT
 		Id: 601
@@ -5348,6 +10260,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 101,86,68
+				RightColor: 100,86,68
 	Template@602:
 		Category: Pavement/Clear LAT
 		Id: 602
@@ -5355,6 +10269,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 103,86,66
+				RightColor: 105,88,68
 	Template@603:
 		Category: Pavement/Clear LAT
 		Id: 603
@@ -5362,6 +10278,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 91,83,72
+				RightColor: 103,85,64
 	Template@604:
 		Category: Pavement/Clear LAT
 		Id: 604
@@ -5369,6 +10287,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 102,90,73
+				RightColor: 92,87,78
 	Template@605:
 		Category: Pavement/Clear LAT
 		Id: 605
@@ -5376,6 +10296,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 105,92,73
+				RightColor: 99,89,74
 	Template@606:
 		Category: Pavement/Clear LAT
 		Id: 606
@@ -5383,6 +10305,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 100,89,75
+				RightColor: 100,88,73
 	Template@607:
 		Category: Pavement/Clear LAT
 		Id: 607
@@ -5390,6 +10314,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 98,85,71
+				RightColor: 108,87,62
 	Template@608:
 		Category: Pavement/Clear LAT
 		Id: 608
@@ -5397,6 +10323,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 109,89,65
+				RightColor: 86,84,78
 	Template@609:
 		Category: Pavement/Clear LAT
 		Id: 609
@@ -5404,6 +10332,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 111,90,63
+				RightColor: 100,88,74
 	Template@610:
 		Category: Pavement/Clear LAT
 		Id: 610
@@ -5411,6 +10341,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 108,89,67
+				RightColor: 99,87,71
 	Template@611:
 		Category: Pavement/Clear LAT
 		Id: 611
@@ -5418,6 +10350,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 100,86,69
+				RightColor: 101,87,69
 	Template@612:
 		Category: Paved road bits
 		Id: 612
@@ -5425,6 +10359,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 62,59,56
+				RightColor: 68,63,58
 	Template@613:
 		Category: Paved road bits
 		Id: 613
@@ -5432,6 +10368,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 73,65,57
+				RightColor: 75,67,58
 	Template@614:
 		Category: Paved road bits
 		Id: 614
@@ -5439,6 +10377,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 65,61,56
+				RightColor: 63,61,57
 	Template@615:
 		Category: Paved road bits
 		Id: 615
@@ -5446,6 +10386,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 58,57,55
+				RightColor: 69,63,55
 	Template@616:
 		Category: Paved road bits
 		Id: 616
@@ -5453,6 +10395,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 75,67,58
+				RightColor: 73,65,57
 	Template@617:
 		Category: Paved road bits
 		Id: 617
@@ -5460,6 +10404,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 70,64,56
+				RightColor: 57,56,56
 	Template@618:
 		Category: Paved road bits
 		Id: 618
@@ -5467,6 +10413,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 64,62,59
+				RightColor: 73,68,63
 	Template@619:
 		Category: Paved road bits
 		Id: 619
@@ -5474,6 +10422,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 74,66,58
+				RightColor: 77,69,59
 	Template@620:
 		Category: Paved road bits
 		Id: 620
@@ -5481,6 +10431,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 71,67,63
+				RightColor: 67,65,61
 	Template@621:
 		Category: Paved road bits
 		Id: 621
@@ -5488,6 +10440,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 64,63,61
+				RightColor: 71,65,57
 	Template@622:
 		Category: Paved road bits
 		Id: 622
@@ -5495,6 +10449,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				LeftColor: 77,69,59
+				RightColor: 74,66,58
 	Template@623:
 		Category: Paved road bits
 		Id: 623
@@ -5502,6 +10458,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
+				LeftColor: 72,66,58
+				RightColor: 64,64,63
 	Template@624:
 		Category: Paved road bits
 		Id: 624
@@ -5509,8 +10467,14 @@ Templates:
 		Size: 1, 3
 		Tiles:
 			0: Road
+				LeftColor: 73,72,70
+				RightColor: 82,80,78
 			1: Road
+				LeftColor: 70,69,66
+				RightColor: 69,67,64
 			2: Road
+				LeftColor: 86,85,82
+				RightColor: 72,71,69
 	Template@625:
 		Category: Paved road bits
 		Id: 625
@@ -5518,8 +10482,14 @@ Templates:
 		Size: 3, 1
 		Tiles:
 			0: Road
+				LeftColor: 82,80,78
+				RightColor: 73,72,70
 			1: Road
+				LeftColor: 69,67,64
+				RightColor: 70,69,66
 			2: Road
+				LeftColor: 72,71,69
+				RightColor: 86,85,82
 	Template@626:
 		Category: Green
 		Id: 626
@@ -5527,6 +10497,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 43,48,12
+				RightColor: 43,51,12
 	Template@627:
 		Category: Green/Clear LAT
 		Id: 627
@@ -5534,6 +10506,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 77,69,44
+				RightColor: 73,67,40
 	Template@628:
 		Category: Green/Clear LAT
 		Id: 628
@@ -5541,6 +10515,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 54,53,24
+				RightColor: 90,76,52
 	Template@629:
 		Category: Green/Clear LAT
 		Id: 629
@@ -5548,6 +10524,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 61,58,33
+				RightColor: 77,67,42
 	Template@630:
 		Category: Green/Clear LAT
 		Id: 630
@@ -5555,6 +10533,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 72,68,38
+				RightColor: 98,81,60
 	Template@631:
 		Category: Green/Clear LAT
 		Id: 631
@@ -5562,6 +10542,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 89,76,52
+				RightColor: 68,66,32
 	Template@632:
 		Category: Green/Clear LAT
 		Id: 632
@@ -5569,6 +10551,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 87,73,46
+				RightColor: 84,73,47
 	Template@633:
 		Category: Green/Clear LAT
 		Id: 633
@@ -5576,6 +10560,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 77,69,41
+				RightColor: 86,73,49
 	Template@634:
 		Category: Green/Clear LAT
 		Id: 634
@@ -5583,6 +10569,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 80,70,41
+				RightColor: 100,83,63
 	Template@635:
 		Category: Green/Clear LAT
 		Id: 635
@@ -5590,6 +10578,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 80,71,45
+				RightColor: 69,65,37
 	Template@636:
 		Category: Green/Clear LAT
 		Id: 636
@@ -5597,6 +10587,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 76,66,43
+				RightColor: 89,76,49
 	Template@637:
 		Category: Green/Clear LAT
 		Id: 637
@@ -5604,6 +10596,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 80,72,46
+				RightColor: 79,71,40
 	Template@638:
 		Category: Green/Clear LAT
 		Id: 638
@@ -5611,6 +10605,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 84,74,48
+				RightColor: 96,80,59
 	Template@639:
 		Category: Green/Clear LAT
 		Id: 639
@@ -5618,6 +10614,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 102,83,59
+				RightColor: 77,69,40
 	Template@640:
 		Category: Green/Clear LAT
 		Id: 640
@@ -5625,6 +10623,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 95,79,56
+				RightColor: 87,74,49
 	Template@641:
 		Category: Green/Clear LAT
 		Id: 641
@@ -5632,6 +10632,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 100,83,59
+				RightColor: 81,71,46
 	Template@642:
 		Category: Green/Clear LAT
 		Id: 642
@@ -5639,6 +10641,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rough
+				LeftColor: 93,78,54
+				RightColor: 91,77,55
 	Template@643:
 		Category: Ramp edge fixup
 		Id: 643
@@ -5646,6 +10650,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 1
+				LeftColor: 112,90,63
+				RightColor: 112,94,70
 	Template@644:
 		Category: Ramp edge fixup
 		Id: 644
@@ -5653,6 +10660,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 1
+				LeftColor: 116,97,72
+				RightColor: 112,91,65
 	Template@645:
 		Category: Ramp edge fixup
 		Id: 645
@@ -5660,6 +10670,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 1
+				LeftColor: 114,96,71
+				RightColor: 112,91,65
 	Template@646:
 		Category: Ramp edge fixup
 		Id: 646
@@ -5667,6 +10680,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 2
+				LeftColor: 76,69,57
+				RightColor: 86,73,57
 	Template@647:
 		Category: Ramp edge fixup
 		Id: 647
@@ -5674,6 +10690,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 2
+				LeftColor: 87,74,57
+				RightColor: 70,64,52
 	Template@648:
 		Category: Ramp edge fixup
 		Id: 648
@@ -5681,6 +10700,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 2
+				LeftColor: 89,76,59
+				RightColor: 86,74,57
 	Template@649:
 		Category: Ramp edge fixup
 		Id: 649
@@ -5688,6 +10710,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 3
+				LeftColor: 89,77,61
+				RightColor: 97,82,63
 	Template@650:
 		Category: Ramp edge fixup
 		Id: 650
@@ -5695,6 +10720,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 3
+				LeftColor: 91,78,60
+				RightColor: 88,77,62
 	Template@651:
 		Category: Ramp edge fixup
 		Id: 651
@@ -5702,6 +10730,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 3
+				LeftColor: 91,78,60
+				RightColor: 97,82,63
 	Template@652:
 		Category: Ramp edge fixup
 		Id: 652
@@ -5709,6 +10740,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 4
+				LeftColor: 102,84,62
+				RightColor: 93,78,58
 	Template@653:
 		Category: Ramp edge fixup
 		Id: 653
@@ -5716,6 +10750,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 4
+				LeftColor: 96,82,62
+				RightColor: 96,79,59
 	Template@654:
 		Category: Ramp edge fixup
 		Id: 654
@@ -5723,6 +10760,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Clear
+				RampType: 4
+				LeftColor: 103,85,63
+				RightColor: 98,81,60
 	Template@667:
 		Category: Water slopes
 		Id: 667
@@ -5730,9 +10770,21 @@ Templates:
 		Size: 1, 4
 		Tiles:
 			0: Cliff
+				RampType: 1
+				LeftColor: 104,97,89
+				RightColor: 110,91,67
 			1: Cliff
+				RampType: 1
+				LeftColor: 68,80,100
+				RightColor: 80,94,121
 			2: Cliff
+				RampType: 1
+				LeftColor: 86,86,90
+				RightColor: 66,82,105
 			3: Cliff
+				RampType: 1
+				LeftColor: 118,94,65
+				RightColor: 114,93,66
 	Template@668:
 		Category: Water slopes
 		Id: 668
@@ -5740,9 +10792,21 @@ Templates:
 		Size: 4, 1
 		Tiles:
 			0: Cliff
+				RampType: 2
+				LeftColor: 84,74,59
+				RightColor: 91,88,86
 			1: Cliff
+				RampType: 2
+				LeftColor: 73,87,113
+				RightColor: 64,79,106
 			2: Cliff
+				RampType: 2
+				LeftColor: 77,88,109
+				RightColor: 84,78,70
 			3: Cliff
+				RampType: 2
+				LeftColor: 84,74,58
+				RightColor: 68,61,48
 	Template@669:
 		Category: Water slopes
 		Id: 669
@@ -5750,9 +10814,21 @@ Templates:
 		Size: 1, 4
 		Tiles:
 			0: Cliff
+				RampType: 3
+				LeftColor: 99,90,79
+				RightColor: 91,80,65
 			1: Cliff
+				RampType: 3
+				LeftColor: 108,121,149
+				RightColor: 87,101,127
 			2: Cliff
+				RampType: 3
+				LeftColor: 107,108,113
+				RightColor: 97,108,131
 			3: Cliff
+				RampType: 3
+				LeftColor: 90,78,61
+				RightColor: 92,79,62
 	Template@670:
 		Category: Water slopes
 		Id: 670
@@ -5760,9 +10836,21 @@ Templates:
 		Size: 4, 1
 		Tiles:
 			0: Cliff
+				RampType: 4
+				LeftColor: 96,79,58
+				RightColor: 86,78,69
 			1: Cliff
+				RampType: 4
+				LeftColor: 105,115,137
+				RightColor: 78,91,114
 			2: Cliff
+				RampType: 4
+				LeftColor: 76,86,101
+				RightColor: 97,99,104
 			3: Cliff
+				RampType: 4
+				LeftColor: 95,81,62
+				RightColor: 96,80,59
 	Template@671:
 		Category: Pavement (Use for LAT)
 		Id: 671
@@ -5770,6 +10858,8 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Road
+				LeftColor: 84,83,80
+				RightColor: 82,82,82
 	Template@672:
 		Category: Paved Road Slopes
 		Id: 672
@@ -5777,8 +10867,17 @@ Templates:
 		Size: 1, 3
 		Tiles:
 			0: Road
+				RampType: 1
+				LeftColor: 72,71,68
+				RightColor: 90,90,90
 			1: Road
+				RampType: 1
+				LeftColor: 69,68,63
+				RightColor: 75,69,55
 			2: Road
+				RampType: 1
+				LeftColor: 86,85,83
+				RightColor: 75,75,74
 	Template@673:
 		Category: Paved Road Slopes
 		Id: 673
@@ -5786,8 +10885,17 @@ Templates:
 		Size: 3, 1
 		Tiles:
 			0: Road
+				RampType: 2
+				LeftColor: 72,72,71
+				RightColor: 56,55,52
 			1: Road
+				RampType: 2
+				LeftColor: 60,54,43
+				RightColor: 53,52,48
 			2: Road
+				RampType: 2
+				LeftColor: 59,59,58
+				RightColor: 68,67,64
 	Template@674:
 		Category: Paved Road Slopes
 		Id: 674
@@ -5795,8 +10903,17 @@ Templates:
 		Size: 1, 3
 		Tiles:
 			0: Road
+				RampType: 3
+				LeftColor: 54,52,48
+				RightColor: 61,60,56
 			1: Road
+				RampType: 3
+				LeftColor: 50,49,48
+				RightColor: 54,51,46
 			2: Road
+				RampType: 3
+				LeftColor: 66,64,59
+				RightColor: 54,54,53
 	Template@675:
 		Category: Paved Road Slopes
 		Id: 675
@@ -5804,8 +10921,17 @@ Templates:
 		Size: 3, 1
 		Tiles:
 			0: DirtRoad
+				RampType: 4
+				LeftColor: 79,75,69
+				RightColor: 62,61,59
 			1: DirtRoad
+				RampType: 4
+				LeftColor: 62,59,52
+				RightColor: 60,59,56
 			2: DirtRoad
+				RampType: 4
+				LeftColor: 63,63,61
+				RightColor: 77,74,69
 	Template@676:
 		Category: Monorail Slopes
 		Id: 676
@@ -5813,6 +10939,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rail
+				RampType: 1
+				LeftColor: 77,77,78
+				RightColor: 78,75,72
 	Template@677:
 		Category: Monorail Slopes
 		Id: 677
@@ -5820,6 +10949,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rail
+				RampType: 2
+				LeftColor: 62,67,74
+				RightColor: 69,70,70
 	Template@678:
 		Category: Monorail Slopes
 		Id: 678
@@ -5827,6 +10959,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rail
+				RampType: 3
+				LeftColor: 75,72,67
+				RightColor: 72,72,72
 	Template@679:
 		Category: Monorail Slopes
 		Id: 679
@@ -5834,6 +10969,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Rail
+				RampType: 4
+				LeftColor: 56,58,60
+				RightColor: 76,72,66
 	Template@680:
 		Category: Waterfalls-B
 		Id: 680
@@ -5841,13 +10979,33 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 17,31,50
+				RightColor: 22,35,53
 			1: Cliff
+				Height: 4
+				LeftColor: 30,46,71
+				RightColor: 51,64,90
 			2: Cliff
+				LeftColor: 128,134,149
+				RightColor: 132,136,144
 			3: Cliff
+				LeftColor: 29,50,83
+				RightColor: 19,40,64
 			4: Cliff
+				Height: 4
+				LeftColor: 65,61,57
+				RightColor: 41,49,58
 			5: Cliff
+				Height: 4
+				LeftColor: 60,59,58
+				RightColor: 67,60,50
 			6: Cliff
+				LeftColor: 65,56,43
+				RightColor: 63,59,50
 			7: Cliff
+				LeftColor: 78,77,77
+				RightColor: 59,67,80
 	Template@681:
 		Category: Waterfalls-B
 		Id: 681
@@ -5855,9 +11013,19 @@ Templates:
 		Size: 4, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 11,25,42
+				RightColor: 14,28,46
 			1: Cliff
+				Height: 4
+				LeftColor: 20,35,57
+				RightColor: 70,81,103
 			2: Cliff
+				LeftColor: 149,155,171
+				RightColor: 158,163,173
 			3: Cliff
+				LeftColor: 20,38,64
+				RightColor: 17,36,59
 	Template@682:
 		Category: Waterfalls-B
 		Id: 682
@@ -5865,13 +11033,33 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 13,28,47
+				RightColor: 14,28,46
 			1: Cliff
+				Height: 4
+				LeftColor: 32,47,70
+				RightColor: 95,103,118
 			2: Cliff
+				LeftColor: 142,149,163
+				RightColor: 142,148,156
 			3: Cliff
+				LeftColor: 27,47,79
+				RightColor: 18,37,61
 			4: Cliff
+				Height: 4
+				LeftColor: 11,25,42
+				RightColor: 17,31,52
 			5: Cliff
+				Height: 4
+				LeftColor: 33,46,66
+				RightColor: 87,94,106
 			6: Cliff
+				LeftColor: 154,160,177
+				RightColor: 167,171,181
 			7: Cliff
+				LeftColor: 21,40,67
+				RightColor: 16,36,58
 	Template@683:
 		Category: Waterfalls-B
 		Id: 683
@@ -5879,13 +11067,33 @@ Templates:
 		Size: 4, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 49,51,54
+				RightColor: 66,58,48
 			1: Cliff
+				Height: 4
+				LeftColor: 66,60,50
+				RightColor: 57,50,41
 			2: Cliff
+				LeftColor: 64,58,49
+				RightColor: 58,53,44
 			3: Rough
+				LeftColor: 61,64,68
+				RightColor: 94,80,63
 			4: Cliff
+				Height: 4
+				LeftColor: 17,32,50
+				RightColor: 26,37,50
 			5: Cliff
+				Height: 4
+				LeftColor: 37,52,75
+				RightColor: 81,78,74
 			6: Cliff
+				LeftColor: 108,116,125
+				RightColor: 98,98,97
 			7: Cliff
+				LeftColor: 26,43,67
+				RightColor: 30,49,78
 	Template@684:
 		Category: Waterfalls-C
 		Id: 684
@@ -5893,8 +11101,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 74,63,49
+				RightColor: 68,63,54
 			2: Rough
+				Height: 4
+				LeftColor: 69,60,50
+				RightColor: 47,51,59
 			3: Cliff
+				Height: 4
+				LeftColor: 26,40,62
+				RightColor: 57,64,77
 	Template@685:
 		Category: Waterfalls-C
 		Id: 685
@@ -5902,6 +11119,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 17,32,52
+				RightColor: 55,66,87
 	Template@686:
 		Category: Waterfalls-C
 		Id: 686
@@ -5909,7 +11129,13 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 17,32,53
+				RightColor: 58,69,90
 			1: Cliff
+				Height: 4
+				LeftColor: 22,37,61
+				RightColor: 51,64,87
 	Template@687:
 		Category: Waterfalls-C
 		Id: 687
@@ -5917,8 +11143,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 50,47,41
+				RightColor: 65,61,53
 			2: Cliff
+				Height: 4
+				LeftColor: 25,38,55
+				RightColor: 61,69,83
 			3: Rough
+				Height: 4
+				LeftColor: 61,57,51
+				RightColor: 70,63,52
 	Template@688:
 		Category: Waterfalls-D
 		Id: 688
@@ -5926,8 +11161,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 33,46,66
+				RightColor: 29,44,67
 			2: Cliff
+				Height: 4
+				LeftColor: 67,60,49
+				RightColor: 55,53,49
 			3: Rough
+				Height: 4
+				LeftColor: 62,55,46
+				RightColor: 53,54,54
 	Template@689:
 		Category: Waterfalls-D
 		Id: 689
@@ -5935,6 +11179,9 @@ Templates:
 		Size: 1, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 37,51,73
+				RightColor: 15,30,49
 	Template@690:
 		Category: Waterfalls-D
 		Id: 690
@@ -5942,7 +11189,13 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 23,38,62
+				RightColor: 35,48,67
 			1: Cliff
+				Height: 4
+				LeftColor: 42,56,80
+				RightColor: 22,38,62
 	Template@691:
 		Category: Waterfalls-D
 		Id: 691
@@ -5950,8 +11203,17 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 50,47,42
+				RightColor: 69,61,49
 			1: Rough
+				Height: 4
+				LeftColor: 54,54,54
+				RightColor: 70,60,48
 			3: Cliff
+				Height: 4
+				LeftColor: 40,48,62
+				RightColor: 33,43,55
 	Template@707:
 		Category: Tunnel Floor
 		Id: 707
@@ -5959,20 +11221,50 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			1: Cliff
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			2: Cliff
+				LeftColor: 69,54,37
+				RightColor: 70,53,37
 			3: Road
+				LeftColor: 66,65,62
+				RightColor: 78,77,74
 			4: Road
+				LeftColor: 56,57,57
+				RightColor: 59,58,55
 			5: Road
+				LeftColor: 32,32,30
+				RightColor: 28,27,26
 			6: Road
+				LeftColor: 59,57,53
+				RightColor: 60,58,53
 			7: Road
+				LeftColor: 54,51,47
+				RightColor: 45,43,40
 			8: Road
+				LeftColor: 31,30,27
+				RightColor: 26,25,24
 			9: Road
+				LeftColor: 76,77,76
+				RightColor: 64,63,61
 			10: Road
+				LeftColor: 71,69,65
+				RightColor: 47,47,47
 			11: Road
+				LeftColor: 37,37,35
+				RightColor: 28,28,28
 			12: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			13: Cliff
+				LeftColor: 111,90,65
+				RightColor: 109,88,63
 			14: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,53,37
 	Template@708:
 		Category: Tunnel Floor
 		Id: 708
@@ -5980,20 +11272,50 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			1: Road
+				LeftColor: 78,77,74
+				RightColor: 66,65,62
 			2: Road
+				LeftColor: 60,58,53
+				RightColor: 59,57,53
 			3: Road
+				LeftColor: 64,63,61
+				RightColor: 76,77,76
 			4: Cliff
+				LeftColor: 109,90,66
+				RightColor: 108,88,62
 			5: Cliff
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			6: Road
+				LeftColor: 59,58,55
+				RightColor: 56,57,57
 			7: Road
+				LeftColor: 45,43,40
+				RightColor: 54,51,47
 			8: Road
+				LeftColor: 47,47,47
+				RightColor: 71,69,65
 			9: Cliff
+				LeftColor: 109,88,62
+				RightColor: 108,88,64
 			10: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			11: Road
+				LeftColor: 28,27,26
+				RightColor: 32,32,30
 			12: Road
+				LeftColor: 26,25,24
+				RightColor: 31,30,27
 			13: Road
+				LeftColor: 28,28,28
+				RightColor: 37,37,35
 			14: Cliff
+				LeftColor: 69,53,37
+				RightColor: 70,53,37
 	Template@709:
 		Category: Tunnel Floor
 		Id: 709
@@ -6001,17 +11323,41 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Cliff
+				LeftColor: 7,7,7
+				RightColor: 47,42,36
 			1: Cliff
+				LeftColor: 91,87,79
+				RightColor: 92,89,84
 			2: Cliff
+				LeftColor: 109,99,84
+				RightColor: 111,88,61
 			3: Road
+				LeftColor: 28,28,28
+				RightColor: 9,9,9
 			4: Road
+				LeftColor: 47,47,47
+				RightColor: 71,69,65
 			5: Road
+				LeftColor: 66,65,62
+				RightColor: 78,76,73
 			6: Road
+				LeftColor: 26,25,24
+				RightColor: 6,6,5
 			7: Road
+				LeftColor: 45,43,40
+				RightColor: 54,51,47
 			8: Road
+				LeftColor: 59,57,53
+				RightColor: 60,58,53
 			9: Road
+				LeftColor: 5,5,5
+				RightColor: 32,32,30
 			10: Road
+				LeftColor: 59,58,55
+				RightColor: 56,57,57
 			11: Road
+				LeftColor: 79,78,76
+				RightColor: 64,63,61
 	Template@710:
 		Category: Tunnel Floor
 		Id: 710
@@ -6019,17 +11365,41 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 22,22,22
+				RightColor: 42,38,32
 			1: Road
+				LeftColor: 37,37,35
+				RightColor: 7,7,7
 			2: Road
+				LeftColor: 31,30,27
+				RightColor: 5,5,4
 			3: Road
+				LeftColor: 32,32,30
+				RightColor: 5,5,5
 			4: Cliff
+				LeftColor: 88,84,76
+				RightColor: 77,75,71
 			5: Road
+				LeftColor: 71,69,65
+				RightColor: 47,47,47
 			6: Road
+				LeftColor: 54,51,47
+				RightColor: 45,43,40
 			7: Road
+				LeftColor: 56,57,57
+				RightColor: 59,58,55
 			8: Cliff
+				LeftColor: 111,88,61
+				RightColor: 112,102,89
 			9: Road
+				LeftColor: 78,76,73
+				RightColor: 66,65,62
 			10: Road
+				LeftColor: 60,58,53
+				RightColor: 59,57,53
 			11: Road
+				LeftColor: 64,63,61
+				RightColor: 79,78,76
 	Template@711:
 		Category: Tunnel Side
 		Id: 711
@@ -6037,8 +11407,15 @@ Templates:
 		Size: 3, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 81,66,47
+				RightColor: 83,72,57
 			1: Cliff
+				LeftColor: 84,70,51
+				RightColor: 128,123,114
 			2: Cliff
+				LeftColor: 111,92,68
+				RightColor: 115,108,97
 	Template@712:
 		Category: Tunnel Side
 		Id: 712
@@ -6046,8 +11423,15 @@ Templates:
 		Size: 1, 3
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 84,73,58
+				RightColor: 80,66,47
 			1: Cliff
+				LeftColor: 65,59,51
+				RightColor: 94,86,75
 			2: Cliff
+				LeftColor: 126,120,112
+				RightColor: 90,75,56
 	Template@713:
 		Category: TrackTunnel Floor
 		Id: 713
@@ -6055,20 +11439,50 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			1: Cliff
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			2: Cliff
+				LeftColor: 69,54,37
+				RightColor: 70,53,37
 			3: Road
+				LeftColor: 66,65,62
+				RightColor: 78,77,74
 			4: Road
+				LeftColor: 56,57,57
+				RightColor: 59,58,55
 			5: Road
+				LeftColor: 32,32,30
+				RightColor: 28,27,26
 			6: Road
+				LeftColor: 71,73,76
+				RightColor: 76,78,80
 			7: Rail
+				LeftColor: 68,70,73
+				RightColor: 74,76,78
 			8: Rail
+				LeftColor: 50,49,47
+				RightColor: 54,53,49
 			9: Road
+				LeftColor: 76,77,76
+				RightColor: 64,63,61
 			10: Road
+				LeftColor: 71,69,65
+				RightColor: 47,47,47
 			11: Road
+				LeftColor: 37,37,35
+				RightColor: 28,28,28
 			12: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			13: Cliff
+				LeftColor: 111,90,65
+				RightColor: 109,88,63
 			14: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,53,37
 	Template@714:
 		Category: TrackTunnel Floor
 		Id: 714
@@ -6076,20 +11490,50 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			1: Road
+				LeftColor: 78,77,74
+				RightColor: 66,65,62
 			2: Road
+				LeftColor: 73,75,77
+				RightColor: 70,73,76
 			3: Road
+				LeftColor: 64,63,61
+				RightColor: 76,77,76
 			4: Cliff
+				LeftColor: 109,90,66
+				RightColor: 108,88,62
 			5: Cliff
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			6: Road
+				LeftColor: 59,58,55
+				RightColor: 56,57,57
 			7: Rail
+				LeftColor: 71,73,75
+				RightColor: 68,70,73
 			8: Road
+				LeftColor: 47,47,47
+				RightColor: 71,69,65
 			9: Cliff
+				LeftColor: 109,88,62
+				RightColor: 108,88,64
 			10: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			11: Road
+				LeftColor: 28,27,26
+				RightColor: 32,32,30
 			12: Rail
+				LeftColor: 51,50,47
+				RightColor: 49,48,46
 			13: Road
+				LeftColor: 28,28,28
+				RightColor: 37,37,35
 			14: Cliff
+				LeftColor: 69,53,37
+				RightColor: 70,53,37
 	Template@715:
 		Category: TrackTunnel Floor
 		Id: 715
@@ -6097,17 +11541,41 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Cliff
+				LeftColor: 7,7,7
+				RightColor: 47,43,37
 			1: Cliff
+				LeftColor: 91,87,79
+				RightColor: 92,89,84
 			2: Cliff
+				LeftColor: 109,99,84
+				RightColor: 111,88,61
 			3: Road
+				LeftColor: 28,28,28
+				RightColor: 9,9,9
 			4: Road
+				LeftColor: 47,47,47
+				RightColor: 71,69,65
 			5: Road
+				LeftColor: 66,65,62
+				RightColor: 78,76,73
 			6: Road
+				LeftColor: 41,38,32
+				RightColor: 8,8,6
 			7: Rail
+				LeftColor: 54,53,51
+				RightColor: 58,57,53
 			8: Rail
+				LeftColor: 71,73,76
+				RightColor: 76,78,80
 			9: Road
+				LeftColor: 5,5,5
+				RightColor: 32,32,30
 			10: Road
+				LeftColor: 59,58,55
+				RightColor: 56,57,57
 			11: Road
+				LeftColor: 79,78,76
+				RightColor: 64,63,61
 	Template@716:
 		Category: TrackTunnel Floor
 		Id: 716
@@ -6115,17 +11583,41 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 22,22,22
+				RightColor: 42,38,33
 			1: Road
+				LeftColor: 37,37,35
+				RightColor: 7,7,7
 			2: Road
+				LeftColor: 43,39,33
+				RightColor: 8,7,6
 			3: Road
+				LeftColor: 32,32,30
+				RightColor: 5,5,5
 			4: Cliff
+				LeftColor: 88,84,76
+				RightColor: 77,75,71
 			5: Road
+				LeftColor: 71,69,65
+				RightColor: 47,47,47
 			6: Rail
+				LeftColor: 55,54,52
+				RightColor: 53,53,51
 			7: Road
+				LeftColor: 56,57,57
+				RightColor: 59,58,55
 			8: Cliff
+				LeftColor: 111,88,61
+				RightColor: 112,102,89
 			9: Road
+				LeftColor: 78,76,73
+				RightColor: 66,65,62
 			10: Rail
+				LeftColor: 73,75,77
+				RightColor: 70,73,76
 			11: Road
+				LeftColor: 64,63,61
+				RightColor: 79,78,76
 	Template@717:
 		Category: Destroyable Cliffs
 		Id: 717
@@ -6133,25 +11625,75 @@ Templates:
 		Size: 6, 4
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 69,60,47
+				RightColor: 67,58,45
 			2: Cliff
+				Height: 4
+				LeftColor: 78,63,44
+				RightColor: 71,59,43
 			3: Cliff
+				Height: 4
+				LeftColor: 82,66,47
+				RightColor: 75,62,46
 			4: Cliff
+				Height: 4
+				LeftColor: 79,67,51
+				RightColor: 76,62,46
 			6: Cliff
+				Height: 4
+				LeftColor: 78,69,57
+				RightColor: 63,55,44
 			7: Cliff
+				Height: 4
+				LeftColor: 80,68,53
+				RightColor: 69,59,47
 			8: Cliff
+				Height: 4
+				LeftColor: 80,65,47
+				RightColor: 88,71,50
 			9: Cliff
+				Height: 4
+				LeftColor: 87,69,48
+				RightColor: 97,78,55
 			10: Cliff
+				Height: 4
+				LeftColor: 73,62,48
+				RightColor: 82,71,56
 			11: Cliff
+				Height: 4
+				LeftColor: 80,69,55
+				RightColor: 66,57,46
 			12: Cliff
+				LeftColor: 97,83,65
+				RightColor: 86,76,63
 			13: Cliff
+				LeftColor: 113,90,64
+				RightColor: 101,83,60
 			14: Cliff
+				LeftColor: 114,90,63
+				RightColor: 96,77,53
 			15: Cliff
+				LeftColor: 122,97,68
+				RightColor: 111,88,62
 			16: Cliff
+				LeftColor: 116,92,64
+				RightColor: 89,79,65
 			17: Cliff
+				LeftColor: 107,91,70
+				RightColor: 64,59,50
 			19: Cliff
+				LeftColor: 107,85,60
+				RightColor: 105,84,59
 			20: Cliff
+				LeftColor: 116,93,66
+				RightColor: 114,90,63
 			21: Cliff
+				LeftColor: 118,95,67
+				RightColor: 112,88,61
 			22: Cliff
+				LeftColor: 106,85,59
+				RightColor: 108,86,61
 	Template@718:
 		Category: Destroyable Cliffs
 		Id: 718
@@ -6159,25 +11701,75 @@ Templates:
 		Size: 4, 6
 		Tiles:
 			1: Cliff
+				Height: 4
+				LeftColor: 71,62,51
+				RightColor: 64,58,50
 			2: Cliff
+				LeftColor: 58,55,49
+				RightColor: 52,50,45
 			4: Cliff
+				Height: 4
+				LeftColor: 65,57,46
+				RightColor: 79,70,57
 			5: Cliff
+				Height: 4
+				LeftColor: 76,67,55
+				RightColor: 77,70,59
 			6: Cliff
+				LeftColor: 79,64,45
+				RightColor: 71,60,45
 			7: Cliff
+				LeftColor: 105,83,59
+				RightColor: 107,86,62
 			8: Cliff
+				Height: 4
+				LeftColor: 65,57,48
+				RightColor: 72,62,49
 			9: Cliff
+				Height: 4
+				LeftColor: 91,74,53
+				RightColor: 82,68,51
 			10: Cliff
+				LeftColor: 100,80,56
+				RightColor: 105,85,61
 			11: Cliff
+				LeftColor: 108,86,61
+				RightColor: 108,85,59
 			12: Cliff
+				Height: 4
+				LeftColor: 81,68,51
+				RightColor: 73,62,49
 			13: Cliff
+				Height: 4
+				LeftColor: 97,79,56
+				RightColor: 85,71,53
 			14: Cliff
+				LeftColor: 112,88,60
+				RightColor: 114,91,64
 			15: Cliff
+				LeftColor: 105,84,60
+				RightColor: 114,90,64
 			16: Cliff
+				Height: 4
+				LeftColor: 77,64,47
+				RightColor: 73,61,46
 			17: Cliff
+				Height: 4
+				LeftColor: 67,59,47
+				RightColor: 73,61,47
 			18: Cliff
+				LeftColor: 80,66,50
+				RightColor: 91,76,58
 			19: Cliff
+				LeftColor: 99,78,54
+				RightColor: 111,89,62
 			21: Cliff
+				Height: 4
+				LeftColor: 75,64,51
+				RightColor: 65,58,47
 			22: Cliff
+				LeftColor: 86,77,64
+				RightColor: 62,58,51
 	Template@719:
 		Category: Water Caves
 		Id: 719
@@ -6185,9 +11777,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 65,56,43
+				RightColor: 77,64,48
 			1: Cliff
+				Height: 4
+				LeftColor: 58,50,38
+				RightColor: 74,63,47
 			2: Cliff
+				LeftColor: 50,54,57
+				RightColor: 77,66,51
 			3: Cliff
+				LeftColor: 33,44,57
+				RightColor: 42,43,43
 	Template@720:
 		Category: Water Caves
 		Id: 720
@@ -6195,9 +11797,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 66,58,46
+				RightColor: 71,60,45
 			1: Cliff
+				Height: 4
+				LeftColor: 62,54,43
+				RightColor: 80,67,51
 			2: Cliff
+				LeftColor: 32,52,78
+				RightColor: 26,31,35
 			3: Cliff
+				LeftColor: 43,51,59
+				RightColor: 39,37,33
 	Template@721:
 		Category: Water Caves
 		Id: 721
@@ -6205,7 +11817,12 @@ Templates:
 		Size: 1, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 56,49,39
+				RightColor: 77,65,49
 			1: Cliff
+				LeftColor: 36,53,75
+				RightColor: 22,26,30
 	Template@722:
 		Category: Water Caves
 		Id: 722
@@ -6213,9 +11830,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 72,62,48
+				RightColor: 80,65,48
 			1: Cliff
+				Height: 4
+				LeftColor: 72,64,52
+				RightColor: 78,65,48
 			2: Cliff
+				LeftColor: 34,53,83
+				RightColor: 22,26,30
 			3: Cliff
+				LeftColor: 56,59,62
+				RightColor: 71,65,55
 	Template@723:
 		Category: Water Caves
 		Id: 723
@@ -6223,9 +11850,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 77,65,49
+				RightColor: 58,50,39
 			1: Cliff
+				LeftColor: 33,48,70
+				RightColor: 27,33,41
 			2: Cliff
+				Height: 4
+				LeftColor: 72,62,48
+				RightColor: 61,54,44
 			3: Cliff
+				LeftColor: 49,53,59
+				RightColor: 47,47,45
 	Template@724:
 		Category: Water Caves
 		Id: 724
@@ -6233,9 +11870,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 68,60,48
+				RightColor: 66,59,48
 			1: Cliff
+				LeftColor: 37,50,73
+				RightColor: 23,30,40
 			2: Cliff
+				Height: 4
+				LeftColor: 71,62,49
+				RightColor: 48,44,36
 			3: Cliff
+				LeftColor: 29,49,81
+				RightColor: 28,35,45
 	Template@725:
 		Category: Water Caves
 		Id: 725
@@ -6243,7 +11890,12 @@ Templates:
 		Size: 2, 1
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 70,62,50
+				RightColor: 63,56,46
 			1: Cliff
+				LeftColor: 29,50,82
+				RightColor: 23,32,42
 	Template@726:
 		Category: Water Caves
 		Id: 726
@@ -6251,9 +11903,19 @@ Templates:
 		Size: 2, 2
 		Tiles:
 			0: Cliff
+				Height: 4
+				LeftColor: 70,59,46
+				RightColor: 70,62,50
 			1: Cliff
+				LeftColor: 47,47,43
+				RightColor: 46,46,44
 			2: Cliff
+				Height: 4
+				LeftColor: 80,66,50
+				RightColor: 70,62,51
 			3: Cliff
+				LeftColor: 34,53,83
+				RightColor: 40,44,46
 	Template@940:
 		Category: Scrin Wreckage
 		Id: 940
@@ -6261,34 +11923,103 @@ Templates:
 		Size: 6, 7
 		Tiles:
 			2: Clear
+				RampType: 15
+				LeftColor: 94,80,62
+				RightColor: 98,82,61
 			3: Clear
+				RampType: 12
+				LeftColor: 117,96,70
+				RightColor: 112,92,67
 			6: Clear
+				RampType: 15
+				LeftColor: 57,47,27
+				RightColor: 96,78,56
 			7: Clear
+				RampType: 4
+				LeftColor: 69,57,39
+				RightColor: 97,79,56
 			8: Clear
+				RampType: 7
+				LeftColor: 66,53,36
+				RightColor: 91,76,56
 			9: Clear
+				RampType: 8
+				LeftColor: 86,71,50
+				RightColor: 110,90,64
 			10: Clear
+				RampType: 12
+				LeftColor: 112,90,63
+				RightColor: 111,91,67
 			12: Clear
+				RampType: 3
+				LeftColor: 42,36,20
+				RightColor: 42,36,19
 			13: Rough
+				LeftColor: 52,43,28
+				RightColor: 47,39,22
 			14: Rough
+				LeftColor: 47,39,23
+				RightColor: 46,35,19
 			15: Rough
+				LeftColor: 66,51,33
+				RightColor: 82,65,45
 			16: Clear
+				RampType: 1
+				LeftColor: 89,69,49
+				RightColor: 66,54,38
 			18: Clear
+				RampType: 3
+				LeftColor: 44,38,23
+				RightColor: 42,38,23
 			19: Rough
+				LeftColor: 60,51,35
+				RightColor: 51,43,28
 			20: Rough
+				LeftColor: 46,40,27
+				RightColor: 73,59,43
 			21: Rough
+				LeftColor: 67,57,40
+				RightColor: 69,57,40
 			22: Cliff
+				LeftColor: 49,43,30
+				RightColor: 42,36,21
 			24: Cliff
+				RampType: 14
+				LeftColor: 51,43,27
+				RightColor: 37,31,16
 			25: Cliff
+				LeftColor: 27,23,11
+				RightColor: 51,45,29
 			26: Rough
+				LeftColor: 45,40,24
+				RightColor: 76,63,45
 			27: Rough
+				LeftColor: 73,61,44
+				RightColor: 59,52,37
 			28: Cliff
+				LeftColor: 50,44,35
+				RightColor: 23,22,19
 			32: Cliff
+				LeftColor: 28,25,11
+				RightColor: 29,26,13
 			33: Cliff
+				LeftColor: 30,26,13
+				RightColor: 40,37,21
 			34: Cliff
+				LeftColor: 43,37,24
+				RightColor: 42,37,31
 			35: Cliff
+				LeftColor: 26,24,21
+				RightColor: 45,40,32
 			39: Cliff
+				LeftColor: 73,62,46
+				RightColor: 41,39,26
 			40: Cliff
+				LeftColor: 43,40,28
+				RightColor: 34,32,23
 			41: Cliff
+				LeftColor: 41,39,31
+				RightColor: 34,32,25
 	Template@941:
 		Category: Scrin Wreckage
 		Id: 941
@@ -6296,19 +12027,59 @@ Templates:
 		Size: 5, 5
 		Tiles:
 			1: Clear
+				RampType: 11
+				LeftColor: 94,77,57
+				RightColor: 103,86,64
 			2: Clear
+				RampType: 12
+				LeftColor: 112,94,71
+				RightColor: 112,91,66
 			3: Clear
+				RampType: 11
+				LeftColor: 90,75,56
+				RightColor: 106,87,64
 			4: Clear
+				RampType: 4
+				LeftColor: 87,72,53
+				RightColor: 104,86,64
 			5: Clear
+				RampType: 11
+				LeftColor: 80,67,50
+				RightColor: 94,78,59
 			6: Clear
+				RampType: 7
+				LeftColor: 105,85,63
+				RightColor: 109,87,64
 			7: Clear
+				RampType: 8
+				LeftColor: 100,83,61
+				RightColor: 104,86,63
 			10: Clear
+				RampType: 3
+				LeftColor: 62,51,33
+				RightColor: 72,59,41
 			11: Rough
+				LeftColor: 52,45,27
+				RightColor: 66,55,37
 			12: Rough
+				LeftColor: 54,47,30
+				RightColor: 63,53,36
 			15: Clear
+				RampType: 10
+				LeftColor: 105,84,60
+				RightColor: 90,72,51
 			16: Clear
+				RampType: 2
+				LeftColor: 88,71,50
+				RightColor: 41,35,20
 			17: Clear
+				RampType: 6
+				LeftColor: 39,34,23
+				RightColor: 37,33,19
 			22: Clear
+				RampType: 10
+				LeftColor: 103,88,67
+				RightColor: 80,67,48
 	Template@942:
 		Category: Scrin Wreckage
 		Id: 942
@@ -6316,51 +12087,149 @@ Templates:
 		Size: 9, 8
 		Tiles:
 			0: DirtRoad
+				LeftColor: 144,111,72
+				RightColor: 126,99,66
 			1: DirtRoad
+				LeftColor: 139,109,74
+				RightColor: 121,100,78
 			2: DirtRoad
+				LeftColor: 129,111,94
+				RightColor: 86,74,58
 			3: Clear
+				LeftColor: 85,71,52
+				RightColor: 103,86,66
 			9: DirtRoad
+				LeftColor: 127,100,68
+				RightColor: 138,105,68
 			10: DirtRoad
+				LeftColor: 136,105,69
+				RightColor: 151,115,73
 			11: DirtRoad
+				LeftColor: 146,112,73
+				RightColor: 152,116,74
 			12: Clear
+				LeftColor: 94,76,55
+				RightColor: 77,63,47
 			13: Clear
+				LeftColor: 70,60,47
+				RightColor: 93,76,56
 			14: Clear
+				LeftColor: 98,84,67
+				RightColor: 110,88,61
 			19: DirtRoad
+				LeftColor: 95,82,64
+				RightColor: 127,106,80
 			20: Clear
+				LeftColor: 103,89,70
+				RightColor: 150,115,75
 			21: DirtRoad
+				LeftColor: 151,116,76
+				RightColor: 123,97,68
 			22: Clear
+				LeftColor: 136,109,77
+				RightColor: 133,107,77
 			23: Clear
+				LeftColor: 132,109,81
+				RightColor: 108,86,59
 			24: Clear
+				LeftColor: 87,73,53
+				RightColor: 109,88,62
 			28: DirtRoad
+				LeftColor: 112,89,62
+				RightColor: 93,82,66
 			29: DirtRoad
+				LeftColor: 119,101,77
+				RightColor: 93,83,68
 			30: Clear
+				LeftColor: 152,118,78
+				RightColor: 158,123,80
 			31: DirtRoad
+				LeftColor: 156,123,82
+				RightColor: 152,120,78
 			32: Clear
+				LeftColor: 139,118,91
+				RightColor: 128,108,83
 			33: Clear
+				LeftColor: 133,110,85
+				RightColor: 113,94,73
 			38: Clear
+				LeftColor: 118,94,66
+				RightColor: 130,105,76
 			39: DirtRoad
+				LeftColor: 146,112,74
+				RightColor: 151,117,77
 			40: DirtRoad
+				LeftColor: 157,121,79
+				RightColor: 158,124,84
 			41: DirtRoad
+				LeftColor: 153,117,75
+				RightColor: 141,111,78
 			42: Clear
+				LeftColor: 145,116,81
+				RightColor: 121,98,71
 			47: Clear
+				LeftColor: 96,76,53
+				RightColor: 111,88,61
 			48: DirtRoad
+				LeftColor: 116,93,65
+				RightColor: 140,109,74
 			49: DirtRoad
+				LeftColor: 146,113,74
+				RightColor: 153,119,80
 			50: DirtRoad
+				LeftColor: 133,107,76
+				RightColor: 143,112,76
 			51: Rough
+				LeftColor: 67,56,41
+				RightColor: 127,108,75
 			52: Cliff
+				LeftColor: 112,94,73
+				RightColor: 104,85,61
 			56: Cliff
+				LeftColor: 51,42,25
+				RightColor: 69,56,40
 			57: Clear
+				LeftColor: 112,89,61
+				RightColor: 111,88,61
 			58: Clear
+				LeftColor: 111,89,62
+				RightColor: 131,102,68
 			59: Clear
+				LeftColor: 127,99,67
+				RightColor: 104,91,77
 			60: Cliff
+				LeftColor: 115,94,68
+				RightColor: 140,119,91
 			61: Cliff
+				LeftColor: 123,108,87
+				RightColor: 103,88,70
 			65: Cliff
+				LeftColor: 22,20,17
+				RightColor: 34,31,21
 			66: Clear
+				RampType: 2
+				LeftColor: 39,36,28
+				RightColor: 26,26,24
 			67: Clear
+				RampType: 2
+				LeftColor: 111,88,61
+				RightColor: 111,88,61
 			68: Clear
+				RampType: 2
+				LeftColor: 111,88,61
+				RightColor: 111,88,61
 			69: Cliff
+				RampType: 2
+				LeftColor: 111,88,61
+				RightColor: 111,88,61
 			70: Cliff
+				RampType: 2
+				LeftColor: 111,88,61
+				RightColor: 96,78,54
 			71: Cliff
+				RampType: 9
+				LeftColor: 61,52,38
+				RightColor: 95,77,56
 	Template@943:
 		Category: Scrin Wreckage
 		Id: 943
@@ -6368,13 +12237,29 @@ Templates:
 		Size: 8, 6
 		Tiles:
 			0: Rough
+				LeftColor: 108,86,61
+				RightColor: 87,71,52
 			18: Rough
+				LeftColor: 112,90,64
+				RightColor: 100,84,64
 			28: Cliff
+				LeftColor: 110,90,66
+				RightColor: 89,73,52
 			29: Cliff
+				LeftColor: 65,55,38
+				RightColor: 37,31,16
 			37: Cliff
+				LeftColor: 113,90,63
+				RightColor: 71,60,44
 			38: Cliff
+				LeftColor: 72,62,46
+				RightColor: 37,33,17
 			46: Clear
+				LeftColor: 116,95,70
+				RightColor: 118,95,68
 			47: Cliff
+				LeftColor: 111,90,65
+				RightColor: 81,69,52
 	Template@944:
 		Category: Scrin Wreckage
 		Id: 944
@@ -6382,42 +12267,116 @@ Templates:
 		Size: 8, 6
 		Tiles:
 			2: Clear
+				LeftColor: 44,39,31
+				RightColor: 29,26,22
 			3: Clear
+				LeftColor: 20,21,19
+				RightColor: 28,26,21
 			4: Clear
+				LeftColor: 27,30,33
+				RightColor: 36,35,29
 			5: Clear
+				LeftColor: 39,37,29
+				RightColor: 31,28,20
 			6: Clear
+				LeftColor: 39,35,25
+				RightColor: 32,32,29
 			7: Clear
+				LeftColor: 38,35,30
+				RightColor: 53,48,36
 			10: Clear
+				LeftColor: 26,24,21
+				RightColor: 41,37,31
 			11: Clear
+				LeftColor: 30,28,23
+				RightColor: 23,21,19
 			12: Clear
+				LeftColor: 38,36,32
+				RightColor: 27,27,26
 			13: Clear
+				LeftColor: 22,21,19
+				RightColor: 30,34,36
 			14: Clear
+				LeftColor: 36,38,36
+				RightColor: 52,55,56
 			15: Clear
+				LeftColor: 62,76,92
+				RightColor: 29,32,34
 			16: Cliff
+				LeftColor: 73,62,46
+				RightColor: 43,39,27
 			17: Cliff
+				LeftColor: 43,40,28
+				RightColor: 39,36,27
 			18: Cliff
+				LeftColor: 41,39,31
+				RightColor: 34,32,25
 			19: Clear
+				LeftColor: 42,40,35
+				RightColor: 30,28,24
 			20: Clear
+				LeftColor: 26,25,22
+				RightColor: 48,44,37
 			21: Clear
+				LeftColor: 53,47,38
+				RightColor: 27,24,17
 			22: Clear
+				LeftColor: 84,72,56
+				RightColor: 70,64,55
 			23: Clear
+				LeftColor: 81,77,70
+				RightColor: 62,61,58
 			24: Clear
+				LeftColor: 113,92,66
+				RightColor: 116,94,67
 			25: Clear
+				LeftColor: 117,94,67
+				RightColor: 90,73,51
 			26: Cliff
+				LeftColor: 101,81,57
+				RightColor: 45,42,31
 			27: Cliff
+				LeftColor: 38,37,30
+				RightColor: 44,44,40
 			28: Clear
+				LeftColor: 51,50,46
+				RightColor: 49,48,44
 			29: Clear
+				LeftColor: 45,43,36
+				RightColor: 24,25,21
 			30: Cliff
+				LeftColor: 42,48,57
+				RightColor: 38,37,35
 			31: Cliff
+				LeftColor: 27,24,15
+				RightColor: 57,50,39
 			34: Clear
+				LeftColor: 111,90,64
+				RightColor: 107,86,61
 			35: Cliff
+				LeftColor: 111,90,63
+				RightColor: 71,61,46
 			36: Cliff
+				LeftColor: 88,74,58
+				RightColor: 78,69,55
 			37: Cliff
+				LeftColor: 72,64,52
+				RightColor: 85,82,77
 			38: Cliff
+				LeftColor: 115,112,111
+				RightColor: 69,70,70
 			39: Cliff
+				LeftColor: 70,58,38
+				RightColor: 46,38,20
 			45: Cliff
+				LeftColor: 113,90,63
+				RightColor: 84,69,48
 			46: Cliff
+				LeftColor: 91,75,54
+				RightColor: 99,85,67
 			47: Cliff
+				LeftColor: 91,85,76
+				RightColor: 84,79,72
 	Template@945:
 		Category: Scrin Wreckage
 		Id: 945
@@ -6425,52 +12384,146 @@ Templates:
 		Size: 7, 10
 		Tiles:
 			0: Cliff
+				LeftColor: 97,80,60
+				RightColor: 97,79,58
 			7: Cliff
+				LeftColor: 70,62,47
+				RightColor: 69,59,44
 			8: Cliff
+				LeftColor: 75,67,54
+				RightColor: 116,94,67
 			14: Cliff
+				LeftColor: 17,19,20
+				RightColor: 42,39,31
 			15: Cliff
+				LeftColor: 79,65,46
+				RightColor: 78,66,48
 			16: Cliff
+				LeftColor: 83,68,47
+				RightColor: 101,83,59
 			17: Rough
+				LeftColor: 90,76,58
+				RightColor: 95,78,57
 			21: Cliff
+				LeftColor: 45,55,72
+				RightColor: 57,60,60
 			22: Cliff
+				LeftColor: 76,67,52
+				RightColor: 79,64,46
 			23: Cliff
+				LeftColor: 95,78,57
+				RightColor: 85,69,47
 			24: Cliff
+				LeftColor: 86,70,49
+				RightColor: 55,47,32
 			25: Rough
+				LeftColor: 71,58,39
+				RightColor: 107,87,63
 			28: Cliff
+				LeftColor: 72,65,51
+				RightColor: 99,92,88
 			29: Cliff
+				LeftColor: 128,104,78
+				RightColor: 101,82,62
 			30: Cliff
+				LeftColor: 101,81,58
+				RightColor: 99,81,60
 			31: Cliff
+				LeftColor: 111,91,68
+				RightColor: 88,71,51
 			32: Cliff
+				LeftColor: 69,55,36
+				RightColor: 59,48,31
 			33: Rough
+				LeftColor: 84,69,51
+				RightColor: 111,91,67
 			34: Clear
+				LeftColor: 109,90,66
+				RightColor: 106,85,61
 			35: Cliff
+				LeftColor: 46,40,24
+				RightColor: 38,34,20
 			36: Cliff
+				LeftColor: 49,42,23
+				RightColor: 72,60,43
 			37: Cliff
+				LeftColor: 69,58,40
+				RightColor: 93,76,56
 			38: Cliff
+				LeftColor: 99,79,56
+				RightColor: 98,79,56
 			39: Cliff
+				LeftColor: 73,59,41
+				RightColor: 68,56,40
 			40: Rough
+				LeftColor: 59,50,33
+				RightColor: 81,67,50
 			41: Clear
+				LeftColor: 100,83,61
+				RightColor: 109,90,66
 			42: Cliff
+				LeftColor: 68,63,52
+				RightColor: 79,70,55
 			43: Cliff
+				LeftColor: 81,72,58
+				RightColor: 57,49,32
 			44: Cliff
+				LeftColor: 83,72,54
+				RightColor: 43,38,21
 			45: Cliff
+				LeftColor: 47,41,23
+				RightColor: 77,61,43
 			46: Cliff
+				LeftColor: 71,57,40
+				RightColor: 69,56,39
 			47: Rough
+				LeftColor: 62,52,37
+				RightColor: 72,61,45
 			48: Clear
+				LeftColor: 96,80,60
+				RightColor: 87,73,53
 			49: Clear
+				LeftColor: 110,90,66
+				RightColor: 120,100,76
 			50: Clear
+				LeftColor: 127,102,73
+				RightColor: 125,102,76
 			51: Cliff
+				LeftColor: 108,89,67
+				RightColor: 69,58,41
 			52: Cliff
+				LeftColor: 68,58,42
+				RightColor: 81,68,48
 			53: Cliff
+				LeftColor: 97,79,56
+				RightColor: 67,55,36
 			54: Cliff
+				LeftColor: 83,67,46
+				RightColor: 93,74,53
 			55: Clear
+				LeftColor: 89,75,58
+				RightColor: 101,82,60
 			57: Clear
+				LeftColor: 83,69,53
+				RightColor: 97,80,61
 			58: Clear
+				LeftColor: 77,65,48
+				RightColor: 78,65,48
 			59: Clear
+				LeftColor: 71,61,43
+				RightColor: 96,79,57
 			62: Clear
+				LeftColor: 105,86,63
+				RightColor: 94,84,71
 			64: Clear
+				LeftColor: 111,88,61
+				RightColor: 111,88,61
 			65: Clear
+				LeftColor: 102,86,65
+				RightColor: 82,69,51
 			66: Clear
+				LeftColor: 91,74,52
+				RightColor: 94,76,53
 	Template@952:
 		Category: DirtTrackTunnel Floor
 		Id: 952
@@ -6478,20 +12531,50 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			1: Cliff
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			2: Cliff
+				LeftColor: 69,54,37
+				RightColor: 70,53,37
 			3: Road
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			4: Clear
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			5: Clear
+				LeftColor: 69,54,37
+				RightColor: 70,53,37
 			6: Road
+				LeftColor: 84,81,78
+				RightColor: 88,85,82
 			7: Rail
+				LeftColor: 84,81,77
+				RightColor: 88,86,83
 			8: Rail
+				LeftColor: 74,72,71
+				RightColor: 79,78,77
 			9: Road
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			10: Clear
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			11: Clear
+				LeftColor: 69,54,37
+				RightColor: 70,53,37
 			12: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			13: Cliff
+				LeftColor: 111,90,65
+				RightColor: 109,88,63
 			14: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,53,37
 	Template@953:
 		Category: DirtTrackTunnel Floor
 		Id: 953
@@ -6499,20 +12582,50 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			1: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			2: Road
+				LeftColor: 85,82,79
+				RightColor: 83,81,78
 			3: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			4: Cliff
+				LeftColor: 109,90,66
+				RightColor: 108,88,62
 			5: Cliff
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			6: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			7: Rail
+				LeftColor: 85,83,80
+				RightColor: 84,81,77
 			8: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			9: Cliff
+				LeftColor: 109,88,62
+				RightColor: 108,88,64
 			10: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			11: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			12: Rail
+				LeftColor: 76,75,74
+				RightColor: 73,72,71
 			13: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			14: Cliff
+				LeftColor: 69,53,37
+				RightColor: 70,53,37
 	Template@954:
 		Category: DirtTrackTunnel Floor
 		Id: 954
@@ -6520,17 +12633,41 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Cliff
+				LeftColor: 7,7,7
+				RightColor: 47,43,37
 			1: Cliff
+				LeftColor: 91,87,79
+				RightColor: 92,89,84
 			2: Cliff
+				LeftColor: 109,99,84
+				RightColor: 111,88,61
 			3: Road
+				LeftColor: 70,53,37
+				RightColor: 16,12,9
 			4: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			5: Clear
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			6: Road
+				LeftColor: 75,72,71
+				RightColor: 15,15,15
 			7: Rail
+				LeftColor: 85,82,79
+				RightColor: 88,85,82
 			8: Rail
+				LeftColor: 85,81,78
+				RightColor: 88,85,82
 			9: Road
+				LeftColor: 14,10,7
+				RightColor: 69,54,37
 			10: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			11: Clear
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 	Template@955:
 		Category: DirtTrackTunnel Floor
 		Id: 955
@@ -6538,17 +12675,41 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 22,22,22
+				RightColor: 42,38,33
 			1: Road
+				LeftColor: 69,54,37
+				RightColor: 16,12,9
 			2: Road
+				LeftColor: 76,75,74
+				RightColor: 14,14,14
 			3: Road
+				LeftColor: 69,54,37
+				RightColor: 14,10,7
 			4: Cliff
+				LeftColor: 88,84,76
+				RightColor: 77,75,71
 			5: Clear
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			6: Rail
+				LeftColor: 85,82,79
+				RightColor: 84,82,79
 			7: Clear
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			8: Cliff
+				LeftColor: 111,88,61
+				RightColor: 112,102,89
 			9: Clear
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			10: Rail
+				LeftColor: 84,82,79
+				RightColor: 84,81,78
 			11: Clear
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 	Template@956:
 		Category: DirtTunnel Floor
 		Id: 956
@@ -6556,20 +12717,50 @@ Templates:
 		Size: 3, 5
 		Tiles:
 			0: Cliff
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			1: Cliff
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			2: Cliff
+				LeftColor: 69,54,37
+				RightColor: 70,53,37
 			3: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			4: Clear
+				LeftColor: 111,90,65
+				RightColor: 109,88,63
 			5: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,53,37
 			6: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			7: Clear
+				LeftColor: 111,90,65
+				RightColor: 109,88,63
 			8: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,53,37
 			9: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			10: Clear
+				LeftColor: 111,90,65
+				RightColor: 109,88,63
 			11: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,53,37
 			12: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			13: Cliff
+				LeftColor: 111,90,65
+				RightColor: 109,88,63
 			14: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,53,37
 	Template@957:
 		Category: DirtTunnel Floor
 		Id: 957
@@ -6577,20 +12768,50 @@ Templates:
 		Size: 5, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			1: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			2: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			3: Road
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			4: Cliff
+				LeftColor: 109,90,66
+				RightColor: 108,88,62
 			5: Cliff
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			6: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			7: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			8: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			9: Cliff
+				LeftColor: 109,88,62
+				RightColor: 108,88,64
 			10: Cliff
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			11: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			12: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			13: Clear
+				LeftColor: 70,53,37
+				RightColor: 69,54,37
 			14: Cliff
+				LeftColor: 69,53,37
+				RightColor: 70,53,37
 	Template@958:
 		Category: DirtTunnel Floor
 		Id: 958
@@ -6598,17 +12819,41 @@ Templates:
 		Size: 3, 4
 		Tiles:
 			0: Cliff
+				LeftColor: 7,7,7
+				RightColor: 47,42,36
 			1: Cliff
+				LeftColor: 91,87,79
+				RightColor: 92,89,84
 			2: Cliff
+				LeftColor: 109,99,84
+				RightColor: 111,88,61
 			3: Road
+				LeftColor: 70,53,37
+				RightColor: 16,12,9
 			4: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			5: Clear
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			6: Road
+				LeftColor: 70,53,37
+				RightColor: 13,10,7
 			7: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			8: Clear
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 			9: Road
+				LeftColor: 14,10,7
+				RightColor: 69,54,37
 			10: Clear
+				LeftColor: 112,92,67
+				RightColor: 109,88,63
 			11: Clear
+				LeftColor: 109,88,62
+				RightColor: 110,89,64
 	Template@959:
 		Category: DirtTunnel Floor
 		Id: 959
@@ -6616,15 +12861,38 @@ Templates:
 		Size: 4, 3
 		Tiles:
 			0: Cliff
+				LeftColor: 22,22,22
+				RightColor: 42,38,32
 			1: Road
+				LeftColor: 69,54,37
+				RightColor: 16,12,9
 			2: Road
+				LeftColor: 69,54,37
+				RightColor: 14,10,7
 			3: Road
+				LeftColor: 69,54,37
+				RightColor: 14,10,7
 			4: Cliff
+				LeftColor: 88,84,76
+				RightColor: 77,75,71
 			5: Clear
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			6: Clear
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			7: Clear
+				LeftColor: 109,88,63
+				RightColor: 112,92,67
 			8: Cliff
+				LeftColor: 111,88,61
+				RightColor: 112,102,89
 			9: Clear
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			10: Clear
+				LeftColor: 110,89,64
+				RightColor: 109,88,62
 			11: Clear
-
+				LeftColor: 110,89,64
+				RightColor: 109,88,62

--- a/mods/ts/tilesets/temperat.yaml
+++ b/mods/ts/tilesets/temperat.yaml
@@ -4,7 +4,7 @@ General:
 	Extensions: .tem, .shp
 	Palette: isotem.pal
 	EditorTemplateOrder: Misc Buildings, Clear, Cliff Pieces, Ice Flow, House, Blank, Ice Ramps, Cliff Set, Civilian Buildings, Shore Pieces, Rough LAT tile, Clear/Rough LAT, Cliff/Water pieces, Bendy Dirt Roads, Dirt Road Junctions, Straight Dirt Roads, Bridges, Paved Roads, Water, Dirt Road Slopes, Slope Set Pieces, Dead Oil Tanker, Ruins, Waterfalls, Ground 01, Ground 02, Sand, Sand/Clear LAT, Rough ground, Paved Road Ends, TrainBridges, Pavement, Pavement/Clear LAT, Paved road bits, Green, Green/Clear LAT, Ramp edge fixup, Water slopes, Pavement (Use for LAT), Paved Road Slopes, Monorail Slopes, Waterfalls-B, Waterfalls-C, Waterfalls-D, Tunnel Floor, Tunnel Side, TrackTunnel Floor, Destroyable Cliffs, Water Caves, Scrin Wreckage, DirtTrackTunnel Floor, DirtTunnel Floor
-	SheetSize: 1024
+	SheetSize: 2048
 
 Terrain:
 	TerrainType@Clear:


### PR DESCRIPTION
This pr adds support for per-tile template data, and converts the minimap color, ramp type, and cell height data for the TS temperate tileset.  It also adds support for the extra sprite data in tmp(ts), and adds a widget for rendering terrain templates.

These features aren't used yet, but can be tested on my [ingame map editor](https://github.com/pchote/OpenRA/tree/ingame-map-editor) branch.

A screenshot showing where this is heading:

![editor](https://cloud.githubusercontent.com/assets/167819/4839174/5180dd92-5ffa-11e4-8309-121d4429d824.png)
