### PR TITLE
StyleCop clean OpenRA.Game Part 2 and enforce rules with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,8 @@ test:
 	@mono --debug OpenRA.Utility.exe ts --check-yaml
 
 check:
+	@echo "Checking for code style violations in OpenRA.Game..."
+	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Game
 	@echo "Checking for code style violations in OpenRA.Renderer.Null..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Renderer.Null
 	@echo "Checking for code style violations in OpenRA.GameMonitor..."

--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -47,11 +47,11 @@ namespace OpenRA.Editor
 				currentMod = toolStripComboBox1.SelectedItem as string;
 
 				Game.InitializeSettings(Arguments.Empty);
-				Game.modData = new ModData(currentMod);
-				GlobalFileSystem.LoadFromManifest(Game.modData.Manifest);
-				Program.Rules = Game.modData.RulesetCache.LoadDefaultRules();
+				Game.ModData = new ModData(currentMod);
+				GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
+				Program.Rules = Game.ModData.RulesetCache.LoadDefaultRules();
 
-				var mod = Game.modData.Manifest.Mod;
+				var mod = Game.ModData.Manifest.Mod;
 				Text = "{0} Mod Version: {1} - OpenRA Editor".F(mod.Title, mod.Version);
 
 				loadedMapName = null;
@@ -129,7 +129,7 @@ namespace OpenRA.Editor
 			if (map.Players.Count == 0)
 				map.MakeDefaultPlayers();
 
-			PrepareMapResources(Game.modData, map);
+			PrepareMapResources(Game.ModData, map);
 
 			// Calculate total net worth of resources in cash
 			cashToolStripStatusLabel.Text = CalculateTotalResource().ToString();
@@ -144,7 +144,7 @@ namespace OpenRA.Editor
 			resourcePalette.Controls.Clear();
 
 			loadedMapName = null;
-			PrepareMapResources(Game.modData, map);
+			PrepareMapResources(Game.ModData, map);
 
 			MakeDirty();
 		}

--- a/OpenRA.Editor/Surface.cs
+++ b/OpenRA.Editor/Surface.cs
@@ -312,7 +312,7 @@ namespace OpenRA.Editor
 			{
 				using (var g = SGraphics.FromImage(bitmap))
 				{
-					var ts = Game.modData.Manifest.TileSize;
+					var ts = Game.ModData.Manifest.TileSize;
 					var rect = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
 					ControlPaint.DrawGrid(g, rect, new Size(2, ts.Height), Color.DarkRed);
 					ControlPaint.DrawGrid(g, rect, new Size(ts.Width, 2), Color.DarkRed);

--- a/OpenRA.Editor/TileSetRenderer.cs
+++ b/OpenRA.Editor/TileSetRenderer.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Editor
 			this.TileSize = Math.Min(tileSize.Width, tileSize.Height);
 
 			templates = new Dictionary<ushort, byte[][]>();
-			var frameCache = new FrameCache(Game.modData.SpriteLoaders, tileset.Extensions);
+			var frameCache = new FrameCache(Game.ModData.SpriteLoaders, tileset.Extensions);
 			foreach (var t in tileset.Templates)
 			{
 				var allFrames = frameCache[t.Value.Image];

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -180,27 +180,27 @@ namespace OpenRA
 
 		public T Trait<T>()
 		{
-			return World.traitDict.Get<T>(this);
+			return World.TraitDict.Get<T>(this);
 		}
 
 		public T TraitOrDefault<T>()
 		{
-			return World.traitDict.GetOrDefault<T>(this);
+			return World.TraitDict.GetOrDefault<T>(this);
 		}
 
 		public IEnumerable<T> TraitsImplementing<T>()
 		{
-			return World.traitDict.WithInterface<T>(this);
+			return World.TraitDict.WithInterface<T>(this);
 		}
 
 		public bool HasTrait<T>()
 		{
-			return World.traitDict.Contains<T>(this);
+			return World.TraitDict.Contains<T>(this);
 		}
 
 		public void AddTrait(object trait)
 		{
-			World.traitDict.AddTrait(this, trait);
+			World.TraitDict.AddTrait(this, trait);
 		}
 
 		public void Destroy()
@@ -213,7 +213,7 @@ namespace OpenRA
 				if (IsInWorld)
 					World.Remove(this);
 
-				World.traitDict.RemoveActor(this);
+				World.TraitDict.RemoveActor(this);
 				Destroyed = true;
 
 				if (luaInterface != null)

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -29,7 +29,7 @@ namespace OpenRA
 		// replay recording stopped.
 		public TimeSpan Duration { get { return EndTimeUtc > StartTimeUtc ? EndTimeUtc - StartTimeUtc : TimeSpan.Zero; } }
 		public IList<Player> Players { get; private set; }
-		public MapPreview MapPreview { get { return Game.modData.MapCache[MapUid]; } }
+		public MapPreview MapPreview { get { return Game.ModData.MapCache[MapUid]; } }
 		public IEnumerable<Player> HumanPlayers { get { return Players.Where(p => p.IsHuman); } }
 		public bool IsSinglePlayer { get { return HumanPlayers.Count() == 1; } }
 

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Graphics
 
 		static void LoadCollection(string name, MiniYaml yaml)
 		{
-			Game.modData.LoadScreen.Display();
+			Game.ModData.LoadScreen.Display();
 			var collection = new Collection()
 			{
 				Src = yaml.Value,

--- a/OpenRA.Game/Graphics/Renderable.cs
+++ b/OpenRA.Game/Graphics/Renderable.cs
@@ -87,19 +87,19 @@ namespace OpenRA.Graphics
 
 		float2 ScreenPosition(WorldRenderer wr)
 		{
-			return wr.ScreenPxPosition(pos) + wr.ScreenPxOffset(offset) - (0.5f * scale * sprite.size).ToInt2();
+			return wr.ScreenPxPosition(pos) + wr.ScreenPxOffset(offset) - (0.5f * scale * sprite.Size).ToInt2();
 		}
 
 		public void BeforeRender(WorldRenderer wr) { }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.WorldSpriteRenderer.DrawSprite(sprite, ScreenPosition(wr), palette, sprite.size * scale);
+			Game.Renderer.WorldSpriteRenderer.DrawSprite(sprite, ScreenPosition(wr), palette, sprite.Size * scale);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
-			var offset = ScreenPosition(wr) + sprite.offset;
-			Game.Renderer.WorldLineRenderer.DrawRect(offset, offset + sprite.size, Color.Red);
+			var offset = ScreenPosition(wr) + sprite.Offset;
+			Game.Renderer.WorldLineRenderer.DrawRect(offset, offset + sprite.Size, Color.Red);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Sequence.cs
+++ b/OpenRA.Game/Graphics/Sequence.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Graphics
 				// Apply offset to each sprite in the sequence
 				// Different sequences may apply different offsets to the same frame
 				sprites = cache[srcOverride ?? unit].Select(
-					s => new Sprite(s.sheet, s.bounds, s.offset + offset, s.channel, blendMode)).ToArray();
+					s => new Sprite(s.Sheet, s.Bounds, s.Offset + offset, s.Channel, blendMode)).ToArray();
 
 				if (!d.ContainsKey("Length"))
 					Length = 1;

--- a/OpenRA.Game/Graphics/SoftwareCursor.cs
+++ b/OpenRA.Game/Graphics/SoftwareCursor.cs
@@ -79,11 +79,11 @@ namespace OpenRA.Graphics
 
 			var cursorSequence = cursorProvider.GetCursorSequence(cursorName);
 			var cursorSprite = sprites[cursorName][((int)cursorFrame % cursorSequence.Length)];
-			var cursorSize = CursorProvider.CursorViewportZoomed ? 2.0f * cursorSprite.size : cursorSprite.size;
+			var cursorSize = CursorProvider.CursorViewportZoomed ? 2.0f * cursorSprite.Size : cursorSprite.Size;
 
 			var cursorOffset = CursorProvider.CursorViewportZoomed ?
-				(2 * cursorSequence.Hotspot) + cursorSprite.size.ToInt2() :
-				cursorSequence.Hotspot + (0.5f * cursorSprite.size).ToInt2();
+				(2 * cursorSequence.Hotspot) + cursorSprite.Size.ToInt2() :
+				cursorSequence.Hotspot + (0.5f * cursorSprite.Size).ToInt2();
 
 			renderer.SetPalette(palette);
 			renderer.SpriteRenderer.DrawSprite(cursorSprite,

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -14,14 +14,14 @@ namespace OpenRA.Graphics
 {
 	public class Sprite
 	{
-		public readonly Rectangle bounds;
-		public readonly Sheet sheet;
-		public readonly BlendMode blendMode;
-		public readonly TextureChannel channel;
-		public readonly float2 size;
-		public readonly float2 offset;
-		public readonly float2 fractionalOffset;
-		public readonly float top, left, bottom, right;
+		public readonly Rectangle Bounds;
+		public readonly Sheet Sheet;
+		public readonly BlendMode BlendMode;
+		public readonly TextureChannel Channel;
+		public readonly float2 Size;
+		public readonly float2 Offset;
+		public readonly float2 FractionalOffset;
+		public readonly float Top, Left, Bottom, Right;
 
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel)
 			: this(sheet, bounds, float2.Zero, channel, BlendMode.Alpha) { }
@@ -31,19 +31,19 @@ namespace OpenRA.Graphics
 
 		public Sprite(Sheet sheet, Rectangle bounds, float2 offset, TextureChannel channel, BlendMode blendMode)
 		{
-			this.sheet = sheet;
-			this.bounds = bounds;
-			this.offset = offset;
-			this.channel = channel;
-			this.size = new float2(bounds.Size);
-			this.blendMode = blendMode;
+			Sheet = sheet;
+			Bounds = bounds;
+			Offset = offset;
+			Channel = channel;
+			Size = new float2(bounds.Size);
+			BlendMode = blendMode;
 
-			this.fractionalOffset = offset / this.size;
+			FractionalOffset = offset / Size;
 
-			left = (float)bounds.Left / sheet.Size.Width;
-			top = (float)bounds.Top / sheet.Size.Height;
-			right = (float)bounds.Right / sheet.Size.Width;
-			bottom = (float)bounds.Bottom / sheet.Size.Height;
+			Left = (float)bounds.Left / sheet.Size.Width;
+			Top = (float)bounds.Top / sheet.Size.Height;
+			Right = (float)bounds.Right / sheet.Size.Width;
+			Bottom = (float)bounds.Bottom / sheet.Size.Height;
 		}
 	}
 

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -117,15 +117,15 @@ namespace OpenRA.Graphics
 				unsafe
 				{
 					var p = (byte*)bitmap.Buffer;
-					var dest = s.sheet.GetData();
-					var destStride = s.sheet.Size.Width * 4;
+					var dest = s.Sheet.GetData();
+					var destStride = s.Sheet.Size.Width * 4;
 
-					for (var j = 0; j < s.size.Y; j++)
+					for (var j = 0; j < s.Size.Y; j++)
 					{
-						for (var i = 0; i < s.size.X; i++)
+						for (var i = 0; i < s.Size.X; i++)
 							if (p[i] != 0)
 							{
-								var q = destStride * (j + s.bounds.Top) + 4 * (i + s.bounds.Left);
+								var q = destStride * (j + s.Bounds.Top) + 4 * (i + s.Bounds.Left);
 								dest[q] = c.Second.B;
 								dest[q + 1] = c.Second.G;
 								dest[q + 2] = c.Second.R;
@@ -136,7 +136,7 @@ namespace OpenRA.Graphics
 					}
 				}
 
-			s.sheet.CommitData();
+			s.Sheet.CommitData();
 
 			return g;
 		}

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Graphics
 
 		public void DrawSprite(Sprite s, float2 location, PaletteReference pal)
 		{
-			DrawSprite(s, location, pal.Index, s.size);
+			DrawSprite(s, location, pal.Index, s.Size);
 		}
 
 		public void DrawSprite(Sprite s, float2 location, PaletteReference pal, float2 size)
@@ -63,25 +63,25 @@ namespace OpenRA.Graphics
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (s.sheet != currentSheet)
+			if (s.Sheet != currentSheet)
 				Flush();
 
-			if (s.blendMode != currentBlend)
+			if (s.BlendMode != currentBlend)
 				Flush();
 
 			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
-			currentBlend = s.blendMode;
-			currentSheet = s.sheet;
-			Util.FastCreateQuad(vertices, location + s.fractionalOffset * size, s, paletteIndex, nv, size);
+			currentBlend = s.BlendMode;
+			currentSheet = s.Sheet;
+			Util.FastCreateQuad(vertices, location + s.FractionalOffset * size, s, paletteIndex, nv, size);
 			nv += 4;
 		}
 
 		// For RGBASpriteRenderer, which doesn't use palettes
 		public void DrawSprite(Sprite s, float2 location)
 		{
-			DrawSprite(s, location, 0, s.size);
+			DrawSprite(s, location, 0, s.Size);
 		}
 
 		public void DrawSprite(Sprite s, float2 location, float2 size)
@@ -93,17 +93,17 @@ namespace OpenRA.Graphics
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (s.sheet != currentSheet)
+			if (s.Sheet != currentSheet)
 				Flush();
 
-			if (s.blendMode != currentBlend)
+			if (s.BlendMode != currentBlend)
 				Flush();
 
 			if (nv + 4 > renderer.TempBufferSize)
 				Flush();
 
-			currentSheet = s.sheet;
-			currentBlend = s.blendMode;
+			currentSheet = s.Sheet;
+			currentBlend = s.BlendMode;
 			Util.FastCreateQuad(vertices, a, b, c, d, s, 0, nv);
 			nv += 4;
 		}

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -31,8 +31,8 @@ namespace OpenRA.Graphics
 			foreach (var cell in map.Cells)
 			{
 				var tile = wr.Theater.TileSprite(map.MapTiles.Value[cell]);
-				var pos = wr.ScreenPosition(map.CenterOfCell(cell)) + tile.offset - 0.5f * tile.size;
-				Util.FastCreateQuad(vertices, pos, tile, terrainPalette, nv, tile.size);
+				var pos = wr.ScreenPosition(map.CenterOfCell(cell)) + tile.Offset - 0.5f * tile.Size;
+				Util.FastCreateQuad(vertices, pos, tile, terrainPalette, nv, tile.Size);
 				nv += 4;
 			}
 
@@ -44,7 +44,7 @@ namespace OpenRA.Graphics
 		{
 			var verticesPerRow = 4 * map.Bounds.Width;
 			var cells = viewport.VisibleCells;
-			var shape = wr.world.Map.TileShape;
+			var shape = wr.World.Map.TileShape;
 
 			// Only draw the rows that are visible.
 			// VisibleCells is clamped to the map, so additional checks are unnecessary

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Graphics
 			sheetBuilder = new SheetBuilder(SheetType.Indexed, allocate);
 			templates = new Dictionary<ushort, Sprite[]>();
 
-			var frameCache = new FrameCache(Game.modData.SpriteLoaders, tileset.Extensions);
+			var frameCache = new FrameCache(Game.ModData.SpriteLoaders, tileset.Extensions);
 			foreach (var t in tileset.Templates)
 			{
 				var allFrames = frameCache[t.Value.Image];
@@ -48,7 +48,7 @@ namespace OpenRA.Graphics
 
 				// Ignore the offsets baked into R8 sprites
 				if (tileset.IgnoreTileSpriteOffsets)
-					sprites = sprites.Select(s => new Sprite(s.sheet, s.bounds, float2.Zero, s.channel, s.blendMode));
+					sprites = sprites.Select(s => new Sprite(s.Sheet, s.Bounds, float2.Zero, s.Channel, s.BlendMode));
 
 				templates.Add(t.Value.Id, sprites.ToArray());
 			}
@@ -91,8 +91,8 @@ namespace OpenRA.Graphics
 					var u = tileShape == TileShape.Rectangle ? x : (x - y) / 2f;
 					var v = tileShape == TileShape.Rectangle ? y : (x + y) / 2f;
 
-					var tl = new float2(u * tileSize.Width, (v - 0.5f * tileInfo.Height) * tileSize.Height) - 0.5f * sprite.size;
-					var rect = new Rectangle((int)(tl.X + sprite.offset.X), (int)(tl.Y + sprite.offset.Y), (int)sprite.size.X, (int)sprite.size.Y);
+					var tl = new float2(u * tileSize.Width, (v - 0.5f * tileInfo.Height) * tileSize.Height) - 0.5f * sprite.Size;
+					var rect = new Rectangle((int)(tl.X + sprite.Offset.X), (int)(tl.Y + sprite.Offset.Y), (int)sprite.Size.X, (int)sprite.Size.Y);
 					templateRect = templateRect.HasValue ? Rectangle.Union(templateRect.Value, rect) : rect;
 				}
 			}

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -49,13 +49,13 @@ namespace OpenRA.Graphics
 		public void BeforeRender(WorldRenderer wr) { }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(sprite, screenPos, palette, sprite.size * scale);
+			Game.Renderer.SpriteRenderer.DrawSprite(sprite, screenPos, palette, sprite.Size * scale);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
-			var offset = screenPos + sprite.offset;
-			Game.Renderer.LineRenderer.DrawRect(offset, offset + sprite.size, Color.Red);
+			var offset = screenPos + sprite.Offset;
+			Game.Renderer.LineRenderer.DrawRect(offset, offset + sprite.Size, Color.Red);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -18,8 +18,8 @@ namespace OpenRA.Graphics
 	public static class Util
 	{
 		// yes, our channel order is nuts.
-		static readonly int[] channelMasks = { 2, 1, 0, 3 };
-		static float[] channelSelect = { 0.75f, 0.25f, -0.25f, -0.75f };
+		static readonly int[] ChannelMasks = { 2, 1, 0, 3 };
+		static readonly float[] ChannelSelect = { 0.75f, 0.25f, -0.25f, -0.75f };
 
 		public static void FastCreateQuad(Vertex[] vertices, float2 o, Sprite r, int palette, int nv, float2 size)
 		{
@@ -32,23 +32,23 @@ namespace OpenRA.Graphics
 		public static void FastCreateQuad(Vertex[] vertices, float2 a, float2 b, float2 c, float2 d, Sprite r, int palette, int nv)
 		{
 			var attribP = palette / (float)HardwarePalette.MaxPalettes;
-			var attribC = channelSelect[(int)r.channel];
+			var attribC = ChannelSelect[(int)r.Channel];
 
-			vertices[nv] = new Vertex(a, r.left, r.top, attribP, attribC);
-			vertices[nv + 1] = new Vertex(b, r.right, r.top, attribP, attribC);
-			vertices[nv + 2] = new Vertex(c, r.right, r.bottom, attribP, attribC);
-			vertices[nv + 3] = new Vertex(d, r.left, r.bottom, attribP, attribC);
+			vertices[nv] = new Vertex(a, r.Left, r.Top, attribP, attribC);
+			vertices[nv + 1] = new Vertex(b, r.Right, r.Top, attribP, attribC);
+			vertices[nv + 2] = new Vertex(c, r.Right, r.Bottom, attribP, attribC);
+			vertices[nv + 3] = new Vertex(d, r.Left, r.Bottom, attribP, attribC);
 		}
 
 		public static void FastCopyIntoChannel(Sprite dest, byte[] src) { FastCopyIntoChannel(dest, 0, src); }
 		public static void FastCopyIntoChannel(Sprite dest, int channelOffset, byte[] src)
 		{
-			var data = dest.sheet.GetData();
-			var srcStride = dest.bounds.Width;
-			var destStride = dest.sheet.Size.Width * 4;
-			var destOffset = destStride * dest.bounds.Top + dest.bounds.Left * 4 + channelMasks[(int)dest.channel + channelOffset];
+			var data = dest.Sheet.GetData();
+			var srcStride = dest.Bounds.Width;
+			var destStride = dest.Sheet.Size.Width * 4;
+			var destOffset = destStride * dest.Bounds.Top + dest.Bounds.Left * 4 + ChannelMasks[(int)dest.Channel + channelOffset];
 			var destSkip = destStride - 4 * srcStride;
-			var height = dest.bounds.Height;
+			var height = dest.Bounds.Height;
 
 			var srcOffset = 0;
 			for (var j = 0; j < height; j++)
@@ -65,12 +65,12 @@ namespace OpenRA.Graphics
 
 		public static void FastCopyIntoSprite(Sprite dest, Bitmap src)
 		{
-			var data = dest.sheet.GetData();
-			var dataStride = dest.sheet.Size.Width * 4;
-			var x = dest.bounds.Left * 4;
-			var width = dest.bounds.Width * 4;
-			var y = dest.bounds.Top;
-			var height = dest.bounds.Height;
+			var data = dest.Sheet.GetData();
+			var dataStride = dest.Sheet.Size.Width * 4;
+			var x = dest.Bounds.Left * 4;
+			var width = dest.Bounds.Width * 4;
+			var y = dest.Bounds.Top;
+			var height = dest.Bounds.Height;
 
 			var bd = src.LockBits(src.Bounds(),
 				ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -98,14 +98,14 @@ namespace OpenRA.Graphics
 			var br = wr.ScreenPxPosition(map.CenterOfCell(Map.MapToCell(map.TileShape, new CPos(b.Right, b.Bottom))) + new WVec(511, 511, 0));
 			mapBounds = Rectangle.FromLTRB(tl.X, tl.Y, br.X, br.Y);
 
-			maxGroundHeight = wr.world.TileSet.MaxGroundHeight;
+			maxGroundHeight = wr.World.TileSet.MaxGroundHeight;
 			CenterLocation = (tl + br) / 2;
 			Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
 		}
 
 		public CPos ViewToWorld(int2 view)
 		{
-			return worldRenderer.world.Map.CellContaining(worldRenderer.Position(ViewToWorldPx(view)));
+			return worldRenderer.World.Map.CellContaining(worldRenderer.Position(ViewToWorldPx(view)));
 		}
 
 		public int2 ViewToWorldPx(int2 view) { return (1f / Zoom * view.ToFloat2()).ToInt2() + TopLeft; }
@@ -142,7 +142,7 @@ namespace OpenRA.Graphics
 			get
 			{
 				// Visible rectangle in world coordinates (expanded to the corners of the cells)
-				var map = worldRenderer.world.Map;
+				var map = worldRenderer.World.Map;
 				var ctl = map.CenterOfCell(VisibleCells.TopLeft) - new WVec(512, 512, 0);
 				var cbr = map.CenterOfCell(VisibleCells.BottomRight) + new WVec(512, 512, 0);
 
@@ -159,7 +159,7 @@ namespace OpenRA.Graphics
 			{
 				if (cellsDirty)
 				{
-					var map = worldRenderer.world.Map;
+					var map = worldRenderer.World.Map;
 					var wtl = worldRenderer.Position(TopLeft);
 					var wbr = worldRenderer.Position(BottomRight);
 

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -86,16 +86,16 @@ namespace OpenRA.Graphics
 			var s = sheetBuilder.Allocate(new Size(su, sv));
 			Util.FastCopyIntoChannel(s, 0, colors);
 			Util.FastCopyIntoChannel(s, 1, normals);
-			s.sheet.CommitData();
+			s.Sheet.CommitData();
 
-			var channelP = ChannelSelect[(int)s.channel];
-			var channelC = ChannelSelect[(int)s.channel + 1];
+			var channelP = ChannelSelect[(int)s.Channel];
+			var channelC = ChannelSelect[(int)s.Channel + 1];
 			return new Vertex[4]
 			{
-				new Vertex(coord(0, 0), s.left, s.top, channelP, channelC),
-				new Vertex(coord(su, 0), s.right, s.top, channelP, channelC),
-				new Vertex(coord(su, sv), s.right, s.bottom, channelP, channelC),
-				new Vertex(coord(0, sv), s.left, s.bottom, channelP, channelC)
+				new Vertex(coord(0, 0), s.Left, s.Top, channelP, channelC),
+				new Vertex(coord(su, 0), s.Right, s.Top, channelP, channelC),
+				new Vertex(coord(su, sv), s.Right, s.Bottom, channelP, channelC),
+				new Vertex(coord(0, sv), s.Left, s.Bottom, channelP, channelC)
 			};
 		}
 

--- a/OpenRA.Game/Graphics/VoxelProvider.cs
+++ b/OpenRA.Game/Graphics/VoxelProvider.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Graphics
 			foreach (var s in sequences)
 				LoadVoxelsForUnit(s.Key, s.Value);
 
-			Game.modData.VoxelLoader.RefreshBuffer();
+			Game.ModData.VoxelLoader.RefreshBuffer();
 		}
 
 		static Voxel LoadVoxel(string unit, MiniYaml info)
@@ -47,12 +47,12 @@ namespace OpenRA.Graphics
 					hva = fields[1].Trim();
 			}
 
-			return Game.modData.VoxelLoader.Load(vxl, hva);
+			return Game.ModData.VoxelLoader.Load(vxl, hva);
 		}
 
 		static void LoadVoxelsForUnit(string unit, MiniYaml sequences)
 		{
-			Game.modData.LoadScreen.Display();
+			Game.ModData.LoadScreen.Display();
 			try
 			{
 				var seq = sequences.ToDictionary(my => LoadVoxel(unit, my));

--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -161,8 +161,8 @@ namespace OpenRA.Graphics
 
 			var sprite = sheetBuilder.Allocate(spriteSize, spriteOffset);
 			var shadowSprite = sheetBuilder.Allocate(shadowSpriteSize, shadowSpriteOffset);
-			var sb = sprite.bounds;
-			var ssb = shadowSprite.bounds;
+			var sb = sprite.Bounds;
+			var ssb = shadowSprite.Bounds;
 			var spriteCenter = new float2(sb.Left + sb.Width / 2, sb.Top + sb.Height / 2);
 			var shadowCenter = new float2(ssb.Left + ssb.Width / 2, ssb.Top + ssb.Height / 2);
 
@@ -171,7 +171,7 @@ namespace OpenRA.Graphics
 			var correctionTransform = Util.MatrixMultiply(translateMtx, FlipMtx);
 			var shadowCorrectionTransform = Util.MatrixMultiply(shadowTranslateMtx, ShadowScaleFlipMtx);
 
-			doRender.Add(Pair.New<Sheet, Action>(sprite.sheet, () =>
+			doRender.Add(Pair.New<Sheet, Action>(sprite.Sheet, () =>
 			{
 				foreach (var v in voxels)
 				{
@@ -262,7 +262,7 @@ namespace OpenRA.Graphics
 			shader.SetVec("AmbientLight", ambientLight, 3);
 			shader.SetVec("DiffuseLight", diffuseLight, 3);
 
-			shader.Render(() => renderer.DrawBatch(Game.modData.VoxelLoader.VertexBuffer, renderData.Start, renderData.Count, PrimitiveType.QuadList));
+			shader.Render(() => renderer.DrawBatch(Game.ModData.VoxelLoader.VertexBuffer, renderData.Start, renderData.Count, PrimitiveType.QuadList));
 		}
 
 		public void BeginFrame()

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -16,19 +16,19 @@ namespace OpenRA
 {
 	public class ActorInitializer
 	{
-		public readonly Actor self;
-		public World world { get { return self.World; } }
+		public readonly Actor Self;
+		public World World { get { return Self.World; } }
 
 		internal TypeDictionary Dict;
 
 		public ActorInitializer(Actor actor, TypeDictionary dict)
 		{
-			self = actor;
+			Self = actor;
 			Dict = dict;
 		}
 
 		public T Get<T>() where T : IActorInit { return Dict.Get<T>(); }
-		public U Get<T, U>() where T : IActorInit<U> { return Dict.Get<T>().Value(world); }
+		public U Get<T, U>() where T : IActorInit<U> { return Dict.Get<T>().Value(World); }
 		public bool Contains<T>() where T : IActorInit { return Dict.Contains<T>(); }
 	}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -204,7 +204,7 @@ namespace OpenRA
 		public static Map FromTileset(TileSet tileset)
 		{
 			var size = new Size(1, 1);
-			var tileShape = Game.modData.Manifest.TileShape;
+			var tileShape = Game.ModData.Manifest.TileShape;
 			var tileRef = new TerrainTile(tileset.Templates.First().Key, (byte)0);
 
 			var makeMapTiles = Exts.Lazy(() =>
@@ -328,10 +328,10 @@ namespace OpenRA
 			MapResources = Exts.Lazy(() => LoadResourceTiles());
 			MapHeight = Exts.Lazy(() => LoadMapHeight());
 
-			TileShape = Game.modData.Manifest.TileShape;
-			SubCellOffsets = Game.modData.Manifest.SubCellOffsets;
+			TileShape = Game.ModData.Manifest.TileShape;
+			SubCellOffsets = Game.ModData.Manifest.SubCellOffsets;
 			LastSubCell = (SubCell)(SubCellOffsets.Length - 1);
-			DefaultSubCell = (SubCell)Game.modData.Manifest.SubCellDefaultIndex;
+			DefaultSubCell = (SubCell)Game.ModData.Manifest.SubCellDefaultIndex;
 
 			if (Container.Exists("map.png"))
 				using (var dataStream = Container.GetContent("map.png"))
@@ -354,7 +354,7 @@ namespace OpenRA
 			{
 				try
 				{
-					return Game.modData.RulesetCache.LoadMapRules(this);
+					return Game.ModData.RulesetCache.LoadMapRules(this);
 				}
 				catch (Exception e)
 				{
@@ -362,7 +362,7 @@ namespace OpenRA
 					Log.Write("debug", "Failed to load rules for {0} with error {1}", Title, e.Message);
 				}
 
-				return Game.modData.DefaultRules;
+				return Game.ModData.DefaultRules;
 			});
 
 			cachedTileSet = Exts.Lazy(() => Rules.TileSets[Tileset]);

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -167,7 +167,7 @@ namespace OpenRA
 				return;
 
 			Status = MapStatus.Downloading;
-			var baseMapPath = Platform.ResolvePath("^", "maps", Game.modData.Manifest.Mod.Id);
+			var baseMapPath = Platform.ResolvePath("^", "maps", Game.ModData.Manifest.Mod.Id);
 
 			// Create the map directory if it doesn't exist
 			if (!Directory.Exists(baseMapPath))

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Network
 			else
 				ModLabel = "Unknown mod: {0}".F(Mods);
 
-			var mapAvailable = Game.Settings.Game.AllowDownloading || Game.modData.MapCache[Map].Status == MapStatus.Available;
+			var mapAvailable = Game.Settings.Game.AllowDownloading || Game.ModData.MapCache[Map].Status == MapStatus.Available;
 			IsJoinable = IsCompatible && State == 1 && mapAvailable;
 		}
 	}

--- a/OpenRA.Game/Network/ReplayRecorderConnection.cs
+++ b/OpenRA.Game/Network/ReplayRecorderConnection.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Network
 		void StartSavingReplay(byte[] initialContent)
 		{
 			var filename = chooseFilename();
-			var mod = Game.modData.Manifest.Mod;
+			var mod = Game.ModData.Manifest.Mod;
 			var dir = Platform.ResolvePath("^", "Replays", mod.Id, mod.Version);
 
 			if (!Directory.Exists(dir))

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Network
 			{
 				if (r.Frame == frame)
 				{
-					var mod = Game.modData.Manifest.Mod;
+					var mod = Game.ModData.Manifest.Mod;
 					Log.Write("sync", "Player: {0} ({1} {2} {3})", Game.Settings.Player.Name, Platform.CurrentPlatform, Environment.OSVersion, Platform.RuntimeVersion);
 					Log.Write("sync", "Game ID: {0} (Mod: {1} at Version {2})", orderManager.LobbyInfo.GlobalSettings.GameUid, mod.Title, mod.Version);
 					Log.Write("sync", "Sync for net frame {0} -------------", r.Frame);

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Network
 
 				case "StartGame":
 					{
-						if (Game.modData.MapCache[orderManager.LobbyInfo.GlobalSettings.Map].Status != MapStatus.Available)
+						if (Game.ModData.MapCache[orderManager.LobbyInfo.GlobalSettings.Map].Status != MapStatus.Available)
 						{
 							Game.Disconnect();
 							Game.LoadShellMap();
@@ -129,7 +129,7 @@ namespace OpenRA.Network
 				case "HandshakeRequest":
 					{
 						// Switch to the server's mod if we need and are able to
-						var mod = Game.modData.Manifest.Mod;
+						var mod = Game.ModData.Manifest.Mod;
 						var request = HandshakeRequest.Deserialize(order.TargetString);
 
 						ModMetadata serverMod;
@@ -142,7 +142,7 @@ namespace OpenRA.Network
 								"Launch.Replay=" + replay.Filename :
 								"Launch.Connect=" + orderManager.Host + ":" + orderManager.Port;
 
-							Game.modData.LoadScreen.Display();
+							Game.ModData.LoadScreen.Display();
 							Game.InitializeMod(request.Mod, new Arguments(launchCommand));
 
 							break;
@@ -261,7 +261,7 @@ namespace OpenRA.Network
 
 				case "SetStance":
 					{
-						if (!Game.orderManager.LobbyInfo.GlobalSettings.FragileAlliances)
+						if (!Game.OrderManager.LobbyInfo.GlobalSettings.FragileAlliances)
 							return;
 
 						var targetPlayer = order.Player.World.Players.FirstOrDefault(p => p.InternalName == order.TargetString);

--- a/OpenRA.Game/Scripting/ScriptActorInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptActorInterface.cs
@@ -38,13 +38,13 @@ namespace OpenRA.Scripting
 
 		void InitializeBindings()
 		{
-			var commandClasses = context.ActorCommands[actor.Info].AsEnumerable();
+			var commandClasses = Context.ActorCommands[actor.Info].AsEnumerable();
 
 			// Destroyed actors cannot have their traits queried
 			if (actor.Destroyed)
 				commandClasses = commandClasses.Where(c => c.HasAttribute<ExposedForDestroyedActors>());
 
-			var args = new object[] { context, actor };
+			var args = new object[] { Context, actor };
 			var objects = commandClasses.Select(cg =>
 			{
 				var groupCtor = cg.GetConstructor(new Type[] { typeof(ScriptContext), typeof(Actor) });

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -47,23 +47,23 @@ namespace OpenRA.Scripting
 
 	public abstract class ScriptActorProperties
 	{
-		protected readonly Actor self;
-		protected readonly ScriptContext context;
+		protected readonly Actor Self;
+		protected readonly ScriptContext Context;
 		public ScriptActorProperties(ScriptContext context, Actor self)
 		{
-			this.self = self;
-			this.context = context;
+			Self = self;
+			Context = context;
 		}
 	}
 
 	public abstract class ScriptPlayerProperties
 	{
-		protected readonly Player player;
-		protected readonly ScriptContext context;
+		protected readonly Player Player;
+		protected readonly ScriptContext Context;
 		public ScriptPlayerProperties(ScriptContext context, Player player)
 		{
-			this.player = player;
-			this.context = context;
+			Player = player;
+			Context = context;
 		}
 	}
 
@@ -123,12 +123,12 @@ namespace OpenRA.Scripting
 
 			World = world;
 			WorldRenderer = worldRenderer;
-			knownActorCommands = Game.modData.ObjectCreator
+			knownActorCommands = Game.ModData.ObjectCreator
 				.GetTypesImplementing<ScriptActorProperties>()
 				.ToArray();
 
 			ActorCommands = new Cache<ActorInfo, Type[]>(FilterActorCommands);
-			PlayerCommands = Game.modData.ObjectCreator
+			PlayerCommands = Game.ModData.ObjectCreator
 				.GetTypesImplementing<ScriptPlayerProperties>()
 				.ToArray();
 
@@ -148,7 +148,7 @@ namespace OpenRA.Scripting
 					registerGlobal.Call("print", fn).Dispose();
 
 				// Register global tables
-				var bindings = Game.modData.ObjectCreator.GetTypesImplementing<ScriptGlobal>();
+				var bindings = Game.ModData.ObjectCreator.GetTypesImplementing<ScriptGlobal>();
 				foreach (var b in bindings)
 				{
 					var ctor = b.GetConstructors(BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(c =>

--- a/OpenRA.Game/Scripting/ScriptObjectWrapper.cs
+++ b/OpenRA.Game/Scripting/ScriptObjectWrapper.cs
@@ -19,12 +19,12 @@ namespace OpenRA.Scripting
 		protected abstract string DuplicateKeyError(string memberName);
 		protected abstract string MemberNotFoundError(string memberName);
 
-		protected readonly ScriptContext context;
+		protected readonly ScriptContext Context;
 		Dictionary<string, ScriptMemberWrapper> members;
 
 		public ScriptObjectWrapper(ScriptContext context)
 		{
-			this.context = context;
+			Context = context;
 		}
 
 		protected void Bind(IEnumerable<object> clrObjects)
@@ -38,7 +38,7 @@ namespace OpenRA.Scripting
 					if (members.ContainsKey(m.Name))
 						throw new LuaException(DuplicateKeyError(m.Name));
 
-					members.Add(m.Name, new ScriptMemberWrapper(context, obj, m));
+					members.Add(m.Name, new ScriptMemberWrapper(Context, obj, m));
 				}
 			}
 		}

--- a/OpenRA.Game/Sound/OpenAlSound.cs
+++ b/OpenRA.Game/Sound/OpenAlSound.cs
@@ -148,7 +148,7 @@ namespace OpenRA
 				return null;
 			}
 
-			var currFrame = Game.orderManager.LocalFrameNumber;
+			var currFrame = Game.OrderManager.LocalFrameNumber;
 			var atten = 1f;
 
 			// Check if max # of instances-per-location reached:

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -49,9 +49,9 @@ namespace OpenRA
 		{
 			Log.AddChannel("exception", "exception.log");
 
-			if (Game.modData != null)
+			if (Game.ModData != null)
 			{
-				var mod = Game.modData.Manifest.Mod;
+				var mod = Game.ModData.Manifest.Mod;
 				Log.Write("exception", "{0} Mod at Version {1}", mod.Title, mod.Version);
 			}
 

--- a/OpenRA.Game/Traits/BodyOrientation.cs
+++ b/OpenRA.Game/Traits/BodyOrientation.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Traits
 			return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing));
 		}
 
-		public object Create(ActorInitializer init) { return new BodyOrientation(init.self, this); }
+		public object Create(ActorInitializer init) { return new BodyOrientation(init.Self, this); }
 	}
 
 	public class BodyOrientation : IBodyOrientation

--- a/OpenRA.Game/Traits/DebugPauseState.cs
+++ b/OpenRA.Game/Traits/DebugPauseState.cs
@@ -13,7 +13,7 @@ namespace OpenRA.Traits
 	[Desc("Checks for pause related desyncs. Attach this to the world actor.")]
 	public class DebugPauseStateInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new DebugPauseState(init.world); }
+		public object Create(ActorInitializer init) { return new DebugPauseState(init.World); }
 	}
 
 	public class DebugPauseState : ISync

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Traits
 	{
 		public readonly int Ticks = 60;
 
-		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.self, this); }
+		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
 	}
 
 	public class DrawLineToTarget : IPostRenderSelection, INotifySelected, INotifyBecomingIdle

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Traits
 	[Desc("Required for FrozenUnderFog to work. Attach this to the player actor.")]
 	public class FrozenActorLayerInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new FrozenActorLayer(init.self); }
+		public object Create(ActorInitializer init) { return new FrozenActorLayer(init.Self); }
 	}
 
 	public class FrozenActor

--- a/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Traits
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new PlayerColorPalette(init.self.Owner, this); }
+		public object Create(ActorInitializer init) { return new PlayerColorPalette(init.Self.Owner, this); }
 	}
 
 	public class PlayerColorPalette : ILoadsPalettes

--- a/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Traits
 		[Desc("The prefix for the resulting player palettes")]
 		public readonly string BaseName = "highlight";
 
-		public object Create(ActorInitializer init) { return new PlayerHighlightPalette(init.self.Owner, this); }
+		public object Create(ActorInitializer init) { return new PlayerHighlightPalette(init.Self.Owner, this); }
 	}
 
 	public class PlayerHighlightPalette : ILoadsPalettes

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Traits
 		public readonly int DefaultCash = 5000;
 		public readonly int AdviceInterval = 250;
 
-		public object Create(ActorInitializer init) { return new PlayerResources(init.self, this); }
+		public object Create(ActorInitializer init) { return new PlayerResources(init.Self, this); }
 	}
 
 	public class PlayerResources : ITick, ISync

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Traits
 		public readonly int[] Bounds = null;
 		[VoiceReference] public readonly string Voice = null;
 
-		public object Create(ActorInitializer init) { return new Selectable(init.self, this); }
+		public object Create(ActorInitializer init) { return new Selectable(init.Self, this); }
 	}
 
 	public class Selectable : IPostRenderSelection

--- a/OpenRA.Game/Traits/SelectionDecorations.cs
+++ b/OpenRA.Game/Traits/SelectionDecorations.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Traits
 	{
 		public readonly string Palette = "chrome";
 
-		public object Create(ActorInitializer init) { return new SelectionDecorations(init.self, this); }
+		public object Create(ActorInitializer init) { return new SelectionDecorations(init.Self, this); }
 	}
 
 	public class SelectionDecorations : IPostRenderSelection
@@ -68,7 +68,7 @@ namespace OpenRA.Traits
 			pipImages.PlayFetchIndex("groups", () => (int)group);
 			pipImages.Tick();
 
-			var pos = basePosition - (0.5f * pipImages.Image.size).ToInt2() + new int2(9, 5);
+			var pos = basePosition - (0.5f * pipImages.Image.Size).ToInt2() + new int2(9, 5);
 			yield return new UISpriteRenderable(pipImages.Image, pos, 0, pal, 1f);
 		}
 
@@ -81,7 +81,7 @@ namespace OpenRA.Traits
 			var pipImages = new Animation(self.World, "pips");
 			pipImages.PlayRepeating(PipStrings[0]);
 
-			var pipSize = pipImages.Image.size.ToInt2();
+			var pipSize = pipImages.Image.Size.ToInt2();
 			var pipxyBase = basePosition + new int2(1 - pipSize.X / 2, -(3 + pipSize.Y / 2));
 			var pipxyOffset = new int2(0, 0);
 			var pal = wr.Palette(Info.Palette);
@@ -127,7 +127,7 @@ namespace OpenRA.Traits
 						continue;
 
 					tagImages.PlayRepeating(TagStrings[(int)tag]);
-					var pos = basePosition + tagxyOffset - (0.5f * tagImages.Image.size).ToInt2();
+					var pos = basePosition + tagxyOffset - (0.5f * tagImages.Image.Size).ToInt2();
 					yield return new UISpriteRenderable(tagImages.Image, pos, 0, pal, 1f);
 
 					// Increment row

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Traits
 		[Desc("Size of partition bins (cells)")]
 		public readonly int BinSize = 10;
 
-		public object Create(ActorInitializer init) { return new ActorMap(init.world, this); }
+		public object Create(ActorInitializer init) { return new ActorMap(init.World, this); }
 	}
 
 	public class ActorMap : ITick

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Traits
 
 		public PipType PipColor = PipType.Yellow;
 
-		public object Create(ActorInitializer init) { return new ResourceType(this, init.world); }
+		public object Create(ActorInitializer init) { return new ResourceType(this, init.World); }
 	}
 
 	public class ResourceType : IWorldLoaded

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Traits
 		[Desc("Size of partition bins (world pixels)")]
 		public readonly int BinSize = 250;
 
-		public object Create(ActorInitializer init) { return new ScreenMap(init.world, this); }
+		public object Create(ActorInitializer init) { return new ScreenMap(init.World, this); }
 	}
 
 	public class ScreenMap : IWorldLoaded
@@ -36,7 +36,7 @@ namespace OpenRA.Traits
 		public ScreenMap(World world, ScreenMapInfo info)
 		{
 			this.info = info;
-			var ts = Game.modData.Manifest.TileSize;
+			var ts = Game.ModData.Manifest.TileSize;
 			cols = world.Map.MapSize.X * ts.Width / info.BinSize + 1;
 			rows = world.Map.MapSize.Y * ts.Height / info.BinSize + 1;
 

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Traits
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
 	public class ShroudInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new Shroud(init.self); }
+		public object Create(ActorInitializer init) { return new Shroud(init.Self); }
 	}
 
 	public class Shroud

--- a/OpenRA.Game/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Game/Widgets/DropDownButtonWidget.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Widgets
 			var color = GetColor();
 			var colorDisabled = GetColorDisabled();
 
-			WidgetUtils.DrawRGBA(image, stateOffset + new float2(rb.Right - rb.Height + 4, rb.Top + (rb.Height - image.bounds.Height) / 2));
+			WidgetUtils.DrawRGBA(image, stateOffset + new float2(rb.Right - rb.Height + 4, rb.Top + (rb.Height - image.Bounds.Height) / 2));
 
 			WidgetUtils.FillRectWithColor(new Rectangle(stateOffset.X + rb.Right - rb.Height,
 				stateOffset.Y + rb.Top + 3, 1, rb.Height - 6),

--- a/OpenRA.Game/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Game/Widgets/MapPreviewWidget.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Widgets
 		public int2 ConvertToPreview(CPos cell)
 		{
 			var preview = Preview();
-			var tileShape = Game.modData.Manifest.TileShape;
+			var tileShape = Game.ModData.Manifest.TileShape;
 			var point = Map.CellToMap(tileShape, cell);
 			var dx = (int)(previewScale * (point.X - preview.Bounds.Left));
 			var dy = (int)(previewScale * (point.Y - preview.Bounds.Top));
@@ -152,9 +152,9 @@ namespace OpenRA.Widgets
 				return;
 
 			// Update map rect
-			previewScale = Math.Min(RenderBounds.Width / minimap.size.X, RenderBounds.Height / minimap.size.Y);
-			var w = (int)(previewScale * minimap.size.X);
-			var h = (int)(previewScale * minimap.size.Y);
+			previewScale = Math.Min(RenderBounds.Width / minimap.Size.X, RenderBounds.Height / minimap.Size.Y);
+			var w = (int)(previewScale * minimap.Size.X);
+			var h = (int)(previewScale * minimap.Size.Y);
 			var x = RenderBounds.X + (RenderBounds.Width - w) / 2;
 			var y = RenderBounds.Y + (RenderBounds.Height - h) / 2;
 			mapRect = new Rectangle(x, y, w, h);
@@ -172,10 +172,10 @@ namespace OpenRA.Widgets
 					var owned = colors.ContainsKey(p);
 					var pos = ConvertToPreview(p);
 					var sprite = owned ? spawnClaimed : spawnUnclaimed;
-					var offset = new int2(sprite.bounds.Width, sprite.bounds.Height) / 2;
+					var offset = new int2(sprite.Bounds.Width, sprite.Bounds.Height) / 2;
 
 					if (owned)
-						WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X - offset.X + 1, pos.Y - offset.Y + 1, sprite.bounds.Width - 2, sprite.bounds.Height - 2), colors[p]);
+						WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X - offset.X + 1, pos.Y - offset.Y + 1, sprite.Bounds.Width - 2, sprite.Bounds.Height - 2), colors[p]);
 
 					Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, pos - offset);
 					var number = Convert.ToChar('A' + spawnPoints.IndexOf(p)).ToString();

