### PR TITLE
Refactored NotifyBlocker() (and several overloads) into ActorExts

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -202,16 +202,6 @@ namespace OpenRA.Mods.Common.Activities
 				throw new InvalidOperationException("(Move) Sanity check failed");
 		}
 
-		static void NotifyBlocker(Actor self, CPos nextCell)
-		{
-			foreach (var blocker in self.World.ActorMap.GetUnitsAt(nextCell))
-			{
-				// Notify the blocker that he's blocking our move:
-				foreach (var moveBlocked in blocker.TraitsImplementing<INotifyBlockingMove>())
-					moveBlocked.OnNotifyBlockingMove(blocker, self);
-			}
-		}
-
 		Pair<CPos, SubCell>? PopPath(Actor self, Mobile mobile)
 		{
 			if (path.Count == 0)
@@ -233,7 +223,7 @@ namespace OpenRA.Mods.Common.Activities
 				// See if they will move
 				if (!hasNotifiedBlocker)
 				{
-					NotifyBlocker(self, nextCell);
+					self.NotifyBlocker(nextCell);
 					hasNotifiedBlocker = true;
 				}
 

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -68,11 +68,7 @@ namespace OpenRA.Mods.Common.Activities
 			var exitSubCell = ChooseExitSubCell(actor);
 			if (exitSubCell == null)
 			{
-				foreach (var blocker in BlockedExitCells(actor).SelectMany(p => self.World.ActorMap.GetUnitsAt(p)))
-				{
-					foreach (var nbm in blocker.TraitsImplementing<INotifyBlockingMove>())
-						nbm.OnNotifyBlockingMove(blocker, self);
-				}
+				self.NotifyBlocker(BlockedExitCells(actor));
 
 				return Util.SequenceActivities(new Wait(10), this);
 			}

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -8,7 +8,9 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -76,6 +78,25 @@ namespace OpenRA.Mods.Common
 			}
 
 			return Target.Invalid;
+		}
+
+		public static void NotifyBlocker(this Actor self, IEnumerable<Actor> blockers)
+		{
+			foreach (var blocker in blockers)
+			{
+				foreach (var moveBlocked in blocker.TraitsImplementing<INotifyBlockingMove>())
+					moveBlocked.OnNotifyBlockingMove(blocker, self);
+			}
+		}
+
+		public static void NotifyBlocker(this Actor self, CPos position)
+		{
+			NotifyBlocker(self, self.World.ActorMap.GetUnitsAt(position));
+		}
+
+		public static void NotifyBlocker(this Actor self, IEnumerable<CPos> positions)
+		{
+			NotifyBlocker(self, positions.SelectMany(p => self.World.ActorMap.GetUnitsAt(p)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -12,9 +12,9 @@ using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -119,12 +119,7 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			var mobileInfo = producee.Traits.GetOrDefault<MobileInfo>();
 
-			foreach (var blocker in self.World.ActorMap.GetUnitsAt(self.Location + s.ExitCell))
-			{
-				// Notify the blocker that he's blocking our move:
-				foreach (var moveBlocked in blocker.TraitsImplementing<INotifyBlockingMove>())
-					moveBlocked.OnNotifyBlockingMove(blocker, self);
-			}
+			self.NotifyBlocker(self.Location + s.ExitCell);
 
 			return mobileInfo == null ||
 				mobileInfo.CanEnterCell(self.World, self, self.Location + s.ExitCell, self);


### PR DESCRIPTION
Moved the notification of blocking actors (INotifyBlockingMove) into Actor class, it was used in three different places more or less the same way.
