### PR TITLE
Remove RenderSprites animation keys.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderGunboat.cs
@@ -47,19 +47,19 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			left = new Animation(init.World, name, () => turret.TurretFacing);
 			left.Play(info.LeftSequence);
-			Add(info.LeftSequence, new AnimationWithOffset(left, null, () => facing.Facing > 128, 0));
+			Add(new AnimationWithOffset(left, null, () => facing.Facing > 128, 0));
 
 			right = new Animation(init.World, name, () => turret.TurretFacing);
 			right.Play(info.RightSequence);
-			Add(info.RightSequence, new AnimationWithOffset(right, null, () => facing.Facing <= 128, 0));
+			Add(new AnimationWithOffset(right, null, () => facing.Facing <= 128, 0));
 
 			var leftWake = new Animation(init.World, name);
 			leftWake.PlayRepeating(info.WakeLeftSequence);
-			Add(info.WakeLeftSequence, new AnimationWithOffset(leftWake, null, () => facing.Facing > 128, -87));
+			Add(new AnimationWithOffset(leftWake, null, () => facing.Facing > 128, -87));
 
 			var rightWake = new Animation(init.World, name);
 			rightWake.PlayRepeating(info.WakeRightSequence);
-			Add(info.WakeRightSequence, new AnimationWithOffset(rightWake, null, () => facing.Facing <= 128, -87));
+			Add(new AnimationWithOffset(rightWake, null, () => facing.Facing <= 128, -87));
 		}
 
 		public void DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var rs = self.Trait<RenderSprites>();
 			var roof = new Animation(self.World, rs.GetImage(self), () => self.Trait<IFacing>().Facing);
 			roof.Play(info.Sequence);
-			rs.Add("roof", new AnimationWithOffset(roof, null, null, 1024));
+			rs.Add(new AnimationWithOffset(roof, null, null, 1024));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
@@ -69,6 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly BibInfo info;
 		readonly RenderSprites rs;
 		readonly BuildingInfo bi;
+		readonly List<AnimationWithOffset> anims = new List<AnimationWithOffset>();
 
 		public Bib(Actor self, BibInfo info)
 		{
@@ -103,17 +104,17 @@ namespace OpenRA.Mods.Common.Traits
 				// Z-order is one set to the top of the footprint
 				var offset = self.World.Map.CenterOfCell(cell) - self.World.Map.CenterOfCell(location) - centerOffset;
 				var awo = new AnimationWithOffset(anim, () => offset, null, -(offset.Y + centerOffset.Y + 512));
-				rs.Add("bib_{0}".F(i), awo, info.Palette);
+				anims.Add(awo);
+				rs.Add(awo, info.Palette);
 			}
 		}
 
 		public void RemovedFromWorld(Actor self)
 		{
-			var width = bi.Dimensions.X;
-			var rows = info.HasMinibib ? 1 : 2;
+			foreach (var a in anims)
+				rs.Remove(a);
 
-			for (var i = 0; i < rows * width; i++)
-				rs.Remove("bib_{0}".F(i));
+			anims.Clear();
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 			var anim = new Animation(self.World, "fire", () => 0);
 			anim.IsDecoration = true;
 			anim.PlayRepeating(info.Anim);
-			self.Trait<RenderSprites>().Add("fire", anim);
+			self.Trait<RenderSprites>().Add(anim);
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 
 			DefaultAnimation = new Animation(init.World, GetImage(init.Self), baseFacing);
-			Add("", DefaultAnimation);
+			Add(DefaultAnimation);
 		}
 
 		public RenderSimple(ActorInitializer init, RenderSimpleInfo info)

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly string race;
 		readonly RenderSpritesInfo info;
