### PR TITLE
Consolidate rules into ^Defense (all) & ^DeployedVehicle (ts)

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -693,3 +693,12 @@
 	CustomSelectionSize:
 		CustomBounds: 20,20
 
+^Defense:
+	Inherits: ^BaseBuilding
+	AutoTarget:
+	RenderRangeCircle:
+	RenderDetectionCircle:
+	-GivesBuildableArea:
+	MustBeDestroyed:
+		RequiredForShortGame: false
+

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -626,7 +626,7 @@ TMPL:
 	ProvidesPrerequisite@buildingname:
 
 GUN:
-	Inherits: ^BaseBuilding
+	Inherits: ^Defense
 	Valued:
 		Cost: 600
 	CustomBuildTimeValue:
@@ -639,7 +639,6 @@ GUN:
 		Prerequisites: barracks
 		Queue: Defence.GDI, Defence.Nod
 	Building:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
@@ -658,20 +657,15 @@ GUN:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
-	AutoTarget:
 	-RenderBuilding:
 	-WithDeathAnimation:
-	RenderRangeCircle:
-	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 3
 	Power:
 		Amount: -20
-	MustBeDestroyed:
-		RequiredForShortGame: false
 
 SAM:
-	Inherits: ^BaseBuilding
+	Inherits: ^Defense
 	Valued:
 		Cost: 750
 	CustomBuildTimeValue:
@@ -688,7 +682,6 @@ SAM:
 		Dimensions: 2,1
 	RequiresPower:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
@@ -704,16 +697,13 @@ SAM:
 		MuzzleSequence: muzzle
 	AttackPopupTurreted:
 	WithMuzzleFlash:
-	AutoTarget:
 	-RenderBuilding:
-	RenderRangeCircle:
+	-RenderDetectionCircle:
 	Power:
 		Amount: -20
-	MustBeDestroyed:
-		RequiredForShortGame: false
 
 OBLI:
-	Inherits: ^BaseBuilding
+	Inherits: ^Defense
 	Valued:
 		Cost: 1500
 	CustomBuildTimeValue:
@@ -732,7 +722,6 @@ OBLI:
 		Bounds: 24,24,0,12
 	RequiresPower:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 600
 	Armor:
@@ -750,20 +739,15 @@ OBLI:
 		ChargeAudio: obelpowr.aud
 		ReloadTime: 40
 		InitialChargeDelay: 50
-	AutoTarget:
 	-RenderBuilding:
-	RenderRangeCircle:
 	-EmitInfantryOnSell:
-	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 5
 	Power:
 		Amount: -150
-	MustBeDestroyed:
-		RequiredForShortGame: false
 
 GTWR:
-	Inherits: ^BaseBuilding
+	Inherits: ^Defense
 	Valued:
 		Cost: 600
 	CustomBuildTimeValue:
@@ -776,7 +760,6 @@ GTWR:
 		Prerequisites: barracks
 		Queue: Defence.GDI, Defence.Nod
 	Building:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	RevealsShroud:
@@ -790,21 +773,16 @@ GTWR:
 	AttackTurreted:
 	BodyOrientation:
 		QuantizedFacings: 8
-	AutoTarget:
 	DetectCloaked:
 		Range: 3
-	RenderDetectionCircle:
-	RenderRangeCircle:
 	WithMuzzleFlash:
 	Turreted:
 		ROT: 255
 	Power:
 		Amount: -10
-	MustBeDestroyed:
-		RequiredForShortGame: false
 
 ATWR:
-	Inherits: ^BaseBuilding
+	Inherits: ^Defense
 	Valued:
 		Cost: 1000
 	CustomBuildTimeValue:
@@ -823,7 +801,6 @@ ATWR:
 		Bounds: 24,24,0,12
 	RequiresPower:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 600
 	Armor:
@@ -844,17 +821,12 @@ ATWR:
 		LocalOffset: 256,128,0, 256,-128,0
 		LocalYaw: -100,100
 	AttackTurreted:
-	AutoTarget:
 	BodyOrientation:
 		QuantizedFacings: 8
-	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 5
-	RenderRangeCircle:
 	Power:
 		Amount: -40
