### PR TITLE
Move maximum terrain height definition to mod.yaml.

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -38,8 +38,6 @@ namespace OpenRA.Graphics
 
 		// Map bounds (world-px)
 		readonly Rectangle mapBounds;
-
-		readonly int maxGroundHeight;
 		readonly Size tileSize;
 
 		// Viewport geometry (world-px)
@@ -103,7 +101,6 @@ namespace OpenRA.Graphics
 			var br = wr.ScreenPxPosition(map.CenterOfCell(cells.BottomRight) + new WVec(511, 511, 0));
 			mapBounds = Rectangle.FromLTRB(tl.X, tl.Y, br.X, br.Y);
 
-			maxGroundHeight = wr.World.TileSet.MaxGroundHeight;
 			CenterLocation = (tl + br) / 2;
 			Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
 			tileSize = Game.ModData.Manifest.TileSize;
@@ -169,7 +166,7 @@ namespace OpenRA.Graphics
 
 			// Find all the cells that could potentially have been clicked
 			var a = map.CellContaining(minPos - new WVec(1024, 0, 0)).ToMPos(map.TileShape);
-			var b = map.CellContaining(minPos + new WVec(512, 512 * maxGroundHeight, 0)).ToMPos(map.TileShape);
+			var b = map.CellContaining(minPos + new WVec(512, 512 * map.MaximumTerrainHeight, 0)).ToMPos(map.TileShape);
 
 			for (var v = b.V; v >= a.V; v--)
 				for (var u = b.U; u >= a.U; u--)
@@ -253,7 +250,7 @@ namespace OpenRA.Graphics
 			// Each height step is equivalent to 512 WRange units, which is
 			// one MPos step for diamond cells, but only half a MPos step
 			// for classic cells. Doh!
-			var heightOffset = map.TileShape == TileShape.Diamond ? maxGroundHeight : maxGroundHeight / 2;
+			var heightOffset = map.TileShape == TileShape.Diamond ? map.MaximumTerrainHeight : map.MaximumTerrainHeight / 2;
 			br = new MPos(br.U, br.V + heightOffset);
 
 			// Finally, make sure that this region doesn't extend outside the map area.

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -49,6 +49,7 @@ namespace OpenRA
 		public readonly Dictionary<string, Pair<string, int>> Fonts;
 		public readonly Size TileSize = new Size(24, 24);
 		public readonly TileShape TileShape = TileShape.Rectangle;
+		public readonly byte MaximumTerrainHeight = 0;
 
 		public readonly string[] SpriteFormats = { };
 
@@ -69,7 +70,7 @@ namespace OpenRA
 		readonly string[] reservedModuleNames = { "Metadata", "Folders", "MapFolders", "Packages", "Rules",
 			"Sequences", "VoxelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
 			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions",
-			"ServerTraits", "LoadScreen", "LobbyDefaults", "Fonts", "TileSize",
+			"ServerTraits", "LoadScreen", "LobbyDefaults", "Fonts", "TileSize", "MaximumTerrainHeight",
 			"TileShape", "SubCells", "SupportsMapsFrom", "SpriteFormats" };
 
 		readonly TypeDictionary modules = new TypeDictionary();
@@ -122,6 +123,9 @@ namespace OpenRA
 
 			if (yaml.ContainsKey("TileShape"))
 				TileShape = FieldLoader.GetValue<TileShape>("TileShape", yaml["TileShape"].Value);
+
+			if (yaml.ContainsKey("MaximumTerrainHeight"))
+				MaximumTerrainHeight = FieldLoader.GetValue<byte>("MaximumTerrainHeight", yaml["MaximumTerrainHeight"].Value);
 
 			if (yaml.ContainsKey("SubCells"))
 			{

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -151,6 +151,7 @@ namespace OpenRA
 
 		public const int MaxTilesInCircleRange = 50;
 		public readonly TileShape TileShape;
+		public readonly byte MaximumTerrainHeight;
 
 		[FieldLoader.Ignore] public readonly WVec[] SubCellOffsets;
 		public readonly SubCell DefaultSubCell;
@@ -297,6 +298,8 @@ namespace OpenRA
 			});
 
 			SpawnPoints = Exts.Lazy(() => new CPos[0]);
