### PR TITLE
Sell and power down icon fixed on captured building

### DIFF
--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -43,8 +43,14 @@ namespace OpenRA.Mods.Common.Orders
 					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.TraitsImplementing<T>()
 						.Any(Exts.IsTraitEnabled));
 
-				if (underCursor != null)
-					yield return new Order(order, underCursor, false);
+				if (underCursor == null)
+					yield break;
+
+				var building = underCursor.TraitOrDefault<Building>();
+				if (building != null && building.Locked)
+					yield break;
+
+				yield return new Order(order, underCursor, false);
 			}
 		}
 


### PR DESCRIPTION
The user can't sell or powerdown a building when it is being captured, the icon however indicated that this was possible. See #7508.