-	MustBeDestroyed:
-		RequiredForShortGame: false
 
 SBAG:
 	Inherits: ^Wall

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -295,3 +295,20 @@
 		Range: 2c0, 5c0
 	WithMakeAnimation:
 
+^Defense:
+	Inherits: ^Building
+	WithTurret:
+	AttackTurreted:
+	AutoTarget:
+	RenderRangeCircle:
+	RenderDetectionCircle:
+	-GivesBuildableArea:
+	-WithCrumbleOverlay:
+	-WithMakeAnimation:
+	-RenderBuilding:
+	RenderBuildingWall:
+	LineBuildNode:
+		Types: turret
+	MustBeDestroyed:
+		RequiredForShortGame: false
+

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -522,7 +522,7 @@ wall:
 		Range: 2c0, 5c0
 
 guntower:
-	Inherits: ^Building
+	Inherits: ^Defense
 	Buildable:
 		Queue: Building
 		Prerequisites: barracks
@@ -540,19 +540,14 @@ guntower:
 	Selectable:
 		Bounds: 32,32
 		Priority: 3
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
 		Type: Concrete
 	RevealsShroud:
 		Range: 8c0
-	RenderRangeCircle:
-	-RenderBuilding:
-	RenderBuildingWall:
 	BodyOrientation:
 		QuantizedFacings: 32
-	WithTurret:
 	WithMuzzleFlash:
 	Turreted:
 		ROT: 6
@@ -561,24 +556,15 @@ guntower:
 		Weapon: TurretGun
 		LocalOffset: 512,0,432
 		MuzzleSequence: muzzle
-	AttackTurreted:
-	AutoTarget:
-	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 5
-	-WithCrumbleOverlay:
-	-WithMakeAnimation:
-	LineBuildNode:
-		Types: turret
 	Power:
 		Amount: -20
-	MustBeDestroyed:
-		RequiredForShortGame: false
 	SelectionDecorations:
 		VisualBounds: 32,40,0,-8
 
 rockettower:
-	Inherits: ^Building
+	Inherits: ^Defense
 	Buildable:
 		Queue: Building
 		Prerequisites: radar, upgrade.conyard, ~techlevel.medium
@@ -596,41 +582,27 @@ rockettower:
 	Selectable:
 		Bounds: 32,32
 		Priority: 3
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
 		Type: Concrete
 	RevealsShroud:
 		Range: 10c0
-	RenderRangeCircle:
-	-RenderBuilding:
-	RenderBuildingWall:
 	BodyOrientation:
 		QuantizedFacings: 32
-	WithTurret:
 	Armament:
 		Weapon: TowerMissile
 		LocalOffset: 256,384,768, 256,-384,768
-	AttackTurreted:
 	Turreted:
 		ROT: 8
 		InitialFacing: 128
-	AutoTarget:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
-	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 6
-	-WithCrumbleOverlay:
-	-WithMakeAnimation:
-	LineBuildNode:
-		Types: turret
 	Power:
 		Amount: -30
-	MustBeDestroyed:
-		RequiredForShortGame: false
 	SelectionDecorations:
 		VisualBounds: 32,40,0,-8
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -429,6 +429,11 @@
 		TargetTypes: Ground, C4, DetonateAttack, Structure, Defense
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	AutoTarget:
+	-GivesBuildableArea:
+	-AcceptsSupplies:
+	DrawLineToTarget:
+	RenderRangeCircle:
 
 ^Wall:
 	AppearsOnRadar:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -393,7 +393,6 @@ TSLA:
 		VisualBounds: 24,36,0,4
 	CanPowerDown:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
@@ -410,11 +409,7 @@ TSLA:
 		ChargeAudio: tslachg2.aud
 		MaxCharges: 3
 		ReloadTime: 120
-	AutoTarget:
 	-RenderBuilding:
-	RenderRangeCircle:
-	-AcceptsSupplies:
-	DrawLineToTarget:
 	Power:
 		Amount: -100
 	DetectCloaked:
@@ -442,7 +437,6 @@ AGUN:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
@@ -461,12 +455,9 @@ AGUN:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
-	AutoTarget:
 	-RenderBuilding:
 	RenderRangeCircle:
 		RangeCircleType: aa
