### PR TITLE
D2K - Fix Barracks Footprint

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -125,7 +125,7 @@ barracks:
 		Name: Barracks
 		Description: Trains infantry
 	Building:
-		Footprint: =x xx
+		Footprint: xx xx
 		Dimensions: 2,2
 	Bib:
 	Health:


### PR DESCRIPTION
Current one loks like only true for Atreides Barracks and looks weird for Harkoonen and Ordos ones.
