### PR TITLE
MadTank deployed teleportation fix.

### DIFF
--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -16,6 +16,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Activities
 {
+	public interface IPreventsTeleport { bool PreventsTeleport(Actor self); }
+
 	public class Teleport : Activity
 	{
 		Actor chronosphere;
@@ -45,6 +47,10 @@ namespace OpenRA.Mods.RA.Activities
 			var pc = self.TraitOrDefault<PortableChrono>();
 			if (pc != null && !pc.CanTeleport)
 				return NextActivity;
+
+			foreach (var condition in self.TraitsImplementing<IPreventsTeleport>())
+				if (condition.PreventsTeleport(self))
+					return NextActivity;
 
 			var bestCell = ChooseBestDestinationCell(self, destination);
 			if (bestCell == null)

--- a/OpenRA.Mods.RA/MadTank.cs
+++ b/OpenRA.Mods.RA/MadTank.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.RA
 		public object Create(ActorInitializer init) { return new MadTank(init.self, this); }
 	}
 
-	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, ITick
+	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, ITick, IPreventsTeleport
 	{
 		readonly Actor self;
 		readonly MadTankInfo info;
@@ -130,6 +130,8 @@ namespace OpenRA.Mods.RA
 			if (driverMobile != null)
 				driverMobile.Nudge(driver, driver, true);
 		}
+
+		public bool PreventsTeleport(Actor self) { return deployed; }
 
 		void StartDetonationSequence()
 		{

--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.RA.Activities;
 
 namespace OpenRA.Mods.RA
 {
@@ -59,7 +60,8 @@ namespace OpenRA.Mods.RA
 			foreach (var t in tiles)
 				units.AddRange(self.World.ActorMap.GetUnitsAt(t));
 
-			return units.Distinct().Where(a => a.HasTrait<Chronoshiftable>());
+			return units.Distinct().Where(a => a.HasTrait<Chronoshiftable>() &&
+				!a.TraitsImplementing<IPreventsTeleport>().Any(condition => condition.PreventsTeleport(a)));
 		}
 
 		public bool SimilarTerrain(CPos xy, CPos sourceLocation)


### PR DESCRIPTION
Implement (new) IPreventsTeleport in MadTank.
Prevents MadTank from being teleported after deployment.
