### PR TITLE
Fix accessing a disposed world when music ends after changing maps

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -68,6 +68,9 @@ namespace OpenRA.Mods.Common.Scripting
 				var f = func.CopyReference() as LuaFunction;
 				onComplete = () =>
 				{
+					if (world.Disposing)
+						return;
+
 					try
 					{
 						using (f)


### PR DESCRIPTION
Fixes #8559.

EDIT by @penev:
This is in fact a bandaid for the crash in #8559 for the sake of getting a playtest moving. The code being changed here is still a remnant of the previous world, running in the new one, which is conflicting with the recently introduced world disposing.
