### PR TITLE
Avoid redundant cell <-> map conversions

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -182,13 +182,13 @@ namespace OpenRA.Graphics
 				var stride = bitmapData.Stride / 4;
 				var shroudObscured = world.ShroudObscuresTest(map.Cells);
 				var fogObscured = world.FogObscuresTest(map.Cells);
-				foreach (var cell in map.Cells)
+				foreach (var uv in map.Cells.MapCoords)
 				{
-					var uv = Map.CellToMap(map.TileShape, cell) - offset;
-					if (shroudObscured(cell))
-						colors[uv.Y * stride + uv.X] = shroud;
-					else if (fogObscured(cell))
-						colors[uv.Y * stride + uv.X] = fog;
+					var bitmapUv = uv - offset;
+					if (shroudObscured(uv.X, uv.Y))
+						colors[bitmapUv.Y * stride + bitmapUv.X] = shroud;
+					else if (fogObscured(uv.X, uv.Y))
+						colors[bitmapUv.Y * stride + bitmapUv.X] = fog;
 				}
 			}
 

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -87,6 +87,11 @@ namespace OpenRA
 			return uv.X >= mapTopLeft.X && uv.X <= mapBottomRight.X && uv.Y >= mapTopLeft.Y && uv.Y <= mapBottomRight.Y;
 		}
 
+		public MapCoordsRegion MapCoords
+		{
+			get { return new MapCoordsRegion(this); }
+		}
+
 		public CellRegionEnumerator GetEnumerator()
 		{
 			return new CellRegionEnumerator(this);
@@ -102,7 +107,7 @@ namespace OpenRA
 			return GetEnumerator();
 		}
 
-		public class CellRegionEnumerator : IEnumerator<CPos>
+		public sealed class CellRegionEnumerator : IEnumerator<CPos>
 		{
 			readonly CellRegion r;
 
@@ -147,6 +152,73 @@ namespace OpenRA
 			public CPos Current { get { return current; } }
 			object IEnumerator.Current { get { return Current; } }
 			public void Dispose() { }
+		}
+
+		public struct MapCoordsRegion : IEnumerable<CPos>
+		{
+			public struct MapCoordsEnumerator : IEnumerator<CPos>
+			{
+				readonly CellRegion r;
+				CPos current;
+
+				public MapCoordsEnumerator(CellRegion region)
+					: this()
+				{
+					r = region;
+					Reset();
+				}
+
+				public bool MoveNext()
+				{
+					var u = current.X + 1;
+					var v = current.Y;
+
+					// Check for column overflow
+					if (u > r.mapBottomRight.X)
+					{
+						v += 1;
+						u = r.mapTopLeft.X;
+
+						// Check for row overflow
+						if (v > r.mapBottomRight.Y)
+							return false;
+					}
+
+					current = new CPos(u, v);
+					return true;
+				}
+
+				public void Reset()
+				{
+					current = new CPos(r.mapTopLeft.X - 1, r.mapTopLeft.Y);
+				}
+
+				public CPos Current { get { return current; } }
+				object IEnumerator.Current { get { return Current; } }
+				public void Dispose() { }
+			}
+
+			readonly CellRegion r;
+
+			public MapCoordsRegion(CellRegion region)
+			{
+				r = region;
+			}
+
+			public MapCoordsEnumerator GetEnumerator()
+			{
+				return new MapCoordsEnumerator(r);
+			}
+
+			IEnumerator<CPos> IEnumerable<CPos>.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
 		}
 	}
 }

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -366,8 +366,8 @@ namespace OpenRA
 			Cells = new CellRegion(TileShape, tl, br);
 
 			CustomTerrain = new CellLayer<byte>(this);
-			foreach (var cell in Cells)
-				CustomTerrain[cell] = byte.MaxValue;
+			foreach (var uv in Cells.MapCoords)
+				CustomTerrain[uv.X, uv.Y] = byte.MaxValue;
 		}
 
 		public Ruleset PreloadRules()
@@ -597,7 +597,12 @@ namespace OpenRA
 		public bool Contains(CPos cell)
 		{
 			var uv = CellToMap(TileShape, cell);
-			return Bounds.Contains(uv.X, uv.Y);
+			return Contains(uv.X, uv.Y);
+		}
+
+		public bool Contains(int u, int v)
+		{
+			return Bounds.Contains(u, v);
 		}
 
 		public WPos CenterOfCell(CPos cell)
