### PR TITLE
Removed Facing: 0 and Health: 1

### DIFF
--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -335,66 +335,55 @@ Actors:
 	Gunboat: boat
 		Location: 51,59
 		Owner: GDI
-		Health: 1
 		Facing: 64
 	Actor92: e1
 		Location: 57,45
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 2
 	Actor93: e1
 		Location: 56,41
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 2
 	Actor94: e1
 		Location: 48,41
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor95: e1
 		Location: 59,45
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor96: e1
 		Location: 46,50
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor97: e1
 		Location: 48,47
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 1
 	Actor98: e1
 		Location: 38,43
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor99: e1
 		Location: 38,43
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor100: e1
 		Location: 48,41
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 2
 	Actor101: e1
 		Location: 41,39
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	spawn27: waypoint

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -304,37 +304,25 @@ Actors:
 		Location: 55,51
 		Owner: GDI
 		Health: 0.34375
-		Facing: 0
 	SiloA: silo
 		Location: 57,32
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	SiloB: silo
 		Location: 59,32
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Actor81: nuke
 		Location: 55,32
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Actor82: fact
 		Location: 52,32
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Actor83: nuke
 		Location: 53,52
 		Owner: GDI
 		Health: 0.025
-		Facing: 0
 	NodRefinery: proc
 		Location: 57,34
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Actor85: bggy
 		Location: 52,39
 		Owner: Nod
@@ -348,7 +336,6 @@ Actors:
 	Actor88: jeep
 		Location: 57,49
 		Owner: GDI
-		Health: 1
 		Facing: 32
 	Actor89: bggy
 		Location: 33,37
@@ -368,246 +355,200 @@ Actors:
 	Actor92: jeep
 		Location: 56,54
 		Owner: GDI
-		Health: 1
 		Facing: 160
 	Actor93: e1
 		Location: 48,32
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor94: e1
 		Location: 35,31
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor95: e1
 		Location: 39,31
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 4
 	Actor96: e1
 		Location: 49,32
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor97: e1
 		Location: 37,32
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 0
 	Actor98: e1
 		Location: 50,34
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 2
 	Actor99: e1
 		Location: 50,32
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	Actor100: e1
 		Location: 36,31
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 4
 	Actor101: e1
 		Location: 49,34
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	Actor102: e1
 		Location: 36,32
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor103: e1
 		Location: 49,33
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor104: e1
 		Location: 48,33
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	Actor105: e1
 		Location: 46,33
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 3
 	Actor106: e1
 		Location: 46,34
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor107: e1
 		Location: 40,37
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor108: e1
 		Location: 40,38
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor109: e1
 		Location: 41,37
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor110: e1
 		Location: 41,38
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 3
 	Actor111: e1
 		Location: 50,39
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 0
 	Actor112: e1
 		Location: 60,36
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor113: e1
 		Location: 60,37
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor114: e1
 		Location: 60,37
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor115: e1
 		Location: 35,39
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor116: e1
 		Location: 50,37
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	Actor117: e1
 		Location: 58,39
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	Actor118: e1
 		Location: 60,40
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 1
 	Actor119: e1
 		Location: 61,39
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor120: e1
 		Location: 59,34
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor121: e1
 		Location: 60,34
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor122: e1
 		Location: 56,32
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 2
 	Actor123: e1
 		Location: 51,32
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor124: e1
 		Location: 60,34
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 4
 	RushRifle3: e1
 		Location: 52,53
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 0
 	Actor126: e1
 		Location: 38,49
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 2
 	Actor127: e1
 		Location: 38,48
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor128: e1
 		Location: 53,40
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 2
 	Actor129: e1
 		Location: 45,36
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor130: e1
 		Location: 50,51
 		Owner: GDI
-		Health: 1
 		Facing: 32
 		SubCell: 2
 	Actor131: e1
 		Location: 50,50
 		Owner: GDI
-		Health: 1
 		Facing: 64
 		SubCell: 0
 	Actor132: e1
 		Location: 53,49
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 3
 	Actor133: e1
@@ -619,7 +560,6 @@ Actors:
 	Actor134: e1
 		Location: 52,40
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 2
 	Actor135: e1
@@ -631,31 +571,25 @@ Actors:
 	Actor136: e1
 		Location: 56,49
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor137: e1
 		Location: 55,42
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor138: e1
 		Location: 56,42
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 4
 	Actor139: e1
 		Location: 45,36
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor140: e1
 		Location: 44,36
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	RushRifle1: e1
@@ -673,37 +607,31 @@ Actors:
 	Actor143: e1
 		Location: 48,37
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 4
 	Actor144: e1
 		Location: 37,37
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor145: e1
 		Location: 50,37
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 2
 	Actor146: e1
 		Location: 38,32
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 1
 	Actor147: e1
 		Location: 49,36
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 0
 	Actor148: e1
 		Location: 48,36
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	waypoint26: waypoint

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -470,7 +470,6 @@ Actors:
 	HiddenBuggy: bggy
 		Location: 6,25
 		Owner: Nod
-		Facing: 0
 	Actor137: bggy
 		Location: 21,30
 		Owner: Nod
@@ -602,22 +601,18 @@ Actors:
 	Actor163: c6
 		Location: 42,56
 		Owner: Neutral
-		Facing: 0
 		SubCell: 1
 	Actor164: c3
 		Location: 43,56
 		Owner: Neutral
-		Facing: 0
 		SubCell: 1
 	Actor165: c2
 		Location: 40,58
 		Owner: Neutral
-		Facing: 0
 		SubCell: 1
 	Actor166: e3
 		Location: 40,43
 		Owner: Nod
-		Facing: 0
 		SubCell: 3
 	Actor167: e3
 		Location: 19,45
