### PR TITLE
Separate terrain geometry visualization from DevMode.

### DIFF
--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -23,7 +23,6 @@ namespace OpenRA.Traits
 		public bool BuildAnywhere;
 		public bool ShowCombatGeometry;
 		public bool ShowDebugGeometry;
-		public bool ShowTerrainGeometry;
 
 		public object Create(ActorInitializer init) { return new DeveloperMode(this); }
 	}
@@ -42,7 +41,6 @@ namespace OpenRA.Traits
 		// Client side only
 		public bool ShowCombatGeometry;
 		public bool ShowDebugGeometry;
-		public bool ShowTerrainGeometry;
 		public bool EnableAll;
 
 		public DeveloperMode(DeveloperModeInfo info)
@@ -56,7 +54,6 @@ namespace OpenRA.Traits
 			BuildAnywhere = info.BuildAnywhere;
 			ShowCombatGeometry = info.ShowCombatGeometry;
 			ShowDebugGeometry = info.ShowDebugGeometry;
-			ShowTerrainGeometry = info.ShowTerrainGeometry;
 		}
 
 		public void ResolveOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -75,11 +75,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				showGeometryCheckbox.OnClick = () => devTrait.ShowDebugGeometry ^= true;
 			}
 
+			var terrainGeometryTrait = world.WorldActor.Trait<TerrainGeometryOverlay>();
 			var showTerrainGeometryCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_TERRAIN_OVERLAY");
-			if (showTerrainGeometryCheckbox != null)
+			if (showTerrainGeometryCheckbox != null && terrainGeometryTrait != null)
 			{
-				showTerrainGeometryCheckbox.IsChecked = () => devTrait.ShowTerrainGeometry;
-				showTerrainGeometryCheckbox.OnClick = () => devTrait.ShowTerrainGeometry ^= true;
+				showTerrainGeometryCheckbox.IsChecked = () => terrainGeometryTrait.Enabled;
+				showTerrainGeometryCheckbox.OnClick = () => terrainGeometryTrait.Enabled ^= true;
 			}
 
 			var allTechCheckbox = widget.GetOrNull<CheckboxWidget>("ENABLE_TECH");


### PR DESCRIPTION
The new map editor remains blocked by #8017, so here's another chunk that can be reviewed in parallel.

This moves the terrain geometry visualization toggle from DevMode onto the layer trait itself, and gives it its own “terrainoverlay" console command that can be used in places where the player doesn't have an associated player actor (observers/replays and the editor).
