### PR TITLE
Rebalanced stat gains from rank-up

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -17,13 +17,13 @@
 			1600: firepower, damage, speed, reload, inaccuracy, rank, eliteweapon, selfheal
 	FirepowerMultiplier@EXPERIENCE:
 		UpgradeTypes: firepower
-		Modifier: 110, 115, 120, 130
+		Modifier: 105, 110, 120, 130
 	DamageMultiplier@EXPERIENCE:
 		UpgradeTypes: damage
-		Modifier: 91, 87, 83, 65
+		Modifier: 95, 90, 85, 75
 	SpeedMultiplier@EXPERIENCE:
 		UpgradeTypes: speed
-		Modifier: 110, 115, 120, 150
+		Modifier: 105, 110, 120, 140
 	ReloadDelayMultiplier@EXPERIENCE:
 		UpgradeTypes: reload
 		Modifier: 95, 90, 85, 75

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -17,13 +17,13 @@
 			1600: firepower, damage, speed, reload, inaccuracy, rank, eliteweapon, selfheal
 	FirepowerMultiplier@EXPERIENCE:
 		UpgradeTypes: firepower
-		Modifier: 110, 115, 120, 130
+		Modifier: 105, 110, 120, 130
 	DamageMultiplier@EXPERIENCE:
 		UpgradeTypes: damage
-		Modifier: 91, 87, 83, 65
+		Modifier: 95, 90, 85, 75
 	SpeedMultiplier@EXPERIENCE:
 		UpgradeTypes: speed
-		Modifier: 110, 115, 120, 150
+		Modifier: 105, 110, 120, 140
 	ReloadDelayMultiplier@EXPERIENCE:
 		UpgradeTypes: reload
 		Modifier: 95, 90, 85, 75

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -18,13 +18,13 @@
 			1600: firepower, damage, speed, reload, inaccuracy, rank, eliteweapon, selfheal
 	DamageMultiplier@EXPERIENCE:
 		UpgradeTypes: damage
-		Modifier: 91, 87, 83, 65
+		Modifier: 95, 90, 85, 75
 	FirepowerMultiplier@EXPERIENCE:
 		UpgradeTypes: firepower
-		Modifier: 110, 115, 120, 130
+		Modifier: 105, 110, 120, 130
 	SpeedMultiplier@EXPERIENCE:
 		UpgradeTypes: speed
-		Modifier: 110, 115, 120, 150
+		Modifier: 105, 110, 120, 140
 	ReloadDelayMultiplier@EXPERIENCE:
 		UpgradeTypes: reload
 		Modifier: 95, 90, 85, 75

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -19,10 +19,10 @@
 		Modifier: 110, 130
 	DamageMultiplier@EXPERIENCE:
 		UpgradeTypes: damage
-		Modifier: 83, 66
+		Modifier: 90, 75
 	SpeedMultiplier@EXPERIENCE:
 		UpgradeTypes: speed
-		Modifier: 120, 150
+		Modifier: 120, 140
 	ReloadDelayMultiplier@EXPERIENCE:
 		UpgradeTypes: reload
 		Modifier: 90, 75


### PR DESCRIPTION
It was mentioned on IRC that the first, relatively powerful rank-up allows jeeps, for example, to safely bring infantry like spies and engineers to enemy buildings.

This is mainly because the firepower, armor and speed bonuses are about 10% each on first rank-up, whereas the next two, harder to reach rank-ups only add 4-5%.

This lowers the initial buffs, generally flattens the 'armor' curve for level-ups, and lowers the maximum bonus for armor and speed.
