### PR TITLE
Rename the Country trait to Faction

### DIFF
--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -114,11 +114,11 @@ namespace OpenRA
 				IsHuman = !runtimePlayer.IsBot,
 				IsBot = runtimePlayer.IsBot,
 				FactionName = runtimePlayer.Country.Name,
-				FactionId = runtimePlayer.Country.Race,
+				FactionId = runtimePlayer.Country.InternalName,
 				Color = runtimePlayer.Color,
 				Team = client.Team,
 				SpawnPoint = runtimePlayer.SpawnPoint,
-				IsRandomFaction = runtimePlayer.Country.Race != client.Race,
+				IsRandomFaction = runtimePlayer.Country.InternalName != client.Race,
 				IsRandomSpawnPoint = runtimePlayer.SpawnPoint != client.SpawnPoint
 			};
 

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -29,7 +29,7 @@ namespace OpenRA
 		public MapPlayers(Ruleset rules, int playerCount)
 		{
 			var firstRace = rules.Actors["world"].Traits
-				.WithInterface<CountryInfo>().First(c => c.Selectable).Race;
+				.WithInterface<FactionInfo>().First(f => f.Selectable).Race;
 
 			Players = new Dictionary<string, PlayerReference>
 			{

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -29,7 +29,7 @@ namespace OpenRA
 		public MapPlayers(Ruleset rules, int playerCount)
 		{
 			var firstRace = rules.Actors["world"].Traits
-				.WithInterface<FactionInfo>().First(f => f.Selectable).Race;
+				.WithInterface<FactionInfo>().First(f => f.Selectable).InternalName;
 
 			Players = new Dictionary<string, PlayerReference>
 			{

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -181,8 +181,8 @@
     <Compile Include="Traits\TraitsInterfaces.cs" />
     <Compile Include="Traits\Util.cs" />
     <Compile Include="Traits\ValidateOrder.cs" />
-    <Compile Include="Traits\World\Country.cs" />
     <Compile Include="Traits\World\MusicPlaylist.cs" />
+    <Compile Include="Traits\World\Faction.cs" />
     <Compile Include="Traits\World\ResourceType.cs" />
     <Compile Include="Traits\World\ScreenShaker.cs" />
     <Compile Include="Traits\World\Shroud.cs" />

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -57,14 +57,14 @@ namespace OpenRA
 				.WithInterface<FactionInfo>().Where(f => !requireSelectable || f.Selectable)
 				.ToList();
 
-			var selected = selectableCountries.FirstOrDefault(f => f.Race == name)
+			var selected = selectableCountries.FirstOrDefault(f => f.InternalName == name)
 				?? selectableCountries.Random(world.SharedRandom);
 
 			// Don't loop infinite
-			for (var i = 0; i <= 10 && selected.RandomRaceMembers.Any(); i++)
+			for (var i = 0; i <= 10 && selected.RandomFactionMembers.Any(); i++)
 			{
-				var race = selected.RandomRaceMembers.Random(world.SharedRandom);
-				selected = selectableCountries.FirstOrDefault(f => f.Race == race);
+				var race = selected.RandomFactionMembers.Random(world.SharedRandom);
+				selected = selectableCountries.FirstOrDefault(f => f.InternalName == race);
 
 				if (selected == null)
 					throw new YamlException("Unknown race: {0}".F(race));
@@ -78,7 +78,7 @@ namespace OpenRA
 			var countries = world.Map.Rules.Actors["world"].Traits
 				.WithInterface<FactionInfo>().ToArray();
 
-			return countries.FirstOrDefault(f => f.Race == race) ?? countries.First();
+			return countries.FirstOrDefault(f => f.InternalName == race) ?? countries.First();
 		}
 
 		public Player(World world, Session.Client client, Session.Slot slot, PlayerReference pr)

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -31,14 +31,14 @@ namespace OpenRA
 
 		public readonly string PlayerName;
 		public readonly string InternalName;
-		public readonly CountryInfo Country;
+		public readonly FactionInfo Country;
 		public readonly bool NonCombatant = false;
 		public readonly bool Playable = true;
 		public readonly int ClientIndex;
 		public readonly PlayerReference PlayerReference;
 
 		// The country (including Random, etc) that was selected in the lobby
-		public readonly CountryInfo DisplayCountry;
+		public readonly FactionInfo DisplayCountry;
 
 		public WinState WinState = WinState.Undefined;
 		public bool IsBot;
@@ -51,20 +51,20 @@ namespace OpenRA
 
 		readonly IFogVisibilityModifier[] fogVisibilities;
 
-		CountryInfo ChooseCountry(World world, string name, bool requireSelectable = true)
+		FactionInfo ChooseCountry(World world, string name, bool requireSelectable = true)
 		{
 			var selectableCountries = world.Map.Rules.Actors["world"].Traits
-				.WithInterface<CountryInfo>().Where(c => !requireSelectable || c.Selectable)
+				.WithInterface<FactionInfo>().Where(f => !requireSelectable || f.Selectable)
 				.ToList();
 
-			var selected = selectableCountries.FirstOrDefault(c => c.Race == name)
+			var selected = selectableCountries.FirstOrDefault(f => f.Race == name)
 				?? selectableCountries.Random(world.SharedRandom);
 
 			// Don't loop infinite
 			for (var i = 0; i <= 10 && selected.RandomRaceMembers.Any(); i++)
 			{
 				var race = selected.RandomRaceMembers.Random(world.SharedRandom);
-				selected = selectableCountries.FirstOrDefault(c => c.Race == race);
+				selected = selectableCountries.FirstOrDefault(f => f.Race == race);
 
 				if (selected == null)
 					throw new YamlException("Unknown race: {0}".F(race));
@@ -73,12 +73,12 @@ namespace OpenRA
 			return selected;
 		}
 
-		CountryInfo ChooseDisplayCountry(World world, string race)
+		FactionInfo ChooseDisplayCountry(World world, string race)
 		{
 			var countries = world.Map.Rules.Actors["world"].Traits
-				.WithInterface<CountryInfo>();
+				.WithInterface<FactionInfo>().ToArray();
 
-			return countries.FirstOrDefault(c => c.Race == race) ?? countries.First();
+			return countries.FirstOrDefault(f => f.Race == race) ?? countries.First();
 		}
 
 		public Player(World world, Session.Client client, Session.Slot slot, PlayerReference pr)

--- a/OpenRA.Game/Traits/BodyOrientation.cs
+++ b/OpenRA.Game/Traits/BodyOrientation.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Traits
 		{
 			this.info = info;
 			var self = init.Self;
-			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : self.Owner.Country.Race;
+			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : self.Owner.Country.InternalName;
 
 			quantizedFacings = Exts.Lazy(() =>
 			{

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Traits
 			{
 				if (Resources > 0.8 * ResourceCapacity)
 				{
-					Sound.PlayNotification(self.World.Map.Rules, owner, "Speech", "SilosNeeded", owner.Country.Race);
+					Sound.PlayNotification(self.World.Map.Rules, owner, "Speech", "SilosNeeded", owner.Country.InternalName);
 					AlertSilo = true;
 				}
 				else
@@ -187,14 +187,14 @@ namespace OpenRA.Traits
 		public void PlayCashTickUp(Actor self)
 		{
 			if (Game.Settings.Sound.CashTicks)
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickUp", self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickUp", self.Owner.Country.InternalName);
 		}
 
 		public void PlayCashTickDown(Actor self)
 		{
 			if (Game.Settings.Sound.CashTicks && nextCashTickTime == 0)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickDown", self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickDown", self.Owner.Country.InternalName);
 				nextCashTickTime = 2;
 			}
 		}

--- a/OpenRA.Game/Traits/World/Faction.cs
+++ b/OpenRA.Game/Traits/World/Faction.cs
@@ -11,7 +11,7 @@
 namespace OpenRA.Traits
 {
 	[Desc("Attach this to the `World` actor.")]
-	public class CountryInfo : TraitInfo<Country>
+	public class FactionInfo : TraitInfo<Faction>
 	{
 		[Desc("This is the name exposed to the players.")]
 		public readonly string Name = null;
@@ -31,5 +31,5 @@ namespace OpenRA.Traits
 		public readonly bool Selectable = true;
 	}
 
-	public class Country { /* we're only interested in the Info */ }
+	public class Faction { /* we're only interested in the Info */ }
 }

--- a/OpenRA.Game/Traits/World/Faction.cs
+++ b/OpenRA.Game/Traits/World/Faction.cs
@@ -17,12 +17,12 @@ namespace OpenRA.Traits
 		public readonly string Name = null;
 
 		[Desc("This is the internal name for owner checks.")]
-		public readonly string Race = null;
+		public readonly string InternalName = null;
 
-		[Desc("Pick a random race as the player's race out of this list.")]
-		public readonly string[] RandomRaceMembers = { };
+		[Desc("Pick a random faction as the player's facton out of this list.")]
+		public readonly string[] RandomFactionMembers = { };
 
-		[Desc("The side that the country belongs to. For example, England belongs to the 'Allies' side.")]
+		[Desc("The side that the faction belongs to. For example, England belongs to the 'Allies' side.")]
 		public readonly string Side = null;
 
 		[Translate]

--- a/OpenRA.Game/VoiceExts.cs
+++ b/OpenRA.Game/VoiceExts.cs
@@ -27,7 +27,7 @@ namespace OpenRA
 				if (string.IsNullOrEmpty(voiced.VoiceSet))
 					return;
 
-				voiced.PlayVoice(self, phrase, self.Owner.Country.Race);
+				voiced.PlayVoice(self, phrase, self.Owner.Country.InternalName);
 			}
 		}
 
@@ -41,7 +41,7 @@ namespace OpenRA
 				if (string.IsNullOrEmpty(voiced.VoiceSet))
 					return;
 
-				voiced.PlayVoiceLocal(self, phrase, self.Owner.Country.Race, volume);
+				voiced.PlayVoiceLocal(self, phrase, self.Owner.Country.InternalName, volume);
 			}
 		}
 
@@ -66,7 +66,7 @@ namespace OpenRA
 					foreach (var v in orderSubject.TraitsImplementing<IOrderVoice>())
 					{
 						if (voice.PlayVoice(orderSubject, v.VoicePhraseForOrder(orderSubject, o),
-							orderSubject.Owner.Country.Race))
+							orderSubject.Owner.Country.InternalName))
 							return;
 					}
 			}

