### PR TITLE
Fix crash in allies03b

### DIFF
--- a/mods/ra/maps/allies-03b/allies03b.lua
+++ b/mods/ra/maps/allies-03b/allies03b.lua
@@ -111,7 +111,9 @@ JeepCheckpointMove = function()
 		if Jeep.Location == JeepCheckpoint.Location then
 			Trigger.ClearAll(Jeep)
 			for i = 1, 2, 1 do
-				CheckpointGuards[i].Move(CheckpointGuardWaypoints[i].Location)
+				if not CheckpointGuards[i].IsDead then
+					CheckpointGuards[i].Move(CheckpointGuardWaypoints[i].Location)
+				end
 			end
 		else
 			Jeep.Move(JeepCheckpoint.Location)


### PR DESCRIPTION
Fixes #7824.

To reproduce the crash, kill at least one of the e1s at the sandbag revetments between the first and second base before the jeep comes to a halt.
