### PR TITLE
More constructor caching and minor random optimisations

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -59,16 +59,16 @@ namespace OpenRA.Mods.Cnc.Traits
 					return;
 
 				var altitude = self.World.Map.Rules.Actors[actorType].Traits.Get<PlaneInfo>().CruiseAltitude;
-				var a = w.CreateActor(actorType, new TypeDictionary
+				var actor = w.CreateActor(actorType, new TypeDictionary
 				{
 					new CenterPositionInit(w.Map.CenterOfCell(startPos) + new WVec(WRange.Zero, WRange.Zero, altitude)),
 					new OwnerInit(owner),
 					new FacingInit(64)
 				});
 
-				a.QueueActivity(new Fly(a, Target.FromCell(w, self.Location + new CVec(9, 0))));
-				a.QueueActivity(new Land(Target.FromActor(self)));
-				a.QueueActivity(new CallFunc(() =>
+				actor.QueueActivity(new Fly(actor, Target.FromCell(w, self.Location + new CVec(9, 0))));
+				actor.QueueActivity(new Land(actor, Target.FromActor(self)));
+				actor.QueueActivity(new CallFunc(() =>
 				{
 					if (!self.IsInWorld || self.IsDead)
 						return;
@@ -80,8 +80,8 @@ namespace OpenRA.Mods.Cnc.Traits
 					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Country.Race);
 				}));
 
-				a.QueueActivity(new Fly(a, Target.FromCell(w, endPos)));
-				a.QueueActivity(new RemoveSelf());
+				actor.QueueActivity(new Fly(actor, Target.FromCell(w, endPos)));
+				actor.QueueActivity(new RemoveSelf());
 			});
 
 			return true;

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -18,20 +18,21 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FallToEarth : Activity
 	{
+		readonly Aircraft aircraft;
+		readonly FallsToEarthInfo info;
 		int acceleration = 0;
 		int spin = 0;
-		FallsToEarthInfo info;
 
 		public FallToEarth(Actor self, FallsToEarthInfo info)
 		{
 			this.info = info;
+			aircraft = self.Trait<Aircraft>();
 			if (info.Spins)
 				acceleration = self.World.SharedRandom.Next(2) * 2 - 1;
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			var aircraft = self.Trait<Aircraft>();
 			if (self.CenterPosition.Z <= 0)
 			{
 				if (info.Explosion != null)

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -52,9 +52,9 @@ namespace OpenRA.Mods.Common.Activities
 
 				// TODO: This should fire each weapon at its maximum range
 				if (target.IsInRange(self.CenterPosition, attackPlane.Armaments.Select(a => a.Weapon.MinRange).Min()))
-					inner = Util.SequenceActivities(new FlyTimed(ticksUntilTurn), new Fly(self, target), new FlyTimed(ticksUntilTurn));
+					inner = Util.SequenceActivities(new FlyTimed(ticksUntilTurn, self), new Fly(self, target), new FlyTimed(ticksUntilTurn, self));
 				else
-					inner = Util.SequenceActivities(new Fly(self, target), new FlyTimed(ticksUntilTurn));
+					inner = Util.SequenceActivities(new Fly(self, target), new FlyTimed(ticksUntilTurn, self));
 			}
 
 			inner = Util.RunActivity(self, inner);

--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -16,16 +16,23 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FlyCircle : Activity
 	{
+		readonly Plane plane;
+		readonly WRange cruiseAltitude;
+
+		public FlyCircle(Actor self)
+		{
+			plane = self.Trait<Plane>();
+			cruiseAltitude = plane.Info.CruiseAltitude;
+		}
+
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceled)
 				return NextActivity;
 
-			var plane = self.Trait<Plane>();
-
 			// We can't possibly turn this fast
 			var desiredFacing = plane.Facing + 64;
-			Fly.FlyToward(self, plane, desiredFacing, plane.Info.CruiseAltitude);
+			Fly.FlyToward(self, plane, desiredFacing, cruiseAltitude);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -8,34 +8,28 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class ResupplyAircraft : Activity
+	public class FlyOffMap : Activity
 	{
-		readonly Aircraft aircraft;
+		readonly Plane plane;
 
-		public ResupplyAircraft(Actor self)
+		public FlyOffMap(Actor self)
 		{
-			aircraft = self.Trait<Aircraft>();
+			plane = self.Trait<Plane>();
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			var host = aircraft.GetActorBelow();
-
-			if (host == null)
+			if (IsCanceled || !self.World.Map.Contains(self.Location))
 				return NextActivity;
 
-			return Util.SequenceActivities(
-				aircraft.GetResupplyActivities(host).Append(NextActivity).ToArray());
+			Fly.FlyToward(self, plane, plane.Facing, plane.Info.CruiseAltitude);
+			return this;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -16,37 +16,25 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FlyTimed : Activity
 	{
+		readonly Plane plane;
+		readonly WRange cruiseAltitude;
 		int remainingTicks;
 
-		public FlyTimed(int ticks) { remainingTicks = ticks; }
+		public FlyTimed(int ticks, Actor self)
+		{
+			remainingTicks = ticks;
+			plane = self.Trait<Plane>();
+			cruiseAltitude = plane.Info.CruiseAltitude;
+		}
 
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceled || remainingTicks-- == 0)
 				return NextActivity;
 
-			var plane = self.Trait<Plane>();
-			Fly.FlyToward(self, plane, plane.Facing, plane.Info.CruiseAltitude);
+			Fly.FlyToward(self, plane, plane.Facing, cruiseAltitude);
 
 			return this;
-		}
-	}
-
-	public class FlyOffMap : Activity
-	{
-		public override Activity Tick(Actor self)
-		{
-			if (IsCanceled || !self.World.Map.Contains(self.Location))
-				return NextActivity;
-
-			var plane = self.Trait<Plane>();
-			Fly.FlyToward(self, plane, plane.Facing, plane.Info.CruiseAltitude);
-			return this;
-		}
-
-		public override void Cancel(Actor self)
-		{
-			base.Cancel(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Activities
 			// If all ammo pools are depleted and none reload automatically, return to helipad to reload and then move to next activity
 			// TODO: This should check whether there is ammo left that is actually suitable for the target
 			if (ammoPools != null && ammoPools.All(x => !x.Info.SelfReloads && !x.HasAmmo()))
-				return Util.SequenceActivities(new HeliReturn(), NextActivity);
+				return Util.SequenceActivities(new HeliReturn(self), NextActivity);
 
 			var dist = target.CenterPosition - self.CenterPosition;
 

--- a/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
@@ -15,11 +15,15 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class HeliLand : Activity
 	{
+		readonly Helicopter helicopter;
+		readonly WRange landAltitude;
 		bool requireSpace;
 
-		public HeliLand(bool requireSpace)
+		public HeliLand(Actor self, bool requireSpace)
 		{
 			this.requireSpace = requireSpace;
+			helicopter = self.Trait<Helicopter>();
+			landAltitude = helicopter.Info.LandAltitude;
 		}
 
 		public override Activity Tick(Actor self)
@@ -27,12 +31,10 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			var helicopter = self.Trait<Helicopter>();
-
 			if (requireSpace && !helicopter.CanLand(self.Location))
 				return this;
 
-			if (HeliFly.AdjustAltitude(self, helicopter, helicopter.Info.LandAltitude))
+			if (HeliFly.AdjustAltitude(self, helicopter, landAltitude))
 				return this;
 
 			return NextActivity;

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -16,9 +16,14 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class Land : Activity
 	{
-		Target target;
+		readonly Target target;
+		readonly Plane plane;
 
-		public Land(Target t) { target = t; }
+		public Land(Actor self, Target t)
+		{
+			target = t;
+			plane = self.Trait<Plane>();
+		}
 
 		public override Activity Tick(Actor self)
 		{
@@ -28,7 +33,6 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			var plane = self.Trait<Plane>();
 			var d = target.CenterPosition - self.CenterPosition;
 
 			// The next move would overshoot, so just set the final position

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -16,10 +16,17 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class TakeOff : Activity
 	{
+		readonly Aircraft aircraft;
+		readonly IMove move;
+
+		public TakeOff(Actor self)
+		{
+			aircraft = self.Trait<Aircraft>();
+			move = self.Trait<IMove>();
+		}
+
 		public override Activity Tick(Actor self)
 		{
-			var aircraft = self.Trait<Aircraft>();
-
 			self.CancelActivity();
 
 			var reservation = aircraft.Reservation;
@@ -36,7 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 			var destination = rp != null ? rp.Location :
 				(hasHost ? self.World.Map.CellContaining(host.CenterPosition) : self.Location);
 
-			return new AttackMoveActivity(self, self.Trait<IMove>().MoveTo(destination, 1));
+			return new AttackMoveActivity(self, move.MoveTo(destination, 1));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -17,16 +17,23 @@ namespace OpenRA.Mods.Common.Activities
 {
 	class ExternalCaptureActor : Activity
 	{
-		Target target;
+		readonly ExternalCapturable capturable;
+		readonly ExternalCapturesInfo capturesInfo;
+		readonly Mobile mobile;
+		readonly Target target;
 
-		public ExternalCaptureActor(Target target) { this.target = target; }
+		public ExternalCaptureActor(Actor self, Target target)
+		{
+			this.target = target;
+			capturable = target.Actor.Trait<ExternalCapturable>();
+			capturesInfo = self.Info.Traits.Get<ExternalCapturesInfo>();
+			mobile = self.Trait<Mobile>();
+		}
 
 		public override Activity Tick(Actor self)
 		{
 			if (target.Type != TargetType.Actor)
 				return NextActivity;
-
-			var capturable = target.Actor.Trait<ExternalCapturable>();
 
 			if (IsCanceled || !self.IsInWorld || self.IsDead || !target.IsValidFor(self))
 			{
@@ -36,7 +43,6 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			var mobile = self.Trait<Mobile>();
 			var nearest = target.Actor.OccupiesSpace.NearestCellTo(mobile.ToCell);
 
 			if ((nearest - mobile.ToCell).LengthSquared > 2)
@@ -56,8 +62,6 @@ namespace OpenRA.Mods.Common.Activities
 
 				if (capturable.CaptureProgressTime == capturable.Info.CaptureCompleteTime * 25)
 				{
-					var capturesInfo = self.Info.Traits.Get<ExternalCapturesInfo>();
-
 					self.World.AddFrameEndTask(w =>
 					{
 						if (target.Actor.IsDead)

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -17,16 +17,23 @@ namespace OpenRA.Mods.Common.Activities
 {
 	class Sell : Activity
 	{
+		readonly Health health;
+		readonly SellableInfo sellableInfo;
+		readonly PlayerResources playerResources;
+
+		public Sell(Actor self)
+		{
+			health = self.TraitOrDefault<Health>();
+			sellableInfo = self.Info.Traits.Get<SellableInfo>();
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
+		}
+
 		public override Activity Tick(Actor self)
 		{
-			var h = self.TraitOrDefault<Health>();
-			var si = self.Info.Traits.Get<SellableInfo>();
-			var pr = self.Owner.PlayerActor.Trait<PlayerResources>();
-
 			var cost = self.GetSellValue();
 
-			var refund = (cost * si.RefundPercent * (h == null ? 1 : h.HP)) / (100 * (h == null ? 1 : h.MaxHP));
-			pr.GiveCash(refund);
+			var refund = (cost * sellableInfo.RefundPercent * (health == null ? 1 : health.HP)) / (100 * (health == null ? 1 : health.MaxHP));
+			playerResources.GiveCash(refund);
 
 			foreach (var ns in self.TraitsImplementing<INotifySold>())
 				ns.Sold(self);

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Activities\Air\FlyAttack.cs" />
     <Compile Include="Activities\Air\FlyCircle.cs" />
     <Compile Include="Activities\Air\FlyFollow.cs" />
+    <Compile Include="Activities\Air\FlyOffMap.cs" />
     <Compile Include="Activities\Air\FlyTimed.cs" />
     <Compile Include="Activities\Air\HeliAttack.cs" />
     <Compile Include="Activities\Air\HeliFly.cs" />

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Scripting
 				if (heli != null)
 				{
 					transport.QueueActivity(new Turn(transport, heli.Info.InitialFacing));
-					transport.QueueActivity(new HeliLand(true));
+					transport.QueueActivity(new HeliLand(transport, true));
 					transport.QueueActivity(new Wait(15));
 				}
 

--- a/OpenRA.Mods.Common/Traits/Air/FlyAwayOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FlyAwayOnIdle.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public void TickIdle(Actor self)
 		{
-			self.QueueActivity(new FlyOffMap());
+			self.QueueActivity(new FlyOffMap(self));
 			self.QueueActivity(new RemoveSelf());
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (airfield != null)
 			{
 				self.QueueActivity(new ReturnToBase(self, airfield));
-				self.QueueActivity(new ResupplyAircraft());
+				self.QueueActivity(new ResupplyAircraft(self));
 			}
 			else
 			{
@@ -49,13 +49,13 @@ namespace OpenRA.Mods.Common.Traits
 				if (someBuilding == null)
 				{
 					// ... going down the garden to eat worms ...
-					self.QueueActivity(new FlyOffMap());
+					self.QueueActivity(new FlyOffMap(self));
 					self.QueueActivity(new RemoveSelf());
 					return;
 				}
 
 				self.QueueActivity(new Fly(self, Target.FromActor(someBuilding)));
-				self.QueueActivity(new FlyCircle());
+				self.QueueActivity(new FlyCircle(self));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -25,8 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	class Burns : ITick, ISync
 	{
+		readonly BurnsInfo info;
 		[Sync] int ticks;
-		BurnsInfo info;
 
 		public Burns(Actor self, BurnsInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 				Unloading = true;
 				self.CancelActivity();
 				if (helicopter != null)
-					self.QueueActivity(new HeliLand(true));
+					self.QueueActivity(new HeliLand(self, true));
 				self.QueueActivity(new UnloadCargo(self, true));
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -51,21 +51,20 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class ExternalCapturable : ITick
 	{
+		readonly Building building;
 		[Sync] public int CaptureProgressTime = 0;
 		[Sync] public Actor Captor;
-		private Actor self;
 		public ExternalCapturableInfo Info;
 		public bool CaptureInProgress { get { return Captor != null; } }
 
 		public ExternalCapturable(Actor self, ExternalCapturableInfo info)
 		{
-			this.self = self;
 			Info = info;
+			building = self.TraitOrDefault<Building>();
 		}
 
 		public void BeginCapture(Actor captor)
 		{
-			var building = self.TraitOrDefault<Building>();
 			if (building != null)
 				building.Lock();
 
@@ -74,7 +73,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void EndCapture()
 		{
-			var building = self.TraitOrDefault<Building>();
 			if (building != null)
 				building.Unlock();
 

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.CancelActivity();
 
 			self.SetTargetLine(target, Color.Red);
-			self.QueueActivity(new ExternalCaptureActor(target));
+			self.QueueActivity(new ExternalCaptureActor(self, target));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync, IRenderInfantrySequenceModifier
 	{
 		readonly ScaredyCatInfo info;
+		readonly Mobile mobile;
 		[Sync] readonly Actor self;
 		[Sync] int panicStartedTick;
 		bool Panicking { get { return panicStartedTick > 0; } }
@@ -41,6 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.self = self;
 			this.info = info;
+			mobile = self.Trait<Mobile>();
 		}
 
 		public void Panic()
@@ -68,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Panicking)
 				return;
 
-			self.Trait<Mobile>().Nudge(self, self, true);
+			mobile.Nudge(self, self, true);
 		}
 
 		public void Damaged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingExplosion.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingExplosion.cs
@@ -27,21 +27,22 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Custom palette name")]
 		public readonly string Palette = "effect";
 
-		public object Create(ActorInitializer init) { return new WithBuildingExplosion(this); }
+		public object Create(ActorInitializer init) { return new WithBuildingExplosion(init.Self, this); }
 	}
 
 	class WithBuildingExplosion : INotifyKilled
 	{
 		WithBuildingExplosionInfo info;
+		BuildingInfo buildingInfo;
 
-		public WithBuildingExplosion(WithBuildingExplosionInfo info)
+		public WithBuildingExplosion(Actor self, WithBuildingExplosionInfo info)
 		{
 			this.info = info;
+			buildingInfo = self.Info.Traits.Get<BuildingInfo>();
 		}
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			var buildingInfo = self.Info.Traits.Get<BuildingInfo>();
 			var cells = FootprintUtils.UnpathableTiles(self.Info.Name, buildingInfo, self.Location);
 
 			if (info.Delay > 0)

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -29,8 +29,14 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly RepairableNearInfo info;
+		readonly IMove movement;
 
-		public RepairableNear(Actor self, RepairableNearInfo info) { this.self = self; this.info = info; }
+		public RepairableNear(Actor self, RepairableNearInfo info)
+		{
+			this.self = self;
+			this.info = info;
+			movement = self.Trait<IMove>();
+		}
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
@@ -63,7 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (order.OrderString == "RepairNear" && CanRepairAt(order.TargetActor) && ShouldRepair())
 			{
-				var movement = self.Trait<IMove>();
 				var target = Target.FromOrder(self.World, order);
 
 				self.CancelActivity();

--- a/OpenRA.Mods.D2k/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.D2k/Activities/PickupUnit.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.D2k.Activities
 					if (selfFacing.Facing != cargoFacing.Facing)
 						return Util.SequenceActivities(new Turn(self, cargoFacing.Facing), this);
 					state = State.Pickup;
-					return Util.SequenceActivities(new HeliLand(false), new Wait(10), this);
+					return Util.SequenceActivities(new HeliLand(self, false), new Wait(10), this);
 
 				case State.Pickup:
 					// Remove our carryable from world

--- a/OpenRA.Mods.RA/Scripting/Properties/ParadropProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ParadropProperties.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Scripting
 		{
 			paradrop.SetLZ(cell, true);
 			Self.QueueActivity(new Fly(Self, Target.FromCell(Self.World, cell)));
-			Self.QueueActivity(new FlyOffMap());
+			Self.QueueActivity(new FlyOffMap(Self));
 			Self.QueueActivity(new RemoveSelf());
 		}
 	}


### PR DESCRIPTION
Moved many trait look-ups from Tick (or other actions) to constructors.
Performance gains are likely negligible, but this also makes the affected code more consistent with traits and activities where this had already been done.
Additionally extracted `FlyOffMap` and `HarvestResource` activities into their own files, and moved harvesting-related activities into their own subfolder.

A couple of notes:
- There are a few more cases (aircraft attack activities and `Repariable` trait, for example) which I intentionally omitted since they're already part of #7324.
- I also omitted `FindResources` for now, because I had trouble dealing with that 'double'-constructor, my attempts compiled fine but crashed the game at launch. Feel free to make suggestions on how to deal with those constructors.
