### PR TITLE
Adds IncludeAllies option to hide-map crate.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
@@ -13,7 +13,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Reveals the entire map.")]
 	class RevealMapCrateActionInfo : CrateActionInfo
 	{
-		[Desc("Should the map also be revealed for the allies of the collector's owner.")]
+		[Desc("Should the map also be revealed for the allies of the collector's owner?")]
 		public readonly bool IncludeAllies = false;
 
 		public override object Create(ActorInitializer init) { return new RevealMapCrateAction(init.Self, this); }


### PR DESCRIPTION
1) Adds an IncludeAllies variable to HideMapCrateAction.
2) Doesn't set the chance of getting hide-map crate as zero when player has fog visibility. Instead, player can get it but it has no effect. This works better with maps that have custom selection shares.
