### PR TITLE
Reorganize palette loading.

### DIFF
--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -30,6 +30,11 @@ namespace OpenRA.Graphics
 			readOnlyModifiablePalettes = modifiablePalettes.AsReadOnly();
 		}
 
+		public bool Contains(string name)
+		{
+			return modifiablePalettes.ContainsKey(name) || palettes.ContainsKey(name);
+		}
+
 		public IPalette GetPalette(string name)
 		{
 			MutablePalette mutable;

--- a/OpenRA.Game/Graphics/PaletteReference.cs
+++ b/OpenRA.Game/Graphics/PaletteReference.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Graphics
+{
+	public sealed class PaletteReference
+	{
+		readonly float index;
+		readonly HardwarePalette hardwarePalette;
+
+		public readonly string Name;
+		public IPalette Palette { get; internal set; }
+		public float TextureIndex { get { return index / hardwarePalette.Height; } }
+		public float TextureMidIndex { get { return (index + 0.5f) / hardwarePalette.Height; } }
+
+		public PaletteReference(string name, int index, IPalette palette, HardwarePalette hardwarePalette)
+		{
+			Name = name;
+			Palette = palette;
+			this.index = index;
+			this.hardwarePalette = hardwarePalette;
+		}
+	}
+}

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -25,6 +25,8 @@ namespace OpenRA.Graphics
 		public readonly Theater Theater;
 		public Viewport Viewport { get; private set; }
 
+		public event Action PaletteInvalidated = null;
+
 		readonly HardwarePalette palette = new HardwarePalette();
 		readonly Dictionary<string, PaletteReference> palettes = new Dictionary<string, PaletteReference>();
 		readonly TerrainRenderer terrainRenderer;
@@ -70,7 +72,13 @@ namespace OpenRA.Graphics
 			if (allowOverwrite && palette.Contains(name))
 				ReplacePalette(name, pal);
 			else
+			{
+				var oldHeight = palette.Height;
 				palette.AddPalette(name, pal, allowModifiers);
+
+				if (oldHeight != palette.Height && PaletteInvalidated != null)
+					PaletteInvalidated();
+			}
 		}
 
 		public void ReplacePalette(string name, IPalette pal)

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -16,23 +16,6 @@ using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {
-	public class PaletteReference
-	{
-		public readonly string Name;
-		public IPalette Palette { get; internal set; }
-		readonly float index;
-		readonly HardwarePalette hardwarePalette;
-		public float TextureIndex { get { return index / hardwarePalette.Height; } }
-		public float TextureMidIndex { get { return (index + 0.5f) / hardwarePalette.Height; } }
-		public PaletteReference(string name, int index, IPalette palette, HardwarePalette hardwarePalette)
-		{
-			Name = name;
-			Palette = palette;
-			this.index = index;
-			this.hardwarePalette = hardwarePalette;
-		}
-	}
-
 	public sealed class WorldRenderer : IDisposable
 	{
 		public static readonly Func<IRenderable, int> RenderableScreenZPositionComparisonKey =

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -41,12 +41,21 @@ namespace OpenRA.Graphics
 			foreach (var pal in world.TraitDict.ActorsWithTrait<ILoadsPalettes>())
 				pal.Trait.LoadPalettes(this);
 
+			foreach (var p in world.Players)
+				UpdatePalettesForPlayer(p.InternalName, p.Color, false);
+
 			palette.Initialize();
 
 			Theater = new Theater(world.TileSet);
 			terrainRenderer = new TerrainRenderer(world, this);
 
 			devTrait = Exts.Lazy(() => world.LocalPlayer != null ? world.LocalPlayer.PlayerActor.Trait<DeveloperMode>() : null);
+		}
+
+		public void UpdatePalettesForPlayer(string internalName, HSLColor color, bool replaceExisting)
+		{
+			foreach (var pal in World.WorldActor.TraitsImplementing<ILoadsPlayerPalettes>())
+				pal.LoadPlayerPalettes(this, internalName, color, replaceExisting);
 		}
 
 		PaletteReference CreatePaletteReference(string name)
@@ -56,9 +65,22 @@ namespace OpenRA.Graphics
 		}
 
 		public PaletteReference Palette(string name) { return palettes.GetOrAdd(name, createPaletteReference); }
