### PR TITLE
Disable legacy sequence parsing in D2K.

### DIFF
--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -1,27 +1,27 @@
 carryall:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1923
 		Facings: -32
-	unload: DATA
+	unload: DATA.R8
 		Start: 1923
 		Facings: -32
-	icon: DATA
+	icon: DATA.R8
 		Start: 4029
 		Offset: -30,-24
 
 
 orni:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1955
 		Facings: -32
 		Length: 3
 		Tick: 120
 		Transpose: true
-	icon: DATA
+	icon: DATA.R8
 		Start: 4031
 		Offset: -30,-24
 
 frigate:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2517
 		Facings: 1

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -1,463 +1,463 @@
 rifle:
-	stand: DATA
+	stand: DATA.R8
 		Start: 206
 		Facings: -8
 		Transpose: true
-	run: DATA
+	run: DATA.R8
 		Start: 214
 		Length: 6
 		Facings: -8
 		Tick: 110
 		Transpose: true
-	shoot: DATA
+	shoot: DATA.R8
 		Start: 254
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA
+	prone-stand: DATA.R8
 		Start: 302
 		Facings: -8
 		Transpose: true
-	prone-run: DATA
+	prone-run: DATA.R8
 		Start: 310
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 110
-	standup-0: DATA
+	standup-0: DATA.R8
 		Start: 302
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-shoot: DATA
+	prone-shoot: DATA.R8
 		Start: 334
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA
+	die1: DATA.R8
 		Frames: 382, 389, 396, 403, 410, 417, 424, 431, 438, 439, 440, 441
 		Length: 12
 		Tick: 80
-	die2: DATA
+	die2: DATA.R8
 		Frames: 383, 390, 397, 404, 411, 418, 425, 432
 		Length: 8
 		Tick: 80
-	die3: DATA
+	die3: DATA.R8
 		Frames: 384, 391, 398, 405, 412, 419, 426, 433
 		Length: 8
 		Tick: 80
-	die4: DATA
+	die4: DATA.R8
 		Frames: 385, 392, 399, 406, 413, 420, 427, 434
 		Length: 8
 		Tick: 80
-	die-crushed: DATA
+	die-crushed: DATA.R8
 		Frames: 386, 393, 400, 407, 414, 421, 428, 435
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA
+	icon: DATA.R8
 		Start: 4011
 		Offset: -30,-24
 
 bazooka:
-	stand: DATA
+	stand: DATA.R8
 		Start: 458
 		Facings: -8
 		Transpose: true
-	run: DATA
+	run: DATA.R8
 		Start: 466
 		Length: 6
 		Facings: -8
 		Tick: 120
 		Transpose: true
-	shoot: DATA
+	shoot: DATA.R8
 		Start: 506
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA
+	prone-stand: DATA.R8
 		Start: 562
 		Length: 1
 		Facings: -8
 		Transpose: true
-	prone-run: DATA
+	prone-run: DATA.R8
 		Start: 570
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA
+	standup-0: DATA.R8
 		Start: 554
 		Length: 1
 		Facings: -8
 		Transpose: true
-	prone-shoot: DATA
+	prone-shoot: DATA.R8
 		Start: 586
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA
+	die1: DATA.R8
 		Frames: 634, 641, 648, 655, 662, 669, 676, 683, 690, 691, 692, 693
 		Length: 12
 		Tick: 80
-	die2: DATA
+	die2: DATA.R8
 		Frames: 635, 642, 649, 656, 663, 670, 677, 684
 		Length: 8
 		Tick: 80
-	die3: DATA
+	die3: DATA.R8
 		Frames: 636, 643, 650, 657, 664, 671, 678, 685
 		Length: 8
 		Tick: 80
-	die4: DATA
+	die4: DATA.R8
 		Frames: 637, 644, 651, 658, 665, 672, 679, 686
 		Length: 8
 		Tick: 80
-	die-crushed: DATA
+	die-crushed: DATA.R8
 		Frames: 638, 645, 652, 659, 666, 673, 680, 687
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA
+	icon: DATA.R8
 		Start: 4012
 		Offset: -30,-24
 
 engineer:
-	stand: DATA
+	stand: DATA.R8
 		Start: 1166
 		Facings: -8
 		Transpose: true
-	run: DATA
+	run: DATA.R8
 		Start: 1174
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	die1: DATA
+	die1: DATA.R8
 		Frames: 1342, 1349, 1356, 1363, 1370, 1377, 1384, 1391, 1398, 1399, 1400, 1401
 		Length: 12
 		Tick: 80
-	die2: DATA
+	die2: DATA.R8
 		Frames: 1343, 1350, 1357, 1364, 1371, 1378, 1385, 1392
 		Length: 8
 		Tick: 80
-	die3: DATA
+	die3: DATA.R8
 		Frames: 1344, 1351, 1358, 1365, 1372, 1379, 1386, 1393
 		Length: 8
 		Tick: 80
-	die4: DATA
+	die4: DATA.R8
 		Frames: 1345, 1352, 1359, 1366, 1373, 1380, 1387, 1394
 		Length: 8
 		Tick: 80
-	die-crushed: DATA
+	die-crushed: DATA.R8
 		Frames: 1346, 1353, 1360, 1367, 1374, 1381, 1388, 1395
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA
+	icon: DATA.R8
 		Start: 4013
 		Offset: -30,-24
 
 medic: # actually thumper
-	stand: DATA
+	stand: DATA.R8
 		Start: 1402
 		Facings: -8
 		Transpose: true
-	run: DATA
+	run: DATA.R8
 		Start: 1410
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	heal: DATA
+	heal: DATA.R8
 		Start: 1458
 		Length: 5
 		Tick: 480
-	die1: DATA
+	die1: DATA.R8
 		Frames: 1543, 1550, 1557, 1564, 1571, 1578, 1585, 1592, 1599, 1600, 1601, 1602
 		Length: 12
 		Tick: 80
-	die2: DATA
+	die2: DATA.R8
 		Frames: 1544, 1551, 1558, 1565, 1572, 1579, 1586, 1593
 		Length: 8
 		Tick: 80
-	die3: DATA
+	die3: DATA.R8
 		Frames: 1546, 1552, 1559, 1566, 1573, 1580, 1587, 1594
 		Length: 8
 		Tick: 80
-	die4: DATA
+	die4: DATA.R8
 		Frames: 1547, 1553, 1560, 1567, 1574, 1581, 1588, 1595
 		Length: 8
 		Tick: 80
-	die-crushed: DATA
+	die-crushed: DATA.R8
 		Frames: 1548, 1554, 1561, 1568, 1575, 1582, 1589, 1596
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA
+	icon: DATA.R8
 		Start: 4014
 		Offset: -30,-24
 
 thumping:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1458
 		Length: 5
 		Tick: 150
-	make: DATA
+	make: DATA.R8
 		Start: 1458
 		Length: 5
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 1458
 		Length: 5
 		Tick: 150
