### PR TITLE
Support HashSet in FieldLoader/FieldSaver

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -429,6 +429,18 @@ namespace OpenRA
 					ret.SetValue(GetValue(fieldName, fieldType.GetElementType(), parts[i].Trim(), field), i);
 				return ret;
 			}
+			else if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(HashSet<>))
+			{
+				var set = Activator.CreateInstance(fieldType);
+				if (value == null)
+					return set;
+
+				var parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+				var addMethod = fieldType.GetMethod("Add", fieldType.GetGenericArguments());
+				for (var i = 0; i < parts.Length; i++)
+					addMethod.Invoke(set, new[] { GetValue(fieldName, fieldType.GetGenericArguments()[0], parts[i].Trim(), field) });
+				return set;
+			}
 			else if (fieldType == typeof(Size))
 			{
 				if (value != null)

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -417,7 +417,7 @@ namespace OpenRA
 			}
 			else if (fieldType == typeof(bool))
 				return ParseYesNo(value, fieldType, fieldName);
-			else if (fieldType.IsArray)
+			else if (fieldType.IsArray && fieldType.GetArrayRank() == 1)
 			{
 				if (value == null)
 					return Array.CreateInstance(fieldType.GetElementType(), 0);

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -89,7 +89,7 @@ namespace OpenRA
 				return "{0},{1},{2},{3}".F(r.X, r.Y, r.Width, r.Height);
 			}
 
-			if (t.IsArray)
+			if (t.IsArray && t.GetArrayRank() == 1)
 			{
 				var elems = ((Array)v).OfType<object>();
 				return elems.JoinWith(", ");

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -91,8 +91,12 @@ namespace OpenRA
 
 			if (t.IsArray && t.GetArrayRank() == 1)
 			{
-				var elems = ((Array)v).OfType<object>();
-				return elems.JoinWith(", ");
+				return ((Array)v).Cast<object>().JoinWith(", ");
+			}
+
+			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(HashSet<>))
+			{
+				return ((System.Collections.IEnumerable)v).Cast<object>().JoinWith(", ");
 			}
 
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(OpenRA.Primitives.Cache<,>))

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -47,10 +47,10 @@ namespace OpenRA.GameRules
 		public readonly bool Charges = false;
 
 		[Desc("What types of targets are affected.")]
-		public readonly string[] ValidTargets = { "Ground", "Water" };
+		public readonly HashSet<string> ValidTargets = new HashSet<string> { "Ground", "Water" };
 
 		[Desc("What types of targets are unaffected.", "Overrules ValidTargets.")]
-		public readonly string[] InvalidTargets = { };
+		public readonly HashSet<string> InvalidTargets = new HashSet<string>();
 
 		[Desc("Delay in ticks between firing shots from the same ammo magazine.")]
 		public readonly int BurstDelay = 5;
@@ -64,14 +64,9 @@ namespace OpenRA.GameRules
 		[FieldLoader.LoadUsing("LoadWarheads")]
 		public readonly List<IWarhead> Warheads = new List<IWarhead>();
 
-		readonly HashSet<string> validTargetSet;
-		readonly HashSet<string> invalidTargetSet;
-
 		public WeaponInfo(string name, MiniYaml content)
 		{
 			FieldLoader.Load(this, content);
-			validTargetSet = new HashSet<string>(ValidTargets);
-			invalidTargetSet = new HashSet<string>(InvalidTargets);
 		}
 
 		static object LoadProjectile(MiniYaml yaml)
@@ -99,7 +94,7 @@ namespace OpenRA.GameRules
 
 		public bool IsValidTarget(IEnumerable<string> targetTypes)
 		{
-			return validTargetSet.Overlaps(targetTypes) && !invalidTargetSet.Overlaps(targetTypes);
+			return ValidTargets.Overlaps(targetTypes) && !InvalidTargets.Overlaps(targetTypes);
 		}
 
 		/// <summary>Checks if the weapon is valid against (can target) the target.</summary>


### PR DESCRIPTION
Adds support to load and save a `HashSet` directly.

This means classes can directly use a set if they need set-based operations, rather than suffering the cost of querying an array.

Lots of places may benefit from changing to sets eventually, for the moment I have limited it to simplifying `WeaponInfo` which was already creating a set for performance reasons.
