### PR TITLE
Avoid preventable allocations

### DIFF
--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -18,6 +18,8 @@ namespace OpenRA.Mods.Common.AI
 {
 	abstract class AirStateBase : StateBase
 	{
+		static readonly string[] AirTargetTypes = new[] { "Air" };
+
 		protected const int MissileUnitMultiplier = 3;
 
 		protected static int CountAntiAirUnits(IEnumerable<Actor> units)
@@ -34,7 +36,7 @@ namespace OpenRA.Mods.Common.AI
 					var arms = unit.TraitsImplementing<Armament>();
 					foreach (var a in arms)
 					{
-						if (a.Weapon.ValidTargets.Contains("Air"))
+						if (a.Weapon.IsValidTarget(AirTargetTypes))
 						{
 							missileUnitsCount++;
 							break;

--- a/OpenRA.Mods.Common/AI/States/StateBase.cs
+++ b/OpenRA.Mods.Common/AI/States/StateBase.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.AI
 
 			var arms = a.TraitsImplementing<Armament>();
 			foreach (var arm in arms)
-				if (arm.Weapon.ValidTargets.Intersect(targetable.TargetTypes).Any())
+				if (arm.Weapon.IsValidTarget(targetable.TargetTypes))
 					return true;
 
 			return false;


### PR DESCRIPTION
Avoid some common allocations so the GC has less work to do. Reduces ongoing allocations on the RA shellmap by ~5%. Provides a very small perf win for CPU (~0.4%).

Also removes some code duplication and fixes some minor bugs in the AI where it wasn't accounting for invalid target types.
