### PR TITLE
Singleton Traits - Implicit & Interface

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -125,33 +125,43 @@ namespace OpenRA
 			{
 				Trait = i,
 				Type = i.GetType(),
-				Dependencies = PrerequisitesOf(i).ToList()
+				Predecessors = PredecessorsOf(i).ToList(),
+				Requisites = RequisitesOf(i).ToList()
 			}).ToList();
 
-			var resolved = source.Where(s => !s.Dependencies.Any()).ToList();
+			var resolved = source.Where(s => !s.Predecessors.Any()).ToList();
 			var unresolved = source.Except(resolved);
 
 			var testResolve = new Func<Type, Type, bool>((a, b) => a == b || a.IsAssignableFrom(b));
-			var more = unresolved.Where(u => u.Dependencies.All(d => resolved.Exists(r => testResolve(d, r.Type))));
+			var more = unresolved.Where(u => u.Predecessors.All(d => !unresolved.Any(r => testResolve(d, r.Type))));
 
 			// Re-evaluate the vars above until sorted
 			while (more.Any())
 				resolved.AddRange(more);
 
-			if (unresolved.Any())
+			var missing = source.SelectMany(u => u.Requisites.Where(d => !source.Any(s => testResolve(d, s.Type)))).Distinct();
+			if (missing.Any() || unresolved.Any())
 			{
 				var exceptionString = "ActorInfo(\"" + Name + "\") failed to initialize because of the following:\r\n";
-				var missing = unresolved.SelectMany(u => u.Dependencies.Where(d => !source.Any(s => testResolve(d, s.Type)))).Distinct();
 
-				exceptionString += "Missing:\r\n";
-				foreach (var m in missing)
-					exceptionString += m + " \r\n";
-
-				exceptionString += "Unresolved:\r\n";
-				foreach (var u in unresolved)
+				if (missing.Any())
 				{
-					var deps = u.Dependencies.Where(d => !resolved.Exists(r => r.Type == d));
-					exceptionString += u.Type + ": { " + string.Join(", ", deps) + " }\r\n";
+					exceptionString += "Missing:\r\n";
+					foreach (var m in missing)
+					{
+						var users = source.Where(s => s.Requisites.Any(r => testResolve(r, m))).Select(s => s.Type);
+						exceptionString += m + ": { " + string.Join(", ", users) + " }\r\n";
+					}
+				}
+
+				if (unresolved.Any())
+				{
+					exceptionString += "Unresolved:\r\n";
+					foreach (var u in unresolved)
+					{
+						var deps = u.Predecessors.Where(d => !resolved.Exists(r => r.Type == d));
+						exceptionString += u.Type + ": { " + string.Join(", ", deps) + " }\r\n";
+					}
 				}
 
 				throw new Exception(exceptionString);
@@ -161,7 +171,16 @@ namespace OpenRA
 			return constructOrderCache;
 		}
 
-		static IEnumerable<Type> PrerequisitesOf(ITraitInfo info)
+		static IEnumerable<Type> PredecessorsOf(ITraitInfo info)
+		{
+			return info
+				.GetType()
+				.GetInterfaces()
+				.Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(InitializeAfter<>))
+				.Select(t => t.GetGenericArguments()[0]);
+		}
+
+		static IEnumerable<Type> RequisitesOf(ITraitInfo info)
 		{
 			return info
 				.GetType()

--- a/OpenRA.Game/Traits/BodyOrientation.cs
+++ b/OpenRA.Game/Traits/BodyOrientation.cs
@@ -12,7 +12,7 @@ using System;
 
 namespace OpenRA.Traits
 {
-	public class BodyOrientationInfo : ITraitInfo, IBodyOrientationInfo
+	public class BodyOrientationInfo : IBodyOrientationInfo
 	{
 		[Desc("Number of facings for gameplay calculations. -1 indicates auto-detection from another trait")]
 		public readonly int QuantizedFacings = -1;

--- a/OpenRA.Game/Traits/Health.cs
+++ b/OpenRA.Game/Traits/Health.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace OpenRA.Traits
 {
-	public class HealthInfo : ITraitInfo, UsesInit<HealthInit>
+	public class HealthInfo : ISingletonTraitInfo, UsesInit<HealthInit>
 	{
 		[Desc("HitPoints")]
 		public readonly int HP = 0;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Traits
 		Player Owner { get; }
 	}
 
-	public interface ITooltipInfo
+	public interface ITooltipInfo : ITraitInfo
 	{
 		string TooltipForPlayerStance(Stance stance);
 		bool IsOwnerRowVisible { get; }
@@ -226,6 +226,7 @@ namespace OpenRA.Traits
 	public interface ITags { IEnumerable<TagType> GetTags(); }
 	public interface ISelectionBar { float GetValue(); Color GetColor(); }
 
+	public interface IPositionableInfo : ITraitInfo { }
 	public interface IPositionable : IOccupySpace
 	{
 		bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any);
@@ -275,6 +276,11 @@ namespace OpenRA.Traits
 
 	public class TraitInfo<T> : ITraitInfo where T : new() { public virtual object Create(ActorInitializer init) { return new T(); } }
 
+	/// <summary>This trait must come after trait T because T is used in the constructor</summary>
+	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
+	public interface InitializeAfter<T> where T : class, ITraitInfo { }
+
+	/// <summary>Use if trait T is required.</summary>
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfo { }
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Traits
 
 	public interface ISeedableResource { void Seed(Actor self); }
 
-	public interface ISelectionDecorationsInfo
+	public interface ISelectionDecorationsInfo : ISingletonTraitInfo
 	{
 		int[] SelectionBoxBounds { get; }
 	}
@@ -138,6 +138,7 @@ namespace OpenRA.Traits
 	public interface IStoreResources { int Capacity { get; } }
 	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
 
+	public interface IEffectiveOwnerInfo : ISingletonTraitInfo { }
 	public interface IEffectiveOwner
 	{
 		bool Disguised { get; }
@@ -172,14 +173,14 @@ namespace OpenRA.Traits
 		IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self);
 	}
 
-	public interface IDefaultVisibilityInfo { }
+	public interface IDefaultVisibilityInfo : ISingletonTraitInfo { }
 	public interface IDefaultVisibility { bool IsVisible(Actor self, Player byPlayer); }
 	public interface IVisibilityModifier { bool IsVisible(Actor self, Player byPlayer); }
 	public interface IFogVisibilityModifier { bool HasFogVisibility(Player byPlayer); }
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self); }
 
-	public interface IOccupySpaceInfo : ITraitInfo
+	public interface IOccupySpaceInfo : ISingletonTraitInfo
 	{
 		IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any);
 		bool SharesCell { get; }
@@ -238,7 +239,7 @@ namespace OpenRA.Traits
 		void SetVisualPosition(Actor self, WPos pos);
 	}
 
-	public interface IMoveInfo : ITraitInfo { }
+	public interface IMoveInfo : ISingletonTraitInfo { }
 	public interface IMove
 	{
 		Activity MoveTo(CPos cell, int nearEnough);
@@ -263,7 +264,7 @@ namespace OpenRA.Traits
 		int Facing { get; set; }
 	}
 
-	public interface IFacingInfo : ITraitInfo { int GetInitialFacing(); }
+	public interface IFacingInfo : ISingletonTraitInfo { int GetInitialFacing(); }
 
 	public interface ICrushable
 	{
@@ -332,15 +333,15 @@ namespace OpenRA.Traits
 		WRot QuantizeOrientation(Actor self, WRot orientation);
 	}
 
-	public interface IBodyOrientationInfo : ITraitInfo
+	public interface IBodyOrientationInfo : ISingletonTraitInfo
 	{
 		WVec LocalToWorld(WVec vec);
 		WRot QuantizeOrientation(WRot orientation, int facings);
 	}
 
-	public interface IQuantizeBodyOrientationInfo { int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race); }
+	public interface IQuantizeBodyOrientationInfo : ISingletonTraitInfo { int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race); }
 
-	public interface ITargetableInfo
+	public interface ITargetableInfo : ISingletonTraitInfo
 	{
 		string[] GetTargetTypes();
 	}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -274,6 +274,12 @@ namespace OpenRA.Traits
 
 	public interface ITraitInfo { object Create(ActorInitializer init); }
 
+	/// <summary>This trait should only exist once per actor.</summary>
+	public interface ISingletonTraitInfo : ITraitInfo { }
+
+	/// <summary>This trait should only exist once per actor and is included implicitly.</summary>
+	public interface IImplicitSingletonTraitInfo : ISingletonTraitInfo { }
+
 	public class TraitInfo<T> : ITraitInfo where T : new() { public virtual object Create(ActorInitializer init) { return new T(); } }
 
 	/// <summary>This trait must come after trait T because T is used in the constructor</summary>
