### PR TITLE
Dispose of a MemoryStream in PackageEntry

### DIFF
--- a/OpenRA.Game/FileSystem/PackageEntry.cs
+++ b/OpenRA.Game/FileSystem/PackageEntry.cs
@@ -65,14 +65,19 @@ namespace OpenRA.FileSystem
 						if (name.Length % 4 != 0)
 							name = name.PadRight(name.Length + (4 - name.Length % 4), '\0');
 
-						var ms = new MemoryStream(Encoding.ASCII.GetBytes(name));
-						var reader = new BinaryReader(ms);
-
-						var len = name.Length >> 2;
 						uint result = 0;
-
-						while (len-- != 0)
-							result = ((result << 1) | (result >> 31)) + reader.ReadUInt32();
+						var bytes = Encoding.ASCII.GetBytes(name);
+						unsafe
+						{
+							// Cast the data to an int array
+							fixed (byte* bd = &bytes[0])
+							{
+								var data = (uint*)bd;
+								var len = name.Length >> 2;
+								for (var i = 0; i < len; i++)
+									result = ((result << 1) | (result >> 31)) + data[i++];
+							}
+						}
 
 						return result;
 					}


### PR DESCRIPTION
There are probably a couple hundred `MemoryStreams` opened and never disposed of each time a mod loads (later research suggests also when a map is being loaded).
