### PR TITLE
Prevent VqaPlayerWidget from eating the radar bin's mouse input

### DIFF
--- a/OpenRA.Game/Widgets/VqaPlayerWidget.cs
+++ b/OpenRA.Game/Widgets/VqaPlayerWidget.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Widgets
 
 		public override bool HandleMouseInput(MouseInput mi)
 		{
-			return RenderBounds.Contains(mi.Location);
+			return RenderBounds.Contains(mi.Location) && Skippable;
 		}
 
 		public void Play()


### PR DESCRIPTION
This fixes a bug not introduced but exposed by #7156: with the vqa player widget in the player bin, it was not possible anymore to slew the radar's viewport using the mouse, since the widget ate all mouse input.

Fixes #7530 then
