### PR TITLE
Makes map script error display more noticeable.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Mods.Common.Scripting;
 using OpenRA.Traits;
@@ -38,10 +37,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				numTabs++;
 				var objectivesTabButton = widget.Get<ButtonWidget>(string.Concat("BUTTON", numTabs.ToString()));
-				objectivesTabButton.GetText = () => "Objectives";
+				objectivesTabButton.GetText = () => hasError ? "Script Error" : "Objectives";
 				objectivesTabButton.IsVisible = () => lp != null && numTabs > 1;
 				objectivesTabButton.OnClick = () => activePanel = IngameInfoPanel.Objectives;
-				objectivesTabButton.IsHighlighted = () => activePanel == IngameInfoPanel.Objectives;
+				objectivesTabButton.IsHighlighted = () =>
+				{
+					if (hasError)
+						return Game.LocalTick % 20 < 10;
+
+					return activePanel == IngameInfoPanel.Objectives;
+				};
 
 				var panel = hasError ? "SCRIPT_ERROR_PANEL" : iop.PanelName;
 				var objectivesPanel = widget.Get<ContainerWidget>("OBJECTIVES_PANEL");

--- a/mods/cnc/chrome/ingame-infoscripterror.yaml
+++ b/mods/cnc/chrome/ingame-infoscripterror.yaml
@@ -10,6 +10,7 @@ Container@SCRIPT_ERROR_PANEL:
 			Font: Bold
 			Align:Center
 			Text: The map script has encountered a fatal error
+			TextColor: 255,0,0
 		Label@DESCB:
 			X: 15
 			Y: 45

--- a/mods/ra/chrome/ingame-infoscripterror.yaml
+++ b/mods/ra/chrome/ingame-infoscripterror.yaml
@@ -10,6 +10,7 @@ Container@SCRIPT_ERROR_PANEL:
 			Font: Bold
 			Align:Center
 			Text: The map script has encountered a fatal error
+			TextColor: 255,0,0
 		Label@DESCB:
 			X: 15
 			Y: 45


### PR DESCRIPTION
The script error display in the ingame menu is now more noticeable. This PR does the following:
- Changes the text of Objectives tab button to Script Error if there was an error. And also flashes the button.
- Changes the title text color of error message from white to red.

Fixes #8962.
