### PR TITLE
Measure SpriteFont in perf.log

### DIFF
--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -60,7 +60,8 @@ namespace OpenRA.Graphics
 
 		public void InitializeFonts(Manifest m)
 		{
-			Fonts = m.Fonts.ToDictionary(x => x.Key, x => new SpriteFont(Platform.ResolvePath(x.Value.First), x.Value.Second));
+			using (new Support.PerfTimer("SpriteFonts"))
+				Fonts = m.Fonts.ToDictionary(x => x.Key, x => new SpriteFont(Platform.ResolvePath(x.Value.First), x.Value.Second));
 		}
 
 		internal IGraphicsDevice Device { get { return device; } }

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Graphics
 {
 	public class SpriteFont
 	{
+		static Library library = new Library();
+		static SheetBuilder builder;
+
 		int size;
 		string name;
 
@@ -30,8 +33,7 @@ namespace OpenRA.Graphics
 			face = new Face(library, name);
 			face.SetPixelSizes((uint)size, (uint)size);
 
-			glyphs = new Cache<Pair<char, Color>, GlyphInfo>(CreateGlyph, 
-			         Pair<char,Color>.EqualityComparer);
+			glyphs = new Cache<Pair<char, Color>, GlyphInfo>(CreateGlyph, Pair<char, Color>.EqualityComparer);
 
 			// setup a SheetBuilder for our private use
 			// TODO: SheetBuilder state is leaked between mod switches
@@ -92,7 +94,7 @@ namespace OpenRA.Graphics
 			return new int2((int)Math.Ceiling(lines.Max(s => s.Sum(a => glyphs[Pair.New(a, Color.White)].Advance))), lines.Length * size);
 		}
 
-		Cache<Pair<char,Color>, GlyphInfo> glyphs;
+		Cache<Pair<char, Color>, GlyphInfo> glyphs;
 		Face face;
 
 		GlyphInfo CreateGlyph(Pair<char, Color> c)
@@ -112,6 +114,7 @@ namespace OpenRA.Graphics
 
 			// A new bitmap is generated each time this property is accessed, so we do need to dispose it.
 			using (var bitmap = face.Glyph.Bitmap)
+			{
 				unsafe
 				{
 					var p = (byte*)bitmap.Buffer;
@@ -133,13 +136,12 @@ namespace OpenRA.Graphics
 						p += bitmap.Pitch;
 					}
 				}
+			}
+
 			s.sheet.CommitData();
 
 			return g;
 		}
-
-		static Library library = new Library();  
-		static SheetBuilder builder;
 	}
 
 	class GlyphInfo

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -12,6 +12,7 @@ using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Primitives;
+using OpenRA.Support;
 using SharpFont;
 
 namespace OpenRA.Graphics
@@ -19,10 +20,12 @@ namespace OpenRA.Graphics
 	public class SpriteFont
 	{
 		int size;
+		string name;
 
 		public SpriteFont(string name, int size)
 		{
 			this.size = size;
+			this.name = name;
 
 			face = library.NewFace(name, 0);
 			face.SetPixelSizes((uint)size, (uint)size);
@@ -41,10 +44,10 @@ namespace OpenRA.Graphics
 
 		void PrecacheColor(Color c)
 		{
-			// precache glyphs for U+0020 - U+007f
-			for (var n = (char)0x20; n < (char)0x7f; n++)
-				if (glyphs[Pair.New(n, c)] == null)
-					throw new InvalidOperationException();
+			using (new PerfTimer("PrecacheColor {0} {1}px {2}".F(name, size, c.Name)))
+				for (var n = (char)0x20; n < (char)0x7f; n++)
+					if (glyphs[Pair.New(n, c)] == null)
+						throw new InvalidOperationException();
 		}
 
 		public void DrawText(string text, float2 location, Color c)

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Graphics
 			this.size = size;
 			this.name = name;
 
-			face = library.NewFace(name, 0);
+			face = new Face(library, name);
 			face.SetPixelSizes((uint)size, (uint)size);
 
 			glyphs = new Cache<Pair<char, Color>, GlyphInfo>(CreateGlyph, 

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -97,8 +97,7 @@ namespace OpenRA.Graphics
 
 		GlyphInfo CreateGlyph(Pair<char, Color> c)
 		{
-			var index = face.GetCharIndex(c.First);
-			face.LoadGlyph(index, LoadFlags.Default, LoadTarget.Normal);
+			face.LoadChar(c.First, LoadFlags.Default, LoadTarget.Normal);
 			face.Glyph.RenderGlyph(RenderMode.Normal);
 
 			var size = new Size((int)face.Glyph.Metrics.Width >> 6, (int)face.Glyph.Metrics.Height >> 6);


### PR DESCRIPTION
Uses FT_Load_Char in our SpriteFont code as suggested in https://github.com/OpenRA/OpenRA/issues/3436. Compare also http://www.freetype.org/freetype2/docs/tutorial/step1.html. Adds performance measurements to the pre cache methods. Spoiler: this does not change anything in that regard. Makes use of the face creation simplification from the https://github.com/Robmaister/SharpFont/#cross-platform-freetype-bindings-for-net README.
