### PR TITLE
Make lower-level Sound not require the server state directly

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -275,7 +275,7 @@ namespace OpenRA
 			Settings.Game.Mod = mod;
 
 			Sound.StopVideo();
-			Sound.Initialize(Settings.Sound, Settings.Server);
+			Sound.Initialize(Settings.Server.Dedicated ? "Null" : Settings.Sound.Engine);
 
 			ModData = new ModData(mod, !Settings.Server.Dedicated);
 			ModData.InitializeLoaders();

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -66,9 +66,8 @@ namespace OpenRA
 			return soundEngine.AddSoundSourceFromMemory(rawData, channels, sampleBits, sampleRate);
 		}
 
-		public static void Initialize(SoundSettings soundSettings, ServerSettings serverSettings)
+		public static void Initialize(string engineName)
 		{
-			var engineName = serverSettings.Dedicated ? "Null" : soundSettings.Engine;
 			var enginePath = Platform.ResolvePath(".", "OpenRA.Platforms." + engineName + ".dll");
 			soundEngine = CreateDevice(Assembly.LoadFile(enginePath));
 


### PR DESCRIPTION
As pointed out in https://github.com/OpenRA/OpenRA/pull/8632#discussion_r37711021
