### PR TITLE
Fix nuke flashes

### DIFF
--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -118,6 +118,18 @@ namespace OpenRA.Graphics
 			return Color.FromArgb(c.A, (byte)(c.R * a + 0.5f), (byte)(c.G * a + 0.5f), (byte)(c.B * a + 0.5f));
 		}
 
+		public static Color PremultipliedColorLerp(float t, Color c1, Color c2)
+		{
+			// Colors must be lerped in a non-multiplied color space
+			var a1 = 255f / c1.A;
+			var a2 = 255f / c2.A;
+			return PremultiplyAlpha(Color.FromArgb(
+				(int)(t * c2.A + (1 - t) * c1.A),
+				(int)((byte)(t * a2 * c2.R + 0.5f) + (1 - t) * (byte)(a1 * c1.R + 0.5f)),
+				(int)((byte)(t * a2 * c2.G + 0.5f) + (1 - t) * (byte)(a1 * c1.G + 0.5f)),
+				(int)((byte)(t * a2 * c2.B + 0.5f) + (1 - t) * (byte)(a1 * c1.B + 0.5f))));
+		}
+
 		public static float[] IdentityMatrix()
 		{
 			return Exts.MakeArray(16, j => (j % 5 == 0) ? 1.0f : 0);

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/NukePaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/NukePaletteEffect.cs
@@ -15,6 +15,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	using GUtil = OpenRA.Graphics.Util;
+
 	[Desc("Apply palette full screen rotations during atom bomb explosions. Add this to the world actor.")]
 	class NukePaletteEffectInfo : TraitInfo<NukePaletteEffect> { }
 
@@ -46,8 +48,8 @@ namespace OpenRA.Mods.Common.Traits
 				for (var x = 0; x < Palette.Size; x++)
 				{
 					var orig = pal.Value.GetColor(x);
-					var white = Color.FromArgb(orig.A, 255, 255, 255);
-					pal.Value.SetColor(x, Exts.ColorLerp(frac, orig, white));
+					var final = GUtil.PremultipliedColorLerp(frac, orig, GUtil.PremultiplyAlpha(Color.FromArgb(orig.A, Color.White)));
+					pal.Value.SetColor(x, final);
 				}
 			}
 		}

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -57,6 +57,11 @@
 		Name: effect50alpha
 		BasePalette: effect
 		Alpha: 0.5
+	PaletteFromPaletteWithAlpha@effectAdditive:
+		Name: effectAdditive
+		BasePalette: effect
+		Alpha: 0
+		Premultiply: false
 	PaletteFromScaledPalette@starportlights:
 		Name: starportlights
 		BasePalette: d2k
@@ -81,4 +86,5 @@
 		Alpha: 0.68
 		Premultiply: false
 	PlayerHighlightPalette:
+	NukePaletteEffect:
 

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -213,6 +213,7 @@ refinery:
 			ordos: refinery.ordos
 	WithDockingOverlay@SMOKE:
 		Sequence: smoke
+		Palette: effectAdditive
 	Power:
 		Amount: -30
 	WithIdleOverlay@TOP:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -378,7 +378,6 @@ refinery.atreides:
 		Length: 14
 		Offset: 10,-16
 		Tick: 200
-		BlendMode: Additive
 
 silo.atreides:
 	idle: DATA.R8
@@ -863,7 +862,6 @@ refinery.harkonnen:
 		Length: 14
 		Offset: 10,-16
 		Tick: 200
-		BlendMode: Additive
 
 silo.harkonnen:
 	idle: DATA.R8
@@ -1257,7 +1255,6 @@ refinery.ordos:
 		Length: 14
 		Offset: 10,-16
 		Tick: 200
-		BlendMode: Additive
 
 silo.ordos:
 	idle: DATA.R8


### PR DESCRIPTION
Fixes #8238 and adds nuke flashes to d2k (which is finally possible now that we use premultiplied alpha).
