### PR TITLE
Fix TS/RA2 tileset importer and apply correctness fixes to TS temperate.

### DIFF
--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -282,7 +282,10 @@ namespace OpenRA
 
 		public TerrainTileInfo GetTileInfo(TerrainTile r)
 		{
-			var tpl = Templates[r.Type];
+			TerrainTemplateInfo tpl;
+			if (!Templates.TryGetValue(r.Type, out tpl))
+				return null;
+
 			return tpl.Contains(r.Index) ? tpl[r.Index] : null;
 		}
 

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.TS.UtilityCommands
 	{
 		public string Name { get { return "--tileset-import"; } }
 
-		[Desc("FILENAME", "Convert a legacy tileset to the OpenRA format.")]
+		[Desc("FILENAME", "TEMPLATEEXTENSION", "Convert a legacy tileset to the OpenRA format.")]
 		public void Run(ModData modData, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
@@ -30,9 +30,9 @@ namespace OpenRA.Mods.TS.UtilityCommands
 			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
 
 			var file = new IniFile(File.Open(args[1], FileMode.Open));
+			var extension = args[2];
 
 			var templateIndex = 0;
-			var extension = "tem";
 
 			var terrainTypes = new string[]
 			{
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.TS.UtilityCommands
 							Console.WriteLine("\tTemplate@{0}:", templateIndex);
 							Console.WriteLine("\t\tCategory: {0}", sectionCategory);
 							Console.WriteLine("\t\tId: {0}", templateIndex);
-							Console.WriteLine("\t\tImage: {0}{1:D2}", sectionFilename, i);
+							Console.WriteLine("\t\tImage: {0}{1:D2}.{2}", sectionFilename, i, extension);
 
 							var templateWidth = s.ReadUInt32();
 							var templateHeight = s.ReadUInt32();

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -34,19 +34,24 @@ namespace OpenRA.Mods.TS.UtilityCommands
 			var templateIndex = 0;
 			var extension = "tem";
 
-			var terrainTypes = new Dictionary<int, string>()
+			var terrainTypes = new string[]
 			{
-				{ 1, "Clear" }, // Desert sand(?)
-				{ 5, "Road" }, // Paved road
-				{ 6, "Rail" }, // Monorail track
-				{ 7, "Impassable" }, // Building
-				{ 9, "Water" }, // Deep water(?)
-				{ 10, "Water" }, // Shallow water
-				{ 11, "Road" }, // Paved road (again?)
-				{ 12, "DirtRoad" }, // Dirt road
-				{ 13, "Clear" }, // Regular clear terrain
-				{ 14, "Rough" }, // Rough terrain (cracks etc)
-				{ 15, "Cliff" }, // Cliffs
+				"Clear",
+				"Clear", // Note: sometimes "Ice"
+				"Ice",
+				"Ice",
+				"Ice",
+				"Road", // TS defines this as "Tunnel", but we don't need this
+				"Rail",
+				"Impassable", // TS defines this as "Rock", but also uses it for buildings
+				"Impassable",
+				"Water",
+				"Water", // TS defines this as "Beach", but uses it for water...?
+				"Road",
+				"DirtRoad", // TS defines this as "Road", but we may want different speeds
+				"Clear",
+				"Rough",
+				"Cliff" // TS defines this as "Rock"
 			};
 
 			// Loop over template sets
@@ -95,7 +100,7 @@ namespace OpenRA.Mods.TS.UtilityCommands
 								var terrainType = s.ReadUInt8();
 								var rampType = s.ReadUInt8();
 
-								if (!terrainTypes.ContainsKey(terrainType))
+								if (terrainType >= terrainTypes.Length)
 									throw new InvalidDataException("Unknown terrain type {0} in {1}".F(terrainType, templateFilename));
 
 								Console.WriteLine("\t\t\t{0}: {1}", j, terrainTypes[terrainType]);

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -110,8 +110,8 @@ namespace OpenRA.Mods.TS.UtilityCommands
 								if (rampType != 0)
 									Console.WriteLine("\t\t\t\tRampType: {0}", rampType);
 
-								Console.WriteLine("\t\t\t\tMinimapLeftColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
-								Console.WriteLine("\t\t\t\tMinimapRightColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
+								Console.WriteLine("\t\t\t\tLeftColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
+								Console.WriteLine("\t\t\t\tRightColor: {0},{1},{2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
 							}
 						}
 					}

--- a/mods/ts/tilesets/temperat.yaml
+++ b/mods/ts/tilesets/temperat.yaml
@@ -58,7 +58,7 @@ Templates:
 	Template@0:
 		Category: Clear
 		Id: 0
-		Image: Clear01
+		Image: Clear01.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -67,7 +67,7 @@ Templates:
 	Template@1:
 		Category: Misc Buildings
 		Id: 1
-		Image: Bld01
+		Image: Bld01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -76,7 +76,7 @@ Templates:
 	Template@2:
 		Category: Misc Buildings
 		Id: 2
-		Image: Bld02
+		Image: Bld02.tem
 		Size: 2, 2
 		Tiles:
 			0: Rough
@@ -94,7 +94,7 @@ Templates:
 	Template@3:
 		Category: Misc Buildings
 		Id: 3
-		Image: Bld03
+		Image: Bld03.tem
 		Size: 3, 3
 		Tiles:
 			0: Cliff
@@ -127,7 +127,7 @@ Templates:
 	Template@4:
 		Category: Clear
 		Id: 4
-		Image: Snow01
+		Image: Snow01.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -136,7 +136,7 @@ Templates:
 	Template@5:
 		Category: Clear
 		Id: 5
-		Image: Snow02
+		Image: Snow02.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -145,7 +145,7 @@ Templates:
 	Template@6:
 		Category: Clear
 		Id: 6
-		Image: Snow03
+		Image: Snow03.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -154,7 +154,7 @@ Templates:
 	Template@7:
 		Category: Clear
 		Id: 7
-		Image: Snow04
+		Image: Snow04.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -163,7 +163,7 @@ Templates:
 	Template@8:
 		Category: Cliff Pieces
 		Id: 8
-		Image: clif01
+		Image: clif01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -172,7 +172,7 @@ Templates:
 	Template@9:
 		Category: Cliff Pieces
 		Id: 9
-		Image: clif02
+		Image: clif02.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -181,7 +181,7 @@ Templates:
 	Template@10:
 		Category: Ice Flow
 		Id: 10
-		Image: flow01
+		Image: flow01.tem
 		Size: 9, 7
 		Tiles:
 			2: Rough
@@ -295,7 +295,7 @@ Templates:
 	Template@11:
 		Category: House
 		Id: 11
-		Image: house01
+		Image: house01.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -313,7 +313,7 @@ Templates:
 	Template@12:
 		Category: Blank
 		Id: 12
-		Image: blank01
+		Image: blank01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -322,7 +322,7 @@ Templates:
 	Template@40:
 		Category: Ice Ramps
 		Id: 40
-		Image: slope01
+		Image: slope01.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -332,7 +332,7 @@ Templates:
 	Template@41:
 		Category: Ice Ramps
 		Id: 41
-		Image: slope02
+		Image: slope02.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -342,7 +342,7 @@ Templates:
 	Template@42:
 		Category: Ice Ramps
 		Id: 42
-		Image: slope03
+		Image: slope03.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -352,7 +352,7 @@ Templates:
 	Template@43:
 		Category: Ice Ramps
 		Id: 43
-		Image: slope04
+		Image: slope04.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -362,7 +362,7 @@ Templates:
 	Template@44:
 		Category: Ice Ramps
 		Id: 44
-		Image: slope05
+		Image: slope05.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -372,7 +372,7 @@ Templates:
 	Template@45:
 		Category: Ice Ramps
 		Id: 45
-		Image: slope06
+		Image: slope06.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -382,7 +382,7 @@ Templates:
 	Template@46:
 		Category: Ice Ramps
 		Id: 46
-		Image: slope07
+		Image: slope07.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -392,7 +392,7 @@ Templates:
 	Template@47:
 		Category: Ice Ramps
 		Id: 47
-		Image: slope08
+		Image: slope08.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -402,7 +402,7 @@ Templates:
 	Template@48:
 		Category: Ice Ramps
 		Id: 48
-		Image: slope09
+		Image: slope09.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -412,7 +412,7 @@ Templates:
 	Template@49:
 		Category: Ice Ramps
 		Id: 49
-		Image: slope10
+		Image: slope10.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -422,7 +422,7 @@ Templates:
 	Template@50:
 		Category: Ice Ramps
 		Id: 50
-		Image: slope11
+		Image: slope11.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -432,7 +432,7 @@ Templates:
 	Template@51:
 		Category: Ice Ramps
 		Id: 51
-		Image: slope12
+		Image: slope12.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -442,7 +442,7 @@ Templates:
 	Template@52:
 		Category: Ice Ramps
 		Id: 52
-		Image: slope13
+		Image: slope13.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -452,7 +452,7 @@ Templates:
 	Template@53:
 		Category: Ice Ramps
 		Id: 53
-		Image: slope14
+		Image: slope14.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -462,7 +462,7 @@ Templates:
 	Template@54:
 		Category: Ice Ramps
 		Id: 54
-		Image: slope15
+		Image: slope15.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -472,7 +472,7 @@ Templates:
 	Template@55:
 		Category: Ice Ramps
 		Id: 55
-		Image: slope16
+		Image: slope16.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -482,7 +482,7 @@ Templates:
 	Template@56:
 		Category: Ice Ramps
 		Id: 56
-		Image: slope17
+		Image: slope17.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -492,7 +492,7 @@ Templates:
 	Template@57:
 		Category: Ice Ramps
 		Id: 57
-		Image: slope18
+		Image: slope18.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -502,7 +502,7 @@ Templates:
 	Template@58:
 		Category: Ice Ramps
 		Id: 58
-		Image: slope19
+		Image: slope19.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -512,7 +512,7 @@ Templates:
 	Template@59:
 		Category: Ice Ramps
 		Id: 59
-		Image: slope20
+		Image: slope20.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -522,7 +522,7 @@ Templates:
 	Template@60:
 		Category: Cliff Set
 		Id: 60
-		Image: Cliff01
+		Image: Cliff01.tem
 		Size: 2, 3
 		Tiles:
 			0: Cliff
@@ -542,7 +542,7 @@ Templates:
 	Template@61:
 		Category: Cliff Set
 		Id: 61
-		Image: Cliff02
+		Image: Cliff02.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -555,7 +555,7 @@ Templates:
 	Template@62:
 		Category: Cliff Set
 		Id: 62
-		Image: Cliff03
+		Image: Cliff03.tem
 		Size: 2, 3
 		Tiles:
 			0: Cliff
@@ -575,7 +575,7 @@ Templates:
 	Template@63:
 		Category: Cliff Set
 		Id: 63
-		Image: Cliff04
+		Image: Cliff04.tem
 		Size: 2, 3
 		Tiles:
 			0: Cliff
@@ -595,7 +595,7 @@ Templates:
 	Template@64:
 		Category: Cliff Set
 		Id: 64
-		Image: Cliff05
+		Image: Cliff05.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -615,7 +615,7 @@ Templates:
 	Template@65:
 		Category: Cliff Set
 		Id: 65
-		Image: Cliff06
+		Image: Cliff06.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -635,7 +635,7 @@ Templates:
 	Template@66:
 		Category: Cliff Set
 		Id: 66
-		Image: Cliff07
+		Image: Cliff07.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -655,7 +655,7 @@ Templates:
 	Template@67:
 		Category: Cliff Set
 		Id: 67
-		Image: Cliff08
+		Image: Cliff08.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -668,7 +668,7 @@ Templates:
 	Template@68:
 		Category: Cliff Set
 		Id: 68
-		Image: Cliff09
+		Image: Cliff09.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -684,7 +684,7 @@ Templates:
 	Template@69:
 		Category: Cliff Set
 		Id: 69
-		Image: Cliff10
+		Image: Cliff10.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -700,7 +700,7 @@ Templates:
 	Template@70:
 		Category: Cliff Set
 		Id: 70
-		Image: Cliff11
+		Image: Cliff11.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -716,7 +716,7 @@ Templates:
 	Template@71:
 		Category: Cliff Set
 		Id: 71
-		Image: Cliff12
+		Image: Cliff12.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -725,7 +725,7 @@ Templates:
 	Template@72:
 		Category: Cliff Set
 		Id: 72
-		Image: Cliff13
+		Image: Cliff13.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -734,7 +734,7 @@ Templates:
 	Template@73:
 		Category: Cliff Set
 		Id: 73
-		Image: Cliff14
+		Image: Cliff14.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -743,7 +743,7 @@ Templates:
 	Template@74:
 		Category: Cliff Set
 		Id: 74
-		Image: Cliff15
+		Image: Cliff15.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -763,7 +763,7 @@ Templates:
 	Template@75:
 		Category: Cliff Set
 		Id: 75
-		Image: Cliff16
+		Image: Cliff16.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -783,7 +783,7 @@ Templates:
 	Template@76:
 		Category: Cliff Set
 		Id: 76
-		Image: Cliff17
+		Image: Cliff17.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -803,7 +803,7 @@ Templates:
 	Template@77:
 		Category: Cliff Set
 		Id: 77
-		Image: Cliff18
+		Image: Cliff18.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -816,7 +816,7 @@ Templates:
 	Template@78:
 		Category: Cliff Set
 		Id: 78
-		Image: Cliff19
+		Image: Cliff19.tem
 		Size: 3, 2
 		Tiles:
 			0: Cliff
@@ -836,7 +836,7 @@ Templates:
 	Template@79:
 		Category: Cliff Set
 		Id: 79
-		Image: Cliff20
+		Image: Cliff20.tem
 		Size: 3, 2
 		Tiles:
 			0: Cliff
@@ -856,7 +856,7 @@ Templates:
 	Template@80:
 		Category: Cliff Set
 		Id: 80
-		Image: Cliff21
+		Image: Cliff21.tem
 		Size: 3, 2
 		Tiles:
 			0: Cliff
@@ -876,7 +876,7 @@ Templates:
 	Template@81:
 		Category: Cliff Set
 		Id: 81
-		Image: Cliff22
+		Image: Cliff22.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -889,7 +889,7 @@ Templates:
 	Template@82:
 		Category: Cliff Set
 		Id: 82
-		Image: Cliff23
+		Image: Cliff23.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -903,7 +903,7 @@ Templates:
 	Template@83:
 		Category: Cliff Set
 		Id: 83
-		Image: Cliff24
+		Image: Cliff24.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -917,7 +917,7 @@ Templates:
 	Template@84:
 		Category: Cliff Set
 		Id: 84
-		Image: Cliff25
+		Image: Cliff25.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -931,7 +931,7 @@ Templates:
 	Template@85:
 		Category: Cliff Set
 		Id: 85
-		Image: Cliff26
+		Image: Cliff26.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -941,7 +941,7 @@ Templates:
 	Template@86:
 		Category: Cliff Set
 		Id: 86
-		Image: Cliff27
+		Image: Cliff27.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -959,7 +959,7 @@ Templates:
 	Template@87:
 		Category: Cliff Set
 		Id: 87
-		Image: Cliff28
+		Image: Cliff28.tem
 		Size: 2, 2
 		Tiles:
 			1: Cliff
@@ -977,7 +977,7 @@ Templates:
 	Template@88:
 		Category: Cliff Set
 		Id: 88
-		Image: Cliff29
+		Image: Cliff29.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -987,7 +987,7 @@ Templates:
 	Template@89:
 		Category: Cliff Set
 		Id: 89
-		Image: Cliff30
+		Image: Cliff30.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -997,7 +997,7 @@ Templates:
 	Template@90:
 		Category: Cliff Set
 		Id: 90
-		Image: Cliff31
+		Image: Cliff31.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -1015,7 +1015,7 @@ Templates:
 	Template@91:
 		Category: Cliff Set
 		Id: 91
-		Image: Cliff32
+		Image: Cliff32.tem
 		Size: 2, 2
 		Tiles:
 			1: Cliff
@@ -1033,7 +1033,7 @@ Templates:
 	Template@92:
 		Category: Cliff Set
 		Id: 92
-		Image: Cliff33
+		Image: Cliff33.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -1043,7 +1043,7 @@ Templates:
 	Template@93:
 		Category: Cliff Set
 		Id: 93
-		Image: Cliff34
+		Image: Cliff34.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -1053,7 +1053,7 @@ Templates:
 	Template@94:
 		Category: Cliff Set
 		Id: 94
-		Image: Cliff35
+		Image: Cliff35.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -1067,7 +1067,7 @@ Templates:
 	Template@95:
 		Category: Cliff Set
 		Id: 95
-		Image: Cliff36
+		Image: Cliff36.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -1081,7 +1081,7 @@ Templates:
 	Template@96:
 		Category: Cliff Set
 		Id: 96
-		Image: Cliff37
+		Image: Cliff37.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -1095,7 +1095,7 @@ Templates:
 	Template@97:
 		Category: Cliff Set
 		Id: 97
-		Image: Cliff38
+		Image: Cliff38.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -1105,7 +1105,7 @@ Templates:
 	Template@98:
 		Category: Cliff Set
 		Id: 98
-		Image: Cliff39
+		Image: Cliff39.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -1115,7 +1115,7 @@ Templates:
 	Template@99:
 		Category: Cliff Set
 		Id: 99
-		Image: Cliff40
+		Image: Cliff40.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -1125,7 +1125,7 @@ Templates:
 	Template@100:
 		Category: Civilian Buildings
 		Id: 100
-		Image: Civ01
+		Image: Civ01.tem
 		Size: 3, 3
 		Tiles:
 			0: Impassable
@@ -1158,7 +1158,7 @@ Templates:
 	Template@101:
 		Category: Civilian Buildings
 		Id: 101
-		Image: Civ02
+		Image: Civ02.tem
 		Size: 1, 2
 		Tiles:
 			0: Impassable
@@ -1170,7 +1170,7 @@ Templates:
 	Template@102:
 		Category: Civilian Buildings
 		Id: 102
-		Image: Civ03
+		Image: Civ03.tem
 		Size: 1, 1
 		Tiles:
 			0: Impassable
@@ -1179,7 +1179,7 @@ Templates:
 	Template@103:
 		Category: Civilian Buildings
 		Id: 103
-		Image: Civ04
+		Image: Civ04.tem
 		Size: 1, 2
 		Tiles:
 			0: Impassable
@@ -1191,7 +1191,7 @@ Templates:
 	Template@104:
 		Category: Civilian Buildings
 		Id: 104
-		Image: Civ05
+		Image: Civ05.tem
 		Size: 2, 2
 		Tiles:
 			1: Impassable
@@ -1206,7 +1206,7 @@ Templates:
 	Template@105:
 		Category: Civilian Buildings
 		Id: 105
-		Image: Civ06
+		Image: Civ06.tem
 		Size: 3, 3
 		Tiles:
 			1: Impassable
@@ -1230,7 +1230,7 @@ Templates:
 	Template@106:
 		Category: Civilian Buildings
 		Id: 106
-		Image: Civ07
+		Image: Civ07.tem
 		Size: 1, 1
 		Tiles:
 			0: Impassable
@@ -1239,7 +1239,7 @@ Templates:
 	Template@107:
 		Category: Civilian Buildings
 		Id: 107
-		Image: Civ08
+		Image: Civ08.tem
 		Size: 1, 2
 		Tiles:
 			0: Impassable
@@ -1251,7 +1251,7 @@ Templates:
 	Template@108:
 		Category: Shore Pieces
 		Id: 108
-		Image: Shore01
+		Image: Shore01.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1269,7 +1269,7 @@ Templates:
 	Template@109:
 		Category: Shore Pieces
 		Id: 109
-		Image: Shore02
+		Image: Shore02.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1287,7 +1287,7 @@ Templates:
 	Template@110:
 		Category: Shore Pieces
 		Id: 110
-		Image: Shore03
+		Image: Shore03.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1305,7 +1305,7 @@ Templates:
 	Template@111:
 		Category: Shore Pieces
 		Id: 111
-		Image: Shore04
+		Image: Shore04.tem
 		Size: 1, 2
 		Tiles:
 			0: Water
@@ -1317,7 +1317,7 @@ Templates:
 	Template@112:
 		Category: Shore Pieces
 		Id: 112
-		Image: Shore05
+		Image: Shore05.tem
 		Size: 2, 3
 		Tiles:
 			0: Water
@@ -1341,7 +1341,7 @@ Templates:
 	Template@113:
 		Category: Shore Pieces
 		Id: 113
-		Image: Shore06
+		Image: Shore06.tem
 		Size: 2, 3
 		Tiles:
 			0: Water
@@ -1365,7 +1365,7 @@ Templates:
 	Template@114:
 		Category: Shore Pieces
 		Id: 114
-		Image: Shore07
+		Image: Shore07.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1383,7 +1383,7 @@ Templates:
 	Template@115:
 		Category: Shore Pieces
 		Id: 115
-		Image: Shore08
+		Image: Shore08.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1401,7 +1401,7 @@ Templates:
 	Template@116:
 		Category: Shore Pieces
 		Id: 116
-		Image: Shore09
+		Image: Shore09.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1419,7 +1419,7 @@ Templates:
 	Template@117:
 		Category: Shore Pieces
 		Id: 117
-		Image: Shore10
+		Image: Shore10.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1437,7 +1437,7 @@ Templates:
 	Template@118:
 		Category: Shore Pieces
 		Id: 118
-		Image: Shore11
+		Image: Shore11.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1455,7 +1455,7 @@ Templates:
 	Template@119:
 		Category: Shore Pieces
 		Id: 119
-		Image: Shore12
+		Image: Shore12.tem
 		Size: 2, 1
 		Tiles:
 			0: Water
@@ -1467,7 +1467,7 @@ Templates:
 	Template@120:
 		Category: Shore Pieces
 		Id: 120
-		Image: Shore13
+		Image: Shore13.tem
 		Size: 3, 2
 		Tiles:
 			0: Clear
@@ -1491,7 +1491,7 @@ Templates:
 	Template@121:
 		Category: Shore Pieces
 		Id: 121
-		Image: Shore14
+		Image: Shore14.tem
 		Size: 3, 2
 		Tiles:
 			0: Water
@@ -1515,7 +1515,7 @@ Templates:
 	Template@122:
 		Category: Shore Pieces
 		Id: 122
-		Image: Shore15
+		Image: Shore15.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1533,7 +1533,7 @@ Templates:
 	Template@123:
 		Category: Shore Pieces
 		Id: 123
-		Image: Shore16
+		Image: Shore16.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1551,7 +1551,7 @@ Templates:
 	Template@124:
 		Category: Shore Pieces
 		Id: 124
-		Image: Shore17
+		Image: Shore17.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1569,7 +1569,7 @@ Templates:
 	Template@125:
 		Category: Shore Pieces
 		Id: 125
-		Image: Shore18
+		Image: Shore18.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1587,7 +1587,7 @@ Templates:
 	Template@126:
 		Category: Shore Pieces
 		Id: 126
-		Image: Shore19
+		Image: Shore19.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1605,7 +1605,7 @@ Templates:
 	Template@127:
 		Category: Shore Pieces
 		Id: 127
-		Image: Shore20
+		Image: Shore20.tem
 		Size: 1, 2
 		Tiles:
 			0: Water
@@ -1617,7 +1617,7 @@ Templates:
 	Template@128:
 		Category: Shore Pieces
 		Id: 128
-		Image: Shore21
+		Image: Shore21.tem
 		Size: 2, 3
 		Tiles:
 			0: Water
@@ -1641,7 +1641,7 @@ Templates:
 	Template@129:
 		Category: Shore Pieces
 		Id: 129
-		Image: Shore22
+		Image: Shore22.tem
 		Size: 2, 3
 		Tiles:
 			0: Water
@@ -1665,7 +1665,7 @@ Templates:
 	Template@130:
 		Category: Shore Pieces
 		Id: 130
-		Image: Shore23
+		Image: Shore23.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1683,7 +1683,7 @@ Templates:
 	Template@131:
 		Category: Shore Pieces
 		Id: 131
-		Image: Shore24
+		Image: Shore24.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1701,7 +1701,7 @@ Templates:
 	Template@132:
 		Category: Shore Pieces
 		Id: 132
-		Image: Shore25
+		Image: Shore25.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1719,7 +1719,7 @@ Templates:
 	Template@133:
 		Category: Shore Pieces
 		Id: 133
-		Image: Shore26
+		Image: Shore26.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1737,7 +1737,7 @@ Templates:
 	Template@134:
 		Category: Shore Pieces
 		Id: 134
-		Image: Shore27
+		Image: Shore27.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1755,7 +1755,7 @@ Templates:
 	Template@135:
 		Category: Shore Pieces
 		Id: 135
-		Image: Shore28
+		Image: Shore28.tem
 		Size: 2, 1
 		Tiles:
 			0: Water
@@ -1767,7 +1767,7 @@ Templates:
 	Template@136:
 		Category: Shore Pieces
 		Id: 136
-		Image: Shore29
+		Image: Shore29.tem
 		Size: 3, 2
 		Tiles:
 			0: Water
@@ -1791,7 +1791,7 @@ Templates:
 	Template@137:
 		Category: Shore Pieces
 		Id: 137
-		Image: Shore30
+		Image: Shore30.tem
 		Size: 3, 2
 		Tiles:
 			0: Water
@@ -1815,7 +1815,7 @@ Templates:
 	Template@138:
 		Category: Shore Pieces
 		Id: 138
-		Image: Shore31
+		Image: Shore31.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1833,7 +1833,7 @@ Templates:
 	Template@139:
 		Category: Shore Pieces
 		Id: 139
-		Image: Shore32
+		Image: Shore32.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1851,7 +1851,7 @@ Templates:
 	Template@140:
 		Category: Shore Pieces
 		Id: 140
-		Image: Shore33
+		Image: Shore33.tem
 		Size: 2, 2
 		Tiles:
 			0: Clear
@@ -1869,7 +1869,7 @@ Templates:
 	Template@141:
 		Category: Shore Pieces
 		Id: 141
-		Image: Shore34
+		Image: Shore34.tem
 		Size: 2, 2
 		Tiles:
 			0: Clear
@@ -1887,7 +1887,7 @@ Templates:
 	Template@142:
 		Category: Shore Pieces
 		Id: 142
-		Image: Shore35
+		Image: Shore35.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1905,7 +1905,7 @@ Templates:
 	Template@143:
 		Category: Shore Pieces
 		Id: 143
-		Image: Shore36
+		Image: Shore36.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1923,7 +1923,7 @@ Templates:
 	Template@144:
 		Category: Shore Pieces
 		Id: 144
-		Image: Shore37
+		Image: Shore37.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1941,7 +1941,7 @@ Templates:
 	Template@145:
 		Category: Shore Pieces
 		Id: 145
-		Image: Shore38
+		Image: Shore38.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1959,7 +1959,7 @@ Templates:
 	Template@146:
 		Category: Shore Pieces
 		Id: 146
-		Image: Shore39
+		Image: Shore39.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1977,7 +1977,7 @@ Templates:
 	Template@147:
 		Category: Shore Pieces
 		Id: 147
-		Image: Shore40
+		Image: Shore40.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -1995,7 +1995,7 @@ Templates:
 	Template@148:
 		Category: Shore Pieces
 		Id: 148
-		Image: Shore41
+		Image: Shore41.tem
 		Size: 6, 4
 		Tiles:
 			1: Clear
@@ -2064,7 +2064,7 @@ Templates:
 	Template@149:
 		Category: Shore Pieces
 		Id: 149
-		Image: Shore42
+		Image: Shore42.tem
 		Size: 9, 5
 		Tiles:
 			2: Water
@@ -2160,7 +2160,7 @@ Templates:
 	Template@150:
 		Category: Rough LAT tile
 		Id: 150
-		Image: Ruff01
+		Image: Ruff01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2169,7 +2169,7 @@ Templates:
 	Template@151:
 		Category: Clear/Rough LAT
 		Id: 151
-		Image: clat01
+		Image: clat01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2178,7 +2178,7 @@ Templates:
 	Template@152:
 		Category: Clear/Rough LAT
 		Id: 152
-		Image: clat02
+		Image: clat02.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2187,7 +2187,7 @@ Templates:
 	Template@153:
 		Category: Clear/Rough LAT
 		Id: 153
-		Image: clat03
+		Image: clat03.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2196,7 +2196,7 @@ Templates:
 	Template@154:
 		Category: Clear/Rough LAT
 		Id: 154
-		Image: clat04
+		Image: clat04.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2205,7 +2205,7 @@ Templates:
 	Template@155:
 		Category: Clear/Rough LAT
 		Id: 155
-		Image: clat05
+		Image: clat05.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2214,7 +2214,7 @@ Templates:
 	Template@156:
 		Category: Clear/Rough LAT
 		Id: 156
-		Image: clat06
+		Image: clat06.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2223,7 +2223,7 @@ Templates:
 	Template@157:
 		Category: Clear/Rough LAT
 		Id: 157
-		Image: clat07
+		Image: clat07.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2232,7 +2232,7 @@ Templates:
 	Template@158:
 		Category: Clear/Rough LAT
 		Id: 158
-		Image: clat08
+		Image: clat08.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2241,7 +2241,7 @@ Templates:
 	Template@159:
 		Category: Clear/Rough LAT
 		Id: 159
-		Image: clat09
+		Image: clat09.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2250,7 +2250,7 @@ Templates:
 	Template@160:
 		Category: Clear/Rough LAT
 		Id: 160
-		Image: clat10
+		Image: clat10.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2259,7 +2259,7 @@ Templates:
 	Template@161:
 		Category: Clear/Rough LAT
 		Id: 161
-		Image: clat11
+		Image: clat11.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2268,7 +2268,7 @@ Templates:
 	Template@162:
 		Category: Clear/Rough LAT
 		Id: 162
-		Image: clat12
+		Image: clat12.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2277,7 +2277,7 @@ Templates:
 	Template@163:
 		Category: Clear/Rough LAT
 		Id: 163
-		Image: clat13
+		Image: clat13.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2286,7 +2286,7 @@ Templates:
 	Template@164:
 		Category: Clear/Rough LAT
 		Id: 164
-		Image: clat14
+		Image: clat14.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2295,7 +2295,7 @@ Templates:
 	Template@165:
 		Category: Clear/Rough LAT
 		Id: 165
-		Image: clat15
+		Image: clat15.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2304,7 +2304,7 @@ Templates:
 	Template@166:
 		Category: Clear/Rough LAT
 		Id: 166
-		Image: clat16
+		Image: clat16.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -2313,7 +2313,7 @@ Templates:
 	Template@167:
 		Category: Cliff/Water pieces
 		Id: 167
-		Image: WCliff01
+		Image: WCliff01.tem
 		Size: 2, 3
 		Tiles:
 			0: Cliff
@@ -2333,7 +2333,7 @@ Templates:
 	Template@168:
 		Category: Cliff/Water pieces
 		Id: 168
-		Image: WCliff02
+		Image: WCliff02.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -2346,7 +2346,7 @@ Templates:
 	Template@169:
 		Category: Cliff/Water pieces
 		Id: 169
-		Image: WCliff03
+		Image: WCliff03.tem
 		Size: 2, 3
 		Tiles:
 			0: Cliff
@@ -2366,7 +2366,7 @@ Templates:
 	Template@170:
 		Category: Cliff/Water pieces
 		Id: 170
-		Image: WCliff04
+		Image: WCliff04.tem
 		Size: 2, 3
 		Tiles:
 			0: Cliff
@@ -2386,7 +2386,7 @@ Templates:
 	Template@171:
 		Category: Cliff/Water pieces
 		Id: 171
-		Image: WCliff05
+		Image: WCliff05.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2406,7 +2406,7 @@ Templates:
 	Template@172:
 		Category: Cliff/Water pieces
 		Id: 172
-		Image: WCliff06
+		Image: WCliff06.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2426,7 +2426,7 @@ Templates:
 	Template@173:
 		Category: Cliff/Water pieces
 		Id: 173
-		Image: WCliff07
+		Image: WCliff07.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2446,7 +2446,7 @@ Templates:
 	Template@174:
 		Category: Cliff/Water pieces
 		Id: 174
-		Image: WCliff08
+		Image: WCliff08.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -2459,7 +2459,7 @@ Templates:
 	Template@175:
 		Category: Cliff/Water pieces
 		Id: 175
-		Image: WCliff09
+		Image: WCliff09.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2475,7 +2475,7 @@ Templates:
 	Template@176:
 		Category: Cliff/Water pieces
 		Id: 176
-		Image: WCliff10
+		Image: WCliff10.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2494,7 +2494,7 @@ Templates:
 	Template@177:
 		Category: Cliff/Water pieces
 		Id: 177
-		Image: WCliff11
+		Image: WCliff11.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2510,7 +2510,7 @@ Templates:
 	Template@178:
 		Category: Cliff/Water pieces
 		Id: 178
-		Image: WCliff12
+		Image: WCliff12.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -2519,7 +2519,7 @@ Templates:
 	Template@179:
 		Category: Cliff/Water pieces
 		Id: 179
-		Image: WCliff13
+		Image: WCliff13.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -2528,7 +2528,7 @@ Templates:
 	Template@180:
 		Category: Cliff/Water pieces
 		Id: 180
-		Image: WCliff14
+		Image: WCliff14.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -2537,7 +2537,7 @@ Templates:
 	Template@181:
 		Category: Cliff/Water pieces
 		Id: 181
-		Image: WCliff15
+		Image: WCliff15.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2557,7 +2557,7 @@ Templates:
 	Template@182:
 		Category: Cliff/Water pieces
 		Id: 182
-		Image: WCliff16
+		Image: WCliff16.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2577,7 +2577,7 @@ Templates:
 	Template@183:
 		Category: Cliff/Water pieces
 		Id: 183
-		Image: WCliff17
+		Image: WCliff17.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -2597,7 +2597,7 @@ Templates:
 	Template@184:
 		Category: Cliff/Water pieces
 		Id: 184
-		Image: WCliff18
+		Image: WCliff18.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -2610,7 +2610,7 @@ Templates:
 	Template@185:
 		Category: Cliff/Water pieces
 		Id: 185
-		Image: WCliff19
+		Image: WCliff19.tem
 		Size: 3, 2
 		Tiles:
 			0: Cliff
@@ -2630,7 +2630,7 @@ Templates:
 	Template@186:
 		Category: Cliff/Water pieces
 		Id: 186
-		Image: WCliff20
+		Image: WCliff20.tem
 		Size: 3, 2
 		Tiles:
 			0: Cliff
@@ -2650,7 +2650,7 @@ Templates:
 	Template@187:
 		Category: Cliff/Water pieces
 		Id: 187
-		Image: WCliff21
+		Image: WCliff21.tem
 		Size: 3, 2
 		Tiles:
 			0: Cliff
@@ -2670,7 +2670,7 @@ Templates:
 	Template@188:
 		Category: Cliff/Water pieces
 		Id: 188
-		Image: WCliff22
+		Image: WCliff22.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -2683,7 +2683,7 @@ Templates:
 	Template@189:
 		Category: Cliff/Water pieces
 		Id: 189
-		Image: WCliff23
+		Image: WCliff23.tem
 		Size: 2, 3
 		Tiles:
 			0: Cliff
@@ -2706,7 +2706,7 @@ Templates:
 	Template@190:
 		Category: Cliff/Water pieces
 		Id: 190
-		Image: WCliff24
+		Image: WCliff24.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -2718,7 +2718,7 @@ Templates:
 	Template@191:
 		Category: Cliff/Water pieces
 		Id: 191
-		Image: WCliff25
+		Image: WCliff25.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -2730,7 +2730,7 @@ Templates:
 	Template@192:
 		Category: Cliff/Water pieces
 		Id: 192
-		Image: WCliff26
+		Image: WCliff26.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -2742,7 +2742,7 @@ Templates:
 	Template@193:
 		Category: Cliff/Water pieces
 		Id: 193
-		Image: WCliff27
+		Image: WCliff27.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -2754,7 +2754,7 @@ Templates:
 	Template@194:
 		Category: Cliff/Water pieces
 		Id: 194
-		Image: WCliff28
+		Image: WCliff28.tem
 		Size: 3, 2
 		Tiles:
 			0: Cliff
@@ -2777,7 +2777,7 @@ Templates:
 	Template@195:
 		Category: Bendy Dirt Roads
 		Id: 195
-		Image: Droadc01
+		Image: Droadc01.tem
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
@@ -2798,7 +2798,7 @@ Templates:
 	Template@196:
 		Category: Bendy Dirt Roads
 		Id: 196
-		Image: Droadc02
+		Image: Droadc02.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -2816,7 +2816,7 @@ Templates:
 	Template@197:
 		Category: Bendy Dirt Roads
 		Id: 197
-		Image: Droadc03
+		Image: Droadc03.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -2834,7 +2834,7 @@ Templates:
 	Template@198:
 		Category: Bendy Dirt Roads
 		Id: 198
-		Image: Droadc04
+		Image: Droadc04.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -2849,7 +2849,7 @@ Templates:
 	Template@199:
 		Category: Bendy Dirt Roads
 		Id: 199
-		Image: Droadc05
+		Image: Droadc05.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -2867,7 +2867,7 @@ Templates:
 	Template@200:
 		Category: Bendy Dirt Roads
 		Id: 200
-		Image: Droadc06
+		Image: Droadc06.tem
 		Size: 3, 2
 		Tiles:
 			1: DirtRoad
@@ -2888,7 +2888,7 @@ Templates:
 	Template@201:
 		Category: Bendy Dirt Roads
 		Id: 201
-		Image: Droadc07
+		Image: Droadc07.tem
 		Size: 2, 3
 		Tiles:
 			0: DirtRoad
@@ -2909,7 +2909,7 @@ Templates:
 	Template@202:
 		Category: Bendy Dirt Roads
 		Id: 202
-		Image: Droadc08
+		Image: Droadc08.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -2927,7 +2927,7 @@ Templates:
 	Template@203:
 		Category: Bendy Dirt Roads
 		Id: 203
-		Image: Droadc09
+		Image: Droadc09.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -2945,7 +2945,7 @@ Templates:
 	Template@204:
 		Category: Bendy Dirt Roads
 		Id: 204
-		Image: Droadc10
+		Image: Droadc10.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -2963,7 +2963,7 @@ Templates:
 	Template@205:
 		Category: Bendy Dirt Roads
 		Id: 205
-		Image: Droadc11
+		Image: Droadc11.tem
 		Size: 3, 2
 		Tiles:
 			1: DirtRoad
@@ -2984,7 +2984,7 @@ Templates:
 	Template@206:
 		Category: Bendy Dirt Roads
 		Id: 206
-		Image: Droadc12
+		Image: Droadc12.tem
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
@@ -3005,7 +3005,7 @@ Templates:
 	Template@207:
 		Category: Bendy Dirt Roads
 		Id: 207
-		Image: Droadc13
+		Image: Droadc13.tem
 		Size: 2, 3
 		Tiles:
 			0: DirtRoad
@@ -3029,7 +3029,7 @@ Templates:
 	Template@208:
 		Category: Bendy Dirt Roads
 		Id: 208
-		Image: Droadc14
+		Image: Droadc14.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3047,7 +3047,7 @@ Templates:
 	Template@209:
 		Category: Bendy Dirt Roads
 		Id: 209
-		Image: Droadc15
+		Image: Droadc15.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3062,7 +3062,7 @@ Templates:
 	Template@210:
 		Category: Bendy Dirt Roads
 		Id: 210
-		Image: Droadc16
+		Image: Droadc16.tem
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
@@ -3077,7 +3077,7 @@ Templates:
 	Template@211:
 		Category: Bendy Dirt Roads
 		Id: 211
-		Image: Droadc17
+		Image: Droadc17.tem
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
@@ -3101,7 +3101,7 @@ Templates:
 	Template@212:
 		Category: Bendy Dirt Roads
 		Id: 212
-		Image: Droadc18
+		Image: Droadc18.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3116,7 +3116,7 @@ Templates:
 	Template@213:
 		Category: Bendy Dirt Roads
 		Id: 213
-		Image: Droadc19
+		Image: Droadc19.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3134,7 +3134,7 @@ Templates:
 	Template@214:
 		Category: Bendy Dirt Roads
 		Id: 214
-		Image: Droadc20
+		Image: Droadc20.tem
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
@@ -3155,7 +3155,7 @@ Templates:
 	Template@215:
 		Category: Bendy Dirt Roads
 		Id: 215
-		Image: Droadc21
+		Image: Droadc21.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3173,7 +3173,7 @@ Templates:
 	Template@216:
 		Category: Bendy Dirt Roads
 		Id: 216
-		Image: Droadc22
+		Image: Droadc22.tem
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
@@ -3188,7 +3188,7 @@ Templates:
 	Template@217:
 		Category: Bendy Dirt Roads
 		Id: 217
-		Image: Droadc23
+		Image: Droadc23.tem
 		Size: 2, 3
 		Tiles:
 			1: DirtRoad
@@ -3206,7 +3206,7 @@ Templates:
 	Template@218:
 		Category: Bendy Dirt Roads
 		Id: 218
-		Image: Droadc24
+		Image: Droadc24.tem
 		Size: 2, 3
 		Tiles:
 			1: DirtRoad
@@ -3227,7 +3227,7 @@ Templates:
 	Template@219:
 		Category: Dirt Road Junctions
 		Id: 219
-		Image: Droadj01
+		Image: Droadj01.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3245,7 +3245,7 @@ Templates:
 	Template@220:
 		Category: Dirt Road Junctions
 		Id: 220
-		Image: Droadj02
+		Image: Droadj02.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3263,7 +3263,7 @@ Templates:
 	Template@221:
 		Category: Dirt Road Junctions
 		Id: 221
-		Image: Droadj03
+		Image: Droadj03.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3281,7 +3281,7 @@ Templates:
 	Template@222:
 		Category: Dirt Road Junctions
 		Id: 222
-		Image: Droadj04
+		Image: Droadj04.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3299,7 +3299,7 @@ Templates:
 	Template@223:
 		Category: Dirt Road Junctions
 		Id: 223
-		Image: Droadj05
+		Image: Droadj05.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3317,7 +3317,7 @@ Templates:
 	Template@224:
 		Category: Dirt Road Junctions
 		Id: 224
-		Image: Droadj06
+		Image: Droadj06.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -3344,7 +3344,7 @@ Templates:
 	Template@225:
 		Category: Dirt Road Junctions
 		Id: 225
-		Image: Droadj07
+		Image: Droadj07.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -3368,7 +3368,7 @@ Templates:
 	Template@226:
 		Category: Dirt Road Junctions
 		Id: 226
-		Image: Droadj08
+		Image: Droadj08.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -3392,7 +3392,7 @@ Templates:
 	Template@227:
 		Category: Dirt Road Junctions
 		Id: 227
-		Image: Droadj09
+		Image: Droadj09.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -3419,7 +3419,7 @@ Templates:
 	Template@228:
 		Category: Dirt Road Junctions
 		Id: 228
-		Image: Droadj10
+		Image: Droadj10.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -3446,7 +3446,7 @@ Templates:
 	Template@229:
 		Category: Dirt Road Junctions
 		Id: 229
-		Image: Droadj11
+		Image: Droadj11.tem
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
@@ -3491,7 +3491,7 @@ Templates:
 	Template@230:
 		Category: Straight Dirt Roads
 		Id: 230
-		Image: Droads01
+		Image: Droads01.tem
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
@@ -3524,7 +3524,7 @@ Templates:
 	Template@231:
 		Category: Straight Dirt Roads
 		Id: 231
-		Image: Droads02
+		Image: Droads02.tem
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
@@ -3557,7 +3557,7 @@ Templates:
 	Template@232:
 		Category: Straight Dirt Roads
 		Id: 232
-		Image: Droads03
+		Image: Droads03.tem
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
@@ -3590,7 +3590,7 @@ Templates:
 	Template@233:
 		Category: Straight Dirt Roads
 		Id: 233
-		Image: Droads04
+		Image: Droads04.tem
 		Size: 4, 4
 		Tiles:
 			0: Clear
@@ -3632,7 +3632,7 @@ Templates:
 	Template@234:
 		Category: Straight Dirt Roads
 		Id: 234
-		Image: Droads05
+		Image: Droads05.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -3656,7 +3656,7 @@ Templates:
 	Template@235:
 		Category: Straight Dirt Roads
 		Id: 235
-		Image: Droads06
+		Image: Droads06.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3671,7 +3671,7 @@ Templates:
 	Template@236:
 		Category: Straight Dirt Roads
 		Id: 236
-		Image: Droads07
+		Image: Droads07.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -3686,7 +3686,7 @@ Templates:
 	Template@237:
 		Category: Straight Dirt Roads
 		Id: 237
-		Image: Droads08
+		Image: Droads08.tem
 		Size: 4, 4
 		Tiles:
 			2: Clear
@@ -3716,7 +3716,7 @@ Templates:
 	Template@238:
 		Category: Straight Dirt Roads
 		Id: 238
-		Image: Droads09
+		Image: Droads09.tem
 		Size: 4, 3
 		Tiles:
 			1: Clear
@@ -3749,7 +3749,7 @@ Templates:
 	Template@239:
 		Category: Straight Dirt Roads
 		Id: 239
-		Image: Droads10
+		Image: Droads10.tem
 		Size: 3, 3
 		Tiles:
 			1: Clear
@@ -3773,7 +3773,7 @@ Templates:
 	Template@240:
 		Category: Straight Dirt Roads
 		Id: 240
-		Image: Droads11
+		Image: Droads11.tem
 		Size: 4, 4
 		Tiles:
 			2: DirtRoad
@@ -3806,7 +3806,7 @@ Templates:
 	Template@241:
 		Category: Straight Dirt Roads
 		Id: 241
-		Image: Droads12
+		Image: Droads12.tem
 		Size: 3, 4
 		Tiles:
 			1: DirtRoad
@@ -3839,7 +3839,7 @@ Templates:
 	Template@242:
 		Category: Straight Dirt Roads
 		Id: 242
-		Image: Droads13
+		Image: Droads13.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -3863,7 +3863,7 @@ Templates:
 	Template@243:
 		Category: Straight Dirt Roads
 		Id: 243
-		Image: Droads14
+		Image: Droads14.tem
 		Size: 5, 3
 		Tiles:
 			1: DirtRoad
@@ -3899,7 +3899,7 @@ Templates:
 	Template@244:
 		Category: Straight Dirt Roads
 		Id: 244
-		Image: Droads15
+		Image: Droads15.tem
 		Size: 3, 5
 		Tiles:
 			1: DirtRoad
@@ -3935,7 +3935,7 @@ Templates:
 	Template@245:
 		Category: Straight Dirt Roads
 		Id: 245
-		Image: Droads16
+		Image: Droads16.tem
 		Size: 2, 4
 		Tiles:
 			1: Clear
@@ -3959,7 +3959,7 @@ Templates:
 	Template@246:
 		Category: Straight Dirt Roads
 		Id: 246
-		Image: Droads17
+		Image: Droads17.tem
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
@@ -3989,7 +3989,7 @@ Templates:
 	Template@247:
 		Category: Straight Dirt Roads
 		Id: 247
-		Image: Droads18
+		Image: Droads18.tem
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
@@ -4019,7 +4019,7 @@ Templates:
 	Template@248:
 		Category: Straight Dirt Roads
 		Id: 248
-		Image: Droads19
+		Image: Droads19.tem
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
@@ -4049,7 +4049,7 @@ Templates:
 	Template@249:
 		Category: Straight Dirt Roads
 		Id: 249
-		Image: Droads20
+		Image: Droads20.tem
 		Size: 4, 2
 		Tiles:
 			0: DirtRoad
@@ -4079,7 +4079,7 @@ Templates:
 	Template@250:
 		Category: Straight Dirt Roads
 		Id: 250
-		Image: Droads21
+		Image: Droads21.tem
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
@@ -4103,7 +4103,7 @@ Templates:
 	Template@251:
 		Category: Straight Dirt Roads
 		Id: 251
-		Image: Droads22
+		Image: Droads22.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -4121,7 +4121,7 @@ Templates:
 	Template@252:
 		Category: Straight Dirt Roads
 		Id: 252
-		Image: Droads23
+		Image: Droads23.tem
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
@@ -4133,7 +4133,7 @@ Templates:
 	Template@253:
 		Category: Straight Dirt Roads
 		Id: 253
-		Image: Droads24
+		Image: Droads24.tem
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
@@ -4145,7 +4145,7 @@ Templates:
 	Template@254:
 		Category: Straight Dirt Roads
 		Id: 254
-		Image: Droads25
+		Image: Droads25.tem
 		Size: 3, 2
 		Tiles:
 			0: DirtRoad
@@ -4169,7 +4169,7 @@ Templates:
 	Template@255:
 		Category: Straight Dirt Roads
 		Id: 255
-		Image: Droads26
+		Image: Droads26.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -4187,7 +4187,7 @@ Templates:
 	Template@256:
 		Category: Straight Dirt Roads
 		Id: 256
-		Image: Droads27
+		Image: Droads27.tem
 		Size: 3, 3
 		Tiles:
 			1: Clear
@@ -4214,7 +4214,7 @@ Templates:
 	Template@257:
 		Category: Straight Dirt Roads
 		Id: 257
-		Image: Droads28
+		Image: Droads28.tem
 		Size: 3, 2
 		Tiles:
 			0: Clear
@@ -4238,7 +4238,7 @@ Templates:
 	Template@258:
 		Category: Straight Dirt Roads
 		Id: 258
-		Image: Droads29
+		Image: Droads29.tem
 		Size: 2, 2
 		Tiles:
 			0: Clear
@@ -4256,7 +4256,7 @@ Templates:
 	Template@259:
 		Category: Straight Dirt Roads
 		Id: 259
-		Image: Droads30
+		Image: Droads30.tem
 		Size: 2, 2
 		Tiles:
 			0: Clear
@@ -4274,7 +4274,7 @@ Templates:
 	Template@260:
 		Category: Straight Dirt Roads
 		Id: 260
-		Image: Droads31
+		Image: Droads31.tem
 		Size: 4, 3
 		Tiles:
 			0: DirtRoad
@@ -4304,7 +4304,7 @@ Templates:
 	Template@261:
 		Category: Straight Dirt Roads
 		Id: 261
-		Image: Droads32
+		Image: Droads32.tem
 		Size: 4, 3
 		Tiles:
 			2: Clear
@@ -4334,7 +4334,7 @@ Templates:
 	Template@262:
 		Category: Straight Dirt Roads
 		Id: 262
-		Image: Droads33
+		Image: Droads33.tem
 		Size: 4, 2
 		Tiles:
 			0: Clear
@@ -4364,7 +4364,7 @@ Templates:
 	Template@263:
 		Category: Straight Dirt Roads
 		Id: 263
-		Image: Droads34
+		Image: Droads34.tem
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
@@ -4397,7 +4397,7 @@ Templates:
 	Template@264:
 		Category: Straight Dirt Roads
 		Id: 264
-		Image: Droads35
+		Image: Droads35.tem
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
@@ -4430,7 +4430,7 @@ Templates:
 	Template@265:
 		Category: Straight Dirt Roads
 		Id: 265
-		Image: Droads36
+		Image: Droads36.tem
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
@@ -4463,7 +4463,7 @@ Templates:
 	Template@266:
 		Category: Straight Dirt Roads
 		Id: 266
-		Image: Droads37
+		Image: Droads37.tem
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
@@ -4496,7 +4496,7 @@ Templates:
 	Template@267:
 		Category: Straight Dirt Roads
 		Id: 267
-		Image: Droads38
+		Image: Droads38.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -4520,7 +4520,7 @@ Templates:
 	Template@268:
 		Category: Straight Dirt Roads
 		Id: 268
-		Image: Droads39
+		Image: Droads39.tem
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
@@ -4535,7 +4535,7 @@ Templates:
 	Template@269:
 		Category: Straight Dirt Roads
 		Id: 269
-		Image: Droads40
+		Image: Droads40.tem
 		Size: 2, 2
 		Tiles:
 			1: DirtRoad
@@ -4550,7 +4550,7 @@ Templates:
 	Template@270:
 		Category: Straight Dirt Roads
 		Id: 270
-		Image: Droads41
+		Image: Droads41.tem
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
@@ -4583,7 +4583,7 @@ Templates:
 	Template@271:
 		Category: Straight Dirt Roads
 		Id: 271
-		Image: Droads42
+		Image: Droads42.tem
 		Size: 4, 5
 		Tiles:
 			1: DirtRoad
@@ -4619,7 +4619,7 @@ Templates:
 	Template@272:
 		Category: Straight Dirt Roads
 		Id: 272
-		Image: Droads43
+		Image: Droads43.tem
 		Size: 3, 3
 		Tiles:
 			1: DirtRoad
@@ -4643,7 +4643,7 @@ Templates:
 	Template@273:
 		Category: Straight Dirt Roads
 		Id: 273
-		Image: Droads44
+		Image: Droads44.tem
 		Size: 4, 4
 		Tiles:
 			1: Clear
@@ -4676,7 +4676,7 @@ Templates:
 	Template@274:
 		Category: Straight Dirt Roads
 		Id: 274
-		Image: Droads45
+		Image: Droads45.tem
 		Size: 2, 3
 		Tiles:
 			0: Clear
@@ -4700,7 +4700,7 @@ Templates:
 	Template@275:
 		Category: Straight Dirt Roads
 		Id: 275
-		Image: Droads46
+		Image: Droads46.tem
 		Size: 3, 3
 		Tiles:
 			1: Clear
@@ -4724,7 +4724,7 @@ Templates:
 	Template@276:
 		Category: Straight Dirt Roads
 		Id: 276
-		Image: Droads47
+		Image: Droads47.tem
 		Size: 5, 3
 		Tiles:
 			1: DirtRoad
@@ -4763,7 +4763,7 @@ Templates:
 	Template@277:
 		Category: Straight Dirt Roads
 		Id: 277
-		Image: Droads48
+		Image: Droads48.tem
 		Size: 3, 5
 		Tiles:
 			1: DirtRoad
@@ -4799,7 +4799,7 @@ Templates:
 	Template@278:
 		Category: Straight Dirt Roads
 		Id: 278
-		Image: Droads49
+		Image: Droads49.tem
 		Size: 4, 4
 		Tiles:
 			1: Clear
@@ -4832,7 +4832,7 @@ Templates:
 	Template@279:
 		Category: Straight Dirt Roads
 		Id: 279
-		Image: Droads50
+		Image: Droads50.tem
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
@@ -4862,7 +4862,7 @@ Templates:
 	Template@280:
 		Category: Straight Dirt Roads
 		Id: 280
-		Image: Droads51
+		Image: Droads51.tem
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
@@ -4892,7 +4892,7 @@ Templates:
 	Template@281:
 		Category: Straight Dirt Roads
 		Id: 281
-		Image: Droads52
+		Image: Droads52.tem
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
@@ -4922,7 +4922,7 @@ Templates:
 	Template@282:
 		Category: Straight Dirt Roads
 		Id: 282
-		Image: Droads53
+		Image: Droads53.tem
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
@@ -4952,7 +4952,7 @@ Templates:
 	Template@283:
 		Category: Straight Dirt Roads
 		Id: 283
-		Image: Droads54
+		Image: Droads54.tem
 		Size: 2, 3
 		Tiles:
 			0: DirtRoad
@@ -4976,7 +4976,7 @@ Templates:
 	Template@284:
 		Category: Straight Dirt Roads
 		Id: 284
-		Image: Droads55
+		Image: Droads55.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -4994,7 +4994,7 @@ Templates:
 	Template@285:
 		Category: Straight Dirt Roads
 		Id: 285
-		Image: Droads56
+		Image: Droads56.tem
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
@@ -5006,7 +5006,7 @@ Templates:
 	Template@286:
 		Category: Straight Dirt Roads
 		Id: 286
-		Image: Droads57
+		Image: Droads57.tem
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
@@ -5018,7 +5018,7 @@ Templates:
 	Template@287:
 		Category: Straight Dirt Roads
 		Id: 287
-		Image: Droads58
+		Image: Droads58.tem
 		Size: 2, 4
 		Tiles:
 			0: Clear
@@ -5048,7 +5048,7 @@ Templates:
 	Template@288:
 		Category: Straight Dirt Roads
 		Id: 288
-		Image: Droads59
+		Image: Droads59.tem
 		Size: 3, 3
 		Tiles:
 			0: Clear
@@ -5075,7 +5075,7 @@ Templates:
 	Template@289:
 		Category: Straight Dirt Roads
 		Id: 289
-		Image: Droads60
+		Image: Droads60.tem
 		Size: 2, 3
 		Tiles:
 			0: Clear
@@ -5096,7 +5096,7 @@ Templates:
 	Template@290:
 		Category: Straight Dirt Roads
 		Id: 290
-		Image: Droads61
+		Image: Droads61.tem
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
@@ -5123,7 +5123,7 @@ Templates:
 	Template@291:
 		Category: Straight Dirt Roads
 		Id: 291
-		Image: Droads62
+		Image: Droads62.tem
 		Size: 2, 4
 		Tiles:
 			0: DirtRoad
@@ -5153,7 +5153,7 @@ Templates:
 	Template@292:
 		Category: Straight Dirt Roads
 		Id: 292
-		Image: Droads63
+		Image: Droads63.tem
 		Size: 2, 2
 		Tiles:
 			0: DirtRoad
@@ -5171,7 +5171,7 @@ Templates:
 	Template@293:
 		Category: Straight Dirt Roads
 		Id: 293
-		Image: Droads64
+		Image: Droads64.tem
 		Size: 3, 4
 		Tiles:
 			1: DirtRoad
@@ -5201,7 +5201,7 @@ Templates:
 	Template@294:
 		Category: Straight Dirt Roads
 		Id: 294
-		Image: Droads65
+		Image: Droads65.tem
 		Size: 3, 4
 		Tiles:
 			0: DirtRoad
@@ -5231,7 +5231,7 @@ Templates:
 	Template@295:
 		Category: Straight Dirt Roads
 		Id: 295
-		Image: Droads66
+		Image: Droads66.tem
 		Size: 2, 3
 		Tiles:
 			0: Clear
@@ -5252,7 +5252,7 @@ Templates:
 	Template@296:
 		Category: Bridges
 		Id: 296
-		Image: Ovrps01
+		Image: Ovrps01.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -5311,7 +5311,7 @@ Templates:
 	Template@297:
 		Category: Bridges
 		Id: 297
-		Image: Ovrps02
+		Image: Ovrps02.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -5370,7 +5370,7 @@ Templates:
 	Template@298:
 		Category: Bridges
 		Id: 298
-		Image: Ovrps03
+		Image: Ovrps03.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -5414,7 +5414,7 @@ Templates:
 	Template@299:
 		Category: Bridges
 		Id: 299
-		Image: Ovrps04
+		Image: Ovrps04.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -5473,7 +5473,7 @@ Templates:
 	Template@300:
 		Category: Bridges
 		Id: 300
-		Image: Ovrps05
+		Image: Ovrps05.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -5532,7 +5532,7 @@ Templates:
 	Template@301:
 		Category: Bridges
 		Id: 301
-		Image: Ovrps06
+		Image: Ovrps06.tem
 		Size: 5, 2
 		Tiles:
 			0: Cliff
@@ -5576,7 +5576,7 @@ Templates:
 	Template@302:
 		Category: Bridges
 		Id: 302
-		Image: Ovrps07
+		Image: Ovrps07.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -5615,7 +5615,7 @@ Templates:
 	Template@303:
 		Category: Bridges
 		Id: 303
-		Image: Ovrps08
+		Image: Ovrps08.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -5654,7 +5654,7 @@ Templates:
 	Template@304:
 		Category: Bridges
 		Id: 304
-		Image: Ovrps09
+		Image: Ovrps09.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -5693,7 +5693,7 @@ Templates:
 	Template@305:
 		Category: Bridges
 		Id: 305
-		Image: Ovrps10
+		Image: Ovrps10.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -5732,7 +5732,7 @@ Templates:
 	Template@306:
 		Category: Bridges
 		Id: 306
-		Image: Ovrps11
+		Image: Ovrps11.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -5768,7 +5768,7 @@ Templates:
 	Template@307:
 		Category: Bridges
 		Id: 307
-		Image: Ovrps12
+		Image: Ovrps12.tem
 		Size: 5, 2
 		Tiles:
 			1: Road
@@ -5804,7 +5804,7 @@ Templates:
 	Template@308:
 		Category: Bridges
 		Id: 308
-		Image: Ovrps13
+		Image: Ovrps13.tem
 		Size: 5, 2
 		Tiles:
 			1: Road
@@ -5840,7 +5840,7 @@ Templates:
 	Template@309:
 		Category: Bridges
 		Id: 309
-		Image: Ovrps14
+		Image: Ovrps14.tem
 		Size: 5, 2
 		Tiles:
 			1: Road
@@ -5876,7 +5876,7 @@ Templates:
 	Template@310:
 		Category: Bridges
 		Id: 310
-		Image: Ovrps15
+		Image: Ovrps15.tem
 		Size: 5, 2
 		Tiles:
 			1: Rough
@@ -5912,7 +5912,7 @@ Templates:
 	Template@311:
 		Category: Bridges
 		Id: 311
-		Image: Ovrps16
+		Image: Ovrps16.tem
 		Size: 5, 2
 		Tiles:
 			1: Cliff
@@ -5948,7 +5948,7 @@ Templates:
 	Template@312:
 		Category: Paved Roads
 		Id: 312
-		Image: Proad01
+		Image: Proad01.tem
 		Size: 1, 3
 		Tiles:
 			0: Road
@@ -5963,7 +5963,7 @@ Templates:
 	Template@313:
 		Category: Paved Roads
 		Id: 313
-		Image: Proad02
+		Image: Proad02.tem
 		Size: 3, 1
 		Tiles:
 			0: Road
@@ -5978,7 +5978,7 @@ Templates:
 	Template@314:
 		Category: Paved Roads
 		Id: 314
-		Image: Proad03
+		Image: Proad03.tem
 		Size: 3, 3
 		Tiles:
 			0: Road
@@ -6011,7 +6011,7 @@ Templates:
 	Template@315:
 		Category: Paved Roads
 		Id: 315
-		Image: Proad04
+		Image: Proad04.tem
 		Size: 3, 3
 		Tiles:
 			0: Road
@@ -6044,7 +6044,7 @@ Templates:
 	Template@316:
 		Category: Paved Roads
 		Id: 316
-		Image: Proad05
+		Image: Proad05.tem
 		Size: 3, 3
 		Tiles:
 			0: Road
@@ -6077,7 +6077,7 @@ Templates:
 	Template@317:
 		Category: Paved Roads
 		Id: 317
-		Image: Proad06
+		Image: Proad06.tem
 		Size: 3, 3
 		Tiles:
 			0: Road
@@ -6110,7 +6110,7 @@ Templates:
 	Template@318:
 		Category: Paved Roads
 		Id: 318
-		Image: Proad07
+		Image: Proad07.tem
 		Size: 3, 3
 		Tiles:
 			0: Road
@@ -6143,7 +6143,7 @@ Templates:
 	Template@319:
 		Category: Paved Roads
 		Id: 319
-		Image: Proad08
+		Image: Proad08.tem
 		Size: 3, 3
 		Tiles:
 			0: Road
@@ -6176,7 +6176,7 @@ Templates:
 	Template@320:
 		Category: Paved Roads
 		Id: 320
-		Image: Proad09
+		Image: Proad09.tem
 		Size: 3, 3
 		Tiles:
 			0: Road
@@ -6209,7 +6209,7 @@ Templates:
 	Template@321:
 		Category: Paved Roads
 		Id: 321
-		Image: Proad10
+		Image: Proad10.tem
 		Size: 4, 3
 		Tiles:
 			0: Clear
@@ -6251,7 +6251,7 @@ Templates:
 	Template@322:
 		Category: Paved Roads
 		Id: 322
-		Image: Proad11
+		Image: Proad11.tem
 		Size: 4, 3
 		Tiles:
 			0: Road
@@ -6293,7 +6293,7 @@ Templates:
 	Template@323:
 		Category: Paved Roads
 		Id: 323
-		Image: Proad12
+		Image: Proad12.tem
 		Size: 4, 3
 		Tiles:
 			0: DirtRoad
@@ -6335,7 +6335,7 @@ Templates:
 	Template@324:
 		Category: Paved Roads
 		Id: 324
-		Image: Proad13
+		Image: Proad13.tem
 		Size: 3, 4
 		Tiles:
 			0: DirtRoad
@@ -6377,7 +6377,7 @@ Templates:
 	Template@325:
 		Category: Paved Roads
 		Id: 325
-		Image: Proad14
+		Image: Proad14.tem
 		Size: 3, 4
 		Tiles:
 			0: Clear
@@ -6419,7 +6419,7 @@ Templates:
 	Template@326:
 		Category: Paved Roads
 		Id: 326
-		Image: Proad15
+		Image: Proad15.tem
 		Size: 3, 4
 		Tiles:
 			0: DirtRoad
@@ -6461,7 +6461,7 @@ Templates:
 	Template@327:
 		Category: Paved Roads
 		Id: 327
-		Image: Proad16
+		Image: Proad16.tem
 		Size: 4, 5
 		Tiles:
 			0: Road
@@ -6515,7 +6515,7 @@ Templates:
 	Template@328:
 		Category: Paved Roads
 		Id: 328
-		Image: Proad17
+		Image: Proad17.tem
 		Size: 4, 4
 		Tiles:
 			1: DirtRoad
@@ -6563,7 +6563,7 @@ Templates:
 	Template@329:
 		Category: Paved Roads
 		Id: 329
-		Image: Proad18
+		Image: Proad18.tem
 		Size: 4, 5
 		Tiles:
 			1: DirtRoad
@@ -6617,7 +6617,7 @@ Templates:
 	Template@330:
 		Category: Paved Roads
 		Id: 330
-		Image: Proad19
+		Image: Proad19.tem
 		Size: 5, 4
 		Tiles:
 			2: Road
@@ -6671,7 +6671,7 @@ Templates:
 	Template@331:
 		Category: Paved Roads
 		Id: 331
-		Image: Proad20
+		Image: Proad20.tem
 		Size: 4, 4
 		Tiles:
 			0: Road
@@ -6719,7 +6719,7 @@ Templates:
 	Template@332:
 		Category: Paved Roads
 		Id: 332
-		Image: Proad21
+		Image: Proad21.tem
 		Size: 5, 4
 		Tiles:
 			1: Road
@@ -6773,7 +6773,7 @@ Templates:
 	Template@333:
 		Category: Water
 		Id: 333
-		Image: Water01
+		Image: Water01.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -6791,7 +6791,7 @@ Templates:
 	Template@334:
 		Category: Water
 		Id: 334
-		Image: Water02
+		Image: Water02.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -6809,7 +6809,7 @@ Templates:
 	Template@335:
 		Category: Water
 		Id: 335
-		Image: Water03
+		Image: Water03.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -6827,7 +6827,7 @@ Templates:
 	Template@336:
 		Category: Water
 		Id: 336
-		Image: Water04
+		Image: Water04.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -6845,7 +6845,7 @@ Templates:
 	Template@337:
 		Category: Water
 		Id: 337
-		Image: Water05
+		Image: Water05.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -6863,7 +6863,7 @@ Templates:
 	Template@338:
 		Category: Water
 		Id: 338
-		Image: Water06
+		Image: Water06.tem
 		Size: 2, 2
 		Tiles:
 			0: Water
@@ -6881,7 +6881,7 @@ Templates:
 	Template@339:
 		Category: Water
 		Id: 339
-		Image: Water07
+		Image: Water07.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -6899,7 +6899,7 @@ Templates:
 	Template@340:
 		Category: Water
 		Id: 340
-		Image: Water08
+		Image: Water08.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -6917,7 +6917,7 @@ Templates:
 	Template@341:
 		Category: Water
 		Id: 341
-		Image: Water09
+		Image: Water09.tem
 		Size: 1, 1
 		Tiles:
 			0: Water
@@ -6926,7 +6926,7 @@ Templates:
 	Template@342:
 		Category: Water
 		Id: 342
-		Image: Water10
+		Image: Water10.tem
 		Size: 1, 1
 		Tiles:
 			0: Water
@@ -6935,7 +6935,7 @@ Templates:
 	Template@343:
 		Category: Water
 		Id: 343
-		Image: Water11
+		Image: Water11.tem
 		Size: 1, 1
 		Tiles:
 			0: Water
@@ -6944,7 +6944,7 @@ Templates:
 	Template@344:
 		Category: Water
 		Id: 344
-		Image: Water12
+		Image: Water12.tem
 		Size: 1, 1
 		Tiles:
 			0: Water
@@ -6953,7 +6953,7 @@ Templates:
 	Template@345:
 		Category: Water
 		Id: 345
-		Image: Water13
+		Image: Water13.tem
 		Size: 1, 1
 		Tiles:
 			0: Water
@@ -6962,7 +6962,7 @@ Templates:
 	Template@346:
 		Category: Water
 		Id: 346
-		Image: Water14
+		Image: Water14.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -6971,7 +6971,7 @@ Templates:
 	Template@387:
 		Category: Dirt Road Slopes
 		Id: 387
-		Image: DRSLPE01
+		Image: DRSLPE01.tem
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
@@ -6985,7 +6985,7 @@ Templates:
 	Template@388:
 		Category: Dirt Road Slopes
 		Id: 388
-		Image: DRSLPE02
+		Image: DRSLPE02.tem
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
@@ -6999,7 +6999,7 @@ Templates:
 	Template@389:
 		Category: Dirt Road Slopes
 		Id: 389
-		Image: DRSLPE03
+		Image: DRSLPE03.tem
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
@@ -7013,7 +7013,7 @@ Templates:
 	Template@390:
 		Category: Dirt Road Slopes
 		Id: 390
-		Image: DRSLPE04
+		Image: DRSLPE04.tem
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
@@ -7027,7 +7027,7 @@ Templates:
 	Template@391:
 		Category: Dirt Road Slopes
 		Id: 391
-		Image: DRSLPE05
+		Image: DRSLPE05.tem
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
@@ -7041,7 +7041,7 @@ Templates:
 	Template@392:
 		Category: Dirt Road Slopes
 		Id: 392
-		Image: DRSLPE06
+		Image: DRSLPE06.tem
 		Size: 1, 2
 		Tiles:
 			0: DirtRoad
@@ -7055,7 +7055,7 @@ Templates:
 	Template@393:
 		Category: Dirt Road Slopes
 		Id: 393
-		Image: DRSLPE07
+		Image: DRSLPE07.tem
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
@@ -7069,7 +7069,7 @@ Templates:
 	Template@394:
 		Category: Dirt Road Slopes
 		Id: 394
-		Image: DRSLPE08
+		Image: DRSLPE08.tem
 		Size: 2, 1
 		Tiles:
 			0: DirtRoad
@@ -7083,7 +7083,7 @@ Templates:
 	Template@403:
 		Category: Slope Set Pieces
 		Id: 403
-		Image: RAMP01
+		Image: RAMP01.tem
 		Size: 3, 4
 		Tiles:
 			1: Clear
@@ -7133,7 +7133,7 @@ Templates:
 	Template@404:
 		Category: Slope Set Pieces
 		Id: 404
-		Image: RAMP02
+		Image: RAMP02.tem
 		Size: 3, 4
 		Tiles:
 			0: Clear
@@ -7183,7 +7183,7 @@ Templates:
 	Template@405:
 		Category: Slope Set Pieces
 		Id: 405
-		Image: RAMP03
+		Image: RAMP03.tem
 		Size: 4, 3
 		Tiles:
 			0: Clear
@@ -7233,7 +7233,7 @@ Templates:
 	Template@406:
 		Category: Slope Set Pieces
 		Id: 406
-		Image: RAMP04
+		Image: RAMP04.tem
 		Size: 4, 3
 		Tiles:
 			1: Cliff
@@ -7283,7 +7283,7 @@ Templates:
 	Template@407:
 		Category: Slope Set Pieces
 		Id: 407
-		Image: RAMP05
+		Image: RAMP05.tem
 		Size: 3, 4
 		Tiles:
 			1: Clear
@@ -7332,7 +7332,7 @@ Templates:
 	Template@408:
 		Category: Slope Set Pieces
 		Id: 408
-		Image: RAMP06
+		Image: RAMP06.tem
 		Size: 3, 4
 		Tiles:
 			0: Clear
@@ -7368,7 +7368,7 @@ Templates:
 	Template@409:
 		Category: Slope Set Pieces
 		Id: 409
-		Image: RAMP07
+		Image: RAMP07.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -7388,7 +7388,7 @@ Templates:
 	Template@410:
 		Category: Slope Set Pieces
 		Id: 410
-		Image: RAMP08
+		Image: RAMP08.tem
 		Size: 4, 3
 		Tiles:
 			1: Cliff
@@ -7437,7 +7437,7 @@ Templates:
 	Template@411:
 		Category: Slope Set Pieces
 		Id: 411
-		Image: RAMP09
+		Image: RAMP09.tem
 		Size: 4, 3
 		Tiles:
 			0: Clear
@@ -7473,7 +7473,7 @@ Templates:
 	Template@412:
 		Category: Slope Set Pieces
 		Id: 412
-		Image: RAMP10
+		Image: RAMP10.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -7493,7 +7493,7 @@ Templates:
 	Template@423:
 		Category: Dead Oil Tanker
 		Id: 423
-		Image: TANKER01
+		Image: TANKER01.tem
 		Size: 5, 8
 		Tiles:
 			0: Cliff
@@ -7577,7 +7577,7 @@ Templates:
 	Template@424:
 		Category: Ruins
 		Id: 424
-		Image: RUIN01
+		Image: RUIN01.tem
 		Size: 3, 3
 		Tiles:
 			1: Cliff
@@ -7604,7 +7604,7 @@ Templates:
 	Template@435:
 		Category: Waterfalls
 		Id: 435
-		Image: W-a-01
+		Image: W-a-01.tem
 		Size: 2, 4
 		Tiles:
 			0: Cliff
@@ -7638,7 +7638,7 @@ Templates:
 	Template@436:
 		Category: Waterfalls
 		Id: 436
-		Image: W-a-02
+		Image: W-a-02.tem
 		Size: 1, 4
 		Tiles:
 			0: Cliff
@@ -7658,7 +7658,7 @@ Templates:
 	Template@437:
 		Category: Waterfalls
 		Id: 437
-		Image: W-a-03
+		Image: W-a-03.tem
 		Size: 2, 4
 		Tiles:
 			0: Cliff
@@ -7692,7 +7692,7 @@ Templates:
 	Template@438:
 		Category: Waterfalls
 		Id: 438
-		Image: W-a-04
+		Image: W-a-04.tem
 		Size: 2, 4
 		Tiles:
 			0: Cliff
@@ -7726,7 +7726,7 @@ Templates:
 	Template@439:
 		Category: Ground 01
 		Id: 439
-		Image: Des0101
+		Image: Des0101.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7735,7 +7735,7 @@ Templates:
 	Template@440:
 		Category: Ground 01
 		Id: 440
-		Image: Des0102
+		Image: Des0102.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7744,7 +7744,7 @@ Templates:
 	Template@441:
 		Category: Ground 01
 		Id: 441
-		Image: Des0103
+		Image: Des0103.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7753,7 +7753,7 @@ Templates:
 	Template@442:
 		Category: Ground 01
 		Id: 442
-		Image: Des0104
+		Image: Des0104.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7762,7 +7762,7 @@ Templates:
 	Template@443:
 		Category: Ground 01
 		Id: 443
-		Image: Des0105
+		Image: Des0105.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7771,7 +7771,7 @@ Templates:
 	Template@444:
 		Category: Ground 01
 		Id: 444
-		Image: Des0106
+		Image: Des0106.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7780,7 +7780,7 @@ Templates:
 	Template@445:
 		Category: Ground 01
 		Id: 445
-		Image: Des0107
+		Image: Des0107.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7789,7 +7789,7 @@ Templates:
 	Template@446:
 		Category: Ground 01
 		Id: 446
-		Image: Des0108
+		Image: Des0108.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7798,7 +7798,7 @@ Templates:
 	Template@447:
 		Category: Ground 01
 		Id: 447
-		Image: Des0109
+		Image: Des0109.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7807,7 +7807,7 @@ Templates:
 	Template@448:
 		Category: Ground 01
 		Id: 448
-		Image: Des0110
+		Image: Des0110.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7816,7 +7816,7 @@ Templates:
 	Template@449:
 		Category: Ground 01
 		Id: 449
-		Image: Des0111
+		Image: Des0111.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7825,7 +7825,7 @@ Templates:
 	Template@450:
 		Category: Ground 01
 		Id: 450
-		Image: Des0112
+		Image: Des0112.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7834,7 +7834,7 @@ Templates:
 	Template@451:
 		Category: Ground 01
 		Id: 451
-		Image: Des0113
+		Image: Des0113.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7843,7 +7843,7 @@ Templates:
 	Template@452:
 		Category: Ground 01
 		Id: 452
-		Image: Des0114
+		Image: Des0114.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7852,7 +7852,7 @@ Templates:
 	Template@453:
 		Category: Ground 01
 		Id: 453
-		Image: Des0115
+		Image: Des0115.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7861,7 +7861,7 @@ Templates:
 	Template@454:
 		Category: Ground 01
 		Id: 454
-		Image: Des0116
+		Image: Des0116.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7870,7 +7870,7 @@ Templates:
 	Template@455:
 		Category: Ground 01
 		Id: 455
-		Image: Des0117
+		Image: Des0117.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7879,7 +7879,7 @@ Templates:
 	Template@456:
 		Category: Ground 01
 		Id: 456
-		Image: Des0118
+		Image: Des0118.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7888,7 +7888,7 @@ Templates:
 	Template@457:
 		Category: Ground 01
 		Id: 457
-		Image: Des0119
+		Image: Des0119.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7897,7 +7897,7 @@ Templates:
 	Template@458:
 		Category: Ground 01
 		Id: 458
-		Image: Des0120
+		Image: Des0120.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7906,7 +7906,7 @@ Templates:
 	Template@459:
 		Category: Ground 01
 		Id: 459
-		Image: Des0121
+		Image: Des0121.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7915,7 +7915,7 @@ Templates:
 	Template@460:
 		Category: Ground 01
 		Id: 460
-		Image: Des0122
+		Image: Des0122.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7924,7 +7924,7 @@ Templates:
 	Template@461:
 		Category: Ground 01
 		Id: 461
-		Image: Des0123
+		Image: Des0123.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7933,7 +7933,7 @@ Templates:
 	Template@462:
 		Category: Ground 01
 		Id: 462
-		Image: Des0124
+		Image: Des0124.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7942,7 +7942,7 @@ Templates:
 	Template@463:
 		Category: Ground 01
 		Id: 463
-		Image: Des0125
+		Image: Des0125.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7951,7 +7951,7 @@ Templates:
 	Template@464:
 		Category: Ground 01
 		Id: 464
-		Image: Des0126
+		Image: Des0126.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7960,7 +7960,7 @@ Templates:
 	Template@465:
 		Category: Ground 01
 		Id: 465
-		Image: Des0127
+		Image: Des0127.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7969,7 +7969,7 @@ Templates:
 	Template@466:
 		Category: Ground 01
 		Id: 466
-		Image: Des0128
+		Image: Des0128.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7978,7 +7978,7 @@ Templates:
 	Template@467:
 		Category: Ground 01
 		Id: 467
-		Image: Des0129
+		Image: Des0129.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7987,7 +7987,7 @@ Templates:
 	Template@468:
 		Category: Ground 01
 		Id: 468
-		Image: Des0130
+		Image: Des0130.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -7996,7 +7996,7 @@ Templates:
 	Template@469:
 		Category: Ground 01
 		Id: 469
-		Image: Des0131
+		Image: Des0131.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8005,7 +8005,7 @@ Templates:
 	Template@470:
 		Category: Ground 01
 		Id: 470
-		Image: Des0132
+		Image: Des0132.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8014,7 +8014,7 @@ Templates:
 	Template@471:
 		Category: Ground 01
 		Id: 471
-		Image: Des0133
+		Image: Des0133.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8023,7 +8023,7 @@ Templates:
 	Template@472:
 		Category: Ground 01
 		Id: 472
-		Image: Des0134
+		Image: Des0134.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8032,7 +8032,7 @@ Templates:
 	Template@473:
 		Category: Ground 01
 		Id: 473
-		Image: Des0135
+		Image: Des0135.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8041,7 +8041,7 @@ Templates:
 	Template@474:
 		Category: Ground 01
 		Id: 474
-		Image: Des0136
+		Image: Des0136.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8050,7 +8050,7 @@ Templates:
 	Template@475:
 		Category: Ground 01
 		Id: 475
-		Image: Des0137
+		Image: Des0137.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8059,7 +8059,7 @@ Templates:
 	Template@476:
 		Category: Ground 01
 		Id: 476
-		Image: Des0138
+		Image: Des0138.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8068,7 +8068,7 @@ Templates:
 	Template@477:
 		Category: Ground 01
 		Id: 477
-		Image: Des0139
+		Image: Des0139.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8077,7 +8077,7 @@ Templates:
 	Template@478:
 		Category: Ground 01
 		Id: 478
-		Image: Des0140
+		Image: Des0140.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8086,7 +8086,7 @@ Templates:
 	Template@479:
 		Category: Ground 01
 		Id: 479
-		Image: Des0141
+		Image: Des0141.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8095,7 +8095,7 @@ Templates:
 	Template@480:
 		Category: Ground 01
 		Id: 480
-		Image: Des0142
+		Image: Des0142.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8104,7 +8104,7 @@ Templates:
 	Template@481:
 		Category: Ground 01
 		Id: 481
-		Image: Des0143
+		Image: Des0143.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8113,7 +8113,7 @@ Templates:
 	Template@482:
 		Category: Ground 01
 		Id: 482
-		Image: Des0144
+		Image: Des0144.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8122,7 +8122,7 @@ Templates:
 	Template@483:
 		Category: Ground 01
 		Id: 483
-		Image: Des0145
+		Image: Des0145.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8131,7 +8131,7 @@ Templates:
 	Template@484:
 		Category: Ground 01
 		Id: 484
-		Image: Des0146
+		Image: Des0146.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8140,7 +8140,7 @@ Templates:
 	Template@485:
 		Category: Ground 01
 		Id: 485
-		Image: Des0147
+		Image: Des0147.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8149,7 +8149,7 @@ Templates:
 	Template@486:
 		Category: Ground 01
 		Id: 486
-		Image: Des0148
+		Image: Des0148.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8158,7 +8158,7 @@ Templates:
 	Template@487:
 		Category: Ground 02
 		Id: 487
-		Image: Des0201
+		Image: Des0201.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8167,7 +8167,7 @@ Templates:
 	Template@488:
 		Category: Ground 02
 		Id: 488
-		Image: Des0202
+		Image: Des0202.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8176,7 +8176,7 @@ Templates:
 	Template@489:
 		Category: Ground 02
 		Id: 489
-		Image: Des0203
+		Image: Des0203.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8185,7 +8185,7 @@ Templates:
 	Template@490:
 		Category: Ground 02
 		Id: 490
-		Image: Des0204
+		Image: Des0204.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8194,7 +8194,7 @@ Templates:
 	Template@491:
 		Category: Ground 02
 		Id: 491
-		Image: Des0205
+		Image: Des0205.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8203,7 +8203,7 @@ Templates:
 	Template@492:
 		Category: Ground 02
 		Id: 492
-		Image: Des0206
+		Image: Des0206.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8212,7 +8212,7 @@ Templates:
 	Template@493:
 		Category: Ground 02
 		Id: 493
-		Image: Des0207
+		Image: Des0207.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8221,7 +8221,7 @@ Templates:
 	Template@494:
 		Category: Ground 02
 		Id: 494
-		Image: Des0208
+		Image: Des0208.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8230,7 +8230,7 @@ Templates:
 	Template@495:
 		Category: Ground 02
 		Id: 495
-		Image: Des0209
+		Image: Des0209.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8239,7 +8239,7 @@ Templates:
 	Template@496:
 		Category: Ground 02
 		Id: 496
-		Image: Des0210
+		Image: Des0210.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8248,7 +8248,7 @@ Templates:
 	Template@497:
 		Category: Ground 02
 		Id: 497
-		Image: Des0211
+		Image: Des0211.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8257,7 +8257,7 @@ Templates:
 	Template@498:
 		Category: Ground 02
 		Id: 498
-		Image: Des0212
+		Image: Des0212.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8266,7 +8266,7 @@ Templates:
 	Template@499:
 		Category: Ground 02
 		Id: 499
-		Image: Des0213
+		Image: Des0213.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8275,7 +8275,7 @@ Templates:
 	Template@500:
 		Category: Ground 02
 		Id: 500
-		Image: Des0214
+		Image: Des0214.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8284,7 +8284,7 @@ Templates:
 	Template@501:
 		Category: Ground 02
 		Id: 501
-		Image: Des0215
+		Image: Des0215.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8293,7 +8293,7 @@ Templates:
 	Template@502:
 		Category: Ground 02
 		Id: 502
-		Image: Des0216
+		Image: Des0216.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8302,7 +8302,7 @@ Templates:
 	Template@503:
 		Category: Ground 02
 		Id: 503
-		Image: Des0217
+		Image: Des0217.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8311,7 +8311,7 @@ Templates:
 	Template@504:
 		Category: Ground 02
 		Id: 504
-		Image: Des0218
+		Image: Des0218.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8320,7 +8320,7 @@ Templates:
 	Template@505:
 		Category: Ground 02
 		Id: 505
-		Image: Des0219
+		Image: Des0219.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8329,7 +8329,7 @@ Templates:
 	Template@506:
 		Category: Ground 02
 		Id: 506
-		Image: Des0220
+		Image: Des0220.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8338,7 +8338,7 @@ Templates:
 	Template@507:
 		Category: Ground 02
 		Id: 507
-		Image: Des0221
+		Image: Des0221.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8347,7 +8347,7 @@ Templates:
 	Template@508:
 		Category: Ground 02
 		Id: 508
-		Image: Des0222
+		Image: Des0222.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8356,7 +8356,7 @@ Templates:
 	Template@509:
 		Category: Ground 02
 		Id: 509
-		Image: Des0223
+		Image: Des0223.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8365,7 +8365,7 @@ Templates:
 	Template@510:
 		Category: Ground 02
 		Id: 510
-		Image: Des0224
+		Image: Des0224.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8374,7 +8374,7 @@ Templates:
 	Template@511:
 		Category: Ground 02
 		Id: 511
-		Image: Des0225
+		Image: Des0225.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8383,7 +8383,7 @@ Templates:
 	Template@512:
 		Category: Ground 02
 		Id: 512
-		Image: Des0226
+		Image: Des0226.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8392,7 +8392,7 @@ Templates:
 	Template@513:
 		Category: Ground 02
 		Id: 513
-		Image: Des0227
+		Image: Des0227.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8401,7 +8401,7 @@ Templates:
 	Template@514:
 		Category: Ground 02
 		Id: 514
-		Image: Des0228
+		Image: Des0228.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8410,7 +8410,7 @@ Templates:
 	Template@515:
 		Category: Ground 02
 		Id: 515
-		Image: Des0229
+		Image: Des0229.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8419,7 +8419,7 @@ Templates:
 	Template@516:
 		Category: Ground 02
 		Id: 516
-		Image: Des0230
+		Image: Des0230.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8428,7 +8428,7 @@ Templates:
 	Template@517:
 		Category: Ground 02
 		Id: 517
-		Image: Des0231
+		Image: Des0231.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8437,7 +8437,7 @@ Templates:
 	Template@518:
 		Category: Ground 02
 		Id: 518
-		Image: Des0232
+		Image: Des0232.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8446,7 +8446,7 @@ Templates:
 	Template@519:
 		Category: Ground 02
 		Id: 519
-		Image: Des0233
+		Image: Des0233.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8455,7 +8455,7 @@ Templates:
 	Template@520:
 		Category: Ground 02
 		Id: 520
-		Image: Des0234
+		Image: Des0234.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8464,7 +8464,7 @@ Templates:
 	Template@521:
 		Category: Ground 02
 		Id: 521
-		Image: Des0235
+		Image: Des0235.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8473,7 +8473,7 @@ Templates:
 	Template@522:
 		Category: Ground 02
 		Id: 522
-		Image: Des0236
+		Image: Des0236.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8482,7 +8482,7 @@ Templates:
 	Template@523:
 		Category: Ground 02
 		Id: 523
-		Image: Des0237
+		Image: Des0237.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8491,7 +8491,7 @@ Templates:
 	Template@524:
 		Category: Ground 02
 		Id: 524
-		Image: Des0238
+		Image: Des0238.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8500,7 +8500,7 @@ Templates:
 	Template@525:
 		Category: Ground 02
 		Id: 525
-		Image: Des0239
+		Image: Des0239.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8509,7 +8509,7 @@ Templates:
 	Template@526:
 		Category: Ground 02
 		Id: 526
-		Image: Des0240
+		Image: Des0240.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8518,7 +8518,7 @@ Templates:
 	Template@527:
 		Category: Ground 02
 		Id: 527
-		Image: Des0241
+		Image: Des0241.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8527,7 +8527,7 @@ Templates:
 	Template@528:
 		Category: Ground 02
 		Id: 528
-		Image: Des0242
+		Image: Des0242.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8536,7 +8536,7 @@ Templates:
 	Template@529:
 		Category: Ground 02
 		Id: 529
-		Image: Des0243
+		Image: Des0243.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8545,7 +8545,7 @@ Templates:
 	Template@530:
 		Category: Ground 02
 		Id: 530
-		Image: Des0244
+		Image: Des0244.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8554,7 +8554,7 @@ Templates:
 	Template@531:
 		Category: Ground 02
 		Id: 531
-		Image: Des0245
+		Image: Des0245.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8563,7 +8563,7 @@ Templates:
 	Template@532:
 		Category: Ground 02
 		Id: 532
-		Image: Des0246
+		Image: Des0246.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8572,7 +8572,7 @@ Templates:
 	Template@533:
 		Category: Ground 02
 		Id: 533
-		Image: Des0247
+		Image: Des0247.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8581,7 +8581,7 @@ Templates:
 	Template@534:
 		Category: Ground 02
 		Id: 534
-		Image: Des0248
+		Image: Des0248.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -8590,7 +8590,7 @@ Templates:
 	Template@535:
 		Category: Sand
 		Id: 535
-		Image: Sandy01
+		Image: Sandy01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8599,7 +8599,7 @@ Templates:
 	Template@536:
 		Category: Sand/Clear LAT
 		Id: 536
-		Image: dlat01
+		Image: dlat01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8608,7 +8608,7 @@ Templates:
 	Template@537:
 		Category: Sand/Clear LAT
 		Id: 537
-		Image: dlat02
+		Image: dlat02.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8617,7 +8617,7 @@ Templates:
 	Template@538:
 		Category: Sand/Clear LAT
 		Id: 538
-		Image: dlat03
+		Image: dlat03.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8626,7 +8626,7 @@ Templates:
 	Template@539:
 		Category: Sand/Clear LAT
 		Id: 539
-		Image: dlat04
+		Image: dlat04.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8635,7 +8635,7 @@ Templates:
 	Template@540:
 		Category: Sand/Clear LAT
 		Id: 540
-		Image: dlat05
+		Image: dlat05.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8644,7 +8644,7 @@ Templates:
 	Template@541:
 		Category: Sand/Clear LAT
 		Id: 541
-		Image: dlat06
+		Image: dlat06.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8653,7 +8653,7 @@ Templates:
 	Template@542:
 		Category: Sand/Clear LAT
 		Id: 542
-		Image: dlat07
+		Image: dlat07.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8662,7 +8662,7 @@ Templates:
 	Template@543:
 		Category: Sand/Clear LAT
 		Id: 543
-		Image: dlat08
+		Image: dlat08.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8671,7 +8671,7 @@ Templates:
 	Template@544:
 		Category: Sand/Clear LAT
 		Id: 544
-		Image: dlat09
+		Image: dlat09.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8680,7 +8680,7 @@ Templates:
 	Template@545:
 		Category: Sand/Clear LAT
 		Id: 545
-		Image: dlat10
+		Image: dlat10.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8689,7 +8689,7 @@ Templates:
 	Template@546:
 		Category: Sand/Clear LAT
 		Id: 546
-		Image: dlat11
+		Image: dlat11.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8698,7 +8698,7 @@ Templates:
 	Template@547:
 		Category: Sand/Clear LAT
 		Id: 547
-		Image: dlat12
+		Image: dlat12.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8707,7 +8707,7 @@ Templates:
 	Template@548:
 		Category: Sand/Clear LAT
 		Id: 548
-		Image: dlat13
+		Image: dlat13.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8716,7 +8716,7 @@ Templates:
 	Template@549:
 		Category: Sand/Clear LAT
 		Id: 549
-		Image: dlat14
+		Image: dlat14.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8725,7 +8725,7 @@ Templates:
 	Template@550:
 		Category: Sand/Clear LAT
 		Id: 550
-		Image: dlat15
+		Image: dlat15.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8734,7 +8734,7 @@ Templates:
 	Template@551:
 		Category: Sand/Clear LAT
 		Id: 551
-		Image: dlat16
+		Image: dlat16.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -8743,7 +8743,7 @@ Templates:
 	Template@552:
 		Category: Rough ground
 		Id: 552
-		Image: Rough01
+		Image: Rough01.tem
 		Size: 9, 7
 		Tiles:
 			2: Rough
@@ -8857,7 +8857,7 @@ Templates:
 	Template@553:
 		Category: Rough ground
 		Id: 553
-		Image: Rough02
+		Image: Rough02.tem
 		Size: 4, 4
 		Tiles:
 			1: Rough
@@ -8893,7 +8893,7 @@ Templates:
 	Template@554:
 		Category: Rough ground
 		Id: 554
-		Image: Rough03
+		Image: Rough03.tem
 		Size: 5, 3
 		Tiles:
 			0: Rough
@@ -8932,7 +8932,7 @@ Templates:
 	Template@555:
 		Category: Rough ground
 		Id: 555
-		Image: Rough04
+		Image: Rough04.tem
 		Size: 4, 3
 		Tiles:
 			0: Rough
@@ -8962,7 +8962,7 @@ Templates:
 	Template@556:
 		Category: Rough ground
 		Id: 556
-		Image: Rough05
+		Image: Rough05.tem
 		Size: 3, 5
 		Tiles:
 			1: Rough
@@ -9004,7 +9004,7 @@ Templates:
 	Template@557:
 		Category: Rough ground
 		Id: 557
-		Image: Rough06
+		Image: Rough06.tem
 		Size: 4, 4
 		Tiles:
 			1: Clear
@@ -9049,7 +9049,7 @@ Templates:
 	Template@558:
 		Category: Rough ground
 		Id: 558
-		Image: Rough07
+		Image: Rough07.tem
 		Size: 3, 3
 		Tiles:
 			0: Rough
@@ -9079,7 +9079,7 @@ Templates:
 	Template@559:
 		Category: Rough ground
 		Id: 559
-		Image: Rough08
+		Image: Rough08.tem
 		Size: 6, 10
 		Tiles:
 			1: Rough
@@ -9151,7 +9151,7 @@ Templates:
 	Template@560:
 		Category: Rough ground
 		Id: 560
-		Image: Rough09
+		Image: Rough09.tem
 		Size: 8, 3
 		Tiles:
 			0: Clear
@@ -9205,7 +9205,7 @@ Templates:
 	Template@561:
 		Category: Rough ground
 		Id: 561
-		Image: Rough10
+		Image: Rough10.tem
 		Size: 3, 4
 		Tiles:
 			0: Rough
@@ -9235,7 +9235,7 @@ Templates:
 	Template@562:
 		Category: Paved Road Ends
 		Id: 562
-		Image: p_end01
+		Image: p_end01.tem
 		Size: 1, 3
 		Tiles:
 			0: Rough
@@ -9250,7 +9250,7 @@ Templates:
 	Template@563:
 		Category: Paved Road Ends
 		Id: 563
-		Image: p_end02
+		Image: p_end02.tem
 		Size: 3, 1
 		Tiles:
 			0: Rough
@@ -9265,7 +9265,7 @@ Templates:
 	Template@564:
 		Category: Paved Road Ends
 		Id: 564
-		Image: p_end03
+		Image: p_end03.tem
 		Size: 1, 3
 		Tiles:
 			0: Rough
@@ -9280,7 +9280,7 @@ Templates:
 	Template@565:
 		Category: Paved Road Ends
 		Id: 565
-		Image: p_end04
+		Image: p_end04.tem
 		Size: 3, 1
 		Tiles:
 			0: Rough
@@ -9295,7 +9295,7 @@ Templates:
 	Template@566:
 		Category: TrainBridges
 		Id: 566
-		Image: Tovrps01
+		Image: Tovrps01.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -9354,7 +9354,7 @@ Templates:
 	Template@567:
 		Category: TrainBridges
 		Id: 567
-		Image: Tovrps02
+		Image: Tovrps02.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -9413,7 +9413,7 @@ Templates:
 	Template@568:
 		Category: TrainBridges
 		Id: 568
-		Image: Tovrps03
+		Image: Tovrps03.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -9457,7 +9457,7 @@ Templates:
 	Template@569:
 		Category: TrainBridges
 		Id: 569
-		Image: Tovrps04
+		Image: Tovrps04.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -9516,7 +9516,7 @@ Templates:
 	Template@570:
 		Category: TrainBridges
 		Id: 570
-		Image: Tovrps05
+		Image: Tovrps05.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -9575,7 +9575,7 @@ Templates:
 	Template@571:
 		Category: TrainBridges
 		Id: 571
-		Image: Tovrps06
+		Image: Tovrps06.tem
 		Size: 5, 2
 		Tiles:
 			0: Cliff
@@ -9619,7 +9619,7 @@ Templates:
 	Template@572:
 		Category: TrainBridges
 		Id: 572
-		Image: Tovrps07
+		Image: Tovrps07.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -9658,7 +9658,7 @@ Templates:
 	Template@573:
 		Category: TrainBridges
 		Id: 573
-		Image: Tovrps08
+		Image: Tovrps08.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -9697,7 +9697,7 @@ Templates:
 	Template@574:
 		Category: TrainBridges
 		Id: 574
-		Image: Tovrps09
+		Image: Tovrps09.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -9736,7 +9736,7 @@ Templates:
 	Template@575:
 		Category: TrainBridges
 		Id: 575
-		Image: Tovrps10
+		Image: Tovrps10.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -9775,7 +9775,7 @@ Templates:
 	Template@576:
 		Category: TrainBridges
 		Id: 576
-		Image: Tovrps11
+		Image: Tovrps11.tem
 		Size: 2, 5
 		Tiles:
 			0: Cliff
@@ -9811,7 +9811,7 @@ Templates:
 	Template@577:
 		Category: TrainBridges
 		Id: 577
-		Image: Tovrps12
+		Image: Tovrps12.tem
 		Size: 5, 2
 		Tiles:
 			0: Cliff
@@ -9850,7 +9850,7 @@ Templates:
 	Template@578:
 		Category: TrainBridges
 		Id: 578
-		Image: Tovrps13
+		Image: Tovrps13.tem
 		Size: 5, 2
 		Tiles:
 			1: Road
@@ -9886,7 +9886,7 @@ Templates:
 	Template@579:
 		Category: TrainBridges
 		Id: 579
-		Image: Tovrps14
+		Image: Tovrps14.tem
 		Size: 5, 2
 		Tiles:
 			0: Cliff
@@ -9925,7 +9925,7 @@ Templates:
 	Template@580:
 		Category: TrainBridges
 		Id: 580
-		Image: Tovrps15
+		Image: Tovrps15.tem
 		Size: 5, 2
 		Tiles:
 			1: Rough
@@ -9961,7 +9961,7 @@ Templates:
 	Template@581:
 		Category: TrainBridges
 		Id: 581
-		Image: Tovrps16
+		Image: Tovrps16.tem
 		Size: 5, 2
 		Tiles:
 			0: Cliff
@@ -9997,7 +9997,7 @@ Templates:
 	Template@582:
 		Category: Pavement
 		Id: 582
-		Image: Pave01
+		Image: Pave01.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10006,7 +10006,7 @@ Templates:
 	Template@583:
 		Category: Pavement
 		Id: 583
-		Image: Pave02
+		Image: Pave02.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10015,7 +10015,7 @@ Templates:
 	Template@584:
 		Category: Pavement
 		Id: 584
-		Image: Pave03
+		Image: Pave03.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10024,7 +10024,7 @@ Templates:
 	Template@585:
 		Category: Pavement
 		Id: 585
-		Image: Pave04
+		Image: Pave04.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10033,7 +10033,7 @@ Templates:
 	Template@586:
 		Category: Pavement
 		Id: 586
-		Image: Pave05
+		Image: Pave05.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10051,7 +10051,7 @@ Templates:
 	Template@587:
 		Category: Pavement
 		Id: 587
-		Image: Pave06
+		Image: Pave06.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10069,7 +10069,7 @@ Templates:
 	Template@588:
 		Category: Pavement
 		Id: 588
-		Image: Pave07
+		Image: Pave07.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10087,7 +10087,7 @@ Templates:
 	Template@589:
 		Category: Pavement
 		Id: 589
-		Image: Pave08
+		Image: Pave08.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10105,7 +10105,7 @@ Templates:
 	Template@590:
 		Category: Pavement
 		Id: 590
-		Image: Pave09
+		Image: Pave09.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10123,7 +10123,7 @@ Templates:
 	Template@591:
 		Category: Pavement
 		Id: 591
-		Image: Pave10
+		Image: Pave10.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10141,7 +10141,7 @@ Templates:
 	Template@592:
 		Category: Pavement
 		Id: 592
-		Image: Pave11
+		Image: Pave11.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10159,7 +10159,7 @@ Templates:
 	Template@593:
 		Category: Pavement
 		Id: 593
-		Image: Pave12
+		Image: Pave12.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10177,7 +10177,7 @@ Templates:
 	Template@594:
 		Category: Pavement
 		Id: 594
-		Image: Pave13
+		Image: Pave13.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10195,7 +10195,7 @@ Templates:
 	Template@595:
 		Category: Pavement
 		Id: 595
-		Image: Pave14
+		Image: Pave14.tem
 		Size: 2, 2
 		Tiles:
 			0: Road
@@ -10213,7 +10213,7 @@ Templates:
 	Template@596:
 		Category: Pavement/Clear LAT
 		Id: 596
-		Image: plat01
+		Image: plat01.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10222,7 +10222,7 @@ Templates:
 	Template@597:
 		Category: Pavement/Clear LAT
 		Id: 597
-		Image: plat02
+		Image: plat02.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10231,7 +10231,7 @@ Templates:
 	Template@598:
 		Category: Pavement/Clear LAT
 		Id: 598
-		Image: plat03
+		Image: plat03.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10240,7 +10240,7 @@ Templates:
 	Template@599:
 		Category: Pavement/Clear LAT
 		Id: 599
-		Image: plat04
+		Image: plat04.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10249,7 +10249,7 @@ Templates:
 	Template@600:
 		Category: Pavement/Clear LAT
 		Id: 600
-		Image: plat05
+		Image: plat05.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10258,7 +10258,7 @@ Templates:
 	Template@601:
 		Category: Pavement/Clear LAT
 		Id: 601
-		Image: plat06
+		Image: plat06.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10267,7 +10267,7 @@ Templates:
 	Template@602:
 		Category: Pavement/Clear LAT
 		Id: 602
-		Image: plat07
+		Image: plat07.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10276,7 +10276,7 @@ Templates:
 	Template@603:
 		Category: Pavement/Clear LAT
 		Id: 603
-		Image: plat08
+		Image: plat08.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10285,7 +10285,7 @@ Templates:
 	Template@604:
 		Category: Pavement/Clear LAT
 		Id: 604
-		Image: plat09
+		Image: plat09.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10294,7 +10294,7 @@ Templates:
 	Template@605:
 		Category: Pavement/Clear LAT
 		Id: 605
-		Image: plat10
+		Image: plat10.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10303,7 +10303,7 @@ Templates:
 	Template@606:
 		Category: Pavement/Clear LAT
 		Id: 606
-		Image: plat11
+		Image: plat11.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10312,7 +10312,7 @@ Templates:
 	Template@607:
 		Category: Pavement/Clear LAT
 		Id: 607
-		Image: plat12
+		Image: plat12.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10321,7 +10321,7 @@ Templates:
 	Template@608:
 		Category: Pavement/Clear LAT
 		Id: 608
-		Image: plat13
+		Image: plat13.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10330,7 +10330,7 @@ Templates:
 	Template@609:
 		Category: Pavement/Clear LAT
 		Id: 609
-		Image: plat14
+		Image: plat14.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10339,7 +10339,7 @@ Templates:
 	Template@610:
 		Category: Pavement/Clear LAT
 		Id: 610
-		Image: plat15
+		Image: plat15.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10348,7 +10348,7 @@ Templates:
 	Template@611:
 		Category: Pavement/Clear LAT
 		Id: 611
-		Image: plat16
+		Image: plat16.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10357,7 +10357,7 @@ Templates:
 	Template@612:
 		Category: Paved road bits
 		Id: 612
-		Image: proadc01
+		Image: proadc01.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10366,7 +10366,7 @@ Templates:
 	Template@613:
 		Category: Paved road bits
 		Id: 613
-		Image: proadc02
+		Image: proadc02.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10375,7 +10375,7 @@ Templates:
 	Template@614:
 		Category: Paved road bits
 		Id: 614
-		Image: proadc03
+		Image: proadc03.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10384,7 +10384,7 @@ Templates:
 	Template@615:
 		Category: Paved road bits
 		Id: 615
-		Image: proadc04
+		Image: proadc04.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10393,7 +10393,7 @@ Templates:
 	Template@616:
 		Category: Paved road bits
 		Id: 616
-		Image: proadc05
+		Image: proadc05.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10402,7 +10402,7 @@ Templates:
 	Template@617:
 		Category: Paved road bits
 		Id: 617
-		Image: proadc06
+		Image: proadc06.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10411,7 +10411,7 @@ Templates:
 	Template@618:
 		Category: Paved road bits
 		Id: 618
-		Image: proadc07
+		Image: proadc07.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10420,7 +10420,7 @@ Templates:
 	Template@619:
 		Category: Paved road bits
 		Id: 619
-		Image: proadc08
+		Image: proadc08.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10429,7 +10429,7 @@ Templates:
 	Template@620:
 		Category: Paved road bits
 		Id: 620
-		Image: proadc09
+		Image: proadc09.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10438,7 +10438,7 @@ Templates:
 	Template@621:
 		Category: Paved road bits
 		Id: 621
-		Image: proadc10
+		Image: proadc10.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10447,7 +10447,7 @@ Templates:
 	Template@622:
 		Category: Paved road bits
 		Id: 622
-		Image: proadc11
+		Image: proadc11.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10456,7 +10456,7 @@ Templates:
 	Template@623:
 		Category: Paved road bits
 		Id: 623
-		Image: proadc12
+		Image: proadc12.tem
 		Size: 1, 1
 		Tiles:
 			0: DirtRoad
@@ -10465,7 +10465,7 @@ Templates:
 	Template@624:
 		Category: Paved road bits
 		Id: 624
-		Image: proadc13
+		Image: proadc13.tem
 		Size: 1, 3
 		Tiles:
 			0: Road
@@ -10480,7 +10480,7 @@ Templates:
 	Template@625:
 		Category: Paved road bits
 		Id: 625
-		Image: proadc14
+		Image: proadc14.tem
 		Size: 3, 1
 		Tiles:
 			0: Road
@@ -10495,7 +10495,7 @@ Templates:
 	Template@626:
 		Category: Green
 		Id: 626
-		Image: Green01
+		Image: Green01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10504,7 +10504,7 @@ Templates:
 	Template@627:
 		Category: Green/Clear LAT
 		Id: 627
-		Image: glat01
+		Image: glat01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10513,7 +10513,7 @@ Templates:
 	Template@628:
 		Category: Green/Clear LAT
 		Id: 628
-		Image: glat02
+		Image: glat02.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10522,7 +10522,7 @@ Templates:
 	Template@629:
 		Category: Green/Clear LAT
 		Id: 629
-		Image: glat03
+		Image: glat03.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10531,7 +10531,7 @@ Templates:
 	Template@630:
 		Category: Green/Clear LAT
 		Id: 630
-		Image: glat04
+		Image: glat04.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10540,7 +10540,7 @@ Templates:
 	Template@631:
 		Category: Green/Clear LAT
 		Id: 631
-		Image: glat05
+		Image: glat05.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10549,7 +10549,7 @@ Templates:
 	Template@632:
 		Category: Green/Clear LAT
 		Id: 632
-		Image: glat06
+		Image: glat06.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10558,7 +10558,7 @@ Templates:
 	Template@633:
 		Category: Green/Clear LAT
 		Id: 633
-		Image: glat07
+		Image: glat07.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10567,7 +10567,7 @@ Templates:
 	Template@634:
 		Category: Green/Clear LAT
 		Id: 634
-		Image: glat08
+		Image: glat08.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10576,7 +10576,7 @@ Templates:
 	Template@635:
 		Category: Green/Clear LAT
 		Id: 635
-		Image: glat09
+		Image: glat09.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10585,7 +10585,7 @@ Templates:
 	Template@636:
 		Category: Green/Clear LAT
 		Id: 636
-		Image: glat10
+		Image: glat10.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10594,7 +10594,7 @@ Templates:
 	Template@637:
 		Category: Green/Clear LAT
 		Id: 637
-		Image: glat11
+		Image: glat11.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10603,7 +10603,7 @@ Templates:
 	Template@638:
 		Category: Green/Clear LAT
 		Id: 638
-		Image: glat12
+		Image: glat12.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10612,7 +10612,7 @@ Templates:
 	Template@639:
 		Category: Green/Clear LAT
 		Id: 639
-		Image: glat13
+		Image: glat13.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10621,7 +10621,7 @@ Templates:
 	Template@640:
 		Category: Green/Clear LAT
 		Id: 640
-		Image: glat14
+		Image: glat14.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10630,7 +10630,7 @@ Templates:
 	Template@641:
 		Category: Green/Clear LAT
 		Id: 641
-		Image: glat15
+		Image: glat15.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10639,7 +10639,7 @@ Templates:
 	Template@642:
 		Category: Green/Clear LAT
 		Id: 642
-		Image: glat16
+		Image: glat16.tem
 		Size: 1, 1
 		Tiles:
 			0: Rough
@@ -10648,7 +10648,7 @@ Templates:
 	Template@643:
 		Category: Ramp edge fixup
 		Id: 643
-		Image: Rmpfx01
+		Image: Rmpfx01.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10658,7 +10658,7 @@ Templates:
 	Template@644:
 		Category: Ramp edge fixup
 		Id: 644
-		Image: Rmpfx02
+		Image: Rmpfx02.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10668,7 +10668,7 @@ Templates:
 	Template@645:
 		Category: Ramp edge fixup
 		Id: 645
-		Image: Rmpfx03
+		Image: Rmpfx03.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10678,7 +10678,7 @@ Templates:
 	Template@646:
 		Category: Ramp edge fixup
 		Id: 646
-		Image: Rmpfx04
+		Image: Rmpfx04.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10688,7 +10688,7 @@ Templates:
 	Template@647:
 		Category: Ramp edge fixup
 		Id: 647
-		Image: Rmpfx05
+		Image: Rmpfx05.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10698,7 +10698,7 @@ Templates:
 	Template@648:
 		Category: Ramp edge fixup
 		Id: 648
-		Image: Rmpfx06
+		Image: Rmpfx06.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10708,7 +10708,7 @@ Templates:
 	Template@649:
 		Category: Ramp edge fixup
 		Id: 649
-		Image: Rmpfx07
+		Image: Rmpfx07.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10718,7 +10718,7 @@ Templates:
 	Template@650:
 		Category: Ramp edge fixup
 		Id: 650
-		Image: Rmpfx08
+		Image: Rmpfx08.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10728,7 +10728,7 @@ Templates:
 	Template@651:
 		Category: Ramp edge fixup
 		Id: 651
-		Image: Rmpfx09
+		Image: Rmpfx09.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10738,7 +10738,7 @@ Templates:
 	Template@652:
 		Category: Ramp edge fixup
 		Id: 652
-		Image: Rmpfx10
+		Image: Rmpfx10.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10748,7 +10748,7 @@ Templates:
 	Template@653:
 		Category: Ramp edge fixup
 		Id: 653
-		Image: Rmpfx11
+		Image: Rmpfx11.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10758,7 +10758,7 @@ Templates:
 	Template@654:
 		Category: Ramp edge fixup
 		Id: 654
-		Image: Rmpfx12
+		Image: Rmpfx12.tem
 		Size: 1, 1
 		Tiles:
 			0: Clear
@@ -10768,7 +10768,7 @@ Templates:
 	Template@667:
 		Category: Water slopes
 		Id: 667
-		Image: WSLOPE01
+		Image: WSLOPE01.tem
 		Size: 1, 4
 		Tiles:
 			0: Cliff
@@ -10790,7 +10790,7 @@ Templates:
 	Template@668:
 		Category: Water slopes
 		Id: 668
-		Image: WSLOPE02
+		Image: WSLOPE02.tem
 		Size: 4, 1
 		Tiles:
 			0: Cliff
@@ -10812,7 +10812,7 @@ Templates:
 	Template@669:
 		Category: Water slopes
 		Id: 669
-		Image: WSLOPE03
+		Image: WSLOPE03.tem
 		Size: 1, 4
 		Tiles:
 			0: Cliff
@@ -10834,7 +10834,7 @@ Templates:
 	Template@670:
 		Category: Water slopes
 		Id: 670
-		Image: WSLOPE04
+		Image: WSLOPE04.tem
 		Size: 4, 1
 		Tiles:
 			0: Cliff
@@ -10856,7 +10856,7 @@ Templates:
 	Template@671:
 		Category: Pavement (Use for LAT)
 		Id: 671
-		Image: Pvclr01
+		Image: Pvclr01.tem
 		Size: 1, 1
 		Tiles:
 			0: Road
@@ -10865,7 +10865,7 @@ Templates:
 	Template@672:
 		Category: Paved Road Slopes
 		Id: 672
-		Image: Prslpe01
+		Image: Prslpe01.tem
 		Size: 1, 3
 		Tiles:
 			0: Road
@@ -10883,7 +10883,7 @@ Templates:
 	Template@673:
 		Category: Paved Road Slopes
 		Id: 673
-		Image: Prslpe02
+		Image: Prslpe02.tem
 		Size: 3, 1
 		Tiles:
 			0: Road
@@ -10901,7 +10901,7 @@ Templates:
 	Template@674:
 		Category: Paved Road Slopes
 		Id: 674
-		Image: Prslpe03
+		Image: Prslpe03.tem
 		Size: 1, 3
 		Tiles:
 			0: Road
@@ -10919,7 +10919,7 @@ Templates:
 	Template@675:
 		Category: Paved Road Slopes
 		Id: 675
-		Image: Prslpe04
+		Image: Prslpe04.tem
 		Size: 3, 1
 		Tiles:
 			0: DirtRoad
@@ -10937,7 +10937,7 @@ Templates:
 	Template@676:
 		Category: Monorail Slopes
 		Id: 676
-		Image: Tslope01
+		Image: Tslope01.tem
 		Size: 1, 1
 		Tiles:
 			0: Rail
@@ -10947,7 +10947,7 @@ Templates:
 	Template@677:
 		Category: Monorail Slopes
 		Id: 677
-		Image: Tslope02
+		Image: Tslope02.tem
 		Size: 1, 1
 		Tiles:
 			0: Rail
@@ -10957,7 +10957,7 @@ Templates:
 	Template@678:
 		Category: Monorail Slopes
 		Id: 678
-		Image: Tslope03
+		Image: Tslope03.tem
 		Size: 1, 1
 		Tiles:
 			0: Rail
@@ -10967,7 +10967,7 @@ Templates:
 	Template@679:
 		Category: Monorail Slopes
 		Id: 679
-		Image: Tslope04
+		Image: Tslope04.tem
 		Size: 1, 1
 		Tiles:
 			0: Rail
@@ -10977,7 +10977,7 @@ Templates:
 	Template@680:
 		Category: Waterfalls-B
 		Id: 680
-		Image: W-b-01
+		Image: W-b-01.tem
 		Size: 4, 2
 		Tiles:
 			0: Cliff
@@ -11011,7 +11011,7 @@ Templates:
 	Template@681:
 		Category: Waterfalls-B
 		Id: 681
-		Image: W-b-02
+		Image: W-b-02.tem
 		Size: 4, 1
 		Tiles:
 			0: Cliff
@@ -11031,7 +11031,7 @@ Templates:
 	Template@682:
 		Category: Waterfalls-B
 		Id: 682
-		Image: W-b-03
+		Image: W-b-03.tem
 		Size: 4, 2
 		Tiles:
 			0: Cliff
@@ -11065,7 +11065,7 @@ Templates:
 	Template@683:
 		Category: Waterfalls-B
 		Id: 683
-		Image: W-b-04
+		Image: W-b-04.tem
 		Size: 4, 2
 		Tiles:
 			0: Cliff
@@ -11099,7 +11099,7 @@ Templates:
 	Template@684:
 		Category: Waterfalls-C
 		Id: 684
-		Image: W-c-01
+		Image: W-c-01.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11117,7 +11117,7 @@ Templates:
 	Template@685:
 		Category: Waterfalls-C
 		Id: 685
-		Image: W-c-02
+		Image: W-c-02.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -11127,7 +11127,7 @@ Templates:
 	Template@686:
 		Category: Waterfalls-C
 		Id: 686
-		Image: W-c-03
+		Image: W-c-03.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -11141,7 +11141,7 @@ Templates:
 	Template@687:
 		Category: Waterfalls-C
 		Id: 687
-		Image: W-c-04
+		Image: W-c-04.tem
 		Size: 2, 2
 		Tiles:
 			1: Cliff
@@ -11159,7 +11159,7 @@ Templates:
 	Template@688:
 		Category: Waterfalls-D
 		Id: 688
-		Image: W-d-01
+		Image: W-d-01.tem
 		Size: 2, 2
 		Tiles:
 			1: Cliff
@@ -11177,7 +11177,7 @@ Templates:
 	Template@689:
 		Category: Waterfalls-D
 		Id: 689
-		Image: W-d-02
+		Image: W-d-02.tem
 		Size: 1, 1
 		Tiles:
 			0: Cliff
@@ -11187,7 +11187,7 @@ Templates:
 	Template@690:
 		Category: Waterfalls-D
 		Id: 690
-		Image: W-d-03
+		Image: W-d-03.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -11201,7 +11201,7 @@ Templates:
 	Template@691:
 		Category: Waterfalls-D
 		Id: 691
-		Image: W-d-04
+		Image: W-d-04.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11219,7 +11219,7 @@ Templates:
 	Template@707:
 		Category: Tunnel Floor
 		Id: 707
-		Image: tunnel01
+		Image: tunnel01.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -11270,7 +11270,7 @@ Templates:
 	Template@708:
 		Category: Tunnel Floor
 		Id: 708
-		Image: tunnel02
+		Image: tunnel02.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -11321,7 +11321,7 @@ Templates:
 	Template@709:
 		Category: Tunnel Floor
 		Id: 709
-		Image: tunnel03
+		Image: tunnel03.tem
 		Size: 3, 4
 		Tiles:
 			0: Cliff
@@ -11363,7 +11363,7 @@ Templates:
 	Template@710:
 		Category: Tunnel Floor
 		Id: 710
-		Image: tunnel04
+		Image: tunnel04.tem
 		Size: 4, 3
 		Tiles:
 			0: Cliff
@@ -11405,7 +11405,7 @@ Templates:
 	Template@711:
 		Category: Tunnel Side
 		Id: 711
-		Image: tunnex01
+		Image: tunnex01.tem
 		Size: 3, 1
 		Tiles:
 			0: Cliff
@@ -11421,7 +11421,7 @@ Templates:
 	Template@712:
 		Category: Tunnel Side
 		Id: 712
-		Image: tunnex02
+		Image: tunnex02.tem
 		Size: 1, 3
 		Tiles:
 			0: Cliff
@@ -11437,7 +11437,7 @@ Templates:
 	Template@713:
 		Category: TrackTunnel Floor
 		Id: 713
-		Image: tunnet01
+		Image: tunnet01.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -11488,7 +11488,7 @@ Templates:
 	Template@714:
 		Category: TrackTunnel Floor
 		Id: 714
-		Image: tunnet02
+		Image: tunnet02.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -11539,7 +11539,7 @@ Templates:
 	Template@715:
 		Category: TrackTunnel Floor
 		Id: 715
-		Image: tunnet03
+		Image: tunnet03.tem
 		Size: 3, 4
 		Tiles:
 			0: Cliff
@@ -11581,7 +11581,7 @@ Templates:
 	Template@716:
 		Category: TrackTunnel Floor
 		Id: 716
-		Image: tunnet04
+		Image: tunnet04.tem
 		Size: 4, 3
 		Tiles:
 			0: Cliff
@@ -11623,7 +11623,7 @@ Templates:
 	Template@717:
 		Category: Destroyable Cliffs
 		Id: 717
-		Image: dcliff01
+		Image: dcliff01.tem
 		Size: 6, 4
 		Tiles:
 			1: Cliff
@@ -11699,7 +11699,7 @@ Templates:
 	Template@718:
 		Category: Destroyable Cliffs
 		Id: 718
-		Image: dcliff02
+		Image: dcliff02.tem
 		Size: 4, 6
 		Tiles:
 			1: Cliff
@@ -11775,7 +11775,7 @@ Templates:
 	Template@719:
 		Category: Water Caves
 		Id: 719
-		Image: Wcave01
+		Image: Wcave01.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11795,7 +11795,7 @@ Templates:
 	Template@720:
 		Category: Water Caves
 		Id: 720
-		Image: Wcave02
+		Image: Wcave02.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11815,7 +11815,7 @@ Templates:
 	Template@721:
 		Category: Water Caves
 		Id: 721
-		Image: Wcave03
+		Image: Wcave03.tem
 		Size: 1, 2
 		Tiles:
 			0: Cliff
@@ -11828,7 +11828,7 @@ Templates:
 	Template@722:
 		Category: Water Caves
 		Id: 722
-		Image: Wcave04
+		Image: Wcave04.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11848,7 +11848,7 @@ Templates:
 	Template@723:
 		Category: Water Caves
 		Id: 723
-		Image: Wcave05
+		Image: Wcave05.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11868,7 +11868,7 @@ Templates:
 	Template@724:
 		Category: Water Caves
 		Id: 724
-		Image: Wcave06
+		Image: Wcave06.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11888,7 +11888,7 @@ Templates:
 	Template@725:
 		Category: Water Caves
 		Id: 725
-		Image: Wcave07
+		Image: Wcave07.tem
 		Size: 2, 1
 		Tiles:
 			0: Cliff
@@ -11901,7 +11901,7 @@ Templates:
 	Template@726:
 		Category: Water Caves
 		Id: 726
-		Image: Wcave08
+		Image: Wcave08.tem
 		Size: 2, 2
 		Tiles:
 			0: Cliff
@@ -11921,7 +11921,7 @@ Templates:
 	Template@940:
 		Category: Scrin Wreckage
 		Id: 940
-		Image: Scrin01
+		Image: Scrin01.tem
 		Size: 6, 7
 		Tiles:
 			2: Clear
@@ -12025,7 +12025,7 @@ Templates:
 	Template@941:
 		Category: Scrin Wreckage
 		Id: 941
-		Image: Scrin02
+		Image: Scrin02.tem
 		Size: 5, 5
 		Tiles:
 			1: Clear
@@ -12085,7 +12085,7 @@ Templates:
 	Template@942:
 		Category: Scrin Wreckage
 		Id: 942
-		Image: Scrin03
+		Image: Scrin03.tem
 		Size: 9, 8
 		Tiles:
 			0: DirtRoad
@@ -12235,7 +12235,7 @@ Templates:
 	Template@943:
 		Category: Scrin Wreckage
 		Id: 943
-		Image: Scrin04
+		Image: Scrin04.tem
 		Size: 8, 6
 		Tiles:
 			0: Rough
@@ -12265,7 +12265,7 @@ Templates:
 	Template@944:
 		Category: Scrin Wreckage
 		Id: 944
-		Image: Scrin05
+		Image: Scrin05.tem
 		Size: 8, 6
 		Tiles:
 			2: Clear
@@ -12382,7 +12382,7 @@ Templates:
 	Template@945:
 		Category: Scrin Wreckage
 		Id: 945
-		Image: Scrin06
+		Image: Scrin06.tem
 		Size: 7, 10
 		Tiles:
 			0: Cliff
@@ -12529,7 +12529,7 @@ Templates:
 	Template@952:
 		Category: DirtTrackTunnel Floor
 		Id: 952
-		Image: dtunnt01
+		Image: dtunnt01.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -12580,7 +12580,7 @@ Templates:
 	Template@953:
 		Category: DirtTrackTunnel Floor
 		Id: 953
-		Image: dtunnt02
+		Image: dtunnt02.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -12631,7 +12631,7 @@ Templates:
 	Template@954:
 		Category: DirtTrackTunnel Floor
 		Id: 954
-		Image: dtunnt03
+		Image: dtunnt03.tem
 		Size: 3, 4
 		Tiles:
 			0: Cliff
@@ -12673,7 +12673,7 @@ Templates:
 	Template@955:
 		Category: DirtTrackTunnel Floor
 		Id: 955
-		Image: dtunnt04
+		Image: dtunnt04.tem
 		Size: 4, 3
 		Tiles:
 			0: Cliff
@@ -12715,7 +12715,7 @@ Templates:
 	Template@956:
 		Category: DirtTunnel Floor
 		Id: 956
-		Image: dtunn01
+		Image: dtunn01.tem
 		Size: 3, 5
 		Tiles:
 			0: Cliff
@@ -12766,7 +12766,7 @@ Templates:
 	Template@957:
 		Category: DirtTunnel Floor
 		Id: 957
-		Image: dtunn02
+		Image: dtunn02.tem
 		Size: 5, 3
 		Tiles:
 			0: Cliff
@@ -12817,7 +12817,7 @@ Templates:
 	Template@958:
 		Category: DirtTunnel Floor
 		Id: 958
-		Image: dtunn03
+		Image: dtunn03.tem
 		Size: 3, 4
 		Tiles:
 			0: Cliff
@@ -12859,7 +12859,7 @@ Templates:
 	Template@959:
 		Category: DirtTunnel Floor
 		Id: 959
-		Image: dtunn04
+		Image: dtunn04.tem
 		Size: 4, 3
 		Tiles:
 			0: Cliff


### PR DESCRIPTION
Extends #7707 to TS, and updates the tileset importer to use the correct terrain types and yaml keys.
