### PR TITLE
Fixed a cryptic error message when feeding non-paletted PNGs into the command line utility

### DIFF
--- a/OpenRA.Game/FileFormats/PngLoader.cs
+++ b/OpenRA.Game/FileFormats/PngLoader.cs
@@ -130,6 +130,9 @@ namespace OpenRA.FileFormats
 
 									bitmap.UnlockBits(bits);
 
+									if (palette == null)
+										throw new InvalidDataException("Non-Palette indexed PNG are not supported.");
+
 									using (var temp = new Bitmap(1, 1, PixelFormat.Format8bppIndexed))
 									{
 										var cp = temp.Palette;


### PR DESCRIPTION
This was detected by Coverity as accessing a null array which will throw. This throws before this can happen with an error message that is easier to understand.
