### PR TITLE
Fixes unselectable and untargetable buildings issue.

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -23,16 +23,30 @@ namespace OpenRA.Orders
 				.Where(a => !world.FogObscures(a) && a.HasTrait<ITargetable>())
 				.WithHighestSelectionPriority();
 
-			Target target;
-			if (underCursor != null)
-				target = Target.FromActor(underCursor);
-			else
-			{
-				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
+			var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
 					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
 					.WithHighestSelectionPriority();
-				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
+
+			Target target;
+			if (underCursor != null)
+			{
+				if (frozen != null)
+				{
+					var boundsU = world.ScreenMap.ActorBounds(underCursor);
+					var distU = new int2(boundsU.Location) + new int2(boundsU.Size) / 2 - mi.Location;
+					var boundsF = world.ScreenMap.FrozenActorBounds(frozen);
+					var distF = new int2(boundsF.Location) + new int2(boundsF.Size) / 2 - mi.Location;
+
+					if (distU.LengthSquared > distF.LengthSquared)
+						target = Target.FromFrozenActor(frozen);
+					else
+						target = Target.FromActor(underCursor);
+				}
+				else
+					target = Target.FromActor(underCursor);
 			}
+			else
+				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 
 			var orders = world.Selection.Actors
 				.Select(a => OrderForUnit(a, target, mi))
@@ -68,16 +82,30 @@ namespace OpenRA.Orders
 					useSelect = true;
 			}
 
-			Target target;
-			if (underCursor != null)
-				target = Target.FromActor(underCursor);
-			else
-			{
-				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
+			var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
 					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
 					.WithHighestSelectionPriority();
-				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
+
+			Target target;
+			if (underCursor != null)
+			{
+				if (frozen != null)
+				{
+					var boundsU = world.ScreenMap.ActorBounds(underCursor);
+					var distU = new int2(boundsU.Location) + new int2(boundsU.Size) / 2 - mi.Location;
+					var boundsF = world.ScreenMap.FrozenActorBounds(frozen);
+					var distF = new int2(boundsF.Location) + new int2(boundsF.Size) / 2 - mi.Location;
+
+					if (distU.LengthSquared > distF.LengthSquared)
+						target = Target.FromFrozenActor(frozen);
+					else
+						target = Target.FromActor(underCursor);
+				}
+				else
+					target = Target.FromActor(underCursor);
 			}
+			else
+				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 
 			var ordersWithCursor = world.Selection.Actors
 				.Select(a => OrderForUnit(a, target, mi))

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -119,6 +119,18 @@ namespace OpenRA.Traits
 			return ActorsAt(worldRenderer.Viewport.ViewToWorldPx(mi.Location));
 		}
 
+		public bool ActorCloserToCursorThanFrozen(Actor act, FrozenActor frz, int2 worldPx)
+		{
+			var boundsAct = ActorBounds(act);
+			var boundsFrz = FrozenActorBounds(frz);
+			var distAct = new int2(boundsAct.Location) + new int2(boundsAct.Size) / 2 - worldPx;
+			var distFrz = new int2(boundsFrz.Location) + new int2(boundsFrz.Size) / 2 - worldPx;
+			if (distAct.LengthSquared > distFrz.LengthSquared)
+				return false;
+			
+			return true;
+		}
+
 		static Rectangle RectWithCorners(int2 a, int2 b)
 		{
 			return Rectangle.FromLTRB(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y), Math.Max(a.X, b.X), Math.Max(a.Y, b.Y));

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Traits
 			var distFrz = new int2(boundsFrz.Location) + new int2(boundsFrz.Size) / 2 - worldPx;
 			if (distAct.LengthSquared > distFrz.LengthSquared)
 				return false;
-			
+
 			return true;
 		}
 

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -290,7 +290,7 @@ namespace OpenRA.Widgets
 			if (frz == null)
 				return act;
 
