### PR TITLE
Moved Tooltip to Mods.Common.Traits

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Traits\Sound\AnnounceOnKill.cs" />
     <Compile Include="Traits\Sound\DeathSounds.cs" />
     <Compile Include="Traits\Sound\SoundOnDamageTransition.cs" />
+    <Compile Include="Traits\Tooltip.cs" />
     <Compile Include="Traits\Upgrades\UpgradableTrait.cs" />
     <Compile Include="Traits\Upgrades\UpgradeManager.cs" />
     <Compile Include="Traits\Valued.cs" />

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -10,7 +10,7 @@
 
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Shown in the build palette widget.")]
 	public class TooltipInfo : ITraitInfo, ITooltipInfo

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -344,7 +344,6 @@
     <Compile Include="Widgets\Logic\WorldTooltipLogic.cs" />
     <Compile Include="Buildings\Bib.cs" />
     <Compile Include="Render\WithIdleOverlay.cs" />
-    <Compile Include="Tooltip.cs" />
     <Compile Include="AI\Squad.cs" />
     <Compile Include="AI\States\StateBase.cs" />
     <Compile Include="AI\States\GroundStates.cs" />


### PR DESCRIPTION
As title says.

Note: I think this is pretty much it for low-hanging fruits. To make any more progress of significance, we'll have to move
- Buildings,
- Movement/Pathfinding stuff,
- Armaments/Attack,
- most Render traits.

Until we get over this one larger hurdle, we'll be pretty much stuck, since most other stuff (AI, Activities, Upgrades, SupportPowers, Player traits, tons of misc traits, and so on) is tied to at least one of these.
