### PR TITLE
Bring back carryall.starport and fix trike.starport's prerequisites

### DIFF
--- a/mods/d2k/rules/starport.yaml
+++ b/mods/d2k/rules/starport.yaml
@@ -21,6 +21,7 @@ trike.starport:
 	Inherits: trike
 	Buildable:
 		Queue: Starport
+		Prerequisites: starport
 	Valued:
 		Cost: 315
 	RenderUnit:
@@ -82,3 +83,10 @@ combato.starport:
 		Cost: 875
 	RenderUnit:
 		Image: combato
+		
+carryall.starport:
+	Inherits: carryall
+	Valued:
+		Cost: 1500
+	Buildable:
+		Queue: Starport


### PR DESCRIPTION
Fixes #7769.
