### PR TITLE
Adjust UpgradeOverlay.ModifyRender to be more efficient.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Modifiers/UpgradeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/UpgradeOverlay.cs
@@ -30,11 +30,18 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
+			if (IsTraitDisabled)
+				return r;
+			return ModifiedRender(self, wr, r);
+		}
+
+		IEnumerable<IRenderable> ModifiedRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
 			foreach (var a in r)
 			{
 				yield return a;
 
-				if (!IsTraitDisabled && !a.IsDecoration)
+				if (!a.IsDecoration)
 					yield return a.WithPalette(wr.Palette(Info.Palette))
 						.WithZOffset(a.ZOffset + 1)
 						.AsDecoration();


### PR DESCRIPTION
When IsTraitDisabled is set, ModifyRender doesn't actually alter the sequence, so we can just return it directly and avoid adding another layer of enumerable. If it is unset, then the modifying enumerable has one less condition to check inside the loop.
