### PR TITLE
Fixed units stopping when making them move while they are already moving.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -150,12 +150,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (path == null)
 			{
-				if (mobile.TicksBeforePathing > 0)
-				{
-					--mobile.TicksBeforePathing;
-					return this;
-				}
-
 				path = EvalPath();
 				SanityCheckPath(mobile);
 			}
@@ -242,12 +236,6 @@ namespace OpenRA.Mods.Common.Activities
 
 				if (--waitTicksRemaining >= 0)
 					return null;
-
-				if (mobile.TicksBeforePathing > 0)
-				{
-					--mobile.TicksBeforePathing;
-					return null;
-				}
 
 				// Calculate a new path
 				mobile.RemoveInfluence();

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -306,10 +306,6 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class Mobile : IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove, IFacing, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove
 	{
-		const int AverageTicksBeforePathing = 5;
-		const int SpreadTicksBeforePathing = 5;
-		internal int TicksBeforePathing = 0;
-
 		readonly Actor self;
 		readonly Lazy<ISpeedModifier[]> speedModifiers;
 		public readonly MobileInfo Info;
@@ -492,8 +488,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			if (!queued) self.CancelActivity();
-
-			TicksBeforePathing = AverageTicksBeforePathing + self.World.SharedRandom.Next(-SpreadTicksBeforePathing, SpreadTicksBeforePathing);
 
 			self.QueueActivity(new Move(self, currentLocation, 8));
 


### PR DESCRIPTION
This fixes an annoying issue where units stop for a moment if you give them an order to move to the same place they are moving to.
