### PR TITLE
Renames "Disable Shroud & Fog" debug option to "Observer view".

### DIFF
--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Traits
 						break;
 					}
 
-				case "DevShroudDisable":
+				case "DevVisibility":
 					{
 						DisableShroud ^= true;
 						self.Owner.Shroud.Disabled = DisableShroud;

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Commands
 				help.RegisterHelp(name, helpText);
 			};
 
-			register("disableshroud", "toggles shroud and minimap.");
+			register("visibility", "toggles visibility checks and minimap.");
 			register("givecash", "gives the default or specified amount of money.");
 			register("givecashall", "gives the default or specified amount of money to all players and ai.");
 			register("instantbuild", "toggles instant building.");
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Commands
 
 					break;
 
-				case "disableshroud": IssueDevCommand(world, "DevShroudDisable"); break;
+				case "visibility": IssueDevCommand(world, "DevVisibility"); break;
 				case "instantbuild": IssueDevCommand(world, "DevFastBuild"); break;
 				case "buildanywhere": IssueDevCommand(world, "DevBuildAnywhere"); break;
 				case "unlimitedpower": IssueDevCommand(world, "DevUnlimitedPower"); break;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Support;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 
@@ -23,11 +21,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var devTrait = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
 
-			var shroudCheckbox = widget.GetOrNull<CheckboxWidget>("DISABLE_SHROUD");
-			if (shroudCheckbox != null)
+			var visibilityCheckbox = widget.GetOrNull<CheckboxWidget>("DISABLE_VISIBILITY_CHECKS");
+			if (visibilityCheckbox != null)
 			{
-				shroudCheckbox.IsChecked = () => devTrait.DisableShroud;
-				shroudCheckbox.OnClick = () => Order(world, "DevShroudDisable");
+				visibilityCheckbox.IsChecked = () => devTrait.DisableShroud;
+				visibilityCheckbox.OnClick = () => Order(world, "DevVisibility");
 			}
 
 			var pathCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_UNIT_PATHS");

--- a/mods/cnc/chrome/ingame-debug.yaml
+++ b/mods/cnc/chrome/ingame-debug.yaml
@@ -44,13 +44,13 @@ Container@DEBUG_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Instant Charge Time
-		Checkbox@DISABLE_SHROUD:
+		Checkbox@DISABLE_VISIBILITY_CHECKS:
 			X: 290
 			Y: 105
 			Height: 20
 			Width: 200
 			Font: Regular
-			Text: Disable Shroud & Fog
+			Text: Disable visibility checks
 		Button@GIVE_CASH:
 			X: 90
 			Y: 145

--- a/mods/ra/chrome/ingame-debug.yaml
+++ b/mods/ra/chrome/ingame-debug.yaml
@@ -45,13 +45,13 @@ Container@DEBUG_PANEL:
 			Height: 20
 			Font: Regular
 			Text: Instant Charge Time
-		Checkbox@DISABLE_SHROUD:
+		Checkbox@DISABLE_VISIBILITY_CHECKS:
 			X: 290
 			Y: 105
 			Height: 20
 			Width: 200
 			Font: Regular
-			Text: Disable Shroud & Fog
+			Text: Disable visibility checks
 		Button@GIVE_CASH:
 			X: 90
 			Y: 150


### PR DESCRIPTION
Because it sets RenderPlayer to null which affects more than shroud and fog.
