### PR TITLE
Added Gates to Red Alert

### DIFF
--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -18,12 +18,12 @@ namespace OpenRA.Mods.Common.Orders
 	{
 		readonly Func<bool> useDeployCursor;
 
-		public DeployOrderTargeter( string order, int priority )
-			: this( order, priority, () => true )
+		public DeployOrderTargeter(string order, int priority)
+			: this(order, priority, () => true)
 		{
 		}
 
-		public DeployOrderTargeter( string order, int priority, Func<bool> useDeployCursor )
+		public DeployOrderTargeter(string order, int priority, Func<bool> useDeployCursor)
 		{
 			this.OrderID = order;
 			this.OrderPriority = priority;

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -460,6 +460,7 @@
     <Compile Include="UtilityCommands\Extensions.cs" />
     <Compile Include="Lint\CheckMapRules.cs" />
     <Compile Include="Activities\Air\HeliFlyCircle.cs" />
+    <Compile Include="ProximityTransforms.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.RA/ProximityTransforms.cs
+++ b/OpenRA.Mods.RA/ProximityTransforms.cs
@@ -1,0 +1,79 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.RA.Move;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA
+{
+	[Desc("Actor will be transformed by mobile units in a specified proximity.")]
+	public class ProxmityTransformsInfo : ITraitInfo, Requires<TransformsInfo>
+	{
+		[Desc("Cells")]
+		public readonly int Range = 3;
+
+		[Desc("Units around have to appear friendly.")]
+		public readonly bool CheckFriendly = true;
+
+		[Desc("Trigger when no units are around.")]
+		public readonly bool WhenAlone = false;
+
+		public object Create(ActorInitializer init) { return new ProxmityTransforms(init.self, this); }
+	}
+
+	public class ProxmityTransforms : ITick
+	{
+		readonly Transforms transforms;
+		readonly ProxmityTransformsInfo info;
+		readonly Actor self;
+
+		public ProxmityTransforms(Actor self, ProxmityTransformsInfo info)
+		{
+			this.info = info;
+			this.self = self;
+
+			transforms = self.Trait<Transforms>();
+		}
+
+		public void Tick(Actor self)
+		{
+			if (info.WhenAlone)
+			{
+				if (info.CheckFriendly)
+				{
+					if (!UnitsInRange().Any(a => a.AppearsFriendlyTo(self)))
+						transforms.DeployTransform(true);
+				}
+				else
+					if (!UnitsInRange().Any())
+						transforms.DeployTransform(true);
+			}
+			else
+			{
+				if (info.CheckFriendly)
+				{
+					if (UnitsInRange().Any(a => a.AppearsFriendlyTo(self)))
+						transforms.DeployTransform(true);
+				}
+				else
+					if (UnitsInRange().Any())
+						transforms.DeployTransform(true);
+			}
+		}
+
+		IEnumerable<Actor> UnitsInRange()
+		{
+			return self.World.FindActorsInCircle(self.CenterPosition, WRange.FromCells(info.Range))
+				.Where(a => a.IsInWorld && a != self && !a.Destroyed && !a.Owner.NonCombatant && a.HasTrait<Mobile>());
+		}
+	}
+}

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1381,6 +1381,72 @@ BRIK:
 	RenderBuildingWall:
 		Type: concrete
 
+^VGATE:
+	Inherits: ^Building
+	Building:
+		Dimensions: 1,3
+	Tooltip:
+		Name: Gate
+		Description: Vertical Gate
+	Valued:
+		Cost: 100
+	Health:
+		HP: 100
+	Armor:
+		Type: Concrete
+	LineBuildNode:
+		Types: concrete
+	RenderBuilding:
+		Palette: terrain
+	-FrozenUnderFog:
+
+VGATE.open:
+	Inherits: ^VGATE
+	Building:
+		Footprint: _ _ _
+	Transforms:
+		IntoActor: vgate.close
+
+VGATE.close:
+	Inherits: ^VGATE
+	Building:
+		Footprint: x x x
+	Transforms:
+		IntoActor: vgate.open
+
+^AGATE:
+	Inherits: ^Building
+	Building:
+		Dimensions: 3,1
+	Tooltip:
+		Name: Gate
+		Description: Horizontal Gate
+	Valued:
+		Cost: 100
+	Health:
+		HP: 100
+	Armor:
+		Type: Concrete
+	LineBuildNode:
+		Types: concrete
+	RenderBuilding:
+		Palette: terrain
+	-FrozenUnderFog:
+
+AGATE.open:
+	Inherits: ^AGATE
+	Building:
+		Footprint: ___
+	Transforms:
+		IntoActor: agate.close
+
+AGATE.close:
+	Inherits: ^AGATE
+	Building:
+		Footprint: xxx
+	Transforms:
+		IntoActor: agate.open
+
 CYCL:
 	Inherits: ^Wall
 	Health:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1399,6 +1399,7 @@ BRIK:
 	RenderBuilding:
 		Palette: terrain
 	-FrozenUnderFog:
+	-Selectable:
 
 VGATE.open:
 	Inherits: ^VGATE
@@ -1406,6 +1407,9 @@ VGATE.open:
 		Footprint: _ _ _
 	Transforms:
 		IntoActor: vgate.close
+	ProxmityTransforms:
+		CheckFriendly: false
+		WhenAlone: true
 
 VGATE.close:
 	Inherits: ^VGATE
@@ -1413,6 +1417,9 @@ VGATE.close:
 		Footprint: x x x
 	Transforms:
 		IntoActor: vgate.open
+	ProxmityTransforms:
+		CheckFriendly: true
+		WhenAlone: false
 
 ^AGATE:
 	Inherits: ^Building
@@ -1432,6 +1439,7 @@ VGATE.close:
 	RenderBuilding:
 		Palette: terrain
 	-FrozenUnderFog:
+	-Selectable:
 
 AGATE.open:
 	Inherits: ^AGATE
@@ -1439,6 +1447,9 @@ AGATE.open:
 		Footprint: ___
 	Transforms:
 		IntoActor: agate.close
+	ProxmityTransforms:
+		CheckFriendly: false
+		WhenAlone: true
 
 AGATE.close:
 	Inherits: ^AGATE
@@ -1446,6 +1457,9 @@ AGATE.close:
 		Footprint: xxx
 	Transforms:
 		IntoActor: agate.open
+	ProxmityTransforms:
+		CheckFriendly: true
+		WhenAlone: false
 
 CYCL:
 	Inherits: ^Wall

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -650,6 +650,43 @@ brik:
 	icon: brikicon
 		Start: 0
 
+vgate.close:
+	icon: clock
+		Start: 0
+	make: vgate
+		Start: 0
+		Length: 7
+	idle: vgate
+		Start: 6
+
+vgate.open:
+	icon: clock
+		Start: 0
+	make: vgate
+		Start: 0
+	idle: vgate
+		Start: 0
+		ZOffset: -1c511
+
+agate.close:
+	icon: clock
+		Start: 0
+	make: agate
+		Start: 0
+		Length: 7
+	idle: agate
+		Start: 6
+
+agate.open:
+	icon: clock
+		Start: 0
+	make: agate
+		Start: 0
+	idle: agate
+		Start: 0
+		ZOffset: -1c511
+
+
 sbag:
 	idle:
 		Start: 0


### PR DESCRIPTION
This adds gates https://github.com/OpenRA/OpenRA/issues/3196 to the game so that can be manually opened, script triggered or run automatized. It is done in a simple fashion reusing the existing https://github.com/OpenRA/OpenRA/wiki/Traits#transforms. They don't interact with path-finding.

You can use http://resource.openra.net/maps/1711 for testing purposes.