--- a/OpenRA.Game/Widgets/RootWidget.cs
+++ b/OpenRA.Game/Widgets/RootWidget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Widgets
 
 				if (hk == Game.Settings.Keys.DevReloadChromeKey)
 				{
-					ChromeProvider.Initialize(Game.modData.Manifest.Chrome);
+					ChromeProvider.Initialize(Game.ModData.Manifest.Chrome);
 					return true;
 				}
 			}

--- a/OpenRA.Game/Widgets/SliderWidget.cs
+++ b/OpenRA.Game/Widgets/SliderWidget.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Widgets
 			for (var i = 0; i < Ticks; i++)
 			{
 				var tickPos = new float2(
-					trackOrigin + (i * (trackRect.Width - (int)tick.size.X) / (Ticks - 1)) - tick.size.X / 2,
+					trackOrigin + (i * (trackRect.Width - (int)tick.Size.X) / (Ticks - 1)) - tick.Size.X / 2,
 					trackRect.Bottom);
 
 				WidgetUtils.DrawRGBA(tick, tickPos);

--- a/OpenRA.Game/Widgets/SpriteSequenceWidget.cs
+++ b/OpenRA.Game/Widgets/SpriteSequenceWidget.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Widgets
 
 			if (Unit != null && Sequence != null)
 			{
-				var anim = new Animation(WorldRenderer.world, Unit, () => Facing);
+				var anim = new Animation(WorldRenderer.World, Unit, () => Facing);
 				anim.PlayFetchIndex(Sequence, () => Frame);
 				GetAnimation = () => anim;
 			}

--- a/OpenRA.Game/Widgets/SpriteWidget.cs
+++ b/OpenRA.Game/Widgets/SpriteWidget.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Widgets
 
 			if (sprite != cachedSprite)
 			{
-				offset = 0.5f * (new float2(RenderBounds.Size) - sprite.size);
+				offset = 0.5f * (new float2(RenderBounds.Size) - sprite.Size);
 				cachedSprite = sprite;
 			}
 

--- a/OpenRA.Game/Widgets/VqaPlayerWidget.cs
+++ b/OpenRA.Game/Widgets/VqaPlayerWidget.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Widgets
 				while (nextFrame > video.CurrentFrame)
 				{
 					video.AdvanceFrame();
-					videoSprite.sheet.GetTexture().SetData(video.FrameData);
+					videoSprite.Sheet.GetTexture().SetData(video.FrameData);
 					skippedFrames++;
 				}
 
@@ -185,7 +185,7 @@ namespace OpenRA.Widgets
 			paused = true;
 			Sound.StopVideo();
 			video.Reset();
-			videoSprite.sheet.GetTexture().SetData(video.FrameData);
+			videoSprite.Sheet.GetTexture().SetData(video.FrameData);
 			world.AddFrameEndTask(_ => onComplete());
 		}
 	}

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Widgets
 
 		public static Widget OpenWindow(string id, WidgetArgs args)
 		{
-			var window = Game.modData.WidgetLoader.LoadWidget(args, Root, id);
+			var window = Game.ModData.WidgetLoader.LoadWidget(args, Root, id);
 			if (WindowList.Count > 0)
 				Root.RemoveChild(WindowList.Peek());
 			WindowList.Push(window);
@@ -67,7 +67,7 @@ namespace OpenRA.Widgets
 
 		public static Widget LoadWidget(string id, Widget parent, WidgetArgs args)
 		{
-			return Game.modData.WidgetLoader.LoadWidget(args, parent, id);
+			return Game.ModData.WidgetLoader.LoadWidget(args, parent, id);
 		}
 
 		public static void Tick() { Root.TickOuter(); }
@@ -235,7 +235,7 @@ namespace OpenRA.Widgets
 
 			args["widget"] = this;
 
-			LogicObject = Game.modData.ObjectCreator.CreateObject<object>(Logic, args);
+			LogicObject = Game.ModData.ObjectCreator.CreateObject<object>(Logic, args);
 
 			args.Remove("widget");
 		}

--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -74,7 +74,7 @@ namespace OpenRA
 		static Widget NewWidget(string widgetType, WidgetArgs args)
 		{
 			widgetType = widgetType.Split('@')[0];
-			return Game.modData.ObjectCreator.CreateObject<Widget>(widgetType + "Widget", args);
+			return Game.ModData.ObjectCreator.CreateObject<Widget>(widgetType + "Widget", args);
 		}
 	}
 }

--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -29,33 +29,33 @@ namespace OpenRA.Widgets
 
 		public static void DrawSHPCentered(Sprite s, float2 pos, WorldRenderer wr)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(s, pos - 0.5f * s.size, wr.Palette("chrome"));
+			Game.Renderer.SpriteRenderer.DrawSprite(s, pos - 0.5f * s.Size, wr.Palette("chrome"));
 		}
 
 		public static void DrawSHPCentered(Sprite s, float2 pos, WorldRenderer wr, float scale)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(s, pos - 0.5f * scale * s.size, wr.Palette("chrome"), scale * s.size);
+			Game.Renderer.SpriteRenderer.DrawSprite(s, pos - 0.5f * scale * s.Size, wr.Palette("chrome"), scale * s.Size);
 		}
 
