### PR TITLE
Color coded the server browser and added a filter for password protected games

### DIFF
--- a/mods/cnc/chrome/serverbrowser.yaml
+++ b/mods/cnc/chrome/serverbrowser.yaml
@@ -30,6 +30,7 @@ Container@SERVERBROWSER_PANEL:
 					Width: 100
 					Height: 20
 					Text: Waiting
+					TextColor: 50,205,50
 				Checkbox@EMPTY:
 					X: 180
 					Y: 468
@@ -37,17 +38,26 @@ Container@SERVERBROWSER_PANEL:
 					Height: 20
 					Text: Empty
 				Checkbox@ALREADY_STARTED:
-					X: 280
+					X: 270
 					Y: 468
 					Width: 100
 					Height: 20
 					Text: Started
+					TextColor: 255,165,0
+				Checkbox@PASSWORD_PROTECTED:
+					X: 370
+					Y: 468
+					Width: 100
+					Height: 20
+					Text: Protected
+					TextColor: 255,0,0
 				Checkbox@INCOMPATIBLE_VERSION:
-					X: 380
+					X: 480
 					Y: 468
 					Width: 100
 					Height: 20
 					Text: Incompatible
+					TextColor: 190,190,190
 				Button@REFRESH_BUTTON:
 					X: PARENT_RIGHT - WIDTH - 20
 					Y: 465

--- a/mods/ra/chrome/serverbrowser.yaml
+++ b/mods/ra/chrome/serverbrowser.yaml
@@ -26,6 +26,7 @@ Background@SERVERBROWSER_PANEL:
 			Width: 100
 			Height: 20
 			Text: Waiting
+			TextColor: 50,205,50
 		Checkbox@EMPTY:
 			X: 180
 			Y: 50
@@ -38,12 +39,21 @@ Background@SERVERBROWSER_PANEL:
 			Width: 100
 			Height: 20
 			Text: Started
-		Checkbox@INCOMPATIBLE_VERSION:
+			TextColor: 255,165,0
+		Checkbox@PASSWORD_PROTECTED:
 			X: 380
 			Y: 50
 			Width: 100
 			Height: 20
+			Text: Protected
+			TextColor: 255,0,0
+		Checkbox@INCOMPATIBLE_VERSION:
+			X: 480
+			Y: 50
+			Width: 100
+			Height: 20
 			Text: Incompatible
+			TextColor: 190,190,190
 		ScrollPanel@SERVER_LIST:
 			X: 20
 			Y: 80


### PR DESCRIPTION
This implements #4495 and applies the color code style from www.openra.net/games/ with a legend:

![image](https://cloud.githubusercontent.com/assets/756669/5157404/c3e91e68-7309-11e4-9c5c-22fa5eface1e.png)

Essentially a followup of https://github.com/OpenRA/OpenRA/pull/6983 whose game name + "(Password)" was a little too subtle and unpolished for my taste.