-			if(world.ScreenMap.ActorCloserToCursorThanFrozen(act, frz, pos))
+			if (world.ScreenMap.ActorCloserToCursorThanFrozen(act, frz, pos))
 				return act;
 
 			return null;

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Widgets
 		{
 			if (!IsDragging)
 			{
-				var act = SelectActorAt(World, lastMousePosition, _ => true);
+				var act = SelectActorAt(World, lastMousePosition);
 				if (act != null)
 					worldRenderer.DrawRollover(act);
 
@@ -279,10 +279,21 @@ namespace OpenRA.Widgets
 				.FirstOrDefault();
 		}
 
-		static Actor SelectActorAt(World world, int2 pos, Func<Actor, bool> cond)
+		static Actor SelectActorAt(World world, int2 pos)
 		{
-			return world.ScreenMap.ActorsAt(pos).Where(x => x.HasTrait<Selectable>() && x.Trait<Selectable>().Info.Selectable
-				&& (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)) && cond(x)).WithHighestSelectionPriority();
+			var act = world.ScreenMap.ActorsAt(pos).Where(x => x.HasTrait<Selectable>() && x.Trait<Selectable>().Info.Selectable
+				&& (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x))).FirstOrDefault();
+			var frz = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, pos).FirstOrDefault();
+			if (act == null)
+				return null;
+
+			if (frz == null)
+				return act;
+
+			if(world.ScreenMap.ActorCloserToCursorThanFrozen(act, frz, pos))
+				return act;
+
+			return null;
 		}
 
 		bool ToggleStatusBars()

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -40,8 +40,9 @@ namespace OpenRA.Widgets
 		{
 			if (!IsDragging)
 			{
-				foreach (var u in SelectActorsInBoxWithDeadzone(World, lastMousePosition, lastMousePosition, _ => true))
-					worldRenderer.DrawRollover(u);
+				var act = SelectActorAt(World, lastMousePosition, _ => true);
+				if (act != null)
+					worldRenderer.DrawRollover(act);
 
 				return;
 			}
@@ -261,7 +262,7 @@ namespace OpenRA.Widgets
 
 		static IEnumerable<Actor> SelectActorsInBoxWithDeadzone(World world, int2 a, int2 b, Func<Actor, bool> cond)
 		{
-			if (a == b || (a - b).Length > Game.Settings.Game.SelectionDeadzone)
+			if ((a - b).Length > Game.Settings.Game.SelectionDeadzone)
 				return SelectActorsInBox(world, a, b, cond);
 			else
 				return SelectActorsInBox(world, b, b, cond);
@@ -276,6 +277,12 @@ namespace OpenRA.Widgets
 				.Select(g => g.AsEnumerable())
 				.DefaultIfEmpty(NoActors)
 				.FirstOrDefault();
+		}
+
+		static Actor SelectActorAt(World world, int2 pos, Func<Actor, bool> cond)
+		{
+			return world.ScreenMap.ActorsAt(pos).Where(x => x.HasTrait<Selectable>() && x.Trait<Selectable>().Info.Selectable
+				&& (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)) && cond(x)).WithHighestSelectionPriority();
 		}
 
 		bool ToggleStatusBars()

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (underCursor == null && frozen == null)
 				return;
 
-			if (underCursor != null && frozen != null && world.ScreenMap.ActorCloserToCursorThanFrozen(underCursor, frozen, mousePosPx) || frozen == null)
+			if ((underCursor != null && frozen != null && world.ScreenMap.ActorCloserToCursorThanFrozen(underCursor, frozen, mousePosPx)) || frozen == null)
 			{
 				ActorTooltip = underCursor.TraitsImplementing<IToolTip>().First();
 				ActorTooltipExtra = underCursor.TraitsImplementing<IProvideTooltipInfo>().ToArray();


### PR DESCRIPTION
Fixes #7662 but not #3871.

This is done by comparing the bounds (selection boxes) of buildings. If the cursor position intersects bounds of multiple buildings, the one with the smallest bounds area is selected.
