### PR TITLE
Dont crash when Documents\OpenRA is hidden

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -22,7 +22,11 @@ namespace OpenRA
 	{
 		public static void WriteToFile(this MiniYamlNodes y, string filename)
 		{
-			File.WriteAllLines(filename, y.ToLines(true).Select(x => x.TrimEnd()).ToArray());
+			try
+			{
+				File.WriteAllLines(filename, y.ToLines(true).Select(x => x.TrimEnd()).ToArray());
+			}
+			catch (UnauthorizedAccessException) { /* Location is readonly or hidden */ }
 		}
 
 		public static string WriteToString(this MiniYamlNodes y)

--- a/OpenRA.Game/Support/Log.cs
+++ b/OpenRA.Game/Support/Log.cs
@@ -58,7 +58,7 @@ namespace OpenRA
 
 					return;
 				}
-				catch (IOException) { }
+				catch (Exception) { }
 		}
 
 		public static void Write(string channel, string format, params object[] args)


### PR DESCRIPTION
It fixes the hidden openra folder crash.

I decided to put a warning on console to the User!

Problems when the openRA runs readonly:
- no settings will be written
- no Log files will be created
- Map editor is not functiontional

Tested so far: when Documents\OpenRA is HIDDEN
-> Download and installing content works as expected
-> Settings and Logs are not written
-> Screenshots will be saved correctly (the files are not hidden)
