### PR TITLE
Lua API : Added floating text and radar video

### DIFF
--- a/OpenRA.Game/Effects/AsyncAction.cs
+++ b/OpenRA.Game/Effects/AsyncAction.cs
@@ -1,0 +1,38 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.Graphics;
+
+namespace OpenRA.Effects
+{
+	public class AsyncAction : IEffect
+	{
+		Action a;
+		IAsyncResult ar;
+
+		public AsyncAction(IAsyncResult ar, Action a)
+		{
+			this.a = a;
+			this.ar = ar;
+		}
+
+		public void Tick(World world)
+		{
+			if (ar.IsCompleted)
+			{
+				world.AddFrameEndTask(w => { w.Remove(this); a(); });
+			}
+		}
+
+		public IEnumerable<IRenderable> Render(WorldRenderer r) { yield break; }
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -88,6 +88,7 @@
     <Compile Include="GameRules\Warhead.cs" />
     <Compile Include="Graphics\QuadRenderer.cs" />
     <Compile Include="Download.cs" />
+    <Compile Include="Effects\AsyncAction.cs" />
     <Compile Include="Effects\DelayedAction.cs" />
     <Compile Include="Effects\FlashTarget.cs" />
     <Compile Include="Effects\IEffect.cs" />

--- a/OpenRA.Mods.Common/Scripting/Media.cs
+++ b/OpenRA.Mods.Common/Scripting/Media.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.IO;
+using OpenRA.FileFormats;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Scripting
@@ -55,6 +56,29 @@ namespace OpenRA.Mods.Common.Scripting
 				w.SetPauseState(false);
 				onComplete();
 			});
+		}
+
+		public static void PlayFMVInRadar(World w, VqaReader movie, Action onComplete)
+		{
+			var player = Ui.Root.Get<VqaPlayerWidget>("PLAYER");
+			player.Open(movie);
+
+			player.PlayThen(() =>
+			{
+				onComplete();
+				player.CloseVideo();
+			});
+		}
+
+		public static void StopFMVInRadar()
+		{
+			var player = Ui.Root.Get<VqaPlayerWidget>("PLAYER");
+			player.Stop();
+		}
+
+		public static VqaReader LoadVqa(Stream s)
+		{
+			return new VqaReader(s);
 		}
 	}
 }

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -314,6 +314,12 @@ Container@PLAYER_WIDGETS:
 							WorldInteractionController: INTERACTION_CONTROLLER
 							Children:
 								LogicTicker@RADAR_TICKER:
+						VqaPlayer@PLAYER:
+							X: 1
+							Y: 1
+							Width: PARENT_RIGHT-2
+							Height: PARENT_BOTTOM-2
+							Skippable: false
 				Background@POWERBAR_PANEL:
 					Logic: IngamePowerBarLogic
 					X: 4

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -161,6 +161,13 @@ Container@PLAYER_WIDGETS:
 							Y: 34
 							Width: 202
 							Height: 202
+							Children:
+						VqaPlayer@PLAYER:
+							X: 12
+							Y: 32
+							Width: 202
+							Height: 202
+							Skippable: false
 						Image@MINIMAP:
 							X: 12
 							Y: 34

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -161,6 +161,13 @@ Container@PLAYER_WIDGETS:
 							Y: 41
 							Width: 220
 							Height: 220
+							Children:
+						VqaPlayer@PLAYER:
+							X: 8
+							Y: 40
+							Width: 220
+							Height: 220
+							Skippable: false
 				Label@GAME_TIMER:
 					Logic: GameTimerLogic
 					X: 3

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -51,6 +51,11 @@ Container@PLAYER_WIDGETS:
 					X: 9
 					Width: 192
 					Height: 192
+				VqaPlayer@PLAYER:
+					X: 9
+					Width: 192
+					Height: 192
+					Skippable: false
 				ResourceBar@POWERBAR:
 					Logic: IngamePowerBarLogic
 					X: 42


### PR DESCRIPTION
This adds two new functions to the Media lua api.
1. FloatingText (string text, WPos position, int duration = 30) displays a text at the specified location.
2. LoadMovieAsync(string movie, LuaFunction func) and 
    PlayMovieInRadar(VqaReader reader, LuaFunction func = null) plays a video over the ingame radar which is used in some CnC campaigns

The simplest way to use the latter is Media.LoadMovieAsync("[videoName].vqa", Media.PlayMovieInRadar), but lua callbacks [func(VqaReader video)] are supported as well as storing the video in a global lua variable.
