### PR TITLE
Remove region assumptions from fast shroud tests

### DIFF
--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -180,8 +180,8 @@ namespace OpenRA.Graphics
 			{
 				var colors = (int*)bitmapData.Scan0;
 				var stride = bitmapData.Stride / 4;
-				var shroudObscured = world.ShroudObscuresTest(map.CellsInsideBounds);
-				var fogObscured = world.FogObscuresTest(map.CellsInsideBounds);
+				var shroudObscured = world.ShroudObscuresTest;
+				var fogObscured = world.FogObscuresTest;
 				foreach (var uv in map.CellsInsideBounds.MapCoords)
 				{
 					var bitmapXy = new int2(uv.U - b.Left, uv.V - b.Top);

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -24,7 +24,9 @@ namespace OpenRA.Graphics
 			theater = wr.Theater;
 			mapTiles = world.Map.MapTiles.Value;
 
-			terrain = new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette("terrain"), true);
+			terrain = new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha,
+				wr.Palette("terrain"), wr.World.Type != WorldType.Editor);
+
 			foreach (var cell in world.Map.AllCells)
 				UpdateCell(cell);
 

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Graphics
 			theater = wr.Theater;
 			mapTiles = world.Map.MapTiles.Value;
 
-			terrain = new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette("terrain"));
+			terrain = new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette("terrain"), true);
 			foreach (var cell in world.Map.AllCells)
 				UpdateCell(cell);
 

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Graphics
 		readonly Vertex[] vertices;
 		readonly HashSet<int> dirtyRows = new HashSet<int>();
 		readonly int rowStride;
+		readonly bool restrictToBounds;
 
 		readonly WorldRenderer worldRenderer;
 		readonly Map map;
@@ -34,9 +35,10 @@ namespace OpenRA.Graphics
 
 		float paletteIndex;
 
