### PR TITLE
Disable the diplomacy menu in mission or campaign maps

### DIFF
--- a/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/Ingame/LeaveMapLogic.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.RA.Widgets
 			}
 
 			var statsButton = dialog.Get<ButtonWidget>("STATS_BUTTON");
-			statsButton.IsVisible = () => !(world.Map.Type == "Mission" || world.Map.Type == "Campaign") || world.IsReplay;
+			statsButton.IsVisible = () => !world.Map.Visibility.HasFlag(MapVisibility.MissionSelector) || world.IsReplay;
 			statsButton.OnClick = () =>
 			{
 				showStats = true;

--- a/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.RA/Widgets/Logic/OrderButtonsChromeLogic.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.RA.Widgets.Logic
 			var diplomacy = widget.GetOrNull<MenuButtonWidget>("DIPLOMACY_BUTTON");
 			if (diplomacy != null)
 			{
-				diplomacy.Visible = world.Players.Any(a => a != world.LocalPlayer && !a.NonCombatant);
+				diplomacy.Visible = !world.Map.Visibility.HasFlag(MapVisibility.MissionSelector) && world.Players.Any(a => a != world.LocalPlayer && !a.NonCombatant);
 				diplomacy.IsDisabled = () => disableSystemButtons;
 				diplomacy.OnClick = () => OpenMenuPanel(diplomacy);
 			}


### PR DESCRIPTION
Before:
![diplomacy](https://cloud.githubusercontent.com/assets/7704140/5925578/c67d8536-a664-11e4-96ff-7b49e368d5f7.png)

Maybe we should expose that to map.yaml (not to the lobby).
