### PR TITLE
Throttle AI order speed to prevent lag spikes

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.AI
 					return false;
 
 				HackyAI.BotDebug("AI: {0} is starting production of {1}".F(player, item.Name));
-				world.IssueOrder(Order.StartProduction(queue.Actor, item.Name, 1));
+				ai.QueueOrder(Order.StartProduction(queue.Actor, item.Name, 1));
 			}
 			else if (currentBuilding.Done)
 			{
@@ -87,11 +87,11 @@ namespace OpenRA.Mods.Common.AI
 				if (location == null)
 				{
 					HackyAI.BotDebug("AI: {0} has nowhere to place {1}".F(player, currentBuilding.Item));
-					world.IssueOrder(Order.CancelProduction(queue.Actor, currentBuilding.Item, 1));
+					ai.QueueOrder(Order.CancelProduction(queue.Actor, currentBuilding.Item, 1));
 				}
 				else
 				{
-					world.IssueOrder(new Order("PlaceBuilding", player.PlayerActor, false)
+					ai.QueueOrder(new Order("PlaceBuilding", player.PlayerActor, false)
 					{
 						TargetLocation = location.Value,
 						TargetString = currentBuilding.Item,

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -195,10 +195,24 @@ namespace OpenRA.Mods.Common.AI
 		public Map Map { get { return World.Map; } }
 		IBotInfo IBot.Info { get { return this.Info; } }
 
+		int rushTicks;
+		int assignRolesTicks;
+		int attackForceTicks;
+		int minAttackForceDelayTicks;
+
 		public HackyAI(HackyAIInfo info, ActorInitializer init)
 		{
 			Info = info;
 			World = init.World;
+
+			// Avoid all AIs trying to rush in the same tick, randomize their initial rush a little.
+			var smallFractionOfRushInterval = Info.RushInterval / 20;
+			rushTicks = World.SharedRandom.Next(Info.RushInterval - smallFractionOfRushInterval, Info.RushInterval + smallFractionOfRushInterval);
+
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			assignRolesTicks = World.SharedRandom.Next(0, Info.AssignRolesInterval);
+			attackForceTicks = World.SharedRandom.Next(0, Info.AttackForceInterval);
+			minAttackForceDelayTicks = World.SharedRandom.Next(0, Info.MinimumAttackForceDelay);
 
 			foreach (var decision in info.PowerDecisions)
 				powerDecisions.Add(decision.OrderName, decision);
@@ -519,11 +533,6 @@ namespace OpenRA.Mods.Common.AI
 			squads.Add(ret);
 			return ret;
 		}
-
-		int assignRolesTicks = 0;
-		int rushTicks = 0;
-		int attackForceTicks = 0;
-		int minAttackForceDelayTicks = 0;
 
 		void AssignRolesToIdleUnits(Actor self)
 		{

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.Common.AI
 					{
 						if (IsRearm(a))
 							continue;
-						owner.World.IssueOrder(new Order("ReturnToBase", a, false));
+						owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
 						continue;
 					}
 
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.AI
 				}
 
 				if (owner.TargetActor.HasTrait<ITargetable>() && CanAttackTarget(a, owner.TargetActor))
-					owner.World.IssueOrder(new Order("Attack", a, false) { TargetActor = owner.TargetActor });
+					owner.Bot.QueueOrder(new Order("Attack", a, false) { TargetActor = owner.TargetActor });
 			}
 		}
 
@@ -247,11 +247,11 @@ namespace OpenRA.Mods.Common.AI
 					if (IsRearm(a))
 						continue;
 
-					owner.World.IssueOrder(new Order("ReturnToBase", a, false));
+					owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
 					continue;
 				}
 
-				owner.World.IssueOrder(new Order("Move", a, false) { TargetLocation = RandomBuildingLocation(owner) });
+				owner.Bot.QueueOrder(new Order("Move", a, false) { TargetLocation = RandomBuildingLocation(owner) });
 			}
 
 			owner.FuzzyStateMachine.ChangeState(owner, new AirIdleState(), true);

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.AI
 				if (owner.AttackOrFleeFuzzy.CanAttack(owner.Units, enemyUnits))
 				{
 					foreach (var u in owner.Units)
-						owner.World.IssueOrder(new Order("AttackMove", u, false) { TargetLocation = owner.TargetActor.Location });
+						owner.Bot.QueueOrder(new Order("AttackMove", u, false) { TargetLocation = owner.TargetActor.Location });
 
 					// We have gathered sufficient units. Attack the nearest enemy unit.
 					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackMoveState(), true);
@@ -87,9 +87,9 @@ namespace OpenRA.Mods.Common.AI
 				.Where(a => a.Owner == owner.Units.FirstOrDefault().Owner && owner.Units.Contains(a)).ToHashSet();
 			if (ownUnits.Count < owner.Units.Count)
 			{
-				owner.World.IssueOrder(new Order("Stop", leader, false));
+				owner.Bot.QueueOrder(new Order("Stop", leader, false));
 				foreach (var unit in owner.Units.Where(a => !ownUnits.Contains(a)))
-					owner.World.IssueOrder(new Order("AttackMove", unit, false) { TargetLocation = leader.Location });
+					owner.Bot.QueueOrder(new Order("AttackMove", unit, false) { TargetLocation = leader.Location });
 			}
 			else
 			{
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.AI
 				}
 				else
 					foreach (var a in owner.Units)
-						owner.World.IssueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
+						owner.Bot.QueueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
 			}
 
 			if (ShouldFlee(owner))
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.AI
 
 			foreach (var a in owner.Units)
 				if (!BusyAttack(a))