--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Widgets
 	{
 		public static Sprite GetChromeImage(World world, string name)
 		{
-			return ChromeProvider.GetImage("chrome-" + world.LocalPlayer.Country.Race, name);
+			return ChromeProvider.GetImage("chrome-" + world.LocalPlayer.Country.InternalName, name);
 		}
 
 		public static void DrawRGBA(Sprite s, float2 pos)

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Traits
 						cargo.Delivered(self);
 
 					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, raceVariant));
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Country.Race);
+					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Country.InternalName);
 				}));
 
 				actor.QueueActivity(new Fly(actor, Target.FromCell(w, endPos)));

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (health.DamageState == DamageState.Undamaged)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.FinishRepairingNotification, self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.FinishRepairingNotification, self.Owner.Country.InternalName);
 				return NextActivity;
 			}
 
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!played)
 				{
 					played = true;
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.StartRepairingNotification, self.Owner.Country.Race);
+					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.StartRepairingNotification, self.Owner.Country.InternalName);
 				}
 
 				if (!self.Owner.PlayerActor.Trait<PlayerResources>().TakeCash(cost))

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var s in Sounds)
 					Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
 
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Notification, self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Notification, self.Owner.Country.InternalName);
 
 				var init = new TypeDictionary
 				{

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			var players = new MapPlayers(map.PlayerDefinitions).Players;
 
-			var playerNames = players.Values.Select(p => p.Name);
+			var playerNames = players.Values.Select(p => p.Name).ToHashSet();
 			foreach (var player in players.Values)
 			{
 				foreach (var ally in player.Allies)
@@ -38,14 +38,14 @@ namespace OpenRA.Mods.Common.Lint
 
 			var worldActor = map.Rules.Actors["world"];
 
-			var races = worldActor.Traits.WithInterface<FactionInfo>().Select(f => f.InternalName);
+			var races = worldActor.Traits.WithInterface<FactionInfo>().Select(f => f.InternalName).ToHashSet();
 			foreach (var player in players.Values)
 				if (!string.IsNullOrWhiteSpace(player.Race) && !races.Contains(player.Race))
 					emitError("Invalid race {0} chosen for player {1}.".F(player.Race, player.Name));
 
 			if (worldActor.Traits.Contains<MPStartLocationsInfo>())
 			{
-				var multiPlayers = players.Where(p => p.Value.Playable).Count();
+				var multiPlayers = players.Count(p => p.Value.Playable);
 				var spawns = map.ActorDefinitions.Where(a => a.Value.Value == "mpspawn");
 				var spawnCount = spawns.Count();
 

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			var worldActor = map.Rules.Actors["world"];
 
-			var races = worldActor.Traits.WithInterface<FactionInfo>().Select(c => c.Race);
+			var races = worldActor.Traits.WithInterface<FactionInfo>().Select(f => f.InternalName);
 			foreach (var player in players.Values)
 				if (!string.IsNullOrWhiteSpace(player.Race) && !races.Contains(player.Race))
 					emitError("Invalid race {0} chosen for player {1}.".F(player.Race, player.Name));

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			var worldActor = map.Rules.Actors["world"];
 
-			var races = worldActor.Traits.WithInterface<CountryInfo>().Select(c => c.Race);
+			var races = worldActor.Traits.WithInterface<FactionInfo>().Select(c => c.Race);
 			foreach (var player in players.Values)
 				if (!string.IsNullOrWhiteSpace(player.Race) && !races.Contains(player.Race))
 					emitError("Invalid race {0} chosen for player {1}.".F(player.Race, player.Name));

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Lint
 			sequenceDefinitions = MiniYaml.MergeLiberal(map.SequenceDefinitions,
 				Game.ModData.Manifest.Sequences.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal));
 
-			var races = map.Rules.Actors["world"].Traits.WithInterface<CountryInfo>().Select(c => c.Race);
+			var races = map.Rules.Actors["world"].Traits.WithInterface<FactionInfo>().Select(c => c.Race);
 
 			foreach (var actorInfo in map.Rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Lint
 			sequenceDefinitions = MiniYaml.MergeLiberal(map.SequenceDefinitions,
 				Game.ModData.Manifest.Sequences.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal));
 
-			var races = map.Rules.Actors["world"].Traits.WithInterface<FactionInfo>().Select(c => c.Race);
+			var races = map.Rules.Actors["world"].Traits.WithInterface<FactionInfo>().Select(c => c.InternalName);
 
 			foreach (var actorInfo in map.Rules.Actors)
 			{

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -28,9 +28,9 @@ namespace OpenRA.Mods.Common.Lint
 			this.emitWarning = emitWarning;
 
 			sequenceDefinitions = MiniYaml.MergeLiberal(map.SequenceDefinitions,
-				Game.ModData.Manifest.Sequences.Select(s => MiniYaml.FromFile(s)).Aggregate(MiniYaml.MergeLiberal));
+				Game.ModData.Manifest.Sequences.Select(MiniYaml.FromFile).Aggregate(MiniYaml.MergeLiberal));
 
-			var races = map.Rules.Actors["world"].Traits.WithInterface<FactionInfo>().Select(c => c.InternalName);
+			var races = map.Rules.Actors["world"].Traits.WithInterface<FactionInfo>().Select(f => f.InternalName).ToArray();
 
 			foreach (var actorInfo in map.Rules.Actors)
 			{
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Lint
 					foreach (var race in races)
 					{
 						var image = renderInfo.GetImage(actorInfo.Value, map.Rules.Sequences[map.Tileset], race);
-						if (!sequenceDefinitions.Any(s => s.Key == image.ToLowerInvariant()) && !actorInfo.Value.Name.Contains("^"))
+						if (sequenceDefinitions.All(s => s.Key != image.ToLowerInvariant()) && !actorInfo.Value.Name.Contains("^"))
 							emitWarning("Sprite image {0} from actor {1} on tileset {2} using race {3} has no sequence definition."
 								.F(image, actorInfo.Value.Name, map.Tileset, race));
 					}
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Lint
 										{
 											foreach (var imageOverride in LintExts.GetFieldValues(traitInfo, imageField, emitError))
 											{
-												if (!string.IsNullOrEmpty(imageOverride) && !sequenceDefinitions.Any(s => s.Key == imageOverride.ToLowerInvariant()))
+												if (!string.IsNullOrEmpty(imageOverride) && sequenceDefinitions.All(s => s.Key != imageOverride.ToLowerInvariant()))
 													emitWarning("Custom sprite image {0} from actor {1} has no sequence definition.".F(imageOverride, actorInfo.Value.Name));
 												else
 													CheckDefintions(imageOverride, sequenceReference, actorInfo, sequence, race, field, traitInfo);
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Lint
 						emitWarning("Sprite image {0} from actor {1} of faction {2} does not define sequence prefix {3} from field {4} of {5}"
 							.F(image, actorInfo.Value.Name, race, sequence, field.Name, traitInfo));
 				}
-				else if (!definitions.Value.Nodes.Any(n => n.Key == sequence))
+				else if (definitions.Value.Nodes.All(n => n.Key != sequence))
 				{
 					emitWarning("Sprite image {0} from actor {1} of faction {2} does not define sequence {3} from field {4} of {5}"
 						.F(image, actorInfo.Value.Name, race, sequence, field.Name, traitInfo));

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Orders
 
 			var buildableInfo = info.Traits.Get<BuildableInfo>();
 			var mostLikelyProducer = queue.MostLikelyProducer();
-			race = buildableInfo.ForceRace ?? (mostLikelyProducer.Trait != null ? mostLikelyProducer.Trait.Race : producer.Owner.Country.Race);
+			race = buildableInfo.ForceRace ?? (mostLikelyProducer.Trait != null ? mostLikelyProducer.Trait.Race : producer.Owner.Country.InternalName);
 
 			buildOk = map.SequenceProvider.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
 			buildBlocked = map.SequenceProvider.GetSequence("overlay", "build-invalid").GetSprite(0);
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Orders
 					orderType = "PlacePlug";
 					if (!AcceptsPlug(topLeft, plugInfo))
 					{
-						Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Country.Race);
+						Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Country.InternalName);
 						yield break;
 					}
 				}
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Orders
 					if (!world.CanPlaceBuilding(building, buildingInfo, topLeft, null)
 						|| !buildingInfo.IsCloseEnoughToBase(world, producer.Owner, building, topLeft))
 					{
-						Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Country.Race);
+						Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Country.InternalName);
 						yield break;
 					}
 

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -38,13 +38,13 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Play an announcer voice listed in notifications.yaml")]
 		public void PlaySpeechNotification(Player player, string notification)
 		{
-			Sound.PlayNotification(world.Map.Rules, player, "Speech", notification, player != null ? player.Country.Race : null);
+			Sound.PlayNotification(world.Map.Rules, player, "Speech", notification, player != null ? player.Country.InternalName : null);
 		}
 
 		[Desc("Play a sound listed in notifications.yaml")]
 		public void PlaySoundNotification(Player player, string notification)
 		{
-			Sound.PlayNotification(world.Map.Rules, player, "Sounds", notification, player != null ? player.Country.Race : null);
+			Sound.PlayNotification(world.Map.Rules, player, "Sounds", notification, player != null ? player.Country.InternalName : null);
 		}
 
 		[Desc("Play a sound file")]

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			isPrimary = true;
 
