### PR TITLE
Make devmode configureable, add two commands and documentate some things

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -38,6 +38,7 @@ namespace OpenRA
 		[Desc("Locks the game with a password.")]
 		public string Password = "";
 
+		[Desc("The Address of the OpenRA masterserver.")]
 		public string MasterServer = "http://master.openra.net/";
 
 		[Desc("Allow users to enable NAT discovery for external IP detection and automatic port forwarding.")]
@@ -118,7 +119,11 @@ namespace OpenRA
 		public bool HardwareCursors = true;
 		public bool PixelDouble = false;
 		public bool CursorDouble = false;
+
+		[Desc("Enables the frame limiter.")]
 		public bool CapFramerate = true;
+
+		[Desc("Max frames per second. Default is 60.")]
 		public int MaxFramerate = 60;
 
 		public int BatchSize = 8192;
@@ -132,8 +137,13 @@ namespace OpenRA
 
 	public class SoundSettings
 	{
+		[Desc("Default Volume of sound effects. To disable sound effects set 0.0f here.")]
 		public float SoundVolume = 0.5f;
+
+		[Desc("Default Volume of music. To disable Music set 0.0f here.")]
 		public float MusicVolume = 0.5f;
+
+		[Desc("Default Volume of videos. To disable sound in Videos set 0.0f here.")]
 		public float VideoVolume = 0.5f;
 
 		public bool Shuffle = false;
@@ -142,42 +152,83 @@ namespace OpenRA
 		public string Engine = "AL";
 		public string Device = null;
 
+		[Desc("Play sound when cash is ticking.")]
 		public bool CashTicks = true;
 	}
 
 	public class PlayerSettings
 	{
+		[Desc("Default name of the player when no name is choosen.")]
 		public string Name = "Newbie";
+
+		[Desc("Default palyer color of the player when no color is choosen.")]
 		public HSLColor Color = new HSLColor(75, 255, 180);
+
+		[Desc("Default server is localhost and port is 1234.")]
 		public string LastServer = "localhost:1234";
 	}
 
+	public class DevelopermodeSettings
+	{
+		[Desc("The amount of Cash what we get when using the /givecash commands.")]
+		public readonly int Cash = 20000;
+
+		[Desc("Increase world ressources by this value.")]
+		public readonly int ResourceGrowth = 100;
+
+		[Desc("Send a Message when using Cheat Commands.")]
+		public readonly bool ReportCheatUsed = true;
+    }
+
 	public class GameSettings
 	{
-		[Desc("Load a specific mod on startup. Shipped ones include: ra, cnc and d2k")]
+		[Desc("Load a specific mod on startup. Shipped ones include: ra, cnc and d2k.")]
 		public string Mod = "modchooser";
 		public string PreviousMod = "ra";
 
+		[Desc("Show a bot controlled skirmish game as background on the shell.")]
 		public bool ShowShellmap = true;
 
+		[Desc("Scroll the Viewport by moving the cursor to the edges.")]
 		public bool ViewportEdgeScroll = true;
+
+		[Desc("Lock Cursor inside the game window.")]
 		public bool LockMouseWindow = false;
 		public MouseScrollType MouseScroll = MouseScrollType.Standard;
 		public MouseButtonPreference MouseButtonPreference = new MouseButtonPreference();
+
+		[Desc("Speed when scrolling by moving the cursor to the edges of the viewport.")]
 		public float ViewportEdgeScrollStep = 10f;
+
+		[Desc("Speed when scrolling normaly.")]
 		public float UIScrollSpeed = 50f;
+
 		public int SelectionDeadzone = 24;
 
+		[Desc("Use classic mouse style.")]
 		public bool UseClassicMouseStyle = false;
+
+		[Desc("Always show status bars.")]
 		public bool AlwaysShowStatusBars = false;
+
+		[Desc("Show health bars of allys.")]
 		public bool TeamHealthColors = false;
+
+		[Desc("Draw target lines when ordering a unit to an location.")]
 		public bool DrawTargetLine = true;
 
+		[Desc("Allow map download when using in dedicated server mode.")]
 		public bool AllowDownloading = true;
+
+		[Desc("The location where maps get downloaded.")]
 		public string MapRepository = "http://resource.openra.net/map/";
 
+		[Desc("Fetch community news.")]
 		public bool FetchNews = true;
+
+		[Desc("Use this url to fetch the community news.")]
 		public string NewsUrl = "http://www.openra.net/gamenews";
+
 		public DateTime NewsFetchedDate;
 	}
 
