### PR TITLE
Re-enable mission replays

### DIFF
--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -69,7 +69,7 @@ namespace OpenRA
 		Player renderPlayer;
 		public Player RenderPlayer
 		{
-			get { return renderPlayer == null || renderPlayer.WinState != WinState.Undefined ? null : renderPlayer; }
+			get { return renderPlayer == null || (renderPlayer.WinState != WinState.Undefined && !Map.Visibility.HasFlag(MapVisibility.MissionSelector)) ? null : renderPlayer; }
 			set { renderPlayer = value; }
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var stats = widget.GetOrNull<MenuButtonWidget>("OBSERVER_STATS_BUTTON");
 			if (stats != null)
 			{
-				stats.IsDisabled = () => disableSystemButtons;
+				stats.IsDisabled = () => disableSystemButtons || world.Map.Visibility.HasFlag(MapVisibility.MissionSelector);
 				stats.OnClick = () => OpenMenuPanel(stats);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -287,7 +287,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 			Game.LobbyInfoChanged += lobbyReady;
 
-			om = Game.JoinServer(IPAddress.Loopback.ToString(), Game.CreateLocalServer(selectedMapPreview.Uid), "", false);
+			om = Game.JoinServer(IPAddress.Loopback.ToString(), Game.CreateLocalServer(selectedMapPreview.Uid), "");
 		}
 
 		class DropDownOption


### PR DESCRIPTION
Replays for missions have been disabled in #6442 due to the issues mentioned there.

The first of these has been fixed a while ago when FMV playback was moved into the UI.

The second is fixed by the first commit in this PR.
