### PR TITLE
Reimplementing Left Click Orders with Fixes

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -27,6 +27,8 @@ namespace OpenRA
 {
 	public static class Game
 	{
+		public static MouseButtonPreference mouseButtonPreference = new MouseButtonPreference();
+
 		public const int NetTickScale = 3; // 120 ms net tick for 40 ms local tick
 		public const int Timestep = 40;
 		public const int TimestepJankThreshold = 250; // Don't catch up for delays larger than 250ms

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -27,8 +27,6 @@ namespace OpenRA
 {
 	public static class Game
 	{
-		public static MouseButtonPreference mouseButtonPreference = new MouseButtonPreference();
-
 		public const int NetTickScale = 3; // 120 ms net tick for 40 ms local tick
 		public const int Timestep = 40;
 		public const int TimestepJankThreshold = 250; // Don't catch up for delays larger than 250ms

--- a/OpenRA.Game/Input/InputHandler.cs
+++ b/OpenRA.Game/Input/InputHandler.cs
@@ -49,4 +49,25 @@ namespace OpenRA
 			Sync.CheckSyncUnchanged(world, () => Ui.HandleInput(input));
 		}
 	}
+
+	public class MouseButtonPreference
+	{
+
+		public MouseButton Action
+		{
+			get
+			{
+				return Game.Settings.Game.UseClassicMouseStyle ? MouseButton.Left : MouseButton.Right;
+			}
+		}
+
+
+		public MouseButton Cancel
+		{
+			get
+			{
+				return Game.Settings.Game.UseClassicMouseStyle ? MouseButton.Right : MouseButton.Left;
+			}
+		}
+	}
 }

--- a/OpenRA.Game/Input/InputHandler.cs
+++ b/OpenRA.Game/Input/InputHandler.cs
@@ -52,7 +52,6 @@ namespace OpenRA
 
 	public class MouseButtonPreference
 	{
-
 		public MouseButton Action
 		{
 			get
@@ -60,7 +59,6 @@ namespace OpenRA
 				return Game.Settings.Game.UseClassicMouseStyle ? MouseButton.Left : MouseButton.Right;
 			}
 		}
-
 
 		public MouseButton Cancel
 		{

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -88,6 +88,20 @@ namespace OpenRA.Orders
 			return cursorOrder != null ? cursorOrder.Cursor : (useSelect ? "select" : "default");
 		}
 
+		// Used for classic mouse orders, determines whether or not action at xy is move or select
+		public static bool InputOverridesSelection(World world, int2 xy, MouseInput mi)
+		{
+			var target = Target.FromActor(world.ScreenMap.ActorsAt(xy).WithHighestSelectionPriority());
+			var underCursor = world.Selection.Actors.WithHighestSelectionPriority();
+
+			var o = OrderForUnit(underCursor, target, mi);
+
+			if (o == null || o.Trait is IMove)
+				return true;
+
+			return false;
+		}
+
 		static UnitOrderResult OrderForUnit(Actor self, Target target, MouseInput mi)
 		{
 			if (self.Owner != self.World.LocalPlayer)
@@ -96,7 +110,7 @@ namespace OpenRA.Orders
 			if (self.Destroyed || !target.IsValidFor(self))
 				return null;
 
-			if (mi.Button == Game.mouseButtonPreference.Action)
+			if (mi.Button == Game.Settings.Game.MouseButtonPreference.Action)
 			{
 				foreach (var o in self.TraitsImplementing<IIssueOrder>()
 					.SelectMany(trait => trait.Orders

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -96,10 +96,10 @@ namespace OpenRA.Orders
 
 			var o = OrderForUnit(underCursor, target, mi);
 
-			if (o == null || o.Trait is IMove)
-				return true;
+			if (o != null && o.Order.OverrideSelection)
+				return false;
 
-			return false;
+			return true;
 		}
 
 		static UnitOrderResult OrderForUnit(Actor self, Target target, MouseInput mi)

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Orders
 			if (self.Destroyed || !target.IsValidFor(self))
 				return null;
 
-			if (mi.Button == MouseButton.Right)
+			if (mi.Button == Game.mouseButtonPreference.Action)
 			{
 				foreach (var o in self.TraitsImplementing<IIssueOrder>()
 					.SelectMany(trait => trait.Orders

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -130,6 +130,7 @@ namespace OpenRA
 		public float ViewportEdgeScrollStep = 10f;
 		public float UIScrollSpeed = 50f;
 
+		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;
 		public bool TeamHealthColors = false;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -127,8 +127,10 @@ namespace OpenRA
 		public bool ViewportEdgeScroll = true;
 		public bool LockMouseWindow = false;
 		public MouseScrollType MouseScroll = MouseScrollType.Standard;
+		public MouseButtonPreference MouseButtonPreference = new MouseButtonPreference();
 		public float ViewportEdgeScrollStep = 10f;
 		public float UIScrollSpeed = 50f;
+		public int SelectionDeadzone = 24;
 
 		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -79,6 +79,7 @@ namespace OpenRA.Traits
 		int OrderPriority { get; }
 		bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor);
 		bool IsQueued { get; }
+		bool OverrideSelection { get; }
 	}
 
 	public interface IResolveOrder { void ResolveOrder(Actor self, Order order); }

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -68,9 +68,15 @@ namespace OpenRA.Widgets
 
 				dragStart = xy;
 
-				// Place buildings
-				if (!useClassicMouseStyle || !World.Selection.Actors.Any())
+				// Place buildings, use support powers, and other non-unit things
+				if (!(World.OrderGenerator is UnitOrderGenerator))
+				{
 					ApplyOrders(World, xy, mi);
+					dragStart = dragEnd = null;
+					YieldMouseFocus(mi);
+					lastMousePosition = xy;
+					return true;
+				}
 			}
 
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Move && dragStart.HasValue)
@@ -114,8 +120,6 @@ namespace OpenRA.Widgets
 						World.Selection.Combine(World, newSelection, mi.Modifiers.HasModifier(Modifiers.Shift), dragStart == xy);
 					}
 				}
-				else if (useClassicMouseStyle)
-						ApplyOrders(World, xy, mi);
 
 				dragStart = dragEnd = null;
 				YieldMouseFocus(mi);

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -45,6 +45,10 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public override IOrderGenerator OrderGenerator(string order, SupportPowerManager manager)
 		{
+			// Clear selection if using Left-Click Orders
+			if (Game.Settings.Game.UseClassicMouseStyle)
+				manager.Self.World.Selection.Clear();
+
 			Sound.PlayToPlayer(manager.Self.Owner, Info.SelectTargetSound);
 			var info = Info as IonCannonPowerInfo;
 			return new SelectGenericPowerTarget(order, manager, info.Cursor, MouseButton.Left);

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		public string OrderID { get; private set; }
 		public int OrderPriority { get; private set; }
+		public bool OverrideSelection { get { return true; } }
 
 		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
 		{

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -34,6 +34,10 @@ namespace OpenRA.Mods.Common.Orders
 			producer = queue.Actor;
 			building = name;
 
+			// Clear selection if using Left-Click Orders
+			if (Game.Settings.Game.UseClassicMouseStyle)
+				producer.World.Selection.Clear();
+
 			var map = producer.World.Map;
 			var tileset = producer.World.TileSet.Id.ToLowerInvariant();
 			buildingInfo = map.Rules.Actors[building].Traits.Get<BuildingInfo>();

--- a/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Orders
 		public string OrderID { get; private set; }
 		public int OrderPriority { get; private set; }
 		public bool? ForceAttack = null;
+		public bool OverrideSelection { get { return true; } }
 
 		public abstract bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor);
 		public abstract bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor);

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -302,6 +302,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public string OrderID { get { return "Move"; } }
 		public int OrderPriority { get { return 4; } }
+		public bool OverrideSelection { get { return false; } }
 
 		readonly AircraftInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -194,6 +194,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get; private set; }
 			public int OrderPriority { get; private set; }
