### PR TITLE
Added an attack overlay for the sand worm

### DIFF
--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -14,6 +14,7 @@ using OpenRA.Activities;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.D2k.Traits;
+using OpenRA.Mods.RA;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
@@ -74,6 +75,8 @@ namespace OpenRA.Mods.D2k.Activities
 				actor.World.AddFrameEndTask(_ => actor.Destroy());
 
 			positionable.SetPosition(worm, targetLocation);
+			foreach (var notify in worm.TraitsImplementing<INotifyAttack>())
+				notify.Attacking(worm, target, null, null);
 			PlayAttackAnimation(worm);
 
 			var attackPosition = worm.CenterPosition;
@@ -86,7 +89,6 @@ namespace OpenRA.Mods.D2k.Activities
 
 		void PlayAttackAnimation(Actor self)
 		{
-			renderUnit.PlayCustomAnim(self, "sand");
 			renderUnit.PlayCustomAnim(self, "mouth");
 		}
 

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Widgets\MoneyBinWidget.cs" />
     <Compile Include="Widgets\SupportPowerBinWidget.cs" />
     <Compile Include="Widgets\SlidingContainerWidget.cs" />
+    <Compile Include="Traits\Render\WithAttackOverlay.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
@@ -1,0 +1,61 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.RA;
+using OpenRA.Mods.RA.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2k.Traits
+{
+	[Desc("Rendered together with an attack.")]
+	public class WithAttackOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	{
+		[Desc("Sequence name to use")]
+		public readonly string Sequence = null;
+
+		[Desc("Custom palette name")]
+		public readonly string Palette = null;
+
+		[Desc("Custom palette is a player palette BaseName")]
+		public readonly bool IsPlayerPalette = false;
+
+		public object Create(ActorInitializer init) { return new WithAttackOverlay(init, this); }
+	}
+
+	public class WithAttackOverlay : INotifyAttack
+	{
+		readonly Animation overlay;
+		readonly RenderSprites renderSprites;
+		readonly WithAttackOverlayInfo info;
+
+		bool attacking;
+
+		public WithAttackOverlay(ActorInitializer init, WithAttackOverlayInfo info)
+		{
+			this.info = info;
+
+			renderSprites = init.self.Trait<RenderSprites>();
+
+			overlay = new Animation(init.world, renderSprites.GetImage(init.self));
+
+			var key = "attack_overlay_{0}".F(info.Sequence);
+			renderSprites.Add(key, new AnimationWithOffset(overlay, null, () => !attacking),
+				info.Palette, info.IsPlayerPalette);
+		}
+
+		public void Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		{
+			attacking = true;
+			overlay.PlayThen(info.Sequence, () => attacking = false);
+		}
+	}
+}

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -39,6 +39,8 @@ SANDWORM:
 	RevealsShroud:
 		Range: 32c0
 	RenderUnit:
+	WithAttackOverlay:
+		Sequence: sand
 	BodyOrientation:
 	HiddenUnderFog:
 	AppearsOnRadar:

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -451,6 +451,7 @@ sandworm:
 	sand: DATA
 		Start: 3565
 		Length: 20
+		Tick: 100
 	idle: DATA
 		Start: 3586
 		Length: 35


### PR DESCRIPTION
fixes the sand being immediately replaced by the mouth instead of overlayed.
