### PR TITLE
Speed up map border shroud & fix viewport visible cells

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -163,16 +163,20 @@ namespace OpenRA.Graphics
 					var wtl = worldRenderer.Position(TopLeft);
 					var wbr = worldRenderer.Position(BottomRight);
 
-					// Visible rectangle in map coordinates
-					var ctl = new MPos(wtl.X / 1024, wtl.Y / 1024);
+					// Due to diamond tile staggering, we need to adjust the top-left bounds outwards by half a cell.
+					if (map.TileShape == TileShape.Diamond)
+						wtl -= new WVec(512, 512, 0);
+
+					// Visible rectangle in map coordinates.
 					var dy = map.TileShape == TileShape.Diamond ? 512 : 1024;
-					var cbr = new MPos((wbr.X + 1023) / 1024, (wbr.Y + dy - 1) / dy);
+					var ctl = new MPos(wtl.X / 1024, wtl.Y / dy);
+					var cbr = new MPos(wbr.X / 1024, wbr.Y / dy);
 
-					// Add a 1 cell cordon to prevent holes, then convert back to cell coordinates
-					var tl = map.Clamp(new MPos(ctl.U - 1, ctl.V - 1).ToCPos(map));
+					var tl = map.Clamp(ctl.ToCPos(map));
 
-					// Also need to account for height of cells in rows below the bottom
-					var br = map.Clamp(new MPos(cbr.U + 1, cbr.V + 2 + maxGroundHeight / 2).ToCPos(map));
+					// Also need to account for height of cells in rows below the bottom.
+					var heightPadding = map.TileShape == TileShape.Diamond ? 2 : 0;
+					var br = map.Clamp(new MPos(cbr.U, cbr.V + heightPadding + maxGroundHeight / 2).ToCPos(map));
 
 					cells = new CellRegion(map.TileShape, tl, br);
 					cellsDirty = false;

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void RenderShroud(WorldRenderer wr, Shroud shroud)
 		{
 			Update(shroud);
-			Render(CellRegion.Expand(wr.Viewport.VisibleCells, 1));
+			Render(wr.Viewport.VisibleCells);
 		}
 
 		void Update(Shroud newShroud)
@@ -269,6 +269,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		void Render(CellRegion visibleRegion)
 		{
+			// Due to diamond tile staggering, we need to expand the cordon to get full shroud coverage.
+			if (map.TileShape == TileShape.Diamond)
+				visibleRegion = CellRegion.Expand(visibleRegion, 1);
+
 			if (currentShroud == null)
 				RenderMapBorderShroud(visibleRegion);
 			else
@@ -279,7 +283,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// The map border shroud only affects the map border. If none of the visible cells are on the border, then
 			// we don't need to render anything and can bail early for performance.
-			if (map.Cells.Contains(visibleRegion))
+			if (CellRegion.Expand(map.Cells, -1).Contains(visibleRegion))
 				return;
 
 			// Render the shroud that just encroaches at the map border. This shroud is always fully cached, so we can


### PR DESCRIPTION
This PR is technically two in one (and I can split it if required) but there is a minor dependency between the commits and they're fairly small so I'm hoping nobody will mind too much :)
#### Speed up map shroud border

When rendering the shroud that only affects the map border (for example, on the RA shellmap, when "disable shroud" is chosen during observing or when the "disable fog and shroud" cheat is active) we can skip the render entirely if the map border isn't even visible onscreen. This buys a surprising amount of performance as looping over all the visible cells to render nothing is still pretty expensive. On the RA shellmap total CPU time spent rendering the shroud drops from 3.75% to 0.05% (the border is never visible here so we can always bail early).

To test this, just make sure the shroud continues to display correctly at the map border when using one of the modes described above.
#### Fix visible cells calculation

Viewport.VisibleCells was actually returning a larger region than it needed to. This is a correctness issue, as well as a small perf hit since cells that are offscreen are being rendered.

I reworked the calculation to something that I hope covers the minimal area.

To test this, make sure that when panning both a rectangular and isometric map that you can always see cells at the edge of the screen.

If you specifically want to test that the new calculation covers a smaller, more correct area, try the following:
Insert a line in Viewport.cs at line 181 (or thereabouts) so it looks like this.

``` csharp
cells = new CellRegion(map.TileShape, tl, br);
cells = CellRegion.Expand(cells, -1); // Extra line. This will leave a 1 cell gap between the edge of the screen and the render area.
cellsDirty = false;
```

In this PR, you should notice a one cell gap around the edge of the map (try using the "disabled shroud & fog" and "show terrain geometry" options to help).

On bleed, you will notice it still renders more than it needs, particularly on the right and bottom of the screen. Try upping the value from -1 to -3 or something like that to see what it is really doing.

This also applies to isometric maps, except for the bottom of the screen. Due to the tile height it renders downwards a bit more than usual to account for the heights. This is normal (I believe).
