### PR TITLE
Fix for the EnemyWatcher-Disguise trait interaction

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -69,9 +69,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var actor in self.World.ActorsWithTrait<AnnounceOnSeen>())
 			{
-				// We don't want notifications for allied actors
-				if ((actor.Actor.EffectiveOwner != null && self.Owner.Stances[actor.Actor.EffectiveOwner.Owner] == Stance.Ally)
-				 || self.Owner.Stances[actor.Actor.Owner] == Stance.Ally)
+				// We don't want notifications for allied actors or actors disguised as such
+				if (actor.Actor.AppearsFriendlyTo(self))
 					continue;
 
 				if (actor.Actor.IsDead || !actor.Actor.IsInWorld)

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -45,9 +45,8 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// Hack to disable notifications for neutral actors so some custom maps don't need fixing
-			if (!Info.AnnounceNeutrals &&
-				((self.EffectiveOwner != null && discoverer.Stances[self.EffectiveOwner.Owner] != Stance.Enemy)
-				 || discoverer.Stances[self.Owner] != Stance.Enemy))
+			// At this point it's either neutral or an enemy
+			if (!Info.AnnounceNeutrals && !self.AppearsHostileTo(discoverer.PlayerActor))
 				return;
 
 			// Audio notification


### PR DESCRIPTION
With the newly added to RA `EnemyWatcher` and `AnnounceOnSeen` traits, a bug was exposed with the RA spies, which resulted in a crash inside `EnemyWatcher`:

> [21:42:38] <John86> https://justpaste.it/k2x2
> [21:42:39]  <orabot> Title: Red Alert Mod at Version {DEV_VERSION} Operating System:... - justpaste.it

This was a result of the questionable way the disguise was removed when the spy attacks.
This is likely not a proper fix, but a bandaid for the hack.
I am doing this so we can get back on the road to a playtest sooner, rather than in a month.

EDIT: It turns out this isn't a problem with undisguising, but with EffectiveOwner in general.
