### PR TITLE
Some general polish

### DIFF
--- a/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
@@ -147,8 +147,8 @@ namespace OpenRA.Graphics
 			var bounds = actor.Bounds;
 			bounds.Offset(screenPos.X, screenPos.Y);
 
-			var start = new float2(bounds.Left, bounds.Top);
-			var end = new float2(bounds.Right, bounds.Top);
+			var start = new float2(bounds.Left + 1, bounds.Top);
+			var end = new float2(bounds.Right - 1, bounds.Top);
 
 			DrawHealthBar(wr, health, start, end);
 			DrawExtraBars(wr, start, end);

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -150,8 +150,9 @@ namespace OpenRA.Traits
 
 			public void Dispose()
 			{
-				foreach (var a in currentActors)
-					onActorExited(a);
+				if (onActorExited != null)
+					foreach (var a in currentActors)
+						onActorExited(a);
 			}
 		}
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -572,6 +572,9 @@ namespace OpenRA.Mods.Common.Server
 				{ "difficulty",
 					s =>
 					{
+						if (!server.Map.Options.Difficulties.Any())
+							return true;
+
 						if (!client.IsAdmin)
 						{
 							server.SendOrderTo(conn, "Message", "Only the host can set that option.");

--- a/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
@@ -387,22 +387,27 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				try
 				{
 					var parts = s.Value.Split(',');
-					var loc = Exts.ParseIntegerInvariant(parts[3]);
 					if (parts[0] == "")
 						parts[0] = "Neutral";
 
 					if (!players.Contains(parts[0]))
 						players.Add(parts[0]);
 
+					var loc = Exts.ParseIntegerInvariant(parts[3]);
+					var health = float.Parse(parts[2], NumberFormatInfo.InvariantInfo) / 256;
+					var facing = (section == "INFANTRY") ? Exts.ParseIntegerInvariant(parts[6]) : Exts.ParseIntegerInvariant(parts[4]);
+
 					var actor = new ActorReference(parts[1].ToLowerInvariant())
 					{
 						new LocationInit(new CPos(loc % mapSize, loc / mapSize)),
 						new OwnerInit(parts[0]),
-						new HealthInit(float.Parse(parts[2], NumberFormatInfo.InvariantInfo) / 256),
-						new FacingInit((section == "INFANTRY")
-							? Exts.ParseIntegerInvariant(parts[6])
-							: Exts.ParseIntegerInvariant(parts[4])),
 					};
+
+					var initDict = actor.InitDict;
+					if (health != 1)
+						initDict.Add(new HealthInit(health));
+					if (facing != 0)
+						initDict.Add(new FacingInit(facing));
 
 					if (section == "INFANTRY")
 						actor.Add(new SubCellInit(Exts.ParseIntegerInvariant(parts[4])));

--- a/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/LobbyLogic.cs
@@ -507,7 +507,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			disconnectButton.OnClick = () => { CloseWindow(); onExit(); };
 
 			if (skirmishMode)
-				disconnectButton.Text = "Cancel";
+				disconnectButton.Text = "Back";
 
 			chatLabel = lobby.Get<LabelWidget>("LABEL_CHATTYPE");
 			var chatTextField = lobby.Get<TextFieldWidget>("CHAT_TEXTFIELD");

--- a/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/MainMenuLogic.cs
@@ -294,7 +294,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			menuType = MenuType.None;
 			Game.OpenWindow("SERVER_LOBBY", new WidgetArgs
 			{
-				{ "onExit", () => { Game.Disconnect(); menuType = MenuType.Main; } },
+				{ "onExit", () => { Game.Disconnect(); menuType = MenuType.Singleplayer; } },
 				{ "onStart", RemoveShellmapUI },
 				{ "skirmishMode", true }
 			});


### PR DESCRIPTION
Split from #7164 as requested (https://github.com/OpenRA/OpenRA/pull/7164#issuecomment-68462738).

What I did in this PR:
- "Disabled" messages like "xyz30 changed map difficulty to ." (that e.g. occur when selecting a mission without any difficulties after playing one with difficulties.)
- Updated the legacy map importer in order to omit `Facing: 0` and `Health: 1` while importing (as they are default values)
- Fixed a crash (my fault) when removing (OnEntered) ProximityTriggers
- Now you return from skirmish lobby to singleplayer menu instead of main menu
- Fixed #4976
