### PR TITLE
Add a GpsRemoveFrozenActor trait

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -369,4 +369,9 @@ namespace OpenRA.Traits
 		bool IsValidAgainst(FrozenActor victim, Actor firedBy);
 		void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers);
 	}
+
+	public interface IRemoveFrozenActor
+	{
+		bool RemoveActor(Actor self, Player owner);
+	}
 }

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Traits\Cloneable.cs" />
     <Compile Include="Traits\DemoTruck.cs" />
     <Compile Include="Traits\Disguise.cs" />
+    <Compile Include="Traits\GpsRemoveFrozenActor.cs" />
     <Compile Include="Traits\HarvesterHuskModifier.cs" />
     <Compile Include="Traits\Infiltration\InfiltrateForCash.cs" />
     <Compile Include="Traits\Infiltration\InfiltrateForExploration.cs" />

--- a/OpenRA.Mods.RA/Traits/GpsRemoveFrozenActor.cs
+++ b/OpenRA.Mods.RA/Traits/GpsRemoveFrozenActor.cs
@@ -1,0 +1,55 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA.Traits
+{
+	[Desc("Removes frozen actors of actors that are dead or sold," +
+		" when having an active GPS power.")]
+	public class GpsRemoveFrozenActorInfo : ITraitInfo
+	{
+		[Desc("Should this trait also affect allied players?")]
+		public bool GrantAllies = true;
+
+		public object Create(ActorInitializer init) { return new GpsRemoveFrozenActor(init.Self, this); }
+	}
+
+	public class GpsRemoveFrozenActor : IRemoveFrozenActor
+	{
+		readonly GpsWatcher[] watchers;
+		readonly GpsRemoveFrozenActorInfo info;
+
+		public GpsRemoveFrozenActor(Actor self, GpsRemoveFrozenActorInfo info)
+		{
+			this.info = info;
+			watchers = self.World.ActorsWithTrait<GpsWatcher>().Select(w => w.Trait).ToArray();
+		}
+
+		public bool RemoveActor(Actor self, Player owner)
+		{
+			if (!self.IsDead)
+				return false;
+
+			foreach (var w in watchers)
+			{
+				if (w.Owner != owner && !(info.GrantAllies && w.Owner.IsAlliedWith(owner)))
+					continue;
+
+				if (w.Launched)
+					return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -25,14 +25,14 @@ namespace OpenRA.Mods.RA.Traits
 
 	class GpsWatcher : ISync, IFogVisibilityModifier
 	{
-		[Sync] bool launched = false;
+		[Sync] public bool Launched = false;
 		[Sync] public bool GrantedAllies = false;
 		[Sync] public bool Granted = false;
-		Player owner;
+		public Player Owner;
 
 		List<Actor> actors = new List<Actor> { };
 
-		public GpsWatcher(Player owner) { this.owner = owner; }
+		public GpsWatcher(Player owner) { Owner = owner; }
 
 		public void GpsRem(Actor atek)
 		{
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.RA.Traits
 			atek.World.Add(new DelayedAction(((GpsPowerInfo)info).RevealDelay * 25,
 					() =>
 					{
-						launched = true;
+						Launched = true;
 						RefreshGps(atek);
 					}));
 		}
@@ -69,11 +69,11 @@ namespace OpenRA.Mods.RA.Traits
 
 		void RefreshGranted()
 		{
-			Granted = actors.Count > 0 && launched;
-			GrantedAllies = owner.World.ActorsWithTrait<GpsWatcher>().Any(p => p.Actor.Owner.IsAlliedWith(owner) && p.Trait.Granted);
+			Granted = actors.Count > 0 && Launched;
+			GrantedAllies = Owner.World.ActorsWithTrait<GpsWatcher>().Any(p => p.Actor.Owner.IsAlliedWith(Owner) && p.Trait.Granted);
 
 			if (Granted || GrantedAllies)
-				owner.Shroud.ExploreAll(owner.World);
+				Owner.Shroud.ExploreAll(Owner.World);
 		}
 
 		public bool HasFogVisibility(Player byPlayer)

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -400,6 +400,7 @@
 	Guardable:
 		Range: 3
 	FrozenUnderFog:
+	GpsRemoveFrozenActor:
 	Tooltip:
 		GenericName: Structure
 	Demolishable:
@@ -461,6 +462,7 @@
 	Guardable:
 	BodyOrientation:
 	FrozenUnderFog:
+	GpsRemoveFrozenActor:
 	ScriptTriggers:
 
 ^TechBuilding:


### PR DESCRIPTION
Fixes #8096.

If you have an active GpsPower, frozen actors are removed when the "real" actor is dead or sold.
