### PR TITLE
Fix carryalls unreserving issue

### DIFF
--- a/OpenRA.Mods.D2k/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.D2k/Activities/DeliverUnit.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.D2k.Activities
 		readonly IFacing cargoFacing;
 		readonly IFacing selfFacing;
 
-		enum State { Transport, Land, Release, Done }
+		enum State { Transport, Land, Release }
 
 		State state;
 
@@ -108,11 +108,6 @@ namespace OpenRA.Mods.D2k.Activities
 					}
 
 					Release();
-					state = State.Done;
-					return Util.SequenceActivities(new Wait(10), this);
-
-				case State.Done:
-					self.Trait<Carryall>().UnreserveCarryable();
 					return NextActivity;
 			}
 
@@ -125,7 +120,11 @@ namespace OpenRA.Mods.D2k.Activities
 			cargoFacing.Facing = selfFacing.Facing;
 
 			// Put back into world
-			self.World.AddFrameEndTask(w => cargo.World.Add(cargo));
+			self.World.AddFrameEndTask(w =>
+			{
+				cargo.World.Add(cargo);
+				carryall.UnreserveCarryable();
+			});
 
 			// Unlock carryable
 			carryall.CarryableReleased();

--- a/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
@@ -64,7 +64,9 @@ namespace OpenRA.Mods.D2k.Traits
 			if (clientInitialActivity != null)
 				cargo.QueueActivity(Game.CreateObject<Activity>(clientInitialActivity));
 
-			cargo.Trait<Carryable>().Destination = location;
+			var carryable = cargo.Trait<Carryable>();
+			carryable.Destination = location;
+			carryable.Reserve(carrier);
 
 			carrier.Trait<Carryall>().AttachCarryable(cargo);
 

--- a/OpenRA.Mods.D2k/Traits/Carryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryable.cs
@@ -116,6 +116,9 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public bool Reserve(Actor carrier)
 		{
+			if (Reserved)
+				return false;
+
 			if ((self.Location - Destination).Length < info.MinDistance)
 			{
 				MovementCancelled(self);

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -122,6 +122,9 @@ namespace OpenRA.Mods.D2k.Traits
 		// Reserve the carryable so its ours exclusively
 		public bool ReserveCarryable(Actor carryable)
 		{
+			if (Carrying != null)
+				return false;
+
 			if (carryable.Trait<Carryable>().Reserve(self))
 			{
 				Carrying = carryable;
@@ -144,6 +147,7 @@ namespace OpenRA.Mods.D2k.Traits
 			}
 
 			IsBusy = false;
+			Carrying = null;
 		}
 
 		// INotifyKilled
@@ -177,6 +181,7 @@ namespace OpenRA.Mods.D2k.Traits
 		// Called when released
 		public void CarryableReleased()
 		{
+			IsBusy = false;
 			IsCarrying = false;
 			anim = null;
 		}


### PR DESCRIPTION
Fixes #7945.
I'm going to explain the problem very simple to facilitate reviewing:
We have CarryallA, CarryallB, CarryallC and Harvester. (**CarryallA should be the one delivering a new harvester to the refinery to reproduce easily; timing is very important**)
- CarryallA dropps off Harvester, and Harvester immediately requests transport to somewhere else.
- CarryallB is called in and reserves Harvester, so another carryall won't bother with it.
- CarryallA has ticked his `Wait(10)` (removed in the diff below) and unreserves Harvester.
- CarryallC, just becoming Idle (what luck, eh?), sees that Harvester wants transport but is not reserved and comes to the rescue to pick him up.

Fix is to unreserve the carryable immediatelly after dropping it off and not waiting for 10 ticks before doing it. This makes `State.Done` unneeded.

`IsBusy = false;` is added because with the current set of changes, the carryall does not ascend to CruiseAltitude otherwise, because of [this check](https://github.com/OpenRA/OpenRA/blob/10ff0be4671140945d461c4da96e3ab8612cf0cc/OpenRA.Mods.D2k/Traits/Carryall.cs#L60).

This will hopefully bring us (somewhat) back on track with the release.
