### PR TITLE
Add sandworm attack sound

### DIFF
--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("The number of ticks it takes to get in place under the target to attack.")]
 		public readonly int AttackTime = 30;
 
+		public readonly string WormAttackSound = "Worm.wav";
 		public readonly string WormAttackNotification = "WormAttack";
 
 		public override object Create(ActorInitializer init) { return new AttackSwallow(init.Self, this); }

--- a/mods/d2k/audio/voices.yaml
+++ b/mods/d2k/audio/voices.yaml
@@ -100,9 +100,3 @@ SaboteurVoice:
 		Guard: I_GUARD
 	DisablePrefixes: Select, Move, Die
 	DisableVariants: Select, Move, Guard
-
-WormVoice:
-	DefaultVariant: .WAV
-	Voices:
-		Select: WRMSIGN1
-		Move: WORM

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -506,7 +506,6 @@ Heal:
 WormJaw:
 	ReloadDelay: 10
 	Range: 3c0
-	Report: WORM.WAV
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Damage: 100


### PR DESCRIPTION
Removes a few unused lines of YAML and adds the worm sound.
May be worth delaying the player notifications by a second; it would probably sound better.

This is also the simplest thing on my Next+1 feature wishlist.