-	icon: DATA
+	icon: DATA.R8
 		Frames: 4014
 		Offset: -30,-24
 
 fremen:
-	stand: DATA
+	stand: DATA.R8
 		Start: 694
 		Facings: -8
 		Transpose: true
-	run: DATA
+	run: DATA.R8
 		Start: 702
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	shoot: DATA
+	shoot: DATA.R8
 		Start: 742
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA
+	prone-stand: DATA.R8
 		Start: 798
 		Length: 1
 		Facings: -8
 		Transpose: true
-	prone-run: DATA
+	prone-run: DATA.R8
 		Start: 806
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA
+	standup-0: DATA.R8
 		Start: 790
 		Length: 1
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-shoot: DATA
+	prone-shoot: DATA.R8
 		Start: 822
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA
+	die1: DATA.R8
 		Frames: 870, 877, 884, 891, 898, 905, 912, 919, 926, 933, 940, 947
 		Length: 12
 		Tick: 80
-	die2: DATA
+	die2: DATA.R8
 		Frames: 871, 878, 885, 892, 899, 906, 913, 920
 		Length: 8
 		Tick: 80
-	die3: DATA
+	die3: DATA.R8
 		Frames: 872, 879, 886, 893, 900, 907, 914, 921
 		Length: 8
 		Tick: 80
-	die4: DATA
+	die4: DATA.R8
 		Frames: 873, 880, 887, 894, 901, 908, 915, 922
 		Length: 8
 		Tick: 80
-	die-crushed: DATA
+	die-crushed: DATA.R8
 		Frames: 874, 881, 888, 895, 902, 909, 916, 923
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA
+	icon: DATA.R8
 		Start: 4032
 		Offset: -30,-24
 
 saboteur:
-	stand: DATA
+	stand: DATA.R8
 		Start: 2149
 		Facings: -8
 		Transpose: true
-	run: DATA
+	run: DATA.R8
 		Start: 2157
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-stand: DATA
+	prone-stand: DATA.R8
 		Start: 2253
 		Length: 1
 		Facings: -8
 		Transpose: true
-	prone-run: DATA
+	prone-run: DATA.R8
 		Start: 2261
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA
+	standup-0: DATA.R8
 		Start: 2245
 		Length: 1
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	die1: DATA
+	die1: DATA.R8
 		Frames: 2325, 2332, 2339, 2346, 2353, 2360, 2367, 2374, 2381, 2383, 2385, 2387
 		Length: 12
 		Tick: 80
-	die2: DATA
+	die2: DATA.R8
 		Frames: 2326, 2333, 2340, 2347, 2354, 2361, 2368, 2375, 2382, 2384, 2386, 2388
 		Length: 12
 		Tick: 80
-	die3: DATA
+	die3: DATA.R8
 		Frames: 2327, 2334, 2341, 2348, 2355, 2362, 2369, 2376
 		Length: 8
 		Tick: 80
-	die4: DATA
+	die4: DATA.R8
 		Frames: 2328, 2335, 2342, 2349, 2356, 2363, 2370, 2377
 		Length: 8
 		Tick: 80
-	die-crushed: DATA
+	die-crushed: DATA.R8
 		Frames: 2329, 2336, 2343, 2350, 2357, 2364, 2371, 2378
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA
+	icon: DATA.R8
 		Start: 4034
 		Offset: -30,-24
 
 sardaukar:
-	stand: DATA
+	stand: DATA.R8
 		Start: 930
 		Facings: -8
 		Transpose: true
-	run: DATA
+	run: DATA.R8
 		Start: 938
 		Length: 6
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	shoot: DATA
+	shoot: DATA.R8
 		Start: 978
 		Length: 6
 		Facings: -8
 		Transpose: true
-	prone-stand: DATA
+	prone-stand: DATA.R8
 		Start: 1034
 		Length: 1
 		Facings: -8
 		Transpose: true
-	prone-run: DATA
+	prone-run: DATA.R8
 		Start: 1042
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA
+	standup-0: DATA.R8
 		Start: 1026
 		Length: 1
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	prone-shoot: DATA
+	prone-shoot: DATA.R8
 		Start: 1058
 		Length: 6
 		Facings: -8
 		Transpose: true
-	die1: DATA
+	die1: DATA.R8
 		Frames: 1106, 1113, 1120, 1127, 1134, 1141, 1148, 1155, 1162, 1163, 1164, 1165
 		Length: 12
 		Tick: 80
-	die2: DATA
+	die2: DATA.R8
 		Frames: 1107, 1114, 1121, 1128, 1135, 1142, 1149, 1156
 		Length: 8
 		Tick: 80
-	die3: DATA
+	die3: DATA.R8
 		Frames: 1108, 1115, 1122, 1129, 1136, 1143, 1150, 1157
 		Length: 8
 		Tick: 80
-	die4: DATA
+	die4: DATA.R8
 		Frames: 1109, 1116, 1123, 1130, 1137, 1144, 1151, 1158
 		Length: 8
 		Tick: 80
-	die-crushed: DATA
+	die-crushed: DATA.R8
 		Frames: 1110, 1117, 1124, 1131, 1138, 1145, 1152, 1159
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	icon: DATA
+	icon: DATA.R8
 		Start: 4015
 		Offset: -30,-24
 
 grenadier: # 2502 - 2749 in 1.06 DATA.R8
-	stand:
+	stand: grenadier.shp
 		Start: 0
 		Facings: 8
-	idle:
+	idle: grenadier.shp
 		Start: 203
 		Length: 16
-	run:
+	run: grenadier.shp
 		Start: 8
 		Length: 6
 		Facings: 8
 		Tick: 120
-	shoot:
+	shoot: grenadier.shp
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 120
-	die1:
+	die1: grenadier.shp
 		Start: 176
 		Length: 19
-	die2:
+	die2: grenadier.shp
 		Start: 176
 		Length: 19
-	die3:
+	die3: grenadier.shp
 		Start: 176
 		Length: 19
-	die4:
+	die4: grenadier.shp
 		Start: 176
 		Length: 19
-	die-crushed:
+	die-crushed: grenadier.shp
 		Start: 195
 		Length: 8
 		Tick: 800
 		ZOffset: -511
-	prone-stand:
+	prone-stand: grenadier.shp
 		Start: 104
 		Length: 4
 		Facings: 8
-	prone-run:
+	prone-run: grenadier.shp
 		Start: 104
 		Length: 4
 		Facings: 8
 		Tick: 120
-	prone-shoot:
+	prone-shoot: grenadier.shp
 		Start: 136
 		Length: 5
 		Facings: 8
 		Tick: 120
-	icon: grenadiericon
+	icon: grenadiericon.shp
 		Start: 0 # 4281 in 1.06 DATA.R8
 
 sandworm:
