### PR TITLE
Enabled the container based Travis CI architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,20 @@
 language: csharp
 mono: 3.12.0
 
-# Don't use the container based infrastructure
-sudo: true
+# http://docs.travis-ci.com/user/migrating-from-legacy
+sudo: false
 
 cache:
   directories:
   - thirdparty/download
+
+addons:
+  apt:
+    packages:
+    - nsis
+    - nsis-common
+    - dpkg
+    - markdown
 
 # Environment variables
 env:
@@ -20,7 +28,6 @@ env:
 # Check source code with StyleCop
 # call OpenRA to check for YAML errors
 script:
- - sudo apt-get remove nuget # https://github.com/travis-ci/travis-ci/issues/3940
  - travis_retry make all-dependencies
  - make all
  - make check
@@ -50,7 +57,6 @@ notifications:
     skip_join: true
 
 before_deploy:
- - sudo apt-get install nsis nsis-common dpkg markdown
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`
  - cd packaging

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,9 +64,6 @@ after_test:
   - cp OpenRA.Game/OpenRA.ico .
   - if not exist nsissetup.exe appveyor DownloadFile "http://downloads.sourceforge.net/project/nsis/NSIS 2/2.46/nsis-2.46-setup.exe" -FileName nsissetup.exe
   - nsissetup /S /D=%NSIS_ROOT%
-  - if not exist NsProcess.zip appveyor DownloadFile "http://nsis.sourceforge.net/mediawiki/images/archive/1/18/20140806212030!NsProcess.zip" -FileName NsProcess.zip
-  - 7z x NsProcess.zip -o%NSIS_ROOT% -y
-  - move /Y %NSIS_ROOT%\Plugin\nsProcess.dll %NSIS_ROOT%\Plugins\nsProcess.dll
   - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\download\windows" /V3 packaging/windows/OpenRA.nsi'
   - move /Y %APPVEYOR_BUILD_FOLDER%\packaging\windows\OpenRA.Setup.exe %APPVEYOR_BUILD_FOLDER%\OpenRA-%APPVEYOR_REPO_TAG_NAME%.exe
 

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -18,7 +18,6 @@
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
 !include "WordFunc.nsh"
-!include "nsProcess.nsh"
 
 Name "OpenRA"
 OutFile "OpenRA.Setup.exe"
@@ -236,17 +235,7 @@ FunctionEnd
 !insertmacro Clean "un."
 
 Section "Uninstall"
-	${nsProcess::FindProcess} "OpenRA.Game.exe" $R0
-	IntCmp $R0 0 gameRunning
-	${nsProcess::FindProcess} "OpenRA.exe" $R0
-	IntCmp $R0 0 gameRunning
-	${nsProcess::Unload}
 	Call un.Clean
-	Goto end
-	gameRunning:
-		MessageBox MB_OK|MB_ICONEXCLAMATION "OpenRA is running. Please close it first" /SD IDOK
-		abort
-	end:
 SectionEnd
 
 ;***************************

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -8,11 +8,6 @@ OUTPUTDIR="$4"
 if [ -x /usr/bin/makensis ]; then
     pushd "$SRCDIR" >/dev/null
     popd >/dev/null
-    if [[ ! -f /usr/share/nsis/Include/nsProcess.nsh &&  ! -f /usr/share/nsis/Plugin/nsProcess.dll ]]; then
-        echo "Installing NsProcess NSIS plugin in /usr/share/nsis"
-        sudo unzip -qq -o ${SRCDIR}/thirdparty/download/NsProcess.zip 'Include/*' -d /usr/share/nsis
-        sudo unzip -qq -j -o ${SRCDIR}/thirdparty/download/NsProcess.zip 'Plugin/*' -d /usr/share/nsis/Plugins
-    fi
     echo "Building Windows setup.exe"
     makensis -V2 -DSRCDIR="$BUILTDIR" -DDEPSDIR="${SRCDIR}/thirdparty/download/windows" OpenRA.nsi
     if [ $? -eq 0 ]; then

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -6,8 +6,6 @@ SRCDIR="$3"
 OUTPUTDIR="$4"
 
 if [ -x /usr/bin/makensis ]; then
-    pushd "$SRCDIR" >/dev/null
-    popd >/dev/null
     echo "Building Windows setup.exe"
     makensis -V2 -DSRCDIR="$BUILTDIR" -DDEPSDIR="${SRCDIR}/thirdparty/download/windows" OpenRA.nsi
     if [ $? -eq 0 ]; then

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -13,7 +13,8 @@ download_dir="${0%/*}/download"
 mkdir -p "${download_dir}"
 cd "${download_dir}"
 
-if which nuget >/dev/null 2>&1; then
+# https://github.com/travis-ci/travis-ci/issues/3940
+if [ ! $TRAVIS ] && which nuget >/dev/null 2>&1; then
 	get()
 	{
 		nuget install $1 -Version $2 -ExcludeVersion

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -17,12 +17,12 @@ cd "${download_dir}"
 if [ ! $TRAVIS ] && which nuget >/dev/null 2>&1; then
 	get()
 	{
-		nuget install $1 -Version $2 -ExcludeVersion
+		nuget install "$1" -Version "$2" -ExcludeVersion
 	}
 else
 	get()
 	{
-		../noget.sh $1 $2
+		../noget.sh "$1" "$2"
 	}
 fi
 


### PR DESCRIPTION
After some back https://github.com/OpenRA/OpenRA/pull/7311 and forth https://github.com/OpenRA/OpenRA/pull/8187 we finally need to upgrade. I had to revert https://github.com/OpenRA/OpenRA/pull/7510 because that is not available nor install-able in the new @Travis-CI environment. http://docs.travis-ci.com/user/migrating-from-legacy
