### PR TITLE
Fixed the AI not avoiding boats when searching for viable paradrop targets

### DIFF
--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -82,7 +82,7 @@ Player:
 				CheckRadius: 10c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense
+				Types: Vehicle, Tank, Infantry, Defense, Water
 				Attractiveness: -10
 				TargetMetric: None
 				CheckRadius: 10c0
@@ -224,7 +224,7 @@ Player:
 				CheckRadius: 10c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense
+				Types: Vehicle, Tank, Infantry, Defense, Water
 				Attractiveness: -10
 				TargetMetric: None
 				CheckRadius: 10c0
@@ -365,7 +365,7 @@ Player:
 				CheckRadius: 10c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense
+				Types: Vehicle, Tank, Infantry, Defense, Water
 				Attractiveness: -10
 				TargetMetric: None
 				CheckRadius: 10c0
@@ -481,7 +481,7 @@ Player:
 				CheckRadius: 10c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense
+				Types: Vehicle, Tank, Infantry, Defense, Water
 				Attractiveness: -10
 				TargetMetric: None
 				CheckRadius: 10c0


### PR DESCRIPTION
Tries to lessen https://github.com/OpenRA/OpenRA/issues/6636 with the adjusting screws we already got.
