### PR TITLE
Distinguish between all map cells and cells inside map bounds.

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -180,9 +180,9 @@ namespace OpenRA.Graphics
 			{
 				var colors = (int*)bitmapData.Scan0;
 				var stride = bitmapData.Stride / 4;
-				var shroudObscured = world.ShroudObscuresTest(map.Cells);
-				var fogObscured = world.FogObscuresTest(map.Cells);
-				foreach (var uv in map.Cells.MapCoords)
+				var shroudObscured = world.ShroudObscuresTest(map.CellsInsideBounds);
+				var fogObscured = world.FogObscuresTest(map.CellsInsideBounds);
+				foreach (var uv in map.CellsInsideBounds.MapCoords)
 				{
 					var bitmapXy = new int2(uv.U - b.Left, uv.V - b.Top);
 					if (shroudObscured(uv))

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Graphics
 			mapTiles = world.Map.MapTiles.Value;
 
 			terrain = new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette("terrain"));
-			foreach (var cell in world.Map.Cells)
+			foreach (var cell in world.Map.AllCells)
 				UpdateCell(cell);
 
 			world.Map.MapTiles.Value.CellEntryChanged += UpdateCell;

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -249,7 +249,7 @@ namespace OpenRA.Traits
 				throw new ArgumentException("The map bounds of these shrouds do not match.", "s");
 
 			var changed = new List<CPos>();
-			foreach (var uv in map.Cells.MapCoords)
+			foreach (var uv in map.CellsInsideBounds.MapCoords)
 			{
 				if (!explored[uv] && s.explored[uv])
 				{
@@ -264,7 +264,7 @@ namespace OpenRA.Traits
 		public void ExploreAll(World world)
 		{
 			var changed = new List<CPos>();
-			foreach (var uv in map.Cells.MapCoords)
+			foreach (var uv in map.CellsInsideBounds.MapCoords)
 			{
 				if (!explored[uv])
 				{
@@ -279,7 +279,7 @@ namespace OpenRA.Traits
 		public void ResetExploration()
 		{
 			var changed = new List<CPos>();
-			foreach (var uv in map.Cells.MapCoords)
+			foreach (var uv in map.CellsInsideBounds.MapCoords)
 			{
 				var visible = visibleCount[uv] > 0;
 				if (explored[uv] != visible)
@@ -318,7 +318,7 @@ namespace OpenRA.Traits
 		public Func<MPos, bool> IsExploredTest(CellRegion region)
 		{
 			// If the region to test extends outside the map we must use the slow test that checks the map boundary every time.
-			if (!map.Cells.Contains(region))
+			if (!map.CellsInsideBounds.Contains(region))
 				return slowExploredTest;
 
 			// If shroud isn't enabled, then we can see everything inside the map.
@@ -361,7 +361,7 @@ namespace OpenRA.Traits
 		public Func<MPos, bool> IsVisibleTest(CellRegion region)
 		{
 			// If the region to test extends outside the map we must use the slow test that checks the map boundary every time.
-			if (!map.Cells.Contains(region))
+			if (!map.CellsInsideBounds.Contains(region))
 				return slowVisibleTest;
 
 			// If fog isn't enabled, then we can see everything.

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (w.Type != WorldType.Editor)
 				return;
 
-			foreach (var cell in Map.Cells)
+			foreach (var cell in Map.AllCells)
 				UpdateCell(cell);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			var resources = w.WorldActor.TraitsImplementing<ResourceType>()
 				.ToDictionary(r => r.Info.ResourceType, r => r);
 
-			foreach (var cell in w.Map.Cells)
+			foreach (var cell in w.Map.AllCells)
 			{
 				ResourceType t;
 				if (!resources.TryGetValue(w.Map.MapResources.Value[cell].Type, out t))
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Set initial density based on the number of neighboring resources
-			foreach (var cell in w.Map.Cells)
+			foreach (var cell in w.Map.AllCells)
 			{
 				var type = content[cell].Type;
 				if (type != null)

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -162,8 +162,8 @@ namespace OpenRA.Mods.Common.Traits
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			// Initialize tile cache
-			// Adds a 1-cell border around the border to cover any sprites peeking outside the map
-			foreach (var uv in CellRegion.Expand(w.Map.Cells, 1).MapCoords)
+			// This includes the region outside the visible area to cover any sprites peeking outside the map
+			foreach (var uv in w.Map.AllCells.MapCoords)
 			{
 				var screen = wr.ScreenPosition(w.Map.CenterOfCell(uv.ToCPos(map)));
 				var variant = (byte)Game.CosmeticRandom.Next(info.ShroudVariants.Length);
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 			wr.PaletteInvalidated += () =>
 			{
 				mapBorderShroudIsCached = false;
-				MarkCellsDirty(CellRegion.Expand(map.Cells, 1));
+				MarkCellsDirty(map.AllCells);
 			};
 		}
 
@@ -278,7 +278,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Cache the whole of the map border shroud ahead of time, since it never changes.
 			Func<MPos, bool> mapContains = map.Contains;
-			foreach (var uv in CellRegion.Expand(map.Cells, 1).MapCoords)
+			foreach (var uv in map.AllCells.MapCoords)
 			{
 				var offset = VertexArrayOffset(uv);
 				var edges = GetEdges(uv, mapContains);
@@ -304,7 +304,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// The map border shroud only affects the map border. If none of the visible cells are on the border, then
 			// we don't need to render anything and can bail early for performance.
-			if (CellRegion.Expand(map.Cells, -1).Contains(visibleRegion))
+			if (CellRegion.Expand(map.CellsInsideBounds, -1).Contains(visibleRegion))
 				return;
 
 			// Render the shroud that just encroaches at the map border. This shroud is always fully cached, so we can

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Widgets
 			actorSprite = new Sprite(radarSheet, new Rectangle(0, height, width, height), TextureChannel.Alpha);
 
 			// Set initial terrain data
-			foreach (var cell in world.Map.Cells)
+			foreach (var cell in world.Map.CellsInsideBounds)
 				UpdateTerrainCell(cell);
 
 			world.Map.MapTiles.Value.CellEntryChanged += UpdateTerrainCell;
@@ -91,6 +91,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void UpdateTerrainCell(CPos cell)
 		{
+			if (!world.Map.Contains(cell))
+				return;
+
 			var stride = radarSheet.Size.Width;
 			var uv = cell.ToMPos(world.Map);
 


### PR DESCRIPTION
This is the next step towards scripted map bounds changes (for missions), and makes the next set of shroud changes a bit cleaner.

The original `Map.Cells` has been renamed to `Map.CellsInsideBounds`, and should be used for anything that cares about the _current_ map state.  `Map.AllCells` covers the entire map (including the cordon cells), and should be used when initializing map state.
