### PR TITLE
Fixed OpenRA.Mods.D2k/Widgets/MoneyBinWidget.cs: [SP2000] Invalid spacing at the end of the line.

### DIFF
--- a/OpenRA.Mods.D2k/Widgets/MoneyBinWidget.cs
+++ b/OpenRA.Mods.D2k/Widgets/MoneyBinWidget.cs
@@ -50,10 +50,10 @@ namespace OpenRA.Mods.D2k.Widgets
 			foreach (var d in cashDigits.Reverse())
 			{
 				var spriteDigit = ChromeProvider.GetImage(digitCollection, (d - '0').ToString());
-				
+
 				if (spriteDigit != null)
 					Game.Renderer.RgbaSpriteRenderer.DrawSprite(spriteDigit, new float2(x, 6));
-				
+
 				x -= 14;
 			}
 		}


### PR DESCRIPTION
Fixes the StyleCop violations introduced by https://github.com/OpenRA/OpenRA/pull/7342.
