### PR TITLE
Check for dependencies of dependencies

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -120,6 +120,13 @@ elseif ($command -eq "dependencies")
 	cp download/windows/*.dll ..
 	cd ..
 	echo "Dependencies copied."
+	
+	$dep = "Microsoft Visual C++ 2010"
+	$results = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | select DisplayName | Where-Object {$_.DisplayName -like $("$dep*")}
+	if (!($results -is [array]) -and !$results.DisplayName)
+	{
+		Write-Host "Warning! Freetype6.dll requires Microsoft Visual C++ 2010 x86 Redistributable!" -Foreground "Red"
+	}
 }
 elseif ($command -eq "test")
 {


### PR DESCRIPTION
This adds a check for MS VC++ 2010 in `make dependencies` and issues a warning if it is not installed.

Closes #8180.
Can be extended to check for implicit dependencies of other DLLs that we fetch.
