### PR TITLE
Fixed high CPU usage due to Socket.Select not blocking the thread properly when the game started

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Also thanks to:
     * Andrew Perkins
     * Andrew Riedi
     * Andreas Beck (baxtor)
+    * Ang Soon Li (asl97)
     * Arik Lirette (Angusm3)
     * Barnaby Smith (mvi)
     * Bellator

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -156,11 +156,11 @@ namespace OpenRA.Server
 				for (;;)
 				{
 					var checkRead = new List<Socket>();
-					checkRead.Add(listener.Server);
+					if (State == ServerState.WaitingPlayers) checkRead.Add(listener.Server);
 					foreach (var c in Conns) checkRead.Add(c.socket);
 					foreach (var c in PreConns) checkRead.Add(c.socket);
 
-					Socket.Select(checkRead, null, null, timeout);
+					if (checkRead.Count > 0) Socket.Select(checkRead, null, null, timeout);
 					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();


### PR DESCRIPTION
As discussed in #7237.
