### PR TITLE
Fixed GDI upgrade center being visible in Nod build palette

### DIFF
--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -326,7 +326,7 @@ GAPLUG:
 		Bounds: 115,72,0,-12
 	Buildable:
 		BuildPaletteOrder: 100
-		Prerequisites: proc, gatech
+		Prerequisites: proc, gatech, ~structures.gdi
 		Queue: Building
 	Building:
 		Footprint: xxx xxx


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/8522.
