### PR TITLE
Move Upgrades and Prerequisites from Mods.RA to Mods.Common

### DIFF
--- a/OpenRA.Mods.Common/CommonTraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/CommonTraitsInterfaces.cs
@@ -37,4 +37,17 @@ namespace OpenRA.Mods.Common
 		void MovementCancelled(Actor self);
 		void Harvested(Actor self, ResourceType resource);
 	}
+
+	public interface ITechTreePrerequisite
+	{
+		IEnumerable<string> ProvidesPrerequisites { get; }
+	}
+
+	public interface ITechTreeElement
+	{
+		void PrerequisitesAvailable (string key);
+		void PrerequisitesUnavailable (string key);
+		void PrerequisitesItemHidden (string key);
+		void PrerequisitesItemVisible (string key);
+	}
 }

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -108,11 +108,13 @@
     <Compile Include="Scripting\Properties\ResourceProperties.cs" />
     <Compile Include="Scripting\Properties\UpgradeProperties.cs" />
     <Compile Include="Traits\BlocksBullets.cs" />
+    <Compile Include="Traits\Buildable.cs" />
     <Compile Include="Traits\Buildings\DeadBuildingState.cs" />
     <Compile Include="Traits\Burns.cs" />
     <Compile Include="Traits\CustomBuildTimeValue.cs" />
     <Compile Include="Traits\CustomSellValue.cs" />
     <Compile Include="Traits\Demolishable.cs" />
+    <Compile Include="Traits\GlobalUpgradable.cs" />
     <Compile Include="Traits\Immobile.cs" />
     <Compile Include="Traits\JamsMissiles.cs" />
     <Compile Include="Traits\Modifiers\DisabledOverlay.cs" />
@@ -123,6 +125,10 @@
     <Compile Include="Traits\PaletteEffects\MenuPaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\NukePaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\WaterPaletteRotation.cs" />
+    <Compile Include="Traits\Player\GlobalUpgradeManager.cs" />
+    <Compile Include="Traits\Player\ProvidesCustomPrerequisite.cs" />
+    <Compile Include="Traits\Player\ProvidesTechPrerequisite.cs" />
+    <Compile Include="Traits\Player\TechTree.cs" />
     <Compile Include="Traits\Power\AffectedByPowerOutage.cs" />
     <Compile Include="Traits\Power\CanPowerDown.cs" />
     <Compile Include="Traits\Power\Player\PowerManager.cs" />

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -10,7 +10,7 @@
 
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	public class BuildableInfo : TraitInfo<Buildable>
 	{

--- a/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
+++ b/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
@@ -8,14 +8,10 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using OpenRA.Mods.Common;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	public class GlobalUpgradableInfo : ITraitInfo, Requires<UpgradeManagerInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/Player/GlobalUpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GlobalUpgradeManager.cs
@@ -8,14 +8,12 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
 	public class GlobalUpgradeManagerInfo : ITraitInfo, Requires<TechTreeInfo>

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesCustomPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesCustomPrerequisite.cs
@@ -13,7 +13,7 @@ using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	public class ProvidesCustomPrerequisiteInfo : ITraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -11,7 +11,7 @@
 using System.Collections.Generic;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	public class ProvidesTechPrerequisiteInfo : ITraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -13,7 +13,7 @@ using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Manages build limits and pre-requisites.", " Attach this to the player actor.")]
 	public class TechTreeInfo : ITraitInfo

--- a/OpenRA.Mods.RA/Activities/Transform.cs
+++ b/OpenRA.Mods.RA/Activities/Transform.cs
@@ -10,6 +10,7 @@
 
 using System.Linq;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/CrateAction.cs
+++ b/OpenRA.Mods.RA/CrateAction.cs
@@ -10,6 +10,7 @@
 
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.RA/Lint/LintBuildablePrerequisites.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Linq;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -154,7 +154,6 @@
     <Compile Include="Attack\AttackWander.cs" />
     <Compile Include="AutoHeal.cs" />
     <Compile Include="AutoTarget.cs" />
-    <Compile Include="Buildable.cs" />
     <Compile Include="CaptureNotification.cs" />
     <Compile Include="Buildings\Building.cs" />
     <Compile Include="Buildings\BuildingInfluence.cs" />
@@ -223,12 +222,10 @@
     <Compile Include="Player\ClassicProductionQueue.cs" />
     <Compile Include="Player\PlaceBuilding.cs" />
     <Compile Include="Player\ProductionQueue.cs" />
-    <Compile Include="Player\ProvidesTechPrerequisite.cs" />
     <Compile Include="Player\MissionObjectives.cs" />
     <Compile Include="PortableChrono.cs" />
     <Compile Include="Scripting\Properties\GuardProperties.cs" />
     <Compile Include="Widgets\Logic\TabCompletionLogic.cs" />
-    <Compile Include="Player\TechTree.cs" />
     <Compile Include="Production.cs" />
     <Compile Include="ProductionBar.cs" />
     <Compile Include="ProximityCaptor.cs" />
@@ -402,7 +399,6 @@
     <Compile Include="Render\WithRepairOverlay.cs" />
     <Compile Include="Activities\MoveWithinRange.cs" />
     <Compile Include="Lint\CheckPlayers.cs" />
-    <Compile Include="Player\ProvidesCustomPrerequisite.cs" />
     <Compile Include="Lint\CheckActors.cs" />
     <Compile Include="Lint\CheckMapCordon.cs" />
     <Compile Include="Parachutable.cs" />
@@ -428,8 +424,6 @@
     <Compile Include="Widgets\Logic\SupportPowerBinLogic.cs" />
     <Compile Include="Widgets\Logic\DebugMenuLogic.cs" />
     <Compile Include="ProductionQueueFromSelection.cs" />
-    <Compile Include="GlobalUpgradable.cs" />
-    <Compile Include="Player\GlobalUpgradeManager.cs" />
     <Compile Include="GainsStatUpgrades.cs" />
     <Compile Include="Player\Extensions.cs" />
     <Compile Include="Warheads\CreateResourceWarhead.cs" />

--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Power;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.RA/Player/PlaceBuilding.cs
@@ -10,6 +10,7 @@
 
 using System.Linq;
 using OpenRA.Effects;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Power;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -12,6 +12,7 @@ using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Move;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.RA/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ProductionProperties.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Scripting;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Scripting;

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Traits/LeavesHusk.cs
+++ b/OpenRA.Mods.RA/Traits/LeavesHusk.cs
@@ -10,6 +10,7 @@
 
 using System.Linq;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Move;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/TraitsInterfaces.cs
+++ b/OpenRA.Mods.RA/TraitsInterfaces.cs
@@ -29,19 +29,6 @@ namespace OpenRA.Mods.RA
 		void OnDock(Actor self, Actor harv, DeliverResources dockOrder);
 	}
 
