### PR TITLE
Fix broken bridges being initialized with a non-zero HP value

### DIFF
--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -41,11 +41,9 @@ namespace OpenRA.Traits
 		public Health(ActorInitializer init, HealthInfo info)
 		{
 			Info = info;
-			MaxHP = info.HP;
+			MaxHP = info.HP > 0 ? info.HP : 1;
 
 			hp = init.Contains<HealthInit>() ? init.Get<HealthInit, int>() * MaxHP / 100 : MaxHP;
-			if (hp <= 0)
-				hp = Math.Max(MaxHP / 100, 1);
 
 			DisplayHp = hp;
 		}
@@ -176,9 +174,21 @@ namespace OpenRA.Traits
 	public class HealthInit : IActorInit<int>
 	{
 		[FieldFromYamlKey] readonly int value = 100;
+		readonly bool allowZero = false;
 		public HealthInit() { }
-		public HealthInit(int init) { value = init; }
-		public int Value(World world) { return value; }
+		public HealthInit(int init, bool allowZero = false)
+		{
+			this.allowZero = allowZero;
+			value = init;
+		}
+
+		public int Value(World world)
+		{
+			if (value < 0 || (value == 0 && !allowZero))
+				return 1;
+
+			return value;
+		}
 	}
 
 	public static class HealthExts

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				new LocationInit(new CPos(ni, nj)),
 				new OwnerInit(w.WorldActor.Owner),
-				new HealthInit(bridgeTypes[tile].Second),
+				new HealthInit(bridgeTypes[tile].Second, true),
 			}).Trait<Bridge>();
 
 			var subTiles = new Dictionary<CPos, byte>();


### PR DESCRIPTION
Fixes the second half of #8219. For an explanation, see https://github.com/OpenRA/OpenRA/issues/8219#issuecomment-104926466

As a side effect this also replaces invalid initial health values with 1 HP instead of 1% of MaxHP.