+			TileShape = tileShape;
+			MaximumTerrainHeight = Game.ModData.Manifest.MaximumTerrainHeight;
 
 			PostInit();
 		}
@@ -362,6 +365,8 @@ namespace OpenRA
 			MapHeight = Exts.Lazy(LoadMapHeight);
 
 			TileShape = Game.ModData.Manifest.TileShape;
+			MaximumTerrainHeight = Game.ModData.Manifest.MaximumTerrainHeight;
+
 			SubCellOffsets = Game.ModData.Manifest.SubCellOffsets;
 			LastSubCell = (SubCell)(SubCellOffsets.Length - 1);
 			DefaultSubCell = (SubCell)Game.ModData.Manifest.SubCellDefaultIndex;
@@ -534,7 +539,6 @@ namespace OpenRA
 
 		public CellLayer<byte> LoadMapHeight()
 		{
-			var maxHeight = cachedTileSet.Value.MaxGroundHeight;
 			var tiles = new CellLayer<byte>(this);
 			using (var s = Container.GetContent("map.bin"))
 			{
@@ -544,7 +548,7 @@ namespace OpenRA
 					s.Position = header.HeightsOffset;
 					for (var i = 0; i < MapSize.X; i++)
 						for (var j = 0; j < MapSize.Y; j++)
-							tiles[new MPos(i, j)] = s.ReadUInt8().Clamp((byte)0, maxHeight);
+							tiles[new MPos(i, j)] = s.ReadUInt8().Clamp((byte)0, MaximumTerrainHeight);
 				}
 			}
 
@@ -590,8 +594,8 @@ namespace OpenRA
 
 				// Data offsets
 				var tilesOffset = 17;
-				var heightsOffset = cachedTileSet.Value.MaxGroundHeight > 0 ? 3 * MapSize.X * MapSize.Y + 17 : 0;
-				var resourcesOffset = (cachedTileSet.Value.MaxGroundHeight > 0 ? 4 : 3) * MapSize.X * MapSize.Y + 17;
+				var heightsOffset = MaximumTerrainHeight > 0 ? 3 * MapSize.X * MapSize.Y + 17 : 0;
+				var resourcesOffset = (MaximumTerrainHeight > 0 ? 4 : 3) * MapSize.X * MapSize.Y + 17;
 
 				writer.Write((uint)tilesOffset);
 				writer.Write((uint)heightsOffset);

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -172,7 +172,6 @@ namespace OpenRA
 		public readonly string Palette;
 		public readonly string PlayerPalette;
 		public readonly int WaterPaletteRotationBase = 0x60;
-		public readonly byte MaxGroundHeight = 0;
 		public readonly Color[] HeightDebugColors = new[] { Color.Red };
 		public readonly string[] EditorTemplateOrder;
 		public readonly bool IgnoreTileSpriteOffsets;

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Widgets
 							continue;
 
 						mapTiles[c] = new TerrainTile(Template, index);
-						mapHeight[c] = (byte)(baseHeight + template[index].Height).Clamp(0, world.TileSet.MaxGroundHeight);
+						mapHeight[c] = (byte)(baseHeight + template[index].Height).Clamp(0, map.MaximumTerrainHeight);
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -60,11 +60,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				width = Math.Max(2, width);
 				height = Math.Max(2, height);
 
+				var maxTerrainHeight = Game.ModData.Manifest.MaximumTerrainHeight;
 				var tileset = modRules.TileSets[tilesetDropDown.Text];
-				var map = new Map(tileset, width + 2, height + tileset.MaxGroundHeight + 2);
+				var map = new Map(tileset, width + 2, height + maxTerrainHeight + 2);
 
 				var tl = new MPos(1, 1);
