### PR TITLE
Fix objectives window

### DIFF
--- a/mods/cnc/chrome/ingame-infoobjectives.yaml
+++ b/mods/cnc/chrome/ingame-infoobjectives.yaml
@@ -21,20 +21,22 @@ Container@MISSION_OBJECTIVES:
 			Y: 50
 			Width: 482
 			Height: 310
-			ItemSpacing: 35
+			ItemSpacing: 15
 			Children:
 				Container@OBJECTIVE_TEMPLATE:
+					Width: PARENT_RIGHT
+					Height: 20
 					Children:
 						Label@OBJECTIVE_TYPE:
 							X: 10
-							Y: 0 - 20
-							Height: 20
+							Y: 0
 							Width: 70
+							Height: PARENT_BOTTOM
 							Align: Center
 						Checkbox@OBJECTIVE_STATUS:
 							X: 90
-							Y: 0 - 20
+							Y: 0
 							Width: PARENT_RIGHT - 100
-							Height: 20
+							Height: PARENT_BOTTOM
 							Disabled: True
 							TextColorDisabled: 255,255,255

--- a/mods/ra/chrome/ingame-infoobjectives.yaml
+++ b/mods/ra/chrome/ingame-infoobjectives.yaml
@@ -21,20 +21,22 @@ Container@MISSION_OBJECTIVES:
 			Y: 60
 			Width: 482
 			Height: 310
-			ItemSpacing: 35
+			ItemSpacing: 15
 			Children:
 				Container@OBJECTIVE_TEMPLATE:
+					Width: PARENT_RIGHT
+					Height: 20
 					Children:
 						Label@OBJECTIVE_TYPE:
 							X: 10
-							Y: 0 - 20
-							Height: 20
+							Y: 0
 							Width: 70
+							Height: PARENT_BOTTOM
 							Align: Center
 						Checkbox@OBJECTIVE_STATUS:
 							X: 90
-							Y: 0 - 20
+							Y: 0
 							Width: PARENT_RIGHT - 100
-							Height: 20
+							Height: PARENT_BOTTOM
 							Disabled: True
 							TextColorDisabled: 255,255,255


### PR DESCRIPTION
Fixes #8100.

The container widget previously had no size, which meant it was being excluded from drawing by the logic introduced into the scroll panel in #7917. Providing a sensibly defined size avoids the problem.
