### PR TITLE
Made sure spice blooms are drawn below harvesters

### DIFF
--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -322,14 +322,15 @@ spicebloom:
 	make: DATA.R8
 		Start: 107
 		Length: 3
+		ZOffset: -1023
 		Offset: -16,-16
 	active: DATA.R8
 		Start: 109
-		ZOffset: -511
+		ZOffset: -1023
 		Offset: -16,-16
 	idle: DATA.R8
 		Start: 109
-		ZOffset: -511
+		ZOffset: -1023
 		Offset: -16,-16
 
 moveflsh:


### PR DESCRIPTION
Increased negative ZOffset to a full cell, this should fix that harvesters (and other larger actors) are drawn below the bloom art when moving around the upper half of the bloom.
