### PR TITLE
Fixed an explicit NRE in TerrainModifiesDamage

### DIFF
--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		public int GetDamageModifier(Actor attacker, DamageWarhead warhead)
 		{
 			var percent = 100;
-			if (attacker.Owner.IsAlliedWith(self.Owner) && warhead.Damage < 0 && !Info.ModifyHealing)
+			if (attacker.Owner.IsAlliedWith(self.Owner) && (warhead != null && warhead.Damage < 0) && !Info.ModifyHealing)
 				return percent;
 
 			var world = self.World;


### PR DESCRIPTION
https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Activities/Demolish.cs#L70 sets warhead to null so it will crash here. I believe this is a real vulnerability introduced by https://github.com/OpenRA/OpenRA/pull/7331.
