### PR TITLE
Skip visibility updates when fog & shroud are disabled via lobby

### DIFF
--- a/OpenRA.Game/Traits/CreatesShroud.cs
+++ b/OpenRA.Game/Traits/CreatesShroud.cs
@@ -15,22 +15,28 @@ namespace OpenRA.Traits
 	public class CreatesShroudInfo : ITraitInfo
 	{
 		public readonly WRange Range = WRange.Zero;
-		public object Create(ActorInitializer init) { return new CreatesShroud(this); }
+
+		public object Create(ActorInitializer init) { return new CreatesShroud(init.Self, this); }
 	}
 
 	public class CreatesShroud : ITick, ISync
 	{
 		readonly CreatesShroudInfo info;
+		readonly bool lobbyShroudFogDisabled;
 		[Sync] CPos cachedLocation;
 		[Sync] bool cachedDisabled;
 
-		public CreatesShroud(CreatesShroudInfo info)
+		public CreatesShroud(Actor self, CreatesShroudInfo info)
 		{
 			this.info = info;
+			lobbyShroudFogDisabled = !self.World.LobbyInfo.GlobalSettings.Shroud && !self.World.LobbyInfo.GlobalSettings.Fog;
 		}
 
 		public void Tick(Actor self)
 		{
+			if (lobbyShroudFogDisabled)
+				return;
+
 			var disabled = self.TraitsImplementing<IDisable>().Any(d => d.Disabled);
 			if (cachedLocation != self.Location || cachedDisabled != disabled)
 			{

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -15,21 +15,27 @@ namespace OpenRA.Traits
 	public class RevealsShroudInfo : ITraitInfo
 	{
 		public readonly WRange Range = WRange.Zero;
-		public object Create(ActorInitializer init) { return new RevealsShroud(this); }
+
+		public object Create(ActorInitializer init) { return new RevealsShroud(init.Self, this); }
 	}
 
 	public class RevealsShroud : ITick, ISync
 	{
 		readonly RevealsShroudInfo info;
+		readonly bool lobbyShroudFogDisabled;
 		[Sync] CPos cachedLocation;
 
-		public RevealsShroud(RevealsShroudInfo info)
+		public RevealsShroud(Actor self, RevealsShroudInfo info)
 		{
 			this.info = info;
+			lobbyShroudFogDisabled = !self.World.LobbyInfo.GlobalSettings.Shroud && !self.World.LobbyInfo.GlobalSettings.Fog;
 		}
 
 		public void Tick(Actor self)
 		{
+			if (lobbyShroudFogDisabled)
+				return;
+
 			if (cachedLocation != self.Location)
 			{
 				cachedLocation = self.Location;


### PR DESCRIPTION
Added a check whether both shroud and fog are disabled for a player, and if they are, completely skip visibility update for that player. Fixes #7669.
