### PR TITLE
Fix veinholes.

### DIFF
--- a/mods/ts/rules/trees.yaml
+++ b/mods/ts/rules/trees.yaml
@@ -102,6 +102,7 @@ VEINHOLEDUMMY:
 		Footprint: xx xx
 		Dimensions: 2, 2
 	BodyOrientation:
+		QuantizedFacings: 1
 
 VEINHOLE:
 	Inherits: VEINHOLEDUMMY


### PR DESCRIPTION
Another `BodyOrientation`-related regression, this time only A River Runs Near It is affected - no other maps have veins atm.
