### PR TITLE
Removed AnnounceOnSeen from Red Alert and fixed Lint warnings

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -50,8 +50,6 @@
 	UpgradeManager:
 	TemporaryOwnerManager:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Tank:
 	AppearsOnRadar:
@@ -105,8 +103,6 @@
 	UpgradeManager:
 	TemporaryOwnerManager:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Husk:
 	Health:
@@ -233,8 +229,6 @@
 		UpgradeMinEnabledLevel: 1
 	UpgradeManager:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 	TerrainModifiesDamage:
 		TerrainModifier:
 			Rough: 80
@@ -271,8 +265,6 @@
 		UpgradeTypes: selfheal
 		UpgradeMinEnabledLevel: 1
 	UpgradeManager:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 	RenderUnit:
 
 ^Helicopter:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -34,7 +34,6 @@ BADR:
 	-EjectOnDeath:
 	-GpsDot:
 	RejectsOrders:
-	-AnnounceOnSeen:
 
 BADR.Bomber:
 	Inherits: ^Plane
@@ -351,5 +350,4 @@ U2:
 		Offset: -1c43,0,0
 		Interval: 2
 	RejectsOrders:
-	-AnnounceOnSeen:
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -72,8 +72,6 @@
 	TimedUpgradeBar:
 		Upgrade: invulnerability
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Tank:
 	AppearsOnRadar:
@@ -159,8 +157,6 @@
 		GroundCorpsePalette:
 		WaterCorpseSequence:
 		WaterCorpsePalette:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Infantry:
 	AppearsOnRadar:
@@ -252,8 +248,6 @@
 		UpgradeMinEnabledLevel: 1
 	UpgradeManager:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Ship:
 	AppearsOnRadar:
@@ -308,8 +302,6 @@
 		Upgrade: invulnerability
 		UpgradeMinEnabledLevel: 1
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Plane:
 	AppearsOnRadar:
@@ -367,8 +359,6 @@
 		Upgrade: invulnerability
 	WithShadow:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Helicopter:
 	Inherits: ^Plane
@@ -377,8 +367,6 @@
 	GpsDot:
 		String: Helicopter
 	Hovers:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsApproaching
 
 ^Building:
 	AppearsOnRadar:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -176,6 +176,7 @@ CAMERA:
 	DetectCloaked:
 		Range: 10
 	RenderEditorOnly:
+		Image: camera
 
 camera.paradrop:
 	Immobile:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -73,5 +73,4 @@ Player:
 		Name: Unrestricted
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.unrestricted
 	GlobalUpgradeManager:
-	EnemyWatcher:
 


### PR DESCRIPTION
This removes the `Enemy Units Approaching` used for what is actually `Enemy unit detected` from the Red Alert mod as suggested in https://github.com/OpenRA/OpenRA/issues/7787#issuecomment-87780876. It can make it's return once it is polished and we've got a properly (cut together) announcer voice file.