-	mouth: DATA
+	mouth: DATA.R8
 		Start: 3549
 		Length: 15
 		Tick: 100
-	sand: DATA
+	sand: DATA.R8
 		Start: 3565
 		Length: 20
 		Tick: 100
-	idle: DATA
+	idle: DATA.R8
 		Start: 3586
 		Length: 35
 		Tick: 180
 		BlendMode: Additive
-	burrowed: DATA
+	burrowed: DATA.R8
 		Start: 39
-	icon: wormicon
+	icon: wormicon.shp
 		Start: 0

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -1,226 +1,226 @@
 explosion:
-	piff: DATA
+	piff: DATA.R8
 		Start: 3626
 		Length: 5
-	piffs: DATA
+	piffs: DATA.R8
 		Start: 3429
 		Length: 4
 		Tick: 80
 		BlendMode: Additive
-	small_explosion: DATA
+	small_explosion: DATA.R8
 		Start: 3403
 		Length: 15
 		BlendMode: Additive
-	med_explosion: DATA
+	med_explosion: DATA.R8
 		Start: 3390
 		Length: 12
 		BlendMode: Additive
-	tiny_explosion: DATA
+	tiny_explosion: DATA.R8
 		Start: 3386
 		Length: 4
 		Tick: 80
 		BlendMode: Additive
-	nuke: DATA
+	nuke: DATA.R8
 		Start: 3965
 		Length: 14
 		Tick: 60
 		BlendMode: Additive
-	mini_explosion: DATA
+	mini_explosion: DATA.R8
 		Start: 3403
 		Length: 15
 		Tick: 60
 		BlendMode: Additive
-	self_destruct: DATA
+	self_destruct: DATA.R8
 		Start: 3433
 		Length: 15
 		BlendMode: Additive
-	building: DATA
+	building: DATA.R8
 		Start: 3448
 		Length: 22
 		BlendMode: Additive
-	large_explosion: DATA
+	large_explosion: DATA.R8
 		Start: 3988
 		Length: 22
 		BlendMode: Additive
-	artillery: DATA
+	artillery: DATA.R8
 		Start: 3988
 		Length: 22
 		BlendMode: Additive
-	small_artillery: DATA
+	small_artillery: DATA.R8
 		Start: 3390
 		Length: 12
 		Tick: 60
 		BlendMode: Additive
-	small_napalm: DATA
+	small_napalm: DATA.R8
 		Start: 3421
 		Length: 8
 		BlendMode: Additive
-	shockwave: DATA
+	shockwave: DATA.R8
 		Start: 3687
 		Length: 6
 		BlendMode: Additive
 		Tick: 120
-	deviator: DATA
+	deviator: DATA.R8
 		Start: 3512
 		Length: 23
 		BlendMode: Additive
 		Tick: 60
-	corpse: DATA
+	corpse: DATA.R8
 		Start: 430
 		Length: 12
 		Tick: 1600
 
 laserfire:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3386
 		Length: 4
 		Tick: 80
 		BlendMode: Additive
 
 pips:
-	groups: DATA
+	groups: DATA.R8
 		Start: 17
 		Length: 10
-	tag-primary: DATA
+	tag-primary: DATA.R8
 		Start: 110
-	pip-empty: DATA
+	pip-empty: DATA.R8
 		Start: 15
-	pip-green: DATA
+	pip-green: DATA.R8
 		Start: 16
 
 clock:
-	idle:
+	idle: clock.shp
 		Start: 0
 		Length: *
 
 powerdown:
-	disabled: speed
+	disabled: speed.shp
 		Start: 3
 
 poweroff:
-	offline:
+	offline: poweroff.shp
 		Start: 0
 		Length: *
 		Tick: 160
 
 rank:
-	rank:
+	rank: rank.shp
 		Start: 0
 		Length: *
 
 overlay:
-	build-valid-arrakis: DATA
+	build-valid-arrakis: DATA.R8
 		Start: 0
 		Offset: -16,-16
-	build-invalid: DATA
+	build-invalid: DATA.R8
 		Start: 1
 		Offset: -16,-16
-	target-select: DATA
+	target-select: DATA.R8
 		Start: 2
 		Offset: -16,-16
-	target-valid-arrakis: DATA
+	target-valid-arrakis: DATA.R8
 		Start: 0
 		Offset: -16,-16
-	target-invalid: DATA
+	target-invalid: DATA.R8
 		Start: 1
 		Offset: -16,-16
 
 rallypoint:
-	flag:flagfly
+	flag: flagfly.shp
 		Start: 0
 		Length: *
 		Offset: 11,-5
-	circles:fpls
+	circles: fpls.shp
 		Start: 0
 		Length: *
 
 beacon:
-	arrow: mouse
+	arrow: mouse.r8
 		Start: 148
 		Offset: -24,-24
-	circles: fpls
+	circles: fpls.shp
 		Start: 0
 		Length: *
 
 rpg:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3015
 		Facings: -32
 
 120mm:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3014
 		Length: 1
 		BlendMode: Additive
 
 155mm:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3081
 		Length: 1
 
 crate-effects:
-	dollar: DATA
+	dollar: DATA.R8
 		Start: 3679
 		Length: 8
-	reveal-map: DATA
+	reveal-map: DATA.R8
 		Start: 3947
 		Length: 18
-	hide-map: DATA
+	hide-map: DATA.R8
 		Frames: 3965, 3964, 3963, 3962, 3961, 3960, 3959, 3958, 3957, 3956, 3955, 3954, 3953, 3952, 3951, 3950, 3949, 3948
 		Length: 18
-	levelup: levelup
+	levelup: levelup.shp
 		Start: 0
 		Length: *
 		Tick: 200
-	cloak: DATA
+	cloak: DATA.R8
 		Start: 3911
 		Lenght: 36
 
 allyrepair:
-	repair: DATA
+	repair: DATA.R8
 		Frames: 3, 39
 		Length: 2
 		Tick: 300
 		Offset: -11,-10
 
 missile:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3088
 		Facings: -32
 
 missile2:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3306
 		Facings: -32
 
 atomic:
-	up: DATA
+	up: DATA.R8
 		Start: 2147
 		Length: 1
-	down: DATA
+	down: DATA.R8
 		Start: 2148
 		Length: 1
 
 fire:
-	1: DATA
+	1: DATA.R8
 		Start: 3712
 		Length: 10
 		Offset: 4,-17
 		ZOffset: 1023
 		BlendMode: Additive
-	2: DATA
+	2: DATA.R8
 		Start: 3723
 		Length: 11
 		Offset: 0,-3
 		ZOffset: 1023
 		BlendMode: Additive
-	3: DATA
+	3: DATA.R8
 		Start: 3885
 		Length: 13
 		Offset: 0,-3
 		ZOffset: 1023
 		BlendMode: Additive
-	4: DATA
+	4: DATA.R8
 		Start: 3712
 		Length: 10
 		Offset: 0,-3
