### PR TITLE
Fix crash when placing buildings in TD

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Orders
 		public PlaceBuildingOrderGenerator(ProductionQueue queue, string name)
 		{
 			producer = queue.Actor;
-			placeBuildingInfo = producer.Info.Traits.Get<PlaceBuildingInfo>();
+			placeBuildingInfo = producer.Owner.PlayerActor.Info.Traits.Get<PlaceBuildingInfo>();
 			building = name;
 
 			// Clear selection if using Left-Click Orders


### PR DESCRIPTION
Caused by production queues being tied to buildings, not the player, in TD.
PBOG would therefore try to find the `PlaceBuilding` trait, which is on the player, on the conyard actor and crash.

Fixes #7821.
