### PR TITLE
Red Alert: Adds satellite icons to badger planes.

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -32,7 +32,6 @@ BADR:
 		Offset: -432,-560,0
 		Interval: 2
 	-EjectOnDeath:
-	-GpsDot:
 	RejectsOrders:
 
 BADR.Bomber:
@@ -70,7 +69,6 @@ BADR.Bomber:
 		Offset: -432,-560,0
 		Interval: 2
 	-EjectOnDeath:
-	-GpsDot:
 	RejectsOrders:
 	RenderSprites:
 		Image: badr


### PR DESCRIPTION
They drop crates, paratroopers and parabombs. This is split from #9096.
