### PR TITLE
Fixed AppVeyor deploying and failing the build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,5 @@ deploy:
       secure: Z7RC+ckfvf7Kxf2EdWZCP7bgGjRnhgbMeieQP6VVhiZprwvbEzGXI2Wma+FGAq65
     artifact: OpenRA-%APPVEYOR_REPO_TAG_NAME%.exe
     on:
-        appveyor_repo_tag: true
+      branch: master
+      appveyor_repo_tag: true


### PR DESCRIPTION
Looking at https://ci.appveyor.com/project/OpenRA/openra/build/1.0.1049 something is going wrong. This fixes the indention (not sure if that is causing a problem) and adding another condition documented at http://www.appveyor.com/docs/deployment#deploy-on-tag-github-only
