### PR TITLE
reorder infantry build palette in TS mod

### DIFF
--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -2,7 +2,7 @@ E2:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 20
 		Prerequisites: ~gapile
 	Valued:
 		Cost: 200
@@ -40,7 +40,7 @@ MEDIC:
 		Description: Heals nearby infantry.\n  Unarmed
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 70
 		Prerequisites: ~gapile
 	Selectable:
 		Bounds: 12,17,0,-6
@@ -79,7 +79,7 @@ JUMPJET:
 		Description: Airborne soldier.\n  Strong vs Infantry, Aircraft\n  Weak vs Vehicles
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 40
 		Prerequisites: ~gapile, garadr
 	Selectable:
 		Bounds: 12,17,0,-6

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -43,7 +43,7 @@ CYBORG:
 		Description: Cybernetic infantry unit.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 40
 		Prerequisites: ~nahand
 	-Crushable:
 	Selectable:
@@ -120,7 +120,7 @@ MHIJACK:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 60
 		Prerequisites: ~nahand, natech # natech must be natmpl
 	Valued:
 		Cost: 100


### PR DESCRIPTION
The order is not the same as the original one (influenced by dependencies) but the main point is to have standard infantry (E1) first, E2 second, ENGINEER third, and the special units on last places. The biggest difference to the original is GDI MEDIC as last (which also applies when both GDI and NOD units are available).
