### PR TITLE
D2k vanilla balance pass

### DIFF
--- a/mods/d2k/maps/atreides-01a/map.yaml
+++ b/mods/d2k/maps/atreides-01a/map.yaml
@@ -64,38 +64,38 @@ Actors:
 	Actor0: trike
 		Location: 15,8
 		Owner: Atreides
-	Actor1: rifle
+	Actor1: light_inf
 		Location: 13,9
 		Owner: Atreides
-	Actor2: rifle
+	Actor2: light_inf
 		Location: 25,9
 		Owner: Harkonnen
-	Actor3: rifle
+	Actor3: light_inf
 		Location: 16,10
 		Owner: Atreides
 	Actor4: trike
 		Location: 9,11
 		Owner: Atreides
-	Actor6: rifle
+	Actor6: light_inf
 		Location: 15,11
 		Owner: Atreides
 	Actor7: trike
 		Location: 9,13
 		Owner: Atreides
-	Actor8: rifle
+	Actor8: light_inf
 		Location: 15,13
 		Owner: Atreides
-	Actor9: rifle
+	Actor9: light_inf
 		Location: 14,14
 		Owner: Atreides
 		Facing: 128
-	Actor10: rifle
+	Actor10: light_inf
 		Location: 12,19
 		Owner: Harkonnen
-	Actor11: rifle
+	Actor11: light_inf
 		Location: 29,19
 		Owner: Harkonnen
-	Actor12: rifle
+	Actor12: light_inf
 		Location: 19,20
 		Owner: Harkonnen
 	Actor13: spicebloom
@@ -104,7 +104,7 @@ Actors:
 	Actor14: wormspawner
 		Location: 7,23
 		Owner: Creeps
-	AtreidesConyard: conyard
+	AtreidesConyard: construction_yard
 		Location: 11,11
 		Owner: Atreides
 	HarkonnenWaypoint1: waypoint
@@ -144,22 +144,22 @@ Rules:
 		WormManager:
 			Minimum: 1
 			Maximum: 1
-	conyard:
-		Production:
-			Produces: Building
+	upgrade.conyard:
+		Buildable:
+			Prerequisites: ~disabled
 	concreteb:
 		Buildable:
 			Prerequisites: ~disabled
 	barracks:
 		Buildable:
 			Prerequisites: ~disabled
-	light:
+	light_factory:
 		Buildable:
 			Prerequisites: ~disabled
-	heavy:
+	heavy_factory:
 		Buildable:
 			Prerequisites: ~disabled
-	guntower:
+	medium_gun_turret:
 		Buildable:
 			Prerequisites: ~disabled
 	wall:

--- a/mods/d2k/maps/atreides-01b/map.yaml
+++ b/mods/d2k/maps/atreides-01b/map.yaml
@@ -61,22 +61,22 @@ Players:
 		Enemies: Atreides
 
 Actors:
-	Actor0: rifle
+	Actor0: light_inf
 		Location: 2,2
 		Owner: Harkonnen
-	Actor1: rifle
+	Actor1: light_inf
 		Location: 21,2
 		Owner: Harkonnen
 	Actor2: wormspawner
 		Location: 4,3
 		Owner: Creeps
-	Actor3: rifle
+	Actor3: light_inf
 		Location: 2,6
 		Owner: Harkonnen
-	Actor4: rifle
+	Actor4: light_inf
 		Location: 11,7
 		Owner: Atreides
-	Actor5: rifle
+	Actor5: light_inf
 		Location: 14,8
 		Owner: Atreides
 	Actor6: trike
@@ -85,22 +85,22 @@ Actors:
 	Actor7: trike
 		Location: 8,9
 		Owner: Atreides
-	Actor9: rifle
+	Actor9: light_inf
 		Location: 14,10
 		Owner: Atreides
 	Actor10: trike
 		Location: 14,12
 		Owner: Atreides
-	Actor11: rifle
+	Actor11: light_inf
 		Location: 7,13
 		Owner: Atreides
-	Actor12: rifle
+	Actor12: light_inf
 		Location: 12,15
 		Owner: Atreides
-	Actor13: rifle
+	Actor13: light_inf
 		Location: 28,20
 		Owner: Harkonnen
-	AtreidesConyard: conyard
+	AtreidesConyard: construction_yard
 		Location: 10,10
 		Owner: Atreides
 	HarkonnenWaypoint1: waypoint
@@ -143,22 +143,22 @@ Rules:
 		WormManager:
 			Minimum: 1
 			Maximum: 1
-	conyard:
-		Production:
-			Produces: Building
+	upgrade.conyard:
+		Buildable:
+			Prerequisites: ~disabled
 	concreteb:
 		Buildable:
 			Prerequisites: ~disabled
 	barracks:
 		Buildable:
 			Prerequisites: ~disabled
-	light:
+	light_factory:
 		Buildable:
 			Prerequisites: ~disabled
-	heavy:
+	heavy_factory:
 		Buildable:
 			Prerequisites: ~disabled
-	guntower:
+	medium_gun_turret:
 		Buildable:
 			Prerequisites: ~disabled
 	wall:

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -61,7 +61,7 @@ Actors:
 	Actor29: concretea
 		Location: 54,59
 		Owner: Neutral
-	Actor30: power
+	Actor30: wind_trap
 		Location: 54,58
 		Owner: Atreides
 	Actor31: concretea
@@ -70,10 +70,10 @@ Actors:
 	Actor32: silo
 		Location: 54,62
 		Owner: Atreides
-	Actor33: guntower
+	Actor33: medium_gun_turret
 		Location: 54,63
 		Owner: Atreides
-	Actor34: siegetank
+	Actor34: siege_tank
 		Location: 54,56
 		Owner: Atreides
 		Facing: 24
@@ -92,7 +92,7 @@ Actors:
 	Actor39: barracks
 		Location: 48,37
 		Owner: Creeps
-	Actor40: rockettower
+	Actor40: large_gun_turret
 		Location: 46,39
 		Owner: Creeps
 	Actor41: sardaukar
@@ -125,9 +125,6 @@ Rules:
 			Maximum: 1
 		MusicPlaylist:
 			BackgroundMusic: options
-	rockettower:
-		Power:
-			Amount: 100
 
 Sequences:
 

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -7,22 +7,23 @@ Player:
 		BuildingCommonNames:
 			ConstructionYard: conyard
 			Refinery: refinery
-			Power: power
-			VehiclesFactory: light, heavy, starport
-			Production: light, heavy, barracks, starport
+			Power: wind_trap
+			VehiclesFactory: light_factory, heavy_factory, starport
+			Production: light_factory, heavy_factory, barracks, starport
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
 		BuildingLimits:
 			refinery: 4
 			barracks: 1
-			light: 1
-			heavy: 1
-			research: 1
-			repair: 1
-			radar: 1
-			hightech: 1
+			light_factory: 1
+			heavy_factory: 1
+			research_centre: 1
+			repair_pad: 1
+			outpost: 1
+			high_tech_factory: 1
 			palace: 1
+			upgrade.conyard: 1
 			upgrade.barracks: 1
 			upgrade.light: 1
 			upgrade.heavy: 1
@@ -30,25 +31,26 @@ Player:
 		BuildingFractions:
 			refinery: 20.1%
 			barracks: 0.1%
-			light: 0.1%
-			heavy: 0.1%
-			radar: 0.1%
-			hightech: 0.1%
+			light_factory: 0.1%
+			heavy_factory: 0.1%
+			outpost: 0.1%
+			high_tech_factory: 0.1%
 			starport: 0.1%
-			research: 0.1%
-			repair: 0.1%
-			guntower: 8%
-			rockettower: 6%
-			power: 10%
+			research_centre: 0.1%
+			repair_pad: 0.1%
+			medium_gun_turret: 8%
+			large_gun_turret: 6%
+			wind_trap: 10%
+			upgrade.conyard: 0.1%
 			upgrade.barracks: 0.1%
 			upgrade.light: 0.1%
 			upgrade.heavy: 0.1%
 			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
-			rifle: 6%
-			bazooka: 5%
-			medic: 1%
+			light_inf: 6%
+			trooper: 5%
+#			thumper: 1%
 			fremen: 0.5%
 			sardaukar: 1.5%
 			saboteur: 0.5%
@@ -56,23 +58,23 @@ Player:
 			grenadier: 1%
 			trike.starport: 5%
 			quad.starport: 7.5%
-			siegetank.starport: 5%
-			missiletank.starport: 7.5%
-			combata.starport: 15%
-			combath.starport: 15%
-			combato.starport: 15%
-			sonictank: 10%
-			devast: 10%
-			deviatortank: 7.5%
+			siege_tank.starport: 5%
+			missile_tank.starport: 7.5%
+			combat_tank_a.starport: 15%
+			combat_tank_h.starport: 15%
+			combat_tank_o.starport: 15%
+			sonic_tank: 10%
+			devastator: 10%
+			deviator: 7.5%
 			trike: 10%
 			raider: 10%
 			quad: 15%
-			siegetank: 10%
-			missiletank: 15%
-			stealthraider: 5%
-			combata: 100%
-			combath: 100%
-			combato: 100%
+			siege_tank: 10%
+			missile_tank: 15%
+			stealth_raider: 5%
+			combat_tank_a: 100%
+			combat_tank_h: 100%
+			combat_tank_o: 100%
 		SquadSize: 8
 		MaxBaseRadius: 40
 		SupportPowerDecision@Airstrike:
@@ -95,21 +97,6 @@ Player:
 				Types: Ground, Water
 				Attractiveness: -10
 				TargetMetric: Value
-				CheckRadius: 4c0
-		SupportPowerDecision@Paratroopers:
-			OrderName: ParatroopersPowerInfoOrder
-			MinimumAttractiveness: 5
-			Consideration@1:
-				Against: Enemy
-				Types: Structure
-				Attractiveness: 1
-				TargetMetric: None
-				CheckRadius: 10c0
-			Consideration@2:
-				Against: Enemy
-				Types: Vehicle, Tank, Infantry
-				Attractiveness: -5
-				TargetMetric: None
 				CheckRadius: 4c0
 		SupportPowerDecision@NukePower:
 			OrderName: NukePowerInfoOrder
@@ -134,22 +121,23 @@ Player:
 		BuildingCommonNames:
 			ConstructionYard: conyard
 			Refinery: refinery
-			Power: power
-			VehiclesFactory: light, heavy, starport
-			Production: light, heavy, barracks, starport
+			Power: wind_trap
+			VehiclesFactory: light_factory, heavy_factory, starport
+			Production: light_factory, heavy_factory, barracks, starport
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
 		BuildingLimits:
 			refinery: 4
-			barracks: 1
-			light: 1
-			heavy: 1
-			research: 1
-			repair: 1
-			radar: 1
-			hightech: 1
+			barracks: 2
+			light_factory: 1
+			heavy_factory: 1
+			research_centre: 1
+			repair_pad: 1
+			outpost: 1
+			high_tech_factory: 1
 			palace: 1
+			upgrade.conyard: 1
 			upgrade.barracks: 1
 			upgrade.light: 1
 			upgrade.heavy: 1
@@ -157,25 +145,26 @@ Player:
 		BuildingFractions:
 			refinery: 20.1%
 			barracks: 0.1%
-			light: 0.1%
-			heavy: 0.1%
-			radar: 0.1%
-			hightech: 0.1%
-			repair: 0.1%
+			light_factory: 0.1%
+			heavy_factory: 0.1%
+			outpost: 0.1%
+			high_tech_factory: 0.1%
+			repair_pad: 0.1%
 			starport: 0.1%
 			palace: 0.1%
-			guntower: 5%
-			rockettower: 10%
-			power: 12%
+			medium_gun_turret: 5%
+			large_gun_turret: 10%
+			wind_trap: 12%
+			upgrade.conyard: 0.1%
 			upgrade.barracks: 0.1%
 			upgrade.light: 0.1%
 			upgrade.heavy: 0.1%
 			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
-			rifle: 2%
-			bazooka: 2%
-			medic: 0.5%
+			light_inf: 2%
+			trooper: 2%
+#			thumper: 0.5%
 			fremen: 0.25%
 			sardaukar: 1%
 			saboteur: 0.5%
@@ -183,23 +172,23 @@ Player:
 			harvester: 0.1%
 			trike.starport: 7.5%
 			quad.starport: 12.5%
-			siegetank.starport: 5%
-			missiletank.starport: 7.5%
-			combata.starport: 15%
-			combath.starport: 15%
-			combato.starport: 15%
-			sonictank: 50%
-			devast: 40%
-			deviatortank: 5%
+			siege_tank.starport: 5%
+			missile_tank.starport: 7.5%
+			combat_tank_a.starport: 15%
+			combat_tank_h.starport: 15%
+			combat_tank_o.starport: 15%
+			sonic_tank: 50%
+			devastator: 40%
+			deviator: 5%
 			trike: 15%
 			raider: 15%
 			quad: 25%
-			siegetank: 10%
-			missiletank: 15%
-			stealthraider: 5%
-			combata: 100%
-			combath: 100%
-			combato: 100%
+			siege_tank: 10%
+			missile_tank: 15%
+			stealth_raider: 5%
+			combat_tank_a: 100%
+			combat_tank_h: 100%
+			combat_tank_o: 100%
 		SquadSize: 6
 		MaxBaseRadius: 40
 		SupportPowerDecision@Airstrike:
@@ -222,21 +211,6 @@ Player:
 				Types: Ground, Water
 				Attractiveness: -10
 				TargetMetric: Value
-				CheckRadius: 4c0
-		SupportPowerDecision@Paratroopers:
-			OrderName: ParatroopersPowerInfoOrder
-			MinimumAttractiveness: 5
-			Consideration@1:
-				Against: Enemy
-				Types: Structure
-				Attractiveness: 1
-				TargetMetric: None
-				CheckRadius: 10c0
-			Consideration@2:
-				Against: Enemy
-				Types: Vehicle, Tank, Infantry
-				Attractiveness: -5
-				TargetMetric: None
 				CheckRadius: 4c0
 		SupportPowerDecision@NukePower:
 			OrderName: NukePowerInfoOrder
@@ -261,22 +235,23 @@ Player:
 		BuildingCommonNames:
 			ConstructionYard: conyard
 			Refinery: refinery
-			Power: power
-			VehiclesFactory: light, heavy, starport
-			Production: light, heavy, barracks, starport
+			Power: wind_trap
+			VehiclesFactory: light_factory, heavy_factory, starport
+			Production: light_factory, heavy_factory, barracks, starport
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
 		BuildingLimits:
 			refinery: 4
-			barracks: 1
-			light: 1
-			heavy: 1
-			research: 1
-			repair: 1
-			radar: 1
-			hightech: 1
+			barracks: 2
+			light_factory: 1
+			heavy_factory: 1
+			research_centre: 1
+			repair_pad: 1
+			outpost: 1
+			high_tech_factory: 1
 			palace: 1
+			upgrade.conyard: 1
 			upgrade.barracks: 1
 			upgrade.light: 1
 			upgrade.heavy: 1
@@ -284,25 +259,26 @@ Player:
 		BuildingFractions:
 			refinery: 20.1%
 			barracks: 0.1%
-			light: 0.1%
-			heavy: 0.1%
-			repair: 0.1%
-			radar: 0.1%
-			hightech: 0.1%
-			research: 0.1%
+			light_factory: 0.1%
+			heavy_factory: 0.1%
+			repair_pad: 0.1%
+			outpost: 0.1%
+			high_tech_factory: 0.1%
+			research_centre: 0.1%
 			palace: 0.1%
-			guntower: 4%
-			rockettower: 12%
-			power: 10%
+			medium_gun_turret: 4%
+			large_gun_turret: 12%
+			wind_trap: 10%
+			upgrade.conyard: 0.1%
 			upgrade.barracks: 0.1%
 			upgrade.light: 0.1%
 			upgrade.heavy: 0.1%
 			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
-			rifle: 15%
-			bazooka: 13%
-			medic: 2%
+			light_inf: 15%
+			trooper: 13%
+#			thumper: 2%
 			fremen: 1%
 			sardaukar: 3%
 			saboteur: 1%
@@ -310,23 +286,23 @@ Player:
 			harvester: 0.1%
 			trike.starport: 5%
 			quad.starport: 7.5%
-			siegetank.starport: 5%
-			missiletank.starport: 7.5%
-			combata.starport: 15%
-			combath.starport: 15%
-			combato.starport: 15%
-			sonictank: 10%
-			devast: 10%
-			deviatortank: 7.5%
+			siege_tank.starport: 5%
+			missile_tank.starport: 7.5%
+			combat_tank_a.starport: 15%
+			combat_tank_h.starport: 15%
+			combat_tank_o.starport: 15%
+			sonic_tank: 10%
+			devastator: 10%
+			deviator: 7.5%
 			trike: 10%
 			raider: 10%
 			quad: 15%
