### PR TITLE
Make buildings explicitly provide their names as prerequisites

### DIFF
--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -19,9 +19,9 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			// ProvidesCustomPrerequisite allows arbitrary prereq definitions
+			// ProvidesPrerequisite allows arbitrary prereq definitions
 			var customPrereqs = map.Rules.Actors.SelectMany(a => a.Value.Traits
-				.WithInterface<ProvidesCustomPrerequisiteInfo>().Select(p => p.Prerequisite ?? a.Value.Name));
+				.WithInterface<ProvidesPrerequisiteInfo>().Select(p => p.Prerequisite ?? a.Value.Name));
 
 			// ProvidesTechPrerequisite allows arbitrary prereq definitions
 			// (but only one group at a time during gameplay)

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -19,14 +19,9 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			// Buildings provide their actor names as a prerequisite
-			var buildingPrereqs = map.Rules.Actors.Where(a => a.Value.Traits.Contains<BuildingInfo>())
-				.Select(a => a.Key);
-
 			// ProvidesCustomPrerequisite allows arbitrary prereq definitions
 			var customPrereqs = map.Rules.Actors.SelectMany(a => a.Value.Traits
-				.WithInterface<ProvidesCustomPrerequisiteInfo>())
-				.Select(p => p.Prerequisite);
+				.WithInterface<ProvidesCustomPrerequisiteInfo>().Select(p => p.Prerequisite ?? a.Value.Name));
 
 			// ProvidesTechPrerequisite allows arbitrary prereq definitions
 			// (but only one group at a time during gameplay)
@@ -34,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 				.WithInterface<ProvidesTechPrerequisiteInfo>())
 				.SelectMany(p => p.Prerequisites);
 
-			var providedPrereqs = buildingPrereqs.Concat(customPrereqs).Concat(techPrereqs);
+			var providedPrereqs = customPrereqs.Concat(techPrereqs);
 
 			// TODO: this check is case insensitive while the real check in-game is not
 			foreach (var i in map.Rules.Actors)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -350,7 +350,7 @@
     <Compile Include="Traits\Player\PlaceBuilding.cs" />
     <Compile Include="Traits\Player\PlayerStatistics.cs" />
     <Compile Include="Traits\Player\ProductionQueue.cs" />
-    <Compile Include="Traits\Player\ProvidesCustomPrerequisite.cs" />
+    <Compile Include="Traits\Player\ProvidesPrerequisite.cs" />
     <Compile Include="Traits\Player\ProvidesTechPrerequisite.cs" />
     <Compile Include="Traits\Player\StrategicVictoryConditions.cs" />
     <Compile Include="Traits\Player\TechTree.cs" />

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -17,8 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The prerequisite names that must be available before this can be built.",
 			"This can be prefixed with ! to invert the prerequisite (disabling production if the prerequisite is available)",
 			"and/or ~ to hide the actor from the production palette if the prerequisite is not available.",
