### PR TITLE
Ensure that we have a working OpenGL Context.

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -75,7 +75,9 @@ namespace OpenRA.Platforms.Default
 			}
 
 			context = SDL.SDL_GL_CreateContext(window);
-			SDL.SDL_GL_MakeCurrent(window, context);
+			if (context == IntPtr.Zero || SDL.SDL_GL_MakeCurrent(window, context) < 0)
+				throw new InvalidOperationException("Can not create OpenGL context. (Error: {0})".F(SDL.SDL_GetError()));
+
 			GraphicsContext.CurrentContext = context;
 
 			GL.LoadAll();


### PR DESCRIPTION
This PR adds an missing error check to the SDL2/OpenGL context creation. When something goes wrong with SDL and OpenGL it will crash...

```
Platform is Windows
Using SDL 2 with OpenGL renderer
Desktop resolution: 1920x1080
No custom resolution provided, using desktop resolution
Using resolution: 1920x1080
Detected OpenGL version: 4.5
```
