### PR TITLE
Fixed the build for Mono 2.10 again

### DIFF
--- a/OpenRA.Mods.TS/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.TS/SpriteLoaders/TmpTSLoader.cs
@@ -172,7 +172,6 @@ namespace OpenRA.Mods.TS.SpriteLoaders
 					var k = j * templateWidth + i;
 					s.Position = offsets[k];
 
-					var tileStart = s.Position;
 					var frame = new TmpTSFrame(s, size, i, j);
 					tiles[k] = frame;
 					tiles[k + stride] = new TmpTSDepthFrame(frame);


### PR DESCRIPTION
Fedora failed at https://build.opensuse.org/package/show/games:openra/development