-		readonly Dictionary<string, AnimationWrapper> anims = new Dictionary<string, AnimationWrapper>();
+		readonly List<AnimationWrapper> anims = new List<AnimationWrapper>();
 		string cachedImage;
 
 		public static Func<int> MakeFacingFunc(Actor self)
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void UpdatePalette()
 		{
-			foreach (var anim in anims.Values)
+			foreach (var anim in anims)
 				anim.OwnerChanged();
 		}
 
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
-			foreach (var a in anims.Values)
+			foreach (var a in anims)
 			{
 				if (!a.IsVisible)
 					continue;
@@ -177,11 +177,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual void Tick(Actor self)
 		{
-			foreach (var a in anims.Values)
+			foreach (var a in anims)
 				a.Animation.Animation.Tick();
 		}
 
-		public void Add(string key, AnimationWithOffset anim, string palette = null, bool isPlayerPalette = false)
+		public void Add(AnimationWithOffset anim, string palette = null, bool isPlayerPalette = false)
 		{
 			// Use defaults
 			if (palette == null)
@@ -190,12 +190,12 @@ namespace OpenRA.Mods.Common.Traits
 				isPlayerPalette = info.Palette == null;
 			}
 
-			anims.Add(key, new AnimationWrapper(anim, palette, isPlayerPalette));
+			anims.Add(new AnimationWrapper(anim, palette, isPlayerPalette));
 		}
 
-		public void Remove(string key)
+		public void Remove(AnimationWithOffset anim)
 		{
-			anims.Remove(key);
+			anims.RemoveAll(a => a.Animation == anim);
 		}
 
 		public static string NormalizeSequence(Animation anim, DamageState state, string sequence)
