### PR TITLE
Make EmitInfantryOnSell compare string[] for owner's race.

### DIFF
--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -22,6 +22,12 @@
 	WithBuildingExplosion:
 	RepairableBuilding:
 	EngineerRepairable:
+	EmitInfantryOnSell@gdi:
+		ActorTypes: e1, e1, e2, medic
+		Races: gdi
+	EmitInfantryOnSell@nod:
+		ActorTypes: e1, e1, e1, e3, e3
+		Races: nod
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	GivesExperience:


### PR DESCRIPTION
`EmitInfantryOnSell` now checks a `string[] Races` against the selling player's race.

I also added EIOS to TS because it was missing.

Kinda off-topic:
This trait should be renamed to `EmitActorsOnSell` and..
We need this same logic for OnDestroyed/Death/whatever.
