### PR TITLE
Avoid a globally shared SheetBuilder in SpriteFont.

### DIFF
--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -37,6 +37,8 @@ namespace OpenRA.Graphics
 		readonly Queue<IVertexBuffer<Vertex>> tempBuffers = new Queue<IVertexBuffer<Vertex>>();
 		readonly Stack<Rectangle> scissorState = new Stack<Rectangle>();
 
+		SheetBuilder fontSheetBuilder;
+
 		Size? lastResolution;
 		int2? lastScroll;
 		float? lastZoom;
@@ -94,8 +96,13 @@ namespace OpenRA.Graphics
 		public void InitializeFonts(Manifest m)
 		{
 			using (new Support.PerfTimer("SpriteFonts"))
+			{
+				if (fontSheetBuilder != null)
+					fontSheetBuilder.Dispose();
+				fontSheetBuilder = new SheetBuilder(SheetType.BGRA);
 				Fonts = m.Fonts.ToDictionary(x => x.Key,
-					x => new SpriteFont(Platform.ResolvePath(x.Value.First), x.Value.Second)).AsReadOnly();
+					x => new SpriteFont(Platform.ResolvePath(x.Value.First), x.Value.Second, fontSheetBuilder)).AsReadOnly();
+			}
 		}
 
 		public void BeginFrame(int2 scroll, float zoom)
@@ -246,6 +253,8 @@ namespace OpenRA.Graphics
 			foreach (var buffer in tempBuffers)
 				buffer.Dispose();
 			tempBuffers.Clear();
+			if (fontSheetBuilder != null)
+				fontSheetBuilder.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -31,8 +31,8 @@ namespace OpenRA.Graphics
 
 	public sealed class SheetBuilder : IDisposable
 	{
+		public readonly SheetType Type;
 		readonly List<Sheet> sheets = new List<Sheet>();
-		readonly SheetType type;
 		readonly Func<Sheet> allocateSheet;
 
 		Sheet current;
@@ -54,7 +54,7 @@ namespace OpenRA.Graphics
 		public SheetBuilder(SheetType t, Func<Sheet> allocateSheet)
 		{
 			channel = TextureChannel.Red;
-			type = t;
+			Type = t;
 			current = allocateSheet();
 			sheets.Add(current);
 			this.allocateSheet = allocateSheet;
@@ -93,7 +93,7 @@ namespace OpenRA.Graphics
 
 		TextureChannel? NextChannel(TextureChannel t)
 		{
-			var nextChannel = (int)t + (int)type;
+			var nextChannel = (int)t + (int)Type;
 			if (nextChannel > (int)TextureChannel.Alpha)
 				return null;
 


### PR DESCRIPTION
A globally shared sheet builder leaks memory and resources between mod switches. Instead, we create and inject the sheet builder during mod startup to ensure we still share the builder across all fonts, but can reclaim it when the mod is unloaded.
