### PR TITLE
Fixed a NullReferenceException when not using the optional MAP LabelWidget

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 
 					var maptitle = item.GetOrNull<LabelWidget>("MAP");
-					if (title != null)
+					if (maptitle != null)
 					{
 						maptitle.GetText = () => map.Title;
 						maptitle.GetColor = () => !compatible ? Color.DarkGray : !canJoin ? Color.LightGray : maptitle.TextColor;


### PR DESCRIPTION
Obviously a copy & paste error. Only a problem if you use a custom chrome though.
