### PR TITLE
Fix issues in gdi05a

### DIFF
--- a/mods/cnc/maps/gdi05a/gdi05a.lua
+++ b/mods/cnc/maps/gdi05a/gdi05a.lua
@@ -72,6 +72,7 @@ Attack = function()
 	local path = Utils.Random(AttackPaths)
 	Build(types[1], types[2], function(units)
 		Utils.Do(units, function(unit)
+			if unit.Owner ~= nod then return end
 			unit.Patrol(path, false)
 			Trigger.OnIdle(unit, unit.Hunt)
 		end)
@@ -83,6 +84,7 @@ end
 Grd1Action = function()
 	Build(Airfield, Grd1UnitTypes, function(units)
 		Utils.Do(units, function(unit)
+			if unit.Owner ~= nod then return end
 			Trigger.OnKilled(unit, function()
 				Trigger.AfterDelay(Grd1Delay[Map.Difficulty], Grd1Action)
 			end)
@@ -94,6 +96,7 @@ end
 Grd2Action = function()
 	Build(Airfield, Grd2UnitTypes, function(units)
 		Utils.Do(units, function(unit)
+			if unit.Owner ~= nod then return end
 			unit.Patrol(Grd2Path, true, DateTime.Seconds(5))
 		end)
 	end)

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -75,223 +75,223 @@ Players:
 Actors:
 	Actor0: sbag
 		Location: 53,59
-		Owner: Neutral
+		Owner: GDI
 	Actor1: sbag
 		Location: 52,59
-		Owner: Neutral
+		Owner: GDI
 	Actor2: sbag
 		Location: 51,59
-		Owner: Neutral
+		Owner: GDI
 	Actor3: sbag
 		Location: 50,59
-		Owner: Neutral
+		Owner: GDI
 	Actor4: sbag
 		Location: 49,59
-		Owner: Neutral
+		Owner: GDI
 	Actor5: sbag
 		Location: 45,59
-		Owner: Neutral
+		Owner: GDI
 	Actor6: sbag
 		Location: 44,59
-		Owner: Neutral
+		Owner: GDI
 	Actor7: sbag
 		Location: 43,59
-		Owner: Neutral
+		Owner: GDI
 	Actor8: sbag
 		Location: 42,59
-		Owner: Neutral
+		Owner: GDI
 	Actor9: sbag
 		Location: 41,59
-		Owner: Neutral
+		Owner: GDI
 	Actor10: sbag
 		Location: 41,57
-		Owner: Neutral
+		Owner: GDI
 	Actor11: sbag
 		Location: 41,56
-		Owner: Neutral
+		Owner: GDI
 	Actor12: sbag
 		Location: 41,53
-		Owner: Neutral
+		Owner: GDI
 	Actor13: sbag
 		Location: 41,52
-		Owner: Neutral
+		Owner: GDI
 	Actor14: sbag
 		Location: 44,51
-		Owner: Neutral
+		Owner: GDI
 	Actor15: sbag
 		Location: 43,51
-		Owner: Neutral
+		Owner: GDI
 	Actor16: sbag
 		Location: 42,51
-		Owner: Neutral
+		Owner: GDI
 	Actor17: sbag
 		Location: 41,51
-		Owner: Neutral
+		Owner: GDI
 	Actor18: sbag
 		Location: 54,50
-		Owner: Neutral
+		Owner: GDI
 	Actor19: sbag
 		Location: 53,50
-		Owner: Neutral
+		Owner: GDI
 	Actor20: sbag
 		Location: 52,50
-		Owner: Neutral
+		Owner: GDI
 	Actor21: sbag
 		Location: 46,50
-		Owner: Neutral
+		Owner: GDI
 	Actor22: sbag
 		Location: 45,50
-		Owner: Neutral
+		Owner: GDI
 	Actor23: sbag
 		Location: 44,50
-		Owner: Neutral
+		Owner: GDI
 	Actor24: sbag
 		Location: 15,31
-		Owner: Neutral
+		Owner: Nod
 	Actor25: sbag
 		Location: 14,31
-		Owner: Neutral
+		Owner: Nod
 	Actor26: sbag
 		Location: 13,31
-		Owner: Neutral
+		Owner: Nod
 	Actor27: sbag
 		Location: 12,31
-		Owner: Neutral
+		Owner: Nod
 	Actor28: sbag
 		Location: 8,31
-		Owner: Neutral
+		Owner: Nod
 	Actor29: sbag
 		Location: 15,30
-		Owner: Neutral
+		Owner: Nod
 	Actor30: sbag
 		Location: 8,30
-		Owner: Neutral
+		Owner: Nod
 	Actor31: sbag
 		Location: 25,29
-		Owner: Neutral
+		Owner: Nod
 	Actor32: sbag
 		Location: 24,29
-		Owner: Neutral
+		Owner: Nod
 	Actor33: sbag
 		Location: 23,29
-		Owner: Neutral
+		Owner: Nod
 	Actor34: sbag
 		Location: 22,29
-		Owner: Neutral
+		Owner: Nod
 	Actor35: sbag
 		Location: 21,29
-		Owner: Neutral
+		Owner: Nod
 	Actor36: sbag
 		Location: 20,29
-		Owner: Neutral
+		Owner: Nod
 	Actor37: sbag
 		Location: 19,29
-		Owner: Neutral
+		Owner: Nod
 	Actor38: sbag
 		Location: 18,29
-		Owner: Neutral
+		Owner: Nod
 	Actor39: sbag
 		Location: 17,29
-		Owner: Neutral
+		Owner: Nod
 	Actor40: sbag
 		Location: 16,29
-		Owner: Neutral
+		Owner: Nod
 	Actor41: sbag
 		Location: 15,29
-		Owner: Neutral
+		Owner: Nod
 	Actor42: sbag
 		Location: 8,29
-		Owner: Neutral
+		Owner: Nod
 	Actor43: sbag
 		Location: 25,28
-		Owner: Neutral
+		Owner: Nod
 	Actor44: sbag
 		Location: 8,28
-		Owner: Neutral
+		Owner: Nod
 	Actor45: sbag
 		Location: 25,27
-		Owner: Neutral
+		Owner: Nod
 	Actor46: sbag
 		Location: 8,27
-		Owner: Neutral
+		Owner: Nod
 	Actor47: sbag
 		Location: 8,26
-		Owner: Neutral
+		Owner: Nod
 	Actor48: sbag
 		Location: 8,25
-		Owner: Neutral
+		Owner: Nod
 	Actor49: sbag
 		Location: 25,24
-		Owner: Neutral
+		Owner: Nod
 	Actor50: sbag
 		Location: 8,24
-		Owner: Neutral
+		Owner: Nod
 	Actor51: sbag
 		Location: 25,23
-		Owner: Neutral
+		Owner: Nod
 	Actor52: sbag
 		Location: 8,23
-		Owner: Neutral
+		Owner: Nod
 	Actor53: sbag
 		Location: 25,22
-		Owner: Neutral
+		Owner: Nod
 	Actor54: sbag
 		Location: 8,22
-		Owner: Neutral
+		Owner: Nod
 	Actor55: sbag
 		Location: 25,21
-		Owner: Neutral
+		Owner: Nod
 	Actor56: sbag
 		Location: 24,21
-		Owner: Neutral
+		Owner: Nod
 	Actor57: sbag
 		Location: 23,21
-		Owner: Neutral
+		Owner: Nod
 	Actor58: sbag
 		Location: 22,21
-		Owner: Neutral
+		Owner: Nod
 	Actor59: sbag
 		Location: 21,21
-		Owner: Neutral
+		Owner: Nod
 	Actor60: sbag
 		Location: 20,21
-		Owner: Neutral
+		Owner: Nod
 	Actor61: sbag
 		Location: 19,21
-		Owner: Neutral
+		Owner: Nod
 	Actor62: sbag
 		Location: 18,21
-		Owner: Neutral
+		Owner: Nod
 	Actor63: sbag
 		Location: 17,21
-		Owner: Neutral
+		Owner: Nod
 	Actor64: sbag
 		Location: 16,21
-		Owner: Neutral
+		Owner: Nod
 	Actor65: sbag
 		Location: 15,21
-		Owner: Neutral
+		Owner: Nod
 	Actor66: sbag
 		Location: 14,21
-		Owner: Neutral
+		Owner: Nod
 	Actor67: sbag
 		Location: 13,21
-		Owner: Neutral
+		Owner: Nod
 	Actor68: sbag
 		Location: 12,21
-		Owner: Neutral
+		Owner: Nod
 	Actor69: sbag
 		Location: 11,21
-		Owner: Neutral
+		Owner: Nod
 	Actor70: sbag
 		Location: 10,21
-		Owner: Neutral
+		Owner: Nod
 	Actor71: sbag
 		Location: 9,21
-		Owner: Neutral
+		Owner: Nod
 	Actor72: sbag
 		Location: 8,21
-		Owner: Neutral
+		Owner: Nod
 	Actor73: t01
 		Location: 12,38
 		Owner: Neutral
@@ -847,6 +847,9 @@ Rules:
 	E3:
 		Buildable:
 			Queue: Infantry.Nod
+	E4:
+		Buildable:
+			Prerequisites: ~disabled
 	E5:
 		Buildable:
 			Prerequisites: ~disabled
@@ -874,6 +877,12 @@ Rules:
 		Buildable:
 			Prerequisites: ~disabled
 	ARTY:
+		Buildable:
+			Prerequisites: ~disabled
+	MLRS:
+		Buildable:
+			Prerequisites: ~disabled
+	FTNK:
 		Buildable:
 			Prerequisites: ~disabled
 	STNK:

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -802,6 +802,7 @@ Rules:
 		MissionObjectives:
 			EarlyGameOver: true
 		EnemyWatcher:
+			NotificationInterval: 25
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy


### PR DESCRIPTION
Fixes #7836.

Fixes tanks running over their own sandbag, and flame troopers, flame tanks and and mobile SAMs from being buildable.
