### PR TITLE
Move more shroud logic to RevealsShroud / GeneratesShroud

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -169,7 +169,6 @@
     <Compile Include="Sync.cs" />
     <Compile Include="TraitDictionary.cs" />
     <Compile Include="Traits\Armor.cs" />
-    <Compile Include="Traits\CreatesShroud.cs" />
     <Compile Include="Traits\DrawLineToTarget.cs" />
     <Compile Include="Traits\EditorTilesetFilter.cs" />
     <Compile Include="Traits\Health.cs" />
@@ -177,7 +176,6 @@
     <Compile Include="Traits\RejectsOrders.cs" />
     <Compile Include="Traits\Player\DeveloperMode.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
-    <Compile Include="Traits\RevealsShroud.cs" />
     <Compile Include="Traits\Selectable.cs" />
     <Compile Include="Traits\Target.cs" />
     <Compile Include="Traits\TraitsInterfaces.cs" />

--- a/OpenRA.Game/Traits/CreatesShroud.cs
+++ b/OpenRA.Game/Traits/CreatesShroud.cs
@@ -32,6 +32,13 @@ namespace OpenRA.Traits
 			lobbyShroudFogDisabled = !self.World.LobbyInfo.GlobalSettings.Shroud && !self.World.LobbyInfo.GlobalSettings.Fog;
 		}
 
+		CPos[] ShroudedTiles(Actor self)
+		{
+			return Shroud.GetVisOrigins(self)
+				.SelectMany(o => Shroud.FindVisibleTiles(self.World, o, Range))
+				.Distinct().ToArray();
+		}
+
 		public void Tick(Actor self)
 		{
 			if (lobbyShroudFogDisabled)
@@ -43,20 +50,20 @@ namespace OpenRA.Traits
 				cachedLocation = self.Location;
 				cachedDisabled = disabled;
 
-				CPos[] shrouded = null;
+				var shrouded = ShroudedTiles(self);
 				foreach (var p in self.World.Players)
 				{
 					p.Shroud.RemoveShroudGeneration(self);
-					p.Shroud.AddShroudGeneration(self, ref shrouded);
+					p.Shroud.AddShroudGeneration(self, shrouded);
 				}
 			}
 		}
 
 		public void AddedToWorld(Actor self)
 		{
-			CPos[] shrouded = null;
+			var shrouded = ShroudedTiles(self);
 			foreach (var p in self.World.Players)
-				p.Shroud.AddShroudGeneration(self, ref shrouded);
+				p.Shroud.AddShroudGeneration(self, shrouded);
 		}
 
 		public void RemovedFromWorld(Actor self)

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -31,6 +31,13 @@ namespace OpenRA.Traits
 			lobbyShroudFogDisabled = !self.World.LobbyInfo.GlobalSettings.Shroud && !self.World.LobbyInfo.GlobalSettings.Fog;
 		}
 
+		CPos[] VisibleTiles(Actor self)
+		{
+			return Shroud.GetVisOrigins(self)
+				.SelectMany(o => Shroud.FindVisibleTiles(self.World, o, Range))
+				.Distinct().ToArray();
+		}
+
 		public void Tick(Actor self)
 		{
 			if (lobbyShroudFogDisabled)
@@ -40,20 +47,20 @@ namespace OpenRA.Traits
 			{
 				cachedLocation = self.Location;
 
-				CPos[] visible = null;
+				var visible = VisibleTiles(self);
 				foreach (var p in self.World.Players)
 				{
 					p.Shroud.RemoveVisibility(self);
-					p.Shroud.AddVisibility(self, ref visible);
+					p.Shroud.AddVisibility(self, visible);
 				}
 			}
 		}
 
 		public void AddedToWorld(Actor self)
 		{
-			CPos[] visible = null;
+			var visible = VisibleTiles(self);
 			foreach (var p in self.World.Players)
-				p.Shroud.AddVisibility(self, ref visible);
+				p.Shroud.AddVisibility(self, visible);
 		}
 
 		public void RemovedFromWorld(Actor self)

--- a/OpenRA.Game/Traits/RevealsShroud.cs
+++ b/OpenRA.Game/Traits/RevealsShroud.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Traits
 		public object Create(ActorInitializer init) { return new RevealsShroud(init.Self, this); }
 	}
 
-	public class RevealsShroud : ITick, ISync
+	public class RevealsShroud : ITick, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		readonly RevealsShroudInfo info;
 		readonly bool lobbyShroudFogDisabled;
@@ -39,8 +39,27 @@ namespace OpenRA.Traits
 			if (cachedLocation != self.Location)
 			{
 				cachedLocation = self.Location;
-				Shroud.UpdateVisibility(self.World.Players.Select(p => p.Shroud), self);
+
+				CPos[] visible = null;
+				foreach (var p in self.World.Players)
+				{
+					p.Shroud.RemoveVisibility(self);
+					p.Shroud.AddVisibility(self, ref visible);
+				}
 			}
+		}
+
+		public void AddedToWorld(Actor self)
+		{
+			CPos[] visible = null;
+			foreach (var p in self.World.Players)
+				p.Shroud.AddVisibility(self, ref visible);
+		}
+
+		public void RemovedFromWorld(Actor self)
+		{
+			foreach (var p in self.World.Players)
+				p.Shroud.RemoveVisibility(self);
 		}
 
 		public WRange Range { get { return info.Range; } }

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -681,6 +681,8 @@
     <Compile Include="Traits\Modifiers\HiddenUnderShroud.cs" />
     <Compile Include="Lint\CheckDefaultVisibility.cs" />
     <Compile Include="Traits\Modifiers\AlwaysVisible.cs" />
+    <Compile Include="Traits\CreatesShroud.cs" />
+    <Compile Include="Traits\RevealsShroud.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -46,12 +46,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		CPos[] Cells(Actor self)
 		{
+			var map = self.World.Map;
 			var range = Range;
 			if (range == WRange.Zero)
 				return NoCells;
 
 			return Shroud.GetVisOrigins(self)
-				.SelectMany(o => Shroud.FindVisibleTiles(self.World, o, range))
+				.SelectMany(c => Shroud.CellsInRange(map, c, range))
 				.Distinct().ToArray();
 		}
 


### PR DESCRIPTION
This moves the last of the actor-specific visibility code from `Shroud` on to the actors themselves.  It is an ugly set of changes with no visible in-game effects, but sets the scene for future PRs that will introduce new features.  Depends on #8474, #8477.
- `Shroud` is now (if we ignore the fragile alliances workaround) focused on a much narrower scope of shroud queries.  Logic related to working out the shroud revealing/generation area now lives in `RevealsShroud`/`GeneratesShroud` and logic related to determining actor visibility is in `IDefaultVisibility` implementations (from #8477).
- This prepares for (but stops short of) splitting `GetVisOrigins` into separate logic for "cells I reveal from" and "cells that reveal me" (needed for heightmap shroud and faithful D2K shroud revealing).
- This prepares for (but stops short of) adding support for non-actor and non-circular shroud reveal sources (#5061, #7916, etc)
- This takes us yet another step towards heightmap-aware shroud.
