### PR TITLE
Move more files away from OpenRA.Mods.RA

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/HarvesterDockSequence.cs
@@ -10,13 +10,13 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Move;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc
+namespace OpenRA.Mods.Cnc.Activities
 {
 	public class HarvesterDockSequence : Activity
 	{

--- a/OpenRA.Mods.Cnc/Traits/Buildings/TiberiumRefinery.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/TiberiumRefinery.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
@@ -11,9 +11,10 @@
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.RA;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.Cnc.Traits
 {
 	class RenderGunboatInfo : RenderSpritesInfo, IQuantizeBodyOrientationInfo, Requires<IBodyOrientationInfo>
 	{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
@@ -8,9 +8,10 @@
  */
 #endregion
 
+using OpenRA.Mods.RA.Render;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Building animation to play when ProductionAirdrop is used to deliver units.")]
 	public class WithDeliveryAnimationInfo : ITraitInfo, Requires<RenderBuildingInfo>

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Move
+namespace OpenRA.Mods.Common.Activities
 {
 	public class Drag : Activity
 	{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -48,6 +48,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Activities\Move\Drag.cs" />
     <Compile Include="CommonTraitsInterfaces.cs" />
     <Compile Include="Effects\Beacon.cs" />
     <Compile Include="Effects\Bullet.cs" />
@@ -107,6 +108,7 @@
     <Compile Include="Scripting\Properties\UpgradeProperties.cs" />
     <Compile Include="Traits\BlocksBullets.cs" />
     <Compile Include="Traits\Buildable.cs" />
+    <Compile Include="Traits\Buildings\BaseProvider.cs" />
     <Compile Include="Traits\Buildings\DeadBuildingState.cs" />
     <Compile Include="Traits\Buildings\RallyPoint.cs" />
     <Compile Include="Traits\Burns.cs" />
@@ -114,6 +116,7 @@
     <Compile Include="Traits\CustomSellValue.cs" />
     <Compile Include="Traits\Demolishable.cs" />
     <Compile Include="Traits\GlobalUpgradable.cs" />
+    <Compile Include="Traits\Husk.cs" />
     <Compile Include="Traits\Immobile.cs" />
     <Compile Include="Traits\JamsMissiles.cs" />
     <Compile Include="Traits\KillsSelf.cs" />
@@ -125,7 +128,9 @@
     <Compile Include="Traits\PaletteEffects\MenuPaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\NukePaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\WaterPaletteRotation.cs" />
+    <Compile Include="Traits\Player\ActorGroupProxy.cs" />
     <Compile Include="Traits\Player\GlobalUpgradeManager.cs" />
+    <Compile Include="Traits\Player\PlaceBeacon.cs" />
     <Compile Include="Traits\Player\ProvidesCustomPrerequisite.cs" />
     <Compile Include="Traits\Player\ProvidesTechPrerequisite.cs" />
     <Compile Include="Traits\Player\TechTree.cs" />

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -14,7 +14,7 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Buildings
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Limits the zone where buildings can be constructed to a radius around this actor.")]
 	public class BaseProviderInfo : ITraitInfo

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -10,14 +10,14 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.RA.Move;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Spawns remains of a husk actor with the correct facing.")]
-	class HuskInfo : ITraitInfo, IOccupySpaceInfo, IFacingInfo
+	public class HuskInfo : IOccupySpaceInfo, IFacingInfo
 	{
 		public readonly string[] AllowedTerrain = { };
 
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Traits
 		public int GetInitialFacing() { return 128; }
 	}
 
-	class Husk : IPositionable, IFacing, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, IDisable
+	public class Husk : IPositionable, IFacing, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, IDisable
 	{
 		readonly HuskInfo info;
 		readonly Actor self;

--- a/OpenRA.Mods.Common/Traits/Player/ActorGroupProxy.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ActorGroupProxy.cs
@@ -12,7 +12,7 @@ using System.Globalization;
 using System.Linq;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Part of the unfinished group-movement system. Attach this to the player actor.")]
 	class ActorGroupProxyInfo : TraitInfo<ActorGroupProxy> { }

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -8,11 +8,10 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	public class PlaceBeaconInfo : ITraitInfo
 	{

--- a/OpenRA.Mods.RA/AI/Squad.cs
+++ b/OpenRA.Mods.RA/AI/Squad.cs
@@ -10,8 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.RA;
-using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Support;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Move/Mobile.cs
+++ b/OpenRA.Mods.RA/Move/Mobile.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Activities\Wait.cs" />
     <Compile Include="ActorExts.cs" />
     <Compile Include="AI\SupportPowerDecision.cs" />
+    <Compile Include="Attack\AttackTurreted.cs" />
     <Compile Include="Crates\DuplicateUnitCrateAction.cs" />
     <Compile Include="Crushable.cs" />
     <Compile Include="Effects\GpsSatellite.cs" />
@@ -137,7 +138,6 @@
     <Compile Include="TeslaZapRenderable.cs" />
     <Compile Include="GainsExperience.cs" />
     <Compile Include="Infiltration\InfiltrateForPowerOutage.cs" />
-    <Compile Include="Player\PlaceBeacon.cs" />
     <Compile Include="EjectOnDeath.cs" />
     <Compile Include="AI\RushFuzzy.cs" />
     <Compile Include="AI\StateMachine.cs" />
@@ -151,7 +151,6 @@
     <Compile Include="Attack\AttackOmni.cs" />
     <Compile Include="Attack\AttackPopupTurreted.cs" />
     <Compile Include="Attack\AttackCharge.cs" />
-    <Compile Include="Attack\AttackTurreted.cs" />
     <Compile Include="Attack\AttackWander.cs" />
     <Compile Include="AutoHeal.cs" />
     <Compile Include="AutoTarget.cs" />
@@ -207,7 +206,6 @@
     <Compile Include="MadTank.cs" />
     <Compile Include="Mine.cs" />
     <Compile Include="Minelayer.cs" />
-    <Compile Include="Move\Drag.cs" />
     <Compile Include="Move\Mobile.cs" />
     <Compile Include="Move\Move.cs" />
     <Compile Include="Move\PathFinder.cs" />
@@ -218,7 +216,6 @@
     <Compile Include="ParaDrop.cs" />
     <Compile Include="Passenger.cs" />
     <Compile Include="Player\PlayerStatistics.cs" />
-    <Compile Include="Player\ActorGroupProxy.cs" />
     <Compile Include="Player\AllyRepair.cs" />
     <Compile Include="Player\ClassicProductionQueue.cs" />
     <Compile Include="Player\PlaceBuilding.cs" />
@@ -226,6 +223,8 @@
     <Compile Include="Player\MissionObjectives.cs" />
     <Compile Include="PortableChrono.cs" />
     <Compile Include="Scripting\Properties\GuardProperties.cs" />
+    <Compile Include="Traits\World\DomainIndex.cs" />
+    <Compile Include="Turreted.cs" />
     <Compile Include="Widgets\Logic\TabCompletionLogic.cs" />
     <Compile Include="Production.cs" />
     <Compile Include="ProductionBar.cs" />
@@ -294,7 +293,6 @@
     <Compile Include="Traits\Cloak.cs" />
     <Compile Include="Traits\Harvester.cs" />
     <Compile Include="Traits\HarvesterHuskModifier.cs" />
-    <Compile Include="Traits\Husk.cs" />
     <Compile Include="Traits\LeavesHusk.cs" />
     <Compile Include="Traits\Modifiers\FrozenUnderFog.cs" />
     <Compile Include="Traits\RepairsBridges.cs" />
@@ -302,13 +300,11 @@
     <Compile Include="Traits\TargetableUnit.cs" />
     <Compile Include="Traits\World\BridgeLayer.cs" />
     <Compile Include="Traits\World\BuildableTerrainLayer.cs" />
-    <Compile Include="Traits\World\DomainIndex.cs" />
     <Compile Include="Traits\World\PathfinderDebugOverlay.cs" />
     <Compile Include="Traits\World\ResourceLayer.cs" />
     <Compile Include="TransformOnCapture.cs" />
     <Compile Include="TransformOnPassenger.cs" />
     <Compile Include="Transforms.cs" />
-    <Compile Include="Turreted.cs" />
     <Compile Include="Widgets\Logic\KickSpectatorsLogic.cs" />
     <Compile Include="Widgets\Logic\MissionBrowserLogic.cs" />
     <Compile Include="Widgets\Logic\IngameMenuLogic.cs" />
@@ -346,7 +342,6 @@
     <Compile Include="RenderShroudCircle.cs" />
     <Compile Include="Infiltration\Infiltrates.cs" />
     <Compile Include="Armament.cs" />
-    <Compile Include="Buildings\BaseProvider.cs" />
     <Compile Include="Widgets\Logic\ObserverShroudSelectorLogic.cs" />
     <Compile Include="Activities\RepairBridge.cs" />
     <Compile Include="Lint\CheckSequences.cs" />
@@ -354,11 +349,6 @@
     <Compile Include="Widgets\Logic\ClientTooltipLogic.cs" />
     <Compile Include="Render\WithTurret.cs" />
     <Compile Include="Render\WithBarrel.cs" />
-    <Compile Include="VoxelNormalsPalette.cs" />
-    <Compile Include="Render\RenderVoxels.cs" />
-    <Compile Include="Render\WithVoxelTurret.cs" />
-    <Compile Include="Render\WithVoxelBody.cs" />
-    <Compile Include="Render\WithVoxelBarrel.cs" />
     <Compile Include="Widgets\Logic\CreditsLogic.cs" />
     <Compile Include="Render\WithHarvestAnimation.cs" />
     <Compile Include="Widgets\Logic\SimpleTooltipLogic.cs" />

--- a/OpenRA.Mods.TS/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.TS/Activities/VoxelHarvesterDockSequence.cs
@@ -11,12 +11,11 @@
 using System;
 using System.Collections.Generic;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Move;
-using OpenRA.Mods.RA.Render;
 using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.TS.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.TS
+namespace OpenRA.Mods.TS.Activities
 {
 	public class VoxelHarvesterDockSequence : Activity
 	{

--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -58,8 +58,13 @@
     <Compile Include="Activities\VoxelHarvesterDockSequence.cs" />
     <Compile Include="SpriteLoaders\TmpTSLoader.cs" />
     <Compile Include="Traits\Buildings\TiberianSunRefinery.cs" />
+    <Compile Include="Traits\Render\RenderVoxels.cs" />
+    <Compile Include="Traits\Render\WithVoxelBarrel.cs" />
+    <Compile Include="Traits\Render\WithVoxelBody.cs" />
+    <Compile Include="Traits\Render\WithVoxelTurret.cs" />
     <Compile Include="Traits\Render\WithVoxelWalkerBody.cs" />
     <Compile Include="Traits\Render\WithVoxelUnloadBody.cs" />
+    <Compile Include="Traits\World\VoxelNormalsPalette.cs" />
     <Compile Include="Traits\World\ShroudPalette.cs" />
     <Compile Include="UtilityCommands\LegacyTilesetImporter.cs" />
   </ItemGroup>

--- a/OpenRA.Mods.TS/Traits/Buildings/TiberianSunRefinery.cs
+++ b/OpenRA.Mods.TS/Traits/Buildings/TiberianSunRefinery.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.TS.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.TS.Traits

--- a/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
@@ -15,7 +15,7 @@ using OpenRA.Mods.Common;
 using OpenRA.Traits;
 using OpenRA.Mods.Common.Graphics;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.TS.Traits
 {
 	public interface IRenderActorPreviewVoxelsInfo { IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p); }
 

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelBarrel.cs
@@ -12,9 +12,10 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.RA;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.TS.Traits
 {
 	public class WithVoxelBarrelInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<ArmamentInfo>, Requires<TurretedInfo>
 	{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelBody.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.TS.Traits
 {
 	[Desc("Also returns a default selection size that is calculated automatically from the voxel dimensions.")]
 	public class WithVoxelBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelTurret.cs
@@ -12,9 +12,10 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.RA;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.TS.Traits
 {
 	public class WithVoxelTurretInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<TurretedInfo>
 	{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.TS.Traits
 {
 	public class WithVoxelUnloadBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
 	{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
@@ -13,7 +13,7 @@ using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Render
+namespace OpenRA.Mods.TS.Traits
 {
 	public class WithVoxelWalkerBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, Requires<RenderVoxelsInfo>, Requires<IMoveInfo>
 	{

--- a/OpenRA.Mods.TS/Traits/World/VoxelNormalsPalette.cs
+++ b/OpenRA.Mods.TS/Traits/World/VoxelNormalsPalette.cs
@@ -12,7 +12,7 @@ using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.TS.Traits
 {
 	public class VoxelNormalsPaletteInfo : ITraitInfo
 	{


### PR DESCRIPTION
Basically what's in this PR:
- Moved several traits from Mods.RA to Mods.Common
- Moved several render traits from Mods.RA to Mods.TS
- Made TD and TS namespaces consistent with what was decided in #7036
- Moved the Drag activity from Mods.RA to Mods.Common

**Note** : It's getting harder and harder to stay away from the `Building` trait with every following migration PR. That thing is tied up to pretty much everything - PathFinding, Movement, Attacks, Weapons, Turrets, Renders...
Either someone has to deal with  #7035 soon, or I will have to make a very big bulk migration of **a lot** of files in the near future.
