### PR TITLE
Fixed TS civilian structures and map decorations

### DIFF
--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -373,8 +373,6 @@ CA0001:
 		Type: heavy
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0002:
 	Inherits: ^CivBuilding
@@ -387,8 +385,6 @@ CA0002:
 		Type: heavy
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0003:
 	Inherits: ^CivBuilding
@@ -401,8 +397,6 @@ CA0003:
 		Type: light
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0004:
 	Inherits: ^CivBuilding
@@ -415,8 +409,6 @@ CA0004:
 		Type: light
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0005:
 	Inherits: ^CivBuilding
@@ -429,8 +421,6 @@ CA0005:
 		Type: light
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0006:
 	Inherits: ^CivBuilding
@@ -443,8 +433,6 @@ CA0006:
 		Type: heavy
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0007:
 	Inherits: ^CivBuilding
@@ -457,8 +445,6 @@ CA0007:
 		Type: light
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0008:
 	Inherits: ^CivBuilding
@@ -471,8 +457,6 @@ CA0008:
 		Type: heavy
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0009:
 	Inherits: ^CivBuilding
@@ -485,8 +469,6 @@ CA0009:
 		Type: heavy
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0010:
 	Inherits: ^CivBuilding
@@ -499,8 +481,6 @@ CA0010:
 		Type: heavy
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0011:
 	Inherits: ^CivBuilding
@@ -513,8 +493,6 @@ CA0011:
 		Type: heavy
 	Health:
 		HP: 200
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0012:
 	Inherits: ^CivBuilding
@@ -527,8 +505,6 @@ CA0012:
 		Type: light
 	Health:
 		HP: 100
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0013:
 	Inherits: ^CivBuilding
@@ -541,8 +517,6 @@ CA0013:
 		Type: heavy
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0014:
 	Inherits: ^CivBuilding
@@ -555,8 +529,6 @@ CA0014:
 		Type: heavy
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0015:
 	Inherits: ^CivBuilding
@@ -569,8 +541,6 @@ CA0015:
 		Type: light
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0016:
 	Inherits: ^CivBuilding
@@ -583,8 +553,6 @@ CA0016:
 		Type: light
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0017:
 	Inherits: ^CivBuilding
@@ -597,8 +565,6 @@ CA0017:
 		Type: heavy
 	Health:
 		HP: 300
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0018:
 	Inherits: ^CivBuilding
@@ -611,8 +577,6 @@ CA0018:
 		Type: light
 	Health:
 		HP: 200
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0019:
 	Inherits: ^CivBuilding
@@ -625,8 +589,6 @@ CA0019:
 		Type: light
 	Health:
 		HP: 200
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0020:
 	Inherits: ^CivBuilding
@@ -639,8 +601,6 @@ CA0020:
 		Type: light
 	Health:
 		HP: 200
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CA0021:
 	Inherits: ^CivBuilding
@@ -653,8 +613,6 @@ CA0021:
 		Type: light
 	Health:
 		HP: 200
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CAARAY:
 	Inherits: ^CivBuilding
@@ -708,8 +666,6 @@ CACRSH01:
 		Type: concrete
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CACRSH02:
 	Inherits: ^CivBuilding
@@ -722,8 +678,6 @@ CACRSH02:
 		Type: concrete
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CACRSH03:
 	Inherits: ^CivBuilding
@@ -736,8 +690,6 @@ CACRSH03:
 		Type: concrete
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CACRSH04:
 	Inherits: ^CivBuilding
@@ -750,8 +702,6 @@ CACRSH04:
 		Type: concrete
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CACRSH05:
 	Inherits: ^CivBuilding
@@ -764,8 +714,6 @@ CACRSH05:
 		Type: concrete
 	Health:
 		HP: 400
-	EditorTilesetFilter:
-		ExcludeTilesets: SNOW
 
 CAHOSP:
 	Inherits: ^CivBuilding

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -3,331 +3,373 @@ ammocrat:
 		ShadowStart: 2
 
 aban01:
-	idle: aban01
+	idle:
 		ShadowStart: 2
 
 aban02:
-	idle: aban02
+	idle:
 		ShadowStart: 2
 
 aban03:
-	idle: aban03
+	idle:
 		ShadowStart: 2
 
 aban04:
-	idle: aban04
+	idle:
 		ShadowStart: 2
 
 aban05:
-	idle: aban05
+	idle:
 		ShadowStart: 2
 
 aban06:
-	idle: aban06
+	idle:
 		ShadowStart: 2
 
 aban07:
-	idle: aban07
+	idle:
 		ShadowStart: 2
 
 aban08:
-	idle: aban08
+	idle:
 		ShadowStart: 2
 
 aban09:
-	idle: aban09
+	idle:
 		ShadowStart: 2
 
 aban10:
-	idle: aban10
+	idle:
 		ShadowStart: 2
 
 aban11:
-	idle: aban11
+	idle:
 		ShadowStart: 2
 
 aban12:
-	idle: aban12
+	idle:
 		ShadowStart: 2
 
 aban13:
-	idle: aban13
+	idle:
 		ShadowStart: 2
 
 aban14:
-	idle: aban14
+	idle:
 		ShadowStart: 2
 
 aban15:
-	idle: aban15
+	idle:
 		ShadowStart: 2
 
 aban16:
-	idle: aban16
+	idle:
 		ShadowStart: 2
 
 aban17:
-	idle: aban17
+	idle:
 		ShadowStart: 2
 
 aban18:
-	idle: aban18
+	idle:
 		ShadowStart: 2
 
 bboard01:
-	idle: bboard01
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard02:
-	idle: bboard02
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard03:
-	idle: bboard03
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard04:
-	idle: bboard04
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard05:
-	idle: bboard05
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard06:
-	idle: bboard06
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard07:
-	idle: bboard07
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard08:
-	idle: bboard08
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard09:
-	idle: bboard09
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard10:
-	idle: bboard10
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard11:
-	idle: bboard11
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard12:
-	idle: bboard12
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard13:
-	idle: bboard13
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard14:
-	idle: bboard14
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard15:
-	idle: bboard15
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 bboard16:
-	idle: bboard16
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0001:
-	idle: ct0001
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0002:
-	idle: ct0002
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0003:
-	idle: ct0003
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0004:
-	idle: ct0004
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0005:
-	idle: ct0005
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0006:
-	idle: ct0006
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0007:
-	idle: ct0007
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0008:
-	idle: ct0008
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0009:
-	idle: ct0009
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0010:
-	idle: ct0010
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0011:
-	idle: ct0011
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0012:
-	idle: ct0012
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0013:
-	idle: ct0013
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0014:
-	idle: ct0014
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0015:
-	idle: ct0015
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0016:
-	idle: ct0016
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0017:
-	idle: ct0017
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0018:
-	idle: ct0018
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0019:
-	idle: ct0019
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0020:
-	idle: ct0020
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
 
 ca0021:
-	idle: ct0021
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
@@ -354,26 +396,37 @@ caaray:
 		ShadowStart: 5
 
 cabhut:
-	idle: cabhut
+	idle:
+		UseTilesetCode: true
 
 cacrsh01:
-	idle: ctcrsh01
+	idle:
+		UseTilesetCode: true
 
 cacrsh02:
-	idle: ctcrsh02
+	idle:
+		UseTilesetCode: true
 
 cacrsh03:
-	idle: ctcrsh03
+	idle:
+		UseTilesetCode: true
 
 cacrsh04:
-	idle: ctcrsh04
+	idle:
+		UseTilesetCode: true
 
 cacrsh05:
-	idle: ctcrsh05
+	idle:
+		UseTilesetCode: true
 
 cahosp:
-	idle: cthosp
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 3
 
 capyr01:
 	idle: ctpyr01
@@ -388,269 +441,277 @@ capyr03:
 		ShadowStart: 1
 
 city01:
-	idle: city01
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city01
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city02:
-	idle: city02
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city02
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city03:
-	idle: city03
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city03
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city04:
-	idle: city04
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city04
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city05:
-	idle: city05
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city05
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city06:
-	idle: city06
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city06
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city07:
-	idle: city07
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city07
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city08:
-	idle: city08
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city08
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city09:
-	idle: city09
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city09
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city10:
-	idle: city10
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city10
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city11:
-	idle: city11
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city11
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city12:
-	idle: city12
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city12
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city13:
-	idle: city13
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city13
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city14:
-	idle: city14
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city14
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city15:
-	idle: city15
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city15
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city16:
-	idle: city16
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city16
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city17:
-	idle: city17
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city17
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city18:
-	idle: city18
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city18
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city19:
-	idle: city19
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city19
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city20:
-	idle: city20
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city20
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city21:
-	idle: city21
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city21
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 city22:
-	idle: city22
+	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make: city22
+	make:
 		ShadowStart: 2
 		Tick: 80
 
 ctdam:
-	idle: ctdam
+	idle:
 
 ctvega:
-	idle: ctvega
+	idle:
 		ShadowStart: 3
-	damaged-idle: ctvega
+	damaged-idle:
 		Start: 1
 		ShadowStart: 4
-	critical-idle: ctvega
+	critical-idle:
 		Start: 2
 		ShadowStart: 5
 
 gaoldcc1:
-	idle: gtoldcc1
+	idle:
 		ShadowStart: 2
+		UseTilesetCode: true
 
 gaoldcc2:
-	idle: gtoldcc2
+	idle:
 		ShadowStart: 2
+		UseTilesetCode: true
 
 gaoldcc3:
 	idle: gtoldcc3
 		ShadowStart: 2
+		UseTilesetCode: true
 
 gaoldcc4:
-	idle: gtoldcc4
+	idle:
 		ShadowStart: 2
+		UseTilesetCode: true
 
 gaoldcc5:
-	idle: gtoldcc5
+	idle:
 		ShadowStart: 2
+		UseTilesetCode: true
 
 gaoldcc6:
-	idle: gtoldcc6
+	idle:
 		ShadowStart: 2
+		UseTilesetCode: true
 
 gakodk:
-	idle: gtkodk
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 3
-	damaged-idle: gtkodk
+	damaged-idle:
 		Start: 1
 		ShadowStart: 4
-	critical-idle: gtkodk
+	critical-idle:
 		Start: 2
 		ShadowStart: 5
 
@@ -698,22 +759,24 @@ galite:
 		UseTilesetCode: false
 
 namntk:
-	idle: ntmntk
+	Defaults:
+		UseTilesetCode: true
+	idle:
 		ShadowStart: 3
-	damaged-idle: ntmntk
+	damaged-idle:
 		Start: 1
 		ShadowStart: 4
-	critical-idle: ntmntk
+	critical-idle:
 		Start: 2
 		ShadowStart: 5
 
 ntpyra:
-	idle: ntpyra
+	idle:
 		ShadowStart: 3
-	damaged-idle: ntpyra
+	damaged-idle:
 		Start: 1
 		ShadowStart: 4
-	critical-idle: ntpyra
+	critical-idle:
 		Start: 2
 		ShadowStart: 5
 

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -1,80 +1,173 @@
 ammocrat:
 	idle: ammo01
 		ShadowStart: 2
+		Offset: 0, -12
 
 aban01:
+	Defaults:
+		Offset: 42, -42
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban02:
+	Defaults:
+		Offset: -30, -48
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban03:
+	Defaults:
+		Offset: 48, -42
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban04:
+	Defaults:
+		Offset: -24, -30
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban05:
+	Defaults:
+		Offset: -24, -33
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban06:
+	Defaults:
+		Offset: 0, -21
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban07:
+	Defaults:
+		Offset: 0, -21
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban08:
+	Defaults:
+		Offset: 0, -21
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban09:
+	Defaults:
+		Offset: 0, -18
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban10:
+	Defaults:
+		Offset: 0, -21
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban11:
+	Defaults:
+		Offset: 0, -21
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban12:
+	Defaults:
+		Offset: 0, -21
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban13:
+	Defaults:
+		Offset: 0, -6
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban14:
+	Defaults:
+		Offset: 0, -9
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban15:
+	Defaults:
+		Offset: 0, -6
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban16:
+	Defaults:
+		Offset: 0, -21
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban17:
+	Defaults:
+		Offset: 0, -9
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 aban18:
+	Defaults:
+		Offset: 0, -9
 	idle:
 		ShadowStart: 2
+	critical-idle:
+		Start: 1
+		ShadowStart: 3
 
 bboard01:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -82,6 +175,8 @@ bboard01:
 		ShadowStart: 3
 
 bboard02:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -89,6 +184,8 @@ bboard02:
 		ShadowStart: 3
 
 bboard03:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -96,6 +193,8 @@ bboard03:
 		ShadowStart: 3
 
 bboard04:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -103,6 +202,8 @@ bboard04:
 		ShadowStart: 3
 
 bboard05:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -110,6 +211,8 @@ bboard05:
 		ShadowStart: 3
 
 bboard06:
