### PR TITLE
Easier Footprints.

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -20,6 +20,17 @@ namespace OpenRA
 {
 	public static class Exts
 	{
+		public static Dictionary<V, K> ReverseKeyValues<K, V>(this Dictionary<K, V> dict)
+		{
+			var ret = new Dictionary<V, K>();
+
+			foreach (var kv in dict)
+				if (!ret.ContainsKey(kv.Value))
+					ret.Add(kv.Value, kv.Key);
+
+			return ret;
+		}
+
 		public static bool IsUppercase(this string str)
 		{
 			return string.Compare(str.ToUpperInvariant(), str, false) == 0;

--- a/OpenRA.Mods.RA/Buildings/Building.cs
+++ b/OpenRA.Mods.RA/Buildings/Building.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.RA.Buildings
 			this.topLeft = init.Get<LocationInit, CPos>();
 			this.Info = info;
 
-			occupiedCells = FootprintUtils.UnpathableTiles( self.Info.Name, Info, TopLeft )
+			occupiedCells = FootprintUtils.TilesOfType(FootprintType.Unpathable, self.Info.Name, info, topLeft)
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
 
 			CenterPosition = init.world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(init.world, Info);

--- a/OpenRA.Mods.RA/Render/WithBuildingExplosion.cs
+++ b/OpenRA.Mods.RA/Render/WithBuildingExplosion.cs
@@ -38,8 +38,8 @@ namespace OpenRA.Mods.RA.Render
 		public void Killed(Actor self, AttackInfo e)
 		{
 			var buildingInfo = self.Info.Traits.Get<BuildingInfo>();
-			FootprintUtils.UnpathableTiles(self.Info.Name, buildingInfo, self.Location).Do(
-				t => self.World.AddFrameEndTask(w => w.Add(new Explosion(w, w.Map.CenterOfCell(t), info.Sequence, info.Palette))));
+			var unpathableTiles = FootprintUtils.TilesOfType(FootprintType.Unpathable, self.Info.Name, buildingInfo, self.Location);
+			unpathableTiles.Do(t => self.World.AddFrameEndTask(w => w.Add(new Explosion(w, w.Map.CenterOfCell(t), info.Sequence, info.Palette))));
 		}
 	}
 }


### PR DESCRIPTION
- Add FootprintType enum
- Add `char → FootprintType` dictionary
- Add `FootprintType → char` dictionary
- Add TilesOfType method to FootprintUtils
- Remove (now obsolete) UnpathableTiles
- Add Dictionary extension method to reverse KV pairs
  - Values → Keys
  - Keys → Values
