### PR TITLE
Add a method to access files via virtual names (alias)

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystemAliases.cs
+++ b/OpenRA.Game/FileSystem/FileSystemAliases.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenRA.FileSystem
+{
+	public class FileSystemAliases
+	{
+		public static Dictionary<string, string> Aliases = new Dictionary<string, string>();
+
+		// Sets an alias for a given filename ("speech01.mix" -> "speech01")
+		public static void Add(string alias, string filename)
+		{
+			if(!ContainsAlias(alias)) Aliases.Add(alias, filename);	
+		}
+
+		public static void RemoveByAlias(string alias)
+		{
+			if (Aliases.ContainsKey(alias))	Aliases.Remove(alias);
+		}
+
+		public static void RemoveByValue(string filename)
+		{
+			if (Aliases.ContainsValue(filename)) Aliases.Remove(GetAlias(filename));
+		}
+
+		public static bool ContainsAlias(string alias)	
+		{ 
+			return Aliases.ContainsKey(alias); 
+		}
+		
+		public static bool ContainsValue(string filename) 
+		{ 
+			return Aliases.ContainsValue(filename); 
+		}
+
+		public static void Clear() { Aliases.Clear(); }
+
+		// Returns the Alias for the filename ("speech01" -> "speech01.mix")
+		public static string GetFileName(string alias) 
+		{
+			return Aliases[alias]; 
+		}
+
+		// Returns the fileame for the given alias ("Speech01.mix" -> "speech01")
+		public static string GetAlias(string filename) 
+		{
+			var entry = "";
+
+			foreach (var a in Aliases)
+				if (a.Value == filename)
+					entry = a.Key;
+				else
+					entry = null;
+			return entry;
+		}
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -84,6 +84,7 @@
     <Compile Include="Activities\Activity.cs" />
     <Compile Include="Activities\CallFunc.cs" />
     <Compile Include="Actor.cs" />
+    <Compile Include="FileSystem\FileSystemAliases.cs" />
     <Compile Include="GameRules\Warhead.cs" />
     <Compile Include="Graphics\QuadRenderer.cs" />
     <Compile Include="Download.cs" />


### PR DESCRIPTION
it sounds stupid and make for the first moment not realy sense but this pr adds support for virtual filenames :)
We can specify an alias for a file which has maybe the same name but must be "unique" (eva & cabal voices).
so we can flag them with an alias:

example:

filename: 
`Speech01.mix -> I001.aud` as alias `eva-i001`
`Speech02.mix -> I001.aud` as alias `cab-i001`

in my testcase i had modified MixFile.cs and printed the `Add()` to debug.log:

```
Added Alias [scores] for [scores.mix]
Added Alias [sidenc01] for [sidenc01.mix]
Added Alias [sidenc02] for [sidenc02.mix]
Added Alias [gmenu] for [gmenu.mix]
Added Alias [e01scd01] for [e01scd01.mix]
Added Alias [e01scd02] for [e01scd02.mix]
Added Alias [maps01] for [maps01.mix]
Added Alias [maps02] for [maps02.mix]
Added Alias [movies01] for [movies01.mix]
Added Alias [movies02] for [movies02.mix]
Added Alias [multi] for [multi.mix]
Added Alias [patch] for [patch.mix]
Added Alias [sidecd01] for [sidecd01.mix]
Added Alias [sidecd02] for [sidecd02.mix]
Added Alias [tibsun] for [tibsun.mix]
Added Alias [cache] for [cache.mix]
Added Alias [conquer] for [conquer.mix]
Added Alias [isosnow] for [isosnow.mix]
Added Alias [isotemp] for [isotemp.mix]
Added Alias [local] for [local.mix]
Added Alias [sidec01] for [sidec01.mix]
Added Alias [sidec02] for [sidec02.mix]
Added Alias [sno] for [sno.mix]
Added Alias [snow] for [snow.mix]
Added Alias [sounds] for [sounds.mix]
Added Alias [speech01] for [speech01.mix]
Added Alias [tem] for [tem.mix]
Added Alias [temperat] for [temperat.mix]
Added Alias [scores01] for [scores01.mix]
Added Alias [expand01] for [expand01.mix]
Added Alias [sounds01] for [sounds01.mix]
Added Alias [e01sc01] for [e01sc01.mix]
Added Alias [e01sc02] for [e01sc02.mix]
Added Alias [e01vox01] for [e01vox01.mix]
Added Alias [e01vox02] for [e01vox02.mix]
Added Alias [ecache01] for [ecache01.mix]
```

As we see we could load all voice files inside `(speech01.mix)` as `gdi-****` and all files in `speech02.mix` as ``nod-****` which can result in `Player.Race + "-I001"`.

Also we should access tileset related building-SHPs via Aliases :)
