### PR TITLE
Add a lint check for actor upgrades

### DIFF
--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -40,4 +40,7 @@ namespace OpenRA.Traits
 
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class UpgradeGrantedReferenceAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class UpgradeUsedReferenceAttribute : Attribute { }
 }

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Traits
 	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class SequenceReferenceAttribute : Attribute
 	{
-		public readonly string ImageReference; // the field name in the same trait info that contains the image name
+		public readonly string ImageReference; // The field name in the same trait info that contains the image name.
 		public readonly bool Prefix;
 		public SequenceReferenceAttribute(string imageReference = null, bool prefix = false)
 		{
@@ -37,4 +37,7 @@ namespace OpenRA.Traits
 			Prefix = prefix;
 		}
 	}
+
+	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class UpgradeGrantedReferenceAttribute : Attribute { }
 }

--- a/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
@@ -1,0 +1,153 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	public class CheckUpgrades : ILintPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		{
+			CheckUpgradesValidity(emitError, map);
+			CheckUpgradesUsage(emitError, emitWarning, map);
+		}
+
+		private static void CheckUpgradesValidity(Action<string> emitError, Map map)
+		{
+			var upgradesGranted = GetAllGrantedUpgrades(emitError, map).ToHashSet();
+
+			foreach (var actorInfo in map.Rules.Actors)
+			{
+				foreach (var trait in actorInfo.Value.Traits)
+				{
+					var fields = trait.GetType().GetFields();
+					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeUsedReferenceAttribute>()))
+					{
+						var values = LintExts.GetFieldValues(trait, field, emitError);
+						foreach (var value in values.Where(x => !upgradesGranted.Contains(x)))
+							emitError("Actor type `{0}` uses upgrade `{1}` that is not granted by anything!".F(actorInfo.Key, value));
+					}
+				}
+			}
+		}
+
+		private static void CheckUpgradesUsage(Action<string> emitError, Action<string> emitWarning, Map map)
+		{
+			var upgradesUsed = GetAllUsedUpgrades(emitError, map).ToHashSet();
+
+			// Check all upgrades granted by traits.
+			foreach (var actorInfo in map.Rules.Actors)
+			{
+				foreach (var trait in actorInfo.Value.Traits)
+				{
+					var fields = trait.GetType().GetFields();
+					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeGrantedReferenceAttribute>()))
+					{
+						var values = LintExts.GetFieldValues(trait, field, emitError);
+						foreach (var value in values.Where(x => !upgradesUsed.Contains(x)))
+							emitWarning("Actor type `{0}` grants upgrade `{1}` that is not used by anything!".F(actorInfo.Key, value));
+					}
+				}
+			}
+
+			// Check all upgrades granted by warheads.
+			foreach (var weapon in map.Rules.Weapons)
+			{
+				foreach (var warhead in weapon.Value.Warheads)
+				{
+					var fields = warhead.GetType().GetFields();
+					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeGrantedReferenceAttribute>()))
+					{
+						var values = LintExts.GetFieldValues(warhead, field, emitError);
+						foreach (var value in values.Where(x => !upgradesUsed.Contains(x)))
+							emitWarning("Weapon type `{0}` grants upgrade `{1}` that is not used by anything!".F(weapon.Key, value));
+					}
+				}
+			}
+		}
+
+		static IEnumerable<string> GetAllGrantedUpgrades(Action<string> emitError, Map map)
+		{
+			// Get all upgrades granted by traits.
+			foreach (var actorInfo in map.Rules.Actors)
+			{
+				foreach (var trait in actorInfo.Value.Traits)
+				{
+					var fields = trait.GetType().GetFields();
+					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeGrantedReferenceAttribute>()))
+					{
+						var values = LintExts.GetFieldValues(trait, field, emitError);
+						foreach (var value in values)
+							yield return value;
+					}
+				}
+			}
+
+			// Get all upgrades granted by warheads.
+			foreach (var weapon in map.Rules.Weapons)
+			{
+				foreach (var warhead in weapon.Value.Warheads)
+				{
+					var fields = warhead.GetType().GetFields();
+					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeGrantedReferenceAttribute>()))
+					{
+						var values = LintExts.GetFieldValues(warhead, field, emitError);
+						foreach (var value in values)
+							yield return value;
+					}
+				}
+			}
+
+			// TODO: HACK because GainsExperience grants upgrades differently to most other sources.
+			var gainsExperience = map.Rules.Actors.SelectMany(x => x.Value.Traits.WithInterface<GainsExperienceInfo>()
+				.SelectMany(y => y.Upgrades.SelectMany(z => z.Value)));
+
+			foreach (var upgrade in gainsExperience)
+				yield return upgrade;
+
+			// TODO: HACK because Pluggable grants upgrades differently to most other sources.
+			var pluggable = map.Rules.Actors.SelectMany(x => x.Value.Traits.WithInterface<PluggableInfo>()
+				.SelectMany(y => y.Upgrades.SelectMany(z => z.Value)));
+
+			foreach (var upgrade in pluggable)
+				yield return upgrade;
+		}
+
+		static IEnumerable<string> GetAllUsedUpgrades(Action<string> emitError, Map map)
+		{
+			foreach (var actorInfo in map.Rules.Actors)
+			{
+				foreach (var trait in actorInfo.Value.Traits)
+				{
+					var fields = trait.GetType().GetFields();
+					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeUsedReferenceAttribute>()))
+					{
+						var values = LintExts.GetFieldValues(trait, field, emitError);
+						foreach (var value in values)
+							yield return value;
+					}
+				}
+			}
+
+			// TODO: HACK because GainsExperience and GainsStatUpgrades do not play by the rules...
+			// We assume everything GainsExperience grants is used by GainsStatUpgrade
+			var gainsExperience = map.Rules.Actors.SelectMany(x => x.Value.Traits.WithInterface<GainsExperienceInfo>()
+				.SelectMany(y => y.Upgrades.SelectMany(z => z.Value)));
+
+			foreach (var upgrade in gainsExperience)
+				yield return upgrade;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Lint/LintExts.cs
+++ b/OpenRA.Mods.Common/Lint/LintExts.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Reflection;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
@@ -20,7 +19,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			var type = fieldInfo.FieldType;
 			if (type == typeof(string))