-		public static void DrawPanel(string collection, Rectangle Bounds)
+		public static void DrawPanel(string collection, Rectangle bounds)
 		{
-			DrawPanelPartial(collection, Bounds, PanelSides.All);
+			DrawPanelPartial(collection, bounds, PanelSides.All);
 		}
 
 		public static void FillRectWithSprite(Rectangle r, Sprite s)
 		{
-			for (var x = r.Left; x < r.Right; x += (int)s.size.X)
-				for (var y = r.Top; y < r.Bottom; y += (int)s.size.Y)
+			for (var x = r.Left; x < r.Right; x += (int)s.Size.X)
+				for (var y = r.Top; y < r.Bottom; y += (int)s.Size.Y)
 				{
 					var ss = s;
 					var left = new int2(r.Right - x, r.Bottom - y);
-					if (left.X < (int)s.size.X || left.Y < (int)s.size.Y)
+					if (left.X < (int)s.Size.X || left.Y < (int)s.Size.Y)
 					{
-						var rr = new Rectangle(s.bounds.Left,
-							s.bounds.Top,
-							Math.Min(left.X, (int)s.size.X),
-							Math.Min(left.Y, (int)s.size.Y));
-						ss = new Sprite(s.sheet, rr, s.channel);
+						var rr = new Rectangle(s.Bounds.Left,
+							s.Bounds.Top,
+							Math.Min(left.X, (int)s.Size.X),
+							Math.Min(left.Y, (int)s.Size.Y));
+						ss = new Sprite(s.Sheet, rr, s.Channel);
 					}
 
 					DrawRGBA(ss, new float2(x, y));
@@ -76,7 +76,7 @@ namespace OpenRA.Widgets
 		{
 			var images = new[] { "border-t", "border-b", "border-l", "border-r" };
 			var ss = images.Select(i => ChromeProvider.GetImage(collection, i)).ToArray();
-			return new[] { (int)ss[0].size.Y, (int)ss[1].size.Y, (int)ss[2].size.X, (int)ss[3].size.X };
+			return new[] { (int)ss[0].Size.Y, (int)ss[1].Size.Y, (int)ss[2].Size.X, (int)ss[3].Size.X };
 		}
 
 		static bool HasFlags(this PanelSides a, PanelSides b) { return (a & b) == b; }
@@ -95,10 +95,10 @@ namespace OpenRA.Widgets
 
 		public static void DrawPanelPartial(Sprite[] ss, Rectangle bounds, PanelSides ps)
 		{
-			var marginLeft = ss[2] == null ? 0 : (int)ss[2].size.X;
-			var marginTop = ss[0] == null ? 0 : (int)ss[0].size.Y;
-			var marginRight = ss[3] == null ? 0 : (int)ss[3].size.X;
-			var marginBottom = ss[1] == null ? 0 : (int)ss[1].size.Y;
+			var marginLeft = ss[2] == null ? 0 : (int)ss[2].Size.X;
+			var marginTop = ss[0] == null ? 0 : (int)ss[0].Size.Y;
+			var marginRight = ss[3] == null ? 0 : (int)ss[3].Size.X;
+			var marginBottom = ss[1] == null ? 0 : (int)ss[1].Size.Y;
 			var marginWidth = marginRight + marginLeft;
 			var marginHeight = marginBottom + marginTop;
 
@@ -135,11 +135,11 @@ namespace OpenRA.Widgets
 			if (ps.HasFlags(PanelSides.Left | PanelSides.Top) && ss[4] != null)
 				DrawRGBA(ss[4], new float2(bounds.Left, bounds.Top));
 			if (ps.HasFlags(PanelSides.Right | PanelSides.Top) && ss[5] != null)
-				DrawRGBA(ss[5], new float2(bounds.Right - ss[5].size.X, bounds.Top));
+				DrawRGBA(ss[5], new float2(bounds.Right - ss[5].Size.X, bounds.Top));
 			if (ps.HasFlags(PanelSides.Left | PanelSides.Bottom) && ss[6] != null)
-				DrawRGBA(ss[6], new float2(bounds.Left, bounds.Bottom - ss[6].size.Y));
+				DrawRGBA(ss[6], new float2(bounds.Left, bounds.Bottom - ss[6].Size.Y));
 			if (ps.HasFlags(PanelSides.Right | PanelSides.Bottom) && ss[7] != null)
-				DrawRGBA(ss[7], new float2(bounds.Right - ss[7].size.X, bounds.Bottom - ss[7].size.Y));
+				DrawRGBA(ss[7], new float2(bounds.Right - ss[7].Size.X, bounds.Bottom - ss[7].Size.Y));
 		}
 
 		public static string FormatTime(int ticks)
@@ -215,7 +215,7 @@ namespace OpenRA.Widgets
 
 		public static string ChooseInitialMap(string initialUid)
 		{
-			if (string.IsNullOrEmpty(initialUid) || Game.modData.MapCache[initialUid].Status != MapStatus.Available)
+			if (string.IsNullOrEmpty(initialUid) || Game.ModData.MapCache[initialUid].Status != MapStatus.Available)
 			{
 				Func<MapPreview, bool> isIdealMap = m =>
 				{
@@ -237,8 +237,8 @@ namespace OpenRA.Widgets
 					return true;
 				};
 
-				var selected = Game.modData.MapCache.Where(m => isIdealMap(m)).RandomOrDefault(Game.CosmeticRandom) ??
-					Game.modData.MapCache.First(m => m.Status == MapStatus.Available && m.Map.Visibility.HasFlag(MapVisibility.Lobby));
+				var selected = Game.ModData.MapCache.Where(m => isIdealMap(m)).RandomOrDefault(Game.CosmeticRandom) ??
+					Game.ModData.MapCache.First(m => m.Status == MapStatus.Available && m.Map.Visibility.HasFlag(MapVisibility.Lobby));
 				return selected.Uid;
 			}
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -25,15 +25,15 @@ namespace OpenRA
 	public class World
 	{
 		static readonly Func<int, int, bool> FalsePredicate = (u, v) => false;
-		internal readonly TraitDictionary traitDict = new TraitDictionary();
+		internal readonly TraitDictionary TraitDict = new TraitDictionary();
 		readonly HashSet<Actor> actors = new HashSet<Actor>();
 		readonly List<IEffect> effects = new List<IEffect>();
 		readonly Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
 
 		public int Timestep;
 
-		internal readonly OrderManager orderManager;
-		public Session LobbyInfo { get { return orderManager.LobbyInfo; } }
+		internal readonly OrderManager OrderManager;
+		public Session LobbyInfo { get { return OrderManager.LobbyInfo; } }
 
 		public readonly MersenneTwister SharedRandom;
 
@@ -87,7 +87,7 @@ namespace OpenRA
 
 		public bool IsReplay
 		{
-			get { return orderManager.Connection is ReplayConnection; }
+			get { return OrderManager.Connection is ReplayConnection; }
 		}
 
 		public bool AllowDevCommands
@@ -111,20 +111,20 @@ namespace OpenRA
 		public readonly ScreenMap ScreenMap;
 		readonly GameInformation gameInfo;
 
-		public void IssueOrder(Order o) { orderManager.IssueOrder(o); } /* avoid exposing the OM to mod code */
+		public void IssueOrder(Order o) { OrderManager.IssueOrder(o); } /* avoid exposing the OM to mod code */
 
-		IOrderGenerator orderGenerator_;
+		IOrderGenerator orderGenerator;
 		public IOrderGenerator OrderGenerator
 		{
 			get
 			{
-				return orderGenerator_;
+				return orderGenerator;
 			}
 
 			set
 			{
 				Sync.AssertUnsynced("The current order generator may not be changed from synced code");
-				orderGenerator_ = value;
+				orderGenerator = value;
 			}
 		}
 
@@ -149,8 +149,8 @@ namespace OpenRA
 		internal World(Map map, OrderManager orderManager, bool isShellmap)
 		{
 			IsShellmap = isShellmap;
-			this.orderManager = orderManager;
-			orderGenerator_ = new UnitOrderGenerator();
+			OrderManager = orderManager;
+			orderGenerator = new UnitOrderGenerator();
 			Map = map;
 
 			TileSet = map.Rules.TileSets[Map.Tileset];
@@ -189,9 +189,9 @@ namespace OpenRA
 
 			gameInfo.StartTimeUtc = DateTime.UtcNow;
 			foreach (var player in Players)
-				gameInfo.AddPlayer(player, orderManager.LobbyInfo);
+				gameInfo.AddPlayer(player, OrderManager.LobbyInfo);
 
-			var rc = orderManager.Connection as ReplayRecorderConnection;
+			var rc = OrderManager.Connection as ReplayRecorderConnection;
 			if (rc != null)
 				rc.Metadata = new ReplayMetadata(gameInfo);
 		}
@@ -330,7 +330,7 @@ namespace OpenRA
 
 		public IEnumerable<TraitPair<T>> ActorsWithTrait<T>()
 		{
-			return traitDict.ActorsWithTrait<T>();
+			return TraitDict.ActorsWithTrait<T>();
 		}
 
 		public void OnPlayerWinStateChanged(Player player)

--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -44,11 +44,11 @@ namespace OpenRA.Mods.Cnc.Traits
 		bool skippedMakeAnimation;
 
 		public AttackPopupTurreted(ActorInitializer init, AttackPopupTurretedInfo info)
-			: base(init.self, info)
+			: base(init.Self, info)
 		{
 			this.info = info;
 			turret = turrets.FirstOrDefault();
-			rb = init.self.Trait<RenderBuilding>();
+			rb = init.Self.Trait<RenderBuilding>();
 			skippedMakeAnimation = init.Contains<SkipMakeAnimsInit>();
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Cargo aircraft used.")]
 		[ActorReference] public readonly string ActorType = "c17";
 
-		public override object Create(ActorInitializer init) { return new ProductionAirdrop(this, init.self); }
+		public override object Create(ActorInitializer init) { return new ProductionAirdrop(this, init.Self); }
 	}
 
 	class ProductionAirdrop : Production

--- a/OpenRA.Mods.Cnc/Traits/Buildings/TiberiumRefinery.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/TiberiumRefinery.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	public class TiberiumRefineryInfo : OreRefineryInfo
 	{
-		public override object Create(ActorInitializer init) { return new TiberiumRefinery(init.self, this); }
+		public override object Create(ActorInitializer init) { return new TiberiumRefinery(init.Self, this); }
 	}
 
 	public class TiberiumRefinery : OreRefinery

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string WakeLeftSequence = "wake-left";
 		public readonly string WakeRightSequence = "wake-right";
 
-		public override object Create(ActorInitializer init) { return new RenderGunboat(init.self, this); }
+		public override object Create(ActorInitializer init) { return new RenderGunboat(init.Self, this); }
 
 		public int QuantizedBodyFacings(SequenceProvider sequenceProvider, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Passenger CargoType to display.")]
 		public readonly string[] DisplayTypes = { };
 
-		public object Create(ActorInitializer init) { return new WithCargo(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithCargo(init.Self, this); }
 	}
 
 	public class WithCargo : IRenderModifier

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly string IdleSequence = "idle";
 
-		public object Create(ActorInitializer init) { return new WithDeliveryAnimation(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithDeliveryAnimation(init.Self, this); }
 	}
 
 	public class WithDeliveryAnimation : INotifyDelivery

--- a/OpenRA.Mods.Cnc/Traits/Render/WithFire.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithFire.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string StartSequence = "fire-start";
 		public readonly string LoopSequence = "fire-loop";
 
-		public object Create(ActorInitializer init) { return new WithFire(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithFire(init.Self, this); }
 	}
 
 	class WithFire

--- a/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		public readonly string Sequence = "roof";
 
-		public object Create(ActorInitializer init) { return new WithRoof(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithRoof(init.Self, this); }
 	}
 
 	public class WithRoof

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Apply the weapon impact this many ticks into the effect")]
 		public readonly int WeaponDelay = 7;
 
-		public override object Create(ActorInitializer init) { return new IonCannonPower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new IonCannonPower(init.Self, this); }
 	}
 
 	class IonCannonPower : SupportPower

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (anim == null || ticks >= length)
 				yield break;
 
-			var cell = wr.world.Map.CellContaining(pos);
+			var cell = wr.World.Map.CellContaining(pos);
 			if (!args.SourceActor.World.FogObscures(cell))
 			{
 				if (info.Shadow)

--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("Use player remap color instead of a custom color?")]
 		public readonly bool UsePlayerColor = true;
 
-		public object Create(ActorInitializer init) { return new Contrail(init.self, this); }
+		public object Create(ActorInitializer init) { return new Contrail(init.Self, this); }
 	}
 
 	class Contrail : ITick, IRender

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (wr.world.FogObscures(wr.world.Map.CellContaining(pos)))
+			if (wr.World.FogObscures(wr.World.Map.CellContaining(pos)))
 				yield break;
 
 			yield return new TextRenderable(font, pos, 0, color, text);

--- a/OpenRA.Mods.Common/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Effects/GravityBomb.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			var cell = wr.world.Map.CellContaining(pos);
+			var cell = wr.World.Map.CellContaining(pos);
 			if (!args.SourceActor.World.FogObscures(cell))
 			{
 				if (info.Shadow)

--- a/OpenRA.Mods.Common/Effects/LaserZap.cs
+++ b/OpenRA.Mods.Common/Effects/LaserZap.cs
@@ -83,8 +83,8 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (wr.world.FogObscures(wr.world.Map.CellContaining(target)) &&
-				wr.world.FogObscures(wr.world.Map.CellContaining(args.Source)))
+			if (wr.World.FogObscures(wr.World.Map.CellContaining(target)) &&
+				wr.World.FogObscures(wr.World.Map.CellContaining(args.Source)))
 				yield break;
 
 			if (ticks < info.BeamDuration)

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.ContrailLength > 0)
 				yield return trail;
 
-			if (!args.SourceActor.World.FogObscures(wr.world.Map.CellContaining(pos)))
+			if (!args.SourceActor.World.FogObscures(wr.World.Map.CellContaining(pos)))
 			{
 				if (info.Shadow)
 				{

--- a/OpenRA.Mods.Common/Effects/PowerdownIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/PowerdownIndicator.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (a.Destroyed || wr.world.FogObscures(a))
+			if (a.Destroyed || wr.World.FogObscures(a))
 				return SpriteRenderable.None;
 
 			return anim.Render(a.CenterPosition, wr.Palette("chrome"));

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!building.IsInWorld || !building.World.Selection.Actors.Contains(building))
 				return SpriteRenderable.None;
 
-			var pos = wr.world.Map.CenterOfCell(cachedLocation);
+			var pos = wr.World.Map.CenterOfCell(cachedLocation);
 			var palette = wr.Palette(palettePrefix + building.Owner.InternalName);
 			return circles.Render(pos, palette).Concat(flag.Render(pos, palette));
 		}

--- a/OpenRA.Mods.Common/Effects/Rank.cs
+++ b/OpenRA.Mods.Common/Effects/Rank.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
 
-			if (wr.world.FogObscures(self))
+			if (wr.World.FogObscures(self))
 				yield break;
 
 			var pos = wr.ScreenPxPosition(self.CenterPosition);

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Graphics
 		public readonly ActorInfo Actor;
 		public readonly Player Owner;
 		public readonly WorldRenderer WorldRenderer;
-		public World World { get { return WorldRenderer.world; } }
+		public World World { get { return WorldRenderer.World; } }
 
 		readonly TypeDictionary dict;
 

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -67,13 +67,13 @@ namespace OpenRA.Mods.Common.Graphics
 
 			// Start of the first line segment is the tail of the list - don't smooth it.
 			var curPos = trail[Index(next - skip - 1)];
-			var curCell = wr.world.Map.CellContaining(curPos);
+			var curCell = wr.World.Map.CellContaining(curPos);
 			var curColor = color;
 			for (var i = 0; i < length - skip - 4; i++)
 			{
 				var j = next - skip - i - 2;
 				var nextPos = Average(trail[Index(j)], trail[Index(j - 1)], trail[Index(j - 2)], trail[Index(j - 3)]);
-				var nextCell = wr.world.Map.CellContaining(nextPos);
+				var nextCell = wr.World.Map.CellContaining(nextPos);
 				var nextColor = Exts.ColorLerp(i * 1f / (length - 4), color, Color.Transparent);
 
 				if (!world.FogObscures(curCell) && !world.FogObscures(nextCell))

--- a/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
@@ -101,9 +101,9 @@ namespace OpenRA.Mods.Common.Graphics
 		public void Render(WorldRenderer wr)
 		{
 			// TODO: This is a temporary workaround until we have a proper ramp-aware height calculation
-			var groundPos = wr.world.Map.CenterOfCell(wr.world.Map.CellContaining(pos));
+			var groundPos = wr.World.Map.CenterOfCell(wr.World.Map.CellContaining(pos));
 
-			var ts = Game.modData.Manifest.TileSize;
+			var ts = Game.ModData.Manifest.TileSize;
 			var groundZ = ts.Height * (groundPos.Z - pos.Z) / 1024f;
 
 			var pxOrigin = wr.ScreenPosition(pos);
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Graphics
 			var sc = shadowOrigin + psb[1];
 			var sd = shadowOrigin + psb[3];
 			Game.Renderer.WorldRgbaSpriteRenderer.DrawSprite(renderProxy.ShadowSprite, sa, sb, sc, sd);
-			Game.Renderer.WorldRgbaSpriteRenderer.DrawSprite(renderProxy.Sprite, pxOrigin - 0.5f * renderProxy.Sprite.size);
+			Game.Renderer.WorldRgbaSpriteRenderer.DrawSprite(renderProxy.Sprite, pxOrigin - 0.5f * renderProxy.Sprite.Size);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)
@@ -125,8 +125,8 @@ namespace OpenRA.Mods.Common.Graphics
 			var shadowOrigin = pxOrigin - groundZ * (new float2(renderProxy.ShadowDirection, 1));
 
 			// Draw sprite rect
-			var offset = pxOrigin + renderProxy.Sprite.offset - 0.5f * renderProxy.Sprite.size;
-			Game.Renderer.WorldLineRenderer.DrawRect(offset, offset + renderProxy.Sprite.size, Color.Red);
+			var offset = pxOrigin + renderProxy.Sprite.Offset - 0.5f * renderProxy.Sprite.Size;
+			Game.Renderer.WorldLineRenderer.DrawRect(offset, offset + renderProxy.Sprite.Size, Color.Red);
 
 			// Draw transformed shadow sprite rect
 			var c = Color.Purple;

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			// Check whether the mod content is installed
 			// TODO: The installation code has finally been beaten into shape, so we can
 			// finally move it all into the planned "Manage Content" panel in the modchooser mod.
-			var installData = Game.modData.Manifest.ContentInstaller;
+			var installData = Game.ModData.Manifest.ContentInstaller;
 			var installModContent = !installData.TestFiles.All(f => GlobalFileSystem.Exists(f));
 			var installModMusic = args != null && args.Contains("Install.Music");
 

--- a/OpenRA.Mods.Common/LoadScreens/ModChooserLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModChooserLoadScreen.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 		public void Dispose()
 		{
 			if (sprite != null)
-				sprite.sheet.Dispose();
+				sprite.Sheet.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Scripting
 			{
 				// Find the requested type
 				var typeName = kv.Key.ToString();
-				var initType = Game.modData.ObjectCreator.FindType(typeName + "Init");
+				var initType = Game.ModData.ObjectCreator.FindType(typeName + "Init");
 				if (initType == null)
 					throw new LuaException("Unknown initializer type '{0}'".F(typeName));
 
@@ -52,9 +52,9 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 
 			// The actor must be added to the world at the end of the tick
-			var a = context.World.CreateActor(false, type, initDict);
+			var a = Context.World.CreateActor(false, type, initDict);
 			if (addToWorld)
-				context.World.AddFrameEndTask(w => w.Add(a));
+				Context.World.AddFrameEndTask(w => w.Add(a));
 
 			return a;
 		}
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public int BuildTime(string type)
 		{
 			ActorInfo ai;
-			if (!context.World.Map.Rules.Actors.TryGetValue(type, out ai))
+			if (!Context.World.Map.Rules.Actors.TryGetValue(type, out ai))
 				throw new LuaException("Unknown actor type '{0}'".F(type));
 
 			return ai.GetBuildTime();
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public int CruiseAltitude(string type)
 		{
 			ActorInfo ai;
-			if (!context.World.Map.Rules.Actors.TryGetValue(type, out ai))
+			if (!Context.World.Map.Rules.Actors.TryGetValue(type, out ai))
 				throw new LuaException("Unknown actor type '{0}'".F(type));
 
 			var pi = ai.Traits.GetOrDefault<ICruiseAltitudeInfo>();

--- a/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
@@ -21,8 +21,8 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("The center of the visible viewport.")]
 		public WPos Position
 		{
-			get { return context.WorldRenderer.Viewport.CenterPosition; }
-			set { context.WorldRenderer.Viewport.Center(value); }
+			get { return Context.WorldRenderer.Viewport.CenterPosition; }
+			set { Context.WorldRenderer.Viewport.Center(value); }
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Get the current game time (in ticks)")]
 		public int GameTime
 		{
-			get { return context.World.WorldTick; }
+			get { return Context.World.WorldTick; }
 		}
 
 		[Desc("Converts the number of seconds into game time (ticks).")]

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -32,13 +32,13 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns a table of all actors within the requested region, filtered using the specified function.")]
 		public Actor[] ActorsInCircle(WPos location, WRange radius, LuaFunction filter = null)
 		{
-			var actors = context.World.FindActorsInCircle(location, radius);
+			var actors = Context.World.FindActorsInCircle(location, radius);
 
 			if (filter != null)
 			{
 				actors = actors.Where(a =>
 				{
-					using (var f = filter.Call(a.ToLuaValue(context)))
+					using (var f = filter.Call(a.ToLuaValue(Context)))
 						return f.First().ToBoolean();
 				});
 			}
@@ -49,13 +49,13 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns a table of all actors within the requested rectangle, filtered using the specified function.")]
 		public Actor[] ActorsInBox(WPos topLeft, WPos bottomRight, LuaFunction filter = null)
 		{
-			var actors = context.World.ActorMap.ActorsInBox(topLeft, bottomRight);
+			var actors = Context.World.ActorMap.ActorsInBox(topLeft, bottomRight);
 
 			if (filter != null)
 			{
 				actors = actors.Where(a =>
 				{
-					using (var f = filter.Call(a.ToLuaValue(context)))
+					using (var f = filter.Call(a.ToLuaValue(Context)))
 						return f.First().ToBoolean();
 				});
 			}
@@ -66,38 +66,38 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns the location of the top-left corner of the map.")]
 		public WPos TopLeft
 		{
-			get { return new WPos(context.World.Map.Bounds.Left * 1024, context.World.Map.Bounds.Top * 1024, 0); }
+			get { return new WPos(Context.World.Map.Bounds.Left * 1024, Context.World.Map.Bounds.Top * 1024, 0); }
 		}
 
 		[Desc("Returns the location of the bottom-right corner of the map.")]
 		public WPos BottomRight
 		{
-			get { return new WPos(context.World.Map.Bounds.Right * 1024, context.World.Map.Bounds.Bottom * 1024, 0); }
+			get { return new WPos(Context.World.Map.Bounds.Right * 1024, Context.World.Map.Bounds.Bottom * 1024, 0); }
 		}
 
 		[Desc("Returns a random cell inside the visible region of the map.")]
 		public CPos RandomCell()
 		{
-			return context.World.Map.ChooseRandomCell(context.World.SharedRandom);
+			return Context.World.Map.ChooseRandomCell(Context.World.SharedRandom);
 		}
 
 		[Desc("Returns a random cell on the visible border of the map.")]
 		public CPos RandomEdgeCell()
 		{
-			return context.World.Map.ChooseRandomEdgeCell(context.World.SharedRandom);
+			return Context.World.Map.ChooseRandomEdgeCell(Context.World.SharedRandom);
 		}
 
 		[Desc("Returns the center of a cell in world coordinates.")]
 		public WPos CenterOfCell(CPos cell)
 		{
-			return context.World.Map.CenterOfCell(cell);
+			return Context.World.Map.CenterOfCell(cell);
 		}
 
 		[Desc("Returns true if there is only one human player.")]
-		public bool IsSinglePlayer { get { return context.World.LobbyInfo.IsSinglePlayer; } }
+		public bool IsSinglePlayer { get { return Context.World.LobbyInfo.IsSinglePlayer; } }
 
 		[Desc("Returns the difficulty selected by the player before starting the mission.")]
-		public string Difficulty { get { return context.World.LobbyInfo.GlobalSettings.Difficulty; } }
+		public string Difficulty { get { return Context.World.LobbyInfo.GlobalSettings.Difficulty; } }
 
 		[Desc("Returns a table of all the actors that were specified in the map file.")]
 		public Actor[] NamedActors { get { return sma.Actors.Values.ToArray(); } }

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Scripting
 					}
 					catch (LuaException e)
 					{
-						context.FatalError(e.Message);
+						Context.FatalError(e.Message);
 					}
 				};
 			}

--- a/OpenRA.Mods.Common/Scripting/Global/PlayerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/PlayerGlobal.cs
@@ -22,16 +22,16 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns the player with the specified internal name, or nil if a match is not found.")]
 		public Player GetPlayer(string name)
 		{
-			return context.World.Players.FirstOrDefault(p => p.InternalName == name);
+			return Context.World.Players.FirstOrDefault(p => p.InternalName == name);
 		}
 
 		[Desc("Returns a table of players filtered by the specified function.")]
 		public Player[] GetPlayers(LuaFunction filter)
 		{
-			return context.World.Players
+			return Context.World.Players
 				.Where(p =>
 				{
-					using (var f = filter.Call(p.ToLuaValue(context)))
+					using (var f = filter.Call(p.ToLuaValue(Context)))
 						return f.First().ToBoolean();
 				}).ToArray();
 		}

--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -45,32 +45,32 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
-			context.World.AddFrameEndTask(w => w.Add(new DelayedAction(delay, doCall)));
+			Context.World.AddFrameEndTask(w => w.Add(new DelayedAction(delay, doCall)));
 		}
 
 		[Desc("Call a function each tick that the actor is idle. " +
 			"The callback function will be called as func(Actor self).")]
 		public void OnIdle(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnIdle, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnIdle, func, Context);
 		}
 
 		[Desc("Call a function when the actor is damaged. The callback " +
 			"function will be called as func(Actor self, Actor attacker).")]
 		public void OnDamaged(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnDamaged, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnDamaged, func, Context);
 		}
 
 		[Desc("Call a function when the actor is killed. The callback " +
 			"function will be called as func(Actor self, Actor killer).")]
 		public void OnKilled(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnKilled, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnKilled, func, Context);
 		}
 
 		[Desc("Call a function when all of the actors in a group are killed. The callback " +
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Scripting
 					if (called)
 						return;
 
-					using (var killed = m.ToLuaValue(context))
+					using (var killed = m.ToLuaValue(Context))
 						copy.Call(killed).Dispose();
 
 					copy.Dispose();
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
@@ -133,56 +133,56 @@ namespace OpenRA.Mods.Common.Scripting
 			"The callback function will be called as func(Actor producer, Actor produced).")]
 		public void OnProduction(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnProduction, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnProduction, func, Context);
 		}
 
 		[Desc("Call a function when this player completes all primary objectives. " +
 			"The callback function will be called as func(Player player).")]
 		public void OnPlayerWon(Player player, LuaFunction func)
 		{
-			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnPlayerWon, func, context);
+			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnPlayerWon, func, Context);
 		}
 
 		[Desc("Call a function when this player fails any primary objective. " +
 			"The callback function will be called as func(Player player).")]
 		public void OnPlayerLost(Player player, LuaFunction func)
 		{
-			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnPlayerLost, func, context);
+			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnPlayerLost, func, Context);
 		}
 
 		[Desc("Call a function when this player is assigned a new objective. " +
 			"The callback function will be called as func(Player player, int objectiveID).")]
 		public void OnObjectiveAdded(Player player, LuaFunction func)
 		{
-			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveAdded, func, context);
+			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveAdded, func, Context);
 		}
 
 		[Desc("Call a function when this player completes an objective. " +
 			"The callback function will be called as func(Player player, int objectiveID).")]
 		public void OnObjectiveCompleted(Player player, LuaFunction func)
 		{
-			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveCompleted, func, context);
+			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveCompleted, func, Context);
 		}
 
 		[Desc("Call a function when this player fails an objective. " +
 			"The callback function will be called as func(Player player, int objectiveID).")]
 		public void OnObjectiveFailed(Player player, LuaFunction func)
 		{
-			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveFailed, func, context);
+			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveFailed, func, Context);
 		}
 
 		[Desc("Call a function when this actor is added to the world. " +
 			"The callback function will be called as func(Actor self).")]
 		public void OnAddedToWorld(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnAddedToWorld, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnAddedToWorld, func, Context);
 		}
 
 		[Desc("Call a function when this actor is removed from the world. " +
 			"The callback function will be called as func(Actor self).")]
 		public void OnRemovedFromWorld(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnRemovedFromWorld, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnRemovedFromWorld, func, Context);
 		}
 
 		[Desc("Call a function when all of the actors in a group have been removed from the world. " +
@@ -205,7 +205,7 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
@@ -217,7 +217,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"will be called as func(Actor self, Actor captor, Player oldOwner, Player newOwner).")]
 		public void OnCapture(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnCapture, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnCapture, func, Context);
 		}
 
 		[Desc("Call a function when this actor is killed or captured. " +
@@ -240,7 +240,7 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
@@ -271,7 +271,7 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
@@ -293,17 +293,17 @@ namespace OpenRA.Mods.Common.Scripting
 			{
 				try
 				{
-					using (var luaActor = a.ToLuaValue(context))
-					using (var id = triggerId.ToLuaValue(context))
+					using (var luaActor = a.ToLuaValue(Context))
+					using (var id = triggerId.ToLuaValue(Context))
 						onEntry.Call(luaActor, id).Dispose();
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
-			triggerId = context.World.ActorMap.AddCellTrigger(cells, invokeEntry, null);
+			triggerId = Context.World.ActorMap.AddCellTrigger(cells, invokeEntry, null);
 
 			return triggerId;
 		}
@@ -319,17 +319,17 @@ namespace OpenRA.Mods.Common.Scripting
 			{
 				try
 				{
-					using (var luaActor = a.ToLuaValue(context))
-					using (var id = triggerId.ToLuaValue(context))
+					using (var luaActor = a.ToLuaValue(Context))
+					using (var id = triggerId.ToLuaValue(Context))
 						onExit.Call(luaActor, id).Dispose();
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
-			triggerId = context.World.ActorMap.AddCellTrigger(cells, null, invokeExit);
+			triggerId = Context.World.ActorMap.AddCellTrigger(cells, null, invokeExit);
 
 			return triggerId;
 		}
@@ -337,7 +337,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Removes a previously created footprint trigger.")]
 		public void RemoveFootprintTrigger(int id)
 		{
-			context.World.ActorMap.RemoveCellTrigger(id);
+			Context.World.ActorMap.RemoveCellTrigger(id);
 		}
 
 		[Desc("Call a function when an actor enters this range." +
@@ -351,17 +351,17 @@ namespace OpenRA.Mods.Common.Scripting
 			{
 				try
 				{
-					using (var luaActor = a.ToLuaValue(context))
-					using (var id = triggerId.ToLuaValue(context))
+					using (var luaActor = a.ToLuaValue(Context))
+					using (var id = triggerId.ToLuaValue(Context))
 						onEntry.Call(luaActor, id).Dispose();
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
-			triggerId = context.World.ActorMap.AddProximityTrigger(pos, range, invokeEntry, null);
+			triggerId = Context.World.ActorMap.AddProximityTrigger(pos, range, invokeEntry, null);
 
 			return triggerId;
 		}
@@ -377,17 +377,17 @@ namespace OpenRA.Mods.Common.Scripting
 			{
 				try
 				{
-					using (var luaActor = a.ToLuaValue(context))
-					using (var id = triggerId.ToLuaValue(context))
+					using (var luaActor = a.ToLuaValue(Context))
+					using (var id = triggerId.ToLuaValue(Context))
 						onExit.Call(luaActor, id).Dispose();
 				}
 				catch (Exception e)
 				{
-					context.FatalError(e.Message);
+					Context.FatalError(e.Message);
 				}
 			};
 
-			triggerId = context.World.ActorMap.AddProximityTrigger(pos, range, null, invokeExit);
+			triggerId = Context.World.ActorMap.AddProximityTrigger(pos, range, null, invokeExit);
 
 			return triggerId;
 		}
@@ -395,14 +395,14 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Removes a previously created proximitry trigger.")]
 		public void RemoveProximityTrigger(int id)
 		{
-			context.World.ActorMap.RemoveProximityTrigger(id);
+			Context.World.ActorMap.RemoveProximityTrigger(id);
 		}
 
 		[Desc("Call a function when this actor is infiltrated. The callback function " +
 			"will be called as func(Actor self, Actor infiltrator).")]
 		public void OnInfiltrated(Actor a, LuaFunction func)
 		{
-			GetScriptTriggers(a).RegisterCallback(Trigger.OnInfiltrated, func, context);
+			GetScriptTriggers(a).RegisterCallback(Trigger.OnInfiltrated, func, Context);
 		}
 
 		[Desc("Removes all triggers from this actor." +

--- a/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Skips over the first numElements members of a table and return the rest.")]
 		public LuaTable Skip(LuaTable table, int numElements)
 		{
-			var t = context.CreateTable();
+			var t = Context.CreateTable();
 
 			for (var i = numElements; i <= table.Count; i++)
 				t.Add(t.Count + 1, table[i]);
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns a random value from a collection.")]
 		public LuaValue Random(LuaValue[] collection)
 		{
-			return collection.Random(context.World.SharedRandom);
+			return collection.Random(Context.World.SharedRandom);
 		}
 
 		[Desc("Expands the given footprint one step along the coordinate axes, and (if requested) diagonals.")]
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Scripting
 			if (high <= low)
 				return low;
 
-			return context.World.SharedRandom.Next(low, high);
+			return Context.World.SharedRandom.Next(low, high);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns true if the player is allied with the other player.")]
 		public bool IsAlliedWith(Player targetPlayer)
 		{
-			return player.IsAlliedWith(targetPlayer);
+			return Player.IsAlliedWith(targetPlayer);
 		}
 
 		[Desc("Changes the current stance of the player against the target player. " +
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public void SetStance(Player targetPlayer, string newStance)
 		{
 			var emergingStance = Enum<Stance>.Parse(newStance);
-			player.SetStance(targetPlayer, emergingStance);
+			Player.SetStance(targetPlayer, emergingStance);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public int Health
 		{
 			get { return health.HP; }
-			set { health.InflictDamage(self, self, health.HP - value, null, true); }
+			set { health.InflictDamage(Self, Self, health.HP - value, null, true); }
 		}
 
 		[Desc("Maximum health of the actor.")]
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Kill the actor.")]
 		public void Kill()
 		{
-			health.InflictDamage(self, self, health.MaxHP, null, true);
+			health.InflictDamage(Self, Self, health.MaxHP, null, true);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/UpgradeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/UpgradeProperties.cs
@@ -27,25 +27,25 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Grant an upgrade to this actor.")]
 		public void GrantUpgrade(string upgrade)
 		{
-			um.GrantUpgrade(self, upgrade, this);
+			um.GrantUpgrade(Self, upgrade, this);
 		}
 
 		[Desc("Revoke an upgrade that was previously granted using GrantUpgrade.")]
 		public void RevokeUpgrade(string upgrade)
 		{
-			um.RevokeUpgrade(self, upgrade, this);
+			um.RevokeUpgrade(Self, upgrade, this);
 		}
 
 		[Desc("Grant a limited-time upgrade to this actor.")]
 		public void GrantTimedUpgrade(string upgrade, int duration)
 		{
-			um.GrantTimedUpgrade(self, upgrade, duration);
+			um.GrantTimedUpgrade(Self, upgrade, duration);
 		}
 
 		[Desc("Check whether this actor accepts a specific upgrade.")]
 		public bool AcceptsUpgrade(string upgrade)
 		{
-			return um.AcceptsUpgrade(self, upgrade);
+			return um.AcceptsUpgrade(Self, upgrade);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Scripting
 	[Desc("Allows map scripts to attach triggers to this actor via the Triggers global.")]
 	public class ScriptTriggersInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new ScriptTriggers(init.world); }
+		public object Create(ActorInitializer init) { return new ScriptTriggers(init.World); }
 	}
 
 	public sealed class ScriptTriggers : INotifyIdle, INotifyDamage, INotifyKilled, INotifyProduction, INotifyOtherProduction, INotifyObjectivesUpdated, INotifyCapture, INotifyInfiltrated, INotifyAddedToWorld, INotifyRemovedFromWorld, IDisposable

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Server
 				return;
 
 			var defaults = new Session.Global();
-			FieldLoader.Load(defaults, Game.modData.Manifest.LobbyDefaults);
+			FieldLoader.Load(defaults, Game.ModData.Manifest.LobbyDefaults);
 
 			if (server.LobbyInfo.GlobalSettings.FragileAlliances != defaults.FragileAlliances)
 				server.SendOrderTo(conn, "Message", "Diplomacy Changes: {0}".F(server.LobbyInfo.GlobalSettings.FragileAlliances));

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Aircraft(ActorInitializer init, AircraftInfo info)
 		{
 			this.info = info;
-			this.self = init.self;
+			this.self = init.Self;
 
 			if (init.Contains<LocationInit>())
 				SetPosition(self, init.Get<LocationInit, CPos>());

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Guns = "secondary";
 		public readonly int FacingTolerance = 2;
 
-		public override object Create(ActorInitializer init) { return new AttackBomber(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackBomber(init.Self, this); }
 	}
 
 	public class AttackBomber : AttackBase, ITick, ISync, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/Air/AttackHeli.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackHeli.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class AttackHeliInfo : AttackFrontalInfo
 	{
-		public override object Create(ActorInitializer init) { return new AttackHeli(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackHeli(init.Self, this); }
 	}
 
 	public class AttackHeli : AttackFrontal

--- a/OpenRA.Mods.Common/Traits/Air/AttackPlane.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackPlane.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class AttackPlaneInfo : AttackFrontalInfo
 	{
-		public override object Create(ActorInitializer init) { return new AttackPlane(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackPlane(init.Self, this); }
 	}
 
 	public class AttackPlane : AttackFrontal

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool Moves = false;
 		public readonly WRange Velocity = new WRange(43);
 
-		public object Create(ActorInitializer init) { return new FallsToEarth(init.self, this); }
+		public object Create(ActorInitializer init) { return new FallsToEarth(init.Self, this); }
 	}
 
 	public class FallsToEarth

--- a/OpenRA.Mods.Common/Traits/Air/Helicopter.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Helicopter.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Helicopter(ActorInitializer init, HelicopterInfo info)
 			: base(init, info)
 		{
-			self = init.self;
+			self = init.Self;
 			Info = info;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/Plane.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Plane.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Plane(ActorInitializer init, PlaneInfo info)
 			: base(init, info)
 		{
-			self = init.self;
+			self = init.Self;
 			Info = info;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Use multiple muzzle images if non-zero")]
 		public readonly int MuzzleSplitFacings = 0;
 
-		public object Create(ActorInitializer init) { return new Armament(init.self, this); }
+		public object Create(ActorInitializer init) { return new Armament(init.Self, this); }
 	}
 
 	public class Armament : UpgradableTrait<ArmamentInfo>, ITick, IExplodeModifier

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharge.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharge.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay between charge attacks (in ticks).")]
 		public readonly int ChargeDelay = 3;
 
-		public override object Create(ActorInitializer init) { return new AttackCharge(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackCharge(init.Self, this); }
 	}
 
 	class AttackCharge : AttackOmni, ITick, INotifyAttack, ISync

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Actor will follow units until in range to attack them.")]
 	public class AttackFollowInfo : AttackBaseInfo
 	{
-		public override object Create(ActorInitializer init) { return new AttackFollow(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackFollow(init.Self, this); }
 	}
 
 	public class AttackFollow : AttackBase, ITick, ISync

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly int FacingTolerance = 1;
 
-		public override object Create(ActorInitializer init) { return new AttackFrontal(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackFrontal(init.Self, this); }
 	}
 
 	public class AttackFrontal : AttackBase

--- a/OpenRA.Mods.Common/Traits/Attack/AttackMedic.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackMedic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		"heal process then. It also won't work with buildings (use RepairsUnits: for them)")]
 	public class AttackMedicInfo : AttackFrontalInfo
 	{
-		public override object Create(ActorInitializer init) { return new AttackMedic(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackMedic(init.Self, this); }
 	}
 
 	public class AttackMedic : AttackFrontal

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	class AttackOmniInfo : AttackBaseInfo
 	{
-		public override object Create(ActorInitializer init) { return new AttackOmni(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackOmni(init.Self, this); }
 	}
 
 	class AttackOmni : AttackBase, ISync

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Actor has a visual turret used to attack.")]
 	public class AttackTurretedInfo : AttackFollowInfo, Requires<TurretedInfo>
 	{
-		public override object Create(ActorInitializer init) { return new AttackTurreted(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackTurreted(init.Self, this); }
 	}
 
 	public class AttackTurreted : AttackFollow, ITick, ISync

--- a/OpenRA.Mods.Common/Traits/Attack/AttackWander.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackWander.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 		"This conflicts with player orders and should only be added to animal creeps.")]
 	class AttackWanderInfo : WandersInfo, Requires<AttackMoveInfo>
 	{
-		public override object Create(ActorInitializer init) { return new AttackWander(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackWander(init.Self, this); }
 	}
 
 	class AttackWander : Wanders

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Provides access to the attack-move command, which will make the actor automatically engage viable targets while moving to the destination.")]
 	class AttackMoveInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new AttackMove(init.self, this); }
+		public object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
 	}
 
 	class AttackMove : IResolveOrder, IOrderVoice, INotifyIdle, ISync

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool TargetWhenIdle = true;
 		public readonly bool TargetWhenDamaged = true;
 
-		public object Create(ActorInitializer init) { return new AutoTarget(init.self, this); }
+		public object Create(ActorInitializer init) { return new AutoTarget(init.Self, this); }
 	}
 
 	public enum UnitStance { HoldFire, ReturnFire, Defend, AttackAnything }

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Cooldown = 0;
 		public readonly int InitialDelay = 0;
 
-		public object Create(ActorInitializer init) { return new BaseProvider(init.self, this); }
+		public object Create(ActorInitializer init) { return new BaseProvider(init.Self, this); }
 	}
 
 	public class BaseProvider : ITick, IPostRenderSelection, ISelectionBar

--- a/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Palette = "terrain";
 		public readonly bool HasMinibib = false;
 
-		public object Create(ActorInitializer init) { return new Bib(init.self, this); }
+		public object Create(ActorInitializer init) { return new Bib(init.Self, this); }
 	}
 
 	public class Bib : INotifyAddedToWorld, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -127,14 +127,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Building(ActorInitializer init, BuildingInfo info)
 		{
-			this.self = init.self;
+			this.self = init.Self;
 			this.topLeft = init.Get<LocationInit, CPos>();
 			this.Info = info;
 
 			occupiedCells = FootprintUtils.UnpathableTiles(self.Info.Name, Info, TopLeft)
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
 
-			CenterPosition = init.world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(init.world, Info);
+			CenterPosition = init.World.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(init.World, Info);
 			SkipMakeAnimation = init.Contains<SkipMakeAnimsInit>();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("A dictionary of buildings placed on the map. Attach this to the world actor.")]
 	public class BuildingInfluenceInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new BuildingInfluence(init.world); }
+		public object Create(ActorInitializer init) { return new BuildingInfluence(init.World); }
 	}
 
 	public class BuildingInfluence

--- a/OpenRA.Mods.Common/Traits/Buildings/DeadBuildingState.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/DeadBuildingState.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly int LingerTime = 20;
 
-		public object Create(ActorInitializer init) { return new DeadBuildingState(init.self, this); }
+		public object Create(ActorInitializer init) { return new DeadBuildingState(init.Self, this); }
 	}
 
 	class DeadBuildingState : INotifyKilled

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -38,13 +38,13 @@ namespace OpenRA.Mods.Common.Traits
 			if (init.Contains<FreeActorInit>() && !init.Get<FreeActorInit>().ActorValue)
 				return;
 
-			init.self.World.AddFrameEndTask(w =>
+			init.Self.World.AddFrameEndTask(w =>
 			{
 				var a = w.CreateActor(info.Actor, new TypeDictionary
 				{
-					new ParentActorInit(init.self),
-					new LocationInit(init.self.Location + info.SpawnOffset),
-					new OwnerInit(init.self.Owner),
+					new ParentActorInit(init.Self),
+					new LocationInit(init.Self.Location + info.SpawnOffset),
+					new OwnerInit(init.Self.Owner),
 					new FacingInit(info.Facing),
 				});
 

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly CVec RallyPoint = new CVec(1, 3);
 		public readonly string IndicatorPalettePrefix = "player";
 
-		public object Create(ActorInitializer init) { return new RallyPoint(init.self, this); }
+		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}
 
 	public class RallyPoint : IIssueOrder, IResolveOrder, ISync

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Damage = 1;
 		public readonly int Interval = 8;
 
-		public object Create(ActorInitializer init) { return new Burns(init.self, this); }
+		public object Create(ActorInitializer init) { return new Burns(init.Self, this); }
 	}
 
 	class Burns : ITick, ISync

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Cargo(ActorInitializer init, CargoInfo info)
 		{
-			self = init.self;
+			self = init.Self;
 			Info = info;
 			Unloading = false;
 

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string[] CloakTypes = { "Cloak" };
 
-		public object Create(ActorInitializer init) { return new Cloak(init.self, this); }
+		public object Create(ActorInitializer init) { return new Cloak(init.Self, this); }
 	}
 
 	public class Cloak : UpgradableTrait<CloakInfo>, IRenderModifier, INotifyDamageStateChanged, INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public GainsExperience(ActorInitializer init, GainsExperienceInfo info)
 		{
-			self = init.self;
+			self = init.Self;
 			this.info = info;
 
 			MaxLevel = info.Upgrades.Count;

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Grant experience for team-kills.")]
 		public readonly bool FriendlyFire = false;
 
-		public object Create(ActorInitializer init) { return new GivesExperience(init.self, this); }
+		public object Create(ActorInitializer init) { return new GivesExperience(init.Self, this); }
 	}
 
 	class GivesExperience : INotifyKilled

--- a/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
+++ b/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string[] Upgrades = { };
 		public readonly string[] Prerequisites = { };
 
-		public object Create(ActorInitializer init) { return new GlobalUpgradable(init.self, this); }
+		public object Create(ActorInitializer init) { return new GlobalUpgradable(init.Self, this); }
 	}
 
 	public class GlobalUpgradable : INotifyAddedToWorld, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -43,14 +43,14 @@ namespace OpenRA.Mods.Common.Traits
 		public Husk(ActorInitializer init, HuskInfo info)
 		{
 			this.info = info;
-			this.self = init.self;
+			this.self = init.Self;
 
 			TopLeft = init.Get<LocationInit, CPos>();
-			CenterPosition = init.Contains<CenterPositionInit>() ? init.Get<CenterPositionInit, WPos>() : init.world.Map.CenterOfCell(TopLeft);
+			CenterPosition = init.Contains<CenterPositionInit>() ? init.Get<CenterPositionInit, WPos>() : init.World.Map.CenterOfCell(TopLeft);
 			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 128;
 
 			dragSpeed = init.Contains<HuskSpeedInit>() ? init.Get<HuskSpeedInit, int>() : 0;
-			finalPosition = init.world.Map.CenterOfCell(TopLeft);
+			finalPosition = init.World.Map.CenterOfCell(TopLeft);
 		}
 
 		public void Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Immobile(ActorInitializer init, ImmobileInfo info)
 		{
 			location = init.Get<LocationInit, CPos>();
-			position = init.world.Map.CenterOfCell(location);
+			position = init.World.Map.CenterOfCell(location);
 
 			if (info.OccupiesSpace)
 				occupied = new[] { Pair.New(TopLeft, SubCell.FullCell) };

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -290,19 +290,19 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Mobile(ActorInitializer init, MobileInfo info)
 		{
-			self = init.self;
+			self = init.Self;
 			Info = info;
 
-			ToSubCell = FromSubCell = info.SharesCell ? init.world.Map.DefaultSubCell : SubCell.FullCell;
+			ToSubCell = FromSubCell = info.SharesCell ? init.World.Map.DefaultSubCell : SubCell.FullCell;
 			if (init.Contains<SubCellInit>())
 			{
-				this.FromSubCell = this.ToSubCell = init.Get<SubCellInit, SubCell>();
+				FromSubCell = ToSubCell = init.Get<SubCellInit, SubCell>();
 			}
 
 			if (init.Contains<LocationInit>())
 			{
-				this.fromCell = this.toCell = init.Get<LocationInit, CPos>();
-				SetVisualPosition(self, init.world.Map.CenterOfSubCell(FromCell, FromSubCell));
+				fromCell = toCell = init.Get<LocationInit, CPos>();
+				SetVisualPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
 			}
 
 			this.Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : info.InitialFacing;

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -44,15 +44,15 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Spawned actors (e.g. building husks) shouldn't be revealed
 			startsRevealed = info.StartsRevealed && !init.Contains<ParentActorInit>();
-			var footprint = FootprintUtils.Tiles(init.self).ToList();
-			footprintInMapsCoords = footprint.Select(cell => Map.CellToMap(init.world.Map.TileShape, cell)).ToArray();
-			footprintRegion = CellRegion.BoundingRegion(init.world.Map.TileShape, footprint);
-			tooltip = Exts.Lazy(() => init.self.TraitsImplementing<IToolTip>().FirstOrDefault());
-			tooltip = Exts.Lazy(() => init.self.TraitsImplementing<IToolTip>().FirstOrDefault());
-			health = Exts.Lazy(() => init.self.TraitOrDefault<Health>());
+			var footprint = FootprintUtils.Tiles(init.Self).ToList();
+			footprintInMapsCoords = footprint.Select(cell => Map.CellToMap(init.World.Map.TileShape, cell)).ToArray();
+			footprintRegion = CellRegion.BoundingRegion(init.World.Map.TileShape, footprint);
+			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<IToolTip>().FirstOrDefault());
+			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<IToolTip>().FirstOrDefault());
+			health = Exts.Lazy(() => init.Self.TraitOrDefault<Health>());
 
 			frozen = new Dictionary<Player, FrozenActor>();
-			visible = init.world.Players.ToDictionary(p => p, p => false);
+			visible = init.World.Players.ToDictionary(p => p, p => false);
 		}
 
 		public bool IsVisible(Actor self, Player byPlayer)

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/WaterPaletteRotation.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/WaterPaletteRotation.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly string[] ExcludePalettes = { };
 
-		public object Create(ActorInitializer init) { return new WaterPaletteRotation(init.world, this); }
+		public object Create(ActorInitializer init) { return new WaterPaletteRotation(init.World, this); }
 	}
 
 	class WaterPaletteRotation : ITick, IPaletteModifier

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay for the end game notification in milliseconds.")]
 		public int NotificationDelay = 1500;
 
-		public object Create(ActorInitializer init) { return new ConquestVictoryConditions(init.self, this); }
+		public object Create(ActorInitializer init) { return new ConquestVictoryConditions(init.Self, this); }
 	}
 
 	public class ConquestVictoryConditions : ITick, INotifyObjectivesUpdated

--- a/OpenRA.Mods.Common/Traits/Player/GlobalUpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GlobalUpgradeManager.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public GlobalUpgradeManager(ActorInitializer init)
 		{
-			self = init.self;
+			self = init.Self;
 			techTree = self.Trait<TechTree>();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay between the game over condition being met, and the game actually ending, in milliseconds.")]
 		public readonly int GameOverDelay = 1500;
 
-		public object Create(ActorInitializer init) { return new MissionObjectives(init.world, this); }
+		public object Create(ActorInitializer init) { return new MissionObjectives(init.World, this); }
 	}
 
 	public class MissionObjectives : INotifyObjectivesUpdated, ISync, IResolveOrder

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Notification = "Beacon";
 		public readonly string PalettePrefix = "player";
 
-		public object Create(ActorInitializer init) { return new PlaceBeacon(init.self, this); }
+		public object Create(ActorInitializer init) { return new PlaceBeacon(init.Self, this); }
 	}
 
 	public class PlaceBeacon : IResolveOrder

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to the player actor to collect observer stats.")]
 	public class PlayerStatisticsInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new PlayerStatistics(init.self); }
+		public object Create(ActorInitializer init) { return new PlayerStatistics(init.Self); }
 	}
 
 	public class PlayerStatistics : ITick, IResolveOrder

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesCustomPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesCustomPrerequisite.cs
@@ -41,9 +41,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 
-			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.self.Owner.Country.Race; 
+			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race; 
 
-			Update(init.self.Owner, race);
+			Update(init.Self.Owner, race);
 		}
 
 		public IEnumerable<string> ProvidesPrerequisites

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public ProvidesTechPrerequisite(ProvidesTechPrerequisiteInfo info, ActorInitializer init)
 		{
 			this.info = info;
-			var tech = init.world.Map.Options.TechLevel ?? init.world.LobbyInfo.GlobalSettings.TechLevel;
+			var tech = init.World.Map.Options.TechLevel ?? init.World.LobbyInfo.GlobalSettings.TechLevel;
 			this.enabled = info.Name == tech;
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay for the end game notification in milliseconds.")]
 		public int NotificationDelay = 1500;
 
-		public object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.self, this); }
+		public object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.Self, this); }
 	}
 
 	public class StrategicVictoryConditions : ITick, ISync, INotifyObjectivesUpdated

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -28,9 +28,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public TechTree(ActorInitializer init)
 		{
-			player = init.self.Owner;
-			init.world.ActorAdded += ActorChanged;
-			init.world.ActorRemoved += ActorChanged;
+			player = init.Self.Owner;
+			init.World.ActorAdded += ActorChanged;
+			init.World.ActorRemoved += ActorChanged;
 		}
 
 		public void ActorChanged(Actor a)

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Disables the actor when a power outage is triggered (see `InfiltrateForPowerOutage` for more information).")]
 	public class AffectedByPowerOutageInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new AffectedByPowerOutage(init.self); }
