### PR TITLE
Separate downloaded files from tracked ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,23 +28,7 @@ mods/*/*.mdb
 /*.pdb
 /*.mdb
 /*.exe
-thirdparty/StyleCop*
-thirdparty/ICSharpCode.SharpZipLib.dll*
-thirdparty/MaxMind*
-thirdparty/RestSharp*
-thirdparty/Newtonsoft.Json*
-thirdparty/SharpFont*
-thirdparty/windows/freetype6.dll
-thirdparty/nunit*
-thirdparty/windows/SDL2.dll
-thirdparty/Mono.Nat.dll
-thirdparty/Moq.dll
-thirdparty/nuget.exe
-thirdparty/windows/lua51.dll
-thirdparty/windows/soft_oal.dll
-thirdparty/FuzzyLogicLibrary.dll
-thirdparty/SDL2-CS.dll
-thirdparty/Eluant.dll
+thirdparty/download/*
 
 # backup files by various editors
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ mono: 3.12.0
 
 # Use the Docker-based infrastructure
 sudo: false
-cache: apt
+
+cache:
+  directories:
+  - thirdparty/download
 
 # Environment variables
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 # Run the build script
 # call RALint to check for YAML errors
 script:
- - travis_retry make cli-dependencies
+ - travis_retry make all-dependencies
  - make all
  - make check
  - make test

--- a/OpenRA.Editor/OpenRA.Editor.csproj
+++ b/OpenRA.Editor/OpenRA.Editor.csproj
@@ -59,7 +59,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Eluant">
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -48,33 +48,33 @@
     <Reference Include="System.Drawing" />
     <Reference Include="SharpFont">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\thirdparty\SharpFont.dll</HintPath>
+      <HintPath>..\thirdparty\download\SharpFont.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Nat">
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
       <Package>mono.nat</Package>
-      <HintPath>..\thirdparty\Mono.Nat.dll</HintPath>
+      <HintPath>..\thirdparty\download\Mono.Nat.dll</HintPath>
     </Reference>
     <Reference Include="Eluant">
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\thirdparty\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\thirdparty\download\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MaxMind.GeoIP2">
-      <HintPath>..\thirdparty\MaxMind.GeoIP2.dll</HintPath>
+      <HintPath>..\thirdparty\download\MaxMind.GeoIP2.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MaxMind.Db">
-      <HintPath>..\thirdparty\MaxMind.Db.dll</HintPath>
+      <HintPath>..\thirdparty\download\MaxMind.Db.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SDL2-CS">
-      <HintPath>..\thirdparty\SDL2-CS.dll</HintPath>
+      <HintPath>..\thirdparty\download\SDL2-CS.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -54,7 +54,7 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="Eluant">
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FuzzyLogicLibrary">
-      <HintPath>..\thirdparty\FuzzyLogicLibrary.dll</HintPath>
+      <HintPath>..\thirdparty\download\FuzzyLogicLibrary.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -42,22 +42,22 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Eluant">
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="StyleCop">
-      <HintPath>..\thirdparty\StyleCop.dll</HintPath>
+      <HintPath>..\thirdparty\download\StyleCop.dll</HintPath>
     </Reference>
     <Reference Include="MaxMind.GeoIP2">
-      <HintPath>..\thirdparty\MaxMind.GeoIP2.dll</HintPath>
+      <HintPath>..\thirdparty\download\MaxMind.GeoIP2.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Nat">
-      <HintPath>..\thirdparty\Mono.Nat.dll</HintPath>
+      <HintPath>..\thirdparty\download\Mono.Nat.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\thirdparty\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\thirdparty\download\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -55,7 +55,7 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="Eluant">
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="Eluant">
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -31,7 +31,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="Eluant">
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Renderer.Sdl2/OpenRA.Renderer.Sdl2.csproj
+++ b/OpenRA.Renderer.Sdl2/OpenRA.Renderer.Sdl2.csproj
@@ -24,7 +24,7 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="SDL2-CS">
-      <HintPath>..\thirdparty\SDL2-CS.dll</HintPath>
+      <HintPath>..\thirdparty\download\SDL2-CS.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -24,12 +24,12 @@
   <ItemGroup>
     <Reference Include="Eluant, Version=1.0.5229.27703, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\thirdparty\Eluant.dll</HintPath>
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\thirdparty\nunit.framework.dll</HintPath>
+      <HintPath>..\thirdparty\download\nunit.framework.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,7 @@ install:
 cache:
   - nsissetup.exe -> appveyor.yaml
   - NsProcess.zip -> appveyor.yaml
-  - thirdparty -> thirdparty\fetch-thirdparty-deps.ps1
-  - thirdparty\windows -> thirdparty\fetch-thirdparty-deps.ps1
+  - thirdparty\download -> thirdparty\fetch-thirdparty-deps.ps1
 
 before_build:
 - make dependencies
@@ -36,7 +35,7 @@ after_test:
   - if not exist NsProcess.zip appveyor DownloadFile "http://nsis.sourceforge.net/mediawiki/images/archive/1/18/20140806212030!NsProcess.zip" -FileName NsProcess.zip
   - 7z x NsProcess.zip -o%NSIS_ROOT% -y
   - move /Y %NSIS_ROOT%\Plugin\nsProcess.dll %NSIS_ROOT%\Plugins\nsProcess.dll
-  - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\windows" /V3 packaging/windows/OpenRA.nsi'
+  - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\download\windows" /V3 packaging/windows/OpenRA.nsi'
   - move /Y %APPVEYOR_BUILD_FOLDER%\packaging\windows\OpenRA.Setup.exe %APPVEYOR_BUILD_FOLDER%\OpenRA-%APPVEYOR_REPO_TAG_NAME%.exe
 
 artifacts:

--- a/make.ps1
+++ b/make.ps1
@@ -74,10 +74,9 @@ elseif ($command -eq "clean")
 		rm *.dll
 		rm *.config
 		rm mods/*/*.dll
