### PR TITLE
Introduce a class for efficient tiled sprite rendering.

### DIFF
--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -82,6 +82,7 @@ namespace OpenRA
 		void Bind();
 		void SetData(T[] vertices, int length);
 		void SetData(T[] vertices, int start, int length);
+		void SetData(IntPtr data, int start, int length);
 	}
 
 	public interface IShader

--- a/OpenRA.Game/Graphics/Renderer.cs
+++ b/OpenRA.Game/Graphics/Renderer.cs
@@ -202,6 +202,11 @@ namespace OpenRA.Graphics
 			}
 		}
 
+		public IVertexBuffer<Vertex> CreateVertexBuffer(int length)
+		{
+			return Device.CreateVertexBuffer(length);
+		}
+
 		public void EnableScissor(Rectangle rect)
 		{
 			// Must remain inside the current scissor rect

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -103,10 +103,10 @@ namespace OpenRA.Graphics
 			nv += 4;
 		}
 
-		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, Sheet sheet)
+		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, PrimitiveType type, Sheet sheet, BlendMode blendMode)
 		{
 			shader.SetTexture("DiffuseTexture", sheet.GetTexture());
-			renderer.Device.SetBlendMode(BlendMode.Alpha);
+			renderer.Device.SetBlendMode(blendMode);
 			shader.Render(() => renderer.DrawBatch(buffer, start, length, type));
 			renderer.Device.SetBlendMode(BlendMode.None);
 		}

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -1,0 +1,134 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Graphics
+{
+	public sealed class TerrainSpriteLayer : IDisposable
+	{
+		readonly Sprite emptySprite;
+
+		readonly IVertexBuffer<Vertex> vertexBuffer;
+		readonly Vertex[] vertices;
+		readonly HashSet<int> dirtyRows = new HashSet<int>();
+		readonly int rowStride;
+
+		readonly WorldRenderer worldRenderer;
+		readonly Map map;
+
+		readonly Sheet sheet;
+		readonly BlendMode blendMode;
+
+		float paletteIndex;
+
+		public TerrainSpriteLayer(World world, WorldRenderer wr, Sheet sheet, BlendMode blendMode, PaletteReference palette)
+		{
+			worldRenderer = wr;
+			this.sheet = sheet;
+			this.blendMode = blendMode;
+			paletteIndex = palette.TextureIndex;
+
+			map = world.Map;
+			rowStride = 4 * map.MapSize.X;
+
+			vertices = new Vertex[rowStride * map.MapSize.Y];
+			vertexBuffer = Game.Renderer.Device.CreateVertexBuffer(vertices.Length);
+			emptySprite = new Sprite(sheet, Rectangle.Empty, TextureChannel.Alpha);
+
+			wr.PaletteInvalidated += () =>
+			{
+				paletteIndex = palette.TextureIndex;
+
+				// Everything in the layer uses the same palette,
+				// so we can fix the indices in one pass
+				for (var i = 0; i < vertices.Length; i++)
+				{
+					var v = vertices[i];
+					vertices[i] = new Vertex(v.X, v.Y, v.Z, v.U, v.V, paletteIndex, v.C);
+				}
+
+				for (var row = 0; row < map.MapSize.Y; row++)
+					dirtyRows.Add(row);
+			};
+		}
+
+		public void Update(CPos cell, Sprite sprite)
+		{
+			var pos = worldRenderer.ScreenPosition(map.CenterOfCell(cell)) + sprite.Offset - 0.5f * sprite.Size;
+			Update(cell.ToMPos(map.TileShape), sprite, pos);
+		}
+
+		public void Update(MPos uv, Sprite sprite, float2 pos)
+		{
+			if (sprite != null)
+			{
+				if (sprite.Sheet != sheet)
+					throw new InvalidDataException("Attempted to add sprite from a different sheet");
+
+				if (sprite.BlendMode != blendMode)
+					throw new InvalidDataException("Attempted to add sprite with a different blend mode");
+			}
+			else
+				sprite = emptySprite;
+
+			var offset = rowStride * uv.V + 4 * uv.U;
+			Util.FastCreateQuad(vertices, pos, sprite, paletteIndex, offset, sprite.Size);
+
+			dirtyRows.Add(uv.V);
+		}
+
+		public void Draw(Viewport viewport)
+		{
+			var cells = viewport.VisibleCells;
+
+			// Only draw the rows that are visible.
+			// VisibleCells is clamped to the map, so additional checks are unnecessary
+			var firstRow = cells.TopLeft.ToMPos(map).V;
+			var lastRow = cells.BottomRight.ToMPos(map).V + 1;
+
+			Game.Renderer.Flush();
+
+			// Flush any visible changes to the GPU
+			for (var row = firstRow; row <= lastRow; row++)
+			{
+				if (!dirtyRows.Remove(row))
+					continue;
+
+				var rowOffset = rowStride * row;
+
+				unsafe
+				{
+					// The compiler / language spec won't let us calculate a pointer to
+					// an offset inside a generic array T[], and so we are forced to
+					// calculate the start-of-row pointer here to pass in to SetData.
+					fixed (Vertex* vPtr = &vertices[0])
+						vertexBuffer.SetData((IntPtr)(vPtr + rowOffset), rowOffset, rowStride);
+				}
+			}
+
+			Game.Renderer.WorldSpriteRenderer.DrawVertexBuffer(
+				vertexBuffer, rowStride * firstRow, rowStride * (lastRow - firstRow),
+				PrimitiveType.QuadList, sheet, blendMode);
+
+			Game.Renderer.Flush();
+		}
+
+		public void Dispose()
+		{
+			vertexBuffer.Dispose();
+		}
+	}
+}

