### PR TITLE
Limit amount of EnemyWatcher announcements

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool AnnounceNeutrals = false;
 
+		[Desc("Notifications will be generated even when the discovering player already sees other units belonging to the same player.")]
+		public readonly bool AnnounceIndividual = false;
+
 		public object Create(ActorInitializer init) { return new AnnounceOnSeen(init.Self, this); }
 	}
 

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -802,6 +802,7 @@ Rules:
 		MissionObjectives:
 			EarlyGameOver: true
 		EnemyWatcher:
+			NotificationInterval: 25
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -52,6 +52,7 @@ sandworm:
 		WanderMoveRadius: 5
 	IgnoresCloak:
 	AnnounceOnSeen:
+		AnnounceIndividual: True
 		Notification: WormSign
 		PingRadar: True
 


### PR DESCRIPTION
The `EnemyWatcher` will now only announce newly discovered enemy units if 1) the player has not seen any other units of the same player in the tick before, or 2) the discovered unit has the `AnnounceIndividual` flag set.

Previously, it would announce all individual units that haven't been seen in the immediately preceding tick.

The effect of the change is that you only get announcements when a new player's army comes into view, not when new units of an already discovered army approach.
