### PR TITLE
Converted sequence ticks to proper game ticks

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Graphics
 
 		string name;
 
-		readonly int defaultTick = 40; // 25 fps == 40 ms
+		const int DefaultTick = 1;
 		bool tickAlways;
 
 		public string Name { get { return name; } }
@@ -136,26 +136,23 @@ namespace OpenRA.Graphics
 
 		public void Tick()
 		{
-			if (Paused == null || !Paused())
-				Tick(40); // tick one frame
-		}
+			if (Paused != null && Paused())
+				return;
 
-		public bool HasSequence(string seq) { return sequenceProvider.HasSequence(name, seq); }
-
-		public void Tick(int t)
-		{
 			if (tickAlways)
 				tickFunc();
 			else
 			{
-				timeUntilNextFrame -= t;
+				timeUntilNextFrame -= DefaultTick;
 				while (timeUntilNextFrame <= 0)
 				{
 					tickFunc();
-					timeUntilNextFrame += CurrentSequence != null ? CurrentSequence.Tick : defaultTick;
+					timeUntilNextFrame += CurrentSequence != null ? CurrentSequence.Tick : DefaultTick;
 				}
 			}
 		}
+
+		public bool HasSequence(string seq) { return sequenceProvider.HasSequence(name, seq); }
 
 		public void ChangeImage(string newImage, string newAnimIfMissing)
 		{

--- a/OpenRA.Game/Graphics/Sequence.cs
+++ b/OpenRA.Game/Graphics/Sequence.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Graphics
 				if (d.ContainsKey("Tick"))
 					Tick = Exts.ParseIntegerInvariant(d["Tick"].Value);
 				else
-					Tick = 40;
+					Tick = 1;
 
 				if (d.ContainsKey("Transpose"))
 					transpose = bool.Parse(d["Transpose"].Value);

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -200,6 +200,7 @@
     <Compile Include="SpriteLoaders\ShpD2Loader.cs" />
     <Compile Include="Widgets\Logic\SettingsLogic.cs" />
     <Compile Include="Widgets\TerrainTemplatePreviewWidget.cs" />
+    <Compile Include="UtilityCommands\UpgradeSequences.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			UpgradeRules.UpgradeWeaponRules(engineDate, ref map.WeaponDefinitions, null, 0);
 			UpgradeRules.UpgradeActorRules(engineDate, ref map.RuleDefinitions, null, 0);
+			UpgradeSequences.UpgradeActorSequences(engineDate, ref map.SequenceDefinitions, null, 0);
 			map.Save(args[1]);
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -40,6 +40,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					file.WriteLine(yaml.WriteToString());
 			}
 
