### PR TITLE
Accept DevCommands only from local players

### DIFF
--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -91,7 +91,8 @@ namespace OpenRA.Mods.Common.Commands
 
 		static void IssueDevCommand(World world, string command)
 		{
-			world.IssueOrder(new Order(command, world.LocalPlayer.PlayerActor, false));
+			if (world.LocalPlayer != null)
+				world.IssueOrder(new Order(command, world.LocalPlayer.PlayerActor, false));
 		}
 
 		class DevException : Exception { }


### PR DESCRIPTION
This Pr fixed the Crash when observers are using Developer Commands.
Fixes #6839 
