### PR TITLE
Added pre-multiplied alpha palettes for cloak effects

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -34,7 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string CloakSound = null;
 		public readonly string UncloakSound = null;
-		[PaletteReference] public readonly string Palette = "cloak";
+
+		public readonly string Palette = "cloak";
+		public readonly bool IsPlayerPalette = false;
 
 		public readonly HashSet<string> CloakTypes = new HashSet<string> { "Cloak" };
 
@@ -112,10 +114,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (Cloaked && IsVisible(self, self.World.RenderPlayer))
 			{
-				if (string.IsNullOrEmpty(Info.Palette))
+				var palette = string.IsNullOrEmpty(Info.Palette) ? null : Info.IsPlayerPalette ? wr.Palette(Info.Palette + self.Owner.InternalName) : wr.Palette(Info.Palette);
+				if (palette == null)
 					return r;
 				else
-					return r.Select(a => a.WithPalette(wr.Palette(Info.Palette)));
+					return r.Select(a => a.WithPalette(palette));
 			}
 			else
 				return SpriteRenderable.None;

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -135,6 +135,7 @@ fremen:
 		CloakDelay: 250
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
+		IsPlayerPalette: true
 	-MustBeDestroyed:
 	Voiced:
 		VoiceSet: FremenVoice

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -26,12 +26,6 @@
 		G: 0
 		B: 0
 		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
-		R: 0
-		G: 0
-		B: 0
-		A: 140
 	PaletteFromRGBA@highlight:
 		Name: highlight
 		R: 255
@@ -87,4 +81,8 @@
 		Premultiply: false
 	PlayerHighlightPalette:
 	FlashPaletteEffect:
+	PaletteFromPlayerPaletteWithAlpha@cloak:
+		BaseName: cloak
+		BasePalette: player
+		Alpha: 0.55
 

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -357,6 +357,7 @@ stealthraider:
 		CloakDelay: 90
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
+		IsPlayerPalette: true
 	AutoTarget:
 		InitialStance: HoldFire
 	-MustBeDestroyed:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -524,7 +524,8 @@ SNIPER:
 		CloakDelay: 120
 		CloakSound:
 		UncloakSound:
-		UncloakOnMove: yes
+		UncloakOnMove: true
+		IsPlayerPalette: true
 	DetectCloaked:
 		Range: 6
 	-MustBeDestroyed:

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -26,8 +26,8 @@
 		G: 0
 		B: 0
 		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
+	PaletteFromRGBA@submerged:
+		Name: submerged
 		R: 0
 		G: 0
 		B: 0
@@ -65,6 +65,10 @@
 	PlayerColorPalette:
 		BasePalette: player
 		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
+	PaletteFromPlayerPaletteWithAlpha@cloak:
+		BaseName: cloak
+		BasePalette: player
+		Alpha: 0.55
 	PlayerHighlightPalette:
 	MenuPaletteEffect:
 	RotationPaletteEffect@defaultwater:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -34,6 +34,7 @@ SS:
 		CloakSound: subshow1.aud
 		UncloakSound: subshow1.aud
 		WhileCloakedUpgrades: underwater
+		Palette: submerged
 	Armament:
 		Weapon: TorpTube
 		LocalOffset: 0,-171,0, 0,171,0
@@ -88,6 +89,7 @@ MSUB:
 		CloakSound: subshow1.aud
 		UncloakSound: subshow1.aud
 		WhileCloakedUpgrades: underwater
+		Palette: submerged
 	Armament:
 		Weapon: SubMissile
 		LocalOffset: 0,-171,0, 0,171,0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -561,6 +561,7 @@ HBOX:
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 60
+		IsPlayerPalette: true
 	Turreted:
 		ROT: 255
 	-QuantizeFacingsFromSequence:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -740,6 +740,7 @@ STNK:
 		CloakDelay: 250
 		CloakSound: appear1.aud
 		UncloakSound: appear1.aud
+		IsPlayerPalette: true
 	DetectCloaked:
 		Range: 6
 	-MustBeDestroyed:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -103,6 +103,7 @@
 		UpgradeMinEnabledLevel: 1
 		InitialDelay: 0
 		CloakDelay: 90
+		IsPlayerPalette: true
 
 ^Building:
 	Inherits: ^BasicBuilding
@@ -208,6 +209,7 @@
 		UpgradeMinEnabledLevel: 1
 		InitialDelay: 0
 		CloakDelay: 90
+		IsPlayerPalette: true
 	MustBeDestroyed:
 
 ^BuildingPlug:
@@ -307,6 +309,7 @@
 		UpgradeMinEnabledLevel: 1
 		InitialDelay: 0
 		CloakDelay: 90
+		IsPlayerPalette: true
 
 ^Soldier:
 	Inherits: ^Infantry
@@ -406,6 +409,7 @@
 		UpgradeMinEnabledLevel: 1
 		InitialDelay: 0
 		CloakDelay: 90
+		IsPlayerPalette: true
 	MustBeDestroyed:
 	RenderSprites:
 	ThrowsShrapnel:

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -63,12 +63,6 @@
 		G: 0
 		B: 0
 		A: 140
-	PaletteFromRGBA@cloak:
-		Name: cloak
-		R: 0
-		G: 0
-		B: 0
-		A: 140
 	PaletteFromRGBA@highlight:
 		Name: highlight
 		R: 255
@@ -110,6 +104,10 @@
 	PlayerColorPalette:
 		BasePalette: player
 		RemapIndex: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+	PaletteFromPlayerPaletteWithAlpha@cloak:
+		BaseName: cloak
+		BasePalette: player
+		Alpha: 0.55
 	PlayerHighlightPalette:
 	MenuPaletteEffect:
 


### PR DESCRIPTION
This implements the cloak effect known from Tiberian Sun and also applies it to Red Alert. Remember the initial "what are the black holes in the ground" impression when we added cloaking to the camo pillbox.
