### PR TITLE
Introduce a new type for representing map coordinates.

### DIFF
--- a/OpenRA.Editor/Surface.cs
+++ b/OpenRA.Editor/Surface.cs
@@ -273,7 +273,8 @@ namespace OpenRA.Editor
 					{
 						var ui = u * ChunkSize + i;
 						var vj = v * ChunkSize + j;
-						var tr = Map.MapTiles.Value[ui, vj];
+						var uv = new MPos(ui, vj);
+						var tr = Map.MapTiles.Value[uv];
 						var tile = TileSetRenderer.Data(tr.Type);
 						if (tile == null)
 							continue;
@@ -284,9 +285,9 @@ namespace OpenRA.Editor
 							for (var y = 0; y < TileSetRenderer.TileSize; y++)
 								p[(j * TileSetRenderer.TileSize + y) * stride + i * TileSetRenderer.TileSize + x] = Palette.GetColor(rawImage[x + TileSetRenderer.TileSize * y]).ToArgb();
 
-						if (Map.MapResources.Value[ui, vj].Type != 0)
+						if (Map.MapResources.Value[uv].Type != 0)
 						{
-							var resourceImage = ResourceTemplates[Map.MapResources.Value[ui, vj].Type].Bitmap;
+							var resourceImage = ResourceTemplates[Map.MapResources.Value[uv].Type].Bitmap;
 							var srcdata = resourceImage.LockBits(resourceImage.Bounds(),
 								ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
 

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Drawing;
 using Eluant;
 using Eluant.ObjectBinding;
 using OpenRA.Scripting;
@@ -28,7 +27,6 @@ namespace OpenRA
 		public static CPos operator +(CVec a, CPos b) { return new CPos(a.X + b.X, a.Y + b.Y); }
 		public static CPos operator +(CPos a, CVec b) { return new CPos(a.X + b.X, a.Y + b.Y); }
 		public static CPos operator -(CPos a, CVec b) { return new CPos(a.X - b.X, a.Y - b.Y); }
-
 		public static CVec operator -(CPos a, CPos b) { return new CVec(a.X - b.X, a.Y - b.Y); }
 
 		public static bool operator ==(CPos me, CPos other) { return me.X == other.X && me.Y == other.Y; }
@@ -37,18 +35,37 @@ namespace OpenRA
 		public static CPos Max(CPos a, CPos b) { return new CPos(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)); }
 		public static CPos Min(CPos a, CPos b) { return new CPos(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y)); }
 
-		public CPos Clamp(Rectangle r)
-		{
-			return new CPos(Math.Min(r.Right, Math.Max(X, r.Left)),
-							Math.Min(r.Bottom, Math.Max(Y, r.Top)));
-		}
-
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
 		public bool Equals(CPos other) { return other == this; }
 		public override bool Equals(object obj) { return obj is CPos && Equals((CPos)obj); }
 
 		public override string ToString() { return X + "," + Y; }
+
+		public MPos ToMPos(Map map)
+		{
+			return ToMPos(map.TileShape);
+		}
+
+		public MPos ToMPos(TileShape shape)
+		{
+			if (shape == TileShape.Rectangle)
+				return new MPos(X, Y);
+
+			// Convert from diamond cell (x, y) position to rectangular map position (u, v)
+			//  - The staggered rows make this fiddly (hint: draw a diagram!)
+			// (a) Consider the relationships:
+			//  - +1x (even -> odd) adds (0, 1) to (u, v)
+			//  - +1x (odd -> even) adds (1, 1) to (u, v)
+			//  - +1y (even -> odd) adds (-1, 1) to (u, v)
+			//  - +1y (odd -> even) adds (0, 1) to (u, v)
+			// (b) Therefore:
+			//  - ax + by adds (a - b)/2 to u (only even increments count)
+			//  - ax + by adds a + b to v
+			var u = (X - Y) / 2;
+			var v = X + Y;
+			return new MPos(u, v);
+		}
 
 		#region Scripting interface
 

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -44,12 +44,11 @@ namespace OpenRA.Graphics
 		{
 			var verticesPerRow = 4 * map.Bounds.Width;
 			var cells = viewport.VisibleCells;
-			var shape = wr.World.Map.TileShape;
 
 			// Only draw the rows that are visible.
 			// VisibleCells is clamped to the map, so additional checks are unnecessary
-			var firstRow = Map.CellToMap(shape, cells.TopLeft).Y - map.Bounds.Top;
-			var lastRow = Map.CellToMap(shape, cells.BottomRight).Y - map.Bounds.Top + 1;
+			var firstRow = cells.TopLeft.ToMPos(map).V - map.Bounds.Top;
+			var lastRow = cells.BottomRight.ToMPos(map).V - map.Bounds.Top + 1;
 
 			Game.Renderer.WorldSpriteRenderer.DrawVertexBuffer(
 				vertexBuffer, verticesPerRow * firstRow, verticesPerRow * (lastRow - firstRow),

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -94,8 +94,8 @@ namespace OpenRA.Graphics
 			var b = map.Bounds;
 
 			// Expand to corners of cells
-			var tl = wr.ScreenPxPosition(map.CenterOfCell(Map.MapToCell(map.TileShape, new CPos(b.Left, b.Top))) - new WVec(512, 512, 0));
-			var br = wr.ScreenPxPosition(map.CenterOfCell(Map.MapToCell(map.TileShape, new CPos(b.Right, b.Bottom))) + new WVec(511, 511, 0));
+			var tl = wr.ScreenPxPosition(map.CenterOfCell(new MPos(b.Left, b.Top).ToCPos(map)) - new WVec(512, 512, 0));
+			var br = wr.ScreenPxPosition(map.CenterOfCell(new MPos(b.Right, b.Bottom).ToCPos(map)) + new WVec(511, 511, 0));
 			mapBounds = Rectangle.FromLTRB(tl.X, tl.Y, br.X, br.Y);
 
 			maxGroundHeight = wr.World.TileSet.MaxGroundHeight;
@@ -164,15 +164,15 @@ namespace OpenRA.Graphics
 					var wbr = worldRenderer.Position(BottomRight);
 
 					// Visible rectangle in map coordinates
-					var ctl = new CPos(wtl.X / 1024, wtl.Y / 1024);
+					var ctl = new MPos(wtl.X / 1024, wtl.Y / 1024);
 					var dy = map.TileShape == TileShape.Diamond ? 512 : 1024;
-					var cbr = new CPos((wbr.X + 1023) / 1024, (wbr.Y + dy - 1) / dy);
+					var cbr = new MPos((wbr.X + 1023) / 1024, (wbr.Y + dy - 1) / dy);
 
 					// Add a 1 cell cordon to prevent holes, then convert back to cell coordinates
-					var tl = map.Clamp(Map.MapToCell(map.TileShape, ctl - new CVec(1, 1)));
+					var tl = map.Clamp(new MPos(ctl.U - 1, ctl.V - 1).ToCPos(map));
 
 					// Also need to account for height of cells in rows below the bottom
-					var br = map.Clamp(Map.MapToCell(map.TileShape, cbr + new CVec(1, 2 + maxGroundHeight / 2)));
+					var br = map.Clamp(new MPos(cbr.U + 1, cbr.V + 2 + maxGroundHeight / 2).ToCPos(map));
 
 					cells = new CellRegion(map.TileShape, tl, br);
 					cellsDirty = false;

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -1,0 +1,64 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+
+namespace OpenRA
+{
+	public struct MPos : IEquatable<MPos>
+	{
+		public readonly int U, V;
+
+		public MPos(int u, int v) { U = u; V = v; }
+		public static readonly MPos Zero = new MPos(0, 0);
+
+		public static bool operator ==(MPos me, MPos other) { return me.U == other.U && me.V == other.V; }
+		public static bool operator !=(MPos me, MPos other) { return !(me == other); }
+
+		public override int GetHashCode() { return U.GetHashCode() ^ V.GetHashCode(); }
+
+		public bool Equals(MPos other) { return other == this; }
+		public override bool Equals(object obj) { return obj is MPos && Equals((MPos)obj); }
+
+		public MPos Clamp(Rectangle r)
+		{
+			return new MPos(Math.Min(r.Right, Math.Max(U, r.Left)),
+							Math.Min(r.Bottom, Math.Max(V, r.Top)));
+		}
+
+		public override string ToString() { return U + "," + V; }
+
+		public CPos ToCPos(Map map)
+		{
+			return ToCPos(map.TileShape);
+		}
+
+		public CPos ToCPos(TileShape shape)
+		{
+			if (shape == TileShape.Rectangle)
+				return new CPos(U, V);
+
+			// Convert from rectangular map position to diamond cell position
+			//  - The staggered rows make this fiddly (hint: draw a diagram!)
+			// (a) Consider the relationships:
+			//  - +1u (even -> odd) adds (1, -1) to (x, y)
+			//  - +1v (even -> odd) adds (1, 0) to (x, y)
+			//  - +1v (odd -> even) adds (0, 1) to (x, y)
+			// (b) Therefore:
+			//  - au + 2bv adds (a + b) to (x, y)
+			//  - a correction factor is added if v is odd
+			var offset = (V & 1) == 1 ? 1 : 0;
+			var y = (V - offset) / 2 - U;
+			var x = V - y;
+			return new CPos(x, y);
+		}
+	}
+}

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -48,14 +48,13 @@ namespace OpenRA
 		// Resolve an array index from cell coordinates
 		int Index(CPos cell)
 		{
-			var uv = Map.CellToMap(Shape, cell);
-			return Index(uv.X, uv.Y);
+			return Index(cell.ToMPos(Shape));
 		}
 
 		// Resolve an array index from map coordinates
-		int Index(int u, int v)
+		int Index(MPos uv)
 		{
-			return v * Size.Width + u;
+			return uv.V * Size.Width + uv.U;
 		}
 
 		/// <summary>Gets or sets the <see cref="OpenRA.CellLayer"/> using cell coordinates</summary>
@@ -76,19 +75,19 @@ namespace OpenRA
 		}
 
 		/// <summary>Gets or sets the layer contents using raw map coordinates (not CPos!)</summary>
-		public T this[int u, int v]
+		public T this[MPos uv]
 		{
 			get
 			{
-				return entries[Index(u, v)];
+				return entries[Index(uv)];
 			}
 
 			set
 			{
-				entries[Index(u, v)] = value;
+				entries[Index(uv)] = value;
 
 				if (CellEntryChanged != null)
-					CellEntryChanged(Map.MapToCell(Shape, new CPos(u, v)));
+					CellEntryChanged(uv.ToCPos(Shape));
 			}
 		}
 
@@ -123,7 +122,7 @@ namespace OpenRA
 			result.Clear(defaultValue);
 			for (var j = 0; j < height; j++)
 				for (var i = 0; i < width; i++)
-					result[i, j] = layer[i, j];
+					result[new MPos(i, j)] = layer[new MPos(i, j)];
 
 			return result;
 		}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Activities\Activity.cs" />
     <Compile Include="Activities\CallFunc.cs" />
     <Compile Include="Actor.cs" />
+    <Compile Include="MPos.cs" />
     <Compile Include="GameRules\Warhead.cs" />
     <Compile Include="Graphics\QuadRenderer.cs" />
     <Compile Include="Download.cs" />

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.FootprintInMapCoords.All(uv => world.ShroudObscures(uv.X, uv.Y)))
+					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}
@@ -74,7 +74,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.FootprintInMapCoords.All(uv => world.ShroudObscures(uv.X, uv.Y)))
+					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Traits
 
 	public class FrozenActor
 	{
-		public readonly CPos[] FootprintInMapCoords;
+		public readonly MPos[] Footprint;
 		public readonly CellRegion FootprintRegion;
 		public readonly WPos CenterPosition;
 		public readonly Rectangle Bounds;
@@ -40,10 +40,10 @@ namespace OpenRA.Traits
 
 		public bool Visible;
 
-		public FrozenActor(Actor self, CPos[] footprintInMapCoords, CellRegion footprintRegion)
+		public FrozenActor(Actor self, MPos[] footprint, CellRegion footprintRegion)
 		{
 			actor = self;
-			FootprintInMapCoords = footprintInMapCoords;
+			Footprint = footprint;
 			FootprintRegion = footprintRegion;
 
 			CenterPosition = self.CenterPosition;
@@ -59,11 +59,11 @@ namespace OpenRA.Traits
 		public void Tick(World world, Shroud shroud)
 		{
 			// We are doing the following LINQ manually to avoid allocating an extra delegate since this is a hot path.
-			// Visible = !FootprintInMapCoords.Any(mapCoord => shroud.IsVisibleTest(FootprintRegion)(mapCoord.X, mapCoord.Y));
+			// Visible = !Footprint.Any(shroud.IsVisibleTest(FootprintRegion));
 			var isVisibleTest = shroud.IsVisibleTest(FootprintRegion);
 			Visible = true;
-			foreach (var mapCoord in FootprintInMapCoords)
-				if (isVisibleTest(mapCoord.X, mapCoord.Y))
+			foreach (var uv in Footprint)
+				if (isVisibleTest(uv))
 				{
 					Visible = false;
 					break;

--- a/OpenRA.Game/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Game/Widgets/MapPreviewWidget.cs
@@ -133,9 +133,9 @@ namespace OpenRA.Widgets
 		{
 			var preview = Preview();
 			var tileShape = Game.ModData.Manifest.TileShape;
-			var point = Map.CellToMap(tileShape, cell);
-			var dx = (int)(previewScale * (point.X - preview.Bounds.Left));
-			var dy = (int)(previewScale * (point.Y - preview.Bounds.Top));
+			var point = cell.ToMPos(tileShape);
+			var dx = (int)(previewScale * (point.U - preview.Bounds.Left));
+			var dy = (int)(previewScale * (point.V - preview.Bounds.Top));
 			return new int2(mapRect.X + dx, mapRect.Y + dy);
 		}
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -24,7 +24,7 @@ namespace OpenRA
 {
 	public class World
 	{
-		static readonly Func<int, int, bool> FalsePredicate = (u, v) => false;
+		static readonly Func<MPos, bool> FalsePredicate = _ => false;
 		internal readonly TraitDictionary TraitDict = new TraitDictionary();
 		readonly HashSet<Actor> actors = new HashSet<Actor>();
 		readonly List<IEffect> effects = new List<IEffect>();
@@ -65,24 +65,24 @@ namespace OpenRA
 		public bool FogObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(p); }
 		public bool ShroudObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(a); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
-		public bool ShroudObscures(int u, int v) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(u, v); }
+		public bool ShroudObscures(MPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
 
-		public Func<int, int, bool> FogObscuresTest(CellRegion region)
+		public Func<MPos, bool> FogObscuresTest(CellRegion region)
 		{
 			var rp = RenderPlayer;
 			if (rp == null)
 				return FalsePredicate;
 			var predicate = rp.Shroud.IsVisibleTest(region);
-			return (u, v) => !predicate(u, v);
+			return uv => !predicate(uv);
 		}
 
-		public Func<int, int, bool> ShroudObscuresTest(CellRegion region)
+		public Func<MPos, bool> ShroudObscuresTest(CellRegion region)
 		{
 			var rp = RenderPlayer;
 			if (rp == null)
 				return FalsePredicate;
 			var predicate = rp.Shroud.IsExploredTest(region);
-			return (u, v) => !predicate(u, v);
+			return uv => !predicate(uv);
 		}
 
 		public bool IsReplay

--- a/OpenRA.Mods.Common/Traits/World/PathSearch.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathSearch.cs
@@ -334,7 +334,7 @@ namespace OpenRA.Mods.Common.Traits
 					defaultCellInfoLayer = new CellLayer<CellInfo>(map);
 					for (var v = 0; v < mapSize.Height; v++)
 						for (var u = 0; u < mapSize.Width; u++)
-							defaultCellInfoLayer[u, v] = new CellInfo(int.MaxValue, Map.MapToCell(map.TileShape, new CPos(u, v)), false);
+							defaultCellInfoLayer[new MPos(u, v)] = new CellInfo(int.MaxValue, new MPos(u, v).ToCPos(map), false);
 				}
 
 				result.CopyValuesFrom(defaultCellInfoLayer);

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -36,12 +36,12 @@ namespace OpenRA.Mods.Common.Traits
 			var shroudObscured = world.ShroudObscuresTest(wr.Viewport.VisibleCells);
 			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
-				if (shroudObscured(uv.X, uv.Y))
+				if (shroudObscured(uv))
 					continue;
 
-				var c = render[uv.X, uv.Y];
+				var c = render[uv];
 				if (c.Sprite != null)
-					new SpriteRenderable(c.Sprite, wr.World.Map.CenterOfCell(Map.MapToCell(world.Map.TileShape, uv)),
+					new SpriteRenderable(c.Sprite, wr.World.Map.CenterOfCell(uv.ToCPos(world.Map)),
 						WVec.Zero, -511, c.Type.Palette, 1f, true).Render(wr); // TODO ZOffset is ignored
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -84,10 +84,10 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
 				var lr = Game.Renderer.WorldLineRenderer;
-				var pos = wr.World.Map.CenterOfCell(Map.MapToCell(wr.World.Map.TileShape, uv));
+				var pos = wr.World.Map.CenterOfCell(uv.ToCPos(wr.World.Map));
 
-				var height = (int)wr.World.Map.MapHeight.Value[uv.X, uv.Y];
-				var tile = wr.World.Map.MapTiles.Value[uv.X, uv.Y];
+				var height = (int)wr.World.Map.MapHeight.Value[uv];
+				var tile = wr.World.Map.MapTiles.Value[uv];
 
 				TerrainTileInfo tileInfo = null;
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Widgets
 		void UpdateTerrainCell(CPos cell)
 		{
 			var stride = radarSheet.Size.Width;
-			var uv = Map.CellToMap(world.Map.TileShape, cell);
+			var uv = cell.ToMPos(world.Map);
 			var terrain = world.Map.GetTerrainInfo(cell);
 
 			var dx = terrainSprite.Bounds.Left - world.Map.Bounds.Left;
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Widgets
 				fixed (byte* colorBytes = &radarData[0])
 				{
 					var colors = (int*)colorBytes;
-					colors[(uv.Y + dy) * stride + uv.X + dx] = terrain.Color.ToArgb();
+					colors[(uv.V + dy) * stride + uv.U + dx] = terrain.Color.ToArgb();
 				}
 			}
 		}
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Widgets
 		void UpdateShroudCell(CPos cell)
 		{
 			var stride = radarSheet.Size.Width;
-			var uv = Map.CellToMap(world.Map.TileShape, cell);
+			var uv = cell.ToMPos(world.Map);
 			var dx = shroudSprite.Bounds.Left - world.Map.Bounds.Left;
 			var dy = shroudSprite.Bounds.Top - world.Map.Bounds.Top;
 
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Widgets
 				fixed (byte* colorBytes = &radarData[0])
 				{
 					var colors = (int*)colorBytes;
-					colors[(uv.Y + dy) * stride + uv.X + dx] = color;
+					colors[(uv.V + dy) * stride + uv.U + dx] = color;
 				}
 			}
 		}
@@ -291,10 +291,10 @@ namespace OpenRA.Mods.Common.Widgets
 							var color = t.Trait.RadarSignatureColor(t.Actor);
 							foreach (var cell in t.Trait.RadarSignatureCells(t.Actor))
 							{
-								var uv = Map.CellToMap(world.Map.TileShape, cell);
+								var uv = cell.ToMPos(world.Map);
 
-								if (world.Map.Bounds.Contains(uv.X, uv.Y))
-									colors[(uv.Y + dy) * stride + uv.X + dx] = color.ToArgb();
+								if (world.Map.Bounds.Contains(uv.U, uv.V))
+									colors[(uv.V + dy) * stride + uv.U + dx] = color.ToArgb();
 							}
 						}
 					}
@@ -329,10 +329,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		int2 CellToMinimapPixel(CPos p)
 		{
-			var mapOrigin = new CVec(world.Map.Bounds.Left, world.Map.Bounds.Top);
-			var mapOffset = Map.CellToMap(world.Map.TileShape, p) - mapOrigin;
-
-			return new int2(mapRect.X, mapRect.Y) + (previewScale * new float2(mapOffset.X, mapOffset.Y)).ToInt2();
+			var uv = p.ToMPos(world.Map);
+			var mapOffset = new float2(uv.U - world.Map.Bounds.Left, uv.V - world.Map.Bounds.Top);
+			return new int2(mapRect.X, mapRect.Y) + (previewScale * mapOffset).ToInt2();
 		}
 
 		CPos MinimapPixelToCell(int2 p)
@@ -340,7 +339,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var viewOrigin = new float2(mapRect.X, mapRect.Y);
 			var mapOrigin = new float2(world.Map.Bounds.Left, world.Map.Bounds.Top);
 			var fcell = mapOrigin + (1f / previewScale) * (p - viewOrigin);
-			return Map.MapToCell(world.Map.TileShape, new CPos((int)fcell.X, (int)fcell.Y));
+			return new MPos((int)fcell.X, (int)fcell.Y).ToCPos(world.Map);
 		}
 	}
 }


### PR DESCRIPTION
To resolve the ambiguity introduced when the introduction of isometric maps meant that cell and map coordinates were no longer equivalent, a new type has been introduced so they can each be represented separately.

The MPos type represents map coordinates. I have moved the static MapToCell and CellToMap methods into instance methods against the CPos and MPos types. I'll probably implement more changes at some point to reduce the number of conversions where possible, but I'd just like to get map coords in the door for now so to speak.

I played a quick round of TS and things looked okay to me.
