### PR TITLE
Release file handles when unmounting file system

### DIFF
--- a/OpenRA.Game/FileSystem/BagFile.cs
+++ b/OpenRA.Game/FileSystem/BagFile.cs
@@ -19,7 +19,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class BagFile : IFolder, IDisposable
+	public sealed class BagFile : IFolder
 	{
 		static readonly uint[] Nothing = { };
 
@@ -37,20 +37,16 @@ namespace OpenRA.FileSystem
 			// For example: audio.bag requires the audio.idx file
 			var indexFilename = Path.ChangeExtension(filename, ".idx");
 
-			s = GlobalFileSystem.Open(filename);
-
 			// Build the index and dispose the stream, it is no longer needed after this
 			List<IdxEntry> entries;
 			using (var indexStream = GlobalFileSystem.Open(indexFilename))
-			{
-				var reader = new IdxReader(indexStream);
-
-				entries = reader.Entries;
-			}
+				entries = new IdxReader(indexStream).Entries;
 
 			index = entries.ToDictionaryWithConflictLog(x => x.Hash,
 				"{0} (bag format)".F(filename),
 				null, x => "(offs={0}, len={1})".F(x.Offset, x.Length));
+
+			s = GlobalFileSystem.Open(filename);
 		}
 
 		public int Priority { get { return 1000 + bagFilePriority; } }
