### PR TITLE
Fail the whole script when nuget fails

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Die on any error for Travis CI to automatically retry:
+set -e
+
 if [ ! -f StyleCop.dll ]; then
 	echo "Fetching StyleCop files from nuget"
 	nuget install StyleCop.MSBuild -Version 4.7.49.0


### PR DESCRIPTION
Only tested it locally with `nuget: command not found`.
