### PR TITLE
Finish wrapping ActorInfo.Traits

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -67,6 +67,13 @@ namespace OpenRA
 			}
 		}
 
+		public ActorInfo(string name, params ITraitInfo[] traitInfos)
+		{
+			Name = name;
+			foreach (var t in traitInfos)
+				Traits.Add(t);
+		}
+
 		static Dictionary<string, MiniYaml> GetParents(MiniYaml node, Dictionary<string, MiniYaml> allUnits)
 		{
 			return node.Nodes.Where(n => n.Key == "Inherits" || n.Key.StartsWith("Inherits@"))

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -187,5 +187,6 @@ namespace OpenRA
 		public bool HasTraitInfo<T>() where T : ITraitInfo { return Traits.Contains<T>(); }
 		public T TraitInfo<T>() where T : ITraitInfo { return Traits.Get<T>(); }
 		public T TraitInfoOrDefault<T>() where T : ITraitInfo { return Traits.GetOrDefault<T>(); }
+		public IEnumerable<T> TraitInfos<T>() where T : ITraitInfo { return Traits.WithInterface<T>(); }
 	}
 }

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -28,7 +28,7 @@ namespace OpenRA
 		/// You can remove inherited traits by adding a - infront of them as in -TraitName: to inherit everything, but this trait.
 		/// </summary>
 		public readonly string Name;
-		public readonly TypeDictionary Traits = new TypeDictionary();
+		readonly TypeDictionary traits = new TypeDictionary();
 		List<ITraitInfo> constructOrderCache = null;
 
 		public ActorInfo(string name, MiniYaml node, Dictionary<string, MiniYaml> allUnits)
@@ -52,7 +52,7 @@ namespace OpenRA
 					if (t.Key != "Inherits" && !t.Key.StartsWith("Inherits@"))
 						try
 						{
-							Traits.Add(LoadTraitInfo(t.Key.Split('@')[0], t.Value));
+							traits.Add(LoadTraitInfo(t.Key.Split('@')[0], t.Value));
 						}
 						catch (FieldLoader.MissingFieldsException e)
 						{
@@ -71,7 +71,7 @@ namespace OpenRA
 		{
 			Name = name;
 			foreach (var t in traitInfos)
-				Traits.Add(t);
+				traits.Add(t);
 		}
 
 		static Dictionary<string, MiniYaml> GetParents(MiniYaml node, Dictionary<string, MiniYaml> allUnits)
@@ -128,7 +128,7 @@ namespace OpenRA
 			if (constructOrderCache != null)
 				return constructOrderCache;
 
-			var source = Traits.WithInterface<ITraitInfo>().Select(i => new
+			var source = traits.WithInterface<ITraitInfo>().Select(i => new
 			{
 				Trait = i,
 				Type = i.GetType(),
@@ -179,7 +179,7 @@ namespace OpenRA
 
 		public IEnumerable<Pair<string, Type>> GetInitKeys()
 		{
-			var inits = Traits.WithInterface<ITraitInfo>().SelectMany(
+			var inits = traits.WithInterface<ITraitInfo>().SelectMany(
 				t => t.GetType().GetInterfaces()
 					.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(UsesInit<>))
 					.Select(i => i.GetGenericArguments()[0])).ToList();
@@ -191,9 +191,9 @@ namespace OpenRA
 					i.Name.Replace("Init", ""), i));
 		}
 
-		public bool HasTraitInfo<T>() where T : ITraitInfo { return Traits.Contains<T>(); }
-		public T TraitInfo<T>() where T : ITraitInfo { return Traits.Get<T>(); }
-		public T TraitInfoOrDefault<T>() where T : ITraitInfo { return Traits.GetOrDefault<T>(); }
-		public IEnumerable<T> TraitInfos<T>() where T : ITraitInfo { return Traits.WithInterface<T>(); }
+		public bool HasTraitInfo<T>() where T : ITraitInfo { return traits.Contains<T>(); }
+		public T TraitInfo<T>() where T : ITraitInfo { return traits.Get<T>(); }
+		public T TraitInfoOrDefault<T>() where T : ITraitInfo { return traits.GetOrDefault<T>(); }
+		public IEnumerable<T> TraitInfos<T>() where T : ITraitInfo { return traits.WithInterface<T>(); }
 	}
 }

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Graphics
 			var width = b.Width;
 			var height = b.Height + heightOffset;
 
