### PR TITLE
Disengage observers

### DIFF
--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -21,13 +21,14 @@ namespace OpenRA.Network
 			public Order Order;
 		}
 
+		public readonly List<int> ObserverIDs = new List<int>();
 		readonly Dictionary<int, int> clientQuitTimes = new Dictionary<int, int>();
 		readonly Dictionary<int, Dictionary<int, byte[]>> framePackets = new Dictionary<int, Dictionary<int, byte[]>>();
 
 		public IEnumerable<int> ClientsPlayingInFrame(int frame)
 		{
 			return clientQuitTimes
-				.Where(x => frame <= x.Value)
+				.Where(x => !ObserverIDs.Contains(x.Key) && frame <= x.Value)
 				.Select(x => x.Key)
 				.OrderBy(x => x);
 		}

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Server
 
 		/* client data */
 		public int PlayerIndex;
+		public bool CanTimeout = true;
 
 		public byte[] PopBytes(int n)
 		{

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -675,8 +675,12 @@ namespace OpenRA.Server
 			State = ServerState.GameStarted;
 
 			foreach (var c in Conns)
+			{
+				if (this.GetClient(c).IsObserver)
+					c.CanTimeout = false;
 				foreach (var d in Conns)
 					DispatchOrdersToClient(c, d.PlayerIndex, 0x7FFFFFFF, new byte[] { 0xBF });
+			}
 
 			DispatchOrders(null, 0,
 				new ServerOrder("StartGame", "").Serialize());

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -36,6 +36,8 @@ namespace OpenRA.Mods.Common.Server
 				lastPing = Game.RunTime;
 				foreach (var c in server.Conns.ToList())
 				{
+					if (!c.CanTimeout)
+						continue;
 					if (c.TimeSinceLastResponse < ConnTimeout)
 					{
 						server.SendOrderTo(c, "Ping", Game.RunTime.ToString());
@@ -58,7 +60,7 @@ namespace OpenRA.Mods.Common.Server
 				lastConnReport = Game.RunTime;
 
 				var timeouts = server.Conns
-					.Where(c => c.TimeSinceLastResponse > ConnReportInterval && c.TimeSinceLastResponse < ConnTimeout)
+					.Where(c => c.CanTimeout && c.TimeSinceLastResponse > ConnReportInterval && c.TimeSinceLastResponse < ConnTimeout)
 					.OrderBy(c => c.TimeSinceLastResponse);
 
 				foreach (var c in timeouts)


### PR DESCRIPTION
We have finally done it by using a mixture of quantum physics and black magic.

Observers have now been disengaged from the order manager.

This means that normal players will no longer lag because the connection of an observer is slow,
this also means that even if the observer lags it he can still watch the whole game.

A testcase for this is easy, just take 2 clients host a bot match with one of the clients as an observer,
pause the observer client with a debugger, resume after half a minute or so.

Enjoy watching the game from behind and talking to the players that are playing in the future.
(The Players can still see your messages even if you are 5 minutes behind and you can still see theirs)