+	Defaults:
+		Offset: -12, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -117,6 +220,8 @@ bboard06:
 		ShadowStart: 3
 
 bboard07:
+	Defaults:
+		Offset: -12, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -124,6 +229,8 @@ bboard07:
 		ShadowStart: 3
 
 bboard08:
+	Defaults:
+		Offset: -12, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -131,6 +238,8 @@ bboard08:
 		ShadowStart: 3
 
 bboard09:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -138,6 +247,8 @@ bboard09:
 		ShadowStart: 3
 
 bboard10:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -145,6 +256,8 @@ bboard10:
 		ShadowStart: 3
 
 bboard11:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -152,6 +265,8 @@ bboard11:
 		ShadowStart: 3
 
 bboard12:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -159,6 +274,8 @@ bboard12:
 		ShadowStart: 3
 
 bboard13:
+	Defaults:
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -166,6 +283,8 @@ bboard13:
 		ShadowStart: 3
 
 bboard14:
+	Defaults:
+		Offset: 12, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -173,6 +292,8 @@ bboard14:
 		ShadowStart: 3
 
 bboard15:
+	Defaults:
+		Offset: 12, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -180,6 +301,8 @@ bboard15:
 		ShadowStart: 3
 
 bboard16:
+	Defaults:
+		Offset: 12, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -189,6 +312,7 @@ bboard16:
 ca0001:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0, -36
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -198,6 +322,7 @@ ca0001:
 ca0002:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0, -36
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -207,6 +332,7 @@ ca0002:
 ca0003:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -216,6 +342,7 @@ ca0003:
 ca0004:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -225,6 +352,7 @@ ca0004:
 ca0005:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -234,6 +362,7 @@ ca0005:
 ca0006:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -243,6 +372,7 @@ ca0006:
 ca0007:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -252,6 +382,7 @@ ca0007:
 ca0008:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 6, -24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -261,6 +392,7 @@ ca0008:
 ca0009:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 6, -24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -270,6 +402,7 @@ ca0009:
 ca0010:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -279,6 +412,7 @@ ca0010:
 ca0011:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -288,6 +422,7 @@ ca0011:
 ca0012:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -297,6 +432,7 @@ ca0012:
 ca0013:
 	Defaults:
 		UseTilesetCode: true
+		Offset: -12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -306,6 +442,7 @@ ca0013:
 ca0014:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -315,6 +452,7 @@ ca0014:
 ca0015:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -324,6 +462,7 @@ ca0015:
 ca0016:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -333,6 +472,7 @@ ca0016:
 ca0017:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 0, -12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -342,6 +482,7 @@ ca0017:
 ca0018:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -351,6 +492,7 @@ ca0018:
 ca0019:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -360,6 +502,7 @@ ca0019:
 ca0020:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -369,6 +512,7 @@ ca0020:
 ca0021:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -376,6 +520,8 @@ ca0021:
 		ShadowStart: 3
 
 caarmr:
+	Defaults:
+		Offset: 0,-48
 	idle: ctarmr
 		ShadowStart: 3
 	damaged-idle: ctarmr
@@ -386,6 +532,8 @@ caarmr:
 		ShadowStart: 5
 
 caaray:
+	Defaults:
+		Offset: 0,-24
 	idle: ctaray
 		ShadowStart: 3
 	damaged-idle: ctaray
@@ -398,272 +546,265 @@ caaray:
 cabhut:
 	idle:
 		UseTilesetCode: true
+		Offset: 0,-12
 
 cacrsh01:
 	idle:
 		UseTilesetCode: true
+		Offset: 0,-12
 
 cacrsh02:
 	idle:
 		UseTilesetCode: true
+		Offset: 0,-12
 
 cacrsh03:
 	idle:
 		UseTilesetCode: true
+		Offset: 0,-12
 
 cacrsh04:
 	idle:
 		UseTilesetCode: true
+		Offset: 0,-12
 
 cacrsh05:
 	idle:
 		UseTilesetCode: true
+		Offset: 0,-12
 
 cahosp:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 12, -36
 	idle:
-		ShadowStart: 2
+		ShadowStart: 3
 	damaged-idle:
 		Start: 1
