### PR TITLE
Fix TS civilian actor/sequence definitions.

### DIFF
--- a/mods/ts/rules/civilian.yaml
+++ b/mods/ts/rules/civilian.yaml
@@ -261,198 +261,106 @@ AMMOCRAT:
 		Type: none
 	Health:
 		HP: 1
+	RenderBuilding:
+		Palette: player
 
 BBOARD01:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Eat at Rade's Roadhouse
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD02:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Drink YEO-CA Cola!
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD03:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Hamburgers $.99
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD04:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Visit Scenic Las Vegas
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD05:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Rooms $29 a nite
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD06:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Kaspm's Tiberium Warhouse
 	Building:
 		Footprint: x x
 		Dimensions: 1, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD07:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Alkaline's Battery Superstore
 	Building:
 		Footprint: x x
 		Dimensions: 1, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD08:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Alex-gators petshop just ahead!
 	Building:
 		Footprint: x x
 		Dimensions: 1, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD09:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: TacticX games rock!
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD10:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: WW Surf and Turf hits the spot!
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD11:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Only 11 miles to Zydeko's cafe!
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD12:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: No escape from Archer's Asylum!
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD13:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Stop in at Hewitt's hair salon
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD14:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Billy Bob's Harvester school
 	Building:
 		Footprint: xx
 		Dimensions: 2, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD15:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Pannullo's hacienda es bueno
 	Building:
 		Footprint: xx
 		Dimensions: 2, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 BBOARD16:
-	Inherits: ^CivBuilding
+	Inherits: ^CivBillboard
 	Tooltip:
 		Name: Join GDI: We save lives.
 	Building:
 		Footprint: xx
 		Dimensions: 2, 1
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
 
 CA0001:
 	Inherits: ^CivBuilding
@@ -868,6 +776,8 @@ CITY01:
 		Type: wood
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY02:
 	Inherits: ^CivBuilding
@@ -880,6 +790,8 @@ CITY02:
 		Type: heavy
 	Health:
 		HP: 700
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY03:
 	Inherits: ^CivBuilding
@@ -892,6 +804,8 @@ CITY03:
 		Type: heavy
 	Health:
 		HP: 500
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY04:
 	Inherits: ^CivBuilding
@@ -904,6 +818,8 @@ CITY04:
 		Type: heavy
 	Health:
 		HP: 600
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY05:
 	Inherits: ^CivBuilding
@@ -916,6 +832,8 @@ CITY05:
 		Type: heavy
 	Health:
 		HP: 600
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY06:
 	Inherits: ^CivBuilding
@@ -928,6 +846,8 @@ CITY06:
 		Type: concrete
 	Health:
 		HP: 500
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY07:
 	Inherits: ^CivBuilding
@@ -940,6 +860,8 @@ CITY07:
 		Type: wood
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY08:
 	Inherits: ^CivBuilding
@@ -952,6 +874,8 @@ CITY08:
 		Type: heavy
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY09:
 	Inherits: ^CivBuilding
@@ -964,6 +888,8 @@ CITY09:
 		Type: wood
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY10:
 	Inherits: ^CivBuilding
@@ -976,6 +902,8 @@ CITY10:
 		Type: heavy
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY11:
 	Inherits: ^CivBuilding
@@ -988,6 +916,8 @@ CITY11:
 		Type: heavy
 	Health:
 		HP: 500
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY12:
 	Inherits: ^CivBuilding
@@ -1000,6 +930,8 @@ CITY12:
 		Type: concrete
 	Health:
 		HP: 600
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY13:
 	Inherits: ^CivBuilding
@@ -1012,6 +944,8 @@ CITY13:
 		Type: wood
 	Health:
 		HP: 500
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY14:
 	Inherits: ^CivBuilding
@@ -1024,6 +958,8 @@ CITY14:
 		Type: heavy
 	Health:
 		HP: 600
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY15:
 	Inherits: ^CivBuilding
@@ -1036,6 +972,8 @@ CITY15:
 		Type: heavy
 	Health:
 		HP: 500
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY16:
 	Inherits: ^CivBuilding
@@ -1048,6 +986,8 @@ CITY16:
 		Type: wood
 	Health:
 		HP: 500
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY17:
 	Inherits: ^CivBuilding
@@ -1060,6 +1000,8 @@ CITY17:
 		Type: wood
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY18:
 	Inherits: ^CivBuilding
@@ -1072,6 +1014,8 @@ CITY18:
 		Type: concrete
 	Health:
 		HP: 600
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY19:
 	Inherits: ^CivBuilding
@@ -1084,6 +1028,8 @@ CITY19:
 		Type: wood
 	Health:
 		HP: 500
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY20:
 	Inherits: ^CivBuilding
@@ -1096,6 +1042,8 @@ CITY20:
 		Type: wood
 	Health:
 		HP: 250
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY21:
 	Inherits: ^CivBuilding
