### PR TITLE
Fixed glitchy remap errors of non-fitting actors on certain tilesets

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -612,6 +612,8 @@
 		StartsRevealed: true
 	ScriptTriggers:
 	WithMakeAnimation:
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
 
 ^Husk:
 	Health:

--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -82,6 +82,8 @@ T03:
 
 T04:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
 
 T05:
 	Inherits: ^Tree
@@ -109,6 +111,8 @@ T09:
 	Building:
 		Footprint: x_
 		Dimensions: 2,1
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
 
 T10:
 	Inherits: ^Tree
@@ -159,6 +163,8 @@ T17:
 
 T18:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
 
 TC01:
 	Inherits: ^Tree

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -114,7 +114,7 @@ V01:
 	RevealsShroud:
 		Range: 10c0
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V02:
 	Inherits: ^CivBuilding
@@ -122,7 +122,7 @@ V02:
 		Footprint: xx xx
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V03:
 	Inherits: ^CivBuilding
@@ -130,7 +130,7 @@ V03:
 		Footprint: xx xx
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V04:
 	Inherits: ^CivBuilding
@@ -138,7 +138,7 @@ V04:
 		Footprint: xx xx
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V05:
 	Inherits: ^CivBuilding
@@ -146,7 +146,7 @@ V05:
 		Footprint: xx
 		Dimensions: 2,1
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V06:
 	Inherits: ^CivBuilding
@@ -154,7 +154,7 @@ V06:
 		Footprint: xx
 		Dimensions: 2,1
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V07:
 	Inherits: ^CivBuilding
@@ -162,62 +162,62 @@ V07:
 		Footprint: xx
 		Dimensions: 2,1
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V08:
 	Inherits: ^CivBuilding
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V09:
 	Inherits: ^CivBuilding
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V10:
 	Inherits: ^CivBuilding
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V11:
 	Inherits: ^CivBuilding
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V12:
 	Inherits: ^CivBuilding
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V13:
 	Inherits: ^CivBuilding
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V14:
 	Inherits: ^CivField
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V15:
 	Inherits: ^CivField
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V16:
 	Inherits: ^CivField
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V17:
 	Inherits: ^CivField
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V18:
 	Inherits: ^CivField
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 V19:
 	Inherits: ^CivBuilding
@@ -617,7 +617,7 @@ RUSHOUSE:
 ASIANHUT:
 	Inherits: ^CivBuilding
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		RequireTilesets: TEMPERAT
 
 SNOWHUT:
 	Inherits: ^CivBuilding

--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -27,6 +27,8 @@ T04:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T05:
 	Inherits: ^Tree
@@ -164,46 +166,64 @@ BOXES01:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES02:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES03:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES04:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES05:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES06:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES07:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES08:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 BOXES09:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 ICE01:
 	Inherits: ^Tree

--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -4,7 +4,7 @@ T01:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T02:
 	Inherits: ^Tree
@@ -12,7 +12,7 @@ T02:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T03:
 	Inherits: ^Tree
@@ -20,7 +20,7 @@ T03:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T04:
 	Inherits: ^Tree
@@ -28,7 +28,7 @@ T04:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: INTERIOR
 
 T05:
 	Inherits: ^Tree
@@ -36,7 +36,7 @@ T05:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T06:
 	Inherits: ^Tree
@@ -44,7 +44,7 @@ T06:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T07:
 	Inherits: ^Tree
@@ -52,7 +52,7 @@ T07:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T08:
 	Inherits: ^Tree
@@ -66,7 +66,7 @@ T10:
 		Footprint: __ xx
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T11:
 	Inherits: ^Tree
@@ -74,7 +74,7 @@ T11:
 		Footprint: __ xx
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T12:
 	Inherits: ^Tree
@@ -82,7 +82,7 @@ T12:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T13:
 	Inherits: ^Tree
@@ -90,7 +90,7 @@ T13:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T14:
 	Inherits: ^Tree
@@ -98,7 +98,7 @@ T14:
 		Footprint: ___ xx_
 		Dimensions: 3,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T15:
 	Inherits: ^Tree
@@ -106,7 +106,7 @@ T15:
 		Footprint: ___ xx_
 		Dimensions: 3,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T16:
 	Inherits: ^Tree
