### PR TITLE
Use correct frame indices in the asset browser.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				frameText.GetText = () =>
 					isVideoLoaded ?
 					"{0} / {1}".F(player.Video.CurrentFrame + 1, player.Video.Frames) :
-					"{0} / {1}".F(currentFrame + 1, currentSprites.Length);
+					"{0} / {1}".F(currentFrame, currentSprites.Length - 1);
 			}
 
 			var playButton = panel.GetOrNull<ButtonWidget>("BUTTON_PLAY");


### PR DESCRIPTION
Puts total frame count in parentheses.
This removes mental math (even as simple as +/-1) while working with sequences.

I can change the VQA frame count info if that is desired, also.
