### PR TITLE
Implement DeployToUpgrade.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -590,6 +590,7 @@
     <Compile Include="Widgets\Logic\ReplayUtils.cs" />
     <Compile Include="InstallUtils.cs" />
     <Compile Include="Graphics\DefaultSpriteSequence.cs" />
+    <Compile Include="Traits\Upgrades\DeployToUpgrade.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -16,18 +16,18 @@ namespace OpenRA.Mods.Common.Orders
 {
 	public class DeployOrderTargeter : IOrderTargeter
 	{
-		readonly Func<bool> useDeployCursor;
+		readonly string cursor;
 
 		public DeployOrderTargeter(string order, int priority)
-			: this(order, priority, () => true)
+			: this(order, priority, "deploy")
 		{
 		}
 
-		public DeployOrderTargeter(string order, int priority, Func<bool> useDeployCursor)
+		public DeployOrderTargeter(string order, int priority, string cursor)
 		{
 			this.OrderID = order;
 			this.OrderPriority = priority;
-			this.useDeployCursor = useDeployCursor;
+			this.cursor = cursor;
 		}
 
 		public string OrderID { get; private set; }
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Orders
 				return false;
 
 			IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
-			cursor = useDeployCursor() ? "deploy" : "deploy-blocked";
+			cursor = this.cursor;
 
 			return self == target.Actor;
 		}

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
-			get { yield return new DeployOrderTargeter("Unload", 10, CanUnload); }
+			get { yield return new DeployOrderTargeter("Unload", 10, CanUnload() ? "deploy" : "deploy-blocked"); }
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
-			get { yield return new DeployOrderTargeter("DeployTransform", 5, () => CanDeploy()); }
+			get { yield return new DeployOrderTargeter("DeployTransform", 5, CanDeploy() ? "deploy" : "deploy-blocked"); }
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -1,0 +1,70 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class DeployToUpgradeInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	{
+		[Desc("The upgrades to grant when deploying and revoke when undeploying.")]
+		public readonly string[] Upgrades = { };
+
+		[Desc("Cursor to display when deploying the actor.")]
+		public readonly string Cursor = "deploy";
+
+		public object Create(ActorInitializer init) { return new DeployToUpgrade(init.Self, this); }
+	}
+
+	public class DeployToUpgrade : IResolveOrder, IIssueOrder
+	{
+		readonly DeployToUpgradeInfo info;
+		readonly UpgradeManager manager;
+
+		bool isUpgraded;
+
+		public DeployToUpgrade(Actor self, DeployToUpgradeInfo info)
+		{
+			this.info = info;
+			manager = self.Trait<UpgradeManager>();
+		}
+
+		public IEnumerable<IOrderTargeter> Orders
+		{
+			get { yield return new DeployOrderTargeter("DeployToUpgrade", 5, info.Cursor); }
+		}
+
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		{
+			if (order.OrderID == "DeployToUpgrade")
+				return new Order(order.OrderID, self, queued);
+
+			return null;
+		}
+
+		public void ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString != "DeployToUpgrade")
+				return;
+
+			if (isUpgraded)
+				foreach (var up in info.Upgrades)
+					manager.RevokeUpgrade(self, up, this);
+			else
+				foreach (var up in info.Upgrades)
+					manager.GrantUpgrade(self, up, this);
+
+			isUpgraded = !isUpgraded;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -135,6 +135,7 @@ namespace OpenRA.Mods.Common.Widgets
 			PerformKeyboardOrderOnSelection(a => new Order("DeployTransform", a, false));
 			PerformKeyboardOrderOnSelection(a => new Order("Unload", a, false));
 			PerformKeyboardOrderOnSelection(a => new Order("Detonate", a, false));
+			PerformKeyboardOrderOnSelection(a => new Order("DeployToUpgrade", a, false));
 			return true;
 		}
 

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.RA.Traits
 			get
 			{
 				yield return new PortableChronoOrderTargeter();
-				yield return new DeployOrderTargeter("PortableChronoDeploy", 5, () => CanTeleport);
+				yield return new DeployOrderTargeter("PortableChronoDeploy", 5, CanTeleport ? "deploy" : "deploy-blocked");
 			}
 		}
 


### PR DESCRIPTION
Will be useful once #7638 is merged.

**Uses**:
- RA2 GI
- TS Nod Artillery (and later GDI Juggernaut) assuming we don't transform them into structures in the same way vanilla TS did
- D2k Thumper
