### PR TITLE
Remove Owner from ActorPreviews.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -25,16 +25,14 @@ namespace OpenRA.Mods.Common.Graphics
 	public class ActorPreviewInitializer
 	{
 		public readonly ActorInfo Actor;
-		public readonly Player Owner;
 		public readonly WorldRenderer WorldRenderer;
 		public World World { get { return WorldRenderer.World; } }
 
 		readonly TypeDictionary dict;
 
-		public ActorPreviewInitializer(ActorInfo actor, Player owner, WorldRenderer worldRenderer, TypeDictionary dict)
+		public ActorPreviewInitializer(ActorInfo actor, WorldRenderer worldRenderer, TypeDictionary dict)
 		{
 			Actor = actor;
-			Owner = owner;
 			WorldRenderer = worldRenderer;
 			this.dict = dict;
 		}

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -170,10 +170,11 @@ namespace OpenRA.Mods.Common.Orders
 					var td = new TypeDictionary()
 					{
 						new RaceInit(race),
+						new OwnerInit(producer.Owner),
 						new HideBibPreviewInit()
 					};
 
-					var init = new ActorPreviewInitializer(rules.Actors[building], producer.Owner, wr, td);
+					var init = new ActorPreviewInitializer(rules.Actors[building], wr, td);
 					preview = rules.Actors[building].Traits.WithInterface<IRenderActorPreviewInfo>()
 						.SelectMany(rpi => rpi.RenderPreview(init))
 						.ToArray();

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -56,15 +56,16 @@ namespace OpenRA.Mods.Common.Traits
 		public IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
 			var sequenceProvider = init.World.Map.SequenceProvider;
-			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Owner.Country.Race;
+			var race = init.Get<RaceInit, string>();
+			var ownerName = init.Get<OwnerInit>().PlayerName;
 			var image = GetImage(init.Actor, sequenceProvider, race);
-			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + init.Owner.InternalName);
+			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + ownerName);
 
 			var facings = 0;
 			var body = init.Actor.Traits.GetOrDefault<BodyOrientationInfo>();
 			if (body != null)
 				facings = body.QuantizedFacings == -1 ?
-					init.Actor.Traits.Get<IQuantizeBodyOrientationInfo>().QuantizedBodyFacings(init.Actor, sequenceProvider, init.Owner.Country.Race) :
+					init.Actor.Traits.Get<IQuantizeBodyOrientationInfo>().QuantizedBodyFacings(init.Actor, sequenceProvider, race) :
 					body.QuantizedFacings;
 
 			foreach (var spi in init.Actor.Traits.WithInterface<IRenderActorPreviewSpritesInfo>())

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -46,9 +46,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override Widget Clone() { return new ActorPreviewWidget(this); }
 
-		public void SetPreview(ActorInfo actor, Player owner, TypeDictionary td)
+		public void SetPreview(ActorInfo actor, TypeDictionary td)
 		{
-			var init = new ActorPreviewInitializer(actor, owner, worldRenderer, td);
+			var init = new ActorPreviewInitializer(actor, worldRenderer, td);
 			preview = actor.Traits.WithInterface<IRenderActorPreviewInfo>()
 				.SelectMany(rpi => rpi.RenderPreview(init))
 				.ToArray();

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -30,8 +30,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var td = new TypeDictionary();
 			td.Add(new HideBibPreviewInit());
-
-			preview.SetPreview(actor, world.WorldActor.Owner, td);
+			td.Add(new OwnerInit(world.WorldActor.Owner));
+			td.Add(new RaceInit(world.WorldActor.Owner.PlayerReference.Race));
+			preview.SetPreview(actor, td);
 
 			var hueSlider = widget.Get<SliderWidget>("HUE");
 			var mixer = widget.Get<ColorMixerWidget>("MIXER");

--- a/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.TS/Traits/Render/RenderVoxels.cs
@@ -49,12 +49,14 @@ namespace OpenRA.Mods.TS.Traits
 		public virtual IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
 			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var race = init.Get<RaceInit, string>();
+			var ownerName = init.Get<OwnerInit>().PlayerName;
 			var sequenceProvider = init.World.Map.SequenceProvider;
 			var image = Image ?? init.Actor.Name;
 			var facings = body.QuantizedFacings == -1 ?
-				init.Actor.Traits.Get<IQuantizeBodyOrientationInfo>().QuantizedBodyFacings(init.Actor, sequenceProvider, init.Owner.Country.Race) :
+				init.Actor.Traits.Get<IQuantizeBodyOrientationInfo>().QuantizedBodyFacings(init.Actor, sequenceProvider, race) :
 				body.QuantizedFacings;
-			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + init.Owner.InternalName);
+			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + ownerName);
 
 			var ifacing = init.Actor.Traits.GetOrDefault<IFacingInfo>();
 			var facing = ifacing != null ? init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing() : 0;


### PR DESCRIPTION
This takes them one step closer to being useable by utilities that don't set up a real world.  Prerequisite of #8065.
