### PR TITLE
Explicitly set current working directory

### DIFF
--- a/OpenRA.GameMonitor/GameMonitor.cs
+++ b/OpenRA.GameMonitor/GameMonitor.cs
@@ -28,6 +28,8 @@ namespace OpenRA
 			var executableDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 			var processName = Path.Combine(executableDirectory, "OpenRA.Game.exe");
 
+			Directory.SetCurrentDirectory(executableDirectory);
+
 			var psi = new ProcessStartInfo(processName, string.Join(" ", args));
 
 			try


### PR DESCRIPTION
Fixes #8592.

Steps to reproduce (**on Windows**):
 **1.** Open http://www.openra.net/games/ and click on a game IP to launch OpenRA.
 **2.** Chances are you won't connect due to version mismatch (most servers run the release and your playtest installer will have overwritten the registry, so the playtest version should run). Doesn't matter.
 **3.** Connected or not, go to the modchooser.
 **4.** You will get a nice exception:

> Exception of type `System.IO.FileNotFoundException`: File not found: ./mods/modchooser/chrome.png

 **5.** Build OpenRA with the provided patch and replace the playtest's exe (`OpenRA.exe`).
**6.** Repeat steps **1**-**3**. Now you should be able to switch mods at will.

**P.S.:** Or use the installer @obrakmann provided in #8592.
