### PR TITLE
Added upgrades and fixed prerequisites to use them

### DIFF
--- a/mods/d2k/audio/notifications.yaml
+++ b/mods/d2k/audio/notifications.yaml
@@ -36,6 +36,7 @@ Speech:
 		EnemyUnitsApproaching: ENEMY
 		UnitRepaired: GANEW
 		CannotDeploy: DPLOY
+		Upgrading: UPGRD
 
 Sounds:
 	DefaultVariant: .WAV

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -45,6 +45,9 @@ production-icons: chrome.png
 	building: 430,0,16,16
 	building-disabled: 446,0,16,16
 	building-alert: 462,0,16,16
+	upgrade: 430,224,16,16
+	upgrade-disabled: 446,224,16,16
+	upgrade-alert: 462,224,16,16
 	infantry: 430,32,16,16
 	infantry-disabled: 446,32,16,16
 	infantry-alert: 462,32,16,16

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -239,7 +239,7 @@ Container@PLAYER_WIDGETS:
 					IconSize: 58, 48
 					IconMargin: 2, 0
 					IconSpriteOffset: 0, 0
-					MinimumRows: 4
+					MinimumRows: 5
 					MaximumRows: 6
 				Container@PALETTE_FOREGROUND:
 					X: 64
@@ -255,7 +255,7 @@ Container@PLAYER_WIDGETS:
 					X: 6
 					Y: 2
 					Width: 25
-					Height: 243
+					Height: 274
 					Children:
 						ProductionTypeButton@BUILDING:
 							Key: e
@@ -271,9 +271,24 @@ Container@PLAYER_WIDGETS:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
+						ProductionTypeButton@UPGRADE:
+							Key: e
+							Y: 31
+							Width: 25
+							Height: 25
+							VisualHeight: 0
+							Background: sidebar-button
+							TooltipText: Upgrades
+							TooltipContainer: TOOLTIP_CONTAINER
+							ProductionGroup: Upgrade
+							Children:
+								Image@ICON:
+									X: 5
+									Y: 5
+									ImageCollection: production-icons
 						ProductionTypeButton@INFANTRY:
 							Key: t
-							Y: 31
+							Y: 62
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -288,12 +303,12 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@VEHICLE:
 							Key: y
-							Y: 62
+							Y: 93
 							Width: 25
 							Height: 25
 							VisualHeight: 0
 							Background: sidebar-button
-							TooltipText: Vehicles
+							TooltipText: Light Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
 							Children:
@@ -303,12 +318,12 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@TANKS:
 							Key: y
-							Y: 93
+							Y: 124
 							Width: 25
 							Height: 25
 							VisualHeight: 0
 							Background: sidebar-button
-							TooltipText: Tanks
+							TooltipText: Heavy Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Armor
 							Children:
@@ -318,7 +333,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@AIRCRAFT:
 							Key: y
-							Y: 124
+							Y: 155
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -333,7 +348,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: production-icons
 						ProductionTypeButton@STARPORT:
 							Key: y
-							Y: 155
+							Y: 186
 							Width: 25
 							Height: 25
 							VisualHeight: 0

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -21,12 +21,37 @@ rifle:
 	AttractsWorms:
 		Intensity: 120
 
+bazooka:
+	Inherits: ^Infantry
+	Buildable:
+		Queue: Infantry
+		BuildPaletteOrder: 20
+		Prerequisites: upgrade.barracks, ~techlevel.medium
+	Valued:
+		Cost: 250
+	Tooltip:
+		Name: Trooper
+		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
+	Selectable:
+		Bounds: 12,17,0,0
+	Health:
+		HP: 45
+	Mobile:
+		Speed: 42
+	Armament:
+		Weapon: Bazooka
+		LocalOffset: 0,0,555
+	AttackFrontal:
+	TakeCover:
+	AttractsWorms:
+		Intensity: 180
+
 engineer:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 50
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: upgrade.barracks, ~techlevel.medium
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -50,37 +75,12 @@ engineer:
 	AttractsWorms:
 		Intensity: 180
 
-bazooka:
-	Inherits: ^Infantry
-	Buildable:
-		Queue: Infantry
-		BuildPaletteOrder: 20
-		Prerequisites: radar, ~techlevel.medium
-	Valued:
-		Cost: 250
-	Tooltip:
-		Name: Trooper
-		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
-	Selectable:
-		Bounds: 12,17,0,0
-	Health:
-		HP: 45
-	Mobile:
-		Speed: 42
-	Armament:
-		Weapon: Bazooka
-		LocalOffset: 0,0,555
-	AttackFrontal:
-	TakeCover:
-	AttractsWorms:
-		Intensity: 180
-
 medic:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 60
-		Prerequisites: ~barracks.medics, ~techlevel.high
+		Prerequisites: ~barracks.medics, upgrade.barracks, ~techlevel.high
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -107,6 +107,37 @@ medic:
 	AttractsWorms:
 		Intensity: 180
 
