### PR TITLE
Fixed a missing call to base clase in OpenRA.Editor.OnPaint

### DIFF
--- a/OpenRA.Editor/Surface.cs
+++ b/OpenRA.Editor/Surface.cs
@@ -517,6 +517,8 @@ namespace OpenRA.Editor
 				if (x.Key != null && actorTemplates.ContainsKey(x.Value.Type))
 					DrawActorBorder(e.Graphics, x.Value.Location(), actorTemplates[x.Value.Type]);
 			}
+
+			base.OnPaint(e);
 		}
 
 		public void CopySelection()


### PR DESCRIPTION
This doesn't seem to fix anything. Still it was violating the API contract.
