### PR TITLE
Fixed vehicles can't move to nearby walled tile

### DIFF
--- a/OpenRA.Mods.RA/Move/Move.cs
+++ b/OpenRA.Mods.RA/Move/Move.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Move
 		readonly IEnumerable<IDisableMove> moveDisablers;
 		readonly WRange nearEnough;
 		readonly Func<List<CPos>> getPath;
-		readonly Actor ignoreBuilding;
+		readonly Actor ignoredActor;
 
 		List<CPos> path;
 		CPos? destination;
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA.Move
 			this.nearEnough = nearEnough;
 		}
 
-		public Move(Actor self, CPos destination, Actor ignoreBuilding)
+		public Move(Actor self, CPos destination, Actor ignoredActor)
 		{
 			mobile = self.Trait<Mobile>();
 			moveDisablers = self.TraitsImplementing<IDisableMove>();
@@ -85,11 +85,11 @@ namespace OpenRA.Mods.RA.Move
 			getPath = () =>
 				self.World.WorldActor.Trait<PathFinder>().FindPath(
 					PathSearch.FromPoint(self.World, mobile.Info, self, mobile.toCell, destination, false)
-					.WithIgnoredBuilding(ignoreBuilding));
+					.WithIgnoredActor(ignoredActor));
 
 			this.destination = destination;
 			this.nearEnough = WRange.Zero;
-			this.ignoreBuilding = ignoreBuilding;
+			this.ignoredActor = ignoredActor;
 		}
 
 		public Move(Actor self, Target target, WRange range)
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.RA.Move
 			var nextCell = path[path.Count - 1];
 
 			// Next cell in the move is blocked by another actor
-			if (!mobile.CanEnterCell(nextCell, ignoreBuilding, true))
+			if (!mobile.CanEnterCell(nextCell, ignoredActor, true))
 			{
 				// Are we close enough?
 				var cellRange = nearEnough.Range / 1024;
@@ -268,7 +268,7 @@ namespace OpenRA.Mods.RA.Move
 			hasWaited = false;
 			path.RemoveAt(path.Count - 1);
 
-			var subCell = mobile.GetAvailableSubCell(nextCell, SubCell.Any, ignoreBuilding);
+			var subCell = mobile.GetAvailableSubCell(nextCell, SubCell.Any, ignoredActor);
 			return Pair.New(nextCell, subCell);
 		}
 

--- a/OpenRA.Mods.RA/Move/PathFinder.cs
+++ b/OpenRA.Mods.RA/Move/PathFinder.cs
@@ -68,9 +68,14 @@ namespace OpenRA.Mods.RA.Move
 						return emptyPath;
 				}
 
+				var fromPoint = PathSearch.FromPoint(world, mi, self, target, from, true)
+				  .WithIgnoredActor(self);
+				var fromPointReverse = PathSearch.FromPoint(world, mi, self, from, target, true)
+				  .WithIgnoredActor(self)
+				  .Reverse();
 				var pb = FindBidiPath(
-					PathSearch.FromPoint(world, mi, self, target, from, true),
-					PathSearch.FromPoint(world, mi, self, from, target, true).Reverse()
+					fromPoint,
+					fromPointReverse
 				);
 
 				CheckSanePath2(pb, from, target);

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.Move
 		public PriorityQueue<PathDistance> Queue;
 		public Func<CPos, int> Heuristic;
 		public bool CheckForBlocked;
-		public Actor IgnoreBuilding;
+		public Actor IgnoredActor;
 		public bool InReverse;
 		public HashSet<CPos> Considered;
 		public Player Owner { get { return self.Owner; } }
@@ -108,9 +108,9 @@ namespace OpenRA.Mods.RA.Move
 			return this;
 		}
 
-		public PathSearch WithIgnoredBuilding(Actor b)
+		public PathSearch WithIgnoredActor(Actor b)
 		{
-			IgnoreBuilding = b;
+			IgnoredActor = b;
 			return this;
 		}
 
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.RA.Move
 				if (costHere == int.MaxValue)
 					continue;
 
-				if (!mobileInfo.CanEnterCell(world, self, newHere, IgnoreBuilding, CheckForBlocked ? CellConditions.TransientActors : CellConditions.None))
+				if (!mobileInfo.CanEnterCell(world, self, newHere, IgnoredActor, CheckForBlocked ? CellConditions.TransientActors : CellConditions.None))
 					continue;
 
 				if (customBlock != null && customBlock(newHere))


### PR DESCRIPTION
The fix for #6989 is mainly done in lines 73,74 in OpenRA.Mods.RA/Move/PathFinder.cs, rest of the patch is mainly naming convention changes. I'm aware that they might be wrong since this is my first pull request to this project.

Anyway the reason for this bug is that the first fromSrc.Expand-call doesn't add the grid position where the vehicle is located to the queue as there is no self awareness in the directional search that's moving towards the vehicle, this makes the search end early since that queue will be empty.
