### PR TITLE
Added separate CloseSequence to WithLandingCraftAnimation

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithAttackAnimationInfo : ITraitInfo, Requires<WithFacingSpriteBodyInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
+	public class WithAttackAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
 	{
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly WithAttackAnimationInfo info;
 		readonly AttackBase attack;
 		readonly Armament armament;
-		readonly WithFacingSpriteBody wfsb;
+		readonly WithSpriteBody wsb;
 
 		public WithAttackAnimation(ActorInitializer init, WithAttackAnimationInfo info)
 		{
@@ -43,13 +43,13 @@ namespace OpenRA.Mods.Common.Traits
 			attack = init.Self.Trait<AttackBase>();
 			armament = init.Self.TraitsImplementing<Armament>()
 				.Single(a => a.Info.Name == info.Armament);
-			wfsb = init.Self.Trait<WithFacingSpriteBody>();
+			wsb = init.Self.Trait<WithSpriteBody>();
 		}
 
 		public void Attacking(Actor self, Target target, Armament a, Barrel barrel)
 		{
 			if (!string.IsNullOrEmpty(info.AttackSequence))
-				wfsb.PlayCustomAnimation(self, info.AttackSequence);
+				wsb.PlayCustomAnimation(self, info.AttackSequence);
 		}
 
 		public void Tick(Actor self)
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (string.IsNullOrEmpty(info.AimSequence) && string.IsNullOrEmpty(info.ReloadPrefix))
 				return;
 
-			var sequence = wfsb.Info.Sequence;
+			var sequence = wsb.Info.Sequence;
 			if (!string.IsNullOrEmpty(info.AimSequence) && attack.IsAttacking)
 				sequence = info.AimSequence;
 
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!string.IsNullOrEmpty(prefix) && sequence != (prefix + sequence))
 				sequence = prefix + sequence;
 
-			wfsb.DefaultAnimation.ReplaceAnim(sequence);
+			wsb.DefaultAnimation.ReplaceAnim(sequence);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithMoveAnimationInfo : ITraitInfo, Requires<WithFacingSpriteBodyInfo>, Requires<IMoveInfo>
+	public class WithMoveAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<IMoveInfo>
 	{
 		[Desc("Displayed while moving.")]
 		[SequenceReference] public readonly string MoveSequence = "move";
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly WithMoveAnimationInfo info;
 		readonly IMove movement;
-		readonly WithFacingSpriteBody wfsb;
+		readonly WithSpriteBody wsb;
 
 		WPos cachedPosition;
 
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			movement = init.Self.Trait<IMove>();
-			wfsb = init.Self.Trait<WithFacingSpriteBody>();
+			wsb = init.Self.Trait<WithSpriteBody>();
 
 			cachedPosition = init.Self.CenterPosition;
 		}
@@ -45,10 +45,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Flying units set IsMoving whenever they are airborne, which isn't enough for our purposes
 			var isMoving = movement.IsMoving && !self.IsDead && (oldCachedPosition - cachedPosition).HorizontalLengthSquared != 0;
-			if (isMoving ^ (wfsb.DefaultAnimation.CurrentSequence.Name != info.MoveSequence))
+			if (isMoving ^ (wsb.DefaultAnimation.CurrentSequence.Name != info.MoveSequence))
 				return;
 
-			wfsb.DefaultAnimation.ReplaceAnim(isMoving ? info.MoveSequence : wfsb.Info.Sequence);
+			wsb.DefaultAnimation.ReplaceAnim(isMoving ? info.MoveSequence : wsb.Info.Sequence);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.RA/Traits/Render/WithLandingCraftAnimation.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		public readonly string[] OpenTerrainTypes = { "Clear" };
 		[SequenceReference] public readonly string OpenSequence = "open";
+		[SequenceReference] public readonly string CloseSequence = "close";
 		[SequenceReference] public readonly string UnloadSequence = "unload";
 
 		public object Create(ActorInitializer init) { return new WithLandingCraftAnimation(init, this); }
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public bool ShouldBeOpen()
 		{
-			if (self.CenterPosition.Z > 0 || move.IsMoving)
+			if (move.IsMoving || self.CenterPosition.Z > 0)
 				return false;
 
 			return cargo.CurrentAdjacentCells.Any(c => self.World.Map.Contains(c)
@@ -65,11 +66,11 @@ namespace OpenRA.Mods.RA.Traits
 
 		void Close()
 		{
-			if (!open || !wsb.DefaultAnimation.HasSequence(info.OpenSequence))
+			if (!open || !wsb.DefaultAnimation.HasSequence(info.CloseSequence))
 				return;
 
 			open = false;
-			wsb.PlayCustomAnimationBackwards(self, info.OpenSequence, null);
+			wsb.PlayCustomAnimation(self, info.CloseSequence);
 		}
 
 		public void Tick(Actor self)

--- a/mods/ra/sequences/ships.yaml
+++ b/mods/ra/sequences/ships.yaml
@@ -34,6 +34,10 @@ lst:
 		Start: 1
 		Length: 4
 		Tick: 150
+	close:
+		Frames: 4, 3, 2, 1
+		Length: 4
+		Tick: 150
 	unload:
 		Start: 4
 		ZOffset: -511


### PR DESCRIPTION
Closing sequence of landing craft is no longer hardcoded to be a reversed opening sequence.

This also fixes (or let's say avoids) the visual glitch that you see when moving an open landing craft away from the shore.
The underlying problem behind the above glitch appears to be an issue with playing animations backwards, which is now no longer used by this trait.

Additionally, modified `WithAttackAnimation` and `WithMoveAnimation` to work with `WithSpriteBody` as well, not just `WithFacingSpriteBody`.
