### PR TITLE
Fixed the initial turret preview facing

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -39,10 +39,13 @@ namespace OpenRA.Mods.Common.Traits
 			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 
-			var anim = new Animation(init.World, image, () => t.InitialFacing);
+			var bodyFacing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
+			var turretFacing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit, int>() : bodyFacing;
+
+			var anim = new Animation(init.World, image, () => turretFacing);
 			anim.Play(Sequence);
 
-			var orientation = body.QuantizeOrientation(new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(t.InitialFacing)), facings);
+			var orientation = body.QuantizeOrientation(new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(bodyFacing)), facings);
 			var offset = body.LocalToWorld(t.Offset.Rotate(orientation));
 			yield return new SpriteActorPreview(anim, offset, offset.Y + offset.Z + 1, p, rs.Scale);
 		}


### PR DESCRIPTION
Split from https://github.com/OpenRA/OpenRA/pull/4496 as this is useful elsewhere.
