### PR TITLE
Fix race condition while evaluating traits on aircraft husks

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Helicopter.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Helicopter.cs
@@ -36,7 +36,6 @@ namespace OpenRA.Mods.Common.Traits
 	public class Helicopter : Aircraft, ITick, IResolveOrder, IMove
 	{
 		public readonly HelicopterInfo Info;
-		readonly bool fallsToEarth;
 		Actor self;
 		bool firstTick = true;
 		public bool IsMoving { get { return self.CenterPosition.Z > 0; } set { } }
@@ -46,7 +45,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 			Info = info;
-			fallsToEarth = self.HasTrait<FallsToEarth>();
 		}
 
 		public void ResolveOrder(Actor self, Order order)
@@ -132,7 +130,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (firstTick)
 			{
 				firstTick = false;
-				if (!fallsToEarth) // TODO: Aircraft husks don't properly unreserve.
+				if (!self.HasTrait<FallsToEarth>()) // TODO: Aircraft husks don't properly unreserve.
 					ReserveSpawnBuilding();
 
 				var host = GetActorBelow();

--- a/OpenRA.Mods.Common/Traits/Air/Plane.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Plane.cs
@@ -26,7 +26,6 @@ namespace OpenRA.Mods.Common.Traits
 	public class Plane : Aircraft, IResolveOrder, IMove, ITick, ISync
 	{
 		public readonly PlaneInfo Info;
-		readonly bool fallsToEarth;
 		[Sync] public WPos RTBPathHash;
 		Actor self;
 		public bool IsMoving { get { return self.CenterPosition.Z > 0; } set { } }
@@ -36,7 +35,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 			Info = info;
-			fallsToEarth = self.HasTrait<FallsToEarth>();
 		}
 
 		bool firstTick = true;
@@ -45,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (firstTick)
 			{
 				firstTick = false;
-				if (!fallsToEarth) // TODO: Aircraft husks don't properly unreserve.
+				if (!self.HasTrait<FallsToEarth>()) // TODO: Aircraft husks don't properly unreserve.
 					ReserveSpawnBuilding();
 
 				var host = GetActorBelow();


### PR DESCRIPTION
The crash happens when a landed aircraft is killed and is caused by the FallsToEarth trait not having been instantiated yet when the Plane constructor runs, causing the check in Plane::Tick() and Helicopter::Tick(), which is supposed to catch the 'Husk' case, to fail.

Due to a bug in the yaml loader (#6818) leading to inherited traits being instantiated last, the order of traits in the yaml rules cannot just be switched, which would have been the easiest solution.

Fixes #7764