@@ -677,27 +672,22 @@ Actors:
 	Actor186: e3
 		Location: 37,28
 		Owner: Nod
-		Facing: 0
 		SubCell: 3
 	Actor187: e3
 		Location: 38,28
 		Owner: Nod
-		Facing: 0
 		SubCell: 0
 	Actor188: e3
 		Location: 14,32
 		Owner: Nod
-		Facing: 0
 		SubCell: 4
 	Sam4Guard3: e1
 		Location: 10,31
 		Owner: Nod
-		Facing: 0
 		SubCell: 3
 	Sam4Guard4: e1
 		Location: 10,31
 		Owner: Nod
-		Facing: 0
 		SubCell: 4
 	Actor191: e3
 		Location: 24,46

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -221,305 +221,230 @@ Actors:
 	Actor50: hq
 		Location: 29,57
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Actor51: nuke
 		Location: 28,54
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	HandOfNod: hand
 		Location: 30,52
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Hunter1: bggy
 		Location: 35,43
 		Owner: Nod
-		Health: 1
 		Facing: 192
 	Actor54: bggy
 		Location: 55,53
 		Owner: Nod
-		Health: 1
 		Facing: 32
 	Actor55: bggy
 		Location: 38,43
 		Owner: Nod
-		Health: 1
 		Facing: 64
 	Actor56: jeep
 		Location: 13,53
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Hunter2: bggy
 		Location: 32,43
 		Owner: Nod
-		Health: 1
 		Facing: 192
 	Actor58: bggy
 		Location: 31,57
 		Owner: Nod
-		Health: 1
 		Facing: 32
 	Actor59: apc
 		Location: 14,53
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor60: apc
 		Location: 12,53
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor61: bggy
 		Location: 26,27
 		Owner: Nod
-		Health: 1
 		Facing: 160
 	Actor62: bggy
 		Location: 51,27
 		Owner: Nod
-		Health: 1
 		Facing: 160
 	Actor63: ltnk
 		Location: 44,53
 		Owner: Nod
-		Health: 1
 		Facing: 192
 	Actor64: e3
 		Location: 45,36
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor65: e3
 		Location: 40,25
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor66: e3
 		Location: 36,41
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor67: e3
 		Location: 39,42
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor68: e3
 		Location: 12,24
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor69: e3
 		Location: 37,43
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 4
 	Actor70: e2
 		Location: 14,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor710: e1
 		Location: 12,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 5
 	Actor71: e1
 		Location: 12,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor72: e1
 		Location: 12,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor73: e1
 		Location: 15,41
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor74: e1
 		Location: 24,35
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	Actor75: e1
 		Location: 36,29
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 1
 	Actor76: e1
 		Location: 28,27
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor77: e1
 		Location: 32,30
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 0
 	Actor78: e1
 		Location: 33,44
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 4
 	Actor79: e1
 		Location: 45,36
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 2
 	Actor80: e3
 		Location: 52,44
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor81: e3
 		Location: 52,43
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor82: e3
 		Location: 52,44
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor83: e1
 		Location: 13,27
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor84: e1
 		Location: 13,36
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 3
 	Actor85: e1
 		Location: 11,29
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 4
 	Actor860: e2
 		Location: 14,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 5
 	Actor86: e2
 		Location: 14,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor87: e2
 		Location: 14,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor88: e2
 		Location: 14,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor89: e1
 		Location: 12,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor90: e1
 		Location: 12,54
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor91: e3
 		Location: 55,41
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 2
 	Actor92: e3
 		Location: 48,42
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 2
 	Actor93: e1
 		Location: 50,26
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 4
 	Actor94: e1
 		Location: 50,28
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 0
 	Actor95: e1
 		Location: 52,26
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 3
 	Actor96: e1
 		Location: 25,43
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 4
 	Actor97: e1
 		Location: 25,26
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor98: e1
 		Location: 30,30
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor99: e3
 		Location: 21,50
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 1
 	Actor100: e3
 		Location: 25,53
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 3
 	NodHeliLZ3: waypoint

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -332,248 +332,191 @@ Actors:
 	HandOfNod: hand
 		Location: 15,14
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Actor88: nuke
 		Location: 11,12
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Actor89: hq
 		Location: 10,14
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Hunter1: bggy
 		Location: 27,37
 		Owner: Nod
-		Health: 1
-		Facing: 0
 	Hunter2: bggy
 		Location: 41,29
 		Owner: Nod
-		Health: 1
 		Facing: 128
 	Actor92: jeep
 		Location: 49,45
 		Owner: GDI
-		Health: 1
 		Facing: 224
 	Actor93: bggy
 		Location: 10,23
 		Owner: Nod
-		Health: 1
 		Facing: 96
 	Actor94: apc
 		Location: 48,46
 		Owner: GDI
-		Health: 1
 		Facing: 224
 	Actor95: apc
 		Location: 51,45
 		Owner: GDI
-		Health: 1
 		Facing: 224
 	Actor96: bggy
 		Location: 34,18
 		Owner: Nod
-		Health: 1
 		Facing: 64
 	Actor97: bggy
 		Location: 53,26
 		Owner: Nod
-		Health: 1
 		Facing: 128
 	tank: ltnk
 		Location: 8,17
 		Owner: Nod
-		Health: 1
 		Facing: 96
 	Actor99: e3
 		Location: 8,45
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor100: e3
 		Location: 9,45
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor101: e2
 		Location: 51,46
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 1
 	Actor102: e3
 		Location: 36,15
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor103: e1
 		Location: 50,47
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 1
 	Actor104: e3
 		Location: 25,33
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor105: e1
 		Location: 11,46
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 3
 	Actor106: e1
 		Location: 30,37
 		Owner: Nod
