### PR TITLE
Add a Cloaking sound to the Phase Transport

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -768,6 +768,8 @@ STNK:
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 250
+		CloakSound: appear1.aud
+		UncloakSound: appear1.aud
 	DetectCloaked:
 		Range: 6
 	Explodes:


### PR DESCRIPTION
Adds a cloaking sound to the phase transport. This uses the same sound the Phase Transport used in the Single Player campaigns in Counterstrike.
