### PR TITLE
Removed the need to give NPCs fake objectives to properly end the game

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -41,6 +41,7 @@ namespace OpenRA
 		public readonly PlayerReference PlayerReference;
 		public bool IsBot;
 		public int SpawnPoint;
+		public bool HasObjectives = false;
 
 		public Shroud Shroud;
 		public World World { get; private set; }

--- a/OpenRA.Mods.RA/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.RA/Player/MissionObjectives.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.RA
 				{
 					foreach (var inou in inous)
 						inou.OnPlayerLost(player);
-	
+
 					CheckIfGameIsOver(player);
 				}
 			}
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.RA
 		{
 			var players = player.World.Players.Where(p => !p.NonCombatant);
 
-			var gameOver = players.All(p => p.WinState != WinState.Undefined);
+			var gameOver = players.All(p => p.WinState != WinState.Undefined || !p.HasObjectives);
 			if (gameOver)
 				Game.RunAfterDelay(info.GameOverDelay, () =>
 				{
@@ -181,6 +181,8 @@ namespace OpenRA.Mods.RA
 					foreach (var p in enemies)
 						p.PlayerActor.Trait<MissionObjectives>().ForceDefeat(p);
 			}
+
+			CheckIfGameIsOver(player);
 		}
 
 		public void OnPlayerLost(Player player)
@@ -218,6 +220,8 @@ namespace OpenRA.Mods.RA
 						p.World.OnPlayerWinStateChanged(p);
 					}
 			}
+
+			CheckIfGameIsOver(player);
 		}
 
 		public void ForceDefeat(Player player)
@@ -227,7 +231,7 @@ namespace OpenRA.Mods.RA
 					MarkFailed(player, id);
 		}
 
-		public event Action<Player> ObjectiveAdded = player => { };
+		public event Action<Player> ObjectiveAdded = player => { player.HasObjectives = true; };
 
 		public void OnObjectiveAdded(Player player, int id) {}
 		public void OnObjectiveCompleted(Player player, int id) {}

--- a/mods/ra/maps/allies-01/allies01.lua
+++ b/mods/ra/maps/allies-01/allies01.lua
@@ -12,7 +12,7 @@ SendInsertionHelicopter = function()
 	local passengers = Reinforcements.ReinforceWithTransport(player, InsertionHelicopterType,
 		TanyaReinforcements, InsertionPath, { InsertionEntry.Location })[2]
 	local tanya = passengers[1]
-	Trigger.OnKilled(tanya, RescueFailed)
+	Trigger.OnKilled(tanya, TanyaKilledInAction)
 	tanya.Stance = "HoldFire"
 end
 
@@ -95,7 +95,13 @@ LabDestroyed = function()
 end
 
 RescueFailed = function()
-	player.MarkFailedObjective(SurviveObjective)
+	Media.PlaySpeechNotification(player, "ObjectiveNotMet")
+	player.MarkFailedObjective(EinsteinSurviveObjective)
+end
+
+TanyaKilledInAction = function()
+	Media.PlaySpeechNotification(player, "ObjectiveNotMet")
+	player.MarkFailedObjective(TanyaSurviveObjective)
 end
 
 OilPumpDestroyed = function()
@@ -123,7 +129,10 @@ HelicopterGone = function()
 		Media.PlaySpeechNotification(player, "TargetRescued")
 		Trigger.AfterDelay(DateTime.Seconds(1), function()
 			player.MarkCompletedObjective(ExtractObjective)
-			player.MarkCompletedObjective(SurviveObjective)
+			player.MarkCompletedObjective(EinsteinSurviveObjective)
+			if not Tanya.IsDead then
+				player.MarkCompletedObjective(TanyaSurviveObjective)
+			end
 			if not collateralDamage then
 				player.MarkCompletedObjective(CivilProtectionObjective)
 			end
@@ -175,7 +184,8 @@ WorldLoaded = function()
 
 	Media.PlayMovieFullscreen("landing.vqa", function()
 		FindEinsteinObjective = player.AddPrimaryObjective("Find Einstein.")
-		SurviveObjective = player.AddPrimaryObjective("Tanya and Einstein must survive.")
+		TanyaSurviveObjective = player.AddPrimaryObjective("Tanya must survive.")
+		EinsteinSurviveObjective = player.AddPrimaryObjective("Einstein must survive.")
 		CivilProtectionObjective = player.AddSecondaryObjective("Protect all civilians.")
 
 		RunInitialActivities()

--- a/mods/ra/maps/allies-01/allies01.lua
+++ b/mods/ra/maps/allies-01/allies01.lua
@@ -96,7 +96,6 @@ end
 
 RescueFailed = function()
 	player.MarkFailedObjective(SurviveObjective)
-	ussr.MarkCompletedObjective(DefendObjective)
 end
 
 OilPumpDestroyed = function()
@@ -125,7 +124,6 @@ HelicopterGone = function()
 		Trigger.AfterDelay(DateTime.Seconds(1), function()
 			player.MarkCompletedObjective(ExtractObjective)
 			player.MarkCompletedObjective(SurviveObjective)
-			ussr.MarkFailedObjective(DefendObjective)
 			if not collateralDamage then
 				player.MarkCompletedObjective(CivilProtectionObjective)
 			end
@@ -178,9 +176,7 @@ WorldLoaded = function()
 	Media.PlayMovieFullscreen("landing.vqa", function()
 		FindEinsteinObjective = player.AddPrimaryObjective("Find Einstein.")
 		SurviveObjective = player.AddPrimaryObjective("Tanya and Einstein must survive.")
-		england.AddPrimaryObjective("Destroy the soviet base after a successful rescue.")
 		CivilProtectionObjective = player.AddSecondaryObjective("Protect all civilians.")
-		DefendObjective = ussr.AddPrimaryObjective("Kill Tanya and keep Einstein hostage.")
 
 		RunInitialActivities()
 	end)

--- a/mods/ra/maps/allies-02/allies02.lua
+++ b/mods/ra/maps/allies-02/allies02.lua
@@ -111,8 +111,6 @@ WorldLoaded = function()
 
 	Media.PlayMovieFullscreen("mcv.vqa", function()
 		ConquestObjective = player.AddPrimaryObjective("Secure the area.")
-		ussr.AddPrimaryObjective("Defend your base.")
-		ukraine.AddPrimaryObjective("Destroy the convoy.")
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(1), function() Media.PlaySpeechNotification(allies, "MissionTimerInitialised") end)


### PR DESCRIPTION
This simplifies setting up single-player objectives a lot. The behavior outlined in https://github.com/OpenRA/OpenRA/pull/6377#issuecomment-53992565 was pretty wonky. I noticed while trying to fix https://github.com/OpenRA/OpenRA/issues/7068. When Tanya gets killed, it would automatically mark Einstein as killed and vice versa.
