### PR TITLE
A few minor portability fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,12 +76,10 @@ VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev
 
 # dependencies
 UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-os-dependencies = linux-dependencies
-else ifneq (,$(findstring BSD,$(UNAME_S)))
-os-dependencies = bsd-dependencies
-else ifeq ($(UNAME_S),Darwin)
+ifeq ($(UNAME_S),Darwin)
 os-dependencies = osx-dependencies
+else
+os-dependencies = linux-dependencies
 endif
 
 
@@ -311,11 +309,6 @@ linux-dependencies: cli-dependencies linux-native-dependencies
 linux-native-dependencies:
 	@./thirdparty/configure-native-deps.sh
 
-bsd-dependencies: cli-dependencies bsd-native-dependencies
-
-bsd-native-dependencies:
-	@./thirdparty/configure-native-deps.sh
-
 windows-dependencies:
 	@./thirdparty/fetch-thirdparty-deps-windows.sh
 
@@ -380,7 +373,7 @@ install-core: default
 	@$(INSTALL_PROGRAM) Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) RestSharp.dll "$(DATA_INSTALL_DIR)"
 
-ifeq ($(shell uname),Linux)
+ifneq ($(UNAME_S),Darwin)
 	@$(CP) *.sh "$(DATA_INSTALL_DIR)"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ INSTALL_DATA = $(INSTALL) -m644
 
 # program targets
 CORE = rsdl2 rnull game utility
-TOOLS = editor crashdialog
+TOOLS = editor gamemonitor
 VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
 
 # dependencies

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ install-tools: tools
 
 install-linux-icons:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/icons/"
-	@$(CP_R) packaging/linux/hicolor/ "$(DESTDIR)$(datadir)/icons"
+	@$(CP_R) packaging/linux/hicolor "$(DESTDIR)$(datadir)/icons/"
 
 install-linux-desktop:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/applications"

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -36,10 +36,10 @@ namespace OpenRA
 				psi.RedirectStandardOutput = true;
 				var p = Process.Start(psi);
 				var kernelName = p.StandardOutput.ReadToEnd();
-				if (kernelName.Contains("Linux") || kernelName.Contains("BSD"))
-					return PlatformType.Linux;
 				if (kernelName.Contains("Darwin"))
 					return PlatformType.OSX;
+				else
+					return PlatformType.Linux;
 			}
 			catch { }
 


### PR DESCRIPTION
An attempt to eliminate some local changes in FreeBSD port. Unix desktop includes the following systems. Adding ifdefs for them all is kinda overkill, so let's simplify instead.
- Linux except Android
- Bitrig, DragonFly, FreeBSD, MirBSD, NetBSD, OpenBSD
- Solaris-based systems
- GNU/kFreeBSD
- GNU/Hurd (not sure if it can do OpenGL 2.0)

Tested with `gmake dependencies` and

``` diff
Index: games/openra/Makefile
===================================================================
--- games/openra/Makefile   (revision 387370)
+++ games/openra/Makefile   (working copy)
@@ -82,10 +82,8 @@ post-patch:
        ${MV} -v ${WRKDIR}/$${f#*/} ${WRKSRC}/thirdparty; \
    done

-   ${REINPLACE_CMD} -e 's/Linux/${OPSYS}/' \
-       -e '/CP_R/s,hicolor/,hicolor,' \
+   ${REINPLACE_CMD} \
        -e '/fetch-thirdparty-deps/d' \
-       -e 's/crashdialog/gamemonitor/' \
        -e '/echo/!s/   @/  /' \
        -e '/^mods:/s/$$/ version/' \
        -e '/^docs:/s/$$/ all/' \
@@ -96,9 +94,6 @@ post-patch:
    ${SED} 's/@LIBLUA51@/liblua-${LUA_VER}.so/' \
        ${WRKSRC}/thirdparty/Eluant.dll.config.in \
        >${WRKSRC}/Eluant.dll.config
-# DragonFly lacks BSD suffix
-   ${REINPLACE_CMD} -e 's/"BSD"/"${OPSYS}"/' \
-       ${WRKSRC}/OpenRA.Game/Platform.cs

 post-build:
 .if ${PORT_OPTIONS:MDOCS}
```
