### PR TITLE
Checked LINQ queries and collections for inefficiencies.

### DIFF
--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Editor
 			foreach (var p in palettes) { p.Visible = false; p.SuspendLayout(); }
 
 			var templateOrder = tileset.EditorTemplateOrder ?? new string[] { };
-			foreach (var tc in tileset.Templates.GroupBy(t => t.Value.Category).OrderBy(t => Array.IndexOf(templateOrder, t.Key)))
+			foreach (var tc in tileset.Templates.GroupBy(t => t.Value.Category).OrderBy(t => templateOrder.IndexOf(t.Key)))
 			{
 				var category = tc.Key ?? "(Uncategorized)";
 				var categoryHeader = new Label

--- a/OpenRA.Game/Effects/FlashTarget.cs
+++ b/OpenRA.Game/Effects/FlashTarget.cs
@@ -25,8 +25,11 @@ namespace OpenRA.Effects
 			this.target = target;
 			player = asPlayer;
 			remainingTicks = ticks;
-			foreach (var e in target.World.Effects.OfType<FlashTarget>().Where(a => a.target == target).ToArray())
-				target.World.Remove(e);
+			target.World.RemoveAll(effect =>
+			{
+				var flashTarget = effect as FlashTarget;
+				return flashTarget != null && flashTarget.target == target;
+			});
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -106,6 +106,11 @@ namespace OpenRA
 			return ret;
 		}
 
+		public static int IndexOf<T>(this T[] array, T value)
+		{
+			return Array.IndexOf(array, value);
+		}
+
 		public static T Random<T>(this IEnumerable<T> ts, MersenneTwister r)
 		{
 			var xs = ts as ICollection<T>;
@@ -299,6 +304,11 @@ namespace OpenRA
 			return ts.Concat(moreTs);
 		}
 
