### PR TITLE
Fix crates dying while not in the world

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Tick(Actor self)
 		{
-			if (info.Lifetime != 0 && ++ticks >= info.Lifetime * 25)
+			if (info.Lifetime != 0 && self.IsInWorld && ++ticks >= info.Lifetime * 25)
 				self.Dispose();
 		}
 


### PR DESCRIPTION
On large maps, it can take the delivery aircraft longer than the crate's
lifetime to reach the paradrop location, so the crate will be destroyed while it's still in the aircraft, leading to an attempt to get a trait from a destroyed object in the Paradrop trait.

This fixes the lifetime logic of crates so that the lifetime will only be increased when the crate is actually in the world. This will probably also better reflect the intention behind the Lifetime property, which I assume was meant to be the time the crate would be on the map available for pickup, rather than the lifetime of the actor itself.

Fixes #8826 
