### PR TITLE
Fixed a possible NRE in Health.InflictDamage debug logging

### DIFF
--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -157,7 +157,10 @@ namespace OpenRA.Traits
 				if (RemoveOnDeath)
 					self.Destroy();
 
-				Log.Write("debug", "{0} #{1} killed by {2} #{3}", self.Info.Name, self.ActorID, attacker.Info.Name, attacker.ActorID);
+				if (attacker == null)
+					Log.Write("debug", "{0} #{1} was killed.", self.Info.Name, self.ActorID);
+				else
+					Log.Write("debug", "{0} #{1} killed by {2} #{3}", self.Info.Name, self.ActorID, attacker.Info.Name, attacker.ActorID);
 			}
 		}
 


### PR DESCRIPTION
This fixes a possible NRE or the null check in line 146 is superfluous. Discovered by Coverity.
