### PR TITLE
TD Balances

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -151,7 +151,7 @@ ARTY:
 	Explodes:
 		Weapon: UnitExplode
 		EmptyWeapon: UnitExplode
-		Chance: 75
+		Chance: 0
 	AutoTarget:
 		InitialStance: Defend
 	LeavesHusk:
@@ -315,7 +315,7 @@ LTNK:
 		ROT: 7
 		Speed: 113
 	Health:
-		HP: 360
+		HP: 350
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -151,7 +151,7 @@ ARTY:
 	Explodes:
 		Weapon: UnitExplode
 		EmptyWeapon: UnitExplode
-		Chance: 0
+		Chance: 75
 	AutoTarget:
 		InitialStance: Defend
 	LeavesHusk:
@@ -315,7 +315,7 @@ LTNK:
 		ROT: 7
 		Speed: 113
 	Health:
-		HP: 350
+		HP: 360
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -462,7 +462,7 @@ BigFlamer:
 		ImpactSound: flamer2.aud
 
 Chemspray:
-	ReloadDelay: 70
+	ReloadDelay: 65
 	Range: 3c0
 	Report: FLAMER2.AUD
 	Projectile: Bullet
@@ -487,7 +487,7 @@ Grenade:
 	Range: 4c0
 	Report: toss1.aud
 	Projectile: Bullet
-		Speed: 119
+		Speed: 140
 		High: yes
 		Angle: 62
 		Inaccuracy: 213
@@ -522,7 +522,7 @@ Grenade:
 			None: 25
 			Wood: 75
 			Light: 100
-			Heavy: 100
+			Heavy: 90
 			Concrete: 50
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -772,7 +772,7 @@ MachineGun:
 			None: 100
 			Wood: 20
 			Light: 50
-			Heavy: 20
+			Heavy: 15
 			Concrete: 10
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -462,7 +462,7 @@ BigFlamer:
 		ImpactSound: flamer2.aud
 
 Chemspray:
-	ReloadDelay: 65
+	ReloadDelay: 70
 	Range: 3c0
 	Report: FLAMER2.AUD
 	Projectile: Bullet
@@ -487,7 +487,7 @@ Grenade:
 	Range: 4c0
 	Report: toss1.aud
 	Projectile: Bullet
-		Speed: 140
+		Speed: 119
 		High: yes
 		Angle: 62
 		Inaccuracy: 213
@@ -522,7 +522,7 @@ Grenade:
 			None: 25
 			Wood: 75
 			Light: 100
-			Heavy: 90
+			Heavy: 100
 			Concrete: 50
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -772,7 +772,7 @@ MachineGun:
 			None: 100
 			Wood: 20
 			Light: 50
-			Heavy: 15
+			Heavy: 20
 			Concrete: 10
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs


### PR DESCRIPTION
Changes:

Light tanks were changed as followed to prevent them from being en massed and overpowering medium tanks.

Artillery changed due to frustration of explosions. Chance to explode also counted towards chance to chain explode. Resulting in 75% chance to lose 3-5 artilleries at once. Explosion also killed infantry.

Chemspray fire rate changed to help defend vs fast moving vehicles that crush. This includes stealth tanks and APCs.

Hummers/buggies damage vs heavy reduced to prevent them from countering light tanks and APCs when they shouldn't. They still make great harvester herassments.

Grenadier projectile speed increase to help vs en mass flame infantry and chem troopers. Making them a useful counter once more.
