### PR TITLE
Fixed "building online" played by power off and vice versa on Tiberian Sun

### DIFF
--- a/mods/ts/audio/sounds-generic.yaml
+++ b/mods/ts/audio/sounds-generic.yaml
@@ -13,8 +13,8 @@ Sounds:
 		ChatLine: message1
 		ClickDisabledSound: wrong1
 		ClickSound: clicky1
-		DisablePower: 00-i230
-		EnablePower: 00-i232
+		DisablePower: 00-i232
+		EnablePower: 00-i230
 		GameForming: gamefrm1
 		Gdiclose: gdiclose
 		Gdiopen: gdiopen


### PR DESCRIPTION
Building offline/online have been twisted. A regression from https://github.com/OpenRA/OpenRA/pull/7854.
