### PR TITLE
Move Warheads from the engine to Mods.Common

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -62,7 +62,7 @@ namespace OpenRA.GameRules
 		public readonly IProjectileInfo Projectile;
 
 		[FieldLoader.LoadUsing("LoadWarheads")]
-		public readonly List<Warhead> Warheads = new List<Warhead>();
+		public readonly List<IWarhead> Warheads = new List<IWarhead>();
 
 		readonly HashSet<string> validTargetSet;
 		readonly HashSet<string> invalidTargetSet;
@@ -86,10 +86,10 @@ namespace OpenRA.GameRules
 
 		static object LoadWarheads(MiniYaml yaml)
 		{
-			var retList = new List<Warhead>();
+			var retList = new List<IWarhead>();
 			foreach (var node in yaml.Nodes.Where(n => n.Key.StartsWith("Warhead")))
 			{
-				var ret = Game.CreateObject<Warhead>(node.Value.Value + "Warhead");
+				var ret = Game.CreateObject<IWarhead>(node.Value.Value + "Warhead");
 				FieldLoader.Load(ret, node.Value);
 				retList.Add(ret);
 			}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -100,7 +100,6 @@
     <Compile Include="FileSystem\BagFile.cs" />
     <Compile Include="Map\MapPlayers.cs" />
     <Compile Include="MPos.cs" />
-    <Compile Include="GameRules\Warhead.cs" />
     <Compile Include="Graphics\QuadRenderer.cs" />
     <Compile Include="Download.cs" />
     <Compile Include="Effects\AsyncAction.cs" />
@@ -235,7 +234,6 @@
     <Compile Include="Graphics\SelectionBarsRenderable.cs" />
     <Compile Include="Graphics\TargetLineRenderable.cs" />
     <Compile Include="Graphics\UISpriteRenderable.cs" />
-    <Compile Include="GameRules\DamageWarhead.cs" />
     <Compile Include="Graphics\SoftwareCursor.cs" />
     <Compile Include="Graphics\HardwareCursor.cs" />
     <Compile Include="Support\PerfItem.cs" />

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Linq;
-using OpenRA.GameRules;
 
 namespace OpenRA.Traits
 {
@@ -88,7 +86,7 @@ namespace OpenRA.Traits
 			{
 				Attacker = repairer,
 				Damage = -MaxHP,
-				DamageState = this.DamageState,
+				DamageState = DamageState,
 				PreviousDamageState = DamageState.Dead,
 				Warhead = null,
 			};
@@ -106,9 +104,9 @@ namespace OpenRA.Traits
 					nd.AppliedDamage(repairer, self, ai);
 		}
 
-		public void InflictDamage(Actor self, Actor attacker, int damage, DamageWarhead warhead, bool ignoreModifiers)
+		public void InflictDamage(Actor self, Actor attacker, int damage, IWarhead warhead, bool ignoreModifiers)
 		{
-			// Overkill! don't count extra hits as more kills!
+			// Overkill! Don't count extra hits as more kills!
 			if (IsDead)
 				return;
 
@@ -177,7 +175,7 @@ namespace OpenRA.Traits
 	public class HealthInit : IActorInit<int>
 	{
 		[FieldFromYamlKey] readonly int value = 100;
-		readonly bool allowZero = false;
+		readonly bool allowZero;
 		public HealthInit() { }
 		public HealthInit(int init, bool allowZero = false)
 		{
@@ -205,7 +203,7 @@ namespace OpenRA.Traits
 			return (health == null) ? DamageState.Undamaged : health.DamageState;
 		}
 
-		public static void InflictDamage(this Actor self, Actor attacker, int damage, DamageWarhead warhead)
+		public static void InflictDamage(this Actor self, Actor attacker, int damage, IWarhead warhead)
 		{
 			if (self.Disposed) return;
 			var health = self.TraitOrDefault<Health>();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -12,9 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Activities;
-using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -48,9 +46,9 @@ namespace OpenRA.Traits
 
 	public class AttackInfo
 	{
-		public Actor Attacker;
-		public DamageWarhead Warhead;
 		public int Damage;
+		public Actor Attacker;
+		public IWarhead Warhead;
 		public DamageState DamageState;
 		public DamageState PreviousDamageState;
 	}
@@ -352,5 +350,13 @@ namespace OpenRA.Traits
 		void OnObjectiveAdded(Player player, int objectiveID);
 		void OnObjectiveCompleted(Player player, int objectiveID);
 		void OnObjectiveFailed(Player player, int objectiveID);
+	}
+
+	public interface IWarhead
+	{
+		int Delay { get; }
+		bool IsValidAgainst(Actor victim, Actor firedBy);
+		bool IsValidAgainst(FrozenActor victim, Actor firedBy);
+		void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers);
 	}
 }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -205,7 +205,7 @@ namespace OpenRA.Traits
 	}
 
 	public interface IRenderModifier { IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r); }
