### PR TITLE
Add margin to CreateEffectWarhead air check

### DIFF
--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -39,8 +39,13 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public static ImpactType GetImpactType(World world, CPos cell, WPos pos)
 		{
+			// Missiles need a margin because they sometimes explode a little above ground
+			// due to their explosion check triggering slightly too early (because of CloseEnough).
+			// TODO: Base ImpactType on target altitude instead of explosion altitude.
+			var airMargin = new WDist(128);
+
 			var dat = world.Map.DistanceAboveTerrain(pos);
-			var isAir = dat.Length > 0;
+			var isAir = dat.Length > airMargin.Length;
 			var isWater = dat.Length <= 0 && world.Map.GetTerrainInfo(cell).IsWater;
 			var isDirectHit = GetDirectHit(world, cell, pos);
 


### PR DESCRIPTION
Instead of considering the ImpactType to be "Air" as soon as the warhead triggers even a single Z WDist above 0 (relative to terrain height), there is now a small margin. This fixes the issue that #9016 originally attempted to fix, namely that missiles sometimes show the "air" explosion even though they were shot at a ground target.

Fixes #9308.
