### PR TITLE
Ensure LF line ending for .yaml files for hash consistency across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 # Enforce LF normalization on Windows
+*.yaml eol=lf
+*.lua eol=lf
 * text=lf
 
 # Custom for Visual Studio


### PR DESCRIPTION
Without this change, the git client will auto-convert the line endings to CRLF, which leads to hash mismatches for unpacked maps, which would be especially bad if we were going to build the Windows package on a Windows system.
