### PR TITLE
Fixed a bad bit shift operation in PriorityQueue

### DIFF
--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Primitives
 
 			var ret = At(0, 0);
 			BubbleInto(0, 0, Last());
-			if (--index < 0)
+			if (level > 0 && --index < 0)
 				index = (1 << --level) - 1;
 
 			return ret;


### PR DESCRIPTION
`--level` can be -1 here. This leads to undefined behavior. https://msdn.microsoft.com/en-us/library/f96c63ed.aspx

Discovered using Coverity.
