### PR TITLE
Updated the list of active developers participating in maintenance and code review

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,20 +3,24 @@ hard work of many contributors.
 
 The OpenRA developers are:
     * Chris Forbes (chrisf)
-    * Curtis Shmyr (hamb)
     * Igor Popov (ihptru)
+    * Lukas Franke (abcdefg30)
     * Matthias Mailänder (Mailaender)
     * Oliver Brakmann (obrakmann)
     * Paul Chote (pchote)
-    * ScottNZ
+    * Pavel Penev (penev92)
+    * Reaperrr
+    * Tom Roostan (RoosterDragon)
 
 Previous developers included:
     * Alli Witheford (alzeih)
     * Caleb Anderson (RobotCaleb)
+    * Curtis Shmyr (hamb)
     * Daniel Hernandez (Mancano)
     * Megan Bowra-Dean (beedee)
     * Mike Bundy (kehaar)
     * Robert Pepperell (ytinasni)
+    * ScottNZ
 
 Also thanks to:
     * Adam Valy (Tschokky)
@@ -70,7 +74,6 @@ Also thanks to:
     * Kyrre Soerensen (zypres)
     * Lawrence Wang
     * Lesueur Benjamin (Valkirie)
-    * Lukas Franke (abcdefg30)
     * Maarten Meuris (Nyerguds)
     * Mark Olson (markolson)
     * Matija Hustic (matija-hustic)
@@ -88,13 +91,11 @@ Also thanks to:
     * Olaf van der Spek
     * Paolo Chiodi (paolochiodi)
     * Paul Dovydaitis (pdovy)
-    * Pavel Penev (penev92)
     * Pavlos Touboulidis (pav)
     * Pizzaoverhead
     * Psydev
     * Raymond Bedrossian (Squiggles211)
     * Raymond Martineau (mart0258)
-    * Reaperrr
     * Riderr3
     * Rikhardur Bjarni Einarsson (WolfGaming)
     * Sascha Biedermann (bidifx)
@@ -105,7 +106,6 @@ Also thanks to:
     * Teemu Nieminen (Temeez)
     * Tim Mylemans (gecko)
     * Tirili
-    * Tom Roostan (RoosterDragon)
     * Tristan Keating (Kilkakon)
     * Tristan Mühlbacher (MicroBit)
     * Vladimir Komarov (VrKomarov)


### PR DESCRIPTION
Source: 
- https://github.com/OpenRA/OpenRA/graphs/contributors
- https://github.com/OpenRA/OpenRA/wiki/Changelog-(bleed)/_history
