### PR TITLE
Make fetch-thirdparty-deps.ps1 work on more Windows platforms.

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -1,7 +1,10 @@
 if (!(Test-Path "nuget.exe"))
 {
 	echo "Fetching NuGet."
-	Invoke-WebRequest "http://nuget.org/nuget.exe" -OutFile "nuget.exe"
+	# Work around PowerShell's Invoke-WebRequest not being available on some versions of PowerShell by using the BCL.
+	# To do that we need to work around further and use absolute paths because DownloadFile is not aware of PowerShell's current directory.
+	$target = Join-Path $pwd.ToString() "nuget.exe"
+	(New-Object System.Net.WebClient).DownloadFile("http://nuget.org/nuget.exe", $target)
 }
 
 if (!(Test-Path "StyleCop.dll"))


### PR DESCRIPTION
Works around a problem some people were having with Invoke-WebRequest not being available on their system because of an old version of PowerShell.