@@ -1108,6 +1056,8 @@ CITY21:
 		Type: none
 	Health:
 		HP: 100
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CITY22:
 	Inherits: ^CivBuilding
@@ -1120,6 +1070,8 @@ CITY22:
 		Type: none
 	Health:
 		HP: 100
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
 
 CTDAM:
 	Inherits: ^CivBuilding
@@ -1322,3 +1274,5 @@ UFO:
 		HP: 1000
 	Armor:
 		Type: Heavy
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -75,6 +75,18 @@
 	RenderBuilding:
 		Palette: terrain
 
+^CivBillboard:
+	Inherits: ^CivBuilding
+	Building:
+		Footprint: x
+		Dimensions: 1, 1
+	Armor:
+		Type: heavy
+	Health:
+		HP: 400
+	EditorTilesetFilter:
+		RequireTilesets: TEMPERAT
+
 ^Wall:
 	AppearsOnRadar:
 	Building:

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -1,96 +1,96 @@
 ammocrat:
-	idle: ammocrat
-		start: 0
+	idle: ammo01
+		Start: 0
 		ShadowStart: 2
 
 aban01:
 	idle: aban01
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban02:
 	idle: aban02
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban03:
 	idle: aban03
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban04:
 	idle: aban04
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban05:
 	idle: aban05
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban06:
 	idle: aban06
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban07:
 	idle: aban07
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban08:
 	idle: aban08
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban09:
 	idle: aban09
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban10:
 	idle: aban10
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban11:
 	idle: aban11
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban12:
 	idle: aban12
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban13:
 	idle: aban13
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban14:
 	idle: aban14
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban15:
 	idle: aban15
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban16:
 	idle: aban16
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban17:
 	idle: aban17
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 aban18:
 	idle: aban18
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 bboard01:
@@ -465,7 +465,7 @@ ca0021:
 
 caarmr:
 	idle: ctarmr
-		start: 0
+		Start: 0
 		ShadowStart: 3
 	damaged-idle: ctarmr
 		Start: 1
@@ -477,7 +477,7 @@ caarmr:
 
 caaray:
 	idle: ctaray
-		start: 0
+		Start: 0
 		ShadowStart: 3
 	damaged-idle: ctaray
 		Start: 1
@@ -489,46 +489,46 @@ caaray:
 
 cabhut:
 	idle: cabhut
-		start: 0
+		Start: 0
 
 cacrsh01:
 	idle: ctcrsh01
-		start: 0
+		Start: 0
 
 cacrsh02:
 	idle: ctcrsh02
-		start: 0
+		Start: 0
 
 cacrsh03:
 	idle: ctcrsh03
-		start: 0
+		Start: 0
 
 cacrsh04:
 	idle: ctcrsh04
-		start: 0
+		Start: 0
 
 cacrsh05:
 	idle: ctcrsh05
-		start: 0
+		Start: 0
 
 cahosp:
 	idle: cthosp
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 capyr01:
 	idle: ctpyr01
-		start: 0
+		Start: 0
 		ShadowStart: 1
 
 capyr02:
 	idle: ctpyr02
-		start: 0
+		Start: 0
 		ShadowStart: 1
 
 capyr03:
 	idle: ctpyr03
-		start: 0
+		Start: 0
 		ShadowStart: 1
 
 city01:
@@ -863,11 +863,11 @@ city22:
 
 ctdam:
 	idle: ctdam
-		start: 0
+		Start: 0
 
 ctvega:
 	idle: ctvega
-		start: 0
+		Start: 0
 		ShadowStart: 3
 	damaged-idle: ctvega
 		Start: 1
@@ -879,42 +879,42 @@ ctvega:
 
 gaoldcc1:
 	idle: gtoldcc1
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 gaoldcc2:
 	idle: gtoldcc2
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 gaoldcc3:
 	idle: gtoldcc3
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 gaoldcc4:
 	idle: gtoldcc4
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 gaoldcc5:
 	idle: gtoldcc5
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 gaoldcc6:
 	idle: gtoldcc6
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 gagreen:
 	idle: gagreen
-		start: 0
+		Start: 0
 		ShadowStart: 2
 
 gakodk:
 	idle: gtkodk
-		start: 0
+		Start: 0
 		ShadowStart: 3
 	damaged-idle: gtkodk
 		Start: 1
@@ -926,7 +926,7 @@ gakodk:
 
 namntk:
 	idle: ntmntk
-		start: 0
+		Start: 0
 		ShadowStart: 3
 	damaged-idle: ntmntk
 		Start: 1
@@ -938,7 +938,7 @@ namntk:
 
 ntpyra:
 	idle: ntpyra
-		start: 0
+		Start: 0
 		ShadowStart: 3
 	damaged-idle: ntpyra
 		Start: 1


### PR DESCRIPTION
This fixes ammocrates, the invalid `Start:` definitions, and sets up the tileset filters for the TS civilian actors.  The easiest way to test this is to use my `ingame-map-editor` branch, which includes the snow tileset.
