### PR TITLE
Vastly improve shroud rendering performance.

### DIFF
--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Drawing;
 
 namespace OpenRA.Graphics
@@ -49,6 +50,17 @@ namespace OpenRA.Graphics
 			}
 		}
 
+		void SetRenderStateForSprite(Sprite s)
+		{
+			renderer.CurrentBatchRenderer = this;
+
+			if (s.Sheet != currentSheet || s.BlendMode != currentBlend || nv + 4 > renderer.TempBufferSize)
+				Flush();
+
+			currentBlend = s.BlendMode;
+			currentSheet = s.Sheet;
+		}
+
 		public void DrawSprite(Sprite s, float2 location, PaletteReference pal)
 		{
 			DrawSprite(s, location, pal.TextureIndex, s.Size);
@@ -61,19 +73,7 @@ namespace OpenRA.Graphics
 
 		void DrawSprite(Sprite s, float2 location, float paletteTextureIndex, float2 size)
 		{
-			renderer.CurrentBatchRenderer = this;
-
-			if (s.Sheet != currentSheet)
-				Flush();
-
-			if (s.BlendMode != currentBlend)
-				Flush();
-
-			if (nv + 4 > renderer.TempBufferSize)
-				Flush();
-
-			currentBlend = s.BlendMode;
-			currentSheet = s.Sheet;
+			SetRenderStateForSprite(s);
 			Util.FastCreateQuad(vertices, location + s.FractionalOffset * size, s, paletteTextureIndex, nv, size);
 			nv += 4;
 		}
@@ -91,20 +91,15 @@ namespace OpenRA.Graphics
 
 		public void DrawSprite(Sprite s, float2 a, float2 b, float2 c, float2 d)
 		{
-			renderer.CurrentBatchRenderer = this;
-
-			if (s.Sheet != currentSheet)
-				Flush();
-
-			if (s.BlendMode != currentBlend)
-				Flush();
-
-			if (nv + 4 > renderer.TempBufferSize)
-				Flush();
-
-			currentSheet = s.Sheet;
-			currentBlend = s.BlendMode;
+			SetRenderStateForSprite(s);
 			Util.FastCreateQuad(vertices, a, b, c, d, s, 0, nv);
+			nv += 4;
+		}
+
+		public void DrawSprite(Sprite s, Vertex[] sourceVertices, int offset)
+		{
+			SetRenderStateForSprite(s);
+			Array.Copy(sourceVertices, offset, vertices, nv, 4);
 			nv += 4;
 		}
 


### PR DESCRIPTION
Changes in the shroud are now tracked. If a cell changes it will mark itself and its neighbours as dirty. During the render phase all dirty cells will have their vertices calculated and cached. If a cell is not dirty, the pre-calculated vertices are retrieved from cache. Then the sprite renderer is provided the sprite and the pre-calculated vertices to draw.

This prevents constant recalculation of vertices for the shroud in the render phase, requiring instead only dirty cells in the visible area. The update phase is reduced to a practical noop, instead incurring the cost only of changed cells each frame, rather than checking the visible area.

---

This is a revival of #7095 with some updates. I initially thought @pchote's proof on concept would be the same for performance, and it was far less code so I thought it'd be a better choice.

Sadly it's not. You need to update the cell and its 8 neighbours. If you generate vertices right away you end up doing a substantial amount of work that can easily be avoided by delaying the work until you actually need to render the vertices.

I tested this version, and saw total CPU time for rendering the shroud drop from 28% (told you it was expensive!) to 9% of all CPU time spent.

In theory, this means if you get a solid 50 fps, you could now be getting 60 fps instead!
