### PR TITLE
Save maps with the correct MapClassification.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -70,10 +70,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				Action<string> afterSave = uid =>
 				{
-					ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
-						Game.CreateLocalServer(uid), "",
-						() => Game.LoadEditor(uid),
-						() => { Game.CloseServer(); onExit(); });
+					// HACK: Work around a synced-code change check.
+					// It's not clear why this is needed here, but not in the other places that load maps.
+					Game.RunAfterTick(() =>
+					{
+						ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
+							Game.CreateLocalServer(uid), "",
+							() => Game.LoadEditor(uid),
+							() => { Game.CloseServer(); onExit(); });
+					});
 
 					Ui.CloseWindow();
 					onSelect(uid);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return item;
 				};
 
-				typeDropdown.Text = Path.GetExtension(map.Path);
+				typeDropdown.Text = map.Path != null ? Path.GetExtension(map.Path) : ".oramap";
 				if (string.IsNullOrEmpty(typeDropdown.Text))
 					typeDropdown.Text = fileTypes.First(t => t.Value == "").Key;
 
@@ -137,7 +137,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var combinedPath = Platform.ResolvePath(Path.Combine(directoryDropdown.Text, filename.Text + fileTypes[typeDropdown.Text]));
 
 				// Invalidate the old map metadata
-				Game.ModData.MapCache[map.Uid].Invalidate();
+				if (map.Uid != null)
+					Game.ModData.MapCache[map.Uid].Invalidate();
 
 				map.Save(combinedPath);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var combinedPath = Platform.ResolvePath(Path.Combine(directoryDropdown.Text, filename.Text + fileTypes[typeDropdown.Text]));
 
 				// Invalidate the old map metadata
-				if (map.Uid != null)
+				if (map.Uid != null && combinedPath == map.Path)
 					Game.ModData.MapCache[map.Uid].Invalidate();
 
 				map.Save(combinedPath);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -130,7 +130,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				map.RequiresMod = Game.ModData.Manifest.Mod.Id;
 
 				var combinedPath = Platform.ResolvePath(Path.Combine(directoryDropdown.Text, filename.Text + fileTypes[typeDropdown.Text]));
+
+				// Invalidate the old map metadata
+				Game.ModData.MapCache[map.Uid].Invalidate();
+
 				map.Save(combinedPath);
+
+				// Reload map to calculate new UID
+				map = new Map(combinedPath);
 
 				// Update the map cache so it can be loaded without restarting the game
 				var classification = mapDirectories[directoryDropdown.Text];

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SaveMapLogic
 	{
 		[ObjectCreator.UseCtor]
-		public SaveMapLogic(Widget widget, Action onExit, Map map, EditorActorLayer editorActorLayer)
+		public SaveMapLogic(Widget widget, Action<string> onSave, Action onExit, Map map, List<MiniYamlNode> playerDefinitions, List<MiniYamlNode> actorDefinitions)
 		{
 			var title = widget.Get<TextFieldWidget>("TITLE");
 			title.Text = map.Title;
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return item;
 				};
 
-				var mapDirectory = Platform.UnresolvePath(Path.GetDirectoryName(map.Path));
+				var mapDirectory = map.Path != null ? Platform.UnresolvePath(Path.GetDirectoryName(map.Path)) : null;
 				var initialDirectory = mapDirectories.Keys.FirstOrDefault(f => f == mapDirectory);
 
 				if (initialDirectory == null)
@@ -125,8 +125,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				map.Description = description.Text;
 				map.Author = author.Text;
 				map.Visibility = (MapVisibility)Enum.Parse(typeof(MapVisibility), visibilityDropdown.Text);
-				map.ActorDefinitions = editorActorLayer.Save();
-				map.PlayerDefinitions = editorActorLayer.Players.ToMiniYaml();
+
+				if (actorDefinitions != null)
+					map.ActorDefinitions = actorDefinitions;
+
+				if (playerDefinitions != null)
+					map.PlayerDefinitions = playerDefinitions;
+
 				map.RequiresMod = Game.ModData.Manifest.Mod.Id;
 
 				var combinedPath = Platform.ResolvePath(Path.Combine(directoryDropdown.Text, filename.Text + fileTypes[typeDropdown.Text]));
@@ -145,7 +150,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				Console.WriteLine("Saved current map at {0}", combinedPath);
 				Ui.CloseWindow();
-				onExit();
+
+				onSave(map.Uid);
 			};
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -50,17 +50,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					visibilityDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, mapVisibility, setupItem);
 			}
 
+			Func<string, string> makeMapDirectory = dir =>
+			{
+				var f = Platform.UnresolvePath(dir);
+				if (f.StartsWith("~"))
+					f = f.Substring(1);
+
+				return f;
+			};
+
+			var mapDirectories = Game.ModData.Manifest.MapFolders
+				.ToDictionary(kv => makeMapDirectory(kv.Key), kv => Enum<MapClassification>.Parse(kv.Value));
+
 			var directoryDropdown = widget.Get<DropDownButtonWidget>("DIRECTORY_DROPDOWN");
 			{
-				var mapDirectories = Game.ModData.Manifest.MapFolders.Keys.Select(ff =>
-				{
-					var f = Platform.UnresolvePath(ff);
-					if (f.StartsWith("~"))
-						f = f.Substring(1);
-
-					return f;
-				}).ToList();
-
 				Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
 				{
 					var item = ScrollItemWidget.Setup(template,
@@ -71,14 +74,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var mapDirectory = Platform.UnresolvePath(Path.GetDirectoryName(map.Path));
-				var initialDirectory = mapDirectories.FirstOrDefault(f => f == mapDirectory);
+				var initialDirectory = mapDirectories.Keys.FirstOrDefault(f => f == mapDirectory);
 
 				if (initialDirectory == null)
-					initialDirectory = mapDirectories.First();
+					initialDirectory = mapDirectories.Keys.First();
 
 				directoryDropdown.Text = initialDirectory;
 				directoryDropdown.OnClick = () =>
-					directoryDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, mapDirectories, setupItem);
+					directoryDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, mapDirectories.Keys, setupItem);
 			}
 
 			var filename = widget.Get<TextFieldWidget>("FILENAME");
@@ -130,7 +133,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				map.Save(combinedPath);
 
 				// Update the map cache so it can be loaded without restarting the game
-				Game.ModData.MapCache[map.Uid].UpdateFromMap(map, MapClassification.User);
+				var classification = mapDirectories[directoryDropdown.Text];
+				Game.ModData.MapCache[map.Uid].UpdateFromMap(map, classification);
 
 				Console.WriteLine("Saved current map at {0}", combinedPath);
 				Ui.CloseWindow();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -102,11 +102,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			saveMapButton.OnClick = () =>
 			{
 				hideMenu = true;
+				var editorActorLayer = world.WorldActor.Trait<EditorActorLayer>();
 				Ui.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
 				{
+					{ "onSave", (Action<string>)(_ => hideMenu = false) },
 					{ "onExit", () => hideMenu = false },
 					{ "map", world.Map },
-					{ "editorActorLayer", world.WorldActor.Trait<EditorActorLayer>() }
+					{ "playerDefinitions", editorActorLayer.Players.ToMiniYaml() },
+					{ "actorDefinitions", editorActorLayer.Save() }
 				});
 			};
 


### PR DESCRIPTION
This fixes system maps being moved to the custom maps tab after you save them.