+		public object Create(ActorInitializer init) { return new AffectedByPowerOutage(init.Self); }
 	}
 
 	public class AffectedByPowerOutage : INotifyOwnerChanged, ISelectionBar, IPowerModifier, IDisable

--- a/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
+++ b/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Restore power when this trait is disabled.")]
 		public readonly bool CancelWhenDisabled = false;
 
-		public object Create(ActorInitializer init) { return new CanPowerDown(init.self, this); }
+		public object Create(ActorInitializer init) { return new CanPowerDown(init.Self, this); }
 	}
 
 	public class CanPowerDown : UpgradableTrait<CanPowerDownInfo>, IPowerModifier, IResolveOrder, IDisable, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int AdviceInterval = 250;
 		public readonly string SpeechNotification = "LowPower";
 
-		public object Create(ActorInitializer init) { return new PowerManager(init.self, this); }
+		public object Create(ActorInitializer init) { return new PowerManager(init.Self, this); }
 	}
 
 	public class PowerManager : ITick, ISync

--- a/OpenRA.Mods.Common/Traits/Power/Power.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Power.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("If negative, it will drain power. If positive, it will provide power.")]
 		public readonly int Amount = 0;
 
-		public object Create(ActorInitializer init) { return new Power(init.self, this); }
+		public object Create(ActorInitializer init) { return new Power(init.Self, this); }
 	}
 
 	public class Power : UpgradableTrait<PowerInfo>, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Power/RequiresPower.cs
+++ b/OpenRA.Mods.Common/Traits/Power/RequiresPower.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Needs power to operate.")]
 	class RequiresPowerInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new RequiresPower(init.self); }
+		public object Create(ActorInitializer init) { return new RequiresPower(init.Self); }
 	}
 
 	class RequiresPower : IDisable, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Scale power amount with the current health.")]
 	public class ScalePowerWithHealthInfo : ITraitInfo, Requires<PowerInfo>, Requires<HealthInfo>
 	{
-		public object Create(ActorInitializer init) { return new ScalePowerWithHealth(init.self); }
+		public object Create(ActorInitializer init) { return new ScalePowerWithHealth(init.Self); }
 	}
 
 	public class ScalePowerWithHealth : IPowerModifier, INotifyDamage, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/RadarColorFromTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/RadarColorFromTerrain.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class RadarColorFromTerrainInfo : ITraitInfo
 	{
 		public readonly string Terrain;
-		public object Create(ActorInitializer init) { return new RadarColorFromTerrain(init.self, Terrain); }
+		public object Create(ActorInitializer init) { return new RadarColorFromTerrain(init.Self, Terrain); }
 	}
 
 	public class RadarColorFromTerrain : IRadarColorModifier

--- a/OpenRA.Mods.Common/Traits/Reloads.cs
+++ b/OpenRA.Mods.Common/Traits/Reloads.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Whether or not reload counter should be reset when ammo has been fired.")]
 		public readonly bool ResetOnFire = false;
 
-		public object Create(ActorInitializer init) { return new Reloads(init.self, this); }
+		public object Create(ActorInitializer init) { return new Reloads(init.Self, this); }
 	}
 
 	public class Reloads : ITick

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Amount of Z axis changes in world units.")]
 		public readonly int OffsetModifier = -43;
 
-		public object Create(ActorInitializer init) { return new Hovers(this, init.self); }
+		public object Create(ActorInitializer init) { return new Hovers(this, init.Self); }
 	}
 
 	class Hovers : IRenderModifier

--- a/OpenRA.Mods.Common/Traits/Render/RenderBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderBuilding.cs
@@ -41,9 +41,9 @@ namespace OpenRA.Mods.Common.Traits
 			: this(init, info, () => 0) { }
 
 		public RenderBuilding(ActorInitializer init, RenderBuildingInfo info, Func<int> baseFacing)
-			: base(init.self, baseFacing)
+			: base(init.Self, baseFacing)
 		{
-			var self = init.self;
+			var self = init.Self;
 			this.info = info;
 
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, "idle"));

--- a/OpenRA.Mods.Common/Traits/Render/RenderBuildingTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderBuildingTurreted.cs
@@ -46,9 +46,9 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public RenderBuildingTurreted(ActorInitializer init, RenderBuildingInfo info)
-			: base(init, info, MakeTurretFacingFunc(init.self))
+			: base(init, info, MakeTurretFacingFunc(init.Self))
 		{
-			t = init.self.TraitsImplementing<Turreted>().FirstOrDefault();
+			t = init.Self.TraitsImplementing<Turreted>().FirstOrDefault();
 			t.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderEditorOnly.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderEditorOnly.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Invisible during games.")]
 	class RenderEditorOnlyInfo : RenderSimpleInfo
 	{
-		public override object Create(ActorInitializer init) { return new RenderEditorOnly(init.self); }
+		public override object Create(ActorInitializer init) { return new RenderEditorOnly(init.Self); }
 	}
 
 	class RenderEditorOnly : RenderSimple

--- a/OpenRA.Mods.Common/Traits/Render/RenderFlare.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderFlare.cs
@@ -12,7 +12,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	class RenderFlareInfo : RenderSimpleInfo
 	{
-		public override object Create(ActorInitializer init) { return new RenderFlare(init.self); }
+		public override object Create(ActorInitializer init) { return new RenderFlare(init.Self); }
 	}
 
 	class RenderFlare : RenderSimple

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string Font = "TinyBold";
 
-		public object Create(ActorInitializer init) { return new RenderNameTag(init.self, this); }
+		public object Create(ActorInitializer init) { return new RenderNameTag(init.Self, this); }
 	}
 
 	class RenderNameTag : IRender

--- a/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class RenderSimpleInfo : RenderSpritesInfo, IRenderActorPreviewSpritesInfo, IQuantizeBodyOrientationInfo, ILegacyEditorRenderInfo, Requires<IBodyOrientationInfo>
 	{
-		public override object Create(ActorInitializer init) { return new RenderSimple(init.self); }
+		public override object Create(ActorInitializer init) { return new RenderSimple(init.Self); }
 
 		public virtual IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Change the sprite image size.")]
 		public readonly float Scale = 1f;
 
-		public virtual object Create(ActorInitializer init) { return new RenderSprites(init.self); }
+		public virtual object Create(ActorInitializer init) { return new RenderSprites(init.Self); }
 
 		public IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
@@ -200,7 +200,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return anims.Values.Where(b => b.IsVisible
 				&& b.Animation.Animation.CurrentSequence != null)
-					.Select(a => (a.Animation.Animation.Image.size * info.Scale).ToInt2())
+					.Select(a => (a.Animation.Animation.Image.Size * info.Scale).ToInt2())
 					.FirstOrDefault();
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/RenderUnit.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderUnit.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class RenderUnitInfo : RenderSimpleInfo, Requires<IFacingInfo>
 	{
-		public override object Create(ActorInitializer init) { return new RenderUnit(init.self); }
+		public override object Create(ActorInitializer init) { return new RenderUnit(init.Self); }
 	}
 
 	public class RenderUnit : RenderSimple

--- a/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly Color Color = Color.Red;
 
-		public object Create(ActorInitializer init) { return new TimedUpgradeBar(init.self, this); }
+		public object Create(ActorInitializer init) { return new TimedUpgradeBar(init.Self, this); }
 	}
 
 	class TimedUpgradeBar : ISelectionBar

--- a/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Visual offset")]
 		public readonly WVec LocalOffset = WVec.Zero;
 
-		public object Create(ActorInitializer init) { return new WithBarrel(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithBarrel(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "build";
 
-		public object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.Self, this); }
 	}
 
 	public class WithBuildingPlacedAnimation : INotifyBuildingPlaced

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Easteregg sequences to use in december.")]
 		public readonly string[] XmasImages = { };
 
