### PR TITLE
Fix WithBuildingPlacedAnimation interrupting WithMakeAnimation

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -21,20 +21,28 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.Self, this); }
 	}
 
-	public class WithBuildingPlacedAnimation : INotifyBuildingPlaced
+	public class WithBuildingPlacedAnimation : INotifyBuildingPlaced, INotifyBuildComplete
 	{
 		WithBuildingPlacedAnimationInfo info;
 		RenderSimple renderSimple;
+		bool buildComplete;
 
 		public WithBuildingPlacedAnimation(Actor self, WithBuildingPlacedAnimationInfo info)
 		{
 			this.info = info;
 			renderSimple = self.Trait<RenderSimple>();
+			buildComplete = !self.HasTrait<Building>();
+		}
+
+		public void BuildingComplete(Actor self)
+		{
+			buildComplete = true;
 		}
 
 		public void BuildingPlaced(Actor self)
 		{
-			renderSimple.PlayCustomAnim(self, info.Sequence);
+			if (buildComplete)
+				renderSimple.PlayCustomAnim(self, info.Sequence);
 		}
 	}
 }


### PR DESCRIPTION
The bug happens when a second (or third, fourth etc.) Conyard deploys while a building is placed from the first Conyard.

The `WithMakeAnimation` running on the second CY uses `Animation::PlayThen` to call `Building::Unlock` in a delegate.

`WithBuildingPlacedAnimation::BuildingPlaced` runs when a building placed and replaces the delegate from `WithMakeAnimation` with its own before it has a chance to run, and so the new Conyard never gets unlocked.

The fix is then to simply not run `BuildingPlaced` on conyards that haven't completed the make animation yet.

Fixes #8041.
