### PR TITLE
Remove redundant IBodyOrientation[Info] & replace with BodyOrientation[Info]

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Renders the cargo loaded into the unit.")]
-	public class WithCargoInfo : ITraitInfo, Requires<CargoInfo>, Requires<IBodyOrientationInfo>
+	public class WithCargoInfo : ITraitInfo, Requires<CargoInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Cargo position relative to turret or body in (forward, right, up) triples. The default offset should be in the middle of the list.")]
 		public readonly WVec[] LocalOffset = { WVec.Zero };
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		readonly Cargo cargo;
 		readonly IFacing facing;
 		readonly WithCargoInfo cargoInfo;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 
 		public WithCargo(Actor self, WithCargoInfo info)
 		{
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			facing = self.TraitOrDefault<IFacing>();
 			cargoInfo = info;
 
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class WithGunboatBodyInfo : WithSpriteBodyInfo, Requires<IBodyOrientationInfo>, Requires<IFacingInfo>, Requires<TurretedInfo>
+	class WithGunboatBodyInfo : WithSpriteBodyInfo, Requires<BodyOrientationInfo>, Requires<IFacingInfo>, Requires<TurretedInfo>
 	{
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";

--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Effects
 {
 	[Desc("Draw a colored contrail behind this actor when they move.")]
-	class ContrailInfo : ITraitInfo, Requires<IBodyOrientationInfo>
+	class ContrailInfo : ITraitInfo, Requires<BodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Effects
 	class Contrail : ITick, IRender
 	{
 		readonly ContrailInfo info;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 
 		// This is a mutable struct, so it can't be readonly.
 		ContrailRenderable trail;
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Effects
 			var color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
 			trail = new ContrailRenderable(self.World, color, info.TrailLength, 0, 0);
 
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly Actor self;
 		Lazy<Turreted> turret;
-		Lazy<IBodyOrientation> coords;
+		Lazy<BodyOrientation> coords;
 		Lazy<AmmoPool> ammoPool;
 		List<Pair<int, Action>> delayedActions = new List<Pair<int, Action>>();
 
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// We can't resolve these until runtime
 			turret = Exts.Lazy(() => self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == info.Turret));
-			coords = Exts.Lazy(() => self.Trait<IBodyOrientation>());
+			coords = Exts.Lazy(() => self.Trait<BodyOrientation>());
 			ammoPool = Exts.Lazy(() => self.TraitsImplementing<AmmoPool>().FirstOrDefault(la => la.Info.Name == info.AmmoPoolName));
 
 			Weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()];

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly FirePort[] Ports;
 
 		AttackGarrisonedInfo info;
-		Lazy<IBodyOrientation> coords;
+		Lazy<BodyOrientation> coords;
 		List<Armament> armaments;
 		List<AnimationWithOffset> muzzles;
 		Dictionary<Actor, IFacing> paxFacing;
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(self, info)
 		{
 			this.info = info;
-			coords = Exts.Lazy(() => self.Trait<IBodyOrientation>());
+			coords = Exts.Lazy(() => self.Trait<BodyOrientation>());
 			armaments = new List<Armament>();
 			muzzles = new List<AnimationWithOffset>();
 			paxFacing = new Dictionary<Actor, IFacing>();

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class BodyOrientationInfo : ITraitInfo, IBodyOrientationInfo
+	public class BodyOrientationInfo : ITraitInfo
 	{
 		[Desc("Number of facings for gameplay calculations. -1 indicates auto-detection from another trait")]
 		public readonly int QuantizedFacings = -1;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new BodyOrientation(init, this); }
 	}
 
-	public class BodyOrientation : IBodyOrientation, ISync
+	public class BodyOrientation : ISync
 	{
 		readonly BodyOrientationInfo info;
 		readonly Lazy<int> quantizedFacings;

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -27,13 +27,13 @@ namespace OpenRA.Mods.Common.Traits
 		readonly DeveloperMode devMode;
 
 		Lazy<AttackBase> attack;
-		Lazy<IBodyOrientation> coords;
+		Lazy<BodyOrientation> coords;
 		Lazy<Health> health;
 
 		public CombatDebugOverlay(Actor self)
 		{
 			attack = Exts.Lazy(() => self.TraitOrDefault<AttackBase>());
-			coords = Exts.Lazy(() => self.Trait<IBodyOrientation>());
+			coords = Exts.Lazy(() => self.Trait<BodyOrientation>());
 			health = Exts.Lazy(() => self.TraitOrDefault<Health>());
 
 			var localPlayer = self.World.LocalPlayer;

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p);
 	}
 
-	public class RenderVoxelsInfo : ITraitInfo, IRenderActorPreviewInfo, Requires<IBodyOrientationInfo>
+	public class RenderVoxelsInfo : ITraitInfo, IRenderActorPreviewInfo, Requires<BodyOrientationInfo>
 	{
 		[Desc("Defaults to the actor name.")]
 		public readonly string Image = null;
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly List<VoxelAnimation> components = new List<VoxelAnimation>();
 		readonly Actor self;
 		readonly RenderVoxelsInfo info;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 		readonly WRot camera;
 		readonly WRot lightSource;
 
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.self = self;
 			this.info = info;
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 			camera = new WRot(WAngle.Zero, body.CameraPitch - new WAngle(256), new WAngle(256));
 			lightSource = new WRot(WAngle.Zero, new WAngle(256) - info.LightPitch, info.LightYaw);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders barrels for units with the Turreted trait.")]
 	public class WithBarrelInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<TurretedInfo>,
-		Requires<ArmamentInfo>, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+		Requires<ArmamentInfo>, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use.")]
 		[SequenceReference] public readonly string Sequence = "barrel";
@@ -59,13 +59,13 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		readonly Armament armament;
 		readonly Turreted turreted;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 
 		public WithBarrel(Actor self, WithBarrelInfo info)
 			: base(info)
 		{
 			this.self = self;
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 			armament = self.TraitsImplementing<Armament>()
 				.First(a => a.Info.Name == Info.Armament);
 			turreted = self.TraitsImplementing<Turreted>()

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Rendered when the actor constructed a building.")]
-	public class WithBuildingPlacedOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithBuildingPlacedOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "crane-overlay";
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WithBuildingPlacedOverlay(Actor self, WithBuildingPlacedOverlayInfo info)
 		{
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Rendered when a harvester is docked.")]
-	public class WithDockingOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithDockingOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "docking-overlay";
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 

--- a/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class WithFacingSpriteBodyInfo : WithSpriteBodyInfo, Requires<IBodyOrientationInfo>, Requires<IFacingInfo>
+	public class WithFacingSpriteBodyInfo : WithSpriteBodyInfo, Requires<BodyOrientationInfo>, Requires<IFacingInfo>
 	{
 		public override object Create(ActorInitializer init) { return new WithFacingSpriteBody(init, this); }
 

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays an overlay whenever resources are harvested by the actor.")]
-	class WithHarvestOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	class WithHarvestOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "harvest";
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			anim = new Animation(self.World, rs.GetImage(self), RenderSprites.MakeFacingFunc(self));
 			anim.IsDecoration = true;

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders a decorative animation on units and buildings.")]
-	public class WithIdleOverlayInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithIdleOverlayInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Animation to play when the actor is created.")]
 		[SequenceReference] public readonly string StartSequence = null;
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders a parachute on units.")]
-	public class WithParachuteInfo : UpgradableTraitInfo, ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithParachuteInfo : UpgradableTraitInfo, ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("The image that contains the parachute sequences.")]
 		public readonly string Image = null;
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// For this, info.Image must not be null
 			var overlay = new Animation(self.World, info.Image);
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 			anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => IsTraitDisabled && !renderProlonged,

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Play an animation when a unit exits or blocks the exit after production finished.")]
-	class WithProductionDoorOverlayInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>, Requires<BuildingInfo>
+	class WithProductionDoorOverlayInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>, Requires<BuildingInfo>
 	{
 		public readonly string Sequence = "build-door";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders an animation when the Production trait of the actor is activated.",
 		"Works both with per player ClassicProductionQueue and per building ProductionQueue, but needs any of these.")]
-	public class WithProductionOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>, Requires<ProductionInfo>
+	public class WithProductionOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>, Requires<ProductionInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "production-overlay";
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WithProductionOverlay(Actor self, WithProductionOverlayInfo info)
 		{
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.Info.Traits.Contains<BuildingInfo>(); // always render instantly for units
 			production = self.Info.Traits.Get<ProductionInfo>();

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays an overlay when the building is being repaired by the player.")]
-	public class WithRepairOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithRepairOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WithRepairOverlay(Actor self, WithRepairOverlayInfo info)
 		{
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.HasTrait<Building>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));

--- a/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRotor.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays a helicopter rotor overlay.")]
-	public class WithRotorInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithRotorInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use when flying")]
 		[SequenceReference] public readonly string Sequence = "rotor";
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 			movement = self.Trait<IMove>();
 
 			rotorAnim = new Animation(self.World, rs.GetImage(self));

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders turrets for units with the Turreted trait.")]
 	public class WithTurretInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo,
-		Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<IBodyOrientationInfo>
+		Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "turret";
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Animation DefaultAnimation;
 		protected readonly AttackBase Attack;
 		readonly RenderSprites rs;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 		readonly Turreted t;
 		readonly Armament[] arms;
 
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			rs = self.Trait<RenderSprites>();
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 			Attack = self.TraitOrDefault<AttackBase>();
 			t = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == info.Turret);

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretedSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretedSpriteBody.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor has turret art with facings baked into the sprite.")]
-	public class WithTurretedSpriteBodyInfo : WithSpriteBodyInfo, Requires<TurretedInfo>, Requires<IBodyOrientationInfo>
+	public class WithTurretedSpriteBodyInfo : WithSpriteBodyInfo, Requires<TurretedInfo>, Requires<BodyOrientationInfo>
 	{
 		public override object Create(ActorInitializer init) { return new WithTurretedSpriteBody(init, this); }
 

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -56,13 +56,13 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		readonly Armament armament;
 		readonly Turreted turreted;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 
 		public WithVoxelBarrel(Actor self, WithVoxelBarrelInfo info)
 			: base(info)
 		{
 			this.self = self;
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 			armament = self.TraitsImplementing<Armament>()
 				.First(a => a.Info.Name == Info.Armament);
 			turreted = self.TraitsImplementing<Turreted>()

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WithVoxelBody(Actor self, WithVoxelBodyInfo info)
 			: base(info)
 		{
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 			var rv = self.Trait<RenderVoxels>();
 
 			var voxel = VoxelProvider.GetVoxel(rv.Image, info.Sequence);

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -49,13 +49,13 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly Turreted turreted;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 
 		public WithVoxelTurret(Actor self, WithVoxelTurretInfo info)
 			: base(info)
 		{
 			this.self = self;
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 			turreted = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == Info.Turret);
 

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<IBodyOrientationInfo>
+	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<BodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -29,13 +29,13 @@ namespace OpenRA.Mods.Common.Traits
 	class SmokeTrailWhenDamaged : ITick
 	{
 		readonly SmokeTrailWhenDamagedInfo info;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 		int ticks;
 
 		public SmokeTrailWhenDamaged(Actor self, SmokeTrailWhenDamagedInfo info)
 		{
 			this.info = info;
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class NukePowerInfo : SupportPowerInfo, Requires<IBodyOrientationInfo>
+	class NukePowerInfo : SupportPowerInfo, Requires<BodyOrientationInfo>
 	{
 		[WeaponReference]
 		public readonly string MissileWeapon = "";
@@ -57,12 +57,12 @@ namespace OpenRA.Mods.Common.Traits
 	class NukePower : SupportPower
 	{
 		readonly NukePowerInfo info;
-		readonly IBodyOrientation body;
+		readonly BodyOrientation body;
 
 		public NukePower(Actor self, NukePowerInfo info)
 			: base(self, info)
 		{
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 			this.info = info;
 		}
 

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class ThrowsParticleInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<IBodyOrientationInfo>
+	class ThrowsParticleInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<BodyOrientationInfo>
 	{
 		[FieldLoader.Require]
 		public readonly string Anim = null;
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var self = init.Self;
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			// TODO: Carry orientation over from the parent instead of just facing
 			var bodyFacing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class TurretedInfo : ITraitInfo, UsesInit<TurretFacingInit>, Requires<IBodyOrientationInfo>
+	public class TurretedInfo : ITraitInfo, UsesInit<TurretFacingInit>, Requires<BodyOrientationInfo>
 	{
 		public readonly string Turret = "primary";
 		[Desc("Rate of Turning")]
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly TurretedInfo info;
 		AttackTurreted attack;
 		IFacing facing;
-		IBodyOrientation body;
+		BodyOrientation body;
 
 		[Sync] public int QuantizedFacings = 0;
 		[Sync] public int TurretFacing = 0;
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			attack = self.TraitOrDefault<AttackTurreted>();
 			facing = self.TraitOrDefault<IFacing>();
-			body = self.Trait<IBodyOrientation>();
+			body = self.Trait<BodyOrientation>();
 		}
 
 		public virtual void Tick(Actor self)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -25,20 +25,6 @@ namespace OpenRA.Mods.Common.Traits
 		void PlayCustomAnimationBackwards(Actor self, string name, Action after);
 	}
 
-	public interface IBodyOrientation
-	{
-		WAngle CameraPitch { get; }
-		int QuantizedFacings { get; }
-		WVec LocalToWorld(WVec vec);
-		WRot QuantizeOrientation(Actor self, WRot orientation);
-	}
-
-	public interface IBodyOrientationInfo : ITraitInfo
-	{
-		WVec LocalToWorld(WVec vec);
-		WRot QuantizeOrientation(WRot orientation, int facings);
-	}
-
 	public interface IQuantizeBodyOrientationInfo : ITraitInfo
 	{
 		int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race);

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Automatically transports harvesters with the Carryable trait between resource fields and refineries.")]
-	public class CarryallInfo : ITraitInfo, Requires<IBodyOrientationInfo>
+	public class CarryallInfo : ITraitInfo, Requires<BodyOrientationInfo>
 	{
 		[Desc("Set to false when the carryall should not automatically get new jobs.")]
 		public readonly bool Automatic = true;

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Rendered when ProductionAirdrop is in progress.")]
-	public class WithDeliveryOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<IBodyOrientationInfo>
+	public class WithDeliveryOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.D2k.Traits
 			this.info = info;
 
 			var rs = self.Trait<RenderSprites>();
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 
 			// always render instantly for units
 			buildComplete = !self.HasTrait<Building>();

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.TS.Traits
 
 		public WithVoxelUnloadBody(Actor self, WithVoxelUnloadBodyInfo info)
 		{
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 			var rv = self.Trait<RenderVoxels>();
 
 			var idleVoxel = VoxelProvider.GetVoxel(rv.Image, info.IdleSequence);

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.TS.Traits
 			this.info = info;
 			movement = self.Trait<IMove>();
 
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 			var rv = self.Trait<RenderVoxels>();
 
 			var voxel = VoxelProvider.GetVoxel(rv.Image, "idle");

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWaterBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWaterBody.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.TS.Traits
 		{
 			this.self = self;
 
-			var body = self.Trait<IBodyOrientation>();
+			var body = self.Trait<BodyOrientation>();
 			var rv = self.Trait<RenderVoxels>();
 
 			var landVoxel = VoxelProvider.GetVoxel(rv.Image, info.LandSequence);


### PR DESCRIPTION
`BodyOrientation[Info]` is the only implementation of `IBodyOrientation[Info]`. Having the redundant interfaces provides inconsistent code (currently uses both to do the same thing). That also has the effect of making `TraitDictionary` keep two identical pairs of lists for the `BodyOrientation` traits and their actors.
I found 9 info classes with `var body = init.Actor.Traits.Get<BodyOrientationInfo>();` in a preview render method:

``` c#
RenderVoxels
    RenderPreview(ActorPreviewInitializer init)

WithBarrelInfo
    RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)

WithIdleOverlayInfo
    RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)

WithParachuteInfo
    RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)

WithRotorInfo
    RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)

WithTurretInfo
    RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)

WithVoxelBodyInfo
    RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)

WithVoxelTurretInfo
    RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)

WithVoxelUnloadBodyInfo
    RenderPreviewVoxels(ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p)
```

`WithVoxel*Info` use `RenderVoxelsInfo` which had `Requires<IBodyOrientationInfo>`.
