### PR TITLE
Added AI search for new resource patches avoiding enemies

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -105,6 +106,9 @@ namespace OpenRA.Mods.Common.AI
 			"Should match maximum adjacency of naval structures.")]
 		public readonly int CheckForWaterRadius = 8;
 
+		[Desc("Avoid enemy actors nearby when searching for a new resource patch. Should be somewhere near the max weapon range.")]
+		public readonly WDist HarvesterEnemyAvoidanceRadius = WDist.FromCells(8);
+
 		[Desc("Production queues AI uses for producing units.")]
 		public readonly string[] UnitQueues = { "Vehicle", "Infantry", "Plane", "Ship", "Aircraft" };
 
@@ -171,6 +175,11 @@ namespace OpenRA.Mods.Common.AI
 
 		public Player Player { get; private set; }
 
+		readonly DomainIndex domainIndex;
+		readonly ResourceLayer resLayer;
+		readonly ResourceClaimLayer territory;
+		readonly IPathFinder pathfinder;
+
 		readonly Func<Actor, bool> isEnemyUnit;
 		Dictionary<SupportPowerInstance, int> waitingPowers = new Dictionary<SupportPowerInstance, int>();
 		Dictionary<string, SupportPowerDecision> powerDecisions = new Dictionary<string, SupportPowerDecision>();
@@ -212,6 +221,12 @@ namespace OpenRA.Mods.Common.AI
 		{
 			Info = info;
 			World = init.World;
+
+			domainIndex = World.WorldActor.Trait<DomainIndex>();
+			resLayer = World.WorldActor.Trait<ResourceLayer>();
+			territory = World.WorldActor.TraitOrDefault<ResourceClaimLayer>();
+			pathfinder = World.WorldActor.Trait<IPathFinder>();
+
 			isEnemyUnit = unit =>
 				Player.Stances[unit.Owner] == Stance.Enemy && !unit.HasTrait<Husk>() && unit.HasTrait<ITargetable>();
 
@@ -634,6 +649,26 @@ namespace OpenRA.Mods.Common.AI
 			FindAndDeployBackupMcv(self);
 		}
 
+		CPos FindNextResource(Actor self)
+		{
+			var harvInfo = self.Info.Traits.Get<HarvesterInfo>();
+			var mobileInfo = self.Info.Traits.Get<MobileInfo>();
+			var passable = (uint)mobileInfo.GetMovementClass(World.TileSet);
+
+			var path = pathfinder.FindPath(
+				PathSearch.Search(World, mobileInfo, self, true,
+					loc => domainIndex.IsPassable(self.Location, loc, passable) && self.CanHarvestAt(loc, resLayer, harvInfo, territory))
+					.WithCustomCost(loc => World.FindActorsInCircle(World.Map.CenterOfCell(loc), Info.HarvesterEnemyAvoidanceRadius)
+						.Where(u => !u.IsDead && self.Owner.Stances[u.Owner] == Stance.Enemy)
+						.Sum(u => Math.Max(WDist.Zero.Length, Info.HarvesterEnemyAvoidanceRadius.Length - (World.Map.CenterOfCell(loc) - u.CenterPosition).Length)))
+					.FromPoint(self.Location));
+
+			if (path.Count == 0)
+				return CPos.Zero;
+
+			return path[0];
+		}
+
 		void GiveOrdersToIdleHarvesters()
 		{
 			// Find idle harvesters and give them orders:
@@ -657,7 +692,9 @@ namespace OpenRA.Mods.Common.AI
 					continue;
 
 				// Tell the idle harvester to quit slacking:
-				QueueOrder(new Order("Harvest", a, false));
+				var newSafeResourcePatch = FindNextResource(a);
+				BotDebug("AI: Harvester {0} is idle. Ordering to {1} in search for new resources.".F(a, newSafeResourcePatch));
+				QueueOrder(new Order("Harvest", a, false) { TargetLocation = newSafeResourcePatch });
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -109,34 +109,13 @@ namespace OpenRA.Mods.Common.Activities
 			}
 		}
 
-		bool IsHarvestable(Actor self, CPos pos)
-		{
-			var resType = resLayer.GetResource(pos);
-			if (resType == null)
-				return false;
-
-			// Can the harvester collect this kind of resource?
-			if (!harvInfo.Resources.Contains(resType.Info.Name))
-				return false;
-
-			if (territory != null)
-			{
-				// Another harvester has claimed this resource:
-				ResourceClaim claim;
-				if (territory.IsClaimedByAnyoneElse(self as Actor, pos, out claim))
-					return false;
-			}
-
-			return true;
-		}
-
 		/// <summary>
 		/// Finds the closest harvestable pos between the current position of the harvester
 		/// and the last order location
 		/// </summary>
 		CPos? ClosestHarvestablePos(Actor self)
 		{
-			if (IsHarvestable(self, self.Location))
+			if (self.CanHarvestAt(self.Location, resLayer, harvInfo, territory))
 				return self.Location;
 
 			// Determine where to search from and how far to search:
@@ -146,7 +125,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			var passable = (uint)mobileInfo.GetMovementClass(self.World.TileSet);
 			var search = PathSearch.Search(self.World, mobileInfo, self, true,
-				loc => domainIndex.IsPassable(self.Location, loc, passable) && IsHarvestable(self, loc))
+				loc => domainIndex.IsPassable(self.Location, loc, passable) && self.CanHarvestAt(loc, resLayer, harvInfo, territory))
 				.WithCustomCost(loc =>
 				{
 					if ((avoidCell.HasValue && loc == avoidCell.Value) ||

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -117,5 +117,26 @@ namespace OpenRA.Mods.Common
 		{
 			NotifyBlocker(self, positions.SelectMany(p => self.World.ActorMap.GetUnitsAt(p)));
 		}
+
+		public static bool CanHarvestAt(this Actor self, CPos pos, ResourceLayer resLayer, HarvesterInfo harvInfo, ResourceClaimLayer territory)
+		{
+			var resType = resLayer.GetResource(pos);
+			if (resType == null)
+				return false;
+
+			// Can the harvester collect this kind of resource?
+			if (!harvInfo.Resources.Contains(resType.Info.Name))
+				return false;
+
+			if (territory != null)
+			{
+				// Another harvester has claimed this resource:
+				ResourceClaim claim;
+				if (territory.IsClaimedByAnyoneElse(self as Actor, pos, out claim))
+					return false;
+			}
+
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
It is a similar check I removed from https://github.com/OpenRA/OpenRA/pull/9144 however it doesn't care about the resource claim layer, because that will run in the FindResource activity limited radius fine grained path search so we can skip it. Running two path finder searches is expensive so this is only the last resort when the current patch has dried out, not the default for every AI harvesting operation.

This also  brings back the enemy avoidance check which has been removed in https://github.com/OpenRA/OpenRA/pull/6986. I believe it didn't work, because it was comparing length of cell position with world distances. I fixed that when rebasing the code snippet.

Closes https://github.com/OpenRA/OpenRA/issues/9232.
