### PR TITLE
Fixed BodyOrientation in 3rd Allies mission

### DIFF
--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1407,7 +1407,6 @@ Rules:
 			Type: CenterPosition
 		Immobile:
 			OccupiesSpace: false
-		BodyOrientation:
 		UpgradeActorsNear:
 			Upgrades: jail
 			Range: 1c0

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -1303,7 +1303,6 @@ Rules:
 			Type: CenterPosition
 		Immobile:
 			OccupiesSpace: false
-		BodyOrientation:
 		UpgradeActorsNear:
 			Upgrades: jail
 			Range: 1c0


### PR DESCRIPTION
Fixed

> Actor type 'prison' does not define a quantized body orientation.

Another followup of #9004.