-					owner.World.IssueOrder(new Order("Attack", a, false) { TargetActor = owner.Bot.FindClosestEnemy(a.CenterPosition) });
+					owner.Bot.QueueOrder(new Order("Attack", a, false) { TargetActor = owner.Bot.FindClosestEnemy(a.CenterPosition) });
 
 			if (ShouldFlee(owner))
 			{

--- a/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.AI
 			else
 			{
 				foreach (var a in owner.Units)
-					owner.World.IssueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
+					owner.Bot.QueueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
 			}
 		}
 

--- a/OpenRA.Mods.Common/AI/States/StateBase.cs
+++ b/OpenRA.Mods.Common/AI/States/StateBase.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var loc = RandomBuildingLocation(squad);
 			foreach (var a in squad.Units)
-				squad.World.IssueOrder(new Order("Move", a, false) { TargetLocation = loc });
+				squad.Bot.QueueOrder(new Order("Move", a, false) { TargetLocation = loc });
 		}
 
 		protected static CPos RandomBuildingLocation(Squad squad)


### PR DESCRIPTION
Fixes #8466
Fixes #8384
Fixes #4584
## Issue

In games with AI, as the game progresses there will start to be lag spikes every ~1 second. The spikes get worse with more AI.
## Cause

AIs re-evaluate their current state at set intervals. For example [assigning of roles](https://github.com/OpenRA/OpenRA/blob/7d56209f3b772ea847cc8c9decb4c33cc4210e7d/OpenRA.Mods.Common/AI/HackyAI.cs#L40-L41) and [updating of squads](https://github.com/OpenRA/OpenRA/blob/7d56209f3b772ea847cc8c9decb4c33cc4210e7d/OpenRA.Mods.Common/AI/HackyAI.cs#L46-L47). You'll notice both of these are 20/30 ticks - which are both roughly 1 second.

Luckily, evaluating AI state is fast.

What happens then is that the AIs issue new orders to be carried out. In a typical case they might issue say 10 orders to one of the squads to attack.

Luckily, issuing orders is fast.

[These orders are processed during the tick by the order manager](https://github.com/OpenRA/OpenRA/blob/7d56209f3b772ea847cc8c9decb4c33cc4210e7d/OpenRA.Game/Network/OrderManager.cs#L212).

Luckily, processing orders is fast.

[Each time an order is processed, a hash of the world state must be generated for sync purposes](https://github.com/OpenRA/OpenRA/blob/7d56209f3b772ea847cc8c9decb4c33cc4210e7d/OpenRA.Game/Network/OrderManager.cs#L213). This allows clients to identify the order responsible in the event of a desync.

Unluckily, hashing the world state is extremely slow.

In games with several AI, a few AI will decide to send orders to their squads, each squad needing maybe a dozen orders. They do this all at the exact same tick. This results in a flood of orders (say about 50 orders instead of the more usual 0-5) to be processed in a single tick. Hashing the world state so many times as a result of processing the orders is the reason for the lag spike.
## The Fix

I address this issue by limiting the ability of the AI to generate a flood of orders in a single tick. Instead, I spread out the orders over several ticks.

The first commit makes each AI in the game operate on different ticks. In games with lots of AI, this prevents them teaming up to make one tick very slow.

The second limits the number of orders an AI can issue per tick. Extra orders are queued up and processed on subsequent ticks. This prevents spikes from issuing orders to entire squads at once by forcing the AI to order each unit on separate ticks.

This throttling means that orders might be outdated by the time they are issued. This seems to work in my testing but somebody who knows how orders work better than I do should confirm I'm not introducing a massive chance for crashes and/or desyncs.
## Results

Perf graphs before and after (we care about the teal line representing tick_time)

![Perf Graph Comparion](http://i.imgur.com/SU5a0Lo.png)

You can check this yourself by just spectating a game with a large number of AI. Wait a few minutes until they start attacking each other and the lag spikes should appear. With this PR they should be prevented.
