### PR TITLE
Fix CellLayer.GetEnumerator

### DIFF
--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -115,7 +115,7 @@ namespace OpenRA
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			return (IEnumerator<T>)entries.GetEnumerator();
+			return ((IEnumerable<T>)entries).GetEnumerator();
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
You can cast an array, but not the enumerator (MS runtime, at least).

Doesn't actually affect the game, but debuggers that enumerate collections automatically for convenience will benefit since it will work now.
