### PR TITLE
Disallowed bots on Hopes Anchor

### DIFF
--- a/mods/ra/maps/koth-hopes-anchor/map.yaml
+++ b/mods/ra/maps/koth-hopes-anchor/map.yaml
@@ -33,41 +33,49 @@ Players:
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Multi1:
 		Name: Multi1
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Multi2:
 		Name: Multi2
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Multi3:
 		Name: Multi3
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Multi4:
 		Name: Multi4
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Multi5:
 		Name: Multi5
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Multi6:
 		Name: Multi6
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Multi7:
 		Name: Multi7
 		Playable: True
 		Race: Random
 		Enemies: Creeps
+		AllowBots: False
 	PlayerReference@Creeps:
 		Name: Creeps
 		NonCombatant: True


### PR DESCRIPTION
They don't understand the KotH rules and island maps which also causes a lot of pathfinder performance problems. https://www.youtube.com/watch?v=GXV8obgVTPI
