### PR TITLE
Replace map.Contains with proper array bounds checks.

### DIFF
--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<Actor> GetUnitsAt(CPos a)
 		{
-			if (!map.Contains(a))
+			if (!influence.Contains(a))
 				yield break;
 
 			for (var i = influence[a]; i != null; i = i.Next)
@@ -204,7 +204,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<Actor> GetUnitsAt(CPos a, SubCell sub)
 		{
-			if (!map.Contains(a))
+			if (!influence.Contains(a))
 				yield break;
 
 			for (var i = influence[a]; i != null; i = i.Next)
@@ -249,7 +249,7 @@ namespace OpenRA.Traits
 		// NOTE: always includes transients with influence
 		public bool AnyUnitsAt(CPos a)
 		{
-			if (!map.Contains(a))
+			if (!influence.Contains(a))
 				return false;
 
 			return influence[a] != null;
@@ -258,7 +258,7 @@ namespace OpenRA.Traits
 		// NOTE: can not check aircraft
 		public bool AnyUnitsAt(CPos a, SubCell sub, bool checkTransient = true)
 		{
-			if (!map.Contains(a))
+			if (!influence.Contains(a))
 				return false;
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
@@ -281,7 +281,7 @@ namespace OpenRA.Traits
 		// NOTE: can not check aircraft
 		public bool AnyUnitsAt(CPos a, SubCell sub, Func<Actor, bool> withCondition)
 		{
-			if (!map.Contains(a))
+			if (!influence.Contains(a))
 				return false;
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
@@ -296,7 +296,7 @@ namespace OpenRA.Traits
 		{
 			foreach (var c in ios.OccupiedCells())
 			{
-				if (!map.Contains(c.First))
+				if (!influence.Contains(c.First))
 					continue;
 
 				influence[c.First] = new InfluenceNode { Next = influence[c.First], SubCell = c.Second, Actor = self };
@@ -312,7 +312,7 @@ namespace OpenRA.Traits
 		{
 			foreach (var c in ios.OccupiedCells())
 			{
-				if (!map.Contains(c.First))
+				if (!influence.Contains(c.First))
 					continue;
 
 				var temp = influence[c.First];
@@ -381,7 +381,7 @@ namespace OpenRA.Traits
 
 			foreach (var c in cells)
 			{
-				if (!map.Contains(c))
+				if (!influence.Contains(c))
 					continue;
 
 				if (!cellTriggerInfluence.ContainsKey(c))

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
-					if (map.Contains(u) && influence[u] == null)
+					if (influence.Contains(u) && influence[u] == null)
 						influence[u] = a;
 			};
 
@@ -47,14 +47,14 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
-					if (map.Contains(u) && influence[u] == a)
+					if (influence.Contains(u) && influence[u] == a)
 						influence[u] = null;
 			};
 		}
 
 		public Actor GetBuildingAt(CPos cell)
 		{
-			if (!map.Contains(cell))
+			if (!influence.Contains(cell))
 				return null;
 
 			return influence[cell];

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -27,14 +27,12 @@ namespace OpenRA.Mods.Common.Traits
 	class BridgeLayer : IWorldLoaded
 	{
 		readonly BridgeLayerInfo info;
-		readonly World world;
 		Dictionary<ushort, Pair<string, int>> bridgeTypes = new Dictionary<ushort, Pair<string, int>>();
 		CellLayer<Bridge> bridges;
 
 		public BridgeLayer(Actor self, BridgeLayerInfo info)
 		{
 			this.info = info;
-			this.world = self.World;
 		}
 
 		public void WorldLoaded(World w, WorldRenderer wr)
@@ -81,6 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			}).Trait<Bridge>();
 
 			var subTiles = new Dictionary<CPos, byte>();
+			var mapTiles = w.Map.MapTiles.Value;
 
 			// For each subtile in the template
 			for (byte ind = 0; ind < template.Size.X * template.Size.Y; ind++)
@@ -89,8 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 				var subtile = new CPos(ni + ind % template.Size.X, nj + ind / template.Size.X);
 
 				// This isn't the bridge you're looking for
-				if (!w.Map.Contains(subtile) || w.Map.MapTiles.Value[subtile].Type != tile ||
-					w.Map.MapTiles.Value[subtile].Index != ind)
+				if (!mapTiles.Contains(subtile) || mapTiles[subtile].Type != tile || mapTiles[subtile].Index != ind)
 					continue;
 
 				subTiles.Add(subtile, ind);
@@ -103,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Used to check for neighbouring bridges
 		public Bridge GetBridge(CPos cell)
 		{
-			if (!world.Map.Contains(cell))
+			if (!bridges.Contains(cell))
 				return null;
 
 			return bridges[cell];

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool IsPassable(CPos p1, CPos p2)
 		{
-			if (!map.Contains(p1) || !map.Contains(p2))
+			if (!domains.Contains(p1) || !domains.Contains(p2))
 				return false;
 
 			if (domains[p1] == domains[p2])


### PR DESCRIPTION
This fixes a bunch of cases where map.Contains is used as a guard against index out of range exceptions.  These cases now use the Contains check on the CellLayer itself.
