### PR TITLE
AI counts all aircraft rearm buildings

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -421,7 +421,7 @@ namespace OpenRA.Mods.Common.AI
 			if (ammoPoolsInfo.Any(x => !x.SelfReloads))
 			{
 				var countOwnAir = CountUnits(actorInfo.Name, Player);
-				var countBuildings = CountBuilding(aircraftInfo.RearmBuildings.FirstOrDefault(), Player);
+				var countBuildings = aircraftInfo.RearmBuildings.Sum(b => CountBuilding(b, Player));
 				if (countOwnAir >= countBuildings)
 					return false;
 			}


### PR DESCRIPTION
Currently the AI only counts `hpad` (Helipad) or whatever is the first entry of `RearmBuildings` for aircraft when deciding whether to build rearm buildings for aircraft, ignoring other entries such as `afld` (Airfield).

~~If count matching behaviour is unwanted for certain aircraft, then a `NeedsRearmBuilding`/`ShouldHaveRearmBuilding` field, `[Recommended]RearmBuildingRatio` field, or the like should be added.~~
