### PR TITLE
Fixed a NullReferenceException in LobbyCommands.ValidateCommand

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Server
 
 		public bool InterpretCommand(S server, Connection conn, Session.Client client, string cmd)
 		{
-			if (!ValidateCommand(server, conn, client, cmd))
+			if (server == null || conn == null || client == null || !ValidateCommand(server, conn, client, cmd))
 				return false;
 
 			var dict = new Dictionary<string, Func<string, bool>>


### PR DESCRIPTION
I believe this fixes https://github.com/OpenRA/OpenRA/issues/4720. It is either `client` or `server` which are null. As this happens on dedicated servers I assume `server` is not null. Also the `server.log` indicates clients dropping and the client state switching constantly which might race here.
