### PR TITLE
Removed the OpenAL/OpenGL/SDL2 dependency from the game engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 
 # program targets
-CORE = rsdl2 rnull game utility
+CORE = pdefault pnull game utility
 TOOLS = gamemonitor
 VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
 
@@ -100,25 +100,25 @@ endif
 game_SRCS := $(shell find OpenRA.Game/ -iname '*.cs')
 game_TARGET = OpenRA.Game.exe
 game_KIND = winexe
-game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SDL2-CS.dll thirdparty/download/SharpFont.dll
+game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SharpFont.dll
 game_FLAGS = -win32icon:OpenRA.Game/OpenRA.ico
 PROGRAMS += game
 game: $(game_TARGET)
 
-# Renderer dlls
-rsdl2_SRCS := $(shell find OpenRA.Renderer.Sdl2/ -iname '*.cs')
-rsdl2_TARGET = OpenRA.Renderer.Sdl2.dll
-rsdl2_KIND = library
-rsdl2_DEPS = $(game_TARGET)
-rsdl2_LIBS = $(COMMON_LIBS) thirdparty/download/SDL2-CS.dll $(rsdl2_DEPS)
+# Platform dlls
+pdefault_SRCS := $(shell find OpenRA.Platforms.Default/ -iname '*.cs')
+pdefault_TARGET = OpenRA.Platforms.Default.dll
+pdefault_KIND = library
+pdefault_DEPS = $(game_TARGET)
+pdefault_LIBS = $(COMMON_LIBS) thirdparty/download/SDL2-CS.dll $(pdefault_DEPS)
 
-rnull_SRCS := $(shell find OpenRA.Renderer.Null/ -iname '*.cs')
-rnull_TARGET = OpenRA.Renderer.Null.dll
-rnull_KIND = library
-rnull_DEPS = $(game_TARGET)
-rnull_LIBS = $(COMMON_LIBS) $(rnull_DEPS)
-PROGRAMS += rsdl2 rnull
-renderers: $(rsdl2_TARGET) $(rnull_TARGET)
+pnull_SRCS := $(shell find OpenRA.Platforms.Null/ -iname '*.cs')
+pnull_TARGET = OpenRA.Platforms.Null.dll
+pnull_KIND = library
+pnull_DEPS = $(game_TARGET)
+pnull_LIBS = $(COMMON_LIBS) $(pnull_DEPS)
+PROGRAMS += pdefault pnull
+platforms: $(pdefault_TARGET) $(pnull_TARGET)
 
 # Mods Common
 mod_common_SRCS := $(shell find OpenRA.Mods.Common/ -iname '*.cs')
@@ -181,8 +181,11 @@ check: utility mods
 	@echo "Checking for code style violations in OpenRA.Game..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Game
 	@echo
-	@echo "Checking for code style violations in OpenRA.Renderer.Null..."
-	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Renderer.Null
+	@echo "Checking for code style violations in OpenRA.Platforms.Default..."
+	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Platforms.Default
+	@echo
+	@echo "Checking for code style violations in OpenRA.Platforms.Null..."
+	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Platforms.Null
 	@echo
 	@echo "Checking for code style violations in OpenRA.GameMonitor..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.GameMonitor
@@ -201,9 +204,6 @@ check: utility mods
 	@echo
 	@echo "Checking for code style violations in OpenRA.Mods.TS..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Mods.TS
-	@echo
-	@echo "Checking for code style violations in OpenRA.Renderer.Sdl2..."
-	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Renderer.Sdl2
 	@echo
 	@echo "Checking for code style violations in OpenRA.Utility..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Utility
@@ -275,7 +275,7 @@ $(foreach prog,$(PROGRAMS),$(eval $(call BUILD_ASSEMBLY,$(prog))))
 #
 default: core
 
-core: game renderers mods utility
+core: game platforms mods utility
 
 tools: gamemonitor
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -391,7 +391,7 @@ namespace OpenRA
 
 			Bitmap bitmap;
 			using (new PerfTimer("Renderer.TakeScreenshot"))