-		Health: 1
 		Facing: 32
 		SubCell: 3
 	Actor107: e3
 		Location: 17,44
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 0
 	Actor108: e1
 		Location: 23,33
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	Actor109: e1
 		Location: 28,31
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 1
 	Actor110: e1
 		Location: 10,31
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor111: e3
 		Location: 33,20
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor112: e3
 		Location: 25,18
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor113: e1
 		Location: 49,46
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor114: e1
 		Location: 49,46
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 3
 	Actor115: e1
 		Location: 49,47
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 2
 	Actor116: e2
 		Location: 51,46
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 2
 	Actor117: e2
 		Location: 51,46
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	Actor118: e2
 		Location: 52,46
 		Owner: GDI
-		Health: 1
 		Facing: 224
 		SubCell: 3
 	Actor119: e3
 		Location: 39,32
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor120: e3
 		Location: 12,16
 		Owner: Nod
-		Health: 1
 		Facing: 96
 		SubCell: 2
 	Actor121: e1
 		Location: 10,35
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 4
 	Actor122: e1
 		Location: 12,20
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor123: e1
 		Location: 14,20
 		Owner: Nod
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor124: e3
 		Location: 52,29
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 3
 	Actor125: e3
 		Location: 8,31
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor126: e3
 		Location: 19,25
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Hunter3: e3
 		Location: 37,36
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Hunter4: e3
 		Location: 38,35
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Hunter5: e3
 		Location: 38,35
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	waypoint26: waypoint
 		Location: 42,41

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -443,360 +443,265 @@ Actors:
 	Actor124: v05
 		Location: 25,55
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	Actor125: v03
 		Location: 21,50
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	Actor128: v05
 		Location: 21,52
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	Actor130: v07
 		Location: 19,52
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	Actor131: v06
 		Location: 17,52
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigLos2Farm1: v04
 		Location: 25,53
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigLos2Farm2: v06
 		Location: 24,50
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigLos2Farm3: v07
 		Location: 19,46
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigLos2Farm4: v01
 		Location: 18,44
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigHuntFarm1: v06
 		Location: 45,43
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigRNF1Farm1: v07
 		Location: 31,53
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigRNF1Farm2: v09
 		Location: 31,50
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigRNF2Farm1: v08
 		Location: 30,53
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	TrigRNF2Farm2: v11
 		Location: 29,50
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 	Actor136: bggy
 		Location: 58,35
 		Owner: Nod
-		Health: 1
 		Facing: 224
 	Actor137: bggy
 		Location: 52,33
 		Owner: Nod
-		Health: 1
 		Facing: 224
 	Actor138: bggy
 		Location: 42,17
 		Owner: Nod
-		Health: 1
 		Facing: 224
 	Actor139: apc
 		Location: 27,15
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	Actor140: apc
 		Location: 29,15
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	Actor141: jeep
 		Location: 28,15
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	Actor142: e3
 		Location: 55,22
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 0
 	Actor143: e1
 		Location: 50,21
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	Actor144: e1
 		Location: 51,23
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 1
 	Actor145: e1
 		Location: 51,22
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	Actor146: e1
 		Location: 50,22
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 1
 	Actor147: e3
 		Location: 49,30
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor148: e3
 		Location: 23,28
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor149: e1
 		Location: 24,28
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor150: e1
 		Location: 23,28
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor151: e3
 		Location: 22,23
 		Owner: Nod
-		Health: 1
 		Facing: 64
 		SubCell: 0
 	civvie1: c8
 		Location: 26,22
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	civvie2: c3
 		Location: 26,22
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor154: c2
 		Location: 23,56
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor155: e1
 		Location: 55,29
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor156: e1
 		Location: 50,32
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor157: c4
 		Location: 24,48
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor158: c6
 		Location: 27,55
 		Owner: Civillians
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor159: c9
 		Location: 22,54
 		Owner: Civillians
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor160: e3
 		Location: 49,29
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor161: e1
 		Location: 43,55
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 1
 	Actor162: e1
 		Location: 42,55
 		Owner: Nod
-		Health: 1
 		Facing: 192
 		SubCell: 3
 	Actor163: e1
 		Location: 50,32
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor164: e1
 		Location: 51,33
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor165: e3
 		Location: 43,18
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 3
 	Actor166: e3
 		Location: 43,18
 		Owner: Nod
-		Health: 1
 		Facing: 224
 		SubCell: 2
 	Actor167: e1
 		Location: 27,18
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor168: e1
 		Location: 27,17
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 3
 	Actor169: e1
 		Location: 27,17
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor170: e1
 		Location: 27,18
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor171: e2
 		Location: 29,17
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 3
 	Actor172: e2
 		Location: 29,17
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor173: e2
 		Location: 29,18
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor174: e2
 		Location: 29,18
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor175: e1
 		Location: 26,24
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor176: e1
 		Location: 27,24
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor177: e1
 		Location: 27,24
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor178: e3
 		Location: 26,24
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor179: e3
 		Location: 27,24
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor182: e3
 		Location: 26,25
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor184: e3
 		Location: 56,29
 		Owner: Nod
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor185: e1
 		Location: 32,21
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor186: e1
 		Location: 33,21
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor187: e1
 		Location: 34,21
 		Owner: Nod
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	waypoint27: waypoint
 		Location: 27,46

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -240,142 +240,90 @@ Actors:
 	Actor56: pyle
 		Location: 25,20
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor57: fact
 		Location: 27,20
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor58: silo
 		Location: 23,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor59: silo
 		Location: 23,19
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor60: proc
 		Location: 20,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor61: nuke
 		Location: 25,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor62: nuke
 		Location: 27,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor63: gtwr
 		Location: 28,24
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor64: v24
 		Location: 20,41
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor65: v26
 		Location: 43,18
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor66: v24
 		Location: 37,16
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor67: v20
 		Location: 13,37
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor68: v21
 		Location: 13,39
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor69: v22
 		Location: 13,41
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor70: v24
 		Location: 15,36
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor71: v25
 		Location: 17,41
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor72: v26
 		Location: 16,38
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor73: v19
 		Location: 27,42
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor74: v19
 		Location: 29,42
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor75: v20
 		Location: 39,17
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor76: v21
 		Location: 43,16
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	TechCenter: miss
 		Location: 14,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor78: v22
 		Location: 39,16
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor79: v26
 		Location: 37,19
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor82: jeep
 		Location: 21,22
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	Actor83: jeep
 		Location: 20,22
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	Actor84: jeep
 		Location: 18,17
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	Actor89: jeep
 		Location: 29,34
 		Owner: GDI
