### PR TITLE
Added hotkeys for support powers

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -212,9 +212,25 @@ namespace OpenRA
 		public Hotkey ProductionTypeTankKey = new Hotkey(Keycode.I, Modifiers.None);
 		public Hotkey ProductionTypeMerchantKey = new Hotkey(Keycode.O, Modifiers.None);
 
+		public Hotkey SupportPower01Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
+		public Hotkey SupportPower02Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
+		public Hotkey SupportPower03Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
+		public Hotkey SupportPower04Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
+		public Hotkey SupportPower05Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
+		public Hotkey SupportPower06Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
+
 		public Hotkey GetProductionHotkey(int index)
 		{
 			var field = GetType().GetField("Production{0:D2}Key".F(index + 1));
+			if (field == null)
+				return Hotkey.Invalid;
+
+			return (Hotkey)field.GetValue(this);
+		}
+
+		public Hotkey GetSupportPowerHotkey(int index)
+		{
+			var field = GetType().GetField("SupportPower{0:D2}Key".F(index + 1));
 			if (field == null)
 				return Hotkey.Invalid;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -19,8 +19,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public SupportPowerTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, SupportPowersWidget palette)
 		{
-			widget.IsVisible = () => palette.TooltipPower != null;
+			widget.IsVisible = () => palette.TooltipIcon != null;
 			var nameLabel = widget.Get<LabelWidget>("NAME");
+			var hotkeyLabel = widget.Get<LabelWidget>("HOTKEY");
 			var timeLabel = widget.Get<LabelWidget>("TIME");
 			var descLabel = widget.Get<LabelWidget>("DESC");
 			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
@@ -35,9 +36,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SupportPowerInstance lastPower = null;
 			tooltipContainer.BeforeRender = () =>
 			{
-				var sp = palette.TooltipPower;
-				if (sp == null)
+				var icon = palette.TooltipIcon;
+
+				if (icon == null)
 					return;
+
+				var sp = icon.Power;
 
 				if (sp.Info == null)
 					return;		// no instances actually exist (race with destroy)
@@ -50,8 +54,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				name = sp.Info.Description;
 				desc = sp.Info.LongDesc.Replace("\\n", "\n");
+
+				var hotkey = icon.Hotkey;
+				var hotkeyText = "({0})".F(hotkey.DisplayString());
+				var hotkeyWidth = hotkey.IsValid() ? nameFont.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
+				hotkeyLabel.GetText = () => hotkeyText;
+				hotkeyLabel.Bounds.X = nameFont.Measure(name).X + 2 * nameLabel.Bounds.X;
+				hotkeyLabel.Visible = hotkey.IsValid();
+
 				var timeWidth = timeFont.Measure(time).X;
-				var topWidth = nameFont.Measure(name).X + timeWidth + timeOffset;
+				var topWidth = nameFont.Measure(name).X + hotkeyWidth + timeWidth + timeOffset;
 				var descSize = descFont.Measure(desc);
 				widget.Bounds.Width = 2 * nameLabel.Bounds.X + Math.Max(topWidth, descSize.X);
 				widget.Bounds.Height = baseHeight + descSize.Y;

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -439,6 +439,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					BindHotkeyPref(kv, ks, productionTemplate, hotkeyList);
 			}
 
+			// Support powers
+			{
+				var hotkeys = new Dictionary<string, string>();
+				for (var i = 1; i <= 6; i++)
+					hotkeys.Add("SupportPower{0:D2}Key".F(i), "Slot {0}".F(i));
+
+				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);
+				header.Get<LabelWidget>("LABEL").GetText = () => "Support Power Commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, productionTemplate, hotkeyList);
+			}
+
 			// Developer
 			{
 				var hotkeys = new Dictionary<string, string>()

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -116,8 +116,12 @@ Background@SUPPORT_POWER_TOOLTIP:
 			X: 5
 			Height: 20
 			Font: Bold
+		Label@HOTKEY:
+			Visible: false
+			Height: 20
+			TextColor: 255,255,0
+			Font: Bold
 		Label@TIME:
-			X: 20
 			Y: 6
 			Font: TinyBold
 			VAlign: Top

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -181,8 +181,13 @@ Background@SUPPORT_POWER_TOOLTIP:
 			Y: 2
 			Height: 20
 			Font: Bold
+		Label@HOTKEY:
+			Visible: false
+			Y: 2
+			Height: 20
+			TextColor: 255,255,0
+			Font: Bold
 		Label@TIME:
-			X: 20
 			Y: 8
 			Font: TinyBold
 			VAlign: Top

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -181,8 +181,13 @@ Background@SUPPORT_POWER_TOOLTIP:
 			Y: 2
 			Height: 20
 			Font: Bold
+		Label@HOTKEY:
+			Visible: false
+			Y: 2
+			Height: 20
+			TextColor: 255,255,0
+			Font: Bold
 		Label@TIME:
-			X: 20
 			Y: 8
 			Font: TinyBold
 			VAlign: Top


### PR DESCRIPTION
Implemented hotkey logic for support powers (as requested in #7369) and UI items for configuring the hotkeys.
Also the hotkey is displayed in the support power tooltip in the same manner as unit/structure tooltips are.
