### PR TITLE
Update widget mouseover when scrolling panels.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -73,7 +73,13 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			targetListOffset = value;
 			if (!smooth)
+			{
 				currentListOffset = value;
+
+				// Update mouseover
+				var mi = new MouseInput(MouseInputEvent.Move, MouseButton.None, 0, Viewport.LastMousePos, Modifiers.None, 0);
+				Ui.HandleInput(mi);
+			}
 		}
 
 		[ObjectCreator.UseCtor]
@@ -235,7 +241,13 @@ namespace OpenRA.Mods.Common.Widgets
 			var offsetDiff = targetListOffset - currentListOffset;
 			var absOffsetDiff = Math.Abs(offsetDiff);
 			if (absOffsetDiff > 1f)
+			{
 				currentListOffset += offsetDiff * SmoothScrollSpeed.Clamp(0.1f, 1.0f);
+
+				// Update mouseover
+				var mi = new MouseInput(MouseInputEvent.Move, MouseButton.None, 0, Viewport.LastMousePos, Modifiers.None, 0);
+				Ui.HandleInput(mi);
+			}
 			else
 				SetListOffset(targetListOffset, false);
 		}


### PR DESCRIPTION
The new map editor remains blocked by #8017, so here's another chunk that can be reviewed in parallel.

This fixes a long-standing bug where scrolling a scrollpanel does not update the mouseover region beneath it.  A simple repro/fix case is to mouse-over a game in the server browser, and then scroll the panel with the mousewheel.  The highlighted game will now correctly change.
