### PR TITLE
Polished d2k

### DIFF
--- a/mods/d2k/rules/corrino.yaml
+++ b/mods/d2k/rules/corrino.yaml
@@ -3,15 +3,11 @@ CONYARDC:
 
 STARPORTC:
 	Inherits: ^STARPORT
-	Buildable:
-		Prerequisites: ~conyarda, radar
+	-Buildable:
 
 PALACEC:
 	Inherits: ^PALACE
-	Buildable:
-		Queue: Building
-		BuildPaletteOrder: 1000
-		Prerequisites: ~conyarda, research
+	-Buildable:
 	Building:
 		Footprint: =x= xxx xxx
 		Dimensions: 3,3
@@ -19,7 +15,4 @@ PALACEC:
 
 HEAVYC:
 	Inherits: ^HEAVY
-	Buildable:
-		Queue: Building
-		BuildPaletteOrder: 1100
-		Prerequisites: ~conyarda, refinery
+	-Buildable:

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -76,7 +76,7 @@ Vulcan:
 	ReloadDelay: 30
 	Range: 5c768
 	Report: VULCAN.AUD
-	ValidTargets: Ground, Air
+	ValidTargets: Ground
 	Projectile: Bullet
 		Speed: 1c256
 		ContrailLength: 3
@@ -87,7 +87,7 @@ Vulcan:
 		Spread: 96
 		Damage: 30
 		DeathType: 4
-		ValidTargets: Ground, Air
+		ValidTargets: Ground
 		Versus:
 			Wood: 0
 			Light: 60


### PR DESCRIPTION
- Fixed #7283
- Removed the `Buildable:` trait from the corrino buildings; fixes #7285 
