### PR TITLE
Fixes location of phase transport being revealed by attack line.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -383,11 +383,11 @@ namespace OpenRA.Traits
 
 		public bool IsTargetable(Actor a)
 		{
-			if (HasFogVisibility())
-				return true;
-
 			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a, self.Owner)))
 				return false;
+
+			if (HasFogVisibility())
+				return true;
 
 			return GetVisOrigins(a).Any(IsVisible);
 		}


### PR DESCRIPTION
Location of cloaked enemy phase transport is revealed by attack line if the player has satellite. Units don't attack it but choose it as a target. This patch fixes it by reordering IsTargetable() checks.

![cloaked_unit_auto_targeted](https://cloud.githubusercontent.com/assets/6599106/7497245/f5b185ea-f421-11e4-9eb5-566bccc51349.png)
