### PR TITLE
Added option to turn off rendering of target lines in the settings

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -140,6 +140,7 @@ namespace OpenRA
 		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;
 		public bool TeamHealthColors = false;
+		public bool DrawTargetLine = true;
 
 		public bool AllowDownloading = true;
 		public string MapRepository = "http://resource.openra.net/map/";

--- a/OpenRA.Game/Traits/DrawLineToTarget.cs
+++ b/OpenRA.Game/Traits/DrawLineToTarget.cs
@@ -64,6 +64,9 @@ namespace OpenRA.Traits
 			if ((lifetime <= 0 || --lifetime <= 0) && !force)
 				yield break;
 
+			if (!(force || Game.Settings.Game.DrawTargetLine))
+				yield break;
+
 			if (targets == null || targets.Count == 0)
 				yield break;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -154,6 +154,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
 			BindCheckboxPref(panel, "SHOW_SHELLMAP", gs, "ShowShellmap");
 			BindCheckboxPref(panel, "ALWAYS_SHOW_STATUS_BARS_CHECKBOX", gs, "AlwaysShowStatusBars");
+			BindCheckboxPref(panel, "DISPLAY_TARGET_LINES_CHECKBOX", gs, "DrawTargetLine");
 			BindCheckboxPref(panel, "TEAM_HEALTH_COLORS_CHECKBOX", gs, "TeamHealthColors");
 
 			var languageDropDownButton = panel.Get<DropDownButtonWidget>("LANGUAGE_DROPDOWNBUTTON");

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -190,6 +190,13 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Always Show Status Bars
+						Checkbox@DISPLAY_TARGET_LINES_CHECKBOX:
+							X: 310
+							Y: 245
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Display Target Lines
 						Label@LOCALIZATION_TITLE:
 							Y: 265
 							Width: PARENT_RIGHT

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -203,6 +203,13 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Always Show Status Bars
+				Checkbox@DISPLAY_TARGET_LINES_CHECKBOX:
+					X: 310
+					Y: 265
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Display Target Lines
 				Label@LOCALIZATION_TITLE:
 					Y: 270
 					Width: PARENT_RIGHT


### PR DESCRIPTION
When disabled, they can still be seen by pressing the Alt key.

Supersedes #8630.
Closes #6915.
