### PR TITLE
Improved AI BaseBuilder

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -101,7 +101,11 @@ namespace OpenRA.Mods.Common.AI
 				if (TickQueue(queue))
 					active = true;
 
-			waitTicks = active ? ai.Info.StructureProductionActiveDelay : ai.Info.StructureProductionInactiveDelay;
+			// Add a random factor so not every AI produces at the same tick early in the game.
+			// Minimum should not be negative as delays in HackyAI could be zero.
+			var randomFactor = world.SharedRandom.Next(0, ai.Info.StructureProductionRandomBonusDelay);
+			waitTicks = active ? ai.Info.StructureProductionActiveDelay + randomFactor
+				: ai.Info.StructureProductionInactiveDelay + randomFactor;
 		}
 
 		bool TickQueue(ProductionQueue queue)

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -55,11 +55,14 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Minimum excess power the AI should try to maintain.")]
 		public readonly int MinimumExcessPower = 0;
 
-		[Desc("How long to wait (in ticks) between structure production checks when there is no active production.")]
+		[Desc("Minimum delay (in ticks) between structure production checks when there is no active production.")]
 		public readonly int StructureProductionInactiveDelay = 125;
 
-		[Desc("How long to wait (in ticks) between structure production checks ticks when actively building things.")]
+		[Desc("Minimum delay (in ticks) between structure production checks when actively building things.")]
 		public readonly int StructureProductionActiveDelay = 10;
+
+		[Desc("A random delay (in ticks) of up to this is added to production delays.")]
+		public readonly int StructureProductionRandomBonusDelay = 10;
 
 		[Desc("How long to wait (in ticks) until retrying to build structure after the last 3 consecutive attempts failed.")]
 		public readonly int StructureProductionResumeDelay = 1500;

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -49,6 +49,9 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Minimum delay (in ticks) between creating squads.")]
 		public readonly int MinimumAttackForceDelay = 0;
 
+		[Desc("Minimum portion of pending orders to issue each tick (e.g. 5 issues at least 1/5th of all pending orders). Excess orders remain queued for subsequent ticks.")]
+		public readonly int MinOrderQuotientPerTick = 5;
+
 		[Desc("Minimum excess power the AI should try to maintain.")]
 		public readonly int MinimumExcessPower = 0;
 
@@ -58,8 +61,12 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("How long to wait (in ticks) between structure production checks ticks when actively building things.")]
 		public readonly int StructureProductionActiveDelay = 10;
 
-		[Desc("Minimum portion of pending orders to issue each tick (e.g. 5 issues at least 1/5th of all pending orders). Excess orders remain queued for subsequent ticks.")]
-		public readonly int MinOrderQuotientPerTick = 5;
+		[Desc("How long to wait (in ticks) until retrying to build structure after the last 3 consecutive attempts failed.")]
+		public readonly int StructureProductionResumeDelay = 1500;
+
+		[Desc("After how many failed attempts to place a structure should AI give up and wait",
+		"for StructureProductionResumeDelay before retrying.")]
+		public readonly int MaximumFailedPlacementAttempts = 3;
 
 		[Desc("Minimum range at which to build defensive structures near a combat hotspot.")]
 		public readonly int MinimumDefenseRadius = 5;

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -56,11 +56,11 @@ namespace OpenRA.Mods.Common.AI
 		public readonly int MinimumExcessPower = 0;
 
 		[Desc("Delay (in ticks) between structure production checks when there is no active production.",
-		"A StructureProductionRandomBonusDelay is added to this.")]
+			"A StructureProductionRandomBonusDelay is added to this.")]
 		public readonly int StructureProductionInactiveDelay = 125;
 
 		[Desc("Delay (in ticks) between structure production checks when actively building things.",
-		"A StructureProductionRandomBonusDelay is added to this.")]
+			"A StructureProductionRandomBonusDelay is added to this.")]
 		public readonly int StructureProductionActiveDelay = 10;
 
 		[Desc("A random delay (in ticks) of up to this is added to active/inactive production delays.")]
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.AI
 		public readonly int StructureProductionResumeDelay = 1500;
 
 		[Desc("After how many failed attempts to place a structure should AI give up and wait",
-		"for StructureProductionResumeDelay before retrying.")]
+			"for StructureProductionResumeDelay before retrying.")]
 		public readonly int MaximumFailedPlacementAttempts = 3;
 
 		[Desc("Delay (in ticks) until rechecking for new BaseProviders.")]