-			Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", "PrimaryBuildingSelected", self.Owner.Country.Race);
+			Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", "PrimaryBuildingSelected", self.Owner.Country.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!Repairers.Remove(player) && Repairers.Count < Info.RepairBonuses.Length)
 				{
 					Repairers.Add(player);
-					Sound.PlayNotification(self.World.Map.Rules, player, "Speech", "Repairing", player.Country.Race);
+					Sound.PlayNotification(self.World.Map.Rules, player, "Speech", "Repairing", player.Country.InternalName);
 
 					self.World.AddFrameEndTask(w =>
 					{

--- a/OpenRA.Mods.Common/Traits/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureNotification.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (captor.World.LocalPlayer != captor.Owner)
 				return;
 
-			var race = info.NewOwnerVoice ? newOwner.Country.Race : oldOwner.Country.Race;
+			var race = info.NewOwnerVoice ? newOwner.Country.InternalName : oldOwner.Country.InternalName;
 			Sound.PlayNotification(self.World.Map.Rules, captor.World.LocalPlayer, "Speech", info.Notification, race);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanGiveTo(Actor collector)
 		{
-			if (info.ValidRaces.Any() && !info.ValidRaces.Contains(collector.Owner.Country.Race))
+			if (info.ValidRaces.Any() && !info.ValidRaces.Contains(collector.Owner.Country.InternalName))
 				return false;
 
 			var targetable = collector.Info.Traits.GetOrDefault<ITargetableInfo>();

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanGiveTo(Actor collector)
 		{
-			if (info.ValidRaces.Any() && !info.ValidRaces.Contains(collector.Owner.Country.Race))
+			if (info.ValidRaces.Any() && !info.ValidRaces.Contains(collector.Owner.Country.InternalName))
 				return false;
 
 			foreach (string unit in info.Units)

--- a/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			var raceList = info.Races;
-			correctRace = raceList.Length == 0 || raceList.Contains(self.Owner.Country.Race);
+			correctRace = raceList.Length == 0 || raceList.Contains(self.Owner.Country.InternalName);
 		}
 
 		public void Selling(Actor self) { }

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!silent)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "LevelUp", self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "LevelUp", self.Owner.Country.InternalName);
 				self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup", info.LevelUpPalette)));
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (self.World.WorldTick - lastAttackTime > info.NotifyInterval * 25)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Country.InternalName);
 
 				if (radarPings != null)
 					radarPings.Add(() => self.Owner == self.World.LocalPlayer, self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 				Game.RunAfterDelay(info.NotificationDelay, () =>
 				{
 					if (Game.IsCurrentWorld(player.World))
-						Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Country.Race);
+						Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Country.InternalName);
 				});
 			}
 		}
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Debug("{0} is victorious.", player.PlayerName);
 
 			if (player == player.World.LocalPlayer)
