### PR TITLE
Fixed the missile silo being visible to GDI commanders

### DIFF
--- a/mods/ts/rules/structures.yaml
+++ b/mods/ts/rules/structures.yaml
@@ -1274,8 +1274,7 @@ NAMISL:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100
-		Owner: nod
-		Prerequisites: natech
+		Prerequisites: natech, ~structures.nod
 		BuildLimit: 1
 	Valued:
 		Cost: 1300


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/7191 which must have been created long before but merged after the refactor from https://github.com/OpenRA/OpenRA/pull/7376.