-		public void AddPalette(string name, ImmutablePalette pal) { palette.AddPalette(name, pal, false); }
-		public void AddPalette(string name, ImmutablePalette pal, bool allowModifiers) { palette.AddPalette(name, pal, allowModifiers); }
-		public void ReplacePalette(string name, IPalette pal) { palette.ReplacePalette(name, pal); palettes[name].Palette = pal; }
+		public void AddPalette(string name, ImmutablePalette pal, bool allowModifiers = false, bool allowOverwrite = false)
+		{
+			if (allowOverwrite && palette.Contains(name))
+				ReplacePalette(name, pal);
+			else
+				palette.AddPalette(name, pal, allowModifiers);
+		}
+
+		public void ReplacePalette(string name, IPalette pal)
+		{
+			palette.ReplacePalette(name, pal);
+
+			// Update cached PlayerReference if one exists
+			if (palettes.ContainsKey(name))
+				palettes[name].Palette = pal;
+		}
 
 		List<IFinalizedRenderable> GenerateRenderables()
 		{

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Widgets\ChromeMetrics.cs" />
     <Compile Include="Widgets\WidgetUtils.cs" />
     <Compile Include="Widgets\WorldInteractionControllerWidget.cs" />
+    <Compile Include="Graphics\PaletteReference.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Graphics;
 
 namespace OpenRA.Traits
@@ -26,24 +27,23 @@ namespace OpenRA.Traits
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new PlayerColorPalette(init.Self.Owner, this); }
+		public object Create(ActorInitializer init) { return new PlayerColorPalette(this); }
 	}
 
-	public class PlayerColorPalette : ILoadsPalettes
+	public class PlayerColorPalette : ILoadsPlayerPalettes
 	{
-		readonly Player owner;
 		readonly PlayerColorPaletteInfo info;
 
-		public PlayerColorPalette(Player owner, PlayerColorPaletteInfo info)
+		public PlayerColorPalette(PlayerColorPaletteInfo info)
 		{
-			this.owner = owner;
 			this.info = info;
 		}
 
-		public void LoadPalettes(WorldRenderer wr)
+		public void LoadPlayerPalettes(WorldRenderer wr, string playerName, HSLColor color, bool replaceExisting)
 		{
-			var remap = new PlayerColorRemap(info.RemapIndex, owner.Color, info.Ramp);
-			wr.AddPalette(info.BaseName + owner.InternalName, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap), info.AllowModifiers);
+			var remap = new PlayerColorRemap(info.RemapIndex, color, info.Ramp);
+			var pal = new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap);
+			wr.AddPalette(info.BaseName + playerName, pal, info.AllowModifiers, replaceExisting);
 		}
 	}
 }

--- a/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
@@ -20,24 +21,23 @@ namespace OpenRA.Traits
 		[Desc("The prefix for the resulting player palettes")]
 		public readonly string BaseName = "highlight";
 
-		public object Create(ActorInitializer init) { return new PlayerHighlightPalette(init.Self.Owner, this); }
+		public object Create(ActorInitializer init) { return new PlayerHighlightPalette(this); }
 	}
 
