### PR TITLE
Render resources using TerrainSpriteLayers

### DIFF
--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Graphics
 {
 	public sealed class TerrainSpriteLayer : IDisposable
 	{
+		public readonly Sheet Sheet;
+		public readonly BlendMode BlendMode;
+
 		readonly Sprite emptySprite;
 
 		readonly IVertexBuffer<Vertex> vertexBuffer;
@@ -30,17 +33,14 @@ namespace OpenRA.Graphics
 		readonly WorldRenderer worldRenderer;
 		readonly Map map;
 
-		readonly Sheet sheet;
-		readonly BlendMode blendMode;
-
 		float paletteIndex;
 
 		public TerrainSpriteLayer(World world, WorldRenderer wr, Sheet sheet, BlendMode blendMode, PaletteReference palette, bool restrictToBounds)
 		{
 			worldRenderer = wr;
 			this.restrictToBounds = restrictToBounds;
-			this.sheet = sheet;
-			this.blendMode = blendMode;
+			Sheet = sheet;
+			BlendMode = blendMode;
 			paletteIndex = palette.TextureIndex;
 
 			map = world.Map;
@@ -77,10 +77,10 @@ namespace OpenRA.Graphics
 		{
 			if (sprite != null)
 			{
-				if (sprite.Sheet != sheet)
+				if (sprite.Sheet != Sheet)
 					throw new InvalidDataException("Attempted to add sprite from a different sheet");
 
-				if (sprite.BlendMode != blendMode)
+				if (sprite.BlendMode != BlendMode)
 					throw new InvalidDataException("Attempted to add sprite with a different blend mode");
 			}
 			else
@@ -122,7 +122,7 @@ namespace OpenRA.Graphics
 
 			Game.Renderer.WorldSpriteRenderer.DrawVertexBuffer(
 				vertexBuffer, rowStride * firstRow, rowStride * (lastRow - firstRow),
-				PrimitiveType.QuadList, sheet, blendMode);
+				PrimitiveType.QuadList, Sheet, BlendMode);
 
 			Game.Renderer.Flush();
 		}

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -69,7 +69,8 @@ namespace OpenRA.Graphics
 
 		public void Update(CPos cell, Sprite sprite)
 		{
-			var pos = worldRenderer.ScreenPosition(map.CenterOfCell(cell)) + sprite.Offset - 0.5f * sprite.Size;
+			var pos = sprite == null ? float2.Zero :
+				worldRenderer.ScreenPosition(map.CenterOfCell(cell)) + sprite.Offset - 0.5f * sprite.Size;
 			Update(cell.ToMPos(map.TileShape), sprite, pos);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly World world;
 		readonly BuildingInfluence buildingInfluence;
-		readonly List<CPos> dirty = new List<CPos>();
+		readonly HashSet<CPos> dirty = new HashSet<CPos>();
 
 		protected readonly CellLayer<CellContents> Content;
 		protected readonly CellLayer<CellContents> RenderContent;
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public ResourceLayer(Actor self)
 		{
 			world = self.World;
-			buildingInfluence = world.WorldActor.Trait<BuildingInfluence>();
+			buildingInfluence = self.Trait<BuildingInfluence>();
 
 			Content = new CellLayer<CellContents>(world.Map);
 			RenderContent = new CellLayer<CellContents>(world.Map);
@@ -102,8 +102,8 @@ namespace OpenRA.Mods.Common.Traits
 					var temp = Content[cell];
 					temp.Density = Math.Max(density, 1);
 
-					RenderContent[cell] = Content[cell] = temp;
-					UpdateRenderedSprite(cell);
+					Content[cell] = temp;
+					dirty.Add(cell);
 				}
 			}
 		}
@@ -200,8 +200,7 @@ namespace OpenRA.Mods.Common.Traits
 			cell.Density = Math.Min(cell.Type.Info.MaxDensity, cell.Density + n);
 			Content[p] = cell;
 
-			if (!dirty.Contains(p))
-				dirty.Add(p);
+			dirty.Add(p);
 		}
 
 		public bool IsFull(CPos cell)
@@ -223,8 +222,7 @@ namespace OpenRA.Mods.Common.Traits
 			else
 				Content[cell] = c;
 
-			if (!dirty.Contains(cell))
-				dirty.Add(cell);
+			dirty.Add(cell);
 
 			return c.Type;
 		}
@@ -239,8 +237,7 @@ namespace OpenRA.Mods.Common.Traits
 			Content[cell] = EmptyCell;
 			world.Map.CustomTerrain[cell] = byte.MaxValue;
 
-			if (!dirty.Contains(cell))
-				dirty.Add(cell);
+			dirty.Add(cell);
 		}
 
 		public ResourceType GetResource(CPos cell) { return Content[cell].Type; }

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
@@ -17,7 +17,10 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Used to render spice with round borders.")]
-	public class D2kResourceLayerInfo : TraitInfo<D2kResourceLayer> { }
+	public class D2kResourceLayerInfo : ResourceLayerInfo
+	{
+		public override object Create(ActorInitializer init) { return new D2kResourceLayer(init.Self); }
+	}
 
 	public class D2kResourceLayer : ResourceLayer
 	{
@@ -96,9 +99,12 @@ namespace OpenRA.Mods.D2k.Traits
 			{ ClearSides.Bottom | ClearSides.TopLeft | ClearSides.BottomLeft | ClearSides.BottomRight, 49 },
 		};
 
+		public D2kResourceLayer(Actor self)
+			: base(self) { }
+
 		bool CellContains(CPos c, ResourceType t)
 		{
-			return render.Contains(c) && render[c].Type == t;
+			return RenderContent.Contains(c) && RenderContent[c].Type == t;
 		}
 
 		ClearSides FindClearSides(ResourceType t, CPos p)
@@ -133,10 +139,10 @@ namespace OpenRA.Mods.D2k.Traits
 
 		void UpdateRenderedTileInner(CPos p)
 		{
-			if (!render.Contains(p))
+			if (!RenderContent.Contains(p))
 				return;
 
-			var t = render[p];
+			var t = RenderContent[p];
 			if (t.Density > 0)
 			{
 				var clear = FindClearSides(t.Type, p);
@@ -156,7 +162,7 @@ namespace OpenRA.Mods.D2k.Traits
 			else
 				t.Sprite = null;
 
-			render[p] = t;
+			RenderContent[p] = t;
 		}
 
 		protected override void UpdateRenderedSprite(CPos p)


### PR DESCRIPTION
This changes ResourceLayer to use a set of TerrainSpriteLayers instead of generating a pile of SpriteRenderables each tick.  This should cut out a bunch of rendering work (ping @RoosterDragon) and removes a dependency on shroud / bounds that complicates the future heightmap-shroud code.

This is mainly a proof of concept: if it's viable, then followup prs will apply the same approach to `EditorResourceLayer`, `SmudgeLayer`, and `BuildableTerrainLayer`.