@@ -228,157 +228,149 @@ fire:
 		BlendMode: Additive
 
 smoke_m:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3418
 		Length: 2
 		BlendMode: Additive
-	loop: DATA
+	loop: DATA.R8
 		Start: 3418
 		Length: 2
 		BlendMode: Additive
-	end: DATA
+	end: DATA.R8
 		Start: 3418
 		Length: 3
 		BlendMode: Additive
 
 bombs:
-	open: DATA
+	open: DATA.R8
 		Start: 3280
 		Length: 4
-	idle: DATA
+	idle: DATA.R8
 		Start: 3280
 		Length: 4
-
-parach:
-	open:
-		Start: 0
-		Length: 5
-	idle:
-		Start: 5
-		Length: 11
 
 mpspawn:
-	idle:
+	idle: mpspawn.shp
 		Start: 0
 		Length: *
 
 waypoint:
-	idle:
+	idle: waypoint.shp
 		Start: 0
 		Length: *
 
 wormspawner:
-	idle:
+	idle: wormspawner.shp
 		Start: 0
 		Length: *
 
 sietch:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2998
 		Offset: -32,32
 
 doubleblast:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3279
 		Facings: -16
 		BlendMode: Additive
 
 doubleblastbullet:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3248
 		Facings: -16
 		BlendMode: Additive
 
 icon:
-	paratroopers: DATA
+	paratroopers: DATA.R8
 		Start: 4029
 		Offset: -30,-24
-	ornistrike: DATA
+	ornistrike: DATA.R8
 		Start: 4031
 		Offset: -30,-24
-	deathhand: DATA
+	deathhand: DATA.R8
 		Start: 4035
 		Offset: -30,-24
 
 crate:
-	idle: DATA
+	idle: DATA.R8
 		Start: 102
 		ZOffset: -511
 		Offset: -16,-16
-	land: DATA
+	land: DATA.R8
 		Start: 102
 		ZOffset: -511
 		Offset: -16,-16
 
 # TODO: keep the redundant spicebloom.shp for now for the awful WinForms maps editor
 spicebloom:
-	make: DATA
+	make: DATA.R8
 		Start: 107
 		Length: 3
 		Offset: -16,-16
-	active: DATA
+	active: DATA.R8
 		Start: 109
 		Length: 1
 		ZOffset: -511
 		Offset: -16,-16
-	idle: DATA
+	idle: DATA.R8
 		Start: 109
 		ZOffset: -511
 		Offset: -16,-16
 
 moveflsh:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3621
 		Length: 5
 		Tick: 80
 		BlendMode: Multiply
 
 resources:
-	spice: BLOXBASE
+	spice: BLOXBASE.R8
 		Frames: 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 300, 301, 320, 321
 		Length: 54
 		Offset: -16,-16
 
 shroud:
-	typea: DATA
+	typea: DATA.R8
 		Start: 40
 		Length: 14
 		Offset: -16,-16
 		BlendMode: Multiply
-	typeb: DATA
+	typeb: DATA.R8
 		Start: 56
 		Length: 14
 		Offset: -16,-16
 		BlendMode: Multiply
-	typec: DATA
+	typec: DATA.R8
 		Start: 72
 		Length: 14
 		Offset: -16,-16
 		BlendMode: Multiply
-	typed: DATA
+	typed: DATA.R8
 		Start: 88
 		Length: 14
 		Offset: -16,-16
 		BlendMode: Multiply
-	full: fullshroud
+	full: fullshroud.shp
 		BlendMode: Multiply
 
 rockcraters:
-	rockcrater1: DATA
+	rockcrater1: DATA.R8
 		Start: 114
 		Length: 16
 		Offset: -16,-16
-	rockcrater2: DATA
+	rockcrater2: DATA.R8
 		Start: 130
 		Length: 16
 		Offset: -16,-16
 
 sandcraters:
-	sandcrater1: DATA
+	sandcrater1: DATA.R8
 		Start: 146
 		Length: 16
 		Offset: -16,-16
-	sandcrater2: DATA
+	sandcrater2: DATA.R8
 		Start: 162
 		Length: 16
 		Offset: -16,-16

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -1,386 +1,386 @@
 concretea:
-	icon: DATA
+	icon: DATA.R8
 		Start:4050
 		Offset: -30,-24
 
 concreteb:
-	icon: DATA
+	icon: DATA.R8
 		Start:4053
 		Offset: -30,-24
 
 wall:
-	idle: DATA
+	idle: DATA.R8
 		Frames: 2527, 2530, 2528, 2538, 2531, 2532, 2542, 2535, 2529, 2539, 2533, 2534, 2540, 2536, 2537, 2541
 		Length: 16
 		Offset: -16,16
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Frames: 2543, 2546, 2544, 2554, 2547, 2548, 2558, 2551, 2545, 2555, 2549, 2550, 2556, 2552, 2553, 2557
 		Length: 16
 		Offset: -16,16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4063
 		Offset: -30,-24
 
 guntower:
-	idle: DATA
+	idle: DATA.R8
 		Frames: 2573, 2576, 2574, 2584, 2577, 2578, 2588, 2581, 2575, 2585, 2579, 2580, 2586, 2582, 2583, 2587
 		Length: 16
 		Offset: -24,16
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Frames: 2621, 2624, 2622, 2632, 2625, 2626, 2636, 2629, 2623, 2633, 2627, 2628, 2634, 2630, 2631, 2635
 		Length: 16
 		Offset: -24,16
-	turret: DATA
+	turret: DATA.R8
 		Start: 2589
 		Facings: -32
 		Offset: -24,16
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3839, 3839, 3840, 3840, 3841, 3841, 3842, 3842, 3843, 3843, 3844, 3844, 3845, 3845, 3846, 3846, 3847, 3847, 3848, 3848, 3849, 3849, 3850, 3850, 3851, 3851, 3852, 3852, 3853, 3853, 3854, 3854, 3855, 3855, 3856, 3856, 3857, 3857, 3858, 3858, 3859, 3859, 3860, 3860, 3861, 3861, 3862, 3862, 3863, 3863, 3864, 3864, 3865, 3865, 3866, 3866, 3867, 3867, 3868, 3868, 3869, 3869, 3870, 3870
 		Facings: -32
 		Length: 2
 		Offset: 0,-12
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4069
 		Offset: -30,-24
 
 rockettower:
-	idle: DATA
+	idle: DATA.R8
 		Frames: 2573, 2576, 2574, 2584, 2577, 2578, 2588, 2581, 2575, 2585, 2579, 2580, 2586, 2582, 2583, 2587
 		Length: 16
 		Offset: -24,16
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Frames: 2621, 2624, 2622, 2632, 2625, 2626, 2636, 2629, 2623, 2633, 2627, 2628, 2634, 2630, 2631, 2635
 		Length: 16
 		Offset: -24,16
