### PR TITLE
Improved the --check-yaml performance

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using System.Reflection;
 using OpenRA.Traits;
 
@@ -20,24 +21,29 @@ namespace OpenRA.Mods.Common.Lint
 
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
+			if (map != null && !map.RuleDefinitions.Any())
+				return;
+
+			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
+
 			this.emitError = emitError;
 
-			foreach (var actorInfo in map.Rules.Actors)
+			foreach (var actorInfo in rules.Actors)
 				foreach (var traitInfo in actorInfo.Value.Traits.WithInterface<ITraitInfo>())
-					CheckTrait(actorInfo.Value, traitInfo, map);
+					CheckTrait(actorInfo.Value, traitInfo, rules);
 		}
 
-		void CheckTrait(ActorInfo actorInfo, ITraitInfo traitInfo, Map map)
+		void CheckTrait(ActorInfo actorInfo, ITraitInfo traitInfo, Ruleset rules)
 		{
 			var actualType = traitInfo.GetType();
 			foreach (var field in actualType.GetFields())
 			{
 				if (field.HasAttribute<ActorReferenceAttribute>())
-					CheckReference(actorInfo, traitInfo, field, map.Rules.Actors, "actor");
+					CheckReference(actorInfo, traitInfo, field, rules.Actors, "actor");
 				if (field.HasAttribute<WeaponReferenceAttribute>())
-					CheckReference(actorInfo, traitInfo, field, map.Rules.Weapons, "weapon");
+					CheckReference(actorInfo, traitInfo, field, rules.Weapons, "weapon");
 				if (field.HasAttribute<VoiceSetReferenceAttribute>())
-					CheckReference(actorInfo, traitInfo, field, map.Rules.Voices, "voice");
+					CheckReference(actorInfo, traitInfo, field, rules.Voices, "voice");
 			}
 		}
 

--- a/OpenRA.Mods.Common/Lint/CheckActors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActors.cs
@@ -18,6 +18,9 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
+			if (map == null)
+				return;
+
 			var actorTypes = map.ActorDefinitions.Select(a => a.Value.Value);
 			foreach (var actor in actorTypes)
 				if (!map.Rules.Actors.Keys.Contains(actor.ToLowerInvariant()))