-		public object Create(ActorInitializer init) { return new WithCrateBody(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithCrateBody(init.Self, this); }
 	}
 
 	class WithCrateBody : INotifyParachuteLanded

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Custom crushed animation palette is a player palette BaseName")]
 		public readonly bool CrushedPaletteIsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithDeathAnimation(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithDeathAnimation(init.Self, this); }
 	}
 
 	public class WithDeathAnimation : INotifyKilled

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		public object Create(ActorInitializer init) { return new WithHarvestAnimation(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithHarvestAnimation(init.Self, this); }
 	}
 
 	class WithHarvestAnimation : INotifyHarvesterAction

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WithMakeAnimation(ActorInitializer init, WithMakeAnimationInfo info)
 		{
 			this.info = info;
-			var self = init.self;
+			var self = init.Self;
 			renderBuilding = self.Trait<RenderBuilding>();
 
 			var building = self.Trait<Building>();

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleFlash.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Ignore the weapon position, and always draw relative to the center of the actor")]
 		public readonly bool IgnoreOffset = false;
 
-		public object Create(ActorInitializer init) { return new WithMuzzleFlash(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithMuzzleFlash(init.Self, this); }
 	}
 
 	class WithMuzzleFlash : INotifyAttack, IRender, ITick

--- a/OpenRA.Mods.Common/Traits/Render/WithResources.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResources.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "resources";
 
-		public object Create(ActorInitializer init) { return new WithResources(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithResources(init.Self, this); }
 	}
 
 	class WithResources : INotifyBuildComplete, INotifySold, INotifyOwnerChanged, INotifyDamageStateChanged

--- a/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Change this when using this trait multiple times on the same actor.")]
 		public readonly string Id = "rotor";
 
-		public object Create(ActorInitializer init) { return new WithRotor(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithRotor(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithSmoke.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSmoke.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Needs to define \"idle\", \"loop\" and \"end\" sub-sequences.")]
 		public readonly string Sequence = "smoke_m";
 
-		public object Create(ActorInitializer init) { return new WithSmoke(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithSmoke(init.Self, this); }
 	}
 
 	public class WithSmoke : INotifyDamage

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Render recoil")]
 		public readonly bool Recoils = true;
 
-		public object Create(ActorInitializer init) { return new WithTurret(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithTurret(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Sprite = "smokey";
 		public readonly DamageState MinDamage = DamageState.Heavy;
 
-		public object Create(ActorInitializer init) { return new SmokeTrailWhenDamaged(init.self, this); }
+		public object Create(ActorInitializer init) { return new SmokeTrailWhenDamaged(init.Self, this); }
 	}
 
 	class SmokeTrailWhenDamaged : ITick

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Minimum duration (in seconds) between sound events.")]
 		public readonly int Interval = 5;
 
-		public object Create(ActorInitializer init) { return new AnnounceOnKill(init.self, this); }
+		public object Create(ActorInitializer init) { return new AnnounceOnKill(init.Self, this); }
 	}
 
 	public class AnnounceOnKill : INotifyAppliedDamage

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence of the actor that contains the cameo.")]
 		public readonly string Icon = "icon";
 
-		public virtual object Create(ActorInitializer init) { return new Tooltip(init.self, this); }
+		public virtual object Create(ActorInitializer init) { return new Tooltip(init.Self, this); }
 
 		public string TooltipForPlayerStance(Stance stance)
 		{

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			upgrades = Exts.Lazy(() =>
 			{
 				var ret = new Dictionary<string, UpgradeState>();
-				foreach (var up in init.self.TraitsImplementing<IUpgradable>())
+				foreach (var up in init.Self.TraitsImplementing<IUpgradable>())
 					foreach (var t in up.UpgradeTypes)
 						ret.GetOrAdd(t).Traits.Add(up);
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int[] ShadowIndex = { };
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new PaletteFromCurrentTileset(init.world, this); }
+		public object Create(ActorInitializer init) { return new PaletteFromCurrentTileset(init.World, this); }
 	}
 
 	class PaletteFromCurrentTileset : ILoadsPalettes

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int[] ShadowIndex = { };
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new PaletteFromFile(init.world, this); }
+		public object Create(ActorInitializer init) { return new PaletteFromFile(init.World, this); }
 	}
 
 	class PaletteFromFile : ILoadsPalettes

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int A = 255;
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new PaletteFromRGBA(init.world, this); }
+		public object Create(ActorInitializer init) { return new PaletteFromRGBA(init.World, this); }
 	}
 
 	class PaletteFromRGBA : ILoadsPalettes

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Calculates routes for mobile units based on the A* search algorithm.", " Attach this to the world actor.")]
 	public class PathFinderInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new PathFinder(init.world); }
+		public object Create(ActorInitializer init) { return new PathFinder(init.World); }
 	}
 
 	public class PathFinder

--- a/OpenRA.Mods.Common/Traits/World/PathfinderDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathfinderDebugOverlay.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 						layer[cell] = layer[cell] * 5 / 6;
 
 					// TODO: This doesn't make sense for isometric terrain
-					var pos = wr.world.Map.CenterOfCell(cell);
+					var pos = wr.World.Map.CenterOfCell(cell);
 					var tl = wr.ScreenPxPosition(pos - new WVec(512, 512, 0));
 					var br = wr.ScreenPxPosition(pos + new WVec(511, 511, 0));
 					qr.FillRect(RectangleF.FromLTRB(tl.X, tl.Y, br.X, br.Y), Color.FromArgb(w, c));

--- a/OpenRA.Mods.Common/Traits/World/PlayMusicOnMapLoad.cs
+++ b/OpenRA.Mods.Common/Traits/World/PlayMusicOnMapLoad.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Music = null;
 		public readonly bool Loop = false;
 
-		public object Create(ActorInitializer init) { return new PlayMusicOnMapLoad(init.world, this); }
+		public object Create(ActorInitializer init) { return new PlayMusicOnMapLoad(init.World, this); }
 	}
 
 	class PlayMusicOnMapLoad : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/PlayerPaletteFromCurrentTileset.cs
+++ b/OpenRA.Mods.Common/Traits/World/PlayerPaletteFromCurrentTileset.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Apply palette rotatotors or not.")]
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new PlayerPaletteFromCurrentTileset(init.world, this); }
+		public object Create(ActorInitializer init) { return new PlayerPaletteFromCurrentTileset(init.World, this); }
 	}
 
 	class PlayerPaletteFromCurrentTileset : ILoadsPalettes

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var c = render[uv.X, uv.Y];
 				if (c.Sprite != null)
-					new SpriteRenderable(c.Sprite, wr.world.Map.CenterOfCell(Map.MapToCell(world.Map.TileShape, uv)),
+					new SpriteRenderable(c.Sprite, wr.World.Map.CenterOfCell(Map.MapToCell(world.Map.TileShape, uv)),
 						WVec.Zero, -511, c.Type.Palette, 1f, true).Render(wr); // TODO ZOffset is ignored
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int OverrideFogIndex = 15;
 
 		public readonly BlendMode ShroudBlend = BlendMode.Alpha;
-		public object Create(ActorInitializer init) { return new ShroudRenderer(init.world, this); }
+		public object Create(ActorInitializer init) { return new ShroudRenderer(init.World, this); }
 	}
 
 	public class ShroudRenderer : IRenderShroud, IWorldLoaded
@@ -298,13 +298,13 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (t.Shroud != null)
 				{
-					var pos = t.ScreenPosition - 0.5f * t.Shroud.size;
+					var pos = t.ScreenPosition - 0.5f * t.Shroud.Size;
 					Game.Renderer.WorldSpriteRenderer.DrawSprite(t.Shroud, pos, shroudPalette);
 				}
 
 				if (t.Fog != null)
 				{
-					var pos = t.ScreenPosition - 0.5f * t.Fog.size;
+					var pos = t.ScreenPosition - 0.5f * t.Fog.Size;
 					Game.Renderer.WorldSpriteRenderer.DrawSprite(t.Fog, pos, fogPalette);
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Renders a debug overlay showing the terrain cells. Attach this to the world actor.")]
 	public class TerrainGeometryOverlayInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new TerrainGeometryOverlay(init.self); }
+		public object Create(ActorInitializer init) { return new TerrainGeometryOverlay(init.Self); }
 	}
 
 	public class TerrainGeometryOverlay : IRenderOverlay
@@ -73,8 +73,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (devMode.Value == null || !devMode.Value.ShowTerrainGeometry)
 				return;
 
-			var ts = wr.world.Map.TileShape;
-			var colors = wr.world.TileSet.HeightDebugColors;
+			var ts = wr.World.Map.TileShape;
+			var colors = wr.World.TileSet.HeightDebugColors;
 
 			var leftDelta = ts == TileShape.Diamond ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
 			var topDelta = ts == TileShape.Diamond ? new WVec(0, -512, 0) : new WVec(512, -512, 0);
@@ -84,10 +84,10 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
 				var lr = Game.Renderer.WorldLineRenderer;
-				var pos = wr.world.Map.CenterOfCell(Map.MapToCell(wr.world.Map.TileShape, uv));
+				var pos = wr.World.Map.CenterOfCell(Map.MapToCell(wr.World.Map.TileShape, uv));
 
-				var height = (int)wr.world.Map.MapHeight.Value[uv.X, uv.Y];
-				var tile = wr.world.Map.MapTiles.Value[uv.X, uv.Y];
+				var height = (int)wr.World.Map.MapHeight.Value[uv.X, uv.Y];
+				var tile = wr.World.Map.MapTiles.Value[uv.X, uv.Y];
 
 				TerrainTileInfo tileInfo = null;
 
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 				// (ra/td templates omit Clear tiles from templates)
 				try
 				{
-					tileInfo = wr.world.TileSet.Templates[tile.Type][tile.Index];
+					tileInfo = wr.World.TileSet.Templates[tile.Type][tile.Index];
 				}
 				catch (Exception) { }
 

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
+			Game.ModData = modData;
 
 			try
 			{
@@ -52,8 +52,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				IEnumerable<Map> maps;
 				if (args.Length < 2)
 				{
-					Game.modData.MapCache.LoadMaps();
-					maps = Game.modData.MapCache
+					Game.ModData.MapCache.LoadMaps();
+					maps = Game.ModData.MapCache
 						.Where(m => m.Status == MapStatus.Available)
 						.Select(m => m.Map);
 				}
@@ -65,12 +65,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					Console.WriteLine("Testing map: {0}".F(testMap.Title));
 					testMap.PreloadRules();
 
-					foreach (var customPassType in Game.modData.ObjectCreator
+					foreach (var customPassType in Game.ModData.ObjectCreator
 						.GetTypesImplementing<ILintPass>())
 					{
 						try
 						{
-							var customPass = (ILintPass)Game.modData.ObjectCreator
+							var customPass = (ILintPass)Game.ModData.ObjectCreator
 								.CreateBasic(customPassType);
 
 							customPass.Run(EmitError, EmitWarning, testMap);

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -24,14 +24,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
-			Game.modData.RulesetCache.LoadDefaultRules();
+			Game.ModData = modData;
+			Game.ModData.RulesetCache.LoadDefaultRules();
 
-			var types = Game.modData.ObjectCreator.GetTypes();
+			var types = Game.ModData.ObjectCreator.GetTypes();
 			var translatableFields = types.SelectMany(t => t.GetFields())
 				.Where(f => f.HasAttribute<TranslateAttribute>()).Distinct();
 
-			foreach (var filename in Game.modData.Manifest.ChromeLayout)
+			foreach (var filename in Game.ModData.Manifest.ChromeLayout)
 			{
 				Console.WriteLine("# {0}:", filename);
 				var yaml = MiniYaml.FromFile(filename);

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -25,9 +25,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
+			Game.ModData = modData;
 
-			Console.WriteLine("This is an automatically generated listing of the new Lua map scripting API, generated for {0} of OpenRA.", Game.modData.Manifest.Mod.Version);
+			Console.WriteLine("This is an automatically generated listing of the new Lua map scripting API, generated for {0} of OpenRA.", Game.ModData.Manifest.Mod.Version);
 			Console.WriteLine();
 			Console.WriteLine("OpenRA allows custom maps and missions to be scripted using Lua 5.1.\n" +
 				"These scripts run in a sandbox that prevents access to unsafe functions (e.g. OS or file access), " +
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				"The properties and commands available on each actor depends on the traits that the actor specifies in its rule definitions.\n");
 			Console.WriteLine();
 
-			var tables = Game.modData.ObjectCreator.GetTypesImplementing<ScriptGlobal>()
+			var tables = Game.ModData.ObjectCreator.GetTypesImplementing<ScriptGlobal>()
 				.OrderBy(t => t.Name);
 
 			Console.WriteLine("<h3>Global Tables</h3>");
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			Console.WriteLine("<h3>Actor Properties / Commands</h3>");
 
-			var actorCategories = Game.modData.ObjectCreator.GetTypesImplementing<ScriptActorProperties>().SelectMany(cg =>
+			var actorCategories = Game.ModData.ObjectCreator.GetTypesImplementing<ScriptActorProperties>().SelectMany(cg =>
 			{
 				var catAttr = cg.GetCustomAttributes<ScriptPropertyGroupAttribute>(false).FirstOrDefault();
 				var category = catAttr != null ? catAttr.Category : "Unsorted";
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			Console.WriteLine("<h3>Player Properties / Commands</h3>");
 
-			var playerCategories = Game.modData.ObjectCreator.GetTypesImplementing<ScriptPlayerProperties>().SelectMany(cg =>
+			var playerCategories = Game.ModData.ObjectCreator.GetTypesImplementing<ScriptPlayerProperties>().SelectMany(cg =>
 			{
 				var catAttr = cg.GetCustomAttributes<ScriptPropertyGroupAttribute>(false).FirstOrDefault();
 				var category = catAttr != null ? catAttr.Category : "Unsorted";

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -24,18 +24,18 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
+			Game.ModData = modData;
 
 			Console.WriteLine(
 				"This documentation is aimed at modders. It displays all traits with default values and developer commentary. " +
 				"Please do not edit it directly, but add new `[Desc(\"String\")]` tags to the source code. This file has been " +
-				"automatically generated for version {0} of OpenRA.", Game.modData.Manifest.Mod.Version);
+				"automatically generated for version {0} of OpenRA.", Game.ModData.Manifest.Mod.Version);
 			Console.WriteLine();
 
 			var toc = new StringBuilder();
 			var doc = new StringBuilder();
 
-			foreach (var t in Game.modData.ObjectCreator.GetTypesImplementing<ITraitInfo>().OrderBy(t => t.Namespace))
+			foreach (var t in Game.ModData.ObjectCreator.GetTypesImplementing<ITraitInfo>().OrderBy(t => t.Namespace))
 			{
 				if (t.ContainsGenericParameters || t.IsAbstract)
 					continue; // skip helpers like TraitInfo<T>
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					continue;
 				doc.AppendLine("<table>");
 				doc.AppendLine("<tr><th>Property</th><th>Default Value</th><th>Type</th><th>Description</th></tr>");
-				var liveTraitInfo = Game.modData.ObjectCreator.CreateBasic(t);
+				var liveTraitInfo = Game.ModData.ObjectCreator.CreateBasic(t);
 				foreach (var info in infos)
 				{
 					var fieldDescLines = info.Field.GetCustomAttributes<DescAttribute>(true).SelectMany(d => d.Lines);

--- a/OpenRA.Mods.Common/UtilityCommands/GenerateMinimapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GenerateMinimapCommand.cs
@@ -25,11 +25,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		[Desc("MAPFILE", "Render PNG minimap of specified oramap file.")]
 		public void Run(ModData modData, string[] args)
 		{
-			Game.modData = modData;
+			Game.ModData = modData;
 			var map = new Map(args[1]);
 
 			GlobalFileSystem.UnmountAll();
-			foreach (var dir in Game.modData.Manifest.Folders)
+			foreach (var dir in Game.ModData.Manifest.Folders)
 				GlobalFileSystem.Mount(dir);
 
 			var minimap = Minimap.RenderMapPreview(map.Rules.TileSets[map.Tileset], map, true);

--- a/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		[Desc("MAPFILE", "Generate hash of specified oramap file.")]
 		public void Run(ModData modData, string[] args)
 		{
-			Game.modData = modData;
+			Game.ModData = modData;
 			var result = new Map(args[1]).Uid;
 			Console.WriteLine(result);
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -23,9 +23,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
+			Game.ModData = modData;
 
-			var rules = Game.modData.RulesetCache.LoadDefaultRules();
+			var rules = Game.ModData.RulesetCache.LoadDefaultRules();
 			var map = LegacyMapImporter.Import(args[1], modData.Manifest.Mod.Id, rules, e => Console.WriteLine(e));
 			var dest = map.Title + ".oramap";
 			map.Save(dest);

--- a/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
@@ -37,16 +37,16 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var srcMod = args[1].Split(':')[0];
 
-			Game.modData = new ModData(srcMod);
-			GlobalFileSystem.LoadFromManifest(Game.modData.Manifest);
-			var srcRules = Game.modData.RulesetCache.LoadDefaultRules();
+			Game.ModData = new ModData(srcMod);
+			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
+			var srcRules = Game.ModData.RulesetCache.LoadDefaultRules();
 			var srcPaletteInfo = srcRules.Actors["player"].Traits.Get<PlayerColorPaletteInfo>();
 			var srcRemapIndex = srcPaletteInfo.RemapIndex;
 
 			var destMod = args[2].Split(':')[0];
-			Game.modData = new ModData(destMod);
-			GlobalFileSystem.LoadFromManifest(Game.modData.Manifest);
-			var destRules = Game.modData.RulesetCache.LoadDefaultRules();
+			Game.ModData = new ModData(destMod);
+			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
+			var destRules = Game.ModData.RulesetCache.LoadDefaultRules();
 			var destPaletteInfo = destRules.Actors["player"].Traits.Get<PlayerColorPaletteInfo>();
 			var destRemapIndex = destPaletteInfo.RemapIndex;
 			var shadowIndex = new int[] { };

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
+			Game.ModData = modData;
 
 			var map = new Map(args[1]);
 			var engineDate = Exts.ParseIntegerInvariant(args[2]);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -24,13 +24,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
-			Game.modData.MapCache.LoadMaps();
+			Game.ModData = modData;
+			Game.ModData.MapCache.LoadMaps();
 
 			var engineDate = Exts.ParseIntegerInvariant(args[1]);
 
 			Console.WriteLine("Processing Rules:");
-			foreach (var filename in Game.modData.Manifest.Rules)
+			foreach (var filename in Game.ModData.Manifest.Rules)
 			{
 				Console.WriteLine("\t" + filename);
 				var yaml = MiniYaml.FromFile(filename);
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 
 			Console.WriteLine("Processing Weapons:");
-			foreach (var filename in Game.modData.Manifest.Weapons)
+			foreach (var filename in Game.ModData.Manifest.Weapons)
 			{
 				Console.WriteLine("\t" + filename);
 				var yaml = MiniYaml.FromFile(filename);
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 
 			Console.WriteLine("Processing Tilesets:");
-			foreach (var filename in Game.modData.Manifest.TileSets)
+			foreach (var filename in Game.ModData.Manifest.TileSets)
 			{
 				Console.WriteLine("\t" + filename);
 				var yaml = MiniYaml.FromFile(filename);
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 
 			Console.WriteLine("Processing Cursors:");
-			foreach (var filename in Game.modData.Manifest.Cursors)
+			foreach (var filename in Game.ModData.Manifest.Cursors)
 			{
 				Console.WriteLine("\t" + filename);
 				var yaml = MiniYaml.FromFile(filename);
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 
 			Console.WriteLine("Processing Maps:");
-			var maps = Game.modData.MapCache
+			var maps = Game.ModData.MapCache
 				.Where(m => m.Status == MapStatus.Available)
 				.Select(m => m.Map);
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		internal static void ConvertPxToRange(ref string input, int scaleMult, int scaleDiv)
 		{
 			var value = Exts.ParseIntegerInvariant(input);
-			var ts = Game.modData.Manifest.TileSize;
+			var ts = Game.ModData.Manifest.TileSize;
 			var world = value * 1024 * scaleMult / (scaleDiv * ts.Height);
 			var cells = world / 1024;
 			var subcells = world - 1024 * cells;
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		internal static void ConvertInt2ToWVec(ref string input)
 		{
 			var offset = FieldLoader.GetValue<int2>("(value)", input);
-			var ts = Game.modData.Manifest.TileSize;
+			var ts = Game.ModData.Manifest.TileSize;
 			var world = new WVec(offset.X * 1024 / ts.Width, offset.Y * 1024 / ts.Height, 0);
 			input = world.ToString();
 		}

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				try
 				{
-					mixerSprite.sheet.GetTexture().SetData(front, 256, 256);
+					mixerSprite.Sheet.GetTexture().SetData(front, 256, 256);
 				}
 				finally
 				{
@@ -138,8 +138,8 @@ namespace OpenRA.Mods.Common.Widgets
 			Game.Renderer.RgbaSpriteRenderer.DrawSprite(mixerSprite, RenderOrigin, new float2(RenderBounds.Size));
 
 			var sprite = ChromeProvider.GetImage("lobby-bits", "colorpicker");
-			var pos = RenderOrigin + PxFromValue() - new int2(sprite.bounds.Width, sprite.bounds.Height) / 2;
-			WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X + 1, pos.Y + 1, sprite.bounds.Width - 2, sprite.bounds.Height - 2), Color.RGB);
+			var pos = RenderOrigin + PxFromValue() - new int2(sprite.Bounds.Width, sprite.Bounds.Height) / 2;
+			WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X + 1, pos.Y + 1, sprite.Bounds.Width - 2, sprite.Bounds.Height - 2), Color.RGB);
 			Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, pos);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets
 			Game.Renderer.RgbaSpriteRenderer.DrawSprite(hueSprite, ro, new float2(rb.Size));
 
 			var sprite = ChromeProvider.GetImage("lobby-bits", "huepicker");
-			var pos = RenderOrigin + new int2(PxFromValue(Value).Clamp(0, rb.Width - 1) - sprite.bounds.Width / 2, (rb.Height - sprite.bounds.Height) / 2);
+			var pos = RenderOrigin + new int2(PxFromValue(Value).Clamp(0, rb.Width - 1) - sprite.Bounds.Width / 2, (rb.Height - sprite.Bounds.Height) / 2);
 			Game.Renderer.RgbaSpriteRenderer.DrawSprite(sprite, pos);
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var panel = widget;
 			var loadButton = panel.Get<ButtonWidget>("LOAD_BUTTON");
 			loadButton.OnClick = () => LoadMod(selectedMod);
-			loadButton.IsDisabled = () => selectedMod.Id == Game.modData.Manifest.Mod.Id;
+			loadButton.IsDisabled = () => selectedMod.Id == Game.ModData.Manifest.Mod.Id;
 
 			panel.Get<ButtonWidget>("QUIT_BUTTON").OnClick = Game.Exit;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			colorPreview.Color = ps.Color;
 
 			var colorDropdown = panel.Get<DropDownButtonWidget>("PLAYERCOLOR");
-			colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorPreview, worldRenderer.world);
+			colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorPreview, worldRenderer.World);
 			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => ps.Color.RGB;
 
 			return () =>
@@ -600,7 +600,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, Game.modData.Languages, setupItem);
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, Game.ModData.Languages, setupItem);
 			return true;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -94,8 +94,8 @@ namespace OpenRA.Mods.Common.Widgets
 			var uv = Map.CellToMap(world.Map.TileShape, cell);
 			var terrain = world.Map.GetTerrainInfo(cell);
 
-			var dx = terrainSprite.bounds.Left - world.Map.Bounds.Left;
-			var dy = terrainSprite.bounds.Top - world.Map.Bounds.Top;
+			var dx = terrainSprite.Bounds.Left - world.Map.Bounds.Left;
+			var dy = terrainSprite.Bounds.Top - world.Map.Bounds.Top;
 
 			unsafe
 			{
@@ -111,8 +111,8 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var stride = radarSheet.Size.Width;
 			var uv = Map.CellToMap(world.Map.TileShape, cell);
-			var dx = shroudSprite.bounds.Left - world.Map.Bounds.Left;
-			var dy = shroudSprite.bounds.Top - world.Map.Bounds.Top;
+			var dx = shroudSprite.Bounds.Left - world.Map.Bounds.Left;
+			var dy = shroudSprite.Bounds.Top - world.Map.Bounds.Top;
 
 			var color = 0;
 			if (world.ShroudObscures(cell))
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (cursor == null)
 				return "default";
 
-			return Game.modData.CursorProvider.HasCursorSequence(cursor + "-minimap") ? cursor + "-minimap" : cursor;
+			return Game.ModData.CursorProvider.HasCursorSequence(cursor + "-minimap") ? cursor + "-minimap" : cursor;
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -272,10 +272,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 				// The actor layer is updated every tick
 				var stride = radarSheet.Size.Width;
-				var dx = actorSprite.bounds.Left - world.Map.Bounds.Left;
-				var dy = actorSprite.bounds.Top - world.Map.Bounds.Top;
+				var dx = actorSprite.Bounds.Left - world.Map.Bounds.Left;
+				var dy = actorSprite.Bounds.Top - world.Map.Bounds.Top;
 	
-				Array.Clear(radarData, 4 * (actorSprite.bounds.Top * stride + actorSprite.bounds.Left), 4 * actorSprite.bounds.Height * stride);
+				Array.Clear(radarData, 4 * (actorSprite.Bounds.Top * stride + actorSprite.Bounds.Left), 4 * actorSprite.Bounds.Height * stride);
 
 				unsafe
 				{

--- a/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
@@ -99,8 +99,8 @@ namespace OpenRA.Mods.Common.Widgets
 					Game.Renderer.LineRenderer.FillRect(new Rectangle(b.X, (int)float2.Lerp(b.Bottom, b.Top, providedFrac),
 					                                                  b.Width, (int)(providedFrac * b.Height)), color);
 
-				var x = (b.Left + b.Right - indicator.size.X) / 2;
-				var y = float2.Lerp(b.Bottom, b.Top, usedFrac) - indicator.size.Y / 2;
+				var x = (b.Left + b.Right - indicator.Size.X) / 2;
+				var y = float2.Lerp(b.Bottom, b.Top, usedFrac) - indicator.Size.Y / 2;
 				Game.Renderer.RgbaSpriteRenderer.DrawSprite(indicator, new float2(x, y));
 			}
 			else
@@ -127,8 +127,8 @@ namespace OpenRA.Mods.Common.Widgets
 				else
 					Game.Renderer.LineRenderer.FillRect(new Rectangle(b.X, b.Y, (int)(providedFrac * b.Width), b.Height), color);
 
-				var x = float2.Lerp(b.Left, b.Right, usedFrac) - indicator.size.X / 2;
-				var y = (b.Bottom + b.Top - indicator.size.Y) / 2;
+				var x = float2.Lerp(b.Left, b.Right, usedFrac) - indicator.Size.X / 2;
+				var y = (b.Bottom + b.Top - indicator.Size.Y) / 2;
 				Game.Renderer.RgbaSpriteRenderer.DrawSprite(indicator, new float2(x, y));
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -41,8 +41,8 @@ namespace OpenRA.Mods.Common.Widgets
 				if (template == null)
 					return;
 
-				var ts = Game.modData.Manifest.TileSize;
-				var shape = Game.modData.Manifest.TileShape;
+				var ts = Game.ModData.Manifest.TileSize;
+				var shape = Game.ModData.Manifest.TileShape;
 				bounds = worldRenderer.Theater.TemplateBounds(template, ts, shape);
 			}
 		}
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Widgets
 			: base(other)
 		{
 			worldRenderer = other.worldRenderer;
-			tileset = other.worldRenderer.world.Map.Rules.TileSets[other.worldRenderer.world.Map.Tileset];
+			tileset = other.worldRenderer.World.Map.Rules.TileSets[other.worldRenderer.World.Map.Tileset];
 			Template = other.Template;
 			GetScale = other.GetScale;
 		}
@@ -70,8 +70,8 @@ namespace OpenRA.Mods.Common.Widgets
 			if (template == null)
 				return;
 
-			var ts = Game.modData.Manifest.TileSize;
-			var shape = Game.modData.Manifest.TileShape;
+			var ts = Game.ModData.Manifest.TileSize;
+			var shape = Game.ModData.Manifest.TileShape;
 			var scale = GetScale();
 
 			var sb = new Rectangle((int)(scale * bounds.X), (int)(scale * bounds.Y), (int)(scale * bounds.Width), (int)(scale * bounds.Height));
@@ -90,11 +90,11 @@ namespace OpenRA.Mods.Common.Widgets
 						continue;
 
 					var sprite = worldRenderer.Theater.TileSprite(tile);
-					var size = new float2(sprite.size.X * scale, sprite.size.Y * scale);
+					var size = new float2(sprite.Size.X * scale, sprite.Size.Y * scale);
 
 					var u = shape == TileShape.Rectangle ? x : (x - y) / 2f;
 					var v = shape == TileShape.Rectangle ? y : (x + y) / 2f;
-					var pos = origin + scale * (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.size);
+					var pos = origin + scale * (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.Size);
 					Game.Renderer.SpriteRenderer.DrawSprite(sprite, pos, worldRenderer.Palette(Palette), size);
 				}
 			}

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public readonly string WormAttackNotification = "WormAttack";
 
-		public override object Create(ActorInitializer init) { return new AttackSwallow(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackSwallow(init.Self, this); }
 	}
 
 	class AttackSwallow : AttackFrontal

--- a/OpenRA.Mods.D2k/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.D2k/Traits/AutoCarryall.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.D2k.Traits
 	[Desc("Automatically transports harvesters with the Carryable trait between resource fields and refineries")]
 	public class AutoCarryallInfo : ITraitInfo, Requires<IBodyOrientationInfo>
 	{
-		public object Create(ActorInitializer init) { return new AutoCarryall(init.self, this); }
+		public object Create(ActorInitializer init) { return new AutoCarryall(init.Self, this); }
 	}
 
 	public class AutoCarryall : INotifyBecomingIdle, INotifyKilled, ISync, IRender

--- a/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public readonly string[] SafeTerrain = { "Concrete" };
 		public readonly int DamageThreshold = 50;
 
-		public object Create(ActorInitializer init) { return new DamagedWithoutFoundation(init.self, this); }
+		public object Create(ActorInitializer init) { return new DamagedWithoutFoundation(init.Self, this); }
 	}
 
 	class DamagedWithoutFoundation : ITick, ISync, INotifyAddedToWorld

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Offset relative to the actor TopLeft. Not used if the template is PickAny")]
 		public readonly CVec Offset = CVec.Zero;
 
-		public object Create(ActorInitializer init) { return new LaysTerrain(init.self, this); }
+		public object Create(ActorInitializer init) { return new LaysTerrain(init.Self, this); }
 	}
 
 	public class LaysTerrain : INotifyAddedToWorld

--- a/OpenRA.Mods.D2k/Traits/Carryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryable.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Required distance away from destination before requesting a pickup.")]
 		public int MinDistance = 6;
 
-		public object Create(ActorInitializer init) { return new Carryable(init.self, this); }
+		public object Create(ActorInitializer init) { return new Carryable(init.Self, this); }
 	}
 
 	public class Carryable : IDisableMove, INotifyHarvesterAction

--- a/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
@@ -43,9 +43,9 @@ namespace OpenRA.Mods.D2k.Traits
 		{
 			this.info = info;
 
-			renderSprites = init.self.Trait<RenderSprites>();
+			renderSprites = init.Self.Trait<RenderSprites>();
 
-			overlay = new Animation(init.world, renderSprites.GetImage(init.self));
+			overlay = new Animation(init.World, renderSprites.GetImage(init.Self));
 
 			var key = "attack_overlay_{0}".F(info.Sequence);
 			renderSprites.Add(key, new AnimationWithOffset(overlay, null, () => !attacking),

--- a/OpenRA.Mods.D2k/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithBuildingPlacedOverlay(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithBuildingPlacedOverlay(init.Self, this); }
 	}
 
 	public class WithBuildingPlacedOverlay : INotifyBuildComplete, INotifySold, INotifyDamageStateChanged, INotifyBuildingPlaced

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -40,12 +40,12 @@ namespace OpenRA.Mods.D2k.Traits
 				return;
 
 			var key = "make_overlay_{0}".F(info.Sequence);
-			var rs = init.self.Trait<RenderSprites>();
+			var rs = init.Self.Trait<RenderSprites>();
 
-			var overlay = new Animation(init.world, rs.GetImage(init.self));
+			var overlay = new Animation(init.World, rs.GetImage(init.Self));
 
 			// Remove the animation once it is complete
-			overlay.PlayThen(info.Sequence, () => init.world.AddFrameEndTask(w => rs.Remove(key)));
+			overlay.PlayThen(info.Sequence, () => init.World.AddFrameEndTask(w => rs.Remove(key)));
 
 			rs.Add(key, new AnimationWithOffset(overlay, null, () => !buildComplete),
 				info.Palette, info.IsPlayerPalette);

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithDeliveryOverlay(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithDeliveryOverlay(init.Self, this); }
 	}
 
 	public class WithDeliveryOverlay : INotifyBuildComplete, INotifySold, INotifyDelivery

--- a/OpenRA.Mods.D2k/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDockingOverlay.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithDockingOverlay(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithDockingOverlay(init.Self, this); }
 	}
 
 	public class WithDockingOverlay : INotifyDocking, INotifyBuildComplete, INotifySold

--- a/OpenRA.Mods.D2k/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithProductionOverlay.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithProductionOverlay(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithProductionOverlay(init.Self, this); }
 	}
 
 	public class WithProductionOverlay : INotifyDamageStateChanged, ITick, INotifyBuildComplete, INotifySold

--- a/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
+++ b/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.D2k.Traits
 	{
 		public readonly Color BarColor = Color.Orange;
 
-		public object Create(ActorInitializer init) { return new TemporaryOwnerManager(init.self, this); }
+		public object Create(ActorInitializer init) { return new TemporaryOwnerManager(init.Self, this); }
 	}
 
 	public class TemporaryOwnerManager : ISelectionBar, ITick, ISync, INotifyOwnerChanged

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			// Terrain tiles define their origin at the topleft
 			var s = theater.TileSprite(tile);
-			dirty[cell] = new Sprite(s.sheet, s.bounds, float2.Zero, s.channel, s.blendMode);
+			dirty[cell] = new Sprite(s.Sheet, s.Bounds, float2.Zero, s.Channel, s.BlendMode);
 		}
 
 		public void TickRender(WorldRenderer wr, Actor self)
@@ -67,10 +67,10 @@ namespace OpenRA.Mods.D2k.Traits
 				if (!wr.Viewport.VisibleCells.Contains(kv.Key))
 					continue;
 
-				if (wr.world.ShroudObscures(kv.Key))
+				if (wr.World.ShroudObscures(kv.Key))
 					continue;
 
-				new SpriteRenderable(kv.Value, wr.world.Map.CenterOfCell(kv.Key),
+				new SpriteRenderable(kv.Value, wr.World.Map.CenterOfCell(kv.Key),
 					WVec.Zero, -511, pal, 1f, true).Render(wr);
 			}
 		}

--- a/OpenRA.Mods.D2k/Traits/World/ChooseBuildTabOnSelect.cs
+++ b/OpenRA.Mods.D2k/Traits/World/ChooseBuildTabOnSelect.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public ChooseBuildTabOnSelect(ActorInitializer init, ChooseBuildTabOnSelectInfo info)
 		{
-			world = init.world;
+			world = init.World;
 			this.info = info;
 		}
 

--- a/OpenRA.Mods.D2k/Traits/World/WormManager.cs
+++ b/OpenRA.Mods.D2k/Traits/World/WormManager.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public readonly string WormSignature = "sandworm";
 		public readonly string WormOwnerPlayer = "Creeps";
 
-		public object Create(ActorInitializer init) { return new WormManager(this, init.self); }
+		public object Create(ActorInitializer init) { return new WormManager(this, init.Self); }
 	}
 
 	class WormManager : ITick

