### PR TITLE
Add MaxMind GeoIP2's dependencies to debian package

### DIFF
--- a/packaging/linux/deb/DEBIAN/control
+++ b/packaging/linux/deb/DEBIAN/control
@@ -3,7 +3,7 @@ Version: {VERSION}
 Architecture: all
 Maintainer: Chris Forbes <chrisf@ijw.co.nz>
 Installed-Size: {SIZE}
-Depends: libopenal1, mono-runtime (>= 2.10), libmono-system-core4.0-cil, libmono-system-drawing4.0-cil, libmono-system-windows-forms4.0-cil, libfreetype6, libc6, libasound2, libgl1-mesa-glx, libgl1-mesa-dri, xdg-utils, zenity, libsdl2 | libsdl2-2.0-0, liblua5.1-0
+Depends: libopenal1, mono-runtime (>= 2.10), libmono-system-core4.0-cil, libmono-system-drawing4.0-cil, libmono-system-windows-forms4.0-cil, libmono-system-data4.0-cil, libmono-system-numerics4.0-cil, libmono-system-runtime-serialization4.0-cil, libmono-system-xml-linq4.0-cil, libfreetype6, libc6, libasound2, libgl1-mesa-glx, libgl1-mesa-dri, xdg-utils, zenity, libsdl2 | libsdl2-2.0-0, liblua5.1-0
 Section: games
 Priority: extra
 Homepage: http://www.openra.net/


### PR DESCRIPTION
Fixes #7417.

It would have been easier to just depend on `libnewtonsoft-json5.0-cil`, but that is only available in Ubuntu 14.04 and higher.
