### PR TITLE
Fixed an exploit where choosing another players color crashes the game

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/ColorValidator.cs
+++ b/OpenRA.Mods.Common/ServerTraits/ColorValidator.cs
@@ -160,17 +160,11 @@ namespace OpenRA.Mods.Common.Server
 			}
 
 			// Validate color against other clients
-			var playerColors = server.LobbyInfo.Clients
-				.Where(c => c.Index != playerIndex)
-				.ToDictionary(c => c.Color.RGB, c => c.Name);
-
-			if (!ValidateColorAgainstForbidden(askedColor, playerColors.Keys, out forbiddenColor))
+			var playerColors = server.LobbyInfo.Clients.Where(c => c.Index != playerIndex).Select(c => c.Color.RGB);
+			if (!ValidateColorAgainstForbidden(askedColor, playerColors, out forbiddenColor))
 			{
 				if (connectionToEcho != null)
-				{
-					var client = playerColors[forbiddenColor];
-					server.SendOrderTo(connectionToEcho, "Message", "Color was too similar to {0}, and has been adjusted.".F(client));
-				}
+					server.SendOrderTo(connectionToEcho, "Message", "Color was too similar to another player's color, and has been adjusted.");
 
 				return false;
 			}


### PR DESCRIPTION
Fixes #8060 by simply not logging to which other player the color belonged. Obviously we can't use the duplicate player colors as keys for our dictionary. It also added extra bloat for a not very interesting information. This simplifies things and adds consistency towards the other checks.
