### PR TITLE
Fixed SystemNotSupportedException caused by thirdparty mod DLLs on .NET > 4.0

### DIFF
--- a/OpenRA.Game.exe.config
+++ b/OpenRA.Game.exe.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <loadFromRemoteSources enabled="true" />
+  </runtime>
+</configuration>

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -68,6 +68,7 @@ Section "Game" GAME
 	SetOutPath "$INSTDIR"
 	File "${SRCDIR}\OpenRA.exe"
 	File "${SRCDIR}\OpenRA.Game.exe"
+	File "${SRCDIR}\OpenRA.Game.exe.config"
 	File "${SRCDIR}\OpenRA.Utility.exe"
 	File "${SRCDIR}\OpenRA.Renderer.Null.dll"
 	File "${SRCDIR}\OpenRA.Renderer.Sdl2.dll"
@@ -183,6 +184,7 @@ Function ${UN}Clean
 	RMDir /r $INSTDIR\lua
 	Delete $INSTDIR\OpenRA.exe
 	Delete $INSTDIR\OpenRA.Game.exe
+	Delete $INSTDIR\OpenRA.Game.exe.config
 	Delete $INSTDIR\OpenRA.Utility.exe
 	Delete $INSTDIR\OpenRA.Editor.exe
 	Delete $INSTDIR\OpenRA.Renderer.Null.dll


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/8156 (untested).

Harvested the file from http://www.ppmforums.com/viewtopic.php?t=39967.