@@ -101,8 +101,8 @@ namespace OpenRA.Mods.Common.AI
 		public readonly int MaxBaseRadius = 20;
 
 		[Desc("Radius in cells around each building with ProvideBuildableArea",
-		"to check for a 3x3 area of water where naval structures can be built.",
-		"Should match maximum adjacency of naval structures.")]
+			"to check for a 3x3 area of water where naval structures can be built.",
+			"Should match maximum adjacency of naval structures.")]
 		public readonly int CheckForWaterRadius = 8;
 
 		[Desc("Production queues AI uses for producing units.")]
@@ -281,6 +281,7 @@ namespace OpenRA.Mods.Common.AI
 			foreach (var b in baseProviders)
 			{
 				// TODO: Unhardcode terrain type
+				// TODO2: Properly check building foundation rather than 3x3 area
 				var playerWorld = Player.World;
 				var countWaterCells = Map.FindTilesInCircle(b.Location, Info.MaxBaseRadius)
 					.Where(c => playerWorld.Map.Contains(c)
@@ -307,6 +308,7 @@ namespace OpenRA.Mods.Common.AI
 			foreach (var a in areaProviders)
 			{
 				// TODO: Unhardcode terrain type
+				// TODO2: Properly check building foundation rather than 3x3 area
 				var playerWorld = Player.World;
 				var adjacentWater = Map.FindTilesInCircle(a.Location, Info.CheckForWaterRadius)
 					.Where(c => playerWorld.Map.Contains(c)

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -55,21 +55,26 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Minimum excess power the AI should try to maintain.")]
 		public readonly int MinimumExcessPower = 0;
 
-		[Desc("Minimum delay (in ticks) between structure production checks when there is no active production.")]
+		[Desc("Delay (in ticks) between structure production checks when there is no active production.",
+		"A StructureProductionRandomBonusDelay is added to this.")]
 		public readonly int StructureProductionInactiveDelay = 125;
 
-		[Desc("Minimum delay (in ticks) between structure production checks when actively building things.")]
+		[Desc("Delay (in ticks) between structure production checks when actively building things.",
+		"A StructureProductionRandomBonusDelay is added to this.")]
 		public readonly int StructureProductionActiveDelay = 10;
 
-		[Desc("A random delay (in ticks) of up to this is added to production delays.")]
+		[Desc("A random delay (in ticks) of up to this is added to active/inactive production delays.")]
 		public readonly int StructureProductionRandomBonusDelay = 10;
 
-		[Desc("How long to wait (in ticks) until retrying to build structure after the last 3 consecutive attempts failed.")]
+		[Desc("Delay (in ticks) until retrying to build structure after the last 3 consecutive attempts failed.")]
 		public readonly int StructureProductionResumeDelay = 1500;
 
 		[Desc("After how many failed attempts to place a structure should AI give up and wait",
 		"for StructureProductionResumeDelay before retrying.")]
 		public readonly int MaximumFailedPlacementAttempts = 3;
+
+		[Desc("Delay (in ticks) until rechecking for new BaseProviders.")]
+		public readonly int CheckForNewBasesDelay = 1500;
 
 		[Desc("Minimum range at which to build defensive structures near a combat hotspot.")]
 		public readonly int MinimumDefenseRadius = 5;
@@ -268,20 +273,20 @@ namespace OpenRA.Mods.Common.AI
 		// TODO: Possibly give this a more generic name when terrain type is unhardcoded
 		public bool EnoughWaterToBuildNaval()
 		{
-			var baseBuildings = World.Actors.Where(
+			var baseProviders = World.Actors.Where(
 				a => a.Owner == Player
-					&& a.HasTrait<BaseBuilding>()
+					&& a.HasTrait<BaseProvider>()
 					&& !a.HasTrait<Mobile>());
 
-			foreach (var b in baseBuildings)
+			foreach (var b in baseProviders)
 			{
 				// TODO: Unhardcode terrain type
 				var playerWorld = Player.World;
 				var countWaterCells = Map.FindTilesInCircle(b.Location, Info.MaxBaseRadius)
 					.Where(c => playerWorld.Map.Contains(c)
-						&& playerWorld.Map.GetTerrainInfo(c).Type == "Water"
+						&& playerWorld.Map.GetTerrainInfo(c).IsWater
 						&& Util.AdjacentCells(playerWorld, Target.FromCell(playerWorld, c))
-							.All(a => playerWorld.Map.GetTerrainInfo(a).Type == "Water"))
+							.All(a => playerWorld.Map.GetTerrainInfo(a).IsWater))
 					.Count();
 
 				if (countWaterCells > 0)
@@ -305,9 +310,9 @@ namespace OpenRA.Mods.Common.AI
 				var playerWorld = Player.World;
 				var adjacentWater = Map.FindTilesInCircle(a.Location, Info.CheckForWaterRadius)
 					.Where(c => playerWorld.Map.Contains(c)
-						&& playerWorld.Map.GetTerrainInfo(c).Type == "Water"
+						&& playerWorld.Map.GetTerrainInfo(c).IsWater
 						&& Util.AdjacentCells(playerWorld, Target.FromCell(playerWorld, c))
-							.All(b => playerWorld.Map.GetTerrainInfo(b).Type == "Water"))
+							.All(b => playerWorld.Map.GetTerrainInfo(b).IsWater))
 					.Count();
 
 				if (adjacentWater > 0)

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -8,7 +8,8 @@ Player:
 			Power: powr,apwr
 			Barracks: barr,tent
 			VehiclesFactory: weap
-			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Production: barr,tent,weap,afld,hpad
+			NavalProduction: spen,syrd
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
@@ -118,7 +119,8 @@ Player:
 			Power: powr,apwr
 			Barracks: barr,tent
 			VehiclesFactory: weap
-			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Production: barr,tent,weap,afld,hpad
+			NavalProduction: spen,syrd
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
@@ -245,7 +247,8 @@ Player:
 			Power: powr,apwr
 			Barracks: barr,tent
 			VehiclesFactory: weap
-			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Production: barr,tent,weap,afld,hpad
+			NavalProduction: spen,syrd
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
@@ -371,7 +374,8 @@ Player:
 			Power: powr,apwr
 			Barracks: barr,tent
 			VehiclesFactory: weap
-			Production: barr,tent,weap,afld,hpad,spen,syrd
+			Production: barr,tent,weap,afld,hpad
+			NavalProduction: spen,syrd
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv


### PR DESCRIPTION
This improves 3 things:

**1. The low power check.** 
Previously, it would check whether players' `ExcessPower` was less than `MinimumExcessPower` or whether the sum of all `Power` traits on the structure it wanted to build _exceeded_ the players' `ExcessPower`, and if either was true, build a power plant instead.
The catch: power _draw_ is represented by _negative_ numbers, so the only structures that would trigger the 2nd check were - power plants.
In other words, as long as current `ExcessPower` was equal or higher than `MinimumExcessPower`, the whole check would effectively fail, hence why the AI was out of power about half the time before I introduced `MinimumExcessPower` recently.
Now the 2nd check properly evaluates whether current `ExcessPower` + to-build actors' `Power` would be _lower_ than `MinimumExcessPower`, and in that case build a power plant instead.
Additionally, unlike before, it now also performs the "do I have enough power" check for the higher-priority overrides (refineries, production buildings, silos).
Last but not least, it now also gives powerplants priority if already on low power (no idea why it was different before).

**2. Repeated placement failures.**
Previously, the AI would constantly and stubbornly retry to build and place a structure even if out of space.
Now, after 3 consecutive failed attempts to place a structure, it is assumed that the AI has run out of build space and further production of structures is paused for a minute (default value of `StructureProductionResumeDelay`) and only resumed if the number of buildings decreased (or number of construction yards increased) in the meantime.

**3. Placement failure of naval structures.**
Previously, the AI would try to build naval structures even if there was no water within the buildable area. Now it first checks whether there is enough water in the base perimeter, and disables production of naval buildings if not. 
If there is actually such water space, when deciding whether to build a naval structure it checks if a building providing buildable area is close enough to that water. Only if that condition is met as well, the naval structure will be produced.

In summary, this should considerably reduce lag spikes from repeated building placement failures (particularly if it runs out of space) and finally prevent the AI reliably from driving itself into low power.

Fixes #8116, mostly adresses #4717.