-				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Country.Race));
+				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Country.InternalName));
 		}
 
 		public void OnObjectiveAdded(Player player, int id) { }

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (self.World.WorldTick - lastAttackTime > info.NotifyInterval * 25)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Country.InternalName);
 
 				if (radarPings != null)
 					radarPings.Add(() => self.Owner == self.World.LocalPlayer, self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
 					Sound.PlayNotification(self.World.Map.Rules, null, info.NotificationType, info.Notification,
-						self.World.RenderPlayer != null ? self.World.RenderPlayer.Country.Race : null);
+						self.World.RenderPlayer != null ? self.World.RenderPlayer.Country.InternalName : null);
 
 				if (radarPings != null)
 				{

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				var producer = queue.MostLikelyProducer();
-				var race = producer.Trait != null ? producer.Trait.Race : self.Owner.Country.Race;
+				var race = producer.Trait != null ? producer.Trait.Race : self.Owner.Country.InternalName;
 				var buildingInfo = unit.Traits.Get<BuildingInfo>();
 
 				var buildableInfo = unit.Traits.GetOrDefault<BuildableInfo>();
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (GetNumBuildables(self.Owner) > prevItems)
 					w.Add(new DelayedAction(info.NewOptionsNotificationDelay,
-							() => Sound.PlayNotification(self.World.Map.Rules, order.Player, "Speech", info.NewOptionsNotification, order.Player.Country.Race)));
+							() => Sound.PlayNotification(self.World.Map.Rules, order.Player, "Speech", info.NewOptionsNotification, order.Player.Country.InternalName)));
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 			playerPower = playerActor.Trait<PowerManager>();
 			developerMode = playerActor.Trait<DeveloperMode>();
 
