### PR TITLE
Added uninstaller check for running game

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ before_deploy:
   - cp OpenRA.Game/OpenRA.ico .
   - appveyor DownloadFile "http://downloads.sourceforge.net/project/nsis/NSIS 2/2.46/nsis-2.46-setup.exe" -FileName nsissetup.exe
   - nsissetup /S /D=%NSIS_ROOT%
+  - appveyor DownloadFile "http://nsis.sourceforge.net/mediawiki/images/archive/1/18/20140806212030!NsProcess.zip" -FileName NsProcess.zip
+  - 7z e NsProcess.zip -o%NSIS_ROOT%
   - appveyor DownloadFile "https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md" -FileName Changelog.md
   - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\windows" /V3 packaging/windows/OpenRA.nsi'
   - appveyor PushArtifact packaging/windows/OpenRA.Setup.exe -FileName OpenRA-%APPVEYOR_REPO_TAG_NAME%.exe

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -229,17 +229,17 @@ FunctionEnd
 !insertmacro Clean "un."
 
 Section "Uninstall"
-	${nsProcess::FindProcess} "OpenRa.Game.exe" $R0
+	${nsProcess::FindProcess} "OpenRA.Game.exe" $R0
 	IntCmp $R0 0 gameRunning
-	${nsProcess::FindProcess} "OpenRa.exe" $R0
+	${nsProcess::FindProcess} "OpenRA.exe" $R0
 	IntCmp $R0 0 gameRunning
-	${nsProcess::FindProcess} "OpenRa.Editor.exe" $R0
+	${nsProcess::FindProcess} "OpenRA.Editor.exe" $R0
 	IntCmp $R0 0 gameRunning
 	${nsProcess::Unload}
 	Call un.Clean
 	Goto end
 	gameRunning:
-		MessageBox MB_OK|MB_ICONEXCLAMATION "OpenRa is running. Please close it first" /SD IDOK
+		MessageBox MB_OK|MB_ICONEXCLAMATION "OpenRA is running. Please close it first" /SD IDOK
 		abort
 	end:
 SectionEnd

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -18,6 +18,7 @@
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
 !include "WordFunc.nsh"
+!include "nsProcess.nsh"
 
 Name "OpenRA"
 OutFile "OpenRA.Setup.exe"
@@ -211,6 +212,7 @@ Function ${UN}Clean
 	Delete $INSTDIR\eluant.dll
 	Delete $INSTDIR\freetype6.dll
 	Delete $INSTDIR\zlib1.dll
+	Delete $INSTDIR\SDL2-CS.dll
 	RMDir /r $INSTDIR\Support
 	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA"
 	Delete $INSTDIR\uninstaller.exe
@@ -227,7 +229,19 @@ FunctionEnd
 !insertmacro Clean "un."
 
 Section "Uninstall"
+	${nsProcess::FindProcess} "OpenRa.Game.exe" $R0
+	IntCmp $R0 0 gameRunning
+	${nsProcess::FindProcess} "OpenRa.exe" $R0
+	IntCmp $R0 0 gameRunning
+	${nsProcess::FindProcess} "OpenRa.Editor.exe" $R0
+	IntCmp $R0 0 gameRunning
+	${nsProcess::Unload}
 	Call un.Clean
+	Goto end
+	gameRunning:
+		MessageBox MB_OK|MB_ICONEXCLAMATION "OpenRa is running. Please close it first" /SD IDOK
+		abort
+	end:
 SectionEnd
 
 ;***************************


### PR DESCRIPTION
The uninstaller now checks if the game or editor is running, fixes #7142.
This requires a new [NSIS plugin(NsProcess)](http://nsis.sourceforge.net/NsProcess_plugin).
I also fixed a dll not getting removed by the uninstaller.
