### PR TITLE
Implements victory and defeat music.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -352,6 +352,8 @@ namespace OpenRA.Traits
 		void OnObjectiveFailed(Player player, int objectiveID);
 	}
 
+	public interface IGameOver { void GameOver(World world); }
+
 	public interface IWarhead
 	{
 		int Delay { get; }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -58,6 +58,10 @@ namespace OpenRA
 			if (!gameOver)
 			{
 				gameOver = true;
+
+				foreach (var t in WorldActor.TraitsImplementing<IGameOver>())
+					t.GameOver(this);
+
 				GameOver();
 			}
 		}

--- a/mods/cnc/audio/music.yaml
+++ b/mods/cnc/audio/music.yaml
@@ -37,9 +37,15 @@ trouble2: In Trouble (Voiced)
 	Filename: trouble
 	Extension: var
 justdoit: Just Do it Up
+justdoit2: Just Do it Up (Voiced)
+	Filename: justdoit
+	Extension: var
 map1: Map Theme
 march: March to Doom
 nomercy: No Mercy
+nomercy2: No Mercy (Voiced)
+	Filename: nomercy
+	Extension: var
 otp: On the Prowl
 prp: Prepare for Battle
 radio: Radio
@@ -52,3 +58,6 @@ target: Target (Mechanical Man)
 j1: Untamed Land
 valkyrie: Ride of the Valkyries
 voic226m: Voice Rhythm
+outtakes: Outtakes
+nod_map1: Nod Map Theme
+nod_win1: Nod Win Theme

--- a/mods/cnc/maps/gdi01/gdi01.lua
+++ b/mods/cnc/maps/gdi01/gdi01.lua
@@ -72,9 +72,6 @@ WorldLoaded = function()
 
 	Trigger.OnPlayerWon(player, function()
 		Media.PlaySpeechNotification(player, "Win")
-		Trigger.AfterDelay(DateTime.Seconds(1), function()
-			Media.PlayMusic("win1")
-		end)
 	end)
 
 	Trigger.OnPlayerLost(player, function()

--- a/mods/cnc/maps/nod01/map.yaml
+++ b/mods/cnc/maps/nod01/map.yaml
@@ -291,6 +291,7 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		MusicPlaylist:
 			StartingMusic: nomercy
+			VictoryMusic: nod_win1
 	C10:
 		Tooltip:
 			Name: Nikoomba

--- a/mods/cnc/maps/nod02a/map.yaml
+++ b/mods/cnc/maps/nod02a/map.yaml
@@ -228,6 +228,7 @@ Rules:
 			Scripts: nod02a.lua
 		MusicPlaylist:
 			StartingMusic: ind2
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod02b/map.yaml
+++ b/mods/cnc/maps/nod02b/map.yaml
@@ -270,6 +270,7 @@ Rules:
 			Scripts: nod02b.lua
 		MusicPlaylist:
 			StartingMusic: ind2
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -469,6 +469,7 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		MusicPlaylist:
 			StartingMusic: chrg226m
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -513,6 +513,7 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		MusicPlaylist:
 			StartingMusic: chrg226m
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod04a/map.yaml
+++ b/mods/cnc/maps/nod04a/map.yaml
@@ -570,6 +570,7 @@ Rules:
 			PanelName: MISSION_OBJECTIVES
 		MusicPlaylist:
 			StartingMusic: valkyrie
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod04b/map.yaml
+++ b/mods/cnc/maps/nod04b/map.yaml
@@ -509,6 +509,7 @@ Rules:
 			Scripts: nod04b.lua
 		MusicPlaylist:
 			StartingMusic: warfare
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -404,6 +404,7 @@ Rules:
 			Scripts: nod05.lua
 		MusicPlaylist:
 			StartingMusic: airstrik
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -677,6 +677,7 @@ Rules:
 			Scripts: nod06a.lua
 		MusicPlaylist:
 			StartingMusic: rout
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod06b/map.yaml
+++ b/mods/cnc/maps/nod06b/map.yaml
@@ -619,6 +619,7 @@ Rules:
 			Scripts: nod06b.lua
 		MusicPlaylist:
 			StartingMusic: rout
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/maps/nod06c/map.yaml
+++ b/mods/cnc/maps/nod06c/map.yaml
@@ -505,6 +505,7 @@ Rules:
 			Scripts: nod06c.lua
 		MusicPlaylist:
 			StartingMusic: rout
+			VictoryMusic: nod_win1
 	^Vehicle:
 		Tooltip:
 			GenericVisibility: Enemy

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -5,7 +5,7 @@
 	ActorMap:
 	MusicPlaylist:
 		VictoryMusic: win1
-		DefeatMusic: heart
+		DefeatMusic: nod_map1
 	TerrainGeometryOverlay:
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -4,6 +4,8 @@
 	ScreenMap:
 	ActorMap:
 	MusicPlaylist:
+		VictoryMusic: win1
+		DefeatMusic: heart
 	TerrainGeometryOverlay:
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -126,7 +126,7 @@ Rules:
 		LuaScript:
 			Scripts: shellmap.lua
 		MusicPlaylist:
-			StartingMusic: score
+			StartingMusic: waitgame
 		GlobalLightingPaletteEffect:
 	rockettower:
 		Power:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -4,6 +4,8 @@
 	ScreenMap:
 	ActorMap:
 	MusicPlaylist:
+		VictoryMusic: score
+		DefeatMusic: options
 	TerrainGeometryOverlay:
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -4,6 +4,8 @@
 	ActorMap:
 	ScreenMap:
 	MusicPlaylist:
+		VictoryMusic: score
+		DefeatMusic: map
 	TerrainGeometryOverlay:
 	LoadWidgetAtGameStart:
 	ShroudRenderer:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -4,6 +4,8 @@
 	ScreenMap:
 	ActorMap:
 	MusicPlaylist:
+		VictoryMusic: score
+		DefeatMusic: maps
 	LoadWidgetAtGameStart:
 	ShroudRenderer:
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255


### PR DESCRIPTION
Followup of #8562.

Due to map loading themes became useless to us, I repurposed them into defeat music at the RA, D2K and the TS mod. In C&C, GDI and Nod had separate loadthemes, so I repurposed the Nod one.
I also changed the D2K shellmap to use the network theme instead of the score track.

The first commit is the logic, the second commit might need it's own PR, because the Nod victory/map themes were unlisted previously alongside three other tracks.
