### PR TITLE
HackyAI can now build buildings near a new MCV

### DIFF
--- a/OpenRA.Mods.Common/AI/States/StateBase.cs
+++ b/OpenRA.Mods.Common/AI/States/StateBase.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.AI
 
 		protected static CPos RandomBuildingLocation(Squad squad)
 		{
-			var location = squad.Bot.BaseCenter;
+			var location = squad.Bot.GetRandomBaseCenter();
 			var buildings = squad.World.ActorsWithTrait<Building>()
 				.Where(a => a.Actor.Owner == squad.Bot.Player).Select(a => a.Actor).ToList();
 			if (buildings.Count > 0)


### PR DESCRIPTION
There was an issue where HackyAI would try and fail to build buildings
at old base location, unless it was placed at the
same place where the old MCV was.

This makes AI more resilient to A-bomb attacks where Construction Yard is destroyed and it builds and deploys a new one.
