### PR TITLE
Fixed NREs in LobbyCommands PingFromClient

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -489,7 +489,11 @@ namespace OpenRA.Server
 							break;
 						}
 
-						var pingFromClient = LobbyInfo.PingFromClient(GetClient(conn));
+						var client = GetClient(conn);
+						if (client == null)
+							return;
+
+						var pingFromClient = LobbyInfo.PingFromClient(client);
 						if (pingFromClient == null)
 							return;
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -186,8 +186,11 @@ namespace OpenRA.Mods.Common.Server
 								server.LobbyInfo.Clients.Remove(occupant);
 								server.SyncLobbyClients();
 								var ping = server.LobbyInfo.PingFromClient(occupant);
-								server.LobbyInfo.ClientPings.Remove(ping);
-								server.SyncClientPing();
+								if (ping != null)
+								{
+									server.LobbyInfo.ClientPings.Remove(ping);
+									server.SyncClientPing();
+								}
 							}
 							else
 							{
@@ -221,7 +224,11 @@ namespace OpenRA.Mods.Common.Server
 						{
 							server.LobbyInfo.Clients.Remove(occupant);
 							var ping = server.LobbyInfo.PingFromClient(occupant);
-							server.LobbyInfo.ClientPings.Remove(ping);
+							if (ping != null)
+							{
+								server.LobbyInfo.ClientPings.Remove(ping);
+								server.SyncClientPing();
+							}
 						}
 
 						server.SyncLobbyClients();


### PR DESCRIPTION
Fixes #7515 as `PingFromClient` return `SingleOrDefault` so it can be null. Also added a missing `SyncClientPing()`. Discovered by my eye balls.
