### PR TITLE
Speed up Player.CanViewActor

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -71,6 +71,8 @@ namespace OpenRA
 		readonly IRenderModifier[] renderModifiers;
 		readonly IRender[] renders;
 		readonly IDisable[] disables;
+		readonly IVisibilityModifier[] visibilityModifiers;
+		readonly IDefaultVisibility defaultVisibility;
 
 		internal Actor(World world, string name, TypeDictionary initDict)
 		{
@@ -130,6 +132,8 @@ namespace OpenRA
 			renderModifiers = TraitsImplementing<IRenderModifier>().ToArray();
 			renders = TraitsImplementing<IRender>().ToArray();
 			disables = TraitsImplementing<IDisable>().ToArray();
+			visibilityModifiers = TraitsImplementing<IVisibilityModifier>().ToArray();
+			defaultVisibility = Trait<IDefaultVisibility>();
 		}
 
 		public void Tick()
@@ -293,6 +297,15 @@ namespace OpenRA
 				if (disable.Disabled)
 					return true;
 			return false;
+		}
+
+		public bool CanBeViewedByPlayer(Player player)
+		{
+			foreach (var visibilityModifier in visibilityModifiers)
+				if (!visibilityModifier.IsVisible(this, player))
+					return false;
+
+			return defaultVisibility.IsVisible(this, player);
 		}
 
 		#region Scripting interface

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -154,10 +154,7 @@ namespace OpenRA
 
 		public bool CanViewActor(Actor a)
 		{
-			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a, this)))
-				return false;
-
-			return a.Trait<IDefaultVisibility>().IsVisible(a, this);
+			return a.CanBeViewedByPlayer(this);
 		}
 
 		public bool CanTargetActor(Actor a)
@@ -165,10 +162,7 @@ namespace OpenRA
 			if (HasFogVisibility)
 				return true;
 
-			if (a.TraitsImplementing<IVisibilityModifier>().Any(t => !t.IsVisible(a, this)))
-				return false;
-
-			return a.Trait<IDefaultVisibility>().IsVisible(a, this);
+			return CanViewActor(a);
 		}
 
 		public bool HasFogVisibility { get { return fogVisibilities.Any(f => f.HasFogVisibility(this)); } }


### PR DESCRIPTION
Create Actor.CanBeViewedByPlayer and simply call this instead. The actor can cache all trait lookups on construction to avoid them being repeated for every visibility check.

This approximately doubles the speed of Player.CanViewActor, which is useful since it gets called a lot from the radar widget (which checks all actors with a radar signature) and when "Always Show Health Bars" is enabled (which checks all selectable actors).
