### PR TITLE
Changed the harvester heuristic, solved several regressions in Pathfinder and harvesters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Also thanks to:
     * D2k Sardaukar
     * Daniel Derejvanik (Harisson)
     * Danny Keary (Dan9550)
+    * David Jiménez (Rydra)
     * David Russell (DavidARussell)
     * DeadlySurprise
     * Erasmus Schroder (rasco)

--- a/OpenRA.Mods.Common/Pathfinder/PathCacheStorage.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathCacheStorage.cs
@@ -60,7 +60,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 					return null;
 				}
 
-				cached.Tick = world.WorldTick;
 				return cached.Result;
 			}
 

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -88,6 +88,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var currentCell = Graph[currentMinNode];
 			Graph[currentMinNode] = new CellInfo(currentCell.CostSoFar, currentCell.EstimatedTotal, currentCell.PreviousPos, CellStatus.Closed);
 
+			if (Graph.CustomCost != null)
+			{
+				var c = Graph.CustomCost(currentMinNode);
+				if (c == int.MaxValue)
+					return currentMinNode;
+			}
+
 			foreach (var connection in Graph.GetConnections(currentMinNode))
 			{
 				// Calculate the cost up to that point


### PR DESCRIPTION
Changed the harvester heuristic so that now takes into account the distance from the initial search location. This makes harvesters somewhat more "intelligent" and gather nearer resources.

Also solved several regressions that were introduced in the recent Pathfinder changes.
