### PR TITLE
Shroudrenderer: fix crash on VERY small maps

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -241,14 +241,16 @@ namespace OpenRA.Mods.Common.Traits
 				// We need to mark newly dirtied areas of the shroud.
 				// Expand the dirty area to cover the neighboring cells, since shroud is affected by neighboring cells.
 				foreach (var cell in cellsDirty)
-				{
-					cellsAndNeighborsDirty.Add(cell);
-					foreach (var direction in CVec.Directions)
-						cellsAndNeighborsDirty.Add(cell + direction);
-				}
+					if (map.Contains(cell))
+					{
+						cellsAndNeighborsDirty.Add(cell);
+						foreach (var direction in CVec.Directions)
+							cellsAndNeighborsDirty.Add(cell + direction);
+					}
 
 				foreach (var cell in cellsAndNeighborsDirty)
-					shroudDirty[cell] = true;
+					if (map.Contains(cell))
+						shroudDirty[cell] = true;
 
 				cellsDirty.Clear();
 				cellsAndNeighborsDirty.Clear();


### PR DESCRIPTION
this crash comes with the new ingame map editor

reproduce case : 
- create a map 10x10 
- load it in skirmish -> game will crash

OR use this TS test map (without this PR) and then with this PR

https://github.com/LipkeGu/Other-crap/blob/master/temp2_shroud.oramap
