### PR TITLE
Carryall edge spawn & Harvester delivery

### DIFF
--- a/OpenRA.Mods.D2k/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.D2k/Activities/DeliverUnit.cs
@@ -7,7 +7,9 @@
  * see COPYING.
  */
 #endregion
-
+using System;
+using System.Drawing;
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -17,35 +19,36 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Activities
 {
-	public class CarryUnit : Activity
+	public class DeliverUnit : Activity
 	{
 		readonly Actor self;
-		readonly Actor carryable;
+		readonly Actor toDeliver;
 		readonly IMove movement;
-		readonly Carryable c;
-		readonly AutoCarryall aca;
+		readonly Carryable carryable;
+		readonly Carryall aca;
 		readonly Helicopter helicopter;
 		readonly IPositionable positionable;
-		readonly IFacing cFacing; // Carryable facing
-		readonly IFacing sFacing; // Self facing
+		readonly IFacing carryableFacing;
+		readonly IFacing selfFacing;
+		readonly CPos destination;
 
-		enum State { Intercept, LockCarryable, MoveToCarryable, Turn, Pickup, Transport, Land, Release, Takeoff, Done }
+		enum State { Transport, Land, Release, Takeoff, Done }
 
 		State state;
 
-		public CarryUnit(Actor self, Actor carryable)
+		public DeliverUnit(Actor self)
 		{
+			aca = self.Trait<Carryall>();
 			this.self = self;
-			this.carryable = carryable;
+			this.toDeliver = aca.Carrying;
 			movement = self.Trait<IMove>();
-			c = carryable.Trait<Carryable>();
-			aca = self.Trait<AutoCarryall>();
+			carryable = toDeliver.Trait<Carryable>();
 			helicopter = self.Trait<Helicopter>();
-			positionable = carryable.Trait<IPositionable>();
-			cFacing = carryable.Trait<IFacing>();
-			sFacing = self.Trait<IFacing>();
-
-			state = State.Intercept;
+			positionable = toDeliver.Trait<IPositionable>();
+			carryableFacing = toDeliver.Trait<IFacing>();
+			selfFacing = self.Trait<IFacing>();
+			this.destination = carryable.Destination;
+			state = State.Transport;
 		}
 
 		// Find a suitable location to drop our carryable
@@ -77,7 +80,7 @@ namespace OpenRA.Mods.D2k.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (carryable.IsDead)
+			if (toDeliver.IsDead || aca.isCarrying == false)
 			{
 				aca.UnreserveCarryable();
 				return NextActivity;
@@ -85,58 +88,10 @@ namespace OpenRA.Mods.D2k.Activities
 
 			switch (state)
 			{
-				case State.Intercept: // Move towards our carryable
-
-					state = State.LockCarryable;
-					return Util.SequenceActivities(movement.MoveWithinRange(Target.FromActor(carryable), WRange.FromCells(4)), this);
-
-				case State.LockCarryable:
-					// Last check
-					if (c.StandbyForPickup(self))
-					{
-						state = State.MoveToCarryable;
-						return this;
-					}
-					else
-					{
-						// We got cancelled
-						aca.UnreserveCarryable();
-						return NextActivity;
-					}
-
-				case State.MoveToCarryable: // We arrived, move on top
-
-					if (self.Location == carryable.Location)
-					{
-						state = State.Turn;
-						return this;
-					}
-					else
-						return Util.SequenceActivities(movement.MoveTo(carryable.Location, 0), this);
-
-				case State.Turn: // Align facing and Land
-
-					if (sFacing.Facing != cFacing.Facing)
-						return Util.SequenceActivities(new Turn(self, cFacing.Facing), this);
-					else
-					{
-						state = State.Pickup;
-						return Util.SequenceActivities(new HeliLand(false), new Wait(10), this);
-					}
-
-				case State.Pickup:
-
-					// Remove our carryable from world
-					self.World.AddFrameEndTask(w => carryable.World.Remove(carryable));
-
-					aca.AttachCarryable(carryable);
-					state = State.Transport;
-					return this;
-
 				case State.Transport:
 
 					// Move self to destination
-					var targetl = GetLocationToDrop(c.Destination);
+					var targetl = GetLocationToDrop(destination);
 
 					state = State.Land;
 					return Util.SequenceActivities(movement.MoveTo(targetl, 0), this);
@@ -151,11 +106,9 @@ namespace OpenRA.Mods.D2k.Activities
 
 					if (HeliFly.AdjustAltitude(self, helicopter, helicopter.Info.LandAltitude))
 						return this;
-					else
-					{
-						state = State.Release;
-						return Util.SequenceActivities(new Wait(15), this);
-					}
+
+					state = State.Release;
+					return Util.SequenceActivities(new Wait(15), this);
 
 				case State.Release:
 
@@ -165,23 +118,23 @@ namespace OpenRA.Mods.D2k.Activities
 						return this;
 					}
 
-					positionable.SetPosition(carryable, self.Location, SubCell.FullCell);
+					positionable.SetPosition(toDeliver, self.Location, SubCell.FullCell);
 
-					cFacing.Facing = sFacing.Facing;
+					carryableFacing.Facing = selfFacing.Facing;
 
 					// Put back into world
-					self.World.AddFrameEndTask(w => carryable.World.Add(carryable));
+					self.World.AddFrameEndTask(w => toDeliver.World.Add(toDeliver));
 
 					// Unlock carryable
 					aca.CarryableReleased();
-					c.Dropped();
+					carryable.Dropped();
 
 					state = State.Done;
 					return Util.SequenceActivities(new Wait(10), this);
 
 				case State.Done:
 
-					self.Trait<AutoCarryall>().UnreserveCarryable();
+					self.Trait<Carryall>().UnreserveCarryable();
 					return NextActivity;
 			}
 

--- a/OpenRA.Mods.D2k/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.D2k/Activities/PickupUnit.cs
@@ -1,0 +1,120 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+using System;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.D2k.Traits;
+using OpenRA.Mods.RA;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.RA.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2k.Activities
+{
+	public class PickupUnit : Activity
+	{
+		readonly Actor toPickup;
+		readonly IMove movement;
+		readonly Carryable carryable;
+		readonly Carryall aca;
+		readonly Helicopter helicopter;
+		readonly IFacing carryableFacing;
+		readonly IFacing selfFacing;
+
+		enum State { Intercept, LockCarryable, MoveToCarryable, Turn, Pickup, TakeOff }
+
+		State state;
+
+		public PickupUnit(Actor self, Actor client)
+		{
+			this.toPickup = client;
+			movement = self.Trait<IMove>();
+			carryable = client.Trait<Carryable>();
+			aca = self.Trait<Carryall>();
+			helicopter = self.Trait<Helicopter>();
+			carryableFacing = client.Trait<IFacing>();
+			selfFacing = self.Trait<IFacing>();
+			state = State.Intercept;
+		}
+
+		public override Activity Tick(Actor self)
+		{
+			if (toPickup.IsDead)
+			{
+				aca.UnreserveCarryable();
+				return NextActivity;
+			}
+
+			switch (state)
+			{
+				case State.Intercept: // Move towards our carryable
+
+					state = State.LockCarryable;
+					return Util.SequenceActivities(movement.MoveWithinRange(Target.FromActor(toPickup), WRange.FromCells(4)), this);
+
+				case State.LockCarryable:
+					// Last check
+					if (carryable.StandbyForPickup(self))
+					{
+						state = State.MoveToCarryable;
+						return this;
+					} 
+
+					// We got cancelled
+					aca.UnreserveCarryable();
+					return NextActivity;
+
+				case State.MoveToCarryable: // We arrived, move on top
+
+					if (self.Location == toPickup.Location)
+					{
+						state = State.Turn;
+						return this;
+					}
+
+					return Util.SequenceActivities(movement.MoveTo(toPickup.Location, 0), this);
+
+				case State.Turn: // Align facing and Land
+
+					if (selfFacing.Facing != carryableFacing.Facing)
+						return Util.SequenceActivities(new Turn(self, carryableFacing.Facing), this);
+			
+					state = State.Pickup;
+					return Util.SequenceActivities(new HeliLand(false), new Wait(10), this);
+
+				case State.Pickup:
+
+					// Remove our carryable from world
+					self.World.AddFrameEndTask(w => toPickup.World.Remove(toPickup));
+
+					aca.AttachCarryable(toPickup);
+					state = State.TakeOff;
+					return this;
+
+				case State.TakeOff:
+
+					if (HeliFly.AdjustAltitude(self, helicopter, helicopter.Info.CruiseAltitude))
+						return this;
+
+					return NextActivity;
+			}
+
+			return NextActivity;
+		}
+
+		public override void Cancel(Actor self)
+		{
+			// TODO: Drop the unit at the nearest available cell
+		}
+	}
+}

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -68,11 +68,12 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Activities\CarryUnit.cs" />
+    <Compile Include="Activities\PickupUnit.cs" />
+    <Compile Include="Activities\DeliverUnit.cs" />
     <Compile Include="Activities\SwallowActor.cs" />
     <Compile Include="SpriteLoaders\R8Loader.cs" />
     <Compile Include="Traits\AttackSwallow.cs" />
-    <Compile Include="Traits\AutoCarryall.cs" />
+    <Compile Include="Traits\Carryall.cs" />
     <Compile Include="Traits\Buildings\DamagedWithoutFoundation.cs" />
     <Compile Include="Traits\Buildings\LaysTerrain.cs" />
     <Compile Include="Traits\Carryable.cs" />
@@ -96,6 +97,9 @@
     <Compile Include="UtilityCommands\D2kMapImporter.cs" />
     <Compile Include="UtilityCommands\ImportD2kMapCommand.cs" />
     <Compile Include="Traits\Render\WithAttackOverlay.cs" />
+    <Compile Include="Widgets\Logic\SlidingRadarBinLogic.cs" />
+    <Compile Include="Traits\ProductionFromMapEdge.cs" />
+    <Compile Include="Traits\Buildings\DeliverFreeActor.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.D2k/Traits/Buildings/DeliverFreeActor.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/DeliverFreeActor.cs
@@ -1,0 +1,97 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.D2k.Activities;
+using OpenRA.Mods.RA.Activities;
+using OpenRA.Mods.RA.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2k.Traits
+{
+	[Desc("Delivers a spice harvester after construction of this building. Optionally provides the harvester insurance function.")]
+	public class DeliverFreeActorInfo : ITraitInfo
+	{
+		[ActorReference]
+		[Desc("Name of actor (use HARV if this trait is for refineries)")]
+		public readonly string Actor = null;
+
+		[Desc("What the unit should start doing. Warning: If this is not a harvester", "it will break if you use FindResources.")]
+		public readonly string InitialActivity = null;
+
+		[Desc("Offset relative to structure-center in 2D (e.g. 1, 2)")]
+		public readonly CVec DeliveryOffset = CVec.Zero;
+
+		[ActorReference]
+		[Desc("Name of the carrying actor. This actor must have the Carryall trait")]
+		public readonly string CarryingActor = null;
+
+		public object Create(ActorInitializer init) { return new DeliverFreeActor(init.Self, this); }
+	}
+
+	public class DeliverFreeActor
+	{
+		readonly Actor self;
+
+		public DeliverFreeActor(Actor self, DeliverFreeActorInfo info)
+		{
+			this.self = self;
+
+			// Get a carryall spawn location
+			var location = ProductionFromMapEdge.GetEdgeCell(self.Location);
+			var spawn = self.World.Map.CenterOfCell(location);
+
+			var initialFacing = self.World.Map.FacingBetween(location, self.Location, 0);
+
+			// If aircraft, spawn at cruise altitude
+			var ai = self.World.Map.Rules.Actors[info.CarryingActor.ToLower()].Traits.GetOrDefault<AircraftInfo>();
+			if (ai != null)
+				spawn += new WVec(0, 0, ai.CruiseAltitude.Range);
+
+			// Create Carryall actor
+			var carrier = self.World.CreateActor(false, info.CarryingActor, new TypeDictionary
+			{
+				new LocationInit(location),
+				new CenterPositionInit(spawn),
+				new OwnerInit(self.Owner),
+				new FacingInit(initialFacing)
+			});
+
+			// Create harvester actor
+			var harv = self.World.CreateActor(false, info.Actor, new TypeDictionary
+			{
+				new OwnerInit(self.Owner),
+			});
+
+			DoHarvesterDelivery(self.Location + info.DeliveryOffset, harv, carrier, info.InitialActivity);
+		}
+
+		public void DoHarvesterDelivery(CPos location, Actor client, Actor carrier, string clientInitialActivity)
+		{
+			if (clientInitialActivity != null)
+				client.QueueActivity(Game.CreateObject<Activity>(clientInitialActivity));
+
+			client.Trait<Carryable>().Destination = location;
+
+			carrier.Trait<Carryall>().AttachCarryable(client);
+
+			carrier.QueueActivity(new DeliverUnit(carrier));
+			carrier.QueueActivity(new HeliFly(carrier, Target.FromCell(self.World, self.World.Map.ChooseRandomEdgeCell(self.World.SharedRandom))));
+			carrier.QueueActivity(new RemoveSelf());
+
+			self.World.AddFrameEndTask(w => self.World.Add(carrier));
+		}
+	}
+}

--- a/OpenRA.Mods.D2k/Traits/Carryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryable.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
-	[Desc("Can be carried by units with the trait `AutoCarryall`.")]
+	[Desc("Can be carried by units with the trait `Carryall`.")]
 	public class CarryableInfo : ITraitInfo
 	{
 		[Desc("Required distance away from destination before requesting a pickup.")]
@@ -62,15 +62,14 @@ namespace OpenRA.Mods.D2k.Traits
 
 			Destination = destination;
 			this.afterLandActivity = afterLandActivity;
-
-			if (locked || Reserved)
-				return;
-
 			WantsTransport = true;
 
+			if (locked || Reserved)
+					return;
+
 			// Inform all idle carriers
-			var carriers = self.World.ActorsWithTrait<AutoCarryall>()
-				.Where(c => !c.Trait.Busy && !c.Actor.IsDead && c.Actor.Owner == self.Owner)
+			var carriers = self.World.ActorsWithTrait<Carryall>()
+				.Where(c => !c.Trait.Busy && !c.Actor.IsDead && c.Actor.Owner == self.Owner && c.Actor.IsInWorld)
 				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
 
 			foreach (var carrier in carriers)
@@ -90,7 +89,7 @@ namespace OpenRA.Mods.D2k.Traits
 			WantsTransport = false;
 			afterLandActivity = null;
 
-			// TODO: We could implement something like a carrier.Trait<AutoCarryAll>().CancelTransportNotify(self) and call it here
+			// TODO: We could implement something like a carrier.Trait<CarryAll>().CancelTransportNotify(self) and call it here
 		}
 
 		// We do not handle Harvested notification
@@ -99,8 +98,8 @@ namespace OpenRA.Mods.D2k.Traits
 		public Actor GetClosestIdleCarrier()
 		{
 			// Find carriers
-			var carriers = self.World.ActorsWithTrait<AutoCarryall>()
-				.Where(p => p.Actor.Owner == self.Owner && !p.Trait.Busy)
+			var carriers = self.World.ActorsWithTrait<Carryall>()
+				.Where(p => p.Actor.Owner == self.Owner && !p.Trait.Busy && p.Actor.IsInWorld)
 				.Select(h => h.Actor);
 
 			return WorldUtils.ClosestTo(carriers, self);

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -16,39 +16,49 @@ using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.D2k.Activities;
 using OpenRA.Mods.RA;
 using OpenRA.Mods.RA.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Automatically transports harvesters with the Carryable trait between resource fields and refineries")]
-	public class AutoCarryallInfo : ITraitInfo, Requires<IBodyOrientationInfo>
+	public class CarryallInfo : ITraitInfo, Requires<IBodyOrientationInfo>
 	{
-		public object Create(ActorInitializer init) { return new AutoCarryall(init.Self, this); }
+		[Desc("Set to false when the carryall should not automatically get new jobs")]
+		public readonly bool Automatic = true;
+
+		public object Create(ActorInitializer init) { return new Carryall(init.Self, this); }
 	}
 
-	public class AutoCarryall : INotifyBecomingIdle, INotifyKilled, ISync, IRender
+	public class Carryall : INotifyBecomingIdle, INotifyKilled, ISync, IRender
 	{
 		readonly Actor self;
 		readonly WRange carryHeight;
+		readonly CarryallInfo info;
 
 		// The actor we are currently carrying.
-		[Sync] Actor carrying;
-		bool isCarrying;
+		[Sync] public Actor Carrying { get; internal set; }
+		public bool isCarrying { get; internal set; }
 
 		// TODO: Use ActorPreviews so that this can support actors with multiple sprites
 		Animation anim;
 
 		public bool Busy { get; internal set; }
 
-		public AutoCarryall(Actor self, AutoCarryallInfo info)
+		public Carryall(Actor self, CarryallInfo info)
 		{
 			this.self = self;
 			carryHeight = self.Trait<Helicopter>().Info.LandAltitude;
+			this.info = info;
+			Busy = false;
+
+			isCarrying = false;
 		}
 
 		public void OnBecomingIdle(Actor self)
 		{
-			FindCarryableForTransport();
+			if (info.Automatic)
+				FindCarryableForTransport();
 
 			if (!Busy)
 				self.QueueActivity(new HeliFlyCircle(self));
@@ -57,12 +67,13 @@ namespace OpenRA.Mods.D2k.Traits
 		// A carryable notifying us that he'd like to be carried
 		public bool RequestTransportNotify(Actor carryable)
 		{
-			if (Busy)
+			if (Busy || !info.Automatic)
 				return false;
 
 			if (ReserveCarryable(carryable))
 			{
-				self.QueueActivity(false, new CarryUnit(self, carryable));
+				self.QueueActivity(false, new PickupUnit(self, carryable));
+				self.QueueActivity(true, new DeliverUnit(self));
 				return true;
 			}
 
@@ -71,6 +82,9 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void FindCarryableForTransport()
 		{
+			if (!self.IsInWorld)
+				return;
+
 			// get all carryables who want transport
 			var carryables = self.World.ActorsWithTrait<Carryable>()
 				.Where(p =>
@@ -101,7 +115,8 @@ namespace OpenRA.Mods.D2k.Traits
 				// Check if its actually me who's the best candidate
 				if (p.Trait.GetClosestIdleCarrier() == self && ReserveCarryable(p.Actor))
 				{
-					self.QueueActivity(false, new CarryUnit(self, p.Actor));
+					self.QueueActivity(false, new PickupUnit(self, p.Actor));
+					self.QueueActivity(true, new DeliverUnit(self));
 					break;
 				}
 			}
@@ -112,7 +127,7 @@ namespace OpenRA.Mods.D2k.Traits
 		{
 			if (carryable.Trait<Carryable>().Reserve(self))
 			{
-				carrying = carryable;
+				Carrying = carryable;
 				Busy = true;
 				return true;
 			}
@@ -123,12 +138,12 @@ namespace OpenRA.Mods.D2k.Traits
 		// Unreserve the carryable
 		public void UnreserveCarryable()
 		{
-			if (carrying != null)
+			if (Carrying != null)
 			{
-				if (carrying.IsInWorld && !carrying.IsDead)
-					carrying.Trait<Carryable>().UnReserve(self);
+				if (Carrying.IsInWorld && !Carrying.IsDead)
+					Carrying.Trait<Carryable>().UnReserve(self);
 
-				carrying = null;
+				Carrying = null;
 			}
 
 			Busy = false;
@@ -137,10 +152,12 @@ namespace OpenRA.Mods.D2k.Traits
 		// INotifyKilled
 		public void Killed(Actor self, AttackInfo e)
 		{
-			if (carrying != null)
+			if (Carrying != null)
 			{
-				if (isCarrying && carrying.IsInWorld && !carrying.IsDead)
-					carrying.Kill(e.Attacker);
+				if (isCarrying && Carrying.IsInWorld && !Carrying.IsDead)
+					Carrying.Kill(e.Attacker);
+
+				Carrying = null;
 			}
 
 			UnreserveCarryable();
@@ -150,6 +167,8 @@ namespace OpenRA.Mods.D2k.Traits
 		public void AttachCarryable(Actor carryable)
 		{
 			isCarrying = true;
+			Busy = true;
+			Carrying = carryable;
 
 			// Create a new animation for our carryable unit
 			anim = new Animation(self.World, RenderSprites.GetImage(carryable.Info), RenderSprites.MakeFacingFunc(self));
@@ -161,6 +180,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public void CarryableReleased()
 		{
 			isCarrying = false;
+
 			anim = null;
 		}
 
@@ -170,7 +190,7 @@ namespace OpenRA.Mods.D2k.Traits
 			if (anim != null && !self.World.FogObscures(self))
 			{
 				anim.Tick();
-				var renderables = anim.Render(self.CenterPosition + new WVec(0, 0, -carryHeight.Range), wr.Palette("player" + carrying.Owner.InternalName));
+				var renderables = anim.Render(self.CenterPosition + new WVec(0, 0, -carryHeight.Range), wr.Palette("player" + Carrying.Owner.InternalName));
 
 				foreach (var rr in renderables)
 					yield return rr;

--- a/OpenRA.Mods.D2k/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.D2k/Traits/ProductionFromMapEdge.cs
@@ -1,0 +1,140 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2014 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.RA;
+using OpenRA.Mods.RA.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2k.Traits
+{
+	[Desc("Produce the unit on map edge or under shroud/fog and move into play.")]
+	public class ProductionFromMapEdgeInfo : ProductionInfo
+	{
+		public override object Create(ActorInitializer init) { return new ProductionFromMapEdge(this, init.Self); }
+	}
+
+	public class ProductionFromMapEdge : Production
+	{
+		public ProductionFromMapEdge(ProductionFromMapEdgeInfo info, Actor self)
+			: base(info, self) { }
+
+		public override bool Produce(Actor self, ActorInfo producee, string raceVariant)
+		{
+			// Get a spawn cell
+			var location = GetEdgeCell(self.Location);
+			var pos = self.World.Map.CenterOfCell(location);
+
+			var initialFacing = self.World.Map.FacingBetween(location, self.Location, 0);
+
+			// If aircraft, spawn at cruise altitude
+			var ai = producee.Traits.WithInterface<AircraftInfo>().FirstOrDefault();
+			if (ai != null)
+				pos += new WVec(0, 0, ai.CruiseAltitude.Range);
+
+			self.World.AddFrameEndTask(w =>
+			{
+				var td = new TypeDictionary
+				{
+					new OwnerInit(self.Owner),
+					new LocationInit(location),
+					new CenterPositionInit(pos),
+					new FacingInit(initialFacing)
+				};
+
+				if (raceVariant != null)
+					td.Add(new RaceInit(raceVariant));
+
+				var newUnit = self.World.CreateActor(producee.Name, td);
+
+				var move = newUnit.TraitOrDefault<IMove>();
+				if (move != null)
+					newUnit.QueueActivity(move.MoveIntoWorld(newUnit, self.Location));
+
+				newUnit.SetTargetLine(Target.FromCell(self.World, self.Location), Color.Green, false);
+
+				if (!self.IsDead)
+					foreach (var t in self.TraitsImplementing<INotifyProduction>())
+						t.UnitProduced(self, newUnit, self.Location);
+
+				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
+				foreach (var notify in notifyOthers)
+					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
+
+				var bi = newUnit.Info.Traits.GetOrDefault<BuildableInfo>();
+				if (bi != null && bi.InitialActivity != null)
+					newUnit.QueueActivity(Game.CreateObject<Activity>(bi.InitialActivity));
+
+				foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
+					t.BuildingComplete(newUnit);
+			});
+
+			return true;
+		}
+
+		public static CPos GetEdgeCell(CPos toCell)
+		{
+			// TODO: Implement edge cell selection
+			return CPos.Zero;
+		}
+
+		// Gives a (1) cell that is invisible due to fog, or if none (2) a cell that has not been explored yet (shrouded) or as a last resort (3) a cell on map edge.
+		/*public static CPos GetNearestInvisibleCell(Player player, CPos toCell)
+		{
+			// Get list of players against wich a shroud/fog test should be done
+			var checkplayers = player.World.Players
+				.Where(p => p.Playable);
+
+			// Please note hack: World.LobbyInfo.GlobalSettings.Fog returns wrong value for shellmap. Therefore skip to edge spawn on shellmap.
+
+			// Get the closest fogged cell
+			if (player.Shroud.FogEnabled && player.World.Type == WorldType.Regular)
+			{
+				var location = player.World.Map.Cells.Where(c => CheckFogged(c, checkplayers) == true).OrderBy(c => (c - toCell).LengthSquared).FirstOrDefault();
+
+				if (location != CPos.Zero)
+					return location;
+			}
+
+			// Get the closest shrouded cell
+			if (player.Shroud.ShroudEnabled && player.World.Type == WorldType.Regular)
+			{
+				var location = player.World.Map.Cells.Where(c => CheckUnexplored(c, checkplayers) == true).OrderBy(c => (c - toCell).LengthSquared).FirstOrDefault();
+
+				if (location != CPos.Zero)
+					return location;
+			}
+
+			// Last resort
+			return player.World.Map.ChooseRandomEdgeCell(player.World.SharedRandom);
+		}*/
+
+		// True when none of the players can see the cell
+		/*static bool CheckFogged(CPos c, IEnumerable<Player> players)
+		{
+			return !players.Any(p => p.Shroud.IsVisible(c));
+		}*/
+
+		// True when none of the players have explored the cell
+		/*static bool CheckUnexplored(CPos c, IEnumerable<Player> players)
+		{
+			return !players.Any(p => p.Shroud.IsExplored(c));
+		}*/
+
+
+	}
+}

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -127,9 +127,9 @@ Rules:
 		LuaScript:
 			Scripts: shellmap.lua
 	REFA:
-		-FreeActor:
+		-DeliverFreeActor:
 	CARRYALLA:
-		-AutoCarryall:
+		-Carryall:
 		Helicopter:
 			CruiseAltitude: 2048
 			LandAltitude: 512

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -27,7 +27,15 @@
 	LeavesHusk:
 		HuskActor: CARRYALL.Husk
 	-Selectable:
-	AutoCarryall:
+	Carryall:
+
+CARRYALL.reinforce:
+	Inherits: ^CARRYALL
+	-Buildable:
+	Carryall:
+		Automatic: false
+	RenderUnit:
+		Image: carryall
 
 FRIGATE:
 	ParaDrop:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -181,11 +181,11 @@ CONCRETEB:
 		Capacity: 2000
 	CustomSellValue:
 		Value: 500
-	FreeActor:
+	DeliverFreeActor:
 		Actor: HARVESTER
 		InitialActivity: FindResources
-		SpawnOffset: 2,1
-		Facing: 160
+		DeliveryOffset: 2,1
+		CarryingActor: CARRYALL.reinforce
 	ProvidesCustomPrerequisite:
 		Prerequisite: refinery
 	WithDockingOverlay@SMOKE:
@@ -606,11 +606,8 @@ WALL:
 	Tooltip:
 		Name: High Tech Facility
 		Description: Unlocks advanced technology
-	Production:
+	ProductionFromMapEdge:
 		Produces: Aircraft
-	Exit:
-		SpawnOffset: 0,0,728
-		ExitCell: 0,0
 	Building:
 		Footprint: _x_ xxx xxx
 		Dimensions: 3,3


### PR DESCRIPTION
This spawns the Carryall under either fog, shroud or -when that's not available- at the map edge.

It has already been debated whether that's the way to go, but looking at original d2k I really believe this is the best way. 

Next PR would be harvester insurance (in case of worm frenzy)
