### PR TITLE
Fix map importer using the map title as the output filename.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -9,9 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
@@ -27,7 +25,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var rules = Game.ModData.RulesetCache.LoadDefaultRules();
 			var map = LegacyMapImporter.Import(args[1], modData.Manifest.Mod.Id, rules, e => Console.WriteLine(e));
-			var dest = map.Title + ".oramap";
+			var dest = Path.ChangeExtension(args[1], "oramap");
 			map.Save(dest);
 			Console.WriteLine(dest + " saved.");
 		}


### PR DESCRIPTION
This is broken because the map title can make an invalid filename. The bug currently prevents people from importing the second Soviet mission as-is because its title is `<none>` in the ini file.
