### PR TITLE
Use WithProductionDoorOverlay on fake weap

### DIFF
--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -39,8 +39,8 @@ WEAF:
 	Bib:
 	RenderBuilding:
 		Image: WEAP
-	WithIdleOverlay@ROOF:
-		Sequence: idle-top
+	WithProductionDoorOverlay:
+		Sequence: build-top
 	Valued:
 		Cost: 200
 


### PR DESCRIPTION
At current bleed trying to place a fake weap crashes the game.