-			var resources = resourceRules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>()
+			var resources = resourceRules.Actors["world"].TraitInfos<ResourceTypeInfo>()
 				.ToDictionary(r => r.ResourceType, r => r.TerrainType);
 
 			var bitmapData = terrain.LockBits(terrain.Bounds(),

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -28,8 +28,8 @@ namespace OpenRA
 
 		public MapPlayers(Ruleset rules, int playerCount)
 		{
-			var firstFaction = rules.Actors["world"].Traits
-				.WithInterface<FactionInfo>().First(f => f.Selectable).InternalName;
+			var firstFaction = rules.Actors["world"].TraitInfos<FactionInfo>()
+				.First(f => f.Selectable).InternalName;
 
 			Players = new Dictionary<string, PlayerReference>
 			{

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -53,8 +53,8 @@ namespace OpenRA
 
 		static FactionInfo ChooseFaction(World world, string name, bool requireSelectable = true)
 		{
-			var selectableFactions = world.Map.Rules.Actors["world"].Traits
-				.WithInterface<FactionInfo>().Where(f => !requireSelectable || f.Selectable)
+			var selectableFactions = world.Map.Rules.Actors["world"].TraitInfos<FactionInfo>()
+				.Where(f => !requireSelectable || f.Selectable)
 				.ToList();
 
 			var selected = selectableFactions.FirstOrDefault(f => f.InternalName == name)
@@ -75,7 +75,7 @@ namespace OpenRA
 
 		static FactionInfo ChooseDisplayFaction(World world, string factionName)
 		{
-			var factions = world.Map.Rules.Actors["world"].Traits.WithInterface<FactionInfo>().ToArray();
+			var factions = world.Map.Rules.Actors["world"].TraitInfos<FactionInfo>().ToArray();
 
 			return factions.FirstOrDefault(f => f.InternalName == factionName) ?? factions.First();
 		}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -394,7 +394,7 @@ namespace OpenRA
 		public static string SanitizedPlayerName(string dirty)
 		{
 			var forbiddenNames = new string[] { "Open", "Closed" };
-			var botNames = OpenRA.Game.ModData.DefaultRules.Actors["player"].Traits.WithInterface<IBotInfo>().Select(t => t.Name);
+			var botNames = OpenRA.Game.ModData.DefaultRules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name);
 
 			var clean = SanitizedName(dirty);
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -279,7 +279,7 @@ namespace OpenRA.Traits
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfo { }
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
-	public interface UsesInit<T> where T : IActorInit { }
+	public interface UsesInit<T> : ITraitInfo where T : IActorInit { }
 
 	public interface INotifySelected { void Selected(Actor self); }
 	public interface INotifySelection { void SelectionChanged(); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Traits
 		bool HasVoice(Actor self, string voice);
 	}
 
-	public interface IDemolishableInfo { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }
+	public interface IDemolishableInfo : ITraitInfo { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }
 	public interface IDemolishable
 	{
 		void Demolish(Actor self, Actor saboteur);
@@ -172,7 +172,7 @@ namespace OpenRA.Traits
 		IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self);
 	}
 
-	public interface IDefaultVisibilityInfo { }
+	public interface IDefaultVisibilityInfo : ITraitInfo { }
 	public interface IDefaultVisibility { bool IsVisible(Actor self, Player byPlayer); }
 	public interface IVisibilityModifier { bool IsVisible(Actor self, Player byPlayer); }
 	public interface IFogVisibilityModifier { bool HasFogVisibility(Player byPlayer); }
@@ -286,7 +286,7 @@ namespace OpenRA.Traits
 	public interface IWorldLoaded { void WorldLoaded(World w, WorldRenderer wr); }
 	public interface ICreatePlayers { void CreatePlayers(World w); }
 
-	public interface IBotInfo { string Name { get; } }
+	public interface IBotInfo : ITraitInfo { string Name { get; } }
 	public interface IBot
 	{
 		void Activate(Player p);

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var endPos = new CPos(owner.World.Map.Bounds.Left - 5, self.Location.Y);
 
 			// Assume a single exit point for simplicity
-			var exit = self.Info.Traits.WithInterface<ExitInfo>().First();
+			var exit = self.Info.TraitInfos<ExitInfo>().First();
 
 			foreach (var tower in self.TraitsImplementing<INotifyDelivery>())
 				tower.IncomingDelivery(self);

--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -209,7 +209,7 @@ namespace OpenRA.Mods.Common.AI
 
 		bool HasSufficientPowerForActor(ActorInfo actorInfo)
 		{
-			return (actorInfo.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1)
+			return (actorInfo.TraitInfos<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1)
 				.Sum(p => p.Amount) + playerPower.ExcessPower) >= ai.Info.MinimumExcessPower;
 		}
 
@@ -219,12 +219,12 @@ namespace OpenRA.Mods.Common.AI
 
 			// This gets used quite a bit, so let's cache it here
 			var power = GetProducibleBuilding("Power", buildableThings,
-				a => a.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(p => p.Amount));
+				a => a.TraitInfos<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(p => p.Amount));
 
 			// First priority is to get out of a low power situation
 			if (playerPower.ExcessPower < ai.Info.MinimumExcessPower)
 			{
-				if (power != null && power.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(p => p.Amount) > 0)
+				if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(p => p.Amount) > 0)
 				{
 					HackyAI.BotDebug("AI: {0} decided to build {1}: Priority override (low power)", queue.Actor.Owner, power.Name);
 					return power;
@@ -331,7 +331,7 @@ namespace OpenRA.Mods.Common.AI
 				if (playerPower.ExcessPower < ai.Info.MinimumExcessPower || !HasSufficientPowerForActor(actor))
 				{
 					// Try building a power plant instead
-					if (power != null && power.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(pi => pi.Amount) > 0)
+					if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(pi => pi.Amount) > 0)
 					{
 						if (playerPower.PowerOutageRemainingTicks > 0)
 							HackyAI.BotDebug("{0} decided to build {1}: Priority override (is low power)", queue.Actor.Owner, power.Name);

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -272,7 +272,7 @@ namespace OpenRA.Mods.Common.AI
 			minAttackForceDelayTicks = Random.Next(0, Info.MinimumAttackForceDelay);
 
 			resourceTypeIndices = new BitArray(World.TileSet.TerrainInfo.Length); // Big enough
-			foreach (var t in Map.Rules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>())
+			foreach (var t in Map.Rules.Actors["world"].TraitInfos<ResourceTypeInfo>())
 				resourceTypeIndices.Set(World.TileSet.GetTerrainIndex(t.TerrainType), true);
 		}
 
@@ -437,7 +437,7 @@ namespace OpenRA.Mods.Common.AI
 			if (aircraftInfo == null)
 				return true;
 
-			var ammoPoolsInfo = actorInfo.Traits.WithInterface<AmmoPoolInfo>();
+			var ammoPoolsInfo = actorInfo.TraitInfos<AmmoPoolInfo>();
 
 			if (ammoPoolsInfo.Any(x => !x.SelfReloads))
 			{

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturn.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturn.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 				heli.Reservation = res.Reserve(dest, self, heli);
 			}
 
-			var exit = dest.Info.Traits.WithInterface<ExitInfo>().FirstOrDefault();
+			var exit = dest.Info.TraitInfos<ExitInfo>().FirstOrDefault();
 			var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
 
 			return Util.SequenceActivities(

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -96,13 +96,13 @@ namespace OpenRA.Mods.Common.Widgets
 					var facing = underCursor.Init<FacingInit>();
 					if (facing != null)
 						underCursor.ReplaceInit(new FacingInit((facing.Value(world) + mi.ScrollDelta) % 256));
-					else if (underCursor.Info.Traits.WithInterface<UsesInit<FacingInit>>().Any())
+					else if (underCursor.Info.HasTraitInfo<UsesInit<FacingInit>>())
 						underCursor.ReplaceInit(new FacingInit(mi.ScrollDelta));
 
 					var turret = underCursor.Init<TurretFacingInit>();
 					if (turret != null)
 						underCursor.ReplaceInit(new TurretFacingInit((turret.Value(world) + mi.ScrollDelta) % 256));
-					else if (underCursor.Info.Traits.WithInterface<UsesInit<TurretFacingInit>>().Any())
+					else if (underCursor.Info.HasTraitInfo<UsesInit<TurretFacingInit>>())
 						underCursor.ReplaceInit(new TurretFacingInit(mi.ScrollDelta));
 				}
 			}

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Lint
 			this.emitError = emitError;
 
 			foreach (var actorInfo in rules.Actors)
-				foreach (var traitInfo in actorInfo.Value.Traits.WithInterface<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
 					CheckTrait(actorInfo.Value, traitInfo, rules);
 		}
 

--- a/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				var animations = actorInfo.Value.Traits.WithInterface<WithDeathAnimationInfo>().ToList();
+				var animations = actorInfo.Value.TraitInfos<WithDeathAnimationInfo>().ToList();
 				if (!animations.Any())
 					continue;
 
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Lint
 				if (!deathTypes.Any())
 					continue;
 
-				var targetable = actorInfo.Value.Traits.WithInterface<ITargetableInfo>().SelectMany(x => x.GetTargetTypes()).ToList();
+				var targetable = actorInfo.Value.TraitInfos<ITargetableInfo>().SelectMany(x => x.GetTargetTypes()).ToList();
 				if (!targetable.Any())
 					continue;
 

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Lint
 				if (actorInfo.Key.StartsWith("^"))
 					continue;
 
-				var count = actorInfo.Value.Traits.WithInterface<IDefaultVisibilityInfo>().Count();
+				var count = actorInfo.Value.TraitInfos<IDefaultVisibilityInfo>().Count();
 
 				if (count == 0)
 					emitError("Actor type `{0}` does not define a default visibility type!".F(actorInfo.Key));

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.Traits)
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<PaletteReferenceAttribute>()))
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.Traits)
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<PaletteDefinitionAttribute>()))

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			var worldActor = map.Rules.Actors["world"];
 
