### PR TITLE
Add plumbing for heighmap-aware shroud and map bounds checks.

### DIFF
--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -98,8 +98,8 @@ namespace OpenRA.Graphics
 			var cells = restrictToBounds ? viewport.VisibleCellsInsideBounds : viewport.AllVisibleCells;
 
 			// Only draw the rows that are visible.
-			var firstRow = cells.MapCoords.TopLeft.V;
-			var lastRow = Math.Min(cells.MapCoords.BottomRight.V + 1, map.MapSize.Y);
+			var firstRow = cells.CandidateMapCoords.TopLeft.V.Clamp(0, map.MapSize.Y);
+			var lastRow = (cells.CandidateMapCoords.BottomRight.V + 1).Clamp(firstRow, map.MapSize.Y);
 
 			Game.Renderer.Flush();
 

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -61,4 +61,34 @@ namespace OpenRA
 			return new CPos(x, y);
 		}
 	}
+
+	/// <summary>
+	/// Projected map position
+	/// </summary>
+	public struct PPos : IEquatable<PPos>
+	{
+		public readonly int U, V;
+
+		public PPos(int u, int v) { U = u; V = v; }
+		public static readonly PPos Zero = new PPos(0, 0);
+
+		public static bool operator ==(PPos me, PPos other) { return me.U == other.U && me.V == other.V; }
+		public static bool operator !=(PPos me, PPos other) { return !(me == other); }
+
+		public static explicit operator MPos(PPos puv) { return new MPos(puv.U, puv.V); }
+		public static explicit operator PPos(MPos uv) { return new PPos(uv.U, uv.V); }
+
+		public PPos Clamp(Rectangle r)
+		{
+			return new PPos(Math.Min(r.Right, Math.Max(U, r.Left)),
+				Math.Min(r.Bottom, Math.Max(V, r.Top)));
+		}
+
+		public override int GetHashCode() { return U.GetHashCode() ^ V.GetHashCode(); }
+
+		public bool Equals(PPos other) { return other == this; }
+		public override bool Equals(object obj) { return obj is PPos && Equals((PPos)obj); }
+
+		public override string ToString() { return U + "," + V; }
+	}
 }

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -87,7 +87,7 @@ namespace OpenRA
 
 		public MapCoordsRegion MapCoords
 		{
-			get { return new MapCoordsRegion(this); }
+			get { return new MapCoordsRegion(mapTopLeft, mapBottomRight); }
 		}
 
 		public CellRegionEnumerator GetEnumerator()
@@ -150,76 +150,6 @@ namespace OpenRA
 			public CPos Current { get { return current; } }
 			object IEnumerator.Current { get { return Current; } }
 			public void Dispose() { }
-		}
-
-		public struct MapCoordsRegion : IEnumerable<MPos>
-		{
-			public struct MapCoordsEnumerator : IEnumerator<MPos>
-			{
-				readonly CellRegion r;
-				MPos current;
-
-				public MapCoordsEnumerator(CellRegion region)
-					: this()
-				{
-					r = region;
-					Reset();
-				}
-
-				public bool MoveNext()
-				{
-					var u = current.U + 1;
-					var v = current.V;
-
-					// Check for column overflow
-					if (u > r.mapBottomRight.U)
-					{
-						v += 1;
-						u = r.mapTopLeft.U;
-
-						// Check for row overflow
-						if (v > r.mapBottomRight.V)
-							return false;
-					}
-
-					current = new MPos(u, v);
-					return true;
-				}
-
-				public void Reset()
-				{
-					current = new MPos(r.mapTopLeft.U - 1, r.mapTopLeft.V);
-				}
-
-				public MPos Current { get { return current; } }
-				object IEnumerator.Current { get { return Current; } }
-				public void Dispose() { }
-			}
-
-			readonly CellRegion r;
-
-			public MapCoordsRegion(CellRegion region)
-			{
-				r = region;
-			}
-
-			public MapCoordsEnumerator GetEnumerator()
-			{
-				return new MapCoordsEnumerator(r);
-			}
-
-			IEnumerator<MPos> IEnumerable<MPos>.GetEnumerator()
-			{
-				return GetEnumerator();
-			}
-
-			IEnumerator IEnumerable.GetEnumerator()
-			{
-				return GetEnumerator();
-			}
-
-			public MPos TopLeft { get { return r.mapTopLeft; } }
-			public MPos BottomRight { get { return r.mapBottomRight; } }
 		}
 	}
 }

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -739,10 +739,10 @@ namespace OpenRA
 
 		public bool Contains(MPos uv)
 		{
-			// The first check ensures that the cell is within the valid map region, avoiding
-			// potential crashes in deeper code.  All CellLayers have the same geometry, and
-			// CustomTerrain is convenient (cellProjection may be null and others are Lazy).
-			return CustomTerrain.Contains(uv) && ProjectedCellsCovering(uv).All(containsTest);
+			// TODO: Checking against the bounds excludes valid parts of the map if MaxTerrainHeight > 0.
+			// Unfortunatley, doing this properly leads to memory corruption issues in the (unsafe) radar
+			// rendering code.
+			return Bounds.Contains(uv.U, uv.V) && ProjectedCellsCovering(uv).All(containsTest);
 		}
 
 		public bool Contains(PPos puv)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -245,6 +246,8 @@ namespace OpenRA
 		[FieldLoader.Ignore] public Lazy<CellLayer<byte>> MapHeight;
 
 		[FieldLoader.Ignore] public CellLayer<byte> CustomTerrain;
