### PR TITLE
Fix showing wrong IP for server admins in the lobby client tooltips

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/ClientTooltipLogic.cs
@@ -76,7 +76,8 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			latency.GetText = () => LobbyUtils.LatencyDescription(ping);
 			latency.GetColor = () => LobbyUtils.LatencyColor(ping);
 			var address = orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
-			if (address == IPAddress.Loopback.ToString() && UPnP.NatDevice != null)
+			if (clientIndex == orderManager.LocalClient.Index && UPnP.NatDevice != null
+				&& address == IPAddress.Loopback.ToString())
 				address = UPnP.NatDevice.GetExternalIP().ToString();
 			var cachedDescriptiveIP = LobbyUtils.DescriptiveIpAddress(address);
 			ip.GetText = () => cachedDescriptiveIP;


### PR DESCRIPTION
The external IP will now only be resolved for the local client.

Fixes #7303.

I couldn't test this since UPnP doesn't work for me (that's why I never could reproduce the problem, btw).
