### PR TITLE
Allow mods to define custom manifest data.

### DIFF
--- a/OpenRA.Game/InstallUtils.cs
+++ b/OpenRA.Game/InstallUtils.cs
@@ -18,7 +18,7 @@ using OpenRA.FileSystem;
 
 namespace OpenRA
 {
-	public class InstallData
+	public class ContentInstaller : IGlobalModData
 	{
 		public readonly string MenuWidget = null;
 		public readonly string MusicMenuWidget = null;

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -34,7 +34,6 @@ namespace OpenRA
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
 		public readonly MiniYaml LoadScreen;
 		public readonly MiniYaml LobbyDefaults;
-		public readonly InstallData ContentInstaller;
 		public readonly Dictionary<string, Pair<string, int>> Fonts;
 		public readonly Size TileSize = new Size(24, 24);
 		public readonly TileShape TileShape = TileShape.Rectangle;
@@ -58,7 +57,7 @@ namespace OpenRA
 		readonly string[] reservedModuleNames = { "Metadata", "Folders", "MapFolders", "Packages", "Rules",
 			"Sequences", "VoxelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
 			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions",
-			"ServerTraits", "LoadScreen", "LobbyDefaults", "ContentInstaller", "Fonts", "TileSize",
+			"ServerTraits", "LoadScreen", "LobbyDefaults", "Fonts", "TileSize",
 			"TileShape", "SubCells", "SupportsMapsFrom", "SpriteFormats" };
 
 		readonly TypeDictionary modules = new TypeDictionary();
@@ -95,9 +94,6 @@ namespace OpenRA
 			ServerTraits = YamlList(yaml, "ServerTraits");
 			LoadScreen = yaml["LoadScreen"];
 			LobbyDefaults = yaml["LobbyDefaults"];
-
-			if (yaml.ContainsKey("ContentInstaller"))
-				ContentInstaller = FieldLoader.Load<InstallData>(yaml["ContentInstaller"]);
 
 			Fonts = yaml["Fonts"].ToDictionary(my =>
 				{

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -38,6 +38,8 @@ namespace OpenRA
 			Languages = new string[0];
 			Manifest = new Manifest(mod);
 			ObjectCreator = new ObjectCreator(Manifest);
+			Manifest.LoadCustomData(ObjectCreator);
+
 			if (useLoadScreen)
 			{
 				LoadScreen = ObjectCreator.CreateObject<ILoadScreen>(Manifest.LoadScreen.Value);

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -275,7 +275,6 @@
     <Compile Include="Map\TileSet.cs" />
     <Compile Include="FieldLoader.cs" />
     <Compile Include="FieldSaver.cs" />
-    <Compile Include="InstallUtils.cs" />
     <Compile Include="Manifest.cs" />
     <Compile Include="Graphics\Vertex.cs" />
     <Compile Include="FileFormats\ImaAdpcmLoader.cs" />

--- a/OpenRA.Mods.Common/InstallUtils.cs
+++ b/OpenRA.Mods.Common/InstallUtils.cs
@@ -16,7 +16,7 @@ using ICSharpCode.SharpZipLib;
 using ICSharpCode.SharpZipLib.Zip;
 using OpenRA.FileSystem;
 
-namespace OpenRA
+namespace OpenRA.Mods.Common
 {
 	public class ContentInstaller : IGlobalModData
 	{

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			// Check whether the mod content is installed
 			// TODO: The installation code has finally been beaten into shape, so we can
 			// finally move it all into the planned "Manage Content" panel in the modchooser mod.
-			var installData = Game.ModData.Manifest.ContentInstaller;
+			var installData = Game.ModData.Manifest.Get<ContentInstaller>();
 			var installModContent = !installData.TestFiles.All(f => GlobalFileSystem.Exists(f));
 			var installModMusic = args != null && args.Contains("Install.Music");
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -63,6 +63,10 @@
       <HintPath>..\thirdparty\Mono.Nat.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\thirdparty\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">
@@ -572,6 +576,7 @@
     <Compile Include="UtilityCommands\CheckCodeStyle.cs" />
     <Compile Include="UtilityCommands\ReplayMetadataCommand.cs" />
     <Compile Include="Widgets\Logic\ReplayUtils.cs" />
+    <Compile Include="InstallUtils.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
@@ -24,10 +24,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Action continueLoading;
 		readonly ButtonWidget retryButton, backButton;
 		readonly Widget installingContainer, insertDiskContainer;
+		readonly ContentInstaller installData;
 
 		[ObjectCreator.UseCtor]
 		public InstallFromCDLogic(Widget widget, Action continueLoading)
 		{
+			installData = Game.ModData.Manifest.Get<ContentInstaller>();
 			this.continueLoading = continueLoading;
 			panel = widget.Get("INSTALL_FROMCD_PANEL");
 			progressBar = panel.Get<ProgressBarWidget>("PROGRESS_BAR");
@@ -46,7 +48,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool IsValidDisk(string diskRoot)
 		{
-			return Game.ModData.Manifest.ContentInstaller.DiskTestFiles.All(f => File.Exists(Path.Combine(diskRoot, f)));
+			return installData.DiskTestFiles.All(f => File.Exists(Path.Combine(diskRoot, f)));
 		}
 
 		void CheckForDisk()
@@ -70,13 +72,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			installingContainer.IsVisible = () => true;
 
 			var dest = Platform.ResolvePath("^", "Content", Game.ModData.Manifest.Mod.Id);
-			var copyFiles = Game.ModData.Manifest.ContentInstaller.CopyFilesFromCD;
+			var copyFiles = installData.CopyFilesFromCD;
 
-			var packageToExtract = Game.ModData.Manifest.ContentInstaller.PackageToExtractFromCD.Split(':');
+			var packageToExtract = installData.PackageToExtractFromCD.Split(':');
 			var extractPackage = packageToExtract.First();
 			var annotation = packageToExtract.Length > 1 ? packageToExtract.Last() : null;
 
-			var extractFiles = Game.ModData.Manifest.ContentInstaller.ExtractFilesFromCD;
+			var extractFiles = installData.ExtractFilesFromCD;
 
 			var installCounter = 0;
 			var installTotal = copyFiles.Length + extractFiles.Length;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallLogic.cs
@@ -19,13 +19,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public InstallLogic(Widget widget, Action continueLoading)
 		{
-			var mirrorListUrl = Game.ModData.Manifest.ContentInstaller.PackageMirrorList;
+			var installData = Game.ModData.Manifest.Get<ContentInstaller>();
 			var panel = widget.Get("INSTALL_PANEL");
 			var widgetArgs = new WidgetArgs()
 			{
 				{ "afterInstall", () => { Ui.CloseWindow(); continueLoading(); } },
 				{ "continueLoading", continueLoading },
-				{ "mirrorListUrl", mirrorListUrl },
+				{ "mirrorListUrl", installData.PackageMirrorList },
 			};
 
 			panel.Get<ButtonWidget>("DOWNLOAD_BUTTON").OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallMusicLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallMusicLogic.cs
@@ -42,13 +42,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var downloadButton = installMusicContainer.GetOrNull<ButtonWidget>("DOWNLOAD_BUTTON");
 			if (downloadButton != null)
 			{
-				var mirrorListUrl = Game.ModData.Manifest.ContentInstaller.MusicPackageMirrorList;
-				downloadButton.IsVisible = () => !string.IsNullOrEmpty(mirrorListUrl);
+				var installData = Game.ModData.Manifest.Get<ContentInstaller>();
+				downloadButton.IsVisible = () => !string.IsNullOrEmpty(installData.MusicPackageMirrorList);
 				downloadButton.OnClick = () =>
 				{
 					Ui.OpenWindow("INSTALL_DOWNLOAD_PANEL", new WidgetArgs() {
 						{ "afterInstall", () => Game.InitializeMod(Game.Settings.Game.Mod, null) },
-						{ "mirrorListUrl", mirrorListUrl },
+						{ "mirrorListUrl", installData.MusicPackageMirrorList },
 					});
 				};
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.InitializeMod(Game.Settings.Game.Mod, new Arguments(args));
 				};
 
-				var installData = Game.ModData.Manifest.ContentInstaller;
+				var installData = Game.ModData.Manifest.Get<ContentInstaller>();
 				installButton.IsVisible = () => modRules.InstalledMusic.ToArray().Length <= installData.ShippedSoundtracks;
 			}
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -121,10 +121,6 @@ ChromeLayout:
 	./mods/cnc/chrome/assetbrowser.yaml
 	./mods/cnc/chrome/missionbrowser.yaml
 
-Movies:
-	./mods/cnc/movies-gdi.yaml
-	./mods/cnc/movies-nod.yaml
-
 Voices:
 	./mods/cnc/audio/voices.yaml
 


### PR DESCRIPTION
This adds a mechanism for mods to define metadata objects that are populated with data from the manifest.

As a demonstration/test case I have converted the installer data to a module and moved it from the engine into the common mod library.  More of the existing modules should be converted in the future, but for now my main motivation is to use this in a future PR.

Suggested changelog (under Engine): Added support for custom mod data definitions in mod.yaml.
