### PR TITLE
Cleaned up Server class

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -348,7 +348,7 @@ namespace OpenRA
 					{
 						Thread.Sleep(100);
 
-						if (server.State == Server.ServerState.GameStarted && server.Conns.Count < 1)
+						if (server.State == Server.ServerState.GameStarted && server.IsEmpty)
 						{
 							Console.WriteLine("No one is playing, shutting down...");
 							server.Shutdown();

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Server
 
 						case ReceiveState.Data:
 							{
-								server.DispatchOrders(this, Frame, bytes);
+								server.ProcessOrders(this, Frame, bytes);
 								MostRecentFrame = Frame;
 								ExpectLength = 8;
 								State = ReceiveState.Header;

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Common.Server
 							}
 							else
 							{
-								var occupantConn = server.Conns.FirstOrDefault(c => c.PlayerIndex == occupant.Index);
+								var occupantConn = server.Connections.FirstOrDefault(c => c.PlayerIndex == occupant.Index);
 								if (occupantConn != null)
 								{
 									server.SendOrderTo(occupantConn, "ServerError", "Your slot was closed by the host.");
@@ -684,7 +684,7 @@ namespace OpenRA.Mods.Common.Server
 						int kickClientID;
 						Exts.TryParseIntegerInvariant(split[0], out kickClientID);
 
-						var kickConn = server.Conns.SingleOrDefault(c => server.GetClient(c) != null && server.GetClient(c).Index == kickClientID);
+						var kickConn = server.Connections.SingleOrDefault(c => server.GetClient(c) != null && server.GetClient(c).Index == kickClientID);
 						if (kickConn == null)
 						{
 							server.SendOrderTo(conn, "Message", "Noone in that slot.");

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -37,11 +37,11 @@ namespace OpenRA.Mods.Common.Server
 
 				// Ignore client timeout in singleplayer games to make debugging easier
 				if (server.LobbyInfo.IsSinglePlayer && !server.Settings.Dedicated)
-					foreach (var c in server.Conns.ToList())
+					foreach (var c in server.Connections)
 						server.SendOrderTo(c, "Ping", Game.RunTime.ToString());
 				else
 				{
-					foreach (var c in server.Conns.ToList())
+					foreach (var c in server.Connections)
 					{
 						if (c == null || c.Socket == null)
 							continue;
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Server
 					{
 						lastConnReport = Game.RunTime;
 
-						var timeouts = server.Conns
+						var timeouts = server.Connections
 							.Where(c => c.TimeSinceLastResponse > ConnReportInterval && c.TimeSinceLastResponse < ConnTimeout)
 							.OrderBy(c => c.TimeSinceLastResponse);
 


### PR DESCRIPTION
In a step towards network data compression, server class needed some cleaning since it hasn't been touched since forever.

Now organized with regions. All those many vague DispatchOrders have been reduced to one method so it's a lot clearer. Added readonly to appropriate fields, removed public access to others, fixed some style issues. Removed the "volatile" field that isn't necessary for an enum (which is an atomic type...and said field is not even set from the server thread)
