### PR TITLE
Fixed infantry prone sequences

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -48,16 +48,16 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithInfantryBody : UpgradableTrait<WithInfantryBodyInfo>, ITick, INotifyAttack, INotifyIdle
+	public class WithInfantryBody : UpgradableTrait<WithInfantryBodyInfo>, ITick, INotifyAttack, INotifyIdle, INotifyCreated
 	{
 		readonly IMove move;
-		readonly IRenderInfantrySequenceModifier rsm;
 		protected readonly Animation DefaultAnimation;
 
 		bool dirty;
 		string idleSequence;
 		int idleDelay;
 		AnimationState state;
+		IRenderInfantrySequenceModifier rsm;
 
 		bool IsModifyingSequence { get { return rsm != null && rsm.IsModifyingSequence; } }
 		bool wasModifying;
@@ -74,7 +74,11 @@ namespace OpenRA.Mods.Common.Traits
 			DefaultAnimation.PlayFetchIndex(NormalizeInfantrySequence(init.Self, info.StandSequences.Random(Game.CosmeticRandom)), () => 0);
 			state = AnimationState.Waiting;
 			move = init.Self.Trait<IMove>();
-			rsm = init.Self.TraitOrDefault<IRenderInfantrySequenceModifier>();
+		}
+
+		public void Created(Actor self)
+		{
+			rsm = self.TraitOrDefault<IRenderInfantrySequenceModifier>();
 		}
 
 		protected virtual string NormalizeInfantrySequence(Actor self, string baseSequence)

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -73,7 +73,11 @@ e1:
 		Facings: 8
 	prone-stand:
 		Start: 144
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 144
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 144
@@ -181,7 +185,11 @@ e2:
 		Facings: 8
 	prone-stand:
 		Start: 240
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 240
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 240
@@ -270,7 +278,11 @@ e3:
 		Facings: 8
 	prone-stand:
 		Start: 144
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 144
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 144
@@ -359,7 +371,11 @@ e4:
 		Facings: 8
 	prone-stand:
 		Start: 208
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 208
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 208
@@ -472,7 +488,11 @@ e5:
 		Facings: 8
 	prone-stand:
 		Start: 208
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 208
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 208
@@ -581,7 +601,11 @@ e6:
 		Facings: 8
 	prone-stand:
 		Start: 82
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 82
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 82
@@ -666,7 +690,11 @@ rmbo:
 		Facings: 8
 	prone-stand:
 		Start: 112
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 112
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 112

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -15,7 +15,6 @@ rifle:
 	Armament:
 		Weapon: LMG
 	AttackFrontal:
-	TakeCover:
 	WithInfantryBody:
 		AttackSequence: shoot
 	AttractsWorms:
@@ -39,8 +38,6 @@ engineer:
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
-	TakeCover:
-	WithInfantryBody:
 	ExternalCaptures:
 		Type: building
 	Captures:
@@ -70,7 +67,6 @@ bazooka:
 		Weapon: Bazooka
 		LocalOffset: 0,0,555
 	AttackFrontal:
-	TakeCover:
 	WithInfantryBody:
 		AttackSequence: shoot
 	AttractsWorms:
@@ -97,7 +93,6 @@ medic:
 	AttackMedic:
 		Cursor: ability
 		OutsideRangeCursor: ability
-	TakeCover:
 	WithInfantryBody:
 		AttackSequence: heal
 	Passenger:
@@ -133,7 +128,6 @@ fremen:
 	Armament@SECONDARY:
 		Weapon: Slung
 	AttackFrontal:
-	TakeCover:
 	WithInfantryBody:
 		AttackSequence: shoot
 	Cloak:
@@ -165,7 +159,6 @@ grenadier:
 		LocalOffset: 0,0,555
 		FireDelay: 15
 	AttackFrontal:
-	TakeCover:
 	WithInfantryBody:
 		AttackSequence: throw
 		IdleSequences: idle
@@ -192,7 +185,6 @@ sardaukar:
 		Speed: 42
 	RevealsShroud:
 		Range: 6c0
-	TakeCover:
 	WithInfantryBody:
 		AttackSequence: shoot
 	Armament@PRIMARY:
@@ -222,8 +214,6 @@ saboteur:
 		Speed: 64
 	RevealsShroud:
 		Range: 7c0
-	TakeCover:
-	WithInfantryBody:
 	C4Demolition:
 		C4Delay: 45
 	-AutoTarget:

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -15,7 +15,7 @@ rifle:
 		Facings: -8
 		Transpose: true
 	prone-stand: DATA.R8
-		Start: 302
+		Start: 310
 		Facings: -8
 		Transpose: true
 	prone-run: DATA.R8

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -18,7 +18,11 @@ e1:
 		Facings: 8
 	prone-stand:
 		Start: 144
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 144
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 144
@@ -95,7 +99,11 @@ sniper:
 		Length: 16
 	prone-stand:
 		Start: 208
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 208
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 208
@@ -207,7 +215,11 @@ e3:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 144
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 144
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 144
@@ -270,7 +282,11 @@ e6:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 82
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 82
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 82
@@ -281,8 +297,6 @@ e6:
 
 medi:
 	stand:
-		Facings: 8
-	stand2:
 		Facings: 8
 	run:
 		Start: 8
