### PR TITLE
Changed TimestampFormat for server logs

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -72,7 +72,7 @@ namespace OpenRA
 		[Desc("Disallow AI bots.")]
 		public bool LockBots = false;
 
-		public string TimestampFormat = "HH:mm";
+		public string TimestampFormat = "s";
 
 		public ServerSettings() { }
 


### PR DESCRIPTION
Thanks for implementing the function in the first place :)

I'd like to change it to this pattern, because I got really confused when I opened my dedicated server window and all I saw was different numbers, there wasn't a lot of activity on my servers that day, so first I thought this was game timer or something, but with this it's easier to see exactly when things happen. This is also good for people who like to make scripts with "grep" and create stats out of that :)
