### PR TITLE
Brought back the HTML documentation for NSIS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ notifications:
     skip_join: true
 
 before_deploy:
- - apt-get download markdown
- - dpkg -x markdown*deb $HOME
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`
  - cd packaging

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,14 +16,20 @@ test_script:
   - nunit-console-x86.exe OpenRA.Test.dll
 
 before_deploy:
+  - choco install pandoc
+  - pandoc -o README.md README.html
+  - pandoc -o CONTRIBUTING.md CONTRIBUTING.html
+  - appveyor DownloadFile "https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md" -FileName Changelog.md
+  - pandoc -o Changelog.md CHANGELOG.html
   - make docs
+  - pandoc -o DOCUMENTATION.md DOCUMENTATION.html
+  - pandoc -o Lua-API.md Lua-API.html
   - cp OpenRA.Game/OpenRA.ico .
   - appveyor DownloadFile "http://downloads.sourceforge.net/project/nsis/NSIS 2/2.46/nsis-2.46-setup.exe" -FileName nsissetup.exe
   - nsissetup /S /D=%NSIS_ROOT%
   - appveyor DownloadFile "http://nsis.sourceforge.net/mediawiki/images/archive/1/18/20140806212030!NsProcess.zip" -FileName NsProcess.zip
   - 7z x NsProcess.zip -o%NSIS_ROOT% -y
   - move /Y %NSIS_ROOT%\Plugin\nsProcess.dll %NSIS_ROOT%\Plugins\nsProcess.dll
-  - appveyor DownloadFile "https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md" -FileName Changelog.md
   - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\windows" /V3 packaging/windows/OpenRA.nsi'
   - move /Y %APPVEYOR_BUILD_FOLDER%\packaging\windows\OpenRA.Setup.exe %APPVEYOR_BUILD_FOLDER%\OpenRA-%APPVEYOR_REPO_TAG_NAME%.exe
 

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -23,11 +23,16 @@ find . -path "*.mdb" -delete
 
 test -e Changelog.md && rm Changelog.md
 wget https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md
-markdown Changelog.md > CHANGELOG.html
-markdown README.md > README.html
-markdown CONTRIBUTING.md > CONTRIBUTING.html
-markdown DOCUMENTATION.md > DOCUMENTATION.html
-markdown Lua-API.md > Lua-API.html
+
+wget http://daringfireball.net/projects/downloads/Markdown_1.0.1.zip
+unzip Markdown_1.0.1.zip
+rm -rf Markdown_1.0.1.zip
+./Markdown_1.0.1/Markdown.pl Changelog.md > CHANGELOG.html
+./Markdown_1.0.1/Markdown.pl README.md > README.html
+./Markdown_1.0.1/Markdown.pl CONTRIBUTING.md > CONTRIBUTING.html
+./Markdown_1.0.1/Markdown.pl DOCUMENTATION.md > DOCUMENTATION.html
+./Markdown_1.0.1/Markdown.pl Lua-API.md > Lua-API.html
+rm -rf Markdown_1.0.1
 
 # List of files that are packaged on all platforms
 FILES=('OpenRA.Game.exe' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' \

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -76,10 +76,10 @@ Section "Game" GAME
 	File "${SRCDIR}\Mono.Nat.dll"
 	File "${SRCDIR}\AUTHORS"
 	File "${SRCDIR}\COPYING"
-	File "${SRCDIR}\README.md"
-	File "${SRCDIR}\CHANGELOG.md"
-	File "${SRCDIR}\CONTRIBUTING.md"
-	File "${SRCDIR}\DOCUMENTATION.md"
+	File "${SRCDIR}\README.html"
+	File "${SRCDIR}\CHANGELOG.html"
+	File "${SRCDIR}\CONTRIBUTING.html"
+	File "${SRCDIR}\DOCUMENTATION.html"
 	File "${SRCDIR}\OpenRA.ico"
 	File "${SRCDIR}\SharpFont.dll"
 	File "${SRCDIR}\SDL2-CS.dll"
@@ -100,8 +100,8 @@ Section "Game" GAME
 		CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
 		CreateShortCut "$SMPROGRAMS\$StartMenuFolder\OpenRA.lnk" $OUTDIR\OpenRA.exe "" \
 			"$OUTDIR\OpenRA.exe" "" "" "" ""
-		CreateShortCut "$SMPROGRAMS\$StartMenuFolder\README.lnk" $OUTDIR\README.md "" \
-			"$OUTDIR\README.md" "" "" "" ""
+		CreateShortCut "$SMPROGRAMS\$StartMenuFolder\README.lnk" $OUTDIR\README.html "" \
+			"$OUTDIR\README.html" "" "" "" ""
 	!insertmacro MUI_STARTMENU_WRITE_END
 
 	SetOutPath "$INSTDIR\lua"
@@ -194,10 +194,10 @@ Function ${UN}Clean
 	Delete $INSTDIR\SharpFont.dll
 	Delete $INSTDIR\AUTHORS
 	Delete $INSTDIR\COPYING
-	Delete $INSTDIR\README.md
-	Delete $INSTDIR\CHANGELOG.md
-	Delete $INSTDIR\CONTRIBUTING.md
-	Delete $INSTDIR\DOCUMENTATION.md
+	Delete $INSTDIR\README.html
+	Delete $INSTDIR\CHANGELOG.html
+	Delete $INSTDIR\CONTRIBUTING.html
+	Delete $INSTDIR\DOCUMENTATION.html
 	Delete $INSTDIR\OpenRA.ico
 	Delete "$INSTDIR\global mix database.dat"
 	Delete $INSTDIR\MaxMind.Db.dll


### PR DESCRIPTION
During https://github.com/OpenRA/OpenRA/pull/7311 we lost the ability to conveniently install http://packages.ubuntu.com/markdown. However it was annoying anyway as there are several Markdown implementations and they are all just scripts so the `/usr/bin` link names are conflicting and different on any system. This downloads the original script locally and runs it. It fixes `*.md` file not found problems when running NSIS on Linux.
