### PR TITLE
Retire classic mouse orders

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -27,8 +27,6 @@ namespace OpenRA
 {
 	public static class Game
 	{
-		public static MouseButtonPreference mouseButtonPreference = new MouseButtonPreference();
-
 		public static ModData modData;
 		public static Settings Settings;
 		static WorldRenderer worldRenderer;

--- a/OpenRA.Game/Input/InputHandler.cs
+++ b/OpenRA.Game/Input/InputHandler.cs
@@ -49,25 +49,4 @@ namespace OpenRA
 			Sync.CheckSyncUnchanged(world, () => Ui.HandleInput(input));
 		}
 	}
-
-	public class MouseButtonPreference
-	{
-
-		public MouseButton Action
-		{
-			get 
-			{ 
-				return Game.Settings.Game.UseClassicMouseStyle ? MouseButton.Left : MouseButton.Right; 
-			}
-		}
-
-		public MouseButton Cancel
-		{
-			get 
-			{ 
-				return Game.Settings.Game.UseClassicMouseStyle ? MouseButton.Right : MouseButton.Left; 
-			}
-		}
-	}
-
 }

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Orders
 			if (self.Destroyed || !target.IsValidFor(self))
 				return null;
 
-			if (mi.Button == Game.mouseButtonPreference.Action)
+			if (mi.Button == MouseButton.Right)
 			{
 				foreach (var o in self.TraitsImplementing<IIssueOrder>()
 					.SelectMany(trait => trait.Orders

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -129,7 +129,6 @@ namespace OpenRA
 		public float ViewportEdgeScrollStep = 10f;
 		public float UIScrollSpeed = 50f;
 
-		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;
 		public bool TeamHealthColors = false;
 

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -54,9 +54,6 @@ namespace OpenRA.Widgets
 		public override bool HandleMouseInput(MouseInput mi)
 		{
 			var xy = worldRenderer.Viewport.ViewToWorldPx(mi.Location);
-
-			var useClassicMouseStyle = Game.Settings.Game.UseClassicMouseStyle;
-
 			var hasBox = SelectionBox != null;
 			var multiClick = mi.MultiTapCount >= 2;
 
@@ -68,7 +65,7 @@ namespace OpenRA.Widgets
 				dragStart = dragEnd = xy;
 
 				// place buildings
-				if (!useClassicMouseStyle || !World.Selection.Actors.Any())
+				if (!World.Selection.Actors.Any())
 					ApplyOrders(World, xy, mi);
 			}
 
@@ -77,17 +74,6 @@ namespace OpenRA.Widgets
 
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up)
 			{
-				if (useClassicMouseStyle && HasMouseFocus)
-				{
-					// order units around
-					if (!hasBox && World.Selection.Actors.Any() && !multiClick)
-					{
-						ApplyOrders(World, xy, mi);
-						YieldMouseFocus(mi);
-						return true;
-					}
-				}
-
 				if (World.OrderGenerator is UnitOrderGenerator)
 				{
 					if (multiClick)
@@ -114,14 +100,9 @@ namespace OpenRA.Widgets
 			if (mi.Button == MouseButton.None && mi.Event == MouseInputEvent.Move)
 				dragStart = dragEnd = xy;
 
-			if (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Down)
-			{
-				if (useClassicMouseStyle)
-					World.Selection.Clear();
-
-				if (!hasBox) // don't issue orders while selecting
-					ApplyOrders(World, xy, mi);
-			}
+			// don't issue orders while selecting
+			if (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Down && !hasBox) 
+				ApplyOrders(World, xy, mi);
 
 			return true;
 		}
@@ -184,7 +165,7 @@ namespace OpenRA.Widgets
 				var mi = new MouseInput
 				{
 					Location = screenPos,
-					Button = Game.mouseButtonPreference.Action,
+					Button = MouseButton.Right,
 					Modifiers = Game.GetModifierKeys()
 				};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -304,7 +304,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var gs = Game.Settings.Game;
 			var ks = Game.Settings.Keys;
 
-			BindCheckboxPref(panel, "CLASSICORDERS_CHECKBOX", gs, "UseClassicMouseStyle");
 			BindCheckboxPref(panel, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
 			BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gs, "LockMouseWindow");
 			BindSliderPref(panel, "SCROLLSPEED_SLIDER", gs, "ViewportEdgeScrollStep");
@@ -453,7 +452,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			return () =>
 			{
-				gs.UseClassicMouseStyle = dgs.UseClassicMouseStyle;
 				gs.MouseScroll = dgs.MouseScroll;
 				gs.LockMouseWindow = dgs.LockMouseWindow;
 				gs.ViewportEdgeScroll = dgs.ViewportEdgeScroll;

--- a/OpenRA.Mods.RA/Guard.cs
+++ b/OpenRA.Mods.RA/Guard.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
-			if (mi.Button == Game.mouseButtonPreference.Cancel)
+			if (mi.Button == MouseButton.Left)
 			{
 				world.CancelInputMode();
 				yield break;

--- a/OpenRA.Mods.RA/Minelayer.cs
+++ b/OpenRA.Mods.RA/Minelayer.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.RA
 
 			public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 			{
-				if (mi.Button == Game.mouseButtonPreference.Cancel)
+				if (mi.Button == MouseButton.Left)
 				{
 					world.CancelInputMode();
 					yield break;
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA
 					.MaxByOrDefault(a => a.Info.Traits.Contains<SelectableInfo>()
 						? a.Info.Traits.Get<SelectableInfo>().Priority : int.MinValue);
 
-				if (mi.Button == Game.mouseButtonPreference.Action && underCursor == null)
+				if (mi.Button == MouseButton.Right && underCursor == null)
 				{
 					minelayer.World.CancelInputMode();
 					yield return new Order("PlaceMinefield", minelayer, false) { TargetLocation = xy };

--- a/OpenRA.Mods.RA/PortableChrono.cs
+++ b/OpenRA.Mods.RA/PortableChrono.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.RA
 
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
-			if (mi.Button == Game.mouseButtonPreference.Cancel)
+			if (mi.Button == MouseButton.Left)
 			{
 				world.CancelInputMode();
 				yield break;

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.RA.Widgets
 
 			if (actors.Any())
 				world.OrderGenerator = new GenericSelectTarget(actors,
-					"AttackMove", "attackmove", Game.mouseButtonPreference.Action);
+					"AttackMove", "attackmove", MouseButton.Right);
 
 			return true;
 		}

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -382,7 +382,7 @@ Container@SETTINGS_PANEL:
 							Y: 155
 							Width: 560
 							ItemSpacing: 4
-							Height: 180
+							Height: 190
 							Children:
 								ScrollItem@HEADER:
 									Width: 528

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -312,52 +312,30 @@ Container@SETTINGS_PANEL:
 							Font: Bold
 							Text: Input
 							Align: Center
-						Checkbox@CLASSICORDERS_CHECKBOX:
-							X: 15
-							Y: 40
-							Width: 250
-							Height: 20
-							Font: Regular
-							Text: Left-Click Orders
-						Label@MOUSE_SCROLL_LABEL:
-							X: PARENT_RIGHT - WIDTH - 120
-							Y: 39
-							Width: 160
-							Height: 20
-							Font: Regular
-							Text: Middle-Mouse Scrolling:
-							Align: Right
-						DropDownButton@MOUSE_SCROLL:
-							X: PARENT_RIGHT - WIDTH - 15
-							Y: 38
-							Width: 100
-							Height: 25
-							Font: Regular
-							Text: Enabled
 						Checkbox@EDGESCROLL_CHECKBOX:
 							X: 15
-							Y: 70
+							Y: 40
 							Width: 130
 							Height: 20
 							Font: Regular
 							Text: Edge Scrolling
 						Checkbox@LOCKMOUSE_CHECKBOX:
 							X: 15
-							Y: 100
+							Y: 70
 							Width: 130
 							Height: 20
 							Font: Regular
 							Text: Lock mouse to window
 						Label@SCROLL_SPEED_LABEL:
 							X: PARENT_RIGHT - WIDTH - 270
-							Y: 67
+							Y: 37
 							Width: 95
 							Height: 25
 							Text: Scroll Speed:
 							Align: Right
 						Slider@SCROLLSPEED_SLIDER:
 							X: PARENT_RIGHT - WIDTH - 15
-							Y: 73
+							Y: 43
 							Width: 250
 							Height: 20
 							Ticks: 5
@@ -365,19 +343,34 @@ Container@SETTINGS_PANEL:
 							MaximumValue: 50
 						Label@UI_SCROLL_SPEED_LABEL:
 							X: PARENT_RIGHT - WIDTH - 270
-							Y: 97
+							Y: 67
 							Width: 95
 							Height: 25
 							Text: UI Scroll Speed:
 							Align: Right
 						Slider@UI_SCROLLSPEED_SLIDER:
 							X: PARENT_RIGHT - WIDTH - 15
-							Y: 103
+							Y: 73
 							Width: 250
 							Height: 20
 							Ticks: 5
 							MinimumValue: 1
 							MaximumValue: 100
+						Label@MOUSE_SCROLL_LABEL:
+							X: PARENT_RIGHT - WIDTH - 120
+							Y: 99
+							Width: 160
+							Height: 20
+							Font: Regular
+							Text: Middle-Mouse Scrolling:
+							Align: Right
+						DropDownButton@MOUSE_SCROLL:
+							X: PARENT_RIGHT - WIDTH - 15
+							Y: 98
+							Width: 100
+							Height: 25
+							Font: Regular
+							Text: Enabled
 						Label@HOTKEYS_TITLE:
 							Y: 135
 							Width: PARENT_RIGHT

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -386,7 +386,7 @@ Background@SETTINGS_PANEL:
 					Y: 155
 					Width: 560
 					ItemSpacing: 4
-					Height: 180
+					Height: 190
 					Children:
 						ScrollItem@HEADER:
 							BaseName: scrollheader

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -316,52 +316,30 @@ Background@SETTINGS_PANEL:
 			Width: PARENT_RIGHT - 10
 			Height: PARENT_BOTTOM
 			Children:
-				Checkbox@CLASSICORDERS_CHECKBOX:
-					X: 15
-					Y: 40
-					Width: 250
-					Height: 20
-					Font: Regular
-					Text: Left-Click Orders
-				Label@MOUSE_SCROLL_LABEL:
-					X: PARENT_RIGHT - WIDTH - 120
-					Y: 39
-					Width: 160
-					Height: 20
-					Font: Regular
-					Text: Middle-Mouse Scrolling:
-					Align: Right
-				DropDownButton@MOUSE_SCROLL:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 38
-					Width: 100
-					Height: 25
-					Font: Regular
-					Text: Enabled
 				Checkbox@EDGESCROLL_CHECKBOX:
 					X: 15
-					Y: 70
+					Y: 40
 					Width: 130
 					Height: 20
 					Font: Regular
 					Text: Edge Scrolling
 				Checkbox@LOCKMOUSE_CHECKBOX:
 					X: 15
-					Y: 100
+					Y: 70
 					Width: 130
 					Height: 20
 					Font: Regular
 					Text: Lock mouse to window
 				Label@SCROLL_SPEED_LABEL:
 					X: PARENT_RIGHT - WIDTH - 270
-					Y: 67
+					Y: 37
 					Width: 95
 					Height: 25
 					Text: Scroll Speed:
 					Align: Right
 				Slider@SCROLLSPEED_SLIDER:
 					X: PARENT_RIGHT - WIDTH - 15
-					Y: 73
+					Y: 43
 					Width: 250
 					Height: 20
 					Ticks: 5
@@ -369,19 +347,34 @@ Background@SETTINGS_PANEL:
 					MaximumValue: 50
 				Label@UI_SCROLL_SPEED_LABEL:
 					X: PARENT_RIGHT - WIDTH - 270
-					Y: 97
+					Y: 67
 					Width: 95
 					Height: 25
 					Text: UI Scroll Speed:
 					Align: Right
 				Slider@UI_SCROLLSPEED_SLIDER:
 					X: PARENT_RIGHT - WIDTH - 15
-					Y: 103
+					Y: 73
 					Width: 250
 					Height: 20
 					Ticks: 5
 					MinimumValue: 1
 					MaximumValue: 100
+				Label@MOUSE_SCROLL_LABEL:
+					X: PARENT_RIGHT - WIDTH - 120
+					Y: 99
+					Width: 160
+					Height: 20
+					Font: Regular
+					Text: Middle-Mouse Scrolling:
+					Align: Right
+				DropDownButton@MOUSE_SCROLL:
+					X: PARENT_RIGHT - WIDTH - 15
+					Y: 98
+					Width: 100
+					Height: 25
+					Font: Regular
+					Text: Enabled
 				Label@HOTKEYS_TITLE:
 					Y: 135
 					Width: PARENT_RIGHT


### PR DESCRIPTION
This feature has never worked properly, and is one of our most frequent support requests / complaints by non-technical players on IRC / comments.  Nobody has shown an interest in fixing and maintaining this feature, so it is time to remove it.
