### PR TITLE
Remove Chronoshiftable trait from TD mod vehicles

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -16,7 +16,6 @@
 	TargetableUnit:
 		TargetTypes: Ground, Vehicle
 	Repairable:
-	Chronoshiftable:
 	Passenger:
 		CargoType: Vehicle
 	HiddenUnderFog:
@@ -70,7 +69,6 @@
 	TargetableUnit:
 		TargetTypes: Ground, Vehicle
 	Repairable:
-	Chronoshiftable:
 	Passenger:
 		CargoType: Vehicle
 	HiddenUnderFog:


### PR DESCRIPTION
I noticed that vehicles in the TD mod have the Chronoshiftable trait. Since I don't think that is really needed, I removed it. It should go without saying that redundant traits are bad.
