### PR TITLE
Refactors the music player.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -286,7 +286,6 @@ namespace OpenRA
 			Console.WriteLine("Loading mod: {0}", mod);
 			Settings.Game.Mod = mod;
 
-			Sound.StopMusic();
 			Sound.StopVideo();
 			Sound.Initialize();
 

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Traits\Util.cs" />
     <Compile Include="Traits\ValidateOrder.cs" />
     <Compile Include="Traits\World\Country.cs" />
+    <Compile Include="Traits\World\MusicPlaylist.cs" />
     <Compile Include="Traits\World\ResourceType.cs" />
     <Compile Include="Traits\World\ScreenShaker.cs" />
     <Compile Include="Traits\World\Shroud.cs" />

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -108,7 +108,6 @@ namespace OpenRA
 
 		public bool Shuffle = false;
 		public bool Repeat = false;
-		public bool MapMusic = true;
 
 		public string Engine = "AL";
 		public string Device = null;

--- a/OpenRA.Game/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Game/Traits/World/MusicPlaylist.cs
@@ -44,8 +44,7 @@ namespace OpenRA.Traits
 
 			random = playlist.Shuffle(Game.CosmeticRandom).ToArray();
 
-			if (Game.Settings.Sound.MapMusic
-				&& !string.IsNullOrEmpty(info.StartingMusic)
+			if (!string.IsNullOrEmpty(info.StartingMusic)
 				&& world.Map.Rules.Music.ContainsKey(info.StartingMusic)
 				&& world.Map.Rules.Music[info.StartingMusic].Exists)
 			{

--- a/OpenRA.Game/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Game/Traits/World/MusicPlaylist.cs
@@ -1,0 +1,150 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.GameRules;
+
+namespace OpenRA.Traits
+{
+	[Desc("Trait for music handling. Attach this to the world actor.")]
+	public class MusicPlaylistInfo : ITraitInfo
+	{
+		public readonly string StartingMusic = null;
+		public readonly bool LoopStartingMusic = false;
+
+		public object Create(ActorInitializer init) { return new MusicPlaylist(init.World, this); }
+	}
+
+	public class MusicPlaylist : INotifyActorDisposing
+	{
+		readonly MusicInfo[] random;
+		readonly MusicInfo[] playlist;
+
+		public readonly bool IsMusicAvailable;
+
+		MusicInfo currentSong;
+		bool repeat;
+
+		public MusicPlaylist(World world, MusicPlaylistInfo info)
+		{
+			IsMusicAvailable = world.Map.Rules.InstalledMusic.Any();
+
+			playlist = world.Map.Rules.InstalledMusic.Select(a => a.Value).ToArray();
+
+			if (!IsMusicAvailable)
+				return;
+
+			random = playlist.Shuffle(Game.CosmeticRandom).ToArray();
+
+			if (Game.Settings.Sound.MapMusic
+				&& !string.IsNullOrEmpty(info.StartingMusic)
+				&& world.Map.Rules.Music.ContainsKey(info.StartingMusic)
+				&& world.Map.Rules.Music[info.StartingMusic].Exists)
+			{
+				currentSong = world.Map.Rules.Music[info.StartingMusic];
+				repeat = info.LoopStartingMusic;
+			}
+			else
+			{
+				currentSong = Game.Settings.Sound.Shuffle ? random.First() : playlist.First();
+				repeat = Game.Settings.Sound.Repeat;
+			}
+
+			Play();
+		}
+
+		public MusicInfo CurrentSong()
+		{
+			return currentSong;
+		}
+
+		public MusicInfo[] AvailablePlaylist()
+		{
+			// TO-DO: add filter options for Race-specific music
+			return playlist;
+		}
+
+		void Play()
+		{
+			if (currentSong == null || !IsMusicAvailable)
+				return;
+
+			Sound.PlayMusicThen(currentSong, () =>
+			{
+				if (!repeat)
+					currentSong = GetNextSong();
+
+				Play();
+			});
+		}
+
+		public void Play(MusicInfo music)
+		{
+			if (music == null || !IsMusicAvailable)
+				return;
+
+			currentSong = music;
+			repeat = Game.Settings.Sound.Repeat;
+
+			Sound.PlayMusicThen(music, () =>
+			{
+				if (!repeat)
+					currentSong = GetNextSong();
+
+				Play();
+			});
+		}
+
+		public void Play(MusicInfo music, Action onComplete)
+		{
+			if (music == null || !IsMusicAvailable)
+				return;
+
+			currentSong = music;
+			Sound.PlayMusicThen(music, onComplete);
+		}
+
+		public MusicInfo GetNextSong()
+		{
+			return GetSong(false);
+		}
+
+		public MusicInfo GetPrevSong()
+		{
+			return GetSong(true);
+		}
+
+		MusicInfo GetSong(bool reverse)
+		{
+			if (!IsMusicAvailable)
+				return null;
+
+			var songs = Game.Settings.Sound.Shuffle ? random : playlist;
+
+			return reverse ? songs.SkipWhile(m => m != currentSong)
+				.Skip(1).FirstOrDefault() ?? songs.FirstOrDefault() :
+				songs.Reverse().SkipWhile(m => m != currentSong)
+				.Skip(1).FirstOrDefault() ?? songs.Reverse().FirstOrDefault();
+		}
+
+		public void Stop()
+		{
+			currentSong = null;
+			Sound.StopMusic();
+		}
+
+		public void Disposing(Actor self)
+		{
+			if (currentSong != null)
+				Stop();
+		}
+	}
+}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -388,7 +388,6 @@ namespace OpenRA
 			frameEndActions.Clear();
 
 			Sound.StopAudio();
-			Sound.StopMusic();
 			Sound.StopVideo();
 
 			// Dispose newer actors first, and the world actor last

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Play track defined in music.yaml or keep it empty for a random song.")]
 		public void PlayMusic(string track = null, LuaFunction func = null)
 		{
-			if (!Game.Settings.Sound.MapMusic || !playlist.IsMusicAvailable)
+			if (!playlist.IsMusicAvailable)
 				return;
 
 			var musicInfo = !string.IsNullOrEmpty(track) ? world.Map.Rules.Music[track]

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -263,7 +263,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var ss = Game.Settings.Sound;
 
-			BindCheckboxPref(panel, "SHELLMAP_MUSIC", ss, "MapMusic");
 			BindCheckboxPref(panel, "CASH_TICKS", ss, "CashTicks");
 
 			BindSliderPref(panel, "SOUND_VOLUME", ss, "SoundVolume");
@@ -295,7 +294,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var dss = new SoundSettings();
 			return () =>
 			{
-				ss.MapMusic = dss.MapMusic;
 				ss.SoundVolume = dss.SoundVolume;
 				ss.MusicVolume = dss.MusicVolume;
 				ss.VideoVolume = dss.VideoVolume;

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -238,13 +238,6 @@ Container@SETTINGS_PANEL:
 							Font: Bold
 							Text: Audio
 							Align: Center
-						Checkbox@SHELLMAP_MUSIC:
-							X: 15
-							Y: 40
-							Width: 200
-							Height: 20
-							Font: Regular
-							Text: Shellmap / Mission Music
 						Label@SOUND_LABEL:
 							X: PARENT_RIGHT - WIDTH - 270
 							Y: 37
@@ -260,7 +253,7 @@ Container@SETTINGS_PANEL:
 							Ticks: 5
 						Checkbox@CASH_TICKS:
 							X: 15
-							Y: 70
+							Y: 40
 							Width: 200
 							Height: 20
 							Font: Regular

--- a/mods/cnc/maps/funpark01/map.yaml
+++ b/mods/cnc/maps/funpark01/map.yaml
@@ -441,6 +441,8 @@ Rules:
 			Scripts: scj01ea.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: j1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/funpark01/scj01ea.lua
+++ b/mods/cnc/maps/funpark01/scj01ea.lua
@@ -32,12 +32,6 @@ ReinforceWithLandingCraft = function(units, transportStart, transportUnload, ral
 	Media.PlaySpeechNotification(player, "Reinforce")
 end
 
-initialSong = "j1"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	nod = Player.GetPlayer("Nod")
 	dinosaur = Player.GetPlayer("Dinosaur")
@@ -91,7 +85,6 @@ WorldLoaded = function()
 	end
 
 	Camera.Position = CameraStart.CenterPosition
-	PlayMusic()
 end
 
 Tick = function()

--- a/mods/cnc/maps/gdi01/gdi01.lua
+++ b/mods/cnc/maps/gdi01/gdi01.lua
@@ -56,12 +56,6 @@ CheckForBase = function()
 	return #baseBuildings >= 3
 end
 
-initialSong = "aoi"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	player = Player.GetPlayer("GDI")
 	enemy = Player.GetPlayer("Nod")
@@ -92,8 +86,6 @@ WorldLoaded = function()
 
 	ReinforceWithLandingCraft(MCVReinforcements, lstStart.Location + CVec.New(2, 0), lstEnd.Location + CVec.New(2, 0), mcvTarget.Location)
 	Reinforce(InfantryReinforcements)
-
-	PlayMusic()
 
 	Trigger.OnIdle(Gunboat, function() SetGunboatPath(Gunboat) end)
 

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -428,6 +428,8 @@ Rules:
 			Scripts: gdi01.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: aoi
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:

--- a/mods/cnc/maps/gdi02/gdi02.lua
+++ b/mods/cnc/maps/gdi02/gdi02.lua
@@ -56,17 +56,9 @@ NodAttack = function()
 	end
 end
 
-initialSong = "befeared"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	player = Player.GetPlayer("GDI")
 	enemy = Player.GetPlayer("Nod")
-
-	PlayMusic()
 
 	Trigger.OnObjectiveAdded(player, function(p, id)
 		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -655,6 +655,8 @@ Rules:
 			Scripts: gdi02.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: befeared
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:

--- a/mods/cnc/maps/gdi03/gdi03.lua
+++ b/mods/cnc/maps/gdi03/gdi03.lua
@@ -45,17 +45,9 @@ SendReinforcements = function()
 	Media.PlaySpeechNotification(player, "Reinforce")
 end
 
-initialSong = "crep226m"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	player = Player.GetPlayer("GDI")
 	enemy = Player.GetPlayer("Nod")
-
-	PlayMusic()
 
 	Trigger.OnObjectiveAdded(player, function(p, id)
 		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -730,6 +730,8 @@ Rules:
 			Scripts: gdi03.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: crep226m
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:

--- a/mods/cnc/maps/gdi04a/gdi04a.lua
+++ b/mods/cnc/maps/gdi04a/gdi04a.lua
@@ -103,19 +103,11 @@ SetupWorld = function()
 	Trigger.OnRemovedFromWorld(crate, function() gdi.MarkCompletedObjective(gdiObjective) end)
 end
 
-initialSong = "fist226m"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	gdi = Player.GetPlayer("GDI")
 	nod = Player.GetPlayer("Nod")
 
 	SetupWorld()
-
-	PlayMusic()
 
 	Trigger.OnObjectiveAdded(gdi, function(p, id)
 		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -489,6 +489,8 @@ Rules:
 			Scripts: gdi04a.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: fist226m
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:

--- a/mods/cnc/maps/gdi04b/gdi04b.lua
+++ b/mods/cnc/maps/gdi04b/gdi04b.lua
@@ -110,12 +110,6 @@ SetupWorld = function()
 	Trigger.OnRemovedFromWorld(crate, function() gdi.MarkCompletedObjective(gdiObjective) end)
 end
 
-initialSong = "fist226m"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	gdi = Player.GetPlayer("GDI")
 	nod = Player.GetPlayer("Nod")
@@ -143,8 +137,6 @@ WorldLoaded = function()
 	nod.AddPrimaryObjective("Defend against the GDI forces.")
 
 	SetupWorld()
-
-	PlayMusic()
 
 	bhndTrigger = false
 	Trigger.OnExitedFootprint(BhndTrigger, function(a, id)

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -560,6 +560,8 @@ Rules:
 			Scripts: gdi04b.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: fist226m
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:

--- a/mods/cnc/maps/gdi04c/gdi04c.lua
+++ b/mods/cnc/maps/gdi04c/gdi04c.lua
@@ -61,17 +61,9 @@ SendGDIReinforcements = function()
 	end)
 end
 
-initialSong = "ind"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	player = Player.GetPlayer("GDI")
 	nod = Player.GetPlayer("Nod")
-
-	PlayMusic()
 
 	Trigger.OnObjectiveAdded(player, function(p, id)
 		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -785,6 +785,8 @@ Rules:
 			Scripts: gdi04c.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: ind
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:

--- a/mods/cnc/maps/gdi05a/gdi05a.lua
+++ b/mods/cnc/maps/gdi05a/gdi05a.lua
@@ -183,12 +183,6 @@ SetupWorld = function()
 	Grd3Action()
 end
 
-initialSong = "rain"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	gdiBase = Player.GetPlayer("AbandonedBase")
 	gdi = Player.GetPlayer("GDI")
@@ -219,9 +213,6 @@ WorldLoaded = function()
 	SetupWorld()
 
 	Camera.Position = GdiTankRallyPoint.CenterPosition
-
-	PlayMusic()
-
 end
 
 Tick = function()

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -797,6 +797,8 @@ Rules:
 			Scripts: gdi05a.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: rain
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:

--- a/mods/cnc/maps/gdi05b/gdi05b.lua
+++ b/mods/cnc/maps/gdi05b/gdi05b.lua
@@ -118,12 +118,6 @@ IdleHunt = function(unit)
 	end
 end
 
-initialSong = "rain"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	gdi = Player.GetPlayer("GDI")
 	gdiBase = Player.GetPlayer("AbandonedBase")
@@ -185,8 +179,6 @@ WorldLoaded = function()
 	end)
 	
 	Camera.Position = UnitsRally.CenterPosition
-
-	PlayMusic()
 	
 	InsertGdiUnits()
 end

--- a/mods/cnc/maps/gdi05b/map.yaml
+++ b/mods/cnc/maps/gdi05b/map.yaml
@@ -639,6 +639,8 @@ Rules:
 		MissionObjectives:
 			EarlyGameOver: true
 		EnemyWatcher:
+		MusicPlaylist:
+			StartingMusic: rain
 	World:
 		-CrateSpawner:
 		-SpawnMPUnits:

--- a/mods/cnc/maps/nod01/map.yaml
+++ b/mods/cnc/maps/nod01/map.yaml
@@ -289,6 +289,8 @@ Rules:
 			Scripts: nod01.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: nomercy
 	C10:
 		Tooltip:
 			Name: Nikoomba

--- a/mods/cnc/maps/nod01/nod01.lua
+++ b/mods/cnc/maps/nod01/nod01.lua
@@ -31,12 +31,6 @@ SendLastInfantryReinforcements = function()
 	end)
 end
 
-initialSong = "nomercy"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	nod = Player.GetPlayer("Nod")
 	gdi = Player.GetPlayer("GDI")
@@ -73,8 +67,6 @@ WorldLoaded = function()
 	end)
 
 	Camera.Position = StartRallyPoint.CenterPosition
-
-	PlayMusic()
 
 	SendInitialForces()
 	Trigger.AfterDelay(DateTime.Seconds(30), SendFirstInfantryReinforcements)

--- a/mods/cnc/maps/nod02a/map.yaml
+++ b/mods/cnc/maps/nod02a/map.yaml
@@ -226,6 +226,8 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		LuaScript:
 			Scripts: nod02a.lua
+		MusicPlaylist:
+			StartingMusic: ind2
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod02a/nod02a.lua
+++ b/mods/cnc/maps/nod02a/nod02a.lua
@@ -159,12 +159,6 @@ Pat1Movement = function(unit)
 	IdleHunt(unit)
 end
 
-initialSong = "ind2"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	GDI = Player.GetPlayer("GDI")
 	Nod = Player.GetPlayer("Nod")
@@ -221,8 +215,6 @@ WorldLoaded = function()
 			Trigger.RemoveFootprintTrigger(id)
 		end
 	end)
-
-	PlayMusic()
 
 	Trigger.AfterDelay(0, getStartUnits)
 	InsertNodUnits()

--- a/mods/cnc/maps/nod02b/map.yaml
+++ b/mods/cnc/maps/nod02b/map.yaml
@@ -268,6 +268,8 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		LuaScript:
 			Scripts: nod02b.lua
+		MusicPlaylist:
+			StartingMusic: ind2
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod02b/nod02b.lua
+++ b/mods/cnc/maps/nod02b/nod02b.lua
@@ -96,12 +96,6 @@ Gdi3Movement = function(unit)
 	IdleHunt(unit)
 end
 
-initialSong = "ind2"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	GDI = Player.GetPlayer("GDI")
 	Nod = Player.GetPlayer("Nod")
@@ -140,8 +134,6 @@ WorldLoaded = function()
 
 	Trigger.AfterDelay(0, getStartUnits)
 	Harvester.FindResources()
-
-	PlayMusic()
 
 	InsertNodUnits()
 end

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -467,6 +467,8 @@ Rules:
 			Scripts: nod03a.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: chrg226m
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod03a/nod03a.lua
+++ b/mods/cnc/maps/nod03a/nod03a.lua
@@ -16,12 +16,6 @@ InsertNodUnits = function()
 	end)
 end
 
-initialSong = "chrg226m"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	player = Player.GetPlayer("Nod")
 	enemy = Player.GetPlayer("GDI")
@@ -57,8 +51,6 @@ WorldLoaded = function()
 	Trigger.OnKilled(TechCenter, function()
 		player.MarkFailedObjective(nodObjective1)
 	end)
-
-	PlayMusic()
 
 	InsertNodUnits()
 	Trigger.AfterDelay(DateTime.Seconds(20), function() SendAttackWave(FirstAttackWave, AttackWaveSpawnA.Location) end)

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -511,6 +511,8 @@ Rules:
 			Scripts: nod03b.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: chrg226m
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod03b/nod03b.lua
+++ b/mods/cnc/maps/nod03b/nod03b.lua
@@ -33,12 +33,6 @@ InsertNodUnits = function()
 	end)
 end
 
-initialSong = "chrg226m"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	player = Player.GetPlayer("Nod")
 	enemy = Player.GetPlayer("GDI")
@@ -71,8 +65,6 @@ WorldLoaded = function()
 			player.MarkCompletedObjective(nodObjective1)
 		end)
 	end)
-
-	PlayMusic()
 
 	InsertNodUnits()
 	Trigger.AfterDelay(DateTime.Seconds(40), function() SendAttackWave(FirstAttackWaveUnits, FirstAttackWave) end)

--- a/mods/cnc/maps/nod04a/map.yaml
+++ b/mods/cnc/maps/nod04a/map.yaml
@@ -568,6 +568,8 @@ Rules:
 			Scripts: nod04a.lua
 		ObjectivesPanel:
 			PanelName: MISSION_OBJECTIVES
+		MusicPlaylist:
+			StartingMusic: valkyrie
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod04a/nod04a.lua
+++ b/mods/cnc/maps/nod04a/nod04a.lua
@@ -171,12 +171,6 @@ CreateCivilians = function(actor, discoverer)
 	end)
 end
 
