### PR TITLE
Fixed a crash when activating a nuke during sudden powerdown

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -230,7 +230,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Ready)
 				return;
 
-			var power = Instances.First(i => !InstanceDisabled(i));
+			var power = Instances.FirstOrDefault(i => !InstanceDisabled(i));
+			if (power == null)
+				return;
 
 			// Note: order.Subject is the *player* actor
 			power.Activate(power.Self, order, manager);


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/8141.
