### PR TITLE
Cleaned up infantry rules (part 1)

### DIFF
--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -380,13 +380,11 @@ BRIDGEHUT:
 
 C1:
 	Inherits: ^CivInfantry
-	Selectable:
 	Voiced:
 		VoiceSet: CivilianMaleVoice
 
 C2:
 	Inherits: ^CivInfantry
-	Selectable:
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
 
@@ -395,7 +393,6 @@ C3:
 
 C4:
 	Inherits: ^CivInfantry
-	Selectable:
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
 
@@ -404,7 +401,6 @@ C5:
 
 C6:
 	Inherits: ^CivInfantry
-	Selectable:
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
 
@@ -413,7 +409,6 @@ C7:
 
 C8:
 	Inherits: ^CivInfantry
-	Selectable:
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
 
@@ -422,7 +417,6 @@ C9:
 
 C10:
 	Inherits: ^CivInfantry
-	Selectable:
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -180,6 +180,7 @@
 			Beach: 80
 	SelectionDecorations:
 	Selectable:
+		Bounds: 12,17,0,-6
 	TargetableUnit:
 		TargetTypes: Ground, Infantry
 	TakeCover:
@@ -259,8 +260,6 @@
 	-TakeCover:
 	AppearsOnRadar:
 	SelectionDecorations:
-	Selectable:
-		Bounds: 12,17,0,-9
 	Valued:
 		Cost: 70
 	Tooltip:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -8,8 +8,6 @@ E1:
 	Buildable:
 		BuildPaletteOrder: 10
 		Queue: Infantry.GDI, Infantry.Nod
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 56
 	Health:
@@ -17,6 +15,7 @@ E1:
 	Armament:
 		Weapon: M16
 	AttackFrontal:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2,idle3,idle4
 		StandSequences: stand, stand2
@@ -32,8 +31,6 @@ E2:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Infantry.GDI
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 71
 	Health:
@@ -43,6 +40,7 @@ E2:
 		LocalOffset: 0,0,427
 		FireDelay: 15
 	AttackFrontal:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand, stand2
@@ -61,8 +59,6 @@ E3:
 	Buildable:
 		BuildPaletteOrder: 20
 		Queue: Infantry.GDI, Infantry.Nod
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 42
 	Health:
@@ -74,6 +70,7 @@ E3:
 		LocalOffset: 256,43,341
 		FireDelay: 5
 	AttackFrontal:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand, stand2
@@ -89,8 +86,6 @@ E4:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Infantry.Nod
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 56
 	Health:
@@ -104,6 +99,7 @@ E4:
 	AttackFrontal:
 	WithMuzzleFlash:
 		SplitFacings: true
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand, stand2
@@ -119,8 +115,6 @@ E5:
 		BuildPaletteOrder: 50
 		Prerequisites: tmpl, ~techlevel.high
 		Queue: Infantry.Nod
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 56
 		TerrainSpeeds:
@@ -140,6 +134,7 @@ E5:
 	WithMuzzleFlash:
 		SplitFacings: true
 	-PoisonedByTiberium:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand, stand2
@@ -154,8 +149,6 @@ E6:
 	Buildable:
 		BuildPaletteOrder: 30
 		Queue: Infantry.GDI, Infantry.Nod
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 56
 	Health:
@@ -167,6 +160,7 @@ E6:
 	Captures:
 		CaptureTypes: building, husk
 	-AutoTarget:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand, stand2
@@ -183,8 +177,6 @@ RMBO:
 		BuildPaletteOrder: 50
 		Prerequisites: eye, ~techlevel.high
 		Queue: Infantry.GDI
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 71
 	Health:
@@ -200,6 +192,7 @@ RMBO:
 	Armament:
 		Weapon: Sniper
 	AttackFrontal:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2,idle3
 		StandSequences: stand, stand2

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -202,6 +202,7 @@
 			Rough: 70
 	SelectionDecorations:
 	Selectable:
+		Bounds: 12,18,0,-6
 	TargetableUnit:
 		TargetTypes: Ground
 	RenderSprites:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -8,8 +8,6 @@ rifle:
 	Tooltip:
 		Name: Rifleman
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
-	Selectable:
-		Bounds: 12,17,0,0
 	Health:
 		HP: 50
 	Mobile:
@@ -18,9 +16,7 @@ rifle:
 		Weapon: LMG
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
+	WithInfantryBody:
 	AttractsWorms:
 		Intensity: 120
 
@@ -35,8 +31,6 @@ engineer:
 	Tooltip:
 		Name: Engineer
 		Description: Infiltrates and captures enemy structures\n  Strong vs Buildings\n  Weak vs Everything
-	Selectable:
-		Bounds: 12,17,0,0
 	Health:
 		HP: 25
 	Mobile:
@@ -44,6 +38,8 @@ engineer:
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
+	TakeCover:
+	WithInfantryBody:
 	ExternalCaptures:
 		Type: building
 	Captures:
@@ -65,8 +61,6 @@ bazooka:
 	Tooltip:
 		Name: Trooper
 		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
-	Selectable:
-		Bounds: 12,17,0,0
 	Health:
 		HP: 45
 	Mobile:
@@ -76,9 +70,7 @@ bazooka:
 		LocalOffset: 0,0,555
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
+	WithInfantryBody:
 	AttractsWorms:
 		Intensity: 180
 
@@ -93,8 +85,6 @@ medic:
 	Tooltip:
 		Name: Medic
 		Description: Heals nearby infantry\n  Strong vs Nothing\n  Weak vs Everything
-	Selectable:
-		Bounds: 12,17,0,0
 	Health:
 		HP: 60
 	Mobile:
@@ -105,6 +95,7 @@ medic:
 	AttackMedic:
 		Cursor: ability
 		OutsideRangeCursor: ability
+	TakeCover:
 	WithInfantryBody:
 		AttackSequence: heal
 	Passenger:
@@ -126,8 +117,6 @@ fremen:
 		Queue: Infantry
 		BuildPaletteOrder: 100
 		Prerequisites: ~barracks.atreides, palace, ~techlevel.high
-	Selectable:
-		Bounds: 12,17,0,0
 	Mobile:
 		Speed: 53
 	Health:
@@ -143,9 +132,7 @@ fremen:
 		Weapon: Slung
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
+	WithInfantryBody:
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 250
@@ -166,8 +153,6 @@ grenadier:
 	Tooltip:
 		Name: Grenadier
 		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
-	Selectable:
-		Bounds: 12,17,0,0
 	Health:
 		HP: 50
 	Mobile:
@@ -178,9 +163,6 @@ grenadier:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle
 	Explodes:
@@ -200,8 +182,6 @@ sardaukar:
 	Tooltip:
 		Name: Sardaukar
 		Description: Elite asssault infantry\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
-	Selectable:
-		Bounds: 12,17,0,0
 	Health:
 		HP: 100
 	Mobile:
@@ -209,9 +189,7 @@ sardaukar:
 	RevealsShroud:
 		Range: 6c0
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
+	WithInfantryBody:
 	Armament@PRIMARY:
 		Weapon: Vulcan
 	Armament@SECONDARY:
@@ -233,14 +211,14 @@ saboteur:
 	Tooltip:
 		Name: Saboteur
 		Description: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
-	Selectable:
-		Bounds: 12,17,0,0
 	Health:
 		HP: 100
 	Mobile:
 		Speed: 64
 	RevealsShroud:
 		Range: 7c0
+	TakeCover:
+	WithInfantryBody:
 	C4Demolition:
 		C4Delay: 45
 	-AutoTarget:

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -130,6 +130,21 @@ engineer:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+	standup-0: DATA.R8
+		Start: 1262
+		Facings: -8
+		Transpose: true
+		Tick: 120
+	prone-stand: DATA.R8
+		Start: 1270
+		Facings: -8
+		Transpose: true
+	prone-run: DATA.R8
+		Start: 1278
+		Length: 3
+		Facings: -8
+		Transpose: true
+		Tick: 120
 	die1: DATA.R8
 		Frames: 1342, 1349, 1356, 1363, 1370, 1377, 1384, 1391, 1398, 1399, 1400, 1401
 		Length: 12