-	turret: DATA
+	turret: DATA.R8
 		Start: 2637
 		Facings: -32
 		Offset: -24,16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4075
 		Offset: -30,-24
 
 conyard.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2559
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4109
 		Length: 30
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4139
 		Length: 12
 		Offset: -48,64
 		Tick: 170
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2560
 		Offset: -48,64
-	crane-overlay: DATA
+	crane-overlay: DATA.R8
 		Start: 4436
 		Length: 14
 		Offset: -48,64
 		Tick: 80
-	damaged-crane-overlay: DATA
+	damaged-crane-overlay: DATA.R8
 		Start: 4436
 		Length: 14
 		Offset: -48,64
 		Tick: 80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4046
 		Offset: -30,-24
 
 repair.atreides:
-	make: DATA
+	make: DATA.R8
 		Start: 4370
 		Length: 10
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4380
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	idle: DATA
+	idle: DATA.R8
 		Start: 2571
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2572
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA
+	active: DATA.R8
 		Start: 4746
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4746
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4096
 		Offset: -30,-24
 
 repair.harkonnen:
-	make: DATA
+	make: DATA.R8
 		Start: 4370
 		Length: 10
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4380
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	idle: DATA
+	idle: DATA.R8
 		Start: 2731
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2732
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA
+	active: DATA.R8
 		Start: 4746
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4746
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4097
 		Offset: -30,-24
 
 repair.ordos:
-	make: DATA
+	make: DATA.R8
 		Start: 4370
 		Length: 10
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4380
 		Length: 10
 		Offset: -48,48
 		Tick: 100
-	idle: DATA
+	idle: DATA.R8
 		Start: 2891
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2892
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA
+	active: DATA.R8
 		Start: 4746
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4746
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4098
 		Offset: -30,-24
 
 starport.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2671
 		ZOffset: -1c511
 		Offset: -48,48
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2672
 		ZOffset: -1c511
 		Offset: -48,48
-	active: DATA
+	active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA
+	make: DATA.R8
 		Start: 4347
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4358
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4092
 		Offset: -30,-24
 
 power.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2523
 		Offset: -32,64
-	make: DATA
+	make: DATA.R8
 		Start: 4151
 		Length: 12
 		Offset: -32,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4163
 		Length: 12
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2524
 		Offset: -32,64
-	idle-zaps: DATA
+	idle-zaps: DATA.R8
 		Start: 4492
 		Length: 10
 		Offset: -32,64
 		Tick: 200
-	damaged-idle-zaps: DATA
+	damaged-idle-zaps: DATA.R8
 		Start: 4497
 		Length: 5
 		Offset: -32,64
 		Tick: 200
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4056
 		Offset: -30,-24
 
 barracks.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2525
 		Offset: -32,64
-	make: DATA
+	make: DATA.R8
 		Start: 4176
 		Length: 8
 		Offset: -32,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4184
 		Length: 9
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2526
 		Offset: -32,64
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4059
 		Offset: -30,-24
 
 radar.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2521
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4254
 		Length: 9
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4263
 		Length: 10
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2522
 		Offset: -48,80
-	idle-dish: DATA
+	idle-dish: DATA.R8
 		Start: 4522
 		Length: 30
 		Offset: -48,80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4072
 		Offset: -30,-24
 
 refinery.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2561
 		Length: 1
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4231
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4241
 		Length: 12
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2561
 		Offset: -48,64
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2562
 		Offset: -48,64
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2563
 		Offset: -48,64
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4066
 		Offset: -30,-24
-	smoke: DATA
+	smoke: DATA.R8
 		Start: 3885
 		Length: 14
 		Offset: 10,-16
@@ -388,488 +388,488 @@ refinery.atreides:
 		BlendMode: Additive
 
 silo.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2566
 		Length: 4
 		Offset: -16,16
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2569
 		Length: 1
 		Offset: -16,16
-	make: DATA
+	make: DATA.R8
 		Start: 4313
 		Length: 7
 		Offset: -16,16
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4320
 		Length: 7
 		Offset: -16,16
 		Tick: 200
-	icon: DATA
+	icon: DATA.R8
 		Start: 4084
 		Offset: -30,-24
 
 hightech.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2564
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4274
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4284
 		Length: 10
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2565
 		Offset: -48,80
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4614
 		Length: 30
 		Offset: -48,80
 		Tick: 500
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4078
 		Offset: -30,-24
 
 research.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2669
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4391
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4401
 		Length: 11
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2670
 		Offset: -48,80
-	idle-lights: DATA
+	idle-lights: DATA.R8
 		Start: 4760
 		Length: 60
 		Tick: 80
 		Offset: -48,80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4099
 		Offset: -30,-24
 
 research.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2829
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4391
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4401
 		Length: 11
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2830
 		Offset: -48,80
-	idle-lights: DATA
+	idle-lights: DATA.R8
 		Start: 4760
 		Length: 60
 		Tick: 80
 		Offset: -48,80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4100
 		Offset: -30,-24
 
 research.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2989
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4391
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4401
 		Length: 11
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2990
 		Offset: -48,80
-	idle-lights: DATA
+	idle-lights: DATA.R8
 		Start: 4760
 		Length: 60
 		Tick: 80
 		Offset: -48,80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4101
 		Offset: -30,-24
 
 palace.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2676
 		Offset: -48,48
-	make: DATA
+	make: DATA.R8
 		Start: 4413
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4424
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2677
 		Offset: -48,48
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4102
 		Offset: -30,-24
 
 light.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2673
 		Length: 1
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4295
 		Length: 8
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4303
 		Length: 9
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2673
 		Offset: -48,64
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2674
 		Offset: -48,64
 		ZOffset: 1023
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2675
 		Offset: -48,64
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4644
 		Length: 30
 		Offset: -48,64
 		Tick: 200
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4081
 		Offset: -30,-24
 
 heavy.atreides:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2518
 		Length: 1
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4328
 		Length: 9
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4337
 		Length: 9
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2518
 		Offset: -48,80
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2519
 		Offset: -48,80
 		ZOffset: 1023
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2520
 		Offset: -48,80
 		ZOffset: 1023
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4674
 		Length: 47
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4087
 		Offset: -30,-24
 
 conyard.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2719
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4109
 		Length: 30
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4139
 		Length: 12
 		Offset: -48,64
 		Tick: 170
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2720
 		Offset: -48,64
-	crane-overlay: DATA
+	crane-overlay: DATA.R8
 		Start: 4450
 		Length: 14
 		Offset: -48,64
 		Tick: 80
-	damaged-crane-overlay: DATA
+	damaged-crane-overlay: DATA.R8
 		Start: 4450
 		Length: 14
 		Offset: -48,64
 		Tick: 80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4047
 		Offset: -30,-24
 
 starport.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2831
 		ZOffset: -1c511
 		Offset: -48,48
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2832
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA
+	active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA
+	make: DATA.R8
 		Start: 4347
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4358
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4093
 		Offset: -30,-24
 
 power.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2683
 		Offset: -32,64
