### PR TITLE
Another cleanup.

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -167,7 +167,7 @@ namespace OpenRA
 					throw new InvalidDataException("`{0}` is not a valid mod manifest entry.".F(kv.Key));
 
 				IGlobalModData module;
-				var ctor = t.GetConstructor(new Type[] { typeof(MiniYaml) });
+				var ctor = t.GetConstructor(new[] { typeof(MiniYaml) });
 				if (ctor != null)
 				{
 					// Class has opted-in to DIY initialization

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using OpenRA.Primitives;

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Traits
 		[Desc("HitPoints")]
 		public readonly int HP = 0;
 
-		[Desc("Physical size of the unit used for damage calculations.  Impacts within this radius apply full damage")]
+		[Desc("Physical size of the unit used for damage calculations. Impacts within this radius apply full damage.")]
 		public readonly WRange Radius = new WRange(426);
 
-		[Desc("Don't trigger interfaces such as AnnounceOnKill.")]
+		[Desc("Trigger interfaces such as AnnounceOnKill?")]
 		public readonly bool NotifyAppliedDamage = true;
 
 		public virtual object Create(ActorInitializer init) { return new Health(init, this); }
@@ -122,7 +122,7 @@ namespace OpenRA.Traits
 				damage = Util.ApplyPercentageModifiers(damage, modifiers);
 			}
 
-			hp = Exts.Clamp(hp - damage, 0, MaxHP);
+			hp = (hp - damage).Clamp(0, MaxHP);
 
 			var ai = new AttackInfo
 			{

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -331,7 +331,7 @@ namespace OpenRA.Traits
 
 		public bool IsExplored(Actor a)
 		{
-			return GetVisOrigins(a).Any(o => IsExplored(o));
+			return GetVisOrigins(a).Any(IsExplored);
 		}
 
 		public bool IsVisible(CPos cell)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -37,7 +37,7 @@ namespace OpenRA
 		class ActorIDComparer : IComparer<Actor>
 		{
 			public static readonly ActorIDComparer Instance = new ActorIDComparer();
-			private ActorIDComparer() { }
+			ActorIDComparer() { }
 			public int Compare(Actor x, Actor y) { return x.ActorID.CompareTo(y.ActorID); }
 		}
 


### PR DESCRIPTION
Remove explicit private.
Remove unnecessary delegate.
Use extension method syntax.
Fix HealthInfo.NotifyAppliedDamage’s desc.
Remove unused using directives.
Remove explicit type declaration in Manifest.