@@ -163,6 +178,21 @@ medic: # actually thumper
 	run: DATA.R8
 		Start: 1410
 		Length: 6
+		Facings: -8
+		Transpose: true
+		Tick: 120
+	standup-0: DATA.R8
+		Start: 1462
+		Facings: -8
+		Transpose: true
+		Tick: 120
+	prone-stand: DATA.R8
+		Start: 1470
+		Facings: -8
+		Transpose: true
+	prone-run: DATA.R8
+		Start: 1478
+		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
@@ -385,6 +415,8 @@ sardaukar:
 		Offset: -30,-24
 
 grenadier: # 2502 - 2749 in 1.06 DATA.R8
+	Defaults:
+		Offset: 1,-4
 	stand: grenadier.shp
 		Facings: 8
 	idle: grenadier.shp
@@ -432,6 +464,7 @@ grenadier: # 2502 - 2749 in 1.06 DATA.R8
 		Facings: 8
 		Tick: 120
 	icon: grenadiericon.shp # 4281 in 1.06 DATA.R8
+		Offset: 0,0
 
 sandworm:
 	mouth: DATA.R8

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -170,8 +170,13 @@
 			Beach: 80
 	SelectionDecorations:
 	Selectable:
+		Bounds: 12,18,0,-6
 	TargetableUnit:
 		TargetTypes: Ground, Infantry, Disguise
+	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	RenderSprites:
 	WithInfantryBody:
 	WithDeathAnimation:
@@ -457,8 +462,6 @@
 
 ^CivInfantry:
 	Inherits: ^Infantry
-	Selectable:
-		Bounds: 12,17,0,-9
 	Valued:
 		Cost: 70
 	Tooltip:
@@ -479,6 +482,7 @@
 	ScaredyCat:
 	Voiced:
 		VoiceSet: CivilianMaleVoice
+	-TakeCover:
 
 ^CivBuilding:
 	Inherits: ^TechBuilding

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -43,8 +43,6 @@ E1:
 	Tooltip:
 		Name: Rifle Infantry
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 50
 	Mobile:
@@ -57,9 +55,6 @@ E1:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -76,8 +71,6 @@ E2:
 	Tooltip:
 		Name: Grenadier
 		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 50
 	Mobile:
@@ -92,9 +85,6 @@ E2:
 		FireDelay: 15
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -114,8 +104,6 @@ E3:
 	Tooltip:
 		Name: Rocket Soldier
 		Description: Anti-tank/Anti-aircraft infantry.\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 45
 	Mobile:
@@ -131,9 +119,6 @@ E3:
 		Weapon: Dragon
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -150,8 +135,6 @@ E4:
 	Tooltip:
 		Name: Flamethrower
 		Description: Advanced anti-structure unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 40
 	Mobile:
@@ -165,9 +148,6 @@ E4:
 		Weapon: Flamer
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -184,8 +164,6 @@ E6:
 	Tooltip:
 		Name: Engineer
 		Description: Infiltrates and captures enemy structures.\n  Strong vs Nothing\n  Weak vs Everything
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 25
 	Mobile:
@@ -196,11 +174,8 @@ E6:
 	RepairsBridges:
 	ExternalCaptures:
 		Type: building
-	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	-AutoTarget:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -221,8 +196,6 @@ SPY:
 		Name: Spy
 		GenericName: Soldier
 		Description: Infiltrates enemy structures for intel or\nsabotage. Exact effect depends on the\nbuilding infiltrated.\n  Strong vs Nothing\n  Weak vs Everything\n  Special Ability: Disguised
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 25
 	Mobile:
@@ -232,9 +205,6 @@ SPY:
 	Passenger:
 		PipType: Yellow
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	Disguise:
 	Infiltrates:
 		Types: SpyInfiltrate
@@ -251,6 +221,7 @@ SPY:
 
 SPY.England:
 	Inherits: SPY