-			"Prerequisites are granted by actors with the Building trait (with a prerequisite string given by the lower case actor name)",
-			"and by the ProvidesCustomPrerequisite trait.")]
+			"Prerequisites are granted by actors with the ProvidesPrerequisite trait.")]
 		public readonly string[] Prerequisites = { };
 
 		[Desc("Production queue(s) that can produce this.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class Building : IOccupySpace, INotifySold, INotifyTransform, ISync, ITechTreePrerequisite, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
+	public class Building : IOccupySpace, INotifySold, INotifyTransform, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		public readonly BuildingInfo Info;
 		public bool BuildComplete { get; private set; }
@@ -130,8 +130,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public CPos TopLeft { get { return topLeft; } }
 		public WPos CenterPosition { get; private set; }
-
-		public IEnumerable<string> ProvidesPrerequisites { get { yield return self.Info.Name; } }
 
 		public Building(ActorInitializer init, BuildingInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesCustomPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesCustomPrerequisite.cs
@@ -17,13 +17,13 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class ProvidesCustomPrerequisiteInfo : ITraitInfo
 	{
-		[Desc("The prerequisite type that this provides")]
+		[Desc("The prerequisite type that this provides. If left empty it defaults to the actor's name.")]
 		public readonly string Prerequisite = null;
 
-		[Desc("Only grant this prerequisite when you have these prerequisites")]
+		[Desc("Only grant this prerequisite when you have these prerequisites.")]
 		public readonly string[] RequiresPrerequisites = { };
 
-		[Desc("Only grant this prerequisite for certain factions")]
+		[Desc("Only grant this prerequisite for certain factions.")]
 		public readonly string[] Race = { };
 
 		[Desc("Should it recheck everything when it is captured?")]
@@ -34,12 +34,17 @@ namespace OpenRA.Mods.Common.Traits
 	public class ProvidesCustomPrerequisite : ITechTreePrerequisite, INotifyOwnerChanged
 	{
 		readonly ProvidesCustomPrerequisiteInfo info;
+		readonly string prerequisite;
 
 		bool enabled = true;
 
 		public ProvidesCustomPrerequisite(ActorInitializer init, ProvidesCustomPrerequisiteInfo info)
 		{
 			this.info = info;
+			prerequisite = info.Prerequisite;
+
+			if (string.IsNullOrEmpty(prerequisite))
+				prerequisite = init.Self.Info.Name;
 
 			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race;
 
@@ -53,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!enabled)
 					yield break;
 
-				yield return info.Prerequisite;
+				yield return prerequisite;
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -10,12 +10,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ProvidesCustomPrerequisiteInfo : ITraitInfo
+	public class ProvidesPrerequisiteInfo : ITraitInfo
 	{
 		[Desc("The prerequisite type that this provides. If left empty it defaults to the actor's name.")]
 		public readonly string Prerequisite = null;
@@ -28,17 +27,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Should it recheck everything when it is captured?")]
 		public readonly bool ResetOnOwnerChange = false;
-		public object Create(ActorInitializer init) { return new ProvidesCustomPrerequisite(init, this); }
+		public object Create(ActorInitializer init) { return new ProvidesPrerequisite(init, this); }
 	}
 
-	public class ProvidesCustomPrerequisite : ITechTreePrerequisite, INotifyOwnerChanged
+	public class ProvidesPrerequisite : ITechTreePrerequisite, INotifyOwnerChanged
 	{
-		readonly ProvidesCustomPrerequisiteInfo info;
+		readonly ProvidesPrerequisiteInfo info;
 		readonly string prerequisite;
 
 		bool enabled = true;
 
-		public ProvidesCustomPrerequisite(ActorInitializer init, ProvidesCustomPrerequisiteInfo info)
+		public ProvidesPrerequisite(ActorInitializer init, ProvidesPrerequisiteInfo info)
 		{
 			this.info = info;
 			prerequisite = info.Prerequisite;

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -937,6 +937,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (depth == 0 && node.Value.Nodes.Exists(n => n.Key == "Inherits" &&
 						(n.Value.Value == "^Building" || n.Value.Value == "^BaseBuilding")))
 						node.Value.Nodes.Add(new MiniYamlNode("ProvidesCustomPrerequisite@buildingname", ""));
+
+					// Rename the ProvidesCustomPrerequisite trait.
+					if (node.Key.StartsWith("ProvidesCustomPrerequisite"))
+						node.Key = node.Key.Replace("ProvidesCustomPrerequisite", "ProvidesPrerequisite");
 				}
 
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -931,6 +931,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20150504)
+				{
+					// Made buildings grant prerequisites explicitly.
+					if (depth == 0 && node.Value.Nodes.Exists(n => n.Key == "Inherits" &&
+						(n.Value.Value == "^Building" || n.Value.Value == "^BaseBuilding")))
+						node.Value.Nodes.Add(new MiniYamlNode("ProvidesCustomPrerequisite@buildingname", ""));
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -68,7 +68,7 @@ FACT:
 	WithBuildingPlacedAnimation:
 	Power:
 		Amount: 0
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 FACT.GDI:
 	Inherits: FACT
@@ -101,7 +101,7 @@ NUKE:
 	Tooltip:
 		Name: Power Plant
 		Description: Generates power
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Buildable:
 		BuildPaletteOrder: 10
@@ -126,7 +126,7 @@ NUK2:
 	Tooltip:
 		Name: Advanced Power Plant
 		Description: Provides more power, cheaper than the \nstandard Power Plant
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Buildable:
 		BuildPaletteOrder: 30
@@ -186,7 +186,7 @@ PROC:
 	WithResources:
 	Power:
 		Amount: -50
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 SILO:
 	Inherits: ^BaseBuilding
@@ -230,7 +230,7 @@ PYLE:
 	Tooltip:
 		Name: Barracks
 		Description: Trains infantry
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Buildable:
 		BuildPaletteOrder: 40
@@ -262,7 +262,7 @@ PYLE:
 	ProductionBar:
 	Power:
 		Amount: -20
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 HAND:
 	Inherits: ^BaseBuilding
@@ -271,7 +271,7 @@ HAND:
 	Tooltip:
 		Name: Hand of Nod
 		Description: Trains infantry
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Buildable:
 		BuildPaletteOrder: 40
@@ -300,7 +300,7 @@ HAND:
 	ProductionBar:
 	Power:
 		Amount: -20
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 AFLD:
 	Inherits: ^BaseBuilding
@@ -309,7 +309,7 @@ AFLD:
 	Tooltip:
 		Name: Airstrip
 		Description: Provides a dropzone\nfor vehicle reinforcements
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: vehicleproduction
 	Buildable:
 		BuildPaletteOrder: 50
@@ -341,7 +341,7 @@ AFLD:
 	ProductionBar:
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 WEAP:
 	Inherits: ^BaseBuilding
@@ -350,7 +350,7 @@ WEAP:
 	Tooltip:
 		Name: Weapons Factory
 		Description: Produces vehicles
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: vehicleproduction
 	Buildable:
 		BuildPaletteOrder: 50
@@ -383,7 +383,7 @@ WEAP:
 	ProductionBar:
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 HPAD:
 	Inherits: ^BaseBuilding
@@ -429,7 +429,7 @@ HPAD:
 		ProductionType: Aircraft.Nod
 	Power:
 		Amount: -10
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 HQ:
 	Inherits: ^BaseBuilding
@@ -438,7 +438,7 @@ HQ:
 	Tooltip:
 		Name: Communications Center
 		Description: Provides radar & Air Strike support power. \nUnlocks higher-tech units & buildings.  \nRequires power to operate.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anyhq
 	Buildable:
 		BuildPaletteOrder: 70
@@ -509,7 +509,7 @@ FIX:
 	WithRepairAnimation:
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 EYE:
 	Inherits: ^BaseBuilding
@@ -518,7 +518,7 @@ EYE:
 	Tooltip:
 		Name: Advanced Communications Center
 		Description: Provides radar & Orbital Ion Cannon support power. \nUnlocks Mammoth Tank & Commando.  \nRequires power to operate.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anyhq
 	Buildable:
 		BuildPaletteOrder: 100
@@ -557,7 +557,7 @@ EYE:
 	SupportPowerChargeBar:
 	Power:
 		Amount: -200
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 TMPL:
 	Inherits: ^BaseBuilding
@@ -566,7 +566,7 @@ TMPL:
 	Tooltip:
 		Name: Temple of Nod
 		Description: Provides Nuclear Strike support power. \nUnlocks Stealth Tank, Chem. Warrior & Obelisk of Light.  \nRequires power to operate.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anyhq
 	Buildable:
 		BuildPaletteOrder: 100
@@ -604,7 +604,7 @@ TMPL:
 	SupportPowerChargeBar:
 	Power:
 		Amount: -150
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GUN:
 	Inherits: ^BaseBuilding

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -68,6 +68,7 @@ FACT:
 	WithBuildingPlacedAnimation:
 	Power:
 		Amount: 0
+	ProvidesCustomPrerequisite@buildingname:
 
 FACT.GDI:
 	Inherits: FACT
@@ -185,6 +186,7 @@ PROC:
 	WithResources:
 	Power:
 		Amount: -50
+	ProvidesCustomPrerequisite@buildingname:
 
 SILO:
 	Inherits: ^BaseBuilding
@@ -260,6 +262,7 @@ PYLE:
 	ProductionBar:
 	Power:
 		Amount: -20
+	ProvidesCustomPrerequisite@buildingname:
 
 HAND:
 	Inherits: ^BaseBuilding
@@ -297,6 +300,7 @@ HAND:
 	ProductionBar:
 	Power:
 		Amount: -20
+	ProvidesCustomPrerequisite@buildingname:
 
 AFLD:
 	Inherits: ^BaseBuilding
@@ -337,6 +341,7 @@ AFLD:
 	ProductionBar:
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 WEAP:
 	Inherits: ^BaseBuilding
@@ -378,6 +383,7 @@ WEAP:
 	ProductionBar:
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 HPAD:
 	Inherits: ^BaseBuilding
@@ -423,6 +429,7 @@ HPAD:
 		ProductionType: Aircraft.Nod
 	Power:
 		Amount: -10
+	ProvidesCustomPrerequisite@buildingname:
 
 HQ:
 	Inherits: ^BaseBuilding
@@ -502,6 +509,7 @@ FIX:
 	WithRepairAnimation:
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 EYE:
 	Inherits: ^BaseBuilding
@@ -549,6 +557,7 @@ EYE:
 	SupportPowerChargeBar:
 	Power:
 		Amount: -200
+	ProvidesCustomPrerequisite@buildingname:
 
 TMPL:
 	Inherits: ^BaseBuilding
@@ -595,6 +604,7 @@ TMPL:
 	SupportPowerChargeBar:
 	Power:
 		Amount: -150
+	ProvidesCustomPrerequisite@buildingname:
 
 GUN:
 	Inherits: ^BaseBuilding

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -36,7 +36,7 @@ HOSP:
 		HuskActor: HOSP.Husk
 	Bib:
 		HasMinibib: Yes
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 HOSP.Husk:
 	Inherits: ^CivBuildingHusk
@@ -71,7 +71,7 @@ BIO:
 		RallyPoint: -1,-1
 	LeavesHusk:
 		HuskActor: BIO.Husk
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 BIO.Husk:
 	Inherits: ^CivBuildingHusk
@@ -98,5 +98,5 @@ MISS:
 	Bib:
 		HasMinibib: Yes
 	WithMakeAnimation:
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -36,6 +36,7 @@ HOSP:
 		HuskActor: HOSP.Husk
 	Bib:
 		HasMinibib: Yes
+	ProvidesCustomPrerequisite@buildingname:
 
 HOSP.Husk:
 	Inherits: ^CivBuildingHusk
@@ -70,6 +71,7 @@ BIO:
 		RallyPoint: -1,-1
 	LeavesHusk:
 		HuskActor: BIO.Husk
+	ProvidesCustomPrerequisite@buildingname:
 
 BIO.Husk:
 	Inherits: ^CivBuildingHusk
@@ -96,4 +98,5 @@ MISS:
 	Bib:
 		HasMinibib: Yes
 	WithMakeAnimation:
+	ProvidesCustomPrerequisite@buildingname:
 

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -75,5 +75,5 @@ sietch:
 	-ExternalCapturableBar:
 	Power:
 		Amount: 0
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -75,3 +75,5 @@ sietch:
 	-ExternalCapturableBar:
 	Power:
 		Amount: 0
+	ProvidesCustomPrerequisite@buildingname:
+

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -105,7 +105,7 @@ power:
 	Power:
 		Amount: 100
 	ScalePowerWithHealth:
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 barracks:
 	Inherits: ^Building
@@ -142,16 +142,16 @@ barracks:
 		Produces: Infantry
 	PrimaryBuilding:
 	ProductionBar:
-	ProvidesCustomPrerequisite@atreides:
+	ProvidesPrerequisite@atreides:
 		Prerequisite: barracks.atreides
 		Race: atreides
-	ProvidesCustomPrerequisite@ordos:
+	ProvidesPrerequisite@ordos:
 		Prerequisite: barracks.ordos
 		Race: ordos
-	ProvidesCustomPrerequisite@harkonnen:
+	ProvidesPrerequisite@harkonnen:
 		Prerequisite: barracks.harkonnen
 		Race: harkonnen
-	ProvidesCustomPrerequisite@medics:
+	ProvidesPrerequisite@medics:
 		Prerequisite: barracks.medics
 		Race: atreides, ordos
 	Power:
@@ -161,7 +161,7 @@ barracks:
 		RaceImages:
 			atreides: barracks.atreides
 			ordos: barracks.ordos
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 refinery:
 	Inherits: ^Building
@@ -213,7 +213,7 @@ refinery:
 		Amount: -30
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 silo:
 	Inherits: ^Building
@@ -290,16 +290,16 @@ light:
 		Produces: Vehicle
 	PrimaryBuilding:
 	ProductionBar:
-	ProvidesCustomPrerequisite@atreides:
+	ProvidesPrerequisite@atreides:
 		Prerequisite: light.atreides
 		Race: atreides
-	ProvidesCustomPrerequisite@ordos:
+	ProvidesPrerequisite@ordos:
 		Prerequisite: light.ordos
 		Race: ordos
-	ProvidesCustomPrerequisite@harkonnen:
+	ProvidesPrerequisite@harkonnen:
 		Prerequisite: light.harkonnen
 		Race: harkonnen
-	ProvidesCustomPrerequisite@TRIKES:
+	ProvidesPrerequisite@TRIKES:
 		Prerequisite: light.regulartrikes
 		Race: atreides, harkonnen
 	WithProductionOverlay@WELDING:
@@ -341,13 +341,13 @@ heavy:
 		Produces: Armor
 	PrimaryBuilding:
 	ProductionBar:
-	ProvidesCustomPrerequisite@atreides:
+	ProvidesPrerequisite@atreides:
 		Prerequisite: heavy.atreides
 		Race: atreides
-	ProvidesCustomPrerequisite@ordos:
+	ProvidesPrerequisite@ordos:
 		Prerequisite: heavy.ordos
 		Race: ordos
-	ProvidesCustomPrerequisite@harkonnen:
+	ProvidesPrerequisite@harkonnen:
 		Prerequisite: heavy.harkonnen
 		Race: harkonnen
 	RenderBuilding:
@@ -362,7 +362,7 @@ heavy:
 		Sequence: idle-top
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 radar:
 	Inherits: ^Building
@@ -404,7 +404,7 @@ radar:
 		PauseOnLowPower: yes
 	Power:
 		Amount: -40
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 starport:
 	Inherits: ^Building
@@ -452,18 +452,18 @@ starport:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
-	ProvidesCustomPrerequisite@atreides:
+	ProvidesPrerequisite@atreides:
 		Prerequisite: starport.atreides
 		Race: atreides
-	ProvidesCustomPrerequisite@ordos:
+	ProvidesPrerequisite@ordos:
 		Prerequisite: starport.ordos
 		Race: ordos
-	ProvidesCustomPrerequisite@harkonnen:
+	ProvidesPrerequisite@harkonnen:
 		Prerequisite: starport.harkonnen
 		Race: harkonnen
 	Power:
 		Amount: -40
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 wall:
 	Buildable:
@@ -659,7 +659,7 @@ repair:
 		Palette: repairlights
 	Power:
 		Amount: -10
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 hightech:
 	Inherits: ^Building
@@ -698,7 +698,7 @@ hightech:
 		Sequence: production-welding
 	Power:
 		Amount: -40
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 research:
 	Inherits: ^Building
@@ -743,7 +743,7 @@ research:
 		Sequence: idle-lights
 	Power:
 		Amount: -40
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 palace:
 	Inherits: ^Building
@@ -780,10 +780,10 @@ palace:
 		Range: 4
 	Power:
 		Amount: -50
-	ProvidesCustomPrerequisite@airstrike:
+	ProvidesPrerequisite@airstrike:
 		Prerequisite: palace.airstrike
 		Race: atreides, ordos
-	ProvidesCustomPrerequisite@nuke:
+	ProvidesPrerequisite@nuke:
 		Prerequisite: palace.nuke
 		Race: harkonnen
 	AirstrikePower:
@@ -817,7 +817,7 @@ palace:
 	DisabledOverlay:
 	RequiresPower:
 	SupportPowerChargeBar:
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 conyard.atreides:
 	Inherits: conyard

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -105,6 +105,7 @@ power:
 	Power:
 		Amount: 100
 	ScalePowerWithHealth:
+	ProvidesCustomPrerequisite@buildingname:
 
 barracks:
 	Inherits: ^Building
@@ -160,6 +161,7 @@ barracks:
 		RaceImages:
 			atreides: barracks.atreides
 			ordos: barracks.ordos
+	ProvidesCustomPrerequisite@buildingname:
 
 refinery:
 	Inherits: ^Building
@@ -211,6 +213,7 @@ refinery:
 		Amount: -30
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
+	ProvidesCustomPrerequisite@buildingname:
 
 silo:
 	Inherits: ^Building
@@ -359,6 +362,7 @@ heavy:
 		Sequence: idle-top
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 radar:
 	Inherits: ^Building
@@ -400,6 +404,7 @@ radar:
 		PauseOnLowPower: yes
 	Power:
 		Amount: -40
+	ProvidesCustomPrerequisite@buildingname:
 
 starport:
 	Inherits: ^Building
@@ -458,6 +463,7 @@ starport:
 		Race: harkonnen
 	Power:
 		Amount: -40
+	ProvidesCustomPrerequisite@buildingname:
 
 wall:
 	Buildable:
@@ -653,6 +659,7 @@ repair:
 		Palette: repairlights
 	Power:
 		Amount: -10
+	ProvidesCustomPrerequisite@buildingname:
 
 hightech:
 	Inherits: ^Building
@@ -691,6 +698,7 @@ hightech:
 		Sequence: production-welding
 	Power:
 		Amount: -40
+	ProvidesCustomPrerequisite@buildingname:
 
 research:
 	Inherits: ^Building
@@ -735,6 +743,7 @@ research:
 		Sequence: idle-lights
 	Power:
 		Amount: -40
+	ProvidesCustomPrerequisite@buildingname:
 
 palace:
 	Inherits: ^Building
@@ -808,6 +817,7 @@ palace:
 	DisabledOverlay:
 	RequiresPower:
 	SupportPowerChargeBar:
+	ProvidesCustomPrerequisite@buildingname:
 
 conyard.atreides:
 	Inherits: conyard

--- a/mods/ra/maps/bomber-john/map.yaml
+++ b/mods/ra/maps/bomber-john/map.yaml
@@ -880,7 +880,7 @@ Rules:
 		Building:
 			Adjacent: 99
 			TerrainTypes: Clear,Road
-		ProvidesCustomPrerequisite:
+		ProvidesPrerequisite:
 			Prerequisite: MNLYVV
 		Buildable:
 			Queue: Building

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2254,15 +2254,15 @@ Rules:
 	WEAP:
 		Buildable:
 			Prerequisites: proc, ~techlevel.low, mainland
-		ProvidesCustomPrerequisite:
+		ProvidesPrerequisite:
 			Prerequisite: givefix
 	MAINLAND:
 		Tooltip:
 			Name: Reach the mainland
-		ProvidesCustomPrerequisite:
+		ProvidesPrerequisite:
 			Prerequisite: mainland
 	HPAD:
-		ProvidesCustomPrerequisite:
+		ProvidesPrerequisite:
 			Prerequisite: givefix
 	FIX:
 		Buildable:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -77,6 +77,7 @@ FCOM:
 	Bib:
 	Power:
 		Amount: -200
+	ProvidesCustomPrerequisite@buildingname:
 
 HOSP:
 	Inherits: ^TechBuilding
@@ -101,6 +102,7 @@ HOSP:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
+	ProvidesCustomPrerequisite@buildingname:
 
 V01:
 	Inherits: ^CivBuilding
@@ -310,6 +312,7 @@ MISS:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
+	ProvidesCustomPrerequisite@buildingname:
 
 BIO:
 	Inherits: ^TechBuilding
@@ -326,6 +329,7 @@ BIO:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
+	ProvidesCustomPrerequisite@buildingname:
 
 OILB:
 	Inherits: ^TechBuilding

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -77,7 +77,7 @@ FCOM:
 	Bib:
 	Power:
 		Amount: -200
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 HOSP:
 	Inherits: ^TechBuilding
@@ -102,7 +102,7 @@ HOSP:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 V01:
 	Inherits: ^CivBuilding
@@ -312,7 +312,7 @@ MISS:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 BIO:
 	Inherits: ^TechBuilding
@@ -329,7 +329,7 @@ BIO:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 OILB:
 	Inherits: ^TechBuilding

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -158,6 +158,7 @@ SPEN:
 	ProvidesCustomPrerequisite@ukrainianstructure:
 		RequiresPrerequisites: structures.ukraine
 		Prerequisite: ships.ukraine
+	ProvidesCustomPrerequisite@buildingname:
 
 SYRD:
 	Inherits: ^Building
@@ -242,6 +243,7 @@ SYRD:
 	ProvidesCustomPrerequisite@germanstructure:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: ships.germany
+	ProvidesCustomPrerequisite@buildingname:
 
 IRON:
 	Inherits: ^Building
@@ -356,6 +358,7 @@ PDOX:
 		Amount: -200
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	ProvidesCustomPrerequisite@buildingname:
 
 TSLA:
 	Inherits: ^Defense
@@ -400,6 +403,7 @@ TSLA:
 		Amount: -100
 	DetectCloaked:
 		Range: 8
+	ProvidesCustomPrerequisite@buildingname:
 
 AGUN:
 	Inherits: ^Defense
@@ -481,6 +485,7 @@ DOME:
 	RenderDetectionCircle:
 	Power:
 		Amount: -40
+	ProvidesCustomPrerequisite@buildingname:
 
 PBOX:
 	Inherits: ^Defense
@@ -655,6 +660,7 @@ FTUR:
 		Amount: -20
 	DetectCloaked:
 		Range: 6
+	ProvidesCustomPrerequisite@buildingname:
 
 SAM:
 	Inherits: ^Defense
@@ -739,6 +745,7 @@ ATEK:
 	DisabledOverlay:
 	Power:
 		Amount: -200
+	ProvidesCustomPrerequisite@buildingname:
 
 WEAP:
 	Inherits: ^Building
@@ -827,6 +834,7 @@ WEAP:
 	ProductionBar:
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 FACT:
 	Inherits: ^Building
@@ -900,6 +908,7 @@ FACT:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
+	ProvidesCustomPrerequisite@buildingname:
 
 PROC:
 	Inherits: ^Building
@@ -951,6 +960,7 @@ PROC:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
+	ProvidesCustomPrerequisite@buildingname:
 
 SILO:
 	Inherits: ^Building
@@ -1045,6 +1055,7 @@ HPAD:
 	ProvidesCustomPrerequisite@germanstructure:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: aircraft.germany
+	ProvidesCustomPrerequisite@buildingname:
 
 AFLD:
 	Inherits: ^Building
@@ -1149,6 +1160,7 @@ AFLD:
 	PrimaryBuilding:
 	Power:
 		Amount: -20
+	ProvidesCustomPrerequisite@buildingname:
 
 POWR:
 	Inherits: ^Building
@@ -1249,6 +1261,7 @@ STEK:
 	Bib:
 	Power:
 		Amount: -100
+	ProvidesCustomPrerequisite@buildingname:
 
 BARR:
 	Inherits: ^Building
@@ -1310,6 +1323,7 @@ BARR:
 		Prerequisite: infantry.ukraine
 	Power:
 		Amount: -20
+	ProvidesCustomPrerequisite@buildingname:
 
 KENN:
 	Inherits: ^Building
@@ -1344,6 +1358,7 @@ KENN:
 	-EmitInfantryOnSell:
 	Power:
 		Amount: -10
+	ProvidesCustomPrerequisite@buildingname:
 
 TENT:
 	Inherits: ^Building
@@ -1411,6 +1426,7 @@ TENT:
 		Prerequisite: infantry.germany
 	Power:
 		Amount: -20
+	ProvidesCustomPrerequisite@buildingname:
 
 FIX:
 	Inherits: ^Building
@@ -1442,6 +1458,7 @@ FIX:
 	WithRepairAnimation:
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 SBAG:
 	Inherits: ^Wall

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -134,31 +134,31 @@ SPEN:
 	ProductionBar:
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@soviet:
+	ProvidesPrerequisite@soviet:
 		Race: soviet, russia, ukraine
 		Prerequisite: ships.soviet
-	ProvidesCustomPrerequisite@sovietvanilla:
+	ProvidesPrerequisite@sovietvanilla:
 		Race: soviet
 		Prerequisite: ships.sovietvanilla
-	ProvidesCustomPrerequisite@russia:
+	ProvidesPrerequisite@russia:
 		Race: russia
 		Prerequisite: ships.russia
-	ProvidesCustomPrerequisite@ukraine:
+	ProvidesPrerequisite@ukraine:
 		Race: ukraine
 		Prerequisite: ships.ukraine
-	ProvidesCustomPrerequisite@sovietstructure:
+	ProvidesPrerequisite@sovietstructure:
 		RequiresPrerequisites: structures.soviet
 		Prerequisite: ships.soviet
-	ProvidesCustomPrerequisite@sovietvanillastructure:
+	ProvidesPrerequisite@sovietvanillastructure:
 		RequiresPrerequisites: structures.sovietvanilla
 		Prerequisite: ships.sovietvanilla
-	ProvidesCustomPrerequisite@russianstructure:
+	ProvidesPrerequisite@russianstructure:
 		RequiresPrerequisites: structures.russia
 		Prerequisite: ships.russia
-	ProvidesCustomPrerequisite@ukrainianstructure:
+	ProvidesPrerequisite@ukrainianstructure:
 		RequiresPrerequisites: structures.ukraine
 		Prerequisite: ships.ukraine
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 SYRD:
 	Inherits: ^Building
@@ -213,37 +213,37 @@ SYRD:
 	ProductionBar:
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@allies:
+	ProvidesPrerequisite@allies:
 		Race: allies, england, france, germany
 		Prerequisite: ships.allies
-	ProvidesCustomPrerequisite@alliesvanilla:
+	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: ships.alliesvanilla
-	ProvidesCustomPrerequisite@england:
+	ProvidesPrerequisite@england:
 		Race: england
 		Prerequisite: ships.england
-	ProvidesCustomPrerequisite@france:
+	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: ships.france
-	ProvidesCustomPrerequisite@germany:
+	ProvidesPrerequisite@germany:
 		Race: germany
 		Prerequisite: ships.germany
-	ProvidesCustomPrerequisite@alliedstructure:
+	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
 		Prerequisite: ships.allies
-	ProvidesCustomPrerequisite@alliedvanillastructure:
+	ProvidesPrerequisite@alliedvanillastructure:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: ships.alliesvanilla
-	ProvidesCustomPrerequisite@englishstructure:
+	ProvidesPrerequisite@englishstructure:
 		RequiresPrerequisites: structures.england
 		Prerequisite: ships.england
-	ProvidesCustomPrerequisite@frenchstructure:
+	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: ships.france
-	ProvidesCustomPrerequisite@germanstructure:
+	ProvidesPrerequisite@germanstructure:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: ships.germany
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 IRON:
 	Inherits: ^Building
@@ -317,10 +317,10 @@ PDOX:
 		Range: 10c0
 	Bib:
 		HasMinibib: Yes
-	ProvidesCustomPrerequisite@germany:
+	ProvidesPrerequisite@germany:
 		Race: germany
 		Prerequisite: pdox.germany
-	ProvidesCustomPrerequisite@germanstructure:
+	ProvidesPrerequisite@germanstructure:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: pdox.germany
 	ChronoshiftPower@chronoshift:
@@ -358,7 +358,7 @@ PDOX:
 		Amount: -200
 	MustBeDestroyed:
 		RequiredForShortGame: false
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 TSLA:
 	Inherits: ^Defense
@@ -403,7 +403,7 @@ TSLA:
 		Amount: -100
 	DetectCloaked:
 		Range: 8
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 AGUN:
 	Inherits: ^Defense
@@ -485,7 +485,7 @@ DOME:
 	RenderDetectionCircle:
 	Power:
 		Amount: -40
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 PBOX:
 	Inherits: ^Defense
@@ -660,7 +660,7 @@ FTUR:
 		Amount: -20
 	DetectCloaked:
 		Range: 6
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 SAM:
 	Inherits: ^Defense
@@ -719,7 +719,7 @@ ATEK:
 	Tooltip:
 		Name: Allied Tech Center
 		Description: Provides Allied advanced technologies.\n  Special Ability: GPS Satellite
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: techcenter
 	Building:
 		Footprint: xx xx
@@ -745,7 +745,7 @@ ATEK:
 	DisabledOverlay:
 	Power:
 		Amount: -200
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 WEAP:
 	Inherits: ^Building
@@ -776,65 +776,65 @@ WEAP:
 		ExitCell: 1,2
 	Production:
 		Produces: Vehicle
-	ProvidesCustomPrerequisite@allies:
+	ProvidesPrerequisite@allies:
 		Race: allies, england, france, germany
 		Prerequisite: vehicles.allies
-	ProvidesCustomPrerequisite@alliesvanilla:
+	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: vehicles.alliesvanilla
-	ProvidesCustomPrerequisite@england:
+	ProvidesPrerequisite@england:
 		Race: england
 		Prerequisite: vehicles.england
-	ProvidesCustomPrerequisite@france:
+	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: vehicles.france
-	ProvidesCustomPrerequisite@germany:
+	ProvidesPrerequisite@germany:
 		Race: germany
 		Prerequisite: vehicles.germany
-	ProvidesCustomPrerequisite@soviet:
+	ProvidesPrerequisite@soviet:
 		Race: soviet, russia, ukraine
 		Prerequisite: vehicles.soviet
-	ProvidesCustomPrerequisite@sovietvanilla:
+	ProvidesPrerequisite@sovietvanilla:
 		Race: soviet
 		Prerequisite: vehicles.sovietvanilla
-	ProvidesCustomPrerequisite@russia:
+	ProvidesPrerequisite@russia:
 		Race: russia
 		Prerequisite: vehicles.russia
-	ProvidesCustomPrerequisite@ukraine:
+	ProvidesPrerequisite@ukraine:
 		Race: ukraine
 		Prerequisite: vehicles.ukraine
-	ProvidesCustomPrerequisite@alliedstructure:
+	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
 		Prerequisite: vehicles.allies
-	ProvidesCustomPrerequisite@alliedvanillastructure:
+	ProvidesPrerequisite@alliedvanillastructure:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: vehicles.alliesvanilla
-	ProvidesCustomPrerequisite@englishstructure:
+	ProvidesPrerequisite@englishstructure:
 		RequiresPrerequisites: structures.england
 		Prerequisite: vehicles.england
-	ProvidesCustomPrerequisite@frenchstructure:
+	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: vehicles.france
-	ProvidesCustomPrerequisite@germanstructure:
+	ProvidesPrerequisite@germanstructure:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: vehicles.germany
-	ProvidesCustomPrerequisite@sovietstructure:
+	ProvidesPrerequisite@sovietstructure:
 		RequiresPrerequisites: structures.soviet
 		Prerequisite: vehicles.soviet
-	ProvidesCustomPrerequisite@sovietvanillastructure:
+	ProvidesPrerequisite@sovietvanillastructure:
 		RequiresPrerequisites: structures.sovietvanilla
 		Prerequisite: vehicles.sovietvanilla
-	ProvidesCustomPrerequisite@russianstructure:
+	ProvidesPrerequisite@russianstructure:
 		RequiresPrerequisites: structures.russia
 		Prerequisite: vehicles.russia
-	ProvidesCustomPrerequisite@ukrainianstructure:
+	ProvidesPrerequisite@ukrainianstructure:
 		RequiresPrerequisites: structures.ukraine
 		Prerequisite: vehicles.ukraine
 	PrimaryBuilding:
 	ProductionBar:
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 FACT:
 	Inherits: ^Building
@@ -845,31 +845,31 @@ FACT:
 		Queue: Building
 		BuildPaletteOrder: 1000
 		Prerequisites: ~disabled
-	ProvidesCustomPrerequisite@allies:
+	ProvidesPrerequisite@allies:
 		Race: allies, england, france, germany
 		Prerequisite: structures.allies
-	ProvidesCustomPrerequisite@alliesvanilla:
+	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: structures.alliesvanilla
-	ProvidesCustomPrerequisite@england:
+	ProvidesPrerequisite@england:
 		Race: england
 		Prerequisite: structures.england
-	ProvidesCustomPrerequisite@france:
+	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: structures.france
-	ProvidesCustomPrerequisite@germany:
+	ProvidesPrerequisite@germany:
 		Race: germany
 		Prerequisite: structures.germany
-	ProvidesCustomPrerequisite@soviet:
+	ProvidesPrerequisite@soviet:
 		Race: soviet, russia, ukraine
 		Prerequisite: structures.soviet
-	ProvidesCustomPrerequisite@sovietvanilla:
+	ProvidesPrerequisite@sovietvanilla:
 		Race: soviet
 		Prerequisite: structures.sovietvanilla
-	ProvidesCustomPrerequisite@russia:
+	ProvidesPrerequisite@russia:
 		Race: russia
 		Prerequisite: structures.russia
-	ProvidesCustomPrerequisite@ukraine:
+	ProvidesPrerequisite@ukraine:
 		Race: ukraine
 		Prerequisite: structures.ukraine
 	Health:
@@ -908,7 +908,7 @@ FACT:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 PROC:
 	Inherits: ^Building
@@ -960,7 +960,7 @@ PROC:
 		UseDeathTypeSuffix: false
 	WithBuildingExplosion:
 		Delay: 1
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 SILO:
 	Inherits: ^Building
@@ -1025,37 +1025,37 @@ HPAD:
 	PrimaryBuilding:
 	Power:
 		Amount: -10
-	ProvidesCustomPrerequisite@allies:
+	ProvidesPrerequisite@allies:
 		Race: allies, england, france, germany
 		Prerequisite: aircraft.allies
-	ProvidesCustomPrerequisite@alliesvanilla:
+	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: aircraft.alliesvanilla
-	ProvidesCustomPrerequisite@england:
+	ProvidesPrerequisite@england:
 		Race: england
 		Prerequisite: aircraft.england
-	ProvidesCustomPrerequisite@france:
+	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: aircraft.france
-	ProvidesCustomPrerequisite@germany:
+	ProvidesPrerequisite@germany:
 		Race: germany
 		Prerequisite: aircraft.germany
-	ProvidesCustomPrerequisite@alliedstructure:
+	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
 		Prerequisite: aircraft.allies
-	ProvidesCustomPrerequisite@alliedvanillastructure:
+	ProvidesPrerequisite@alliedvanillastructure:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: aircraft.alliesvanilla
-	ProvidesCustomPrerequisite@englishstructure:
+	ProvidesPrerequisite@englishstructure:
 		RequiresPrerequisites: structures.england
 		Prerequisite: aircraft.england
-	ProvidesCustomPrerequisite@frenchstructure:
+	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: aircraft.france
-	ProvidesCustomPrerequisite@germanstructure:
+	ProvidesPrerequisite@germanstructure:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: aircraft.germany
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 AFLD:
 	Inherits: ^Building
@@ -1086,28 +1086,28 @@ AFLD:
 	Production:
 		Produces: Aircraft, Plane
 	Reservable:
-	ProvidesCustomPrerequisite@soviet:
+	ProvidesPrerequisite@soviet:
 		Race: soviet, russia, ukraine
 		Prerequisite: aircraft.soviet
-	ProvidesCustomPrerequisite@sovietvanilla:
+	ProvidesPrerequisite@sovietvanilla:
 		Race: soviet
 		Prerequisite: aircraft.sovietvanilla
-	ProvidesCustomPrerequisite@russia:
+	ProvidesPrerequisite@russia:
 		Race: russia
 		Prerequisite: aircraft.russia
-	ProvidesCustomPrerequisite@ukraine:
+	ProvidesPrerequisite@ukraine:
 		Race: ukraine
 		Prerequisite: aircraft.ukraine
-	ProvidesCustomPrerequisite@sovietstructure:
+	ProvidesPrerequisite@sovietstructure:
 		RequiresPrerequisites: structures.soviet
 		Prerequisite: aircraft.soviet
-	ProvidesCustomPrerequisite@sovietvanillastructure:
+	ProvidesPrerequisite@sovietvanillastructure:
 		RequiresPrerequisites: structures.sovietvanilla
 		Prerequisite: aircraft.sovietvanilla
-	ProvidesCustomPrerequisite@russianstructure:
+	ProvidesPrerequisite@russianstructure:
 		RequiresPrerequisites: structures.russia
 		Prerequisite: aircraft.russia
-	ProvidesCustomPrerequisite@ukrainianstructure:
+	ProvidesPrerequisite@ukrainianstructure:
 		RequiresPrerequisites: structures.ukraine
 		Prerequisite: aircraft.ukraine
 	AirstrikePower@spyplane:
@@ -1160,7 +1160,7 @@ AFLD:
 	PrimaryBuilding:
 	Power:
 		Amount: -20
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 POWR:
 	Inherits: ^Building
@@ -1173,7 +1173,7 @@ POWR:
 	Tooltip:
 		Name: Power Plant
 		Description: Provides power for other structures.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
 		Footprint: xx xx
@@ -1210,7 +1210,7 @@ APWR:
 	Tooltip:
 		Name: Advanced Power Plant
 		Description: Provides double the power of a\nstandard Power Plant.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
 		Footprint: ___ xxx xxx
@@ -1247,7 +1247,7 @@ STEK:
 	Tooltip:
 		Name: Soviet Tech Center
 		Description: Provides Soviet advanced technologies.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: techcenter
 	Building:
 		Footprint: xxx xxx
@@ -1261,7 +1261,7 @@ STEK:
 	Bib:
 	Power:
 		Amount: -100
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 BARR:
 	Inherits: ^Building
@@ -1295,35 +1295,35 @@ BARR:
 		Produces: Infantry, Soldier
 	PrimaryBuilding:
 	ProductionBar:
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: barracks
-	ProvidesCustomPrerequisite@soviet:
+	ProvidesPrerequisite@soviet:
 		Race: soviet, russia, ukraine
 		Prerequisite: infantry.soviet
-	ProvidesCustomPrerequisite@sovietvanilla:
+	ProvidesPrerequisite@sovietvanilla:
 		Race: soviet
 		Prerequisite: infantry.sovietvanilla
-	ProvidesCustomPrerequisite@russia:
+	ProvidesPrerequisite@russia:
 		Race: russia
 		Prerequisite: infantry.russia
-	ProvidesCustomPrerequisite@ukraine:
+	ProvidesPrerequisite@ukraine:
 		Race: ukraine
 		Prerequisite: infantry.ukraine
-	ProvidesCustomPrerequisite@sovietstructure:
+	ProvidesPrerequisite@sovietstructure:
 		RequiresPrerequisites: structures.soviet
 		Prerequisite: infantry.soviet
-	ProvidesCustomPrerequisite@sovietvanillastructure:
+	ProvidesPrerequisite@sovietvanillastructure:
 		RequiresPrerequisites: structures.sovietvanilla
 		Prerequisite: infantry.sovietvanilla
-	ProvidesCustomPrerequisite@russianstructure:
+	ProvidesPrerequisite@russianstructure:
 		RequiresPrerequisites: structures.russia
 		Prerequisite: infantry.russia
-	ProvidesCustomPrerequisite@ukrainianstructure:
+	ProvidesPrerequisite@ukrainianstructure:
 		RequiresPrerequisites: structures.ukraine
 		Prerequisite: infantry.ukraine
 	Power:
 		Amount: -20
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 KENN:
 	Inherits: ^Building
@@ -1358,7 +1358,7 @@ KENN:
 	-EmitInfantryOnSell:
 	Power:
 		Amount: -10
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 TENT:
 	Inherits: ^Building
@@ -1392,41 +1392,41 @@ TENT:
 		Produces: Infantry, Soldier
 	PrimaryBuilding:
 	ProductionBar:
-	ProvidesCustomPrerequisite@barracks:
+	ProvidesPrerequisite@barracks:
 		Prerequisite: barracks
-	ProvidesCustomPrerequisite@allies:
+	ProvidesPrerequisite@allies:
 		Race: allies, england, france, germany
 		Prerequisite: infantry.allies
-	ProvidesCustomPrerequisite@alliesvanilla:
+	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: infantry.alliesvanilla
-	ProvidesCustomPrerequisite@england:
+	ProvidesPrerequisite@england:
 		Race: england
 		Prerequisite: infantry.england
-	ProvidesCustomPrerequisite@france:
+	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: infantry.france
-	ProvidesCustomPrerequisite@germany:
+	ProvidesPrerequisite@germany:
 		Race: germany
 		Prerequisite: infantry.germany
-	ProvidesCustomPrerequisite@alliedstructure:
+	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
 		Prerequisite: infantry.allies
-	ProvidesCustomPrerequisite@alliedvanillastructure:
+	ProvidesPrerequisite@alliedvanillastructure:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: infantry.alliesvanilla
-	ProvidesCustomPrerequisite@englishstructure:
+	ProvidesPrerequisite@englishstructure:
 		RequiresPrerequisites: structures.england
 		Prerequisite: infantry.england
-	ProvidesCustomPrerequisite@frenchstructure:
+	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: infantry.france
-	ProvidesCustomPrerequisite@germanstructure:
+	ProvidesPrerequisite@germanstructure:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: infantry.germany
 	Power:
 		Amount: -20
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 FIX:
 	Inherits: ^Building
@@ -1458,7 +1458,7 @@ FIX:
 	WithRepairAnimation:
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 SBAG:
 	Inherits: ^Wall

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -1087,7 +1087,7 @@ CTDAM:
 		Type: heavy
 	Health:
 		HP: 1000
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 
 CTVEGA:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -9,7 +9,7 @@ GAPOWR:
 	Tooltip:
 		Name: GDI Power Plant
 		Description: Provides power for other structures.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
 		Footprint: xx xx
@@ -58,7 +58,7 @@ GAPOWR:
 		UpgradeTypes: powrup.b
 		UpgradeMinEnabledLevel: 1
 		Amount: 50
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GAPILE:
 	Inherits: ^Building
@@ -71,7 +71,7 @@ GAPILE:
 	Tooltip:
 		Name: GDI Barracks
 		Description: Produces infantry.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Building:
 		Footprint: xx xx
@@ -101,7 +101,7 @@ GAPILE:
 		Sequence: idle-flag
 	Power:
 		Amount: -20
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GAWEAP:
 	Inherits: ^Building
@@ -110,7 +110,7 @@ GAWEAP:
 	Tooltip:
 		Name: GDI War Factory
 		Description: Produces vehicles.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: factory
 	Buildable:
 		Queue: Building
@@ -148,7 +148,7 @@ GAWEAP:
 		Sequence: bib
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GAHPAD:
 	Inherits: ^Building
@@ -188,7 +188,7 @@ GAHPAD:
 		Amount: -10
 	Selectable:
 		Bounds: 88, 66, 0, -5
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GADEPT:
 	Inherits: ^Building
@@ -228,7 +228,7 @@ GADEPT:
 		UseDeathTypeSuffix: false
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GARADR:
 	Inherits: ^Building
@@ -241,7 +241,7 @@ GARADR:
 	Tooltip:
 		Name: GDI Radar
 		Description: Provides an overview of the battlefield.\nCan detect cloaked units.\nRequires power to operate.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: radar
 	Building:
 		Footprint: xx xx
@@ -269,7 +269,7 @@ GARADR:
 		TargetTypes: Ground, C4, SpyInfiltrate
 	Power:
 		Amount: -50
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GATECH:
 	Inherits: ^Building
@@ -282,7 +282,7 @@ GATECH:
 	Tooltip:
 		Name: GDI Tech Center
 		Description: Provides access to advanced GDI technologies.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: tech
 	Building:
 		Footprint: xxx xxx
@@ -299,7 +299,7 @@ GATECH:
 		Sequence: idle-lights
 	Power:
 		Amount: -150
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GAPLUG:
 	Inherits: ^Building
@@ -372,4 +372,4 @@ GAPLUG:
 		UpgradeTypes: plug.ioncannonb
 		UpgradeMinEnabledLevel: 1
 		Sequence: idle-ioncannonb
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -58,6 +58,7 @@ GAPOWR:
 		UpgradeTypes: powrup.b
 		UpgradeMinEnabledLevel: 1
 		Amount: 50
+	ProvidesCustomPrerequisite@buildingname:
 
 GAPILE:
 	Inherits: ^Building
@@ -100,6 +101,7 @@ GAPILE:
 		Sequence: idle-flag
 	Power:
 		Amount: -20
+	ProvidesCustomPrerequisite@buildingname:
 
 GAWEAP:
 	Inherits: ^Building
@@ -146,6 +148,7 @@ GAWEAP:
 		Sequence: bib
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 GAHPAD:
 	Inherits: ^Building
@@ -185,6 +188,7 @@ GAHPAD:
 		Amount: -10
 	Selectable:
 		Bounds: 88, 66, 0, -5
+	ProvidesCustomPrerequisite@buildingname:
 
 GADEPT:
 	Inherits: ^Building
@@ -224,6 +228,7 @@ GADEPT:
 		UseDeathTypeSuffix: false
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 GARADR:
 	Inherits: ^Building
@@ -264,6 +269,7 @@ GARADR:
 		TargetTypes: Ground, C4, SpyInfiltrate
 	Power:
 		Amount: -50
+	ProvidesCustomPrerequisite@buildingname:
 
 GATECH:
 	Inherits: ^Building
@@ -293,6 +299,7 @@ GATECH:
 		Sequence: idle-lights
 	Power:
 		Amount: -150
+	ProvidesCustomPrerequisite@buildingname:
 
 GAPLUG:
 	Inherits: ^Building
@@ -365,3 +372,4 @@ GAPLUG:
 		UpgradeTypes: plug.ioncannonb
 		UpgradeMinEnabledLevel: 1
 		Sequence: idle-ioncannonb
+	ProvidesCustomPrerequisite@buildingname:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -23,7 +23,6 @@ GAWALL:
 	LineBuild:
 		NodeTypes: wall, turret
 
-
 GACTWR:
 	Inherits: ^Building
 	Valued:
@@ -128,6 +127,7 @@ GACTWR:
 			tower.vulcan: tower, tower.vulcan
 			tower.rocket: tower, tower.rocket
 			tower.sam: tower, tower.sam
+	ProvidesCustomPrerequisite@buildingname:
 
 GAVULC:
 	Inherits: ^BuildingPlug

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -127,7 +127,7 @@ GACTWR:
 			tower.vulcan: tower, tower.vulcan
 			tower.rocket: tower, tower.rocket
 			tower.sam: tower, tower.sam
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GAVULC:
 	Inherits: ^BuildingPlug

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -9,7 +9,7 @@ NAPOWR:
 	Tooltip:
 		Name: Nod Power Plant
 		Description: Provides power for other structures.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
 		Footprint: xx xx
@@ -44,7 +44,7 @@ NAAPWR:
 	Tooltip:
 		Name: Advanced Power Plant
 		Description: Provides twice as much power as\nthe normal Power Plant.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
 		Footprint: xxx xxx
@@ -79,7 +79,7 @@ NAHAND:
 	Tooltip:
 		Name: Hand of Nod
 		Description: Produces infantry.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Building:
 		Footprint: xxx xxx
@@ -107,7 +107,7 @@ NAHAND:
 		Sequence: production-light
 	Power:
 		Amount: -20
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 NAWEAP:
 	Inherits: ^Building
@@ -116,7 +116,7 @@ NAWEAP:
 	Tooltip:
 		Name: Nod War Factory
 		Description: Produces vehicles.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: factory
 	Buildable:
 		Queue: Building
@@ -150,7 +150,7 @@ NAWEAP:
 		Sequence: bib
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 NAHPAD:
 	Inherits: ^Building
@@ -190,7 +190,7 @@ NAHPAD:
 		Amount: -10
 	Selectable:
 		Bounds: 78, 54, 0, -8
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 NARADR:
 	Inherits: ^Building
@@ -203,7 +203,7 @@ NARADR:
 	Tooltip:
 		Name: Nod Radar
 		Description: Provides an overview of the battlefield.\nCan detect cloaked units.\nRequires power to operate.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: radar
 	Building:
 		Footprint: xx xx
@@ -231,7 +231,7 @@ NARADR:
 		TargetTypes: Ground, C4, SpyInfiltrate
 	Power:
 		Amount: -50
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 NATECH:
 	Inherits: ^Building
@@ -244,7 +244,7 @@ NATECH:
 	Tooltip:
 		Name: Nod Tech Center
 		Description: Provides access to advanced Nod technologies.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: tech
 	Building:
 		Footprint: xx xx
@@ -261,7 +261,7 @@ NATECH:
 		Sequence: idle-lights
 	Power:
 		Amount: -150
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 NASTLH:
 	Inherits: ^Building

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -107,6 +107,7 @@ NAHAND:
 		Sequence: production-light
 	Power:
 		Amount: -20
+	ProvidesCustomPrerequisite@buildingname:
 
 NAWEAP:
 	Inherits: ^Building
@@ -149,6 +150,7 @@ NAWEAP:
 		Sequence: bib
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 NAHPAD:
 	Inherits: ^Building
@@ -188,6 +190,7 @@ NAHPAD:
 		Amount: -10
 	Selectable:
 		Bounds: 78, 54, 0, -8
+	ProvidesCustomPrerequisite@buildingname:
 
 NARADR:
 	Inherits: ^Building
@@ -228,6 +231,7 @@ NARADR:
 		TargetTypes: Ground, C4, SpyInfiltrate
 	Power:
 		Amount: -50
+	ProvidesCustomPrerequisite@buildingname:
 
 NATECH:
 	Inherits: ^Building
@@ -257,6 +261,7 @@ NATECH:
 		Sequence: idle-lights
 	Power:
 		Amount: -150
+	ProvidesCustomPrerequisite@buildingname:
 
 NASTLH:
 	Inherits: ^Building

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -255,7 +255,7 @@ NAMISL:
 	Tooltip:
 		Name: Nod Missile Silo
 		Description: Launches a devastating missile\nat a target location.\nRequires power to operate.
-	ProvidesCustomPrerequisite:
+	ProvidesPrerequisite:
 		Prerequisite: tech
 	Building:
 		Footprint: xx xx

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -43,10 +43,10 @@ GACNST:
 		Amount: 0
 	Selectable:
 		Bounds: 144, 80, 0, -12
-	ProvidesCustomPrerequisite@gdi:
+	ProvidesPrerequisite@gdi:
 		Race: gdi
 		Prerequisite: structures.gdi
-	ProvidesCustomPrerequisite@nod:
+	ProvidesPrerequisite@nod:
 		Race: nod
 		Prerequisite: structures.nod
 
@@ -93,7 +93,7 @@ PROC:
 		Palette: effect
 	Power:
 		Amount: -30
-	ProvidesCustomPrerequisite@buildingname:
+	ProvidesPrerequisite@buildingname:
 
 GASILO:
 	Inherits: ^Building

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -93,6 +93,7 @@ PROC:
 		Palette: effect
 	Power:
 		Amount: -30
+	ProvidesCustomPrerequisite@buildingname:
 
 GASILO:
 	Inherits: ^Building


### PR DESCRIPTION
The `Building` trait no longer provides any custom prerequisites automatically in order to keep things consistent.
Naturally, the lint check no longer cares about buildings. Overall, this amounts to 2 bogus trait dependencies being removed.
Buildings that need to provide their name as prerequisite now have `ProvidesCustomPrerequisite` with it's default value, which is now the actor's name.
Next step is to use that last part for upgrades, so the lint check passes for #7597.

Closes #5287.

Commits will be squashed, of course.
