### PR TITLE
The 'Jump to base' hotkey is useless if the Construction Yard is dest…

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -65,9 +65,6 @@ namespace OpenRA.Mods.Common.Traits
 
 			var crateActions = self.TraitsImplementing<CrateAction>();
 
-			self.Dispose();
-			collected = true;
-
 			if (crateActions.Any())
 			{
 				var shares = crateActions.Select(a => Pair.New(a, a.GetSelectionSharesOuter(crusher)));
@@ -79,7 +76,11 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					if (n < s.Second)
 					{
+						if (!crusher.HasTrait<Armament>() && s.First.GetEffectName().Equals("firepower"))
+							return;
 						s.First.Activate(crusher);
+						self.Dispose();
+						collected = true;
 						return;
 					}
 					else

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -65,6 +65,13 @@ namespace OpenRA.Mods.Common.Traits
 			return GetSelectionShares(collector);
 		}
 
+		public string GetEffectName()
+		{
+			if (info.Effect == null)
+				return "";
+			return info.Effect.ToString();
+		}
+
 		public virtual int GetSelectionShares(Actor collector)
 		{
 			return info.SelectionShares;

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -191,28 +191,24 @@ namespace OpenRA.Mods.Common.Widgets
 				.Select(b => b.Actor)
 				.ToList();
 
-            var noBase = false;
-
-            // If no base found the nondestroyed buildings are selected.
+            // If no base is found all existing buildings are selected.
             if (!bases.Any())
             {
-                bases = world.ActorsWithTrait<TargetableBuilding>()
+				bases = world.ActorsWithTrait<TargetableBuilding>()
                 .Where(a => a.Actor.Owner == world.LocalPlayer)
                 .Select(b => b.Actor)
                 .ToList();
-                noBase = true;
-            }
-
-            if (!bases.Any())
-                return true;
+                if (!bases.Any())
+					return true;
+            }   
 
 			var next = bases
 				.SkipWhile(b => !world.Selection.Actors.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 
-            // If no construction yard exists then next is set to only the oldest non-destroyed building
-			if (next == null || noBase)
+            // If no construction yard exists then next is set to only the oldest existing building
+			if (next == null || !next.HasTrait<BaseBuilding>())
 				next = bases.First();
 
 			world.Selection.Combine(world, new Actor[] { next }, false, true);

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -191,15 +191,27 @@ namespace OpenRA.Mods.Common.Widgets
 				.Select(b => b.Actor)
 				.ToList();
 
-			if (!bases.Any())
-				return true;
+            var noBase = false;
+
+            // If no base found the first nondestroyed building is selected.
+            if (!bases.Any())
+            {
+                bases = world.ActorsWithTrait<TargetableBuilding>()
+                .Where(a => a.Actor.Owner == world.LocalPlayer)
+                .Select(b => b.Actor)
+                .ToList();
+                noBase = true;
+            }
+
+            if (!bases.Any())
+                return true;
 
 			var next = bases
 				.SkipWhile(b => !world.Selection.Actors.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 
-			if (next == null)
+			if (next == null || noBase)
 				next = bases.First();
 
 			world.Selection.Combine(world, new Actor[] { next }, false, true);

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -191,23 +191,23 @@ namespace OpenRA.Mods.Common.Widgets
 				.Select(b => b.Actor)
 				.ToList();
 
-            // If no base is found all existing buildings are selected.
-            if (!bases.Any())
-            {
+			// If no base is found all existing buildings are selected.
+			if (!bases.Any())
+			{
 				bases = world.ActorsWithTrait<TargetableBuilding>()
-                .Where(a => a.Actor.Owner == world.LocalPlayer)
-                .Select(b => b.Actor)
-                .ToList();
-                if (!bases.Any())
+				.Where(a => a.Actor.Owner == world.LocalPlayer)
+				.Select(b => b.Actor)
+				.ToList();
+				if (!bases.Any())
 					return true;
-            }   
+			}
 
 			var next = bases
 				.SkipWhile(b => !world.Selection.Actors.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 
-            // If no construction yard exists then next is set to only the oldest existing building
+			// If no construction yard exists then next is set to only the oldest existing building
 			if (next == null || !next.HasTrait<BaseBuilding>())
 				next = bases.First();
 

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.Common.Widgets
 
             var noBase = false;
 
-            // If no base found the first nondestroyed building is selected.
+            // If no base found the nondestroyed buildings are selected.
             if (!bases.Any())
             {
                 bases = world.ActorsWithTrait<TargetableBuilding>()
@@ -211,6 +211,7 @@ namespace OpenRA.Mods.Common.Widgets
 				.Skip(1)
 				.FirstOrDefault();
 
+            // If no construction yard exists then next is set to only the oldest non-destroyed building
 			if (next == null || noBase)
 				next = bases.First();
 


### PR DESCRIPTION
…royed #3318

Now works like original Red Alert.  When there are no more Construction Yards the 'Jump to base' hotkey goes to the oldest undestroyed building.
