### PR TITLE
Move silo from defense to building queue

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -993,7 +993,7 @@ PROC:
 SILO:
 	Inherits: ^Building
 	Buildable:
-		Queue: Defense
+		Queue: Building
 		BuildPaletteOrder: 35
 		Prerequisites: proc, ~techlevel.infonly
 	Valued:


### PR DESCRIPTION
Love the game. I cannot stand the fact that the silos are in the defence category! Can someone convince me why that makes sense?

Cheers,

Ben