-	make: DATA
+	make: DATA.R8
 		Start: 4151
 		Length: 12
 		Offset: -32,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4163
 		Length: 12
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2684
 		Offset: -32,64
-	idle-zaps: DATA
+	idle-zaps: DATA.R8
 		Start: 4502
 		Length: 10
 		Offset: -32,64
 		Tick: 200
-	damaged-idle-zaps: DATA
+	damaged-idle-zaps: DATA.R8
 		Start: 4507
 		Length: 5
 		Offset: -32,64
 		Tick: 200
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4057
 		Offset: -30,-24
 
 barracks.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2685
 		Offset: -32,64
-	make: DATA
+	make: DATA.R8
 		Start: 4213
 		Length: 8
 		Offset: -32,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4221
 		Length: 9
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2686
 		Offset: -32,64
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4060
 		Offset: -30,-24
 
 radar.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2681
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4254
 		Length: 9
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4263
 		Length: 10
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2682
 		Offset: -48,80
-	idle-dish: DATA
+	idle-dish: DATA.R8
 		Start: 4553
 		Length: 30
 		Offset: -48,80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4073
 		Offset: -30,-24
 
 refinery.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2721
 		Length: 1
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4231
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4241
 		Length: 12
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2721
 		Offset: -48,64
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2722
 		Offset: -48,64
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2723
 		Offset: -48,64
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4067
 		Offset: -30,-24
-	smoke: DATA
+	smoke: DATA.R8
 		Start: 3885
 		Length: 14
 		Offset: 10,-16
@@ -877,398 +877,398 @@ refinery.harkonnen:
 		BlendMode: Additive
 
 silo.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2726
 		Length: 4
 		Offset: -16,16
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2730
 		Length: 1
 		Offset: -16,16
-	make: DATA
+	make: DATA.R8
 		Start: 4313
 		Length: 7
 		Offset: -16,16
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4320
 		Length: 7
 		Offset: -16,16
 		Tick: 200
-	icon: DATA
+	icon: DATA.R8
 		Start: 4085
 		Offset: -30,-24
 
 hightech.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2724
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4274
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4284
 		Length: 10
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2725
 		Offset: -48,80
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4614
 		Length: 30
 		Offset: -48,80
 		Tick: 500
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4079
 		Offset: -30,-24
 
 palace.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2836
 		Offset: -48,48
-	make: DATA
+	make: DATA.R8
 		Start: 4413
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4424
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2837
 		Offset: -48,48
-#	active: DATA # TODO: overlay
+#	active: DATA.R8 # TODO: overlay
 #		Start: 4820
 #		Length: 20
 #		Offset: -48,64
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4820
 		Length: 20
 		Offset: -48,48
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4103
 		Offset: -30,-24
 
 light.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2833
 		Length: 1
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4295
 		Length: 8
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4303
 		Length: 9
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2833
 		Offset: -48,64
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2834
 		Offset: -48,64
 		ZOffset: 1023
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2835
 		Offset: -48,64
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4644
 		Length: 30
 		Offset: -48,64
 		Tick: 200
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4082
 		Offset: -30,-24
 
 heavy.harkonnen:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2678
 		Length: 1
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4328
 		Length: 9
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4337
 		Length: 9
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2678
 		Offset: -48,80
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2679
 		Offset: -48,80
 		ZOffset: 1023
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2680
 		Offset: -48,80
 		ZOffset: 1023
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4674
 		Length: 47
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4088
 		Offset: -30,-24
 
 conyard.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2879
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4109
 		Length: 30
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4139
 		Length: 12
 		Offset: -48,64
 		Tick: 170
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2880
 		Offset: -48,64
-	crane-overlay: DATA
+	crane-overlay: DATA.R8
 		Start: 4464
 		Length: 14
 		Offset: -48,64
 		Tick: 80
-	damaged-crane-overlay: DATA
+	damaged-crane-overlay: DATA.R8
 		Start: 4464
 		Length: 14
 		Offset: -48,64
 		Tick: 80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4048
 		Offset: -30,-24
 
 starport.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2991
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2992
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA
+	active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA
+	make: DATA.R8
 		Start: 4347
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4358
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4094
 		Offset: -30,-24
 
 power.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2843
 		Length: 1
 		Offset: -32,64
-	make: DATA
+	make: DATA.R8
 		Start: 4151
 		Length: 12
 		Offset: -32,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4163
 		Length: 12
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2844
 		Offset: -32,64
-	idle-zaps: DATA
+	idle-zaps: DATA.R8
 		Start: 4512
 		Length: 10
 		Offset: -32,64
 		Tick: 200
-	damaged-idle-zaps: DATA
+	damaged-idle-zaps: DATA.R8
 		Start: 4517
 		Length: 5
 		Offset: -32,64
 		Tick: 200
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4058
 		Offset: -30,-24
 
 barracks.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2845
 		Offset: -32,64
-	make: DATA
+	make: DATA.R8
 		Start: 4213
 		Length: 8
 		Offset: -32,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4221
 		Length: 9
 		Offset: -32,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2846
 		Offset: -32,64
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 649, 650, 669, 670
 		Length: 4
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4061
 		Offset: -30,-24
 
 radar.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2841
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4254
 		Length: 9
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4263
 		Length: 10
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2842
 		Offset: -48,80
-	idle-dish: DATA
+	idle-dish: DATA.R8
 		Start: 4583
 		Length: 30
 		Offset: -48,80
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4074
 		Offset: -30,-24
 
 refinery.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2881
 		Length: 1
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4231
 		Length: 11
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4241
 		Length: 12
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2881
 		Offset: -48,64
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2882
 		Offset: -48,64
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2883
 		Offset: -48,64
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4068
 		Offset: -30,-24
-	smoke: DATA
+	smoke: DATA.R8
 		Start: 3885
 		Length: 14
 		Offset: 10,-16
@@ -1276,295 +1276,295 @@ refinery.ordos:
 		BlendMode: Additive
 
 silo.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2886
 		Length: 4
 		Offset: -16,16
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2890
 		Length: 1
 		Offset: -16,16
-	make: DATA
+	make: DATA.R8
 		Start: 4313
 		Length: 7
 		Offset: -16,16
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4320
 		Length: 7
 		Offset: -16,16
 		Tick: 200
-	icon: DATA
+	icon: DATA.R8
 		Start: 4086
 		Offset: -30,-24
 
 hightech.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2884
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4274
 		Length: 10
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4284
 		Length: 10
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2885
 		Offset: -48,80
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4614
 		Length: 30
 		Offset: -48,80
 		Tick: 500
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4080
 		Offset: -30,-24
 
 palace.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2996
 		Offset: -48,48
