### PR TITLE
Improve rendering performance

### DIFF
--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -178,6 +178,11 @@ namespace OpenRA.Graphics
 
 		public Size Resolution { get { return Device.WindowSize; } }
 
+		public IVertexBuffer<Vertex> CreateVertexBuffer(int length)
+		{
+			return Device.CreateVertexBuffer(length);
+		}
+
 		internal IVertexBuffer<Vertex> GetTempVertexBuffer()
 		{
 			return tempBuffers.Peek();

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -97,14 +97,27 @@ namespace OpenRA.Graphics
 
 		public Bitmap AsBitmap()
 		{
-			var d = GetData();
+			var data = GetData();
 			var dataStride = 4 * Size.Width;
 			var bitmap = new Bitmap(Size.Width, Size.Height);
+
+			var copy = (byte[])data.Clone();
+			for (var i = 0; i < copy.Length; i += 4)
+			{
+				var b = copy[i + 0];
+				var g = copy[i + 1];
+				var r = copy[i + 2];
+				var a = copy[i + 3];
+				copy[i + 0] = a;
+				copy[i + 1] = r;
+				copy[i + 2] = g;
+				copy[i + 3] = b;
+			}
 
 			var bd = bitmap.LockBits(bitmap.Bounds(),
 				ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
 			for (var y = 0; y < Size.Height; y++)
-				Marshal.Copy(d, y * dataStride, IntPtr.Add(bd.Scan0, y * bd.Stride), dataStride);
+				Marshal.Copy(copy, y * dataStride, IntPtr.Add(bd.Scan0, y * bd.Stride), dataStride);
 			bitmap.UnlockBits(bd);
 
 			return bitmap;

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -42,13 +42,21 @@ namespace OpenRA.Graphics
 
 		public static Sheet AllocateSheet(int sheetSize)
 		{
-			return new Sheet(new Size(sheetSize, sheetSize));
+			return AllocateSheet(new Size(sheetSize, sheetSize));
+		}
+
+		public static Sheet AllocateSheet(Size sheetSize)
+		{
+			return new Sheet(sheetSize);
 		}
 
 		public SheetBuilder(SheetType t)
 			: this(t, Game.Settings.Graphics.SheetSize) { }
 
 		public SheetBuilder(SheetType t, int sheetSize)
+			: this(t, () => AllocateSheet(sheetSize)) { }
+
+		public SheetBuilder(SheetType t, Size sheetSize)
 			: this(t, () => AllocateSheet(sheetSize)) { }
 
 		public SheetBuilder(SheetType t, Func<Sheet> allocateSheet)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -103,10 +103,10 @@ namespace OpenRA.Graphics
 			nv += 4;
 		}
 
-		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, Sheet sheet)
+		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, Sheet sheet, BlendMode blendMode)
 		{
 			shader.SetTexture("DiffuseTexture", sheet.GetTexture());
-			renderer.Device.SetBlendMode(BlendMode.Alpha);
+			renderer.Device.SetBlendMode(blendMode);
 			shader.Render(() => renderer.DrawBatch(buffer, start, length, type));
 			renderer.Device.SetBlendMode(BlendMode.None);
 		}

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Graphics
 
 			Game.Renderer.WorldSpriteRenderer.DrawVertexBuffer(
 				vertexBuffer, rowStride * firstRow, rowStride * (lastRow - firstRow),
-				PrimitiveType.QuadList, wr.Theater.Sheet);
+				PrimitiveType.QuadList, wr.Theater.Sheet, BlendMode.Alpha);
 
 			foreach (var r in wr.World.WorldActor.TraitsImplementing<IRenderOverlay>())
 				r.Render(wr);

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -21,6 +21,11 @@ namespace OpenRA.Graphics
 		static readonly int[] ChannelMasks = { 2, 1, 0, 3 };
 		static readonly float[] ChannelSelect = { 0.75f, 0.25f, -0.25f, -0.75f };
 
