### PR TITLE
Add D2k faction description tooltips

### DIFF
--- a/mods/d2k/chrome/lobby-playerbin.yaml
+++ b/mods/d2k/chrome/lobby-playerbin.yaml
@@ -63,6 +63,9 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 					Width: 130
 					Height: 25
 					IgnoreChildMouseOver: true
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: FACTION_DESCRIPTION_TOOLTIP
+					PanelRoot: FACTION_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
 					Children:
 						Image@FACTIONFLAG:
 							Width: 23
@@ -328,12 +331,27 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 ScrollPanel@RACE_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:
+		ScrollItem@HEADER:
+			BaseName: scrollheader
+			Width: PARENT_RIGHT-27
+			Height: 13
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					Font: TinyBold
+					Width: PARENT_RIGHT
+					Height: 10
+					Align: Center
 		ScrollItem@TEMPLATE:
 			Width: PARENT_RIGHT-27
 			Height: 25
 			X: 2
 			Y: 0
 			Visible: false
+			TooltipContainer: TOOLTIP_CONTAINER
+			TooltipTemplate: FACTION_DESCRIPTION_TOOLTIP
 			Children:
 				Image@FLAG:
 					X: 2

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -196,3 +196,22 @@ Background@SUPPORT_POWER_TOOLTIP:
 			Y: 22
 			Font: TinyBold
 			VAlign: Top
+
+Background@FACTION_DESCRIPTION_TOOLTIP:
+	Logic: CountryTooltipLogic
+	Background: dialog4
+	Children:
+		Label@HEADER:
+			X: 7
+			Y: 6
+			Width: 8
+			Height: 12
+			Font: Bold
+			VAlign: Top
+		Label@DESCRIPTION:
+			X: 14
+			Y: 0
+			Width: 15
+			Height: 14
+			Font: TinyBold
+			VAlign: Top

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -98,15 +98,19 @@ World:
 		Name: Any
 		Race: Random
 		RandomRaceMembers: atreides, harkonnen, ordos
+		Description: Select a random House.
 	Country@Atreides:
 		Name: Atreides
 		Race: atreides
+		Description: House Atreides\nThe noble Atreides, from the water world of Caladan,\nrely on their ornithopters to ensure air superiority.\nThey have allied themselves with the Fremen, the fearsome\nnative warriors of Dune that can move undetected in battle.
 	Country@Harkonnen:
 		Name: Harkonnen
 		Race: harkonnen
+		Description: House Harkonnen\nThe evil Harkonnen will stop at nothing to gain control of the spice.\nThey rely on brute force and atomic weapons to achieve their goals:\nwealth, and the destruction of House Atreides.
 	Country@Ordos:
 		Name: Ordos
 		Race: ordos
+		Description: House Ordos\nThe insidious Ordos of the icy planet Sigma Draconis IV\nare known for their wealth, greed and treachery.\nRelying heavily on mercenaries they often resort\nto sabotage and forbidden Ixian technologies.
 	Country@Corrino:
 		Name: Corrino
 		Race: corrino


### PR DESCRIPTION
Fixes the D2k part of #6288 using 4f4c67735d45bf20f62b9b334e19a6294a9e4b7b as template.
Depends on #8099. When that is merged the (sloppy) first commit will be gone.
