### PR TITLE
Only issue a MouseMove event if the scroll offset actually changed.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -74,11 +74,15 @@ namespace OpenRA.Mods.Common.Widgets
 			targetListOffset = value;
 			if (!smooth)
 			{
+				var oldListOffset = currentListOffset;
 				currentListOffset = value;
 
 				// Update mouseover
-				var mi = new MouseInput(MouseInputEvent.Move, MouseButton.None, 0, Viewport.LastMousePos, Modifiers.None, 0);
-				Ui.HandleInput(mi);
+				if (oldListOffset != currentListOffset)
+				{
+					var mi = new MouseInput(MouseInputEvent.Move, MouseButton.None, 0, Viewport.LastMousePos, Modifiers.None, 0);
+					Ui.HandleInput(mi);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #8098.  Easiest testcase is the lobby.