+		public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
+		{
+			return new HashSet<T>(source);
+		}
+
 		public static Dictionary<TKey, TSource> ToDictionaryWithConflictLog<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, string debugName, Func<TKey, string> logKey, Func<TSource, string> logValue)
 		{
 			return ToDictionaryWithConflictLog(source, keySelector, x => x, debugName, logKey, logValue);
@@ -341,7 +351,7 @@ namespace OpenRA
 			// If any duplicates were found, throw a descriptive error
 			if (dupKeys.Count > 0)
 			{
-				var badKeysFormatted = string.Join(", ", dupKeys.Select(p => "{0}: [{1}]".F(logKey(p.Key), string.Join(",", p.Value.ToArray()))).ToArray());
+				var badKeysFormatted = string.Join(", ", dupKeys.Select(p => "{0}: [{1}]".F(logKey(p.Key), string.Join(",", p.Value))));
 				var msg = "{0}, duplicate values found for the following keys: {1}".F(debugName, badKeysFormatted);
 				throw new ArgumentException(msg);
 			}

--- a/OpenRA.Game/Graphics/PlayerColorRemap.cs
+++ b/OpenRA.Game/Graphics/PlayerColorRemap.cs
@@ -32,14 +32,14 @@ namespace OpenRA.Graphics
 			var c1 = new HSLColor(c.H, c.S, (byte)Math.Max(rampRange, c.L)).RGB;
 			var c2 = new HSLColor(c.H, c.S, (byte)Math.Max(0, c.L - rampRange)).RGB;
 			var baseIndex = ramp[0];
-			var remapRamp = ramp.Select(r => r - ramp[0]).ToArray();
+			var remapRamp = ramp.Select(r => r - ramp[0]);
 
 			// reversed remapping
 			if (ramp[0] > ramp[15])
 			{
 				baseIndex = ramp[15];
 				for (var i = 15; i > 0; i--)
-					remapRamp = ramp.Select(r => r - ramp[15]).ToArray();
+					remapRamp = ramp.Select(r => r - ramp[15]);
 			}
 
 			remapColors = remapRamp.Select((x, i) => Pair.New(baseIndex + i, Exts.ColorLerp(x / 16f, c1, c2)))

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -80,12 +80,11 @@ namespace OpenRA.Graphics
 		List<IRenderable> GenerateRenderables()
 		{
 			var actors = World.ScreenMap.ActorsInBox(Viewport.TopLeft, Viewport.BottomRight)
-				.Append(World.WorldActor)
-				.ToList();
+				.Append(World.WorldActor);
 
 			// Include player actor for the rendered player
 			if (World.RenderPlayer != null)
-				actors.Add(World.RenderPlayer.PlayerActor);
+				actors = actors.Append(World.RenderPlayer.PlayerActor);
 
 			var worldRenderables = actors.SelectMany(a => a.Render(this));
 			if (World.OrderGenerator != null)

--- a/OpenRA.Game/Group.cs
+++ b/OpenRA.Game/Group.cs
@@ -15,7 +15,7 @@ namespace OpenRA
 {
 	public class Group
 	{
-		List<Actor> actors;
+		Actor[] actors;
 		int id;
 
 		static int nextGroup;
@@ -24,7 +24,7 @@ namespace OpenRA
 
 		public Group(IEnumerable<Actor> actors)
 		{
-			this.actors = actors.ToList();
+			this.actors = actors.ToArray();
 
 			foreach (var a in actors)
 				a.Group = this;

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -79,7 +79,7 @@ namespace OpenRA
 			foreach (var p in maps.Values)
 				p.UpdateRemoteSearch(MapStatus.Searching, null);
 
-			var url = Game.Settings.Game.MapRepository + "hash/" + string.Join(",", maps.Keys.ToArray()) + "/yaml";
+			var url = Game.Settings.Game.MapRepository + "hash/" + string.Join(",", maps.Keys) + "/yaml";
 
 			Action<DownloadDataCompletedEventArgs, bool> onInfoComplete = (i, cancelled) =>
 			{

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -46,7 +46,7 @@ namespace OpenRA
 
 	public class MapPreview
 	{
-		static readonly List<CPos> NoSpawns = new List<CPos>();
+		static readonly CPos[] NoSpawns = new CPos[] { };
 		MapCache cache;
 
 		public readonly string Uid;
@@ -54,7 +54,7 @@ namespace OpenRA
 		public string Type { get; private set; }
 		public string Author { get; private set; }
 		public int PlayerCount { get; private set; }
-		public List<CPos> SpawnPoints { get; private set; }
+		public CPos[] SpawnPoints { get; private set; }
 		public Rectangle Bounds { get; private set; }
 		public Bitmap CustomPreview { get; private set; }
 		public Map Map { get; private set; }
@@ -112,7 +112,7 @@ namespace OpenRA
 			Author = m.Author;
 			PlayerCount = m.Players.Count(x => x.Value.Playable);
 			Bounds = m.Bounds;
-			SpawnPoints = m.GetSpawnPoints().ToList();
+			SpawnPoints = m.GetSpawnPoints();
 			CustomPreview = m.CustomPreview;
 			Status = MapStatus.Available;
 			Class = classification;
@@ -143,9 +143,9 @@ namespace OpenRA
 						PlayerCount = r.players;
 						Bounds = r.bounds;
 
-						var spawns = new List<CPos>();
+						var spawns = new CPos[r.spawnpoints.Length / 2];
 						for (var j = 0; j < r.spawnpoints.Length; j += 2)
-							spawns.Add(new CPos(r.spawnpoints[j], r.spawnpoints[j + 1]));
+							spawns[j / 2] = new CPos(r.spawnpoints[j], r.spawnpoints[j + 1]);
 						SpawnPoints = spawns;
 
 						CustomPreview = new Bitmap(new MemoryStream(Convert.FromBase64String(r.minimap)));

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Orders
 			var orders = world.Selection.Actors
 				.Select(a => OrderForUnit(a, target, mi))
 				.Where(o => o != null)
-				.ToArray();
+				.ToList();
 
 			var actorsInvolved = orders.Select(o => o.Actor).Distinct();
 			if (actorsInvolved.Any())
@@ -81,8 +81,7 @@ namespace OpenRA.Orders
 
 			var orders = world.Selection.Actors
 				.Select(a => OrderForUnit(a, target, mi))
-				.Where(o => o != null)
-				.ToArray();
+				.Where(o => o != null);
 
 			var cursorName = orders.Select(o => o.Cursor).FirstOrDefault();
 			return cursorName ?? (useSelect ? "select" : "default");

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -50,7 +50,7 @@ namespace OpenRA
 		{
 			var selectableCountries = world.Map.Rules.Actors["world"].Traits
 				.WithInterface<CountryInfo>().Where(c => c.Selectable)
-				.ToArray();
+				.ToList();
 
 			return selectableCountries.FirstOrDefault(c => c.Race == name)
 				?? selectableCountries.Random(world.SharedRandom);

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Scripting
 			// The 'this.' resolves the actual (subclass) type
 			var type = this.GetType();
 			var names = type.GetCustomAttributes<ScriptGlobalAttribute>(true);
-			if (names.Count() != 1)
+			if (names.Length != 1)
 				throw new InvalidOperationException("[LuaGlobal] attribute not found for global table '{0}'".F(type));
 
 			Name = names.First().Name;
@@ -242,13 +242,13 @@ namespace OpenRA.Scripting
 				runtime.Dispose();
 		}
 
-		static Type[] ExtractRequiredTypes(Type t)
+		static IEnumerable<Type> ExtractRequiredTypes(Type t)
 		{
 			// Returns the inner types of all the Requires<T> interfaces on this type
 			var outer = t.GetInterfaces()
 				.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(Requires<>));
 
-			return outer.SelectMany(i => i.GetGenericArguments()).ToArray();
+			return outer.SelectMany(i => i.GetGenericArguments());
 		}
 
 		static readonly object[] NoArguments = new object[0];

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -406,7 +406,7 @@ namespace OpenRA.Server
 		public void DispatchOrdersToClients(Connection conn, int frame, byte[] data)
 		{
 			var from = conn != null ? conn.PlayerIndex : 0;
-			foreach (var c in Conns.Except(conn).ToArray())
+			foreach (var c in Conns.Except(conn).ToList())
 				DispatchOrdersToClient(c, from, frame, data);
 		}
 
@@ -517,9 +517,7 @@ namespace OpenRA.Server
 
 		public void DropClient(Connection toDrop, int frame)
 		{
-			if (PreConns.Contains(toDrop))
-				PreConns.Remove(toDrop);
-			else
+			if (!PreConns.Remove(toDrop))
 			{
 				Conns.Remove(toDrop);
 

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -130,10 +130,7 @@ namespace OpenRA.Traits
 
 		public static IEnumerable<CPos> ExpandFootprint(IEnumerable<CPos> cells, bool allowDiagonal)
 		{
-			var result = new Dictionary<CPos, bool>();
-			foreach (var c in cells.SelectMany(c => Neighbours(c, allowDiagonal)))
-				result[c] = true;
-			return result.Keys;
+			return cells.SelectMany(c => Neighbours(c, allowDiagonal)).Distinct();
 		}
 
 		public static IEnumerable<CPos> AdjacentCells(World w, Target target)

--- a/OpenRA.Game/Widgets/PerfGraphWidget.cs
+++ b/OpenRA.Game/Widgets/PerfGraphWidget.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Widgets
 			Game.Renderer.LineRenderer.DrawLine(origin + new float2(100, 0) * basis, origin + new float2(100, 100) * basis, Color.White, Color.White);
 
 			var k = 0;
-			foreach (var item in PerfHistory.Items.Values.ToArray())
+			foreach (var item in PerfHistory.Items.Values)
 			{
 				var n = 0;
 				item.Samples().Aggregate((a, b) =>
@@ -55,7 +55,7 @@ namespace OpenRA.Widgets
 			}
 
 			k = 0;
-			foreach (var item in PerfHistory.Items.Values.ToArray())
+			foreach (var item in PerfHistory.Items.Values)
 			{
 				Game.Renderer.Fonts["Tiny"].DrawText(item.Name, new float2(rect.Left, rect.Top) + new float2(18, 10 * k - 3), Color.White);
 				++k;

--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Widgets
 		public static int[] GetBorderSizes(string collection)
 		{
 			var images = new[] { "border-t", "border-b", "border-l", "border-r" };
-			var ss = images.Select(i => ChromeProvider.GetImage(collection, i)).ToArray();
+			var ss = images.Select(i => ChromeProvider.GetImage(collection, i)).ToList();
 			return new[] { (int)ss[0].Size.Y, (int)ss[1].Size.Y, (int)ss[2].Size.X, (int)ss[3].Size.X };
 		}
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -26,9 +26,16 @@ namespace OpenRA
 
 	public class World
 	{
+		class ActorIDComparer : IComparer<Actor>
+		{
+			public static readonly ActorIDComparer Instance = new ActorIDComparer();
+			private ActorIDComparer() { }
+			public int Compare(Actor x, Actor y) { return x.ActorID.CompareTo(y.ActorID); }
+		}
+
 		static readonly Func<MPos, bool> FalsePredicate = _ => false;
 		internal readonly TraitDictionary TraitDict = new TraitDictionary();
-		readonly HashSet<Actor> actors = new HashSet<Actor>();
+		readonly SortedSet<Actor> actors = new SortedSet<Actor>(ActorIDComparer.Instance);
 		readonly List<IEffect> effects = new List<IEffect>();
 		readonly Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
 
@@ -237,6 +244,7 @@ namespace OpenRA
 
 		public void Add(IEffect b) { effects.Add(b); }
 		public void Remove(IEffect b) { effects.Remove(b); }
+		public void RemoveAll(Predicate<IEffect> predicate) { effects.RemoveAll(predicate); }
 
 		public void AddFrameEndTask(Action<World> a) { frameEndActions.Enqueue(a); }
 

--- a/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Mods.Common.Lint
 			foreach (var actorInfo in map.Rules.Actors.Where(a => !a.Key.StartsWith("^")))
 				try
 				{
-					var traits = actorInfo.Value.TraitsInConstructOrder().ToArray();
-					if (traits.Length == 0)
+					var hasTraits = actorInfo.Value.TraitsInConstructOrder().Any();
+					if (!hasTraits)
 						emitWarning("Actor {0} has no traits. Is this intended?".F(actorInfo.Key));
 				}
 				catch (Exception e)

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -47,8 +47,8 @@ namespace OpenRA.Mods.Common.Orders
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
 
-			var ret = InnerOrder(world, xy, mi).ToList();
-			if (ret.Count > 0)
+			var ret = InnerOrder(world, xy, mi).ToArray();
+			if (ret.Length > 0)
 				world.CancelInputMode();
 
 			return ret;

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTDLoader.cs
@@ -203,14 +203,14 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 
 		public static void Write(Stream s, Size size, IEnumerable<byte[]> frames)
 		{
-			var compressedFrames = frames.Select(f => Format80.Encode(f)).ToArray();
+			var compressedFrames = frames.Select(f => Format80.Encode(f)).ToList();
 
 			// note: end-of-file and all-zeroes headers
-			var dataOffset = 14 + (compressedFrames.Length + 2) * 8;
+			var dataOffset = 14 + (compressedFrames.Count + 2) * 8;
 
 			using (var bw = new BinaryWriter(s))
 			{
-				bw.Write((ushort)compressedFrames.Length);
+				bw.Write((ushort)compressedFrames.Count);
 				bw.Write((ushort)0);
 				bw.Write((ushort)0);
 				bw.Write((ushort)size.Width);

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -103,8 +103,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		CPos? ChooseEmptyCellNear(Actor a, string unit)
 		{
-			var possibleCells = GetSuitableCells(a.Location, unit).Where(c => !usedCells.Contains(c)).ToArray();
-			if (possibleCells.Length == 0)
+			var possibleCells = GetSuitableCells(a.Location, unit).Where(c => !usedCells.Contains(c)).ToList();
+			if (possibleCells.Count == 0)
 				return null;
 
 			return possibleCells.Random(self.World.SharedRandom);

--- a/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			dudesValue /= 100;
 
 			var eligibleLocations = FootprintUtils.Tiles(self).ToList();
-			var actorTypes = info.ActorTypes.Select(a => new { Name = a, Cost = self.World.Map.Rules.Actors[a].Traits.Get<ValuedInfo>().Cost }).ToArray();
+			var actorTypes = info.ActorTypes.Select(a => new { Name = a, Cost = self.World.Map.Rules.Actors[a].Traits.Get<ValuedInfo>().Cost }).ToList();
 
 			while (eligibleLocations.Count > 0 && actorTypes.Any(a => a.Cost <= dudesValue))
 			{

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -29,9 +29,9 @@ namespace OpenRA.Mods.Common.Traits
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
-			var movementClasses = new HashSet<uint>(
+			var movementClasses =
 				world.Map.Rules.Actors.Where(ai => ai.Value.Traits.Contains<MobileInfo>())
-				.Select(ai => (uint)ai.Value.Traits.Get<MobileInfo>().GetMovementClass(world.TileSet)));
+				.Select(ai => (uint)ai.Value.Traits.Get<MobileInfo>().GetMovementClass(world.TileSet)).Distinct();
 
 			foreach (var mc in movementClasses)
 				domainIndexes[mc] = new MovementClassDomainIndex(world, mc);
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		/// Regenerate the domain index for a group of cells
 		public void UpdateCells(World world, IEnumerable<CPos> cells)
 		{
-			var dirty = new HashSet<CPos>(cells);
+			var dirty = cells.ToHashSet();
 			foreach (var index in domainIndexes)
 				index.Value.UpdateCells(world, dirty);
 		}

--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
-			var spawns = world.Map.GetSpawnPoints().ToList();
+			var spawns = world.Map.GetSpawnPoints();
 			var taken = world.LobbyInfo.Clients.Where(c => c.SpawnPoint != 0 && c.Slot != null)
 					.Select(c => spawns[c.SpawnPoint - 1]).ToList();
 			var available = spawns.Except(taken).ToList();

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Add map smudges
-			foreach (var s in w.Map.Smudges.Value.Where(s => smudges.Keys.Contains(s.Type)))
+			foreach (var s in w.Map.Smudges.Value.Where(s => smudges.ContainsKey(s.Type)))
 			{
 				var smudge = new Smudge
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
@@ -187,8 +187,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var wps = file.GetSection("Waypoints")
 					.Where(kv => Exts.ParseIntegerInvariant(kv.Value) > 0)
 					.Select(kv => Pair.New(Exts.ParseIntegerInvariant(kv.Key),
-						LocationFromMapOffset(Exts.ParseIntegerInvariant(kv.Value), mapSize)))
-					.ToArray();
+						LocationFromMapOffset(Exts.ParseIntegerInvariant(kv.Value), mapSize)));
 
 			// Add waypoint actors
 			foreach (var kv in wps)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ContainerWidget chatTemplate;
 		readonly TextFieldWidget chatText;
 
-		readonly List<INotifyChat> chatTraits;
+		readonly INotifyChat[] chatTraits;
 
 		readonly TabCompletionLogic tabCompletion = new TabCompletionLogic();
 
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.orderManager = orderManager;
 			this.modRules = modRules;
 
-			chatTraits = world.WorldActor.TraitsImplementing<INotifyChat>().ToList();
+			chatTraits = world.WorldActor.TraitsImplementing<INotifyChat>().ToArray();
 
 			var players = world.Players.Where(p => p != world.LocalPlayer && !p.NonCombatant && !p.IsBot);
 			disableTeamChat = world.LocalPlayer == null || world.LobbyInfo.IsSinglePlayer || !players.Any(p => p.IsAlliedWith(world.LocalPlayer));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -459,10 +459,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var techLevel = optionsBin.GetOrNull<DropDownButtonWidget>("TECHLEVEL_DROPDOWNBUTTON");
 			if (techLevel != null)
 			{
-				var techTraits = modRules.Actors["player"].Traits.WithInterface<ProvidesTechPrerequisiteInfo>().ToArray();
-				techLevel.IsVisible = () => techTraits.Length > 0;
-				optionsBin.GetOrNull<LabelWidget>("TECHLEVEL_DESC").IsVisible = () => techTraits.Length > 0;
-				techLevel.IsDisabled = () => Map.Status != MapStatus.Available || Map.Map.Options.TechLevel != null || configurationDisabled() || techTraits.Length <= 1;
+				var techTraits = modRules.Actors["player"].Traits.WithInterface<ProvidesTechPrerequisiteInfo>().ToList();
+				techLevel.IsVisible = () => techTraits.Count > 0;
+				optionsBin.GetOrNull<LabelWidget>("TECHLEVEL_DESC").IsVisible = () => techTraits.Count > 0;
+				techLevel.IsDisabled = () => Map.Status != MapStatus.Available || Map.Map.Options.TechLevel != null || configurationDisabled() || techTraits.Count <= 1;
 				techLevel.GetText = () => Map.Status != MapStatus.Available || Map.Map.Options.TechLevel != null ? "Not Available" : "{0}".F(orderManager.LobbyInfo.GlobalSettings.TechLevel);
 				techLevel.OnMouseDown = _ =>
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var spawns = preview.SpawnPoints;
 			return lobbyInfo.Clients
-				.Where(c => (c.SpawnPoint - 1 >= 0) && (c.SpawnPoint - 1 < spawns.Count))
+				.Where(c => (c.SpawnPoint - 1 >= 0) && (c.SpawnPoint - 1 < spawns.Length))
 				.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c));
 		}
 
@@ -164,7 +164,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var spawns = preview.SpawnPoints;
 			return players
-					.Where(c => (c.SpawnPoint - 1 >= 0) && (c.SpawnPoint - 1 < spawns.Count))
+					.Where(c => (c.SpawnPoint - 1 >= 0) && (c.SpawnPoint - 1 < spawns.Length))
 					.ToDictionary(c => spawns[c.SpawnPoint - 1], c => new SpawnOccupant(c));
 		}
 
@@ -430,7 +430,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var dropdown = parent.Get<DropDownButtonWidget>("SPAWN");
 			dropdown.IsDisabled = () => s.LockSpawn || orderManager.LocalClient.IsReady;
-			dropdown.OnMouseDown = _ => ShowSpawnDropDown(dropdown, c, orderManager, Enumerable.Range(0, map.SpawnPoints.Count + 1).Except(orderManager.LobbyInfo.Clients.Where(client => client != c && client.SpawnPoint != 0).Select(client => client.SpawnPoint)));
+			dropdown.OnMouseDown = _ =>
+			{
+				var spawnPoints = Enumerable.Range(0, map.SpawnPoints.Length + 1).Except(
+					orderManager.LobbyInfo.Clients.Where(
+					client => client != c && client.SpawnPoint != 0).Select(client => client.SpawnPoint));
+				ShowSpawnDropDown(dropdown, c, orderManager, spawnPoints);
+			};
 			dropdown.GetText = () => (c.SpawnPoint == 0) ? "-" : Convert.ToChar('A' - 1 + c.SpawnPoint).ToString();
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		string selectedUid;
 
 		// May be a subset of available maps if a mode filter is active
-		List<string> visibleMaps;
+		string[] visibleMaps;
 
 		ScrollPanelWidget scrollpanel;
 		ScrollItemWidget itemTemplate;
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					selectedUid = uid;
 					scrollpanel.ScrollToItem(uid, smooth: true);
 				};
-				randomMapButton.IsDisabled = () => visibleMaps == null || visibleMaps.Count == 0;
+				randomMapButton.IsDisabled = () => visibleMaps == null || visibleMaps.Length == 0;
 			}
 
 			EnumerateMaps(onSelect, filter);
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				scrollpanel.AddChild(item);
 			}
 
-			visibleMaps = maps.Select(m => m.Uid).ToList();
+			visibleMaps = maps.Select(m => m.Uid).ToArray();
 			if (visibleMaps.Contains(selectedUid))
 				scrollpanel.ScrollToItem(selectedUid);
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var ddb = panel.GetOrNull<DropDownButtonWidget>("FLT_MAPNAME_DROPDOWNBUTTON");
 				if (ddb != null)
 				{
-					var options = new HashSet<string>(replays.Select(r => r.GameInfo.MapTitle), StringComparer.OrdinalIgnoreCase).ToList();
+					var options = replays.Select(r => r.GameInfo.MapTitle).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 					options.Sort(StringComparer.OrdinalIgnoreCase);
 					options.Insert(0, null);	// no filter
 
@@ -231,7 +231,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var ddb = panel.GetOrNull<DropDownButtonWidget>("FLT_PLAYER_DROPDOWNBUTTON");
 				if (ddb != null)
 				{
-					var options = new HashSet<string>(replays.SelectMany(r => r.GameInfo.Players.Select(p => p.Name)), StringComparer.OrdinalIgnoreCase).ToList();
+					var options = replays.SelectMany(r => r.GameInfo.Players.Select(p => p.Name)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 					options.Sort(StringComparer.OrdinalIgnoreCase);
 					options.Insert(0, null);	// no filter
 
@@ -295,7 +295,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					ddb.IsDisabled = () => string.IsNullOrEmpty(filter.PlayerName);
 
-					var options = new HashSet<string>(replays.SelectMany(r => r.GameInfo.Players.Select(p => p.FactionName).Where(n => !string.IsNullOrEmpty(n))), StringComparer.OrdinalIgnoreCase).ToList();
+					var options = replays.SelectMany(r => r.GameInfo.Players.Select(p => p.FactionName).Where(n => !string.IsNullOrEmpty(n))).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 					options.Sort(StringComparer.OrdinalIgnoreCase);
 					options.Insert(0, null);	// no filter
 

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -281,7 +281,7 @@ namespace OpenRA.Mods.Common.Widgets
 					Hotkey = ks.GetProductionHotkey(DisplayedIconCount),
 					Sprite = icon.Image,
 					Pos = new float2(rect.Location),
-					Queued = CurrentQueue.AllQueued().Where(a => a.Item == item.Name).ToList(),
+					Queued = CurrentQueue.AllQueued().Where(a => a.Item == item.Name).ToList()
 				};
 
 				icons.Add(rect, pi);

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -196,7 +196,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var allQueues = a.World.ActorsWithTrait<ProductionQueue>()
 					.Where(p => p.Actor.Owner == p.Actor.World.LocalPlayer && p.Actor.IsInWorld && p.Trait.Enabled)
-					.Select(p => p.Trait).ToArray();
+					.Select(p => p.Trait).ToList();
 
 				foreach (var g in Groups.Values)
 					g.Update(allQueues);

--- a/OpenRA.Mods.D2k/Traits/World/ChooseBuildTabOnSelect.cs
+++ b/OpenRA.Mods.D2k/Traits/World/ChooseBuildTabOnSelect.cs
@@ -57,9 +57,9 @@ namespace OpenRA.Mods.D2k.Traits
 			var types = world.Selection.Actors.Where(a => a.IsInWorld && (a.World.LocalPlayer == a.Owner))
 				.SelectMany(a => a.TraitsImplementing<Production>())
 				.SelectMany(t => t.Info.Produces)
-				.ToArray();
+				.ToHashSet();
 
-			if (types.Length == 0)
+			if (types.Count == 0)
 				return;
 
 			palette.SetCurrentTab(world.LocalPlayer.PlayerActor.TraitsImplementing<ProductionQueue>()

--- a/OpenRA.Mods.D2k/Widgets/BuildPaletteWidget.cs
+++ b/OpenRA.Mods.D2k/Widgets/BuildPaletteWidget.cs
@@ -215,12 +215,12 @@ namespace OpenRA.Mods.D2k.Widgets
 
 			if (queue != null)
 			{
-				var buildableItems = queue.BuildableItems().ToArray();
-				var allBuildables = queue.AllItems().OrderBy(a => a.Traits.Get<BuildableInfo>().BuildPaletteOrder).ToArray();
+				var buildableItems = queue.BuildableItems().ToList();
+				var allBuildables = queue.AllItems().OrderBy(a => a.Traits.Get<BuildableInfo>().BuildPaletteOrder).ToList();
 
 				var overlayBits = new List<Pair<Sprite, float2>>();
 				var textBits = new List<Pair<float2, string>>();
-				numActualRows = Math.Max((allBuildables.Count() + Columns - 1) / Columns, Rows);
+				numActualRows = Math.Max((allBuildables.Count + Columns - 1) / Columns, Rows);
 
 				// Palette Background
 				WidgetUtils.DrawRGBA(ChromeProvider.GetImage(paletteCollection, "top"), new float2(origin.X - 9, origin.Y - 9));

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.RA.AI
 			if (!buildableThings.Any())
 				return null;
 
-			var unit = buildableThings.ElementAtOrDefault(Random.Next(buildableThings.Count()));
+			var unit = buildableThings.Random(Random);
 			return HasAdequateAirUnits(unit) ? unit : null;
 		}
 
@@ -231,11 +231,11 @@ namespace OpenRA.Mods.RA.AI
 			var myUnits = Player.World
 				.ActorsWithTrait<IPositionable>()
 				.Where(a => a.Actor.Owner == Player)
-				.Select(a => a.Actor.Info.Name).ToArray();
+				.Select(a => a.Actor.Info.Name).ToList();
 
 			foreach (var unit in Info.UnitsToBuild.Shuffle(Random))
 				if (buildableThings.Any(b => b.Name == unit.Key))
-					if (myUnits.Count(a => a == unit.Key) < unit.Value * myUnits.Length)
+					if (myUnits.Count(a => a == unit.Key) < unit.Value * myUnits.Count)
 						if (HasAdequateAirUnits(Map.Rules.Actors[unit.Key]))
 							return Map.Rules.Actors[unit.Key];
 
@@ -463,12 +463,9 @@ namespace OpenRA.Mods.RA.AI
 		{
 			var enemyUnits = World.FindActorsInCircle(pos, radius)
 				.Where(unit => Player.Stances[unit.Owner] == Stance.Enemy &&
-					!unit.HasTrait<Husk>() && unit.HasTrait<ITargetable>()).ToList();
+					!unit.HasTrait<Husk>() && unit.HasTrait<ITargetable>());
 
-			if (enemyUnits.Count > 0)
-				return enemyUnits.ClosestTo(pos);
-
-			return null;
+			return enemyUnits.ClosestTo(pos);
 		}
 
 		List<Actor> FindEnemyConstructionYards()
@@ -645,7 +642,7 @@ namespace OpenRA.Mods.RA.AI
 			{
 				var ownUnits = World.FindActorsInCircle(World.Map.CenterOfCell(BaseCenter), WRange.FromCells(Info.ProtectUnitScanRadius))
 					.Where(unit => unit.Owner == Player && !unit.HasTrait<Building>()
-						&& unit.HasTrait<AttackBase>()).ToList();
+						&& unit.HasTrait<AttackBase>());
 
 				foreach (var a in ownUnits)
 					protectSq.Units.Add(a);

--- a/OpenRA.Mods.RA/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.RA/AI/States/GroundStates.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.RA.AI
 			if (leader == null)
 				return;
 			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WRange.FromCells(owner.Units.Count) / 3)
-				.Where(a => a.Owner == owner.Units.FirstOrDefault().Owner && owner.Units.Contains(a)).ToList();
+				.Where(a => a.Owner == owner.Units.FirstOrDefault().Owner && owner.Units.Contains(a)).ToHashSet();
 			if (ownUnits.Count < owner.Units.Count)
 			{
 				owner.World.IssueOrder(new Order("Stop", leader, false));
@@ -94,11 +94,12 @@ namespace OpenRA.Mods.RA.AI
 			else
 			{
 				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WRange.FromCells(12))
-					.Where(a1 => !a1.Destroyed && !a1.IsDead).ToList();
-				var enemynearby = enemies.Where(a1 => a1.HasTrait<ITargetable>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy).ToList();
-				if (enemynearby.Any())
+					.Where(a1 => !a1.Destroyed && !a1.IsDead);
+				var enemynearby = enemies.Where(a1 => a1.HasTrait<ITargetable>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
+				var target = enemynearby.ClosestTo(leader.CenterPosition);
+				if (target != null)
 				{
-					owner.TargetActor = enemynearby.ClosestTo(leader.CenterPosition);
+					owner.TargetActor = target;
 					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackState(), true);
 					return;
 				}

--- a/OpenRA.Mods.RA/AI/States/StateBase.cs
+++ b/OpenRA.Mods.RA/AI/States/StateBase.cs
@@ -34,8 +34,8 @@ namespace OpenRA.Mods.RA.AI
 		{
 			var location = squad.Bot.BaseCenter;
 			var buildings = squad.World.ActorsWithTrait<Building>()
-				.Where(a => a.Actor.Owner == squad.Bot.Player).Select(a => a.Actor).ToArray();
-			if (buildings.Length > 0)
+				.Where(a => a.Actor.Owner == squad.Bot.Player).Select(a => a.Actor).ToList();
+			if (buildings.Count > 0)
 				location = buildings.Random(squad.Random).Location;
 			return location;
 		}

--- a/OpenRA.Mods.RA/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.RA/Traits/Attack/AttackGarrisoned.cs
@@ -95,9 +95,9 @@ namespace OpenRA.Mods.RA.Traits
 			paxFacing.Add(passenger, passenger.Trait<IFacing>());
 			paxPos.Add(passenger, passenger.Trait<IPositionable>());
 			paxRender.Add(passenger, passenger.Trait<RenderSprites>());
-			armaments = armaments.Append(passenger.TraitsImplementing<Armament>()
-				.Where(a => info.Armaments.Contains(a.Info.Name))
-				.ToArray()).ToList();
+			armaments.AddRange(
+				passenger.TraitsImplementing<Armament>()
+				.Where(a => info.Armaments.Contains(a.Info.Name)));
 		}
 
 		public void PassengerExited(Actor self, Actor passenger)
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.RA.Traits
 			base.Tick(self);
 
 			// Take a copy so that Tick() can remove animations
-			foreach (var m in muzzles.ToList())
+			foreach (var m in muzzles.ToArray())
 				m.Animation.Tick();
 		}
 	}

--- a/OpenRA.Mods.RA/Traits/Harvester.cs
+++ b/OpenRA.Mods.RA/Traits/Harvester.cs
@@ -137,11 +137,8 @@ namespace OpenRA.Mods.RA.Traits
 						return occupancy * 12;
 					}));
 
-			// Reverse the found-path to find the refinery location instead of our location:
-			path.Reverse();
-
 			if (path.Count != 0)
-				return refs[path[0]].Actor;
+				return refs[path.Last()].Actor;
 
 			return null;
 		}

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -57,11 +57,11 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			var range = ((ChronoshiftPowerInfo)Info).Range;
 			var tiles = Self.World.Map.FindTilesInCircle(xy, range);
-			var units = new List<Actor>();
+			var units = new HashSet<Actor>();
 			foreach (var t in tiles)
-				units.AddRange(Self.World.ActorMap.GetUnitsAt(t));
+				units.UnionWith(Self.World.ActorMap.GetUnitsAt(t));
 
-			return units.Distinct().Where(a => a.HasTrait<Chronoshiftable>() &&
+			return units.Where(a => a.HasTrait<Chronoshiftable>() &&
 				!a.TraitsImplementing<IPreventsTeleport>().Any(condition => condition.PreventsTeleport(a)));
 		}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/InstallFromCDLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/InstallFromCDLogic.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var extractFiles = Game.ModData.Manifest.ContentInstaller.ExtractFilesFromCD;
 
 			var installCounter = 0;
-			var installTotal = copyFiles.Count() + extractFiles.Count();
+			var installTotal = copyFiles.Length + extractFiles.Length;
 			var onProgress = (Action<string>)(s => Game.RunAfterTick(() =>
 			{
 				progressBar.Percentage = installCounter * 100 / installTotal;

--- a/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.RA/Widgets/WorldCommandWidget.cs
@@ -188,19 +188,19 @@ namespace OpenRA.Mods.RA.Widgets
 		{
 			var bases = world.ActorsWithTrait<BaseBuilding>()
 				.Where(a => a.Actor.Owner == world.LocalPlayer)
-				.ToArray();
+				.Select(b => b.Actor)
+				.ToList();
 
 			if (!bases.Any())
 				return true;
 
 			var next = bases
-				.Select(b => b.Actor)
 				.SkipWhile(b => !world.Selection.Actors.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 
 			if (next == null)
-				next = bases.Select(b => b.Actor).First();
+				next = bases.First();
 
 			world.Selection.Combine(world, new Actor[] { next }, false, true);
 
@@ -212,19 +212,19 @@ namespace OpenRA.Mods.RA.Widgets
 			var facilities = world.ActorsWithTrait<Production>()
 				.Where(a => a.Actor.Owner == world.LocalPlayer && !a.Actor.HasTrait<BaseBuilding>())
 				.OrderBy(f => f.Actor.Info.Traits.Get<ProductionInfo>().Produces.First())
-				.ToArray();
+				.Select(b => b.Actor)
+				.ToList();
 
 			if (!facilities.Any())
 				return true;
 
 			var next = facilities
-				.Select(b => b.Actor)
 				.SkipWhile(b => !world.Selection.Actors.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 
 			if (next == null)
-				next = facilities.Select(b => b.Actor).First();
+				next = facilities.First();
 
 			world.Selection.Combine(world, new Actor[] { next }, false, true);
 


### PR DESCRIPTION
- Made Array.IndexOf available via extension method.
- Made ToHashSet extension method.
- Change collections queried often via Contains into sets.
- Avoid Count() extension if Count or Length property exist.
- Made Count() > 0 checks and variations calls to Any() instead.
- Don't call ToList/ToArray if there is no benefit to materializing the sequence.
- If the sequence does benefit from materialization, follow this general pattern:
  - Collection queried often via Contains use ToHashSet to speed up lookups.
  - Short lived variables use ToList. This is because ToArray requires an extra copy to output the final size.
  - Collections persisted into fields or for a long time use ToArray to minimize memory overhead.
