### PR TITLE
Extends MapChooserLogic.mapFilter to match against PlayerCount

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -200,11 +200,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void EnumerateMaps(MapClassification tab, ScrollItemWidget template)
 		{
+			int playerCountFilter;
+			if (!int.TryParse(mapFilter, out playerCountFilter))
+				playerCountFilter = -1;
+
 			var maps = tabMaps[tab]
 				.Where(m => gameMode == null || m.Type == gameMode)
 				.Where(m => mapFilter == null ||
 					m.Title.IndexOf(mapFilter, StringComparison.OrdinalIgnoreCase) >= 0 ||
-					m.Author.IndexOf(mapFilter, StringComparison.OrdinalIgnoreCase) >= 0)
+					m.Author.IndexOf(mapFilter, StringComparison.OrdinalIgnoreCase) >= 0 ||
+					m.PlayerCount == playerCountFilter)
 				.OrderBy(m => m.PlayerCount)
 				.ThenBy(m => m.Title);
 


### PR DESCRIPTION
`MapChooserLogic.EnumerateMaps` currently matches `mapFilter` against map's `Title` and `Author`.
This PR extends `Where` predicate to match against `PlayerCount`. 

When choosing a map I often like to browse maps by number of players.