-		Health: 1
 		Facing: 96
 	TibFieldHumvee01: jeep
 		Location: 52,19
@@ -383,61 +331,50 @@ Actors:
 	Actor95: e1
 		Location: 33,20
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor96: e1
 		Location: 34,19
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 3
 	VillageGuard01: e1
 		Location: 38,22
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 2
 	VillageGuard02: e1
 		Location: 38,22
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor99: e1
 		Location: 14,44
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor100: e1
 		Location: 33,31
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor101: e1
 		Location: 34,23
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 2
 	Actor102: c1
 		Location: 19,40
 		Owner: Neutral
-		Health: 1
 		Facing: 96
 		SubCell: 1
 	Actor103: c3
 		Location: 19,39
 		Owner: Neutral
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor104: c5
 		Location: 15,42
 		Owner: Neutral
-		Health: 1
 		Facing: 32
 		SubCell: 2
 	Actor105: c6
@@ -449,61 +386,50 @@ Actors:
 	Actor106: c7
 		Location: 15,41
 		Owner: Neutral
-		Health: 1
 		Facing: 224
 		SubCell: 0
 	VillageGuard03: e1
 		Location: 39,22
 		Owner: GDI
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor108: e1
 		Location: 34,31
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor109: e1
 		Location: 34,25
 		Owner: GDI
-		Health: 1
 		Facing: 160
 		SubCell: 2
 	Actor111: e1
 		Location: 39,31
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor112: e1
 		Location: 40,37
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor116: e2
 		Location: 34,22
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor117: e2
 		Location: 34,23
 		Owner: GDI
-		Health: 1
 		Facing: 160
 		SubCell: 4
 	Actor118: e2
 		Location: 42,18
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor119: e2
 		Location: 33,19
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	AttackWaveSpawnA: waypoint

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -72,157 +72,126 @@ Actors:
 	Actor117: e1
 		Location: 41,21
 		Owner: GDI
-		Health: 1
 		Facing: 192
 		SubCell: 0
 	Actor118: e1
 		Location: 48,21
 		Owner: GDI
-		Health: 1
 		Facing: 192
 		SubCell: 4
 	Actor119: e2
 		Location: 27,25
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	Actor120: e2
 		Location: 36,30
 		Owner: GDI
-		Health: 1
 		Facing: 64
 		SubCell: 4
 	Actor121: e2
 		Location: 41,39
 		Owner: GDI
-		Health: 1
 		Facing: 64
 		SubCell: 1
 	Actor122: e2
 		Location: 42,49
 		Owner: GDI
-		Health: 1
 		Facing: 32
 		SubCell: 0
 	Actor123: e2
 		Location: 43,26
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor111: e1
 		Location: 34,31
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor106: e1
 		Location: 40,22
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor107: e1
 		Location: 40,21
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor108: e1
 		Location: 36,33
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor109: e1
 		Location: 34,24
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor86: e1
 		Location: 51,21
 		Owner: GDI
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor87: e1
 		Location: 16,39
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor88: e1
 		Location: 20,28
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor89: e1
 		Location: 19,21
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor90: e1
 		Location: 30,43
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 1
 	Actor91: e1
 		Location: 30,43
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor92: e1
 		Location: 34,32
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor93: e1
 		Location: 23,35
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Actor94: e1
 		Location: 17,32
 		Owner: GDI
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor95: e1
 		Location: 24,43
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor96: e1
 		Location: 15,37
 		Owner: GDI
-		Health: 1
 		Facing: 64
 		SubCell: 1
 	Actor97: e1
 		Location: 24,30
 		Owner: GDI
-		Health: 1
 		Facing: 64
 		SubCell: 3
 	Actor98: e1
 		Location: 35,27
 		Owner: GDI
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Actor82: e1
 		Location: 25,43
 		Owner: GDI
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor0: sbag
@@ -381,88 +350,54 @@ Actors:
 	Actor51: silo
 		Location: 23,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor52: silo
 		Location: 18,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor53: pyle
 		Location: 23,19
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor54: nuke
 		Location: 25,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor55: fact
 		Location: 27,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor56: gtwr
 		Location: 18,23
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor57: v20
 		Location: 13,38
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor58: v21
 		Location: 13,40
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor59: v22
 		Location: 18,40
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor60: v24
 		Location: 15,37
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor61: v25
 		Location: 17,41
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor62: v19
 		Location: 28,41
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor63: proc
 		Location: 20,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	TechCenter: miss
 		Location: 14,17
 		Owner: GDI
-		Health: 1
-		Facing: 0
 	Actor65: v19
 		Location: 29,41
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor67: v19
 		Location: 30,42
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	Actor68: v19
 		Location: 29,42
 		Owner: Neutral
-		Health: 1
-		Facing: 0
 	McvEntry: waypoint
 		Location: 54,38
 		Owner: Neutral