-			Race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : self.Owner.Country.Race;
+			Race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : self.Owner.Country.InternalName;
 			Enabled = !info.Race.Any() || info.Race.Contains(Race);
 
 			CacheProduceables(playerActor);
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!Info.Sticky)
 			{
-				Race = self.Owner.Country.Race;
+				Race = self.Owner.Country.InternalName;
 				Enabled = !Info.Race.Any() || Info.Race.Contains(Race);
 			}
 
@@ -277,13 +277,13 @@ namespace OpenRA.Mods.Common.Traits
 								var isBuilding = unit.Traits.Contains<BuildingInfo>();
 
 								if (isBuilding && !hasPlayedSound)
-									hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Country.Race);
+									hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Country.InternalName);
 								else if (!isBuilding)
 								{
 									if (BuildUnit(order.TargetString))
-										Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Country.Race);
+										Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Country.InternalName);
 									else if (!hasPlayedSound && time > 0)
-										hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Country.Race);
+										hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Country.InternalName);
 								}
 							})));
 						}

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (string.IsNullOrEmpty(prerequisite))
 				prerequisite = init.Self.Info.Name;
 
-			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race;
+			var race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.InternalName;
 
 			Update(init.Self.Owner, race);
 		}
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (info.ResetOnOwnerChange)
-				Update(newOwner, newOwner.Country.Race);
+				Update(newOwner, newOwner.Country.InternalName);
 		}
 
 		void Update(Player owner, string race)

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 				Game.RunAfterDelay(info.NotificationDelay, () =>
 				{
 					if (Game.IsCurrentWorld(player.World))
-						Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Country.Race);
+						Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Country.InternalName);
 				});
 			}
 		}
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Debug("{0} is victorious.", player.PlayerName);
 
 			if (player == player.World.LocalPlayer)
-				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Country.Race));
+				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Country.InternalName));
 		}
 
 		public void OnObjectiveAdded(Player player, int id) { }

--- a/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
+++ b/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsTraitDisabled && order.OrderString == "PowerDown")
 			{
 				disabled = !disabled;
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", disabled ? "EnablePower" : "DisablePower", self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", disabled ? "EnablePower" : "DisablePower", self.Owner.Country.InternalName);
 				power.UpdateActor(self);
 
 				if (disabled)
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!disabled || !Info.CancelWhenDisabled)
 				return;
 			disabled = false;
-			Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "EnablePower", self.Owner.Country.Race);
+			Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "EnablePower", self.Owner.Country.InternalName);
 			power.UpdateActor(self);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (--nextPowerAdviceTime <= 0)
 			{
 				if (lowPower)
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.SpeechNotification, self.Owner.Country.Race);
+					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.SpeechNotification, self.Owner.Country.InternalName);
 				nextPowerAdviceTime = info.AdviceInterval;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Info = info;
 			rp = Exts.Lazy(() => init.Self.IsDead ? null : init.Self.TraitOrDefault<RallyPoint>());
-			Race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race;
+			Race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.InternalName;
 		}
 
 		public void DoProduction(Actor self, ActorInfo producee, ExitInfo exitinfo, string raceVariant)

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 		public RenderSprites(ActorInitializer init, RenderSpritesInfo info)
 		{
 			this.info = info;
-			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race;
+			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.InternalName;
 		}
 
 		public string GetImage(Actor self)

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Killed(Actor self, AttackInfo e)
 		{
 			var player = info.NotifyAll ? self.World.LocalPlayer : self.Owner;
-			Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Country.Race);
+			Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Country.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Audio notification
 			if (discoverer != null && !string.IsNullOrEmpty(Info.Notification))
-				Sound.PlayNotification(self.World.Map.Rules, discoverer, "Speech", Info.Notification, discoverer.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, discoverer, "Speech", Info.Notification, discoverer.Country.InternalName);
 
 			// Radar notificaion
 			if (Info.PingRadar && radarPings.Value != null)

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			this.info = info;
 			buildingInfo = self.World.Map.Rules.Actors[info.IntoActor].Traits.GetOrDefault<BuildingInfo>();
-			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : self.Owner.Country.Race;
+			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : self.Owner.Country.InternalName;
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var s in info.NoTransformSounds)
 					Sound.PlayToPlayer(self.Owner, s);
 
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.NoTransformNotification, self.Owner.Country.Race);
+				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.NoTransformNotification, self.Owner.Country.InternalName);
 
 				return;
 			}

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -31,11 +31,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var spawnClass = p.PlayerReference.StartingUnitsClass ?? w.LobbyInfo.GlobalSettings.StartingUnitsClass;
 			var unitGroup = w.Map.Rules.Actors["world"].Traits.WithInterface<MPStartUnitsInfo>()
-				.Where(g => g.Class == spawnClass && g.Races != null && g.Races.Contains(p.Country.Race))
+				.Where(g => g.Class == spawnClass && g.Races != null && g.Races.Contains(p.Country.InternalName))
 				.RandomOrDefault(w.SharedRandom);
 
 			if (unitGroup == null)
