### PR TITLE
Add WPos shroud visibility queries.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -292,6 +292,11 @@ namespace OpenRA.Traits
 			Invalidate(changed);
 		}
 
+		public bool IsExplored(WPos pos)
+		{
+			return IsExplored(map.CellContaining(pos));
+		}
+
 		public bool IsExplored(CPos cell)
 		{
 			return IsExplored(cell.ToMPos(map));
@@ -332,6 +337,11 @@ namespace OpenRA.Traits
 		public bool IsExplored(Actor a)
 		{
 			return GetVisOrigins(a).Any(IsExplored);
+		}
+
+		public bool IsVisible(WPos pos)
+		{
+			return IsVisible(map.CellContaining(pos));
 		}
 
 		public bool IsVisible(CPos cell)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -72,8 +72,10 @@ namespace OpenRA
 
 		public bool FogObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(a); }
 		public bool FogObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(p); }
+		public bool FogObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(pos); }
 		public bool ShroudObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(a); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
+		public bool ShroudObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(pos); }
 		public bool ShroudObscures(MPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
 
 		public Func<MPos, bool> FogObscuresTest(CellRegion region)

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -158,8 +158,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (anim == null || ticks >= length)
 				yield break;
 
-			var cell = wr.World.Map.CellContaining(pos);
-			if (!args.SourceActor.World.FogObscures(cell))
+			if (!args.SourceActor.World.FogObscures(pos))
 			{
 				if (info.Shadow)
 				{

--- a/OpenRA.Mods.Common/Effects/Corpse.cs
+++ b/OpenRA.Mods.Common/Effects/Corpse.cs
@@ -18,7 +18,6 @@ namespace OpenRA.Mods.Common.Effects
 	{
 		readonly World world;
 		readonly WPos pos;
-		readonly CPos cell;
 		readonly string paletteName;
 		readonly Animation anim;
 
@@ -26,7 +25,6 @@ namespace OpenRA.Mods.Common.Effects
 		{
 			this.world = world;
 			this.pos = pos;
-			this.cell = world.Map.CellContaining(pos);
 			this.paletteName = paletteName;
 			anim = new Animation(world, image);
 			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
@@ -36,7 +34,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (world.FogObscures(cell))
+			if (world.FogObscures(pos))
 				return SpriteRenderable.None;
 
 			return anim.Render(pos, wr.Palette(paletteName));

--- a/OpenRA.Mods.Common/Effects/CrateEffect.cs
+++ b/OpenRA.Mods.Common/Effects/CrateEffect.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (!a.IsInWorld || a.World.FogObscures(a.Location))
+			if (!a.IsInWorld || a.World.FogObscures(a.CenterPosition))
 				return SpriteRenderable.None;
 
 			return anim.Render(a.CenterPosition, wr.Palette(palette));

--- a/OpenRA.Mods.Common/Effects/Explosion.cs
+++ b/OpenRA.Mods.Common/Effects/Explosion.cs
@@ -20,13 +20,11 @@ namespace OpenRA.Mods.Common.Effects
 		readonly string palette;
 		readonly Animation anim;
 		WPos pos;
-		CPos cell;
 
 		public Explosion(World world, WPos pos, string sequence, string palette)
 		{
 			this.world = world;
 			this.pos = pos;
-			this.cell = world.Map.CellContaining(pos);
 			this.palette = palette;
 			anim = new Animation(world, "explosion");
 			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
@@ -36,7 +34,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (world.FogObscures(cell))
+			if (world.FogObscures(pos))
 				return SpriteRenderable.None;
 
 			return anim.Render(pos, wr.Palette(palette));

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (wr.World.FogObscures(wr.World.Map.CellContaining(pos)))
+			if (wr.World.FogObscures(pos))
 				yield break;
 
 			yield return new TextRenderable(font, pos, 0, color, text);

--- a/OpenRA.Mods.Common/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Effects/GravityBomb.cs
@@ -78,8 +78,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			var cell = wr.World.Map.CellContaining(pos);
-			if (!args.SourceActor.World.FogObscures(cell))
+			if (!args.SourceActor.World.FogObscures(pos))
 			{
 				if (info.Shadow)
 				{

--- a/OpenRA.Mods.Common/Effects/LaserZap.cs
+++ b/OpenRA.Mods.Common/Effects/LaserZap.cs
@@ -85,8 +85,8 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (wr.World.FogObscures(wr.World.Map.CellContaining(target)) &&
-				wr.World.FogObscures(wr.World.Map.CellContaining(args.Source)))
+			if (wr.World.FogObscures(target) &&
+				wr.World.FogObscures(args.Source))
 				yield break;
 
 			if (ticks < info.BeamDuration)

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -210,7 +210,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.ContrailLength > 0)
 				yield return contrail;
 
-			if (!args.SourceActor.World.FogObscures(wr.World.Map.CellContaining(pos)))
+			if (!args.SourceActor.World.FogObscures(pos))
 			{
 				if (info.Shadow)
 				{

--- a/OpenRA.Mods.Common/Effects/Smoke.cs
+++ b/OpenRA.Mods.Common/Effects/Smoke.cs
@@ -18,7 +18,6 @@ namespace OpenRA.Mods.Common.Effects
 	{
 		readonly World world;
 		readonly WPos pos;
-		readonly CPos cell;
 		readonly Animation anim;
 		readonly string palette;
 
@@ -26,7 +25,6 @@ namespace OpenRA.Mods.Common.Effects
 		{
 			this.world = world;
 			this.pos = pos;
-			this.cell = world.Map.CellContaining(pos);
 			this.palette = palette;
 
 			anim = new Animation(world, trail);
@@ -38,7 +36,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (world.FogObscures(cell))
+			if (world.FogObscures(pos))
 				return SpriteRenderable.None;
 
 			return anim.Render(pos, wr.Palette(palette));

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -65,20 +65,17 @@ namespace OpenRA.Mods.Common.Graphics
 
 			// Start of the first line segment is the tail of the list - don't smooth it.
 			var curPos = trail[Index(next - skip - 1)];
-			var curCell = wr.World.Map.CellContaining(curPos);
 			var curColor = color;
 			for (var i = 0; i < length - skip - 4; i++)
 			{
 				var j = next - skip - i - 2;
 				var nextPos = Average(trail[Index(j)], trail[Index(j - 1)], trail[Index(j - 2)], trail[Index(j - 3)]);
-				var nextCell = wr.World.Map.CellContaining(nextPos);
 				var nextColor = Exts.ColorLerp(i * 1f / (length - 4), color, Color.Transparent);
 
-				if (!world.FogObscures(curCell) && !world.FogObscures(nextCell))
+				if (!world.FogObscures(curPos) && !world.FogObscures(nextPos))
 					wlr.DrawLine(wr.ScreenPosition(curPos), wr.ScreenPosition(nextPos), curColor, nextColor);
 
 				curPos = nextPos;
-				curCell = nextCell;
 				curColor = nextColor;
 			}
 

--- a/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
@@ -70,8 +70,8 @@ namespace OpenRA.Mods.RA.Graphics
 		public void RenderDebugGeometry(WorldRenderer wr) { }
 		public void Render(WorldRenderer wr)
 		{
-			if (wr.World.FogObscures(wr.World.Map.CellContaining(pos)) &&
-				wr.World.FogObscures(wr.World.Map.CellContaining(pos + length)))
+			if (wr.World.FogObscures(pos) &&
+				wr.World.FogObscures(pos + length))
 				return;
 
 			if (!cache.Any() || length != cachedLength || pos != cachedPos)


### PR DESCRIPTION
Another small step towards heightmap-aware shroud, which can return different results depending on where inside a cell you query.
