### PR TITLE
Brought back the Windows setup deployment via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ notifications:
     skip_join: true
 
 before_deploy:
+ - apt-get download nsis nsis-common
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`
  - cd packaging
@@ -56,6 +57,7 @@ deploy:
   api_key:
     secure: "g/LU11f+mjqv+lj0sR1UliHwogXL4ofJUwoG5Dbqlvdf5UTLWytw/OWSCv8RGyuh10miyWeaoqHh1cn2C1IFhUEqN1sSeKKKOWOTvJ2FR5mzi9uH3d/MOBzG5icQ7Qh0fZ1YPz5RaJJhYu6bmfvA/1gD49GoaX2kxQL4J5cEBgg="
   file:
+    - build/OpenRA-${TRAVIS_TAG}.exe
     - build/OpenRA-${TRAVIS_TAG}.zip
     - build/openra_${DOTVERSION}_all.deb
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@
 language: csharp
 mono: 3.12.0
 
-# Use the Docker-based infrastructure
-sudo: false
+# Don't use the container based infrastructure
+sudo: true
 
 cache:
   directories:
@@ -48,7 +48,7 @@ notifications:
     skip_join: true
 
 before_deploy:
- - apt-get download nsis nsis-common
+ - sudo apt-get install nsis nsis-common dpkg
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`
  - cd packaging

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ cache:
 env:
   secure: "C0+Hlfa0YGErxUuWV00Tj6p45otC/D3YwYFuLpi2mj1rDFn/4dgh5WRngjvdDBVbXJ3duaZ78jPHWm1jr7vn2jqj9yETsCIK9psWd38ep/FEBM0SDr6MUD89OuXk/YyvxJAE+UXF6bXg7giey09g/CwBigjMW7ynET3wNAWPHPs="
 
+# Fetch dependencies
 # Run the build script
-# call RALint to check for YAML errors
+# Check source code with StyleCop
+# call OpenRA to check for YAML errors
 script:
  - travis_retry make all-dependencies
  - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ notifications:
     skip_join: true
 
 before_deploy:
- - sudo apt-get install nsis nsis-common dpkg
+ - sudo apt-get install nsis nsis-common dpkg markdown
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`
  - cd packaging

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,11 +41,3 @@ after_test:
 artifacts:
   - path: OpenRA-$(APPVEYOR_REPO_TAG_NAME).exe
     name: Installer
-
-deploy:
-  - provider: GitHub
-    auth_token:
-      secure: Z7RC+ckfvf7Kxf2EdWZCP7bgGjRnhgbMeieQP6VVhiZprwvbEzGXI2Wma+FGAq65
-    artifact: Installer
-    on:
-      appveyor_repo_tag: true

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -24,15 +24,11 @@ find . -path "*.mdb" -delete
 test -e Changelog.md && rm Changelog.md
 curl -s -L -O https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md
 
-curl -s -L -O http://daringfireball.net/projects/downloads/Markdown_1.0.1.zip
-unzip -qq Markdown_1.0.1.zip
-rm -rf Markdown_1.0.1.zip
-./Markdown_1.0.1/Markdown.pl Changelog.md > CHANGELOG.html
-./Markdown_1.0.1/Markdown.pl README.md > README.html
-./Markdown_1.0.1/Markdown.pl CONTRIBUTING.md > CONTRIBUTING.html
-./Markdown_1.0.1/Markdown.pl DOCUMENTATION.md > DOCUMENTATION.html
-./Markdown_1.0.1/Markdown.pl Lua-API.md > Lua-API.html
-rm -rf Markdown_1.0.1
+markdown Changelog.md > CHANGELOG.html
+markdown README.md > README.html
+markdown CONTRIBUTING.md > CONTRIBUTING.html
+markdown DOCUMENTATION.md > DOCUMENTATION.html
+markdown Lua-API.md > Lua-API.html
 
 # List of files that are packaged on all platforms
 FILES=('OpenRA.Game.exe' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' \


### PR DESCRIPTION
Closes #8153
- Travis CI will do the final Windows deployment so every official release CLI get's compiled by the same compiler using the same flags to avoid possible desyncs.
- We switch back the legacy Travis CI non-Docker environment, because we need sudo to install NSIS. ~~The nuget connectivity problems should be gone now thanks to caching.~~ Caching is not supported on the non-container based infrastructure. :(
- I decided to still keep the AppVeyor Setup creation so we keep our nightly builds and CI checks for the NSIS scripts which tend to bit rot faster, because everything has to be listed and the syntax is error prone.
