### PR TITLE
Fixes WithIdleOverlay to start with first frame after make animation

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => IsTraitDisabled || !buildComplete,
-				() => info.PauseOnLowPower && self.IsDisabled(),
+				() => (info.PauseOnLowPower && self.IsDisabled()) || !buildComplete,
 				p => WithTurret.ZOffsetFromCenter(self, p, 1));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);


### PR DESCRIPTION
Fixes #8108, as noticed in #8106.

The difference is most visible if you compare bleed TS mod with this branch and build a Nod radar. Before this fix, the idle dish animation would start at the wrong frame, so there would be a noticable misalignment between the end of the make animation and "start" of the idle overlay.

This is because before this fix, the idle overlay was just not drawn, but not actually stopped/disabled, so (assuming identical Tick rate) if the make anim was 15 frames, and the idle overlay 30 frames, the overlay would "start" at frame 16 once the make anim finished.

With this fix, the idle overlay is properly stopped/disabled until the build is complete/make anim finishes, and then starts with the first frame.

Fixes starting frame for all buildings with idle overlays (mostly affects TS).