-	public interface ITechTreeElement
-	{
-		void PrerequisitesAvailable(string key);
-		void PrerequisitesUnavailable(string key);
-		void PrerequisitesItemHidden(string key);
-		void PrerequisitesItemVisible(string key);
-	}
-
-	public interface ITechTreePrerequisite
-	{
-		IEnumerable<string> ProvidesPrerequisites {get;}
-	}
-
 	public interface INotifyParachuteLanded { void OnLanded(); }
 	public interface INotifyTransform { void BeforeTransform(Actor self); void OnTransform(Actor self); void AfterTransform(Actor toActor); }
 	public interface INotifyAttack { void Attacking(Actor self, Target target, Armament a, Barrel barrel); }

--- a/OpenRA.Mods.RA/Transforms.cs
+++ b/OpenRA.Mods.RA/Transforms.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 using OpenRA.Mods.RA.Render;
 using OpenRA.Mods.RA.Buildings;

--- a/OpenRA.Mods.RA/UtilityCommands/ActorStatsExport.cs
+++ b/OpenRA.Mods.RA/UtilityCommands/ActorStatsExport.cs
@@ -14,6 +14,7 @@ using System.Data;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.UtilityCommands

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Threading;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Widgets;
 using OpenRA.Network;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Widgets/Logic/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ProductionTooltipLogic.cs
@@ -13,6 +13,7 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Power;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 


### PR DESCRIPTION
Moved two interfaces from `Mods.RA.TraitInterfaces.cs` to `Mods.RA.CommonTraitInterfaces.cs`:
- ITechTreePrerequisite
- ITechTreeElement

Moved six classes from Mods.RA to Mods.Common:
- Buildable
- ProvidesTechPrerequisite
- ProvidesCustomPrerequisite
- GlobalUpgradable
- GlobalUpgradeManager
- TechTree

Note: I noticed a folder called "Upgrades" in Mods.Common, containing an `UpgradeManager`. Should I be using that folder for the upgrades, or move them to locations corresponding to their current ones (as I did)?
