### PR TITLE
Made the tech description label optional

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -468,7 +468,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var techTraits = modRules.Actors["player"].Traits.WithInterface<ProvidesTechPrerequisiteInfo>().ToList();
 				techLevel.IsVisible = () => techTraits.Count > 0;
-				optionsBin.GetOrNull<LabelWidget>("TECHLEVEL_DESC").IsVisible = () => techTraits.Count > 0;
+
+				var techLevelDescription = optionsBin.GetOrNull<LabelWidget>("TECHLEVEL_DESC");
+				if (techLevelDescription != null)
+					techLevelDescription.IsVisible = () => techTraits.Count > 0;
+
 				techLevel.IsDisabled = () => Map.Status != MapStatus.Available ||
 					Map.Map.Options.TechLevel != null || configurationDisabled() || techTraits.Count <= 1;
 				techLevel.GetText = () => Map.Status != MapStatus.Available ||


### PR DESCRIPTION
It is inconsistent to use `GetOrNull` and then crash on the null state which was picked up by Coverity.
