### PR TITLE
Add PlugInit

### DIFF
--- a/mods/ts/maps/gdi4a/map.yaml
+++ b/mods/ts/maps/gdi4a/map.yaml
@@ -94,6 +94,8 @@ Actors:
 		Owner: Neutral
 		Health: 100
 		Facing: 37
+		Plugs:
+			0,0: tower.vulcan
 	Actor12: gapile
 		Location: 79,34
 		Owner: Neutral
@@ -114,6 +116,8 @@ Actors:
 		Owner: Neutral
 		Health: 100
 		Facing: 179
+		Plugs:
+			0,0: tower.vulcan
 	Actor16: garadr
 		Location: 70,30
 		Owner: Neutral
@@ -129,11 +133,15 @@ Actors:
 		Owner: Neutral
 		Health: 100
 		Facing: 24
+		Plugs:
+			0,0: tower.vulcan
 	Actor19: gactwr
 		Location: 98,54
 		Owner: Neutral
 		Health: 100
 		Facing: 219
+		Plugs:
+			0,0: tower.vulcan
 	Actor20: ammocrat
 		Location: 69,34
 		Owner: Neutral


### PR DESCRIPTION
Add `PlugInit` for use with map-placed structures in TS (or whatever custom mod decides to use plugs). There have been a couple of requests by people who wanted to have plugs on their maps.
I also figured I should use this to make the towers on the new TS shellmap look better.