@@ -228,7 +228,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Required by RenderSimple
 		protected int2 AutoSelectionSize(Actor self)
 		{
-			return anims.Values.Where(b => b.IsVisible
+			return anims.Where(b => b.IsVisible
 				&& b.Animation.Animation.CurrentSequence != null)
 					.Select(a => (a.Animation.Animation.Image.Size * info.Scale).ToInt2())
 					.FirstOrDefault();

--- a/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			anim = new Animation(self.World, rs.GetImage(self), () => turreted.TurretFacing);
 			anim.Play(info.Sequence);
-			rs.Add("barrel_{0}".F(info.Barrel), new AnimationWithOffset(
+			rs.Add(new AnimationWithOffset(
 				anim, () => BarrelOffset(), null, () => false, p => WithTurret.ZOffsetFromCenter(self, p, 0)));
 
 			// Restrict turret facings to match the sprite

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -44,12 +44,13 @@ namespace OpenRA.Mods.Common.Traits
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 
 			overlay = new Animation(self.World, rs.GetImage(self));
+
+			var anim = new AnimationWithOffset(overlay,
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => !buildComplete);
+
 			overlay.Play(info.Sequence);
-			rs.Add("crane_overlay_{0}".F(info.Sequence),
-				new AnimationWithOffset(overlay,
-					() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-					() => !buildComplete),
-				info.Palette, info.IsPlayerPalette);
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			var images = info.XmasImages.Any() && DateTime.Today.Month == 12 ? info.XmasImages : info.Images;
 			anim = new Animation(self.World, images.Random(Game.CosmeticRandom));
 			anim.Play("idle");
-			rs.Add("crate", anim);
+			rs.Add(anim);
 		}
 
 		public void OnLanded()

--- a/OpenRA.Mods.Common/Traits/Render/WithFire.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithFire.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var fire = new Animation(self.World, rs.GetImage(self));
 			fire.PlayThen(info.StartSequence, () => fire.PlayRepeating(info.LoopSequence));
-			rs.Add("fire", new AnimationWithOffset(fire, null, null, 1024));
+			rs.Add(new AnimationWithOffset(fire, null, null, 1024));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			anim = new Animation(self.World, rs.GetImage(self), RenderSimple.MakeFacingFunc(self));
 			anim.IsDecoration = true;
 			anim.Play(info.Sequence);
-			rs.Add("harvest_{0}".F(info.Sequence), new AnimationWithOffset(anim,
+			rs.Add(new AnimationWithOffset(anim,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => !visible,
 				() => false,

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -68,13 +68,14 @@ namespace OpenRA.Mods.Common.Traits
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence));
-			rs.Add("idle_overlay_{0}".F(info.Sequence),
-				new AnimationWithOffset(overlay,
-					() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-					() => IsTraitDisabled || !buildComplete,
-					() => info.PauseOnLowPower && self.IsDisabled(),
-					p => WithTurret.ZOffsetFromCenter(self, p, 1)),
-				info.Palette, info.IsPlayerPalette);
+
+			var anim = new AnimationWithOffset(overlay,
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => IsTraitDisabled || !buildComplete,
+				() => info.PauseOnLowPower && self.IsDisabled(),
+				p => WithTurret.ZOffsetFromCenter(self, p, 1));
+
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 
 			DefaultAnimation = new Animation(init.World, rs.GetImage(self), RenderSprites.MakeFacingFunc(self));
-			rs.Add("", DefaultAnimation);
+			rs.Add(DefaultAnimation);
 
 			DefaultAnimation.PlayFetchIndex(NormalizeInfantrySequence(init.Self, info.StandSequences.Random(Game.CosmeticRandom)), () => 0);
 			state = AnimationState.Waiting;

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.TS.Traits
 			var buildingInfo = self.Info.Traits.Get<BuildingInfo>();
 
 			var offset = FootprintUtils.CenterOffset(self.World, buildingInfo).Y + 512;
-			renderSprites.Add("door_overlay_{0}".F(info.Sequence), new AnimationWithOffset(door, null, () => !buildComplete, offset));
+			renderSprites.Add(new AnimationWithOffset(door, null, () => !buildComplete, offset));
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -54,11 +54,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.PlayRepeating(info.Sequence);
-			rs.Add("production_overlay_{0}".F(info.Sequence),
-				new AnimationWithOffset(overlay,
-					() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-					() => !IsProducing || !buildComplete),
-				info.Palette, info.IsPlayerPalette);
+
+			var anim = new AnimationWithOffset(overlay,
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => !IsProducing || !buildComplete);
+
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -48,13 +48,14 @@ namespace OpenRA.Mods.Common.Traits
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);
-			rs.Add("repair_{0}".F(info.Sequence),
-				new AnimationWithOffset(overlay,
-					() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-					() => !buildComplete,
-					() => info.PauseOnLowPower && self.IsDisabled(),
-					p => WithTurret.ZOffsetFromCenter(self, p, 1)),
-				info.Palette, info.IsPlayerPalette);
+
+			var anim = new AnimationWithOffset(overlay,
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => !buildComplete,
+				() => info.PauseOnLowPower && self.IsDisabled(),
+				p => WithTurret.ZOffsetFromCenter(self, p, 1));
+
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
@@ -28,9 +28,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[Desc("Change this when using this trait multiple times on the same actor.")]
-		public readonly string Id = "rotor";
-
 		public object Create(ActorInitializer init) { return new WithRotor(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
@@ -61,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			rotorAnim = new Animation(self.World, rs.GetImage(self));
 			rotorAnim.PlayRepeating(info.Sequence);
-			rs.Add(info.Id, new AnimationWithOffset(rotorAnim,
+			rs.Add(new AnimationWithOffset(rotorAnim,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				null, () => false, p => ZOffsetFromCenter(self, p, 1)));
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithSmoke.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSmoke.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 
 			anim = new Animation(self.World, info.Sequence);
-			rs.Add("smoke", new AnimationWithOffset(anim, null, () => !isSmoking));
+			rs.Add(new AnimationWithOffset(anim, null, () => !isSmoking));
 		}
 
 		public void Damaged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			anim = new Animation(self.World, rs.GetImage(self), () => t.TurretFacing);
 			anim.Play(info.Sequence);
-			rs.Add("turret_{0}_{1}".F(info.Turret, info.Sequence), new AnimationWithOffset(
+			rs.Add(new AnimationWithOffset(
 				anim, () => TurretOffset(self), () => IsTraitDisabled, () => false, p => ZOffsetFromCenter(self, p, 1)));
 
 			// Restrict turret facings to match the sprite

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var anim = new Animation(init.World, rs.GetImage(self), () => (int)facing);
 			anim.PlayRepeating(info.Anim);
-			rs.Add(info.Anim, new AnimationWithOffset(anim, () => pos, null));
+			rs.Add(new AnimationWithOffset(anim, () => pos, null));
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -872,6 +872,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 201504277)
+					if (node.Key.StartsWith("WithRotor"))
+						node.Value.Nodes.RemoveAll(p => p.Key == "Id");
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
@@ -45,8 +45,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			overlay = new Animation(init.World, renderSprites.GetImage(init.Self));
 
-			var key = "attack_overlay_{0}".F(info.Sequence);
-			renderSprites.Add(key, new AnimationWithOffset(overlay, null, () => !attacking),
+			renderSprites.Add(new AnimationWithOffset(overlay, null, () => !attacking),
 				info.Palette, info.IsPlayerPalette);
 		}
 

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -38,16 +38,15 @@ namespace OpenRA.Mods.D2k.Traits
 			if (init.Contains<SkipMakeAnimsInit>())
 				return;
 
-			var key = "make_overlay_{0}".F(info.Sequence);
 			var rs = init.Self.Trait<RenderSprites>();
 
 			var overlay = new Animation(init.World, rs.GetImage(init.Self));
+			var anim = new AnimationWithOffset(overlay, null, () => !buildComplete);
 
 			// Remove the animation once it is complete
-			overlay.PlayThen(info.Sequence, () => init.World.AddFrameEndTask(w => rs.Remove(key)));
+			overlay.PlayThen(info.Sequence, () => init.World.AddFrameEndTask(w => rs.Remove(anim)));
 
-			rs.Add(key, new AnimationWithOffset(overlay, null, () => !buildComplete),
-				info.Palette, info.IsPlayerPalette);
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.D2k/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDockingOverlay.cs
@@ -35,9 +35,10 @@ namespace OpenRA.Mods.D2k.Traits
 
 	public class WithDockingOverlay : INotifyDocking, INotifyBuildComplete, INotifySold
 	{
-		WithDockingOverlayInfo info;
-		Animation overlay;
-		bool buildComplete, docked;
+		readonly WithDockingOverlayInfo info;
+		readonly AnimationWithOffset anim;
+		bool buildComplete;
+		bool docked;
 
 		public WithDockingOverlay(Actor self, WithDockingOverlayInfo info)
 		{
@@ -48,19 +49,20 @@ namespace OpenRA.Mods.D2k.Traits
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 
-			overlay = new Animation(self.World, rs.GetImage(self));
+			var overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);
-			rs.Add("docking_overlay_{0}".F(info.Sequence),
-				new AnimationWithOffset(overlay,
-					() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-					() => !buildComplete),
-				info.Palette, info.IsPlayerPalette);
+
+			anim = new AnimationWithOffset(overlay,
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => !buildComplete);
+
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
 		void PlayDockingOverlay()
 		{
 			if (docked)
-				overlay.PlayThen(info.Sequence, PlayDockingOverlay);
+				anim.Animation.PlayThen(info.Sequence, PlayDockingOverlay);
 		}
 
 		public void BuildingComplete(Actor self)

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -30,7 +30,6 @@ TRAN:
 		Sequence: rotor2
 		GroundSequence: slow-rotor2
 	WithRotor@SECONDARY:
-		Id: rotor_2
 		Offset: 597,0,85
 	Cargo:
 		Types: Infantry
@@ -231,7 +230,6 @@ TRAN.Husk:
 	WithRotor@PRIMARY:
 		Offset: -597,0,171
 	WithRotor@SECONDARY:
-		Id: rotor_2
 		Offset: 597,0,85
 	RenderUnit:
 		Image: tran

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -210,7 +210,6 @@ TRAN:
 		Sequence: rotor2
 		GroundSequence: slow-rotor2
 	WithRotor@SECONDARY:
-		Id: rotor_2
 		Offset: 597,0,213
 	Cargo:
 		Types: Infantry

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -94,7 +94,6 @@ TRAN.Husk:
 	WithRotor@PRIMARY:
 		Offset: -597,0,341
 	WithRotor@SECONDARY:
-		Id: rotor_2
 		Offset: 597,0,213
 	RevealsShroud:
 		Range: 12c0


### PR DESCRIPTION
The code that previously required these was removed ages ago, and they now just cause problems (duplicate key exceptions when adding multiple traits).  Conflicts with several existing prs.
