### PR TITLE
Remove version information from NuGet folder names

### DIFF
--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -9,36 +9,36 @@ fi
 
 if [ ! -f windows/SDL2.dll ]; then
 	echo "Fetching SDL2 from nuget"
-	nuget install sdl2 -Version 2.0.3
-	cp ./sdl2.redist.2.0.3/build/native/bin/Win32/dynamic/SDL2.dll ./windows/
-	rm -rf sdl2.2.0.3 sdl2.redist.2.0.3
+	nuget install sdl2 -Version 2.0.3 -ExcludeVersion
+	cp ./sdl2.redist/build/native/bin/Win32/dynamic/SDL2.dll ./windows/
+	rm -rf sdl2.2.0.3 sdl2.redist
 fi
 
 if [ ! -f windows/freetype6.dll ]; then
 	echo "Fetching FreeType2 from nuget"
-	nuget install freetype2.redist -Version 2.4.11.3
-	cp ./freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/
-	cp ./freetype2.redist.2.4.11.3/bin/win32/freetype6.dll ./windows/
-	rm -rf freetype2.redist.2.4.11.3
+	nuget install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
+	cp ./freetype2.redist/bin/win32/zlib1.dll ./windows/
+	cp ./freetype2.redist/bin/win32/freetype6.dll ./windows/
+	rm -rf freetype2.redist
 fi
 
 if [ ! -f windows/lua51.dll ]; then
 	echo "Fetching Lua 5.1 from nuget"
-	nuget install lua.binaries -Version 5.1.5
-	cp ./lua.binaries.5.1.5/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
-	rm -rf lua.binaries.5.1.5
+	nuget install lua.binaries -Version 5.1.5 -ExcludeVersion
+	cp ./lua.binaries/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
+	rm -rf lua.binaries
 fi
 
 if [ ! -f windows/zlib1.dll ]; then
 	echo "Fetching ZLib from nuget"
-	nuget install freetype2.redist -Version 2.4.11.3
-	cp ./freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/
-	rm -rf freetype2.redist.2.4.11.3
+	nuget install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
+	cp ./freetype2.redist/bin/win32/zlib1.dll ./windows/
+	rm -rf freetype2.redist
 fi
 
 if [ ! -f windows/soft_oal.dll ]; then
 	echo "Fetching OpenAL Soft from nuget"
