### PR TITLE
Improve pathfinder performance

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -767,6 +767,9 @@ namespace OpenRA
 
 		bool ContainsAllProjectedCellsCovering(MPos uv)
 		{
+			if (MaximumTerrainHeight == 0)
+				return Contains((PPos)uv);
+
 			foreach (var puv in ProjectedCellsCovering(uv))
 				if (!Contains(puv))
 					return false;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -292,6 +292,8 @@ namespace OpenRA
 			{
 				var ret = new CellLayer<TerrainTile>(tileShape, size);
 				ret.Clear(tileRef);
+				if (MaximumTerrainHeight > 0)
+					ret.CellEntryChanged += UpdateProjection;
 				return ret;
 			});
 
@@ -299,6 +301,8 @@ namespace OpenRA
 			{
 				var ret = new CellLayer<byte>(tileShape, size);
 				ret.Clear(0);
+				if (MaximumTerrainHeight > 0)
+					ret.CellEntryChanged += UpdateProjection;
 				return ret;
 			});
 

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -74,7 +74,7 @@ namespace OpenRA
 		public readonly bool PickAny;
 		public readonly string Category;
 
-		TerrainTileInfo[] tileInfo;
+		readonly TerrainTileInfo[] tileInfo;
 
 		public TerrainTemplateInfo(ushort id, string[] images, int2 size, byte[] tiles)
 		{
@@ -177,7 +177,7 @@ namespace OpenRA
 		public readonly bool IgnoreTileSpriteOffsets;
 
 		[FieldLoader.Ignore]
-		public readonly Dictionary<ushort, TerrainTemplateInfo> Templates = new Dictionary<ushort, TerrainTemplateInfo>();
+		public readonly IReadOnlyDictionary<ushort, TerrainTemplateInfo> Templates;
 
 		[FieldLoader.Ignore]
 		public readonly TerrainTypeInfo[] TerrainInfo;
@@ -217,7 +217,7 @@ namespace OpenRA
 
 			// Templates
 			Templates = yaml["Templates"].ToDictionary().Values
-				.Select(y => new TerrainTemplateInfo(this, y)).ToDictionary(t => t.Id);
+				.Select(y => new TerrainTemplateInfo(this, y)).ToDictionary(t => t.Id).AsReadOnly();
 		}
 
 		public TileSet(string name, string id, string palette, TerrainTypeInfo[] terrainInfo)

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -188,20 +188,22 @@ namespace OpenRA.Traits
 
 		public IEnumerable<Actor> GetUnitsAt(CPos a)
 		{
-			if (!influence.Contains(a))
+			var uv = a.ToMPos(map);
+			if (!influence.Contains(uv))
 				yield break;
 
-			for (var i = influence[a]; i != null; i = i.Next)
+			for (var i = influence[uv]; i != null; i = i.Next)
 				if (!i.Actor.Disposed)
 					yield return i.Actor;
 		}
 
 		public IEnumerable<Actor> GetUnitsAt(CPos a, SubCell sub)
 		{
-			if (!influence.Contains(a))
+			var uv = a.ToMPos(map);
+			if (!influence.Contains(uv))
 				yield break;
 
-			for (var i = influence[a]; i != null; i = i.Next)
+			for (var i = influence[uv]; i != null; i = i.Next)
 				if (!i.Actor.Disposed && (i.SubCell == sub || i.SubCell == SubCell.FullCell))
 					yield return i.Actor;
 		}