@@ -114,7 +114,7 @@ T16:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 T17:
 	Inherits: ^Tree
@@ -122,13 +122,15 @@ T17:
 		Footprint: __ x_
 		Dimensions: 2,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 TC01:
 	Inherits: ^Tree
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 TC02:
 	Inherits: ^Tree
@@ -136,7 +138,7 @@ TC02:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 TC03:
 	Inherits: ^Tree
@@ -144,7 +146,7 @@ TC03:
 		Footprint: xx_ xx_
 		Dimensions: 3,2
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 TC04:
 	Inherits: ^Tree
@@ -152,7 +154,7 @@ TC04:
 		Footprint: ____ xxx_ x___
 		Dimensions: 4,3
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 TC05:
 	Inherits: ^Tree
@@ -160,7 +162,7 @@ TC05:
 		Footprint: __x_ xxx_ _xx_
 		Dimensions: 4,3
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 BOXES01:
 	Inherits: ^Tree
@@ -233,7 +235,7 @@ ICE01:
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 ICE02:
 	Inherits: ^Tree
@@ -243,7 +245,7 @@ ICE02:
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 ICE03:
 	Inherits: ^Tree
@@ -253,21 +255,21 @@ ICE03:
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 ICE04:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 ICE05:
 	Inherits: ^Tree
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+		ExcludeTilesets: DESERT, INTERIOR
 
 ROCK1:
 	Inherits: ^Rock

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -599,11 +599,15 @@
 	FrozenUnderFog:
 		StartsRevealed: true
 	ScriptTriggers:
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
 
 ^DesertCivBuilding:
 	Inherits: ^CivBuilding
 	RenderBuilding:
 		Palette: terrain
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
 
 ^Crate:
 	Tooltip:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -252,6 +252,8 @@
 	MustBeDestroyed:
 	AnnounceOnSeen:
 		Notification: EnemyDetected
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 ^Plane:
 	Inherits@1: ^ExistsInWorld
@@ -471,6 +473,8 @@
 		Palette: terrain
 	EditorAppearance:
 		UseTerrainPalette: true
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 ^CivField:
 	Inherits: ^CivBuilding
@@ -481,6 +485,8 @@
 	-Demolishable:
 	ProximityCaptor:
 		Types: CivilianField
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 ^Tree:
 	Tooltip:
@@ -507,6 +513,8 @@
 	FrozenUnderFog:
 		StartsRevealed: true
 	ScriptTriggers:
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 ^Husk:
 	Husk:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -68,6 +68,8 @@ SYRF:
 		Image: SYRD
 	Valued:
 		Cost: 100
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 SPEF:
 	Inherits: ^FakeBuilding
@@ -93,6 +95,8 @@ SPEF:
 		Image: SPEN
 	Valued:
 		Cost: 100
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 DOMF:
 	Inherits: ^FakeBuilding

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -271,6 +271,8 @@ RAILMINE:
 		UseTerrainPalette: false
 	AutoTargetIgnore:
 	BodyOrientation:
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 QUEE:
 	Tooltip:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -159,6 +159,8 @@ SPEN:
 		RequiresPrerequisites: structures.ukraine
 		Prerequisite: ships.ukraine
 	ProvidesPrerequisite@buildingname:
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 SYRD:
 	Inherits: ^Building
@@ -244,6 +246,8 @@ SYRD:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: ships.germany
 	ProvidesPrerequisite@buildingname:
+	EditorTilesetFilter:
+		ExcludeTilesets: INTERIOR
 
 IRON:
 	Inherits: ^Building

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -373,6 +373,8 @@ CA0001:
 		Type: heavy
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0002:
 	Inherits: ^CivBuilding
@@ -385,6 +387,8 @@ CA0002:
 		Type: heavy
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0003:
 	Inherits: ^CivBuilding
@@ -397,6 +401,8 @@ CA0003:
 		Type: light
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0004:
 	Inherits: ^CivBuilding
@@ -409,6 +415,8 @@ CA0004:
 		Type: light
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0005:
 	Inherits: ^CivBuilding
@@ -421,6 +429,8 @@ CA0005:
 		Type: light
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0006:
 	Inherits: ^CivBuilding
