### PR TITLE
Improve radar rendering performance

### DIFF
--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -20,6 +20,8 @@ namespace OpenRA
 	{
 		public readonly Size Size;
 		public readonly TileShape Shape;
+		public event Action<CPos> CellEntryChanged = null;
+
 		readonly T[] entries;
 
 		public CellLayer(Map map)
@@ -48,15 +50,35 @@ namespace OpenRA
 		/// <summary>Gets or sets the <see cref="OpenRA.CellLayer"/> using cell coordinates</summary>
 		public T this[CPos cell]
 		{
-			get { return entries[Index(cell)]; }
-			set { entries[Index(cell)] = value; }
+			get
+			{
+				return entries[Index(cell)];
+			}
+
+			set
+			{
+				entries[Index(cell)] = value;
+
+				if (CellEntryChanged != null)
+					CellEntryChanged(cell);
+			}
 		}
 
 		/// <summary>Gets or sets the layer contents using raw map coordinates (not CPos!)</summary>
 		public T this[int u, int v]
 		{
-			get { return entries[Index(u, v)]; }
-			set { entries[Index(u, v)] = value; }
+			get
+			{
+				return entries[Index(u, v)];
+			}
+
+			set
+			{
+				entries[Index(u, v)] = value;
+
+				if (CellEntryChanged != null)
+					CellEntryChanged(Map.MapToCell(Shape, new CPos(u, v)));
+			}
 		}
 
 		/// <summary>Clears the layer contents with a known value</summary>

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -31,6 +31,23 @@ namespace OpenRA.Traits
 		readonly CellLayer<short> generatedShroudCount;
 		readonly CellLayer<bool> explored;
 
+		public event Action<CPos> CellEntryChanged
+		{
+			add
+			{
+				visibleCount.CellEntryChanged += value;
+				generatedShroudCount.CellEntryChanged += value;
+				explored.CellEntryChanged += value;
+			}
+
+			remove
+			{
+				visibleCount.CellEntryChanged -= value;
+				generatedShroudCount.CellEntryChanged -= value;
+				explored.CellEntryChanged -= value;
+			}
+		}
+
 		readonly Lazy<IFogVisibilityModifier[]> fogVisibilities;
 
 		// Cache of visibility that was added, so no matter what crazy trait code does, it


### PR DESCRIPTION
This introduces a CellEntryChanged event on CellLayer, and uses this to cut out most of the heavy looping from the radar updates.  These events will also be used by the ingame map editor, and should help significantly with our shroud rendering performance.

The old radar code split the update over 12 ticks, with only three of these doing actual work.  This is no longer necessary, which gives us a much smoother radar view.

I verified that this doesn't regress performance by timing `RadarWidget.Tick` over 1000 ticks on the biggest and smallest maps that I could find:
![histogram](https://cloud.githubusercontent.com/assets/167819/5260885/c092c220-7a78-11e4-9abb-26d9a4f7cd72.png)
