### PR TITLE
Remove DeathType from DamageWarhead

### DIFF
--- a/OpenRA.Game/GameRules/DamageWarhead.cs
+++ b/OpenRA.Game/GameRules/DamageWarhead.cs
@@ -8,10 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.GameRules
@@ -23,9 +20,6 @@ namespace OpenRA.GameRules
 
 		[Desc("Types of damage that this warhead causes. Leave empty for no damage.")]
 		public readonly string[] DamageTypes = new string[0];
-
-		[Desc("Infantry death animation to use.")]
-		public readonly string DeathType = "1";
 
 		[FieldLoader.LoadUsing("LoadVersus")]
 		[Desc("Damage percentage versus each armortype. 0% = can't target.")]

--- a/OpenRA.Mods.Cnc/Traits/SpawnViceroid.cs
+++ b/OpenRA.Mods.Cnc/Traits/SpawnViceroid.cs
@@ -19,36 +19,36 @@ namespace OpenRA.Mods.Cnc.Traits
 		[ActorReference] public readonly string ViceroidActor = "vice";
 		public readonly int Probability = 10;
 		public readonly string Owner = "Creeps";
-		public readonly string DeathType = "6";
+		public readonly string DeathType = "TiberiumDeath";
 
 		public object Create(ActorInitializer init) { return new SpawnViceroid(this); }
 	}
 
 	class SpawnViceroid : INotifyKilled
 	{
-		readonly SpawnViceroidInfo spawnViceroidInfo;
+		readonly SpawnViceroidInfo info;
 
-		public SpawnViceroid(SpawnViceroidInfo info) { spawnViceroidInfo = info; }
+		public SpawnViceroid(SpawnViceroidInfo info) { this.info = info; }
 
 		public void Killed(Actor self, AttackInfo e)
 		{
 			if (!self.World.LobbyInfo.GlobalSettings.Creeps) return;
-			if (e.Warhead == null || e.Warhead.DeathType != spawnViceroidInfo.DeathType) return;
-			if (self.World.SharedRandom.Next(100) > spawnViceroidInfo.Probability) return;
+			if (e.Warhead == null || !e.Warhead.DamageTypes.Contains(info.DeathType)) return;
+			if (self.World.SharedRandom.Next(100) > info.Probability) return;
 
 			self.World.AddFrameEndTask(w =>
 			{
 				var td = new TypeDictionary
 				{
 					new LocationInit(self.Location),
-					new OwnerInit(self.World.Players.First(p => p.InternalName == spawnViceroidInfo.Owner))
+					new OwnerInit(self.World.Players.First(p => p.InternalName == info.Owner))
 				};
 
 				var facing = self.TraitOrDefault<IFacing>();
 				if (facing != null)
 					td.Add(new FacingInit(facing.Facing));
 
-				w.CreateActor(spawnViceroidInfo.ViceroidActor, td);
+				w.CreateActor(info.ViceroidActor, td);
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -22,7 +22,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Multiply volume with this factor.")]
 		public readonly float VolumeMultiplier = 1f;
 
-		[Desc("DeathTypes that this should be used for. If empty, this will be used as the default sound.")]
+		[Desc("Damage types that this should be used for (defined on the warheads).",
+			"If empty, this will be used as the default sound for all death types.")]
 		public readonly string[] DeathTypes = { };
 
 		public object Create(ActorInitializer init) { return new DeathSounds(this); }
@@ -40,8 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (e.Warhead == null)
 				return;
 
-			if (info.DeathTypes.Contains(e.Warhead.DeathType) || (!info.DeathTypes.Any() &&
-				!self.Info.Traits.WithInterface<DeathSoundsInfo>().Any(dsi => dsi.DeathTypes.Contains(e.Warhead.DeathType))))
+			if (info.DeathTypes.Intersect(e.Warhead.DamageTypes).Any())
 				self.PlayVoiceLocal(info.DeathSound, info.VolumeMultiplier);
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -75,6 +75,42 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			input = world.ToString();
 		}
 
+		internal static void RenameDamageTypes(MiniYamlNode damageTypes)
+		{
+			var mod = Game.ModData.Manifest.Mod.Id;
+			if (mod == "cnc" || mod == "ra")
+			{
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType1", "DefaultDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType2", "BulletDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType3", "SmallExplosionDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType4", "ExplosionDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType5", "FireDeath");
+			}
+
+			if (mod == "cnc")
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType6", "TiberiumDeath");
+
+			if (mod == "ra")
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType6", "ElectricityDeath");
+
+			if (mod == "d2k")
+			{
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType1", "ExplosionDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType2", "SoundDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType3", "SmallExplosionDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType4", "BulletDeath");
+			}
+
+			if (mod == "ts")
+			{
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType1", "BulletDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType2", "SmallExplosionDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType3", "ExplosionDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType5", "FireDeath");
+				damageTypes.Value.Value = damageTypes.Value.Value.Replace("DeathType6", "EnergyDeath");
+			}
+		}
+
 		internal static void UpgradeActorRules(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			var parentKey = parent != null ? parent.Key.Split('@').First() : null;
@@ -1381,6 +1417,31 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						// Remove obsolete PreventProne and ProneModifier
 						node.Value.Nodes.RemoveAll(x => x.Key == "PreventProne");
 						node.Value.Nodes.RemoveAll(x => x.Key == "ProneModifier");
+					}
+				}
+
+				if (engineVersion < 20150517)
+				{
+					// Remove DeathType from DamageWarhead
+					if (node.Key.StartsWith("Warhead") && node.Value.Value == "SpreadDamage")
+					{
+						var deathTypeNode = node.Value.Nodes.FirstOrDefault(x => x.Key == "DeathType");
+						var deathType = deathTypeNode == null ? "1" : FieldLoader.GetValue<string>("DeathType", deathTypeNode.Value.Value);
+						var damageTypes = node.Value.Nodes.FirstOrDefault(x => x.Key == "DamageTypes");
+						if (damageTypes != null)
+							damageTypes.Value.Value += ", DeathType" + deathType;
+						else
+							node.Value.Nodes.Add(new MiniYamlNode("DamageTypes", "DeathType" + deathType));
+
+						node.Value.Nodes.RemoveAll(x => x.Key == "DeathType");
+					}
+
+					// Replace "DeathTypeX" damage types with proper words
+					if (node.Key.StartsWith("Warhead") && node.Value.Value == "SpreadDamage")
+					{
+						var damageTypes = node.Value.Nodes.FirstOrDefault(x => x.Key == "DamageTypes");
+						if (damageTypes != null)
+							RenameDamageTypes(damageTypes);
 					}
 				}
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -190,6 +190,13 @@
 	RenderSprites:
 	WithInfantryBody:
 	WithDeathAnimation:
+		DeathTypes:
+			DefaultDeath: 1
+			BulletDeath: 2
+			SmallExplosionDeath: 3
+			ExplosionDeath: 4
+			FireDeath: 5
+			TiberiumDeath: 6
 	AttackMove:
 	Passenger:
 		CargoType: Infantry

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -233,13 +233,13 @@
 		Range: 1
 	ScriptTriggers:
 	DeathSounds@NORMAL:
-		DeathTypes: 1, 2, 3, 4
+		DeathTypes: DefaultDeath, BulletDeath, SmallExplosionDeath, ExplosionDeath
 	DeathSounds@BURNED:
 		DeathSound: Burned
-		DeathTypes: 5
+		DeathTypes: FireDeath
 	DeathSounds@POISONED:
 		DeathSound: Poisoned
-		DeathTypes: 6
+		DeathTypes: TiberiumDeath
 	GainsStatUpgrades:
 	SelfHealing@ELITE:
 		Step: 2

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -2,8 +2,7 @@ FlametankExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
 		Damage: 100
-		DeathType: 5
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: big_napalm
 		ImpactSound: xplobig6.aud
@@ -12,15 +11,14 @@ HeliCrash:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		DeathType: 4
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: poof
 		ImpactSound: xplos.aud
 
 HeliExplode:
 	Warhead@1Dam: SpreadDamage
-		DeathType: 4
+		DamageTypes: ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_building
 		ImpactSound: xplos.aud
@@ -30,13 +28,12 @@ UnitExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: poof
 		ImpactSound: xplobig6.aud
@@ -45,13 +42,12 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: big_frag
 		ImpactSound: xplobig4.aud
@@ -60,13 +56,12 @@ GrenadierExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 10
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: poof
 		ImpactSound: xplosml2.aud
@@ -76,14 +71,13 @@ Napalm.Crate:
 		Spread: 170
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Versus:
 			None: 90
 			Wood: 100
 			Light: 60
 			Heavy: 25
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect

--- a/mods/cnc/weapons/largecaliber.yaml
+++ b/mods/cnc/weapons/largecaliber.yaml
@@ -8,14 +8,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		DeathType: 4
 		Versus:
 			None: 25
 			Wood: 75
 			Light: 100
 			Heavy: 100
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -32,13 +31,12 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Heavy: 100
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -55,14 +53,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 4
 		Versus:
 			None: 25
 			Wood: 100
 			Light: 100
 			Heavy: 100
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -81,14 +78,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 4
 		Versus:
 			None: 25
 			Wood: 100
 			Light: 100
 			Heavy: 100
 			Concrete: 100
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -105,13 +101,12 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 25
 			Light: 100
 			Heavy: 100
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -133,13 +128,12 @@ ArtilleryShell:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 150
-		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 80
 			Light: 75
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -17,7 +17,6 @@ Rockets:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
@@ -25,7 +24,7 @@ Rockets:
 			Light: 100
 			Heavy: 100
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -52,7 +51,6 @@ BikeRockets:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -60,7 +58,7 @@ BikeRockets:
 			Light: 100
 			Heavy: 100
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -88,14 +86,13 @@ OrcaAGMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			None: 50
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -123,12 +120,11 @@ OrcaAAMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		DeathType: 4
 		ValidTargets: Air
 		Versus:
 			Light: 75
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -155,14 +151,13 @@ MammothMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
 		Damage: 45
-		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
 			Wood: 75
 			Light: 100
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -196,14 +191,13 @@ MammothMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
 		Damage: 25
-		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			None: 35
 			Wood: 60
 			Light: 100
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -230,14 +224,13 @@ MammothMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		DeathType: 4
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
 			Wood: 75
 			Light: 100
 			Heavy: 90
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -263,13 +256,12 @@ BoatMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 60
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -299,14 +291,13 @@ TowerMissle:
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
 		Damage: 25
-		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 50
 			Wood: 25
 			Light: 100
 			Heavy: 100
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -335,9 +326,8 @@ SAMMissile:
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		DeathType: 4
 		Damage: 30
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -361,13 +351,12 @@ HonestJohn:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 100
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -397,9 +386,8 @@ Patriot:
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		DeathType: 4
 		Damage: 32
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -8,14 +8,13 @@ Flamethrower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 40
-		DeathType: 5
 		InvalidTargets: Wall
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 100
 			Heavy: 20
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -34,14 +33,13 @@ BigFlamer:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 75
-		DeathType: 5
 		InvalidTargets: Wall
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 67
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -57,13 +55,12 @@ Chemspray:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 80
-		DeathType: 6
 		Versus:
 			None: 100
 			Wood: 35
 			Light: 75
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, TiberiumDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -83,13 +80,12 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 50
-		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 50
 			Light: 75
 			Heavy: 35
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -108,14 +104,13 @@ Napalm:
 		Spread: 341
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		ValidTargets: Ground, Water
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 100
 			Heavy: 80
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -133,10 +128,9 @@ Laser:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 360
-		DeathType: 5
 		Versus:
 			Wood: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 
@@ -145,19 +139,18 @@ Tiberium:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 2
-		DeathType: 6
+		DamageTypes: TiberiumDeath
 
 TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Res: CreateResource
 		AddsResourceType: Tiberium
 		Size: 1,1
@@ -180,14 +173,13 @@ Tail:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 180
-		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 
 Horn:
 	ReloadDelay: 20
@@ -198,14 +190,13 @@ Horn:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 120
-		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 
 Teeth:
 	ReloadDelay: 30
@@ -216,14 +207,13 @@ Teeth:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 180
-		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 
 Claw:
 	ReloadDelay: 10
@@ -234,17 +224,17 @@ Claw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 60
-		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 
 Demolish:
 	Warhead@1Dam: SpreadDamage
+		DamageTypes: DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: xplobig6.aud

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -8,9 +8,8 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		DeathType: 2
 		ValidTargets: Infantry
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
 HighV:
 	ReloadDelay: 25
@@ -21,13 +20,12 @@ HighV:
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
 		Damage: 30
-		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 50
 			Light: 70
 			Heavy: 35
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -45,14 +43,13 @@ HeliAGGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 20
-		DeathType: 2
 		ValidTargets: Ground
 		Versus:
 			None: 100
 			Wood: 50
 			Light: 75
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -70,14 +67,13 @@ HeliAAGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 20
-		DeathType: 2
 		ValidTargets: Air
 		Versus:
 			None: 100
 			Wood: 50
 			Light: 50
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -91,14 +87,13 @@ Pistol:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 1
-		DeathType: 2
 		InvalidTargets: Wall
 		Versus:
 			None: 100
 			Wood: 50
 			Light: 50
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 
@@ -112,14 +107,13 @@ M16:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		DeathType: 2
 		InvalidTargets: Wall
 		Versus:
 			None: 100
 			Wood: 25
 			Light: 30
 			Heavy: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 
@@ -134,7 +128,6 @@ MachineGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		DeathType: 2
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -142,7 +135,7 @@ MachineGun:
 			Light: 50
 			Heavy: 20
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -156,14 +149,13 @@ Vulcan:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 100
-		DeathType: 2
 		ValidTargets: Ground, Water
 		Versus:
 			None: 100
 			Wood: 25
 			Light: 100
 			Heavy: 35
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -183,7 +175,7 @@ APCGun:
 			Wood: 50
 			Light: 100
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_poof
 
@@ -201,7 +193,7 @@ APCGun.AA:
 		ValidTargets: Air
 		Versus:
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_frag
 

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -5,14 +5,13 @@ Atomic:
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		ValidTargets: Ground, Air
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Eff_impact: CreateEffect
 		Explosion: nuke_explosion
 		ImpactSound: nukexplo.aud
@@ -20,7 +19,6 @@ Atomic:
 		Spread: 2c512
 		Damage: 100
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 3
 		ValidTargets: Ground, Air
 		Versus:
@@ -28,7 +26,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@4Res_areanukea: DestroyResource
 		Size: 3
 		Delay: 3
@@ -43,7 +41,6 @@ Atomic:
 		Spread: 3c768
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 6
 		ValidTargets: Ground, Air
 		Versus:
@@ -51,7 +48,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@8Res_areanukeb: DestroyResource
 		Size: 4
 		Delay: 6
@@ -63,7 +60,6 @@ Atomic:
 		Spread: 5c0
 		Damage: 20
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 9
 		ValidTargets: Ground, Air
 		Versus:
@@ -71,7 +67,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@11Res_areanukec: DestroyResource
 		Size: 5
 		Delay: 9
@@ -86,9 +82,8 @@ IonCannon:
 		Range: 0, 1c1, 2c1, 2c512
 		Damage: 100
 		Falloff: 1000, 1000, 250, 100
-		DeathType: 5
 		ValidTargets: Ground, Air
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Smu_area: LeaveSmudge

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -225,6 +225,7 @@
 	Huntable:
 	ScriptTriggers:
 	DeathSounds:
+		DeathTypes: 1, 2, 3, 4
 	Parachutable:
 		FallRate: 130
 	GainsStatUpgrades:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -201,6 +201,11 @@
 			Prone50Percent: 50
 		DamageTriggers: TriggerProne
 	WithDeathAnimation:
+		DeathTypes:
+			ExplosionDeath: 1
+			SoundDeath: 2
+			SmallExplosionDeath: 3
+			BulletDeath: 4
 	AutoTarget:
 	AttackMove:
 	Passenger:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -230,7 +230,7 @@
 	Huntable:
 	ScriptTriggers:
 	DeathSounds:
-		DeathTypes: 1, 2, 3, 4
+		DeathTypes: ExplosionDeath, SoundDeath, SmallExplosionDeath, BulletDeath
 	Parachutable:
 		FallRate: 130
 	GainsStatUpgrades:

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -11,13 +11,12 @@ LMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 15
-		DeathType: 4
 		Versus:
 			Wood: 25
 			Light: 40
 			Heavy: 10
 			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -39,7 +38,6 @@ Bazooka:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 50
-		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 10
@@ -47,7 +45,7 @@ Bazooka:
 			Light: 60
 			Heavy: 90
 			Concrete: 40
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -67,14 +65,13 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 32
 		Damage: 60
-		DeathType: 4
 		Versus:
 			None: 100
 			Wood: 0
 			Light: 1
 			Heavy: 0
 			Concrete: 0
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
 Vulcan:
 	ReloadDelay: 30
@@ -90,14 +87,13 @@ Vulcan:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 30
-		DeathType: 4
 		ValidTargets: Ground
 		Versus:
 			Wood: 0
 			Light: 60
 			Heavy: 10
 			Concrete: 0
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -117,7 +113,6 @@ Slung:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Damage: 30
-		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 0
@@ -125,7 +120,7 @@ Slung:
 			Light: 40
 			Heavy: 90
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_explosion
 		ImpactSound: EXPLLG5.WAV
@@ -145,13 +140,12 @@ HMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 30
-		DeathType: 4
 		Versus:
 			Wood: 15
 			Light: 45
 			Heavy: 20
 			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -170,13 +164,12 @@ HMGo:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 40
-		DeathType: 4
 		Versus:
 			Wood: 15
 			Light: 45
 			Heavy: 25
 			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -199,7 +192,6 @@ QuadRockets:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 25
-		DeathType: 3
 		ValidTargets: Ground, Air
 		Versus:
 			None: 35
@@ -207,7 +199,7 @@ QuadRockets:
 			Light: 100
 			Heavy: 100
 			Concrete: 35
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -227,13 +219,12 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 55
-		DeathType: 3
 		Versus:
 			None: 50
 			Wood: 75
 			Light: 100
 			Concrete: 65
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -260,7 +251,6 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Damage: 50
-		DeathType: 1
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
@@ -268,7 +258,7 @@ TowerMissile:
 			Light: 100
 			Heavy: 50
 			Concrete: 35
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -286,13 +276,12 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40
-		DeathType: 3
 		Versus:
 			None: 50
 			Wood: 50
 			Light: 100
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -310,13 +299,12 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40
-		DeathType: 3
 		Versus:
 			None: 50
 			Wood: 50
 			Light: 100
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -333,14 +321,13 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 100
-		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 50
 			Light: 100
 			Heavy: 100
 			Concrete: 80
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -366,7 +353,6 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Damage: 60
-		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 20
@@ -374,7 +360,7 @@ DevBullet:
 			Light: 100
 			Heavy: 50
 			Concrete: 80
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -432,14 +418,13 @@ NerveGasMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Damage: 100
-		DeathType: 1
 		Versus:
 			None: 100
 			Wood: 80
 			Light: 75
 			Heavy: 50
 			Concrete: 100
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -458,13 +443,12 @@ Sound:
 	Warhead@1Dam: SpreadDamage
 		Spread: 32
 		Damage: 150
-		DeathType: 2
 		Versus:
 			None: 60
 			Wood: 85
 			Light: 80
 			Concrete: 75
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 
 ChainGun:
 	ReloadDelay: 10
@@ -477,13 +461,12 @@ ChainGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 20
-		DeathType: 4
 		Versus:
 			Wood: 50
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
@@ -496,7 +479,6 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Damage: -50
-		DeathType: 4
 		Versus:
 			Wood: 0
 			Light: 0
@@ -523,13 +505,12 @@ ParaBomb:
 		Spread: 192
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 3
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -545,14 +526,13 @@ Napalm:
 		Spread: 640
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 3
 		Versus:
 			None: 20
 			Wood: 100
 			Light: 30
 			Heavy: 20
 			Concrete: 70
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -562,11 +542,13 @@ Napalm:
 Crush:
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
+		DamageTypes: ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		ImpactSound: CRUSH1.WAV
 
 Demolish:
 	Warhead@1Dam: SpreadDamage
+		DamageTypes: ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: EXPLLG2.WAV
@@ -576,14 +558,13 @@ Atomic:
 		Spread: 2c0
 		Damage: 180
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 100
 			Heavy: 50
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: nuke
 		ImpactSound: EXPLLG2.WAV
@@ -593,7 +574,6 @@ CrateNuke:
 		Spread: 1c576
 		Damage: 80
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 2
 		Versus:
 			None: 20
 			Wood: 75
@@ -601,7 +581,7 @@ CrateNuke:
 			Heavy: 25
 			Concrete: 50
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: nuke
 		ImpactSound: EXPLLG2.WAV
@@ -611,14 +591,13 @@ CrateExplosion:
 		Spread: 320
 		Damage: 40
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: EXPLSML4.WAV
@@ -628,13 +607,12 @@ UnitExplode:
 		Spread: 320
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: EXPLMD1.WAV
@@ -643,13 +621,12 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Damage: 60
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: self_destruct
 		ImpactSound: EXPLHG1.WAV, EXPLLG1.WAV, EXPLMD1.WAV, EXPLSML4.WAV
@@ -658,13 +635,12 @@ UnitExplodeTiny:
 	Warhead@1Dam: SpreadDamage
 		Spread: 224
 		Damage: 30
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: EXPLMD2.WAV, EXPLSML1.WAV, EXPLSML2.WAV, EXPLSML3.WAV
@@ -673,13 +649,12 @@ UnitExplodeScale:
 	Warhead@1Dam: SpreadDamage
 		Spread: 416
 		Damage: 90
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: EXPLLG2.WAV, EXPLLG3.WAV, EXPLLG5.WAV
@@ -697,13 +672,12 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Damage: 60
-		DeathType: 1
 		Versus:
 			None: 50
 			Wood: 100
 			Light: 25
 			Heavy: 5
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 	Warhead@3Eff: CreateEffect
@@ -728,13 +702,12 @@ Shrapnel:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Damage: 60
-		DeathType: 1
 		Versus:
 			None: 50
 			Wood: 100
 			Light: 25
 			Heavy: 5
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 	Warhead@3Eff: CreateEffect
@@ -745,13 +718,12 @@ SpiceExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Res: CreateResource
 		AddsResourceType: Spice
 		Size: 2,2

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1805,14 +1805,13 @@ Weapons:
 		Warhead@1Dam: SpreadDamage
 			Spread: 42
 			Damage: 50
-			DeathType: 2
 			Versus:
 				None: 0
 				Wood: 10
 				Light: 0
 				Heavy: 0
 				Concrete: 0
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 		Warhead@2Eff: CreateEffect
 			Explosion: piffs
 			InvalidImpactTypes: Water

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -362,9 +362,8 @@ Weapons:
 		Range: 10c0
 		Warhead: SpreadDamage
 			Spread: 42
-			DeathType: 5
 			Damage: 80
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, FireDeath
 
 Voices:
 

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -294,9 +294,8 @@ Weapons:
 				Wood: 75
 				Light: 60
 				Heavy: 25
-			DeathType: 2
 			Damage: 250
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 		Warhead@1Eff: CreateEffect
 			Explosion: large_explosion
 			WaterExplosion: large_splash
@@ -323,9 +322,8 @@ Weapons:
 				None: 40
 				Light: 30
 				Heavy: 30
-			DeathType: blownaway
 			Damage: 400
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, Explosion
 		Warhead@1Eff: CreateEffect
 			Explosion: large_explosion
 			WaterExplosion: large_splash

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -257,9 +257,8 @@ Weapons:
 		Range: 10c0
 		Warhead: SpreadDamage
 			Spread: 42
-			DeathType: 5
 			Damage: 80
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, FireDeath
 
 Voices:
 

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -757,9 +757,8 @@ Weapons:
 				Wood: 75
 				Light: 75
 				Concrete: 100
-			DeathType: 4
 			Damage: 150
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -792,9 +791,8 @@ Weapons:
 				Light: 110
 				Heavy: 100
 				Concrete: 200
-			DeathType: 3
 			Damage: 250
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -822,9 +820,8 @@ Weapons:
 				Light: 100
 				Heavy: 100
 				Concrete: 100
-			DeathType: 4
 			Damage: 15
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
 		Warhead@3Eff: CreateEffect
@@ -844,9 +841,8 @@ Weapons:
 				Wood: 100
 				Light: 60
 				Concrete: 25
-			DeathType: 5
 			Damage: 200
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, FireDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -875,9 +871,8 @@ Weapons:
 				Light: 60
 				Heavy: 75
 				Concrete: 35
-			DeathType: 5
 			Damage: 10
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, FireDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
 		Warhead@3Eff: CreateEffect
@@ -902,7 +897,7 @@ Weapons:
 				Heavy: 40
 				Concrete: 30
 			Damage: 25
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Scorch
 		Warhead@3Eff: CreateEffect
@@ -929,9 +924,8 @@ Weapons:
 				Wood: 90
 				Light: 80
 				Heavy: 70
-			DeathType: 3
 			Damage: 500
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect
@@ -952,9 +946,8 @@ Weapons:
 				Light: 0
 				Heavy: 50
 				Concrete: 0
-			DeathType: 2
 			Damage: 150
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 		Warhead@2Eff: CreateEffect
 			Explosion: piffs
 

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2375,14 +2375,13 @@ Weapons:
 		Warhead@1Dam: SpreadDamage
 			Spread: 128
 			Damage: 50
-			DeathType: 4
 			InvalidTargets: Air, Infantry
 			Versus:
 				None: 20
 				Wood: 75
 				Light: 75
 				Concrete: 50
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3EffGround: CreateEffect

--- a/mods/ra/maps/survival02/map.yaml
+++ b/mods/ra/maps/survival02/map.yaml
@@ -1165,14 +1165,13 @@ Weapons:
 		Warhead@1Dam: SpreadDamage
 			Spread: 150
 			Damage: 3500
-			DeathType: 5
 			Versus:
 				None: 125
 				Wood: 100
 				Light: 60
 				Heavy: 50
 				Concrete: 25
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, FireDeath
 		Warhead@2Smu: LeaveSmudge
 			SmudgeType: Crater
 		Warhead@3Eff: CreateEffect

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -210,13 +210,13 @@
 		Upgrades: hospitalheal
 		Prerequisites: hosp
 	DeathSounds@NORMAL:
-		DeathTypes: 1, 2, 3, 4
+		DeathTypes: DefaultDeath, BulletDeath, SmallExplosionDeath, ExplosionDeath
 	DeathSounds@BURNED:
 		DeathSound: Burned
-		DeathTypes: 5
+		DeathTypes: FireDeath
 	DeathSounds@ZAPPED:
 		DeathSound: Zapped
-		DeathTypes: 6
+		DeathTypes: ElectricityDeath
 	Parachutable:
 		ParachuteOffset: 0,0,427
 		KilledOnImpassableTerrain: true

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -175,6 +175,13 @@
 	RenderSprites:
 	WithInfantryBody:
 	WithDeathAnimation:
+		DeathTypes:
+			DefaultDeath: 1
+			BulletDeath: 2
+			SmallExplosionDeath: 3
+			ExplosionDeath: 4
+			FireDeath: 5
+			ElectricityDeath: 6
 	AutoTarget:
 	AttackMove:
 	Passenger:

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -3,14 +3,13 @@ CrateNapalm:
 		Spread: 170
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Versus:
 			None: 90
 			Light: 60
 			Heavy: 25
 			Concrete: 50
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -22,14 +21,13 @@ CrateExplosion:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: self_destruct
 		ImpactSound: kaboom15.aud
@@ -39,12 +37,11 @@ CrateNuke:
 		Spread: 1c0
 		Damage: 100
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Res_impact: DestroyResource
 	Warhead@3Eff_impact: CreateEffect
 		Explosion: nuke
@@ -53,13 +50,12 @@ CrateNuke:
 		Spread: 1c0
 		Damage: 60
 		Falloff: 1000, 600, 400, 250, 150, 100, 0
-		DeathType: 5
 		Delay: 4
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@5Res_areanuke: DestroyResource
 		Size: 5,4
 		Delay: 4
@@ -77,12 +73,11 @@ MiniNuke:
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Res_impact: DestroyResource
 		Size: 1
 	Warhead@3Eff_impact: CreateEffect
@@ -92,12 +87,11 @@ MiniNuke:
 		Spread: 2c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@5Res_areanuke1: DestroyResource
 		Size: 2
 		Delay: 5
@@ -108,12 +102,11 @@ MiniNuke:
 		Spread: 3c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 10
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@8Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -121,12 +114,11 @@ MiniNuke:
 		Spread: 4c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 15
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@10Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15
@@ -140,13 +132,12 @@ UnitExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: self_destruct
 		ImpactSound: kaboom22.aud
@@ -160,13 +151,12 @@ UnitExplodeShip:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 50
-		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: kaboom25.aud
@@ -175,13 +165,12 @@ UnitExplodeSubmarine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 50
-		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_splash
 		ImpactSound: splash9.aud
@@ -190,13 +179,12 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		DeathType: 4
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: kaboom15.aud
@@ -211,7 +199,6 @@ BarrelExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 4
 		Delay: 5
 		Versus:
 			None: 120
@@ -219,7 +206,7 @@ BarrelExplode:
 			Light: 50
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 		Size: 2,1
@@ -234,7 +221,7 @@ ATMine:
 		Spread: 256
 		Damage: 400
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: mineblo1.aud
@@ -244,8 +231,7 @@ APMine:
 		Spread: 256
 		Damage: 400
 		AffectsParent: true
-		DeathType: 3
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: napalm
 		ImpactSound: mine1.aud
@@ -254,13 +240,12 @@ OreExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Res: CreateResource
 		AddsResourceType: Ore
 		Size: 1,1

--- a/mods/ra/weapons/largecaliber.yaml
+++ b/mods/ra/weapons/largecaliber.yaml
@@ -8,13 +8,12 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 16
-		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 40
 			Heavy: 40
 			Concrete: 30
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -34,13 +33,12 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -64,13 +62,12 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -94,14 +91,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		DeathType: 4
 		InvalidTargets: Air, Infantry
 		Versus:
 			None: 20
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -123,13 +119,12 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		DeathType: 4
 		Versus:
 			None: 20
 			Wood: 50
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -156,14 +151,13 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 220
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -191,13 +185,12 @@ TurretGun:
 		Spread: 213
 		Damage: 25
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 3
 		Versus:
 			None: 60
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -219,13 +212,12 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -18,14 +18,13 @@ Maverick:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 70
-		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -56,14 +55,13 @@ Dragon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 10
 			Wood: 75
 			Light: 35
 			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -95,14 +93,13 @@ HellfireAG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -134,14 +131,13 @@ HellfireAA:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 4
 		ValidTargets: Air
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -171,14 +167,13 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 50
-		DeathType: 3
 		ValidTargets: Air, Infantry
 		Versus:
 			None: 100
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3EffGround: CreateEffect
@@ -210,7 +205,6 @@ Nike:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		DeathType: 3
 		ValidTargets: Air
 		Versus:
 			None: 90
@@ -218,7 +212,7 @@ Nike:
 			Light: 90
 			Heavy: 50
 			Concrete: 0
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -241,14 +235,13 @@ RedEye:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 3
 		ValidTargets: Air
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -272,12 +265,11 @@ SubMissile:
 		Spread: 426
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 3
 		Versus:
 			None: 40
 			Light: 30
 			Heavy: 30
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -307,14 +299,13 @@ Stinger:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 4
 		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -348,14 +339,13 @@ StingerAA:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 4
 		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -390,14 +380,13 @@ TorpTube:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 180
-		DeathType: 4
 		ValidTargets: Water, Underwater, Bridge
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 500
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -431,13 +420,12 @@ SCUD:
 		Spread: 341
 		Damage: 45
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 70
 			Heavy: 40
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -467,14 +455,13 @@ APTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 4
 		ValidTargets: Ground, Water
 		Versus:
 			None: 25
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -10,14 +10,13 @@ FireballLauncher:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 150
-		DeathType: 5
 		Versus:
 			None: 90
 			Wood: 50
 			Light: 60
 			Heavy: 25
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -38,14 +37,13 @@ Flamer:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 8
-		DeathType: 5
 		Versus:
 			None: 90
 			Wood: 100
 			Light: 60
 			Heavy: 25
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -62,13 +60,12 @@ Napalm:
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
 		Damage: 100
-		DeathType: 5
 		Versus:
 			None: 90
 			Light: 60
 			Heavy: 25
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -93,13 +90,12 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 60
-		DeathType: 3
 		Versus:
 			None: 50
 			Wood: 100
 			Light: 25
 			Heavy: 5
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -124,13 +120,13 @@ DepthCharge:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 80
-		DeathType: 4
 		ValidTargets: Underwater
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
+		DamageTypes: ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -150,11 +146,10 @@ TeslaZap:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		DeathType: 6
 		Versus:
 			None: 1000
 			Wood: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ElectricityDeath
 
 PortaTesla:
 	ReloadDelay: 70
@@ -165,10 +160,9 @@ PortaTesla:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 45
-		DeathType: 6
 		Versus:
 			None: 1000
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ElectricityDeath
 
 TTankZap:
 	ReloadDelay: 120
@@ -179,10 +173,9 @@ TTankZap:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		DeathType: 6
 		Versus:
 			None: 1000
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ElectricityDeath
 
 DogJaw:
 	ValidTargets: Infantry
@@ -192,13 +185,13 @@ DogJaw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 100
-		DeathType: 1
 		ValidTargets: Infantry
 		Versus:
 			Wood: 0
 			Light: 0
 			Heavy: 0
 			Concrete: 0
+		DamageTypes: DefaultDeath
 
 Heal:
 	ReloadDelay: 80
@@ -209,7 +202,6 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		DeathType: 1
 		Versus:
 			Wood: 0
 			Light: 0
@@ -226,7 +218,6 @@ Repair:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -20
-		DeathType: 1
 		ValidTargets: Repair
 		Versus:
 			None: 0
@@ -238,12 +229,13 @@ Repair:
 Crush:
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		ImpactSound: squishy2.aud
 
 Demolish:
 	Warhead@1Dam: SpreadDamage
+		DamageTypes: DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
 		ImpactSound: kaboom25.aud
@@ -256,14 +248,13 @@ Claw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 33
-		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 
 Mandible:
 	ReloadDelay: 10
@@ -273,14 +264,13 @@ Mandible:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 60
-		DeathType: 1
 		Versus:
 			None: 90
 			Wood: 10
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 
 MADTankThump:
 	InvalidTargets: MADTank

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -7,14 +7,13 @@ Colt45:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 50
-		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 0
 			Light: 0
 			Heavy: 0
 			Concrete: 0
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 		InvalidImpactTypes: Water
@@ -41,7 +40,7 @@ ZSU-23:
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_explosion_air
 
@@ -54,14 +53,13 @@ Vulcan:
 	Warhead@1Dam_1: SpreadDamage
 		Spread: 128
 		Damage: 10
-		DeathType: 2
 		Versus:
 			None: 200
 			Wood: 50
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff_1: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -71,7 +69,6 @@ Vulcan:
 	Warhead@3Dam_2: SpreadDamage
 		Spread: 128
 		Damage: 10
-		DeathType: 2
 		Delay: 2
 		Versus:
 			None: 200
@@ -79,7 +76,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@4Eff_2: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -91,7 +88,6 @@ Vulcan:
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
 		Damage: 10
-		DeathType: 2
 		Delay: 4
 		Versus:
 			None: 200
@@ -99,7 +95,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@6Eff_3: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -111,7 +107,6 @@ Vulcan:
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
 		Damage: 10
-		DeathType: 2
 		Delay: 6
 		Versus:
 			None: 200
@@ -119,7 +114,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@8Eff_4: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -131,7 +126,6 @@ Vulcan:
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
 		Damage: 10
-		DeathType: 2
 		Delay: 8
 		Versus:
 			None: 200
@@ -139,7 +133,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@10Eff_5: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -151,7 +145,6 @@ Vulcan:
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
 		Damage: 10
-		DeathType: 2
 		Delay: 10
 		Versus:
 			None: 200
@@ -159,7 +152,7 @@ Vulcan:
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@12Eff_6: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -180,14 +173,13 @@ ChainGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 2
 		Versus:
 			None: 120
 			Wood: 50
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -206,13 +198,12 @@ ChainGun.Yak:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 2
 		Versus:
 			Wood: 50
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -229,13 +220,12 @@ Pistol:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 1
-		DeathType: 2
 		Versus:
 			Wood: 50
 			Light: 60
 			Heavy: 25
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 		InvalidImpactTypes: Water
@@ -252,13 +242,12 @@ M1Carbine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		DeathType: 2
 		Versus:
 			Wood: 25
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -276,13 +265,12 @@ M60mg:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		DeathType: 2
 		Versus:
 			Wood: 10
 			Light: 30
 			Heavy: 10
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -299,13 +287,12 @@ SilencedPPK:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 150
-		DeathType: 2
 		Versus:
 			Wood: 0
 			Light: 0
 			Heavy: 0
 			Concrete: 0
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -331,7 +318,7 @@ FLAK-23:
 			Light: 60
 			Heavy: 10
 			Concrete: 20
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_explosion
 		InvalidImpactTypes: Air, AirHit, Water
@@ -351,12 +338,11 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 140
-		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 0
 			Light: 0
 			Heavy: 0
 			Concrete: 0
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -10,13 +10,12 @@ ParaBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 768
 		Damage: 300
-		DeathType: 4
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 75
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
@@ -34,11 +33,10 @@ Atomic:
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Res_impact: DestroyResource
 		Size: 1
 	Warhead@3Smu_impact: LeaveSmudge
@@ -51,12 +49,11 @@ Atomic:
 		Spread: 2c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@6Res_areanuke1: DestroyResource
 		Size: 2
 		Delay: 5
@@ -71,12 +68,11 @@ Atomic:
 		Spread: 3c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 10
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@10Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -88,12 +84,11 @@ Atomic:
 		Spread: 4c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 15
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@13Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15
@@ -105,12 +100,11 @@ Atomic:
 		Spread: 5c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 20
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@16Res_areanuke4: DestroyResource
 		Size: 5
 		Delay: 20

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -241,13 +241,13 @@
 	Huntable:
 	ScriptTriggers:
 	DeathSounds@NORMAL:
-		DeathTypes: 1, 2, 3
+		DeathTypes: BulletDeath, SmallExplosionDeath, ExplosionDeath
 	DeathSounds@BURNED:
 		DeathSound: Burned
-		DeathTypes: 5
+		DeathTypes: FireDeath
 	DeathSounds@ZAPPED:
 		DeathSound: Zapped
-		DeathTypes: 6
+		DeathTypes: EnergyDeath
 	UpgradeManager:
 	Cloak@CLOAKGENERATOR:
 		UpgradeTypes: cloakgenerator

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -232,6 +232,7 @@
 	PoisonedByTiberium:
 	SpawnViceroid:
 		ViceroidActor: vissml
+		DeathType: EnergyDeath # TODO: FIX ME! (Tiberium currently uses the wrong damage type!)
 	UpdatesPlayerStatistics:
 	CombatDebugOverlay:
 	Guard:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -192,6 +192,13 @@
 	RenderSprites:
 	WithInfantryBody:
 	WithDeathAnimation:
+		DeathTypes:
+			BulletDeath: 1
+			SmallExplosionDeath: 2
+			ExplosionDeath: 3
+			InfantryExplodeDeath: 4 #not used by any warhead; TODO: check what should use this type and add it!
+			FireDeath: 5
+			EnergyDeath: 6
 	AutoTarget:
 	AttackMove:
 	Passenger:

--- a/mods/ts/weapons/bombsandgrenades.yaml
+++ b/mods/ts/weapons/bombsandgrenades.yaml
@@ -11,14 +11,13 @@ Grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
 		Damage: 40
-		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 85
 			Light: 70
 			Heavy: 35
 			Concrete: 28
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_grey_explosion
 		ImpactSound: expnew13.aud
@@ -43,14 +42,13 @@ Bomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
 		Damage: 160
-		DeathType: 3
 		Versus:
 			None: 200
 			Wood: 90
 			Light: 75
 			Heavy: 32
 			Concrete: 100
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew09.aud
@@ -76,14 +74,13 @@ RPGTower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 110
-		DeathType: 2
 		Versus:
 			None: 30
 			Wood: 75
 			Light: 90
 			Heavy: 100
 			Concrete: 70
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_clsn
 		ImpactSound: expnew14.aud

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -10,14 +10,13 @@ LtRail:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 150
-		DeathType: 2
 		Versus:
 			None: 100
 			Wood: 130
 			Light: 150
 			Heavy: 110
 			Concrete: 5
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, SmallExplosionDeath
 
 MechRailgun:
 	ReloadDelay: 60
@@ -31,14 +30,13 @@ MechRailgun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 200
-		DeathType: 5
 		Versus:
 			None: 200
 			Wood: 175
 			Light: 160
 			Heavy: 100
 			Concrete: 25
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, FireDeath
 
 SonicZap:
 	ReloadDelay: 120
@@ -52,11 +50,10 @@ SonicZap:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
-		DeathType: 5
 		Versus:
 			Heavy: 80
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 
 CyCannon:
 	ReloadDelay: 50
@@ -72,7 +69,6 @@ CyCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 43
 		Damage: 120
-		DeathType: 6
 		ValidTargets: Ground
 		Versus:
 			None: 350
@@ -80,7 +76,7 @@ CyCannon:
 			Light: 205
 			Heavy: 150
 			Concrete: 80
-		DamageTypes: Prone350Percent, TriggerProne
+		DamageTypes: Prone350Percent, TriggerProne, EnergyDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_bang
 		ImpactSound: expnew12.aud
@@ -109,7 +105,6 @@ Proton:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 20
-		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -117,7 +112,7 @@ Proton:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_bang
 		ImpactSound: expnew12.aud
@@ -138,8 +133,7 @@ LaserFire:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 250
-		DeathType: 5
-		DamageTypes: Prone60Percent, TriggerProne
+		DamageTypes: Prone60Percent, TriggerProne, EnergyDeath
 
 # Laser turret
 LaserFire2:
@@ -152,6 +146,5 @@ LaserFire2:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 30
-		DeathType: 5
-		DamageTypes: Prone60Percent, TriggerProne
+		DamageTypes: Prone60Percent, TriggerProne, EnergyDeath
 

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -3,13 +3,12 @@ UnitExplode:
 		Spread: 426
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 2
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_twlt
 		ImpactSound: expnew09.aud
@@ -18,13 +17,12 @@ UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 40
-		DeathType: 2
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: medium_brnl
 		ImpactSound: expnew13.aud
@@ -33,13 +31,12 @@ TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 10
-		DeathType: 3
 		Versus:
 			None: 90
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Res: CreateResource
 		AddsResourceType: Tiberium
 		Size: 1,1

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -7,7 +7,6 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		DeathType: 1
 		Versus:
 			Wood: 0
 			Light: 0
@@ -23,7 +22,6 @@ Repair:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		DeathType: 1
 		Versus:
 			None: 0
 			Wood: 0
@@ -36,5 +34,4 @@ TiberiumHeal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: -2
-		DeathType: 6
 

--- a/mods/ts/weapons/largeguns.yaml
+++ b/mods/ts/weapons/largeguns.yaml
@@ -11,14 +11,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 36
-		DeathType: 2
 		Versus:
 			None: 25
 			Wood: 65
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: medium_clsn
 		ImpactSound: expnew14.aud
@@ -39,14 +38,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 70
-		DeathType: 2
 		Versus:
 			None: 25
 			Wood: 65
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_clsn
 		ImpactSound: expnew14.aud
@@ -73,14 +71,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		DeathType: 2
 		Versus:
 			None: 25
 			Wood: 65
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: medium_clsn
 		ImpactSound: expnew14.aud
@@ -107,14 +104,13 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
 		Damage: 150
-		DeathType: 3
 		Versus:
 			None: 100
 			Wood: 85
 			Light: 68
 			Heavy: 35
 			Concrete: 35
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew06.aud

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -17,7 +17,6 @@ Bazooka:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -25,7 +24,7 @@ Bazooka:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -61,7 +60,6 @@ HoverMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -69,7 +67,7 @@ HoverMissile:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -104,7 +102,6 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
 		Damage: 40
-		DeathType: 3
 		ValidTargets: Air
 		Versus:
 			None: 100
@@ -112,6 +109,7 @@ MammothTusk:
 			Light: 70
 			Heavy: 35
 			Concrete: 28
+		DamageTypes: Explosion
 	Warhead@2Eff: CreateEffect
 		Explosion: medium_bang
 		ImpactSound: expnew12.aud
@@ -142,7 +140,6 @@ BikeMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40
-		DeathType: 2
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -150,7 +147,7 @@ BikeMissile:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -182,7 +179,6 @@ Dragon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
-		DeathType: 2
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -190,7 +186,7 @@ Dragon:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud
@@ -226,7 +222,6 @@ Hellfire:
 	Warhead@1Dam: SpreadDamage
 		Spread: 85
 		Damage: 30
-		DeathType: 2
 		ValidTargets: Ground
 		Versus:
 			None: 30
@@ -234,7 +229,7 @@ Hellfire:
 			Light: 150
 			Heavy: 100
 			Concrete: 30
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_bang
 		ImpactSound: expnew12.aud
@@ -269,8 +264,8 @@ RedEye2:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 33
-		DeathType: 2
 		ValidTargets: Air
+		DamageTypes: SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: small_clsn
 		ImpactSound: expnew12.aud

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -11,14 +11,13 @@ FireballLauncher:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 25
-		DeathType: 5
 		Versus:
 			None: 600
 			Wood: 148
 			Light: 59
 			Heavy: 6
 			Concrete: 2
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SmallScorch
 
@@ -36,12 +35,11 @@ FiendShard:
 		Palette: greentiberium
 	Warhead@1Dam: SpreadDamage
 		Damage: 35
-		DeathType: 1
 		Versus:
 			Light: 60
 			Heavy: 40
 			Concrete: 20
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, BulletDeath
 	Warhead@3EffWater: CreateEffect
 		Explosion: small_watersplash
 		ImpactSound: ssplash3.aud
@@ -55,17 +53,16 @@ SlimeAttack:
 		Speed: 426
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
-		DeathType: 2
 		Versus:
 			Light: 60
 			Heavy: 40
 			Concrete: 20
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, SmallExplosionDeath
 
 Tiberium:
 	ReloadDelay: 16
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 2
-		DeathType: 6
+		DamageTypes: EnergyDeath # TODO: FIX ME!
 

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -7,13 +7,12 @@ Minigun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 8
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -30,13 +29,12 @@ M1Carbine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -53,13 +51,12 @@ Vulcan:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 20
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -77,14 +74,13 @@ Vulcan2:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		DeathType: 1
 		Versus:
 			None: 100
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -102,13 +98,12 @@ Vulcan3:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 10
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -125,13 +120,12 @@ VulcanTower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 18
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -149,13 +143,12 @@ JumpCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 15
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -172,13 +165,12 @@ AssaultCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -197,13 +189,12 @@ RaiderCannon:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -221,14 +212,13 @@ HarpyClaw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
-		DeathType: 1
 		ValidTargets: Ground, Air
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 		InvalidImpactTypes: Water
@@ -245,13 +235,12 @@ Pistola:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 2
-		DeathType: 1
 		Versus:
 			Wood: 60
 			Light: 40
 			Heavy: 25
 			Concrete: 10
-		DamageTypes: Prone70Percent, TriggerProne
+		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
 		InvalidImpactTypes: Water
@@ -268,12 +257,11 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 150
-		DeathType: 1
 		Versus:
 			None: 100
 			Wood: 5
 			Light: 5
 			Heavy: 5
 			Concrete: 5
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, BulletDeath
 

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -16,7 +16,6 @@ MultiCluster:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 65
-		DeathType: 3
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -24,7 +23,7 @@ MultiCluster:
 			Light: 75
 			Heavy: 100
 			Concrete: 60
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew09.aud
@@ -44,13 +43,12 @@ SuicideBomb:
 		Spread: 256
 		Damage: 110
 		Falloff: 10000, 3680, 1350, 500, 180, 70, 0
-		DeathType: 5
 		Versus:
 			None: 90
 			Light: 60
 			Heavy: 25
 			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Res: DestroyResource
 
 IonCannon:
@@ -59,9 +57,8 @@ IonCannon:
 		Spread: 1c0
 		Damage: 100
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		ValidTargets: Ground, Air
-		DamageTypes: Prone100Percent, TriggerProne
+		DamageTypes: Prone100Percent, TriggerProne, EnergyDeath
 	Warhead@2Eff_impact: CreateEffect
 		Explosion: ionring
 		ImpactSound: ion1.aud
@@ -69,10 +66,9 @@ IonCannon:
 		Spread: 1c0
 		Damage: 250
 		Falloff: 100, 50, 25, 0
-		DeathType: 5
 		Delay: 3
 		ValidTargets: Ground, Air
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, EnergyDeath
 	Warhead@4Smu_area: LeaveSmudge
 		SmudgeType: SmallScorch
 		Size: 2,1
@@ -107,11 +103,10 @@ ClusterMissile:
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@SoundEffect0: CreateEffect
 		Explosion: large_explosion
 		ImpactSound: expnew19.aud
@@ -124,12 +119,11 @@ ClusterMissile:
 		Spread: 2c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 5
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@ResourceDestruction1: DestroyResource
 		Size: 2
 		Delay: 5
@@ -141,12 +135,11 @@ ClusterMissile:
 		Spread: 3c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 10
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@ResourceDestruction2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -158,12 +151,11 @@ ClusterMissile:
 		Spread: 4c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 15
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@ResourceDestruction3: DestroyResource
 		Size: 4
 		Delay: 15
@@ -175,12 +167,11 @@ ClusterMissile:
 		Spread: 5c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		DeathType: 5
 		Delay: 20
 		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@ResourceDestruction4: DestroyResource
 		Size: 5
 		Delay: 20


### PR DESCRIPTION
Step 2 toward fixing #7997 and my personal goal - making the `Armor` trait upgradable.

I made the logic changes and fixed RA so it works. I will add an upgrade rule to remove the redundant `DeathType` from YAML and will do the rest of the mods once the brunt of the bikeshedding over naming and the likes is over.

Closes #7997 (or maybe the next one will close it?).
Enables further warhead cleanups (creating `IWarhead`, moving `DamageWarhead` (and probably `Warhead`) to `Mods.Common`).