+			Console.WriteLine("Processing Sequences:");
+			foreach (var filename in Game.modData.Manifest.Sequences)
+			{
+				Console.WriteLine("\t" + filename);
+				var yaml = MiniYaml.FromFile(filename);
+				UpgradeSequences.UpgradeActorSequences(engineDate, ref yaml, null, 0);
+
+				using (var file = new StreamWriter(filename))
+					file.WriteLine(yaml.WriteToString());
+			}
+
 			Console.WriteLine("Processing Weapons:");
 			foreach (var filename in Game.modData.Manifest.Weapons)
 			{

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeSequences.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeSequences.cs
@@ -1,0 +1,42 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UtilityCommands
+{
+	static class UpgradeSequences
+	{
+		internal static void UpgradeActorSequences(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		{
+			foreach (var node in nodes)
+			{
+				// Tick is now measured in real game ticks not miliseconds
+				if (engineVersion < 20141207)
+				{
+					if (node.Key == "Tick")
+					{
+						var value = int.Parse(node.Value.Value);
+						var tick = value / 40;
+						if (tick <= 0)
+							tick = 1;
+
+						node.Value.Value = tick.ToString();
+					}
+				}
+
+				UpgradeActorSequences(engineVersion, ref node.Value.Nodes, node, depth + 1);
+			}
+		}
+	}
+}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -652,6 +652,7 @@
 		DestroyedSound: xplobig4.aud
 	BodyOrientation:
 	ScriptTriggers:
+
 ^Crate:
 	Tooltip:
 		Name: Crate

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -70,3 +70,4 @@ LST:
 		MaxWeight: 5
 		PipCount: 5
 		PassengerFacing: 0
+

--- a/mods/cnc/sequences/aircraft.yaml
+++ b/mods/cnc/sequences/aircraft.yaml
@@ -66,3 +66,4 @@ a10:
 		Facings: 8
 	icon: a10icnh
 		Start: 0
+

--- a/mods/cnc/sequences/campaign.yaml
+++ b/mods/cnc/sequences/campaign.yaml
@@ -25,7 +25,7 @@ boat:
 		Start: 6
 		Length: 6
 		Offset: 1,2
-		Tick: 120
+		Tick: 3
 	right:
 		Start: 96
 		Facings: 32
@@ -39,6 +39,7 @@ boat:
 		Start: 0
 		Length: 6
 		Offset: -1,2
-		Tick: 120
+		Tick: 3
 	icon: boaticnh
 		Start: 0
+

--- a/mods/cnc/sequences/civilian.yaml
+++ b/mods/cnc/sequences/civilian.yaml
@@ -22,35 +22,36 @@ c1:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c2:
 	stand:
 		Start: 0
@@ -75,35 +76,36 @@ c2:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c3:
 	stand:
 		Start: 0
@@ -128,35 +130,36 @@ c3:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c4:
 	stand:
 		Start: 0
@@ -181,35 +184,36 @@ c4:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c5:
 	stand:
 		Start: 0
@@ -234,35 +238,36 @@ c5:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c6:
 	stand:
 		Start: 0
@@ -287,35 +292,36 @@ c6:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c7:
 	stand:
 		Start: 0
@@ -340,35 +346,36 @@ c7:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c8:
 	stand:
 		Start: 0
@@ -393,35 +400,36 @@ c8:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c9:
 	stand:
 		Start: 0
@@ -446,35 +454,36 @@ c9:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+
 c10:
 	stand:
 		Start: 0
@@ -499,32 +508,33 @@ c10:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 329
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 337
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4:
 		Start: 345
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 357
 		Length: 18
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 182
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
+

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -60,7 +60,7 @@ tc04:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc05:
 	idle:
@@ -70,7 +70,7 @@ tc05:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc03:
 	idle:
@@ -80,7 +80,7 @@ tc03:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc02:
 	idle:
@@ -90,7 +90,7 @@ tc02:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc01:
 	idle:
@@ -100,7 +100,7 @@ tc01:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t18:
 	idle:
@@ -110,7 +110,7 @@ t18:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t17:
 	idle:
@@ -120,7 +120,7 @@ t17:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t16:
 	idle:
@@ -130,7 +130,7 @@ t16:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t15:
 	idle:
@@ -140,7 +140,7 @@ t15:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t14:
 	idle:
@@ -150,7 +150,7 @@ t14:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t13:
 	idle:
@@ -160,7 +160,7 @@ t13:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t12:
 	idle:
@@ -170,7 +170,7 @@ t12:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t11:
 	idle:
@@ -180,7 +180,7 @@ t11:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t10:
 	idle:
@@ -190,7 +190,7 @@ t10:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t09:
 	idle:
@@ -200,7 +200,7 @@ t09:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t08:
 	idle:
@@ -210,7 +210,7 @@ t08:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t07:
 	idle:
@@ -220,7 +220,7 @@ t07:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t06:
 	idle:
@@ -230,7 +230,7 @@ t06:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t05:
 	idle:
@@ -240,7 +240,7 @@ t05:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t04:
 	idle:
@@ -250,7 +250,7 @@ t04:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t03:
 	idle:
@@ -260,7 +260,7 @@ t03:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t02:
 	idle:
@@ -270,7 +270,7 @@ t02:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t01:
 	idle:
@@ -280,7 +280,7 @@ t01:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 v01:
 	idle:
@@ -487,11 +487,11 @@ v19:
 	idle:
 		Start: 0
 		Length: 14
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 14
 		Length: 14
-		Tick: 120
+		Tick: 3
 
 v19.husk:
 	idle: v19
@@ -509,11 +509,11 @@ v20:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v20.husk:
 	idle: v20
@@ -523,11 +523,11 @@ v21:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v21.husk:
 	idle: v21
@@ -537,11 +537,11 @@ v22:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v22.husk:
 	idle: v22
@@ -551,11 +551,11 @@ v23:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v23.husk:
 	idle: v23
@@ -710,3 +710,4 @@ arco:
 arco.husk:
 	idle: arco
 		Start: 1
+

--- a/mods/cnc/sequences/funpark.yaml
+++ b/mods/cnc/sequences/funpark.yaml
@@ -81,3 +81,4 @@ rapt:
 		Length: 40
 	icon: rapticnh
 		Start: 0
+

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -87,7 +87,7 @@ e1:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 8
@@ -100,8 +100,8 @@ e1:
 		Start: 144
 		Length: 4
 		Facings: 8
-		Tick: 100
 	# stand -> prone transition
+		Tick: 2
 	liedown:
 		Start: 128
 		Length: 2
@@ -118,59 +118,59 @@ e1:
 	idle1:
 		Start: 257
 		Length: 15
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 272
 		Length: 16
-		Tick: 120
+		Tick: 3
 	idle3:
 		Start: 289
 		Length: 22
-		Tick: 120
+		Tick: 3
 	cheer:
 		Start: 460
 		Length: 3
 		Facings: 8
-		Tick: 120
 	# Dancing
+		Tick: 3
 	idle4:
 		Start: 517
 		Length: 9
-		Tick: 120
 	# Shot
+		Tick: 3
 	die1:
 		Start: 381
 		Length: 9
-		Tick: 80
 	# Explode
+		Tick: 2
 	die2:
 		Start: 390
 		Length: 8
-		Tick: 80
 	# Fly and explode in air
+		Tick: 2
 	die3:
 		Start: 398
 		Length: 8
-		Tick: 80
 	# Fly through air squish on ground
+		Tick: 2
 	die4:
 		Start: 406
 		Length: 12
-		Tick: 80
 	# Burn
+		Tick: 2
 	die5:
 		Start: 418
 		Length: 18
-		Tick: 80
 	# Tib
+		Tick: 2
 	die6:
 		Start: 366
 		Length: 11
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	icon: e1icnh
 		Start: 0
@@ -186,7 +186,7 @@ e2:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 20
@@ -209,7 +209,7 @@ e2:
 		Start: 240
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	prone-shoot:
 		Start: 288
 		Length: 12
@@ -217,50 +217,50 @@ e2:
 	idle1:
 		Start: 384
 		Length: 16
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 400
 		Length: 13
-		Tick: 120
+		Tick: 3
 	cheer:
 		Start: 588
 		Length: 3
 		Facings: 8
-		Tick: 120
 	# Shot
+		Tick: 3
 	die1:
 		Start: 509
 		Length: 9
-		Tick: 80
 	# Explode
+		Tick: 2
 	die2:
 		Start: 518
 		Length: 8
-		Tick: 80
 	# Fly and explode in air
+		Tick: 2
 	die3:
 		Start: 526
 		Length: 8
-		Tick: 80
 	# Fly through air squish on ground
+		Tick: 2
 	die4:
 		Start: 534
 		Length: 12
-		Tick: 80
 	# Burn
+		Tick: 2
 	die5:
 		Start: 546
 		Length: 18
-		Tick: 80
 	# Tib
+		Tick: 2
 	die6:
 		Start: 494
 		Length: 11
-		Tick: 80
+		Tick: 2
 	die-crushed: e2rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	icon: e2icnh
 		Start: 0
@@ -276,7 +276,7 @@ e3:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 8
@@ -299,7 +299,7 @@ e3:
 		Start: 144
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	prone-shoot:
 		Start: 192
 		Length: 10
@@ -307,50 +307,50 @@ e3:
 	idle1:
 		Start: 274
 		Length: 12
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 289
 		Length: 14
-		Tick: 120
+		Tick: 3
 	cheer:
 		Start: 476
 		Length: 3
 		Facings: 8
-		Tick: 120	
 	# Shot
+		Tick: 3
 	die1:
 		Start: 397
 		Length: 9
-		Tick: 80
 	# Explode
+		Tick: 2
 	die2:
 		Start: 406
 		Length: 8
-		Tick: 80
 	# Fly and explode in air
+		Tick: 2
 	die3:
 		Start: 414
 		Length: 8
-		Tick: 80
 	# Fly through air squish on ground
+		Tick: 2
 	die4:
 		Start: 422
 		Length: 12
-		Tick: 80
 	# Burn
+		Tick: 2
 	die5:
 		Start: 434
 		Length: 18
-		Tick: 80
 	# Tib
+		Tick: 2
 	die6:
 		Start: 382
 		Length: 11
-		Tick: 80
+		Tick: 2
 	die-crushed: e3rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	icon: e3icnh
 		Start: 0
@@ -366,7 +366,7 @@ e4:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 16
@@ -389,7 +389,7 @@ e4:
 		Start: 208
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	prone-shoot:
 		Start: 256
 		Length: 16
@@ -397,50 +397,50 @@ e4:
 	idle1:
 		Start: 384
 		Length: 16
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 400
 		Length: 16
-		Tick: 120
+		Tick: 3
 	cheer:
 		Start: 588
 		Length: 3
 		Facings: 8
-		Tick: 120	
 	# Shot
+		Tick: 3
 	die1:
 		Start: 509
 		Length: 9
-		Tick: 80
 	# Explode
+		Tick: 2
 	die2:
 		Start: 518
 		Length: 8
-		Tick: 80
 	# Fly and explode in air
+		Tick: 2
 	die3:
 		Start: 526
 		Length: 8
-		Tick: 80
 	# Fly through air squish on ground
+		Tick: 2
 	die4:
 		Start: 534
 		Length: 12
-		Tick: 80
 	# Burn
+		Tick: 2
 	die5:
 		Start: 546
 		Length: 18
-		Tick: 80
 	# Tib
+		Tick: 2
 	die6:
 		Start: 494
 		Length: 10
-		Tick: 80
+		Tick: 2
 	die-crushed: e4rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	muzzle0: flame-n
 		Start: 0
@@ -488,7 +488,7 @@ e5:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 16
@@ -511,7 +511,7 @@ e5:
 		Start: 208
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	prone-shoot:
 		Start: 256
 		Length: 16
@@ -519,50 +519,50 @@ e5:
 	idle1:
 		Start: 384
 		Length: 16
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 400
 		Length: 16
-		Tick: 120
+		Tick: 3
 	cheer:
 		Start: 588
 		Length: 3
 		Facings: 8
-		Tick: 120	
 	# Shot
+		Tick: 3
 	die1:
 		Start: 509
 		Length: 9
-		Tick: 80
 	# Explode
+		Tick: 2
 	die2:
 		Start: 518
 		Length: 8
-		Tick: 80
 	# Fly and explode in air
+		Tick: 2
 	die3:
 		Start: 526
 		Length: 8
-		Tick: 80
 	# Fly through air squish on ground
+		Tick: 2
 	die4:
 		Start: 534
 		Length: 12
-		Tick: 80
 	# Burn
+		Tick: 2
 	die5:
 		Start: 546
 		Length: 18
-		Tick: 80
 	# Tib
+		Tick: 2
 	die6:
 		Start: 494
 		Length: 10
-		Tick: 80
+		Tick: 2
 	die-crushed: e4rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	muzzle0: chem-n
 		Start: 0
@@ -610,8 +610,8 @@ e6:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
 	# stand -> prone transition
+		Tick: 2
 	liedown:
 		Start: 66
 		Length: 2
@@ -629,54 +629,54 @@ e6:
 		Start: 82
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	idle1:
 		Start: 114
 		Length: 6
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 200
 		Length: 6
-		Tick: 120
+		Tick: 3
 	cheer:
 		Start: 200
 		Length: 3
 		Facings: 8
-		Tick: 120
 	# Shot
+		Tick: 3
 	die1:
 		Start: 146
 		Length: 8
-		Tick: 80
 	# Explode
+		Tick: 2
 	die2:
 		Start: 154
 		Length: 8
-		Tick: 80
 	# Fly and explode in air
+		Tick: 2
 	die3:
 		Start: 162
 		Length: 8
-		Tick: 80
 	# Fly through air squish on ground
+		Tick: 2
 	die4:
 		Start: 170
 		Length: 12
-		Tick: 80
 	# Burn
+		Tick: 2
 	die5:
 		Start: 182
 		Length: 18
-		Tick: 80
 	# Tib
+		Tick: 2
 	die6:
 		Start: 130
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	icon: e6icnh
 		Start: 0
@@ -692,7 +692,7 @@ rmbo:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 4
@@ -715,7 +715,7 @@ rmbo:
 		Start: 112
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	prone-shoot:
 		Start: 160
 		Length: 4
@@ -723,54 +723,55 @@ rmbo:
 	idle1:
 		Start: 192
 		Length: 16
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 208
 		Length: 16
-		Tick: 120
+		Tick: 3
 	idle3:
 		Start: 224
 		Length: 15
-		Tick: 120
+		Tick: 3
 	cheer:
 		Start: 396
 		Length: 3
 		Facings: 8
-		Tick: 120
 	# Shot
+		Tick: 3
 	die1:
 		Start: 318
 		Length: 8
-		Tick: 80
 	# Explode
+		Tick: 2
 	die2:
 		Start: 326
 		Length: 8
-		Tick: 80
 	# Fly and explode in air
+		Tick: 2
 	die3:
 		Start: 334
 		Length: 8
-		Tick: 80
 	# Fly through air squish on ground
+		Tick: 2
 	die4:
 		Start: 342
 		Length: 12
-		Tick: 80
 	# Burn
+		Tick: 2
 	die5:
 		Start: 354
 		Length: 18
-		Tick: 80
 	# Tib
+		Tick: 2
 	die6:
 		Start: 308
 		Length: 4
-		Tick: 80
+		Tick: 2
 	die-crushed: e1rot
 		Start: 16
 		Length: 4
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	icon: rmboicnh
 		Start: 0
+

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -37,7 +37,7 @@ smoke_m:
 		ZOffset: 512
 
 laserfire:
-	idle:veh-hit3
+	idle: veh-hit3
 		Start: 0
 		Length: *
 
@@ -116,11 +116,11 @@ rank:
 		Length: *
 
 rallypoint:
-	flag:flagfly
+	flag: flagfly
 		Start: 0
 		Length: *
 		Offset: 10,-5
-	circles:fpls
+	circles: fpls
 		Start: 0
 		Length: *
 
@@ -152,7 +152,7 @@ allyrepair:
 	repair:
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 
 crate:
 	idle:
@@ -225,7 +225,7 @@ crate-effects:
 	levelup: levelup
 		Start: 0
 		Length: *
-		Tick: 200
+		Tick: 5
 	firepowerup: firepowercrate
 		Start: 0
 		Length: *
@@ -280,6 +280,7 @@ clock:
 	idle: hclock
 		Start: 0
 		Length: *
+
 pips:
 	pip-empty:
 		Start: 0
@@ -333,7 +334,7 @@ poweroff:
 	offline:
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 
 icon:
 	airstrike: bombicnh
@@ -347,7 +348,7 @@ moveflsh:
 	idle:
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 
 resources:
 	ti1: ti1
@@ -443,3 +444,4 @@ craters:
 		Length: *
 	cr6: cr6
 		Length: *
+

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -2,25 +2,25 @@ fact:
 	build:
 		Start: 4
 		Length: 20
-		Tick: 100
+		Tick: 2
 	idle:
 		Start: 0
 		Length: 4
-		Tick: 100
+		Tick: 2
 	damaged-idle:
 		Start: 24
 		Length: 4
-		Tick: 100
+		Tick: 2
 	damaged-build:
 		Start: 28
 		Length: 20
-		Tick: 100
+		Tick: 2
 	dead:
 		Start: 48
 	make: factmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib2
 		Start: 0
 		Length: *
@@ -31,18 +31,18 @@ nuke:
 	idle:
 		Start: 0
 		Length: 4
-		Tick: 1000
+		Tick: 25
 	damaged-idle:
 		Start: 4
 		Length: 4
-		Tick: 1000
+		Tick: 25
 	dead:
 		Start: 8
-		Tick: 1000
+		Tick: 25
 	make: nukemake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib3
 		Start: 0
 		Length: *
@@ -53,17 +53,17 @@ proc:
 	idle:
 		Start: 0
 		Length: 6
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 30
 		Length: 6
-		Tick: 120
+		Tick: 3
 	dead:
 		Start: 60
 	make: procmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	resources: proctwr
 		Start: 0
 		Length: 6
@@ -93,7 +93,7 @@ silo:
 	make: silomake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 		Offset: 0,-1
 	bib: mbSILO
 		Start: 0
@@ -112,7 +112,7 @@ hand:
 	make: handmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib3
 		Start: 0
 		Length: *
@@ -123,18 +123,18 @@ pyle:
 	idle:
 		Start: 0
 		Length: 10
-		Tick: 100		
+		Tick: 2
 	damaged-idle:
 		Start: 10
 		Length: 10
-		Tick: 100		
+		Tick: 2
 	dead:
 		Start: 20
-		Tick: 100
+		Tick: 2
 	make: pylemake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib3
 		Start: 0
 		Length: *
@@ -161,7 +161,7 @@ weap:
 	make: weapmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib2
 		Start: 0
 		Length: *
@@ -171,21 +171,21 @@ weap:
 afld:
 	idle:
 		Start: 0
-		Tick: 120
+		Tick: 3
 		ZOffset: -1023
 	active:
 		Start: 0
 		Length: 16
-		Tick: 120
+		Tick: 3
 		ZOffset: -1023
 	damaged-idle:
 		Start: 16
-		Tick: 120
+		Tick: 3
 		ZOffset: -1023
 	damaged-active:
 		Start: 16
 		Length: 16
-		Tick: 120
+		Tick: 3
 		ZOffset: -1023
 	dead:
 		Start: 32
@@ -193,7 +193,7 @@ afld:
 	make: afldmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib1
 		Start: 0
 		Length: *
@@ -204,17 +204,17 @@ hq:
 	idle:
 		Start: 0
 		Length: 16
-		Tick: 100
+		Tick: 2
 	damaged-idle:
 		Start: 16
 		Length: 16
-		Tick: 100
+		Tick: 2
 	dead:
 		Start: 32
 	make: hqmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib3
 		Start: 0
 		Length: *
@@ -225,17 +225,17 @@ nuk2:
 	idle:
 		Start: 0
 		Length: 4
-		Tick: 1000
+		Tick: 25
 	damaged-idle:
 		Start: 4
 		Length: 4
-		Tick: 1000
+		Tick: 25
 	dead:
 		Start: 8
 	make: nuk2make
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib3
 		Start: 0
 		Length: *
@@ -252,12 +252,12 @@ hpad:
 	active:
 		Start: 1
 		Length: 6
-		Tick: 100
+		Tick: 2
 		ZOffset: -1023
 	damaged-active:
 		Start: 8
 		Length: 6
-		Tick: 100		
+		Tick: 2
 		ZOffset: -1023
 	dead:
 		Start: 14
@@ -265,7 +265,7 @@ hpad:
 	make: hpadmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: hpadicnh
 		Start: 0
 
@@ -290,7 +290,7 @@ fix:
 	make: fixmake
 		Start: 0
 		Length: 14
-		Tick: 60
+		Tick: 1
 	bib: mbFIX
 		Start: 0
 		Length: *
@@ -302,17 +302,17 @@ eye:
 	idle:
 		Start: 0
 		Length: 16
-		Tick: 100
+		Tick: 2
 	damaged-idle:
 		Start: 16
 		Length: 16
-		Tick: 100
+		Tick: 2
 	dead:
 		Start: 32
 	make: eyemake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	bib: bib3
 		Start: 0
 		Length: *
@@ -335,7 +335,7 @@ tmpl:
 	make: tmplmake
 		Start: 0
 		Length: *
-		Tick: 60
+		Tick: 1
 	bib: bib2
 		Start: 0
 		Length: *
@@ -350,17 +350,17 @@ obli:
 	active:
 		Start: 0
 		Length: 4
-		Tick: 680
+		Tick: 17
 	damaged-active:
 		Start: 4
 		Length: 4
-		Tick: 680
+		Tick: 17
 	dead:
 		Start: 8
 	make: oblimake
 		Start: 0
 		Length: 13
-		Tick: 80
+		Tick: 2
 	bib: mbOBLI
 		Start: 0
 		Length: *
@@ -430,7 +430,7 @@ gun:
 	make: gunmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	muzzle: gunfire2
 		Start: 0
 		Length: *
@@ -443,37 +443,37 @@ gun:
 
 sam:
 	closed-idle:
-		Start:0
+		Start: 0
 	opening:
 		Start: 1
 		Length: 16
-		Tick: 30
+		Tick: 1
 	idle:
 		Start: 17
 		Facings: 32
 	closing:
 		Start: 50
 		Length: 14
-		Tick: 30
+		Tick: 1
 	damaged-closed-idle:
-		Start:64
+		Start: 64
 	damaged-opening:
 		Start: 65
 		Length: 16
-		Tick: 30
+		Tick: 1
 	damaged-idle:
 		Start: 81
 		Facings: 32
 	damaged-closing:
 		Start: 114
 		Length: 14
-		Tick: 30
+		Tick: 1
 	dead:
 		Start: 128
 	make: sammake
 		Start: 0
 		Length: 20
-		Tick: 30
+		Tick: 1
 	muzzle: samfire
 		Start: 0
 		Length: 18
@@ -491,7 +491,7 @@ gtwr:
 	make: gtwrmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	muzzle: minigun
 		Start: 0
 		Length: 6
@@ -516,7 +516,7 @@ atwr:
 	make: atwrmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 		Offset: 0,-1
 	muzzle: gunfire2
 		Start: 0
@@ -533,7 +533,7 @@ hosp:
 	idle:
 		Start: 0
 		Length: 4
-		Tick: 100
+		Tick: 2
 		Offset: 0,-2
 	damaged-idle:
 		Start: 4
@@ -542,7 +542,7 @@ hosp:
 	make: hospmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 		Offset: 0,-2
 	bib: mbHOSP
 		Start: 0
@@ -565,7 +565,7 @@ bio:
 	make: biomake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 
 bio.husk:
 	idle: bio
@@ -581,7 +581,7 @@ miss:
 	make: missmake
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 		Offset: 0,-1
 	bib: mbMISS
 		Start: 0
@@ -597,3 +597,4 @@ miss.husk:
 		Start: 0
 		Length: *
 		Offset: 0,1
+

--- a/mods/cnc/sequences/vehicles.yaml
+++ b/mods/cnc/sequences/vehicles.yaml
@@ -19,7 +19,7 @@ harv:
 		Start: 32
 		Length: 4
 		Facings: 8
-		Tick: 60
+		Tick: 1
 	dock: harvdump
 		Start: 0
 		Length: 7
@@ -330,3 +330,4 @@ apc.destroyed:
 		Start: 0
 		Facings: 32
 		ZOffset: -512
+

--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -9,13 +9,12 @@ carryall:
 		Start: 4029
 		Offset: -30,-24
 
-
 orni:
 	idle: DATA
 		Start: 1955
 		Facings: -32
 		Length: 3
-		Tick: 120
+		Tick: 3
 		Transpose: true
 	icon: DATA
 		Start: 4031
@@ -25,3 +24,4 @@ frigate:
 	idle: DATA
 		Start: 2517
 		Facings: 1
+

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -7,7 +7,7 @@ rifle:
 		Start: 214
 		Length: 6
 		Facings: -8
-		Tick: 110
+		Tick: 2
 		Transpose: true
 	shoot: DATA
 		Start: 254
@@ -23,12 +23,12 @@ rifle:
 		Length: 3
 		Facings: -8
 		Transpose: true
-		Tick: 110
+		Tick: 2
 	standup-0: DATA
 		Start: 302
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	prone-shoot: DATA
 		Start: 334
 		Length: 6
@@ -37,23 +37,23 @@ rifle:
 	die1: DATA
 		Frames: 382, 389, 396, 403, 410, 417, 424, 431, 438, 439, 440, 441
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die2: DATA
 		Frames: 383, 390, 397, 404, 411, 418, 425, 432
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3: DATA
 		Frames: 384, 391, 398, 405, 412, 419, 426, 433
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4: DATA
 		Frames: 385, 392, 399, 406, 413, 420, 427, 434
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die-crushed: DATA
 		Frames: 386, 393, 400, 407, 414, 421, 428, 435
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	icon: DATA
 		Start: 4011
@@ -68,7 +68,7 @@ bazooka:
 		Start: 466
 		Length: 6
 		Facings: -8
-		Tick: 120
+		Tick: 3
 		Transpose: true
 	shoot: DATA
 		Start: 506
@@ -85,7 +85,7 @@ bazooka:
 		Length: 3
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	standup-0: DATA
 		Start: 554
 		Length: 1
@@ -99,23 +99,23 @@ bazooka:
 	die1: DATA
 		Frames: 634, 641, 648, 655, 662, 669, 676, 683, 690, 691, 692, 693
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die2: DATA
 		Frames: 635, 642, 649, 656, 663, 670, 677, 684
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3: DATA
 		Frames: 636, 643, 650, 657, 664, 671, 678, 685
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4: DATA
 		Frames: 637, 644, 651, 658, 665, 672, 679, 686
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die-crushed: DATA
 		Frames: 638, 645, 652, 659, 666, 673, 680, 687
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	icon: DATA
 		Start: 4012
@@ -131,27 +131,27 @@ engineer:
 		Length: 6
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	die1: DATA
 		Frames: 1342, 1349, 1356, 1363, 1370, 1377, 1384, 1391, 1398, 1399, 1400, 1401
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die2: DATA
 		Frames: 1343, 1350, 1357, 1364, 1371, 1378, 1385, 1392
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3: DATA
 		Frames: 1344, 1351, 1358, 1365, 1372, 1379, 1386, 1393
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4: DATA
 		Frames: 1345, 1352, 1359, 1366, 1373, 1380, 1387, 1394
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die-crushed: DATA
 		Frames: 1346, 1353, 1360, 1367, 1374, 1381, 1388, 1395
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	icon: DATA
 		Start: 4013
@@ -167,31 +167,31 @@ medic: # actually thumper
 		Length: 6
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	heal: DATA
 		Start: 1458
 		Length: 5
-		Tick: 480
+		Tick: 12
 	die1: DATA
 		Frames: 1543, 1550, 1557, 1564, 1571, 1578, 1585, 1592, 1599, 1600, 1601, 1602
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die2: DATA
 		Frames: 1544, 1551, 1558, 1565, 1572, 1579, 1586, 1593
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3: DATA
 		Frames: 1546, 1552, 1559, 1566, 1573, 1580, 1587, 1594
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4: DATA
 		Frames: 1547, 1553, 1560, 1567, 1574, 1581, 1588, 1595
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die-crushed: DATA
 		Frames: 1548, 1554, 1561, 1568, 1575, 1582, 1589, 1596
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	icon: DATA
 		Start: 4014
@@ -201,14 +201,14 @@ thumping:
 	idle: DATA
 		Start: 1458
 		Length: 5
-		Tick: 150
+		Tick: 3
 	make: DATA
 		Start: 1458
 		Length: 5
 	damaged-idle: DATA
 		Start: 1458
 		Length: 5
-		Tick: 150
+		Tick: 3
 	icon: DATA
 		Frames: 4014
 		Offset: -30,-24
@@ -223,7 +223,7 @@ fremen:
 		Length: 6
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	shoot: DATA
 		Start: 742
 		Length: 6
@@ -239,13 +239,13 @@ fremen:
 		Length: 3
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	standup-0: DATA
 		Start: 790
 		Length: 1
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	prone-shoot: DATA
 		Start: 822
 		Length: 6
@@ -254,23 +254,23 @@ fremen:
 	die1: DATA
 		Frames: 870, 877, 884, 891, 898, 905, 912, 919, 926, 933, 940, 947
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die2: DATA
 		Frames: 871, 878, 885, 892, 899, 906, 913, 920
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3: DATA
 		Frames: 872, 879, 886, 893, 900, 907, 914, 921
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4: DATA
 		Frames: 873, 880, 887, 894, 901, 908, 915, 922
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die-crushed: DATA
 		Frames: 874, 881, 888, 895, 902, 909, 916, 923
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	icon: DATA
 		Start: 4032
@@ -286,7 +286,7 @@ saboteur:
 		Length: 6
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	prone-stand: DATA
 		Start: 2253
 		Length: 1
@@ -297,33 +297,33 @@ saboteur:
 		Length: 3
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	standup-0: DATA
 		Start: 2245
 		Length: 1
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	die1: DATA
 		Frames: 2325, 2332, 2339, 2346, 2353, 2360, 2367, 2374, 2381, 2383, 2385, 2387
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die2: DATA
 		Frames: 2326, 2333, 2340, 2347, 2354, 2361, 2368, 2375, 2382, 2384, 2386, 2388
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die3: DATA
 		Frames: 2327, 2334, 2341, 2348, 2355, 2362, 2369, 2376
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4: DATA
 		Frames: 2328, 2335, 2342, 2349, 2356, 2363, 2370, 2377
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die-crushed: DATA
 		Frames: 2329, 2336, 2343, 2350, 2357, 2364, 2371, 2378
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	icon: DATA
 		Start: 4034
@@ -339,7 +339,7 @@ sardaukar:
 		Length: 6
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	shoot: DATA
 		Start: 978
 		Length: 6
@@ -355,13 +355,13 @@ sardaukar:
 		Length: 3
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	standup-0: DATA
 		Start: 1026
 		Length: 1
 		Facings: -8
 		Transpose: true
-		Tick: 120
+		Tick: 3
 	prone-shoot: DATA
 		Start: 1058
 		Length: 6
@@ -370,23 +370,23 @@ sardaukar:
 	die1: DATA
 		Frames: 1106, 1113, 1120, 1127, 1134, 1141, 1148, 1155, 1162, 1163, 1164, 1165
 		Length: 12
-		Tick: 80
+		Tick: 2
 	die2: DATA
 		Frames: 1107, 1114, 1121, 1128, 1135, 1142, 1149, 1156
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die3: DATA
 		Frames: 1108, 1115, 1122, 1129, 1136, 1143, 1150, 1157
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die4: DATA
 		Frames: 1109, 1116, 1123, 1130, 1137, 1144, 1151, 1158
 		Length: 8
-		Tick: 80
+		Tick: 2
 	die-crushed: DATA
 		Frames: 1110, 1117, 1124, 1131, 1138, 1145, 1152, 1159
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	icon: DATA
 		Start: 4015
@@ -403,12 +403,12 @@ grenadier: # 2502 - 2749 in 1.06 DATA.R8
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	shoot:
 		Start: 56
 		Length: 6
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 176
 		Length: 19
@@ -424,7 +424,7 @@ grenadier: # 2502 - 2749 in 1.06 DATA.R8
 	die-crushed:
 		Start: 195
 		Length: 8
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	prone-stand:
 		Start: 104
@@ -434,11 +434,11 @@ grenadier: # 2502 - 2749 in 1.06 DATA.R8
 		Start: 104
 		Length: 4
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	prone-shoot:
 		Start: 136
 		Length: 5
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	icon: grenadiericon
 		Start: 0 # 4281 in 1.06 DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -5,7 +5,7 @@ explosion:
 	piffs: DATA
 		Start: 3429
 		Length: 4
-		Tick: 80
+		Tick: 2
 		BlendMode: Additive
 	small_explosion: DATA
 		Start: 3403
@@ -18,17 +18,17 @@ explosion:
 	tiny_explosion: DATA
 		Start: 3386
 		Length: 4
-		Tick: 80
+		Tick: 2
 		BlendMode: Additive
 	nuke: DATA
 		Start: 3965
 		Length: 14
-		Tick: 60
+		Tick: 1
 		BlendMode: Additive
 	mini_explosion: DATA
 		Start: 3403
 		Length: 15
-		Tick: 60
+		Tick: 1
 		BlendMode: Additive
 	self_destruct: DATA
 		Start: 3433
@@ -49,7 +49,7 @@ explosion:
 	small_artillery: DATA
 		Start: 3390
 		Length: 12
-		Tick: 60
+		Tick: 1
 		BlendMode: Additive
 	small_napalm: DATA
 		Start: 3421
@@ -59,22 +59,22 @@ explosion:
 		Start: 3687
 		Length: 6
 		BlendMode: Additive
-		Tick: 120
+		Tick: 3
 	deviator: DATA
 		Start: 3512
 		Length: 23
 		BlendMode: Additive
-		Tick: 60
+		Tick: 1
 	corpse: DATA
 		Start: 430
 		Length: 12
-		Tick: 1600
+		Tick: 40
 
 laserfire:
 	idle: DATA
 		Start: 3386
 		Length: 4
-		Tick: 80
+		Tick: 2
 		BlendMode: Additive
 
 pips:
@@ -101,7 +101,7 @@ poweroff:
 	offline:
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 
 rank:
 	rank:
@@ -126,11 +126,11 @@ overlay:
 		Offset: -16,-16
 
 rallypoint:
-	flag:flagfly
+	flag: flagfly
 		Start: 0
 		Length: *
 		Offset: 11,-5
-	circles:fpls
+	circles: fpls
 		Start: 0
 		Length: *
 
@@ -171,7 +171,7 @@ crate-effects:
 	levelup: levelup
 		Start: 0
 		Length: *
-		Tick: 200
+		Tick: 5
 	cloak: DATA
 		Start: 3911
 		Lenght: 36
@@ -180,7 +180,7 @@ allyrepair:
 	repair: DATA
 		Frames: 3, 39
 		Length: 2
-		Tick: 300
+		Tick: 7
 		Offset: -11,-10
 
 missile:
@@ -324,7 +324,7 @@ moveflsh:
 	idle: DATA
 		Start: 3621
 		Length: 5
-		Tick: 80
+		Tick: 2
 		BlendMode: Multiply
 
 resources:
@@ -376,3 +376,4 @@ sandcraters:
 		Start: 162
 		Length: 16
 		Offset: -16,-16
+

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -1702,13 +1702,3 @@ conyardc: # TODO: unused
 		Start: 4049
 		Offset: -30,-24
 
-plates: # TODO: unused
-	idle: DATA
-		Start: 3008
-		Length: 6
-	4-plates-icon: DATA
-		Start: 4050
-		Offset: -30,-24
-	6-plates-icon: DATA
-		Start: 4053
-		Offset: -30,-24

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -1,11 +1,11 @@
 concretea:
 	icon: DATA
-		Start:4050
+		Start: 4050
 		Offset: -30,-24
 
 concreteb:
 	icon: DATA
-		Start:4053
+		Start: 4053
 		Offset: -30,-24
 
 walla:
@@ -179,7 +179,7 @@ conyarda:
 		Start: 4139
 		Length: 12
 		Offset: -48,64
-		Tick: 170
+		Tick: 4
 	damaged-idle: DATA
 		Start: 2560
 		Offset: -48,64
@@ -187,12 +187,12 @@ conyarda:
 		Start: 4436
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	damaged-crane-overlay: DATA
 		Start: 4436
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -214,7 +214,7 @@ repaira:
 		Start: 4380
 		Length: 10
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	idle: DATA
 		Start: 2571
 		Offset: -48,48
@@ -232,7 +232,7 @@ repaira:
 	damaged-active: DATA
 		Start: 4746
 		Length: 14
-		Tick: 60
+		Tick: 1
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
@@ -249,7 +249,7 @@ repairh:
 		Start: 4380
 		Length: 10
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	idle: DATA
 		Start: 2731
 		Offset: -48,48
@@ -267,7 +267,7 @@ repairh:
 	damaged-active: DATA
 		Start: 4746
 		Length: 14
-		Tick: 60
+		Tick: 1
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
@@ -284,7 +284,7 @@ repairo:
 		Start: 4380
 		Length: 10
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	idle: DATA
 		Start: 2891
 		Offset: -48,48
@@ -302,7 +302,7 @@ repairo:
 	damaged-active: DATA
 		Start: 4746
 		Length: 14
-		Tick: 60
+		Tick: 1
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
@@ -325,14 +325,14 @@ starporta:
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	damaged-active: DATA
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	make: DATA
 		Start: 4347
 		Length: 11
@@ -341,7 +341,7 @@ starporta:
 		Start: 4358
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -366,7 +366,7 @@ pwra:
 		Start: 4163
 		Length: 12
 		Offset: -32,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2524
 		Offset: -32,64
@@ -374,12 +374,12 @@ pwra:
 		Start: 4492
 		Length: 10
 		Offset: -32,64
-		Tick: 200
+		Tick: 5
 	damaged-idle-zaps: DATA
 		Start: 4497
 		Length: 5
 		Offset: -32,64
-		Tick: 200
+		Tick: 5
 	bib: BLOXBASE
 		Frames: 617, 618, 637, 638
 		Length: 4
@@ -404,7 +404,7 @@ barra:
 		Start: 4184
 		Length: 9
 		Offset: -32,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2526
 		Offset: -32,64
@@ -432,7 +432,7 @@ radara:
 		Start: 4263
 		Length: 10
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2522
 		Offset: -48,80
@@ -465,7 +465,7 @@ refa:
 		Start: 4241
 		Length: 12
 		Offset: -48,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2561
 		Offset: -48,64
@@ -490,7 +490,7 @@ refa:
 		Start: 3885
 		Length: 14
 		Offset: 10,-16
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 
 siloa:
@@ -510,7 +510,7 @@ siloa:
 		Start: 4320
 		Length: 7
 		Offset: -16,16
-		Tick: 200
+		Tick: 5
 	icon: DATA
 		Start: 4084
 		Offset: -30,-24
@@ -527,7 +527,7 @@ hightecha:
 		Start: 4284
 		Length: 10
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2565
 		Offset: -48,80
@@ -535,7 +535,7 @@ hightecha:
 		Start: 4614
 		Length: 30
 		Offset: -48,80
-		Tick: 500
+		Tick: 12
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -561,14 +561,14 @@ researcha:
 		Start: 4401
 		Length: 11
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2670
 		Offset: -48,80
 	idle-lights: DATA
 		Start: 4760
 		Length: 60
-		Tick: 80
+		Tick: 2
 		Offset: -48,80
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -594,14 +594,14 @@ researchh:
 		Start: 4401
 		Length: 11
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2830
 		Offset: -48,80
 	idle-lights: DATA
 		Start: 4760
 		Length: 60
-		Tick: 80
+		Tick: 2
 		Offset: -48,80
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -627,14 +627,14 @@ researcho:
 		Start: 4401
 		Length: 11
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2990
 		Offset: -48,80
 	idle-lights: DATA
 		Start: 4760
 		Length: 60
-		Tick: 80
+		Tick: 2
 		Offset: -48,80
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -660,7 +660,7 @@ palacea:
 		Start: 4424
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2677
 		Offset: -48,48
@@ -689,7 +689,7 @@ lighta:
 		Start: 4303
 		Length: 9
 		Offset: -48,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2673
 		Offset: -48,64
@@ -704,7 +704,7 @@ lighta:
 		Start: 4644
 		Length: 30
 		Offset: -48,64
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -731,7 +731,7 @@ heavya:
 		Start: 4337
 		Length: 9
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2518
 		Offset: -48,80
@@ -747,7 +747,7 @@ heavya:
 		Start: 4674
 		Length: 47
 		Offset: -48,80
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -773,7 +773,7 @@ conyardh:
 		Start: 4139
 		Length: 12
 		Offset: -48,64
-		Tick: 170
+		Tick: 4
 	damaged-idle: DATA
 		Start: 2720
 		Offset: -48,64
@@ -781,12 +781,12 @@ conyardh:
 		Start: 4450
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	damaged-crane-overlay: DATA
 		Start: 4450
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -814,14 +814,14 @@ starporth:
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	damaged-active: DATA
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	make: DATA
 		Start: 4347
 		Length: 11
@@ -830,7 +830,7 @@ starporth:
 		Start: 4358
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -855,7 +855,7 @@ pwrh:
 		Start: 4163
 		Length: 12
 		Offset: -32,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2684
 		Offset: -32,64
@@ -863,12 +863,12 @@ pwrh:
 		Start: 4502
 		Length: 10
 		Offset: -32,64
-		Tick: 200
+		Tick: 5
 	damaged-idle-zaps: DATA
 		Start: 4507
 		Length: 5
 		Offset: -32,64
-		Tick: 200
+		Tick: 5
 	bib: BLOXBASE
 		Frames: 617, 618, 637, 638
 		Length: 4
@@ -893,7 +893,7 @@ barrh:
 		Start: 4221
 		Length: 9
 		Offset: -32,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2686
 		Offset: -32,64
@@ -921,7 +921,7 @@ radarh:
 		Start: 4263
 		Length: 10
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2682
 		Offset: -48,80
@@ -954,7 +954,7 @@ refh:
 		Start: 4241
 		Length: 12
 		Offset: -48,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2721
 		Offset: -48,64
@@ -979,7 +979,7 @@ refh:
 		Start: 3885
 		Length: 14
 		Offset: 10,-16
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 
 siloh:
@@ -999,7 +999,7 @@ siloh:
 		Start: 4320
 		Length: 7
 		Offset: -16,16
-		Tick: 200
+		Tick: 5
 	icon: DATA
 		Start: 4085
 		Offset: -30,-24
@@ -1016,7 +1016,7 @@ hightechh:
 		Start: 4284
 		Length: 10
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2725
 		Offset: -48,80
@@ -1024,7 +1024,7 @@ hightechh:
 		Start: 4614
 		Length: 30
 		Offset: -48,80
-		Tick: 500
+		Tick: 12
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1050,7 +1050,7 @@ palaceh:
 		Start: 4424
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2837
 		Offset: -48,48
@@ -1087,7 +1087,7 @@ lighth:
 		Start: 4303
 		Length: 9
 		Offset: -48,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2833
 		Offset: -48,64
@@ -1102,7 +1102,7 @@ lighth:
 		Start: 4644
 		Length: 30
 		Offset: -48,64
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1129,7 +1129,7 @@ heavyh:
 		Start: 4337
 		Length: 9
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2678
 		Offset: -48,80
@@ -1145,7 +1145,7 @@ heavyh:
 		Start: 4674
 		Length: 47
 		Offset: -48,80
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1171,7 +1171,7 @@ conyardo:
 		Start: 4139
 		Length: 12
 		Offset: -48,64
-		Tick: 170
+		Tick: 4
 	damaged-idle: DATA
 		Start: 2880
 		Offset: -48,64
@@ -1179,12 +1179,12 @@ conyardo:
 		Start: 4464
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	damaged-crane-overlay: DATA
 		Start: 4464
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -1212,14 +1212,14 @@ starporto:
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	damaged-active: DATA
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	make: DATA
 		Start: 4347
 		Length: 11
@@ -1228,7 +1228,7 @@ starporto:
 		Start: 4358
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -1254,7 +1254,7 @@ pwro:
 		Start: 4163
 		Length: 12
 		Offset: -32,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2844
 		Offset: -32,64
@@ -1262,12 +1262,12 @@ pwro:
 		Start: 4512
 		Length: 10
 		Offset: -32,64
-		Tick: 200
+		Tick: 5
 	damaged-idle-zaps: DATA
 		Start: 4517
 		Length: 5
 		Offset: -32,64
-		Tick: 200
+		Tick: 5
 	bib: BLOXBASE
 		Frames: 617, 618, 637, 638
 		Length: 4
@@ -1292,7 +1292,7 @@ barro:
 		Start: 4221
 		Length: 9
 		Offset: -32,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2846
 		Offset: -32,64
@@ -1320,7 +1320,7 @@ radaro:
 		Start: 4263
 		Length: 10
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2842
 		Offset: -48,80
@@ -1353,7 +1353,7 @@ refo:
 		Start: 4241
 		Length: 12
 		Offset: -48,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2881
 		Offset: -48,64
@@ -1378,7 +1378,7 @@ refo:
 		Start: 3885
 		Length: 14
 		Offset: 10,-16
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 
 siloo:
@@ -1398,7 +1398,7 @@ siloo:
 		Start: 4320
 		Length: 7
 		Offset: -16,16
-		Tick: 200
+		Tick: 5
 	icon: DATA
 		Start: 4086
 		Offset: -30,-24
@@ -1415,7 +1415,7 @@ hightecho:
 		Start: 4284
 		Length: 10
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2885
 		Offset: -48,80
@@ -1423,7 +1423,7 @@ hightecho:
 		Start: 4614
 		Length: 30
 		Offset: -48,80
-		Tick: 500
+		Tick: 12
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1449,7 +1449,7 @@ palaceo:
 		Start: 4424
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2997
 		Offset: -48,48
@@ -1478,7 +1478,7 @@ lighto:
 		Start: 4303
 		Length: 9
 		Offset: -48,64
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2993
 		Offset: -48,64
@@ -1493,7 +1493,7 @@ lighto:
 		Start: 4644
 		Length: 30
 		Offset: -48,64
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1520,7 +1520,7 @@ heavyo:
 		Start: 4337
 		Length: 9
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 2838
 		Offset: -48,80
@@ -1536,7 +1536,7 @@ heavyo:
 		Start: 4674
 		Length: 47
 		Offset: -48,80
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1575,7 +1575,7 @@ palacec: # TODO: unused
 		Start: 4424
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 
 starportc: # TODO: unused
 	idle: DATA
@@ -1592,14 +1592,14 @@ starportc: # TODO: unused
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	damaged-active: DATA
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
-		Tick: 200
+		Tick: 5
 	make: DATA
 		Start: 4347
 		Length: 11
@@ -1608,7 +1608,7 @@ starportc: # TODO: unused
 		Start: 4358
 		Length: 11
 		Offset: -48,48
-		Tick: 100
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -1634,7 +1634,7 @@ heavyc: # TODO: unused
 		Start: 4337
 		Length: 9
 		Offset: -48,80
-		Tick: 100
+		Tick: 2
 	damaged-idle: DATA
 		Start: 3001
 		Offset: -48,64
@@ -1650,7 +1650,7 @@ heavyc: # TODO: unused
 		Start: 4674
 		Length: 47
 		Offset: -48,80
-		Tick: 200
+		Tick: 5
 		BlendMode: Additive
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1676,7 +1676,7 @@ conyardc: # TODO: unused
 		Start: 4139
 		Length: 12
 		Offset: -48,64
-		Tick: 200
+		Tick: 5
 	damaged-idle: DATA
 		Start: 3007
 		Offset: -48,64
@@ -1684,12 +1684,12 @@ conyardc: # TODO: unused
 		Start: 4478
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	damaged-crane-overlay: DATA
 		Start: 4478
 		Length: 14
 		Offset: -48,64
-		Tick: 80
+		Tick: 2
 	bib: BLOXBASE
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -20,7 +20,7 @@ harvester:
 		Start: 3631
 		Length: 6
 		Facings: -8
-		Tick: 80
+		Tick: 2
 		ZOffset: 1
 	dock: DATA
 		Start: 3370
@@ -259,3 +259,4 @@ deviatortank.destroyed:
 		Start: 2389
 		Facings: -32
 		ZOffset: -512
+

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -357,3 +357,4 @@ CTFLAG:
 	Invulnerable:
 	-Selectable:
 	-TargetableBuilding:
+

--- a/mods/ra/sequences/aircraft.yaml
+++ b/mods/ra/sequences/aircraft.yaml
@@ -69,7 +69,7 @@ tran:
 		Start: 35
 	icon: tranicon
 		Start: 0
-		
+
 tran1husk:
 	idle:
 		Start: 0
@@ -89,3 +89,4 @@ badr:
 	idle:
 		Start: 0
 		Facings: 16
+

--- a/mods/ra/sequences/decorations.yaml
+++ b/mods/ra/sequences/decorations.yaml
@@ -6,7 +6,7 @@ tc04:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc05:
 	idle:
@@ -16,7 +16,7 @@ tc05:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc03:
 	idle:
@@ -26,7 +26,7 @@ tc03:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc02:
 	idle:
@@ -36,7 +36,7 @@ tc02:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 tc01:
 	idle:
@@ -46,7 +46,7 @@ tc01:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t17:
 	idle:
@@ -56,7 +56,7 @@ t17:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t16:
 	idle:
@@ -66,7 +66,7 @@ t16:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t15:
 	idle:
@@ -76,7 +76,7 @@ t15:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t14:
 	idle:
@@ -86,7 +86,7 @@ t14:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t13:
 	idle:
@@ -96,7 +96,7 @@ t13:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t12:
 	idle:
@@ -106,7 +106,7 @@ t12:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t11:
 	idle:
@@ -116,7 +116,7 @@ t11:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t10:
 	idle:
@@ -126,7 +126,7 @@ t10:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t08:
 	idle:
@@ -136,7 +136,7 @@ t08:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t07:
 	idle:
@@ -146,7 +146,7 @@ t07:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t06:
 	idle:
@@ -156,7 +156,7 @@ t06:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t05:
 	idle:
@@ -166,7 +166,7 @@ t05:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t03:
 	idle:
@@ -176,7 +176,7 @@ t03:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 ice01:
 	idle:
@@ -211,7 +211,7 @@ t02:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 t01:
 	idle:
@@ -221,7 +221,7 @@ t01:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 v01:
 	idle:
@@ -530,47 +530,47 @@ t04:
 	dead:
 		Start: 2
 		Length: 8
-		Tick: 80
+		Tick: 2
 
 v20:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v21:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v22:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v23:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 120
+		Tick: 3
 	damaged-idle:
 		Start: 3
 		Length: 3
-		Tick: 120
+		Tick: 3
 
 v24:
 	idle:
@@ -660,8 +660,9 @@ snowhut:
 	idle:
 		Start: 0
 		Length: 3
-		Tick: 360
+		Tick: 9
 	damaged-idle:
 		Start: 3
 		Length: 1
-		Tick: 120
+		Tick: 3
+

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -12,7 +12,7 @@ e1:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 8
@@ -25,7 +25,7 @@ e1:
 		Start: 144
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	standup-0:
 		Start: 176
 		Length: 2
@@ -37,11 +37,11 @@ e1:
 	idle1:
 		Start: 256
 		Length: 16
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 272
 		Length: 16
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 288
 		Length: 8
@@ -63,7 +63,7 @@ e1:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	garrison-muzzle: minigun
 		Start: 0
@@ -83,7 +83,7 @@ sniper:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 16
@@ -99,7 +99,7 @@ sniper:
 		Start: 208
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	standup:
 		Start: 240
 		Length: 2
@@ -111,11 +111,11 @@ sniper:
 	idle1:
 		Start: 384
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 399
 		Length: 16
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 416
 		Length: 8
@@ -136,7 +136,7 @@ sniper:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	garrison-muzzle: minigun
 		Start: 0
@@ -157,7 +157,7 @@ e3:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	shoot:
 		Start: 64
 		Length: 8
@@ -165,11 +165,11 @@ e3:
 	idle1:
 		Start: 272
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 287
 		Length: 16
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 304
 		Length: 8
@@ -191,7 +191,7 @@ e3:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 144
@@ -201,7 +201,7 @@ e3:
 		Start: 144
 		Length: 4
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	prone-shoot:
 		Start: 192
 		Length: 10
@@ -220,15 +220,15 @@ e6:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	idle1:
 		Start: 121
 		Length: 8
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 130
 		Length: 14
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 146
 		Length: 8
@@ -250,7 +250,7 @@ e6:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 82
@@ -260,7 +260,7 @@ e6:
 		Start: 82
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	icon: e6icon
 		Start: 0
 
@@ -275,11 +275,11 @@ medi:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	heal:
 		Start: 56
 		Length: 58
-		Tick: 120
+		Tick: 3
 	standup:
 		Start: 114
 		Length: 2
@@ -287,11 +287,11 @@ medi:
 	idle1:
 		Start: 163
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 178
 		Length: 14
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 193
 		Length: 7
@@ -313,7 +313,7 @@ medi:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 130
@@ -323,10 +323,10 @@ medi:
 		Start: 130
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	icon: mediicon
 		Start: 0
-		
+
 mech:
 	stand:
 		Start: 0
@@ -338,11 +338,11 @@ mech:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	heal:
 		Start: 56
 		Length: 58
-		Tick: 120
+		Tick: 3
 	standup:
 		Start: 114
 		Length: 2
@@ -350,11 +350,11 @@ mech:
 	idle1:
 		Start: 163
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 178
 		Length: 14
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 193
 		Length: 7
@@ -376,7 +376,7 @@ mech:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 130
@@ -386,7 +386,7 @@ mech:
 		Start: 130
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	icon: mechicon
 		Start: 0
 
@@ -401,7 +401,7 @@ e2:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 20
@@ -409,11 +409,11 @@ e2:
 	idle1:
 		Start: 384
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 399
 		Length: 16
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 416
 		Length: 8
@@ -435,7 +435,7 @@ e2:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 240
@@ -445,7 +445,7 @@ e2:
 		Start: 240
 		Length: 4
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 288
 		Length: 12
@@ -464,15 +464,15 @@ dog:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	idle1:
 		Start: 216
 		Length: 7
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 224
 		Length: 11
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 236
 		Length: 6
@@ -494,7 +494,7 @@ dog:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	shoot: dogbullt
 		Start: 0
@@ -514,7 +514,7 @@ spy:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	shoot:
 		Start: 64
 		Length: 8
@@ -522,11 +522,11 @@ spy:
 	idle1:
 		Start: 256
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 271
 		Length: 16
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 288
 		Length: 8
@@ -548,7 +548,7 @@ spy:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 144
@@ -558,7 +558,7 @@ spy:
 		Start: 144
 		Length: 4
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	prone-shoot:
 		Start: 192
 		Length: 8
@@ -577,7 +577,7 @@ thf:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	die1:
 		Start: 139
 		Length: 8
@@ -599,7 +599,7 @@ thf:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	crawl:
 		Start: 72
@@ -619,7 +619,7 @@ hijacker:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 100
+		Tick: 2
 	die1: thf
 		Start: 139
 		Length: 8
@@ -641,7 +641,7 @@ hijacker:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	crawl: thf
 		Start: 72
@@ -661,7 +661,7 @@ e7:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 56
 		Length: 7
@@ -669,11 +669,11 @@ e7:
 	idle1:
 		Start: 233
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 248
 		Length: 15
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 262
 		Length: 8
@@ -695,7 +695,7 @@ e7:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 128
@@ -705,7 +705,7 @@ e7:
 		Start: 128
 		Length: 4
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 176
 		Length: 7
@@ -729,7 +729,7 @@ e4:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	shoot:
 		Start: 64
 		Length: 16
@@ -737,11 +737,11 @@ e4:
 	idle1:
 		Start: 384
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 399
 		Length: 16
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 416
 		Length: 8
@@ -763,7 +763,7 @@ e4:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	prone-stand:
 		Start: 208
@@ -773,7 +773,7 @@ e4:
 		Start: 208
 		Length: 4
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	prone-shoot:
 		Start: 256
 		Length: 16
@@ -792,7 +792,7 @@ gnrl:
 		Start: 8
 		Length: 5
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 56
 		Length: 4
@@ -816,7 +816,7 @@ gnrl:
 	idle1:
 		Start: 184
 		Length: 26
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 210
 		Length: 8
@@ -838,7 +838,7 @@ gnrl:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 
 shok:
@@ -852,7 +852,7 @@ shok:
 		Start: 16
 		Length: 6
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	shoot:
 		Start: 64
 		Length: 16
@@ -868,7 +868,7 @@ shok:
 		Start: 208
 		Length: 4
 		Facings: 8
-		Tick: 120
+		Tick: 3
 	standup:
 		Start: 240
 		Length: 2
@@ -880,11 +880,11 @@ shok:
 	idle1:
 		Start: 384
 		Length: 14
-		Tick: 120
+		Tick: 3
 	idle2:
 		Start: 399
 		Length: 16
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 416
 		Length: 8
@@ -906,7 +906,7 @@ shok:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	icon: shokicon
 		Start: 0
@@ -951,13 +951,13 @@ c1:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 
 c2:
 	stand:
@@ -999,13 +999,13 @@ c2:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 
 c3:
 	stand:
@@ -1047,13 +1047,13 @@ c3:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 
 einstein:
 	stand:
@@ -1074,7 +1074,7 @@ einstein:
 		Start: 56
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	die1:
 		Start: 115
 		Length: 8
@@ -1096,7 +1096,7 @@ einstein:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 
 delphi:
@@ -1118,7 +1118,7 @@ delphi:
 		Start: 56
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	die1:
 		Start: 115
 		Length: 8
@@ -1140,7 +1140,7 @@ delphi:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 
 chan:
@@ -1162,7 +1162,7 @@ chan:
 		Start: 56
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	die1:
 		Start: 115
 		Length: 8
@@ -1184,7 +1184,7 @@ chan:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 
 zombie:
@@ -1205,7 +1205,7 @@ zombie:
 	idle1:
 		Start: 96
 		Length: 10
-		Tick: 120
+		Tick: 3
 	die1:
 		Start: 106
 		Length: 7
@@ -1227,7 +1227,7 @@ zombie:
 	die-crushed: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 		ZOffset: -511
 	icon: zombicon
 		Start: 0
@@ -1250,11 +1250,12 @@ ant:
 	die:
 		Start: 104
 		Length: 8
-		Tick: 300
+		Tick: 7
 	die-crushed:
 		Start: 104
 		Length: 8
-		Tick: 400
+		Tick: 10
 		ZOffset: -511
 	icon: anticon
 		Start: 0
+

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -75,7 +75,7 @@ explosion:
 	corpse: corpse1
 		Start: 0
 		Length: 6
-		Tick: 1600
+		Tick: 40
 
 pips:
 	groups:
@@ -110,11 +110,11 @@ v2:
 		Facings: 32
 
 rallypoint:
-	flag:flagfly
+	flag: flagfly
 		Start: 0
 		Length: *
 		Offset: 11,-5
-	circles:fpls
+	circles: fpls
 		Start: 0
 		Length: *
 
@@ -193,7 +193,7 @@ litning:
 		Length: 4
 
 fb1:
-	idle: 
+	idle:
 		Start: 0
 		Length: *
 
@@ -201,7 +201,7 @@ moveflsh:
 	idle:
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 
 select:
 	repair:
@@ -211,13 +211,13 @@ poweroff:
 	offline:
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 
 allyrepair:
 	repair:
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 
 tabs:
 	left-normal:
@@ -253,6 +253,7 @@ fb3:
 	idle:
 		Start: 0
 		Facings: 32
+
 fb4:
 	idle:
 		Start: 0
@@ -268,7 +269,7 @@ scrate:
 	water:
 		Start: 2
 		Length: 4
-		Tick: 500
+		Tick: 12
 		ZOffset: -511
 
 wcrate:
@@ -286,7 +287,7 @@ xcratea:
 	water:
 		Start: 2
 		Length: 4
-		Tick: 500
+		Tick: 12
 		ZOffset: -511
 
 xcrateb:
@@ -299,7 +300,7 @@ xcrateb:
 	water:
 		Start: 2
 		Length: 4
-		Tick: 500
+		Tick: 12
 		ZOffset: -511
 
 xcratec:
@@ -312,7 +313,7 @@ xcratec:
 	water:
 		Start: 2
 		Length: 4
-		Tick: 500
+		Tick: 12
 		ZOffset: -511
 
 xcrated:
@@ -325,7 +326,7 @@ xcrated:
 	water:
 		Start: 2
 		Length: 4
-		Tick: 500
+		Tick: 12
 		ZOffset: -511
 
 crate-effects:
@@ -380,7 +381,7 @@ crate-effects:
 	levelup: levelup
 		Start: 0
 		Length: *
-		Tick: 200
+		Tick: 5
 
 parach:
 	open:
@@ -430,12 +431,12 @@ smokland:
 	open: playersmoke
 		Start: 0
 		Length: 60
-		Tick: 120
+		Tick: 3
 		ZOffset: 1023
 	idle: playersmoke
 		Start: 60
 		Length: 32
-		Tick: 120
+		Tick: 3
 		ZOffset: 1023
 
 fire:
@@ -477,7 +478,7 @@ bubbles:
 	idle:
 		Start: 0
 		Length: *
-		Tick: 220
+		Tick: 5
 
 mpspawn:
 	idle:
@@ -645,8 +646,9 @@ ctflag:
 	idle:
 		Start: 0
 		Length: 9
-		Tick: 50
+		Tick: 1
 		Offset: 0,-12
 	bib: mbGAP
 		Start: 0
 		Length: *
+

--- a/mods/ra/sequences/ships.yaml
+++ b/mods/ra/sequences/ships.yaml
@@ -47,7 +47,7 @@ lst:
 	open:
 		Start: 1
 		Length: 4
-		Tick: 150
+		Tick: 3
 	unload:
 		Start: 4
 		ZOffset: -511
@@ -60,3 +60,4 @@ msub:
 		Facings: 16
 	icon: msubicon
 		Start: 0
+

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -51,6 +51,7 @@ oilb:
 	bib: bib3
 		Start: 0
 		Length: *
+
 fact:
 	idle:
 		Start: 0
@@ -299,22 +300,22 @@ afld:
 	idle: afldidle
 		Start: 0
 		Length: 8
-		Tick: 160
+		Tick: 4
 		ZOffset: -1023
 	damaged-idle: afldidle
 		Start: 8
 		Length: 8
-		Tick: 160
+		Tick: 4
 		ZOffset: -1023
 	active:
 		Start: 0
 		Length: 8
-		Tick: 160
+		Tick: 4
 		ZOffset: -1023
 	damaged-active:
 		Start: 8
 		Length: 8
-		Tick: 160
+		Tick: 4
 		ZOffset: -1023
 	make: afldmake
 		Start: 0
@@ -492,12 +493,12 @@ tsla:
 	active:
 		Start: 1
 		Length: 9
-		Tick: 100
+		Tick: 2
 		Offset: 0,-1
 	damaged-active:
 		Start: 11
 		Length: 9
-		Tick: 100
+		Tick: 2
 		Offset: 0,-1
 	bib: mbTSLA
 		Start: 0
@@ -616,7 +617,7 @@ mslo:
 	active:
 		Start: 1
 		Length: 7
-		Tick: 80
+		Tick: 2
 	damaged-active:
 		Start: 9
 		Length: 7
@@ -671,3 +672,4 @@ cycl:
 	damaged-idle:
 		Start: 16
 		Length: 16
+

--- a/mods/ra/sequences/vehicles.yaml
+++ b/mods/ra/sequences/vehicles.yaml
@@ -331,3 +331,4 @@ stnk:
 		Facings: 32
 	icon: stnkicon
 		Start: 0
+

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -35,3 +35,4 @@ apache:
 	slow-rotor: lrotor
 		Start: 4
 		Length: 8
+

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -7,23 +7,23 @@ e1:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -35,49 +35,49 @@ e1:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die3: infdie
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: e1icon
 		Start: 0
 
@@ -90,23 +90,23 @@ e2:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -118,49 +118,49 @@ e2:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die3: infdie
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: e2icon
 		Start: 0
 
@@ -173,23 +173,23 @@ e3:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -201,49 +201,49 @@ e3:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die3: infdie
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: e4icon
 		Start: 0
 
@@ -256,28 +256,28 @@ weedguy:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 210
 	shoot: weed
 		Start: 56
 		Length: 1
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	prone-shoot: weed
 		Start: 212
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	standup-0: weed
 		Start: 260
 		Length: 2
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	prone-run: weed
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 288
 	prone-stand: weed
 		Start: 86
@@ -289,36 +289,36 @@ weedguy:
 		Start: 149
 		Length: 11
 		ShadowStart: 351
-		Tick: 80
+		Tick: 2
 	die2: weed
 		Start: 160
 		Length: 6
 		ShadowStart: 362
-		Tick: 80
+		Tick: 2
 	die3: weed
 		Start: 166
 		Length: 11
 		ShadowStart: 368
-		Tick: 80
+		Tick: 2
 	die4: weed
 		Start: 197
 		Length: 5
 		ShadowStart: 399
-		Tick: 80
+		Tick: 2
 	die5: weed
 		Start: 177
 		Length: 19
 		ShadowStart: 379
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	die-crushed: weed
 		Start: 174
 		Length: 3
 		ShadowStart: 376
-		Tick: 1000
+		Tick: 25
 	icon: weaticon
 		Start: 0
 
@@ -331,23 +331,23 @@ medic:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 315
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -359,52 +359,52 @@ medic:
 		Start: 134
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 455
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 455
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 567
-		Tick: 80
+		Tick: 2
 	heal:
 		Start: 292
 		Length: 14
 		ShadowStart: 599
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mediicon
 		Start: 0
 
@@ -417,23 +417,23 @@ engineer:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -445,38 +445,38 @@ engineer:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: engnicon
 		Start: 0
 
@@ -489,23 +489,23 @@ umagon:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -517,50 +517,50 @@ umagon:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: umagicon
 		Start: 0
 
@@ -573,23 +573,23 @@ ghost: # TODO unused GUNFIRE.SHP
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -601,50 +601,50 @@ ghost: # TODO unused GUNFIRE.SHP
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: gosticon
 		Start: 0
 
@@ -657,76 +657,76 @@ jumpjet: # TODO: ShadowStart:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 459
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 507
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 523
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 538
 	prone-stand:
 		Start: 0
 		Facings: 8
 		ShadowStart: 451
-	die1: 
+	die1:
 		Start: 134
 		Length: 15
 		ShadowStart: 585
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 600
-		Tick: 80
 	die3: #TODO: animation doesn't fit this InfDeath
+		Tick: 2
 		Start: 436
 		Length: 15
 		ShadowStart: 887
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 615
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 663
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 711
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: jjeticon
 		Start: 0
 
@@ -739,23 +739,23 @@ mhijack:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -767,50 +767,50 @@ mhijack:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mutcicon
 		Start: 0
 
@@ -823,23 +823,23 @@ chamspy:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -851,50 +851,50 @@ chamspy:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: chamicon
 		Start: 0
 
@@ -907,23 +907,23 @@ cyc2:
 		Start: 8
 		Length: 9
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 316
 	idle1:
 		Start: 80
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 388
 	idle2:
 		Start: 95
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 403
 	prone-run:
 		Start: 110
 		Length: 9
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 418
 	prone-stand:
 		Start: 110
@@ -935,43 +935,43 @@ cyc2:
 		Start: 182
 		Length: 15
 		ShadowStart: 490
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 197
 		Length: 15
 		ShadowStart: 505
-		Tick: 80
+		Tick: 2
 	die3: infexpl
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 520
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 260
 		Length: 6
 		Facings: 8
 		ShadowStart: 568
-		Tick: 80
 	standup-0: # TODO: N/A as they only crawl when severly damaged
+		Tick: 2
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 568
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: cybcicon
 		Start: 0
 
@@ -984,23 +984,23 @@ cyborg:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 426
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 441
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 456
 	prone-stand:
 		Start: 86
@@ -1012,44 +1012,44 @@ cyborg:
 		Start: 134
 		Length: 15
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 519
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 534
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 582
-		Tick: 80
 	standup-0: # TODO: N/A as they don't do that
+		Tick: 2
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 630
-		Tick: 80
 	die5: # TODO: unused running frame 322 and following
+		Tick: 2
 		Start: 292
 		Length: 14
 		ShadowStart: 662
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 307
 		Length: 14
 		ShadowStart: 677
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: cybiicon
 		Start: 0
 
@@ -1062,23 +1062,23 @@ mutant:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -1090,50 +1090,50 @@ mutant:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mutcicon
 		Start: 0
 
@@ -1146,23 +1146,23 @@ mwmn:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -1174,50 +1174,50 @@ mwmn:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mutcicon
 		Start: 0
 
@@ -1230,23 +1230,23 @@ mutant3: # TODO unused MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -1258,50 +1258,50 @@ mutant3: # TODO unused MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mutcicon
 		Start: 0
 
@@ -1314,23 +1314,23 @@ tratos:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -1342,50 +1342,50 @@ tratos:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mutcicon
 		Start: 0
 
@@ -1398,23 +1398,23 @@ oxanna:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -1426,50 +1426,50 @@ oxanna:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mutcicon
 		Start: 0
 
@@ -1482,23 +1482,23 @@ slav:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 300
 	idle1:
 		Start: 56
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 348
 	idle2:
 		Start: 71
 		Length: 15
-		Tick: 80
+		Tick: 2
 		ShadowStart: 363
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 378
 	prone-stand:
 		Start: 86
@@ -1510,50 +1510,50 @@ slav:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
-		Tick: 80
+		Tick: 2
 	prone-shoot:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
-		Tick: 80
+		Tick: 2
 	standup-0:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
 	die5: flameguy # TODO: walking animation unused
+		Tick: 2
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: mutcicon
 		Start: 0
 
@@ -1566,45 +1566,45 @@ doggie: # TODO: not sure what frame 88 and following is
 		Start: 8
 		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 2
 		ShadowStart: 127
 	die1:
 		Start: 99
 		Length: 10
 		ShadowStart: 218
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 99
 		Length: 10
 		ShadowStart: 218
-		Tick: 80
+		Tick: 2
 	die3:
 		Start: 99
 		Length: 10
 		ShadowStart: 218
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 105
 		Length: 4
 		ShadowStart: 224
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	shoot:
 		Start: 56
 		Length: 4
 		Facings: 8
 		ShadowStart: 175
-		Tick: 80
+		Tick: 2
 	die5:
 		Start: 109
 		Length: 10
 		ShadowStart: 228
-		Tick: 80
+		Tick: 2
 	die6:
 		Start: 109
 		Length: 10
 		ShadowStart: 228
-		Tick: 80
+		Tick: 2
 	icon: xxicon
 		Start: 0
 
@@ -1639,55 +1639,55 @@ civ1:
 		Length: 6
 		Facings: 8
 		ShadowStart: 300
-		Tick: 80
+		Tick: 2
 	panic-stand:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
+		Tick: 2
 	panic-run:
 		Start: 86
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 457
-		Tick: 80
+		Tick: 2
 	die1:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	die5: flameguy # TODO: walking animation unused
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: xxicon
 		Start: 0
 
@@ -1701,55 +1701,55 @@ civ2:
 		Length: 6
 		Facings: 8
 		ShadowStart: 300
-		Tick: 80
+		Tick: 2
 	panic-stand:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
+		Tick: 2
 	panic-run:
 		Start: 86
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 457
-		Tick: 80
+		Tick: 2
 	die1:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	die5: flameguy # TODO: walking animation unused
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: xxicon
 		Start: 0
 
@@ -1763,54 +1763,55 @@ civ3:
 		Length: 6
 		Facings: 8
 		ShadowStart: 300
-		Tick: 80
+		Tick: 2
 	panic-stand:
 		Start: 260
 		Length: 2
 		Facings: 8
 		ShadowStart: 552
-		Tick: 80
+		Tick: 2
 	panic-run:
 		Start: 86
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
-		Tick: 80
+		Tick: 2
 	shoot:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 457
-		Tick: 80
+		Tick: 2
 	die1:
 		Start: 134
 		Length: 15
 		ShadowStart: 426
-		Tick: 80
+		Tick: 2
 	die2:
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
 	die3: # TODO: copy-paste of die2
+		Tick: 2
 		Start: 149
 		Length: 15
 		ShadowStart: 441
-		Tick: 80
+		Tick: 2
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
-		Tick: 800
+		Tick: 20
 		ZOffset: -511
 	die5: flameguy # TODO: walking animation unused
 		Start: 42
 		Length: 104
 		ShadowStart: 190
-		Tick: 80
+		Tick: 2
 	die6: electro
 		Start: 0
 		Length: *
-		Tick: 80
+		Tick: 2
 	icon: xxicon
 		Start: 0
+

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -34,13 +34,13 @@ poweroff:
 	offline: poweroff
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 
 allyrepair:
 	repair: wrench
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 
 # TODO: fix/replace them, just placeholders
 rallypoint:
@@ -113,7 +113,7 @@ clock:
 		Length: *
 
 pips:
-	medic: 
+	medic:
 		Start: 6
 	groups: pipsra #TODO: backfall to RA asset
 		Start: 8
@@ -157,7 +157,7 @@ explosion:
 	ionring: ring1
 		Start: 0
 		Length: *
-		Tick: 160
+		Tick: 4
 	pulse_explosion: pulsefx2
 		Start: 0
 		Length: *
@@ -308,7 +308,7 @@ flameall:
 		Start: 0
 		Length: 19
 		Facings: -8
-		Tick: 160
+		Tick: 4
 
 largesmoke:
 	idle: lgrysmk1
@@ -344,7 +344,7 @@ moveflsh:
 	idle: ring
 		Start: 0
 		Length: *
-		Tick: 30
+		Tick: 1
 
 resources:
 	tib01: tib01
@@ -537,3 +537,4 @@ largecraters:
 	cr12: crater12
 		Length: 1
 		Offset: 0, -24
+

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -31,12 +31,12 @@ gacnst:
 	idle-top: gtcnst_c
 		Start: 0
 		Length: 15
-		Tick: 200
+		Tick: 5
 		Offset: 0, -36
 	damaged-idle-top: gtcnst_c
 		Start: 15
 		Length: 15
-		Tick: 200
+		Tick: 5
 		Offset: 0, -36
 	critical-idle-top: gtcnst_c
 		Start: 30
@@ -84,32 +84,32 @@ gapowr:
 	idle-lights: gtpowr_a
 		Start: 0
 		Length: 12
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	damaged-idle-lights: gtpowr_a
 		Start: 12
 		Length: 12
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	critical-idle-lights: gtpowr_a
 		Start: 24
 		Length: 12
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	idle-plug: gtpowr_b
 		Start: 0
 		Length: 12
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	damaged-idle-plug: gtpowr_b
 		Start: 0
 		Length: 12
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	critical-idle-plug: gtpowr_b
 		Start: 0
 		Length: 12
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	make: gtpowrmk
 		Start: 0
@@ -135,29 +135,29 @@ gapile:
 	production-lights: gtpile_a
 		Start: 0
 		Length: 7
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	damaged-production-lights: gtpile_a
-		Start:7
+		Start: 7
 		Length: 7
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	idle-light: gtpile_b
 		Start: 0
 		Length: 7
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	damaged-idle-light: gtpile_b
-		Start:7
+		Start: 7
 		Length: 7
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	idle-flag: gtpile_c
-		Start:0
+		Start: 0
 		Length: 7
 		Offset: 0, -24
 	damaged-idle-flag: gtpile_c
-		Start:7
+		Start: 7
 		Length: 7
 		Offset: 0, -24
 	make: gtpilemk
@@ -184,37 +184,37 @@ gaweap:
 	production-lights-white: gtweap_a
 		Start: 0
 		Length: 8
-		Tick: 100
+		Tick: 2
 		ZOffset: 2048
 		Offset: -12, -42
 	damaged-production-lights-white: gtweap_a
 		Start: 8
 		Length: 8
-		Tick: 100
+		Tick: 2
 		ZOffset: 2048
 		Offset: -12, -42
 	production-lights-red: gtweap_b
 		Start: 0
 		Length: 4
-		Tick: 120
+		Tick: 3
 		ZOffset: 2048
 		Offset: -12, -42
 	damaged-production-lights-red: gtweap_b
 		Start: 4
 		Length: 4
-		Tick: 120
+		Tick: 3
 		ZOffset: 2048
 		Offset: -12, -42
 	idle-turbines: gtweap_c
 		Start: 0
 		Length: 4
-		Tick: 80
+		Tick: 2
 		ZOffset: 2048
 		Offset: -12, -42
 	damaged-idle-turbines: gtweap_c
 		Start: 0
 		Length: 4
-		Tick: 80
+		Tick: 2
 		ZOffset: 2048
 		Offset: -12, -42
 	build-top: gtweap_d
@@ -236,7 +236,7 @@ gaweap:
 	make: gtweapmk
 		Start: 0
 		Length: 20
-		Tick: 80
+		Tick: 2
 		ShadowStart: 20
 		Offset: -12, -42
 	icon: weapicon
@@ -271,17 +271,17 @@ napowr:
 	idle-lights: ntpowr_a
 		Start: 0
 		Length: 9
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	damaged-idle-lights: ntpowr_a
 		Start: 9
 		Length: 9
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	critical-idle-lights: ntpowr_a
 		Start: 9
 		Length: 9
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	make: ntpowrmk
 		Start: 0
@@ -307,17 +307,17 @@ naapwr:
 	idle-lights: ntapwr_a
 		Start: 0
 		Length: 9
-		Tick: 200
+		Tick: 5
 		Offset: 12, -30
 	damaged-idle-lights: ntapwr_a
 		Start: 9
 		Length: 9
-		Tick: 200
+		Tick: 5
 		Offset: 12, -30
 	critical-idle-lights: ntapwr_a
 		Start: 9
 		Length: 9
-		Tick: 200
+		Tick: 5
 		Offset: 12, -30
 	make: ntapwrmk
 		Start: 0
@@ -343,22 +343,22 @@ nahand:
 	production-light: nthand_a
 		Start: 0
 		Length: 5
-		Tick: 100
+		Tick: 2
 		Offset: -6, -30
 	damaged-production-light: nthand_a
 		Start: 5
 		Length: 5
-		Tick: 100
+		Tick: 2
 		Offset: -6, -30
 	idle-lights: nthand_b
 		Start: 0
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: -6, -30
 	damaged-idle-lights: nthand_b
 		Start: 8
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: -6, -30
 	make: nthandmk
 		Start: 0
@@ -384,13 +384,13 @@ naweap:
 	production-lights: ntweap_a
 		Start: 0
 		Length: 16
-		Tick: 100
+		Tick: 2
 		ZOffset: 2048
 		Offset: -12, -42
 	damaged-production-lights: ntweap_a
 		Start: 16
 		Length: 16
-		Tick: 100
+		Tick: 2
 		ZOffset: 2048
 		Offset: -12, -42
 	build-top: ntweap_b
@@ -412,7 +412,7 @@ naweap:
 	make: ntweapmk
 		Start: 0
 		Length: 22
-		Tick: 80
+		Tick: 2
 		ShadowStart: 22
 		Offset: -12, -42
 	icon: nwepicon
@@ -447,12 +447,12 @@ naradr:
 	idle-dish: ntradr_a
 		Start: 0
 		Length: 24
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 	damaged-idle-dish: ntradr_a
 		Start: 24
 		Length: 24
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 	make: ntradrmk
 		Start: 0
@@ -478,17 +478,17 @@ natech:
 	idle-lights: nttech_a
 		Start: 0
 		Length: 9
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 	damaged-idle-lights: nttech_a
 		Start: 0
 		Length: 9
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 	critical-idle-lights: nttech_a
 		Start: 0
 		Length: 9
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 	make: nttechmk
 		Start: 0
@@ -514,12 +514,12 @@ garadr:
 	idle-dish: gtradr_a
 		Frames: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
 		Length: 28
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	damaged-idle-dish: gtradr_a
 		Frames: 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16
 		Length: 28
-		Tick: 240
+		Tick: 6
 		Offset: 0, -24
 	make: gtradrmk
 		Start: 0
@@ -545,17 +545,17 @@ gatech:
 	idle-lights: gttech_a
 		Start: 0
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: -12, -30
 	damaged-idle-lights: gttech_a
 		Start: 8
 		Length: 8
-		Tick: 240
+		Tick: 6
 		Offset: -12, -30
 	critical-idle-lights: gttech_a
 		Start: 8
 		Length: 8
-		Tick: 240
+		Tick: 6
 		Offset: -12, -30
 	make: gttechmk
 		Start: 0
@@ -717,7 +717,7 @@ naobel:
 	idle-lights: ntobel_a
 		Start: 0
 		Length: 12
-		Tick: 80
+		Tick: 2
 		Offset: 0, -24
 	make: ntobelmk
 		Start: 0
@@ -811,11 +811,11 @@ nastlh:
 	pulse: ntstlh_a
 		Start: 0
 		Length: 4
-		Tick: 480
+		Tick: 12
 	damaged-pulse: ntstlh_a
 		Start: 4
 		Length: 4
-		Tick: 480
+		Tick: 12
 	make: ntstlhmk
 		Start: 0
 		Length: 18
@@ -875,17 +875,17 @@ gavulc:
 	idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	damaged-idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	critical-idle-lights: gtctwr_a
 		Start: 6
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	make: gtctwrmk
 		Start: 0
@@ -915,17 +915,17 @@ garock:
 	idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	damaged-idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	critical-idle-lights: gtctwr_a
 		Start: 6
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	make: gtctwrmk
 		Start: 0
@@ -955,17 +955,17 @@ gacsam:
 	idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	damaged-idle-lights: gtctwr_a
 		Start: 0
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	critical-idle-lights: gtctwr_a
 		Start: 6
 		Length: 6
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	make: gtctwrmk
 		Start: 0
@@ -991,17 +991,17 @@ gaspot:
 	idle-lights: gaspot_a
 		Start: 0
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	damaged-idle-lights: gaspot_a
 		Start: 8
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	critical-idle-lights: gaspot_a
 		Start: 16
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: 0, -12
 	make: gaspotmk
 		Start: 0
@@ -1045,19 +1045,19 @@ gahpad:
 	idle-lights: gthpad_a
 		Start: 0
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: 0, -36
 		ZOffset: -1c511
 	damaged-idle-lights: gthpad_a
 		Start: 8
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: 0, -36
 		ZOffset: -1c511
 	critical-idle-lights: gthpad_a
 		Start: 16
 		Length: 8
-		Tick: 200
+		Tick: 5
 		Offset: 0, -36
 		ZOffset: -1c511
 	make: gthpadmk
@@ -1105,17 +1105,17 @@ nahpad:
 		Length: 46
 		Offset: 0, -24
 		ZOffset: -1c511
-		Tick: 120
+		Tick: 3
 	damaged-idle-lights: nthpad_a
 		Start: 46
 		Length: 46
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 		ZOffset: -1c511
 	critical-idle-lights: nthpad_a
 		Start: 46
 		Length: 46
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 		ZOffset: -1c511
 	make: nthpadmk
@@ -1147,17 +1147,17 @@ proc: # TODO: unused narefn_a, narefn_b
 	idle-redlights: ntrefn_c
 		Start: 0
 		Length: 16
-		Tick: 120
+		Tick: 3
 		Offset: -12, -42
 	damaged-idle-redlights: ntrefn_c
 		Start: 0
 		Length: 16
-		Tick: 120
+		Tick: 3
 		Offset: -12, -42
 	critical-idle-redlights: ntrefn_c
 		Start: 16
 		Length: 16
-		Tick: 200
+		Tick: 5
 		Offset: -12, -42
 	bib: ntrefnbb
 		Start: 0
@@ -1201,17 +1201,17 @@ gasilo:
 	idle-lights: gtsilo_b
 		Start: 0
 		Length: 16
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 	damaged-idle-lights: gtsilo_b
 		Start: 16
 		Length: 16
-		Tick: 120
+		Tick: 3
 		Offset: 0, -24
 	critical-idle-lights: gtsilo_b
 		Start: 32
 		Length: 16
-		Tick: 200
+		Tick: 5
 		Offset: 0, -24
 	icon: siloicon
 		Start: 0
@@ -1268,12 +1268,12 @@ gadept:
 	idle-light: gtdept_b
 		Start: 0
 		Length: 7
-		Tick: 120
+		Tick: 3
 		Offset: 0, -36
 	damaged-idle-light: gtdept_b
 		Start: 7
 		Length: 7
-		Tick: 120
+		Tick: 3
 		Offset: 0, -36
 	circuits: gtdept_a
 		Start: 0
@@ -1302,8 +1302,9 @@ gadept:
 	make: gtdeptmk
 		Start: 0
 		Length: 10
-		Tick: 60
+		Tick: 1
 		ShadowStart: 10
 		Offset: 0, -36
 	icon: fixicon
 		Start: 0
+

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -8,7 +8,7 @@ tibtre01:
 		Start: 1
 		Length: 10
 		ShadowStart: 12
-		Tick: 160
+		Tick: 4
 		Offset: 0, -12
 
 tibtre02:
@@ -21,7 +21,7 @@ tibtre02:
 		Start: 1
 		Length: 10
 		ShadowStart: 12
-		Tick: 160
+		Tick: 4
 		Offset: 0, -12
 
 tibtre03:
@@ -34,7 +34,7 @@ tibtre03:
 		Start: 1
 		Length: 10
 		ShadowStart: 12
-		Tick: 160
+		Tick: 4
 		Offset: 0, -12
 
 bigblue:
@@ -47,5 +47,6 @@ bigblue:
 		Start: 1
 		Length: 9
 		ShadowStart: 11
-		Tick: 160
+		Tick: 4
 		Offset: 0, -12
+

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -164,6 +164,7 @@ smech:
 		Length: 4
 		Facings: -8
 		ShadowStart: 240
-		Tick: 100
+		Tick: 2
 	icon: smchicon
 		Start: 0
+


### PR DESCRIPTION
As discussed in https://github.com/OpenRA/OpenRA/issues/6389 the `Tick:` in the sequence definitions is not actually a game tick, but a value in milliseconds that gets processed in a function that uses game ticks again. That is not only contra-intuitive for modders, but also poses a problem when using values that are not divisible by 40. This tidies this relic up with the help of an automated upgrade rule whose results have been hand cleaned to avoid loosing inline comments.
