### PR TITLE
Speed up PremultiplyAlpha

### DIFF
--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -114,6 +114,8 @@ namespace OpenRA.Graphics
 
 		public static Color PremultiplyAlpha(Color c)
 		{
+			if (c.A == byte.MaxValue)
+				return c;
 			var a = c.A / 255f;
 			return Color.FromArgb(c.A, (byte)(c.R * a + 0.5f), (byte)(c.G * a + 0.5f), (byte)(c.B * a + 0.5f));
 		}


### PR DESCRIPTION
The bugfix in #8248 means all line rendering requires pre-multiplying the line colours. This mitigates the perf impact for rendering solid colours.
