### PR TITLE
Hides crates under fog.

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -691,7 +691,7 @@
 
 ^Crate:
 	Inherits@1: ^SpriteActor
-	HiddenUnderShroud:
+	HiddenUnderFog:
 	Tooltip:
 		Name: Crate
 		GenericName: Crate

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -1,5 +1,5 @@
 crate:
-	HiddenUnderShroud:
+	HiddenUnderFog:
 	Tooltip:
 		Name: Crate
 	Crate:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -671,7 +671,7 @@
 
 ^Crate:
 	Inherits@1: ^SpriteActor
-	HiddenUnderShroud:
+	HiddenUnderFog:
 	Tooltip:
 		Name: Crate
 		GenericName: Crate

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -157,7 +157,7 @@
 		RequireTilesets: TEMPERATE
 
 ^Crate:
-	HiddenUnderShroud:
+	HiddenUnderFog:
 	Tooltip:
 		Name: Crate
 	Crate:


### PR DESCRIPTION
Crates are hidden under fog of war like units. So to find them, scouting of the map is required. Also adds a satellite icon for crates. They are shown as white empty squares.

![crate_icon](https://cloud.githubusercontent.com/assets/6599106/9300127/65334094-44cb-11e5-84b0-55de723d295d.png)

This is the enlarged view of the image I used for the icon:
![crate_icon_source](https://cloud.githubusercontent.com/assets/6599106/9300212/4cb56eec-44cc-11e5-9152-99af3e569cd5.png)

What I don't understand however is that gpsdot.shp got smaller after I added the crate image. How did that happen?
