### PR TITLE
Don’t create multiple sound contexts.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -234,6 +234,8 @@ namespace OpenRA
 				}
 			}
 
+			Sound.Create(Settings.Server.Dedicated ? "Null" : Settings.Sound.Engine);
+
 			Console.WriteLine("Available mods:");
 			foreach (var mod in ModMetadata.AllMods)
 				Console.WriteLine("\t{0}: {1} ({2})", mod.Key, mod.Value.Title, mod.Value.Version);
@@ -275,7 +277,7 @@ namespace OpenRA
 			Settings.Game.Mod = mod;
 
 			Sound.StopVideo();
-			Sound.Initialize(Settings.Server.Dedicated ? "Null" : Settings.Sound.Engine);
+			Sound.Initialize();
 
 			ModData = new ModData(mod, !Settings.Server.Dedicated);
 			ModData.InitializeLoaders();

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -29,6 +29,12 @@ namespace OpenRA
 		static ISound video;
 		static MusicInfo currentMusic;
 
+		public static void Create(string engineName)
+		{
+			var enginePath = Platform.ResolvePath(".", "OpenRA.Platforms." + engineName + ".dll");
+			soundEngine = CreateDevice(Assembly.LoadFile(enginePath));
+		}
+
 		static ISoundEngine CreateDevice(Assembly platformDll)
 		{
 			foreach (PlatformAttribute r in platformDll.GetCustomAttributes(typeof(PlatformAttribute), false))
@@ -66,11 +72,8 @@ namespace OpenRA
 			return soundEngine.AddSoundSourceFromMemory(rawData, channels, sampleBits, sampleRate);
 		}
 
-		public static void Initialize(string engineName)
+		public static void Initialize()
 		{
-			var enginePath = Platform.ResolvePath(".", "OpenRA.Platforms." + engineName + ".dll");
-			soundEngine = CreateDevice(Assembly.LoadFile(enginePath));
-
 			sounds = new Cache<string, ISoundSource>(LoadSound);
 			music = null;
 			currentMusic = null;


### PR DESCRIPTION
Fixes #9271, which was a regression introduced by #8632.