-	public class PlayerHighlightPalette : ILoadsPalettes
+	public class PlayerHighlightPalette : ILoadsPlayerPalettes
 	{
-		readonly Player owner;
 		readonly PlayerHighlightPaletteInfo info;
 
-		public PlayerHighlightPalette(Player owner, PlayerHighlightPaletteInfo info)
+		public PlayerHighlightPalette(PlayerHighlightPaletteInfo info)
 		{
-			this.owner = owner;
 			this.info = info;
 		}
 
-		public void LoadPalettes(WorldRenderer wr)
+		public void LoadPlayerPalettes(WorldRenderer wr, string playerName, HSLColor color, bool replaceExisting)
 		{
-			var argb = (uint)Color.FromArgb(128, owner.Color.RGB).ToArgb();
-			wr.AddPalette(info.BaseName + owner.InternalName, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => i == 0 ? 0 : argb)));
+			var argb = (uint)Color.FromArgb(128, color.RGB).ToArgb();
+			var pal = new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => i == 0 ? 0 : argb));
+			wr.AddPalette(info.BaseName + playerName, pal, false, replaceExisting);
 		}
 	}
 }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -194,6 +194,7 @@ namespace OpenRA.Traits
 	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
 	public interface IPowerModifier { int GetPowerModifier(); }
 	public interface ILoadsPalettes { void LoadPalettes(WorldRenderer wr); }
+	public interface ILoadsPlayerPalettes { void LoadPlayerPalettes(WorldRenderer wr, string playerName, HSLColor playerColor, bool replaceExisting); }
 	public interface IPaletteModifier { void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> b); }
 	public interface IPips { IEnumerable<PipType> GetPips(Actor self); }
 	public interface ITags { IEnumerable<TagType> GetTags(); }

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -172,6 +172,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			fogPalette = wr.Palette(info.FogPalette);
 			shroudPalette = wr.Palette(info.ShroudPalette);
+
+			wr.PaletteInvalidated += () =>
+			{
+				mapBorderShroudIsCached = false;
+				MarkCellsDirty(CellRegion.Expand(map.Cells, 1));
+			};
 		}
 
 		Edges GetEdges(MPos uv, Func<MPos, bool> isVisible)

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -38,6 +38,7 @@ Rules:
 	./mods/cnc/rules/ai.yaml
 	./mods/cnc/rules/player.yaml
 	./mods/cnc/rules/world.yaml
+	./mods/cnc/rules/palettes.yaml
 	./mods/cnc/rules/defaults.yaml
 	./mods/cnc/rules/structures.yaml
 	./mods/cnc/rules/infantry.yaml

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -1,0 +1,76 @@
+^Palettes:
+	PaletteFromCurrentTileset@terrain:
+		Name: terrain
+		ShadowIndex: 4
+	PaletteFromCurrentTileset@static:
+		Name: staticterrain
+		ShadowIndex: 4
+	PaletteFromFile@chrome:
+		Name: chrome
+		Filename: temperat.pal
+		ShadowIndex: 3
+		AllowModifiers: false
+	PaletteFromFile@beaconposter:
+		Name: beaconposter
+		Filename: temperat.pal
+		ShadowIndex: 3
+	PaletteFromFile@effect:
+		Name: effect
+		Filename: temperat.pal
+		ShadowIndex: 4
+	PaletteFromFile@colorpicker:
+		Name: colorpicker
+		Filename: temperat.pal
+		ShadowIndex: 4
+		AllowModifiers: false
+	PaletteFromRGBA@shadow:
+		Name: shadow
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@cloak:
+		Name: cloak
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@highlight:
+		Name: highlight
+		R: 255
+		G: 255
+		B: 255
+		A: 128
+	PaletteFromRGBA@moveflash:
+		Name: moveflash
+		R: 255
+		G: 255
+		B: 255
+		A: 64
+	PaletteFromRGBA@disabled:
+		Name: disabled
+		R: 0
+		G: 0
+		B: 0
+		A: 180
+	ShroudPalette@shroud:
+		Type: Shroud
+	ShroudPalette@fog:
+		Name: fog
+		Fog: true
+	FixedColorPalette@BlueTiberium:
+		Base: terrain
+		Name: bluetiberium
+		Color: 152, 255, 196
+		RemapIndex: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
+	PlayerColorPalette:
+		BasePalette: terrain
+		RemapIndex: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
+	PlayerHighlightPalette:
+	MenuPaletteEffect:
+		MenuEffect: Desaturated
+	CloakPaletteEffect:
+	NukePaletteEffect:
+	WaterPaletteRotation:
+		ExcludePalettes: effect
+

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -10,10 +10,6 @@ Player:
 	PlayerResources:
 	ActorGroupProxy:
 	DeveloperMode:
-	PlayerColorPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
-	PlayerHighlightPalette:
 	BaseAttackNotifier:
 	Shroud:
 	PlayerStatistics:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -1,4 +1,5 @@
 World:
+	Inherits: ^Palettes
 	ChatCommands:
 	DevCommands:
 	PlayerCommands:
@@ -7,75 +8,10 @@ World:
 	ActorMap:
 	LoadWidgetAtGameStart:
 		ShellmapRoot: MENU_BACKGROUND
-	MenuPaletteEffect:
-		MenuEffect: Desaturated
-	CloakPaletteEffect:
 	ScreenShaker:
-	NukePaletteEffect:
-	WaterPaletteRotation:
-		ExcludePalettes: effect
 	BuildingInfluence:
 	BridgeLayer:
 		Bridges: bridge1, bridge2, bridge3, bridge4
-	PaletteFromCurrentTileset@terrain:
-		Name: terrain
-		ShadowIndex: 4
-	PaletteFromCurrentTileset@static:
-		Name: staticterrain
-		ShadowIndex: 4
-	PaletteFromFile@chrome:
-		Name: chrome
-		Filename: temperat.pal
-		ShadowIndex: 3
-		AllowModifiers: false
-	PaletteFromFile@beaconposter:
-		Name: beaconposter
-		Filename: temperat.pal
-		ShadowIndex: 3
-	PaletteFromFile@effect:
-		Name: effect
-		Filename: temperat.pal
-		ShadowIndex: 4
-	PaletteFromFile@colorpicker:
-		Name: colorpicker
-		Filename: temperat.pal
-		ShadowIndex: 4
-		AllowModifiers: false
-	PaletteFromRGBA@shadow:
-		Name: shadow
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@highlight:
-		Name: highlight
-		R: 255
-		G: 255
-		B: 255
-		A: 128
-	PaletteFromRGBA@moveflash:
-		Name: moveflash
-		R: 255
-		G: 255
-		B: 255
-		A: 64
-	PaletteFromRGBA@disabled:
-		Name: disabled
-		R: 0
-		G: 0
-		B: 0
-		A: 180
-	ShroudPalette@shroud:
-		Type: Shroud
-	ShroudPalette@fog:
-		Name: fog
-		Fog: true
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed
 		FogVariants: typea, typeb, typec, typed
@@ -115,11 +51,6 @@ World:
 		PipColor: Green
 		AllowedTerrainTypes: Clear,Road
 		AllowUnderActors: true
-	FixedColorPalette@BlueTiberium:
-		Base: terrain
-		Name: bluetiberium
-		Color: 152, 255, 196
-		RemapIndex: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
 	ResourceType@blue-tib:
 		ResourceType: 2
 		Palette: bluetiberium

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -28,6 +28,7 @@ Rules:
 	./mods/d2k/rules/ai.yaml
 	./mods/d2k/rules/player.yaml
 	./mods/d2k/rules/world.yaml
