### PR TITLE
disable beacon button if game is in single player mode

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -68,6 +68,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (beacon != null)
 			{
 				beacon.GetKey = _ => Game.Settings.Keys.PlaceBeaconKey;
+				beacon.IsDisabled = () => world.LobbyInfo.IsSinglePlayer;
 				OrderButtonsChromeUtils.BindOrderButton<BeaconOrderGenerator>(world, beacon, "beacon");
 			}
 		}


### PR DESCRIPTION
Check to see if the game is in single player mode and if it is disable the beacon button.

Closes #8535 
