### PR TITLE
Fix ChronoshiftPower shroud checks.

### DIFF
--- a/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ChronoshiftPower.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA
 				var targetCell = target.Location + (order.TargetLocation - order.ExtraLocation);
 				var cpi = Info as ChronoshiftPowerInfo;
 
-				if (self.Owner.Shroud.IsExplored(targetCell) && cs.CanChronoshiftTo(target, targetCell))
+				if (order.Subject.Owner.Shroud.IsExplored(targetCell) && cs.CanChronoshiftTo(target, targetCell))
 					cs.Teleport(target, targetCell, cpi.Duration * 25, cpi.KillCargo, self);
 			}
 		}


### PR DESCRIPTION
Fixed ChronoshiftPower checking the actor's owner's shroud vs the player using the power.
Closes #6999
