### PR TITLE
Fixed a possible NRE in WRange.TryParse

### DIFF
--- a/OpenRA.Game/WRange.cs
+++ b/OpenRA.Game/WRange.cs
@@ -55,11 +55,15 @@ namespace OpenRA
 
 		public static bool TryParse(string s, out WRange result)
 		{
+			result = WRange.Zero;
+
+			if (string.IsNullOrEmpty(s))
+				return false;
+
 			s = s.ToLowerInvariant();
 			var components = s.Split('c');
 			var cell = 0;
 			var subcell = 0;
-			result = WRange.Zero;
 
 			switch (components.Length)
 			{


### PR DESCRIPTION
Coverity detected that FieldLoader could forward a null value here. This adds extra safety.
