### PR TITLE
Refine the music playlist code.

### DIFF
--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -15,8 +15,10 @@ namespace OpenRA.GameRules
 {
 	public class MusicInfo
 	{
-		public readonly string Filename = null;
-		public readonly string Title = null;
+		public readonly string Filename;
+		public readonly string Title;
+		public readonly bool Hidden;
+
 		public int Length { get; private set; } // seconds
 		public bool Exists { get; private set; }
 
@@ -25,17 +27,23 @@ namespace OpenRA.GameRules
 			Title = value.Value;
 
 			var nd = value.ToDictionary();
+			if (nd.ContainsKey("Hidden"))
+				bool.TryParse(nd["Hidden"].Value, out Hidden);
+
 			var ext = nd.ContainsKey("Extension") ? nd["Extension"].Value : "aud";
 			Filename = (nd.ContainsKey("Filename") ? nd["Filename"].Value : key) + "." + ext;
+
 			if (!GlobalFileSystem.Exists(Filename))
 				return;
 
 			Exists = true;
 			using (var s = GlobalFileSystem.Open(Filename))
+			{
 				if (Filename.ToLowerInvariant().EndsWith("wav"))
 					Length = (int)WavLoader.WaveLength(s);
 				else
 					Length = (int)AudLoader.SoundLength(s);
+			}
 		}
 
 		public void Reload()
@@ -45,10 +53,12 @@ namespace OpenRA.GameRules
 
 			Exists = true;
 			using (var s = GlobalFileSystem.Open(Filename))
+			{
 				if (Filename.ToLowerInvariant().EndsWith("wav"))
 					Length = (int)WavLoader.WaveLength(s);
 				else
 					Length = (int)AudLoader.SoundLength(s);
+			}
 		}
 	}
 }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -181,7 +181,6 @@
     <Compile Include="Traits\TraitsInterfaces.cs" />
     <Compile Include="Traits\Util.cs" />
     <Compile Include="Traits\ValidateOrder.cs" />
-    <Compile Include="Traits\World\MusicPlaylist.cs" />
     <Compile Include="Traits\World\Faction.cs" />
     <Compile Include="Traits\World\ResourceType.cs" />
     <Compile Include="Traits\World\ScreenShaker.cs" />

--- a/OpenRA.Game/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Game/Traits/World/MusicPlaylist.cs
@@ -61,10 +61,11 @@ namespace OpenRA.Traits
 
 			random = playlist.Shuffle(Game.CosmeticRandom).ToArray();
 
+			// Always start with a random song
+			currentSong = random.FirstOrDefault();
+
 			if (SongExists(info.StartingMusic))
-			{
 				currentSong = world.Map.Rules.Music[info.StartingMusic];
-			}
 			else if (SongExists(info.BackgroundMusic))
 			{
 				currentSong = currentBackgroundSong = world.Map.Rules.Music[info.BackgroundMusic];

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -702,6 +702,7 @@
     <Compile Include="Traits\RevealsShroud.cs" />
     <Compile Include="Lint\CheckRevealFootprint.cs" />
     <Compile Include="Traits\ThrowsShrapnel.cs" />
+    <Compile Include="Traits\World\MusicPlaylist.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -17,6 +17,7 @@ using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -63,12 +63,8 @@ namespace OpenRA.Mods.Common.Traits
 				.Select(a => a.Value)
 				.ToArray();
 
-			IsMusicAvailable = playlist.Any();
-
 			random = playlist.Shuffle(Game.CosmeticRandom).ToArray();
-
-			// Always start with a random song
-			currentSong = random.FirstOrDefault();
+			IsMusicAvailable = playlist.Any();
 
 			if (SongExists(info.StartingMusic))
 				currentSong = world.Map.Rules.Music[info.StartingMusic];
@@ -76,6 +72,13 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				currentSong = currentBackgroundSong = world.Map.Rules.Music[info.BackgroundMusic];
 				CurrentSongIsBackground = true;
+			}
+			else
+			{
+				// Start playback with a random song, but only if the player has installed more music
+				var installData = Game.ModData.Manifest.Get<ContentInstaller>();
+				if (playlist.Length > installData.ShippedSoundtracks)
+					currentSong = random.FirstOrDefault();
 			}
 
 			Play();

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -11,8 +11,9 @@
 using System;
 using System.Linq;
 using OpenRA.GameRules;
+using OpenRA.Traits;
 
-namespace OpenRA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Trait for music handling. Attach this to the world actor.")]
 	public class MusicPlaylistInfo : ITraitInfo

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -560,7 +560,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				musicButton.OnClick = () => Ui.OpenWindow("MUSIC_PANEL", new WidgetArgs
 				{
 					{ "onExit", DoNothing },
-					{ "world", orderManager.World }
+					{ "world", worldRenderer.World }
 				});
 
 			var settingsButton = lobby.GetOrNull<ButtonWidget>("SETTINGS_BUTTON");

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -11,7 +11,7 @@
 using System;
 using System.Linq;
 using OpenRA.GameRules;
-using OpenRA.Traits;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -125,16 +125,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var music = musicPlaylist.AvailablePlaylist();
 			currentSong = musicPlaylist.CurrentSong();
