### PR TITLE
Speed up FrozenUnderFog.Tick

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -41,13 +41,14 @@ namespace OpenRA.Traits
 		public DamageState DamageState;
 
 		public bool Visible = true;
-		public bool NeedRenderables;
+		public bool NeedRenderables { get; private set; }
 		public bool IsRendering { get; private set; }
 
-		public FrozenActor(Actor self, PPos[] footprint, Shroud shroud)
+		public FrozenActor(Actor self, PPos[] footprint, Shroud shroud, bool startsRevealed)
 		{
 			actor = self;
 			this.shroud = shroud;
+			NeedRenderables = startsRevealed;
 			removeFrozenActors = self.TraitsImplementing<IRemoveFrozenActor>().ToArray();
 
 			// Consider all cells inside the map area (ignoring the current map bounds)

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -38,10 +38,19 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Lazy<IToolTip> tooltip;
 		readonly Lazy<Health> health;
 
-		readonly Dictionary<Player, bool> visible;
-		readonly Dictionary<Player, FrozenActor> frozen;
+		readonly Dictionary<Player, FrozenState> stateByPlayer = new Dictionary<Player, FrozenState>();
 
 		bool initialized;
+
+		class FrozenState
+		{
+			public readonly FrozenActor FrozenActor;
+			public bool IsVisible;
+			public FrozenState(FrozenActor frozenActor)
+			{
+				FrozenActor = frozenActor;
+			}
+		}
 
 		public FrozenUnderFog(ActorInitializer init, FrozenUnderFogInfo info)
 		{
@@ -55,9 +64,6 @@ namespace OpenRA.Mods.Common.Traits
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
 			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<IToolTip>().FirstOrDefault());
 			health = Exts.Lazy(() => init.Self.TraitOrDefault<Health>());
-
-			frozen = new Dictionary<Player, FrozenActor>();
-			visible = init.World.Players.ToDictionary(p => p, p => false);
 		}
 
 		bool IsVisibleInner(Actor self, Player byPlayer)
@@ -67,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 				return self.OccupiesSpace.OccupiedCells()
 					.Any(o => byPlayer.Shroud.IsExplored(o.First));
 
-			return visible[byPlayer];
+			return initialized && stateByPlayer[byPlayer].IsVisible;
 		}
 
 		public bool IsVisible(Actor self, Player byPlayer)
@@ -87,19 +93,21 @@ namespace OpenRA.Mods.Common.Traits
 			VisibilityHash = 0;
 			foreach (var player in self.World.Players)
 			{
-				bool isVisible;
 				FrozenActor frozenActor;
+				bool isVisible;
 				if (!initialized)
 				{
-					frozen[player] = frozenActor = new FrozenActor(self, footprint, player.Shroud);
-					frozen[player].NeedRenderables = frozenActor.NeedRenderables = startsRevealed;
+					frozenActor = new FrozenActor(self, footprint, player.Shroud, startsRevealed);
+					isVisible = startsRevealed;
+					stateByPlayer.Add(player, new FrozenState(frozenActor) { IsVisible = isVisible });
 					player.PlayerActor.Trait<FrozenActorLayer>().Add(frozenActor);
-					isVisible = visible[player] |= startsRevealed;
 				}
 				else
 				{
-					frozenActor = frozen[player];
-					isVisible = visible[player] = !frozenActor.Visible;
+					var state = stateByPlayer[player];
+					frozenActor = state.FrozenActor;
+					isVisible = !frozenActor.Visible;
+					state.IsVisible = isVisible;
 				}
 
 				if (isVisible)
@@ -127,7 +135,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			return IsVisible(self, self.World.RenderPlayer) || (initialized && frozen[self.World.RenderPlayer].IsRendering) ? r : SpriteRenderable.None;
+			return
+				IsVisible(self, self.World.RenderPlayer) ||
+				(initialized && stateByPlayer[self.World.RenderPlayer].FrozenActor.IsRendering) ?
+				r : SpriteRenderable.None;
 		}
 	}
 }


### PR DESCRIPTION
FrozenUnderFog.Tick gets called a lot, and most of that time is spent doing the two dictionary lookups.

This change stuffs everything into one dictionary. This means only one lookup and saves 40% of the time spent in this method.
