### PR TITLE
TerrainModifiesDamage trait.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -285,6 +285,7 @@
     <Compile Include="Traits\Infantry\ScaredyCat.cs" />
     <Compile Include="Traits\Infantry\TakeCover.cs" />
     <Compile Include="Traits\Invulnerable.cs" />
+    <Compile Include="Traits\Infantry\TerrainModifiesDamage.cs" />
     <Compile Include="Traits\JamsMissiles.cs" />
     <Compile Include="Traits\KillsSelf.cs" />
     <Compile Include="Traits\LimitedAmmo.cs" />

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -1,0 +1,75 @@
+﻿ #region Copyright & License Information
+ /*
+  * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+  * This file is part of OpenRA, which is free software. It is made
+  * available to you under the terms of the GNU General Public License
+  * as published by the Free Software Foundation. For more information,
+  * see COPYING.
+  */
+ #endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class TerrainModifiesDamageInfo : ITraitInfo
+	{
+		[FieldLoader.LoadUsing("LoadPercents")]
+		[Desc("Damage percentage for specific terrain types. 120 = 120%, 80 = 80%, etc.")]
+		public readonly Dictionary<string, int> TerrainModifier = null;
+
+		[Desc("Modify healing damage? For example: A friendly medic.")]
+		public readonly bool ModifyHealing = false;
+
+		public object Create(ActorInitializer init) { return new TerrainModifiesDamage(init.Self, this); }
+
+		static object LoadPercents(MiniYaml y)
+		{
+			MiniYaml percents;
+
+			if (!y.ToDictionary().TryGetValue("TerrainModifier", out percents))
+				return new Dictionary<string, int>();
+
+			return percents.Nodes.ToDictionary(
+				kv => FieldLoader.GetValue<string>("(key)", kv.Key),
+				kv => FieldLoader.GetValue<int>("(value)", kv.Value.Value));
+		}
+	}
+
+	public class TerrainModifiesDamage : IDamageModifier
+	{
+		public readonly TerrainModifiesDamageInfo Info;
+
+		readonly Actor self;
+
+		public TerrainModifiesDamage(Actor self, TerrainModifiesDamageInfo info)
+		{
+			Info = info;
+			this.self = self;
+		}
+
+		public int GetDamageModifier(Actor attacker, DamageWarhead warhead)
+		{
+			var percent = 100;
+			if (attacker.Owner.IsAlliedWith(self.Owner) && warhead.Damage < 0 && !Info.ModifyHealing)
+				return percent;
+
+			var world = self.World;
+			var map = world.Map;
+			var tileSet = world.TileSet;
+
+			var tiles = map.MapTiles.Value;
+			var pos = map.CellContaining(self.CenterPosition);
+			var terrainType = tileSet[tileSet.GetTerrainIndex(tiles[pos])].Type;
+
+			if (!Info.TerrainModifier.ContainsKey(terrainType))
+				return percent;
+
+			return Info.TerrainModifier[terrainType];
+		}
+	}
+}

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -233,6 +233,9 @@
 	MustBeDestroyed:
 	AnnounceOnSeen:
 		Notification: EnemyUnitsApproaching
+	TerrainModifiesDamage:
+		TerrainModifier:
+			Rough: 80
 
 ^Plane:
 	AppearsOnRadar:
@@ -326,4 +329,3 @@
 		Range: 2c0, 5c0
 	ScriptTriggers:
 	WithMakeAnimation:
-


### PR DESCRIPTION
^Infantry in D2k now take 80% damage if they are standing on Rough terrain.

Closes #7328 
Even if this doesn't belong/exist in D2k it will be nice to have.

I chose to allow negative percentages because if someone wants an actor healed when damaged on a specific tile they should have the ability to do so.

/cc @MicroJOo and @penev92

Note: I won't integrate this with #7110 as they have different purposes.