@@ -472,22 +407,18 @@ Actors:
 	Actor72: jeep
 		Location: 28,21
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	Actor73: jeep
 		Location: 35,30
 		Owner: GDI
-		Health: 1
 		Facing: 96
 	Actor74: jeep
 		Location: 32,36
 		Owner: GDI
-		Health: 1
 		Facing: 96
 	Actor75: jeep
 		Location: 29,21
 		Owner: GDI
-		Health: 1
 		Facing: 128
 	NodEntry: waypoint
 		Location: 54,40
@@ -498,36 +429,30 @@ Actors:
 	Actor77: jeep
 		Location: 47,21
 		Owner: GDI
-		Health: 1
 		Facing: 160
 	Actor101: c1
 		Location: 16,36
 		Owner: Neutral
-		Health: 1
 		Facing: 192
 		SubCell: 4
 	Actor102: c3
 		Location: 17,40
 		Owner: Neutral
-		Health: 1
 		Facing: 224
 		SubCell: 2
 	Actor103: c5
 		Location: 16,40
 		Owner: Neutral
-		Health: 1
 		Facing: 224
 		SubCell: 1
 	Actor104: c6
 		Location: 14,36
 		Owner: Neutral
 		Health: 0.5976563
-		Facing: 0
 		SubCell: 4
 	Actor105: c7
 		Location: 18,38
 		Owner: Neutral
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	PlayerBase: waypoint

--- a/mods/ra/maps/allies-01/map.yaml
+++ b/mods/ra/maps/allies-01/map.yaml
@@ -136,279 +136,195 @@ Actors:
 	Actor22: tsla
 		Location: 71,59
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor23: powr
 		Location: 75,64
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor24: powr
 		Location: 67,57
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor25: powr
 		Location: 61,57
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Lab: stek
 		Location: 61,60
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor27: fact
 		Location: 69,62
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor28: dome
 		Location: 67,65
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor29: barr
 		Location: 61,64
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor30: tsla
 		Location: 67,67
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor31: tsla
 		Location: 60,66
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor32: weap
 		Location: 65,62
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor33: proc
 		Location: 73,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		FreeActor: False
 	Actor34: kenn
 		Location: 64,65
 		Owner: USSR
 		Health: 0.9921875
-		Facing: 0
 	Actor35: powr
 		Location: 65,57
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor36: powr
 		Location: 77,64
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor37: powr
 		Location: 75,67
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor38: silo
 		Location: 59,64
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor39: powr
 		Location: 77,67
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	OilPump: v19
 		Location: 59,57
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor41: brl3
 		Location: 60,57
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor42: barl
 		Location: 60,56
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor43: barl
 		Location: 61,56
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor44: brl3
 		Location: 60,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor45: barl
 		Location: 58,56
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor46: barl
 		Location: 59,59
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor47: jeep
 		Location: 63,50
 		Owner: Greece
-		Health: 1
 		Facing: 128
 	Harvester: harv
 		Location: 72,60
 		Owner: USSR
-		Health: 1
 		Facing: 224
 	Actor49: jeep
 		Location: 62,50
 		Owner: Greece
-		Health: 1
 		Facing: 128
 	Actor50: jeep
 		Location: 64,50
 		Owner: Greece
-		Health: 1
 		Facing: 128
 	Patrol1: dog
 		Location: 63,59
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	Patrol2: e1
 		Location: 64,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	LabGuard3: e1
 		Location: 61,63
 		Owner: USSR
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	LabGuard2: e1
 		Location: 63,63
 		Owner: USSR
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor55: e2
 		Location: 73,66
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor56: e1
 		Location: 62,67
 		Owner: USSR
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor57: e1
 		Location: 67,67
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor58: e1
 		Location: 65,67
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor59: e1
 		Location: 56,60
 		Owner: USSR
-		Health: 1
 		Facing: 96
 		SubCell: 1
 	Patrol4: e1
 		Location: 62,55
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Patrol3: e1
 		Location: 64,59
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 2
 	LabGuard1: e1
 		Location: 64,61
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor63: e1
 		Location: 58,60
 		Owner: USSR
-		Health: 1
 		Facing: 64
 		SubCell: 1
 	Actor64: e1
 		Location: 64,49
 		Owner: Greece
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor65: e1
 		Location: 63,49
 		Owner: Greece
-		Health: 1
 		Facing: 128
 		SubCell: 0
 	Actor66: e1
 		Location: 62,49
 		Owner: Greece
-		Health: 1
 		Facing: 160
 		SubCell: 2
 	Civilian1: c8
 		Location: 74,50
 		Owner: England
-		Health: 1
-		Facing: 0
 		SubCell: 0
 	Civilian2: c7
 		Location: 76,48
 		Owner: England
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor69: e2
 		Location: 62,56
 		Owner: USSR
-		Health: 1
 		Facing: 32
 		SubCell: 1
 	Actor70: e2
 		Location: 62,56
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 4
 	Actor71: e1
 		Location: 64,49
 		Owner: Greece
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor72: e1
 		Location: 62,49
 		Owner: Greece
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	ExtractionLZ: waypoint

--- a/mods/ra/maps/allies-02/map.yaml
+++ b/mods/ra/maps/allies-02/map.yaml
@@ -248,194 +248,120 @@ Actors:
 	SovietWarfactory: weap
 		Location: 60,66
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor58: fact
 		Location: 62,61
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor59: proc
 		Location: 53,62
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		FreeActor: False
 	Actor60: powr
 		Location: 57,62
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor61: barr
 		Location: 56,66
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor62: powr
 		Location: 59,62
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor63: kenn
 		Location: 58,68
 		Owner: USSR
 		Health: 0.9921875
