### PR TITLE
Use the correct ShadowPalette for d2k paradrops

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference("ShadowImage")] public readonly string ShadowSequence = null;
 
 		[Desc("Palette used to render the paradropped unit's shadow.")]
-		public readonly string ShadowPalette = "player";
+		public readonly string ShadowPalette = "shadow";
 
 		[Desc("Shadow position relative to the paradropped unit's intended landing position.")]
 		public readonly WVec ShadowOffset = new WVec(0, 128, 0);

--- a/mods/ra/maps/allies-03a/allies03a.lua
+++ b/mods/ra/maps/allies-03a/allies03a.lua
@@ -16,7 +16,13 @@ else
 	ChangeStance = true
 end
 
-IdleHunt = function(actor) Trigger.OnIdle(actor, actor.Hunt) end
+IdleHunt = function(actor)
+	Trigger.OnIdle(actor, function(a)
+		if a.IsInWorld then
+			a.Hunt()
+		end
+	end)
+end
 
 ProduceUnits = function(factory, count)
 	if ussr.IsProducing("e1") then

--- a/mods/ra/maps/allies-03b/allies03b.lua
+++ b/mods/ra/maps/allies-03b/allies03b.lua
@@ -27,7 +27,13 @@ else
 	ChangeStance = true
 end
 
-IdleHunt = function(actor) Trigger.OnIdle(actor, actor.Hunt) end
+IdleHunt = function(actor)
+	Trigger.OnIdle(actor, function(a)
+		if a.IsInWorld then
+			a.Hunt()
+		end
+	end)
+end
 
 Tick = function()
 	if TeleportJeepCamera and Jeep.IsInWorld then

