### PR TITLE
Change default facing to 0

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string[] RepairBuildings = { "fix" };
 		[ActorReference]
 		public readonly string[] RearmBuildings = { "hpad", "afld" };
-		public readonly int InitialFacing = 128;
+		public readonly int InitialFacing = 0;
 		public readonly int ROT = 255;
 		public readonly int Speed = 1;
 		public readonly string[] LandableTerrainTypes = { };

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int WaitSpread = 2;
 
-		public readonly int InitialFacing = 128;
+		public readonly int InitialFacing = 0;
 
 		[Desc("Rate of Turning")]
 		public readonly int ROT = 255;

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 					new LocationInit(sp),
 					new OwnerInit(p),
 					new SkipMakeAnimsInit(),
+					new FacingInit(128),
 				});
 			}
 


### PR DESCRIPTION
As noone can say what the reason was for the previous default value of 128, and the original games used 0 as default facing as well according to reaperrr, I went ahead and changed it.

I did not notice any impact ingame, except that the starting MCV in skirmish games then faced north, so I added a little change to fix that. The facing of the other starting units was already randomized. Everything else continues to work as before.

Fixes #7516.
