### PR TITLE
Remove target line drawing in settings

### DIFF
--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -47,7 +47,8 @@ namespace OpenRA.Graphics
 			var a = first;
 			foreach (var b in waypoints.Skip(1).Select(pos => wr.ScreenPxPosition(pos)))
 			{
-				Game.Renderer.WorldLineRenderer.DrawLine(a, b, color);
+				if (Game.Settings.Game.DrawTargetLine)
+					Game.Renderer.WorldLineRenderer.DrawLine(a, b, color);
 				wr.DrawTargetMarker(color, b);
 				a = b;
 			}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -140,6 +140,7 @@ namespace OpenRA
 		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;
 		public bool TeamHealthColors = false;
+		public bool DrawTargetLine = true;
 
 		public bool AllowDownloading = true;
 		public string MapRepository = "http://resource.openra.net/map/";

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -154,6 +154,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
 			BindCheckboxPref(panel, "SHOW_SHELLMAP", gs, "ShowShellmap");
 			BindCheckboxPref(panel, "ALWAYS_SHOW_STATUS_BARS_CHECKBOX", gs, "AlwaysShowStatusBars");
+			BindCheckboxPref(panel, "DISPLAY_TARGET_LINES_CHECKBOX", gs, "DrawTargetLine");
 			BindCheckboxPref(panel, "TEAM_HEALTH_COLORS_CHECKBOX", gs, "TeamHealthColors");
 
 			var languageDropDownButton = panel.Get<DropDownButtonWidget>("LANGUAGE_DROPDOWNBUTTON");

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -190,6 +190,13 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Always Show Status Bars
+						Checkbox@DISPLAY_TARGET_LINES_CHECKBOX:
+							X: 310
+							Y: 245
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Display Target Lines
 						Label@LOCALIZATION_TITLE:
 							Y: 265
 							Width: PARENT_RIGHT

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -203,6 +203,13 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Always Show Status Bars
+				Checkbox@DISPLAY_TARGET_LINES_CHECKBOX:
+					X: 310
+					Y: 260
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Display Target Lines
 				Label@LOCALIZATION_TITLE:
 					Y: 270
 					Width: PARENT_RIGHT


### PR DESCRIPTION
Adds an option in the settings to turn off the drawing of lines from units to their target. Closes #6915. Useful for visibility while moving large amount of units.
