### PR TITLE
Account for terrain height and slope when calculating order location.

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -87,6 +87,29 @@ namespace OpenRA
 			return r.Contains(p.ToPointF());
 		}
 
+		static int WindingDirectionTest(int2 v0, int2 v1, int2 p)
+		{
+			return (v1.X - v0.X) * (p.Y - v0.Y) - (p.X - v0.X) * (v1.Y - v0.Y);
+		}
+
+		public static bool PolygonContains(this int2[] polygon, int2 p)
+		{
+			var windingNumber = 0;
+
+			for (var i = 0; i < polygon.Length; i++)
+			{
+				var tv = polygon[i];
+				var nv = polygon[(i + 1) % polygon.Length];
+
+				if (tv.Y <= p.Y && nv.Y > p.Y && WindingDirectionTest(tv, nv, p) > 0)
+					windingNumber++;
+				else if (tv.Y > p.Y && nv.Y <= p.Y && WindingDirectionTest(tv, nv, p) < 0)
+					windingNumber--;
+			}
+
+			return windingNumber != 0;
+		}
+
 		public static bool HasModifier(this Modifiers k, Modifiers mod)
 		{
 			return (k & mod) == mod;

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -494,7 +494,7 @@ namespace OpenRA
 				if (worldRenderer != null)
 				{
 					Renderer.BeginFrame(worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.Zoom);
-					Sound.SetListenerPosition(worldRenderer.Position(worldRenderer.Viewport.CenterLocation));
+					Sound.SetListenerPosition(worldRenderer.Viewport.CenterPosition);
 					worldRenderer.Draw();
 				}
 				else

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -105,7 +105,64 @@ namespace OpenRA.Graphics
 
 		public CPos ViewToWorld(int2 view)
 		{
+			var world = worldRenderer.Viewport.ViewToWorldPx(view);
+			var map = worldRenderer.World.Map;
+			var ts = Game.ModData.Manifest.TileSize;
+			var candidates = CandidateMouseoverCells(world);
+			var tileSet = worldRenderer.World.TileSet;
+
+			foreach (var uv in candidates)
+			{
+				// Coarse filter to nearby cells
+				var p = map.CenterOfCell(uv.ToCPos(map.TileShape));
+				var s = worldRenderer.ScreenPxPosition(p);
+				if (Math.Abs(s.X - world.X) <= ts.Width && Math.Abs(s.Y - world.Y) <= ts.Height)
+				{
+					var tile = map.MapTiles.Value[uv];
+					var ti = tileSet.GetTileInfo(tile);
+					var ramp = ti != null ? ti.RampType : 0;
+
+					var corners = map.CellCorners[ramp];
+					var pos = map.CenterOfCell(uv.ToCPos(map));
+					var screen = corners.Select(c => worldRenderer.ScreenPxPosition(pos + c)).ToArray();
+
+					if (screen.PolygonContains(world))
+						return uv.ToCPos(map);
+				}
+			}
+
+			// Mouse is not directly over a cell (perhaps on a cliff)
+			// Try and find the closest cell
+			if (candidates.Any())
+			{
+				return candidates.OrderBy(uv =>
+				{
+					var p = map.CenterOfCell(uv.ToCPos(map.TileShape));
+					var s = worldRenderer.ScreenPxPosition(p);
+					var dx = Math.Abs(s.X - world.X);
+					var dy = Math.Abs(s.Y - world.Y);
+
+					return dx * dx + dy * dy;
+				}).First().ToCPos(map);
+			}
+
+			// Something is very wrong, but lets return something that isn't completely bogus and hope the caller can recover
 			return worldRenderer.World.Map.CellContaining(worldRenderer.Position(ViewToWorldPx(view)));
+		}
+
+		/// <summary> Returns an unfiltered list of all cells that could potentially contain the mouse cursor</summary>
+		IEnumerable<MPos> CandidateMouseoverCells(int2 world)
+		{
+			var map = worldRenderer.World.Map;
+			var minPos = worldRenderer.Position(world);
+
+			// Find all the cells that could potentially have been clicked
+			var a = map.CellContaining(minPos - new WVec(1024, 0, 0)).ToMPos(map.TileShape);
+			var b = map.CellContaining(minPos + new WVec(512, 512 * maxGroundHeight, 0)).ToMPos(map.TileShape);
+
+			for (var v = b.V; v >= a.V; v--)
+				for (var u = b.U; u >= a.U; u--)
+					yield return new MPos(u, v);
 		}
 
 		public int2 ViewToWorldPx(int2 view) { return (1f / Zoom * view.ToFloat2()).ToInt2() + TopLeft; }

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -118,9 +118,14 @@ namespace OpenRA.Graphics
 				var s = worldRenderer.ScreenPxPosition(p);
 				if (Math.Abs(s.X - world.X) <= ts.Width && Math.Abs(s.Y - world.Y) <= ts.Height)
 				{
-					var tile = map.MapTiles.Value[uv];
-					var ti = tileSet.GetTileInfo(tile);
-					var ramp = ti != null ? ti.RampType : 0;
+					var ramp = 0;
+					if (map.Contains(uv))
+					{
+						var tile = map.MapTiles.Value[uv];
+						var ti = tileSet.GetTileInfo(tile);
+						if (ti != null)
+							ramp = ti.RampType;
+					}
 
 					var corners = map.CellCorners[ramp];
 					var pos = map.CenterOfCell(uv.ToCPos(map));

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -641,7 +641,7 @@ namespace OpenRA
 			//  - ax + by adds (a - b) * 512 + 512 to u
 			//  - ax + by adds (a + b) * 512 + 512 to v
 			var z = Contains(cell) ? 512 * MapHeight.Value[cell] : 0;
-			return new WPos(512 * (cell.X - cell.Y + 1), 512 * (cell.X + cell.Y + 1), z);
+			return new WPos(512 * (cell.X - cell.Y), 512 * (cell.X + cell.Y + 1), z);
 		}
 
 		public WPos CenterOfSubCell(CPos cell, SubCell subCell)
@@ -660,10 +660,10 @@ namespace OpenRA
 			// Convert from world position to diamond cell position:
 			// (a) Subtract (512, 512) to move the rotation center to the middle of the corner cell
 			// (b) Rotate axes by -pi/4
-			// (c) Add 512 to x (but not y) to realign the cell
+			// (c) Add (512, 512) to move back to the center of the cell
 			// (d) Divide by 1024 to find final cell coords
 			var u = (pos.Y + pos.X - 512) / 1024;
-			var v = (pos.Y - pos.X) / 1024;
+			var v = (pos.Y - pos.X - 512) / 1024;
 			return new CPos(u, v);
 		}
 

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Traits
 
 		float GetIntensity()
 		{
-			var cp = worldRenderer.Position(worldRenderer.Viewport.CenterLocation);
+			var cp = worldRenderer.Viewport.CenterPosition;
 			var intensity = 100 * 1024 * 1024 * shakeEffects.Sum(
 				e => (float)e.Intensity / (e.Position - cp).LengthSquared);
 

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Widgets
 				// Place buildings, use support powers, and other non-unit things
 				if (!(World.OrderGenerator is UnitOrderGenerator))
 				{
-					ApplyOrders(World, xy, mi);
+					ApplyOrders(World, mi);
 					dragStart = dragEnd = null;
 					YieldMouseFocus(mi);
 					lastMousePosition = xy;
@@ -95,7 +95,7 @@ namespace OpenRA.Widgets
 								!mi.Modifiers.HasModifier(Modifiers.Alt) && UnitOrderGenerator.InputOverridesSelection(World, xy, mi)))
 							{
 								// Order units instead of selecting
-								ApplyOrders(World, xy, mi);
+								ApplyOrders(World, mi);
 								dragStart = dragEnd = null;
 								YieldMouseFocus(mi);
 								lastMousePosition = xy;
@@ -133,7 +133,7 @@ namespace OpenRA.Widgets
 					if (useClassicMouseStyle)
 						World.Selection.Clear();
 
-					ApplyOrders(World, xy, mi);
+					ApplyOrders(World, mi);
 				}
 			}
 
