### PR TITLE
Fix for WithAttackAnimation breaking WithMoveAnimation

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Attacking(Actor self, Target target, Armament a, Barrel barrel)
 		{
 			if (!string.IsNullOrEmpty(info.AttackSequence))
-				wsb.PlayCustomAnimation(self, info.AttackSequence);
+				wsb.PlayCustomAnimation(self, info.AttackSequence, () => wsb.CancelCustomAnimation(self));
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -95,6 +95,11 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
+		public void CancelCustomAnimation(Actor self)
+		{
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
+		}
+
 		public virtual void DamageStateChanged(Actor self, AttackInfo e)
 		{
 			if (DefaultAnimation.CurrentSequence != null)


### PR DESCRIPTION
Closes #8977.

Test cases: TS wolverine (does it properly restore move animation after attack?), RA V2 launcher (does it still work as before?).

Fix works according to my own testing.
