### PR TITLE
Set version before creating docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/modchooser/mo
 	done
 
 # Documentation (d2k depends on all mod libraries)
-docs: utility mods
+docs: utility mods version
 	@mono --debug OpenRA.Utility.exe d2k --docs > DOCUMENTATION.md
 	@mono --debug OpenRA.Utility.exe ra --lua-docs > Lua-API.md
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ test_script:
   - nunit-console-x86.exe OpenRA.Test.dll
 
 after_test:
-  - make version
   - choco install pandoc -y
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o README.html README.md'
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o CONTRIBUTING.html CONTRIBUTING.md'

--- a/make.ps1
+++ b/make.ps1
@@ -157,6 +157,7 @@ elseif ($command -eq "check")
 }
 elseif ($command -eq "docs")
 {
+	./make.ps1 version
 	./OpenRA.Utility.exe d2k --docs | Out-File -Encoding "UTF8" DOCUMENTATION.md
 	./OpenRA.Utility.exe ra --lua-docs | Out-File -Encoding "UTF8" Lua-API.md
 }


### PR DESCRIPTION
Since the version string gets embedded into the created documentation (see https://github.com/OpenRA/OpenRA/wiki/Lua-API-(playtest), for example).
