### PR TITLE
Made projectiles accept empty to disable image or sequence

### DIFF
--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Effects
 			facing = OpenRA.Traits.Util.GetFacing(target - pos, 0);
 			length = Math.Max((target - pos).Length / speed.Range, 1);
 
-			if (info.Image != null)
+			if (!string.IsNullOrEmpty(info.Image))
 			{
 				anim = new Animation(world, info.Image, GetEffectiveFacing);
 				anim.PlayRepeating("idle");
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Effects
 
 			pos = WPos.LerpQuadratic(args.Source, target, angle, ticks, length);
 
-			if (info.Trail != null && --smokeTicks < 0)
+			if (!string.IsNullOrEmpty(info.Trail) && --smokeTicks < 0)
 			{
 				var delayedPos = WPos.LerpQuadratic(args.Source, target, angle, ticks - info.TrailDelay, length);
 				world.AddFrameEndTask(w => w.Add(new Smoke(w, delayedPos, info.Trail, trailPalette)));

--- a/OpenRA.Mods.Common/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Effects/GravityBomb.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly string Image = null;
 		[Desc("Sequence to loop while falling.")]
 		public readonly string Sequence = "idle";
-		[Desc("Sequence to play when launched. Skipped if null.")]
+		[Desc("Sequence to play when launched. Skipped if null or empty.")]
 		public readonly string OpenSequence = null;
 		public readonly string Palette = "effect";
 		public readonly bool Shadow = false;
@@ -51,9 +51,9 @@ namespace OpenRA.Mods.Common.Effects
 
 			anim = new Animation(args.SourceActor.World, info.Image);
 
-			if (info.Image != null)
+			if (!string.IsNullOrEmpty(info.Image))
 			{
-				if (info.OpenSequence != null)
+				if (!string.IsNullOrEmpty(info.OpenSequence))
 					anim.PlayThen(info.OpenSequence, () => anim.PlayRepeating(info.Sequence));
 				else
 					anim.PlayRepeating(info.Sequence);

--- a/OpenRA.Mods.Common/Effects/LaserZap.cs
+++ b/OpenRA.Mods.Common/Effects/LaserZap.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.color = color;
 			this.target = args.PassiveTarget;
 
-			if (info.HitAnim != null)
+			if (!string.IsNullOrEmpty(info.HitAnim))
 				this.hitanim = new Animation(args.SourceActor.World, info.HitAnim);
 		}
 

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Effects
 				offset = WVec.FromPDF(world.SharedRandom, 2) * inaccuracy / 1024;
 			}
 
-			if (info.Image != null)
+			if (!string.IsNullOrEmpty(info.Image))
 			{
 				anim = new Animation(world, info.Image, () => facing);
 				anim.PlayRepeating("idle");
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.Common.Effects
 
 			pos += move;
 
-			if (info.Trail != null && --ticksToNextSmoke < 0)
+			if (!string.IsNullOrEmpty(info.Trail) && --ticksToNextSmoke < 0)
 			{
 				world.AddFrameEndTask(w => w.Add(new Smoke(w, pos - 3 * move / 2, info.Trail, trailPalette)));
 				ticksToNextSmoke = info.TrailInterval;


### PR DESCRIPTION
In addition to accepting null.

I agree that syntax-wise negating a value with `-` looks cleaner, but considering even some developers (including myself) were not aware that this is even possible, I think it would be better if both work, since quite a few parts of the engine (and official mod yaml code) allow empty strings to disable inherited properties.

Follow-up on #8220.
