### PR TITLE
Speed up shroud rendering using cell changed notifications

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -182,13 +182,13 @@ namespace OpenRA.Graphics
 				var stride = bitmapData.Stride / 4;
 				var shroudObscured = world.ShroudObscuresTest(map.Cells);
 				var fogObscured = world.FogObscuresTest(map.Cells);
-				foreach (var cell in map.Cells)
+				foreach (var uv in map.Cells.MapCoords)
 				{
-					var uv = Map.CellToMap(map.TileShape, cell) - offset;
-					if (shroudObscured(cell))
-						colors[uv.Y * stride + uv.X] = shroud;
-					else if (fogObscured(cell))
-						colors[uv.Y * stride + uv.X] = fog;
+					var bitmapUv = uv - offset;
+					if (shroudObscured(uv.X, uv.Y))
+						colors[bitmapUv.Y * stride + bitmapUv.X] = shroud;
+					else if (fogObscured(uv.X, uv.Y))
+						colors[bitmapUv.Y * stride + bitmapUv.X] = fog;
 				}
 			}
 

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Drawing;
 
 namespace OpenRA.Graphics
@@ -104,6 +105,21 @@ namespace OpenRA.Graphics
 			currentSheet = s.sheet;
 			currentBlend = s.blendMode;
 			Util.FastCreateQuad(vertices, a, b, c, d, s, 0, nv);
+			nv += 4;
+		}
+
+		public void DrawSprite(Sprite s, Vertex[] sourceVertices, int offset)
+		{
+			Renderer.CurrentBatchRenderer = this;
+
+			if (s.sheet != currentSheet ||
+				s.blendMode != currentBlend ||
+				nv + 4 > Renderer.TempBufferSize)
+				Flush();
+
+			currentBlend = s.blendMode;
+			currentSheet = s.sheet;
+			Array.Copy(sourceVertices, offset, vertices, nv, 4);
 			nv += 4;
 		}
 

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -87,6 +87,11 @@ namespace OpenRA
 			return uv.X >= mapTopLeft.X && uv.X <= mapBottomRight.X && uv.Y >= mapTopLeft.Y && uv.Y <= mapBottomRight.Y;
 		}
 
+		public MapCoordsRegion MapCoords
+		{
+			get { return new MapCoordsRegion(this); }
+		}
+
 		public CellRegionEnumerator GetEnumerator()
 		{
 			return new CellRegionEnumerator(this);
@@ -102,7 +107,7 @@ namespace OpenRA
 			return GetEnumerator();
 		}
 
-		public class CellRegionEnumerator : IEnumerator<CPos>
+		public sealed class CellRegionEnumerator : IEnumerator<CPos>
 		{
 			readonly CellRegion r;
 
@@ -147,6 +152,73 @@ namespace OpenRA
 			public CPos Current { get { return current; } }
 			object IEnumerator.Current { get { return Current; } }
 			public void Dispose() { }
+		}
+
+		public struct MapCoordsRegion : IEnumerable<CPos>
+		{
+			public struct MapCoordsEnumerator : IEnumerator<CPos>
+			{
+				readonly CellRegion r;
+				CPos current;
+
+				public MapCoordsEnumerator(CellRegion region)
+					: this()
+				{
+					r = region;
+					Reset();
+				}
+
+				public bool MoveNext()
+				{
+					var u = current.X + 1;
+					var v = current.Y;
+
+					// Check for column overflow
+					if (u > r.mapBottomRight.X)
+					{
+						v += 1;
+						u = r.mapTopLeft.X;
+
+						// Check for row overflow
+						if (v > r.mapBottomRight.Y)
+							return false;
+					}
+
+					current = new CPos(u, v);
+					return true;
+				}
+
+				public void Reset()
+				{
+					current = new CPos(r.mapTopLeft.X - 1, r.mapTopLeft.Y);
+				}
+
+				public CPos Current { get { return current; } }
+				object IEnumerator.Current { get { return Current; } }
+				public void Dispose() { }
+			}
+
+			readonly CellRegion r;
+
+			public MapCoordsRegion(CellRegion region)
+			{
+				r = region;
+			}
+
+			public MapCoordsEnumerator GetEnumerator()
+			{
+				return new MapCoordsEnumerator(r);
+			}
+
+			IEnumerator<CPos> IEnumerable<CPos>.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
 		}
 	}
 }

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -342,8 +342,8 @@ namespace OpenRA
 			Cells = new CellRegion(TileShape, tl, br);
 
 			CustomTerrain = new CellLayer<byte>(this);
