### PR TITLE
Add more resources to the D2k mod

### DIFF
--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -37,6 +37,7 @@ Rules:
 	./mods/d2k/rules/harkonnen.yaml
 	./mods/d2k/rules/ordos.yaml
 	./mods/d2k/rules/arrakis.yaml
+	./mods/d2k/rules/corrino.yaml
 
 Sequences:
 	./mods/d2k/sequences/aircraft.yaml
@@ -119,7 +120,7 @@ Translations:
 
 LoadScreen: LogoStripeLoadScreen
 	Image: ./mods/d2k/uibits/loadscreen.png
-	Text: Filling Crates..., Breeding Sandworms...
+	Text: Filling Crates..., Breeding Sandworms..., Fuelling carryalls..., Deploying harvesters..., Preparing 'thopters..., Summoning mentats...
 
 ContentInstaller:
 	MenuWidget: INSTALL_PANEL

--- a/mods/d2k/notifications.yaml
+++ b/mods/d2k/notifications.yaml
@@ -33,6 +33,7 @@ Speech:
 		BuildingCaptured: CAPT
 		WormSign: WSIGN
 		WormAttack: WATTK
+		EnemyUnitsApproaching: ENEMY
 
 Sounds:
 	DefaultVariant: .WAV

--- a/mods/d2k/rules/corrino.yaml
+++ b/mods/d2k/rules/corrino.yaml
@@ -1,0 +1,25 @@
+CONYARDC:
+	Inherits: ^CONYARD
+
+STARPORTC:
+	Inherits: ^STARPORT
+	Buildable:
+		Prerequisites: ~conyarda, radar
+
+PALACEC:
+	Inherits: ^PALACE
+	Buildable:
+		Queue: Building
+		BuildPaletteOrder: 1000
+		Prerequisites: ~conyarda, research
+	Building:
+		Footprint: =x= xxx xxx
+		Dimensions: 3,3
+	RenderBuilding:
+
+HEAVYC:
+	Inherits: ^HEAVY
+	Buildable:
+		Queue: Building
+		BuildPaletteOrder: 1100
+		Prerequisites: ~conyarda, refinery

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -723,28 +723,6 @@ SIETCH:
 	Power:
 		Amount: 0
 
-STARPORTC:
-	Inherits: ^STARPORT
-	-Buildable:
-
-PALACEC:
-	Inherits: ^PALACE
-	Buildable:
-		Queue: Building
-		BuildPaletteOrder: 1000
-		Prerequisites: ~disabled
-	Building:
-		Footprint: =x= xxx xxx
-		Dimensions: 3,3
-	RenderBuilding:
-
-HEAVYC:
-	Inherits: ^HEAVY
-	Buildable:
-		Queue: Building
-		BuildPaletteOrder: 1100
-		Prerequisites: ~disabled
-
 CONYARD:
 	Tooltip:
 		Name: Construction Yard

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -1550,7 +1550,7 @@ heavyo:
 		Start: 4089
 		Offset: -30,-24
 
-palacec: # TODO: unused
+palacec:
 	idle: DATA
 		Start: 3004
 		Offset: -48,48
@@ -1577,7 +1577,7 @@ palacec: # TODO: unused
 		Offset: -48,48
 		Tick: 100
 
-starportc: # TODO: unused
+starportc:
 	idle: DATA
 		Start: 2999
 		Offset: -48,48
@@ -1621,7 +1621,7 @@ starportc: # TODO: unused
 		Start: 4020
 		Offset: -30,-24
 
-heavyc: # TODO: unused
+heavyc:
 	idle: DATA
 		Start: 3001
 		Length: 1
@@ -1664,7 +1664,7 @@ heavyc: # TODO: unused
 		Start: 4020
 		Offset: -30,-24
 
-conyardc: # TODO: unused
+conyardc:
 	idle: DATA
 		Start: 3006
 		Offset: -48,64


### PR DESCRIPTION
1. With the map importer for Dune 2000 maps in the making (#7135), we will need a few more things:
   **a) add "missing" tiles to the `arrakis.yaml` tileset file**
   While we (_may, but questionably_) have all different tiles referenced in the file and this is good enough for the map editor, the map import does not have everything it needs (terrain-wise), which results in incorrect tiles (nothing deal-breaking, but they have to be then manually replaced via the map editor). I've gone over this in several other tickets and on IRC. (#5875)
   **b) add House Corrino, Fremen, Smugglers and Mercenaries as non-playable subfactions**
   This is required for importing missions.
2. Also I am adding a few voice notifications that we are not, but should be using.
   a) The code that will use the `EnemyUnitsApproaching` notification is currently being worked on.
   b) `Guarding` should really be used by the existing Guard command.
   c) Once the new UI is in place and the upgrades for the production structures are implemented, the `Upgrading` notification should be used. (#6043, #3211)
3. Please don't bash me for the empty `corrino.yaml`. I will need some advice on what structures does this faction have that are visually different from the other houses to populate it properly.
4. Added a few more loading screen messages :)
