### PR TITLE
Sticky Selection

### DIFF
--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -35,6 +35,7 @@ namespace OpenRA
 
         public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
         {
+            var classicmouse = Game.Settings.Game.UseClassicMouseStyle;
             if (isClick)
             {
                 var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
@@ -42,13 +43,18 @@ namespace OpenRA
                     actors.SymmetricExceptWith(adjNewSelection);
                 else
                 {
-                    if (newSelection.Count() == 0)
-                        actors.UnionWith(adjNewSelection);
+                    if (classicmouse == true){  
+                        if (newSelection.Count() == 0){
+                            actors.UnionWith(adjNewSelection);
+                        }
+                            else
+                                actors.Clear();
+                                actors.UnionWith(newSelection);
+                    }
+                       
                     else
-                    {
                         actors.Clear();
                         actors.UnionWith(newSelection);
-                    }
                 }
             }
             else
@@ -68,8 +74,10 @@ namespace OpenRA
             }
 
             var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
+            if (newSelection.Count() != 0) { 
             if (voicedUnit != null)
                 Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
+                                           }
 
             foreach (var a in newSelection)
                 foreach (var sel in a.TraitsImplementing<INotifySelected>())

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -63,14 +63,19 @@ namespace OpenRA
                     actors.UnionWith(newSelection);
                 else
                 {
-                    if (newSelection.Count() == 0)
-                        actors.UnionWith(newSelection);
-                    else
+                    if (classicmouse == true)
                     {
+                        if (newSelection.Count() == 0)
+                            actors.UnionWith(newSelection);
+                        else
+                            actors.Clear();
+                            actors.UnionWith(newSelection);
+                    }
+                    else
                         actors.Clear();
                         actors.UnionWith(newSelection);
-                    }
-                }
+
+               }
             }
 
             var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -33,40 +33,50 @@ namespace OpenRA
 			return actors.Contains(a);
 		}
 
-		public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
-		{
-			if (isClick)
-			{
-				var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
-				if (isCombine)
-					actors.SymmetricExceptWith(adjNewSelection);
-				else
-				{
-					actors.Clear();
-					actors.UnionWith(adjNewSelection);
-				}
-			}
-			else
-			{
-				if (isCombine)
-					actors.UnionWith(newSelection);
-				else
-				{
-					actors.Clear();
-					actors.UnionWith(newSelection);
-				}
-			}
+        public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
+        {
+            if (isClick)
+            {
+                var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
+                if (isCombine)
+                    actors.SymmetricExceptWith(adjNewSelection);
+                else
+                {
+                    if (newSelection.Count() == 0)
+                        actors.UnionWith(adjNewSelection);
+                    else
+                    {
+                        actors.Clear();
+                        actors.UnionWith(newSelection);
+                    }
+                }
+            }
+            else
+            {
+                if (isCombine)
+                    actors.UnionWith(newSelection);
+                else
+                {
+                    if (newSelection.Count() == 0)
+                        actors.UnionWith(newSelection);
+                    else
+                    {
+                        actors.Clear();
+                        actors.UnionWith(newSelection);
+                    }
+                }
+            }
 
-			var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
-			if (voicedUnit != null)
-				Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
+            var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
+            if (voicedUnit != null)
+                Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
 
-			foreach (var a in newSelection)
-				foreach (var sel in a.TraitsImplementing<INotifySelected>())
-					sel.Selected(a);
-			foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
-				ns.SelectionChanged();
-		}
+            foreach (var a in newSelection)
+                foreach (var sel in a.TraitsImplementing<INotifySelected>())
+                    sel.Selected(a);
+            foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
+                ns.SelectionChanged();
+        }
 
 		public IEnumerable<Actor> Actors { get { return actors; } }
 		public void Clear() { actors.Clear(); }

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -33,64 +33,63 @@ namespace OpenRA
 			return actors.Contains(a);
 		}
 