-			foreach (var cell in Cells)
-				CustomTerrain[cell] = byte.MaxValue;
+			foreach (var uv in Cells.MapCoords)
+				CustomTerrain[uv.X, uv.Y] = byte.MaxValue;
 		}
 
 		public Ruleset PreloadRules()
@@ -572,7 +572,12 @@ namespace OpenRA
 		public bool Contains(CPos cell)
 		{
 			var uv = CellToMap(TileShape, cell);
-			return Bounds.Contains(uv.X, uv.Y);
+			return Contains(uv.X, uv.Y);
+		}
+
+		public bool Contains(int u, int v)
+		{
+			return Bounds.Contains(u, v);
 		}
 
 		public WPos CenterOfCell(CPos cell)
@@ -770,8 +775,11 @@ namespace OpenRA
 
 		public byte GetTerrainIndex(CPos cell)
 		{
-			var custom = CustomTerrain[cell];
-			return custom != byte.MaxValue ? custom : cachedTileSet.Value.GetTerrainIndex(MapTiles.Value[cell]);
+			var uv = Map.CellToMap(TileShape, cell);
+			var u = uv.X;
+			var v = uv.Y;
+			var custom = CustomTerrain[u, v];
+			return custom != byte.MaxValue ? custom : cachedTileSet.Value.GetTerrainIndex(MapTiles.Value[u, v]);
 		}
 
 		public TerrainTypeInfo GetTerrainInfo(CPos cell)

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(c => world.ShroudObscures(c)))
+					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.FootprintInMapCoords.All(c => world.ShroudObscures(c)))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}
@@ -74,7 +74,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(c => world.ShroudObscures(c)))
+					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.FootprintInMapCoords.All(c => world.ShroudObscures(c)))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -57,12 +57,12 @@ namespace OpenRA.Traits
 
 		public int Hash { get; private set; }
 
-		static readonly Func<CPos, bool> TruthPredicate = cell => true;
-		readonly Func<CPos, bool> shroudEdgeTest;
-		readonly Func<CPos, bool> fastExploredTest;
-		readonly Func<CPos, bool> slowExploredTest;
-		readonly Func<CPos, bool> fastVisibleTest;
-		readonly Func<CPos, bool> slowVisibleTest;
+		static readonly Func<int, int, bool> TruthPredicate = (u, v) => true;
+		readonly Func<int, int, bool> shroudEdgeTest;
+		readonly Func<int, int, bool> fastExploredTest;
+		readonly Func<int, int, bool> slowExploredTest;
+		readonly Func<int, int, bool> fastVisibleTest;
+		readonly Func<int, int, bool> slowVisibleTest;
 
 		public Shroud(Actor self)
 		{
@@ -81,7 +81,7 @@ namespace OpenRA.Traits
 
 			fogVisibilities = Exts.Lazy(() => self.TraitsImplementing<IFogVisibilityModifier>().ToArray());
 
-			shroudEdgeTest = cell => map.Contains(cell);
+			shroudEdgeTest = (u, v) => map.Contains(u, v);
 			fastExploredTest = IsExploredCore;
 			slowExploredTest = IsExplored;
 			fastVisibleTest = IsVisibleCore;
@@ -232,49 +232,54 @@ namespace OpenRA.Traits
 			if (map.Bounds != s.map.Bounds)
 				throw new ArgumentException("The map bounds of these shrouds do not match.", "s");
 
-			foreach (var cell in map.Cells)
-				if (s.explored[cell])
-					explored[cell] = true;
+			foreach (var uv in map.Cells.MapCoords)
+				if (s.explored[uv.X, uv.Y])
+					explored[uv.X, uv.Y] = true;
 
 			Invalidate();
 		}
 
 		public void ExploreAll(World world)
 		{
-			foreach (var cell in map.Cells)
-				explored[cell] = true;
+			foreach (var uv in map.Cells.MapCoords)
+				explored[uv.X, uv.Y] = true;
 
 			Invalidate();
 		}
 
 		public void ResetExploration()
 		{
-			foreach (var cell in map.Cells)
-				explored[cell] = visibleCount[cell] > 0;
+			foreach (var uv in map.Cells.MapCoords)
+				explored[uv.X, uv.Y] = visibleCount[uv.X, uv.Y] > 0;
 
 			Invalidate();
 		}
 
 		public bool IsExplored(CPos cell)
 		{
-			if (!map.Contains(cell))
+			var uv = Map.CellToMap(map.TileShape, cell);
+			return IsExplored(uv.X, uv.Y);
+		}
+
+		bool IsExplored(int u, int v)
+		{
+			if (!map.Contains(u, v))
 				return false;
 
 			if (!ShroudEnabled)
 				return true;
 
-			return IsExploredCore(cell);
+			return IsExploredCore(u, v);
 		}
 
 		bool ShroudEnabled { get { return !Disabled && self.World.LobbyInfo.GlobalSettings.Shroud; } }
 