-		public TerrainSpriteLayer(World world, WorldRenderer wr, Sheet sheet, BlendMode blendMode, PaletteReference palette)
+		public TerrainSpriteLayer(World world, WorldRenderer wr, Sheet sheet, BlendMode blendMode, PaletteReference palette, bool restrictToBounds)
 		{
 			worldRenderer = wr;
+			this.restrictToBounds = restrictToBounds;
 			this.sheet = sheet;
 			this.blendMode = blendMode;
 			paletteIndex = palette.TextureIndex;
@@ -92,7 +94,7 @@ namespace OpenRA.Graphics
 
 		public void Draw(Viewport viewport)
 		{
-			var cells = viewport.VisibleCells;
+			var cells = restrictToBounds ? viewport.VisibleCellsInsideBounds : viewport.AllVisibleCells;
 
 			// Only draw the rows that are visible.
 			var firstRow = cells.MapCoords.TopLeft.V;

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -261,7 +261,7 @@ namespace OpenRA.Graphics
 			{
 				if (cellsDirty)
 				{
-					cells = CalculateVisibleCells(worldRenderer.World.Type != WorldType.Editor);
+					cells = CalculateVisibleCells(false);
 					cellsDirty = false;
 				}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -870,7 +870,7 @@ namespace OpenRA
 		// it rounds the actual distance up to the next integer so that this call
 		// will return any cells that intersect with the requested range circle.
 		// The returned positions are sorted by distance from the center.
-		public IEnumerable<CPos> FindTilesInAnnulus(CPos center, int minRange, int maxRange)
+		public IEnumerable<CPos> FindTilesInAnnulus(CPos center, int minRange, int maxRange, bool allowOutsideBounds = false)
 		{
 			if (maxRange < minRange)
 				throw new ArgumentOutOfRangeException("maxRange", "Maximum range is less than the minimum range.");
@@ -878,20 +878,24 @@ namespace OpenRA
 			if (maxRange > TilesByDistance.Length)
 				throw new ArgumentOutOfRangeException("maxRange", "The requested range ({0}) exceeds the maximum allowed ({1})".F(maxRange, MaxTilesInCircleRange));
 
+			Func<CPos, bool> valid = Contains;
+			if (allowOutsideBounds)
+				valid = MapTiles.Value.Contains;
+
 			for (var i = minRange; i <= maxRange; i++)
 			{
 				foreach (var offset in TilesByDistance[i])
 				{
 					var t = offset + center;
-					if (Contains(t))
+					if (valid(t))
 						yield return t;
 				}
 			}
 		}
 
-		public IEnumerable<CPos> FindTilesInCircle(CPos center, int maxRange)
+		public IEnumerable<CPos> FindTilesInCircle(CPos center, int maxRange, bool allowOutsideBounds = false)
 		{
-			return FindTilesInAnnulus(center, 0, maxRange);
+			return FindTilesInAnnulus(center, 0, maxRange, allowOutsideBounds);
 		}
 	}
 }

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Traits
 		public readonly WPos CenterPosition;
 		public readonly Rectangle Bounds;
 		readonly Actor actor;
-		readonly Func<MPos, bool> isVisibleTest;
+		readonly Shroud shroud;
 
 		public Player Owner;
 
@@ -45,7 +45,7 @@ namespace OpenRA.Traits
 		public FrozenActor(Actor self, MPos[] footprint, Shroud shroud)
 		{
 			actor = self;
-			isVisibleTest = shroud.IsVisibleTest;
+			this.shroud = shroud;
 
 			// Consider all cells inside the map area (ignoring the current map bounds)
 			Footprint = footprint
@@ -79,6 +79,7 @@ namespace OpenRA.Traits
 		void UpdateVisibility()
 		{
 			var wasVisible = Visible;
+			var isVisibleTest = shroud.IsVisibleTest;
 
 			// We are doing the following LINQ manually for performance since this is a hot path.
 			// Visible = !Footprint.Any(isVisibleTest);

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -42,12 +42,16 @@ namespace OpenRA.Traits
 		public bool NeedRenderables;
 		public bool IsRendering { get; private set; }
 
-		public FrozenActor(Actor self, MPos[] footprint, CellRegion footprintRegion, Shroud shroud)
+		public FrozenActor(Actor self, MPos[] footprint, Shroud shroud)
 		{
 			actor = self;
-			isVisibleTest = shroud.IsVisibleTest(footprintRegion);
+			isVisibleTest = shroud.IsVisibleTest;
 
-			Footprint = footprint;
+			// Consider all cells inside the map area (ignoring the current map bounds)
+			Footprint = footprint
+				.Where(m => shroud.Contains(m))
+				.ToArray();
+
 			CenterPosition = self.CenterPosition;
 			Bounds = self.Bounds;
 
@@ -80,11 +84,13 @@ namespace OpenRA.Traits
 			// Visible = !Footprint.Any(isVisibleTest);
 			Visible = true;
 			foreach (var uv in Footprint)
+			{
 				if (isVisibleTest(uv))
 				{
 					Visible = false;
 					break;
 				}
+			}
 
 			if (Visible && !wasVisible)
 				NeedRenderables = true;

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Traits
 			var limit = radius.RangeSquared;
 			var pos = map.CenterOfCell(position);
 
-			foreach (var cell in map.FindTilesInCircle(position, r))
+			foreach (var cell in map.FindTilesInCircle(position, r, true))
 				if ((map.CenterOfCell(cell) - pos).HorizontalLengthSquared <= limit)
 					yield return cell;
 		}
@@ -129,6 +129,11 @@ namespace OpenRA.Traits
 			foreach (var c in visible)
 			{
 				var uv = c.ToMPos(map);
+
+				// Force cells outside the visible bounds invisible
+				if (!map.Contains(uv))
+					continue;
+
 				visibleCount[uv]++;
 				explored[uv] = true;
 			}
@@ -147,7 +152,11 @@ namespace OpenRA.Traits
 				return;
 
 			foreach (var c in visible)
-				visibleCount[c.ToMPos(map)]--;
+			{
+				// Cells outside the visible bounds don't increment visibleCount
+				if (map.Contains(c))
+					visibleCount[c.ToMPos(map)]--;
+			}
 
 			visibility.Remove(a);
 			Invalidate(visible);

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -325,6 +325,11 @@ namespace OpenRA.Traits
 			return explored[uv] && (generatedShroudCount[uv] == 0 || visibleCount[uv] > 0);
 		}
 
+		/// <summary>
+		/// Returns a fast exploration lookup that skips the usual validation.
+		/// The return value should not be cached across ticks, and should not
+		/// be called with cells outside the map bounds.
+		/// </summary>
 		public Func<MPos, bool> IsExploredTest
 		{
 			get
@@ -371,6 +376,11 @@ namespace OpenRA.Traits
 			return visibleCount[uv] > 0;
 		}
 
+		/// <summary>
+		/// Returns a fast visibility lookup that skips the usual validation.
+		/// The return value should not be cached across ticks, and should not
+		/// be called with cells outside the map bounds.
+		/// </summary>
 		public Func<MPos, bool> IsVisibleTest
 		{
 			get

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -73,27 +73,37 @@ namespace OpenRA
 		public bool FogObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(a); }
 		public bool FogObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(p); }
 		public bool FogObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(pos); }
