### PR TITLE
Prevents satellite icons from being drawn over frozen actors.

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -38,8 +38,8 @@ namespace OpenRA.Traits
 		public int HP;
 		public DamageState DamageState;
 
-		public bool Visible;
-
+		public bool Visible = true;
+		public bool NeedRenderables;
 		public bool IsRendering { get; private set; }
 
 		public FrozenActor(Actor self, MPos[] footprint, CellRegion footprintRegion, Shroud shroud)
@@ -63,7 +63,6 @@ namespace OpenRA.Traits
 
 		int flashTicks;
 		IRenderable[] renderables = NoRenderables;
-		bool needRenderables;
 
 		public void Tick()
 		{
@@ -88,7 +87,7 @@ namespace OpenRA.Traits
 				}
 
 			if (Visible && !wasVisible)
-				needRenderables = true;
+				NeedRenderables = true;
 		}
 
 		public void Flash()
@@ -98,9 +97,9 @@ namespace OpenRA.Traits
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (needRenderables)
+			if (NeedRenderables)
 			{
-				needRenderables = false;
+				NeedRenderables = false;
 				if (!actor.Destroyed)
 				{
 					IsRendering = true;

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -72,6 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!initialized)
 				{
 					frozen[player] = frozenActor = new FrozenActor(self, footprint, footprintRegion, player.Shroud);
+					frozen[player].NeedRenderables = frozenActor.NeedRenderables = startsRevealed;
 					player.PlayerActor.Trait<FrozenActorLayer>().Add(frozenActor);
 					isVisible = visible[player] |= startsRevealed;
 				}

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -81,7 +81,10 @@ namespace OpenRA.Mods.RA.Effects
 			if (f == null)
 				return false;
 
-			return f.Visible && !f.HasRenderables;
+			if (f.HasRenderables || f.NeedRenderables)
+				return false;
+
+			return f.Visible;
 		}
 
 		public void Tick(World world)


### PR DESCRIPTION
Fixes #7920. Steps to test if this patch works:
Build satellite, move a unit next to an enemy building that is shown as satellite icon. Move away from the building so that its frozen fog image is rendered for the first time. Watch the building closely right when it becomes frozen under fog. Before this patch -> satellite icon is shown for a fraction of a second. After this patch -> no satellite icon is shown over frozen image.
