### PR TITLE
Added missing disposings of the *LoadScreen base class

### DIFF
--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -125,6 +125,8 @@ namespace OpenRA.Mods.Cnc
 		{
 			if (sheet != null)
 				sheet.Dispose();
+
+			base.Dispose();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
@@ -70,6 +70,8 @@ namespace OpenRA.Mods.Common.LoadScreens
 		{
 			if (sheet != null)
 				sheet.Dispose();
+
+			base.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
`BlankLoadScreen.Dispose` is empty at the moment, so nothing bad has happened yet. Still Coverity marks it as a class hierarchy inconsistency that will lead to errors when expanded.
