### PR TITLE
Added the unloaded truck to Tiberian Sun

### DIFF
--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -34,7 +34,7 @@
 	WithVoxelBarrel:
 	WithMuzzleFlash:
 
-TRUCKB:
+^TRUCK:
 	Inherits: ^CivilianVoxelVehicle
 	Valued:
 		Cost: 500
@@ -48,6 +48,12 @@ TRUCKB:
 		Speed: 56
 	RevealsShroud:
 		Range: 5c0
+
+TRUCKA:
+	Inherits: ^TRUCK
+
+TRUCKB:
+	Inherits: ^TRUCK
 
 ICBM:
 	Inherits: ^CivilianVoxelVehicle


### PR DESCRIPTION
Just noticed

> Ignoring unknown actor type: `trucka`

when trying to import http://ra2maps.zzattack.org/Tiberian%20Sun/Official%20Multiplayer/getmap.php?map=Tunnel+Training
