### PR TITLE
Speed up depth sorting of renderables.

### DIFF
--- a/OpenRA.Game/Graphics/Renderable.cs
+++ b/OpenRA.Game/Graphics/Renderable.cs
@@ -14,22 +14,6 @@ using System.Linq;
 
 namespace OpenRA.Graphics
 {
-	public class RenderableComparer : IComparer<IRenderable>
-	{
-		WorldRenderer wr;
-		public RenderableComparer(WorldRenderer wr)
-		{
-			this.wr = wr;
-		}
-
-		public int Compare(IRenderable x, IRenderable y)
-		{
-			var xOrder = wr.ScreenZPosition(x.Pos, x.ZOffset);
-			var yOrder = wr.ScreenZPosition(y.Pos, y.ZOffset);
-			return xOrder.CompareTo(yOrder);
-		}
-	}
-
 	public interface IRenderable
 	{
 		WPos Pos { get; }

--- a/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.RA/Orders/PlaceBuildingOrderGenerator.cs
@@ -127,11 +127,10 @@ namespace OpenRA.Mods.RA.Orders
 					initialized = true;
 				}
 
-				var comparer = new RenderableComparer(wr);
 				var offset = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(world, buildingInfo);
 				var previewRenderables = preview
 					.SelectMany(p => p.Render(wr, offset))
-					.OrderBy(r => r, comparer);
+					.OrderBy(WorldRenderer.RenderableScreenZPositionComparisonKey);
 
 				foreach (var r in previewRenderables)
 					yield return r;


### PR DESCRIPTION
By inlining the calls to ScreenZPosition in the compare method, we can cancel some terms around the comparison and improve performance. The comparer has been moved and renamed in order to make its function more obvious, and to help ensure the comparison stays in sync with the ScreenZPosition function.

This reduces time spent doing compares from 5.0% to 3.0%.
