### PR TITLE
Make some navigation keys available to spectators

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Faction.InternalName);
 
 				if (radarPings != null)
-					radarPings.Add(() => self.Owner == self.World.LocalPlayer, self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);
+					radarPings.Add(() => self.Owner.IsAlliedWith(self.World.RenderPlayer), self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);
 			}
 
 			lastAttackTime = self.World.WorldTick;

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Faction.InternalName);
 
 				if (radarPings != null)
-					radarPings.Add(() => self.Owner == self.World.LocalPlayer, self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);
+					radarPings.Add(() => self.Owner.IsAlliedWith(self.World.RenderPlayer), self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);
 			}
 
 			lastAttackTime = self.World.WorldTick;

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override bool HandleKeyPress(KeyInput e)
 		{
-			if (world == null || world.LocalPlayer == null)
+			if (world == null)
 				return false;
 
 			return ProcessInput(e);
@@ -63,6 +63,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (key == ks.ToSelectionKey)
 					return ToSelection();
+
+				// Put all functions that are valid for observers/spectators above this line.
+				if (world.LocalPlayer == null || world.LocalPlayer.Spectating)
+					return false;
 
 				// Put all functions that aren't unit-specific before this line!
 				if (!world.Selection.Actors.Any() || world.IsGameOver)
@@ -188,7 +192,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool CycleBases()
 		{
 			var bases = world.ActorsWithTrait<BaseBuilding>()
-				.Where(a => a.Actor.Owner == world.LocalPlayer)
+				.Where(a => a.Actor.Owner == world.RenderPlayer)
 				.Select(b => b.Actor)
 				.ToList();
 
@@ -197,7 +201,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var building = world.ActorsWithTrait<Building>()
 					.Select(b => b.Actor)
-					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<SelectableInfo>());
+					.FirstOrDefault(a => a.Owner == world.RenderPlayer && a.Info.HasTraitInfo<SelectableInfo>());
 
 				// No buildings left
 				if (building == null)
@@ -223,7 +227,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool CycleProductionBuildings()
 		{
 			var facilities = world.ActorsWithTrait<Production>()
-				.Where(a => a.Actor.Owner == world.LocalPlayer && !a.Actor.Info.HasTraitInfo<BaseBuildingInfo>())
+				.Where(a => a.Actor.Owner == world.RenderPlayer && !a.Actor.Info.HasTraitInfo<BaseBuildingInfo>())
 				.OrderBy(f => f.Actor.Info.TraitInfo<ProductionInfo>().Produces.First())
 				.Select(b => b.Actor)
 				.ToList();


### PR DESCRIPTION
This will make the following keys available to spectators and in replays:
- Center screen on last event/beacon [Space]
- Center screen on current selection [Home]
- Cycle construction yards [H]
- Cycle production buildings [Tab]

The latter two need a player view to work, the former two work in all views.

We may or may not want the first commit, please discuss. At the very least the `LocalPlayer`->`RenderPlayer` change from that commit should be kept, though.

Fixes #6174.
