### PR TITLE
Replaced GitHub access token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: "cMC68erxuf0jb4Pe0sOH4m1f7I2LWPUatD9BC0WeZ9PwTnWOzrm0hnjZIES4TTKVo8WIfZIiCfxpdAFeoh6bomG2MsKwSKMc8qHGhfNGqPnyzYh6zdPZaA+4Q3TDQI3DrziyDnQUFeH1h/7UZLDLxtDrOtcYcGdNg5VjvV9fJ7g="
+    secure: "g/LU11f+mjqv+lj0sR1UliHwogXL4ofJUwoG5Dbqlvdf5UTLWytw/OWSCv8RGyuh10miyWeaoqHh1cn2C1IFhUEqN1sSeKKKOWOTvJ2FR5mzi9uH3d/MOBzG5icQ7Qh0fZ1YPz5RaJJhYu6bmfvA/1gD49GoaX2kxQL4J5cEBgg="
   file:
     - build/OpenRA-${TRAVIS_TAG}.exe
     - build/OpenRA-${TRAVIS_TAG}.zip


### PR DESCRIPTION
This is a related security issue such as https://github.com/OpenRA/OpenRAWeb/pull/179 and I also took the time to give access to the @orabot account instead of myself. I already revoked all my GitHub access tokens so you can't use GitHub releases until this is merged.
