### PR TITLE
Fixes Empty filter in server browser.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
@@ -381,7 +381,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if ((game.State == (int)ServerState.GameStarted) && !showStarted)
 				return true;
 
-			if ((game.State == (int)ServerState.WaitingPlayers) && !showWaiting)
+			if ((game.State == (int)ServerState.WaitingPlayers) && !showWaiting && game.Players != 0)
 				return true;
 
 			if ((game.Players == 0) && !showEmpty)


### PR DESCRIPTION
Currently, the Empty filter in server browser doesn't work. Waiting covers empty servers too, so when only Empty is selected, nothing is shown. Deselecting Waiting shouldn't filter out empty servers.

I haven't tested this code but when only Empty is checked, it should show servers with zero players.
