### PR TITLE
Package after the units tests instead of before deploy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build:
 test_script:
   - nunit-console-x86.exe OpenRA.Test.dll
 
-before_deploy:
+after_test:
   - choco install pandoc -y
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o README.html README.md'
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o CONTRIBUTING.html CONTRIBUTING.md'


### PR DESCRIPTION
https://ci.appveyor.com/project/OpenRA/openra/build/1.0.1907 failed again and it seems to show `Packaging artifacts...OK` after a unit tests so try packaging earlier.
