### PR TITLE
Fixed actors should lose target

### DIFF
--- a/OpenRA.Mods.Common/AI/Squad.cs
+++ b/OpenRA.Mods.Common/AI/Squad.cs
@@ -42,7 +42,6 @@ namespace OpenRA.Mods.Common.AI
 			Type = type;
 			Target = Target.FromActor(target);
 			FuzzyStateMachine = new StateMachine();
-
 			switch (type)
 			{
 				case SquadType.Assault:
@@ -75,6 +74,11 @@ namespace OpenRA.Mods.Common.AI
 		public bool TargetIsValid
 		{
 			get { return Target.IsValidFor(Units.FirstOrDefault()) && !Target.Actor.HasTrait<Husk>(); }
+		}
+
+		public bool TargetIsVisible
+		{
+			get { return Bot.Player.PlayerActor.Owner.Shroud.IsTargetable(TargetActor); }
 		}
 
 		public WPos CenterPosition { get { return Units.Select(u => u.CenterPosition).Average(); } }

--- a/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Mods.Common.AI
 
 	class UnitsForProtectionAttackState : GroundStateBase, IState
 	{
+		public const int BackoffTicks = 4;
+		internal int Backoff = BackoffTicks;
+
 		public void Activate(Squad owner) { }
 
 		public void Tick(Squad owner)
@@ -37,8 +40,21 @@ namespace OpenRA.Mods.Common.AI
 				}
 			}
 
-			foreach (var a in owner.Units)
-				owner.World.IssueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
+			if (!owner.TargetIsVisible)
+			{
+				if (Backoff < 0)
+				{
+					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), true);
+					Backoff = BackoffTicks;
+					return;
+				} else
+					Backoff--;
+			}
+			else
+			{
+				foreach (var a in owner.Units)
+					owner.World.IssueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
+			}
 		}
 
 		public void Deactivate(Squad owner) { }


### PR DESCRIPTION
In issue https://github.com/OpenRA/OpenRA/issues/7567, actors would keep chasing the enemy even if it moved under the shroud. The target-line was also visible making it very easy to track the target. I changed the FlyAttack, HeliAttack and MoveAdjacent activity to check if the target moved under shroud, if so, the attack activity is cancelled and a regular move is issued to the last known location.

Would also fix:
    - https://github.com/OpenRA/OpenRA/issues/7584
    - https://github.com/OpenRA/OpenRA/issues/7498
