### PR TITLE
Add StartSequence to WithIdleOverlay & change V19.Husk

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Renders a decorative animation on units and buildings.")]
 	public class WithIdleOverlayInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
 	{
+		[Desc("Animation to play when the actor is created.")]
+		[SequenceReference] public readonly string StartSequence = null;
+
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "idle-overlay";
 
@@ -67,7 +70,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
-			overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence));
+			if (info.StartSequence != null)
+				overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.StartSequence),
+					() => overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence)));
+			else
+				overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence));
 
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -57,11 +57,11 @@ namespace OpenRA.Mods.Common.Traits
 			DefaultAnimation = new Animation(init.World, rs.GetImage(init.Self), baseFacing);
 			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled));
 
-			if (Info.StartSequence != null)
-				PlayCustomAnimation(init.Self, Info.StartSequence,
-					() => DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, Info.Sequence)));
+			if (info.StartSequence != null)
+				PlayCustomAnimation(init.Self, info.StartSequence,
+					() => PlayCustomAnimationRepeating(init.Self, info.Sequence));
 			else
-				DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, Info.Sequence));
+				DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence));
 		}
 
 		public string NormalizeSequence(Actor self, string sequence)

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -11,8 +11,13 @@ V19:
 
 V19.Husk:
 	Inherits: ^CivBuildingHusk
+	-RenderBuilding:
+	AutoSelectionSize:
 	RenderSprites:
+	BodyOrientation:
+		QuantizedFacings: 1
 	WithSpriteBody:
+	WithIdleOverlay:
 		StartSequence: fire-start
 		Sequence: fire-loop
 	Building:

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -667,10 +667,12 @@ v19.husk:
 	fire-start: flmspt
 		Length: *
 		Offset: 7,-15
+		ZOffset: 1
 	fire-loop: flmspt
 		Start: 50
 		Length: *
 		Offset: 7,-15
+		ZOffset: 1
 
 v20:
 	Defaults:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -232,8 +232,13 @@ V19.Husk:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Husk (Oil Pump)
+	-RenderBuilding:
+	AutoSelectionSize:
 	RenderSprites:
+	BodyOrientation:
+		QuantizedFacings: 1
 	WithSpriteBody:
+	WithIdleOverlay:
 		StartSequence: fire-start
 		Sequence: fire-loop
 	-Health:

--- a/mods/ra/sequences/decorations.yaml
+++ b/mods/ra/sequences/decorations.yaml
@@ -514,10 +514,12 @@ v19.husk:
 	fire-start: flmspt
 		Length: *
 		Offset: 7,-15
+		ZOffset: 1
 	fire-loop: flmspt
 		Start: 50
 		Length: *
 		Offset: 7,-15
+		ZOffset: 1
 
 utilpol1:
 	idle:


### PR DESCRIPTION
V19.Husk uses RenderBuilding & WithSpriteBody which implement IQuantizeBodyOrientation.
The problem is that `self.Info.Traits.GetOrDefault<IQuantizeBodyOrientationInfo>()` is called in BodyOrientation. While this probably has no noticeable affect on the game, it can be fixed simply by adding these two lines.
