### PR TITLE
Added transparency to the Tiberian Sun building placement overlay

### DIFF
--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -1,6 +1,7 @@
 overlay:
 	Defaults: place
 		Offset: 0, -12
+		BlendMode: Translucency75
 	build-valid-snow:
 	build-valid-temperat:
 	build-invalid:


### PR DESCRIPTION
A followup of https://github.com/OpenRA/OpenRA/pull/7811 and https://github.com/OpenRA/OpenRA/pull/7806:

![image](https://cloud.githubusercontent.com/assets/756669/6980916/8d999e08-d9f9-11e4-9368-885ea98c97c6.png)
