### PR TITLE
Added a NuGet replacement script as fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 # Check source code with StyleCop
 # call OpenRA to check for YAML errors
 script:
+ - sudo apt-get remove nuget # https://github.com/travis-ci/travis-ci/issues/3940
  - travis_retry make all-dependencies
  - make all
  - make check

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -8,30 +8,39 @@ download_dir="${0%/*}/download/windows"
 mkdir -p "${download_dir}"
 cd "${download_dir}"
 
+function get()
+{
+	if which nuget >/dev/null; then
+		nuget install $1 -Version $2 -ExcludeVersion
+	else
+		../../noget.sh $1 $2
+	fi
+}
+
 if [ ! -f SDL2.dll ]; then
 	echo "Fetching SDL2 from nuget"
-	nuget install sdl2 -Version 2.0.3 -ExcludeVersion
+	get sdl2.redist 2.0.3
 	cp ./sdl2.redist/build/native/bin/Win32/dynamic/SDL2.dll .
-	rm -rf sdl2 sdl2.redist
+	rm -rf sdl2.redist
 fi
 
 if [ ! -f freetype6.dll ]; then
 	echo "Fetching FreeType2 from nuget"
-	nuget install SharpFont.Dependencies -Version 2.5.5.1 -ExcludeVersion
+	get SharpFont.Dependencies 2.5.5.1
 	cp ./SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll .
 	rm -rf SharpFont.Dependencies
 fi
 
 if [ ! -f lua51.dll ]; then
 	echo "Fetching Lua 5.1 from nuget"
-	nuget install lua.binaries -Version 5.1.5 -ExcludeVersion
+	get lua.binaries 5.1.5
 	cp ./lua.binaries/bin/win32/dll8/lua5.1.dll ./lua51.dll
 	rm -rf lua.binaries
 fi
 
 if [ ! -f soft_oal.dll ]; then
 	echo "Fetching OpenAL Soft from nuget"
-	nuget install OpenAL-Soft -Version 1.16.0 -ExcludeVersion
+	get OpenAL-Soft 1.16.0
 	cp ./OpenAL-Soft/bin/Win32/soft_oal.dll ./soft_oal.dll
 	rm -rf OpenAL-Soft
 fi

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -18,28 +18,28 @@ function get()
 }
 
 if [ ! -f SDL2.dll ]; then
-	echo "Fetching SDL2 from nuget"
+	echo "Fetching SDL2 from NuGet"
 	get sdl2.redist 2.0.3
 	cp ./sdl2.redist/build/native/bin/Win32/dynamic/SDL2.dll .
 	rm -rf sdl2.redist
 fi
 
 if [ ! -f freetype6.dll ]; then
-	echo "Fetching FreeType2 from nuget"
+	echo "Fetching FreeType2 from NuGet"
 	get SharpFont.Dependencies 2.5.5.1
 	cp ./SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll .
 	rm -rf SharpFont.Dependencies
 fi
 
 if [ ! -f lua51.dll ]; then
-	echo "Fetching Lua 5.1 from nuget"
+	echo "Fetching Lua 5.1 from NuGet"
 	get lua.binaries 5.1.5
 	cp ./lua.binaries/bin/win32/dll8/lua5.1.dll ./lua51.dll
 	rm -rf lua.binaries
 fi
 
 if [ ! -f soft_oal.dll ]; then
-	echo "Fetching OpenAL Soft from nuget"
+	echo "Fetching OpenAL Soft from NuGet"
 	get OpenAL-Soft 1.16.0
 	cp ./OpenAL-Soft/bin/Win32/soft_oal.dll ./soft_oal.dll
 	rm -rf OpenAL-Soft

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -18,28 +18,28 @@ function get()
 }
 
 if [ ! -f StyleCopPlus.dll ]; then
-	echo "Fetching StyleCopPlus from nuget"
+	echo "Fetching StyleCopPlus from NuGet"
 	get StyleCopPlus.MSBuild 4.7.49.5
 	cp ./StyleCopPlus.MSBuild/tools/StyleCopPlus.dll .
 	rm -rf StyleCopPlus.MSBuild
 fi
 
 if [ ! -f StyleCop.dll ]; then
-	echo "Fetching StyleCop files from nuget"
+	echo "Fetching StyleCop files from NuGet"
 	get StyleCop.MSBuild 4.7.49.0
 	cp ./StyleCop.MSBuild/tools/StyleCop*.dll .
 	rm -rf StyleCop.MSBuild
 fi
 
 if [ ! -f ICSharpCode.SharpZipLib.dll ]; then
-	echo "Fetching ICSharpCode.SharpZipLib from nuget"
+	echo "Fetching ICSharpCode.SharpZipLib from NuGet"
 	get SharpZipLib 0.86.0
 	cp ./SharpZipLib/lib/20/ICSharpCode.SharpZipLib.dll .
 	rm -rf SharpZipLib
 fi
 
 if [ ! -f MaxMind.GeoIP2.dll ]; then
-	echo "Fetching MaxMind.GeoIP2 from nuget"
+	echo "Fetching MaxMind.GeoIP2 from NuGet"
 	get MaxMind.Db 1.0.0.0
 	get Newtonsoft.Json 6.0.5
 	get RestSharp 105.0.1
@@ -55,7 +55,7 @@ if [ ! -f MaxMind.GeoIP2.dll ]; then
 fi
 
 if [ ! -f SharpFont.dll ]; then
-	echo "Fetching SharpFont from nuget"
+	echo "Fetching SharpFont from NuGet"
 	get SharpFont 3.0.1
 	cp ./SharpFont/lib/net20/SharpFont* .
 	cp ./SharpFont/config/SharpFont.dll.config .
