### PR TITLE
Move more traits to Mods.Common

### DIFF
--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -8,14 +8,12 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Activities
+namespace OpenRA.Mods.Common.Activities
 {
-	class CaptureActor : Enter
+	public class CaptureActor : Enter
 	{
 		readonly Actor actor;
 		readonly Capturable capturable;

--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -10,12 +10,10 @@
 
 using OpenRA.Activities;
 using OpenRA.Effects;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Activities
+namespace OpenRA.Mods.Common.Activities
 {
 	class ExternalCaptureActor : Activity
 	{

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -8,11 +8,10 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Activities
+namespace OpenRA.Mods.Common.Activities
 {
 	class RepairBridge : Enter
 	{

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -14,9 +14,9 @@ using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Activities
+namespace OpenRA.Mods.Common.Activities
 {
-	class Transform : Activity
+	public class Transform : Activity
 	{
 		public readonly string ToActor;
 		public CVec Offset = CVec.Zero;

--- a/OpenRA.Mods.Common/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RepairIndicator.cs
@@ -12,9 +12,9 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
-using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.Common.Traits;
 
-namespace OpenRA.Mods.RA.Effects
+namespace OpenRA.Mods.Common.Effects
 {
 	class RepairIndicator : IEffect
 	{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Activities\Air\ReturnToBase.cs" />
     <Compile Include="Activities\Air\TakeOff.cs" />
     <Compile Include="Activities\Attack.cs" />
+    <Compile Include="Activities\CaptureActor.cs" />
     <Compile Include="Activities\Enter.cs" />
     <Compile Include="Activities\EnterTransport.cs" />
     <Compile Include="Activities\ExternalCaptureActor.cs" />
@@ -90,6 +91,7 @@
     <Compile Include="Activities\RepairBuilding.cs" />
     <Compile Include="Activities\Sell.cs" />
     <Compile Include="Activities\SimpleTeleport.cs" />
+    <Compile Include="Activities\Transform.cs" />
     <Compile Include="Activities\Turn.cs" />
     <Compile Include="Activities\UnloadCargo.cs" />
     <Compile Include="Activities\Wait.cs" />
@@ -198,6 +200,9 @@
     <Compile Include="Traits\Buildings\Reservable.cs" />
     <Compile Include="Traits\Buildings\TargetableBuilding.cs" />
     <Compile Include="Traits\Burns.cs" />
+    <Compile Include="Traits\Capturable.cs" />
+    <Compile Include="Traits\CaptureNotification.cs" />
+    <Compile Include="Traits\Captures.cs" />
     <Compile Include="Traits\Cargo.cs" />
     <Compile Include="Traits\CashTrickler.cs" />
     <Compile Include="Traits\Cloak.cs" />
@@ -256,6 +261,8 @@
     <Compile Include="Traits\Power\RequiresPower.cs" />
     <Compile Include="Traits\Power\ScalePowerWithHealth.cs" />
     <Compile Include="Traits\ProvidesRadar.cs" />
+    <Compile Include="Traits\ProximityCaptor.cs" />
+    <Compile Include="Traits\ProximityCapturable.cs" />
     <Compile Include="Traits\RadarColorFromTerrain.cs" />
     <Compile Include="Traits\Reloads.cs" />
     <Compile Include="Traits\Render\Hovers.cs" />
@@ -307,6 +314,7 @@
     <Compile Include="Traits\TargetableUnit.cs" />
     <Compile Include="Traits\ThrowsParticle.cs" />
     <Compile Include="Traits\Tooltip.cs" />
+    <Compile Include="Traits\TransformOnCapture.cs" />
     <Compile Include="Traits\Turreted.cs" />
     <Compile Include="Traits\Upgrades\UpgradableTrait.cs" />
     <Compile Include="Traits\Upgrades\UpgradeManager.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Activities\Rearm.cs" />
     <Compile Include="Activities\RemoveSelf.cs" />
     <Compile Include="Activities\Repair.cs" />
+    <Compile Include="Activities\RepairBridge.cs" />
     <Compile Include="Activities\RepairBuilding.cs" />
     <Compile Include="Activities\Sell.cs" />
     <Compile Include="Activities\SimpleTeleport.cs" />
@@ -177,6 +178,8 @@
     <Compile Include="Traits\Buildings\BaseBuilding.cs" />
     <Compile Include="Traits\Buildings\BaseProvider.cs" />
     <Compile Include="Traits\Buildings\Bib.cs" />
+    <Compile Include="Traits\Buildings\Bridge.cs" />
+    <Compile Include="Traits\Buildings\BridgeHut.cs" />
     <Compile Include="Traits\Buildings\Building.cs" />
     <Compile Include="Traits\Buildings\BuildingInfluence.cs" />
     <Compile Include="Traits\Buildings\BuildingUtils.cs" />
@@ -277,6 +280,7 @@
     <Compile Include="Traits\Render\WithShadow.cs" />
     <Compile Include="Traits\Render\WithSmoke.cs" />
     <Compile Include="Traits\Render\WithTurret.cs" />
+    <Compile Include="Traits\RepairsBridges.cs" />
     <Compile Include="Traits\SeedsResource.cs" />
     <Compile Include="Traits\StoresResources.cs" />
     <Compile Include="Traits\SelfHealing.cs" />
@@ -296,6 +300,7 @@
     <Compile Include="Traits\Upgrades\UpgradeManager.cs" />
     <Compile Include="Traits\Valued.cs" />
     <Compile Include="Traits\Wanders.cs" />
+    <Compile Include="Traits\World\BridgeLayer.cs" />
     <Compile Include="Traits\World\CreateMPPlayers.cs" />
     <Compile Include="Traits\World\DomainIndex.cs" />
     <Compile Include="Traits\World\LoadWidgetAtGameStart.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Activities\Attack.cs" />
     <Compile Include="Activities\Enter.cs" />
     <Compile Include="Activities\EnterTransport.cs" />
+    <Compile Include="Activities\ExternalCaptureActor.cs" />
     <Compile Include="Activities\Heal.cs" />
     <Compile Include="Activities\Hunt.cs" />
     <Compile Include="Activities\Move\AttackMoveActivity.cs" />
@@ -201,6 +202,9 @@
     <Compile Include="Traits\CashTrickler.cs" />
     <Compile Include="Traits\Cloak.cs" />
     <Compile Include="Traits\Crushable.cs" />
+    <Compile Include="Traits\ExternalCapturable.cs" />
+    <Compile Include="Traits\ExternalCapturableBar.cs" />
+    <Compile Include="Traits\ExternalCaptures.cs" />
     <Compile Include="Traits\IgnoresDisguise.cs" />
     <Compile Include="Traits\DetectCloaked.cs" />
     <Compile Include="Traits\EngineerRepair.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Effects\PowerdownIndicator.cs" />
     <Compile Include="Effects\RallyPointIndicator.cs" />
     <Compile Include="Effects\Rank.cs" />
+    <Compile Include="Effects\RepairIndicator.cs" />
     <Compile Include="Effects\Smoke.cs" />
     <Compile Include="Commands\ChatCommands.cs" />
     <Compile Include="Commands\DevCommands.cs" />
@@ -124,6 +125,7 @@
     <Compile Include="LoadScreens\ModChooserLoadScreen.cs" />
     <Compile Include="Orders\DeployOrderTargeter.cs" />
     <Compile Include="Orders\EnterAlliedActorTargeter.cs" />
+    <Compile Include="Orders\RepairOrderGenerator.cs" />
     <Compile Include="Orders\UnitOrderTargeter.cs" />
     <Compile Include="PlayerExtensions.cs" />
     <Compile Include="ServerTraits\ColorValidator.cs" />
@@ -190,6 +192,7 @@
     <Compile Include="Traits\Buildings\LineBuild.cs" />
     <Compile Include="Traits\Buildings\LineBuildNode.cs" />
     <Compile Include="Traits\Buildings\RallyPoint.cs" />
+    <Compile Include="Traits\Buildings\RepairableBuilding.cs" />
     <Compile Include="Traits\Buildings\RepairsUnits.cs" />
     <Compile Include="Traits\Buildings\Reservable.cs" />
     <Compile Include="Traits\Buildings\TargetableBuilding.cs" />
@@ -232,6 +235,7 @@
     <Compile Include="Traits\PaletteEffects\NukePaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\WaterPaletteRotation.cs" />
     <Compile Include="Traits\Player\ActorGroupProxy.cs" />
+    <Compile Include="Traits\Player\AllyRepair.cs" />
     <Compile Include="Traits\Player\ConquestVictoryConditions.cs" />
     <Compile Include="Traits\Player\GlobalUpgradeManager.cs" />
     <Compile Include="Traits\Player\MissionObjectives.cs" />
@@ -275,11 +279,15 @@
     <Compile Include="Traits\Render\WithHarvestAnimation.cs" />
     <Compile Include="Traits\Render\WithMuzzleFlash.cs" />
     <Compile Include="Traits\Render\WithRangeCircle.cs" />
+    <Compile Include="Traits\Render\WithRepairAnimation.cs" />
+    <Compile Include="Traits\Render\WithRepairOverlay.cs" />
     <Compile Include="Traits\Render\WithResources.cs" />
     <Compile Include="Traits\Render\WithRotor.cs" />
     <Compile Include="Traits\Render\WithShadow.cs" />
     <Compile Include="Traits\Render\WithSmoke.cs" />
     <Compile Include="Traits\Render\WithTurret.cs" />
+    <Compile Include="Traits\Repairable.cs" />
+    <Compile Include="Traits\RepairableNear.cs" />
     <Compile Include="Traits\RepairsBridges.cs" />
     <Compile Include="Traits\SeedsResource.cs" />
     <Compile Include="Traits\StoresResources.cs" />

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -11,11 +11,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Orders
+namespace OpenRA.Mods.Common.Orders
 {
 	public class RepairOrderGenerator : IOrderGenerator
 	{

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -12,13 +12,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
-using OpenRA.GameRules;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	class BridgeInfo : ITraitInfo, Requires<HealthInfo>, Requires<BuildingInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
@@ -8,12 +8,10 @@
  */
 #endregion
 
-using System;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows bridges to be targeted for demolition and repair.")]
 	class BridgeHutInfo : IDemolishableInfo, ITraitInfo

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -11,12 +11,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Effects;
+using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Building can be repaired by the repair button.")]
 	public class RepairableBuildingInfo : UpgradableTraitInfo, ITraitInfo, Requires<HealthInfo>

--- a/OpenRA.Mods.Common/Traits/Capturable.cs
+++ b/OpenRA.Mods.Common/Traits/Capturable.cs
@@ -11,10 +11,10 @@
 using System.Linq;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be captured by a unit with Captures: trait.")]
-	class CapturableInfo : ITraitInfo
+	public class CapturableInfo : ITraitInfo
 	{
 		[Desc("Type listed under Types in Captures: trait of actors that can capture this).")]
 		public readonly string Type = "building";
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Traits
 		}
 	}
 
-	class Capturable : INotifyCapture
+	public class Capturable : INotifyCapture
 	{
 		public readonly CapturableInfo Info;
 		public bool BeingCaptured { get; private set; }

--- a/OpenRA.Mods.Common/Traits/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureNotification.cs
@@ -10,9 +10,9 @@
 
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
-	class CaptureNotificationInfo : ITraitInfo
+	public class CaptureNotificationInfo : ITraitInfo
 	{
 		public readonly string Notification = "BuildingCaptured";
 		public readonly bool NewOwnerVoice = true;
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.RA.Traits
 		public object Create(ActorInitializer init) { return new CaptureNotification(this); }
 	}
 
-	class CaptureNotification : INotifyCapture
+	public class CaptureNotification : INotifyCapture
 	{
 		CaptureNotificationInfo info;
 		public CaptureNotification(CaptureNotificationInfo info)

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -10,15 +10,14 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can capture other actors which have the Capturable: trait.")]
-	class CapturesInfo : ITraitInfo
+	public class CapturesInfo : ITraitInfo
 	{
 		[Desc("Types of actors that it can capture, as long as the type also exists in the Capturable Type: trait.")]
 		public readonly string[] CaptureTypes = { "building" };
@@ -30,7 +29,7 @@ namespace OpenRA.Mods.RA.Traits
 		public object Create(ActorInitializer init) { return new Captures(init.Self, this); }
 	}
 
-	class Captures : IIssueOrder, IResolveOrder, IOrderVoice
+	public class Captures : IIssueOrder, IResolveOrder, IOrderVoice
 	{
 		public readonly CapturesInfo Info;
 

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -9,10 +9,9 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be captured by a unit with ExternalCaptures: trait.")]
 	public class ExternalCapturableInfo : ITraitInfo

--- a/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
@@ -11,7 +11,7 @@
 using System.Drawing;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Visualize the remaining CaptureCompleteTime from ExternalCapturable: trait.")]
 	class ExternalCapturableBarInfo : ITraitInfo, Requires<ExternalCapturableInfo>

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -10,12 +10,11 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can capture other actors which have the ExternalCapturable: trait.")]
 	class ExternalCapturesInfo : ITraitInfo

--- a/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
+++ b/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
@@ -8,10 +8,9 @@
  */
 #endregion
 
-using OpenRA.Mods.Common;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor to allow building repair by team mates.")]
 	class AllyRepairInfo : TraitInfo<AllyRepair> { }

--- a/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
@@ -11,7 +11,7 @@
 using System.Linq;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can capture ProximityCapturable actors.")]
 	public class ProximityCaptorInfo : ITraitInfo

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -13,7 +13,7 @@ using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can be captured by units in a specified proximity.")]
 	public class ProximityCapturableInfo : ITraitInfo

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -10,10 +10,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Replaces the building animation when it repairs a unit.")]
 	public class WithRepairAnimationInfo : ITraitInfo, Requires<RenderBuildingInfo>

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -11,10 +11,9 @@
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays an overlay when the building is being repaired by the player.")]
 	public class WithRepairOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -14,11 +14,9 @@ using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be sent to a structure for repairs.")]
 	class RepairableInfo : ITraitInfo, Requires<HealthInfo>

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -13,10 +13,9 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	class RepairableNearInfo : ITraitInfo, Requires<HealthInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -10,11 +10,11 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Can enter a BridgeHut to trigger a repair.")]
 	class RepairsBridgesInfo : TraitInfo<RepairsBridges> { }

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -8,12 +8,12 @@
  */
 #endregion
 
-using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA
+namespace OpenRA.Mods.Common.Traits
 {
-	class TransformOnCaptureInfo : ITraitInfo
+	public class TransformOnCaptureInfo : ITraitInfo
 	{
 		[ActorReference] public readonly string IntoActor = null;
 		public readonly int ForceHealthPercentage = 0;
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA
 		public virtual object Create(ActorInitializer init) { return new TransformOnCapture(this); }
 	}
 
-	class TransformOnCapture : INotifyCapture
+	public class TransformOnCapture : INotifyCapture
 	{
 		readonly TransformOnCaptureInfo info;
 

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -14,7 +14,7 @@ using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.RA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	class BridgeLayerInfo : ITraitInfo
 	{

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -84,7 +84,6 @@
     <Compile Include="AI\HackyAI.cs" />
     <Compile Include="Render\WithIdleOverlay.cs" />
     <Compile Include="Traits\AcceptsSupplies.cs" />
-    <Compile Include="Activities\ExternalCaptureActor.cs" />
     <Compile Include="Activities\DeliverResources.cs" />
     <Compile Include="Activities\Demolish.cs" />
     <Compile Include="Activities\DonateSupplies.cs" />
@@ -108,10 +107,7 @@
     <Compile Include="CaptureNotification.cs" />
     <Compile Include="Scripting\Properties\RepairableBuildingProperties.cs" />
     <Compile Include="C4Demolition.cs" />
-    <Compile Include="ExternalCapturable.cs" />
-    <Compile Include="ExternalCapturableBar.cs" />
     <Compile Include="Capturable.cs" />
-    <Compile Include="ExternalCaptures.cs" />
     <Compile Include="Traits\PaletteEffects\ChronoshiftPaletteEffect.cs" />
     <Compile Include="Traits\Chronoshiftable.cs" />
     <Compile Include="CrateSpawner.cs" />

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -82,7 +82,6 @@
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />
     <Compile Include="AI\BaseBuilder.cs" />
     <Compile Include="AI\HackyAI.cs" />
-    <Compile Include="Player\AllyRepair.cs" />
     <Compile Include="Render\WithIdleOverlay.cs" />
     <Compile Include="Traits\AcceptsSupplies.cs" />
     <Compile Include="Activities\ExternalCaptureActor.cs" />
@@ -132,7 +131,6 @@
     <Compile Include="Traits\DemoTruck.cs" />
     <Compile Include="Effects\GpsDot.cs" />
     <Compile Include="Effects\Parachute.cs" />
-    <Compile Include="Effects\RepairIndicator.cs" />
     <Compile Include="EmitInfantryOnSell.cs" />
     <Compile Include="Invulnerable.cs" />
     <Compile Include="Captures.cs" />
@@ -145,7 +143,6 @@
     <Compile Include="Traits\Minelayer.cs" />
     <Compile Include="Orders\PlaceBuildingOrderGenerator.cs" />
     <Compile Include="Orders\GlobalButtonOrderGenerator.cs" />
-    <Compile Include="Orders\RepairOrderGenerator.cs" />
     <Compile Include="ParaDrop.cs" />
     <Compile Include="Player\ClassicProductionQueue.cs" />
     <Compile Include="Player\PlaceBuilding.cs" />
@@ -162,8 +159,6 @@
     <Compile Include="Render\RenderHarvester.cs" />
     <Compile Include="Render\RenderDisguise.cs" />
     <Compile Include="Render\RenderLandingCraft.cs" />
-    <Compile Include="Repairable.cs" />
-    <Compile Include="RepairableNear.cs" />
     <Compile Include="Disguise.cs" />
     <Compile Include="Traits\SupplyTruck.cs" />
     <Compile Include="SupportPowers\AirstrikePower.cs" />
@@ -178,7 +173,6 @@
     <Compile Include="Traits\Buildings\Fake.cs" />
     <Compile Include="Traits\Buildings\OreRefinery.cs" />
     <Compile Include="Traits\Buildings\PrimaryBuilding.cs" />
-    <Compile Include="Traits\Buildings\RepairableBuilding.cs" />
     <Compile Include="Traits\Harvester.cs" />
     <Compile Include="Traits\HarvesterHuskModifier.cs" />
     <Compile Include="Traits\LeavesHusk.cs" />
@@ -252,8 +246,6 @@
     <Compile Include="Scripting\Properties\PlayerProperties.cs" />
     <Compile Include="Scripting\Properties\TransportProperties.cs" />
     <Compile Include="Scripting\Properties\ChronosphereProperties.cs" />
-    <Compile Include="Render\WithRepairAnimation.cs" />
-    <Compile Include="Render\WithRepairOverlay.cs" />
     <Compile Include="Lint\CheckPlayers.cs" />
     <Compile Include="Lint\CheckActors.cs" />
     <Compile Include="Lint\CheckMapCordon.cs" />

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -78,7 +78,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Activities\CaptureActor.cs" />
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />
     <Compile Include="AI\BaseBuilder.cs" />
     <Compile Include="AI\HackyAI.cs" />
@@ -93,7 +92,6 @@
     <Compile Include="Activities\Leap.cs" />
     <Compile Include="Activities\RAHarvesterDockSequence.cs" />
     <Compile Include="Activities\Teleport.cs" />
-    <Compile Include="Activities\Transform.cs" />
     <Compile Include="AI\SupportPowerDecision.cs" />
     <Compile Include="Effects\GpsSatellite.cs" />
     <Compile Include="Effects\SatelliteLaunch.cs" />
@@ -104,10 +102,8 @@
     <Compile Include="AI\RushFuzzy.cs" />
     <Compile Include="AI\StateMachine.cs" />
     <Compile Include="Traits\Attack\AttackLeap.cs" />
-    <Compile Include="CaptureNotification.cs" />
     <Compile Include="Scripting\Properties\RepairableBuildingProperties.cs" />
     <Compile Include="C4Demolition.cs" />
-    <Compile Include="Capturable.cs" />
     <Compile Include="Traits\PaletteEffects\ChronoshiftPaletteEffect.cs" />
     <Compile Include="Traits\Chronoshiftable.cs" />
     <Compile Include="CrateSpawner.cs" />
@@ -129,7 +125,6 @@
     <Compile Include="Effects\Parachute.cs" />
     <Compile Include="EmitInfantryOnSell.cs" />
     <Compile Include="Invulnerable.cs" />
-    <Compile Include="Captures.cs" />
     <Compile Include="Lint\CheckActorReferences.cs" />
     <Compile Include="Lint\CheckSyncAnnotations.cs" />
     <Compile Include="Lint\CheckTraitPrerequisites.cs" />
@@ -148,8 +143,6 @@
     <Compile Include="Widgets\Logic\TabCompletionLogic.cs" />
     <Compile Include="Production.cs" />
     <Compile Include="ProductionBar.cs" />
-    <Compile Include="ProximityCaptor.cs" />
-    <Compile Include="ProximityCapturable.cs" />
     <Compile Include="Traits\Render\RenderJammerCircle.cs" />
     <Compile Include="Render\RenderBuildingWarFactory.cs" />
     <Compile Include="Render\RenderHarvester.cs" />
@@ -173,7 +166,6 @@
     <Compile Include="Traits\HarvesterHuskModifier.cs" />
     <Compile Include="Traits\LeavesHusk.cs" />
     <Compile Include="Traits\TargetableSubmarine.cs" />
-    <Compile Include="TransformOnCapture.cs" />
     <Compile Include="TransformOnPassenger.cs" />
     <Compile Include="Transforms.cs" />
     <Compile Include="Widgets\Logic\KickSpectatorsLogic.cs" />

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -175,8 +175,6 @@
     <Compile Include="SupportPowers\SupportPowerChargeBar.cs" />
     <Compile Include="SupportPowers\SupportPowerManager.cs" />
     <Compile Include="TraitsInterfaces.cs" />
-    <Compile Include="Traits\Buildings\Bridge.cs" />
-    <Compile Include="Traits\Buildings\BridgeHut.cs" />
     <Compile Include="Traits\Buildings\Fake.cs" />
     <Compile Include="Traits\Buildings\OreRefinery.cs" />
     <Compile Include="Traits\Buildings\PrimaryBuilding.cs" />
@@ -184,9 +182,7 @@
     <Compile Include="Traits\Harvester.cs" />
     <Compile Include="Traits\HarvesterHuskModifier.cs" />
     <Compile Include="Traits\LeavesHusk.cs" />
-    <Compile Include="Traits\RepairsBridges.cs" />
     <Compile Include="Traits\TargetableSubmarine.cs" />
-    <Compile Include="Traits\World\BridgeLayer.cs" />
     <Compile Include="TransformOnCapture.cs" />
     <Compile Include="TransformOnPassenger.cs" />
     <Compile Include="Transforms.cs" />
@@ -228,7 +224,6 @@
     <Compile Include="Traits\Infiltration\InfiltrateForSupportPower.cs" />
     <Compile Include="Traits\Infiltration\Infiltrates.cs" />
     <Compile Include="Widgets\Logic\ObserverShroudSelectorLogic.cs" />
-    <Compile Include="Activities\RepairBridge.cs" />
     <Compile Include="Lint\CheckSequences.cs" />
     <Compile Include="Widgets\Logic\SpawnSelectorTooltipLogic.cs" />
     <Compile Include="Widgets\Logic\ClientTooltipLogic.cs" />
@@ -344,5 +339,4 @@ cd "$(SolutionDir)thirdparty/"
 copy "FuzzyLogicLibrary.dll" "$(SolutionDir)"
 cd "$(SolutionDir)"</PostBuildEvent>
   </PropertyGroup>
-  <ItemGroup />
 </Project>

--- a/OpenRA.Mods.RA/Scripting/Properties/RepairableBuildingProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/RepairableBuildingProperties.cs
@@ -8,7 +8,7 @@
  */
 #endregion
 
-using OpenRA.Mods.RA.Traits;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/TransformOnPassenger.cs
+++ b/OpenRA.Mods.RA/TransformOnPassenger.cs
@@ -9,8 +9,8 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA

--- a/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
@@ -10,10 +10,10 @@
 
 using System;
 using System.Linq;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Widgets;
 using OpenRA.Mods.RA.Orders;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.RA.Widgets.Logic


### PR DESCRIPTION
After @reaperrr's big effort with the buildings, some things got a lot easier to move.
The PR is divided into 4 self-contained commits for those who find it easier to review commit-by-commit ;)

Also something I just thought - perhaps we should make all `Traits`, `Orders`, `Activities`, `Effects`, etc. in `Mods.Common` `public`? After all, the idea (one of them) is to provide people with an engine they can mod/use/build upon, right?
While traits can be used in YAMLs without being public (right?), they can't be used in third-party DLLs. Same for `Orders`, `Activities`, etc.
