### PR TITLE
Fixed make dependencies not copying the cached GeoLite2-Country.mmdb.gz into the root.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ osx-dependencies: cli-dependencies
 
 dependencies: $(os-dependencies)
 	@./thirdparty/fetch-geoip-db.sh
+	@ $(CP) thirdparty/download/GeoLite2-Country.mmdb.gz .
 
 all-dependencies: cli-dependencies windows-dependencies osx-dependencies
 

--- a/make.ps1
+++ b/make.ps1
@@ -116,6 +116,7 @@ elseif ($command -eq "dependencies")
 	cd thirdparty
 	./fetch-thirdparty-deps.ps1
 	cp download/*.dll ..
+	cp download/GeoLite2-Country.mmdb.gz ..
 	cp download/windows/*.dll ..
 	cd ..
 	echo "Dependencies copied."

--- a/thirdparty/fetch-geoip-db.sh
+++ b/thirdparty/fetch-geoip-db.sh
@@ -14,6 +14,5 @@ if [[ ! -e $filename ]] || [[ -n $(find . -name $filename -mtime +30 -print) ]];
 	rm -f $filename
 	echo "Updating GeoIP country database from MaxMind."
 	curl -s -L -O http://geolite.maxmind.com/download/geoip/database/$filename
-	cp $filename ../..
 fi
 

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -135,7 +135,6 @@ if (!(Test-Path "GeoLite2-Country.mmdb.gz") -Or (((get-date) - (get-item "GeoLit
 	echo "Updating GeoIP country database from MaxMind."
 	$target = Join-Path $pwd.ToString() "GeoLite2-Country.mmdb.gz"
 	(New-Object System.Net.WebClient).DownloadFile("http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz", $target)
-	cp GeoLite2-Country.mmdb.gz ..\..
 }
 
 cd ..


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/8236.