-				throw new InvalidOperationException("No starting units defined for country {0} with class {1}".F(p.Country.Race, spawnClass));
+				throw new InvalidOperationException("No starting units defined for country {0} with class {1}".F(p.Country.InternalName, spawnClass));
 
 			if (unitGroup.BaseActor != null)
 			{

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
-			Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Country.Race);
+			Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Country.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1404,28 +1404,29 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						{
 							// Common code for making each trait
 							Action<string, string, string> addTrait = (type, newType, values) =>
-							{
-								var upgradeTypes = trait.Value.Nodes.FirstOrDefault(n => n.Key == type + "Upgrade");
-								var modifier = trait.Value.Nodes.FirstOrDefault(n => n.Key == type + "Modifier");
-
-								if (upgradeTypes == null || !string.IsNullOrEmpty(upgradeTypes.Value.Value) || modifier == null || !string.IsNullOrEmpty(modifier.Value.Value))
 								{
-									var yaml = new MiniYaml(null);
-									if (modifier == null)
-										modifier = new MiniYamlNode("Modifier", new MiniYaml(values));
-									else
-										modifier.Key = "Modifier";
-									yaml.Nodes.Add(modifier);
+									var upgradeTypes = trait.Value.Nodes.FirstOrDefault(n => n.Key == type + "Upgrade");
+									var modifier = trait.Value.Nodes.FirstOrDefault(n => n.Key == type + "Modifier");
 
-									if (upgradeTypes == null)
-										upgradeTypes = new MiniYamlNode("UpgradeTypes", new MiniYaml(type.ToLowerInvariant()));
-									else
-										upgradeTypes.Key = "UpgradeTypes";
-									yaml.Nodes.Add(upgradeTypes);
+									if (upgradeTypes == null || !string.IsNullOrEmpty(upgradeTypes.Value.Value) || modifier == null ||
+									    !string.IsNullOrEmpty(modifier.Value.Value))
+									{
+										var yaml = new MiniYaml(null);
+										if (modifier == null)
+											modifier = new MiniYamlNode("Modifier", new MiniYaml(values));
+										else
+											modifier.Key = "Modifier";
+										yaml.Nodes.Add(modifier);
 
-									node.Value.Nodes.Add(new MiniYamlNode((newType ?? type) + "Multiplier@EXPERIENCE", yaml));
-								}
-							};
+										if (upgradeTypes == null)
+											upgradeTypes = new MiniYamlNode("UpgradeTypes", new MiniYaml(type.ToLowerInvariant()));
+										else
+											upgradeTypes.Key = "UpgradeTypes";
+										yaml.Nodes.Add(upgradeTypes);
+
+										node.Value.Nodes.Add(new MiniYamlNode((newType ?? type) + "Multiplier@EXPERIENCE", yaml));
+									}
+								};
 
 							// Execute common code for each trait
 							addTrait("Firepower", null, "110, 115, 120, 130");
@@ -1502,6 +1503,24 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							trait.Key = "DamageMultiplier@INVULNERABLE";
 							trait.Value.Nodes.Add(new MiniYamlNode("Modifier", "0"));
 						}
