### PR TITLE
TD: renames tooltip on "Defence" tab to "Support" 

### DIFF
--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -396,7 +396,7 @@ Container@PLAYER_WIDGETS:
 							X: 35
 							Width: 30
 							Height: 30
-							TooltipText: Defence
+							TooltipText: Support
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Defence
 							HotkeyName: ProductionTypeDefenseKey


### PR DESCRIPTION
as suggested by GraionDilach in #9047
