### PR TITLE
Unhardcoded and self-documented render sequences

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/RenderBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderBuilding.cs
@@ -46,25 +46,25 @@ namespace OpenRA.Mods.Common.Traits
 			var self = init.Self;
 			this.info = info;
 
-			DefaultAnimation.PlayRepeating(NormalizeSequence(self, "idle"));
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 		}
 
 		public virtual void BuildingComplete(Actor self)
 		{
-			DefaultAnimation.PlayRepeating(NormalizeSequence(self, "idle"));
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 
 			if (info.PauseOnLowPower)
 			{
 				var disabled = self.TraitsImplementing<IDisable>();
 				DefaultAnimation.Paused = () => disabled.Any(d => d.Disabled)
-					&& DefaultAnimation.CurrentSequence.Name == NormalizeSequence(self, "idle");
+					&& DefaultAnimation.CurrentSequence.Name == NormalizeSequence(self, info.Sequence);
 			}
 		}
 
 		public void PlayCustomAnimThen(Actor self, string name, Action a)
 		{
 			DefaultAnimation.PlayThen(NormalizeSequence(self, name),
-				() => { DefaultAnimation.PlayRepeating(NormalizeSequence(self, "idle")); a(); });
+				() => { DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence)); a(); });
 		}
 
 		public void PlayCustomAnimRepeating(Actor self, string name)
@@ -76,12 +76,12 @@ namespace OpenRA.Mods.Common.Traits
 		public void PlayCustomAnimBackwards(Actor self, string name, Action a)
 		{
 			DefaultAnimation.PlayBackwardsThen(NormalizeSequence(self, name),
-				() => { DefaultAnimation.PlayRepeating(NormalizeSequence(self, "idle")); a(); });
+				() => { DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence)); a(); });
 		}
 
 		public void CancelCustomAnim(Actor self)
 		{
-			DefaultAnimation.PlayRepeating(NormalizeSequence(self, "idle"));
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 		}
 
 		public virtual void DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/RenderBuildingSilo.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderBuildingSilo.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Show a static frame instead of animating all of the fullness states
 			var anim = new Animation(init.World, image, () => 0);
-			anim.PlayFetchIndex("idle", () => 0);
+			anim.PlayFetchIndex(Sequence, () => 0);
 
 			yield return new SpriteActorPreview(anim, WVec.Zero, 0, p, rs.Scale);
 		}
@@ -31,17 +31,19 @@ namespace OpenRA.Mods.Common.Traits
 
 	class RenderBuildingSilo : RenderBuilding, INotifyBuildComplete, INotifyOwnerChanged
 	{
+		readonly RenderBuildingSiloInfo info;
 		PlayerResources playerResources;
 
 		public RenderBuildingSilo(ActorInitializer init, RenderBuildingSiloInfo info)
 			: base(init, info)
 		{
+			this.info = info;
 			playerResources = init.Self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 
 		public override void BuildingComplete(Actor self)
 		{
-			var animation = (self.GetDamageState() >= DamageState.Heavy) ? "damaged-idle" : "idle";
+			var animation = RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), info.Sequence);
 
 			DefaultAnimation.PlayFetchIndex(animation,
 				() => playerResources.ResourceCapacity != 0

--- a/OpenRA.Mods.Common/Traits/Render/RenderBuildingTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderBuildingTurreted.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Show the correct turret facing
 			var anim = new Animation(init.World, image, () => t.InitialFacing);
-			anim.PlayRepeating("idle");
+			anim.PlayRepeating(Sequence);
 
 			yield return new SpriteActorPreview(anim, WVec.Zero, 0, p, rs.Scale);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/RenderBuildingWall.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderBuildingWall.cs
@@ -19,7 +19,6 @@ namespace OpenRA.Mods.Common.Traits
 	class RenderBuildingWallInfo : RenderBuildingInfo
 	{
 		public readonly string Type = "wall";
-		public readonly string Sequence = "idle";
 
 		public override object Create(ActorInitializer init) { return new RenderBuildingWall(init, this); }
 
@@ -27,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Show a static frame instead of animating all of the wall states
 			var anim = new Animation(init.World, image, () => 0);
-			anim.PlayFetchIndex("idle", () => 0);
+			anim.PlayFetchIndex(Sequence, () => 0);
 
 			yield return new SpriteActorPreview(anim, WVec.Zero, 0, p, rs.Scale);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/RenderFlare.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderFlare.cs
@@ -12,6 +12,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	class RenderFlareInfo : RenderSimpleInfo
 	{
+		public readonly string OpenSequence = "open";
+
 		public override object Create(ActorInitializer init) { return new RenderFlare(init, this); }
 	}
 
@@ -20,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public RenderFlare(ActorInitializer init, RenderFlareInfo info)
 			: base(init, info, () => 0)
 		{
-			DefaultAnimation.PlayThen("open", () => DefaultAnimation.PlayRepeating("idle"));
+			DefaultAnimation.PlayThen(info.OpenSequence, () => DefaultAnimation.PlayRepeating(info.Sequence));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderHarvester.cs
@@ -17,6 +17,9 @@ namespace OpenRA.Mods.Common.Traits
 	class RenderHarvesterInfo : RenderUnitInfo, Requires<HarvesterInfo>
 	{
 		public readonly string[] ImagesByFullness = { "harv" };
+
+		public readonly string HarvestSequence = "harvest";
+
 		public override object Create(ActorInitializer init) { return new RenderHarvester(init, this); }
 	}
 
@@ -42,15 +45,15 @@ namespace OpenRA.Mods.Common.Traits
 			var desiredImage = info.ImagesByFullness[desiredState];
 
 			if (DefaultAnimation.Name != desiredImage)
-				DefaultAnimation.ChangeImage(desiredImage, "idle");
+				DefaultAnimation.ChangeImage(desiredImage, info.Sequence);
 
 			base.Tick(self);
 		}
 
 		public void Harvested(Actor self, ResourceType resource)
 		{
-			if (DefaultAnimation.CurrentSequence.Name != "harvest")
-				PlayCustomAnim(self, "harvest");
+			if (DefaultAnimation.CurrentSequence.Name != info.HarvestSequence)
+				PlayCustomAnim(self, info.HarvestSequence);
 		}
 
 		public void MovingToResources(Actor self, CPos targetCell, Activity next) { }

--- a/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
@@ -18,6 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class RenderSimpleInfo : RenderSpritesInfo, IRenderActorPreviewSpritesInfo, IQuantizeBodyOrientationInfo, ILegacyEditorRenderInfo, Requires<IBodyOrientationInfo>
 	{
+		public readonly string Sequence = "idle";
+
 		public override object Create(ActorInitializer init) { return new RenderSimple(init, this); }
 
 		public virtual IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
@@ -26,13 +28,13 @@ namespace OpenRA.Mods.Common.Traits
 			var facing = ifacing != null ? init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing() : 0;
 
 			var anim = new Animation(init.World, image, () => facing);
-			anim.PlayRepeating("idle");
+			anim.PlayRepeating(Sequence);
 			yield return new SpriteActorPreview(anim, WVec.Zero, 0, p, rs.Scale);
 		}
 
 		public virtual int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race)
 		{
-			return sequenceProvider.GetSequence(GetImage(ai, sequenceProvider, race), "idle").Facings;
+			return sequenceProvider.GetSequence(GetImage(ai, sequenceProvider, race), Sequence).Facings;
 		}
 
 		public string EditorPalette { get { return Palette; } }
@@ -43,9 +45,13 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly Animation DefaultAnimation;
 
+		readonly RenderSimpleInfo info;
+
 		public RenderSimple(ActorInitializer init, RenderSimpleInfo info, Func<int> baseFacing)
 			: base(init, info)
 		{
+			this.info = info;
+
 			DefaultAnimation = new Animation(init.World, GetImage(init.Self), baseFacing);
 			Add("", DefaultAnimation);
 		}
@@ -53,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 		public RenderSimple(ActorInitializer init, RenderSimpleInfo info)
 			: this(init, info, MakeFacingFunc(init.Self))
 		{
-			DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, "idle"));
+			DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence));
 		}
 
 		public int2 SelectionSize(Actor self) { return AutoSelectionSize(self); }
