### PR TITLE
Make DuplicateUnitCrateAction only check enabled targetability

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.ValidFactions.Any() && !info.ValidFactions.Contains(collector.Owner.Faction.InternalName))
 				return false;
 
-			var targetable = collector.TraitsImplementing<ITargetable>();
+			var targetable = collector.TraitsImplementing<ITargetable>().Where(Exts.IsTraitEnabled);
 			if (!info.ValidTargets.Overlaps(targetable.SelectMany(t => t.TargetTypes)))
 				return false;
 


### PR DESCRIPTION
Make DuplicateUnitCrateAction only use enabled `ITargetable` traits for valid target check.
Missed this in #8727.
