### PR TITLE
Add target validation to GrantUpgrade warheads.

### DIFF
--- a/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
@@ -28,6 +28,10 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public readonly WRange Range = WRange.FromCells(1);
 
+		// TODO: This can be removed after the legacy and redundant 0% = not targetable
+		// assumption has been removed from the yaml definitions
+		public override bool CanTargetActor(ActorInfo victim, Actor firedBy) { return true; }
+
 		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :
@@ -35,6 +39,9 @@ namespace OpenRA.Mods.Common.Warheads
 
 			foreach (var a in actors)
 			{
+				if (!IsValidAgainst(a, firedBy))
+					continue;
+
 				var um = a.TraitOrDefault<UpgradeManager>();
 				if (um == null)
 					continue;

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -84,13 +84,8 @@ EMPulseCannon:
 		Shadow: true
 		Angle: 62
 		Image: pulsball
-	Warhead@2Eff: CreateEffect
+	Warhead@1Eff: CreateEffect
 		Explosion: pulse_explosion
-# Dummy warhead to allow targeting
-	Warhead@target: SpreadDamage
-		Spread: 0
-		Damage: 0
-		ValidTargets: Vehicle
 	Warhead@emp: GrantUpgrade
 		Range: 3c0
 		Duration: 250


### PR DESCRIPTION
This seems like a bug to me.