-			if (currentSong == null && music.Any())
-				currentSong = musicPlaylist.GetNextSong();
 
 			musicList.RemoveChildren();
 			foreach (var s in music)
 			{
 				var song = s;
-				if (currentSong == null)
-					currentSong = song;
-
 				var item = ScrollItemWidget.Setup(song.Filename, itemTemplate, () => currentSong == song, () => { currentSong = song; Play(); }, () => { });
 				item.Get<LabelWidget>("TITLE").GetText = () => song.Title;
 				item.Get<LabelWidget>("LENGTH").GetText = () => SongLengthLabel(song);

--- a/mods/cnc/audio/music.yaml
+++ b/mods/cnc/audio/music.yaml
@@ -24,6 +24,7 @@ fwp: Fight Win Prevail
 fist226m: Iron Fist
 warfare: Warfare (Full Stop)
 win1: Great Shot!
+	Hidden: true
 win2: Great Shot! (Voiced)
 	Filename: win2
 	Extension: var
@@ -41,6 +42,7 @@ justdoit2: Just Do it Up (Voiced)
 	Filename: justdoit
 	Extension: var
 map1: Map Theme
+	Hidden: true
 march: March to Doom
 nomercy: No Mercy
 nomercy2: No Mercy (Voiced)
@@ -58,5 +60,9 @@ target: Target (Mechanical Man)
 j1: Untamed Land
 valkyrie: Ride of the Valkyries
 voic226m: Voice Rhythm
+outtakes: Outtakes
+	Hidden: true
 nod_map1: Nod Map Theme
+	Hidden: true
 nod_win1: Nod Win Theme
+	Hidden: true

--- a/mods/cnc/maps/shellmap/map.yaml
+++ b/mods/cnc/maps/shellmap/map.yaml
@@ -995,8 +995,7 @@ Rules:
 		LuaScript:
 			Scripts: shellmap.lua
 		MusicPlaylist:
-			StartingMusic: map1
-			LoopStartingMusic: True
+			BackgroundMusic: map1
 	LST:
 		Mobile:
 			Speed: 42

--- a/mods/d2k/audio/music.yaml
+++ b/mods/d2k/audio/music.yaml
@@ -17,6 +17,7 @@ LANDSAND: Land of Sand
 	Extension: AUD
 OPTIONS: Options
 	Extension: AUD
+	Hidden: true
 PLOTTING: Plotting
 	Extension: AUD
 RISEHARK: Rise of Harkonnen
@@ -25,6 +26,7 @@ ROBOTIX: Robotix
 	Extension: AUD
 SCORE: Score
 	Extension: AUD
+	Hidden: true
 SOLDAPPR: The Soldiers Approach
 	Extension: AUD
 SPICESCT: Spice Scouting

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -124,8 +124,7 @@ Rules:
 			Minimum: 1
 			Maximum: 1
 		MusicPlaylist:
-			StartingMusic: options
-			LoopStartingMusic: True
+			BackgroundMusic: options
 	rockettower:
 		Power:
 			Amount: 100

--- a/mods/ra/audio/music.yaml
+++ b/mods/ra/audio/music.yaml
@@ -1,9 +1,12 @@
 intro: Intro
+	Hidden: true
 map: Map
+	Hidden: true
 score: Militant Force
+	Hidden: true
 await_r: Await
 bigf226m: Bigfoot
-credits: End Credits
+credits: Reload Fire
 crus226m: Crush
 dense_r: Dense
 fac1226m: Face to the Enemy 1

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -1255,6 +1255,8 @@ Rules:
 		-CrateSpawner:
 		-SpawnMPUnits:
 		-MPStartLocations:
+		MusicPlaylist:
+			BackgroundMusic: intro
 		ResourceType@ore:
 			ValuePerUnit: 0
 		LuaScript:

--- a/mods/ts/audio/music.yaml
+++ b/mods/ts/audio/music.yaml
@@ -1,5 +1,6 @@
 #Tiberian Sun
 intro: Intro
+	Hidden: true
 approach: Approach
 defense: The Defense
 duskhour: Dusk Hour
@@ -14,12 +15,14 @@ nodcrush: Nod Crush
 pharotek: Pharotek
 redsky: Red Sky
 score: Score
+	Hidden: true
 scout: Scouting
 storm: Storm
 timebomb: Timebomb
 valves1b: Valves
 whatlurk: What Lurks
 maps: Map Selection
+	Hidden: true
 #Firestorm
 dmachine: Deploy Machines
 elusive: Elusive

--- a/mods/ts/maps/blank-shellmap/map.yaml
+++ b/mods/ts/maps/blank-shellmap/map.yaml
@@ -41,8 +41,7 @@ Rules:
 		-SpawnMPUnits:
 		-MPStartLocations:
 		MusicPlaylist:
-			StartingMusic: intro
-			LoopStartingMusic: True
+			BackgroundMusic: intro
 
 Sequences:
 


### PR DESCRIPTION
This implements the plan from #8746 with some adaptations.
Also fixes a crash when opening the music player from the TD lobby, and randomizes the default starting song so that it doesn't always play the first song in music.yaml if shuffle is disabled.