+	TakeCover:
 	WithDisguisingInfantryBody:
 	Buildable:
 		Prerequisites: ~infantry.england, dome, ~tent, ~techlevel.medium
@@ -274,8 +245,6 @@ E7:
 	Tooltip:
 		Name: Tanya
 		Description: Elite commando infantry. Armed with\ndual pistols and C4.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles\n  Special Ability: Destroy Building with C4\n\nMaximum 1 can be trained
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 100
 	Mobile:
@@ -297,9 +266,6 @@ E7:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 	AnnounceOnBuild:
@@ -319,8 +285,6 @@ MEDI:
 	Tooltip:
 		Name: Medic
 		Description: Heals nearby infantry.\n  Strong vs Nothing\n  Weak vs Everything
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 80
 	Mobile:
@@ -336,9 +300,6 @@ MEDI:
 		Cursor: heal
 		OutsideRangeCursor: heal
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -358,8 +319,6 @@ MECH:
 	Tooltip:
 		Name: Mechanic
 		Description: Repairs nearby vehicles and restores\nhusks to working condition.\n  Strong vs Nothing\n  Weak vs Everything
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 80
 	Mobile:
@@ -377,9 +336,6 @@ MECH:
 	Captures:
 		CaptureTypes: husk
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -389,8 +345,6 @@ MECH:
 
 EINSTEIN:
 	Inherits: ^Infantry
-	Selectable:
-		Bounds: 12,17,0,-9
 	Valued:
 		Cost: 10
 	Tooltip:
@@ -402,6 +356,7 @@ EINSTEIN:
 	RevealsShroud:
 		Range: 2c0
 	-AutoTarget:
+	-TakeCover:
 	ProximityCaptor:
 		Types: CivilianInfantry
 	WithInfantryBody:
@@ -411,8 +366,6 @@ EINSTEIN:
 
 DELPHI:
 	Inherits: ^Infantry
-	Selectable:
-		Bounds: 12,17,0,-9
 	Valued:
 		Cost: 10
 	Tooltip:
@@ -424,6 +377,7 @@ DELPHI:
 	RevealsShroud:
 		Range: 2c0
 	-AutoTarget:
+	-TakeCover:
 	ProximityCaptor:
 		Types: CivilianInfantry
 	WithInfantryBody:
@@ -451,8 +405,6 @@ THF:
 	Tooltip:
 		Name: Thief
 		Description: Steals enemy credits.\n  Strong vs Nothing\n  Weak vs Everything\n
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 25
 	Mobile:
@@ -464,9 +416,6 @@ THF:
 	Infiltrates:
 		InfiltrateTypes: Cash
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	-AutoTarget:
 	Voiced:
 		VoiceSet: ThiefVoice
@@ -483,8 +432,6 @@ HIJACKER:
 	Tooltip:
 		Name: Hijacker
 		Description: Hijacks enemy vehicles. Unarmed\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 50
 	Mobile:
@@ -498,6 +445,7 @@ HIJACKER:
 	-AutoTarget:
 	Voiced:
 		VoiceSet: ThiefVoice
+	-TakeCover:
 
 SHOK:
 	Inherits: ^Infantry
@@ -511,8 +459,6 @@ SHOK:
 	Tooltip:
 		Name: Shock Trooper
 		Description: Elite infantry with portable tesla coils.\n Strong vs Infantry\n Weak vs Aircraft
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 100
 	Mobile:
@@ -527,9 +473,6 @@ SHOK:
 		Weapon: PortaTesla
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -548,8 +491,6 @@ SNIPER:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 80
 		Prerequisites: ~disabled
-	Selectable:
-		Bounds: 12,17,0,-6
 	Mobile:
 		Speed: 56
 	Health:
@@ -568,9 +509,6 @@ SNIPER:
 		MuzzleSequence: garrison-muzzle
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
@@ -595,8 +533,6 @@ Zombie:
 		Queue: Infantry
 		BuildPaletteOrder: 200
 		Prerequisites: ~bio
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 250
 	Mobile:

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -4,8 +4,6 @@ WEEDGUY:
 		Cost: 300
 	Tooltip:
 		Name: Chem Spray Infantry
