### PR TITLE
Force helicopters to land before transforming.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -112,6 +112,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.HasTrait<IFacing>())
 				self.QueueActivity(new Turn(self, info.Facing));
 
+			if (self.HasTrait<Helicopter>())
+				self.QueueActivity(new HeliLand(self, true));
+
 			foreach (var nt in self.TraitsImplementing<INotifyTransform>())
 				nt.BeforeTransform(self);
 


### PR DESCRIPTION
Fixes the issue shown in http://www.ppmforums.com/viewtopic.php?p=534110

This does not need a flag because Transforms is not to be used for aircraft -> aircraft transformations.  We have the upgrade system for intra-actor state changes.
