### PR TITLE
Load textures using premultiplied alpha.

### DIFF
--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -41,8 +41,6 @@ namespace OpenRA
 		Additive,
 		Subtractive,
 		Multiply,
-		SoftAdditive,
-		Translucency,
 		Multiplicative,
 		DoubleMultiplicative
 	}
@@ -70,7 +68,7 @@ namespace OpenRA
 		void EnableDepthBuffer();
 		void DisableDepthBuffer();
 
-		void SetBlendMode(BlendMode mode, float alpha = 1f);
+		void SetBlendMode(BlendMode mode);
 
 		void GrabWindowMouseFocus();
 		void ReleaseWindowMouseFocus();

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -49,15 +49,9 @@ namespace OpenRA.Graphics
 			using (var bitmap = (Bitmap)Image.FromStream(stream))
 			{
 				Size = bitmap.Size;
+				data = new byte[4 * Size.Width * Size.Height];
 
-				var dataStride = 4 * Size.Width;
-				data = new byte[dataStride * Size.Height];
-
-				var bd = bitmap.LockBits(bitmap.Bounds(),
-					ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
-				for (var y = 0; y < Size.Height; y++)
-					Marshal.Copy(IntPtr.Add(bd.Scan0, y * bd.Stride), data, y * dataStride, dataStride);
-				bitmap.UnlockBits(bd);
+				Util.FastCopyIntoSprite(new Sprite(this, bitmap.Bounds(), TextureChannel.Red), bitmap);
 			}
 
 			ReleaseBuffer();

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -17,7 +17,6 @@ namespace OpenRA.Graphics
 		public readonly Rectangle Bounds;
 		public readonly Sheet Sheet;
 		public readonly BlendMode BlendMode;
-		public readonly float Alpha;
 		public readonly TextureChannel Channel;
 		public readonly float2 Size;
 		public readonly float2 Offset;
@@ -27,7 +26,7 @@ namespace OpenRA.Graphics
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel)
 			: this(sheet, bounds, float2.Zero, channel) { }
 
