### PR TITLE
Fix radar not showing frozen actors

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -39,7 +39,11 @@ namespace OpenRA.Traits
 		public int HP;
 		public DamageState DamageState;
 
-		public bool Visible = true;
+		/// <summary>
+		/// Is the frozen preview of the real actor currently visible?
+		/// That means the real actor is currently under fog.
+		/// </summary>
+		public bool IsVisible = true;
 		public bool NeedRenderables;
 		public bool IsRendering { get; private set; }
 
@@ -85,22 +89,22 @@ namespace OpenRA.Traits
 
 		void UpdateVisibility()
 		{
-			var wasVisible = Visible;
+			var wasVisible = IsVisible;
 			var isVisibleTest = shroud.IsVisibleTest;
 
 			// We are doing the following LINQ manually for performance since this is a hot path.
-			// Visible = !Footprint.Any(isVisibleTest);
-			Visible = true;
+			// IsVisible = !Footprint.Any(isVisibleTest);
+			IsVisible = true;
 			foreach (var uv in Footprint)
 			{
 				if (isVisibleTest(uv))
 				{
-					Visible = false;
+					IsVisible = false;
 					break;
 				}
 			}
 
-			if (Visible && !wasVisible)
+			if (IsVisible && !wasVisible)
 				NeedRenderables = true;
 		}
 
@@ -188,7 +192,7 @@ namespace OpenRA.Traits
 
 				if (frozenActor.ShouldBeRemoved(owner))
 					remove.Add(kvp.Key);
-				else if (frozenActor.Visible)
+				else if (frozenActor.IsVisible)
 					VisibilityHash += hash;
 				else if (frozenActor.Actor == null)
 					remove.Add(kvp.Key);
@@ -204,7 +208,7 @@ namespace OpenRA.Traits
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
 			return world.ScreenMap.FrozenActorsInBox(owner, wr.Viewport.TopLeft, wr.Viewport.BottomRight)
-				.Where(f => f.Visible)
+				.Where(f => f.IsVisible)
 				.SelectMany(ff => ff.Render(wr));
 		}
 

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -43,6 +42,11 @@ namespace OpenRA.Traits
 		public bool NeedRenderables;
 		public bool IsRendering { get; private set; }
 
+		public uint ID { get { return actor.ActorID; } }
+		public bool IsValid { get { return Owner != null; } }
+		public ActorInfo Info { get { return actor.Info; } }
+		public Actor Actor { get { return !actor.IsDead ? actor : null; } }
+
 		public FrozenActor(Actor self, PPos[] footprint, Shroud shroud)
 		{
 			actor = self;
@@ -50,20 +54,13 @@ namespace OpenRA.Traits
 			removeFrozenActors = self.TraitsImplementing<IRemoveFrozenActor>().ToArray();
 
 			// Consider all cells inside the map area (ignoring the current map bounds)
-			Footprint = footprint
-				.Where(m => shroud.Contains(m))
-				.ToArray();
+			Footprint = footprint.Where(shroud.Contains).ToArray();
 
 			CenterPosition = self.CenterPosition;
 			Bounds = self.Bounds;
 
 			UpdateVisibility();
 		}
-
-		public uint ID { get { return actor.ActorID; } }
-		public bool IsValid { get { return Owner != null; } }
-		public ActorInfo Info { get { return actor.Info; } }
-		public Actor Actor { get { return !actor.IsDead ? actor : null; } }
 
 		static readonly IRenderable[] NoRenderables = new IRenderable[0];
 

--- a/OpenRA.Mods.Common/Traits/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnRadar.cs
@@ -23,21 +23,29 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new AppearsOnRadar(this); }
 	}
 
