### PR TITLE
A few map / bounds cleanups.

### DIFF
--- a/OpenRA.Game/GameRules/RulesetCache.cs
+++ b/OpenRA.Game/GameRules/RulesetCache.cs
@@ -43,12 +43,11 @@ namespace OpenRA
 			this.modData = modData;
 		}
 
-		public Ruleset LoadDefaultRules()
-		{
-			return LoadMapRules(null);
-		}
-
-		public Ruleset LoadMapRules(Map map)
+		/// <summary>
+		/// Cache and return the Ruleset for a given map.
+		/// If a map isn't specified then return the default mod Ruleset.
+		/// </summary>
+		public Ruleset Load(Map map = null)
 		{
 			var m = modData.Manifest;
 

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Graphics
 		public Sequences LoadSequences(Map map)
 		{
 			using (new Support.PerfTimer("LoadSequences"))
-				return Load(map.SequenceDefinitions);
+				return Load(map != null ? map.SequenceDefinitions : new List<MiniYamlNode>());
 		}
 
 		Sequences Load(List<MiniYamlNode> sequenceNodes)

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Graphics
 		// Viewport geometry (world-px)
 		public int2 CenterLocation { get; private set; }
 
-		public WPos CenterPosition { get { return worldRenderer.Position(CenterLocation); } }
+		public WPos CenterPosition { get { return worldRenderer.ProjectedPosition(CenterLocation); } }
 
 		public int2 TopLeft { get { return CenterLocation - viewportSize / 2; } }
 		public int2 BottomRight { get { return CenterLocation + viewportSize / 2; } }
@@ -158,14 +158,14 @@ namespace OpenRA.Graphics
 			}
 
 			// Something is very wrong, but lets return something that isn't completely bogus and hope the caller can recover
-			return worldRenderer.World.Map.CellContaining(worldRenderer.Position(ViewToWorldPx(view)));
+			return worldRenderer.World.Map.CellContaining(worldRenderer.ProjectedPosition(ViewToWorldPx(view)));
 		}
 
 		/// <summary> Returns an unfiltered list of all cells that could potentially contain the mouse cursor</summary>
 		IEnumerable<MPos> CandidateMouseoverCells(int2 world)
 		{
 			var map = worldRenderer.World.Map;
-			var minPos = worldRenderer.Position(world);
+			var minPos = worldRenderer.ProjectedPosition(world);
 
 			// Find all the cells that could potentially have been clicked
 			var a = map.CellContaining(minPos - new WVec(1024, 0, 0)).ToMPos(map.TileShape);
@@ -230,8 +230,8 @@ namespace OpenRA.Graphics
 
 			// Calculate the viewport corners in "projected wpos" (at ground level), and
 			// this to an equivalent projected cell for the two corners
-			var tl = map.CellContaining(worldRenderer.Position(TopLeft)).ToMPos(map);
-			var br = map.CellContaining(worldRenderer.Position(BottomRight)).ToMPos(map);
+			var tl = map.CellContaining(worldRenderer.ProjectedPosition(TopLeft)).ToMPos(map);
+			var br = map.CellContaining(worldRenderer.ProjectedPosition(BottomRight)).ToMPos(map);
 
 			// Diamond tile shapes don't have straight edges, and so we need
 			// an additional cell margin to include the cells that are half

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -264,7 +264,11 @@ namespace OpenRA.Graphics
 			return pos.Y + pos.Z + offset;
 		}
 
-		public WPos Position(int2 screenPx)
+		/// <summary>
+		/// Returns a position in the world that is projected to the given screen position.
+		/// There are many possible world positions, and the returned value chooses the value with no elevation.
+		/// </summary>
+		public WPos ProjectedPosition(int2 screenPx)
 		{
 			var ts = Game.ModData.Manifest.TileSize;
 			return new WPos(1024 * screenPx.X / ts.Width, 1024 * screenPx.Y / ts.Height, 0);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -664,7 +664,7 @@ namespace OpenRA
 			// (b) Therefore:
 			//  - ax + by adds (a - b) * 512 + 512 to u
 			//  - ax + by adds (a + b) * 512 + 512 to v
-			var z = Contains(cell) ? 512 * MapHeight.Value[cell] : 0;
+			var z = MapHeight.Value.Contains(cell) ? 512 * MapHeight.Value[cell] : 0;
 			return new WPos(512 * (cell.X - cell.Y), 512 * (cell.X + cell.Y + 1), z);
 		}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -254,47 +254,6 @@ namespace OpenRA
 		[FieldLoader.Ignore] public CellRegion CellsInsideBounds;
 		[FieldLoader.Ignore] public CellRegion AllCells;
 
