### PR TITLE
Implement "Enemy unit sighted" notification

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -256,6 +256,7 @@
     <Compile Include="Traits\Player\AllyRepair.cs" />
     <Compile Include="Traits\Player\ClassicProductionQueue.cs" />
     <Compile Include="Traits\Player\ConquestVictoryConditions.cs" />
+    <Compile Include="Traits\Player\EnemyWatcher.cs" />
     <Compile Include="Traits\Player\GlobalUpgradeManager.cs" />
     <Compile Include="Traits\Player\MissionObjectives.cs" />
     <Compile Include="Traits\Player\PlaceBeacon.cs" />
@@ -328,6 +329,7 @@
     <Compile Include="Traits\Sound\ActorLostNotification.cs" />
     <Compile Include="Traits\Sound\AnnounceOnBuild.cs" />
     <Compile Include="Traits\Sound\AnnounceOnKill.cs" />
+    <Compile Include="Traits\Sound\AnnounceOnSeen.cs" />
     <Compile Include="Traits\Sound\DeathSounds.cs" />
     <Compile Include="Traits\Sound\SoundOnDamageTransition.cs" />
     <Compile Include="Traits\SupportPowers\AirstrikePower.cs" />

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -1,0 +1,115 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Tracks neutral and enemy actors' visibility and notifies the player.",
+		"Attach this to the player actor.")]
+	class EnemyWatcherInfo : ITraitInfo
+	{
+		[Desc("Interval in ticks between scanning for enemies.")]
+		public readonly int ScanInterval = 25;
+
+		[Desc("Minimal interval in ticks between notifications.")]
+		public readonly int NotificationInterval = 200;
+
+		public object Create(ActorInitializer init) { return new EnemyWatcher(init.Self, this); }
+	}
+
+	class EnemyWatcher : ITick
+	{
+		readonly EnemyWatcherInfo info;
+		readonly Lazy<RadarPings> radarPings;
+
+		bool announcedAny;
+		int rescanInterval;
+		int ticksBeforeNextNotification;
+		HashSet<uint> lastKnownActorIds;
+		HashSet<uint> visibleActorIds;
+		HashSet<string> playedNotifications;
+
+		public EnemyWatcher(Actor self, EnemyWatcherInfo info)
+		{
+			lastKnownActorIds = new HashSet<uint>();
+			this.info = info;
+			rescanInterval = info.ScanInterval;
+			ticksBeforeNextNotification = info.NotificationInterval;
+			radarPings = Exts.Lazy(() => self.World.WorldActor.Trait<RadarPings>());
+		}
+
+		public void Tick(Actor self)
+		{
+			// TODO: Make the AI handle such notifications and remove Owner.IsBot from this check
+			// Disable notifications for AI and neutral players (creeps) and for spectators
+			if (self.Owner.Shroud.Disabled || self.Owner.IsBot || !self.Owner.Playable || self.Owner.PlayerReference.Spectating)
+				return;
+
+			rescanInterval--;
+			ticksBeforeNextNotification--;
+
+			if (rescanInterval > 0 || ticksBeforeNextNotification > 0)
+				return;
+
+			rescanInterval = info.ScanInterval;
+
+			announcedAny = false;
+			visibleActorIds = new HashSet<uint>();
+			playedNotifications = new HashSet<string>();
+
+			foreach (var actor in self.World.ActorsWithTrait<AnnounceOnSeen>())
+			{
+				// We only care about enemy actors (creeps should be enemies)
+				if ((actor.Actor.EffectiveOwner != null && self.Owner.Stances[actor.Actor.EffectiveOwner.Owner] != Stance.Enemy)
+				 || self.Owner.Stances[actor.Actor.Owner] != Stance.Enemy)
+					continue;
+
+				// The actor is not currently visible
+				if (!self.Owner.Shroud.IsVisible(actor.Actor))
+					continue;
+
+				visibleActorIds.Add(actor.Actor.ActorID);
+
+				// We already know about this actor
+				if (lastKnownActorIds.Contains(actor.Actor.ActorID))
+					continue;
+
+				// We have already played this type of notification
+				if (playedNotifications.Contains(actor.Trait.Info.Notification))
+					continue;
+
+				Announce(self, actor);
+			}
+
+			if (announcedAny)
+				ticksBeforeNextNotification = info.NotificationInterval;
+
+			lastKnownActorIds = visibleActorIds;
+		}
+
+		void Announce(Actor self, TraitPair<AnnounceOnSeen> announce)
+		{
+			// Audio notification
+			if (self.World.LocalPlayer != null)
+				Sound.PlayNotification(self.World.Map.Rules, self.World.LocalPlayer, "Speech", announce.Trait.Info.Notification, self.Owner.Country.Race);
+
+			// Radar notificaion
+			if (announce.Trait.Info.PingRadar && radarPings.Value != null)
+				radarPings.Value.Add(() => true, announce.Actor.CenterPosition, Color.Red, 50);
+
+			playedNotifications.Add(announce.Trait.Info.Notification);
+			announcedAny = true;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -1,0 +1,35 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Players will be notified when this actor becomes visible to them.")]
+	public class AnnounceOnSeenInfo : ITraitInfo
+	{
+		[Desc("Should there be a radar ping on enemies' radar at the actor's location when they see him")]
+		public readonly bool PingRadar = false;
+
+		public readonly string Notification = "EnemyUnitSighted";
+
+		public object Create(ActorInitializer init) { return new AnnounceOnSeen(this); }
+	}
+
+	public class AnnounceOnSeen
+	{
+		public readonly AnnounceOnSeenInfo Info;
+
+		public AnnounceOnSeen(AnnounceOnSeenInfo info)
+		{
+			Info = info;
+		}
+	}
+}

--- a/OpenRA.Mods.D2k/Traits/World/WormManager.cs
+++ b/OpenRA.Mods.D2k/Traits/World/WormManager.cs
@@ -43,7 +43,6 @@ namespace OpenRA.Mods.D2k.Traits
 	{
 		readonly WormManagerInfo info;
 		readonly Lazy<Actor[]> spawnPointActors;
-		readonly Lazy<RadarPings> radarPings;
 
 		int spawnCountdown;
 		int wormsPresent;
@@ -51,7 +50,6 @@ namespace OpenRA.Mods.D2k.Traits
 		public WormManager(Actor self, WormManagerInfo info)
 		{
 			this.info = info;
-			radarPings = Exts.Lazy(() => self.World.WorldActor.Trait<RadarPings>());
 			spawnPointActors = Exts.Lazy(() => self.World.ActorsWithTrait<WormSpawner>().Select(x => x.Actor).ToArray());
 		}
 
@@ -80,8 +78,6 @@ namespace OpenRA.Mods.D2k.Traits
 				// more we need to reach the defined minimum count.
 				wormLocations.Add(SpawnWorm(self));
 			} while (wormsPresent < info.Minimum);
-
-			AnnounceWormSign(self, wormLocations);
 		}
 
 		WPos SpawnWorm(Actor self)
