### PR TITLE
Fix a divide by zero crash in TabCompletionLogic.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (string.IsNullOrWhiteSpace(text))
 				return text;
 
-			if (lastCompleted == text)
+			if (lastCompleted == text && candidates.Any())
 			{
 				lastCompleted = prefix + candidates[++currentCandidateIndex % candidates.Count] + suffix;
 				return lastCompleted;


### PR DESCRIPTION
Repro case: type "/alld" into the chat, press tab, delete the last character, press tab again.
