### PR TITLE
Remove "Enemy Unit Detected" announcements

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -63,8 +63,6 @@
 	UpgradeManager:
 	TemporaryOwnerManager:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsDetected
 	Voiced:
 		VoiceSet: VehicleVoice
 	Carryable:
@@ -119,8 +117,6 @@
 	UpgradeManager:
 	TemporaryOwnerManager:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsDetected
 	Voiced:
 		VoiceSet: VehicleVoice
 	Carryable:
@@ -259,8 +255,6 @@
 		FallRate: 130
 	UpgradeManager:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsDetected
 	TerrainModifiesDamage:
 		TerrainModifier:
 			Rough: 80
@@ -292,8 +286,6 @@
 	AttackMove:
 	ScriptTriggers:
 	UpgradeManager:
-	AnnounceOnSeen:
-		Notification: EnemyUnitsDetected
 	Voiced:
 		VoiceSet: GenericVoice
 	WithFacingSpriteBody:

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2119,17 +2119,14 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
-		-AnnounceOnSeen:
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
-		-AnnounceOnSeen:
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
-		-AnnounceOnSeen:
 	^Ship:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -33,7 +33,6 @@ BADR:
 	-EjectOnDeath:
 	-GpsDot:
 	RejectsOrders:
-	-AnnounceOnSeen:
 	AutoSelectionSize:
 	RenderSprites:
 
@@ -363,7 +362,6 @@ U2:
 		Offset: -1c43,0,0
 		Interval: 2
 	RejectsOrders:
-	-AnnounceOnSeen:
 	AutoSelectionSize:
 	RenderSprites:
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -91,8 +91,6 @@
 	CaptureNotification:
 		Notification: UnitStolen
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyDetected
 	Voiced:
 		VoiceSet: VehicleVoice
 
@@ -155,8 +153,6 @@
 		GroundCorpsePalette:
 		WaterCorpseSequence:
 		WaterCorpsePalette:
-	AnnounceOnSeen:
-		Notification: EnemyDetected
 	Voiced:
 		VoiceSet: VehicleVoice
 
@@ -244,8 +240,6 @@
 	Cloneable:
 		Types: Infantry
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyDetected
 	Voiced:
 		VoiceSet: GenericVoice
 
@@ -277,8 +271,6 @@
 	Tooltip:
 		GenericName: Ship
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyDetected
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
 	Voiced:
@@ -317,8 +309,6 @@
 		GenericName: Plane
 	WithShadow:
 	MustBeDestroyed:
-	AnnounceOnSeen:
-		Notification: EnemyDetected
 	Voiced:
 		VoiceSet: GenericVoice
 
@@ -329,8 +319,6 @@
 	GpsDot:
 		String: Helicopter
 	Hovers:
-	AnnounceOnSeen:
-		Notification: EnemyDetected
 
 ^Building:
 	Inherits@1: ^ExistsInWorld


### PR DESCRIPTION
By popular demand.  The `EnemyWatcher` removal is deferred to the next playtest.
