### PR TITLE
Package the *.exe.config files on all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,8 @@ install-core: default
 	@-echo "Installing OpenRA to $(DATA_INSTALL_DIR)"
 	@$(INSTALL_DIR) "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) $(foreach prog,$(CORE),$($(prog)_TARGET)) "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_DATA) $(game_TARGET).config "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_DATA) $(utility_TARGET).config "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_DIR) "$(DATA_INSTALL_DIR)/mods"
 	@$(CP_R) mods/common "$(DATA_INSTALL_DIR)/mods/"
 	@$(INSTALL_PROGRAM) $(mod_common_TARGET) "$(DATA_INSTALL_DIR)/mods/common"

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -32,7 +32,7 @@ markdown Lua-API.md > Lua-API.html
 
 # List of files that are packaged on all platforms
 FILES=('OpenRA.Game.exe' 'OpenRA.Game.exe.config' 'OpenRA.Editor.exe' 'OpenRA.Utility.exe' \
-'OpenRA.Renderer.Sdl2.dll' 'OpenRA.Renderer.Null.dll' \
+'OpenRA.Utility.exe.config' 'OpenRA.Renderer.Sdl2.dll' 'OpenRA.Renderer.Null.dll' \
  'lua' 'glsl' 'mods/common' 'mods/ra' 'mods/cnc' 'mods/d2k' 'mods/modchooser' \
 'AUTHORS' 'COPYING' 'README.html' 'CONTRIBUTING.html' 'DOCUMENTATION.html' 'CHANGELOG.html' \
 'global mix database.dat' 'GeoLite2-Country.mmdb.gz')

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -84,6 +84,7 @@ Section "Game" GAME
 	File "${SRCDIR}\OpenRA.Game.exe"
 	File "${SRCDIR}\OpenRA.Game.exe.config"
 	File "${SRCDIR}\OpenRA.Utility.exe"
+	File "${SRCDIR}\OpenRA.Utility.exe.config"
 	File "${SRCDIR}\OpenRA.Renderer.Null.dll"
 	File "${SRCDIR}\OpenRA.Renderer.Sdl2.dll"
 	File "${SRCDIR}\ICSharpCode.SharpZipLib.dll"


### PR DESCRIPTION
I just noticed that the packaging of the .exe.config files was inconsistent.

Windows and Mac OS X only shipped the Game.exe.config, not the Utility.exe.config.
Debian shipped neither.

The Game.exe.config is currently only used on Windows, while the Utility.exe.config is only used on systems using mono.

I opted to ship all .configs on all platforms. If someday someone decides to add something to those files, it would just be forgotten to add them to the packages.
