### PR TITLE
Removed an unnecessary (too late) null check at EditorResourceBrush.AllowResourceAt

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!ResourceType.AllowedTerrainTypes.Contains(terrainType.Type))
 				return false;
 
-			return ResourceType.AllowOnRamps || tileInfo == null || tileInfo.RampType == 0;
+			return ResourceType.AllowOnRamps || tileInfo.RampType == 0;
 		}
 
 		public void Tick()


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/8253. Note: this was bogus before. Another Coverity rule catched it.
