### PR TITLE
Adjust the minigames' lobby settings

### DIFF
--- a/mods/cnc/maps/the-hot-box/map.yaml
+++ b/mods/cnc/maps/the-hot-box/map.yaml
@@ -28,6 +28,7 @@ Options:
 	FragileAlliances: False
 	StartingCash: 5000
 	ConfigurableStartingUnits: False
+	TechLevel: Unrestricted
 
 Players:
 	PlayerReference@Neutral:
@@ -38,63 +39,73 @@ Players:
 	PlayerReference@Multi0:
 		Name: Multi0
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi9, Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7, Multi8
+		Enemies: Creeps
 	PlayerReference@Multi1:
 		Name: Multi1
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7, Multi8, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi2:
 		Name: Multi2
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi3, Multi4, Multi5, Multi6, Multi7, Multi8, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi3:
 		Name: Multi3
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi2, Multi4, Multi5, Multi6, Multi7, Multi8, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi4:
 		Name: Multi4
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi5, Multi6, Multi7, Multi8, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi5:
 		Name: Multi5
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi4, Multi6, Multi7, Multi8, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi6:
 		Name: Multi6
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi4, Multi5, Multi7, Multi8, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi7:
 		Name: Multi7
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi8, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi8:
 		Name: Multi8
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7, Multi9
+		Enemies: Creeps
 	PlayerReference@Multi9:
 		Name: Multi9
 		Playable: True
+		AllowBots: False
 		LockRace: True
 		Race: nod
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7, Multi8
+		Enemies: Creeps
 	PlayerReference@Creeps:
 		Name: Creeps
 		NonCombatant: True

--- a/mods/ra/maps/bomber-john/map.yaml
+++ b/mods/ra/maps/bomber-john/map.yaml
@@ -28,6 +28,7 @@ Options:
 	FragileAlliances: False
 	StartingCash: 60
 	ConfigurableStartingUnits: False
+	TechLevel: Unrestricted
 
 Players:
 	PlayerReference@Neutral:
@@ -39,63 +40,63 @@ Players:
 		Name: Creeps
 		NonCombatant: True
 		Race: allies
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi0:
 		Name: Multi0
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi1:
 		Name: Multi1
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi2:
 		Name: Multi2
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi3:
 		Name: Multi3
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi4:
 		Name: Multi4
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi5:
 		Name: Multi5
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi1, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi6:
 		Name: Multi6
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi1, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi7:
 		Name: Multi7
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi1
+		Enemies: Creeps
 
 Actors:
 	Actor69: ftur

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -28,6 +28,7 @@ Options:
 	FragileAlliances: False
 	StartingCash: 5000
 	ConfigurableStartingUnits: False
+	TechLevel: Unrestricted
 
 Players:
 	PlayerReference@Neutral:
@@ -45,56 +46,56 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi1:
 		Name: Multi1
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi2:
 		Name: Multi2
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi3:
 		Name: Multi3
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi4:
 		Name: Multi4
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi5:
 		Name: Multi5
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi1, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi6:
 		Name: Multi6
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi1, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi7:
 		Name: Multi7
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi1
+		Enemies: Creeps
 
 Actors:
 	Actor0: apc

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -28,6 +28,7 @@ Options:
 	FragileAlliances: False
 	StartingCash: 5000
 	ConfigurableStartingUnits: False
+	TechLevel: Unrestricted
 
 Players:
 	PlayerReference@Neutral:
@@ -46,7 +47,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 	PlayerReference@Multi1:
 		Name: Multi1
@@ -54,7 +54,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 	PlayerReference@Multi2:
 		Name: Multi2
@@ -62,7 +61,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 	PlayerReference@Multi3:
 		Name: Multi3
@@ -70,7 +68,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 	PlayerReference@Multi4:
 		Name: Multi4
@@ -78,7 +75,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 	PlayerReference@Multi5:
 		Name: Multi5
@@ -86,7 +82,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 	PlayerReference@Multi6:
 		Name: Multi6
@@ -94,7 +89,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 	PlayerReference@Multi7:
 		Name: Multi7
@@ -102,7 +96,6 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: allies
-		LockSpawn: True
 		Enemies: Creeps
 
 Actors:

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -28,6 +28,7 @@ Options:
 	FragileAlliances: False
 	StartingCash: 5000
 	ConfigurableStartingUnits: False
+	TechLevel: Unrestricted
 
 Players:
 	PlayerReference@Neutral:
@@ -45,56 +46,56 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi1:
 		Name: Multi1
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi2:
 		Name: Multi2
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi3:
 		Name: Multi3
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi4:
 		Name: Multi4
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi5:
 		Name: Multi5
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi1, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi6:
 		Name: Multi6
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi1, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi7:
 		Name: Multi7
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi1
+		Enemies: Creeps
 
 Actors:
 	Actor0: apc

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -28,6 +28,7 @@ Options:
 	StartingCash: 50
 	ConfigurableStartingUnits: False
 	ShortGame: False
+	TechLevel: Unrestricted
 
 Players:
 	PlayerReference@Neutral:
@@ -40,6 +41,9 @@ Players:
 		Playable: True
 		AllowBots: False
 		LockTeam: True
+		Team: 0
+		LockRace: True
+		Race: allies
 		Allies: Multi1, Multi2, Multi3
 		Enemies: Soviets
 	PlayerReference@Multi1:
@@ -47,6 +51,9 @@ Players:
 		Playable: True
 		AllowBots: False
 		LockTeam: True
+		Team: 0
+		LockRace: True
+		Race: allies
 		Allies: Multi0, Multi2, Multi3
 		Enemies: Soviets
 	PlayerReference@Multi2:
@@ -54,6 +61,9 @@ Players:
 		Playable: True
 		AllowBots: False
 		LockTeam: True
+		Team: 0
+		LockRace: True
+		Race: allies
 		Allies: Multi0, Multi1, Multi3
 		Enemies: Soviets
 	PlayerReference@Multi3:
@@ -61,6 +71,9 @@ Players:
 		Playable: True
 		AllowBots: False
 		LockTeam: True
+		Team: 0
+		LockRace: True
+		Race: allies
 		Allies: Multi0, Multi1, Multi2
 		Enemies: Soviets
 	PlayerReference@Soviets:
@@ -136,7 +149,7 @@ Actors:
 	Actor73: tc05
 		Location: 16,34
 		Owner: Neutral
-	Actor30: barr
+	Actor30: tent
 		Location: 36,26
 		Owner: Multi0
 	Actor84: brik
@@ -358,13 +371,13 @@ Actors:
 	Actor88: brik
 		Location: 25,29
 		Owner: Neutral
-	Actor100: barr
+	Actor100: tent
 		Location: 27,26
 		Owner: Multi3
-	Actor99: barr
+	Actor99: tent
 		Location: 27,36
 		Owner: Multi2
-	Actor31: barr
+	Actor31: tent
 		Location: 36,36
 		Owner: Multi1
 	Sniper1: sniper.soviets
@@ -524,7 +537,7 @@ Rules:
 		CashTrickler:
 			Period: 250
 			Amount: 50
-	BARR:
+	TENT:
 		Health:
 			HP: 1000
 		Production:
@@ -695,6 +708,9 @@ Rules:
 		AutoSelectionSize:
 		RenderSprites:
 			Image: mig
+	SILO:
+		Buildable:
+			Prerequisites: ~disabled
 	BRIK:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/ra/maps/training-camp/map.yaml
+++ b/mods/ra/maps/training-camp/map.yaml
@@ -28,6 +28,7 @@ Options:
 	FragileAlliances: False
 	StartingCash: 100
 	ConfigurableStartingUnits: False
+	TechLevel: Unrestricted
 
 Players:
 	PlayerReference@Neutral:
@@ -45,56 +46,56 @@ Players:
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi1, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi1:
 		Name: Multi1
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi2:
 		Name: Multi2
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi3, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi3:
 		Name: Multi3
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi4, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi4:
 		Name: Multi4
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi1, Multi2, Multi3, Multi5, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi5:
 		Name: Multi5
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi1, Multi6, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi6:
 		Name: Multi6
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi1, Multi7
+		Enemies: Creeps
 	PlayerReference@Multi7:
 		Name: Multi7
 		Playable: True
 		AllowBots: False
 		LockRace: True
 		Race: soviet
-		Enemies: Multi0, Multi2, Multi3, Multi4, Multi5, Multi6, Multi1
+		Enemies: Creeps
 
 Actors:
 	Actor93: barr


### PR DESCRIPTION
- Disabled messing around with `TechLevel` as you can't build on those maps or the prerequisites are defined by the map.
- Removed "hardcoded" `Enemies: xyz` as you can't define teams anymore (for e.g. a 2vs2). Exception: `fort-lonestar`
- Removed `LockSpawn: True` from `dropzone-w`. That way it's useless anyway (see #7704).
- Disabled bots in `the-hot-box`
- Disabled different teams in `fort-lonestar` and also forced the race to `allies`