@@ -295,6 +346,7 @@ namespace OpenRA
 		public PlayerSettings Player = new PlayerSettings();
 		public GameSettings Game = new GameSettings();
 		public SoundSettings Sound = new SoundSettings();
+		public DevelopermodeSettings Cheats = new DevelopermodeSettings();
 		public GraphicSettings Graphics = new GraphicSettings();
 		public ServerSettings Server = new ServerSettings();
 		public DebugSettings Debug = new DebugSettings();

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -13,8 +13,8 @@ namespace OpenRA.Traits
 	[Desc("Attach this to the player actor.")]
 	public class DeveloperModeInfo : ITraitInfo
 	{
-		public int Cash = 20000;
-		public int ResourceGrowth = 100;
+		public int Cash = Game.Settings.Cheats.Cash;
+		public int ResourceGrowth = Game.Settings.Cheats.ResourceGrowth;
 		public bool FastBuild;
 		public bool FastCharge;
 		public bool DisableShroud;
@@ -104,7 +104,12 @@ namespace OpenRA.Traits
 						FastBuild ^= true;
 						break;
 					}
-
+				case "DevFragileAlliances":
+					if (self.World.LobbyInfo.GlobalSettings.FragileAlliances)
+						self.World.LobbyInfo.GlobalSettings.FragileAlliances = false;
+					else
+						self.World.LobbyInfo.GlobalSettings.FragileAlliances = true;
+					break;
 				case "DevGiveCash":
 					{
 						var amount = order.ExtraData != 0 ? (int)order.ExtraData : info.Cash;
@@ -131,7 +136,12 @@ namespace OpenRA.Traits
 							self.World.RenderPlayer = DisableShroud ? null : self.Owner;
 						break;
 					}
-
+				case "DevDisableCheats":
+					{
+						self.World.LobbyInfo.GlobalSettings.AllowCheats = false;
+						Game.Debug("Cheats are now disabled.");
+						return;
+					}
 				case "DevPathDebug":
 					{
 						PathDebug ^= true;
@@ -166,7 +176,8 @@ namespace OpenRA.Traits
 					return;
 			}
 
-			Game.Debug("Cheat used: {0} by {1}", order.OrderString, self.Owner.PlayerName);
+			if (Game.Settings.Cheats.ReportCheatUsed)
+				Game.Debug("Cheat used: {0} by {1}", order.OrderString, self.Owner.PlayerName);
 		}
 	}
 }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -79,7 +79,7 @@ namespace OpenRA
 
 		public bool AllowDevCommands
 		{
-			get { return LobbyInfo.GlobalSettings.AllowCheats || LobbyInfo.IsSinglePlayer; }
+			get { return LobbyInfo.GlobalSettings.AllowCheats; }
 		}
 
 		public void SetLocalPlayer(string pr)

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -36,6 +36,8 @@ namespace OpenRA.Mods.Common.Commands
 				help.RegisterHelp(name, helpText);
 			};
 
+			register("fragilealliances", "toggles Diplomancy.");
+			register("disablecheats", "toggles cheat mode.");
 			register("disableshroud", "toggles shroud and minimap.");
 			register("givecash", "gives the default or specified amount of money.");
 			register("givecashall", "gives the default or specified amount of money to all players and ai.");
@@ -85,7 +87,8 @@ namespace OpenRA.Mods.Common.Commands
 					}
 
 					break;
-
+				case "fragilealliances": IssueDevCommand(world, "DevFragileAlliances"); break;
+				case "disablecheats": IssueDevCommand(world, "DevDisableCheats"); break;
 				case "disableshroud": IssueDevCommand(world, "DevShroudDisable"); break;
 				case "instantbuild": IssueDevCommand(world, "DevFastBuild"); break;
 				case "buildanywhere": IssueDevCommand(world, "DevBuildAnywhere"); break;


### PR DESCRIPTION
This Pr adds adds the ability to make some cheats configureable:
- The amount of cash
- Growrate of world resources
- Enable or Disable the report when developer commands was used.

In addition this PR adds the following commands:
- disablecheats -> Disable cheat mode
- fragilealliances -> Disable or Enable Diplomancy options

Also some settings was documented.
