### PR TITLE
Fixed the faction insignia being drawn over the radar minimap

### DIFF
--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -161,7 +161,6 @@ Container@PLAYER_WIDGETS:
 							Y: 34
 							Width: 202
 							Height: 202
-							Children:
 						Image@MINIMAP:
 							X: 12
 							Y: 34

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -149,6 +149,12 @@ Container@PLAYER_WIDGETS:
 							Y: 34
 							Width: 202
 							Height: 202
+						Image@INSIGNIA:
+							Logic: AddRaceSuffixLogic
+							X: 60
+							Y: 75
+							ImageCollection: radar
+							ImageName: insignia
 						Radar@RADAR_MINIMAP:
 							WorldInteractionController: INTERACTION_CONTROLLER
 							X: 12
@@ -161,12 +167,6 @@ Container@PLAYER_WIDGETS:
 							Y: 34
 							ImageName: overlapping-elements
 							ImageCollection: minimap
-						Image@INSIGNIA:
-							Logic: AddRaceSuffixLogic
-							X: 60
-							Y: 75
-							ImageCollection: radar
-							ImageName: insignia
 				Label@GAME_TIMER:
 					Logic: GameTimerLogic
 					X: 10

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -161,7 +161,6 @@ Container@PLAYER_WIDGETS:
 							Y: 41
 							Width: 220
 							Height: 220
-							Children:
 				Label@GAME_TIMER:
 					Logic: GameTimerLogic
 					X: 3


### PR DESCRIPTION
An oversight introduced by https://github.com/OpenRA/OpenRA/pull/7384.
