### PR TITLE
Fixed the offsets for Tiberian Sun transformable units

### DIFF
--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -193,8 +193,7 @@ GATICK:
 	WithVoxelTurret:
 	Transforms:
 		IntoActor: ttnk
-		Offset: 1,1
-		Facing: 96
+		Facing: 159
 		TransformSounds: place2.aud
 		NoTransformSounds:
 	WithMuzzleFlash:
@@ -237,7 +236,6 @@ GAARTY:
 	WithVoxelTurret:
 	Transforms:
 		IntoActor: art2
-		Offset: 1,1
 		Facing: 96
 		TransformSounds: place2.aud
 		NoTransformSounds:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -231,6 +231,7 @@ GAARTY:
 	DrawLineToTarget:
 	RenderBuilding:
 	RenderVoxels:
+		LightAmbientColor: 0.4, 0.4, 0.4
 	WithVoxelBarrel:
 		LocalOffset: 0,0,-512
 	WithVoxelTurret:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -132,6 +132,7 @@ ART2:
 		Range: 9c0
 	RenderSprites:
 	RenderVoxels:
+		LightAmbientColor: 0.4, 0.4, 0.4
 	WithVoxelBody:
 	Transforms:
 		IntoActor: gaarty

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -107,8 +107,7 @@ TTNK:
 	WithVoxelBody:
 	Transforms:
 		IntoActor: gatick
-		Offset: -1,-1
-		Facing: 96
+		Facing: 159
 		TransformSounds: place2.aud
 		NoTransformSounds:
 
@@ -136,7 +135,6 @@ ART2:
 	WithVoxelBody:
 	Transforms:
 		IntoActor: gaarty
-		Offset: -1,-1
 		Facing: 96
 		TransformSounds:
 		NoTransformSounds:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -14,8 +14,7 @@ GADPSA:
 		Range: 8c0
 	Transforms:
 		IntoActor: lpst
-		Offset: 1,1
-		Facing: 96
+		Facing: 159
 		TransformSounds: place2.aud
 		NoTransformSounds:
 	RenderDetectionCircle:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -109,8 +109,7 @@ LPST:
 	WithVoxelBody:
 	Transforms:
 		IntoActor: gadpsa
-		Offset: -1,-1
-		Facing: 96
+		Facing: 159
 		TransformSounds:
 		NoTransformSounds:
 


### PR DESCRIPTION
Fixes #5906 though it seems already fixed as the issue is old. We just used incorrect offset values here as far as I see it. Those may have worked around isometric perspective problems in the past. I don't remember. Anyway, this tweaks them.

Also for some reason the lightning of the artillery voxel is quite different compared to http://cnc.wikia.com/wiki/Artillery_(Tiberian_Sun) and the sprite so I essentially did the opposite of https://github.com/Phrohdoh/oramod-ra2/pull/56/ to fix it.
