### PR TITLE
Test sync implementations

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -30,7 +30,7 @@ namespace OpenRA
 
 		public readonly uint ActorID;
 
-		[Sync] public Player Owner { get; set; }
+		public Player Owner { get; set; }
 
 		public bool IsInWorld { get; internal set; }
 		public bool Disposed { get; private set; }

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Traits
 		public object Create(ActorInitializer init) { return new Shroud(init.Self); }
 	}
 
-	public class Shroud
+	public class Shroud : ISync
 	{
 		[Sync] public bool Disabled;
 

--- a/OpenRA.Mods.Common/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Effects/GravityBomb.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Effects
 		public IEffect Create(ProjectileArgs args) { return new GravityBomb(this, args); }
 	}
 
-	public class GravityBomb : IEffect
+	public class GravityBomb : IEffect, ISync
 	{
 		readonly GravityBombInfo info;
 		readonly Animation anim;

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new ExternalCapturable(init.Self, this); }
 	}
 
-	public class ExternalCapturable : ITick
+	public class ExternalCapturable : ITick, ISync
 	{
 		[Sync] public int CaptureProgressTime = 0;
 		[Sync] public Actor Captor;

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new ParaDrop(init.Self, this); }
 	}
 
-	public class ParaDrop : ITick, INotifyRemovedFromWorld
+	public class ParaDrop : ITick, ISync, INotifyRemovedFromWorld
 	{
 		readonly ParaDropInfo info;
 		readonly Actor self;


### PR DESCRIPTION
Added tests to verify classes use both the ISync interface and the Sync attribute and don't forget one or the other when implementing syncable traits.

Fixed some traits that failed the tests.
