### PR TITLE
Added Tiberian Sun decorational actors

### DIFF
--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -565,3 +565,19 @@
 	Tooltip:
 		Name: Rock
 
+^Decoration:
+	HiddenUnderShroud:
+	RenderSprites:
+		Palette: terraindecoration
+	WithSpriteBody:
+	AutoSelectionSize:
+	Building:
+		Footprint: x
+		Dimensions: 1, 1
+	BodyOrientation:
+		UseClassicPerspectiveFudge: False
+
+^Box:
+	Inherits: ^Decoration
+	Tooltip:
+		Name: Box

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -581,3 +581,8 @@
 	Inherits: ^Decoration
 	Tooltip:
 		Name: Box
+
+^Drum:
+	Inherits: ^Decoration
+	Tooltip:
+		Name: Drum

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -586,3 +586,8 @@
 	Inherits: ^Decoration
 	Tooltip:
 		Name: Drum
+
+^Palette:
+	Inherits: ^Decoration
+	Tooltip:
+		Name: Palette

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -115,3 +115,21 @@ TROCK04:
 TROCK05:
 	Inherits: ^Rock
 
+CRAT01:
+	Inherits: ^Box
+
+CRAT02:
+	Inherits: ^Box
+
+CRAT03:
+	Inherits: ^Box
+
+CRAT04:
+	Inherits: ^Box
+
+CRAT0A:
+	Inherits: ^Box
+
+CRAT0B:
+	Inherits: ^Box
+

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -133,3 +133,8 @@ CRAT0A:
 CRAT0B:
 	Inherits: ^Box
 
+DRUM01:
+	Inherits: ^Drum
+
+DRUM02:
+	Inherits: ^Drum

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -138,3 +138,15 @@ DRUM01:
 
 DRUM02:
 	Inherits: ^Drum
+
+PALET01:
+	Inherits: ^Palette
+
+PALET02:
+	Inherits: ^Palette
+
+PALET03:
+	Inherits: ^Palette
+
+PALET04:
+	Inherits: ^Palette

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -499,3 +499,9 @@ crat0b:
 
 crat0c:
 	idle:
+
+drum01:
+	idle:
+
+drum02:
+	idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -505,3 +505,15 @@ drum01:
 
 drum02:
 	idle:
+
+palet01:
+	idle:
+
+palet02:
+	idle:
+
+palet03:
+	idle:
+
+palet04:
+	idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -478,3 +478,24 @@ dbris8lg:
 dbris9lg:
 	idle:
 		Length:*
+
+crat01:
+	idle:
+
+crat02:
+	idle:
+
+crat03:
+	idle:
+
+crat04:
+	idle:
+
+crat0a:
+	idle:
+
+crat0b:
+	idle:
+
+crat0c:
+	idle:


### PR DESCRIPTION
including boxes/crates, barrels and palettes which for some reasons are overlays in Tiberian Sun. We will make them normal actors. Kept the names compatible with the conversion code at https://github.com/OpenRA/OpenRA/compare/bleed...pchote:ts-map-importer#diff-0ae9cae5772783a57dba2df98e2bde26R82
