### PR TITLE
Workarounds for a bug in certain versions of Mono (3.10 and certain versions of 3.8) which stops OpenRA building

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -374,8 +374,12 @@ namespace OpenRA
 			var result = new T[width, height];
 			for (var i = 0; i < width; i++)
 				for (var j = 0; j < height; j++)
-					result[i, j] = i <= ts.GetUpperBound(0) && j <= ts.GetUpperBound(1)
-						? ts[i, j] : t;
+					// Workaround for broken ternary operators in certain versions of mono (3.10 and  
+					// certain versions of the 3.8 series): https://bugzilla.xamarin.com/show_bug.cgi?id=23319
+					if (i <= ts.GetUpperBound(0) && j <= ts.GetUpperBound(1))
+						result[i, j] = ts[i, j];
+					else
+						result[i, j] = t;
 			return result;
 		}
 

--- a/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.RA/Render/WithMuzzleFlash.cs
@@ -51,8 +51,14 @@ namespace OpenRA.Mods.RA.Render
 					var turreted = self.TraitsImplementing<Turreted>()
 						.FirstOrDefault(t => t.Name ==  arm.Info.Turret);
 
-					getFacing = turreted != null ? () => turreted.TurretFacing :
-						facing != null ? (Func<int>)(() => facing.Facing) : () => 0;
+					// Workaround for broken ternary operators in certain versions of mono (3.10 and  
+					// certain versions of the 3.8 series): https://bugzilla.xamarin.com/show_bug.cgi?id=23319
+					if (turreted != null)
+						getFacing = () => turreted.TurretFacing;
+					else if (facing != null)
+						getFacing = (Func<int>)(() => facing.Facing);
+					else
+						getFacing = () => 0;
 
 					var muzzleFlash = new Animation(self.World, render.GetImage(self), getFacing);
 					visible.Add(barrel, false);


### PR DESCRIPTION
[happy0@gamma OpenRA]$ make
CSC OpenRA.Game.exe
OpenRA.Game/Exts.cs(378,6): error CS1525: Unexpected symbol `?'
Compilation failed: 1 error(s), 0 warnings
Makefile:249: recipe for target 'OpenRA.Game.exe' failed
make: **\* [OpenRA.Game.exe] Error 1
[happy0@gamma OpenRA]$ mono -V
Mono JIT compiler version 3.10.0 (tarball Mon Oct  6 20:46:04 UTC 2014)

Mono bug report : https://bugzilla.xamarin.com/show_bug.cgi?id=23319 (it appears to have been resolved in master so shouldn't be present in future versions of Mono)

Mono 3.10 seems to be unhappy with ternary statements of a certain format, so I desugared those breaking the build into if statements (and OpenRA subsequently built.)

I wasn't sure whether you would accept this pull request, since I'm not sure whether changing code to work around compiler bugs is even a good idea, but I thought I'd give you guys the option anyway. Arguably the code is a bit more readable this way anyway :P. Up to you!
