### PR TITLE
Fixed a dereference after null check in UnitOrderGenerator.CheckSameOrder

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -140,7 +140,7 @@ namespace OpenRA.Orders
 		{
 			if (order == null && iot.OrderID != null)
 				Game.Debug("BUG: in order targeter - decided on {0} but then didn't order", iot.OrderID);
-			else if (iot.OrderID != order.OrderString)
+			else if (order != null && iot.OrderID != order.OrderString)
 				Game.Debug("BUG: in order targeter - decided on {0} but ordered {1}", iot.OrderID, order.OrderString);
 			return order;
 		}


### PR DESCRIPTION
Discovered by Coverity.
