### PR TITLE
Fix flag-related crash for scripted "players"

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -101,6 +101,8 @@ namespace OpenRA
 				Spectating = pr.Spectating;
 				botType = pr.Bot;
 				Country = ChooseCountry(world, pr.Race, false);
+				pr.RaceFlagName = pr.Race;
+				pr.Race = Country.Name;
 			}
 
 			PlayerActor = world.CreateActor("Player", new TypeDictionary { new OwnerInit(this) });


### PR DESCRIPTION
Fixes #7929, which is caused by flags not being set for scripted "players" like the Fort Lonestar soviet attackers and the scripted attackers on @Unit158's WIP map.

First line fixes the crash by setting the flag name.
Second line fixes the scripted "player"'s faction being shows as "soviet" instead of "Soviet", which is a regression from #7722, I believe. (well actually they both are)
