### PR TITLE
Fixed the missing version tag in the Windows installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ test_script:
   - nunit-console-x86.exe OpenRA.Test.dll
 
 after_test:
+  - make version
   - choco install pandoc -y
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o README.html README.md'
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o CONTRIBUTING.html CONTRIBUTING.md'


### PR DESCRIPTION
as suggested in https://github.com/OpenRA/OpenRA/pull/7763#issuecomment-87329098.
