### PR TITLE
Corrected the NSIS Setup.exe renaming in the last AppVeyor step

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ before_deploy:
   - move /Y %NSIS_ROOT%\Plugin\nsProcess.dll %NSIS_ROOT%\Plugins\nsProcess.dll
   - appveyor DownloadFile "https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md" -FileName Changelog.md
   - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\windows" /V3 packaging/windows/OpenRA.nsi'
-  - move /Y packaging/windows/OpenRA.Setup.exe %APPVEYOR_BUILD_FOLDER%/OpenRA-%APPVEYOR_REPO_TAG_NAME%.exe
+  - move /Y %APPVEYOR_BUILD_FOLDER%\packaging\windows\OpenRA.Setup.exe %APPVEYOR_BUILD_FOLDER%\OpenRA-%APPVEYOR_REPO_TAG_NAME%.exe
 
 artifacts:
   - name: Installer


### PR DESCRIPTION
Backslash instead of slash and using absolute paths prefixed with %APPVEYOR_BUILD_FOLDER%.
