### PR TITLE
Cache render related TraitsImplementing calls in Actor.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -65,6 +65,9 @@ namespace OpenRA
 			}
 		}
 
+		readonly IEnumerable<IRenderModifier> traitsImplementingRenderModifier;
+		readonly IEnumerable<IRender> traitsImplementingRender;
+
 		internal Actor(World world, string name, TypeDictionary initDict)
 		{
 			var init = new ActorInitializer(this, initDict);
@@ -104,6 +107,9 @@ namespace OpenRA
 
 				return new Rectangle(offset.X, offset.Y, size.X, size.Y);
 			});
+
+			traitsImplementingRenderModifier = TraitsImplementing<IRenderModifier>();
+			traitsImplementingRender = TraitsImplementing<IRender>();
 		}
 
 		public void Tick()
@@ -119,14 +125,14 @@ namespace OpenRA
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
 			var renderables = Renderables(wr);
-			foreach (var modifier in TraitsImplementing<IRenderModifier>())
+			foreach (var modifier in traitsImplementingRenderModifier)
 				renderables = modifier.ModifyRender(this, wr, renderables);
 			return renderables;
 		}
 
 		IEnumerable<IRenderable> Renderables(WorldRenderer wr)
 		{
-			foreach (var render in TraitsImplementing<IRender>())
+			foreach (var render in traitsImplementingRender)
 				foreach (var renderable in render.Render(this, wr))
 					yield return renderable;
 		}


### PR DESCRIPTION
The TraitsImplementing<T> performs a dictionary lookup to match up its generic type parameter with the right trait collection. Since actors are rendered so much, it is useful to cache this result to avoid looking it up repeatedly.

This saves 1.4% in CPU time that was being spent calling these methods in the RA shellmap.
