### PR TITLE
Fix TD tower selection boxes and improve TS sequence offsets

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -720,6 +720,8 @@ OBLI:
 		Dimensions: 1,2
 	Selectable:
 		Bounds: 24,24,0,12
+	SelectionDecorations:
+		VisualBounds: 22,42
 	RequiresPower:
 	DisabledOverlay:
 	Health:
@@ -799,6 +801,8 @@ ATWR:
 		Dimensions: 1,2
 	Selectable:
 		Bounds: 24,24,0,12
+	SelectionDecorations:
+		VisualBounds: 22,40,0,4
 	RequiresPower:
 	DisabledOverlay:
 	Health:

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -232,7 +232,7 @@ napowr:
 
 naapwr:
 	Defaults:
-		Offset: 12, -30
+		Offset: 12, -40
 		UseTilesetCode: true
 	idle:
 		ShadowStart: 3
@@ -1176,7 +1176,7 @@ namisl:
 
 gaplug:
 	Defaults:
-		Offset: 12, -30
+		Offset: 12, -40
 		UseTilesetCode: true
 	idle:
 		ShadowStart: 3


### PR DESCRIPTION
- Fixes that the Obelisk and AGT in TD only have 24x24 visual selection boxes.
- Improves offsets of TS Adv. Nod Power Plant and GDI Comm. Center. This does NOT fix the offset issues on "A River Runs Near It", but makes them more accurate everywhere else.