-		public Sprite(Sheet sheet, Rectangle bounds, float2 offset, TextureChannel channel, BlendMode blendMode = BlendMode.Alpha, float alpha = 1f)
+		public Sprite(Sheet sheet, Rectangle bounds, float2 offset, TextureChannel channel, BlendMode blendMode = BlendMode.Alpha)
 		{
 			Sheet = sheet;
 			Bounds = bounds;
@@ -35,7 +34,6 @@ namespace OpenRA.Graphics
 			Channel = channel;
 			Size = new float2(bounds.Size);
 			BlendMode = blendMode;
-			Alpha = alpha;
 
 			FractionalOffset = offset / Size;
 

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -114,6 +114,7 @@ namespace OpenRA.Graphics
 
 			// A new bitmap is generated each time this property is accessed, so we do need to dispose it.
 			using (var bitmap = face.Glyph.Bitmap)
+			{
 				unsafe
 				{
 					var p = (byte*)bitmap.Buffer;
@@ -123,18 +124,23 @@ namespace OpenRA.Graphics
 					for (var j = 0; j < s.Size.Y; j++)
 					{
 						for (var i = 0; i < s.Size.X; i++)
+						{
 							if (p[i] != 0)
 							{
 								var q = destStride * (j + s.Bounds.Top) + 4 * (i + s.Bounds.Left);
-								dest[q] = c.Second.B;
-								dest[q + 1] = c.Second.G;
-								dest[q + 2] = c.Second.R;
-								dest[q + 3] = p[i];
+								var pmc = Util.PremultiplyAlpha(Color.FromArgb(p[i], c.Second));
+
+								dest[q] = pmc.B;
+								dest[q + 1] = pmc.G;
+								dest[q + 2] = pmc.R;
+								dest[q + 3] = pmc.A;
 							}
+						}
 
 						p += bitmap.Pitch;
 					}
 				}
+			}
 
 			s.Sheet.CommitBufferedData();
 

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -21,7 +21,6 @@ namespace OpenRA.Graphics
 		readonly Vertex[] vertices;
 		Sheet currentSheet;
 		BlendMode currentBlend = BlendMode.Alpha;
-		float currentAlpha = 1f;
 		int nv = 0;
 
 		public SpriteRenderer(Renderer renderer, IShader shader)
@@ -37,14 +36,14 @@ namespace OpenRA.Graphics
 			{
 				shader.SetTexture("DiffuseTexture", currentSheet.GetTexture());
 
-				renderer.Device.SetBlendMode(currentBlend, currentAlpha);
+				renderer.Device.SetBlendMode(currentBlend);
 				shader.Render(() =>
 				{
 					var vb = renderer.GetTempVertexBuffer();
 					vb.SetData(vertices, nv);
 					renderer.DrawBatch(vb, 0, nv, PrimitiveType.QuadList);
 				});
-				renderer.Device.SetBlendMode(BlendMode.None, currentAlpha);
+				renderer.Device.SetBlendMode(BlendMode.None);
 
 				nv = 0;
 				currentSheet = null;
@@ -55,10 +54,9 @@ namespace OpenRA.Graphics
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (s.Alpha != currentAlpha || s.BlendMode != currentBlend || s.Sheet != currentSheet || nv + 4 > renderer.TempBufferSize)
+			if (s.BlendMode != currentBlend || s.Sheet != currentSheet || nv + 4 > renderer.TempBufferSize)
 				Flush();
 
-			currentAlpha = s.Alpha;
 			currentBlend = s.BlendMode;
 			currentSheet = s.Sheet;
 		}

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -73,24 +73,49 @@ namespace OpenRA.Graphics
 
 			try
 			{
-				var data = dest.Sheet.GetData();
-				var dataStride = dest.Sheet.Size.Width * 4;
-				var x = dest.Bounds.Left * 4;
-				var width = dest.Bounds.Width * 4;
-				var y = dest.Bounds.Top;
+				var destData = dest.Sheet.GetData();
+				var destStride = dest.Sheet.Size.Width;
+				var width = dest.Bounds.Width;
 				var height = dest.Bounds.Height;
 
-				var bd = src.LockBits(src.Bounds(),
-					ImageLockMode.ReadWrite, src.PixelFormat);
-				for (var row = 0; row < height; row++)
-					Marshal.Copy(IntPtr.Add(bd.Scan0, row * bd.Stride), data, (y + row) * dataStride + x, width);
-				src.UnlockBits(bd);
+				var srcData = src.LockBits(src.Bounds(),
+					ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+
+				unsafe
+				{
+					var c = (int*)srcData.Scan0;
+
+					// Cast the data to an int array so we can copy the src data directly
+					fixed (byte* bd = &destData[0])
+					{
+						var data = (int*)bd;
+						var x = dest.Bounds.Left;
+						var y = dest.Bounds.Top;
+
+						for (var j = 0; j < height; j++)
+						{
+							for (var i = 0; i < width; i++)
+							{
+								var cc = Color.FromArgb(*(c + (j * srcData.Stride >> 2) + i));
+								data[(y + j) * destStride + x + i] = PremultiplyAlpha(cc).ToArgb();
+							}
+						}
+					}
+				}
+
+				src.UnlockBits(srcData);
 			}
 			finally
 			{
 				if (createdTempBitmap)
 					src.Dispose();
 			}
+		}
+
+		public static Color PremultiplyAlpha(Color c)
+		{
+			var a = c.A / 255f;
+			return Color.FromArgb(c.A, (byte)(c.R * a + 0.5f), (byte)(c.G * a + 0.5f), (byte)(c.B * a + 0.5f));
 		}
 
 		public static float[] IdentityMatrix()

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -119,13 +119,12 @@ namespace OpenRA.Mods.Common.Graphics
 
 				var offset = LoadField<float2>(d, "Offset", float2.Zero);
 				var blendMode = LoadField<BlendMode>(d, "BlendMode", BlendMode.Alpha);
-				var alpha = LoadField<float>(d, "Alpha", 1f);
 
 				// Apply offset to each sprite in the sequence
 				// Different sequences may apply different offsets to the same frame
 				var src = GetSpriteSrc(modData, tileSet, sequence, animation, info.Value, d);
 				sprites = cache[src].Select(
-					s => new Sprite(s.Sheet, s.Bounds, s.Offset + offset, s.Channel, blendMode, alpha)).ToArray();
+					s => new Sprite(s.Sheet, s.Bounds, s.Offset + offset, s.Channel, blendMode)).ToArray();
 
 				MiniYaml length;
 				if (d.TryGetValue("Length", out length) && length.Value == "*")

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -644,6 +644,7 @@
     <Compile Include="Traits\World\EditorResourceLayer.cs" />
     <Compile Include="Widgets\EditorViewportControllerWidget.cs" />
     <Compile Include="Traits\World\PaletteFromPaletteWithAlpha.cs" />
