### PR TITLE
Fixed black dots on Tiberian Sun build palette icons

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -27,6 +27,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public Hotkey Hotkey;
 		public Sprite Sprite;
 		public PaletteReference Palette;
+		public PaletteReference IconClockPalette;
+		public PaletteReference IconDarkenPalette;
 		public float2 Pos;
 		public List<ProductionItem> Queued;
 	}
@@ -45,6 +47,14 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string DisabledTabClick = null;
 		public readonly string TooltipContainer;
 		public readonly string TooltipTemplate = "PRODUCTION_TOOLTIP";
+
+		public readonly string ClockAnimation = "clock";
+		public readonly string ClockSequence = "idle";
+		public readonly string ClockPalette = "chrome";
+
+		public readonly string NotBuildableAnimation = "clock";
+		public readonly string NotBuildableSequence = "idle";
+		public readonly string NotBuildablePalette = "chrome";
 
 		[Translate] public readonly string ReadyText = "";
 		[Translate] public readonly string HoldText = "";
@@ -89,9 +99,9 @@ namespace OpenRA.Mods.Common.Widgets
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
 
-			cantBuild = new Animation(world, "clock");
-			cantBuild.PlayFetchIndex("idle", () => 0);
-			clock = new Animation(world, "clock");
+			cantBuild = new Animation(world, NotBuildableAnimation);
+			cantBuild.PlayFetchIndex(NotBuildableSequence, () => 0);
+			clock = new Animation(world, ClockAnimation);
 		}
 
 		public void ScrollDown()
@@ -322,6 +332,8 @@ namespace OpenRA.Mods.Common.Widgets
 					Hotkey = ks.GetProductionHotkey(DisplayedIconCount),
 					Sprite = icon.Image,
 					Palette = worldRenderer.Palette(bi.IconPalette),
+					IconClockPalette = worldRenderer.Palette(ClockPalette),
+					IconDarkenPalette = worldRenderer.Palette(NotBuildablePalette),
 					Pos = new float2(rect.Location),
 					Queued = CurrentQueue.AllQueued().Where(a => a.Item == item.Name).ToList()
 				};
@@ -367,15 +379,15 @@ namespace OpenRA.Mods.Common.Widgets
 				if (icon.Queued.Count > 0)
 				{
 					var first = icon.Queued[0];
-					clock.PlayFetchIndex("idle",
+					clock.PlayFetchIndex(ClockSequence,
 						() => (first.TotalTime - first.RemainingTime)
 							* (clock.CurrentSequence.Length - 1) / first.TotalTime);
 					clock.Tick();
 
-					WidgetUtils.DrawSHPCentered(clock.Image, icon.Pos + iconOffset, icon.Palette);
+					WidgetUtils.DrawSHPCentered(clock.Image, icon.Pos + iconOffset, icon.IconClockPalette);
 				}
 				else if (!buildableItems.Any(a => a.Name == icon.Name))
-					WidgetUtils.DrawSHPCentered(cantBuild.Image, icon.Pos + iconOffset, icon.Palette);
+					WidgetUtils.DrawSHPCentered(cantBuild.Image, icon.Pos + iconOffset, icon.IconDarkenPalette);
 			}
 
 			// Overlays

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -30,6 +30,10 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string TooltipContainer;
 		public readonly string TooltipTemplate = "SUPPORT_POWER_TOOLTIP";
 
+		public readonly string ClockAnimation = "clock";
+		public readonly string ClockSequence = "idle";
+		public readonly string ClockPalette = "chrome";
+
 		public int IconCount { get; private set; }
 		public event Action<int, int> OnIconCountChanged = (a, b) => { };
 
@@ -57,7 +61,7 @@ namespace OpenRA.Mods.Common.Widgets
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
 
 			icon = new Animation(world, "icon");
-			clock = new Animation(world, "clock");
+			clock = new Animation(world, ClockAnimation);
 		}
 
 		public class SupportPowerIcon
@@ -66,6 +70,7 @@ namespace OpenRA.Mods.Common.Widgets
 			public float2 Pos;
 			public Sprite Sprite;
 			public PaletteReference Palette;
+			public PaletteReference IconClockPalette;
 			public Hotkey Hotkey;
 		}
 
@@ -91,6 +96,7 @@ namespace OpenRA.Mods.Common.Widgets
 					Pos = new float2(rect.Location),
 					Sprite = icon.Image,
 					Palette = worldRenderer.Palette(p.Info.IconPalette),
+					IconClockPalette = worldRenderer.Palette(ClockPalette),
 					Hotkey = ks.GetSupportPowerHotkey(IconCount)
 				};
 
@@ -145,12 +151,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 				// Charge progress
 				var sp = p.Power;
-				clock.PlayFetchIndex("idle",
+				clock.PlayFetchIndex(ClockSequence,
 					() => sp.TotalTime == 0 ? clock.CurrentSequence.Length - 1 : (sp.TotalTime - sp.RemainingTime)
 					* (clock.CurrentSequence.Length - 1) / sp.TotalTime);
 
 				clock.Tick();
-				WidgetUtils.DrawSHPCentered(clock.Image, p.Pos + iconOffset, p.Palette);
+				WidgetUtils.DrawSHPCentered(clock.Image, p.Pos + iconOffset, p.IconClockPalette);
 			}
 
 			// Overlay

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -14,6 +14,7 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
+					ClockPalette: iconclock
 				Container@PALETTE_FOREGROUND:
 					Children:
 						Image@ICON_TEMPLATE:
@@ -254,6 +255,9 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
+					ClockPalette: iconclock
+					NotBuildableAnimation: darken
+					NotBuildablePalette: chromewithshadow
 					IconSize: 64, 48
 					IconMargin: 3, 4
 					IconSpriteOffset: 0, 0

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -24,7 +24,6 @@
 		Name: chrome
 		Filename: cameo.pal
 		AllowModifiers: false
-		ShadowIndex: 242
 	PaletteFromFile@pips:
 		Name: pips
 		Filename: palette.pal

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -24,6 +24,11 @@
 		Name: chrome
 		Filename: cameo.pal
 		AllowModifiers: false
+	PaletteFromFile@chromewithshadow:
+		Name: chromewithshadow
+		Filename: cameo.pal
+		AllowModifiers: false
+		ShadowIndex: 242
 	PaletteFromFile@pips:
 		Name: pips
 		Filename: palette.pal
@@ -36,6 +41,14 @@
 	PaletteFromFile@effect:
 		Name: effect
 		Filename: anim.pal
+	PaletteFromFile@sidebar:
+		Name: sidebar
+		Filename: sidec02.mix:sidebar.pal
+	PaletteFromPaletteWithAlpha@clock:
+		Name: iconclock
+		BasePalette: sidebar
+		Alpha: 0.5
+		AllowModifiers: false
 	PaletteFromFile@colorpicker:
 		Name: colorpicker
 		Filename: unittem.pal

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -67,6 +67,10 @@ clock:
 	idle: gclock2
 		Length: *
 
+darken:
+	idle: gclock2
+		Length: 1
+
 pips:
 	medic: 
 		Start: 6


### PR DESCRIPTION
Extracted from earlier versions of https://github.com/OpenRA/OpenRA/pull/8912.