-	Selectable:
-		Bounds: 12,17,0,-6
 	Voiced:
 		VoiceSet: Weed
 	Mobile:
@@ -20,13 +18,6 @@ WEEDGUY:
 	AttackFrontal:
 	WithInfantryBody:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 
 UMAGON:
 	Inherits: ^Infantry
@@ -34,8 +25,6 @@ UMAGON:
 		Cost: 400
 	Tooltip:
 		Name: Umagon
-	Selectable:
-		Bounds: 12,17,0,-6
 	Voiced:
 		VoiceSet: Umagon
 	Mobile:
@@ -51,13 +40,6 @@ UMAGON:
 		Weapon: Sniper
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -69,8 +51,6 @@ CHAMSPY:
 		Name: Chameleon Spy
 	Voiced:
 		VoiceSet: Spy
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 120
 	Mobile:
@@ -79,13 +59,6 @@ CHAMSPY:
 		Range: 9c0
 	Passenger:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	Disguise:
 	Infiltrates:
 		Types: SpyInfiltrate
@@ -100,8 +73,6 @@ MUTANT:
 		Cost: 100
 	Tooltip:
 		Name: Mutant
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: Mutant
 	Health:
@@ -116,13 +87,6 @@ MUTANT:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -132,8 +96,6 @@ MWMN:
 		Cost: 100
 	Tooltip:
 		Name: Mutant Soldier
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: CivilianFemale
 	Health:
@@ -148,13 +110,6 @@ MWMN:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -164,8 +119,6 @@ MUTANT3:
 		Cost: 100
 	Tooltip:
 		Name: Mutant Sergeant
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: Mutant
 	Health:
@@ -180,13 +133,6 @@ MUTANT3:
 		Weapon: Vulcan
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -196,8 +142,6 @@ TRATOS:
 		Cost: 100
 	Tooltip:
 		Name: Tratos
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: Tratos
 	Health:
@@ -209,13 +153,6 @@ TRATOS:
 	RevealsShroud:
 		Range: 4c0
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -226,8 +163,6 @@ OXANNA:
 		Cost: 100
 	Tooltip:
 		Name: Oxanna
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: Oxanna
 	Health:
@@ -237,13 +172,6 @@ OXANNA:
 	RevealsShroud:
 		Range: 4c0
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -254,8 +182,6 @@ SLAV:
 		Cost: 100
 	Tooltip:
 		Name: Slavick
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: Slavick
 	Health:
@@ -265,13 +191,6 @@ SLAV:
 	RevealsShroud:
 		Range: 4c0
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	-AutoTarget:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
@@ -289,8 +208,7 @@ DOGGIE:
 		Cost: 100
 	Armor:
 		Type: Light
-	RevealsShroud:
-		Range: 4c0
+	-RevealsShroud:
 	Mobile:
 		Speed: 113
 	Voiced:
@@ -306,66 +224,32 @@ DOGGIE:
 		MaxMoveDelayInTicks: 45
 
 VISSML:
-	Inherits: ^Infantry
+	Inherits: ^Viceroid
 	Tooltip:
 		Name: Baby Visceroid
 	Health:
 		HP: 200
-	PoisonedByTiberium:
-		Weapon: TiberiumHeal
-	Valued:
-		Cost: 1
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 0c0
-	Mobile:
-		Speed: 113
-		ROT: 16
-	-Crushable:
-	Voiced:
-		VoiceSet: Fiend
-	TargetableUnit:
-		TargetTypes: Ground
-	-AutoTarget:
-	-RenderSprites:
-	-WithInfantryBody:
-	-WithDeathAnimation:
-	RenderUnit:
+	AttackWander:
+		WanderMoveRadius: 2
+		MinMoveDelayInTicks: 30
+		MaxMoveDelayInTicks: 60
 
 VISLRG:
-	Inherits: ^Infantry
+	Inherits: ^Viceroid
 	Tooltip:
 		Name: Adult Visceroid
 	Health:
 		HP: 500
