### PR TITLE
Dispose of the old world before creating a new one

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -135,6 +135,10 @@ namespace OpenRA
 		public static event Action BeforeGameStart = () => { };
 		internal static void StartGame(string mapUID, WorldType type)
 		{
+			// Dispose of the old world before creating a new one.
+			if (worldRenderer != null)
+				worldRenderer.Dispose();
+
 			Cursor.SetCursor(null);
 			BeforeGameStart();
 
@@ -143,13 +147,7 @@ namespace OpenRA
 			using (new PerfTimer("PrepareMap"))
 				map = ModData.PrepareMap(mapUID);
 			using (new PerfTimer("NewWorld"))
-			{
-				OrderManager.World = new World(map, OrderManager, type);
-				OrderManager.World.Timestep = Timestep;
-			}
-
-			if (worldRenderer != null)
-				worldRenderer.Dispose();
+				OrderManager.World = new World(map, OrderManager, type) { Timestep = Timestep };
 
 			worldRenderer = new WorldRenderer(OrderManager.World);
 


### PR DESCRIPTION
As discussed on IRC - [link](http://logs.openra.net/?year=2015&month=06&day=30#11:26:44).
The problem was that the new world was initialized before the old one was destroyed, so they overlapped, which led to a bunch of issues that we dealt with in different ways (unfortunately).
