### PR TITLE
Remove Outtakes (the blooper song) from C&C.

### DIFF
--- a/mods/cnc/audio/music.yaml
+++ b/mods/cnc/audio/music.yaml
@@ -58,6 +58,5 @@ target: Target (Mechanical Man)
 j1: Untamed Land
 valkyrie: Ride of the Valkyries
 voic226m: Voice Rhythm
-outtakes: Outtakes
 nod_map1: Nod Map Theme
 nod_win1: Nod Win Theme


### PR DESCRIPTION
I thought I'll get the hiding-music-from-UI done in time, but that didn't happened.

Outtakes shouldn't pop up in a playtest.
