### PR TITLE
Reverts #8097.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -383,11 +383,11 @@ namespace OpenRA.Traits
 
 		public bool IsTargetable(Actor a)
 		{
-			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a, self.Owner)))
-				return false;
-
 			if (HasFogVisibility())
 				return true;
+
+			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a, self.Owner)))
+				return false;
 
 			return GetVisOrigins(a).Any(IsVisible);
 		}


### PR DESCRIPTION
#8097 fixed location of cloaked units being revealed by attack line but caused enemies under fog not being targeted even with satellite. See #8190 for further discussion.
