### PR TITLE
stop "Unit Ready" sound spaming when Instant Buildtime is enabled

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -280,8 +280,8 @@ namespace OpenRA.Mods.Common.Traits
 									hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
 								else if (!isBuilding)
 								{
-									if (BuildUnit(order.TargetString))
-										Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+									if (BuildUnit(order.TargetString) && time > 0)
+										hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
 									else if (!hasPlayedSound && time > 0)
 										hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
 								}


### PR DESCRIPTION
By adding the missing condition... Normal mode works as expected...
