### PR TITLE
Some more renaming from "race" to "faction"

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -33,8 +33,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The list of unit target types we are allowed to duplicate.")]
 		public readonly string[] ValidTargets = { "Ground", "Water" };
 
-		[Desc("Which races this crate action can occur for.")]
-		public readonly string[] ValidRaces = { };
+		[Desc("Which factions this crate action can occur for.")]
+		public readonly string[] ValidFactions = { };
 
 		[Desc("Is the new duplicates given to a specific owner, regardless of whom collected it?")]
 		public readonly string Owner = null;
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanGiveTo(Actor collector)
 		{
-			if (info.ValidRaces.Any() && !info.ValidRaces.Contains(collector.Owner.Faction.InternalName))
+			if (info.ValidFactions.Any() && !info.ValidFactions.Contains(collector.Owner.Faction.InternalName))
 				return false;
 
 			var targetable = collector.Info.Traits.GetOrDefault<ITargetableInfo>();

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference, FieldLoader.Require]
 		public readonly string[] Units = { };
 
-		[Desc("Races that are allowed to trigger this action")]
-		public readonly string[] ValidRaces = { };
+		[Desc("Factions that are allowed to trigger this action.")]
+		public readonly string[] ValidFactions = { };
 
 		[Desc("Override the owner of the newly spawned unit: e.g. Creeps or Neutral")]
 		public readonly string Owner = null;
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanGiveTo(Actor collector)
 		{
-			if (info.ValidRaces.Any() && !info.ValidRaces.Contains(collector.Owner.Faction.InternalName))
+			if (info.ValidFactions.Any() && !info.ValidFactions.Contains(collector.Owner.Faction.InternalName))
 				return false;
 
 			foreach (string unit in info.Units)

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		readonly string race;
+		readonly string faction;
 		readonly RenderSpritesInfo info;
 		readonly List<AnimationWrapper> anims = new List<AnimationWrapper>();
 		string cachedImage;
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 		public RenderSprites(ActorInitializer init, RenderSpritesInfo info)
 		{
 			this.info = info;
-			race = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}
 
 		public string GetImage(Actor self)
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (cachedImage != null)
 				return cachedImage;
 
-			return cachedImage = info.GetImage(self.Info, self.World.Map.SequenceProvider, race);
+			return cachedImage = info.GetImage(self.Info, self.World.Map.SequenceProvider, faction);
 		}
 
 		public void UpdatePalette()

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -29,9 +29,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The sequence name that defines the actor sprites. Defaults to the actor name.")]
 		public readonly string Image = null;
 
-		[FieldLoader.LoadUsing("LoadRaceImages")]
-		[Desc("A dictionary of race-specific image overrides.")]
-		public readonly Dictionary<string, string> RaceImages = null;
+		[FieldLoader.LoadUsing("LoadFactionImages")]
+		[Desc("A dictionary of faction-specific image overrides.")]
+		public readonly Dictionary<string, string> FactionImages = null;
 
 		[Desc("Custom palette name")]
 		[PaletteReference] public readonly string Palette = null;
@@ -42,11 +42,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Change the sprite image size.")]
 		public readonly float Scale = 1f;
 
