### PR TITLE
WIP predefined upgrade strings.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -110,6 +110,12 @@ namespace OpenRA.Traits
 		void UpgradeAvailable(Actor self, string type, bool available);
 	}
 
+	public interface IResolvePredefinedUpgrades
+	{
+		/// <summary>Example: foo.[name] -> foo.e1 (resolved from actor.Info.Name)</summary>
+		string ResolveUpgrade(string upgrade);
+	}
+
 	public interface ISeedableResource { void Seed(Actor self); }
 
 	public interface IDemolishableInfo { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }

--- a/OpenRA.Mods.RA/Cargo.cs
+++ b/OpenRA.Mods.RA/Cargo.cs
@@ -199,11 +199,11 @@ namespace OpenRA.Mods.RA
 			foreach (var npe in self.TraitsImplementing<INotifyPassengerExited>())
 				npe.PassengerExited(self, a);
 
+			foreach (var notify in a.TraitsImplementing<INotifyExitCargo>())
+				notify.OnExitCargo(a, self);
+
 			var p = a.Trait<Passenger>();
 			p.Transport = null;
-
-			foreach (var u in p.Info.GrantUpgrades)
-				self.Trait<UpgradeManager>().RevokeUpgrade(self, u, p);
 
 			return a;
 		}
@@ -262,8 +262,9 @@ namespace OpenRA.Mods.RA
 
 			var p = a.Trait<Passenger>();
 			p.Transport = self;
-			foreach (var u in p.Info.GrantUpgrades)
-				self.Trait<UpgradeManager>().GrantUpgrade(self, u, p);
+
+			foreach (var notify in a.TraitsImplementing<INotifyEnterCargo>())
+				notify.OnEnterCargo(a, self);
 		}
 
 		public void Killed(Actor self, AttackInfo e)

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -122,6 +122,9 @@
 	AttackMove:
 	Passenger:
 		CargoType: Infantry
+		#TEST
+		GrantUpgrades: passenger.[type], passenger.[name], passenger.weight.[weight]
+		#TEST END
 	HiddenUnderFog:
 	GainsExperience:
 		ChevronPalette: ra
@@ -406,4 +409,3 @@
 		ResourceType: Tiberium
 		Interval: 55
 	WithActiveAnimation:
-

--- a/mods/ts/rules/infantry.yaml
+++ b/mods/ts/rules/infantry.yaml
@@ -192,6 +192,9 @@ UMAGON:
 	PoisonedByTiberium:
 		Weapon: TiberiumHeal
 	Passenger:
+		#TEST
+		Weight: 2
+		#TEST END
 	RevealsShroud:
 		Range: 7c0
 	Armament:
@@ -652,4 +655,3 @@ CIV2:
 
 CIV3:
 	Inherits: ^CivilianInfantry
-

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -990,17 +990,32 @@ GAVULC:
 	AttackTurreted:
 	WithTurret:
 		Recoils: no
+	# Armament@PRIMARY:
+	# 	Weapon: VulcanTower
+	# 	LocalOffset: 768,85,512
+	# 	MuzzleSequence: muzzle
+	# 	MuzzleSplitFacings: 8
+	# Armament@SECONDARY:
+	# 	Name: secondary
+	# 	Weapon: VulcanTower
+	# 	LocalOffset: 768,-85,512
+	# 	MuzzleSequence: muzzle
+	# 	MuzzleSplitFacings: 8
+	#TEST
+	Cargo:
+		Types: Infantry
+		PipCount: 2
+		MaxWeight: 2
 	Armament@PRIMARY:
 		Weapon: VulcanTower
-		LocalOffset: 768,85,512
-		MuzzleSequence: muzzle
-		MuzzleSplitFacings: 8
-	Armament@SECONDARY:
-		Name: secondary
-		Weapon: VulcanTower
-		LocalOffset: 768,-85,512
-		MuzzleSequence: muzzle
-		MuzzleSplitFacings: 8
+		RestrictedByUpgrade: passenger.Infantry
+	Armament@WEIGHT:
+		Weapon: EMPulseCannon
+		RequiresUpgrade: passenger.weight.2
+	Armament@E3:
+		Weapon: SAMTower
+		RequiresUpgrade: passenger.e3
+	#TEST END
 	WithMuzzleFlash:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
@@ -1309,4 +1324,3 @@ TECH:
 	Tooltip:
 		Name: Tech Center
 		Description: Tech Center
-


### PR DESCRIPTION
- Adds 2 interfaces: `INotifyExitCargo` and `INotifyEnterCargo` (used in Passenger)
- Adds interface `IResolvePredefinedUpgrades` (could possibly be reflected for docs), does not enforce a dictionary or any other specific implementation
- Passenger now handles upgrades for Cargo
- The commit message explains the test changes present which will of course be removed before merging

I'm sure this has quite a ways to go but I'd rather open this PR than let the feature rot.

**Help Wanted:**
I would like to match the `[name]`, `[weight]`, `[type]`, etc values via Regex which will allow strings such as `passenger.[name].[weight]` → `passenger.e1.1`.
Currently there can only be one replacement in each string as I iterate over the available substitutions in a poor manner.
_Note:_ I use dot notation as a preference, it is not enforced.
`passenger.e1 -- weight(1)` is viable if something grants `passenger.[name] -- weight([weight])`

**Ingame Testing:** _Tiberian Sun_
GDI's `GAVULC` is a `Cargo` actor with a `MaxWeight` of 2, so go ahead and throw some **infantry** in there.

``` yaml
GAVULC:
    Cargo:
        Types: Infantry
        PipCount: 2
        MaxWeight: 2
    Armament@PRIMARY:
        Weapon: VulcanTower
        RestrictedByUpgrade: passenger.Infantry
    Armament@WEIGHT:
        Weapon: EMPulseCannon
        RequiresUpgrade: passenger.weight.2 #Testing: Umagon's weight is 2
    Armament@E3:
        Weapon: SAMTower
        RequiresUpgrade: passenger.e3

^Infantry:
    Passenger:
        GrantUpgrades: passenger.[type], passenger.[name], passenger.weight.[weight]
```

**Technical Notes:**
The Passenger impl uses a a simple `Dictionary<string, string>` for the time being, so every substitution must become a string somehow. 
