### PR TITLE
 Move NAT Logic from ClientTooltipLogic into its own Function at LobbyUtils.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
@@ -79,10 +79,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var ping = orderManager.LobbyInfo.PingFromClient(client);
 			latency.GetText = () => LobbyUtils.LatencyDescription(ping);
 			latency.GetColor = () => LobbyUtils.LatencyColor(ping);
-			var address = orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
-			if (clientIndex == orderManager.LocalClient.Index && UPnP.NatDevice != null
-				&& address == IPAddress.Loopback.ToString())
-				address = UPnP.NatDevice.GetExternalIP().ToString();
+
+			var address = LobbyUtils.GetExternalIP(clientIndex, orderManager);
 			var cachedDescriptiveIP = LobbyUtils.DescriptiveIpAddress(address);
 			ip.GetText = () => cachedDescriptiveIP;
 			var cachedCountryLookup = GeoIP.LookupCountry(address);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -482,5 +482,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 			playerName.GetColor = () => player.Color.RGB;
 		}
+
+		public static string GetExternalIP(int clientIndex, OrderManager orderManager)
+		{
+			var address = orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
+			if (clientIndex == orderManager.LocalClient.Index && address == IPAddress.Loopback.ToString() && UPnP.NatDevice != null)
+			{
+				var externalIP = UPnP.NatDevice.GetExternalIP();
+				if (externalIP != null)
+					address = externalIP.ToString();
+			}
+
+			return address;
+		}
 	}
 }


### PR DESCRIPTION
This PR is fixing a Crash when the Client has problems to get the IP-Adress from the NAT Devices.

fixes #8787
