### PR TITLE
Add D2k building upgrades

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -211,6 +211,7 @@ namespace OpenRA
 		public Hotkey ProductionTypeNavalKey = new Hotkey(Keycode.I, Modifiers.None);
 		public Hotkey ProductionTypeTankKey = new Hotkey(Keycode.I, Modifiers.None);
 		public Hotkey ProductionTypeMerchantKey = new Hotkey(Keycode.O, Modifiers.None);
+		public Hotkey ProductionTypeUpgradeKey = new Hotkey(Keycode.R, Modifiers.None);
 
 		public Hotkey SupportPower01Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
 		public Hotkey SupportPower02Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -425,7 +425,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "ProductionTypeAircraftKey", "Aircraft Tab" },
 					{ "ProductionTypeNavalKey", "Naval Tab" },
 					{ "ProductionTypeTankKey", "Tank Tab" },
-					{ "ProductionTypeMerchantKey", "Starport Tab" }
+					{ "ProductionTypeMerchantKey", "Starport Tab" },
+					{ "ProductionTypeUpgradeKey", "Upgrade Tab" }
 				};
 
 				for (var i = 1; i <= 24; i++)

--- a/mods/d2k/audio/notifications.yaml
+++ b/mods/d2k/audio/notifications.yaml
@@ -37,6 +37,7 @@ Speech:
 		EnemyUnitsDetected: ENEMY_DETECTED
 		UnitRepaired: GANEW
 		CannotDeploy: DPLOY
+		Upgrading: UPGRD
 
 Sounds:
 	DefaultVariant: .WAV

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -45,6 +45,9 @@ production-icons: chrome.png
 	building: 430,0,16,16
 	building-disabled: 446,0,16,16
 	building-alert: 462,0,16,16
+	upgrade: 430,224,16,16
+	upgrade-disabled: 446,224,16,16
+	upgrade-alert: 462,224,16,16
 	infantry: 430,32,16,16
 	infantry-disabled: 446,32,16,16
 	infantry-alert: 462,32,16,16

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -243,7 +243,7 @@ Container@PLAYER_WIDGETS:
 					IconSize: 58, 48
 					IconMargin: 2, 0
 					IconSpriteOffset: 0, 0
-					MinimumRows: 4
+					MinimumRows: 5
 					MaximumRows: 6
 				Container@PALETTE_FOREGROUND:
 					X: 64
@@ -259,7 +259,7 @@ Container@PLAYER_WIDGETS:
 					X: 6
 					Y: 2
 					Width: 25
-					Height: 243
+					Height: 274
 					Children:
 						ProductionTypeButton@BUILDING:
 							Width: 25
@@ -275,8 +275,23 @@ Container@PLAYER_WIDGETS:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
-						ProductionTypeButton@INFANTRY:
+						ProductionTypeButton@UPGRADE:
 							Y: 31
+							Width: 25
+							Height: 25
+							VisualHeight: 0
+							Background: sidebar-button
+							TooltipText: Upgrades
+							TooltipContainer: TOOLTIP_CONTAINER
+							ProductionGroup: Upgrade
+							HotkeyName: ProductionTypeUpgradeKey
+							Children:
+								Image@ICON:
+									X: 5
+									Y: 5
+									ImageCollection: production-icons
+						ProductionTypeButton@INFANTRY:
+							Y: 62
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -291,12 +306,12 @@ Container@PLAYER_WIDGETS:
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@VEHICLE:
-							Y: 62
+							Y: 93
 							Width: 25
 							Height: 25
 							VisualHeight: 0
 							Background: sidebar-button
-							TooltipText: Vehicles
+							TooltipText: Light Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
 							HotkeyName: ProductionTypeVehicleKey
@@ -306,12 +321,12 @@ Container@PLAYER_WIDGETS:
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@TANKS:
-							Y: 93
+							Y: 124
 							Width: 25
 							Height: 25
 							VisualHeight: 0
 							Background: sidebar-button
-							TooltipText: Tanks
+							TooltipText: Heavy Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Armor
 							HotkeyName: ProductionTypeTankKey
@@ -321,7 +336,7 @@ Container@PLAYER_WIDGETS:
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@AIRCRAFT:
-							Y: 124
+							Y: 155
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -336,7 +351,7 @@ Container@PLAYER_WIDGETS:
 									Y: 5
 									ImageCollection: production-icons
 						ProductionTypeButton@STARPORT:
-							Y: 155
+							Y: 186
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -351,7 +366,7 @@ Container@PLAYER_WIDGETS:
 									Y: 5
 									ImageCollection: production-icons
 						Button@SCROLL_UP_BUTTON:
-							Y: 186
+							Y: 217
 							Width: 25
 							Height: 25
 							VisualHeight: 0
@@ -365,7 +380,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: scrollbar
 									ImageName: up_arrow
 						Button@SCROLL_DOWN_BUTTON:
-							Y: 217
+							Y: 248
 							Width: 25
 							Height: 25
 							VisualHeight: 0

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@Omnius:
 		Name: Omnius
+		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
 			ConstructionYard: conyard
@@ -21,6 +22,10 @@ Player:
 			radar: 1
 			hightech: 1
 			palace: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
 		BuildingFractions:
 			refinery: 20.1%
 			barracks: 0.1%
@@ -34,6 +39,10 @@ Player:
 			guntower: 8%
 			rockettower: 6%
 			power: 10%
+			upgrade.barracks: 0.1%
+			upgrade.light: 0.1%
+			upgrade.heavy: 0.1%
+			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
 			rifle: 6%
@@ -118,6 +127,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@Vidius:
 		Name: Vidious
+		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
 			ConstructionYard: conyard
@@ -138,6 +148,10 @@ Player:
 			radar: 1
 			hightech: 1
 			palace: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
 		BuildingFractions:
 			refinery: 20.1%
 			barracks: 0.1%
@@ -151,6 +165,10 @@ Player:
 			guntower: 5%
 			rockettower: 10%
 			power: 12%
+			upgrade.barracks: 0.1%
+			upgrade.light: 0.1%
+			upgrade.heavy: 0.1%
+			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
 			rifle: 2%
@@ -235,6 +253,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@Gladius:
 		Name: Gladius
+		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
 			ConstructionYard: conyard
@@ -255,6 +274,10 @@ Player:
 			radar: 1
 			hightech: 1
 			palace: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
 		BuildingFractions:
 			refinery: 20.1%
 			barracks: 0.1%
@@ -268,6 +291,10 @@ Player:
 			guntower: 4%
 			rockettower: 12%
 			power: 10%
+			upgrade.barracks: 0.1%
+			upgrade.light: 0.1%
+			upgrade.heavy: 0.1%
+			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
 			rifle: 15%

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -29,7 +29,7 @@ engineer:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 50
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: upgrade.barracks, ~techlevel.medium
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -58,7 +58,7 @@ bazooka:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 20
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: upgrade.barracks, ~techlevel.medium
 	Valued:
 		Cost: 250
 	Tooltip:
@@ -72,7 +72,7 @@ bazooka:
 		Speed: 42
 	Armament:
 		Weapon: Bazooka
-		LocalOffset: 128,0,256
+		LocalOffset: 0,0,555
 	AttackFrontal:
 	TakeCover:
 		DamageModifiers:
@@ -86,7 +86,7 @@ medic:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 60
-		Prerequisites: ~barracks.medics, ~techlevel.high
+		Prerequisites: ~barracks.medics, upgrade.barracks, ~techlevel.high
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -122,7 +122,7 @@ fremen:
 		Description: Elite sniper infantry unit\n  Strong vs Infantry\n  Weak vs Vehicles\n  Special Ability: Invisibility
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 85
+		BuildPaletteOrder: 100
 		Prerequisites: ~barracks.atreides, palace, ~techlevel.high
 	Selectable:
 		Bounds: 12,17,0,0
@@ -156,8 +156,8 @@ grenadier:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 10
-		Prerequisites: ~barracks.atreides, ~techlevel.medium
+		BuildPaletteOrder: 80
+		Prerequisites: ~barracks.atreides, upgrade.barracks, hightech, ~techlevel.medium
 	Valued:
 		Cost: 160
 	Tooltip:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -152,3 +152,91 @@ wormspawner:
 	RenderEditorOnly:
 	BodyOrientation:
 	WormSpawner:
+
+upgrade.conyard:
+	Tooltip:
+		Name: Construction Yard Upgrade
+		Description: Unlocks new construction options
+	Buildable:
+		BuildPaletteOrder: 50
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 1000
+	RenderSprites:
+		Image: conyard.harkonnen
+		RaceImages:
+			atreides: conyard.atreides
+			ordos: conyard.ordos
+			corrino: conyard.corrino
+	ProvidesPrerequisite@upgradename:
+
+upgrade.barracks:
+	Tooltip:
+		Name: Barracks Upgrade
+		Description: Unlocks additional infantry
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: barracks
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 500
+	RenderSprites:
+		Image: barracks.harkonnen
+		RaceImages:
+			atreides: barracks.atreides
+			ordos: barracks.ordos
+	ProvidesPrerequisite@upgradename:
+
+upgrade.light:
+	Tooltip:
+		Name: Light Factory Upgrade
+		Description: Unlocks additional light units
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: light
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 400
+	RenderSprites:
+		Image: light.harkonnen
+		RaceImages:
+			atreides: light.atreides
+			ordos: light.ordos
+	ProvidesPrerequisite@upgradename:
+
+upgrade.heavy:
+	Tooltip:
+		Name: Heavy Factory Upgrade
+		Description: Unlocks advanced technology and heavy weapons
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: heavy
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 800
+	RenderSprites:
+		Image: heavy.harkonnen
+		RaceImages:
+			atreides: heavy.atreides
+			ordos: heavy.ordos
+			corrino: heavy.corrino
+	ProvidesPrerequisite@upgradename:
+
+upgrade.hightech:
+	Tooltip:
+		Name: High Tech Factory Upgrade
+		Description: Unlocks the Air Strike superweapon
+	Buildable:
+		BuildPaletteOrder: 50
+		Prerequisites: ~hightech.atreides, ~techlevel.superweapons
+		Queue: Upgrade
+		BuildLimit: 1
+	Valued:
+		Cost: 1500
+	RenderSprites:
+		Image: hightech.atreides
+	ProvidesPrerequisite@upgradename:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -6,6 +6,12 @@ Player:
 		QueuedAudio: Building
 		ReadyAudio: BuildingReady
 		BlockedAudio: NoRoom
+	ClassicProductionQueue@Upgrade:
+		Type: Upgrade
+		LowPowerSlowdown: 3
+		QueuedAudio: Upgrading
+		ReadyAudio: NewOptions
+		BlockedAudio: NoRoom
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		LowPowerSlowdown: 2

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -32,6 +32,8 @@ concreteb:
 		Dimensions: 3,3
 	Valued:
 		Cost: 50
+	Buildable:
+		Prerequisites: upgrade.conyard
 
 conyard:
 	Inherits: ^Building
@@ -301,9 +303,10 @@ light:
 	ProvidesPrerequisite@harkonnen:
 		Prerequisite: light.harkonnen
 		Race: harkonnen
-	ProvidesPrerequisite@TRIKES:
+	ProvidesPrerequisite@trikes:
 		Prerequisite: light.regulartrikes
 		Race: atreides, harkonnen
+	ProvidesPrerequisite@buildingname:
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
 	WithIdleOverlay@TOP:
@@ -352,6 +355,9 @@ heavy:
 	ProvidesPrerequisite@harkonnen:
 		Prerequisite: heavy.harkonnen
 		Race: harkonnen
+	ProvidesPrerequisite@missiletank:
+		Prerequisite: heavy.missiletank
+		Race: atreides, harkonnen
 	RenderBuilding:
 		Image: heavy.harkonnen
 		RaceImages:
@@ -416,7 +422,7 @@ starport:
 		Name: Starport
 		Description: Dropzone for quick reinforcements, at a price.\n  Requires power to operate
 	Buildable:
-		Prerequisites: radar, ~techlevel.high
+		Prerequisites: heavy, radar, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 80
 	Building:
@@ -525,7 +531,7 @@ guntower:
 	Valued:
 		Cost: 650
 	Tooltip:
-		Name: Gun Tower
+		Name: Gun Turret
 		Description: Defensive structure\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
 	Building:
 		Adjacent: 4
@@ -574,12 +580,12 @@ rockettower:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: radar, upgrade.conyard, ~techlevel.medium
 		BuildPaletteOrder: 120
 	Valued:
 		Cost: 850
 	Tooltip:
-		Name: Rocket Tower
+		Name: Rocket Turret
 		Description: Defensive structure\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks\n\n  Requires power to operate
 	Building:
 		Adjacent: 4
@@ -629,7 +635,7 @@ repair:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: heavy, ~techlevel.medium
+		Prerequisites: heavy, upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 130
 	Valued:
 		Cost: 500
@@ -674,7 +680,7 @@ hightech:
 	Valued:
 		Cost: 750
 	Tooltip:
-		Name: High Tech Facility
+		Name: High Tech Factory
 		Description: Unlocks advanced technology
 	ProductionFromMapEdge:
 		Produces: Aircraft
