### PR TITLE
D2K - Carryall moved to last in Starport.

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -7,7 +7,7 @@
 		Description: Large winged, planet-bound ship\n  Automatically lifts harvesters.
 	Buildable:
 		Queue: Aircraft
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 120
 	Health:
 		HP: 250
 	Armor:


### PR DESCRIPTION
Carryall was between trike and quad in Starport and looks a bit odd. It should be in last like orginal Starport.
