### PR TITLE
Proper TS alpha cloak rendering.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -331,6 +331,7 @@
     <Compile Include="Traits\Parachutable.cs" />
     <Compile Include="Traits\ParaDrop.cs" />
     <Compile Include="Traits\Passenger.cs" />
+    <Compile Include="Traits\PaletteEffects\AlphaPaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\CloakPaletteEffect.cs" />
     <Compile Include="Traits\PaletteEffects\LightPaletteRotator.cs" />
     <Compile Include="Traits\PaletteEffects\MenuPaletteEffect.cs" />

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/AlphaPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/AlphaPaletteEffect.cs
@@ -1,0 +1,59 @@
+﻿ #region Copyright & License Information
+ /*
+  * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+  * This file is part of OpenRA, which is free software. It is made
+  * available to you under the terms of the GNU General Public License
+  * as published by the Free Software Foundation. For more information,
+  * see COPYING.
+  */
+ #endregion
+
+using System;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Renders actors using the given palettes with alpha-transparency. Attach this to the world actor.")]
+	public class AlphaPaletteEffectInfo : ITraitInfo
+	{
+		[Desc("The alpha value used to draw cloaked actors. Ranges from 0-255.")]
+		public readonly int Alpha = 255;
+
+		[Desc("The palettes to modify. You most likely want to match this with Cloak's Palette.")]
+		public readonly string[] Palettes = { "alpha-cloak" };
+
+		public object Create(ActorInitializer init) { return new AlphaPaletteEffect(init.Self, this); }
+	}
+
+	public class AlphaPaletteEffect : IPaletteModifier
+	{
+		readonly AlphaPaletteEffectInfo info;
+		readonly int alpha;
+
+		public AlphaPaletteEffect(Actor self, AlphaPaletteEffectInfo info)
+		{
+			this.info = info;
+			alpha = info.Alpha.Clamp(0, 255);
+		}
+
+		public void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> palettes)
+		{
+			foreach (var kvp in palettes)
+			{
+				if (!info.Palettes.Contains(kvp.Key))
+					continue;
+
+				var palette = kvp.Value;
+
+				for (var i = 1; i < 256; i++)
+				{
+					var from = palette.GetColor(i);
+					palette.SetColor(i, Color.FromArgb(alpha, from.R, from.G, from.B));
+				}
+			}
+		}
+	}
+}

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -59,6 +59,7 @@
 		UpgradeMinEnabledLevel: 1
 		InitialDelay: 0
 		CloakDelay: 90
+		Palette: alpha-cloak
 
 ^CivBuilding:
 	Inherits: ^Building
@@ -139,6 +140,7 @@
 		UpgradeMinEnabledLevel: 1
 		InitialDelay: 0
 		CloakDelay: 90
+		Palette: alpha-cloak
 	MustBeDestroyed:
 
 ^BuildingPlug:
@@ -230,6 +232,7 @@
 		UpgradeMinEnabledLevel: 1
 		InitialDelay: 0
 		CloakDelay: 90
+		Palette: alpha-cloak
 	MustBeDestroyed:
 
 ^CivilianInfantry:
@@ -338,6 +341,7 @@
 		UpgradeMaxAcceptedLevel: 2
 		InitialDelay: 0
 		CloakDelay: 90
+		Palette: alpha-cloak
 	MustBeDestroyed:
 
 ^Tank:
@@ -422,6 +426,7 @@
 		UpgradeMaxAcceptedLevel: 2
 		InitialDelay: 0
 		CloakDelay: 90
+		Palette: alpha-cloak
 	MustBeDestroyed:
 
 ^Helicopter:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -20,6 +20,16 @@ World:
 		Tileset: TEMPERAT
 		Filename: unittem.pal
 		ShadowIndex: 1
+	PaletteFromFile@player-sno-cloak:
+		Name: alpha-cloak
+		Tileset: SNOW
+		Filename: unitsno.pal
+		ShadowIndex: 1
+	PaletteFromFile@player-tem-cloak:
+		Name: alpha-cloak
+		Tileset: TEMPERAT
+		Filename: unittem.pal
+		ShadowIndex: 1
 	PaletteFromCurrentTileset:
 		Name: terrain
 		ShadowIndex: 1
@@ -224,4 +234,7 @@ World:
 	ScreenShaker:
 	RadarPings:
 	StartGameNotification:
+	AlphaPaletteEffect:
+		Palettes: alpha-cloak
+		Alpha: 140
 


### PR DESCRIPTION
Draw cloaked TS actors at alpha 140 with new `AlphaPaletteEffect`.

![screenshot](http://i.imgur.com/XTpj0xO.png)
![in-action](http://i.imgur.com/e7fmJr3.gif)
![snow](https://cloud.githubusercontent.com/assets/4861023/7001586/3faa8d5a-dc02-11e4-8cc8-99296e187914.png)

I ended up with something prettier than this but didn't get a gif of it. The code can be found in the logs.
![gify](http://i.imgur.com/T6y2Igx.gif)
