### PR TITLE
Don't skip the heal animation

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void TickIdle(Actor self)
 		{
-			if (state != AnimationState.Idle && state != AnimationState.IdleAnimating)
+			if (state != AnimationState.Idle && state != AnimationState.IdleAnimating && state != AnimationState.Attacking)
 			{
 				DefaultAnimation.PlayFetchIndex(NormalizeInfantrySequence(self, info.StandSequences.Random(Game.CosmeticRandom)), () => 0);
 				state = AnimationState.Idle;


### PR DESCRIPTION
On bleed the medic heal animation is skipped/aborted:
![medi1](https://cloud.githubusercontent.com/assets/7704140/7810147/e2bf5fce-039f-11e5-9a04-f44694235c01.gif)
On this PR:
![medi2](https://cloud.githubusercontent.com/assets/7704140/7810150/e68aece0-039f-11e5-997c-b6103234208f.gif)