-		bool IsExploredCore(CPos cell)
+		bool IsExploredCore(int u, int v)
 		{
-			var uv = Map.CellToMap(map.TileShape, cell);
-			return explored[uv.X, uv.Y] && (generatedShroudCount[uv.X, uv.Y] == 0 || visibleCount[uv.X, uv.Y] > 0);
+			return explored[u, v] && (generatedShroudCount[u, v] == 0 || visibleCount[u, v] > 0);
 		}
 
-		public Func<CPos, bool> IsExploredTest(CellRegion region)
+		public Func<int, int, bool> IsExploredTest(CellRegion region)
 		{
 			// If the region to test extends outside the map we must use the slow test that checks the map boundary every time.
 			if (!map.Cells.Contains(region))
@@ -295,23 +300,29 @@ namespace OpenRA.Traits
 
 		public bool IsVisible(CPos cell)
 		{
-			if (!map.Contains(cell))
+			var uv = Map.CellToMap(map.TileShape, cell);
+			return IsVisible(uv.X, uv.Y);
+		}
+
+		bool IsVisible(int u, int v)
+		{
+			if (!map.Contains(u, v))
 				return false;
 
 			if (!FogEnabled)
 				return true;
 
-			return IsVisibleCore(cell);
+			return IsVisibleCore(u, v);
 		}
 
 		bool FogEnabled { get { return !Disabled && self.World.LobbyInfo.GlobalSettings.Fog; } }
 
-		bool IsVisibleCore(CPos cell)
+		bool IsVisibleCore(int u, int v)
 		{
-			return visibleCount[cell] > 0;
+			return visibleCount[u, v] > 0;
 		}
 
-		public Func<CPos, bool> IsVisibleTest(CellRegion region)
+		public Func<int, int, bool> IsVisibleTest(CellRegion region)
 		{
 			// If the region to test extends outside the map we must use the slow test that checks the map boundary every time.
 			if (!map.Cells.Contains(region))

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -24,7 +24,7 @@ namespace OpenRA
 {
 	public class World
 	{
-		static readonly Func<CPos, bool> FalsePredicate = cell => false;
+		static readonly Func<int, int, bool> FalsePredicate = (u, v) => false;
 		internal readonly TraitDictionary traitDict = new TraitDictionary();
 		readonly HashSet<Actor> actors = new HashSet<Actor>();
 		readonly List<IEffect> effects = new List<IEffect>();
@@ -66,22 +66,22 @@ namespace OpenRA
 		public bool ShroudObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(a); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
 		
-		public Func<CPos, bool> FogObscuresTest(CellRegion region)
+		public Func<int, int, bool> FogObscuresTest(CellRegion region)
 		{
 			var rp = RenderPlayer;
 			if (rp == null)
 				return FalsePredicate;
 			var predicate = rp.Shroud.IsVisibleTest(region);
-			return cell => !predicate(cell);
+			return (u, v) => !predicate(u, v);
 		}
 
-		public Func<CPos, bool> ShroudObscuresTest(CellRegion region)
+		public Func<int, int, bool> ShroudObscuresTest(CellRegion region)
 		{
 			var rp = RenderPlayer;
 			if (rp == null)
 				return FalsePredicate;
 			var predicate = rp.Shroud.IsExploredTest(region);
-			return cell => !predicate(cell);
+			return (u, v) => !predicate(u, v);
 		}
 
 		public bool IsReplay

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -81,13 +81,13 @@ namespace OpenRA.Mods.Common.Traits
 			var rightDelta = ts == TileShape.Diamond ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
 			var bottomDelta = ts == TileShape.Diamond ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
 
-			foreach (var cell in wr.Viewport.VisibleCells)
+			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
 				var lr = Game.Renderer.WorldLineRenderer;
-				var pos = wr.world.Map.CenterOfCell(cell);
+				var pos = wr.world.Map.CenterOfCell(Map.MapToCell(wr.world.Map.TileShape, uv));
 
-				var height = (int)wr.world.Map.MapHeight.Value[cell];
-				var tile = wr.world.Map.MapTiles.Value[cell];
+				var height = (int)wr.world.Map.MapHeight.Value[uv.X, uv.Y];
+				var tile = wr.world.Map.MapTiles.Value[uv.X, uv.Y];
 
 				TerrainTileInfo tileInfo = null;
 

--- a/OpenRA.Mods.RA/Move/PathSearch.cs
+++ b/OpenRA.Mods.RA/Move/PathSearch.cs
@@ -332,8 +332,8 @@ namespace OpenRA.Mods.RA.Move
 					defaultCellInfoLayer.Shape != map.TileShape)
 				{
 					defaultCellInfoLayer = new CellLayer<CellInfo>(map);
-					foreach (var cell in map.Cells)
-						defaultCellInfoLayer[cell] = new CellInfo(int.MaxValue, cell, false);
+					foreach (var uv in map.Cells.MapCoords)
+						defaultCellInfoLayer[uv.X, uv.Y] = new CellInfo(int.MaxValue, Map.MapToCell(map.TileShape, uv), false);
 				}
 
 				result.CopyValuesFrom(defaultCellInfoLayer);

--- a/OpenRA.Mods.RA/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.RA/Traits/World/ResourceLayer.cs
@@ -35,14 +35,14 @@ namespace OpenRA.Mods.RA.Traits
 		public void Render(WorldRenderer wr)
 		{
 			var shroudObscured = world.ShroudObscuresTest(wr.Viewport.VisibleCells);
-			foreach (var cell in wr.Viewport.VisibleCells)
+			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
-				if (shroudObscured(cell))
+				if (shroudObscured(uv.X, uv.Y))
 					continue;
 
-				var c = render[cell];
+				var c = render[uv.X, uv.Y];
 				if (c.Sprite != null)
-					new SpriteRenderable(c.Sprite, wr.world.Map.CenterOfCell(cell),
+					new SpriteRenderable(c.Sprite, wr.world.Map.CenterOfCell(Map.MapToCell(world.Map.TileShape, uv)),
 						WVec.Zero, -511, c.Type.Palette, 1f, true).Render(wr); // TODO ZOffset is ignored
 			}
 		}


### PR DESCRIPTION
Using the CellEntryChanged event introduced in #7057, this PR utilises it in the ShroudRenderer in order to track changes in the shroud, and prevent repeated work.

By keeping a cache of pre-calculated vertices for the shroud, they do not need to be recalculated every single frame vastly reducing the work required. In testing I saw CPU time used by the RenderShroud method drop from 27% to 14%.

(Here's hoping I haven't screwed this up somehow!)

Depends on #7071.
