### PR TITLE
Fix AI using SharedRandom values

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.AI
 
 			// Add a random factor so not every AI produces at the same tick early in the game.
 			// Minimum should not be negative as delays in HackyAI could be zero.
-			var randomFactor = world.SharedRandom.Next(0, ai.Info.StructureProductionRandomBonusDelay);
+			var randomFactor = ai.Random.Next(0, ai.Info.StructureProductionRandomBonusDelay);
 			waitTicks = active ? ai.Info.StructureProductionActiveDelay + randomFactor
 				: ai.Info.StructureProductionInactiveDelay + randomFactor;
 		}

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -230,15 +230,6 @@ namespace OpenRA.Mods.Common.AI
 			Info = info;
 			World = init.World;
 
-			// Avoid all AIs trying to rush in the same tick, randomize their initial rush a little.
-			var smallFractionOfRushInterval = Info.RushInterval / 20;
-			rushTicks = World.SharedRandom.Next(Info.RushInterval - smallFractionOfRushInterval, Info.RushInterval + smallFractionOfRushInterval);
-
-			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
-			assignRolesTicks = World.SharedRandom.Next(0, Info.AssignRolesInterval);
-			attackForceTicks = World.SharedRandom.Next(0, Info.AttackForceInterval);
-			minAttackForceDelayTicks = World.SharedRandom.Next(0, Info.MinimumAttackForceDelay);
-
 			foreach (var decision in info.PowerDecisions)
 				powerDecisions.Add(decision.OrderName, decision);
 		}
@@ -264,6 +255,15 @@ namespace OpenRA.Mods.Common.AI
 				builders.Add(new BaseBuilder(this, defense, p, playerPower, playerResource));
 
 			Random = new MersenneTwister((int)p.PlayerActor.ActorID);
+
+			// Avoid all AIs trying to rush in the same tick, randomize their initial rush a little.
+			var smallFractionOfRushInterval = Info.RushInterval / 20;
+			rushTicks = Random.Next(Info.RushInterval - smallFractionOfRushInterval, Info.RushInterval + smallFractionOfRushInterval);
+
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			assignRolesTicks = Random.Next(0, Info.AssignRolesInterval);
+			attackForceTicks = Random.Next(0, Info.AttackForceInterval);
+			minAttackForceDelayTicks = Random.Next(0, Info.MinimumAttackForceDelay);
 
 			resourceTypeIndices = new BitArray(World.TileSet.TerrainInfo.Length); // Big enough
 			foreach (var t in Map.Rules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>())


### PR DESCRIPTION
The AI code runs on only one hosts, so by having the AI use SharedRandom values, the host's random gets out of sync with the other players' and crashes the game.
