### PR TITLE
Fixes regression with selection classes

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Primitives\MergedStream.cs" />
     <Compile Include="Primitives\SpatiallyPartitioned.cs" />
     <Compile Include="Primitives\ConcurrentCache.cs" />
+    <Compile Include="SelectableExts.cs" />
     <Compile Include="Selection.cs" />
     <Compile Include="Server\Connection.cs" />
     <Compile Include="Server\Exts.cs" />

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -162,23 +162,4 @@ namespace OpenRA.Orders
 			}
 		}
 	}
-
-	public static class SelectableExts
-	{
-		public static int SelectionPriority(this ActorInfo a)
-		{
-			var selectableInfo = a.Traits.GetOrDefault<SelectableInfo>();
-			return selectableInfo != null ? selectableInfo.Priority : int.MinValue;
-		}
-
-		public static Actor WithHighestSelectionPriority(this IEnumerable<Actor> actors)
-		{
-			return actors.MaxByOrDefault(a => a.Info.SelectionPriority());
-		}
-
-		public static FrozenActor WithHighestSelectionPriority(this IEnumerable<FrozenActor> actors)
-		{
-			return actors.MaxByOrDefault(a => a.Info.SelectionPriority());
-		}
-	}
 }

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -1,0 +1,67 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Traits
+{
+	public static class SelectableExts
+	{
+		public static int SelectionPriority(this ActorInfo a)
+		{
+			var selectableInfo = a.Traits.GetOrDefault<SelectableInfo>();
+			return selectableInfo != null ? selectableInfo.Priority : int.MinValue;
+		}
+
+		const int PriorityRange = 30;
+
+		public static int SelectionPriority(this Actor a)
+		{
+			var basePriority = a.Info.Traits.Get<SelectableInfo>().Priority;
+			var lp = a.World.LocalPlayer;
+
+			if (a.Owner == lp || lp == null)
+				return basePriority;
+
+			switch (lp.Stances[a.Owner])
+			{
+				case Stance.Ally: return basePriority - PriorityRange;
+				case Stance.Neutral: return basePriority - 2 * PriorityRange;
+				case Stance.Enemy: return basePriority - 3 * PriorityRange;
+
+				default:
+					throw new InvalidOperationException();
+			}
+		}
+
+		public static Actor WithHighestSelectionPriority(this IEnumerable<Actor> actors)
+		{
+			return actors.MaxByOrDefault(a => a.Info.SelectionPriority());
+		}
+
+		public static FrozenActor WithHighestSelectionPriority(this IEnumerable<FrozenActor> actors)
+		{
+			return actors.MaxByOrDefault(a => a.Info.SelectionPriority());
+		}
+
+		static readonly Actor[] NoActors = { };
+
+		public static IEnumerable<Actor> SubsetWithHighestSelectionPriority(this IEnumerable<Actor> actors)
+		{
+			return actors.GroupBy(x => x.SelectionPriority())
+				.OrderByDescending(g => g.Key)
+				.Select(g => g.AsEnumerable())
+				.DefaultIfEmpty(NoActors)
+				.FirstOrDefault();
+		}
+	}
+}


### PR DESCRIPTION
Fixes regression from #8212, as @Phrohdoh remarked:
Select all units on screen should use selection priorities to determine who actually gets selected. I have falsely understood the function of this command to be selecting all units that belong to the current player no matter the selection priorities.
