### PR TITLE
Fixes D2K not finding paratrooper shadow sequence

### DIFF
--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -386,5 +386,5 @@ sandcraters:
 		Offset: -16,-16
 
 parach-shadow:
-	idle:
+	idle: parach-shadow.shp
 		Length: *


### PR DESCRIPTION
Fixes regression from #8339

https://github.com/OpenRA/OpenRA/pull/8339/files#r34637358

The engine wasn't able to locate the sequence. I haven't gone deeply into it, but it seems all sequences in d2k/sequences/misc.yaml specify the exact file where the sequence resides...
