### PR TITLE
Implement ammo-dependent turret art for TD Mobile SAM

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Traits\Render\WithGunboatBody.cs" />
     <Compile Include="Traits\Render\WithCargo.cs" />
     <Compile Include="Traits\Render\WithDeliveryAnimation.cs" />
+    <Compile Include="Traits\Render\WithReloadingTurret.cs" />
     <Compile Include="Traits\Render\WithRoof.cs" />
     <Compile Include="Traits\SpawnViceroid.cs" />
     <Compile Include="Traits\SupportPowers\IonCannonPower.cs" />

--- a/OpenRA.Mods.Cnc/Traits/Render/WithReloadingTurret.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithReloadingTurret.cs
@@ -1,0 +1,76 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Desc("Renders ammo-dependent turret graphics for units with the Turreted trait.")]
+	public class WithReloadingTurretInfo : WithTurretInfo, Requires<AmmoPoolInfo>, Requires<ArmamentInfo>
+	{
+		[Desc("AmmoPool to use for ammo-dependent sequences.")]
+		public readonly string AmmoPoolName = null;
+
+		[Desc("How many reload stages does this turret have. Defaults to AmmoPool's Ammo.",
+			"Adds current reload stage to Sequence as suffix when a matching AmmoPool is present.")]
+		public readonly int ReloadStages = -1;
+
+		public override object Create(ActorInitializer init) { return new WithReloadingTurret(init.Self, this); }
+	}
+
+	public class WithReloadingTurret : WithTurret
+	{
+		readonly int reloadStages;
+		readonly AmmoPool ammoPool;
+		string sequence;
+		string ammoSuffix;
+
+		public WithReloadingTurret(Actor self, WithReloadingTurretInfo info)
+			: base(self, info)
+		{
+			ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault(a => a.Info.Name == info.AmmoPoolName);
+			if (ammoPool == null)
+				throw new InvalidOperationException("Actor type '" + self.Info.Name + "' does not define a valid ammo pool for its reloading turret.");
+
+			sequence = Info.Sequence;
+			reloadStages = info.ReloadStages;
+
+			var initialAmmo = ammoPool.Info.InitialAmmo;
+			var ammo = ammoPool.Info.Ammo;
+			var initialAmmoStage = initialAmmo >= 0 && initialAmmo != ammo ? initialAmmo : ammo;
+
+			if (ammoPool != null && reloadStages < 0)
+				ammoSuffix = initialAmmoStage.ToString();
+			if (ammoPool != null && reloadStages >= 0)
+				ammoSuffix = (initialAmmoStage * reloadStages / ammo).ToString();
+		}
+
+		public override void Tick(Actor self)
+		{
+			if (Info.AimSequence != null)
+				sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;
+
+			var currentAmmo = ammoPool.GetAmmoCount();
+			if (reloadStages < 0)
+				ammoSuffix = currentAmmo.ToString();
+			if (reloadStages >= 0)
+				ammoSuffix = (currentAmmo * reloadStages / ammoPool.Info.Ammo).ToString();
+
+			var newSequence = NormalizeSequence(self, sequence + ammoSuffix);
+			if (DefaultAnimation.CurrentSequence.Name != newSequence)
+				DefaultAnimation.ReplaceAnim(newSequence);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -58,20 +58,19 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class WithTurret : UpgradableTrait<WithTurretInfo>, ITick, INotifyDamageStateChanged
 	{
+		public readonly Animation DefaultAnimation;
+		protected readonly AttackBase Attack;
 		readonly RenderSprites rs;
 		readonly IBodyOrientation body;
-		readonly AttackBase ab;
 		readonly Turreted t;
 		readonly Armament[] arms;
-		public readonly Animation DefaultAnimation;
 
 		public WithTurret(Actor self, WithTurretInfo info)
 			: base(info)
 		{
 			rs = self.Trait<RenderSprites>();
 			body = self.Trait<IBodyOrientation>();
-
-			ab = self.TraitOrDefault<AttackBase>();
+			Attack = self.TraitOrDefault<AttackBase>();
 			t = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == info.Turret);
 			arms = self.TraitsImplementing<Armament>()
@@ -109,12 +108,12 @@ namespace OpenRA.Mods.Common.Traits
 				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
 		}
 
-		public void Tick(Actor self)
+		public virtual void Tick(Actor self)
 		{
 			if (Info.AimSequence == null)
 				return;
 
-			var sequence = ab.IsAttacking ? Info.AimSequence : Info.Sequence;
+			var sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;
 			DefaultAnimation.ReplaceAnim(sequence);
 		}
 

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -477,9 +477,15 @@ MLRS:
 	Armament:
 		Weapon: Patriot
 		LocalOffset: 0,-171,0, 0,171,0
+	AmmoPool:
+		Ammo: 2
+		PipCount: 0
+		SelfReloads: true
+		ReloadCount: 1
+		SelfReloadTicks: 100
 	AttackTurreted:
-	WithTurret:
-		AimSequence: aim
+	WithReloadingTurret:
+		AmmoPoolName: primary
 	AutoTarget:
 		InitialStance: Defend
 	RenderRangeCircle:

--- a/mods/cnc/sequences/vehicles.yaml
+++ b/mods/cnc/sequences/vehicles.yaml
@@ -215,10 +215,13 @@ mlrs:
 	turret:
 		Start: 32
 		Facings: 32
-	aim:
+	turret2:
 		Start: 32
 		Facings: 32
-	empty-aim:
+	turret1:
+		Start: 64
+		Facings: 32
+	turret0:
 		Start: 96
 		Facings: 32
 	icon: mlrsicnh.tem

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -377,16 +377,12 @@ Patriot:
 		RateOfTurn: 20
 		Speed: 341
 		RangeLimit: 30
-		Angle: 88
 	Warhead@1Dam: SpreadDamage
 		Spread: 682
 		ValidTargets: Air
 		Versus:
-			None: 100
-			Wood: 100
-			Light: 100
 			Heavy: 75
-		Damage: 32
+		Damage: 50
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater


### PR DESCRIPTION
Another result of my work on TDX.

Mobile SAM (SSM in original game) now changes turret art depending on current amount of ammo. Uses `AmmoPool`.

Had to change the weapon's reload behavior to give this more limelight, so this might need some balance testing in addition to regular reviewing.

Closes #7493.
