### PR TITLE
Update MaxMind.GeoIP2 version to 2.3.1

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -38,7 +38,7 @@ if (!(Test-Path "ICSharpCode.SharpZipLib.dll"))
 if (!(Test-Path "MaxMind.GeoIP2.dll"))
 {
 	echo "Fetching MaxMind.GeoIP2 from NuGet."
-	./nuget.exe install MaxMind.GeoIP2 -Version 2.1.0 -ExcludeVersion
+	./nuget.exe install MaxMind.GeoIP2 -Version 2.3.1 -ExcludeVersion
 	cp MaxMind.Db/lib/net40/MaxMind.Db.* .
 	rmdir MaxMind.Db -Recurse
 	cp MaxMind.GeoIP2/lib/net40/MaxMind.GeoIP2* .

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -49,10 +49,10 @@ fi
 
 if [ ! -f MaxMind.GeoIP2.dll ]; then
 	echo "Fetching MaxMind.GeoIP2 from NuGet"
-	get MaxMind.Db 1.0.0.0
-	get Newtonsoft.Json 6.0.5
-	get RestSharp 105.0.1
-	get MaxMind.GeoIP2 2.1.0
+	get Newtonsoft.Json 7.0.1
+	get MaxMind.Db 1.1.0.0
+	get RestSharp 105.2.3
+	get MaxMind.GeoIP2 2.3.1
 	cp ./MaxMind.Db/lib/net40/MaxMind.Db.* .
 	rm -rf MaxMind.Db
 	cp ./MaxMind.GeoIP2/lib/net40/MaxMind.GeoIP2* .


### PR DESCRIPTION
Fixes an "Operation did not complete successfully because the file contains a virus." message when making dependencies.
