### PR TITLE
Fixed EndOfStreamException in MixFile.ReadBlocks

### DIFF
--- a/OpenRA.Game/FileSystem/MixFile.cs
+++ b/OpenRA.Game/FileSystem/MixFile.cs
@@ -122,6 +122,15 @@ namespace OpenRA.FileSystem
 
 		static uint[] ReadBlocks(Stream s, long offset, int count)
 		{
+			if (offset < 0)
+				throw new ArgumentOutOfRangeException("offset", "Non-negative number required.");
+
+			if (count < 0)
+				throw new ArgumentOutOfRangeException("count", "Non-negative number required.");
+
+			if (offset + (count * 2) > s.Length)
+				throw new ArgumentException("Bytes to read {0} and offset {1} greater than stream length {2}.".F(count * 2, offset, s.Length));
+
 			s.Seek(offset, SeekOrigin.Begin);
 
 			// A block is a single encryption unit (represented as two 32-bit integers)


### PR DESCRIPTION
Closes #5866 by replacing the EndOfStreamException with more useful ones for debugging like we do in StreamExts. I am not sure what is happening. It seems to be a Windows .NET only issue. Probably related to https://github.com/OpenRA/OpenRA/issues/2441.
