### PR TITLE
Make rocks and trees HiddenUnderShroud instead of FrozenUnderFog

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -591,8 +591,7 @@
 	Armor:
 		Type: Wood
 	AutoTargetIgnore:
-	FrozenUnderFog:
-		StartsRevealed: true
+	HiddenUnderShroud:
 	ScriptTriggers:
 
 ^TibTree:
@@ -608,8 +607,7 @@
 	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Tiberium
-	FrozenUnderFog:
-		StartsRevealed: true
+	HiddenUnderShroud:
 	WithMakeAnimation:
 
 ^Rock:
@@ -625,8 +623,7 @@
 	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Tree
-	FrozenUnderFog:
-		StartsRevealed: true
+	HiddenUnderShroud:
 	ScriptTriggers:
 	EditorTilesetFilter:
 		RequireTilesets: DESERT

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -566,8 +566,7 @@
 	Armor:
 		Type: Wood
 	AutoTargetIgnore:
-	FrozenUnderFog:
-		StartsRevealed: true
+	HiddenUnderShroud:
 	ScriptTriggers:
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
@@ -656,8 +655,7 @@
 		Terrain: Tree
 	ProximityCaptor:
 		Types: Tree
-	FrozenUnderFog:
-		StartsRevealed: true
+	HiddenUnderShroud:
 	ScriptTriggers:
 	EditorTilesetFilter:
 		RequireTilesets: DESERT


### PR DESCRIPTION
This improves performance significantly when many trees and rocks are on the map and shroud/fog are enabled.

Should reduce the performance issues described in #9244.
