### PR TITLE
Fixed FreeType2 depending on too new VS C++ runtime DLLs

### DIFF
--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -15,10 +15,11 @@ if [ ! -f windows/SDL2.dll ]; then
 fi
 
 if [ ! -f windows/freetype6.dll ]; then
-	echo "Fetching SharpFont from nuget"
-	nuget install SharpFont -Version 2.5.0.1
-	cp ./SharpFont.2.5.0.1/Content/freetype6.dll ./windows/
-	rm -rf SharpFont.2.5.0.1
+	echo "Fetching FreeType2 from nuget"
+	nuget install freetype2.redist -Version 2.4.11.3
+	cp ./freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/
+	cp ./freetype2.redist.2.4.11.3/bin/win32/freetype6.dll ./windows/
+	rm -rf freetype2.redist.2.4.11.3
 fi
 
 if [ ! -f windows/lua51.dll ]; then
@@ -30,9 +31,9 @@ fi
 
 if [ ! -f windows/zlib1.dll ]; then
 	echo "Fetching ZLib from nuget"
-	nuget install zlib.redist -Version 1.2.8.7
-	cp ./zlib.redist.1.2.8.7/build/native/bin/v120/Win32/Release/dynamic/stdcall/zlib.dll windows/zlib1.dll
-	rm -rf zlib.redist.1.2.8.7
+	nuget install freetype2.redist -Version 2.4.11.3
+	cp ./freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/
+	rm -rf freetype2.redist.2.4.11.3
 fi
 
 if [ ! -f windows/soft_oal.dll ]; then

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -53,7 +53,6 @@ if (!(Test-Path "SharpFont.dll"))
 	./nuget.exe install SharpFont -Version 2.5.0.1
 	cp SharpFont.2.5.0.1/lib/net20/SharpFont* .
 	cp SharpFont.2.5.0.1/Content/SharpFont.dll.config .
-	cp SharpFont.2.5.0.1/Content/freetype6.dll ./windows/
 	rmdir SharpFont.2.5.0.1 -Recurse
 }
 
@@ -90,12 +89,21 @@ if (!(Test-Path "windows/lua51.dll"))
 	rmdir lua51.redist.5.1.5 -Recurse
 }
 
+if (!(Test-Path "windows/freetype6.dll"))
+{
+	echo "Fetching FreeType2 from NuGet."
+	./nuget.exe install freetype2.redist -Version 2.4.11.3
+	cp freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/zlib1.dll
+	cp freetype2.redist.2.4.11.3/bin/win32/freetype6.dll ./windows/freetype6.dll
+	rmdir freetype2.redist.2.4.11.3 -Recurse
+}
+
 if (!(Test-Path "windows/zlib1.dll"))
 {
 	echo "Fetching ZLib from NuGet."
-	./nuget.exe install zlib.redist -Version 1.2.8.7
-	cp zlib.redist.1.2.8.7/build/native/bin/v120/Win32/Release/dynamic/stdcall/zlib.dll windows/zlib1.dll
-	rmdir zlib.redist.1.2.8.7 -Recurse
+	./nuget.exe install freetype2.redist -Version 2.4.11.3
+	cp freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/zlib1.dll
+	rmdir freetype2.redist.2.4.11.3 -Recurse
 }
 
 if (!(Test-Path "windows/soft_oal.dll"))


### PR DESCRIPTION
Fixes #7363.

This reverts the FreeType2 binary from https://github.com/OpenRA/OpenRA/pull/7197 back to the older versions from http://www.gtk.org/download/win32.php we used before.
