### PR TITLE
Fixed yaml bug with leading spaces

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -262,7 +262,7 @@ namespace OpenRA
 			AssertExists("map.yaml");
 			AssertExists("map.bin");
 
-			var yaml = new MiniYaml(null, MiniYaml.FromStream(Container.GetContent("map.yaml")));
+			var yaml = new MiniYaml(null, MiniYaml.FromStream(Container.GetContent("map.yaml"), path));
 			FieldLoader.Load(this, yaml);
 
 			// Support for formats 1-3 dropped 2011-02-11.

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -60,6 +60,8 @@ namespace OpenRA
 				{
 					Console.WriteLine("Failed to load map: {0}", path);
 					Console.WriteLine("Details: {0}", e);
+					Log.Write("Debug", "Failed to load map: {0}", path);
+					Log.Write("Debug", "Details: {0}", e);
 				}
 			}
 		}

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -98,6 +98,8 @@ namespace OpenRA
 		/// <summary>Replace special character prefixes with full paths</summary>
 		public static string ResolvePath(string path)
 		{
+			path = path.TrimEnd(new char[] { ' ', '\t' });
+
 			// paths starting with ^ are relative to the support dir
 			if (path.StartsWith("^"))
 				path = SupportDir + path.Substring(1);

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -26,12 +26,40 @@ namespace OpenRA.Test
 	FromParent:
 	FromParentRemove:
 ";
+
 		readonly string yamlForChild = @"
 Child:
 	Inherits: ^Parent
 	FromChild:
 	-FromParentRemove:
 ";
+
+		readonly string yamlTabStyle = @"
+Root1:
+	Child1:
+		Attribute1: Test
+		Attribute2: Test
+	Child2:
+		Attribute1: Test
+		Attribute2: Test
+Root2:
+	Child1:
+		Attribute1: Test
+";
+
+		readonly string yamlMixedStyle = @"
+Root1:
+    Child1:
+        Attribute1: Test
+        Attribute2: Test
+	Child2:
+		Attribute1: Test
+	    Attribute2: Test
+Root2:
+    Child1:
+		Attribute1: Test
+";
+
 		List<MiniYamlNode> parentList;
 		List<MiniYamlNode> childList;
 		MiniYaml parent;
@@ -84,6 +112,16 @@ Child:
 			var res = MiniYaml.MergeLiberal(parentList, childList).Last();
 			Assert.That(res.Key, Is.EqualTo("Child"));
 			InheritanceTest(res.Value.Nodes);
+		}
+
+		[TestCase(TestName = "Mixed tabs & spaces indents")]
+		public void TestIndents()
+		{
+			var tabs = MiniYaml.FromString(yamlTabStyle, "yamlTabStyle").WriteToString();
+			Console.WriteLine(tabs);
+			var mixed = MiniYaml.FromString(yamlMixedStyle, "yamlMixedStyle").WriteToString();
+			Console.WriteLine(mixed);
+			Assert.That(tabs, Is.EqualTo(mixed));
 		}
 	}
 }


### PR DESCRIPTION
The yaml decoder could not read yaml files that used spaces instead of tabs.

I also improved the error output for the yaml reader a little. 
