### PR TITLE
Removes spacing between dropdown menu items.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/GridLayout.cs
+++ b/OpenRA.Mods.Common/Widgets/GridLayout.cs
@@ -24,14 +24,14 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (widget.Children.Count == 0)
 			{
-				widget.ContentHeight = widget.ItemSpacing;
-				pos = new int2(widget.ItemSpacing, widget.ItemSpacing);
+				widget.ContentHeight = 2 * widget.TopBottomSpacing;
+				pos = new int2(widget.ItemSpacing, widget.TopBottomSpacing);
 			}
 
-			if (pos.X + widget.ItemSpacing + w.Bounds.Width > widget.Bounds.Width - widget.ScrollbarWidth)
+			if (pos.X + w.Bounds.Width + widget.ItemSpacing > widget.Bounds.Width - widget.ScrollbarWidth)
 			{
 				/* start a new row */
-				pos = new int2(widget.ItemSpacing, widget.ContentHeight);
+				pos = new int2(widget.ItemSpacing, widget.ContentHeight - widget.TopBottomSpacing + widget.ItemSpacing);
 			}
 
 			w.Bounds.X += pos.X;
@@ -39,11 +39,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			pos = pos.WithX(pos.X + w.Bounds.Width + widget.ItemSpacing);
 
-			widget.ContentHeight = Math.Max(widget.ContentHeight, pos.Y + widget.ItemSpacing + w.Bounds.Height);
+			widget.ContentHeight = Math.Max(widget.ContentHeight, pos.Y + w.Bounds.Height + widget.TopBottomSpacing);
 		}
 
-		public void AdjustChildren()
-		{
-		}
+		public void AdjustChildren() { }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ListLayout.cs
+++ b/OpenRA.Mods.Common/Widgets/ListLayout.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.Widgets
 					widget.ContentHeight += w.Bounds.Height + widget.ItemSpacing;
 			}
 
