### PR TITLE
Introduce new options for shroud visibility and revealing.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -183,21 +183,6 @@ namespace OpenRA.Traits
 			}
 		}
 
-		// TODO: Actor vis will be split into separate cases for
-		// "cells that I reveal from" and "cells that reveal me"
-		public static IEnumerable<CPos> GetVisOrigins(Actor a)
-		{
-			var ios = a.OccupiesSpace;
-			if (ios != null)
-			{
-				var cells = ios.OccupiedCells();
-				if (cells.Any())
-					return cells.Select(c => c.First);
-			}
-
-			return new[] { a.World.Map.CellContaining(a.CenterPosition) };
-		}
-
 		public void Explore(World world, IEnumerable<CPos> cells)
 		{
 			var changed = new HashSet<CPos>();

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Linq;
 using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
@@ -30,6 +31,18 @@ namespace OpenRA.Mods.Common.Lint
 					emitError("Actor type `{0}` does not define a default visibility type!".F(actorInfo.Key));
 				else if (count > 1)
 					emitError("Actor type `{0}` defines multiple default visibility types!".F(actorInfo.Key));
+				else
+				{
+					var vis = actorInfo.Value.Traits.GetOrDefault<HiddenUnderShroudInfo>();
+					if (vis != null && vis.Type == VisibilityType.Footprint)
+					{
+						var ios = actorInfo.Value.Traits.GetOrDefault<IOccupySpaceInfo>();
+						if (ios == null)
+							emitError("Actor type `{0}` defines VisibilityType.Footprint in `{1}` but has no IOccupySpace traits!".F(actorInfo.Key, vis.GetType()));
+						else if (!ios.OccupiedCells(actorInfo.Value, CPos.Zero).Any())
+							emitError("Actor type `{0}` defines VisibilityType.Footprint in `{1}` but does not have any footprint cells!".F(actorInfo.Key, vis.GetType()));
+					}
+				}
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -1,0 +1,42 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckRevealFootprint : ILintPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		{
+			foreach (var actorInfo in map.Rules.Actors)
+			{
+				if (actorInfo.Key.StartsWith("^"))
+					continue;
+
+				var ios = actorInfo.Value.Traits.GetOrDefault<IOccupySpaceInfo>();
+				foreach (var rsi in actorInfo.Value.Traits.WithInterface<RevealsShroudInfo>())
+				{
+					if (rsi.Type == VisibilityType.CenterPosition)
+						continue;
+
+					if (ios == null)
+						emitError("Actor type `{0}` defines VisibilityType.Footprint in `{1}` but has no IOccupySpace traits!".F(actorInfo.Key, rsi.GetType()));
+					else if (!ios.OccupiedCells(actorInfo.Value, CPos.Zero).Any())
+						emitError("Actor type `{0}` defines VisibilityType.Footprint in `{1}`  but does not have any footprint cells!".F(actorInfo.Key, rsi.GetType()));
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -688,6 +688,7 @@
     <Compile Include="Traits\Modifiers\AlwaysVisible.cs" />
     <Compile Include="Traits\CreatesShroud.cs" />
     <Compile Include="Traits\RevealsShroud.cs" />
+    <Compile Include="Lint\CheckRevealFootprint.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
@@ -28,10 +28,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override bool IsVisibleInner(Actor self, Player byPlayer)
 		{
-			if (!VisibilityFootprint(self).Any(byPlayer.Shroud.IsVisible))
-				return false;
+			if (Info.Type == VisibilityType.Footprint)
+				return self.OccupiesSpace.OccupiedCells()
+					.Any(o => byPlayer.Shroud.IsVisible(o.First));
 
-			return base.IsVisibleInner(self, byPlayer);
+			return byPlayer.Shroud.IsVisible(self.CenterPosition);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -18,6 +18,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly WRange Range = WRange.Zero;
 
+		[Desc("Possible values are CenterPosition (measure range from the center) and ",
+			"Footprint (measure range from the footprint)")]
+		public readonly VisibilityType Type = VisibilityType.Footprint;
+
 		public virtual object Create(ActorInitializer init) { return new RevealsShroud(init.Self, this); }
 	}
 
@@ -51,9 +55,13 @@ namespace OpenRA.Mods.Common.Traits
 			if (range == WRange.Zero)
 				return NoCells;
 
-			return Shroud.GetVisOrigins(self)
-				.SelectMany(c => Shroud.CellsInRange(map, c, range))
-				.Distinct().ToArray();
+			if (info.Type == VisibilityType.Footprint)
+				return self.OccupiesSpace.OccupiedCells()
+					.SelectMany(kv => Shroud.CellsInRange(map, kv.First, range))
+						.Distinct().ToArray();
+
+			return Shroud.CellsInRange(map, self.CenterPosition, range)
+				.ToArray();
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1206,6 +1206,21 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// VisibilityType was introduced
+				if (engineVersion < 20150704)
+				{
+					if (depth == 0 && node.Value.Nodes.Exists(n => n.Key == "Helicopter" || n.Key == "Plane" || n.Key == "Immobile"))
+					{
+						var visibility = node.Value.Nodes.FirstOrDefault(n => n.Key == "HiddenUnderShroud" || n.Key == "HiddenUnderFog");
+						if (visibility != null)
+							visibility.Value.Nodes.Add(new MiniYamlNode("Type", "CenterPosition"));
+
+						var reveals = node.Value.Nodes.FirstOrDefault(n => n.Key == "RevealsShroud");
+						if (reveals != null)
+							reveals.Value.Nodes.Add(new MiniYamlNode("Type", "CenterPosition"));
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -22,6 +22,7 @@ TRAN:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	WithRotor@PRIMARY:
 		Offset: -597,0,171
 		Sequence: rotor2
@@ -61,6 +62,7 @@ HELI:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
 		LocalOffset: 128,-213,-85, 128,213,-85
@@ -111,6 +113,7 @@ ORCA:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
 		LocalOffset: 427,-171,-213, 427,171,-213
@@ -155,6 +158,7 @@ C17:
 		Type: Heavy
 	HiddenUnderFog:
 		AlwaysVisibleStances: None
+		Type: CenterPosition
 	Cargo:
 		MaxWeight: 10
 		PipCount: 10
@@ -216,6 +220,7 @@ TRAN.Husk:
 		Speed: 140
 	RevealsShroud:
 		Range: 8c0
+		Type: CenterPosition
 	WithRotor@PRIMARY:
 		Offset: -597,0,171
 	WithRotor@SECONDARY:
@@ -232,6 +237,7 @@ HELI.Husk:
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	WithRotor:
 		Offset: 0,0,85
 	RenderSprites:
@@ -246,6 +252,7 @@ ORCA.Husk:
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: orca
 

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -367,7 +367,7 @@ BRIDGE4:
 		SpawnOffset: 3,2
 
 BRIDGEHUT:
-	HiddenUnderShroud:
+	AlwaysVisible:
 	Building:
 		Footprint: __ __
 		Dimensions: 2,2

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -107,6 +107,7 @@
 		RearmBuildings:
 		LandWhenIdle: false
 	HiddenUnderFog:
+		Type: CenterPosition
 	ActorLostNotification:
 	Explodes:
 		Weapon: HeliExplode
@@ -354,6 +355,7 @@
 	AppearsOnRadar:
 		UseLocation: yes
 	HiddenUnderFog:
+		Type: CenterPosition
 	ActorLostNotification:
 	AttackMove:
 	WithShadow:
@@ -592,6 +594,7 @@
 	Armor:
 		Type: Light
 	HiddenUnderFog:
+		Type: CenterPosition
 	AutoTargetIgnore:
 	BodyOrientation:
 	WithFacingSpriteBody:
@@ -631,7 +634,7 @@
 		GenericName: Destroyed Helicopter
 
 ^Bridge:
-	HiddenUnderShroud:
+	AlwaysVisible:
 	Tooltip:
 		Name: Bridge
 	TargetableBuilding:

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -60,6 +60,7 @@ CAMERA:
 		HP: 1000
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	BodyOrientation:
 
 CAMERA.small:
@@ -70,6 +71,7 @@ CAMERA.small:
 		HP: 1000
 	RevealsShroud:
 		Range: 6c0
+		Type: CenterPosition
 	BodyOrientation:
 
 FLARE:
@@ -77,11 +79,13 @@ FLARE:
 		OccupiesSpace: false
 	RevealsShroud:
 		Range: 3c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: smokland
 	WithSpriteBody:
 		StartSequence: open
 	HiddenUnderFog:
+		Type: CenterPosition
 	Tooltip:
 		Name: Flare
 	BodyOrientation:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -46,6 +46,7 @@ carryall.infantry:
 		Type: Light
 	RevealsShroud:
 		Range: 12c0
+		Type: CenterPosition
 	Plane:
 		ROT: 4
 		Speed: 280
@@ -101,6 +102,7 @@ orni:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	Armament:
 		Weapon: ChainGun
 		LocalOffset: 85,-213,-85

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -93,6 +93,7 @@
 	Armor:
 		Type: Light
 	HiddenUnderFog:
+		Type: CenterPosition
 	Tooltip:
 		Name: Wreck
 	BodyOrientation:
@@ -211,6 +212,7 @@
 	AppearsOnRadar:
 		UseLocation: yes
 	HiddenUnderFog:
+		Type: CenterPosition
 		AlwaysVisibleStances: None
 	ActorLostNotification:
 	AttackMove:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -142,6 +142,7 @@ camera:
 		HP: 1000
 	RevealsShroud:
 		Range: 8c0
+		Type: CenterPosition
 	BodyOrientation:
 
 wormspawner:

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1406,6 +1406,7 @@ Rules:
 			Image: E7
 	PRISON:
 		HiddenUnderShroud:
+			Type: CenterPosition
 		Immobile:
 			OccupiesSpace: false
 		BodyOrientation:

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -1302,6 +1302,7 @@ Rules:
 			Image: E7
 	PRISON:
 		HiddenUnderShroud:
+			Type: CenterPosition
 		Immobile:
 			OccupiesSpace: false
 		BodyOrientation:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -89,6 +89,7 @@ MIG:
 		Type: Light
 	RevealsShroud:
 		Range: 12c0
+		Type: CenterPosition
 	Armament:
 		Weapon: Maverick
 		LocalOffset: 0,-640,0, 0,640,0
@@ -140,6 +141,7 @@ YAK:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
 		LocalOffset: 256,-213,0
@@ -195,6 +197,7 @@ TRAN:
 		Type: Light
 	RevealsShroud:
 		Range: 12c0
+		Type: CenterPosition
 	Helicopter:
 		CruiseAltitude: 1024
 		RearmBuildings: hpad
@@ -234,6 +237,7 @@ HELI:
 		Type: Light
 	RevealsShroud:
 		Range: 12c0
+		Type: CenterPosition
 	Armament@PRIMARY:
 		Weapon: HellfireAA
 		LocalOffset: 0,-213,-85
@@ -280,6 +284,7 @@ HIND:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun
 		LocalOffset: 85,-213,-85

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -484,7 +484,7 @@ SBRIDGE4:
 		SpawnOffset: 2,1
 
 BRIDGEHUT:
-	HiddenUnderShroud:
+	AlwaysVisible:
 	Building:
 		Footprint: __ __
 		Dimensions: 2,2
@@ -495,7 +495,7 @@ BRIDGEHUT:
 		TargetTypes: BridgeHut, C4
 
 BRIDGEHUT.small:
-	HiddenUnderShroud:
+	AlwaysVisible:
 	Building:
 		Footprint: _
 		Dimensions: 1,1

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -303,6 +303,7 @@
 		TargetTypes: Air
 		GroundedTargetTypes: Ground, Repair
 	HiddenUnderFog:
+		Type: CenterPosition
 	AttackMove:
 	Guard:
 	Guardable:
@@ -517,6 +518,7 @@
 	Armor:
 		Type: Heavy
 	HiddenUnderFog:
+		Type: CenterPosition
 	BodyOrientation:
 	AutoTargetIgnore:
 	ScriptTriggers:
@@ -563,7 +565,7 @@
 	FallsToEarth:
 
 ^Bridge:
-	HiddenUnderShroud:
+	AlwaysVisible:
 	Tooltip:
 		Name: Bridge
 	TargetableBuilding:

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -94,6 +94,7 @@ TRAN.Husk:
 		Offset: 597,0,213
 	RevealsShroud:
 		Range: 12c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: tran
 
@@ -146,6 +147,7 @@ MIG.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 12c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: mig
 
@@ -164,6 +166,7 @@ YAK.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: yak
 
@@ -181,6 +184,7 @@ HELI.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 12c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: heli
 
@@ -197,6 +201,7 @@ HIND.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: hind
 

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -1,5 +1,6 @@
 MINP:
 	HiddenUnderShroud:
+		Type: CenterPosition
 	Mine:
 		CrushClasses: mine
 		DetonateClasses: mine
@@ -29,6 +30,7 @@ MINP:
 
 MINV:
 	HiddenUnderShroud:
+		Type: CenterPosition
 	Mine:
 		CrushClasses: mine
 		DetonateClasses: mine
@@ -173,6 +175,7 @@ CAMERA:
 		HP: 1000
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	ProximityCaptor:
 		Types: Camera
 	BodyOrientation:
@@ -189,6 +192,7 @@ camera.paradrop:
 		HP: 1000
 	RevealsShroud:
 		Range: 6c0
+		Type: CenterPosition
 	ProximityCaptor:
 		Types: Camera
 	BodyOrientation:
@@ -201,6 +205,7 @@ SONAR:
 		HP: 1000
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	ProximityCaptor:
 		Types: Sonar
 	BodyOrientation:
@@ -213,11 +218,13 @@ FLARE:
 		OccupiesSpace: false
 	RevealsShroud:
 		Range: 3c0
+		Type: CenterPosition
 	RenderSprites:
 		Image: smokland
 	WithSpriteBody:
 		StartSequence: open
 	HiddenUnderFog:
+		Type: CenterPosition
 	Tooltip:
 		Name: Flare
 		ShowOwnerRow: false

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -16,6 +16,7 @@ DPOD:
 		Type: Light
 	RevealsShroud:
 		Range: 5c0
+		Type: CenterPosition
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
@@ -50,6 +51,7 @@ DSHP:
 		Type: Heavy
 	RevealsShroud:
 		Range: 3c0
+		Type: CenterPosition
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
@@ -80,6 +82,7 @@ ORCA:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	Armament:
 		Weapon: Hellfire
 	AttackHeli:
@@ -118,6 +121,7 @@ ORCAB:
 		Type: Light
 	RevealsShroud:
 		Range: 2c0
+		Type: CenterPosition
 	Armament:
 		Weapon: Bomb
 	AttackPlane:
@@ -152,6 +156,7 @@ ORCATRAN:
 		Type: Light
 	RevealsShroud:
 		Range: 2c0
+		Type: CenterPosition
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
@@ -182,6 +187,7 @@ TRNSPORT:
 		Type: Light
 	RevealsShroud:
 		Range: 2c0
+		Type: CenterPosition
 	RenderSprites:
 	Hovers:
 	Selectable:
@@ -212,6 +218,7 @@ SCRIN:
 		Type: Light
 	RevealsShroud:
 		Range: 2c0
+		Type: CenterPosition
 	Armament:
 		Weapon: Proton
 	AttackPlane:
@@ -249,6 +256,7 @@ APACHE:
 		Type: Light
 	RevealsShroud:
 		Range: 2c0
+		Type: CenterPosition
 	Armament:
 		Weapon: HarpyClaw
 	AttackHeli:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -420,6 +420,7 @@
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:
+		Type: CenterPosition
 	AttackMove:
 		Voice: Move
 	ActorLostNotification:

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -35,6 +35,7 @@ CAMERA:
 		HP: 1000
 	RevealsShroud:
 		Range: 10c0
+		Type: CenterPosition
 	ProximityCaptor:
 		Types: Camera
 	BodyOrientation:


### PR DESCRIPTION
This splits the `GetVisOrigins` query into different configurable options for shroud visibility and revealing.

`HiddenUnderShroud.Type = CenterPosition` will be used in TS to ensure that units are revealed correctly when they are on an odd-height tile (where the shroud tiles are staggered over position tiles, and units would otherwise be revealed if any of the 4 nearby tiles are revealed).  It does not change anything in the classic mods. 

`RevealsShroud.Type = CenterPosition` is used for units that should reveal in a circle around their center instead of from every cell in their footprint.  This is used for aircraft (which don't have any cells in their footprint), and can be used to replicate the original games' building shroud revealing behavior.
