### PR TITLE
Clean up the post-build commands in the csprojs

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -511,8 +511,6 @@
   <PropertyGroup>
     <PostBuildEvent>mkdir "$(SolutionDir)mods/common/"
 copy "$(TargetPath)" "$(SolutionDir)mods/common/"
-cd "$(SolutionDir)thirdparty/"
-copy "FuzzyLogicLibrary.dll" "$(SolutionDir)"
 cd "$(SolutionDir)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -40,7 +40,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CustomCommands>
       <CustomCommands>
-        <Command type="AfterBuild" command="cp ../thirdparty/FuzzyLogicLibrary.dll ../" workingdir="${ProjectDir}" />
         <Command type="AfterBuild" command="cp ${TargetFile} ../mods/ra" workingdir="${ProjectDir}" />
         <Command type="AfterBuild" command="cp ${TargetFile}.mdb ../mods/ra" workingdir="${ProjectDir}" />
       </CustomCommands>
@@ -214,8 +213,6 @@
   <PropertyGroup>
     <PostBuildEvent>mkdir "$(SolutionDir)mods/ra/"
 copy "$(TargetPath)" "$(SolutionDir)mods/ra/"
-cd "$(SolutionDir)thirdparty/"
-copy "FuzzyLogicLibrary.dll" "$(SolutionDir)"
 cd "$(SolutionDir)"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The FuzzyLogicLibrary copy is already handled in make dependencies, and the cd command is unnecessary.
