### PR TITLE
Make AttackBase.GetMinimumRange() return WDist.Zero if there are no available armaments

### DIFF
--- a/OpenRA.Game/WDist.cs
+++ b/OpenRA.Game/WDist.cs
@@ -27,6 +27,7 @@ namespace OpenRA
 
 		public WDist(int r) { Length = r; }
 		public static readonly WDist Zero = new WDist(0);
+		public static readonly WDist MaxValue = new WDist(int.MaxValue);
 		public static WDist FromCells(int cells) { return new WDist(1024 * cells); }
 
 		public static WDist operator +(WDist a, WDist b) { return new WDist(a.Length + b.Length); }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -167,8 +167,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled)
 				return WDist.Zero;
 
-			return Armaments.Where(a => !a.IsTraitDisabled)
-				.Select(a => a.Weapon.MinRange).Min();
+			var min = Armaments.Where(a => !a.IsTraitDisabled)
+				.Select(a => a.Weapon.MinRange)
+				.Append(WDist.MaxValue).Min();
+			return min != WDist.MaxValue ? min : WDist.Zero;
 		}
 
 		public WDist GetMaximumRange()


### PR DESCRIPTION
This applies similar logic to that of `AttackBase.GetMaximumRange()`. Actually, the current version of `AttackBase.GetMinimumRange()` should crash if there are not any armaments where `IsTraitDisabled` is false.
