### PR TITLE
Dehardcode the scale-inaccuracy option.

### DIFF
--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -25,8 +25,9 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("Projectile speed in WDist / tick, two values indicate variable velocity.")]
 		public readonly WDist[] Speed = { new WDist(17) };
 
-		[Desc("Maximum offset at the maximum range.")]
-		public readonly WDist Inaccuracy = WDist.Zero;
+		[Desc("Maximum inaccuracy offset. Can have two values.",
+			"First value determinates a fixed limit, second value scales along with weapon's range.")]
+		public readonly WDist[] Inaccuracy = { WDist.Zero };
 
 		[Desc("Image to display.")]
 		public readonly string Image = null;
@@ -105,10 +106,13 @@ namespace OpenRA.Mods.Common.Effects
 				speed = info.Speed[0];
 
 			target = args.PassiveTarget;
-			if (info.Inaccuracy.Length > 0)
+
+			if (info.Inaccuracy.Length > 1 || info.Inaccuracy[0].Length > 0)
 			{
-				var inaccuracy = OpenRA.Traits.Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-				var maxOffset = inaccuracy * (target - pos).Length / args.Weapon.Range.Length;
+				var inaccuracy = info.Inaccuracy.Length > 1
+					? info.Inaccuracy[1].Length * (target - pos).Length / args.Weapon.Range.Length + info.Inaccuracy[0].Length
+					: info.Inaccuracy[0].Length;
+				var maxOffset = OpenRA.Traits.Util.ApplyPercentageModifiers(inaccuracy, args.InaccuracyModifiers);
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2285,6 +2285,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// update inaccuracy modes
+				if (engineVersion < 20150902)
+				{
+					if (node.Key.StartsWith("Projectile") && node.Value.Value == "Bullet")
+					{
+						var inaccuracynode = node.Value.Nodes.FirstOrDefault(x => x.Key == "Inaccuracy");
+						if (inaccuracynode != null)
+							inaccuracynode.Value.Value = "0, " + inaccuracynode.Value.Value;
+					}
+				}
+
 				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/weapons/largecaliber.yaml
+++ b/mods/cnc/weapons/largecaliber.yaml
@@ -122,7 +122,7 @@ ArtilleryShell:
 		Speed: 204
 		Blockable: false
 		Angle: 56
-		Inaccuracy: 1c256
+		Inaccuracy: 0, 1c256
 		ContrailLength: 30
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -181,7 +181,7 @@ MammothMissiles:
 		Arm: 5
 		Blockable: false
 		Shadow: true
-		Inaccuracy: 853
+		Inaccuracy: 0, 853
 		Angle: 62
 		Image: DRAGON
 		RateOfTurn: 2
@@ -342,7 +342,7 @@ HonestJohn:
 		Arm: 10
 		Blockable: false
 		Shadow: true
-		Inaccuracy: 213
+		Inaccuracy: 0, 213
 		Image: patriot
 		Trail: smokey
 		Speed: 187

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -75,7 +75,7 @@ Grenade:
 		Speed: 140
 		Blockable: false
 		Angle: 62
-		Inaccuracy: 213
+		Inaccuracy: 0, 213
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
 		Spread: 341

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -104,7 +104,7 @@ Slung:
 		Blockable: false
 		Shadow: yes
 		Angle: 88
-		Inaccuracy: 384
+		Inaccuracy: 0, 384
 		Image: MISSILE
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
@@ -210,7 +210,7 @@ TurretGun:
 		Speed: 704
 		Blockable: false
 		Shadow: no
-		Inaccuracy: 288
+		Inaccuracy: 0, 288
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
@@ -238,7 +238,7 @@ TowerMissile:
 	Projectile: Bullet
 		Blockable: false
 		Shadow: yes
-		Inaccuracy: 384
+		Inaccuracy: 0, 384
 		Image: MISSILE2
 		Trail: large_trail
 		TrailInterval: 1
@@ -267,7 +267,7 @@ TowerMissile:
 	Report: MEDTANK1.WAV
 	Projectile: Bullet
 		Speed: 640
-		Inaccuracy: 384
+		Inaccuracy: 0, 384
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
@@ -290,7 +290,7 @@ TowerMissile:
 	Report: MEDTANK1.WAV
 	Projectile: Bullet
 		Speed: 704
-		Inaccuracy: 352
+		Inaccuracy: 0, 352
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
@@ -341,7 +341,7 @@ DevBullet:
 		Speed: 320
 		Blockable: false
 		Shadow: yes
-		Inaccuracy: 1c416
+		Inaccuracy: 0, 1c416
 		Angle: 90
 		Image: MISSILE2
 		Trail: large_trail
@@ -373,7 +373,7 @@ NerveGasMissile:
 		Blockable: false
 		Shadow: yes
 		Angle: 90
-		Inaccuracy: 1c96
+		Inaccuracy: 0, 1c96
 		Image: MISSILE
 		Trail: deviator_trail
 		TrailPalette: deviatorgas
@@ -405,7 +405,7 @@ NerveGasMissile:
 		Blockable: false
 		Shadow: yes
 		Angle: 62
-		Inaccuracy: 1c256
+		Inaccuracy: 0, 1c256
 		ContrailLength: 20
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
@@ -656,7 +656,7 @@ Grenade:
 		Speed: 204
 		Blockable: false
 		Angle: 62
-		Inaccuracy: 416
+		Inaccuracy: 0, 416
 		Image: BOMBS
 	Warhead@1Dam: SpreadDamage
 		Spread: 192

--- a/mods/ra/maps/drop-zone-w/map.yaml
+++ b/mods/ra/maps/drop-zone-w/map.yaml
@@ -275,7 +275,7 @@ Weapons:
 			Speed: 546
 			High: true
 			Angle: 62
-			Inaccuracy: 3c341
+			Inaccuracy: 0, 3c341
 			Image: 120MM
 			ContrailLength: 30
 		Warhead: SpreadDamage
@@ -303,7 +303,7 @@ Weapons:
 			Speed: 409
 			High: true
 			Angle: 62
-			Inaccuracy: 2c938
+			Inaccuracy: 0, 2c938
 			Image: MISSILE
 			Trail: smokey
 			ContrailLength: 30

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -778,7 +778,7 @@ Weapons:
 		Projectile: Bullet
 			Speed: 204
 			High: true
-			Inaccuracy: 1c682
+			Inaccuracy: 0, 1c682
 			Image: 120MM
 			ContrailLength: 50
 		Warhead: SpreadDamage
@@ -839,7 +839,7 @@ Weapons:
 		Projectile: Bullet
 			Speed: 426
 			Image: 120MM
-			Inaccuracy: 2c512
+			Inaccuracy: 0, 2c512
 			Trail: smokey
 			ContrailLength: 2
 		Warhead: SpreadDamage
@@ -893,7 +893,7 @@ Weapons:
 			Image: fb3
 			High: true
 			Angle: 30
-			Inaccuracy: 1c682
+			Inaccuracy: 0, 1c682
 			ContrailLength: 2
 		Warhead: SpreadDamage
 			Spread: 426
@@ -946,7 +946,7 @@ Weapons:
 			Shadow: false
 			Proximity: true
 			Trail: smokey
-			Inaccuracy: 426
+			Inaccuracy: 0, 426
 			Image: V2
 			Angle: 216
 		Warhead: SpreadDamage

--- a/mods/ra/weapons/largecaliber.yaml
+++ b/mods/ra/weapons/largecaliber.yaml
@@ -145,7 +145,7 @@ TurretGun:
 		Speed: 204
 		Blockable: false
 		Angle: 62
-		Inaccuracy: 1c682
+		Inaccuracy: 0, 1c682
 		Image: 120MM
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
@@ -178,7 +178,7 @@ TurretGun:
 		Speed: 204
 		Blockable: false
 		Angle: 62
-		Inaccuracy: 2c938
+		Inaccuracy: 0, 2c938
 		Image: 120MM
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -255,7 +255,7 @@ SubMissile:
 		Speed: 102
 		Blockable: false
 		Angle: 165
-		Inaccuracy: 2c938
+		Inaccuracy: 0, 2c938
 		Image: MISSILE
 		Trail: smokey
 		ContrailLength: 30
@@ -411,7 +411,7 @@ SCUD:
 		Shadow: false
 		Trail: smokey
 		TrailDelay: 5
-		Inaccuracy: 213
+		Inaccuracy: 0, 213
 		Image: V2
 		Angle: 62
 	Warhead@1Dam: SpreadDamage

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -33,7 +33,7 @@ Flamer:
 		Trail: fb4
 		Image: fb3
 		Angle: 62
-		Inaccuracy: 853
+		Inaccuracy: 0, 853
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 8
@@ -85,7 +85,7 @@ Grenade:
 		Speed: 136
 		Blockable: false
 		Angle: 62
-		Inaccuracy: 554
+		Inaccuracy: 0, 554
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
@@ -116,7 +116,7 @@ DepthCharge:
 		Image: BOMB
 		Angle: 62
 		Blockable: false
-		Inaccuracy: 128
+		Inaccuracy: 0, 128
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 80

--- a/mods/ts/weapons/bombsandgrenades.yaml
+++ b/mods/ts/weapons/bombsandgrenades.yaml
@@ -6,7 +6,7 @@ Grenade:
 		Blockable: false
 		Shadow: true
 		Angle: 45
-		Inaccuracy: 384
+		Inaccuracy: 0, 384
 		Image: DISCUS
 	Warhead@1Dam: SpreadDamage
 		Spread: 171

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -100,7 +100,7 @@ Proton:
 		Speed: 341
 		Blockable: false
 		Shadow: true
-		Inaccuracy: 128
+		Inaccuracy: 0, 128
 		Image: TORPEDO
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -5,7 +5,7 @@ FireballLauncher:
 	Projectile: Bullet
 		Speed: 64
 		Image: FLAMEALL
-		Inaccuracy: 384
+		Inaccuracy: 0, 384
 	Burst: 5
 	BurstDelay: 5
 	Warhead@1Dam: SpreadDamage
@@ -29,7 +29,7 @@ FiendShard:
 	Projectile: Bullet
 		Speed: 213
 		Image: CRYSTAL4
-		Inaccuracy: 512
+		Inaccuracy: 0, 512
 		Shadow: true
 		Angle: 60
 		Palette: greentiberium


### PR DESCRIPTION
In current bleed, inaccuracy behaves odd, it's hardcoded to scale with the range at bullets and not on missiles.

I can understand this is benefical in the current mods, but besides not being consistent with itself, there are also cases where the softcoding is preferred.
- In TS and RA2, Westwood inaccuracy never scaled. Although I can't remember if TS used this, the RA2 Flak weaponry was notorious of having around 0c300 inaccuracy even at point-blank range while being a Bullet weapon.
- Modders might try to use high-burst inaccurate bullet-based weapons, which end up impossible to balance - perfect example is @DoGyAUT's Wolverine at http://media.moddb.com/images/mods/1/15/14166/wolverine.gif - resulting either being overpowered in close-range either underpowered at max range.

This PR adds a `ScaleInaccurancyWithRange` option to bullets and missiles, with a default value of `true`, while also brings an upgrade rule for missiles to not change their behaviour.
