### PR TITLE
Improve YAML parse time.

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -142,7 +142,7 @@ namespace OpenRA
 			return nd.ContainsKey(s) ? nd[s].Nodes : new List<MiniYamlNode>();
 		}
 
-		static List<MiniYamlNode> FromLines(string[] lines, string filename)
+		static List<MiniYamlNode> FromLines(IEnumerable<string> lines, string filename)
 		{
 			var levels = new List<List<MiniYamlNode>>();
 			levels.Add(new List<MiniYamlNode>());
@@ -152,8 +152,9 @@ namespace OpenRA
 			{
 				var line = ll;
 				++lineNo;
-				if (line.Contains('#'))
-					line = line.Substring(0, line.IndexOf('#')).TrimEnd(' ', '\t');
+				var commentIndex = line.IndexOf('#');
+				if (commentIndex != -1)
+					line = line.Substring(0, commentIndex).TrimEnd(' ', '\t');
 				var t = line.TrimStart(' ', '\t');
 				if (t.Length == 0)
 					continue;
@@ -189,12 +190,8 @@ namespace OpenRA
 
 		public static List<MiniYamlNode> FromFileInPackage(string path)
 		{
-			var lines = new List<string>();
 			using (var stream = GlobalFileSystem.Open(path))
-			using (var reader = new StreamReader(stream))
-				while (!reader.EndOfStream)
-					lines.Add(reader.ReadLine());
-			return FromLines(lines.ToArray(), path);
+				return FromLines(stream.ReadAllLines(), path);
 		}
 
 		public static Dictionary<string, MiniYaml> DictFromFile(string path)

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -124,17 +124,10 @@ namespace OpenRA
 
 		public static IEnumerable<string> ReadAllLines(this Stream s)
 		{
+			string line;
 			using (var sr = new StreamReader(s))
-			{
-				for (;;)
-				{
-					var line = sr.ReadLine();
-					if (line == null)
-						yield break;
-					else
-						yield return line;
-				}
-			}
+				while ((line = sr.ReadLine()) != null)
+					yield return line;
 		}
 
 		// The string is assumed to be length-prefixed, as written by WriteString()


### PR DESCRIPTION
Stream lines to avoid needing to load the whole file first, and avoid a LINQ Contains call when string.IndexOf will be much faster.
