### PR TITLE
Moving more files to Common

### DIFF
--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -9,13 +9,11 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Activities
+namespace OpenRA.Mods.Common.Activities
 {
 	public abstract class Enter : Activity
 	{

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -8,10 +8,9 @@
  */
 #endregion
 
-using OpenRA.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Activities
+namespace OpenRA.Mods.Common.Activities
 {
 	class RepairBuilding : Enter
 	{

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -9,9 +9,10 @@
 #endregion
 
 using System.Drawing;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common
 {
 	public static class ActorExts
 	{

--- a/OpenRA.Mods.Common/Effects/Rank.cs
+++ b/OpenRA.Mods.Common/Effects/Rank.cs
@@ -11,8 +11,9 @@
 using System.Collections.Generic;
 using OpenRA.Effects;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 
-namespace OpenRA.Mods.RA.Effects
+namespace OpenRA.Mods.Common.Effects
 {
 	class Rank : IEffect
 	{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Traits\Player\GlobalUpgradeManager.cs" />
     <Compile Include="Traits\Player\MissionObjectives.cs" />
     <Compile Include="Traits\Player\PlaceBeacon.cs" />
+    <Compile Include="Traits\Player\PlayerStatistics.cs" />
     <Compile Include="Traits\Player\ProvidesCustomPrerequisite.cs" />
     <Compile Include="Traits\Player\ProvidesTechPrerequisite.cs" />
     <Compile Include="Traits\Player\StrategicVictoryConditions.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Traits\Buildings\RepairsUnits.cs" />
     <Compile Include="Traits\Buildings\FootprintUtils.cs" />
     <Compile Include="Traits\Burns.cs" />
+    <Compile Include="Traits\DetectCloaked.cs" />
     <Compile Include="Traits\GainsExperience.cs" />
     <Compile Include="Traits\GivesBounty.cs" />
     <Compile Include="Traits\GivesExperience.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Effects\NukeLaunch.cs" />
     <Compile Include="Effects\PowerdownIndicator.cs" />
     <Compile Include="Effects\RallyPointIndicator.cs" />
+    <Compile Include="Effects\Rank.cs" />
     <Compile Include="Effects\Smoke.cs" />
     <Compile Include="Commands\ChatCommands.cs" />
     <Compile Include="Commands\DevCommands.cs" />
@@ -134,6 +135,9 @@
     <Compile Include="Traits\Buildings\RepairsUnits.cs" />
     <Compile Include="Traits\Buildings\FootprintUtils.cs" />
     <Compile Include="Traits\Burns.cs" />
+    <Compile Include="Traits\GainsExperience.cs" />
+    <Compile Include="Traits\GivesBounty.cs" />
+    <Compile Include="Traits\GivesExperience.cs" />
     <Compile Include="Traits\Huntable.cs" />
     <Compile Include="Traits\CustomBuildTimeValue.cs" />
     <Compile Include="Traits\CustomSellValue.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -56,11 +56,14 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Activities\Enter.cs" />
     <Compile Include="Activities\Move\Drag.cs" />
     <Compile Include="Activities\RemoveSelf.cs" />
+    <Compile Include="Activities\RepairBuilding.cs" />
     <Compile Include="Activities\SimpleTeleport.cs" />
     <Compile Include="Activities\Turn.cs" />
     <Compile Include="Activities\Wait.cs" />
+    <Compile Include="ActorExts.cs" />
     <Compile Include="Effects\Beacon.cs" />
     <Compile Include="Effects\Bullet.cs" />
     <Compile Include="Effects\Contrail.cs" />
@@ -135,7 +138,9 @@
     <Compile Include="Traits\Buildings\RepairsUnits.cs" />
     <Compile Include="Traits\Buildings\FootprintUtils.cs" />
     <Compile Include="Traits\Burns.cs" />
+    <Compile Include="Traits\IgnoresDisguise.cs" />
     <Compile Include="Traits\DetectCloaked.cs" />
+    <Compile Include="Traits\EngineerRepair.cs" />
     <Compile Include="Traits\GainsExperience.cs" />
     <Compile Include="Traits\GivesBounty.cs" />
     <Compile Include="Traits\GivesExperience.cs" />

--- a/OpenRA.Mods.Common/Traits/DetectCloaked.cs
+++ b/OpenRA.Mods.Common/Traits/DetectCloaked.cs
@@ -10,10 +10,10 @@
 
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can reveal Cloak actors in a specified range.")]
-	class DetectCloakedInfo : TraitInfo<DetectCloaked>
+	public class DetectCloakedInfo : TraitInfo<DetectCloaked>
 	{
 		[Desc("Specific cloak classifications I can reveal.")]
 		public readonly string[] CloakTypes = { "Cloak" };
@@ -22,5 +22,5 @@ namespace OpenRA.Mods.RA
 		public readonly int Range = 5;
 	}
 
-	class DetectCloaked { }
+	public class DetectCloaked { }
 }

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -10,11 +10,11 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Can instantly repair other actors, but gets consumed afterwards.")]
 	class EngineerRepairInfo : TraitInfo<EngineerRepair> { }

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -12,12 +12,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Effects;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor's experience increases when it has killed a GivesExperience actor.")]
 	public class GainsExperienceInfo : ITraitInfo, Requires<ValuedInfo>
@@ -125,7 +123,7 @@ namespace OpenRA.Mods.RA
 
 	class ExperienceInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] public readonly int value = 0;
+		[FieldFromYamlKey] readonly int value;
 		public ExperienceInit() { }
 		public ExperienceInit(int init) { value = init; }
 		public int Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -13,7 +13,7 @@ using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("You get money for playing this actor.")]
 	class GivesBountyInfo : TraitInfo<GivesBounty>

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -8,10 +8,9 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor gives experience to a GainsExperience actor when they are killed.")]
 	class GivesExperienceInfo : ITraitInfo

--- a/OpenRA.Mods.Common/Traits/IgnoresDisguise.cs
+++ b/OpenRA.Mods.Common/Traits/IgnoresDisguise.cs
@@ -1,0 +1,19 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+    [Desc("Allows automatic targeting of disguised actors.")]
+    class IgnoresDisguiseInfo : TraitInfo<IgnoresDisguise> { }
+
+    class IgnoresDisguise { }
+}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -10,11 +10,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor to collect observer stats.")]
 	public class PlayerStatisticsInfo : ITraitInfo

--- a/OpenRA.Mods.RA/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.RA/Activities/CaptureActor.cs
@@ -8,7 +8,7 @@
  */
 #endregion
 
-using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Activities/Demolish.cs
+++ b/OpenRA.Mods.RA/Activities/Demolish.cs
@@ -10,10 +10,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
 using OpenRA.Effects;
-using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
+using OpenRA.Mods.RA.Traits;
 
 namespace OpenRA.Mods.RA.Activities
 {

--- a/OpenRA.Mods.RA/Activities/DonateSupplies.cs
+++ b/OpenRA.Mods.RA/Activities/DonateSupplies.cs
@@ -8,7 +8,7 @@
  */
 #endregion
 
-using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.RA/Activities/EnterTransport.cs
@@ -9,8 +9,7 @@
 #endregion
 
 using System;
-using System.Linq;
-using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Activities

--- a/OpenRA.Mods.RA/Activities/Hunt.cs
+++ b/OpenRA.Mods.RA/Activities/Hunt.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Traits;

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -8,7 +8,7 @@
  */
 #endregion
 
-using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.RA/Activities/RepairBridge.cs
@@ -8,7 +8,7 @@
  */
 #endregion
 
-using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Attack/AttackBase.cs
+++ b/OpenRA.Mods.RA/Attack/AttackBase.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.GameRules;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/AutoHeal.cs
+++ b/OpenRA.Mods.RA/AutoHeal.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits

--- a/OpenRA.Mods.RA/AutoTarget.cs
+++ b/OpenRA.Mods.RA/AutoTarget.cs
@@ -10,7 +10,7 @@
 
 using System.Drawing;
 using System.Linq;
-using OpenRA.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits

--- a/OpenRA.Mods.RA/C4Demolition.cs
+++ b/OpenRA.Mods.RA/C4Demolition.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Captures.cs
+++ b/OpenRA.Mods.RA/Captures.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Disguise.cs
+++ b/OpenRA.Mods.RA/Disguise.cs
@@ -135,8 +135,4 @@ namespace OpenRA.Mods.RA.Traits
 
 		public void Attacking(Actor self, Target target, Armament a, Barrel barrel) { DisguiseAs(self, null); }
 	}
-
-	[Desc("Allows automatic targeting of disguised actors.")]
-	class IgnoresDisguiseInfo : TraitInfo<IgnoresDisguise> { }
-	class IgnoresDisguise { }
 }

--- a/OpenRA.Mods.RA/ExternalCaptures.cs
+++ b/OpenRA.Mods.RA/ExternalCaptures.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Guard.cs
+++ b/OpenRA.Mods.RA/Guard.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -106,7 +106,6 @@
     <Compile Include="Activities\DeliverResources.cs" />
     <Compile Include="Activities\Demolish.cs" />
     <Compile Include="Activities\DonateSupplies.cs" />
-    <Compile Include="Activities\Enter.cs" />
     <Compile Include="Activities\EnterTransport.cs" />
     <Compile Include="Activities\FindResources.cs" />
     <Compile Include="Activities\Follow.cs" />
@@ -118,12 +117,10 @@
     <Compile Include="Activities\RAHarvesterDockSequence.cs" />
     <Compile Include="Activities\Rearm.cs" />
     <Compile Include="Activities\Repair.cs" />
-    <Compile Include="Activities\RepairBuilding.cs" />
     <Compile Include="Activities\Sell.cs" />
     <Compile Include="Activities\Teleport.cs" />
     <Compile Include="Activities\Transform.cs" />
     <Compile Include="Activities\UnloadCargo.cs" />
-    <Compile Include="ActorExts.cs" />
     <Compile Include="AI\SupportPowerDecision.cs" />
     <Compile Include="Attack\AttackTurreted.cs" />
     <Compile Include="Crushable.cs" />
@@ -175,7 +172,6 @@
     <Compile Include="Effects\Parachute.cs" />
     <Compile Include="Effects\RepairIndicator.cs" />
     <Compile Include="EmitInfantryOnSell.cs" />
-    <Compile Include="EngineerRepair.cs" />
     <Compile Include="Explodes.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Invulnerable.cs" />

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -127,12 +127,10 @@
     <Compile Include="Attack\AttackTurreted.cs" />
     <Compile Include="Crushable.cs" />
     <Compile Include="Effects\GpsSatellite.cs" />
-    <Compile Include="Effects\Rank.cs" />
     <Compile Include="Effects\SatelliteLaunch.cs" />
     <Compile Include="Effects\TeslaZap.cs" />
     <Compile Include="Render\RenderUnitReload.cs" />
     <Compile Include="Graphics\TeslaZapRenderable.cs" />
-    <Compile Include="GainsExperience.cs" />
     <Compile Include="EjectOnDeath.cs" />
     <Compile Include="AI\RushFuzzy.cs" />
     <Compile Include="AI\StateMachine.cs" />
@@ -179,8 +177,6 @@
     <Compile Include="EmitInfantryOnSell.cs" />
     <Compile Include="EngineerRepair.cs" />
     <Compile Include="Explodes.cs" />
-    <Compile Include="GivesBounty.cs" />
-    <Compile Include="GivesExperience.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="Invulnerable.cs" />
     <Compile Include="Captures.cs" />

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -170,7 +170,6 @@
     <Compile Include="Traits\Crates\RevealMapCrateAction.cs" />
     <Compile Include="Traits\Crates\SupportPowerCrateAction.cs" />
     <Compile Include="Traits\DemoTruck.cs" />
-    <Compile Include="DetectCloaked.cs" />
     <Compile Include="Effects\GpsDot.cs" />
     <Compile Include="Effects\Parachute.cs" />
     <Compile Include="Effects\RepairIndicator.cs" />

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -97,6 +97,7 @@
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />
     <Compile Include="AI\BaseBuilder.cs" />
     <Compile Include="AI\HackyAI.cs" />
+    <Compile Include="Player\AllyRepair.cs" />
     <Compile Include="Render\WithIdleOverlay.cs" />
     <Compile Include="Traits\AcceptsSupplies.cs" />
     <Compile Include="Activities\Attack.cs" />
@@ -197,8 +198,6 @@
     <Compile Include="Orders\RepairOrderGenerator.cs" />
     <Compile Include="ParaDrop.cs" />
     <Compile Include="Passenger.cs" />
-    <Compile Include="Player\PlayerStatistics.cs" />
-    <Compile Include="Player\AllyRepair.cs" />
     <Compile Include="Player\ClassicProductionQueue.cs" />
     <Compile Include="Player\PlaceBuilding.cs" />
     <Compile Include="Player\ProductionQueue.cs" />

--- a/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/RepairOrderGenerator.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Player/AllyRepair.cs
+++ b/OpenRA.Mods.RA/Player/AllyRepair.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits

--- a/OpenRA.Mods.RA/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.RA/RenderDetectionCircle.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits

--- a/OpenRA.Mods.RA/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.RA/Traits/Air/Aircraft.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Activities;

--- a/OpenRA.Mods.RA/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/RepairableBuilding.cs
@@ -9,11 +9,11 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.RA.Effects;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits

--- a/OpenRA.Mods.RA/Traits/Crates/LevelUpCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/LevelUpCrateAction.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {

--- a/OpenRA.Mods.RA/Traits/DemoTruck.cs
+++ b/OpenRA.Mods.RA/Traits/DemoTruck.cs
@@ -11,10 +11,9 @@
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Activities;
-using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits

--- a/OpenRA.Mods.RA/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/Infiltrates.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Traits/MadTank.cs
+++ b/OpenRA.Mods.RA/Traits/MadTank.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.RA/Traits/Mobile.cs
+++ b/OpenRA.Mods.RA/Traits/Mobile.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.RA/Traits/SupplyTruck.cs
+++ b/OpenRA.Mods.RA/Traits/SupplyTruck.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -8,11 +8,9 @@
  */
 #endregion
 
-using System;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Mods.RA;
-using OpenRA.Traits;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.RA.Widgets.Logic


### PR DESCRIPTION
- Moved `GivesBounty`, `GivesExperience` and `GainsExperience` traits, along with the `Rank` effect
- Moved the `DetectCloaked` trait
- Moved the `PlayerStatistics` trait
- Moved the `Enter` and `RepairBuilding` activities
- Moved the `EngineerRepair` trait
- Moved `ActorExts`
- Extracted the `IgnoresDisguise` trait to its own file
