### PR TITLE
Avoid MSVC120 runtime dependency for Lua Windows DLLs

### DIFF
--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -23,9 +23,9 @@ fi
 
 if [ ! -f windows/lua51.dll ]; then
 	echo "Fetching Lua 5.1 from nuget"
-	nuget install lua51.redist -Version 5.1.5
-	cp ./lua51.redist.5.1.5/build/native/bin/Win32/v120/Release/lua5.1.dll ./windows/lua51.dll
-	rm -rf lua51.redist.5.1.5
+	nuget install lua.binaries -Version 5.1.5
+	cp ./lua.binaries.5.1.5/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
+	rm -rf lua.binaries.5.1.5
 fi
 
 if [ ! -f windows/zlib1.dll ]; then

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -85,9 +85,9 @@ if (!(Test-Path "Mono.Nat.dll"))
 if (!(Test-Path "windows/lua51.dll"))
 {
 	echo "Fetching Lua 5.1 from NuGet."
-	./nuget.exe install lua51.redist -Version 5.1.5
-	cp lua51.redist.5.1.5/build/native/bin/Win32/v120/Release/lua5.1.dll ./windows/lua51.dll
-	rmdir lua51.redist.5.1.5 -Recurse
+	./nuget.exe install lua.binaries -Version 5.1.5
+	cp lua.binaries.5.1.5/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
+	rmdir lua.binaries.5.1.5 -Recurse
 }
 
 if (!(Test-Path "windows/zlib1.dll"))


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/7363.

Essentially the same thing we did in https://github.com/OpenRA/OpenRA/pull/7212, but this time for `lua51.dll` as well.
