### PR TITLE
Cache the initial path layer for faster path search startups.

### DIFF
--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -34,6 +34,17 @@ namespace OpenRA
 			entries = new T[size.Width * size.Height];
 		}
 
+		public void CopyValuesFrom(CellLayer<T> anotherLayer)
+		{
+			if (Size != anotherLayer.Size || Shape != anotherLayer.Shape)
+				throw new ArgumentException(
+					"layers must have a matching size and shape.", "anotherLayer");
+			if (CellEntryChanged != null)
+				throw new InvalidOperationException(
+					"Cannot copy values when there are listeners attached to the CellEntryChanged event.");
+			Array.Copy(anotherLayer.entries, entries, entries.Length);
+		}
+
 		// Resolve an array index from cell coordinates
 		int Index(CPos cell)
 		{


### PR DESCRIPTION
Reinitializing the initial cell info layer for the path search took a fair bit of time. We cache this initial setup so it only has to be done each time the map size changes. A CopyValuesFrom method in CellLayer is provided which copies values between layers by just copying the internal arrays for speed.

On the RA shellmap, this reduces CPU time spent in InitCellInfo from 3.4% overall to 0.3% overall.
