### PR TITLE
Fixed TS crane overlay's last frame hiding idle overlay

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Animation overlay;
 		bool buildComplete;
+		bool visible;
 
 		public WithBuildingPlacedOverlay(Actor self, WithBuildingPlacedOverlayInfo info)
 		{
@@ -47,15 +48,16 @@ namespace OpenRA.Mods.Common.Traits
 
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-				() => !buildComplete);
+				() => !visible || !buildComplete);
 
-			overlay.Play(info.Sequence);
+			overlay.PlayThen(info.Sequence, () => visible = false);
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
 		public void BuildingComplete(Actor self)
 		{
 			buildComplete = true;
+			visible = false;
 		}
 
 		public void Sold(Actor self) { }
@@ -79,7 +81,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void BuildingPlaced(Actor self)
 		{
-			overlay.Play(overlay.CurrentSequence.Name);
+			visible = true;
+			overlay.PlayThen(overlay.CurrentSequence.Name, () => visible = false);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -39,6 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Animation overlay;
 		bool buildComplete;
+		bool visible;
 
 		public WithRepairOverlay(Actor self, WithRepairOverlayInfo info)
 		{
@@ -47,11 +48,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
-			overlay.Play(info.Sequence);
+			overlay.PlayThen(info.Sequence, () => visible = false);
 
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-				() => !buildComplete,
+				() => !visible || !buildComplete,
 				() => info.PauseOnLowPower && self.IsDisabled(),
 				p => WithTurret.ZOffsetFromCenter(self, p, 1));
 
@@ -77,7 +78,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Repairing(Actor self, Actor host)
 		{
-			overlay.Play(overlay.CurrentSequence.Name);
+			visible = true;
+			overlay.PlayThen(overlay.CurrentSequence.Name, () => visible = false);
 		}
 	}
 }

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -233,7 +233,7 @@ GADEPT:
 		Sequence: idle-light
 	WithIdleOverlay@GROUND:
 		Sequence: ground
-	WithRepairOverlay@CIRCUITS:
+	WithIdleOverlay@CIRCUITS:
 		Sequence: circuits
 	WithRepairOverlay@CRANE:
 		Sequence: crane

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -1073,10 +1073,12 @@ gadept.gdi:
 	circuits: gtdept_a
 		Length: 5
 		ZOffset: -1c511
+		Tick: 120
 	damaged-circuits: gtdept_a
 		Start: 5
 		Length: 5
 		ZOffset: -1c511
+		Tick: 120
 	crane: gtdept_c
 		Length: 16
 	platform: gtdept_d
@@ -1129,10 +1131,12 @@ gadept.nod:
 	circuits: gtdept_a
 		Length: 5
 		ZOffset: -1c511
+		Tick: 120
 	damaged-circuits: gtdept_a
 		Start: 5
 		Length: 5
 		ZOffset: -1c511
+		Tick: 120
 	crane: gtdept_c
 		Length: 16
 	platform: gtdept_d


### PR DESCRIPTION
TS crane overlay's last frame no longer overlaps idle overlay. `WithBuildingPlacedOverlay` is now only visible while playing the animation, rather than sticking around.

Fixes #9319.
