### PR TITLE
Added selection classes

### DIFF
--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -21,11 +21,17 @@ namespace OpenRA.Traits
 		public readonly int Priority = 10;
 		public readonly int[] Bounds = null;
 
+		[Desc("All units having the same selection class specified will be selected with select-by-type commands (e.g. double-click). "
+		+ "Defaults to the actor name when not defined or inherited.")]
+		public readonly string Class = null;
+
 		public object Create(ActorInitializer init) { return new Selectable(init.Self, this); }
 	}
 
 	public class Selectable : IPostRenderSelection
 	{
+		public readonly string Class = null;
+
 		public SelectableInfo Info;
 		readonly Actor self;
 
@@ -33,6 +39,7 @@ namespace OpenRA.Traits
 		{
 			this.self = self;
 			Info = info;
+			Class = string.IsNullOrEmpty(info.Class) ? self.Info.Name : info.Class;
 		}
 
 		IEnumerable<WPos> ActivityTargetPath()

--- a/mods/d2k/rules/starport.yaml
+++ b/mods/d2k/rules/starport.yaml
@@ -23,7 +23,6 @@ trike.starport:
 	Inherits: trike
 	Buildable:
 		Queue: Starport
-		Prerequisites: starport
 	Valued:
 		Cost: 315
 	WithFacingSpriteBody:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -10,6 +10,7 @@ mcv:
 		Name: Mobile Construction Vehicle
 		Description: Deploys into another Construction Yard\n  Unarmed
 	Selectable:
+		Class: mcv
 		Priority: 3
 		Bounds: 42,42
 	Health:
@@ -51,6 +52,7 @@ harvester:
 		Name: Spice Harvester
 		Description: Collects Spice for processing\n  Unarmed
 	Selectable:
+		Class: harvester
 		Priority: 7
 		Bounds: 42,42
 	Harvester:
@@ -96,6 +98,7 @@ trike:
 		Name: Scout Trike
 		Description: Fast Scout\n Strong vs Infantry\n Weak vs Tanks, Aircraft
 	Selectable:
+		Class: trike
 		Bounds: 24,24
 	Health:
 		HP: 100
@@ -151,6 +154,7 @@ quad:
 		Weapon: UnitExplodeTiny
 		EmptyWeapon: UnitExplodeTiny
 	Selectable:
+		Class: quad
 		Bounds: 24,24
 	AttractsWorms:
 		Intensity: 470
@@ -195,6 +199,7 @@ siegetank:
 	AutoTarget:
 		InitialStance: Defend
 	Selectable:
+		Class: siegetank
 		Bounds: 30,30
 	LeavesHusk:
 		HuskActor: siegetank.husk
@@ -235,6 +240,7 @@ missiletank:
 		Weapon: UnitExplodeScale
 		EmptyWeapon: UnitExplodeScale
 	Selectable:
+		Class: missiletank
 		Bounds: 30,30
 	LeavesHusk:
 		HuskActor: missiletank.husk
@@ -449,6 +455,7 @@ deviatortank:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
 	Selectable:
+		Class: combat
 		Bounds: 30,30
 	AttractsWorms:
 		Intensity: 520

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -462,6 +462,8 @@
 
 ^CivInfantry:
 	Inherits: ^Infantry
+	Selectable:
+		Class: CivInfantry
 	Valued:
 		Cost: 70
 	Tooltip:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -388,6 +388,8 @@ DELPHI:
 
 CHAN:
 	Inherits: ^CivInfantry
+	Selectable:
+		Class: CHAN
 	Tooltip:
 		Name: Agent Chan
 
@@ -396,6 +398,7 @@ GNRL:
 	Tooltip:
 		Name: General
 	Selectable:
+		Class: GNRL
 	Voiced:
 		VoiceSet: StavrosVoice
 


### PR DESCRIPTION
Option 3 from #7469 that would support the type of functionality proposed by @MustaphaTR:

http://ares-developers.github.io/Ares-docs/new/typeselect.html

Basically whenever the standard select-by-type functionality is supposed to be extended to select any custom class of selectable actors, these custom classes can be defined using the Class property of the Selectable trait.

If the basic idea is fine, I'd define any remaining selection classes in the YAMLs.
