### PR TITLE
Fix the prerequisites of mobile gap generator

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -495,7 +495,7 @@ MGG:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 160
-		Prerequisites: atek, ~vehicles.allies, ~techlevel.unrestricted
+		Prerequisites: atek, ~vehicles.france, ~techlevel.unrestricted
 	Valued:
 		Cost: 1200
 	Tooltip:


### PR DESCRIPTION
According to the lobby tooltips, it should be available to france only.
