### PR TITLE
Decompose RenderInfantry into WithInfantryBody and RenderSprites.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -373,7 +373,6 @@
     <Compile Include="Traits\Render\RenderEditorOnly.cs" />
     <Compile Include="Traits\Render\RenderFlare.cs" />
     <Compile Include="Traits\Render\RenderHarvester.cs" />
-    <Compile Include="Traits\Render\RenderInfantry.cs" />
     <Compile Include="Traits\Render\RenderNameTag.cs" />
     <Compile Include="Traits\Render\RenderSimple.cs" />
     <Compile Include="Traits\Render\RenderSprites.cs" />
@@ -616,6 +615,7 @@
     <Compile Include="Widgets\TooltipContainerWidget.cs" />
     <Compile Include="Widgets\ViewportControllerWidget.cs" />
     <Compile Include="Widgets\VqaPlayerWidget.cs" />
+    <Compile Include="Traits\Render\WithInfantryBody.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Traits
 			return cachedImage = info.GetImage(self.Info, self.World.Map.SequenceProvider, race);
 		}
 
-		protected void UpdatePalette()
+		public void UpdatePalette()
 		{
 			foreach (var anim in anims.Values)
 				anim.OwnerChanged();

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor has a death animation.")]
-	public class WithDeathAnimationInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	public class WithDeathAnimationInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Sequence to play when this actor is killed by a warhead.")]
 		public readonly string DeathSequence = "die";
@@ -35,12 +35,12 @@ namespace OpenRA.Mods.Common.Traits
 	public class WithDeathAnimation : INotifyKilled
 	{
 		public readonly WithDeathAnimationInfo Info;
-		readonly RenderSimple renderSimple;
+		readonly RenderSprites rs;
 
 		public WithDeathAnimation(Actor self, WithDeathAnimationInfo info)
 		{
 			Info = info;
-			renderSimple = self.Trait<RenderSimple>();
+			rs = self.Trait<RenderSprites>();
 		}
 
 		public void Killed(Actor self, AttackInfo e)
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.AddFrameEndTask(w =>
 			{
 				if (!self.Destroyed)
-					w.Add(new Corpse(w, self.CenterPosition, renderSimple.GetImage(self), sequence, palette));
+					w.Add(new Corpse(w, self.CenterPosition, rs.GetImage(self), sequence, palette));
 			});
 		}
 	}

--- a/OpenRA.Mods.RA/Activities/Leap.cs
+++ b/OpenRA.Mods.RA/Activities/Leap.cs
@@ -45,7 +45,8 @@ namespace OpenRA.Mods.RA.Activities
 			to = self.World.Map.CenterOfSubCell(targetMobile.FromCell, targetMobile.FromSubCell);
 			length = Math.Max((to - from).Length / speed.Range, 1);
 
