### PR TITLE
Fix a visual glitch in WithBuildingPlacedOverlay

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public object Create(ActorInitializer init) { return new WithBuildingPlacedOverlay(init.Self, this); }
 	}
 
-	public class WithBuildingPlacedOverlay : INotifyBuildComplete, INotifySold, INotifyDamageStateChanged, INotifyBuildingPlaced
+	public class WithBuildingPlacedOverlay : INotifyBuildComplete, INotifySold, INotifyDamageStateChanged, INotifyBuildingPlaced, INotifyTransform
 	{
 		Animation overlay;
 		bool buildComplete;
@@ -64,6 +64,14 @@ namespace OpenRA.Mods.D2k.Traits
 		{
 			buildComplete = false;
 		}
+
+		public void BeforeTransform(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		public void OnTransform(Actor self) { }
+		public void AfterTransform(Actor self) { }
 
 		public void DamageStateChanged(Actor self, AttackInfo e)
 		{

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -32,7 +32,6 @@ GACNST:
 		ProductionType: Building
 	ProductionBar@Defense:
 		ProductionType: Defense
-	-Sellable:
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
 	WithIdleOverlay@SIDE:


### PR DESCRIPTION
Before it looked like this, when undeploying a ts conyard:
![buildingplacedglitch](https://cloud.githubusercontent.com/assets/7704140/6245531/ddfe6750-b75f-11e4-8e29-a8f8285d5fd7.png)