+grenadier:
+	Inherits: ^Infantry
+	Buildable:
+		Queue: Infantry
+		BuildPaletteOrder: 80
+		Prerequisites: ~barracks.atreides, upgrade.barracks, hightech, ~techlevel.medium
+	Valued:
+		Cost: 160
+	Tooltip:
+		Name: Grenadier
+		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
+	Selectable:
+		Bounds: 12,17,0,0
+	Health:
+		HP: 50
+	Mobile:
+		Speed: 53
+	Armament:
+		Weapon: Grenade
+		LocalOffset: 0,0,555
+		FireDelay: 15
+	AttackFrontal:
+	TakeCover:
+	RenderInfantry:
+		IdleAnimations: idle
+	Explodes:
+		Weapon: UnitExplodeSmall
+		Chance: 100
+	AttractsWorms:
+		Intensity: 180
+
 fremen:
 	Inherits: ^Infantry
 	Valued:
@@ -116,7 +147,7 @@ fremen:
 		Description: Elite sniper infantry unit\n  Strong vs Infantry\n  Weak vs Vehicles\n  Special Ability: Invisibility
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 85
+		BuildPaletteOrder: 100
 		Prerequisites: ~barracks.atreides, palace, ~techlevel.high
 	Selectable:
 		Bounds: 12,17,0,0
@@ -142,37 +173,6 @@ fremen:
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
 	-MustBeDestroyed:
-
-grenadier:
-	Inherits: ^Infantry
-	Buildable:
-		Queue: Infantry
-		BuildPaletteOrder: 10
-		Prerequisites: ~barracks.atreides, ~techlevel.medium
-	Valued:
-		Cost: 160
-	Tooltip:
-		Name: Grenadier
-		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
-	Selectable:
-		Bounds: 12,17,0,0
-	Health:
-		HP: 50
-	Mobile:
-		Speed: 53
-	Armament:
-		Weapon: Grenade
-		LocalOffset: 0,0,555
-		FireDelay: 15
-	AttackFrontal:
-	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle
-	Explodes:
-		Weapon: UnitExplodeSmall
-		Chance: 100
-	AttractsWorms:
-		Intensity: 180
 
 sardaukar:
 	Inherits: ^Infantry

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -152,3 +152,86 @@ wormspawner:
 	RenderEditorOnly:
 	BodyOrientation:
 	WormSpawner:
+
+upgrade.conyard:
+	Tooltip:
+		Name: Construction Yard Upgrade
+		Description: Unlocks new construction options
+	Buildable:
+		BuildPaletteOrder: 50
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 1000
+	RenderSprites:
+		Image: conyard.harkonnen
+		RaceImages:
+			atreides: conyard.atreides
+			ordos: conyard.ordos
+			corrino: conyard.corrino
+
+upgrade.barracks:
+	Tooltip:
+		Name: Barracks Upgrade
+		Description: Unlocks additional infantry
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: barracks
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 500
+	RenderSprites:
+		Image: barracks.harkonnen
+		RaceImages:
+			atreides: barracks.atreides
+			ordos: barracks.ordos
+
+upgrade.light:
+	Tooltip:
+		Name: Light Factory Upgrade
+		Description: Unlocks additional light units
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: light
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 400
+	RenderSprites:
+		Image: light.harkonnen
+		RaceImages:
+			atreides: light.atreides
+			ordos: light.ordos
+
+upgrade.heavy:
+	Tooltip:
+		Name: Heavy Factory Upgrade
+		Description: Unlocks advanced technology and heavy weapons
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: heavy
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 800
+	RenderSprites:
+		Image: heavy.harkonnen
+		RaceImages:
+			atreides: heavy.atreides
+			ordos: heavy.ordos
+			corrino: heavy.corrino
+
+upgrade.hightech:
+	Tooltip:
+		Name: High Tech Factory Upgrade
+		Description: Unlocks the Air Strike superweapon
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: hightech.atreides, ~techlevel.superweapons
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 1500
+	RenderSprites:
+		Image: hightech.atreides

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -7,6 +7,13 @@ Player:
 		ReadyAudio: BuildingReady
 		BlockedAudio: NoRoom
 		RequireOwner: false
+	ClassicProductionQueue@Upgrade:
+		Type: Upgrade
+		LowPowerSlowdown: 3
+		QueuedAudio: Upgrading
+		ReadyAudio: NewOptions
+		BlockedAudio: NoRoom
+		RequireOwner: false
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		LowPowerSlowdown: 2

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -32,6 +32,8 @@ concreteb:
 		Dimensions: 3,3
 	Valued:
 		Cost: 50
+	Buildable:
+		Prerequisites: upgrade.conyard
 
 conyard:
 	Inherits: ^Building
@@ -52,7 +54,9 @@ conyard:
 	RevealsShroud:
 		Range: 10c0
 	Production:
-		Produces: Building
+		Produces: Building, Upgrade
+		MoveIntoWorld: false
+	Exit:
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -347,6 +351,9 @@ heavy:
 	ProvidesCustomPrerequisite@harkonnen:
 		Prerequisite: heavy.harkonnen
 		Race: harkonnen
