### PR TITLE
Fix orphaned tooltips when dismissing a dropdown.

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -131,6 +131,13 @@ namespace OpenRA.Widgets
 			while (WindowList.Count > 0)
 				CloseWindow();
 		}
+
+		public static void ResetTooltips()
+		{
+			// Issue a no-op mouse move to force any tooltips to be recalculated
+			HandleInput(new MouseInput(MouseInputEvent.Move, MouseButton.None, 0,
+				Viewport.LastMousePos, Modifiers.None, 0));
+		}
 	}
 
 	public abstract class Widget

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -67,6 +67,8 @@ namespace OpenRA.Mods.Common.Widgets
 			panelRoot.RemoveChild(fullscreenMask);
 			panelRoot.RemoveChild(panel);
 			panel = fullscreenMask = null;
+
+			Ui.ResetTooltips();
 		}
 
 		public void AttachPanel(Widget p) { AttachPanel(p, null); }

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -79,10 +79,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				// Update mouseover
 				if (oldListOffset != currentListOffset)
-				{
-					var mi = new MouseInput(MouseInputEvent.Move, MouseButton.None, 0, Viewport.LastMousePos, Modifiers.None, 0);
-					Ui.HandleInput(mi);
-				}
+					Ui.ResetTooltips();
 			}
 		}
 
@@ -266,9 +263,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				currentListOffset += offsetDiff * SmoothScrollSpeed.Clamp(0.1f, 1.0f);
 
-				// Update mouseover
-				var mi = new MouseInput(MouseInputEvent.Move, MouseButton.None, 0, Viewport.LastMousePos, Modifiers.None, 0);
-				Ui.HandleInput(mi);
+				Ui.ResetTooltips();
 			}
 			else
 				SetListOffset(targetListOffset, false);


### PR DESCRIPTION
This forces tooltips to be recalculated when a DropDownButtonWidget is dismissed.

Fixes #8944.
