### PR TITLE
Fixed the RallyPoint trait for Tiberian Sun polish

### DIFF
--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -20,22 +20,22 @@ namespace OpenRA.Mods.Common.Effects
 	{
 		readonly Actor building;
 		readonly RallyPoint rp;
-		readonly string palettePrefix;
+		readonly string paletteName;
 		readonly Animation flag;
 		readonly Animation circles;
 
-		public RallyPointIndicator(Actor building, string palettePrefix)
+		public RallyPointIndicator(Actor building, string paletteName)
 		{
 			this.building = building;
-			this.palettePrefix = palettePrefix;
+			this.paletteName = paletteName;
 
 			rp = building.Trait<RallyPoint>();
 
-			flag = new Animation(building.World, "rallypoint");
-			circles = new Animation(building.World, "rallypoint");
+			flag = new Animation(building.World, rp.Info.Image);
+			flag.PlayRepeating(rp.Info.FlagSequence);
 
-			flag.PlayRepeating("flag");
-			circles.Play("circles");
+			circles = new Animation(building.World, rp.Info.Image);
+			circles.Play(rp.Info.CirclesSequence);
 		}
 
 		CPos cachedLocation;
@@ -43,10 +43,11 @@ namespace OpenRA.Mods.Common.Effects
 		{
 			flag.Tick();
 			circles.Tick();
+
 			if (cachedLocation != rp.Location)
 			{
 				cachedLocation = rp.Location;
-				circles.Play("circles");
+				circles.Play(rp.Info.CirclesSequence);
 			}
 
 			if (!building.IsInWorld || building.IsDead)
@@ -62,7 +63,7 @@ namespace OpenRA.Mods.Common.Effects
 				return SpriteRenderable.None;
 
 			var pos = wr.World.Map.CenterOfCell(cachedLocation);
-			var palette = wr.Palette(palettePrefix + building.Owner.InternalName);
+			var palette = wr.Palette(paletteName);
 			return circles.Render(pos, palette).Concat(flag.Render(pos, palette));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -17,8 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Used to waypoint units after production or repair is finished.")]
 	public class RallyPointInfo : ITraitInfo
 	{
-		public readonly CVec RallyPoint = new CVec(1, 3);
 		public readonly string IndicatorPalettePrefix = "player";
+		public readonly CVec Offset = new CVec(1, 3);
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -17,7 +17,16 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Used to waypoint units after production or repair is finished.")]
 	public class RallyPointInfo : ITraitInfo
 	{
-		public readonly string IndicatorPalettePrefix = "player";
+		public readonly string Image = "rallypoint";
+		[SequenceReference("Image")] public readonly string FlagSequence = "flag";
+		[SequenceReference("Image")] public readonly string CirclesSequence = "circles";
+
+		[Desc("Custom indicator palette name")]
+		public readonly string Palette = "player";
+
+		[Desc("Custom palette is a player palette BaseName")]
+		public readonly bool IsPlayerPalette = true;
+
 		public readonly CVec Offset = new CVec(1, 3);
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
@@ -26,11 +35,14 @@ namespace OpenRA.Mods.Common.Traits
 	public class RallyPoint : IIssueOrder, IResolveOrder, ISync
 	{
 		[Sync] public CPos Location;
+		public RallyPointInfo Info;
 
 		public RallyPoint(Actor self, RallyPointInfo info)
 		{
-			Location = self.Location + info.RallyPoint;
-			self.World.AddFrameEndTask(w => w.Add(new RallyPointIndicator(self, info.IndicatorPalettePrefix)));
+			Info = info;
+			Location = self.Location + info.Offset;
+			var palette = info.IsPlayerPalette ? info.Palette + self.Owner.InternalName : info.Palette;
+			self.World.AddFrameEndTask(w => w.Add(new RallyPointIndicator(self, palette)));
 		}
 
 		public IEnumerable<IOrderTargeter> Orders

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1730,6 +1730,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "SpawnActorOnDeath";
 				}
 
+				if (engineVersion < 20150810)
+				{
+					if (depth == 2 && parentKey == "RallyPoint" && node.Key == "RallyPoint")
+						node.Key = "Offset";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -329,7 +329,7 @@ AFLD:
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
 	RallyPoint:
-		RallyPoint: 4,2
+		Offset: 4,2
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
@@ -374,7 +374,7 @@ WEAP:
 	WithProductionDoorOverlay:
 		Sequence: build-top
 	RallyPoint:
-		RallyPoint: 0,3
+		Offset: 0,3
 	Exit@1:
 		SpawnOffset: -341,-341,0
 		ExitCell: 0,2

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -73,7 +73,7 @@ BIO:
 		LowPowerSlowdown: 3
 	ProductionBar:
 	RallyPoint:
-		RallyPoint: -1,-1
+		Offset: -1,-1
 	SpawnActorOnDeath:
 		HuskActor: BIO.Husk
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -136,7 +136,7 @@ barracks:
 	RevealsShroud:
 		Range: 5c0
 	RallyPoint:
-		RallyPoint: 1,3
+		Offset: 1,3
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
@@ -287,7 +287,7 @@ light:
 			atreides: light.atreides
 			ordos: light.ordos
 	RallyPoint:
-		RallyPoint: 2,2
+		Offset: 2,2
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
@@ -339,7 +339,7 @@ heavy:
 	RevealsShroud:
 		Range: 4c0
 	RallyPoint:
-		RallyPoint: 0,3
+		Offset: 0,3
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
@@ -440,7 +440,7 @@ starport:
 	RevealsShroud:
 		Range: 7c0
 	RallyPoint:
-		RallyPoint: 1,3
+		Offset: 1,3
 	Exit@1:
 		SpawnOffset: 0,-480,0
 		ExitCell: 2,2
@@ -665,7 +665,7 @@ repair:
 		ValuePercentage: 50
 		FinishRepairingNotification: UnitRepaired
 	RallyPoint:
-		RallyPoint: 1,3
+		Offset: 1,3
 	RenderBuilding:
 		Image: repair.harkonnen
 		RaceImages:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1390,7 +1390,7 @@ KENN:
 	Bib:
 		HasMinibib: True
 	RallyPoint:
-		RallyPoint: 0,2
+		Offset: 0,2
 	Exit:
 		SpawnOffset: -280,400,0
 		ExitCell: 0,1

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -88,6 +88,8 @@ GAPILE:
 		Range: 5c0
 	RallyPoint:
 		Offset: 2,3
+		Palette: mouse
+		IsPlayerPalette: false
 	Exit@1:
 		SpawnOffset: -256,1024,0
 		ExitCell: 2,2
@@ -131,6 +133,8 @@ GAWEAP:
 		Range: 4c0
 	RallyPoint:
 		Offset: 6,1
+		Palette: mouse
+		IsPlayerPalette: false
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 4,1
@@ -177,6 +181,8 @@ GAHPAD:
 	Exit@1:
 		SpawnOffset: 0,-256,0
 	RallyPoint:
+		Palette: mouse
+		IsPlayerPalette: false
 	Production:
 		Produces: Air
 	PrimaryBuilding:
@@ -221,6 +227,8 @@ GADEPT:
 	Reservable:
 	RepairsUnits:
 	RallyPoint:
+		Palette: mouse
+		IsPlayerPalette: false
 	WithIdleOverlay@LIGHT:
 		Sequence: idle-light
 	WithIdleOverlay@GROUND:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -87,7 +87,7 @@ GAPILE:
 	RevealsShroud:
 		Range: 5c0
 	RallyPoint:
-		RallyPoint: 2,3
+		Offset: 2,3
 	Exit@1:
 		SpawnOffset: -256,1024,0
 		ExitCell: 2,2
@@ -130,7 +130,7 @@ GAWEAP:
 	RevealsShroud:
 		Range: 4c0
 	RallyPoint:
-		RallyPoint: 6,1
+		Offset: 6,1
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 4,1

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -100,7 +100,7 @@ NAHAND:
 		SpawnOffset: 384,768,0
 		ExitCell: 3,2
 	RallyPoint:
-		RallyPoint: 3,3
+		Offset: 3,3
 	Production:
 		Produces: Infantry
 	PrimaryBuilding:
@@ -138,7 +138,7 @@ NAWEAP:
 	RevealsShroud:
 		Range: 4c0
 	RallyPoint:
-		RallyPoint: 6,1
+		Offset: 6,1
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 4,1

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -101,6 +101,8 @@ NAHAND:
 		ExitCell: 3,2
 	RallyPoint:
 		Offset: 3,3
+		Palette: mouse
+		IsPlayerPalette: false
 	Production:
 		Produces: Infantry
 	PrimaryBuilding:
@@ -139,6 +141,8 @@ NAWEAP:
 		Range: 4c0
 	RallyPoint:
 		Offset: 6,1
+		Palette: mouse
+		IsPlayerPalette: false
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 4,1
@@ -181,6 +185,8 @@ NAHPAD:
 	Exit@1:
 		SpawnOffset: 0,-256,0
 	RallyPoint:
+		Palette: mouse
+		IsPlayerPalette: false
 	Production:
 		Produces: Air
 	PrimaryBuilding:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -17,16 +17,11 @@ allyrepair:
 		Length: *
 		Tick: 160
 
-# TODO: fix/replace them, just placeholders
 rallypoint:
-	flag: smokland
-		Start: 40
-		Length: 50
-		Offset: 5,-3
-		BlendMode: Additive
-	circles: ring
-		Length: 12
-		BlendMode: Additive
+	flag: mouse
+		Start: 221
+		Length: 8
+	circles: null
 
 beacon:
 	arrow: mouse


### PR DESCRIPTION
The sprites are not hard-coded, but configurable, self-documented and partly optional. Makes it lint testable regarding sprites and also future palette references https://github.com/OpenRA/OpenRA/pull/8749 as well.