--- a/OpenRA.Mods.RA/AI/HackyAI.cs
+++ b/OpenRA.Mods.RA/AI/HackyAI.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.RA.AI
 		public HackyAI(HackyAIInfo info, ActorInitializer init)
 		{
 			Info = info;
-			world = init.world;
+			world = init.World;
 			
 			foreach (var decision in info.PowerDecisions)
 				powerDecisions.Add(decision.OrderName, decision);

--- a/OpenRA.Mods.RA/Captures.cs
+++ b/OpenRA.Mods.RA/Captures.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Only used if Sabotage=true. Sabotage damage expressed as a percentage of enemy health removed.")]
 		public readonly float SabotageHPRemoval = 0.5f;
 
-		public object Create(ActorInitializer init) { return new Captures(init.self, this); }
+		public object Create(ActorInitializer init) { return new Captures(init.Self, this); }
 	}
 
 	class Captures : IIssueOrder, IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.RA/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.RA/CombatDebugOverlay.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 	[Desc("Displays fireports, muzzle offsets, and hit areas in developer mode.")]
 	public class CombatDebugOverlayInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new CombatDebugOverlay(init.self); }
+		public object Create(ActorInitializer init) { return new CombatDebugOverlay(init.Self); }
 	}
 
 	public class CombatDebugOverlay : IPostRender, INotifyDamage

--- a/OpenRA.Mods.RA/CrateSpawner.cs
+++ b/OpenRA.Mods.RA/CrateSpawner.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Spawn and remove the plane this far outside the map.")]
 		public readonly WRange Cordon = new WRange(5120);
 
-		public object Create(ActorInitializer init) { return new CrateSpawner(this, init.self); }
+		public object Create(ActorInitializer init) { return new CrateSpawner(this, init.Self); }
 	}
 
 	public class CrateSpawner : ITick

--- a/OpenRA.Mods.RA/Crushable.cs
+++ b/OpenRA.Mods.RA/Crushable.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Will friendly units just crush me instead of pathing around.")]
 		public readonly bool CrushedByFriendlies = false;
 
-		public object Create(ActorInitializer init) { return new Crushable(init.self, this); }
+		public object Create(ActorInitializer init) { return new Crushable(init.Self, this); }
 	}
 
 	class Crushable : ICrushable

--- a/OpenRA.Mods.RA/Disguise.cs
+++ b/OpenRA.Mods.RA/Disguise.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA.Traits
 	[Desc("Overrides the default ToolTip when this actor is disguised (aids in deceiving enemy players).")]
 	class DisguiseToolTipInfo : TooltipInfo, Requires<DisguiseInfo>
 	{
-		public override object Create(ActorInitializer init) { return new DisguiseToolTip(init.self, this); }
+		public override object Create(ActorInitializer init) { return new DisguiseToolTip(init.Self, this); }
 	}
 
 	class DisguiseToolTip : IToolTip

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public object Create(ActorInitializer init)
 		{
-			return new GpsDot(init.self, this);
+			return new GpsDot(init.Self, this);
 		}
 	}
 

--- a/OpenRA.Mods.RA/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.RA/Effects/RepairIndicator.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (building.Destroyed || wr.world.FogObscures(building) || rb.Repairers.Count == 0)
+			if (building.Destroyed || wr.World.FogObscures(building) || rb.Repairers.Count == 0)
 				return SpriteRenderable.None;
 
 			var palette = wr.Palette(palettePrefix + rb.Repairers[shownPlayer % rb.Repairers.Count].InternalName);

--- a/OpenRA.Mods.RA/ExternalCapturable.cs
+++ b/OpenRA.Mods.RA/ExternalCapturable.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Traits
 			return true;
 		}
 
-		public object Create(ActorInitializer init) { return new ExternalCapturable(init.self, this); }
+		public object Create(ActorInitializer init) { return new ExternalCapturable(init.Self, this); }
 	}
 
 	public class ExternalCapturable : ITick

--- a/OpenRA.Mods.RA/ExternalCapturableBar.cs
+++ b/OpenRA.Mods.RA/ExternalCapturableBar.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.RA.Traits
 	[Desc("Visualize the remaining CaptureCompleteTime from ExternalCapturable: trait.")]
 	class ExternalCapturableBarInfo : ITraitInfo, Requires<ExternalCapturableInfo>
 	{
-		public object Create(ActorInitializer init) { return new ExternalCapturableBar(init.self); }
+		public object Create(ActorInitializer init) { return new ExternalCapturableBar(init.Self); }
 	}
 
 	class ExternalCapturableBar : ISelectionBar

--- a/OpenRA.Mods.RA/ExternalCaptures.cs
+++ b/OpenRA.Mods.RA/ExternalCaptures.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Destroy the unit after capturing.")]
 		public readonly bool ConsumeActor = false;
 
-		public object Create(ActorInitializer init) { return new ExternalCaptures(init.self, this); }
+		public object Create(ActorInitializer init) { return new ExternalCaptures(init.Self, this); }
 	}
 
 	class ExternalCaptures : IIssueOrder, IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
@@ -79,8 +79,8 @@ namespace OpenRA.Mods.RA.Graphics
 
 		public IEnumerable<IRenderable> GenerateRenderables(WorldRenderer wr)
 		{
-			var bright = wr.world.Map.SequenceProvider.GetSequence(image, "bright");
-			var dim = wr.world.Map.SequenceProvider.GetSequence(image, "dim");
+			var bright = wr.World.Map.SequenceProvider.GetSequence(image, "bright");
+			var dim = wr.World.Map.SequenceProvider.GetSequence(image, "dim");
 			
 			var source = wr.ScreenPosition(pos);
 			var target = wr.ScreenPosition(pos + length);

--- a/OpenRA.Mods.RA/Lint/CheckMapRules.cs
+++ b/OpenRA.Mods.RA/Lint/CheckMapRules.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA
 		{
 			try
 			{
-				Game.modData.RulesetCache.LoadMapRules(map);
+				Game.ModData.RulesetCache.LoadMapRules(map);
 			}
 			catch (Exception e)
 			{

--- a/OpenRA.Mods.RA/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.RA/Lint/CheckSequences.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			var sequences = MiniYaml.MergeLiberal(map.SequenceDefinitions, Game.modData.Manifest.Sequences.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal));
+			var sequences = MiniYaml.MergeLiberal(map.SequenceDefinitions, Game.ModData.Manifest.Sequences.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal));
 
 			foreach (var actorInfo in map.Rules.Actors)
 				foreach (var renderInfo in actorInfo.Value.Traits.WithInterface<RenderSimpleInfo>())

--- a/OpenRA.Mods.RA/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.RA/Lint/CheckSyncAnnotations.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
 			/* first, check all the types implementing ISync */
-			foreach (var t in Game.modData.ObjectCreator.GetTypesImplementing<ISync>())
+			foreach (var t in Game.ModData.ObjectCreator.GetTypesImplementing<ISync>())
 				if (!HasAnySyncFields(t))
 					emitWarning("{0} has ISync but nothing marked with [Sync]".F(t.Name));
 		}

--- a/OpenRA.Mods.RA/ParaDrop.cs
+++ b/OpenRA.Mods.RA/ParaDrop.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA
 		[Desc("Sound to play when dropping.")]
 		public readonly string ChuteSound = "chute1.aud";
 
-		public object Create(ActorInitializer init) { return new ParaDrop(init.self, this); }
+		public object Create(ActorInitializer init) { return new ParaDrop(init.Self, this); }
 	}
 
 	public class ParaDrop : ITick, INotifyRemovedFromWorld

--- a/OpenRA.Mods.RA/Parachutable.cs
+++ b/OpenRA.Mods.RA/Parachutable.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.RA
 
 		public Parachutable(ActorInitializer init, ParachutableInfo info)
 		{
-			this.self = init.self;
+			this.self = init.Self;
 			this.info = info;
 
 			positionable = self.TraitOrDefault<IPositionable>();

--- a/OpenRA.Mods.RA/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.RA/Player/BaseAttackNotifier.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("The audio notification type to play.")]
 		public string Notification = "BaseAttack";
 
-		public object Create(ActorInitializer init) { return new BaseAttackNotifier(init.self, this); }
+		public object Create(ActorInitializer init) { return new BaseAttackNotifier(init.Self, this); }
 	}
 
 	public class BaseAttackNotifier : INotifyDamage

--- a/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ClassicProductionQueue.cs
@@ -40,9 +40,9 @@ namespace OpenRA.Mods.RA
 		readonly ClassicProductionQueueInfo info;
 
 		public ClassicProductionQueue(ActorInitializer init, ClassicProductionQueueInfo info)
-			: base(init, init.self, info)
+			: base(init, init.Self, info)
 		{
-			this.self = init.self;
+			this.self = init.Self;
 			this.info = info;
 		}
 

--- a/OpenRA.Mods.RA/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.RA/Player/HarvesterAttackNotifier.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("The audio notification type to play.")]
 		public string Notification = "HarvesterAttack";
 
-		public object Create(ActorInitializer init) { return new HarvesterAttackNotifier(init.self, this); }
+		public object Create(ActorInitializer init) { return new HarvesterAttackNotifier(init.Self, this); }
 	}
 
 	public class HarvesterAttackNotifier : INotifyDamage

--- a/OpenRA.Mods.RA/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.RA/Player/ProductionQueue.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string CancelledAudio = "Cancelled";
 
-		public virtual object Create(ActorInitializer init) { return new ProductionQueue(init, init.self.Owner.PlayerActor, this); }
+		public virtual object Create(ActorInitializer init) { return new ProductionQueue(init, init.Self.Owner.PlayerActor, this); }
 	}
 
 	public class ProductionQueue : IResolveOrder, ITick, ITechTreeElement, INotifyOwnerChanged, INotifyKilled, INotifySold, ISync, INotifyTransform
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.RA
 
 		public ProductionQueue(ActorInitializer init, Actor playerActor, ProductionQueueInfo info)
 		{
-			self = init.self;
+			self = init.Self;
 			Info = info;
 			playerResources = playerActor.Trait<PlayerResources>();
 			playerPower = playerActor.Trait<PowerManager>();

--- a/OpenRA.Mods.RA/Production.cs
+++ b/OpenRA.Mods.RA/Production.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("e.g. Infantry, Vehicles, Aircraft, Buildings")]
 		public readonly string[] Produces = { };
 
-		public virtual object Create(ActorInitializer init) { return new Production(this, init.self); }
+		public virtual object Create(ActorInitializer init) { return new Production(this, init.Self); }
 	}
 
 	public class Production

--- a/OpenRA.Mods.RA/ProductionBar.cs
+++ b/OpenRA.Mods.RA/ProductionBar.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA
 
 		public readonly Color Color = Color.SkyBlue;
 
-		public object Create(ActorInitializer init) { return new ProductionBar(init.self, this); }
+		public object Create(ActorInitializer init) { return new ProductionBar(init.Self, this); }
 	}
 
 	class ProductionBar : ISelectionBar, ITick

--- a/OpenRA.Mods.RA/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.RA/ProductionQueueFromSelection.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public string ProductionTabsWidget = null;
 		public string ProductionPaletteWidget = null;
 
-		public object Create(ActorInitializer init) { return new ProductionQueueFromSelection(init.world, this); }
+		public object Create(ActorInitializer init) { return new ProductionQueueFromSelection(init.World, this); }
 	}
 
 	class ProductionQueueFromSelection : INotifySelection

--- a/OpenRA.Mods.RA/ProximityCapturable.cs
+++ b/OpenRA.Mods.RA/ProximityCapturable.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA
 		public readonly bool MustBeClear = false;
 		public readonly string[] CaptorTypes = { "Vehicle", "Tank", "Infantry" };
 
-		public object Create(ActorInitializer init) { return new ProximityCapturable(init.self, this); }
+		public object Create(ActorInitializer init) { return new ProximityCapturable(init.Self, this); }
 	}
 
 	public class ProximityCapturable : ITick

--- a/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingSilo.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Traits
 		public RenderBuildingSilo(ActorInitializer init, RenderBuildingSiloInfo info)
 			: base(init, info)
 		{
-			playerResources = init.self.Owner.PlayerActor.Trait<PlayerResources>();
+			playerResources = init.Self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 
 		public override void BuildingComplete(Actor self)

--- a/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
+++ b/OpenRA.Mods.RA/Render/RenderBuildingWarFactory.cs
@@ -46,11 +46,11 @@ namespace OpenRA.Mods.RA.Traits
 		public RenderBuildingWarFactory(ActorInitializer init, RenderBuildingInfo info)
 			: base(init, info)
 		{
-			roof = new Animation(init.world, GetImage(init.self));
-			var bi = init.self.Info.Traits.Get<BuildingInfo>();
+			roof = new Animation(init.World, GetImage(init.Self));
+			var bi = init.Self.Info.Traits.Get<BuildingInfo>();
 
 			// Additional 512 units move from center -> top of cell
-			var offset = FootprintUtils.CenterOffset(init.world, bi).Y + 512;
+			var offset = FootprintUtils.CenterOffset(init.World, bi).Y + 512;
 			Add("roof", new AnimationWithOffset(roof, null,
 				() => !buildComplete, offset));
 		}

--- a/OpenRA.Mods.RA/Render/RenderDisguise.cs
+++ b/OpenRA.Mods.RA/Render/RenderDisguise.cs
@@ -14,7 +14,7 @@ namespace OpenRA.Mods.RA.Traits
 {
 	class RenderDisguiseInfo : RenderInfantryInfo, Requires<DisguiseInfo>
 	{
-		public override object Create(ActorInitializer init) { return new RenderDisguise(init.self, this); }
+		public override object Create(ActorInitializer init) { return new RenderDisguise(init.Self, this); }
 	}
 
 	class RenderDisguise : RenderInfantry

--- a/OpenRA.Mods.RA/Render/RenderHarvester.cs
+++ b/OpenRA.Mods.RA/Render/RenderHarvester.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Traits
 	class RenderHarvesterInfo : RenderUnitInfo, Requires<HarvesterInfo>
 	{
 		public readonly string[] ImagesByFullness = { "harv" };
-		public override object Create(ActorInitializer init) { return new RenderHarvester(init.self, this); }
+		public override object Create(ActorInitializer init) { return new RenderHarvester(init.Self, this); }
 	}
 
 	class RenderHarvester : RenderUnit, INotifyHarvesterAction

--- a/OpenRA.Mods.RA/Render/RenderInfantry.cs
+++ b/OpenRA.Mods.RA/Render/RenderInfantry.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly string[] IdleAnimations = { };
 		public readonly string[] StandAnimations = { "stand" };
 
-		public override object Create(ActorInitializer init) { return new RenderInfantry(init.self, this); }
+		public override object Create(ActorInitializer init) { return new RenderInfantry(init.Self, this); }
 
 		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
+++ b/OpenRA.Mods.RA/Render/RenderLandingCraft.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly string OpenAnim = "open";
 		public readonly string UnloadAnim = "unload";
 
-		public override object Create(ActorInitializer init) { return new RenderLandingCraft(init.self, this); }
+		public override object Create(ActorInitializer init) { return new RenderLandingCraft(init.Self, this); }
 	}
 
 	public class RenderLandingCraft : RenderUnit

--- a/OpenRA.Mods.RA/Render/RenderUnitReload.cs
+++ b/OpenRA.Mods.RA/Render/RenderUnitReload.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";
 
-		public override object Create(ActorInitializer init) { return new RenderUnitReload(init.self, this); }
+		public override object Create(ActorInitializer init) { return new RenderUnitReload(init.Self, this); }
 	}
 
 	class RenderUnitReload : RenderUnit

--- a/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithActiveAnimation.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly bool PauseOnLowPower = false;
 
-		public object Create(ActorInitializer init) { return new WithActiveAnimation(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithActiveAnimation(init.Self, this); }
 	}
 
 	public class WithActiveAnimation : ITick, INotifyBuildComplete, INotifySold

--- a/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithIdleOverlay.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly bool PauseOnLowPower = false;
 
-		public object Create(ActorInitializer init) { return new WithIdleOverlay(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithIdleOverlay(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.RA/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.RA/Render/WithRepairAnimation.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly bool PauseOnLowPower = false;
 
-		public object Create(ActorInitializer init) { return new WithRepairAnimation(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithRepairAnimation(init.Self, this); }
 	}
 
 	public class WithRepairAnimation : INotifyRepair

--- a/OpenRA.Mods.RA/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.RA/Render/WithRepairOverlay.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly bool PauseOnLowPower = false;
 
-		public object Create(ActorInitializer init) { return new WithRepairOverlay(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithRepairOverlay(init.Self, this); }
 	}
 
 	public class WithRepairOverlay : INotifyDamageStateChanged, INotifyBuildComplete, INotifySold, INotifyRepair

--- a/OpenRA.Mods.RA/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.RA/RenderDetectionCircle.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Traits
 {
 	class RenderDetectionCircleInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new RenderDetectionCircle(init.self); }
+		public object Create(ActorInitializer init) { return new RenderDetectionCircle(init.Self); }
 	}
 
 	class RenderDetectionCircle : IPostRenderSelection

--- a/OpenRA.Mods.RA/RenderJammerCircle.cs
+++ b/OpenRA.Mods.RA/RenderJammerCircle.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Traits
 						yield return r;
 		}
 
-		public object Create(ActorInitializer init) { return new RenderJammerCircle(init.self); }
+		public object Create(ActorInitializer init) { return new RenderJammerCircle(init.Self); }
 	}
 
 	class RenderJammerCircle : IPostRenderSelection

--- a/OpenRA.Mods.RA/RenderRangeCircle.cs
+++ b/OpenRA.Mods.RA/RenderRangeCircle.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.RA.Traits
 							yield return r;
 		}
 
-		public object Create(ActorInitializer init) { return new RenderRangeCircle(init.self); }
+		public object Create(ActorInitializer init) { return new RenderRangeCircle(init.Self); }
 	}
 
 	class RenderRangeCircle : IPostRenderSelection

--- a/OpenRA.Mods.RA/RenderShroudCircle.cs
+++ b/OpenRA.Mods.RA/RenderShroudCircle.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Traits
 						yield return r;
 		}
 
-		public object Create(ActorInitializer init) { return new RenderShroudCircle(init.self); }
+		public object Create(ActorInitializer init) { return new RenderShroudCircle(init.Self); }
 	}
 
 	class RenderShroudCircle : IPostRenderSelection

--- a/OpenRA.Mods.RA/Repairable.cs
+++ b/OpenRA.Mods.RA/Repairable.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA.Traits
 	class RepairableInfo : ITraitInfo, Requires<HealthInfo>
 	{
 		public readonly string[] RepairBuildings = { "fix" };
-		public virtual object Create(ActorInitializer init) { return new Repairable(init.self); }
+		public virtual object Create(ActorInitializer init) { return new Repairable(init.Self); }
 	}
 
 	class Repairable : IIssueOrder, IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.RA/RepairableNear.cs
+++ b/OpenRA.Mods.RA/RepairableNear.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.Traits
 		[ActorReference] public readonly string[] Buildings = { "spen", "syrd" };
 		public readonly int CloseEnough = 4;	/* cells */
 
-		public object Create(ActorInitializer init) { return new RepairableNear(init.self, this); }
+		public object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
 	}
 
 	class RepairableNear : IIssueOrder, IResolveOrder

--- a/OpenRA.Mods.RA/ScaredyCat.cs
+++ b/OpenRA.Mods.RA/ScaredyCat.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Chance (out of 100) the unit has to enter panic mode when attacked.")]
 		public readonly int AttackPanicChance = 20;
 
-		public object Create(ActorInitializer init) { return new ScaredyCat(init.self, this); }
+		public object Create(ActorInitializer init) { return new ScaredyCat(init.Self, this); }
 	}
 
 	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync, IRenderInfantrySequenceModifier

--- a/OpenRA.Mods.RA/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.RA/Scripting/Global/ReinforcementsGlobal.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Scripting
 		Actor CreateActor(Player owner, string actorType, bool addToWorld, CPos? entryLocation = null, CPos? nextLocation = null)
 		{
 			ActorInfo ai;
-			if (!context.World.Map.Rules.Actors.TryGetValue(actorType, out ai))
+			if (!Context.World.Map.Rules.Actors.TryGetValue(actorType, out ai))
 				throw new LuaException("Unknown actor type '{0}'".F(actorType));
 
 			var initDict = new TypeDictionary();
@@ -48,9 +48,9 @@ namespace OpenRA.Mods.RA.Scripting
 			}
 
 			if (entryLocation.HasValue && nextLocation.HasValue)
-				initDict.Add(new FacingInit(context.World.Map.FacingBetween(CPos.Zero, CPos.Zero + (nextLocation.Value - entryLocation.Value), 0)));
+				initDict.Add(new FacingInit(Context.World.Map.FacingBetween(CPos.Zero, CPos.Zero + (nextLocation.Value - entryLocation.Value), 0)));
 
-			var actor = context.World.CreateActor(addToWorld, actorType, initDict);
+			var actor = Context.World.CreateActor(addToWorld, actorType, initDict);
 
 			return actor;
 		}
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.RA.Scripting
 				var actionDelay = i * interval;
 				Action actorAction = () =>
 				{
-					context.World.Add(actor);
+					Context.World.Add(actor);
 					for (var j = 1; j < entryPath.Length; j++)
 						Move(actor, entryPath[j]);
 
@@ -89,13 +89,13 @@ namespace OpenRA.Mods.RA.Scripting
 					{
 					    actor.QueueActivity(new CallFunc(() =>
 						{
-							af.Call(actor.ToLuaValue(context));
+							af.Call(actor.ToLuaValue(Context));
 							af.Dispose();
 						}));
 					}
 				};
 
-				context.World.AddFrameEndTask(w => w.Add(new DelayedAction(actionDelay, actorAction)));
+				Context.World.AddFrameEndTask(w => w.Add(new DelayedAction(actionDelay, actorAction)));
 			}
 
 			return actors.ToArray();
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.RA.Scripting
 				var af = actionFunc.CopyReference() as LuaFunction;
 				transport.QueueActivity(new CallFunc(() =>
 				{
-					af.Call(transport.ToLuaValue(context), passengers.ToArray().ToLuaValue(context));
+					af.Call(transport.ToLuaValue(Context), passengers.ToArray().ToLuaValue(Context));
 					af.Dispose();
 				}));
 			}
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.RA.Scripting
 				var ef = exitFunc.CopyReference() as LuaFunction;
 				transport.QueueActivity(new CallFunc(() =>
 				{
-					ef.Call(transport.ToLuaValue(context));
+					ef.Call(transport.ToLuaValue(Context));
 					ef.Dispose();
 				}));
 			}
@@ -174,9 +174,9 @@ namespace OpenRA.Mods.RA.Scripting
 				transport.QueueActivity(new RemoveSelf());
 			}
 
