### PR TITLE
Lua API documentation cleanup

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Scripting
 {
-	[ScriptGlobal("Air Support Powers")]
+	[ScriptPropertyGroup("Support Powers")]
 	public class AirstrikeProperties : ScriptActorProperties, Requires<AirstrikePowerInfo>
 	{
 		readonly AirstrikePower ap;

--- a/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Scripting
 {
-	[ScriptPropertyGroup("Guard")]
+	[ScriptPropertyGroup("Combat")]
 	public class GuardProperties : ScriptActorProperties, Requires<GuardInfo>, Requires<IMoveInfo>
 	{
 		Guard guard;

--- a/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Scripting
 {
-	[ScriptPropertyGroup("Harvester")]
+	[ScriptPropertyGroup("Movement")]
 	public class HarvesterProperties : ScriptActorProperties, Requires<HarvesterInfo>
 	{
 		readonly Harvester harvester;

--- a/OpenRA.Mods.Common/Scripting/Properties/TransformProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransformProperties.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Scripting
 {
-	[ScriptPropertyGroup("Transform")]
+	[ScriptPropertyGroup("General")]
 	public class TransformProperties : ScriptActorProperties, Requires<TransformsInfo>
 	{
 		readonly Transforms transforms;

--- a/OpenRA.Mods.RA/Scripting/Properties/ParadropProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ParadropProperties.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Scripting
 {
-	[ScriptPropertyGroup("Paradrop")]
+	[ScriptPropertyGroup("Transports")]
 	public class ParadropProperties : ScriptActorProperties, Requires<CargoInfo>, Requires<ParaDropInfo>
 	{
 		readonly ParaDrop paradrop;

--- a/OpenRA.Mods.RA/Scripting/Properties/ParatroopersProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/ParatroopersProperties.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Scripting
 {
-	[ScriptPropertyGroup("Paratroopers")]
+	[ScriptPropertyGroup("Support Powers")]
 	public class ParatroopersProperties : ScriptActorProperties, Requires<ParatroopersPowerInfo>
 	{
 		readonly ParatroopersPower pp;


### PR DESCRIPTION
also reduces amount of headings with only a single entry
- SendAirStrike() - now listed under "Support Powers"
- Guard() - now listed under "Combat"
- FindResources() - now listed under "Movement"
- Deploy() - now listed under "General"
- SendParaTroopers() - now listed under "Support Powers"
- Paradrop() - now listed under "Transports"

Teleport() should probably be listed under "Movement", but I don't know how to change that (currently listed under "General").

note that I changed "ScriptGlobal" to "ScriptPropertyGroup" for SendAirStrike() - I hope that does not screw up anything
