### PR TITLE
Moved the Grenadier to the Allies

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -64,7 +64,7 @@ E2:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 20
-		Prerequisites: ~barr, ~techlevel.infonly
+		Prerequisites: ~tent, ~techlevel.infonly
 	Valued:
 		Cost: 160
 	Tooltip:


### PR DESCRIPTION
Reasoning:
- Soviets already got a fast infantry scout (dog).
- Soviets already got a strong unit against buildings (flame thrower). #7503
- Allies lacked a suitable infantry unit to drop into an undefended base.
- They seem to fit better with the Allies theme as they work somehow similar to artillery (explosions, chain reaction) while the flame thrower fit better with V2 (splash damage, fire).
- The soviets already have a lot of (redundant) infantry actors.
