### PR TITLE
Replaced Mono.Nat with Open.NAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,13 +37,14 @@ thirdparty/SharpFont*
 thirdparty/windows/freetype6.dll
 thirdparty/nunit*
 thirdparty/windows/SDL2.dll
-thirdparty/Mono.Nat.dll
 thirdparty/Moq.dll
 thirdparty/nuget.exe
 thirdparty/windows/lua51.dll
 thirdparty/windows/zlib1.dll
 thirdparty/windows/soft_oal.dll
 thirdparty/FuzzyLogicLibrary.dll
+thirdparty/AsyncBridge.dll
+thirdparty/Open.Nat.dll
 
 # backup files by various editors
 *~

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@
 CSC         = dmcs
 CSFLAGS     = -nologo -warn:4 -debug:full -optimize- -codepage:utf8 -unsafe -warnaserror
 DEFINE      = DEBUG;TRACE
-COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/ICSharpCode.SharpZipLib.dll thirdparty/FuzzyLogicLibrary.dll thirdparty/Mono.Nat.dll thirdparty/MaxMind.Db.dll thirdparty/MaxMind.GeoIP2.dll thirdparty/Eluant.dll
+COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/ICSharpCode.SharpZipLib.dll thirdparty/FuzzyLogicLibrary.dll thirdparty/AsyncBridge.dll thirdparty/Open.Nat.dll thirdparty/MaxMind.Db.dll thirdparty/MaxMind.GeoIP2.dll thirdparty/Eluant.dll
 
 
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -209,12 +209,9 @@ namespace OpenRA
 			Log.AddChannel("geoip", "geoip.log");
 
 			if (Settings.Server.DiscoverNatDevices)
-				UPnP.TryNatDiscovery();
+				Settings.Server.AllowPortForward = UPnP.NatDiscovery().Wait(Settings.Server.NatDiscoveryTimeout);
 			else
-			{
-				Settings.Server.NatDeviceAvailable = false;
 				Settings.Server.AllowPortForward = false;
-			}
 
 			try
 			{
@@ -262,9 +259,6 @@ namespace OpenRA
 				Console.WriteLine("\t{0}: {1} ({2})", mod.Key, mod.Value.Title, mod.Value.Version);
 
 			InitializeMod(Settings.Game.Mod, args);
-
-			if (Settings.Server.DiscoverNatDevices)
-				RunAfterDelay(Settings.Server.NatDiscoveryTimeout, UPnP.StoppingNatDiscovery);
 		}
 
 		public static void InitializeMod(string mod, Arguments args)

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -53,12 +53,6 @@
       <HintPath>..\thirdparty\SharpFont.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Nat">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-      <Package>mono.nat</Package>
-      <HintPath>..\thirdparty\Mono.Nat.dll</HintPath>
-    </Reference>
     <Reference Include="Eluant">
       <HintPath>..\thirdparty\Eluant.dll</HintPath>
       <Private>False</Private>
@@ -78,6 +72,12 @@
     <Reference Include="SDL2-CS">
       <HintPath>..\thirdparty\SDL2-CS.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Open.Nat">
+      <HintPath>..\Open.Nat.dll</HintPath>
+    </Reference>
+    <Reference Include="AsyncBridge">
+      <HintPath>..\AsyncBridge.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using Open.Nat;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -132,7 +133,7 @@ namespace OpenRA.Server
 			randomSeed = (int)DateTime.Now.ToBinary();
 
 			if (Settings.AllowPortForward)
-				UPnP.ForwardPort(3600);
+				UPnP.ForwardPort();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
 				serverTraits.Add(modData.ObjectCreator.CreateObject<ServerTrait>(trait));
@@ -150,7 +151,7 @@ namespace OpenRA.Server
 			Log.Write("server", "Initial mod: {0}", ModData.Manifest.Mod.Id);
 			Log.Write("server", "Initial map: {0}", LobbyInfo.GlobalSettings.Map);
 
