### PR TITLE
Some chrome logic cleanups

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -143,8 +143,8 @@ namespace OpenRA.Widgets
 		public string Y = "0";
 		public string Width = "0";
 		public string Height = "0";
-		public string Logic = null;
-		public object LogicObject { get; private set; }
+		public string[] Logic = { };
+		public object[] LogicObjects { get; private set; }
 		public bool Visible = true;
 		public bool IgnoreMouseOver;
 		public bool IgnoreChildMouseOver;
@@ -232,12 +232,13 @@ namespace OpenRA.Widgets
 
 		public void PostInit(WidgetArgs args)
 		{
-			if (Logic == null)
+			if (!Logic.Any())
 				return;
 
 			args["widget"] = this;
 
-			LogicObject = Game.ModData.ObjectCreator.CreateObject<object>(Logic, args);
+			LogicObjects = Logic.Select(l => Game.ModData.ObjectCreator.CreateObject<object>(l, args))
+				.ToArray();
 
 			args.Remove("widget");
 		}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -624,6 +624,7 @@
     <Compile Include="Graphics\TilesetSpecificSpriteSequence.cs" />
     <Compile Include="Traits\Pluggable.cs" />
     <Compile Include="Traits\Plug.cs" />
+    <Compile Include="Widgets\Logic\Ingame\MenuButtonsChromeLogic.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -625,6 +625,7 @@
     <Compile Include="Traits\Pluggable.cs" />
     <Compile Include="Traits\Plug.cs" />
     <Compile Include="Widgets\Logic\Ingame\MenuButtonsChromeLogic.cs" />
