### PR TITLE
Safer country lookup

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -237,14 +237,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public static string LookupCountry(string ip)
 		{
+			const string Unknown = "Unknown Location";
+
 			try
 			{
-				return Game.GeoIpDatabase.Country(ip).Country.Name;
+				return Game.GeoIpDatabase.Country(ip).Country.Name ?? Unknown;
 			}
 			catch (Exception e)
 			{
 				Log.Write("geoip", "LookupCountry failed: {0}", e);
-				return "Unknown Location";
+				return Unknown;
 			}
 		}
 


### PR DESCRIPTION
Avoid returning a null string. Fixes #8016.
