### PR TITLE
TraitInfo through ActorInfo and HasTrait Removal

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -103,7 +103,7 @@ namespace OpenRA
 
 			bounds = Exts.Lazy(() =>
 			{
-				var si = Info.Traits.GetOrDefault<SelectableInfo>();
+				var si = Info.TraitInfoOrDefault<SelectableInfo>();
 				var size = (si != null && si.Bounds != null) ? new int2(si.Bounds[0], si.Bounds[1]) :
 					TraitsImplementing<IAutoSelectionSize>().Select(x => x.SelectionSize(this)).FirstOrDefault();
 
@@ -116,7 +116,7 @@ namespace OpenRA
 
 			visualBounds = Exts.Lazy(() =>
 			{
-				var sd = Info.Traits.GetOrDefault<ISelectionDecorationsInfo>();
+				var sd = Info.TraitInfoOrDefault<ISelectionDecorationsInfo>();
 				if (sd == null || sd.SelectionBoxBounds == null)
 					return bounds.Value;
 

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -226,11 +226,6 @@ namespace OpenRA
 			return World.TraitDict.WithInterface<T>(this);
 		}
 
-		public bool HasTrait<T>()
-		{
-			return World.TraitDict.Contains<T>(this);
-		}
-
 		public void AddTrait(object trait)
 		{
 			World.TraitDict.AddTrait(this, trait);

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -183,5 +183,7 @@ namespace OpenRA
 				i => Pair.New(
 					i.Name.Replace("Init", ""), i));
 		}
+
+		public bool HasTraitInfo<T>() where T : ITraitInfo { return Traits.Contains<T>(); }
 	}
 }

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -185,5 +185,7 @@ namespace OpenRA
 		}
 
 		public bool HasTraitInfo<T>() where T : ITraitInfo { return Traits.Contains<T>(); }
