### PR TITLE
Adds a new IFogCoverHandler interface.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -154,6 +154,7 @@ namespace OpenRA.Traits
 	}
 
 	public interface IVisibilityModifier { bool IsVisible(Actor self, Player byPlayer); }
+	public interface IFogCoverHandler : IVisibilityModifier { }
 	public interface IFogVisibilityModifier { bool HasFogVisibility(Player byPlayer); }
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self); }

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -383,7 +383,8 @@ namespace OpenRA.Traits
 
 		public bool IsTargetable(Actor a)
 		{
-			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a, self.Owner)))
+			var h = a.TraitsImplementing<IFogCoverHandler>();
+			if (a.TraitsImplementing<IVisibilityModifier>().Where(t => h.All(f => f != t)).Any(t => !t.IsVisible(a, self.Owner)))
 				return false;
 
 			if (HasFogVisibility())

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
 	}
 
-	public class FrozenUnderFog : IRenderModifier, IVisibilityModifier, ITick, ISync
+	public class FrozenUnderFog : IRenderModifier, IFogCoverHandler, ITick, ISync
 	{
 		[Sync] public int VisibilityHash;
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("The actor stays invisible under fog of war.")]
 	public class HiddenUnderFogInfo : TraitInfo<HiddenUnderFog> { }
 
-	public class HiddenUnderFog : IRenderModifier, IVisibilityModifier
+	public class HiddenUnderFog : IRenderModifier, IFogCoverHandler
 	{
 		public bool IsVisible(Actor self, Player byPlayer)
 		{


### PR DESCRIPTION
This makes it possible to distinguish cloaked units. Also fixes a bug introduced by #8097 where units wouldn't fire at enemies under fog even with fog visibility. Because hidden under fog and cloak were using the same IVisibilityModifier interface.
