### PR TITLE
Clean up state properly when a Carryall's cargo has died

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -146,8 +146,7 @@ namespace OpenRA.Mods.D2k.Traits
 				Carrying = null;
 			}
 
-			IsBusy = false;
-			Carrying = null;
+			CarryableReleased();
 		}
 
 		// INotifyKilled


### PR DESCRIPTION
Fixes #8006.

To elaborate a bit, the [`PickupUnit` activity checks the health of the cargo and calls `Carryall::UnreserveCarryable` if it's dead](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.D2k/Activities/PickupUnit.cs#L49), so that would be the right place to unset `anim`.