-		Facing: 0
 	Actor64: brl3
 		Location: 65,59
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor65: barl
 		Location: 66,60
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor66: barl
 		Location: 65,60
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor67: brl3
 		Location: 64,60
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor68: barl
 		Location: 65,61
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor69: v19
 		Location: 67,60
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor70: v19
 		Location: 67,59
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor71: barl
 		Location: 65,62
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor72: silo
 		Location: 54,68
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor73: brl3
 		Location: 55,70
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor74: brl3
 		Location: 54,70
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor75: barl
 		Location: 53,69
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor76: barl
 		Location: 54,69
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor77: barl
 		Location: 55,71
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor78: brl3
 		Location: 56,71
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor79: brl3
 		Location: 53,68
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor80: v19
 		Location: 56,70
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor81: barl
 		Location: 55,69
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor82: brl3
 		Location: 72,51
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor83: barl
 		Location: 72,50
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor84: barl
 		Location: 74,48
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor85: barl
 		Location: 72,49
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor86: barl
 		Location: 73,48
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor87: v19
 		Location: 75,48
 		Owner: USSR
 		Health: 0.5195313
-		Facing: 0
 	Actor88: v19
 		Location: 62,57
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor89: v19
 		Location: 60,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor90: brl3
 		Location: 62,56
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor91: brl3
 		Location: 61,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor92: barl
 		Location: 61,57
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor93: brl3
 		Location: 59,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Actor94: barl
 		Location: 58,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 	Harvester: harv
 		Location: 55,65
 		Owner: USSR
@@ -444,248 +370,204 @@ Actors:
 	Actor96: dog
 		Location: 53,58
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor97: dog
 		Location: 65,68
 		Owner: USSR
-		Health: 1
 		Facing: 64
 		SubCell: 3
 	Actor98: dog
 		Location: 65,66
 		Owner: USSR
-		Health: 1
 		Facing: 32
 		SubCell: 2
 	Actor99: dog
 		Location: 59,70
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 2
 	Actor100: e2
 		Location: 61,56
 		Owner: USSR
-		Health: 1
 		Facing: 32
 		SubCell: 3
 	Actor101: e2
 		Location: 59,57
 		Owner: USSR
-		Health: 1
 		Facing: 224
 		SubCell: 4
 	Actor102: e2
 		Location: 64,67
 		Owner: USSR
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor103: e1
 		Location: 77,74
 		Owner: Ukraine
-		Health: 1
 		Facing: 128
 		SubCell: 2
 	Actor104: e1
 		Location: 80,74
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor105: e1
 		Location: 56,68
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 3
 	Actor106: e1
 		Location: 50,72
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 4
 	Actor107: e1
 		Location: 73,60
 		Owner: USSR
-		Health: 1
 		Facing: 32
 		SubCell: 2
 	Actor108: e1
 		Location: 74,61
 		Owner: USSR
-		Health: 1
 		Facing: 224
 		SubCell: 1
 	Actor109: e1
 		Location: 72,60
 		Owner: USSR
-		Health: 1
 		Facing: 64
 		SubCell: 0
 	Actor110: e1
 		Location: 49,58
 		Owner: USSR
-		Health: 1
 		Facing: 192
 		SubCell: 0
 	Actor111: e1
 		Location: 51,58
 		Owner: USSR
-		Health: 1
 		Facing: 32
 		SubCell: 1
 	Actor112: e1
 		Location: 60,78
 		Owner: USSR
-		Health: 1
 		Facing: 192
 		SubCell: 4
 	Actor113: e2
 		Location: 62,79
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 4
 	Actor114: e1
 		Location: 57,82
 		Owner: USSR
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor115: e1
 		Location: 60,64
 		Owner: USSR
-		Health: 1
 		Facing: 224
 		SubCell: 3
 	Actor116: e2
 		Location: 68,45
 		Owner: USSR
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor117: e1
 		Location: 48,72
 		Owner: USSR
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor118: e1
 		Location: 57,69
 		Owner: USSR
-		Health: 1
 		Facing: 96
 		SubCell: 1
 	Actor119: e2
 		Location: 60,70
 		Owner: USSR
-		Health: 1
 		Facing: 32
 		SubCell: 0
 	Actor120: e1
 		Location: 89,48
 		Owner: Greece
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor121: e1
 		Location: 87,48
 		Owner: Greece
-		Health: 1
 		Facing: 192
 		SubCell: 4
 	Actor122: e1
 		Location: 87,48
 		Owner: Greece
-		Health: 1
 		Facing: 192
 		SubCell: 1
 	Actor123: e1
 		Location: 88,48
 		Owner: Greece
-		Health: 1
 		Facing: 128
 		SubCell: 4
 	Actor124: e1
 		Location: 88,49
 		Owner: Greece
-		Health: 1
 		Facing: 128
 		SubCell: 1
 	Actor125: dog
 		Location: 78,75
 		Owner: Ukraine
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor126: e1
 		Location: 71,61
 		Owner: Ukraine
-		Health: 1
 		Facing: 160
 		SubCell: 0
 	Actor127: dog
 		Location: 70,61
 		Owner: Ukraine
-		Health: 1
 		Facing: 96
 		SubCell: 4
 	Actor128: e1
 		Location: 50,46
 		Owner: Ukraine
-		Health: 1
 		Facing: 32
 		SubCell: 1
 	Actor129: e1
 		Location: 49,47
 		Owner: Ukraine
-		Health: 1
 		Facing: 64
 		SubCell: 0
 	Actor130: e2
 		Location: 49,49
 		Owner: Ukraine
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	Actor131: e2
 		Location: 47,46
 		Owner: Ukraine
