### PR TITLE
Added unit repair via order button with optional Carryall transport

### DIFF
--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -1,0 +1,51 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+	public class WaitForTransport : Activity
+	{
+		readonly ICallForTransport transportable;
+
+		Activity inner;
+
+		public WaitForTransport(Actor self, Activity innerActivity)
+		{
+			transportable = self.TraitOrDefault<ICallForTransport>();
+			inner = innerActivity;
+		}
+
+		public override Activity Tick(Actor self)
+		{
+			if (inner == null)
+			{
+				if (transportable != null)
+					transportable.MovementCancelled(self);
+
+				return NextActivity;
+			}
+
+			inner = Util.RunActivity(self, inner);
+			return this;
+		}
+
+		public override void Cancel(Actor self)
+		{
+			if (transportable != null)
+				transportable.WantsTransport = false;
+
+			inner.Cancel(self);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Activities\Turn.cs" />
     <Compile Include="Activities\UnloadCargo.cs" />
     <Compile Include="Activities\Wait.cs" />
+    <Compile Include="Activities\WaitForTransport.cs" />
     <Compile Include="ActorExts.cs" />
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />
     <Compile Include="AI\BaseBuilder.cs" />

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -108,5 +108,17 @@ namespace OpenRA.Mods.Common.Traits
 					}));
 			}
 		}
+
+		public Actor FindRepairBuilding(Actor self)
+		{
+			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
+				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
+					&& a.Actor.Owner == self.Owner &&
+					info.RepairBuildings.Contains(a.Actor.Info.Name))
+				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
+
+			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.
+			return repairBuilding.FirstOrDefault().Actor;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -85,4 +85,12 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		IEnumerable<string> PaletteNames { get; }
 	}
+
+	public interface ICallForTransport
+	{
+		WRange MinimumDistance { get; }
+		bool WantsTransport { get; set; }
+		void MovementCancelled(Actor self);
+		void RequestTransport(CPos destination, Activity afterLandActivity);
+	}
 }

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -103,6 +103,9 @@ namespace OpenRA.Mods.D2k.Traits
 					if (!trait.WantsTransport)
 						return false;
 
+					if (actor.IsIdle)
+						return false;
+
 					return true;
 				})
 				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -53,6 +53,11 @@
 		Notification: EnemyUnitsDetected
 	Voiced:
 		VoiceSet: VehicleVoice
+	Carryable:
+	WithDecorationCarryable:
+		Image: pips
+		Sequence: pickup-indicator
+		Offset: -12, -12
 
 ^Tank:
 	AppearsOnRadar:
@@ -109,6 +114,11 @@
 		Notification: EnemyUnitsDetected
 	Voiced:
 		VoiceSet: VehicleVoice
+	Carryable:
+	WithDecorationCarryable:
+		Image: pips
+		Sequence: pickup-indicator
+		Offset: -12, -12
 
 ^Husk:
 	Health:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -61,11 +61,6 @@ harvester:
 		UnloadTicksPerBale: 5
 		SearchFromProcRadius: 24
 		SearchFromOrderRadius: 12
-	Carryable:
-	WithDecorationCarryable:
-		Image: pips
-		Sequence: pickup-indicator
-		Offset: -12, -12
 	Health:
 		HP: 1000
 	Armor:


### PR DESCRIPTION
Carryalls are supposed to be able to carry units back to the repair pad.
This PR enables this:
![](http://i.imgur.com/U04lNeC.gif)

You can also see a better example ingame with [this replay](https://www.dropbox.com/s/8qzyh3xmvj0c3dp/OpenRA-2015-04-28T180905Z.orarep). (Still, don't forget to test yourselves :P )
The replay is just short of 4 minutes long and shows a group of units being transported for repair. After that a quick verification that carryall-harvester interaction hasn't changed.