-			new Thread(_ =>
+			new Thread(() =>
 			{
 				var timeout = serverTraits.WithInterface<ITick>().Min(t => t.TickTimeout);
 				for (;;)
@@ -186,7 +187,8 @@ namespace OpenRA.Server
 					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();
-						if (Settings.AllowPortForward) UPnP.RemovePortforward();
+						if (Settings.AllowPortForward)
+							UPnP.RemovePortforward();
 						break;
 					}
 				}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -27,7 +27,6 @@ namespace OpenRA
 		public string MasterServer = "http://master.openra.net/";
 		public bool DiscoverNatDevices = false; // Allow users to disable NAT discovery if problems occur
 		public bool AllowPortForward = true; // let the user disable it even if compatible devices are found
-		public bool NatDeviceAvailable = false; // internal check if discovery succeeded
 		public int NatDiscoveryTimeout = 1000; // ms to search for UPnP enabled NATs
 		public bool VerboseNatDiscovery = false; // print very detailed logs for debugging
 		public string Map = null;
@@ -50,7 +49,6 @@ namespace OpenRA
 			MasterServer = other.MasterServer;
 			DiscoverNatDevices = other.DiscoverNatDevices;
 			AllowPortForward = other.AllowPortForward;
-			NatDeviceAvailable = other.NatDeviceAvailable;
 			NatDiscoveryTimeout = other.NatDiscoveryTimeout;
 			VerboseNatDiscovery = other.VerboseNatDiscovery;
 			Map = other.Map;

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -59,13 +59,15 @@
       <HintPath>..\thirdparty\MaxMind.GeoIP2.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Nat">
-      <HintPath>..\thirdparty\Mono.Nat.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\thirdparty\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Open.Nat">
+      <HintPath>..\Open.Nat.dll</HintPath>
+    </Reference>
+    <Reference Include="AsyncBridge">
+      <HintPath>..\AsyncBridge.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
@@ -80,9 +80,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			latency.GetText = () => LobbyUtils.LatencyDescription(ping);
 			latency.GetColor = () => LobbyUtils.LatencyColor(ping);
 			var address = orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
-			if (clientIndex == orderManager.LocalClient.Index && UPnP.NatDevice != null
-				&& address == IPAddress.Loopback.ToString())
-				address = UPnP.NatDevice.GetExternalIP().ToString();
+			if (clientIndex == orderManager.LocalClient.Index && address == IPAddress.Loopback.ToString() && UPnP.ExternalIP != null)
+				address = UPnP.ExternalIP.ToString();
 			var cachedDescriptiveIP = LobbyUtils.DescriptiveIpAddress(address);
 			ip.GetText = () => cachedDescriptiveIP;
 			var cachedCountryLookup = LobbyUtils.LookupCountry(address);

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Net;
+using OpenRA.Network;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var checkboxUPnP = panel.Get<CheckboxWidget>("UPNP_CHECKBOX");
 			checkboxUPnP.IsChecked = () => allowPortForward;
 			checkboxUPnP.OnClick = () => allowPortForward ^= true;
-			checkboxUPnP.IsDisabled = () => !Game.Settings.Server.NatDeviceAvailable;
+			checkboxUPnP.IsDisabled = () => UPnP.NatDevice == null;
 
 			var passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");
 			if (passwordField != null)

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -73,14 +73,6 @@ if (!(Test-Path "windows/SDL2.dll"))
 	rmdir sdl2.redist.2.0.3 -Recurse
 }
 
-if (!(Test-Path "Mono.Nat.dll"))
-{
-	echo "Fetching Mono.Nat from NuGet."
-	./nuget.exe install Mono.Nat -Version 1.2.21
-	cp Mono.Nat.1.2.21.0/lib/net40/Mono.Nat.dll .
-	rmdir Mono.Nat.1.2.21.0 -Recurse
-}
-
 if (!(Test-Path "windows/lua51.dll"))
 {
 	echo "Fetching Lua 5.1 from NuGet."
@@ -128,4 +120,20 @@ if (!(Test-Path "FuzzyLogicLibrary.dll"))
 	./nuget.exe install FuzzyLogicLibrary -Version 1.2.0
 	cp FuzzyLogicLibrary.1.2.0/bin/Release/FuzzyLogicLibrary.dll .
 	rmdir FuzzyLogicLibrary.1.2.0 -Recurse
+}
+
+if (!(Test-Path "AsyncBridge.dll"))
+{
+	echo "Fetching .NET 4.0 AsyncBridge from NuGet."
+	./nuget.exe install AsyncBridge -Version 0.1.1
+	cp ./AsyncBridge.0.1.1/lib/net40-Client/AsyncBridge.dll .
+	rmdir AsyncBridge.0.1.1 -Recurse
+}
+
+if (!(Test-Path "Open.Nat.dll"))
+{
+	echo "Fetching Open.NAT from NuGet"
+	./nuget.exe install Open.Nat -Version 2.0.11
+	cp Open.Nat.2.0.11.0/lib/net45/Open.Nat.dll .
+	rmdir Open.Nat.2.0.11.0 -Recurse
 }

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -52,13 +52,6 @@ if [ ! -f nunit.framework.dll ]; then
 	rm -rf NUnit.2.6.4
 fi
 
-if [ ! -f Mono.Nat.dll ]; then
-	echo "Fetching Mono.Nat from nuget"
-	nuget install Mono.Nat -Version 1.2.21
-	cp ./Mono.Nat.1.2.21.0/lib/net40/Mono.Nat.dll .
-	rm -rf Mono.Nat.1.2.21.0
-fi
-
 if [ ! -f Moq.dll ]; then
 	echo "Fetching Moq from NuGet."
 	nuget install Moq -Version 4.2.1502.0911
@@ -71,4 +64,18 @@ if [ ! -f FuzzyLogicLibrary.dll ]; then
 	nuget install FuzzyLogicLibrary -Version 1.2.0
 	cp ./FuzzyLogicLibrary.1.2.0/bin/Release/FuzzyLogicLibrary.dll .
 	rm -rf FuzzyLogicLibrary.1.2.0
+fi
+
+if [ ! -f AsyncBridge.dll ]; then
+	echo "Fetching .NET 4.0 AsyncBridge from NuGet."
+	nuget install AsyncBridge -Version 0.1.1
+	cp ./AsyncBridge.0.1.1/lib/net40-Client/AsyncBridge.dll .
+	rm -rf AsyncBridge.0.1.1
+fi
+
+if [ ! -f Open.Nat.dll ]; then
+	echo "Fetching Open.NAT from nuget"
+	nuget install Open.Nat -Version 2.0.11
+	cp ./Open.Nat.2.0.11.0/lib/net45/Open.Nat.dll .
+	rm -rf Open.Nat.2.0.11.0
 fi


### PR DESCRIPTION
as suggested in https://github.com/OpenRA/OpenRA/issues/7140. I found a way to get us async support without raising the .NET version requirement.

~~I have some trouble getting this to work. See https://github.com/lontivero/Open.NAT/issues/20. This is the first time I experiment with AsyncTasks so I may be doing this wrong or Open.NAT is not yet ready for productive use with FRITZ!Box (a popular router in Germany).~~ Fixed.
