### PR TITLE
Fix broken pathing

### DIFF
--- a/OpenRA.Mods.RA/Traits/World/PathSearch.cs
+++ b/OpenRA.Mods.RA/Traits/World/PathSearch.cs
@@ -332,8 +332,9 @@ namespace OpenRA.Mods.RA.Traits
 					defaultCellInfoLayer.Shape != map.TileShape)
 				{
 					defaultCellInfoLayer = new CellLayer<CellInfo>(map);
-					foreach (var uv in map.Cells.MapCoords)
-						defaultCellInfoLayer[uv.X, uv.Y] = new CellInfo(int.MaxValue, Map.MapToCell(map.TileShape, uv), false);
+					for (var v = 0; v < mapSize.Height; v++)
+						for (var u = 0; u < mapSize.Width; u++)
+							defaultCellInfoLayer[u, v] = new CellInfo(int.MaxValue, Map.MapToCell(map.TileShape, new CPos(u, v)), false);
 				}
 
 				result.CopyValuesFrom(defaultCellInfoLayer);


### PR DESCRIPTION
Fixes #7258 by fixing a regression introduced in #7108.

The region covered by map.Cells may not cover the whole map size, but we need the whole cache initialized so it can be used correctly when a different map is used, because that map may have the same size but a different offset which means a different region is covered.
