### PR TITLE
Cache or inline some delegates to avoid allocations.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -46,11 +46,14 @@ namespace OpenRA.Graphics
 		readonly Dictionary<string, PaletteReference> palettes = new Dictionary<string, PaletteReference>();
 		readonly TerrainRenderer terrainRenderer;
 		readonly Lazy<DeveloperMode> devTrait;
+		readonly Func<string, PaletteReference> createPaletteReference;
 
 		internal WorldRenderer(World world)
 		{
 			World = world;
 			Viewport = new Viewport(this, world.Map);
+
+			createPaletteReference = CreatePaletteReference;
 
 			foreach (var pal in world.TraitDict.ActorsWithTrait<ILoadsPalettes>())
 				pal.Trait.LoadPalettes(this);
@@ -69,7 +72,7 @@ namespace OpenRA.Graphics
 			return new PaletteReference(name, palette.GetPaletteIndex(name), pal, palette);
 		}
 
-		public PaletteReference Palette(string name) { return palettes.GetOrAdd(name, CreatePaletteReference); }
+		public PaletteReference Palette(string name) { return palettes.GetOrAdd(name, createPaletteReference); }
 		public void AddPalette(string name, ImmutablePalette pal) { palette.AddPalette(name, pal, false); }
 		public void AddPalette(string name, ImmutablePalette pal, bool allowModifiers) { palette.AddPalette(name, pal, allowModifiers); }
 		public void ReplacePalette(string name, IPalette pal) { palette.ReplacePalette(name, pal); palettes[name].Palette = pal; }

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -157,20 +157,19 @@ namespace OpenRA.Mods.Common.Traits
 				return notVisibleEdges;
 
 			var cell = uv.ToCPos(map);
-			Func<CPos, bool> isCellVisible = c => isVisible(c.ToMPos(map));
 
 			// If a side is shrouded then we also count the corners
 			var edge = Edges.None;
-			if (!isCellVisible(cell + new CVec(0, -1))) edge |= Edges.Top;
-			if (!isCellVisible(cell + new CVec(1, 0))) edge |= Edges.Right;
-			if (!isCellVisible(cell + new CVec(0, 1))) edge |= Edges.Bottom;
-			if (!isCellVisible(cell + new CVec(-1, 0))) edge |= Edges.Left;
+			if (!isVisible((cell + new CVec(0, -1)).ToMPos(map))) edge |= Edges.Top;
+			if (!isVisible((cell + new CVec(1, 0)).ToMPos(map))) edge |= Edges.Right;
+			if (!isVisible((cell + new CVec(0, 1)).ToMPos(map))) edge |= Edges.Bottom;
+			if (!isVisible((cell + new CVec(-1, 0)).ToMPos(map))) edge |= Edges.Left;
 
 			var ucorner = edge & Edges.AllCorners;
-			if (!isCellVisible(cell + new CVec(-1, -1))) edge |= Edges.TopLeft;
-			if (!isCellVisible(cell + new CVec(1, -1))) edge |= Edges.TopRight;
-			if (!isCellVisible(cell + new CVec(1, 1))) edge |= Edges.BottomRight;
-			if (!isCellVisible(cell + new CVec(-1, 1))) edge |= Edges.BottomLeft;
+			if (!isVisible((cell + new CVec(-1, -1)).ToMPos(map))) edge |= Edges.TopLeft;
+			if (!isVisible((cell + new CVec(1, -1)).ToMPos(map))) edge |= Edges.TopRight;
+			if (!isVisible((cell + new CVec(1, 1)).ToMPos(map))) edge |= Edges.BottomRight;
+			if (!isVisible((cell + new CVec(-1, 1)).ToMPos(map))) edge |= Edges.BottomLeft;
 
 			// RA provides a set of frames for tiles with shrouded
 			// corners but unshrouded edges. We want to detect this


### PR DESCRIPTION
Standard stuff, just avoiding allocating some delegates that get used a lot to help keep GC activity low.
