### PR TITLE
Fix a crash in dropzone-w

### DIFF
--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -230,8 +230,6 @@ Rules:
 			HP: 1000
 		Mobile:
 			Speed: 170
-		RevealsShroud:
-			Range: 50c0
 		Armament@PRIMARY:
 			Weapon: M60mg
 		Armament@SECONDARY:


### PR DESCRIPTION
We don't need RevealsShroud here anyway, as the map disabled Shroud and Fog.

Fixes the following crash:

```
Red Alert Mod at Version {DEV_VERSION}
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.34209
Exception of type `System.IndexOutOfRangeException`: Index was outside of the array. (Der Index war außerhalb des Arraybereichs.)
   at OpenRA.Map.<FindTilesInAnnulus>d__26.MoveNext() in OpenRA\OpenRA.Game\Map\Map.cs:Line 1177.
   at OpenRA.Traits.Shroud.<ProjectedCellsInRange>d__0.MoveNext() in OpenRA\OpenRA.Game\Traits\World\Shroud.cs:Line 86.
   at System.Linq.Enumerable.<SelectManyIterator>d__14`2.MoveNext()
   at System.Linq.Enumerable.<DistinctIterator>d__81`1.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at OpenRA.Mods.Common.Traits.RevealsShroud.ProjectedCells(Actor self)
   at OpenRA.Mods.Common.Traits.RevealsShroud.AddedToWorld(Actor self)
   at OpenRA.World.Add(Actor a) in OpenRA\OpenRA.Game\World.cs:Line 225.
   at OpenRA.World.CreateActor(Boolean addToWorld, String name, TypeDictionary initDict) in OpenRA\OpenRA.Game\World.cs:Line 214.
   at OpenRA.World.CreateActor(String name, TypeDictionary initDict) in OpenRA\OpenRA.Game\World.cs:Line 205.
   at OpenRA.Mods.Common.Traits.SpawnMapActors.WorldLoaded(World world, WorldRenderer wr)
   at OpenRA.World.LoadComplete(WorldRenderer wr) in OpenRA\OpenRA.Game\World.cs:Line 191.
   at OpenRA.Game.StartGame(String mapUID, WorldType type) in OpenRA\OpenRA.Game\Game.cs:Line 155.
   at OpenRA.Network.UnitOrders.ProcessOrder(OrderManager orderManager, World world, Int32 clientId, Order order) in OpenRA\OpenRA.Game\Network\UnitOrders.cs:Line 110.
   at OpenRA.Network.OrderManager.TickImmediate() in OpenRA\OpenRA.Game\Network\OrderManager.cs:Line 130.
   at OpenRA.Sync.<>c__DisplayClass5.<CheckSyncUnchanged>b__4() in OpenRA\OpenRA.Game\Sync.cs:Line 170.
   at OpenRA.Sync.CheckSyncUnchanged[T](World world, Func`1 fn) in OpenRA\OpenRA.Game\Sync.cs:Line 178.
   at OpenRA.Sync.CheckSyncUnchanged(World world, Action fn) in OpenRA\OpenRA.Game\Sync.cs:Line 170.
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in OpenRA\OpenRA.Game\Game.cs:Line 462.
   at OpenRA.Game.LogicTick() in OpenRA\OpenRA.Game\Game.cs:Line 507.
   at OpenRA.Game.Loop() in OpenRA\OpenRA.Game\Game.cs:Line 631.
   at OpenRA.Game.Run() in OpenRA\OpenRA.Game\Game.cs:Line 671.
   at OpenRA.Program.Run(String[] args) in OpenRA\OpenRA.Game\Support\Program.cs:Line 111.
   at OpenRA.Program.Main(String[] args) in OpenRA\OpenRA.Game\Support\Program.cs:Line 39.
```

The range was probably too high.
