### PR TITLE
Added filters to repeated orders

### DIFF
--- a/OpenRA.Mods.RA/C4Demolition.cs
+++ b/OpenRA.Mods.RA/C4Demolition.cs
@@ -22,14 +22,19 @@ namespace OpenRA.Mods.RA
 		[Desc("Delay to demolish the target once the C4 is planted." +
 			"Measured in game ticks. Default is 1.8 seconds.")]
 		public readonly int C4Delay = 45;
+
 		[Desc("Number of times to flash the target")]
 		public readonly int Flashes = 3;
+
 		[Desc("Delay before the flashing starts")]
 		public readonly int FlashesDelay = 4;
+
 		[Desc("Interval between each flash")]
 		public readonly int FlashInterval = 4;
+
 		[Desc("Duration of each flash")]
 		public readonly int FlashDuration = 3;
+
 		[Desc("Voice string when planting explosive charges.")]
 		public readonly string Voice = "Attack";
 

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Move
 		TransientActors,
 		BlockedByMovers,
 		All = TransientActors | BlockedByMovers
-	};
+	}
 
 	[Desc("Unit is able to move.")]
 	public class MobileInfo : ITraitInfo, IOccupySpaceInfo, IFacingInfo, IMoveInfo, UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.RA.Move
 			if (otherMobile == null) return false;
 
 			// Sign of dot-product indicates (roughly) if vectors are facing in same or opposite directions:
-			var dp = CVec.Dot((selfMobile.toCell - self.Location), (otherMobile.toCell - other.Location));
+			var dp = CVec.Dot(selfMobile.toCell - self.Location, otherMobile.toCell - other.Location);
 			if (dp <= 0) return false;
 
 			return true;
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.RA.Move
 			{
 				var canIgnoreMovingAllies = self != null && !check.HasFlag(CellConditions.BlockedByMovers);
 				var needsCellExclusively = self == null || Crushes == null || !Crushes.Any();
-				foreach(var a in world.ActorMap.GetUnitsAt(cell))
+				foreach (var a in world.ActorMap.GetUnitsAt(cell))
 				{
 					if (a == ignoreActor)
 						continue;
@@ -252,7 +252,6 @@ namespace OpenRA.Mods.RA.Move
 		CPos __fromCell, __toCell;
 		public SubCell fromSubCell, toSubCell;
 
-		//int __altitude;
 
 		[Sync] public int Facing
 		{
@@ -328,6 +327,7 @@ namespace OpenRA.Mods.RA.Move
 				if (preferred != SubCell.FullCell)
 					return SubCell.FullCell;
 			}
+
 			return preferred;
 		}
 


### PR DESCRIPTION
I hope https://github.com/OpenRA/OpenRA/issues/3923 addresses a lot of CPU and network performance problems when people click the same spot many times as seen by high APM *Craft players.

~~Note: there is still some leakage. You order a unit to attack, move somewhere, attack the same thing and it gets filtered. Not sure why. I added a lot of resets.~~ I simplified the implementation a lot and solved this on my own.
