### PR TITLE
Fix missing infantry in the legacy editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSimple.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RenderSimpleInfo : RenderSpritesInfo, IRenderActorPreviewSpritesInfo, IQuantizeBodyOrientationInfo, ILegacyEditorRenderInfo, Requires<IBodyOrientationInfo>
+	public class RenderSimpleInfo : RenderSpritesInfo, IRenderActorPreviewSpritesInfo, IQuantizeBodyOrientationInfo, Requires<IBodyOrientationInfo>
 	{
 		public readonly string Sequence = "idle";
 
@@ -36,9 +36,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return sequenceProvider.GetSequence(GetImage(ai, sequenceProvider, race), Sequence).Facings;
 		}
-
-		public string EditorPalette { get { return Palette; } }
-		public string EditorImage(ActorInfo actor, SequenceProvider sequenceProvider, string race) { return GetImage(actor, sequenceProvider, race); }
 	}
 
 	public class RenderSimple : RenderSprites, IAutoSelectionSize

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p);
 	}
 
-	public class RenderSpritesInfo : IRenderActorPreviewInfo, ITraitInfo
+	public class RenderSpritesInfo : IRenderActorPreviewInfo, ITraitInfo, ILegacyEditorRenderInfo
 	{
 		[Desc("The sequence name that defines the actor sprites. Defaults to the actor name.")]
 		public readonly string Image = null;
@@ -83,6 +83,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			return (Image ?? actor.Name).ToLowerInvariant();
 		}
+
+		public string EditorPalette { get { return Palette; } }
+		public string EditorImage(ActorInfo actor, SequenceProvider sequenceProvider, string race) { return GetImage(actor, sequenceProvider, race); }
 	}
 
 	public class RenderSprites : IRender, ITick, INotifyOwnerChanged, INotifyEffectiveOwnerChanged


### PR DESCRIPTION
The editor is looking for actor types that implement ILegacyEditorRender, but infantry units don't anymore since #7638.

This moves ILegacyEditorRender to the root of the Render\* inheritance tree, so that all actor types have access to it.