@@ -795,8 +800,11 @@ namespace OpenRA
 
 		public byte GetTerrainIndex(CPos cell)
 		{
-			var custom = CustomTerrain[cell];
-			return custom != byte.MaxValue ? custom : cachedTileSet.Value.GetTerrainIndex(MapTiles.Value[cell]);
+			var uv = Map.CellToMap(TileShape, cell);
+			var u = uv.X;
+			var v = uv.Y;
+			var custom = CustomTerrain[u, v];
+			return custom != byte.MaxValue ? custom : cachedTileSet.Value.GetTerrainIndex(MapTiles.Value[u, v]);
 		}
 
 		public TerrainTypeInfo GetTerrainInfo(CPos cell)

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(c => world.ShroudObscures(c)))
+					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.FootprintInMapCoords.All(uv => world.ShroudObscures(uv.X, uv.Y)))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}
@@ -74,7 +74,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(c => world.ShroudObscures(c)))
+					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.FootprintInMapCoords.All(uv => world.ShroudObscures(uv.X, uv.Y)))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -24,7 +24,7 @@ namespace OpenRA
 {
 	public class World
 	{
-		static readonly Func<CPos, bool> FalsePredicate = cell => false;
+		static readonly Func<int, int, bool> FalsePredicate = (u, v) => false;
 		internal readonly TraitDictionary traitDict = new TraitDictionary();
 		readonly HashSet<Actor> actors = new HashSet<Actor>();
 		readonly List<IEffect> effects = new List<IEffect>();
@@ -65,23 +65,24 @@ namespace OpenRA
 		public bool FogObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(p); }
 		public bool ShroudObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(a); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
+		public bool ShroudObscures(int u, int v) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(u, v); }
 		
-		public Func<CPos, bool> FogObscuresTest(CellRegion region)
+		public Func<int, int, bool> FogObscuresTest(CellRegion region)
 		{
 			var rp = RenderPlayer;
 			if (rp == null)
 				return FalsePredicate;
 			var predicate = rp.Shroud.IsVisibleTest(region);
-			return cell => !predicate(cell);
+			return (u, v) => !predicate(u, v);
 		}
 
-		public Func<CPos, bool> ShroudObscuresTest(CellRegion region)
+		public Func<int, int, bool> ShroudObscuresTest(CellRegion region)
 		{
 			var rp = RenderPlayer;
 			if (rp == null)
 				return FalsePredicate;
 			var predicate = rp.Shroud.IsExploredTest(region);
-			return cell => !predicate(cell);
+			return (u, v) => !predicate(u, v);
 		}
 
 		public bool IsReplay

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -81,13 +81,13 @@ namespace OpenRA.Mods.Common.Traits
 			var rightDelta = ts == TileShape.Diamond ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
 			var bottomDelta = ts == TileShape.Diamond ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
 
-			foreach (var cell in wr.Viewport.VisibleCells)
+			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
 				var lr = Game.Renderer.WorldLineRenderer;
-				var pos = wr.world.Map.CenterOfCell(cell);
+				var pos = wr.world.Map.CenterOfCell(Map.MapToCell(wr.world.Map.TileShape, uv));
 
-				var height = (int)wr.world.Map.MapHeight.Value[cell];
-				var tile = wr.world.Map.MapTiles.Value[cell];
+				var height = (int)wr.world.Map.MapHeight.Value[uv.X, uv.Y];
+				var tile = wr.world.Map.MapTiles.Value[uv.X, uv.Y];
 
 				TerrainTileInfo tileInfo = null;
 

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -332,8 +332,8 @@ namespace OpenRA.Mods.RA.Move
 					defaultCellInfoLayer.Shape != map.TileShape)
 				{
 					defaultCellInfoLayer = new CellLayer<CellInfo>(map);
-					foreach (var cell in map.Cells)
-						defaultCellInfoLayer[cell] = new CellInfo(int.MaxValue, cell, false);
+					foreach (var uv in map.Cells.MapCoords)
+						defaultCellInfoLayer[uv.X, uv.Y] = new CellInfo(int.MaxValue, Map.MapToCell(map.TileShape, uv), false);
 				}
 
 				result.CopyValuesFrom(defaultCellInfoLayer);

--- a/OpenRA.Mods.RA/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.RA/Traits/World/ResourceLayer.cs
@@ -35,14 +35,14 @@ namespace OpenRA.Mods.RA.Traits
 		public void Render(WorldRenderer wr)
 		{
 			var shroudObscured = world.ShroudObscuresTest(wr.Viewport.VisibleCells);
-			foreach (var cell in wr.Viewport.VisibleCells)
+			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
-				if (shroudObscured(cell))
+				if (shroudObscured(uv.X, uv.Y))
 					continue;
 
-				var c = render[cell];
+				var c = render[uv.X, uv.Y];
 				if (c.Sprite != null)
-					new SpriteRenderable(c.Sprite, wr.world.Map.CenterOfCell(cell),
+					new SpriteRenderable(c.Sprite, wr.world.Map.CenterOfCell(Map.MapToCell(world.Map.TileShape, uv)),
 						WVec.Zero, -511, c.Type.Palette, 1f, true).Render(wr); // TODO ZOffset is ignored
 			}
 		}


### PR DESCRIPTION
The CellRegion and CellLayer classes prefer map-coords internally since they can be used more directly for array indexing, but their APIs all expose cell co-ordinates.

The lead to a particularly bad case where enumerating the cells of a region would do map->cell conversions for you, only to use those cells as an indexer into a layer which would convert the cell back into a map co-ordinate. All the round trips are quite expensive since so many are performed.

This PR adds the ability to enumerate a region in map-coords and then uses this ability in several key places to index into the layer using those map-coords. I didn't fix every use since there's so many.