-		Health: 1
 		Facing: 96
 		SubCell: 3
 	Actor132: e2
 		Location: 48,63
 		Owner: Ukraine
-		Health: 1
-		Facing: 0
 		SubCell: 1
 	Actor133: e1
 		Location: 49,63
 		Owner: Ukraine
-		Health: 1
 		Facing: 96
 		SubCell: 2
 	Actor134: e1
 		Location: 74,81
 		Owner: Ukraine
-		Health: 1
 		Facing: 64
 		SubCell: 3
 	Actor135: e2
 		Location: 75,83
 		Owner: Ukraine
-		Health: 1
 		Facing: 96
 		SubCell: 0
 	Actor136: e2
 		Location: 69,66
 		Owner: USSR
-		Health: 1
-		Facing: 0
 		SubCell: 3
 	Actor137: e2
 		Location: 73,51
@@ -696,7 +578,6 @@ Actors:
 	Actor138: medi
 		Location: 88,48
 		Owner: Greece
-		Health: 1
 		Facing: 160
 		SubCell: 1
 	TruckEntryPoint: waypoint

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -909,7 +909,6 @@ Actors:
 	USSRBaseGuard3: e2
 		Location: 48,70
 		Owner: USSR
-		Facing: 0
 		SubCell: 4
 	USSRBaseGuard4: e2
 		Location: 49,69
@@ -969,7 +968,6 @@ Actors:
 	USSRBaseGuard13: e2
 		Location: 80,76
 		Owner: USSR
-		Facing: 0
 		SubCell: 0
 	USSRBaseGuard14: dog
 		Location: 81,76
@@ -1009,7 +1007,6 @@ Actors:
 	Actor287: e1.autotarget
 		Location: 84,53
 		Owner: USSR
-		Facing: 0
 		SubCell: 4
 	Actor288: e1.autotarget
 		Location: 90,53
@@ -1019,7 +1016,6 @@ Actors:
 	Actor289: e1.autotarget
 		Location: 88,58
 		Owner: USSR
-		Facing: 0
 		SubCell: 4
 	Actor290: e2.autotarget
 		Location: 89,58
@@ -1059,7 +1055,6 @@ Actors:
 	Actor297: e1.autotarget
 		Location: 94,65
 		Owner: USSR
-		Facing: 0
 		SubCell: 4
 	Actor298: e1.autotarget
 		Location: 96,65
@@ -1089,7 +1084,6 @@ Actors:
 	PrisonedMedi1: medi
 		Location: 58,60
 		Owner: Greece
-		Facing: 0
 		SubCell: 0
 	Actor309: fenc
 		Location: 72,63

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -76,7 +76,6 @@ Actors:
 	Actor78: 2tnk
 		Location: 77,68
 		Owner: Allies
-		Facing: 0
 	Actor23: v23
 		Location: 22,51
 		Owner: Neutral
@@ -140,7 +139,6 @@ Actors:
 	Actor10: gun
 		Location: 64,63
 		Owner: Allies
-		Facing: 0
 	Actor153: apwr
 		Location: 93,87
 		Owner: Allies
@@ -150,7 +148,6 @@ Actors:
 	Actor33: gun
 		Location: 85,69
 		Owner: Allies
-		Facing: 0
 	Actor40: dome
 		Location: 55,19
 		Owner: Soviets
@@ -166,7 +163,6 @@ Actors:
 	Actor28: gun
 		Location: 74,67
 		Owner: Allies
-		Facing: 0
 	Actor50: apwr
 		Location: 51,14
 		Owner: Soviets
@@ -233,7 +229,6 @@ Actors:
 	Actor303: mrj
 		Location: 61,60
 		Owner: Allies
-		Facing: 0
 	Actor87: tc01
 		Location: 92,50
 		Owner: Neutral
@@ -258,7 +253,6 @@ Actors:
 	Actor253: arty
 		Location: 44,68
 		Owner: Allies
-		Facing: 0
 	Actor64: brik
 		Location: 69,63
 		Owner: Allies
@@ -617,7 +611,6 @@ Actors:
 	Actor228: mgg
 		Location: 49,63
 		Owner: Allies
-		Facing: 0
 	Actor255: e1
 		Location: 67,76
 		Owner: Allies
@@ -627,7 +620,6 @@ Actors:
 	Actor82: 2tnk
 		Location: 82,69
 		Owner: Allies
-		Facing: 0
 	Actor30: pbox
 		Location: 47,77
 		Owner: Allies
@@ -678,7 +670,6 @@ Actors:
 	Actor233: 2tnk
 		Location: 66,62
 		Owner: Allies
-		Facing: 0
 	Actor240: sbag
 		Location: 54,62
 		Owner: Allies
@@ -826,7 +817,6 @@ Actors:
 	Actor225: 2tnk
 		Location: 47,61
 		Owner: Allies
-		Facing: 0
 	Actor239: 1tnk
 		Location: 44,65
 		Owner: Allies
@@ -842,11 +832,9 @@ Actors:
 	Actor224: 2tnk
 		Location: 41,62
 		Owner: Allies
-		Facing: 0
 	Actor237: jeep
 		Location: 63,63
 		Owner: Allies
-		Facing: 0
 	Actor304: e1
 		Location: 57,72
 		Owner: Allies
@@ -907,7 +895,6 @@ Actors:
 	Actor257: arty
 		Location: 72,68
 		Owner: Allies
-		Facing: 0
 	Actor344: e1
 		Location: 78,69
 		Owner: Allies

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -1769,11 +1769,9 @@ Actors:
 	Actor533: gun
 		Location: 83,24
 		Owner: Soviets
-		Facing: 0
 	Actor534: gun
 		Location: 73,24
 		Owner: Soviets