-initialSong = "valkyrie"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	NodSupporter = Player.GetPlayer("NodSupporter")
 	Nod = Player.GetPlayer("Nod")
@@ -289,8 +283,6 @@ WorldLoaded = function()
 
 	GDIObjective = GDI.AddPrimaryObjective("Eliminate all Nod forces in the area.")
 	NodObjective1 = Nod.AddPrimaryObjective("Kill all civilian GDI supporters.")
-
-	PlayMusic()
 
 	InsertNodUnits()
 	Camera.Position = waypoint6.CenterPosition

--- a/mods/cnc/maps/nod04b/map.yaml
+++ b/mods/cnc/maps/nod04b/map.yaml
@@ -507,6 +507,8 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		LuaScript:
 			Scripts: nod04b.lua
+		MusicPlaylist:
+			StartingMusic: warfare
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod04b/nod04b.lua
+++ b/mods/cnc/maps/nod04b/nod04b.lua
@@ -74,12 +74,6 @@ InsertNodUnits = function()
 	Reinforcements.ReinforceWithTransport(Nod, 'tran', NodUnitsGunner, { EntryPointGunner.Location, RallyPointGunner.Location }, { EntryPointGunner.Location }, nil, nil)
 end
 
-initialSong = "warfare"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	GDI = Player.GetPlayer("GDI")
 	Nod = Player.GetPlayer("Nod")