+	./mods/d2k/rules/palettes.yaml
 	./mods/d2k/rules/defaults.yaml
 	./mods/d2k/rules/vehicles.yaml
 	./mods/d2k/rules/starport.yaml

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -1,0 +1,76 @@
+^Palettes:
+	PaletteFromCurrentTileset:
+		Name: terrain
+	PaletteFromFile@d2k:
+		Name: d2k
+		Filename: d2k.pal
+		ShadowIndex: 1
+	PaletteFromFile@chrome:
+		Name: chrome
+		Filename: d2k.pal
+		ShadowIndex: 3
+		AllowModifiers: false
+	PaletteFromFile@effect:
+		Name: effect
+		Filename: d2k.pal
+		ShadowIndex: 4
+		AllowModifiers: false
+	PaletteFromFile@colorpicker:
+		Name: colorpicker
+		Filename: d2k.pal
+		ShadowIndex: 4
+		AllowModifiers: false
+	PaletteFromRGBA@shadow:
+		Name: shadow
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@cloak:
+		Name: cloak
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@highlight:
+		Name: highlight
+		R: 255
+		G: 255
+		B: 255
+		A: 128
+	PaletteFromR8@moveflash:
+		Name: moveflash
+		Filename: DATA.R8
+		Offset: 2572352
+		InvertColor: true
+	PaletteFromRGBA@disabled:
+		Name: disabled
+		R: 0
+		G: 0
+		B: 0
+		A: 180
+	PaletteFromScaledPalette@starportlights:
+		Name: starportlights
+		BasePalette: d2k
+		AllowModifiers: false
+		Offset: -64
+	PaletteFromScaledPalette@repairlights:
+		Name: repairlights
+		BasePalette: d2k
+		AllowModifiers: false
+		Offset: -128
+	PaletteFromR8@shroud:
+		Name: shroud
+		Filename: DATA.R8
+		Offset: 12007
+		InvertColor: true
+	FogPaletteFromR8@fog:
+		Name: fog
+		Filename: DATA.R8
+		Offset: 12007
+		InvertColor: true
+	PlayerColorPalette:
+		BasePalette: d2k
+		RemapIndex: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
+	PlayerHighlightPalette:
+

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -44,10 +44,6 @@ Player:
 		AdviceInterval: 650
 	ActorGroupProxy:
 	DeveloperMode:
-	PlayerColorPalette:
-		BasePalette: d2k
-		RemapIndex: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
-	PlayerHighlightPalette:
 	BaseAttackNotifier:
 	Shroud:
 	FrozenActorLayer:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -1,4 +1,5 @@
 World:
+	Inherits: ^Palettes
 	ChatCommands:
 	DevCommands:
 	PlayerCommands:
@@ -17,76 +18,6 @@ World:
 		SpawnInterval: 60
 		WaterChance: 0
 		ValidGround: Sand, Dune, Rock
-	PaletteFromCurrentTileset:
-		Name: terrain
-	PaletteFromFile@d2k:
-		Name: d2k
-		Filename: d2k.pal
-		ShadowIndex: 1
-	PaletteFromFile@chrome:
-		Name: chrome
-		Filename: d2k.pal
-		ShadowIndex: 3
-		AllowModifiers: false
-	PaletteFromFile@effect:
-		Name: effect
-		Filename: d2k.pal
-		ShadowIndex: 4
-		AllowModifiers: false
-	PaletteFromFile@colorpicker:
-		Name: colorpicker
-		Filename: d2k.pal
-		ShadowIndex: 4
-		AllowModifiers: false
-	PaletteFromRGBA@shadow:
-		Name: shadow
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@highlight:
-		Name: highlight
-		R: 255
-		G: 255
-		B: 255
-		A: 128
-	PaletteFromR8@moveflash:
-		Name: moveflash
-		Filename: DATA.R8
-		Offset: 2572352
-		InvertColor: true
-	PaletteFromRGBA@disabled:
-		Name: disabled
-		R: 0
-		G: 0
-		B: 0
-		A: 180
-	PaletteFromScaledPalette@starportlights:
-		Name: starportlights
-		BasePalette: d2k
-		AllowModifiers: false
-		Offset: -64
-	PaletteFromScaledPalette@repairlights:
-		Name: repairlights
-		BasePalette: d2k
-		AllowModifiers: false
-		Offset: -128
-	PaletteFromR8@shroud:
-		Name: shroud
-		Filename: DATA.R8
-		Offset: 12007
-		InvertColor: true
-	FogPaletteFromR8@fog:
-		Name: fog
-		Filename: DATA.R8
-		Offset: 12007
-		InvertColor: true
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed
 		FogVariants: typea, typeb, typec, typed

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -37,6 +37,7 @@ Rules:
 	./mods/ra/rules/misc.yaml
 	./mods/ra/rules/ai.yaml
 	./mods/ra/rules/player.yaml