+    <Compile Include="Traits\World\PaletteFromPlayerPaletteWithAlpha.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -643,6 +643,7 @@
     <Compile Include="Traits\World\EditorActorPreview.cs" />
     <Compile Include="Traits\World\EditorResourceLayer.cs" />
     <Compile Include="Widgets\EditorViewportControllerWidget.cs" />
+    <Compile Include="Traits\World\PaletteFromPaletteWithAlpha.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
@@ -1,0 +1,76 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2k.Traits
+{
+	[Desc("Create a palette by applying alpha transparency to another palette.")]
+	class PaletteFromPaletteWithAlphaInfo : ITraitInfo
+	{
+		[Desc("Internal palette name")]
+		public readonly string Name = null;
+
+		[Desc("The name of the palette to base off.")]
+		public readonly string BasePalette = null;
+
+		[Desc("Allow palette modifiers to change the palette.")]
+		public readonly bool AllowModifiers = true;
+
+		[Desc("Alpha component that is applied to the base palette.")]
+		public readonly float Alpha = 1.0f;
+
+		[Desc("Premultiply color by the alpha component.")]
+		public readonly bool Premultiply = true;
+
+		public object Create(ActorInitializer init) { return new PaletteFromPaletteWithAlpha(this); }
+	}
+
+	class PaletteFromPaletteWithAlpha : ILoadsPalettes, IProvidesAssetBrowserPalettes
+	{
+		readonly PaletteFromPaletteWithAlphaInfo info;
+
+		public PaletteFromPaletteWithAlpha(PaletteFromPaletteWithAlphaInfo info) { this.info = info; }
+
+		public void LoadPalettes(WorldRenderer wr)
+		{
+			var remap = new AlphaPaletteRemap(info.Alpha, info.Premultiply);
+			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap), info.AllowModifiers);
+		}
+
+		public IEnumerable<string> PaletteNames { get { yield return info.Name; } }
+	}
+
+	class AlphaPaletteRemap : IPaletteRemap
+	{
+		readonly float alpha;
+		readonly bool premultiply;
+
+		public AlphaPaletteRemap(float alpha, bool premultiply)
+		{
+			this.alpha = alpha;
+			this.premultiply = premultiply;
+		}
+
+		public Color GetRemappedColor(Color original, int index)
+		{
+			var a = (int)(original.A * alpha).Clamp(0, 255);
+			var r = premultiply ? (int)(alpha * original.R + 0.5f).Clamp(0, 255) : original.R;
+			var g = premultiply ? (int)(alpha * original.G + 0.5f).Clamp(0, 255) : original.G;
+			var b = premultiply ? (int)(alpha * original.B + 0.5f).Clamp(0, 255) : original.B;
+
+			return Color.FromArgb(a, r, g, b);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
@@ -1,0 +1,53 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.D2k.Traits
+{
+	[Desc("Create player palettes by applying alpha transparency to another player palette.")]
+	class PaletteFromPlayerPaletteWithAlphaInfo : ITraitInfo
+	{
+		[Desc("The prefix for the resulting player palettes")]
+		public readonly string BaseName = null;
+
+		[Desc("The name of the player palette to base off.")]
+		public readonly string BasePalette = null;
+
+		[Desc("Allow palette modifiers to change the palette.")]
+		public readonly bool AllowModifiers = true;
+
+		[Desc("Alpha component that is applied to the base palette.")]
+		public readonly float Alpha = 1.0f;
+
+		[Desc("Premultiply color by the alpha component.")]
+		public readonly bool Premultiply = true;
+
+		public object Create(ActorInitializer init) { return new PaletteFromPlayerPaletteWithAlpha(this); }
+	}
+
+	class PaletteFromPlayerPaletteWithAlpha : ILoadsPlayerPalettes
+	{
+		readonly PaletteFromPlayerPaletteWithAlphaInfo info;
+
+		public PaletteFromPlayerPaletteWithAlpha(PaletteFromPlayerPaletteWithAlphaInfo info) { this.info = info; }
+
+		public void LoadPlayerPalettes(WorldRenderer wr, string playerName, HSLColor color, bool replaceExisting)
+		{
+			var remap = new AlphaPaletteRemap(info.Alpha, info.Premultiply);
+			var pal = new ImmutablePalette(wr.Palette(info.BasePalette + playerName).Palette, remap);
+			wr.AddPalette(info.BaseName + playerName, pal, info.AllowModifiers, replaceExisting);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -50,7 +51,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.Tileset != null && info.Tileset.ToLowerInvariant() != world.Map.Tileset.ToLowerInvariant())
 				return;
 
-			var c = (uint)((info.A << 24) | (info.R << 16) | (info.G << 8) | info.B);
+			var a = info.A / 255f;
+			var r = (int)(a * info.R + 0.5f).Clamp(0, 255);
+			var g = (int)(a * info.G + 0.5f).Clamp(0, 255);
+			var b = (int)(a * info.B + 0.5f).Clamp(0, 255);
+			var c = (uint)Color.FromArgb(info.A, r, g, b).ToArgb();
 			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == 0) ? 0 : c)), info.AllowModifiers);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudPalette.cs
