### PR TITLE
Added a total resource cash counter to the map editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -38,6 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly Dictionary<PaletteReference, TerrainSpriteLayer> spriteLayers = new Dictionary<PaletteReference, TerrainSpriteLayer>();
 
+		public int NetWorth { get; private set; }
+
 		public EditorResourceLayer(Actor self)
 		{
 			if (self.World.Type != WorldType.Editor)
@@ -88,6 +90,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var uv = cell.ToMPos(Map);
 			var tile = Map.MapResources.Value[uv];
+
+			var t = Tiles[cell];
+			if (t.Density > 0)
+				NetWorth -= t.Density * t.Type.Info.ValuePerUnit;
 
 			ResourceType type;
 			if (Resources.TryGetValue(tile.Type, out type))
@@ -149,8 +155,12 @@ namespace OpenRA.Mods.Common.Traits
 				return t;
 			}
 
+			NetWorth -= t.Density * type.Info.ValuePerUnit;
+
 			// Set density based on the number of neighboring resources
 			t.Density = ResourceDensityAt(c);
+
+			NetWorth += t.Density * type.Info.ValuePerUnit;
 
 			var sprites = type.Variants[t.Variant];
 			var frame = int2.Lerp(0, sprites.Length - 1, t.Density - 1, type.Info.MaxDensity);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
@@ -65,6 +66,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var coordinateLabel = widget.GetOrNull<LabelWidget>("COORDINATE_LABEL");
 			if (coordinateLabel != null)
 				coordinateLabel.GetText = () => worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos).ToString();
+
+			var cashLabel = widget.GetOrNull<LabelWidget>("CASH_LABEL");
+			if (cashLabel != null)
+			{
+				var reslayer = worldRenderer.World.WorldActor.TraitsImplementing<EditorResourceLayer>().FirstOrDefault();
+				if (reslayer != null)
+					cashLabel.GetText = () => "$ {0}".F(reslayer.NetWorth);
+			}
 		}
 	}
 }

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -393,3 +393,10 @@ Container@EDITOR_WORLD_ROOT:
 			Align: Left
 			Font: Bold
 			Contrast: true
+		Label@CASH_LABEL:
+			X: 95
+			Width: 50
+			Height: 25
+			Align: Left
+			Font: Bold
+			Contrast: true

--- a/mods/ra/chrome/editor.yaml
+++ b/mods/ra/chrome/editor.yaml
@@ -380,3 +380,10 @@ Container@EDITOR_WORLD_ROOT:
 			Align: Left
 			Font: Bold
 			Contrast: true
+		Label@CASH_LABEL:
+			X: 570
+			Width: 50
+			Height: 25
+			Align: Left
+			Font: Bold
+			Contrast: true


### PR DESCRIPTION
We had this in the legacy WinForms application https://github.com/OpenRA/OpenRA/pull/2894. This together with https://github.com/OpenRA/OpenRA/pull/9089 will give it feature parity with what we already had displayed in the status bar.