-	public interface IDamageModifier { int GetDamageModifier(Actor attacker, DamageWarhead warhead); }
+	public interface IDamageModifier { int GetDamageModifier(Actor attacker, IWarhead warhead); }
 	public interface ISpeedModifier { int GetSpeedModifier(); }
 	public interface IFirepowerModifier { int GetFirepowerModifier(); }
 	public interface IReloadModifier { int GetReloadModifier(); }

--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -101,7 +100,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public int GetDamageModifier(Actor attacker, DamageWarhead warhead)
+		public int GetDamageModifier(Actor attacker, IWarhead warhead)
 		{
 			return state == PopupState.Closed ? info.ClosedDamageMultiplier : 100;
 		}

--- a/OpenRA.Mods.Cnc/Traits/SpawnViceroid.cs
+++ b/OpenRA.Mods.Cnc/Traits/SpawnViceroid.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -33,8 +34,11 @@ namespace OpenRA.Mods.Cnc.Traits
 		public void Killed(Actor self, AttackInfo e)
 		{
 			if (!self.World.LobbyInfo.GlobalSettings.Creeps) return;
-			if (e.Warhead == null || !e.Warhead.DamageTypes.Contains(info.DeathType)) return;
 			if (self.World.SharedRandom.Next(100) > info.Probability) return;
+
+			var warhead = e.Warhead as DamageWarhead;
+			if (warhead == null || !warhead.DamageTypes.Contains(info.DeathType))
+				return;
 
 			self.World.AddFrameEndTask(w =>
 			{

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -12,8 +12,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using AI.Fuzzy.Library;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.AI
@@ -191,13 +191,13 @@ namespace OpenRA.Mods.Common.AI
 
 		protected float RelativePower(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
 		{
-			return RelativeValue(own, enemy, 100, SumOfValues<AttackBase>, (Actor a) =>
+			return RelativeValue(own, enemy, 100, SumOfValues<AttackBase>, a =>
 			{
 				var sumOfDamage = 0;
 				var arms = a.TraitsImplementing<Armament>();
 				foreach (var arm in arms)
 				{
-					var warhead = arm.Weapon.Warheads.Select(w => w as DamageWarhead).FirstOrDefault(w => w != null);
+					var warhead = arm.Weapon.Warheads.OfType<DamageWarhead>().FirstOrDefault();
 					if (warhead != null)
 						sumOfDamage += warhead.Damage;
 				}

--- a/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
@@ -10,8 +10,8 @@
 
 using System;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -539,11 +539,13 @@
     <Compile Include="UtilityCommands\UpgradeRules.cs" />
     <Compile Include="Warheads\CreateEffectWarhead.cs" />
     <Compile Include="Warheads\CreateResourceWarhead.cs" />
+    <Compile Include="Warheads\DamageWarhead.cs" />
     <Compile Include="Warheads\DestroyResourceWarhead.cs" />
     <Compile Include="Warheads\GrantUpgradeWarhead.cs" />
     <Compile Include="Warheads\HealthPercentageDamageWarhead.cs" />
     <Compile Include="Warheads\LeaveSmudgeWarhead.cs" />
     <Compile Include="Warheads\SpreadDamageWarhead.cs" />
+    <Compile Include="Warheads\Warhead.cs" />
     <Compile Include="Widgets\ActorPreviewWidget.cs" />
     <Compile Include="Widgets\ColorMixerWidget.cs" />
     <Compile Include="Widgets\ColorPreviewManagerWidget.cs" />

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.GameRules;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -101,8 +101,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
+				if (IsTraitDisabled)
+					yield break;
+
 				var armament = Armaments.FirstOrDefault(a => a.Weapon.Warheads.Any(w => (w is DamageWarhead)));
-				if (armament == null || IsTraitDisabled)
+				if (armament == null)
 					yield break;
 
 				var negativeDamage = (armament.Weapon.Warheads.FirstOrDefault(w => (w is DamageWarhead)) as DamageWarhead).Damage < 0;

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -40,7 +41,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.World.SharedRandom.Next(100) > info.Chance)
 				return;
 
-			if (info.DeathType != null && e.Warhead != null && !info.DeathType.Intersect(e.Warhead.DamageTypes).Any())
+			var warhead = e.Warhead as DamageWarhead;
+			if (info.DeathType != null && warhead != null && !info.DeathType.Intersect(warhead.DamageTypes).Any())
 				return;
 
 			var weaponName = ChooseWeaponForExplosion(self);

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -10,7 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.GameRules;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -64,7 +64,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Damaged(Actor self, AttackInfo e)
 		{
-			if (e.Damage <= 0 || e.Warhead == null || !e.Warhead.DamageTypes.Any(x => info.DamageTriggers.Contains(x)))
+			var warhead = e.Warhead as DamageWarhead;
+			if (e.Damage <= 0 || warhead == null || !warhead.DamageTypes.Any(x => info.DamageTriggers.Contains(x)))
 				return;
 
 			if (!IsProne)
@@ -81,12 +82,16 @@ namespace OpenRA.Mods.Common.Traits
 				localOffset = WVec.Zero;
 		}
 
-		public int GetDamageModifier(Actor attacker, DamageWarhead warhead)
+		public int GetDamageModifier(Actor attacker, IWarhead warhead)
 		{
 			if (!IsProne)
 				return 100;
 
-			var modifierPercentages = info.DamageModifiers.Where(x => warhead.DamageTypes.Contains(x.Key)).Select(x => x.Value);
+			var damageWh = warhead as DamageWarhead;
+			if (damageWh == null)
+				return 100;
+
+			var modifierPercentages = info.DamageModifiers.Where(x => damageWh.DamageTypes.Contains(x.Key)).Select(x => x.Value);
 			return Util.ApplyPercentageModifiers(100, modifierPercentages);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -8,10 +8,9 @@
   */
  #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.GameRules;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -42,6 +41,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class TerrainModifiesDamage : IDamageModifier
 	{
+		const int FullDamage = 100;
+
 		public readonly TerrainModifiesDamageInfo Info;
 
 		readonly Actor self;
@@ -52,11 +53,11 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 		}
 
-		public int GetDamageModifier(Actor attacker, DamageWarhead warhead)
+		public int GetDamageModifier(Actor attacker, IWarhead warhead)
 		{
-			var percent = 100;
-			if (attacker.Owner.IsAlliedWith(self.Owner) && (warhead != null && warhead.Damage < 0) && !Info.ModifyHealing)
-				return percent;
+			var damageWh = warhead as DamageWarhead;
+			if (attacker.Owner.IsAlliedWith(self.Owner) && (damageWh != null && damageWh.Damage < 0) && !Info.ModifyHealing)
+				return FullDamage;
 
 			var world = self.World;
 			var map = world.Map;
@@ -67,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			var terrainType = tileSet[tileSet.GetTerrainIndex(tiles[pos])].Type;
 
 			if (!Info.TerrainModifier.ContainsKey(terrainType))
-				return percent;
+				return FullDamage;
 
 			return Info.TerrainModifier[terrainType];
 		}

--- a/OpenRA.Mods.Common/Traits/Invulnerable.cs
+++ b/OpenRA.Mods.Common/Traits/Invulnerable.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -18,6 +17,6 @@ namespace OpenRA.Mods.Common.Traits
 
 	class Invulnerable : IDamageModifier
 	{
-		public int GetDamageModifier(Actor attacker, DamageWarhead warhead) { return 0; }
+		public int GetDamageModifier(Actor attacker, IWarhead warhead) { return 0; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -72,16 +73,17 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Killed by some non-standard means. This includes being crushed
 			// by a vehicle (Actors with Crushable trait will spawn CrushedSequence instead).
-			if (e.Warhead == null)
+			if (e.Warhead == null || !(e.Warhead is DamageWarhead))
 				return;
 
 			var sequence = Info.DeathSequence;
 			if (Info.UseDeathTypeSuffix)
 			{
-				var damageType = e.Warhead.DamageTypes.Intersect(Info.DeathTypes.Keys).FirstOrDefault();
+				var warhead = e.Warhead as DamageWarhead;
+				var damageType = warhead.DamageTypes.Intersect(Info.DeathTypes.Keys).FirstOrDefault();
 				if (damageType == null)
 					throw new Exception("Actor type `{0}` does not define a death animation for weapon with damage types `{1}`!"
-						.F(self.Info.Name, string.Join(", ", e.Warhead.DamageTypes)));
+						.F(self.Info.Name, string.Join(", ", warhead.DamageTypes)));
 
 				sequence += Info.DeathTypes[damageType];
 			}

--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -37,11 +38,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Killed(Actor self, AttackInfo e)
 		{
+			var warhead = e.Warhead as DamageWarhead;
+
 			// Killed by some non-standard means
-			if (e.Warhead == null)
+			if (warhead == null)
 				return;
 
-			if (info.DeathTypes.Intersect(e.Warhead.DamageTypes).Any())
+			if (info.DeathTypes.Intersect(warhead.DamageTypes).Any())
 				self.PlayVoiceLocal(info.Voice, info.VolumeMultiplier);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Upgrades/GainsStatUpgrades.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/GainsStatUpgrades.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 				inaccuracyLevel = newLevel.Clamp(0, info.InaccuracyModifier.Length);
 		}
 
-		public int GetDamageModifier(Actor attacker, DamageWarhead warhead)
+		public int GetDamageModifier(Actor attacker, IWarhead warhead)
 		{
 			return damageLevel > 0 ? info.DamageModifier[damageLevel - 1] : 100;
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/ActorStatsExport.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ActorStatsExport.cs
@@ -12,8 +12,8 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -11,7 +11,7 @@
 using System.Collections.Generic;
 using OpenRA.Traits;
 
-namespace OpenRA.GameRules
+namespace OpenRA.Mods.Common.Warheads
 {
 	public abstract class DamageWarhead : Warhead
 	{

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -8,11 +8,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -10,9 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Effects;
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -9,14 +9,12 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Effects;
 using OpenRA.Traits;
 
-namespace OpenRA.GameRules
+namespace OpenRA.Mods.Common.Warheads
 {
 	[Desc("Base warhead class. This can be used to derive other warheads from.")]
-	public abstract class Warhead
+	public abstract class Warhead : IWarhead
 	{
 		[Desc("What types of targets are affected.")]
 		public readonly string[] ValidTargets = { "Ground", "Water" };
@@ -32,6 +30,7 @@ namespace OpenRA.GameRules
 
 		[Desc("Delay in ticks before applying the warhead effect.", "0 = instant (old model).")]
 		public readonly int Delay = 0;
+		int IWarhead.Delay { get { return Delay; } }
 
 		HashSet<string> validTargetSet;
 		HashSet<string> invalidTargetSet;

--- a/OpenRA.Mods.D2k/Warheads/ChangeOwnerWarhead.cs
+++ b/OpenRA.Mods.D2k/Warheads/ChangeOwnerWarhead.cs
@@ -9,7 +9,7 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.GameRules;
+using OpenRA.Mods.Common.Warheads;
 using OpenRA.Mods.D2k.Traits;
 using OpenRA.Traits;
 
@@ -30,11 +30,12 @@ namespace OpenRA.Mods.D2k.Warheads
 
 			foreach (var a in actors)
 			{
-				if (a.Owner == firedBy.Owner) // don't do anything on friendly fire
+				// Don't do anything on friendly fire
+				if (a.Owner == firedBy.Owner)
 					continue;
 
 				if (Duration == 0)
-					a.ChangeOwner(firedBy.Owner); // permanent
+					a.ChangeOwner(firedBy.Owner); // Permanent
 				else
 				{
 					var tempOwnerManager = a.TraitOrDefault<TemporaryOwnerManager>();
@@ -44,7 +45,8 @@ namespace OpenRA.Mods.D2k.Warheads
 					tempOwnerManager.ChangeOwner(a, firedBy.Owner, Duration);
 				}
 
-				a.CancelActivity(); // stop shooting, you have got new enemies
+				// Stop shooting, you have new enemies
+				a.CancelActivity();
 			}
 		}
 	}

--- a/OpenRA.Mods.RA/Traits/InvulnerabilityUpgrade.cs
+++ b/OpenRA.Mods.RA/Traits/InvulnerabilityUpgrade.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -24,7 +23,7 @@ namespace OpenRA.Mods.RA
 		public InvulnerabilityUpgrade(InvulnerabilityUpgradeInfo info)
 			: base(info) { }
 
-		public int GetDamageModifier(Actor attacker, DamageWarhead warhead)
+		public int GetDamageModifier(Actor attacker, IWarhead warhead)
 		{
 			return IsTraitDisabled ? 100 : 0;
 		}


### PR DESCRIPTION
Introduces `IWarhead` to enable moving `Warhead` and `DamageWarhead` outside of the engine and into `OpenRA.Mods.Common.Warheads`, where they belong.
Split into several commits to make reviewing easier.
This is the last step before `Armor` can be moved to `Mods.Common` and made upgradable.
