### PR TITLE
Fix the EnemyWatcher trait (hotfix)

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Interval in ticks between scanning for enemies.")]
 		public readonly int ScanInterval = 25;
 
-		[Desc("Minimal interval in ticks between notifications.")]
+		[Desc("Minimal ticks in-between notifications.")]
 		public readonly int NotificationInterval = 750;
 
 		public object Create(ActorInitializer init) { return new EnemyWatcher(init.Self, this); }
@@ -89,7 +89,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (playedNotifications.Contains(actor.Trait.Info.Notification))
 					continue;
 
-				Announce(self, actor);
+				if (self.Owner == self.World.RenderPlayer)
+					Announce(self, actor);
 			}
 
 			if (announcedAny)
@@ -101,8 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Announce(Actor self, TraitPair<AnnounceOnSeen> announce)
 		{
 			// Audio notification
-			if (self.World.LocalPlayer != null)
-				Sound.PlayNotification(self.World.Map.Rules, self.World.LocalPlayer, "Speech", announce.Trait.Info.Notification, self.Owner.Country.Race);
+			Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", announce.Trait.Info.Notification, self.Owner.Country.Race);
 
 			// Radar notificaion
 			if (announce.Trait.Info.PingRadar && radarPings.Value != null)

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -75,6 +75,9 @@ namespace OpenRA.Mods.Common.Traits
 				 || self.Owner.Stances[actor.Actor.Owner] != Stance.Enemy)
 					continue;
 
+				if (actor.Actor.IsDead || !actor.Actor.IsInWorld)
+					continue;
+
 				// The actor is not currently visible
 				if (!self.Owner.Shroud.IsVisible(actor.Actor))
 					continue;

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int ScanInterval = 25;
 
 		[Desc("Minimal interval in ticks between notifications.")]
-		public readonly int NotificationInterval = 200;
+		public readonly int NotificationInterval = 750;
 
 		public object Create(ActorInitializer init) { return new EnemyWatcher(init.Self, this); }
 	}

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -93,7 +93,9 @@ namespace OpenRA.Mods.D2k.Activities
 		void NotifyPlayer(Player player, WPos location)
 		{
 			Sound.PlayNotification(player.World.Map.Rules, player, "Speech", swallow.Info.WormAttackNotification, player.Country.Race);
-			radarPings.Add(() => true, location, Color.Red, 50);
+
+			if (player == player.World.RenderPlayer)
+				radarPings.Add(() => true, location, Color.Red, 50);
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -115,11 +115,7 @@ namespace OpenRA.Mods.D2k.Activities
 				if (self.World.SharedRandom.Next() % 100 <= sandworm.Info.ChanceToDisappear)
 				{
 					self.CancelActivity();
-					self.World.AddFrameEndTask(w => w.Remove(self));
-
-					var wormManager = self.World.WorldActor.TraitOrDefault<WormManager>();
-					if (wormManager != null)
-						wormManager.DecreaseWormCount();
+					self.World.AddFrameEndTask(w => self.Kill(self));
 				}
 				else
 					renderUnit.DefaultAnimation.ReplaceAnim("idle");


### PR DESCRIPTION
Fixing two things that popped up in today's test game with @obrakmann and @pchote - notification intervals and players that hear the notifications. Currently in a muliplayer game you hear everyone's notifications, not just yours.
