### PR TITLE
Fix wrong template definition in the d2k tileset

### DIFF
--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -2037,7 +2037,7 @@ Templates:
 		Category: Rock-Cliff
 		PickAny: False
 		Tiles:
-			0: Sand
+			0: Cliff
 			2: Cliff
 			3: Cliff
 			1: Cliff


### PR DESCRIPTION
Fixes this:

![screenshot from 2015-01-14 19 05 12](https://cloud.githubusercontent.com/assets/4331210/5744377/aca6b7ac-9c20-11e4-81a7-96cbc6124357.png)
