### PR TITLE
Fixed a potential null reference exception during in-game editor resource placement

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -87,6 +87,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var tile = world.Map.MapTiles.Value[cell];
 			var tileInfo = world.TileSet.GetTileInfo(tile);
+			if (tileInfo == null)
+				return false;
+
 			var terrainType = world.TileSet.TerrainInfo[tileInfo.TerrainType];
 
 			if (world.Map.MapResources.Value[cell].Type == ResourceType.ResourceType)


### PR DESCRIPTION
Discovered by Coverity. I assume wrongly set up tileset definitions could lead to a crash here, if it wouldn't blow before so probably not too severe.
