### PR TITLE
Applys decloak to units activating a C4 demolition or infiltrate ability

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Also thanks to:
     * D2k Sardaukar
     * Daniel Derejvanik (Harisson)
     * Danny Keary (Dan9550)
+    * David Russell (DavidARussell)
     * DeadlySurprise
     * Erasmus Schroder (rasco)
     * Eric Bajumpaa (SteelPhase)

--- a/OpenRA.Mods.RA/Activities/Demolish.cs
+++ b/OpenRA.Mods.RA/Activities/Demolish.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Effects;
 using OpenRA.Traits;
+using OpenRA.Mods.RA.Traits;
 
 namespace OpenRA.Mods.RA.Activities
 {
@@ -26,6 +27,8 @@ namespace OpenRA.Mods.RA.Activities
 		readonly int flashInterval;
 		readonly int flashDuration;
 
+		readonly Cloak cloak;
+
 		public Demolish(Actor self, Actor target, int delay, int flashes, int flashesDelay, int flashInterval, int flashDuration)
 			: base(self, target)
 		{
@@ -36,6 +39,7 @@ namespace OpenRA.Mods.RA.Activities
 			this.flashesDelay = flashesDelay;
 			this.flashInterval = flashInterval;
 			this.flashDuration = flashDuration;
+			cloak = self.TraitOrDefault<Cloak>();
 		}
 
 		protected override bool CanReserve(Actor self)
@@ -49,6 +53,9 @@ namespace OpenRA.Mods.RA.Activities
 			{
 				if (target.IsDead)
 					return;
+
+				if (cloak != null && cloak.Info.UncloakOnDemolish)
+					cloak.Uncloak();
 
 				for (var f = 0; f < flashes; f++)
 					w.Add(new DelayedAction(flashesDelay + f * flashInterval, () =>

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -11,22 +11,31 @@
 using OpenRA.Activities;
 using OpenRA.Mods.RA.Buildings;
 using OpenRA.Traits;
+using OpenRA.Mods.RA.Traits;
 
 namespace OpenRA.Mods.RA.Activities
 {
 	class Infiltrate : Enter
 	{
 		readonly Actor target;
+
+		readonly Cloak cloak;
+
 		public Infiltrate(Actor self, Actor target)
 			: base(self, target)
 		{
 			this.target = target;
+
+			cloak = self.TraitOrDefault<Cloak>();
 		}
 
 		protected override void OnInside(Actor self)
 		{
 			if (target.IsDead || target.Owner == self.Owner)
 				return;
+
+			if (cloak != null && cloak.Info.UncloakOnInfiltrate)
+				cloak.Uncloak();
 
 			foreach (var t in target.TraitsImplementing<INotifyInfiltrated>())
 				t.Infiltrated(target, self);

--- a/OpenRA.Mods.RA/Traits/Cloak.cs
+++ b/OpenRA.Mods.RA/Traits/Cloak.cs
@@ -30,6 +30,8 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly bool UncloakOnAttack = true;
 		public readonly bool UncloakOnMove = false;
 		public readonly bool UncloakOnUnload = true;
+		public readonly bool UncloakOnInfiltrate = true;
+		public readonly bool UncloakOnDemolish = true;
 
 		public readonly string CloakSound = null;
 		public readonly string UncloakSound = null;


### PR DESCRIPTION
Closes #7028

Units which have a cloak and a C4/infiltrate ability will now decloak upon exiting the target building. Of course infiltration normally consumes the unit, so there will be no actual impact in that case. However infiltration was included in the original feature request, so applying the change to both allows for the possibility of a reusable infiltration unit.
