### PR TITLE
Remove legacy 0% = not targetable assumption

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2143,6 +2143,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20150809)
+				{
+					// Removed 0% versus armor type = cannot target actor assumptions from warheads
+					if (depth == 3 && parentKey == "Versus" && node.Value.Value == "0")
+					{
+						Console.WriteLine("The '0% versus armor type = cannot target this actor' assumption has been removed.");
+						Console.WriteLine("If you want to reproduce its behavior, use ValidTargets/InvalidTargets in");
+						Console.WriteLine("conjunction with one of the Targetable* actor traits.");
+					}
+				}
+
 				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -47,17 +47,6 @@ namespace OpenRA.Mods.Common.Warheads
 			return 100;
 		}
 
-		// TODO: This can be removed after the legacy and redundant 0% = not targetable
-		// assumption has been removed from the yaml definitions
-		public override bool CanTargetActor(ActorInfo victim, Actor firedBy)
-		{
-			var health = victim.Traits.GetOrDefault<HealthInfo>();
-			if (health == null)
-				return false;
-
-			return DamageVersus(victim) > 0;
-		}
-
 		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
 			// Used by traits that damage a single actor, rather than a position

--- a/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
@@ -29,10 +29,6 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public readonly WDist Range = WDist.FromCells(1);
 
-		// TODO: This can be removed after the legacy and redundant 0% = not targetable
-		// assumption has been removed from the yaml definitions
-		public override bool CanTargetActor(ActorInfo victim, Actor firedBy) { return true; }
-
 		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -47,16 +47,9 @@ namespace OpenRA.Mods.Common.Warheads
 		/// <summary>Applies the warhead's effect against the target.</summary>
 		public abstract void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers);
 
