### PR TITLE
Add repairing and unit repaired sounds to ra service depo

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/RepairsUnits.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairsUnits.cs
@@ -14,9 +14,18 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class RepairsUnitsInfo : TraitInfo<RepairsUnits>
 	{
-		public readonly int ValuePercentage = 20; // charge 20% of the unit value to fully repair
+		[Desc("Cost in % of the unit value to fully repair the unit.")]
+		public readonly int ValuePercentage = 20;
 		public readonly int HpPerStep = 10;
-		public readonly int Interval = 24; // Ticks
+
+		[Desc("Time (in ticks) between two repair steps.")]
+		public readonly int Interval = 24;
+
+		[Desc("The sound played when starting to repair a unit.")]
+		public readonly string StartRepairingNotification = "Repairing";
+
+		[Desc("The sound played when repairing a unit is done.")]
+		public readonly string FinishRepairingNotification = null;
 	}
 
 	public class RepairsUnits { }

--- a/mods/d2k/notifications.yaml
+++ b/mods/d2k/notifications.yaml
@@ -34,6 +34,7 @@ Speech:
 		WormSign: WSIGN
 		WormAttack: WATTK
 		EnemyUnitsApproaching: ENEMY
+		UnitRepaired: GANEW
 
 Sounds:
 	DefaultVariant: .WAV

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -585,6 +585,7 @@ WALL:
 	RepairsUnits:
 		Interval: 15
 		ValuePercentage: 50
+		FinishRepairingNotification: UnitRepaired
 	RallyPoint:
 		RallyPoint: 1,3
 	ProvidesCustomPrerequisite:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -142,6 +142,7 @@ SPEN:
 	PrimaryBuilding:
 	-EmitInfantryOnSell:
 	RepairsUnits:
+		FinishRepairingNotification: UnitRepaired
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -219,6 +220,7 @@ SYRD:
 	PrimaryBuilding:
 	-EmitInfantryOnSell:
 	RepairsUnits:
+		FinishRepairingNotification: UnitRepaired
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -1435,6 +1437,7 @@ FIX:
 	RallyPoint:
 	RepairsUnits:
 		Interval: 10
+		FinishRepairingNotification: UnitRepaired
 	WithRepairAnimation:
 	Power:
 		Amount: -30


### PR DESCRIPTION
In TD and D2K it currently only plays the "repairing" sound when entering a service depo
(because they don't have "unit repaired" notifications).
Should that stay that way, or should I use `StartRepairingNotification = null;` as default?
