### PR TITLE
Updated SDL2-CS to use current upstream version

### DIFF
--- a/OpenRA.Renderer.Sdl2/FrameBuffer.cs
+++ b/OpenRA.Renderer.Sdl2/FrameBuffer.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Renderer.Sdl2
 			GL.Ext.BindRenderbuffer(RenderbufferTarget.RenderbufferExt, depth);
 			ErrorHandler.CheckGlError();
 
-			GL.Ext.RenderbufferStorage(RenderbufferTarget.RenderbufferExt, (RenderbufferStorage)All.DepthComponent, size.Width, size.Height);
+			GL.Ext.RenderbufferStorage(RenderbufferTarget.RenderbufferExt, RenderbufferStorage.DepthComponent, size.Width, size.Height);
 			ErrorHandler.CheckGlError();
 
 			GL.Ext.FramebufferRenderbuffer(FramebufferTarget.FramebufferExt, FramebufferAttachment.DepthAttachmentExt, RenderbufferTarget.RenderbufferExt, depth);

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -120,7 +120,7 @@ if (!(Test-Path "SDL2-CS.dll"))
 {
 	echo "Fetching SDL2 C# from GitHub."
 	$target = Join-Path $pwd.ToString() "SDL2-CS.dll"
-	(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/SDL2-CS/releases/download/20140407/SDL2-CS.dll", $target)
+	(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/SDL2-CS/releases/download/20150709/SDL2-CS.dll", $target)
 }
 
 if (!(Test-Path "Eluant.dll"))

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -93,7 +93,7 @@ fi
 
 if [ ! -f SDL2-CS.dll ]; then
 	echo "Fetching SDL2-CS from GitHub."
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20140407/SDL2-CS.dll
+	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20150709/SDL2-CS.dll
 fi
 
 if [ ! -f Eluant.dll ]; then


### PR DESCRIPTION
This shouldn't change much other than our version being re-united with upstream again which is better in terms of maintenance and collaboration. See https://github.com/OpenRA/SDL2-CS/compare/openra...OpenRA:minitk for a changelog.