+					}
+				}
+
+				// Rename the `Country` trait to `Faction`
+				if (engineVersion < 20150714)
+				{
+					var split = node.Key.Split('@');
+					if (split.Any() && split[0] == "Country")
+					{
+						node.Key = node.Key.Replace("Country", "Faction");
+
+						var race = node.Value.Nodes.FirstOrDefault(x => x.Key == "Race");
+						if (race != null)
+							race.Key = "InternalName";
+
+						var randomRace = node.Value.Nodes.FirstOrDefault(x => x.Key == "RandomRaceMembers");
+						if (randomRace != null)
+							randomRace.Key = "RandomFactionMembers";
 					}
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddRaceSuffixLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddRaceSuffixLogic.cs
@@ -19,8 +19,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public AddRaceSuffixLogic(Widget widget, World world)
 		{
 			string race;
-			if (!ChromeMetrics.TryGet("RaceSuffix-" + world.LocalPlayer.Country.Race, out race))
-				race = world.LocalPlayer.Country.Race;
+			if (!ChromeMetrics.TryGet("RaceSuffix-" + world.LocalPlayer.Country.InternalName, out race))
+				race = world.LocalPlayer.Country.InternalName;
 			var suffix = "-" + race;
 
 			if (widget is ButtonWidget)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -62,12 +62,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				flag.GetImageCollection = () => "flags";
 				if (lp.Stances[pp] == Stance.Ally || lp.WinState != WinState.Undefined)
 				{
-					flag.GetImageName = () => pp.Country.Race;
+					flag.GetImageName = () => pp.Country.InternalName;
 					item.Get<LabelWidget>("FACTION").GetText = () => pp.Country.Name;
 				}
 				else
 				{
-					flag.GetImageName = () => pp.DisplayCountry.Race;
+					flag.GetImageName = () => pp.DisplayCountry.InternalName;
 					item.Get<LabelWidget>("FACTION").GetText = () => pp.DisplayCountry.Name;
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Action onQuit = () =>
 			{
 				if (world.Type == WorldType.Regular)
-					Sound.PlayNotification(world.Map.Rules, null, "Speech", "Leave", world.LocalPlayer == null ? null : world.LocalPlayer.Country.Race);
+					Sound.PlayNotification(world.Map.Rules, null, "Speech", "Leave", world.LocalPlayer == null ? null : world.LocalPlayer.Country.InternalName);
 
 				resumeDisabled = true;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LeaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LeaveMapLogic.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (world.Type == WorldType.Regular)
 					Sound.PlayNotification(world.Map.Rules, null, "Speech", "Leave",
-						world.LocalPlayer == null ? null : world.LocalPlayer.Country.Race);
+						world.LocalPlayer == null ? null : world.LocalPlayer.Country.InternalName);
 
 				var exitDelay = iop != null ? iop.ExitDelay : 0;
 				if (mpe != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Player = p;
 				Label = p.PlayerName;
 				Color = p.Color.RGB;
-				Race = p.Country.Race;
+				Race = p.Country.InternalName;
 				IsSelected = () => p.World.RenderPlayer == p;
 				OnClick = () => { p.World.RenderPlayer = p; logic.selected = this; p.World.Selection.Clear(); };
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (showOwner)
 				{
-					flagRace = o.Country.Race;
+					flagRace = o.Country.InternalName;
 					ownerName = o.PlayerName;
 					ownerColor = o.Color.RGB;
 					widget.Bounds.Height = doubleHeight;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			colorPreview.Color = Game.Settings.Player.Color;
 
 			foreach (var f in modRules.Actors["world"].Traits.WithInterface<FactionInfo>())
-				countries.Add(f.Race, new LobbyCountry { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });
+				countries.Add(f.InternalName, new LobbyCountry { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });
 
 			var gameStarting = false;
 			Func<bool> configurationDisabled = () => !Game.IsHost || gameStarting ||

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -144,8 +144,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			colorPreview = lobby.Get<ColorPreviewManagerWidget>("COLOR_MANAGER");
 			colorPreview.Color = Game.Settings.Player.Color;
 
-			foreach (var c in modRules.Actors["world"].Traits.WithInterface<CountryInfo>())
-				countries.Add(c.Race, new LobbyCountry { Selectable = c.Selectable, Name = c.Name, Side = c.Side, Description = c.Description });
+			foreach (var f in modRules.Actors["world"].Traits.WithInterface<FactionInfo>())
+				countries.Add(f.Race, new LobbyCountry { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });
 
 			var gameStarting = false;
 			Func<bool> configurationDisabled = () => !Game.IsHost || gameStarting ||

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -456,9 +456,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var flag = template.Get<ImageWidget>("FLAG");
 			flag.GetImageCollection = () => "flags";
 			if (player.World.RenderPlayer != null && player.World.RenderPlayer.Stances[player] != Stance.Ally)
-				flag.GetImageName = () => player.DisplayCountry.Race;
+				flag.GetImageName = () => player.DisplayCountry.InternalName;
 			else
-				flag.GetImageName = () => player.Country.Race;
+				flag.GetImageName = () => player.Country.InternalName;
 
 			var playerName = template.Get<LabelWidget>("PLAYER");
 			var client = player.World.LobbyInfo.ClientWithIndex(player.ClientIndex);

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets
 				if (current == null)
 					continue;
 
-				var race = queue.Trait.Actor.Owner.Country.Race;
+				var race = queue.Trait.Actor.Owner.Country.InternalName;
 				var actor = queue.Trait.AllItems().FirstOrDefault(a => a.Name == current.Item);
 				if (actor == null)
 					continue;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				// Queue a new item
 				Sound.Play(TabClick);
-				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, World.LocalPlayer.Country.Race);
+				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, World.LocalPlayer.Country.InternalName);
 				World.IssueOrder(Order.StartProduction(CurrentQueue.Actor, icon.Name,
 					handleMultiple ? 5 : 1));
 				return true;
@@ -245,14 +245,14 @@ namespace OpenRA.Mods.Common.Widgets
 			if (item.Paused || item.Done || item.TotalCost == item.RemainingCost)
 			{
 				// Instant cancel of things we have not started yet and things that are finished
-				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Country.Race);
+				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Country.InternalName);
 				World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name,
 					handleMultiple ? 5 : 1));
 			}
 			else
 			{
 				// Pause an existing item
-				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.OnHoldAudio, World.LocalPlayer.Country.Race);
+				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.OnHoldAudio, World.LocalPlayer.Country.InternalName);
 				World.IssueOrder(Order.PauseProduction(CurrentQueue.Actor, icon.Name, true));
 			}
 

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.D2k.Activities
 
 		void NotifyPlayer(Player player, WPos location)
 		{
-			Sound.PlayNotification(player.World.Map.Rules, player, "Speech", swallow.Info.WormAttackNotification, player.Country.Race);
+			Sound.PlayNotification(player.World.Map.Rules, player, "Speech", swallow.Info.WormAttackNotification, player.Country.InternalName);
 
 			if (player == player.World.RenderPlayer)
 				radarPings.Add(() => true, location, Color.Red, 50);

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			this.info = info;
 			production = init.Self.Trait<Production>();
-			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race;
+			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.InternalName;
 		}
 
 		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.RA.Traits
 			var oldEffectiveOwner = AsPlayer;
 
 			var renderSprites = actorInfo.Traits.GetOrDefault<RenderSpritesInfo>();
-			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.SequenceProvider, newOwner.Country.Race);
+			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.SequenceProvider, newOwner.Country.InternalName);
 			AsPlayer = newOwner;
 			AsTooltipInfo = actorInfo.Traits.WithInterface<TooltipInfo>().FirstOrDefault();
 

--- a/OpenRA.Mods.RA/Traits/LeavesHusk.cs
+++ b/OpenRA.Mods.RA/Traits/LeavesHusk.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			this.info = info;
 
-			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.Race;
+			race = init.Contains<RaceInit>() ? init.Get<RaceInit, string>() : init.Self.Owner.Country.InternalName;
 		}
 
 		public void Killed(Actor self, AttackInfo e)

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -12,18 +12,18 @@
 		FogVariants: typea, typeb, typec, typed
 		OverrideFullShroud: full
 		OverrideFullFog: full
-	Country@Random:
+	Faction@Random:
 		Name: Any
-		Race: Random
-		RandomRaceMembers: gdi, nod
+		InternalName: Random
+		RandomFactionMembers: gdi, nod
 		Description: Select a random faction.
-	Country@gdi:
+	Faction@gdi:
 		Name: GDI