-	-AcceptsSupplies:
-	DrawLineToTarget:
 	Power:
 		Amount: -50
 	DetectCloaked:
@@ -517,7 +508,6 @@ PBOX:
 		Queue: Defense
 		BuildPaletteOrder: 40
 		Prerequisites: tent, ~structures.allies, ~techlevel.low
-	-GivesBuildableArea:
 	Valued:
 		Cost: 400
 	Health:
@@ -528,7 +518,6 @@ PBOX:
 		Range: 6c0
 	Bib:
 		HasMinibib: Yes
-	-AcceptsSupplies:
 	Turreted:
 		ROT: 255
 	BodyOrientation:
@@ -539,7 +528,6 @@ PBOX:
 		PipCount: 1
 		InitialUnits: e1
 	-EmitInfantryOnSell:
-	DrawLineToTarget:
 	AttackGarrisoned:
 		Armaments: garrisoned
 		PortOffsets: 384,0,128, 224,-341,128, -224,-341,128, -384,0,128, -224,341,128, 224,341,128
@@ -547,7 +535,6 @@ PBOX:
 		PortCones: 86, 86, 86, 86, 86, 86
 	RenderRangeCircle:
 		FallbackRange: 6c0
-	AutoTarget:
 	Power:
 		Amount: -15
 	DetectCloaked:
@@ -563,7 +550,6 @@ HBOX:
 		Queue: Defense
 		BuildPaletteOrder: 50
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
-	-GivesBuildableArea:
 	Valued:
 		Cost: 600
 	Health:
@@ -575,7 +561,6 @@ HBOX:
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 60
-	-AcceptsSupplies:
 	Turreted:
 		ROT: 255
 	BodyOrientation:
@@ -586,12 +571,10 @@ HBOX:
 		PipCount: 1
 		InitialUnits: e1
 	-EmitInfantryOnSell:
-	DrawLineToTarget:
 	DetectCloaked:
 		Range: 6
 	RenderRangeCircle:
 		FallbackRange: 6c0
-	AutoTarget:
 	AttackGarrisoned:
 		Armaments: garrisoned
 		PortOffsets: 384,0,128, 224,-341,128, -224,-341,128, -384,0,128, -224,341,128, 224,341,128
@@ -613,7 +596,6 @@ GUN:
 		Name: Turret
 		Description: Anti-Armor base defense.\nCan detect cloaked units.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Building:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
@@ -632,11 +614,7 @@ GUN:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
-	AutoTarget:
 	-RenderBuilding:
-	RenderRangeCircle:
-	-AcceptsSupplies:
-	DrawLineToTarget:
 	Power:
 		Amount: -40
 	DetectCloaked:
@@ -654,7 +632,6 @@ FTUR:
 		Name: Flame Tower
 		Description: Anti-Infantry base defense.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Building:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
@@ -672,10 +649,6 @@ FTUR:
 	AttackTurreted:
 	BodyOrientation:
 		QuantizedFacings: 8
-	AutoTarget:
-	RenderRangeCircle:
-	-AcceptsSupplies:
-	DrawLineToTarget:
 	Power:
 		Amount: -20
 	DetectCloaked:
@@ -699,7 +672,6 @@ SAM:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
@@ -717,12 +689,9 @@ SAM:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
-	AutoTarget:
 	-RenderBuilding:
 	RenderRangeCircle:
 		RangeCircleType: aa
-	-AcceptsSupplies:
-	DrawLineToTarget:
 	Power:
 		Amount: -40
 	DetectCloaked:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -595,3 +595,40 @@
 	Inherits: ^Decoration
 	Tooltip:
 		Name: Palette
