### PR TITLE
Don’t crash when asking for the offset of an invalid subcell.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -190,7 +190,13 @@ namespace OpenRA
 		public Bitmap CustomPreview;
 		public bool InvalidCustomRules { get; private set; }
 
-		public WVec OffsetOfSubCell(SubCell subCell) { return SubCellOffsets[(int)subCell]; }
+		public WVec OffsetOfSubCell(SubCell subCell)
+		{
+			if (subCell == SubCell.Invalid || subCell == SubCell.Any)
+				return WVec.Zero;
+
+			return SubCellOffsets[(int)subCell];
+		}
 
 		[FieldLoader.LoadUsing("LoadOptions")] public MapOptions Options;
 


### PR DESCRIPTION
Fixes #7813.
Fixes #7975.