-	PoisonedByTiberium:
-		Weapon: TiberiumHeal
-	Valued:
-		Cost: 1
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 0c0
-	Mobile:
-		Speed: 113
-		ROT: 16
-	-Crushable:
-	Voiced:
-		VoiceSet: Fiend
-	TargetableUnit:
-		TargetTypes: Ground
 	Armament:
 		Weapon: SlimeAttack
+	AutoTarget:
 	AttackFrontal:
 	AttackWander:
 		WanderMoveRadius: 2
 		MinMoveDelayInTicks: 25
 		MaxMoveDelayInTicks: 45
-	-RenderSprites:
-	-WithInfantryBody:
-	-WithDeathAnimation:
-	RenderUnit:
+	Mobile:
+		Crushes: crate, infantry
 
 CIV1:
 	Inherits: ^CivilianInfantry

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -185,10 +185,19 @@
 	SelectionDecorations:
 		Palette: pips
 	Selectable:
+		Bounds: 14,23,-1,-9
 	Voiced:
 		VoiceSet: Infantry
 	TargetableUnit:
 		TargetTypes: Ground, Infantry
+	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+			Prone60Percent: 60
+			Prone70Percent: 70
+			Prone100Percent: 100
+			Prone350Percent: 350
+		DamageTriggers: TriggerProne
 	RenderSprites:
 	WithInfantryBody:
 	WithDeathAnimation:
@@ -274,6 +283,7 @@
 		Range: 2c0
 	ProximityCaptor:
 		Types: CivilianInfantry
+	-TakeCover:
 	WithInfantryBody:
 	ScaredyCat:
 	-MustBeDestroyed:
@@ -505,6 +515,43 @@
 		LandWhenIdle: no
 		CruiseAltitude: 2560
 	ReturnOnIdle:
+
+^Viceroid:
+	RenderUnit:
+	AppearsOnRadar:
+	Health:
+		Radius: 256
+	Armor:
+		Type: Light
+	Mobile:
+		Speed: 113
+		ROT: 16
+		Crushes: crate
+		SharesCell: no
+		TerrainSpeeds:
+			Clear: 90
+			Road: 100
+			Rail: 80
+			DirtRoad: 90
+			Rough: 70
+			Tiberium: 100
+			BlueTiberium: 100
+	SelectionDecorations:
+		Palette: pips
+	Selectable:
+		Bounds: 26,26,0,-3
+	TargetableUnit:
+		TargetTypes: Ground
+	AttackMove:
+	HiddenUnderFog:
+	DrawLineToTarget:
+	PoisonedByTiberium:
+		Weapon: TiberiumHeal
+	CombatDebugOverlay:
+	Guardable:
+	BodyOrientation:
+	Huntable:
+	ScriptTriggers:
 
 ^BlossomTree:
 	Tooltip:

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -9,8 +9,6 @@ E2:
 	Tooltip:
 		Name: Disc Thrower
 		Description: Infantry armed with special explosive discs.\n  Strong vs Buildings, Infantry\n  Weak vs Vehicles, Aircraft
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 150
 	Mobile:
@@ -21,13 +19,6 @@ E2:
 		FireDelay: 5
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -42,8 +33,6 @@ MEDIC:
 		Queue: Infantry
 		BuildPaletteOrder: 70
 		Prerequisites: ~gapile
-	Selectable:
-		Bounds: 12,17,0,-6
 	Voiced:
 		VoiceSet: Medic
 	Mobile:
@@ -56,13 +45,6 @@ MEDIC:
 		Weapon: Heal
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		AttackSequence: heal
@@ -81,9 +63,8 @@ JUMPJET:
 		Queue: Infantry
 		BuildPaletteOrder: 40
 		Prerequisites: ~gapile, garadr
-	Selectable:
-		Bounds: 12,17,0,-6
-		Voice: JumpJet
+	Voiced:
+		VoiceSet: JumpJet
 	Mobile:
 		Speed: 56
 	Health:
@@ -99,13 +80,6 @@ JUMPJET:
 	-Crushable:
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 
 GHOST:
@@ -120,9 +94,8 @@ GHOST:
 		BuildPaletteOrder: 50
 		Prerequisites: ~gapile, gatech
 		BuildLimit: 1
-	Selectable:
-		Bounds: 12,17,0,-6
-		Voice: Ghost
+	Voiced:
+		VoiceSet: Ghost
 	Mobile:
 		Speed: 56
 	Health:
@@ -141,13 +114,6 @@ GHOST:
 	C4Demolition:
 		C4Delay: 45
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -9,8 +9,6 @@ E3:
 	Tooltip:
 		Name: Rocket Infantry
 		Description: Anti-tank infantry.\n  Strong vs Vehicles, Aircraft, Buildings\n  Weak vs Infantry
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: Rocket
 	Health:
@@ -22,13 +20,6 @@ E3:
 		LocalOffset: 128,0,640
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -47,7 +38,7 @@ CYBORG:
 		Prerequisites: ~nahand
 	-Crushable:
 	Selectable:
-		Bounds: 14,30,0,-7
+		Bounds: 16,31,0,-10
 	Voiced:
 		VoiceSet: Cyborg
 	Mobile:
@@ -82,7 +73,7 @@ CYC2:
 		BuildLimit: 1
 	-Crushable:
 	Selectable:
-		Bounds: 14,30,0,-7
+		Bounds: 16,32,-1,-12
 	Voiced:
 		VoiceSet: CyborgCommando
 	Mobile:
@@ -109,12 +100,10 @@ MHIJACK:
 		BuildPaletteOrder: 60
 		Prerequisites: ~nahand, natech # natech must be natmpl
 	Valued:
-		Cost: 100
+		Cost: 1850
 	Tooltip:
 		Name: Mutant Hijacker
 		Description: Hijacks enemy vehicles.\n  Unarmed
-	Selectable:
-		Bounds: 12,17,0,-9
 	Voiced:
 		VoiceSet: Hijacker
 	Health:
@@ -129,13 +118,6 @@ MHIJACK:
 		Range: 6c0
 	-AutoTarget:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -9,8 +9,6 @@ E1:
 	Tooltip:
 		Name: Light Infantry
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
-	Selectable:
-		Bounds: 12,17,0,-9
 	Health:
 		HP: 125
 	Mobile:
@@ -26,13 +24,6 @@ E1:
 		UpgradeMinEnabledLevel: 1
 	AttackFrontal:
 	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 
@@ -47,8 +38,6 @@ ENGINEER:
 		Queue: Infantry
 		BuildPaletteOrder: 30
 		Prerequisites: ~barracks
-	Selectable:
-		Bounds: 12,17,0,-6
 	Voiced:
 		VoiceSet: Engineer
 	Mobile:
@@ -62,15 +51,8 @@ ENGINEER:
 	Captures:
 		CaptureTypes: building
 	-AutoTarget:
+	TakeCover:
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
-	TakeCover:
-		DamageModifiers:
-			Prone50Percent: 50
-			Prone60Percent: 60
-			Prone70Percent: 70
-			Prone100Percent: 100
-			Prone350Percent: 350
-		DamageTriggers: TriggerProne
 	-GainsExperience:
 


### PR DESCRIPTION
This is a first step to reduce the large amount of (often unnecessary) duplication in yaml rules as well as a sort-of a prerequisite for #8012 (would reduce the required yaml changes in that PR greatly).

TS:
- Introduces a `^Viceroid` default to TS, to cut down removals/duplications
- Sets default `Bounds` on infantry default to reduce duplication, fixes position
- Moves `TakeCover` definitions to infantry default to cut down yaml lines

D2k:
- Sets default `Bounds` on infantry default to reduce duplication, fixes position
- Removes `TakeCover` properties from individual infantry types to reduce duplication
- Adds prone sequences for engineer and medic/thumper.

TD:
- Sets default `Bounds` on infantry default to reduce duplication
- Adds `TakeCover` trait to individual infantry to work around issue that prone anims don't show

RA:
- Sets default `Bounds` on infantry default to reduce duplication
- Moves `TakeCover` properties to infantry default to reduce duplication