@@ -67,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (DefaultAnimation.HasSequence(name))
 				DefaultAnimation.PlayThen(NormalizeSequence(self, name),
-					() => DefaultAnimation.PlayRepeating(NormalizeSequence(self, "idle")));
+					() => DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderUnit.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderUnit.cs
@@ -20,12 +20,17 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class RenderUnit : RenderSimple
 	{
+		readonly RenderUnitInfo info;
+
 		public RenderUnit(ActorInitializer init, RenderUnitInfo info)
-			: base(init, info) { }
+			: base(init, info)
+		{
+			this.info = info;
+		}
 
 		public void PlayCustomAnimation(Actor self, string newAnim, Action after)
 		{
-			DefaultAnimation.PlayThen(newAnim, () => { DefaultAnimation.Play("idle"); if (after != null) after(); });
+			DefaultAnimation.PlayThen(newAnim, () => { DefaultAnimation.Play(info.Sequence); if (after != null) after(); });
 		}
 
 		public void PlayCustomAnimRepeating(Actor self, string name)
@@ -37,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void PlayCustomAnimBackwards(Actor self, string name, Action after)
 		{
 			DefaultAnimation.PlayBackwardsThen(name,
-				() => { DefaultAnimation.PlayRepeating("idle"); if (after != null) after(); });
+				() => { DefaultAnimation.PlayRepeating(info.Sequence); if (after != null) after(); });
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Traits/Render/RenderUnitReload.cs
+++ b/OpenRA.Mods.RA/Traits/Render/RenderUnitReload.cs
@@ -19,6 +19,12 @@ namespace OpenRA.Mods.RA.Traits
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";
 
+		[Desc("Displayed while targeting.")]
+		public readonly string AimSequence = "aim";
+
+		[Desc("Shown while reloading.")]
+		public readonly string EmptyPrefix = "empty-";
+
 		public override object Create(ActorInitializer init) { return new RenderUnitReload(init, this); }
 	}
 
@@ -26,10 +32,12 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		readonly AttackBase attack;
 		readonly Armament armament;
+		readonly RenderUnitReloadInfo info;
 
 		public RenderUnitReload(ActorInitializer init, RenderUnitReloadInfo info)
 			: base(init, info)
 		{
+			this.info = info;
 			attack = init.Self.Trait<AttackBase>();
 			armament = init.Self.TraitsImplementing<Armament>()
 				.Single(a => a.Info.Name == info.Armament);
@@ -37,7 +45,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public override void Tick(Actor self)
 		{
-			var sequence = (armament.IsReloading ? "empty-" : "") + (attack.IsAttacking ? "aim" : "idle");
+			var sequence = (armament.IsReloading ? info.EmptyPrefix : "") + (attack.IsAttacking ? info.AimSequence : info.Sequence);
 			if (sequence != DefaultAnimation.CurrentSequence.Name)
 				DefaultAnimation.ReplaceAnim(sequence);
 


### PR DESCRIPTION
This exposes our default sequence name "idle" to https://github.com/OpenRA/OpenRA/wiki/Traits.
