### PR TITLE
Fix an invalid owner init entry in nod05.

### DIFF
--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -229,7 +229,7 @@ Actors:
 		Owner: Neutral
 	Actor66: v32
 		Location: 19,41
-		Owner: Special
+		Owner: Neutral
 	Actor67: v30
 		Location: 15,40
 		Owner: Neutral


### PR DESCRIPTION
Interestingly, the game deals with it fine, but the in-game editor crashes when loading it.

@42foobar42 / @alexander-boll: was this just an oversight, or did you have something special in mind with that building?

I guess it's an oversight, since that Owner existed already in the original .ini, but wasn't wired to any trigger, so didn't do anything.
