### PR TITLE
Make global chat the default mode in the ingame chat widget

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/IngameChatLogic.cs
@@ -49,7 +49,6 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 
 			var players = world.Players.Where(p => p != world.LocalPlayer && !p.NonCombatant && !p.IsBot);
 			disableTeamChat = world.LocalPlayer == null || world.LobbyInfo.IsSinglePlayer || !players.Any(p => p.IsAlliedWith(world.LocalPlayer));
-			teamChat = !disableTeamChat;
 
 			tabCompletion.Commands = chatTraits.OfType<ChatCommands>().SelectMany(x => x.Commands.Keys).ToList();
 			tabCompletion.Names = orderManager.LobbyInfo.Clients.Select(c => c.Name).Distinct().ToList();


### PR DESCRIPTION
Currently, the in-game chat widget starts off in team chat mode. This changes it so that global chat is selected and alt-tab has to be used to switch to team chat.
