### PR TITLE
Increased harvester search radii

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -57,8 +57,8 @@ HARV:
 		Capacity: 20
 		LoadTicksPerBale: 12
 		UnloadTicksPerBale: 6
-		SearchFromProcRadius: 24
-		SearchFromOrderRadius: 12
+		SearchFromProcRadius: 25
+		SearchFromOrderRadius: 15
 	Mobile:
 		Speed: 85
 	Health:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -61,8 +61,8 @@ harvester:
 		HarvestFacings: 8
 		Resources: Spice
 		UnloadTicksPerBale: 5
-		SearchFromProcRadius: 24
-		SearchFromOrderRadius: 12
+		SearchFromProcRadius: 30
+		SearchFromOrderRadius: 15
 	Health:
 		HP: 1000
 	Armor:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -254,8 +254,8 @@ HARV:
 		Capacity: 20
 		Resources: Ore,Gems
 		UnloadTicksPerBale: 1
-		SearchFromProcRadius: 24
-		SearchFromOrderRadius: 12
+		SearchFromProcRadius: 30
+		SearchFromOrderRadius: 15
 	Health:
 		HP: 600
 	Armor:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -57,8 +57,8 @@ HARV:
 		Capacity: 20
 		Resources: Tiberium, BlueTiberium
 		UnloadTicksPerBale: 1
-		SearchFromProcRadius: 24
-		SearchFromOrderRadius: 12
+		SearchFromProcRadius: 36
+		SearchFromOrderRadius: 18
 		HarvestVoice: Attack
 		DeliverVoice: Move
 	Mobile:


### PR DESCRIPTION
Even before performance of harvesters was improved, I felt the search radius was a little too low.

This PR slightly-tomoderately increases the search radii in all mods.

This should improve the situation in cases where #9256 doesn't help.