-				bitmap = Renderer.TakeScreenshot();
+				bitmap = Renderer.Device.TakeScreenshot();
 
 			ThreadPool.QueueUserWorkItem(_ =>
 			{

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -215,7 +215,7 @@ namespace OpenRA
 			GeoIP.Initialize();
 
 			GlobalFileSystem.Mount(Platform.GameDir); // Needed to access shaders
-			var renderers = new[] { Settings.Graphics.Renderer, "Sdl2", null };
+			var renderers = new[] { Settings.Graphics.Renderer, "Default", null };
 			foreach (var r in renderers)
 			{
 				if (r == null)
@@ -232,18 +232,6 @@ namespace OpenRA
 					Log.Write("graphics", "{0}", e);
 					Console.WriteLine("Renderer initialization failed. Fallback in place. Check graphics.log for details.");
 				}
-			}
-
-			try
-			{
-				Sound.Create(Settings.Sound.Engine);
-			}
-			catch (Exception e)
-			{
-				Log.Write("sound", "{0}", e);
-				Console.WriteLine("Creating the sound engine failed. Fallback in place. Check sound.log for details.");
-				Settings.Sound.Engine = "Null";
-				Sound.Create(Settings.Sound.Engine);
 			}
 
 			Console.WriteLine("Available mods:");
@@ -287,7 +275,7 @@ namespace OpenRA
 			Settings.Game.Mod = mod;
 
 			Sound.StopVideo();
-			Sound.Initialize();
+			Sound.Initialize(Settings.Sound, Settings.Server);
 
 			ModData = new ModData(mod, !Settings.Server.Dedicated);
 			ModData.InitializeLoaders();

--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -15,11 +15,11 @@ using OpenRA.Graphics;
 namespace OpenRA
 {
 	[AttributeUsage(AttributeTargets.Assembly)]
-	public sealed class RendererAttribute : Attribute
+	public sealed class PlatformAttribute : Attribute
 	{
 		public readonly Type Type;
 
-		public RendererAttribute(Type graphicsDeviceType)
+		public PlatformAttribute(Type graphicsDeviceType)
 		{
 			if (!typeof(IDeviceFactory).IsAssignableFrom(graphicsDeviceType))
 				throw new InvalidOperationException("Incorrect type in RendererAttribute");
@@ -29,7 +29,8 @@ namespace OpenRA
 
 	public interface IDeviceFactory
 	{
-		IGraphicsDevice Create(Size size, WindowMode windowMode);
+		IGraphicsDevice CreateGraphics(Size size, WindowMode windowMode);
+		ISoundEngine CreateSound();
 	}
 
 	public interface IHardwareCursor : IDisposable { }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -84,10 +84,6 @@
       <HintPath>..\thirdparty\download\MaxMind.Db.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SDL2-CS">
-      <HintPath>..\thirdparty\download\SDL2-CS.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activities\Activity.cs" />
@@ -120,7 +116,6 @@
     <Compile Include="Graphics\LineRenderer.cs" />
     <Compile Include="Graphics\MappedImage.cs" />
     <Compile Include="Graphics\Minimap.cs" />
-    <Compile Include="Graphics\Renderer.cs" />
     <Compile Include="Graphics\SequenceProvider.cs" />
     <Compile Include="Graphics\Sheet.cs" />
     <Compile Include="Graphics\SheetBuilder.cs" />
@@ -228,8 +223,6 @@
     <Compile Include="Graphics\IGraphicsDevice.cs" />
     <Compile Include="Sound\Sound.cs" />
     <Compile Include="Sound\SoundDevice.cs" />
-    <Compile Include="Sound\OpenAlSound.cs" />
-    <Compile Include="Sound\NullSound.cs" />
     <Compile Include="Effects\SpriteEffect.cs" />
     <Compile Include="Graphics\SelectionBarsRenderable.cs" />
     <Compile Include="Graphics\TargetLineRenderable.cs" />
@@ -249,6 +242,8 @@
     <Compile Include="Graphics\TerrainSpriteLayer.cs" />
     <Compile Include="Map\ProjectedCellRegion.cs" />
     <Compile Include="Map\MapCoordsRegion.cs" />
+    <Compile Include="Renderer.cs" />
+    <Compile Include="Platform.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />
@@ -298,7 +293,6 @@
     <Compile Include="Support\PerfTimer.cs" />
     <Compile Include="Exts.cs" />
     <Compile Include="MiniYaml.cs" />
-    <Compile Include="Platform.cs" />
     <Compile Include="StreamExts.cs" />
     <Compile Include="Map\Map.cs" />
     <Compile Include="Map\MapCache.cs" />

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -13,9 +13,10 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Reflection;
+using OpenRA.Graphics;
 using OpenRA.Support;
 
-namespace OpenRA.Graphics
+namespace OpenRA
 {
 	public sealed class Renderer : IDisposable
 	{
@@ -49,7 +50,7 @@ namespace OpenRA.Graphics
 			var resolution = GetResolution(graphicSettings);
 
 			var rendererName = serverSettings.Dedicated ? "Null" : graphicSettings.Renderer;
-			var rendererPath = Platform.ResolvePath(".", "OpenRA.Renderer." + rendererName + ".dll");
+			var rendererPath = Platform.ResolvePath(".", "OpenRA.Platforms." + rendererName + ".dll");
 
 			Device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, graphicSettings.Mode);
 
@@ -79,12 +80,12 @@ namespace OpenRA.Graphics
 			return new Size(size.X, size.Y);
 		}
 
-		static IGraphicsDevice CreateDevice(Assembly rendererDll, int width, int height, WindowMode window)
+		static IGraphicsDevice CreateDevice(Assembly platformDll, int width, int height, WindowMode window)
 		{
-			foreach (RendererAttribute r in rendererDll.GetCustomAttributes(typeof(RendererAttribute), false))
+			foreach (PlatformAttribute r in platformDll.GetCustomAttributes(typeof(PlatformAttribute), false))
 			{
 				var factory = (IDeviceFactory)r.Type.GetConstructor(Type.EmptyTypes).Invoke(null);
-				return factory.Create(new Size(width, height), window);
+				return factory.CreateGraphics(new Size(width, height), window);
 			}
 
 			throw new InvalidOperationException("Renderer DLL is missing RendererAttribute to tell us what type to use!");

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -161,11 +161,6 @@ namespace OpenRA
 			DrawBatch(tempBuffer, 0, numVertices, type);
 		}
 
-		public Bitmap TakeScreenshot()
-		{
-			return Device.TakeScreenshot();
-		}
-
 		public void DrawBatch<T>(IVertexBuffer<T> vertices,
 			int firstVertex, int numVertices, PrimitiveType type)
 			where T : struct

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -111,7 +111,7 @@ namespace OpenRA
 
 	public class GraphicSettings
 	{
-		public string Renderer = "Sdl2";
+		public string Renderer = "Default";
 		public WindowMode Mode = WindowMode.PseudoFullscreen;
 		public int2 FullscreenSize = new int2(0, 0);
 		public int2 WindowedSize = new int2(1024, 768);
@@ -139,7 +139,7 @@ namespace OpenRA
 		public bool Shuffle = false;
 		public bool Repeat = false;
 
-		public string Engine = "AL";
+		public string Engine = "Default";
 		public string Device = null;
 
 		public bool CashTicks = true;

--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -8,10 +8,13 @@
  */
 #endregion
 
+using System;
+
 namespace OpenRA
 {
-	interface ISoundEngine
+	public interface ISoundEngine
 	{
+		SoundDevice[] AvailableDevices();
 		ISoundSource AddSoundSourceFromMemory(byte[] data, int channels, int sampleBits, int sampleRate);
 		ISound Play2D(ISoundSource sound, bool loop, bool relative, WPos pos, float volume, bool attenuateVolume);
 		float Volume { get; set; }
@@ -41,7 +44,7 @@ namespace OpenRA
 		}
 	}
 
-	interface ISoundSource { }
+	public interface ISoundSource { }
 
 	public interface ISound
 	{

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -1,0 +1,32 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Reflection;
+using OpenRA;
+
+[assembly: Platform(typeof(OpenRA.Platforms.Default.DeviceFactory))]
+
+namespace OpenRA.Platforms.Default
+{
+	public class DeviceFactory : IDeviceFactory
+	{
+		public IGraphicsDevice CreateGraphics(Size size, WindowMode windowMode)
+		{
+			return new Sdl2GraphicsDevice(size, windowMode);
+		}
+
+		public ISoundEngine CreateSound()
+		{
+			return new OpenAlSoundEngine();
+		}
+	}
+}

--- a/OpenRA.Platforms.Default/ErrorHandler.cs
+++ b/OpenRA.Platforms.Default/ErrorHandler.cs
@@ -1,18 +1,18 @@
 #region Copyright & License Information
 /*
-* Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
-* This file is part of OpenRA, which is free software. It is made
-* available to you under the terms of the GNU General Public License
-* as published by the Free Software Foundation. For more information,
-* see COPYING.
-*/
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
 #endregion
 
 using System;
 using System.Diagnostics;
 using OpenTK.Graphics.OpenGL;
 
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
 	public static class ErrorHandler
 	{

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -14,7 +14,7 @@ using System.Drawing;
 using System.IO;
 using OpenTK.Graphics.OpenGL;
 
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
 	public sealed class FrameBuffer : IFrameBuffer
 	{

--- a/OpenRA.Platforms.Default/MultiTapDetection.cs
+++ b/OpenRA.Platforms.Default/MultiTapDetection.cs
@@ -11,7 +11,7 @@
 using System;
 using OpenRA.Primitives;
 
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
 	public static class MultiTapDetection
 	{

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -19,10 +19,22 @@ using OpenRA.Traits;
 using OpenTK;
 using OpenTK.Audio.OpenAL;
 
-namespace OpenRA
+namespace OpenRA.Platforms.Default
 {
 	class OpenAlSoundEngine : ISoundEngine
 	{
+		public SoundDevice[] AvailableDevices()
+		{
+			var defaultDevices = new[]
+			{
+				new SoundDevice("Default", null, "Default Output"),
+				new SoundDevice("Null", null, "Output Disabled")
+			};
+
+			var physicalDevices = PhysicalDevices().Select(d => new SoundDevice("Default", d, d));
+			return defaultDevices.Concat(physicalDevices).ToArray();
+		}
+
 		class PoolSlot
 		{
 			public bool IsActive;
@@ -55,7 +67,7 @@ namespace OpenRA
 			return devices;
 		}
 
-		public static string[] AvailableDevices()
+		static string[] PhysicalDevices()
 		{
 			// Returns all devices under Windows Vista and newer
 			if (Alc.IsExtensionPresent(IntPtr.Zero, "ALC_ENUMERATE_ALL_EXT"))
@@ -148,7 +160,7 @@ namespace OpenRA
 				return null;
 			}
 
-			var currFrame = Game.OrderManager.LocalFrameNumber;
+			var currFrame = Game.LocalTick;
 			var atten = 1f;
 
 			// Check if max # of instances-per-location reached:

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -7,8 +7,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{33D03738-C154-4028-8EA8-63A3C488A651}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>OpenRA.Renderer.Sdl2</RootNamespace>
-    <AssemblyName>OpenRA.Renderer.Sdl2</AssemblyName>
+    <RootNamespace>OpenRA.Platforms.Default</RootNamespace>
+    <AssemblyName>OpenRA.Platforms.Default</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -34,20 +34,24 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
+    <Reference Include="Eluant">
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
+    </Reference>
     <Reference Include="SDL2-CS">
       <HintPath>..\thirdparty\download\SDL2-CS.dll</HintPath>
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Sdl2Input.cs" />
+    <Compile Include="DefaultPlatform.cs" />
     <Compile Include="Sdl2GraphicsDevice.cs" />
+    <Compile Include="Sdl2Input.cs" />
     <Compile Include="Shader.cs" />
     <Compile Include="ErrorHandler.cs" />
     <Compile Include="FrameBuffer.cs" />
     <Compile Include="MultiTapDetection.cs" />
     <Compile Include="Texture.cs" />
     <Compile Include="VertexBuffer.cs" />
+    <Compile Include="OpenAlSoundEngine.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Platforms.Default
 					if (surface == IntPtr.Zero)
 						throw new InvalidDataException("Failed to create surface: {0}".F(SDL.SDL_GetError()));
 
-					var sur = (SDL2.SDL.SDL_Surface)Marshal.PtrToStructure(surface, typeof(SDL2.SDL.SDL_Surface));
+					var sur = (SDL.SDL_Surface)Marshal.PtrToStructure(surface, typeof(SDL.SDL_Surface));
 					Marshal.Copy(data, 0, sur.pixels, data.Length);
 
 					// This call very occasionally fails on Windows, but often works when retried.

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -1,11 +1,11 @@
 #region Copyright & License Information
 /*
-* Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
-* This file is part of OpenRA, which is free software. It is made
-* available to you under the terms of the GNU General Public License
-* as published by the Free Software Foundation. For more information,
-* see COPYING.
-*/
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
 #endregion
 
 using System;
@@ -14,22 +14,12 @@ using System.IO;
 using System.Runtime.InteropServices;
 using OpenRA;
 using OpenRA.Graphics;
+using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using SDL2;
 
-[assembly: Renderer(typeof(OpenRA.Renderer.Sdl2.DeviceFactory))]
-
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
-	public class DeviceFactory : IDeviceFactory
-	{
-		public IGraphicsDevice Create(Size size, WindowMode windowMode)
-		{
-			Console.WriteLine("Using SDL 2 with OpenGL renderer");
-			return new Sdl2GraphicsDevice(size, windowMode);
-		}
-	}
-
 	public sealed class Sdl2GraphicsDevice : IGraphicsDevice
 	{
 		Size size;
@@ -41,6 +31,8 @@ namespace OpenRA.Renderer.Sdl2
 
 		public Sdl2GraphicsDevice(Size windowSize, WindowMode windowMode)
 		{
+			Console.WriteLine("Using SDL 2 with OpenGL renderer");
+
 			size = windowSize;
 
 			SDL.SDL_Init(SDL.SDL_INIT_NOPARACHUTE | SDL.SDL_INIT_VIDEO);
@@ -84,6 +76,7 @@ namespace OpenRA.Renderer.Sdl2
 
 			context = SDL.SDL_GL_CreateContext(window);
 			SDL.SDL_GL_MakeCurrent(window, context);
+
 			GL.LoadAll();
 			ErrorHandler.CheckGlVersion();
 			ErrorHandler.CheckGlError();

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Platforms.Default
 			GL.EnableClientState(ArrayCap.TextureCoordArray);
 			ErrorHandler.CheckGlError();
 
-			SDL.SDL_SetModState(0);
+			SDL.SDL_SetModState(SDL.SDL_Keymod.KMOD_NONE);
 			input = new Sdl2Input();
 		}
 
@@ -114,10 +114,10 @@ namespace OpenRA.Platforms.Default
 		{
 			var c = cursor as SDL2HardwareCursor;
 			if (c == null)
-				SDL.SDL_ShowCursor(0);
+				SDL.SDL_ShowCursor((int)SDL.SDL_bool.SDL_FALSE);
 			else
 			{
-				SDL.SDL_ShowCursor(1);
+				SDL.SDL_ShowCursor((int)SDL.SDL_bool.SDL_TRUE);
 				SDL.SDL_SetCursor(c.Cursor);
 			}
 		}

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -76,6 +76,7 @@ namespace OpenRA.Platforms.Default
 
 			context = SDL.SDL_GL_CreateContext(window);
 			SDL.SDL_GL_MakeCurrent(window, context);
+			GraphicsContext.CurrentContext = context;
 
 			GL.LoadAll();
 			ErrorHandler.CheckGlVersion();

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using SDL2;
 
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
 	public class Sdl2Input
 	{

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -15,7 +15,7 @@ using System.Text;
 using OpenRA.FileSystem;
 using OpenTK.Graphics.OpenGL;
 
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
 	public class Shader : IShader
 	{

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -14,7 +14,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using OpenTK.Graphics.OpenGL;
 
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
 	public sealed class Texture : ITexture
 	{

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -12,7 +12,7 @@ using System;
 using System.Runtime.InteropServices;
 using OpenTK.Graphics.OpenGL;
 
-namespace OpenRA.Renderer.Sdl2
+namespace OpenRA.Platforms.Default
 {
 	public sealed class VertexBuffer<T> : IVertexBuffer<T>
 			where T : struct

--- a/OpenRA.Platforms.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Platforms.Null/NullGraphicsDevice.cs
@@ -10,21 +10,10 @@
 
 using System;
 using System.Drawing;
-using OpenRA;
 using OpenRA.Graphics;
 
-[assembly: Renderer(typeof(OpenRA.Renderer.Null.DeviceFactory))]
-
-namespace OpenRA.Renderer.Null
+namespace OpenRA.Platforms.Null
 {
-	public class DeviceFactory : IDeviceFactory
-	{
-		public IGraphicsDevice Create(Size size, WindowMode windowMode)
-		{
-			return new NullGraphicsDevice(size, windowMode);
-		}
-	}
-
 	public sealed class NullGraphicsDevice : IGraphicsDevice
 	{
 		public Size WindowSize { get; internal set; }

--- a/OpenRA.Platforms.Null/NullPlatform.cs
+++ b/OpenRA.Platforms.Null/NullPlatform.cs
@@ -1,0 +1,31 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using OpenRA;
+
+[assembly: Platform(typeof(OpenRA.Platforms.Null.DeviceFactory))]
+
+namespace OpenRA.Platforms.Null
+{
+	public class DeviceFactory : IDeviceFactory
+	{
+		public IGraphicsDevice CreateGraphics(Size size, WindowMode windowMode)
+		{
+			return new NullGraphicsDevice(size, windowMode);
+		}
+
+		public ISoundEngine CreateSound()
+		{
+			return new NullSoundEngine();
+		}
+	}
+}

--- a/OpenRA.Platforms.Null/NullSound.cs
+++ b/OpenRA.Platforms.Null/NullSound.cs
@@ -10,10 +10,15 @@
 
 using System;
 
-namespace OpenRA
+namespace OpenRA.Platforms.Null
 {
 	class NullSoundEngine : ISoundEngine
 	{
+		public SoundDevice[] AvailableDevices()
+		{
+			return new[] { new SoundDevice("Null", null, "Output Disabled") };
+		}
+
 		public NullSoundEngine()
 		{
 			Console.WriteLine("Using Null sound engine which disables SFX completely");

--- a/OpenRA.Platforms.Null/OpenRA.Platforms.Null.csproj
+++ b/OpenRA.Platforms.Null/OpenRA.Platforms.Null.csproj
@@ -8,11 +8,10 @@
     <ProjectGuid>{0C4AEC1A-E7D5-4114-8CCD-3EEC82872981}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>OpenRA.Renderer.Null</RootNamespace>
-    <AssemblyName>OpenRA.Renderer.Null</AssemblyName>
+    <RootNamespace>OpenRA.Platforms.Null</RootNamespace>
+    <AssemblyName>OpenRA.Platforms.Null</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
+    <FileUpgradeFlags></FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation />
     <PublishUrl>publish\</PublishUrl>
@@ -55,9 +54,14 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
+    <Reference Include="Eluant">
+      <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NullGraphicsDevice.cs" />
+    <Compile Include="NullSound.cs" />
+    <Compile Include="NullPlatform.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.sln
+++ b/OpenRA.sln
@@ -11,13 +11,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Mods.Cnc", "OpenRA.M
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Utility", "OpenRA.Utility\OpenRA.Utility.csproj", "{F33337BE-CB69-4B24-850F-07D23E408DDF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Renderer.Null", "OpenRA.Renderer.Null\OpenRA.Renderer.Null.csproj", "{0C4AEC1A-E7D5-4114-8CCD-3EEC82872981}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Platforms.Null", "OpenRA.Platforms.Null\OpenRA.Platforms.Null.csproj", "{0C4AEC1A-E7D5-4114-8CCD-3EEC82872981}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Mods.D2k", "OpenRA.Mods.D2k\OpenRA.Mods.D2k.csproj", "{C0B0465C-6BE2-409C-8770-3A9BF64C4344}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Mods.TS", "OpenRA.Mods.TS\OpenRA.Mods.TS.csproj", "{5457CBF5-4CE4-421E-A8BF-9FD6C9732E1D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Renderer.Sdl2", "OpenRA.Renderer.Sdl2\OpenRA.Renderer.Sdl2.csproj", "{33D03738-C154-4028-8EA8-63A3C488A651}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Platforms.Default", "OpenRA.Platforms.Default\OpenRA.Platforms.Default.csproj", "{33D03738-C154-4028-8EA8-63A3C488A651}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Mods.Common", "OpenRA.Mods.Common\OpenRA.Mods.Common.csproj", "{FE6C8CC0-2F07-442A-B29F-17617B3B7FC6}"
 EndProject

--- a/make.ps1
+++ b/make.ps1
@@ -150,8 +150,10 @@ elseif ($command -eq "check")
 {
 	if (Test-Path OpenRA.Utility.exe)
 	{
-		echo "Checking for code style violations in OpenRA.Renderer.Null..."
-		./OpenRA.Utility.exe ra --check-code-style OpenRA.Renderer.Null
+		echo "Checking for code style violations in OpenRA.Platforms.Default..."
+		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Platforms.Default
+		echo "Checking for code style violations in OpenRA.Platforms.Null..."
+		./OpenRA.Utility.exe ra --check-code-style OpenRA.Platforms.Null
 		echo "Checking for code style violations in OpenRA.GameMonitor..."
 		./OpenRA.Utility.exe ra --check-code-style OpenRA.GameMonitor
 		echo "Checking for code style violations in OpenRA.Game..."
@@ -166,8 +168,6 @@ elseif ($command -eq "check")
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Mods.D2k
 		echo "Checking for code style violations in OpenRA.Mods.TS..."
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Mods.TS
-		echo "Checking for code style violations in OpenRA.Renderer.Sdl2..."
-		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Renderer.Sdl2
 		echo "Checking for code style violations in OpenRA.Utility..."
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Utility
 		echo "Checking for code style violations in OpenRA.Test..."

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -32,7 +32,7 @@ markdown Lua-API.md > Lua-API.html
 
 # List of files that are packaged on all platforms
 FILES=('OpenRA.Game.exe' 'OpenRA.Game.exe.config' 'OpenRA.Utility.exe' \
-'OpenRA.Renderer.Sdl2.dll' 'OpenRA.Renderer.Null.dll' \
+'OpenRA.Platforms.Default.dll' 'OpenRA.Platforms.Null.dll' \
  'lua' 'glsl' 'mods/common' 'mods/ra' 'mods/cnc' 'mods/d2k' 'mods/modchooser' \
 'AUTHORS' 'COPYING' 'README.html' 'CONTRIBUTING.html' 'DOCUMENTATION.html' 'CHANGELOG.html' \
 'global mix database.dat' 'GeoLite2-Country.mmdb.gz')

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -83,8 +83,8 @@ Section "Game" GAME
 	File "${SRCDIR}\OpenRA.Game.exe"
 	File "${SRCDIR}\OpenRA.Game.exe.config"
 	File "${SRCDIR}\OpenRA.Utility.exe"
-	File "${SRCDIR}\OpenRA.Renderer.Null.dll"
-	File "${SRCDIR}\OpenRA.Renderer.Sdl2.dll"
+	File "${SRCDIR}\OpenRA.Platforms.Null.dll"
+	File "${SRCDIR}\OpenRA.Platforms.Default.dll"
 	File "${SRCDIR}\ICSharpCode.SharpZipLib.dll"
 	File "${SRCDIR}\FuzzyLogicLibrary.dll"
 	File "${SRCDIR}\Mono.Nat.dll"
@@ -188,8 +188,8 @@ Function ${UN}Clean
 	Delete $INSTDIR\OpenRA.Game.exe
 	Delete $INSTDIR\OpenRA.Game.exe.config
 	Delete $INSTDIR\OpenRA.Utility.exe
-	Delete $INSTDIR\OpenRA.Renderer.Null.dll
-	Delete $INSTDIR\OpenRA.Renderer.Sdl2.dll
+	Delete $INSTDIR\OpenRA.Platforms.Null.dll
+	Delete $INSTDIR\OpenRA.Platforms.Default.dll
 	Delete $INSTDIR\ICSharpCode.SharpZipLib.dll
 	Delete $INSTDIR\FuzzyLogicLibrary.dll
 	Delete $INSTDIR\Mono.Nat.dll


### PR DESCRIPTION
I removed the OpenAL (and subsequent OpenTK) dependency from OpenRA.Game and placed it into the renderer DLLs, which in fact do a lot more than just rendering nowadays (input, window creation, etc.) so I renamed things to reflect this.

Our SDL2/OpenGL/OpenAL combination works fine, but isn't far from ideal. Now it is possible for anyone to create a DirectX platform DLL or something more light weight new based on GLFW or other stripped down OpenGL bindings etc.

Closes #5274.
