### PR TITLE
Fix culture in FieldSaver for collections

### DIFF
--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -55,10 +55,12 @@ namespace OpenRA
 			return new MiniYamlNode(field, FormatValue(o, o.GetType().GetField(field)));
 		}
 
-		public static string FormatValue(object v, Type t)
+		public static string FormatValue(object v)
 		{
 			if (v == null)
 				return "";
+
+			var t = v.GetType();
 
 			// Color.ToString() does the wrong thing; force it to format as an array
 			if (t == typeof(Color))
@@ -83,12 +85,12 @@ namespace OpenRA
 
 			if (t.IsArray && t.GetArrayRank() == 1)
 			{
-				return ((Array)v).Cast<object>().JoinWith(", ");
+				return ((Array)v).Cast<object>().Select(FormatValue).JoinWith(", ");
 			}
 
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(HashSet<>))
 			{
-				return ((System.Collections.IEnumerable)v).Cast<object>().JoinWith(", ");
+				return ((System.Collections.IEnumerable)v).Cast<object>().Select(FormatValue).JoinWith(", ");
 			}
 
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(OpenRA.Primitives.Cache<,>))
@@ -115,7 +117,7 @@ namespace OpenRA
 
 		public static string FormatValue(object o, FieldInfo f)
 		{
-			return FormatValue(f.GetValue(o), f.FieldType);
+			return FormatValue(f.GetValue(o));
 		}
 	}
 }

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -70,14 +70,6 @@ namespace OpenRA
 					((int)c.B).Clamp(0, 255));
 			}
 
-			// Don't save using country-specific decimal separators which can be misunderstood as group seperators.
-			if (t == typeof(float))
-				return ((float)v).ToString(CultureInfo.InvariantCulture);
-			if (t == typeof(decimal))
-				return ((decimal)v).ToString(CultureInfo.InvariantCulture);
-			if (t == typeof(double))
-				return ((double)v).ToString(CultureInfo.InvariantCulture);
-
 			if (t == typeof(ImageFormat))
 			{
 				return ((ImageFormat)v).ToString();


### PR DESCRIPTION
Ensure arrays and sets format all elements in their collections. This ensures they use the invariant culture and other formatting correctly.

Currently, the formatting of a type depends on if it is in a collection or not, which is not ideal.