@@ -63,14 +63,14 @@ if [ ! -f SharpFont.dll ]; then
 fi
 
 if [ ! -f nunit.framework.dll ]; then
-	echo "Fetching NUnit from nuget"
+	echo "Fetching NUnit from NuGet"
 	get NUnit 2.6.4
 	cp ./NUnit/lib/nunit.framework* .
 	rm -rf NUnit
 fi
 
 if [ ! -f Mono.Nat.dll ]; then
-	echo "Fetching Mono.Nat from nuget"
+	echo "Fetching Mono.Nat from NuGet"
 	get Mono.Nat 1.2.21
 	cp ./Mono.Nat/lib/net40/Mono.Nat.dll .
 	rm -rf Mono.Nat

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -8,30 +8,42 @@ download_dir="${0%/*}/download"
 mkdir -p "${download_dir}"
 cd "${download_dir}"
 
+function get()
+{
+	if which nuget >/dev/null; then
+		nuget install $1 -Version $2 -ExcludeVersion
+	else
+		../noget.sh $1 $2
+	fi
+}
+
 if [ ! -f StyleCopPlus.dll ]; then
 	echo "Fetching StyleCopPlus from nuget"
-	nuget install StyleCopPlus.MSBuild -Version 4.7.49.5 -ExcludeVersion
+	get StyleCopPlus.MSBuild 4.7.49.5
 	cp ./StyleCopPlus.MSBuild/tools/StyleCopPlus.dll .
 	rm -rf StyleCopPlus.MSBuild
 fi
 
 if [ ! -f StyleCop.dll ]; then
 	echo "Fetching StyleCop files from nuget"
-	nuget install StyleCop.MSBuild -Version 4.7.49.0 -ExcludeVersion
+	get StyleCop.MSBuild 4.7.49.0
 	cp ./StyleCop.MSBuild/tools/StyleCop*.dll .
 	rm -rf StyleCop.MSBuild
 fi
 
 if [ ! -f ICSharpCode.SharpZipLib.dll ]; then
 	echo "Fetching ICSharpCode.SharpZipLib from nuget"
-	nuget install SharpZipLib -Version 0.86.0 -ExcludeVersion
+	get SharpZipLib 0.86.0
 	cp ./SharpZipLib/lib/20/ICSharpCode.SharpZipLib.dll .
 	rm -rf SharpZipLib
 fi
 
 if [ ! -f MaxMind.GeoIP2.dll ]; then
 	echo "Fetching MaxMind.GeoIP2 from nuget"
-	nuget install MaxMind.GeoIP2 -Version 2.1.0 -ExcludeVersion
+	get MaxMind.Db 1.0.0.0
+	get Newtonsoft.Json 6.0.5
+	get RestSharp 105.0.1
+	get MaxMind.GeoIP2 2.1.0
 	cp ./MaxMind.Db/lib/net40/MaxMind.Db.* .
 	rm -rf MaxMind.Db
 	cp ./MaxMind.GeoIP2/lib/net40/MaxMind.GeoIP2* .
@@ -44,7 +56,7 @@ fi
 
 if [ ! -f SharpFont.dll ]; then
 	echo "Fetching SharpFont from nuget"
-	nuget install SharpFont -Version 3.0.1 -ExcludeVersion
+	get SharpFont 3.0.1
 	cp ./SharpFont/lib/net20/SharpFont* .
 	cp ./SharpFont/config/SharpFont.dll.config .
 	rm -rf SharpFont SharpFont.Dependencies
@@ -52,21 +64,21 @@ fi
 
 if [ ! -f nunit.framework.dll ]; then
 	echo "Fetching NUnit from nuget"
-	nuget install NUnit -Version 2.6.4 -ExcludeVersion
+	get NUnit 2.6.4
 	cp ./NUnit/lib/nunit.framework* .
 	rm -rf NUnit
 fi
 
 if [ ! -f Mono.Nat.dll ]; then
 	echo "Fetching Mono.Nat from nuget"
-	nuget install Mono.Nat -Version 1.2.21 -ExcludeVersion
+	get Mono.Nat 1.2.21
 	cp ./Mono.Nat/lib/net40/Mono.Nat.dll .
 	rm -rf Mono.Nat
 fi
 
 if [ ! -f FuzzyLogicLibrary.dll ]; then
 	echo "Fetching FuzzyLogicLibrary from NuGet."
-	nuget install FuzzyLogicLibrary -Version 1.2.0 -ExcludeVersion
+	get FuzzyLogicLibrary 1.2.0
 	cp ./FuzzyLogicLibrary/bin/Release/FuzzyLogicLibrary.dll .
 	rm -rf FuzzyLogicLibrary
 fi

--- a/thirdparty/noget.sh
+++ b/thirdparty/noget.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# fallback without dependency resolution if nuget is not present on the system
+
+archive="$1"
+version="$2"
+curl -o "$archive.zip" -Ls https://nuget.org/api/v2/package/"$archive"/"$version"
+mkdir -p "$archive"
+unzip -o -qq "$archive.zip" -d "$archive" && rm "$archive.zip"


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/7386.

Added a simple (no dependency resolution) `noget.sh` based upon https://gist.github.com/Phrohdoh/a4aae3982824e87fefb6.

NuGet on Unix is still a problem. It is either not packaged or broken: the certificate storage is fiddly to get right and the error messages that produces are confusing. Also somehow it is not behaving properly. For unexplained reasons the cloud servers often run into trouble breaking the builds so I enforce the replacement now until https://github.com/travis-ci/travis-ci/issues/3940 is resolved.