+
+^Defense:
+	Inherits: ^Building
+	-GivesBuildableArea:
+	AutoTarget:
+	RenderRangeCircle:
+	RenderDetectionCircle:
+	RevealsShroud:
+		Range: 6c0
+	DetectCloaked:
+		Range: 5
+
+^DeployedVehicle:
+	Inherits@1: ^GainsExperience
+	Inherits@2: ^ExistsInWorld
+	Voiced:
+		VoiceSet: Vehicle
+	AttackTurreted:
+		Voice: Attack
+	AutoTarget:
+	RenderRangeCircle:
+	DrawLineToTarget:
+	Building:
+		Dimensions: 1,1
+		Footprint: x
+		TerrainTypes: Clear, Road, DirtRoad, Rough
+	RenderBuilding:
+	WithMakeAnimation:
+	SelectionDecorations:
+		Palette: pips
+	Selectable:
+	TargetableBuilding:
+		TargetTypes: Ground, Repair
+	Guardable:
+	HiddenUnderFog:
+	ActorLostNotification:
+

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -24,7 +24,7 @@ GAWALL:
 		NodeTypes: wall, turret
 
 GACTWR:
-	Inherits: ^Building
+	Inherits: ^Defense
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -38,22 +38,15 @@ GACTWR:
 	Selectable:
 		Bounds: 48, 36, 0, -6
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 500
 	Armor:
 		Type: Light
-	RevealsShroud:
-		Range: 6c0
 	BodyOrientation:
 		QuantizedFacings: 32
-	RenderRangeCircle:
-	RenderDetectionCircle:
 	DetectCloaked:
 		UpgradeTypes: tower
 		UpgradeMinEnabledLevel: 1
-		Range: 5
-	AutoTarget:
 	Turreted:
 		ROT: 10
 		InitialFacing: 50

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -24,7 +24,7 @@ NAWALL:
 		NodeTypes: wall, turret
 
 NALASR:
-	Inherits: ^Building
+	Inherits: ^Defense
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -39,15 +39,12 @@ NALASR:
 		Bounds: 40, 30, -8, -6
 	RequiresPower:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 400
 	Armor:
 		Type: Light
 	RevealsShroud:
 		Range: 5c0
-	RenderRangeCircle:
-	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 3
 	Turreted:
@@ -59,14 +56,13 @@ NALASR:
 		Weapon: LaserFire2
 	RenderVoxels:
 	WithVoxelTurret:
-	AutoTarget:
 	Power:
 		Amount: -40
 	SelectionDecorations:
 		VisualBounds: 40, 36, -8, -8
 
 NAOBEL:
-	Inherits: ^Building
+	Inherits: ^Defense
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -83,7 +79,6 @@ NAOBEL:
 		Bounds: 88, 42, 0, -6
 	RequiresPower:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 600
 	Armor:
@@ -101,11 +96,6 @@ NAOBEL:
 		Sequence: active
 		Palette: player
 		IsPlayerPalette: true
-	AutoTarget:
-	RenderRangeCircle:
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 5
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	Power:
@@ -114,7 +104,7 @@ NAOBEL:
 		VisualBounds: 88, 72, 0, -12
 
 NASAM:
-	Inherits: ^Building
+	Inherits: ^Defense
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -129,20 +119,14 @@ NASAM:
 		Bounds: 40, 30, -3, -8
 	RequiresPower:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 500
 	Armor:
 		Type: Light
-	RevealsShroud:
-		Range: 6c0
 	BodyOrientation:
 		QuantizedFacings: 32
 	RenderRangeCircle:
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 5
-	AutoTarget:
+		RangeCircleType: aa
 	Turreted:
 		ROT: 10
 		InitialFacing: 50
@@ -158,8 +142,7 @@ NASAM:
 		VisualBounds: 40, 36, -3, -8
 
 GATICK:
-	Inherits@1: ^GainsExperience
-	Inherits@2: ^ExistsInWorld
+	Inherits: ^DeployedVehicle
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -170,8 +153,6 @@ GATICK:
 		Type: Concrete
 	RevealsShroud:
 		Range: 5c0
-	Voiced:
-		VoiceSet: Vehicle
 	Turreted:
 		ROT: 6
 		InitialFacing: 128
@@ -189,18 +170,8 @@ GATICK:
 		UpgradeTypes: eliteweapon
 		UpgradeMinEnabledLevel: 1
 		MuzzleSequence: muzzle
-	AttackTurreted:
-		Voice: Attack
 	BodyOrientation:
 		QuantizedFacings: 32