-			siegetank: 10%
-			missiletank: 15%
-			stealthraider: 7.5%
-			combata: 100%
-			combath: 100%
-			combato: 100%
+			siege_tank: 10%
+			missile_tank: 15%
+			stealth_raider: 7.5%
+			combat_tank_a: 100%
+			combat_tank_h: 100%
+			combat_tank_o: 100%
 		SquadSize: 10
 		MaxBaseRadius: 40
 		SupportPowerDecision@Airstrike:
@@ -349,21 +325,6 @@ Player:
 				Types: Ground, Water
 				Attractiveness: -10
 				TargetMetric: Value
-				CheckRadius: 4c0
-		SupportPowerDecision@Paratroopers:
-			OrderName: ParatroopersPowerInfoOrder
-			MinimumAttractiveness: 5
-			Consideration@1:
-				Against: Enemy
-				Types: Structure
-				Attractiveness: 1
-				TargetMetric: None
-				CheckRadius: 10c0
-			Consideration@2:
-				Against: Enemy
-				Types: Vehicle, Tank, Infantry
-				Attractiveness: -5
-				TargetMetric: None
 				CheckRadius: 4c0
 		SupportPowerDecision@NukePower:
 			OrderName: NukePowerInfoOrder

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -1,21 +1,23 @@
 carryall.reinforce:
 	Inherits: ^Plane
 	Valued:
-		Cost: 1200
+		Cost: 1100
+	CustomBuildTimeValue:
+		Value: 648
 	Tooltip:
 		Name: Carryall
 		Description: Large winged, planet-bound ship\n  Automatically lifts harvesters.
 	Health:
-		HP: 250
+		HP: 4800
 	Armor:
-		Type: Light
+		Type: light
 	Helicopter:
 		CruiseAltitude: 2100
 		InitialFacing: 0
-		ROT: 4
-		Speed: 160
+		ROT: 7
+		Speed: 262	##131
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, Dune
-		RepairBuildings: repair
+		RepairBuildings: repair_pad
 		RearmBuildings:
 		Repulsable: False
 		LandAltitude: 100
@@ -26,6 +28,10 @@ carryall.reinforce:
 		Automatic: False
 	RenderSprites:
 		Image: carryall
+	SelfHealing:
+		Step: 5
+		Ticks: 3
+		HealIfBelow: 50%
 
 carryall:
 	Inherits: carryall.reinforce
@@ -35,35 +41,6 @@ carryall:
 		Queue: Aircraft
 		BuildPaletteOrder: 120
 
-carryall.infantry:
-	Inherits: ^Plane
-	ParaDrop:
-		DropRange: 5c0
-		ChuteSound:
-	Health:
-		HP: 200
-	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 12c0
-		Type: CenterPosition
-	Plane:
-		ROT: 4
-		Speed: 280
-		RepairBuildings: repair
-		RearmBuildings:
-		Repulsable: False
-	Cargo:
-		MaxWeight: 5
-		Types: Infantry
-	Tooltip:
-		Name: Carryall
-	SpawnActorOnDeath:
-		Actor: carryall.infantry.husk
-	RejectsOrders:
-	RenderSprites:
-		Image: carryall
-
 frigate:
 	Inherits: ^Plane
 	ParaDrop:
@@ -72,16 +49,17 @@ frigate:
 		Name: Frigate
 		Description: Supply spacecraft
 	Plane:
-		ROT: 5
-		Speed: 350
-		RepairBuildings: repair
+		CruiseAltitude: 1800
+		ROT: 7
+		Speed: 296	##148
+		RepairBuildings: repair_pad
 		RearmBuildings:
 		Repulsable: False
 	Health:
 		HP: 500
 	-AppearsOnRadar:
 	Armor:
-		Type: Heavy
+		Type: heavy
 	Cargo:
 		MaxWeight: 20
 		PipCount: 10
@@ -90,7 +68,7 @@ frigate:
 	FlyAwayOnIdle:
 	RejectsOrders:
 
-orni:
+ornithopter:
 	Inherits: ^Plane
 	Valued:
 		Cost: 1000
@@ -98,105 +76,46 @@ orni:
 		Name: Ornithopter
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles.\n  Weak vs Tanks
 	Health:
-		HP: 150
+		HP: 900
 	Armor:
-		Type: Light
-	RevealsShroud:
-		Range: 10c0
-		Type: CenterPosition
+		Type: light
 	Armament:
-		Weapon: ChainGun
+		Weapon: OrniBomb
 		LocalOffset: 85,-213,-85
-	AttackHeli:
-		FacingTolerance: 20
-	Helicopter:
-		LandWhenIdle: false
-		InitialFacing: 20
-		ROT: 6
-		Speed: 280
-		RepairBuildings: repair
+	AttackBomber:
+	Plane:
+		CruiseAltitude: 1800
+		ROT: 7
+		Speed: 442	##221
+		RepairBuildings: repair_pad
 		RearmBuildings:
+		Repulsable: False
 	SpawnActorOnDeath:
-		Actor: orni.husk
-	SelectionDecorations:
-	Selectable:
-		Bounds: 32,32
-	TargetableAircraft:
-		TargetTypes: Air
-		GroundedTargetTypes: Ground
+		Actor: ornithopter.husk
+	RejectsOrders:
 	Voiced:
 		VoiceSet: GenericVoice
 
-orni.bomber:
-	Inherits: ^Plane
-	AttackBomber:
-	Armament:
-		Weapon: Napalm
-	Health:
-		HP: 100
-	Armor:
-		Type: Light
-	Plane:
-		ROT: 5
-		Speed: 350
-		RepairBuildings: repair
-		RearmBuildings:
-		Repulsable: False
-	AmmoPool:
-		Ammo: 5
-	Tooltip:
-		Name: Ornithopter
-	SpawnActorOnDeath:
-		Actor: orni.bomber.husk
-	RejectsOrders:
-	RenderSprites:
-		Image: orni
-
-orni.husk:
+ornithopter.husk:
 	Inherits: ^AircraftHusk
 	Tooltip:
 		Name: Ornithopter
 	Helicopter:
-		ROT: 6
+		ROT: 7
 		Speed: 280
 		RepairBuildings:
 		RearmBuildings:
 	RenderSprites:
-		Image: orni
-
-orni.bomber.husk:
-	Inherits: ^AircraftHusk
-	Tooltip:
-		Name: Ornithopter
-	Plane:
-		ROT: 5
-		Speed: 350
-		RepairBuildings:
-		RearmBuildings:
-	RenderSprites:
-		Image: orni
+		Image: ornithopter
 
 carryall.husk:
 	Inherits: ^AircraftHusk
 	Tooltip:
 		Name: Carryall
 	Helicopter:
-		ROT: 4
+		ROT: 7
 		Speed: 210
 		RepairBuildings:
 		RearmBuildings:
 	RenderSprites:
 		Image: carryall
-
-carryall.infantry.husk:
-	Inherits: ^AircraftHusk
-	Tooltip:
-		Name: Carryall
-	Plane:
-		ROT: 4
-		Speed: 280
-		RepairBuildings:
-		RearmBuildings:
-	RenderSprites:
-		Image: carryall
-

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -21,12 +21,12 @@ sandworm:
 		Name: Sandworm
 		Description: Attracted by vibrations in the sand.\nWill eat units whole and has a large appetite.
 	Health:
-		HP: 1200
+		HP: 9990
 		Radius: 3
 	Armor:
-		Type: None
+		Type: heavy
 	Mobile:
-		Speed: 50
+		Speed: 40 ##20
 		TerrainSpeeds:
 			Sand: 100
 			Dune: 100
@@ -47,6 +47,7 @@ sandworm:
 		Weapon: WormJaw
 	Sandworm:
 		WanderMoveRadius: 5
+		ChanceToDisappear: 100
 	IgnoresCloak:
 	AnnounceOnSeen:
 		Notification: WormSign
@@ -63,15 +64,14 @@ sietch:
 		Dimensions: 2,2
 		TerrainTypes: Cliff
 	Health:
-		HP: 400
+		HP: 6000
 	Armor:
-		Type: Concrete
+		Type: wood
 	RevealsShroud:
-		Range: 10c0
+		Range: 4c768
 	-GivesBuildableArea:
 	-Sellable:
-	-ExternalCapturable:
-	-ExternalCapturableBar:
+	-Capturable:
 	Power:
 		Amount: 0
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -49,18 +49,18 @@
 		UpgradeMaxAcceptedLevel: 4
 
 ^Vehicle:
-	Inherits@1: ^ExistsInWorld
-	Inherits@2: ^GainsExperience
+	Inherits: ^ExistsInWorld
+##	Inherits@2: ^GainsExperience
 	Mobile:
 		Crushes: crate
 		TerrainSpeeds:
-			Sand: 90
+			Sand: 100
 			Rock: 100
-			Transition: 95
+			Transition: 100
 			Concrete: 100
-			Spice: 80
-			SpiceBlobs: 80
-			Dune: 60
+			Spice: 100
+			SpiceBlobs: 100
+			Dune: 50
 		ROT: 5
 	SelectionDecorations:
 	Selectable:
@@ -73,9 +73,9 @@
 	DrawLineToTarget:
 	HiddenUnderFog:
 	ActorLostNotification:
-	GivesBounty:
+##	GivesBounty:
 	Repairable:
-		RepairBuildings: repair
+		RepairBuildings: repair_pad
 	Guard:
 		Voice: Guard
 	Guardable:
@@ -97,20 +97,12 @@
 	Inherits: ^Vehicle
 	Mobile:
 		Crushes: crate, infantry
-		TerrainSpeeds:
-			Sand: 85
-			Rock: 100
-			Transition: 92
-			Concrete: 100
-			Spice: 80
-			SpiceBlobs: 80
-			Dune: 70
 
 ^Husk:
 	Health:
-		HP: 75
+		HP: 125
 	Armor:
-		Type: Light
+		Type: light
 	HiddenUnderFog:
 		Type: CenterPosition
 	Tooltip:
@@ -131,13 +123,16 @@
 	TargetableUnit:
 		TargetTypes: Ground
 		RequiresForceFire: yes
-	Capturable:
-		Type: husk
-		AllowAllies: yes
-		CaptureThreshold: 1.0
-	TransformOnCapture:
-		ForceHealthPercentage: 25
+#	Capturable:
+#		Type: husk
+#		AllowAllies: yes
+#		CaptureThreshold: 1.0
+#	TransformOnCapture:
+#		ForceHealthPercentage: 25
 	DisabledOverlay:
+	Explodes:
+		Weapon: UnitExplodeMed
+		EmptyWeapon: UnitExplodeMed
 
 ^AircraftHusk:
 	Inherits: ^Husk
@@ -145,47 +140,33 @@
 	FallsToEarth:
 		Spins: False
 		Moves: True
-		Explosion: UnitExplodeScale
-
-^TowerHusk:
-	Health:
-		HP: 125
-	Armor:
-		Type: Concrete
-	Husk:
-	AppearsOnRadar:
-	HiddenUnderFog:
-	Burns:
-		Interval: 2
-	Tooltip:
-		Name: Destroyed Tower
-	BodyOrientation:
-	ScriptTriggers:
+		Explosion: UnitExplodeLarge
 
 ^Infantry:
-	Inherits@1: ^ExistsInWorld
-	Inherits@2: ^GainsExperience
+	Inherits: ^ExistsInWorld
+##	Inherits@2: ^GainsExperience
 	Health:
 		Radius: 96
 	Armor:
-		Type: None
+		Type: none
 	RevealsShroud:
-		Range: 6c0
+		Range: 3c768
 	Mobile:
+		ROT: 7
 		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
-			Sand: 80
+			Sand: 100
 			Rock: 100
-			Transition: 90
+			Transition: 100
 			Concrete: 100
-			Spice: 80
-			SpiceBlobs: 80
-			Dune: 60
-			Rough: 70
+			Spice: 100
+			SpiceBlobs: 100
+			Dune: 100
+			Rough: 100
 	SelectionDecorations:
 	Selectable:
-		Bounds: 12,18,0,-6
+		Bounds: 12,20,0,-4
 	TargetableUnit:
 		TargetTypes: Ground
 		UpgradeTypes: parachute
@@ -204,6 +185,7 @@
 			BulletDeath: 4
 		CrushedSequence: die-crushed
 	AutoTarget:
+		AllowMovement: false
 	AttackMove:
 	DrawLineToTarget:
 	Passenger:
@@ -211,7 +193,7 @@
 		PipType: Green
 	HiddenUnderFog:
 	ActorLostNotification:
-	GivesBounty:
+##	GivesBounty:
 	Crushable:
 		CrushSound: CRUSH1.WAV
 	Guard:
@@ -237,7 +219,7 @@
 	Inherits@1: ^ExistsInWorld
 	AppearsOnRadar:
 		UseLocation: yes
-	HiddenUnderFog:
+	HiddenUnderShroud:
 		Type: CenterPosition
 		AlwaysVisibleStances: None
 	ActorLostNotification:
@@ -255,6 +237,8 @@
 	SelectionDecorations:
 	Selectable:
 		Priority: 2
+	RevealsShroud:
+		VisibilityType: CenterPosition
 	TargetableBuilding:
 		TargetTypes: Ground, C4, Structure
 	Building:
@@ -264,8 +248,8 @@
 		BuildSounds: BUILD1.WAV
 		Adjacent: 3
 	GivesBuildableArea:
-	ExternalCapturable:
-	ExternalCapturableBar:
+	Capturable:
+		CaptureThreshold: 1.0
 	SoundOnDamageTransition:
 		DamagedSounds: EXPLSML1.WAV
 		DestroyedSounds: EXPLHG1.WAV
@@ -273,7 +257,7 @@
 	WithBuildingExplosion:
 	RepairableBuilding:
 	EmitInfantryOnSell:
-		ActorTypes: rifle,rifle,rifle,rifle,rifle,bazooka,bazooka,bazooka,engineer
+		ActorTypes: light_inf
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	FrozenUnderFog:
@@ -283,15 +267,16 @@
 	ShakeOnDeath:
 	Sellable:
 		SellSounds: BUILD1.WAV
-	GivesBounty:
+##	GivesBounty:
+	AutoTargetIgnore:
 	Guardable:
 		Range: 3
 	WithCrumbleOverlay:
 	Demolishable:
 	DamagedWithoutFoundation:
 	ThrowsShrapnel:
-		Weapons: shrapnel
-		Pieces: 3, 7
-		Range: 2c0, 5c0
+		Weapons: debris, debris2, debris3, debris4
+		Pieces: 3, 5
+		Range: 1c0, 3c0
 	WithMakeAnimation:
 

--- a/mods/d2k/rules/husks.yaml
+++ b/mods/d2k/rules/husks.yaml
@@ -1,67 +1,59 @@
 mcv.husk:
 	Inherits: ^VehicleHusk
-	Health:
-		HP: 175
 	Tooltip:
 		Name: Destroyed Mobile Construction Vehicle
 
 harvester.husk:
 	Inherits: ^VehicleHusk
-	Health:
-		HP: 150
 	Tooltip:
 		Name: Destroyed Spice Harvester
 	TransformOnCapture:
 		IntoActor: harvester
 
-siegetank.husk:
+siege_tank.husk:
 	Inherits: ^VehicleHusk
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
-		IntoActor: siegetank
+		IntoActor: siege_tank
 
-missiletank.husk:
+missile_tank.husk:
 	Inherits: ^VehicleHusk
 	TransformOnCapture:
-		IntoActor: missiletank
+		IntoActor: missile_tank
 
-sonictank.husk:
+sonic_tank.husk:
 	Inherits: ^VehicleHusk
 	TransformOnCapture:
-		IntoActor: sonictank
+		IntoActor: sonic_tank
 
-devast.husk:
-	Inherits: ^VehicleHusk
-	Health:
-		HP: 125
-	TransformOnCapture:
-		IntoActor: devast
-
-deviatortank.husk:
+devastator.husk:
 	Inherits: ^VehicleHusk
 	TransformOnCapture:
-		IntoActor: deviatortank
+		IntoActor: devastator
 
-^combat.husk:
+deviator.husk:
 	Inherits: ^VehicleHusk
-	Health:
-		HP: 100
+	TransformOnCapture:
+		IntoActor: deviator
+
+^combat_tank.husk:
+	Inherits: ^VehicleHusk
 	ThrowsParticle@turret:
 		Anim: turret
 
-combata.husk:
-	Inherits: ^combat.husk
+combat_tank_a.husk:
+	Inherits: ^combat_tank.husk
 	TransformOnCapture:
-		IntoActor: combata
+		IntoActor: combat_tank_a
 
-combath.husk:
-	Inherits: ^combat.husk
+combat_tank_h.husk:
+	Inherits: ^combat_tank.husk
 	TransformOnCapture:
-		IntoActor: combath
+		IntoActor: combat_tank_h
 
-combato.husk:
-	Inherits: ^combat.husk
+combat_tank_o.husk:
+	Inherits: ^combat_tank.husk
 	TransformOnCapture:
-		IntoActor: combato
+		IntoActor: combat_tank_o
 

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -1,24 +1,24 @@
-rifle:
+light_inf:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 10
 	Valued:
-		Cost: 100
+		Cost: 50
+	CustomBuildTimeValue:
+		Value: 54
 	Tooltip:
-		Name: Rifleman
+		Name: Light Infantry
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
 	Health:
-		HP: 50
+		HP: 600
 	Mobile:
-		Speed: 53
+		Speed: 66	##33
 	Armament:
 		Weapon: LMG
 	AttackFrontal:
 	WithInfantryBody:
 		AttackSequence: shoot
-	AttractsWorms:
-		Intensity: 120
 
 engineer:
 	Inherits: ^Infantry
@@ -27,66 +27,72 @@ engineer:
 		BuildPaletteOrder: 50
 		Prerequisites: upgrade.barracks, ~techlevel.medium
 	Valued:
-		Cost: 500
+		Cost: 400
+	CustomBuildTimeValue:
+		Value: 108
 	Tooltip:
 		Name: Engineer
 		Description: Infiltrates and captures enemy structures\n  Strong vs Buildings\n  Weak vs Everything
 	Health:
-		HP: 25
+		HP: 500
+	RevealsShroud:
+		Range: 2c768
 	Mobile:
-		Speed: 53
+		Speed: 50	##25
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
-	ExternalCaptures:
-		Type: building
 	Captures:
-		CaptureTypes: husk
+		Type: building, husk
 	-AutoTarget:
-	AttractsWorms:
-		Intensity: 180
 	Voiced:
 		VoiceSet: EngineerVoice
 
-bazooka:
+trooper:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 20
 		Prerequisites: upgrade.barracks, ~techlevel.medium
 	Valued:
-		Cost: 250
+		Cost: 90
+	CustomBuildTimeValue:
+		Value: 73
 	Tooltip:
 		Name: Trooper
 		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
 	Health:
-		HP: 45
+		HP: 700
+	RevealsShroud:
+		Range: 4c768
 	Mobile:
-		Speed: 42
+		Speed: 50	##25
 	Armament:
 		Weapon: Bazooka
-		LocalOffset: 0,0,555
+		LocalOffset: 35,0,555
 	AttackFrontal:
 	WithInfantryBody:
 		AttackSequence: shoot
-	AttractsWorms:
-		Intensity: 180
 
-medic:
+thumper:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 60
-		Prerequisites: ~barracks.medics, upgrade.barracks, ~techlevel.high
+		Prerequisites: upgrade.barracks, ~techlevel.high
 	Valued:
-		Cost: 500
+		Cost: 200
+	CustomBuildTimeValue:
+		Value: 108
 	Tooltip:
 		Name: Medic
 		Description: Heals nearby infantry\n  Strong vs Nothing\n  Weak vs Everything
 	Health:
-		HP: 60
+		HP: 375
+	RevealsShroud:
+		Range: 2c768
 	Mobile:
-		Speed: 42
+		Speed: 66	##33
 	AutoHeal:
 	Armament:
 		Weapon: Heal
@@ -98,41 +104,41 @@ medic:
 	Passenger:
 		PipType: Blue
 	-AutoTarget:
-	AttractsWorms:
-		Intensity: 180
 	Voiced:
 		VoiceSet: EngineerVoice
 
 fremen:
 	Inherits: ^Infantry
-	Valued:
-		Cost: 800
-	Tooltip:
-		Name: Fremen
-		Description: Elite sniper infantry unit\n  Strong vs Infantry\n  Weak vs Vehicles\n  Special Ability: Invisibility
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 100
 		Prerequisites: ~barracks.atreides, palace, ~techlevel.high
-	Mobile:
-		Speed: 53
+	Valued:
+		Cost: 200	## actually 0, but spawns from support power at Palace
+	##CustomBuildTimeValue:
+	##	Value: 1944
+	Tooltip:
+		Name: Fremen
+		Description: Elite sniper infantry unit\n  Strong vs Infantry\n  Weak vs Vehicles\n  Special Ability: Invisibility
 	Health:
-		HP: 70
-	Passenger:
+		HP: 700
 	RevealsShroud:
-		Range: 7c0
+		Range: 4c768
+	Mobile:
+		Speed: 66	##33
+	Passenger:
 	AutoTarget:
 		ScanRadius: 7
 	Armament@PRIMARY:
-		Weapon: Sniper
+		Weapon: Fremen_S
 	Armament@SECONDARY:
-		Weapon: Slung
+		Weapon: Fremen_L
 	AttackFrontal:
 	WithInfantryBody:
 		AttackSequence: shoot
 	Cloak:
-		InitialDelay: 250
-		CloakDelay: 250
+		InitialDelay: 85
+		CloakDelay: 85
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
 	-MustBeDestroyed:
@@ -144,58 +150,59 @@ grenadier:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 80
-		Prerequisites: ~barracks.atreides, upgrade.barracks, hightech, ~techlevel.medium
+		Prerequisites: ~barracks.atreides, upgrade.barracks, high_tech_factory, ~techlevel.medium
 	Valued:
-		Cost: 160
+		Cost: 80
+	CustomBuildTimeValue:
+		Value: 81	## Wasn't converted, copied from Sardauker who has same value in TibEd.
 	Tooltip:
 		Name: Grenadier
 		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
 	Health:
-		HP: 50
+		HP: 600
 	Mobile:
-		Speed: 53
+		Speed: 66	##33
 	Armament:
-		Weapon: Grenade
-		LocalOffset: 0,0,555
+		Weapon: grenade
+		LocalOffset: 0,0,500
 		FireDelay: 15
 	AttackFrontal:
 	WithInfantryBody:
 		AttackSequence: throw
 		IdleSequences: idle
-	Explodes:
-		Weapon: UnitExplodeSmall
-		Chance: 100
-	AttractsWorms:
-		Intensity: 180
 
 sardaukar:
 	Inherits: ^Infantry
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 80
-		Prerequisites: ~barracks.harkonnen, palace, ~techlevel.high
+		Prerequisites: ~barracks.harkonnen, upgrade.barracks, high_tech_factory, ~techlevel.high
 	Valued:
-		Cost: 400
+		Cost: 200
+	CustomBuildTimeValue:
+		Value: 81
 	Tooltip:
 		Name: Sardaukar
-		Description: Elite asssault infantry\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
+		Description: Elite assault infantry\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
 	Health:
-		HP: 100
+		HP: 1000
 	Mobile:
-		Speed: 42
+		Speed: 50	##25
 	RevealsShroud:
-		Range: 6c0
+		Range: 4c768
 	WithInfantryBody:
 		AttackSequence: shoot
 	Armament@PRIMARY:
-		Weapon: Vulcan
+		Weapon: M_LMG
 	Armament@SECONDARY:
-		Weapon: Slung
+		Weapon: M_HMG
 	AttackFrontal:
-	AttractsWorms:
-		Intensity: 180
 	Voiced:
 		VoiceSet: GenericVoice
+	Explodes:
+		Weapon: SardDeath
+		EmptyWeapon: SardDeath
+		Chance: 100
 
 saboteur:
 	Inherits: ^Infantry
@@ -204,21 +211,54 @@ saboteur:
 		BuildPaletteOrder: 100
 		Prerequisites: ~barracks.ordos, palace, ~techlevel.high
 	Valued:
-		Cost: 800
+		Cost: 300	## actually 0, but spawns from support power at Palace
+	##CustomBuildTimeValue:
+	##	Value: 1944
 	Tooltip:
 		Name: Saboteur
 		Description: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 	Health:
-		HP: 100
+		HP: 400
 	Mobile:
-		Speed: 64
-	RevealsShroud:
-		Range: 7c0
+		Speed: 66	##33
 	C4Demolition:
 		C4Delay: 45
 	-AutoTarget:
-	AttractsWorms:
-		Intensity: 120
+	Cloak:
+		InitialDelay: 85
+		CloakDelay: 85
+		CloakSound: STEALTH1.WAV
+		UncloakSound: STEALTH2.WAV
+		UncloakOnMove: true
 	Voiced:
 		VoiceSet: SaboteurVoice
+
+nsfremen:
+	Inherits: ^Infantry
+	Valued:
+		Cost: 0
+	Tooltip:
+		Name: Fremen
+		Description: Elite sniper infantry unit\n  Strong vs Infantry\n  Weak vs Vehicles\n  Special Ability: Invisibility
+	Health:
+		HP: 700
+	RevealsShroud:
+		Range: 4c768
+	Mobile:
+		Speed: 66	##33
+	Passenger:
+	AutoTarget:
+		ScanRadius: 7
+	Armament@PRIMARY:
+		Weapon: Fremen_S
+	Armament@SECONDARY:
+		Weapon: Fremen_L
+	AttackFrontal:
+	RenderSprites:
+		Image: fremen
+	WithInfantryBody:
+		AttackSequence: shoot
+	-MustBeDestroyed:
+	Voiced:
+		VoiceSet: FremenVoice
 

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -20,14 +20,14 @@ crate:
 	ExplodeCrateAction@1:
 		Weapon: CrateExplosion
 		SelectionShares: 5
-	HideMapCrateAction:
-		SelectionShares: 5
-		Effect: hide-map
-	LevelUpCrateAction:
-		SelectionShares: 40
-	RevealMapCrateAction:
-		SelectionShares: 2
-		Effect: reveal-map
+#	HideMapCrateAction:
+#		SelectionShares: 5
+#		Effect: hide-map
+#	LevelUpCrateAction:
+#		SelectionShares: 40
+#	RevealMapCrateAction:
+#		SelectionShares: 2
+#		Effect: reveal-map
 	GiveUnitCrateAction@Trike:
 		SelectionShares: 20
 		Units: trike
@@ -43,30 +43,30 @@ crate:
 		Prerequisites: techlevel.medium, Light, Outpost
 	GiveUnitCrateAction@CombatA:
 		SelectionShares: 10
-		Units: combata
+		Units: combat_tank_a
 		ValidRaces: atreides
 		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@CombatH:
 		SelectionShares: 10
-		Units: combath
+		Units: combat_tank_h
 		ValidRaces: harkonnen
 		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@CombatO:
 		SelectionShares: 10
-		Units: combato
+		Units: combat_tank_o
 		ValidRaces: ordos
 		Prerequisites: techlevel.low, Heavy
 	GiveUnitCrateAction@SiegeTank:
 		SelectionShares: 10
-		Units: siegetank
+		Units: siege_tank
 		Prerequisites: techlevel.medium, Heavy, Outpost
 	GiveUnitCrateAction@MissileTank:
 		SelectionShares: 10
-		Units: missiletank
+		Units: missile_tank
 		Prerequisites: techlevel.high, Hitech
 	GiveUnitCrateAction@StealthRaider:
 		SelectionShares: 7
-		Units: stealthraider
+		Units: stealth_raider
 		ValidRaces: ordos
 		Prerequisites: techlevel.medium, Hitech
 	GiveUnitCrateAction@Fremen:
@@ -86,17 +86,17 @@ crate:
 		Prerequisites: techlevel.high, Palace
 	GiveUnitCrateAction@SonicTank:
 		SelectionShares: 5
-		Units: sonictank
+		Units: sonic_tank
 		ValidRaces: atreides
 		Prerequisites: techlevel.high, Research
 	GiveUnitCrateAction@Devast:
 		SelectionShares: 2
-		Units: devast
+		Units: devastator
 		ValidRaces: harkonnen
 		Prerequisites: techlevel.high, Research
 	GiveUnitCrateAction@DeviatorTank:
 		SelectionShares: 5
-		Units: deviatortank
+		Units: deviator
 		ValidRaces: ordos
 		Prerequisites: techlevel.high, Research
 	GiveMcvCrateAction:
@@ -141,7 +141,7 @@ camera:
 	Health:
 		HP: 1000
 	RevealsShroud:
-		Range: 8c0
+		Range: 6c768
 		Type: CenterPosition
 	BodyOrientation:
 
@@ -161,10 +161,13 @@ upgrade.conyard:
 		Description: Unlocks new construction options
 	Buildable:
 		BuildPaletteOrder: 50
+		Prerequisites: construction_yard
 		Queue: Upgrade
 		BuildLimit: 1
 	Valued:
 		Cost: 1000
+	CustomBuildTimeValue:
+		Value: 590
 	RenderSprites:
 		Image: conyard.harkonnen
 		RaceImages:
@@ -185,6 +188,8 @@ upgrade.barracks:
 		BuildLimit: 1
 	Valued:
 		Cost: 500
+	CustomBuildTimeValue:
+		Value: 290
 	RenderSprites:
 		Image: barracks.harkonnen
 		RaceImages:
@@ -199,11 +204,13 @@ upgrade.light:
 		Description: Unlocks additional light units
 	Buildable:
 		BuildPaletteOrder: 50
-		Prerequisites: light
+		Prerequisites: light_factory
 		Queue: Upgrade
 		BuildLimit: 1
 	Valued:
 		Cost: 400
+	CustomBuildTimeValue:
+		Value: 215
 	RenderSprites:
 		Image: light.harkonnen
 		RaceImages:
@@ -218,11 +225,13 @@ upgrade.heavy:
 		Description: Unlocks advanced technology and heavy weapons
 	Buildable:
 		BuildPaletteOrder: 50
-		Prerequisites: heavy
+		Prerequisites: heavy_factory
 		Queue: Upgrade
 		BuildLimit: 1
 	Valued:
 		Cost: 800
+	CustomBuildTimeValue:
+		Value: 380
 	RenderSprites:
 		Image: heavy.harkonnen
 		RaceImages:
@@ -243,6 +252,8 @@ upgrade.hightech:
 		BuildLimit: 1
 	Valued:
 		Cost: 1500
+	CustomBuildTimeValue:
+		Value: 720
 	RenderSprites:
 		Image: hightech.atreides
 	ProvidesPrerequisite@upgradename:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -1,41 +1,51 @@
 Player:
 	AlwaysVisible:
 	TechTree:
+	Production:
+		Produces: Building, Upgrade
+	Exit:
+		MoveIntoWorld: false
 	ClassicProductionQueue@Building:
 		Type: Building
+		BuildSpeed: 1.0
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: BuildingReady
 		BlockedAudio: NoRoom
 	ClassicProductionQueue@Upgrade:
 		Type: Upgrade
-		LowPowerSlowdown: 3
+		BuildSpeed: 1.0
+		LowPowerSlowdown: 0
 		QueuedAudio: Upgrading
 		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
-		LowPowerSlowdown: 2
+		BuildSpeed: 1.0
+		LowPowerSlowdown: 3
 		BlockedAudio: NoRoom
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
+		BuildSpeed: 1.0
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		BlockedAudio: NoRoom
 	ClassicProductionQueue@Armor:
 		Type: Armor
+		BuildSpeed: 1.0
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		BlockedAudio: NoRoom
 	ClassicProductionQueue@Starport:
 		Type: Starport
-		BuildSpeed: .2
-		LowPowerSlowdown: 1
+		BuildSpeed: 0.85
+		LowPowerSlowdown: 0
 		BlockedAudio: NoRoom
 		QueuedAudio: OrderPlaced
 		ReadyAudio:
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
+		BuildSpeed: 1.25
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		BlockedAudio: NoRoom

--- a/mods/d2k/rules/starport.yaml
+++ b/mods/d2k/rules/starport.yaml
@@ -1,7 +1,7 @@
 mcv.starport:
 	Inherits: mcv
 	Buildable:
-		Prerequisites: repair
+		Prerequisites: starport
 		Queue: Starport
 	Valued:
 		Cost: 2500
@@ -11,6 +11,7 @@ mcv.starport:
 harvester.starport:
 	Inherits: harvester
 	Buildable:
+		Prerequisites: starport
 		Queue: Starport
 	Valued:
 		Cost: 1500
@@ -20,6 +21,7 @@ harvester.starport:
 trike.starport:
 	Inherits: trike
 	Buildable:
+		Prerequisites: starport
 		Queue: Starport
 	Valued:
 		Cost: 315
@@ -29,64 +31,68 @@ trike.starport:
 quad.starport:
 	Inherits: quad
 	Buildable:
+		Prerequisites: starport
 		Queue: Starport
 	Valued:
 		Cost: 500
 	RenderSprites:
 		Image: quad
 
-siegetank.starport:
-	Inherits: siegetank
+siege_tank.starport:
+	Inherits: siege_tank
 	Buildable:
+		Prerequisites: starport
 		Queue: Starport
 	Valued:
 		Cost: 1075
 	RenderSprites:
-		Image: siegetank
+		Image: siege_tank
 
-missiletank.starport:
-	Inherits: missiletank
+missile_tank.starport:
+	Inherits: missile_tank
 	Buildable:
+		Prerequisites: starport
 		Queue: Starport
 	Valued:
 		Cost: 1250
 	RenderSprites:
-		Image: missiletank
+		Image: missile_tank
 
-combata.starport:
-	Inherits: combata
+combat_tank_a.starport:
+	Inherits: combat_tank_a
 	Buildable:
 		Prerequisites: ~starport.atreides
 		Queue: Starport
 	Valued:
 		Cost: 875
 	RenderSprites:
-		Image: combata
+		Image: combat_tank_a
 
-combath.starport:
-	Inherits: combath
+combat_tank_h.starport:
+	Inherits: combat_tank_h
 	Buildable:
 		Prerequisites: ~starport.harkonnen
 		Queue: Starport
 	Valued:
 		Cost: 875
 	RenderSprites:
-		Image: combath
+		Image: combat_tank_h
 
-combato.starport:
-	Inherits: combato
+combat_tank_o.starport:
+	Inherits: combat_tank_o
 	Buildable:
 		Prerequisites: ~starport.ordos
 		Queue: Starport
 	Valued:
 		Cost: 875
 	RenderSprites:
-		Image: combato
+		Image: combat_tank_o
 
 carryall.starport:
 	Inherits: carryall
+	Buildable:
+		Prerequisites: starport
+		Queue: Starport
 	Valued:
 		Cost: 1500
-	Buildable:
-		Queue: Starport
 

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -16,6 +16,7 @@
 		RemoveInstead: true
 	Buildable:
 		Queue: Building
+		Prerequisites: construction_yard
 		BuildPaletteOrder: 10
 
 concretea:
@@ -25,6 +26,8 @@ concretea:
 		Dimensions: 2,2
 	Valued:
 		Cost: 20
+	CustomBuildTimeValue:
+		Value: 54
 
 concreteb:
 	Inherits: ^concrete
@@ -33,10 +36,12 @@ concreteb:
 		Dimensions: 3,3
 	Valued:
 		Cost: 50
+	CustomBuildTimeValue:
+		Value: 81
 	Buildable:
-		Prerequisites: upgrade.conyard
+		Prerequisites: construction_yard, upgrade.conyard
 
-conyard:
+construction_yard:
 	Inherits: ^Building
 	Building:
 		Footprint: xxx xxx
@@ -49,21 +54,21 @@ conyard:
 	Selectable:
 		Bounds: 96,64
 	Health:
-		HP: 1000
+		HP: 3000
 	Armor:
-		Type: Concrete
+		Type: cy
 	RevealsShroud:
-		Range: 10c0
+		Range: 4c768
 	Production:
-		Produces: Building, Upgrade
-		MoveIntoWorld: false
-	Exit:
+		Produces: Building
 	Valued:
 		Cost: 2000
 	Tooltip:
 		Name: Construction Yard
 	CustomSellValue:
 		Value: 2000
+	EmitInfantryOnSell:
+		ActorTypes: light_inf, light_inf, engineer
 	BaseBuilding:
 	ProductionBar:
 	Power:
@@ -77,29 +82,33 @@ conyard:
 	WithBuildingPlacedOverlay:
 		Palette: d2k
 	PrimaryBuilding:
+	ProvidesPrerequisite@buildingname:
 
-power:
+wind_trap:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
+		Prerequisites: construction_yard
 		BuildPaletteOrder: 10
 	Selectable:
 		Bounds: 64,64
 	Valued:
-		Cost: 300
+		Cost: 225
+	CustomBuildTimeValue:
+		Value: 180
 	Tooltip:
-		Name: Windtrap
+		Name: Wind Trap
 		Description: Provides power for other structures
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Bib:
 	Health:
-		HP: 400
+		HP: 3000
 	Armor:
-		Type: Wood
+		Type: building
 	RevealsShroud:
-		Range: 4c0
+		Range: 3c768
 	RenderBuilding:
 		Image: power.harkonnen
 		RaceImages:
@@ -108,20 +117,22 @@ power:
 	WithIdleOverlay@ZAPS:
 		Sequence: idle-zaps
 	Power:
-		Amount: 100
+		Amount: 200
 	ScalePowerWithHealth:
 	ProvidesPrerequisite@buildingname:
 
 barracks:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: power
+		Prerequisites: construction_yard, wind_trap
 		Queue: Building
 		BuildPaletteOrder: 40
 	Selectable:
 		Bounds: 64,64
 	Valued:
-		Cost: 300
+		Cost: 225
+	CustomBuildTimeValue:
+		Value: 231
 	Tooltip:
 		Name: Barracks
 		Description: Trains infantry
@@ -130,13 +141,13 @@ barracks:
 		Dimensions: 2,2
 	Bib:
 	Health:
-		HP: 800
+		HP: 3200
 	Armor:
-		Type: Wood
+		Type: wood
 	RevealsShroud:
-		Range: 5c0
+		Range: 3c768
 	RallyPoint:
-		Offset: 1,3
+		Offset: 1,2
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
@@ -156,11 +167,8 @@ barracks:
 	ProvidesPrerequisite@harkonnen:
 		Prerequisite: barracks.harkonnen
 		Factions: harkonnen
-	ProvidesPrerequisite@medics:
-		Prerequisite: barracks.medics
-		Factions: atreides, ordos
 	Power:
-		Amount: -20
+		Amount: -30
 	RenderBuilding:
 		Image: barracks.harkonnen
 		RaceImages:
@@ -171,13 +179,15 @@ barracks:
 refinery:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: power
+		Prerequisites: construction_yard, wind_trap
 		Queue: Building
 		BuildPaletteOrder: 20
 	Selectable:
 		Bounds: 96,64
 	Valued:
 		Cost: 1500
+	CustomBuildTimeValue:
+		Value: 540
 	Tooltip:
 		Name: Spice Refinery
 		Description: Harvesters unload Spice here for processing
@@ -186,11 +196,11 @@ refinery:
 		Dimensions: 3,2
 	Bib:
 	Health:
-		HP: 900
+		HP: 3000
 	Armor:
-		Type: Wood
+		Type: building
 	RevealsShroud:
-		Range: 6c0
+		Range: 4c768
 	Refinery:
 		DockAngle: 160
 		DockOffset: 2,1
@@ -215,7 +225,7 @@ refinery:
 		Sequence: smoke
 		Palette: effectAdditive
 	Power:
-		Amount: -30
+		Amount: -75
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
 	ProvidesPrerequisite@buildingname:
@@ -223,13 +233,15 @@ refinery:
 silo:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: refinery
+		Prerequisites: construction_yard, refinery
 		Queue: Building
 		BuildPaletteOrder: 30
 	Selectable:
 		Bounds: 32,32
 	Valued:
-		Cost: 150
+		Cost: 120
+	CustomBuildTimeValue:
+		Value: 135
 	Tooltip:
 		Name: Silo
 		Description: Stores excess harvested Spice
@@ -237,11 +249,11 @@ silo:
 		Adjacent: 4
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 1500
 	Armor:
-		Type: Wood
+		Type: wall
 	RevealsShroud:
-		Range: 4c0
+		Range: 2c768
 	-RenderBuilding:
 	RenderBuildingSilo:
 		Image: silo.harkonnen
@@ -254,20 +266,22 @@ silo:
 		Capacity: 2000
 	-EmitInfantryOnSell:
 	Power:
-		Amount: -5
+		Amount: -15
 	MustBeDestroyed:
 		RequiredForShortGame: false
 
-light:
+light_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: refinery
+		Prerequisites: construction_yard, refinery
 		Queue: Building
 		BuildPaletteOrder: 70
 	Selectable:
 		Bounds: 96,64
 	Valued:
 		Cost: 500
+	CustomBuildTimeValue:
+		Value: 277
 	Tooltip:
 		Name: Light Factory
 		Description: Produces light vehicles
@@ -276,11 +290,11 @@ light:
 		Dimensions: 3,2
 	Bib:
 	Health:
-		HP: 750
+		HP: 3300
 	Armor:
-		Type: Wood
+		Type: light
 	RevealsShroud:
-		Range: 4c0
+		Range: 4c768
 	RenderBuilding:
 		Image: light.harkonnen
 		RaceImages:
@@ -313,18 +327,20 @@ light:
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
 	Power:
-		Amount: -20
+		Amount: -125
 
-heavy:
+heavy_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: refinery
+		Prerequisites: construction_yard, refinery
 		Queue: Building
 		BuildPaletteOrder: 100
 	Selectable:
 		Bounds: 96,68,0,12
 	Valued:
-		Cost: 2000
+		Cost: 1000
+	CustomBuildTimeValue:
+		Value: 648
 	Tooltip:
 		Name: Heavy Factory
 		Description: Produces heavy vehicles
@@ -333,11 +349,11 @@ heavy:
 		Dimensions: 3,3
 	Bib:
 	Health:
-		HP: 1500
+		HP: 3500
 	Armor:
-		Type: Wood
+		Type: wood
 	RevealsShroud:
-		Range: 4c0
+		Range: 4c768
 	RallyPoint:
 		Offset: 0,3
 	Exit@1:
@@ -370,24 +386,26 @@ heavy:
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
 	Power:
-		Amount: -30
+		Amount: -150
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 		VisualBounds: 96,96
 
-radar:
+outpost:
 	Inherits: ^Building
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
 	Buildable:
-		Prerequisites: barracks, ~techlevel.medium
+		Prerequisites: construction_yard, barracks, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 50
 	Selectable:
 		Bounds: 96,64
 	Valued:
-		Cost: 700
+		Cost: 750
+	CustomBuildTimeValue:
+		Value: 270
 	Tooltip:
 		Name: Outpost
 		Description: Provides a radar map of the battlefield\n  Requires power to operate
@@ -396,49 +414,48 @@ radar:
 		Dimensions: 3,2
 	Bib:
 	Health:
-		HP: 1000
+		HP: 3500
 	Armor:
-		Type: Wood
+		Type: light
 	RevealsShroud:
-		Range: 10c0
+		Range: 4c768
 	ProvidesRadar:
-	DetectCloaked:
-		Range: 6
-	RenderDetectionCircle:
 	RenderBuilding:
-		Image: radar.harkonnen
+		Image: outpost.harkonnen
 		RaceImages:
-			atreides: radar.atreides
-			ordos: radar.ordos
+			atreides: outpost.atreides
+			ordos: outpost.ordos
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
 		PauseOnLowPower: yes
 	Power:
-		Amount: -40
+		Amount: -125
 	ProvidesPrerequisite@buildingname:
 
 starport:
 	Inherits: ^Building
-	Valued:
-		Cost: 2000
 	Tooltip:
 		Name: Starport
 		Description: Dropzone for quick reinforcements, at a price.\n  Requires power to operate
 	Buildable:
-		Prerequisites: heavy, radar, ~techlevel.high
+		Prerequisites: construction_yard, heavy_factory, outpost, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 80
+	Selectable:
+		Bounds: 96,64
+	Valued:
+		Cost: 1500
+	CustomBuildTimeValue:
+		Value: 540
 	Building:
 		Footprint: xxx x=x =x=
 		Dimensions: 3,3
-	Selectable:
-		Bounds: 96,64
 	Health:
-		HP: 1000
+		HP: 3500
 	Armor:
-		Type: Wood
+		Type: building
 	RevealsShroud:
-		Range: 7c0
+		Range: 4c768
 	RallyPoint:
 		Offset: 1,3
 	Exit@1:
@@ -455,7 +472,7 @@ starport:
 		RaceImages:
 			atreides: starport.atreides
 			ordos: starport.ordos
-			corrino: starport.corrino
+			corrino: starport.smuggler
 	WithDeliveryOverlay:
 		Palette: starportlights
 	ProductionBar:
@@ -473,20 +490,22 @@ starport:
 		Prerequisite: starport.harkonnen
 		Factions: harkonnen
 	Power:
-		Amount: -40
+		Amount: -150
 	ProvidesPrerequisite@buildingname:
 
 wall:
 	HiddenUnderShroud:
 	Buildable:
 		Queue: Building
-		Prerequisites: barracks
+		Prerequisites: construction_yard, wind_trap
 		BuildPaletteOrder: 60
 	SoundOnDamageTransition:
 		DamagedSounds:
 		DestroyedSounds: EXPLSML4.WAV
 	Valued:
-		Cost: 100
+		Cost: 20
+	CustomBuildTimeValue:
+		Value: 54
 	CustomSellValue:
 		Value: 0
 	Tooltip:
@@ -498,38 +517,37 @@ wall:
 		Adjacent: 7
 		TerrainTypes: Rock, Concrete
 	Health:
-		HP: 300
+		HP: 2000
 	Armor:
-		Type: Concrete
+		Type: none
+	RevealsShroud:
+		Range: 2c768
 	Crushable:
 		CrushClasses: Concretewall
 	BlocksProjectiles:
 	LineBuild:
-		Range: 8
+		Range: 5
 		NodeTypes: wall, turret
 	LineBuildNode:
 		Types: wall
 	TargetableBuilding:
 		TargetTypes: Ground
 	RenderBuildingWall:
-	AutoTargetIgnore:
 	Sellable:
 		SellSounds: CHUNG.WAV
 	Guardable:
 	BodyOrientation:
-	ThrowsShrapnel:
-		Weapons: shrapnel
-		Pieces: 3, 7
-		Range: 2c0, 5c0
 
-guntower:
+medium_gun_turret:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: barracks
+		Prerequisites: construction_yard, barracks
 		BuildPaletteOrder: 90
 	Valued:
-		Cost: 650
+		Cost: 550
+	CustomBuildTimeValue:
+		Value: 231
 	Tooltip:
 		Name: Gun Turret
 		Description: Defensive structure\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
@@ -543,11 +561,11 @@ guntower:
 		Priority: 3
 	-GivesBuildableArea:
 	Health:
-		HP: 400
+		HP: 2700
 	Armor:
-		Type: Concrete
+		Type: heavy
 	RevealsShroud:
-		Range: 8c0
+		Range: 2c768
 	RenderRangeCircle:
 	-RenderBuilding:
 	RenderBuildingWall:
@@ -559,33 +577,32 @@ guntower:
 		ROT: 6
 		InitialFacing: 128
 	Armament:
-		Weapon: TurretGun
+		Weapon: 110mm_Gun
 		LocalOffset: 512,0,432
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	AutoTarget:
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 5
-	-WithCrumbleOverlay:
+	-AutoTargetIgnore:
 	-WithMakeAnimation:
 	LineBuildNode:
 		Types: turret
 	Power:
-		Amount: -20
+		Amount: -50
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	SelectionDecorations:
 		VisualBounds: 32,40,0,-8
 
-rockettower:
+large_gun_turret:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: radar, upgrade.conyard, ~techlevel.medium
+		Prerequisites: construction_yard, outpost, upgrade.conyard, ~techlevel.medium
 		BuildPaletteOrder: 120
 	Valued:
-		Cost: 850
+		Cost: 750
+	CustomBuildTimeValue:
+		Value: 270
 	Tooltip:
 		Name: Rocket Turret
 		Description: Defensive structure\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks\n\n  Requires power to operate
@@ -599,11 +616,11 @@ rockettower:
 		Priority: 3
 	-GivesBuildableArea:
 	Health:
-		HP: 400
+		HP: 3000
 	Armor:
-		Type: Concrete
+		Type: concrete
 	RevealsShroud:
-		Range: 10c0
+		Range: 2c768
 	RenderRangeCircle:
 	-RenderBuilding:
 	RenderBuildingWall:
@@ -612,37 +629,37 @@ rockettower:
 	WithTurret:
 	Armament:
 		Weapon: TowerMissile
-		LocalOffset: 256,384,768, 256,-384,768
+		LocalOffset: 256,0,768
 	AttackTurreted:
 	Turreted:
 		ROT: 8
 		InitialFacing: 128
 	AutoTarget:
+	-AutoTargetIgnore:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 6
-	-WithCrumbleOverlay:
+	WithCrumbleOverlay:
 	-WithMakeAnimation:
 	LineBuildNode:
 		Types: turret
 	Power:
-		Amount: -30
+		Amount: -60
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	SelectionDecorations:
 		VisualBounds: 32,40,0,-8
 
-repair:
+repair_pad:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: heavy, upgrade.heavy, ~techlevel.medium
+		Prerequisites: construction_yard, heavy_factory, upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 130
 	Valued:
-		Cost: 500
+		Cost: 800
+	CustomBuildTimeValue:
+		Value: 324
 	Tooltip:
 		Name: Repair Pad
 		Description: Repairs vehicles\n Allows construction of MCVs
@@ -650,11 +667,11 @@ repair:
 		Footprint: =x= =x= ===
 		Dimensions: 3,3
 	Health:
-		HP: 500
+		HP: 3000
 	Armor:
-		Type: Concrete
+		Type: building
 	RevealsShroud:
-		Range: 5c0
+		Range: 4c768
 	Selectable:
 		Bounds: 96,64
 	SelectionDecorations:
@@ -667,26 +684,28 @@ repair:
 	RallyPoint:
 		Offset: 1,3
 	RenderBuilding:
-		Image: repair.harkonnen
+		Image: repair_pad.harkonnen
 		RaceImages:
-			atreides: repair.atreides
-			ordos: repair.ordos
+			atreides: repair_pad.atreides
+			ordos: repair_pad.ordos
 	WithRepairOverlay:
 		Palette: effect75alpha
 	Power:
-		Amount: -10
+		Amount: -50
 	ProvidesPrerequisite@buildingname:
 
-hightech:
+high_tech_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: radar, ~techlevel.medium
+		Prerequisites: construction_yard, outpost, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 110
 	Selectable:
 		Bounds: 96,68,0,12
 	Valued:
-		Cost: 750
+		Cost: 1150
+	CustomBuildTimeValue:
+		Value: 405
 	Tooltip:
 		Name: High Tech Factory
 		Description: Unlocks advanced technology
@@ -700,11 +719,11 @@ hightech:
 		Dimensions: 3,3
 	Bib:
 	Health:
-		HP: 1500
+		HP: 3500
 	Armor:
-		Type: Wood
+		Type: wood
 	RevealsShroud:
-		Range: 4c0
+		Range: 4c768
 	RenderBuilding:
 		Image: hightech.harkonnen
 		RaceImages:
@@ -721,51 +740,42 @@ hightech:
 		ChargeTime: 180
 		SquadSize: 3
 		LongDesc: Ornithopters hit the target with parabombs
-		UnitType: orni.bomber
+		UnitType: ornithopter
 		SelectTargetSound:
 		DisplayBeacon: True
 		CameraActor: camera
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
 	Power:
-		Amount: -40
+		Amount: -75
 	SelectionDecorations:
 		VisualBounds: 96,96
 
-research:
+research_centre:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: radar, heavy, upgrade.heavy, ~techlevel.high
+		Prerequisites: construction_yard, outpost, heavy_factory, upgrade.heavy, ~techlevel.high
 		BuildPaletteOrder: 140
 	Selectable:
 		Bounds: 96,64,0,16
 	Valued:
-		Cost: 1500
+		Cost: 1000
+	CustomBuildTimeValue:
+		Value: 270
 	Tooltip:
 		Name: Ix Lab
-		Description: Unlocks experimental tanks\n  Special Ability: Carryall Combat Drop
-	ParatroopersPower:
-		Icon: paratroopers
-		Prerequisites: ~techlevel.superweapons
-		UnitType: carryall.infantry
-		FlareTime: 0
-		ChargeTime: 180
-		Description: Paratroopers
-		LongDesc: A Carryall drops a squad of Infantry \nanywhere on the map
-		DropItems: RIFLE, RIFLE, BAZOOKA, BAZOOKA, ENGINEER, BAZOOKA, RIFLE, RIFLE
-		SelectTargetSound:
-		FlareType:
+		Description: Unlocks experimental tanks
 	Building:
 		Footprint: _x_ xxx xxx
 		Dimensions: 3,3
 	Bib:
 	Health:
-		HP: 1000
+		HP: 2500
 	Armor:
-		Type: Wood
+		Type: wood
 	RevealsShroud:
-		Range: 4c0
+		Range: 4c768
 	RenderBuilding:
 		Image: research.harkonnen
 		RaceImages:
@@ -774,7 +784,7 @@ research:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	Power:
-		Amount: -40
+		Amount: -175
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 		VisualBounds: 96,80
@@ -782,13 +792,15 @@ research:
 palace:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: research, ~techlevel.high
+		Prerequisites: construction_yard, research_centre, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 150
 	Selectable:
 		Bounds: 96,96
 	Valued:
-		Cost: 2000
+		Cost: 1600
+	CustomBuildTimeValue:
+		Value: 810
 	Tooltip:
 		Name: Palace
 		Description: Unlocks elite infantry
@@ -798,22 +810,19 @@ palace:
 	Bib:
 		HasMinibib: True
 	Health:
-		HP: 2000
+		HP: 4000
 	Armor:
-		Type: Wood
+		Type: wood
 	RevealsShroud:
-		Range: 8c0
+		Range: 4c768
 	RenderBuilding:
 		Image: palace.harkonnen
 		RaceImages:
 			atreides: palace.atreides
 			ordos: palace.ordos
 			corrino: palace.corrino
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 4
 	Power:
-		Amount: -50
+		Amount: -200
 	ProvidesPrerequisite@nuke:
 		Prerequisite: palace.nuke
 		Factions: harkonnen
@@ -823,7 +832,7 @@ palace:
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke
 		ChargeTime: 300
 		Description: Death Hand
-		LongDesc: Launches a nuclear missile at a target location
+		LongDesc: Launches an atomic missile at a target location
 		BeginChargeSound: HI_PREP.AUD
 		EndChargeSound: HI_DHRDY.AUD
 		SelectTargetSound:
@@ -841,7 +850,7 @@ palace:
 	ProvidesPrerequisite@buildingname:
 
 conyard.atreides:
-	Inherits: conyard
+	Inherits: construction_yard
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 1000
@@ -852,7 +861,7 @@ conyard.atreides:
 		-RaceImages:
 
 conyard.harkonnen:
-	Inherits: conyard
+	Inherits: construction_yard
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 1000
@@ -863,7 +872,7 @@ conyard.harkonnen:
 		-RaceImages:
 
 conyard.ordos:
-	Inherits: conyard
+	Inherits: construction_yard
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 1000

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -1,11 +1,13 @@
 mcv:
 	Inherits: ^Vehicle
 	Buildable:
-		Prerequisites: repair, upgrade.heavy, ~techlevel.medium
+		Prerequisites: repair_pad, upgrade.heavy, ~techlevel.medium
 		Queue: Armor
 		BuildPaletteOrder: 110
 	Valued:
 		Cost: 2000
+	CustomBuildTimeValue:
+		Value: 648
 	Tooltip:
 		Name: Mobile Construction Vehicle
 		Description: Deploys into another Construction Yard\n  Unarmed
@@ -13,23 +15,24 @@ mcv:
 		Class: mcv
 		Priority: 3
 	Health:
-		HP: 800
+		HP: 4500
 	Armor:
-		Type: Light
+		Type: light
 	Mobile:
-		Speed: 64
+		ROT: 5
+		Speed: 50	##25
 		Crushes: crate, infantry
 	RevealsShroud:
-		Range: 8c0
+		Range: 2c768
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	BaseBuilding:
 	Explodes:
-		Weapon: UnitExplodeScale
-		EmptyWeapon: UnitExplodeScale
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
 	Transforms:
 		Facing: 16
-		IntoActor: conyard
+		IntoActor: construction_yard
 		Offset: -1,-1
 		TransformSounds: BUILD1.WAV
 		NoTransformNotification: CannotDeploy
@@ -39,6 +42,10 @@ mcv:
 		Intensity: 700
 	SelectionDecorations:
 		VisualBounds: 42,42
+	SelfHealing:
+		Step: 5
+		Ticks: 3
+		HealIfBelow: 50%
 
 harvester:
 	Inherits: ^Vehicle
@@ -48,7 +55,9 @@ harvester:
 		BuildPaletteOrder: 10
 		InitialActivity: FindResources
 	Valued:
-		Cost: 1000
+		Cost: 1200
+	CustomBuildTimeValue:
+		Value: 540
 	Tooltip:
 		Name: Spice Harvester
 		Description: Collects Spice for processing\n  Unarmed
@@ -56,27 +65,28 @@ harvester:
 		Class: harvester
 		Priority: 7
 	Harvester:
-		PipCount: 10
-		Capacity: 40
+		PipCount: 7
+		Capacity: 28
 		HarvestFacings: 8
 		Resources: Spice
 		UnloadTicksPerBale: 5
 		SearchFromProcRadius: 24
 		SearchFromOrderRadius: 12
 	Health:
-		HP: 1000
+		HP: 4500
 	Armor:
-		Type: Heavy
+		Type: harvester
 	Mobile:
-		Speed: 64
+		ROT: 5
+		Speed: 66	##33
 		Crushes: crate, infantry
 	RevealsShroud:
-		Range: 4c0
+		Range: 2c768
 	Explodes:
-		Weapon: SpiceExplosion
-		EmptyWeapon: UnitExplodeScale
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
-		Actor: Harvester.Husk
+		Actor: harvester.Husk
 	WithHarvestOverlay:
 		Palette: effect50alpha
 	WithDockingAnimation:
@@ -84,6 +94,10 @@ harvester:
 		Intensity: 700
 	SelectionDecorations:
 		VisualBounds: 42,42
+	SelfHealing:
+		Step: 5
+		Ticks: 3
+		HealIfBelow: 50%
 
 trike:
 	Inherits: ^Vehicle
@@ -92,21 +106,23 @@ trike:
 		BuildPaletteOrder: 10
 		Prerequisites: ~light.regulartrikes
 	Valued:
-		Cost: 250
+		Cost: 300
+	CustomBuildTimeValue:
+		Value: 194
 	Tooltip:
-		Name: Scout Trike
-		Description: Fast Scout\n Strong vs Infantry\n Weak vs Tanks, Aircraft
+		Name: Trike
+		Description: Fast scout\n Strong vs Infantry\n Weak vs Tanks, Aircraft
 	Selectable:
 		Class: trike
 	Health:
-		HP: 100
+		HP: 900
 	Armor:
-		Type: Light
+		Type: wood
 	Mobile:
 		ROT: 10
-		Speed: 128
+		Speed: 196	##98
 	RevealsShroud:
-		Range: 7c0
+		Range: 4c768
 	WithMuzzleFlash:
 	Armament:
 		Weapon: HMG
@@ -115,8 +131,8 @@ trike:
 	AttackFrontal:
 	AutoTarget:
 	Explodes:
-		Weapon: UnitExplodeTiny
-		EmptyWeapon: UnitExplodeTiny
+		Weapon: UnitExplodeSmall
+		EmptyWeapon: UnitExplodeSmall
 	AttractsWorms:
 		Intensity: 420
 
@@ -128,54 +144,57 @@ quad:
 		BuildPaletteOrder: 20
 	Valued:
 		Cost: 400
+	CustomBuildTimeValue:
+		Value: 277
 	Tooltip:
 		Name: Missile Quad
 		Description: Missile Scout\n Strong vs Vehicles\n  Weak vs Infantry
 	Health:
-		HP: 125
+		HP: 1100
 	Armor:
-		Type: Light
+		Type: light
 	Mobile:
-		ROT: 8
-		Speed: 96
+		ROT: 10
+		Speed: 148	##74
 	RevealsShroud:
-		Range: 8c0
+		Range: 4c768
 	Armament:
-		Weapon: QuadRockets
+		Weapon: Rocket
 		LocalOffset: 128,64,64, 128,-64,64
 	AttackFrontal:
 	AutoTarget:
 	Explodes:
-		Weapon: UnitExplodeTiny
-		EmptyWeapon: UnitExplodeTiny
+		Weapon: UnitExplodeSmall
+		EmptyWeapon: UnitExplodeSmall
 	Selectable:
 		Class: quad
 	AttractsWorms:
 		Intensity: 470
 
-siegetank:
+siege_tank:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Armor
 		Prerequisites: upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 50
 	Valued:
-		Cost: 850
+		Cost: 700
+	CustomBuildTimeValue:
+		Value: 324
 	Tooltip:
 		Name: Siege Tank
 		Description: Siege Artillery\n  Strong vs Infantry, Buildings\n  Weak vs Tanks, Aircraft
 	Health:
-		HP: 120
+		HP: 1200
 	Armor:
-		Type: Heavy
+		Type: light
 	Mobile:
-		Speed: 53
-		ROT: 3
-		Crushes: crate, infantry
+		Speed: 66	##33
+		ROT: 7
 	RevealsShroud:
-		Range: 8c0
+		Range: 6c768
 	Turreted:
-		ROT: 3
+		ROT: 7
 		Offset: 0,0,-32
 	Armament:
 		Weapon: 155mm
@@ -187,110 +206,113 @@ siegetank:
 	WithMuzzleFlash:
 	WithTurret:
 	Explodes:
-		Weapon: UnitExplodeScale
-		EmptyWeapon: UnitExplodeScale
+		Weapon: UnitExplodeMed
+		EmptyWeapon: UnitExplodeMed
 	AutoTarget:
 		InitialStance: Defend
 	Selectable:
 		Class: siegetank
 	SpawnActorOnDeath:
-		Actor: siegetank.husk
+		Actor: siege_tank.husk
 	AttractsWorms:
 		Intensity: 600
-	RenderSprites:
-		Image: SIEGETANK
 
-missiletank:
+missile_tank:
 	Inherits: ^Tank
-	Valued:
-		Cost: 1000
-	Tooltip:
-		Name: Rocket Tank
-		Description: Rocket Artillery\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Buildable:
 		Queue: Armor
-		Prerequisites: ~heavy.missiletank, upgrade.heavy, research, ~techlevel.high
+		Prerequisites: ~heavy.missiletank, upgrade.heavy, research_centre, ~techlevel.high
 		BuildPaletteOrder: 60
+	Valued:
+		Cost: 900
+	CustomBuildTimeValue:
+		Value: 441
+	Tooltip:
+		Name: Missile Tank
+		Description: Rocket Artillery\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Mobile:
-		Speed: 64
-		ROT: 5
+		Speed: 98	##49
+		ROT: 7
 	Health:
-		HP: 90
+		HP: 1300
 	Armor:
-		Type: Light
+		Type: wood
 	RevealsShroud:
-		Range: 9c0
+		Range: 6c768
 	Armament:
 		Weapon: 227mm
-		LocalOffset: -213,128,171, -213,-256,171
+		LocalOffset: -128,0,171
 		FireDelay: 15
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend
 	Explodes:
-		Weapon: UnitExplodeScale
-		EmptyWeapon: UnitExplodeScale
+		Weapon: UnitExplodeMed
+		EmptyWeapon: UnitExplodeMed
 	Selectable:
 		Class: missiletank
 	SpawnActorOnDeath:
-		Actor: missiletank.husk
+		Actor: missile_tank.husk
 	AttractsWorms:
 		Intensity: 600
 
-sonictank:
-	Inherits: ^Vehicle
-	Buildable:
-		Queue: Armor
-		BuildPaletteOrder: 100
-		Prerequisites: ~heavy.atreides, research, ~techlevel.high
-	Valued:
-		Cost: 1250
-	Tooltip:
-		Name: Sonic Tank
-		Description: Fires sonic shocks\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery, Aircraft
-	Health:
-		HP: 130
-	Armor:
-		Type: Light
-	Mobile:
-		ROT: 3
-		Speed: 74
-	RevealsShroud:
-		Range: 6c0
-	Armament:
-		Weapon: Sound
-		LocalOffset: 640,0,427
-	AttackFrontal:
-	AutoTarget:
-	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
-	SpawnActorOnDeath:
-		Actor: sonictank.husk
-	AttractsWorms:
-		Intensity: 600
-
-devast:
+sonic_tank:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 100
-		Prerequisites: ~heavy.harkonnen, research, ~techlevel.high
+		Prerequisites: ~heavy.atreides, research_centre, ~techlevel.high
 	Valued:
-		Cost: 1200
+		Cost: 1000
+	CustomBuildTimeValue:
+		Value: 486
+	Tooltip:
+		Name: Sonic Tank
+		Description: Fires sonic shocks\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery, Aircraft
+	Health:
+		HP: 3000
+	Armor:
+		Type: light
+	Mobile:
+		ROT: 5
+		Speed: 50	##25
+	RevealsShroud:
+		Range: 5c768
+	Armament:
+		Weapon: Sound
+		LocalOffset: 600,0,427
+	AttackFrontal:
+	AutoTarget:
+	Explodes:
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
+	SpawnActorOnDeath:
+		Actor: sonic_tank.husk
+	AttractsWorms:
+		Intensity: 600
+
+devastator:
+	Inherits: ^Tank
+	Buildable:
+		Queue: Armor
+		BuildPaletteOrder: 100
+		Prerequisites: ~heavy.harkonnen, research_centre, ~techlevel.high
+	Valued:
+		Cost: 1050
+	CustomBuildTimeValue:
+		Value: 540
 	Tooltip:
 		Name: Devastator
 		Description: Super Heavy Tank\n  Strong vs Tanks\n  Weak vs Artillery, Aircraft
 	Health:
-		HP: 650
+		HP: 5000
 	Armor:
-		Type: Heavy
+		Type: heavy
 	Mobile:
-		ROT: 3
-		Speed: 42
-		Crushes: crate, infantry
+		ROT: 5
+		Speed: 50	##25
 	RevealsShroud:
-		Range: 7c0
+		Range: 4c768
 	Armament:
 		Weapon: DevBullet
 		LocalOffset: 640,0,32
@@ -300,14 +322,18 @@ devast:
 		IgnoreOffset: true
 	AutoTarget:
 	Explodes:
-		Weapon: UnitExplodeScale
-		EmptyWeapon: UnitExplodeScale
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
-		Actor: devast.husk
+		Actor: devastator.husk
 	AttractsWorms:
 		Intensity: 700
 	SelectionDecorations:
 		VisualBounds: 44,38,0,0
+	SelfHealing:
+		Step: 5
+		Ticks: 3
+		HealIfBelow: 50%
 
 raider:
 	Inherits: ^Vehicle
@@ -316,19 +342,21 @@ raider:
 		BuildPaletteOrder: 10
 		Prerequisites: ~light.ordos
 	Valued:
-		Cost: 300
+		Cost: 350
+	CustomBuildTimeValue:
+		Value: 194
 	Tooltip:
 		Name: Raider Trike
 		Description: Improved Scout\n Strong vs Infantry, Light Vehicles
 	Health:
-		HP: 110
+		HP: 1000
 	Armor:
-		Type: Light
+		Type: wood
 	Mobile:
 		ROT: 10
-		Speed: 149
+		Speed: 230	##115
 	RevealsShroud:
-		Range: 7c0
+		Range: 4c768
 	WithMuzzleFlash:
 	Armament:
 		Weapon: HMGo
@@ -337,18 +365,20 @@ raider:
 	AttackFrontal:
 	AutoTarget:
 	Explodes:
-		Weapon: UnitExplodeTiny
-		EmptyWeapon: UnitExplodeTiny
+		Weapon: UnitExplodeSmall
+		EmptyWeapon: UnitExplodeSmall
 	AttractsWorms:
 		Intensity: 420
 
-stealthraider:
+stealth_raider:
 	Inherits: raider
 	Buildable:
-		Prerequisites: ~light.ordos, upgrade.light, hightech, ~techlevel.medium
+		Prerequisites: ~light.ordos, upgrade.light, high_tech_factory, ~techlevel.medium
 		BuildPaletteOrder: 30
 	Valued:
 		Cost: 400
+	CustomBuildTimeValue:
+		Value: 194	## Copied from Raider, not included in conversion. Both have same "BuildSpeed" in TibEd
 	Tooltip:
 		Name: Stealth Raider Trike
 		Description: Invisible Raider Trike\n Strong vs Infantry, Light Vehicles
@@ -361,65 +391,68 @@ stealthraider:
 		InitialStance: HoldFire
 	-MustBeDestroyed:
 
-deviatortank:
+deviator:
 	Inherits: ^Tank
-	Valued:
-		Cost: 1000
-	Tooltip:
-		Name: Deviator
-		Description: Fires a warhead which changes\nthe allegiance of enemy vehicles
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 50
-		Prerequisites: ~heavy.ordos, research, ~techlevel.high
+		Prerequisites: ~heavy.ordos, research_centre, ~techlevel.high
+	Valued:
+		Cost: 1000
+	CustomBuildTimeValue:
+		Value: 486
+	Tooltip:
+		Name: Deviator
+		Description: Fires a warhead which changes\nthe allegiance of enemy vehicles
 	Mobile:
-		ROT: 3
-		Speed: 64
+		ROT: 5
+		Speed: 82	##41
 	Health:
-		HP: 125
+		HP: 1100
 	Armor:
-		Type: Light
+		Type: wood
 	RevealsShroud:
-		Range: 5c0
+		Range: 4c768
 	Armament:
-		Weapon: NerveGasMissile
+		Weapon: DeviatorMissile
 		LocalOffset: -299,0,85
 	AttackFrontal:
 	AutoTarget:
 		InitialStance: Defend
 	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
+		Weapon: UnitExplodeLarge
+		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
-		Actor: deviatortank.husk
+		Actor: deviator.husk
 	AttractsWorms:
 		Intensity: 600
 
-^combat:
+^combat_tank:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 40
 	Valued:
 		Cost: 700
+	CustomBuildTimeValue:
+		Value: 373
 	Tooltip:
 		Name: Combat Tank
 		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft\n \n  Atreides:      +Range\n  Harkonnen: +Health\n  Ordos:         +Speed
 	Health:
-		HP: 350
+		HP: 2100
 	Armor:
-		Type: Heavy
+		Type: heavy
 	Mobile:
-		Speed: 64
-		ROT: 6
-		Crushes: crate, infantry
+		Speed: 144	##57
+		ROT: 7
 	RevealsShroud:
-		Range: 8c0
+		Range: 5c768
 	Turreted:
-		ROT: 6
+		ROT: 8
 		RealignDelay: 0
 	Armament:
-		Weapon: 90mm
+		Weapon: 80mm_A
 		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 256,0,0
@@ -429,48 +462,45 @@ deviatortank:
 	WithTurret:
 	AutoTarget:
 	Explodes:
-		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
+		Weapon: UnitExplodeMed
+		EmptyWeapon: UnitExplodeMed
 	Selectable:
 		Class: combat
 	AttractsWorms:
 		Intensity: 520
 
-combata:
-	Inherits: ^combat
+combat_tank_a:
+	Inherits: ^combat_tank
 	Buildable:
 		Prerequisites: ~heavy.atreides
 	Armament:
-		Weapon: 90mma
+		Weapon: 80mm_A
 	SpawnActorOnDeath:
-		Actor: combata.husk
+		Actor: combat_tank_a.husk
 
-combath:
-	Inherits: ^combat
+combat_tank_h:
+	Inherits: ^combat_tank
 	Buildable:
 		Prerequisites: ~heavy.harkonnen
+	Armament:
+		Weapon: 80mm_H
 	Mobile:
-		Speed: 53
-		ROT: 4
-	Turreted:
-		ROT: 5
-	RevealsShroud:
-		Range: 7c0
+		Speed: 98	##49
 	Health:
-		HP: 440
+		HP: 2700
 	SpawnActorOnDeath:
-		Actor: combath.husk
+		Actor: combat_tank_h.husk
 
-combato:
-	Inherits: ^combat
+combat_tank_o:
+	Inherits: ^combat_tank
 	Buildable:
 		Prerequisites: ~heavy.ordos
-	Turreted:
-		ROT: 8
+	Armament:
+		Weapon: 80mm_O
 	Mobile:
-		Speed: 96
-		ROT: 8
-		Crushes: crate, infantry
+		Speed: 132	##66
+	Health:
+		HP: 1800
 	SpawnActorOnDeath:
-		Actor: combato.husk
+		Actor: combat_tank_o.husk
 

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -35,6 +35,10 @@
 		Name: Corrino
 		InternalName: corrino
 		Selectable: false
+	Faction@Smuggler:
+		Name: Smugglers
+		InternalName: smuggler
+		Selectable: false
 	ResourceType@Spice:
 		ResourceType: 1
 		Palette: d2k
@@ -59,6 +63,8 @@ World:
 	ProductionQueueFromSelection:
 		ProductionPaletteWidget: PRODUCTION_PALETTE
 	WormManager:
+		Minimum: 0
+		SpawnInterval: 6000
 	CrateSpawner:
 		Minimum: 0
 		Maximum: 2
@@ -91,7 +97,7 @@ World:
 		ClassName: Light Support
 		Factions: atreides
 		BaseActor: mcv
-		SupportActors: rifle, rifle, rifle, bazooka, grenadier, trike, quad
+		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, quad
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@lightharkonnen:
@@ -99,7 +105,7 @@ World:
 		ClassName: Light Support
 		Factions: harkonnen
 		BaseActor: mcv
-		SupportActors: rifle, rifle, rifle, bazooka, bazooka, trike, quad
+		SupportActors: light_inf, light_inf, light_inf, trooper, trooper, trike, quad
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@lightordos:
@@ -107,7 +113,7 @@ World:
 		ClassName: Light Support
 		Factions: ordos
 		BaseActor: mcv
-		SupportActors: rifle, rifle, rifle, bazooka, engineer, raider, quad
+		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, quad
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@heavyatreides:
@@ -115,7 +121,7 @@ World:
 		ClassName: Heavy Support
 		Factions: atreides
 		BaseActor: mcv
-		SupportActors: rifle, rifle, rifle, bazooka, grenadier, trike, combata, missiletank
+		SupportActors: light_inf, light_inf, light_inf, trooper, grenadier, trike, combat_tank_a, missile_tank
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@heavyharkonnen:
@@ -123,7 +129,7 @@ World:
 		ClassName: Heavy Support
 		Factions: harkonnen
 		BaseActor: mcv
-		SupportActors: rifle, rifle, rifle, bazooka, engineer, quad, combath, siegetank
+		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, quad, combat_tank_h, siege_tank
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@heavyordos:
@@ -131,7 +137,7 @@ World:
 		ClassName: Heavy Support
 		Factions: ordos
 		BaseActor: mcv
-		SupportActors: rifle, rifle, rifle, bazooka, engineer, raider, combato, missiletank
+		SupportActors: light_inf, light_inf, light_inf, trooper, engineer, raider, combat_tank_o, missile_tank
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	SpawnMPUnits:

--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -10,7 +10,7 @@ carryall:
 		Offset: -30,-24
 
 
-orni:
+ornithopter:
 	idle: DATA.R8
 		Start: 1955
 		Facings: -32

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -1,4 +1,4 @@
-rifle:
+light_inf:
 	stand: DATA.R8
 		Start: 206
 		Facings: -8
@@ -54,12 +54,12 @@ rifle:
 		Frames: 386, 393, 400, 407, 414, 421, 428, 435
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	icon: DATA.R8
 		Start: 4011
 		Offset: -30,-24
 
-bazooka:
+trooper:
 	stand: DATA.R8
 		Start: 458
 		Facings: -8
@@ -114,7 +114,7 @@ bazooka:
 		Frames: 638, 645, 652, 659, 666, 673, 680, 687
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	icon: DATA.R8
 		Start: 4012
 		Offset: -30,-24
@@ -165,12 +165,12 @@ engineer:
 		Frames: 1346, 1353, 1360, 1367, 1374, 1381, 1388, 1395
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	icon: DATA.R8
 		Start: 4013
 		Offset: -30,-24
 
-medic: # actually thumper
+thumper:
 	stand: DATA.R8
 		Start: 1402
 		Facings: -8
@@ -220,7 +220,7 @@ medic: # actually thumper
 		Frames: 1548, 1554, 1561, 1568, 1575, 1582, 1589, 1596
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	icon: DATA.R8
 		Start: 4014
 		Offset: -30,-24
@@ -297,7 +297,7 @@ fremen:
 		Frames: 874, 881, 888, 895, 902, 909, 916, 923
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	icon: DATA.R8
 		Start: 4032
 		Offset: -30,-24
@@ -348,7 +348,7 @@ saboteur:
 		Frames: 2329, 2336, 2343, 2350, 2357, 2364, 2371, 2378
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	icon: DATA.R8
 		Start: 4034
 		Offset: -30,-24
@@ -409,7 +409,7 @@ sardaukar:
 		Frames: 1110, 1117, 1124, 1131, 1138, 1145, 1152, 1159
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	icon: DATA.R8
 		Start: 4015
 		Offset: -30,-24
@@ -448,7 +448,7 @@ grenadier: # 2502 - 2749 in 1.06 DATA.R8
 		Start: 195
 		Length: 8
 		Tick: 800
-		ZOffset: -511
+		ZOffset: 2048
 	prone-stand: grenadier.shp
 		Start: 104
 		Length: 4

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -296,9 +296,6 @@ doubleblastbullet:
 		BlendMode: Additive
 
 icon:
-	paratroopers: DATA.R8
-		Start: 4029
-		Offset: -30,-24
 	ornistrike: DATA.R8
 		Start: 4031
 		Offset: -30,-24

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -21,7 +21,7 @@ wall:
 		Start: 4063
 		Offset: -30,-24
 
-guntower:
+medium_gun_turret:
 	idle: DATA.R8
 		Frames: 2573, 2576, 2574, 2584, 2577, 2578, 2588, 2581, 2575, 2585, 2579, 2580, 2586, 2582, 2583, 2587
 		Length: 16
@@ -30,6 +30,11 @@ guntower:
 		Frames: 2621, 2624, 2622, 2632, 2625, 2626, 2636, 2629, 2623, 2633, 2627, 2628, 2634, 2630, 2631, 2635
 		Length: 16
 		Offset: -24,16
+	crumble-overlay: DATA.R8
+		Start: 4320
+		Length: 7
+		Offset: -16,16
+		Tick: 200
 	turret: DATA.R8
 		Start: 2589
 		Facings: -32
@@ -44,7 +49,7 @@ guntower:
 		Start: 4069
 		Offset: -30,-24
 
-rockettower:
+large_gun_turret:
 	idle: DATA.R8
 		Frames: 2573, 2576, 2574, 2584, 2577, 2578, 2588, 2581, 2575, 2585, 2579, 2580, 2586, 2582, 2583, 2587
 		Length: 16
@@ -53,6 +58,11 @@ rockettower:
 		Frames: 2621, 2624, 2622, 2632, 2625, 2626, 2636, 2629, 2623, 2633, 2627, 2628, 2634, 2630, 2631, 2635
 		Length: 16
 		Offset: -24,16
+	crumble-overlay: DATA.R8
+		Start: 4320
+		Length: 7
+		Offset: -16,16
+		Tick: 200
 	turret: DATA.R8
 		Start: 2637
 		Facings: -32
@@ -99,7 +109,7 @@ conyard.atreides:
 		Start: 4046
 		Offset: -30,-24
 
-repair.atreides:
+repair_pad.atreides:
 	make: DATA.R8
 		Start: 4370
 		Length: 10
@@ -132,7 +142,7 @@ repair.atreides:
 		Start: 4096
 		Offset: -30,-24
 
-repair.harkonnen:
+repair_pad.harkonnen:
 	make: DATA.R8
 		Start: 4370
 		Length: 10
@@ -165,7 +175,7 @@ repair.harkonnen:
 		Start: 4097
 		Offset: -30,-24
 
-repair.ordos:
+repair_pad.ordos:
 	make: DATA.R8
 		Start: 4370
 		Length: 10
@@ -308,7 +318,7 @@ barracks.atreides:
 		Start: 4059
 		Offset: -30,-24
 
-radar.atreides:
+outpost.atreides:
 	idle: DATA.R8
 		Start: 2521
 		Offset: -48,80
@@ -792,7 +802,7 @@ barracks.harkonnen:
 		Start: 4060
 		Offset: -30,-24
 
-radar.harkonnen:
+outpost.harkonnen:
 	idle: DATA.R8
 		Start: 2681
 		Offset: -48,80
@@ -1185,7 +1195,7 @@ barracks.ordos:
 		Start: 4061
 		Offset: -30,-24
 
-radar.ordos:
+outpost.ordos:
 	idle: DATA.R8
 		Start: 2841
 		Offset: -48,80
@@ -1448,7 +1458,7 @@ palace.corrino:
 		Offset: -48,48
 		Tick: 100
 
-starport.corrino:
+starport.smuggler:
 	idle: DATA.R8
 		Start: 2999
 		Offset: -48,48

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -65,7 +65,7 @@ quad:
 		Start: 4018
 		Offset: -30,-24
 
-siegetank:
+siege_tank:
 	idle: DATA.R8
 		Start: 1763
 		Facings: -32
@@ -80,7 +80,7 @@ siegetank:
 		Start: 4026
 		Offset: -30,-24
 
-siegetank.husk:
+siege_tank.husk:
 	idle: DATA.R8
 		Start: 1763
 		Facings: -32
@@ -90,7 +90,7 @@ siegetank.husk:
 		Facings: -32
 		ZOffset: -512
 
-missiletank:
+missile_tank:
 	idle: DATA.R8
 		Start: 1603
 		Facings: -32
@@ -98,13 +98,13 @@ missiletank:
 		Start: 4024
 		Offset: -30,-24
 
-missiletank.husk:
+missile_tank.husk:
 	idle: DATA.R8
 		Start: 1603
 		Facings: -32
 		ZOffset: -512
 
-sonictank:
+sonic_tank:
 	idle: DATA.R8
 		Start: 1827
 		Facings: -32
@@ -112,13 +112,13 @@ sonictank:
 		Start: 4027
 		Offset: -30,-24
 
-sonictank.husk:
+sonic_tank.husk:
 	idle: DATA.R8
 		Start: 1827
 		Facings: -32
 		ZOffset: -512
 
-combata:
+combat_tank_a:
 	idle: DATA.R8
 		Start: 1731
 		Facings: -32
@@ -134,7 +134,7 @@ combata:
 		Start: 4020
 		Offset: -30,-24
 
-combata.husk:
+combat_tank_a.husk:
 	idle: DATA.R8
 		Start: 1731
 		Facings: -32
@@ -144,7 +144,7 @@ combata.husk:
 		Facings: -32
 		ZOffset: -512
 
-combath:
+combat_tank_h:
 	idle: DATA.R8
 		Start: 2051
 		Facings: -32
@@ -160,7 +160,7 @@ combath:
 		Start: 4021
 		Offset: -30,-24
 