-	public class AppearsOnRadar : IRadarSignature
+	public class AppearsOnRadar : IRadarSignature, INotifyCreated
 	{
-		AppearsOnRadarInfo info;
+		readonly AppearsOnRadarInfo info;
+		IRadarColorModifier modifier;
 
-		public AppearsOnRadar(AppearsOnRadarInfo info) { this.info = info; }
+		public AppearsOnRadar(AppearsOnRadarInfo info)
+		{
+			this.info = info;
+		}
+
+		public void Created(Actor self)
+		{
+			modifier = self.TraitsImplementing<IRadarColorModifier>().FirstOrDefault();
+		}
 
 		public IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self)
 		{
-			var mod = self.TraitsImplementing<IRadarColorModifier>().FirstOrDefault();
-			var color = mod != null ? mod.RadarColorOverride(self) : self.Owner.Color.RGB;
+			var color = modifier != null ? modifier.RadarColorOverride(self) : self.Owner.Color.RGB;
 
 			if (info.UseLocation)
 				return new[] { Pair.New(self.Location, color) };
-			else
-				return self.OccupiesSpace.OccupiedCells().Select(c => Pair.New(c.First, color));
+
+			return self.OccupiesSpace.OccupiedCells().Select(c => Pair.New(c.First, color));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 				else
 				{
 					frozenActor = frozen[player];
-					isVisible = visible[player] = !frozenActor.Visible;
+					isVisible = visible[player] = !frozenActor.IsVisible;
 				}
 
 				if (isVisible)

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
 	}
 
-	public class FrozenUnderFog : IRenderModifier, IDefaultVisibility, ITick, ISync
+	public class FrozenUnderFog : IRenderModifier, IDefaultVisibility, ITick, ISync, INotifyOwnerChanged
 	{
 		[Sync] public int VisibilityHash;
 
@@ -39,6 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Lazy<Health> health;
 
 		readonly Dictionary<Player, bool> visible;
+		readonly Dictionary<Player, bool> ownerHasChanged;
 		readonly Dictionary<Player, FrozenActor> frozen;
 
 		bool initialized;
@@ -58,6 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			frozen = new Dictionary<Player, FrozenActor>();
 			visible = init.World.Players.ToDictionary(p => p, p => false);
+			ownerHasChanged = init.World.Players.ToDictionary(p => p, p => false);
 		}
 
 		bool IsVisibleInner(Actor self, Player byPlayer)
@@ -121,6 +123,13 @@ namespace OpenRA.Mods.Common.Traits
 					frozenActor.TooltipInfo = tooltip.Value.TooltipInfo;
 					frozenActor.TooltipOwner = tooltip.Value.Owner;
 				}
+
+				if (ownerHasChanged[player])
+				{
+					var mod = self.TraitsImplementing<IRadarColorModifier>().FirstOrDefault();
+					frozenActor.RadarColor = mod != null ? mod.RadarColorOverride(self) : self.Owner.Color.RGB;
+					ownerHasChanged[player] = false;
+				}
 			}
 
 			initialized = true;
@@ -129,6 +138,12 @@ namespace OpenRA.Mods.Common.Traits
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
 			return IsVisible(self, self.World.RenderPlayer) || (initialized && frozen[self.World.RenderPlayer].IsRendering) ? r : SpriteRenderable.None;
+		}
+
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			foreach (var player in self.World.Players)
+				ownerHasChanged[player] = true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -87,22 +87,23 @@ namespace OpenRA.Mods.Common.Traits
 			VisibilityHash = 0;
 			foreach (var player in self.World.Players)
 			{
-				bool isVisible;
+				bool isCurrentlyVisible;
 				FrozenActor frozenActor;
 				if (!initialized)
 				{
 					frozen[player] = frozenActor = new FrozenActor(self, footprint, player.Shroud);
 					frozen[player].NeedRenderables = frozenActor.NeedRenderables = startsRevealed;
 					player.PlayerActor.Trait<FrozenActorLayer>().Add(frozenActor);
-					isVisible = visible[player] |= startsRevealed;
+					isCurrentlyVisible = visible[player] |= startsRevealed;
 				}
 				else
 				{
 					frozenActor = frozen[player];
-					isVisible = visible[player] = !frozenActor.IsVisible;
+					isCurrentlyVisible = visible[player] = !frozenActor.IsVisible;
 				}
 
-				if (isVisible)
+				// Sum of the ClientIndexes for all players that can currently see this actor.
+				if (isCurrentlyVisible)
 					VisibilityHash += player.ClientIndex;
 				else
 					continue;

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (f.HasRenderables || f.NeedRenderables)
 				return false;
 
-			return f.Visible;
+			return f.IsVisible;
 		}
 
 		public void Tick(World world)


### PR DESCRIPTION
Fixes #9155.

Also saves trait lookups on every render tick in `AppearsOnRadar`.

Individual commits should be pretty simple to review on a 1-by-1 basis.
Not sure if we want this for stable.