-		// TODO: This can be removed after the legacy and redundant 0% = not targetable
-		// assumption has been removed from the yaml definitions
-		public virtual bool CanTargetActor(ActorInfo victim, Actor firedBy) { return false; }
-
 		/// <summary>Checks if the warhead is valid against (can do something to) the actor.</summary>
 		public bool IsValidAgainst(Actor victim, Actor firedBy)
 		{
-			if (!CanTargetActor(victim.Info, firedBy))
-				return false;
-
 			if (!AffectsParent && victim == firedBy)
 				return false;
 
@@ -75,9 +68,6 @@ namespace OpenRA.Mods.Common.Warheads
 		/// <summary>Checks if the warhead is valid against (can do something to) the frozen actor.</summary>
 		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
 		{
-			if (!CanTargetActor(victim.Info, firedBy))
-				return false;
-
 			// AffectsParent checks do not make sense for FrozenActors, so skip to stance checks
 			var stance = firedBy.Owner.Stances[victim.Owner];
 			if (!ValidStances.HasStance(stance))

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -117,7 +117,7 @@
 		UseLocation: yes
 	TargetableAircraft:
 		TargetTypes: Air
-		GroundedTargetTypes: Ground
+		GroundedTargetTypes: Ground, Vehicle
 	SelectionDecorations:
 	Selectable:
 		Bounds: 24,24
@@ -294,7 +294,7 @@
 	Selectable:
 		Bounds: 24,24
 	TargetableUnit:
-		TargetTypes: Ground, Infantry
+		TargetTypes: Ground
 	HiddenUnderFog:
 	WithInfantryBody:
 		AttackSequence: attack
@@ -634,7 +634,7 @@
 		Interval: 2
 	TargetableUnit:
 		RequiresForceFire: yes
-		TargetTypes: Ground
+		TargetTypes: Ground, Husk
 	Capturable:
 		Type: husk
 		AllowAllies: yes

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -1,6 +1,7 @@
 Sniper:
 	Report: RAMGUN2.AUD
-	ValidTargets: Infantry
+	ValidTargets: Ground, Infantry
+	InvalidTargets: Vehicle, Water, Structure, Wall, Husk
 	ReloadDelay: 40
 	Range: 6c0
 	Projectile: Bullet

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -123,7 +123,7 @@ orni:
 		Bounds: 32,32
 	TargetableAircraft:
 		TargetTypes: Air
-		GroundedTargetTypes: Ground
+		GroundedTargetTypes: Ground, Vehicle
 	Voiced:
 		VoiceSet: GenericVoice
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -66,7 +66,7 @@
 	Selectable:
 		Bounds: 32,32
 	TargetableUnit:
-		TargetTypes: Ground, C4
+		TargetTypes: Ground, Vehicle, C4
 	Passenger:
 		CargoType: Vehicle
 	AttackMove:
@@ -129,7 +129,7 @@
 	Burns:
 		Interval: 4
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Vehicle
 		RequiresForceFire: yes
 	Capturable:
 		Type: husk
@@ -187,7 +187,7 @@
 	Selectable:
 		Bounds: 12,18,0,-6
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Infantry
 		UpgradeTypes: parachute
 		UpgradeMaxEnabledLevel: 0
 	RenderSprites:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -510,7 +510,7 @@ wall:
 	LineBuildNode:
 		Types: wall
 	TargetableBuilding:
-		TargetTypes: Ground
+		TargetTypes: Ground, Wall
 	RenderBuildingWall:
 	AutoTargetIgnore:
 	Sellable:

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -57,6 +57,8 @@ Sniper:
 	ReloadDelay: 100
 	Range: 8c512
 	Report: FREMODD1.WAV
+	ValidTargets: Ground, Infantry
+	InvalidTargets: Vehicle, Structure, Wall
 	Projectile: Bullet
 		Speed: 1c896
 		ContrailLength: 6
@@ -66,19 +68,14 @@ Sniper:
 	Warhead@1Dam: SpreadDamage
 		Spread: 32
 		Damage: 60
-		Versus:
-			None: 100
-			Wood: 0
-			Light: 1
-			Heavy: 0
-			Concrete: 0
+		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
 Vulcan:
 	ReloadDelay: 30
 	Range: 5c768
 	Report: VULCAN.AUD
-	ValidTargets: Ground
+	InvalidTargets: Structure
 	Projectile: Bullet
 		Speed: 1c256
 		ContrailLength: 3
@@ -88,12 +85,10 @@ Vulcan:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 30
-		ValidTargets: Ground
+		InvalidTargets: Structure
 		Versus:
-			Wood: 0
 			Light: 60
 			Heavy: 10
-			Concrete: 0
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
@@ -103,7 +98,7 @@ Slung:
 	Delay: 5
 	Range: 5c512
 	Report: BAZOOK2.WAV
-	ValidTargets: Ground
+	InvalidTargets: Infantry
 	Projectile: Bullet
 		Speed: 320
 		Blockable: false
@@ -114,9 +109,8 @@ Slung:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Damage: 30
-		ValidTargets: Ground
+		InvalidTargets: Infantry
 		Versus:
-			None: 0
 			Wood: 75
 			Light: 40
 			Heavy: 90
@@ -372,8 +366,8 @@ DevBullet:
 NerveGasMissile:
 	ReloadDelay: 120
 	Range: 8c0
-	Burst: 1
 	Report: MISSLE1.WAV
+	InvalidTargets: Infantry, Structure
 	Projectile: Bullet
 		Speed: 384
 		Blockable: false
@@ -388,10 +382,7 @@ NerveGasMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 96
 		Damage: 10
-		Versus:
-			None: 0
-			Wood: 0
-			Concrete: 0
+		InvalidTargets: Infantry, Structure
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -476,26 +467,22 @@ Heal:
 	ReloadDelay: 160
 	Range: 4c0
 	Report:
+	ValidTargets: Infantry
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Damage: -50
-		Versus:
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
+		ValidTargets: Infantry
 
 WormJaw:
 	ReloadDelay: 10
 	Range: 3c0
+	InvalidTargets: Structure
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Damage: 100
-		Versus:
-			Wood: 0
-			Concrete: 0
+		InvalidTargets: Structure
 
 ParaBomb:
 	ReloadDelay: 10

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -337,7 +337,7 @@
 		Bounds: 24,24
 	TargetableAircraft:
 		TargetTypes: Air
-		GroundedTargetTypes: Ground, Repair
+		GroundedTargetTypes: Ground, Repair, Vehicle
 	HiddenUnderFog:
 		Type: CenterPosition
 	AttackMove:
@@ -449,7 +449,7 @@
 	LineBuildNode:
 		Types: wall
 	TargetableBuilding:
-		TargetTypes: Ground, DetonateAttack
+		TargetTypes: Ground, DetonateAttack, Wall
 	RenderBuildingWall:
 		Palette: effect
 	GivesExperience:
@@ -580,7 +580,7 @@
 		ForceHealthPercentage: 25
 	DisabledOverlay:
 	TargetableUnit:
-		TargetTypes: Ground
+		TargetTypes: Ground, Husk
 		RequiresForceFire: true
 	Chronoshiftable:
 	Tooltip:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -208,10 +208,8 @@ Nike:
 		ValidTargets: Air
 		Versus:
 			None: 90
-			Wood: 0
 			Light: 90
 			Heavy: 50
-			Concrete: 0
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -186,27 +186,19 @@ DogJaw:
 		Spread: 213
 		Damage: 100
 		ValidTargets: Infantry
-		Versus:
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
 		DamageTypes: DefaultDeath
 
 Heal:
 	ReloadDelay: 80
 	Range: 4c0
 	Report: HEAL2.AUD
+	ValidTargets: Infantry
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		Versus:
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
+		ValidTargets: Infantry
 
 Repair:
 	ReloadDelay: 80
@@ -219,12 +211,6 @@ Repair:
 		Spread: 213
 		Damage: -20
 		ValidTargets: Repair
-		Versus:
-			None: 0
-			Wood: 0
-			Light: 100
-			Heavy: 100
-			Concrete: 0
 
 Crush:
 	Warhead@1Dam: SpreadDamage
@@ -273,22 +259,18 @@ Mandible:
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 
 MADTankThump:
-	InvalidTargets: MADTank
+	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 7c0
 		Damage: 1
-		InvalidTargets: MADTank
-		Versus:
-			None: 0
+		InvalidTargets: MADTank, Infantry
 
 MADTankDetonate:
-	InvalidTargets: MADTank
+	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 7c0
 		Damage: 19
-		InvalidTargets: MADTank
-		Versus:
-			None: 0
+		InvalidTargets: MADTank, Infantry
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		Size: 7,6

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -2,17 +2,14 @@ Colt45:
 	ReloadDelay: 5
 	Range: 7c0
 	Report: GUN5.AUD
+	ValidTargets: Ground, Infantry
+	InvalidTargets: Vehicle, Tank, Water, Structure, Wall, Husk
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 50
-		Versus:
-			None: 100
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
+		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piff
@@ -282,16 +279,14 @@ SilencedPPK:
 	ReloadDelay: 80
 	Range: 2c512
 	Report: silppk.aud
+	ValidTargets: Ground, Infantry
+	InvalidTargets: Vehicle, Tank, Water, Structure, Wall, Husk
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 150
-		Versus:
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
+		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
@@ -333,16 +328,13 @@ Sniper:
 	Report: GUN5.AUD
 	ReloadDelay: 70
 	Range: 10c0
+	ValidTargets: Ground, Infantry
+	InvalidTargets: Vehicle, Tank, Water, Structure, Wall, Husk
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 140
-		Versus:
-			None: 100
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
+		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -2,16 +2,13 @@ Heal:
 	ReloadDelay: 80
 	Range: 2c849
 	Report: HEALER1.AUD
+	ValidTargets: Infantry
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -50
-		Versus:
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
+		ValidTargets: Infantry
 
 Repair:
 	ReloadDelay: 80


### PR DESCRIPTION
None of the first-party mods use the above assumption anymore as far as I could tell, so we might as well remove it now.
