### PR TITLE
Fixed D2k trails and deviator explosion color

### DIFF
--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -39,6 +39,8 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly int TrailInterval = 2;
 		[Desc("Delay in ticks until trail animaion is spawned.")]
 		public readonly int TrailDelay = 1;
+		public readonly string TrailPalette = "effect";
+		public readonly bool TrailUsePlayerPalette = false;
 		public readonly int ContrailLength = 0;
 		public readonly Color ContrailColor = Color.White;
 		public readonly bool ContrailUsePlayerColor = false;
@@ -56,6 +58,7 @@ namespace OpenRA.Mods.Common.Effects
 		[Sync] readonly WRange speed;
 
 		ContrailRenderable contrail;
+		string trailPalette;
 
 		[Sync] WPos pos, target;
 		[Sync] int length;
@@ -105,6 +108,10 @@ namespace OpenRA.Mods.Common.Effects
 				contrail = new ContrailRenderable(world, color, info.ContrailLength, info.ContrailDelay, 0);
 			}
 
+			trailPalette = info.TrailPalette;
+			if (info.TrailUsePlayerPalette)
+				trailPalette += args.SourceActor.Owner.InternalName;
+
 			smokeTicks = info.TrailDelay;
 		}
 
@@ -131,7 +138,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.Trail != null && --smokeTicks < 0)
 			{
 				var delayedPos = WPos.LerpQuadratic(args.Source, target, angle, ticks - info.TrailDelay, length);
-				world.AddFrameEndTask(w => w.Add(new Smoke(w, delayedPos, info.Trail)));
+				world.AddFrameEndTask(w => w.Add(new Smoke(w, delayedPos, info.Trail, trailPalette)));
 				smokeTicks = info.TrailInterval;
 			}
 

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -45,6 +45,8 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly string Trail = null;
 		[Desc("Interval in ticks between each spawned Trail animation.")]
 		public readonly int TrailInterval = 2;
+		public readonly string TrailPalette = "effect";
+		public readonly bool TrailUsePlayerPalette = false;
 		public readonly int ContrailLength = 0;
 		public readonly Color ContrailColor = Color.White;
 		public readonly bool ContrailUsePlayerColor = false;
@@ -69,6 +71,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		int ticksToNextSmoke;
 		ContrailRenderable contrail;
+		string trailPalette;
 
 		[Sync] WPos pos;
 		[Sync] int facing;
@@ -114,6 +117,10 @@ namespace OpenRA.Mods.Common.Effects
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
 				contrail = new ContrailRenderable(world, color, info.ContrailLength, info.ContrailDelay, 0);
 			}
+
+			trailPalette = info.TrailPalette;
+			if (info.TrailUsePlayerPalette)
+				trailPalette += args.SourceActor.Owner.InternalName;
 		}
 
 		bool JammedBy(TraitPair<JamsMissiles> tp)
@@ -164,7 +171,7 @@ namespace OpenRA.Mods.Common.Effects
 
 			if (info.Trail != null && --ticksToNextSmoke < 0)
 			{
-				world.AddFrameEndTask(w => w.Add(new Smoke(w, pos - 3 * move / 2, info.Trail)));
+				world.AddFrameEndTask(w => w.Add(new Smoke(w, pos - 3 * move / 2, info.Trail, trailPalette)));
 				ticksToNextSmoke = info.TrailInterval;
 			}
 

--- a/OpenRA.Mods.Common/Effects/Smoke.cs
+++ b/OpenRA.Mods.Common/Effects/Smoke.cs
@@ -20,12 +20,14 @@ namespace OpenRA.Mods.Common.Effects
 		readonly WPos pos;
 		readonly CPos cell;
 		readonly Animation anim;
+		readonly string palette;
 