@@ -433,6 +443,8 @@ CA0006:
 		Type: heavy
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0007:
 	Inherits: ^CivBuilding
@@ -445,6 +457,8 @@ CA0007:
 		Type: light
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0008:
 	Inherits: ^CivBuilding
@@ -457,6 +471,8 @@ CA0008:
 		Type: heavy
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0009:
 	Inherits: ^CivBuilding
@@ -469,6 +485,8 @@ CA0009:
 		Type: heavy
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0010:
 	Inherits: ^CivBuilding
@@ -481,6 +499,8 @@ CA0010:
 		Type: heavy
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0011:
 	Inherits: ^CivBuilding
@@ -493,6 +513,8 @@ CA0011:
 		Type: heavy
 	Health:
 		HP: 200
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0012:
 	Inherits: ^CivBuilding
@@ -505,6 +527,8 @@ CA0012:
 		Type: light
 	Health:
 		HP: 100
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0013:
 	Inherits: ^CivBuilding
@@ -517,6 +541,8 @@ CA0013:
 		Type: heavy
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0014:
 	Inherits: ^CivBuilding
@@ -529,6 +555,8 @@ CA0014:
 		Type: heavy
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0015:
 	Inherits: ^CivBuilding
@@ -541,6 +569,8 @@ CA0015:
 		Type: light
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0016:
 	Inherits: ^CivBuilding
@@ -553,6 +583,8 @@ CA0016:
 		Type: light
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0017:
 	Inherits: ^CivBuilding
@@ -565,6 +597,8 @@ CA0017:
 		Type: heavy
 	Health:
 		HP: 300
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0018:
 	Inherits: ^CivBuilding
@@ -577,6 +611,8 @@ CA0018:
 		Type: light
 	Health:
 		HP: 200
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0019:
 	Inherits: ^CivBuilding
@@ -589,6 +625,8 @@ CA0019:
 		Type: light
 	Health:
 		HP: 200
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0020:
 	Inherits: ^CivBuilding
@@ -601,6 +639,8 @@ CA0020:
 		Type: light
 	Health:
 		HP: 200
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CA0021:
 	Inherits: ^CivBuilding
@@ -613,6 +653,8 @@ CA0021:
 		Type: light
 	Health:
 		HP: 200
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CAARAY:
 	Inherits: ^CivBuilding
@@ -666,6 +708,8 @@ CACRSH01:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CACRSH02:
 	Inherits: ^CivBuilding
@@ -678,6 +722,8 @@ CACRSH02:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CACRSH03:
 	Inherits: ^CivBuilding
@@ -690,6 +736,8 @@ CACRSH03:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CACRSH04:
 	Inherits: ^CivBuilding
@@ -702,6 +750,8 @@ CACRSH04:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CACRSH05:
 	Inherits: ^CivBuilding
@@ -714,6 +764,8 @@ CACRSH05:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CAHOSP:
 	Inherits: ^CivBuilding
@@ -740,6 +792,8 @@ CAPYR01:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CAPYR02:
 	Inherits: ^CivBuilding
@@ -752,6 +806,8 @@ CAPYR02:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CAPYR03:
 	Inherits: ^CivBuilding
@@ -764,6 +820,8 @@ CAPYR03:
 		Type: concrete
 	Health:
 		HP: 400
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CITY01:
 	Inherits: ^CivBuilding
@@ -1089,6 +1147,8 @@ CTDAM:
 		HP: 1000
 	ProvidesPrerequisite:
 		Prerequisite: anypower
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 CTVEGA:
 	Inherits: ^CivBuilding
@@ -1101,6 +1161,8 @@ CTVEGA:
 		Type: none
 	Health:
 		HP: 100
+	EditorTilesetFilter:
+		ExcludeTilesets: SNOW
 
 GAKODK:
 	Inherits: ^CivBuilding


### PR DESCRIPTION
The new map editor / sprite loader will fall back and loads actor regarding of missing/incompatible file ending which introduces palette problems that were hidden by the behavior of OpenRA.Editor.exe and my #4496. This fixes all glitches I could spot such as a cactus/sand/pyramids in TEMPERAT terrain etc. To be tested with https://github.com/OpenRA/OpenRA/pull/8065.
