### PR TITLE
Fixed the hard-coded Dune 2000 production tab hotkeys

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -209,6 +209,8 @@ namespace OpenRA
 		public Hotkey ProductionTypeVehicleKey = new Hotkey(Keycode.Y, Modifiers.None);
 		public Hotkey ProductionTypeAircraftKey = new Hotkey(Keycode.U, Modifiers.None);
 		public Hotkey ProductionTypeNavalKey = new Hotkey(Keycode.I, Modifiers.None);
+		public Hotkey ProductionTypeTankKey = new Hotkey(Keycode.I, Modifiers.None);
+		public Hotkey ProductionTypeMerchantKey = new Hotkey(Keycode.O, Modifiers.None);
 
 		public Hotkey GetProductionHotkey(int index)
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -423,7 +423,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "ProductionTypeInfantryKey", "Infantry Tab" },
 					{ "ProductionTypeVehicleKey", "Vehicle Tab" },
 					{ "ProductionTypeAircraftKey", "Aircraft Tab" },
-					{ "ProductionTypeNavalKey", "Naval Tab" }
+					{ "ProductionTypeNavalKey", "Naval Tab" },
+					{ "ProductionTypeTankKey", "Tank Tab" },
+					{ "ProductionTypeMerchantKey", "Starport Tab" }
 				};
 
 				for (var i = 1; i <= 24; i++)

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -258,7 +258,6 @@ Container@PLAYER_WIDGETS:
 					Height: 243
 					Children:
 						ProductionTypeButton@BUILDING:
-							Key: e
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -266,13 +265,13 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Buildings
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Building
+							HotkeyName: ProductionTypeBuildingKey
 							Children:
 								Image@ICON:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@INFANTRY:
-							Key: t
 							Y: 31
 							Width: 25
 							Height: 25
@@ -281,13 +280,13 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Infantry
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Infantry
+							HotkeyName: ProductionTypeInfantryKey
 							Children:
 								Image@ICON:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@VEHICLE:
-							Key: y
 							Y: 62
 							Width: 25
 							Height: 25
@@ -296,13 +295,13 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
+							HotkeyName: ProductionTypeVehicleKey
 							Children:
 								Image@ICON:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@TANKS:
-							Key: y
 							Y: 93
 							Width: 25
 							Height: 25
@@ -311,13 +310,13 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Tanks
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Armor
+							HotkeyName: ProductionTypeTankKey
 							Children:
 								Image@ICON:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@AIRCRAFT:
-							Key: y
 							Y: 124
 							Width: 25
 							Height: 25
@@ -326,13 +325,13 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Aircraft
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Aircraft
+							HotkeyName: ProductionTypeAircraftKey
 							Children:
 								Image@ICON:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@STARPORT:
-							Key: y
 							Y: 155
 							Width: 25
 							Height: 25
@@ -341,6 +340,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Starport
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Starport
+							HotkeyName: ProductionTypeMerchantKey
 							Children:
 								Image@ICON:
 									X: 5


### PR DESCRIPTION
A followup of https://github.com/OpenRA/OpenRA/pull/7384. This makes them configurable in the Input tab and displays them in the tooltip.
