### PR TITLE
Fixed a crash when disguising the spy as infantry without stand2

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -10,6 +10,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Support;
 
 namespace OpenRA.Graphics
 {
@@ -198,6 +200,11 @@ namespace OpenRA.Graphics
 		public ISpriteSequence GetSequence(string sequenceName)
 		{
 			return sequenceProvider.GetSequence(name, sequenceName);
+		}
+
+		public string GetRandomExistingSequence(string[] sequences, MersenneTwister random)
+		{
+			return sequences.Where(s => HasSequence(s)).RandomOrDefault(random);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -70,10 +70,17 @@ namespace OpenRA.Mods.Common.Traits
 
 			DefaultAnimation = new Animation(init.World, rs.GetImage(self), RenderSprites.MakeFacingFunc(self));
 			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled));
+			PlayStandAnimation(self);
 
-			DefaultAnimation.PlayFetchIndex(NormalizeInfantrySequence(init.Self, info.StandSequences.Random(Game.CosmeticRandom)), () => 0);
 			state = AnimationState.Waiting;
 			move = init.Self.Trait<IMove>();
+		}
+
+		public void PlayStandAnimation(Actor self)
+		{
+			var sequence = DefaultAnimation.GetRandomExistingSequence(Info.StandSequences, Game.CosmeticRandom);
+			if (sequence != null)
+				DefaultAnimation.PlayFetchIndex(NormalizeInfantrySequence(self, sequence), () => 0);
 		}
 
 		public void Created(Actor self)
@@ -123,7 +130,7 @@ namespace OpenRA.Mods.Common.Traits
 			if ((state == AnimationState.Moving || dirty) && !move.IsMoving)
 			{
 				state = AnimationState.Waiting;
-				DefaultAnimation.PlayFetchIndex(NormalizeInfantrySequence(self, Info.StandSequences.Random(Game.CosmeticRandom)), () => 0);
+				PlayStandAnimation(self);
 			}
 			else if ((state != AnimationState.Moving || dirty) && move.IsMoving)
 			{
@@ -138,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (state != AnimationState.Idle && state != AnimationState.IdleAnimating && state != AnimationState.Attacking)
 			{
-				DefaultAnimation.PlayFetchIndex(NormalizeInfantrySequence(self, Info.StandSequences.Random(Game.CosmeticRandom)), () => 0);
+				PlayStandAnimation(self);
 				state = AnimationState.Idle;
 
 				if (Info.IdleSequences.Length > 0)
@@ -156,14 +163,14 @@ namespace OpenRA.Mods.Common.Traits
 						state = AnimationState.IdleAnimating;
 						DefaultAnimation.PlayThen(idleSequence, () =>
 						{
-							DefaultAnimation.PlayRepeating(NormalizeInfantrySequence(self, Info.StandSequences.Random(Game.CosmeticRandom)));
+							PlayStandAnimation(self);
 							state = AnimationState.Waiting;
 						});
 					}
 				}
 				else
 				{
-					DefaultAnimation.PlayRepeating(NormalizeInfantrySequence(self, Info.StandSequences.Random(Game.CosmeticRandom)));
+					PlayStandAnimation(self);
 					state = AnimationState.Waiting;
 				}
 			}

--- a/OpenRA.Mods.RA/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.RA/Traits/Render/WithDisguisingInfantryBody.cs
@@ -39,7 +39,9 @@ namespace OpenRA.Mods.RA.Traits
 			if (disguise.AsSprite != intendedSprite)
 			{
 				intendedSprite = disguise.AsSprite;
-				DefaultAnimation.ChangeImage(intendedSprite ?? rs.GetImage(self), info.StandSequences.Random(Game.CosmeticRandom));
+				var sequence = DefaultAnimation.GetRandomExistingSequence(info.StandSequences, Game.CosmeticRandom);
+				if (sequence != null)
+					DefaultAnimation.ChangeImage(intendedSprite ?? rs.GetImage(self), sequence);
 				rs.UpdatePalette();
 			}
 


### PR DESCRIPTION
Some recent sequence cleanups must have undone my workaround in https://github.com/OpenRA/OpenRA/pull/4265. Time to fix it properly. http://resource.openra.net/maps/3367/ is a good test case. It has c2 in the creep base near the weapon factory.
