### PR TITLE
Removed a redundant bot production debug message

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -132,7 +132,6 @@ namespace OpenRA.Mods.Common.AI
 				if (item == null)
 					return false;
 
-				HackyAI.BotDebug("AI: {0} is starting production of {1}".F(player, item.Name));
 				ai.QueueOrder(Order.StartProduction(queue.Actor, item.Name, 1));
 			}
 			else if (currentBuilding != null && currentBuilding.Done)


### PR DESCRIPTION
This is spammy and not really useful, because a) you can already see this via the observer tools and b) it is announced in the line before which tracks the prioritizing and decision making `AI: {0} decided to build {1}: Priority override` or `{0} decided to build {1}: Desired is {2} ({3} / {4}); current is {5} / {4}` so we can just skip this and keep an overview in the already crowded bot debug lines.