-		public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
-		{
-			var stickyselect = Game.Settings.Game.StickySelection;
-			if (isClick)
-			{
-				var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
-				if (isCombine)
-					actors.SymmetricExceptWith(adjNewSelection);
-				else
-				{
-					if (stickyselect == true)
-					{
-						if (newSelection.Count() == 0)
-						{
-							actors.UnionWith(adjNewSelection);
-						}
-						else
-						actors.Clear();
-						actors.UnionWith(newSelection);
-					}
-					else
-					actors.Clear();
-					actors.UnionWith(newSelection);
-				}
-			}
-			else
-			{
-				if (isCombine)
-					actors.UnionWith(newSelection);
-				else
-				{
-					if (stickyselect == true)
-					{
-						if (newSelection.Count() == 0)
-							actors.UnionWith(newSelection);
-						else
-						actors.Clear();
-						actors.UnionWith(newSelection);
-					}
-					else
-					actors.Clear();
-					actors.UnionWith(newSelection);
-				}
-			}
+        public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
+        {
+            var classicmouse = Game.Settings.Game.UseClassicMouseStyle;
+            if (isClick)
+            {
+                var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
+                if (isCombine)
+                    actors.SymmetricExceptWith(adjNewSelection);
+                else
+                {
+                    if (classicmouse == true){  
+                        if (newSelection.Count() == 0){
+                            actors.UnionWith(adjNewSelection);
+                        }
+                            else
+                                actors.Clear();
+                                actors.UnionWith(newSelection);
+                    }
+                       
+                    else
+                        actors.Clear();
+                        actors.UnionWith(newSelection);
+                }
+            }
+            else
+            {
+                if (isCombine)
+                    actors.UnionWith(newSelection);
+                else
+                {
+                    if (classicmouse == true)
+                    {
+                        if (newSelection.Count() == 0)
+                            actors.UnionWith(newSelection);
+                        else
+                            actors.Clear();
+                            actors.UnionWith(newSelection);
+                    }
+                    else
+                        actors.Clear();
+                        actors.UnionWith(newSelection);
 
-			var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
-			if (newSelection.Count() != 0)
-			{
-				if (voicedUnit != null)
-					Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
-			}
+               }
+            }
 
-			foreach (var a in newSelection)
-				foreach (var sel in a.TraitsImplementing<INotifySelected>())
-					sel.Selected(a);
-			foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
-				ns.SelectionChanged();
-		}
+            var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
+            if (newSelection.Count() != 0) { 
+            if (voicedUnit != null)
+                Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
+                                           }
+
+            foreach (var a in newSelection)
+                foreach (var sel in a.TraitsImplementing<INotifySelected>())
+                    sel.Selected(a);
+            foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
+                ns.SelectionChanged();
+        }
 
 		public IEnumerable<Actor> Actors { get { return actors; } }
 		public void Clear() { actors.Clear(); }
@@ -105,6 +104,7 @@ namespace OpenRA
 				cg.RemoveAll(a => a.Destroyed || a.Owner != world.LocalPlayer);
 			}
 		}
+
 		Cache<int, List<Actor>> controlGroups = new Cache<int, List<Actor>>(_ => new List<Actor>());
 
 		public void DoControlGroup(World world, WorldRenderer worldRenderer, int group, Modifiers mods, int multiTapCount)

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -33,63 +33,64 @@ namespace OpenRA
 			return actors.Contains(a);
 		}
 
