### PR TITLE
Make use of DeployToUpgrade

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -142,6 +142,9 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (IsCanceled)
+				return NextActivity;
+
 			if (moveDisablers.Any(d => d.MoveDisabled(self)))
 				return this;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -18,11 +18,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Also returns a default selection size that is calculated automatically from the voxel dimensions.")]
-	public class WithVoxelBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
+	public class WithVoxelBodyInfo : UpgradableTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
 	{
 		public readonly string Sequence = "idle";
 
-		public object Create(ActorInitializer init) { return new WithVoxelBody(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithVoxelBody(init.Self, this); }
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{
@@ -35,11 +35,12 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithVoxelBody : IAutoSelectionSize
+	public class WithVoxelBody : UpgradableTrait<WithVoxelBodyInfo>, IAutoSelectionSize
 	{
 		readonly int2 size;
 
 		public WithVoxelBody(Actor self, WithVoxelBodyInfo info)
+			: base(info)
 		{
 			var body = self.Trait<IBodyOrientation>();
 			var rv = self.Trait<RenderVoxels>();
@@ -47,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 			var voxel = VoxelProvider.GetVoxel(rv.Image, info.Sequence);
 			rv.Add(new VoxelAnimation(voxel, () => WVec.Zero,
 				() => new[] { body.QuantizeOrientation(self, self.Orientation) },
-				() => false, () => 0));
+				() => IsTraitDisabled, () => 0));
 
 			// Selection size
 			var rvi = self.Info.Traits.Get<RenderVoxelsInfo>();

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (isUpgraded)
 			{
 				// Play undeploy animation and after that revoke the upgrades
-				self.QueueActivity(new CallFunc(() =>
+				self.QueueActivity(false, new CallFunc(() =>
 				{
 					if (!string.IsNullOrEmpty(info.UndeploySound))
 						Sound.Play(info.UndeploySound, self.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -40,6 +40,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Facing that the actor must face before deploying. Set to -1 to deploy regardless of facing.")]
 		public readonly int Facing = -1;
 
+		[Desc("Sound to play when deploying.")]
+		public readonly string DeploySound = null;
+
+		[Desc("Sound to play when undeploying.")]
+		public readonly string UndeploySound = null;
+
 		public object Create(ActorInitializer init) { return new DeployToUpgrade(init.Self, this); }
 	}
 
@@ -91,6 +97,9 @@ namespace OpenRA.Mods.Common.Traits
 				// Play undeploy animation and after that revoke the upgrades
 				self.QueueActivity(new CallFunc(() =>
 				{
+					if (!string.IsNullOrEmpty(info.UndeploySound))
+						Sound.Play(info.UndeploySound, self.CenterPosition);
+
 					if (string.IsNullOrEmpty(info.DeployAnimation))
 					{
 						RevokeUpgrades();
@@ -114,9 +123,12 @@ namespace OpenRA.Mods.Common.Traits
 				// Grant the upgrade
 				self.QueueActivity(new CallFunc(GrantUpgrades));
 
-				// Play deploy animation
+				// Play deploy sound and animation
 				self.QueueActivity(new CallFunc(() =>
 				{
+					if (!string.IsNullOrEmpty(info.DeploySound))
+						Sound.Play(info.DeploySound, self.CenterPosition);
+
 					if (string.IsNullOrEmpty(info.DeployAnimation))
 						return;
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/DisableUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DisableUpgrade.cs
@@ -8,13 +8,11 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Desc("Disable the actor when this trait is enabled by an upgrade.")]
 	public class DisableUpgradeInfo : UpgradableTraitInfo
 	{
 		public override object Create(ActorInitializer init) { return new DisableUpgrade(this); }
@@ -25,7 +23,6 @@ namespace OpenRA.Mods.Common.Traits
 		public DisableUpgrade(DisableUpgradeInfo info)
 			: base(info) { }
 
-		// Disable the actor when this trait is enabled.
 		public bool Disabled { get { return !IsTraitDisabled; } }
 		public bool MoveDisabled(Actor self) { return !IsTraitDisabled; }
 	}

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -100,35 +100,54 @@ HARV:
 
 LPST:
 	Inherits: ^VoxelVehicle
+	-AppearsOnRadar:
+	-GainsExperience:
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 100
+		Prerequisites: ~factory, radar
 	Valued:
 		Cost: 950
 	Tooltip:
 		Name: Mobile Sensor Array
 		Description: Can detect cloaked and subterranean\nunits when deployed.\n  Unarmed
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 100
-		Prerequisites: ~factory, radar
 	Health:
 		HP: 600
 	Armor:
-		Type: Light
+		Type: Wood
 	Mobile:
 		Speed: 85
 		ROT: 5
 	RevealsShroud:
-		Range: 10c0
-	Transforms:
-		IntoActor: gadpsa
-		Facing: 159
-		TransformSounds:
-		NoTransformSounds:
-		Voice: Move
+		Range: 7c0
 	RenderSprites:
 		Image: lpst.gdi
 		FactionImages:
 			gdi: lpst.gdi
 			nod: lpst.nod
+	DeployToUpgrade:
+		Upgrades: deployed
+		DeployAnimation: make
+		Facing: 160
+		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
+		DeploySound: place2.aud
+		UndeploySound: clicky1.aud
+	WithVoxelBody:
+		Image: lpst
+		UpgradeTypes: deployed
+		UpgradeMaxEnabledLevel: 0
+	WithSpriteBody@deployed:
+		StartSequence: make
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
+	DisableUpgrade:
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
+	DetectCloaked:
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
+		Range: 18
+	RenderDetectionCircle:
 
 GGHUNT:
 	Inherits: ^Vehicle

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -26,9 +26,23 @@ hvr:
 
 lpst.gdi:
 	icon: sidec01.mix:lpsticon
+	idle: gadpsa
+		Offset: 0, -12
+		ShadowStart: 3
+	make: gadpsamk
+		Offset: 0, -12
+		Length: 36
+		ShadowStart: 36
 
 lpst.nod:
 	icon: sidec02.mix:lpsticon
+	idle: gadpsa
+		Offset: 0, -12
+		ShadowStart: 3
+	make: gadpsamk
+		Offset: 0, -12
+		Length: 36
+		ShadowStart: 36
 
 repair:
 	icon: rboticon


### PR DESCRIPTION
Enhance `DeployToUpgrade` and make use of it for the TS Mobile Sensor Array.

This is split into nice small commits that explain what is happening and why.
While reviewing by commits is not necessary here, it would likely be easier.

First three commits set the scene, next 4 commits add the necessary logic to `DeployToUpgrade`, and finally we have a use-case for finally using this trait.
(_[Awesomer Mobile Sensor Array](http://i.imgur.com/pBfXvvA.gif) is back!!_)

Notes:
- [x] The Mobile Sensor Array's deployed version (along with the deploy animation) has half a cell vertical offset. I noticed this after rebasing, and as shown in the gif, it wasn't an issue several months ago. Also not present in the normal `gadpsa`.
- [x] The original has `RadarInvisible=yes` as shown [here](https://github.com/LipkeGu/TSIniFiles/blob/4cc5adac88b012e27a6a82ba7c93d182451d9d64/rules.ini#L2073), so I've [removed](https://github.com/OpenRA/OpenRA/pull/9124/files#diff-20162b6ff85d8da38c40f5095744bad2R152) the `AppearsOnRadar` trait. But do we actually want this?

When this is all over I will remove the current mobile sensor array in favor of the new one (but keep the original name and tooltip, of course).
After that Tick tanks and Nod Artilleries can be done as well, thanks to @reaperrr's efforts (and mine :P ) toward making the necessary traits upgradable. (Ofc RA2 GIs can also be done now.)

Closes  #8932.
