### PR TITLE
Higher level timed upgrades

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/GrantUpgradeCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GrantUpgradeCrateAction.cs
@@ -47,7 +47,8 @@ namespace OpenRA.Mods.Common.Traits
 		bool AcceptsUpgrade(Actor a)
 		{
 			var um = a.TraitOrDefault<UpgradeManager>();
-			return um != null && info.Upgrades.Any(u => um.AcceptsUpgrade(a, u));
+			return um != null && (info.Duration > 0 ?
+				info.Upgrades.Any(u => um.AcknowledgesUpgrade(a, u)) : info.Upgrades.Any(u => um.AcceptsUpgrade(a, u)));
 		}
 
 		public override int GetSelectionShares(Actor collector)
@@ -73,13 +74,16 @@ namespace OpenRA.Mods.Common.Traits
 					var um = a.TraitOrDefault<UpgradeManager>();
 					foreach (var u in info.Upgrades)
 					{
-						if (!um.AcceptsUpgrade(a, u))
-							continue;
-
 						if (info.Duration > 0)
-							um.GrantTimedUpgrade(a, u, info.Duration);
+						{
+							if (um.AcknowledgesUpgrade(a, u))
+								um.GrantTimedUpgrade(a, u, info.Duration);
+						}
 						else
-							um.GrantUpgrade(a, u, this);
+						{
+							if (um.AcceptsUpgrade(a, u))
+								um.GrantUpgrade(a, u, this);
+						}
 					}
 				}
 			});

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -65,13 +65,16 @@ namespace OpenRA.Mods.Common.Traits
 
 				foreach (var u in info.Upgrades)
 				{
-					if (!um.AcceptsUpgrade(a, u))
-						continue;
-
 					if (info.Duration > 0)
-						um.GrantTimedUpgrade(a, u, info.Duration);
+					{
+						if (um.AcknowledgesUpgrade(a, u))
+							um.GrantTimedUpgrade(a, u, info.Duration);
+					}
 					else
-						um.GrantUpgrade(a, u, this);
+					{
+						if (um.AcceptsUpgrade(a, u))
+							um.GrantUpgrade(a, u, this);
+					}
 				}
 			}
 		}
@@ -90,7 +93,8 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				var um = a.TraitOrDefault<UpgradeManager>();
-				return um != null && info.Upgrades.Any(u => um.AcceptsUpgrade(a, u));
+				return um != null && (info.Duration > 0 ?
+					info.Upgrades.Any(u => um.AcknowledgesUpgrade(a, u)) : info.Upgrades.Any(u => um.AcceptsUpgrade(a, u)));
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Traits
 				var um = produced.TraitOrDefault<UpgradeManager>();
 				if (um != null)
 					foreach (var u in info.Upgrades)
-						if (um.AcceptsUpgrade(produced, u))
+						if (um.AcknowledgesUpgrade(produced, u))
 							um.GrantTimedUpgrade(produced, u, 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
@@ -49,13 +49,16 @@ namespace OpenRA.Mods.Common.Warheads
 
 				foreach (var u in Upgrades)
 				{
-					if (!um.AcceptsUpgrade(a, u))
-						continue;
-
 					if (Duration > 0)
-						um.GrantTimedUpgrade(a, u, Duration);
+					{
+						if (um.AcknowledgesUpgrade(a, u))
+							um.GrantTimedUpgrade(a, u, Duration, firedBy);
+					}
 					else
-						um.GrantUpgrade(a, u, this);
+					{
+						if (um.AcceptsUpgrade(a, u))
+							um.GrantUpgrade(a, u, this);
+					}
 				}
 			}
 		}

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -55,7 +55,7 @@
 		UpgradeMinEnabledLevel: 1
 	DamageMultiplier@IRONCURTAIN:
 		UpgradeTypes: invulnerability
-		Modifier: 0, 0
+		Modifier: 0
 	TimedUpgradeBar:
 		Upgrade: invulnerability
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -359,12 +359,10 @@
 	UpgradeOverlay@EMPDISABLE:
 		UpgradeTypes: empdisable
 		UpgradeMinEnabledLevel: 1
-		UpgradeMaxAcceptedLevel: 2
 		Palette: disabled
 	DisableUpgrade@EMPDISABLE:
 		UpgradeTypes: empdisable
 		UpgradeMinEnabledLevel: 1
-		UpgradeMaxAcceptedLevel: 2
 	TimedUpgradeBar@EMPDISABLE:
 		Upgrade: empdisable
 		Color: 255,255,255
@@ -377,11 +375,9 @@
 		ShowToEnemies: true
 		ZOffset: 512
 		UpgradeMinEnabledLevel: 1
-		UpgradeMaxAcceptedLevel: 2
 	Cloak@CLOAKGENERATOR:
 		UpgradeTypes: cloakgenerator
 		UpgradeMinEnabledLevel: 1
-		UpgradeMaxAcceptedLevel: 2
 		InitialDelay: 0
 		CloakDelay: 90
 	MustBeDestroyed:


### PR DESCRIPTION
Right now timed upgrades are not allowed to get past level 1, i.e., every new granting of the upgrade just refreshes the duration of the previous upgrade instead of increasing its level.

I'd like to loosen this constraint to allow timed upgrades to reach higher levels if different sources grant the same timed upgrade. Per source, however, the highest level would still remain constrained to 1, refreshing duration with every new granting instead of increasing the level. That's the first commit.

This would be used for #8563 through `GrantUpgradeWarhead`. Adapting this warhead to register itself as a source of the upgrade is what commit number two is about.
