### PR TITLE
Sheet fixes

### DIFF
--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -18,7 +18,6 @@ namespace OpenRA.Graphics
 {
 	public sealed class Sheet : IDisposable
 	{
-		readonly object textureLock = new object();
 		bool dirty;
 		bool releaseBufferOnCommit;
 		ITexture texture;
@@ -66,33 +65,21 @@ namespace OpenRA.Graphics
 
 		public ITexture GetTexture()
 		{
-			// This is only called from the main thread but 'dirty'
-			// is set from other threads too via CommitData().
-			GenerateTexture();
-			return texture;
-		}
-
-		void GenerateTexture()
-		{
-			lock (textureLock)
+			if (texture == null)
 			{
-				if (texture == null)
-				{
-					texture = Game.Renderer.Device.CreateTexture();
-					dirty = true;
-				}
-
-				if (data != null)
-				{
-					if (dirty)
-					{
-						texture.SetData(data, Size.Width, Size.Height);
-						dirty = false;
-						if (releaseBufferOnCommit)
-							data = null;
-					}
-				}
+				texture = Game.Renderer.Device.CreateTexture();
+				dirty = true;
 			}
+
+			if (data != null && dirty)
+			{
+				texture.SetData(data, Size.Width, Size.Height);
+				dirty = false;
+				if (releaseBufferOnCommit)
+					data = null;
+			}
+
+			return texture;
 		}
 
 		public Bitmap AsBitmap()
@@ -141,41 +128,32 @@ namespace OpenRA.Graphics
 
 		public void CreateBuffer()
 		{
-			lock (textureLock)
-			{
-				if (data != null)
-					return;
-				if (texture == null)
-					data = new byte[4 * Size.Width * Size.Height];
-				else
-					data = texture.GetData();
-				releaseBufferOnCommit = false;
-			}
+			if (data != null)
+				return;
+			if (texture == null)
+				data = new byte[4 * Size.Width * Size.Height];
+			else
+				data = texture.GetData();
+			releaseBufferOnCommit = false;
 		}
 
-		public void CommitData()
+		public void CommitBufferedData()
 		{
-			lock (textureLock)
-			{
-				if (!Buffered)
-					throw new InvalidOperationException(
-						"This sheet is unbuffered. You cannot call CommitData on an unbuffered sheet. " +
-						"If you need to completely replace the texture data you should set data into the texture directly. " +
-						"If you need to make only small changes to the texture data consider creating a buffered sheet instead.");
+			if (!Buffered)
+				throw new InvalidOperationException(
+					"This sheet is unbuffered. You cannot call CommitBufferedData on an unbuffered sheet. " +
+					"If you need to completely replace the texture data you should set data into the texture directly. " +
+					"If you need to make only small changes to the texture data consider creating a buffered sheet instead.");
 
-				dirty = true;
-			}
+			dirty = true;
 		}
 
 		public void ReleaseBuffer()
 		{
-			lock (textureLock)
-			{
-				if (!Buffered)
-					return;
-				dirty = true;
-				releaseBufferOnCommit = true;
-			}
+			if (!Buffered)
+				return;
+			dirty = true;
+			releaseBufferOnCommit = true;
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -155,16 +155,6 @@ namespace OpenRA.Graphics
 
 		public void CommitData()
 		{
-			CommitData(false);
-		}
-
-		public void ReleaseBuffer()
-		{
-			CommitData(true);
-		}
-
-		void CommitData(bool releaseBuffer)
-		{
 			lock (textureLock)
 			{
 				if (!Buffered)
@@ -174,8 +164,17 @@ namespace OpenRA.Graphics
 						"If you need to make only small changes to the texture data consider creating a buffered sheet instead.");
 
 				dirty = true;
-				if (releaseBuffer)
-					releaseBufferOnCommit = true;
+			}
+		}
+
+		public void ReleaseBuffer()
+		{
+			lock (textureLock)
+			{
+				if (!Buffered)
+					return;
+				dirty = true;
+				releaseBufferOnCommit = true;
 			}
 		}
 

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Graphics
 
 			var rect = Allocate(size, spriteOffset);
 			Util.FastCopyIntoChannel(rect, src);
-			current.CommitData();
+			current.CommitBufferedData();
 			return rect;
 		}
 
@@ -78,7 +78,7 @@ namespace OpenRA.Graphics
 		{
 			var rect = Allocate(src.Size);
 			Util.FastCopyIntoSprite(rect, src);
-			current.CommitData();
+			current.CommitBufferedData();
 			return rect;
 		}
 

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Graphics
 					}
 				}
 
-			s.Sheet.CommitData();
+			s.Sheet.CommitBufferedData();
 
 			return g;
 		}

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Graphics
 			var s = sheetBuilder.Allocate(new Size(su, sv));
 			Util.FastCopyIntoChannel(s, 0, colors);
 			Util.FastCopyIntoChannel(s, 1, normals);
-			s.Sheet.CommitData();
+			s.Sheet.CommitBufferedData();
 
 			var channelP = ChannelSelect[(int)s.Channel];
 			var channelC = ChannelSelect[(int)s.Channel + 1];

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Common.Widgets
 				dirtyShroudCells.Clear();
 			}
 
-			radarSheet.CommitData();
+			radarSheet.CommitBufferedData();
 
 			var o = new float2(mapRect.Location.X, mapRect.Location.Y + world.Map.Bounds.Height * previewScale * (1 - radarMinimapHeight) / 2);
 			var s = new float2(mapRect.Size.Width, mapRect.Size.Height * radarMinimapHeight);


### PR DESCRIPTION
Fixes #8197 (disclaimer: untested).

The voxel renderer creates unbuffered sheets but still allocates sprites over them. This unusual use case caused the sheet builder to fall over as it always assumed buffered sheets would be created and thus need releasing.

Ultimately, releasing the buffer if the sheet is unbuffered is not a problem. You only need to get the exception when calling CommitData as that assumes you were writing to the buffer and now want that buffer committed to texture. If you try and commit and there was no buffer, that's a logic error you want to know about.
- If you call ReleaseBuffer and the buffer is already released, this now is a no-op rather than an exception.
- I have renamed CommitData to CommitBufferedData for a bit of extra clarity. This remains an exception if called when there is no buffer.
- The junk code doing some thread-safety in Sheet has been removed. It is not needed as the only cross-thread call was removed in #8103 because the thread-safety was half-baked anyway.
