### PR TITLE
Cache render traits in Actor

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -83,8 +83,8 @@ namespace OpenRA
 			}
 		}
 
-		readonly IEnumerable<IRenderModifier> traitsImplementingRenderModifier;
-		readonly IEnumerable<IRender> traitsImplementingRender;
+		readonly IRenderModifier[] traitsImplementingRenderModifier;
+		readonly IRender[] traitsImplementingRender;
 
 		internal Actor(World world, string name, TypeDictionary initDict)
 		{
@@ -126,8 +126,8 @@ namespace OpenRA
 				return new Rectangle(offset.X, offset.Y, size.X, size.Y);
 			});
 
-			traitsImplementingRenderModifier = TraitsImplementing<IRenderModifier>();
-			traitsImplementingRender = TraitsImplementing<IRender>();
+			traitsImplementingRenderModifier = TraitsImplementing<IRenderModifier>().ToArray();
+			traitsImplementingRender = TraitsImplementing<IRender>().ToArray();
 		}
 
 		public void Tick()


### PR DESCRIPTION
In #7281 we cached the query object for gathering these traits, but now we cache the full results. This avoids having to re-evaluate them every render.

This reduces total CPU time spent enumerating these traits from 2.5% to 0.3% in the RA shellmap.