@@ -243,20 +245,22 @@ namespace OpenRA.Traits
 		// NOTE: always includes transients with influence
 		public bool AnyUnitsAt(CPos a)
 		{
-			if (!influence.Contains(a))
+			var uv = a.ToMPos(map);
+			if (!influence.Contains(uv))
 				return false;
 
-			return influence[a] != null;
+			return influence[uv] != null;
 		}
 
 		// NOTE: can not check aircraft
 		public bool AnyUnitsAt(CPos a, SubCell sub, bool checkTransient = true)
 		{
-			if (!influence.Contains(a))
+			var uv = a.ToMPos(map);
+			if (!influence.Contains(uv))
 				return false;
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
-			for (var i = influence[a]; i != null; i = i.Next)
+			for (var i = influence[uv]; i != null; i = i.Next)
 			{
 				if (always || i.SubCell == sub || i.SubCell == SubCell.FullCell)
 				{
@@ -275,11 +279,12 @@ namespace OpenRA.Traits
 		// NOTE: can not check aircraft
 		public bool AnyUnitsAt(CPos a, SubCell sub, Func<Actor, bool> withCondition)
 		{
-			if (!influence.Contains(a))
+			var uv = a.ToMPos(map);
+			if (!influence.Contains(uv))
 				return false;
 
 			var always = sub == SubCell.FullCell || sub == SubCell.Any;
-			for (var i = influence[a]; i != null; i = i.Next)
+			for (var i = influence[uv]; i != null; i = i.Next)
 				if ((always || i.SubCell == sub || i.SubCell == SubCell.FullCell) && !i.Actor.Disposed && withCondition(i.Actor))
 					return true;
 
@@ -290,10 +295,11 @@ namespace OpenRA.Traits
 		{
 			foreach (var c in ios.OccupiedCells())
 			{
-				if (!influence.Contains(c.First))
+				var uv = c.First.ToMPos(map);
+				if (!influence.Contains(uv))
 					continue;
 
-				influence[c.First] = new InfluenceNode { Next = influence[c.First], SubCell = c.Second, Actor = self };
+				influence[uv] = new InfluenceNode { Next = influence[uv], SubCell = c.Second, Actor = self };
 
 				List<CellTrigger> triggers;
 				if (cellTriggerInfluence.TryGetValue(c.First, out triggers))
@@ -306,12 +312,13 @@ namespace OpenRA.Traits
 		{
 			foreach (var c in ios.OccupiedCells())
 			{
-				if (!influence.Contains(c.First))
+				var uv = c.First.ToMPos(map);
+				if (!influence.Contains(uv))
 					continue;
 
-				var temp = influence[c.First];
+				var temp = influence[uv];
 				RemoveInfluenceInner(ref temp, self);
-				influence[c.First] = temp;
+				influence[uv] = temp;
 
 				List<CellTrigger> triggers;
 				if (cellTriggerInfluence.TryGetValue(c.First, out triggers))

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -47,13 +47,11 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 	public struct GraphConnection
 	{
-		public readonly CPos Source;
 		public readonly CPos Destination;
 		public readonly int Cost;
 
-		public GraphConnection(CPos source, CPos destination, int cost)
+		public GraphConnection(CPos destination, int cost)
 		{
-			Source = source;
 			Destination = destination;
 			Cost = cost;
 		}
@@ -117,7 +115,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				var neighbor = position + directions[i];
 				var movementCost = GetCostToNode(neighbor, directions[i]);
 				if (movementCost != Constants.InvalidNode)
-					validNeighbors.AddLast(new GraphConnection(position, neighbor, movementCost));
+					validNeighbors.AddLast(new GraphConnection(neighbor, movementCost));
 			}
 
 			return validNeighbors;

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -71,6 +71,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		readonly CellConditions checkConditions;
 		readonly MobileInfo mobileInfo;
+		readonly MobileInfo.WorldMovementInfo worldMovementInfo;
 		CellLayer<CellInfo> cellInfo;
 
 		public PathGraph(CellLayer<CellInfo> cellInfo, MobileInfo mobileInfo, Actor actor, World world, bool checkForBlocked)
@@ -78,6 +79,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			this.cellInfo = cellInfo;
 			World = world;
 			this.mobileInfo = mobileInfo;
+			worldMovementInfo = mobileInfo.GetWorldMovementInfo(world);
 			Actor = actor;
 			LaneBias = 1;
 			checkConditions = checkForBlocked ? CellConditions.TransientActors : CellConditions.None;
@@ -123,17 +125,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		int GetCostToNode(CPos destNode, CVec direction)
 		{
-			int movementCost;
-			if (mobileInfo.CanEnterCell(
-				World,
-				Actor,
-				destNode,
-				out movementCost,
-				IgnoredActor,
-				checkConditions) && !(CustomBlock != null && CustomBlock(destNode)))
-			{
+			var movementCost = mobileInfo.MovementCostToEnterCell(worldMovementInfo, Actor, destNode, IgnoredActor, checkConditions);
+			if (movementCost != int.MaxValue && !(CustomBlock != null && CustomBlock(destNode)))
 				return CalculateCellCost(destNode, direction, movementCost);
-			}
 
 			return Constants.InvalidNode;
 		}

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// <summary>
 		/// Gets all the Connections for a given node in the graph
 		/// </summary>
-		IEnumerable<GraphConnection> GetConnections(CPos position);
+		List<GraphConnection> GetConnections(CPos position);
 
 		/// <summary>
 		/// Retrieves an object given a node in the graph
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			new[] { new CVec(1, -1), new CVec(1, 0), new CVec(-1, 1), new CVec(0, 1), new CVec(1, 1) },
 		};
 
-		public IEnumerable<GraphConnection> GetConnections(CPos position)
+		public List<GraphConnection> GetConnections(CPos position)
 		{
 			var previousPos = cellInfo[position].PreviousPos;
 
@@ -108,14 +108,14 @@ namespace OpenRA.Mods.Common.Pathfinder
 			var dy = position.Y - previousPos.Y;
 			var index = dy * 3 + dx + 4;
 
-			var validNeighbors = new LinkedList<GraphConnection>();
 			var directions = DirectedNeighbors[index];
+			var validNeighbors = new List<GraphConnection>(directions.Length);
 			for (var i = 0; i < directions.Length; i++)
 			{
 				var neighbor = position + directions[i];
 				var movementCost = GetCostToNode(neighbor, directions[i]);
 				if (movementCost != Constants.InvalidNode)
-					validNeighbors.AddLast(new GraphConnection(neighbor, movementCost));
+					validNeighbors.Add(new GraphConnection(neighbor, movementCost));
 			}
 
 			return validNeighbors;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -242,11 +242,17 @@ namespace OpenRA.Mods.Common.Traits
 
 			// If the other actor in our way cannot be crushed, we are blocked.
 			var crushables = otherActor.TraitsImplementing<ICrushable>();
-			if (!crushables.Any())
-				return true;
+			var lacksCrushability = true;
 			foreach (var crushable in crushables)
+			{
+				lacksCrushability = false;
 				if (!crushable.CrushableBy(Crushes, self.Owner))
 					return true;
+			}
+
+			// If there are no crushable traits at all, this means the other actor cannot be crushed - we are blocked.
+			if (lacksCrushability)
+				return true;
 
 			// We are not blocked by the other actor.
 			return false;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -310,7 +310,7 @@ namespace OpenRA.Mods.Common.Traits
 		internal int TicksBeforePathing = 0;
 
 		readonly Actor self;
-		readonly Lazy<ISpeedModifier[]> speedModifiers;
+		readonly Lazy<IEnumerable<int>> speedModifiers;
 		public readonly MobileInfo Info;
 		public bool IsMoving { get; set; }
 
@@ -351,7 +351,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			Info = info;
 
-			speedModifiers = Exts.Lazy(() => self.TraitsImplementing<ISpeedModifier>().ToArray());
+			speedModifiers = Exts.Lazy(() => self.TraitsImplementing<ISpeedModifier>().ToArray().Select(x => x.GetSpeedModifier()));
 
 			ToSubCell = FromSubCell = info.SharesCell ? init.World.Map.DefaultSubCell : SubCell.FullCell;
 			if (init.Contains<SubCellInit>())
@@ -608,7 +608,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (terrainSpeed == 0)
 				return 0;
 
-			var modifiers = speedModifiers.Value.Select(x => x.GetSpeedModifier()).Append(terrainSpeed);
+			var modifiers = speedModifiers.Value.Append(terrainSpeed);
 
 			return Util.ApplyPercentageModifiers(Info.Speed, modifiers);
 		}


### PR DESCRIPTION
A number of commits intended to make the pathfinder faster by reducing small inefficiencies in the parts of the engine it relies on.

This PR should not affect the pathfinder output at all. For testing I recommend recording a replay on bleed and replaying it with this PR - there should be no desyncs unless I've messed up.

Overall, these changes save ~21% in pathfinding time.
