### PR TITLE
Use travis_retry to reduce the nuget timeout errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: csharp
 # Run the build script
 # call RALint to check for YAML errors
 script:
- - make cli-dependencies
+ - travis_retry make cli-dependencies
  - make all
  - make test
  - make check


### PR DESCRIPTION
As suggested by http://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/
