### PR TITLE
Disable EnemyWatcher in all ra missions

### DIFF
--- a/mods/ra/maps/allies-01/map.yaml
+++ b/mods/ra/maps/allies-01/map.yaml
@@ -470,6 +470,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/allies-02/map.yaml
+++ b/mods/ra/maps/allies-02/map.yaml
@@ -703,6 +703,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1330,6 +1330,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -1225,6 +1225,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1577,6 +1577,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -510,6 +510,7 @@ Rules:
 			InitialCash: 50
 		ClassicProductionQueue@Infantry:
 			BuildSpeed: 1
+		-EnemyWatcher:
 	OILB:
 		Health:
 			HP: 3000

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -2213,6 +2213,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2120,14 +2120,17 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		-AnnounceOnSeen:
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		-AnnounceOnSeen:
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		-AnnounceOnSeen:
 	^Ship:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/ra/maps/soviet-01/map.yaml
+++ b/mods/ra/maps/soviet-01/map.yaml
@@ -609,6 +609,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/survival01/map.yaml
+++ b/mods/ra/maps/survival01/map.yaml
@@ -1216,6 +1216,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/ra/maps/survival02/map.yaml
+++ b/mods/ra/maps/survival02/map.yaml
@@ -1025,6 +1025,7 @@ Rules:
 		-ConquestVictoryConditions:
 		MissionObjectives:
 			EarlyGameOver: true
+		-EnemyWatcher:
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:


### PR DESCRIPTION
IMHO it does not make sense in some of then.
(E.g. in allies05a when your spy drives with the truck into the enemy base, you get notifications...)
