### PR TITLE
Tweaks RA and TD helicopter weapon minimum ranges

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -57,6 +57,19 @@ namespace OpenRA.Mods.Common.Activities
 			if (!target.IsInRange(self.CenterPosition, attackHeli.GetMaximumRange()))
 				helicopter.SetPosition(self, helicopter.CenterPosition + helicopter.FlyStep(desiredFacing));
 
+			// Fly backwards from the target
+			// TODO: Same problem as with MaximumRange
+			if (target.IsInRange(self.CenterPosition, attackHeli.GetMinimumRange()))
+			{
+				// Facing 0 doesn't work with the following position change
+				var facing = 1;
+				if (desiredFacing != 0)
+					facing = desiredFacing;
+				else if (helicopter.Facing != 0)
+					facing = helicopter.Facing;
+				helicopter.SetPosition(self, helicopter.CenterPosition + helicopter.FlyStep(-facing));
+			}
+
 			attackHeli.DoAttack(self, target);
 
 			return this;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -157,6 +157,15 @@ namespace OpenRA.Mods.Common.Traits
 			return Armaments.Any(a => a.Weapon.IsValidAgainst(t, self.World, self));
 		}
 
+		public WRange GetMinimumRange()
+		{
+			if (IsTraitDisabled)
+				return WRange.Zero;
+
+			return Armaments.Where(a => !a.IsTraitDisabled)
+				.Select(a => a.Weapon.MinRange).Min();
+		}
+
 		public WRange GetMaximumRange()
 		{
 			if (IsTraitDisabled)

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -70,17 +70,18 @@ OrcaAGMissiles:
 	Burst: 2
 	BurstDelay: 12
 	Range: 5c0
+	MinRange: 1c256
 	Report: BAZOOK1.AUD
 	ValidTargets: Ground
 	Projectile: Missile
-		Arm: 0
+		Arm: 1
 		Blockable: false
 		Inaccuracy: 128
 		Image: DRAGON
 		RateOfTurn: 20
 		Trail: smokey
 		ContrailLength: 8
-		Speed: 298
+		Speed: 256
 		RangeLimit: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -103,6 +104,7 @@ OrcaAAMissiles:
 	Burst: 2
 	BurstDelay: 12
 	Range: 5c0
+	MinRange: 1c256
 	Report: BAZOOK1.AUD
 	ValidTargets: Air
 	Projectile: Missile

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -34,6 +34,7 @@ HeliAGGun:
 	Burst: 2
 	BurstDelay: 0
 	Range: 4c0
+	MinRange: 0c768
 	ValidTargets: Ground
 	Report: gun5.aud
 	Projectile: Bullet
@@ -57,6 +58,7 @@ HeliAAGun:
 	Burst: 2
 	BurstDelay: 0
 	Range: 4c0
+	MinRange: 0c768
 	ValidTargets: Air
 	Report: gun5.aud
 	Projectile: Bullet

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -76,6 +76,7 @@ Dragon:
 HellfireAG:
 	ReloadDelay: 60
 	Range: 4c0
+	MinRange: 1c256
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 10
@@ -113,6 +114,7 @@ HellfireAG:
 HellfireAA:
 	ReloadDelay: 60
 	Range: 4c0
+	MinRange: 1c256
 	Report: MISSILE6.AUD
 	Burst: 2
 	BurstDelay: 10

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -164,7 +164,7 @@ Vulcan:
 ChainGun:
 	ReloadDelay: 10
 	Range: 5c0
-	MinRange: 1c0
+	MinRange: 0c768
 	Report: GUN13.AUD
 	Projectile: Bullet
 		Speed: 1c682


### PR DESCRIPTION
As well as their AG missile MaximumPitch, to prevent them from shooting at targets they cannot hit.

Fixes the 2nd part of #7499.
