### PR TITLE
Fixed RA grenadier prone-stand sequences

### DIFF
--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -476,11 +476,11 @@ e2:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	prone-stand:
-		Start: 144
+		Start: 240
 		Stride: 4
 		Facings: 8
 	prone-stand2:
-		Start: 144
+		Start: 240
 		Stride: 4
 		Facings: 8
 	prone-run:


### PR DESCRIPTION
On bleed, RA grenadiers use the wrong frames for prone-stand(2).
