### PR TITLE
Fixed an explicit NRE from SwallowActor.WormAttack

### DIFF
--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Attacking(Actor self, Target target, Armament a, Barrel barrel)
 		{
-			if (a.Info.AmmoPoolName == Info.Name)
+			if (a != null && a.Info.AmmoPoolName == Info.Name)
 				TakeAmmo();
 		}
 


### PR DESCRIPTION
I guess the only reason this didn't blow already is that the sandworms don't have the `AmmoPool` trait attached.
