### PR TITLE
Remove ProximityCaptor from TS camera.

### DIFF
--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -38,8 +38,6 @@ CAMERA:
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
-	ProximityCaptor:
-		Types: Camera
 	BodyOrientation:
 	DetectCloaked:
 		Range: 10


### PR DESCRIPTION
Removes some more rules uglyness that leaked from RA.
