### PR TITLE
Configure dl agent

### DIFF
--- a/thirdparty/configure-utils.sh
+++ b/thirdparty/configure-utils.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+####
+# This file must stay /bin/sh and POSIX compliant for BSD portability.
+# Copy-paste the entire script into http://shellcheck.net to check.
+####
+
+# We configure the default download agent.
+if hash curl >/dev/null 2>&1; then
+    curl()
+    {
+        command curl --silent --location --output "$1" "$2"
+    }
+elif hash fetch >/dev/null 2>&1; then
+    curl()
+    {
+        command fetch --quiet --output "$1" "$2"
+    }
+else
+    curl()
+    {
+        echo "Can't download: didn't find curl(1), nor fetch(1)"
+    }
+fi

--- a/thirdparty/configure-utils.sh
+++ b/thirdparty/configure-utils.sh
@@ -7,17 +7,17 @@
 
 # We configure the default download agent.
 if hash curl >/dev/null 2>&1; then
-    curl()
+    download()
     {
         command curl --silent --location --output "$1" "$2"
     }
 elif hash fetch >/dev/null 2>&1; then
-    curl()
+    download()
     {
         command fetch --quiet --output "$1" "$2"
     }
 else
-    curl()
+    download()
     {
         echo "Can't download: didn't find curl(1), nor fetch(1)"
     }

--- a/thirdparty/fetch-geoip-db.sh
+++ b/thirdparty/fetch-geoip-db.sh
@@ -3,6 +3,8 @@
 # Die on any error for Travis CI to automatically retry:
 set -e
 
+. ./thirdparty/configure-utils.sh
+
 download_dir="${0%/*}/download"
 mkdir -p "${download_dir}"
 cd "${download_dir}"
@@ -13,6 +15,6 @@ filename="GeoLite2-Country.mmdb.gz"
 if [ ! -e $filename ] || [ -n "$(find . -name $filename -mtime +30 -print)" ]; then
 	rm -f $filename
 	echo "Updating GeoIP country database from MaxMind."
-	curl -s -L -O http://geolite.maxmind.com/download/geoip/database/$filename
+	curl $filename http://geolite.maxmind.com/download/geoip/database/$filename
 fi
 

--- a/thirdparty/fetch-geoip-db.sh
+++ b/thirdparty/fetch-geoip-db.sh
@@ -15,6 +15,6 @@ filename="GeoLite2-Country.mmdb.gz"
 if [ ! -e $filename ] || [ -n "$(find . -name $filename -mtime +30 -print)" ]; then
 	rm -f $filename
 	echo "Updating GeoIP country database from MaxMind."
-	curl $filename http://geolite.maxmind.com/download/geoip/database/$filename
+	download $filename http://geolite.maxmind.com/download/geoip/database/$filename
 fi
 

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -87,10 +87,10 @@ fi
 
 if [ ! -f SDL2-CS.dll ]; then
 	echo "Fetching SDL2-CS from GitHub."
-	curl SDL2-CS.dll https://github.com/OpenRA/SDL2-CS/releases/download/20140407/SDL2-CS.dll
+	download SDL2-CS.dll https://github.com/OpenRA/SDL2-CS/releases/download/20140407/SDL2-CS.dll
 fi
 
 if [ ! -f Eluant.dll ]; then
 	echo "Fetching Eluant from GitHub."
-	curl Eluant.dll https://github.com/OpenRA/Eluant/releases/download/20140425/Eluant.dll
+	download Eluant.dll https://github.com/OpenRA/Eluant/releases/download/20140425/Eluant.dll
 fi

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -3,6 +3,8 @@
 # Die on any error for Travis CI to automatically retry:
 set -e
 
+. ./thirdparty/configure-utils.sh
+
 download_dir="${0%/*}/download"
 
 mkdir -p "${download_dir}"
@@ -85,10 +87,10 @@ fi
 
 if [ ! -f SDL2-CS.dll ]; then
 	echo "Fetching SDL2-CS from GitHub."
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20140407/SDL2-CS.dll
+	curl SDL2-CS.dll https://github.com/OpenRA/SDL2-CS/releases/download/20140407/SDL2-CS.dll
 fi
 
 if [ ! -f Eluant.dll ]; then
 	echo "Fetching Eluant from GitHub."
-	curl -s -L -O https://github.com/OpenRA/Eluant/releases/download/20140425/Eluant.dll
+	curl Eluant.dll https://github.com/OpenRA/Eluant/releases/download/20140425/Eluant.dll
 fi

--- a/thirdparty/noget.sh
+++ b/thirdparty/noget.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 # fallback without dependency resolution if nuget is not present on the system
 
+. ../configure-utils.sh
+
 archive="$1"
 version="$2"
-curl -o "$archive.zip" -Ls https://nuget.org/api/v2/package/"$archive"/"$version"
+curl "$archive.zip" https://nuget.org/api/v2/package/"$archive"/"$version"
 mkdir -p "$archive"
 unzip -o -qq "$archive.zip" -d "$archive" && rm "$archive.zip"

--- a/thirdparty/noget.sh
+++ b/thirdparty/noget.sh
@@ -5,6 +5,6 @@
 
 archive="$1"
 version="$2"
-curl "$archive.zip" https://nuget.org/api/v2/package/"$archive"/"$version"
+download "$archive.zip" https://nuget.org/api/v2/package/"$archive"/"$version"
 mkdir -p "$archive"
 unzip -o -qq "$archive.zip" -d "$archive" && rm "$archive.zip"


### PR DESCRIPTION
`curl(1)` is not available in a base FreeBSD install. As it has a counterpart (`fetch(1)`), we use it if curl is not available.

Tested and fully functionnal on FreeBSD 10.1