@@ -42,8 +42,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		static readonly Color[] Fog = new[]
 		{
-			Color.Transparent, Color.Green,
-			Color.Blue, Color.Yellow,
+			Color.FromArgb(0, 0, 0, 0),
+			Color.Green, Color.Blue, Color.Yellow,
 			Color.FromArgb(128, 0, 0, 0),
 			Color.FromArgb(96, 0, 0, 0),
 			Color.FromArgb(64, 0, 0, 0),
@@ -52,8 +52,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		static readonly Color[] Shroud = new[]
 		{
-			Color.Transparent, Color.Green,
-			Color.Blue, Color.Yellow,
+			Color.FromArgb(0, 0, 0, 0),
+			Color.Green, Color.Blue, Color.Yellow,
 			Color.Black,
 			Color.FromArgb(160, 0, 0, 0),
 			Color.FromArgb(128, 0, 0, 0),

--- a/OpenRA.Renderer.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Renderer.Null/NullGraphicsDevice.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Renderer.Null
 		public void EnableDepthBuffer() { }
 		public void DisableDepthBuffer() { }
 
-		public void SetBlendMode(BlendMode mode, float alpha = 1f) { }
+		public void SetBlendMode(BlendMode mode) { }
 
 		public void GrabWindowMouseFocus() { }
 		public void ReleaseWindowMouseFocus() { }

--- a/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
@@ -259,7 +259,7 @@ namespace OpenRA.Renderer.Sdl2
 				case BlendMode.Alpha:
 					GL.Enable(EnableCap.Blend);
 					ErrorHandler.CheckGlError();
-					GL.BlendFunc(BlendingFactorSrc.SrcAlpha, BlendingFactorDest.OneMinusSrcAlpha);
+					GL.BlendFunc(BlendingFactorSrc.One, BlendingFactorDest.OneMinusSrcAlpha);
 					break;
 				case BlendMode.Additive:
 					GL.Enable(EnableCap.Blend);

--- a/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Renderer.Sdl2/Sdl2GraphicsDevice.cs
@@ -246,7 +246,7 @@ namespace OpenRA.Renderer.Sdl2
 			ErrorHandler.CheckGlError();
 		}
 
-		public void SetBlendMode(BlendMode mode, float alpha = 1f)
+		public void SetBlendMode(BlendMode mode)
 		{
 			GL.BlendEquation(BlendEquationMode.FuncAdd);
 			ErrorHandler.CheckGlError();
@@ -262,32 +262,21 @@ namespace OpenRA.Renderer.Sdl2
 					GL.BlendFunc(BlendingFactorSrc.One, BlendingFactorDest.OneMinusSrcAlpha);
 					break;
 				case BlendMode.Additive:
-					GL.Enable(EnableCap.Blend);
-					ErrorHandler.CheckGlError();
-					GL.BlendFunc(BlendingFactorSrc.One, BlendingFactorDest.One);
-					break;
 				case BlendMode.Subtractive:
 					GL.Enable(EnableCap.Blend);
 					ErrorHandler.CheckGlError();
 					GL.BlendFunc(BlendingFactorSrc.One, BlendingFactorDest.One);
-					ErrorHandler.CheckGlError();
-					GL.BlendEquation(BlendEquationMode.FuncReverseSubtract);
+					if (mode == BlendMode.Subtractive)
+					{
+						ErrorHandler.CheckGlError();
+						GL.BlendEquation(BlendEquationMode.FuncReverseSubtract);
+					}
+
 					break;
 				case BlendMode.Multiply:
 					GL.Enable(EnableCap.Blend);
 					ErrorHandler.CheckGlError();
 					GL.BlendFunc(BlendingFactorSrc.DstColor, BlendingFactorDest.OneMinusSrcAlpha);
-					ErrorHandler.CheckGlError();
-					break;
-				case BlendMode.SoftAdditive:
-					GL.Enable(EnableCap.Blend);
-					ErrorHandler.CheckGlError();
-					GL.BlendFunc(BlendingFactorSrc.OneMinusDstColor, BlendingFactorDest.One);
-					break;
-				case BlendMode.Translucency:
-					GL.Enable(EnableCap.Blend);
-					ErrorHandler.CheckGlError();
-					GL.BlendFunc(BlendingFactorSrc.OneMinusConstantAlpha, BlendingFactorDest.One);
 					ErrorHandler.CheckGlError();
 					break;
 				case BlendMode.Multiplicative:
@@ -301,9 +290,6 @@ namespace OpenRA.Renderer.Sdl2
 					GL.BlendFunc(BlendingFactorSrc.DstColor, BlendingFactorDest.SrcColor);
 					break;
 			}
-
-			if (alpha != 1f)
-				GL.BlendColor(1f, 1f, 1f, alpha);
 
 			ErrorHandler.CheckGlError();
 		}

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -62,11 +62,6 @@
 		BasePalette: d2k
 		AllowModifiers: false
 		Offset: -64
