### PR TITLE
Updated to latest FreeType6 version for Windows while downgrading the dependency to MSVC++ 2008

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -125,13 +125,6 @@ elseif ($command -eq "dependencies")
 	cp download/windows/*.dll ..
 	cd ..
 	echo "Dependencies copied."
-	
-	$dep = "Microsoft Visual C++ 201"
-	$results = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | select DisplayName | Where-Object {$_.DisplayName -like $("$dep*")}
-	if (!($results -is [array]) -and !$results.DisplayName)
-	{
-		Write-Host "Warning! Freetype6.dll requires Microsoft Visual C++ 2010 x86 Redistributable!" -Foreground "Red"
-	}
 }
 elseif ($command -eq "test")
 {

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -26,8 +26,8 @@ fi
 
 if [ ! -f freetype6.dll ]; then
 	echo "Fetching FreeType2 from NuGet"
-	get SharpFont.Dependencies 2.5.5.1
-	cp ./SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll .
+	get SharpFont.Dependencies 2.6.0
+	cp ./SharpFont.Dependencies/bin/msvc9/x86/freetype6.dll .
 	rm -rf SharpFont.Dependencies
 fi
 

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -95,8 +95,8 @@ if (!(Test-Path "windows/lua51.dll"))
 if (!(Test-Path "windows/freetype6.dll"))
 {
 	echo "Fetching FreeType2 from NuGet."
-	./nuget.exe install SharpFont.Dependencies -Version 2.5.5.1 -ExcludeVersion
-	cp SharpFont.Dependencies/bin/msvc10/x86/freetype6.dll ./windows/freetype6.dll
+	./nuget.exe install SharpFont.Dependencies -Version 2.6.0 -ExcludeVersion
+	cp SharpFont.Dependencies/bin/msvc9/x86/freetype6.dll ./windows/freetype6.dll
 	rmdir SharpFont.Dependencies -Recurse
 }
 


### PR DESCRIPTION
This brings it on par with Lua which we were able to only depend on the 2008 version as well. https://github.com/OpenRA/OpenRA/pull/7579

Closes #8493.
