### PR TITLE
Changed missed ActorInfo.Traits.Contains => ActorInfo.HasTraitInfo

### DIFF
--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -254,9 +254,9 @@ namespace OpenRA.Scripting
 		static readonly object[] NoArguments = new object[0];
 		Type[] FilterActorCommands(ActorInfo ai)
 		{
-			var method = typeof(TypeDictionary).GetMethod("Contains");
+			var method = typeof(ActorInfo).GetMethod("HasTraitInfo");
 			return knownActorCommands.Where(c => ExtractRequiredTypes(c)
-				.All(t => (bool)method.MakeGenericMethod(t).Invoke(ai.Traits, NoArguments)))
+				.All(t => (bool)method.MakeGenericMethod(t).Invoke(ai, NoArguments)))
 				.ToArray();
 		}
 

--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -141,9 +141,9 @@ namespace OpenRA.Mods.Common.AI
 				// HACK: HACK HACK HACK
 				// TODO: Derive this from BuildingCommonNames instead
 				var type = BuildingType.Building;
-				if (world.Map.Rules.Actors[currentBuilding.Item].Traits.Contains<AttackBaseInfo>())
+				if (world.Map.Rules.Actors[currentBuilding.Item].HasTraitInfo<AttackBaseInfo>())
 					type = BuildingType.Defense;
-				else if (world.Map.Rules.Actors[currentBuilding.Item].Traits.Contains<RefineryInfo>())
+				else if (world.Map.Rules.Actors[currentBuilding.Item].HasTraitInfo<RefineryInfo>())
 					type = BuildingType.Refinery;
 
 				var location = ai.ChooseBuildLocation(currentBuilding.Item, true, type);


### PR DESCRIPTION
Somehow (possibly by rebasing) I missed a couple in `OpenRA.Mods.Common/AI/BaseBuilder.cs`.
The change to is both for completeness and my next PR to finish wrapping of `ActorInfo.Traits` and make it private.
