### PR TITLE
Lazily generate frozen actor renderables.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
 	}
 
-	public class FrozenUnderFog : IRenderModifier, IVisibilityModifier, ITick, ITickRender, ISync
+	public class FrozenUnderFog : IRenderModifier, IVisibilityModifier, ITick, ISync
 	{
 		[Sync] public int VisibilityHash;
 
@@ -104,20 +104,9 @@ namespace OpenRA.Mods.Common.Traits
 			initialized = true;
 		}
 
-		public void TickRender(WorldRenderer wr, Actor self)
-		{
-			if (self.Destroyed || !initialized || !visible.Values.Any(v => v))
-				return;
-
-			var renderables = self.Render(wr).ToArray();
-			foreach (var player in self.World.Players)
-				if (visible[player])
-					frozen[player].Renderables = renderables;
-		}
-
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			return IsVisible(self, self.World.RenderPlayer) ? r : SpriteRenderable.None;
+			return IsVisible(self, self.World.RenderPlayer) || (initialized && frozen[self.World.RenderPlayer].IsRendering) ? r : SpriteRenderable.None;
 		}
 	}
 }


### PR DESCRIPTION
Previously actors that could be frozen under fog but were currently visible would be rendered by the frozen under fog system constantly in order to keep a copy of the renderables ready to go for the frozen counterpart when the actor became invisible. Instead, we now delay this extra rendering until the actor actually becomes invisible. This eliminates the wasted rendering to generate renderables that were never used.

A great example is the RA shellmap, which previously spent 7.0% of the total CPU time generating these renderables just in case. Since the viewer can never see a frozen actor on the shellmap, this was all wasted. With this PR, it now spends 0% of its time doing this.
