### PR TITLE
Fix the Windows Make script

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -73,9 +73,12 @@ elseif ($command -eq "clean")
 		$proc = Start-Process $msBuild $msBuildArguments -NoNewWindow -PassThru -Wait
 		rm *.dll
 		rm *.config
-		rm thirdparty/*.dll
-		rmdir thirdparty/windows/
 		rm mods/*/*.dll
+		rm thirdparty/*.dll
+		if(Test-Path -Path thirdparty/windows/)
+		{
+			rmdir thirdparty/windows/ -Recurse
+		}
 		echo "Clean complete."
 	}
 }


### PR DESCRIPTION
The last changes to it appear to have introduced some less than desirable behavior regarding the `thirdparty\windows\` directory.
- Removing the directory on `make clean` will complain the it isn't empty and wants confirmation from the user whether to proceed
- Running a second `make clean` will error because the same directory cannot be found for removal