-			var ret = context.CreateTable();
-			ret.Add(1, transport.ToLuaValue(context));
-			ret.Add(2, passengers.ToArray().ToLuaValue(context));
+			var ret = Context.CreateTable();
+			ret.Add(1, transport.ToLuaValue(Context));
+			ret.Add(2, passengers.ToArray().ToLuaValue(Context));
 			return ret;
 		}
 	}

--- a/OpenRA.Mods.RA/Scripting/Properties/ChronosphereProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ChronosphereProperties.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Scripting
 
 				var cs = actor.TraitOrDefault<Chronoshiftable>();
 				if (cs != null && cs.CanChronoshiftTo(actor, cell))
-					cs.Teleport(actor, cell, duration, killCargo, self);
+					cs.Teleport(actor, cell, duration, killCargo, Self);
 			}
 		}
 	}

--- a/OpenRA.Mods.RA/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/CombatProperties.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Seek out and attack nearby targets.")]
 		public void Hunt()
 		{
-			self.QueueActivity(new Hunt(self));
+			Self.QueueActivity(new Hunt(Self));
 		}
 
 		[ScriptActorPropertyActivity]
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Scripting
 			"close enough to complete the activity.")]
 		public void AttackMove(CPos cell, int closeEnough = 0)
 		{
-			self.QueueActivity(new AttackMoveActivity(self, move.MoveTo(cell, closeEnough)));
+			Self.QueueActivity(new AttackMoveActivity(Self, move.MoveTo(cell, closeEnough)));
 		}
 
 		[ScriptActorPropertyActivity]
@@ -54,12 +54,12 @@ namespace OpenRA.Mods.RA.Scripting
 		{
 			foreach (var wpt in waypoints)
 			{
-				self.QueueActivity(new AttackMoveActivity(self, move.MoveTo(wpt, 2)));
-				self.QueueActivity(new Wait(wait));
+				Self.QueueActivity(new AttackMoveActivity(Self, move.MoveTo(wpt, 2)));
+				Self.QueueActivity(new Wait(wait));
 			}
 
 			if (loop)
-				self.QueueActivity(new CallFunc(() => Patrol(waypoints, loop, wait)));
+				Self.QueueActivity(new CallFunc(() => Patrol(waypoints, loop, wait)));
 		}
 
 		[ScriptActorPropertyActivity]
@@ -69,10 +69,10 @@ namespace OpenRA.Mods.RA.Scripting
 		{
 			Patrol(waypoints, false, wait);
 
-			var repeat = func.Call(self.ToLuaValue(context)).First().ToBoolean();
+			var repeat = func.Call(Self.ToLuaValue(Context)).First().ToBoolean();
 			if (repeat)
 				using (var f = func.CopyReference() as LuaFunction)
-					self.QueueActivity(new CallFunc(() => PatrolUntil(waypoints, f, wait)));
+					Self.QueueActivity(new CallFunc(() => PatrolUntil(waypoints, f, wait)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/GeneralProperties.cs
@@ -32,46 +32,46 @@ namespace OpenRA.Mods.RA.Scripting
 		{
 			get
 			{
-				return self.IsInWorld;
+				return Self.IsInWorld;
 			}
 
 			set
 			{
 				if (value)
-					self.World.AddFrameEndTask(w => w.Add(self));
+					Self.World.AddFrameEndTask(w => w.Add(Self));
 				else
-					self.World.AddFrameEndTask(w => w.Remove(self));
+					Self.World.AddFrameEndTask(w => w.Remove(Self));
 			}
 		}
 
 		[Desc("Specifies whether the actor is alive or dead.")]
-		public bool IsDead { get { return self.IsDead; } }
+		public bool IsDead { get { return Self.IsDead; } }
 
 		[Desc("Specifies whether the actor is idle (not performing any activities).")]
-		public bool IsIdle { get { return self.IsIdle; } }
+		public bool IsIdle { get { return Self.IsIdle; } }
 
 		[Desc("The player that owns the actor.")]
 		public Player Owner
 		{
 			get
 			{
-				return self.Owner;
+				return Self.Owner;
 			}
 
 			set
 			{
-				if (self.Owner != value)
-					self.ChangeOwner(value);
+				if (Self.Owner != value)
+					Self.ChangeOwner(value);
 			}
 		}
 
 		[Desc("The type of the actor (e.g. \"e1\").")]
-		public string Type { get { return self.Info.Name; } }
+		public string Type { get { return Self.Info.Name; } }
 
 		[Desc("Test whether an actor has a specific property.")]
 		public bool HasProperty(string name)
 		{
-			return self.HasScriptProperty(name);
+			return Self.HasScriptProperty(name);
 		}
 	}
 
@@ -89,10 +89,10 @@ namespace OpenRA.Mods.RA.Scripting
 		}
 
 		[Desc("The actor position in cell coordinates.")]
-		public CPos Location { get { return self.Location; } }
+		public CPos Location { get { return Self.Location; } }
 
 		[Desc("The actor position in world coordinates.")]
-		public WPos CenterPosition { get { return self.CenterPosition; } }
+		public WPos CenterPosition { get { return Self.CenterPosition; } }
 
 		[Desc("The direction that the actor is facing.")]
 		public int Facing
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.RA.Scripting
 			get
 			{
 				if (facing == null)
-					throw new LuaException("Actor '{0}' doesn't define a facing".F(self));
+					throw new LuaException("Actor '{0}' doesn't define a facing".F(Self));
 
 				return facing.Facing;
 			}
@@ -110,34 +110,34 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Instantly moves the actor to the specified cell.")]
 		public void Teleport(CPos cell)
 		{
-			self.QueueActivity(new SimpleTeleport(cell));
+			Self.QueueActivity(new SimpleTeleport(cell));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Run an arbitrary Lua function.")]
 		public void CallFunc(LuaFunction func)
 		{
-			self.QueueActivity(new CallLuaFunc(func, context));
+			Self.QueueActivity(new CallLuaFunc(func, Context));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Wait for a specified number of game ticks (25 ticks = 1 second).")]
 		public void Wait(int ticks)
 		{
-			self.QueueActivity(new Wait(ticks));
+			Self.QueueActivity(new Wait(ticks));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Remove the actor from the game, without triggering any death notification.")]
 		public void Destroy()
 		{
-			self.QueueActivity(new RemoveSelf());
+			Self.QueueActivity(new RemoveSelf());
 		}
 
 		[Desc("Attempt to cancel any active activities.")]
 		public void Stop()
 		{
-			self.CancelActivity();
+			Self.CancelActivity();
 		}
 
 		[Desc("Current actor stance. Returns nil if this actor doesn't support stances.")]

--- a/OpenRA.Mods.RA/Scripting/Properties/GuardProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/GuardProperties.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Scripting
 		public void Guard(Actor targetActor)
 		{
 			if (targetActor.HasTrait<Guardable>())
-				guard.GuardTarget(self, Target.FromActor(targetActor));
+				guard.GuardTarget(Self, Target.FromActor(targetActor));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/HarvesterProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/HarvesterProperties.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Search for nearby resources and begin harvesting.")]
 		public void FindResources()
 		{
-			harvester.ContinueHarvesting(self);
+			harvester.ContinueHarvesting(Self);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/HelicopterProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/HelicopterProperties.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Fly within the cell grid.")]
 		public void Move(CPos cell)
 		{
-			self.QueueActivity(new HeliFly(self, Target.FromCell(self.World, cell)));
+			Self.QueueActivity(new HeliFly(Self, Target.FromCell(Self.World, cell)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/MissionObjectiveProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/MissionObjectiveProperties.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Scripting
 			"ID of the newly created objective, so that it can be referred to later.")]
 		public int AddPrimaryObjective(string description)
 		{
-			return mo.Add(player, description, ObjectiveType.Primary);
+			return mo.Add(Player, description, ObjectiveType.Primary);
 		}
 
 		[ScriptActorPropertyActivity]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Scripting
 			"ID of the newly created objective, so that it can be referred to later.")]
 		public int AddSecondaryObjective(string description)
 		{
-			return mo.Add(player, description, ObjectiveType.Secondary);
+			return mo.Add(Player, description, ObjectiveType.Secondary);
 		}
 
 		[ScriptActorPropertyActivity]
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.RA.Scripting
 			if (id < 0 || id >= mo.Objectives.Count)
 				throw new LuaException("Objective ID is out of range.");
 
-			mo.MarkCompleted(player, id);
+			mo.MarkCompleted(Player, id);
 		}
 
 		[ScriptActorPropertyActivity]
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.RA.Scripting
 			if (id < 0 || id >= mo.Objectives.Count)
 				throw new LuaException("Objective ID is out of range.");
 
-			mo.MarkFailed(player, id);
+			mo.MarkFailed(Player, id);
 		}
 
 		[ScriptActorPropertyActivity]
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.RA.Scripting
 			"the MustBeDestroyed trait (according to the short game option).")]
 		public bool HasNoRequiredUnits()
 		{
-			return player.HasNoRequiredUnits();
+			return Player.HasNoRequiredUnits();
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/MobileProperties.cs
@@ -33,28 +33,28 @@ namespace OpenRA.Mods.RA.Scripting
 			"(in cells) that will be considered close enough to complete the activity.")]
 		public void Move(CPos cell, int closeEnough = 0)
 		{
-			self.QueueActivity(new Move(self, cell, WRange.FromCells(closeEnough)));
+			Self.QueueActivity(new Move(Self, cell, WRange.FromCells(closeEnough)));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Moves within the cell grid, ignoring lane biases.")]
 		public void ScriptedMove(CPos cell)
 		{
-			self.QueueActivity(new Move(self, cell));
+			Self.QueueActivity(new Move(Self, cell));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Moves from outside the world into the cell grid")]
 		public void MoveIntoWorld(CPos cell)
 		{
-			self.QueueActivity(mobile.MoveIntoWorld(self, cell, mobile.ToSubCell));
+			Self.QueueActivity(mobile.MoveIntoWorld(Self, cell, mobile.ToSubCell));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Leave the current position in a random direction.")]
 		public void Scatter()
 		{
-			self.Trait<Mobile>().Nudge(self, self, true);
+			Self.Trait<Mobile>().Nudge(Self, Self, true);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/PlaneProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/PlaneProperties.cs
@@ -26,14 +26,14 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Fly within the cell grid.")]
 		public void Move(CPos cell)
 		{
-			self.QueueActivity(new Fly(self, Target.FromCell(self.World, cell)));
+			Self.QueueActivity(new Fly(Self, Target.FromCell(Self.World, cell)));
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Return to the base, which is either the airfield given, or an auto-selected one otherwise.")]
 		public void ReturnToBase(Actor airfield = null)
 		{
-			self.QueueActivity(new ReturnToBase(self, airfield));
+			Self.QueueActivity(new ReturnToBase(Self, airfield));
 		}
 	}
 
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Fly an attack against the target actor.")]
 		public void Attack(Actor target)
 		{
-			self.QueueActivity(new FlyAttack(Target.FromActor(target)));
+			Self.QueueActivity(new FlyAttack(Target.FromActor(target)));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/PlayerProperties.cs
@@ -24,13 +24,13 @@ namespace OpenRA.Mods.RA.Scripting
 		: base(context, player) { }
 
 		[Desc("The player's name.")]
-		public string Name { get { return player.PlayerName; } }
+		public string Name { get { return Player.PlayerName; } }
 
 		[Desc("Returns an array of actors representing all ground attack units of this player.")]
 		public Actor[] GetGroundAttackers()
 		{
-			return player.World.ActorsWithTrait<AttackBase>().Select(a => a.Actor)
-				.Where(a => a.Owner == player && !a.IsDead && a.IsInWorld && a.HasTrait<Mobile>())
+			return Player.World.ActorsWithTrait<AttackBase>().Select(a => a.Actor)
+				.Where(a => a.Owner == Player && !a.IsDead && a.IsInWorld && a.HasTrait<Mobile>())
 				.ToArray();
 		}
 	}

--- a/OpenRA.Mods.RA/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ProductionProperties.cs
@@ -37,10 +37,10 @@ namespace OpenRA.Mods.RA.Scripting
 		public void Produce(string actorType, string raceVariant = null)
 		{
 			ActorInfo actorInfo;
-			if (!self.World.Map.Rules.Actors.TryGetValue(actorType, out actorInfo))
+			if (!Self.World.Map.Rules.Actors.TryGetValue(actorType, out actorInfo))
 				throw new LuaException("Unknown actor type '{0}'".F(actorType));
 
-			self.QueueActivity(new WaitFor(() => p.Produce(self, actorInfo, raceVariant)));
+			Self.QueueActivity(new WaitFor(() => p.Produce(Self, actorInfo, raceVariant)));
 		}
 	}
 
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.RA.Scripting
 		public bool IsPrimaryBuilding
 		{
 			get { return pb.IsPrimary; }
-			set { pb.SetPrimaryProducer(self, value); }
+			set { pb.SetPrimaryProducer(Self, value); }
 		}
 	}
 
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.RA.Scripting
 
 			if (actionFunc != null)
 			{
-				var playerIndex = self.Owner.ClientIndex;
+				var playerIndex = Self.Owner.ClientIndex;
 				var squadSize = actorTypes.Length;
 				var squad = new List<Actor>();
 				var func = actionFunc.CopyReference() as LuaFunction;
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.RA.Scripting
 					if (squad.Count >= squadSize)
 					{
 						using (func)
-						using (var luaSquad = squad.Where(u => !u.IsDead).ToArray().ToLuaValue(context))
+						using (var luaSquad = squad.Where(u => !u.IsDead).ToArray().ToLuaValue(Context))
 							func.Call(luaSquad).Dispose();
 
 						triggers.OnProducedInternal -= productionHandler;
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.RA.Scripting
 			}
 
 			foreach (var actorType in actorTypes)
-				queue.ResolveOrder(self, Order.StartProduction(self, actorType, 1));
+				queue.ResolveOrder(Self, Order.StartProduction(Self, actorType, 1));
 
 			return true;
 		}
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.RA.Scripting
 
 		BuildableInfo GetBuildableInfo(string actorType)
 		{
-			var ri = self.World.Map.Rules.Actors[actorType];
+			var ri = Self.World.Map.Rules.Actors[actorType];
 			var bi = ri.Traits.GetOrDefault<BuildableInfo>();
 
 			if (bi == null)
@@ -232,7 +232,7 @@ namespace OpenRA.Mods.RA.Scripting
 					if (squad.Count >= squadSize)
 					{
 						using (func)
-						using (var luaSquad = squad.Where(u => !u.IsDead).ToArray().ToLuaValue(context))
+						using (var luaSquad = squad.Where(u => !u.IsDead).ToArray().ToLuaValue(Context))
 							func.Call(luaSquad).Dispose();
 
 						foreach (var q in queueTypes)
@@ -267,7 +267,7 @@ namespace OpenRA.Mods.RA.Scripting
 
 		BuildableInfo GetBuildableInfo(string actorType)
 		{
-			var ri = player.World.Map.Rules.Actors[actorType];
+			var ri = Player.World.Map.Rules.Actors[actorType];
 			var bi = ri.Traits.GetOrDefault<BuildableInfo>();
 
 			if (bi == null)

--- a/OpenRA.Mods.RA/Scripting/Properties/RepairableBuildingProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/RepairableBuildingProperties.cs
@@ -28,19 +28,19 @@ namespace OpenRA.Mods.RA.Scripting
 		[Desc("Start repairs on this building. `repairer` can be an allied player.")]
 		public void StartBuildingRepairs(Player repairer = null)
 		{
-			repairer = repairer ?? self.Owner;
+			repairer = repairer ?? Self.Owner;
 
 			if (!rb.Repairers.Contains(repairer))
-				rb.RepairBuilding(self, repairer);
+				rb.RepairBuilding(Self, repairer);
 		}
 
 		[Desc("Stop repairs on this building. `repairer` can be an allied player.")]
 		public void StopBuildingRepairs(Player repairer = null)
 		{
-			repairer = repairer ?? self.Owner;
+			repairer = repairer ?? Self.Owner;
 
 			if (rb.RepairActive && rb.Repairers.Contains(repairer))
-				rb.RepairBuilding(self, repairer);
+				rb.RepairBuilding(Self, repairer);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/TransportProperties.cs
@@ -31,16 +31,16 @@ namespace OpenRA.Mods.RA.Scripting
 		public bool HasPassengers { get { return cargo.Passengers.Any(); } }
 
 		[Desc("Teleport an existing actor inside this transport.")]
-		public void LoadPassenger(Actor a) { cargo.Load(self, a); }
+		public void LoadPassenger(Actor a) { cargo.Load(Self, a); }
 
 		[Desc("Remove the first actor from the transport.  This actor is not added to the world.")]
-		public Actor UnloadPassenger() { return cargo.Unload(self); }
+		public Actor UnloadPassenger() { return cargo.Unload(Self); }
 
 		[ScriptActorPropertyActivity]
 		[Desc("Command transport to unload passengers.")]
 		public void UnloadPassengers()
 		{
-			self.QueueActivity(new UnloadCargo(self, true));
+			Self.QueueActivity(new UnloadCargo(Self, true));
 		}
 	}
 
@@ -60,9 +60,9 @@ namespace OpenRA.Mods.RA.Scripting
 		public void Paradrop(CPos cell)
 		{
 			paradrop.SetLZ(cell, true);
-			self.QueueActivity(new Fly(self, Target.FromCell(self.World, cell)));
-			self.QueueActivity(new FlyOffMap());
-			self.QueueActivity(new RemoveSelf());
+			Self.QueueActivity(new Fly(Self, Target.FromCell(Self.World, cell)));
+			Self.QueueActivity(new FlyOffMap());
+			Self.QueueActivity(new RemoveSelf());
 		}
 	}
 }

--- a/OpenRA.Mods.RA/SelfHealing.cs
+++ b/OpenRA.Mods.RA/SelfHealing.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA
 		public readonly float HealIfBelow = .5f;
 		public readonly int DamageCooldown = 0;
 
-		public virtual object Create(ActorInitializer init) { return new SelfHealing(init.self, this); }
+		public virtual object Create(ActorInitializer init) { return new SelfHealing(init.Self, this); }
 	}
 
 	class SelfHealing : UpgradableTrait<SelfHealingInfo>, ITick, INotifyDamage

--- a/OpenRA.Mods.RA/StoresResources.cs
+++ b/OpenRA.Mods.RA/StoresResources.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA
 		public readonly int PipCount = 0;
 		public readonly PipType PipColor = PipType.Yellow;
 		public readonly int Capacity = 0;
-		public object Create(ActorInitializer init) { return new StoresResources(init.self, this); }
+		public object Create(ActorInitializer init) { return new StoresResources(init.Self, this); }
 	}
 
 	class StoresResources : IPips, INotifyOwnerChanged, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreResources, ISync

--- a/OpenRA.Mods.RA/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/AirstrikePower.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Weapon range offset to apply during the beacon clock calculation")]
 		public readonly WRange BeaconDistanceOffset = WRange.FromCells(6);
 
-		public override object Create(ActorInitializer init) { return new AirstrikePower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AirstrikePower(init.Self, this); }
 	}
 
 	class AirstrikePower : SupportPower

--- a/OpenRA.Mods.RA/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/GrantUpgradePower.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly int Range = 1;
 		public readonly string GrantUpgradeSound = "ironcur9.aud";
 
-		public override object Create(ActorInitializer init) { return new GrantUpgradePower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new GrantUpgradePower(init.Self, this); }
 	}
 
 	class GrantUpgradePower : SupportPower
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.RA.Traits
 				var pal = wr.Palette("terrain");
 
 				foreach (var t in world.Map.FindTilesInCircle(xy, range))
-					yield return new SpriteRenderable(tile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 			}
 
 			public string GetCursor(World world, CPos xy, MouseInput mi)

--- a/OpenRA.Mods.RA/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/NukePower.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Amount of time after detonation to remove the camera")]
 		public readonly int CameraRemoveDelay = 25;
 
-		public override object Create(ActorInitializer init) { return new NukePower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new NukePower(init.Self, this); }
 	}
 
 	class NukePower : SupportPower

--- a/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/ParatroopersPower.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Weapon range offset to apply during the beacon clock calculation.")]
 		public readonly WRange BeaconDistanceOffset = WRange.FromCells(4);
 
-		public override object Create(ActorInitializer init) { return new ParatroopersPower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new ParatroopersPower(init.Self, this); }
 	}
 
 	public class ParatroopersPower : SupportPower

--- a/OpenRA.Mods.RA/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SpawnActorPower.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly string EffectSequence = null;
 		public readonly string EffectPalette = null;
 
-		public override object Create(ActorInitializer init) { return new SpawnActorPower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new SpawnActorPower(init.Self, this); }
 	}
 
 	public class SpawnActorPower : SupportPower

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerChargeBar.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		public readonly Color Color = Color.Magenta;
 
-		public object Create(ActorInitializer init) { return new SupportPowerChargeBar(init.self, this); }
+		public object Create(ActorInitializer init) { return new SupportPowerChargeBar(init.Self, this); }
 	}
 
 	class SupportPowerChargeBar : ISelectionBar

--- a/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.RA/SupportPowers/SupportPowerManager.cs
@@ -34,13 +34,13 @@ namespace OpenRA.Mods.RA.Traits
 
 		public SupportPowerManager(ActorInitializer init)
 		{
-			self = init.self;
+			self = init.Self;
 			DevMode = self.Trait<DeveloperMode>();
 			TechTree = self.Trait<TechTree>();
-			RadarPings = Exts.Lazy(() => init.world.WorldActor.TraitOrDefault<RadarPings>());
+			RadarPings = Exts.Lazy(() => init.World.WorldActor.TraitOrDefault<RadarPings>());
 
-			init.world.ActorAdded += ActorAdded;
-			init.world.ActorRemoved += ActorRemoved;
+			init.World.ActorAdded += ActorAdded;
+			init.World.ActorRemoved += ActorRemoved;
 		}
 
 		static string MakeKey(SupportPower sp)

--- a/OpenRA.Mods.RA/ThrowsParticle.cs
+++ b/OpenRA.Mods.RA/ThrowsParticle.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public ThrowsParticle(ActorInitializer init, ThrowsParticleInfo info)
 		{
-			var self = init.self;
+			var self = init.Self;
 			var rs = self.Trait<RenderSimple>();
 			var body = self.Trait<IBodyOrientation>();
 
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.RA.Traits
 			// Facing rotation
 			rotation = WRange.FromPDF(Game.CosmeticRandom, 2).Range * info.ROT / 1024;
 
-			var anim = new Animation(init.world, rs.GetImage(self), () => (int)facing);
+			var anim = new Animation(init.World, rs.GetImage(self), () => (int)facing);
 			anim.PlayRepeating(info.Anim);
 			rs.Add(info.Anim, new AnimationWithOffset(anim, () => pos, null));
 		}

--- a/OpenRA.Mods.RA/Traits/Air/TargetableAircraft.cs
+++ b/OpenRA.Mods.RA/Traits/Air/TargetableAircraft.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA.Traits
 	public class TargetableAircraftInfo : TargetableUnitInfo
 	{
 		public readonly string[] GroundedTargetTypes = { };
-		public override object Create(ActorInitializer init) { return new TargetableAircraft(init.self, this); }
+		public override object Create(ActorInitializer init) { return new TargetableAircraft(init.Self, this); }
 	}
 
 	public class TargetableAircraft : TargetableUnit

--- a/OpenRA.Mods.RA/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.RA/Traits/Attack/AttackGarrisoned.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly string MuzzlePalette = "effect";
 
-		public override object Create(ActorInitializer init) { return new AttackGarrisoned(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackGarrisoned(init.Self, this); }
 	}
 
 	public class AttackGarrisoned : AttackFollow, INotifyPassengerEntered, INotifyPassengerExited, IRender

--- a/OpenRA.Mods.RA/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.RA/Traits/Attack/AttackLeap.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly WRange Speed = new WRange(426);
 		public readonly WAngle Angle = WAngle.FromDegrees(20);
 
-		public override object Create(ActorInitializer init) { return new AttackLeap(init.self, this); }
+		public override object Create(ActorInitializer init) { return new AttackLeap(init.Self, this); }
 	}
 
 	class AttackLeap : AttackFrontal, ISync

--- a/OpenRA.Mods.RA/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/Bridge.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("The name of the weapon to use when demolishing the bridge")]
 		public readonly string DemolishWeapon = "Demolish";
 
-		public object Create(ActorInitializer init) { return new Bridge(init.self, this); }
+		public object Create(ActorInitializer init) { return new Bridge(init.Self, this); }
 
 		public IEnumerable<Pair<ushort, float>> Templates
 		{
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.RA.Traits
 
 			return footprint.Select(c => (IRenderable)(new SpriteRenderable(
 				wr.Theater.TileSprite(new TerrainTile(template, c.Value)),
-				wr.world.Map.CenterOfCell(c.Key), WVec.Zero, -offset, palette, 1f, true))).ToArray();
+				wr.World.Map.CenterOfCell(c.Key), WVec.Zero, -offset, palette, 1f, true))).ToArray();
 		}
 
 		bool initialized;

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Uses the \"Cloneable\" trait to determine whether or not we should clone a produced unit.")]
 		public readonly string[] CloneableTypes = { };
 
-		public object Create(ActorInitializer init) { return new ClonesProducedUnits(init.self, this); }
+		public object Create(ActorInitializer init) { return new ClonesProducedUnits(init.Self, this); }
 	}
 
 	public class ClonesProducedUnits : INotifyOtherProduction

--- a/OpenRA.Mods.RA/Traits/Buildings/OreRefinery.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/OreRefinery.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Actually harvester facing when docking, 0-255 counter-clock-wise.")]
 		public readonly int DockAngle = 64;
 
-		public virtual object Create(ActorInitializer init) { return new OreRefinery(init.self, this); }
+		public virtual object Create(ActorInitializer init) { return new OreRefinery(init.Self, this); }
 	}
 
 	public class OreRefinery : ITick, IAcceptOre, INotifyKilled, INotifySold, INotifyCapture, INotifyOwnerChanged, IExplodeModifier, ISync

--- a/OpenRA.Mods.RA/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/RepairableBuilding.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly string IndicatorPalettePrefix = "player";
 
-		public object Create(ActorInitializer init) { return new RepairableBuilding(init.self, this); }
+		public object Create(ActorInitializer init) { return new RepairableBuilding(init.Self, this); }
 	}
 
 	public class RepairableBuilding : UpgradableTrait<RepairableBuildingInfo>, ITick

--- a/OpenRA.Mods.RA/Traits/Buildings/TargetableBuilding.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/TargetableBuilding.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public bool RequiresForceFire = false;
 
-		public object Create(ActorInitializer init) { return new TargetableBuilding(init.self, this); }
+		public object Create(ActorInitializer init) { return new TargetableBuilding(init.Self, this); }
 	}
 
 	public class TargetableBuilding : ITargetable

--- a/OpenRA.Mods.RA/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/Crate.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public Crate(ActorInitializer init, CrateInfo info)
 		{
-			this.self = init.self;
+			this.self = init.Self;
 			this.info = info;
 
 			if (init.Contains<LocationInit>())

--- a/OpenRA.Mods.RA/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/CrateAction.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Actor types that this crate action will not occur for.")]
 		[ActorReference] public string[] ExcludedActorTypes = { };
 
-		public virtual object Create(ActorInitializer init) { return new CrateAction(init.self, this); }
+		public virtual object Create(ActorInitializer init) { return new CrateAction(init.Self, this); }
 	}
 
 	public class CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Is the new duplicates given to a specific owner, regardless of whom collected it?")]
 		public readonly string Owner = null;
 
-		public override object Create(ActorInitializer init) { return new DuplicateUnitCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new DuplicateUnitCrateAction(init.Self, this); }
 	}
 
 	class DuplicateUnitCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/ExplodeCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/ExplodeCrateAction.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("The weapon to fire upon collection.")]
 		[WeaponReference] public string Weapon = null;
 
-		public override object Create(ActorInitializer init) { return new ExplodeCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new ExplodeCrateAction(init.Self, this); }
 	}
 
 	class ExplodeCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/GiveCashCrateAction.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Should the collected amount be displayed as a cash tick?")]
 		public bool UseCashTick = false;
 
-		public override object Create(ActorInitializer init) { return new GiveCashCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new GiveCashCrateAction(init.Self, this); }
 	}
 
 	class GiveCashCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/GiveMcvCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/GiveMcvCrateAction.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("The selection shares to use if the collector has no base.")]
 		public int NoBaseSelectionShares = 1000;
 
-		public override object Create(ActorInitializer init) { return new GiveMcvCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new GiveMcvCrateAction(init.Self, this); }
 	}
 
 	class GiveMcvCrateAction : GiveUnitCrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/GiveUnitCrateAction.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Override the owner of the newly spawned unit: e.g. Creeps or Neutral")]
 		public readonly string Owner = null;
 
