### PR TITLE
Fixed a desync when creating a new map on a tileset that differs from the shellmap

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -82,12 +82,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var newMap = new Map(tempLocation);
 				Game.ModData.MapCache[newMap.Uid].UpdateFromMap(newMap, MapClassification.User);
 
-				ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
-					Game.CreateLocalServer(newMap.Uid),
-					"",
-					() => { Game.LoadEditor(newMap.Uid); },
-					() => { Game.CloseServer(); onExit(); });
-				onSelect(newMap.Uid);
+				Game.RunAfterTick(() =>
+				{
+					ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
+						Game.CreateLocalServer(newMap.Uid),
+						"",
+						() => { Game.LoadEditor(newMap.Uid); },
+						() => { Game.CloseServer(); onExit(); });
+						onSelect(newMap.Uid);
+				});
 			};
 		}
 	}


### PR DESCRIPTION
To reproduce:
- Settings - Advanced: Check Sync around unsynced code.
- Create a new SNOW map in the Tiberian Sun mod.

Fix was inspired by https://github.com/OpenRA/OpenRA/pull/8502.
