### PR TITLE
Improved RA mod AI (yaml tweaks)

### DIFF
--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -75,13 +75,13 @@ Player:
 				Types: Structure
 				Attractiveness: 1
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense, Water
-				Attractiveness: -10
+				Types: Water
+				Attractiveness: -5
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 		SupportPowerDecision@parabombs:
 			OrderName: UkraineParabombs
 			MinimumAttractiveness: 1
@@ -199,13 +199,13 @@ Player:
 				Types: Structure
 				Attractiveness: 1
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense, Water
-				Attractiveness: -10
+				Types: Water
+				Attractiveness: -5
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 		SupportPowerDecision@parabombs:
 			OrderName: UkraineParabombs
 			MinimumAttractiveness: 1
@@ -322,13 +322,13 @@ Player:
 				Types: Structure
 				Attractiveness: 1
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense, Water
-				Attractiveness: -10
+				Types: Water
+				Attractiveness: -5
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 		SupportPowerDecision@parabombs:
 			OrderName: UkraineParabombs
 			MinimumAttractiveness: 1
@@ -423,13 +423,13 @@ Player:
 				Types: Structure
 				Attractiveness: 1
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 			Consideration@2:
 				Against: Enemy
-				Types: Vehicle, Tank, Infantry, Defense, Water
-				Attractiveness: -10
+				Types: Water
+				Attractiveness: -5
 				TargetMetric: None
-				CheckRadius: 10c0
+				CheckRadius: 8c0
 		SupportPowerDecision@parabombs:
 			OrderName: UkraineParabombs
 			MinimumAttractiveness: 1

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -16,7 +16,6 @@ Player:
 			proc: 4
 			barr: 1
 			tent: 1
-			kenn: 1
 			dome: 1
 			weap: 1
 			hpad: 4
@@ -30,7 +29,6 @@ Player:
 			apwr: 20%
 			barr: 1%
 			tent: 1%
-			kenn: 0.5%
 			weap: 1%
 			pbox: 7%
 			gun: 7%
@@ -47,7 +45,6 @@ Player:
 			e2: 20%
 			e3: 10%
 			e4: 2%
-			dog: 2%
 			shok: 2%
 			apc: 30%
 			jeep: 40%
@@ -126,7 +123,6 @@ Player:
 			proc: 4
 			barr: 1
 			tent: 1
-			kenn: 1
 			dome: 1
 			weap: 1
 			spen: 1
@@ -142,7 +138,6 @@ Player:
 			apwr: 30%
 			tent: 1%
 			barr: 1%
-			kenn: 0.5%
 			dome: 1%
 			weap: 6%
 			hpad: 4%
@@ -164,7 +159,6 @@ Player:
 			e2: 10%
 			e3: 10%
 			e4: 5%
-			dog: 3%
 			shok: 5%
 			harv: 10%
 			apc: 30%
@@ -253,7 +247,6 @@ Player:
 			proc: 4
 			barr: 1
 			tent: 1
-			kenn: 1
 			dome: 1
 			weap: 1
 			spen: 1
@@ -269,7 +262,6 @@ Player:
 			apwr: 30%
 			tent: 1%
 			barr: 1%
-			kenn: 0.5%
 			weap: 3%
 			hpad: 2%
 			spen: 1%
@@ -290,7 +282,6 @@ Player:
 			e2: 10%
 			e3: 10%
 			e4: 8%
-			dog: 4%
 			shok: 8%
 			harv: 10%
 			apc: 30%

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -292,7 +292,6 @@ Player:
 			e4: 8%
 			dog: 4%
 			shok: 8%
-			sniper: 5%
 			harv: 10%
 			apc: 30%
 			jeep: 40%

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -259,21 +259,21 @@ Player:
 		BuildingFractions:
 			proc: 30%
 			powr: 1%
-			apwr: 30%
+			apwr: 20%
 			tent: 1%
 			barr: 1%
 			weap: 3%
 			hpad: 2%
 			spen: 1%
 			syrd: 1%
-			pbox: 7%
-			gun: 7%
+			pbox: 10%
+			gun: 10%
 			ftur: 10%
-			tsla: 5%
+			tsla: 7%
 			fix: 0.1%
 			dome: 10%
 			agun: 5%
-			sam: 1%
+			sam: 5%
 			atek: 1%
 			stek: 1%
 			mslo: 1%


### PR DESCRIPTION
- Removed kennels from AI.
- Tweaked Turtle AI to build more defenses and less excess adv. power plants, works better in conjunction with #8759.
- Fixed soviet paratroops target evaluation so it doesn't always fail.
- Removed obsolete sniper entry.

Fixes #8564.
