### PR TITLE
Add option for delayed observers.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -80,7 +80,8 @@ namespace OpenRA
 		public static int RunTime { get { return (int)Game.stopwatch.ElapsedMilliseconds; } }
 
 		public static int RenderFrame = 0;
-		public static int NetFrameNumber { get { return orderManager.NetFrameNumber; } }
+		public static int NetFrameNumber { get { return orderManager.CanSend() ? orderManager.NetFrameNumber :
+			orderManager.NetFrameNumber + orderManager.LobbyInfo.GlobalSettings.SpectatorDelay; } }
 		public static int LocalTick { get { return orderManager.LocalFrameNumber; } }
 		public const int NetTickScale = 3; // 120 ms net tick for 40 ms local tick
 		public const int Timestep = 40;

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -21,13 +21,14 @@ namespace OpenRA.Network
 			public Order Order;
 		}
 
+		public readonly List<int> ObserverIDs = new List<int>();
 		readonly Dictionary<int, int> clientQuitTimes = new Dictionary<int, int>();
 		readonly Dictionary<int, Dictionary<int, byte[]>> framePackets = new Dictionary<int, Dictionary<int, byte[]>>();
 
 		public IEnumerable<int> ClientsPlayingInFrame(int frame)
 		{
 			return clientQuitTimes
-				.Where(x => frame <= x.Value)
+				.Where(x => !ObserverIDs.Contains(x.Key) && frame <= x.Value)
 				.Select(x => x.Key)
 				.OrderBy(x => x);
 		}

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -177,6 +177,7 @@ namespace OpenRA.Network
 			public bool FragileAlliances = false; // Allow diplomatic stance changes after game start.
 			public bool AllowCheats = false;
 			public bool AllowSpectators = true;
+			public int SpectatorDelay = 100;
 			public bool Dedicated;
 			public string Difficulty;
 			public bool Crates = true;

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Server
 
 		/* client data */
 		public int PlayerIndex;
+		public bool CanTimeout = true;
 
 		public byte[] PopBytes(int n)
 		{

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -675,8 +675,12 @@ namespace OpenRA.Server
 			State = ServerState.GameStarted;
 
 			foreach (var c in Conns)
+			{
+				if (this.GetClient(c).IsObserver)
+					c.CanTimeout = false;
 				foreach (var d in Conns)
 					DispatchOrdersToClient(c, d.PlayerIndex, 0x7FFFFFFF, new byte[] { 0xBF });
+			}
 
 			DispatchOrders(null, 0,
 				new ServerOrder("StartGame", "").Serialize());

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -256,7 +256,7 @@ namespace OpenRA
 
 		public void Tick()
 		{
-			if (!Paused && (!IsShellmap || Game.Settings.Game.ShowShellmap))
+			if (!Paused && (!IsShellmap || Game.Settings.Game.ShowShellmap) && orderManager.DelayedNetFrameNumber >= 0)
 			{
 				WorldTick++;
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -157,6 +157,27 @@ namespace OpenRA.Mods.Common.Server
 						}
 					}
 				},
+				{ "spectator_delay",
+					s =>
+					{
+						if (!client.IsAdmin)
+						{
+							server.SendOrderTo(conn, "Message", "Only the host can set that option");
+							return true;
+						}
+
+						if (int.TryParse(s, out server.LobbyInfo.GlobalSettings.SpectatorDelay))
+						{
+							server.SyncLobbyGlobalSettings();
+							return true;
+						}
+						else
+						{
+							server.SendOrderTo(conn, "Message", "Malformed spectator_delay command");
+							return true;
+						}
+					}
+				},
 				{ "spectate",
 					s =>
 					{

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -36,6 +36,8 @@ namespace OpenRA.Mods.Common.Server
 				lastPing = Game.RunTime;
 				foreach (var c in server.Conns.ToList())
 				{
+					if (!c.CanTimeout)
+						continue;
 					if (c.TimeSinceLastResponse < ConnTimeout)
 					{
 						server.SendOrderTo(c, "Ping", Game.RunTime.ToString());
@@ -58,7 +60,7 @@ namespace OpenRA.Mods.Common.Server
 				lastConnReport = Game.RunTime;
 
 				var timeouts = server.Conns
-					.Where(c => c.TimeSinceLastResponse > ConnReportInterval && c.TimeSinceLastResponse < ConnTimeout)
+					.Where(c => c.CanTimeout && c.TimeSinceLastResponse > ConnReportInterval && c.TimeSinceLastResponse < ConnTimeout)
 					.OrderBy(c => c.TimeSinceLastResponse);
 
 				foreach (var c in timeouts)

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -463,6 +463,24 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				};
 			}
 
+			var spectatorDelay = optionsBin.GetOrNull<TextFieldWidget>("SPECTATORDELAY_TEXTFIELD");
+			if (spectatorDelay != null)
+			{
+				spectatorDelay.IsDisabled = () => Map.Status != MapStatus.Available || configurationDisabled();
+				spectatorDelay.OnTextEdited = () =>
+				{
+					if (int.TryParse(spectatorDelay.Text, out orderManager.LobbyInfo.GlobalSettings.SpectatorDelay))
+					{
+						orderManager.LobbyInfo.GlobalSettings.SpectatorDelay *= 25;
+						orderManager.IssueOrder(Order.Command("spectator_delay {0}".F(orderManager.LobbyInfo.GlobalSettings.SpectatorDelay)));
+					}
+				};
+				spectatorDelay.OnLoseFocus = () =>
+				{
+					spectatorDelay.Text = "" + orderManager.LobbyInfo.GlobalSettings.SpectatorDelay;
+				};
+			}
+
 			var enableShroud = optionsBin.GetOrNull<CheckboxWidget>("SHROUD_CHECKBOX");
 			if (enableShroud != null)
 			{

--- a/mods/cnc/chrome/lobby-dialogs.yaml
+++ b/mods/cnc/chrome/lobby-dialogs.yaml
@@ -194,6 +194,18 @@ Background@LOBBY_OPTIONS_BIN:
 					Height: 25
 					Text: Tech Level:
 					Align: Right
+				TextField@SPECTATORDELAY_TEXTFIELD:
+					X: PARENT_RIGHT - WIDTH + 10
+					Y: 112
+					Width: 140
+					Height: 25
+				Label@SPECTATORDELAY_DESC:
+					X: PARENT_RIGHT - WIDTH - 135
+					Y: 112
+					Width: 80
+					Height: 25
+					Text: Spectator Delay:
+					Align: Right
 
 Background@FORCE_START_DIALOG:
 	X: 15

--- a/mods/ra/chrome/lobby-dialogs.yaml
+++ b/mods/ra/chrome/lobby-dialogs.yaml
@@ -192,6 +192,18 @@ Background@LOBBY_OPTIONS_BIN:
 					Height: 25
 					Text: Tech Level:
 					Align: Right
+				TextField@SPECTATORDELAY_TEXTFIELD:
+					X: PARENT_RIGHT - WIDTH
+					Y: 127
+					Width: 140
+					Height: 25
+				Label@SPECTATORDELAY_DESC:
+					X: PARENT_RIGHT - WIDTH - 145
+					Y: 127
+					Width: 80
+					Height: 25
+					Text: Spectator Delay:
+					Align: Right
 
 Background@FORCE_START_DIALOG:
 	X: 20


### PR DESCRIPTION
Depends on #7050,
allows the admin to specify a delay for observers.

P.S. This delay does not apply to the admin if he is a spectator simply because that would screw up the AI completely.
