### PR TITLE
Escape dev commands for chatting.

### DIFF
--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -29,7 +29,9 @@ namespace OpenRA.Mods.Common.Commands
 
 		public bool OnChat(string playername, string message)
 		{
-			if (message.StartsWith("/"))
+			if (message.StartsWith("//"))
+				Game.Debug(message.Substring(1));
+			else if (message.StartsWith("/"))
 			{
 				var name = message.Substring(1).Split(' ')[0].ToLowerInvariant();
 				var command = Commands.FirstOrDefault(x => x.Key == name);


### PR DESCRIPTION
Allow chatting command strings if prefixed with "//" instead of executing (with a prefix of "/").

> Newbie01: Hey Phrohdoh, how did you give yourself cash?
> Phrohdoh: /givecash

We could either do this or players can prefix their message with a space (as is possible already).