-			self.Trait<RenderInfantry>().Attacking(self, Target.FromActor(target));
+			// HACK: why isn't this using the interface?
+			self.Trait<WithInfantryBody>().Attacking(self, Target.FromActor(target));
 
 			if (weapon.Report != null && weapon.Report.Any())
 				Sound.Play(weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -94,7 +94,6 @@
     <Compile Include="Traits\PaletteEffects\ChronoshiftPaletteEffect.cs" />
     <Compile Include="Traits\PortableChrono.cs" />
     <Compile Include="Traits\Render\RenderJammerCircle.cs" />
-    <Compile Include="Traits\Render\RenderDisguise.cs" />
     <Compile Include="Traits\Render\RenderLandingCraft.cs" />
     <Compile Include="Traits\Render\RenderShroudCircle.cs" />
     <Compile Include="Traits\Render\RenderUnitReload.cs" />
@@ -106,6 +105,7 @@
     <Compile Include="Scripting\Properties\ChronosphereProperties.cs" />
     <Compile Include="Scripting\Properties\ParadropProperties.cs" />
     <Compile Include="Scripting\Properties\ParatroopersProperties.cs" />
+    <Compile Include="Traits\Render\WithDisguisingInfantryBody.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.RA/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.RA/Traits/Render/WithDisguisingInfantryBody.cs
@@ -13,21 +13,23 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	class RenderDisguiseInfo : RenderInfantryInfo, Requires<DisguiseInfo>
+	class WithDisguisingInfantryBodyInfo : WithInfantryBodyInfo, Requires<DisguiseInfo>
 	{
-		public override object Create(ActorInitializer init) { return new RenderDisguise(init, this); }
+		public override object Create(ActorInitializer init) { return new WithDisguisingInfantryBody(init, this); }
 	}
 
-	class RenderDisguise : RenderInfantry
+	class WithDisguisingInfantryBody : WithInfantryBody
 	{
-		RenderDisguiseInfo info;
+		readonly WithDisguisingInfantryBodyInfo info;
+		readonly Disguise disguise;
+		readonly RenderSprites rs;
 		string intendedSprite;
-		Disguise disguise;
 
-		public RenderDisguise(ActorInitializer init, RenderDisguiseInfo info)
+		public WithDisguisingInfantryBody(ActorInitializer init, WithDisguisingInfantryBodyInfo info)
 			: base(init, info)
 		{
 			this.info = info;
+			rs = init.Self.Trait<RenderSprites>();
 			disguise = init.Self.Trait<Disguise>();
 			intendedSprite = disguise.AsSprite;
 		}
@@ -37,8 +39,8 @@ namespace OpenRA.Mods.RA.Traits
 			if (disguise.AsSprite != intendedSprite)
 			{
 				intendedSprite = disguise.AsSprite;
-				DefaultAnimation.ChangeImage(intendedSprite ?? GetImage(self), info.StandAnimations.Random(Game.CosmeticRandom));
-				UpdatePalette();
+				DefaultAnimation.ChangeImage(intendedSprite ?? rs.GetImage(self), info.StandSequences.Random(Game.CosmeticRandom));
+				rs.UpdatePalette();
 			}
 
 			base.Tick(self);

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -182,7 +182,8 @@
 		TargetTypes: Ground, Infantry
 	TakeCover:
 		SpeedModifier: 60
-	RenderInfantry:
+	RenderSprites:
+	WithInfantryBody:
 	WithDeathAnimation:
 	AttackMove:
 	Passenger:
@@ -300,8 +301,7 @@
 		TargetTypes: Ground, Infantry
 	HiddenUnderFog:
 	GivesExperience:
-	RenderInfantry:
-		Palette: terrain
+	WithInfantryBody:
 	WithDeathAnimation:
 		UseDeathTypeSuffix: false
 	EditorAppearance:
@@ -316,6 +316,8 @@
 	Huntable:
 	ScriptTriggers:
 	DeathSounds:
+	RenderSprites:
+		Palette: terrain
 
 ^Plane:
 	AppearsOnRadar:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -17,9 +17,9 @@ E1:
 	Armament:
 		Weapon: M16
 	AttackFrontal:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2,idle3,idle4
-		StandAnimations: stand, stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2,idle3,idle4
+		StandSequences: stand, stand2
 
 E2:
 	Inherits: ^Infantry
@@ -43,9 +43,9 @@ E2:
 		LocalOffset: 0,0,427
 		FireDelay: 15
 	AttackFrontal:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand, stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand, stand2
 	Explodes:
 		Weapon: GrenadierExplode
 		EmptyWeapon: GrenadierExplode
@@ -74,9 +74,9 @@ E3:
 		LocalOffset: 256,43,341
 		FireDelay: 5
 	AttackFrontal:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand, stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand, stand2
 
 E4:
 	Inherits: ^Infantry
@@ -104,9 +104,9 @@ E4:
 	AttackFrontal:
 	WithMuzzleFlash:
 		SplitFacings: true
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand, stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand, stand2
 
 E5:
 	Inherits: ^Infantry
@@ -140,9 +140,9 @@ E5:
 	WithMuzzleFlash:
 		SplitFacings: true
 	-PoisonedByTiberium:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand, stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand, stand2
 
 E6:
 	Inherits: ^Infantry
@@ -167,9 +167,9 @@ E6:
 	Captures:
 		CaptureTypes: building, husk
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand, stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand, stand2
 	-GainsExperience:
 
 RMBO:
@@ -201,9 +201,9 @@ RMBO:
 	Armament:
 		Weapon: Sniper
 	AttackFrontal:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2,idle3
-		StandAnimations: stand, stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2,idle3
+		StandSequences: stand, stand2
 	AnnounceOnBuild:
 	AnnounceOnKill:
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -193,7 +193,8 @@
 		Voice: InfantryVoice
 	TargetableUnit:
 		TargetTypes: Ground
-	RenderInfantry:
+	RenderSprites:
+	WithInfantryBody:
 	TakeCover:
 	WithDeathAnimation:
 	AutoTarget:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -99,8 +99,8 @@ medic:
 	AttackMedic:
 		Cursor: ability
 		OutsideRangeCursor: ability
-	RenderInfantry:
-		AttackAnimation: heal
+	WithInfantryBody:
+		AttackSequence: heal
 	Passenger:
 		PipType: Blue
 	-AutoTarget:
@@ -166,8 +166,8 @@ grenadier:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle
+	WithInfantryBody:
+		IdleSequences: idle
 	Explodes:
 		Weapon: UnitExplodeSmall
 		Chance: 100
@@ -228,3 +228,4 @@ saboteur:
 	-AutoTarget:
 	AttractsWorms:
 		Intensity: 120
+

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1381,14 +1381,14 @@ Rules:
 		-ExternalCaptures:
 		Captures:
 			CaptureTypes: building
-		RenderInfantry:
-			Image: E6
 		Cloak@JAIL:
 			UpgradeTypes: jail
 			UpgradeMinEnabledLevel: 1
 			InitialDelay: 0
 			CloakDelay: 0
 			Palette:
+		RenderSprites:
+			Image: E6
 	MEDI:
 		Cloak@JAIL:
 			UpgradeTypes: jail
@@ -1398,11 +1398,11 @@ Rules:
 			Palette:
 	E7.noautotarget:
 		Inherits: E7
-		RenderInfantry:
-			Image: E7
 		AutoTarget:
 			EnableStances: false
 		-AttackMove:
+		RenderSprites:
+			Image: E7
 	PRISON:
 		Immobile:
 			OccupiesSpace: false
@@ -1430,7 +1430,7 @@ Rules:
 			Range: 8c0
 		AutoTarget:
 			ScanRadius: 7
-		RenderInfantry:
+		RenderSprites:
 			Image: E1
 	E2.Autotarget:
 		Inherits: E2
@@ -1440,7 +1440,7 @@ Rules:
 			Range: 8c0
 		AutoTarget:
 			ScanRadius: 7
-		RenderInfantry:
+		RenderSprites:
 			Image: E2
 	DOG:
 		RevealsShroud:

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -1276,14 +1276,15 @@ Rules:
 		-ExternalCaptures:
 		Captures:
 			CaptureTypes: building
-		RenderInfantry:
-			Image: E6
+		WithInfantryBody:
 		Cloak@JAIL:
 			UpgradeTypes: jail
 			UpgradeMinEnabledLevel: 1
 			InitialDelay: 0
 			CloakDelay: 0
 			Palette:
+		RenderSprites:
+			Image: E6
 	MEDI:
 		Cloak@JAIL:
 			UpgradeTypes: jail
@@ -1293,11 +1294,11 @@ Rules:
 			Palette:
 	E7.noautotarget:
 		Inherits: E7
-		RenderInfantry:
-			Image: E7
 		AutoTarget:
 			EnableStances: false
 		-AttackMove:
+		RenderSprites:
+			Image: E7
 	PRISON:
 		Immobile:
 			OccupiesSpace: false
@@ -1338,7 +1339,7 @@ Rules:
 			Range: 8c0
 		AutoTarget:
 			ScanRadius: 7
-		RenderInfantry:
+		RenderSprites:
 			Image: E1
 	E2.Autotarget:
 		Inherits: E2
@@ -1348,7 +1349,7 @@ Rules:
 			Range: 8c0
 		AutoTarget:
 			ScanRadius: 7
-		RenderInfantry:
+		RenderSprites:
 			Image: E2
 	DOG:
 		Buildable:

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1687,11 +1687,11 @@ Rules:
 			TargetTypes: Ground, C4, DetonateAttack, Structure, Mission Objectives
 	E7.noautotarget:
 		Inherits: E7
-		RenderInfantry:
-			Image: E7
 		AutoTarget:
 			EnableStances: false
 		-AttackMove:
+		RenderSprites:
+			Image: E7
 	Colt:
 		-Huntable:
 		AutoTargetIgnore:
@@ -1727,7 +1727,7 @@ Rules:
 			Range: 8c0
 		AutoTarget:
 			ScanRadius: 7
-		RenderInfantry:
+		RenderSprites:
 			Image: E1
 	E2.Autotarget:
 		Inherits: E2
@@ -1737,7 +1737,7 @@ Rules:
 			Range: 8c0
 		AutoTarget:
 			ScanRadius: 7
-		RenderInfantry:
+		RenderSprites:
 			Image: E2
 	AFLD:
 		AirstrikePower@spyplane:

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -617,12 +617,12 @@ Rules:
 		Inherits: SNIPER
 		Buildable:
 			Prerequisites: ~disabled
-		RenderInfantry:
-			Image: SNIPER
 		MustBeDestroyed:
 		InvulnerabilityUpgrade@UNKILLABLE:
 			UpgradeTypes: unkillable
 			UpgradeMinEnabledLevel: 1
+		RenderSprites:
+			Image: SNIPER
 	SPY:
 		Inherits: ^Infantry
 		Buildable:

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2240,7 +2240,7 @@ Rules:
 		Captures:
 			CaptureTypes: building
 			Sabotage: False
-		RenderInfantry:
+		RenderSprites:
 			Image: e6
 	E6:
 		Buildable:

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2145,10 +2145,10 @@ Rules:
 		Inherits: DELPHI
 		Tooltip:
 			Name: Dr. Demitri
-		RenderInfantry:
-			Image: DELPHI
 		Passenger:
 			CargoType: Demitri
+		RenderSprites:
+			Image: DELPHI
 	TRAN:
 		RevealsShroud:
 			Range: 0c0

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -13,43 +13,50 @@ C4:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	WithInfantryBody:
+	RenderSprites:
 		Image: C2
 
 C5:
 	Inherits: ^CivInfantry
-	RenderInfantry:
+	WithInfantryBody:
+	RenderSprites:
 		Image: C1
 
 C6:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	WithInfantryBody:
+	RenderSprites:
 		Image: C2
 
 C7:
 	Inherits: ^CivInfantry
-	RenderInfantry:
+	WithInfantryBody:
+	RenderSprites:
 		Image: C1
 
 C8:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	WithInfantryBody:
+	RenderSprites:
 		Image: C2
 
 C9:
 	Inherits: ^CivInfantry
-	RenderInfantry:
+	WithInfantryBody:
+	RenderSprites:
 		Image: C1
 
 C10:
 	Inherits: ^CivInfantry
 	Selectable:
 		Voice: CivilianFemaleVoice
-	RenderInfantry:
+	WithInfantryBody:
+	RenderSprites:
 		Image: C2
 
 FCOM:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -182,7 +182,8 @@
 		Voice: GenericVoice
 	TargetableUnit:
 		TargetTypes: Ground, Infantry, Disguise
-	RenderInfantry:
+	RenderSprites:
+	WithInfantryBody:
 	WithDeathAnimation:
 	AutoTarget:
 	AttackMove:
@@ -545,7 +546,7 @@
 	AttackFrontal:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	WithInfantryBody:
 	ScaredyCat:
 
 ^CivBuilding:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -22,8 +22,8 @@ DOG:
 	Armament:
 		Weapon: DogJaw
 	AttackLeap:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 	IgnoresDisguise:
 	DetectCloaked:
 		Range: 5
@@ -54,9 +54,9 @@ E1:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 
 E2:
 	Inherits: ^Infantry
@@ -86,9 +86,9 @@ E2:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 	Explodes:
 		Weapon: UnitExplodeSmall
 		Chance: 50
@@ -122,9 +122,9 @@ E3:
 		Weapon: Dragon
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 
 E4:
 	Inherits: ^Infantry
@@ -153,9 +153,9 @@ E4:
 		Weapon: Flamer
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 
 E6:
 	Inherits: ^Infantry
@@ -184,9 +184,9 @@ E6:
 		Type: building
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 
 SPY:
 	Inherits: ^Infantry
@@ -218,24 +218,25 @@ SPY:
 	Infiltrates:
 		Types: SpyInfiltrate
 	-AutoTarget:
-	-RenderInfantry:
-	RenderDisguise:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	-WithInfantryBody:
+	WithDisguisingInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 	Armament:
 		Weapon: SilencedPPK
 	AttackFrontal:
 
 SPY.England:
 	Inherits: SPY
-	RenderDisguise:
-		Image: spy
+	WithDisguisingInfantryBody:
 	Buildable:
 		Prerequisites: ~infantry.england, dome, ~tent, ~techlevel.medium
 	Valued:
 		Cost: 250
 	DisguiseToolTip:
 		Name: British Spy
+	RenderSprites:
+		Image: spy
 
 E7:
 	Inherits: ^Infantry
@@ -274,8 +275,8 @@ E7:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 	AnnounceOnBuild:
 	AnnounceOnKill:
 
@@ -310,9 +311,9 @@ MEDI:
 		OutsideRangeCursor: heal
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		AttackAnimation: heal
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		AttackSequence: heal
 
 MECH:
 	Inherits: ^Infantry
@@ -347,9 +348,9 @@ MECH:
 		CaptureTypes: husk
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		AttackAnimation: heal
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		AttackSequence: heal
 
 EINSTEIN:
 	Inherits: ^Infantry
@@ -369,7 +370,7 @@ EINSTEIN:
 	-AutoTarget:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	WithInfantryBody:
 	ScaredyCat:
 
 DELPHI:
@@ -390,7 +391,7 @@ DELPHI:
 	-AutoTarget:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	WithInfantryBody:
 	ScaredyCat:
 
 CHAN:
@@ -484,9 +485,9 @@ SHOK:
 		Weapon: PortaTesla
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 
 SNIPER:
 	Inherits: ^Infantry
@@ -520,9 +521,9 @@ SNIPER:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		StandAnimations: stand,stand2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		StandSequences: stand,stand2
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 120

--- a/mods/ts/rules/civilian.yaml
+++ b/mods/ts/rules/civilian.yaml
@@ -80,7 +80,7 @@ ABAN06:
 	Health:
 		HP: 500
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN07:
 	Inherits: ^CivBuilding
@@ -94,7 +94,7 @@ ABAN07:
 	Health:
 		HP: 350
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN08:
 	Inherits: ^CivBuilding
@@ -108,7 +108,7 @@ ABAN08:
 	Health:
 		HP: 500
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN09:
 	Inherits: ^CivBuilding
@@ -122,7 +122,7 @@ ABAN09:
 	Health:
 		HP: 350
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN10:
 	Inherits: ^CivBuilding
@@ -136,7 +136,7 @@ ABAN10:
 	Health:
 		HP: 500
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN11:
 	Inherits: ^CivBuilding
@@ -150,7 +150,7 @@ ABAN11:
 	Health:
 		HP: 400
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN12:
 	Inherits: ^CivBuilding
@@ -164,7 +164,7 @@ ABAN12:
 	Health:
 		HP: 400
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN13:
 	Inherits: ^CivBuilding
@@ -178,7 +178,7 @@ ABAN13:
 	Health:
 		HP: 400
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN14:
 	Inherits: ^CivBuilding
@@ -192,7 +192,7 @@ ABAN14:
 	Health:
 		HP: 300
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN15:
 	Inherits: ^CivBuilding
@@ -206,7 +206,7 @@ ABAN15:
 	Health:
 		HP: 400
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN16:
 	Inherits: ^CivBuilding
@@ -220,7 +220,7 @@ ABAN16:
 	Health:
 		HP: 400
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN17:
 	Inherits: ^CivBuilding
@@ -234,7 +234,7 @@ ABAN17:
 	Health:
 		HP: 400
 	EditorTilesetFilter:
-		ExcludeTilesets: TEMPERAT	
+		ExcludeTilesets: TEMPERAT
 
 ABAN18:
 	Inherits: ^CivBuilding
@@ -1081,7 +1081,7 @@ CTDAM:
 	Building:
 		Footprint: xx xx xx xx xx
 		Dimensions: 2, 5
-	Power: 
+	Power:
 		Amount: 200
 	Armor:
 		Type: heavy
@@ -1220,7 +1220,7 @@ GASPOT:
 	Building:
 		Footprint: x
 		Dimensions: 1, 1
-	Power: 
+	Power:
 		Amount: -10
 	Armor:
 		Type: wood
@@ -1250,7 +1250,7 @@ NTPYRA:
 	Building:
 		Footprint: xxxx xxxx xxxx xxxx
 		Dimensions: 4, 4
-	Power: 
+	Power:
 		Amount: -40
 	Armor:
 		Type: heavy

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -162,7 +162,8 @@
 		Voice: Infantry
 	TargetableUnit:
 		TargetTypes: Ground, Infantry
-	RenderInfantry:
+	RenderSprites:
+	WithInfantryBody:
 	WithDeathAnimation:
 	AutoTarget:
 	AttackMove:
@@ -244,7 +245,7 @@
 	AttackFrontal:
 	ProximityCaptor:
 		Types: CivilianInfantry
-	RenderInfantry:
+	WithInfantryBody:
 	ScaredyCat:
 	-MustBeDestroyed:
 

--- a/mods/ts/rules/infantry.yaml
+++ b/mods/ts/rules/infantry.yaml
@@ -26,8 +26,8 @@ E1:
 		UpgradeMinEnabledLevel: 1
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 E2:
 	Inherits: ^Infantry
@@ -52,8 +52,8 @@ E2:
 		FireDelay: 5
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 E3:
 	Inherits: ^Infantry
@@ -78,8 +78,8 @@ E3:
 		LocalOffset: 128,0,640
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 WEEDGUY:
 	Inherits: ^Infantry
@@ -106,7 +106,7 @@ WEEDGUY:
 		Weapon: FireballLauncher
 		LocalOffset: 85,0,384
 	AttackFrontal:
-	RenderInfantry:
+	WithInfantryBody:
 	TakeCover:
 
 MEDIC:
@@ -133,9 +133,9 @@ MEDIC:
 		Weapon: Heal
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
-		AttackAnimation: heal
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
+		AttackSequence: heal
 	SelfHealing:
 	Passenger:
 		PipType: Red
@@ -165,8 +165,8 @@ ENGINEER:
 	Captures:
 		CaptureTypes: building
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 	TakeCover:
 	-GainsExperience:
 
@@ -197,8 +197,8 @@ UMAGON:
 		Weapon: Sniper
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 GHOST:
 	Inherits: ^Infantry
@@ -233,8 +233,8 @@ GHOST:
 	C4Demolition:
 		C4Delay: 45
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 JUMPJET:
 	Inherits: ^Infantry
@@ -264,7 +264,7 @@ JUMPJET:
 	-Crushable:
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
+	WithInfantryBody:
 
 CHAMSPY:
 	Inherits: ^Infantry
@@ -292,9 +292,9 @@ CHAMSPY:
 	Infiltrates:
 		Types: SpyInfiltrate
 	-AutoTarget:
-	-RenderInfantry:
-	RenderDisguise:
-		IdleAnimations: idle1,idle2
+	-WithInfantryBody:
+	WithDisguisingInfantryBody:
+		IdleSequences: idle1,idle2
 
 CYBORG:
 	Inherits: ^Infantry
@@ -326,8 +326,8 @@ CYBORG:
 		Weapon: Vulcan3
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 CYC2:
 	Inherits: ^Infantry
@@ -360,8 +360,8 @@ CYC2:
 		LocalOffset: 170,85,683
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 MUTANT:
 	Inherits: ^Infantry
@@ -388,8 +388,8 @@ MUTANT:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 MWMN:
 	Inherits: ^Infantry
@@ -416,8 +416,8 @@ MWMN:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 MUTANT3:
 	Inherits: ^Infantry
@@ -444,8 +444,8 @@ MUTANT3:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 MHIJACK:
 	Inherits: ^Infantry
@@ -471,8 +471,8 @@ MHIJACK:
 		Range: 6c0
 	-AutoTarget:
 	TakeCover:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 TRATOS:
 	Inherits: ^Infantry
@@ -496,8 +496,8 @@ TRATOS:
 		Range: 4c0
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 OXANNA:
 	Inherits: ^Infantry
@@ -519,8 +519,8 @@ OXANNA:
 		Range: 4c0
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 SLAV:
 	Inherits: ^Infantry
@@ -542,8 +542,8 @@ SLAV:
 		Range: 4c0
 	TakeCover:
 	-AutoTarget:
-	RenderInfantry:
-		IdleAnimations: idle1,idle2
+	WithInfantryBody:
+		IdleSequences: idle1,idle2
 
 DOGGIE:
 	Inherits: ^Infantry
@@ -603,9 +603,10 @@ VISSML:
 	TargetableUnit:
 		TargetTypes: Ground
 	-AutoTarget:
-	-RenderInfantry:
-	RenderUnit:
+	-RenderSprites:
+	-WithInfantryBody:
 	-WithDeathAnimation:
+	RenderUnit:
 
 VISLRG:
 	Inherits: ^Infantry
@@ -639,9 +640,10 @@ VISLRG:
 		WanderMoveRadius: 2
 		MinMoveDelayInTicks: 25
 		MaxMoveDelayInTicks: 45
-	-RenderInfantry:
-	RenderUnit:
+	-RenderSprites:
+	-WithInfantryBody:
 	-WithDeathAnimation:
+	RenderUnit:
 
 CIV1:
 	Inherits: ^CivilianInfantry

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -16,11 +16,12 @@ waypoint:
 		InitialFacing: 160
 	Turreted:
 		InitialFacing: 160
-	RenderInfantry:
-		Image: mmch
-		StandAnimations: run
-		Palette: colorpicker
+	WithInfantryBody:
+		StandSequences: run
 	RenderVoxels:
+		Image: mmch
+		Palette: colorpicker
+	RenderSprites:
 		Image: mmch
 		Palette: colorpicker
 
@@ -66,3 +67,4 @@ TROCK04:
 
 TROCK05:
 	Inherits: ^Rock
+

--- a/mods/ts/rules/vehicles.yaml
+++ b/mods/ts/rules/vehicles.yaml
@@ -168,7 +168,7 @@ HVR:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
- 		Prerequisites: ~gaweap
+		Prerequisites: ~gaweap
 	Mobile:
 		Speed: 56
 		ROT: 5
@@ -518,7 +518,8 @@ MMCH:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
-	RenderInfantry:
+	RenderSprites:
+	WithInfantryBody:
 	Turreted:
 		ROT: 5
 	AttackTurreted:
@@ -590,7 +591,8 @@ SMECH:
 	AutoTarget:
 	Armament:
 		Weapon: AssaultCannon
-	RenderInfantry:
+	RenderSprites:
+	WithInfantryBody:
 	Selectable:
 		Voices: Mech
 		Bounds: 16, 32


### PR DESCRIPTION
Followup to #3348.  This untangles the default (body) sprite from `RenderSprites` for infantry.

A future PR can now make this implement `UpgradableTrait` and switch the infantry artwork based on an external condition (RA2 GIs / thumpers / TS cyborgs).