-		ShadowStart: 3
+		ShadowStart: 4
+	critical-idle:
+		Start: 2
+		ShadowStart: 5
 
 capyr01:
 	idle: ctpyr01
 		ShadowStart: 1
+		Offset: 0,-24
 
 capyr02:
 	idle: ctpyr02
 		ShadowStart: 1
+		Offset: 0,-48
 
 capyr03:
 	idle: ctpyr03
 		ShadowStart: 1
+		Offset: 0,-48
 
 city01:
+	Defaults:
+		Offset: -12, -30
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city02:
+	Defaults:
+		Offset: 6, -30
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city03:
+	Defaults:
+		Offset: -12, -30
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city04:
+	Defaults:
+		Offset: -12, -30
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city05:
+	Defaults:
+		Offset: -12, -30
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city06:
+	Defaults:
+		Offset: -18, -36
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city07:
+	Defaults:
+		Offset: -12, -30
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city08:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city09:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city10:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city11:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city12:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city13:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city14:
+	Defaults:
+		Offset: 0,-12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city15:
+	Defaults:
+		Offset: -18, -36
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city16:
+	Defaults:
+		Offset: -18, -36
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city17:
+	Defaults:
+		Offset: -12, -42
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city18:
+	Defaults:
+		Offset: 24, -48
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city19:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city20:
+	Defaults:
+		Offset: 0,-12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city21:
+	Defaults:
+		Offset: 0,-12
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 city22:
+	Defaults:
+		Offset: 0,-24
 	idle:
 		ShadowStart: 2
 	damaged-idle:
 		Start: 1
 		ShadowStart: 3
-	make:
-		ShadowStart: 2
-		Tick: 80
 
 ctdam:
 	idle:
 
 ctvega:
+	Defaults:
+		Offset: 0,-48
 	idle:
 		ShadowStart: 3
 	damaged-idle:
@@ -677,35 +818,42 @@ gaoldcc1:
 	idle:
 		ShadowStart: 2
 		UseTilesetCode: true
+		Offset: 0, -24
 
 gaoldcc2:
 	idle:
 		ShadowStart: 2
 		UseTilesetCode: true
+		Offset: 0, -24
 
 gaoldcc3:
-	idle: gtoldcc3
+	idle:
 		ShadowStart: 2
 		UseTilesetCode: true
+		Offset: 0, -24
 
 gaoldcc4:
 	idle:
 		ShadowStart: 2
 		UseTilesetCode: true
+		Offset: 0, -24
 
 gaoldcc5:
 	idle:
 		ShadowStart: 2
 		UseTilesetCode: true
+		Offset: 0, -24
 
 gaoldcc6:
 	idle:
 		ShadowStart: 2
 		UseTilesetCode: true
+		Offset: 0, -24
 
 gakodk:
 	Defaults:
 		UseTilesetCode: true
+		Offset: -24, -36
 	idle:
 		ShadowStart: 3
 	damaged-idle:
@@ -761,6 +909,7 @@ galite:
 namntk:
 	Defaults:
 		UseTilesetCode: true
+		Offset: 24, -24
 	idle:
 		ShadowStart: 3
 	damaged-idle:
@@ -771,6 +920,8 @@ namntk:
 		ShadowStart: 5
 
 ntpyra:
+	Defaults:
+		Offset: 0,-42
 	idle:
 		ShadowStart: 3
 	damaged-idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -342,48 +342,58 @@ trock01:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 trock02:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 trock03:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 trock04:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 trock05:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 srock01:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 srock02:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 srock03:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 srock04:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 srock05:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -49,126 +49,151 @@ tree01:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree02:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree03:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree04:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree05:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree06:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree07:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree08:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree09:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree10:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree11:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree12:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree13:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree14:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree15:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree16:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree17:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree18:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree19:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree20:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree21:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree22:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree23:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree24:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 tree25:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
+		Offset: 0, -12
 
 veinhole:
 	idle:


### PR DESCRIPTION
- fixed offsets for all civilian structures (closes #7744)
- fixed (or at least improved) offsets for rocks and trees
- CA00*\* structures are no longer exclusive to temperate theater and use the correct palette on snow maps as well
- same for CACRASH*\* crash sites
- removed some redundant junk from civilian structure sequences
