### PR TITLE
Fixes #7219. In addition, sets cursor corresponding to the order with hi...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Also thanks to:
     * Iran
     * Jacob Dufault (jacobdufault)
     * James Dunne (jsd)
+    * Jan-Willem Buurlage (jwbuurlage)
     * Jason (atlimit8)
     * Jeff Harris (jeff_1amstudios)
     * Jes

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -79,12 +79,13 @@ namespace OpenRA.Orders
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}
 
-			var orders = world.Selection.Actors
+			var ordersWithCursor = world.Selection.Actors
 				.Select(a => OrderForUnit(a, target, mi))
-				.Where(o => o != null);
+				.Where(o => o != null && o.Cursor != null);
 
-			var cursorName = orders.Select(o => o.Cursor).FirstOrDefault();
-			return cursorName ?? (useSelect ? "select" : "default");
+			var cursorOrder = ordersWithCursor.MaxByOrDefault(o => o.Order.OrderPriority);
+
+			return cursorOrder != null ? cursorOrder.Cursor : (useSelect ? "select" : "default");
 		}
 
 		static UnitOrderResult OrderForUnit(Actor self, Target target, MouseInput mi)

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -117,10 +117,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterTransportTargeter("EnterTransport", 6,
+				yield return new EnterTransportTargeter("EnterTransport", 5,
 					target => IsCorrectCargoType(target), target => CanEnter(target),
 					Info.AlternateTransportsMode);
-				yield return new EnterTransportsTargeter("EnterTransports", 6,
+				yield return new EnterTransportsTargeter("EnterTransports", 5,
 					target => IsCorrectCargoType(target), target => CanEnter(target),
 					Info.AlternateTransportsMode);
 			}


### PR DESCRIPTION
...ghest priority.

While fixing #7219 I noticed that cursors do not correspond to the orders with highest priority. I went ahead and fixed this in what I think is the best way possible, select orders that have a cursor and take the one with highest priority. Testing confirms that these issues are fixed, and it is highly unlikely that this breaks functionality elsewhere.