-		Race: gdi
+		InternalName: gdi
 		Description: Global Defense Initiative\nThe GDI is an international military branch of the United Nations tasked\nwith keeping world peace. Commanding the combined forces of the world's\nmost powerful nations, they possess an unmatched arsenal of high-tech weaponry.
-	Country@nod:
+	Faction@nod:
 		Name: Nod
-		Race: nod
+		InternalName: nod
 		Description: Brotherhood of Nod\nThe Brotherhood is a religious cult centered around their leader Kane\nand the alien substance Tiberium. They utilize stealth technology\nand guerilla tactics to defeat those who oppose them.
 	ResourceType@green-tib:
 		ResourceType: 1

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -14,26 +14,26 @@
 		OverrideFullShroud: full
 		OverrideFullFog: full
 		ShroudBlend: Multiply
-	Country@Random:
+	Faction@Random:
 		Name: Any
-		Race: Random
-		RandomRaceMembers: atreides, harkonnen, ordos
+		InternalName: Random
+		RandomFactionMembers: atreides, harkonnen, ordos
 		Description: Select a random House.
-	Country@Atreides:
+	Faction@Atreides:
 		Name: Atreides
-		Race: atreides
+		InternalName: atreides
 		Description: House Atreides\nThe noble Atreides, from the water world of Caladan,\nrely on their ornithopters to ensure air superiority.\nThey have allied themselves with the Fremen, the fearsome\nnative warriors of Dune that can move undetected in battle.
-	Country@Harkonnen:
+	Faction@Harkonnen:
 		Name: Harkonnen
-		Race: harkonnen
+		InternalName: harkonnen
 		Description: House Harkonnen\nThe evil Harkonnen will stop at nothing to gain control of the spice.\nThey rely on brute force and atomic weapons to achieve their goals:\nwealth, and the destruction of House Atreides.
-	Country@Ordos:
+	Faction@Ordos:
 		Name: Ordos
-		Race: ordos
+		InternalName: ordos
 		Description: House Ordos\nThe insidious Ordos of the icy planet Sigma Draconis IV\nare known for their wealth, greed and treachery.\nRelying heavily on mercenaries they often resort\nto sabotage and forbidden Ixian technologies.
-	Country@Corrino:
+	Faction@Corrino:
 		Name: Corrino
-		Race: corrino
+		InternalName: corrino
 		Selectable: false
 	ResourceType@Spice:
 		ResourceType: 1

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -12,57 +12,57 @@
 		FogVariants: shroud
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255
 		UseExtendedIndex: true
-	Country@0:
+	Faction@0:
 		Name: Allies
-		Race: allies
+		InternalName: allies
 		Side: Allies
 		Selectable: False
-	Country@1:
+	Faction@1:
 		Name: England
-		Race: england
+		InternalName: england
 		Side: Allies
 		Description: England: Espionage\nSpecial Unit: British Spy\nSpecial Unit: Phase Transport
-	Country@2:
+	Faction@2:
 		Name: France
-		Race: france
+		InternalName: france
 		Side: Allies
 		Description: France: Deception\nSpecial Ability: Can build fake structures\nSpecial Unit: Mobile Gap Generator
-	Country@3:
+	Faction@3:
 		Name: Germany
-		Race: germany
+		InternalName: germany
 		Side: Allies
 		Description: Germany: Technology\nSpecial Ability: Advanced Chronoshift\nSpecial Unit: Chrono Tank
-	Country@4:
+	Faction@4:
 		Name: Soviet
-		Race: soviet
+		InternalName: soviet
 		Side: Soviet
 		Selectable: False
-	Country@5:
+	Faction@5:
 		Name: Russia
-		Race: russia
+		InternalName: russia
 		Side: Soviet
 		Description: Russia: Tesla Weapons\nSpecial Unit: Tesla Tank\nSpecial Unit: Shock Trooper
-	Country@6:
+	Faction@6:
 		Name: Ukraine
-		Race: ukraine
+		InternalName: ukraine
 		Side: Soviet
 		Description: Ukraine: Demolitions\nSpecial Ability: Parabombs\nSpecial Unit: Demolition Truck
-	Country@random:
+	Faction@random:
 		Name: Any
-		Race: Random
-		RandomRaceMembers: RandomAllies, RandomSoviet
+		InternalName: Random
+		RandomFactionMembers: RandomAllies, RandomSoviet
 		Side: Random
 		Description: A random country.
-	Country@randomallies:
+	Faction@randomallies:
 		Name: Allies
-		Race: RandomAllies
-		RandomRaceMembers: england, france, germany
+		InternalName: RandomAllies
+		RandomFactionMembers: england, france, germany
 		Side: Random
 		Description: A random Allied country.
-	Country@randomsoviet:
+	Faction@randomsoviet:
 		Name: Soviet
-		Race: RandomSoviet
-		RandomRaceMembers: russia, ukraine
+		InternalName: RandomSoviet
+		RandomFactionMembers: russia, ukraine
 		Side: Random
 		Description: A random Soviet country.
 	ResourceType@ore:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -12,16 +12,16 @@
 		UseExtendedIndex: true
 		ShroudPalette: shroud
 		FogPalette: shroud
-	Country@Random:
+	Faction@Random:
 		Name: Any
-		Race: Random
-		RandomRaceMembers: gdi, nod
-	Country@0:
+		InternalName: Random
+		RandomFactionMembers: gdi, nod
+	Faction@0:
 		Name: GDI
-		Race: gdi
-	Country@1:
+		InternalName: gdi
+	Faction@1:
 		Name: Nod
-		Race: nod
+		InternalName: nod
 	ResourceType@Tiberium:
 		ResourceType: 1
 		Palette: greentiberium


### PR DESCRIPTION
This is another split off from #7873.
It's not as scary as it looks at first glance - it only renames 3 things.

P.S.: A long time ago, when this was planned, it was proposed that Race be renamed to ID. I am open to suggestions on that point, in case anyone doesn't like InternalName too much. I can go with ID (or something else) if requested.