+		public bool FogObscures(MPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(uv); }
+
 		public bool ShroudObscures(Actor a) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(a); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
 		public bool ShroudObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(pos); }
 		public bool ShroudObscures(MPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
 
-		public Func<MPos, bool> FogObscuresTest(CellRegion region)
+		public Func<MPos, bool> FogObscuresTest
 		{
-			var rp = RenderPlayer;
-			if (rp == null)
-				return FalsePredicate;
-			var predicate = rp.Shroud.IsVisibleTest(region);
-			return uv => !predicate(uv);
+			get
+			{
+				var rp = RenderPlayer;
+				if (rp == null)
+					return FalsePredicate;
+
+				var predicate = rp.Shroud.IsVisibleTest;
+				return uv => !predicate(uv);
+			}
 		}
 
-		public Func<MPos, bool> ShroudObscuresTest(CellRegion region)
+		public Func<MPos, bool> ShroudObscuresTest
 		{
-			var rp = RenderPlayer;
-			if (rp == null)
-				return FalsePredicate;
-			var predicate = rp.Shroud.IsExploredTest(region);
-			return uv => !predicate(uv);
+			get
+			{
+				var rp = RenderPlayer;
+				if (rp == null)
+					return FalsePredicate;
+
+				var predicate = rp.Shroud.IsExploredTest;
+				return uv => !predicate(uv);
+			}
 		}
 
 		public bool IsReplay

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -30,7 +30,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly bool startsRevealed;
 		readonly MPos[] footprint;
-		readonly CellRegion footprintRegion;
 
 		readonly Lazy<IToolTip> tooltip;
 		readonly Lazy<Health> health;
@@ -46,7 +45,6 @@ namespace OpenRA.Mods.Common.Traits
 			startsRevealed = info.StartsRevealed && !init.Contains<ParentActorInit>();
 			var footprintCells = FootprintUtils.Tiles(init.Self).ToList();
 			footprint = footprintCells.Select(cell => cell.ToMPos(init.World.Map)).ToArray();
-			footprintRegion = CellRegion.BoundingRegion(init.World.Map.TileShape, footprintCells);
 			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<IToolTip>().FirstOrDefault());
 			health = Exts.Lazy(() => init.Self.TraitOrDefault<Health>());
 
