### PR TITLE
Remove OwnerRow from explosive barrels

### DIFF
--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1700,6 +1700,7 @@ Rules:
 	MISS:
 		Tooltip:
 			Name: Prison
+			ShowOwnerRow: False
 		TargetableBuilding:
 			TargetTypes: Ground, C4, DetonateAttack, Structure, Mission Objectives
 	E7.noautotarget:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -251,6 +251,7 @@ BARL:
 		Weapon: BarrelExplode
 	Tooltip:
 		Name: Explosive Barrel
+		ShowOwnerRow: False
 	AutoTargetIgnore:
 	Armor:
 		Type: None
@@ -270,6 +271,7 @@ BRL3:
 		Weapon: BarrelExplode
 	Tooltip:
 		Name: Explosive Barrel
+		ShowOwnerRow: False
 	AutoTargetIgnore:
 	Armor:
 		Type: None


### PR DESCRIPTION
Also removed the OwnerRow from the soviet prison in allies05a.
