### PR TITLE
Fix broken bridges being initialized with a non-zero HP value

### DIFF
--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -44,8 +44,6 @@ namespace OpenRA.Traits
 			MaxHP = info.HP;
 
 			hp = init.Contains<HealthInit>() ? init.Get<HealthInit, int>() * MaxHP / 100 : MaxHP;
-			if (hp <= 0)
-				hp = Math.Max(MaxHP / 100, 1);
 
 			DisplayHp = hp;
 		}
@@ -176,9 +174,21 @@ namespace OpenRA.Traits
 	public class HealthInit : IActorInit<int>
 	{
 		[FieldFromYamlKey] readonly int value = 100;
+		readonly bool allowZero = false;
 		public HealthInit() { }
-		public HealthInit(int init) { value = init; }
-		public int Value(World world) { return value; }
+		public HealthInit(int init)
+		{
+			allowZero = true;
+			value = init;
+		}
+
+		public int Value(World world)
+		{
+			if (value < 0 || (value == 0 && !allowZero))
+				return 1;
+
+			return value;
+		}
 	}
 
 	public static class HealthExts


### PR DESCRIPTION
Fixes the second half of #8219. For an explanation, see https://github.com/OpenRA/OpenRA/issues/8219#issuecomment-104926466