@@ -336,7 +350,7 @@ medi:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 130
-		Length: 4
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 130
@@ -347,8 +361,6 @@ medi:
 		
 mech:
 	stand:
-		Facings: 8
-	stand2:
 		Facings: 8
 	run:
 		Start: 8
@@ -402,7 +414,7 @@ mech:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 130
-		Length: 4
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 130
@@ -464,8 +476,12 @@ e2:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	prone-stand:
-		Start: 240
-		Length: 4
+		Start: 144
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 144
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 240
@@ -480,8 +496,6 @@ e2:
 
 dog:
 	stand:
-		Facings: 8
-	stand2:
 		Facings: 8
 	run:
 		Start: 8
@@ -580,7 +594,11 @@ spy:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 144
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 144
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 144
@@ -595,8 +613,6 @@ spy:
 
 thf:
 	stand:
-		Facings: 8
-	stand2:
 		Facings: 8
 	run:
 		Start: 8
@@ -634,7 +650,7 @@ thf:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 72
-		Length: 4
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 72
@@ -645,8 +661,6 @@ thf:
 
 hijacker:
 	stand: thf
-		Facings: 8
-	stand2: thf
 		Facings: 8
 	run: thf
 		Start: 8
@@ -684,7 +698,7 @@ hijacker:
 			INTERIOR: TEMPERAT
 	prone-stand: thf
 		Start: 72
-		Length: 4
+		Stride: 4
 		Facings: 8
 	prone-run: thf
 		Start: 72
@@ -695,8 +709,6 @@ hijacker:
 
 e7:
 	stand:
-		Facings: 8
-	stand2:
 		Facings: 8
 	run:
 		Start: 8
@@ -746,7 +758,7 @@ e7:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 128
-		Length: 4
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 128
@@ -817,7 +829,11 @@ e4:
 			INTERIOR: TEMPERAT
 	prone-stand:
 		Start: 208
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 208
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 208
@@ -833,8 +849,6 @@ e4:
 gnrl:
 	stand:
 		Facings: 8
-	stand2:
-		Facings: 8
 	run:
 		Start: 8
 		Length: 5
@@ -846,7 +860,7 @@ gnrl:
 		Facings: 8
 	prone-stand:
 		Start: 88
-		Length: 2
+		Stride: 2
 		Facings: 8
 	prone-run:
 		Start: 104
@@ -914,7 +928,11 @@ shok:
 		Length: 16
 	prone-stand:
 		Start: 208
-		Length: 4
+		Stride: 4
+		Facings: 8
+	prone-stand2:
+		Start: 208
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 208
@@ -971,11 +989,9 @@ shok:
 c1:
 	stand:
 		Facings: 8
-	stand2:
-		Facings: 8
 	panic-stand:
 		Start: 8
-		Length: 6
+		Stride: 6
 		Facings: 8
 	panic-run:
 		Start: 8
@@ -1023,11 +1039,9 @@ c1:
 c2:
 	stand:
 		Facings: 8
-	stand2:
-		Facings: 8
 	panic-stand:
 		Start: 8
-		Length: 6
+		Stride: 6
 		Facings: 8
 	panic-run:
 		Start: 8
@@ -1075,11 +1089,9 @@ c2:
 c3:
 	stand:
 		Facings: 8
-	stand2:
-		Facings: 8
 	panic-stand:
 		Start: 8
-		Length: 6
+		Stride: 6
 		Facings: 8
 	panic-run:
 		Start: 8
@@ -1127,15 +1139,13 @@ c3:
 einstein:
 	stand:
 		Facings: 8
-	stand2:
-		Facings: 8
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
 	panic-stand:
 		Start: 8
-		Length: 6
+		Stride: 6
 		Facings: 8
 	run:
 		Start: 56
@@ -1175,15 +1185,13 @@ einstein:
 delphi:
 	stand:
 		Facings: 8
-	stand2:
-		Facings: 8
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
 	panic-stand:
 		Start: 8
-		Length: 6
+		Stride: 6
 		Facings: 8
 	run:
 		Start: 56
@@ -1223,15 +1231,13 @@ delphi:
 chan:
 	stand:
 		Facings: 8
-	stand2:
-		Facings: 8
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
 	panic-stand:
 		Start: 8
-		Length: 6
+		Stride: 6
 		Facings: 8
 	run:
 		Start: 56


### PR DESCRIPTION
Code fix:
`WithInfantryBody` now populates `rsm` when infantry is created, rather than in the constructor. This fixes override issues between `WithInfantryBody` and traits implementing `IRenderInfantrySequenceModifier` (currently `TakeCover`, `ScaredyCat`, `WithPermanentInjury`).

Yaml fixes:
- removed `stand2` if it was unused and/or a duplicate of `stand`
- fixed `prone-stand` sequences to define `Stride` instead of `Length`
- added `prone-stand2` (copy-paste of `prone-stand`) to all infantry with `stand2`
- fixed d2k rifle infantry `prone-stand` sequence (it was using standup frames)
- removed now redundant duplicate trait definitions from individual d2k infantry types.*

*I did NOT forget about the other mods, but I'm working on a larger yaml cleanup PR that will adress this for the other mods and want to keep rebase conflicts to a minimum.

Closes #8075.
