### PR TITLE
Fixed #7472 so that cargo is only shown on allied vehicles

### DIFF
--- a/OpenRA.Game/Traits/SelectionDecorations.cs
+++ b/OpenRA.Game/Traits/SelectionDecorations.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
 		{
-			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer) && self.World.FogObscures(self))
+			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer) || self.World.FogObscures(self))
 				yield break;
 
 			var b = self.Bounds;


### PR DESCRIPTION
Fixed issue #7472 so that only allied vehicle pips are shown. Did the check for EffectiveOwner to show the pips when a vehicle is disguised as ally.
