### PR TITLE
Minor targeting cleanup

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -27,14 +27,6 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackFollow(Actor self, AttackFollowInfo info)
 			: base(self, info) { }
 
-		protected override bool CanAttack(Actor self, Target target)
-		{
-			if (!target.IsValidFor(self))
-				return false;
-
-			return base.CanAttack(self, target);
-		}
-
 		public virtual void Tick(Actor self)
 		{
 			DoAttack(self, Target);

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -123,14 +123,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Cloaked || self.Owner.IsAlliedWith(viewer))
 				return true;
 
-			return self.World.ActorsWithTrait<DetectCloaked>().Any(a =>
-			{
-				var dc = a.Actor.Info.Traits.Get<DetectCloakedInfo>();
-
-				return a.Actor.Owner.IsAlliedWith(viewer)
-					&& Info.CloakTypes.Intersect(dc.CloakTypes).Any()
-					&& (self.CenterPosition - a.Actor.CenterPosition).Length <= WRange.FromCells(dc.Range).Range;
-			});
+			return self.World.ActorsWithTrait<DetectCloaked>().Any(a => a.Actor.Owner.IsAlliedWith(viewer)
+				&& Info.CloakTypes.Intersect(a.Trait.Info.CloakTypes).Any()
+				&& (self.CenterPosition - a.Actor.CenterPosition).Length <= WRange.FromCells(a.Trait.Info.Range).Range);
 		}
 
 		public Color RadarColorOverride(Actor self)

--- a/OpenRA.Mods.Common/Traits/DetectCloaked.cs
+++ b/OpenRA.Mods.Common/Traits/DetectCloaked.cs
@@ -13,14 +13,24 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can reveal Cloak actors in a specified range.")]
-	public class DetectCloakedInfo : TraitInfo<DetectCloaked>
+	public class DetectCloakedInfo : ITraitInfo
 	{
 		[Desc("Specific cloak classifications I can reveal.")]
 		public readonly string[] CloakTypes = { "Cloak" };
 
 		[Desc("Measured in cells.")]
 		public readonly int Range = 5;
+
+		public object Create(ActorInitializer init) { return new DetectCloaked(this); }
 	}
 
-	public class DetectCloaked { }
+	public class DetectCloaked
+	{
+		public readonly DetectCloakedInfo Info;
+
+		public DetectCloaked(DetectCloakedInfo info)
+		{
+			Info = info;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Traits/TargetableUnit.cs
+++ b/OpenRA.Mods.Common/Traits/TargetableUnit.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual bool TargetableBy(Actor self, Actor viewer)
 		{
-			if (cloak == null || !cloak.Cloaked)
+			if (cloak == null)
 				return true;
 
 			return cloak.IsVisible(self, viewer.Owner);


### PR DESCRIPTION
A couple of simple clean-up fixes to the current targeting:
- Removed `AttackFollow.CanAttack()` since it doesn't do anything that its `base.CanAttack()` doesn't. Also unlike `AttackFollow.CanAttack()`, the base method has a `self.IsInWorld` check, which comes after the removed target validity check.
- Exposed an Info field in the `DetectCloaked` trait in order to remove
  `a.Actor.Info.Traits.Get<DetectCloakedInfo>();`
  because `ActorsWithTrait<DetectCloaked>()` already gives us the needed trait and it is redundant to do another `Traits.Get<>()`
- `TargetableUnit.TargetableBy()` shouldn't check if the actor is cloaked. `cloak.IsVisible()` does that.

In theory this should have a marginally positive effect on late-game performance. Other than that, mostly cleanup stuff.
