### PR TITLE
Ignore designer generated files during StyleCop checks.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/CheckCodeStyle.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckCodeStyle.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var console = new StyleCopConsole(null, false, null, null, true);
 			var project = new CodeProject(0, projectPath, new Configuration(null));
-			foreach (var filePath in Directory.GetFiles(projectPath, "*.cs", SearchOption.AllDirectories).Where(p => !p.Contains(".Designer")))
+			foreach (var filePath in Directory.GetFiles(projectPath, "*.cs", SearchOption.AllDirectories))
 				console.Core.Environment.AddSourceCode(project, filePath, null);
 
 			console.ViolationEncountered += OnViolationEncountered;

--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -1,4 +1,11 @@
 <StyleCopSettings Version="105">
+  <Parsers>
+      <Parser ParserId="StyleCop.CSharp.CsParser">
+        <ParserSettings>
+          <BooleanProperty Name="AnalyzeDesignerFiles">False</BooleanProperty>
+        </ParserSettings>
+      </Parser>
+  </Parsers>
   <Analyzers>
     <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
       <Rules>


### PR DESCRIPTION
Designer generated file have always been able to generate style warnings, but until the introduction of StyleCopPlus in #7382 they happened to not.

Enforcing style on these files seems useless, and they're now failing some style checks, so it would seem to make sense to disable checks on these files.
