### PR TITLE
TakeCover refactor

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1663,6 +1663,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Refactored TakeCover, removed ProneOffset
+				if (engineVersion < 20150801)
+				{
+					if (depth == 1)
+					{
+						node.Value.Nodes.RemoveAll(n => n.Key == "ProneOffset");
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -75,15 +75,18 @@ e1:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -2
 	# stand -> prone transition
 	liedown:
 		Start: 128
@@ -98,6 +101,7 @@ e1:
 		Start: 192
 		Length: 8
 		Facings: 8
+		Offset: 0, -2
 	idle1:
 		Start: 257
 		Length: 15
@@ -187,19 +191,23 @@ e2:
 		Start: 240
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-stand2:
 		Start: 240
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-run:
 		Start: 240
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -2
 	prone-throw:
 		Start: 288
 		Length: 12
 		Facings: 8
+		Offset: 0, -2
 	idle1:
 		Start: 384
 		Length: 16
@@ -280,19 +288,23 @@ e3:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -2
 	prone-shoot:
 		Start: 192
 		Length: 10
 		Facings: 8
+		Offset: 0, -2
 	idle1:
 		Start: 274
 		Length: 12
@@ -373,19 +385,23 @@ e4:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -2
 	prone-shoot:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Offset: 0, -2
 	idle1:
 		Start: 384
 		Length: 16
@@ -490,19 +506,23 @@ e5:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -2
 	prone-shoot:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Offset: 0, -2
 	idle1:
 		Start: 384
 		Length: 16
@@ -603,15 +623,18 @@ e6:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-stand2:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-run:
 		Start: 82
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -2
 	idle1:
 		Start: 114
 		Length: 6
@@ -692,19 +715,23 @@ rmbo:
 		Start: 112
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-stand2:
 		Start: 112
 		Stride: 4
 		Facings: 8
+		Offset: 0, -2
 	prone-run:
 		Start: 112
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -2
 	prone-shoot:
 		Start: 160
 		Length: 4
 		Facings: 8
+		Offset: 0, -2
 	idle1:
 		Start: 192
 		Length: 16

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -18,12 +18,14 @@ rifle:
 		Start: 310
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	prone-run: DATA.R8
 		Start: 310
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 110
+		Offset: 0, -3
 	standup-0: DATA.R8
 		Start: 302
 		Facings: -8
@@ -34,6 +36,7 @@ rifle:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	die1: DATA.R8
 		Frames: 382, 389, 396, 403, 410, 417, 424, 431, 438, 439, 440, 441
 		Length: 12
@@ -79,12 +82,14 @@ bazooka:
 		Start: 562
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	prone-run: DATA.R8
 		Start: 570
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Offset: 0, -3
 	standup-0: DATA.R8
 		Start: 554
 		Facings: -8
@@ -94,6 +99,7 @@ bazooka:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	die1: DATA.R8
 		Frames: 634, 641, 648, 655, 662, 669, 676, 683, 690, 691, 692, 693
 		Length: 12
@@ -139,12 +145,14 @@ engineer:
 		Start: 1270
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	prone-run: DATA.R8
 		Start: 1278
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Offset: 0, -3
 	die1: DATA.R8
 		Frames: 1342, 1349, 1356, 1363, 1370, 1377, 1384, 1391, 1398, 1399, 1400, 1401
 		Length: 12
@@ -190,12 +198,14 @@ medic: # actually thumper
 		Start: 1470
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	prone-run: DATA.R8
 		Start: 1478
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Offset: 0, -3
 	heal: DATA.R8
 		Start: 1458
 		Length: 5
@@ -261,12 +271,14 @@ fremen:
 		Start: 798
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	prone-run: DATA.R8
 		Start: 806
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Offset: 0, -3
 	standup-0: DATA.R8
 		Start: 790
 		Facings: -8
@@ -277,6 +289,7 @@ fremen:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	die1: DATA.R8
 		Frames: 870, 877, 884, 891, 898, 905, 912, 919, 926, 933, 940, 947
 		Length: 12
@@ -317,12 +330,14 @@ saboteur:
 		Start: 2253
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	prone-run: DATA.R8
 		Start: 2261
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Offset: 0, -3
 	standup-0: DATA.R8
 		Start: 2245
 		Facings: -8
@@ -373,12 +388,14 @@ sardaukar:
 		Start: 1034
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	prone-run: DATA.R8
 		Start: 1042
 		Length: 3
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Offset: 0, -3
 	standup-0: DATA.R8
 		Start: 1026
 		Facings: -8
@@ -389,6 +406,7 @@ sardaukar:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Offset: 0, -3
 	die1: DATA.R8
 		Frames: 1106, 1113, 1120, 1127, 1134, 1141, 1148, 1155, 1162, 1163, 1164, 1165
 		Length: 12
@@ -453,16 +471,19 @@ grenadier: # 2502 - 2749 in 1.06 DATA.R8
 		Start: 104
 		Length: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run: grenadier.shp
 		Start: 104
 		Length: 4
 		Facings: 8
 		Tick: 120
+		Offset: 0, -3
 	prone-throw: grenadier.shp
 		Start: 136
 		Length: 5
 		Facings: 8
 		Tick: 120
+		Offset: 0, -3
 	icon: grenadiericon.shp # 4281 in 1.06 DATA.R8
 		Offset: 0,0
 

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -20,15 +20,18 @@ e1:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -3
 	standup-0:
 		Start: 176
 		Length: 2
@@ -37,6 +40,7 @@ e1:
 		Start: 192
 		Length: 8
 		Facings: 8
+		Offset: 0, -3
 	idle1:
 		Start: 256
 		Length: 16
@@ -101,15 +105,18 @@ sniper:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -3
 	standup:
 		Start: 240
 		Length: 2
@@ -118,6 +125,7 @@ sniper:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Offset: 0, -3
 	idle1:
 		Start: 384
 		Length: 14
@@ -217,19 +225,23 @@ e3:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 120
+		Offset: 0, -3
 	prone-shoot:
 		Start: 192
 		Length: 10
 		Facings: 8
+		Offset: 0, -3
 	icon: e3icon
 
 e6:
@@ -284,15 +296,18 @@ e6:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 82
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -3
 	icon: e6icon
 
 medi:
@@ -352,11 +367,13 @@ medi:
 		Start: 130
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 130
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -3
 	icon: mediicon
 		
 mech:
@@ -416,11 +433,13 @@ mech:
 		Start: 130
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 130
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -3
 	icon: mechicon
 
 e2:
@@ -476,22 +495,26 @@ e2:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
 	prone-stand:
-		Start: 144
+		Start: 240
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
-		Start: 144
+		Start: 240
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 240
 		Length: 4
 		Facings: 8
 		Tick: 80
+		Offset: 0, -3
 	prone-throw:
 		Start: 288
 		Length: 12
 		Facings: 8
+		Offset: 0, -3
 	icon: e2icon
 
 dog:
@@ -596,19 +619,23 @@ spy:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Offset: 0, -3
 	prone-shoot:
 		Start: 192
 		Length: 8
 		Facings: 8
+		Offset: 0, -3
 	icon: spyicon
 
 thf:
@@ -652,11 +679,13 @@ thf:
 		Start: 72
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 72
 		Length: 4
 		Facings: 8
 		Tick: 80
+		Offset: 0, -3
 	icon: thficon
 
 hijacker:
@@ -700,11 +729,13 @@ hijacker:
 		Start: 72
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run: thf
 		Start: 72
 		Length: 4
 		Facings: 8
 		Tick: 80
+		Offset: 0, -3
 	icon: hijackericon
 
 e7:
@@ -760,15 +791,18 @@ e7:
 		Start: 128
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 128
 		Length: 4
 		Facings: 8
 		Tick: 80
+		Offset: 0, -3
 	prone-shoot:
 		Start: 176
 		Length: 7
 		Facings: 8
+		Offset: 0, -3
 	garrison-muzzle: minigun
 		Length: 3
 		Stride: 6
@@ -831,19 +865,23 @@ e4:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 120
+		Offset: 0, -3
 	prone-shoot:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Offset: 0, -3
 	icon: e4icon
 
 gnrl:
@@ -862,10 +900,12 @@ gnrl:
 		Start: 88
 		Stride: 2
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 104
 		Length: 4
 		Facings: 8
+		Offset: 0, -3
 	standup-0:
 		Start: 136
 		Length: 2
@@ -874,6 +914,7 @@ gnrl:
 		Start: 152
 		Length: 4
 		Facings: 8
+		Offset: 0, -3
 	idle1:
 		Start: 184
 		Length: 26
@@ -930,15 +971,18 @@ shok:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Offset: 0, -3
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 120
+		Offset: 0, -3
 	standup:
 		Start: 240
 		Length: 2
@@ -947,6 +991,7 @@ shok:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Offset: 0, -3
 	idle1:
 		Start: 384
 		Length: 14

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -22,11 +22,13 @@ e1:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -55,6 +57,7 @@ e1:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -92,11 +95,13 @@ e2:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -126,6 +131,7 @@ e2:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -163,11 +169,13 @@ e3:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -198,6 +206,7 @@ e3:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -230,6 +239,7 @@ weedguy:
 		Start: 56
 		Facings: 8
 		ShadowStart: 258
+		Offset: 0, -4
 	standup-0:
 		Start: 112
 		Length: 2
@@ -240,11 +250,13 @@ weedguy:
 		Length: 6
 		Facings: 8
 		ShadowStart: 288
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 288
+		Offset: 0, -4
 	idle1:
 		Start: 128
 		Length: 8
@@ -305,11 +317,13 @@ medic:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -371,11 +385,13 @@ engineer:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -433,11 +449,13 @@ umagon:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -468,6 +486,7 @@ umagon:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -505,11 +524,13 @@ ghost:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -540,6 +561,7 @@ ghost:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -577,6 +599,7 @@ jumpjet:
 		Length: 6
 		Facings: 8
 		ShadowStart: 537
+		Offset: 0, -4
 	prone-stand:
 		Facings: 8
 		ShadowStart: 451
@@ -646,11 +669,13 @@ mhijack:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -681,6 +706,7 @@ mhijack:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -718,11 +744,13 @@ chamspy:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -753,6 +781,7 @@ chamspy:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -908,11 +937,13 @@ mutant:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -943,6 +974,7 @@ mutant:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -980,11 +1012,13 @@ mwmn:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -1016,6 +1050,7 @@ mwmn:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -1053,11 +1088,13 @@ mutant3:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -1089,6 +1126,7 @@ mutant3:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -1126,11 +1164,13 @@ tratos:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -1162,6 +1202,7 @@ tratos:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -1199,11 +1240,13 @@ oxanna:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -1235,6 +1278,7 @@ oxanna:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2
@@ -1271,11 +1315,13 @@ slav:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Offset: 0, -4
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 378
+		Offset: 0, -4
 	die1:
 		Start: 134
 		Length: 15
@@ -1307,6 +1353,7 @@ slav:
 		Length: 6
 		Facings: 8
 		ShadowStart: 504
+		Offset: 0, -4
 	standup-0:
 		Start: 260
 		Length: 2


### PR DESCRIPTION
`TakeCover` no longer inherits `Turreted`, and is now upgradable (so it can be enabled/disabled by upgrades).

I ditched `ProneOffset` because in my opinion, custom offsets should be done directly on the sequence definitions whenever possible.