-		public static Map FromTileset(TileSet tileset)
-		{
-			var size = new Size(1, 1);
-			var tileShape = Game.ModData.Manifest.TileShape;
-			var tileRef = new TerrainTile(tileset.Templates.First().Key, (byte)0);
-
-			var makeMapTiles = Exts.Lazy(() =>
-			{
-				var ret = new CellLayer<TerrainTile>(tileShape, size);
-				ret.Clear(tileRef);
-				return ret;
-			});
-
-			var makeMapHeight = Exts.Lazy(() =>
-			{
-				var ret = new CellLayer<byte>(tileShape, size);
-				ret.Clear(0);
-				return ret;
-			});
-
-			var map = new Map()
-			{
-				Title = "Name your map here",
-				Description = "Describe your map here",
-				Author = "Your name here",
-				MapSize = new int2(size),
-				Tileset = tileset.Id,
-				Videos = new MapVideos(),
-				Options = new MapOptions(),
-				MapResources = Exts.Lazy(() => new CellLayer<ResourceTile>(tileShape, size)),
-				MapTiles = makeMapTiles,
-				MapHeight = makeMapHeight,
-
-				SpawnPoints = Exts.Lazy(() => new CPos[0])
-			};
-
-			map.PostInit();
-
-			return map;
-		}
-
 		void AssertExists(string filename)
 		{
 			using (var s = Container.GetContent(filename))
@@ -302,11 +261,50 @@ namespace OpenRA
 					throw new InvalidOperationException("Required file {0} not present in this map".F(filename));
 		}
 
-		// Stub constructor that doesn't produce a valid map, but is
-		// sufficient for loading a mod to the content-install panel
+		/// <summary>A stub constructor that doesn't produce a valid map. Do not use.</summary>
 		public Map() { }
 