+    <Compile Include="Widgets\Logic\Ingame\LoadIngamePerfLogic.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
@@ -1,0 +1,24 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class LoadIngamePerfLogic
+	{
+		[ObjectCreator.UseCtor]
+		public LoadIngamePerfLogic(Widget widget, World world)
+		{
+			var perfRoot = widget.Get("PERF_ROOT");
+			Game.LoadWidget(world, "PERF_WIDGETS", perfRoot, new WidgetArgs());
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -1,0 +1,125 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class MenuButtonsChromeLogic
+	{
+		readonly World world;
+		readonly Widget worldRoot;
+		readonly Widget menuRoot;
+		bool disableSystemButtons;
+		Widget currentWidget;
+
+		[ObjectCreator.UseCtor]
+		public MenuButtonsChromeLogic(Widget widget, World world)
+		{
+			this.world = world;
+
+			worldRoot = Ui.Root.Get("WORLD_ROOT");
+			menuRoot = Ui.Root.Get("MENU_ROOT");
+
+			Action removeCurrentWidget = () => menuRoot.RemoveChild(currentWidget);
+			world.GameOver += removeCurrentWidget;
+
+			// System buttons
+			var options = widget.GetOrNull<MenuButtonWidget>("OPTIONS_BUTTON");
+			if (options != null)
+			{
+				var blinking = false;
+				var lp = world.LocalPlayer;
+				options.IsDisabled = () => disableSystemButtons;
+				options.OnClick = () =>
+				{
+					blinking = false;
+					OpenMenuPanel(options, new WidgetArgs()
+					{
+						{ "activePanel", IngameInfoPanel.AutoSelect }
+					});
+				};
+				options.IsHighlighted = () => blinking && Game.LocalTick % 50 < 25;
+
+				if (lp != null)
+				{
+					Action<Player> startBlinking = player =>
+					{
+						if (player == world.LocalPlayer)
+							blinking = true;
+					};
+
+					var mo = lp.PlayerActor.TraitOrDefault<MissionObjectives>();
+
+					if (mo != null)
+						mo.ObjectiveAdded += startBlinking;
+				}
+			}
+
+			var diplomacy = widget.GetOrNull<MenuButtonWidget>("DIPLOMACY_BUTTON");
+			if (diplomacy != null)
+			{
+				diplomacy.Visible = !world.Map.Visibility.HasFlag(MapVisibility.MissionSelector) && world.Players.Any(a => a != world.LocalPlayer && !a.NonCombatant);
+				diplomacy.IsDisabled = () => disableSystemButtons;
+				diplomacy.OnClick = () => OpenMenuPanel(diplomacy);
+			}
+
+			var debug = widget.GetOrNull<MenuButtonWidget>("DEBUG_BUTTON");
+			if (debug != null)
+			{
+				debug.IsVisible = () => world.LobbyInfo.GlobalSettings.AllowCheats;
+				debug.IsDisabled = () => disableSystemButtons;
+				debug.OnClick = () => OpenMenuPanel(debug, new WidgetArgs()
+				{
+					{ "activePanel", IngameInfoPanel.Debug }
+				});
+			}
+
+			var stats = widget.GetOrNull<MenuButtonWidget>("OBSERVER_STATS_BUTTON");
+			if (stats != null)
+			{
+				stats.IsDisabled = () => disableSystemButtons;
+				stats.OnClick = () => OpenMenuPanel(stats);
+			}
+		}
+
+		void OpenMenuPanel(MenuButtonWidget button, WidgetArgs widgetArgs = null)
+		{
+			disableSystemButtons = true;
+			var cachedPause = world.PredictedPaused;
+
+			if (button.HideIngameUI)
+				worldRoot.IsVisible = () => false;
+
+			if (button.Pause && world.LobbyInfo.IsSinglePlayer)
+				world.SetPauseState(true);
+
+			widgetArgs = widgetArgs ?? new WidgetArgs();
+			widgetArgs.Add("onExit", () =>
+			{
+				if (button.HideIngameUI)
+					worldRoot.IsVisible = () => true;
+
+				if (button.Pause && world.LobbyInfo.IsSinglePlayer)
+					world.SetPauseState(cachedPause);
+
+				menuRoot.RemoveChild(currentWidget);
+				disableSystemButtons = false;
+			});
+
+			currentWidget = Game.LoadWidget(world, button.MenuContainer, menuRoot, widgetArgs);
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -2,6 +2,7 @@ Container@INGAME_ROOT:
 	Logic: LoadIngamePlayerOrObserverUILogic
 	Children:
 		Container@WORLD_ROOT:
+			Logic: LoadIngamePerfLogic
 			Children:
 				LogicTicker@DISCONNECT_WATCHER:
 					Logic: DisconnectWatcherLogic
@@ -27,28 +28,7 @@ Container@INGAME_ROOT:
 				StrategicProgress@STRATEGIC_PROGRESS:
 					X: WINDOW_RIGHT/2
 					Y: 40
-				Container@PERFORMANCE_INFO:
-					Logic: PerfDebugLogic
-					Children:
-						Label@PERF_TEXT:
-							X: WINDOW_RIGHT - 200
-							Y: WINDOW_BOTTOM - 70
-							Width: 170
-							Height: 40
-							Contrast: true
-							VAlign: Top
-						Background@GRAPH_BG:
-							X: 10
-							Y: WINDOW_BOTTOM-HEIGHT-10
-							Width: 220
-							Height: 220
-							Background: panel-black
-							Children:
-								PerfGraph@GRAPH:
-									X: 10
-									Y: 10
-									Width: 200
-									Height: 200
+				Container@PERF_ROOT:
 				WorldInteractionController@INTERACTION_CONTROLLER:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
@@ -59,6 +39,29 @@ Container@INGAME_ROOT:
 				Container@PLAYER_ROOT:
 		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
+
+Container@PERF_WIDGETS:
+	Logic: PerfDebugLogic
+	Children:
+		Label@PERF_TEXT:
+			X: WINDOW_RIGHT - 200
+			Y: WINDOW_BOTTOM - 70
+			Width: 170
+			Height: 40
+			Contrast: true
+			VAlign: Top
+		Background@GRAPH_BG:
+			X: 10
+			Y: WINDOW_BOTTOM-HEIGHT-10
+			Width: 220
+			Height: 220
+			Background: panel-black
+			Children:
+				PerfGraph@GRAPH:
+					X: 10
+					Y: 10
+					Width: 200
+					Height: 200
 
 Container@OBSERVER_WIDGETS:
 	Logic: MenuButtonsChromeLogic

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -61,7 +61,7 @@ Container@INGAME_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Container@OBSERVER_WIDGETS:
-	Logic: OrderButtonsChromeLogic
+	Logic: MenuButtonsChromeLogic
 	Children:
 		MenuButton@OPTIONS_BUTTON:
 			Key: escape
@@ -237,7 +237,7 @@ Container@PLAYER_WIDGETS:
 					ReadyText: Ready
 					HoldText: On Hold
 		Background@SIDEBAR_BACKGROUND:
-			Logic: OrderButtonsChromeLogic
+			Logic: MenuButtonsChromeLogic
 			X: WINDOW_RIGHT - 204
 			Y: 30
 			Width: 194
@@ -260,6 +260,7 @@ Container@PLAYER_WIDGETS:
 							ImageCollection: order-icons
 							ImageName: options
 				Button@BEACON_BUTTON:
+					Logic: BeaconOrderButtonLogic
 					X: 62
 					Y: 0-24
 					Width: 30
@@ -273,6 +274,7 @@ Container@PLAYER_WIDGETS:
 							Y: 5
 							ImageCollection: order-icons
 				Button@SELL_BUTTON:
+					Logic: SellOrderButtonLogic
 					X: 102
 					Y: 0-24
 					Width: 30
@@ -286,6 +288,7 @@ Container@PLAYER_WIDGETS:
 							Y: 5
 							ImageCollection: order-icons
 				Button@REPAIR_BUTTON:
+					Logic: RepairOrderButtonLogic
 					X: 142
 					Y: 0-24
 					Width: 30

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -1,16 +1,13 @@
 Container@OBSERVER_WIDGETS:
+	Logic: MenuButtonsChromeLogic
 	Children:
 		MenuButton@OPTIONS_BUTTON:
-			Logic: OrderButtonsChromeLogic
-			X: 0
-			Y: 0
 			Width: 160
 			Height: 25
 			Text: Options (Esc)
 			Font: Bold
 			Key: escape
 		MenuButton@OBSERVER_STATS_BUTTON:
-			Logic: OrderButtonsChromeLogic
 			MenuContainer: INGAME_OBSERVERSTATS_BG
 			HideIngameUI: False
 			Pause: False

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -34,7 +34,7 @@ Container@PLAYER_WIDGETS:
 			ClickThrough: false
 			Children:
 				Container@TOP_BUTTONS:
-					Logic: OrderButtonsChromeLogic
+					Logic: MenuButtonsChromeLogic
 					X: 16
 					Y: 236
 					Children:
@@ -54,6 +54,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: order-icons
 									ImageName: debug
 						Button@REPAIR_BUTTON:
+							Logic: RepairOrderButtonLogic
 							X: 29
 							Width: 34
 							Height: 35
@@ -67,6 +68,7 @@ Container@PLAYER_WIDGETS:
 									Y: 0
 									ImageCollection: order-icons
 						Button@SELL_BUTTON:
+							Logic: SellOrderButtonLogic
 							X: 54
 							Width: 34
 							Height: 35
@@ -80,6 +82,7 @@ Container@PLAYER_WIDGETS:
 									Y: 0
 									ImageCollection: order-icons
 						Button@BEACON_BUTTON:
+							Logic: BeaconOrderButtonLogic
 							X: 108
 							Width: 36
 							Height: 35
@@ -94,6 +97,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: order-icons
 
 						Button@POWER_BUTTON:
+							Logic: PowerdownOrderButtonLogic
 							X: 133
 							Width: 36
 							Height: 35

--- a/mods/d2k/chrome/ingame.yaml
+++ b/mods/d2k/chrome/ingame.yaml
@@ -2,23 +2,18 @@ Container@INGAME_ROOT:
 	Logic: LoadIngamePlayerOrObserverUILogic
 	Children:
 		Container@WORLD_ROOT:
+			Logic: LoadIngamePerfLogic
 			Children:
 				LogicTicker@DISCONNECT_WATCHER:
 					Logic: DisconnectWatcherLogic
 				WorldInteractionController@INTERACTION_CONTROLLER:
-					X: 0
-					Y: 0
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 				ViewportController:
-					X: 0
-					Y: 0
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 					TooltipContainer: TOOLTIP_CONTAINER
 				WorldCommand:
-					X: 0
-					Y: 0
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 				StrategicProgress@STRATEGIC_PROGRESS:
@@ -29,28 +24,7 @@ Container@INGAME_ROOT:
 					Y: 34
 					Order: Descending
 				Container@PLAYER_ROOT:
-				Container@PERFORMANCE_INFO:
-					Logic: PerfDebugLogic
-					Children:
-						Label@PERF_TEXT:
-							X: WINDOW_RIGHT - 200
-							Y: WINDOW_BOTTOM - 70
-							Width: 170
-							Height: 40
-							Contrast: true
-						Background@GRAPH_BG:
-							ClickThrough: true
-							Background: dialog4
-							X: 30
-							Y: WINDOW_BOTTOM - 240
-							Width: 210
-							Height: 210
-							Children:
-								PerfGraph@GRAPH:
-									X: 5
-									Y: 5
-									Width: 200
-									Height: 200
+				Container@PERF_ROOT:
 				Container@GAME_TIMER_BLOCK:
 					Logic: GameTimerLogic
 					X: WINDOW_RIGHT/2 - WIDTH

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -76,6 +76,7 @@ ChromeLayout:
 	./mods/d2k/chrome/ingame-observer.yaml
 	./mods/ra/chrome/ingame-observerstats.yaml
 	./mods/d2k/chrome/ingame-player.yaml
+	./mods/ra/chrome/ingame-perf.yaml
 	./mods/ra/chrome/ingame-debug.yaml
 	./mods/d2k/chrome/ingame-leavemap.yaml
 	./mods/d2k/chrome/mainmenu.yaml

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -31,7 +31,7 @@ Container@OBSERVER_WIDGETS:
 							Align: Right
 							Font: TinyBold
 				Container@TOP_BUTTONS:
-					Logic: OrderButtonsChromeLogic
+					Logic: MenuButtonsChromeLogic
 					X: 9
 					Y: 7
 					Children:

--- a/mods/ra/chrome/ingame-perf.yaml
+++ b/mods/ra/chrome/ingame-perf.yaml
@@ -1,0 +1,22 @@
+Container@PERF_WIDGETS:
+	Logic: PerfDebugLogic
+	Children:
+		Label@PERF_TEXT:
+			X: WINDOW_RIGHT - 200
+			Y: WINDOW_BOTTOM - 70
+			Width: 170
+			Height: 40
+			Contrast: true
+		Background@GRAPH_BG:
+			ClickThrough: true
+			Background: dialog4
+			X: 30
+			Y: WINDOW_BOTTOM - 240
+			Width: 210
+			Height: 210
+			Children:
+				PerfGraph@GRAPH:
+					X: 5
+					Y: 5
+					Width: 200
+					Height: 200

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -36,12 +36,12 @@ Container@PLAYER_WIDGETS:
 			ClickThrough: false
 			Children:
 				Container@TOP_BUTTONS:
-					Logic: OrderButtonsChromeLogic
+					Logic: MenuButtonsChromeLogic
 					X: 9
 					Y: 7
 					Children:
 						Button@BEACON_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: BeaconOrderButtonLogic, AddRaceSuffixLogic
 							Width: 28
 							Height: 28
 							Background: sidebar-button
@@ -54,7 +54,7 @@ Container@PLAYER_WIDGETS:
 									Y: 6
 									ImageCollection: order-icons
 						Button@SELL_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: SellOrderButtonLogic, AddRaceSuffixLogic
 							X: 32
 							Width: 28
 							Height: 28
@@ -68,7 +68,7 @@ Container@PLAYER_WIDGETS:
 									Y: 6
 									ImageCollection: order-icons
 						Button@POWER_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: PowerdownOrderButtonLogic, AddRaceSuffixLogic
 							X: 64
 							Width: 28
 							Height: 28
@@ -82,7 +82,7 @@ Container@PLAYER_WIDGETS:
 									Y: 6
 									ImageCollection: order-icons
 						Button@REPAIR_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: RepairOrderButtonLogic, AddRaceSuffixLogic
 							X: 96
 							Width: 28
 							Height: 28

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -2,23 +2,18 @@ Container@INGAME_ROOT:
 	Logic: LoadIngamePlayerOrObserverUILogic
 	Children:
 		Container@WORLD_ROOT:
+			Logic: LoadIngamePerfLogic
 			Children:
 				LogicTicker@DISCONNECT_WATCHER:
 					Logic: DisconnectWatcherLogic
 				WorldInteractionController@INTERACTION_CONTROLLER:
-					X: 0
-					Y: 0
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 				ViewportController:
-					X: 0
-					Y: 0
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 					TooltipContainer: TOOLTIP_CONTAINER
 				WorldCommand:
-					X: 0
-					Y: 0
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 				StrategicProgress@STRATEGIC_PROGRESS:
@@ -29,27 +24,6 @@ Container@INGAME_ROOT:
 					Y: 10
 					Order: Descending
 				Container@PLAYER_ROOT:
-				Container@PERFORMANCE_INFO:
-					Logic: PerfDebugLogic
-					Children:
-						Label@PERF_TEXT:
-							X: WINDOW_RIGHT - 200
-							Y: WINDOW_BOTTOM - 70
-							Width: 170
-							Height: 40
-							Contrast: true
-						Background@GRAPH_BG:
-							ClickThrough: true
-							Background: dialog4
-							X: 30
-							Y: WINDOW_BOTTOM - 240
-							Width: 210
-							Height: 210
-							Children:
-								PerfGraph@GRAPH:
-									X: 5
-									Y: 5
-									Width: 200
-									Height: 200
+				Container@PERF_ROOT:
 		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -91,6 +91,7 @@ ChromeLayout:
 	./mods/ra/chrome/ingame-observer.yaml
 	./mods/ra/chrome/ingame-observerstats.yaml
 	./mods/ra/chrome/ingame-player.yaml
+	./mods/ra/chrome/ingame-perf.yaml
 	./mods/ra/chrome/ingame-debug.yaml
 	./mods/ra/chrome/mainmenu.yaml
 	./mods/ra/chrome/settings.yaml

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -36,7 +36,7 @@ Container@PLAYER_WIDGETS:
 			ClickThrough: false
 			Children:
 				Container@TOP_BUTTONS:
-					Logic: OrderButtonsChromeLogic
+					Logic: MenuButtonsChromeLogic
 					X: 0
 					Y: 21
 					Children:
@@ -58,7 +58,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: order-icons
 									ImageName: debug
 						Button@REPAIR_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: RepairOrderButtonLogic, AddRaceSuffixLogic
 							X: 43
 							Width: 30
 							Height: 31
@@ -73,7 +73,7 @@ Container@PLAYER_WIDGETS:
 									Y: 0
 									ImageCollection: order-icons
 						Button@SELL_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: SellOrderButtonLogic, AddRaceSuffixLogic
 							X: 73
 							Width: 30
 							Height: 31
@@ -88,7 +88,7 @@ Container@PLAYER_WIDGETS:
 									Y: 0
 									ImageCollection: order-icons
 						Button@BEACON_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: BeaconOrderButtonLogic, AddRaceSuffixLogic
 							X: 103
 							Width: 30
 							Height: 31
@@ -103,7 +103,7 @@ Container@PLAYER_WIDGETS:
 									Y: 0
 									ImageCollection: order-icons
 						Button@POWER_BUTTON:
-							Logic: AddRaceSuffixLogic
+							Logic: PowerdownOrderButtonLogic, AddRaceSuffixLogic
 							X: 133
 							Width: 30
 							Height: 31

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -144,6 +144,7 @@ ChromeLayout:
 	./mods/d2k/chrome/ingame-observer.yaml
 	./mods/ra/chrome/ingame-observerstats.yaml
 	./mods/ts/chrome/ingame-player.yaml
+	./mods/ra/chrome/ingame-perf.yaml
 	./mods/ra/chrome/ingame-debug.yaml
 	./mods/ra/chrome/ingame-leavemap.yaml
 	./mods/ra/chrome/mainmenu.yaml


### PR DESCRIPTION
Some cleanups in preparation for the new map editor:
- Allow a widget to define multiple Logic objects.
- Split the order button logics from the menu opening logic.
- Separate the ingame perf graphs into their own trees.
