### PR TITLE
Fixed parsing of hotkeys with no name (such as tilde)

### DIFF
--- a/OpenRA.Game/Input/Hotkey.cs
+++ b/OpenRA.Game/Input/Hotkey.cs
@@ -28,7 +28,12 @@ namespace OpenRA
 
 			Keycode key;
 			if (!Enum<Keycode>.TryParse(parts[0], true, out key))
-				return false;
+			{
+				int c;
+				if (!int.TryParse(parts[0], out c))
+					return false;
+				key = (Keycode)c;
+			}
 
 			var mods = Modifiers.None;
 			if (parts.Length >= 2)


### PR DESCRIPTION
Quick fix to #7838
Keys with no name are parsed as numeric key codes (i.e. "126" for tilde)
