### PR TITLE
Use background music for Fort Lonestar rain.

### DIFF
--- a/mods/ra/audio/music.yaml
+++ b/mods/ra/audio/music.yaml
@@ -25,7 +25,7 @@ twin: Twin Cannon
 vector1a: Vector
 work226m: Workmen
 
-#Counterstrike tracks
+# Counterstrike tracks
 2nd_hand: The Second Hand
 backstab: Backstab
 shut_it: Shut It
@@ -35,7 +35,7 @@ twinmix1: Twin Cannon Remix
 vr2: Voice Rhythm 2
 araziod: Arazoid
 
-#Aftermath tracks
+# Aftermath tracks
 bog: Bog
 gloom: Gloom
 rpt: Running through Pipes (Mech Man 2)
@@ -44,3 +44,7 @@ float_v2: Floating
 grndwire: Ground Wire
 search: The Search
 wastelnd: Wasteland
+
+# Special effects
+rain: Rain (ambient)
+	Hidden: true

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -506,8 +506,8 @@ Rules:
 			Green: 0.85
 			Blue: 1.5
 			Ambient: 0.35
-		AmbientSound:
-			SoundFile: rain.aud
+		MusicPlaylist:
+			BackgroundMusic: rain
 		FlashPaletteEffect@LIGHTNINGSTRIKE:
 			Type: LightningStrike
 		LuaScript:


### PR DESCRIPTION
This improves the ambience (as the rain is not masked with music by default) and prevents a conflict with the game music if the player does choose to play something manually.  The volume of the rain effect is now also tied to the music volume.