-	make: DATA
+	make: DATA.R8
 		Start: 4413
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4424
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2997
 		Offset: -48,48
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4104
 		Offset: -30,-24
 
 light.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2993
 		Length: 1
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4295
 		Length: 8
 		Offset: -48,64
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4303
 		Length: 9
 		Offset: -48,64
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2993
 		Offset: -48,64
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2994
 		Offset: -48,64
 		ZOffset: 1023
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2995
 		Offset: -48,64
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4644
 		Length: 30
 		Offset: -48,64
 		Tick: 200
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4083
 		Offset: -30,-24
 
 heavy.ordos:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2838
 		Length: 1
 		Offset: -48,80
-	make: DATA
+	make: DATA.R8
 		Start: 4328
 		Length: 9
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4337
 		Length: 9
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 2838
 		Offset: -48,80
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 2839
 		Offset: -48,80
 		ZOffset: 1023
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 2840
 		Offset: -48,80
 		ZOffset: 1023
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4674
 		Length: 47
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA
+	icon: DATA.R8
 		Start: 4089
 		Offset: -30,-24
 
 palace.corrino:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3004
 		Offset: -48,48
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 3005
 		Offset: -48,48
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 663, 664, 665
 		Length: 3
 		Offset: -16,-16
-	icon: palacecicon
+	icon: palacecicon.shp
 		Start: 0
-	make: DATA
+	make: DATA.R8
 		Start: 4413
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4424
 		Length: 11
 		Offset: -48,48
 		Tick: 100
 
 starport.corrino:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2999
 		Offset: -48,48
 		ZOffset: -1c511
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 3000
 		Offset: -48,48
 		ZOffset: -1c511
-	active: DATA
+	active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	damaged-active: DATA
+	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
 		ZOffset: -1c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
-	make: DATA
+	make: DATA.R8
 		Start: 4347
 		Length: 11
 		Offset: -48,48
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4358
 		Length: 11
 		Offset: -48,48
 		Tick: 100
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA # TODO: blank
+	icon: DATA.R8 # TODO: blank
 		Start: 4020
 		Offset: -30,-24
 
 heavy.corrino:
-	idle: DATA
+	idle: DATA.R8
 		Start: 3001
 		Length: 1
 		Offset: -48,64
-	make: DATA
+	make: DATA.R8
 		Start: 4328
 		Length: 9
 		Offset: -48,80
-	crumble-overlay: DATA
+	crumble-overlay: DATA.R8
 		Start: 4337
 		Length: 9
 		Offset: -48,80
 		Tick: 100
-	damaged-idle: DATA
+	damaged-idle: DATA.R8
 		Start: 3001
 		Offset: -48,64
-	idle-top: DATA
+	idle-top: DATA.R8
 		Start: 3002
 		Offset: -48,64
 		ZOffset: 1023
-	damaged-idle-top: DATA
+	damaged-idle-top: DATA.R8
 		Start: 3003
 		Offset: -48,64
 		ZOffset: 1023
-	production-welding: DATA
+	production-welding: DATA.R8
 		Start: 4674
 		Length: 47
 		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
-	bib: BLOXBASE
+	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
-	bib-Concrete: BLOXBASE
+	bib-Concrete: BLOXBASE.R8
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA # TODO: blank
+	icon: DATA.R8 # TODO: blank
 		Start: 4020
 		Offset: -30,-24
 
 plates: # TODO: unused
-	idle: DATA
+	idle: DATA.R8
 		Start: 3008
 		Length: 6
-	4-plates-icon: DATA
+	4-plates-icon: DATA.R8
 		Start: 4050
 		Offset: -30,-24
-	6-plates-icon: DATA
+	6-plates-icon: DATA.R8
 		Start: 4053
 		Offset: -30,-24

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -1,261 +1,261 @@
 mcv:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1795
 		Facings: -32
-	icon: DATA
+	icon: DATA.R8
 		Start: 4023
 		Offset: -30,-24
 
 mcv.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1795
 		Facings: -32
 		ZOffset: -1023
 
 harvester:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1699
 		Facings: -32
-	harvest: DATA
+	harvest: DATA.R8
 		Start: 3631
 		Length: 6
 		Facings: -8
 		Tick: 80
 		ZOffset: 1
-	dock: DATA
+	dock: DATA.R8
 		Start: 3370
 		Length: 10
-	dock-loop: DATA
+	dock-loop: DATA.R8
 		Start: 3380
 		Length: 1
-	icon: DATA
+	icon: DATA.R8
 		Start: 4019
 		Offset: -30,-24
 
 harvester.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1699
 		Facings: -32
 		ZOffset: -1023
 
 trike:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1635
 		Facings: -32
-	unload: DATA
+	unload: DATA.R8
 		Start: 1635
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3839, 3839, 3840, 3840, 3841, 3841, 3842, 3842, 3843, 3843, 3844, 3844, 3845, 3845, 3846, 3846, 3847, 3847, 3848, 3848, 3849, 3849, 3850, 3850, 3851, 3851, 3852, 3852, 3853, 3853, 3854, 3854, 3855, 3855, 3856, 3856, 3857, 3857, 3858, 3858, 3859, 3859, 3860, 3860, 3861, 3861, 3862, 3862, 3863, 3863, 3864, 3864, 3865, 3865, 3866, 3866, 3867, 3867, 3868, 3868, 3869, 3869, 3870, 3870
 		Facings: -32
 		Length: 2
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4041
 		Offset: -30,-24
 
 quad:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1667
 		Facings: -32
-	unload: DATA
+	unload: DATA.R8
 		Start: 1667
 		Facings: -32
-	icon: DATA
+	icon: DATA.R8
 		Start: 4018
 		Offset: -30,-24
 
 siegetank:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1763
 		Facings: -32
-	turret: DATA
+	turret: DATA.R8
 		Start: 1891
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Start: 3418
 		Length: 3
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4026
 		Offset: -30,-24
 
 siegetank.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1763
 		Facings: -32
 		ZOffset: -512
-	turret: DATA
+	turret: DATA.R8
 		Start: 1891
 		Facings: -32
 		ZOffset: -512
 
 missiletank:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1603
 		Facings: -32
-	icon: DATA
+	icon: DATA.R8
 		Start: 4024
 		Offset: -30,-24
 
 missiletank.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1603
 		Facings: -32
 		ZOffset: -512
 
 sonictank:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1827
 		Facings: -32
-	icon: DATA
+	icon: DATA.R8
 		Start: 4027
 		Offset: -30,-24
 
 sonictank.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1827
 		Facings: -32
 		ZOffset: -512
 
 combata:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1731
 		Facings: -32
