### PR TITLE
Improve support power timer display.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -11,8 +11,8 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Primitives;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
@@ -20,46 +20,216 @@ namespace OpenRA.Mods.Common.Widgets
 	public class SupportPowerTimerWidget : Widget
 	{
 		public readonly string Font = "Bold";
-		public readonly string Format = "{0}: {1}";
-		public readonly TimerOrder Order = TimerOrder.Descending;
+		[Translate] public readonly string NoTeamLabel = "No Team";
+		[Translate] public readonly string TeamLabel = "Team {0}";
 
-		readonly IEnumerable<SupportPowerInstance> powers;
-		Pair<string, Color>[] texts;
+		readonly int updatesPerSecond = 2;	// Range: 1 - 26	// 26 means no delay
+											// Values are in game time.
+											// Higher is more responsive
+											// but also more computationally intensive.
+		readonly World world;
+		readonly Dictionary<Player, SupportPowerManager> init;
+		struct Timer
+		{
+			public string PowerName;
+			public string RemainingTime;
+			public Color TimerColor;
+		}
+
+		struct TextBlock
+		{
+			public string Label;	// Used only if the text block is a team label.
+			public int Team;
+			public string PlayerName;
+			public Color PlayerColor;
+			public List<Timer> Timers;
+		}
+
+		List<TextBlock> temp, texts;
+		int yIncrement, padding, leftColumnWidth, middleColumnWidth, lastTick, waitTicks;
+		Player cachedPlayer;
+		SpriteFont font;
 
 		[ObjectCreator.UseCtor]
 		public SupportPowerTimerWidget(World world)
 		{
-			powers = world.ActorsWithTrait<SupportPowerManager>()
-				.Where(p => !p.Actor.IsDead && !p.Actor.Owner.NonCombatant)
-				.SelectMany(s => s.Trait.Powers.Values)
-				.Where(p => p.Instances.Any() && p.Info.DisplayTimer && !p.Disabled);
+			init = new Dictionary<Player, SupportPowerManager>();
+			foreach (var tp in world.ActorsWithTrait<SupportPowerManager>()
+				.Where(p => !p.Actor.IsDead && !p.Actor.Owner.NonCombatant))
+				init[tp.Actor.Owner] = tp.Trait;
+
+			texts = new List<TextBlock>();
+			font = Game.Renderer.Fonts[Font];
+			yIncrement = font.Measure(" ").Y + 5;
+			padding = font.Measure("   ").X;
+			this.world = world;
+			waitTicks = 25 / updatesPerSecond;
 		}
 
-		public override void Tick()
+		bool AddTextBlock(Player p, int team, TextBlock? label, List<TextBlock> list)
 		{
-			texts = powers.Select(p =>
+			var spiArray = init[p].Powers.Values.Where(i => i.Instances.Any() && i.Info.DisplayTimer && !i.Disabled).ToArray();
+			if (spiArray.Length == 0)
+				return false;
+
+			if (label != null)
+				list.Add((TextBlock)label);
+
+			var tb = new TextBlock();
+			tb.Timers = new List<Timer>();
+			foreach (var spi in spiArray)
 			{
-				var time = WidgetUtils.FormatTime(p.RemainingTime, false);
-				var text = Format.F(p.Info.Description, time);
-				var color = !p.Ready || Game.LocalTick % 50 < 25 ? p.Instances[0].Self.Owner.Color.RGB : Color.White;
-				return Pair.New(text, color);
-			}).ToArray();
+				var t = new Timer();
+				t.PowerName = spi.Info.Description;
+				t.RemainingTime = WidgetUtils.FormatTime(spi.RemainingTime, false);
+				t.TimerColor = spi.Ready && Game.LocalTick % 50 > 25 ? Color.White : p.Color.RGB;
+				tb.Timers.Add(t);
+			}
+
+			tb.Team = team;
+			tb.PlayerName = p.PlayerName;
+			tb.PlayerColor = p.Color.RGB;
+			list.Add(tb);
+			return true;
+		}
+
+		void OrderTexts(bool hasSelf, int selfTeam)
+		{
+			var grouping = temp.GroupBy(t => t.Team).OrderBy(g => g.Key);
+			foreach (var team in grouping)
+			{
+				if (!hasSelf || team.Key != -selfTeam)
+				{
+					var tb = new TextBlock();
+					tb.Label = team.Key == 0 ? NoTeamLabel : TeamLabel.F(team.Key < 0 ? -team.Key : team.Key);
+					texts.Add(tb);
+				}
+
+				foreach (var tb in team)
+					texts.Add(tb);
+			}
+		}
+
+		void UpdateColumnWidth()
+		{
+			if (texts.Count == 0)
+				return;
+
+			leftColumnWidth = texts.Max(tb => font.Measure(tb.PlayerName ?? tb.Label).X);
+			middleColumnWidth = texts.Max(tb => tb.Timers == null ? 0 : tb.Timers.Max(t => font.Measure(t.PowerName).X));
+		}
+
+		void GenerateTexts(Player player, bool showSelf)
+		{
+			temp = new List<TextBlock>();
+			texts = new List<TextBlock>();
+			var hasSelf = false;
+			var selfTeam = world.LobbyInfo.ClientWithIndex(player.ClientIndex).Team;
+			foreach (var p in init.Keys)
+			{
+				if (p != player)
+				{
+					var pTeam = world.LobbyInfo.ClientWithIndex(p.ClientIndex).Team;
+					if (pTeam == selfTeam)
+						pTeam = -pTeam;
+
+					AddTextBlock(p, pTeam, null, temp);
+				}
+				else if (showSelf)
+				{
+					var tb = new TextBlock();
+					tb.Label = selfTeam == 0 ? NoTeamLabel : TeamLabel.F(selfTeam);
+					hasSelf = AddTextBlock(p, selfTeam, tb, texts);
+				}
+			}
+
+			OrderTexts(hasSelf, selfTeam);
+			UpdateColumnWidth();
+		}
+
+		void MainLogic()
+		{
+			if (world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Undefined)
+			{
+				// Viewer is a player.
+				if (cachedPlayer != world.LocalPlayer || world.WorldTick - lastTick >= waitTicks)
+				{
+					GenerateTexts(world.LocalPlayer, false);
+					cachedPlayer = world.LocalPlayer;
+					lastTick = world.WorldTick;
+				}
+
+				return;
+			}
+
+			if (world.RenderPlayer != null && world.RenderPlayer.InternalName != "Everyone")
+			{
+				// Viewer is an observer who selected a player's view.
+				if (cachedPlayer != world.RenderPlayer || world.WorldTick - lastTick >= waitTicks)
+				{
+					GenerateTexts(world.RenderPlayer, true);
+					cachedPlayer = world.RenderPlayer;
+					lastTick = world.WorldTick;
+				}
+
+				return;
+			}
+
+			// Viewer is an observer who selected "Disable Shroud" or "All Players" view.
+			if ((cachedPlayer == null || cachedPlayer.InternalName == "Everyone") && world.WorldTick - lastTick < waitTicks)
+				return;
+
+			temp = new List<TextBlock>();
+			texts = new List<TextBlock>();
+			foreach (var p in init.Keys)
+				AddTextBlock(p, world.LobbyInfo.ClientWithIndex(p.ClientIndex).Team, null, temp);
+
+			OrderTexts(false, 0);
+			UpdateColumnWidth();
+			cachedPlayer = world.RenderPlayer;
+			lastTick = world.WorldTick;
 		}
 
 		public override void Draw()
 		{
-			if (!IsVisible() || texts == null)
+			if (!IsVisible())
 				return;
 
-			var y = 0;
-			foreach (var t in texts)
+			MainLogic();
+
+			if (texts.Count == 0)
+				return;
+
+			var b = new float2(Bounds.Location);
+			var pos = new float2(0, 0);
+
+			foreach (var tb in texts)
 			{
-				var font = Game.Renderer.Fonts[Font];
-				font.DrawTextWithContrast(t.First, new float2(Bounds.Location) + new float2(0, y), t.Second, Color.Black, 1);
-				y += (font.Measure(t.First).Y + 5) * (int)Order;
+				if (tb.Label != null)
+				{
+					pos.X = 0;
+					pos.Y += 6;
+					font.DrawTextWithContrast(tb.Label, b + pos, Color.White, Color.Black, 1);
+					pos.Y += yIncrement + 3;
+					continue;
+				}
+
+				pos.X = leftColumnWidth - font.Measure(tb.PlayerName).X;
+				font.DrawTextWithContrast(tb.PlayerName, b + pos, tb.PlayerColor, Color.Black, 1);
+
+				foreach (var timer in tb.Timers)
+				{
+					pos.X = leftColumnWidth + padding;
+					font.DrawTextWithContrast(timer.PowerName, b + pos, timer.TimerColor, Color.Black, 1);
+
+					pos.X += middleColumnWidth + padding;
+					font.DrawTextWithContrast(timer.RemainingTime, b + pos, timer.TimerColor, Color.Black, 1);
+
+					pos.Y += yIncrement;
+				}
+
+				pos.Y += 3;
 			}
 		}
