### PR TITLE
Tried to cache AppVeyor downloads

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ environment:
 
 install:
 
+cache:
+  - nsissetup.exe -> appveyor.yaml
+  - NsProcess.zip -> appveyor.yaml
+
 before_build:
 - make dependencies
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ install:
 cache:
   - nsissetup.exe -> appveyor.yaml
   - NsProcess.zip -> appveyor.yaml
+  - thirdparty\windows -> thirdparty\fetch-thirdparty-deps.ps1
 
 before_build:
 - make dependencies


### PR DESCRIPTION
According to http://www.appveyor.com/docs/build-cache everything but chocolatey packages may be cached. I see the downloads failing the build annoyingly often. Hope this helps.
