### PR TITLE
Removed InitialActivity from FreeActor and Buildable

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -29,9 +29,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Disable production when there are more than this many of this actor on the battlefield. Set to 0 to disable.")]
 		public readonly int BuildLimit = 0;
 
-		[Desc("What the unit should start doing. Warning: If this is not a harvester", "it will break if you use FindResources.")]
-		public readonly string InitialActivity = null;
-
 		[Desc("Force a specific race variant, overriding the race of the producing actor.")]
 		public readonly string ForceRace = null;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -8,22 +8,18 @@
  */
 #endregion
 
-using OpenRA.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Player recives a unit for free once the building is placed. This also works for structures.",
+	[Desc("Player receives a unit for free once the building is placed. This also works for structures.",
 		"If you want more than one unit to appear copy this section and assign IDs like FreeActor@2, ...")]
 	public class FreeActorInfo : ITraitInfo
 	{
 		[ActorReference]
 		[Desc("Name of the actor.")]
 		public readonly string Actor = null;
-
-		[Desc("What the unit should start doing. Warning: If this is not a harvester", "it will break if you use FindResources.")]
-		public readonly string InitialActivity = null;
 
 		[Desc("Offset relative to the top-left cell of the building.")]
 		public readonly CVec SpawnOffset = CVec.Zero;
@@ -43,16 +39,13 @@ namespace OpenRA.Mods.Common.Traits
 
 			init.Self.World.AddFrameEndTask(w =>
 			{
-				var a = w.CreateActor(info.Actor, new TypeDictionary
+				w.CreateActor(info.Actor, new TypeDictionary
 				{
 					new ParentActorInit(init.Self),
 					new LocationInit(init.Self.Location + info.SpawnOffset),
 					new OwnerInit(init.Self.Owner),
 					new FacingInit(info.Facing),
 				});
-
-				if (info.InitialActivity != null)
-					a.QueueActivity(Game.CreateObject<Activity>(info.InitialActivity));
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -42,6 +42,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Percentage of maximum speed when fully loaded.")]
 		public readonly int FullyLoadedSpeed = 85;
 
+		[Desc("Automatically scan for resources when created.")]
+		public readonly bool SearchOnCreation = true;
+
 		[Desc("Initial search radius (in cells) from the refinery that created us.")]
 		public readonly int SearchFromProcRadius = 24;
 
@@ -55,8 +58,8 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Harvester : IIssueOrder, IResolveOrder, IPips,
-		IExplodeModifier, IOrderVoice, ISpeedModifier, ISync,
-		INotifyResourceClaimLost, INotifyIdle, INotifyBlockingMove
+		IExplodeModifier, IOrderVoice, ISpeedModifier, ISync, INotifyCreated,
+		INotifyResourceClaimLost, INotifyIdle, INotifyBlockingMove, INotifyBuildComplete
 	{
 		readonly HarvesterInfo info;
 		Dictionary<ResourceTypeInfo, int> contents = new Dictionary<ResourceTypeInfo, int>();
@@ -74,6 +77,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			self.QueueActivity(new CallFunc(() => ChooseNewProc(self, null)));
+		}
+
+		public void Created(Actor self)
+		{
+			if (info.SearchOnCreation)
+				self.QueueActivity(new FindResources());
+		}
+
+		public void BuildingComplete(Actor self)
+		{
+			if (info.SearchOnCreation)
+				self.QueueActivity(new FindResources());
 		}
 
 		public void SetProcLines(Actor proc)

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -96,9 +96,6 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var notify in notifyOthers)
 					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
 
-				if (bi != null && bi.InitialActivity != null)
-					newUnit.QueueActivity(Game.CreateObject<Activity>(bi.InitialActivity));
-
 				foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
 					t.BuildingComplete(newUnit);
 			});

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1360,6 +1360,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "FlashPaletteEffect";
 				}
 
+				// InitialActivity on FreeActor and Buildable was removed (due to being too hacky)
+				if (engineVersion < 20150707)
+				{
+					if (depth == 1)
+						node.Value.Nodes.RemoveAll(n => n.Key == "InitialActivity");
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
@@ -51,18 +51,15 @@ namespace OpenRA.Mods.D2k.Traits
 			self = init.Self;
 			Info = info;
 
-			DoDelivery(self.Location + info.DeliveryOffset, info.Actor, info.DeliveringActor, info.InitialActivity);
+			DoDelivery(self.Location + info.DeliveryOffset, info.Actor, info.DeliveringActor);
 		}
 
-		public void DoDelivery(CPos location, string actorName, string carrierActorName, string clientInitialActivity)
+		public void DoDelivery(CPos location, string actorName, string carrierActorName)
 		{
 			Actor cargo;
 			Actor carrier;
 
 			CreateActors(actorName, carrierActorName, out cargo, out carrier);
-
-			if (clientInitialActivity != null)
-				cargo.QueueActivity(Game.CreateObject<Activity>(clientInitialActivity));
 
 			var carryable = cargo.Trait<Carryable>();
 			carryable.Destination = location;

--- a/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
@@ -68,10 +68,6 @@ namespace OpenRA.Mods.D2k.Traits
 					foreach (var notify in notifyOthers)
 						notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
 
-					var bi = newUnit.Info.Traits.GetOrDefault<BuildableInfo>();
-					if (bi != null && bi.InitialActivity != null)
-						newUnit.QueueActivity(Game.CreateObject<Activity>(bi.InitialActivity));
-
 					foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
 						t.BuildingComplete(newUnit);
 				});

--- a/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
+++ b/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.D2k.Traits
 			var refinery = refineries.First().Actor;
 			var delivery = refinery.Trait<FreeActorWithDelivery>();
 			delivery.DoDelivery(refinery.Location + delivery.Info.DeliveryOffset, delivery.Info.Actor,
-				delivery.Info.DeliveringActor, delivery.Info.InitialActivity);
+				delivery.Info.DeliveringActor);
 		}
 	}
 }

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -180,7 +180,6 @@ PROC:
 		Value: 500
 	FreeActor:
 		Actor: HARV
-		InitialActivity: FindResources
 		SpawnOffset: 1,2
 		Facing: 64
 	WithResources:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -203,7 +203,6 @@ refinery:
 		Value: 500
 	FreeActorWithDelivery:
 		Actor: harvester
-		InitialActivity: FindResources
 		DeliveryOffset: 2,2
 		DeliveringActor: carryall.reinforce
 		Facing: 160

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -972,7 +972,6 @@ PROC:
 		Value: 600
 	FreeActor:
 		Actor: HARV
-		InitialActivity: FindResources
 		SpawnOffset: 1,2
 		Facing: 64
 	InfiltrateForCash:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -83,7 +83,6 @@ PROC:
 		Value: 600
 	FreeActor:
 		Actor: HARV
-		InitialActivity: FindResources
 		SpawnOffset: 3,1
 		Facing: 160
 	WithIdleOverlay@REDLIGHTS:


### PR DESCRIPTION
For `Harvester`s, `FindResources` is now queued from `Created()`, provided `SearchOnCreation` is set to `true`.
