### PR TITLE
Fixed the trait documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ cli-dependencies:
 native-dependencies:
 	@./configure
 
-version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/modchooser/mod.yaml
+version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/modchooser/mod.yaml mods/all/mod.yaml
 	@for i in $? ; do \
 		awk '{sub("Version:.*$$","Version: $(VERSION)"); print $0}' $${i} > $${i}.tmp && \
 		mv -f $${i}.tmp $${i} ; \

--- a/Makefile
+++ b/Makefile
@@ -310,9 +310,8 @@ version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/modchooser/mo
 		mv -f $${i}.tmp $${i} ; \
 	done
 
-# Documentation (d2k depends on all mod libraries)
 docs: utility mods version
-	@mono --debug OpenRA.Utility.exe d2k --docs > DOCUMENTATION.md
+	@mono --debug OpenRA.Utility.exe all --docs > DOCUMENTATION.md
 	@mono --debug OpenRA.Utility.exe ra --lua-docs > Lua-API.md
 
 install: install-core

--- a/OpenRA.Game/ModMetadata.cs
+++ b/OpenRA.Game/ModMetadata.cs
@@ -23,6 +23,7 @@ namespace OpenRA
 		public string Description;
 		public string Version;
 		public string Author;
+		public bool Hidden;
 
 		static Dictionary<string, ModMetadata> ValidateMods()
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -34,11 +34,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var toc = new StringBuilder();
 			var doc = new StringBuilder();
+			var currentNamespace = "";
 
 			foreach (var t in Game.ModData.ObjectCreator.GetTypesImplementing<ITraitInfo>().OrderBy(t => t.Namespace))
 			{
 				if (t.ContainsGenericParameters || t.IsAbstract)
 					continue; // skip helpers like TraitInfo<T>
+
+				if (currentNamespace != t.Namespace)
+				{
+					currentNamespace = t.Namespace;
+					doc.AppendLine();
+					doc.AppendLine("## {0}".F(currentNamespace));
+				}
 
 				var traitName = t.Name.EndsWith("Info") ? t.Name.Substring(0, t.Name.Length - 4) : t.Name;
 				toc.AppendLine("* [{0}](#{1})".F(traitName, traitName.ToLowerInvariant()));

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			sheetBuilder = new SheetBuilder(SheetType.BGRA);
-			allMods = ModMetadata.AllMods.Values.Where(m => m.Id != "modchooser")
+			allMods = ModMetadata.AllMods.Values.Where(m => !m.Hidden)
 				.OrderBy(m => m.Title)
 				.ToArray();
 

--- a/make.ps1
+++ b/make.ps1
@@ -160,7 +160,7 @@ elseif ($command -eq "check")
 elseif ($command -eq "docs")
 {
 	./make.ps1 version
-	./OpenRA.Utility.exe d2k --docs | Out-File -Encoding "UTF8" DOCUMENTATION.md
+	./OpenRA.Utility.exe all --docs | Out-File -Encoding "UTF8" DOCUMENTATION.md
 	./OpenRA.Utility.exe ra --lua-docs | Out-File -Encoding "UTF8" Lua-API.md
 }
 else

--- a/mods/all/mod.yaml
+++ b/mods/all/mod.yaml
@@ -1,0 +1,36 @@
+Metadata:
+	Title: All mods
+	Version: {DEV_VERSION}
+	Author: The OpenRA Developers
+	Hidden: true
+	Description: Depending on all DLLs.
+
+Folders:
+	.
+
+Cursors:
+
+Chrome:
+
+Assemblies:
+	./mods/common/OpenRA.Mods.Common.dll
+	./mods/ra/OpenRA.Mods.RA.dll
+	./mods/d2k/OpenRA.Mods.D2k.dll
+	./mods/cnc/OpenRA.Mods.Cnc.dll
+	./mods/ts/OpenRA.Mods.TS.dll
+
+ChromeLayout:
+
+Notifications:
+
+LoadScreen: BlankLoadScreen
+
+ChromeMetrics:
+
+Fonts:
+
+LobbyDefaults:
+
+SpriteFormats:
+
+SpriteSequenceFormat: DefaultSpriteSequence

--- a/mods/modchooser/mod.yaml
+++ b/mods/modchooser/mod.yaml
@@ -2,6 +2,7 @@ Metadata:
 	Title: Mod Chooser
 	Version: {DEV_VERSION}
 	Author: The OpenRA Developers
+	Hidden: true
 
 Folders:
 	.


### PR DESCRIPTION
The `d2k` mod does not depend on all mod DLLs anymore. That assumption was a hack anyway. Same as the `modchooser` being the only invisible helper mod. This fixes the https://github.com/OpenRA/OpenRA/wiki/Traits documentation not showing voxel rendering traits which is not helpful when trying to explain things at www.ppmforums.com. I also decided to separate the traits by namespaces to structure the file and so modders know which DLL they need for which feature.