+	./mods/ra/rules/palettes.yaml
 	./mods/ra/rules/world.yaml
 	./mods/ra/rules/defaults.yaml
 	./mods/ra/rules/vehicles.yaml

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -1,0 +1,73 @@
+^Palettes:
+	PlayerPaletteFromCurrentTileset:
+		Name: player
+		ShadowIndex: 3,4
+	PaletteFromCurrentTileset:
+		Name: terrain
+		ShadowIndex: 3,4
+	PaletteFromFile@chrome:
+		Name: chrome
+		Filename: temperat.pal
+		ShadowIndex: 3
+		AllowModifiers: false
+	PaletteFromFile@effect:
+		Name: effect
+		Filename: temperat.pal
+		ShadowIndex: 4
+	PaletteFromFile@colorpicker:
+		Name: colorpicker
+		Filename: temperat.pal
+		ShadowIndex: 4
+		AllowModifiers: false
+	PaletteFromRGBA@shadow:
+		Name: shadow
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@cloak:
+		Name: cloak
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@highlight:
+		Name: highlight
+		R: 255
+		G: 255
+		B: 255
+		A: 128
+	PaletteFromRGBA@moveflash:
+		Name: moveflash
+		R: 255
+		G: 255
+		B: 255
+		A: 64
+	PaletteFromRGBA@invuln:
+		Name: invuln
+		R: 128
+		G: 0
+		B: 0
+		A: 128
+	PaletteFromRGBA@disabled:
+		Name: disabled
+		R: 0
+		G: 0
+		B: 0
+		A: 180
+	ShroudPalette@shroud:
+		Type: Shroud
+	ShroudPalette@fog:
+		Name: fog
+		Fog: true
+	PlayerColorPalette:
+		BasePalette: player
+		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
+	PlayerHighlightPalette:
+	MenuPaletteEffect:
+	WaterPaletteRotation:
+		ExcludePalettes: player, effect
+	LightPaletteRotator:
+		ExcludePalettes: terrain, effect
+	ChronoshiftPaletteEffect:
+	NukePaletteEffect:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -44,10 +44,6 @@ Player:
 	PlayerResources:
 	ActorGroupProxy:
 	DeveloperMode:
-	PlayerColorPalette:
-		BasePalette: player
-		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
-	PlayerHighlightPalette:
 	GpsWatcher:
 	Shroud:
 	FrozenActorLayer:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -1,4 +1,5 @@
 World:
+	Inherits: ^Palettes
 	ChatCommands:
 	DevCommands:
 	PlayerCommands:
@@ -7,13 +8,6 @@ World:
 	ActorMap:
 	LoadWidgetAtGameStart:
 	ScreenShaker:
-	MenuPaletteEffect:
-	WaterPaletteRotation:
-		ExcludePalettes: player, effect
-	ChronoshiftPaletteEffect:
-	NukePaletteEffect:
-	LightPaletteRotator:
-		ExcludePalettes: terrain, effect
 	BuildingInfluence:
 	ProductionQueueFromSelection:
 		ProductionPaletteWidget: PRODUCTION_PALETTE
@@ -26,67 +20,6 @@ World:
 		Maximum: 3
 		SpawnInterval: 120
 		WaterChance: .2