+		public static void FastCreateQuad(Vertex[] vertices, float2 loc, Sprite r, PaletteReference pr, int nv)
+		{
+			FastCreateQuad(vertices, loc + r.FractionalOffset * r.Size, r, pr.TextureIndex, nv, r.Size);
+		}
+
 		public static void FastCreateQuad(Vertex[] vertices, float2 o, Sprite r, float paletteTextureIndex, int nv, float2 size)
 		{
 			var b = new float2(o.X + size.X, o.Y);

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -25,7 +25,7 @@ namespace OpenRA
 
 		public override int GetHashCode() { return U.GetHashCode() ^ V.GetHashCode(); }
 
-		public bool Equals(MPos other) { return other == this; }
+		public bool Equals(MPos other) { return U == other.U && V == other.V; }
 		public override bool Equals(object obj) { return obj is MPos && Equals((MPos)obj); }
 
 		public MPos Clamp(Rectangle r)

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -81,7 +81,11 @@ namespace OpenRA
 
 		public bool Contains(CPos cell)
 		{
-			var uv = cell.ToMPos(shape);
+			return Contains(cell.ToMPos(shape));
+		}
+
+		public bool Contains(MPos uv)
+		{
 			return uv.U >= mapTopLeft.U && uv.U <= mapBottomRight.U && uv.V >= mapTopLeft.V && uv.V <= mapBottomRight.V;
 		}
 

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Player.cs" />
     <Compile Include="Primitives\MergedStream.cs" />
     <Compile Include="Primitives\SpatiallyPartitioned.cs" />
+    <Compile Include="Primitives\VertexCache.cs" />
     <Compile Include="Selection.cs" />
     <Compile Include="Server\Connection.cs" />
     <Compile Include="Server\Exts.cs" />

--- a/OpenRA.Game/Primitives/VertexCache.cs
+++ b/OpenRA.Game/Primitives/VertexCache.cs
@@ -1,0 +1,75 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+
+namespace OpenRA.Primitives
+{
+	public sealed class VertexCache
+	{
+		readonly HashSet<MPos> valid = new HashSet<MPos>();
+		readonly Map map;
+		readonly int mapWidth;
+		readonly Vertex[] vertices;
+
+		public VertexCache(Map map)
+		{
+			this.map = map;
+			var size = map.MapSize;
+			mapWidth = size.X;
+			vertices = new Vertex[4 * size.X * size.Y];
+		}
+
+		public void Invalidate(CPos cell)
+		{
+			Invalidate(cell.ToMPos(map));
+		}
+
+		public void Invalidate(IEnumerable<CPos> cells)
+		{
+			Invalidate(cells.Select(cell => cell.ToMPos(map)));
+		}
+
+		public void Invalidate(MPos uv)
+		{
+			valid.Remove(uv);
+		}
+
+		public void Invalidate(IEnumerable<MPos> uvs)
+		{
+			valid.ExceptWith(uvs);
+		}
+
+		int ArrayOffset(MPos uv)
+		{
+			return uv.V * mapWidth + uv.U;
+		}
+
+		int VertexArrayOffset(MPos uv)
+		{
+			return 4 * ArrayOffset(uv);
+		}
+
+		public void RenderCenteredOverCell(WorldRenderer wr, Sprite sprite, PaletteReference pal, MPos uv)
+		{
+			var offset = VertexArrayOffset(uv);
+			if (valid.Add(uv))
+			{
+				// TODO: Need to account for ZOffset (-511)
+				var location = wr.ScreenPosition(map.CenterOfCell(uv.ToCPos(map))) - 0.5f * sprite.Size;
+				Util.FastCreateQuad(vertices, location, sprite, pal, offset);
+			}
+
+			Game.Renderer.WorldSpriteRenderer.DrawSprite(sprite, vertices, offset);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -365,11 +365,8 @@ namespace OpenRA.Mods.Common.Traits
 			var sprite = GetSprite(sprites, edges, tileInfo.Variant);
 			if (sprite != null)
 			{
-				var size = sprite.Size;
-				var location = tileInfo.ScreenPosition - 0.5f * size;
-				OpenRA.Graphics.Util.FastCreateQuad(
-					vertices, location + sprite.FractionalOffset * size,
-					sprite, palette.TextureIndex, offset, size);
+				var location = tileInfo.ScreenPosition - 0.5f * sprite.Size;
+				OpenRA.Graphics.Util.FastCreateQuad(vertices, location, sprite, palette, offset);
 			}
 
 			spriteLayer[uv] = sprite;

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void UpdateRenderedTileInner(CPos p)
 		{
-			var t = render[p];
+			var t = content[p];
 			if (t.Density > 0)
 			{
 				var clear = FindClearSides(t.Type, p);


### PR DESCRIPTION
Reuse information generated in previous renders where possible, to reduce the amount of new work to be done each frame.

This PR caches rendering information in two ways:
- A VertexCache class which allows calculated vertices to be reused across frames. Resources, smudges and buildable terrain benefit from this as they represent large regions that don't change often.
- The shroud was previously employing some manual vertex caching of its own, but still had to rebuild vertex buffers every frame. It now avoids this costly rebuild by maintaining its own vertex buffers.

The VertexCache changes reduce CPU time spent in rendering these parts of the terrain from about 6% to 5%.

The shroud vertex buffers reduce CPU time spent rendering the shroud from about 12% to 3%.

Testing wise, I would recommend checking that shroud, resources, smudges and buildable terrain work as expected across all the mods. You should not notice any changes in the visuals.