+		[FieldLoader.Ignore] CellLayer<PPos[]> cellProjection;
+		[FieldLoader.Ignore] CellLayer<List<MPos>> inverseCellProjection;
 
 		[FieldLoader.Ignore] Lazy<TileSet> cachedTileSet;
 		[FieldLoader.Ignore] Lazy<Ruleset> rules;
@@ -252,8 +255,10 @@ namespace OpenRA
 		public SequenceProvider SequenceProvider { get { return Rules.Sequences[Tileset]; } }
 
 		public WVec[][] CellCorners { get; private set; }
-		[FieldLoader.Ignore] public CellRegion CellsInsideBounds;
+		[FieldLoader.Ignore] public ProjectedCellRegion ProjectedCellBounds;
 		[FieldLoader.Ignore] public CellRegion AllCells;
+
+		readonly Func<PPos, bool> containsTest;
 
 		void AssertExists(string filename)
 		{
@@ -268,6 +273,8 @@ namespace OpenRA
 		/// </summary>
 		public Map(TileSet tileset, int width, int height)
 		{
+			containsTest = Contains;
+
 			var size = new Size(width, height);
 			var tileShape = Game.ModData.Manifest.TileShape;
 			var tileRef = new TerrainTile(tileset.Templates.First().Key, (byte)0);
@@ -307,6 +314,8 @@ namespace OpenRA
 		/// <summary>Initializes a map loaded from disk.</summary>
 		public Map(string path)
 		{
+			containsTest = Contains;
+
 			Path = path;
 			Container = GlobalFileSystem.OpenPackage(path, null, int.MaxValue);
 
@@ -409,8 +418,8 @@ namespace OpenRA
 			var br = new MPos(MapSize.X - 1, MapSize.Y - 1).ToCPos(this);
 			AllCells = new CellRegion(TileShape, tl, br);
 
-			var btl = new MPos(Bounds.Left, Bounds.Top);
-			var bbr = new MPos(Bounds.Right - 1, Bounds.Bottom - 1);
+			var btl = new PPos(Bounds.Left, Bounds.Top);
+			var bbr = new PPos(Bounds.Right - 1, Bounds.Bottom - 1);
 			SetBounds(btl, bbr);
 
 			CustomTerrain = new CellLayer<byte>(this);
@@ -428,6 +437,80 @@ namespace OpenRA
 				rightDelta + new WVec(0, 0, 512 * ramp[2]),
 				bottomDelta + new WVec(0, 0, 512 * ramp[3])
 			}).ToArray();
+
+			if (MaximumTerrainHeight != 0)
+			{
+				cellProjection = new CellLayer<PPos[]>(this);
+				inverseCellProjection = new CellLayer<List<MPos>>(this);
+
+				// Initialize collections
+				foreach (var cell in AllCells)
+				{
+					var uv = cell.ToMPos(TileShape);
+					cellProjection[uv] = new PPos[0];
+					inverseCellProjection[uv] = new List<MPos>();
+				}
+
+				// Initialize projections
+				foreach (var cell in AllCells)
+					UpdateProjection(cell);
+			}
+		}
+
+		void UpdateProjection(CPos cell)
+		{
+			if (MaximumTerrainHeight == 0)
+				return;
+
+			var uv = cell.ToMPos(TileShape);
+
+			// Remove old reverse projection
+			foreach (var puv in cellProjection[uv])
+				inverseCellProjection[(MPos)puv].Remove(uv);
+
+			var projected = ProjectCellInner(uv);
+			cellProjection[uv] = projected;
+
+			foreach (var puv in projected)
+				inverseCellProjection[(MPos)puv].Add(uv);
+		}
+
+		PPos[] ProjectCellInner(MPos uv)
+		{
+			var mapHeight = MapHeight.Value;
+			if (!mapHeight.Contains(uv))
+				return NoProjectedCells;
+
+			var height = mapHeight[uv];
+			if (height == 0)
+				return new[] { (PPos)uv };
+
+			// Odd-height ramps get bumped up a level to the next even height layer
+			if ((height & 1) == 1)
+			{
+				var ti = cachedTileSet.Value.GetTileInfo(MapTiles.Value[uv]);
+				if (ti != null && ti.RampType != 0)
+					height += 1;
+			}
+
+			var candidates = new List<PPos>();
+
+			// Odd-height level tiles are equally covered by four projected tiles
+			if ((height & 1) == 1)
+			{
+				if ((uv.V & 1) == 1)
+					candidates.Add(new PPos(uv.U + 1, uv.V - height));
+				else
+					candidates.Add(new PPos(uv.U - 1, uv.V - height));
+
+				candidates.Add(new PPos(uv.U, uv.V - height));
+				candidates.Add(new PPos(uv.U, uv.V - height + 1));
+				candidates.Add(new PPos(uv.U, uv.V - height - 1));
+			}
+			else
+				candidates.Add(new PPos(uv.U, uv.V - height));
+
+			return candidates.Where(c => mapHeight.Contains((MPos)c)).ToArray();
 		}
 
 		public Ruleset PreloadRules()
@@ -534,6 +617,8 @@ namespace OpenRA
 				}
 			}
 
+			tiles.CellEntryChanged += UpdateProjection;
+
 			return tiles;
 		}
 
@@ -551,6 +636,8 @@ namespace OpenRA
 							tiles[new MPos(i, j)] = s.ReadUInt8().Clamp((byte)0, MaximumTerrainHeight);
 				}
 			}