-	PlayerPaletteFromCurrentTileset:
-		Name: player
-		ShadowIndex: 3,4
-	PaletteFromCurrentTileset:
-		Name: terrain
-		ShadowIndex: 3,4
-	PaletteFromFile@chrome:
-		Name: chrome
-		Filename: temperat.pal
-		ShadowIndex: 3
-		AllowModifiers: false
-	PaletteFromFile@effect:
-		Name: effect
-		Filename: temperat.pal
-		ShadowIndex: 4
-	PaletteFromFile@colorpicker:
-		Name: colorpicker
-		Filename: temperat.pal
-		ShadowIndex: 4
-		AllowModifiers: false
-	PaletteFromRGBA@shadow:
-		Name: shadow
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@highlight:
-		Name: highlight
-		R: 255
-		G: 255
-		B: 255
-		A: 128
-	PaletteFromRGBA@moveflash:
-		Name: moveflash
-		R: 255
-		G: 255
-		B: 255
-		A: 64
-	PaletteFromRGBA@invuln:
-		Name: invuln
-		R: 128
-		G: 0
-		B: 0
-		A: 128
-	PaletteFromRGBA@disabled:
-		Name: disabled
-		R: 0
-		G: 0
-		B: 0
-		A: 180
-	ShroudPalette@shroud:
-		Type: Shroud
-	ShroudPalette@fog:
-		Name: fog
-		Fog: true
 	ShroudRenderer:
 		FogVariants: shroud
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -65,6 +65,7 @@ Rules:
 	./mods/ts/rules/misc.yaml
 	./mods/ts/rules/player.yaml
 	./mods/ts/rules/world.yaml
+	./mods/ts/rules/palettes.yaml
 	./mods/ts/rules/defaults.yaml
 	./mods/ts/rules/aircraft.yaml
 	./mods/ts/rules/civilian-infantry.yaml

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -1,0 +1,95 @@
+^Palettes:
+	PaletteFromFile@mouse:
+		Name: mouse
+		Filename: mousepal.pal
+	PaletteFromFile@playersno:
+		Name: player
+		Tileset: SNOW
+		Filename: unitsno.pal
+		ShadowIndex: 1
+	PaletteFromFile@playertem:
+		Name: player
+		Tileset: TEMPERAT
+		Filename: unittem.pal
+		ShadowIndex: 1
+	PaletteFromFile@depth:
+		Name: depth
+		Filename: depth.pal
+	PaletteFromCurrentTileset:
+		Name: terrain
+		ShadowIndex: 1
+	PaletteFromFile@chrome:
+		Name: chrome
+		Filename: cameo.pal
+		AllowModifiers: false
+		ShadowIndex: 242
+	PaletteFromFile@pips:
+		Name: pips
+		Filename: palette.pal
+		AllowModifiers: false
+		ShadowIndex: 4
+	PaletteFromFile@ra:
+		Name: ra
+		Filename: palette.pal
+		ShadowIndex: 4
+	PaletteFromFile@effect:
+		Name: effect
+		Filename: anim.pal
+	PaletteFromFile@colorpicker:
+		Name: colorpicker
+		Filename: unittem.pal
+		AllowModifiers: false
+		ShadowIndex: 1
+	PaletteFromFile@alpha:
+		Name: alpha
+		Filename: alpha.pal
+	PaletteFromRGBA@shadow:
+		Name: shadow
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@cloak:
+		Name: cloak
+		R: 0
+		G: 0
+		B: 0
+		A: 140
+	PaletteFromRGBA@highlight:
+		Name: highlight
+		R: 255
+		G: 255
+		B: 255
+		A: 128
+	PaletteFromRGBA@moveflash:
+		Name: moveflash
+		R: 255
+		G: 255
+		B: 255
+		A: 64
+	PaletteFromRGBA@disabled:
+		Name: disabled
+		R: 0
+		G: 0
+		B: 0
+		A: 180
+	TSShroudPalette@shroud:
+		Type: Shroud
+	VoxelNormalsPalette@normals:
+		Name: normals
+		Type: TiberianSun
+	FixedColorPalette@GreenTiberium:
+		Base: player
+		Name: greentiberium
+		Color: 64, 255, 128
+		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+	FixedColorPalette@BlueTiberium:
+		Base: player
+		Name: bluetiberium
+		Color: 160, 255, 172
+		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+	PlayerColorPalette:
+		BasePalette: player
+		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+	PlayerHighlightPalette:
+	MenuPaletteEffect:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -40,10 +40,6 @@ Player:
 	PlayerResources:
 	ActorGroupProxy:
 	DeveloperMode:
-	PlayerColorPalette:
-		BasePalette: player
-		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
-	PlayerHighlightPalette:
 	GpsWatcher:
 	Shroud:
 	FrozenActorLayer:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -1,4 +1,5 @@
 World:
+	Inherits: ^Palettes
 	ChatCommands:
 	DevCommands:
 	PlayerCommands:
@@ -6,94 +7,14 @@ World:
 	ScreenMap:
 	ActorMap:
 	LoadWidgetAtGameStart:
-	MenuPaletteEffect:
 	BuildingInfluence:
 	ProductionQueueFromSelection:
 		ProductionPaletteWidget: PRODUCTION_PALETTE
-	PaletteFromFile@mouse:
-		Name: mouse
-		Filename: mousepal.pal
-	PaletteFromFile@playersno:
-		Name: player
-		Tileset: SNOW
-		Filename: unitsno.pal
-		ShadowIndex: 1
-	PaletteFromFile@playertem:
-		Name: player
-		Tileset: TEMPERAT
-		Filename: unittem.pal
-		ShadowIndex: 1
-	PaletteFromFile@depth:
-		Name: depth
-		Filename: depth.pal
-	PaletteFromCurrentTileset:
-		Name: terrain
-		ShadowIndex: 1
-	PaletteFromFile@chrome:
-		Name: chrome
-		Filename: cameo.pal
-		AllowModifiers: false
-		ShadowIndex: 242
-	PaletteFromFile@pips:
-		Name: pips
-		Filename: palette.pal
-		AllowModifiers: false
-		ShadowIndex: 4
-	PaletteFromFile@ra:
-		Name: ra
-		Filename: palette.pal
-		ShadowIndex: 4
-	PaletteFromFile@effect:
-		Name: effect
-		Filename: anim.pal
-	PaletteFromFile@colorpicker:
-		Name: colorpicker
-		Filename: unittem.pal
-		AllowModifiers: false
-		ShadowIndex: 1
-	PaletteFromFile@alpha:
-		Name: alpha
-		Filename: alpha.pal
-	PaletteFromRGBA@shadow:
-		Name: shadow
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
-		R: 0
-		G: 0
-		B: 0
-		A: 140
-	PaletteFromRGBA@highlight:
-		Name: highlight
-		R: 255
-		G: 255
-		B: 255
-		A: 128
-	PaletteFromRGBA@moveflash:
-		Name: moveflash
-		R: 255
-		G: 255
-		B: 255
-		A: 64
-	PaletteFromRGBA@disabled:
-		Name: disabled
-		R: 0
-		G: 0
-		B: 0
-		A: 180
-	TSShroudPalette@shroud:
-		Type: Shroud
 	ShroudRenderer:
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255
 		UseExtendedIndex: true
 		ShroudPalette: shroud
 		FogPalette: shroud
-	VoxelNormalsPalette@normals:
-		Name: normals
-		Type: TiberianSun
 	Country@Random:
 		Name: Any
 		Race: Random
@@ -134,11 +55,6 @@ World:
 		Sequence: largecraters
 	ResourceLayer:
 	ResourceClaimLayer:
-	FixedColorPalette@GreenTiberium:
-		Base: player
-		Name: greentiberium
-		Color: 64, 255, 128
-		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 	ResourceType@Tiberium:
 		ResourceType: 1
 		Palette: greentiberium
@@ -151,11 +67,6 @@ World:
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
 		TerrainType: Tiberium
-	FixedColorPalette@BlueTiberium:
-		Base: player
-		Name: bluetiberium
-		Color: 160, 255, 172
-		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 	ResourceType@BlueTiberium:
 		ResourceType: 2
 		Palette: bluetiberium


### PR DESCRIPTION
Reorganizes the way that player palettes are loaded, and fixes a bug that would cause the shroud and terrain palettes to break if too many players were added in the editor.  Preqrequisite of #8065.
