### PR TITLE
Fix incorrect name for lobby headers container in TD

### DIFF
--- a/mods/cnc/chrome/lobby-dialogs.yaml
+++ b/mods/cnc/chrome/lobby-dialogs.yaml
@@ -98,7 +98,7 @@ Background@LOBBY_OPTIONS_BIN:
 	Children:
 		Label@TITLE:
 			X: 0
-			Y: 30
+			Y: 0 - 25
 			Width: PARENT_RIGHT
 			Height: 25
 			Font: Bold
@@ -106,7 +106,7 @@ Background@LOBBY_OPTIONS_BIN:
 			Text: Map Options
 		Container:
 			X: 30
-			Y: 65
+			Y: 30
 			Width: PARENT_RIGHT-60
 			Height: PARENT_BOTTOM-75
 			Children:

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -20,7 +20,7 @@ Container@SERVER_LOBBY:
 				Container@MAP_PREVIEW_ROOT:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
-				Container@LOBBY_LABEL_CONTAINER:
+				Container@LABEL_CONTAINER:
 					X: 20
 					Y: 5
 					Children:

--- a/mods/d2k/chrome/lobby-dialogs.yaml
+++ b/mods/d2k/chrome/lobby-dialogs.yaml
@@ -97,7 +97,7 @@ Background@LOBBY_OPTIONS_BIN:
 	Children:
 		Label@TITLE:
 			X: 0
-			Y: 5
+			Y: 0 - 27
 			Width: PARENT_RIGHT
 			Height: 25
 			Font: Bold
@@ -105,7 +105,7 @@ Background@LOBBY_OPTIONS_BIN:
 			Text: Map Options
 		Container:
 			X: 30
-			Y: 50
+			Y: 30
 			Width: PARENT_RIGHT-60
 			Height: PARENT_BOTTOM-75
 			Children:

--- a/mods/ra/chrome/lobby-dialogs.yaml
+++ b/mods/ra/chrome/lobby-dialogs.yaml
@@ -97,7 +97,7 @@ Background@LOBBY_OPTIONS_BIN:
 	Children:
 		Label@TITLE:
 			X: 0
-			Y: 5
+			Y: 0 - 27
 			Width: PARENT_RIGHT
 			Height: 25
 			Font: Bold
@@ -105,7 +105,7 @@ Background@LOBBY_OPTIONS_BIN:
 			Text: Map Options
 		Container:
 			X: 30
-			Y: 50
+			Y: 30
 			Width: PARENT_RIGHT-60
 			Height: PARENT_BOTTOM-75
 			Children:


### PR DESCRIPTION
...which caused the headers to still be visible when the options bin was open.