-			var factions = worldActor.Traits.WithInterface<FactionInfo>().Select(f => f.InternalName).ToHashSet();
+			var factions = worldActor.TraitInfos<FactionInfo>().Select(f => f.InternalName).ToHashSet();
 			foreach (var player in players.Values)
 				if (!string.IsNullOrWhiteSpace(player.Faction) && !factions.Contains(player.Faction))
 					emitError("Invalid faction {0} chosen for player {1}.".F(player.Faction, player.Name));

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Lint
 					continue;
 
 				var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();
-				foreach (var rsi in actorInfo.Value.Traits.WithInterface<RevealsShroudInfo>())
+				foreach (var rsi in actorInfo.Value.TraitInfos<RevealsShroudInfo>())
 				{
 					if (rsi.Type == VisibilityType.CenterPosition)
 						continue;

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -36,12 +36,12 @@ namespace OpenRA.Mods.Common.Lint
 				Game.ModData.Manifest.Sequences.Select(MiniYaml.FromFile).Aggregate(MiniYaml.MergeLiberal));
 
 			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
-			var factions = rules.Actors["world"].Traits.WithInterface<FactionInfo>().Select(f => f.InternalName).ToArray();
+			var factions = rules.Actors["world"].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();
 			var sequenceProviders = map == null ? rules.Sequences.Values : new[] { rules.Sequences[map.Tileset] };
 
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var renderInfo in actorInfo.Value.Traits.WithInterface<RenderSpritesInfo>())
+				foreach (var renderInfo in actorInfo.Value.TraitInfos<RenderSpritesInfo>())
 				{
 					foreach (var faction in factions)
 					{
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Lint
 								if (string.IsNullOrEmpty(sequence))
 									continue;
 
-								var renderInfo = actorInfo.Value.Traits.WithInterface<RenderSpritesInfo>().FirstOrDefault();
+								var renderInfo = actorInfo.Value.TraitInfos<RenderSpritesInfo>().FirstOrDefault();
 								if (renderInfo == null)
 									continue;
 

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Lint
 					}
 				}
 
