### PR TITLE
Fixed a NullReferenceException in SanitizedPlayerName

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -334,12 +334,12 @@ namespace OpenRA
 
 			var clean = SanitizedName(dirty);
 
+			if (string.IsNullOrWhiteSpace(clean) || forbiddenNames.Contains(clean) || botNames.Contains(clean))
+				clean = new PlayerSettings().Name;
+
 			// avoid UI glitches
 			if (clean.Length > 16)
 				clean = clean.Substring(0, 16);
-
-			if (string.IsNullOrWhiteSpace(clean) || forbiddenNames.Contains(clean) || botNames.Contains(clean))
-				clean = new PlayerSettings().Name;
 
 			return clean;
 		}


### PR DESCRIPTION
Introduced just recently by myself in https://github.com/OpenRA/OpenRA/pull/8449. Detected by Coverity.
