### PR TITLE
Fixed a NullReferenceException in Sync.HashTarget

### DIFF
--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -144,6 +144,9 @@ namespace OpenRA
 					return (int)(t.Actor.ActorID << 16) * 0x567;
 
 				case TargetType.FrozenActor:
+					if (t.FrozenActor.Actor == null)
+						return 0;
+
 					return (int)(t.FrozenActor.Actor.ActorID << 16) * 0x567;
 
 				case TargetType.Terrain:


### PR DESCRIPTION
`FrozenActor.Actor` can be null when the actor `IsDead`. Detected by Coverity.
