### PR TITLE
Move ra silo to defense queue

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -955,8 +955,8 @@ PROC:
 SILO:
 	Inherits: ^Building
 	Buildable:
-		Queue: Building
-		BuildPaletteOrder: 70
+		Queue: Defense
+		BuildPaletteOrder: 35
 		Prerequisites: proc, ~techlevel.infonly
 	Valued:
 		Cost: 150


### PR DESCRIPTION
4 reasons:
- Consistency with the TD mod
- Lets you build real structures in parallel with the silo, so players that want to build them aren't penalised as much
- The defense queue is actually the support queue, and the silo is a support structure
- People keep asking for it (to me personally, and general discussion on the forum)
