### PR TITLE
Added thread-affinity checks to SDL2 renderer

### DIFF
--- a/OpenRA.Platforms.Default/ErrorHandler.cs
+++ b/OpenRA.Platforms.Default/ErrorHandler.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Platforms.Default
 {
-	public static class ErrorHandler
+	static class ErrorHandler
 	{
 		public static void CheckGlVersion()
 		{

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -16,10 +16,10 @@ using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Platforms.Default
 {
-	public sealed class FrameBuffer : IFrameBuffer
+	sealed class FrameBuffer : ThreadAffine, IFrameBuffer
 	{
-		Texture texture;
-		Size size;
+		readonly Texture texture;
+		readonly Size size;
 		int framebuffer, depth;
 		bool disposed;
 
@@ -83,6 +83,8 @@ namespace OpenRA.Platforms.Default
 		int[] cv = new int[4];
 		public void Bind()
 		{
+			VerifyThreadAffinity();
+
 			// Cache viewport rect to restore when unbinding
 			cv = ViewportRectangle();
 
@@ -100,6 +102,7 @@ namespace OpenRA.Platforms.Default
 
 		public void Unbind()
 		{
+			VerifyThreadAffinity();
 			GL.Flush();
 			ErrorHandler.CheckGlError();
 			GL.Ext.BindFramebuffer(FramebufferTarget.FramebufferExt, 0);
@@ -108,7 +111,14 @@ namespace OpenRA.Platforms.Default
 			ErrorHandler.CheckGlError();
 		}
 
-		public ITexture Texture { get { return texture; } }
+		public ITexture Texture
+		{
+			get
+			{
+				VerifyThreadAffinity();
+				return texture;
+			}
+		}
 
 		~FrameBuffer()
 		{

--- a/OpenRA.Platforms.Default/MultiTapDetection.cs
+++ b/OpenRA.Platforms.Default/MultiTapDetection.cs
@@ -13,7 +13,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Platforms.Default
 {
-	public static class MultiTapDetection
+	static class MultiTapDetection
 	{
 		static Cache<Keycode, TapHistory> keyHistoryCache =
 			new Cache<Keycode, TapHistory>(_ => new TapHistory(DateTime.Now - TimeSpan.FromSeconds(1)));

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -50,6 +50,7 @@
     <Compile Include="FrameBuffer.cs" />
     <Compile Include="MultiTapDetection.cs" />
     <Compile Include="Texture.cs" />
+    <Compile Include="ThreadAffine.cs" />
     <Compile Include="VertexBuffer.cs" />
     <Compile Include="OpenAlSoundEngine.cs" />
   </ItemGroup>

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -15,7 +15,7 @@ using SDL2;
 
 namespace OpenRA.Platforms.Default
 {
-	public class Sdl2Input
+	class Sdl2Input
 	{
 		MouseButton lastButtonBits = (MouseButton)0;
 

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -17,11 +17,11 @@ using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Platforms.Default
 {
-	public class Shader : IShader
+	class Shader : ThreadAffine, IShader
 	{
 		readonly Dictionary<string, int> samplers = new Dictionary<string, int>();
 		readonly Dictionary<int, ITexture> textures = new Dictionary<int, ITexture>();
-		int program;
+		readonly int program;
 
 		protected int CompileShaderObject(ShaderType type, string name)
 		{
@@ -122,6 +122,7 @@ namespace OpenRA.Platforms.Default
 
 		public void Render(Action a)
 		{
+			VerifyThreadAffinity();
 			GL.UseProgram(program);
 
 			// bind the textures
@@ -138,6 +139,7 @@ namespace OpenRA.Platforms.Default
 
 		public void SetTexture(string name, ITexture t)
 		{
+			VerifyThreadAffinity();
 			if (t == null)
 				return;
 
@@ -148,6 +150,7 @@ namespace OpenRA.Platforms.Default
 
 		public void SetVec(string name, float x)
 		{
+			VerifyThreadAffinity();
 			GL.UseProgram(program);
 			ErrorHandler.CheckGlError();
 			var param = GL.GetUniformLocation(program, name);
@@ -158,6 +161,7 @@ namespace OpenRA.Platforms.Default
 
 		public void SetVec(string name, float x, float y)
 		{
+			VerifyThreadAffinity();
 			GL.UseProgram(program);
 			ErrorHandler.CheckGlError();
 			var param = GL.GetUniformLocation(program, name);
@@ -168,6 +172,7 @@ namespace OpenRA.Platforms.Default
 
 		public void SetVec(string name, float[] vec, int length)
 		{
+			VerifyThreadAffinity();
 			var param = GL.GetUniformLocation(program, name);
 			ErrorHandler.CheckGlError();
 			switch (length)
@@ -184,6 +189,7 @@ namespace OpenRA.Platforms.Default
 
 		public void SetMatrix(string name, float[] mtx)
 		{
+			VerifyThreadAffinity();
 			if (mtx.Length != 16)
 				throw new InvalidDataException("Invalid 4x4 matrix");
 

--- a/OpenRA.Platforms.Default/ThreadAffine.cs
+++ b/OpenRA.Platforms.Default/ThreadAffine.cs
@@ -1,0 +1,31 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Threading;
+
+namespace OpenRA.Platforms.Default
+{
+	abstract class ThreadAffine
+	{
+		readonly int managedThreadId;
+
+		protected ThreadAffine()
+		{
+			managedThreadId = Thread.CurrentThread.ManagedThreadId;
+		}
+
+		protected void VerifyThreadAffinity()
+		{
+			if (managedThreadId != Thread.CurrentThread.ManagedThreadId)
+				throw new InvalidOperationException("Cross-thread operation not valid: This method must be called from the same thread that created this object.");
+		}
+	}
+}

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Platforms.Default
 {
-	public sealed class VertexBuffer<T> : IVertexBuffer<T>
+	sealed class VertexBuffer<T> : ThreadAffine, IVertexBuffer<T>
 			where T : struct
 	{
 		static readonly int VertexSize = Marshal.SizeOf(typeof(T));
@@ -60,6 +60,7 @@ namespace OpenRA.Platforms.Default
 
 		public void Bind()
 		{
+			VerifyThreadAffinity();
 			GL.BindBuffer(BufferTarget.ArrayBuffer, buffer);
 			ErrorHandler.CheckGlError();
 			GL.VertexPointer(3, VertexPointerType.Float, VertexSize, IntPtr.Zero);

--- a/OpenRA.Platforms.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Platforms.Null/NullGraphicsDevice.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Platforms.Null
 {
 	public sealed class NullGraphicsDevice : IGraphicsDevice
 	{
-		public Size WindowSize { get; internal set; }
+		public Size WindowSize { get; private set; }
 
 		public NullGraphicsDevice(Size size, WindowMode window)
 		{


### PR DESCRIPTION
If a call is made into a graphics resource that has thread-affinity, from a thread other than the one that created the graphics device, an exception will now be thrown to make debugging easier.