-		// The standard constructor for most purposes
+		/// <summary>
+		/// Initializes a new map created by the editor or importer.
+		/// The map will not recieve a valid UID until after it has been saved and reloaded.
+		/// </summary>
+		public Map(TileSet tileset, int width, int height)
+		{
+			var size = new Size(width, height);
+			var tileShape = Game.ModData.Manifest.TileShape;
+			var tileRef = new TerrainTile(tileset.Templates.First().Key, (byte)0);
+
+			Title = "Name your map here";
+			Description = "Describe your map here";
+			Author = "Your name here";
+
+			MapSize = new int2(size);
+			Tileset = tileset.Id;
+			Videos = new MapVideos();
+			Options = new MapOptions();
+
+			MapResources = Exts.Lazy(() => new CellLayer<ResourceTile>(tileShape, size));
+
+			MapTiles = Exts.Lazy(() =>
+			{
+				var ret = new CellLayer<TerrainTile>(tileShape, size);
+				ret.Clear(tileRef);
+				return ret;
+			});
+
+			MapHeight = Exts.Lazy(() =>
+			{
+				var ret = new CellLayer<byte>(tileShape, size);
+				ret.Clear(0);
+				return ret;
+			});
+
+			SpawnPoints = Exts.Lazy(() => new CPos[0]);
+
+			PostInit();
+		}
+
+		/// <summary>Initializes a map loaded from disk.</summary>
 		public Map(string path)
 		{
 			Path = path;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -387,7 +387,7 @@ namespace OpenRA
 			{
 				try
 				{
-					return Game.ModData.RulesetCache.LoadMapRules(this);
+					return Game.ModData.RulesetCache.Load(this);
 				}
 				catch (Exception e)
 				{

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -261,9 +261,6 @@ namespace OpenRA
 					throw new InvalidOperationException("Required file {0} not present in this map".F(filename));
 		}
 
-		/// <summary>A stub constructor that doesn't produce a valid map. Do not use.</summary>
-		public Map() { }
-
 		/// <summary>
 		/// Initializes a new map created by the editor or importer.
 		/// The map will not recieve a valid UID until after it has been saved and reloaded.

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -79,7 +79,7 @@ namespace OpenRA
 			foreach (var dir in Manifest.Folders)
 				GlobalFileSystem.Mount(dir);
 
-			defaultRules = Exts.Lazy(() => RulesetCache.LoadDefaultRules());
+			defaultRules = Exts.Lazy(() => RulesetCache.Load());
 
 			initialThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
 		}

--- a/OpenRA.Mods.Common/Lint/CheckMapRules.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapRules.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			try
 			{
-				Game.ModData.RulesetCache.LoadMapRules(map);
+				Game.ModData.RulesetCache.Load(map);
 			}
 			catch (Exception e)
 			{

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -64,16 +64,26 @@ namespace OpenRA.Mods.Common.Scripting
 			return actors.ToArray();
 		}
 
-		[Desc("Returns the location of the top-left corner of the map.")]
+		[Desc("Returns the location of the top-left corner of the map (assuming zero terrain height).")]
 		public WPos TopLeft
 		{
-			get { return new WPos(Context.World.Map.Bounds.Left * 1024, Context.World.Map.Bounds.Top * 1024, 0); }
+			get
+			{
+				// HACK: This api method abuses the coordinate system, and should be removed
+				// in favour of proper actor queries.  See #8549.
+				return Context.World.Map.ProjectedTopLeft;
+			}
 		}
 
-		[Desc("Returns the location of the bottom-right corner of the map.")]
+		[Desc("Returns the location of the bottom-right corner of the map (assuming zero terrain height).")]
 		public WPos BottomRight
 		{
-			get { return new WPos(Context.World.Map.Bounds.Right * 1024, Context.World.Map.Bounds.Bottom * 1024, 0); }
+			get
+			{
+				// HACK: This api method abuses the coordinate system, and should be removed
+				// in favour of proper actor queries.  See #8549.
+				return Context.World.Map.ProjectedBottomRight;
+			}
 		}
 
 		[Desc("Returns a random cell inside the visible region of the map.")]

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			var bounds = self.Bounds;
 			bounds.Offset(pos.X, pos.Y);
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
-			var effectPos = wr.Position(new int2(pos.X, bounds.Y - spaceBuffer));
+			var effectPos = wr.ProjectedPosition(new int2(pos.X, bounds.Y - spaceBuffer));
 
 			yield return new TextRenderable(font, effectPos, 0, color, name);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 			pxPos += info.Offset;
 
 			// HACK: Because WorldRenderer.Position() does not care about terrain height at the location
-			var renderPos = wr.Position(pxPos);
+			var renderPos = wr.ProjectedPosition(pxPos);
 			renderPos = new WPos(renderPos.X, renderPos.Y + self.CenterPosition.Z, self.CenterPosition.Z);
 
 			anim.Tick();

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -50,15 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Loop through the map looking for templates to overlay
-			for (var i = w.Map.Bounds.Left; i < w.Map.Bounds.Right; i++)
-			{
-				for (var j = w.Map.Bounds.Top; j < w.Map.Bounds.Bottom; j++)
-				{
-					var cell = new CPos(i, j);
-					if (bridgeTypes.ContainsKey(w.Map.MapTiles.Value[cell].Type))
-						ConvertBridgeToActor(w, cell);
-				}
-			}
+			foreach (var cell in w.Map.AllCells)
+				if (bridgeTypes.ContainsKey(w.Map.MapTiles.Value[cell].Type))
+					ConvertBridgeToActor(w, cell);
 
 			// Link adjacent (long)-bridges so that artwork is updated correctly
 			foreach (var b in w.Actors.SelectMany(a => a.TraitsImplementing<Bridge>()))

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -159,6 +159,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanTraverseTile(World world, CPos p)
 		{
+			if (!map.Contains(p))
+				return false;
+
 			var terrainOffset = world.Map.GetTerrainIndex(p);
 			return (movementClass & (1 << terrainOffset)) > 0;
 		}
@@ -172,7 +175,7 @@ namespace OpenRA.Mods.Common.Traits
 			var visited = new CellLayer<bool>(map);
 
 			var toProcess = new Queue<CPos>();
-			toProcess.Enqueue(new CPos(map.Bounds.Left, map.Bounds.Top));
+			toProcess.Enqueue(MPos.Zero.ToCPos(map));
 
 			// Flood-fill over each domain
 			while (toProcess.Count != 0)
@@ -209,7 +212,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					// Don't crawl off the map, or add already-visited cells
 					var neighbors = CVec.Directions.Select(d => n + d)
-						.Where(p => map.Contains(p) && !visited[p]);
+						.Where(p => visited.Contains(p) && !visited[p]);
 
 					foreach (var neighbor in neighbors)
 						domainQueue.Enqueue(neighbor);

--- a/OpenRA.Mods.Common/UtilityCommands/ActorStatsExport.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ActorStatsExport.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		public static DataTable GenerateTable()
 		{
-			var rules = Game.ModData.RulesetCache.LoadDefaultRules();
+			var rules = Game.ModData.RulesetCache.Load();
 
 			var table = new DataTable();
 			table.Columns.Add("Name", typeof(string));

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = modData;
-			Game.ModData.RulesetCache.LoadDefaultRules();
+			Game.ModData.RulesetCache.Load();
 
 			var types = Game.ModData.ObjectCreator.GetTypes();
 			var translatableFields = types.SelectMany(t => t.GetFields())

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = modData;
 
-			var rules = Game.ModData.RulesetCache.LoadDefaultRules();
+			var rules = Game.ModData.RulesetCache.Load();
 			var map = LegacyMapImporter.Import(args[1], modData.Manifest.Mod.Id, rules, Console.WriteLine);
 
 			var fileName = Path.GetFileNameWithoutExtension(args[1]);

--- a/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
@@ -143,21 +143,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var width = Exts.ParseIntegerInvariant(mapSection.GetValue("Width", "0"));
 				var height = Exts.ParseIntegerInvariant(mapSection.GetValue("Height", "0"));
 				mapSize = (legacyMapFormat == IniMapFormat.RedAlert) ? 128 : 64;
-				var size = new Size(mapSize, mapSize);
 
 				var tileset = Truncate(mapSection.GetValue("Theater", "TEMPERAT"), 8);
-				map = Map.FromTileset(rules.TileSets[tileset]);
-				map.Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(iniFile));
-				map.Author = "Westwood Studios";
-				map.MapSize = new int2(mapSize, mapSize);
-				map.Bounds = Rectangle.FromLTRB(offsetX, offsetY, offsetX + width, offsetY + height);
+				map = new Map(rules.TileSets[tileset], mapSize, mapSize)
+				{
+					Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(iniFile)),
+					Author = "Westwood Studios"
+				};
 
