### PR TITLE
Aligns observer support power timers to the left edge of the screen.

### DIFF
--- a/mods/d2k/chrome/ingame.yaml
+++ b/mods/d2k/chrome/ingame.yaml
@@ -19,10 +19,6 @@ Container@INGAME_ROOT:
 				StrategicProgress@STRATEGIC_PROGRESS:
 					X: WINDOW_RIGHT/2
 					Y: 40
-				SupportPowerTimer@SUPPORT_POWER_TIMER:
-					X: 80
-					Y: 34
-					Order: Descending
 				Container@PLAYER_ROOT:
 				Container@PERF_ROOT:
 		Container@MENU_ROOT:

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -1,5 +1,9 @@
 Container@OBSERVER_WIDGETS:
 	Children:
+		SupportPowerTimer@SUPPORT_POWER_TIMER:
+			X: 10
+			Y: 10
+			Order: Descending
 		Image@SIDEBAR_BACKGROUND_TOP:
 			X: WINDOW_RIGHT - 250
 			Y: 10

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -25,6 +25,10 @@ Container@PLAYER_WIDGETS:
 							IgnoreMouseOver: true
 							ImageCollection: sidebar
 							ImageName: background-supportoverlay
+		SupportPowerTimer@SUPPORT_POWER_TIMER:
+			X: 80
+			Y: 10
+			Order: Descending
 		Image@SIDEBAR_BACKGROUND_TOP:
 			Logic: AddRaceSuffixLogic
 			X: WINDOW_RIGHT - 250

--- a/mods/ra/chrome/ingame.yaml
+++ b/mods/ra/chrome/ingame.yaml
@@ -19,10 +19,6 @@ Container@INGAME_ROOT:
 				StrategicProgress@STRATEGIC_PROGRESS:
 					X: WINDOW_RIGHT/2
 					Y: 40
-				SupportPowerTimer@SUPPORT_POWER_TIMER:
-					X: 80
-					Y: 10
-					Order: Descending
 				Container@PLAYER_ROOT:
 				Container@PERF_ROOT:
 		Container@MENU_ROOT:


### PR DESCRIPTION
Since observers don't have support power icons, countdown timers can be aligned to the left edge of the screen. This PR removes the timer widget definition from ingame.yaml and adds it to ingame-observer.yaml and ingame-player.yaml. This way, the bounds can be defined separately for players and observers. It also removes the unused widget definition from d2k yaml.

This is split from #8619.
