### PR TITLE
Fix worms not releasing targets when they move deep onto rock

### DIFF
--- a/OpenRA.Mods.RA/Activities/Attack.cs
+++ b/OpenRA.Mods.RA/Activities/Attack.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.RA.Activities
 		readonly IFacing facing;
 		readonly WRange minRange;
 		readonly WRange maxRange;
+		readonly IPositionable positionable;
 
 		public Attack(Actor self, Target target, WRange minRange, WRange maxRange, bool allowMovement)
 		{
@@ -32,6 +33,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			attack = self.Trait<AttackBase>();
 			facing = self.Trait<IFacing>();
+			positionable = self.Trait<IPositionable>();
 
 			move = allowMovement ? self.TraitOrDefault<IMove>() : null;
 		}
@@ -50,6 +52,9 @@ namespace OpenRA.Mods.RA.Activities
 
 			var type = Target.Type;
 			if (!Target.IsValidFor(self) || type == TargetType.FrozenActor)
+				return NextActivity;
+			
+			if (attack.Info.AttackRequiresEnteringCell && !positionable.CanEnterCell(Target.Actor.Location, null, false))
 				return NextActivity;
 
 			// Drop the target if it moves under the shroud / fog.


### PR DESCRIPTION
Meant to fix the problem described in #7125, introduced by  #6821.
Basically the worm checked if a target is valid when:
- Searching for one
- Launching an attack against the current target

This means that if a unit reached solid ground before an attack, one of 2 things would happen:
- It will be on rock, but near the edge and inside the worm's attack range. The worm will then try to launch the attack and see that the target is no longer valid and move on.
- It will move deep within the rock "island", far from the worm's attack range. The worm would then continue its AttackMoveActivity indefinitely, causing it to not move and also ignore any other possible targets.

I added a check for target validity on each tick of the Attack activity. Now once the target is out of reach the worm should just move on and forget about it.

Note: There were several approaches proposed for fixing the issue, but I feel that:
- This is the simplest one
- It is the most consistent one with what the worm logic already uses
- It is probably the safest way to go and not have a 100 cases where the other approaches might fail