@@ -146,8 +140,6 @@ WorldLoaded = function()
 	GDIObjective = GDI.AddPrimaryObjective("Kill all enemies.")
 	NodObjective1 = Nod.AddPrimaryObjective("Destroy the village and kill all civilians.")
 	NodObjective2 = Nod.AddSecondaryObjective("Kill all GDI units in the area.")
-
-	PlayMusic()
 
 	InsertNodUnits()
 end

--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -402,6 +402,8 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		LuaScript:
 			Scripts: nod05.lua
+		MusicPlaylist:
+			StartingMusic: airstrik
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod05/nod05.lua
+++ b/mods/cnc/maps/nod05/nod05.lua
@@ -163,12 +163,6 @@ InsertNodUnits = function()
 	end)
 end
 
-initialSong = "airstrik"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	GDI = Player.GetPlayer("GDI")
 	Nod = Player.GetPlayer("Nod")
@@ -247,9 +241,6 @@ WorldLoaded = function()
 	end)
 
 	Trigger.AfterDelay(0, getStartUnits)
-
-	PlayMusic()
-
 end
 
 Tick = function()

--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -675,6 +675,8 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		LuaScript:
 			Scripts: nod06a.lua
+		MusicPlaylist:
+			StartingMusic: rout
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod06a/nod06a.lua
+++ b/mods/cnc/maps/nod06a/nod06a.lua
@@ -118,12 +118,6 @@ InsertNodUnits = function()
 	Reinforcements.Reinforce(Nod, NodStartUnitsRight, { UnitsEntryRight.Location, UnitsRallyRight.Location }, 15)
 end
 