-			// The loop above appended an extra widget.ItemSpacing after the last item. Replace it with proper bottom spacing.
+			// The loop above appended an extra widget.ItemSpacing after the last item.
+			// Replace it with proper bottom spacing.
 			widget.ContentHeight += widget.TopBottomSpacing - widget.ItemSpacing;
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/ListLayout.cs
+++ b/OpenRA.Mods.Common/Widgets/ListLayout.cs
@@ -21,22 +21,25 @@ namespace OpenRA.Mods.Common.Widgets
 		public void AdjustChild(Widget w)
 		{
 			if (widget.Children.Count == 0)
-				widget.ContentHeight = widget.ItemSpacing;
+				widget.ContentHeight = 2 * widget.TopBottomSpacing - widget.ItemSpacing;
 
-			w.Bounds.Y = widget.ContentHeight;
+			w.Bounds.Y = widget.ContentHeight - widget.TopBottomSpacing + widget.ItemSpacing;
 			if (!widget.CollapseHiddenChildren || w.IsVisible())
 				widget.ContentHeight += w.Bounds.Height + widget.ItemSpacing;
 		}
 
 		public void AdjustChildren()
 		{
-			widget.ContentHeight = widget.ItemSpacing;
+			widget.ContentHeight = widget.TopBottomSpacing;
 			foreach (var w in widget.Children)
 			{
 				w.Bounds.Y = widget.ContentHeight;
 				if (!widget.CollapseHiddenChildren || w.IsVisible())
 					widget.ContentHeight += w.Bounds.Height + widget.ItemSpacing;
 			}
+
+			// The loop above appended an extra widget.ItemSpacing after the last item. Replace it with proper bottom spacing.
+			widget.ContentHeight += widget.TopBottomSpacing - widget.ItemSpacing;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -33,7 +33,8 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		readonly Ruleset modRules;
 		public int ScrollbarWidth = 24;
-		public int ItemSpacing = 2;
+		public int TopBottomSpacing = 2;
+		public int ItemSpacing = 0;
 		public int ButtonDepth = ChromeMetrics.Get<int>("ButtonDepth");
 		public string Background = "scrollpanel-bg";
 		public string Button = "scrollpanel-button";

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -250,6 +250,7 @@ ScrollPanel@NEWS_PANEL:
 	Width: 400
 	Height: 265
 	Background: panel-black
+	TopBottomSpacing: 5
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -264,6 +264,7 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 24
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM - 24
+							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
 								ScrollItem@TILEPREVIEW_TEMPLATE:
@@ -289,6 +290,7 @@ Container@EDITOR_WORLD_ROOT:
 						ScrollPanel@LAYERTEMPLATE_LIST:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
+							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
 								ScrollItem@LAYERPREVIEW_TEMPLATE:
@@ -320,6 +322,7 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 24
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM - 24
+							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
 								ScrollItem@ACTORPREVIEW_TEMPLATE:

--- a/mods/cnc/chrome/ingame-chat.yaml
+++ b/mods/cnc/chrome/ingame-chat.yaml
@@ -45,6 +45,7 @@ Container@CHAT_PANEL:
 					Y: PARENT_BOTTOM - HEIGHT - 30
 					Width: 550
 					Height: 164
+					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Align: Bottom
 					Children:

--- a/mods/cnc/chrome/ingame-infoobjectives.yaml
+++ b/mods/cnc/chrome/ingame-infoobjectives.yaml
@@ -21,6 +21,7 @@ Container@MISSION_OBJECTIVES:
 			Y: 50
 			Width: 482
 			Height: 310
+			TopBottomSpacing: 15
 			ItemSpacing: 15
 			Children:
 				Container@OBJECTIVE_TEMPLATE:

--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -69,6 +69,7 @@ Container@SKIRMISH_STATS:
 			Y: 105
 			Width: 482
 			Height: 255
+			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				Container@PLAYER_TEMPLATE:

--- a/mods/cnc/chrome/ingame-observerstats.yaml
+++ b/mods/cnc/chrome/ingame-observerstats.yaml
@@ -258,6 +258,7 @@ Background@INGAME_OBSERVERSTATS_BG:
 					Y: 70
 					Width: PARENT_RIGHT-30
 					Height: PARENT_BOTTOM-35-50
+					TopBottomSpacing: 5
 					ItemSpacing: 5
 					Children:
 						ScrollItem@TEAM_TEMPLATE:

--- a/mods/cnc/chrome/lobby-playerbin.yaml
+++ b/mods/cnc/chrome/lobby-playerbin.yaml
@@ -3,6 +3,7 @@ ScrollPanel@LOBBY_PLAYER_BIN:
 	Y: 30
 	Width: 556
 	Height: 219
+	TopBottomSpacing: 5
 	ItemSpacing: 5
 	Children:
 		Container@TEMPLATE_EDITABLE_PLAYER:

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -94,6 +94,7 @@ Container@SERVER_LOBBY:
 					Y: 285
 					Width: PARENT_RIGHT - 30
 					Height: PARENT_BOTTOM - 324
+					TopBottomSpacing: 2
 					ItemSpacing: 2
 					Children:
 						Container@CHAT_TEMPLATE:

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -396,6 +396,7 @@ Container@SETTINGS_PANEL:
 							X: 15
 							Y: 155
 							Width: 560
+							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Height: 190
 							Children:

--- a/mods/d2k/chrome/dropdowns.yaml
+++ b/mods/d2k/chrome/dropdowns.yaml
@@ -98,6 +98,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 ScrollPanel@NEWS_PANEL:
 	Width: 370
 	Height: 265
+	TopBottomSpacing: 5
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:

--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -69,6 +69,7 @@ Container@SKIRMISH_STATS:
 			Y: 105
 			Width: 482
 			Height: 265
+			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				Container@PLAYER_TEMPLATE:

--- a/mods/d2k/chrome/lobby-playerbin.yaml
+++ b/mods/d2k/chrome/lobby-playerbin.yaml
@@ -1,6 +1,7 @@
 ScrollPanel@LOBBY_PLAYER_BIN:
 	X: 20
 	Y: 67
+	TopBottomSpacing: 5
 	ItemSpacing: 5
 	Width: 593
 	Height: 235

--- a/mods/ra/chrome/dropdowns.yaml
+++ b/mods/ra/chrome/dropdowns.yaml
@@ -101,6 +101,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 ScrollPanel@NEWS_PANEL:
 	Width: 370
 	Height: 265
+	TopBottomSpacing: 5
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:

--- a/mods/ra/chrome/editor.yaml
+++ b/mods/ra/chrome/editor.yaml
@@ -241,6 +241,7 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 35
 							Width: PARENT_RIGHT-20
 							Height: PARENT_BOTTOM-45
+							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
 								ScrollItem@TILEPREVIEW_TEMPLATE:
@@ -266,6 +267,7 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 10
 							Width: PARENT_RIGHT-20
 							Height: PARENT_BOTTOM-20
+							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
 								ScrollItem@LAYERPREVIEW_TEMPLATE:
@@ -298,6 +300,7 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 35
 							Width: PARENT_RIGHT-20
 							Height: PARENT_BOTTOM-45
+							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
 								ScrollItem@ACTORPREVIEW_TEMPLATE:

--- a/mods/ra/chrome/ingame-chat.yaml
+++ b/mods/ra/chrome/ingame-chat.yaml
@@ -41,6 +41,7 @@ Container@CHAT_PANEL:
 					Y: PARENT_BOTTOM - HEIGHT - 30
 					Width: 550
 					Height: 164
+					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Align: Bottom
 					Children:

--- a/mods/ra/chrome/ingame-diplomacy.yaml
+++ b/mods/ra/chrome/ingame-diplomacy.yaml
@@ -44,6 +44,7 @@ Background@INGAME_DIPLOMACY_BG:
 			Y: 67
 			Width: PARENT_RIGHT-40
 			Height: PARENT_BOTTOM-87-35
+			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:

--- a/mods/ra/chrome/ingame-infoobjectives.yaml
+++ b/mods/ra/chrome/ingame-infoobjectives.yaml
@@ -21,6 +21,7 @@ Container@MISSION_OBJECTIVES:
 			Y: 60
 			Width: 482
 			Height: 310
+			TopBottomSpacing: 15
 			ItemSpacing: 15
 			Children:
 				Container@OBJECTIVE_TEMPLATE:

--- a/mods/ra/chrome/ingame-infostats.yaml
+++ b/mods/ra/chrome/ingame-infostats.yaml
@@ -69,6 +69,7 @@ Container@SKIRMISH_STATS:
 			Y: 105
 			Width: 482
 			Height: 265
+			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				Container@PLAYER_TEMPLATE:

--- a/mods/ra/chrome/ingame-observerstats.yaml
+++ b/mods/ra/chrome/ingame-observerstats.yaml
@@ -258,6 +258,7 @@ Background@INGAME_OBSERVERSTATS_BG:
 					Y: 70
 					Width: PARENT_RIGHT-50
 					Height: PARENT_BOTTOM-45-50
+					TopBottomSpacing: 5
 					ItemSpacing: 5
 					Children:
 						ScrollItem@TEAM_TEMPLATE:

--- a/mods/ra/chrome/lobby-playerbin.yaml
+++ b/mods/ra/chrome/lobby-playerbin.yaml
@@ -1,6 +1,7 @@
 ScrollPanel@LOBBY_PLAYER_BIN:
 	X: 20
 	Y: 67
+	TopBottomSpacing: 5
 	ItemSpacing: 5
 	Width: 593
 	Height: 235

--- a/mods/ra/chrome/lobby.yaml
+++ b/mods/ra/chrome/lobby.yaml
@@ -96,6 +96,7 @@ Background@SERVER_LOBBY:
 			Y: PARENT_BOTTOM - HEIGHT - 52
 			Width: 818
 			Height: 210
+			TopBottomSpacing: 2
 			ItemSpacing: 2
 			Children:
 				Container@CHAT_TEMPLATE:

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -400,6 +400,7 @@ Background@SETTINGS_PANEL:
 					X: 15
 					Y: 155
 					Width: 560
+					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Height: 190
 					Children:

--- a/mods/ts/chrome/dropdowns.yaml
+++ b/mods/ts/chrome/dropdowns.yaml
@@ -98,6 +98,7 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 ScrollPanel@NEWS_PANEL:
 	Width: 370
 	Height: 265
+	TopBottomSpacing: 5
 	ItemSpacing: 5
 	Children:
 		Container@NEWS_ITEM_TEMPLATE:


### PR DESCRIPTION
Fixes #8829. Adds a new TopBottomSpacing variable that controls the padding at the top and the bottom of the list. ItemSpacing is now added only between two menu items and not at the beginning and at the end of a list. So it is arranged like this:

**TopBottomSpacing**
Menu Item 1
**ItemSpacing**
Menu Item 2
**ItemSpacing**
Menu Item 3
**TopBottomSpacing**
