### PR TITLE
Fix crash when aircraft is rearming at a helipad in TS

### DIFF
--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -56,7 +56,9 @@ namespace OpenRA.Mods.Common.Activities
 				if (!pool.GiveAmmo())
 					continue;
 
-				hostBuilding.Trait<WithSpriteBody>().PlayCustomAnimation(hostBuilding, "active");
+				var wsb = hostBuilding.Trait<WithSpriteBody>();
+				if (wsb.DefaultAnimation.HasSequence("active"))
+					wsb.PlayCustomAnimation(hostBuilding, "active");
 
 				var sound = pool.Info.RearmSound;
 				if (sound != null)


### PR DESCRIPTION
Caused by both helipads missing an "active" animation.
TLDR - https://github.com/OpenRA/OpenRA/pull/9240/files?w=1