-initialSong = "rout"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	GDI = Player.GetPlayer("GDI")
 	Nod = Player.GetPlayer("Nod")
@@ -152,8 +146,6 @@ WorldLoaded = function()
 	NodObjective2 = Nod.AddSecondaryObjective("Destroy the houses of the GDI supporters\nin the village.")
 
 	GDIObjective = GDI.AddPrimaryObjective("Stop the Nod taskforce from escaping with the detonator.")
-
-	PlayMusic()
 
 	InsertNodUnits()
 

--- a/mods/cnc/maps/nod06b/map.yaml
+++ b/mods/cnc/maps/nod06b/map.yaml
@@ -617,6 +617,8 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		LuaScript:
 			Scripts: nod06b.lua
+		MusicPlaylist:
+			StartingMusic: rout
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod06b/nod06b.lua
+++ b/mods/cnc/maps/nod06b/nod06b.lua
@@ -94,12 +94,6 @@ InsertNodUnits = function()
 	Reinforcements.Reinforce(Nod, NodUnitsRocket, { UnitsEntryRocket.Location, UnitsRallyRocket.Location }, 25)
 end
 
-initialSong = "rout"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	GDI = Player.GetPlayer("GDI")
 	Nod = Player.GetPlayer("Nod")
@@ -126,8 +120,6 @@ WorldLoaded = function()
 
 	NodObjective1 = Nod.AddPrimaryObjective("Steal the GDI nuclear detonator.")
 	GDIObjective = GDI.AddPrimaryObjective("Stop the Nod taskforce from escaping with the detonator.")
