### PR TITLE
Faster replay browser loading

### DIFF
--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -116,7 +116,6 @@ namespace OpenRA
 			if (!Manifest.Translations.Any())
 			{
 				Languages = new string[0];
-				FieldLoader.Translations = new Dictionary<string, string>();
 				return;
 			}
 
@@ -144,7 +143,7 @@ namespace OpenRA
 					translations.Add(tkv.Key, tkv.Value);
 			}
 
-			FieldLoader.Translations = translations;
+			FieldLoader.SetTranslations(translations);
 		}
 
 		public Map PrepareMap(string uid)

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Player.cs" />
     <Compile Include="Primitives\MergedStream.cs" />
     <Compile Include="Primitives\SpatiallyPartitioned.cs" />
+    <Compile Include="Primitives\ConcurrentCache.cs" />
     <Compile Include="Selection.cs" />
     <Compile Include="Server\Connection.cs" />
     <Compile Include="Server\Exts.cs" />

--- a/OpenRA.Game/Primitives/ConcurrentCache.cs
+++ b/OpenRA.Game/Primitives/ConcurrentCache.cs
@@ -1,4 +1,4 @@
-#region Copyright & License Information
+﻿#region Copyright & License Information
 /*
  * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
@@ -9,25 +9,26 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace OpenRA.Primitives
 {
-	public class Cache<T, U> : IReadOnlyDictionary<T, U>
+	public class ConcurrentCache<T, U> : IReadOnlyDictionary<T, U>
 	{
-		readonly Dictionary<T, U> cache;
+		readonly ConcurrentDictionary<T, U> cache;
 		readonly Func<T, U> loader;
 
-		public Cache(Func<T, U> loader, IEqualityComparer<T> c)
+		public ConcurrentCache(Func<T, U> loader, IEqualityComparer<T> c)
 		{
 			if (loader == null)
 				throw new ArgumentNullException("loader");
 
 			this.loader = loader;
-			cache = new Dictionary<T, U>(c);
+			cache = new ConcurrentDictionary<T, U>(c);
 		}
 
-		public Cache(Func<T, U> loader)
+		public ConcurrentCache(Func<T, U> loader)
 			: this(loader, EqualityComparer<T>.Default) { }
 
 		public U this[T key]

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -156,10 +156,13 @@ namespace OpenRA.Mods.Common.Widgets
 			WidgetUtils.DrawRGBA(ChromeProvider.GetImage("scrollbar", downPressed || downDisabled ? "down_pressed" : "down_arrow"),
 				new float2(downButtonRect.Left + downOffset, downButtonRect.Top + downOffset));
 
-			Game.Renderer.EnableScissor(backgroundRect.InflateBy(-1, -1, -1, -1));
+			var drawBounds = backgroundRect.InflateBy(-1, -1, -1, -1);
+			Game.Renderer.EnableScissor(drawBounds);
 
+			drawBounds.Offset((-ChildOrigin).ToPoint());
 			foreach (var child in Children)
-				child.DrawOuter();
+				if (child.Bounds.IntersectsWith(drawBounds))
+					child.DrawOuter();
 
 			Game.Renderer.DisableScissor();
 		}


### PR DESCRIPTION
#5971 is back.

The improves the speed of replay loading with several optimizations:
- FieldLoader now caches some of the more expensive reflection calls, which speeds up loading.
- ReplayBrowserLogic will now load replays on another thread so the UI doesn't block.
- ReplayBrowserLogic will load replays in parallel. This means we can use all your cores to load all your replays.
- If you had a lot of replays (we're talking hundreds to thousands), your framerate might drop significantly because it would have to draw so many items in the list, even the ones you couldn't see - I have made a change so it only draws the ones that are visible, which prevents the framerate tanking.

Fixes #5942.