@@ -106,18 +102,6 @@ namespace OpenRA.Mods.D2k.Traits
 		public void DecreaseWormCount()
 		{
 			wormsPresent--;
-		}
-
-		void AnnounceWormSign(Actor self, IEnumerable<WPos> wormLocations)
-		{
-			if (self.World.LocalPlayer != null)
-				Sound.PlayNotification(self.World.Map.Rules, self.World.LocalPlayer, "Speech", info.WormSignNotification, self.World.LocalPlayer.Country.Race);
-
-			if (radarPings.Value == null)
-				return;
-
-			foreach (var wormLocation in wormLocations)
-				radarPings.Value.Add(() => true, wormLocation, Color.Red, 50);
 		}
 	}
 }

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -51,3 +51,6 @@ SANDWORM:
 	Sandworm:
 		WanderMoveRadius: 5
 	IgnoresCloak:
+	AnnounceOnSeen:
+		Notification: WormSign
+		PingRadar: True

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -50,6 +50,8 @@
 	UpgradeManager:
 	TemporaryOwnerManager:
 	MustBeDestroyed:
+	AnnounceOnSeen:
+		Notification: EnemyUnitsApproaching
 
 ^Tank:
 	AppearsOnRadar:
@@ -103,6 +105,8 @@
 	UpgradeManager:
 	TemporaryOwnerManager:
 	MustBeDestroyed:
+	AnnounceOnSeen:
+		Notification: EnemyUnitsApproaching
 
 ^Husk:
 	Health:
@@ -230,6 +234,8 @@
 		UpgradeMinEnabledLevel: 1
 	UpgradeManager:
 	MustBeDestroyed:
+	AnnounceOnSeen:
+		Notification: EnemyUnitsApproaching
 
 ^Plane:
 	AppearsOnRadar:
@@ -263,6 +269,8 @@
 		UpgradeTypes: selfheal
 		UpgradeMinEnabledLevel: 1
 	UpgradeManager:
+	AnnounceOnSeen:
+		Notification: EnemyUnitsApproaching
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -72,4 +72,4 @@ Player:
 	ProvidesTechPrerequisite@all:
 		Name: Unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
-
+	EnemyWatcher:


### PR DESCRIPTION
OpenRA currently has no such notification, and I think it needs it.
This adds a trait for the Player actor to track all neutral/enemy units that the player sees and a trait for units/structures/creeps to announce themselves when seen.
Currently added to D2k units and the sandworms.
Not added to D2k structures and TD/RA/TS mods because I don't have the appropriate notifications. If someone could assist me with those I'll add them.
Also removed the "WormSign" notification on worm spawn, since it never belonged there.