@@ -71,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 				FrozenActor frozenActor;
 				if (!initialized)
 				{
-					frozen[player] = frozenActor = new FrozenActor(self, footprint, footprintRegion, player.Shroud);
+					frozen[player] = frozenActor = new FrozenActor(self, footprint, player.Shroud);
 					frozen[player].NeedRenderables = frozenActor.NeedRenderables = startsRevealed;
 					player.PlayerActor.Trait<FrozenActorLayer>().Add(frozenActor);
 					isVisible = visible[player] |= startsRevealed;

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			Dirty.Clear();
 
-			foreach (var uv in wr.Viewport.VisibleCellsInsideBounds.MapCoords)
+			foreach (var uv in wr.Viewport.AllVisibleCells.MapCoords)
 			{
 				var t = Tiles[uv];
 				if (t.Sprite != null)

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			Dirty.Clear();
 
-			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
+			foreach (var uv in wr.Viewport.VisibleCellsInsideBounds.MapCoords)
 			{
 				var t = Tiles[uv];
 				if (t.Sprite != null)

--- a/OpenRA.Mods.Common/Traits/World/PathfinderDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathfinderDebugOverlay.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 				var layer = pair.Value;
 
 				// Only render quads in viewing range:
-				foreach (var cell in wr.Viewport.VisibleCells)
+				foreach (var cell in wr.Viewport.VisibleCellsInsideBounds)
 				{
 					if (layer[cell] <= 0)
 						continue;

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Render(WorldRenderer wr)
 		{
 			var shroudObscured = world.ShroudObscuresTest;
-			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
+			foreach (var uv in wr.Viewport.VisibleCellsInsideBounds.MapCoords)
 			{
 				if (shroudObscured(uv))
 					continue;

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Render(WorldRenderer wr)
 		{
-			var shroudObscured = world.ShroudObscuresTest(wr.Viewport.VisibleCells);
+			var shroudObscured = world.ShroudObscuresTest;
 			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
 			{
 				if (shroudObscured(uv))

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -189,8 +189,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (fogSprites.Any(s => s.BlendMode != fogBlend))
 				throw new InvalidDataException("Fog sprites must all use the same blend mode.");
 
-			shroudLayer = new TerrainSpriteLayer(w, wr, shroudSheet, shroudBlend, wr.Palette(info.ShroudPalette));
-			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, wr.Palette(info.FogPalette));
+			shroudLayer = new TerrainSpriteLayer(w, wr, shroudSheet, shroudBlend, wr.Palette(info.ShroudPalette), false);
+			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, wr.Palette(info.FogPalette), false);
 		}
 
 		Edges GetEdges(MPos uv, Func<MPos, bool> isVisible)

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var kv in tiles)
 			{
-				if (!wr.Viewport.VisibleCells.Contains(kv.Key))
+				if (!wr.Viewport.VisibleCellsInsideBounds.Contains(kv.Key))
 					continue;
 
 				if (world.ShroudObscures(kv.Key))

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			var colors = wr.World.TileSet.HeightDebugColors;
 			var mouseCell = wr.Viewport.ViewToWorld(Viewport.LastMousePos).ToMPos(wr.World.Map);
 
-			foreach (var uv in wr.Viewport.VisibleCells.MapCoords)
+			foreach (var uv in wr.Viewport.VisibleCellsInsideBounds.MapCoords)
 			{
 				var height = (int)map.MapHeight.Value[uv];
 				var tile = map.MapTiles.Value[uv];

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -122,6 +122,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void UpdateShroudCell(CPos cell)
 		{
+			if (!world.Map.Contains(cell))
+				return;
+
 			var stride = radarSheet.Size.Width;
 			var uv = cell.ToMPos(world.Map);
 			var dx = shroudSprite.Bounds.Left - world.Map.Bounds.Left;

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			foreach (var kv in tiles)
 			{
-				if (!wr.Viewport.VisibleCells.Contains(kv.Key))
+				if (!wr.Viewport.VisibleCellsInsideBounds.Contains(kv.Key))
 					continue;
 
 				if (wr.World.ShroudObscures(kv.Key))


### PR DESCRIPTION
The next step towards heightmap-aware shroud and scripted map bound changes.  This removes the region tests by making _all_ cases use the fast path.

This is possible because of two changes:
1. Coordinates are pre-filtered to ensure they are inside the map area (note: this includes the cordon outside the current map bounds).
2. When updating the current visibility any cells outside the current bounds are forced to be hidden.
