### PR TITLE
Catched an explicit null dereference in PngLoader

### DIFF
--- a/OpenRA.Game/FileFormats/PngLoader.cs
+++ b/OpenRA.Game/FileFormats/PngLoader.cs
@@ -99,6 +99,9 @@ namespace OpenRA.FileFormats
 
 							case "IEND":
 								{
+									if (bitmap == null)
+										throw new InvalidDataException("Image header not found.");
+
 									var bits = bitmap.LockBits(bitmap.Bounds(),
 										ImageLockMode.WriteOnly, PixelFormat.Format8bppIndexed);
 


### PR DESCRIPTION
`bitmap` stays null when `IHDR` is not parsed so I decided to throw because of invalid data here. Detected by Coverity.
