### PR TITLE
Fixed a wrong tileset definition in d2k

### DIFF
--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -3619,10 +3619,10 @@ Templates:
 		Size: 2,2
 		Category: Rock-Detail
 		Tiles:
-			0: Sand
-			1: Sand
-			2: Sand
-			3: Sand
+			0: Rough
+			1: Rough
+			2: Rough
+			3: Rough
 	Template@422:
 		Id: 422
 		Images: BLOXTREE.R8


### PR DESCRIPTION
On bleed you can move on this tile:
![d2krockb](https://cloud.githubusercontent.com/assets/7704140/9828885/c195b474-58f4-11e5-839a-79a09f72a07f.png)
![d2krocka](https://cloud.githubusercontent.com/assets/7704140/9828882/c05f07b8-58f4-11e5-9522-c066a65442d0.png)
`Atreides01a` can be used as a testmap.
