### PR TITLE
Disables WithDeathAnimation for deployed TS units

### DIFF
--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -525,6 +525,7 @@ GATICK:
 		TransformSounds: place2.aud
 		NoTransformSounds:
 	WithMuzzleFlash:
+	-WithDeathAnimation:
 
 GAICBM:
 	Inherits: ^Building
@@ -546,6 +547,7 @@ GAICBM:
 		Facing: 96
 		TransformSounds: place2.aud
 		NoTransformSounds:
+	-WithDeathAnimation:
 
 GADPSA:
 	Inherits: ^Building
@@ -570,6 +572,7 @@ GADPSA:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 6
+	-WithDeathAnimation:
 
 GAARTY:
 	Inherits: ^Building
@@ -613,6 +616,7 @@ GAARTY:
 		TransformSounds: place2.aud
 		NoTransformSounds:
 	WithMuzzleFlash:
+	-WithDeathAnimation:
 
 GASPOT:
 	Inherits: ^Building


### PR DESCRIPTION
Fixes regression from #7687.
Fixes crash when destroying deployed Tick Tank, Arty, Sensor Array or ICBM launcher.