+
+			tiles.CellEntryChanged += UpdateProjection;
 
 			return tiles;
 		}
@@ -652,7 +739,15 @@ namespace OpenRA
 
 		public bool Contains(MPos uv)
 		{
-			return Bounds.Contains(uv.U, uv.V);
+			// The first check ensures that the cell is within the valid map region, avoiding
+			// potential crashes in deeper code.  All CellLayers have the same geometry, and
+			// CustomTerrain is convenient (cellProjection may be null and others are Lazy).
+			return CustomTerrain.Contains(uv) && ProjectedCellsCovering(uv).All(containsTest);
+		}
+
+		public bool Contains(PPos puv)
+		{
+			return Bounds.Contains(puv.U, puv.V);
 		}
 
 		public WPos CenterOfCell(CPos cell)
@@ -695,6 +790,39 @@ namespace OpenRA
 			return new CPos(u, v);
 		}
 
+		public PPos ProjectedCellCovering(WPos pos)
+		{
+			var projectedPos = pos - new WVec(0, pos.Z, pos.Z);
+			return (PPos)CellContaining(projectedPos).ToMPos(TileShape);
+		}
+
+		static readonly PPos[] NoProjectedCells = { };
+		public PPos[] ProjectedCellsCovering(MPos uv)
+		{
+			// Shortcut for mods that don't use heightmaps
+			if (MaximumTerrainHeight == 0)
+				return new[] { (PPos)uv };
+
+			if (!cellProjection.Contains(uv))
+				return NoProjectedCells;
+
+			return cellProjection[uv];
+		}
+
+		public MPos[] Unproject(PPos puv)
+		{
+			var uv = (MPos)puv;
+
+			// Shortcut for mods that don't use heightmaps
+			if (MaximumTerrainHeight == 0)
+				return new[] { uv };
+
+			if (!inverseCellProjection.Contains(uv))
+				return new MPos[0];
+
+			return inverseCellProjection[uv].ToArray();
+		}
+
 		public int FacingBetween(CPos cell, CPos towards, int fallbackfacing)
 		{
 			return Traits.Util.GetFacing(CenterOfCell(towards) - CenterOfCell(cell), fallbackfacing);
@@ -717,12 +845,11 @@ namespace OpenRA
 			AllCells = new CellRegion(TileShape, tl, br);
 		}
 
-		public void SetBounds(MPos tl, MPos br)
+		public void SetBounds(PPos tl, PPos br)
 		{
 			// The tl and br coordinates are inclusive, but the Rectangle
 			// is exclusive.  Pad the right and bottom edges to match.
 			Bounds = Rectangle.FromLTRB(tl.U, tl.V, br.U + 1, br.V + 1);
-			CellsInsideBounds = new CellRegion(TileShape, tl.ToCPos(this), br.ToCPos(this));
 
 			// Directly calculate the projected map corners in world units avoiding unnecessary
 			// conversions.  This abuses the definition that the width of the cell is always
@@ -738,6 +865,8 @@ namespace OpenRA
 
 			ProjectedTopLeft = new WPos(tl.U * 1024, wtop, 0);
 			ProjectedBottomRight = new WPos(br.U * 1024 - 1, wbottom - 1, 0);
+
+			ProjectedCellBounds = new ProjectedCellRegion(this, tl, br);
 		}
 
 		string ComputeHash()
