### PR TITLE
Rework sequence parsing.

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Graphics
 	public class Animation
 	{
 		readonly int defaultTick = 40; // 25 fps == 40 ms
-		public Sequence CurrentSequence { get; private set; }
+		public ISpriteSequence CurrentSequence { get; private set; }
 		public bool IsDecoration = false;
 		public Func<bool> Paused;
 
@@ -177,7 +177,7 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public Sequence GetSequence(string sequenceName)
+		public ISpriteSequence GetSequence(string sequenceName)
 		{
 			return sequenceProvider.GetSequence(name, sequenceName);
 		}

--- a/OpenRA.Game/Graphics/Sequence.cs
+++ b/OpenRA.Game/Graphics/Sequence.cs
@@ -13,21 +13,39 @@ using System.Linq;
 
 namespace OpenRA.Graphics
 {
-	public class Sequence
+	public interface ISpriteSequence
+	{
+		string Name { get; }
+		int Start { get; }
+		int Length { get; }
+		int Stride { get; }
+		int Facings { get; }
+		int Tick { get; }
+		int ZOffset { get; }
+		int ShadowStart { get; }
+		int ShadowZOffset { get; }
+		int[] Frames { get; }
+
+		Sprite GetSprite(int frame);
+		Sprite GetSprite(int frame, int facing);
+		Sprite GetShadow(int frame, int facing);
+	}
+
+	public class Sequence : ISpriteSequence
 	{
 		readonly Sprite[] sprites;
 		readonly bool reverseFacings, transpose;
 
-		public readonly string Name;
-		public readonly int Start;
-		public readonly int Length;
-		public readonly int Stride;
-		public readonly int Facings;
-		public readonly int Tick;
-		public readonly int ZOffset;
-		public readonly int ShadowStart;
-		public readonly int ShadowZOffset;
-		public readonly int[] Frames;
+		public string Name { get; private set; }
+		public int Start { get; private set; }
+		public int Length { get; private set; }
+		public int Stride { get; private set; }
+		public int Facings { get; private set; }
+		public int Tick { get; private set; }
+		public int ZOffset { get; private set; }
+		public int ShadowStart { get; private set; }
+		public int ShadowZOffset { get; private set; }
+		public int[] Frames { get; private set; }
 
 		public Sequence(SpriteCache cache, string unit, string name, MiniYaml info)
 		{

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Graphics
 
 	public interface ISpriteSequenceLoader
 	{
-		IReadOnlyDictionary<string, ISpriteSequence> ParseUnitSequences(ModData modData, TileSet tileSet, SpriteCache cache, MiniYamlNode node);
+		IReadOnlyDictionary<string, ISpriteSequence> ParseSequences(ModData modData, TileSet tileSet, SpriteCache cache, MiniYamlNode node);
 	}
 
 	public class SequenceProvider
@@ -143,7 +143,7 @@ namespace OpenRA.Graphics
 					items.Add(node.Key, t);
 				else
 				{
-					t = Exts.Lazy(() => modData.SpriteSequenceLoader.ParseUnitSequences(modData, tileSet, SpriteCache, node));
+					t = Exts.Lazy(() => modData.SpriteSequenceLoader.ParseSequences(modData, tileSet, SpriteCache, node));
 					sequenceCache.Add(key, t);
 					items.Add(node.Key, t);
 				}

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -12,11 +12,35 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace OpenRA.Graphics
 {
 	using Sequences = IReadOnlyDictionary<string, Lazy<IReadOnlyDictionary<string, ISpriteSequence>>>;
 	using UnitSequences = Lazy<IReadOnlyDictionary<string, ISpriteSequence>>;
+
+	public interface ISpriteSequence
+	{
+		string Name { get; }
+		int Start { get; }
+		int Length { get; }
+		int Stride { get; }
+		int Facings { get; }
+		int Tick { get; }
+		int ZOffset { get; }
+		int ShadowStart { get; }
+		int ShadowZOffset { get; }
+		int[] Frames { get; }
+
+		Sprite GetSprite(int frame);
+		Sprite GetSprite(int frame, int facing);
+		Sprite GetShadow(int frame, int facing);
+	}
+
+	public interface ISpriteSequenceLoader
+	{
+		IReadOnlyDictionary<string, ISpriteSequence> ParseUnitSequences(ModData modData, TileSet tileSet, SpriteCache cache, MiniYamlNode node);
+	}
 
 	public class SequenceProvider
 	{
@@ -77,6 +101,7 @@ namespace OpenRA.Graphics
 	public sealed class SequenceCache : IDisposable
 	{
 		readonly ModData modData;
+		readonly TileSet tileSet;
 		readonly Lazy<SpriteCache> spriteCache;
 		public SpriteCache SpriteCache { get { return spriteCache.Value; } }
 
@@ -85,7 +110,9 @@ namespace OpenRA.Graphics
 		public SequenceCache(ModData modData, TileSet tileSet)
 		{
 			this.modData = modData;
+			this.tileSet = tileSet;
 
+			// Every time we load a tile set, we create a sequence cache for it
 			spriteCache = Exts.Lazy(() => new SpriteCache(modData.SpriteLoaders, tileSet.Extensions, new SheetBuilder(SheetType.Indexed)));
 		}
 
@@ -116,35 +143,13 @@ namespace OpenRA.Graphics
 					items.Add(node.Key, t);
 				else
 				{
-					t = Exts.Lazy(() => CreateUnitSequences(node));
+					t = Exts.Lazy(() => modData.SpriteSequenceLoader.ParseUnitSequences(modData, tileSet, SpriteCache, node));
 					sequenceCache.Add(key, t);
 					items.Add(node.Key, t);
 				}
 			}
 
 			return new ReadOnlyDictionary<string, UnitSequences>(items);
-		}
-
-		IReadOnlyDictionary<string, ISpriteSequence> CreateUnitSequences(MiniYamlNode node)
-		{
-			var unitSequences = new Dictionary<string, ISpriteSequence>();
-
-			foreach (var kvp in node.Value.ToDictionary())
-			{
-				using (new Support.PerfTimer("new Sequence(\"{0}\")".F(node.Key), 20))
-				{
-					try
-					{
-						unitSequences.Add(kvp.Key, new Sequence(spriteCache.Value, node.Key, kvp.Key, kvp.Value));
-					}
-					catch (FileNotFoundException ex)
-					{
-						Log.Write("debug", ex.Message);
-					}
-				}
-			}
-
-			return new ReadOnlyDictionary<string, ISpriteSequence>(unitSequences);
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -15,8 +15,8 @@ using System.Linq;
 
 namespace OpenRA.Graphics
 {
-	using Sequences = IReadOnlyDictionary<string, Lazy<IReadOnlyDictionary<string, Sequence>>>;
-	using UnitSequences = Lazy<IReadOnlyDictionary<string, Sequence>>;
+	using Sequences = IReadOnlyDictionary<string, Lazy<IReadOnlyDictionary<string, ISpriteSequence>>>;
+	using UnitSequences = Lazy<IReadOnlyDictionary<string, ISpriteSequence>>;
 
 	public class SequenceProvider
 	{
@@ -29,13 +29,13 @@ namespace OpenRA.Graphics
 			this.SpriteCache = cache.SpriteCache;
 		}
 
-		public Sequence GetSequence(string unitName, string sequenceName)
+		public ISpriteSequence GetSequence(string unitName, string sequenceName)
 		{
 			UnitSequences unitSeq;
 			if (!sequences.Value.TryGetValue(unitName, out unitSeq))
 				throw new InvalidOperationException("Unit `{0}` does not have any sequences defined.".F(unitName));
 
-			Sequence seq;
+			ISpriteSequence seq;
 			if (!unitSeq.Value.TryGetValue(sequenceName, out seq))
 				throw new InvalidOperationException("Unit `{0}` does not have a sequence named `{1}`".F(unitName, sequenceName));
 
@@ -125,9 +125,9 @@ namespace OpenRA.Graphics
 			return new ReadOnlyDictionary<string, UnitSequences>(items);
 		}
 
-		IReadOnlyDictionary<string, Sequence> CreateUnitSequences(MiniYamlNode node)
+		IReadOnlyDictionary<string, ISpriteSequence> CreateUnitSequences(MiniYamlNode node)
 		{
-			var unitSequences = new Dictionary<string, Sequence>();
+			var unitSequences = new Dictionary<string, ISpriteSequence>();
 
 			foreach (var kvp in node.Value.ToDictionary())
 			{
@@ -144,7 +144,7 @@ namespace OpenRA.Graphics
 				}
 			}
 
-			return new ReadOnlyDictionary<string, Sequence>(unitSequences);
+			return new ReadOnlyDictionary<string, ISpriteSequence>(unitSequences);
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -92,8 +92,12 @@ namespace OpenRA
 			Missions = YamlList(yaml, "Missions", true);
 
 			ServerTraits = YamlList(yaml, "ServerTraits");
-			LoadScreen = yaml["LoadScreen"];
-			LobbyDefaults = yaml["LobbyDefaults"];
+
+			if (!yaml.TryGetValue("LoadScreen", out LoadScreen))
+				throw new InvalidDataException("`LoadScreen` section is not defined.");
+
+			if (!yaml.TryGetValue("LobbyDefaults", out LobbyDefaults))
+				throw new InvalidDataException("`LobbyDefaults` section is not defined.");
 
 			Fonts = yaml["Fonts"].ToDictionary(my =>
 				{

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -20,6 +20,17 @@ namespace OpenRA
 	public enum TileShape { Rectangle, Diamond }
 	public interface IGlobalModData { }
 
+	public sealed class SpriteSequenceFormat : IGlobalModData
+	{
+		public readonly string Type;
+		public readonly IReadOnlyDictionary<string, MiniYaml> Metadata;
+		public SpriteSequenceFormat(MiniYaml yaml)
+		{
+			Type = yaml.Value;
+			Metadata = new ReadOnlyDictionary<string, MiniYaml>(yaml.ToDictionary());
+		}
+	}
+
 	// Describes what is to be loaded in order to run a mod
 	public class Manifest
 	{
@@ -34,6 +45,7 @@ namespace OpenRA
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
 		public readonly MiniYaml LoadScreen;
 		public readonly MiniYaml LobbyDefaults;
+
 		public readonly Dictionary<string, Pair<string, int>> Fonts;
 		public readonly Size TileSize = new Size(24, 24);
 		public readonly TileShape TileShape = TileShape.Rectangle;
@@ -155,7 +167,7 @@ namespace OpenRA
 					throw new InvalidDataException("`{0}` is not a valid mod manifest entry.".F(kv.Key));
 
 				IGlobalModData module;
-				var ctor = t.GetConstructor(new Type[] { typeof(MiniYaml) } );
+				var ctor = t.GetConstructor(new Type[] { typeof(MiniYaml) });
 				if (ctor != null)
 				{
 					// Class has opted-in to DIY initialization

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -154,8 +154,20 @@ namespace OpenRA
 				if (t == null || !typeof(IGlobalModData).IsAssignableFrom(t))
 					throw new InvalidDataException("`{0}` is not a valid mod manifest entry.".F(kv.Key));
 
-				var module = oc.CreateObject<IGlobalModData>(kv.Key);
-				FieldLoader.Load(module, kv.Value);
+				IGlobalModData module;
+				var ctor = t.GetConstructor(new Type[] { typeof(MiniYaml) } );
+				if (ctor != null)
+				{
+					// Class has opted-in to DIY initialization
+					module = (IGlobalModData)ctor.Invoke(new object[] { kv.Value });
+				}
+				else
+				{
+					// Automatically load the child nodes using FieldLoader
+					module = oc.CreateObject<IGlobalModData>(kv.Key);
+					FieldLoader.Load(module, kv.Value);
+				}
+
 				modules.Add(module);
 			}
 		}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -109,7 +109,6 @@
     <Compile Include="Graphics\MappedImage.cs" />
     <Compile Include="Graphics\Minimap.cs" />
     <Compile Include="Graphics\Renderer.cs" />
-    <Compile Include="Graphics\Sequence.cs" />
     <Compile Include="Graphics\SequenceProvider.cs" />
     <Compile Include="Graphics\Sheet.cs" />
     <Compile Include="Graphics\SheetBuilder.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -577,6 +577,7 @@
     <Compile Include="UtilityCommands\ReplayMetadataCommand.cs" />
     <Compile Include="Widgets\Logic\ReplayUtils.cs" />
     <Compile Include="InstallUtils.cs" />
+    <Compile Include="Graphics\DefaultSpriteSequence.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.RA.Graphics
 					yield return z;
 		}
 
-		static IEnumerable<IFinalizedRenderable> DrawZapWandering(WorldRenderer wr, float2 from, float2 to, Sequence s, string pal)
+		static IEnumerable<IFinalizedRenderable> DrawZapWandering(WorldRenderer wr, float2 from, float2 to, ISpriteSequence s, string pal)
 		{
 			var z = float2.Zero;	/* hack */
 			var dist = to - from;
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.RA.Graphics
 			return renderables;
 		}
 
-		static IEnumerable<IFinalizedRenderable> DrawZap(WorldRenderer wr, float2 from, float2 to, Sequence s, out float2 p, string palette)
+		static IEnumerable<IFinalizedRenderable> DrawZap(WorldRenderer wr, float2 from, float2 to, ISpriteSequence s, out float2 p, string palette)
 		{
 			var dist = to - from;
 			var q = new float2(-dist.Y, dist.X);

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -203,3 +203,5 @@ Missions:
 SupportsMapsFrom: cnc
 
 SpriteFormats: ShpTD, TmpTD, ShpTS, TmpRA
+
+SpriteSequenceFormat: DefaultSpriteSequence

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -178,3 +178,5 @@ Fonts:
 SupportsMapsFrom: d2k
 
 SpriteFormats: R8, ShpTD, TmpRA
+
+SpriteSequenceFormat: DefaultSpriteSequence

--- a/mods/modchooser/mod.yaml
+++ b/mods/modchooser/mod.yaml
@@ -52,3 +52,5 @@ Fonts:
 LobbyDefaults:
 
 SpriteFormats: ShpTD
+
+SpriteSequenceFormat: DefaultSpriteSequence

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -201,3 +201,5 @@ Missions:
 SupportsMapsFrom: ra
 
 SpriteFormats: ShpTD, TmpRA, TmpTD, ShpTS
+
+SpriteSequenceFormat: DefaultSpriteSequence

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -219,3 +219,5 @@ Fonts:
 SupportsMapsFrom: ts
 
 SpriteFormats: ShpTS, TmpTS, ShpTD
+
+SpriteSequenceFormat: DefaultSpriteSequence


### PR DESCRIPTION
This adds the plumbing which will be used in future prs to fix #5272, #4823, and add support for the facing reflection needed by #3274.

This is a pure plumbing patch, so there should be no changes ingame.  My [ts-snow](https://github.com/pchote/OpenRA/commits/ts-snow) branch demonstrates how this this will be used to implement stricter terrain-specific artwork for RA/TD (and will eventually include a utility command to verify sequence correctness), remove redundancy from D2K, and add the snow tileset to TS.  809215c956620ac8f6d89e7f4784d62768f94596 is the most important one to see how these will work.