-combath.husk:
+combat_tank_h.husk:
 	idle: DATA.R8
 		Start: 2051
 		Facings: -32
@@ -170,7 +170,7 @@ combath.husk:
 		Facings: -32
 		ZOffset: -512
 
-combato:
+combat_tank_o:
 	idle: DATA.R8
 		Start: 2453
 		Facings: -32
@@ -186,7 +186,7 @@ combato:
 		Start: 4022
 		Offset: -30,-24
 
-combato.husk:
+combat_tank_o.husk:
 	idle: DATA.R8
 		Start: 2453
 		Facings: -32
@@ -196,7 +196,7 @@ combato.husk:
 		Facings: -32
 		ZOffset: -512
 
-devast:
+devastator:
 	idle: DATA.R8
 		Start: 2083
 		Facings: -32
@@ -209,7 +209,7 @@ devast:
 		Start: 4028
 		Offset: -30,-24
 
-devast.husk:
+devastator.husk:
 	idle: DATA.R8
 		Start: 2083
 		Facings: -32
@@ -231,7 +231,7 @@ raider:
 		Start: 4017
 		Offset: -30,-24
 
-stealthraider:
+stealth_raider:
 	idle: DATA.R8
 		Start: 2421
 		Facings: -32
@@ -245,7 +245,7 @@ stealthraider:
 		BlendMode: Additive
 	icon: raidersicon.shp # 4282 in 1.06 DATA.R8
 
-deviatortank:
+deviator:
 	idle: DATA.R8
 		Start: 2389
 		Facings: -32
@@ -253,7 +253,7 @@ deviatortank:
 		Start: 4025
 		Offset: -30,-24
 
-deviatortank.husk:
+deviator.husk:
 	idle: DATA.R8
 		Start: 2389
 		Facings: -32

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -309,10 +309,10 @@ Templates:
 		Size: 2,2
 		Category: Sand-Cliff
 		Tiles:
-			0: Rough
-			1: Rough
-			2: Rough
-			3: Rough
+			0: Cliff
+			1: Cliff
+			2: Cliff
+			3: Cliff
 	Template@23:
 		Id: 23
 		Images: BLOXBASE.R8
@@ -320,10 +320,10 @@ Templates:
 		Size: 2,2
 		Category: Sand-Cliff
 		Tiles:
-			0: Rough
-			1: Rough
-			2: Rough
-			3: Rough
+			0: Cliff
+			1: Cliff
+			2: Cliff
+			3: Cliff
 	Template@24:
 		Id: 24
 		Images: BLOXBASE.R8
@@ -364,10 +364,10 @@ Templates:
 		Size: 2,2
 		Category: Sand-Cliff
 		Tiles:
-			0: Rough
-			1: Rough
-			2: Rough
-			3: Rough
+			0: Cliff
+			1: Cliff
+			2: Cliff
+			3: Cliff
 	Template@28:
 		Id: 28
 		Images: BLOXBASE.R8
@@ -375,10 +375,10 @@ Templates:
 		Size: 2,2
 		Category: Rock-Detail
 		Tiles:
-			0: Rough
-			1: Rough
-			2: Rough
-			3: Rough
+			0: Cliff
+			1: Cliff
+			2: Cliff
+			3: Cliff
 	Template@29:
 		Id: 29
 		Images: BLOXBASE.R8

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -1,6 +1,6 @@
 LMG:
-	ReloadDelay: 20
-	Range: 5c0
+	ReloadDelay: 30
+	Range: 2c512
 	Report: MGUN2.WAV
 	Projectile: Bullet
 		Speed: 1c256
@@ -9,74 +9,95 @@ LMG:
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Damage: 15
+		Spread: 48
+		Falloff: 100, 100, 65, 30, 0, 0, 0
+		Damage: 125
 		Versus:
-			Wood: 25
-			Light: 40
-			Heavy: 10
-			Concrete: 20
+			none: 100
+			wall: 10
+			building: 25
+			wood: 75
+			light: 40
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
 Bazooka:
-	ReloadDelay: 50
-	Range: 5c0
-	MinRange: 0c512
+	ReloadDelay: 40
+	Range: 3c0
 	Report: BAZOOK1.WAV
 	ValidTargets: Ground
 	Projectile: Missile
-		Speed: 160
-		Arm: 2
-		Inaccuracy: 96
+		Speed: 320
+		Arm: 0
+		Inaccuracy: 64
 		Image: RPG
-		RateOfTurn: 5
+		RateOfTurn: 1
 		Trail: bazooka_trail
 		TrailPalette: effect75alpha
 		TrailInterval: 1
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Damage: 50
+		Spread: 250
+		Falloff: 100, 95, 70, 50, 25, 5, 0
+		Damage: 300
 		ValidTargets: Ground
 		Versus:
-			None: 10
-			Wood: 75
-			Light: 60
-			Heavy: 90
-			Concrete: 40
+			none: 8
+			wall: 75
+			building: 40
+			wood: 45
+			light: 70
+			heavy: 100
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
 		Explosion: small_explosion
-		ImpactSound: EXPLSML1.WAV
+		ImpactSound: EXPLSML2.WAV
 
-Sniper:
-	ReloadDelay: 100
-	Range: 8c512
+Fremen_S:
+	ReloadDelay: 40
+	Range: 2c512
 	Report: FREMODD1.WAV
 	Projectile: Bullet
-		Speed: 1c896
-		ContrailLength: 6
+		Speed: 1c256
+		ContrailLength: 3
 		TrailInterval: 1
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 32
-		Damage: 60
+		Spread: 48
+		Falloff: 100, 100, 65, 30, 0, 0, 0
+		Damage: 125
 		Versus:
-			None: 100
-			Wood: 0
-			Light: 1
-			Heavy: 0
-			Concrete: 0
+			none: 100
+			wall: 10
+			building: 25
+			wood: 75
+			light: 40
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: small_explosion
+		ImpactSound: EXPLSML2.WAV
 
-Vulcan:
-	ReloadDelay: 30
-	Range: 5c768
+M_LMG:
+	ReloadDelay: 40
+	Range: 2c512
 	Report: VULCAN.AUD
 	ValidTargets: Ground
 	Projectile: Bullet
@@ -86,51 +107,28 @@ Vulcan:
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Damage: 30
+		Spread: 48
+		Falloff: 100, 100, 65, 30, 0, 0, 0
+		Damage: 125
 		ValidTargets: Ground
 		Versus:
-			Wood: 0
-			Light: 60
-			Heavy: 10
-			Concrete: 0
+			none: 100
+			wall: 10
+			building: 25
+			wood: 75
+			light: 40
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
-Slung:
-	ReloadDelay: 60
-	Delay: 5
-	Range: 5c512
-	Report: BAZOOK2.WAV
-	ValidTargets: Ground
-	Projectile: Bullet
-		Speed: 320
-		Blockable: false
-		Shadow: yes
-		Angle: 88
-		Inaccuracy: 384
-		Image: MISSILE
-	Warhead@1Dam: SpreadDamage
-		Spread: 192
-		Damage: 30
-		ValidTargets: Ground
-		Versus:
-			None: 0
-			Wood: 75
-			Light: 40
-			Heavy: 90
-			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Eff: CreateEffect
-		Explosion: small_explosion
-		ImpactSound: EXPLLG5.WAV
-
-HMG:
-	ReloadDelay: 30
-	Range: 5c0
-	Burst: 2
-	BurstDelay: 5
+M_HMG:
+	ReloadDelay: 40
+	Range: 3c512
 	Report: 20MMGUN1.WAV
 	Projectile: Bullet
 		Speed: 1c256
@@ -139,22 +137,93 @@ HMG:
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Damage: 30
+		Spread: 48
+		Falloff: 100, 100, 65, 30, 0, 0, 0
+		Damage: 250
 		Versus:
-			Wood: 15
-			Light: 45
-			Heavy: 20
-			Concrete: 20
+			none: 25
+			wall: 100
+			building: 50
+			wood: 65
+			light: 100
+			heavy: 50
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
+		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: piffs
+
+Fremen_L:
+	ReloadDelay: 40
+	Delay: 5
+	Range: 3c512
+	Report: BAZOOK2.WAV
+	ValidTargets: Ground
+	Projectile: Bullet
+		Speed: 1c256
+		ContrailLength: 3
+		TrailInterval: 1
+		ContrailDelay: 0
+		ContrailUsePlayerColor: true
+	Warhead@1Dam: SpreadDamage
+		Spread: 64
+		Falloff: 100, 100, 65, 30, 0, 0, 0
+		Damage: 250
+		ValidTargets: Ground
+		Versus:
+			none: 25
+			wall: 100
+			building: 50
+			wood: 65
+			light: 100
+			heavy: 50
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: small_explosion
+		ImpactSound: EXPLSML1.WAV
+
+HMG:
+	ReloadDelay: 20
+	Range: 3c0
+#	Burst: 3	# Actually fires 3 times in D2k but deals damage all at once, purely visual/audio effect
+#	BurstDelay: 5
+	Report: 20MMGUN1.WAV
+	Projectile: Bullet
+		Speed: 1c256
+		ContrailLength: 3
+		TrailInterval: 1
+		ContrailDelay: 0
+		ContrailUsePlayerColor: true
+	Warhead@1Dam: SpreadDamage
+		Spread: 48
+		Falloff: 100, 100, 65, 30, 0, 0, 0
+		Damage: 180
+		Versus:
+			none: 100
+			wall: 10
+			building: 25
+			wood: 75
+			light: 40
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
 HMGo:
-	ReloadDelay: 30
+	ReloadDelay: 18
 	Range: 5c0
-	Burst: 2
-	BurstDelay: 5
+#	Burst: 3	# Actually fires 3 times in D2k but deals damage all at once, purely visual/audio effect
+#	BurstDelay: 5
 	Report: 20MMGUN1.WAV
 	Projectile: Bullet
 		Speed: 1c256
@@ -163,44 +232,55 @@ HMGo:
 		ContrailDelay: 0
 		ContrailUsePlayerColor: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Damage: 40
+		Spread: 48
+		Falloff: 100, 100, 65, 30, 0, 0, 0
+		Damage: 180
 		Versus:
-			Wood: 15
-			Light: 45
-			Heavy: 25
-			Concrete: 20
+			none: 100
+			wall: 10
+			building: 25
+			wood: 75
+			light: 40
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: piffs
 
-QuadRockets:
-	ReloadDelay: 40
-	Burst: 2
-	BurstDelay: 25
-	Range: 7c0
+Rocket:
+	ReloadDelay: 30
+	Range: 3c512
 	Report: ROCKET1.WAV
 	ValidTargets: Ground, Air
 	Projectile: Missile
 		Arm: 0
-		Inaccuracy: 96
+		Inaccuracy: 64
 		Image: RPG
-		RateOfTurn: 10
+		RateOfTurn: 0
 		Trail: bazooka_trail2
 		TrailPalette: effect75alpha
 		TrailInterval: 1
-		Speed: 256
+		Speed: 400
 		RangeLimit: 40
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Damage: 25
+		Spread: 250
+		Falloff: 100, 95, 70, 50, 25, 5, 0
+		Damage: 250
 		ValidTargets: Ground, Air
 		Versus:
-			None: 35
-			Wood: 45
-			Light: 100
-			Heavy: 100
-			Concrete: 35
+			none: 25
+			wall: 100
+			building: 50
+			wood: 65
+			light: 100
+			heavy: 50
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -208,24 +288,31 @@ QuadRockets:
 		Explosion: med_explosion
 		ImpactSound: EXPLSML1.WAV
 
-TurretGun:
+110mm_Gun:
 	ReloadDelay: 35
-	Range: 7c0
+	Range: 5c0
 	Report: TURRET1.WAV
 	Projectile: Bullet
-		Speed: 704
+		Speed: 650
 		Blockable: false
 		Shadow: no
-		Inaccuracy: 288
+		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Damage: 55
+		Spread: 160
+		Falloff: 100, 100, 85, 50, 0, 0, 0
+		Damage: 290
 		Versus:
-			None: 50
-			Wood: 75
-			Light: 100
-			Concrete: 65
+			none: 20
+			wall: 50
+			building: 50
+			wood: 60
+			light: 100
+			heavy: 75
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -234,13 +321,11 @@ TurretGun:
 		ImpactSound: EXPLSML4.WAV
 
 TowerMissile:
-	ReloadDelay: 35
-	Range: 7c768
+	ReloadDelay: 60
+	Range: 5c512
 	MinRange: 1c0
 	Report: ROCKET1.WAV
 	ValidTargets: Ground, Air
-	Burst: 2
-	BurstDelay: 15
 	Projectile: Bullet
 		Blockable: false
 		Shadow: yes
@@ -248,150 +333,216 @@ TowerMissile:
 		Image: MISSILE2
 		Trail: large_trail
 		TrailInterval: 1
-		Speed: 298
+		Speed: 320
 		Angle: 90
 	Warhead@1Dam: SpreadDamage
-		Spread: 384
-		Damage: 50
+		Spread: 280
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 480
 		ValidTargets: Ground, Air
 		Versus:
-			None: 50
-			Wood: 45
-			Light: 100
-			Heavy: 50
-			Concrete: 35
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+			none: 15
+			wall: 75
+			building: 60
+			wood: 65
+			light: 90
+			heavy: 100
+			concrete: 100
+			invulnerable: 0
+			cy: 30
+			harvester: 50
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
-		Explosion: small_explosion
+		Explosion: large_explosion
 		ImpactSound: EXPLMD1.WAV
 
-90mm:
+80mm_A:
 	ReloadDelay: 50
-	Range: 5c768
+	Range: 4c0
 	Report: MEDTANK1.WAV
 	Projectile: Bullet
-		Speed: 640
-		Inaccuracy: 384
+		Speed: 512
+		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Damage: 40
+		Spread: 180
+		Falloff: 100, 100, 85, 50, 15, 0, 0
+		Damage: 270
 		Versus:
-			None: 50
-			Wood: 50
-			Light: 100
-			Concrete: 50
+			none: 20
+			wall: 50
+			building: 50
+			wood: 60
+			light: 100
+			heavy: 75
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
 		Explosion: small_napalm
-		ImpactSound: EXPLSML4.WAV
+		ImpactSound: EXPLSML2.WAV
 
-90mma:
-	ReloadDelay: 50
-	Range: 7c0
+80mm_H:
+	ReloadDelay: 55
+	Range: 4c0
 	Report: MEDTANK1.WAV
 	Projectile: Bullet
-		Speed: 704
-		Inaccuracy: 352
+		Speed: 512
+		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Damage: 40
+		Spread: 180
+		Falloff: 100, 100, 85, 50, 15, 0, 0
+		Damage: 270
 		Versus:
-			None: 50
-			Wood: 50
-			Light: 100
-			Concrete: 50
+			none: 20
+			wall: 50
+			building: 50
+			wood: 60
+			light: 100
+			heavy: 75
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
 		Explosion: small_napalm
-		ImpactSound: EXPLSML4.WAV
+		ImpactSound: EXPLSML2.WAV
+
+80mm_O:
+	ReloadDelay: 45
+	Range: 4c0
+	Report: MEDTANK1.WAV
+	Projectile: Bullet
+		Speed: 512
+		Inaccuracy: 380
+		Image: 120mm
+	Warhead@1Dam: SpreadDamage
+		Spread: 180
+		Falloff: 100, 100, 85, 50, 15, 0, 0
+		Damage: 270
+		Versus:
+			none: 20
+			wall: 50
+			building: 50
+			wood: 60
+			light: 100
+			heavy: 75
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+	Warhead@3Eff: CreateEffect
+		Explosion: small_napalm
+		ImpactSound: EXPLSML2.WAV
 
 DevBullet:
-	ReloadDelay: 50
-	Range: 5c0
+	ReloadDelay: 75
+	Range: 4c0
 	Report: TANKHVY1.WAV
 	Projectile: Bullet
 		Speed: 640
 		Image: doubleblastbullet
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Damage: 100
+		Spread: 192
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 650
 		Versus:
-			None: 100
-			Wood: 50
-			Light: 100
-			Heavy: 100
-			Concrete: 80
+			none: 50
+			wall: 100
+			building: 75
+			wood: 60
+			light: 100
+			heavy: 100
+			concrete: 100
+			invulnerable: 0
+			cy: 40
+			harvester: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
 		Explosion: shockwave
+		ImpactSound: EXPLMD1.WAV
 
 227mm:
-	ReloadDelay: 100
-	Range: 10c0
-	MinRange: 4c0
-	Burst: 4
-	BurstDelay: 15
+	ReloadDelay: 115
+	Range: 6c0
 	Report: MISSLE1.WAV
-	ValidTargets: Ground
+	ValidTargets: Ground, Air
 	Projectile: Bullet
 		Speed: 320
 		Blockable: false
 		Shadow: yes