@@ -159,13 +159,13 @@ namespace OpenRA.Widgets
 			}
 		}
 
-		void ApplyOrders(World world, int2 xy, MouseInput mi)
+		void ApplyOrders(World world, MouseInput mi)
 		{
 			if (world.OrderGenerator == null)
 				return;
 
-			var pos = worldRenderer.Position(xy);
-			var orders = world.OrderGenerator.Order(world, world.Map.CellContaining(pos), mi).ToArray();
+			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
+			var orders = world.OrderGenerator.Order(world, cell, mi).ToArray();
 			world.PlayVoiceForOrders(orders);
 
 			var flashed = false;
@@ -184,8 +184,8 @@ namespace OpenRA.Widgets
 					}
 					else if (o.TargetLocation != CPos.Zero)
 					{
-						world.AddFrameEndTask(w => w.Add(
-							new SpriteEffect(worldRenderer.Position(worldRenderer.Viewport.ViewToWorldPx(mi.Location)), world, "moveflsh", "moveflash")));
+						var pos = world.Map.CenterOfCell(cell);
+						world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, world, "moveflsh", "moveflash")));
 						flashed = true;
 					}
 				}
@@ -202,9 +202,7 @@ namespace OpenRA.Widgets
 				if (SelectionBox != null)
 					return null;
 
