### PR TITLE
Cactus improvement

### DIFF
--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -24,6 +24,8 @@ T03:
 
 T04:
 	Inherits: ^Tree
+	Tooltip:
+		Name: Cactus
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2


### PR DESCRIPTION
Solves the highly debated cactus tooltip issue in Red Alert desert maps. They are finally identified as what they are: cacti. :cactus: 
