### PR TITLE
Improved Explodes trait and how artillery explodes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -14,14 +14,22 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Desc("This actor explodes when killed.")]
 	public class ExplodesInfo : ITraitInfo
 	{
-		[WeaponReference]
+		[WeaponReference, Desc("Weapon to use for explosion if ammo/payload is loaded.")]
 		public readonly string Weapon = "UnitExplode";
-		[WeaponReference]
+
+		[WeaponReference, Desc("Weapon to use for explosion if no ammo/payload is loaded.")]
 		public readonly string EmptyWeapon = "UnitExplode";
 
+		[Desc("Chance that the explosion will use Weapon if the actor has ammo/payload.")]
+		public readonly int LoadedChance = 100;
+
+		[Desc("Chance that this actor will explode at all.")]
 		public readonly int Chance = 100;
+
+		[Desc("DeathType(s) to apply upon explosion.")]
 		public readonly string[] DeathType = null;
 
 		public object Create(ActorInitializer init) { return new Explodes(this); }
@@ -60,7 +68,8 @@ namespace OpenRA.Mods.Common.Traits
 		string ChooseWeaponForExplosion(Actor self)
 		{
 			var shouldExplode = self.TraitsImplementing<IExplodeModifier>().All(a => a.ShouldExplode(self));
-			return shouldExplode ? info.Weapon : info.EmptyWeapon;
+			var useFullExplosion = self.World.SharedRandom.Next(100) <= info.LoadedChance;
+			return (shouldExplode && useFullExplosion) ? info.Weapon : info.EmptyWeapon;
 		}
 	}
 }

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -153,6 +153,10 @@ ARTY:
 		InitialStance: Defend
 	LeavesHusk:
 		HuskActor: ARTY.Husk
+	Explodes:
+		Weapon: ArtilleryShell
+		EmptyWeapon: UnitExplode
+		LoadedChance: 75
 
 FTNK:
 	Inherits: ^Tank

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -27,7 +27,6 @@ UnitExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 50
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -226,8 +226,9 @@ ARTY:
 	AttackFrontal:
 	WithMuzzleFlash:
 	Explodes:
-		Weapon: UnitExplode
-		Chance: 75
+		Weapon: ArtilleryExplode
+		EmptyWeapon: UnitExplodeSmall
+		LoadedChance: 75
 	AutoTarget:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -25,7 +25,6 @@ V2RL:
 	AutoTarget:
 	Explodes:
 		Weapon: SCUD
-		EmptyWeapon: UnitExplodeSmall
 	WithAttackAnimation:
 		AimSequence: aim
 		ReloadPrefix: empty-
@@ -64,9 +63,6 @@ V2RL:
 	WithMuzzleFlash:
 	WithTurret:
 	AutoTarget:
-	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	LeavesHusk:
 		HuskActor: 1TNK.Husk
 	ProducibleWithLevel:
@@ -104,9 +100,6 @@ V2RL:
 	WithMuzzleFlash:
 	WithTurret:
 	AutoTarget:
-	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	LeavesHusk:
 		HuskActor: 2TNK.Husk
 	SelectionDecorations:
@@ -146,9 +139,6 @@ V2RL:
 	WithMuzzleFlash:
 	WithTurret:
 	AutoTarget:
-	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	LeavesHusk:
 		HuskActor: 3TNK.Husk
 	SelectionDecorations:
@@ -197,9 +187,6 @@ V2RL:
 	WithMuzzleFlash:
 	WithTurret:
 	AutoTarget:
-	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	LeavesHusk:
 		HuskActor: 4TNK.Husk
 	SelfHealing:
@@ -289,7 +276,6 @@ HARV:
 		FullnessThreshold: 50
 	Explodes:
 		Weapon: OreExplosion
-		EmptyWeapon: UnitExplodeSmall
 
 MCV:
 	Inherits: ^Vehicle
@@ -328,9 +314,6 @@ MCV:
 	BaseBuilding:
 	LeavesHusk:
 		HuskActor: MCV.Husk
-	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 
 JEEP:
 	Inherits: ^Vehicle

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -197,6 +197,25 @@ UnitExplodeSmall:
 		ImpactSound: splash9.aud
 		ValidImpactTypes: Water
 
+ArtilleryExplode:
+	Warhead@1Dam: SpreadDamage
+		Spread: 426
+		Damage: 150
+		Versus:
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: self_destruct
+		ImpactSound: kaboom22.aud
+		InvalidImpactTypes: Water
+	Warhead@3EffWater: CreateEffect
+		Explosion: large_splash
+		ImpactSound: splash9.aud
+		ValidImpactTypes: Water
+
 BarrelExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426


### PR DESCRIPTION
Added `LoadedChance` to `Explodes`, changed how RA/TD artillery explodes.

See individual commits for more detailed descriptions.
