### PR TITLE
Added a warning when the map cordon is small

### DIFF
--- a/OpenRA.Mods.RA/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.RA/Lint/CheckMapCordon.cs
@@ -16,6 +16,8 @@ namespace OpenRA.Mods.RA
 {
 	public class CheckMapCordon : ILintPass
 	{
+		const int RecommendedCordonSize = 12;
+
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
 			if (map.Bounds.Left == 0 || map.Bounds.Top == 0
@@ -23,6 +25,11 @@ namespace OpenRA.Mods.RA
 					emitError("This map does not define a valid cordon.\n"
 						+"A one cell (or greater) border is required on all four sides "
 						+"between the playable bounds and the map edges");
+
+			if (map.Bounds.Left < RecommendedCordonSize || map.Bounds.Top < RecommendedCordonSize
+				|| map.MapSize.X - map.Bounds.Right < RecommendedCordonSize
+				|| map.MapSize.Y - map.Bounds.Bottom < RecommendedCordonSize)
+					emitWarning("This map defines a map cordon < {0} cells which may lead to problems.".F(RecommendedCordonSize));
 		}
 	}
 }


### PR DESCRIPTION
Tiny map cordons caused problems in the past. This warns about them. The RecommendedCordonSize is probably still debatable. Also whether we should remove some maps from the repository that violate this rule.
