### PR TITLE
Add a missing DamageType to missions which re-define weapons

### DIFF
--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -554,7 +554,7 @@ Weapons:
 			Versus:
 				Heavy: 50
 			Damage: 50
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 
 Voices:
 

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -392,7 +392,7 @@ NerveGasMissile:
 			None: 0
 			Wood: 0
 			Concrete: 0
-		DamageTypes: Prone50Percent, TriggerProne
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect

--- a/mods/ra/maps/allies-01/map.yaml
+++ b/mods/ra/maps/allies-01/map.yaml
@@ -562,7 +562,7 @@ Weapons:
 		Burst: 1
 		Warhead: SpreadDamage
 			Damage: 20
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
 Voices:
 

--- a/mods/ra/maps/allies-02/map.yaml
+++ b/mods/ra/maps/allies-02/map.yaml
@@ -840,7 +840,7 @@ Weapons:
 		Burst: 1
 		Warhead: SpreadDamage
 			Damage: 20
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
 Voices:
 

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -323,7 +323,7 @@ Weapons:
 				Light: 30
 				Heavy: 30
 			Damage: 400
-			DamageTypes: Prone50Percent, TriggerProne, Explosion
+			DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 		Warhead@1Eff: CreateEffect
 			Explosion: large_explosion
 			WaterExplosion: large_splash

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2403,7 +2403,7 @@ Weapons:
 	Maverick:
 		Warhead@1Dam: SpreadDamage
 			Damage: 175
-			DamageTypes: Prone50Percent, TriggerProne
+			DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 
 Voices:
 


### PR DESCRIPTION
The rest seems to be fine:

```
$ rgrep DamageTypes mods/*/maps/*/map.yaml 
mods/cnc/maps/gdi01/map.yaml:           DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
mods/ra/maps/allies-01/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, BulletDeath
mods/ra/maps/allies-02/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, BulletDeath
mods/ra/maps/allies-05a/map.yaml:           DamageTypes: Prone50Percent, TriggerProne, BulletDeath
mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml:          DamageTypes: Prone50Percent, TriggerProne, FireDeath
mods/ra/maps/drop-zone-w/map.yaml:          DamageTypes: Prone50Percent, TriggerProne, BulletDeath
mods/ra/maps/drop-zone-w/map.yaml:          DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
mods/ra/maps/drop-zone/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, FireDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, FireDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, FireDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
mods/ra/maps/fort-lonestar/map.yaml:            DamageTypes: Prone50Percent, TriggerProne, BulletDeath
mods/ra/maps/intervention/map.yaml:         DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
mods/ra/maps/monster-tank-madness/map.yaml:         DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
mods/ra/maps/survival02/map.yaml:           DamageTypes: Prone50Percent, TriggerProne, FireDeath

```

Fixes #8266 
