### PR TITLE
Fixed a dereference of an explicit null value in VoxelRenderer

### DIFF
--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -315,7 +315,8 @@ namespace OpenRA.Graphics
 				v.Second();
 			}
 
-			DisableFrameBuffer(fbo);
+			if (fbo != null)
+				DisableFrameBuffer(fbo);
 		}
 
 		public Sheet AllocateSheet()


### PR DESCRIPTION
Coverity detected that code paths can lead there where this is explicitly set to null. Not sure how likely it is. The code a few lines above already has this null check.