-				var br = new MPos(width, height + tileset.MaxGroundHeight);
+				var br = new MPos(width, height + maxTerrainHeight);
 				map.SetBounds(tl, br);
 
 				map.PlayerDefinitions = new MapPlayers(map.Rules, map.SpawnPoints.Value.Length).ToMiniYaml();

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -117,6 +117,7 @@ TileShape: Diamond
 SubCells:
 	Offsets: 0,0,0, -256,128,0, 0,-128,0, 256,128,0
 	DefaultIndex: 2
+MaximumTerrainHeight: 16
 
 Cursors:
 	./mods/ts/cursors.yaml

--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -2,7 +2,6 @@ General:
 	Name: Snow
 	Id: SNOW
 	Palette: isosno.pal
-	MaxGroundHeight: 16
 	HeightDebugColors: 128,0,0,0, 128,0,0,68, 128,0,0,136, 128,0,0,204, 128,0,0,255, 128,68,0,204, 128,136,0,136, 128,204,0,68, 128,255,17,0, 128,255,85,0, 128,255,153,0, 128,255,221,0, 128,221,255,0, 128,153,255,0, 128,85,255,0, 128,17,255,0
 	EditorTemplateOrder: Bendy Dirt Roads, Blank, Bridges, Civilian Buildings, Clear, Clear/Rough LAT, Cliff Pieces, Cliff Set, Cliff/Water pieces, Dead Oil Tanker, Destroyable Cliffs, Dirt Road Junctions, Dirt Road Slopes, DirtTrackTunnel Floor, DirtTunnel Floor, Grey/Clear LAT, House, Ice Flow, Ice Ramps, Ice shore, Misc Buildings, Monorail Slopes, Paved Road Ends, Paved Road Slopes, Paved Roads, Pavement, Pavement (Use for LAT), Pavement/Clear LAT, Ramp edge fixup, Rough ground, Rough lat, Ruins, Shore Pieces, Slope Set Pieces, Straight Dirt Roads, TrackTunnel Floor, TrainBridges, Tunnel Side, Tunnels, Water, Water slopes, Waterfalls, Waterfalls-B, Waterfalls-C, Waterfalls-D
 	SheetSize: 2048

--- a/mods/ts/tilesets/temperate.yaml
+++ b/mods/ts/tilesets/temperate.yaml
@@ -2,7 +2,6 @@ General:
 	Name: Temperate
 	Id: TEMPERATE
 	Palette: isotem.pal
-	MaxGroundHeight: 16
 	HeightDebugColors: 128,0,0,0, 128,0,0,68, 128,0,0,136, 128,0,0,204, 128,0,0,255, 128,68,0,204, 128,136,0,136, 128,204,0,68, 128,255,17,0, 128,255,85,0, 128,255,153,0, 128,255,221,0, 128,221,255,0, 128,153,255,0, 128,85,255,0, 128,17,255,0
 	EditorTemplateOrder: Misc Buildings, Clear, Cliff Pieces, Ice Flow, House, Blank, Ice Ramps, Cliff Set, Civilian Buildings, Shore Pieces, Rough LAT tile, Clear/Rough LAT, Cliff/Water pieces, Bendy Dirt Roads, Dirt Road Junctions, Straight Dirt Roads, Bridges, Paved Roads, Water, Dirt Road Slopes, Slope Set Pieces, Dead Oil Tanker, Ruins, Waterfalls, Ground 01, Ground 02, Sand, Sand/Clear LAT, Rough ground, Paved Road Ends, TrainBridges, Pavement, Pavement/Clear LAT, Paved road bits, Green, Green/Clear LAT, Ramp edge fixup, Water slopes, Pavement (Use for LAT), Paved Road Slopes, Monorail Slopes, Waterfalls-B, Waterfalls-C, Waterfalls-D, Tunnel Floor, Tunnel Side, TrackTunnel Floor, Destroyable Cliffs, Water Caves, Scrin Wreckage, DirtTrackTunnel Floor, DirtTunnel Floor
 	SheetSize: 2048


### PR DESCRIPTION
One of the upcoming heightmap-related PRs needs to use this value from a place where it is not convenient to access a TileSet.  There is no reason for this value to be tileset-specific, so it has been moved to the Manifest.