--- a/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
@@ -20,7 +20,12 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			foreach (var actorInfo in map.Rules.Actors)
+			if (map != null && !map.RuleDefinitions.Any())
+				return;
+
+			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
+
+			foreach (var actorInfo in rules.Actors)
 			{
 				var animations = actorInfo.Value.Traits.WithInterface<WithDeathAnimationInfo>().ToList();
 				if (!animations.Any())
@@ -34,7 +39,7 @@ namespace OpenRA.Mods.Common.Lint
 				if (!targetable.Any())
 					continue;
 
-				foreach (var weaponInfo in map.Rules.Weapons)
+				foreach (var weaponInfo in rules.Weapons)
 				{
 					var warheads = weaponInfo.Value.Warheads.OfType<DamageWarhead>().Where(dw => dw.Damage > 0);
 

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -20,7 +20,12 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			foreach (var actorInfo in map.Rules.Actors)
+			if (map != null && !map.RuleDefinitions.Any())
+				return;
+
+			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
+
+			foreach (var actorInfo in rules.Actors)
 			{
 				if (actorInfo.Key.StartsWith("^"))
 					continue;

--- a/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
@@ -18,6 +18,9 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
+			if (map == null)
+				return;
+
 			if (map.Bounds.Left == 0 || map.Bounds.Top == 0
 				|| map.Bounds.Right == map.MapSize.X || map.Bounds.Bottom == map.MapSize.Y)
 				emitError("This map does not define a valid cordon.\n"

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
+			if (map == null)
+				return;
+
 			var players = new MapPlayers(map.PlayerDefinitions).Players;
 
 			var playerNames = players.Values.Select(p => p.Name).ToHashSet();

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -20,7 +20,12 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			foreach (var actorInfo in map.Rules.Actors)
+			if (map != null && !map.RuleDefinitions.Any())
+				return;
+
+			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
+
+			foreach (var actorInfo in rules.Actors)
 			{
 				if (actorInfo.Key.StartsWith("^"))
 					continue;

--- a/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
+			if (map != null)
+				return;
+
 			/* first, check all the types implementing ISync */
 			foreach (var t in Game.ModData.ObjectCreator.GetTypesImplementing<ISync>())
 				if (!HasAnySyncFields(t))

--- a/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
@@ -18,7 +18,12 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			foreach (var actorInfo in map.Rules.Actors.Where(a => !a.Key.StartsWith("^")))
+			if (map != null && !map.RuleDefinitions.Any())
+				return;
+
+			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
+
+			foreach (var actorInfo in rules.Actors.Where(a => !a.Key.StartsWith("^")))
 				try
 				{
 					var hasTraits = actorInfo.Value.TraitsInConstructOrder().Any();

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -19,7 +19,12 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			foreach (var actorInfo in map.Rules.Actors)
+			if (map != null && !map.RuleDefinitions.Any() && !map.VoiceDefinitions.Any())
+				return;
+
+			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
+
+			foreach (var actorInfo in rules.Actors)
 			{
 				foreach (var traitInfo in actorInfo.Value.Traits.WithInterface<ITraitInfo>())
 				{
@@ -32,16 +37,16 @@ namespace OpenRA.Mods.Common.Lint
 							if (string.IsNullOrEmpty(voiceSet))
 								continue;
 
-							CheckVoices(actorInfo.Value, emitError, map, voiceSet);
+							CheckVoices(actorInfo.Value, emitError, rules, voiceSet);
 						}
 					}
 				}
 			}
 		}
 
-		void CheckVoices(ActorInfo actorInfo, Action<string> emitError, Map map, string voiceSet)
+		void CheckVoices(ActorInfo actorInfo, Action<string> emitError, Ruleset rules, string voiceSet)
 		{
-			var soundInfo = map.Rules.Voices[voiceSet.ToLowerInvariant()];
+			var soundInfo = rules.Voices[voiceSet.ToLowerInvariant()];
 
 			foreach (var traitInfo in actorInfo.Traits.WithInterface<ITraitInfo>())
 			{

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -19,20 +19,25 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
+			if (map != null && !map.RuleDefinitions.Any())
+				return;
+
+			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
+
 			// ProvidesPrerequisite allows arbitrary prereq definitions
-			var customPrereqs = map.Rules.Actors.SelectMany(a => a.Value.Traits
+			var customPrereqs = rules.Actors.SelectMany(a => a.Value.Traits
 				.WithInterface<ProvidesPrerequisiteInfo>().Select(p => p.Prerequisite ?? a.Value.Name));
 
 			// ProvidesTechPrerequisite allows arbitrary prereq definitions
 			// (but only one group at a time during gameplay)
-			var techPrereqs = map.Rules.Actors.SelectMany(a => a.Value.Traits
+			var techPrereqs = rules.Actors.SelectMany(a => a.Value.Traits
 				.WithInterface<ProvidesTechPrerequisiteInfo>())
 				.SelectMany(p => p.Prerequisites);
 
 			var providedPrereqs = customPrereqs.Concat(techPrereqs);
 
 			// TODO: this check is case insensitive while the real check in-game is not
-			foreach (var i in map.Rules.Actors)
+			foreach (var i in rules.Actors)
 			{
 				var bi = i.Value.Traits.GetOrDefault<BuildableInfo>();
 				if (bi != null)

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -49,21 +49,29 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				ObjectCreator.MissingTypeAction = s => EmitError("Missing Type: {0}".F(s));
 				FieldLoader.UnknownFieldAction = (s, f) => EmitError("FieldLoader: Missing field `{0}` on `{1}`".F(s, f.Name));
 
-				IEnumerable<Map> maps;
+				var maps = new List<Map>();
 				if (args.Length < 2)
 				{
+					maps.Add(null);
 					Game.ModData.MapCache.LoadMaps();
-					maps = Game.ModData.MapCache
+					maps.AddRange(Game.ModData.MapCache
 						.Where(m => m.Status == MapStatus.Available)
-						.Select(m => m.Map);
+						.Select(m => m.Map));
 				}
 				else
-					maps = new[] { new Map(args[1]) };
+					maps.Add(new Map(args[1]));
 
 				foreach (var testMap in maps)
 				{
-					Console.WriteLine("Testing map: {0}".F(testMap.Title));
-					testMap.PreloadRules();
+					if (testMap != null)
+					{
+						Console.WriteLine("Testing map: {0}".F(testMap.Title));
+						testMap.PreloadRules();
+					}
+					else
+					{
+						Console.WriteLine("Testing mod: {0}".F(Game.ModData.Manifest.Mod.Title));
+					}
 
 					foreach (var customPassType in Game.ModData.ObjectCreator
 						.GetTypesImplementing<ILintPass>())


### PR DESCRIPTION
This speeds up the linter by aborting early. It checks either mod or map and skips redundant checks such as unchanged rules.