-				foreach (var traitInfo in actorInfo.Value.Traits.WithInterface<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields)

--- a/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var trait in actorInfo.Value.Traits)
+				foreach (var trait in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = trait.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeUsedReferenceAttribute>()))
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Lint
 			// Check all upgrades granted by traits.
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var trait in actorInfo.Value.Traits)
+				foreach (var trait in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = trait.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeGrantedReferenceAttribute>()))
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Lint
 			// Get all upgrades granted by traits.
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var trait in actorInfo.Value.Traits)
+				foreach (var trait in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = trait.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeGrantedReferenceAttribute>()))
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var trait in actorInfo.Value.Traits)
+				foreach (var trait in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = trait.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeUsedReferenceAttribute>()))

--- a/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
@@ -111,14 +111,14 @@ namespace OpenRA.Mods.Common.Lint
 			}
 
 			// TODO: HACK because GainsExperience grants upgrades differently to most other sources.
-			var gainsExperience = rules.Actors.SelectMany(x => x.Value.Traits.WithInterface<GainsExperienceInfo>()
+			var gainsExperience = rules.Actors.SelectMany(x => x.Value.TraitInfos<GainsExperienceInfo>()
 				.SelectMany(y => y.Upgrades.SelectMany(z => z.Value)));
 
 			foreach (var upgrade in gainsExperience)
 				yield return upgrade;
 
 			// TODO: HACK because Pluggable grants upgrades differently to most other sources.
-			var pluggable = rules.Actors.SelectMany(x => x.Value.Traits.WithInterface<PluggableInfo>()
+			var pluggable = rules.Actors.SelectMany(x => x.Value.TraitInfos<PluggableInfo>()
 				.SelectMany(y => y.Upgrades.SelectMany(z => z.Value)));
 
 			foreach (var upgrade in pluggable)
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			// TODO: HACK because GainsExperience and GainsStatUpgrades do not play by the rules...
 			// We assume everything GainsExperience grants is used by GainsStatUpgrade
-			var gainsExperience = rules.Actors.SelectMany(x => x.Value.Traits.WithInterface<GainsExperienceInfo>()
+			var gainsExperience = rules.Actors.SelectMany(x => x.Value.TraitInfos<GainsExperienceInfo>()
 				.SelectMany(y => y.Upgrades.SelectMany(z => z.Value)));
 
 			foreach (var upgrade in gainsExperience)

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.Traits.WithInterface<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<VoiceSetReferenceAttribute>());
 					foreach (var field in fields)
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			var soundInfo = rules.Voices[voiceSet.ToLowerInvariant()];
 
-			foreach (var traitInfo in actorInfo.Traits.WithInterface<ITraitInfo>())
+			foreach (var traitInfo in actorInfo.TraitInfos<ITraitInfo>())
 			{
 				var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<VoiceReferenceAttribute>());
 				foreach (var field in fields)

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -20,13 +20,12 @@ namespace OpenRA.Mods.Common.Lint
 		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
 		{
 			// ProvidesPrerequisite allows arbitrary prereq definitions
-			var customPrereqs = rules.Actors.SelectMany(a => a.Value.Traits
-				.WithInterface<ProvidesPrerequisiteInfo>().Select(p => p.Prerequisite ?? a.Value.Name));
+			var customPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ProvidesPrerequisiteInfo>()
+				.Select(p => p.Prerequisite ?? a.Value.Name));
 
 			// ProvidesTechPrerequisite allows arbitrary prereq definitions
 			// (but only one group at a time during gameplay)
-			var techPrereqs = rules.Actors.SelectMany(a => a.Value.Traits
-				.WithInterface<ProvidesTechPrerequisiteInfo>())
+			var techPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ProvidesTechPrerequisiteInfo>())
 				.SelectMany(p => p.Prerequisites);
 
 			var providedPrereqs = customPrereqs.Concat(techPrereqs);

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Orders
 			var rules = world.Map.Rules;
 
 			var actorInfo = rules.Actors[building];
-			foreach (var dec in actorInfo.Traits.WithInterface<IPlaceBuildingDecoration>())
+			foreach (var dec in actorInfo.TraitInfos<IPlaceBuildingDecorationInfo>())
 				foreach (var r in dec.Render(wr, world, actorInfo, world.Map.CenterOfCell(xy)))
 					yield return r;
 
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.Common.Orders
 					};
 
 					var init = new ActorPreviewInitializer(rules.Actors[building], wr, td);
