### PR TITLE
Don't do trait lookups for Health on each processed order

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -297,8 +297,7 @@ namespace OpenRA.Network
 						if (!order.IsImmediate)
 						{
 							var self = order.Subject;
-							var health = self.TraitOrDefault<Health>();
-							if (health == null || !health.IsDead)
+							if (!self.IsDead)
 								foreach (var t in self.TraitsImplementing<IResolveOrder>())
 									t.ResolveOrder(self, order);
 						}


### PR DESCRIPTION
A small random fix that will save _a ton_ of unnecessary trait lookups.