-		public override object Create(ActorInitializer init) { return new GiveUnitCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new GiveUnitCrateAction(init.Self, this); }
 	}
 
 	class GiveUnitCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/GrantUpgradeCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/GrantUpgradeCrateAction.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("The maximum number of extra collectors to grant the crate action to.", "-1 = no limit")]
 		public readonly int MaxExtraCollectors = 4;
 
-		public override object Create(ActorInitializer init) { return new GrantUpgradeCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new GrantUpgradeCrateAction(init.Self, this); }
 	}
 
 	public class GrantUpgradeCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/HealUnitsCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/HealUnitsCrateAction.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.RA.Traits
 	[Desc("Heals all actors that belong to the owner of the collector.")]
 	class HealUnitsCrateActionInfo : CrateActionInfo
 	{
-		public override object Create(ActorInitializer init) { return new HealUnitsCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new HealUnitsCrateAction(init.Self, this); }
 	}
 
 	class HealUnitsCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/HideMapCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/HideMapCrateAction.cs
@@ -13,7 +13,7 @@ namespace OpenRA.Mods.RA.Traits
 	[Desc("Hides the entire map in shroud.")]
 	class HideMapCrateActionInfo : CrateActionInfo
 	{
-		public override object Create(ActorInitializer init) { return new HideMapCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new HideMapCrateAction(init.Self, this); }
 	}
 
 	class HideMapCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/LevelUpCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/LevelUpCrateAction.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("The maximum number of extra collectors to grant the crate action to.")]
 		public readonly int MaxExtraCollectors = 4;
 
-		public override object Create(ActorInitializer init) { return new LevelUpCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new LevelUpCrateAction(init.Self, this); }
 	}
 
 	class LevelUpCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/RevealMapCrateAction.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Should the map also be revealed for the allies of the collector's owner.")]
 		public readonly bool IncludeAllies = false;
 
-		public override object Create(ActorInitializer init) { return new RevealMapCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new RevealMapCrateAction(init.Self, this); }
 	}
 
 	class RevealMapCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Crates/SupportPowerCrateAction.cs
+++ b/OpenRA.Mods.RA/Traits/Crates/SupportPowerCrateAction.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Which proxy actor, which grants the support power, to spawn.")]
 		[ActorReference] public readonly string Proxy = null;
 
-		public override object Create(ActorInitializer init) { return new SupportPowerCrateAction(init.self, this); }
+		public override object Create(ActorInitializer init) { return new SupportPowerCrateAction(init.Self, this); }
 	}
 
 	class SupportPowerCrateAction : CrateAction

--- a/OpenRA.Mods.RA/Traits/Harvester.cs
+++ b/OpenRA.Mods.RA/Traits/Harvester.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Search radius (in cells) from the last harvest order location to find more resources.")]
 		public readonly int SearchFromOrderRadius = 12;
 
-		public object Create(ActorInitializer init) { return new Harvester(init.self, this); }
+		public object Create(ActorInitializer init) { return new Harvester(init.Self, this); }
 	}
 
 	public class Harvester : IIssueOrder, IResolveOrder, IPips,

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		public readonly int Duration = 25 * 30;
 
-		public object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.self, this); }
+		public object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.Self, this); }
 	}
 
 	class InfiltrateForPowerOutage : INotifyOwnerChanged, INotifyInfiltrated

--- a/OpenRA.Mods.RA/Traits/LeavesHusk.cs
+++ b/OpenRA.Mods.RA/Traits/LeavesHusk.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			this.info = info;
 
-			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.self.Owner.Country.Race;
+			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race;
 		}
 
 		public void Killed(Actor self, AttackInfo e)

--- a/OpenRA.Mods.RA/Traits/MadTank.cs
+++ b/OpenRA.Mods.RA/Traits/MadTank.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA.Traits
 		[ActorReference]
 		public readonly string DriverActor = "e1";
 
-		public object Create(ActorInitializer init) { return new MadTank(init.self, this); }
+		public object Create(ActorInitializer init) { return new MadTank(init.Self, this); }
 	}
 
 	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, ITick, IPreventsTeleport

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public Mine(ActorInitializer init, MineInfo info)
 		{
-			this.self = init.self;
+			this.self = init.Self;
 			this.info = info;
 		}
 

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly float MinefieldDepth = 1.5f;
 
-		public object Create(ActorInitializer init) { return new Minelayer(init.self); }
+		public object Create(ActorInitializer init) { return new Minelayer(init.Self); }
 	}
 
 	class Minelayer : IIssueOrder, IResolveOrder, IPostRenderSelection, ISync

--- a/OpenRA.Mods.RA/Traits/SeedsResource.cs
+++ b/OpenRA.Mods.RA/Traits/SeedsResource.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly string ResourceType = "Ore";
 		public readonly int MaxRange = 100;
 
-		public object Create(ActorInitializer init) { return new SeedsResource(init.self, this); }
+		public object Create(ActorInitializer init) { return new SeedsResource(init.Self, this); }
 	}
 
 	class SeedsResource : ITick, ISeedableResource

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly int Duration = 30;
 		public readonly bool KillCargo = true;
 
-		public override object Create(ActorInitializer init) { return new ChronoshiftPower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new ChronoshiftPower(init.Self, this); }
 	}
 
 	class ChronoshiftPower : SupportPower
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.RA.Traits
 				var tiles = world.Map.FindTilesInCircle(xy, range);
 				var pal = wr.Palette("terrain");
 				foreach (var t in tiles)
-					yield return new SpriteRenderable(tile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 			}
 
 			public string GetCursor(World world, CPos xy, MouseInput mi)
@@ -220,11 +220,11 @@ namespace OpenRA.Mods.RA.Traits
 
 				// Source tiles
 				foreach (var t in world.Map.FindTilesInCircle(sourceLocation, range))
-					yield return new SpriteRenderable(sourceTile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(sourceTile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 
 				// Destination tiles
 				foreach (var t in world.Map.FindTilesInCircle(xy, range))
-					yield return new SpriteRenderable(sourceTile, wr.world.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
+					yield return new SpriteRenderable(sourceTile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 
 				// Unit previews
 				foreach (var unit in power.UnitsInRange(sourceLocation))
@@ -244,7 +244,7 @@ namespace OpenRA.Mods.RA.Traits
 						var canEnter = manager.self.Owner.Shroud.IsExplored(targetCell) &&
 						                unit.Trait<Chronoshiftable>().CanChronoshiftTo(unit, targetCell);
 						var tile = canEnter ? validTile : invalidTile;
-						yield return new SpriteRenderable(tile, wr.world.Map.CenterOfCell(targetCell), WVec.Zero, -511, pal, 1f, true);
+						yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(targetCell), WVec.Zero, -511, pal, 1f, true);
 					}
 				}
 			}

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Traits
 	[Desc("Required for GpsPower. Attach this to the player actor.")]
 	class GpsWatcherInfo : ITraitInfo
 	{
-		public object Create(ActorInitializer init) { return new GpsWatcher(init.self.Owner); }
+		public object Create(ActorInitializer init) { return new GpsWatcher(init.Self.Owner); }
 	}
 
 	class GpsWatcher : ISync, IFogVisibilityModifier
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		public readonly int RevealDelay = 0;
 
-		public override object Create(ActorInitializer init) { return new GpsPower(init.self, this); }
+		public override object Create(ActorInitializer init) { return new GpsPower(init.Self, this); }
 	}
 
 	class GpsPower : SupportPower, INotifyKilled, INotifyStanceChanged, INotifySold, INotifyOwnerChanged

--- a/OpenRA.Mods.RA/Traits/TargetableSubmarine.cs
+++ b/OpenRA.Mods.RA/Traits/TargetableSubmarine.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		public readonly string[] CloakedTargetTypes = { };
 
-		public override object Create(ActorInitializer init) { return new TargetableSubmarine(init.self, this); }
+		public override object Create(ActorInitializer init) { return new TargetableSubmarine(init.Self, this); }
 	}
 
 	public class TargetableSubmarine : TargetableUnit

--- a/OpenRA.Mods.RA/Traits/TargetableUnit.cs
+++ b/OpenRA.Mods.RA/Traits/TargetableUnit.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public bool RequiresForceFire = false;
 
-		public virtual object Create(ActorInitializer init) { return new TargetableUnit(init.self, this); }
+		public virtual object Create(ActorInitializer init) { return new TargetableUnit(init.Self, this); }
 	}
 
 	public class TargetableUnit : ITargetable

--- a/OpenRA.Mods.RA/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.RA/Traits/World/BridgeLayer.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.RA.Traits
 		[ActorReference]
 		public readonly string[] Bridges = { "bridge1", "bridge2" };
 
-		public object Create(ActorInitializer init) { return new BridgeLayer(init.self, this); }
+		public object Create(ActorInitializer init) { return new BridgeLayer(init.Self, this); }
 	}
 
 	class BridgeLayer : IWorldLoaded

--- a/OpenRA.Mods.RA/Transforms.cs
+++ b/OpenRA.Mods.RA/Transforms.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public Transforms(ActorInitializer init, TransformsInfo info)
 		{
-			self = init.self;
+			self = init.Self;
 			this.info = info;
 			bi = self.World.Map.Rules.Actors[info.IntoActor].Traits.GetOrDefault<BuildingInfo>();
 			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : self.Owner.Country.Race;

--- a/OpenRA.Mods.RA/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.RA/UpgradeActorsNear.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA
 		public readonly string EnableSound = null;
 		public readonly string DisableSound = null;
 
-		public object Create(ActorInitializer init) { return new UpgradeActorsNear(init.self, this); }
+		public object Create(ActorInitializer init) { return new UpgradeActorsNear(init.Self, this); }
 	}
 
 	public class UpgradeActorsNear : ITick, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyOtherProduction

--- a/OpenRA.Mods.RA/UtilityCommands/ActorStatsExport.cs
+++ b/OpenRA.Mods.RA/UtilityCommands/ActorStatsExport.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.UtilityCommands
 	{
 		public static DataTable GenerateTable()
 		{
-			var rules = Game.modData.RulesetCache.LoadDefaultRules();
+			var rules = Game.ModData.RulesetCache.LoadDefaultRules();
 
 			var table = new DataTable();
 			table.Columns.Add("Name", typeof(string));

--- a/OpenRA.Mods.RA/UtilityCommands/ExportCharacterSeparatedRules.cs
+++ b/OpenRA.Mods.RA/UtilityCommands/ExportCharacterSeparatedRules.cs
@@ -20,9 +20,9 @@ namespace OpenRA.Mods.RA.UtilityCommands
 		[Desc("Export the damage per second evaluation into a CSV file for inspection.")]
 		public void Run(ModData modData, string[] args)
 		{
-			Game.modData = modData;
+			Game.ModData = modData;
 			var table = ActorStatsExport.GenerateTable();
-			var filename = "{0}-mod-dps.csv".F(Game.modData.Manifest.Mod.Id);
+			var filename = "{0}-mod-dps.csv".F(Game.ModData.Manifest.Mod.Id);
 			using (var outfile = new StreamWriter(filename))
 				outfile.Write(table.ToCharacterSeparatedValues(";", true));
 			Console.WriteLine("{0} has been saved.".F(filename));

--- a/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/DownloadPackagesLogic.cs
@@ -52,9 +52,9 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			var cancelButton = panel.Get<ButtonWidget>("CANCEL_BUTTON");
 
-			var mirrorsFile = Platform.ResolvePath("^", "Content", Game.modData.Manifest.Mod.Id, "mirrors.txt");
+			var mirrorsFile = Platform.ResolvePath("^", "Content", Game.ModData.Manifest.Mod.Id, "mirrors.txt");
 			var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-			var dest = Platform.ResolvePath("^", "Content", Game.modData.Manifest.Mod.Id);
+			var dest = Platform.ResolvePath("^", "Content", Game.ModData.Manifest.Mod.Id);
 
 			Action<DownloadProgressChangedEventArgs> onDownloadProgress = i =>
 			{

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		public GameInfoBriefingLogic(Widget widget, World world)
 		{
 			var previewWidget = widget.Get<MapPreviewWidget>("MAP_PREVIEW");
-			previewWidget.Preview = () => Game.modData.MapCache[world.Map.Uid];
+			previewWidget.Preview = () => Game.ModData.MapCache[world.Map.Uid];
 
 			var mapDescriptionPanel = widget.Get<ScrollPanelWidget>("MAP_DESCRIPTION_PANEL");
 			var mapDescription = widget.Get<LabelWidget>("MAP_DESCRIPTION");

--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Widgets
 			if (mpe != null)
 				mpe.Fade(mpe.Info.MenuEffect);
 
-			widget.Get<LabelWidget>("VERSION_LABEL").Text = Game.modData.Manifest.Mod.Version;
+			widget.Get<LabelWidget>("VERSION_LABEL").Text = Game.ModData.Manifest.Mod.Version;
 
 			var showStats = false;
 

--- a/OpenRA.Mods.RA/Widgets/Logic/IngameMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameMenuLogic.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			if (mpe != null)
 				mpe.Fade(mpe.Info.MenuEffect);
 
-			menu.Get<LabelWidget>("VERSION_LABEL").Text = Game.modData.Manifest.Mod.Version;
+			menu.Get<LabelWidget>("VERSION_LABEL").Text = Game.ModData.Manifest.Mod.Version;
 
 			var hideMenu = false;
 			menu.Get("MENU_BUTTONS").IsVisible = () => !hideMenu;

--- a/OpenRA.Mods.RA/Widgets/Logic/InstallFromCDLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/InstallFromCDLogic.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		bool IsValidDisk(string diskRoot)
 		{
-			return Game.modData.Manifest.ContentInstaller.DiskTestFiles.All(f => File.Exists(Path.Combine(diskRoot, f)));
+			return Game.ModData.Manifest.ContentInstaller.DiskTestFiles.All(f => File.Exists(Path.Combine(diskRoot, f)));
 		}
 
 		void CheckForDisk()
@@ -69,14 +69,14 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
 
-			var dest = Platform.ResolvePath("^", "Content", Game.modData.Manifest.Mod.Id);
-			var copyFiles = Game.modData.Manifest.ContentInstaller.CopyFilesFromCD;
+			var dest = Platform.ResolvePath("^", "Content", Game.ModData.Manifest.Mod.Id);
+			var copyFiles = Game.ModData.Manifest.ContentInstaller.CopyFilesFromCD;
 
-			var packageToExtract = Game.modData.Manifest.ContentInstaller.PackageToExtractFromCD.Split(':');
+			var packageToExtract = Game.ModData.Manifest.ContentInstaller.PackageToExtractFromCD.Split(':');
 			var extractPackage = packageToExtract.First();
 			var annotation = packageToExtract.Length > 1 ? packageToExtract.Last() : null;
 
-			var extractFiles = Game.modData.Manifest.ContentInstaller.ExtractFilesFromCD;
+			var extractFiles = Game.ModData.Manifest.ContentInstaller.ExtractFilesFromCD;
 
 			var installCounter = 0;
 			var installTotal = copyFiles.Count() + extractFiles.Count();

--- a/OpenRA.Mods.RA/Widgets/Logic/InstallLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/InstallLogic.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public InstallLogic(Widget widget, Action continueLoading)
 		{
-			var mirrorListUrl = Game.modData.Manifest.ContentInstaller.PackageMirrorList;
+			var mirrorListUrl = Game.ModData.Manifest.ContentInstaller.PackageMirrorList;
 			var panel = widget.Get("INSTALL_PANEL");
 			var widgetArgs = new WidgetArgs()
 			{
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
 			{
-				Game.Settings.Game.PreviousMod = Game.modData.Manifest.Mod.Id;
+				Game.Settings.Game.PreviousMod = Game.ModData.Manifest.Mod.Id;
 				Game.InitializeMod("modchooser", null);
 			};
 		}

--- a/OpenRA.Mods.RA/Widgets/Logic/InstallMusicLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/InstallMusicLogic.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var downloadButton = installMusicContainer.GetOrNull<ButtonWidget>("DOWNLOAD_BUTTON");
 			if (downloadButton != null)
 			{
-				var mirrorListUrl = Game.modData.Manifest.ContentInstaller.MusicPackageMirrorList;
+				var mirrorListUrl = Game.ModData.Manifest.ContentInstaller.MusicPackageMirrorList;
 				downloadButton.IsVisible = () => !string.IsNullOrEmpty(mirrorListUrl);
 				downloadButton.OnClick = () =>
 				{

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -625,7 +625,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			if (Map.Uid == uid)
 				return;
 
-			Map = Game.modData.MapCache[uid];
+			Map = Game.ModData.MapCache[uid];
 			if (Map.Status == MapStatus.Available)
 			{
 				// Maps need to be validated and pre-loaded before they can be accessed
@@ -653,7 +653,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				}).Start();
 			}
 			else if (Game.Settings.Game.AllowDownloading)
-				Game.modData.MapCache.QueryRemoteMapDetails(new[] { uid });
+				Game.ModData.MapCache.QueryRemoteMapDetails(new[] { uid });
 		}
 
 		void UpdatePlayerList()

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyMapPreviewLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyMapPreviewLogic.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 						if (lobby.Map.Status == MapStatus.DownloadError)
 							lobby.Map.Install();
 						else if (lobby.Map.Status == MapStatus.Unavailable)
-							Game.modData.MapCache.QueryRemoteMapDetails(new[] { lobby.Map.Uid });
+							Game.ModData.MapCache.QueryRemoteMapDetails(new[] { lobby.Map.Uid });
 					};
 
 					retry.GetText = () => lobby.Map.Status == MapStatus.DownloadError ? "Retry Install" : "Retry Search";

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyUtils.cs
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			if (!orderManager.LocalClient.IsObserver && orderManager.LocalClient.State == Session.ClientState.Ready)
 				return;
 
-			var spawnSize = new float2(ChromeProvider.GetImage("lobby-bits", "spawn-unclaimed").bounds.Size);
+			var spawnSize = new float2(ChromeProvider.GetImage("lobby-bits", "spawn-unclaimed").Bounds.Size);
 			var selectedSpawn = preview.SpawnPoints
 				.Select((sp, i) => Pair.New(mapPreview.ConvertToPreview(sp), i))
 				.Where(a => ((a.First - mi.Location).ToFloat2() / spawnSize * 2).LengthSquared <= 1)

--- a/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 		public MainMenuLogic(Widget widget, World world)
 		{
 			rootMenu = widget;
-			rootMenu.Get<LabelWidget>("VERSION_LABEL").Text = Game.modData.Manifest.Mod.Version;
+			rootMenu.Get<LabelWidget>("VERSION_LABEL").Text = Game.ModData.Manifest.Mod.Version;
 
 			// Menu buttons
 			var mainMenu = widget.Get("MAIN_MENU");
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			mainMenu.Get<ButtonWidget>("MODS_BUTTON").OnClick = () =>
 			{
-				Game.Settings.Game.PreviousMod = Game.modData.Manifest.Mod.Id;
+				Game.Settings.Game.PreviousMod = Game.ModData.Manifest.Mod.Id;
 				Game.InitializeMod("modchooser", null);
 			};
 
@@ -88,8 +88,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				});
 			};
 
-			var hasCampaign = Game.modData.Manifest.Missions.Any();
-			var hasMissions = Game.modData.MapCache
+			var hasCampaign = Game.ModData.Manifest.Missions.Any();
+			var hasMissions = Game.ModData.MapCache
 				.Any(p => p.Status == MapStatus.Available && p.Map.Visibility.HasFlag(MapVisibility.MissionSelector));
 
 			missionsButton.Disabled = !hasCampaign && !hasMissions;

--- a/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MapChooserLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var gameModeDropdown = widget.GetOrNull<DropDownButtonWidget>("GAMEMODE_FILTER");
 			if (gameModeDropdown != null)
 			{
-				var selectableMaps = Game.modData.MapCache.Where(m => m.Status == MapStatus.Available && (m.Map.Visibility & filter) != 0);
+				var selectableMaps = Game.ModData.MapCache.Where(m => m.Status == MapStatus.Available && (m.Map.Visibility & filter) != 0);
 				var gameModes = selectableMaps
 					.GroupBy(m => m.Type)
 					.Select(g => Pair.New(g.Key, g.Count())).ToList();
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		void EnumerateMaps(Action<string> onSelect, MapVisibility filter)
 		{
-			var maps = Game.modData.MapCache
+			var maps = Game.ModData.MapCache
 				.Where(m => m.Status == MapStatus.Available && (m.Map.Visibility & filter) != 0)
 				.Where(m => gameMode == null || m.Type == gameMode)
 				.Where(m => mapFilter == null || m.Title.IndexOf(mapFilter, StringComparison.OrdinalIgnoreCase) >= 0 || m.Author.IndexOf(mapFilter, StringComparison.OrdinalIgnoreCase) >= 0)

--- a/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MissionBrowserLogic.cs
@@ -92,15 +92,15 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			missionList.RemoveChildren();
 
 			// Add a group for each campaign
-			if (Game.modData.Manifest.Missions.Any())
+			if (Game.ModData.Manifest.Missions.Any())
 			{
-				var yaml = Game.modData.Manifest.Missions.Select(MiniYaml.FromFile).Aggregate(MiniYaml.MergeLiberal);
+				var yaml = Game.ModData.Manifest.Missions.Select(MiniYaml.FromFile).Aggregate(MiniYaml.MergeLiberal);
 
 				foreach (var kv in yaml)
 				{
 					var missionMapPaths = kv.Value.Nodes.Select(n => Path.GetFullPath(n.Key));
 
-					var maps = Game.modData.MapCache
+					var maps = Game.ModData.MapCache
 						.Where(p => p.Status == MapStatus.Available && missionMapPaths.Contains(Path.GetFullPath(p.Map.Path)))
 						.Select(p => p.Map);
 
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			}
 
 			// Add an additional group for loose missions
-			var looseMissions = Game.modData.MapCache
+			var looseMissions = Game.ModData.MapCache
 				.Where(p => p.Status == MapStatus.Available && p.Map.Visibility.HasFlag(MapVisibility.MissionSelector) && !allMaps.Contains(p.Map))
 				.Select(p => p.Map);
 
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 		void SelectMap(Map map)
 		{
-			selectedMapPreview = Game.modData.MapCache[map.Uid];
+			selectedMapPreview = Game.ModData.MapCache[map.Uid];
 
 			// Cache the rules on a background thread to avoid jank
 			new Thread(selectedMapPreview.CacheRules).Start();

--- a/OpenRA.Mods.RA/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MusicPlayerLogic.cs
@@ -88,11 +88,11 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				var args = new string[] { "Install.Music=true" };
 				installButton.OnClick = () =>
 				{
-					Game.modData.LoadScreen.Display(); // HACK: prevent a flicker when transitioning to the installation dialog
+					Game.ModData.LoadScreen.Display(); // HACK: prevent a flicker when transitioning to the installation dialog
 					Game.InitializeMod(Game.Settings.Game.Mod, new Arguments(args));
 				};
 
-				var installData = Game.modData.Manifest.ContentInstaller;
+				var installData = Game.ModData.Manifest.ContentInstaller;
 				installButton.IsVisible = () => modRules.InstalledMusic.ToArray().Length <= installData.ShippedSoundtracks;
 			}
 

--- a/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ReplayBrowserLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			replayList = panel.Get<ScrollPanelWidget>("REPLAY_LIST");
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
-			var mod = Game.modData.Manifest.Mod;
+			var mod = Game.ModData.Manifest.Mod;
 			var dir = Platform.ResolvePath("^", "Replays", mod.Id, mod.Version);
 
 			replayList.RemoveChildren();

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerBrowserLogic.cs
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 				return 0;
 
 			// Games for the current mod+version are sorted first
-			if (testEntry.ModId == Game.modData.Manifest.Mod.Id)
+			if (testEntry.ModId == Game.ModData.Manifest.Mod.Id)
 				return 2;
 
 			// Followed by games for different mods that are joinable
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 					var item = ScrollItemWidget.Setup(serverTemplate, () => currentServer == game, () => currentServer = game, () => Join(game));
 
-					var map = Game.modData.MapCache[game.Map];
+					var map = Game.ModData.MapCache[game.Map];
 					var preview = item.GetOrNull<MapPreviewWidget>("MAP_PREVIEW");
 					if (preview != null)
 						preview.Preview = () => map;
@@ -283,7 +283,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 				// Search for any unknown maps
 				if (Game.Settings.Game.AllowDownloading)
-					Game.modData.MapCache.QueryRemoteMapDetails(games.Where(g => !Filtered(g)).Select(g => g.Map));
+					Game.ModData.MapCache.QueryRemoteMapDetails(games.Where(g => !Filtered(g)).Select(g => g.Map));
 
 				foreach (var row in rows)
 					serverList.AddChild(row);

--- a/OpenRA.Mods.RA/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ServerCreationLogic.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			this.onExit = onExit;
 
 			var settings = Game.Settings;
-			preview = Game.modData.MapCache[WidgetUtils.ChooseInitialMap(Game.Settings.Server.Map)];
+			preview = Game.ModData.MapCache[WidgetUtils.ChooseInitialMap(Game.Settings.Server.Map)];
 
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
 			panel.Get<ButtonWidget>("CREATE_BUTTON").OnClick = CreateAndJoin;
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 					{
 						{ "initialMap", preview.Uid },
 						{ "onExit", () => { } },
-						{ "onSelect", (Action<string>)(uid => preview = Game.modData.MapCache[uid]) }
+						{ "onSelect", (Action<string>)(uid => preview = Game.ModData.MapCache[uid]) }
 					});
 				};
 

--- a/OpenRA.Mods.RA/WithRangeCircle.cs
+++ b/OpenRA.Mods.RA/WithRangeCircle.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Traits
 						yield return r;
 		}
 
-		public object Create(ActorInitializer init) { return new WithRangeCircle(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithRangeCircle(init.Self, this); }
 	}
 
 	class WithRangeCircle : IPostRenderSelection

--- a/OpenRA.Mods.TS/Traits/Buildings/TiberianSunRefinery.cs
+++ b/OpenRA.Mods.TS/Traits/Buildings/TiberianSunRefinery.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.TS.Traits
 {
 	public class TiberianSunRefineryInfo : OreRefineryInfo
 	{
-		public override object Create(ActorInitializer init) { return new TiberianSunRefinery(init.self, this); }
+		public override object Create(ActorInitializer init) { return new TiberianSunRefinery(init.Self, this); }
 	}
 
 	public class TiberianSunRefinery : OreRefinery

--- a/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.TS.Traits
 		public readonly float[] LightAmbientColor = new float[] { 0.6f, 0.6f, 0.6f };
 		public readonly float[] LightDiffuseColor = new float[] { 0.4f, 0.4f, 0.4f };
 
-		public virtual object Create(ActorInitializer init) { return new RenderVoxels(init.self, this); }
+		public virtual object Create(ActorInitializer init) { return new RenderVoxels(init.Self, this); }
 
 		public virtual IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelBarrel.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.TS.Traits
 		[Desc("Visual offset")]
 		public readonly WVec LocalOffset = WVec.Zero;
 
-		public object Create(ActorInitializer init) { return new WithVoxelBarrel(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithVoxelBarrel(init.Self, this); }
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelBody.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.TS.Traits
 	{
 		public readonly string Sequence = "idle";
 
-		public object Create(ActorInitializer init) { return new WithVoxelBody(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithVoxelBody(init.Self, this); }
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelTurret.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.TS.Traits
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";
 
-		public object Create(ActorInitializer init) { return new WithVoxelTurret(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithVoxelTurret(init.Self, this); }
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.TS.Traits
 		[Desc("Voxel sequence name to use when undocked from a refinery.")]
 		public readonly string IdleSequence = "idle";
 
-		public object Create(ActorInitializer init) { return new WithVoxelUnloadBody(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithVoxelUnloadBody(init.Self, this); }
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.TS.Traits
 	public class WithVoxelWalkerBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, Requires<RenderVoxelsInfo>, Requires<IMoveInfo>
 	{
 		public readonly int TickRate = 5;
-		public object Create(ActorInitializer init) { return new WithVoxelWalkerBody(init.self, this); }
+		public object Create(ActorInitializer init) { return new WithVoxelWalkerBody(init.Self, this); }
 
 		public int QuantizedBodyFacings(SequenceProvider sequenceProvider, ActorInfo ai) { return 0; }
 	}

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -25,9 +25,9 @@ namespace OpenRA.Mods.TS.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
-			Game.modData = modData;
+			Game.ModData = modData;
 
-			GlobalFileSystem.LoadFromManifest(Game.modData.Manifest);
+			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
 
 			var file = new IniFile(File.Open(args[1], FileMode.Open));
 


### PR DESCRIPTION
This is a followup of https://github.com/OpenRA/OpenRA/pull/7251. The last 30 warnings are heavy, because they rename the most frequently referenced public variables. Don't worry about the diff cut off. Everything outside `OpenRA.Game` is just automatic renamings to adjust to the changes.
