### PR TITLE
Move prone-related logic from DamageWarhead to TakeCover

### DIFF
--- a/OpenRA.Game/GameRules/DamageWarhead.cs
+++ b/OpenRA.Game/GameRules/DamageWarhead.cs
@@ -18,17 +18,14 @@ namespace OpenRA.GameRules
 {
 	public abstract class DamageWarhead : Warhead
 	{
-		[Desc("How much (raw) damage to deal")]
+		[Desc("How much (raw) damage to deal.")]
 		public readonly int Damage = 0;
 
-		[Desc("Infantry death animation to use")]
+		[Desc("Types of damage that this warhead causes. Leave empty for no damage.")]
+		public readonly string[] DamageTypes = new string[0];
+
+		[Desc("Infantry death animation to use.")]
 		public readonly string DeathType = "1";
-
-		[Desc("Whether we should prevent prone response for infantry.")]
-		public readonly bool PreventProne = false;
-
-		[Desc("By what percentage should damage be modified against prone infantry.")]
-		public readonly int ProneModifier = 50;
 
 		[FieldLoader.LoadUsing("LoadVersus")]
 		[Desc("Damage percentage versus each armortype. 0% = can't target.")]

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -855,6 +855,23 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20150426)
+				{
+					// Add DamageModifiers to TakeCover with a "Prone50Percent" default
+					// Add ProneTriggers to TakeCover with a "TriggerProne" default
+					if (node.Key == "TakeCover")
+					{
+						var percent = new MiniYamlNode("Prone50Percent", "50");
+						var dictionary = new MiniYamlNode("DamageModifiers", "");
+						dictionary.Value.Nodes.Add(percent);
+
+						if (node.Value.Nodes.All(x => x.Key != "DamageModifiers"))
+							node.Value.Nodes.Add(dictionary);
+
+						node.Value.Nodes.Add(new MiniYamlNode("DamageTriggers", "TriggerProne"));
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -554,6 +554,7 @@ Weapons:
 			Versus:
 				Heavy: 50
 			Damage: 50
+			DamageTypes: Prone50Percent, TriggerProne
 
 Voices:
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -182,6 +182,9 @@
 		TargetTypes: Ground, Infantry
 	TakeCover:
 		SpeedModifier: 60
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	RenderSprites:
 	WithInfantryBody:
 	WithDeathAnimation:

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -3,6 +3,7 @@ FlametankExplode:
 		Spread: 1c0
 		Damage: 100
 		DeathType: 5
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: big_napalm
 		ImpactSound: xplobig6.aud
@@ -12,6 +13,7 @@ HeliCrash:
 		Spread: 426
 		Damage: 40
 		DeathType: 4
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: poof
 		ImpactSound: xplos.aud
@@ -34,6 +36,7 @@ UnitExplode:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: poof
 		ImpactSound: xplobig6.aud
@@ -48,6 +51,7 @@ UnitExplodeSmall:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: big_frag
 		ImpactSound: xplobig4.aud
@@ -62,6 +66,7 @@ GrenadierExplode:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: poof
 		ImpactSound: xplosml2.aud
@@ -78,6 +83,7 @@ Napalm.Crate:
 			Light: 60
 			Heavy: 25
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect

--- a/mods/cnc/weapons/largecaliber.yaml
+++ b/mods/cnc/weapons/largecaliber.yaml
@@ -15,6 +15,7 @@
 			Light: 100
 			Heavy: 100
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -37,6 +38,7 @@
 			Wood: 75
 			Light: 75
 			Heavy: 100
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -60,6 +62,7 @@
 			Light: 100
 			Heavy: 100
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -85,6 +88,7 @@
 			Light: 100
 			Heavy: 100
 			Concrete: 100
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -107,6 +111,7 @@ TurretGun:
 			Wood: 25
 			Light: 100
 			Heavy: 100
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -134,6 +139,7 @@ ArtilleryShell:
 			Wood: 80
 			Light: 75
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -25,6 +25,7 @@ Rockets:
 			Light: 100
 			Heavy: 100
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -59,6 +60,7 @@ BikeRockets:
 			Light: 100
 			Heavy: 100
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -93,6 +95,7 @@ OrcaAGMissiles:
 			Wood: 100
 			Light: 100
 			Heavy: 75
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -125,6 +128,7 @@ OrcaAAMissiles:
 		Versus:
 			Light: 75
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -158,6 +162,7 @@ MammothMissiles:
 			Wood: 75
 			Light: 100
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -198,6 +203,7 @@ MammothMissiles:
 			Wood: 60
 			Light: 100
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -231,6 +237,7 @@ MammothMissiles:
 			Wood: 75
 			Light: 100
 			Heavy: 90
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -262,6 +269,7 @@ BoatMissile:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -298,6 +306,7 @@ TowerMissle:
 			Wood: 25
 			Light: 100
 			Heavy: 100
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -328,6 +337,7 @@ SAMMissile:
 			Heavy: 75
 		DeathType: 4
 		Damage: 30
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -357,6 +367,7 @@ HonestJohn:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -388,6 +399,7 @@ Patriot:
 			Heavy: 75
 		DeathType: 4
 		Damage: 32
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -15,6 +15,7 @@ Flamethrower:
 			Wood: 100
 			Light: 100
 			Heavy: 20
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -40,6 +41,7 @@ BigFlamer:
 			Wood: 100
 			Light: 67
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -61,6 +63,7 @@ Chemspray:
 			Wood: 35
 			Light: 75
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -86,6 +89,7 @@ Grenade:
 			Wood: 50
 			Light: 75
 			Heavy: 35
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -111,6 +115,7 @@ Napalm:
 			Wood: 100
 			Light: 100
 			Heavy: 80
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -131,6 +136,7 @@ Laser:
 		DeathType: 5
 		Versus:
 			Wood: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 
@@ -140,7 +146,6 @@ Tiberium:
 		Spread: 42
 		Damage: 2
 		DeathType: 6
-		PreventProne: yes
 
 TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage
@@ -152,6 +157,7 @@ TiberiumExplosion:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res: CreateResource
 		AddsResourceType: Tiberium
 		Size: 1,1
@@ -164,7 +170,6 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: -1
-		PreventProne: yes
 
 Tail:
 	ReloadDelay: 30
@@ -181,6 +186,7 @@ Tail:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 
 Horn:
 	ReloadDelay: 20
@@ -197,6 +203,7 @@ Horn:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 
 Teeth:
 	ReloadDelay: 30
@@ -213,6 +220,7 @@ Teeth:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 
 Claw:
 	ReloadDelay: 10
@@ -229,6 +237,7 @@ Claw:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 
 Demolish:
 	Warhead@1Dam: SpreadDamage

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -10,6 +10,7 @@ Sniper:
 		Damage: 100
 		DeathType: 2
 		ValidTargets: Infantry
+		DamageTypes: Prone50Percent, TriggerProne
 
 HighV:
 	ReloadDelay: 25
@@ -26,6 +27,7 @@ HighV:
 			Wood: 50
 			Light: 70
 			Heavy: 35
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -50,6 +52,7 @@ HeliAGGun:
 			Wood: 50
 			Light: 75
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -74,6 +77,7 @@ HeliAAGun:
 			Wood: 50
 			Light: 50
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -94,6 +98,7 @@ Pistol:
 			Wood: 50
 			Light: 50
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 
@@ -114,6 +119,7 @@ M16:
 			Wood: 25
 			Light: 30
 			Heavy: 10
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 
@@ -136,6 +142,7 @@ MachineGun:
 			Light: 50
 			Heavy: 20
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -156,6 +163,7 @@ Vulcan:
 			Wood: 25
 			Light: 100
 			Heavy: 35
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -175,6 +183,7 @@ APCGun:
 			Wood: 50
 			Light: 100
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_poof
 
@@ -192,6 +201,7 @@ APCGun.AA:
 		ValidTargets: Air
 		Versus:
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_frag
 

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -12,6 +12,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff_impact: CreateEffect
 		Explosion: nuke_explosion
 		ImpactSound: nukexplo.aud
@@ -27,6 +28,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@4Res_areanukea: DestroyResource
 		Size: 3
 		Delay: 3
@@ -49,6 +51,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@8Res_areanukeb: DestroyResource
 		Size: 4
 		Delay: 6
@@ -68,6 +71,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@11Res_areanukec: DestroyResource
 		Size: 5
 		Delay: 9
@@ -84,6 +88,7 @@ IonCannon:
 		Falloff: 1000, 1000, 250, 100
 		DeathType: 5
 		ValidTargets: Ground, Air
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Smu_area: LeaveSmudge

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -192,6 +192,9 @@
 	RenderSprites:
 	WithInfantryBody:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithDeathAnimation:
 	AutoTarget:
 	AttackMove:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -18,6 +18,9 @@ rifle:
 		Weapon: LMG
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	AttractsWorms:
 		Intensity: 120
 
@@ -72,6 +75,9 @@ bazooka:
 		LocalOffset: 128,0,256
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	AttractsWorms:
 		Intensity: 180
 
@@ -136,6 +142,9 @@ fremen:
 		Weapon: Slung
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 250
@@ -166,6 +175,9 @@ grenadier:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle
 	Explodes:
@@ -195,6 +207,9 @@ sardaukar:
 	RevealsShroud:
 		Range: 6c0
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	Armament@PRIMARY:
 		Weapon: Vulcan
 	Armament@SECONDARY:

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -17,6 +17,7 @@ LMG:
 			Light: 40
 			Heavy: 10
 			Concrete: 20
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -46,6 +47,7 @@ Bazooka:
 			Light: 60
 			Heavy: 90
 			Concrete: 40
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -72,6 +74,7 @@ Sniper:
 			Light: 1
 			Heavy: 0
 			Concrete: 0
+		DamageTypes: Prone50Percent, TriggerProne
 
 Vulcan:
 	ReloadDelay: 30
@@ -94,6 +97,7 @@ Vulcan:
 			Light: 60
 			Heavy: 10
 			Concrete: 0
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -121,6 +125,7 @@ Slung:
 			Light: 40
 			Heavy: 90
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_explosion
 		ImpactSound: EXPLLG5.WAV
@@ -146,6 +151,7 @@ HMG:
 			Light: 45
 			Heavy: 20
 			Concrete: 20
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -170,6 +176,7 @@ HMGo:
 			Light: 45
 			Heavy: 25
 			Concrete: 20
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -200,6 +207,7 @@ QuadRockets:
 			Light: 100
 			Heavy: 100
 			Concrete: 35
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -225,6 +233,7 @@ TurretGun:
 			Wood: 75
 			Light: 100
 			Concrete: 65
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -259,6 +268,7 @@ TowerMissile:
 			Light: 100
 			Heavy: 50
 			Concrete: 35
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -282,6 +292,7 @@ TowerMissile:
 			Wood: 50
 			Light: 100
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -305,6 +316,7 @@ TowerMissile:
 			Wood: 50
 			Light: 100
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -328,6 +340,7 @@ DevBullet:
 			Light: 100
 			Heavy: 100
 			Concrete: 80
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -361,6 +374,7 @@ DevBullet:
 			Light: 100
 			Heavy: 50
 			Concrete: 80
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -390,6 +404,7 @@ NerveGasMissile:
 			None: 0
 			Wood: 0
 			Concrete: 0
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -424,6 +439,7 @@ NerveGasMissile:
 			Light: 75
 			Heavy: 50
 			Concrete: 100
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -448,6 +464,7 @@ Sound:
 			Wood: 85
 			Light: 80
 			Concrete: 75
+		DamageTypes: Prone50Percent, TriggerProne
 
 ChainGun:
 	ReloadDelay: 10
@@ -466,6 +483,7 @@ ChainGun:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -512,6 +530,7 @@ ParaBomb:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -534,6 +553,7 @@ Napalm:
 			Light: 30
 			Heavy: 20
 			Concrete: 70
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -564,6 +584,7 @@ Atomic:
 			Light: 100
 			Heavy: 50
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: nuke
 		ImpactSound: EXPLLG2.WAV
@@ -581,6 +602,7 @@ CrateNuke:
 			Heavy: 25
 			Concrete: 50
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: nuke
 		ImpactSound: EXPLLG2.WAV
@@ -597,6 +619,7 @@ CrateExplosion:
 			Light: 60
 			Heavy: 25
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: EXPLSML4.WAV
@@ -612,6 +635,7 @@ UnitExplode:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: EXPLMD1.WAV
@@ -626,6 +650,7 @@ UnitExplodeSmall:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: self_destruct
 		ImpactSound: EXPLHG1.WAV, EXPLLG1.WAV, EXPLMD1.WAV, EXPLSML4.WAV
@@ -640,6 +665,7 @@ UnitExplodeTiny:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: EXPLMD2.WAV, EXPLSML1.WAV, EXPLSML2.WAV, EXPLSML3.WAV
@@ -654,6 +680,7 @@ UnitExplodeScale:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: EXPLLG2.WAV, EXPLLG3.WAV, EXPLLG5.WAV
@@ -677,6 +704,7 @@ Grenade:
 			Wood: 100
 			Light: 25
 			Heavy: 5
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 	Warhead@3Eff: CreateEffect
@@ -707,6 +735,7 @@ Shrapnel:
 			Wood: 100
 			Light: 25
 			Heavy: 5
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 	Warhead@3Eff: CreateEffect
@@ -723,6 +752,7 @@ SpiceExplosion:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res: CreateResource
 		AddsResourceType: Spice
 		Size: 2,2

--- a/mods/ra/maps/allies-01/map.yaml
+++ b/mods/ra/maps/allies-01/map.yaml
@@ -562,6 +562,7 @@ Weapons:
 		Burst: 1
 		Warhead: SpreadDamage
 			Damage: 20
+			DamageTypes: Prone50Percent, TriggerProne
 
 Voices:
 

--- a/mods/ra/maps/allies-02/map.yaml
+++ b/mods/ra/maps/allies-02/map.yaml
@@ -840,6 +840,7 @@ Weapons:
 		Burst: 1
 		Warhead: SpreadDamage
 			Damage: 20
+			DamageTypes: Prone50Percent, TriggerProne
 
 Voices:
 

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1812,6 +1812,7 @@ Weapons:
 				Light: 0
 				Heavy: 0
 				Concrete: 0
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Eff: CreateEffect
 			Explosion: piffs
 			InvalidImpactTypes: Water

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -364,6 +364,7 @@ Weapons:
 			Spread: 42
 			DeathType: 5
 			Damage: 80
+			DamageTypes: Prone50Percent, TriggerProne
 
 Voices:
 

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -296,6 +296,7 @@ Weapons:
 				Heavy: 25
 			DeathType: 2
 			Damage: 250
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@1Eff: CreateEffect
 			Explosion: large_explosion
 			WaterExplosion: large_splash
@@ -324,6 +325,7 @@ Weapons:
 				Heavy: 30
 			DeathType: blownaway
 			Damage: 400
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@1Eff: CreateEffect
 			Explosion: large_explosion
 			WaterExplosion: large_splash

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -259,6 +259,7 @@ Weapons:
 			Spread: 42
 			DeathType: 5
 			Damage: 80
+			DamageTypes: Prone50Percent, TriggerProne
 
 Voices:
 

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -759,6 +759,7 @@ Weapons:
 				Concrete: 100
 			DeathType: 4
 			Damage: 150
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -793,6 +794,7 @@ Weapons:
 				Concrete: 200
 			DeathType: 3
 			Damage: 250
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -822,6 +824,7 @@ Weapons:
 				Concrete: 100
 			DeathType: 4
 			Damage: 15
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
 		Warhead@3Eff: CreateEffect
@@ -843,6 +846,7 @@ Weapons:
 				Concrete: 25
 			DeathType: 5
 			Damage: 200
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -873,6 +877,7 @@ Weapons:
 				Concrete: 35
 			DeathType: 5
 			Damage: 10
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
 		Warhead@3Eff: CreateEffect
@@ -897,6 +902,7 @@ Weapons:
 				Heavy: 40
 				Concrete: 30
 			Damage: 25
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
 		Warhead@3Eff: CreateEffect
@@ -925,6 +931,7 @@ Weapons:
 				Heavy: 70
 			DeathType: 3
 			Damage: 500
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -947,6 +954,7 @@ Weapons:
 				Concrete: 0
 			DeathType: 2
 			Damage: 150
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Eff: CreateEffect
 			Explosion: piffs
 

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2403,6 +2403,7 @@ Weapons:
 	Maverick:
 		Warhead@1Dam: SpreadDamage
 			Damage: 175
+			DamageTypes: Prone50Percent, TriggerProne
 
 Voices:
 

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2380,6 +2380,7 @@ Weapons:
 				Wood: 75
 				Light: 75
 				Concrete: 50
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3EffGround: CreateEffect

--- a/mods/ra/maps/survival02/map.yaml
+++ b/mods/ra/maps/survival02/map.yaml
@@ -1172,6 +1172,7 @@ Weapons:
 				Light: 60
 				Heavy: 50
 				Concrete: 25
+			DamageTypes: Prone50Percent, TriggerProne
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -54,6 +54,9 @@ E1:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -86,6 +89,9 @@ E2:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -122,6 +128,9 @@ E3:
 		Weapon: Dragon
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -153,6 +162,9 @@ E4:
 		Weapon: Flamer
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -183,6 +195,9 @@ E6:
 	ExternalCaptures:
 		Type: building
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -214,6 +229,9 @@ SPY:
 	Passenger:
 		PipType: Yellow
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	Disguise:
 	Infiltrates:
 		Types: SpyInfiltrate
@@ -275,6 +293,9 @@ E7:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 	AnnounceOnBuild:
@@ -310,6 +331,9 @@ MEDI:
 		Cursor: heal
 		OutsideRangeCursor: heal
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -347,6 +371,9 @@ MECH:
 	Captures:
 		CaptureTypes: husk
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -427,6 +454,9 @@ THF:
 	Infiltrates:
 		InfiltrateTypes: Cash
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	-AutoTarget:
 
 HIJACKER:
@@ -485,6 +515,9 @@ SHOK:
 		Weapon: PortaTesla
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -521,6 +554,9 @@ SNIPER:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -10,6 +10,7 @@ CrateNapalm:
 			Heavy: 25
 			Concrete: 50
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -28,6 +29,7 @@ CrateExplosion:
 			Light: 60
 			Heavy: 25
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: self_destruct
 		ImpactSound: kaboom15.aud
@@ -42,6 +44,7 @@ CrateNuke:
 		Versus:
 			Concrete: 25
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res_impact: DestroyResource
 	Warhead@3Eff_impact: CreateEffect
 		Explosion: nuke
@@ -56,6 +59,7 @@ CrateNuke:
 		Versus:
 			Concrete: 25
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@5Res_areanuke: DestroyResource
 		Size: 5,4
 		Delay: 4
@@ -78,6 +82,7 @@ MiniNuke:
 		Versus:
 			Concrete: 25
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res_impact: DestroyResource
 		Size: 1
 	Warhead@3Eff_impact: CreateEffect
@@ -92,6 +97,7 @@ MiniNuke:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@5Res_areanuke1: DestroyResource
 		Size: 2
 		Delay: 5
@@ -107,6 +113,7 @@ MiniNuke:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@8Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -119,6 +126,7 @@ MiniNuke:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@10Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15
@@ -138,6 +146,7 @@ UnitExplode:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: self_destruct
 		ImpactSound: kaboom22.aud
@@ -157,6 +166,7 @@ UnitExplodeShip:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: kaboom25.aud
@@ -171,6 +181,7 @@ UnitExplodeSubmarine:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_splash
 		ImpactSound: splash9.aud
@@ -185,6 +196,7 @@ UnitExplodeSmall:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: kaboom15.aud
@@ -207,6 +219,7 @@ BarrelExplode:
 			Light: 50
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 		Size: 2,1
@@ -221,6 +234,7 @@ ATMine:
 		Spread: 256
 		Damage: 400
 		AffectsParent: true
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: mineblo1.aud
@@ -231,6 +245,7 @@ APMine:
 		Damage: 400
 		AffectsParent: true
 		DeathType: 3
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: napalm
 		ImpactSound: mine1.aud
@@ -245,6 +260,7 @@ OreExplosion:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res: CreateResource
 		AddsResourceType: Ore
 		Size: 1,1

--- a/mods/ra/weapons/largecaliber.yaml
+++ b/mods/ra/weapons/largecaliber.yaml
@@ -14,6 +14,7 @@
 			Wood: 40
 			Heavy: 40
 			Concrete: 30
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -39,6 +40,7 @@
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -68,6 +70,7 @@
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -98,6 +101,7 @@
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -125,6 +129,7 @@ TurretGun:
 			Wood: 50
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -158,6 +163,7 @@ TurretGun:
 			Light: 60
 			Heavy: 25
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -191,6 +197,7 @@ TurretGun:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -218,6 +225,7 @@ TurretGun:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -25,6 +25,7 @@ Maverick:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -62,6 +63,7 @@ Dragon:
 			Wood: 75
 			Light: 35
 			Concrete: 20
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -100,6 +102,7 @@ HellfireAG:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -138,6 +141,7 @@ HellfireAA:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -174,6 +178,7 @@ MammothTusk:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -213,6 +218,7 @@ Nike:
 			Light: 90
 			Heavy: 50
 			Concrete: 0
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -242,6 +248,7 @@ RedEye:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -270,6 +277,7 @@ SubMissile:
 			None: 40
 			Light: 30
 			Heavy: 30
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -306,6 +314,7 @@ Stinger:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -346,6 +355,7 @@ StingerAA:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -387,6 +397,7 @@ TorpTube:
 			Wood: 75
 			Light: 75
 			Concrete: 500
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -426,6 +437,7 @@ SCUD:
 			Wood: 75
 			Light: 70
 			Heavy: 40
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -462,6 +474,7 @@ APTusk:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -17,6 +17,7 @@ FireballLauncher:
 			Light: 60
 			Heavy: 25
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -44,6 +45,7 @@ Flamer:
 			Light: 60
 			Heavy: 25
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -66,6 +68,7 @@ Napalm:
 			Light: 60
 			Heavy: 25
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -96,6 +99,7 @@ Grenade:
 			Wood: 100
 			Light: 25
 			Heavy: 5
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -150,6 +154,7 @@ TeslaZap:
 		Versus:
 			None: 1000
 			Wood: 60
+		DamageTypes: Prone50Percent, TriggerProne
 
 PortaTesla:
 	ReloadDelay: 70
@@ -163,6 +168,7 @@ PortaTesla:
 		DeathType: 6
 		Versus:
 			None: 1000
+		DamageTypes: Prone50Percent, TriggerProne
 
 TTankZap:
 	ReloadDelay: 120
@@ -176,6 +182,7 @@ TTankZap:
 		DeathType: 6
 		Versus:
 			None: 1000
+		DamageTypes: Prone50Percent, TriggerProne
 
 DogJaw:
 	ValidTargets: Infantry
@@ -231,6 +238,7 @@ Repair:
 Crush:
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		ImpactSound: squishy2.aud
 
@@ -255,6 +263,7 @@ Claw:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 
 Mandible:
 	ReloadDelay: 10
@@ -271,6 +280,7 @@ Mandible:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 
 MADTankThump:
 	InvalidTargets: MADTank

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -14,6 +14,7 @@ Colt45:
 			Light: 0
 			Heavy: 0
 			Concrete: 0
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 		InvalidImpactTypes: Water
@@ -40,6 +41,7 @@ ZSU-23:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_explosion_air
 
@@ -59,6 +61,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff_1: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -76,6 +79,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@4Eff_2: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -95,6 +99,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@6Eff_3: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -114,6 +119,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@8Eff_4: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -133,6 +139,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@10Eff_5: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -152,6 +159,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@12Eff_6: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -179,6 +187,7 @@ ChainGun:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -203,6 +212,7 @@ ChainGun.Yak:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -225,6 +235,7 @@ Pistol:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 		InvalidImpactTypes: Water
@@ -247,6 +258,7 @@ M1Carbine:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -270,6 +282,7 @@ M60mg:
 			Light: 30
 			Heavy: 10
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -292,6 +305,7 @@ SilencedPPK:
 			Light: 0
 			Heavy: 0
 			Concrete: 0
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -317,6 +331,7 @@ FLAK-23:
 			Light: 60
 			Heavy: 10
 			Concrete: 20
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_explosion
 		InvalidImpactTypes: Air, AirHit, Water
@@ -343,4 +358,5 @@ Sniper:
 			Light: 0
 			Heavy: 0
 			Concrete: 0
+		DamageTypes: Prone50Percent, TriggerProne
 

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -16,6 +16,7 @@ ParaBomb:
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -37,6 +38,7 @@ Atomic:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res_impact: DestroyResource
 		Size: 1
 	Warhead@3Smu_impact: LeaveSmudge
@@ -54,6 +56,7 @@ Atomic:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@6Res_areanuke1: DestroyResource
 		Size: 2
 		Delay: 5
@@ -73,6 +76,7 @@ Atomic:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@10Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -89,6 +93,7 @@ Atomic:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@13Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15
@@ -105,6 +110,7 @@ Atomic:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@16Res_areanuke4: DestroyResource
 		Size: 5
 		Delay: 20

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -19,6 +19,13 @@ WEEDGUY:
 	AttackFrontal:
 	WithInfantryBody:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 
 UMAGON:
 	Inherits: ^Infantry
@@ -42,6 +49,13 @@ UMAGON:
 		Weapon: Sniper
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -62,6 +76,13 @@ CHAMSPY:
 		Range: 9c0
 	Passenger:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	Disguise:
 	Infiltrates:
 		Types: SpyInfiltrate
@@ -91,6 +112,13 @@ MUTANT:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -115,6 +143,13 @@ MWMN:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -139,6 +174,13 @@ MUTANT3:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -160,6 +202,13 @@ TRATOS:
 	RevealsShroud:
 		Range: 4c0
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -180,6 +229,13 @@ OXANNA:
 	RevealsShroud:
 		Range: 4c0
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -200,6 +256,13 @@ SLAV:
 	RevealsShroud:
 		Range: 4c0
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -310,3 +373,4 @@ CIV3:
 	Armament:
 		Weapon: Pistola
 	AttackFrontal:
+

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -21,6 +21,13 @@ E2:
 		FireDelay: 5
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -48,6 +55,13 @@ MEDIC:
 		Weapon: Heal
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		AttackSequence: heal
@@ -84,6 +98,13 @@ JUMPJET:
 	-Crushable:
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 
 GHOST:
@@ -119,5 +140,13 @@ GHOST:
 	C4Demolition:
 		C4Delay: 45
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
+

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -21,6 +21,13 @@ E3:
 		LocalOffset: 128,0,640
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -54,6 +61,13 @@ CYBORG:
 		Weapon: Vulcan3
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -89,6 +103,13 @@ CYC2:
 		LocalOffset: 170,85,683
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -118,5 +139,13 @@ MHIJACK:
 		Range: 6c0
 	-AutoTarget:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
+

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -26,6 +26,13 @@ E1:
 		UpgradeMinEnabledLevel: 1
 	AttackFrontal:
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -57,4 +64,12 @@ ENGINEER:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	-GainsExperience:
+

--- a/mods/ts/weapons/bombsandgrenades.yaml
+++ b/mods/ts/weapons/bombsandgrenades.yaml
@@ -12,13 +12,13 @@ Grenade:
 		Spread: 171
 		Damage: 40
 		DeathType: 3
-		ProneModifier: 70
 		Versus:
 			None: 100
 			Wood: 85
 			Light: 70
 			Heavy: 35
 			Concrete: 28
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_grey_explosion
 		ImpactSound: expnew13.aud
@@ -44,13 +44,13 @@ Bomb:
 		Spread: 298
 		Damage: 160
 		DeathType: 3
-		ProneModifier: 100
 		Versus:
 			None: 200
 			Wood: 90
 			Light: 75
 			Heavy: 32
 			Concrete: 100
+		DamageTypes: Prone100Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew09.aud
@@ -77,13 +77,13 @@ RPGTower:
 		Spread: 128
 		Damage: 110
 		DeathType: 2
-		ProneModifier: 70
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 90
 			Heavy: 100
 			Concrete: 70
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_clsn
 		ImpactSound: expnew14.aud
@@ -94,3 +94,4 @@ RPGTower:
 		ValidImpactTypes: Water
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
+

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -11,13 +11,13 @@ LtRail:
 		Spread: 42
 		Damage: 150
 		DeathType: 2
-		ProneModifier: 100
 		Versus:
 			None: 100
 			Wood: 130
 			Light: 150
 			Heavy: 110
 			Concrete: 5
+		DamageTypes: Prone100Percent, TriggerProne
 
 MechRailgun:
 	ReloadDelay: 60
@@ -32,13 +32,13 @@ MechRailgun:
 		Spread: 42
 		Damage: 200
 		DeathType: 5
-		ProneModifier: 100
 		Versus:
 			None: 200
 			Wood: 175
 			Light: 160
 			Heavy: 100
 			Concrete: 25
+		DamageTypes: Prone100Percent, TriggerProne
 
 SonicZap:
 	ReloadDelay: 120
@@ -56,6 +56,7 @@ SonicZap:
 		Versus:
 			Heavy: 80
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 
 CyCannon:
 	ReloadDelay: 50
@@ -72,7 +73,6 @@ CyCannon:
 		Spread: 43
 		Damage: 120
 		DeathType: 6
-		ProneModifier: 350
 		ValidTargets: Ground
 		Versus:
 			None: 350
@@ -80,6 +80,7 @@ CyCannon:
 			Light: 205
 			Heavy: 150
 			Concrete: 80
+		DamageTypes: Prone350Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_bang
 		ImpactSound: expnew12.aud
@@ -116,6 +117,7 @@ Proton:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_bang
 		ImpactSound: expnew12.aud
@@ -137,7 +139,7 @@ LaserFire:
 		Spread: 42
 		Damage: 250
 		DeathType: 5
-		ProneModifier: 60
+		DamageTypes: Prone60Percent, TriggerProne
 
 # Laser turret
 LaserFire2:
@@ -151,4 +153,5 @@ LaserFire2:
 		Spread: 42
 		Damage: 30
 		DeathType: 5
-		ProneModifier: 60
+		DamageTypes: Prone60Percent, TriggerProne
+

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -9,6 +9,7 @@ UnitExplode:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_twlt
 		ImpactSound: expnew09.aud
@@ -23,6 +24,7 @@ UnitExplodeSmall:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: medium_brnl
 		ImpactSound: expnew13.aud
@@ -37,9 +39,11 @@ TiberiumExplosion:
 			Wood: 75
 			Light: 60
 			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res: CreateResource
 		AddsResourceType: Tiberium
 		Size: 1,1
 	Warhead@3Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew09.aud
+

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -8,7 +8,6 @@ Heal:
 		Spread: 213
 		Damage: -50
 		DeathType: 1
-		ProneModifier: 100
 		Versus:
 			Wood: 0
 			Light: 0
@@ -25,7 +24,6 @@ Repair:
 		Spread: 213
 		Damage: -50
 		DeathType: 1
-		ProneModifier: 100
 		Versus:
 			None: 0
 			Wood: 0
@@ -39,4 +37,4 @@ TiberiumHeal:
 		Spread: 42
 		Damage: -2
 		DeathType: 6
-		PreventProne: yes
+

--- a/mods/ts/weapons/largeguns.yaml
+++ b/mods/ts/weapons/largeguns.yaml
@@ -18,6 +18,7 @@
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: medium_clsn
 		ImpactSound: expnew14.aud
@@ -45,6 +46,7 @@
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_clsn
 		ImpactSound: expnew14.aud
@@ -78,6 +80,7 @@
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: medium_clsn
 		ImpactSound: expnew14.aud
@@ -105,13 +108,13 @@
 		Spread: 298
 		Damage: 150
 		DeathType: 3
-		ProneModifier: 100
 		Versus:
 			None: 100
 			Wood: 85
 			Light: 68
 			Heavy: 35
 			Concrete: 35
+		DamageTypes: Prone100Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew06.aud
@@ -122,3 +125,4 @@
 		ValidImpactTypes: Water
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
+

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -25,6 +25,7 @@ Bazooka:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -68,6 +69,7 @@ HoverMissile:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -103,7 +105,6 @@ MammothTusk:
 		Spread: 171
 		Damage: 40
 		DeathType: 3
-		ProneModifier: 70
 		ValidTargets: Air
 		Versus:
 			None: 100
@@ -149,6 +150,7 @@ BikeMissile:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -188,6 +190,7 @@ Dragon:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -231,6 +234,7 @@ Hellfire:
 			Light: 150
 			Heavy: 100
 			Concrete: 30
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: small_bang
 		ImpactSound: expnew12.aud
@@ -270,3 +274,4 @@ RedEye2:
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
+

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -12,13 +12,13 @@ FireballLauncher:
 		Spread: 341
 		Damage: 25
 		DeathType: 5
-		ProneModifier: 100
 		Versus:
 			None: 600
 			Wood: 148
 			Light: 59
 			Heavy: 6
 			Concrete: 2
+		DamageTypes: Prone100Percent, TriggerProne
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SmallScorch
 
@@ -37,11 +37,11 @@ FiendShard:
 	Warhead@1Dam: SpreadDamage
 		Damage: 35
 		DeathType: 1
-		ProneModifier: 100
 		Versus:
 			Light: 60
 			Heavy: 40
 			Concrete: 20
+		DamageTypes: Prone100Percent, TriggerProne
 	Warhead@3EffWater: CreateEffect
 		Explosion: small_watersplash
 		ImpactSound: ssplash3.aud
@@ -56,11 +56,11 @@ SlimeAttack:
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
 		DeathType: 2
-		ProneModifier: 100
 		Versus:
 			Light: 60
 			Heavy: 40
 			Concrete: 20
+		DamageTypes: Prone100Percent, TriggerProne
 
 Tiberium:
 	ReloadDelay: 16
@@ -68,4 +68,4 @@ Tiberium:
 		Spread: 42
 		Damage: 2
 		DeathType: 6
-		PreventProne: yes
+

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -8,12 +8,12 @@ Minigun:
 		Spread: 128
 		Damage: 8
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -31,12 +31,12 @@ M1Carbine:
 		Spread: 128
 		Damage: 15
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -54,12 +54,12 @@ Vulcan:
 		Spread: 128
 		Damage: 20
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -78,13 +78,13 @@ Vulcan2:
 		Spread: 128
 		Damage: 50
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			None: 100
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -103,12 +103,12 @@ Vulcan3:
 		Spread: 128
 		Damage: 10
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -131,6 +131,7 @@ VulcanTower:
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -149,12 +150,12 @@ JumpCannon:
 		Spread: 128
 		Damage: 15
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -172,12 +173,12 @@ AssaultCannon:
 		Spread: 128
 		Damage: 40
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -197,12 +198,12 @@ RaiderCannon:
 		Spread: 128
 		Damage: 40
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -221,13 +222,13 @@ HarpyClaw:
 		Spread: 128
 		Damage: 60
 		DeathType: 1
-		ProneModifier: 70
 		ValidTargets: Ground, Air
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -245,12 +246,12 @@ Pistola:
 		Spread: 128
 		Damage: 2
 		DeathType: 1
-		ProneModifier: 70
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
+		DamageTypes: Prone70Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 		InvalidImpactTypes: Water
@@ -268,10 +269,11 @@ Sniper:
 		Spread: 42
 		Damage: 150
 		DeathType: 1
-		ProneModifier: 100
 		Versus:
 			None: 100
 			Wood: 5
 			Light: 5
 			Heavy: 5
 			Concrete: 5
+		DamageTypes: Prone100Percent, TriggerProne
+

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -24,6 +24,7 @@ MultiCluster:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew09.aud
@@ -49,6 +50,7 @@ SuicideBomb:
 			Light: 60
 			Heavy: 25
 			Concrete: 50
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@2Res: DestroyResource
 
 IonCannon:
@@ -58,8 +60,8 @@ IonCannon:
 		Damage: 100
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		DeathType: 5
-		ProneModifier: 100
 		ValidTargets: Ground, Air
+		DamageTypes: Prone100Percent, TriggerProne
 	Warhead@2Eff_impact: CreateEffect
 		Explosion: ionring
 		ImpactSound: ion1.aud
@@ -70,6 +72,7 @@ IonCannon:
 		DeathType: 5
 		Delay: 3
 		ValidTargets: Ground, Air
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@4Smu_area: LeaveSmudge
 		SmudgeType: SmallScorch
 		Size: 2,1
@@ -91,7 +94,6 @@ EMPulseCannon:
 	Warhead@target: SpreadDamage
 		Spread: 0
 		Damage: 0
-		PreventProne: true
 		ValidTargets: Vehicle
 	Warhead@emp: GrantUpgrade
 		Range: 3c0
@@ -109,6 +111,7 @@ ClusterMissile:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@SoundEffect0: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew19.aud
@@ -126,6 +129,7 @@ ClusterMissile:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@ResourceDestruction1: DestroyResource
 		Size: 2
 		Delay: 5
@@ -142,6 +146,7 @@ ClusterMissile:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@ResourceDestruction2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -158,6 +163,7 @@ ClusterMissile:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@ResourceDestruction3: DestroyResource
 		Size: 4
 		Delay: 15
@@ -174,6 +180,7 @@ ClusterMissile:
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
+		DamageTypes: Prone50Percent, TriggerProne
 	Warhead@ResourceDestruction4: DestroyResource
 		Size: 5
 		Delay: 20
@@ -181,3 +188,4 @@ ClusterMissile:
 		SmudgeType: SmallScorch
 		Size: 5
 		Delay: 20
+


### PR DESCRIPTION
This is some random logic cleanup. The "prone" state in infantry-specific logic, which is handled by the `TakeCover` trait. Warheads should know nothing of it. Especially while they are in the engine.
The `DamageTypes` property of `DamageWarhead` can be used for interaction with other traits in the future. First thing that comes to mind are shields.

This is hopefully the first step to cleaning up the warhead code a bit.
Sorry for the big PR, but it's 90% YAML, so it's not as scary as it looks ;)
