### PR TITLE
[Proof-of-Concept] Improved the performance and intelligence of resource harvesting

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -110,6 +110,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		public bool Debug { get; set; }
 		string id;
 		protected Func<CPos, int> heuristic;
+		protected Func<CPos, bool> isGoal;
 
 		// This member is used to compute the ID of PathSearch.
 		// Essentially, it represents a collection of the initial
@@ -194,8 +195,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		public bool IsTarget(CPos location)
 		{
-			var locInfo = Graph[location];
-			return locInfo.EstimatedTotal - locInfo.CostSoFar == 0;
+			return isGoal(location);
 		}
 
 		public abstract CPos Expand();

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		public abstract IEnumerable<Pair<CPos, int>> Considered { get; }
 
-		public Player Owner { get { return this.Graph.Actor.Owner; } }
+		public Player Owner { get { return Graph.Actor.Owner; } }
 		public int MaxCost { get; protected set; }
 		public bool Debug { get; set; }
 		string id;
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		public IPathSearch FromPoint(CPos from)
 		{
-			if (this.Graph.World.Map.Contains(from))
+			if (Graph.World.Map.Contains(from))
 				AddInitialCell(from);
 
 			return this;

--- a/OpenRA.Mods.Common/Pathfinder/Constants.cs
+++ b/OpenRA.Mods.Common/Pathfinder/Constants.cs
@@ -25,5 +25,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// a unit took to move one cell diagonally)
 		/// </summary>
 		public const int DiagonalCellCost = 177;
+
+		public const int InvalidNode = int.MaxValue;
 	}
 }

--- a/OpenRA.Mods.Common/Pathfinder/PathFinderCacheDecorator.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathFinderCacheDecorator.cs
@@ -68,19 +68,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		public List<CPos> FindPath(IPathSearch search)
 		{
 			using (new PerfSample("Pathfinder"))
-			{
-				var key = "FindPath" + search.Id;
-				var cachedPath = cacheStorage.Retrieve(key);
-
-				if (cachedPath != null)
-					return cachedPath;
-
-				var pb = pathFinder.FindPath(search);
-
-				cacheStorage.Store(key, pb);
-
-				return pb;
-			}
+				return pathFinder.FindPath(search);
 		}
 
 		public List<CPos> FindBidiPath(IPathSearch fromSrc, IPathSearch fromDest)

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// <summary>
 		/// Gets all the Connections for a given node in the graph
 		/// </summary>
-		ICollection<GraphConnection> GetConnections(CPos position);
+		IEnumerable<GraphConnection> GetConnections(CPos position);
 
 		/// <summary>
 		/// Retrieves an object given a node in the graph
@@ -73,8 +73,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 		readonly IMobileInfo mobileInfo;
 		CellLayer<CellInfo> cellInfo;
 
-		public const int InvalidNode = int.MaxValue;
-
 		public PathGraph(CellLayer<CellInfo> cellInfo, IMobileInfo mobileInfo, IActor actor, IWorld world, bool checkForBlocked)
 		{
 			this.cellInfo = cellInfo;
@@ -102,7 +100,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			new[] { new CVec(1, -1), new CVec(1, 0), new CVec(-1, 1), new CVec(0, 1), new CVec(1, 1) },
 		};
 
-		public ICollection<GraphConnection> GetConnections(CPos position)
+		public IEnumerable<GraphConnection> GetConnections(CPos position)
 		{
 			var previousPos = cellInfo[position].PreviousPos;
 
@@ -116,7 +114,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			{
 				var neighbor = position + directions[i];
 				var movementCost = GetCostToNode(neighbor, directions[i]);
-				if (movementCost != InvalidNode)
+				if (movementCost != Constants.InvalidNode)
 					validNeighbors.AddLast(new GraphConnection(position, neighbor, movementCost));
 			}
 
@@ -137,7 +135,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				return CalculateCellCost(destNode, direction, movementCost);
 			}
 
-			return InvalidNode;
+			return Constants.InvalidNode;
 		}
 
 		int CalculateCellCost(CPos neighborCPos, CVec direction, int movementCost)
@@ -148,7 +146,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 				cellCost = (cellCost * 34) / 24;
 
 			if (CustomCost != null)
+			{
+				var customCost = CustomCost(neighborCPos);
+				if (customCost == Constants.InvalidNode)
+					return Constants.InvalidNode;
+
 				cellCost += CustomCost(neighborCPos);
+			}
 
 			// directional bonuses for smoother flow!
 			if (LaneBias != 0)
@@ -184,15 +188,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		public CellInfo this[CPos pos]
 		{
-			get
-			{
-				return cellInfo[pos];
-			}
-
-			set
-			{
-				cellInfo[pos] = value;
-			}
+			get { return cellInfo[pos]; }
+			set { cellInfo[pos] = value; }
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				if (customCost == Constants.InvalidNode)
 					return Constants.InvalidNode;
 
-				cellCost += CustomCost(neighborCPos);
+				cellCost += customCost;
 			}
 
 			// directional bonuses for smoother flow!

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -88,13 +88,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var currentCell = Graph[currentMinNode];
 			Graph[currentMinNode] = new CellInfo(currentCell.CostSoFar, currentCell.EstimatedTotal, currentCell.PreviousPos, CellStatus.Closed);
 