+	ProvidesCustomPrerequisite@MISSILETANK:
+		Prerequisite: heavy.missiletank
+		Race: atreides, harkonnen
 	RenderBuilding:
 		Image: heavy.harkonnen
 		RaceImages:
@@ -409,7 +416,7 @@ starport:
 		Name: Starport
 		Description: Dropzone for quick reinforcements, at a price.\n  Requires power to operate
 	Buildable:
-		Prerequisites: radar, ~techlevel.high
+		Prerequisites: heavy, radar, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 80
 	Building:
@@ -567,7 +574,7 @@ rockettower:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: radar, upgrade.conyard, ~techlevel.medium
 		BuildPaletteOrder: 120
 	Valued:
 		Cost: 850
@@ -622,7 +629,7 @@ repair:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: heavy, ~techlevel.medium
+		Prerequisites: heavy, upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 130
 	Valued:
 		Cost: 500
@@ -666,7 +673,7 @@ hightech:
 	Valued:
 		Cost: 750
 	Tooltip:
-		Name: High Tech Facility
+		Name: High Tech Factory
 		Description: Unlocks advanced technology
 	Production:
 		Produces: Aircraft
@@ -688,6 +695,19 @@ hightech:
 		RaceImages:
 			atreides: hightech.atreides
 			ordos: hightech.ordos
+	ProvidesCustomPrerequisite@UPGRADE:
+		Prerequisite: hightech.atreides
+		Race: atreides
+	AirstrikePower:
+		Icon: ornistrike
+		Description: Air Strike
+		Prerequisites: ~techlevel.superweapons
+		ChargeTime: 180
+		LongDesc: Ornithopters hit the target with parabombs
+		UnitType: orni.bomber
+		SelectTargetSound:
+		DisplayBeacon: True
+		CameraActor: camera
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
 	Power:
@@ -697,7 +717,7 @@ research:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: hightech, ~techlevel.high
+		Prerequisites: radar, heavy, upgrade.heavy, ~techlevel.high
 		BuildPaletteOrder: 140
 	Selectable:
 		Bounds: 96,64
@@ -749,7 +769,7 @@ palace:
 		Cost: 2000
 	Tooltip:
 		Name: Palace
-		Description: Unlocks elite infantry and support powers
+		Description: Unlocks elite infantry and superweapons
 	Building:
 		Footprint: xx= xxx =xx
 		Dimensions: 3,3
@@ -772,22 +792,9 @@ palace:
 		Range: 4
 	Power:
 		Amount: -50
-	ProvidesCustomPrerequisite@airstrike:
-		Prerequisite: palace.airstrike
-		Race: atreides, ordos
 	ProvidesCustomPrerequisite@nuke:
 		Prerequisite: palace.nuke
 		Race: harkonnen
-	AirstrikePower:
-		Icon: ornistrike
-		Prerequisites: ~techlevel.superweapons, ~palace.airstrike
-		Description: Air Strike
-		ChargeTime: 180
-		LongDesc: Ornithopter drops a load of parachuted\nbombs on your target
-		UnitType: orni.bomber
-		SelectTargetSound:
-		DisplayBeacon: True
-		CameraActor: camera
 	NukePower:
 		Icon: deathhand
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -1,7 +1,7 @@
 mcv:
 	Inherits: ^Vehicle
 	Buildable:
-		Prerequisites: repair, ~techlevel.medium
+		Prerequisites: repair, upgrade.heavy, ~techlevel.medium
 		Queue: Armor
 		BuildPaletteOrder: 110
 	Valued:
@@ -120,7 +120,7 @@ quad:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: upgrade.light, ~techlevel.medium
 		BuildPaletteOrder: 20
 	Valued:
 		Cost: 400
@@ -153,7 +153,7 @@ siegetank:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Armor
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 50
 	Valued:
 		Cost: 850
@@ -205,7 +205,7 @@ missiletank:
 		Description: Rocket Artillery\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Buildable:
 		Queue: Armor
-		Prerequisites: hightech, ~techlevel.high
+		Prerequisites: ~heavy.missiletank, upgrade.heavy, research, ~techlevel.high
 		BuildPaletteOrder: 60
 	Mobile:
 		Speed: 64
@@ -345,7 +345,7 @@ raider:
 stealthraider:
 	Inherits: raider
 	Buildable:
-		Prerequisites: ~light.ordos, hightech, ~techlevel.medium
+		Prerequisites: ~light.ordos, upgrade.light, ~techlevel.medium
 		BuildPaletteOrder: 30
 	Valued:
 		Cost: 400


### PR DESCRIPTION
- Added upgrades production queue and sidebar tab
- Added upgrades for the Con Yard, Barracks, Light, Heavy and High Tech Factory (last one is Atreides only)
- Updated the prerequisites of all structures, infantry and vehicles to use the upgrades
- Fixed the Ix Research building to use vanilla Dune 2000 prerequisites
- Renamed High Tech Facility to High Tech Factory like vanilla Dune 2000
- Given the Air Strike power to the High Tech Factory Upgrade like vanilla

Edit: Closes #3211.
