### PR TITLE
Mobile Blocking Refactor

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -29,6 +29,14 @@ namespace OpenRA.Mods.Common.Traits
 		All = TransientActors | BlockedByMovers
 	}
 
+	public static class CellConditionsExts
+	{
+		public static bool HasCellCondition(this CellConditions c, CellConditions cellCondition)
+		{
+			return (c & cellCondition) == cellCondition;
+		}
+	}
+
 	[Desc("Unit is able to move.")]
 	public class MobileInfo : IMoveInfo, IOccupySpaceInfo, IFacingInfo, UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>
 	{
@@ -189,9 +197,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (SharesCell && world.ActorMap.HasFreeSubCell(cell))
 				return true;
 
-			if (check.HasFlag(CellConditions.TransientActors))
+			if (check.HasCellCondition(CellConditions.TransientActors))
 			{
-				var canIgnoreMovingAllies = self != null && !check.HasFlag(CellConditions.BlockedByMovers);
+				var canIgnoreMovingAllies = self != null && !check.HasCellCondition(CellConditions.BlockedByMovers);
 				var needsCellExclusively = self == null || Crushes == null || !Crushes.Any();
 				foreach (var a in world.ActorMap.GetUnitsAt(cell))
 				{
@@ -230,9 +238,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (MovementCostForCell(world, cell) == int.MaxValue)
 				return SubCell.Invalid;
 
-			if (check.HasFlag(CellConditions.TransientActors))
+			if (check.HasCellCondition(CellConditions.TransientActors))
 			{
-				var canIgnoreMovingAllies = self != null && !check.HasFlag(CellConditions.BlockedByMovers);
+				var canIgnoreMovingAllies = self != null && !check.HasCellCondition(CellConditions.BlockedByMovers);
 				var needsCellExclusively = self == null || Crushes == null || !Crushes.Any();
 
 				Func<Actor, bool> checkTransient = a =>

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -618,9 +618,8 @@ namespace OpenRA.Mods.Common.Traits
 					var p = ToCell + new CVec(i, j);
 					if (CanEnterCell(p))
 						availCells.Add(p);
-					else
-						if (p != nudger.Location && p != ToCell)
-							notStupidCells.Add(p);
+					else if (p != nudger.Location && p != ToCell)
+						notStupidCells.Add(p);
 				}
 
 			var moveTo = availCells.Any() ? availCells.Random(self.World.SharedRandom) : (CPos?)null;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -194,13 +194,15 @@ namespace OpenRA.Mods.Common.Traits
 		// Determines whether the actor is blocked by other Actors
 		public bool CanMoveFreelyInto(World world, Actor self, CPos cell, Actor ignoreActor, CellConditions check)
 		{
+			if (!check.HasCellCondition(CellConditions.TransientActors))
+				return true;
+
 			if (SharesCell && world.ActorMap.HasFreeSubCell(cell))
 				return true;
 
-			if (check.HasCellCondition(CellConditions.TransientActors))
-				foreach (var otherActor in world.ActorMap.GetUnitsAt(cell))
-					if (IsBlockedBy(self, otherActor, ignoreActor, check))
-						return false;
+			foreach (var otherActor in world.ActorMap.GetUnitsAt(cell))
+				if (IsBlockedBy(self, otherActor, ignoreActor, check))
+					return false;
 
 			return true;
 		}


### PR DESCRIPTION
This is a refactoring in Mobile.cs of the logic used to determine if actors block movement.

This centralises some duplicated logic in `CanMoveFreelyInto` and into `GetAvailableSubCell` into a new method and makes some minor changes to squeeze out a bit more performance as the pathfinder calls `CanMoveFreelyInto` frequently.

This is intended to have no impact on the output of these functions. This means for testing you could record a game on bleed and replaying it with this PR should not desync. That's how I tested it.