-	nuget install OpenAL-Soft -Version 1.16.0
-	cp ./OpenAL-Soft.1.16.0/bin/Win32/soft_oal.dll windows/soft_oal.dll
-	rm -rf OpenAL-Soft.1.16.0
+	nuget install OpenAL-Soft -Version 1.16.0 -ExcludeVersion
+	cp ./OpenAL-Soft/bin/Win32/soft_oal.dll windows/soft_oal.dll
+	rm -rf OpenAL-Soft
 fi

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -12,120 +12,120 @@ if (!(Test-Path "nuget.exe"))
 if (!(Test-Path "StyleCopPlus.dll"))
 {
 	echo "Fetching StyleCopPlus from NuGet."
-	./nuget.exe install StyleCopPlus.MSBuild -Version 4.7.49.5
-	cp StyleCopPlus.MSBuild.4.7.49.5/tools/StyleCopPlus.dll .
-	rmdir StyleCopPlus.MSBuild.4.7.49.5 -Recurse
+	./nuget.exe install StyleCopPlus.MSBuild -Version 4.7.49.5 -ExcludeVersion
+	cp StyleCopPlus.MSBuild/tools/StyleCopPlus.dll .
+	rmdir StyleCopPlus.MSBuild -Recurse
 }
 
 if (!(Test-Path "StyleCop.dll"))
 {
 	echo "Fetching StyleCop files from NuGet."
-	./nuget.exe install StyleCop.MSBuild -Version 4.7.49.0
-	cp StyleCop.MSBuild.4.7.49.0/tools/StyleCop*.dll .
-	rmdir StyleCop.MSBuild.4.7.49.0 -Recurse
+	./nuget.exe install StyleCop.MSBuild -Version 4.7.49.0 -ExcludeVersion
+	cp StyleCop.MSBuild/tools/StyleCop*.dll .
+	rmdir StyleCop.MSBuild -Recurse
 }
 
 if (!(Test-Path "ICSharpCode.SharpZipLib.dll"))
 {
 	echo "Fetching ICSharpCode.SharpZipLib from NuGet."
-	./nuget.exe install SharpZipLib -Version 0.86.0
-	cp SharpZipLib.0.86.0/lib/20/ICSharpCode.SharpZipLib.dll .
-	rmdir SharpZipLib.0.86.0 -Recurse
+	./nuget.exe install SharpZipLib -Version 0.86.0 -ExcludeVersion
+	cp SharpZipLib/lib/20/ICSharpCode.SharpZipLib.dll .
+	rmdir SharpZipLib -Recurse
 }
 
 if (!(Test-Path "MaxMind.GeoIP2.dll"))
 {
 	echo "Fetching MaxMind.GeoIP2 from NuGet."
-	./nuget.exe install MaxMind.GeoIP2 -Version 2.1.0
-	cp MaxMind.Db.1.0.0.0/lib/net40/MaxMind.Db.* .
-	rmdir MaxMind.Db.1.0.0.0 -Recurse
-	cp MaxMind.GeoIP2.2.1.0.0/lib/net40/MaxMind.GeoIP2* .
-	rmdir MaxMind.GeoIP2.2.1.0.0 -Recurse
-	cp Newtonsoft.Json.6.0.5/lib/net40/Newtonsoft.Json* .
-	rmdir Newtonsoft.Json.6.0.5 -Recurse
-	cp RestSharp.105.0.0/lib/net4-client/RestSharp* .
-	rmdir RestSharp.105.0.0 -Recurse
+	./nuget.exe install MaxMind.GeoIP2 -Version 2.1.0 -ExcludeVersion
+	cp MaxMind.Db/lib/net40/MaxMind.Db.* .
+	rmdir MaxMind.Db -Recurse
+	cp MaxMind.GeoIP2/lib/net40/MaxMind.GeoIP2* .
+	rmdir MaxMind.GeoIP2 -Recurse
+	cp Newtonsoft.Json/lib/net40/Newtonsoft.Json* .
+	rmdir Newtonsoft.Json -Recurse
+	cp RestSharp/lib/net4-client/RestSharp* .
+	rmdir RestSharp -Recurse
 }
 
 if (!(Test-Path "SharpFont.dll"))
 {
 	echo "Fetching SharpFont from NuGet."
-	./nuget.exe install SharpFont -Version 2.5.0.1
-	cp SharpFont.2.5.0.1/lib/net20/SharpFont* .
-	cp SharpFont.2.5.0.1/Content/SharpFont.dll.config .
-	rmdir SharpFont.2.5.0.1 -Recurse
+	./nuget.exe install SharpFont -Version 2.5.0.1 -ExcludeVersion
+	cp SharpFont/lib/net20/SharpFont* .
+	cp SharpFont/Content/SharpFont.dll.config .
+	rmdir SharpFont -Recurse
 }
 
 if (!(Test-Path "nunit.framework.dll"))
 {
 	echo "Fetching NUnit from NuGet."
-	./nuget.exe install NUnit -Version 2.6.4
-	cp NUnit.2.6.4/lib/nunit.framework* .
-	rmdir NUnit.2.6.4 -Recurse
+	./nuget.exe install NUnit -Version 2.6.4 -ExcludeVersion
+	cp NUnit/lib/nunit.framework* .
+	rmdir NUnit -Recurse
 }
 
 if (!(Test-Path "windows/SDL2.dll"))
 {
 	echo "Fetching SDL2 from NuGet."
-	./nuget.exe install sdl2 -Version 2.0.3
-	cp sdl2.redist.2.0.3/build/native/bin/Win32/dynamic/SDL2.dll ./windows/
-	rmdir sdl2.2.0.3 -Recurse
-	rmdir sdl2.redist.2.0.3 -Recurse
+	./nuget.exe install sdl2 -Version 2.0.3 -ExcludeVersion
+	cp sdl2.redist/build/native/bin/Win32/dynamic/SDL2.dll ./windows/
+	rmdir sdl2 -Recurse
+	rmdir sdl2.redist -Recurse
 }
 
 if (!(Test-Path "Mono.Nat.dll"))
 {
 	echo "Fetching Mono.Nat from NuGet."
-	./nuget.exe install Mono.Nat -Version 1.2.21
-	cp Mono.Nat.1.2.21.0/lib/net40/Mono.Nat.dll .
-	rmdir Mono.Nat.1.2.21.0 -Recurse
+	./nuget.exe install Mono.Nat -Version 1.2.21 -ExcludeVersion
+	cp Mono.Nat/lib/net40/Mono.Nat.dll .
+	rmdir Mono.Nat -Recurse
 }
 
 if (!(Test-Path "windows/lua51.dll"))
 {
 	echo "Fetching Lua 5.1 from NuGet."
-	./nuget.exe install lua.binaries -Version 5.1.5
-	cp lua.binaries.5.1.5/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
-	rmdir lua.binaries.5.1.5 -Recurse
+	./nuget.exe install lua.binaries -Version 5.1.5 -ExcludeVersion
+	cp lua.binaries/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
+	rmdir lua.binaries -Recurse
 }
 
 if (!(Test-Path "windows/freetype6.dll"))
 {
 	echo "Fetching FreeType2 from NuGet."
-	./nuget.exe install freetype2.redist -Version 2.4.11.3
-	cp freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/zlib1.dll
-	cp freetype2.redist.2.4.11.3/bin/win32/freetype6.dll ./windows/freetype6.dll
-	rmdir freetype2.redist.2.4.11.3 -Recurse
+	./nuget.exe install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
+	cp freetype2.redist/bin/win32/zlib1.dll ./windows/zlib1.dll
+	cp freetype2.redist/bin/win32/freetype6.dll ./windows/freetype6.dll
+	rmdir freetype2.redist -Recurse
 }
 
 if (!(Test-Path "windows/zlib1.dll"))
 {
 	echo "Fetching ZLib from NuGet."
-	./nuget.exe install freetype2.redist -Version 2.4.11.3
-	cp freetype2.redist.2.4.11.3/bin/win32/zlib1.dll ./windows/zlib1.dll
-	rmdir freetype2.redist.2.4.11.3 -Recurse
+	./nuget.exe install freetype2.redist -Version 2.4.11.3 -ExcludeVersion
+	cp freetype2.redist/bin/win32/zlib1.dll ./windows/zlib1.dll
+	rmdir freetype2.redist -Recurse
 }
 
 if (!(Test-Path "windows/soft_oal.dll"))
 {
 	echo "Fetching OpenAL Soft from NuGet."
-	./nuget.exe install OpenAL-Soft -Version 1.16.0
-	cp OpenAL-Soft.1.16.0/bin/Win32/soft_oal.dll windows/soft_oal.dll
-	rmdir OpenAL-Soft.1.16.0 -Recurse
+	./nuget.exe install OpenAL-Soft -Version 1.16.0 -ExcludeVersion
+	cp OpenAL-Soft/bin/Win32/soft_oal.dll windows/soft_oal.dll
+	rmdir OpenAL-Soft -Recurse
 }
 
 if (!(Test-Path "Moq.dll"))
 {
 	echo "Fetching Moq from NuGet."
-	./nuget.exe install Moq -Version 4.2.1502.0911
-	cp Moq.4.2.1502.0911/lib/net40/Moq.dll .
-	rmdir Moq.4.2.1502.0911 -Recurse
+	./nuget.exe install Moq -Version 4.2.1502.0911 -ExcludeVersion
+	cp Moq/lib/net40/Moq.dll .
+	rmdir Moq -Recurse
 }
 
 if (!(Test-Path "FuzzyLogicLibrary.dll"))
 {
 	echo "Fetching FuzzyLogicLibrary from NuGet."
-	./nuget.exe install FuzzyLogicLibrary -Version 1.2.0
-	cp FuzzyLogicLibrary.1.2.0/bin/Release/FuzzyLogicLibrary.dll .
-	rmdir FuzzyLogicLibrary.1.2.0 -Recurse
+	./nuget.exe install FuzzyLogicLibrary -Version 1.2.0 -ExcludeVersion
+	cp FuzzyLogicLibrary/bin/Release/FuzzyLogicLibrary.dll .
+	rmdir FuzzyLogicLibrary -Recurse
 }

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -5,70 +5,70 @@ set -e
 
 if [ ! -f StyleCopPlus.dll ]; then
 	echo "Fetching StyleCopPlus from nuget"
