### PR TITLE
 Disable legacy sequence parsing in TD.

### DIFF
--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -269,7 +269,7 @@ namespace OpenRA.Editor
 			{
 				try
 				{
-					var template = RenderUtils.RenderResourceType(a, tileset.Extensions, shadowedPalette);
+					var template = RenderUtils.RenderResourceType(a, tileset, shadowedPalette);
 					var ibox = new PictureBox
 					{
 						Image = template.Bitmap,

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -1,0 +1,75 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Graphics
+{
+	public class TilesetSpecificSpriteSequenceLoader : DefaultSpriteSequenceLoader
+	{
+		public readonly string DefaultSpriteExtension = ".shp";
+		public readonly Dictionary<string, string> TilesetExtensions = new Dictionary<string, string>();
+
+		public TilesetSpecificSpriteSequenceLoader(ModData modData)
+			: base(modData)
+		{
+			var metadata = modData.Manifest.Get<SpriteSequenceFormat>().Metadata;
+			MiniYaml yaml;
+			if (metadata.TryGetValue("DefaultSpriteExtension", out yaml))
+				DefaultSpriteExtension = yaml.Value;
+
+			if (metadata.TryGetValue("TilesetExtensions", out yaml))
+				TilesetExtensions = yaml.ToDictionary(kv => kv.Value);
+		}
+
+		public override ISpriteSequence CreateSequence(ModData modData, TileSet tileSet, SpriteCache cache, string sequence, string animation, MiniYaml info)
+		{
+			return new TilesetSpecificSpriteSequence(modData, tileSet, cache, this, sequence, animation, info);
+		}
+	}
+
+	public class TilesetSpecificSpriteSequence : DefaultSpriteSequence
+	{
+		public TilesetSpecificSpriteSequence(ModData modData, TileSet tileSet, SpriteCache cache, ISpriteSequenceLoader loader, string sequence, string animation, MiniYaml info)
+			: base(modData, tileSet, cache, loader, sequence, animation, info) { }
+
+		protected override string GetSpriteSrc(ModData modData, TileSet tileSet, string sequence, string animation, string sprite, Dictionary<string, MiniYaml> d)
+		{
+			var loader = (TilesetSpecificSpriteSequenceLoader)Loader;
+
+			var spriteName = sprite ?? sequence;
+			if (LoadField<bool>(d, "AddExtension", true))
+			{
+				var useTilesetExtension = LoadField<bool>(d, "UseTilesetExtension", false);
+				var tsId = tileSet.Id;
+
+				MiniYaml yaml;
+				if (d.TryGetValue("TilesetOverrides", out yaml))
+				{
+					var tsNode = yaml.Nodes.FirstOrDefault(n => n.Key == tsId);
+					if (tsNode != null)
+						tsId = tsNode.Value.Value;
+				}
+
+				string tilesetExtension;
+				if (useTilesetExtension && loader.TilesetExtensions.TryGetValue(tsId, out tilesetExtension))
+					return spriteName + tilesetExtension;
+
+				return spriteName + loader.DefaultSpriteExtension;
+			}
+
+			return spriteName;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -618,6 +618,7 @@
     <Compile Include="Traits\Render\WithInfantryBody.cs" />
     <Compile Include="UtilityCommands\CheckSequenceSprites.cs" />
     <Compile Include="UtilityCommands\FixClassicTilesets.cs" />
+    <Compile Include="Graphics\TilesetSpecificSpriteSequence.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -203,4 +203,10 @@ SupportsMapsFrom: cnc
 
 SpriteFormats: ShpTD, TmpTD, ShpTS, TmpRA
 
-SpriteSequenceFormat: DefaultSpriteSequence
+SpriteSequenceFormat: TilesetSpecificSpriteSequence
+	TilesetExtensions:
+		TEMPERAT: .tem
+		WINTER: .win
+		SNOW: .sno
+		DESERT: .des
+		JUNGLE: .jun

--- a/mods/cnc/sequences/aircraft.yaml
+++ b/mods/cnc/sequences/aircraft.yaml
@@ -1,19 +1,14 @@
 c17:
 	idle:
-		Start: 0
 		Facings: 32
 	icon: c17icnh
-		Start: 0
 
 tran:
 	idle:
-		Start: 0
 		Facings: 32
 	rotor: lrotor
-		Start: 0
 		Length: 4
 	rotor2: rrotor
-		Start: 0
 		Length: 4
 	slow-rotor: lrotor
 		Start: 4
@@ -26,43 +21,37 @@ tran:
 		Length: 4
 	unload:
 		Start: 35
-	icon: tranicnh
-		Start: 0
+	icon: tranicnh.tem
+		AddExtension: False
 
 heli:
 	idle:
-		Start: 0
 		Facings: 32
 	rotor: lrotor
-		Start: 0
 		Length: 4
 	slow-rotor: lrotor
 		Start: 4
 		Length: 8
 	muzzle: minigun
-		Start: 0
 		Length: 6
 		Facings: 8
-	icon: heliicnh
-		Start: 0
+	icon: heliicnh.tem
+		AddExtension: False
 
 orca:
 	idle:
-		Start: 0
 		Facings: 32
 	damaged-idle:
 		Start: 32
 		Facings: 32
-	icon: orcaicnh
-		Start: 0
+	icon: orcaicnh.tem
+		AddExtension: False
 
 a10:
 	idle:
-		Start: 0
 		Facings: 32
 	muzzle: minigun
-		Start: 0
 		Length: 6
 		Facings: 8
-	icon: a10icnh
-		Start: 0
+	icon: a10icnh.tem
+		AddExtension: False

--- a/mods/cnc/sequences/campaign.yaml
+++ b/mods/cnc/sequences/campaign.yaml
@@ -1,19 +1,15 @@
 lst:
 	idle: lstnew
-		Start: 0
 		Facings: 32
 	unload: lstnew
-		Start: 0
 		Facings: 32
 	roof: lstnew2
-		Start: 0
 		Facings: 32
-	icon: lsticnh
-		Start: 0
+	icon: lsticnh.tem
+		AddExtension: False
 
 boat:
 	left:
-		Start: 0
 		Facings: 32
 	damaged-left:
 		Start: 32
@@ -36,9 +32,8 @@ boat:
 		Start: 160
 		Facings: 32
 	wake-right: wake
-		Start: 0
 		Length: 6
 		Offset: -1,2
 		Tick: 120
-	icon: boaticnh
-		Start: 0
+	icon: boaticnh.tem
+		AddExtension: False

--- a/mods/cnc/sequences/civilian.yaml
+++ b/mods/cnc/sequences/civilian.yaml
@@ -1,6 +1,5 @@
 c1:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -53,7 +52,6 @@ c1:
 		Tick: 1600
 c2:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -106,7 +104,6 @@ c2:
 		Tick: 1600
 c3:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -159,7 +156,6 @@ c3:
 		Tick: 1600
 c4:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -212,7 +208,6 @@ c4:
 		Tick: 1600
 c5:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -265,7 +260,6 @@ c5:
 		Tick: 1600
 c6:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -318,7 +312,6 @@ c6:
 		Tick: 1600
 c7:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -371,7 +364,6 @@ c7:
 		Tick: 1600
 c8:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -424,7 +416,6 @@ c8:
 		Tick: 1600
 c9:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8
@@ -477,7 +468,6 @@ c9:
 		Tick: 1600
 c10:
 	stand:
-		Start: 0
 		Facings: 8
 	panic-stand:
 		Start: 8

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -1,60 +1,63 @@
 split2:
-	make:
-		Start: 0
-		Length: 30
+	Defaults:
 		Offset: 11, -15
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	make:
+		Length: 30
 	active:
 		Start: 30
 		Length: 24
-		Offset: 11, -15
 	idle:
 		Start: 54
-		Offset: 11, -15
 
 split3:
-	make:
-		Start: 0
-		Length: 30
+	Defaults:
 		Offset: 7, -13
+		UseTilesetExtension: true
+	make:
+		Length: 30
 	active:
 		Start: 30
 		Length: 24
-		Offset: 7, -13
 	idle:
 		Start: 54
-		Offset: 7, -13
 
 rock1:
-	idle:
-		Start: 0
+	idle: rock1.des
+		AddExtension: false
 
 rock2:
-	idle:
-		Start: 0
+	idle: rock2.des
+		AddExtension: false
 
 rock3:
-	idle:
-		Start: 0
+	idle: rock3.des
+		AddExtension: false
 
 rock4:
-	idle:
-		Start: 0
+	idle: rock4.des
+		AddExtension: false
 
 rock5:
-	idle:
-		Start: 0
+	idle: rock5.des
+		AddExtension: false
 
 rock6:
-	idle:
-		Start: 0
+	idle: rock6.des
+		AddExtension: false
 
 rock7:
-	idle:
-		Start: 0
+	idle: rock7.des
+		AddExtension: false
 
 tc04:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -63,8 +66,11 @@ tc04:
 		Tick: 80
 
 tc05:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -73,8 +79,11 @@ tc05:
 		Tick: 80
 
 tc03:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -83,8 +92,11 @@ tc03:
 		Tick: 80
 
 tc02:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -93,8 +105,11 @@ tc02:
 		Tick: 80
 
 tc01:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -103,18 +118,22 @@ tc01:
 		Tick: 80
 
 t18:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: t18.des
+	damaged-idle: t18.des
 		Start: 1
-	dead:
+	dead: t18.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 t17:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -123,8 +142,11 @@ t17:
 		Tick: 80
 
 t16:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -133,8 +155,11 @@ t16:
 		Tick: 80
 
 t15:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -143,8 +168,11 @@ t15:
 		Tick: 80
 
 t14:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -153,8 +181,11 @@ t14:
 		Tick: 80
 
 t13:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -163,8 +194,11 @@ t13:
 		Tick: 80
 
 t12:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -173,8 +207,11 @@ t12:
 		Tick: 80
 
 t11:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -183,8 +220,11 @@ t11:
 		Tick: 80
 
 t10:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -193,18 +233,20 @@ t10:
 		Tick: 80
 
 t09:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: t09.des
+	damaged-idle: t09.des
 		Start: 1
-	dead:
+	dead: t09.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 t08:
+	Defaults:
+		UseTilesetExtension: true
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -213,8 +255,11 @@ t08:
 		Tick: 80
 
 t07:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -223,8 +268,11 @@ t07:
 		Tick: 80
 
 t06:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -233,8 +281,11 @@ t06:
 		Tick: 80
 
 t05:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -243,18 +294,22 @@ t05:
 		Tick: 80
 
 t04:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: t04.des
+	damaged-idle: t04.des
 		Start: 1
-	dead:
+	dead: t04.des
 		Start: 2
 		Length: 8
 		Tick: 80
 
 t03:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -263,8 +318,11 @@ t03:
 		Tick: 80
 
 t02:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -273,8 +331,11 @@ t02:
 		Tick: 80
 
 t01:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
@@ -283,118 +344,187 @@ t01:
 		Tick: 80
 
 v01:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v01.husk:
 	idle: v01
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v02:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v02.husk:
 	idle: v02
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v03:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v03.husk:
 	idle: v03
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v04:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v04.husk:
 	idle: v04
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v05:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v05.husk:
 	idle: v05
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v06:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v06.husk:
 	idle: v06
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v07:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 2
 
 v07.husk:
 	idle: v07
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v08:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v08.husk:
 	idle: v08
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v09:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v09.husk:
 	idle: v09
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v10:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v10.husk:
 	idle: v10
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v11:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 
 v11.husk:
 	idle: v11
 		Start: 2
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v12:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 		ZOffset: -512
 	damaged-idle:
 		Start: 1
@@ -404,10 +534,16 @@ v12.husk:
 	idle: v12
 		Start: 2
 		ZOffset: -512
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v13:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 		ZOffset: -512
 	damaged-idle:
 		Start: 1
@@ -417,10 +553,16 @@ v13.husk:
 	idle: v13
 		Start: 2
 		ZOffset: -512
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v14:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 		ZOffset: -512
 	damaged-idle:
 		Start: 1
@@ -430,10 +572,16 @@ v14.husk:
 	idle: v14
 		Start: 2
 		ZOffset: -512
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v15:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 		ZOffset: -512
 	damaged-idle:
 		Start: 1
@@ -443,10 +591,16 @@ v15.husk:
 	idle: v15
 		Start: 2
 		ZOffset: -512
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v16:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 		ZOffset: -512
 	damaged-idle:
 		Start: 1
@@ -456,10 +610,16 @@ v16.husk:
 	idle: v16
 		Start: 2
 		ZOffset: -512
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v17:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 		ZOffset: -512
 	damaged-idle:
 		Start: 1
@@ -469,10 +629,16 @@ v17.husk:
 	idle: v17
 		Start: 2
 		ZOffset: -512
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v18:
+	Defaults:
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 	idle:
-		Start: 0
 		ZOffset: -512
 	damaged-idle:
 		Start: 1
@@ -482,10 +648,12 @@ v18.husk:
 	idle: v18
 		Start: 2
 		ZOffset: -512
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
 
 v19:
 	idle:
-		Start: 0
 		Length: 14
 		Tick: 120
 	damaged-idle:
@@ -497,7 +665,6 @@ v19.husk:
 	idle: v19
 		Start: 28
 	fire-start: flmspt
-		Start: 0
 		Length: *
 		Offset: 7,-15
 	fire-loop: flmspt
@@ -506,204 +673,239 @@ v19.husk:
 		Offset: 7,-15
 
 v20:
-	idle:
-		Start: 0
+	Defaults:
+		AddExtension: false
+	idle: v20.des
 		Length: 3
 		Tick: 120
-	damaged-idle:
+	damaged-idle: v20.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v20.husk:
-	idle: v20
+	idle: v20.des
 		Start: 6
+		AddExtension: false
 
 v21:
-	idle:
-		Start: 0
+	Defaults:
+		AddExtension: false
+	idle: v21.des
 		Length: 3
 		Tick: 120
-	damaged-idle:
+	damaged-idle: v21.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v21.husk:
-	idle: v21
+	idle: v21.des
 		Start: 6
+		AddExtension: false
 
 v22:
-	idle:
-		Start: 0
+	Defaults:
+		AddExtension: false
+	idle: v22.des
 		Length: 3
 		Tick: 120
-	damaged-idle:
+	damaged-idle: v22.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v22.husk:
-	idle: v22
+	idle: v22.des
 		Start: 6
+		AddExtension: false
 
 v23:
-	idle:
-		Start: 0
+	Defaults:
+		AddExtension: false
+	idle: v23.des
 		Length: 3
 		Tick: 120
-	damaged-idle:
+	damaged-idle: v23.des
 		Start: 3
 		Length: 3
 		Tick: 120
 
 v23.husk:
-	idle: v23
+	idle: v23.des
 		Start: 6
+		AddExtension: false
 
 v24:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v24.des
+	damaged-idle: v24.des
 		Start: 1
 
 v24.husk:
-	idle: v24
+	idle: v24.des
 		Start: 2
+		AddExtension: false
 
 v25:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v25.des
+	damaged-idle: v25.des
 		Start: 1
 
 v25.husk:
-	idle: v25
+	idle: v25.des
 		Start: 2
+		AddExtension: false
 
 v26:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v26.des
+	damaged-idle: v26.des
 		Start: 1
 
 v26.husk:
-	idle: v26
+	idle: v26.des
 		Start: 2
+		AddExtension: false
 
 v27:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v27.des
+	damaged-idle: v27.des
 		Start: 1
 
 v27.husk:
-	idle: v27
+	idle: v27.des
 		Start: 2
+		AddExtension: false
 
 v28:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v28.des
+	damaged-idle: v28.des
 		Start: 1
 
 v28.husk:
-	idle: v28
+	idle: v28.des
 		Start: 2
+		AddExtension: false
 
 v29:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v29.des
+	damaged-idle: v29.des
 		Start: 1
 
 v29.husk:
-	idle: v29
+	idle: v29.des
 		Start: 2
+		AddExtension: false
 
 v30:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v30.des
+	damaged-idle: v30.des
 		Start: 2
 
 v30.husk:
-	idle: v30
+	idle: v30.des
 		Start: 2
+		AddExtension: false
 
 v31:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v31.des
+	damaged-idle: v31.des
 		Start: 1
 
 v31.husk:
-	idle: v31
+	idle: v31.des
 		Start: 2
+		AddExtension: false
 
 v32:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v32.des
+	damaged-idle: v32.des
 		Start: 1
 
 v32.husk:
-	idle: v32
+	idle: v32.des
 		Start: 2
+		AddExtension: false
 
 v33:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v33.des
+	damaged-idle: v33.des
 		Start: 1
 
 v33.husk:
-	idle: v33
+	idle: v33.des
 		Start: 2
+		AddExtension: false
 
 v34:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v34.des
+	damaged-idle: v34.des
 		Start: 1
 
 v34.husk:
-	idle: v34
+	idle: v34.des
 		Start: 2
+		AddExtension: false
 
 v35:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v35.des
+	damaged-idle: v35.des
 		Start: 1
 
 v35.husk:
-	idle: v35
+	idle: v35.des
 		Start: 2
+		AddExtension: false
 
 v36:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v36.des
+	damaged-idle: v36.des
 		Start: 1
 
 v36.husk:
-	idle: v36
+	idle: v36.des
 		Start: 2
+		AddExtension: false
 
 v37:
-	idle:
-		Start: 0
-	damaged-idle:
+	Defaults:
+		AddExtension: false
+	idle: v37.des
+	damaged-idle: v37.des
 		Start: 1
 
 v37.husk:
-	idle: v37
+	idle: v37.des
 		Start: 2
+		AddExtension: false
 
 arco:
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 

--- a/mods/cnc/sequences/funpark.yaml
+++ b/mods/cnc/sequences/funpark.yaml
@@ -1,6 +1,5 @@
 steg:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -17,11 +16,9 @@ steg:
 		Start: 176
 		Length: 22
 	icon: stegicnh
-		Start: 0
 
 trex:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -38,11 +35,9 @@ trex:
 		Start: 144
 		Length: 40
 	icon: trexicnh
-		Start: 0
 
 tric:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -59,11 +54,9 @@ tric:
 		Start: 176
 		Length: 20
 	icon: tricicnh
-		Start: 0
 
 rapt:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -80,4 +73,3 @@ rapt:
 		Start: 144
 		Length: 40
 	icon: rapticnh
-		Start: 0

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -1,84 +1,63 @@
 vice:
 	idle:
-		Start: 0
 		Length: *
 	muzzle0: chem-n
-		Start: 0
 		Length: *
 		Offset: 3,4
 	muzzle1: chem-nw
-		Start: 0
 		Length: *
 		Offset: 4,1
 	muzzle2: chem-w
-		Start: 0
 		Length: *
 		Offset: 7,-3
 	muzzle3: chem-sw
-		Start: 0
 		Length: *
 		Offset: 3,-6
 	muzzle4: chem-s
-		Start: 0
 		Length: *
 		Offset: 1,-6
 	muzzle5: chem-se
-		Start: 0
 		Length: *
 		Offset: -3,-5
 	muzzle6: chem-e
-		Start: 0
 		Length: *
 		Offset: -6,-3
 	muzzle7: chem-ne
-		Start: 0
 		Length: *
 		Offset: -1,0
 	icon: viceicnh
-		Start: 0
 
 pvice:
 	idle:
-		Start: 0
 		Length: *
 	muzzle0: chem-n
-		Start: 0
 		Length: *
 		Offset: 3,4
 	muzzle1: chem-nw
-		Start: 0
 		Length: *
 		Offset: 4,1
 	muzzle2: chem-w
-		Start: 0
 		Length: *
 		Offset: 7,-3
 	muzzle3: chem-sw
-		Start: 0
 		Length: *
 		Offset: 3,-6
 	muzzle4: chem-s
-		Start: 0
 		Length: *
 		Offset: 1,-6
 	muzzle5: chem-se
-		Start: 0
 		Length: *
 		Offset: -3,-5
 	muzzle6: chem-e
-		Start: 0
 		Length: *
 		Offset: -6,-3
 	muzzle7: chem-ne
-		Start: 0
 		Length: *
 		Offset: -1,0
 	icon: viceicnh
-		Start: 0
 
 e1:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -172,12 +151,11 @@ e1:
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e1icnh
-		Start: 0
+	icon: e1icnh.tem
+		AddExtension: False
 
 e2:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -262,12 +240,11 @@ e2:
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e2icnh
-		Start: 0
+	icon: e2icnh.tem
+		AddExtension: False
 
 e3:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -352,12 +329,11 @@ e3:
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e3icnh
-		Start: 0
+	icon: e3icnh.tem
+		AddExtension: False
 
 e4:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -443,43 +419,34 @@ e4:
 		Tick: 1600
 		ZOffset: -511
 	muzzle0: flame-n
-		Start: 0
 		Length: *
 		Offset: 1,6
 	muzzle1: flame-nw
-		Start: 0
 		Length: *
 		Offset: 8,7
 	muzzle2: flame-w
-		Start: 0
 		Length: *
 		Offset: 8,2
 	muzzle3: flame-sw
-		Start: 0
 		Length: *
 		Offset: 7,-2
 	muzzle4: flame-s
-		Start: 0
 		Length: *
 		Offset: 1,-2
 	muzzle5: flame-se
-		Start: 0
 		Length: *
 		Offset: -5,-2
 	muzzle6: flame-e
-		Start: 0
 		Length: *
 		Offset: -7,2
 	muzzle7: flame-ne
-		Start: 0
 		Length: *
 		Offset: -7,8
-	icon: e4icnh
-		Start: 0
+	icon: e4icnh.tem
+		AddExtension: False
 
 e5:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -565,43 +532,34 @@ e5:
 		Tick: 1600
 		ZOffset: -511
 	muzzle0: chem-n
-		Start: 0
 		Length: *
 		Offset: 1,2
 	muzzle1: chem-nw
-		Start: 0
 		Length: *
 		Offset: 8,2
 	muzzle2: chem-w
-		Start: 0
 		Length: *
 		Offset: 8,-3
 	muzzle3: chem-sw
-		Start: 0
 		Length: *
 		Offset: 7,-6
 	muzzle4: chem-s
-		Start: 0
 		Length: *
 		Offset: 1,-6
 	muzzle5: chem-se
-		Start: 0
 		Length: *
 		Offset: -5,-6
 	muzzle6: chem-e
-		Start: 0
 		Length: *
 		Offset: -7,-3
 	muzzle7: chem-ne
-		Start: 0
 		Length: *
 		Offset: -3,2
-	icon: e5icnh
-		Start: 0
+	icon: e5icnh.tem
+		AddExtension: False
 
 e6:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -678,12 +636,11 @@ e6:
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: e6icnh
-		Start: 0
+	icon: e6icnh.tem
+		AddExtension: False
 
 rmbo:
 	stand:
-		Start: 0
 		Facings: 8
 	stand2:
 		Start: 8
@@ -772,5 +729,5 @@ rmbo:
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
-	icon: rmboicnh
-		Start: 0
+	icon: rmboicnh.tem
+		AddExtension: False

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -1,27 +1,22 @@
 fb4:
 	idle:
-		Start: 0
 		Length: 4
 
 fire:
 	1: fire1
-		Start: 0
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
 	2: fire2
-		Start: 0
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
 
 120mm:
 	idle:
-		Start: 0
 
 smoke_m:
 	idle:
-		Start: 0
 		Length: *
 		Offset: 2, -5
 		ZOffset: 512
@@ -31,97 +26,73 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 	end:
-		Start: 0
 		Length: 26
 		Offset: 2, -5
 		ZOffset: 512
 
 laserfire:
 	idle:veh-hit3
-		Start: 0
 		Length: *
 
 dragon:
 	idle:
-		Start: 0
 		Facings: 32
 
 smokey:
 	idle:
-		Start: 0
 		Length: *
 
 bomb:
 	idle:
-		Start: 0
 		Length: *
 
 missile:
 	idle:
-		Start: 0
 		Facings: 32
 
 patriot:
 	idle:
-		Start: 0
 		Facings: 32
 
 explosion:
 	nuke_explosion: atomsfx
-		Start: 0
 		Length: *
 	piff: piff
-		Start: 0
 		Length: *
 	piffs: piffpiff
-		Start: 0
 		Length: *
 	chemball: chemball		#same size as small_napalm, but bright green.
-		Start: 0
 		Length: *
 	small_napalm: napalm1		#not used by much. currently used for flamethrower.
-		Start: 0
 		Length: *
 	med_napalm: napalm2		#explosion for bomblets
-		Start: 0
 		Length: *
 	big_napalm: napalm3		#huge; not used. (SSM used this explosion in C&C Gold?)
-		Start: 0
 		Length: *
 	small_frag: veh-hit3		#the most common weapon-hit explosion. For rockets, tank shells, etc. 
-		Start: 0
 		Length: *
 	med_frag: frag1			#fragmentation-style; quite large. (MLRS used this explosion in C&C Gold?)
-		Start: 0
 		Length: *
 	big_frag: frag3			#Same as med_frag, except fire hangs around longer.
-		Start: 0
 		Length: *
 	small_poof: veh-hit2		#for Grenades; tower missiles; boat missiles; APC AA gun.
-		Start: 0
 		Length: *
 	poof: art-exp1			#For UnitExplode (artillery); artillery shell hit; GrenadierExplode, 
-		Start: 0
 		Length: *
 	small_building: veh-hit1	#like "building' explosion, but much smaller. (Used for heli-explosion in C&C Gold?)
-		Start: 0
 		Length: *
 	building: fball1		#Large explosion, for when a building explodes. 
-		Start: 0
 		Length: *
 
 rank:
 	rank:
-		Start: 0
 		Length: *
 
 rallypoint:
 	flag:flagfly
-		Start: 0
 		Length: *
 		Offset: 10,-5
 	circles:fpls
-		Start: 0
 		Length: *
 
 beacon:
@@ -129,18 +100,12 @@ beacon:
 		Start: 5
 		Offset: 1,-12
 	circles: fpls
-		Start: 0
 		Length: *
 	airstrike: bombicon
-		Start: 0
-		Length: 1
 		Offset: 0,-42
 	atomic: atomicon
-		Start: 0
-		Length: 1
 		Offset: 0,-42
 	clock: beaconclock
-		Start: 0
 		Length: *
 		Offset: 0,-42
 
@@ -150,24 +115,19 @@ select:
 
 allyrepair:
 	repair:
-		Start: 0
 		Length: *
 		Tick: 160
 
 crate:
 	idle:
-		Start: 0
 		ZOffset: -511
 	land:
-		Start: 0
 		ZOffset: -511
 
 xcratea:
 	idle: xcrate
-		Start: 0
 		ZOffset: -511
 	land: xcrate
-		Start: 0
 		ZOffset: -511
 
 xcrateb:
@@ -196,93 +156,70 @@ xcrated:
 
 crate-effects:
 	airstrike: deviator
-		Start: 0
 		Length: *
 	nuke: missile2
-		Start: 0
 		Length: *
 	dollar: dollar
-		Start: 0
 		Length: *
 	reveal-map: radarcrate
-		Start: 0
 		Length: *
 	hide-map: empulse
-		Start: 0
 		Length: *
 	heal: healcrate
-		Start: 0
 		Length: *
 	mine: mine
-		Start: 0
 		Length: *
 	redskull: rapid
-		Start: 0
 		Length: *
 	cloak: cloakcrate
-		Start: 0
 		Length: *
 	levelup: levelup
-		Start: 0
 		Length: *
 		Tick: 200
 	firepowerup: firepowercrate
-		Start: 0
 		Length: *
 	armorup: armorcrate
-		Start: 0
 		Length: *
 	speedup: speedcrate
-		Start: 0
 		Length: *
 
 atomicup:
 	idle:
-		Start: 0
 		Length: *
 
 atomicdn:
 	idle:
-		Start: 0
 		Length: *
 
 atomic:
 	up: atomicup
-		Start: 0
 		Length: *
 	down: atomicdn
-		Start: 0
 		Length: *
 
 ionsfx:
 	idle:
-		Start: 0
 		Length: *
 		Offset: 0, -78
 		ZOffset: 1
 
 bomblet:
 	idle:
-		Start: 0
 		Length: *
 
 mpspawn:
 	idle:
-		Start: 0
 		Length: *
 
 waypoint:
 	idle:
-		Start: 0
 		Length: *
 
 clock:
 	idle: hclock
-		Start: 0
 		Length: *
 pips:
 	pip-empty:
-		Start: 0
 	pip-green:
 		Start: 1
 	pip-yellow:
@@ -294,152 +231,156 @@ pips:
 	pip-blue:
 		Start: 5
 	groups: pdigits
-		Start: 0
 		Length: *
 
 overlay:
 	build-valid-desert:
-		Start: 0
 	build-valid-snow:
 		Start: 2
 	build-valid-temperat:
-		Start: 0
 	build-valid-winter:
-		Start: 0
 	build-valid-jungle:
-		Start: 0
 	build-invalid:
 		Start: 1
 	target-select:
 		Start: 3
 	target-valid-desert:
-		Start: 0
 	target-valid-snow:
 		Start: 2
 	target-valid-temperat:
-		Start: 0
 	target-valid-winter:
-		Start: 0
 	target-valid-jungle:
-		Start: 0
 	target-invalid:
 		Start: 1
 
-powerdown:
-	disabled: speed
-		Start: 3
-
 poweroff:
 	offline:
-		Start: 0
 		Length: *
 		Tick: 160
 
 icon:
-	airstrike: bombicnh
-		Start: 0
-	ioncannon: ionicnh
-		Start: 0
-	abomb: atomicnh
-		Start: 0
+	airstrike: bombicnh.tem
+		AddExtension: False
+	ioncannon: ionicnh.tem
+		AddExtension: False
+	abomb: atomicnh.tem
+		AddExtension: False
 
 moveflsh:
 	idle:
-		Start: 0
 		Length: *
 		Tick: 80
 
 resources:
+	Defaults:
+		UseTilesetExtension: true
+		Length: *
 	ti1: ti1
-		Length: *
 	ti2: ti2
-		Length: *
 	ti3: ti3
-		Length: *
 	ti4: ti4
-		Length: *
 	ti5: ti5
-		Length: *
 	ti6: ti6
-		Length: *
 	ti7: ti7
-		Length: *
 	ti8: ti8
-		Length: *
 	ti9: ti9
-		Length: *
 	ti10: ti10
-		Length: *
 	ti11: ti11
-		Length: *
 	ti12: ti12
-		Length: *
 	bti1: rtib1
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti2: rtib2
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti3: rtib3
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti4: rtib4
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti5: rtib5
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti6: rtib6
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti7: rtib7
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti8: rtib8
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti9: rtib9
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti10: rtib10
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti11: rtib11
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 	bti12: rtib12
-		Length: *
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 
 shroud:
-	typea: shadow
-		Start: 0
+	Defaults:
 		Length: 12
+	typea: shadow
 	typeb: shadow
 		Start: 12
-		Length: 12
 	typec: shadow
 		Start: 24
-		Length: 12
 	typed: shadow
 		Start: 36
-		Length: 12
 	full: fullshroud
+		Length: 1
 
 # Note: The order of smudges and craters determines
 # the index that is mapped to them in maps
 scorches:
+	Defaults:
+		UseTilesetExtension: true
+		Length: *
 	sc1: sc1
-		Length: *
 	sc2: sc2
-		Length: *
 	sc3: sc3
-		Length: *
 	sc4: sc4
-		Length: *
 	sc5: sc5
-		Length: *
 	sc6: sc6
-		Length: *
 
 craters:
+	Defaults:
+		UseTilesetExtension: true
+		Length: *
 	cr1: cr1
-		Length: *
 	cr2: cr2
-		Length: *
 	cr3: cr3
-		Length: *
 	cr4: cr4
-		Length: *
 	cr5: cr5
-		Length: *
 	cr6: cr6
-		Length: *

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -4,7 +4,6 @@ fact:
 		Length: 20
 		Tick: 100
 	idle:
-		Start: 0
 		Length: 4
 		Tick: 100
 	damaged-idle:
@@ -19,18 +18,15 @@ fact:
 		Start: 48
 		Tick: 800
 	make: factmake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib2
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
 	icon: facticnh
-		Start: 0
 
 nuke:
 	idle:
-		Start: 0
 		Length: 4
 		Tick: 1000
 	damaged-idle:
@@ -41,18 +37,16 @@ nuke:
 		Start: 8
 		Tick: 800
 	make: nukemake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib3
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: nukeicnh
-		Start: 0
+	icon: nukeicnh.tem
+		AddExtension: False
 
 proc:
 	idle:
-		Start: 0
 		Length: 6
 		Tick: 120
 	damaged-idle:
@@ -63,11 +57,9 @@ proc:
 		Start: 60
 		Tick: 800
 	make: procmake
-		Start: 0
 		Length: *
 		Tick: 80
 	resources: proctwr
-		Start: 0
 		Length: 6
 		Offset: -32,-21
 	damaged-resources: proctwr
@@ -75,14 +67,13 @@ proc:
 		Length: 6
 		Offset: -32,-21
 	bib: bib2
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: procicnh
-		Start: 0
+	icon: procicnh.tem
+		AddExtension: False
 
 silo:
 	idle:
-		Start: 0
 		Length: 5
 		Offset: 0,-1
 	damaged-idle:
@@ -94,38 +85,38 @@ silo:
 		Offset: 0,-1
 		Tick: 800
 	make: silomake
-		Start: 0
 		Length: *
 		Tick: 80
 		Offset: 0,-1
 	bib: mbSILO
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: 0,1
-	icon: siloicnh
-		Start: 0
+	icon: siloicnh.tem
+		AddExtension: False
 
 hand:
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
 		Start: 2
 		Tick: 800
 	make: handmake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib3
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: handicnh
-		Start: 0
+	icon: handicnh.tem
+		AddExtension: False
 
 pyle:
 	idle:
-		Start: 0
 		Length: 10
 		Tick: 100		
 	damaged-idle:
@@ -136,50 +127,43 @@ pyle:
 		Start: 20
 		Tick: 800
 	make: pylemake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib3
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: pyleicnh
-		Start: 0
+	icon: pyleicnh.tem
+		AddExtension: False
 
 weap:
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
 		Start: 2
 		Tick: 800
 	build-top: weap2
-		Start: 0
 		Length: 10
 	damaged-build-top: weap2
 		Start: 10
 		Length: 10
 	idle-top: weap2
-		Start: 0
 	damaged-idle-top: weap2
 		Start: 4
 	make: weapmake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib2
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: weapicnh
-		Start: 0
+	icon: weapicnh.tem
+		AddExtension: False
 
 afld:
 	idle:
-		Start: 0
 		Tick: 120
 		ZOffset: -1023
 	active:
-		Start: 0
 		Length: 16
 		Tick: 120
 		ZOffset: -1023
@@ -197,18 +181,16 @@ afld:
 		ZOffset: -1023
 		Tick: 800
 	make: afldmake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib1
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: afldicnh
-		Start: 0
+	icon: afldicnh.tem
+		AddExtension: False
 
 hq:
 	idle:
-		Start: 0
 		Length: 16
 		Tick: 100
 	damaged-idle:
@@ -219,18 +201,16 @@ hq:
 		Start: 32
 		Tick: 800
 	make: hqmake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib3
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: hqicnh
-		Start: 0
+	icon: hqicnh.tem
+		AddExtension: False
 
 nuk2:
 	idle:
-		Start: 0
 		Length: 4
 		Tick: 1000
 	damaged-idle:
@@ -241,18 +221,16 @@ nuk2:
 		Start: 8
 		Tick: 800
 	make: nuk2make
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib3
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: nuk2icnh
-		Start: 0
+	icon: nuk2icnh.tem
+		AddExtension: False
 
 hpad:
 	idle:
-		Start: 0
 		ZOffset: -1023
 	damaged-idle:
 		Start: 7
@@ -272,21 +250,18 @@ hpad:
 		ZOffset: -1023
 		Tick: 800
 	make: hpadmake
-		Start: 0
 		Length: *
 		Tick: 80
-	icon: hpadicnh
-		Start: 0
+	icon: hpadicnh.tem
+		AddExtension: False
 
 fix:
 	idle:
-		Start: 0
 		ZOffset: -1c511
 	damaged-idle:
 		Start: 7
 		ZOffset: -1c511
 	active:
-		Start: 0
 		Length: 7
 		ZOffset: -1c511
 	damaged-active:
@@ -298,19 +273,21 @@ fix:
 		ZOffset: -1c511
 		Tick: 800
 	make: fixmake
-		Start: 0
 		Length: 14
 		Tick: 60
 	bib: mbFIX
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: 0,-9
-	icon: fixicnh
-		Start: 0
+	icon: fixicnh.tem
+		AddExtension: False
 
 eye:
 	idle:
-		Start: 0
 		Length: 16
 		Tick: 100
 	damaged-idle:
@@ -321,22 +298,19 @@ eye:
 		Start: 32
 		Tick: 800
 	make: eyemake
-		Start: 0
 		Length: *
 		Tick: 80
 	bib: bib3
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: eyeicnh
-		Start: 0
+	icon: eyeicnh.tem
+		AddExtension: False
 
 tmpl:
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 5
 	active:
-		Start: 0
 		Length: 5
 	damaged-active:
 		Start: 5
@@ -345,22 +319,19 @@ tmpl:
 		Start: 10
 		Tick: 800
 	make: tmplmake
-		Start: 0
 		Length: *
 		Tick: 60
 	bib: bib2
-		Start: 0
+		UseTilesetExtension: true
 		Length: *
-	icon: tmplicnh
-		Start: 0
+	icon: tmplicnh.tem
+		AddExtension: False
 
 obli:
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 4
 	active:
-		Start: 0
 		Length: 4
 		Tick: 680
 	damaged-active:
@@ -371,19 +342,21 @@ obli:
 		Start: 8
 		Tick: 800
 	make: oblimake
-		Start: 0
 		Length: 13
 		Tick: 80
 	bib: mbOBLI
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: -1,-3
-	icon: obliicnh
-		Start: 0
+	icon: obliicnh.tem
+		AddExtension: False
 
 brik:
 	idle:
-		Start: 0
 		Length: 16
 	scratched-idle:
 		Start: 16
@@ -391,29 +364,26 @@ brik:
 	damaged-idle:
 		Start: 32
 		Length: 16
-	icon: brikicnh
-		Start: 0
+	icon: brikicnh.tem
+		AddExtension: False
 
 sbag:
 	idle:
-		Start: 0
 		Length: 16
-	icon: sbagicnh
-		Start: 0
+	icon: sbagicnh.tem
+		AddExtension: False
 
 cycl:
 	idle:
-		Start: 0
 		Length: 16
 	damaged-idle:
 		Start: 16
 		Length: 16
-	icon: cyclicnh
-		Start: 0
+	icon: cyclicnh.tem
+		AddExtension: False
 
 barb:
 	idle:
-		Start: 0
 		Length: 16
 	damaged-idle:
 		Start: 16
@@ -421,7 +391,6 @@ barb:
 
 wood:
 	idle:
-		Start: 0
 		Length: 16
 	damaged-idle:
 		Start: 16
@@ -429,7 +398,6 @@ wood:
 
 gun:
 	idle:
-		Start: 0
 		Facings: 32
 	recoil:
 		Start: 32
@@ -441,18 +409,20 @@ gun:
 		Start: 96
 		Facings: 32
 	make: gunmake
-		Start: 0
 		Length: *
 		Tick: 80
 	muzzle: gunfire2
-		Start: 0
 		Length: *
 	bib: mbGUN
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: -1,-1
-	icon: gunicnh
-		Start: 0
+	icon: gunicnh.tem
+		AddExtension: False
 
 sam:
 	closed-idle:
@@ -485,42 +455,40 @@ sam:
 		Start: 128
 		Tick: 800
 	make: sammake
-		Start: 0
 		Length: 20
 		Tick: 30
 	muzzle: samfire
-		Start: 0
 		Length: 18
 		Facings: 8
-	icon: samicnh
-		Start: 0
+	icon: samicnh.tem
+		AddExtension: False
 
 gtwr:
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	dead:
 		Start: 2
 		Tick: 800
 	make: gtwrmake
-		Start: 0
 		Length: *
 		Tick: 80
 	muzzle: minigun
-		Start: 0
 		Length: 6
 		Facings: 8
 	bib: mbGTWR
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: 0,-2
-	icon: gtwricnh
-		Start: 0
+	icon: gtwricnh.tem
+		AddExtension: False
 
 atwr:
 	idle:
-		Start: 0
 		Offset: 0,-1
 	damaged-idle:
 		Start: 1
@@ -530,24 +498,25 @@ atwr:
 		Offset: 0,-1
 		Tick: 800
 	make: atwrmake
-		Start: 0
 		Length: *
 		Tick: 80
 		Offset: 0,-1
 	muzzle: gunfire2
-		Start: 0
 		Length: *
 		Offset: 0,-1
 	bib: mbGTWR
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: -3,0
-	icon: atwricnh
-		Start: 0
+	icon: atwricnh.tem
+		AddExtension: False
 
 hosp:
 	idle:
-		Start: 0
 		Length: 4
 		Tick: 100
 		Offset: 0,-2
@@ -556,12 +525,15 @@ hosp:
 		Length: 4
 		Offset: 0,-2
 	make: hospmake
-		Start: 0
 		Length: *
 		Tick: 80
 		Offset: 0,-2
 	bib: mbHOSP
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: 0,1
 
@@ -569,17 +541,19 @@ hosp.husk:
 	idle: hosp
 		Start: 8
 	bib: mbHOSP
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: 0,1
 
 bio:
 	idle:
-		Start: 0
 	damaged-idle:
 		Start: 1
 	make: biomake
-		Start: 0
 		Length: *
 		Tick: 80
 
@@ -589,27 +563,32 @@ bio.husk:
 
 miss:
 	idle:
-		Start: 0
 		Offset: 0,-1
 	damaged-idle:
 		Start: 1
 		Offset: 0,-1
 	make: missmake
-		Start: 0
 		Length: *
 		Tick: 80
 		Offset: 0,-1
 	bib: mbMISS
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: 0,1
 	icon: missicnh
-		Start: 0
 
 miss.husk:
 	idle: miss
 		Start: 2
 	bib: mbMISS
-		Start: 0
+		UseTilesetExtension: true
+		TilesetOverrides:
+			WINTER: TEMPERAT
+			JUNGLE: TEMPERAT
+			SNOW: TEMPERAT
 		Length: *
 		Offset: 0,1

--- a/mods/cnc/sequences/vehicles.yaml
+++ b/mods/cnc/sequences/vehicles.yaml
@@ -1,19 +1,16 @@
 mcv:
 	idle:
-		Start: 0
 		Facings: 32
-	icon: mcvicnh
-		Start: 0
+	icon: mcvicnh.tem
+		AddExtension: False
 
 mcv.destroyed:
 	idle: mcv
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 
 harv:
 	idle:
-		Start: 0
 		Facings: 32
 	harvest:
 		Start: 32
@@ -21,37 +18,31 @@ harv:
 		Facings: 8
 		Tick: 60
 	dock: harvdump
-		Start: 0
 		Length: 7
 	dock-loop: harvdump
 		Start: 7
-		Length: 1
-	icon: harvicnh
-		Start: 0
+	icon: harvicnh.tem
+		AddExtension: False
 
 harv.destroyed:
 	idle: harv
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 
 bggy:
 	idle:
-		Start: 0
 		Facings: 32
 	turret:
 		Start: 32
 		Facings: 32
 	muzzle: minigun
-		Start: 0
 		Length: 6
 		Facings: 8
-	icon: bggyicnh
-		Start: 0
+	icon: bggyicnh.tem
+		AddExtension: False
 
 bggy.destroyed:
 	idle: bggy
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: bggy
@@ -61,20 +52,17 @@ bggy.destroyed:
 
 mtnk:
 	idle:
-		Start: 0
 		Facings: 32
 	turret:
 		Start: 32
 		Facings: 32
 	muzzle: gunfire2
-		Start: 0
 		Length: *
-	icon: mtnkicnh
-		Start: 0
+	icon: mtnkicnh.tem
+		AddExtension: False
 
 mtnk.destroyed:
 	idle: mtnk
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: mtnk
@@ -84,20 +72,17 @@ mtnk.destroyed:
 
 ltnk:
 	idle:
-		Start: 0
 		Facings: 32
 	turret:
 		Start: 32
 		Facings: 32
 	muzzle: gunfire2
-		Start: 0
 		Length: *
-	icon: ltnkicnh
-		Start: 0
+	icon: ltnkicnh.tem
+		AddExtension: False
 
 ltnk.destroyed:
 	idle: ltnk
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: ltnk
@@ -107,20 +92,17 @@ ltnk.destroyed:
 
 htnk:
 	idle:
-		Start: 0
 		Facings: 32
 	turret:
 		Start: 32
 		Facings: 32
 	muzzle: gunfire2
-		Start: 0
 		Length: *
-	icon: htnkicnh
-		Start: 0
+	icon: htnkicnh.tem
+		AddExtension: False
 
 htnk.destroyed:
 	idle: htnk
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: htnk
@@ -130,21 +112,18 @@ htnk.destroyed:
 
 jeep:
 	idle:
-		Start: 0
 		Facings: 32
 	turret:
 		Start: 32
 		Facings: 32
 	muzzle: minigun
-		Start: 0
 		Length: 6
 		Facings: 8
-	icon: jeepicnh
-		Start: 0
+	icon: jeepicnh.tem
+		AddExtension: False
 
 jeep.destroyed:
 	idle: jeep
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: jeep
@@ -154,75 +133,60 @@ jeep.destroyed:
 
 bike:
 	idle:
-		Start: 0
 		Facings: 32
-	icon: bikeicnh
-		Start: 0
+	icon: bikeicnh.tem
+		AddExtension: False
 
 bike.destroyed:
 	idle: bike
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 
 ftnk:
 	idle:
-		Start: 0
 		Facings: 32
 	muzzle0: flame-n
-		Start: 0
 		Length: *
 		Offset: 3,8
 	muzzle1: flame-nw
-		Start: 0
 		Length: *
 		Offset: 4,6
 	muzzle2: flame-w
-		Start: 0
 		Length: *
 		Offset: 7,2
 	muzzle3: flame-sw
-		Start: 0
 		Length: *
 		Offset: 3,-2
 	muzzle4: flame-s
-		Start: 0
 		Length: *
 		Offset: 1,-2
 	muzzle5: flame-se
-		Start: 0
 		Length: *
 		Offset: -3,-1
 	muzzle6: flame-e
-		Start: 0
 		Length: *
 		Offset: -6,2
 	muzzle7: flame-ne
-		Start: 0
 		Length: *
 		Offset: -5,6
-	icon: ftnkicnh
-		Start: 0
+	icon: ftnkicnh.tem
+		AddExtension: False
 
 ftnk.destroyed:
 	idle: ftnk
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 
 mhq:
 	idle:
-		Start: 0
 		Facings: 32
 	spinner:
 		Start: 32
 		Length: 32
 	icon: mhqicnh
-		Start: 0
 
 msam:
 	idle:
-		Start: 0
 		Facings: 32
 	turret:
 		Start: 32
@@ -233,12 +197,11 @@ msam:
 	turret-3:
 		Start: 64
 		Facings: 32
-	icon: msamicnh
-		Start: 0
+	icon: msamicnh.tem
+		AddExtension: False
 
 msam.destroyed:
 	idle: msam
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: msam
@@ -248,7 +211,6 @@ msam.destroyed:
 
 mlrs:
 	idle:
-		Start: 0
 		Facings: 32
 	turret:
 		Start: 32
@@ -259,12 +221,11 @@ mlrs:
 	turret-3:
 		Start: 96
 		Facings: 32
-	icon: mlrsicnh
-		Start: 0
+	icon: mlrsicnh.tem
+		AddExtension: False
 
 mlrs.destroyed:
 	idle: mlrs
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: mlrs
@@ -274,42 +235,34 @@ mlrs.destroyed:
 
 stnk:
 	idle:
-		Start: 0
 		Facings: 32
-	icon: stnkicnh
-		Start: 0
+	icon: stnkicnh.tem
+		AddExtension: False
 
 stnk.destroyed:
 	idle: stnk
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 
 arty:
 	idle:
-		Start: 0
 		Facings: 32
 	muzzle: gunfire2
-		Start: 0
 		Length: *
-	icon: artyicnh
-		Start: 0
+	icon: artyicnh.tem
+		AddExtension: False
 
 arty.destroyed:
 	idle: arty
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 
 apc:
 	idle:
-		Start: 0
 		Facings: 32
 	turret: apctur
-		Start: 0
 		Facings: 32
 	muzzle: apcmuz
-		Start: 0
 		Length: 3
 		Stride: 6
 		Facings: 8
@@ -318,15 +271,13 @@ apc:
 		Length: 3
 	unload:
 		Start: 32
-	icon: apcicnh
-		Start: 0
+	icon: apcicnh.tem
+		AddExtension: False
 
 apc.destroyed:
 	idle: apc
-		Start: 0
 		Facings: 32
 		ZOffset: -512
 	turret: apctur
-		Start: 0
 		Facings: 32
 		ZOffset: -512

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -2,7 +2,7 @@ General:
 	Name: Desert
 	Id: DESERT
 	Palette: desert.pal
-	Extensions: .des, .shp, .tem
+	Extensions: # Obsolete
 	WaterPaletteRotationBase: 32
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -2,7 +2,7 @@ General:
 	Name: Jungle
 	Id: JUNGLE
 	Palette: jungle.pal
-	Extensions: .jun, .tem, .shp
+	Extensions: # Obsolete
 	WaterPaletteRotationBase: 32
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -2,7 +2,7 @@ General:
 	Name: Snow
 	Id: SNOW
 	Palette: snow.pal
-	Extensions: .sno, .shp, .tem
+	Extensions: # Obsolete
 	WaterPaletteRotationBase: 32
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -2,7 +2,7 @@ General:
 	Name: Temperate
 	Id: TEMPERAT
 	Palette: temperat.pal
-	Extensions: .tem, .shp
+	Extensions: # Obsolete
 	WaterPaletteRotationBase: 32
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -2,7 +2,7 @@ General:
 	Name: Winter
 	Id: WINTER
 	Palette: winter.pal
-	Extensions: .win, .shp, .tem
+	Extensions: # Obsolete
 	WaterPaletteRotationBase: 32
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 


### PR DESCRIPTION
This adds new sequence parser support for tileset-specific filename resolution (the last addition needed for #5272), and disables the legacy filename resolution for TD.

`OpenRA.Utility.exe cnc --check-sequence-sprites` now passes.

This and #7731 are the final prerequisites for TS/RA2 style tileset-specific art.  The next pr after these will add the long-awaited TS snow tileset and artwork.
