### PR TITLE
Add upgrade rules support for map PlayerReferences

### DIFF
--- a/OpenRA.Editor/Form1.cs
+++ b/OpenRA.Editor/Form1.cs
@@ -126,8 +126,11 @@ namespace OpenRA.Editor
 
 			// upgrade maps that have no player definitions. editor doesnt care,
 			// but this breaks the game pretty badly.
-			if (map.Players.Count == 0)
-				map.MakeDefaultPlayers();
+			if (map.PlayerDefinitions.Count == 0)
+			{
+				var players = new MapPlayers(map.Rules, map.GetSpawnPoints().Length);
+				map.PlayerDefinitions = players.ToMiniYaml();
+			}
 
 			PrepareMapResources(Game.ModData, map);
 
@@ -315,7 +318,7 @@ namespace OpenRA.Editor
 		void PopulateActorOwnerChooser()
 		{
 			actorOwnerChooser.Items.Clear();
-			actorOwnerChooser.Items.AddRange(surface1.Map.Players.Values.ToArray());
+			actorOwnerChooser.Items.AddRange(new MapPlayers(surface1.Map.PlayerDefinitions).Players.Values.ToArray());
 			actorOwnerChooser.SelectedIndex = 0;
 			surface1.NewActorOwner = ((PlayerReference)actorOwnerChooser.SelectedItem).Name;
 		}
@@ -412,8 +415,9 @@ namespace OpenRA.Editor
 					map.ResizeCordon((int)nmd.CordonLeft.Value, (int)nmd.CordonTop.Value,
 						(int)nmd.CordonRight.Value, (int)nmd.CordonBottom.Value);
 
-					map.Players.Clear();
-					map.MakeDefaultPlayers();
+					var players = new MapPlayers(map.Rules, map.GetSpawnPoints().Length);
+					map.PlayerDefinitions = players.ToMiniYaml();
+
 					map.FixOpenAreas(Program.Rules);
 
 					NewMap(map);
