### PR TITLE
Generate the selection bitmap when opening the ColorMixerWidget

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -58,6 +58,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var mixerSheet = new Sheet(new Size(256, 256));
 			mixerSheet.GetTexture().SetData(front, 256, 256);
 			mixerSprite = new Sprite(mixerSheet, rect, TextureChannel.Alpha);
+			GenerateBitmap();
 		}
 
 		void GenerateBitmap()


### PR DESCRIPTION
Fixes a bug where opening the widget with a red colour (i.e. hue = 0) would not generate this bitmap when opening the widget as that would not cause the selection bitmap to be refreshed.

You can recreate this bug on bleed by selecting a red colour on the widget (slide the hue slider to the extreme left), closing and then reopening the picker.