--- a/mods/ra/maps/desert-shellmap/desert-shellmap.lua
+++ b/mods/ra/maps/desert-shellmap/desert-shellmap.lua
@@ -36,9 +36,17 @@ ParadropWaypoints = { Paradrop1, Paradrop2, Paradrop3, Paradrop4, Paradrop5, Par
 BindActorTriggers = function(a)
 	if a.HasProperty("Hunt") then
 		if a.Owner == allies then
-			Trigger.OnIdle(a, a.Hunt)
+			Trigger.OnIdle(a, function(a)
+				if a.IsInWorld then
+					a.Hunt()
+				end
+			end)
 		else
-			Trigger.OnIdle(a, function(a) a.AttackMove(AlliedTechnologyCenter.Location) end)
+			Trigger.OnIdle(a, function(a)
+				if a.IsInWorld then
+					a.AttackMove(AlliedTechnologyCenter.Location)
+				end
+			end)
 		end
 	end
 

--- a/mods/ra/maps/intervention/intervention.lua
+++ b/mods/ra/maps/intervention/intervention.lua
@@ -60,7 +60,11 @@ ParadropSovietUnits = function()
 	local units = powerproxy.SendParatroopers(MCVDeployLocation.CenterPosition, false, 256 - 53)
 
 	Utils.Do(units, function(a)
-		Trigger.OnIdle(a, a.Hunt)
+		Trigger.OnIdle(a, function(actor)
+			if actor.IsInWorld then
+				actor.Hunt()
+			end
+		end)
 	end)
 
 	powerproxy.Destroy()

--- a/mods/ra/maps/survival01/map.yaml
+++ b/mods/ra/maps/survival01/map.yaml
@@ -1252,6 +1252,10 @@ Rules:
 	powerproxy.paratroopers:
 		ParatroopersPower:
 			DropItems: E1,E1,E1,E2,E2
+	powerproxy.allied:
+		Inherits: powerproxy.paratroopers
+		ParatroopersPower:
+			DropItems: ARTY,ARTY,ARTY
 	CAMERA.sam:
 		Inherits: CAMERA
 		RevealsShroud:
@@ -1261,12 +1265,6 @@ Rules:
 		RevealsShroud:
 			Range: 1000
 	ARTY:
-		Parachutable:
-			KilledOnImpassableTerrain: false
-		WithParachute:
-			UpgradeTypes: parachute
-			UpgradeMinEnabledLevel: 1
-			Image: parach
 		UpgradeManager:
 		BodyOrientation:
 	AFLD.mission:

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -28,7 +28,6 @@ else --Difficulty == "Hard"
 	LongBowReinforcements = { "heli" }
 end
 
-AlliedArtilleryParadrops = { "arty", "arty", "arty" }
 AlliedAirReinforcementsWaypoints =
 {
 	{ AirReinforcementsEntry1.Location, AirReinforcementsEntry2.Location },
@@ -279,21 +278,20 @@ TimerExpired = function()
 	end
 end
 
-DropAlliedArtillery = function(table)
-	local plane = Actor.Create("badr", true, { Owner = allies, Location = table[1] })
-	Utils.Do(AlliedArtilleryParadrops, function(type)
-		local unit = Actor.Create(type, false, { Owner = allies })
-		plane.LoadPassenger(unit)
-	end)
-	plane.Paradrop(table[2])
+DropAlliedArtillery = function(facing, dropzone)
+	local proxy = Actor.Create("powerproxy.allied", true, { Owner = allies })
+	proxy.SendParatroopers(dropzone, false, facing)
+	proxy.Destroy()
 end
 
 SendLongBowReinforcements = function()
 	Media.PlaySpeechNotification(allies, "AlliedReinforcementsArrived")
 	Reinforcements.Reinforce(allies, LongBowReinforcements, AlliedAirReinforcementsWaypoints[1])
 	Reinforcements.Reinforce(allies, LongBowReinforcements, AlliedAirReinforcementsWaypoints[2])
+
 	if ParadropArtillery then
-		DropAlliedArtillery({ Utils.Random(AlliedAirReinforcementsWaypoints)[1], Alliesbase.Location })
+		local facing = Utils.RandomInteger(Facing.NorthWest, Facing.SouthWest)
+		DropAlliedArtillery(facing, Alliesbase.CenterPosition)
 	end
 end
 

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -185,7 +185,11 @@ SendSovietParadrops = function(table)
 	local units = powerproxy.SendParatroopers(table[2].CenterPosition, false, table[1])
 
 	Utils.Do(units, function(unit)
-		Trigger.OnIdle(unit, unit.Hunt)
+		Trigger.OnIdle(unit, function(a)
+			if a.IsInWorld then
+				a.Hunt()
+			end
+		end)
 	end)
 end
 

--- a/mods/ra/maps/survival02/survival02.lua
+++ b/mods/ra/maps/survival02/survival02.lua
@@ -35,7 +35,13 @@ ParaWaves =
 	{ AttackTicks * 3, { "SovietSquad", SovietParaDrop1 } }
 }
 
-IdleHunt = function(unit) Trigger.OnIdle(unit, unit.Hunt) end
+IdleHunt = function(unit)
+	Trigger.OnIdle(unit, function(a)
+		if a.IsInWorld then
+			a.Hunt()
+		end
+	end)
+end
 
 GuardHarvester = function(unit, harvester)
 	if not unit.IsDead then

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -128,7 +128,11 @@
 	WithParachute:
 		UpgradeTypes: parachute
 		UpgradeMinEnabledLevel: 1
+		ShadowImage: parach-shadow
+		ShadowSequence: idle
 		Image: parach
+		Sequence: idle
+		OpeningSequence: open
 		Offset: 0,0,200
 
 ^Tank:


### PR DESCRIPTION
Followup from #8719.
Fixes this crash when paradroping units on bleed:

```
Dune 2000 Mod at Version {DEV_VERSION}
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.34209
Exception of type `System.InvalidOperationException`: Palette `player` does not exist
   at OpenRA.Graphics.HardwarePalette.GetPalette(String name) in \OpenRA\OpenRA.Game\Graphics\HardwarePalette.cs:Line 46.
   at OpenRA.Graphics.WorldRenderer.CreatePaletteReference(String name) in \OpenRA\OpenRA.Game\Graphics\WorldRenderer.cs:Line 65.
   at OpenRA.Exts.GetOrAdd[K,V](Dictionary`2 d, K k, Func`2 createFn) in \OpenRA\OpenRA.Game\Exts.cs:Line 129.
   at OpenRA.Graphics.WorldRenderer.Palette(String name) in \OpenRA\OpenRA.Game\Graphics\WorldRenderer.cs:Line 69.
   at OpenRA.Mods.Common.Traits.WithParachute.<Render>d__e.MoveNext()
   at OpenRA.Actor.<Renderables>d__d.MoveNext() in \OpenRA\OpenRA.Game\Actor.cs:Line 156.
   at System.Linq.Enumerable.<SelectManyIterator>d__14`2.MoveNext()
   at System.Linq.Enumerable.<ConcatIterator>d__71`1.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.OrderedEnumerable`1.<GetEnumerator>d__0.MoveNext()
   at System.Linq.Enumerable.<ConcatIterator>d__71`1.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at OpenRA.Graphics.WorldRenderer.GenerateRenderables() in \OpenRA\OpenRA.Game\Graphics\WorldRenderer.cs:Line 117.
   at OpenRA.Graphics.WorldRenderer.Draw() in \OpenRA\OpenRA.Game\Graphics\WorldRenderer.cs:Line 134.
   at OpenRA.Game.RenderTick() in \OpenRA\OpenRA.Game\Game.cs:Line 525.
   at OpenRA.Game.Loop() in \OpenRA\OpenRA.Game\Game.cs:Line 653.
   at OpenRA.Game.Run() in \OpenRA\OpenRA.Game\Game.cs:Line 671.
   at OpenRA.Program.Run(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 111.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 39.
```
