### PR TITLE
Fixed a NullReferenceException in GameTimeLogic

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var connection = orderManager.Connection as ReplayConnection;
 				if (connection != null && connection.TickCount != 0)
 					percentage.GetText = () => "({0}%)".F(orderManager.NetFrameNumber * 100 / connection.TickCount);
-				else
+				else if (timer != null)
 					timer.Bounds.Width += percentage.Bounds.Width;
 			}
 		}


### PR DESCRIPTION
The `GAME_TIMER` label was meant to be optional as seen in the code above. Never crashed, because everyone copy & pasted the RA chrome MiniYaml definitions.
