### PR TITLE
Fix actor placement and typo in nod06a

### DIFF
--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -508,17 +508,17 @@ Actors:
 		Owner: GDI
 		SubCell: 4
 	Actor158: e2
-		Location: 32,58
+		Location: 32,57
 		Owner: GDI
-		SubCell: 1
+		SubCell: 4
 	Actor159: e2
 		Location: 39,52
 		Owner: GDI
 		SubCell: 0
 	Actor160: e2
-		Location: 40,51
+		Location: 40,50
 		Owner: GDI
-		SubCell: 1
+		SubCell: 4
 	waypoint27: waypoint
 		Location: 54,58
 		Owner: Neutral

--- a/mods/cnc/maps/nod06a/nod06a.lua
+++ b/mods/cnc/maps/nod06a/nod06a.lua
@@ -189,7 +189,7 @@ WorldLoaded = function()
 	end)
 
 	Trigger.OnEnteredFootprint(Win2CellTriggerActivator, function(a, id)
-		if a.Owner == Nod and NodObjective1 then
+		if a.Owner == Nod and NodObjective3 then
 			Nod.MarkCompletedObjective(NodObjective3)
 			Trigger.RemoveFootprintTrigger(id)
 		end


### PR DESCRIPTION
I have no idea why those actors are stuck. The E2's just a little to the north are in the absolute same position relative to the tree and aren't stuck.

Fixes #8343 
Fixes #8344 