-		protected static object LoadRaceImages(MiniYaml y)
+		protected static object LoadFactionImages(MiniYaml y)
 		{
 			MiniYaml images;
 
-			if (!y.ToDictionary().TryGetValue("RaceImages", out images))
+			if (!y.ToDictionary().TryGetValue("FactionImages", out images))
 				return null;
 
 			return images.Nodes.ToDictionary(kv => kv.Key, kv => kv.Value.Value);
@@ -82,10 +82,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public string GetImage(ActorInfo actor, SequenceProvider sequenceProvider, string race)
 		{
-			if (RaceImages != null && !string.IsNullOrEmpty(race))
+			if (FactionImages != null && !string.IsNullOrEmpty(race))
 			{
 				string raceImage = null;
-				if (RaceImages.TryGetValue(race, out raceImage) && sequenceProvider.HasSequence(raceImage))
+				if (FactionImages.TryGetValue(race, out raceImage) && sequenceProvider.HasSequence(raceImage))
 					return raceImage;
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1768,6 +1768,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20150816)
+				{
+					// Rename RenderSprites.RaceImages
+					if (depth == 2 && node.Key == "RaceImages")
+						node.Key = "FactionImages";
+					if (depth == 2 && node.Key == "-RaceImages")
+						node.Key = "-FactionImages";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1775,6 +1775,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "FactionImages";
 					if (depth == 2 && node.Key == "-RaceImages")
 						node.Key = "-FactionImages";
+
+					// Rename *CrateAction.ValidRaces
+					if (depth == 2 && node.Key == "ValidRaces"
+					    && (parentKey == "DuplicateUnitCrateAction" || parentKey == "GiveUnitCrateAction"))
+						node.Key = "ValidFactions";
 				}
 
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -28,13 +28,13 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		readonly ClonesProducedUnitsInfo info;
 		readonly Production production;
-		readonly string race;
+		readonly string faction;
 
 		public ClonesProducedUnits(ActorInitializer init, ClonesProducedUnitsInfo info)
 		{
 			this.info = info;
 			production = init.Self.Trait<Production>();
-			race = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}
 
 		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.RA.Traits
 			if (ci == null || !info.CloneableTypes.Intersect(ci.Types).Any())
 				return;
 
-			production.Produce(self, produced.Info, race);
+			production.Produce(self, produced.Info, faction);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.RA/Traits/SpawnActorOnDeath.cs
@@ -51,13 +51,13 @@ namespace OpenRA.Mods.RA.Traits
 	public class SpawnActorOnDeath : INotifyKilled
 	{
 		readonly SpawnActorOnDeathInfo info;
-		readonly string race;
+		readonly string faction;
 
 		public SpawnActorOnDeath(ActorInitializer init, SpawnActorOnDeathInfo info)
 		{
 			this.info = info;
 
-			race = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}
 
 		public void Killed(Actor self, AttackInfo e)
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.RA.Traits
 					new ParentActorInit(self),
 					new LocationInit(self.Location),
 					new CenterPositionInit(self.CenterPosition),
-					new FactionInit(race)
+					new FactionInit(faction)
 				};
 
 				if (info.OwnerType == OwnerType.Victim)

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -35,7 +35,7 @@ crate:
 	GiveUnitCrateAction@Raider:
 		SelectionShares: 15
 		Units: raider
-		ValidRaces: ordos
+		ValidFactions: ordos
 		Prerequisites: techlevel.low, Light
 	GiveUnitCrateAction@Quad:
 		SelectionShares: 40
@@ -44,17 +44,17 @@ crate:
 	GiveUnitCrateAction@CombatA:
 		SelectionShares: 10
 		Units: combata
-		ValidRaces: atreides
+		ValidFactions: atreides
 		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@CombatH:
 		SelectionShares: 10
 		Units: combath
-		ValidRaces: harkonnen
+		ValidFactions: harkonnen
 		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@CombatO:
 		SelectionShares: 10
 		Units: combato
-		ValidRaces: ordos
+		ValidFactions: ordos
 		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@SiegeTank:
 		SelectionShares: 10
@@ -67,37 +67,37 @@ crate:
 	GiveUnitCrateAction@StealthRaider:
 		SelectionShares: 7
 		Units: stealthraider
-		ValidRaces: ordos
+		ValidFactions: ordos
 		Prerequisites: techlevel.medium, Hitech
 	GiveUnitCrateAction@Fremen:
 		SelectionShares: 5
 		Units: fremen,fremen
-		ValidRaces: atreides
+		ValidFactions: atreides
 		Prerequisites: techlevel.high, Palace
 	GiveUnitCrateAction@Sardaukar:
 		SelectionShares: 8
 		Units: sardaukar,sardaukar
-		ValidRaces: harkonnen
+		ValidFactions: harkonnen
 		Prerequisites: techlevel.high, Palace
 	GiveUnitCrateAction@Saboteur:
 		SelectionShares: 3
 		Units: saboteur,saboteur
-		ValidRaces: ordos
+		ValidFactions: ordos
 		Prerequisites: techlevel.high, Palace
 	GiveUnitCrateAction@SonicTank:
 		SelectionShares: 5
 		Units: sonictank
-		ValidRaces: atreides
+		ValidFactions: atreides
 		Prerequisites: techlevel.high, Research
 	GiveUnitCrateAction@Devast:
 		SelectionShares: 2
 		Units: devast
-		ValidRaces: harkonnen
+		ValidFactions: harkonnen
 		Prerequisites: techlevel.high, Research
 	GiveUnitCrateAction@DeviatorTank:
 		SelectionShares: 5
 		Units: deviatortank
-		ValidRaces: ordos
+		ValidFactions: ordos
 		Prerequisites: techlevel.high, Research
 	GiveMcvCrateAction:
 		SelectionShares: 0

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -167,7 +167,7 @@ upgrade.conyard:
 		Cost: 1000
 	RenderSprites:
 		Image: conyard.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: conyard.atreides
 			ordos: conyard.ordos
 			corrino: conyard.corrino
@@ -187,7 +187,7 @@ upgrade.barracks:
 		Cost: 500
 	RenderSprites:
 		Image: barracks.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: barracks.atreides
 			ordos: barracks.ordos
 	ProvidesPrerequisite@upgradename:
@@ -206,7 +206,7 @@ upgrade.light:
 		Cost: 400
 	RenderSprites:
 		Image: light.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: light.atreides
 			ordos: light.ordos
 	ProvidesPrerequisite@upgradename:
@@ -225,7 +225,7 @@ upgrade.heavy:
 		Cost: 800
 	RenderSprites:
 		Image: heavy.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: heavy.atreides
 			ordos: heavy.ordos
 			corrino: heavy.corrino

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -70,7 +70,7 @@ conyard:
 		Amount: 20
 	RenderBuilding:
 		Image: conyard.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: conyard.atreides
 			ordos: conyard.ordos
 			corrino: conyard.corrino
@@ -102,7 +102,7 @@ power:
 		Range: 4c0
 	RenderBuilding:
 		Image: power.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: power.atreides
 			ordos: power.ordos
 	WithIdleOverlay@ZAPS:
@@ -163,7 +163,7 @@ barracks:
 		Amount: -20
 	RenderBuilding:
 		Image: barracks.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: barracks.atreides
 			ordos: barracks.ordos
 	ProvidesPrerequisite@buildingname:
@@ -208,7 +208,7 @@ refinery:
 		Facing: 160
 	RenderBuilding:
 		Image: refinery.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: refinery.atreides
 			ordos: refinery.ordos
 	WithDockingOverlay@SMOKE:
@@ -245,7 +245,7 @@ silo:
 	-RenderBuilding:
 	RenderBuildingSilo:
 		Image: silo.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: silo.atreides
 			ordos: silo.ordos
 	StoresResources:
@@ -283,7 +283,7 @@ light:
 		Range: 4c0
 	RenderBuilding:
 		Image: light.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: light.atreides
 			ordos: light.ordos
 	RallyPoint:
@@ -361,7 +361,7 @@ heavy:
 		Factions: atreides, harkonnen
 	RenderBuilding:
 		Image: heavy.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: heavy.atreides
 			ordos: heavy.ordos
 			corrino: heavy.corrino
@@ -407,7 +407,7 @@ radar:
 	RenderDetectionCircle:
 	RenderBuilding:
 		Image: radar.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: radar.atreides
 			ordos: radar.ordos
 	WithIdleOverlay@DISH:
@@ -452,7 +452,7 @@ starport:
 		ActorType: frigate
 	RenderBuilding:
 		Image: starport.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: starport.atreides
 			ordos: starport.ordos
 			corrino: starport.corrino
@@ -668,7 +668,7 @@ repair:
 		Offset: 1,3
 	RenderBuilding:
 		Image: repair.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: repair.atreides
 			ordos: repair.ordos
 	WithRepairOverlay:
@@ -707,7 +707,7 @@ hightech:
 		Range: 4c0
 	RenderBuilding:
 		Image: hightech.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: hightech.atreides
 			ordos: hightech.ordos
 	ProvidesPrerequisite@upgrade:
@@ -768,7 +768,7 @@ research:
 		Range: 4c0
 	RenderBuilding:
 		Image: research.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: research.atreides
 			ordos: research.ordos
 	WithIdleOverlay@LIGHTS:
@@ -805,7 +805,7 @@ palace:
 		Range: 8c0
 	RenderBuilding:
 		Image: palace.harkonnen
-		RaceImages:
+		FactionImages:
 			atreides: palace.atreides
 			ordos: palace.ordos
 			corrino: palace.corrino
@@ -849,7 +849,7 @@ conyard.atreides:
 		ForceFaction: atreides
 	RenderBuilding:
 		Image: conyard.atreides
-		-RaceImages:
+		-FactionImages:
 
 conyard.harkonnen:
 	Inherits: conyard
@@ -860,7 +860,7 @@ conyard.harkonnen:
 		ForceFaction: harkonnen
 	RenderBuilding:
 		Image: conyard.harkonnen
-		-RaceImages:
+		-FactionImages:
 
 conyard.ordos:
 	Inherits: conyard
@@ -871,5 +871,5 @@ conyard.ordos:
 		ForceFaction: ordos
 	RenderBuilding:
 		Image: conyard.ordos
-		-RaceImages:
+		-FactionImages:
 

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -94,51 +94,51 @@ CRATE:
 	GiveUnitCrateAction@jeep:
 		SelectionShares: 7
 		Units: jeep
-		ValidRaces: allies, england, france, germany
+		ValidFactions: allies, england, france, germany
 		Prerequisites: techlevel.low
 	GiveUnitCrateAction@arty:
 		SelectionShares: 6
 		Units: arty
-		ValidRaces: allies, england, france, germany
+		ValidFactions: allies, england, france, germany
 		Prerequisites: techlevel.medium, dome
 	GiveUnitCrateAction@v2rl:
 		SelectionShares: 6
 		Units: v2rl
-		ValidRaces: soviet, russia, ukraine
+		ValidFactions: soviet, russia, ukraine
 		Prerequisites: techlevel.medium, dome
 	GiveUnitCrateAction@1tnk:
 		SelectionShares: 5
 		Units: 1tnk
-		ValidRaces: allies, england, france, germany
+		ValidFactions: allies, england, france, germany
 		Prerequisites: techlevel.low
 	GiveUnitCrateAction@2tnk:
 		SelectionShares: 4
 		Units: 2tnk
-		ValidRaces: allies, england, france, germany
+		ValidFactions: allies, england, france, germany
 		Prerequisites: techlevel.medium, fix
 	GiveUnitCrateAction@3tnk:
 		SelectionShares: 4
 		Units: 3tnk
-		ValidRaces: soviet, russia, ukraine
+		ValidFactions: soviet, russia, ukraine
 		Prerequisites: techlevel.medium, fix
 	GiveUnitCrateAction@4tnk:
 		SelectionShares: 3
 		Units: 4tnk
-		ValidRaces: soviet, russia, ukraine
+		ValidFactions: soviet, russia, ukraine
 		Prerequisites: techlevel.unrestricted, fix, techcenter
 	GiveUnitCrateAction@squadlight:
 		SelectionShares: 7
 		Units: e1,e1,e1,e3,e3
-		ValidRaces: allies, england, france, germany, soviet, russia, ukraine
+		ValidFactions: allies, england, france, germany, soviet, russia, ukraine
 	GiveUnitCrateAction@squadheavyallies:
 		SelectionShares: 7
 		Units: e1,e1,e1,e1,e3,e3,e3,e6,medi
-		ValidRaces: allies, england, france, germany
+		ValidFactions: allies, england, france, germany
 		TimeDelay: 4500
 	GiveUnitCrateAction@squadheavysoviet:
 		SelectionShares: 7
 		Units: e1,e1,e4,e4,e3,e3,e3
-		ValidRaces: soviet, russia, ukraine
+		ValidFactions: soviet, russia, ukraine
 		TimeDelay: 4500
 	GrantUpgradeCrateAction@invuln:
 		SelectionShares: 5

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -249,7 +249,7 @@ GADEPT:
 		VisualBounds: 98, 68, -6, -6
 	RenderBuilding:
 		Image: gadept.gdi
-		RaceImages:
+		FactionImages:
 			gdi: gadept.gdi
 			nod: gadept.nod
 

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -30,7 +30,7 @@ E1:
 		Prerequisites: barracks.upgraded
 	RenderSprites:
 		Image: e1.gdi
-		RaceImages:
+		FactionImages:
 			gdi: e1.gdi
 			nod: e1.nod
 
@@ -61,7 +61,7 @@ ENGINEER:
 	-GainsExperience:
 	RenderSprites:
 		Image: engineer.gdi
-		RaceImages:
+		FactionImages:
 			gdi: engineer.gdi
 			nod: engineer.nod
 

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -99,7 +99,7 @@ PROC:
 		VisualBounds: 134, 122, 0, -18
 	RenderBuilding:
 		Image: proc.gdi
-		RaceImages:
+		FactionImages:
 			gdi: proc.gdi
 			nod: proc.nod
 
@@ -129,7 +129,7 @@ GASILO:
 	-RenderBuilding:
 	RenderBuildingSilo:
 		Image: gasilo.gdi
-		RaceImages:
+		FactionImages:
 			gdi: gasilo.gdi
 			nod: gasilo.nod
 	WithIdleOverlay@UNDERLAY:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -81,7 +81,7 @@ NAPULS:
 		VisualBounds: 78, 54, 0, -12
 	RenderBuilding:
 		Image: napuls.gdi
-		RaceImages:
+		FactionImages:
 			gdi: napuls.gdi
 			nod: napuls.nod
 

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -34,7 +34,7 @@ MCV:
 		VisualBounds: 42,42
 	RenderSprites:
 		Image: mcv.gdi
-		RaceImages:
+		FactionImages:
 			gdi: mcv.gdi
 			nod: mcv.nod
 
@@ -94,7 +94,7 @@ HARV:
 		VisualBounds: 36,36
 	RenderSprites:
 		Image: harv.gdi
-		RaceImages:
+		FactionImages:
 			gdi: harv.gdi
 			nod: harv.nod
 
@@ -126,7 +126,7 @@ LPST:
 		Voice: Move
 	RenderSprites:
 		Image: lpst.gdi
-		RaceImages:
+		FactionImages:
 			gdi: lpst.gdi
 			nod: lpst.nod
 


### PR DESCRIPTION
Next step toward #7873.
This takes care of the last occurrences of "race" in class member names (except `PlayerProperties.Race`, which will stay until the release is out, I guess).
Split into nice small commits for easy reviewing.
