### PR TITLE
Changes faction name from England to Britain so that it matches the flag

### DIFF
--- a/OpenRA.Game/Traits/World/Country.cs
+++ b/OpenRA.Game/Traits/World/Country.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Traits
 		[Desc("Pick a random race as the player's race out of this list.")]
 		public readonly string[] RandomRaceMembers = { };
 
-		[Desc("The side that the country belongs to. For example, England belongs to the 'Allies' side.")]
+		[Desc("The side that the country belongs to. For example, Britain belongs to the 'Allies' side.")]
 		public readonly string Side = null;
 
 		[Translate]

--- a/mods/ra/audio/voices.yaml
+++ b/mods/ra/audio/voices.yaml
@@ -1,7 +1,7 @@
 GenericVoice:
 	Variants:
 		allies: .v01,.v03
-		england: .v01,.v03
+		britain: .v01,.v03
 		france: .v01,.v03
 		germany: .v01,.v03
 		soviet: .r01,.r03
@@ -18,7 +18,7 @@ GenericVoice:
 VehicleVoice:
 	Variants:
 		allies: .v00,.v02
-		england: .v00,.v02
+		britain: .v00,.v02
 		france: .v00,.v02
 		germany: .v00,.v02
 		soviet: .r00,.r02

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -478,7 +478,7 @@ flags: buttons.png
 	
 	russia: 0,127,30,15
 	ukraine: 30,127,30,15
-	england: 60,127,30,15
+	britain: 60,127,30,15
 	
 	germany: 0,142,30,15
 	spain: 30,142,30,15

--- a/mods/ra/maps/allies-01/allies01.lua
+++ b/mods/ra/maps/allies-01/allies01.lua
@@ -38,7 +38,7 @@ LabGuardsKilled = function()
 	CreateEinstein()
 
 	Trigger.AfterDelay(DateTime.Seconds(2), function()
-		Actor.Create(FlareType, true, { Owner = england, Location = ExtractionFlarePoint.Location })
+		Actor.Create(FlareType, true, { Owner = britain, Location = ExtractionFlarePoint.Location })
 		Media.PlaySpeechNotification(player, "SignalFlareNorth")
 		SendExtractionHelicopter()
 	end)
@@ -82,7 +82,7 @@ end
 SendCruisers = function()
 	local i = 1
 	Utils.Do(CruisersReinforcements, function(cruiser)
-		local ca = Actor.Create(cruiser, true, { Owner = england, Location = SouthReinforcementsPoint.Location + CVec.New(2 * i, 0) })
+		local ca = Actor.Create(cruiser, true, { Owner = britain, Location = SouthReinforcementsPoint.Location + CVec.New(2 * i, 0) })
 		ca.Move(Map.NamedActor("CruiserPoint" .. i).Location)
 		i = i + 1
 	end)
@@ -162,7 +162,7 @@ end
 
 WorldLoaded = function()
 	player = Player.GetPlayer("Greece")
