### PR TITLE
Prevent EndOfStreamException being thrown in ServerOrder.Deserialize()

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -431,7 +431,6 @@ namespace OpenRA.Server
 					InterpretServerOrder(conn, so);
 				}
 			}
-			catch (EndOfStreamException) { }
 			catch (NotImplementedException) { }
 		}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -420,9 +420,8 @@ namespace OpenRA.Server
 
 		void InterpretServerOrders(Connection conn, byte[] data)
 		{
-			var ms = new MemoryStream(data);
-			var br = new BinaryReader(ms);
-
+			using (var ms = new MemoryStream(data))
+			using (var br = new BinaryReader(ms))
 			try
 			{
 				for (;;)

--- a/OpenRA.Game/Server/ServerOrder.cs
+++ b/OpenRA.Game/Server/ServerOrder.cs
@@ -26,6 +26,11 @@ namespace OpenRA.Server
 
 		public static ServerOrder Deserialize(BinaryReader r)
 		{
+			if (r.BaseStream.Position == r.BaseStream.Length)
+			{
+				return null;
+			}
+
 			byte b;
 			switch (b = r.ReadByte())
 			{
@@ -48,13 +53,14 @@ namespace OpenRA.Server
 
 		public byte[] Serialize()
 		{
-			var ms = new MemoryStream();
-			var bw = new BinaryWriter(ms);
-
-			bw.Write((byte)0xfe);
-			bw.Write(Name);
-			bw.Write(Data);
-			return ms.ToArray();
+			using (var ms = new MemoryStream())
+			using (var bw = new BinaryWriter(ms))
+			{
+				bw.Write((byte)0xfe);
+				bw.Write(Name);
+				bw.Write(Data);
+				return ms.ToArray();
+			}
 		}
 	}
 }


### PR DESCRIPTION
As there is no PeekChar function for BinaryReader the proposed solution is to compare BaseStream.Position with BaseStream.Length.

Reference:
http://stackoverflow.com/questions/10942848/c-sharp-checking-for-binary-reader-end-of-file

Also added using statements in InterpretServerOrders() and ServerOrder.Serialize().
