### PR TITLE
Modified actor tooltips to include friendly name and internal name

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -69,8 +69,8 @@ namespace OpenRA.Mods.Common.Traits
 				Footprint = new ReadOnlyDictionary<CPos, SubCell>(footprint);
 			}
 
-			var tooltipInfo = Info.Traits.GetOrDefault<ITooltipInfo>();
-			Tooltip = "{0} ({1})".F(tooltipInfo != null ? tooltipInfo.TooltipForPlayerStance(Stance.None) : Info.Name, ID);
+			var tooltip = Info.Traits.GetOrDefault<TooltipInfo>();
+			Tooltip = tooltip == null ? Info.Name + " - " + ID : tooltip.Name + " (" + Info.Name + ") - " + ID;
 
 			GeneratePreviews();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -135,7 +135,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					item.Bounds.Width = preview.Bounds.Width + 2 * preview.Bounds.X;
 					item.Bounds.Height = preview.Bounds.Height + 2 * preview.Bounds.Y;
 					item.IsVisible = () => true;
-					item.GetTooltipText = () => actor.Name;
+
+					var tooltip = actor.Traits.GetOrDefault<TooltipInfo>();
+					item.GetTooltipText = () => tooltip == null ? actor.Name : tooltip.Name + " (" + actor.Name + ")";
+
 					panel.AddChild(item);
 				}
 				catch


### PR DESCRIPTION
Partially fixes #8267.

Before:
![before](https://cloud.githubusercontent.com/assets/11020536/8341504/0ba2b1ee-1ace-11e5-9e79-dee9b4cbe201.png)

After:
![after](https://cloud.githubusercontent.com/assets/11020536/8341512/134c619c-1ace-11e5-8753-edd1de79e7f8.png)

I can't find the source code where this tooltip is being generated: 

> "Hovering over an actor in the world shows the actor's friendly name in a tooltip (e.g. Allied Tech Center) but not the internal name (e.g. atek)."
