### PR TITLE
Fix Observers/players using the nofogcheat crashing during win/lose the game.

### DIFF
--- a/OpenRA.Game/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Game/Traits/World/MusicPlaylist.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Traits
 
 			var playedSong = currentSong;
 
-			if (world.LocalPlayer.WinState == WinState.Won)
+			if (world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Won)
 			{
 				if (!string.IsNullOrEmpty(info.VictoryMusic)
 				&& world.Map.Rules.Music.ContainsKey(info.VictoryMusic)


### PR DESCRIPTION
Fixes #8778.