-	england = Player.GetPlayer("England")
+	britain = Player.GetPlayer("Britain")
 	ussr = Player.GetPlayer("USSR")
 
 	Trigger.OnObjectiveAdded(player, function(p, id)

--- a/mods/ra/maps/allies-01/map.yaml
+++ b/mods/ra/maps/allies-01/map.yaml
@@ -39,13 +39,13 @@ Players:
 		Name: USSR
 		Race: soviet
 		ColorRamp: 3,255,127
-		Enemies: Greece, England
+		Enemies: Greece, Britain
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
 		NonCombatant: True
 		Race: allies
-		Enemies: USSR, Greece, England
+		Enemies: USSR, Greece, Britain
 	PlayerReference@Greece:
 		Name: Greece
 		Playable: True
@@ -57,10 +57,10 @@ Players:
 		ColorRamp: 161,134,200
 		LockSpawn: True
 		LockTeam: True
-		Allies: England
+		Allies: Britain
 		Enemies: Neutral, USSR
-	PlayerReference@England:
-		Name: England
+	PlayerReference@Britain:
+		Name: Britain
 		Race: allies
 		ColorRamp: 76,196,190
 		Allies: Greece
@@ -417,11 +417,11 @@ Actors:
 		SubCell: 4
 	Civilian1: c8
 		Location: 74,50
-		Owner: England
+		Owner: Britain
 		SubCell: 0
 	Civilian2: c7
 		Location: 76,48
-		Owner: England
+		Owner: Britain
 		SubCell: 3
 	EinsteinSpawnPoint: waypoint
 		Location: 62,61

--- a/mods/ra/metrics.yaml
+++ b/mods/ra/metrics.yaml
@@ -26,7 +26,7 @@ Metrics:
 	SpawnContrastColor: 0,0,0
 	SpawnLabelOffset: 0,1
 	RaceSuffix-allies: allies
-	RaceSuffix-england: allies
+	RaceSuffix-britain: allies
 	RaceSuffix-france: allies
 	RaceSuffix-germany: allies
 	RaceSuffix-soviet: soviet

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -209,7 +209,7 @@ SPY:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 90
-		Prerequisites: ~!infantry.england, dome, ~tent, ~techlevel.medium
+		Prerequisites: ~!infantry.britain, dome, ~tent, ~techlevel.medium
 	Valued:
 		Cost: 500
 	-Tooltip:
@@ -244,11 +244,11 @@ SPY:
 		Weapon: SilencedPPK
 	AttackFrontal:
 
-SPY.England:
+SPY.Britain:
 	Inherits: SPY
 	WithDisguisingInfantryBody:
 	Buildable:
-		Prerequisites: ~infantry.england, dome, ~tent, ~techlevel.medium
+		Prerequisites: ~infantry.britain, dome, ~tent, ~techlevel.medium
 	Valued:
 		Cost: 250
 	DisguiseToolTip:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -90,12 +90,12 @@ CRATE:
 	GiveUnitCrateAction@jeep:
 		SelectionShares: 7
 		Units: jeep
-		ValidRaces: allies, england, france, germany
+		ValidRaces: allies, britain, france, germany
 		Prerequisites: techlevel.low
 	GiveUnitCrateAction@arty:
 		SelectionShares: 6
 		Units: arty
-		ValidRaces: allies, england, france, germany
+		ValidRaces: allies, britain, france, germany
 		Prerequisites: techlevel.medium, dome
 	GiveUnitCrateAction@v2rl:
 		SelectionShares: 6
@@ -105,12 +105,12 @@ CRATE:
 	GiveUnitCrateAction@1tnk:
 		SelectionShares: 5
 		Units: 1tnk
-		ValidRaces: allies, england, france, germany
+		ValidRaces: allies, britain, france, germany
 		Prerequisites: techlevel.low
 	GiveUnitCrateAction@2tnk:
 		SelectionShares: 4
 		Units: 2tnk
-		ValidRaces: allies, england, france, germany
+		ValidRaces: allies, britain, france, germany
 		Prerequisites: techlevel.medium, fix
 	GiveUnitCrateAction@3tnk:
 		SelectionShares: 4
@@ -125,11 +125,11 @@ CRATE:
 	GiveUnitCrateAction@squadlight:
 		SelectionShares: 7
 		Units: e1,e1,e1,e3,e3
-		ValidRaces: allies, england, france, germany, soviet, russia, ukraine
+		ValidRaces: allies, britain, france, germany, soviet, russia, ukraine
 	GiveUnitCrateAction@squadheavyallies:
 		SelectionShares: 7
 		Units: e1,e1,e1,e1,e3,e3,e3,e6,medi
-		ValidRaces: allies, england, france, germany
+		ValidRaces: allies, britain, france, germany
 		TimeDelay: 4500
 	GiveUnitCrateAction@squadheavysoviet:
 		SelectionShares: 7

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -214,14 +214,14 @@ SYRD:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@allies:
-		Race: allies, england, france, germany
+		Race: allies, britain, france, germany
 		Prerequisite: ships.allies
 	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: ships.alliesvanilla
-	ProvidesPrerequisite@england:
-		Race: england
-		Prerequisite: ships.england
+	ProvidesPrerequisite@britain:
+		Race: britain
+		Prerequisite: ships.britain
 	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: ships.france
@@ -235,8 +235,8 @@ SYRD:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: ships.alliesvanilla
 	ProvidesPrerequisite@englishstructure:
-		RequiresPrerequisites: structures.england
-		Prerequisite: ships.england
+		RequiresPrerequisites: structures.britain
+		Prerequisite: ships.britain
 	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: ships.france
@@ -777,14 +777,14 @@ WEAP:
 	Production:
 		Produces: Vehicle
 	ProvidesPrerequisite@allies:
-		Race: allies, england, france, germany
+		Race: allies, britain, france, germany
 		Prerequisite: vehicles.allies
 	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: vehicles.alliesvanilla
-	ProvidesPrerequisite@england:
-		Race: england
-		Prerequisite: vehicles.england
+	ProvidesPrerequisite@britain:
+		Race: britain
+		Prerequisite: vehicles.britain
 	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: vehicles.france
@@ -810,8 +810,8 @@ WEAP:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: vehicles.alliesvanilla
 	ProvidesPrerequisite@englishstructure:
-		RequiresPrerequisites: structures.england
-		Prerequisite: vehicles.england
+		RequiresPrerequisites: structures.britain
+		Prerequisite: vehicles.britain
 	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: vehicles.france
@@ -846,14 +846,14 @@ FACT:
 		BuildPaletteOrder: 1000
 		Prerequisites: ~disabled
 	ProvidesPrerequisite@allies:
-		Race: allies, england, france, germany
+		Race: allies, britain, france, germany
 		Prerequisite: structures.allies
 	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: structures.alliesvanilla
-	ProvidesPrerequisite@england:
-		Race: england
-		Prerequisite: structures.england
+	ProvidesPrerequisite@britain:
+		Race: britain
+		Prerequisite: structures.britain
 	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: structures.france
@@ -1026,14 +1026,14 @@ HPAD:
 	Power:
 		Amount: -10
 	ProvidesPrerequisite@allies:
-		Race: allies, england, france, germany
+		Race: allies, britain, france, germany
 		Prerequisite: aircraft.allies
 	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: aircraft.alliesvanilla
-	ProvidesPrerequisite@england:
-		Race: england
-		Prerequisite: aircraft.england
+	ProvidesPrerequisite@britain:
+		Race: britain
+		Prerequisite: aircraft.britain
 	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: aircraft.france
@@ -1047,8 +1047,8 @@ HPAD:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: aircraft.alliesvanilla
 	ProvidesPrerequisite@englishstructure:
-		RequiresPrerequisites: structures.england
-		Prerequisite: aircraft.england
+		RequiresPrerequisites: structures.britain
+		Prerequisite: aircraft.britain
 	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: aircraft.france
@@ -1395,14 +1395,14 @@ TENT:
 	ProvidesPrerequisite@barracks:
 		Prerequisite: barracks
 	ProvidesPrerequisite@allies:
-		Race: allies, england, france, germany
+		Race: allies, britain, france, germany
 		Prerequisite: infantry.allies
 	ProvidesPrerequisite@alliesvanilla:
 		Race: allies
 		Prerequisite: infantry.alliesvanilla
-	ProvidesPrerequisite@england:
-		Race: england
-		Prerequisite: infantry.england
+	ProvidesPrerequisite@britain:
+		Race: britain
+		Prerequisite: infantry.britain
 	ProvidesPrerequisite@france:
 		Race: france
 		Prerequisite: infantry.france
@@ -1416,8 +1416,8 @@ TENT:
 		RequiresPrerequisites: structures.alliesvanilla
 		Prerequisite: infantry.alliesvanilla
 	ProvidesPrerequisite@englishstructure:
-		RequiresPrerequisites: structures.england
-		Prerequisite: infantry.england
+		RequiresPrerequisites: structures.britain
+		Prerequisite: infantry.britain
 	ProvidesPrerequisite@frenchstructure:
 		RequiresPrerequisites: structures.france
 		Prerequisite: infantry.france

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -736,7 +736,7 @@ STNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 140
-		Prerequisites: atek, ~vehicles.england, ~techlevel.unrestricted
+		Prerequisites: atek, ~vehicles.britain, ~techlevel.unrestricted
 	Valued:
 		Cost: 1350
 	Tooltip:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -30,10 +30,10 @@ World:
 		Side: Allies
 		Selectable: False
 	Country@1:
-		Name: England
-		Race: england
+		Name: Britain
+		Race: britain
 		Side: Allies
-		Description: England: Espionage\nSpecial Unit: British Spy\nSpecial Unit: Phase Transport
+		Description: Britain: Espionage\nSpecial Unit: British Spy\nSpecial Unit: Phase Transport
 	Country@2:
 		Name: France
 		Race: france
@@ -68,7 +68,7 @@ World:
 	Country@randomallies:
 		Name: Allies
 		Race: RandomAllies
-		RandomRaceMembers: england, france, germany
+		RandomRaceMembers: britain, france, germany
 		Side: Random
 		Description: A random Allied country.
 	Country@randomsoviet:
@@ -118,12 +118,12 @@ World:
 	MPStartUnits@mcvonly:
 		Class: none
 		ClassName: MCV Only
-		Races: allies, england, france, germany, soviet, russia, ukraine
+		Races: allies, britain, france, germany, soviet, russia, ukraine
 		BaseActor: mcv
 	MPStartUnits@lightallies:
 		Class: light
 		ClassName: Light Support
-		Races: allies, england, france, germany
+		Races: allies, britain, france, germany
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk
 		InnerSupportRadius: 3
@@ -139,7 +139,7 @@ World:
 	MPStartUnits@heavyallies:
 		Class: heavy
 		ClassName: Heavy Support
-		Races: allies, england, france, germany
+		Races: allies, britain, france, germany
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk,2tnk,2tnk,2tnk
 		InnerSupportRadius: 3


### PR DESCRIPTION
Second attempt at fixing #8024. Changing flag to match name was rejected so I changed name to match flag. I changed all occurances of "england" I could find except for the one here: https://github.com/OpenRA/OpenRA/blob/89a1bdd4f15d7a960a9ece1e89181b440a839705/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs#L460

I didn't know if that would need to be changed.
