### PR TITLE
Fixed CS0172 compile error on Fedora 21

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 				var height = (int)map.MapHeight.Value[uv];
 				var tile = map.MapTiles.Value[uv];
 				var ti = tileSet.GetTileInfo(tile);
-				var ramp = ti != null ? ti.RampType : 0;
+				var ramp = ti != null ? (int)ti.RampType : 0;
 
 				var corners = map.CellCorners[ramp];
 				var color = corners.Select(c => colors[height + c.Z / 512]).ToArray();


### PR DESCRIPTION
Tries to address 

```
OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs(51,60): error CS0172: Type of conditional expression cannot be determined as `byte' and `int' convert implicitly to each other` 
```

on Mono 2.10
