### PR TITLE
Fix OpenRA.Game.exe.config issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ mods: mod_common mod_ra mod_cnc mod_d2k mod_ts
 all: dependencies core tools
 
 clean:
-	@-$(RM_F) *.exe *.dll *.dylib *.config ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
+	@-$(RM_F) *.exe *.dll *.dylib *.dll.config ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
 	@-$(RM_RF) ./*/bin ./*/obj
 	@-$(RM_RF) ./thirdparty/download
 

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -31,7 +31,7 @@ markdown DOCUMENTATION.md > DOCUMENTATION.html
 markdown Lua-API.md > Lua-API.html
 
 # List of files that are packaged on all platforms
-FILES=('OpenRA.Game.exe' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' \
+FILES=('OpenRA.Game.exe' 'OpenRA.Game.exe.config' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' \
 'OpenRA.Renderer.Sdl2.dll' 'OpenRA.Renderer.Null.dll' \
  'lua' 'glsl' 'mods/common' 'mods/ra' 'mods/cnc' 'mods/d2k' 'mods/modchooser' \
 'AUTHORS' 'COPYING' 'README.html' 'CONTRIBUTING.html' 'DOCUMENTATION.html' 'CHANGELOG.html' \


### PR DESCRIPTION
1. it got removed during `make clean`
2. it didn't get copied to `packaging/built`, so nsis couldn't find it and failed to produce a package.
