### PR TITLE
Fixed a common NullReferenceException at SpriteFont.Measure

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -93,6 +93,9 @@ namespace OpenRA.Graphics
 
 		public int2 Measure(string text)
 		{
+			if (string.IsNullOrEmpty(text))
+				return int2.Zero;
+
 			var lines = text.Split('\n');
 			return new int2((int)Math.Ceiling(lines.Max(lineWidth)), lines.Length * size);
 		}


### PR DESCRIPTION
This is a common pitfall so I decided to fix this once and for all at the source of the problem.

Fixes #6743.
Fixes #6813.
