### PR TITLE
Fixed RotationPaletteEffect tileset validity check

### DIFF
--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -66,6 +66,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.Tilesets.Count == 0 && info.ExcludeTilesets.Count == 0)
 				return true;
 
+			if (info.Tilesets.Count == 0 && !info.ExcludeTilesets.Contains(tilesetId))
+				return true;
+
 			return info.Tilesets.Contains(tilesetId) && !info.ExcludeTilesets.Contains(tilesetId);
 		}
 


### PR DESCRIPTION
Fixes a regression from #9103, RA temperate/snow terrain water effect is currently broken on bleed.

If `Tilesets` was empty but `ExcludeTilesets` was not, it would always return `false` even though that combination is supposed to mean only the excluded tileset(s) is/are not valid for this effect.
