### PR TITLE
Add HealsPassengers and change UnloadCargo to take an actor reference (or IEnumerable<Actor>).

### DIFF
--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -188,6 +188,15 @@ namespace OpenRA.Traits
 			return (health == null) ? DamageState.Undamaged : health.DamageState;
 		}
 
+		public static bool IsDamaged(this Actor self)
+		{
+			if (self.Destroyed || self.IsDead)
+				return false;
+
+			var health = self.TraitOrDefault<Health>();
+			return health != null && health.HP < health.MaxHP;
+		}
+
 		public static void InflictDamage(this Actor self, Actor attacker, int damage, DamageWarhead warhead)
 		{
 			if (self.Destroyed) return;

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -622,6 +622,7 @@
     <Compile Include="UtilityCommands\CheckSequenceSprites.cs" />
     <Compile Include="UtilityCommands\FixClassicTilesets.cs" />
     <Compile Include="Graphics\TilesetSpecificSpriteSequence.cs" />
+    <Compile Include="Traits\HealsPassengers.cs" />
     <Compile Include="Traits\Pluggable.cs" />
     <Compile Include="Traits\Plug.cs" />
     <Compile Include="Widgets\Logic\Ingame\MenuButtonsChromeLogic.cs" />

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -147,7 +147,9 @@ namespace OpenRA.Mods.Common.Scripting
 
 				if (cargo != null)
 				{
-					transport.QueueActivity(new UnloadCargo(transport, true));
+					var toUnload = cargo.Passengers.ToList();
+					toUnload.Reverse();
+					transport.QueueActivity(new UnloadCargo(transport, toUnload));
 					transport.QueueActivity(new WaitFor(() => cargo.IsEmpty(transport)));
 				}
 

--- a/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
@@ -34,13 +34,15 @@ namespace OpenRA.Mods.Common.Scripting
 		public void LoadPassenger(Actor a) { cargo.Load(Self, a); }
 
 		[Desc("Remove the first actor from the transport.  This actor is not added to the world.")]
-		public Actor UnloadPassenger() { return cargo.Unload(Self); }
+		public Actor UnloadPassenger() { return cargo.UnloadLastEntered(Self); }
 
 		[ScriptActorPropertyActivity]
 		[Desc("Command transport to unload passengers.")]
 		public void UnloadPassengers()
 		{
-			Self.QueueActivity(new UnloadCargo(Self, true));
+			var toUnload = cargo.Passengers.ToList();
+			toUnload.Reverse();
+			Self.QueueActivity(new UnloadCargo(Self, toUnload));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -51,6 +51,8 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
 
+	public interface IPreventsCargoLoading { bool CanLoadPassenger(Actor self, Actor toLoad); }
+
 	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyKilled, INotifyOwnerChanged, INotifyAddedToWorld, ITick, INotifySold, IDisableMove
 	{
 		public readonly CargoInfo Info;
@@ -164,6 +166,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanLoad(Actor self, Actor a)
 		{
+			foreach (var prevents in self.TraitsImplementing<IPreventsCargoLoading>())
+				if (!prevents.CanLoadPassenger(self, a))
+					return false;
+
 			return (reserves.Contains(a) || HasSpace(GetWeight(a))) && self.CenterPosition.Z == 0;
 		}
 

--- a/OpenRA.Mods.Common/Traits/HealsPassengers.cs
+++ b/OpenRA.Mods.Common/Traits/HealsPassengers.cs
@@ -1,0 +1,82 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Heals all viable passengers simultaneously then optionally unloads fully-healed actors.",
+		"Example use: Hospital structure.")]
+	public class HealsPassengersInfo : ITraitInfo, Requires<CargoInfo>
+	{
+		[Desc("Ticks in-between healing actors.")]
+		public readonly int HealFrequency = 25;
+
+		[Desc("Amount to heal passengers on each iteration.")]
+		public readonly int HealAmount = 10;
+
+		[Desc("Should this actor automatically unload passengers that have been fully healed?")]
+		public readonly bool UnloadUndamagedPassengers = true;
+
+		[Desc("Allow undamages actors to enter?",
+			"These actors will not be affected in any way by the healing effects of this trait.")]
+		public readonly bool AllowUndamagedPassengers = false;
+
+		public object Create(ActorInitializer init) { return new HealsPassengers(init.Self, this); }
+	}
+
+	public class HealsPassengers : ITick, IPreventsCargoLoading
+	{
+		readonly HealsPassengersInfo info;
+		readonly Cargo cargo;
+
+		IEnumerable<Actor> damagedPassengers;
+		int countdownTicks;
+
+		public HealsPassengers(Actor self, HealsPassengersInfo info)
+		{
+			this.info = info;
+			cargo = self.Trait<Cargo>();
+			countdownTicks = info.HealFrequency;
+		}
+
+		public bool CanLoadPassenger(Actor self, Actor toLoad)
+		{
+			return info.AllowUndamagedPassengers || toLoad.IsDamaged();
+		}
+
+		public void Tick(Actor self)
+		{
+			if (!cargo.Passengers.Any())
+				return;
+
+			damagedPassengers = cargo.Passengers.Where(HealthExts.IsDamaged);
+			if (!damagedPassengers.Any())
+				return;
+
+			if (--countdownTicks > 0)
+				return;
+
+			countdownTicks = info.HealFrequency;
+
+			foreach (var toHeal in damagedPassengers)
+			{
+				var health = toHeal.Trait<Health>();
+				health.InflictDamage(toHeal, self, -info.HealAmount, null, true);
+
+				if (info.UnloadUndamagedPassengers && health.HP >= health.MaxHP)
+					self.QueueActivity(new UnloadCargo(self, toHeal));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!inDropRange || cargo.IsEmpty(self))
 				return;
 
-			if (droppedAt.Contains(self.Location) || (checkForSuitableCell && !IsSuitableCell(cargo.Peek(self), self.Location)))
+			if (droppedAt.Contains(self.Location) || (checkForSuitableCell && !IsSuitableCell(cargo.GetLastEntered(self), self.Location)))
 				return;
 
 			if (!self.World.Map.Contains(self.Location))
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 			// unload a dude here
 			droppedAt.Add(self.Location);
 
-			var a = cargo.Unload(self);
+			var a = cargo.UnloadLastEntered(self);
 			self.World.AddFrameEndTask(w => w.Add(new Parachute(a, self.CenterPosition)));
 			Sound.Play(info.ChuteSound, self.CenterPosition);
 		}

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.RA.Activities
 				{
 					while (!cargo.IsEmpty(self))
 					{
-						var a = cargo.Unload(self);
+						var a = cargo.UnloadLastEntered(self);
 
 						// Kill all the units that are unloaded into the void
 						// Kill() handles kill and death statistics


### PR DESCRIPTION
Makes use of new `Cargo::UnloadSpecific` to unload a specific passenger.
The English **TODO** still needs to be done.

Fulfills `Hospital (hurt inf goes in, exits healed)` from #7874.

Currently heals all actors simultaneously, do we want a queue instead (dependent on input order or damage level)?

Depends on #8052.
