### PR TITLE
Updated Travis CI configuration to enforce Mono 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # see travis-ci.org for details
 
 language: csharp
+mono: 3.12.0
 
 # Use the Docker-based infrastructure
 sudo: false


### PR DESCRIPTION
as advised in https://github.com/travis-ci/travis-ci/issues/3776 so our builds stop erroring.
