### PR TITLE
Speed up RepairIndicator.Render.

### DIFF
--- a/OpenRA.Mods.Common/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RepairIndicator.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (building.Disposed || wr.World.FogObscures(building) || rb.Repairers.Count == 0)
+			if (building.Disposed || rb.Repairers.Count == 0 || wr.World.FogObscures(building))
 				return SpriteRenderable.None;
 
 			PaletteReference palette;


### PR DESCRIPTION
Check repairer count first, as this is quicker than checking fog visibility.
