### PR TITLE
Don't track downloaded files in thirdparty/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,24 @@ mods/*/*.mdb
 /*.mdb
 /*.exe
 thirdparty/download/*
+thirdparty/StyleCop*
+thirdparty/StyleCop*
+thirdparty/ICSharpCode.SharpZipLib.dll*
+thirdparty/MaxMind*
+thirdparty/RestSharp*
+thirdparty/Newtonsoft.Json*
+thirdparty/SharpFont*
+thirdparty/windows/freetype6.dll
+thirdparty/nunit*
+thirdparty/windows/SDL2.dll
+thirdparty/Mono.Nat.dll
+thirdparty/Moq.dll
+thirdparty/nuget.exe
+thirdparty/windows/lua51.dll
+thirdparty/windows/soft_oal.dll
+thirdparty/FuzzyLogicLibrary.dll
+thirdparty/SDL2-CS.dll
+thirdparty/Eluant.dll
 
 # backup files by various editors
 *~


### PR DESCRIPTION
On bleed git shows me untracked files:
![track_bleed](https://cloud.githubusercontent.com/assets/7704140/7567501/a155d96c-f7fd-11e4-9379-8cb352970f2b.png)

Brings back the lines removed in #8083.
