### PR TITLE
Allied units will not attack a building being captured

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -45,11 +45,14 @@ namespace OpenRA.Mods.Common.Traits
 		readonly AutoTargetInfo info;
 		readonly AttackBase attack;
 		readonly AttackFollow at;
-		[Sync] int nextScanTime = 0;
+		[Sync]
+		int nextScanTime = 0;
 
 		public UnitStance Stance;
-		[Sync] public Actor Aggressor;
-		[Sync] public Actor TargetedActor;
+		[Sync]
+		public Actor Aggressor;
+		[Sync]
+		public Actor TargetedActor;
 
 		// NOT SYNCED: do not refer to this anywhere other than UI code
 		public UnitStance PredictedStance;
@@ -153,15 +156,19 @@ namespace OpenRA.Mods.Common.Traits
 
 			return inRange
 				.Where(a =>
+				{
+					var target = Target.FromActor(a);
+					return target.IsValidFor(self) &&
 					a.AppearsHostileTo(self) &&
-					!a.HasTrait<AutoTargetIgnore>() &&
 					attack.HasAnyValidWeapons(Target.FromActor(a)) &&
-					self.Owner.CanTargetActor(a))
+					self.Owner.CanTargetActor(a) &&
+					a.TraitsImplementing<IPreventsAutoTarget>().Any(t => t.CanAutoTarget(a, self));
+				})
 				.ClosestTo(self);
 		}
 	}
 
 	[Desc("Will not get automatically targeted by enemy (like walls)")]
 	class AutoTargetIgnoreInfo : TraitInfo<AutoTargetIgnore> { }
-	class AutoTargetIgnore { }
+	class AutoTargetIgnore : IPreventsAutoTarget { public bool CanAutoTarget(Actor self, Actor target) { return false; } }
 }

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -49,10 +49,12 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new ExternalCapturable(init.Self, this); }
 	}
 
-	public class ExternalCapturable : ITick
+	public class ExternalCapturable : ITick, IPreventsAutoTarget
 	{
-		[Sync] public int CaptureProgressTime = 0;
-		[Sync] public Actor Captor;
+		[Sync]
+		public int CaptureProgressTime = 0;
+		[Sync]
+		public Actor Captor;
 		private Actor self;
 		public ExternalCapturableInfo Info;
 		public bool CaptureInProgress { get { return Captor != null; } }
@@ -65,6 +67,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void BeginCapture(Actor captor)
 		{
+			// Stops actors currently targeting this actor from targeting it.
+			self.Generation++;
 			var building = self.TraitOrDefault<Building>();
 			if (building != null)
 				building.Lock();
@@ -91,5 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			else
 				CaptureProgressTime++;
 		}
+
+		public bool CanAutoTarget(Actor self, Actor attacker) { return !CaptureInProgress; }
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -96,4 +96,6 @@ namespace OpenRA.Mods.Common.Traits
 		void MovementCancelled(Actor self);
 		void RequestTransport(CPos destination, Activity afterLandActivity);
 	}
+
+	public interface IPreventsAutoTarget { bool CanAutoTarget(Actor self, Actor attacker); }
 }


### PR DESCRIPTION
Fixes #6170.
Units will still attack if the intent was to sabotage the building.
