### PR TITLE
Dispose traits when destroying an actor.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -225,6 +225,9 @@ namespace OpenRA
 				if (IsInWorld)
 					World.Remove(this);
 
+				foreach (var t in TraitsImplementing<INotifyActorDisposing>())
+					t.Disposing(this);
+
 				World.TraitDict.RemoveActor(this);
 				Disposed = true;
 

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -22,7 +22,7 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
-	public class Actor : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding, IEquatable<Actor>
+	public sealed class Actor : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding, IEquatable<Actor>, IDisposable
 	{
 		public readonly ActorInfo Info;
 

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -33,7 +33,7 @@ namespace OpenRA
 		[Sync] public Player Owner { get; set; }
 
 		public bool IsInWorld { get; internal set; }
-		public bool Destroyed { get; private set; }
+		public bool Disposed { get; private set; }
 
 		Activity currentActivity;
 
@@ -51,7 +51,7 @@ namespace OpenRA
 		public IEffectiveOwner EffectiveOwner { get { return effectiveOwner.Value; } }
 
 		public bool IsIdle { get { return currentActivity == null; } }
-		public bool IsDead { get { return Destroyed || (health.Value == null ? false : health.Value.IsDead); } }
+		public bool IsDead { get { return Disposed || (health.Value == null ? false : health.Value.IsDead); } }
 
 		public CPos Location { get { return occupySpace.Value.TopLeft; } }
 		public WPos CenterPosition { get { return occupySpace.Value.CenterPosition; } }
@@ -215,18 +215,18 @@ namespace OpenRA
 			World.TraitDict.AddTrait(this, trait);
 		}
 
