### PR TITLE
Added support for damage stages to WithSpriteBody and WithTurret

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithSpriteBody : UpgradableTrait<WithSpriteBodyInfo>, ISpriteBody
+	public class WithSpriteBody : UpgradableTrait<WithSpriteBodyInfo>, ISpriteBody, INotifyDamageStateChanged
 	{
 		public readonly Animation DefaultAnimation;
 
@@ -93,6 +93,12 @@ namespace OpenRA.Mods.Common.Traits
 				if (after != null)
 					after();
 			});
+		}
+
+		public virtual void DamageStateChanged(Actor self, AttackInfo e)
+		{
+			if (DefaultAnimation.CurrentSequence != null)
+				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
 		}
 	}
 }


### PR DESCRIPTION
Allows visible damage stages on non-building sprite actors and turrets.