-		Inaccuracy: 1c416
+		Inaccuracy: 96
 		Angle: 90
 		Image: MISSILE2
 		Trail: large_trail
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
-		Spread: 384
-		Damage: 60
-		ValidTargets: Ground
+		Spread: 280
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 600
+		ValidTargets: Ground, Air
 		Versus:
-			None: 20
-			Wood: 50
-			Light: 100
-			Heavy: 50
-			Concrete: 80
+			none: 15
+			wall: 75
+			building: 60
+			wood: 65
+			light: 90
+			heavy: 100
+			concrete: 100
+			invulnerable: 0
+			cy: 30
+			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
-		Explosion: mini_explosion
+		Explosion: large_explosion
 		ImpactSound: EXPLMD3.WAV
 
-NerveGasMissile:
-	ReloadDelay: 120
-	Range: 8c0
-	Burst: 1
+DeviatorMissile:
+	ReloadDelay: 160
+	Range: 5c0
 	Report: MISSLE1.WAV
 	Projectile: Bullet
-		Speed: 384
+		Speed: 320
 		Blockable: false
 		Shadow: yes
 		Angle: 90
-		Inaccuracy: 1c96
+		Inaccuracy: 256
 		Image: MISSILE
 		Trail: deviator_trail
 		TrailPalette: deviatorgas
 		TrailUsePlayerPalette: true
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Damage: 10
+		Spread: 280
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 500
 		Versus:
-			None: 0
-			Wood: 0
-			Concrete: 0
+			none: 20
+			wall: 20
+			building: 20
+			wood: 20
+			light: 20
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 10
+			harvester: 20
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -401,76 +552,67 @@ NerveGasMissile:
 		UsePlayerPalette: true
 		ImpactSound: EXPLSML2.WAV
 	Warhead@4OwnerChange: ChangeOwner
-		Range: 1c0
+		Range: 256
 		Duration: 750
 
 155mm:
-	ReloadDelay: 75
-	Range: 8c0
-	MinRange: 2c0
+	ReloadDelay: 80
+	Range: 5c512
 	Report: MORTAR1.WAV
 	Projectile: Bullet
 		Speed: 256
 		Blockable: false
 		Shadow: yes
 		Angle: 62
-		Inaccuracy: 1c256
+		Inaccuracy: 768
 		ContrailLength: 20
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 384
-		Damage: 100
+		Spread: 280
+		Falloff: 100, 100, 85, 65, 40, 25, 0
+		Damage: 450
 		Versus:
-			None: 100
-			Wood: 80
-			Light: 75
-			Heavy: 50
-			Concrete: 100
+			none: 125
+			wall: 100
+			building: 100
+			wood: 70
+			light: 30
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
-		Explosion: large_explosion
+		Explosion: med_explosion
 		ImpactSound: EXPLLG3.WAV
 
 Sound:
-	ReloadDelay: 100
-	Range: 8c512
+	ReloadDelay: 90
+	Range: 5c0
 	Report: SONIC1.WAV
 	Projectile: LaserZap
-		BeamWidth: 2
-		HitAnim: laserfire
+		BeamWidth: 10
 		BeamDuration: 8
 		UsePlayerColor: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 32
-		Damage: 150
-		Versus:
-			None: 60
-			Wood: 85
-			Light: 80
-			Concrete: 75
-		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
-
-ChainGun:
-	ReloadDelay: 10
-	Range: 5c0
-	MinRange: 1c0
-	Report: 20MMGUN1.WAV
-	Projectile: Bullet
-		Speed: 1c256
-		Blockable: false
-	Warhead@1Dam: SpreadDamage
 		Spread: 96
-		Damage: 20
+		Falloff: 100, 100, 100, 50, 25, 0, 0
+		Damage: 500	#80 D2k but damages through all in path
 		Versus:
-			Wood: 50
-			Light: 60
-			Heavy: 25
-			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@2Eff: CreateEffect
-		Explosion: piffs
+			none: 100
+			wall: 50
+			building: 60
+			wood: 100
+			light: 100
+			heavy: 60
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
+		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 
 Heal:
 	ReloadDelay: 160
@@ -480,60 +622,50 @@ Heal:
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
-		Damage: -50
+		Damage: -200
 		Versus:
-			Wood: 0
-			Light: 0
-			Heavy: 0
-			Concrete: 0
+			none: 100
+			wall: 0
+			building: 0
+			wood: 0
+			light: 0
+			heavy: 0
+			concrete: 0
+			invulnerable: 0
+			cy: 0
+			harvester: 0
 
 WormJaw:
 	ReloadDelay: 10
-	Range: 3c0
+	Range: 1c512
 	Warhead@1Dam: SpreadDamage
-		Spread: 160
-		Damage: 100
+		Spread: 768
+		Falloff: 100, 100, 0, 0, 0, 0, 0
+		Damage: 10000
 		Versus:
-			Wood: 0
-			Concrete: 0
 
-ParaBomb:
-	ReloadDelay: 10
-	Range: 4c512
-	Report:
-	Projectile: GravityBomb
-		Image: BOMBS
-	Warhead@1Dam: SpreadDamage
-		Spread: 192
-		Damage: 50
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Versus:
-			None: 30
-			Wood: 75
-			Light: 75
-			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: Crater
-	Warhead@3Eff: CreateEffect
-		Explosion: self_destruct
-		ImpactSound: EXPLLG3.WAV
-
-Napalm:
-	ReloadDelay: 2
+OrniBomb:
+	ReloadDelay: 3
+	Burst: 5
+	BurstDelay: 3
 	Range: 3c0
 	Projectile: GravityBomb
 		Image: BOMBS
 	Warhead@1Dam: SpreadDamage
-		Spread: 640
-		Damage: 30
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Spread: 276
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 400
 		Versus:
-			None: 20
-			Wood: 100
-			Light: 30
-			Heavy: 20
-			Concrete: 70
+			none: 90
+			wall: 50
+			building: 75
+			wood: 60
+			light: 60
+			heavy: 60
+			concrete: 100
+			invulnerable: 0
+			cy: 25
+			harvester: 60
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -557,15 +689,20 @@ Demolish:
 
 Atomic:
 	Warhead@1Dam: SpreadDamage
-		Spread: 2c0
-		Damage: 180
+		Spread: 320
+		Damage: 500	##225 in vanilla but of course is a cluster bomb instead, so damage spread out
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
-			None: 100
-			Wood: 100
-			Light: 100
-			Heavy: 50
-			Concrete: 50
+			none: 90
+			wall: 50
+			building: 75
+			wood: 60
+			light: 60
+			heavy: 60
+			concrete: 100
+			invulnerable: 0
+			cy: 25
+			harvester: 60
 		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: nuke
@@ -573,15 +710,20 @@ Atomic:
 
 CrateNuke:
 	Warhead@1Dam: SpreadDamage
-		Spread: 1c576
-		Damage: 80
+		Spread: 320
+		Damage: 500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
-			None: 20
-			Wood: 75
-			Light: 25
-			Heavy: 25
-			Concrete: 50
+			none: 90
+			wall: 50
+			building: 75
+			wood: 60
+			light: 60
+			heavy: 60
+			concrete: 100
+			invulnerable: 0
+			cy: 25
+			harvester: 60
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
 	Warhead@2Eff: CreateEffect
@@ -590,125 +732,231 @@ CrateNuke:
 
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Damage: 40
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Spread: 276
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 200
 		Versus:
-			None: 90
-			Wood: 75
-			Light: 60
-			Heavy: 25
+			none: 90
+			wall: 5
+			building: 65
+			wood: 50
+			light: 40
+			heavy: 30
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
-		Explosion: building
+		Explosion: artillery
 		ImpactSound: EXPLSML4.WAV
-
-UnitExplode:
-	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Damage: 50
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Versus:
-			None: 90
-			Wood: 75
-			Light: 60
-			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Eff: CreateEffect
-		Explosion: building
-		ImpactSound: EXPLMD1.WAV
 
 UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Damage: 60
+		Spread: 0
+		Damage: 0
 		Versus:
-			None: 90
-			Wood: 75
-			Light: 60
-			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Eff: CreateEffect
-		Explosion: self_destruct
-		ImpactSound: EXPLHG1.WAV, EXPLLG1.WAV, EXPLMD1.WAV, EXPLSML4.WAV
-
-UnitExplodeTiny:
-	Warhead@1Dam: SpreadDamage
-		Spread: 224
-		Damage: 30
-		Versus:
-			None: 90
-			Wood: 75
-			Light: 60
-			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Eff: CreateEffect
-		Explosion: med_explosion
-		ImpactSound: EXPLMD2.WAV, EXPLSML1.WAV, EXPLSML2.WAV, EXPLSML3.WAV
-
-UnitExplodeScale:
-	Warhead@1Dam: SpreadDamage
-		Spread: 416
-		Damage: 90
-		Versus:
-			None: 90
-			Wood: 75
-			Light: 60
-			Heavy: 25
+			none: 0
+			wall: 0
+			building: 0
+			wood: 0
+			light: 0
+			heavy: 0
+			concrete: 0
+			invulnerable: 0
+			cy: 0
+			harvester: 0
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: building
+		ImpactSound: EXPLHG1.WAV, EXPLLG1.WAV, EXPLMD1.WAV, EXPLSML4.WAV
+
+UnitExplodeMed:
+	Warhead@1Dam: SpreadDamage
+		Spread: 0
+		Damage: 0
+		Versus:
+			none: 0
+			wall: 0
+			building: 0
+			wood: 0
+			light: 0
+			heavy: 0
+			concrete: 0
+			invulnerable: 0
+			cy: 0
+			harvester: 0
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: self_destruct
+		ImpactSound: EXPLMD2.WAV, EXPLSML1.WAV, EXPLSML2.WAV, EXPLSML3.WAV
+
+UnitExplodeLarge:
+	Warhead@1Dam: SpreadDamage
+		Spread: 0
+		Damage: 0
+		Versus:
+			none: 0
+			wall: 0
+			building: 0
+			wood: 0
+			light: 0
+			heavy: 0
+			concrete: 0
+			invulnerable: 0
+			cy: 0
+			harvester: 0
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: artillery
 		ImpactSound: EXPLLG2.WAV, EXPLLG3.WAV, EXPLLG5.WAV
 
-Grenade:
-	ReloadDelay: 60
+grenade:
+	ReloadDelay: 50
 	Range: 4c0
 	Report:
 	Projectile: Bullet
-		Speed: 204
+		Speed: 256
 		Blockable: false
 		Angle: 62
 		Inaccuracy: 416
 		Image: BOMBS
 	Warhead@1Dam: SpreadDamage
-		Spread: 192
-		Damage: 60
+		Spread: 200
+		Falloff: 100, 100, 100, 95, 60, 0, 0
+		Damage: 150
 		Versus:
-			None: 50
-			Wood: 100
-			Light: 25
-			Heavy: 5
+			none: 125
+			wall: 100
+			building: 100
+			wood: 70
+			light: 30
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: EXPLLG5.WAV
+
+GrenDeath:
+	Report:
+	Warhead@1Dam: SpreadDamage
+		Spread: 280
+		Falloff: 100, 100, 100, 95, 60, 0, 0
+		Damage: 150
+		Versus:
+			none: 125
+			wall: 100
+			building: 100
+			wood: 70
+			light: 30
+			heavy: 20
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+	Warhead@3Eff: CreateEffect
+		Explosion: building
+		ImpactSound: S_SMALLEXP1.WAV
+
+SardDeath:
+	Report:
+	Warhead@1Dam: SpreadDamage
+		Spread: 280
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 300
+		Versus:
+			none: 15
+			wall: 75
+			building: 60
+			wood: 65
+			light: 90
+			heavy: 100
+			concrete: 100
+			invulnerable: 0
+			cy: 30
+			harvester: 50
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater, RockCrater
+	Warhead@3Eff: CreateEffect
+		Explosion: small_napalm
+		ImpactSound: EXPLSML2.WAV
 
 Weathering:
 	ReloadDelay: 100
 	Warhead@1Dam: SpreadDamage
-		Damage: 5
+		Damage: 10
 
-Shrapnel:
+Debris:
 	ReloadDelay: 60
 	Range: 4c0
 	Report:
 	Projectile: Bullet
-		Speed: 50, 125
+		Speed: 35, 85
 		Blockable: false
-		Angle: 91, 264
-		Inaccuracy: 416
+		Angle: 30, 90
+		Inaccuracy: 1c0
 		Image: shrapnel
 	Warhead@1Dam: SpreadDamage
-		Spread: 192
-		Damage: 60
+		Spread: 320
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 150
 		Versus:
-			None: 50
-			Wood: 100
-			Light: 25
-			Heavy: 5
+			none: 20
+			wall: 50
+			building: 50
+			wood: 60
+			light: 100
+			heavy: 75
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 50
+		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater
+	Warhead@3Eff: CreateEffect
+		Explosion: small_explosion
+		ImpactSound: EXPLLG5.WAV
+
+Debris2:
+	ReloadDelay: 60
+	Range: 4c0
+	Report:
+	Projectile: Bullet
+		Speed: 35, 85
+		Blockable: false
+		Angle: 30, 90
+		Inaccuracy: 1c0
+		Image: shrapnel
+		Trail: bazooka_trail
+		TrailPalette: effect75alpha
+		TrailInterval: 2
+	Warhead@1Dam: SpreadDamage
+		Spread: 320
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 250
+		Versus:
+			none: 90
+			wall: 5
+			building: 65
+			wood: 50
+			light: 40
+			heavy: 30
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
@@ -716,15 +964,92 @@ Shrapnel:
 		Explosion: med_explosion
 		ImpactSound: EXPLLG5.WAV
 
+Debris3:
+	ReloadDelay: 60
+	Range: 4c0
+	Report:
+	Projectile: Bullet
+		Speed: 35, 85
+		Blockable: false
+		Angle: 30, 90
+		Inaccuracy: 1c0
+		Image: shrapnel
+		Trail: large_trail
+		TrailPalette: effect75alpha
+		TrailInterval: 1
+	Warhead@1Dam: SpreadDamage
+		Spread: 320
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 150
+		Versus:
+			none: 90
+			wall: 5
+			building: 65
+			wood: 50
+			light: 40
+			heavy: 30
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater
+	Warhead@3Eff: CreateEffect
+		Explosion: med_explosion
+		ImpactSound: EXPLLG5.WAV
+
+Debris4:
+	ReloadDelay: 60
+	Range: 4c0
+	Report:
+	Projectile: Bullet
+		Speed: 35, 85
+		Blockable: false
+		Angle: 30, 90
+		Inaccuracy: 1c0
+		Image: shrapnel
+		Trail: large_trail
+		TrailPalette: effect75alpha
+		TrailInterval: 1
+	Warhead@1Dam: SpreadDamage
+		Spread: 320
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 250
+		Versus:
+			none: 90
+			wall: 5
+			building: 65
+			wood: 50
+			light: 40
+			heavy: 30
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+	Warhead@2Smu: LeaveSmudge
+		SmudgeType: SandCrater
+	Warhead@3Eff: CreateEffect
+		Explosion: large_explosion
+		ImpactSound: EXPLLG5.WAV
+
 SpiceExplosion:
 	Warhead@1Dam: SpreadDamage
-		Spread: 9
-		Damage: 10
+		Spread: 480
+		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Damage: 75
 		Versus:
-			None: 90
-			Wood: 75
-			Light: 60
-			Heavy: 25
+			none: 90
+			wall: 5
+			building: 65
+			wood: 50
+			light: 40
+			heavy: 30
+			concrete: 100
+			invulnerable: 0
+			cy: 20
+			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Res: CreateResource
 		AddsResourceType: Spice


### PR DESCRIPTION
-- All costs, prerequisites, CustomBuildTimeValue, health, armour, weapon damage, range, warhead values and sight ranges should be D2k accurate
-- Made aircraft and sandworms visible through fog because it is quite oppressive (especially for carryalls)
-- Removed paradrop power, bounty, veterancy
-- Unit names were partially copied from D2k until they got a bit silly, such as upgrade.high_tech_factory
-- Unit speeds were worked out using "unit speed- (([speed value] / 32) / 10) x 1024 / 25", then multiplied by 2 to be a playable speed
-- ROT is a guess, but should be respectful of unit's ROT relative to each other
-- Warhead spreads are as accurate as I could get them through trial and error
-- Gave husks an explosion on death
-- Buildings are no longer automatically targeted (except turrets)
-- Buildings no longer emit Troopers on sale
-- Worms no longer target infantry, spawn less frequently and always disappear after an attack
-- Fixed a couple of cliff tiles that were set to Sand instead of Cliff
-- All Starport units can now be gotten with no other prerequisites
-- The Upgrades queue is now independent of the Con Yard
    - Gave the Building production trait to the player actor as well, so that it will be the first tab to open after deploying a Con Yard. Added construction_yard as prerequisite to necessary buildings. The side effect is that if you use the debug menu to enable the construction of everything you will be able to build and place structures without a Con Yard.