-		Facing: 0
 	Actor535: ftur
 		Location: 58,81
 		Owner: Soviets
@@ -1912,7 +1910,6 @@ Actors:
 	Actor83: sam
 		Location: 75,24
 		Owner: Soviets
-		Facing: 0
 	Actor84: sam
 		Location: 63,28
 		Owner: Soviets
@@ -1967,7 +1964,6 @@ Actors:
 	Actor641: 3tnk
 		Location: 23,48
 		Owner: Soviets
-		Facing: 0
 	Actor642: v2rl
 		Location: 20,45
 		Owner: Soviets

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -1862,15 +1862,12 @@ Actors:
 	stnk1: 5tnk
 		Location: 89,59
 		Owner: Turkey
-		Facing: 0
 	stnk2: 5tnk
 		Location: 77,57
 		Owner: Turkey
-		Facing: 0
 	stnk3: 5tnk
 		Location: 94,53
 		Owner: Turkey
-		Facing: 0
 	Actor588: v2rl
 		Location: 91,75
 		Owner: USSR
@@ -1890,7 +1887,6 @@ Actors:
 	Actor592: badtruk
 		Location: 89,36
 		Owner: BadGuy
-		Facing: 0
 	Actor593: v2rl
 		Location: 32,48
 		Owner: BadGuy
@@ -1898,23 +1894,18 @@ Actors:
 	Actor594: 3tnk
 		Location: 85,86
 		Owner: USSR
-		Facing: 0
 	Actor595: v2rl
 		Location: 86,86
 		Owner: USSR
-		Facing: 0
 	Actor596: dtrk
 		Location: 74,81
 		Owner: USSR
-		Facing: 0
 	Actor597: dtrk
 		Location: 77,83
 		Owner: USSR
-		Facing: 0
 	Actor598: ttnk
 		Location: 55,61
 		Owner: USSR
-		Facing: 0
 	Actor599: bad3tnk
 		Location: 76,27
 		Owner: BadGuy
@@ -1922,7 +1913,6 @@ Actors:
 	Actor600: dtrk
 		Location: 86,83
 		Owner: USSR
-		Facing: 0
 	Actor601: e1
 		Location: 24,71
 		Owner: BadGuy
@@ -1941,7 +1931,6 @@ Actors:
 	Actor604: e1
 		Location: 29,72
 		Owner: BadGuy
-		Facing: 0
 		SubCell: 1
 	Actor605: e2
 		Location: 29,70
@@ -1956,57 +1945,46 @@ Actors:
 	Actor607: e1
 		Location: 81,88
 		Owner: USSR
-		Facing: 0
 		SubCell: 1
 	Actor608: e1
 		Location: 81,88
 		Owner: USSR
-		Facing: 0
 		SubCell: 2
 	Actor609: e1
 		Location: 82,88
 		Owner: USSR
-		Facing: 0
 		SubCell: 1
 	Actor610: e1
 		Location: 81,88
 		Owner: USSR
-		Facing: 0
 		SubCell: 0
 	Actor611: e1
 		Location: 81,88
 		Owner: USSR
-		Facing: 0
 		SubCell: 4
 	Actor612: e3
 		Location: 83,89
 		Owner: USSR
-		Facing: 0
 		SubCell: 0
 	Actor613: e3
 		Location: 83,89
 		Owner: USSR
-		Facing: 0
 		SubCell: 2
 	Actor614: e3
 		Location: 84,89
 		Owner: USSR
-		Facing: 0
 		SubCell: 1
 	Actor615: e4
 		Location: 85,89
 		Owner: USSR
-		Facing: 0
 		SubCell: 2
 	Actor616: e4
 		Location: 85,89
 		Owner: USSR
-		Facing: 0
 		SubCell: 3
 	Actor617: e4
 		Location: 85,90
 		Owner: USSR
-		Facing: 0
 		SubCell: 2
 	Actor618: e1
 		Location: 61,23
@@ -2016,12 +1994,10 @@ Actors:
 	Actor619: e1
 		Location: 74,26
 		Owner: BadGuy
-		Facing: 0
 		SubCell: 1
 	Actor620: e1
 		Location: 75,25
 		Owner: BadGuy
-		Facing: 0
 		SubCell: 4
 	Actor621: e2
 		Location: 78,19

--- a/mods/ra/maps/soviet-01/map.yaml
+++ b/mods/ra/maps/soviet-01/map.yaml
@@ -451,7 +451,6 @@ Actors:
 	Actor128: c8
 		Location: 47,61
 		Owner: France
-		Facing: 0
 		SubCell: 3
 	Actor129: c8
 		Location: 41,50
@@ -466,7 +465,6 @@ Actors:
 	Actor131: c5
 		Location: 46,61
 		Owner: France
-		Facing: 0
 		SubCell: 1
 	Actor132: c4
 		Location: 44,67
@@ -526,7 +524,6 @@ Actors:
 	Actor143: c7
 		Location: 56,54
 		Owner: France
-		Facing: 0
 		SubCell: 3
 	Actor144: e1
 		Location: 40,51
@@ -541,7 +538,6 @@ Actors:
 	Actor146: e1
 		Location: 35,54
 		Owner: France
-		Facing: 0
 		SubCell: 4
 	Actor147: e1
 		Location: 43,64
@@ -571,7 +567,6 @@ Actors:
 		Location: 42,81
 		Owner: USSR
 		Health: 0.1367188
-		Facing: 0
 		SubCell: 2
 	Airfield1: afld
 		Location: 39,77


### PR DESCRIPTION
Split from #7261 as requested (https://github.com/OpenRA/OpenRA/pull/7261#issuecomment-69472628).

This PR removes "Facing: 0" on actors that don't use facings and "Health: 1" as it's default in all map.yaml files.
