### PR TITLE
Allow the use of race variants in "StartGameNotification:"

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
-			Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, null);
+			Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Country.Race);
 		}
 	}
 }


### PR DESCRIPTION
Needed for ra2, as there are two different notifications (allied and soviet).
