### PR TITLE
Fix an NRE when cancelling repair orders on units at the wrong time

### DIFF
--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -45,7 +45,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (transportable != null)
 				transportable.WantsTransport = false;
 
-			inner.Cancel(self);
+			if (inner != null)
+				inner.Cancel(self);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8789.

Not too easy to reproduce (although I managed once). I suggest using the replay from #8781.
