### PR TITLE
Added more useful exceptions to the command line utility replay parser

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.IO;
 using OpenRA.FileFormats;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -21,6 +22,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			var replay = ReplayMetadata.Read(args[1]);
+			if (replay == null)
+				throw new InvalidDataException("Failed to read replay meta data");
+
 			var info = replay.GameInfo;
 
 			var lines = FieldSaver.Save(info).ToLines(replay.FilePath);


### PR DESCRIPTION
This was picked up by Coverity as a "Dereference null return value" violation. As NREs are often cryptic to read by users I decided to add more appropriate ones with additional context.