-				var xy = worldRenderer.Viewport.ViewToWorldPx(screenPos);
-				var pos = worldRenderer.Position(xy);
-				var cell = World.Map.CellContaining(pos);
+				var cell = worldRenderer.Viewport.ViewToWorld(screenPos);
 
 				var mi = new MouseInput
 				{

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -41,6 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			var tileSet = wr.World.TileSet;
 			var lr = Game.Renderer.WorldLineRenderer;
 			var colors = wr.World.TileSet.HeightDebugColors;
+			var mouseCell = wr.Viewport.ViewToWorld(Viewport.LastMousePos).ToMPos(wr.World.Map);
 
 			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
@@ -54,11 +55,16 @@ namespace OpenRA.Mods.Common.Traits
 				var pos = map.CenterOfCell(uv.ToCPos(map));
 				var screen = corners.Select(c => wr.ScreenPxPosition(pos + c).ToFloat2()).ToArray();
 
+				if (uv == mouseCell)
+					lr.LineWidth = 3;
+
 				for (var i = 0; i < 4; i++)
 				{
 					var j = (i + 1) % 4;
 					lr.DrawLine(screen[i], screen[j], color[i], color[j]);
 				}
+
+				lr.LineWidth = 1;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -37,19 +37,21 @@ namespace OpenRA.Mods.Common.Traits
 			if (devMode.Value == null || !devMode.Value.ShowTerrainGeometry)
 				return;
 
+			var map = wr.World.Map;
+			var tileSet = wr.World.TileSet;
 			var lr = Game.Renderer.WorldLineRenderer;
 			var colors = wr.World.TileSet.HeightDebugColors;
 
 			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
-				var height = (int)wr.World.Map.MapHeight.Value[uv];
-				var tile = wr.World.Map.MapTiles.Value[uv];
-				var ti = wr.World.TileSet.GetTileInfo(tile);
+				var height = (int)map.MapHeight.Value[uv];
+				var tile = map.MapTiles.Value[uv];
+				var ti = tileSet.GetTileInfo(tile);
 				var ramp = ti != null ? ti.RampType : 0;
 
-				var corners = wr.World.Map.CellCorners[ramp];
+				var corners = map.CellCorners[ramp];
 				var color = corners.Select(c => colors[height + c.Z / 512]).ToArray();
-				var pos = wr.World.Map.CenterOfCell(uv.ToCPos(wr.World.Map));
+				var pos = map.CenterOfCell(uv.ToCPos(map));
 				var screen = corners.Select(c => wr.ScreenPxPosition(pos + c).ToFloat2()).ToArray();
 
 				for (var i = 0; i < 4; i++)


### PR DESCRIPTION
Units will now move where you tell them to on TS maps that include slopes (i.e. all except our one debug map).  The terrain geometry overlay will now also highlight the mouseover cell to aid in debugging any future problems.
