### PR TITLE
Speed up shroud visibility updates.

### DIFF
--- a/OpenRA.Game/Traits/CreatesShroud.cs
+++ b/OpenRA.Game/Traits/CreatesShroud.cs
@@ -36,10 +36,7 @@ namespace OpenRA.Traits
 			{
 				cachedLocation = self.Location;
 				cachedDisabled = disabled;
-
-				var shroud = self.World.Players.Select(p => p.Shroud);
-				foreach (var s in shroud)
-					s.UpdateShroudGeneration(self);
+				Shroud.UpdateShroudGeneration(self.World.Players.Select(p => p.Shroud), self);
 			}
 		}
 

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -33,9 +33,7 @@ namespace OpenRA.Traits
 			if (cachedLocation != self.Location)
 			{
 				cachedLocation = self.Location;
-
-				foreach (var s in self.World.Players.Select(p => p.Shroud))
-					s.UpdateVisibility(self);
+				Shroud.UpdateVisibility(self.World.Players.Select(p => p.Shroud), self);
 			}
 		}
 


### PR DESCRIPTION
A unit with the CreatesShroud or RevealsShroud trait must update all shrouds when it changes position. Calculating the tiles it can currently see is an expensive calculation that previously had to be repeated for every shroud that needed to know these tiles.

Now, we lazily populate a ref parameter to allow it to be reused for an actor if possible. The biggest improvement comes from the fact that allied players can re-use this calculation when updating their shrouds. Since many games includes a neutral player allied to both sides, most games will see a decent speedup.

On the RA shellmap, shroud updates dropped from 2.80% of total CPU time to 1.50% (because of the neutral player). Games with large teams will see an even more significant improvement.
