### PR TITLE
Fixed Warning: Sprite image delphi from actor DELPHI does not define sequence shoot

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -357,8 +357,7 @@ EINSTEIN:
 		VoiceSet: EinsteinVoice
 
 DELPHI:
-	Inherits@1: ^CivInfantry
-	Inherits@2: ^ArmedCivilian
+	Inherits: ^CivInfantry
 	Tooltip:
 		Name: Agent Delphi
 	Mobile:


### PR DESCRIPTION
Revealed by https://github.com/OpenRA/OpenRA/pull/8634.
