### PR TITLE
Moved the sequence image check to RenderSprites level

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -20,8 +20,6 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Renders crates with both water and land variants.")]
 	class WithCrateBodyInfo : ITraitInfo, Requires<RenderSpritesInfo>, IQuantizeBodyOrientationInfo, IRenderActorPreviewSpritesInfo
 	{
-		public readonly string[] Images = { "crate" };
-
 		[Desc("Easteregg sequences to use in december.")]
 		public readonly string[] XmasImages = { };
 
@@ -29,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			var anim = new Animation(init.World, Images.First(), () => 0);
+			var anim = new Animation(init.World, rs.Image, () => 0);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), "idle"));
 			yield return new SpriteActorPreview(anim, WVec.Zero, 0, p, rs.Scale);
 		}
@@ -46,7 +44,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.self = self;
 			var rs = self.Trait<RenderSprites>();
-			var images = info.XmasImages.Any() && DateTime.Today.Month == 12 ? info.XmasImages : info.Images;
+			var image = rs.GetImage(self);
+			var images = info.XmasImages.Any() && DateTime.Today.Month == 12 ? info.XmasImages : new[] { image };
 			anim = new Animation(self.World, images.Random(Game.CosmeticRandom));
 			anim.Play("idle");
 			rs.Add(anim);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1119,6 +1119,36 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Images from WithCrateBody was moved into RenderSprites
+				if (engineVersion < 20150530)
+				{
+					if (depth == 0)
+					{
+						var actorTraits = node.Value.Nodes;
+						var withCrateBody = actorTraits.FirstOrDefault(t => t.Key == "WithCrateBody");
+						if (withCrateBody != null)
+						{
+							var withCrateBodyFields = withCrateBody.Value.Nodes;
+							var images = withCrateBodyFields.FirstOrDefault(n => n.Key == "Images");
+							if (images == null)
+								images = new MiniYamlNode("Images", "crate");
+							else
+								withCrateBodyFields.Remove(images);
+
+							images.Key = "Image";
+
+							var renderSprites = actorTraits.FirstOrDefault(t => t.Key == "RenderSprites");
+							if (renderSprites != null)
+								renderSprites.Value.Nodes.Add(images);
+							else
+							{
+								Console.WriteLine("Warning: Adding RenderSprites trait to {0} in {1}".F(node.Key, node.Location.Filename));
+								actorTraits.Add(new MiniYamlNode("RenderSprites", new MiniYaml("", new List<MiniYamlNode> { images })));
+							}
+						}
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -62,8 +62,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				layerPreview.GetPalette = () => resource.Palette;
 
 				var variant = resource.Variants.FirstOrDefault();
-				var sequenceProvier = modRules.Sequences[world.TileSet.Id];
-				var sequence = sequenceProvier.GetSequence("resources", variant);
+				var sequenceProvider = modRules.Sequences[world.TileSet.Id];
+				var sequence = sequenceProvider.GetSequence("resources", variant);
 				var frame = sequence.Frames != null ? sequence.Frames.Last() : resource.MaxDensity - 1;
 				layerPreview.GetSprite = () => sequence.GetSprite(frame);
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -658,6 +658,7 @@
 		TerrainTypes: Clear, Rough, Road, Tiberium, BlueTiberium, Beach
 	RenderSprites:
 		Palette: effect
+		Image: crate
 	WithCrateBody:
 		XmasImages: xcratea, xcrateb, xcratec, xcrated
 	Selectable:

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -67,7 +67,7 @@ CAMERA.small:
 	RevealsShroud:
 		Range: 6c0
 	BodyOrientation:
-	
+
 FLARE:
 	Immobile:
 		OccupiesSpace: false
@@ -81,3 +81,4 @@ FLARE:
 	Tooltip:
 		Name: Flare
 	BodyOrientation:
+

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -151,3 +151,4 @@ EditorWorld:
 	Inherits: ^BaseWorld
 	EditorActorLayer:
 	EditorResourceLayer:
+

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1422,7 +1422,8 @@ Rules:
 		Tooltip:
 			Name: Crate
 		WithCrateBody:
-			Images: scrate
+		RenderSprites:
+			Image: scrate
 	E1.Autotarget:
 		Inherits: E1
 		Buildable:

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -1331,7 +1331,8 @@ Rules:
 		Tooltip:
 			Name: Crate
 		WithCrateBody:
-			Images: scrate
+		RenderSprites:
+			Image: scrate
 	E1.Autotarget:
 		Inherits: E1
 		Buildable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -655,8 +655,8 @@
 		TerrainTypes: Clear, Rough, Road, Ore, Beach
 	RenderSprites:
 		Palette: effect
+		Image: scrate
 	WithCrateBody:
-		Images: scrate
 		XmasImages: xcratea, xcrateb, xcratec, xcrated
 	Selectable:
 		Selectable: false

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -195,3 +195,4 @@ MSLF:
 		Cost: 250
 	RequiresPower:
 	DisabledOverlay:
+

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -152,7 +152,8 @@ MONEYCRATE:
 		SelectionShares: 1
 		UseCashTick: true
 	WithCrateBody:
-		Images: wcrate
+	RenderSprites:
+		Image: wcrate
 
 HEALCRATE:
 	Inherits: ^Crate

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -71,3 +71,4 @@
 		ExcludePalettes: terrain, effect
 	ChronoshiftPaletteEffect:
 	NukePaletteEffect:
+

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -169,3 +169,4 @@ EditorWorld:
 	Inherits: ^BaseWorld
 	EditorActorLayer:
 	EditorResourceLayer:
+

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -29,7 +29,6 @@ DPOD:
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 
@@ -55,7 +54,6 @@ DSHP:
 		Types: Infantry
 		MaxWeight: 5
 		PipCount: 5
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 	Hovers:
@@ -161,7 +159,6 @@ ORCATRAN:
 		Types: Infantry
 		MaxWeight: 5
 		PipCount: 5
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 	Hovers:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -50,7 +50,6 @@ TRUCKB:
 		Speed: 56
 	RevealsShroud:
 		Range: 5c0
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 
@@ -69,7 +68,6 @@ ICBM:
 		ROT: 5
 	RevealsShroud:
 		Range: 7c0
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 	Transforms:
@@ -98,7 +96,6 @@ BUS:
 		Types: Infantry
 		MaxWeight: 20
 		PipCount: 5
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 
@@ -121,7 +118,6 @@ PICK:
 		Types: Infantry
 		MaxWeight: 2
 		PipCount: 5
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 
@@ -144,7 +140,6 @@ CAR:
 		Types: Infantry
 		MaxWeight: 4
 		PipCount: 5
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:
 
@@ -167,6 +162,5 @@ WINI:
 		Types: Infantry
 		MaxWeight: 5
 		PipCount: 5
-	RenderSprites:
 	RenderVoxels:
 	WithVoxelBody:


### PR DESCRIPTION
This detected several unnecessary RenderSprites traits in the Tiberian Sun mods. Split from https://github.com/OpenRA/OpenRA/pull/7709.
