### PR TITLE
Added configurable MinimumExcessPower to HackyAI

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.AI
 			var buildableThings = queue.BuildableItems();
 
 			// First priority is to get out of a low power situation
-			if (playerPower.ExcessPower < 0)
+			if (playerPower.ExcessPower < ai.Info.MinimumExcessPower)
 			{
 				var power = GetProducibleBuilding("Power", buildableThings, a => a.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(p => p.Amount));
 				if (power != null && power.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(p => p.Amount) > 0)
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.Common.AI
 				// Will this put us into low power?
 				var actor = world.Map.Rules.Actors[frac.Key];
 				var pis = actor.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1);
-				if (playerPower.ExcessPower < 0 || playerPower.ExcessPower < pis.Sum(pi => pi.Amount))
+				if (playerPower.ExcessPower < ai.Info.MinimumExcessPower || playerPower.ExcessPower < pis.Sum(pi => pi.Amount))
 				{
 					// Try building a power plant instead
 					var power = GetProducibleBuilding("Power",

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -49,6 +49,9 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Minimum delay (in ticks) between creating squads.")]
 		public readonly int MinimumAttackForceDelay = 0;
 
+		[Desc("Minimum excess power the AI should try to maintain.")]
+		public readonly int MinimumExcessPower = 0;
+
 		[Desc("How long to wait (in ticks) between structure production checks when there is no active production.")]
 		public readonly int StructureProductionInactiveDelay = 125;
 

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@Cabal:
 		Name: Cabal
+		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -119,6 +120,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@Watson:
 		Name: Watson
+		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -237,6 +239,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@HAL9001:
 		Name: HAL 9001
+		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@Omnius:
 		Name: Omnius
+		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
@@ -127,6 +128,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@Vidius:
 		Name: Vidious
+		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
@@ -253,6 +255,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@Gladius:
 		Name: Gladius
+		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@RushAI:
 		Name: Rush AI
+		MinimumExcessPower: 40
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -25,7 +26,8 @@ Player:
 			fix: 1
 		BuildingFractions:
 			proc: 30%
-			powr: 35%
+			powr: 15%
+			apwr: 20%
 			barr: 1%
 			tent: 1%
 			kenn: 0.5%
@@ -109,6 +111,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@NormalAI:
 		Name: Normal AI
+		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -235,6 +238,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@TurtleAI:
 		Name: Turtle AI
+		MinimumExcessPower: 100
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -18,8 +18,6 @@ Player:
 			kenn: 1
 			dome: 1
 			weap: 1
-			spen: 1
-			syrd: 1
 			hpad: 4
 			afld: 4
 			atek: 1
@@ -49,7 +47,6 @@ Player:
 			e4: 2%
 			dog: 2%
 			shok: 2%
-			sniper: 1%
 			apc: 30%
 			jeep: 40%
 			arty: 15%
@@ -166,7 +163,6 @@ Player:
 			e4: 5%
 			dog: 3%
 			shok: 5%
-			sniper: 2%
 			harv: 10%
 			apc: 30%
 			jeep: 40%

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@TestAI:
 		Name: Test AI
+		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: gacnst
 			Refinery: proc


### PR DESCRIPTION
Reduces the problem that AI constantly builds itself out of power.

Partially adresses #8565.
