### PR TITLE
Actors will lose targets and AI won't follow indefinitely

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -664,7 +664,7 @@ namespace OpenRA.Mods.Common.AI
 			if (protectSq == null)
 				protectSq = RegisterNewSquad(SquadType.Protection, attacker);
 
-			if (!protectSq.TargetIsValid)
+			if (!protectSq.IsTargetValid)
 				protectSq.TargetActor = attacker;
 
 			if (!protectSq.IsValid)

--- a/OpenRA.Mods.Common/AI/Squad.cs
+++ b/OpenRA.Mods.Common/AI/Squad.cs
@@ -72,9 +72,14 @@ namespace OpenRA.Mods.Common.AI
 			set { Target = Target.FromActor(value); }
 		}
 
-		public bool TargetIsValid
+		public bool IsTargetValid
 		{
 			get { return Target.IsValidFor(Units.FirstOrDefault()) && !Target.Actor.HasTrait<Husk>(); }
+		}
+
+		public bool IsTargetVisible
+		{
+			get { return Bot.Player.PlayerActor.Owner.CanTargetActor(TargetActor); }
 		}
 
 		public WPos CenterPosition { get { return Units.Select(u => u.CenterPosition).Average(); } }

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.AI
 			if (!owner.IsValid)
 				return;
 
-			if (!owner.TargetIsValid)
+			if (!owner.IsTargetValid)
 			{
 				var a = owner.Units.Random(owner.Random);
 				var closestEnemy = owner.Bot.FindClosestEnemy(a.CenterPosition);

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.AI
 			if (!owner.IsValid)
 				return;
 
-			if (!owner.TargetIsValid)
+			if (!owner.IsTargetValid)
 			{
 				var t = owner.Bot.FindClosestEnemy(owner.Units.FirstOrDefault().CenterPosition);
 				if (t == null) return;
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.AI
 			if (!owner.IsValid)
 				return;
 
-			if (!owner.TargetIsValid)
+			if (!owner.IsTargetValid)
 			{
 				var closestEnemy = owner.Bot.FindClosestEnemy(owner.Units.Random(owner.Random).CenterPosition);
 				if (closestEnemy != null)
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.AI
 			if (!owner.IsValid)
 				return;
 
-			if (!owner.TargetIsValid)
+			if (!owner.IsTargetValid)
 			{
 				var closestEnemy = owner.Bot.FindClosestEnemy(owner.Units.Random(owner.Random).CenterPosition);
 				if (closestEnemy != null)

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Target target;
 		readonly AttackPlane attackPlane;
 		readonly AmmoPool[] ammoPools;
+
 		Activity inner;
 		int ticksUntilTurn;
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Pathfinder;
@@ -27,7 +28,23 @@ namespace OpenRA.Mods.Common.Activities
 		readonly DomainIndex domainIndex;
 		readonly uint movementClass;
 
-		protected Target Target { get; private set; }
+		Target target;
+		bool canHideUnderFog;
+		protected Target Target
+		{
+			get
+			{
+				return target;
+			}
+
+			private set
+			{
+				target = value;
+				if (target.Type == TargetType.Actor)
+					canHideUnderFog = target.Actor.HasTrait<HiddenUnderFog>();
+			}
+		}
+
 		protected CPos targetPosition;
 		Activity inner;
 		bool repath;
@@ -65,6 +82,17 @@ namespace OpenRA.Mods.Common.Activities
 		public override Activity Tick(Actor self)
 		{
 			var targetIsValid = Target.IsValidFor(self);
+
+			// Target moved under the fog. Move to its last known position.
+			if (Target.Type == TargetType.Actor && canHideUnderFog
+				&& !self.Owner.CanTargetActor(Target.Actor))
+			{
+				if (inner != null)
+					inner.Cancel(self);
+
+				self.SetTargetLine(Target.FromCell(self.World, targetPosition), Color.Green);
+				return Util.RunActivity(self, new AttackMoveActivity(self, mobile.MoveTo(targetPosition, 0)));
+			}
 
 			// Inner move order has completed.
 			if (inner == null)


### PR DESCRIPTION
In issue #7567, actors would keep chasing the enemy even if it moved under the shroud. The target-line was also visible making it very easy to track the target. I changed the FlyAttack, HeliAttack and MoveAdjacent activity to check if the target moved under shroud, if so, the attack activity is cancelled and a regular move is issued to the last known location.

Closes #7567.
Closes #7584.
Closes #7498.

This supersedes #7654. Changes to that pr are:
1. Uses `HiddenUnderFog` instead of `FrozenUnderFog`.
2. Adds a switch for `HeliAttack` and `FlyAttack` to ignore the behaviour, and makes it available to the Lua API.
