### PR TITLE
Hide faction for players who randomed in diplomacy and objectives panels

### DIFF
--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -27,6 +27,7 @@ namespace OpenRA
 
 		public bool LockRace = false;
 		public string Race;
+		public string RaceFlagName;
 
 		// ColorRamp naming retained for backward compatibility
 		public bool LockColor = false;

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -46,7 +46,9 @@ namespace OpenRA
 		public Shroud Shroud;
 		public World World { get; private set; }
 
-		static CountryInfo ChooseCountry(World world, string name, bool requireSelectable = true)
+		string selectedCountryName;
+
+		CountryInfo ChooseCountry(World world, string name, bool requireSelectable = true)
 		{
 			var selectableCountries = world.Map.Rules.Actors["world"].Traits
 				.WithInterface<CountryInfo>().Where(c => !requireSelectable || c.Selectable)
@@ -54,6 +56,8 @@ namespace OpenRA
 
 			var selected = selectableCountries.FirstOrDefault(c => c.Race == name)
 				?? selectableCountries.Random(world.SharedRandom);
+
+			selectedCountryName = selected.Name;
 
 			// Don't loop infinite
 			for (var i = 0; i <= 10 && selected.RandomRaceMembers.Any(); i++)
@@ -83,6 +87,8 @@ namespace OpenRA
 				PlayerName = client.Name;
 				botType = client.Bot;
 				Country = ChooseCountry(world, client.Race);
+				pr.Race = selectedCountryName;
+				pr.RaceFlagName = client.Race;
 			}
 			else
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 				else
 				{
-					flag.GetImageName = () => pp.PlayerReference.Race;
+					flag.GetImageName = () => pp.PlayerReference.RaceFlagName;
 					item.Get<LabelWidget>("FACTION").GetText = () => pp.PlayerReference.Race;
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -11,6 +11,7 @@
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -53,9 +54,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				nameLabel.GetColor = () => pp.Color.RGB;
 
 				var flag = item.Get<ImageWidget>("FACTIONFLAG");
-				flag.GetImageName = () => pp.Country.Race;
 				flag.GetImageCollection = () => "flags";
-				item.Get<LabelWidget>("FACTION").GetText = () => pp.Country.Name;
+				if (lp.Stances[pp] == Stance.Ally || lp.WinState != WinState.Undefined)
+				{
+					flag.GetImageName = () => pp.Country.Race;
+					item.Get<LabelWidget>("FACTION").GetText = () => pp.Country.Name;
+				}
+				else
+				{
+					flag.GetImageName = () => pp.PlayerReference.Race;
+					item.Get<LabelWidget>("FACTION").GetText = () => pp.PlayerReference.Race;
+				}
 
 				var team = item.Get<LabelWidget>("TEAM");
 				var teamNumber = (client == null) ? 0 : client.Team;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -466,7 +466,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var flag = template.Get<ImageWidget>("FLAG");
 			flag.GetImageCollection = () => "flags";
 			if (player.World.RenderPlayer != null && player.World.RenderPlayer.Stances[player] != Stance.Ally)
-				flag.GetImageName = () => player.PlayerReference.Race;
+				flag.GetImageName = () => player.PlayerReference.RaceFlagName;
 			else
 				flag.GetImageName = () => player.Country.Race;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -464,8 +464,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void AddPlayerFlagAndName(ScrollItemWidget template, Player player)
 		{
 			var flag = template.Get<ImageWidget>("FLAG");
-			flag.GetImageName = () => player.Country.Race;
 			flag.GetImageCollection = () => "flags";
+			if (player.World.RenderPlayer != null && player.World.RenderPlayer.Stances[player] != Stance.Ally)
+				flag.GetImageName = () => player.PlayerReference.Race;
+			else
+				flag.GetImageName = () => player.Country.Race;
 
 			var playerName = template.Get<LabelWidget>("PLAYER");
 			var client = player.World.LobbyInfo.ClientWithIndex(player.ClientIndex);


### PR DESCRIPTION
As requested in  #7391.
Allies will show up as normal, enemy and neutral players will show up as unknown.
I don't consider that issue closed until the UI gets updated with the players' factions once you discover them, but that's a personal opinion. If people say this is enough, then we can close the issue once this is merged.