-				map.MapResources = Exts.Lazy(() => new CellLayer<ResourceTile>(TileShape.Rectangle, size));
-				map.MapTiles = Exts.Lazy(() => new CellLayer<TerrainTile>(TileShape.Rectangle, size));
-
-				map.Videos = new MapVideos();
-
-				map.Options = new MapOptions();
+				var tl = new MPos(offsetX, offsetY);
+				var br = new MPos(offsetX + width - 1, offsetY + height - 1);
+				map.SetBounds(tl, br);
 
 				if (legacyMapFormat == IniMapFormat.RedAlert)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
@@ -39,14 +39,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			Game.ModData = new ModData(srcMod);
 			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
-			var srcRules = Game.ModData.RulesetCache.LoadDefaultRules();
+			var srcRules = Game.ModData.RulesetCache.Load();
 			var srcPaletteInfo = srcRules.Actors["player"].Traits.Get<PlayerColorPaletteInfo>();
 			var srcRemapIndex = srcPaletteInfo.RemapIndex;
 
 			var destMod = args[2].Split(':')[0];
 			Game.ModData = new ModData(destMod);
 			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
-			var destRules = Game.ModData.RulesetCache.LoadDefaultRules();
+			var destRules = Game.ModData.RulesetCache.Load();
 			var destPaletteInfo = destRules.Actors["player"].Traits.Get<PlayerColorPaletteInfo>();
 			var destRemapIndex = destPaletteInfo.RemapIndex;
 			var shadowIndex = new int[] { };

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -64,7 +64,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				height = Math.Max(2, height);
 
 				map.Resize(width + 2, height + tileset.MaxGroundHeight + 2);
