### PR TITLE
Adjust DisabledOverlay.ModifyRender to be more efficient.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Modifiers/DisabledOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/DisabledOverlay.cs
@@ -21,11 +21,19 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			var disabled = self.IsDisabled();
+			if (!self.IsDisabled())
+				return r;
+
+			return ModifiedRender(self, wr, r);
+		}
+
+		IEnumerable<IRenderable> ModifiedRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
+		{
 			foreach (var a in r)
 			{
 				yield return a;
-				if (disabled && !a.IsDecoration)
+
+				if (!a.IsDecoration)
 					yield return a.WithPalette(wr.Palette("disabled"))
 						.WithZOffset(a.ZOffset + 1)
 						.AsDecoration();

--- a/OpenRA.Mods.Common/Traits/Modifiers/UpgradeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/UpgradeOverlay.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (IsTraitDisabled)
 				return r;
+
 			return ModifiedRender(self, wr, r);
 		}
 


### PR DESCRIPTION
When not disabled, ModifyRender doesn't actually alter the sequence, so we can just return it directly and avoid adding another layer of enumerable. If it is disabled, then the modifying enumerable has one less condition to check inside the loop.

Note: This is basically the same PR as #7292, just applied to the disabled overlay instead.
