### PR TITLE
Small code cleanup.

### DIFF
--- a/OpenRA.Game/Group.cs
+++ b/OpenRA.Game/Group.cs
@@ -15,8 +15,8 @@ namespace OpenRA
 {
 	public class Group
 	{
-		Actor[] actors;
-		int id;
+		readonly Actor[] actors;
+		readonly int id;
 
 		static int nextGroup;
 

--- a/OpenRA.Game/Traits/CreatesShroud.cs
+++ b/OpenRA.Game/Traits/CreatesShroud.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Traits
 
 	public class CreatesShroud : ITick, ISync
 	{
-		CreatesShroudInfo info;
+		readonly CreatesShroudInfo info;
 		[Sync] CPos cachedLocation;
 		[Sync] bool cachedDisabled;
 

--- a/OpenRA.Game/Traits/DebugPauseState.cs
+++ b/OpenRA.Game/Traits/DebugPauseState.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Traits
 
 	public class DebugPauseState : ISync
 	{
-		World world;
+		readonly World world;
 		[Sync] public bool Paused { get { return world.Paused; } }
 		public DebugPauseState(World world) { this.world = world; }
 	}

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Traits
 
 		public void SetTarget(Actor self, Target target, Color c, bool display)
 		{
-			this.targets = new List<Target> { target };
+			targets = new List<Target> { target };
 			this.c = c;
 
 			if (display)

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Traits
 			if (IsDead)
 				return;
 
-			var oldState = this.DamageState;
+			var oldState = DamageState;
 
 			// Apply any damage modifiers
 			if (!ignoreModifiers && damage > 0)
@@ -128,7 +128,7 @@ namespace OpenRA.Traits
 			{
 				Attacker = attacker,
 				Damage = damage,
-				DamageState = this.DamageState,
+				DamageState = DamageState,
 				PreviousDamageState = oldState,
 				Warhead = warhead,
 			};

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -12,7 +12,7 @@ using System;
 
 namespace OpenRA.Traits
 {
-	/* attributes used by RALint to understand the rules */
+	/* attributes used by OpenRA.Lint to understand the rules */
 
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class ActorReferenceAttribute : Attribute { }

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Traits
 
 	public class RevealsShroud : ITick, ISync
 	{
-		RevealsShroudInfo info;
+		readonly RevealsShroudInfo info;
 		[Sync] CPos cachedLocation;
 
 		public RevealsShroud(RevealsShroudInfo info)

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Traits
 	public class Selectable : IPostRenderSelection
 	{
 		public SelectableInfo Info;
-		Actor self;
+		readonly Actor self;
 
 		public Selectable(Actor self, SelectableInfo info)
 		{

--- a/OpenRA.Game/Traits/SelectionDecorations.cs
+++ b/OpenRA.Game/Traits/SelectionDecorations.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Traits
 		static readonly string[] TagStrings = { "", "tag-fake", "tag-primary" };
 
 		public SelectionDecorationsInfo Info;
-		Actor self;
+		readonly Actor self;
 
 		public SelectionDecorations(Actor self, SelectionDecorationsInfo info)
 		{

--- a/OpenRA.Mods.Cnc/Effects/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Effects/IonCannon.cs
@@ -13,7 +13,6 @@ using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
-using OpenRA.Mods.RA;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Effects

--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -9,11 +9,8 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Activities;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
@@ -35,7 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		enum PopupState { Open, Rotating, Transitioning, Closed }
 
-		AttackPopupTurretedInfo info;
+		readonly AttackPopupTurretedInfo info;
 		RenderBuilding rb;
 
 		int idleTicks = 0;
@@ -72,10 +69,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				return false;
 			}
 
-			if (!turret.FaceTarget(self, target))
-				return false;
-
-			return true;
+			return turret.FaceTarget(self, target);
 		}
 
 		public void TickIdle(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -12,9 +12,6 @@ using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA;
-using OpenRA.Mods.RA.Activities;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/PoisonedByTiberium.cs
+++ b/OpenRA.Mods.Cnc/Traits/PoisonedByTiberium.cs
@@ -11,8 +11,6 @@
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
@@ -11,7 +11,6 @@
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
@@ -26,8 +25,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	public class WithDeliveryAnimation : INotifyDelivery
 	{
-		WithDeliveryAnimationInfo info;
-		RenderBuilding building;
+		readonly WithDeliveryAnimationInfo info;
+		readonly RenderBuilding building;
 
 		public WithDeliveryAnimation(Actor self, WithDeliveryAnimationInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Guardable.cs
+++ b/OpenRA.Mods.Common/Traits/Guardable.cs
@@ -15,6 +15,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This unit can be guarded (followed and protected) by a Guard unit.")]
 	public class GuardableInfo : TraitInfo<Guardable>
 	{
+		[Desc("Maximum range that guarding actors will maintain. Measured in cells.")]
 		public readonly int Range = 2;
 	}
 

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -74,9 +74,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!checkTransientActors)
 				return SubCell.FullCell;
 
-			return !self.World.ActorMap.GetUnitsAt(cell)
-				.Where(x => x != ignoreActor)
-				.Any() ? SubCell.FullCell : SubCell.Invalid;
+			return self.World.ActorMap.GetUnitsAt(cell)
+				.All(x => x == ignoreActor) ? SubCell.FullCell : SubCell.Invalid;
 		}
 
 		public bool CanEnterCell(CPos a, Actor ignoreActor = null, bool checkTransientActors = true)

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -8,12 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using OpenRA.Effects;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -168,9 +168,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Sign of dot-product indicates (roughly) if vectors are facing in same or opposite directions:
 			var dp = CVec.Dot(selfMobile.ToCell - self.Location, otherMobile.ToCell - other.Location);
-			if (dp <= 0) return false;
 
-			return true;
+			return dp > 0;
 		}
 
 		public int TileSetMovementHash(TileSet tileSet)
@@ -688,7 +687,7 @@ namespace OpenRA.Mods.Common.Traits
 			public MoveOrderTargeter(Actor self, MobileInfo unitType)
 			{
 				this.unitType = unitType;
-				this.rejectMove = !self.AcceptsOrder("Move");
+				rejectMove = !self.AcceptsOrder("Move");
 			}
 
 			public string OrderID { get { return "Move"; } }

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 using OpenRA.Graphics;
 
 namespace OpenRA.Mods.D2k.SpriteLoaders

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -10,7 +10,6 @@
 
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits

--- a/OpenRA.Mods.D2k/Traits/Carryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryable.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.D2k.Traits
 				.Where(p => p.Actor.Owner == self.Owner && !p.Trait.IsBusy && p.Actor.IsInWorld)
 				.Select(h => h.Actor);
 
-			return WorldUtils.ClosestTo(carriers, self);
+			return carriers.ClosestTo(self);
 		}
 
 		// This gets called by carrier after we touched down

--- a/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
@@ -10,8 +10,6 @@
 
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -10,7 +10,6 @@
 
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -11,7 +11,6 @@
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits

--- a/OpenRA.Mods.D2k/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDockingOverlay.cs
@@ -11,7 +11,6 @@
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits

--- a/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
@@ -61,9 +61,9 @@ namespace OpenRA.Mods.D2k.Traits
 		public Color GetRemappedColor(Color original, int index)
 		{
 			return Color.FromArgb(original.A,
-				(int)Exts.Clamp((int)(scale * original.R + offset), 0, 255),
-				(int)Exts.Clamp((int)(scale * original.G + offset), 0, 255),
-				(int)Exts.Clamp((int)(scale * original.B + offset), 0, 255));
+				(int)(scale * original.R + offset).Clamp(0, 255),
+				(int)(scale * original.G + offset).Clamp(0, 255),
+				(int)(scale * original.B + offset).Clamp(0, 255));
 		}
 	}
 }

--- a/OpenRA.Mods.D2k/Traits/World/WormManager.cs
+++ b/OpenRA.Mods.D2k/Traits/World/WormManager.cs
@@ -10,9 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 
 namespace OpenRA.Mods.D2k.UtilityCommands
 {

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -10,7 +10,6 @@
 
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Activities

--- a/OpenRA.Mods.RA/Activities/LayMines.cs
+++ b/OpenRA.Mods.RA/Activities/LayMines.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.RA.Activities
 		static bool ShouldLayMine(Actor self, CPos p)
 		{
 			// If there is no unit (other than me) here, we want to place a mine here
-			return !self.World.ActorMap.GetUnitsAt(p).Any(a => a != self);
+			return self.World.ActorMap.GetUnitsAt(p).All(a => a == self);
 		}
 
 		void LayMine(Actor self)

--- a/OpenRA.Mods.RA/Activities/Leap.cs
+++ b/OpenRA.Mods.RA/Activities/Leap.cs
@@ -13,20 +13,19 @@ using System.Linq;
 using OpenRA.Activities;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Activities
 {
 	class Leap : Activity
 	{
-		Mobile mobile;
-		WeaponInfo weapon;
+		readonly Mobile mobile;
+		readonly WeaponInfo weapon;
+		readonly int length;
 
 		WPos from;
 		WPos to;
 		int ticks;
-		int length;
 		WAngle angle;
 
 		public Leap(Actor self, Actor target, WeaponInfo weapon, WRange speed, WAngle angle)

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -23,9 +23,9 @@ namespace OpenRA.Mods.RA.Activities
 	public class Teleport : Activity
 	{
 		const int MaxCellSearchRange = Map.MaxTilesInCircleRange;
-		Actor teleporter;
+		readonly Actor teleporter;
+		readonly int? maximumDistance;
 		CPos destination;
-		int? maximumDistance;
 		bool killCargo;
 		bool screenFlash;
 		string sound;

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -32,9 +32,9 @@ namespace OpenRA.Mods.RA.Effects
 
 	class GpsDot : IEffect
 	{
-		Actor self;
-		GpsDotInfo info;
-		Animation anim;
+		readonly Actor self;
+		readonly GpsDotInfo info;
+		readonly Animation anim;
 
 		Lazy<HiddenUnderFog> huf;
 		Lazy<FrozenUnderFog> fuf;

--- a/OpenRA.Mods.RA/Scripting/Properties/ParadropProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ParadropProperties.cs
@@ -8,10 +8,8 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Scripting/Properties/ParatroopersProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ParatroopersProperties.cs
@@ -9,8 +9,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.RA/Traits/Attack/AttackLeap.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
@@ -25,9 +24,9 @@ namespace OpenRA.Mods.RA.Traits
 		public override object Create(ActorInitializer init) { return new AttackLeap(init.Self, this); }
 	}
 
-	class AttackLeap : AttackFrontal, ISync
+	class AttackLeap : AttackFrontal
 	{
-		AttackLeapInfo info;
+		readonly AttackLeapInfo info;
 
 		public AttackLeap(Actor self, AttackLeapInfo info)
 			: base(self, info)

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -8,7 +8,6 @@
   */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.RA.Traits
 				return true;
 			}
 
-			/// Set up return-to-sender info
+			// Set up return-to-sender info
 			Origin = self.Location;
 			ReturnTicks = duration;
 			this.duration = duration;

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -25,9 +25,9 @@ namespace OpenRA.Mods.RA.Traits
 
 	class DisguiseToolTip : IToolTip
 	{
-		Actor self;
+		readonly Actor self;
+		readonly Disguise disguise;
 		TooltipInfo info;
-		Disguise disguise;
 
 		public DisguiseToolTip(Actor self, TooltipInfo info)
 		{
@@ -49,12 +49,7 @@ namespace OpenRA.Mods.RA.Traits
 			get
 			{
 				if (disguise.Disguised)
-				{
-					if (self.Owner == self.World.LocalPlayer)
-						return self.Owner;
-
-					return disguise.AsPlayer;
-				}
+					return self.Owner == self.World.LocalPlayer ? self.Owner : disguise.AsPlayer;
 
 				return self.Owner;
 			}

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Traits/InvulnerabilityUpgrade.cs
+++ b/OpenRA.Mods.RA/Traits/InvulnerabilityUpgrade.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Traits/MadTank.cs
+++ b/OpenRA.Mods.RA/Traits/MadTank.cs
@@ -32,9 +32,11 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly float2 ThumpShakeMultiplier = new float2(1, 0);
 		public readonly int ThumpShakeTime = 10;
 
+		[Desc("Measured in ticks.")]
 		public readonly int ChargeDelay = 96;
 		public readonly string ChargeSound = "madchrg2.aud";
 
+		[Desc("Measured in ticks.")]
 		public readonly int DetonationDelay = 42;
 		public readonly string DetonationSound = "madexplo.aud";
 		[WeaponReference]

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public Mine(ActorInitializer init, MineInfo info)
 		{
-			this.self = init.Self;
+			self = init.Self;
 			this.info = info;
 		}
 

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -34,9 +34,9 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		/* TODO: [Sync] when sync can cope with arrays! */
 		public CPos[] Minefield = null;
+		readonly Actor self;
+		readonly Sprite tile;
 		[Sync] CPos minefieldStart;
-		Actor self;
-		Sprite tile;
 
 		public Minelayer(Actor self)
 		{

--- a/OpenRA.Mods.RA/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
+++ b/OpenRA.Mods.RA/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.RA.Traits
 	[Desc("Apply palette full screen rotations during chronoshifts. Add this to the world actor.")]
 	public class ChronoshiftPaletteEffectInfo : ITraitInfo
 	{
+		[Desc("Measured in ticks.")]
 		public readonly int ChronoEffectLength = 60;
 
 		public object Create(ActorInitializer init) { return new ChronoshiftPaletteEffect(this); }
@@ -25,8 +26,8 @@ namespace OpenRA.Mods.RA.Traits
 
 	public class ChronoshiftPaletteEffect : IPaletteModifier, ITick
 	{
+		readonly ChronoshiftPaletteEffectInfo info;
 		int remainingFrames;
-		ChronoshiftPaletteEffectInfo info;
 
 		public ChronoshiftPaletteEffect(ChronoshiftPaletteEffectInfo info)
 		{

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
@@ -14,7 +14,6 @@ using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.TS/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.TS/SpriteLoaders/TmpTSLoader.cs
@@ -9,11 +9,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
 
 namespace OpenRA.Mods.TS.SpriteLoaders

--- a/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
@@ -41,8 +41,8 @@ namespace OpenRA.Mods.TS.Traits
 
 		public readonly WAngle LightPitch = WAngle.FromDegrees(50);
 		public readonly WAngle LightYaw = WAngle.FromDegrees(240);
-		public readonly float[] LightAmbientColor = new float[] { 0.6f, 0.6f, 0.6f };
-		public readonly float[] LightDiffuseColor = new float[] { 0.4f, 0.4f, 0.4f };
+		public readonly float[] LightAmbientColor = { 0.6f, 0.6f, 0.6f };
+		public readonly float[] LightDiffuseColor = { 0.4f, 0.4f, 0.4f };
 
 		public virtual object Create(ActorInitializer init) { return new RenderVoxels(init.Self, this); }
 
@@ -63,17 +63,17 @@ namespace OpenRA.Mods.TS.Traits
 				.SelectMany(rvpi => rvpi.RenderPreviewVoxels(init, this, image, orientation, facings, palette))
 				.ToArray();
 
-			yield return new VoxelPreview(components, WVec.Zero, 0, this.Scale, this.LightPitch,
-				this.LightYaw, this.LightAmbientColor, this.LightDiffuseColor, body.CameraPitch,
+			yield return new VoxelPreview(components, WVec.Zero, 0, Scale, LightPitch,
+				LightYaw, LightAmbientColor, LightDiffuseColor, body.CameraPitch,
 				palette, init.WorldRenderer.Palette(NormalsPalette), init.WorldRenderer.Palette(ShadowPalette));
 		}
 	}
 
 	public class RenderVoxels : IRender, INotifyOwnerChanged
 	{
+		readonly List<VoxelAnimation> components = new List<VoxelAnimation>();
 		Actor self;
 		RenderVoxelsInfo info;
-		List<VoxelAnimation> components = new List<VoxelAnimation>();
 		IBodyOrientation body;
 		WRot camera;
 		WRot lightSource;

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelBarrel.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.TS.Traits
 
 			var rv = self.Trait<RenderVoxels>();
 			rv.Add(new VoxelAnimation(VoxelProvider.GetVoxel(rv.Image, info.Sequence),
-				() => BarrelOffset(), () => BarrelRotation(),
+				BarrelOffset, BarrelRotation,
 				() => false, () => 0));
 		}
 

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelTurret.cs
@@ -45,9 +45,9 @@ namespace OpenRA.Mods.TS.Traits
 
 	public class WithVoxelTurret
 	{
-		Actor self;
-		Turreted turreted;
-		IBodyOrientation body;
+		readonly Actor self;
+		readonly Turreted turreted;
+		readonly IBodyOrientation body;
 
 		public WithVoxelTurret(Actor self, WithVoxelTurretInfo info)
 		{
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.TS.Traits
 
 			var rv = self.Trait<RenderVoxels>();
 			rv.Add(new VoxelAnimation(VoxelProvider.GetVoxel(rv.Image, info.Sequence),
-				() => turreted.Position(self), () => TurretRotation(),
+				() => turreted.Position(self), TurretRotation,
 				() => false, () => 0));
 		}
 

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using OpenRA.FileFormats;
 using OpenRA.FileSystem;

--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -117,7 +117,7 @@ GAPOWRUP:
 		Cost: 150
 	Tooltip:
 		Name: Power Turbine
-		Description: Provides extra power generation
+		Description: Provides extra power generation.
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 10
@@ -1328,7 +1328,7 @@ GAPLUG:
 		Cost: 1000
 	Tooltip:
 		Name: GDI Upgrade Center
-		Description: Can be upgraded for additional technology
+		Description: Can be upgraded for additional technology.
 	Selectable:
 		Bounds: 115,120,0,-20
 	Buildable:
@@ -1399,7 +1399,7 @@ GAPLUG3:
 		Cost: 1500
 	Tooltip:
 		Name: Ion Cannon Uplink
-		Description: Enables use of the Ion Cannon
+		Description: Enables use of the Ion Cannon.
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 1000


### PR DESCRIPTION
Simplify return statements.
Remove redundant ‘this’.
Remove unused using directives.
Simplify LINQ chains.
Add some trait property descriptions.
Add readonly where viable.
Add fullstops to some yaml descriptions.
