### PR TITLE
Updated SharpFont to 3.0.0, adjusted font rendering code for new fixed-point types

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -102,13 +102,13 @@ namespace OpenRA.Graphics
 			face.LoadChar(c.First, LoadFlags.Default, LoadTarget.Normal);
 			face.Glyph.RenderGlyph(RenderMode.Normal);
 
-			var size = new Size((int)face.Glyph.Metrics.Width >> 6, (int)face.Glyph.Metrics.Height >> 6);
+			var size = new Size((int)face.Glyph.Metrics.Width, (int)face.Glyph.Metrics.Height);
 			var s = builder.Allocate(size);
 
 			var g = new GlyphInfo
 			{
 				Sprite = s,
-				Advance = (int)face.Glyph.Metrics.HorizontalAdvance / 64f,
+				Advance = (float)face.Glyph.Metrics.HorizontalAdvance,
 				Offset = new int2(face.Glyph.BitmapLeft, -face.Glyph.BitmapTop)
 			};
 

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -93,7 +93,6 @@ Section "Game" GAME
 	File "${DEPSDIR}\soft_oal.dll"
 	File "${DEPSDIR}\SDL2.dll"
 	File "${DEPSDIR}\freetype6.dll"
-	File "${DEPSDIR}\zlib1.dll"
 	File "${DEPSDIR}\lua51.dll"
 
 	!insertmacro MUI_STARTMENU_WRITE_BEGIN Application
@@ -211,7 +210,6 @@ Function ${UN}Clean
 	Delete $INSTDIR\lua51.dll
 	Delete $INSTDIR\eluant.dll
 	Delete $INSTDIR\freetype6.dll
-	Delete $INSTDIR\zlib1.dll
 	Delete $INSTDIR\SDL2-CS.dll
 	RMDir /r $INSTDIR\Support
 	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA"

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -16,10 +16,9 @@ fi
 
 if [ ! -f windows/freetype6.dll ]; then
 	echo "Fetching FreeType2 from nuget"
-	nuget install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
-	cp ./freetype2.redist/bin/win32/zlib1.dll ./windows/
-	cp ./freetype2.redist/bin/win32/freetype6.dll ./windows/
-	rm -rf freetype2.redist
+	nuget install SharpFont.Dependencies -Version 2.5.5.1 -ExcludeVersion
+	cp ./SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll ./windows/
+	rm -rf SharpFont.Dependencies
 fi
 
 if [ ! -f windows/lua51.dll ]; then
@@ -27,13 +26,6 @@ if [ ! -f windows/lua51.dll ]; then
 	nuget install lua.binaries -Version 5.1.5 -ExcludeVersion
 	cp ./lua.binaries/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
 	rm -rf lua.binaries
-fi
-
-if [ ! -f windows/zlib1.dll ]; then
-	echo "Fetching ZLib from nuget"
-	nuget install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
-	cp ./freetype2.redist/bin/win32/zlib1.dll ./windows/
-	rm -rf freetype2.redist
 fi
 
 if [ ! -f windows/soft_oal.dll ]; then

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -11,7 +11,7 @@ if [ ! -f windows/SDL2.dll ]; then
 	echo "Fetching SDL2 from nuget"
 	nuget install sdl2 -Version 2.0.3 -ExcludeVersion
 	cp ./sdl2.redist/build/native/bin/Win32/dynamic/SDL2.dll ./windows/
-	rm -rf sdl2.2.0.3 sdl2.redist
+	rm -rf sdl2 sdl2.redist
 fi
 
 if [ ! -f windows/freetype6.dll ]; then

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -50,10 +50,11 @@ if (!(Test-Path "MaxMind.GeoIP2.dll"))
 if (!(Test-Path "SharpFont.dll"))
 {
 	echo "Fetching SharpFont from NuGet."
-	./nuget.exe install SharpFont -Version 2.5.0.1 -ExcludeVersion
+	./nuget.exe install SharpFont -Version 3.0.0 -ExcludeVersion
 	cp SharpFont/lib/net20/SharpFont* .
-	cp SharpFont/Content/SharpFont.dll.config .
+	cp SharpFont/config/SharpFont.dll.config .
 	rmdir SharpFont -Recurse
+    rmdir SharpFont.Dependencies -Recurse
 }
 
 if (!(Test-Path "nunit.framework.dll"))
@@ -92,18 +93,9 @@ if (!(Test-Path "windows/lua51.dll"))
 if (!(Test-Path "windows/freetype6.dll"))
 {
 	echo "Fetching FreeType2 from NuGet."
-	./nuget.exe install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
-	cp freetype2.redist/bin/win32/zlib1.dll ./windows/zlib1.dll
-	cp freetype2.redist/bin/win32/freetype6.dll ./windows/freetype6.dll
-	rmdir freetype2.redist -Recurse
-}
-
-if (!(Test-Path "windows/zlib1.dll"))
-{
-	echo "Fetching ZLib from NuGet."
-	./nuget.exe install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
-	cp freetype2.redist/bin/win32/zlib1.dll ./windows/zlib1.dll
-	rmdir freetype2.redist -Recurse
+	./nuget.exe install SharpFont.Dependencies -Version 2.5.5.1 -ExcludeVersion
+	cp SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll ./windows/freetype6.dll
+	rmdir SharpFont.Dependencies -Recurse
 }
 
 if (!(Test-Path "windows/soft_oal.dll"))

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -54,7 +54,7 @@ if (!(Test-Path "SharpFont.dll"))
 	cp SharpFont/lib/net20/SharpFont* .
 	cp SharpFont/config/SharpFont.dll.config .
 	rmdir SharpFont -Recurse
-    rmdir SharpFont.Dependencies -Recurse
+	rmdir SharpFont.Dependencies -Recurse
 }
 
 if (!(Test-Path "nunit.framework.dll"))

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -39,10 +39,11 @@ fi
 
 if [ ! -f SharpFont.dll ]; then
 	echo "Fetching SharpFont from nuget"
-	nuget install SharpFont -Version 2.5.0.1 -ExcludeVersion
+	nuget install SharpFont -Version 3.0.1 -ExcludeVersion
 	cp ./SharpFont/lib/net20/SharpFont* .
-	sed '/osx/s@\(dll="\)[^"]*\(" />\)@\1/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib\2@' ./SharpFont/Content/SharpFont.dll.config > SharpFont.dll.config
+	cp ./SharpFont/config/SharpFont.dll.config .
 	rm -rf SharpFont
+    rm -rf SharpFont.Dependencies
 fi
 
 if [ ! -f nunit.framework.dll ]; then

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -42,8 +42,7 @@ if [ ! -f SharpFont.dll ]; then
 	nuget install SharpFont -Version 3.0.1 -ExcludeVersion
 	cp ./SharpFont/lib/net20/SharpFont* .
 	cp ./SharpFont/config/SharpFont.dll.config .
-	rm -rf SharpFont
-    rm -rf SharpFont.Dependencies
+	rm -rf SharpFont SharpFont.Dependencies
 fi
 
 if [ ! -f nunit.framework.dll ]; then


### PR DESCRIPTION
Tested, main menu seems to be rendering fonts just fine.

If you'd prefer the fetch-thirdparty-deps scripts to be organized slightly differently, let me know. I just went with the minimal number of lines I'd have to change.

I'm also using the MSVC10 x86 version of freetype6.dll, if you wanted a different one also let me know.
