### PR TITLE
Sync only once per tick

### DIFF
--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -19,6 +19,11 @@ namespace OpenRA.Network
 		{
 			public int Client;
 			public Order Order;
+
+			public override string ToString()
+			{
+				return "ClientId: {0} {1}".F(Client, Order);
+			}
 		}
 
 		readonly Dictionary<int, int> clientQuitTimes = new Dictionary<int, int>();

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -35,14 +35,13 @@ namespace OpenRA.Network
 			return ret;
 		}
 
-		public static byte[] SerializeSync(this List<int> sync)
+		public static byte[] SerializeSync(int sync)
 		{
 			var ms = new MemoryStream();
 			using (var writer = new BinaryWriter(ms))
 			{
 				writer.Write((byte)0x65);
-				foreach (var s in sync)
-					writer.Write(s);
+				writer.Write(sync);
 			}
 
 			return ms.ToArray();

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -51,9 +51,9 @@ namespace OpenRA.Network
 
 		bool disposed;
 
-		static void OutOfSync(int frame)
+		void OutOfSync(int frame)
 		{
-			syncReport.DumpSyncReport(frame);
+			syncReport.DumpSyncReport(frame, frameData.OrdersForFrame(World, frame));
 			throw new InvalidOperationException("Out of sync in frame {0}.\n Compare syncreport.log with other players.".F(frame));
 		}
 

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Network
 			}
 		}
 
-		internal void DumpSyncReport(int frame)
+		internal void DumpSyncReport(int frame, IEnumerable<FrameData.ClientOrder> orders)
 		{
 			foreach (var r in syncReports)
 			{
@@ -127,6 +127,10 @@ namespace OpenRA.Network
 							if (nvp.Second[i] != null)
 								Log.Write("sync", "\t\t {0}: {1}".F(nvp.First[i], nvp.Second[i]));
 					}
+
+					Log.Write("sync", "Orders Issued:");
+					foreach (var o in orders)
+						Log.Write("sync", "\t {0}", o.ToString());
 
 					return;
 				}


### PR DESCRIPTION
This greatly improves performance by not syncing the world state for every single order processed as this becomes very expensive, at the cost of being unable to directly pinpoint the order that causes a desync. Instead the granularity of detecting desyncs is reduced to the tick level.

As noted in https://github.com/OpenRA/OpenRA/issues/9008#issuecomment-129202470, in the worst case scenario of running a max speed replay with high orders rates (due to many players, particularly AI in this case), this could represent upto 50% of CPU!

Only syncing once per tick will benefit tick times when:
- Overall orders rates are high (e.g. due to many players or players with high APM (such as AI))
- An order is given to large groups of units (this should reduce the lag spike significantly)

The disadvantage is that in the event of a desync we won't know what specific order caused it, instead we will only know the frame the desync occurred in. This is hopefully a worthwhile tradeoff.
