### PR TITLE
Fixed TD shellmap mammoth turrets drawn below body

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -389,6 +389,7 @@ HTNK:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
+	WithTurret:
 	Turreted:
 		ROT: 3
 	Armament@PRIMARY:
@@ -406,7 +407,6 @@ HTNK:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleFlash:
-	WithTurret:
 	AutoTarget:
 	SelfHealing:
 		Ticks: 10


### PR DESCRIPTION
On bleed, the turrets of the mammoth tanks on the TD shellmap are drawn below the body. This is an initialization order issue, different ZOffsets don't help.

Note1: This is a band-aid, we need #8848 to fix this properly.
Note2: This was probably introduced in #9004, but we should check the release branch just in case.