-	PaletteFromScaledPalette@repairlights:
-		Name: repairlights
-		BasePalette: d2k
-		AllowModifiers: false
-		Offset: -128
 	PaletteFromR8@shroud:
 		Name: shroud
 		Filename: DATA.R8

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -49,6 +49,14 @@
 		G: 0
 		B: 0
 		A: 180
+	PaletteFromPaletteWithAlpha@effect75alpha:
+		Name: effect75alpha
+		BasePalette: effect
+		Alpha: 0.75
+	PaletteFromPaletteWithAlpha@effect50alpha:
+		Name: effect50alpha
+		BasePalette: effect
+		Alpha: 0.5
 	PaletteFromScaledPalette@starportlights:
 		Name: starportlights
 		BasePalette: d2k

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -80,5 +80,10 @@
 	PlayerColorPalette:
 		BasePalette: d2k
 		RemapIndex: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
+	PaletteFromPlayerPaletteWithAlpha@deviatorgas:
+		BaseName: deviatorgas
+		BasePalette: player
+		Alpha: 0.68
+		Premultiply: false
 	PlayerHighlightPalette:
 

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -656,7 +656,7 @@ repair:
 			atreides: repair.atreides
 			ordos: repair.ordos
 	WithRepairOverlay:
-		Palette: repairlights
+		Palette: effect75alpha
 	Power:
 		Amount: -10
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -81,6 +81,7 @@ harvester:
 	LeavesHusk:
 		HuskActor: Harvester.Husk
 	WithHarvestAnimation:
+		Palette: effect50alpha
 	AttractsWorms:
 		Intensity: 700
 

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -52,7 +52,7 @@ explosion:
 	deviator: DATA.R8
 		Start: 3512
 		Length: 23
-		BlendMode: SoftAdditive
+		BlendMode: Alpha
 		Tick: 80
 	corpse: DATA.R8
 		Start: 430
@@ -95,7 +95,6 @@ deviator_trail:
 		Start: 3535
 		Length: 5
 		Tick: 80
-		BlendMode: SoftAdditive
 
 laserfire:
 	idle: DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -71,30 +71,24 @@ small_trail:
 		Start: 3735
 		Length: 4
 		Tick: 80
-		BlendMode: SoftAdditive
 
 small_trail2:
 	idle: DATA.R8
 		Start: 3540
 		Length: 4
 		Tick: 80
-		BlendMode: SoftAdditive
 
 bazooka_trail:
 	idle: DATA.R8
 		Start: 3381
 		Length: 4
 		Tick: 80