-
-		public enum TimerOrder { Ascending = -1, Descending = 1 }
 	}
 }

--- a/mods/d2k/chrome/ingame.yaml
+++ b/mods/d2k/chrome/ingame.yaml
@@ -19,10 +19,6 @@ Container@INGAME_ROOT:
 				StrategicProgress@STRATEGIC_PROGRESS:
 					X: WINDOW_RIGHT/2
 					Y: 40
-				SupportPowerTimer@SUPPORT_POWER_TIMER:
-					X: 80
-					Y: 34
-					Order: Descending
 				Container@PLAYER_ROOT:
 				Container@PERF_ROOT:
 		Container@MENU_ROOT:

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -1,5 +1,8 @@
 Container@OBSERVER_WIDGETS:
 	Children:
+		SupportPowerTimer@SUPPORT_POWER_TIMER:
+			X: 10
+			Y: 10
 		Image@SIDEBAR_BACKGROUND_TOP:
 			X: WINDOW_RIGHT - 250
 			Y: 10

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -25,6 +25,9 @@ Container@PLAYER_WIDGETS:
 							IgnoreMouseOver: true
 							ImageCollection: sidebar
 							ImageName: background-supportoverlay
+		SupportPowerTimer@SUPPORT_POWER_TIMER:
+			X: 80
+			Y: 10
 		Image@SIDEBAR_BACKGROUND_TOP:
 			Logic: AddRaceSuffixLogic
 			X: WINDOW_RIGHT - 250

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -19,10 +19,6 @@ Container@INGAME_ROOT:
 				StrategicProgress@STRATEGIC_PROGRESS:
 					X: WINDOW_RIGHT/2
 					Y: 40
-				SupportPowerTimer@SUPPORT_POWER_TIMER:
-					X: 80
-					Y: 10
-					Order: Descending
 				Container@PLAYER_ROOT:
 				Container@PERF_ROOT:
 		Container@MENU_ROOT:


### PR DESCRIPTION
Improves support power countdown timer text display on top left of the screen. Fixes #4798. Also see #6282.

This commit will change the following:
1) Player's own countdown timers aren't shown in the text. This is redundant since it is already shown in the icons.
2) Timers are divided into two groups: Allies and Enemies.
3) Each group has a header which can be configured in ingame.yaml under SupportPowerTimer@SUPPORT_POWER_TIMER:.
4) The old Order parameter in ingame.yaml is repurposed to configure which group will be shown on top. Default is EnemiesFirst, I thought enemy timers would be more important. Old Order parameter wasn't working for Ascending value.
5) Player names are also shown in front of timer text. When the timer is zero, only the description text flashes white and not the player name.

Here's what it looks like:
![timer](https://cloud.githubusercontent.com/assets/6599106/6831126/0582ab3c-d327-11e4-9999-5eaed3efd253.png)

I tested this and seems to work.