-	nuget install StyleCopPlus.MSBuild -Version 4.7.49.5
-	cp ./StyleCopPlus.MSBuild.4.7.49.5/tools/StyleCopPlus.dll .
-	rm -rf StyleCopPlus.MSBuild.4.7.49.5
+	nuget install StyleCopPlus.MSBuild -Version 4.7.49.5 -ExcludeVersion
+	cp ./StyleCopPlus.MSBuild/tools/StyleCopPlus.dll .
+	rm -rf StyleCopPlus.MSBuild
 fi
 
 if [ ! -f StyleCop.dll ]; then
 	echo "Fetching StyleCop files from nuget"
-	nuget install StyleCop.MSBuild -Version 4.7.49.0
-	cp ./StyleCop.MSBuild.4.7.49.0/tools/StyleCop*.dll .
-	rm -rf StyleCop.MSBuild.4.7.49.0
+	nuget install StyleCop.MSBuild -Version 4.7.49.0 -ExcludeVersion
+	cp ./StyleCop.MSBuild/tools/StyleCop*.dll .
+	rm -rf StyleCop.MSBuild
 fi
 
 if [ ! -f ICSharpCode.SharpZipLib.dll ]; then
 	echo "Fetching ICSharpCode.SharpZipLib from nuget"
-	nuget install SharpZipLib -Version 0.86.0
-	cp ./SharpZipLib.0.86.0/lib/20/ICSharpCode.SharpZipLib.dll .
-	rm -rf SharpZipLib.0.86.0
+	nuget install SharpZipLib -Version 0.86.0 -ExcludeVersion
+	cp ./SharpZipLib/lib/20/ICSharpCode.SharpZipLib.dll .
+	rm -rf SharpZipLib
 fi
 
 if [ ! -f MaxMind.GeoIP2.dll ]; then
 	echo "Fetching MaxMind.GeoIP2 from nuget"
