### PR TITLE
Fixed silo placement preview

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
@@ -51,6 +51,11 @@ namespace OpenRA.Mods.Common.Traits
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
+
+			wsb.DefaultAnimation.PlayFetchIndex(wsb.NormalizeSequence(self, info.Sequence),
+				() => playerResources.ResourceCapacity != 0
+				? ((info.Stages * wsb.DefaultAnimation.CurrentSequence.Length - 1) * playerResources.Resources) / (info.Stages * playerResources.ResourceCapacity)
+					: 0);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
@@ -18,6 +18,10 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Render trait for buildings that change the sprite according to the remaining resource storage capacity across all depots.")]
 	class WithSiloAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
+		[Desc("Sequence to use for resources-dependent 'stages'."), SequenceReference]
+		public readonly string Sequence = "stages";
+
+		[Desc("Internal resource stages. Does not have to match number of sequence frames.")]
 		public readonly int Stages = 10;
 
 		public object Create(ActorInitializer init) { return new WithSiloAnimation(init, this); }
@@ -38,9 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void BuildingComplete(Actor self)
 		{
-			var animation = wsb.NormalizeSequence(self, wsb.Info.Sequence);
-
-			wsb.DefaultAnimation.PlayFetchIndex(animation,
+			wsb.DefaultAnimation.PlayFetchIndex(wsb.NormalizeSequence(self, info.Sequence),
 				() => playerResources.ResourceCapacity != 0
 				? ((info.Stages * wsb.DefaultAnimation.CurrentSequence.Length - 1) * playerResources.Resources) / (info.Stages * playerResources.ResourceCapacity)
 					: 0);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2148,6 +2148,16 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = node.Key.Replace("-WithMuzzleFlash", "-WithMuzzleOverlay");
 				}
 
+				// WithSiloAnimation received own Sequence property, idle sequence is only 1 frame long now
+				if (engineVersion < 20150925)
+				{
+					if (depth == 2 && node.Key == "WithSiloAnimation")
+					{
+						Console.WriteLine("WithSiloAnimation received its own Sequence property, which defaults to 'stages'.");
+						Console.WriteLine("Update your sequences accordingly, if necessary.");
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -78,16 +78,21 @@ proc:
 
 silo:
 	idle:
-		Length: 5
 		Offset: 0,-1
 	damaged-idle:
 		Start: 5
-		Length: 5
 		Offset: 0,-1
 	dead:
 		Start: 10
 		Offset: 0,-1
 		Tick: 800
+	stages:
+		Length: 5
+		Offset: 0,-1
+	damaged-stages:
+		Start: 5
+		Length: 5
+		Offset: 0,-1
 	make: silomake
 		Length: *
 		Tick: 80

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -384,9 +384,15 @@ refinery.atreides:
 silo.atreides:
 	idle: DATA.R8
 		Start: 2566
-		Length: 4
 		Offset: -16,16
 	damaged-idle: DATA.R8
+		Start: 2569
+		Offset: -16,16
+	stages: DATA.R8
+		Start: 2566
+		Length: 4
+		Offset: -16,16
+	damaged-stages: DATA.R8
 		Start: 2569
 		Offset: -16,16
 	make: DATA.R8
@@ -872,9 +878,15 @@ refinery.harkonnen:
 silo.harkonnen:
 	idle: DATA.R8
 		Start: 2726
-		Length: 4
 		Offset: -16,16
 	damaged-idle: DATA.R8
+		Start: 2730
+		Offset: -16,16
+	stages: DATA.R8
+		Start: 2726
+		Length: 4
+		Offset: -16,16
+	damaged-stages: DATA.R8
 		Start: 2730
 		Offset: -16,16
 	make: DATA.R8
@@ -1269,9 +1281,15 @@ refinery.ordos:
 silo.ordos:
 	idle: DATA.R8
 		Start: 2886
-		Length: 4
 		Offset: -16,16
 	damaged-idle: DATA.R8
+		Start: 2890
+		Offset: -16,16
+	stages: DATA.R8
+		Start: 2886
+		Length: 4
+		Offset: -16,16
+	damaged-stages: DATA.R8
 		Start: 2890
 		Offset: -16,16
 	make: DATA.R8

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -94,9 +94,14 @@ proc:
 
 silo:
 	idle: silo2
-		Length: 9
 		Offset: 0,-1
 	damaged-idle: silo2
+		Start: 9
+		Offset: 0,-1
+	stages: silo2
+		Length: 9
+		Offset: 0,-1
+	damaged-stages: silo2
 		Start: 9
 		Length: 9
 		Offset: 0,-1

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -973,8 +973,11 @@ gasilo.gdi:
 		Offset: 0, -24
 		UseTilesetCode: true
 	idle: gtsilo_a
-		Length: 4
 	damaged-idle: gtsilo_a
+		Start: 4
+	stages: gtsilo_a
+		Length: 4
+	damaged-stages: gtsilo_a
 		Start: 4
 		Length: 4
 	idle-underlay:
@@ -1008,8 +1011,11 @@ gasilo.nod:
 		Offset: 0, -24
 		UseTilesetCode: true
 	idle: gtsilo_a
-		Length: 4
 	damaged-idle: gtsilo_a
+		Start: 4
+	stages: gtsilo_a
+		Length: 4
+	damaged-stages: gtsilo_a
 		Start: 4
 		Length: 4
 	idle-underlay:


### PR DESCRIPTION
Rather than applying some magic work-around to `WithSpriteBody` preview code, I opted for giving `WithSiloAnimation` its own `Sequence` property, allowing us to split sequences into normal, 1-frame `idle` and fill `stages` sequence.

Fixes #9345.