+		public T TraitInfo<T>() where T : ITraitInfo { return Traits.Get<T>(); }
+		public T TraitInfoOrDefault<T>() where T : ITraitInfo { return Traits.GetOrDefault<T>(); }
 	}
 }

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Graphics
 			if (World.Type == WorldType.Regular && Game.Settings.Game.AlwaysShowStatusBars)
 			{
 				foreach (var g in World.Actors.Where(a => !a.Disposed
-					&& a.HasTrait<Selectable>()
+					&& a.Info.Traits.Contains<SelectableInfo>()
 					&& !World.FogObscures(a)
 					&& !World.Selection.Actors.Contains(a)))
 
@@ -193,7 +193,7 @@ namespace OpenRA.Graphics
 
 		public void DrawRollover(Actor unit)
 		{
-			if (unit.HasTrait<Selectable>())
+			if (unit.Info.Traits.Contains<SelectableInfo>())
 				new SelectionBarsRenderable(unit).Render(this);
 		}
 

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Graphics
 			if (World.Type == WorldType.Regular && Game.Settings.Game.AlwaysShowStatusBars)
 			{
 				foreach (var g in World.Actors.Where(a => !a.Disposed
-					&& a.Info.Traits.Contains<SelectableInfo>()
+					&& a.Info.HasTraitInfo<SelectableInfo>()
 					&& !World.FogObscures(a)
 					&& !World.Selection.Actors.Contains(a)))
 
@@ -193,7 +193,7 @@ namespace OpenRA.Graphics
 
 		public void DrawRollover(Actor unit)
 		{
-			if (unit.Info.Traits.Contains<SelectableInfo>())
+			if (unit.Info.HasTraitInfo<SelectableInfo>())
 				new SelectionBarsRenderable(unit).Render(this);
 		}
 

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Orders
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
 			var underCursor = world.ScreenMap.ActorsAt(mi)
-				.Where(a => !world.FogObscures(a) && a.Info.Traits.Contains<ITargetableInfo>())
+				.Where(a => !world.FogObscures(a) && a.Info.HasTraitInfo<ITargetableInfo>())
 				.WithHighestSelectionPriority();
 
 			Target target;
@@ -29,7 +29,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
+					.Where(a => a.Info.HasTraitInfo<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}
@@ -58,12 +58,12 @@ namespace OpenRA.Orders
 		{
 			var useSelect = false;
 			var underCursor = world.ScreenMap.ActorsAt(mi)
-				.Where(a => !world.FogObscures(a) && a.Info.Traits.Contains<ITargetableInfo>())
+				.Where(a => !world.FogObscures(a) && a.Info.HasTraitInfo<ITargetableInfo>())
 				.WithHighestSelectionPriority();
 
 			if (underCursor != null && (mi.Modifiers.HasModifier(Modifiers.Shift) || !world.Selection.Actors.Any()))
 			{
-				if (underCursor.Info.Traits.Contains<SelectableInfo>())
+				if (underCursor.Info.HasTraitInfo<SelectableInfo>())
 					useSelect = true;
 			}
 
@@ -73,7 +73,7 @@ namespace OpenRA.Orders
 			else
 			{
 				var frozen = world.ScreenMap.FrozenActorsAt(world.RenderPlayer, mi)
-					.Where(a => a.Info.Traits.Contains<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
+					.Where(a => a.Info.HasTraitInfo<ITargetableInfo>() && !a.Footprint.All(world.ShroudObscures))
 					.WithHighestSelectionPriority();
 				target = frozen != null ? Target.FromFrozenActor(frozen) : Target.FromCell(world, xy);
 			}

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Orders
 		public IEnumerable<Order> Order(World world, CPos xy, MouseInput mi)
 		{
 			var underCursor = world.ScreenMap.ActorsAt(mi)
-				.Where(a => !world.FogObscures(a) && a.HasTrait<ITargetable>())
+				.Where(a => !world.FogObscures(a) && a.Info.Traits.Contains<ITargetableInfo>())
 				.WithHighestSelectionPriority();
 
 			Target target;
@@ -58,12 +58,12 @@ namespace OpenRA.Orders
 		{
 			var useSelect = false;
 			var underCursor = world.ScreenMap.ActorsAt(mi)
-				.Where(a => !world.FogObscures(a) && a.HasTrait<ITargetable>())
+				.Where(a => !world.FogObscures(a) && a.Info.Traits.Contains<ITargetableInfo>())
 				.WithHighestSelectionPriority();
 
 			if (underCursor != null && (mi.Modifiers.HasModifier(Modifiers.Shift) || !world.Selection.Actors.Any()))
 			{
-				if (underCursor.HasTrait<Selectable>())
+				if (underCursor.Info.Traits.Contains<SelectableInfo>())
 					useSelect = true;
 			}
 

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Traits
 	{
 		public static int SelectionPriority(this ActorInfo a)
 		{
-			var selectableInfo = a.Traits.GetOrDefault<SelectableInfo>();
+			var selectableInfo = a.TraitInfoOrDefault<SelectableInfo>();
 			return selectableInfo != null ? selectableInfo.Priority : int.MinValue;
 		}
 
@@ -26,7 +26,7 @@ namespace OpenRA.Traits
 
 		public static int SelectionPriority(this Actor a)
 		{
-			var basePriority = a.Info.Traits.Get<SelectableInfo>().Priority;
+			var basePriority = a.Info.TraitInfo<SelectableInfo>().Priority;
 			var lp = a.World.LocalPlayer;
 
 			if (a.Owner == lp || lp == null)

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -75,7 +75,7 @@ namespace OpenRA
 				if (actor.Owner != world.LocalPlayer || !actor.IsInWorld)
 					continue;
 
-				var selectable = actor.Info.Traits.GetOrDefault<SelectableInfo>();
+				var selectable = actor.Info.TraitInfoOrDefault<SelectableInfo>();
 				if (selectable == null || !actor.HasVoice(selectable.Voice))
 					continue;
 

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -84,12 +84,6 @@ namespace OpenRA
 				throw new InvalidOperationException("Attempted to get trait from destroyed object ({0})".F(actor));
 		}
 
-		public bool Contains<T>(Actor actor)
-		{
-			CheckDestroyed(actor);
-			return InnerGet<T>().GetMultiple(actor.ActorID).Any();
-		}
-
 		public T Get<T>(Actor actor)
 		{
 			CheckDestroyed(actor);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -144,13 +144,13 @@ namespace OpenRA.Traits
 		Player Owner { get; }
 	}
 
-	public interface IToolTip
+	public interface ITooltip
 	{
 		ITooltipInfo TooltipInfo { get; }
 		Player Owner { get; }
 	}
 
-	public interface ITooltipInfo
+	public interface ITooltipInfo : ITraitInfo
 	{
 		string TooltipForPlayerStance(Stance stance);
 		bool IsOwnerRowVisible { get; }
@@ -226,6 +226,7 @@ namespace OpenRA.Traits
 	public interface ITags { IEnumerable<TagType> GetTags(); }
 	public interface ISelectionBar { float GetValue(); Color GetColor(); }
 
+	public interface IPositionableInfo : ITraitInfo { }
 	public interface IPositionable : IOccupySpace
 	{
 		bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any);
@@ -296,6 +297,7 @@ namespace OpenRA.Traits
 	public interface INotifyBecomingIdle { void OnBecomingIdle(Actor self); }
 	public interface INotifyIdle { void TickIdle(Actor self); }
 
+	public interface IBlocksProjectilesInfo : ITraitInfo { }
 	public interface IBlocksProjectiles { }
 	public interface IRenderInfantrySequenceModifier
 	{
@@ -309,7 +311,7 @@ namespace OpenRA.Traits
 
 	public interface IPostRenderSelection { IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr); }
 
-	public interface ITargetableInfo
+	public interface ITargetableInfo : ITraitInfo
 	{
 		HashSet<string> GetTargetTypes();
 	}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Traits
 
 	public interface ISeedableResource { void Seed(Actor self); }
 
-	public interface ISelectionDecorationsInfo
+	public interface ISelectionDecorationsInfo : ITraitInfo
 	{
 		int[] SelectionBoxBounds { get; }
 	}

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Widgets
 					{
 						if (!hasBox && World.Selection.Actors.Any() && !multiClick)
 						{
-							if (!(World.ScreenMap.ActorsAt(xy).Where(x => x.Info.Traits.Contains<SelectableInfo>() &&
+							if (!(World.ScreenMap.ActorsAt(xy).Where(x => x.Info.HasTraitInfo<SelectableInfo>() &&
 								(x.Owner.IsAlliedWith(World.RenderPlayer) || !World.FogObscures(x))).Any() && !mi.Modifiers.HasModifier(Modifiers.Ctrl) &&
 								!mi.Modifiers.HasModifier(Modifiers.Alt) && UnitOrderGenerator.InputOverridesSelection(World, xy, mi)))
 							{
@@ -301,7 +301,7 @@ namespace OpenRA.Widgets
 				a = b;
 
 			return world.ScreenMap.ActorsInBox(a, b)
-				.Where(x => x.Info.Traits.Contains<SelectableInfo>() && (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)))
+				.Where(x => x.Info.HasTraitInfo<SelectableInfo>() && (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)))
 				.SubsetWithHighestSelectionPriority();
 		}
 

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Widgets
 					{
 						if (!hasBox && World.Selection.Actors.Any() && !multiClick)
 						{
-							if (!(World.ScreenMap.ActorsAt(xy).Where(x => x.HasTrait<Selectable>() &&
+							if (!(World.ScreenMap.ActorsAt(xy).Where(x => x.Info.Traits.Contains<SelectableInfo>() &&
 								(x.Owner.IsAlliedWith(World.RenderPlayer) || !World.FogObscures(x))).Any() && !mi.Modifiers.HasModifier(Modifiers.Ctrl) &&
 								!mi.Modifiers.HasModifier(Modifiers.Alt) && UnitOrderGenerator.InputOverridesSelection(World, xy, mi)))
 							{
@@ -301,7 +301,7 @@ namespace OpenRA.Widgets
 				a = b;
 
 			return world.ScreenMap.ActorsInBox(a, b)
-				.Where(x => x.HasTrait<Selectable>() && (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)))
+				.Where(x => x.Info.Traits.Contains<SelectableInfo>() && (x.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(x)))
 				.SubsetWithHighestSelectionPriority();
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (!self.IsInWorld || self.IsDead)
 					return;
 
-				var altitude = self.World.Map.Rules.Actors[actorType].Traits.Get<PlaneInfo>().CruiseAltitude;
+				var altitude = self.World.Map.Rules.Actors[actorType].TraitInfo<PlaneInfo>().CruiseAltitude;
 				var actor = w.CreateActor(actorType, new TypeDictionary
 				{
 					new CenterPositionInit(w.Map.CenterOfCell(startPos) + new WVec(WDist.Zero, WDist.Zero, altitude)),

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.AI
 			var sumOfHp = 0;
 			foreach (var a in actors)
 			{
-				if (a.Info.Traits.Contains<HealthInfo>())
+				if (a.Info.HasTraitInfo<HealthInfo>())
 				{
 					sumOfMaxHp += a.Trait<Health>().MaxHP;
 					sumOfHp += a.Trait<Health>().HP;
@@ -228,7 +228,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var sum = 0;
 			foreach (var a in actors)
-				if (a.Info.Traits.Contains<TTraitInfo>())
+				if (a.Info.HasTraitInfo<TTraitInfo>())
 					sum += getValue(a);
 
 			return sum;
@@ -240,7 +240,7 @@ namespace OpenRA.Mods.Common.AI
 			var countActors = 0;
 			foreach (var a in actors)
 			{
-				if (a.Info.Traits.Contains<TTraitInfo>())
+				if (a.Info.HasTraitInfo<TTraitInfo>())
 				{
 					sum += getValue(a);
 					countActors++;

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.AI
 
 		protected float RelativeSpeed(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
 		{
-			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Info.Traits.Get<MobileInfo>().Speed);
+			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Info.TraitInfo<MobileInfo>().Speed);
 		}
 
 		protected static float RelativeValue(IEnumerable<Actor> own, IEnumerable<Actor> enemy, float normalizeByValue,

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.AI
 			var sumOfHp = 0;
 			foreach (var a in actors)
 			{
-				if (a.HasTrait<Health>())
+				if (a.Info.Traits.Contains<HealthInfo>())
 				{
 					sumOfMaxHp += a.Trait<Health>().MaxHP;
 					sumOfHp += a.Trait<Health>().HP;
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Common.AI
 
 		protected float RelativePower(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
 		{
-			return RelativeValue(own, enemy, 100, SumOfValues<AttackBase>, a =>
+			return RelativeValue(own, enemy, 100, SumOfValues<AttackBaseInfo>, a =>
 			{
 				var sumOfDamage = 0;
 				var arms = a.TraitsImplementing<Armament>();
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.AI
 
 		protected float RelativeSpeed(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
 		{
-			return RelativeValue(own, enemy, 100, Average<Mobile>, (Actor a) => a.Trait<Mobile>().Info.Speed);
+			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Trait<Mobile>().Info.Speed);
 		}
 
 		protected static float RelativeValue(IEnumerable<Actor> own, IEnumerable<Actor> enemy, float normalizeByValue,
@@ -224,23 +224,23 @@ namespace OpenRA.Mods.Common.AI
 			return relative.Clamp(0.0f, 999.0f);
 		}
 
-		protected float SumOfValues<Trait>(IEnumerable<Actor> actors, Func<Actor, int> getValue)
+		protected float SumOfValues<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfo
 		{
 			var sum = 0;
 			foreach (var a in actors)
-				if (a.HasTrait<Trait>())
+				if (a.Info.Traits.Contains<TTraitInfo>())
 					sum += getValue(a);
 
 			return sum;
 		}
 
-		protected float Average<Trait>(IEnumerable<Actor> actors, Func<Actor, int> getValue)
+		protected float Average<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfo
 		{
 			var sum = 0;
 			var countActors = 0;
 			foreach (var a in actors)
 			{
-				if (a.HasTrait<Trait>())
+				if (a.Info.Traits.Contains<TTraitInfo>())
 				{
 					sum += getValue(a);
 					countActors++;

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.AI
 
 		protected float RelativeSpeed(IEnumerable<Actor> own, IEnumerable<Actor> enemy)
 		{
-			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Trait<Mobile>().Info.Speed);
+			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Info.Traits.Get<MobileInfo>().Speed);
 		}
 
 		protected static float RelativeValue(IEnumerable<Actor> own, IEnumerable<Actor> enemy, float normalizeByValue,

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -167,8 +167,8 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var randomBaseBuilding = World.Actors.Where(
 				a => a.Owner == Player
-					&& a.HasTrait<BaseBuilding>()
-					&& !a.HasTrait<Mobile>())
+					&& a.Info.Traits.Contains<BaseBuildingInfo>()
+					&& !a.Info.Traits.Contains<MobileInfo>())
 				.RandomOrDefault(Random);
 
 			return randomBaseBuilding != null ? randomBaseBuilding.Location : initialBaseCenter;
@@ -232,7 +232,9 @@ namespace OpenRA.Mods.Common.AI
 			pathfinder = World.WorldActor.Trait<IPathFinder>();
 
 			isEnemyUnit = unit =>
-				Player.Stances[unit.Owner] == Stance.Enemy && !unit.HasTrait<Husk>() && unit.HasTrait<ITargetable>();
+				Player.Stances[unit.Owner] == Stance.Enemy
+					&& !unit.Info.Traits.Contains<HuskInfo>()
+					&& unit.Info.Traits.Contains<ITargetableInfo>();
 
 			foreach (var decision in info.PowerDecisions)
 				powerDecisions.Add(decision.OrderName, decision);
@@ -279,8 +281,8 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var baseProviders = World.Actors.Where(
 				a => a.Owner == Player
-					&& a.HasTrait<BaseProvider>()
-					&& !a.HasTrait<Mobile>());
+					&& a.Info.Traits.Contains<BaseProviderInfo>()
+					&& !a.Info.Traits.Contains<MobileInfo>());
 
 			foreach (var b in baseProviders)
 			{
@@ -306,8 +308,8 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var areaProviders = World.Actors.Where(
 				a => a.Owner == Player
-					&& a.HasTrait<GivesBuildableArea>()
-					&& !a.HasTrait<Mobile>());
+					&& a.Info.Traits.Contains<GivesBuildableAreaInfo>()
+					&& !a.Info.Traits.Contains<MobileInfo>());
 
 			foreach (var a in areaProviders)
 			{
@@ -487,7 +489,7 @@ namespace OpenRA.Mods.Common.AI
 				case BuildingType.Defense:
 
 					// Build near the closest enemy structure
-					var closestEnemy = World.Actors.Where(a => !a.Disposed && a.HasTrait<Building>() && Player.Stances[a.Owner] == Stance.Enemy)
+					var closestEnemy = World.Actors.Where(a => !a.Disposed && a.Info.Traits.Contains<BuildingInfo>() && Player.Stances[a.Owner] == Stance.Enemy)
 						.ClosestTo(World.Map.CenterOfCell(defenseCenter));
 
 					var targetCell = closestEnemy != null ? closestEnemy.Location : baseCenter;
@@ -563,7 +565,7 @@ namespace OpenRA.Mods.Common.AI
 
 			// Pick something worth attacking owned by that player
 			var target = World.Actors
-				.Where(a => a.Owner == enemy && a.HasTrait<IOccupySpace>())
+				.Where(a => a.Owner == enemy && a.Info.Traits.Contains<IOccupySpaceInfo>())
 				.ClosestTo(World.Map.CenterOfCell(GetRandomBaseCenter()));
 
 			if (target == null)
@@ -595,7 +597,7 @@ namespace OpenRA.Mods.Common.AI
 		List<Actor> FindEnemyConstructionYards()
 		{
 			return World.Actors.Where(a => Player.Stances[a.Owner] == Stance.Enemy && !a.IsDead
-				&& a.HasTrait<BaseBuilding>() && !a.HasTrait<Mobile>()).ToList();
+				&& a.Info.Traits.Contains<BaseBuildingInfo>() && !a.Info.Traits.Contains<MobileInfo>()).ToList();
 		}
 
 		void CleanSquads()
@@ -705,18 +707,18 @@ namespace OpenRA.Mods.Common.AI
 		void FindNewUnits(Actor self)
 		{
 			var newUnits = self.World.ActorsWithTrait<IPositionable>()
-				.Where(a => a.Actor.Owner == Player && !a.Actor.HasTrait<BaseBuilding>()
+				.Where(a => a.Actor.Owner == Player && !a.Actor.Info.Traits.Contains<BaseBuildingInfo>()
 					&& !activeUnits.Contains(a.Actor))
 				.Select(a => a.Actor);
 
 			foreach (var a in newUnits)
 			{
-				if (a.HasTrait<Harvester>())
+				if (a.Info.Traits.Contains<HarvesterInfo>())
 					QueueOrder(new Order("Harvest", a, false));
 				else
 					unitsHangingAroundTheBase.Add(a);
 
-				if (a.HasTrait<Aircraft>() && a.HasTrait<AttackBase>())
+				if (a.Info.Traits.Contains<AircraftInfo>() && a.Info.Traits.Contains<AttackBaseInfo>())
 				{
 					var air = GetSquadOfType(SquadType.Air);
 					if (air == null)
@@ -740,7 +742,7 @@ namespace OpenRA.Mods.Common.AI
 				var attackForce = RegisterNewSquad(SquadType.Assault);
 
 				foreach (var a in unitsHangingAroundTheBase)
-					if (!a.HasTrait<Aircraft>())
+					if (!a.Info.Traits.Contains<AircraftInfo>())
 						attackForce.Units.Add(a);
 
 				unitsHangingAroundTheBase.Clear();
@@ -751,7 +753,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var allEnemyBaseBuilder = FindEnemyConstructionYards();
 			var ownUnits = activeUnits
-				.Where(unit => unit.HasTrait<AttackBase>() && !unit.HasTrait<Aircraft>() && unit.IsIdle).ToList();
+				.Where(unit => unit.Info.Traits.Contains<AttackBaseInfo>() && !unit.Info.Traits.Contains<AircraftInfo>() && unit.IsIdle).ToList();
 
 			if (!allEnemyBaseBuilder.Any() || (ownUnits.Count < Info.SquadSize))
 				return;
@@ -759,7 +761,7 @@ namespace OpenRA.Mods.Common.AI
 			foreach (var b in allEnemyBaseBuilder)
 			{
 				var enemies = World.FindActorsInCircle(b.CenterPosition, WDist.FromCells(Info.RushAttackScanRadius))
-					.Where(unit => Player.Stances[unit.Owner] == Stance.Enemy && unit.HasTrait<AttackBase>()).ToList();
+					.Where(unit => Player.Stances[unit.Owner] == Stance.Enemy && unit.Info.Traits.Contains<AttackBaseInfo>()).ToList();
 
 				if (rushFuzzy.CanAttack(ownUnits, enemies))
 				{
@@ -788,8 +790,8 @@ namespace OpenRA.Mods.Common.AI
 			if (!protectSq.IsValid)
 			{
 				var ownUnits = World.FindActorsInCircle(World.Map.CenterOfCell(GetRandomBaseCenter()), WDist.FromCells(Info.ProtectUnitScanRadius))
-					.Where(unit => unit.Owner == Player && !unit.HasTrait<Building>()
-						&& unit.HasTrait<AttackBase>());
+					.Where(unit => unit.Owner == Player && !unit.Info.Traits.Contains<BuildingInfo>()
+						&& unit.Info.Traits.Contains<AttackBaseInfo>());
 
 				foreach (var a in ownUnits)
 					protectSq.Units.Add(a);
@@ -830,7 +832,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			// Find and deploy our mcv
 			var mcv = self.World.Actors
-				.FirstOrDefault(a => a.Owner == Player && a.HasTrait<BaseBuilding>());
+				.FirstOrDefault(a => a.Owner == Player && a.Info.Traits.Contains<BaseBuildingInfo>());
 
 			if (mcv != null)
 			{
@@ -839,7 +841,7 @@ namespace OpenRA.Mods.Common.AI
 
 				// Don't transform the mcv if it is a fact
 				// HACK: This needs to query against MCVs directly
-				if (mcv.HasTrait<Mobile>())
+				if (mcv.Info.Traits.Contains<MobileInfo>())
 					QueueOrder(new Order("DeployTransform", mcv, false));
 			}
 			else
@@ -851,7 +853,8 @@ namespace OpenRA.Mods.Common.AI
 		void FindAndDeployBackupMcv(Actor self)
 		{
 			// HACK: This needs to query against MCVs directly
-			var mcvs = self.World.Actors.Where(a => a.Owner == Player && a.HasTrait<BaseBuilding>() && a.HasTrait<Mobile>());
+			var mcvs = self.World.Actors
+				.Where(a => a.Owner == Player && a.Info.Traits.Contains<BaseBuildingInfo>() && a.Info.Traits.Contains<MobileInfo>());
 			if (!mcvs.Any())
 				return;
 
@@ -1010,7 +1013,8 @@ namespace OpenRA.Mods.Common.AI
 				return;
 
 			// No construction yards - Build a new MCV
-			if (!HasAdequateFact() && !self.World.Actors.Any(a => a.Owner == Player && a.HasTrait<BaseBuilding>() && a.HasTrait<Mobile>()))
+			if (!HasAdequateFact() && !self.World.Actors.Any(a =>
+					a.Owner == Player && a.Info.Traits.Contains<BaseBuildingInfo>() && a.Info.Traits.Contains<MobileInfo>()))
 				BuildUnit("Vehicle", GetUnitInfoByCommonName("Mcv", Player).Name);
 
 			foreach (var q in Info.UnitQueues)
@@ -1069,14 +1073,14 @@ namespace OpenRA.Mods.Common.AI
 			if (e.Attacker.Disposed)
 				return;
 
-			if (!e.Attacker.HasTrait<ITargetable>())
+			if (!e.Attacker.Info.Traits.Contains<ITargetableInfo>())
 				return;
 
 			if (e.Damage > 0)
 				aggro[e.Attacker.Owner].Aggro += e.Damage;
 
 			// Protected harvesters or building
-			if ((self.HasTrait<Harvester>() || self.HasTrait<Building>()) &&
+			if ((self.Info.Traits.Contains<HarvesterInfo>() || self.Info.Traits.Contains<BuildingInfo>()) &&
 				Player.Stances[e.Attacker.Owner] == Stance.Enemy)
 			{
 				defenseCenter = e.Attacker.Location;

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -167,8 +167,8 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var randomBaseBuilding = World.Actors.Where(
 				a => a.Owner == Player
-					&& a.Info.Traits.Contains<BaseBuildingInfo>()
-					&& !a.Info.Traits.Contains<MobileInfo>())
+					&& a.Info.HasTraitInfo<BaseBuildingInfo>()
+					&& !a.Info.HasTraitInfo<MobileInfo>())
 				.RandomOrDefault(Random);
 
 			return randomBaseBuilding != null ? randomBaseBuilding.Location : initialBaseCenter;
@@ -233,8 +233,8 @@ namespace OpenRA.Mods.Common.AI
 
 			isEnemyUnit = unit =>
 				Player.Stances[unit.Owner] == Stance.Enemy
-					&& !unit.Info.Traits.Contains<HuskInfo>()
-					&& unit.Info.Traits.Contains<ITargetableInfo>();
+					&& !unit.Info.HasTraitInfo<HuskInfo>()
+					&& unit.Info.HasTraitInfo<ITargetableInfo>();
 
 			foreach (var decision in info.PowerDecisions)
 				powerDecisions.Add(decision.OrderName, decision);
@@ -281,8 +281,8 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var baseProviders = World.Actors.Where(
 				a => a.Owner == Player
-					&& a.Info.Traits.Contains<BaseProviderInfo>()
-					&& !a.Info.Traits.Contains<MobileInfo>());
+					&& a.Info.HasTraitInfo<BaseProviderInfo>()
+					&& !a.Info.HasTraitInfo<MobileInfo>());
 
 			foreach (var b in baseProviders)
 			{
@@ -308,8 +308,8 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var areaProviders = World.Actors.Where(
 				a => a.Owner == Player
-					&& a.Info.Traits.Contains<GivesBuildableAreaInfo>()
-					&& !a.Info.Traits.Contains<MobileInfo>());
+					&& a.Info.HasTraitInfo<GivesBuildableAreaInfo>()
+					&& !a.Info.HasTraitInfo<MobileInfo>());
 
 			foreach (var a in areaProviders)
 			{
@@ -489,7 +489,7 @@ namespace OpenRA.Mods.Common.AI
 				case BuildingType.Defense:
 
 					// Build near the closest enemy structure
-					var closestEnemy = World.Actors.Where(a => !a.Disposed && a.Info.Traits.Contains<BuildingInfo>() && Player.Stances[a.Owner] == Stance.Enemy)
+					var closestEnemy = World.Actors.Where(a => !a.Disposed && a.Info.HasTraitInfo<BuildingInfo>() && Player.Stances[a.Owner] == Stance.Enemy)
 						.ClosestTo(World.Map.CenterOfCell(defenseCenter));
 
 					var targetCell = closestEnemy != null ? closestEnemy.Location : baseCenter;
@@ -565,7 +565,7 @@ namespace OpenRA.Mods.Common.AI
 
 			// Pick something worth attacking owned by that player
 			var target = World.Actors
-				.Where(a => a.Owner == enemy && a.Info.Traits.Contains<IOccupySpaceInfo>())
+				.Where(a => a.Owner == enemy && a.Info.HasTraitInfo<IOccupySpaceInfo>())
 				.ClosestTo(World.Map.CenterOfCell(GetRandomBaseCenter()));
 
 			if (target == null)
@@ -597,7 +597,7 @@ namespace OpenRA.Mods.Common.AI
 		List<Actor> FindEnemyConstructionYards()
 		{
 			return World.Actors.Where(a => Player.Stances[a.Owner] == Stance.Enemy && !a.IsDead
-				&& a.Info.Traits.Contains<BaseBuildingInfo>() && !a.Info.Traits.Contains<MobileInfo>()).ToList();
+				&& a.Info.HasTraitInfo<BaseBuildingInfo>() && !a.Info.HasTraitInfo<MobileInfo>()).ToList();
 		}
 
 		void CleanSquads()
@@ -707,18 +707,18 @@ namespace OpenRA.Mods.Common.AI
 		void FindNewUnits(Actor self)
 		{
 			var newUnits = self.World.ActorsWithTrait<IPositionable>()
-				.Where(a => a.Actor.Owner == Player && !a.Actor.Info.Traits.Contains<BaseBuildingInfo>()
+				.Where(a => a.Actor.Owner == Player && !a.Actor.Info.HasTraitInfo<BaseBuildingInfo>()
 					&& !activeUnits.Contains(a.Actor))
 				.Select(a => a.Actor);
 
 			foreach (var a in newUnits)
 			{
-				if (a.Info.Traits.Contains<HarvesterInfo>())
+				if (a.Info.HasTraitInfo<HarvesterInfo>())
 					QueueOrder(new Order("Harvest", a, false));
 				else
 					unitsHangingAroundTheBase.Add(a);
 
-				if (a.Info.Traits.Contains<AircraftInfo>() && a.Info.Traits.Contains<AttackBaseInfo>())
+				if (a.Info.HasTraitInfo<AircraftInfo>() && a.Info.HasTraitInfo<AttackBaseInfo>())
 				{
 					var air = GetSquadOfType(SquadType.Air);
 					if (air == null)
@@ -742,7 +742,7 @@ namespace OpenRA.Mods.Common.AI
 				var attackForce = RegisterNewSquad(SquadType.Assault);
 
 				foreach (var a in unitsHangingAroundTheBase)
-					if (!a.Info.Traits.Contains<AircraftInfo>())
+					if (!a.Info.HasTraitInfo<AircraftInfo>())
 						attackForce.Units.Add(a);
 
 				unitsHangingAroundTheBase.Clear();
@@ -753,7 +753,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var allEnemyBaseBuilder = FindEnemyConstructionYards();
 			var ownUnits = activeUnits
-				.Where(unit => unit.Info.Traits.Contains<AttackBaseInfo>() && !unit.Info.Traits.Contains<AircraftInfo>() && unit.IsIdle).ToList();
+				.Where(unit => unit.Info.HasTraitInfo<AttackBaseInfo>() && !unit.Info.HasTraitInfo<AircraftInfo>() && unit.IsIdle).ToList();
 
 			if (!allEnemyBaseBuilder.Any() || (ownUnits.Count < Info.SquadSize))
 				return;
@@ -761,7 +761,7 @@ namespace OpenRA.Mods.Common.AI
 			foreach (var b in allEnemyBaseBuilder)
 			{
 				var enemies = World.FindActorsInCircle(b.CenterPosition, WDist.FromCells(Info.RushAttackScanRadius))
-					.Where(unit => Player.Stances[unit.Owner] == Stance.Enemy && unit.Info.Traits.Contains<AttackBaseInfo>()).ToList();
+					.Where(unit => Player.Stances[unit.Owner] == Stance.Enemy && unit.Info.HasTraitInfo<AttackBaseInfo>()).ToList();
 
 				if (rushFuzzy.CanAttack(ownUnits, enemies))
 				{
@@ -790,8 +790,8 @@ namespace OpenRA.Mods.Common.AI
 			if (!protectSq.IsValid)
 			{
 				var ownUnits = World.FindActorsInCircle(World.Map.CenterOfCell(GetRandomBaseCenter()), WDist.FromCells(Info.ProtectUnitScanRadius))
-					.Where(unit => unit.Owner == Player && !unit.Info.Traits.Contains<BuildingInfo>()
-						&& unit.Info.Traits.Contains<AttackBaseInfo>());
+					.Where(unit => unit.Owner == Player && !unit.Info.HasTraitInfo<BuildingInfo>()
+						&& unit.Info.HasTraitInfo<AttackBaseInfo>());
 
 				foreach (var a in ownUnits)
 					protectSq.Units.Add(a);
@@ -832,7 +832,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			// Find and deploy our mcv
 			var mcv = self.World.Actors
-				.FirstOrDefault(a => a.Owner == Player && a.Info.Traits.Contains<BaseBuildingInfo>());
+				.FirstOrDefault(a => a.Owner == Player && a.Info.HasTraitInfo<BaseBuildingInfo>());
 
 			if (mcv != null)
 			{
@@ -841,7 +841,7 @@ namespace OpenRA.Mods.Common.AI
 
 				// Don't transform the mcv if it is a fact
 				// HACK: This needs to query against MCVs directly
-				if (mcv.Info.Traits.Contains<MobileInfo>())
+				if (mcv.Info.HasTraitInfo<MobileInfo>())
 					QueueOrder(new Order("DeployTransform", mcv, false));
 			}
 			else
@@ -854,7 +854,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			// HACK: This needs to query against MCVs directly
 			var mcvs = self.World.Actors
-				.Where(a => a.Owner == Player && a.Info.Traits.Contains<BaseBuildingInfo>() && a.Info.Traits.Contains<MobileInfo>());
+				.Where(a => a.Owner == Player && a.Info.HasTraitInfo<BaseBuildingInfo>() && a.Info.HasTraitInfo<MobileInfo>());
 			if (!mcvs.Any())
 				return;
 
@@ -1014,7 +1014,7 @@ namespace OpenRA.Mods.Common.AI
 
 			// No construction yards - Build a new MCV
 			if (!HasAdequateFact() && !self.World.Actors.Any(a =>
-					a.Owner == Player && a.Info.Traits.Contains<BaseBuildingInfo>() && a.Info.Traits.Contains<MobileInfo>()))
+					a.Owner == Player && a.Info.HasTraitInfo<BaseBuildingInfo>() && a.Info.HasTraitInfo<MobileInfo>()))
 				BuildUnit("Vehicle", GetUnitInfoByCommonName("Mcv", Player).Name);
 
 			foreach (var q in Info.UnitQueues)
@@ -1073,14 +1073,14 @@ namespace OpenRA.Mods.Common.AI
 			if (e.Attacker.Disposed)
 				return;
 
-			if (!e.Attacker.Info.Traits.Contains<ITargetableInfo>())
+			if (!e.Attacker.Info.HasTraitInfo<ITargetableInfo>())
 				return;
 
 			if (e.Damage > 0)
 				aggro[e.Attacker.Owner].Aggro += e.Damage;
 
 			// Protected harvesters or building
-			if ((self.Info.Traits.Contains<HarvesterInfo>() || self.Info.Traits.Contains<BuildingInfo>()) &&
+			if ((self.Info.HasTraitInfo<HarvesterInfo>() || self.Info.HasTraitInfo<BuildingInfo>()) &&
 				Player.Stances[e.Attacker.Owner] == Stance.Enemy)
 			{
 				defenseCenter = e.Attacker.Location;

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -433,7 +433,7 @@ namespace OpenRA.Mods.Common.AI
 		// For mods like RA (number of building must match the number of aircraft)
 		bool HasAdequateAirUnitReloadBuildings(ActorInfo actorInfo)
 		{
-			var aircraftInfo = actorInfo.Traits.GetOrDefault<AircraftInfo>();
+			var aircraftInfo = actorInfo.TraitInfoOrDefault<AircraftInfo>();
 			if (aircraftInfo == null)
 				return true;
 
@@ -453,7 +453,7 @@ namespace OpenRA.Mods.Common.AI
 		CPos defenseCenter;
 		public CPos? ChooseBuildLocation(string actorType, bool distanceToBaseIsImportant, BuildingType type)
 		{
-			var bi = Map.Rules.Actors[actorType].Traits.GetOrDefault<BuildingInfo>();
+			var bi = Map.Rules.Actors[actorType].TraitInfoOrDefault<BuildingInfo>();
 			if (bi == null)
 				return null;
 
@@ -657,8 +657,8 @@ namespace OpenRA.Mods.Common.AI
 
 		CPos FindNextResource(Actor self)
 		{
-			var harvInfo = self.Info.Traits.Get<HarvesterInfo>();
-			var mobileInfo = self.Info.Traits.Get<MobileInfo>();
+			var harvInfo = self.Info.TraitInfo<HarvesterInfo>();
+			var mobileInfo = self.Info.TraitInfo<MobileInfo>();
 			var passable = (uint)mobileInfo.GetMovementClass(World.TileSet);
 
 			var path = pathfinder.FindPath(
@@ -807,7 +807,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var buildings = self.World.ActorsWithTrait<RallyPoint>()
 				.Where(rp => rp.Actor.Owner == Player &&
-					!IsRallyPointValid(rp.Trait.Location, rp.Actor.Info.Traits.GetOrDefault<BuildingInfo>())).ToArray();
+					!IsRallyPointValid(rp.Trait.Location, rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>())).ToArray();
 
 			foreach (var a in buildings)
 				QueueOrder(new Order("SetRallyPoint", a.Actor, false) { TargetLocation = ChooseRallyLocationNear(a.Actor), SuppressVisualFeedback = true });
@@ -817,7 +817,7 @@ namespace OpenRA.Mods.Common.AI
 		CPos ChooseRallyLocationNear(Actor producer)
 		{
 			var possibleRallyPoints = Map.FindTilesInCircle(producer.Location, Info.RallyPointScanRadius)
-				.Where(c => IsRallyPointValid(c, producer.Info.Traits.GetOrDefault<BuildingInfo>()));
+				.Where(c => IsRallyPointValid(c, producer.Info.TraitInfoOrDefault<BuildingInfo>()));
 
 			if (!possibleRallyPoints.Any())
 			{
@@ -863,7 +863,7 @@ namespace OpenRA.Mods.Common.AI
 				if (mcv.IsMoving())
 					continue;
 
-				var factType = mcv.Info.Traits.Get<TransformsInfo>().IntoActor;
+				var factType = mcv.Info.TraitInfo<TransformsInfo>().IntoActor;
 				var desiredLocation = ChooseBuildLocation(factType, false, BuildingType.Building);
 				if (desiredLocation == null)
 					continue;

--- a/OpenRA.Mods.Common/AI/Squad.cs
+++ b/OpenRA.Mods.Common/AI/Squad.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.AI
 
 		public bool IsTargetValid
 		{
-			get { return Target.IsValidFor(Units.FirstOrDefault()) && !Target.Actor.HasTrait<Husk>(); }
+			get { return Target.IsValidFor(Units.FirstOrDefault()) && !Target.Actor.Info.Traits.Contains<HuskInfo>(); }
 		}
 
 		public bool IsTargetVisible

--- a/OpenRA.Mods.Common/AI/Squad.cs
+++ b/OpenRA.Mods.Common/AI/Squad.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.AI
 
 		public bool IsTargetValid
 		{
-			get { return Target.IsValidFor(Units.FirstOrDefault()) && !Target.Actor.Info.Traits.Contains<HuskInfo>(); }
+			get { return Target.IsValidFor(Units.FirstOrDefault()) && !Target.Actor.Info.HasTraitInfo<HuskInfo>(); }
 		}
 
 		public bool IsTargetVisible

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.AI
 			var missileUnitsCount = 0;
 			foreach (var unit in units)
 			{
-				if (unit != null && unit.Info.Traits.Contains<AttackBaseInfo>() && !unit.Info.Traits.Contains<AircraftInfo>()
+				if (unit != null && unit.Info.HasTraitInfo<AttackBaseInfo>() && !unit.Info.HasTraitInfo<AircraftInfo>()
 					&& !unit.IsDisabled())
 				{
 					var arms = unit.TraitsImplementing<Armament>();
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.Common.AI
 						continue;
 				}
 
-				if (owner.TargetActor.Info.Traits.Contains<ITargetableInfo>() && CanAttackTarget(a, owner.TargetActor))
+				if (owner.TargetActor.Info.HasTraitInfo<ITargetableInfo>() && CanAttackTarget(a, owner.TargetActor))
 					owner.Bot.QueueOrder(new Order("Attack", a, false) { TargetActor = owner.TargetActor });
 			}
 		}

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.AI
 			var missileUnitsCount = 0;
 			foreach (var unit in units)
 			{
-				if (unit != null && unit.HasTrait<AttackBase>() && !unit.HasTrait<Aircraft>()
+				if (unit != null && unit.Info.Traits.Contains<AttackBaseInfo>() && !unit.Info.Traits.Contains<AircraftInfo>()
 					&& !unit.IsDisabled())
 				{
 					var arms = unit.TraitsImplementing<Armament>();
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.Common.AI
 						continue;
 				}
 
-				if (owner.TargetActor.HasTrait<ITargetable>() && CanAttackTarget(a, owner.TargetActor))
+				if (owner.TargetActor.Info.Traits.Contains<ITargetableInfo>() && CanAttackTarget(a, owner.TargetActor))
 					owner.Bot.QueueOrder(new Order("Attack", a, false) { TargetActor = owner.TargetActor });
 			}
 		}

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.AI
 			{
 				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(12))
 					.Where(a1 => !a1.Disposed && !a1.IsDead);
-				var enemynearby = enemies.Where(a1 => a1.HasTrait<ITargetable>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
+				var enemynearby = enemies.Where(a1 => a1.Info.Traits.Contains<ITargetableInfo>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
 				var target = enemynearby.ClosestTo(leader.CenterPosition);
 				if (target != null)
 				{

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.AI
 			{
 				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(12))
 					.Where(a1 => !a1.Disposed && !a1.IsDead);
-				var enemynearby = enemies.Where(a1 => a1.Info.Traits.Contains<ITargetableInfo>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
+				var enemynearby = enemies.Where(a1 => a1.Info.HasTraitInfo<ITargetableInfo>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
 				var target = enemynearby.ClosestTo(leader.CenterPosition);
 				if (target != null)
 				{

--- a/OpenRA.Mods.Common/AI/States/StateBase.cs
+++ b/OpenRA.Mods.Common/AI/States/StateBase.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.AI
 
 		protected static bool CanAttackTarget(Actor a, Actor target)
 		{
-			if (!a.HasTrait<AttackBase>())
+			if (!a.Info.Traits.Contains<AttackBaseInfo>())
 				return false;
 
 			var targetTypes = target.TraitsImplementing<ITargetable>().Where(Exts.IsTraitEnabled).SelectMany(t => t.TargetTypes);
@@ -82,11 +82,11 @@ namespace OpenRA.Mods.Common.AI
 
 			var u = squad.Units.Random(squad.Random);
 			var units = squad.World.FindActorsInCircle(u.CenterPosition, WDist.FromCells(DangerRadius)).ToList();
-			var ownBaseBuildingAround = units.Where(unit => unit.Owner == squad.Bot.Player && unit.HasTrait<Building>());
+			var ownBaseBuildingAround = units.Where(unit => unit.Owner == squad.Bot.Player && unit.Info.Traits.Contains<BuildingInfo>());
 			if (ownBaseBuildingAround.Any())
 				return false;
 
-			var enemyAroundUnit = units.Where(unit => squad.Bot.Player.Stances[unit.Owner] == Stance.Enemy && unit.HasTrait<AttackBase>());
+			var enemyAroundUnit = units.Where(unit => squad.Bot.Player.Stances[unit.Owner] == Stance.Enemy && unit.Info.Traits.Contains<AttackBaseInfo>());
 			if (!enemyAroundUnit.Any())
 				return false;
 

--- a/OpenRA.Mods.Common/AI/States/StateBase.cs
+++ b/OpenRA.Mods.Common/AI/States/StateBase.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.AI
 
 		protected static bool CanAttackTarget(Actor a, Actor target)
 		{
-			if (!a.Info.Traits.Contains<AttackBaseInfo>())
+			if (!a.Info.HasTraitInfo<AttackBaseInfo>())
 				return false;
 
 			var targetTypes = target.TraitsImplementing<ITargetable>().Where(Exts.IsTraitEnabled).SelectMany(t => t.TargetTypes);
@@ -82,11 +82,11 @@ namespace OpenRA.Mods.Common.AI
 
 			var u = squad.Units.Random(squad.Random);
 			var units = squad.World.FindActorsInCircle(u.CenterPosition, WDist.FromCells(DangerRadius)).ToList();
-			var ownBaseBuildingAround = units.Where(unit => unit.Owner == squad.Bot.Player && unit.Info.Traits.Contains<BuildingInfo>());
+			var ownBaseBuildingAround = units.Where(unit => unit.Owner == squad.Bot.Player && unit.Info.HasTraitInfo<BuildingInfo>());
 			if (ownBaseBuildingAround.Any())
 				return false;
 
-			var enemyAroundUnit = units.Where(unit => squad.Bot.Player.Stances[unit.Owner] == Stance.Enemy && unit.Info.Traits.Contains<AttackBaseInfo>());
+			var enemyAroundUnit = units.Where(unit => squad.Bot.Player.Stances[unit.Owner] == Stance.Enemy && unit.Info.HasTraitInfo<AttackBaseInfo>());
 			if (!enemyAroundUnit.Any())
 				return false;
 

--- a/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.AI
 					switch (TargetMetric)
 					{
 						case DecisionMetric.Value:
-							var valueInfo = a.Info.Traits.GetOrDefault<ValuedInfo>();
+							var valueInfo = a.Info.TraitInfoOrDefault<ValuedInfo>();
 							return (valueInfo != null) ? valueInfo.Cost * Attractiveness : 0;
 
 						case DecisionMetric.Health:

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				target = value;
 				if (target.Type == TargetType.Actor)
-					canHideUnderFog = target.Actor.Info.Traits.Contains<HiddenUnderFogInfo>();
+					canHideUnderFog = target.Actor.Info.HasTraitInfo<HiddenUnderFogInfo>();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				target = value;
 				if (target.Type == TargetType.Actor)
-					canHideUnderFog = target.Actor.HasTrait<HiddenUnderFog>();
+					canHideUnderFog = target.Actor.Info.Traits.Contains<HiddenUnderFogInfo>();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturn.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturn.cs
@@ -17,20 +17,16 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class HeliReturn : Activity
 	{
-		readonly AircraftInfo aircraftInfo;
 		readonly Helicopter heli;
-		readonly HelicopterInfo heliInfo;
 
 		public HeliReturn(Actor self)
 		{
-			aircraftInfo = self.Info.Traits.Get<AircraftInfo>();
 			heli = self.Trait<Helicopter>();
-			heliInfo = self.Info.Traits.Get<HelicopterInfo>();
 		}
 
-		public static Actor ChooseHelipad(Actor self)
+		public Actor ChooseHelipad(Actor self)
 		{
-			var rearmBuildings = self.Info.Traits.Get<HelicopterInfo>().RearmBuildings;
+			var rearmBuildings = heli.Info.RearmBuildings;
 			return self.World.Actors.Where(a => a.Owner == self.Owner).FirstOrDefault(
 				a => rearmBuildings.Contains(a.Info.Name) && !Reservable.IsReserved(a));
 		}
@@ -41,11 +37,11 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			var dest = ChooseHelipad(self);
-			var initialFacing = aircraftInfo.InitialFacing;
+			var initialFacing = heli.Info.InitialFacing;
 
 			if (dest == null)
 			{
-				var rearmBuildings = heliInfo.RearmBuildings;
+				var rearmBuildings = heli.Info.RearmBuildings;
 				var nearestHpad = self.World.ActorsWithTrait<Reservable>()
 									.Where(a => a.Actor.Owner == self.Owner && rearmBuildings.Contains(a.Actor.Info.Name))
 									.Select(a => a.Actor)

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -28,12 +28,12 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			this.dest = dest;
 			plane = self.Trait<Plane>();
-			planeInfo = self.Info.Traits.Get<PlaneInfo>();
+			planeInfo = self.Info.TraitInfo<PlaneInfo>();
 		}
 
 		public static Actor ChooseAirfield(Actor self, bool unreservedOnly)
 		{
-			var rearmBuildings = self.Info.Traits.Get<PlaneInfo>().RearmBuildings;
+			var rearmBuildings = self.Info.TraitInfo<PlaneInfo>().RearmBuildings;
 			return self.World.ActorsWithTrait<Reservable>()
 				.Where(a => a.Actor.Owner == self.Owner)
 				.Where(a => rearmBuildings.Contains(a.Actor.Info.Name)

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			// HACK: This would otherwise break targeting frozen actors
 			// The problem is that Shroud.IsTargetable returns false (as it should) for
 			// frozen actors, but we do want to explicitly target the underlying actor here.
-			if (!attack.Info.IgnoresVisibility && type == TargetType.Actor && !Target.Actor.Info.Traits.Contains<FrozenUnderFogInfo>() && !self.Owner.CanTargetActor(Target.Actor))
+			if (!attack.Info.IgnoresVisibility && type == TargetType.Actor && !Target.Actor.Info.HasTraitInfo<FrozenUnderFogInfo>() && !self.Owner.CanTargetActor(Target.Actor))
 				return NextActivity;
 
 			// Try to move within range

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			// HACK: This would otherwise break targeting frozen actors
 			// The problem is that Shroud.IsTargetable returns false (as it should) for
 			// frozen actors, but we do want to explicitly target the underlying actor here.
-			if (!attack.Info.IgnoresVisibility && type == TargetType.Actor && !Target.Actor.HasTrait<FrozenUnderFog>() && !self.Owner.CanTargetActor(Target.Actor))
+			if (!attack.Info.IgnoresVisibility && type == TargetType.Actor && !Target.Actor.Info.Traits.Contains<FrozenUnderFogInfo>() && !self.Owner.CanTargetActor(Target.Actor))
 				return NextActivity;
 
 			// Try to move within range

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			actor = target;
 			building = actor.TraitOrDefault<Building>();
-			capturesInfo = self.Info.Traits.Get<CapturesInfo>();
+			capturesInfo = self.Info.TraitInfo<CapturesInfo>();
 			capturable = target.Trait<Capturable>();
 			health = actor.Trait<Health>();
 		}

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -21,7 +21,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		readonly IMove movement;
 		readonly Harvester harv;
-		readonly HarvesterInfo harvInfo;
 
 		bool isDocking;
 		int chosenTicks;
@@ -30,7 +29,6 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			movement = self.Trait<IMove>();
 			harv = self.Trait<Harvester>();
-			harvInfo = self.Info.Traits.Get<HarvesterInfo>();
 		}
 
 		public override Activity Tick(Actor self)
@@ -57,7 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// No refineries exist; check again after delay defined in Harvester.
 			if (harv.LinkedProc == null)
-				return Util.SequenceActivities(new Wait(harvInfo.SearchForDeliveryBuildingDelay), this);
+				return Util.SequenceActivities(new Wait(harv.Info.SearchForDeliveryBuildingDelay), this);
 
 			var proc = harv.LinkedProc;
 			var iao = proc.Trait<IAcceptResources>();

--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			this.target = target;
 			capturable = target.Actor.Trait<ExternalCapturable>();
-			capturesInfo = self.Info.Traits.Get<ExternalCapturesInfo>();
+			capturesInfo = self.Info.TraitInfo<ExternalCapturesInfo>();
 			mobile = self.Trait<Mobile>();
 		}
 

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -34,9 +34,9 @@ namespace OpenRA.Mods.Common.Activities
 		public FindResources(Actor self)
 		{
 			harv = self.Trait<Harvester>();
-			harvInfo = self.Info.Traits.Get<HarvesterInfo>();
+			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			mobile = self.Trait<Mobile>();
-			mobileInfo = self.Info.Traits.Get<MobileInfo>();
+			mobileInfo = self.Info.TraitInfo<MobileInfo>();
 			resLayer = self.World.WorldActor.Trait<ResourceLayer>();
 			territory = self.World.WorldActor.TraitOrDefault<ResourceClaimLayer>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Activities
 		public HarvestResource(Actor self)
 		{
 			harv = self.Trait<Harvester>();
-			harvInfo = self.Info.Traits.Get<HarvesterInfo>();
+			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			facing = self.Trait<IFacing>();
 			territory = self.World.WorldActor.TraitOrDefault<ResourceClaimLayer>();
 			resLayer = self.World.WorldActor.Trait<ResourceLayer>();

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			var attack = self.Trait<AttackBase>();
 			targets = self.World.Actors.Where(a => self != a && !a.IsDead && a.IsInWorld && a.AppearsHostileTo(self)
-				&& a.HasTrait<Huntable>() && IsTargetable(a, self) && attack.HasAnyValidWeapons(Target.FromActor(a)));
+				&& a.Info.Traits.Contains<HuntableInfo>() && IsTargetable(a, self) && attack.HasAnyValidWeapons(Target.FromActor(a)));
 		}
 
 		bool IsTargetable(Actor self, Actor viewer)

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			var attack = self.Trait<AttackBase>();
 			targets = self.World.Actors.Where(a => self != a && !a.IsDead && a.IsInWorld && a.AppearsHostileTo(self)
-				&& a.Info.Traits.Contains<HuntableInfo>() && IsTargetable(a, self) && attack.HasAnyValidWeapons(Target.FromActor(a)));
+				&& a.Info.HasTraitInfo<HuntableInfo>() && IsTargetable(a, self) && attack.HasAnyValidWeapons(Target.FromActor(a)));
 		}
 
 		bool IsTargetable(Actor self, Actor viewer)

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				target = value;
 				if (target.Type == TargetType.Actor)
-					canHideUnderFog = target.Actor.HasTrait<HiddenUnderFog>();
+					canHideUnderFog = target.Actor.Info.Traits.Contains<HiddenUnderFogInfo>();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				target = value;
 				if (target.Type == TargetType.Actor)
-					canHideUnderFog = target.Actor.Info.Traits.Contains<HiddenUnderFogInfo>();
+					canHideUnderFog = target.Actor.Info.HasTraitInfo<HiddenUnderFogInfo>();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 			pos = self.TraitOrDefault<IPositionable>();
 
 			// Parachutable trait is a prerequisite for running this activity
-			para = self.Info.Traits.Get<ParachutableInfo>();
+			para = self.Info.TraitInfo<ParachutableInfo>();
 			fallVector = new WVec(0, 0, para.FallRate);
 			this.dropPosition = dropPosition;
 		}

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -48,7 +48,8 @@ namespace OpenRA.Mods.Common.Activities
 					continue;
 
 				// HACK to check if we are on the helipad/airfield/etc.
-				var hostBuilding = self.World.ActorMap.GetUnitsAt(self.Location).FirstOrDefault(a => a.HasTrait<Building>());
+				var hostBuilding = self.World.ActorMap.GetUnitsAt(self.Location)
+					.FirstOrDefault(a => a.Info.Traits.Contains<BuildingInfo>());
 
 				if (hostBuilding == null || !hostBuilding.IsInWorld)
 					return NextActivity;

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				// HACK to check if we are on the helipad/airfield/etc.
 				var hostBuilding = self.World.ActorMap.GetUnitsAt(self.Location)
-					.FirstOrDefault(a => a.Info.Traits.Contains<BuildingInfo>());
+					.FirstOrDefault(a => a.Info.HasTraitInfo<BuildingInfo>());
 
 				if (hostBuilding == null || !hostBuilding.IsInWorld)
 					return NextActivity;

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 		public Repair(Actor host)
 		{
 			this.host = host;
-			repairsUnits = host.Info.Traits.Get<RepairsUnitsInfo>();
+			repairsUnits = host.Info.TraitInfo<RepairsUnitsInfo>();
 		}
 
 		public override Activity Tick(Actor self)
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (remainingTicks == 0)
 			{
-				var unitCost = self.Info.Traits.Get<ValuedInfo>().Cost;
+				var unitCost = self.Info.TraitInfo<ValuedInfo>().Cost;
 				var hpToRepair = repairsUnits.HpPerStep;
 				var cost = Math.Max(1, (hpToRepair * unitCost * repairsUnits.ValuePercentage) / (health.MaxHP * 100));
 

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		public Sell(Actor self)
 		{
 			health = self.TraitOrDefault<Health>();
-			sellableInfo = self.Info.Traits.Get<SellableInfo>();
+			sellableInfo = self.Info.TraitInfo<SellableInfo>();
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -16,13 +16,13 @@ namespace OpenRA.Mods.Common.Activities
 	public class SpriteHarvesterDockSequence : HarvesterDockSequence
 	{
 		readonly WithSpriteBody wsb;
-		readonly WithDockingAnimation wda;
+		readonly WithDockingAnimationInfo wda;
 
 		public SpriteHarvesterDockSequence(Actor self, Actor refinery, int dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
 			: base(self, refinery, dockAngle, isDragRequired, dragOffset, dragLength)
 		{
 			wsb = self.Trait<WithSpriteBody>();
-			wda = self.Trait<WithDockingAnimation>();
+			wda = self.Info.Traits.Get<WithDockingAnimationInfo>();
 		}
 
 		public override Activity OnStateDock(Actor self)
@@ -30,14 +30,14 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 				trait.Docked();
 
-			wsb.PlayCustomAnimation(self, wda.Info.DockSequence, () => wsb.PlayCustomAnimationRepeating(self, wda.Info.DockLoopSequence));
+			wsb.PlayCustomAnimation(self, wda.DockSequence, () => wsb.PlayCustomAnimationRepeating(self, wda.DockLoopSequence));
 			dockingState = State.Loop;
 			return this;
 		}
 
 		public override Activity OnStateUndock(Actor self)
 		{
-			wsb.PlayCustomAnimationBackwards(self, wda.Info.DockSequence,
+			wsb.PlayCustomAnimationBackwards(self, wda.DockSequence,
 				() =>
 				{
 					dockingState = State.Complete;

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 			: base(self, refinery, dockAngle, isDragRequired, dragOffset, dragLength)
 		{
 			wsb = self.Trait<WithSpriteBody>();
-			wda = self.Info.Traits.Get<WithDockingAnimationInfo>();
+			wda = self.Info.TraitInfo<WithDockingAnimationInfo>();
 		}
 
 		public override Activity OnStateDock(Actor self)

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common
 			if (self.IsDead)
 				return false;
 
-			if (!self.HasTrait<IOccupySpace>())
+			if (!self.Info.Traits.Contains<IOccupySpace>())
 				return false;
 
 			if (!self.IsInWorld)
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common
 			if (stance == Stance.Ally)
 				return true;
 
-			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.HasTrait<IgnoresDisguise>())
+			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.Traits.Contains<IgnoresDisguiseInfo>())
 				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Ally;
 
 			return stance == Stance.Ally;
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common
 			if (stance == Stance.Ally)
 				return false;		/* otherwise, we'll hate friendly disguised spies */
 
-			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.HasTrait<IgnoresDisguise>())
+			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.Traits.Contains<IgnoresDisguiseInfo>())
 				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Enemy;
 
 			return stance == Stance.Enemy;

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common
 			if (self.IsDead)
 				return false;
 
-			if (!self.Info.Traits.Contains<IOccupySpace>())
+			if (!self.Info.HasTraitInfo<IOccupySpaceInfo>())
 				return false;
 
 			if (!self.IsInWorld)
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common
 			if (stance == Stance.Ally)
 				return true;
 
-			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.Traits.Contains<IgnoresDisguiseInfo>())
+			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.HasTraitInfo<IgnoresDisguiseInfo>())
 				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Ally;
 
 			return stance == Stance.Ally;
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common
 			if (stance == Stance.Ally)
 				return false;		/* otherwise, we'll hate friendly disguised spies */
 
-			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.Traits.Contains<IgnoresDisguiseInfo>())
+			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.HasTraitInfo<IgnoresDisguiseInfo>())
 				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Enemy;
 
 			return stance == Stance.Enemy;

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Commands
 						var leveluporder = new Order("DevLevelUp", actor, false);
 						leveluporder.ExtraData = (uint)level;
 
-						if (actor.Info.Traits.Contains<GainsExperienceInfo>())
+						if (actor.Info.HasTraitInfo<GainsExperienceInfo>())
 							world.IssueOrder(leveluporder);
 					}
 

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Commands
 						var leveluporder = new Order("DevLevelUp", actor, false);
 						leveluporder.ExtraData = (uint)level;
 
-						if (actor.HasTrait<GainsExperience>())
+						if (actor.Info.Traits.Contains<GainsExperienceInfo>())
 							world.IssueOrder(leveluporder);
 					}
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -116,10 +116,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var initDict = newActorReference.InitDict;
 
-				if (Actor.Traits.Contains<IFacingInfo>())
+				if (Actor.HasTraitInfo<IFacingInfo>())
 					initDict.Add(new FacingInit(facing));
 
-				if (Actor.Traits.Contains<TurretedInfo>())
+				if (Actor.HasTraitInfo<TurretedInfo>())
 					initDict.Add(new TurretFacingInit(facing));
 
 				editorLayer.Add(newActorReference);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Widgets
 			preview.GetScale = () => worldRenderer.Viewport.Zoom;
 			preview.IsVisible = () => editorWidget.CurrentBrush == this;
 
-			var buildingInfo = actor.Traits.GetOrDefault<BuildingInfo>();
+			var buildingInfo = actor.TraitInfoOrDefault<BuildingInfo>();
 			if (buildingInfo != null)
 			{
 				locationOffset = -FootprintUtils.AdjustForBuildingSize(buildingInfo);
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Widgets
 			td.Add(new FactionInit(owner.Faction));
 			preview.SetPreview(actor, td);
 
-			var ios = actor.Traits.GetOrDefault<IOccupySpaceInfo>();
+			var ios = actor.TraitInfoOrDefault<IOccupySpaceInfo>();
 			if (ios != null)
 				footprint = ios.OccupiedCells(actor, CPos.Zero)
 					.Select(c => c.Key - CPos.Zero)
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Widgets
 				cell += locationOffset;
 				newActorReference.Add(new LocationInit(cell));
 
-				var ios = Actor.Traits.GetOrDefault<IOccupySpaceInfo>();
+				var ios = Actor.TraitInfoOrDefault<IOccupySpaceInfo>();
 				if (ios != null && ios.SharesCell)
 				{
 					var subcell = editorLayer.FreeSubCellAt(cell);

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Effects
 				contrail.Update(pos);
 
 			if (ticks++ >= length || (info.Blockable && world.ActorMap
-				.GetUnitsAt(world.Map.CellContaining(pos)).Any(a => a.HasTrait<IBlocksProjectiles>())))
+				.GetUnitsAt(world.Map.CellContaining(pos)).Any(a => a.Info.Traits.Contains<IBlocksProjectilesInfo>())))
 				Explode(world);
 		}
 

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Effects
 				contrail.Update(pos);
 
 			if (ticks++ >= length || (info.Blockable && world.ActorMap
-				.GetUnitsAt(world.Map.CellContaining(pos)).Any(a => a.Info.Traits.Contains<IBlocksProjectilesInfo>())))
+				.GetUnitsAt(world.Map.CellContaining(pos)).Any(a => a.Info.HasTraitInfo<IBlocksProjectilesInfo>())))
 				Explode(world);
 		}
 

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Effects
 			var shouldExplode = (pos.Z < 0) // Hit the ground
 				|| (dist.LengthSquared < info.CloseEnough.LengthSquared) // Within range
 				|| (info.RangeLimit != 0 && ticks > info.RangeLimit) // Ran out of fuel
-				|| (info.Blockable && world.ActorMap.GetUnitsAt(cell).Any(a => a.Info.Traits.Contains<IBlocksProjectilesInfo>())) // Hit a wall or other blocking obstacle
+				|| (info.Blockable && world.ActorMap.GetUnitsAt(cell).Any(a => a.Info.HasTraitInfo<IBlocksProjectilesInfo>())) // Hit a wall or other blocking obstacle
 				|| !world.Map.Contains(cell) // This also avoids an IndexOutOfRangeException in GetTerrainInfo below.
 				|| (!string.IsNullOrEmpty(info.BoundToTerrainType) && world.Map.GetTerrainInfo(cell).Type != info.BoundToTerrainType); // Hit incompatible terrain
 

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Effects
 			var shouldExplode = (pos.Z < 0) // Hit the ground
 				|| (dist.LengthSquared < info.CloseEnough.LengthSquared) // Within range
 				|| (info.RangeLimit != 0 && ticks > info.RangeLimit) // Ran out of fuel
-				|| (info.Blockable && world.ActorMap.GetUnitsAt(cell).Any(a => a.HasTrait<IBlocksProjectiles>())) // Hit a wall or other blocking obstacle
+				|| (info.Blockable && world.ActorMap.GetUnitsAt(cell).Any(a => a.Info.Traits.Contains<IBlocksProjectilesInfo>())) // Hit a wall or other blocking obstacle
 				|| !world.Map.Contains(cell) // This also avoids an IndexOutOfRangeException in GetTerrainInfo below.
 				|| (!string.IsNullOrEmpty(info.BoundToTerrainType) && world.Map.GetTerrainInfo(cell).Type != info.BoundToTerrainType); // Hit incompatible terrain
 

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -33,10 +33,10 @@ namespace OpenRA.Mods.Common.Lint
 					emitError("Actor type `{0}` defines multiple default visibility types!".F(actorInfo.Key));
 				else
 				{
-					var vis = actorInfo.Value.Traits.GetOrDefault<HiddenUnderShroudInfo>();
+					var vis = actorInfo.Value.TraitInfoOrDefault<HiddenUnderShroudInfo>();
 					if (vis != null && vis.Type == VisibilityType.Footprint)
 					{
-						var ios = actorInfo.Value.Traits.GetOrDefault<IOccupySpaceInfo>();
+						var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();
 						if (ios == null)
 							emitError("Actor type `{0}` defines VisibilityType.Footprint in `{1}` but has no IOccupySpace traits!".F(actorInfo.Key, vis.GetType()));
 						else if (!ios.OccupiedCells(actorInfo.Value, CPos.Zero).Any())

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Lint
 				if (!string.IsNullOrWhiteSpace(player.Faction) && !factions.Contains(player.Faction))
 					emitError("Invalid faction {0} chosen for player {1}.".F(player.Faction, player.Name));
 
-			if (worldActor.Traits.Contains<MPStartLocationsInfo>())
+			if (worldActor.HasTraitInfo<MPStartLocationsInfo>())
 			{
 				var multiPlayers = players.Count(p => p.Value.Playable);
 				var spawns = map.ActorDefinitions.Where(a => a.Value.Value == "mpspawn");

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Lint
 				if (actorInfo.Key.StartsWith("^"))
 					continue;
 
-				var ios = actorInfo.Value.Traits.GetOrDefault<IOccupySpaceInfo>();
+				var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();
 				foreach (var rsi in actorInfo.Value.Traits.WithInterface<RevealsShroudInfo>())
 				{
 					if (rsi.Type == VisibilityType.CenterPosition)

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Lint
 			// TODO: this check is case insensitive while the real check in-game is not
 			foreach (var i in rules.Actors)
 			{
-				var bi = i.Value.Traits.GetOrDefault<BuildableInfo>();
+				var bi = i.Value.TraitInfoOrDefault<BuildableInfo>();
 				if (bi != null)
 					foreach (var prereq in bi.Prerequisites)
 						if (!prereq.StartsWith("~disabled"))

--- a/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 		{
-			if (!target.Info.Traits.Contains<T>() || !canTarget(target))
+			if (!target.Info.HasTraitInfo<T>() || !canTarget(target))
 				return false;
 
 			cursor = useEnterCursor(target) ? "enter" : "enter-blocked";

--- a/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class EnterAlliedActorTargeter<T> : UnitOrderTargeter
+	public class EnterAlliedActorTargeter<T> : UnitOrderTargeter where T : ITraitInfo
 	{
 		readonly Func<Actor, bool> canTarget;
 		readonly Func<Actor, bool> useEnterCursor;
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 		{
-			if (!target.HasTrait<T>() || !canTarget(target))
+			if (!target.Info.Traits.Contains<T>() || !canTarget(target))
 				return false;
 
 			cursor = useEnterCursor(target) ? "enter" : "enter-blocked";

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Orders
 						yield break;
 					}
 
-					if (world.Map.Rules.Actors[building].Traits.Contains<LineBuildInfo>())
+					if (world.Map.Rules.Actors[building].HasTraitInfo<LineBuildInfo>())
 						orderType = "LineBuild";
 				}
 
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Orders
 
 				cells.Add(topLeft, AcceptsPlug(topLeft, plugInfo));
 			}
-			else if (rules.Actors[building].Traits.Contains<LineBuildInfo>())
+			else if (rules.Actors[building].HasTraitInfo<LineBuildInfo>())
 			{
 				// Linebuild for walls.
 				if (buildingInfo.Dimensions.X != 1 || buildingInfo.Dimensions.Y != 1)

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Orders
 		public PlaceBuildingOrderGenerator(ProductionQueue queue, string name)
 		{
 			producer = queue.Actor;
-			placeBuildingInfo = producer.Owner.PlayerActor.Info.Traits.Get<PlaceBuildingInfo>();
+			placeBuildingInfo = producer.Owner.PlayerActor.Info.TraitInfo<PlaceBuildingInfo>();
 			building = name;
 
 			// Clear selection if using Left-Click Orders
@@ -46,9 +46,9 @@ namespace OpenRA.Mods.Common.Orders
 			var tileset = producer.World.TileSet.Id.ToLowerInvariant();
 
 			var info = map.Rules.Actors[building];
-			buildingInfo = info.Traits.Get<BuildingInfo>();
+			buildingInfo = info.TraitInfo<BuildingInfo>();
 
-			var buildableInfo = info.Traits.Get<BuildableInfo>();
+			var buildableInfo = info.TraitInfo<BuildableInfo>();
 			var mostLikelyProducer = queue.MostLikelyProducer();
 			faction = buildableInfo.ForceFaction
 				?? (mostLikelyProducer.Trait != null ? mostLikelyProducer.Trait.Faction : producer.Owner.Faction.InternalName);
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Orders
 				var orderType = "PlaceBuilding";
 				var topLeft = xy - FootprintUtils.AdjustForBuildingSize(buildingInfo);
 
-				var plugInfo = world.Map.Rules.Actors[building].Traits.GetOrDefault<PlugInfo>();
+				var plugInfo = world.Map.Rules.Actors[building].TraitInfoOrDefault<PlugInfo>();
 				if (plugInfo != null)
 				{
 					orderType = "PlacePlug";
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Orders
 
 			var cells = new Dictionary<CPos, bool>();
 
-			var plugInfo = rules.Actors[building].Traits.GetOrDefault<PlugInfo>();
+			var plugInfo = rules.Actors[building].TraitInfoOrDefault<PlugInfo>();
 			if (plugInfo != null)
 			{
 				if (buildingInfo.Dimensions.X != 1 || buildingInfo.Dimensions.Y != 1)

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Orders
 				yield break;
 
 			// Repair a building.
-			if (underCursor.Info.Traits.Contains<RepairableBuildingInfo>())
+			if (underCursor.Info.HasTraitInfo<RepairableBuildingInfo>())
 				yield return new Order("RepairBuilding", world.LocalPlayer.PlayerActor, false) { TargetActor = underCursor };
 
 			// Test for generic Repairable (used on units).

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Scripting
 			if (!Context.World.Map.Rules.Actors.TryGetValue(type, out ai))
 				throw new LuaException("Unknown actor type '{0}'".F(type));
 
-			var pi = ai.Traits.GetOrDefault<ICruiseAltitudeInfo>();
+			var pi = ai.TraitInfoOrDefault<ICruiseAltitudeInfo>();
 			return pi != null ? pi.GetCruiseAltitude().Length : 0;
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -137,10 +137,10 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 			else
 			{
-				var heli = transport.TraitOrDefault<Helicopter>();
+				var heli = transport.Info.Traits.GetOrDefault<HelicopterInfo>();
 				if (heli != null)
 				{
-					transport.QueueActivity(new Turn(transport, heli.Info.InitialFacing));
+					transport.QueueActivity(new Turn(transport, heli.InitialFacing));
 					transport.QueueActivity(new HeliLand(transport, true));
 					transport.QueueActivity(new Wait(15));
 				}

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Scripting
 
 			if (entryLocation.HasValue)
 			{
-				var pi = ai.Traits.GetOrDefault<AircraftInfo>();
+				var pi = ai.TraitInfoOrDefault<AircraftInfo>();
 				initDict.Add(new CenterPositionInit(owner.World.Map.CenterOfCell(entryLocation.Value) + new WVec(0, 0, pi != null ? pi.CruiseAltitude.Length : 0)));
 				initDict.Add(new LocationInit(entryLocation.Value));
 			}
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 			else
 			{
-				var heli = transport.Info.Traits.GetOrDefault<HelicopterInfo>();
+				var heli = transport.Info.TraitInfoOrDefault<HelicopterInfo>();
 				if (heli != null)
 				{
 					transport.QueueActivity(new Turn(transport, heli.InitialFacing));

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -26,15 +26,15 @@ namespace OpenRA.Mods.Common.Scripting
 		public CaptureProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			normalInfo = Self.Info.Traits.GetOrDefault<CapturesInfo>();
-			externalInfo = Self.Info.Traits.GetOrDefault<ExternalCapturesInfo>();
+			normalInfo = Self.Info.TraitInfoOrDefault<CapturesInfo>();
+			externalInfo = Self.Info.TraitInfoOrDefault<ExternalCapturesInfo>();
 		}
 
 		[Desc("Captures the target actor.")]
 		public void Capture(Actor target)
 		{
-			var normalCapturable = target.Info.Traits.GetOrDefault<CapturableInfo>();
-			var externalCapturable = target.Info.Traits.GetOrDefault<ExternalCapturableInfo>();
+			var normalCapturable = target.Info.TraitInfoOrDefault<CapturableInfo>();
+			var externalCapturable = target.Info.TraitInfoOrDefault<ExternalCapturableInfo>();
 
 			if (normalInfo != null && normalCapturable != null && normalInfo.CaptureTypes.Contains(normalCapturable.Type))
 				Self.QueueActivity(new CaptureActor(Self, target));

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Scripting
 			if (!target.IsValidFor(Self) || target.Type == TargetType.FrozenActor)
 				Log.Write("lua", "{1} is an invalid target for {0}!", Self, targetActor);
 
-			if (!targetActor.HasTrait<FrozenUnderFog>() && !Self.Owner.CanTargetActor(targetActor))
+			if (!targetActor.Info.Traits.Contains<FrozenUnderFogInfo>() && !Self.Owner.CanTargetActor(targetActor))
 				Log.Write("lua", "{1} is not revealed for player {0}!", Self.Owner, targetActor);
 
 			attackBase.AttackTarget(target, true, allowMove);

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Scripting
 			if (!target.IsValidFor(Self) || target.Type == TargetType.FrozenActor)
 				Log.Write("lua", "{1} is an invalid target for {0}!", Self, targetActor);
 
-			if (!targetActor.Info.Traits.Contains<FrozenUnderFogInfo>() && !Self.Owner.CanTargetActor(targetActor))
+			if (!targetActor.Info.HasTraitInfo<FrozenUnderFogInfo>() && !Self.Owner.CanTargetActor(targetActor))
 				Log.Write("lua", "{1} is not revealed for player {0}!", Self.Owner, targetActor);
 
 			attackBase.AttackTarget(target, true, allowMove);

--- a/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public DemolitionProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			info = Self.Info.Traits.Get<C4DemolitionInfo>();
+			info = Self.Info.TraitInfo<C4DemolitionInfo>();
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Guard the target actor.")]
 		public void Guard(Actor targetActor)
 		{
-			if (targetActor.HasTrait<Guardable>())
+			if (targetActor.Info.Traits.Contains<GuardableInfo>())
 				guard.GuardTarget(Self, Target.FromActor(targetActor));
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Guard the target actor.")]
 		public void Guard(Actor targetActor)
 		{
-			if (targetActor.Info.Traits.Contains<GuardableInfo>())
+			if (targetActor.Info.HasTraitInfo<GuardableInfo>())
 				guard.GuardTarget(Self, Target.FromActor(targetActor));
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public Actor[] GetGroundAttackers()
 		{
 			return Player.World.ActorsWithTrait<AttackBase>().Select(a => a.Actor)
-				.Where(a => a.Owner == Player && !a.IsDead && a.IsInWorld && a.HasTrait<Mobile>())
+				.Where(a => a.Owner == Player && !a.IsDead && a.IsInWorld && a.Info.Traits.Contains<MobileInfo>())
 				.ToArray();
 		}
 

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public Actor[] GetGroundAttackers()
 		{
 			return Player.World.ActorsWithTrait<AttackBase>().Select(a => a.Actor)
-				.Where(a => a.Owner == Player && !a.IsDead && a.IsInWorld && a.Info.Traits.Contains<MobileInfo>())
+				.Where(a => a.Owner == Player && !a.IsDead && a.IsInWorld && a.Info.HasTraitInfo<MobileInfo>())
 				.ToArray();
 		}
 

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.Common.Scripting
 		BuildableInfo GetBuildableInfo(string actorType)
 		{
 			var ri = Self.World.Map.Rules.Actors[actorType];
-			var bi = ri.Traits.GetOrDefault<BuildableInfo>();
+			var bi = ri.TraitInfoOrDefault<BuildableInfo>();
 
 			if (bi == null)
 				throw new LuaException("Actor of type {0} cannot be produced".F(actorType));
@@ -267,7 +267,7 @@ namespace OpenRA.Mods.Common.Scripting
 		BuildableInfo GetBuildableInfo(string actorType)
 		{
 			var ri = Player.World.Map.Rules.Actors[actorType];
-			var bi = ri.Traits.GetOrDefault<BuildableInfo>();
+			var bi = ri.TraitInfoOrDefault<BuildableInfo>();
 
 			if (bi == null)
 				throw new LuaException("Actor of type {0} cannot be produced".F(actorType));

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 				return WVec.Zero;
 
 			return self.World.FindActorsInCircle(self.CenterPosition, info.IdealSeparation)
-				.Where(a => !a.IsDead && a.Info.HasTraitInfo<AircraftInfo>() && a.Info.Traits.Get<AircraftInfo>().CruiseAltitude == info.CruiseAltitude)
+				.Where(a => !a.IsDead && a.Info.HasTraitInfo<AircraftInfo>() && a.Info.TraitInfo<AircraftInfo>().CruiseAltitude == info.CruiseAltitude)
 				.Select(GetRepulsionForce)
 				.Aggregate(WVec.Zero, (a, b) => a + b);
 		}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 				firstTick = false;
 
 				// TODO: Aircraft husks don't properly unreserve.
-				if (self.Info.Traits.Contains<FallsToEarthInfo>())
+				if (self.Info.HasTraitInfo<FallsToEarthInfo>())
 					return;
 
 				ReserveSpawnBuilding();
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 				return WVec.Zero;
 
 			return self.World.FindActorsInCircle(self.CenterPosition, info.IdealSeparation)
-				.Where(a => !a.IsDead && a.Info.Traits.Contains<AircraftInfo>() && a.Info.Traits.Get<AircraftInfo>().CruiseAltitude == info.CruiseAltitude)
+				.Where(a => !a.IsDead && a.Info.HasTraitInfo<AircraftInfo>() && a.Info.Traits.Get<AircraftInfo>().CruiseAltitude == info.CruiseAltitude)
 				.Select(GetRepulsionForce)
 				.Aggregate(WVec.Zero, (a, b) => a + b);
 		}
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Common.Traits
 				return null; // not on the ground.
 
 			return self.World.ActorMap.GetUnitsAt(self.Location)
-				.FirstOrDefault(a => a.Info.Traits.Contains<ReservableInfo>());
+				.FirstOrDefault(a => a.Info.HasTraitInfo<ReservableInfo>());
 		}
 
 		protected void ReserveSpawnBuilding()

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class AircraftInfo : ITraitInfo, IFacingInfo, IOccupySpaceInfo, ICruiseAltitudeInfo, UsesInit<LocationInit>, UsesInit<FacingInit>
+	public class AircraftInfo : IPositionableInfo, IFacingInfo, IOccupySpaceInfo, ICruiseAltitudeInfo, UsesInit<LocationInit>, UsesInit<FacingInit>
 	{
 		public readonly WDist CruiseAltitude = new WDist(1280);
 		public readonly WDist IdealSeparation = new WDist(1706);
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 				firstTick = false;
 
 				// TODO: Aircraft husks don't properly unreserve.
-				if (self.HasTrait<FallsToEarth>())
+				if (self.Info.Traits.Contains<FallsToEarthInfo>())
 					return;
 
 				ReserveSpawnBuilding();
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 				return WVec.Zero;
 
 			return self.World.FindActorsInCircle(self.CenterPosition, info.IdealSeparation)
-				.Where(a => !a.IsDead && a.HasTrait<Aircraft>() && a.Info.Traits.Get<AircraftInfo>().CruiseAltitude == info.CruiseAltitude)
+				.Where(a => !a.IsDead && a.Info.Traits.Contains<AircraftInfo>() && a.Info.Traits.Get<AircraftInfo>().CruiseAltitude == info.CruiseAltitude)
 				.Select(GetRepulsionForce)
 				.Aggregate(WVec.Zero, (a, b) => a + b);
 		}
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Common.Traits
 				return null; // not on the ground.
 
 			return self.World.ActorMap.GetUnitsAt(self.Location)
-				.FirstOrDefault(a => a.HasTrait<Reservable>());
+				.FirstOrDefault(a => a.Info.Traits.Contains<ReservableInfo>());
 		}
 
 		protected void ReserveSpawnBuilding()
@@ -341,7 +341,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<Building>("Enter", 5,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5,
 					target => AircraftCanEnter(target), target => !Reservable.IsReserved(target));
 
 				yield return new AircraftMoveOrderTargeter(info);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool IsReachableTarget(Target target, bool allowMove)
 		{
 			return HasAnyValidWeapons(target)
-				&& (target.IsInRange(self.CenterPosition, GetMaximumRange()) || (allowMove && self.Info.Traits.Contains<IMoveInfo>()));
+				&& (target.IsInRange(self.CenterPosition, GetMaximumRange()) || (allowMove && self.Info.HasTraitInfo<IMoveInfo>()));
 		}
 
 		class AttackOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool IsReachableTarget(Target target, bool allowMove)
 		{
 			return HasAnyValidWeapons(target)
-				&& (target.IsInRange(self.CenterPosition, GetMaximumRange()) || (allowMove && self.HasTrait<IMove>()));
+				&& (target.IsInRange(self.CenterPosition, GetMaximumRange()) || (allowMove && self.Info.Traits.Contains<IMoveInfo>()));
 		}
 
 		class AttackOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -81,8 +81,8 @@ namespace OpenRA.Mods.Common.Traits
 				var weapon = attack.ChooseArmamentForTarget(target);
 				if (weapon != null)
 				{
-					var targetIsMobile = (target.Type == TargetType.Actor && target.Actor.Info.Traits.Contains<IMoveInfo>())
-						|| (target.Type == TargetType.FrozenActor && target.FrozenActor.Info.Traits.Contains<IMoveInfo>());
+					var targetIsMobile = (target.Type == TargetType.Actor && target.Actor.Info.HasTraitInfo<IMoveInfo>())
+						|| (target.Type == TargetType.FrozenActor && target.FrozenActor.Info.HasTraitInfo<IMoveInfo>());
 
 					// Try and sit at least one cell closer than the max range to give some leeway if the target starts moving.
 					var maxRange = targetIsMobile ? new WDist(Math.Max(weapon.Weapon.MinRange.Length, weapon.Weapon.Range.Length - 1024))

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -81,8 +81,8 @@ namespace OpenRA.Mods.Common.Traits
 				var weapon = attack.ChooseArmamentForTarget(target);
 				if (weapon != null)
 				{
-					var targetIsMobile = (target.Type == TargetType.Actor && target.Actor.HasTrait<IMove>())
-						|| (target.Type == TargetType.FrozenActor && target.FrozenActor.Info.Traits.Contains<IMove>());
+					var targetIsMobile = (target.Type == TargetType.Actor && target.Actor.Info.Traits.Contains<IMoveInfo>())
+						|| (target.Type == TargetType.FrozenActor && target.FrozenActor.Info.Traits.Contains<IMoveInfo>());
 
 					// Try and sit at least one cell closer than the max range to give some leeway if the target starts moving.
 					var maxRange = targetIsMobile ? new WDist(Math.Max(weapon.Weapon.MinRange.Length, weapon.Weapon.Range.Length - 1024))

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Traits
 			return inRange
 				.Where(a =>
 					a.AppearsHostileTo(self) &&
-					!a.HasTrait<AutoTargetIgnore>() &&
+					!a.Info.Traits.Contains<AutoTargetIgnoreInfo>() &&
 					attack.HasAnyValidWeapons(Target.FromActor(a)) &&
 					self.Owner.CanTargetActor(a))
 				.ClosestTo(self);

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Traits
 			return inRange
 				.Where(a =>
 					a.AppearsHostileTo(self) &&
-					!a.Info.Traits.Contains<AutoTargetIgnoreInfo>() &&
+					!a.Info.HasTraitInfo<AutoTargetIgnoreInfo>() &&
 					attack.HasAnyValidWeapons(Target.FromActor(a)) &&
 					self.Owner.CanTargetActor(a))
 				.ClosestTo(self);

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -15,6 +15,6 @@ namespace OpenRA.Mods.Common.Traits
 {
 	// TODO: Add functionality like a customizable Height that is compared to projectile altitude
 	[Desc("This actor blocks bullets and missiles with 'Blockable' property.")]
-	public class BlocksProjectilesInfo : TraitInfo<BlocksProjectiles> { }
+	public class BlocksProjectilesInfo : TraitInfo<BlocksProjectiles>, IBlocksProjectilesInfo { }
 	public class BlocksProjectiles : IBlocksProjectiles { }
 }

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				// If a sprite actor has neither custom QuantizedFacings nor a trait implementing IQuantizeBodyOrientationInfo, throw
 				if (qboi == null)
 				{
-					if (self.HasTrait<ISpriteBody>())
+					if (self.Info.Traits.Contains<ISpriteBodyInfo>())
 						throw new InvalidOperationException("Actor '" + self.Info.Name + "' has a sprite body but no facing quantization."
 							+ " Either add the QuantizeFacingsFromSequence trait or set custom QuantizedFacings on BodyOrientation.");
 					else

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				// If a sprite actor has neither custom QuantizedFacings nor a trait implementing IQuantizeBodyOrientationInfo, throw
 				if (qboi == null)
 				{
-					if (self.Info.Traits.Contains<ISpriteBodyInfo>())
+					if (self.Info.HasTraitInfo<ISpriteBodyInfo>())
 						throw new InvalidOperationException("Actor '" + self.Info.Name + "' has a sprite body but no facing quantization."
 							+ " Either add the QuantizeFacingsFromSequence trait or set custom QuantizedFacings on BodyOrientation.");
 					else

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (info.QuantizedFacings >= 0)
 					return info.QuantizedFacings;
 
-				var qboi = self.Info.Traits.GetOrDefault<IQuantizeBodyOrientationInfo>();
+				var qboi = self.Info.TraitInfoOrDefault<IQuantizeBodyOrientationInfo>();
 
 				// If a sprite actor has neither custom QuantizedFacings nor a trait implementing IQuantizeBodyOrientationInfo, throw
 				if (qboi == null)

--- a/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bib.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Palette != null)
 				p = init.WorldRenderer.Palette(Palette);
 
-			var bi = init.Actor.Traits.Get<BuildingInfo>();
+			var bi = init.Actor.TraitInfo<BuildingInfo>();
 
 			var width = bi.Dimensions.X;
 			var bibOffset = bi.Dimensions.Y - 1;
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			rs = self.Trait<RenderSprites>();
-			bi = self.Info.Traits.Get<BuildingInfo>();
+			bi = self.Info.TraitInfo<BuildingInfo>();
 		}
 
 		public void AddedToWorld(Actor self)

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			type = self.Info.Name;
 			isDangling = new Lazy<bool>(() => huts[0] == huts[1] && (neighbours[0] == null || neighbours[1] == null));
-			building = self.Info.Traits.Get<BuildingInfo>();
+			building = self.Info.TraitInfo<BuildingInfo>();
 		}
 
 		public Bridge Neighbour(int direction) { return neighbours[direction]; }

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var c in footprint.Keys)
 				foreach (var a in self.World.ActorMap.GetUnitsAt(c))
-					if (a.Info.Traits.Contains<IPositionableInfo>() && !a.Trait<IPositionable>().CanEnterCell(c))
+					if (a.Info.HasTraitInfo<IPositionableInfo>() && !a.Trait<IPositionable>().CanEnterCell(c))
 						a.Kill(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var c in footprint.Keys)
 				foreach (var a in self.World.ActorMap.GetUnitsAt(c))
-					if (a.HasTrait<IPositionable>() && !a.Trait<IPositionable>().CanEnterCell(c))
+					if (a.Info.Traits.Contains<IPositionableInfo>() && !a.Trait<IPositionable>().CanEnterCell(c))
 						a.Kill(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	class Bridge : IRender, INotifyDamageStateChanged
 	{
-		readonly Building building;
+		readonly BuildingInfo building;
 		readonly Bridge[] neighbours = new Bridge[2];
 		readonly BridgeHut[] huts = new BridgeHut[2]; // Huts before this / first & after this / last
 		readonly Health health;
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			type = self.Info.Name;
 			isDangling = new Lazy<bool>(() => huts[0] == huts[1] && (neighbours[0] == null || neighbours[1] == null));
-			building = self.Trait<Building>();
+			building = self.Info.Traits.Get<BuildingInfo>();
 		}
 
 		public Bridge Neighbour(int direction) { return neighbours[direction]; }
@@ -173,7 +173,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IRenderable[] TemplateRenderables(WorldRenderer wr, PaletteReference palette, ushort template)
 		{
-			var offset = FootprintUtils.CenterOffset(self.World, building.Info).Y + 1024;
+			var offset = FootprintUtils.CenterOffset(self.World, building).Y + 1024;
 
 			return footprint.Select(c => (IRenderable)(new SpriteRenderable(
 				wr.Theater.TileSprite(new TerrainTile(template, c.Value)),

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -64,8 +64,8 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var buildingMaxBounds = Dimensions;
-			var buildingTraits = world.Map.Rules.Actors[buildingName].Traits;
-			if (buildingTraits.Contains<BibInfo>() && !buildingTraits.Get<BibInfo>().HasMinibib)
+			var bibInfo = world.Map.Rules.Actors[buildingName].TraitInfoOrDefault<BibInfo>();
+			if (bibInfo != null && !bibInfo.HasMinibib)
 				buildingMaxBounds += new CVec(0, 1);
 
 			var scanStart = world.Map.Clamp(topLeft - new CVec(Adjacent, Adjacent));

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -87,12 +87,12 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						var unitsAtPos = world.ActorMap.GetUnitsAt(pos).Where(a => a.IsInWorld
 							&& (a.Owner == p || (allyBuildRadius && a.Owner.Stances[p] == Stance.Ally))
-							&& a.HasTrait<GivesBuildableArea>());
+							&& a.Info.Traits.Contains<GivesBuildableAreaInfo>());
 
 						if (unitsAtPos.Any())
 							nearnessCandidates.Add(pos);
 					}
-					else if (buildingAtPos.IsInWorld && buildingAtPos.HasTrait<GivesBuildableArea>()
+					else if (buildingAtPos.IsInWorld && buildingAtPos.Info.Traits.Contains<GivesBuildableAreaInfo>()
 						&& (buildingAtPos.Owner == p || (allyBuildRadius && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
 						nearnessCandidates.Add(pos);
 				}
@@ -164,7 +164,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Created(Actor self)
 		{
-			if (SkipMakeAnimation || !self.HasTrait<WithMakeAnimation>())
+			if (SkipMakeAnimation || !self.Info.Traits.Contains<WithMakeAnimationInfo>())
 				NotifyBuildingComplete(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -87,12 +87,12 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						var unitsAtPos = world.ActorMap.GetUnitsAt(pos).Where(a => a.IsInWorld
 							&& (a.Owner == p || (allyBuildRadius && a.Owner.Stances[p] == Stance.Ally))
-							&& a.Info.Traits.Contains<GivesBuildableAreaInfo>());
+							&& a.Info.HasTraitInfo<GivesBuildableAreaInfo>());
 
 						if (unitsAtPos.Any())
 							nearnessCandidates.Add(pos);
 					}
-					else if (buildingAtPos.IsInWorld && buildingAtPos.Info.Traits.Contains<GivesBuildableAreaInfo>()
+					else if (buildingAtPos.IsInWorld && buildingAtPos.Info.HasTraitInfo<GivesBuildableAreaInfo>()
 						&& (buildingAtPos.Owner == p || (allyBuildRadius && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
 						nearnessCandidates.Add(pos);
 				}
@@ -164,7 +164,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Created(Actor self)
 		{
-			if (SkipMakeAnimation || !self.Info.Traits.Contains<WithMakeAnimationInfo>())
+			if (SkipMakeAnimation || !self.Info.HasTraitInfo<WithMakeAnimationInfo>())
 				NotifyBuildingComplete(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			world.ActorAdded += a =>
 			{
-				var b = a.Info.Traits.GetOrDefault<BuildingInfo>();
+				var b = a.Info.TraitInfoOrDefault<BuildingInfo>();
 				if (b == null)
 					return;
 
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			world.ActorRemoved += a =>
 			{
-				var b = a.Info.Traits.GetOrDefault<BuildingInfo>();
+				var b = a.Info.TraitInfoOrDefault<BuildingInfo>();
 				if (b == null)
 					return;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -31,22 +31,22 @@ namespace OpenRA.Mods.Common.Traits
 
 			world.ActorAdded += a =>
 			{
-				var b = a.TraitOrDefault<Building>();
+				var b = a.Info.Traits.GetOrDefault<BuildingInfo>();
 				if (b == null)
 					return;
 
-				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
+				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b, a.Location))
 					if (influence.Contains(u) && influence[u] == null)
 						influence[u] = a;
 			};
 
 			world.ActorRemoved += a =>
 			{
-				var b = a.TraitOrDefault<Building>();
+				var b = a.Info.Traits.GetOrDefault<BuildingInfo>();
 				if (b == null)
 					return;
 
-				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b.Info, a.Location))
+				foreach (var u in FootprintUtils.Tiles(map.Rules, a.Info.Name, b, a.Location))
 					if (influence.Contains(u) && influence[u] == a)
 						influence[u] = null;
 			};

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public static IEnumerable<CPos> GetLineBuildCells(World world, CPos location, string name, BuildingInfo bi)
 		{
-			var lbi = world.Map.Rules.Actors[name].Traits.Get<LineBuildInfo>();
+			var lbi = world.Map.Rules.Actors[name].TraitInfo<LineBuildInfo>();
 			var topLeft = location;	// 1x1 assumption!
 
 			if (world.IsCellBuildable(topLeft, bi))
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 					// Cell contains an actor. Is it the type we want?
 					if (world.ActorsWithTrait<LineBuildNode>().Any(a =>
 					(a.Actor.Location == cell &&
-						a.Actor.Info.Traits.Get<LineBuildNodeInfo>()
+						a.Actor.Info.TraitInfo<LineBuildNodeInfo>()
 						.Types.Overlaps(lbi.NodeTypes))))
 						dirs[d] = i; // Cell contains actor of correct type
 					else

--- a/OpenRA.Mods.Common/Traits/Buildings/FootprintUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FootprintUtils.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var footprint = buildingInfo.Footprint.Where(x => !char.IsWhiteSpace(x));
 
-			var buildingTraits = rules.Actors[name].Traits;
-			if (buildingTraits.Contains<BibInfo>() && !buildingTraits.Get<BibInfo>().HasMinibib)
+			var bibInfo = rules.Actors[name].TraitInfoOrDefault<BibInfo>();
+			if (bibInfo != null && !bibInfo.HasMinibib)
 			{
 				dim += new CVec(0, 1);
 				footprint = footprint.Concat(new char[dim.X]);
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public static IEnumerable<CPos> Tiles(Actor a)
 		{
-			return Tiles(a.World.Map.Rules, a.Info.Name, a.Info.Traits.Get<BuildingInfo>(), a.Location);
+			return Tiles(a.World.Map.Rules, a.Info.Name, a.Info.TraitInfo<BuildingInfo>(), a.Location);
 		}
 
 		public static IEnumerable<CPos> UnpathableTiles(string name, BuildingInfo buildingInfo, CPos position)

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// TODO: THIS IS SHIT
 			// Cancel existing primaries
-			foreach (var p in self.Info.Traits.Get<ProductionInfo>().Produces)
+			foreach (var p in self.Info.TraitInfo<ProductionInfo>().Produces)
 			{
 				var productionType = p;		// benign closure hazard
 				foreach (var b in self.World
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 					.Where(a =>
 						a.Actor.Owner == self.Owner &&
 						a.Trait.IsPrimary &&
-						a.Actor.Info.Traits.Get<ProductionInfo>().Produces.Contains(productionType)))
+						a.Actor.Info.TraitInfo<ProductionInfo>().Produces.Contains(productionType)))
 					b.Trait.SetPrimaryProducer(b.Actor, false);
 			}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RefineryInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
+	public class RefineryInfo : IAcceptResourcesInfo, Requires<WithSpriteBodyInfo>
 	{
 		[Desc("Actual harvester facing when docking, 0-255 counter-clock-wise.")]
 		public readonly int DockAngle = 0;

--- a/OpenRA.Mods.Common/Traits/Capturable.cs
+++ b/OpenRA.Mods.Common/Traits/Capturable.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanBeTargetedBy(Actor captor, Player owner)
 		{
-			var c = captor.Info.Traits.GetOrDefault<CapturesInfo>();
+			var c = captor.Info.TraitInfoOrDefault<CapturesInfo>();
 			if (c == null)
 				return false;
 

--- a/OpenRA.Mods.Common/Traits/Capturable.cs
+++ b/OpenRA.Mods.Common/Traits/Capturable.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanBeTargetedBy(Actor captor, Player owner)
 		{
-			var c = captor.TraitOrDefault<Captures>();
+			var c = captor.Info.Traits.GetOrDefault<CapturesInfo>();
 			if (c == null)
 				return false;
 
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (playerRelationship == Stance.Neutral && !AllowNeutral)
 				return false;
 
-			if (!c.Info.CaptureTypes.Contains(Type))
+			if (!c.CaptureTypes.Contains(Type))
 				return false;
 
 			return true;

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				var c = target.Info.Traits.GetOrDefault<CapturableInfo>();
+				var c = target.Info.TraitInfoOrDefault<CapturableInfo>();
 				if (c == null || !c.CanBeTargetedBy(self, target.Owner))
 				{
 					cursor = "enter-blocked";
@@ -109,14 +109,14 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
-				var c = target.Info.Traits.GetOrDefault<CapturableInfo>();
+				var c = target.Info.TraitInfoOrDefault<CapturableInfo>();
 				if (c == null || !c.CanBeTargetedBy(self, target.Owner))
 				{
 					cursor = "enter-blocked";
 					return false;
 				}
 
-				var health = target.Info.Traits.GetOrDefault<HealthInfo>();
+				var health = target.Info.TraitInfoOrDefault<HealthInfo>();
 				var lowEnoughHealth = target.HP <= c.CaptureThreshold * health.HP;
 
 				cursor = !sabotage || lowEnoughHealth || target.Owner.NonCombatant

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			helicopter = self.TraitOrDefault<Helicopter>();
 		}
 
-		static int GetWeight(Actor a) { return a.Info.Traits.Get<PassengerInfo>().Weight; }
+		static int GetWeight(Actor a) { return a.Info.TraitInfo<PassengerInfo>().Weight; }
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
@@ -268,7 +268,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var c in cargo)
 			{
-				var pi = c.Info.Traits.Get<PassengerInfo>();
+				var pi = c.Info.TraitInfo<PassengerInfo>();
 				if (n < pi.Weight)
 					return pi.PipType;
 				else

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public CombatDebugOverlay(Actor self)
 		{
-			healthInfo = self.Info.Traits.GetOrDefault<HealthInfo>();
+			healthInfo = self.Info.TraitInfoOrDefault<HealthInfo>();
 			attack = Exts.Lazy(() => self.TraitOrDefault<AttackBase>());
 			coords = Exts.Lazy(() => self.Trait<BodyOrientation>());
 

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -26,15 +26,15 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly DeveloperMode devMode;
 
+		readonly HealthInfo healthInfo;
 		Lazy<AttackBase> attack;
 		Lazy<BodyOrientation> coords;
-		Lazy<Health> health;
 
 		public CombatDebugOverlay(Actor self)
 		{
+			healthInfo = self.Info.Traits.GetOrDefault<HealthInfo>();
 			attack = Exts.Lazy(() => self.TraitOrDefault<AttackBase>());
 			coords = Exts.Lazy(() => self.Trait<BodyOrientation>());
-			health = Exts.Lazy(() => self.TraitOrDefault<Health>());
 
 			var localPlayer = self.World.LocalPlayer;
 			devMode = localPlayer != null ? localPlayer.PlayerActor.Trait<DeveloperMode>() : null;
@@ -45,8 +45,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (devMode == null || !devMode.ShowCombatGeometry)
 				return;
 
-			if (health.Value != null)
-				wr.DrawRangeCircle(self.CenterPosition, health.Value.Info.Radius, Color.Red);
+			if (healthInfo != null)
+				wr.DrawRangeCircle(self.CenterPosition, healthInfo.Radius, Color.Red);
 
 			// No armaments to draw
 			if (attack.Value == null)
@@ -96,11 +96,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (devMode == null || !devMode.ShowCombatGeometry || e.Damage == 0)
 				return;
 
-			var health = self.TraitOrDefault<Health>();
-			if (health == null)
+			if (healthInfo == null)
 				return;
 
-			var damageText = "{0} ({1}%)".F(-e.Damage, e.Damage * 100 / health.MaxHP);
+			var maxHP = healthInfo.HP > 0 ? healthInfo.HP : 1;
+			var damageText = "{0} ({1}%)".F(-e.Damage, e.Damage * 100 / maxHP);
 
 			self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.Owner.Color.RGB, damageText, 30)));
 		}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			var collector = landedOn.FirstOrDefault(a =>
 			{
 				// Mobile is (currently) the only trait that supports crushing
-				var mi = a.Info.Traits.GetOrDefault<MobileInfo>();
+				var mi = a.Info.TraitInfoOrDefault<MobileInfo>();
 				if (mi == null)
 					return false;
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class CrateInfo : ITraitInfo, IOccupySpaceInfo, Requires<RenderSpritesInfo>
+	class CrateInfo : IPositionableInfo, IOccupySpaceInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Length of time (in seconds) until the crate gets removed automatically. " +
 			"A value of zero disables auto-removal.")]

--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Restrict duplicate count to a maximum value
 			if (info.MaxDuplicateValue > 0)
 			{
-				var vi = collector.Info.Traits.GetOrDefault<ValuedInfo>();
+				var vi = collector.Info.TraitInfoOrDefault<ValuedInfo>();
 				if (vi != null && vi.Cost > 0)
 					duplicates = Math.Min(duplicates, info.MaxDuplicateValue / vi.Cost);
 			}

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<CPos> GetSuitableCells(CPos near, string unitName)
 		{
-			var mi = self.World.Map.Rules.Actors[unitName].Traits.Get<MobileInfo>();
+			var mi = self.World.Map.Rules.Actors[unitName].TraitInfo<MobileInfo>();
 
 			for (var i = -1; i < 2; i++)
 				for (var j = -1; j < 2; j++)

--- a/OpenRA.Mods.Common/Traits/CustomBuildTimeValue.cs
+++ b/OpenRA.Mods.Common/Traits/CustomBuildTimeValue.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (csv != null)
 				return csv.Value;
 
-			var cost = a.Traits.Contains<ValuedInfo>() ? a.Traits.Get<ValuedInfo>().Cost : 0;
+			var cost = a.HasTraitInfo<ValuedInfo>() ? a.Traits.Get<ValuedInfo>().Cost : 0;
 			var time = cost
 							* (25 * 60) /* frames per min */
 							/ 1000;

--- a/OpenRA.Mods.Common/Traits/CustomBuildTimeValue.cs
+++ b/OpenRA.Mods.Common/Traits/CustomBuildTimeValue.cs
@@ -26,11 +26,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static int GetBuildTime(this ActorInfo a)
 		{
-			var csv = a.Traits.GetOrDefault<CustomBuildTimeValueInfo>();
+			var csv = a.TraitInfoOrDefault<CustomBuildTimeValueInfo>();
 			if (csv != null)
 				return csv.Value;
 
-			var cost = a.HasTraitInfo<ValuedInfo>() ? a.Traits.Get<ValuedInfo>().Cost : 0;
+			var cost = a.HasTraitInfo<ValuedInfo>() ? a.TraitInfo<ValuedInfo>().Cost : 0;
 			var time = cost
 							* (25 * 60) /* frames per min */
 							/ 1000;

--- a/OpenRA.Mods.Common/Traits/CustomSellValue.cs
+++ b/OpenRA.Mods.Common/Traits/CustomSellValue.cs
@@ -25,10 +25,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static int GetSellValue(this Actor a)
 		{
-			var csv = a.Info.Traits.GetOrDefault<CustomSellValueInfo>();
+			var csv = a.Info.TraitInfoOrDefault<CustomSellValueInfo>();
 			if (csv != null) return csv.Value;
 
-			var valued = a.Info.Traits.GetOrDefault<ValuedInfo>();
+			var valued = a.Info.TraitInfoOrDefault<ValuedInfo>();
 			if (valued != null) return valued.Cost;
 
 			return 0;

--- a/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
@@ -51,8 +51,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!correctFaction)
 				return;
 
-			var csv = self.Info.Traits.GetOrDefault<CustomSellValueInfo>();
-			var valued = self.Info.Traits.GetOrDefault<ValuedInfo>();
+			var csv = self.Info.TraitInfoOrDefault<CustomSellValueInfo>();
+			var valued = self.Info.TraitInfoOrDefault<ValuedInfo>();
 			var cost = csv != null ? csv.Value : (valued != null ? valued.Cost : 0);
 
 			var health = self.TraitOrDefault<Health>();
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			dudesValue /= 100;
 
 			var eligibleLocations = FootprintUtils.Tiles(self).ToList();
-			var actorTypes = info.ActorTypes.Select(a => new { Name = a, Cost = self.World.Map.Rules.Actors[a].Traits.Get<ValuedInfo>().Cost }).ToList();
+			var actorTypes = info.ActorTypes.Select(a => new { Name = a, Cost = self.World.Map.Rules.Actors[a].TraitInfo<ValuedInfo>().Cost }).ToList();
 
 			while (eligibleLocations.Count > 0 && actorTypes.Any(a => a.Cost <= dudesValue))
 			{

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				if (!target.HasTrait<EngineerRepairable>())
+				if (!target.Info.Traits.Contains<EngineerRepairableInfo>())
 					return false;
 
 				if (self.Owner.Stances[target.Owner] != Stance.Ally)
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
-				if (!target.Info.Traits.Contains<EngineerRepairable>())
+				if (!target.Info.Traits.Contains<EngineerRepairableInfo>())
 					return false;
 
 				if (self.Owner.Stances[target.Owner] != Stance.Ally)

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				if (!target.Info.Traits.Contains<EngineerRepairableInfo>())
+				if (!target.Info.HasTraitInfo<EngineerRepairableInfo>())
 					return false;
 
 				if (self.Owner.Stances[target.Owner] != Stance.Ally)
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
-				if (!target.Info.Traits.Contains<EngineerRepairableInfo>())
+				if (!target.Info.HasTraitInfo<EngineerRepairableInfo>())
 					return false;
 
 				if (self.Owner.Stances[target.Owner] != Stance.Ally)

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanBeTargetedBy(Actor captor, Player owner)
 		{
-			var c = captor.Info.Traits.GetOrDefault<ExternalCapturesInfo>();
+			var c = captor.Info.TraitInfoOrDefault<ExternalCapturesInfo>();
 			if (c == null)
 				return false;
 

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanBeTargetedBy(Actor captor, Player owner)
 		{
-			var c = captor.TraitOrDefault<ExternalCaptures>();
+			var c = captor.Info.Traits.GetOrDefault<ExternalCapturesInfo>();
 			if (c == null)
 				return false;
 
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (playerRelationship == Stance.Neutral && !AllowNeutral)
 				return false;
 
-			if (!c.Info.CaptureTypes.Contains(Type))
+			if (!c.CaptureTypes.Contains(Type))
 				return false;
 
 			return true;

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (frozen == null)
 					return false;
 
-				var ci = frozen.Info.Traits.GetOrDefault<ExternalCapturableInfo>();
+				var ci = frozen.Info.TraitInfoOrDefault<ExternalCapturableInfo>();
 				return ci != null && ci.CanBeTargetedBy(self, frozen.Owner);
 			}
 
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 		{
-			var c = target.Info.Traits.GetOrDefault<ExternalCapturableInfo>();
+			var c = target.Info.TraitInfoOrDefault<ExternalCapturableInfo>();
 
 			var canTargetActor = c != null && c.CanBeTargetedBy(self, target.Owner);
 			cursor = canTargetActor ? "ability" : "move-blocked";

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			MaxLevel = info.Upgrades.Count;
 
-			var cost = self.Info.Traits.Get<ValuedInfo>().Cost;
+			var cost = self.Info.TraitInfo<ValuedInfo>().Cost;
 			foreach (var kv in info.Upgrades)
 				nextLevel.Add(Pair.New(kv.Key * cost, kv.Value));
 

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		static int GetMultiplier(Actor self)
 		{
 			// returns 100's as 1, so as to keep accuracy for longer.
-			var info = self.Info.Traits.Get<GivesBountyInfo>();
+			var info = self.Info.TraitInfo<GivesBountyInfo>();
 			var gainsExp = self.TraitOrDefault<GainsExperience>();
 			if (gainsExp == null)
 				return 100;
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			var info = self.Info.Traits.Get<GivesBountyInfo>();
+			var info = self.Info.TraitInfo<GivesBountyInfo>();
 
 			if (e.Attacker == null || e.Attacker.Disposed) return;
 

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (e.Attacker == null || e.Attacker.Disposed || (!info.FriendlyFire && e.Attacker.Owner.Stances[self.Owner] == Stance.Ally))
 				return;
 
-			var valued = self.Info.Traits.GetOrDefault<ValuedInfo>();
+			var valued = self.Info.TraitInfoOrDefault<ValuedInfo>();
 
 			// Default experience is 100 times our value
 			var exp = info.Experience >= 0

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Tick(World world)
 		{
-			if (subjects.All(s => s.IsDead || !s.HasTrait<Guard>()))
+			if (subjects.All(s => s.IsDead || !s.Info.Traits.Contains<GuardInfo>()))
 				world.CancelInputMode();
 		}
 
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 			return world.ScreenMap.ActorsAt(mi)
 				.Where(a => !world.FogObscures(a) && !a.IsDead &&
 					a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) &&
-					a.HasTrait<Guardable>());
+					a.Info.Traits.Contains<GuardableInfo>());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Tick(World world)
 		{
-			if (subjects.All(s => s.IsDead || !s.Info.Traits.Contains<GuardInfo>()))
+			if (subjects.All(s => s.IsDead || !s.Info.HasTraitInfo<GuardInfo>()))
 				world.CancelInputMode();
 		}
 
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 			return world.ScreenMap.ActorsAt(mi)
 				.Where(a => !world.FogObscures(a) && !a.IsDead &&
 					a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) &&
-					a.Info.Traits.Contains<GuardableInfo>());
+					a.Info.HasTraitInfo<GuardableInfo>());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self.SetTargetLine(target, Color.Yellow);
 
-			var range = WDist.FromCells(target.Actor.Info.Traits.Get<GuardableInfo>().Range);
+			var range = WDist.FromCells(target.Actor.Info.TraitInfo<GuardableInfo>().Range);
 			self.QueueActivity(false, new AttackMoveActivity(self, self.Trait<IMove>().MoveFollow(self, target, WDist.Zero, range)));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 		IExplodeModifier, IOrderVoice, ISpeedModifier, ISync, INotifyCreated,
 		INotifyResourceClaimLost, INotifyIdle, INotifyBlockingMove, INotifyBuildComplete
 	{
-		readonly HarvesterInfo info;
+		public readonly HarvesterInfo Info;
 		readonly Mobile mobile;
 		Dictionary<ResourceTypeInfo, int> contents = new Dictionary<ResourceTypeInfo, int>();
 		bool idleSmart = true;
@@ -92,20 +92,20 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Harvester(Actor self, HarvesterInfo info)
 		{
-			this.info = info;
+			Info = info;
 			mobile = self.Trait<Mobile>();
 			self.QueueActivity(new CallFunc(() => ChooseNewProc(self, null)));
 		}
 
 		public void Created(Actor self)
 		{
-			if (info.SearchOnCreation)
+			if (Info.SearchOnCreation)
 				self.QueueActivity(new FindResources(self));
 		}
 
 		public void BuildingComplete(Actor self)
 		{
-			if (info.SearchOnCreation)
+			if (Info.SearchOnCreation)
 				self.QueueActivity(new FindResources(self));
 		}
 
@@ -151,8 +151,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IsAcceptableProcType(Actor proc)
 		{
-			return info.DeliveryBuildings.Count == 0 ||
-				info.DeliveryBuildings.Contains(proc.Info.Name);
+			return Info.DeliveryBuildings.Count == 0 ||
+				Info.DeliveryBuildings.Contains(proc.Info.Name);
 		}
 
 		public Actor ClosestProc(Actor self, Actor ignore)
@@ -192,9 +192,9 @@ namespace OpenRA.Mods.Common.Traits
 			return null;
 		}
 
-		public bool IsFull { get { return contents.Values.Sum() == info.Capacity; } }
+		public bool IsFull { get { return contents.Values.Sum() == Info.Capacity; } }
 		public bool IsEmpty { get { return contents.Values.Sum() == 0; } }
-		public int Fullness { get { return contents.Values.Sum() * 100 / info.Capacity; } }
+		public int Fullness { get { return contents.Values.Sum() * 100 / Info.Capacity; } }
 
 		public void AcceptResource(ResourceType type)
 		{
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (self.Location == deliveryLoc)
 				{
 					// Get out of the way:
-					var unblockCell = LastHarvestedCell ?? (deliveryLoc + info.UnblockCell);
+					var unblockCell = LastHarvestedCell ?? (deliveryLoc + Info.UnblockCell);
 					var moveTo = mobile.NearestMoveableCell(unblockCell, 1, 5);
 					self.QueueActivity(mobile.MoveTo(moveTo, 1));
 					self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
@@ -287,7 +287,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (--contents[type] == 0)
 					contents.Remove(type);
 
-				currentUnloadTicks = info.UnloadTicksPerBale;
+				currentUnloadTicks = Info.UnloadTicksPerBale;
 			}
 
 			return contents.Count == 0;
@@ -318,10 +318,10 @@ namespace OpenRA.Mods.Common.Traits
 		public string VoicePhraseForOrder(Actor self, Order order)
 		{
 			if (order.OrderString == "Harvest")
-				return info.HarvestVoice;
+				return Info.HarvestVoice;
 
 			if (order.OrderString == "Deliver" && !IsEmpty)
-				return info.DeliverVoice;
+				return Info.DeliverVoice;
 
 			return null;
 		}
@@ -421,7 +421,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		PipType GetPipAt(int i)
 		{
-			var n = i * info.Capacity / info.PipCount;
+			var n = i * Info.Capacity / Info.PipCount;
 
 			foreach (var rt in contents)
 				if (n < rt.Value)
@@ -434,7 +434,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			var numPips = info.PipCount;
+			var numPips = Info.PipCount;
 
 			for (var i = 0; i < numPips; i++)
 				yield return GetPipAt(i);
@@ -444,7 +444,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public int GetSpeedModifier()
 		{
-			return 100 - (100 - info.FullyLoadedSpeed) * contents.Values.Sum() / info.Capacity;
+			return 100 - (100 - Info.FullyLoadedSpeed) * contents.Values.Sum() / Info.Capacity;
 		}
 
 		class HarvestOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -297,7 +297,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<IAcceptResources>("Deliver", 5,
+				yield return new EnterAlliedActorTargeter<IAcceptResourcesInfo>("Deliver", 5,
 					proc => IsAcceptableProcType(proc),
 					proc => !IsEmpty && proc.Trait<IAcceptResources>().AllowDocking);
 				yield return new HarvestOrderTargeter();

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Start a search from each refinery's delivery location:
 			List<CPos> path;
-			var mi = self.Info.Traits.Get<MobileInfo>();
+			var mi = self.Info.TraitInfo<MobileInfo>();
 			using (var search = PathSearch.FromPoints(self.World, mi, self, refs.Values.Select(r => r.Location), self.Location, false)
 				.WithCustomCost(loc =>
 				{
@@ -469,7 +469,7 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				var res = self.World.WorldActor.Trait<ResourceLayer>().GetRenderedResource(location);
-				var info = self.Info.Traits.Get<HarvesterInfo>();
+				var info = self.Info.TraitInfo<HarvesterInfo>();
 
 				if (res == null || !info.Resources.Contains(res.Info.Name))
 					return false;

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.IsDead)
 				return;
 
-			if (Info.RemoveInstead || !self.Info.Traits.Contains<HealthInfo>())
+			if (Info.RemoveInstead || !self.Info.HasTraitInfo<HealthInfo>())
 				self.Dispose();
 			else
 				self.Kill(self);

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.IsDead)
 				return;
 
-			if (Info.RemoveInstead || !self.HasTrait<Health>())
+			if (Info.RemoveInstead || !self.Info.Traits.Contains<HealthInfo>())
 				self.Dispose();
 			else
 				self.Kill(self);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Unit is able to move.")]
-	public class MobileInfo : IMoveInfo, IOccupySpaceInfo, IFacingInfo, UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>
+	public class MobileInfo : IMoveInfo, IPositionableInfo, IOccupySpaceInfo, IFacingInfo,
+		UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>
 	{
 		[FieldLoader.LoadUsing("LoadSpeeds", true)]
 		[Desc("Set Water: 0 for ground units and lower the value on rough terrain.")]
@@ -664,7 +665,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var cellInfo = notStupidCells
 					.SelectMany(c => self.World.ActorMap.GetUnitsAt(c)
-						.Where(a => a.IsIdle && a.HasTrait<Mobile>()),
+						.Where(a => a.IsIdle && a.Info.Traits.Contains<MobileInfo>()),
 						(c, a) => new { Cell = c, Actor = a })
 					.RandomOrDefault(self.World.SharedRandom);
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -665,7 +665,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var cellInfo = notStupidCells
 					.SelectMany(c => self.World.ActorMap.GetUnitsAt(c)
-						.Where(a => a.IsIdle && a.Info.Traits.Contains<MobileInfo>()),
+						.Where(a => a.IsIdle && a.Info.HasTraitInfo<MobileInfo>()),
 						(c, a) => new { Cell = c, Actor = a })
 					.RandomOrDefault(self.World.SharedRandom);
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool startsRevealed;
 		readonly PPos[] footprint;
 
-		readonly Lazy<IToolTip> tooltip;
+		readonly Lazy<ITooltip> tooltip;
 		readonly Lazy<Health> health;
 
 		readonly Dictionary<Player, bool> visible;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			startsRevealed = info.StartsRevealed && !init.Contains<ParentActorInit>();
 			var footprintCells = FootprintUtils.Tiles(init.Self).ToList();
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
-			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<IToolTip>().FirstOrDefault());
+			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<ITooltip>().FirstOrDefault());
 			health = Exts.Lazy(() => init.Self.TraitOrDefault<Health>());
 
 			frozen = new Dictionary<Player, FrozenActor>();

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public enum AlternateTransportsMode { None, Force, Default, Always }
 
-	public class EnterTransportTargeter : EnterAlliedActorTargeter<Cargo>
+	public class EnterTransportTargeter : EnterAlliedActorTargeter<CargoInfo>
 	{
 		readonly AlternateTransportsMode mode;
 
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class EnterTransportsTargeter : EnterAlliedActorTargeter<Cargo>
+	public class EnterTransportsTargeter : EnterAlliedActorTargeter<CargoInfo>
 	{
 		readonly AlternateTransportsMode mode;
 
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Traits
 			Info = info;
 			Func<Actor, bool> canTarget = IsCorrectCargoType;
 			Func<Actor, bool> useEnterCursor = CanEnter;
-			Orders = new EnterAlliedActorTargeter<Cargo>[]
+			Orders = new EnterAlliedActorTargeter<CargoInfo>[]
 			{
 				new EnterTransportTargeter("EnterTransport", 5, canTarget, useEnterCursor, Info.AlternateTransportsMode),
 				new EnterTransportsTargeter("EnterTransports", 5, canTarget, useEnterCursor, Info.AlternateTransportsMode)

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IsCorrectCargoType(Actor target)
 		{
-			var ci = target.Info.Traits.Get<CargoInfo>();
+			var ci = target.Info.TraitInfo<CargoInfo>();
 			return ci.Types.Contains(Info.CargoType);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
+++ b/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var building = order.TargetActor;
 
-				if (building.HasTrait<RepairableBuilding>())
+				if (building.Info.Traits.Contains<RepairableBuildingInfo>())
 					if (building.AppearsFriendlyTo(self))
 						building.Trait<RepairableBuilding>().RepairBuilding(building, self.Owner);
 			}

--- a/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
+++ b/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var building = order.TargetActor;
 
-				if (building.Info.Traits.Contains<RepairableBuildingInfo>())
+				if (building.Info.HasTraitInfo<RepairableBuildingInfo>())
 					if (building.AppearsFriendlyTo(self))
 						building.Trait<RepairableBuilding>().RepairBuilding(building, self.Owner);
 			}

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Damaged(Actor self, AttackInfo e)
 		{
 			// only track last hit against our base
-			if (!self.HasTrait<Building>())
+			if (!self.Info.Traits.Contains<BuildingInfo>())
 				return;
 
 			if (e.Attacker == null)

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Damaged(Actor self, AttackInfo e)
 		{
 			// only track last hit against our base
-			if (!self.Info.Traits.Contains<BuildingInfo>())
+			if (!self.Info.HasTraitInfo<BuildingInfo>())
 				return;
 
 			if (e.Attacker == null)

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Find a production structure to build this actor
 			var ai = self.World.Map.Rules.Actors[name];
-			var bi = ai.Traits.GetOrDefault<BuildableInfo>();
+			var bi = ai.TraitInfoOrDefault<BuildableInfo>();
 
 			// Some units may request a specific production type, which is ignored if the AllTech cheat is enabled
 			var type = bi == null || developerMode.AllTech ? Info.Type : bi.BuildAtProductionType ?? Info.Type;
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override int GetBuildTime(string unitString)
 		{
 			var ai = self.World.Map.Rules.Actors[unitString];
-			var bi = ai.Traits.GetOrDefault<BuildableInfo>();
+			var bi = ai.TraitInfoOrDefault<BuildableInfo>();
 			if (bi == null)
 				return 0;
 

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Damaged(Actor self, AttackInfo e)
 		{
 			// only track last hit against our harvesters
-			if (!self.Info.Traits.Contains<HarvesterInfo>())
+			if (!self.Info.HasTraitInfo<HarvesterInfo>())
 				return;
 
 			// don't track self-damage

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -47,8 +47,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Damaged(Actor self, AttackInfo e)
 		{
-			// only track last hit against our base
-			if (!self.HasTrait<Harvester>())
+			// only track last hit against our harvesters
+			if (!self.Info.Traits.Contains<HarvesterInfo>())
 				return;
 
 			// don't track self-damage

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
-			if (!ai.Traits.Get<BuildingInfo>().RequiresBaseProvider)
+			if (!ai.TraitInfo<BuildingInfo>().RequiresBaseProvider)
 				yield break;
 
 			foreach (var a in w.ActorsWithTrait<BaseProvider>())
@@ -75,9 +75,9 @@ namespace OpenRA.Mods.Common.Traits
 
 				var producer = queue.MostLikelyProducer();
 				var faction = producer.Trait != null ? producer.Trait.Faction : self.Owner.Faction.InternalName;
-				var buildingInfo = unit.Traits.Get<BuildingInfo>();
+				var buildingInfo = unit.TraitInfo<BuildingInfo>();
 
-				var buildableInfo = unit.Traits.GetOrDefault<BuildableInfo>();
+				var buildableInfo = unit.TraitInfoOrDefault<BuildableInfo>();
 				if (buildableInfo != null && buildableInfo.ForceFaction != null)
 					faction = buildableInfo.ForceFaction;
 
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (host == null)
 						return;
 
-					var plugInfo = unit.Traits.GetOrDefault<PlugInfo>();
+					var plugInfo = unit.TraitInfoOrDefault<PlugInfo>();
 					if (plugInfo == null)
 						return;
 

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -107,18 +107,18 @@ namespace OpenRA.Mods.Common.Traits
 
 			var attackerStats = e.Attacker.Owner.PlayerActor.Trait<PlayerStatistics>();
 			var defenderStats = self.Owner.PlayerActor.Trait<PlayerStatistics>();
-			if (self.Info.Traits.Contains<BuildingInfo>())
+			if (self.Info.HasTraitInfo<BuildingInfo>())
 			{
 				attackerStats.BuildingsKilled++;
 				defenderStats.BuildingsDead++;
 			}
-			else if (self.Info.Traits.Contains<IPositionableInfo>())
+			else if (self.Info.HasTraitInfo<IPositionableInfo>())
 			{
 				attackerStats.UnitsKilled++;
 				defenderStats.UnitsDead++;
 			}
 
-			if (self.Info.Traits.Contains<ValuedInfo>())
+			if (self.Info.HasTraitInfo<ValuedInfo>())
 			{
 				var cost = self.Info.Traits.Get<ValuedInfo>().Cost;
 				attackerStats.KillsCost += cost;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -107,18 +107,18 @@ namespace OpenRA.Mods.Common.Traits
 
 			var attackerStats = e.Attacker.Owner.PlayerActor.Trait<PlayerStatistics>();
 			var defenderStats = self.Owner.PlayerActor.Trait<PlayerStatistics>();
-			if (self.HasTrait<Building>())
+			if (self.Info.Traits.Contains<BuildingInfo>())
 			{
 				attackerStats.BuildingsKilled++;
 				defenderStats.BuildingsDead++;
 			}
-			else if (self.HasTrait<IPositionable>())
+			else if (self.Info.Traits.Contains<IPositionableInfo>())
 			{
 				attackerStats.UnitsKilled++;
 				defenderStats.UnitsDead++;
 			}
 
-			if (self.HasTrait<Valued>())
+			if (self.Info.Traits.Contains<ValuedInfo>())
 			{
 				var cost = self.Info.Traits.Get<ValuedInfo>().Cost;
 				attackerStats.KillsCost += cost;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (self.Info.HasTraitInfo<ValuedInfo>())
 			{
-				var cost = self.Info.Traits.Get<ValuedInfo>().Cost;
+				var cost = self.Info.TraitInfo<ValuedInfo>().Cost;
 				attackerStats.KillsCost += cost;
 				defenderStats.DeathsCost += cost;
 			}

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Traits
 			return self.World.Map.Rules.Actors.Values
 				.Where(x =>
 					x.Name[0] != '^' &&
-					x.Traits.Contains<BuildableInfo>() &&
+					x.HasTraitInfo<BuildableInfo>() &&
 					x.Traits.Get<BuildableInfo>().Queue.Contains(category));
 		}
 
@@ -254,7 +254,7 @@ namespace OpenRA.Mods.Common.Traits
 						if (!bi.Queue.Contains(Info.Type))
 							return; /* Not built by this queue */
 
-						var cost = unit.Traits.Contains<ValuedInfo>() ? unit.Traits.Get<ValuedInfo>().Cost : 0;
+						var cost = unit.HasTraitInfo<ValuedInfo>() ? unit.Traits.Get<ValuedInfo>().Cost : 0;
 						var time = GetBuildTime(order.TargetString);
 
 						if (BuildableItems().All(b => b.Name != order.TargetString))
@@ -278,7 +278,7 @@ namespace OpenRA.Mods.Common.Traits
 							var hasPlayedSound = false;
 							BeginProduction(new ProductionItem(this, order.TargetString, cost, playerPower, () => self.World.AddFrameEndTask(_ =>
 							{
-								var isBuilding = unit.Traits.Contains<BuildingInfo>();
+								var isBuilding = unit.HasTraitInfo<BuildingInfo>();
 
 								if (isBuilding && !hasPlayedSound)
 									hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
@@ -314,7 +314,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual int GetBuildTime(string unitString)
 		{
 			var unit = self.World.Map.Rules.Actors[unitString];
-			if (unit == null || !unit.Traits.Contains<BuildableInfo>())
+			if (unit == null || !unit.HasTraitInfo<BuildableInfo>())
 				return 0;
 
 			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var a in AllBuildables(Info.Type))
 			{
-				var bi = a.Traits.Get<BuildableInfo>();
+				var bi = a.TraitInfo<BuildableInfo>();
 
 				produceable.Add(a, new ProductionState());
 				ttc.Add(a.Name, bi.Prerequisites, bi.BuildLimit, this);
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 				.Where(x =>
 					x.Name[0] != '^' &&
 					x.HasTraitInfo<BuildableInfo>() &&
-					x.Traits.Get<BuildableInfo>().Queue.Contains(category));
+					x.TraitInfo<BuildableInfo>().Queue.Contains(category));
 		}
 
 		public void PrerequisitesAvailable(string key)
@@ -250,11 +250,11 @@ namespace OpenRA.Mods.Common.Traits
 				case "StartProduction":
 					{
 						var unit = self.World.Map.Rules.Actors[order.TargetString];
-						var bi = unit.Traits.Get<BuildableInfo>();
+						var bi = unit.TraitInfo<BuildableInfo>();
 						if (!bi.Queue.Contains(Info.Type))
 							return; /* Not built by this queue */
 
-						var cost = unit.HasTraitInfo<ValuedInfo>() ? unit.Traits.Get<ValuedInfo>().Cost : 0;
+						var cost = unit.HasTraitInfo<ValuedInfo>() ? unit.TraitInfo<ValuedInfo>().Cost : 0;
 						var time = GetBuildTime(order.TargetString);
 
 						if (BuildableItems().All(b => b.Name != order.TargetString))

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ProvidesPrerequisiteInfo : ITraitInfo
+	public class ProvidesPrerequisiteInfo : ITechTreePrerequisiteInfo
 	{
 		[Desc("The prerequisite type that this provides. If left empty it defaults to the actor's name.")]
 		public readonly string Prerequisite = null;

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ProvidesTechPrerequisiteInfo : ITraitInfo
+	public class ProvidesTechPrerequisiteInfo : ITechTreePrerequisiteInfo
 	{
 		public readonly string Name;
 		public readonly string[] Prerequisites = { };

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void ActorChanged(Actor a)
 		{
 			var bi = a.Info.Traits.GetOrDefault<BuildableInfo>();
-			if (a.Owner == player && (a.Info.Traits.Contains<ITechTreePrerequisiteInfo>() || (bi != null && bi.BuildLimit > 0)))
+			if (a.Owner == player && (a.Info.HasTraitInfo<ITechTreePrerequisiteInfo>() || (bi != null && bi.BuildLimit > 0)))
 				Update();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ActorChanged(Actor a)
 		{
-			var bi = a.Info.Traits.GetOrDefault<BuildableInfo>();
+			var bi = a.Info.TraitInfoOrDefault<BuildableInfo>();
 			if (a.Owner == player && (a.Info.HasTraitInfo<ITechTreePrerequisiteInfo>() || (bi != null && bi.BuildLimit > 0)))
 				Update();
 		}
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 					  a.Actor.IsInWorld &&
 					  !a.Actor.IsDead &&
 					  !ret.ContainsKey(a.Actor.Info.Name) &&
-					  a.Actor.Info.Traits.Get<BuildableInfo>().BuildLimit > 0)
+					  a.Actor.Info.TraitInfo<BuildableInfo>().BuildLimit > 0)
 				  .Do(b => ret[b.Actor.Info.Name].Add(b.Actor));
 
 			return ret;

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void ActorChanged(Actor a)
 		{
 			var bi = a.Info.Traits.GetOrDefault<BuildableInfo>();
-			if (a.Owner == player && (a.HasTrait<ITechTreePrerequisite>() || (bi != null && bi.BuildLimit > 0)))
+			if (a.Owner == player && (a.Info.Traits.Contains<ITechTreePrerequisiteInfo>() || (bi != null && bi.BuildLimit > 0)))
 				Update();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Production(ActorInitializer init, ProductionInfo info)
 		{
 			Info = info;
-			occupiesSpace = init.Self.Info.Traits.Contains<IOccupySpaceInfo>();
+			occupiesSpace = init.Self.Info.HasTraitInfo<IOccupySpaceInfo>();
 			rp = Exts.Lazy(() => init.Self.IsDead ? null : init.Self.TraitOrDefault<RallyPoint>());
 			Faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			var exitLocation = CPos.Zero;
 			var target = Target.Invalid;
 
-			var bi = producee.Traits.GetOrDefault<BuildableInfo>();
+			var bi = producee.TraitInfoOrDefault<BuildableInfo>();
 			if (bi != null && bi.ForceFaction != null)
 				factionVariant = bi.ForceFaction;
 
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 				var spawn = self.CenterPosition + exitinfo.SpawnOffset;
 				var to = self.World.Map.CenterOfCell(exit);
 
-				var fi = producee.Traits.GetOrDefault<IFacingInfo>();
+				var fi = producee.TraitInfoOrDefault<IFacingInfo>();
 				var initialFacing = exitinfo.Facing < 0 ? Util.GetFacing(to - spawn, fi == null ? 0 : fi.GetInitialFacing()) : exitinfo.Facing;
 
 				exitLocation = rp.Value != null ? rp.Value.Location : exit;
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		static bool CanUseExit(Actor self, ActorInfo producee, ExitInfo s)
 		{
-			var mobileInfo = producee.Traits.GetOrDefault<MobileInfo>();
+			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
 
 			self.NotifyBlocker(self.Location + s.ExitCell);
 

--- a/OpenRA.Mods.Common/Traits/ProvidesRadar.cs
+++ b/OpenRA.Mods.Common/Traits/ProvidesRadar.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.IsDisabled()) return false;
 
 			var isJammed = self.World.ActorsWithTrait<JamsRadar>().Any(a => a.Actor.Owner.Stances[self.Owner] != Stance.Ally
-				&& (self.Location - a.Actor.Location).Length <= a.Actor.Info.Traits.Get<JamsRadarInfo>().Range);
+				&& (self.Location - a.Actor.Location).Length <= a.Actor.Info.TraitInfo<JamsRadarInfo>().Range);
 
 			return !isJammed;
 		}

--- a/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
@@ -15,22 +15,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can capture ProximityCapturable actors.")]
-	public class ProximityCaptorInfo : ITraitInfo
+	public class ProximityCaptorInfo : TraitInfo<ProximityCaptor>
 	{
 		[FieldLoader.Require]
 		public readonly HashSet<string> Types = new HashSet<string>();
-		public object Create(ActorInitializer init) { return new ProximityCaptor(this); }
 	}
 
-	public class ProximityCaptor
-	{
-		public readonly ProximityCaptorInfo Info;
-
-		public ProximityCaptor(ProximityCaptorInfo info) { Info = info; }
-
-		public bool HasAny(IEnumerable<string> typesList)
-		{
-			return Info.Types.Overlaps(typesList);
-		}
-	}
+	public class ProximityCaptor { }
 }

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanBeCapturedBy(Actor a)
 		{
-			var pc = a.Info.Traits.GetOrDefault<ProximityCaptorInfo>();
+			var pc = a.Info.TraitInfoOrDefault<ProximityCaptorInfo>();
 			return pc != null && pc.Types.Overlaps(Info.CaptorTypes);
 		}
 

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -105,8 +105,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanBeCapturedBy(Actor a)
 		{
-			var pc = a.TraitOrDefault<ProximityCaptor>();
-			return pc != null && pc.HasAny(Info.CaptorTypes);
+			var pc = a.Info.Traits.GetOrDefault<ProximityCaptorInfo>();
+			return pc != null && pc.Types.Overlaps(Info.CaptorTypes);
 		}
 
 		IEnumerable<Actor> UnitsInRange()

--- a/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
+++ b/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (string.IsNullOrEmpty(Sequence))
 				throw new InvalidOperationException("Actor " + ai.Name + " is missing sequence to quantize facings from.");
 
-			var rsi = ai.Traits.Get<RenderSpritesInfo>();
+			var rsi = ai.TraitInfo<RenderSpritesInfo>();
 			return sequenceProvider.GetSequence(rsi.GetImage(ai, sequenceProvider, race), Sequence).Facings;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Hovers(HoversInfo info, Actor self)
 		{
 			this.info = info;
-			aircraft = self.HasTrait<Aircraft>();
+			aircraft = self.Info.Traits.Contains<AircraftInfo>();
 		}
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Hovers(HoversInfo info, Actor self)
 		{
 			this.info = info;
-			aircraft = self.Info.Traits.Contains<AircraftInfo>();
+			aircraft = self.Info.HasTraitInfo<AircraftInfo>();
 		}
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (queue == null)
 			{
-				var type = info.ProductionType ?? self.Trait<Production>().Info.Produces.First();
+				var type = info.ProductionType ?? self.Info.TraitInfo<ProductionInfo>().Produces.First();
 
 				// Per-actor queue
 				// Note: this includes disabled queues, as each bar must bind to exactly one queue.

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var a in w.ActorsWithTrait<RenderRangeCircle>())
 				if (a.Actor.Owner.IsAlliedWith(w.RenderPlayer))
-					if (a.Actor.Info.Traits.Get<RenderRangeCircleInfo>().RangeCircleType == RangeCircleType)
+					if (a.Actor.Info.TraitInfo<RenderRangeCircleInfo>().RangeCircleType == RangeCircleType)
 						foreach (var r in a.Trait.RenderAfterWorld(wr))
 							yield return r;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -52,14 +52,14 @@ namespace OpenRA.Mods.Common.Traits
 			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + ownerName);
 
 			var facings = 0;
-			var body = init.Actor.Traits.GetOrDefault<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfoOrDefault<BodyOrientationInfo>();
 			if (body != null)
 			{
 				facings = body.QuantizedFacings;
 
 				if (facings == -1)
 				{
-					var qbo = init.Actor.Traits.GetOrDefault<IQuantizeBodyOrientationInfo>();
+					var qbo = init.Actor.TraitInfoOrDefault<IQuantizeBodyOrientationInfo>();
 					facings = qbo != null ? qbo.QuantizedBodyFacings(init.Actor, sequenceProvider, faction) : 1;
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -47,17 +47,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var faction = init.Get<FactionInit, string>();
 			var ownerName = init.Get<OwnerInit>().PlayerName;
 			var sequenceProvider = init.World.Map.SequenceProvider;
 			var image = Image ?? init.Actor.Name;
 			var facings = body.QuantizedFacings == -1 ?
-				init.Actor.Traits.Get<IQuantizeBodyOrientationInfo>().QuantizedBodyFacings(init.Actor, sequenceProvider, faction) :
+				init.Actor.TraitInfo<IQuantizeBodyOrientationInfo>().QuantizedBodyFacings(init.Actor, sequenceProvider, faction) :
 				body.QuantizedFacings;
 			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + ownerName);
 
-			var ifacing = init.Actor.Traits.GetOrDefault<IFacingInfo>();
+			var ifacing = init.Actor.TraitInfoOrDefault<IFacingInfo>();
 			var facing = ifacing != null ? init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing() : 0;
 			var orientation = WRot.FromFacing(facing);
 			var components = init.Actor.Traits.WithInterface<IRenderActorPreviewVoxelsInfo>()

--- a/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (UpgradeMinEnabledLevel > 0)
 				yield break;
 
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var armament = init.Actor.Traits.WithInterface<ArmamentInfo>()
 				.First(a => a.Name == Armament);
 			var t = init.Actor.Traits.WithInterface<TurretedInfo>()

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingExplosion.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingExplosion.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WithBuildingExplosion(Actor self, WithBuildingExplosionInfo info)
 		{
 			this.info = info;
-			buildingInfo = self.Info.Traits.Get<BuildingInfo>();
+			buildingInfo = self.Info.TraitInfo<BuildingInfo>();
 		}
 
 		public void Killed(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			wsb = self.Trait<WithSpriteBody>();
-			buildComplete = !self.Info.Traits.Contains<BuildingInfo>();
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>();
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			wsb = self.Trait<WithSpriteBody>();
-			buildComplete = !self.HasTrait<Building>();
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>();
 		}
 
 		public void BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 
 			overlay = new Animation(self.World, rs.GetImage(self));
 

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
 
 			overlay = new Animation(self.World, rs.GetImage(self));
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
@@ -12,24 +12,14 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithDockingAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
+	public class WithDockingAnimationInfo : TraitInfo<WithDockingAnimation>, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
 	{
 		[Desc("Displayed when docking to refinery.")]
 		[SequenceReference] public readonly string DockSequence = "dock";
 
 		[Desc("Looped while unloading at refinery.")]
 		[SequenceReference] public readonly string DockLoopSequence = "dock-loop";
-
-		public object Create(ActorInitializer init) { return new WithDockingAnimation(init, this); }
 	}
 
-	public class WithDockingAnimation
-	{
-		public readonly WithDockingAnimationInfo Info;
-
-		public WithDockingAnimation(ActorInitializer init, WithDockingAnimationInfo info)
-		{
-			Info = info;
-		}
-	}
+	public class WithDockingAnimation { }
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 
 			var overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
 
 			var overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);

--- a/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			var ifacing = init.Actor.Traits.GetOrDefault<IFacingInfo>();
+			var ifacing = init.Actor.TraitInfoOrDefault<IFacingInfo>();
 			var facing = ifacing != null ? init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing() : 0;
 
 			var anim = new Animation(init.World, image, () => facing);

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Palette != null)
 				p = init.WorldRenderer.Palette(Palette);
 
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
 			var anim = new Animation(init.World, image, () => facing);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
 			if (info.StartSequence != null)
 				overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.StartSequence),

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
 			if (info.StartSequence != null)
 				overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.StartSequence),

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
 			var facing = 0;
-			var ifacing = init.Actor.Traits.GetOrDefault<IFacingInfo>();
+			var ifacing = init.Actor.TraitInfoOrDefault<IFacingInfo>();
 			if (ifacing != null)
 				facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 			var anim = new Animation(init.World, image);
 			anim.PlayThen(OpeningSequence, () => anim.PlayRepeating(Sequence));
 
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
 			var orientation = body.QuantizeOrientation(new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing)), facings);
 			var offset = body.LocalToWorld(Offset.Rotate(orientation));

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 			var anim = new Animation(init.World, image, () => 0);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => 0);
 
-			var bi = init.Actor.Traits.Get<BuildingInfo>();
+			var bi = init.Actor.TraitInfo<BuildingInfo>();
 			var offset = FootprintUtils.CenterOffset(init.World, bi).Y + 512; // Additional 512 units move from center -> top of cell
 			yield return new SpriteActorPreview(anim, WVec.Zero, offset, p, rs.Scale);
 		}
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			door.PlayFetchDirection(RenderSprites.NormalizeSequence(door, self.GetDamageState(), info.Sequence),
 				() => desiredFrame - door.CurrentFrame);
 
-			var buildingInfo = self.Info.Traits.Get<BuildingInfo>();
+			var buildingInfo = self.Info.TraitInfo<BuildingInfo>();
 
 			var offset = FootprintUtils.CenterOffset(self.World, buildingInfo).Y + 512;
 			renderSprites.Add(new AnimationWithOffset(door, null, () => !buildComplete, offset));

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
-			production = self.Info.Traits.Get<ProductionInfo>();
+			production = self.Info.TraitInfo<ProductionInfo>();
 
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.PlayRepeating(info.Sequence);

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			production = self.Info.Traits.Get<ProductionInfo>();
 
 			overlay = new Animation(self.World, rs.GetImage(self));

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
 			var anim = new Animation(init.World, image, () => facing);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Default trait for rendering sprite-based actors.")]
-	public class WithSpriteBodyInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
+	public class WithSpriteBodyInfo : UpgradableTraitInfo, ISpriteBodyInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Animation to play when the actor is created."), SequenceReference]
 		public readonly string StartSequence = null;

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -39,11 +39,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (UpgradeMinEnabledLevel > 0)
 				yield break;
 
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 
-			var ifacing = init.Actor.Traits.GetOrDefault<IFacingInfo>();
+			var ifacing = init.Actor.TraitInfoOrDefault<IFacingInfo>();
 			var bodyFacing = ifacing != null ? init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing() : 0;
 			var turretFacing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit, int>() : t.InitialFacing;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (UpgradeMinEnabledLevel > 0)
 				yield break;
 
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var armament = init.Actor.Traits.WithInterface<ArmamentInfo>()
 				.First(a => a.Name == Armament);
 			var t = init.Actor.Traits.WithInterface<TurretedInfo>()

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var voxel = VoxelProvider.GetVoxel(image, "idle");
 			var bodyOrientation = new[] { body.QuantizeOrientation(orientation, facings) };
 			yield return new VoxelAnimation(voxel, () => WVec.Zero,
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 				() => IsTraitDisabled, () => 0));
 
 			// Selection size
-			var rvi = self.Info.Traits.Get<RenderVoxelsInfo>();
+			var rvi = self.Info.TraitInfo<RenderVoxelsInfo>();
 			var s = (int)(rvi.Scale * voxel.Size.Aggregate(Math.Max));
 			size = new int2(s, s);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (UpgradeMinEnabledLevel > 0)
 				yield break;
 
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 					var haveNeighbour = false;
 					foreach (var n in kv.Value)
 					{
-						var rb = init.World.Map.Rules.Actors[n].Traits.GetOrDefault<WithWallSpriteBodyInfo>();
+						var rb = init.World.Map.Rules.Actors[n].TraitInfoOrDefault<WithWallSpriteBodyInfo>();
 						if (rb != null && rb.Type == Type)
 						{
 							haveNeighbour = true;

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<Building>("Repair", 5, CanRepairAt, _ => CanRepair() || CanRearm());
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, CanRepairAt, _ => CanRepair() || CanRearm());
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<Building>("RepairNear", 5,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("RepairNear", 5,
 					target => CanRepairAt(target), _ => ShouldRepair());
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public AmbientSound(Actor self, AmbientSoundInfo info)
 		{
-			if (self.Info.Traits.Contains<IOccupySpaceInfo>())
+			if (self.Info.HasTraitInfo<IOccupySpaceInfo>())
 				Sound.PlayLooped(info.SoundFile, self.CenterPosition);
 			else
 				Sound.PlayLooped(info.SoundFile);

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public AmbientSound(Actor self, AmbientSoundInfo info)
 		{
-			if (self.HasTrait<IOccupySpace>())
+			if (self.Info.Traits.Contains<IOccupySpaceInfo>())
 				Sound.PlayLooped(info.SoundFile, self.CenterPosition);
 			else
 				Sound.PlayLooped(info.SoundFile);

--- a/OpenRA.Mods.Common/Traits/SupplyTruck.cs
+++ b/OpenRA.Mods.Common/Traits/SupplyTruck.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				return target.HasTrait<AcceptsSupplies>();
+				return target.Info.Traits.Contains<AcceptsSuppliesInfo>();
 			}
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)

--- a/OpenRA.Mods.Common/Traits/SupplyTruck.cs
+++ b/OpenRA.Mods.Common/Traits/SupplyTruck.cs
@@ -82,12 +82,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				return target.Info.Traits.Contains<AcceptsSuppliesInfo>();
+				return target.Info.HasTraitInfo<AcceptsSuppliesInfo>();
 			}
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
-				return target.Info.Traits.Contains<AcceptsSuppliesInfo>();
+				return target.Info.HasTraitInfo<AcceptsSuppliesInfo>();
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (randomize)
 				attackFacing = Util.QuantizeFacing(self.World.SharedRandom.Next(256), info.QuantizedFacings) * (256 / info.QuantizedFacings);
 
-			var altitude = self.World.Map.Rules.Actors[info.UnitType].Traits.Get<PlaneInfo>().CruiseAltitude.Length;
+			var altitude = self.World.Map.Rules.Actors[info.UnitType].TraitInfo<PlaneInfo>().CruiseAltitude.Length;
 			var attackRotation = WRot.FromFacing(attackFacing);
 			var delta = new WVec(0, -1024, 0).Rotate(attackRotation);
 			target = target + new WVec(0, 0, altitude);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ActorRemoved(Actor a)
 		{
-			if (a.Owner != Self.Owner || !a.HasTrait<SupportPower>())
+			if (a.Owner != Self.Owner || !a.Info.Traits.Contains<SupportPowerInfo>())
 				return;
 
 			foreach (var t in a.TraitsImplementing<SupportPower>())
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<SupportPowerInstance> GetPowersForActor(Actor a)
 		{
-			if (a.Owner != Self.Owner || !a.HasTrait<SupportPower>())
+			if (a.Owner != Self.Owner || !a.Info.Traits.Contains<SupportPowerInfo>())
 				return NoInstances;
 
 			return a.TraitsImplementing<SupportPower>()

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ActorRemoved(Actor a)
 		{
-			if (a.Owner != Self.Owner || !a.Info.Traits.Contains<SupportPowerInfo>())
+			if (a.Owner != Self.Owner || !a.Info.HasTraitInfo<SupportPowerInfo>())
 				return;
 
 			foreach (var t in a.TraitsImplementing<SupportPower>())
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<SupportPowerInstance> GetPowersForActor(Actor a)
 		{
-			if (a.Owner != Self.Owner || !a.Info.Traits.Contains<SupportPowerInfo>())
+			if (a.Owner != Self.Owner || !a.Info.HasTraitInfo<SupportPowerInfo>())
 				return NoInstances;
 
 			return a.TraitsImplementing<SupportPower>()

--- a/OpenRA.Mods.Common/Traits/Targetable.cs
+++ b/OpenRA.Mods.Common/Traits/Targetable.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (IsTraitDisabled)
 				return false;
-			if (cloak == null || (!viewer.IsDead && viewer.Info.Traits.Contains<IgnoresCloakInfo>()))
+			if (cloak == null || (!viewer.IsDead && viewer.Info.HasTraitInfo<IgnoresCloakInfo>()))
 				return true;
 
 			return cloak.IsVisible(self, viewer.Owner);

--- a/OpenRA.Mods.Common/Traits/Targetable.cs
+++ b/OpenRA.Mods.Common/Traits/Targetable.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (IsTraitDisabled)
 				return false;
-			if (cloak == null || (!viewer.IsDead && viewer.HasTrait<IgnoresCloak>()))
+			if (cloak == null || (!viewer.IsDead && viewer.Info.Traits.Contains<IgnoresCloakInfo>()))
 				return true;
 
 			return cloak.IsVisible(self, viewer.Owner);

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool IsOwnerRowVisible { get { return ShowOwnerRow; } }
 	}
 
-	public class Tooltip : IToolTip
+	public class Tooltip : ITooltip
 	{
 		readonly Actor self;
 		readonly TooltipInfo info;

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -109,10 +109,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (!queued)
 				self.CancelActivity();
 
-			if (self.HasTrait<IFacing>())
+			if (self.Info.Traits.Contains<IFacingInfo>())
 				self.QueueActivity(new Turn(self, info.Facing));
 
-			if (self.HasTrait<Helicopter>())
+			if (self.Info.Traits.Contains<HelicopterInfo>())
 				self.QueueActivity(new HeliLand(self, true));
 
 			foreach (var nt in self.TraitsImplementing<INotifyTransform>())

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -109,10 +109,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (!queued)
 				self.CancelActivity();
 
-			if (self.Info.Traits.Contains<IFacingInfo>())
+			if (self.Info.HasTraitInfo<IFacingInfo>())
 				self.QueueActivity(new Turn(self, info.Facing));
 
-			if (self.Info.Traits.Contains<HelicopterInfo>())
+			if (self.Info.HasTraitInfo<HelicopterInfo>())
 				self.QueueActivity(new HeliLand(self, true));
 
 			foreach (var nt in self.TraitsImplementing<INotifyTransform>())

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 			this.info = info;
-			buildingInfo = self.World.Map.Rules.Actors[info.IntoActor].Traits.GetOrDefault<BuildingInfo>();
+			buildingInfo = self.World.Map.Rules.Actors[info.IntoActor].TraitInfoOrDefault<BuildingInfo>();
 			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
 		}
 

--- a/OpenRA.Mods.Common/Traits/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/VeteranProductionIconOverlay.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var a in self.World.Map.Rules.Actors.Values)
 			{
-				var uwc = a.Traits.GetOrDefault<ProducibleWithLevelInfo>();
+				var uwc = a.TraitInfoOrDefault<ProducibleWithLevelInfo>();
 				if (uwc != null)
 					ttc.Add(MakeKey(a.Name), uwc.Prerequisites, 0, this);
 			}

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Build a list of templates that should be overlayed with bridges
 			foreach (var bridge in info.Bridges)
 			{
-				var bi = w.Map.Rules.Actors[bridge].Traits.Get<BridgeInfo>();
+				var bi = w.Map.Rules.Actors[bridge].TraitInfo<BridgeInfo>();
 				foreach (var template in bi.Templates)
 					bridgeTypes.Add(template.First, Pair.New(bridge, template.Second));
 			}

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Traits
 					var dropFacing = Util.QuantizeFacing(self.World.SharedRandom.Next(256), info.QuantizedFacings) * (256 / info.QuantizedFacings);
 					var delta = new WVec(0, -1024, 0).Rotate(WRot.FromFacing(dropFacing));
 
-					var altitude = self.World.Map.Rules.Actors[info.DeliveryAircraft].Traits.Get<PlaneInfo>().CruiseAltitude.Length;
+					var altitude = self.World.Map.Rules.Actors[info.DeliveryAircraft].TraitInfo<PlaneInfo>().CruiseAltitude.Length;
 					var target = self.World.Map.CenterOfCell(p) + new WVec(0, 0, altitude);
 					var startEdge = target - (self.World.Map.DistanceToEdge(target, -delta) + info.Cordon).Length * delta / 1024;
 					var finishEdge = target + (self.World.Map.DistanceToEdge(target, delta) + info.Cordon).Length * delta / 1024;

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
 			var movementClasses =
-				world.Map.Rules.Actors.Where(ai => ai.Value.Traits.Contains<MobileInfo>())
+				world.Map.Rules.Actors.Where(ai => ai.Value.HasTraitInfo<MobileInfo>())
 				.Select(ai => (uint)ai.Value.Traits.Get<MobileInfo>().GetMovementClass(world.TileSet)).Distinct();
 
 			foreach (var mc in movementClasses)

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
 			var movementClasses =
 				world.Map.Rules.Actors.Where(ai => ai.Value.HasTraitInfo<MobileInfo>())
-				.Select(ai => (uint)ai.Value.Traits.Get<MobileInfo>().GetMovementClass(world.TileSet)).Distinct();
+				.Select(ai => (uint)ai.Value.TraitInfo<MobileInfo>().GetMovementClass(world.TileSet)).Distinct();
 
 			foreach (var mc in movementClasses)
 				domainIndexes[mc] = new MovementClassDomainIndex(world, mc);

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			CenterPosition = PreviewPosition(world, actor.InitDict);
 
 			var location = actor.InitDict.Get<LocationInit>().Value(worldRenderer.World);
-			var ios = Info.Traits.GetOrDefault<IOccupySpaceInfo>();
+			var ios = Info.TraitInfoOrDefault<IOccupySpaceInfo>();
 
 			var subCellInit = actor.InitDict.GetOrDefault<SubCellInit>();
 			var subCell = subCellInit != null ? subCellInit.Value(worldRenderer.World) : SubCell.Any;
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 				Footprint = new ReadOnlyDictionary<CPos, SubCell>(footprint);
 			}
 
-			var tooltip = Info.Traits.GetOrDefault<TooltipInfo>();
+			var tooltip = Info.TraitInfoOrDefault<TooltipInfo>();
 			Tooltip = tooltip == null ? ID + ": " + Info.Name : ID + ": " + tooltip.Name + " (" + Info.Name + ")";
 
 			GeneratePreviews();
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 				var subCellInit = actor.InitDict.GetOrDefault<SubCellInit>();
 				var subCell = subCellInit != null ? subCellInit.Value(worldRenderer.World) : SubCell.Any;
 
-				var buildingInfo = Info.Traits.GetOrDefault<BuildingInfo>();
+				var buildingInfo = Info.TraitInfoOrDefault<BuildingInfo>();
 				if (buildingInfo != null)
 					offset = FootprintUtils.CenterOffset(world, buildingInfo);
 

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self)
 		{
-			var mi = self.Info.Traits.Get<MobileInfo>();
+			var mi = self.Info.TraitInfo<MobileInfo>();
 
 			// If a water-land transition is required, bail early
 			var domainIndex = world.WorldActor.TraitOrDefault<DomainIndex>();
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self)
 		{
-			var mi = self.Info.Traits.Get<MobileInfo>();
+			var mi = self.Info.TraitInfo<MobileInfo>();
 			var targetCell = world.Map.CellContaining(target);
 
 			// Correct for SubCell offset

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var s in unitGroup.SupportActors)
 			{
-				var mi = w.Map.Rules.Actors[s.ToLowerInvariant()].Traits.Get<MobileInfo>();
+				var mi = w.Map.Rules.Actors[s.ToLowerInvariant()].TraitInfo<MobileInfo>();
 				var validCells = supportSpawnCells.Where(c => mi.CanEnterCell(w, null, c));
 				if (!validCells.Any())
 					throw new InvalidOperationException("No cells available to spawn starting unit {0}".F(s));

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -18,6 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	public interface ISpriteBodyInfo : ITraitInfo { }
 	public interface ISpriteBody
 	{
 		void PlayCustomAnimation(Actor self, string newAnimation, Action after);
@@ -67,6 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Undocked();
 	}
 
+	public interface ITechTreePrerequisiteInfo : ITraitInfo { }
 	public interface ITechTreePrerequisite
 	{
 		IEnumerable<string> ProvidesPrerequisites { get; }
@@ -91,6 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface INotifyTransform { void BeforeTransform(Actor self); void OnTransform(Actor self); void AfterTransform(Actor toActor); }
 
+	public interface IAcceptResourcesInfo : ITraitInfo { }
 	public interface IAcceptResources
 	{
 		void OnDock(Actor harv, DeliverResources dockOrder);

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -45,8 +45,8 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyCharging { void Charging(Actor self, Target target); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
 	public interface INotifyParachuteLanded { void OnLanded(); }
-	public interface IRenderActorPreviewInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
-	public interface ICruiseAltitudeInfo { WDist GetCruiseAltitude(); }
+	public interface IRenderActorPreviewInfo : ITraitInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
+	public interface ICruiseAltitudeInfo : ITraitInfo { WDist GetCruiseAltitude(); }
 
 	public interface IUpgradable
 	{

--- a/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
@@ -40,14 +40,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Game.ModData = new ModData(srcMod);
 			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
 			var srcRules = Game.ModData.RulesetCache.Load();
-			var srcPaletteInfo = srcRules.Actors["player"].Traits.Get<PlayerColorPaletteInfo>();
+			var srcPaletteInfo = srcRules.Actors["player"].TraitInfo<PlayerColorPaletteInfo>();
 			var srcRemapIndex = srcPaletteInfo.RemapIndex;
 
 			var destMod = args[2].Split(':')[0];
 			Game.ModData = new ModData(destMod);
 			GlobalFileSystem.LoadFromManifest(Game.ModData.Manifest);
 			var destRules = Game.ModData.RulesetCache.Load();
-			var destPaletteInfo = destRules.Actors["player"].Traits.Get<PlayerColorPaletteInfo>();
+			var destPaletteInfo = destRules.Actors["player"].TraitInfo<PlayerColorPaletteInfo>();
 			var destRemapIndex = destPaletteInfo.RemapIndex;
 			var shadowIndex = new int[] { };
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Warheads
 		{
 			foreach (var unit in world.ActorMap.GetUnitsAt(cell))
 			{
-				var healthInfo = unit.Info.Traits.GetOrDefault<HealthInfo>();
+				var healthInfo = unit.Info.TraitInfoOrDefault<HealthInfo>();
 				if (healthInfo == null)
 					continue;
 

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public override void DoImpact(Actor victim, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
-			var healthInfo = victim.Info.Traits.GetOrDefault<HealthInfo>();
+			var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
 			if (healthInfo == null)
 				return;
 

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Warheads
 					continue;
 
 				var localModifiers = damageModifiers;
-				var healthInfo = victim.Info.Traits.GetOrDefault<HealthInfo>();
+				var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
 				if (healthInfo != null)
 				{
 					var distance = Math.Max(0, (victim.CenterPosition - pos).Length - healthInfo.Radius.Length);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (!actor.HasTraitInfo<IRenderActorPreviewInfo>())
 					continue;
 
-				var filter = actor.Traits.GetOrDefault<EditorTilesetFilterInfo>();
+				var filter = actor.TraitInfoOrDefault<EditorTilesetFilterInfo>();
 				if (filter != null)
 				{
 					if (filter.ExcludeTilesets != null && filter.ExcludeTilesets.Contains(world.TileSet.Id))
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					item.Bounds.Height = preview.Bounds.Height + 2 * preview.Bounds.Y;
 					item.IsVisible = () => true;
 
-					var tooltip = actor.Traits.GetOrDefault<TooltipInfo>();
+					var tooltip = actor.TraitInfoOrDefault<TooltipInfo>();
 					item.GetTooltipText = () => tooltip == null ? actor.Name : tooltip.Name + " (" + actor.Name + ")";
 
 					panel.AddChild(item);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -92,10 +92,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var a in actors)
 			{
 				var actor = a;
-				if (actor.Traits.Contains<BridgeInfo>()) // bridge layer takes care about that automatically
+				if (actor.HasTraitInfo<BridgeInfo>()) // bridge layer takes care about that automatically
 					continue;
 
-				if (!actor.Traits.Contains<IRenderActorPreviewInfo>())
+				if (!actor.HasTraitInfo<IRenderActorPreviewInfo>())
 					continue;
 
 				var filter = actor.Traits.GetOrDefault<EditorTilesetFilterInfo>();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var playerWidgets = Game.LoadWidget(world, "PLAYER_WIDGETS", playerRoot, new WidgetArgs());
 				var sidebarTicker = playerWidgets.Get<LogicTickerWidget>("SIDEBAR_TICKER");
-				var objectives = world.LocalPlayer.PlayerActor.Info.Traits.GetOrDefault<MissionObjectivesInfo>();
+				var objectives = world.LocalPlayer.PlayerActor.Info.TraitInfoOrDefault<MissionObjectivesInfo>();
 
 				sidebarTicker.OnTick = () =>
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var playerWidgets = Game.LoadWidget(world, "PLAYER_WIDGETS", playerRoot, new WidgetArgs());
 				var sidebarTicker = playerWidgets.Get<LogicTickerWidget>("SIDEBAR_TICKER");
-				var objectives = world.LocalPlayer.PlayerActor.TraitOrDefault<MissionObjectives>();
+				var objectives = world.LocalPlayer.PlayerActor.Info.Traits.GetOrDefault<MissionObjectivesInfo>();
 
 				sidebarTicker.OnTick = () =>
 				{
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (world.LocalPlayer.WinState != WinState.Undefined && !loadingObserverWidgets)
 					{
 						loadingObserverWidgets = true;
-						Game.RunAfterDelay(objectives != null ? objectives.Info.GameOverDelay : 0, () =>
+						Game.RunAfterDelay(objectives != null ? objectives.GameOverDelay : 0, () =>
 						{
 							playerRoot.RemoveChildren();
 							Game.LoadWidget(world, "OBSERVER_WIDGETS", playerRoot, new WidgetArgs());

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.Sum(a => a.Info.Traits.WithInterface<ValuedInfo>().First().Cost);
 
 			var harvesters = template.Get<LabelWidget>("HARVESTERS");
-			harvesters.GetText = () => world.Actors.Count(a => a.Owner == player && !a.IsDead && a.Info.Traits.Contains<HarvesterInfo>()).ToString();
+			harvesters.GetText = () => world.Actors.Count(a => a.Owner == player && !a.IsDead && a.Info.HasTraitInfo<HarvesterInfo>()).ToString();
 
 			return template;
 		}
@@ -280,7 +280,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			return ScrollItemWidget.Setup(template, () => false, () =>
 			{
-				var playerBase = world.Actors.FirstOrDefault(a => !a.IsDead && a.Info.Traits.Contains<BaseBuildingInfo>() && a.Owner == player);
+				var playerBase = world.Actors.FirstOrDefault(a => !a.IsDead && a.Info.HasTraitInfo<BaseBuildingInfo>() && a.Owner == player);
 				if (playerBase != null)
 					worldRenderer.Viewport.Center(playerBase.CenterPosition);
 			});

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.Sum(a => a.Info.Traits.WithInterface<ValuedInfo>().First().Cost);
 
 			var harvesters = template.Get<LabelWidget>("HARVESTERS");
-			harvesters.GetText = () => world.Actors.Count(a => a.Owner == player && !a.IsDead && a.HasTrait<Harvester>()).ToString();
+			harvesters.GetText = () => world.Actors.Count(a => a.Owner == player && !a.IsDead && a.Info.Traits.Contains<HarvesterInfo>()).ToString();
 
 			return template;
 		}
@@ -280,7 +280,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			return ScrollItemWidget.Setup(template, () => false, () =>
 			{
-				var playerBase = world.Actors.FirstOrDefault(a => !a.IsDead && a.HasTrait<BaseBuilding>() && a.Owner == player);
+				var playerBase = world.Actors.FirstOrDefault(a => !a.IsDead && a.Info.Traits.Contains<BaseBuildingInfo>() && a.Owner == player);
 				if (playerBase != null)
 					worldRenderer.Viewport.Center(playerBase.CenterPosition);
 			});

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -54,9 +54,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (actor == null || actor == lastActor)
 					return;
 
-				var tooltip = actor.Traits.Get<TooltipInfo>();
-				var buildable = actor.Traits.Get<BuildableInfo>();
-				var cost = actor.Traits.Get<ValuedInfo>().Cost;
+				var tooltip = actor.TraitInfo<TooltipInfo>();
+				var buildable = actor.TraitInfo<BuildableInfo>();
+				var cost = actor.TraitInfo<ValuedInfo>().Cost;
 
 				nameLabel.GetText = () => tooltip.Name;
 
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			ActorInfo ai;
 			if (rules.Actors.TryGetValue(a.ToLowerInvariant(), out ai) && ai.HasTraitInfo<TooltipInfo>())
-				return ai.Traits.Get<TooltipInfo>().Name;
+				return ai.TraitInfo<TooltipInfo>().Name;
 
 			return a;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		static string ActorName(Ruleset rules, string a)
 		{
 			ActorInfo ai;
-			if (rules.Actors.TryGetValue(a.ToLowerInvariant(), out ai) && ai.Traits.Contains<TooltipInfo>())
+			if (rules.Actors.TryGetValue(a.ToLowerInvariant(), out ai) && ai.HasTraitInfo<TooltipInfo>())
 				return ai.Traits.Get<TooltipInfo>().Name;
 
 			return a;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -438,7 +438,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Map.Map.Options.StartingCash.HasValue ? "Not Available" : "${0}".F(orderManager.LobbyInfo.GlobalSettings.StartingCash);
 				startingCash.OnMouseDown = _ =>
 				{
-					var options = modRules.Actors["player"].Traits.Get<PlayerResourcesInfo>().SelectableCash.Select(c => new DropDownOption
+					var options = modRules.Actors["player"].TraitInfo<PlayerResourcesInfo>().SelectableCash.Select(c => new DropDownOption
 					{
 						Title = "${0}".F(c),
 						IsSelected = () => orderManager.LobbyInfo.GlobalSettings.StartingCash == c,
@@ -689,7 +689,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							orderManager.IssueOrder(Order.Command("state {0}".F(Session.ClientState.NotReady)));
 
 							// Restore default starting cash if the last map set it to something invalid
-							var pri = modRules.Actors["player"].Traits.Get<PlayerResourcesInfo>();
+							var pri = modRules.Actors["player"].TraitInfo<PlayerResourcesInfo>();
 							if (!Map.Map.Options.StartingCash.HasValue && !pri.SelectableCash.Contains(orderManager.LobbyInfo.GlobalSettings.StartingCash))
 								orderManager.IssueOrder(Order.Command("startingcash {0}".F(pri.DefaultCash)));
 						}

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -72,10 +72,10 @@ namespace OpenRA.Mods.Common.Widgets
 				if (actor == null)
 					continue;
 
-				var rsi = actor.Traits.Get<RenderSpritesInfo>();
+				var rsi = actor.TraitInfo<RenderSpritesInfo>();
 				var icon = new Animation(world, rsi.GetImage(actor, world.Map.SequenceProvider, faction));
-				icon.Play(actor.Traits.Get<TooltipInfo>().Icon);
-				var bi = actor.Traits.Get<BuildableInfo>();
+				icon.Play(actor.TraitInfo<TooltipInfo>().Icon);
+				var bi = actor.TraitInfo<BuildableInfo>();
 				var location = new float2(RenderBounds.Location) + new float2(queue.i * (IconWidth + IconSpacing), 0);
 				WidgetUtils.DrawSHPCentered(icon.Image, location + 0.5f * iconSize, worldRenderer.Palette(bi.IconPalette), 0.5f);
 

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Widgets
 				if (CurrentQueue == null)
 					return Enumerable.Empty<ActorInfo>();
 
-				return CurrentQueue.AllItems().OrderBy(a => a.Traits.Get<BuildableInfo>().BuildPaletteOrder);
+				return CurrentQueue.AllItems().OrderBy(a => a.TraitInfo<BuildableInfo>().BuildPaletteOrder);
 			}
 		}
 
@@ -319,11 +319,11 @@ namespace OpenRA.Mods.Common.Widgets
 				var y = DisplayedIconCount / Columns;
 				var rect = new Rectangle(rb.X + x * (IconSize.X + IconMargin.X), rb.Y + y * (IconSize.Y + IconMargin.Y), IconSize.X, IconSize.Y);
 
-				var rsi = item.Traits.Get<RenderSpritesInfo>();
+				var rsi = item.TraitInfo<RenderSpritesInfo>();
 				var icon = new Animation(World, rsi.GetImage(item, World.Map.SequenceProvider, faction));
-				icon.Play(item.Traits.Get<TooltipInfo>().Icon);
+				icon.Play(item.TraitInfo<TooltipInfo>().Icon);
 
-				var bi = item.Traits.Get<BuildableInfo>();
+				var bi = item.TraitInfo<BuildableInfo>();
 
 				var pi = new ProductionIcon()
 				{

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var actor = World.Map.Rules.Actors[icon.Name];
 
-			if (item != null && item.Done && actor.Traits.Contains<BuildingInfo>())
+			if (item != null && item.Done && actor.HasTraitInfo<BuildingInfo>())
 			{
 				World.OrderGenerator = new PlaceBuildingOrderGenerator(CurrentQueue, icon.Name);
 				return true;

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.Common.Widgets
 		// Is added to world.ActorAdded by the SidebarLogic handler
 		public void ActorChanged(Actor a)
 		{
-			if (a.HasTrait<ProductionQueue>())
+			if (a.Info.Traits.Contains<ProductionQueueInfo>())
 			{
 				var allQueues = a.World.ActorsWithTrait<ProductionQueue>()
 					.Where(p => p.Actor.Owner == p.Actor.World.LocalPlayer && p.Actor.IsInWorld && p.Trait.Enabled)

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.Common.Widgets
 		// Is added to world.ActorAdded by the SidebarLogic handler
 		public void ActorChanged(Actor a)
 		{
-			if (a.Info.Traits.Contains<ProductionQueueInfo>())
+			if (a.Info.HasTraitInfo<ProductionQueueInfo>())
 			{
 				var allQueues = a.World.ActorsWithTrait<ProductionQueue>()
 					.Where(p => p.Actor.Owner == p.Actor.World.LocalPlayer && p.Actor.IsInWorld && p.Trait.Enabled)

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Widgets
 		Lazy<TooltipContainerWidget> tooltipContainer;
 
 		public WorldTooltipType TooltipType { get; private set; }
-		public IToolTip ActorTooltip { get; private set; }
+		public ITooltip ActorTooltip { get; private set; }
 		public IProvideTooltipInfo[] ActorTooltipExtra { get; private set; }
 		public FrozenActor FrozenActorTooltip { get; private set; }
 
@@ -106,12 +106,12 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			var underCursor = world.ScreenMap.ActorsAt(worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos))
-				.Where(a => !world.FogObscures(a) && a.HasTrait<IToolTip>())
+				.Where(a => !world.FogObscures(a) && a.Info.Traits.Contains<ITooltipInfo>())
 				.WithHighestSelectionPriority();
 
 			if (underCursor != null)
 			{
-				ActorTooltip = underCursor.TraitsImplementing<IToolTip>().First();
+				ActorTooltip = underCursor.TraitsImplementing<ITooltip>().First();
 				ActorTooltipExtra = underCursor.TraitsImplementing<IProvideTooltipInfo>().ToArray();
 				TooltipType = WorldTooltipType.Actor;
 				return;

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			var underCursor = world.ScreenMap.ActorsAt(worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos))
-				.Where(a => !world.FogObscures(a) && a.Info.Traits.Contains<ITooltipInfo>())
+				.Where(a => !world.FogObscures(a) && a.Info.HasTraitInfo<ITooltipInfo>())
 				.WithHighestSelectionPriority();
 
 			if (underCursor != null)

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformGuard()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.Info.Traits.Contains<GuardInfo>());
+				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<GuardInfo>());
 
 			if (actors.Any())
 				world.OrderGenerator = new GuardOrderGenerator(actors);
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var building = world.ActorsWithTrait<Building>()
 					.Select(b => b.Actor)
-					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.Info.Traits.Contains<SelectableInfo>());
+					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<SelectableInfo>());
 
 				// No buildings left
 				if (building == null)
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool CycleProductionBuildings()
 		{
 			var facilities = world.ActorsWithTrait<Production>()
-				.Where(a => a.Actor.Owner == world.LocalPlayer && !a.Actor.Info.Traits.Contains<BaseBuildingInfo>())
+				.Where(a => a.Actor.Owner == world.LocalPlayer && !a.Actor.Info.HasTraitInfo<BaseBuildingInfo>())
 				.OrderBy(f => f.Actor.Info.Traits.Get<ProductionInfo>().Produces.First())
 				.Select(b => b.Actor)
 				.ToList();

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformGuard()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.HasTrait<Guard>());
+				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.Info.Traits.Contains<GuardInfo>());
 
 			if (actors.Any())
 				world.OrderGenerator = new GuardOrderGenerator(actors);
@@ -197,7 +197,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var building = world.ActorsWithTrait<Building>()
 					.Select(b => b.Actor)
-					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.HasTrait<Selectable>());
+					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.Info.Traits.Contains<SelectableInfo>());
 
 				// No buildings left
 				if (building == null)
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool CycleProductionBuildings()
 		{
 			var facilities = world.ActorsWithTrait<Production>()
-				.Where(a => a.Actor.Owner == world.LocalPlayer && !a.Actor.HasTrait<BaseBuilding>())
+				.Where(a => a.Actor.Owner == world.LocalPlayer && !a.Actor.Info.Traits.Contains<BaseBuildingInfo>())
 				.OrderBy(f => f.Actor.Info.Traits.Get<ProductionInfo>().Produces.First())
 				.Select(b => b.Actor)
 				.ToList();

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (actor.First == null)
 				return true;
 
-			var ati = actor.First.Info.Traits.GetOrDefault<AutoTargetInfo>();
+			var ati = actor.First.Info.TraitInfoOrDefault<AutoTargetInfo>();
 			if (ati == null || !ati.EnableStances)
 				return false;
 
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var facilities = world.ActorsWithTrait<Production>()
 				.Where(a => a.Actor.Owner == world.LocalPlayer && !a.Actor.Info.HasTraitInfo<BaseBuildingInfo>())
-				.OrderBy(f => f.Actor.Info.Traits.Get<ProductionInfo>().Produces.First())
+				.OrderBy(f => f.Actor.Info.TraitInfo<ProductionInfo>().Produces.First())
 				.Select(b => b.Actor)
 				.ToList();
 

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.D2k.Activities
 						actor1.Dispose();
 
 						// Harvester insurance
-						if (!actor1.HasTrait<Harvester>())
+						if (!actor1.Info.Traits.Contains<HarvesterInfo>())
 							return;
 
 						var insurance = actor1.Owner.PlayerActor.TraitOrDefault<HarvesterInsurance>();

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.D2k.Activities
 						actor1.Dispose();
 
 						// Harvester insurance
-						if (!actor1.Info.Traits.Contains<HarvesterInfo>())
+						if (!actor1.Info.HasTraitInfo<HarvesterInfo>())
 							return;
 
 						var insurance = actor1.Owner.PlayerActor.TraitOrDefault<HarvesterInsurance>();

--- a/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.D2k.Traits
 			var initialFacing = self.World.Map.FacingBetween(location, self.Location, 0);
 
 			// If aircraft, spawn at cruise altitude
-			var aircraftInfo = self.World.Map.Rules.Actors[deliveringActorName.ToLower()].Traits.GetOrDefault<AircraftInfo>();
+			var aircraftInfo = self.World.Map.Rules.Actors[deliveringActorName.ToLower()].TraitInfoOrDefault<AircraftInfo>();
 			if (aircraftInfo != null)
 				spawn += new WVec(0, 0, aircraftInfo.CruiseAltitude.Length);
 

--- a/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.D2k.Traits
 			var pos = self.World.Map.CenterOfCell(location);
 
 			// If aircraft, spawn at cruise altitude
-			var aircraftInfo = producee.Traits.GetOrDefault<AircraftInfo>();
+			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			if (aircraftInfo != null)
 				pos += new WVec(0, 0, aircraftInfo.CruiseAltitude.Length);
 

--- a/OpenRA.Mods.D2k/Traits/Carryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryable.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.D2k.Traits
 			{
 				// HACK: Harvesters need special treatment to avoid getting stuck on resource fields,
 				// so if a Harvester's afterLandActivity is not DeliverResources, queue a new FindResources activity
-				var findResources = self.Info.Traits.Contains<HarvesterInfo>() && !(afterLandActivity is DeliverResources);
+				var findResources = self.Info.HasTraitInfo<HarvesterInfo>() && !(afterLandActivity is DeliverResources);
 				if (findResources)
 					self.QueueActivity(new FindResources(self));
 				else

--- a/OpenRA.Mods.D2k/Traits/Carryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryable.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.D2k.Traits
 			{
 				// HACK: Harvesters need special treatment to avoid getting stuck on resource fields,
 				// so if a Harvester's afterLandActivity is not DeliverResources, queue a new FindResources activity
-				var findResources = self.HasTrait<Harvester>() && !(afterLandActivity is DeliverResources);
+				var findResources = self.Info.Traits.Contains<HarvesterInfo>() && !(afterLandActivity is DeliverResources);
 				if (findResources)
 					self.QueueActivity(new FindResources(self));
 				else

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -50,7 +50,8 @@ namespace OpenRA.Mods.D2k.Traits
 
 			IsBusy = false;
 			IsCarrying = false;
-			carryHeight = self.Trait<Helicopter>().Info.LandAltitude;
+			var helicopter = self.Info.Traits.GetOrDefault<HelicopterInfo>();
+			carryHeight = helicopter != null ? helicopter.LandAltitude : WDist.Zero;
 		}
 
 		public void OnBecomingIdle(Actor self)

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			IsBusy = false;
 			IsCarrying = false;
-			var helicopter = self.Info.Traits.GetOrDefault<HelicopterInfo>();
+			var helicopter = self.Info.TraitInfoOrDefault<HelicopterInfo>();
 			carryHeight = helicopter != null ? helicopter.LandAltitude : WDist.Zero;
 		}
 

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.D2k.Traits
 			var body = self.Trait<BodyOrientation>();
 
 			// always render instantly for units
-			buildComplete = !self.Info.Traits.Contains<BuildingInfo>();
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>();
 
 			var overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.D2k.Traits
 			var body = self.Trait<BodyOrientation>();
 
 			// always render instantly for units
-			buildComplete = !self.HasTrait<Building>();
+			buildComplete = !self.Info.Traits.Contains<BuildingInfo>();
 
 			var overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.Play(info.Sequence);

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.D2k.Traits
 			targetCountdown = Info.TargetRescanInterval;
 
 			// If close enough, we don't care about other actors.
-			var target = self.World.FindActorsInCircle(self.CenterPosition, Info.IgnoreNoiseAttackRange).FirstOrDefault(x => x.Info.Traits.Contains<AttractsWormsInfo>());
+			var target = self.World.FindActorsInCircle(self.CenterPosition, Info.IgnoreNoiseAttackRange).FirstOrDefault(x => x.Info.HasTraitInfo<AttractsWormsInfo>());
 			if (target != null)
 			{
 				self.CancelActivity();
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			Func<Actor, bool> isValidTarget = a =>
 			{
-				if (!a.Info.Traits.Contains<AttractsWormsInfo>())
+				if (!a.Info.HasTraitInfo<AttractsWormsInfo>())
 					return false;
 
 				return mobile.CanEnterCell(a.Location, null, false);

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.D2k.Traits
 			targetCountdown = Info.TargetRescanInterval;
 
 			// If close enough, we don't care about other actors.
-			var target = self.World.FindActorsInCircle(self.CenterPosition, Info.IgnoreNoiseAttackRange).FirstOrDefault(x => x.HasTrait<AttractsWorms>());
+			var target = self.World.FindActorsInCircle(self.CenterPosition, Info.IgnoreNoiseAttackRange).FirstOrDefault(x => x.Info.Traits.Contains<AttractsWormsInfo>());
 			if (target != null)
 			{
 				self.CancelActivity();
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			Func<Actor, bool> isValidTarget = a =>
 			{
-				if (!a.HasTrait<AttractsWorms>())
+				if (!a.Info.Traits.Contains<AttractsWormsInfo>())
 					return false;
 
 				return mobile.CanEnterCell(a.Location, null, false);

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			self.Dispose();
 
-			if (target.HasTrait<Building>())
+			if (target.Info.Traits.Contains<BuildingInfo>())
 				Sound.PlayToPlayer(self.Owner, "bldginf1.aud");
 		}
 	}

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Activities
 
 			self.Dispose();
 
-			if (target.Info.Traits.Contains<BuildingInfo>())
+			if (target.Info.HasTraitInfo<BuildingInfo>())
 				Sound.PlayToPlayer(self.Owner, "bldginf1.aud");
 		}
 	}

--- a/OpenRA.Mods.RA/Activities/LayMines.cs
+++ b/OpenRA.Mods.RA/Activities/LayMines.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.RA.Activities
 		public LayMines(Actor self)
 		{
 			minelayer = self.TraitOrDefault<Minelayer>();
-			info = self.Info.Traits.Get<MinelayerInfo>();
+			info = self.Info.TraitInfo<MinelayerInfo>();
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 			movement = self.Trait<IMove>();
 			rearmBuildings = info.RearmBuildings;

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Traits
 		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)
 		{
 			// No recursive cloning!
-			if (producer.Owner != self.Owner || producer.HasTrait<ClonesProducedUnits>())
+			if (producer.Owner != self.Owner || producer.Info.Traits.Contains<ClonesProducedUnitsInfo>())
 				return;
 
 			var ci = produced.Info.Traits.GetOrDefault<CloneableInfo>();

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Traits
 		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)
 		{
 			// No recursive cloning!
-			if (producer.Owner != self.Owner || producer.Info.Traits.Contains<ClonesProducedUnitsInfo>())
+			if (producer.Owner != self.Owner || producer.Info.HasTraitInfo<ClonesProducedUnitsInfo>())
 				return;
 
 			var ci = produced.Info.Traits.GetOrDefault<CloneableInfo>();

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Traits
 			if (producer.Owner != self.Owner || producer.Info.HasTraitInfo<ClonesProducedUnitsInfo>())
 				return;
 
-			var ci = produced.Info.Traits.GetOrDefault<CloneableInfo>();
+			var ci = produced.Info.TraitInfoOrDefault<CloneableInfo>();
 			if (ci == null || !info.CloneableTypes.Overlaps(ci.Types))
 				return;
 

--- a/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Traits
 		public virtual bool CanChronoshiftTo(Actor self, CPos targetLocation)
 		{
 			// TODO: Allow enemy units to be chronoshifted into bad terrain to kill them
-			return self.HasTrait<IPositionable>() && self.Trait<IPositionable>().CanEnterCell(targetLocation);
+			return self.Info.Traits.Contains<IPositionableInfo>() && self.Trait<IPositionable>().CanEnterCell(targetLocation);
 		}
 
 		public virtual bool Teleport(Actor self, CPos targetLocation, int duration, bool killCargo, Actor chronosphere)

--- a/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Traits
 		public virtual bool CanChronoshiftTo(Actor self, CPos targetLocation)
 		{
 			// TODO: Allow enemy units to be chronoshifted into bad terrain to kill them
-			return self.Info.Traits.Contains<IPositionableInfo>() && self.Trait<IPositionable>().CanEnterCell(targetLocation);
+			return self.Info.HasTraitInfo<IPositionableInfo>() && self.Trait<IPositionable>().CanEnterCell(targetLocation);
 		}
 
 		public virtual bool Teleport(Actor self, CPos targetLocation, int duration, bool killCargo, Actor chronosphere)

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.RA.Traits
 		public override object Create(ActorInitializer init) { return new DisguiseToolTip(init.Self, this); }
 	}
 
-	class DisguiseToolTip : IToolTip
+	class DisguiseToolTip : ITooltip
 	{
 		readonly Actor self;
 		readonly Disguise disguise;
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.RA.Traits
 				else
 				{
 					AsSprite = target.Trait<RenderSprites>().GetImage(target);
-					var tooltip = target.TraitsImplementing<IToolTip>().FirstOrDefault();
+					var tooltip = target.TraitsImplementing<ITooltip>().FirstOrDefault();
 					AsPlayer = tooltip.Owner;
 					AsTooltipInfo = tooltip.TooltipInfo;
 				}

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.RA.Traits
 			var oldDisguiseSetting = Disguised;
 			var oldEffectiveOwner = AsPlayer;
 
-			var renderSprites = actorInfo.Traits.GetOrDefault<RenderSpritesInfo>();
+			var renderSprites = actorInfo.TraitInfoOrDefault<RenderSpritesInfo>();
 			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.SequenceProvider, newOwner.Faction.InternalName);
 			AsPlayer = newOwner;
 			AsTooltipInfo = actorInfo.Traits.WithInterface<TooltipInfo>().FirstOrDefault();

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public void OnCrush(Actor crusher)
 		{
-			if (crusher.HasTrait<MineImmune>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly))
+			if (crusher.Info.Traits.Contains<MineImmuneInfo>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly))
 				return;
 
 			var mobile = crusher.TraitOrDefault<Mobile>();

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public void OnCrush(Actor crusher)
 		{
-			if (crusher.Info.Traits.Contains<MineImmuneInfo>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly))
+			if (crusher.Info.HasTraitInfo<MineImmuneInfo>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly))
 				return;
 
 			var mobile = crusher.TraitOrDefault<Mobile>();

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.RA.Traits
 				var movement = self.Trait<IPositionable>();
 
 				Minefield = GetMinefieldCells(minefieldStart, order.TargetLocation,
-					self.Info.Traits.Get<MinelayerInfo>().MinefieldDepth)
+					self.Info.TraitInfo<MinelayerInfo>().MinefieldDepth)
 					.Where(p => movement.CanEnterCell(p, null, false)).ToArray();
 
 				self.CancelActivity();
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.RA.Traits
 				var underCursor = world.ScreenMap.ActorsAt(mi)
 					.Where(a => !world.FogObscures(a))
 					.MaxByOrDefault(a => a.Info.HasTraitInfo<SelectableInfo>()
-						? a.Info.Traits.Get<SelectableInfo>().Priority : int.MinValue);
+						? a.Info.TraitInfo<SelectableInfo>().Priority : int.MinValue);
 
 				if (mi.Button == Game.Settings.Game.MouseButtonPreference.Action && underCursor == null)
 				{
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.RA.Traits
 
 				var movement = minelayer.Trait<IPositionable>();
 				var minefield = GetMinefieldCells(minefieldStart, lastMousePos,
-					minelayer.Info.Traits.Get<MinelayerInfo>().MinefieldDepth);
+					minelayer.Info.TraitInfo<MinelayerInfo>().MinefieldDepth);
 
 				var pal = wr.Palette("terrain");
 				foreach (var c in minefield)

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.RA.Traits
 
 				var underCursor = world.ScreenMap.ActorsAt(mi)
 					.Where(a => !world.FogObscures(a))
-					.MaxByOrDefault(a => a.Info.Traits.Contains<SelectableInfo>()
+					.MaxByOrDefault(a => a.Info.HasTraitInfo<SelectableInfo>()
 						? a.Info.Traits.Get<SelectableInfo>().Priority : int.MinValue);
 
 				if (mi.Button == Game.Settings.Game.MouseButtonPreference.Action && underCursor == null)

--- a/OpenRA.Mods.RA/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.RA/Traits/Render/RenderJammerCircle.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.RA.Traits
 	{
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
-			var jamsMissiles = ai.Traits.GetOrDefault<JamsMissilesInfo>();
+			var jamsMissiles = ai.TraitInfoOrDefault<JamsMissilesInfo>();
 			if (jamsMissiles != null)
 			{
 				yield return new RangeCircleRenderable(
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.RA.Traits
 					Color.FromArgb(96, Color.Black));
 			}
 
-			var jamsRadar = ai.Traits.GetOrDefault<JamsRadarInfo>();
+			var jamsRadar = ai.TraitInfoOrDefault<JamsRadarInfo>();
 			if (jamsRadar != null)
 			{
 				yield return new RangeCircleRenderable(
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Traits
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
 
-			var jamsMissiles = self.Info.Traits.GetOrDefault<JamsMissilesInfo>();
+			var jamsMissiles = self.Info.TraitInfoOrDefault<JamsMissilesInfo>();
 			if (jamsMissiles != null)
 			{
 				yield return new RangeCircleRenderable(
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.RA.Traits
 					Color.FromArgb(96, Color.Black));
 			}
 
-			var jamsRadar = self.Info.Traits.GetOrDefault<JamsRadarInfo>();
+			var jamsRadar = self.Info.TraitInfoOrDefault<JamsRadarInfo>();
 			if (jamsRadar != null)
 			{
 				yield return new RangeCircleRenderable(

--- a/OpenRA.Mods.RA/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.RA/Traits/Render/RenderShroudCircle.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			yield return new RangeCircleRenderable(
 				centerPosition,
-				ai.Traits.Get<CreatesShroudInfo>().Range,
+				ai.TraitInfo<CreatesShroudInfo>().Range,
 				0,
 				Color.FromArgb(128, Color.Cyan),
 				Color.FromArgb(96, Color.Black));
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.RA.Traits
 
 			yield return new RangeCircleRenderable(
 				self.CenterPosition,
-				self.Info.Traits.Get<CreatesShroudInfo>().Range,
+				self.Info.TraitInfo<CreatesShroudInfo>().Range,
 				0,
 				Color.FromArgb(128, Color.Cyan),
 				Color.FromArgb(96, Color.Black));

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Traits
 			foreach (var t in tiles)
 				units.UnionWith(Self.World.ActorMap.GetUnitsAt(t));
 
-			return units.Where(a => a.HasTrait<Chronoshiftable>() &&
+			return units.Where(a => a.Info.Traits.Contains<ChronoshiftableInfo>() &&
 				!a.TraitsImplementing<IPreventsTeleport>().Any(condition => condition.PreventsTeleport(a)));
 		}
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.RA.Traits
 			foreach (var t in tiles)
 				units.UnionWith(Self.World.ActorMap.GetUnitsAt(t));
 
-			return units.Where(a => a.Info.Traits.Contains<ChronoshiftableInfo>() &&
+			return units.Where(a => a.Info.HasTraitInfo<ChronoshiftableInfo>() &&
 				!a.TraitsImplementing<IPreventsTeleport>().Any(condition => condition.PreventsTeleport(a)));
 		}
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.RA.Traits
 			if (randomize)
 				dropFacing = Util.QuantizeFacing(self.World.SharedRandom.Next(256), info.QuantizedFacings) * (256 / info.QuantizedFacings);
 
-			var altitude = self.World.Map.Rules.Actors[info.UnitType].Traits.Get<PlaneInfo>().CruiseAltitude.Length;
+			var altitude = self.World.Map.Rules.Actors[info.UnitType].TraitInfo<PlaneInfo>().CruiseAltitude.Length;
 			var dropRotation = WRot.FromFacing(dropFacing);
 			var delta = new WVec(0, -1024, 0).Rotate(dropRotation);
 			target = target + new WVec(0, 0, altitude);

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.TS.Traits
 
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
 		{
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var voxel = VoxelProvider.GetVoxel(image, "idle");
 			yield return new VoxelAnimation(voxel, () => WVec.Zero,
 				() => new[] { body.QuantizeOrientation(orientation, facings) },
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.TS.Traits
 				() => 0));
 
 			// Selection size
-			var rvi = self.Info.Traits.Get<RenderVoxelsInfo>();
+			var rvi = self.Info.TraitInfo<RenderVoxelsInfo>();
 			var s = (int)(rvi.Scale * idleVoxel.Size.Aggregate(Math.Max));
 			size = new int2(s, s);
 

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.TS.Traits
 				() => false, () => frame));
 
 			// Selection size
-			var rvi = self.Info.Traits.Get<RenderVoxelsInfo>();
+			var rvi = self.Info.TraitInfo<RenderVoxelsInfo>();
 			var s = (int)(rvi.Scale * voxel.Size.Aggregate(Math.Max));
 			size = new int2(s, s);
 		}

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWaterBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWaterBody.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.TS.Traits
 				sequence = onWater ? WaterSequence : LandSequence;
 			}
 
-			var body = init.Actor.Traits.Get<BodyOrientationInfo>();
+			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var voxel = VoxelProvider.GetVoxel(image, sequence);
 			yield return new VoxelAnimation(voxel, () => WVec.Zero,
 				() => new[] { body.QuantizeOrientation(orientation, facings) },
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.TS.Traits
 				() => 0));
 
 			// Selection size
-			var rvi = self.Info.Traits.Get<RenderVoxelsInfo>();
+			var rvi = self.Info.TraitInfo<RenderVoxelsInfo>();
 			var s = (int)(rvi.Scale * landVoxel.Size.Aggregate(Math.Max));
 			size = new int2(s, s);
 


### PR DESCRIPTION
Split and rebased from #8927; the reason for taking the earlier commits is the discussion about LINQ-like methods in the comments for #8927.

_selfOrOtherActor_`.HasTrait<`_Trait_`>()` => _selfOrOtherActor_`.Info.HasTraitInfo<`_TraitInfo_`>`
 // with ITraitInfo restriction

_actorInfo_`.Traits.Contains` => _actorInfo_`.HasTraitInfo` // with ITraitInfo restriction

_actorInfo_`.Traits.Get` => _actorInfo_`.TraitInfo` // with ITraitInfo restriction

_actorInfo_`.Traits.GetOrDefault` => _actorInfo_`.TraitInfoOrDefault` // with ITraitInfo restriction

Foundation for a future PR for reducing trait access and allocation where trait state is not needed.

Separated because a few of these changes were put in #8848 to reduce ordering (`InitializeAfter<>`) and requirement (`Requires<>`) requirements and @pchote requested the changes be made everywhere before the split (`Requires<>` => `Requires<>` and `InitializeAfter<>`) in #8848.

Almost all of this is just `for f in $(git grep -lF ...); do sed -i s/.../.../g $f; done` substitutions with 1 method removed from `Actor` and 3 wrapper methods with `where T : ITraitInfo` added to `ActorInfo`.

@RoosterDragon profile this one.