@@ -185,8 +181,7 @@ namespace OpenRA.FileSystem
 
 		public void Dispose()
 		{
-			if (s != null)
-				s.Dispose();
+			s.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/FileSystem/D2kSoundResources.cs
+++ b/OpenRA.Game/FileSystem/D2kSoundResources.cs
@@ -14,7 +14,7 @@ using System.IO;
 
 namespace OpenRA.FileSystem
 {
-	public class D2kSoundResources : IFolder
+	public sealed class D2kSoundResources : IFolder
 	{
 		readonly Stream s;
 
@@ -30,22 +30,28 @@ namespace OpenRA.FileSystem
 			this.priority = priority;
 
 			s = GlobalFileSystem.Open(filename);
-			s.Seek(0, SeekOrigin.Begin);
-
-			filenames = new List<string>();
-
-			var headerLength = s.ReadUInt32();
-			while (s.Position < headerLength + 4)
+			try
 			{
-				var name = s.ReadASCIIZ();
-				var offset = s.ReadUInt32();
-				var length = s.ReadUInt32();
+				filenames = new List<string>();
 
-				var hash = PackageEntry.HashFilename(name, PackageHashType.Classic);
-				if (!index.ContainsKey(hash))
-					index.Add(hash, new PackageEntry(hash, offset, length));
+				var headerLength = s.ReadUInt32();
+				while (s.Position < headerLength + 4)
+				{
+					var name = s.ReadASCIIZ();
+					var offset = s.ReadUInt32();
+					var length = s.ReadUInt32();
 
-				filenames.Add(name);
+					var hash = PackageEntry.HashFilename(name, PackageHashType.Classic);
+					if (!index.ContainsKey(hash))
+						index.Add(hash, new PackageEntry(hash, offset, length));
+
+					filenames.Add(name);
+				}
+			}
+			catch
+			{
+				Dispose();
+				throw;
 			}
 		}
 
@@ -91,6 +97,11 @@ namespace OpenRA.FileSystem
 		public void Write(Dictionary<string, byte[]> contents)
 		{
 			throw new NotImplementedException("Cannot save Dune 2000 Sound Resources.");
+		}
+
+		public void Dispose()
+		{
+			s.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -13,7 +13,7 @@ using System.IO;
 
 namespace OpenRA.FileSystem
 {
-	public class Folder : IFolder
+	public sealed class Folder : IFolder
 	{
 		readonly string path;
 		readonly int priority;
@@ -78,5 +78,7 @@ namespace OpenRA.FileSystem
 				using (var writer = new BinaryWriter(dataStream))
 					writer.Write(file.Value);
 		}
+
+		public void Dispose() { }
 	}
 }

--- a/OpenRA.Game/FileSystem/GlobalFileSystem.cs
+++ b/OpenRA.Game/FileSystem/GlobalFileSystem.cs
@@ -17,7 +17,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.FileSystem
 {
-	public interface IFolder
+	public interface IFolder : IDisposable
 	{
 		Stream GetContent(string filename);
 		bool Exists(string filename);
@@ -127,6 +127,9 @@ namespace OpenRA.FileSystem
 
 		public static void UnmountAll()
 		{
+			foreach (var folder in MountedFolders)
+				folder.Dispose();
+
 			MountedFolders.Clear();
 			FolderPaths.Clear();
 			classicHashIndex = new Cache<uint, List<IFolder>>(_ => new List<IFolder>());
@@ -135,6 +138,9 @@ namespace OpenRA.FileSystem
 
 		public static bool Unmount(IFolder mount)
 		{
+			if (MountedFolders.Contains(mount))
+				mount.Dispose();
+
 			return MountedFolders.RemoveAll(f => f == mount) > 0;
 		}
 

--- a/OpenRA.Game/FileSystem/Pak.cs
+++ b/OpenRA.Game/FileSystem/Pak.cs
@@ -21,34 +21,42 @@ namespace OpenRA.FileSystem
 		public string Filename;
 	}
 
-	public class PakFile : IFolder
+	public sealed class PakFile : IFolder
 	{
-		string filename;
-		int priority;
-		Dictionary<string, Entry> index;
-		Stream stream;
+		readonly string filename;
+		readonly int priority;
+		readonly Dictionary<string, Entry> index;
+		readonly Stream stream;
 
 		public PakFile(string filename, int priority)
 		{
 			this.filename = filename;
 			this.priority = priority;
 			index = new Dictionary<string, Entry>();
+
 			stream = GlobalFileSystem.Open(filename);
-
-			index = new Dictionary<string, Entry>();
-			var offset = stream.ReadUInt32();
-			while (offset != 0)
+			try
 			{
-				var file = stream.ReadASCIIZ();
-				var next = stream.ReadUInt32();
-				var length = (next == 0 ? (uint)stream.Length : next) - offset;
+				index = new Dictionary<string, Entry>();
+				var offset = stream.ReadUInt32();
+				while (offset != 0)
+				{
+					var file = stream.ReadASCIIZ();
+					var next = stream.ReadUInt32();
+					var length = (next == 0 ? (uint)stream.Length : next) - offset;
 
-				// Ignore duplicate files
-				if (index.ContainsKey(file))
-					continue;
+					// Ignore duplicate files
+					if (index.ContainsKey(file))
+						continue;
 
-				index.Add(file, new Entry { Offset = offset, Length = length, Filename = file });
-				offset = next;
+					index.Add(file, new Entry { Offset = offset, Length = length, Filename = file });
+					offset = next;
+				}
+			}
+			catch
+			{
+				Dispose();
+				throw;
 			}
 		}
 
@@ -92,5 +100,10 @@ namespace OpenRA.FileSystem
 
 		public int Priority { get { return 1000 + priority; } }
 		public string Name { get { return filename; } }
+
+		public void Dispose()
+		{
+			stream.Dispose();
+		}
 	}
 }

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -17,11 +17,11 @@ using SZipFile = ICSharpCode.SharpZipLib.Zip.ZipFile;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class ZipFile : IFolder, IDisposable
+	public sealed class ZipFile : IFolder
 	{
-		string filename;
+		readonly string filename;
+		readonly int priority;
 		SZipFile pkg;
-		int priority;
 
 		static ZipFile()
 		{


### PR DESCRIPTION
Make `IFolder` implement `IDisposable`, and fix all concrete classes to dispose any streams they open.

When a folder is unmounted from `GlobalFileSystem`, dispose the folder to ensure all the streams are released in a timely manner.

This prevents us eating up file handles longer than we should be, but as a secondary effect also means we'll avoid having multiple open file streams to the same file. It's a long shot, that might help with #2441 if having multiple streams is somehow causing occasional garbage reads (I doubt it - but on the other hand the only-occasionally-broken weirdness of #2441 is so crazy that maybe the solution is more crazy).

Tested by loading the game and switching between all the mods.

[Diff ignoring whitespace](https://github.com/OpenRA/OpenRA/pull/8762/files?w=1)
