### PR TITLE
Bogus yaml checking

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -38,7 +38,7 @@ namespace OpenRA
 				Name = name;
 				foreach (var t in mergedNode)
 					if (t.Key != "Inherits" && !t.Key.StartsWith("-"))
-						Traits.Add(LoadTraitInfo(t.Key.Split('@')[0], t.Value));
+						Traits.Add(LoadTraitInfo(Name, t.Key.Split('@')[0], t.Value));
 			}
 			catch (YamlException e)
 			{
@@ -76,13 +76,15 @@ namespace OpenRA
 			return node;
 		}
 
-		static ITraitInfo LoadTraitInfo(string traitName, MiniYaml my)
+		static ITraitInfo LoadTraitInfo(string actorName, string traitName, MiniYaml my)
 		{
 			if (!string.IsNullOrEmpty(my.Value))
 				throw new YamlException("Junk value `{0}` on trait node {1}"
 				.F(my.Value, traitName));
 			var info = Game.CreateObject<ITraitInfo>(traitName + "Info");
 			FieldLoader.Load(info, my);
+			if (info is ICheckBogusYaml)
+				((ICheckBogusYaml)info).CheckBogusYaml(actorName, traitName);
 			return info;
 		}
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -234,6 +234,7 @@ namespace OpenRA.Traits
 		bool CrushableBy(string[] crushClasses, Player owner);
 	}
 
+	public interface ICheckBogusYaml { void CheckBogusYaml(string actorName, string traitName); }
 	public interface ITraitInfo { object Create(ActorInitializer init); }
 
 	public class TraitInfo<T> : ITraitInfo where T : new() { public virtual object Create(ActorInitializer init) { return new T(); } }

--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Sounds to play when killed.")]
-	public class DeathSoundsInfo : ITraitInfo
+	public class DeathSoundsInfo : ITraitInfo, ICheckBogusYaml
 	{
 		[Desc("Death notification voice.")]
 		public readonly string DeathSound = "Die";
@@ -26,6 +26,12 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string[] DeathTypes = { };
 
 		public object Create(ActorInitializer init) { return new DeathSounds(this); }
+
+		public void CheckBogusYaml(string actorName, string traitName)
+		{
+			if (VolumeMultiplier < 0)
+				throw new YamlException("{0}.{1}.VolumeMultiplier is negative.".F(actorName, traitName));
+		}
 	}
 
 	public class DeathSounds : INotifyKilled

--- a/OpenRA.Mods.Common/Traits/World/RadarPings.cs
+++ b/OpenRA.Mods.Common/Traits/World/RadarPings.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RadarPingsInfo : ITraitInfo
+	public class RadarPingsInfo : ITraitInfo, ICheckBogusYaml
 	{
 		public readonly int FromRadius = 200;
 		public readonly int ToRadius = 15;
@@ -23,6 +23,14 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly float RotationSpeed = 0.12f;
 
 		public object Create(ActorInitializer init) { return new RadarPings(this); }
+
+		public void CheckBogusYaml(string actorName, string traitName)
+		{
+			if (FromRadius < ToRadius)
+				throw new YamlException("{0}.{1}.FromRadius is smaller than {0}.{1}.ToRadius".F(actorName, traitName));
+			if (ShrinkSpeed < 0)
+				throw new YamlException("{0}.{1} ShrinkSpeed is negative".F(actorName, traitName));
+		}
 	}
 
 	public class RadarPings : ITick

--- a/OpenRA.Mods.RA/Traits/Harvester.cs
+++ b/OpenRA.Mods.RA/Traits/Harvester.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	public class HarvesterInfo : ITraitInfo
+	public class HarvesterInfo : ITraitInfo, ICheckBogusYaml
 	{
 		public readonly string[] DeliveryBuildings = { };
 		[Desc("How much resources it can carry.")]
@@ -41,6 +41,20 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly int SearchFromOrderRadius = 12;
 
 		public object Create(ActorInitializer init) { return new Harvester(init.self, this); }
+
+		public void CheckBogusYaml(string actorName, string traitName)
+		{
+			if (Capacity < 0)
+				throw new YamlException("{0}.{1}.Capacity is negative".F(actorName, traitName));
+			if (Resources.Count() < 0)
+				throw new YamlException("{0}.{1}.Resources is Empty".F(actorName, traitName));
+			if (SearchFromOrderRadius < 0)
+				throw new YamlException("{0}.{1}.SearchFromOrderRadius is negative".F(actorName, traitName));
+			if (SearchFromProcRadius < 0)
+				throw new YamlException("{0}.{1}.SearchFromProcRadius is negative".F(actorName, traitName));
+			if (FullyLoadedSpeed < 0)
+				throw new YamlException("{0}.{1}.FullyLoadedSpeed is negative".F(actorName, traitName));
+		}
 	}
 
 	public class Harvester : IIssueOrder, IResolveOrder, IPips,


### PR DESCRIPTION
Allows classes that implement ITraitInfo to specify a method that is called after the Info class has been made and checks for some TraitSpecific stuff like if two arrays should be the same size.