-					preview = rules.Actors[building].Traits.WithInterface<IRenderActorPreviewInfo>()
+					preview = rules.Actors[building].TraitInfos<IRenderActorPreviewInfo>()
 						.SelectMany(rpi => rpi.RenderPreview(init))
 						.ToArray();
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -620,7 +620,7 @@ namespace OpenRA.Mods.Common.Server
 							return true;
 						}
 
-						var startUnitsInfo = server.Map.Rules.Actors["world"].Traits.WithInterface<MPStartUnitsInfo>();
+						var startUnitsInfo = server.Map.Rules.Actors["world"].TraitInfos<MPStartUnitsInfo>();
 						var selectedClass = startUnitsInfo.Where(u => u.Class == s).Select(u => u.ClassName).FirstOrDefault();
 						var className = selectedClass != null ? selectedClass : s;
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Server
 
 			if (server.LobbyInfo.GlobalSettings.StartingUnitsClass != defaults.StartingUnitsClass)
 			{
-				var startUnitsInfo = server.Map.Rules.Actors["world"].Traits.WithInterface<MPStartUnitsInfo>();
+				var startUnitsInfo = server.Map.Rules.Actors["world"].TraitInfos<MPStartUnitsInfo>();
 				var selectedClass = startUnitsInfo.Where(u => u.Class == server.LobbyInfo.GlobalSettings.StartingUnitsClass).Select(u => u.ClassName).FirstOrDefault();
 				var className = selectedClass != null ? selectedClass : server.LobbyInfo.GlobalSettings.StartingUnitsClass;
 				server.SendOrderTo(conn, "Message", "Starting Units: {0}".F(className));

--- a/OpenRA.Mods.Common/Traits/Air/Helicopter.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Helicopter.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 						if (res != null)
 							Reservation = res.Reserve(order.TargetActor, self, this);
 
-						var exit = order.TargetActor.Info.Traits.WithInterface<ExitInfo>().FirstOrDefault();
+						var exit = order.TargetActor.Info.TraitInfos<ExitInfo>().FirstOrDefault();
 						var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
 
 						self.SetTargetLine(Target.FromActor(order.TargetActor), Color.Green);

--- a/OpenRA.Mods.Common/Traits/C4Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/C4Demolition.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
-				return target.Info.Traits.WithInterface<IDemolishableInfo>().Any(i => i.IsValidTarget(target.Info, self));
+				return target.Info.TraitInfos<IDemolishableInfo>().Any(i => i.IsValidTarget(target.Info, self));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows the player to execute build orders.", " Attach this to the player actor.")]
-	public class PlaceBuildingInfo : ITraitInfo, IPlaceBuildingDecoration
+	public class PlaceBuildingInfo : ITraitInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Palette to use for rendering the placement sprite.")]
 		[PaletteReference] public readonly string Palette = "terrain";

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			// Pick a spawn/exit point pair
-			var exit = self.Info.Traits.WithInterface<ExitInfo>().Shuffle(self.World.SharedRandom)
+			var exit = self.Info.TraitInfos<ExitInfo>().Shuffle(self.World.SharedRandom)
 				.FirstOrDefault(e => CanUseExit(self, producee, e));
 
 			if (exit != null || !occupiesSpace)

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Draw a circle indicating my weapon's range.")]
-	class RenderRangeCircleInfo : ITraitInfo, IPlaceBuildingDecoration, Requires<AttackBaseInfo>
+	class RenderRangeCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo, Requires<AttackBaseInfo>
 	{
 		public readonly string RangeCircleType = null;
 
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
-			var armaments = ai.Traits.WithInterface<ArmamentInfo>()
+			var armaments = ai.TraitInfos<ArmamentInfo>()
 				.Where(a => a.UpgradeMinEnabledLevel == 0);
 			var range = FallbackRange;
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public interface IRenderActorPreviewSpritesInfo
+	public interface IRenderActorPreviewSpritesInfo : ITraitInfo
 	{
 		IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p);
 	}
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			foreach (var spi in init.Actor.Traits.WithInterface<IRenderActorPreviewSpritesInfo>())
+			foreach (var spi in init.Actor.TraitInfos<IRenderActorPreviewSpritesInfo>())
 				foreach (var preview in spi.RenderPreviewSprites(init, this, image, facings, palette))
 					yield return preview;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public interface IRenderActorPreviewVoxelsInfo
+	public interface IRenderActorPreviewVoxelsInfo : ITraitInfo
 	{
 		IEnumerable<VoxelAnimation> RenderPreviewVoxels(
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, WRot orientation, int facings, PaletteReference p);
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			var ifacing = init.Actor.TraitInfoOrDefault<IFacingInfo>();
 			var facing = ifacing != null ? init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing() : 0;
 			var orientation = WRot.FromFacing(facing);
-			var components = init.Actor.Traits.WithInterface<IRenderActorPreviewVoxelsInfo>()
+			var components = init.Actor.TraitInfos<IRenderActorPreviewVoxelsInfo>()
 				.SelectMany(rvpi => rvpi.RenderPreviewVoxels(init, this, image, orientation, facings, palette))
 				.ToArray();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
@@ -37,9 +37,9 @@ namespace OpenRA.Mods.Common.Traits
 				yield break;
 
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var armament = init.Actor.Traits.WithInterface<ArmamentInfo>()
+			var armament = init.Actor.TraitInfos<ArmamentInfo>()
 				.First(a => a.Name == Armament);
-			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
+			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == armament.Turret);
 
 			var anim = new Animation(init.World, image, () => t.InitialFacing);

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders an arbitrary circle when selected or placing a structure")]
-	class WithRangeCircleInfo : ITraitInfo, IPlaceBuildingDecoration
+	class WithRangeCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Type of range circle. used to decide which circles to draw on other structures during building placement.")]
 		public readonly string Type = null;

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 				yield break;
 
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
+			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 
 			var ifacing = init.Actor.TraitInfoOrDefault<IFacingInfo>();

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretedSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretedSpriteBody.cs
@@ -24,8 +24,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			var t = init.Actor.Traits.WithInterface<TurretedInfo>().FirstOrDefault();
-			var wsb = init.Actor.Traits.WithInterface<WithSpriteBodyInfo>().FirstOrDefault();
+			var t = init.Actor.TraitInfos<TurretedInfo>().FirstOrDefault();
+			var wsb = init.Actor.TraitInfos<WithSpriteBodyInfo>().FirstOrDefault();
 
 			// Show the correct turret facing
 			var anim = new Animation(init.World, image, () => t.InitialFacing);

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -35,9 +35,9 @@ namespace OpenRA.Mods.Common.Traits
 				yield break;
 
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var armament = init.Actor.Traits.WithInterface<ArmamentInfo>()
+			var armament = init.Actor.TraitInfos<ArmamentInfo>()
 				.First(a => a.Name == Armament);
-			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
+			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == armament.Turret);
 
 			var voxel = VoxelProvider.GetVoxel(image, Sequence);

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 				yield break;
 
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var t = init.Actor.Traits.WithInterface<TurretedInfo>()
+			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 
 			var voxel = VoxelProvider.GetVoxel(image, Sequence);

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			manager = self.Trait<UpgradeManager>();
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
-			canTurn = self.Info.Traits.WithInterface<IFacingInfo>().Any();
+			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
 			body = Exts.Lazy(self.TraitOrDefault<ISpriteBody>);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Traits
 		void GeneratePreviews()
 		{
 			var init = new ActorPreviewInitializer(Info, worldRenderer, actor.InitDict);
-			previews = Info.Traits.WithInterface<IRenderActorPreviewInfo>()
+			previews = Info.TraitInfos<IRenderActorPreviewInfo>()
 				.SelectMany(rpi => rpi.RenderPreview(init))
 				.ToArray();
 		}

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		static void SpawnUnitsForPlayer(World w, Player p, CPos sp)
 		{
 			var spawnClass = p.PlayerReference.StartingUnitsClass ?? w.LobbyInfo.GlobalSettings.StartingUnitsClass;
-			var unitGroup = w.Map.Rules.Actors["world"].Traits.WithInterface<MPStartUnitsInfo>()
+			var unitGroup = w.Map.Rules.Actors["world"].TraitInfos<MPStartUnitsInfo>()
 				.Where(g => g.Class == spawnClass && g.Factions != null && g.Factions.Contains(p.Faction.InternalName))
 				.RandomOrDefault(w.SharedRandom);
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		void OnNotifyResourceClaimLost(Actor self, ResourceClaim claim, Actor claimer);
 	}
 
