### PR TITLE
Reduce enum memory

### DIFF
--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -32,7 +32,7 @@ namespace OpenRA
 		IGraphicsDevice Create(Size size, WindowMode windowMode);
 	}
 
-	public enum BlendMode { None, Alpha, Additive, Subtractive, Multiply }
+	public enum BlendMode : byte { None, Alpha, Additive, Subtractive, Multiply }
 
 	public interface IGraphicsDevice : IDisposable
 	{

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Graphics
 		}
 	}
 
-	public enum TextureChannel
+	public enum TextureChannel : byte
 	{
 		Red = 0,
 		Green = 1,


### PR DESCRIPTION
TextureChannel and BlendMode enums are both used in the Sprite class - since there are so many sprites reducing the footprint of these enums from ints to bytes saves a small amount of memory.
