### PR TITLE
Avoid initialization of graphical elements for a server.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -300,10 +300,11 @@ namespace OpenRA
 			Sound.StopVideo();
 			Sound.Initialize();
 
-			ModData = new ModData(mod, true);
-
-			Renderer.InitializeFonts(ModData.Manifest);
+			ModData = new ModData(mod, !Settings.Server.Dedicated);
 			ModData.InitializeLoaders();
+			if (!Settings.Server.Dedicated)
+				Renderer.InitializeFonts(ModData.Manifest);
+
 			using (new PerfTimer("LoadMaps"))
 				ModData.MapCache.LoadMaps();
 

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -70,7 +70,8 @@ namespace OpenRA.Graphics
 
 		static void LoadCollection(string name, MiniYaml yaml)
 		{
-			Game.ModData.LoadScreen.Display();
+			if (Game.ModData.LoadScreen != null)
+				Game.ModData.LoadScreen.Display();
 			var collection = new Collection()
 			{
 				Src = yaml.Value,

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -52,9 +52,12 @@ namespace OpenRA.Graphics
 
 			Device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, graphicSettings.Mode);
 
-			TempBufferSize = graphicSettings.BatchSize;
-			TempBufferCount = graphicSettings.NumTempBuffers;
-			SheetSize = graphicSettings.SheetSize;
+			if (!serverSettings.Dedicated)
+			{
+				TempBufferSize = graphicSettings.BatchSize;
+				TempBufferCount = graphicSettings.NumTempBuffers;
+				SheetSize = graphicSettings.SheetSize;
+			}
 
 			WorldSpriteRenderer = new SpriteRenderer(this, Device.CreateShader("shp"));
 			WorldRgbaSpriteRenderer = new SpriteRenderer(this, Device.CreateShader("rgba"));

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Graphics
 				if (allocated)
 					throw new SheetOverflowException("");
 				allocated = true;
-				return SheetBuilder.AllocateSheet(Game.Renderer.SheetSize);
+				return SheetBuilder.AllocateSheet(Game.Settings.Graphics.SheetSize);
 			};
 
 			return new SheetBuilder(SheetType.DualIndexed, allocate);


### PR DESCRIPTION
Avoid allocating memory and resources for graphical elements that will never be drawn when starting a dedicated server. This reduces the server memory footprint by approx 17 MiB.
