### PR TITLE
Offset the TS shroud sequences.

### DIFF
--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -258,6 +258,8 @@ resources:
 	tib20: tib20
 
 shroud:
+	Defaults:
+		Offset: 0, -1
 	shroud:
 		Length: *
 	fog: fog


### PR DESCRIPTION
For some reason WW thought it was a good idea to offset the shroud/fog sprites by 1px vertically relative to the terrain tiles (see screenshot).  This applies the opposite offset in our sequences to line them up again.  The easiest way to test this is to look at the edges of the map in #8430.

![offset](https://cloud.githubusercontent.com/assets/167819/8046431/bcfc02f4-0e32-11e5-966a-16f4f0a42886.png)