@@ -283,6 +289,10 @@ namespace OpenRA.Traits
 	/// <summary>Use if trait T is required.</summary>
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfo { }
+
+	/// <summary>This trait requires implicit singleton trait, which may be added automatically.</summary>
+	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
+	public interface RequiresSingleton<T> where T : class, IImplicitSingletonTraitInfo { }
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
 	public interface UsesInit<T> where T : IActorInit { }
 

--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Actor's turret rises from the ground before attacking.")]
-	class AttackPopupTurretedInfo : AttackTurretedInfo, Requires<BuildingInfo>, Requires<RenderBuildingInfo>
+	class AttackPopupTurretedInfo : AttackTurretedInfo, Requires<BuildingInfo>, Requires<RenderBuildingInfo>, InitializeAfter<RenderBuildingInfo>
 	{
 		[Desc("How many game ticks should pass before closing the actor's turret.")]
 		public int CloseDelay = 125;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Renders the cargo loaded into the unit.")]
-	public class WithCargoInfo : ITraitInfo, Requires<CargoInfo>, Requires<IBodyOrientationInfo>
+	public class WithCargoInfo : ITraitInfo, Requires<CargoInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<CargoInfo>, InitializeAfter<IFacingInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Cargo position relative to turret or body in (forward, right, up) triples. The default offset should be in the middle of the list.")]
 		public readonly WVec[] LocalOffset = { WVec.Zero };

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Building animation to play when ProductionAirdrop is used to deliver units.")]
-	public class WithDeliveryAnimationInfo : ITraitInfo, Requires<RenderBuildingInfo>
+	public class WithDeliveryAnimationInfo : ITraitInfo, Requires<RenderBuildingInfo>, InitializeAfter<RenderBuildingInfo>
 	{
 		public readonly string ActiveSequence = "active";
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -16,7 +16,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class WithGunboatBodyInfo : WithSpriteBodyInfo, Requires<IBodyOrientationInfo>, Requires<IFacingInfo>, Requires<TurretedInfo>
+	class WithGunboatBodyInfo : WithSpriteBodyInfo, Requires<IBodyOrientationInfo>, Requires<IFacingInfo>, Requires<TurretedInfo>,
+		InitializeAfter<IFacingInfo>, InitializeAfter<TurretedInfo>
 	{
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";

--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Effects
 {
 	[Desc("Draw a colored contrail behind this actor when they move.")]
-	class ContrailInfo : ITraitInfo, Requires<IBodyOrientationInfo>
+	class ContrailInfo : ITraitInfo, Requires<IBodyOrientationInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;

--- a/OpenRA.Mods.Common/Scripting/LuaScript.cs
+++ b/OpenRA.Mods.Common/Scripting/LuaScript.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Scripting
 {
 	[Desc("Part of the new Lua API.")]
-	public class LuaScriptInfo : ITraitInfo, Requires<SpawnMapActorsInfo>
+	public class LuaScriptInfo : ITraitInfo, Requires<SpawnMapActorsInfo>, InitializeAfter<SpawnMapActorsInfo>
 	{
 		public readonly string[] Scripts = { };
 

--- a/OpenRA.Mods.Common/Scripting/ScriptUpgradesCache.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptUpgradesCache.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Scripting
 {
 	[Desc("Allows granting upgrades to actors from Lua scripts.")]
-	public class ScriptUpgradesCacheInfo : ITraitInfo
+	public class ScriptUpgradesCacheInfo : IImplicitSingletonTraitInfo
 	{
 		[UpgradeGrantedReference]
 		[Desc("Upgrades that can be granted from the scripts.")]

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class AircraftInfo : ITraitInfo, IFacingInfo, IOccupySpaceInfo, ICruiseAltitudeInfo, UsesInit<LocationInit>, UsesInit<FacingInit>
+	public class AircraftInfo : IFacingInfo, IOccupySpaceInfo, ICruiseAltitudeInfo, UsesInit<LocationInit>, UsesInit<FacingInit>
 	{
 		public readonly WDist CruiseAltitude = new WDist(1280);
 		public readonly WDist IdealSeparation = new WDist(1706);

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Allows you to attach weapons to the unit (use @IdentifierSuffix for > 1)")]
-	public class ArmamentInfo : UpgradableTraitInfo, Requires<AttackBaseInfo>
+	public class ArmamentInfo : UpgradableTraitInfo, Requires<AttackBaseInfo>, InitializeAfter<AttackBaseInfo>
 	{
 		public readonly string Name = "primary";
 

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -24,7 +24,8 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Allows you to attach weapons to the unit (use @IdentifierSuffix for > 1)")]
-	public class ArmamentInfo : UpgradableTraitInfo, Requires<AttackBaseInfo>, InitializeAfter<AttackBaseInfo>
+	public class ArmamentInfo : UpgradableTraitInfo, Requires<AttackBaseInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<AttackBaseInfo>, InitializeAfter<AmmoPoolInfo>
 	{
 		public readonly string Name = "primary";
 
@@ -65,15 +66,15 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Armament(init.Self, this); }
 	}
 
-	public class Armament : UpgradableTrait<ArmamentInfo>, ITick, IExplodeModifier
+	public class Armament : UpgradableTrait<ArmamentInfo>, ITick, IExplodeModifier, INotifyCreated
 	{
 		public readonly WeaponInfo Weapon;
 		public readonly Barrel[] Barrels;
 
 		readonly Actor self;
-		Lazy<Turreted> turret;
-		Lazy<IBodyOrientation> coords;
-		Lazy<AmmoPool> ammoPool;
+		readonly AmmoPool ammoPool;
+		Turreted turret;
+		IBodyOrientation coords;
 		List<Pair<int, Action>> delayedActions = new List<Pair<int, Action>>();
 
 		public WDist Recoil;
@@ -85,10 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.self = self;
 
-			// We can't resolve these until runtime
-			turret = Exts.Lazy(() => self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == info.Turret));
-			coords = Exts.Lazy(() => self.Trait<IBodyOrientation>());
-			ammoPool = Exts.Lazy(() => self.TraitsImplementing<AmmoPool>().FirstOrDefault(la => la.Info.Name == info.AmmoPoolName));
+			ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault(la => la.Info.Name == info.AmmoPoolName);
 
 			Weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()];
 			Burst = Weapon.Burst;
@@ -107,6 +105,12 @@ namespace OpenRA.Mods.Common.Traits
 				barrels.Add(new Barrel { Offset = WVec.Zero, Yaw = WAngle.Zero });
 
 			Barrels = barrels.ToArray();
+		}
+
+		public void Created(Actor self)
+		{
+			turret = self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == Info.Turret);
+			coords = self.Trait<IBodyOrientation>();
 		}
 
 		public void Tick(Actor self)
@@ -145,7 +149,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsReloading)
 				return null;
 
-			if (ammoPool.Value != null && !ammoPool.Value.HasAmmo())
+			if (ammoPool != null && !ammoPool.HasAmmo())
 				return null;
 
 			if (!target.IsInRange(self.CenterPosition, Weapon.Range))
@@ -214,23 +218,23 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WVec MuzzleOffset(Actor self, Barrel b)
 		{
-			var bodyOrientation = coords.Value.QuantizeOrientation(self, self.Orientation);
+			var bodyOrientation = coords.QuantizeOrientation(self, self.Orientation);
 			var localOffset = b.Offset + new WVec(-Recoil, WDist.Zero, WDist.Zero);
-			if (turret.Value != null)
+			if (turret != null)
 			{
-				var turretOrientation = coords.Value.QuantizeOrientation(self, turret.Value.LocalOrientation(self));
+				var turretOrientation = coords.QuantizeOrientation(self, turret.LocalOrientation(self));
 				localOffset = localOffset.Rotate(turretOrientation);
-				localOffset += turret.Value.Offset;
+				localOffset += turret.Offset;
 			}
 
-			return coords.Value.LocalToWorld(localOffset.Rotate(bodyOrientation));
+			return coords.LocalToWorld(localOffset.Rotate(bodyOrientation));
 		}
 
 		public WRot MuzzleOrientation(Actor self, Barrel b)
 		{
 			var orientation = self.Orientation + WRot.FromYaw(b.Yaw);
-			if (turret.Value != null)
-				orientation += turret.Value.LocalOrientation(self);
+			if (turret != null)
+				orientation += turret.LocalOrientation(self);
 			return orientation;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Cargo can fire their weapons out of fire ports.")]
-	public class AttackGarrisonedInfo : AttackFollowInfo, Requires<CargoInfo>
+	public class AttackGarrisonedInfo : AttackFollowInfo, Requires<CargoInfo>, Requires<IBodyOrientationInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Fire port offsets in local coordinates.")]

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor has a visual turret used to attack.")]
-	public class AttackTurretedInfo : AttackFollowInfo, Requires<TurretedInfo>
+	public class AttackTurretedInfo : AttackFollowInfo, Requires<TurretedInfo>, InitializeAfter<TurretedInfo>
 	{
 		public override object Create(ActorInitializer init) { return new AttackTurreted(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackWander.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackWander.cs
@@ -14,7 +14,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Will AttackMove to a random location within MoveRadius when idle.",
 		"This conflicts with player orders and should only be added to animal creeps.")]
-	class AttackWanderInfo : WandersInfo, Requires<AttackMoveInfo>
+	class AttackWanderInfo : WandersInfo, Requires<AttackMoveInfo>, InitializeAfter<AttackMoveInfo>
 	{
 		public override object Create(ActorInitializer init) { return new AttackWander(init.Self, this); }
 	}
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackWander(Actor self, AttackWanderInfo info)
 			: base(self, info)
 		{
-			attackMove = self.TraitOrDefault<AttackMove>();
+			attackMove = self.Trait<AttackMove>();
 		}
 
 		public override void DoAction(Actor self, CPos targetCell)

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Provides access to the attack-move command, which will make the actor automatically engage viable targets while moving to the destination.")]
-	class AttackMoveInfo : ITraitInfo, Requires<IMoveInfo>
+	class AttackMoveInfo : ITraitInfo, Requires<IMoveInfo>, InitializeAfter<IMoveInfo>
 	{
 		[VoiceReference] public readonly string Voice = "Action";
 

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The actor will automatically engage the enemy when it is in range.")]
-	public class AutoTargetInfo : ITraitInfo, Requires<AttackBaseInfo>
+	public class AutoTargetInfo : ITraitInfo, Requires<AttackBaseInfo>, InitializeAfter<AttackBaseInfo>, InitializeAfter<AttackFollowInfo>
 	{
 		[Desc("It will try to hunt down the enemy if it is not set to defend.")]
 		public readonly bool AllowMovement = true;
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Traits
 			return inRange
 				.Where(a =>
 					a.AppearsHostileTo(self) &&
-					!a.HasTrait<AutoTargetIgnore>() &&
+					!a.Info.Traits.Contains<AutoTargetIgnoreInfo>() &&
 					attack.HasAnyValidWeapons(Target.FromActor(a)) &&
 					self.Owner.CanTargetActor(a))
 				.ClosestTo(self);

--- a/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
@@ -15,7 +15,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class BibInfo : ITraitInfo, Requires<BuildingInfo>, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
+	public class BibInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BuildingInfo>,
+		InitializeAfter<RenderSpritesInfo>
 	{
 		public readonly string Sequence = "bib";
 		public readonly string Palette = "terrain";

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class BridgeInfo : ITraitInfo, Requires<HealthInfo>, Requires<BuildingInfo>
+	class BridgeInfo : ITraitInfo, Requires<HealthInfo>, Requires<BuildingInfo>, InitializeAfter<HealthInfo>, InitializeAfter<BuildingInfo>
 	{
 		public readonly bool Long = false;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RefineryInfo : ITraitInfo
+	public class RefineryInfo : IAcceptResourcesInfo
 	{
 		[Desc("Actual harvester facing when docking, 0-255 counter-clock-wise.")]
 		public readonly int DockAngle = 0;

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Building can be repaired by the repair button.")]
-	public class RepairableBuildingInfo : UpgradableTraitInfo, Requires<HealthInfo>
+	public class RepairableBuildingInfo : UpgradableTraitInfo, Requires<HealthInfo>, InitializeAfter<HealthInfo>
 	{
 		public readonly int RepairPercent = 20;
 		public readonly int RepairInterval = 24;

--- a/OpenRA.Mods.Common/Traits/Buildings/TargetableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TargetableBuilding.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class TargetableBuildingInfo : ITraitInfo, ITargetableInfo, Requires<BuildingInfo>
+	public class TargetableBuildingInfo : ITraitInfo, ITargetableInfo, Requires<BuildingInfo>, InitializeAfter<BuildingInfo>
 	{
 		[FieldLoader.Require]
 		public readonly string[] TargetTypes = { };

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor will play a fire animation over its body and take damage over time.")]
-	class BurnsInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	class BurnsInfo : ITraitInfo, Requires<RenderSpritesInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		public readonly string Anim = "1";
 		public readonly int Damage = 1;

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can transport Passenger actors.")]
-	public class CargoInfo : ITraitInfo, Requires<IOccupySpaceInfo>
+	public class CargoInfo : ITraitInfo, Requires<IOccupySpaceInfo>, InitializeAfter<IFacingInfo>
 	{
 		[Desc("The maximum sum of Passenger.Weight that this actor can support.")]
 		public readonly int MaxWeight = 0;
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		readonly Stack<Actor> cargo = new Stack<Actor>();
 		readonly HashSet<Actor> reserves = new HashSet<Actor>();
-		readonly Lazy<IFacing> facing;
+		readonly IFacing facing;
 		readonly bool checkTerrainType;
 
 		int totalWeight = 0;
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 				totalWeight = cargo.Sum(c => GetWeight(c));
 			}
 
-			facing = Exts.Lazy(self.TraitOrDefault<IFacing>);
+			facing = self.TraitOrDefault<IFacing>();
 		}
 
 		public void Created(Actor self)
@@ -242,16 +242,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		void SetPassengerFacing(Actor passenger)
 		{
-			if (facing.Value == null)
+			if (facing == null)
 				return;
 
 			var passengerFacing = passenger.TraitOrDefault<IFacing>();
 			if (passengerFacing != null)
-				passengerFacing.Facing = facing.Value.Facing + Info.PassengerFacing;
+				passengerFacing.Facing = facing.Facing + Info.PassengerFacing;
 
 			var passengerTurreted = passenger.TraitOrDefault<Turreted>();
 			if (passengerTurreted != null)
-				passengerTurreted.TurretFacing = facing.Value.Facing + Info.PassengerFacing;
+				passengerTurreted.TurretFacing = facing.Facing + Info.PassengerFacing;
 		}
 
 		public IEnumerable<PipType> GetPips(Actor self)

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays fireports, muzzle offsets, and hit areas in developer mode.")]
-	public class CombatDebugOverlayInfo : ITraitInfo
+	public class CombatDebugOverlayInfo : ITraitInfo, InitializeAfter<AttackBaseInfo>, InitializeAfter<IBodyOrientationInfo>,
+		InitializeAfter<HealthInfo>
 	{
 		public object Create(ActorInitializer init) { return new CombatDebugOverlay(init.Self); }
 	}
@@ -26,15 +27,15 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly DeveloperMode devMode;
 
-		Lazy<AttackBase> attack;
-		Lazy<IBodyOrientation> coords;
-		Lazy<Health> health;
+		AttackBase attack;
+		IBodyOrientation coords;
+		Health health;
 
 		public CombatDebugOverlay(Actor self)
 		{
-			attack = Exts.Lazy(() => self.TraitOrDefault<AttackBase>());
-			coords = Exts.Lazy(() => self.Trait<IBodyOrientation>());
-			health = Exts.Lazy(() => self.TraitOrDefault<Health>());
+			attack = self.TraitOrDefault<AttackBase>();
+			coords = attack is AttackGarrisoned ? self.Trait<IBodyOrientation>() : null;
+			health = self.TraitOrDefault<Health>();
 
 			var localPlayer = self.World.LocalPlayer;
 			devMode = localPlayer != null ? localPlayer.PlayerActor.Trait<DeveloperMode>() : null;
@@ -45,26 +46,26 @@ namespace OpenRA.Mods.Common.Traits
 			if (devMode == null || !devMode.ShowCombatGeometry)
 				return;
 
-			if (health.Value != null)
-				wr.DrawRangeCircle(self.CenterPosition, health.Value.Info.Radius, Color.Red);
+			if (health != null)
+				wr.DrawRangeCircle(self.CenterPosition, health.Info.Radius, Color.Red);
 
 			// No armaments to draw
-			if (attack.Value == null)
+			if (attack == null)
 				return;
 
 			var wlr = Game.Renderer.WorldLineRenderer;
 			var c = Color.White;
 
 			// Fire ports on garrisonable structures
-			var garrison = attack.Value as AttackGarrisoned;
+			var garrison = attack as AttackGarrisoned;
 			if (garrison != null)
 			{
-				var bodyOrientation = coords.Value.QuantizeOrientation(self, self.Orientation);
+				var bodyOrientation = coords.QuantizeOrientation(self, self.Orientation);
 				foreach (var p in garrison.Ports)
 				{
-					var pos = self.CenterPosition + coords.Value.LocalToWorld(p.Offset.Rotate(bodyOrientation));
-					var da = coords.Value.LocalToWorld(new WVec(224, 0, 0).Rotate(WRot.FromYaw(p.Yaw + p.Cone)).Rotate(bodyOrientation));
-					var db = coords.Value.LocalToWorld(new WVec(224, 0, 0).Rotate(WRot.FromYaw(p.Yaw - p.Cone)).Rotate(bodyOrientation));
+					var pos = self.CenterPosition + coords.LocalToWorld(p.Offset.Rotate(bodyOrientation));
+					var da = coords.LocalToWorld(new WVec(224, 0, 0).Rotate(WRot.FromYaw(p.Yaw + p.Cone)).Rotate(bodyOrientation));
+					var db = coords.LocalToWorld(new WVec(224, 0, 0).Rotate(WRot.FromYaw(p.Yaw - p.Cone)).Rotate(bodyOrientation));
 
 					var o = wr.ScreenPosition(pos);
 					var a = wr.ScreenPosition(pos + da * 224 / da.Length);
@@ -76,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 			}
 
-			foreach (var a in attack.Value.Armaments)
+			foreach (var a in attack.Armaments)
 			{
 				foreach (var b in a.Barrels)
 				{

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class CrateActionInfo : ITraitInfo
+	public class CrateActionInfo : ITraitInfo, Requires<CrateInfo>
 	{
 		[Desc("Chance of getting this crate, assuming the collector is compatible.")]
 		public readonly int SelectionShares = 10;

--- a/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Visualize the remaining CaptureCompleteTime from ExternalCapturable: trait.")]
-	class ExternalCapturableBarInfo : ITraitInfo, Requires<ExternalCapturableInfo>
+	class ExternalCapturableBarInfo : ITraitInfo, Requires<ExternalCapturableInfo>, InitializeAfter<ExternalCapturableInfo>
 	{
 		public object Create(ActorInitializer init) { return new ExternalCapturableBar(init.Self); }
 	}

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor's experience increases when it has killed a GivesExperience actor.")]
-	public class GainsExperienceInfo : ITraitInfo, Requires<ValuedInfo>, Requires<UpgradeManagerInfo>
+	public class GainsExperienceInfo : ITraitInfo, Requires<ValuedInfo>, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[FieldLoader.LoadUsing("LoadUpgrades", true)]
 		[Desc("Upgrades to grant at each level.",

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor's experience increases when it has killed a GivesExperience actor.")]
-	public class GainsExperienceInfo : ITraitInfo, Requires<ValuedInfo>, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
+	public class GainsExperienceInfo : ITraitInfo, Requires<ValuedInfo>, RequiresSingleton<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[FieldLoader.LoadUsing("LoadUpgrades", true)]
 		[Desc("Upgrades to grant at each level.",

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("You get money for playing this actor.")]
-	class GivesBountyInfo : TraitInfo<GivesBounty>
+	class GivesBountyInfo : TraitInfo<GivesBounty>, InitializeAfter<GainsExperienceInfo>
 	{
 		[Desc("Calculated by Cost or CustomSellValue so they have to be set to avoid crashes.")]
 		public readonly int Percentage = 10;

--- a/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
+++ b/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants upgrades to the actor this is attached to when prerequisites are available.")]
-	public class GlobalUpgradableInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	public class GlobalUpgradableInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[UpgradeGrantedReference, FieldLoader.Require]
 		[Desc("List of upgrades to apply.")]

--- a/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
+++ b/OpenRA.Mods.Common/Traits/GlobalUpgradable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants upgrades to the actor this is attached to when prerequisites are available.")]
-	public class GlobalUpgradableInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
+	public class GlobalUpgradableInfo : ITraitInfo, RequiresSingleton<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[UpgradeGrantedReference, FieldLoader.Require]
 		[Desc("List of upgrades to apply.")]

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class HarvesterInfo : ITraitInfo, Requires<MobileInfo>
+	public class HarvesterInfo : ITraitInfo, Requires<MobileInfo>, InitializeAfter<MobileInfo>
 	{
 		public readonly string[] DeliveryBuildings = { };
 

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Makes the unit automatically run around when taking damage.")]
-	class ScaredyCatInfo : ITraitInfo, Requires<MobileInfo>
+	class ScaredyCatInfo : ITraitInfo, Requires<MobileInfo>, InitializeAfter<MobileInfo>
 	{
 		[Desc("How long (in ticks) the actor should panic for.")]
 		public readonly int PanicLength = 25 * 10;

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -12,7 +12,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class KillsSelfInfo : UpgradableTraitInfo
+	class KillsSelfInfo : UpgradableTraitInfo, InitializeAfter<HealthInfo>
 	{
 		[Desc("Remove the actor from the world (and destroy it) instead of killing it.")]
 		public readonly bool RemoveInstead = false;

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor will remain visible (but not updated visually) under fog, once discovered.")]
-	public class FrozenUnderFogInfo : ITraitInfo, IDefaultVisibilityInfo, Requires<BuildingInfo>, InitializeAfter<BuildingInfo>
+	public class FrozenUnderFogInfo : ITraitInfo, IDefaultVisibilityInfo, Requires<BuildingInfo>,
+		InitializeAfter<ITooltipInfo>, InitializeAfter<HealthInfo>
 	{
 		public readonly bool StartsRevealed = false;
 
@@ -35,8 +36,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool startsRevealed;
 		readonly PPos[] footprint;
 
-		readonly Lazy<IToolTip> tooltip;
-		readonly Lazy<Health> health;
+		readonly IToolTip tooltip;
+		readonly Health health;
 
 		readonly Dictionary<Player, bool> visible;
 		readonly Dictionary<Player, FrozenActor> frozen;
@@ -53,8 +54,8 @@ namespace OpenRA.Mods.Common.Traits
 			startsRevealed = info.StartsRevealed && !init.Contains<ParentActorInit>();
 			var footprintCells = FootprintUtils.Tiles(init.Self).ToList();
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
-			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<IToolTip>().FirstOrDefault());
-			health = Exts.Lazy(() => init.Self.TraitOrDefault<Health>());
+			tooltip = init.Self.TraitsImplementing<IToolTip>().FirstOrDefault();
+			health = init.Self.TraitOrDefault<Health>();
 
 			frozen = new Dictionary<Player, FrozenActor>();
 			visible = init.World.Players.ToDictionary(p => p, p => false);
@@ -99,16 +100,16 @@ namespace OpenRA.Mods.Common.Traits
 
 				frozenActor.Owner = self.Owner;
 
-				if (health.Value != null)
+				if (health != null)
 				{
-					frozenActor.HP = health.Value.HP;
-					frozenActor.DamageState = health.Value.DamageState;
+					frozenActor.HP = health.HP;
+					frozenActor.DamageState = health.DamageState;
 				}
 
-				if (tooltip.Value != null)
+				if (tooltip != null)
 				{
-					frozenActor.TooltipInfo = tooltip.Value.TooltipInfo;
-					frozenActor.TooltipOwner = tooltip.Value.Owner;
+					frozenActor.TooltipInfo = tooltip.TooltipInfo;
+					frozenActor.TooltipOwner = tooltip.Owner;
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor will remain visible (but not updated visually) under fog, once discovered.")]
-	public class FrozenUnderFogInfo : ITraitInfo, Requires<BuildingInfo>, IDefaultVisibilityInfo
+	public class FrozenUnderFogInfo : ITraitInfo, IDefaultVisibilityInfo, Requires<BuildingInfo>, InitializeAfter<BuildingInfo>
 	{
 		public readonly bool StartsRevealed = false;
 

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This unit can spawn and eject other actors while flying.")]
-	public class ParaDropInfo : ITraitInfo, Requires<CargoInfo>
+	public class ParaDropInfo : ITraitInfo, Requires<CargoInfo>, InitializeAfter<CargoInfo>
 	{
 		[Desc("Distance around the drop-point to unload troops.")]
 		public readonly WDist DropRange = WDist.FromCells(4);

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Can be paradropped by a ParaDrop actor.")]
-	class ParachutableInfo : ITraitInfo
+	class ParachutableInfo : ITraitInfo, InitializeAfter<IPositionableInfo>
 	{
 		[Desc("If we land on invalid terrain for my actor type should we be killed?")]
 		public readonly bool KilledOnImpassableTerrain = true;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -17,7 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to the player actor (not a building!) to define a new shared build queue.",
 		"Will only work together with the Production: trait on the actor that actually does the production.",
 		"You will also want to add PrimaryBuildings: to let the user choose where new units should exit.")]
-	public class ClassicProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PowerManagerInfo>, Requires<PlayerResourcesInfo>
+	public class ClassicProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PowerManagerInfo>, Requires<PlayerResourcesInfo>,
+		InitializeAfter<TechTreeInfo>, InitializeAfter<PlayerResourcesInfo>, InitializeAfter<PowerManagerInfo>
 	{
 		[Desc("If you build more actors of the same type,", "the same queue will get its build time lowered for every actor produced there.")]
 		public readonly bool SpeedUp = false;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		"Will only work together with the Production: trait on the actor that actually does the production.",
 		"You will also want to add PrimaryBuildings: to let the user choose where new units should exit.")]
 	public class ClassicProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PowerManagerInfo>, Requires<PlayerResourcesInfo>,
-		InitializeAfter<TechTreeInfo>, InitializeAfter<PlayerResourcesInfo>, InitializeAfter<PowerManagerInfo>
+		InitializeAfter<PlayerResourcesInfo>, InitializeAfter<PowerManagerInfo>
 	{
 		[Desc("If you build more actors of the same type,", "the same queue will get its build time lowered for every actor produced there.")]
 		public readonly bool SpeedUp = false;

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ConquestVictoryConditionsInfo : ITraitInfo, Requires<MissionObjectivesInfo>
+	public class ConquestVictoryConditionsInfo : ITraitInfo, Requires<MissionObjectivesInfo>, InitializeAfter<MissionObjectivesInfo>
 	{
 		[Desc("Delay for the end game notification in milliseconds.")]
 		public readonly int NotificationDelay = 1500;

--- a/OpenRA.Mods.Common/Traits/Player/GlobalUpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GlobalUpgradeManager.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
-	public class GlobalUpgradeManagerInfo : ITraitInfo, Requires<TechTreeInfo>
+	public class GlobalUpgradeManagerInfo : ITraitInfo, Requires<TechTreeInfo>, InitializeAfter<TechTreeInfo>
 	{
 		public object Create(ActorInitializer init) { return new GlobalUpgradeManager(init); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class StrategicPoint { }
 
 	[Desc("Allows King of the Hill (KotH) style gameplay.")]
-	public class StrategicVictoryConditionsInfo : ITraitInfo, Requires<MissionObjectivesInfo>
+	public class StrategicVictoryConditionsInfo : ITraitInfo, Requires<MissionObjectivesInfo>, InitializeAfter<MissionObjectivesInfo>
 	{
 		[Desc("Amount of time (in game ticks) that the player has to hold all the strategic points.", "Defaults to 5 minutes.")]
 		public readonly int TicksToHold = 25 * 60 * 5;

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PluggableInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
+	public class PluggableInfo : ITraitInfo, RequiresSingleton<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[Desc("Footprint cell offset where a plug can be placed.")]
 		public readonly CVec Offset = CVec.Zero;

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PluggableInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	public class PluggableInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[Desc("Footprint cell offset where a plug can be placed.")]
 		public readonly CVec Offset = CVec.Zero;

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>
+	public class PowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>, InitializeAfter<DeveloperModeInfo>
 	{
 		public readonly int AdviceInterval = 250;
 		public readonly string SpeechNotification = "LowPower";

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>, InitializeAfter<DeveloperModeInfo>
+	public class PowerManagerInfo : IImplicitSingletonTraitInfo, Requires<DeveloperModeInfo>, InitializeAfter<DeveloperModeInfo>
 	{
 		public readonly int AdviceInterval = 250;
 		public readonly string SpeechNotification = "LowPower";

--- a/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
@@ -13,7 +13,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Scale power amount with the current health.")]
-	public class ScalePowerWithHealthInfo : ITraitInfo, Requires<PowerInfo>, Requires<HealthInfo>
+	public class ScalePowerWithHealthInfo : ITraitInfo, Requires<PowerInfo>, Requires<HealthInfo>,
+		InitializeAfter<PowerInfo>, InitializeAfter<HealthInfo>
 	{
 		public object Create(ActorInitializer init) { return new ScalePowerWithHealth(init.Self); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Hovers(HoversInfo info, Actor self)
 		{
 			this.info = info;
-			aircraft = self.HasTrait<Aircraft>();
+			aircraft = self.Info.Traits.Contains<Aircraft>();
 		}
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)

--- a/OpenRA.Mods.Common/Traits/Render/RenderBuildingTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderBuildingTurreted.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class RenderBuildingTurretedInfo : RenderBuildingInfo, Requires<TurretedInfo>
+	class RenderBuildingTurretedInfo : RenderBuildingInfo, Requires<TurretedInfo>, InitializeAfter<TurretedInfo>
 	{
 		public override object Create(ActorInitializer init) { return new RenderBuildingTurreted(init, this); }
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Draw a circle indicating my weapon's range.")]
-	class RenderRangeCircleInfo : ITraitInfo, IPlaceBuildingDecoration, Requires<AttackBaseInfo>
+	class RenderRangeCircleInfo : ITraitInfo, IPlaceBuildingDecoration, Requires<AttackBaseInfo>, InitializeAfter<AttackBaseInfo>
 	{
 		public readonly string RangeCircleType = null;
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p);
 	}
 
-	public class RenderVoxelsInfo : ITraitInfo, IRenderActorPreviewInfo, Requires<IBodyOrientationInfo>
+	public class RenderVoxelsInfo : ITraitInfo, IRenderActorPreviewInfo, Requires<IBodyOrientationInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Defaults to the actor name.")]
 		public readonly string Image = null;

--- a/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Visualizes the remaining time for an upgrade.")]
-	class TimedUpgradeBarInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	class TimedUpgradeBarInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Upgrade that this bar corresponds to")]
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new TimedUpgradeBar(init.Self, this); }
 	}
 
-	class TimedUpgradeBar : ISelectionBar, INotifyCreated
+	class TimedUpgradeBar : ISelectionBar
 	{
 		readonly TimedUpgradeBarInfo info;
 		readonly Actor self;
@@ -37,10 +37,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.self = self;
 			this.info = info;
-		}
-
-		public void Created(Actor self)
-		{
 			self.Trait<UpgradeManager>().RegisterWatcher(info.Upgrade, Update);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Visualizes the remaining time for an upgrade.")]
-	class TimedUpgradeBarInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
+	class TimedUpgradeBarInfo : ITraitInfo, RequiresSingleton<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Upgrade that this bar corresponds to")]

--- a/OpenRA.Mods.Common/Traits/Render/WithActiveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithActiveAnimation.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Replaces the idle animation of a building.")]
-	public class WithActiveAnimationInfo : ITraitInfo, Requires<RenderBuildingInfo>
+	public class WithActiveAnimationInfo : ITraitInfo, Requires<RenderBuildingInfo>, InitializeAfter<RenderBuildingInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -13,7 +13,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithAttackAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
+	public class WithAttackAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>,
+		InitializeAfter<WithSpriteBodyInfo>, InitializeAfter<ArmamentInfo>, InitializeAfter<AttackBaseInfo>
 	{
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";

--- a/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders barrels for units with the Turreted trait.")]
-	class WithBarrelInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	class WithBarrelInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>, InitializeAfter<ArmamentInfo>, InitializeAfter<TurretedInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "barrel";

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Changes the animation when the actor constructed a building.")]
-	public class WithBuildingPlacedAnimationInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	public class WithBuildingPlacedAnimationInfo : ITraitInfo, Requires<RenderSimpleInfo>, InitializeAfter<RenderSimpleInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "build";
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			renderSimple = self.Trait<RenderSimple>();
-			buildComplete = !self.HasTrait<Building>();
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>();
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -14,7 +14,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Rendered when the actor constructed a building.")]
-	public class WithBuildingPlacedOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithBuildingPlacedOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "crane-overlay";
@@ -41,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<IBodyOrientation>();
 
-			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
 
 			overlay = new Animation(self.World, rs.GetImage(self));
 

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Rendered together with AttackCharge.")]
-	public class WithChargeOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithChargeOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders crates with both water and land variants.")]
-	class WithCrateBodyInfo : ITraitInfo, Requires<RenderSpritesInfo>, IQuantizeBodyOrientationInfo, IRenderActorPreviewSpritesInfo
+	class WithCrateBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewSpritesInfo,
+		Requires<RenderSpritesInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		[Desc("Easteregg sequences to use in december.")]
 		public readonly string[] XmasImages = { };

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor has a death animation.")]
-	public class WithDeathAnimationInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithDeathAnimationInfo : ITraitInfo, Requires<RenderSpritesInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		[Desc("Sequence prefix to play when this actor is killed by a warhead.")]
 		[SequenceReference(null, true)] public readonly string DeathSequence = "die";

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
@@ -15,7 +15,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Rendered when a harvester is docked.")]
-	public class WithDockingOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithDockingOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "docking-overlay";

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -13,7 +13,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithHarvestAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
+	public class WithHarvestAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>,
+		InitializeAfter<WithSpriteBodyInfo>, InitializeAfter<HarvesterInfo>
 	{
 		[Desc("Prefix added to idle and harvest sequences depending on fullness of harvester.")]
 		[SequenceReference(null, true)] public readonly string[] PrefixByFullness = { "" };

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -15,7 +15,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays an overlay whenever resources are harvested by the actor.")]
-	class WithHarvestOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	class WithHarvestOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "harvest";

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders a decorative animation on units and buildings.")]
-	public class WithIdleOverlayInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithIdleOverlayInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Animation to play when the actor is created.")]
 		[SequenceReference] public readonly string StartSequence = null;

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	public class WithInfantryBodyInfo : UpgradableTraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewSpritesInfo,
-		Requires<IMoveInfo>, Requires<RenderSpritesInfo>
+		Requires<IMoveInfo>, Requires<RenderSpritesInfo>, InitializeAfter<IMoveInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		public readonly int MinIdleWaitTicks = 30;
 		public readonly int MaxIdleWaitTicks = 110;

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Replaces the sprite during construction.")]
-	public class WithMakeAnimationInfo : ITraitInfo, Requires<BuildingInfo>, Requires<RenderBuildingInfo>
+	public class WithMakeAnimationInfo : ITraitInfo, Requires<BuildingInfo>, Requires<RenderBuildingInfo>,
+		InitializeAfter<BuildingInfo>, InitializeAfter<RenderBuildingInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "make";

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -13,7 +13,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithMoveAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<IMoveInfo>
+	public class WithMoveAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<IMoveInfo>,
+		InitializeAfter<WithSpriteBodyInfo>, InitializeAfter<IMoveInfo>
 	{
 		[Desc("Displayed while moving.")]
 		[SequenceReference] public readonly string MoveSequence = "move";

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleFlash.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleFlash.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders the MuzzleSequence from the Armament trait.")]
-	class WithMuzzleFlashInfo : UpgradableTraitInfo, Requires<RenderSpritesInfo>, Requires<AttackBaseInfo>, Requires<ArmamentInfo>
+	class WithMuzzleFlashInfo : UpgradableTraitInfo, Requires<RenderSpritesInfo>, Requires<AttackBaseInfo>, Requires<ArmamentInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IFacingInfo>, InitializeAfter<ArmamentInfo>
 	{
 		[Desc("Ignore the weapon position, and always draw relative to the center of the actor")]
 		public readonly bool IgnoreOffset = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -17,7 +17,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders a parachute on units.")]
-	public class WithParachuteInfo : UpgradableTraitInfo, ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithParachuteInfo : UpgradableTraitInfo, ITraitInfo, IRenderActorPreviewSpritesInfo,
+		Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("The image that contains the parachute sequences.")]
 		public readonly string Image = null;

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.TS.Traits
 {
 	[Desc("Play an animation when a unit exits or blocks the exit after production finished.")]
-	class WithProductionDoorOverlayInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>, Requires<BuildingInfo>
+	class WithProductionDoorOverlayInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>, Requires<BuildingInfo>,
+		InitializeAfter<RenderSpritesInfo>
 	{
 		public readonly string Sequence = "build-door";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -17,7 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders an animation when the Production trait of the actor is activated.",
 		"Works both with per player ClassicProductionQueue and per building ProductionQueue, but needs any of these.")]
-	public class WithProductionOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithProductionOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "production-overlay";
@@ -50,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<IBodyOrientation>();
 
-			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
 
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.PlayRepeating(info.Sequence);

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -16,7 +16,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays an overlay when the building is being repaired by the player.")]
-	public class WithRepairOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithRepairOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";

--- a/OpenRA.Mods.Common/Traits/Render/WithResources.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResources.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays the fill status of PlayerResources with an extra sprite overlay on the actor.")]
-	class WithResourcesInfo : ITraitInfo, Requires<RenderSimpleInfo>
+	class WithResourcesInfo : ITraitInfo, Requires<RenderSimpleInfo>, InitializeAfter<RenderSimpleInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "resources";

--- a/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays a helicopter rotor overlay.")]
-	public class WithRotorInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithRotorInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>, Requires<IMoveInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>, InitializeAfter<IMoveInfo>
 	{
 		[Desc("Sequence name to use when flying")]
 		[SequenceReference] public readonly string Sequence = "rotor";

--- a/OpenRA.Mods.Common/Traits/Render/WithSmoke.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSmoke.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders an overlay when the actor is taking heavy damage.")]
-	public class WithSmokeInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithSmokeInfo : ITraitInfo, Requires<RenderSpritesInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		public readonly string Sequence = "smoke_m";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Default trait for rendering sprite-based actors.")]
 	public class WithSpriteBodyInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, IQuantizeBodyOrientationInfo,
-		Requires<RenderSpritesInfo>
+		Requires<RenderSpritesInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		[Desc("Animation to play when the actor is created.")]
 		[SequenceReference] public readonly string StartSequence = null;

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -18,7 +18,9 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders turrets for units with the Turreted trait.")]
 	public class WithTurretInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo,
-		Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<IBodyOrientationInfo>
+		Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<TurretedInfo>, InitializeAfter<IBodyOrientationInfo>,
+		InitializeAfter<AttackBaseInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "turret";

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -16,7 +16,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithVoxelBarrelInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<ArmamentInfo>, Requires<TurretedInfo>
+	public class WithVoxelBarrelInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo,
+		Requires<RenderVoxelsInfo>, Requires<ArmamentInfo>, Requires<TurretedInfo>,
+		InitializeAfter<RenderVoxelsInfo>, InitializeAfter<IBodyOrientationInfo>, InitializeAfter<ArmamentInfo>, InitializeAfter<TurretedInfo>
 	{
 		[Desc("Voxel sequence name to use")]
 		public readonly string Sequence = "barrel";

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -18,7 +18,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Also returns a default selection size that is calculated automatically from the voxel dimensions.")]
-	public class WithVoxelBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
+	public class WithVoxelBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo,
+		Requires<RenderVoxelsInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderVoxelsInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		public readonly string Sequence = "idle";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -16,7 +16,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithVoxelTurretInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, Requires<TurretedInfo>
+	public class WithVoxelTurretInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo,
+		Requires<RenderVoxelsInfo>, Requires<IBodyOrientationInfo>, Requires<TurretedInfo>,
+		InitializeAfter<RenderVoxelsInfo>, InitializeAfter<IBodyOrientationInfo>, InitializeAfter<TurretedInfo>
 	{
 		[Desc("Voxel sequence name to use")]
 		public readonly string Sequence = "turret";

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be sent to a structure for repairs.")]
-	class RepairableInfo : ITraitInfo, Requires<HealthInfo>
+	class RepairableInfo : ITraitInfo, Requires<HealthInfo>, InitializeAfter<HealthInfo>, InitializeAfter<AmmoPoolInfo>
 	{
 		public readonly string[] RepairBuildings = { "fix" };
 

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class RepairableNearInfo : ITraitInfo, Requires<HealthInfo>, Requires<IMoveInfo>
+	class RepairableNearInfo : ITraitInfo, Requires<HealthInfo>, Requires<IMoveInfo>, InitializeAfter<IMoveInfo>
 	{
 		[ActorReference] public readonly string[] Buildings = { "spen", "syrd" };
 		public readonly int CloseEnough = 4;	/* cells */

--- a/OpenRA.Mods.Common/Traits/SelfHealing.cs
+++ b/OpenRA.Mods.Common/Traits/SelfHealing.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to actors which should be able to regenerate their health points.")]
-	class SelfHealingInfo : UpgradableTraitInfo, Requires<HealthInfo>
+	class SelfHealingInfo : UpgradableTraitInfo, Requires<HealthInfo>, InitializeAfter<HealthInfo>
 	{
 		public readonly int Step = 5;
 		public readonly int Ticks = 5;

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can be sold")]
-	public class SellableInfo : UpgradableTraitInfo
+	public class SellableInfo : UpgradableTraitInfo, InitializeAfter<HealthInfo>
 	{
 		public readonly int RefundPercent = 50;
 		public readonly string[] SellSounds = { };
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class Sellable : UpgradableTrait<SellableInfo>, IResolveOrder, IProvideTooltipInfo
 	{
 		readonly Actor self;
-		readonly Lazy<Health> health;
+		readonly Health health;
 		readonly SellableInfo info;
 
 		public Sellable(Actor self, SellableInfo info)
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.self = self;
 			this.info = info;
-			health = Exts.Lazy(() => self.TraitOrDefault<Health>());
+			health = self.TraitOrDefault<Health>();
 		}
 
 		public void ResolveOrder(Actor self, Order order)
@@ -81,10 +81,10 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				var sellValue = self.GetSellValue() * info.RefundPercent / 100;
-				if (health.Value != null)
+				if (health != null)
 				{
-					sellValue *= health.Value.HP;
-					sellValue /= health.Value.MaxHP;
+					sellValue *= health.HP;
+					sellValue /= health.MaxHP;
 				}
 
 				return "Refund: $" + sellValue;

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<IBodyOrientationInfo>
+	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<IBodyOrientationInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class NukePowerInfo : SupportPowerInfo, Requires<IBodyOrientationInfo>
+	class NukePowerInfo : SupportPowerInfo, Requires<IBodyOrientationInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[WeaponReference]
 		public readonly string MissileWeapon = "";

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -17,7 +17,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
-	public class SupportPowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>, Requires<TechTreeInfo>
+	public class SupportPowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>, Requires<TechTreeInfo>,
+		InitializeAfter<DeveloperModeInfo>, InitializeAfter<TechTreeInfo>
 	{
 		public object Create(ActorInitializer init) { return new SupportPowerManager(init); }
 	}

--- a/OpenRA.Mods.Common/Traits/TargetableUnit.cs
+++ b/OpenRA.Mods.Common/Traits/TargetableUnit.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can be targeted.")]
-	public class TargetableUnitInfo : UpgradableTraitInfo, ITargetableInfo
+	public class TargetableUnitInfo : UpgradableTraitInfo, ITargetableInfo, InitializeAfter<CloakInfo>
 	{
 		[Desc("Target type. Used for filtering (in)valid targets.")]
 		public readonly string[] TargetTypes = { };

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -13,7 +13,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class ThrowsParticleInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<IBodyOrientationInfo>
+	class ThrowsParticleInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[FieldLoader.Require]
 		public readonly string Anim = null;

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class DeployToUpgradeInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	public class DeployToUpgradeInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[UpgradeGrantedReference, FieldLoader.Require]
 		[Desc("The upgrades to grant when deploying and revoke when undeploying.")]

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class DeployToUpgradeInfo : ITraitInfo, Requires<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
+	public class DeployToUpgradeInfo : ITraitInfo, RequiresSingleton<UpgradeManagerInfo>, InitializeAfter<UpgradeManagerInfo>
 	{
 		[UpgradeGrantedReference, FieldLoader.Require]
 		[Desc("The upgrades to grant when deploying and revoke when undeploying.")]

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	/// <summary>Use as base class for *Info to subclass of UpgradableTrait. (See UpgradableTrait.)</summary>
-	public abstract class UpgradableTraitInfo : IUpgradableInfo
+	public abstract class UpgradableTraitInfo : IUpgradableInfo, RequiresSingleton<UpgradeManagerInfo>
 	{
 		[UpgradeUsedReference]
 		[Desc("The upgrade types which can enable or disable this trait.")]

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to a unit to enable dynamic upgrades by warheads, experience, crates, support powers, etc.")]
-	public class UpgradeManagerInfo : ITraitInfo, Requires<IUpgradableInfo>
+	public class UpgradeManagerInfo : ITraitInfo, InitializeAfter<IUpgradableInfo>
 	{
 		public object Create(ActorInitializer init) { return new UpgradeManager(init); }
 	}

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
@@ -69,20 +69,15 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		readonly List<TimedUpgrade> timedUpgrades = new List<TimedUpgrade>();
-		readonly Lazy<Dictionary<string, UpgradeState>> upgrades;
+		readonly Dictionary<string, UpgradeState> upgrades;
 		readonly Dictionary<IUpgradable, int> levels = new Dictionary<IUpgradable, int>();
 
 		public UpgradeManager(ActorInitializer init)
 		{
-			upgrades = Exts.Lazy(() =>
-			{
-				var ret = new Dictionary<string, UpgradeState>();
-				foreach (var up in init.Self.TraitsImplementing<IUpgradable>())
-					foreach (var t in up.UpgradeTypes)
-						ret.GetOrAdd(t).Traits.Add(up);
-
-				return ret;
-			});
+			upgrades = new Dictionary<string, UpgradeState>();
+			foreach (var up in init.Self.TraitsImplementing<IUpgradable>())
+				foreach (var t in up.UpgradeTypes)
+					upgrades.GetOrAdd(t).Traits.Add(up);
 		}
 
 		/// <summary>Upgrade level increments are limited to one per source, i.e., if a single source
@@ -142,7 +137,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void GrantUpgrade(Actor self, string upgrade, object source)
 		{
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return;
 
 			// Track the upgrade source so that the upgrade can be removed without conflicts
@@ -154,7 +149,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void RevokeUpgrade(Actor self, string upgrade, object source)
 		{
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return;
 
 			if (!s.Sources.Remove(source))
@@ -166,14 +161,14 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>Returns true if the actor uses the given upgrade. Does not check the actual level of the upgrade.</summary>
 		public bool AcknowledgesUpgrade(Actor self, string upgrade)
 		{
-			return upgrades.Value.ContainsKey(upgrade);
+			return upgrades.ContainsKey(upgrade);
 		}
 
 		/// <summary>Returns true only if the actor can accept another level of the upgrade.</summary>
 		public bool AcceptsUpgrade(Actor self, string upgrade)
 		{
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return false;
 
 			return s.Traits.Any(up => up.AcceptsUpgradeLevel(self, upgrade, GetOverallLevel(up) + 1));
@@ -182,7 +177,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void RegisterWatcher(string upgrade, Action<int, int> action)
 		{
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return;
 
 			s.Watchers.Add(action);
@@ -203,7 +198,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				u.Sources.RemoveWhere(source => source.Remaining <= 0);
 
-				foreach (var a in upgrades.Value[u.Upgrade].Watchers)
+				foreach (var a in upgrades[u.Upgrade].Watchers)
 					a(u.Duration, u.Remaining);
 			}
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to a unit to enable dynamic upgrades by warheads, experience, crates, support powers, etc.")]
-	public class UpgradeManagerInfo : ITraitInfo, InitializeAfter<IUpgradableInfo>
+	public class UpgradeManagerInfo : IImplicitSingletonTraitInfo, InitializeAfter<IUpgradableInfo>
 	{
 		public object Create(ActorInitializer init) { return new UpgradeManager(init); }
 	}

--- a/OpenRA.Mods.Common/Traits/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/VeteranProductionIconOverlay.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to the player actor. When attached, enables all actors possessing the LevelupWhenCreated ",
 		"trait to have their production queue icons render with an overlay defined in this trait. ",
 		"The icon change occurs when LevelupWhenCreated.Prerequisites are met.")]
-	public class VeteranProductionIconOverlayInfo : ITraitInfo, Requires<TechTreeInfo>
+	public class VeteranProductionIconOverlayInfo : ITraitInfo, Requires<TechTreeInfo>, InitializeAfter<TechTreeInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Image used for the overlay.")]

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the world actor.", "Order of the layers defines the Z sorting.")]
-	public class ResourceLayerInfo : ITraitInfo, Requires<ResourceTypeInfo>, Requires<BuildingInfluenceInfo>
+	public class ResourceLayerInfo : ITraitInfo, Requires<ResourceTypeInfo>, Requires<BuildingInfluenceInfo>,
+		InitializeAfter<BuildingInfluenceInfo>
 	{
 		public virtual object Create(ActorInitializer init) { return new ResourceLayer(init.Self); }
 	}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyChat { bool OnChat(string from, string message); }
 	public interface INotifyParachuteLanded { void OnLanded(); }
 	public interface IRenderActorPreviewInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
-	public interface ICruiseAltitudeInfo { WDist GetCruiseAltitude(); }
+	public interface ICruiseAltitudeInfo : ISingletonTraitInfo { WDist GetCruiseAltitude(); }
 
 	public interface IUpgradable
 	{
@@ -86,6 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface INotifyTransform { void BeforeTransform(Actor self); void OnTransform(Actor self); void AfterTransform(Actor toActor); }
 
+	public interface IAcceptResourcesInfo : ISingletonTraitInfo { }
 	public interface IAcceptResources
 	{
 		void OnDock(Actor harv, DeliverResources dockOrder);

--- a/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Reduces health points over time when the actor is placed on unsafe terrain.")]
-	class DamagedWithoutFoundationInfo : ITraitInfo, Requires<HealthInfo>
+	class DamagedWithoutFoundationInfo : ITraitInfo, Requires<HealthInfo>, InitializeAfter<HealthInfo>
 	{
 		[WeaponReference]
 		public readonly string Weapon = "weathering";

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Automatically transports harvesters with the Carryable trait between resource fields and refineries.")]
-	public class CarryallInfo : ITraitInfo, Requires<IBodyOrientationInfo>
+	public class CarryallInfo : ITraitInfo, Requires<IBodyOrientationInfo>, Requires<HelicopterInfo>, InitializeAfter<HelicopterInfo>
 	{
 		[Desc("Set to false when the carryall should not automatically get new jobs.")]
 		public readonly bool Automatic = true;

--- a/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithAttackOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Rendered together with an attack.")]
-	public class WithAttackOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithAttackOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, InitializeAfter<RenderSpritesInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Sequence name to use")]

--- a/OpenRA.Mods.D2k/Traits/Render/WithDecorationCarryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDecorationCarryable.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Displays a sprite when the carryable actor is waiting for pickup.")]
-	public class WithDecorationCarryableInfo : WithDecorationInfo, Requires<CarryableInfo>
+	public class WithDecorationCarryableInfo : WithDecorationInfo, Requires<CarryableInfo>, InitializeAfter<CarryableInfo>
 	{
 		public override object Create(ActorInitializer init) { return new WithDecorationCarryable(init.Self, this); }
 	}

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -16,7 +16,8 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Rendered when ProductionAirdrop is in progress.")]
-	public class WithDeliveryOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithDeliveryOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderSpritesInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
@@ -49,7 +50,7 @@ namespace OpenRA.Mods.D2k.Traits
 			var body = self.Trait<IBodyOrientation>();
 
 			// always render instantly for units
-			buildComplete = !self.HasTrait<Building>();
+			buildComplete = !self.Info.Traits.Contains<Building>();
 
 			var overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -15,7 +15,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
-	class SandwormInfo : WandersInfo, Requires<MobileInfo>, Requires<WithSpriteBodyInfo>, Requires<AttackBaseInfo>
+	class SandwormInfo : WandersInfo, Requires<MobileInfo>, Requires<WithSpriteBodyInfo>, Requires<AttackBaseInfo>,
+		InitializeAfter<MobileInfo>, InitializeAfter<WithSpriteBodyInfo>, InitializeAfter<AttackBaseInfo>
 	{
 		[Desc("Time between rescanning for targets (in ticks).")]
 		public readonly int TargetRescanInterval = 32;

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA.Traits
 {
 	[Desc("Creates a free duplicate of produced units.")]
-	public class ClonesProducedUnitsInfo : ITraitInfo, Requires<ProductionInfo>, Requires<ExitInfo>
+	public class ClonesProducedUnitsInfo : ITraitInfo, Requires<ProductionInfo>, Requires<ExitInfo>, InitializeAfter<ProductionInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Uses the \"Cloneable\" trait to determine whether or not we should clone a produced unit.")]

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA.Traits
 {
 	[Desc("Overrides the default ToolTip when this actor is disguised (aids in deceiving enemy players).")]
-	class DisguiseToolTipInfo : TooltipInfo, Requires<DisguiseInfo>
+	class DisguiseToolTipInfo : TooltipInfo, Requires<DisguiseInfo>, InitializeAfter<DisguiseInfo>
 	{
 		public override object Create(ActorInitializer init) { return new DisguiseToolTip(init.Self, this); }
 	}

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.RA.Traits
 	}
 
 	[Desc("Provides access to the disguise command, which makes the actor appear to be another player's actor.")]
-	class DisguiseInfo : ITraitInfo
+	class DisguiseInfo : IEffectiveOwnerInfo
 	{
 		[VoiceReference] public readonly string Voice = "Action";
 

--- a/OpenRA.Mods.RA/Traits/MadTank.cs
+++ b/OpenRA.Mods.RA/Traits/MadTank.cs
@@ -22,7 +22,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	class MadTankInfo : ITraitInfo, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>
+	class MadTankInfo : ITraitInfo, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>, InitializeAfter<WithFacingSpriteBodyInfo>
 	{
 		[SequenceReference] public readonly string ThumpSequence = "piston";
 		public readonly int ThumpInterval = 8;

--- a/OpenRA.Mods.RA/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.RA/Traits/Render/WithDisguisingInfantryBody.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	class WithDisguisingInfantryBodyInfo : WithInfantryBodyInfo, Requires<DisguiseInfo>
+	class WithDisguisingInfantryBodyInfo : WithInfantryBodyInfo, Requires<DisguiseInfo>, InitializeAfter<DisguiseInfo>
 	{
 		public override object Create(ActorInitializer init) { return new WithDisguisingInfantryBody(init, this); }
 	}

--- a/OpenRA.Mods.RA/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.RA/Traits/Render/WithLandingCraftAnimation.cs
@@ -14,7 +14,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	public class WithLandingCraftAnimationInfo : ITraitInfo, Requires<IMoveInfo>, Requires<WithSpriteBodyInfo>, Requires<CargoInfo>
+	public class WithLandingCraftAnimationInfo : ITraitInfo, Requires<IMoveInfo>, Requires<WithSpriteBodyInfo>, Requires<CargoInfo>,
+		InitializeAfter<IMoveInfo>, InitializeAfter<WithSpriteBodyInfo>, InitializeAfter<CargoInfo>
 	{
 		public readonly string[] OpenTerrainTypes = { "Clear" };
 		[SequenceReference] public readonly string OpenSequence = "open";

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.TS.Traits
 {
-	public class WithVoxelUnloadBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
+	public class WithVoxelUnloadBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo,
+		Requires<RenderVoxelsInfo>, Requires<IBodyOrientationInfo>, InitializeAfter<RenderVoxelsInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		[Desc("Voxel sequence name to use when docked to a refinery.")]
 		public readonly string UnloadSequence = "unload";

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
@@ -16,7 +16,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.TS.Traits
 {
-	public class WithVoxelWalkerBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, Requires<RenderVoxelsInfo>, Requires<IMoveInfo>
+	public class WithVoxelWalkerBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo,
+		Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IBodyOrientationInfo>,
+		InitializeAfter<RenderVoxelsInfo>, InitializeAfter<IMoveInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		public readonly int TickRate = 5;
 		public object Create(ActorInitializer init) { return new WithVoxelWalkerBody(init.Self, this); }

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWaterBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWaterBody.cs
@@ -18,7 +18,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.TS.Traits
 {
-	public class WithVoxelWaterBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
+	public class WithVoxelWaterBodyInfo : ITraitInfo, IQuantizeBodyOrientationInfo, IRenderActorPreviewVoxelsInfo,
+		Requires<RenderVoxelsInfo>, Requires<IBodyOrientationInfo>, InitializeAfter<RenderVoxelsInfo>, InitializeAfter<IBodyOrientationInfo>
 	{
 		public readonly string WaterSequence = "water";
 		public readonly string LandSequence = "idle";

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -28,11 +28,12 @@ namespace OpenRA.Test
 		class MockTrait : ITraitInfo { public object Create(ActorInitializer init) { return null; } }
 		class MockInherit : MockTrait { }
 		class MockA : MockInherit, IMock { }
-		class MockB : MockTrait, Requires<MockA>, Requires<IMock>, Requires<MockInherit> { }
-		class MockC : MockTrait, Requires<MockB> { }
-		class MockD : MockTrait, Requires<MockE> { }
-		class MockE : MockTrait, Requires<MockF> { }
-		class MockF : MockTrait, Requires<MockD> { }
+		class MockB : MockTrait, Requires<MockA>, Requires<IMock>, Requires<MockInherit>,
+			InitializeAfter<MockA>, InitializeAfter<IMock>, InitializeAfter<MockInherit> { }
+		class MockC : MockTrait, Requires<MockB>, InitializeAfter<MockB> { }
+		class MockD : MockTrait, Requires<MockE>, InitializeAfter<MockE> { }
+		class MockE : MockTrait, Requires<MockF>, InitializeAfter<MockF> { }
+		class MockF : MockTrait, Requires<MockD>, InitializeAfter<MockD> { }
 
 		[SetUp]
 		public void SetUp()
@@ -70,7 +71,6 @@ namespace OpenRA.Test
 			{
 				Assert.That(e.Message, Is.StringContaining("MockA"));
 				Assert.That(e.Message, Is.StringContaining("MockB"));
-				Assert.That(e.Message, Is.StringContaining("MockC"));
 				Assert.That(e.Message, Is.StringContaining("MockInherit"), "Should recognize base classes");
 				Assert.That(e.Message, Is.StringContaining("IMock"), "Should recognize interfaces");
 			}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -5,7 +5,6 @@
 	GivesExperience:
 	BodyOrientation:
 	ScriptTriggers:
-	UpgradeManager:
 	Huntable:
 
 ^GainsExperience:
@@ -461,7 +460,6 @@
 
 ^CivBuilding:
 	Inherits: ^Building
-	-UpgradeManager:
 	Health:
 		HP: 400
 	Tooltip:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -5,7 +5,6 @@
 	GivesExperience:
 	BodyOrientation:
 	ScriptTriggers:
-	UpgradeManager:
 	Huntable:
 
 ^GainsExperience:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -6,7 +6,6 @@
 	GivesExperience:
 	BodyOrientation:
 	ScriptTriggers:
-	UpgradeManager:
 	Huntable:
 
 ^GainsExperience:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -5,7 +5,6 @@
 	GivesExperience:
 	BodyOrientation:
 	ScriptTriggers:
-	UpgradeManager:
 	Huntable:
 
 ^GainsExperience:


### PR DESCRIPTION
Requires #8848.
This is how I discovered the issue addressed by #8774.

Allows for singleton traits, that coordinate or otherwise manage other traits, such as `UpgradeManager` to be included automatically and allows checking for inclusion of multiple traits implementing the same singleton interface (usually accessed by `.Trait[OrDefault]` or `.Traits.Get[OrDefault]`).
Is part of my effort to improve inter-trait handling (#8786).
