### PR TITLE
Move actors outside of the desired footprint when placing a building

### DIFF
--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -118,7 +118,8 @@ namespace OpenRA.Mods.Common
 			NotifyBlocker(self, positions.SelectMany(p => self.World.ActorMap.GetUnitsAt(p)));
 		}
 
-		public static bool CanHarvestAt(this Actor self, CPos pos, ResourceLayer resLayer, HarvesterInfo harvInfo, ResourceClaimLayer territory)
+		public static bool CanHarvestAt(this Actor self, CPos pos, ResourceLayer resLayer, HarvesterInfo harvInfo,
+			ResourceClaimLayer territory)
 		{
 			var resType = resLayer.GetResource(pos);
 			if (resType == null)
@@ -137,6 +138,11 @@ namespace OpenRA.Mods.Common
 			}
 
 			return true;
+		}
+
+		public static CPos ClosestCell(this Actor self, IEnumerable<CPos> cells)
+		{
+			return cells.MinByOrDefault(c => (self.Location - c).LengthSquared);
 		}
 	}
 }


### PR DESCRIPTION
What the title says.
Spiritual successor to #7800.
Closes #3682.

Tested with 3 clients in a 2v2 match (+ 1 AI) and couldn't get anything to break or behave exploit-y.
You **cannot** tell allied units to move. This is a very basic engine design choice to prevent exploits - orders are accepted only if the client that issued them is the one that has the owner of the order's subject. See [here](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/Traits/ValidateOrder.cs#L37).
