### PR TITLE
Improve TFD Installation logic

### DIFF
--- a/OpenRA.Mods.Common/InstallUtils.cs
+++ b/OpenRA.Mods.Common/InstallUtils.cs
@@ -36,11 +36,11 @@ namespace OpenRA.Mods.Common
 		public readonly string MusicPackageMirrorList = null;
 		public readonly int ShippedSoundtracks = 0;
 
-		/// <summary> InstallShield .cab File Ids, used to extract Mod specific files. </summary>
-		public readonly int[] InstallShieldCABFileIds = { };
+		/// <summary> InstallShield PackageName, used to extract Mod specific files </summary>
+		public readonly string InstallShieldPackageName;
 
-		/// <summary> InstallShield .cab File Ids, used to extract Mod specific archives and extract contents of ExtractFilesFromCD. </summary>
-		public readonly string[] InstallShieldCABFilePackageIds = { };
+		/// <summary> InstallShield Package file list, used to lookup the index of Mod specific files </summary>
+		public readonly string[] ExtractFromInstallShieldPackage = { };
 	}
 
 	public static class InstallUtils

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -153,7 +153,8 @@ ContentInstaller:
 		.: conquer.mix, desert.mix, general.mix, scores.mix, sounds.mix, temperat.mix, winter.mix
 	ShippedSoundtracks: 4
 	MusicPackageMirrorList: http://www.openra.net/packages/cnc-music-mirrors.txt
-	InstallShieldCABFileIds: 66, 45, 42, 65, 68, 67, 71, 47, 49, 60, 75, 73, 53
+	InstallShieldPackageName: CnC
+	ExtractFromInstallShieldPackage: speech.mix, conquer.mix, cclocal.mix, sounds.mix, tempicnh.mix, temperat.mix, transit.mix, desert.mix, general.mix, scores.mix, winter.mix, updatec.mix
 
 ServerTraits:
 	LobbyCommands

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -152,8 +152,8 @@ ContentInstaller:
 		.: INSTALL/REDALERT.MIX
 	ShippedSoundtracks: 2
 	MusicPackageMirrorList: http://www.openra.net/packages/ra-music-mirrors.txt
-	InstallShieldCABFilePackageIds: 105
-	InstallShieldCABFileIds: 116
+	InstallShieldPackageName: Red Alert
+	ExtractFromInstallShieldPackage: redalert.mix, main.mix
 
 ServerTraits:
 	LobbyCommands

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -190,18 +190,18 @@ LoadScreen: LogoStripeLoadScreen
 ContentInstaller:
 	MenuWidget: INSTALL_PANEL
 	MusicMenuWidget: INSTALL_MUSIC_PANEL
-	TestFiles: cache.mix, conquer.mix, isosnow.mix, isotemp.mix, local.mix, sidec01.mix, sidec02.mix, sno.mix, snow.mix, sounds.mix, speech01.mix, tem.mix, temperat.mix
+	TestFiles: cache.mix, conquer.mix, isosnow.mix, isotemp.mix, local.mix, sidec01.mix, sidec02.mix, sno.mix, snow.mix, sounds.mix, speech01.mix, speech02.mix, tem.mix, temperat.mix
 	PackageMirrorList: http://www.openra.net/packages/ts-mirrors.txt
 	DiskTestFiles: MULTI.MIX, INSTALL/TIBSUN.MIX
 	CopyFilesFromCD:
 		.: INSTALL/TIBSUN.MIX, SCORES.MIX, MULTI.MIX
 	PackageToExtractFromCD: INSTALL/TIBSUN.MIX:CRC32
 	ExtractFilesFromCD:
-		.: cache.mix, conquer.mix, isosnow.mix, isotemp.mix, local.mix, sidec01.mix, sidec02.mix, sno.mix, snow.mix, sounds.mix, speech01.mix, tem.mix, temperat.mix
+		.: cache.mix, conquer.mix, isosnow.mix, isotemp.mix, local.mix, sidec01.mix, sidec02.mix, sno.mix, snow.mix, sounds.mix, speech01.mix, speech02.mix, tem.mix, temperat.mix
 	ShippedSoundtracks: 2
 	MusicPackageMirrorList: http://www.openra.net/packages/ts-music-mirrors.txt
-	InstallShieldCABFilePackageIds: 332:CRC32
-	InstallShieldCABFileIds: 323, 364
+	InstallShieldPackageName: Tiberian Sun
+	ExtractFromInstallShieldPackage: tibsun.mix:CRC32, scores.mix
 
 ServerTraits:
 	LobbyCommands


### PR DESCRIPTION
This Pr adds more flexibilty to the TFD Installer when installing content from TFD discs. by using index lookup. Closes https://github.com/OpenRA/OpenRA/issues/9082. 

also this Pr pays attention to:  https://github.com/OpenRA/OpenRA/pull/8170#issuecomment-129621166
