### PR TITLE
Removes Spy's ability to disguise as Attack Dog or Giant Ant.

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -22,6 +22,8 @@ DOG:
 	Armament:
 		Weapon: DogJaw
 	AttackLeap:
+	TargetableUnit:
+		TargetTypes: Ground, Infantry
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 	IgnoresDisguise:
@@ -620,6 +622,8 @@ Ant:
 	AttackFrontal:
 	Armament:
 		Weapon: mandible
+	TargetableUnit:
+		TargetTypes: Ground, Infantry
 	WithDeathAnimation:
 		UseDeathTypeSuffix: false
 


### PR DESCRIPTION
Fixes #7478. Also currently when spy disguises as giant ant, it has glitchy idle animation.