-        public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
-        {
-            var classicmouse = Game.Settings.Game.UseClassicMouseStyle;
-            if (isClick)
-            {
-                var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
-                if (isCombine)
-                    actors.SymmetricExceptWith(adjNewSelection);
-                else
-                {
-                    if (classicmouse == true){  
-                        if (newSelection.Count() == 0){
-                            actors.UnionWith(adjNewSelection);
-                        }
-                            else
-                                actors.Clear();
-                                actors.UnionWith(newSelection);
-                    }
-                       
-                    else
-                        actors.Clear();
-                        actors.UnionWith(newSelection);
-                }
-            }
-            else
-            {
-                if (isCombine)
-                    actors.UnionWith(newSelection);
-                else
-                {
-                    if (classicmouse == true)
-                    {
-                        if (newSelection.Count() == 0)
-                            actors.UnionWith(newSelection);
-                        else
-                            actors.Clear();
-                            actors.UnionWith(newSelection);
-                    }
-                    else
-                        actors.Clear();
-                        actors.UnionWith(newSelection);
+		public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
+		{
+			var stickyselect = Game.Settings.Game.StickySelection;
+			if (isClick)
+			{
+				var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
+				if (isCombine)
+					actors.SymmetricExceptWith(adjNewSelection);
+				else
+				{
+					if (stickyselect == true)
+					{
+						if (newSelection.Count() == 0)
+						{
+							actors.UnionWith(adjNewSelection);
+						}
+						else
+						actors.Clear();
+						actors.UnionWith(newSelection);
+					}
+					else
+					actors.Clear();
+					actors.UnionWith(newSelection);
+				}
+			}
+			else
+			{
+				if (isCombine)
+					actors.UnionWith(newSelection);
+				else
+				{
+					if (stickyselect == true)
+					{
+						if (newSelection.Count() == 0)
+							actors.UnionWith(newSelection);
+						else
+						actors.Clear();
+						actors.UnionWith(newSelection);
+					}
+					else
+					actors.Clear();
+					actors.UnionWith(newSelection);
+				}
+			}
 
-               }
-            }
+			var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
+			if (newSelection.Count() != 0)
+			{
+				if (voicedUnit != null)
+					Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
+			}
 
-            var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
-            if (newSelection.Count() != 0) { 
-            if (voicedUnit != null)
-                Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
-                                           }
-
-            foreach (var a in newSelection)
-                foreach (var sel in a.TraitsImplementing<INotifySelected>())
-                    sel.Selected(a);
-            foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
-                ns.SelectionChanged();
-        }
+			foreach (var a in newSelection)
+				foreach (var sel in a.TraitsImplementing<INotifySelected>())
+					sel.Selected(a);
+			foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
+				ns.SelectionChanged();
+		}
 
 		public IEnumerable<Actor> Actors { get { return actors; } }
 		public void Clear() { actors.Clear(); }
@@ -104,7 +105,6 @@ namespace OpenRA
 				cg.RemoveAll(a => a.Destroyed || a.Owner != world.LocalPlayer);
 			}
 		}
-
 		Cache<int, List<Actor>> controlGroups = new Cache<int, List<Actor>>(_ => new List<Actor>());
 
 		public void DoControlGroup(World world, WorldRenderer worldRenderer, int group, Modifiers mods, int multiTapCount)

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -33,63 +33,72 @@ namespace OpenRA
 			return actors.Contains(a);
 		}
 
-        public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
-        {
-            var classicmouse = Game.Settings.Game.UseClassicMouseStyle;
-            if (isClick)
-            {
-                var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
-                if (isCombine)
-                    actors.SymmetricExceptWith(adjNewSelection);
-                else
-                {
-                    if (classicmouse == true){  
-                        if (newSelection.Count() == 0){
-                            actors.UnionWith(adjNewSelection);
-                        }
-                            else
-                                actors.Clear();
-                                actors.UnionWith(newSelection);
-                    }
-                       
-                    else
-                        actors.Clear();
-                        actors.UnionWith(newSelection);
-                }
-            }
-            else
-            {
-                if (isCombine)
-                    actors.UnionWith(newSelection);
-                else
-                {
-                    if (classicmouse == true)
-                    {
-                        if (newSelection.Count() == 0)
-                            actors.UnionWith(newSelection);
-                        else
-                            actors.Clear();
-                            actors.UnionWith(newSelection);
-                    }
-                    else
-                        actors.Clear();
-                        actors.UnionWith(newSelection);
+		public void Combine(World world, IEnumerable<Actor> newSelection, bool isCombine, bool isClick)
+		{
+			var stickyselect = Game.Settings.Game.StickySelection;
+			if (isClick)
+			{
+				var adjNewSelection = newSelection.Take(1);	/* TODO: select BEST, not FIRST */
+				if (isCombine)
+					actors.SymmetricExceptWith(adjNewSelection);
+				else
+				{
+					if (stickyselect == true)
+					{
+						if (newSelection.Count() == 0)
+						{
+							actors.UnionWith(adjNewSelection);
+						}
+						else
+						{
+							actors.Clear();
+							actors.UnionWith(newSelection);
+						}
+					}
+					else
+					{
+						actors.Clear();
+						actors.UnionWith(newSelection);
+					}
+				}
+			}
+			else
+			{
+				if (isCombine)
+					actors.UnionWith(newSelection);
+				else
+				{
+					if (stickyselect == true)
+					{
+						if (newSelection.Count() == 0)
+							actors.UnionWith(newSelection);
+						else
+						{
+							actors.Clear();
+							actors.UnionWith(newSelection);
+						}
+					}
+					else
+					{
+						actors.Clear();
+						actors.UnionWith(newSelection);
+					}
+				}
+			}
 
-               }
-            }
+			var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
+			if (newSelection.Count() != 0)
+			{
+				if (voicedUnit != null)
+					Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
+			}
 
-            var voicedUnit = actors.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.IsInWorld && a.HasVoices());
-            if (newSelection.Count() != 0) { 
-            if (voicedUnit != null)
-                Sound.PlayVoice("Select", voicedUnit, voicedUnit.Owner.Country.Race);
-                                           }
-
-            foreach (var a in newSelection)
-                foreach (var sel in a.TraitsImplementing<INotifySelected>())
-                    sel.Selected(a);
-            foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
-                ns.SelectionChanged();
-        }
+			foreach (var a in newSelection)
+				foreach (var sel in a.TraitsImplementing<INotifySelected>())
+					sel.Selected(a);
+			foreach (var ns in world.WorldActor.TraitsImplementing<INotifySelection>())
+				ns.SelectionChanged();
+		}
 
 		public IEnumerable<Actor> Actors { get { return actors; } }
 		public void Clear() { actors.Clear(); }

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -135,6 +135,7 @@ namespace OpenRA
 		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;
 		public bool TeamHealthColors = false;