-		public void Destroy()
+		public void Dispose()
 		{
 			World.AddFrameEndTask(w =>
 			{
-				if (Destroyed)
+				if (Disposed)
 					return;
 
 				if (IsInWorld)
 					World.Remove(this);
 
 				World.TraitDict.RemoveActor(this);
-				Destroyed = true;
+				Disposed = true;
 
 				if (luaInterface != null)
 					luaInterface.Value.OnActorDestroyed();
@@ -238,7 +238,7 @@ namespace OpenRA
 		{
 			World.AddFrameEndTask(w =>
 			{
-				if (Destroyed)
+				if (Disposed)
 					return;
 
 				var oldOwner = Owner;

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -140,7 +140,7 @@ namespace OpenRA.Graphics
 
 			// added for contrails
 			foreach (var a in World.ActorsWithTrait<IPostRender>())
-				if (a.Actor.IsInWorld && !a.Actor.Destroyed)
+				if (a.Actor.IsInWorld && !a.Actor.Disposed)
 					a.Trait.RenderAfterWorld(this, a.Actor);
 
 			var renderShroud = World.RenderPlayer != null ? World.RenderPlayer.Shroud : null;
@@ -154,7 +154,7 @@ namespace OpenRA.Graphics
 
 			Game.Renderer.DisableScissor();
 
-			var overlayRenderables = World.Selection.Actors.Where(a => !a.Destroyed)
+			var overlayRenderables = World.Selection.Actors.Where(a => !a.Disposed)
 				.SelectMany(a => a.TraitsImplementing<IPostRenderSelection>())
 				.SelectMany(t => t.RenderAfterWorld(this));
 
@@ -174,7 +174,7 @@ namespace OpenRA.Graphics
 
 			if (World.Type == WorldType.Regular && Game.Settings.Game.AlwaysShowStatusBars)
 			{
-				foreach (var g in World.Actors.Where(a => !a.Destroyed
+				foreach (var g in World.Actors.Where(a => !a.Disposed
 					&& a.HasTrait<Selectable>()
 					&& !World.FogObscures(a)
 					&& !World.Selection.Actors.Contains(a)))

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -123,6 +123,9 @@ namespace OpenRA.Graphics
 
 		public void Draw()
 		{
+			if (World.WorldActor.Disposed)
+				return;
+
 			RefreshPalette();
 
 			if (World.Type == WorldType.Shellmap && !Game.Settings.Game.ShowShellmap)
@@ -273,6 +276,12 @@ namespace OpenRA.Graphics
 
 		public void Dispose()
 		{
+			// HACK: Disposing the world from here violates ownership
+			// but the WorldRenderer lifetime matches the disposal
+			// behavior we want for the world, and the root object setup
+			// is so horrible that doing it properly would be a giant mess.
+			World.Dispose();
+
 			palette.Dispose();
 			Theater.Dispose();
 			terrainRenderer.Dispose();

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Orders
 			if (self.Owner != self.World.LocalPlayer)
 				return null;
 
-			if (self.Destroyed || !target.IsValidFor(self))
+			if (self.Disposed || !target.IsValidFor(self))
 				return null;
 
 			if (mi.Button == Game.Settings.Game.MouseButtonPreference.Action)

--- a/OpenRA.Game/Scripting/ScriptActorInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptActorInterface.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Scripting
 			var commandClasses = Context.ActorCommands[actor.Info].AsEnumerable();
 
 			// Destroyed actors cannot have their traits queried
-			if (actor.Destroyed)
+			if (actor.Disposed)
 				commandClasses = commandClasses.Where(c => c.HasAttribute<ExposedForDestroyedActors>());
 
 			var args = new object[] { Context, actor };

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -78,7 +78,7 @@ namespace OpenRA
 			foreach (var cg in controlGroups.Values)
 			{
 				// note: NOT `!a.IsInWorld`, since that would remove things that are in transports.
-				cg.RemoveAll(a => a.Destroyed || a.Owner != world.LocalPlayer);
+				cg.RemoveAll(a => a.Disposed || a.Owner != world.LocalPlayer);
 			}
 		}
 

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -80,7 +80,7 @@ namespace OpenRA
 
 		static void CheckDestroyed(Actor actor)
 		{
-			if (actor.Destroyed)
+			if (actor.Disposed)
 				throw new InvalidOperationException("Attempted to get trait from destroyed object ({0})".F(actor));
 		}
 

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				if (self.Destroyed)
+				if (self.Disposed)
 					return;
 
 				var line = self.TraitOrDefault<DrawLineToTarget>();
@@ -120,7 +120,7 @@ namespace OpenRA.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				if (self.Destroyed)
+				if (self.Disposed)
 					return;
 
 				target.Flash();

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Traits
 					nd.Killed(self, ai);
 
 				if (RemoveOnDeath)
-					self.Destroy();
+					self.Dispose();
 
 				Log.Write("debug", "{0} #{1} killed by {2} #{3}", self.Info.Name, self.ActorID, attacker.Info.Name, attacker.ActorID);
 			}
@@ -195,7 +195,7 @@ namespace OpenRA.Traits
 	{
 		public static DamageState GetDamageState(this Actor self)
 		{
-			if (self.Destroyed)
+			if (self.Disposed)
 				return DamageState.Dead;
 
 			var health = self.TraitOrDefault<Health>();
@@ -204,7 +204,7 @@ namespace OpenRA.Traits
 
 		public static void InflictDamage(this Actor self, Actor attacker, int damage, DamageWarhead warhead)
 		{
-			if (self.Destroyed) return;
+			if (self.Disposed) return;
 			var health = self.TraitOrDefault<Health>();
 			if (health == null) return;
 			health.InflictDamage(self, attacker, damage, warhead, false);

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Traits
 			if (NeedRenderables)
 			{
 				NeedRenderables = false;
-				if (!actor.Destroyed)
+				if (!actor.Disposed)
 				{
 					IsRendering = true;
 					renderables = actor.Render(wr).ToArray();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -94,6 +94,7 @@ namespace OpenRA.Traits
 	public interface INotifyDamageStateChanged { void DamageStateChanged(Actor self, AttackInfo e); }
 	public interface INotifyRepair { void Repairing(Actor self, Actor host); }
 	public interface INotifyKilled { void Killed(Actor self, AttackInfo e); }
+	public interface INotifyActorDisposing { void Disposing(Actor self); }
 	public interface INotifyAppliedDamage { void AppliedDamage(Actor self, Actor damaged, AttackInfo e); }
 	public interface INotifyBuildComplete { void BuildingComplete(Actor self); }
 	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -198,7 +198,7 @@ namespace OpenRA.Traits
 				yield break;
 
 			for (var i = influence[a]; i != null; i = i.Next)
-				if (!i.Actor.Destroyed)
+				if (!i.Actor.Disposed)
 					yield return i.Actor;
 		}
 
@@ -208,7 +208,7 @@ namespace OpenRA.Traits
 				yield break;
 
 			for (var i = influence[a]; i != null; i = i.Next)
-				if (!i.Actor.Destroyed && (i.SubCell == sub || i.SubCell == SubCell.FullCell))
+				if (!i.Actor.Disposed && (i.SubCell == sub || i.SubCell == SubCell.FullCell))
 					yield return i.Actor;
 		}
 
@@ -285,7 +285,7 @@ namespace OpenRA.Traits
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
 			for (var i = influence[a]; i != null; i = i.Next)
-				if ((always || i.SubCell == sub || i.SubCell == SubCell.FullCell) && !i.Actor.Destroyed && withCondition(i.Actor))
+				if ((always || i.SubCell == sub || i.SubCell == SubCell.FullCell) && !i.Actor.Disposed && withCondition(i.Actor))
 					return true;
 
 			return false;

--- a/OpenRA.Game/VoiceExts.cs
+++ b/OpenRA.Game/VoiceExts.cs
@@ -59,7 +59,7 @@ namespace OpenRA
 					continue;
 
 				var orderSubject = o.Subject;
-				if (orderSubject.Destroyed)
+				if (orderSubject.Disposed)
 					continue;
 
 				foreach (var voice in orderSubject.TraitsImplementing<IVoiced>())

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -24,7 +24,7 @@ namespace OpenRA
 {
 	public enum WorldType { Regular, Shellmap, Editor }
 
-	public class World
+	public sealed class World : IDisposable
 	{
 		class ActorIDComparer : IComparer<Actor>
 		{
@@ -368,6 +368,19 @@ namespace OpenRA
 				pi.Outcome = player.WinState;
 				pi.OutcomeTimestampUtc = DateTime.UtcNow;
 			}
+		}
+
+		public void Dispose()
+		{
+			frameEndActions.Clear();
+
+			// Dispose newer actors first, and the world actor last
+			foreach (var a in actors.Reverse())
+				a.Dispose();
+
+			// Actor disposals are done in a FrameEndTask
+			while (frameEndActions.Count != 0)
+				frameEndActions.Dequeue()(this);
 		}
 	}
 

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -382,7 +382,7 @@ namespace OpenRA.Mods.Common.AI
 				case BuildingType.Defense:
 
 					// Build near the closest enemy structure
-					var closestEnemy = World.Actors.Where(a => !a.Destroyed && a.HasTrait<Building>() && Player.Stances[a.Owner] == Stance.Enemy)
+					var closestEnemy = World.Actors.Where(a => !a.Disposed && a.HasTrait<Building>() && Player.Stances[a.Owner] == Stance.Enemy)
 						.ClosestTo(World.Map.CenterOfCell(defenseCenter));
 
 					var targetCell = closestEnemy != null ? closestEnemy.Location : baseCenter;
@@ -944,7 +944,7 @@ namespace OpenRA.Mods.Common.AI
 				}
 			}
 
-			if (e.Attacker.Destroyed)
+			if (e.Attacker.Disposed)
 				return;
 
 			if (!e.Attacker.HasTrait<ITargetable>())

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.AI
 			else
 			{
 				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WRange.FromCells(12))
-					.Where(a1 => !a1.Destroyed && !a1.IsDead);
+					.Where(a1 => !a1.Disposed && !a1.IsDead);
 				var enemynearby = enemies.Where(a1 => a1.HasTrait<ITargetable>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
 				var target = enemynearby.ClosestTo(leader.CenterPosition);
 				if (target != null)

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 					weapon.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
 				}
 
-				self.Destroy();
+				self.Dispose();
 				return null;
 			}
 

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Activities
 					actor.InflictDamage(self, damage, null);
 				}
 
-				self.Destroy();
+				self.Dispose();
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/DonateSupplies.cs
+++ b/OpenRA.Mods.Common/Activities/DonateSupplies.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 				return;
 
 			target.Owner.PlayerActor.Trait<PlayerResources>().GiveCash(payload);
-			self.Destroy();
+			self.Dispose();
 
 			if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				self.World.AddFrameEndTask(w => w.Add(new FloatingText(target.CenterPosition, target.Owner.Color.RGB, FloatingText.FormatCashTick(payload), 30)));

--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Activities
 						capturable.EndCapture();
 
 						if (capturesInfo != null && capturesInfo.ConsumeActor)
-							self.Destroy();
+							self.Dispose();
 					});
 				}
 			}

--- a/OpenRA.Mods.Common/Activities/RemoveSelf.cs
+++ b/OpenRA.Mods.Common/Activities/RemoveSelf.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Activities
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceled) return NextActivity;
-			self.Destroy();
+			self.Dispose();
 			return null;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (hut.BridgeDamageState == DamageState.Undamaged || hut.Repairing || hut.Bridge.GetHut(0) == null || hut.Bridge.GetHut(1) == null)
 				return;
 			hut.Repair(self);
-			self.Destroy();
+			self.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (health.DamageState == DamageState.Undamaged)
 				return;
 			target.InflictDamage(self, -health.MaxHP, null);
-			self.Destroy();
+			self.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (refund > 0 && self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.Owner.Color.RGB, FloatingText.FormatCashTick(refund), 30)));
 
-			self.Destroy();
+			self.Dispose();
 			return this;
 		}
 

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 				var selected = w.Selection.Contains(self);
 				var controlgroup = w.Selection.GetControlGroupForActor(self);
 
