### PR TITLE
Do not try to draw "null" sprites

### DIFF
--- a/OpenRA.Mods.D2k/Widgets/MoneyBinWidget.cs
+++ b/OpenRA.Mods.D2k/Widgets/MoneyBinWidget.cs
@@ -38,9 +38,10 @@ namespace OpenRA.Mods.D2k.Widgets
 			var digitCollection = "digits-" + world.LocalPlayer.Country.Race;
 			var chromeCollection = "chrome-" + world.LocalPlayer.Country.Race;
 
-			Game.Renderer.RgbaSpriteRenderer.DrawSprite(
-				ChromeProvider.GetImage(chromeCollection, "moneybin"),
-				new float2(Bounds.Left, 0));
+			var spriteMoneyBin = ChromeProvider.GetImage(chromeCollection, "moneybin");
+
+			if (spriteMoneyBin != null)
+				Game.Renderer.RgbaSpriteRenderer.DrawSprite(spriteMoneyBin, new float2(Bounds.Left, 0));
 
 			// Cash
 			var cashDigits = (playerResources.DisplayCash + playerResources.DisplayResources).ToString();
@@ -48,9 +49,11 @@ namespace OpenRA.Mods.D2k.Widgets
 
 			foreach (var d in cashDigits.Reverse())
 			{
-				Game.Renderer.RgbaSpriteRenderer.DrawSprite(
-					ChromeProvider.GetImage(digitCollection, (d - '0').ToString()),
-					new float2(x, 6));
+				var spriteDigit = ChromeProvider.GetImage(digitCollection, (d - '0').ToString());
+				
+				if (spriteDigit != null)
+					Game.Renderer.RgbaSpriteRenderer.DrawSprite(spriteDigit, new float2(x, 6));
+				
 				x -= 14;
 			}
 		}


### PR DESCRIPTION
This Pr prevents a crash which can happen when we pass "null-sprites" to DrawSprite

To Reproduce this Crash:
- Add more than 999999999++ Credits to player
- game will crash with NRE 

Dependencies:
#7344

```
Tiberian Sun Mod at Version {DEV_VERSION}
Operating System: Windows (Microsoft Windows NT 6.1.7601 Service Pack 1)
Runtime Version: .NET CLR 4.0.30319.18408
Exception of type `System.NullReferenceException`: Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.
   bei OpenRA.Graphics.SpriteRenderer.DrawSprite(Sprite s, float2 location) in d:\Projekte\OpenRA\OpenRA.Game\Graphics\SpriteRenderer.cs:Zeile 84.
   bei OpenRA.Mods.D2k.Widgets.MoneyBinWidget.Draw()
   bei OpenRA.Widgets.Widget.DrawOuter() in d:\Projekte\OpenRA\OpenRA.Game\Widgets\Widget.cs:Zeile 396.
   bei OpenRA.Widgets.Widget.DrawOuter() in d:\Projekte\OpenRA\OpenRA.Game\Widgets\Widget.cs:Zeile 398.
   bei OpenRA.Widgets.Widget.DrawOuter() in d:\Projekte\OpenRA\OpenRA.Game\Widgets\Widget.cs:Zeile 398.
   bei OpenRA.Widgets.Widget.DrawOuter() in d:\Projekte\OpenRA\OpenRA.Game\Widgets\Widget.cs:Zeile 398.
   bei OpenRA.Widgets.Widget.DrawOuter() in d:\Projekte\OpenRA\OpenRA.Game\Widgets\Widget.cs:Zeile 398.
   bei OpenRA.Widgets.Widget.DrawOuter() in d:\Projekte\OpenRA\OpenRA.Game\Widgets\Widget.cs:Zeile 398.
   bei OpenRA.Widgets.Ui.Draw() in d:\Projekte\OpenRA\OpenRA.Game\Widgets\Widget.cs:Zeile 75.
   bei OpenRA.Game.RenderTick() in d:\Projekte\OpenRA\OpenRA.Game\Game.cs:Zeile 505.
   bei OpenRA.Game.Loop() in d:\Projekte\OpenRA\OpenRA.Game\Game.cs:Zeile 616.
   bei OpenRA.Game.Run() in d:\Projekte\OpenRA\OpenRA.Game\Game.cs:Zeile 636.
   bei OpenRA.Program.Run(String[] args) in d:\Projekte\OpenRA\OpenRA.Game\Support\Program.cs:Zeile 111.
   bei OpenRA.Program.Main(String[] args) in d:\Projekte\OpenRA\OpenRA.Game\Support\Program.cs:Zeile 39.
```
