### PR TITLE
TD Balance Additions.

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -46,7 +46,7 @@ TRAN:
 HELI:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 1200
+		Cost: 1100
 	Tooltip:
 		Name: Apache Longbow
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
@@ -98,7 +98,7 @@ HELI:
 ORCA:
 	Inherits: ^Helicopter
 	Valued:
-		Cost: 1200
+		Cost: 1100
 	Tooltip:
 		Name: Orca
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -446,6 +446,9 @@ VICE:
 		MuzzleSplitFacings: 8
 	AttackFrontal:
 	AttackWander:
+		WanderMoveRadius: 1
+		MinMoveDelayInTicks: 2000
+		MaxMoveDelayInTicks: 3000
 	RenderUnit:
 	WithMuzzleFlash:
 		SplitFacings: true

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -166,7 +166,7 @@
 	SpawnViceroid:
 		Probability: 10
 	Crushable:
-		WarnProbability: 67
+		WarnProbability: 75
 		CrushSound: squish2.aud
 	CombatDebugOverlay:
 	Guard:
@@ -182,7 +182,7 @@
 	Huntable:
 	LuaScriptEvents:
 	DetectCloaked:
-		Range: 1
+		Range: 3
 	ScriptTriggers:
 	DeathSounds@NORMAL:
 		DeathTypes: 1, 2, 3, 4

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -470,7 +470,7 @@ FIX:
 		Footprint: _x_ xxx _x_
 		Dimensions: 3,3
 	Health:
-		HP: 400
+		HP: 600
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -480,7 +480,7 @@ FIX:
 	RallyPoint:
 	WithRepairAnimation:
 	Power:
-		Amount: -30
+		Amount: -10
 
 EYE:
 	Inherits: ^BaseBuilding
@@ -621,9 +621,9 @@ GUN:
 SAM:
 	Inherits: ^BaseBuilding
 	Valued:
-		Cost: 750
+		Cost: 650
 	CustomBuildTimeValue:
-		Value: 2160
+		Value: 2000
 	Tooltip:
 		Name: SAM Site
 		Description: Anti-Aircraft base defense.\n  Strong vs Aircraft\n  Cannot target Ground units.

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -151,7 +151,7 @@ ARTY:
 	Explodes:
 		Weapon: UnitExplode
 		EmptyWeapon: UnitExplode
-		Chance: 75
+		Chance: 0
 	AutoTarget:
 		InitialStance: Defend
 	LeavesHusk:
@@ -315,7 +315,7 @@ LTNK:
 		ROT: 7
 		Speed: 113
 	Health:
-		HP: 360
+		HP: 350
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -151,7 +151,7 @@ ARTY:
 	Explodes:
 		Weapon: UnitExplode
 		EmptyWeapon: UnitExplode
-		Chance: 0
+		Chance: 75
 	AutoTarget:
 		InitialStance: Defend
 	LeavesHusk:
@@ -315,7 +315,7 @@ LTNK:
 		ROT: 7
 		Speed: 113
 	Health:
-		HP: 350
+		HP: 360
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -435,7 +435,7 @@ HTNK:
 MSAM:
 	Inherits: ^Tank
 	Valued:
-		Cost: 1200
+		Cost: 900
 	Tooltip:
 		Name: Rocket Launcher
 		Description: Long range rocket artillery.\n  Strong vs all Ground units.

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -119,7 +119,7 @@ World:
 		EditorSprite: bti1
 		Variants: bti1,bti2,bti3,bti4,bti5,bti6,bti7,bti8,bti9,bti10,bti11,bti12
 		MaxDensity: 12
-		ValuePerUnit: 75
+		ValuePerUnit: 60
 		Name: BlueTiberium
 		PipColor: Blue
 		AllowedTerrainTypes: Clear,Road

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -462,7 +462,7 @@ BigFlamer:
 		ImpactSound: flamer2.aud
 
 Chemspray:
-	ReloadDelay: 70
+	ReloadDelay: 65
 	Range: 3c0
 	Report: FLAMER2.AUD
 	Projectile: Bullet
@@ -487,7 +487,7 @@ Grenade:
 	Range: 4c0
 	Report: toss1.aud
 	Projectile: Bullet
-		Speed: 119
+		Speed: 140
 		High: yes
 		Angle: 62
 		Inaccuracy: 213
@@ -522,7 +522,7 @@ Grenade:
 			None: 25
 			Wood: 75
 			Light: 100
-			Heavy: 100
+			Heavy: 90
 			Concrete: 50
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -772,7 +772,7 @@ MachineGun:
 			None: 100
 			Wood: 20
 			Light: 50
-			Heavy: 20
+			Heavy: 15
 			Concrete: 10
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -462,7 +462,7 @@ BigFlamer:
 		ImpactSound: flamer2.aud
 
 Chemspray:
-	ReloadDelay: 65
+	ReloadDelay: 70
 	Range: 3c0
 	Report: FLAMER2.AUD
 	Projectile: Bullet
@@ -487,7 +487,7 @@ Grenade:
 	Range: 4c0
 	Report: toss1.aud
 	Projectile: Bullet
-		Speed: 140
+		Speed: 119
 		High: yes
 		Angle: 62
 		Inaccuracy: 213
@@ -522,7 +522,7 @@ Grenade:
 			None: 25
 			Wood: 75
 			Light: 100
-			Heavy: 90
+			Heavy: 100
 			Concrete: 50
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -772,7 +772,7 @@ MachineGun:
 			None: 100
 			Wood: 20
 			Light: 50
-			Heavy: 15
+			Heavy: 20
 			Concrete: 10
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs

--- a/mods/cnc/weapons.yaml
+++ b/mods/cnc/weapons.yaml
@@ -307,7 +307,7 @@ Rockets:
 			None: 50
 			Wood: 85
 			Light: 100
-			Heavy: 100
+			Heavy: 105
 			Concrete: 25
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater


### PR DESCRIPTION
The following additions being added. Reference from http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=17430&start=15  |||

Infantry: Detect cloak range 3 from 1. Evade chance 75 from 67.

MLRS: Price reduction 900 from 1200.

Repair Pad: power reduced 10 from 30. HP increased 600 from 400.

Samsite: cost reduced 650 from 750. Build time reduced 32 from 35.

Blue Tiberium: Value decreased 180 from 225.

Rocket Infantry: Damage vs armor increase 105 from 100

Apache and Orca: Price reduced 1100 from 1200. Build time reduced 27 from 29

Visceroids: Now move at a slower rate to prevent rush base attacks.

---

Let me know if I goofed yet again (As I did previously.)