-			if (Graph.CustomCost != null)
-			{
-				var c = Graph.CustomCost(currentMinNode);
-				if (c == int.MaxValue)
-					return currentMinNode;
-			}
-
 			foreach (var connection in Graph.GetConnections(currentMinNode))
 			{
 				// Calculate the cost up to that point

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
@@ -32,10 +33,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 			considered = new LinkedList<Pair<CPos, int>>();
 		}
 
-		public static IPathSearch Search(IWorld world, IMobileInfo mi, IActor self, bool checkForBlocked)
+		public static IPathSearch Search(IWorld world, IMobileInfo mi, IActor self, bool checkForBlocked, Func<CPos, bool> goalCondition)
 		{
 			var graph = new PathGraph(CellInfoLayerManager.Instance.NewLayer(world.Map), mi, self, world, checkForBlocked);
-			return new PathSearch(graph);
+			var search = new PathSearch(graph);
+			search.isGoal = goalCondition;
+			search.heuristic = loc => 0;
+			return search;
 		}
 
 		public static IPathSearch FromPoint(IWorld world, IMobileInfo mi, IActor self, CPos from, CPos target, bool checkForBlocked)
@@ -44,6 +48,12 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)
+			};
+
+			search.isGoal = loc =>
+			{
+				var locInfo = search.Graph[loc];
+				return locInfo.EstimatedTotal - locInfo.CostSoFar == 0;
 			};
 
 			if (world.Map.Contains(from))
@@ -58,6 +68,12 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)
+			};
+
+			search.isGoal = loc =>
+			{
+				var locInfo = search.Graph[loc];
+				return locInfo.EstimatedTotal - locInfo.CostSoFar == 0;
 			};
 
 			foreach (var sl in froms.Where(sl => world.Map.Contains(sl)))

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -88,6 +88,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var currentCell = Graph[currentMinNode];
 			Graph[currentMinNode] = new CellInfo(currentCell.CostSoFar, currentCell.EstimatedTotal, currentCell.PreviousPos, CellStatus.Closed);
 
+			if (Graph.CustomCost != null && Graph.CustomCost(currentMinNode) == Constants.InvalidNode)
+				return currentMinNode;
+
 			foreach (var connection in Graph.GetConnections(currentMinNode))
 			{
 				// Calculate the cost up to that point

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 			var mi = self.Info.Traits.Get<MobileInfo>();
 			var path = self.World.WorldActor.Trait<IPathFinder>().FindPath(
 				PathSearch.FromPoints(self.World, mi, self, refs.Values.Select(r => r.Location), self.Location, false)
-					.WithCustomCost((loc) =>
+					.WithCustomCost(loc =>
 					{
 						if (!refs.ContainsKey(loc)) return 0;
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.Common.Traits
 					foreach (var n in notify)
 						n.MovingToResources(self, moveTo, next);
 
-					self.QueueActivity(new FindResources());
+					self.QueueActivity(next);
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -371,32 +371,31 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Find any harvestable resources:
 			var path = self.World.WorldActor.Trait<IPathFinder>().FindPath(
-				PathSearch.Search(self.World, mobileInfo, self, true)
-					.WithHeuristic(loc =>
+				PathSearch.Search(self.World, mobileInfo, self, true,
+					loc =>
 					{
-						// Get the resource at this location:
 						var resType = resLayer.GetResource(loc);
 						if (resType == null)
-							return Constants.CellCost;
+							return false;
 
 						// Can the harvester collect this kind of resource?
 						if (!harvInfo.Resources.Contains(resType.Info.Name))
-							return Constants.CellCost;
+							return false;
 
-						// Another harvester has claimed this resource:
 						if (territory != null)
 						{
+							// Another harvester has claimed this resource:
 							ResourceClaim claim;
 							if (territory.IsClaimedByAnyoneElse(self, loc, out claim))
-								return Constants.CellCost;
+								return false;
 						}
 
-						return 0;
+						return true;
 					})
 					.FromPoint(self.Location));
 
 			if (path.Count == 0)
-				return (CPos?)null;
+				return null;
 
 			return path[0];
 		}


### PR DESCRIPTION
Improved the performance and intelligence of resource harvesting by refactoring the Harvesters' pathfinding. Now in first place they assess which is the closest resource inside their search area (previously it was quite "randomized" by the heuristic) and then a path is calculated. In fact, this change allowed me to get rid of the Harvester heuristic, which is great. This should improve performance as well.

I would appreciate help in testing that everything is in place, no regressions have appeared and any feedback you consider. This is a proof-of-concept and a work under development, so it would be cool if I require lot of input for it to improve performance and correctness.
