### PR TITLE
Removes attack cursor on disguised spies.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Heal.cs
+++ b/OpenRA.Mods.Common/Activities/Heal.cs
@@ -21,7 +21,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override Activity InnerTick(Actor self, AttackBase attack)
 		{
-			if (!Target.IsValidFor(self) || !self.Owner.IsAlliedWith(Target.Actor.Owner))
+			if (!Target.IsValidFor(self))
+				return NextActivity;
+
+			var disguise = Target.Actor.EffectiveOwner;
+			var targetOwner = disguise != null && disguise.Disguised && !Target.Actor.Owner.IsAlliedWith(self.Owner) ?
+				disguise.Owner : Target.Actor.Owner;
+			if (!self.Owner.IsAlliedWith(targetOwner))
 				return NextActivity;
 
 			if (Target.Type == TargetType.Actor && Target.Actor.GetDamageState() == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -246,8 +246,17 @@ namespace OpenRA.Mods.Common.Traits
 
 				var targetableRelationship = negativeDamage ? Stance.Ally : Stance.Enemy;
 
-				var owner = target.Type == TargetType.FrozenActor ? target.FrozenActor.Owner : target.Actor.Owner;
-				return self.Owner.Stances[owner] == targetableRelationship;
+				Player targetOwner;
+				if (target.Type == TargetType.FrozenActor)
+					targetOwner = target.FrozenActor.Owner;
+				else
+				{
+					var disguise = target.Actor.EffectiveOwner;
+					targetOwner = disguise != null && disguise.Disguised && !target.Actor.Owner.IsAlliedWith(self.Owner) ?
+						disguise.Owner : target.Actor.Owner;
+				}
+
+				return self.Owner.Stances[targetOwner] == targetableRelationship;
 			}
 
 			bool CanTargetLocation(Actor self, CPos location, List<Actor> actorsAtLocation, TargetModifiers modifiers, ref string cursor)


### PR DESCRIPTION
The attack cursor will not be shown on enemy spies disguised as own unit. Force firing is required to attack them. I also want to make them selectable like player's own units but couldn't find the code where it's determined.
