### PR TITLE
Fix a crash in UpgradeActorsNear.cs

### DIFF
--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -115,7 +115,8 @@ namespace OpenRA.Mods.Common.Traits
 				var um = produced.TraitOrDefault<UpgradeManager>();
 				if (um != null)
 					foreach (var u in info.Upgrades)
-						um.GrantTimedUpgrade(produced, u, 1);
+						if (um.AcceptsUpgrade(produced, u))
+							um.GrantTimedUpgrade(produced, u, 1);
 			}
 		}
 


### PR DESCRIPTION
Repo case:
Cloak `gahpad` or `nahpad` with `nastlh`.
Build some units.
