### PR TITLE
Made JamsMissiles and Hovers classes public

### DIFF
--- a/OpenRA.Mods.Common/Traits/JamsMissiles.cs
+++ b/OpenRA.Mods.Common/Traits/JamsMissiles.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new JamsMissiles(this); }
 	}
 
-	class JamsMissiles
+	public class JamsMissiles
 	{
 		readonly JamsMissilesInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Changes the visual Z position periodically.")]
-	class HoversInfo : ITraitInfo, Requires<IMoveInfo>
+	public class HoversInfo : ITraitInfo, Requires<IMoveInfo>
 	{
 		[Desc("Amount of Z axis changes in world units.")]
 		public readonly int OffsetModifier = -43;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Hovers(this, init.Self); }
 	}
 
-	class Hovers : IRenderModifier
+	public class Hovers : IRenderModifier
 	{
 		readonly HoversInfo info;
 		readonly bool aircraft;


### PR DESCRIPTION
I want to base the first public version of one of my projects on the upcoming release, so if at all possible, I'd like to see this merged before the release so I won't have to ship a custom Mods.Common.dll.
