### PR TITLE
Sync members of base classes

### DIFF
--- a/OpenRA.Test/OpenRA.Game/SyncTest.cs
+++ b/OpenRA.Test/OpenRA.Game/SyncTest.cs
@@ -1,0 +1,78 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using NUnit.Framework;
+using OpenRA.Traits;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	class SyncTest
+	{
+		class Complex : ISync
+		{
+			[Sync]
+			public bool Bool = true;
+			[Sync]
+			public int Int = -123456789;
+			[Sync]
+			public int2 Int2 = new int2(123, -456);
+			[Sync]
+			public CPos CPos = new CPos(123, -456);
+			[Sync]
+			public CVec CVec = new CVec(123, -456);
+			[Sync]
+			public WDist WDist = new WDist(123);
+			[Sync]
+			public WPos WPos = new WPos(123, -456, int.MaxValue);
+			[Sync]
+			public WVec WVec = new WVec(123, -456, int.MaxValue);
+			[Sync]
+			public WAngle WAngle = new WAngle(123);
+			[Sync]
+			public WRot WRot = new WRot(new WAngle(123), new WAngle(-456), new WAngle(int.MaxValue));
+			[Sync]
+			public Target Target = Target.FromPos(new WPos(123, -456, int.MaxValue));
+		}
+
+		[TestCase(TestName = "Sync hashing has not accidentally changed")]
+		public void ComplexHash()
+		{
+			// If you have intentionally changed the values used for sync hashing, just update the expected value.
+			Assert.AreEqual(-2024026914, Sync.CalculateSyncHash(new Complex()));
+		}
+
+		class Flat : ISync
+		{
+			[Sync]
+			int a = 123456789;
+			[Sync]
+			bool b = true;
+		}
+
+		class Base : ISync
+		{
+			[Sync]
+			bool b = true;
+		}
+
+		class Derived : Base
+		{
+			[Sync]
+			int a = 123456789;
+		}
+
+		[TestCase(TestName = "All sync members in inheritance hierarchy are hashed")]
+		public void DerivedHash()
+		{
+			Assert.AreEqual(Sync.CalculateSyncHash(new Flat()), Sync.CalculateSyncHash(new Derived()));
+		}
+	}
+}

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -49,6 +49,7 @@
     <Compile Include="OpenRA.Game\ActorInfoTest.cs" />
     <Compile Include="OpenRA.Game\OrderTest.cs" />
     <Compile Include="OpenRA.Game\PlatformTest.cs" />
+    <Compile Include="OpenRA.Game\SyncTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">


### PR DESCRIPTION
The method that generates sync hashing functions for traits was missing out non-public members in base classes of that trait. This meant the hash function might not be syncing over all the members you had tagged.

Now, if a trait has a base class with syncable members, we ensure these are included when hashing the state of the trait. This is verified by a test.

I also include a test to guard against unintended changes of the output from the sync mechanism in the future.
