### PR TITLE
Fix Aircraft.GetActorBelow() altitude checking

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -127,7 +127,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Actor GetActorBelow()
 		{
-			if (self.CenterPosition.Z != 0)
+			// Map.DistanceAboveTerrain(WPos pos) is called directly because Aircraft is an IPositionable trait
+			// and all calls occur in Tick methods.
+			if (self.World.Map.DistanceAboveTerrain(CenterPosition).Length != 0)
 				return null; // not on the ground.
 
 			return self.World.ActorMap.GetUnitsAt(self.Location)


### PR DESCRIPTION
`Map.DistanceAboveTerrain(WPos pos)` is called directly because `Aircraft` is an `IPositionable` trait and all calls to `Aircraft.GetActorBelow()` occur in `Tick` methods.
