### PR TITLE
Make GainsExperience upgrades explicit in MiniYaml.

### DIFF
--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class GainsExperienceInfo : ITraitInfo, Requires<ValuedInfo>, Requires<UpgradeManagerInfo>
 	{
 		[FieldLoader.LoadUsing("LoadUpgrades")]
-		[Desc("Upgrades to grant at each level",
+		[Desc("Upgrades to grant at each level. (Required property)",
 			"Key is the XP requirements for each level as a percentage of our own value.",
 			"Value is a list of the upgrade types to grant")]
 		public readonly Dictionary<int, string[]> Upgrades = null;
@@ -39,15 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 			MiniYaml upgrades;
 
 			if (!y.ToDictionary().TryGetValue("Upgrades", out upgrades))
-			{
-				return new Dictionary<int, string[]>()
-				{
-					{ 200, new[] { "firepower", "damage", "speed", "reload", "inaccuracy", "rank" } },
-					{ 400, new[] { "firepower", "damage", "speed", "reload", "inaccuracy", "rank" } },
-					{ 800, new[] { "firepower", "damage", "speed", "reload", "inaccuracy", "rank" } },
-					{ 1600, new[] { "firepower", "damage", "speed", "reload", "inaccuracy", "rank", "eliteweapon", "selfheal" } }
-				};
-			}
+				throw new YamlException("GainsExperience is missing Upgrades.");
 
 			return upgrades.Nodes.ToDictionary(
 				kv => FieldLoader.GetValue<int>("(key)", kv.Key),

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1367,6 +1367,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Value.Nodes.RemoveAll(n => n.Key == "InitialActivity");
 				}
 
+				// Make default upgrades explicit for GainsExperience
+				if (engineVersion < 20150709)
+				{
+					if (depth == 1 && (node.Key == "GainsExperience" || node.Key.StartsWith("GainsExperience@"))
+							&& node.Value.Nodes.FirstOrDefault(n => n.Key == "Upgrades") == null)
+						node.Value.Nodes.Add(new MiniYamlNode("Upgrades", new MiniYaml("", new List<MiniYamlNode> {
+							new MiniYamlNode("200", "firepower, damage, speed, reload, inaccuracy, rank"),
+							new MiniYamlNode("400", "firepower, damage, speed, reload, inaccuracy, rank"),
+							new MiniYamlNode("800", "firepower, damage, speed, reload, inaccuracy, rank"),
+							new MiniYamlNode("1600", "firepower, damage, speed, reload, inaccuracy, rank, eliteweapon, selfheal")
+						})));
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -10,6 +10,11 @@
 
 ^GainsExperience:
 	GainsExperience:
+		Upgrades:
+			200: firepower, damage, speed, reload, inaccuracy, rank
+			400: firepower, damage, speed, reload, inaccuracy, rank
+			800: firepower, damage, speed, reload, inaccuracy, rank
+			1600: firepower, damage, speed, reload, inaccuracy, rank, eliteweapon, selfheal
 	GainsStatUpgrades:
 	SelfHealing@ELITE:
 		Step: 2

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -10,6 +10,11 @@
 
 ^GainsExperience:
 	GainsExperience:
+		Upgrades:
+			200: firepower, damage, speed, reload, inaccuracy, rank
+			400: firepower, damage, speed, reload, inaccuracy, rank
+			800: firepower, damage, speed, reload, inaccuracy, rank
+			1600: firepower, damage, speed, reload, inaccuracy, rank, eliteweapon, selfheal
 	GainsStatUpgrades:
 	SelfHealing@ELITE:
 		Step: 2

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -11,6 +11,11 @@
 
 ^GainsExperience:
 	GainsExperience:
+		Upgrades:
+			200: firepower, damage, speed, reload, inaccuracy, rank
+			400: firepower, damage, speed, reload, inaccuracy, rank
+			800: firepower, damage, speed, reload, inaccuracy, rank
+			1600: firepower, damage, speed, reload, inaccuracy, rank, eliteweapon, selfheal
 	GainsStatUpgrades:
 	SelfHealing@ELITE:
 		Step: 2


### PR DESCRIPTION
Applies a similar policy as requested in comments for #8572 to GainsExperience.