@@ -696,17 +702,31 @@ hightech:
 		RaceImages:
 			atreides: hightech.atreides
 			ordos: hightech.ordos
+	ProvidesPrerequisite@upgrade:
+		Prerequisite: hightech.atreides
+		Race: atreides
+	ProvidesPrerequisite@buildingname:
+	AirstrikePower:
+		Icon: ornistrike
+		Description: Air Strike
+		Prerequisites: ~techlevel.superweapons, upgrade.hightech
+		ChargeTime: 180
+		SquadSize: 3
+		LongDesc: Ornithopters hit the target with parabombs
+		UnitType: orni.bomber
+		SelectTargetSound:
+		DisplayBeacon: True
+		CameraActor: camera
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
 	Power:
 		Amount: -40
-	ProvidesPrerequisite@buildingname:
 
 research:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: hightech, ~techlevel.high
+		Prerequisites: radar, heavy, upgrade.heavy, ~techlevel.high
 		BuildPaletteOrder: 140
 	Selectable:
 		Bounds: 96,64
@@ -759,7 +779,7 @@ palace:
 		Cost: 2000
 	Tooltip:
 		Name: Palace
-		Description: Unlocks elite infantry and support powers
+		Description: Unlocks elite infantry
 	Building:
 		Footprint: xx= xxx =xx
 		Dimensions: 3,3
@@ -782,23 +802,9 @@ palace:
 		Range: 4
 	Power:
 		Amount: -50
-	ProvidesPrerequisite@airstrike:
-		Prerequisite: palace.airstrike
-		Race: atreides, ordos
 	ProvidesPrerequisite@nuke:
 		Prerequisite: palace.nuke
 		Race: harkonnen
-	AirstrikePower:
-		Icon: ornistrike
-		Prerequisites: ~techlevel.superweapons, ~palace.airstrike
-		Description: Air Strike
-		ChargeTime: 180
-		SquadSize: 3
-		LongDesc: Ornithopter drops a load of parachuted\nbombs on your target
-		UnitType: orni.bomber
-		SelectTargetSound:
-		DisplayBeacon: True
-		CameraActor: camera
 	NukePower:
 		Icon: deathhand
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -52,7 +52,9 @@ conyard:
 	RevealsShroud:
 		Range: 10c0
 	Production:
-		Produces: Building
+		Produces: Building, Upgrade
+		MoveIntoWorld: false
+	Exit:
 	Valued:
 		Cost: 2000
 	Tooltip:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -1,7 +1,7 @@
 mcv:
 	Inherits: ^Vehicle
 	Buildable:
-		Prerequisites: repair, ~techlevel.medium
+		Prerequisites: repair, upgrade.heavy, ~techlevel.medium
 		Queue: Armor
 		BuildPaletteOrder: 110
 	Valued:
@@ -124,7 +124,7 @@ quad:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: upgrade.light, ~techlevel.medium
 		BuildPaletteOrder: 20
 	Valued:
 		Cost: 400
@@ -157,7 +157,7 @@ siegetank:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Armor
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 50
 	Valued:
 		Cost: 850
@@ -209,7 +209,7 @@ missiletank:
 		Description: Rocket Artillery\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Buildable:
 		Queue: Armor
-		Prerequisites: hightech, ~techlevel.high
+		Prerequisites: ~heavy.missiletank, upgrade.heavy, research, ~techlevel.high
 		BuildPaletteOrder: 60
 	Mobile:
 		Speed: 64
@@ -350,7 +350,7 @@ raider:
 stealthraider:
 	Inherits: raider
 	Buildable:
-		Prerequisites: ~light.ordos, hightech, ~techlevel.medium
+		Prerequisites: ~light.ordos, upgrade.light, ~techlevel.medium
 		BuildPaletteOrder: 30
 	Valued:
 		Cost: 400


### PR DESCRIPTION
This PR supersedes #7597, including an update for removed traits and a couple of fixes.
As stated on the previous PR, this fixes the tech tree + some actor namings.

Same rules apply: if you can't check the original game, consult [this for buildings](http://dune2k.com/Duniverse/Games/Dune2000/Details/HierarchyCharts) and [this for units](http://dune2k.com/View/Images/Duniverse/Games/Dune2000/HierarchyCharts/Dune2000Hierarchy.jpg).
Production tab hotkeys have been fixed.

Closes #3211.
Fixes #8010.
