### PR TITLE
Fixed another null reference exception in PngLoader

### DIFF
--- a/OpenRA.Game/FileFormats/PngLoader.cs
+++ b/OpenRA.Game/FileFormats/PngLoader.cs
@@ -84,6 +84,9 @@ namespace OpenRA.FileFormats
 
 							case "tRNS":
 								{
+									if (palette == null)
+										throw new InvalidDataException("Non-Palette indexed PNG are not supported.");
+
 									for (var i = 0; i < length; i++)
 										palette[i] = Color.FromArgb(cr.ReadByte(), palette[i]);
 								}


### PR DESCRIPTION
Discovered by Coverity. Just like https://github.com/OpenRA/OpenRA/pull/8312 catching it and re-throw gives a more helpful error message.
