### PR TITLE
Batch shroud cell changes

### DIFF
--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -37,7 +37,7 @@ namespace OpenRA
 
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
-		public bool Equals(CPos other) { return other == this; }
+		public bool Equals(CPos other) { return X == other.X && Y == other.Y; }
 		public override bool Equals(object obj) { return obj is CPos && Equals((CPos)obj); }
 
 		public override string ToString() { return X + "," + Y; }

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -128,8 +128,9 @@ namespace OpenRA.Traits
 
 			foreach (var c in visible)
 			{
-				visibleCount[c]++;
-				explored[c] = true;
+				var uv = c.ToMPos(map);
+				visibleCount[uv]++;
+				explored[uv] = true;
 			}
 
 			if (visibility.ContainsKey(a))
@@ -146,7 +147,7 @@ namespace OpenRA.Traits
 				return;
 
 			foreach (var c in visible)
-				visibleCount[c]--;
+				visibleCount[c.ToMPos(map)]--;
 
 			visibility.Remove(a);
 			Invalidate(visible);

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
@@ -32,6 +33,8 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly World world;
 		readonly WorldRenderer worldRenderer;
 		readonly RadarPings radarPings;
+
+		readonly HashSet<CPos> dirtyShroudCells = new HashSet<CPos>();
 
 		float radarMinimapHeight;
 		int frame;
@@ -130,6 +133,11 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
+		void MarkShroudDirty(IEnumerable<CPos> cellsChanged)
+		{
+			dirtyShroudCells.UnionWith(cellsChanged);
+		}
+
 		public override string GetCursor(int2 pos)
 		{
 			if (world == null || !hasRadar)
@@ -194,6 +202,15 @@ namespace OpenRA.Mods.Common.Widgets
 			if (world == null)
 				return;
 
+			if (renderShroud != null)
+			{
+				foreach (var cell in dirtyShroudCells)
+					UpdateShroudCell(cell);
+				dirtyShroudCells.Clear();
+			}
+
+			radarSheet.CommitData();
+
 			var o = new float2(mapRect.Location.X, mapRect.Location.Y + world.Map.Bounds.Height * previewScale * (1 - radarMinimapHeight) / 2);
 			var s = new float2(mapRect.Size.Width, mapRect.Size.Height * radarMinimapHeight);
 
@@ -255,7 +272,7 @@ namespace OpenRA.Mods.Common.Widgets
 				if (newRenderShroud != renderShroud)
 				{
 					if (renderShroud != null)
-						renderShroud.CellEntryChanged -= UpdateShroudCell;
+						renderShroud.CellsChanged -= MarkShroudDirty;
 
 					if (newRenderShroud != null)
 					{
@@ -264,8 +281,10 @@ namespace OpenRA.Mods.Common.Widgets
 							OpenRA.Graphics.Util.FastCopyIntoSprite(shroudSprite, bitmap);
 
 						// Update the notification binding
-						newRenderShroud.CellEntryChanged += UpdateShroudCell;
+						newRenderShroud.CellsChanged += MarkShroudDirty;
 					}
+
+					dirtyShroudCells.Clear();
 
 					renderShroud = newRenderShroud;
 				}
@@ -299,8 +318,6 @@ namespace OpenRA.Mods.Common.Widgets
 						}
 					}
 				}
-
-				radarSheet.CommitData();
 			}
 
 			var targetFrame = enabled ? AnimationLength : 0;


### PR DESCRIPTION
Significantly improves the perf issue noted in #7669 when you have many moving actors causing a lot of shroud changes.

This change reduces repeated work when actor visibilities overlap and when units move. Moving individual units should be slightly less costly in terms of performance now, and moving large groups of units together should be significantly less costly.

This shouldn't affect any in-game functionality - in particular when testing you should verify the radar and the shroud/fog still act correctly.
