### PR TITLE
Give ally players a yellow health bar (team health colors)

### DIFF
--- a/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
@@ -76,12 +76,28 @@ namespace OpenRA.Graphics
 
 		Color GetHealthColor(Health health)
 		{
-			if (Game.Settings.Game.TeamHealthColors)
+			var player = actor.World.RenderPlayer ?? actor.World.LocalPlayer;
+
+			if (Game.Settings.Game.TeamHealthColors && player != null && !player.Spectating)
 			{
-				var isAlly = actor.Owner.IsAlliedWith(actor.World.LocalPlayer)
-					|| (actor.EffectiveOwner != null && actor.EffectiveOwner.Disguised
-					&& actor.World.LocalPlayer.IsAlliedWith(actor.EffectiveOwner.Owner));
-				return isAlly ? Color.LimeGreen : actor.Owner.NonCombatant ? Color.Tan : Color.Red;
+				var apparentOwner = actor.EffectiveOwner != null && actor.EffectiveOwner.Disguised
+					? actor.EffectiveOwner.Owner
+					: actor.Owner;
+
+				// For friendly spies, treat the unit's owner as the actual owner
+				if (actor.Owner.IsAlliedWith(actor.World.RenderPlayer))
+					apparentOwner = actor.Owner;
+
+				if (apparentOwner == player)
+					return Color.LimeGreen;
+
+				if (apparentOwner.IsAlliedWith(player))
+					return Color.Yellow;
+
+				if (apparentOwner.NonCombatant)
+					return Color.Tan;
+
+				return Color.Red;
 			}
 			else
 				return health.DamageState == DamageState.Critical ? Color.Red :

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -33,7 +33,6 @@ namespace OpenRA
 		public readonly string InternalName;
 		public readonly CountryInfo Country;
 		public readonly bool NonCombatant = false;
-		public readonly bool Spectating = false;
 		public readonly bool Playable = true;
 		public readonly int ClientIndex;
 		public readonly PlayerReference PlayerReference;
@@ -45,6 +44,7 @@ namespace OpenRA
 		public bool IsBot;
 		public int SpawnPoint;
 		public bool HasObjectives = false;
+		public bool Spectating;
 
 		public Shroud Shroud;
 		public World World { get; private set; }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (world.ObserveAfterWinOrLose && world.LocalPlayer.WinState != WinState.Undefined)
 						Game.RunAfterTick(() =>
 						{
+							world.LocalPlayer.Spectating = true;
 							playerRoot.RemoveChildren();
 							Game.LoadWidget(world, "OBSERVER_WIDGETS", playerRoot, new WidgetArgs());
 						});


### PR DESCRIPTION
Was originally noted in #2462 but missed. Helps to differentiate your own forces from an ally.

Down the road, or even now, we should make these colours configurable for colorblindness. Several RTS replace green with blue as an example.
