### PR TITLE
Fix aircraft fly endlessly in a circle when ordered to attack inside own...

### DIFF
--- a/OpenRA.Mods.RA/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.RA/Activities/Air/FlyAttack.cs
@@ -10,6 +10,7 @@
 
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
+using System.Linq;
 
 namespace OpenRA.Mods.RA.Activities
 {
@@ -17,6 +18,7 @@ namespace OpenRA.Mods.RA.Activities
 	{
 		readonly Target target;
 		Activity inner;
+		int ticksUntilTurn = 50;
 
 		public FlyAttack(Target target) { this.target = target; }
 
@@ -38,9 +40,11 @@ namespace OpenRA.Mods.RA.Activities
 				if (IsCanceled)
 					return NextActivity;
 
-				inner = Util.SequenceActivities(new Fly(self, target), new FlyTimed(50));
+				if (target.IsInRange(self.CenterPosition, attack.Armaments.Select(a => a.Weapon.MinRange).Min()))
+					inner = Util.SequenceActivities(new FlyTimed(ticksUntilTurn), new Fly(self, target), new FlyTimed(ticksUntilTurn));
+				else
+					inner = Util.SequenceActivities(new Fly(self, target), new FlyTimed(ticksUntilTurn));
 			}
-
 			inner = Util.RunActivity(self, inner);
 
 			return this;


### PR DESCRIPTION
... turning radius

Fixes #7083 

This fixed is based on the minimum range of the aircraft's weapons and seems to be working quite well. If the target is inside the minimum attack radius of the aircraft, it simply does an extra attack run turn before attacking. 
