### PR TITLE
Check also for 2012 and 2013 Visual C runtimes libaries

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -121,7 +121,7 @@ elseif ($command -eq "dependencies")
 	cd ..
 	echo "Dependencies copied."
 	
-	$dep = "Microsoft Visual C++ 2010"
+	$dep = "Microsoft Visual C++ 201"
 	$results = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | select DisplayName | Where-Object {$_.DisplayName -like $("$dep*")}
 	if (!($results -is [array]) -and !$results.DisplayName)
 	{


### PR DESCRIPTION
freetype6.dll is accepting also 2012 and 2013 revisions of the Visual C runtimes.