-		BlendMode: Translucency
-		Alpha: 0.75
 
 bazooka_trail2:
 	idle: DATA.R8
 		Start: 3544
 		Length: 4
 		Tick: 80
-		BlendMode: Translucency
-		Alpha: 0.75
 
 deviator_trail:
 	idle: DATA.R8

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -122,14 +122,12 @@ repair.atreides:
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
-		BlendMode: Additive
 	damaged-active: DATA.R8
 		Start: 4746
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
-		BlendMode: Additive
 	icon: DATA.R8
 		Start: 4096
 		Offset: -30,-24
@@ -157,14 +155,12 @@ repair.harkonnen:
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
-		BlendMode: Additive
 	damaged-active: DATA.R8
 		Start: 4746
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
-		BlendMode: Additive
 	icon: DATA.R8
 		Start: 4097
 		Offset: -30,-24
@@ -192,14 +188,12 @@ repair.ordos:
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
-		BlendMode: Additive
 	damaged-active: DATA.R8
 		Start: 4746
 		Length: 14
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
-		BlendMode: Additive
 	icon: DATA.R8
 		Start: 4098
 		Offset: -30,-24

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -23,7 +23,6 @@ harvester:
 		Tick: 80
 		ZOffset: 1
 		BlendMode: Multiply
-		Alpha: 0.5
 	dock: DATA.R8
 		Start: 3370
 		Length: 10

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -396,7 +396,7 @@ NerveGasMissile:
 		Inaccuracy: 1c96
 		Image: MISSILE
 		Trail: deviator_trail
-		TrailPalette: player
+		TrailPalette: deviatorgas
 		TrailUsePlayerPalette: true
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
@@ -411,7 +411,7 @@ NerveGasMissile:
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
 		Explosion: deviator
-		ExplosionPalette: player
+		ExplosionPalette: deviatorgas
 		UsePlayerPalette: true
 		ImpactSound: EXPLSML2.WAV
 	Warhead@4OwnerChange: ChangeOwner

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -34,6 +34,7 @@ Bazooka:
 		Image: RPG
 		RateOfTurn: 5
 		Trail: bazooka_trail
+		TrailPalette: effect75alpha
 		TrailInterval: 1
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage
@@ -193,6 +194,7 @@ QuadRockets:
 		Image: RPG
 		RateOfTurn: 10
 		Trail: bazooka_trail2
+		TrailPalette: effect75alpha
 		TrailInterval: 1
 		Speed: 256
 		RangeLimit: 40

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -73,6 +73,10 @@
 		G: 0
 		B: 0
 		A: 180
+	PaletteFromPaletteWithAlpha@placebuilding:
+		Name: placebuilding
+		BasePalette: ra
+		Alpha: 0.75
 	TSShroudPalette@shroud:
 		Type: Shroud
 	VoxelNormalsPalette@normals:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -30,7 +30,7 @@ Player:
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	PlaceBuilding:
-		Palette: ra
+		Palette: placebuilding
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -1,8 +1,6 @@
 overlay:
 	Defaults: place
 		Offset: 0, -12
-		BlendMode: Translucency
-		Alpha: 0.75
 	build-valid-snow:
 	build-valid-temperat:
 	build-invalid:
@@ -114,10 +112,10 @@ explosion:
 		Length: *
 	building: twlt070
 	ionring: ring1
-		BlendMode: SoftAdditive
+		BlendMode: Additive
 		Tick: 120
 	pulse_explosion: pulsefx2
-		BlendMode: SoftAdditive
+		BlendMode: Additive
 		Tick: 80
 	small_watersplash: h2o_exp2
 	large_watersplash: h2o_exp1


### PR DESCRIPTION
There is a bunch of literature online about why premultiplied alpha is a good thing, so I won't repeat it here.  It also lets us simplify and improve our world sprite blend modes.

Improved harvester animation:
![harv](https://cloud.githubusercontent.com/assets/167819/7667377/08a4c972-fbfd-11e4-8005-86055bfa9610.png)

Improved Deviator gas (same panel order as above):
![deviator](https://cloud.githubusercontent.com/assets/167819/7668114/df9abba0-fc1e-11e4-83c7-6bc7f315af1d.png)

In the premultiplied color space additive blend mode is the same as the alpha blend mode with Alpha: 0 and Premultiply: false.  You can create various soft mixed blends by setting Alpha part way between 0 and 1.

Fixes #8168.
