### PR TITLE
Desaturate beacon posters in TD menu.

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -454,6 +454,7 @@ HQ:
 		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
+		BeaconPosterPalette: beaconposter
 		DisplayRadarPing: True
 		CameraActor: camera
 	SupportPowerChargeBar:
@@ -573,6 +574,7 @@ TMPL:
 		MissileWeapon: atomic
 		DisplayBeacon: True
 		BeaconPoster: atomic
+		BeaconPosterPalette: beaconposter
 		DisplayRadarPing: True
 		CameraActor: camera
 	SupportPowerChargeBar:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -28,6 +28,10 @@ World:
 		Filename: temperat.pal
 		ShadowIndex: 3
 		AllowModifiers: false
+	PaletteFromFile@beaconposter:
+		Name: beaconposter
+		Filename: temperat.pal
+		ShadowIndex: 3
 	PaletteFromFile@effect:
 		Name: effect
 		Filename: temperat.pal


### PR DESCRIPTION
Fixes #7395.  The health bar part of that ticket is a duplicate of #6734.
