### PR TITLE
Added a global palette effect for day/night lighting

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -332,6 +332,7 @@
     <Compile Include="Traits\ParaDrop.cs" />
     <Compile Include="Traits\Passenger.cs" />
     <Compile Include="Traits\PaletteEffects\CloakPaletteEffect.cs" />
+    <Compile Include="Traits\PaletteEffects\GlobalLightingPaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\LightPaletteRotator.cs" />
     <Compile Include="Traits\PaletteEffects\MenuPaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\NukePaletteEffect.cs" />

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
@@ -1,0 +1,67 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Used for day/night effects.")]
+	class GlobalLightingPaletteEffectInfo : ITraitInfo
+	{
+		[Desc("Do not modify graphics that use any palette in this list.")]
+		public readonly string[] ExcludePalettes = { "cursor", "chrome", "colorpicker", "fog", "shroud", "alpha" };
+
+		[Desc("Do not modify graphics that start with these letters.")]
+		public readonly string[] ExcludePalettePrefixes = { };
+
+		public readonly float Red = 1f;
+		public readonly float Green = 1f;
+		public readonly float Blue = 1f;
+		public readonly float Ambient = 1f;
+
+		public object Create(ActorInitializer init) { return new GlobalLightingPaletteEffect(this); }
+	}
+
+	class GlobalLightingPaletteEffect : IPaletteModifier
+	{
+		readonly GlobalLightingPaletteEffectInfo info;
+
+		public GlobalLightingPaletteEffect(GlobalLightingPaletteEffectInfo info)
+		{
+			this.info = info;
+		}
+
+		public void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> palettes)
+		{
+			foreach (var kvp in palettes)
+			{
+				if (info.ExcludePalettes.Contains(kvp.Key))
+					continue;
+
+				if (info.ExcludePalettePrefixes.Any(kvp.Key.StartsWith))
+					continue;
+
+				var palette = kvp.Value;
+
+				for (var x = 0; x < Palette.Size; x++)
+				{
+					var from = palette.GetColor(x);
+					var red = (int)(from.R * info.Ambient * info.Red).Clamp(0, 255);
+					var green = (int)(from.G * info.Ambient * info.Green).Clamp(0, 255);
+					var blue = (int)(from.B * info.Ambient * info.Blue).Clamp(0, 255);
+					palette.SetColor(x, Color.FromArgb(from.A, red, green, blue));
+				}
+			}
+		}
+	}
+}

--- a/mods/ts/maps/arivruns/map.yaml
+++ b/mods/ts/maps/arivruns/map.yaml
@@ -174,6 +174,9 @@ Actors:
 Smudges:
 
 Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.72
 
 Sequences:
 

--- a/mods/ts/maps/tread_l/map.yaml
+++ b/mods/ts/maps/tread_l/map.yaml
@@ -1171,6 +1171,9 @@ Actors:
 Smudges:
 
 Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.75
 
 Sequences:
 


### PR DESCRIPTION
Add the following to any `map.yaml` which defaults to night:

``` yaml
Rules:
    World:
        GlobalPaletteEffect:
```

and if you are not epileptic try

``` yaml
Rules:
    World:
        GlobalPaletteEffect:
            Flash: true
```
