### PR TITLE
Disable worms in preparation for a playtest.

### DIFF
--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -121,8 +121,6 @@ Rules:
 		-MPStartLocations:
 		ResourceType@Spice:
 			ValuePerUnit: 0
-		WormManager:
-			Minimum: 1
 
 Sequences:
 

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -10,7 +10,6 @@ World:
 	ScreenShaker:
 	BuildingInfluence:
 	ChooseBuildTabOnSelect:
-	WormManager:
 	CrateSpawner:
 		Minimum: 0
 		Maximum: 2


### PR DESCRIPTION
Worms aren't ready for primetime yet, so this temporarily disables them in preparation for a playtest.

We can reenable them in a future playtest after worm spawners have been added to our shipped maps and the graphical issues have been fixed.
