### PR TITLE
Changes shroud lobby setting from disabling shroud to revealing it.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -282,7 +282,7 @@ namespace OpenRA.Traits
 			return explored.Contains(uv) && explored[uv] && (generatedShroudCount[uv] == 0 || visibleCount[uv] > 0);
 		}
 
-		public bool ShroudEnabled { get { return !Disabled && self.World.LobbyInfo.GlobalSettings.Shroud; } }
+		public bool ShroudEnabled { get { return !Disabled; } }
 
 		/// <summary>
 		/// Returns a fast exploration lookup that skips the usual validation.

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -180,6 +180,10 @@ namespace OpenRA
 				MapUid = Map.Uid,
 				MapTitle = Map.Title
 			};
+
+			if (!LobbyInfo.GlobalSettings.Shroud)
+				foreach (var player in Players)
+					player.Shroud.ExploreAll(this);
 		}
 
 		public void LoadComplete(WorldRenderer wr)

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -440,8 +440,8 @@ namespace OpenRA.Mods.Common.Server
 
 						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.Shroud);
 						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} Shroud."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.Shroud ? "enabled" : "disabled"));
+						server.SendMessage("{0} {1} Explored map."
+							.F(client.Name, server.LobbyInfo.GlobalSettings.Shroud ? "disabled" : "enabled"));
 
 						return true;
 					}

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Server
 				server.SendOrderTo(conn, "Message", "Allow Cheats: {0}".F(server.LobbyInfo.GlobalSettings.AllowCheats));
 
 			if (server.LobbyInfo.GlobalSettings.Shroud != defaults.Shroud)
-				server.SendOrderTo(conn, "Message", "Shroud: {0}".F(server.LobbyInfo.GlobalSettings.Shroud));
+				server.SendOrderTo(conn, "Message", "Explored map: {0}".F(!server.LobbyInfo.GlobalSettings.Shroud));
 
 			if (server.LobbyInfo.GlobalSettings.Fog != defaults.Fog)
 				server.SendOrderTo(conn, "Message", "Fog of war: {0}".F(server.LobbyInfo.GlobalSettings.Fog));

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -30,7 +30,6 @@ namespace OpenRA.Mods.Common.Traits
 		static readonly PPos[] NoCells = { };
 
 		readonly RevealsShroudInfo info;
-		readonly bool lobbyShroudFogDisabled;
 		[Sync] CPos cachedLocation;
 		[Sync] bool cachedDisabled;
 
@@ -41,7 +40,6 @@ namespace OpenRA.Mods.Common.Traits
 		public RevealsShroud(Actor self, RevealsShroudInfo info)
 		{
 			this.info = info;
-			lobbyShroudFogDisabled = !self.World.LobbyInfo.GlobalSettings.Shroud && !self.World.LobbyInfo.GlobalSettings.Fog;
 
 			addCellsToPlayerShroud = (p, uv) => p.Shroud.AddProjectedVisibility(self, uv);
 			removeCellsFromPlayerShroud = p => p.Shroud.RemoveVisibility(self);
@@ -66,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Tick(Actor self)
 		{
-			if (lobbyShroudFogDisabled || !self.IsInWorld)
+			if (!self.IsInWorld)
 				return;
 
 			var centerPosition = self.CenterPosition;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -497,12 +497,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 			}
 
-			var enableShroud = optionsBin.GetOrNull<CheckboxWidget>("SHROUD_CHECKBOX");
-			if (enableShroud != null)
+			var exploredMap = optionsBin.GetOrNull<CheckboxWidget>("EXPLORED_MAP_CHECKBOX");
+			if (exploredMap != null)
 			{
-				enableShroud.IsChecked = () => orderManager.LobbyInfo.GlobalSettings.Shroud;
-				enableShroud.IsDisabled = () => Map.Status != MapStatus.Available || Map.Map.Options.Shroud.HasValue || configurationDisabled();
-				enableShroud.OnClick = () => orderManager.IssueOrder(Order.Command(
+				exploredMap.IsChecked = () => !orderManager.LobbyInfo.GlobalSettings.Shroud;
+				exploredMap.IsDisabled = () => Map.Status != MapStatus.Available || Map.Map.Options.Shroud.HasValue || configurationDisabled();
+				exploredMap.OnClick = () => orderManager.IssueOrder(Order.Command(
 					"shroud {0}".F(!orderManager.LobbyInfo.GlobalSettings.Shroud)));
 			}
 

--- a/mods/cnc/chrome/lobby-dialogs.yaml
+++ b/mods/cnc/chrome/lobby-dialogs.yaml
@@ -110,11 +110,11 @@ Background@LOBBY_OPTIONS_BIN:
 			Width: PARENT_RIGHT-60
 			Height: PARENT_BOTTOM-75
 			Children:
-				Checkbox@SHROUD_CHECKBOX:
+				Checkbox@EXPLORED_MAP_CHECKBOX:
 					Width: 230
 					Height: 20
 					Font: Regular
-					Text: Shroud
+					Text: Explored map
 				Checkbox@FOG_CHECKBOX:
 					Y: 35
 					Width: 230

--- a/mods/d2k/chrome/lobby-dialogs.yaml
+++ b/mods/d2k/chrome/lobby-dialogs.yaml
@@ -109,10 +109,10 @@ Background@LOBBY_OPTIONS_BIN:
 			Width: PARENT_RIGHT-60
 			Height: PARENT_BOTTOM-75
 			Children:
-				Checkbox@SHROUD_CHECKBOX:
+				Checkbox@EXPLORED_MAP_CHECKBOX:
 					Width: 140
 					Height: 20
-					Text: Shroud
+					Text: Explored map
 				Checkbox@FOG_CHECKBOX:
 					Y: 35
 					Width: 140

--- a/mods/ra/chrome/lobby-dialogs.yaml
+++ b/mods/ra/chrome/lobby-dialogs.yaml
@@ -109,10 +109,10 @@ Background@LOBBY_OPTIONS_BIN:
 			Width: PARENT_RIGHT-60
 			Height: PARENT_BOTTOM-75
 			Children:
-				Checkbox@SHROUD_CHECKBOX:
+				Checkbox@EXPLORED_MAP_CHECKBOX:
 					Width: 140
 					Height: 20
-					Text: Shroud
+					Text: Explored map
 				Checkbox@FOG_CHECKBOX:
 					Y: 35
 					Width: 140


### PR DESCRIPTION
Disabling shroud in lobby will reveal shroud at game start. It does the same thing as clear shroud debug option. But shroud as a gameplay element will still be available. This means that gap generators will work.

Fixes #6123.
