### PR TITLE
Adds FindActorsInAnnulus and tweaks AI scan for enemies

### DIFF
--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -32,12 +32,25 @@ namespace OpenRA
 
 		public static IEnumerable<Actor> FindActorsInCircle(this World world, WPos origin, WDist r)
 		{
-			using (new PerfSample("FindUnitsInCircle"))
+			using (new PerfSample("FindActorsInCircle"))
 			{
 				// Target ranges are calculated in 2D, so ignore height differences
 				var vec = new WVec(r, r, WDist.Zero);
 				return world.ActorMap.ActorsInBox(origin - vec, origin + vec).Where(
 					a => (a.CenterPosition - origin).HorizontalLengthSquared <= r.LengthSquared);
+			}
+		}
+
+		public static IEnumerable<Actor> FindActorsInAnnulus(this World world, WPos origin, WDist min, WDist max)
+		{
+			using (new PerfSample("FindActorsInAnnulus"))
+			{
+				// Target ranges are calculated in 2D, so ignore height differences
+				var minVec = new WVec(min, min, WDist.Zero);
+				var maxVec = new WVec(max, max, WDist.Zero);
+				return world.ActorMap.ActorsInBox((origin + minVec) - maxVec, (origin - minVec) + maxVec).Where(
+					a => (a.CenterPosition - origin).HorizontalLengthSquared <= max.LengthSquared
+						&& (a.CenterPosition - origin).HorizontalLengthSquared >= min.LengthSquared);
 			}
 		}
 

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -502,16 +502,16 @@ namespace OpenRA.Mods.Common.AI
 
 					foreach (var c in nearbyResources)
 					{
-						var found = findPos(c, baseCenter, 0, Info.MaxBaseRadius);
+						var found = findPos(c, baseCenter, 2, Info.MaxBaseRadius);
 						if (found != null)
 							return found;
 					}
 
 					// Try and find a free spot somewhere else in the base
-					return findPos(baseCenter, baseCenter, 0, Info.MaxBaseRadius);
+					return findPos(baseCenter, baseCenter, 2, Info.MaxBaseRadius);
 
 				case BuildingType.Building:
-					return findPos(baseCenter, baseCenter, 0, distanceToBaseIsImportant ? Info.MaxBaseRadius : Map.MaxTilesInCircleRange);
+					return findPos(baseCenter, baseCenter, 2, distanceToBaseIsImportant ? Info.MaxBaseRadius : Map.MaxTilesInCircleRange);
 			}
 
 			// Can't find a build location

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -37,8 +37,12 @@ namespace OpenRA.Mods.Common.AI
 				owner.TargetActor = t;
 			}
 
-			var enemyUnits = owner.World.FindActorsInCircle(owner.TargetActor.CenterPosition, WDist.FromCells(10))
+			var enemyUnits = owner.World.FindActorsInAnnulus(owner.TargetActor.CenterPosition, WDist.FromCells(1), WDist.FromCells(7))
 				.Where(unit => owner.Bot.Player.Stances[unit.Owner] == Stance.Enemy).ToList();
+
+			if (!enemyUnits.Any())
+				enemyUnits = owner.World.FindActorsInAnnulus(owner.TargetActor.CenterPosition, WDist.FromCells(7), WDist.FromCells(10))
+					.Where(unit => owner.Bot.Player.Stances[unit.Owner] == Stance.Enemy).ToList();
 
 			if (enemyUnits.Any())
 			{
@@ -93,8 +97,13 @@ namespace OpenRA.Mods.Common.AI
 			}
 			else
 			{
-				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(12))
+				var enemies = owner.World.FindActorsInAnnulus(leader.CenterPosition, WDist.FromCells(1), WDist.FromCells(8))
 					.Where(a1 => !a1.Disposed && !a1.IsDead);
+
+				if (!enemies.Any())
+					enemies = owner.World.FindActorsInAnnulus(leader.CenterPosition, WDist.FromCells(8), WDist.FromCells(12))
+						.Where(a1 => !a1.Disposed && !a1.IsDead);
+
 				var enemynearby = enemies.Where(a1 => a1.HasTrait<ITargetable>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
 				var target = enemynearby.ClosestTo(leader.CenterPosition);
 				if (target != null)


### PR DESCRIPTION
An attempt to improve performance of AI scans for nearby enemies by only checking the last third of the radius if nothing was found in the first 2/3.

Additionally gave ChooseBuildLocation check a minimum distance of 2 cells, as the center cell and the 8 adjacent cells will normally be occupied by the construction yard (or its bib) anyway.
