### PR TITLE
Enable the EMP overlay animation in TS.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -143,7 +143,10 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			pxPos += info.Offset;
+
+			// HACK: Because WorldRenderer.Position() does not care about terrain height at the location
 			var renderPos = wr.Position(pxPos);
+			renderPos = new WPos(renderPos.X, renderPos.Y + self.CenterPosition.Z, self.CenterPosition.Z);
 
 			anim.Tick();
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -357,6 +357,16 @@
 	TimedUpgradeBar@EMPDISABLE:
 		Upgrade: empdisable
 		Color: 255,255,255
+	WithDecoration@EMPDISABLE:
+		Image: emp
+		Sequence: idle
+		ReferencePoint: HCenter, VCenter
+		Palette: effect
+		UpgradeTypes: empdisable
+		ShowToEnemies: true
+		ZOffset: 512
+		UpgradeMinEnabledLevel: 1
+		UpgradeMaxAcceptedLevel: 2
 	Cloak@CLOAKGENERATOR:
 		UpgradeTypes: cloakgenerator
 		UpgradeMinEnabledLevel: 1

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -167,6 +167,7 @@ canister:
 pulsball:
 	idle:
 		Length: *
+		BlendMode: Additive
 
 dragon:
 	idle:
@@ -232,6 +233,11 @@ wake:
 	idle: wake2
 		Length: *
 		Tick: 180
+
+emp:
+	idle: emp_fx01
+		Length: *
+		BlendMode: Additive
 
 resources:
 	Defaults:


### PR DESCRIPTION
NB: This must use `WithDecoration` because `WithIdleOverlay` forces the Image be taken from the source actor, requiring it specified on every sequence - this is a more maintainable solution.

This is mostly aimed to @pchote after the discussion last night.
