### PR TITLE
Catch exception when hosting server on busy port

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -119,13 +119,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				Game.CreateServer(settings);
 			}
-			catch (System.Net.Sockets.SocketException)
+			catch (System.Net.Sockets.SocketException e)
 			{
-				ConfirmationDialogs.CancelPrompt(
-					"Server Creation Failed",
-					"Could not listen on port {0}.\n\nCheck if the port is already being used.".F(Game.Settings.Server.ListenPort),
-					cancelText: "OK");
+				var err_msg = "Could not listen on port {0}.".F(Game.Settings.Server.ListenPort);
+				if (e.ErrorCode == 10048) { // AddressAlreadyInUse (WSAEADDRINUSE)
+					err_msg += "\n\nCheck if the port is already being used.";
+				} else {
+					err_msg += "\n\nError is: \"{0}\" ({1})".F(e.Message, e.ErrorCode);
+				}
 
+				ConfirmationDialogs.CancelPrompt("Server Creation Failed", err_msg, cancelText: "OK");
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -115,7 +115,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var settings = new ServerSettings(Game.Settings.Server);
 
 			// Create and join the server
-			Game.CreateServer(settings);
+			try
+			{
+				Game.CreateServer(settings);
+			}
+			catch (System.Net.Sockets.SocketException)
+			{
+				ConfirmationDialogs.CancelPrompt(
+					"Server Creation Failed",
+					"Could not listen on port {0}.\n\nCheck if the port is already being used.".F(Game.Settings.Server.ListenPort),
+					cancelText: "OK");
+
+				return;
+			}
+
 			Ui.CloseWindow();
 			ConnectionLogic.Connect(IPAddress.Loopback.ToString(), Game.Settings.Server.ListenPort, password, onCreate, onExit);
 		}


### PR DESCRIPTION
First PR, haven't coded in C# before. But the changes should be fairly simple.

Closes #9354

Suggested changelog: "Now displays an error when attempting to host a game on a busy port instead of crashing".
