### PR TITLE
Fixed GASPOT again

### DIFF
--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -1228,7 +1228,12 @@ GASAND:
 		Type: sandbags
 
 GASPOT:
-	Inherits: ^CivBuilding
+	Inherits: ^Building
+	Buildable:
+		Queue: Defense
+		Prerequisites: ~disabled
+	Valued:
+		Cost: 300
 	Tooltip:
 		Name: Light Tower
 	Building:
@@ -1242,8 +1247,8 @@ GASPOT:
 		Type: wood
 	Health:
 		HP: 400
-	RenderBuilding:
-		Palette: player
+	RevealsShroud:
+		Range: 6c0
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -677,6 +677,9 @@ gaspot:
 	make: gaspotmk
 		Length: 14
 		ShadowStart: 14
+	icon: spoticon
+		Offset: 0, 0
+		UseTilesetCode: false
 
 galite:
 	Defaults:


### PR DESCRIPTION
Lot's of regressions introduced in https://github.com/OpenRA/OpenRA/pull/7776.
- Fixed missing make animation
- Fixed crash due to missing icon
- Fixed missing player color remap
- Fixed crash: TypeDictionary does not contain instance of type `OpenRA.Mods.Common.Traits.ValuedInfo`
- Fixed shroud revealing
- Fixed not being buildable with cheats on
