### PR TITLE
Make OccupiedCells implementations return arrays.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(new Drag(self, CenterPosition, finalPosition, distance / dragSpeed));
 		}
 
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { yield return Pair.New(TopLeft, SubCell.FullCell); }
+		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; }
 		public SubCell GetValidSubCell(SubCell preferred = SubCell.Any) { return SubCell.FullCell; }
 		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)

--- a/OpenRA.Mods.RA/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/Crate.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.RA.Traits
 		}
 
 		public CPos TopLeft { get { return Location; } }
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { yield return Pair.New(Location, SubCell.FullCell); }
+		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return new[] { Pair.New(Location, SubCell.FullCell) }; }
 
 		public WPos CenterPosition { get; private set; }
 		public void SetPosition(Actor self, WPos pos) { SetPosition(self, self.World.Map.CellContaining(pos)); }

--- a/OpenRA.Mods.RA/Traits/Mobile.cs
+++ b/OpenRA.Mods.RA/Traits/Mobile.cs
@@ -486,14 +486,10 @@ namespace OpenRA.Mods.RA.Traits
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells()
 		{
 			if (fromCell == toCell)
-				yield return Pair.New(fromCell, fromSubCell);
-			else if (CanEnterCell(toCell))
-				yield return Pair.New(toCell, toSubCell);
-			else
-			{
-				yield return Pair.New(fromCell, fromSubCell);
-				yield return Pair.New(toCell, toSubCell);
-			}
+				return new[] { Pair.New(fromCell, fromSubCell) };
+			if (CanEnterCell(toCell))
+				return new[] { Pair.New(toCell, toSubCell) };
+			return new[] { Pair.New(fromCell, fromSubCell), Pair.New(toCell, toSubCell) };
 		}
 
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any)


### PR DESCRIPTION
Since there are only one or two items, it's cheaper to return a concrete collection and avoid the overhead of the compiler generated state machine.

This in particular speeds up Shroud.GetVisOrigins when dealing with Mobile.OccupiedCells, as the expensive CanEnterCell call is made only once rather than twice.