@@ -799,18 +928,28 @@ namespace OpenRA
 
 		public CPos Clamp(CPos cell)
 		{
-			var bounds = new Rectangle(Bounds.X, Bounds.Y, Bounds.Width - 1, Bounds.Height - 1);
-			return cell.ToMPos(this).Clamp(bounds).ToCPos(this);
+			return Clamp(cell.ToMPos(this)).ToCPos(this);
 		}
 
 		public MPos Clamp(MPos uv)
 		{
+			// Already in bounds, so don't need to do anything.
+			if (Contains(uv))
+				return uv;
+
+			// TODO: Account for terrain height
+			return (MPos)Clamp((PPos)uv);
+		}
+
+		public PPos Clamp(PPos puv)
+		{
 			var bounds = new Rectangle(Bounds.X, Bounds.Y, Bounds.Width - 1, Bounds.Height - 1);
-			return uv.Clamp(bounds);
+			return puv.Clamp(bounds);
 		}
 
 		public CPos ChooseRandomCell(MersenneTwister rand)
 		{
+			// TODO: Account for terrain height
 			var x = rand.Next(Bounds.Left, Bounds.Right);
 			var y = rand.Next(Bounds.Top, Bounds.Bottom);
 
@@ -819,6 +958,7 @@ namespace OpenRA
 
 		public CPos ChooseClosestEdgeCell(CPos pos)
 		{
+			// TODO: Account for terrain height
 			var mpos = pos.ToMPos(this);
 
 			var horizontalBound = ((mpos.U - Bounds.Left) < Bounds.Width / 2) ? Bounds.Left : Bounds.Right;
@@ -832,6 +972,7 @@ namespace OpenRA
 
 		public CPos ChooseRandomEdgeCell(MersenneTwister rand)
 		{
+			// TODO: Account for terrain height
 			var isX = rand.Next(2) == 0;
 			var edge = rand.Next(2) == 0;
 
@@ -843,8 +984,10 @@ namespace OpenRA
 
 		public WDist DistanceToEdge(WPos pos, WVec dir)
 		{
-			var tl = CenterOfCell(CellsInsideBounds.TopLeft) - new WVec(512, 512, 0);
-			var br = CenterOfCell(CellsInsideBounds.BottomRight) + new WVec(511, 511, 0);
+			// TODO: Account for terrain height
+			// Project into the screen plane and then compare against ProjectedWorldBounds.
+			var tl = CenterOfCell(((MPos)ProjectedCellBounds.TopLeft).ToCPos(this)) - new WVec(512, 512, 0);
+			var br = CenterOfCell(((MPos)ProjectedCellBounds.BottomRight).ToCPos(this)) + new WVec(511, 511, 0);
 			var x = dir.X == 0 ? int.MaxValue : ((dir.X < 0 ? tl.X : br.X) - pos.X) / dir.X;
 			var y = dir.Y == 0 ? int.MaxValue : ((dir.Y < 0 ? tl.Y : br.Y) - pos.Y) / dir.Y;
 			return new WDist(Math.Min(x, y) * dir.Length);

--- a/OpenRA.Game/Map/MapCoordsRegion.cs
+++ b/OpenRA.Game/Map/MapCoordsRegion.cs
@@ -1,0 +1,89 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA
+{
+	public struct MapCoordsRegion : IEnumerable<MPos>
+	{
+		public struct MapCoordsEnumerator : IEnumerator<MPos>
+		{
+			readonly MapCoordsRegion r;
+			MPos current;
+
+			public MapCoordsEnumerator(MapCoordsRegion region)
+				: this()
+			{
+				r = region;
+				Reset();
+			}
+
+			public bool MoveNext()
+			{
+				var u = current.U + 1;
+				var v = current.V;
+
+				// Check for column overflow
+				if (u > r.bottomRight.U)
+				{
+					v += 1;
+					u = r.topLeft.U;
+
+					// Check for row overflow
+					if (v > r.bottomRight.V)
+						return false;
+				}
+
+				current = new MPos(u, v);
+				return true;
+			}
+
+			public void Reset()
+			{
+				current = new MPos(r.topLeft.U - 1, r.topLeft.V);
+			}
+
+			public MPos Current { get { return current; } }
+			object IEnumerator.Current { get { return Current; } }
+			public void Dispose() { }
+		}
+
+		readonly MPos topLeft;
+		readonly MPos bottomRight;
+
+		public MapCoordsRegion(MPos mapTopLeft, MPos mapBottomRight)
+		{
+			this.topLeft = mapTopLeft;
+			this.bottomRight = mapBottomRight;
+		}
+
+		public MapCoordsEnumerator GetEnumerator()
+		{
+			return new MapCoordsEnumerator(this);
+		}
+
+		IEnumerator<MPos> IEnumerable<MPos>.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		public MPos TopLeft { get { return topLeft; } }
+		public MPos BottomRight { get { return bottomRight; } }
+	}
+}

--- a/OpenRA.Game/Map/ProjectedCellRegion.cs
+++ b/OpenRA.Game/Map/ProjectedCellRegion.cs
@@ -1,0 +1,125 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA
+{
+	// Represents a (on-screen) rectangular collection of tiles.
+	// TopLeft and BottomRight are inclusive
+	public class ProjectedCellRegion : IEnumerable<PPos>
+	{
+		// Corners of the region
+		public readonly PPos TopLeft;
+		public readonly PPos BottomRight;
+
+		// Corners of the bounding map region that contains all the cells that
+		// may be projected within this region.
+		readonly MPos mapTopLeft;
+		readonly MPos mapBottomRight;
+
+		public ProjectedCellRegion(Map map, PPos topLeft, PPos bottomRight)
+		{
+			TopLeft = topLeft;
+			BottomRight = bottomRight;
+
+			// The projection from MPos -> PPos cannot produce a larger V coordinate
+			// so the top edge of the MPos region is the same as the PPos region.
+			// (in fact the cells are identical if height == 0)
+			mapTopLeft = (MPos)topLeft;
+
+			// The bottom edge is trickier: cells at MPos.V > bottomRight.V may have
+			// been projected into this region if they have height > 0.
+			// Each height step is equivalent to 512 WRange units, which is one MPos
+			// step for diamond cells, but only half a MPos step for classic cells. Doh!
+			var heightOffset = map.TileShape == TileShape.Diamond ? map.MaximumTerrainHeight : map.MaximumTerrainHeight / 2;
+
+			// Use the MapHeight data array to clamp the bottom coordinate so it doesn't overflow the map
+			mapBottomRight = map.MapHeight.Value.Clamp(new MPos(bottomRight.U, bottomRight.V + heightOffset));
+		}
+
+		public bool Contains(PPos puv)
+		{
+			return puv.U >= TopLeft.U && puv.U <= BottomRight.U && puv.V >= TopLeft.V && puv.V <= BottomRight.V;
+		}
+
+		/// <summary>
+		/// The region in map coordinates that contains all the cells that
+		/// may be projected inside this region.  For increased performance,
+		/// this does not validate whether individual map cells are actually
+		/// projected inside the region.
+		/// </summary>
+		public MapCoordsRegion CandidateMapCoords { get { return new MapCoordsRegion(mapTopLeft, mapBottomRight); } }
+
+		public ProjectedCellRegionEnumerator GetEnumerator()
+		{
+			return new ProjectedCellRegionEnumerator(this);
+		}
+
+		IEnumerator<PPos> IEnumerable<PPos>.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		public sealed class ProjectedCellRegionEnumerator : IEnumerator<PPos>
+		{
+			readonly ProjectedCellRegion r;
+
+			// Current position, in projected map coordinates
+			int u, v;
+
+			PPos current;
+
+			public ProjectedCellRegionEnumerator(ProjectedCellRegion region)
+			{
+				r = region;
+				Reset();
+			}
+
+			public bool MoveNext()
+			{
+				u += 1;
+
+				// Check for column overflow
+				if (u > r.BottomRight.U)
+				{
+					v += 1;
+					u = r.TopLeft.U;
+
+					// Check for row overflow
+					if (v > r.BottomRight.V)
+						return false;
+				}
+
+				current = new PPos(u, v);
+				return true;
+			}
+
+			public void Reset()
+			{
+				// Enumerator starts *before* the first element in the sequence.
+				u = r.TopLeft.U - 1;
+				v = r.TopLeft.V;
+			}
+
+			public PPos Current { get { return current; } }
+			object IEnumerator.Current { get { return Current; } }
+			public void Dispose() { }
+		}
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Widgets\WorldInteractionControllerWidget.cs" />
     <Compile Include="Graphics\PaletteReference.cs" />
     <Compile Include="Graphics\TerrainSpriteLayer.cs" />
+    <Compile Include="Map\MapCoordsRegion.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Widgets\WorldInteractionControllerWidget.cs" />
     <Compile Include="Graphics\PaletteReference.cs" />
     <Compile Include="Graphics\TerrainSpriteLayer.cs" />
+    <Compile Include="Map\ProjectedCellRegion.cs" />
     <Compile Include="Map\MapCoordsRegion.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Traits
 
 	public class FrozenActor
 	{
-		public readonly MPos[] Footprint;
+		public readonly PPos[] Footprint;
 		public readonly WPos CenterPosition;
 		public readonly Rectangle Bounds;
 		readonly Actor actor;
@@ -42,7 +42,7 @@ namespace OpenRA.Traits
 		public bool NeedRenderables;
 		public bool IsRendering { get; private set; }
 
-		public FrozenActor(Actor self, MPos[] footprint, Shroud shroud)
+		public FrozenActor(Actor self, PPos[] footprint, Shroud shroud)
 		{
 			actor = self;
 			this.shroud = shroud;

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -204,7 +204,7 @@ namespace OpenRA.Traits
 				throw new ArgumentException("The map bounds of these shrouds do not match.", "s");
 
 			var changed = new List<CPos>();
-			foreach (var uv in map.CellsInsideBounds.MapCoords)
+			foreach (var uv in map.ProjectedCellBounds.CandidateMapCoords)
 			{
 				if (!explored[uv] && s.explored[uv])
 				{
@@ -219,7 +219,7 @@ namespace OpenRA.Traits
 		public void ExploreAll(World world)
 		{
 			var changed = new List<CPos>();
-			foreach (var uv in map.CellsInsideBounds.MapCoords)
+			foreach (var uv in map.ProjectedCellBounds.CandidateMapCoords)
 			{
 				if (!explored[uv])
 				{
@@ -234,7 +234,7 @@ namespace OpenRA.Traits
 		public void ResetExploration()
 		{
 			var changed = new List<CPos>();
-			foreach (var uv in map.CellsInsideBounds.MapCoords)
+			foreach (var uv in map.ProjectedCellBounds.CandidateMapCoords)
 			{
 				var visible = visibleCount[uv] > 0;
 				if (explored[uv] != visible)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -33,7 +33,6 @@ namespace OpenRA
 			public int Compare(Actor x, Actor y) { return x.ActorID.CompareTo(y.ActorID); }
 		}
 
-		static readonly Func<MPos, bool> FalsePredicate = _ => false;
 		internal readonly TraitDictionary TraitDict = new TraitDictionary();
 		readonly SortedSet<Actor> actors = new SortedSet<Actor>(ActorIDComparer.Instance);
 		readonly List<IEffect> effects = new List<IEffect>();
@@ -78,33 +77,7 @@ namespace OpenRA
 		public bool FogObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(pos); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
 		public bool ShroudObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(pos); }
-		public bool ShroudObscures(MPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
-
-		public Func<MPos, bool> FogObscuresTest
-		{
-			get
-			{
-				var rp = RenderPlayer;
-				if (rp == null)
-					return FalsePredicate;
-
-				var predicate = rp.Shroud.IsVisibleTest;
-				return uv => !predicate(uv);
-			}
-		}
-
-		public Func<MPos, bool> ShroudObscuresTest
-		{
-			get
-			{
-				var rp = RenderPlayer;
-				if (rp == null)
-					return FalsePredicate;
-
-				var predicate = rp.Shroud.IsExploredTest;
-				return uv => !predicate(uv);
-			}
-		}
+		public bool ShroudObscures(PPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
 
 		public bool IsReplay
 		{

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public CreatesShroud(Actor self, CreatesShroudInfo info)
 			: base(self, info)
 		{
-			addCellsToPlayerShroud = (p, c) => p.Shroud.AddShroudGeneration(self, c);
+			addCellsToPlayerShroud = (p, uv) => p.Shroud.AddProjectedShroudGeneration(self, uv);
 			removeCellsFromPlayerShroud = p => p.Shroud.RemoveShroudGeneration(self);
 			isDisabled = () => self.IsDisabled();
 		}

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly FrozenUnderFogInfo info;
 		readonly bool startsRevealed;
-		readonly MPos[] footprint;
+		readonly PPos[] footprint;
 
 		readonly Lazy<IToolTip> tooltip;
 		readonly Lazy<Health> health;
@@ -47,10 +47,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 
+			var map = init.World.Map;
+
 			// Spawned actors (e.g. building husks) shouldn't be revealed
 			startsRevealed = info.StartsRevealed && !init.Contains<ParentActorInit>();
 			var footprintCells = FootprintUtils.Tiles(init.Self).ToList();
-			footprint = footprintCells.Select(cell => cell.ToMPos(init.World.Map)).ToArray();
+			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
 			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<IToolTip>().FirstOrDefault());
 			health = Exts.Lazy(() => init.Self.TraitOrDefault<Health>());
 

--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -64,10 +64,10 @@ namespace OpenRA.Mods.Common.Traits
 			var map = world.Map;
 			foreach (var p in Start.Keys)
 			{
-				var cells = Shroud.CellsInRange(map, Start[p], info.InitialExploreRange);
+				var cells = Shroud.ProjectedCellsInRange(map, Start[p], info.InitialExploreRange);
 				foreach (var q in world.Players)
 					if (p.IsAlliedWith(q))
-						q.Shroud.Explore(world, cells);
+						q.Shroud.ExploreProjectedCells(world, cells);
 			}
 
 			// Set viewport

--- a/OpenRA.Mods.Common/Traits/World/PathfinderDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathfinderDebugOverlay.cs
@@ -60,23 +60,24 @@ namespace OpenRA.Mods.Common.Traits
 			var doDim = refreshTick - world.WorldTick <= 0;
 			if (doDim) refreshTick = world.WorldTick + 20;
 
+			var map = wr.World.Map;
 			foreach (var pair in layers)
 			{
 				var c = (pair.Key != null) ? pair.Key.Color.RGB : Color.PaleTurquoise;
 				var layer = pair.Value;
 
 				// Only render quads in viewing range:
-				foreach (var cell in wr.Viewport.VisibleCellsInsideBounds)
+				foreach (var uv in wr.Viewport.VisibleCellsInsideBounds.CandidateMapCoords)
 				{
-					if (layer[cell] <= 0)
+					if (layer[uv] <= 0)
 						continue;
 
-					var w = Math.Max(0, Math.Min(layer[cell], 128));
+					var w = Math.Max(0, Math.Min(layer[uv], 128));
 					if (doDim)
-						layer[cell] = layer[cell] * 5 / 6;
+						layer[uv] = layer[uv] * 5 / 6;
 
 					// TODO: This doesn't make sense for isometric terrain
-					var pos = wr.World.Map.CenterOfCell(cell);
+					var pos = wr.World.Map.CenterOfCell(uv.ToCPos(map));
 					var tl = wr.ScreenPxPosition(pos - new WVec(512, 512, 0));
 					var br = wr.ScreenPxPosition(pos + new WVec(511, 511, 0));
 					qr.FillRect(RectangleF.FromLTRB(tl.X, tl.Y, br.X, br.Y), Color.FromArgb(w, c));

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -249,7 +249,9 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				currentShroud = shroud;
-				DirtyCells(map.CellsInsideBounds);
+				var dirty = map.ProjectedCellBounds
+					.SelectMany(puv => map.Unproject(puv).Select(uv => uv.ToCPos(map)));
+				DirtyCells(dirty);
 			}
 
 			// We need to update newly dirtied areas of the shroud.

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -91,11 +91,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly CellLayer<TileInfo> tileInfos;
 		readonly Sprite[] fogSprites, shroudSprites;
-		readonly HashSet<CPos> cellsDirty = new HashSet<CPos>();
-		readonly HashSet<CPos> cellsAndNeighborsDirty = new HashSet<CPos>();
+		readonly HashSet<PPos> cellsDirty = new HashSet<PPos>();
+		readonly HashSet<PPos> cellsAndNeighborsDirty = new HashSet<PPos>();
 
 		Shroud currentShroud;
-		Func<MPos, bool> visibleUnderShroud, visibleUnderFog;
+		Func<PPos, bool> visibleUnderShroud, visibleUnderFog;
 		TerrainSpriteLayer shroudLayer, fogLayer;
 
 		public ShroudRenderer(World world, ShroudRendererInfo info)
@@ -158,20 +158,22 @@ namespace OpenRA.Mods.Common.Traits
 			// This includes the region outside the visible area to cover any sprites peeking outside the map
 			foreach (var uv in w.Map.AllCells.MapCoords)
 			{
-				var screen = wr.ScreenPosition(w.Map.CenterOfCell(uv.ToCPos(map)));
+				var pos = w.Map.CenterOfCell(uv.ToCPos(map));
+				var screen = wr.ScreenPosition(pos - new WVec(0, 0, pos.Z));
 				var variant = (byte)Game.CosmeticRandom.Next(info.ShroudVariants.Length);
 				tileInfos[uv] = new TileInfo(screen, variant);
 			}
 
-			DirtyCells(map.AllCells);
+			// Dirty the whole projected space
+			DirtyCells(map.AllCells.MapCoords.Select(uv => (PPos)uv));
 
 			// All tiles are visible in the editor
 			if (w.Type == WorldType.Editor)
 				visibleUnderShroud = _ => true;
 			else
-				visibleUnderShroud = map.Contains;
+				visibleUnderShroud = puv => map.Contains(puv);
 
-			visibleUnderFog = map.Contains;
+			visibleUnderFog = puv => map.Contains(puv);
 
 			var shroudSheet = shroudSprites[0].Sheet;
 			if (shroudSprites.Any(s => s.Sheet != shroudSheet))
@@ -193,25 +195,25 @@ namespace OpenRA.Mods.Common.Traits
 			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, wr.Palette(info.FogPalette), false);
 		}
 
-		Edges GetEdges(MPos uv, Func<MPos, bool> isVisible)
+		Edges GetEdges(PPos puv, Func<PPos, bool> isVisible)
 		{
-			if (!isVisible(uv))
+			if (!isVisible(puv))
 				return notVisibleEdges;
 
-			var cell = uv.ToCPos(map);
+			var cell = ((MPos)puv).ToCPos(map);
 
 			// If a side is shrouded then we also count the corners.
 			var edge = Edges.None;
-			if (!isVisible((cell + new CVec(0, -1)).ToMPos(map))) edge |= Edges.Top;
-			if (!isVisible((cell + new CVec(1, 0)).ToMPos(map))) edge |= Edges.Right;
-			if (!isVisible((cell + new CVec(0, 1)).ToMPos(map))) edge |= Edges.Bottom;
-			if (!isVisible((cell + new CVec(-1, 0)).ToMPos(map))) edge |= Edges.Left;
+			if (!isVisible((PPos)(cell + new CVec(0, -1)).ToMPos(map))) edge |= Edges.Top;
+			if (!isVisible((PPos)(cell + new CVec(1, 0)).ToMPos(map))) edge |= Edges.Right;
+			if (!isVisible((PPos)(cell + new CVec(0, 1)).ToMPos(map))) edge |= Edges.Bottom;
+			if (!isVisible((PPos)(cell + new CVec(-1, 0)).ToMPos(map))) edge |= Edges.Left;
 
 			var ucorner = edge & Edges.AllCorners;
-			if (!isVisible((cell + new CVec(-1, -1)).ToMPos(map))) edge |= Edges.TopLeft;
-			if (!isVisible((cell + new CVec(1, -1)).ToMPos(map))) edge |= Edges.TopRight;
-			if (!isVisible((cell + new CVec(1, 1)).ToMPos(map))) edge |= Edges.BottomRight;
-			if (!isVisible((cell + new CVec(-1, 1)).ToMPos(map))) edge |= Edges.BottomLeft;
+			if (!isVisible((PPos)(cell + new CVec(-1, -1)).ToMPos(map))) edge |= Edges.TopLeft;
+			if (!isVisible((PPos)(cell + new CVec(1, -1)).ToMPos(map))) edge |= Edges.TopRight;
+			if (!isVisible((PPos)(cell + new CVec(1, 1)).ToMPos(map))) edge |= Edges.BottomRight;
+			if (!isVisible((PPos)(cell + new CVec(-1, 1)).ToMPos(map))) edge |= Edges.BottomLeft;
 
 			// RA provides a set of frames for tiles with shrouded
 			// corners but unshrouded edges. We want to detect this
@@ -222,7 +224,7 @@ namespace OpenRA.Mods.Common.Traits
 			return info.UseExtendedIndex ? edge ^ ucorner : edge & Edges.AllCorners;
 		}
 
-		void DirtyCells(IEnumerable<CPos> cells)
+		void DirtyCells(IEnumerable<PPos> cells)
 		{
 			cellsDirty.UnionWith(cells);
 		}
@@ -244,38 +246,37 @@ namespace OpenRA.Mods.Common.Traits
 				}
 				else
 				{
-					visibleUnderShroud = map.Contains;
-					visibleUnderFog = map.Contains;
+					visibleUnderShroud = puv => map.Contains(puv);
+					visibleUnderFog = puv => map.Contains(puv);
 				}
 
 				currentShroud = shroud;
-				var dirty = map.ProjectedCellBounds
-					.SelectMany(puv => map.Unproject(puv).Select(uv => uv.ToCPos(map)));
-				DirtyCells(dirty);
+				DirtyCells(map.ProjectedCellBounds);
 			}
 
 			// We need to update newly dirtied areas of the shroud.
 			// Expand the dirty area to cover the neighboring cells, since shroud is affected by neighboring cells.
-			foreach (var cell in cellsDirty)
+			foreach (var uv in cellsDirty)
 			{
-				cellsAndNeighborsDirty.Add(cell);
+				cellsAndNeighborsDirty.Add(uv);
+				var cell = ((MPos)uv).ToCPos(map);
 				foreach (var direction in CVec.Directions)
-					cellsAndNeighborsDirty.Add(cell + direction);
+					cellsAndNeighborsDirty.Add((PPos)(cell + direction).ToMPos(map));
 			}
 
-			foreach (var cell in cellsAndNeighborsDirty)
+			foreach (var puv in cellsAndNeighborsDirty)
 			{
-				var uv = cell.ToMPos(map.TileShape);
+				var uv = (MPos)puv;
 				if (!tileInfos.Contains(uv))
 					continue;
 
 				var tileInfo = tileInfos[uv];
-				var shroudSprite = GetSprite(shroudSprites, GetEdges(uv, visibleUnderShroud), tileInfo.Variant);
+				var shroudSprite = GetSprite(shroudSprites, GetEdges(puv, visibleUnderShroud), tileInfo.Variant);
 				var shroudPos = tileInfo.ScreenPosition;
 				if (shroudSprite != null)
 					shroudPos += shroudSprite.Offset - 0.5f * shroudSprite.Size;
 
-				var fogSprite = GetSprite(fogSprites, GetEdges(uv, visibleUnderFog), tileInfo.Variant);
+				var fogSprite = GetSprite(fogSprites, GetEdges(puv, visibleUnderFog), tileInfo.Variant);
 				var fogPos = tileInfo.ScreenPosition;
 				if (fogSprite != null)
 					fogPos += fogSprite.Offset - 0.5f * fogSprite.Size;

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			var colors = wr.World.TileSet.HeightDebugColors;
 			var mouseCell = wr.Viewport.ViewToWorld(Viewport.LastMousePos).ToMPos(wr.World.Map);
 
-			foreach (var uv in wr.Viewport.AllVisibleCells.MapCoords)
+			foreach (var uv in wr.Viewport.AllVisibleCells.CandidateMapCoords)
 			{
 				var height = (int)map.MapHeight.Value[uv];
 				var tile = map.MapTiles.Value[uv];
@@ -80,6 +80,22 @@ namespace OpenRA.Mods.Common.Traits
 
 				lr.LineWidth = 1;
 			}
+
+			// Projected cell coordinates for the current cell
+			var projectedCorners = map.CellCorners[0];
+			lr.LineWidth = 3;
+			foreach (var puv in map.ProjectedCellsCovering(mouseCell))
+			{
+				var pos = map.CenterOfCell(((MPos)puv).ToCPos(map));
+				var screen = projectedCorners.Select(c => wr.ScreenPxPosition(pos + c - new WVec(0, 0, pos.Z)).ToFloat2()).ToArray();
+				for (var i = 0; i < 4; i++)
+				{
+					var j = (i + 1) % 4;
+					lr.DrawLine(screen[i], screen[j], Color.Navy);
+				}
+			}
+
+			lr.LineWidth = 1;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -59,6 +59,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var uv in wr.Viewport.AllVisibleCells.CandidateMapCoords)
 			{
+				if (!map.MapHeight.Value.Contains(uv))
+					continue;
+
 				var height = (int)map.MapHeight.Value[uv];
 				var tile = map.MapTiles.Value[uv];
 				var ti = tileSet.GetTileInfo(tile);

--- a/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
@@ -151,8 +151,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					Author = "Westwood Studios"
 				};
 
-				var tl = new MPos(offsetX, offsetY);
-				var br = new MPos(offsetX + width - 1, offsetY + height - 1);
+				var tl = new PPos(offsetX, offsetY);
+				var br = new PPos(offsetX + width - 1, offsetY + height - 1);
 				map.SetBounds(tl, br);
 
 				if (legacyMapFormat == IniMapFormat.RedAlert)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -64,8 +64,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var tileset = modRules.TileSets[tilesetDropDown.Text];
 				var map = new Map(tileset, width + 2, height + maxTerrainHeight + 2);
 
-				var tl = new MPos(1, 1);
-				var br = new MPos(width, height + maxTerrainHeight);
+				var tl = new PPos(1, 1);
+				var br = new PPos(width, height + maxTerrainHeight);
 				map.SetBounds(tl, br);
 
 				map.PlayerDefinitions = new MapPlayers(map.Rules, map.SpawnPoints.Value.Length).ToMiniYaml();

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Widgets
 			actorSprite = new Sprite(radarSheet, new Rectangle(0, height, width, height), TextureChannel.Alpha);
 
 			// Set initial terrain data
-			foreach (var cell in world.Map.CellsInsideBounds)
+			foreach (var cell in world.Map.AllCells)
 				UpdateTerrainCell(cell);
 
 			world.Map.MapTiles.Value.CellEntryChanged += UpdateTerrainCell;
@@ -290,7 +290,7 @@ namespace OpenRA.Mods.Common.Widgets
 					if (newRenderShroud != null)
 					{
 						// Redraw the full shroud sprite
-						MarkShroudDirty(world.Map.CellsInsideBounds);
+						MarkShroudDirty(world.Map.AllCells);
 
 						// Update the notification binding
 						newRenderShroud.CellsChanged += MarkShroudDirty;

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -315,8 +315,8 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 				Author = "Westwood Studios"
 			};
 
-			var tl = new MPos(MapCordonWidth, MapCordonWidth);
-			var br = new MPos(MapCordonWidth + mapSize.Width - 1, MapCordonWidth + mapSize.Height - 1);
+			var tl = new PPos(MapCordonWidth, MapCordonWidth);
+			var br = new PPos(MapCordonWidth + mapSize.Width - 1, MapCordonWidth + mapSize.Height - 1);
 			map.SetBounds(tl, br);
 
 			// Get all templates from the tileset YAML file that have at least one frame and an Image property corresponding to the requested tileset


### PR DESCRIPTION
This introduces a new coordinate system ("projected map cells", or `PPos`) for code that deals with the map border and shroud.  For mods that don't use terrain height `PPos` maps identically to `MPos`.

From the first commit message:

```
PPos is best thought of as a cell grid applied in
screen space.  Multiple cells with different
terrain heights may be projected to the same PPos,
or to multiple PPos if they do not align with the
screen grid (i.e. odd-height or sloped).

PPos coordinates are used primarily for map edge
checks and shroud / visibility queries.
```

For the sake of keeping the PR as reviewable as possible I have limited this to what we need for the shroud.  Future PRs will deal with the map-edge coordinate helpers which are fiddly and harder to review.

Expected behaviour with this PR applied is for there to be no visible changes in TD/RA/D2K, and for the TS shroud rendering to behave logically.  Edge of map behaviour in TS should be no worse than in current bleed.
