### PR TITLE
Reduce allocations

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Lint\LintBuildablePrerequisites.cs" />
     <Compile Include="Lint\LintExts.cs" />
     <Compile Include="LoadScreens\ModChooserLoadScreen.cs" />
+    <Compile Include="ShroudExts.cs" />
     <Compile Include="Orders\BeaconOrderGenerator.cs" />
     <Compile Include="Orders\DeployOrderTargeter.cs" />
     <Compile Include="Orders\EnterAlliedActorTargeter.cs" />

--- a/OpenRA.Mods.Common/ShroudExts.cs
+++ b/OpenRA.Mods.Common/ShroudExts.cs
@@ -1,0 +1,39 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common
+{
+	using OccupiedCells = IEnumerable<Pair<CPos, SubCell>>;
+
+	public static class ShroudExts
+	{
+		public static bool AnyExplored(this Shroud shroud, OccupiedCells cells)
+		{
+			foreach (var cell in cells)
+				if (shroud.IsExplored(cell.First))
+					return true;
+
+			return false;
+		}
+
+		public static bool AnyVisible(this Shroud shroud, OccupiedCells cells)
+		{
+			foreach (var cell in cells)
+				if (shroud.IsVisible(cell.First))
+					return true;
+
+			return false;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -70,8 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// If fog is disabled visibility is determined by shroud
 			if (!byPlayer.Shroud.FogEnabled)
-				return self.OccupiesSpace.OccupiedCells()
-					.Any(o => byPlayer.Shroud.IsExplored(o.First));
+				return byPlayer.Shroud.AnyExplored(self.OccupiesSpace.OccupiedCells());
 
 			return initialized && stateByPlayer[byPlayer].IsVisible;
 		}

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
@@ -33,8 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 				return base.IsVisibleInner(self, byPlayer);
 
 			if (Info.Type == VisibilityType.Footprint)
-				return self.OccupiesSpace.OccupiedCells()
-					.Any(o => byPlayer.Shroud.IsVisible(o.First));
+				return byPlayer.Shroud.AnyVisible(self.OccupiesSpace.OccupiedCells());
 
 			return byPlayer.Shroud.IsVisible(self.CenterPosition);
 		}

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
@@ -42,8 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected virtual bool IsVisibleInner(Actor self, Player byPlayer)
 		{
 			if (Info.Type == VisibilityType.Footprint)
-				return self.OccupiesSpace.OccupiedCells()
-					.Any(o => byPlayer.Shroud.IsExplored(o.First));
+				return byPlayer.Shroud.AnyExplored(self.OccupiesSpace.OccupiedCells());
 
 			return byPlayer.Shroud.IsExplored(self.CenterPosition);
 		}


### PR DESCRIPTION
A couple more small tweaks to reduce allocations and thus reduce the work the GC has to do.

These changes save about ~8% in allocations during the main game loop in an AI heavy replay.