-	turret: DATA
+	turret: DATA.R8
 		Start: 1859
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3775, 3775, 3776, 3776, 3777, 3777, 3778, 3778, 3779, 3779, 3780, 3780, 3781, 3781, 3782, 3782, 3783, 3783, 3784, 3784, 3785, 3785, 3786, 3786, 3787, 3787, 3788, 3788, 3789, 3789, 3790, 3790, 3791, 3791, 3792, 3792, 3793, 3793, 3794, 3794, 3795, 3795, 3796, 3796, 3797, 3797, 3798, 3798, 3799, 3799, 3800, 3800, 3801, 3801, 3802, 3802, 3803, 3803, 3804, 3804, 3805, 3805, 3806, 3806
 		Facings: -32
 		Length: 2
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4020
 		Offset: -30,-24
 
 combata.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 1731
 		Facings: -32
 		ZOffset: -512
-	turret: DATA
+	turret: DATA.R8
 		Start: 1859
 		Facings: -32
 		ZOffset: -512
 
 combath:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2051
 		Facings: -32
-	turret: DATA
+	turret: DATA.R8
 		Start: 2115
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3775, 3775, 3776, 3776, 3777, 3777, 3778, 3778, 3779, 3779, 3780, 3780, 3781, 3781, 3782, 3782, 3783, 3783, 3784, 3784, 3785, 3785, 3786, 3786, 3787, 3787, 3788, 3788, 3789, 3789, 3790, 3790, 3791, 3791, 3792, 3792, 3793, 3793, 3794, 3794, 3795, 3795, 3796, 3796, 3797, 3797, 3798, 3798, 3799, 3799, 3800, 3800, 3801, 3801, 3802, 3802, 3803, 3803, 3804, 3804, 3805, 3805, 3806, 3806
 		Facings: -32
 		Length: 2
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4021
 		Offset: -30,-24
 
 combath.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2051
 		Facings: -32
 		ZOffset: -512
-	turret: DATA
+	turret: DATA.R8
 		Start: 2115
 		Facings: -32
 		ZOffset: -512
 
 combato:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2453
 		Facings: -32
-	turret: DATA
+	turret: DATA.R8
 		Start: 2485
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3775, 3775, 3776, 3776, 3777, 3777, 3778, 3778, 3779, 3779, 3780, 3780, 3781, 3781, 3782, 3782, 3783, 3783, 3784, 3784, 3785, 3785, 3786, 3786, 3787, 3787, 3788, 3788, 3789, 3789, 3790, 3790, 3791, 3791, 3792, 3792, 3793, 3793, 3794, 3794, 3795, 3795, 3796, 3796, 3797, 3797, 3798, 3798, 3799, 3799, 3800, 3800, 3801, 3801, 3802, 3802, 3803, 3803, 3804, 3804, 3805, 3805, 3806, 3806
 		Facings: -32
 		Length: 2
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4022
 		Offset: -30,-24
 
 combato.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2453
 		Facings: -32
 		ZOffset: -512
-	turret: DATA
+	turret: DATA.R8
 		Start: 2485
 		Facings: -32
 		ZOffset: -512
 
 devast:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2083
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3807, 3807, 3808, 3808, 3809, 3809, 3810, 3810, 3810, 3811, 3811, 3812, 3812, 3813, 3813, 3814, 3814, 3815, 3816, 3816, 3817, 3817, 3818, 3819, 3819, 3820, 3820, 3821, 3821, 3822, 3822, 3823, 3823, 3824, 3824, 3825, 3825, 3826, 3826, 3827, 3827, 3828, 3828, 3829, 3829, 3830, 3830, 3831, 3831, 3832, 3832, 3832, 3833, 3833, 3834, 3834, 3835, 3835, 3836, 3836, 3837, 3837, 3838, 3838
 		Facings: -32
 		Length: 2
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4028
 		Offset: -30,-24
 
 devast.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2083
 		Facings: -32
 		ZOffset: -512
 
 raider:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2421
 		Facings: -32
-	unload: DATA
+	unload: DATA.R8
 		Start: 2421
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3743, 3743, 3744, 3744, 3745, 3745, 3746, 3746, 3747, 3747, 3748, 3748, 3749, 3749, 3750, 3750, 3751, 3751, 3752, 3752, 3753, 3753, 3754, 3754, 3755, 3755, 3756, 3756, 3757, 3757, 3758, 3758, 3759, 3759, 3760, 3760, 3761, 3761, 3762, 3762, 3763, 3763, 3764, 3764, 3765, 3765, 3766, 3766, 3767, 3767, 3768, 3768, 3769, 3769, 3770, 3770, 3771, 3771, 3772, 3772, 3773, 3773, 3774, 3774
 		Facings: -32
 		Length: 2
 		BlendMode: Additive
-	icon: DATA
+	icon: DATA.R8
 		Start: 4017
 		Offset: -30,-24
 
 stealthraider:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2421
 		Facings: -32
-	unload: DATA
+	unload: DATA.R8
 		Start: 2421
 		Facings: -32
-	muzzle: DATA
+	muzzle: DATA.R8
 		Frames: 3743, 3743, 3744, 3744, 3745, 3745, 3746, 3746, 3747, 3747, 3748, 3748, 3749, 3749, 3750, 3750, 3751, 3751, 3752, 3752, 3753, 3753, 3754, 3754, 3755, 3755, 3756, 3756, 3757, 3757, 3758, 3758, 3759, 3759, 3760, 3760, 3761, 3761, 3762, 3762, 3763, 3763, 3764, 3764, 3765, 3765, 3766, 3766, 3767, 3767, 3768, 3768, 3769, 3769, 3770, 3770, 3771, 3771, 3772, 3772, 3773, 3773, 3774, 3774
 		Facings: -32
 		Length: 2
 		BlendMode: Additive
-	icon: raidersicon
+	icon: raidersicon.shp
 		Start: 0 # 4282 in 1.06 DATA.R8
 
 deviatortank:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2389
 		Facings: -32
-	icon: DATA
+	icon: DATA.R8
 		Start: 4025
 		Offset: -30,-24
 
 deviatortank.husk:
-	idle: DATA
+	idle: DATA.R8
 		Start: 2389
 		Facings: -32
 		ZOffset: -512

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -3,7 +3,7 @@ General:
 	Id: ARRAKIS
 	SheetSize: 1024
 	Palette: d2k.pal
-	Extensions: .R8, .r8, .shp, .tmp
+	Extensions: # Obsolete
 	EditorTemplateOrder: Basic, Dune, Sand-Detail, Brick, Sand-Cliff, Sand-Smooth, Cliff-Type-Changer, Rock-Sand-Smooth, Rock-Detail, Rock-Cliff, Rock-Cliff-Rock, Rotten-Base, Dead-Worm, Ice, Ice-Detail, Rock-Cliff-Sand, Sand-Platform, Unidentified
 	IgnoreTileSpriteOffsets: True
 


### PR DESCRIPTION
This disables the magic sprite filename resolution (#5272) for D2K and removes the unused parachute sequence definition.  `OpenRA.Utility.exe d2k --check-sequence-sprites` now passes for D2K.