-		rm thirdparty/*.dll
-		if(Test-Path -Path thirdparty/windows/)
+		if (Test-Path -Path thirdparty/download/)
 		{
-			rmdir thirdparty/windows/ -Recurse
+			rmdir thirdparty/download -Recurse -Force
 		}
 		echo "Clean complete."
 	}
@@ -116,8 +115,8 @@ elseif ($command -eq "dependencies")
 {
 	cd thirdparty
 	./fetch-thirdparty-deps.ps1
-	cp *.dll ..
-	cp windows/*.dll ..
+	cp download/*.dll ..
+	cp download/windows/*.dll ..
 	cd ..
 	echo "Dependencies copied."
 }

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -28,12 +28,12 @@ make install-linux-mime prefix="/usr" DESTDIR="$PWD/packaging/linux/$ROOTDIR"
 mkdir -p $PWD/packaging/linux/$ROOTDIR/usr/share/doc/openra/
 cp *.html $PWD/packaging/linux/$ROOTDIR/usr/share/doc/openra/
 
-cd packaging/linux
-
-pushd deb
+pushd packaging/linux/deb >/dev/null
 echo "Building Debian package."
-bash buildpackage.sh "$TAG" ../$ROOTDIR "$PACKAGEDIR"
+./buildpackage.sh "$TAG" ../$ROOTDIR "$PACKAGEDIR"
 if [ $? -ne 0 ]; then
     echo "Debian package build failed."
 fi
-popd
+popd >/dev/null
+
+rm -rf $PWD/packaging/linux/$ROOTDIR/

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -50,7 +50,7 @@ PACKAGE_SIZE=`du --apparent-size -c "${DEB_BUILD_ROOT}/usr" | grep "total" | awk
 sed "s/{VERSION}/$VERSION/" DEBIAN/control | sed "s/{SIZE}/$PACKAGE_SIZE/" > "${DEB_BUILD_ROOT}/DEBIAN/control"
 
 # Build it in the temp directory, but place the finished deb in our starting directory
-pushd "${DEB_BUILD_ROOT}"
+pushd "${DEB_BUILD_ROOT}" >/dev/null
 
 # Calculate md5sums and clean up the ./usr/ part of them
 find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 md5sum | sed 's|\./usr/|/usr/|' > DEBIAN/md5sums
@@ -63,6 +63,6 @@ PKGVERSION=`echo $1 | sed "s/-/\\./g"`
 fakeroot dpkg-deb -b . "$3/openra_${PKGVERSION}_all.deb"
 
 # Clean up
-popd
+popd >/dev/null
 rm -rf "${DEB_BUILD_ROOT}"
 

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -15,11 +15,11 @@ if [ -e "OpenRA.app" ]; then
 fi
 
 curl -s -L -O https://github.com/OpenRA/OpenRALauncherOSX/releases/download/${LAUNCHER_TAG}/launcher.zip || exit 3
-unzip launcher.zip
+unzip -qq launcher.zip
 rm launcher.zip
 
 # Copy the template to build the game package
-cp -rv $2/* "OpenRA.app/Contents/Resources/" || exit 3
+cp -r $2/* "OpenRA.app/Contents/Resources/" || exit 3
 
 # Remove unused icon
 rm OpenRA.app/Contents/Resources/OpenRA.ico
@@ -27,9 +27,6 @@ rm OpenRA.app/Contents/Resources/OpenRA.ico
 # Remove broken WinForms applications
 rm OpenRA.app/Contents/Resources/OpenRA.exe
 rm OpenRA.app/Contents/Resources/OpenRA.Editor.exe
-
-# Remove linux cruft
-rm Eluant.dll.config.in
 
 # Set version string
 sed "s/{DEV_VERSION}/${1}/" OpenRA.app/Contents/Info.plist > OpenRA.app/Contents/Info.plist.tmp

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -47,28 +47,29 @@ for i in "${FILES[@]}"; do
 done
 
 # SharpZipLib for zip file support
-cp thirdparty/ICSharpCode.SharpZipLib.dll packaging/built
+cp thirdparty/download/ICSharpCode.SharpZipLib.dll packaging/built
 
 # FuzzyLogicLibrary for improved AI
-cp thirdparty/FuzzyLogicLibrary.dll packaging/built
+cp thirdparty/download/FuzzyLogicLibrary.dll packaging/built
 
 # SharpFont for FreeType support
-cp thirdparty/SharpFont* packaging/built
+cp thirdparty/download/SharpFont* packaging/built
 
 # SDL2-CS
+cp thirdparty/download/SDL2-CS* packaging/built
 cp thirdparty/SDL2-CS* packaging/built
 
 # Mono.NAT for UPnP support
-cp thirdparty/Mono.Nat.dll packaging/built
+cp thirdparty/download/Mono.Nat.dll packaging/built
 
 # Eluant (Lua integration)
-cp thirdparty/Eluant* packaging/built
+cp thirdparty/download/Eluant* packaging/built
 
 # GeoIP database access
-cp thirdparty/MaxMind.Db.dll packaging/built
-cp thirdparty/MaxMind.GeoIP2.dll packaging/built
-cp thirdparty/Newtonsoft.Json.dll packaging/built
-cp thirdparty/RestSharp.dll packaging/built
+cp thirdparty/download/MaxMind.Db.dll packaging/built
+cp thirdparty/download/MaxMind.GeoIP2.dll packaging/built
+cp thirdparty/download/Newtonsoft.Json.dll packaging/built
+cp thirdparty/download/RestSharp.dll packaging/built
 
 # Copy game icon for windows package
 cp OpenRA.Game/OpenRA.ico packaging/built
@@ -79,23 +80,16 @@ cp OpenRA.exe packaging/built
 cd packaging
 echo "Creating packages..."
 
-if [ -x /usr/bin/makensis ]; then
-    pushd windows
-    echo "Building Windows setup.exe"
-    makensis -V2 -DSRCDIR="$BUILTDIR" -DDEPSDIR="${SRCDIR}/thirdparty/windows" OpenRA.nsi
-    if [ $? -eq 0 ]; then
-        mv OpenRA.Setup.exe "$OUTPUTDIR"/OpenRA-$TAG.exe
-    else
-        echo "Windows package build failed."
-    fi
-    popd
-else
-    echo "Skipping Windows setup.exe build due to missing NSIS"
+pushd windows
+./buildpackage.sh "$TAG" "$BUILTDIR" "$SRCDIR" "$OUTPUTDIR"
+if [ $? -ne 0 ]; then
+    echo "Windows package build failed."
 fi
+popd
 
 pushd osx
 echo "Zipping OS X package"
-bash buildpackage.sh "$TAG" "$BUILTDIR" "$OUTPUTDIR"
+./buildpackage.sh "$TAG" "$BUILTDIR" "$OUTPUTDIR"
 if [ $? -ne 0 ]; then
     echo "OS X package build failed."
 fi
@@ -103,7 +97,7 @@ popd
 
 pushd linux
 echo "Building Linux packages"
-bash buildpackage.sh "$TAG" "$BUILTDIR" "$OUTPUTDIR"
+./buildpackage.sh "$TAG" "$BUILTDIR" "$OUTPUTDIR"
 if [ $? -ne 0 ]; then
     echo "Linux package build failed."
 fi

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -25,7 +25,7 @@ test -e Changelog.md && rm Changelog.md
 curl -s -L -O https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md
 
 curl -s -L -O http://daringfireball.net/projects/downloads/Markdown_1.0.1.zip
-unzip Markdown_1.0.1.zip
+unzip -qq Markdown_1.0.1.zip
 rm -rf Markdown_1.0.1.zip
 ./Markdown_1.0.1/Markdown.pl Changelog.md > CHANGELOG.html
 ./Markdown_1.0.1/Markdown.pl README.md > README.html
@@ -80,28 +80,28 @@ cp OpenRA.exe packaging/built
 cd packaging
 echo "Creating packages..."
 
-pushd windows
+pushd windows >/dev/null
 ./buildpackage.sh "$TAG" "$BUILTDIR" "$SRCDIR" "$OUTPUTDIR"
 if [ $? -ne 0 ]; then
     echo "Windows package build failed."
 fi
-popd
+popd >/dev/null
 
-pushd osx
+pushd osx >/dev/null
 echo "Zipping OS X package"
 ./buildpackage.sh "$TAG" "$BUILTDIR" "$OUTPUTDIR"
 if [ $? -ne 0 ]; then
     echo "OS X package build failed."
 fi
-popd
+popd >/dev/null
 
-pushd linux
+pushd linux >/dev/null
 echo "Building Linux packages"
 ./buildpackage.sh "$TAG" "$BUILTDIR" "$OUTPUTDIR"
 if [ $? -ne 0 ]; then
     echo "Linux package build failed."
 fi
-popd
+popd >/dev/null
 
 echo "Package build done."
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TAG="$1"
+BUILTDIR="$2"
+SRCDIR="$3"
+OUTPUTDIR="$4"
+
+if [ -x /usr/bin/makensis ]; then
+    pushd "$SRCDIR" >/dev/null
+    popd >/dev/null
+    if [[ ! -f /usr/share/nsis/Include/nsProcess.nsh &&  ! -f /usr/share/nsis/Plugin/nsProcess.dll ]]; then
+        echo "Installing NsProcess NSIS plugin in /usr/share/nsis"
+        sudo unzip -qq -o ${SRCDIR}/thirdparty/download/NsProcess.zip 'Include/*' -d /usr/share/nsis
+        sudo unzip -qq -j -o ${SRCDIR}/thirdparty/download/NsProcess.zip 'Plugin/*' -d /usr/share/nsis/Plugins
+    fi
+    echo "Building Windows setup.exe"
+    makensis -V2 -DSRCDIR="$BUILTDIR" -DDEPSDIR="${SRCDIR}/thirdparty/download/windows" OpenRA.nsi
+    if [ $? -eq 0 ]; then
+        mv OpenRA.Setup.exe "$OUTPUTDIR"/OpenRA-$TAG.exe
+    else
+        exit 1
+    fi
+else
+    echo "Skipping Windows setup.exe build due to missing NSIS"
+fi

--- a/thirdparty/configure-linux-native-deps.sh
+++ b/thirdparty/configure-linux-native-deps.sh
@@ -27,19 +27,4 @@ if [ "$os" == 'Linux' ]; then
 		sed "s/@LIBLUA51@/${liblua51}/" thirdparty/Eluant.dll.config.in > Eluant.dll.config
 		echo "Eluant.dll.config has been created successfully."
 	fi
-elif [ "$os" == 'Darwin' ]; then
-	if [ ! -f libSDL2.dylib ]; then
-		echo "Fetching OS X SDL2 library from GitHub."
-		curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/libSDL2.dylib
-	fi
-
-	if [ ! -f liblua.5.1.dylib ]; then
-		echo "Fetching OS X Lua 5.1 library from GitHub."
-		curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/liblua.5.1.dylib
-	fi
-
-	if [ ! -f Eluant.dll.config ]; then
-		echo "Fetching OS X Lua configuration file from GitHub."
-		curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/Eluant.dll.config
-	fi
 fi

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+download_dir="${0%/*}/download/osx"
+mkdir -p "$download_dir"
+cd "$download_dir"
+
+if [ ! -f libSDL2.dylib ]; then
+	echo "Fetching OS X SDL2 library from GitHub."
+	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/libSDL2.dylib
+fi
+
+if [ ! -f liblua.5.1.dylib ]; then
+	echo "Fetching OS X Lua 5.1 library from GitHub."
+	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/liblua.5.1.dylib
+fi
+
+if [ ! -f Eluant.dll.config ]; then
+	echo "Fetching OS X Lua configuration file from GitHub."
+	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/Eluant.dll.config
+fi

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -3,34 +3,39 @@
 # Die on any error for Travis CI to automatically retry:
 set -e
 
-if [ ! -d windows ]; then
-	mkdir windows
-fi
+download_dir="${0%/*}/download/windows"
 
-if [ ! -f windows/SDL2.dll ]; then
+mkdir -p "${download_dir}"
+cd "${download_dir}"
+
+if [ ! -f SDL2.dll ]; then
 	echo "Fetching SDL2 from nuget"
 	nuget install sdl2 -Version 2.0.3 -ExcludeVersion
-	cp ./sdl2.redist/build/native/bin/Win32/dynamic/SDL2.dll ./windows/
+	cp ./sdl2.redist/build/native/bin/Win32/dynamic/SDL2.dll .
 	rm -rf sdl2 sdl2.redist
 fi
 
-if [ ! -f windows/freetype6.dll ]; then
+if [ ! -f freetype6.dll ]; then
 	echo "Fetching FreeType2 from nuget"
 	nuget install SharpFont.Dependencies -Version 2.5.5.1 -ExcludeVersion
-	cp ./SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll ./windows/
+	cp ./SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll .
 	rm -rf SharpFont.Dependencies
 fi
 
-if [ ! -f windows/lua51.dll ]; then
+if [ ! -f lua51.dll ]; then
 	echo "Fetching Lua 5.1 from nuget"
 	nuget install lua.binaries -Version 5.1.5 -ExcludeVersion
-	cp ./lua.binaries/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
+	cp ./lua.binaries/bin/win32/dll8/lua5.1.dll ./lua51.dll
 	rm -rf lua.binaries
 fi
 
-if [ ! -f windows/soft_oal.dll ]; then
+if [ ! -f soft_oal.dll ]; then
 	echo "Fetching OpenAL Soft from nuget"
 	nuget install OpenAL-Soft -Version 1.16.0 -ExcludeVersion
-	cp ./OpenAL-Soft/bin/Win32/soft_oal.dll windows/soft_oal.dll
+	cp ./OpenAL-Soft/bin/Win32/soft_oal.dll ./soft_oal.dll
 	rm -rf OpenAL-Soft
+fi
+
+if [ ! -f ../NsProcess.zip ]; then
+	curl -s -L -o ../NsProcess.zip http://nsis.sourceforge.net/mediawiki/images/archive/1/18/20140806212030!NsProcess.zip
 fi

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -1,4 +1,6 @@
-mkdir windows -Force >$null
+mkdir download/windows -Force >$null
+
+cd download
 
 if (!(Test-Path "nuget.exe"))
 {
@@ -127,3 +129,5 @@ if (!(Test-Path "Eluant.dll"))
 	$target = Join-Path $pwd.ToString() "Eluant.dll"
 	(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/Eluant/releases/download/20140425/Eluant.dll", $target)
 }
+
+cd ..

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -3,6 +3,11 @@
 # Die on any error for Travis CI to automatically retry:
 set -e
 
+download_dir="${0%/*}/download"
+
+mkdir -p "${download_dir}"
+cd "${download_dir}"
+
 if [ ! -f StyleCopPlus.dll ]; then
 	echo "Fetching StyleCopPlus from nuget"
 	nuget install StyleCopPlus.MSBuild -Version 4.7.49.5 -ExcludeVersion


### PR DESCRIPTION
This change puts all downloaded files in a separate directory, so that tracked files don't get cached anymore.

Side effects are that building Windows installers on Linux works again, the build scripts produce less distracting output, and [travis now uses caching](http://docs.travis-ci.com/user/caching), too.
