### PR TITLE
EndOfStream first chance exceptions on server

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -425,7 +425,7 @@ namespace OpenRA.Server
 
 			try
 			{
-				for (;;)
+				while (ms.Position < ms.Length)
 				{
 					var so = ServerOrder.Deserialize(br);
 					if (so == null) return;


### PR DESCRIPTION
The server class reads the memory stream in a forever loop until an
EndOfStreamException occurs. This causes repeated first chance
exceptions due to EndOfStreamException. This change verifies that the
memory stream's reader position is not past the length of the memory
stream.
