### PR TITLE
Fixed StyleCop on Mono 4

### DIFF
--- a/OpenRA.Utility.exe.config
+++ b/OpenRA.Utility.exe.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1" appliesTo="v1.0.3705">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-100.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/8015.

We need MSBuild in the .NET Framework 3.5 version. Mono 4 dropped those so we need to manually install them as a dependency now. I consider this a workaround until we replace this with something modern probably https://github.com/dotnet/roslyn based in the future.
