### PR TITLE
Fix an issue in EnemyWatcher.cs

### DIFF
--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -802,7 +802,6 @@ Rules:
 		MissionObjectives:
 			EarlyGameOver: true
 		EnemyWatcher:
-			NotificationInterval: 25
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy


### PR DESCRIPTION
Previously the first scan could only occur after 750 ticks and was blocked
for another 750 ticks after a notification played.
