### PR TITLE
Made all body, turret and barrel render traits upgradable

### DIFF
--- a/OpenRA.Game/Traits/BodyOrientation.cs
+++ b/OpenRA.Game/Traits/BodyOrientation.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Linq;
 
 namespace OpenRA.Traits
 {
@@ -62,7 +63,7 @@ namespace OpenRA.Traits
 				if (info.QuantizedFacings >= 0)
 					return info.QuantizedFacings;
 
-				var qboi = self.Info.Traits.GetOrDefault<IQuantizeBodyOrientationInfo>();
+				var qboi = self.Info.Traits.WithInterface<IQuantizeBodyOrientationInfo>().FirstOrDefault();
 				if (qboi == null)
 					throw new InvalidOperationException("Actor type '" + self.Info.Name + "' does not define a quantized body orientation.");
 

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -58,12 +58,12 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class WithTurret : UpgradableTrait<WithTurretInfo>, ITick, INotifyDamageStateChanged
 	{
-		RenderSprites rs;
-		IBodyOrientation body;
-		AttackBase ab;
-		Turreted t;
-		Armament[] arms;
 		public readonly Animation DefaultAnimation;
+		readonly RenderSprites rs;
+		readonly IBodyOrientation body;
+		readonly AttackBase ab;
+		readonly Turreted t;
+		readonly Armament[] arms;
 
 		public WithTurret(Actor self, WithTurretInfo info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -16,19 +16,24 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithVoxelBarrelInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<ArmamentInfo>, Requires<TurretedInfo>
+	public class WithVoxelBarrelInfo : UpgradableTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<ArmamentInfo>, Requires<TurretedInfo>
 	{
 		[Desc("Voxel sequence name to use")]
-		public readonly string Sequence = "barrel";
+		[SequenceReference] public readonly string Sequence = "barrel";
+
 		[Desc("Armament to use for recoil")]
 		public readonly string Armament = "primary";
+
 		[Desc("Visual offset")]
 		public readonly WVec LocalOffset = WVec.Zero;
 
-		public object Create(ActorInitializer init) { return new WithVoxelBarrel(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithVoxelBarrel(init.Self, this); }
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{
+			if (UpgradeMinEnabledLevel > 0)
+				yield break;
+
 			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
 			var armament = init.Actor.Traits.WithInterface<ArmamentInfo>()
 				.First(a => a.Name == Armament);
@@ -46,33 +51,32 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithVoxelBarrel
+	public class WithVoxelBarrel : UpgradableTrait<WithVoxelBarrelInfo>
 	{
-		WithVoxelBarrelInfo info;
-		Actor self;
-		Armament armament;
-		Turreted turreted;
-		IBodyOrientation body;
+		readonly Actor self;
+		readonly Armament armament;
+		readonly Turreted turreted;
+		readonly IBodyOrientation body;
 
 		public WithVoxelBarrel(Actor self, WithVoxelBarrelInfo info)
+			: base(info)
 		{
 			this.self = self;
-			this.info = info;
 			body = self.Trait<IBodyOrientation>();
 			armament = self.TraitsImplementing<Armament>()
-				.First(a => a.Info.Name == info.Armament);
+				.First(a => a.Info.Name == Info.Armament);
 			turreted = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == armament.Info.Turret);
 
 			var rv = self.Trait<RenderVoxels>();
-			rv.Add(new VoxelAnimation(VoxelProvider.GetVoxel(rv.Image, info.Sequence),
+			rv.Add(new VoxelAnimation(VoxelProvider.GetVoxel(rv.Image, Info.Sequence),
 				BarrelOffset, BarrelRotation,
-				() => false, () => 0));
+				() => IsTraitDisabled, () => 0));
 		}
 
 		WVec BarrelOffset()
 		{
-			var localOffset = info.LocalOffset + new WVec(-armament.Recoil, WDist.Zero, WDist.Zero);
+			var localOffset = Info.LocalOffset + new WVec(-armament.Recoil, WDist.Zero, WDist.Zero);
 			var turretOffset = turreted != null ? turreted.Position(self) : WVec.Zero;
 			var turretOrientation = turreted != null ? turreted.LocalOrientation(self) : WRot.Zero;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -16,18 +16,21 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithVoxelTurretInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<TurretedInfo>
+	public class WithVoxelTurretInfo : UpgradableTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<TurretedInfo>
 	{
 		[Desc("Voxel sequence name to use")]
-		public readonly string Sequence = "turret";
+		[SequenceReference] public readonly string Sequence = "turret";
 
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";
 
-		public object Create(ActorInitializer init) { return new WithVoxelTurret(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithVoxelTurret(init.Self, this); }
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{
+			if (UpgradeMinEnabledLevel > 0)
+				yield break;
+
 			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
 			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
@@ -42,23 +45,24 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithVoxelTurret
+	public class WithVoxelTurret : UpgradableTrait<WithVoxelTurretInfo>
 	{
 		readonly Actor self;
 		readonly Turreted turreted;
 		readonly IBodyOrientation body;
 
 		public WithVoxelTurret(Actor self, WithVoxelTurretInfo info)
+			: base(info)
 		{
 			this.self = self;
 			body = self.Trait<IBodyOrientation>();
 			turreted = self.TraitsImplementing<Turreted>()
-				.First(tt => tt.Name == info.Turret);
+				.First(tt => tt.Name == Info.Turret);
 
 			var rv = self.Trait<RenderVoxels>();
-			rv.Add(new VoxelAnimation(VoxelProvider.GetVoxel(rv.Image, info.Sequence),
+			rv.Add(new VoxelAnimation(VoxelProvider.GetVoxel(rv.Image, Info.Sequence),
 				() => turreted.Position(self), TurretRotation,
-				() => false, () => 0));
+				() => IsTraitDisabled, () => 0));
 		}
 
 		IEnumerable<WRot> TurretRotation()

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -4,6 +4,7 @@
 	CombatDebugOverlay:
 	DrawLineToTarget:
 	GivesExperience:
+		FriendlyFire: true
 	BodyOrientation:
 	ScriptTriggers:
 	UpgradeManager:
@@ -363,6 +364,8 @@
 	ProximityCaptor:
 		Types: Building
 	GivesBounty:
+	GivesExperience:
+		FriendlyFire: true
 	Guardable:
 		Range: 3
 	FrozenUnderFog:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -150,7 +150,7 @@ CA:
 		BuildPaletteOrder: 50
 		Prerequisites: ~syrd, atek, ~techlevel.unrestricted
 	Valued:
-		Cost: 2400
+		Cost: 500#2400
 	Tooltip:
 		Name: Cruiser
 		Description: Very slow long-range ship.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft
@@ -192,8 +192,68 @@ CA:
 		VisualBounds: 44,44
 	WithTurret@PRIMARY:
 		Turret: primary
+		UpgradeTypes: rank
+		UpgradeMaxEnabledLevel: 0
+		UpgradeMaxAcceptedLevel: 1
 	WithTurret@SECONDARY:
 		Turret: secondary
+		UpgradeTypes: rank
+		UpgradeMaxEnabledLevel: 0
+		UpgradeMaxAcceptedLevel: 1
+	WithTurret@PRIMARYV:
+		Turret: primary
+		Sequence: turret-veteran
+		UpgradeTypes: rank
+		UpgradeMinEnabledLevel: 1
+		UpgradeMaxEnabledLevel: 1
+		UpgradeMaxAcceptedLevel: 2
+	WithTurret@SECONDARYV:
+		Turret: secondary
+		Sequence: turret-veteran
+		UpgradeTypes: rank
+		UpgradeMinEnabledLevel: 1
+		UpgradeMaxEnabledLevel: 1
+		UpgradeMaxAcceptedLevel: 2
+	WithTurret@PRIMARYE:
+		Turret: primary
+		Sequence: turret-elite
+		UpgradeTypes: rank
+		UpgradeMinEnabledLevel: 2
+		UpgradeMaxEnabledLevel: 2
+		UpgradeMaxAcceptedLevel: 2
+	WithTurret@SECONDARYE:
+		Turret: secondary
+		Sequence: turret-elite
+		UpgradeTypes: rank
+		UpgradeMinEnabledLevel: 2
+		UpgradeMaxEnabledLevel: 2
+		UpgradeMaxAcceptedLevel: 2
+	WithBarrel@DEFAULT:
+		Sequence: barrel
+		LocalOffset: 0,-768,0
+	WithBarrel@VET:
+		Sequence: elitebarrel
+		LocalOffset: 0,768,0
+		UpgradeTypes: rank
+		UpgradeMinEnabledLevel: 2
+		UpgradeMaxEnabledLevel: 2
+		UpgradeMaxAcceptedLevel: 2
+	WithFacingSpriteBody:
+		UpgradeTypes: rank
+		UpgradeMaxEnabledLevel: 0
+		UpgradeMaxAcceptedLevel: 1
+	WithFacingSpriteBody@VET:
+		Sequence: idle-veteran
+		UpgradeTypes: rank
+		UpgradeMinEnabledLevel: 1
+		UpgradeMaxEnabledLevel: 1
+		UpgradeMaxAcceptedLevel: 2
+	WithFacingSpriteBody@EL:
+		Sequence: idle-elite
+		UpgradeTypes: rank
+		UpgradeMinEnabledLevel: 2
+		UpgradeMaxEnabledLevel: 2
+		UpgradeMaxAcceptedLevel: 2
 	AutoTarget:
 
 LST:

--- a/mods/ra/sequences/ships.yaml
+++ b/mods/ra/sequences/ships.yaml
@@ -4,12 +4,24 @@ ss:
 	icon: ssicon
 
 ca:
-	idle:
+	idle: pt
 		Facings: 16
-	turret: turr
+	idle-veteran: dd
+		Facings: 16
+	idle-elite:
+		Facings: 16
+	turret: mgun
+		Facings: 32
+	turret-veteran: ssam
+		Facings: 32
+	turret-elite: turr
 		Facings: 32
 	muzzle: gunfire2
 		Length: 5
+	barrel: patriot
+		Facings: 32
+	elitebarrel: v2
+		Facings: 32
 	icon: caicon
 
 dd:

--- a/mods/ra/weapons/largecaliber.yaml
+++ b/mods/ra/weapons/largecaliber.yaml
@@ -170,7 +170,7 @@ TurretGun:
 		ValidImpactTypes: Water
 
 8Inch:
-	ReloadDelay: 250
+	ReloadDelay: 50#250
 	Range: 16c0
 	Burst: 2
 	Report: TURRET1.AUD

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -3,6 +3,7 @@
 	UpdatesPlayerStatistics:
 	CombatDebugOverlay:
 	GivesExperience:
+		FriendlyFire: true
 	BodyOrientation:
 	ScriptTriggers:
 	UpgradeManager:
@@ -11,8 +12,8 @@
 ^GainsExperience:
 	GainsExperience:
 		Upgrades:
-			500: rank, firepower, damage, speed, reload
-			1000: rank, firepower, damage, speed, reload, selfheal, eliteweapon
+			200: rank, firepower, damage, speed, reload, veteranweapon, veteranvoxel
+			400: rank, firepower, damage, speed, reload, selfheal, eliteweapon, elitevoxel
 	GainsStatUpgrades:
 		FirepowerModifier: 110, 130
 		DamageModifier: 83, 66
@@ -304,7 +305,6 @@
 ^Vehicle:
 	Inherits@1: ^GainsExperience
 	Inherits@2: ^ExistsInWorld
-	DrawLineToTarget:
 	Mobile:
 		Crushes: crate
 		TerrainSpeeds:
@@ -335,6 +335,7 @@
 	AttackMove:
 		Voice: Move
 	HiddenUnderFog:
+	DrawLineToTarget:
 	ActorLostNotification:
 	Capturable:
 		Type: Vehicle
@@ -397,6 +398,7 @@
 			Tiberium: 70
 			BlueTiberium: 70
 			Veins: 70
+		ROT: 5
 
 ^VoxelVehicle:
 	Inherits: ^Vehicle

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -224,3 +224,89 @@ SONIC:
 	AutoTarget:
 	WithVoxelTurret:
 
+2TNK:
+	Inherits: ^VoxelTank
+	Valued:
+		Cost: 200
+	Tooltip:
+		Name: Medium Tank
+		Description: Transforms when gaining veterancy!\nTotally awesome!
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 90
+		Prerequisites: ~factory
+	Mobile:
+		ROT: 4
+		Speed: 56
+		Crushes: wall, crate, infantry
+	Health:
+		HP: 500
+	Armor:
+		Type: Heavy
+	RevealsShroud:
+		Range: 7c0
+	Armament@PRIMARY:
+		Weapon: 90mm
+		UpgradeTypes: veteranweapon
+		UpgradeMaxEnabledLevel: 0
+		UpgradeMaxAcceptedLevel: 1
+		LocalOffset: 512,0,384
+	Armament@VETERAN:
+		Weapon: 120mmx
+		UpgradeTypes: veteranweapon
+		UpgradeMinEnabledLevel: 1
+		LocalOffset: 512,256,384, 512,-256,384
+	Armament@ELITE:
+		Weapon: HoverMissile
+		UpgradeTypes: eliteweapon
+		UpgradeMinEnabledLevel: 1
+		LocalOffset: 0,512,384, 0,-512,384
+	AttackTurreted:
+		Voice: Attack
+	Turreted:
+		ROT: 5
+		Offset: -170,0,0
+	AutoTarget:
+	WithVoxelBody@DEFAULT:
+		UpgradeTypes: veteranvoxel
+		UpgradeMaxEnabledLevel: 0
+		UpgradeMaxAcceptedLevel: 1
+	WithVoxelTurret@DEFAULT:
+		UpgradeTypes: veteranvoxel
+		UpgradeMaxEnabledLevel: 0
+		UpgradeMaxAcceptedLevel: 1
+	WithVoxelBarrel@DEFAULT:
+		UpgradeTypes: veteranvoxel
+		UpgradeMaxEnabledLevel: 0
+		UpgradeMaxAcceptedLevel: 1
+	WithVoxelBody@VET:
+		Sequence: idle-veteran
+		UpgradeTypes: veteranvoxel
+		UpgradeMinEnabledLevel: 1
+		UpgradeMaxEnabledLevel: 1
+		UpgradeMaxAcceptedLevel: 2
+	WithVoxelTurret@VET:
+		Sequence: turret-veteran
+		UpgradeTypes: veteranvoxel
+		UpgradeMinEnabledLevel: 1
+		UpgradeMaxEnabledLevel: 1
+		UpgradeMaxAcceptedLevel: 2
+	WithVoxelBarrel@VET:
+		Sequence: barrel-veteran
+		UpgradeTypes: veteranvoxel
+		UpgradeMinEnabledLevel: 1
+		UpgradeMaxEnabledLevel: 1
+		UpgradeMaxAcceptedLevel: 2
+	WithVoxelBody@EL:
+		Sequence: idle-elite
+		UpgradeTypes: elitevoxel
+		UpgradeMinEnabledLevel: 1
+	WithVoxelTurret@EL:
+		Sequence: turret-elite
+		UpgradeTypes: elitevoxel
+		UpgradeMinEnabledLevel: 1
+	WithVoxelBarrel@EL:
+		Sequence: barrel-elite
+		UpgradeTypes: elitevoxel
+		UpgradeMinEnabledLevel: 1
+

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -16,6 +16,9 @@ hvr:
 	muzzle: gunfire
 		Length: *
 
+2tnk:
+	icon: xxicon
+
 lpst:
 	icon: lpsticon
 

--- a/mods/ts/sequences/voxels.yaml
+++ b/mods/ts/sequences/voxels.yaml
@@ -77,6 +77,17 @@ dshp:
 	turret: 4tnktur
 	barrel: 4tnkbarl
 
+2tnk:
+	idle:
+	turret: 2tnktur
+	barrel: 2tnkbarl
+	idle-veteran: 3tnk
+	turret-veteran: 3tnktur
+	barrel-veteran: 3tnkbarl
+	idle-elite: 4tnk
+	turret-elite: 4tnktur
+	barrel-elite: 4tnkbarl
+
 trucka:
 	idle:
 


### PR DESCRIPTION
Another milestone towards implementing TS deployed units (artillery, tick tank etc.) via `DeployToUpgrade`.

Allows actors to change appearance on upgrade/levelup too, of course.
