### PR TITLE
Fixed Sprite.Measure returning a 0 height

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Graphics
 		public int2 Measure(string text)
 		{
 			if (string.IsNullOrEmpty(text))
-				return int2.Zero;
+				return new int2(0, size);
 
 			var lines = text.Split('\n');
 			return new int2((int)Math.Ceiling(lines.Max(lineWidth)), lines.Length * size);


### PR DESCRIPTION
Fixes #8459, a regression introduced by https://github.com/OpenRA/OpenRA/pull/8457.