-		public Smoke(World world, WPos pos, string trail)
+		public Smoke(World world, WPos pos, string trail, string palette)
 		{
 			this.world = world;
 			this.pos = pos;
 			this.cell = world.Map.CellContaining(pos);
+			this.palette = palette;
 
 			anim = new Animation(world, trail);
 			anim.PlayThen("idle",
@@ -39,7 +41,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (world.FogObscures(cell))
 				return SpriteRenderable.None;
 
-			return anim.Render(pos, wr.Palette("effect"));
+			return anim.Render(pos, wr.Palette(palette));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WVec Offset = WVec.Zero;
 		public readonly int Interval = 3;
 		public readonly string Sprite = "smokey";
+		public readonly string Palette = "effect";
 		public readonly DamageState MinDamage = DamageState.Heavy;
 
 		public object Create(ActorInitializer init) { return new SmokeTrailWhenDamaged(init.Self, this); }
@@ -45,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 					var pos = position + body.LocalToWorld(offset);
-					self.World.AddFrameEndTask(w => w.Add(new Smoke(w, pos, info.Sprite)));
+					self.World.AddFrameEndTask(w => w.Add(new Smoke(w, pos, info.Sprite, info.Palette)));
 				}
 
 				ticks = info.Interval;

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -29,6 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sprite sequence name")]
 		public readonly string SmokeType = "smoke_m";
 
+		public readonly string SmokePalette = "effect";
+
 		public readonly string Palette = "terrain";
 
 		public object Create(ActorInitializer init) { return new SmudgeLayer(this); }
@@ -86,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void AddSmudge(CPos loc)
 		{
 			if (Game.CosmeticRandom.Next(0, 100) <= Info.SmokePercentage)
-				world.AddFrameEndTask(w => w.Add(new Smoke(w, world.Map.CenterOfCell(loc), Info.SmokeType)));
+				world.AddFrameEndTask(w => w.Add(new Smoke(w, world.Map.CenterOfCell(loc), Info.SmokeType, Info.SmokePalette)));
 
 			if (!dirty.ContainsKey(loc) && !tiles.ContainsKey(loc))
 			{

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -25,6 +25,9 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Palette to use for explosion effect.")]
 		public readonly string ExplosionPalette = "effect";
 
+		[Desc("Remap explosion effect to player color, if art supports it.")]
+		public readonly bool UsePlayerPalette = false;
+
 		[Desc("Sound to play on impact.")]
 		public readonly string ImpactSound = null;
 
@@ -80,8 +83,12 @@ namespace OpenRA.Mods.Common.Warheads
 			if ((!world.Map.Contains(targetTile)) || (!isValid))
 				return;
 
+			var palette = ExplosionPalette;
+			if (UsePlayerPalette)
+				palette += firedBy.Owner.InternalName;
+
 			if (Explosion != null)
-				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, Explosion, ExplosionPalette)));
+				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, Explosion, palette)));
 
 			if (ImpactSound != null)
 				Sound.Play(ImpactSound, pos);

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -64,11 +64,53 @@ explosion:
 		Start: 3512
 		Length: 23
 		BlendMode: Additive
-		Tick: 60
+		Tick: 80
 	corpse: DATA.R8
 		Start: 430
 		Length: 12
 		Tick: 1600
+
+large_trail: 
+	idle: DATA.R8
+		Start: 3873
+		Length: 4
+		Tick: 80
+		BlendMode: Additive
+
+small_trail:
+	idle: DATA.R8
+		Start: 3735
+		Length: 4
+		Tick: 80
+		BlendMode: Additive
+
+small_trail2:
+	idle: DATA.R8
+		Start: 3540
+		Length: 4
+		Tick: 80
+		BlendMode: Additive
+
+bazooka_trail:
+	idle: DATA.R8
+		Start: 3381
+		Length: 4
+		Tick: 80
+		BlendMode: Additive
+
+bazooka_trail2:
+	idle: DATA.R8
+		Start: 3544
+		Length: 4
+		Tick: 80
+		BlendMode: Additive
+
+deviator_trail:
+	idle: DATA.R8
+		Start: 3535
+		Length: 5
+		Tick: 80
+		BlendMode: Additive
 
 laserfire:
 	idle: DATA.R8

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -29,10 +29,11 @@ Bazooka:
 	Projectile: Missile
 		Speed: 160
 		Arm: 2
-		ContrailLength: 10
 		Inaccuracy: 96
 		Image: RPG
 		RateOfTurn: 5
+		Trail: bazooka_trail
+		TrailInterval: 1
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
@@ -184,6 +185,8 @@ QuadRockets:
 		Inaccuracy: 96
 		Image: RPG
 		RateOfTurn: 10
+		Trail: bazooka_trail2
+		TrailInterval: 1
 		Speed: 256
 		RangeLimit: 40
 	Warhead@1Dam: SpreadDamage
@@ -243,6 +246,8 @@ TowerMissile:
 		Inaccuracy: 384
 		Image: MISSILE2
 		RateOfTurn: 10
+		Trail: large_trail
+		TrailInterval: 1
 		Speed: 256
 		RangeLimit: 50
 		Angle: 110
@@ -348,7 +353,8 @@ DevBullet:
 		Angle: 110
 		Image: MISSILE2
 		RateOfTurn: 5
-		ContrailLength: 5
+		Trail: large_trail
+		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Damage: 60
@@ -378,8 +384,10 @@ NerveGasMissile:
 		Angle: 110
 		Inaccuracy: 1c96
 		Image: MISSILE
-		ContrailLength: 15
-		ContrailUsePlayerColor: True
+		Trail: deviator_trail
+		TrailPalette: player
+		TrailUsePlayerPalette: true
+		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 10
@@ -391,6 +399,8 @@ NerveGasMissile:
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
 		Explosion: deviator
+		ExplosionPalette: player
+		UsePlayerPalette: true
 		ImpactSound: EXPLSML2.WAV
 	Warhead@4OwnerChange: ChangeOwner
 		Range: 1c0


### PR DESCRIPTION
Uses the correct trail animations for D2k missiles.
Removes contrails.
Makes explosion and trail of Deviator weapon player-colored.

Fixes points 1-3 of #7689.

Requires #7639.