-				return new string[] { (string)fieldInfo.GetValue(ruleInfo) };
+				return new[] { (string)fieldInfo.GetValue(ruleInfo) };
 			if (type == typeof(string[]))
 				return (string[])fieldInfo.GetValue(ruleInfo);
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Pathfinder\CellInfo.cs" />
     <Compile Include="PlayerExtensions.cs" />
     <Compile Include="Scripting\Global\FacingGlobal.cs" />
+    <Compile Include="Scripting\ScriptUpgradesCache.cs" />
     <Compile Include="Scripting\Global\HSLColorGlobal.cs" />
     <Compile Include="Scripting\Global\UserInterfaceGlobal.cs" />
     <Compile Include="ServerTraits\ColorValidator.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Lint\CheckTraitPrerequisites.cs" />
     <Compile Include="Lint\CheckDeathTypes.cs" />
     <Compile Include="Lint\CheckVoiceReferences.cs" />
+    <Compile Include="Lint\CheckUpgrades.cs" />
     <Compile Include="Lint\LintBuildablePrerequisites.cs" />
     <Compile Include="Lint\LintExts.cs" />
     <Compile Include="LoadScreens\ModChooserLoadScreen.cs" />

--- a/OpenRA.Mods.Common/Scripting/ScriptUpgradesCache.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptUpgradesCache.cs
@@ -15,6 +15,7 @@ namespace OpenRA.Mods.Common.Scripting
 	[Desc("Allows granting upgrades to actors from Lua scripts.")]
 	public class ScriptUpgradesCacheInfo : ITraitInfo
 	{
+		[UpgradeGrantedReference]
 		[Desc("Upgrades that can be granted from the scripts.")]
 		public readonly string[] Upgrades = { };
 

--- a/OpenRA.Mods.Common/Scripting/ScriptUpgradesCache.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptUpgradesCache.cs
@@ -1,0 +1,33 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[Desc("Allows granting upgrades to actors from Lua scripts.")]
+	public class ScriptUpgradesCacheInfo : ITraitInfo
+	{
+		[Desc("Upgrades that can be granted from the scripts.")]
+		public readonly string[] Upgrades = { };
+
+		public object Create(ActorInitializer init) { return new ScriptUpgradesCache(this); }
+	}
+
+	public sealed class ScriptUpgradesCache
+	{
+		public readonly ScriptUpgradesCacheInfo Info;
+
+		public ScriptUpgradesCache(ScriptUpgradesCacheInfo info)
+		{
+			Info = info;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Crates/GrantUpgradeCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GrantUpgradeCrateAction.cs
@@ -9,12 +9,14 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants an upgrade to the collector.")]
 	public class GrantUpgradeCrateActionInfo : CrateActionInfo
 	{
+		[UpgradeGrantedReference]
 		[Desc("The upgrades to apply.")]
 		public readonly string[] Upgrades = { };
 

--- a/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
+++ b/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
@@ -13,9 +13,13 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Desc("Grants upgrades to the actor this is attached to when prerequisites are available.")]
 	public class GlobalUpgradableInfo : ITraitInfo, Requires<UpgradeManagerInfo>
 	{
+		[Desc("List of upgrades to apply.")]
 		public readonly string[] Upgrades = { };
+
+		[Desc("List of required prerequisites.")]
 		public readonly string[] Prerequisites = { };
 
 		public object Create(ActorInitializer init) { return new GlobalUpgradable(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
+++ b/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
@@ -16,6 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Grants upgrades to the actor this is attached to when prerequisites are available.")]
 	public class GlobalUpgradableInfo : ITraitInfo, Requires<UpgradeManagerInfo>
 	{
+		[UpgradeGrantedReference]
 		[Desc("List of upgrades to apply.")]
 		public readonly string[] Upgrades = { };
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	class GrantUpgradePowerInfo : SupportPowerInfo
 	{
+		[UpgradeGrantedReference]
 		[Desc("The upgrades to apply.")]
 		public readonly string[] Upgrades = { };
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class DeployToUpgradeInfo : ITraitInfo, Requires<UpgradeManagerInfo>
 	{
+		[UpgradeGrantedReference]
 		[Desc("The upgrades to grant when deploying and revoke when undeploying.")]
 		public readonly string[] Upgrades = { };
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
@@ -7,6 +7,7 @@
  * see COPYING.
  */
 #endregion
+
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -16,6 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	/// <summary>Use as base class for *Info to subclass of UpgradableTrait. (See UpgradableTrait.)</summary>
 	public abstract class UpgradableTraitInfo
 	{
+		[UpgradeUsedReference]
 		[Desc("The upgrade types which can enable or disable this trait.")]
 		public readonly string[] UpgradeTypes = { };
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Applies an upgrade to actors within a specified range.")]
 	public class UpgradeActorsNearInfo : ITraitInfo
 	{
+		[UpgradeGrantedReference]
 		[Desc("The upgrades to grant.")]
 		public readonly string[] Upgrades = { };
 

--- a/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class GrantUpgradeWarhead : Warhead
 	{
+		[UpgradeGrantedReference]
 		[Desc("The upgrades to apply.")]
 		public readonly string[] Upgrades = { };
 

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -103,10 +103,6 @@ crate:
 		SelectionShares: 0
 		NoBaseSelectionShares: 9001
 		Units: mcv
-	GrantUpgradeCrateAction@cloak:
-		SelectionShares: 5
-		Effect: cloak
-		Upgrades: cloak
 	RenderSprites:
 		Palette: effect
 	WithCrateBody:

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -1259,6 +1259,8 @@ Rules:
 			ValuePerUnit: 0
 		LuaScript:
 			Scripts: desert-shellmap.lua
+		ScriptUpgradesCache:
+			Upgrades: unkillable
 		-StartGameNotification:
 	^Vehicle:
 		GivesBounty:

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -488,6 +488,8 @@ Rules:
 		-MPStartLocations:
 		LuaScript:
 			Scripts: fort-lonestar.lua
+		ScriptUpgradesCache:
+			Upgrades: unkillable
 	FORTCRATE:
 		Inherits: ^Crate
 		SupportPowerCrateAction@parabombs:


### PR DESCRIPTION
While this doesn't check whether actor A that grants upgrade X and actor B that uses it can actually interact ingame, it does check whether:
- All upgrades that can be granted by various sources have at least one actor that uses them.
- All upgrades that are consumed by any actor have at least one source to grant them.

It also adds a proxy trait that allows Lua scripts to declare in YAML what custom upgrades they will be using (this enables validation of Lua-granted upgrades).

The main purpose is to close #8272 by checking for unused upgrades, spelling errors and upgrades that nothing can grant.

Closes #8272.

I strongly recommend reviewing per-commit!