@@ -502,8 +506,8 @@ namespace OpenRA.Editor
 		void SetupDefaultPlayers(object sender, EventArgs e)
 		{
 			dirty = true;
-			surface1.Map.Players.Clear();
-			surface1.Map.MakeDefaultPlayers();
+			var players = new MapPlayers(surface1.Map.Rules, surface1.Map.GetSpawnPoints().Length);
+			surface1.Map.PlayerDefinitions = players.ToMiniYaml();
 
 			surface1.Chunks.Clear();
 			surface1.Invalidate();

--- a/OpenRA.Editor/Surface.cs
+++ b/OpenRA.Editor/Surface.cs
@@ -386,7 +386,7 @@ namespace OpenRA.Editor
 
 		ColorPalette GetPaletteForPlayerInner(string name)
 		{
-			var pr = Map.Players[name];
+			var pr = new MapPlayers(Map.PlayerDefinitions).Players[name];
 			var pcpi = Program.Rules.Actors["player"].Traits.Get<PlayerColorPaletteInfo>();
 			var remap = new PlayerColorRemap(pcpi.RemapIndex, pr.Color, pcpi.Ramp);
 			return new ImmutablePalette(PlayerPalette, remap).AsSystemPalette();

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -218,12 +217,9 @@ namespace OpenRA
 
 		[FieldLoader.Ignore] public Lazy<Dictionary<string, ActorReference>> Actors;
 
-		public int PlayerCount { get { return Players.Count(p => p.Value.Playable); } }
-
 		public Rectangle Bounds;
 
 		// Yaml map data
-		[FieldLoader.Ignore] public Dictionary<string, PlayerReference> Players = new Dictionary<string, PlayerReference>();
 		[FieldLoader.Ignore] public Lazy<List<SmudgeReference>> Smudges;
 
 		[FieldLoader.Ignore] public List<MiniYamlNode> RuleDefinitions = new List<MiniYamlNode>();
@@ -233,6 +229,7 @@ namespace OpenRA
 		[FieldLoader.Ignore] public List<MiniYamlNode> VoiceDefinitions = new List<MiniYamlNode>();
 		[FieldLoader.Ignore] public List<MiniYamlNode> NotificationDefinitions = new List<MiniYamlNode>();
 		[FieldLoader.Ignore] public List<MiniYamlNode> TranslationDefinitions = new List<MiniYamlNode>();
+		[FieldLoader.Ignore] public List<MiniYamlNode> PlayerDefinitions = new List<MiniYamlNode>();
 
 		// Binary map data
 		[FieldLoader.Ignore] public byte TileFormat = 2;
@@ -342,13 +339,6 @@ namespace OpenRA
 					Visibility = MapVisibility.MissionSelector;
 			}
 
-			// Load players
-			foreach (var my in nd["Players"].ToDictionary().Values)
-			{
-				var player = new PlayerReference(my);
-				Players.Add(player.Name, player);
-			}
-
 			Actors = Exts.Lazy(() =>
 			{
 				var ret = new Dictionary<string, ActorReference>();
@@ -381,10 +371,11 @@ namespace OpenRA
 			VoiceDefinitions = MiniYaml.NodesOrEmpty(yaml, "Voices");
 			NotificationDefinitions = MiniYaml.NodesOrEmpty(yaml, "Notifications");
 			TranslationDefinitions = MiniYaml.NodesOrEmpty(yaml, "Translations");
+			PlayerDefinitions = MiniYaml.NodesOrEmpty(yaml, "Players");
 
-			MapTiles = Exts.Lazy(() => LoadMapTiles());
-			MapResources = Exts.Lazy(() => LoadResourceTiles());
-			MapHeight = Exts.Lazy(() => LoadMapHeight());
+			MapTiles = Exts.Lazy(LoadMapTiles);
+			MapResources = Exts.Lazy(LoadResourceTiles);
+			MapHeight = Exts.Lazy(LoadMapHeight);
 
 			TileShape = Game.ModData.Manifest.TileShape;
 			SubCellOffsets = Game.ModData.Manifest.SubCellOffsets;
@@ -490,8 +481,7 @@ namespace OpenRA
 
 			root.Add(new MiniYamlNode("Options", FieldSaver.SaveDifferences(Options, new MapOptions())));
 
-			root.Add(new MiniYamlNode("Players", null,
-				Players.Select(p => new MiniYamlNode("PlayerReference@{0}".F(p.Key), FieldSaver.SaveDifferences(p.Value, new PlayerReference()))).ToList()));
+			root.Add(new MiniYamlNode("Players", null, PlayerDefinitions));
 
 			root.Add(new MiniYamlNode("Actors", null,
 				Actors.Value.Select(x => new MiniYamlNode(x.Key, x.Value.Save())).ToList()));
@@ -760,45 +750,6 @@ namespace OpenRA
 				using (var csp = SHA1.Create())
 					return new string(csp.ComputeHash(ms).SelectMany(a => a.ToString("x2")).ToArray());
 			}
-		}
-
-		public void MakeDefaultPlayers()
-		{
-			var firstRace = Rules.Actors["world"].Traits
-				.WithInterface<CountryInfo>().First(c => c.Selectable).Race;
-
-			if (!Players.ContainsKey("Neutral"))
-				Players.Add("Neutral", new PlayerReference
-				{
-					Name = "Neutral",
-					Race = firstRace,
-					OwnsWorld = true,
-					NonCombatant = true
-				});
-
-			var numSpawns = GetSpawnPoints().Length;
-			for (var index = 0; index < numSpawns; index++)
-			{
-				if (Players.ContainsKey("Multi{0}".F(index)))
-					continue;
-
-				var p = new PlayerReference
-				{
-					Name = "Multi{0}".F(index),
-					Race = "Random",
-					Playable = true,
-					Enemies = new[] { "Creeps" }
-				};
-				Players.Add(p.Name, p);
-			}
-
-			Players.Add("Creeps", new PlayerReference
-			{
-				Name = "Creeps",
-				Race = firstRace,
-				NonCombatant = true,
-				Enemies = Players.Where(p => p.Value.Playable).Select(p => p.Key).ToArray()
-			});
 		}
 
 		public void FixOpenAreas(Ruleset rules)

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -1,0 +1,75 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA
+{
+	public class MapPlayers
+	{
+		public readonly Dictionary<string, PlayerReference> Players;
+
+		public MapPlayers() : this(new List<MiniYamlNode>()) { }
+
+		public MapPlayers(IEnumerable<MiniYamlNode> playerDefinitions)
+		{
+			Players = playerDefinitions.Select(pr => new PlayerReference(new MiniYaml(pr.Key, pr.Value.Nodes)))
+				.ToDictionary(player => player.Name);
+		}
+
+		public MapPlayers(Ruleset rules, int playerCount)
+		{
+			var firstRace = rules.Actors["world"].Traits
+				.WithInterface<CountryInfo>().First(c => c.Selectable).Race;
+
+			Players = new Dictionary<string, PlayerReference>
+			{
+				{
+					"Neutral", new PlayerReference
+					{
+						Name = "Neutral",
+						Race = firstRace,
+						OwnsWorld = true,
+						NonCombatant = true
+					}
+				},
+				{
+					"Creeps", new PlayerReference
+					{
+						Name = "Creeps",
+						Race = firstRace,
+						NonCombatant = true,
+						Enemies = Exts.MakeArray(playerCount, i => "Multi{0}".F(i))
+					}
+				}
+			};
+
+			for (var index = 0; index < playerCount; index++)
+			{
+				var p = new PlayerReference
+				{
+					Name = "Multi{0}".F(index),
+					Race = "Random",
+					Playable = true,
+					Enemies = new[] { "Creeps" }
+				};
+				Players.Add(p.Name, p);
+			}
+		}
+
+		public List<MiniYamlNode> ToMiniYaml()
+		{
+			return Players.Select(p => new MiniYamlNode("PlayerReference@{0}".F(p.Key),
+				FieldSaver.SaveDifferences(p.Value, new PlayerReference()))).ToList();
+		}
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -89,6 +89,7 @@
     <Compile Include="LogProxy.cs" />
     <Compile Include="FileFormats\IdxReader.cs" />
     <Compile Include="FileSystem\BagFile.cs" />
+    <Compile Include="Map\MapPlayers.cs" />
     <Compile Include="MPos.cs" />
     <Compile Include="GameRules\Warhead.cs" />
     <Compile Include="Graphics\QuadRenderer.cs" />

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -52,7 +52,10 @@ namespace OpenRA.Server
 
 		public ServerSettings Settings;
 		public ModData ModData;
+
+		// Managed by LobbyCommands
 		public Map Map;
+		public MapPlayers MapPlayers;
 		XTimer gameTimeout;
 
 		public static void SyncClientToPlayerReference(Session.Client c, PlayerReference pr)
@@ -304,7 +307,7 @@ namespace OpenRA.Server
 				}
 
 				if (client.Slot != null)
-					SyncClientToPlayerReference(client, Map.Players[client.Slot]);
+					SyncClientToPlayerReference(client, MapPlayers.Players[client.Slot]);
 				else
 					client.Color = HSLColor.FromRGB(255, 255, 255);
 

--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -233,27 +233,7 @@ namespace OpenRA.Widgets
 		{
 			if (string.IsNullOrEmpty(initialUid) || Game.ModData.MapCache[initialUid].Status != MapStatus.Available)
 			{
-				Func<MapPreview, bool> isIdealMap = m =>
-				{
-					if (m.Status != MapStatus.Available || !m.Map.Visibility.HasFlag(MapVisibility.Lobby))
-						return false;
-
-					// Other map types may have confusing settings or gameplay
-					if (m.Type != "Conquest")
-						return false;
-
-					// Maps with bots disabled confuse new players
-					if (m.Map.Players.Any(s => !s.Value.AllowBots))
-						return false;
-
-					// Large maps expose unfortunate performance problems
-					if (m.Bounds.Width > 128 || m.Bounds.Height > 128)
-						return false;
-
-					return true;
-				};
-
-				var selected = Game.ModData.MapCache.Where(m => isIdealMap(m)).RandomOrDefault(Game.CosmeticRandom) ??
+				var selected = Game.ModData.MapCache.Where(x => x.SuitableForInitialMap).RandomOrDefault(Game.CosmeticRandom) ??
 					Game.ModData.MapCache.First(m => m.Status == MapStatus.Available && m.Map.Visibility.HasFlag(MapVisibility.Lobby));
 				return selected.Uid;
 			}

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -18,19 +18,21 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			var playerNames = map.Players.Values.Select(p => p.Name);
-			foreach (var player in map.Players)
+			var players = new MapPlayers(map.PlayerDefinitions).Players;
+
+			var playerNames = players.Values.Select(p => p.Name);
+			foreach (var player in players)
 				foreach (var ally in player.Value.Allies)
 					if (!playerNames.Contains(ally))
 						emitError("Allies contains player {0} that is not in list.".F(ally));
 
-			foreach (var player in map.Players)
+			foreach (var player in players)
 				foreach (var enemy in player.Value.Enemies)
 					if (!playerNames.Contains(enemy))
 						emitError("Enemies contains player {0} that is not in list.".F(enemy));
 
 			var races = map.Rules.Actors["world"].Traits.WithInterface<CountryInfo>().Select(c => c.Race);
-			foreach (var player in map.Players)
+			foreach (var player in players)
 				if (!string.IsNullOrWhiteSpace(player.Value.Race) && player.Value.Race != "Random" && !races.Contains(player.Value.Race))
 					emitError("Invalid race {0} chosen for player {1}.".F(player.Value.Race, player.Value.Name));
 		}

--- a/OpenRA.Mods.Common/ServerTraits/ColorValidator.cs
+++ b/OpenRA.Mods.Common/ServerTraits/ColorValidator.cs
@@ -175,8 +175,7 @@ namespace OpenRA.Mods.Common.Server
 				return false;
 			}
 
-			var mapPlayerColors = server.Map.Players.Values
-				.Select(p => p.ColorRamp.RGB);
+			var mapPlayerColors = server.MapPlayers.Players.Values.Select(p => p.ColorRamp.RGB);
 
 			if (!ValidateColorAgainstForbidden(askedColor, mapPlayerColors, out forbiddenColor))
 			{

--- a/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
@@ -21,8 +21,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public void CreatePlayers(World w)
 		{
-			// create the unplayable map players -- neutral, shellmap, scripted, etc.
-			foreach (var kv in w.Map.Players.Where(p => !p.Value.Playable))
+			var players = new MapPlayers(w.Map.PlayerDefinitions).Players;
+
+			// Create the unplayable map players -- neutral, shellmap, scripted, etc.
+			foreach (var kv in players.Where(p => !p.Value.Playable))
 			{
 				var player = new Player(w, null, null, kv.Value);
 				w.AddPlayer(player);
@@ -30,14 +32,14 @@ namespace OpenRA.Mods.Common.Traits
 					w.WorldActor.Owner = player;
 			}
 
-			// create the players which are bound through slots.
+			// Create the players which are bound through slots.
 			foreach (var kv in w.LobbyInfo.Slots)
 			{
 				var client = w.LobbyInfo.ClientInSlot(kv.Key);
 				if (client == null)
 					continue;
 
-				var player = new Player(w, client, kv.Value, w.Map.Players[kv.Value.PlayerReference]);
+				var player = new Player(w, client, kv.Value, players[kv.Value.PlayerReference]);
 				w.AddPlayer(player);
 
 				if (client.Index == Game.LocalClientId)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			UpgradeRules.UpgradeWeaponRules(engineDate, ref map.WeaponDefinitions, null, 0);
 			UpgradeRules.UpgradeActorRules(engineDate, ref map.RuleDefinitions, null, 0);
+			UpgradeRules.UpgradePlayers(engineDate, ref map.PlayerDefinitions, null, 0);
 			map.Save(args[1]);
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -83,6 +83,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				Console.WriteLine("\t" + map.Path);
 				UpgradeRules.UpgradeActorRules(engineDate, ref map.RuleDefinitions, null, 0);
 				UpgradeRules.UpgradeWeaponRules(engineDate, ref map.WeaponDefinitions, null, 0);
+				UpgradeRules.UpgradePlayers(engineDate, ref map.PlayerDefinitions, null, 0);
 				map.Save(map.Path);
 			}
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1269,5 +1269,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				UpgradeCursors(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
+
+		internal static void UpgradePlayers(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		{
+			foreach (var node in nodes)
+				UpgradePlayers(engineVersion, ref node.Value.Nodes, node, depth + 1);
+		}
 	}
 }

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -297,7 +297,8 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 				return null;
 
 			map.RequiresMod = mod;
-			map.MakeDefaultPlayers();
+			var players = new MapPlayers(map.Rules, map.GetSpawnPoints().Length);
+			map.PlayerDefinitions = players.ToMiniYaml();
 
 			return map;
 		}


### PR DESCRIPTION
Split off from #7873, because that needs to be able to upgrade the PlayerReferences in maps.
This just adds support for that. The other PR will add the first use-case.

I used [this commit](https://github.com/pchote/OpenRA/commit/cb32f8aa80542c7f059bc62df6f4bdc043260eaf) as example and now the PlayerReferences are loaded as MiniYAML by the map and kept that way.

Reviews should start with `Map.cs`, because that is where all the action is happening. Most of the rest is noise.

**Edit:** The action has moved to `MapPlayers.cs` now, but it all still starts from `Map.cs`.