-	AutoTarget:
-	RenderRangeCircle:
-	DrawLineToTarget:
-	Building:
-		Dimensions: 1,1
-		Footprint: x
-		TerrainTypes: Clear, Road, DirtRoad, Rough
-	RenderBuilding:
 	RenderVoxels:
 	WithVoxelBarrel:
 		LocalOffset: 170,0,0
@@ -212,19 +183,9 @@ GATICK:
 		NoTransformSounds:
 		Voice: Move
 	WithMuzzleFlash:
-	WithMakeAnimation:
-	SelectionDecorations:
-		Palette: pips
-	Selectable:
-	TargetableBuilding:
-		TargetTypes: Ground, Repair
-	Guardable:
-	HiddenUnderFog:
-	ActorLostNotification:
 
 GAARTY:
-	Inherits@1: ^GainsExperience
-	Inherits@2: ^ExistsInWorld
+	Inherits@1: ^DeployedVehicle
 	Valued:
 		Cost: 975
 	Tooltip:
@@ -235,8 +196,6 @@ GAARTY:
 		Type: Light
 	RevealsShroud:
 		Range: 9c0
-	Voiced:
-		VoiceSet: Vehicle
 	Turreted:
 		ROT: 5
 		InitialFacing: 128
@@ -245,13 +204,8 @@ GAARTY:
 		Weapon: 155mm
 		LocalOffset: 811,0,0
 		MuzzleSequence: muzzle
-	AttackTurreted:
-		Voice: Attack
 	BodyOrientation:
 		QuantizedFacings: 32
-	AutoTarget:
-	RenderRangeCircle:
-	DrawLineToTarget:
 	RenderBuilding:
 	RenderVoxels:
 		LightAmbientColor: 0.4, 0.4, 0.4
@@ -265,19 +219,6 @@ GAARTY:
 		NoTransformSounds:
 		Voice: Move
 	WithMuzzleFlash:
-	Building:
-		Dimensions: 1,1
-		Footprint: x
-		TerrainTypes: Clear, Road, DirtRoad, Rough
-	WithMakeAnimation:
-	SelectionDecorations:
-		Palette: pips
-	Selectable:
-	TargetableBuilding:
-		TargetTypes: Ground, Repair
-	Guardable:
-	HiddenUnderFog:
-	ActorLostNotification:
 
 NAMISL:
 	Inherits: ^Building

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -1,6 +1,5 @@
 GADPSA:
-	Inherits@1: ^GainsExperience
-	Inherits@2: ^ExistsInWorld
+	Inherits: ^DeployedVehicle
 	Valued:
 		Cost: 950
 	Tooltip:
@@ -17,28 +16,16 @@ GADPSA:
 		TransformSounds: place2.aud
 		NoTransformSounds:
 		Voice: Move
+	-AutoTarget:
+	-DrawLineToTarget:
+	-AttackTurreted:
+	-RenderRangeCircle:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 6
-	Building:
-		Dimensions: 1,1
-		Footprint: x
-		TerrainTypes: Clear, Road, DirtRoad, Rough
-	RenderBuilding:
-	Voiced:
-		VoiceSet: Vehicle
-	WithMakeAnimation:
-	SelectionDecorations:
-		Palette: pips
-	Selectable:
-	TargetableBuilding:
-		TargetTypes: Ground, Repair
-	Guardable:
-	HiddenUnderFog:
-	ActorLostNotification:
 
 NAPULS:
-	Inherits: ^Building
+	Inherits: ^Defense
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -55,7 +42,6 @@ NAPULS:
 		Bounds: 78, 54, 0, -12
 	RequiresPower:
 	DisabledOverlay:
-	-GivesBuildableArea:
 	Health:
 		HP: 500
 	Armor:
@@ -68,11 +54,6 @@ NAPULS:
 	AttackTurreted:
 	Armament:
 		Weapon: EMPulseCannon
-	AutoTarget:
-	RenderRangeCircle:
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 5
 	WithTurret:
 		Sequence: turret
 	Power:


### PR DESCRIPTION
Started by reducing the number of locations of `RenderRangeCircle` and `RenderDetectionCircle` since my `GenericWithRangeCircle` branch replaces them with a more generic (and thus more verbose) `WithRangeCircle` trait (requiring a `Type` and a `Color`).