+		public bool StickySelection = false;
 
 		public bool AllowDownloading = true;
 		public string MapRepository = "http://resource.openra.net/map/";

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -135,7 +135,6 @@ namespace OpenRA
 		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;
 		public bool TeamHealthColors = false;
-		public bool StickySelection = false;
 
 		public bool AllowDownloading = true;
 		public string MapRepository = "http://resource.openra.net/map/";

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -317,7 +317,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gs, "LockMouseWindow");
 			BindSliderPref(panel, "SCROLLSPEED_SLIDER", gs, "ViewportEdgeScrollStep");
 			BindSliderPref(panel, "UI_SCROLLSPEED_SLIDER", gs, "UIScrollSpeed");
-			BindCheckboxPref(panel, "STICKYSELECTION_CHECKBOX", gs, "StickySelection");
 
 			// Apply mouse focus preferences immediately
 			var lockMouseCheckbox = panel.Get<CheckboxWidget>("LOCKMOUSE_CHECKBOX");

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -317,6 +317,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gs, "LockMouseWindow");
 			BindSliderPref(panel, "SCROLLSPEED_SLIDER", gs, "ViewportEdgeScrollStep");
 			BindSliderPref(panel, "UI_SCROLLSPEED_SLIDER", gs, "UIScrollSpeed");
+			BindCheckboxPref(panel, "STICKYSELECTION_CHECKBOX", gs, "StickySelection");
 
 			// Apply mouse focus preferences immediately
 			var lockMouseCheckbox = panel.Get<CheckboxWidget>("LOCKMOUSE_CHECKBOX");

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -331,6 +331,13 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Left-Click Orders
+				Checkbox@STICKYSELECTION_CHECKBOX:
+					X: 175
+					Y: 40
+					Width: 250
+					Height: 20
+					Font: Regular
+					Text: Sticky Selection
 				Label@MOUSE_SCROLL_LABEL:
 					X: PARENT_RIGHT - WIDTH - 120
 					Y: 39

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -331,13 +331,6 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Left-Click Orders
-				Checkbox@STICKYSELECTION_CHECKBOX:
-					X: 175
-					Y: 40
-					Width: 250
-					Height: 20
-					Font: Regular
-					Text: Sticky Selection
 				Label@MOUSE_SCROLL_LABEL:
 					X: PARENT_RIGHT - WIDTH - 120
 					Y: 39


### PR DESCRIPTION
Refine micro mechanics. Allow for more organic feeling controls.

This mechanic is very helpful for a number of micro techniques, such as:

Splitting.
Concaves.
And Kiting.

Mechanics that allow for players to show off their skill in unit control
makes a more exciting to watch and more rewarding to play game without raising the skill floor.

Video showcasing the change in work:

http://www.mediafire.com/watch/dj9i9bba4r4inbt/OpenRA.Game_2015-05-17_03-20-27-896.avi
