### PR TITLE
Don't require "LockSpawn" to set "Spawn"

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -65,10 +65,11 @@ namespace OpenRA.Server
 				c.Color = c.PreferredColor;
 			if (pr.LockRace)
 				c.Race = pr.Race;
-			if (pr.LockSpawn)
-				c.SpawnPoint = pr.Spawn;
 			if (pr.LockTeam)
 				c.Team = pr.Team;
+
+			// Set the players spawnpoint
+			c.SpawnPoint = pr.Spawn;
 		}
 
 		static void SendData(Socket s, byte[] data)


### PR DESCRIPTION
```
    PlayerReference@Multi0:
        Name: Multi0
        Playable: True
        Race: Random
        Spawn: 1
        Enemies: Creeps
```

didn't work before, until you added  `LockSpawn: true`.