-				self.Destroy();
+				self.Dispose();
 				foreach (var s in Sounds)
 					Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
 

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Activities
 			cargo.Unload(self);
 			self.World.AddFrameEndTask(w =>
 			{
-				if (actor.Destroyed)
+				if (actor.Disposed)
 					return;
 
 				var move = actor.Trait<IMove>();

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Commands
 
 					foreach (var actor in world.Selection.Actors)
 					{
-						if (actor.IsDead || actor.Destroyed)
+						if (actor.IsDead || actor.Disposed)
 							continue;
 
 						var leveluporder = new Order("DevLevelUp", actor, false);

--- a/OpenRA.Mods.Common/Effects/PowerdownIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/PowerdownIndicator.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (a.Destroyed || wr.World.FogObscures(a))
+			if (a.Disposed || wr.World.FogObscures(a))
 				return SpriteRenderable.None;
 
 			return anim.Render(a.CenterPosition, wr.Palette(canPowerDown.Info.IndicatorPalette));

--- a/OpenRA.Mods.Common/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RepairIndicator.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (building.Destroyed || wr.World.FogObscures(building) || rb.Repairers.Count == 0)
+			if (building.Disposed || wr.World.FogObscures(building) || rb.Repairers.Count == 0)
 				return SpriteRenderable.None;
 
 			PaletteReference palette;

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Scripting
 			if (!sma.Actors.TryGetValue(actorName, out ret))
 				return null;
 
-			if (ret.Destroyed)
+			if (ret.Disposed)
 				return null;
 
 			return ret;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 	}
 
-	public class Aircraft : IFacing, IPositionable, ISync, INotifyKilled, IIssueOrder, IOrderVoice, INotifyAddedToWorld, INotifyRemovedFromWorld
+	public class Aircraft : IFacing, IPositionable, ISync, IIssueOrder, IOrderVoice, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing
 	{
 		static readonly Pair<CPos, SubCell>[] NoCells = { };
 
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void Killed(Actor self, AttackInfo e)
+		public void Disposing(Actor self)
 		{
 			UnReserve();
 		}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -75,10 +75,10 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var attacker = e.Attacker;
-			if (attacker.Destroyed || Stance < UnitStance.ReturnFire)
+			if (attacker.Disposed || Stance < UnitStance.ReturnFire)
 				return;
 
-			if (!attacker.IsInWorld && !attacker.Destroyed)
+			if (!attacker.IsInWorld && !attacker.Disposed)
 			{
 				// If the aggressor is in a transport, then attack the transport instead
 				var passenger = attacker.TraitOrDefault<Passenger>();

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new Refinery(init.Self, this); }
 	}
 
-	public class Refinery : ITick, IAcceptResources, INotifyKilled, INotifySold, INotifyCapture, INotifyOwnerChanged, IExplodeModifier, ISync
+	public class Refinery : ITick, IAcceptResources, INotifySold, INotifyCapture, INotifyOwnerChanged, IExplodeModifier, ISync, INotifyActorDisposing
 	{
 		readonly Actor self;
 		readonly RefineryInfo info;
@@ -118,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void Killed(Actor self, AttackInfo e)
+		public void Disposing(Actor self)
 		{
 			CancelDock(self);
 			foreach (var harv in GetLinkedHarvesters())

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Reserve landing places for aircraft.")]
 	class ReservableInfo : TraitInfo<Reservable> { }
 
-	public class Reservable : ITick, INotifyKilled, INotifyOwnerChanged, INotifySold
+	public class Reservable : ITick, INotifyOwnerChanged, INotifySold, INotifyActorDisposing
 	{
 		Actor reservedFor;
 		Aircraft reservedForAircraft;
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			return res != null && res.reservedFor != null;
 		}
 
-		public void Killed(Actor self, AttackInfo e)
+		public void Disposing(Actor self)
 		{
 			if (reservedForAircraft != null)
 				reservedForAircraft.UnReserve();

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -54,7 +54,8 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
 
-	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyKilled, INotifyOwnerChanged, INotifyAddedToWorld, ITick, INotifySold, IDisableMove
+	public class Cargo : IPips, IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyKilled,
+		INotifyOwnerChanged, INotifyAddedToWorld, ITick, INotifySold, IDisableMove, INotifyActorDisposing
 	{
 		public readonly CargoInfo Info;
 		readonly Actor self;
@@ -301,6 +302,14 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var c in cargo)
 				c.Kill(e.Attacker);
+
+			cargo.Clear();
+		}
+
+		public void Disposing(Actor self)
+		{
+			foreach (var c in cargo)
+				c.Dispose();
 
 			cargo.Clear();
 		}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var crateActions = self.TraitsImplementing<CrateAction>();
 
-			self.Destroy();
+			self.Dispose();
 			collected = true;
 
 			if (crateActions.Any())
@@ -112,13 +112,13 @@ namespace OpenRA.Mods.Common.Traits
 			if (collector != null)
 				OnCrush(collector);
 			else
-				self.Destroy();
+				self.Dispose();
 		}
 
 		public void Tick(Actor self)
 		{
 			if (info.Lifetime != 0 && ++ticks >= info.Lifetime * 25)
-				self.Destroy();
+				self.Dispose();
 		}
 
 		public CPos TopLeft { get { return Location; } }

--- a/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 			else
-				pilot.Destroy();
+				pilot.Dispose();
 		}
 
 		static bool IsSuitableCell(Actor self, Actor actorToDrop)

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var info = self.Info.Traits.Get<GivesBountyInfo>();
 
-			if (e.Attacker == null || e.Attacker.Destroyed) return;
+			if (e.Attacker == null || e.Attacker.Disposed) return;
 
 			if (!info.Stances.Contains(e.Attacker.Owner.Stances[self.Owner])) return;
 

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Killed(Actor self, AttackInfo e)
 		{
 			// Prevent TK from giving exp
-			if (e.Attacker == null || e.Attacker.Destroyed || (!info.FriendlyFire && e.Attacker.Owner.Stances[self.Owner] == Stance.Ally))
+			if (e.Attacker == null || e.Attacker.Disposed || (!info.FriendlyFire && e.Attacker.Owner.Stances[self.Owner] == Stance.Ally))
 				return;
 
 			var valued = self.Info.Traits.GetOrDefault<ValuedInfo>();

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void SetProcLines(Actor proc)
 		{
 			if (proc == null) return;
-			if (proc.Destroyed) return;
+			if (proc.Disposed) return;
 
 			var linkedHarvs = proc.World.ActorsWithTrait<Harvester>()
 				.Where(a => a.Trait.LinkedProc == proc)
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Check that we're not in a critical location and being useless (refinery drop-off):
 			var lastproc = LastLinkedProc ?? LinkedProc;
-			if (lastproc != null && !lastproc.Destroyed)
+			if (lastproc != null && !lastproc.Disposed)
 			{
 				var deliveryLoc = lastproc.Location + lastproc.Trait<IAcceptResources>().DeliveryOffset;
 				if (self.Location == deliveryLoc)

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (Info.RemoveInstead || !self.HasTrait<Health>())
-				self.Destroy();
+				self.Dispose();
 			else
 				self.Kill(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Tick(Actor self)
 		{
-			if (self.Destroyed)
+			if (self.Disposed)
 				return;
 
 			VisibilityHash = 0;

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self.World.AddFrameEndTask(w =>
 			{
-				if (self.Destroyed || captor.Destroyed) return;
+				if (self.Disposed || captor.Disposed) return;
 
 				var previousOwner = self.Owner;
 
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<Actor> UnitsInRange()
 		{
 			return Self.World.FindActorsInCircle(Self.CenterPosition, WRange.FromCells(Info.Range))
-				.Where(a => a.IsInWorld && a != Self && !a.Destroyed && !a.Owner.NonCombatant);
+				.Where(a => a.IsInWorld && a != Self && !a.Disposed && !a.Owner.NonCombatant);
 		}
 
 		bool IsClear(Actor self, Player currentOwner, Player originalOwner)

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self.World.AddFrameEndTask(w =>
 			{
-				if (!self.Destroyed)
+				if (!self.Disposed)
 					w.Add(new Corpse(w, self.CenterPosition, rs.GetImage(self), sequence, palette));
 			});
 		}

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -24,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new StoresResources(init.Self, this); }
 	}
 
-	class StoresResources : IPips, INotifyOwnerChanged, INotifyCapture, INotifyKilled, IExplodeModifier, IStoreResources, ISync
+	class StoresResources : IPips, INotifyOwnerChanged, INotifyCapture, IExplodeModifier, IStoreResources, ISync, INotifyActorDisposing
 	{
 		readonly StoresResourcesInfo info;
 
@@ -51,9 +52,14 @@ namespace OpenRA.Mods.Common.Traits
 			newOwner.PlayerActor.Trait<PlayerResources>().GiveResources(resources);
 		}
 
-		public void Killed(Actor self, AttackInfo e)
+		bool disposed;
+		public void Disposing(Actor self)
 		{
+			if (disposed)
+				return;
+
 			player.TakeResources(Stored); // lose the stored resources
+			disposed = true;
 		}
 
 		public IEnumerable<PipType> GetPips(Actor self)

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ActorEntered(Actor a)
 		{
-			if (a.Destroyed)
+			if (a.Disposed)
 				return;
 
 			if (a == self && !info.AffectsParent)
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ActorExited(Actor a)
 		{
-			if (a == self || a.Destroyed)
+			if (a == self || a.Disposed)
 				return;
 
 			var stance = self.Owner.Stances[a.Owner];

--- a/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (claimByActor.Remove(claim.Claimer) & claimByCell.Remove(claim.Cell))
 			{
-				if (claim.Claimer.Destroyed) return;
+				if (claim.Claimer.Disposed) return;
 				if (!claim.Claimer.IsInWorld) return;
 				if (claim.Claimer.IsDead) return;
 

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Widgets
 		void PerformKeyboardOrderOnSelection(Func<Actor, Order> f)
 		{
 			var orders = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && !a.Destroyed)
+				.Where(a => a.Owner == world.LocalPlayer && !a.Disposed)
 				.Select(f)
 				.ToArray();
 
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformStanceCycle()
 		{
 			var actor = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && !a.Destroyed)
+				.Where(a => a.Owner == world.LocalPlayer && !a.Disposed)
 				.Select(a => Pair.New(a, a.TraitOrDefault<AutoTarget>()))
 				.FirstOrDefault(a => a.Second != null);
 
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformGuard()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => !a.Destroyed && a.Owner == world.LocalPlayer && a.HasTrait<Guard>());
+				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.HasTrait<Guard>());
 
 			if (actors.Any())
 				world.OrderGenerator = new GuardOrderGenerator(actors);

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.D2k.Activities
 
 				actor.World.AddFrameEndTask(_ =>
 					{
-						actor1.Destroy();
+						actor1.Dispose();
 
 						// Harvester insurance
 						if (!actor1.HasTrait<Harvester>())

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -27,7 +28,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public object Create(ActorInitializer init) { return new Carryall(init.Self, this); }
 	}
 
-	public class Carryall : INotifyBecomingIdle, INotifyKilled, ISync, IRender
+	public class Carryall : INotifyBecomingIdle, INotifyKilled, ISync, IRender, INotifyActorDisposing
 	{
 		readonly Actor self;
 		readonly WRange carryHeight;
@@ -164,6 +165,15 @@ namespace OpenRA.Mods.D2k.Traits
 			}
 
 			UnreserveCarryable();
+		}
+
+		public void Disposing(Actor self)
+		{
+			if (Carrying != null && IsCarrying)
+			{
+				Carrying.Dispose();
+				Carrying = null;
+			}
 		}
 
 		// Called when carryable is inside.

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public override object Create(ActorInitializer init) { return new Sandworm(init.Self, this); }
 	}
 
-	class Sandworm : Wanders, ITick, INotifyKilled
+	class Sandworm : Wanders, ITick, INotifyActorDisposing
 	{
 		public readonly SandwormInfo Info;
 
@@ -151,9 +151,14 @@ namespace OpenRA.Mods.D2k.Traits
 			IsMovingTowardTarget = true;
 		}
 
-		public void Killed(Actor self, AttackInfo e)
+		bool disposed;
+		public void Disposing(Actor self)
 		{
+			if (disposed)
+				return;
+
 			manager.DecreaseWormCount();
+			disposed = true;
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Activities
 			foreach (var t in target.TraitsImplementing<INotifyInfiltrated>())
 				t.Infiltrated(target, self);
 
-			self.Destroy();
+			self.Dispose();
 
 			if (target.HasTrait<Building>())
 				Sound.PlayToPlayer(self.Owner, "bldginf1.aud");

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.RA.Activities
 				foreach (var a in self.World.ActorsWithTrait<ChronoshiftPaletteEffect>())
 					a.Trait.Enable();
 
-			if (teleporter != null && self != teleporter && !teleporter.Destroyed)
+			if (teleporter != null && self != teleporter && !teleporter.Disposed)
 			{
 				var building = teleporter.TraitOrDefault<RenderBuilding>();
 				if (building != null)

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public void Tick(World world)
 		{
-			if (self.Destroyed)
+			if (self.Disposed)
 				world.AddFrameEndTask(w => w.Remove(this));
 
 			show = false;
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.RA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (!show || self.Destroyed)
+			if (!show || self.Disposed)
 				return SpriteRenderable.None;
 
 			var palette = wr.Palette(info.IndicatorPalettePrefix + self.Owner.InternalName);

--- a/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.RA.Traits
 				self.World.AddFrameEndTask(w =>
 				{
 					// damage is inflicted by the chronosphere
-					if (!self.Destroyed)
+					if (!self.Disposed)
 						self.InflictDamage(chronosphere, int.MaxValue, null);
 				});
 				return true;


### PR DESCRIPTION
This addresses some long-standing bogosity with our world/actor teardown logic.  Traits that implement `IDisposable` should now be cleaned up whenever their actor is permanently removed from the world.  Several traits that were previously forced to hook only death have been updated to use disposing instead.
