### PR TITLE
Use ActorMap instead of BuildingInfluence for finding buildable area

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -72,8 +72,6 @@ namespace OpenRA.Mods.Common.Traits
 			var scanEnd = world.Map.Clamp(topLeft + buildingMaxBounds + new CVec(Adjacent, Adjacent));
 
 			var nearnessCandidates = new List<CPos>();
-
-			var bi = world.WorldActor.Trait<BuildingInfluence>();
 			var allyBuildRadius = world.LobbyInfo.GlobalSettings.AllyBuildRadius;
 
 			for (var y = scanStart.Y; y < scanEnd.Y; y++)
@@ -81,11 +79,12 @@ namespace OpenRA.Mods.Common.Traits
 				for (var x = scanStart.X; x < scanEnd.X; x++)
 				{
 					var pos = new CPos(x, y);
-					var at = bi.GetBuildingAt(pos);
-					if (at == null || !at.IsInWorld || !at.HasTrait<GivesBuildableArea>())
-						continue;
 
-					if (at.Owner == p || (allyBuildRadius && at.Owner.Stances[p] == Stance.Ally))
+					var at = world.ActorMap.GetUnitsAt(pos).Where(a => a.IsInWorld
+						&& (a.Owner == p || (allyBuildRadius && a.Owner.Stances[p] == Stance.Ally))
+						&& a.HasTrait<GivesBuildableArea>());
+
+					if (at.Any())
 						nearnessCandidates.Add(pos);
 				}
 			}


### PR DESCRIPTION
This allows for any actors (previously only those tagged as a `Building`) to work with `GivesBuildableArea`. This costs some performance as it will check all actors within the scan radius for the proper criteria, not just buildings.