-
-	PlayMusic()
 
 	InsertNodUnits()
 

--- a/mods/cnc/maps/nod06c/map.yaml
+++ b/mods/cnc/maps/nod06c/map.yaml
@@ -503,6 +503,8 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		LuaScript:
 			Scripts: nod06c.lua
+		MusicPlaylist:
+			StartingMusic: rout
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod06c/nod06c.lua
+++ b/mods/cnc/maps/nod06c/nod06c.lua
@@ -82,12 +82,6 @@ InsertNodUnits = function()
 	Reinforcements.Reinforce(Nod, NodStartUnitsRight, { UnitsEntryRight.Location, UnitsRallyRight.Location }, 15)
 end
 
-initialSong = "rout"
-PlayMusic = function()
-	Media.PlayMusic(initialSong, PlayMusic)
-	initialSong = nil
-end
-
 WorldLoaded = function()
 	GDI = Player.GetPlayer("GDI")
 	Nod = Player.GetPlayer("Nod")
@@ -115,8 +109,6 @@ WorldLoaded = function()
 	NodObjective1 = Nod.AddPrimaryObjective("Steal the GDI nuclear detonator.")
 	NodObjective3 = Nod.AddSecondaryObjective("Infiltrate the barracks, weapon factory and \nthe construction yard.")
 	GDIObjective = GDI.AddPrimaryObjective("Stop the Nod taskforce from escaping with the detonator.")
