### PR TITLE
Make FrozenActorsInBox a streaming enumerable.

### DIFF
--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -175,15 +175,17 @@ namespace OpenRA.Traits
 			var right = (r.Right / info.BinSize).Clamp(0, cols - 1);
 			var top = (r.Top / info.BinSize).Clamp(0, rows - 1);
 			var bottom = (r.Bottom / info.BinSize).Clamp(0, rows - 1);
+			var bins = frozen[p];
 
-			var frozenInBox = new List<FrozenActor>();
+			var actorsChecked = new HashSet<FrozenActor>();
 			for (var j = top; j <= bottom; j++)
 				for (var i = left; i <= right; i++)
-					frozenInBox.AddRange(frozen[p][j * cols + i]
-					                     .Where(kv => kv.Key.IsValid && kv.Value.IntersectsWith(r))
-					                     .Select(kv => kv.Key));
-
-			return frozenInBox.Distinct();
+					foreach (var kvp in bins[j * cols + i])
+					{
+						var actor = kvp.Key;
+						if (actor.IsValid && kvp.Value.IntersectsWith(r) && actorsChecked.Add(actor))
+							yield return actor;
+					}
 		}
 	}
 }


### PR DESCRIPTION
I basically missed this when I rewrote the other ActorsInBox methods in #5679 some time ago. Same idea - avoid building an extra list and keep the stream lazy should anybody ever only enumerate part of it.
