### PR TITLE
Allow players locked to unplayable factions in the lobby

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -144,8 +144,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			colorPreview = lobby.Get<ColorPreviewManagerWidget>("COLOR_MANAGER");
 			colorPreview.Color = Game.Settings.Player.Color;
 
-			foreach (var c in modRules.Actors["world"].Traits.WithInterface<CountryInfo>().Where(c => c.Selectable))
-				countries.Add(c.Race, new LobbyCountry { Name = c.Name, Side = c.Side, Description = c.Description });
+			foreach (var c in modRules.Actors["world"].Traits.WithInterface<CountryInfo>())
+				countries.Add(c.Race, new LobbyCountry { Selectable = c.Selectable, Name = c.Name, Side = c.Side, Description = c.Description });
 
 			var gameStarting = false;
 			Func<bool> configurationDisabled = () => !Game.IsHost || gameStarting ||
@@ -829,6 +829,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 	public class LobbyCountry
 	{
+		public bool Selectable;
 		public string Name;
 		public string Description;
 		public string Side;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -121,7 +121,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			var options = countries.GroupBy(c => c.Value.Side).ToDictionary(g => g.Key ?? "", g => g.Select(c => c.Key));
+			var options = countries.Where(c => c.Value.Selectable).GroupBy(c => c.Value.Side)
+				.ToDictionary(g => g.Key ?? "", g => g.Select(c => c.Key));
 
 			dropdown.ShowDropDown("RACE_DROPDOWN_TEMPLATE", 150, options, setupItem);
 		}


### PR DESCRIPTION
This allows maps that are selectable in the lobby to assign unselectable factions to players without crashing.

There are two issues with this:
1. The race needs to be locked, otherwise it gets ignored, and the default "Any" is used.
2. When the map is changed, the slot keeps its previous (unselectable) race. A player may start a game with that configuration, but `Player::ChooseCountry` prevents that from actually working. The player will get a random faction instead. A similar thing happens with lobby options that get set by maps, they won't get unset either. There's a ticket for that somewhere.

This fixes #7927 and unbreaks our minigames.

If this fix is deemed to ugly, I propose to just make the allies and soviet factions selectable again.