-	nuget install MaxMind.GeoIP2 -Version 2.1.0
-	cp ./MaxMind.Db.1.0.0.0/lib/net40/MaxMind.Db.* .
-	rm -rf MaxMind.Db.1.0.0.0
-	cp ./MaxMind.GeoIP2.2.1.0.0/lib/net40/MaxMind.GeoIP2* .
-	rm -rf MaxMind.GeoIP2.2.1.0.0
-	cp ./Newtonsoft.Json.6.0.5/lib/net40/Newtonsoft.Json* .
-	rm -rf Newtonsoft.Json.6.0.5
-	cp ./RestSharp.105.0.0/lib/net4-client/RestSharp* .
-	rm -rf RestSharp.105.0.0
+	nuget install MaxMind.GeoIP2 -Version 2.1.0 -ExcludeVersion
+	cp ./MaxMind.Db/lib/net40/MaxMind.Db.* .
+	rm -rf MaxMind.Db
+	cp ./MaxMind.GeoIP2/lib/net40/MaxMind.GeoIP2* .
+	rm -rf MaxMind.GeoIP2
+	cp ./Newtonsoft.Json/lib/net40/Newtonsoft.Json* .
+	rm -rf Newtonsoft.Json
+	cp ./RestSharp/lib/net4-client/RestSharp* .
+	rm -rf RestSharp
 fi
 
 if [ ! -f SharpFont.dll ]; then
 	echo "Fetching SharpFont from nuget"
-	nuget install SharpFont -Version 2.5.0.1
-	cp ./SharpFont.2.5.0.1/lib/net20/SharpFont* .
-	sed '/osx/s@\(dll="\)[^"]*\(" />\)@\1/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib\2@' ./SharpFont.2.5.0.1/Content/SharpFont.dll.config > SharpFont.dll.config
-	rm -rf SharpFont.2.5.0.1
+	nuget install SharpFont -Version 2.5.0.1 -ExcludeVersion
+	cp ./SharpFont/lib/net20/SharpFont* .
+	sed '/osx/s@\(dll="\)[^"]*\(" />\)@\1/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib\2@' ./SharpFont/Content/SharpFont.dll.config > SharpFont.dll.config
+	rm -rf SharpFont
 fi
 
 if [ ! -f nunit.framework.dll ]; then
 	echo "Fetching NUnit from nuget"
-	nuget install NUnit -Version 2.6.4
-	cp ./NUnit.2.6.4/lib/nunit.framework* .
-	rm -rf NUnit.2.6.4
+	nuget install NUnit -Version 2.6.4 -ExcludeVersion
+	cp ./NUnit/lib/nunit.framework* .
+	rm -rf NUnit
 fi
 
 if [ ! -f Mono.Nat.dll ]; then
 	echo "Fetching Mono.Nat from nuget"
-	nuget install Mono.Nat -Version 1.2.21
-	cp ./Mono.Nat.1.2.21.0/lib/net40/Mono.Nat.dll .
-	rm -rf Mono.Nat.1.2.21.0
+	nuget install Mono.Nat -Version 1.2.21 -ExcludeVersion
+	cp ./Mono.Nat/lib/net40/Mono.Nat.dll .
+	rm -rf Mono.Nat
 fi
 
 if [ ! -f Moq.dll ]; then
 	echo "Fetching Moq from NuGet."
-	nuget install Moq -Version 4.2.1502.0911
-	cp ./Moq.4.2.1502.0911/lib/net40/Moq.dll .
-	rm -rf Moq.4.2.1502.0911
+	nuget install Moq -Version 4.2.1502.0911 -ExcludeVersion
+	cp ./Moq/lib/net40/Moq.dll .
+	rm -rf Moq
 fi
 
 if [ ! -f FuzzyLogicLibrary.dll ]; then
 	echo "Fetching FuzzyLogicLibrary from NuGet."
-	nuget install FuzzyLogicLibrary -Version 1.2.0
-	cp ./FuzzyLogicLibrary.1.2.0/bin/Release/FuzzyLogicLibrary.dll .
-	rm -rf FuzzyLogicLibrary.1.2.0
+	nuget install FuzzyLogicLibrary -Version 1.2.0 -ExcludeVersion
+	cp ./FuzzyLogicLibrary/bin/Release/FuzzyLogicLibrary.dll .
+	rm -rf FuzzyLogicLibrary
 fi


### PR DESCRIPTION
This makes the names consistent and prevents changes in versions of
dependencies from breaking the build.

If you like this I can update the .ps1 and -windows scripts as well.