-				map.ResizeCordon(1, 1, width + 1, height + tileset.MaxGroundHeight + 1);
+
+				var tl = new MPos(1, 1);
+				var br = new MPos(width, height + tileset.MaxGroundHeight);
+				map.SetBounds(tl, br);
+
 				map.PlayerDefinitions = new MapPlayers(map.Rules, map.SpawnPoints.Value.Length).ToMiniYaml();
 				map.FixOpenAreas(modRules);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -51,9 +51,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			panel.Get<ButtonWidget>("CREATE_BUTTON").OnClick = () =>
 			{
-				var tileset = modRules.TileSets[tilesetDropDown.Text];
-				var map = Map.FromTileset(tileset);
-
 				int width, height;
 				int.TryParse(widthTextField.Text, out width);
 				int.TryParse(heightTextField.Text, out height);
@@ -63,7 +60,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				width = Math.Max(2, width);
 				height = Math.Max(2, height);
 
-				map.Resize(width + 2, height + tileset.MaxGroundHeight + 2);
+				var tileset = modRules.TileSets[tilesetDropDown.Text];
+				var map = new Map(tileset, width + 2, height + tileset.MaxGroundHeight + 2);
 
 				var tl = new MPos(1, 1);
 				var br = new MPos(width, height + tileset.MaxGroundHeight);

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -237,8 +237,8 @@ namespace OpenRA.Mods.Common.Widgets
 			// Draw viewport rect
 			if (hasRadar)
 			{
-				var tl = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.Position(worldRenderer.Viewport.TopLeft)));
-				var br = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.Position(worldRenderer.Viewport.BottomRight)));
+				var tl = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.TopLeft)));
+				var br = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.BottomRight)));
 
 				Game.Renderer.EnableScissor(mapRect);
 				DrawRadarPings();

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -308,16 +308,16 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 			mapSize = new Size(stream.ReadUInt16(), stream.ReadUInt16());
 
 			tileSet = rules.TileSets["ARRAKIS"];
-			map = Map.FromTileset(tileSet);
-			map.Title = Path.GetFileNameWithoutExtension(mapFile);
-			map.Author = "Westwood Studios";
-			map.MapSize = new int2(mapSize.Width + 2 * MapCordonWidth, mapSize.Height + 2 * MapCordonWidth);
-			map.Bounds = new Rectangle(MapCordonWidth, MapCordonWidth, mapSize.Width, mapSize.Height);
 
-			map.MapResources = Exts.Lazy(() => new CellLayer<ResourceTile>(TileShape.Rectangle, new Size(map.MapSize.X, map.MapSize.Y)));
-			map.MapTiles = Exts.Lazy(() => new CellLayer<TerrainTile>(TileShape.Rectangle, new Size(map.MapSize.X, map.MapSize.Y)));
+			map = new Map(tileSet, mapSize.Width + 2 * MapCordonWidth, mapSize.Height + 2 * MapCordonWidth)
+			{
+				Title = Path.GetFileNameWithoutExtension(mapFile),
+				Author = "Westwood Studios"
+			};
 
-			map.Options = new MapOptions();
+			var tl = new MPos(MapCordonWidth, MapCordonWidth);
+			var br = new MPos(MapCordonWidth + mapSize.Width - 1, MapCordonWidth + mapSize.Height - 1);
+			map.SetBounds(tl, br);
 
 			// Get all templates from the tileset YAML file that have at least one frame and an Image property corresponding to the requested tileset
 			// Each frame is a tile from the Dune 2000 tileset files, with the Frame ID being the index of the tile in the original file

--- a/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = modData;
 
-			var rules = Game.ModData.RulesetCache.LoadDefaultRules();
+			var rules = Game.ModData.RulesetCache.Load();
 
 			var map = D2kMapImporter.Import(args[1], modData.Manifest.Mod.Id, args[2], rules);
 

--- a/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.RA.Graphics
 				var step = steps.Where(t => (to - (z + new float2(t[0], t[1]))).LengthSquared < (to - z).LengthSquared)
 					.MinBy(t => Math.Abs(float2.Dot(z + new float2(t[0], t[1]), q) + c));
 
-				var pos = wr.Position((z + new float2(step[2], step[3])).ToInt2());
+				var pos = wr.ProjectedPosition((z + new float2(step[2], step[3])).ToInt2());
 				rs.Add(new SpriteRenderable(s.GetSprite(step[4]), pos, WVec.Zero, 0, pal, 1f, true).PrepareRender(wr));
 
 				z += new float2(step[0], step[1]);


### PR DESCRIPTION
This cleans up a couple of self-contained issues before the big push to introduce projected cell coordinates for map bounds and shroud queries.

There are four parts to this:
- Making #8549 suck a little less (fixes the bonus point until we can eventually remove the offending API).
- Cleaning up the map creation code a little now the legacy editor is gone.
- Renaming `WorldRenderer.Position` to reflect that it isn't giving a real world position.
- Cleaning up some incorrect coordinate checks that are otherwise broken by a future change.
