### PR TITLE
Implement CalculateOnePercentofMaximum() and implement overflow protection

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProgressBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProgressBarWidget.cs
@@ -18,17 +18,35 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		public int Percentage = 0;
 		public bool Indeterminate = false;
+		public int Maximum = 100;
 
 		public Func<int> GetPercentage;
+		public Func<int> GetMaximumPercentage;
 		public Func<bool> IsIndeterminate;
 
 		// Indeterminant bar properties
 		float offset = 0f;
 		float tickStep = 0.04f;
 
+		public int CalculateOnePercentofMaximum(int maxValue)
+		{
+			if (maxValue > 0)
+				Maximum = maxValue;
+
+			return maxValue / GetMaximumPercentage();
+		}
+
 		public ProgressBarWidget()
 		{
-			GetPercentage = () => Percentage;
+			GetMaximumPercentage = () => Maximum;
+			GetPercentage = () =>
+			{
+				if (Percentage < Maximum)
+					return Percentage;
+				else
+					return GetMaximumPercentage();
+			};
+
 			IsIndeterminate = () => Indeterminate;
 		}
 
@@ -36,6 +54,8 @@ namespace OpenRA.Mods.Common.Widgets
 			: base(other)
 		{
 			Percentage = other.Percentage;
+			Maximum = other.Maximum;
+			GetMaximumPercentage = other.GetMaximumPercentage;
 			GetPercentage = other.GetPercentage;
 			IsIndeterminate = other.IsIndeterminate;
 		}
@@ -44,11 +64,13 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var rb = RenderBounds;
 			var percentage = GetPercentage();
+			var maximum = GetMaximumPercentage();
+
 			WidgetUtils.DrawPanel("progressbar-bg", rb);
 
 			var barRect = wasIndeterminate ?
 				new Rectangle(rb.X + 2 + (int)(0.75 * offset * (rb.Width - 4)), rb.Y + 2, (rb.Width - 4) / 4, rb.Height - 4) :
-				new Rectangle(rb.X + 2, rb.Y + 2, percentage * (rb.Width - 4) / 100, rb.Height - 4);
+				new Rectangle(rb.X + 2, rb.Y + 2, percentage * (rb.Width - 4) / maximum, rb.Height - 4);
 
 			if (barRect.Width > 0)
 				WidgetUtils.DrawPanel("progressbar-thumb", barRect);


### PR DESCRIPTION
This PR make the PercentageCalculation for ProgressBars easier, by implementing a function which does the calculation for 1 Percent of Maximum for us. This functions also sets the Maximum value for the Progressbar. It is not required to use this function the default of maximum is 100. Thats important for things like Webclients (download progress). They doesnt need a calculation for the Steps otherwise the calculation will make problems.
- This PR adds `CalculateOnePercentofMaximum(int maxValue)` to the ProgressbarWidget
  Example of this function how you can use them:

```
var onePercentofmaximum = CalculateOnePercentofMaximum(FilesToCopyList.Count() - 1)
```
- This Pr adds an maximum value to the ProgressBar (thats important for the following) non maybe understandable sense of this PR but i will try to explain what i mean: 
- When you have 12 files (maximum = 12)
  While the function is called, the ProgressBar will get an maximum value like 12 (we have 12 files)
  the ProgressbarSteps for one percent will be calculated. it will return 1 in this case. In addition the Progressbar rectangle which indicated the Progress will be devided into 12 parts to get the size for 1 step
- when you have 100 files as maximum, the ProgressBar is unscaled as like in normal 
- This PR also touches the the scaling area of the ProgressBar this is also the reason why the maximum is and has to be 100 as maximum by default when we doesnt use the Function. In this case the ProgressBar can be used normaly.
- Also this PR adds an Overflow protection which prevents the use of higher percentage values (120%) than the Maximum value is allowing. This overflow can happen when the calculation for one percent of the maximum is wrong.

For example when you specify as maximum 100 and the ProgressBar value is above or equal the maximum the ProgressBarWidget will return the maximum as value.

In real case: The Content installer is using the file count as maximum. BUT but the ProgressBar has not realy an maximum value!, so when we have 4 files, the value for each step without the function and the maximum value is `0,04`. The calculation hast to be done elsewhere in OpenRA outside the ProgressBarWidget class. such like in the Content installer. By using this example as like in the content installer.

```
var onePercent = 100 / files.count(); 
```

Now we can do a wrong calculation by recalculating the value for one percent again a few lines later in another `foreach`and we ends with values like while we have no maximum value and overflow protection.

For example:
RA ends at 110%
TS is instant 100%
CNC ends at 130%

or could the value can have 200% while we expect 100%

In this case when we have a wrong step calculation which is happening in the above named example. We will have in some cases only an half filled ProgressBar and have to cheat by doing a mode swicht to marquee.... or have an ProgressBar value visualisation which is larger than our Desktop resolution, like this:

Oversized:

```
[=========140%============]======================
```

or Undersized:

```
[=======100%                            ]

```

But in this case the ProgressBar is oversized. and can be produce bad behavor. The result of this wrong scaling happens here: https://github.com/OpenRA/OpenRA/pull/9136/files#diff-310eea0d75516e1a7e005d1919405287L51 (The rectangle is alsways devided by 100).

We have 4 files but dividing by 100 (which is hardcoded) so we will only can have 20 percent steps of 100 percent. While the Progressbar shows 2 as value can recalculate 1 percent of 100 files In another Line elswhere in the content installer and going to continue filling the progressBar. The result is 104% and so on.

Part to reviewers:
- Test all ProgressBars without this function. That Changes should not produce bugs any bad behavor is a bug!

Because this function is a addition to and should (but not have to) be merged before #9093 