+			public bool OverrideSelection { get { return true; } }
 
 			bool CanTargetActor(Actor self, Target target, TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -56,6 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			public string OrderID { get { return "SetRallyPoint"; } }
 			public int OrderPriority { get { return 0; } }
+			public bool OverrideSelection { get { return true; } }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
-			if (mi.Button == MouseButton.Left)
+			if (mi.Button == Game.mouseButtonPreference.Cancel)
 			{
 				world.CancelInputMode();
 				yield break;

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
-			if (mi.Button == Game.mouseButtonPreference.Cancel)
+			if (mi.Button == Game.Settings.Game.MouseButtonPreference.Cancel)
 			{
 				world.CancelInputMode();
 				yield break;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -445,6 +445,7 @@ namespace OpenRA.Mods.Common.Traits
 			public string OrderID { get { return "Harvest"; } }
 			public int OrderPriority { get { return 10; } }
 			public bool IsQueued { get; protected set; }
+			public bool OverrideSelection { get { return true; } }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -619,6 +619,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly MobileInfo unitType;
 			readonly bool rejectMove;
+			public bool OverrideSelection { get { return false; } }
 
 			public MoveOrderTargeter(Actor self, MobileInfo unitType)
 			{

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -102,6 +102,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			public SelectTarget(World world, string order, SupportPowerManager manager, GrantUpgradePower power)
 			{
+				// Clear selection if using Left-Click Orders
+				if (Game.Settings.Game.UseClassicMouseStyle)
+					manager.Self.World.Selection.Clear();
+
 				this.manager = manager;
 				this.order = order;
 				this.power = power;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -239,6 +239,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public SelectGenericPowerTarget(string order, SupportPowerManager manager, string cursor, MouseButton button)
 		{
+			// Clear selection if using Left-Click Orders
+			if (Game.Settings.Game.UseClassicMouseStyle)
+				manager.Self.World.Selection.Clear();
+
 			this.manager = manager;
 			this.order = order;
 			this.cursor = cursor;

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -312,6 +312,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var gs = Game.Settings.Game;
 			var ks = Game.Settings.Keys;
 
+			BindCheckboxPref(panel, "CLASSICORDERS_CHECKBOX", gs, "UseClassicMouseStyle");
 			BindCheckboxPref(panel, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
 			BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gs, "LockMouseWindow");
 			BindSliderPref(panel, "SCROLLSPEED_SLIDER", gs, "ViewportEdgeScrollStep");
@@ -472,6 +473,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			return () =>
 			{
+				gs.UseClassicMouseStyle = dgs.UseClassicMouseStyle;
 				gs.MouseScroll = dgs.MouseScroll;
 				gs.LockMouseWindow = dgs.LockMouseWindow;
 				gs.ViewportEdgeScroll = dgs.ViewportEdgeScroll;

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (actors.Any())
 				world.OrderGenerator = new GenericSelectTarget(actors,
-					"AttackMove", "attackmove", MouseButton.Right);
+					"AttackMove", "attackmove", Game.mouseButtonPreference.Action);
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (actors.Any())
 				world.OrderGenerator = new GenericSelectTarget(actors,
-					"AttackMove", "attackmove", Game.mouseButtonPreference.Action);
+					"AttackMove", "attackmove", Game.Settings.Game.MouseButtonPreference.Action);
 
 			return true;
 		}

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.RA.Traits
 
 			public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 			{
-				if (mi.Button == MouseButton.Left)
+				if (mi.Button == Game.mouseButtonPreference.Cancel)
 				{
 					world.CancelInputMode();
 					yield break;
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA.Traits
 					.MaxByOrDefault(a => a.Info.Traits.Contains<SelectableInfo>()
 						? a.Info.Traits.Get<SelectableInfo>().Priority : int.MinValue);
 
-				if (mi.Button == MouseButton.Right && underCursor == null)
+				if (mi.Button == Game.mouseButtonPreference.Action && underCursor == null)
 				{
 					minelayer.World.CancelInputMode();
 					yield return new Order("PlaceMinefield", minelayer, false) { TargetLocation = xy };

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -197,6 +197,7 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			public string OrderID { get { return "BeginMinefield"; } }
 			public int OrderPriority { get { return 5; } }
+			public bool OverrideSelection { get { return true; } }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.RA.Traits
 
 			public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 			{
-				if (mi.Button == Game.mouseButtonPreference.Cancel)
+				if (mi.Button == Game.Settings.Game.MouseButtonPreference.Cancel)
 				{
 					world.CancelInputMode();
 					yield break;
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.RA.Traits
 					.MaxByOrDefault(a => a.Info.Traits.Contains<SelectableInfo>()
 						? a.Info.Traits.Get<SelectableInfo>().Priority : int.MinValue);
 
-				if (mi.Button == Game.mouseButtonPreference.Action && underCursor == null)
+				if (mi.Button == Game.Settings.Game.MouseButtonPreference.Action && underCursor == null)
 				{
 					minelayer.World.CancelInputMode();
 					yield return new Order("PlaceMinefield", minelayer, false) { TargetLocation = xy };

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
-			if (mi.Button == Game.mouseButtonPreference.Cancel)
+			if (mi.Button == Game.Settings.Game.MouseButtonPreference.Cancel)
 			{
 				world.CancelInputMode();
 				yield break;

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
-			if (mi.Button == MouseButton.Left)
+			if (mi.Button == Game.mouseButtonPreference.Cancel)
 			{
 				world.CancelInputMode();
 				yield break;

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -119,6 +119,7 @@ namespace OpenRA.Mods.RA.Traits
 		public string OrderID { get { return "PortableChronoTeleport"; } }
 		public int OrderPriority { get { return 5; } }
 		public bool IsQueued { get; protected set; }
+		public bool OverrideSelection { get { return true; } }
 
 		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
 		{

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -101,6 +101,10 @@ namespace OpenRA.Mods.RA.Traits
 
 			public SelectTarget(World world, string order, SupportPowerManager manager, ChronoshiftPower power)
 			{
+				// Clear selection if using Left-Click Orders
+				if (Game.Settings.Game.UseClassicMouseStyle)
+					manager.Self.World.Selection.Clear();
+
 				this.manager = manager;
 				this.order = order;
 				this.power = power;

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -320,53 +320,16 @@ Container@SETTINGS_PANEL:
 							Font: Bold
 							Text: Input
 							Align: Center
-						Checkbox@EDGESCROLL_CHECKBOX:
+						Checkbox@CLASSICORDERS_CHECKBOX:
 							X: 15
 							Y: 40
-							Width: 130
-							Height: 20
-							Font: Regular
-							Text: Edge Scrolling
-						Checkbox@LOCKMOUSE_CHECKBOX:
-							X: 15
-							Y: 70
-							Width: 130
-							Height: 20
-							Font: Regular
-							Text: Lock mouse to window
-						Label@SCROLL_SPEED_LABEL:
-							X: PARENT_RIGHT - WIDTH - 270
-							Y: 37
-							Width: 95
-							Height: 25
-							Text: Scroll Speed:
-							Align: Right
-						Slider@SCROLLSPEED_SLIDER:
-							X: PARENT_RIGHT - WIDTH - 15
-							Y: 43
 							Width: 250
 							Height: 20
-							Ticks: 5
-							MinimumValue: 10
-							MaximumValue: 50
-						Label@UI_SCROLL_SPEED_LABEL:
-							X: PARENT_RIGHT - WIDTH - 270
-							Y: 67
-							Width: 95
-							Height: 25
-							Text: UI Scroll Speed:
-							Align: Right
-						Slider@UI_SCROLLSPEED_SLIDER:
-							X: PARENT_RIGHT - WIDTH - 15
-							Y: 73
-							Width: 250
-							Height: 20
-							Ticks: 5
-							MinimumValue: 1
-							MaximumValue: 100
+							Font: Regular
+							Text: Left-Click Orders
 						Label@MOUSE_SCROLL_LABEL:
 							X: PARENT_RIGHT - WIDTH - 120
-							Y: 99
+							Y: 39
 							Width: 160
 							Height: 20
 							Font: Regular
@@ -374,11 +337,55 @@ Container@SETTINGS_PANEL:
 							Align: Right
 						DropDownButton@MOUSE_SCROLL:
 							X: PARENT_RIGHT - WIDTH - 15
-							Y: 98
+							Y: 38
 							Width: 100
 							Height: 25
 							Font: Regular
 							Text: Enabled
+						Checkbox@EDGESCROLL_CHECKBOX:
+							X: 15
+							Y: 70
+							Width: 130
+							Height: 20
+							Font: Regular
+							Text: Edge Scrolling
+						Checkbox@LOCKMOUSE_CHECKBOX:
+							X: 15
+							Y: 100
+							Width: 130
+							Height: 20
+							Font: Regular
+							Text: Lock mouse to window
+						Label@SCROLL_SPEED_LABEL:
+							X: PARENT_RIGHT - WIDTH - 270
+							Y: 67
+							Width: 95
+							Height: 25
+							Text: Scroll Speed:
+							Align: Right
+						Slider@SCROLLSPEED_SLIDER:
+							X: PARENT_RIGHT - WIDTH - 15
+							Y: 73
+							Width: 250
+							Height: 20
+							Ticks: 5
+							MinimumValue: 10
+							MaximumValue: 50
+						Label@UI_SCROLL_SPEED_LABEL:
+							X: PARENT_RIGHT - WIDTH - 270
+							Y: 97
+							Width: 95
+							Height: 25
+							Text: UI Scroll Speed:
+							Align: Right
+						Slider@UI_SCROLLSPEED_SLIDER:
+							X: PARENT_RIGHT - WIDTH - 15
+							Y: 103
+							Width: 250
+							Height: 20
+							Ticks: 5
+							MinimumValue: 1
+							MaximumValue: 100
 						Label@HOTKEYS_TITLE:
 							Y: 135
 							Width: PARENT_RIGHT

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -324,53 +324,16 @@ Background@SETTINGS_PANEL:
 			Width: PARENT_RIGHT - 10
 			Height: PARENT_BOTTOM
 			Children:
-				Checkbox@EDGESCROLL_CHECKBOX:
+				Checkbox@CLASSICORDERS_CHECKBOX:
 					X: 15
 					Y: 40
-					Width: 130
-					Height: 20
-					Font: Regular
-					Text: Edge Scrolling
-				Checkbox@LOCKMOUSE_CHECKBOX:
-					X: 15
-					Y: 70
-					Width: 130
-					Height: 20
-					Font: Regular
-					Text: Lock mouse to window
-				Label@SCROLL_SPEED_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 37
-					Width: 95
-					Height: 25
-					Text: Scroll Speed:
-					Align: Right
-				Slider@SCROLLSPEED_SLIDER:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 43
 					Width: 250
 					Height: 20
-					Ticks: 5
-					MinimumValue: 10
-					MaximumValue: 50
-				Label@UI_SCROLL_SPEED_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 67
-					Width: 95
-					Height: 25
-					Text: UI Scroll Speed:
-					Align: Right
-				Slider@UI_SCROLLSPEED_SLIDER:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 73
-					Width: 250
-					Height: 20
-					Ticks: 5
-					MinimumValue: 1
-					MaximumValue: 100
+					Font: Regular
+					Text: Left-Click Orders
 				Label@MOUSE_SCROLL_LABEL:
 					X: PARENT_RIGHT - WIDTH - 120
-					Y: 99
+					Y: 39
 					Width: 160
 					Height: 20
 					Font: Regular
@@ -378,11 +341,55 @@ Background@SETTINGS_PANEL:
 					Align: Right
 				DropDownButton@MOUSE_SCROLL:
 					X: PARENT_RIGHT - WIDTH - 15
-					Y: 98
+					Y: 38
 					Width: 100
 					Height: 25
 					Font: Regular
 					Text: Enabled
+				Checkbox@EDGESCROLL_CHECKBOX:
+					X: 15
+					Y: 70
+					Width: 130
+					Height: 20
+					Font: Regular
+					Text: Edge Scrolling
+				Checkbox@LOCKMOUSE_CHECKBOX:
+					X: 15
+					Y: 100
+					Width: 130
+					Height: 20
+					Font: Regular
+					Text: Lock mouse to window
+				Label@SCROLL_SPEED_LABEL:
+					X: PARENT_RIGHT - WIDTH - 270
+					Y: 67
+					Width: 95
+					Height: 25
+					Text: Scroll Speed:
+					Align: Right
+				Slider@SCROLLSPEED_SLIDER:
+					X: PARENT_RIGHT - WIDTH - 15
+					Y: 73
+					Width: 250
+					Height: 20
+					Ticks: 5
+					MinimumValue: 10
+					MaximumValue: 50
+				Label@UI_SCROLL_SPEED_LABEL:
+					X: PARENT_RIGHT - WIDTH - 270
+					Y: 97
+					Width: 95
+					Height: 25
+					Text: UI Scroll Speed:
+					Align: Right
+				Slider@UI_SCROLLSPEED_SLIDER:
+					X: PARENT_RIGHT - WIDTH - 15
+					Y: 103
+					Width: 250
+					Height: 20
+					Ticks: 5
+					MinimumValue: 1
+					MaximumValue: 100
 				Label@HOTKEYS_TITLE:
 					Y: 135
 					Width: PARENT_RIGHT


### PR DESCRIPTION
I know they were removed for being unsupported and right click is realistically superior but gosh darn it, it just can't be C&C to me if this isn't there. I fixed the issues stated in #3153 so that it should function much better. This also adds a deadzone in the selection box as per #4952 with a hardcoded value of 50. This is needed mostly to fix It's probably a bit wider than necessary so it could be changed to another hardcoded value if need be pretty easily, but it probably should be bound to a slider on the options menu.

It's still not perfect, but it's much better than it was previously. At any rate, I don't plan to do too much fiddling with this, so if everyone seems to think major changes are still needed I'll just close the request and forget about it for now. I spent too much time already messing around with something so realistically trivial.
