### PR TITLE
Enable stances for helicopters in RA

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -251,9 +251,7 @@ HELI:
 		ROT: 4
 		Speed: 149
 	AutoTarget:
-		TargetWhenIdle: false
-		TargetWhenDamaged: false
-		EnableStances: false
+		InitialStance: HoldFire
 	RenderUnit:
 	WithRotor:
 		Offset: 0,0,85
@@ -302,9 +300,7 @@ HIND:
 		ROT: 4
 		Speed: 112
 	AutoTarget:
-		TargetWhenIdle: false
-		TargetWhenDamaged: false
-		EnableStances: false
+		InitialStance: HoldFire
 	RenderUnit:
 	WithRotor:
 	LimitedAmmo:


### PR DESCRIPTION
Commit enables stance changes for helicopters in RA. It also sets default stance
to HoldFire to keep previous behaviour.

Closes #7117
