### PR TITLE
Removed redundant ISync and ITick from Attack* traits

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharge.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharge.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackCharge(init.Self, this); }
 	}
 
-	class AttackCharge : AttackOmni, ITick, INotifyAttack, ISync
+	class AttackCharge : AttackOmni, ITick, INotifyAttack
 	{
 		readonly AttackChargeInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackFollow(init.Self, this); }
 	}
 
-	public class AttackFollow : AttackBase, ITick, INotifyOwnerChanged, ISync
+	public class AttackFollow : AttackBase, ITick, INotifyOwnerChanged
 	{
 		public Target Target { get; protected set; }
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackOmni(init.Self, this); }
 	}
 
-	class AttackOmni : AttackBase, ISync
+	class AttackOmni : AttackBase
 	{
 		public AttackOmni(Actor self, AttackOmniInfo info)
 			: base(self, info) { }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackTurreted(init.Self, this); }
 	}
 
-	public class AttackTurreted : AttackFollow, ITick, ISync
+	public class AttackTurreted : AttackFollow
 	{
 		protected Turreted[] turrets;
 


### PR DESCRIPTION
`ISync` is implemented by `AttackBase`, so there's no need for other `Attack*` traits that inherit it to implement it again.
`AttackTurreted` inherits `AttackFollow`, which already implements `ITick`.
