### PR TITLE
Spy veterancy leftovers

### DIFF
--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -95,12 +95,12 @@ namespace OpenRA.Mods.Common.Traits
 
 				foreach (var u in upgrades)
 					um.GrantUpgrade(self, u, this);
-			}
 
-			if (!silent)
-			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "LevelUp", self.Owner.Country.InternalName);
-				self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup", info.LevelUpPalette)));
+				if (!silent)
+				{
+					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "LevelUp", self.Owner.Country.InternalName);
+					self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup", info.LevelUpPalette)));
+				}
 			}
 		}
 

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1695,6 +1695,7 @@ Rules:
 		DisguiseToolTip:
 			ShowOwnerRow: false
 	WEAP:
+		-InfiltrateForSupportPower:
 		TargetableBuilding:
 			TargetTypes: Ground, C4, DetonateAttack, Structure, Mission Objectives
 	MISS:


### PR DESCRIPTION
Fixes regression from #8210 (RANK+1 displayed for every experience increase instead of only on level increments).

Disables levelup thru war factory spy infiltration in Allies05 (https://github.com/OpenRA/OpenRA/pull/8210#issuecomment-117320639)

Sorry bout missing these in #8210
