### PR TITLE
Shows real owner of disguised units to allies.

### DIFF
--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -49,10 +49,10 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			get
 			{
-				if (disguise.Disguised)
-					return self.Owner == self.World.LocalPlayer ? self.Owner : disguise.AsPlayer;
+				if (!disguise.Disguised || self.Owner.IsAlliedWith(self.World.RenderPlayer))
+					return self.Owner;
 
-				return self.Owner;
+				return disguise.AsPlayer;
 			}
 		}
 	}
@@ -135,8 +135,8 @@ namespace OpenRA.Mods.RA.Traits
 
 			if (target != null)
 			{
-				// Take the image of the target's disguise, if it exist.
-				// E.g., SpyA is disguised as a dog. SpyB then targets SpyA. We should use the dog image.
+				// Take the image of the target's disguise, if it exists.
+				// E.g., SpyA is disguised as a rifle infantry. SpyB then targets SpyA. We should use the rifle infantry image.
 				var targetDisguise = target.TraitOrDefault<Disguise>();
 				if (targetDisguise != null && targetDisguise.Disguised)
 				{


### PR DESCRIPTION
Continuation of #8298.

I changed the code. If disable shroud cheat should actually give the player observer view, then it is enough to only check for RenderPlayer as ally. I think then that debug option should be renamed to "Get observer view" or similar. Also, then it is much simpler than how I was trying to do it. No need for shared method to get current player...

This PR does the following:
- In tooltip, shows the real owner of disguised units to allies. Now it matches their radar color. Previously it was shown only to the owner.
- Corrects some comments.