-	public interface IPlaceBuildingDecoration
+	public interface IPlaceBuildingDecorationInfo : ITraitInfo
 	{
 		IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition);
 	}

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public void SetPreview(ActorInfo actor, TypeDictionary td)
 		{
 			var init = new ActorPreviewInitializer(actor, worldRenderer, td);
-			preview = actor.Traits.WithInterface<IRenderActorPreviewInfo>()
+			preview = actor.TraitInfos<IRenderActorPreviewInfo>()
 				.SelectMany(rpi => rpi.RenderPreview(init))
 				.ToArray();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			layerTemplateList.RemoveChildren();
 
-			var resources = modRules.Actors["world"].Traits.WithInterface<ResourceTypeInfo>();
+			var resources = modRules.Actors["world"].TraitInfos<ResourceTypeInfo>();
 			foreach (var resource in resources)
 			{
 				var newResourcePreviewTemplate = ScrollItemWidget.Setup(layerPreviewTemplate,

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -242,7 +242,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var assets = template.Get<LabelWidget>("ASSETS");
 			assets.GetText = () => "$" + world.Actors
 				.Where(a => a.Owner == player && !a.IsDead && a.Info.HasTraitInfo<ValuedInfo>())
-				.Sum(a => a.Info.Traits.WithInterface<ValuedInfo>().First().Cost);
+				.Sum(a => a.Info.TraitInfos<ValuedInfo>().First().Cost);
 
 			var harvesters = template.Get<LabelWidget>("HARVESTERS");
 			harvesters.GetText = () => world.Actors.Count(a => a.Owner == player && !a.IsDead && a.Info.HasTraitInfo<HarvesterInfo>()).ToString();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -241,7 +241,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var assets = template.Get<LabelWidget>("ASSETS");
 			assets.GetText = () => "$" + world.Actors
-				.Where(a => a.Owner == player && !a.IsDead && a.Info.Traits.WithInterface<ValuedInfo>().Any())
+				.Where(a => a.Owner == player && !a.IsDead && a.Info.HasTraitInfo<ValuedInfo>())
 				.Sum(a => a.Info.Traits.WithInterface<ValuedInfo>().First().Cost);
 
 			var harvesters = template.Get<LabelWidget>("HARVESTERS");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var requiresString = prereqs.Any() ? requiresLabel.Text.F(prereqs.JoinWith(", ")) : "";
 				requiresLabel.GetText = () => requiresString;
 
-				var power = actor.Traits.WithInterface<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(i => i.Amount);
+				var power = actor.TraitInfos<PowerInfo>().Where(i => i.UpgradeMinEnabledLevel < 1).Sum(i => i.Amount);
 				var powerString = power.ToString();
 				powerLabel.GetText = () => powerString;
 				powerLabel.GetColor = () => ((pm.PowerProvided - pm.PowerDrained) >= -power || power > 0)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			colorPreview = lobby.Get<ColorPreviewManagerWidget>("COLOR_MANAGER");
 			colorPreview.Color = Game.Settings.Player.Color;
 
-			foreach (var f in modRules.Actors["world"].Traits.WithInterface<FactionInfo>())
+			foreach (var f in modRules.Actors["world"].TraitInfos<FactionInfo>())
 				factions.Add(f.InternalName, new LobbyFaction { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });
 
 			var gameStarting = false;
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				slotsButton.IsDisabled = () => configurationDisabled() || panel != PanelType.Players ||
 					Map.RuleStatus != MapRuleStatus.Cached || !orderManager.LobbyInfo.Slots.Values.Any(s => s.AllowBots || !s.LockTeam);
 
-				var botNames = modRules.Actors["player"].Traits.WithInterface<IBotInfo>().Select(t => t.Name);
+				var botNames = modRules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name);
 				slotsButton.OnMouseDown = _ =>
 				{
 					var options = new Dictionary<string, IEnumerable<DropDownOption>>();
@@ -395,7 +395,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var startingUnits = optionsBin.GetOrNull<DropDownButtonWidget>("STARTINGUNITS_DROPDOWNBUTTON");
 			if (startingUnits != null)
 			{
-				var startUnitsInfo = modRules.Actors["world"].Traits.WithInterface<MPStartUnitsInfo>();
+				var startUnitsInfo = modRules.Actors["world"].TraitInfos<MPStartUnitsInfo>();
 				var classes = startUnitsInfo.Select(a => a.Class).Distinct();
 				Func<string, string> className = c =>
 				{
@@ -459,7 +459,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var techLevel = optionsBin.GetOrNull<DropDownButtonWidget>("TECHLEVEL_DROPDOWNBUTTON");
 			if (techLevel != null)
 			{
-				var techTraits = modRules.Actors["player"].Traits.WithInterface<ProvidesTechPrerequisiteInfo>().ToList();
+				var techTraits = modRules.Actors["player"].TraitInfos<ProvidesTechPrerequisiteInfo>().ToList();
 				techLevel.IsVisible = () => techTraits.Count > 0;
 
 				var techLevelDescription = optionsBin.GetOrNull<LabelWidget>("TECHLEVEL_DESC");
@@ -610,7 +610,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.LobbyInfoChanged += WidgetUtils.Once(() =>
 				{
 					var slot = orderManager.LobbyInfo.FirstEmptyBotSlot();
-					var bot = modRules.Actors["player"].Traits.WithInterface<IBotInfo>().Select(t => t.Name).FirstOrDefault();
+					var bot = modRules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name).FirstOrDefault();
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
 					if (slot != null && bot != null)
 						orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot, botController.Index, bot)));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var bots = new List<SlotDropDownOption>();
 			if (slot.AllowBots)
 			{
-				foreach (var b in rules.Actors["player"].Traits.WithInterface<IBotInfo>().Select(t => t.Name))
+				foreach (var b in rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name))
 				{
 					var bot = b;
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			this.world = world;
 
-			Groups = world.Map.Rules.Actors.Values.SelectMany(a => a.Traits.WithInterface<ProductionQueueInfo>())
+			Groups = world.Map.Rules.Actors.Values.SelectMany(a => a.TraitInfos<ProductionQueueInfo>())
 				.Select(q => q.Group).Distinct().ToDictionary(g => g, g => new ProductionTabGroup() { Group = g });
 
 			// Only visible if the production palette has icons to display

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.RA.Traits
 			var renderSprites = actorInfo.TraitInfoOrDefault<RenderSpritesInfo>();
 			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.SequenceProvider, newOwner.Faction.InternalName);
 			AsPlayer = newOwner;
-			AsTooltipInfo = actorInfo.Traits.WithInterface<TooltipInfo>().FirstOrDefault();
+			AsTooltipInfo = actorInfo.TraitInfos<TooltipInfo>().FirstOrDefault();
 
 			HandleDisguise(oldEffectiveOwner, oldDisguiseSetting);
 		}

--- a/OpenRA.Mods.RA/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/Infiltrates.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.RA.Traits
 			if (!info.ValidStances.HasStance(stance))
 				return false;
 
-			return target.Info.Traits.WithInterface<ITargetableInfo>().Any(t => info.Types.Overlaps(t.GetTargetTypes()));
+			return target.Info.TraitInfos<ITargetableInfo>().Any(t => info.Types.Overlaps(t.GetTargetTypes()));
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.RA/Traits/Render/RenderJammerCircle.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA.Traits
 {
 	// TODO: remove all the Render*Circle duplication
-	class RenderJammerCircleInfo : ITraitInfo, IPlaceBuildingDecoration
+	class RenderJammerCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo
 	{
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{

--- a/OpenRA.Mods.RA/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.RA/Traits/Render/RenderShroudCircle.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	class RenderShroudCircleInfo : ITraitInfo, IPlaceBuildingDecoration
+	class RenderShroudCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo
 	{
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -18,48 +18,40 @@ using OpenRA.Traits;
 
 namespace OpenRA.Test
 {
+	interface IMock : ITraitInfo { }
+	class MockTraitInfo : ITraitInfo { public object Create(ActorInitializer init) { return null; } }
+	class MockInheritInfo : MockTraitInfo { }
+	class MockAInfo : MockInheritInfo, IMock { }
+	class MockBInfo : MockTraitInfo, Requires<MockAInfo>, Requires<IMock>, Requires<MockInheritInfo> { }
+	class MockCInfo : MockTraitInfo, Requires<MockBInfo> { }
+	class MockDInfo : MockTraitInfo, Requires<MockEInfo> { }
+	class MockEInfo : MockTraitInfo, Requires<MockFInfo> { }
+	class MockFInfo : MockTraitInfo, Requires<MockDInfo> { }
+
 	[TestFixture]
 	public class ActorInfoTest
 	{
-		ActorInfo actorInfo;
-		Dictionary<string, MiniYaml> allUnits;
-
-		interface IMock : ITraitInfo { }
-		class MockTrait : ITraitInfo { public object Create(ActorInitializer init) { return null; } }
-		class MockInherit : MockTrait { }
-		class MockA : MockInherit, IMock { }
-		class MockB : MockTrait, Requires<MockA>, Requires<IMock>, Requires<MockInherit> { }
-		class MockC : MockTrait, Requires<MockB> { }
-		class MockD : MockTrait, Requires<MockE> { }
-		class MockE : MockTrait, Requires<MockF> { }
-		class MockF : MockTrait, Requires<MockD> { }
-
 		[SetUp]
 		public void SetUp()
 		{
-			allUnits = new Dictionary<string, MiniYaml>();
-			actorInfo = new ActorInfo("", new MiniYaml(""), allUnits);
 		}
 
 		[TestCase(TestName = "Sort traits in order of dependency")]
 		public void TraitsInConstructOrderA()
 		{
-			actorInfo.Traits.Add(new MockC());
-			actorInfo.Traits.Add(new MockB());
-			actorInfo.Traits.Add(new MockA());
+			var actorInfo = new ActorInfo("test", new MockCInfo(), new MockBInfo(), new MockAInfo());
 
 			var i = new List<ITraitInfo>(actorInfo.TraitsInConstructOrder());
 
-			Assert.That(i[0], Is.InstanceOf<MockA>());
-			Assert.That(i[1], Is.InstanceOf<MockB>());
-			Assert.That(i[2], Is.InstanceOf<MockC>());
+			Assert.That(i[0], Is.InstanceOf<MockAInfo>());
+			Assert.That(i[1].GetType().Name, Is.EqualTo("MockBInfo"));
+			Assert.That(i[2].GetType().Name, Is.EqualTo("MockCInfo"));
 		}
 
 		[TestCase(TestName = "Exception reports missing dependencies")]
 		public void TraitsInConstructOrderB()
 		{
-			actorInfo.Traits.Add(new MockB());
-			actorInfo.Traits.Add(new MockC());
+			var actorInfo = new ActorInfo("test", new MockBInfo(), new MockCInfo());
 
 			try
 			{
@@ -79,9 +71,7 @@ namespace OpenRA.Test
 		[TestCase(TestName = "Exception reports cyclic dependencies")]
 		public void TraitsInConstructOrderC()
 		{
-			actorInfo.Traits.Add(new MockD());
-			actorInfo.Traits.Add(new MockE());
-			actorInfo.Traits.Add(new MockF());
+			var actorInfo = new ActorInfo("test", new MockDInfo(), new MockEInfo(), new MockFInfo());
 
 			try
 			{


### PR DESCRIPTION
With this, _actorInfo_`.Traits` is no longer accessible preventing direct access issues with a compile-time error.

Added:

``` c#
        public IEnumerable<ITraitInfo> TraitInfos() { return traits.WithInterface<ITraitInfo>(); }
        public IEnumerable<T> TraitInfos<T>() where T : ITraitInfo { return traits.WithInterface<T>(); }
```
