### PR TITLE
Prevent shroud from being revealed outside the map cordon.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -193,7 +193,7 @@ namespace OpenRA.Traits
 			foreach (var puv in cells)
 			{
 				var uv = (MPos)puv;
-				if (!explored[uv])
+				if (map.Contains(puv) && !explored[uv])
 				{
 					explored[uv] = true;
 					changed.Add(puv);


### PR DESCRIPTION
Fixes #8947.  Also fixes a potential crash if somebody passed a coordinate outside the map (not bounds) area.

Easy testcase is to increase `MPStartLocations: InitialExploreRange` to a large value and then pick a spawn point near the edge in any mod.
