### PR TITLE
Added tunnel top rendering

### DIFF
--- a/mods/ts/maps/arivruns/map.yaml
+++ b/mods/ts/maps/arivruns/map.yaml
@@ -1286,6 +1286,18 @@ Actors:
 	Actor422: trock02
 		Location: 147,106
 		Owner: Neutral
+	Actor423: tuntop04
+		Owner: Neutral
+		Location: 145,5
+	Actor424: tuntop04
+		Owner: Neutral
+		Location: 116,9
+	Actor425: tuntop02
+		Owner: Neutral
+		Location: 144,-19
+	Actor426: tuntop02
+		Owner: Neutral
+		Location: 115,-15
 
 Smudges:
 

--- a/mods/ts/maps/gdi4a/map.yaml
+++ b/mods/ts/maps/gdi4a/map.yaml
@@ -1735,6 +1735,12 @@ Actors:
 	Actor486: tracks04
 		Location: 134,22
 		Owner: Neutral
+	Actor487: tuntop04
+		Owner: Neutral
+		Location: 111,25
+	Actor488: tuntop02
+		Owner: Neutral
+		Location: 111,13
 
 Smudges:
 

--- a/mods/ts/maps/springs/map.yaml
+++ b/mods/ts/maps/springs/map.yaml
@@ -810,6 +810,54 @@ Actors:
 	Actor218: waypoint
 		Location: 78,-2
 		Owner: Neutral
+	Actor219: tuntop03
+		Owner: Neutral
+		Location: 68,-5
+	Actor220: tuntop04
+		Owner: Neutral
+		Location: 73,-12
+	Actor221: tuntop04
+		Owner: Neutral
+		Location: 107,-7
+	Actor222: tuntop03
+		Owner: Neutral
+		Location: 109,4
+	Actor223: tuntop02
+		Owner: Neutral
+		Location: 106,-16
+	Actor224: tuntop04
+		Owner: Neutral
+		Location: 87,28
+	Actor225: tuntop03
+		Owner: Neutral
+		Location: 73,34
+	Actor226: tuntop02
+		Owner: Neutral
+		Location: 86,13
+	Actor227: tuntop01
+		Owner: Neutral
+		Location: 60,34
+	Actor228: tuntop04
+		Owner: Neutral
+		Location: 42,13
+	Actor229: tuntop02
+		Owner: Neutral
+		Location: 40,-2
+	Actor230: tuntop01
+		Owner: Neutral
+		Location: 51,-6
+	Actor231: tuntop02
+		Owner: Neutral
+		Location: 72,-28
+	Actor232: tuntop01
+		Owner: Neutral
+		Location: 77,-38
+	Actor233: tuntop03
+		Owner: Neutral
+		Location: 93,-37
+	Actor234: tuntop01
+		Owner: Neutral
+		Location: 95,3
 
 Smudges:
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -694,7 +694,7 @@
 		Pieces: 3, 7
 		Range: 2c0, 5c0
 
-^Railway:
+^TerrainOverlay:
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: False
@@ -704,3 +704,11 @@
 	BodyOrientation:
 		UseClassicPerspectiveFudge: False
 		QuantizedFacings: 1
+
+^Railway:
+	Inherits: ^TerrainOverlay
+
+^Tunnel:
+	Inherits: ^TerrainOverlay
+	CustomSelectionSize:
+		CustomBounds: 220,220

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -199,3 +199,15 @@ TRACKS15:
 
 TRACKS16:
 	Inherits: ^Railway
+
+TUNTOP01:
+	Inherits: ^Tunnel
+
+TUNTOP02:
+	Inherits: ^Tunnel
+
+TUNTOP03:
+	Inherits: ^Tunnel
+
+TUNTOP04:
+	Inherits: ^Tunnel

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -569,3 +569,26 @@ tracks16:
 		UseTilesetExtension: true
 		ZOffset: -1c0
 
+tuntop01:
+	idle:
+		Offset: 0, -13
+		UseTilesetExtension: true
+		ShadowStart: 1
+
+tuntop02:
+	idle:
+		Offset: 0, -13
+		UseTilesetExtension: true
+		ShadowStart: 1
+
+tuntop03:
+	idle:
+		Offset: 0, -13
+		UseTilesetExtension: true
+		ShadowStart: 1
+
+tuntop04:
+	idle:
+		Offset: 0, -13
+		UseTilesetExtension: true
+		ShadowStart: 1


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/756669/9567454/46d1837a-4f2c-11e5-8496-25a8d84bcb75.png)

After:
![image](https://cloud.githubusercontent.com/assets/756669/9567450/1ba7abac-4f2c-11e5-9458-0f8081e68900.png)

Only polishes the rendering. Does not add support for http://modenc.renegadeprojects.com/Tubes.