-
-	PlayMusic()
 
 	InsertNodUnits()
 

--- a/mods/cnc/maps/shellmap/map.yaml
+++ b/mods/cnc/maps/shellmap/map.yaml
@@ -994,6 +994,9 @@ Rules:
 			Effect: Desaturated
 		LuaScript:
 			Scripts: shellmap.lua
+		MusicPlaylist:
+			StartingMusic: map1
+			LoopStartingMusic: True
 	LST:
 		Mobile:
 			Speed: 42

--- a/mods/cnc/maps/shellmap/shellmap.lua
+++ b/mods/cnc/maps/shellmap/shellmap.lua
@@ -17,17 +17,12 @@ WorldLoaded = function()
 	for i, unit in ipairs(units) do
 		LoopTrack(unit, CPos.New(8, unit.Location.Y), CPos.New(87, unit.Location.Y))
 	end
-	PlayMusic()
 end
 
 LoopTrack = function(actor, left, right)
 	actor.ScriptedMove(left)
 	actor.Teleport(right)
 	actor.CallFunc(function() LoopTrack(actor, left, right) end)
-end
-
-PlayMusic = function()
-	Media.PlayMusic("map1", PlayMusic)
 end
 
 LoadTransport = function(transport, passenger)

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -3,6 +3,7 @@
 	Inherits: ^Palettes
 	ScreenMap:
 	ActorMap:
+	MusicPlaylist:
 	TerrainGeometryOverlay:
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -125,6 +125,8 @@ Rules:
 			Maximum: 1
 		LuaScript:
 			Scripts: shellmap.lua
+		MusicPlaylist:
+			StartingMusic: score
 	rockettower:
 		Power:
 			Amount: 100

--- a/mods/d2k/maps/shellmap/shellmap.lua
+++ b/mods/d2k/maps/shellmap/shellmap.lua
@@ -1,3 +1,0 @@
-WorldLoaded = function()
-	Media.PlayMusic("score")
-end

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -3,6 +3,7 @@
 	AlwaysVisible:
 	ScreenMap:
 	ActorMap:
+	MusicPlaylist:
 	TerrainGeometryOverlay:
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -246,13 +246,6 @@ Background@SETTINGS_PANEL:
 			Width: PARENT_RIGHT - 10
 			Height: PARENT_BOTTOM
 			Children:
-				Checkbox@SHELLMAP_MUSIC:
-					X: 15
-					Y: 40
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Shellmap / Mission Music
 				Label@SOUND_LABEL:
 					X: PARENT_RIGHT - WIDTH - 270
 					Y: 37
@@ -268,7 +261,7 @@ Background@SETTINGS_PANEL:
 					Ticks: 5
 				Checkbox@CASH_TICKS:
 					X: 15
-					Y: 70
+					Y: 40
 					Width: 200
 					Height: 20
 					Font: Regular

--- a/mods/ra/maps/desert-shellmap/desert-shellmap.lua
+++ b/mods/ra/maps/desert-shellmap/desert-shellmap.lua
@@ -162,6 +162,4 @@ WorldLoaded = function()
 	SendSovietUnits(Entry5.Location, UnitTypes, 50)
 	SendSovietUnits(Entry6.Location, UnitTypes, 50)
 	SendSovietUnits(Entry7.Location, BeachUnitTypes, 15)
-
-	Media.PlayMusic()
 end

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -3,6 +3,7 @@
 	AlwaysVisible:
 	ActorMap:
 	ScreenMap:
+	MusicPlaylist:
 	TerrainGeometryOverlay:
 	LoadWidgetAtGameStart:
 	ShroudRenderer:

--- a/mods/ts/maps/blank-shellmap/map.yaml
+++ b/mods/ts/maps/blank-shellmap/map.yaml
@@ -40,8 +40,9 @@ Rules:
 		-StartGameNotification:
 		-SpawnMPUnits:
 		-MPStartLocations:
-		LuaScript:
-			Scripts: shellmap.lua
+		MusicPlaylist:
+			StartingMusic: intro
+			LoopStartingMusic: True
 
 Sequences:
 

--- a/mods/ts/maps/blank-shellmap/shellmap.lua
+++ b/mods/ts/maps/blank-shellmap/shellmap.lua
@@ -1,7 +1,0 @@
-PlayMusic = function()
-	Media.PlayMusic("intro", PlayMusic)
-end
-
-WorldLoaded = function()
-	PlayMusic()
-end

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -3,6 +3,7 @@
 	AlwaysVisible:
 	ScreenMap:
 	ActorMap:
+	MusicPlaylist:
 	LoadWidgetAtGameStart:
 	ShroudRenderer:
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255


### PR DESCRIPTION
Proper fix for #8559.
Closes  #8671, #8587 and #8033.

<del>ATM it has one regression: due to the playlist getting set up before the shellmap's lua scripts, the game plays a maximum of two seconds maybe before the shellmap music at game start, depending on settings. That will probably need a StartingMusic trait.</del>
