### PR TITLE
Renderer: Do not use (Pseudo-)Fullscreen when Debugger is attached.

### DIFF
--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Reflection;
@@ -51,8 +52,8 @@ namespace OpenRA
 
 			var rendererName = serverSettings.Dedicated ? "Null" : graphicSettings.Renderer;
 			var rendererPath = Platform.ResolvePath(".", "OpenRA.Platforms." + rendererName + ".dll");
-
-			Device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, graphicSettings.Mode);
+			var winMode = Debugger.IsAttached ? WindowMode.Windowed : graphicSettings.Mode;
+			Device = CreateDevice(Assembly.LoadFile(rendererPath), resolution.Width, resolution.Height, winMode);
 
 			if (!serverSettings.Dedicated)
 			{


### PR DESCRIPTION
This Pr implements a check which forces the Renderer to run OpenRA in Window Mode when a Debugger is attached. This elimimnates also the problem that you cant switch back to the IDE when the IDE freezes the Process ( in such cases Windows user has to log out and re login.

The actions are the following:
- User is runnig OpenRA with attached Debugger (Visual studio, etc) = OpenRA is running in a Window
- User runs OpenRA without Debugger = The selected mode from settings will be used.