--- a/OpenRA.Game/Graphics/Vertex.cs
+++ b/OpenRA.Game/Graphics/Vertex.cs
@@ -15,24 +15,19 @@ namespace OpenRA.Graphics
 	[StructLayout(LayoutKind.Sequential)]
 	public struct Vertex
 	{
-		// TODO Workaround for unused field warnings in mono 2.10
-		#pragma warning disable 414
-		float x, y, z, u, v;
-		float p, c;
-		#pragma warning restore
+		public readonly float X, Y, Z, U, V, P, C;
 
 		public Vertex(float2 xy, float u, float v, float p, float c)
-		{
-			this.x = xy.X; this.y = xy.Y; this.z = 0;
-			this.u = u; this.v = v;
-			this.p = p; this.c = c;
-		}
+			: this(xy.X, xy.Y, 0, u, v, p, c) { }
 
 		public Vertex(float[] xyz, float u, float v, float p, float c)
+			: this(xyz[0], xyz[1], xyz[2], u, v, p, c) { }
+
+		public Vertex(float x, float y, float z, float u, float v, float p, float c)
 		{
-			this.x = xyz[0]; this.y = xyz[1]; this.z = xyz[2];
-			this.u = u; this.v = v;
-			this.p = p; this.c = c;
+			X = x; Y = y; Z = z;
+			U = u; V = v;
+			P = p; C = c;
 		}
 	}
 }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Widgets\WidgetUtils.cs" />
     <Compile Include="Widgets\WorldInteractionControllerWidget.cs" />
     <Compile Include="Graphics\PaletteReference.cs" />
+    <Compile Include="Graphics\TerrainSpriteLayer.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Renderer.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Renderer.Null/NullGraphicsDevice.cs
@@ -105,6 +105,7 @@ namespace OpenRA.Renderer.Null
 		public void Bind() { }
 		public void SetData(T[] vertices, int length) { }
 		public void SetData(T[] vertices, int start, int length) { }
+		public void SetData(IntPtr data, int start, int length) { }
 		public void Dispose() { }
 	}
 }

--- a/OpenRA.Renderer.Sdl2/VertexBuffer.cs
+++ b/OpenRA.Renderer.Sdl2/VertexBuffer.cs
@@ -48,6 +48,16 @@ namespace OpenRA.Renderer.Sdl2
 			ErrorHandler.CheckGlError();
 		}
 
+		public void SetData(IntPtr data, int start, int length)
+		{
+			Bind();
+			GL.BufferSubData(BufferTarget.ArrayBuffer,
+				new IntPtr(VertexSize * start),
+				new IntPtr(VertexSize * length),
+				data);
+			ErrorHandler.CheckGlError();
+		}
+
 		public void Bind()
 		{
 			GL.BindBuffer(BufferTarget.ArrayBuffer, buffer);


### PR DESCRIPTION
`TerrainSpriteLayer` wraps a vertex buffer and state management that can be used for sprite map layers (terrain, resources, shroud, etc).  It also removes the assumptions about static map bounds, which is a step towards supporting map-scripted bound changes (needed for TS/RA2) and cordon manipulation in the new editor.

This pr introduces the new class and hooks it up for the terrain renderer.  There shouldn't be any significant perf or gameplay changes.  The real benefits will come in the next few prs that will use this for the shroud, resources, etc.

Pinging @chrisforbes and @RoosterDragon who are the best suited to review this.
