### PR TITLE
Fixed drawing lines under the fog

### DIFF
--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -72,6 +72,9 @@ namespace OpenRA.Traits
 				if (target.Type == TargetType.Invalid)
 					continue;
 
+				if (target.IsVisibleFor(self))
+					continue;
+
 				yield return new TargetLineRenderable(new[] { self.CenterPosition, target.CenterPosition }, c);
 			}
 		}

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Traits
 				if (target.Type == TargetType.Invalid)
 					continue;
 
-				if (target.IsVisibleFor(self))
+				if (self.IsVisibleFor(target))
 					continue;
 
 				yield return new TargetLineRenderable(new[] { self.CenterPosition, target.CenterPosition }, c);

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Traits
 				if (target.Type == TargetType.Invalid)
 					continue;
 
-				if (self.IsVisibleFor(target))
+				if (!target.IsVisibleFor(self))
 					continue;
 
 				yield return new TargetLineRenderable(new[] { self.CenterPosition, target.CenterPosition }, c);

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -89,6 +89,14 @@ namespace OpenRA.Traits
 			return true;
 		}
 
+		public bool IsVisibleFor(Actor targeter)
+		{
+			if (targeter == null || actor == null)
+				return false;
+
+			return targeter.Owner.Shroud.IsVisible(actor);
+		}
+
 		public bool RequiresForceFire
 		{
 			get { return targetable != null && targetable.RequiresForceFire; }


### PR DESCRIPTION
Fixed https://github.com/OpenRA/OpenRA/issues/7498 so that lines won't be drawn if the actor has moved in the shroud. 
