### PR TITLE
Add `nunit` NUnit make target to Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ StyleCopViolations.xml
 # SublimeText
 *.sublime-project
 *.sublime-workspace
+
+# NUnit
+/TestResult.xml
+/lib/

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -78,6 +78,16 @@ if [ ! -f nunit.framework.dll ]; then
 	rm -rf NUnit
 fi
 
+if [ ! -f nunit-console.exe ]; then
+	echo "Fetching NUnit.Runners from NuGet"
+	get NUnit.Runners 2.6.4
+	cp ./NUnit.Runners/tools/nunit-console.exe .
+	chmod +x nunit-console.exe
+	cp ./NUnit.Runners/tools/nunit-console.exe.config .
+	cp -R ./NUnit.Runners/tools/lib .
+	rm -rf NUnit.Runners
+fi
+
 if [ ! -f Mono.Nat.dll ]; then
 	echo "Fetching Mono.Nat from NuGet"
 	get Mono.Nat 1.2.21


### PR DESCRIPTION
This allows for overrides from the `make nunit ...` command line:
- Use NUNIT_CONSOLE if nunit[2]-console is not in bin search paths
- Use NUNIT_LIBS_PATH if NUnit libs are not in search paths. Include trailing /
- Use NUNIT_LIBS if NUnit libs have different names (such as including a prefix or suffix)

Closes https://github.com/OpenRA/OpenRA/issues/8849.
