### PR TITLE
Fix replay freeze

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Also thanks to:
     * Gordon Martin (Happy0)
     * Guido Lipke (LipkeGu)
     * Gyula Zimmermann (Graion Dilach)
+    * Hervé Matysiak (Herve-M)
     * Huw Pascoe
     * Ian T. Jacobsen (Smilex)
     * Imago


### PR DESCRIPTION
This PR normally fix the freezing problem when a player disconnect from game.
- Get the list of client 
  - Get all clients + last frame [ReplayConnection.cs#L59-L65](https://github.com/Herve-M/OpenRA/blob/fix-replay/OpenRA.Game/Network/ReplayConnection.cs#L59-L65)
- Correct the datas
  - Parsing (2nd pass) [ReplayConnection.cs#L97-L112](https://github.com/Herve-M/OpenRA/blob/fix-replay/OpenRA.Game/Network/ReplayConnection.cs#L97-L112)
  - Using 4 first byte from packet to store frame n° [ReplayConnection.cs#L108](https://github.com/Herve-M/OpenRA/blob/fix-replay/OpenRA.Game/Network/ReplayConnection.cs#L108)

More info's [here](https://github.com/OpenRA/OpenRA/issues/6241#issuecomment-140373166)
Was tested on release-20150424 (depend of given replay files)
