### PR TITLE
Some D2k cleanup

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -57,7 +57,6 @@ frigate:
 		RepairBuildings: repair_pad
 		RearmBuildings:
 		Repulsable: False
-		AirborneUpgrades: airborne
 	Health:
 		HP: 500
 	-AppearsOnRadar:
@@ -86,7 +85,6 @@ ornithopter:
 		RepairBuildings: repair_pad
 		RearmBuildings:
 		Repulsable: False
-		AirborneUpgrades: airborne
 	AmmoPool:
 		Ammo: 5
 	Tooltip:
@@ -104,7 +102,6 @@ ornithopter.husk:
 		Speed: 350
 		RepairBuildings:
 		RearmBuildings:
-		AirborneUpgrades: airborne
 	RenderSprites:
 		Image: ornithopter
 
@@ -117,7 +114,6 @@ carryall.husk:
 		Speed: 210
 		RepairBuildings:
 		RearmBuildings:
-		AirborneUpgrades: airborne
 	RenderSprites:
 		Image: carryall
 

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -21,6 +21,14 @@ carryall.reinforce:
 		LandAltitude: 100
 		LandWhenIdle: False
 		AirborneUpgrades: airborne
+	Targetable@GROUND:
+		TargetTypes: Ground, Vehicle
+		UpgradeTypes: airborne
+		UpgradeMaxEnabledLevel: 0
+	Targetable@AIRBORNE:
+		TargetTypes: Air
+		UpgradeTypes: airborne
+		UpgradeMinEnabledLevel: 1
 	SpawnActorOnDeath:
 		Actor: carryall.husk
 	Carryall:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -72,6 +72,8 @@ frigate:
 
 ornithopter:
 	Inherits: ^Plane
+	Targetable:
+		TargetTypes: Air
 	AttackBomber:
 	Armament:
 		Weapon: OrniBomb

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -218,8 +218,6 @@
 	Guardable:
 	DeathSounds:
 		DeathTypes: ExplosionDeath, SoundDeath, SmallExplosionDeath, BulletDeath
-	Parachutable:
-		FallRate: 130
 	MustBeDestroyed:
 	TerrainModifiesDamage:
 		TerrainModifier:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -133,7 +133,6 @@ waypoint:
 	Inherits: carryall
 	Helicopter:
 		InitialFacing: 104
-		AirborneUpgrades: airborne
 	RenderSprites:
 		Image: carryall
 		Palette: colorpicker


### PR DESCRIPTION
- removed Parachutable from infantry default
- Carryalls and Ornithopters are now targetable by anti-air missiles like in the original
- removed redundant airborne upgrade from aircraft that can't land or isn't targetable
