### PR TITLE
Unstatic the Sound class.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -42,6 +42,7 @@ namespace OpenRA
 		public static MersenneTwister CosmeticRandom = new MersenneTwister(); // not synced
 
 		public static Renderer Renderer;
+		public static Sound Sound;
 		public static bool HasInputFocus = false;
 
 		public static OrderManager JoinServer(string host, int port, string password, bool recordReplay = true)
@@ -234,7 +235,7 @@ namespace OpenRA
 				}
 			}
 
-			Sound.Create(Settings.Server.Dedicated ? "Null" : Settings.Sound.Engine);
+			Sound = new Sound(Settings.Server.Dedicated ? "Null" : Settings.Sound.Engine);
 
 			Console.WriteLine("Available mods:");
 			foreach (var mod in ModMetadata.AllMods)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -672,6 +672,7 @@ namespace OpenRA
 				worldRenderer.Dispose();
 			ModData.Dispose();
 			ChromeProvider.Deinitialize();
+			Sound.Dispose();
 			Renderer.Dispose();
 
 			OnQuit();

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
-	public class Sound
+	public sealed class Sound : IDisposable
 	{
 		readonly ISoundEngine soundEngine;
 		Cache<string, ISoundSource> sounds;
@@ -367,6 +367,11 @@ namespace OpenRA
 				return false;
 
 			return PlayPredefined(rules, player, null, type.ToLowerInvariant(), notification, variant, true, WPos.Zero, 1f, false);
+		}
+
+		public void Dispose()
+		{
+			soundEngine.Dispose();
 		}
 	}
 }

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -20,16 +20,16 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
-	public static class Sound
+	public class Sound
 	{
-		static ISoundEngine soundEngine;
-		static Cache<string, ISoundSource> sounds;
-		static ISoundSource rawSource;
-		static ISound music;
-		static ISound video;
-		static MusicInfo currentMusic;
+		readonly ISoundEngine soundEngine;
+		Cache<string, ISoundSource> sounds;
+		ISoundSource rawSource;
+		ISound music;
+		ISound video;
+		MusicInfo currentMusic;
 
-		public static void Create(string engineName)
+		public Sound(string engineName)
 		{
 			var enginePath = Platform.ResolvePath(".", "OpenRA.Platforms." + engineName + ".dll");
 			soundEngine = CreateDevice(Assembly.LoadFile(enginePath));
@@ -46,7 +46,7 @@ namespace OpenRA
 			throw new InvalidOperationException("Platform DLL is missing PlatformAttribute to tell us what type to use!");
 		}
 
-		static ISoundSource LoadSound(string filename)
+		ISoundSource LoadSound(string filename)
 		{
 			if (!GlobalFileSystem.Exists(filename))
 			{
@@ -62,17 +62,17 @@ namespace OpenRA
 				return LoadSoundRaw(AudLoader.LoadSound(s), 1, 16, 22050);
 		}
 
-		static ISoundSource LoadWave(WavLoader wave)
+		ISoundSource LoadWave(WavLoader wave)
 		{
 			return soundEngine.AddSoundSourceFromMemory(wave.RawOutput, wave.Channels, wave.BitsPerSample, wave.SampleRate);
 		}
 
-		static ISoundSource LoadSoundRaw(byte[] rawData, int channels, int sampleBits, int sampleRate)
+		ISoundSource LoadSoundRaw(byte[] rawData, int channels, int sampleBits, int sampleRate)
 		{
 			return soundEngine.AddSoundSourceFromMemory(rawData, channels, sampleBits, sampleRate);
 		}
 
-		public static void Initialize()
+		public void Initialize()
 		{
 			sounds = new Cache<string, ISoundSource>(LoadSound);
 			music = null;
@@ -80,7 +80,7 @@ namespace OpenRA
 			video = null;
 		}
 
-		public static SoundDevice[] AvailableDevices()
+		public SoundDevice[] AvailableDevices()
 		{
 			var defaultDevices = new[]
 			{
@@ -91,12 +91,12 @@ namespace OpenRA
 			return defaultDevices.Concat(soundEngine.AvailableDevices()).ToArray();
 		}
 
-		public static void SetListenerPosition(WPos position)
+		public void SetListenerPosition(WPos position)
 		{
 			soundEngine.SetListenerPosition(position);
 		}
 
-		static ISound Play(Player player, string name, bool headRelative, WPos pos, float volumeModifier = 1f, bool loop = false)
+		ISound Play(Player player, string name, bool headRelative, WPos pos, float volumeModifier = 1f, bool loop = false)
 		{
 			if (string.IsNullOrEmpty(name))
 				return null;
@@ -108,45 +108,45 @@ namespace OpenRA
 				InternalSoundVolume * volumeModifier, true);
 		}
 
-		public static void StopAudio()
+		public void StopAudio()
 		{
 			soundEngine.StopAllSounds();
 		}
 
-		public static ISound Play(string name) { return Play(null, name, true, WPos.Zero, 1f); }
-		public static ISound Play(string name, WPos pos) { return Play(null, name, false, pos, 1f); }
-		public static ISound Play(string name, float volumeModifier) { return Play(null, name, true, WPos.Zero, volumeModifier); }
-		public static ISound Play(string name, WPos pos, float volumeModifier) { return Play(null, name, false, pos, volumeModifier); }
-		public static ISound PlayToPlayer(Player player, string name) { return Play(player, name, true, WPos.Zero, 1f); }
-		public static ISound PlayToPlayer(Player player, string name, WPos pos) { return Play(player, name, false, pos, 1f); }
-		public static ISound PlayLooped(string name) { return PlayLooped(name, WPos.Zero); }
-		public static ISound PlayLooped(string name, WPos pos) { return Play(null, name, true, pos, 1f, true); }
+		public ISound Play(string name) { return Play(null, name, true, WPos.Zero, 1f); }
+		public ISound Play(string name, WPos pos) { return Play(null, name, false, pos, 1f); }
+		public ISound Play(string name, float volumeModifier) { return Play(null, name, true, WPos.Zero, volumeModifier); }
+		public ISound Play(string name, WPos pos, float volumeModifier) { return Play(null, name, false, pos, volumeModifier); }
+		public ISound PlayToPlayer(Player player, string name) { return Play(player, name, true, WPos.Zero, 1f); }
+		public ISound PlayToPlayer(Player player, string name, WPos pos) { return Play(player, name, false, pos, 1f); }
+		public ISound PlayLooped(string name) { return PlayLooped(name, WPos.Zero); }
+		public ISound PlayLooped(string name, WPos pos) { return Play(null, name, true, pos, 1f, true); }
 
-		public static void PlayVideo(byte[] raw, int channels, int sampleBits, int sampleRate)
+		public void PlayVideo(byte[] raw, int channels, int sampleBits, int sampleRate)
 		{
 			rawSource = LoadSoundRaw(raw, channels, sampleBits, sampleRate);
 			video = soundEngine.Play2D(rawSource, false, true, WPos.Zero, InternalSoundVolume, false);
 		}
 
-		public static void PlayVideo()
+		public void PlayVideo()
 		{
 			if (video != null)
 				soundEngine.PauseSound(video, false);
 		}
 
-		public static void PauseVideo()
+		public void PauseVideo()
 		{
 			if (video != null)
 				soundEngine.PauseSound(video, true);
 		}
 
-		public static void StopVideo()
+		public void StopVideo()
 		{
 			if (video != null)
 				soundEngine.StopSound(video);
 		}
 
-		public static void Tick()
+		public void Tick()
 		{
 			// Song finished
 			if (MusicPlaying && !music.Playing)
@@ -156,16 +156,16 @@ namespace OpenRA
 			}
 		}
 
-		static Action onMusicComplete;
-		public static bool MusicPlaying { get; private set; }
-		public static MusicInfo CurrentMusic { get { return currentMusic; } }
+		Action onMusicComplete;
+		public bool MusicPlaying { get; private set; }
+		public MusicInfo CurrentMusic { get { return currentMusic; } }
 
-		public static void PlayMusic(MusicInfo m)
+		public void PlayMusic(MusicInfo m)
 		{
 			PlayMusicThen(m, () => { });
 		}
 
-		public static void PlayMusicThen(MusicInfo m, Action then)
+		public void PlayMusicThen(MusicInfo m, Action then)
 		{
 			if (m == null || !m.Exists)
 				return;
@@ -190,7 +190,7 @@ namespace OpenRA
 			MusicPlaying = true;
 		}
 
-		public static void PlayMusic()
+		public void PlayMusic()
 		{
 			if (music == null)
 				return;
@@ -199,13 +199,13 @@ namespace OpenRA
 			soundEngine.PauseSound(music, false);
 		}
 
-		public static void StopSound(ISound sound)
+		public void StopSound(ISound sound)
 		{
 			if (sound != null)
 				soundEngine.StopSound(sound);
 		}
 
-		public static void StopMusic()
+		public void StopMusic()
 		{
 			if (music != null)
 				soundEngine.StopSound(music);
@@ -214,7 +214,7 @@ namespace OpenRA
 			currentMusic = null;
 		}
 
-		public static void PauseMusic()
+		public void PauseMusic()
 		{
 			if (music == null)
 				return;
@@ -223,14 +223,14 @@ namespace OpenRA
 			soundEngine.PauseSound(music, true);
 		}
 
-		public static float GlobalVolume
+		public float GlobalVolume
 		{
 			get { return soundEngine.Volume; }
 			set { soundEngine.Volume = value; }
 		}
 
-		static float soundVolumeModifier = 1.0f;
-		public static float SoundVolumeModifier
+		float soundVolumeModifier = 1.0f;
+		public float SoundVolumeModifier
 		{
 			get
 			{
@@ -244,8 +244,8 @@ namespace OpenRA
 			}
 		}
 
-		static float InternalSoundVolume { get { return SoundVolume * soundVolumeModifier; } }
-		public static float SoundVolume
+		float InternalSoundVolume { get { return SoundVolume * soundVolumeModifier; } }
+		public float SoundVolume
 		{
 			get
 			{
@@ -259,7 +259,7 @@ namespace OpenRA
 			}
 		}
 
-		public static float MusicVolume
+		public float MusicVolume
 		{
 			get
 			{
@@ -274,7 +274,7 @@ namespace OpenRA
 			}
 		}
 
-		public static float VideoVolume
+		public float VideoVolume
 		{
 			get
 			{
@@ -289,18 +289,18 @@ namespace OpenRA
 			}
 		}
 
-		public static float MusicSeekPosition
+		public float MusicSeekPosition
 		{
 			get { return music != null ? music.SeekPosition : 0; }
 		}
 
-		public static float VideoSeekPosition
+		public float VideoSeekPosition
 		{
 			get { return video != null ? video.SeekPosition : 0; }
 		}
 
 		// Returns true if played successfully
-		public static bool PlayPredefined(Ruleset ruleset, Player p, Actor voicedActor, string type, string definition, string variant,
+		public bool PlayPredefined(Ruleset ruleset, Player p, Actor voicedActor, string type, string definition, string variant,
 			bool relative, WPos pos, float volumeModifier, bool attenuateVolume)
 		{
 			if (ruleset == null)
@@ -358,7 +358,7 @@ namespace OpenRA
 			return true;
 		}
 
-		public static bool PlayNotification(Ruleset rules, Player player, string type, string notification, string variant)
+		public bool PlayNotification(Ruleset rules, Player player, string type, string notification, string variant)
 		{
 			if (rules == null)
 				throw new ArgumentNullException("rules");

--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -12,7 +12,7 @@ using System;
 
 namespace OpenRA
 {
-	public interface ISoundEngine
+	public interface ISoundEngine : IDisposable
 	{
 		SoundDevice[] AvailableDevices();
 		ISoundSource AddSoundSourceFromMemory(byte[] data, int channels, int sampleBits, int sampleRate);

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Traits
 			{
 				if (Resources > 0.8 * ResourceCapacity)
 				{
-					Sound.PlayNotification(self.World.Map.Rules, owner, "Speech", "SilosNeeded", owner.Faction.InternalName);
+					Game.Sound.PlayNotification(self.World.Map.Rules, owner, "Speech", "SilosNeeded", owner.Faction.InternalName);
 					AlertSilo = true;
 				}
 				else
@@ -187,14 +187,14 @@ namespace OpenRA.Traits
 		public void PlayCashTickUp(Actor self)
 		{
 			if (Game.Settings.Sound.CashTicks)
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickUp", self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickUp", self.Owner.Faction.InternalName);
 		}
 
 		public void PlayCashTickDown(Actor self)
 		{
 			if (Game.Settings.Sound.CashTicks && nextCashTickTime == 0)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickDown", self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "CashTickDown", self.Owner.Faction.InternalName);
 				nextCashTickTime = 2;
 			}
 		}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -164,7 +164,7 @@ namespace OpenRA
 					if (!p.Stances.ContainsKey(q))
 						p.Stances[q] = Stance.Neutral;
 
-			Sound.SoundVolumeModifier = 1.0f;
+			Game.Sound.SoundVolumeModifier = 1.0f;
 
 			gameInfo = new GameInformation
 			{
@@ -369,8 +369,8 @@ namespace OpenRA
 
 			frameEndActions.Clear();
 
-			Sound.StopAudio();
-			Sound.StopVideo();
+			Game.Sound.StopAudio();
+			Game.Sound.StopVideo();
 
 			// Dispose newer actors first, and the world actor last
 			foreach (var a in actors.Values.Reverse())

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Traits
 						cargo.Delivered(self);
 
 					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, factionVariant));
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
+					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
 				}));
 
 				actor.QueueActivity(new Fly(actor, Target.FromCell(w, endPos)));

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				Sound.Play(Info.LaunchSound, self.World.Map.CenterOfCell(order.TargetLocation));
+				Game.Sound.Play(Info.LaunchSound, self.World.Map.CenterOfCell(order.TargetLocation));
 				w.Add(new IonCannon(self.Owner, info.Weapon, w, order.TargetLocation, info.Effect, info.EffectPalette, info.WeaponDelay));
 
 				if (info.CameraActor == null)

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (!playedSound && helicopter.Info.TakeoffSound != null && self.IsAtGroundLevel())
 			{
-				Sound.Play(helicopter.Info.TakeoffSound);
+				Game.Sound.Play(helicopter.Info.TakeoffSound);
 				playedSound = true;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (!playedSound && helicopter.Info.LandingSound != null && !self.IsAtGroundLevel())
 			{
-				Sound.Play(helicopter.Info.LandingSound);
+				Game.Sound.Play(helicopter.Info.LandingSound);
 				playedSound = true;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				var sound = pool.Info.RearmSound;
 				if (sound != null)
-					Sound.Play(sound, self.CenterPosition);
+					Game.Sound.Play(sound, self.CenterPosition);
 
 				ammoPoolsReloadTimes[pool] = pool.Info.ReloadTicks;
 			}

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (health.DamageState == DamageState.Undamaged)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.FinishRepairingNotification, self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.FinishRepairingNotification, self.Owner.Faction.InternalName);
 				return NextActivity;
 			}
 
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!played)
 				{
 					played = true;
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.StartRepairingNotification, self.Owner.Faction.InternalName);
+					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", repairsUnits.StartRepairingNotification, self.Owner.Faction.InternalName);
 				}
 
 				if (!self.Owner.PlayerActor.Trait<PlayerResources>().TakeCash(cost))

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -50,9 +50,9 @@ namespace OpenRA.Mods.Common.Activities
 
 				self.Dispose();
 				foreach (var s in Sounds)
-					Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
+					Game.Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
 
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Notification, self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Notification, self.Owner.Faction.InternalName);
 
 				var init = new TypeDictionary
 				{

--- a/OpenRA.Mods.Common/Effects/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Effects/NukeLaunch.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Effects
 			pos = launchPos;
 			var weaponRules = firedBy.World.Map.Rules.Weapons[weapon.ToLowerInvariant()];
 			if (weaponRules.Report != null && weaponRules.Report.Any())
-				Sound.Play(weaponRules.Report.Random(firedBy.World.SharedRandom), pos);
+				Game.Sound.Play(weaponRules.Report.Random(firedBy.World.SharedRandom), pos);
 
 			if (skipAscent)
 				ticks = turn;

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Orders
 					orderType = "PlacePlug";
 					if (!AcceptsPlug(topLeft, plugInfo))
 					{
-						Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Faction.InternalName);
+						Game.Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Faction.InternalName);
 						yield break;
 					}
 				}
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Orders
 					if (!world.CanPlaceBuilding(building, buildingInfo, topLeft, null)
 						|| !buildingInfo.IsCloseEnoughToBase(world, producer.Owner, building, topLeft))
 					{
-						Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Faction.InternalName);
+						Game.Sound.PlayNotification(world.Map.Rules, producer.Owner, "Speech", "BuildingCannotPlaceAudio", producer.Owner.Faction.InternalName);
 						yield break;
 					}
 

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -39,19 +39,19 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Play an announcer voice listed in notifications.yaml")]
 		public void PlaySpeechNotification(Player player, string notification)
 		{
-			Sound.PlayNotification(world.Map.Rules, player, "Speech", notification, player != null ? player.Faction.InternalName : null);
+			Game.Sound.PlayNotification(world.Map.Rules, player, "Speech", notification, player != null ? player.Faction.InternalName : null);
 		}
 
 		[Desc("Play a sound listed in notifications.yaml")]
 		public void PlaySoundNotification(Player player, string notification)
 		{
-			Sound.PlayNotification(world.Map.Rules, player, "Sounds", notification, player != null ? player.Faction.InternalName : null);
+			Game.Sound.PlayNotification(world.Map.Rules, player, "Sounds", notification, player != null ? player.Faction.InternalName : null);
 		}
 
 		[Desc("Play a sound file")]
 		public void PlaySound(string file)
 		{
-			Sound.Play(file);
+			Game.Sound.Play(file);
 		}
 
 		Action onComplete;

--- a/OpenRA.Mods.Common/Scripting/Media.cs
+++ b/OpenRA.Mods.Common/Scripting/Media.cs
@@ -37,23 +37,23 @@ namespace OpenRA.Mods.Common.Scripting
 			w.SetPauseState(true);
 
 			// Mute world sounds
-			var oldModifier = Sound.SoundVolumeModifier;
+			var oldModifier = Game.Sound.SoundVolumeModifier;
 
 			// TODO: this also modifies vqa audio
-			// Sound.SoundVolumeModifier = 0f;
+			// Game.Sound.SoundVolumeModifier = 0f;
 
 			// Stop music while fmv plays
-			var music = Sound.MusicPlaying;
+			var music = Game.Sound.MusicPlaying;
 			if (music)
-				Sound.PauseMusic();
+				Game.Sound.PauseMusic();
 
 			player.PlayThen(() =>
 			{
 				if (music)
-					Sound.PlayMusic();
+					Game.Sound.PlayMusic();
 
 				Ui.CloseWindow();
-				Sound.SoundVolumeModifier = oldModifier;
+				Game.Sound.SoundVolumeModifier = oldModifier;
 				w.SetPauseState(false);
 				onComplete();
 			});

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Traits
 						self.World.Add(projectile);
 
 					if (args.Weapon.Report != null && args.Weapon.Report.Any())
-						Sound.Play(args.Weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
+						Game.Sound.Play(args.Weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
 				}
 			});
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharge.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharge.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 					notify.Charging(self, target);
 
 				if (!string.IsNullOrEmpty(attack.info.ChargeAudio))
-					Sound.Play(attack.info.ChargeAudio, self.CenterPosition);
+					Game.Sound.Play(attack.info.ChargeAudio, self.CenterPosition);
 
 				return Util.SequenceActivities(new Wait(attack.info.InitialChargeDelay), new ChargeFire(attack, target), this);
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -204,7 +204,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void BeforeTransform(Actor self)
 		{
 			foreach (var s in Info.UndeploySounds)
-				Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
+				Game.Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
 		}
 
 		public void OnTransform(Actor self) { }

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			isPrimary = true;
 
-			Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", "PrimaryBuildingSelected", self.Owner.Faction.InternalName);
+			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", "PrimaryBuildingSelected", self.Owner.Faction.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!Repairers.Remove(player) && Repairers.Count < Info.RepairBonuses.Length)
 				{
 					Repairers.Add(player);
-					Sound.PlayNotification(self.World.Map.Rules, player, "Speech", "Repairing", player.Faction.InternalName);
+					Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", "Repairing", player.Faction.InternalName);
 
 					self.World.AddFrameEndTask(w =>
 					{

--- a/OpenRA.Mods.Common/Traits/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureNotification.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var faction = info.NewOwnerVoice ? newOwner.Faction.InternalName : oldOwner.Faction.InternalName;
-			Sound.PlayNotification(self.World.Map.Rules, captor.World.LocalPlayer, "Speech", info.Notification, faction);
+			Game.Sound.PlayNotification(self.World.Map.Rules, captor.World.LocalPlayer, "Speech", info.Notification, faction);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (Cloaked)
 			{
-				Sound.Play(Info.UncloakSound, self.CenterPosition);
+				Game.Sound.Play(Info.UncloakSound, self.CenterPosition);
 				if (upgradeManager != null)
 					foreach (var u in Info.WhileCloakedUpgrades)
 						upgradeManager.RevokeUpgrade(self, u, this);
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (remainingTime > 0 && !IsTraitDisabled && !damageDisabled && --remainingTime <= 0)
 			{
-				Sound.Play(Info.CloakSound, self.CenterPosition);
+				Game.Sound.Play(Info.CloakSound, self.CenterPosition);
 				if (upgradeManager != null)
 					foreach (var u in Info.WhileCloakedUpgrades)
 						upgradeManager.GrantUpgrade(self, u, this);

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual void Activate(Actor collector)
 		{
-			Sound.PlayToPlayer(collector.Owner, info.Notification);
+			Game.Sound.PlayToPlayer(collector.Owner, info.Notification);
 
 			if (info.Effect != null)
 				collector.World.AddFrameEndTask(w => w.Add(new CrateEffect(collector, info.Effect, info.Palette)));

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnCrush(Actor crusher)
 		{
-			Sound.Play(info.CrushSound, crusher.CenterPosition);
+			Game.Sound.Play(info.CrushSound, crusher.CenterPosition);
 			var wda = self.TraitsImplementing<WithDeathAnimation>()
 				.FirstOrDefault(s => s.Info.CrushedSequence != null);
 			if (wda != null)

--- a/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 						w.Add(pilot);
 						pilot.QueueActivity(new Parachute(pilot, cp));
 					});
-					Sound.Play(info.ChuteSound, cp);
+					Game.Sound.Play(info.ChuteSound, cp);
 				}
 				else
 				{

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var weapon = e.Attacker.World.Map.Rules.Weapons[weaponName.ToLowerInvariant()];
 			if (weapon.Report != null && weapon.Report.Any())
-				Sound.Play(weapon.Report.Random(e.Attacker.World.SharedRandom), self.CenterPosition);
+				Game.Sound.Play(weapon.Report.Random(e.Attacker.World.SharedRandom), self.CenterPosition);
 
 			// Use .FromPos since this actor is killed. Cannot use Target.FromActor
 			weapon.Impact(Target.FromPos(self.CenterPosition), e.Attacker, Enumerable.Empty<int>());

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (!silent)
 				{
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "LevelUp", self.Owner.Faction.InternalName);
+					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "LevelUp", self.Owner.Faction.InternalName);
 					self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup", info.LevelUpPalette)));
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 				w.Add(a);
 				a.QueueActivity(new Parachute(a, self.CenterPosition));
 			});
-			Sound.Play(info.ChuteSound, self.CenterPosition);
+			Game.Sound.Play(info.ChuteSound, self.CenterPosition);
 		}
 
 		static bool IsSuitableCell(Actor actorToDrop, CPos p)

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 			var terrain = self.World.Map.GetTerrainInfo(self.Location);
 
 			var sound = terrain.IsWater ? info.WaterImpactSound : info.GroundImpactSound;
-			Sound.Play(sound, self.CenterPosition);
+			Game.Sound.Play(sound, self.CenterPosition);
 
 			var sequence = terrain.IsWater ? info.WaterCorpseSequence : info.GroundCorpseSequence;
 			var palette = terrain.IsWater ? info.WaterCorpsePalette : info.GroundCorpsePalette;

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (self.World.WorldTick - lastAttackTime > info.NotifyInterval * 25)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Faction.InternalName);
 
 				if (radarPings != null)
 					radarPings.Add(() => self.Owner == self.World.LocalPlayer, self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 				Game.RunAfterDelay(info.NotificationDelay, () =>
 				{
 					if (Game.IsCurrentWorld(player.World))
-						Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Faction.InternalName);
+						Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Faction.InternalName);
 				});
 			}
 		}
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Debug("{0} is victorious.", player.PlayerName);
 
 			if (player == player.World.LocalPlayer)
-				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Faction.InternalName));
+				Game.RunAfterDelay(info.NotificationDelay, () => Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Faction.InternalName));
 		}
 
 		public void OnObjectiveAdded(Player player, int id) { }

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (self.World.WorldTick - lastAttackTime > info.NotifyInterval * 25)
 			{
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.Notification, self.Owner.Faction.InternalName);
 
 				if (radarPings != null)
 					radarPings.Add(() => self.Owner == self.World.LocalPlayer, self.CenterPosition, info.RadarPingColor, info.RadarPingDuration);

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.Add(playerBeacon);
 
 				if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
-					Sound.PlayNotification(self.World.Map.Rules, null, info.NotificationType, info.Notification,
+					Game.Sound.PlayNotification(self.World.Map.Rules, null, info.NotificationType, info.Notification,
 						self.World.RenderPlayer != null ? self.World.RenderPlayer.Faction.InternalName : null);
 
 				if (radarPings != null)

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 
 						if (playSounds)
 							foreach (var s in buildingInfo.BuildSounds)
-								Sound.PlayToPlayer(order.Player, s, building.CenterPosition);
+								Game.Sound.PlayToPlayer(order.Player, s, building.CenterPosition);
 
 						playSounds = false;
 					}
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					pluggable.EnablePlug(host, plugInfo.Type);
 					foreach (var s in buildingInfo.BuildSounds)
-						Sound.PlayToPlayer(order.Player, s, host.CenterPosition);
+						Game.Sound.PlayToPlayer(order.Player, s, host.CenterPosition);
 				}
 				else
 				{
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Traits
 					});
 
 					foreach (var s in buildingInfo.BuildSounds)
-						Sound.PlayToPlayer(order.Player, s, building.CenterPosition);
+						Game.Sound.PlayToPlayer(order.Player, s, building.CenterPosition);
 				}
 
 				if (producer.Actor != null)
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (GetNumBuildables(self.Owner) > prevItems)
 					w.Add(new DelayedAction(info.NewOptionsNotificationDelay,
-							() => Sound.PlayNotification(self.World.Map.Rules, order.Player, "Speech", info.NewOptionsNotification, order.Player.Faction.InternalName)));
+							() => Game.Sound.PlayNotification(self.World.Map.Rules, order.Player, "Speech", info.NewOptionsNotification, order.Player.Faction.InternalName)));
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -281,13 +281,13 @@ namespace OpenRA.Mods.Common.Traits
 								var isBuilding = unit.HasTraitInfo<BuildingInfo>();
 
 								if (isBuilding && !hasPlayedSound)
-									hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+									hasPlayedSound = Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
 								else if (!isBuilding)
 								{
 									if (BuildUnit(order.TargetString))
-										Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+										Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
 									else if (!hasPlayedSound && time > 0)
-										hasPlayedSound = Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
+										hasPlayedSound = Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
 								}
 							})));
 						}

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -245,11 +245,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Enabled)
 				return;
 
+			var rules = self.World.Map.Rules;
 			switch (order.OrderString)
 			{
 				case "StartProduction":
 					{
-						var unit = self.World.Map.Rules.Actors[order.TargetString];
+						var unit = rules.Actors[order.TargetString];
 						var bi = unit.TraitInfo<BuildableInfo>();
 						if (!bi.Queue.Contains(Info.Type))
 							return; /* Not built by this queue */
@@ -281,13 +282,13 @@ namespace OpenRA.Mods.Common.Traits
 								var isBuilding = unit.HasTraitInfo<BuildingInfo>();
 
 								if (isBuilding && !hasPlayedSound)
-									hasPlayedSound = Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+									hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
 								else if (!isBuilding)
 								{
 									if (BuildUnit(order.TargetString))
-										Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+										Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
 									else if (!hasPlayedSound && time > 0)
-										hasPlayedSound = Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
+										hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
 								}
 							})));
 						}

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 				Game.RunAfterDelay(info.NotificationDelay, () =>
 				{
 					if (Game.IsCurrentWorld(player.World))
-						Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Faction.InternalName);
+						Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Faction.InternalName);
 				});
 			}
 		}
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Debug("{0} is victorious.", player.PlayerName);
 
 			if (player == player.World.LocalPlayer)
-				Game.RunAfterDelay(info.NotificationDelay, () => Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Faction.InternalName));
+				Game.RunAfterDelay(info.NotificationDelay, () => Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Faction.InternalName));
 		}
 
 		public void OnObjectiveAdded(Player player, int id) { }

--- a/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
+++ b/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsTraitDisabled && order.OrderString == "PowerDown")
 			{
 				disabled = !disabled;
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", disabled ? "EnablePower" : "DisablePower", self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", disabled ? "EnablePower" : "DisablePower", self.Owner.Faction.InternalName);
 				power.UpdateActor(self);
 
 				if (disabled)
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!disabled || !Info.CancelWhenDisabled)
 				return;
 			disabled = false;
-			Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "EnablePower", self.Owner.Faction.InternalName);
+			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "EnablePower", self.Owner.Faction.InternalName);
 			power.UpdateActor(self);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (--nextPowerAdviceTime <= 0)
 			{
 				if (lowPower)
-					Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.SpeechNotification, self.Owner.Faction.InternalName);
+					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.SpeechNotification, self.Owner.Faction.InternalName);
 				nextPowerAdviceTime = info.AdviceInterval;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.CancelActivity();
 
 			foreach (var s in info.SellSounds)
-				Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
+				Game.Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
 
 			foreach (var ns in self.TraitsImplementing<INotifySold>())
 				ns.Selling(self);

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Killed(Actor self, AttackInfo e)
 		{
 			var player = info.NotifyAll ? self.World.LocalPlayer : self.Owner;
-			Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Faction.InternalName);
+			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Faction.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -26,9 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 		public AmbientSound(Actor self, AmbientSoundInfo info)
 		{
 			if (self.Info.HasTraitInfo<IOccupySpaceInfo>())
-				Sound.PlayLooped(info.SoundFile, self.CenterPosition);
+				Game.Sound.PlayLooped(info.SoundFile, self.CenterPosition);
 			else
-				Sound.PlayLooped(info.SoundFile);
+				Game.Sound.PlayLooped(info.SoundFile);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Audio notification
 			if (discoverer != null && !string.IsNullOrEmpty(Info.Notification))
-				Sound.PlayNotification(self.World.Map.Rules, discoverer, "Speech", Info.Notification, discoverer.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, discoverer, "Speech", Info.Notification, discoverer.Faction.InternalName);
 
 			// Radar notificaion
 			if (Info.PingRadar && radarPings.Value != null)

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -40,12 +40,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (e.DamageState == DamageState.Dead)
 			{
 				var sound = info.DestroyedSounds.RandomOrDefault(rand);
-				Sound.Play(sound, self.CenterPosition);
+				Game.Sound.Play(sound, self.CenterPosition);
 			}
 			else if (e.DamageState >= DamageState.Heavy && e.PreviousDamageState < DamageState.Heavy)
 			{
 				var sound = info.DamagedSounds.RandomOrDefault(rand);
-				Sound.Play(sound, self.CenterPosition);
+				Game.Sound.Play(sound, self.CenterPosition);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.AddFrameEndTask(w =>
 			{
 				var notification = self.Owner.IsAlliedWith(self.World.RenderPlayer) ? Info.LaunchSound : Info.IncomingSound;
-				Sound.Play(notification);
+				Game.Sound.Play(notification);
 
 				Actor distanceTestActor = null;
 				for (var i = -info.SquadSize / 2; i <= info.SquadSize / 2; i++)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override IOrderGenerator OrderGenerator(string order, SupportPowerManager manager)
 		{
-			Sound.PlayToPlayer(manager.Self.Owner, Info.SelectTargetSound);
+			Game.Sound.PlayToPlayer(manager.Self.Owner, Info.SelectTargetSound);
 			return new SelectTarget(Self.World, order, manager, this);
 		}
 
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.Trait<WithSpriteBody>().PlayCustomAnimation(self, info.GrantUpgradeSequence);
 
-			Sound.Play(info.GrantUpgradeSound, self.World.Map.CenterOfCell(order.TargetLocation));
+			Game.Sound.Play(info.GrantUpgradeSound, self.World.Map.CenterOfCell(order.TargetLocation));
 
 			foreach (var a in UnitsInRange(order.TargetLocation))
 			{

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -71,9 +71,9 @@ namespace OpenRA.Mods.Common.Traits
 			base.Activate(self, order, manager);
 
 			if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				Sound.Play(Info.LaunchSound);
+				Game.Sound.Play(Info.LaunchSound);
 			else
-				Sound.Play(Info.IncomingSound);
+				Game.Sound.Play(Info.IncomingSound);
 
 			if (!string.IsNullOrEmpty(info.ActivationSequence))
 			{

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var location = self.World.Map.CenterOfCell(order.TargetLocation);
 
-					Sound.Play(info.DeploySound, location);
+					Game.Sound.Play(info.DeploySound, location);
 
 					if (!string.IsNullOrEmpty(info.EffectSequence) && !string.IsNullOrEmpty(info.EffectPalette))
 						w.Add(new SpriteEffect(location, w, info.EffectSequence, info.EffectPalette));

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -73,12 +73,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual void Charging(Actor self, string key)
 		{
-			Sound.PlayToPlayer(self.Owner, Info.BeginChargeSound);
+			Game.Sound.PlayToPlayer(self.Owner, Info.BeginChargeSound);
 		}
 
 		public virtual void Charged(Actor self, string key)
 		{
-			Sound.PlayToPlayer(self.Owner, Info.EndChargeSound);
+			Game.Sound.PlayToPlayer(self.Owner, Info.EndChargeSound);
 		}
 
 		public virtual void Activate(Actor self, Order order, SupportPowerManager manager)
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IOrderGenerator OrderGenerator(string order, SupportPowerManager manager)
 		{
-			Sound.PlayToPlayer(manager.Self.Owner, Info.SelectTargetSound);
+			Game.Sound.PlayToPlayer(manager.Self.Owner, Info.SelectTargetSound);
 			return new SelectGenericPowerTarget(order, manager, info.Cursor, MouseButton.Left);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 								self.World.Add(projectile);
 
 							if (args.Weapon.Report != null && args.Weapon.Report.Any())
-								Sound.Play(args.Weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
+								Game.Sound.Play(args.Weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
 						}
 					});
 				}

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -99,9 +99,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanDeploy() || (building != null && !building.Lock()))
 			{
 				foreach (var s in info.NoTransformSounds)
-					Sound.PlayToPlayer(self.Owner, s);
+					Game.Sound.PlayToPlayer(self.Owner, s);
 
-				Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.NoTransformNotification, self.Owner.Faction.InternalName);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.NoTransformNotification, self.Owner.Faction.InternalName);
 
 				return;
 			}

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(false, new CallFunc(() =>
 				{
 					if (!string.IsNullOrEmpty(info.UndeploySound))
-						Sound.Play(info.UndeploySound, self.CenterPosition);
+						Game.Sound.Play(info.UndeploySound, self.CenterPosition);
 
 					if (string.IsNullOrEmpty(info.DeployAnimation))
 					{
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(new CallFunc(() =>
 				{
 					if (!string.IsNullOrEmpty(info.DeploySound))
-						Sound.Play(info.DeploySound, self.CenterPosition);
+						Game.Sound.Play(info.DeploySound, self.CenterPosition);
 
 					if (string.IsNullOrEmpty(info.DeployAnimation))
 						return;

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (cachedDisabled != disabled)
 			{
-				Sound.Play(disabled ? info.DisableSound : info.EnableSound, self.CenterPosition);
+				Game.Sound.Play(disabled ? info.DisableSound : info.EnableSound, self.CenterPosition);
 				desiredRange = disabled ? WDist.Zero : info.Range;
 				cachedDisabled = disabled;
 			}

--- a/OpenRA.Mods.Common/Traits/Voiced.cs
+++ b/OpenRA.Mods.Common/Traits/Voiced.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var type = Info.VoiceSet.ToLowerInvariant();
 			var volume = Info.Volume;
-			return Sound.PlayPredefined(self.World.Map.Rules, null, self, type, phrase, variant, true, WPos.Zero, volume, true);
+			return Game.Sound.PlayPredefined(self.World.Map.Rules, null, self, type, phrase, variant, true, WPos.Zero, volume, true);
 		}
 
 		public bool PlayVoiceLocal(Actor self, string phrase, string variant, float volume)
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var type = Info.VoiceSet.ToLowerInvariant();
-			return Sound.PlayPredefined(self.World.Map.Rules, null, self, type, phrase, variant, false, self.CenterPosition, volume, true);
+			return Game.Sound.PlayPredefined(self.World.Map.Rules, null, self, type, phrase, variant, false, self.CenterPosition, volume, true);
 		}
 
 		public bool HasVoice(Actor self, string voice)

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!SongExists(currentSong))
 				return;
 
-			Sound.PlayMusicThen(currentSong, () =>
+			Game.Sound.PlayMusicThen(currentSong, () =>
 			{
 				if (!CurrentSongIsBackground && !Game.Settings.Sound.Repeat)
 					currentSong = GetNextSong();
@@ -161,7 +161,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			currentSong = music;
 			CurrentSongIsBackground = false;
-			Sound.PlayMusicThen(music, onComplete);
+			Game.Sound.PlayMusicThen(music, onComplete);
 		}
 
 		public MusicInfo GetNextSong()
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Stop()
 		{
 			currentSong = null;
-			Sound.StopMusic();
+			Game.Sound.StopMusic();
 
 			if (currentBackgroundSong != null)
 			{
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Disposing(Actor self)
 		{
 			if (currentSong != null)
-				Sound.StopMusic();
+				Game.Sound.StopMusic();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
-			Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+			Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Warheads
 				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, Explosion, palette)));
 
 			if (ImpactSound != null)
-				Sound.Play(ImpactSound, pos);
+				Game.Sound.Play(ImpactSound, pos);
 		}
 
 		public bool IsValidImpact(WPos pos, Actor firedBy)

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -126,10 +126,10 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!IsDisabled())
 			{
 				OnKeyPress(e);
-				Sound.PlayNotification(ModRules, null, "Sounds", "ClickSound", null);
+				Game.Sound.PlayNotification(ModRules, null, "Sounds", "ClickSound", null);
 			}
 			else
-				Sound.PlayNotification(ModRules, null, "Sounds", "ClickDisabledSound", null);
+				Game.Sound.PlayNotification(ModRules, null, "Sounds", "ClickDisabledSound", null);
 
 			return true;
 		}
@@ -167,12 +167,12 @@ namespace OpenRA.Mods.Common.Widgets
 				{
 					OnMouseDown(mi);
 					Depressed = true;
-					Sound.PlayNotification(ModRules, null, "Sounds", "ClickSound", null);
+					Game.Sound.PlayNotification(ModRules, null, "Sounds", "ClickSound", null);
 				}
 				else
 				{
 					YieldMouseFocus(mi);
-					Sound.PlayNotification(ModRules, null, "Sounds", "ClickDisabledSound", null);
+					Game.Sound.PlayNotification(ModRules, null, "Sounds", "ClickDisabledSound", null);
 				}
 			}
 			else if (mi.Event == MouseInputEvent.Move && HasMouseFocus)

--- a/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Widgets
 			recentLines.Add(new ChatLine(from, text, Game.LocalTick + RemoveTime, c));
 
 			if (Notification != null)
-				Sound.Play(Notification);
+				Game.Sound.Play(Notification);
 
 			while (recentLines.Count > LogLength)
 				recentLines.RemoveAt(0);

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Widgets
 			// Mask to prevent any clicks from being sent to other widgets
 			fullscreenMask = new MaskWidget();
 			fullscreenMask.Bounds = new Rectangle(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
-			fullscreenMask.OnMouseDown += mi => { Sound.PlayNotification(this.ModRules, null, "Sounds", "ClickSound", null); RemovePanel(); };
+			fullscreenMask.OnMouseDown += mi => { Game.Sound.PlayNotification(this.ModRules, null, "Sounds", "ClickSound", null); RemovePanel(); };
 			if (onCancel != null)
 				fullscreenMask.OnMouseDown += _ => onCancel();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				chatScrollPanel.ScrollToBottom(smooth: true);
 
 			if (!replayCache)
-				Sound.PlayNotification(modRules, null, "Sounds", "ChatLine", null);
+				Game.Sound.PlayNotification(modRules, null, "Sounds", "ChatLine", null);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Action onQuit = () =>
 			{
 				if (world.Type == WorldType.Regular)
-					Sound.PlayNotification(world.Map.Rules, null, "Speech", "Leave", world.LocalPlayer == null ? null : world.LocalPlayer.Faction.InternalName);
+					Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", "Leave", world.LocalPlayer == null ? null : world.LocalPlayer.Faction.InternalName);
 
 				leaving = true;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					.Any(a => a.Actor.Owner == world.LocalPlayer && a.Trait.IsActive);
 
 				if (radarEnabled != cachedRadarEnabled)
-					Sound.PlayNotification(world.Map.Rules, null, "Sounds", radarEnabled ? "RadarUp" : "RadarDown", null);
+					Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", radarEnabled ? "RadarUp" : "RadarDown", null);
 				cachedRadarEnabled = radarEnabled;
 			};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -653,7 +653,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (scrolledToBottom)
 				chatPanel.ScrollToBottom(smooth: true);
 
-			Sound.PlayNotification(modRules, null, "Sounds", "ChatLine", null);
+			Game.Sound.PlayNotification(modRules, null, "Sounds", "ChatLine", null);
 		}
 
 		bool SwitchTeamChat()

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -213,18 +213,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		float cachedMusicVolume;
 		void MuteSounds()
 		{
-			cachedSoundVolume = Sound.SoundVolume;
-			cachedMusicVolume = Sound.MusicVolume;
-			Sound.SoundVolume = Sound.MusicVolume = 0;
+			cachedSoundVolume = Game.Sound.SoundVolume;
+			cachedMusicVolume = Game.Sound.MusicVolume;
+			Game.Sound.SoundVolume = Game.Sound.MusicVolume = 0;
 		}
 
 		void UnMuteSounds()
 		{
 			if (cachedSoundVolume > 0)
-				Sound.SoundVolume = cachedSoundVolume;
+				Game.Sound.SoundVolume = cachedSoundVolume;
 
 			if (cachedMusicVolume > 0)
-				Sound.MusicVolume = cachedMusicVolume;
+				Game.Sound.MusicVolume = cachedMusicVolume;
 		}
 
 		void PlayVideo(VqaPlayerWidget player, string video, PlayingVideo pv, Action onComplete)

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -41,12 +41,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var playButton = panel.Get<ButtonWidget>("BUTTON_PLAY");
 			playButton.OnClick = Play;
 			playButton.IsDisabled = noMusic;
-			playButton.IsVisible = () => !Sound.MusicPlaying;
+			playButton.IsVisible = () => !Game.Sound.MusicPlaying;
 
 			var pauseButton = panel.Get<ButtonWidget>("BUTTON_PAUSE");
-			pauseButton.OnClick = Sound.PauseMusic;
+			pauseButton.OnClick = Game.Sound.PauseMusic;
 			pauseButton.IsDisabled = noMusic;
-			pauseButton.IsVisible = () => Sound.MusicPlaying;
+			pauseButton.IsVisible = () => Game.Sound.MusicPlaying;
 
 			var stopButton = panel.Get<ButtonWidget>("BUTTON_STOP");
 			stopButton.OnClick = () => { musicPlaylist.Stop(); };
@@ -75,8 +75,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (currentSong == null || musicPlaylist.CurrentSongIsBackground)
 					return "";
 
-				var minutes = (int)Sound.MusicSeekPosition / 60;
-				var seconds = (int)Sound.MusicSeekPosition % 60;
+				var minutes = (int)Game.Sound.MusicSeekPosition / 60;
+				var seconds = (int)Game.Sound.MusicSeekPosition % 60;
 				var totalMinutes = currentSong.Length / 60;
 				var totalSeconds = currentSong.Length % 60;
 
@@ -84,8 +84,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			var musicSlider = panel.Get<SliderWidget>("MUSIC_SLIDER");
-			musicSlider.OnChange += x => Sound.MusicVolume = x;
-			musicSlider.Value = Sound.MusicVolume;
+			musicSlider.OnChange += x => Game.Sound.MusicVolume = x;
+			musicSlider.Value = Game.Sound.MusicVolume;
 
 			var installButton = widget.GetOrNull<ButtonWidget>("INSTALL_BUTTON");
 			if (installButton != null)
@@ -108,10 +108,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (musicPlaylist.CurrentSongIsBackground && currentSong != null)
 						currentSong = null;
 
-					if (Sound.CurrentMusic == null || currentSong == Sound.CurrentMusic || musicPlaylist.CurrentSongIsBackground)
+					if (Game.Sound.CurrentMusic == null || currentSong == Game.Sound.CurrentMusic || musicPlaylist.CurrentSongIsBackground)
 						return;
 
-					currentSong = Sound.CurrentMusic;
+					currentSong = Game.Sound.CurrentMusic;
 				};
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -307,11 +307,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindSliderPref(panel, "VIDEO_VOLUME", ss, "VideoVolume");
 
 			// Update volume immediately
-			panel.Get<SliderWidget>("SOUND_VOLUME").OnChange += x => Sound.SoundVolume = x;
-			panel.Get<SliderWidget>("MUSIC_VOLUME").OnChange += x => Sound.MusicVolume = x;
-			panel.Get<SliderWidget>("VIDEO_VOLUME").OnChange += x => Sound.VideoVolume = x;
+			panel.Get<SliderWidget>("SOUND_VOLUME").OnChange += x => Game.Sound.SoundVolume = x;
+			panel.Get<SliderWidget>("MUSIC_VOLUME").OnChange += x => Game.Sound.MusicVolume = x;
+			panel.Get<SliderWidget>("VIDEO_VOLUME").OnChange += x => Game.Sound.VideoVolume = x;
 
-			var devices = Sound.AvailableDevices();
+			var devices = Game.Sound.AvailableDevices();
 			soundDevice = devices.FirstOrDefault(d => d.Engine == ss.Engine && d.Device == ss.Device) ?? devices.First();
 
 			var audioDeviceDropdown = panel.Get<DropDownButtonWidget>("AUDIO_DEVICE");
@@ -339,12 +339,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ss.Engine = dss.Engine;
 
 				panel.Get<SliderWidget>("SOUND_VOLUME").Value = ss.SoundVolume;
-				Sound.SoundVolume = ss.SoundVolume;
+				Game.Sound.SoundVolume = ss.SoundVolume;
 				panel.Get<SliderWidget>("MUSIC_VOLUME").Value = ss.MusicVolume;
-				Sound.MusicVolume = ss.MusicVolume;
+				Game.Sound.MusicVolume = ss.MusicVolume;
 				panel.Get<SliderWidget>("VIDEO_VOLUME").Value = ss.VideoVolume;
-				Sound.VideoVolume = ss.VideoVolume;
-				soundDevice = Sound.AvailableDevices().First();
+				Game.Sound.VideoVolume = ss.VideoVolume;
+				soundDevice = Game.Sound.AvailableDevices().First();
 			};
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -220,14 +220,14 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (PickUpCompletedBuildingIcon(icon, item))
 			{
-				Sound.Play(TabClick);
+				Game.Sound.Play(TabClick);
 				return true;
 			}
 
 			if (item != null && item.Paused)
 			{
 				// Resume a paused item
-				Sound.Play(TabClick);
+				Game.Sound.Play(TabClick);
 				World.IssueOrder(Order.PauseProduction(CurrentQueue.Actor, icon.Name, false));
 				return true;
 			}
@@ -235,8 +235,8 @@ namespace OpenRA.Mods.Common.Widgets
 			if (CurrentQueue.BuildableItems().Any(a => a.Name == icon.Name))
 			{
 				// Queue a new item
-				Sound.Play(TabClick);
-				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, World.LocalPlayer.Faction.InternalName);
+				Game.Sound.Play(TabClick);
+				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, World.LocalPlayer.Faction.InternalName);
 				World.IssueOrder(Order.StartProduction(CurrentQueue.Actor, icon.Name,
 					handleMultiple ? 5 : 1));
 				return true;
@@ -250,19 +250,19 @@ namespace OpenRA.Mods.Common.Widgets
 			if (item == null)
 				return false;
 
-			Sound.Play(TabClick);
+			Game.Sound.Play(TabClick);
 
 			if (item.Paused || item.Done || item.TotalCost == item.RemainingCost)
 			{
 				// Instant cancel of things we have not started yet and things that are finished
-				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Faction.InternalName);
+				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Faction.InternalName);
 				World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name,
 					handleMultiple ? 5 : 1));
 			}
 			else
 			{
 				// Pause an existing item
-				Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.OnHoldAudio, World.LocalPlayer.Faction.InternalName);
+				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.OnHoldAudio, World.LocalPlayer.Faction.InternalName);
 				World.IssueOrder(Order.PauseProduction(CurrentQueue.Actor, icon.Name, true));
 			}
 
@@ -276,7 +276,7 @@ namespace OpenRA.Mods.Common.Widgets
 				: HandleRightClick(item, icon, handleMultiple);
 
 			if (!handled)
-				Sound.Play(DisabledTabClick);
+				Game.Sound.Play(DisabledTabClick);
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -261,9 +261,9 @@ namespace OpenRA.Mods.Common.Widgets
 			if (leftPressed || rightPressed)
 			{
 				if ((leftPressed && !leftDisabled) || (rightPressed && !rightDisabled))
-					Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
+					Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 				else
-					Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickDisabledSound", null);
+					Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickDisabledSound", null);
 			}
 
 			// Check production tabs
@@ -271,7 +271,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (offsetloc.X > 0 && offsetloc.X < contentWidth)
 			{
 				CurrentQueue = Groups[queueGroup].Tabs[offsetloc.X / (TabWidth - 1)].Queue;
-				Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 			}
 
 			return true;
@@ -286,12 +286,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (hotkey == Game.Settings.Keys.NextProductionTabKey)
 			{
-				Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 				return SelectNextTab(false);
 			}
 			else if (hotkey == Game.Settings.Keys.PreviousProductionTabKey)
 			{
-				Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 				return SelectNextTab(true);
 			}
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -335,7 +335,7 @@ namespace OpenRA.Mods.Common.Widgets
 			// Enable/Disable the radar
 			var enabled = IsEnabled();
 			if (enabled != cachedEnabled)
-				Sound.Play(enabled ? RadarOnlineSound : RadarOfflineSound);
+				Game.Sound.Play(enabled ? RadarOnlineSound : RadarOfflineSound);
 			cachedEnabled = enabled;
 
 			if (enabled)

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -321,7 +321,7 @@ namespace OpenRA.Mods.Common.Widgets
 					lastMouseLocation = mi.Location;
 
 				if (mi.Event == MouseInputEvent.Down && ((upPressed && !upDisabled) || (downPressed && !downDisabled) || thumbPressed))
-					Sound.PlayNotification(modRules, null, "Sounds", "ClickSound", null);
+					Game.Sound.PlayNotification(modRules, null, "Sounds", "ClickSound", null);
 			}
 
 			return upPressed || downPressed || thumbPressed;

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets
 		protected void ClickIcon(SupportPowerIcon clicked)
 		{
 			if (!clicked.Power.Active)
-				Sound.PlayToPlayer(spm.Self.Owner, clicked.Power.Info.InsufficientPowerSound);
+				Game.Sound.PlayToPlayer(spm.Self.Owner, clicked.Power.Info.InsufficientPowerSound);
 			else
 				clicked.Power.Target();
 		}

--- a/OpenRA.Mods.Common/Widgets/VqaPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VqaPlayerWidget.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			stopped = true;
 			paused = true;
-			Sound.StopVideo();
+			Game.Sound.StopVideo();
 			onComplete = () => { };
 
 			invLength = video.Framerate * 1f / video.Frames;
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var nextFrame = 0;
 				if (video.HasAudio)
-					nextFrame = (int)float2.Lerp(0, video.Frames, Sound.VideoSeekPosition * invLength);
+					nextFrame = (int)float2.Lerp(0, video.Frames, Game.Sound.VideoSeekPosition * invLength);
 				else
 					nextFrame = video.CurrentFrame + 1;
 
@@ -176,9 +176,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			onComplete = after;
 			if (stopped)
-				Sound.PlayVideo(video.AudioData, video.AudioChannels, video.SampleBits, video.SampleRate);
+				Game.Sound.PlayVideo(video.AudioData, video.AudioChannels, video.SampleBits, video.SampleRate);
 			else
-				Sound.PlayVideo();
+				Game.Sound.PlayVideo();
 
 			stopped = paused = false;
 		}
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			paused = true;
-			Sound.PauseVideo();
+			Game.Sound.PauseVideo();
 		}
 
 		public void Stop()
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			stopped = true;
 			paused = true;
-			Sound.StopVideo();
+			Game.Sound.StopVideo();
 			video.Reset();
 			videoSprite.Sheet.GetTexture().SetData(video.FrameData);
 			world.AddFrameEndTask(_ => onComplete());

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -241,7 +241,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			world.Selection.Combine(world, new Actor[] { next }, false, true);
 
-			Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
+			Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 
 			return ToSelection();
 		}

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.D2k.Activities
 		void PlayAttack(Actor self, WPos attackPosition, List<Player> affectedPlayers)
 		{
 			withSpriteBody.PlayCustomAnimation(self, sandworm.Info.MouthSequence);
-			Sound.Play(swallow.Info.WormAttackSound, self.CenterPosition);
+			Game.Sound.Play(swallow.Info.WormAttackSound, self.CenterPosition);
 
 			Game.RunAfterDelay(1000, () =>
 			{
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.D2k.Activities
 
 		void NotifyPlayer(Player player, WPos location)
 		{
-			Sound.PlayNotification(player.World.Map.Rules, player, "Speech", swallow.Info.WormAttackNotification, player.Faction.InternalName);
+			Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", swallow.Info.WormAttackNotification, player.Faction.InternalName);
 
 			if (player == player.World.RenderPlayer)
 				radarPings.Add(() => true, location, Color.Red, 50);

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.RA.Activities
 			self.Dispose();
 
 			if (target.Info.HasTraitInfo<BuildingInfo>())
-				Sound.PlayToPlayer(self.Owner, "bldginf1.aud");
+				Game.Sound.PlayToPlayer(self.Owner, "bldginf1.aud");
 		}
 	}
 }

--- a/OpenRA.Mods.RA/Activities/Leap.cs
+++ b/OpenRA.Mods.RA/Activities/Leap.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.RA.Activities
 			self.Trait<WithInfantryBody>().Attacking(self, Target.FromActor(target));
 
 			if (weapon.Report != null && weapon.Report.Any())
-				Sound.Play(weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
+				Game.Sound.Play(weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -59,8 +59,8 @@ namespace OpenRA.Mods.RA.Activities
 
 			destination = bestCell.Value;
 
-			Sound.Play(sound, self.CenterPosition);
-			Sound.Play(sound, self.World.Map.CenterOfCell(destination));
+			Game.Sound.Play(sound, self.CenterPosition);
+			Game.Sound.Play(sound, self.World.Map.CenterOfCell(destination));
 
 			self.Trait<IPositionable>().SetPosition(self, destination);
 			self.Generation++;

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForCash.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Traits
 			targetResources.TakeCash(toTake);
 			spyResources.GiveCash(toGive);
 
-			Sound.PlayToPlayer(self.Owner, info.SoundToVictim);
+			Game.Sound.PlayToPlayer(self.Owner, info.SoundToVictim);
 
 			self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, infiltrator.Owner.Color.RGB, FloatingText.FormatCashTick(toGive), 30)));
 		}

--- a/OpenRA.Mods.RA/Traits/MadTank.cs
+++ b/OpenRA.Mods.RA/Traits/MadTank.cs
@@ -152,9 +152,9 @@ namespace OpenRA.Mods.RA.Traits
 				wfsb.PlayCustomAnimationRepeating(self, info.ThumpSequence);
 			deployed = true;
 			self.QueueActivity(new Wait(info.ChargeDelay, false));
-			self.QueueActivity(new CallFunc(() => Sound.Play(info.ChargeSound, self.CenterPosition)));
+			self.QueueActivity(new CallFunc(() => Game.Sound.Play(info.ChargeSound, self.CenterPosition)));
 			self.QueueActivity(new Wait(info.DetonationDelay, false));
-			self.QueueActivity(new CallFunc(() => Sound.Play(info.DetonationSound, self.CenterPosition)));
+			self.QueueActivity(new CallFunc(() => Game.Sound.Play(info.DetonationSound, self.CenterPosition)));
 			self.QueueActivity(new CallFunc(Detonate));
 		}
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public override IOrderGenerator OrderGenerator(string order, SupportPowerManager manager)
 		{
-			Sound.PlayToPlayer(manager.Self.Owner, Info.SelectTargetSound);
+			Game.Sound.PlayToPlayer(manager.Self.Owner, Info.SelectTargetSound);
 			return new SelectTarget(Self.World, order, manager, this);
 		}
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.RA.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				Sound.PlayToPlayer(self.Owner, Info.LaunchSound);
+				Game.Sound.PlayToPlayer(self.Owner, Info.LaunchSound);
 
 				w.Add(new SatelliteLaunch(self));
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.RA.Traits
 			self.World.AddFrameEndTask(w =>
 			{
 				var notification = self.Owner.IsAlliedWith(self.World.RenderPlayer) ? Info.LaunchSound : Info.IncomingSound;
-				Sound.Play(notification);
+				Game.Sound.Play(notification);
 
 				Actor distanceTestActor = null;
 

--- a/OpenRA.Platforms.Null/NullSound.cs
+++ b/OpenRA.Platforms.Null/NullSound.cs
@@ -12,7 +12,7 @@ using System;
 
 namespace OpenRA.Platforms.Null
 {
-	class NullSoundEngine : ISoundEngine
+	sealed class NullSoundEngine : ISoundEngine
 	{
 		public SoundDevice[] AvailableDevices()
 		{
@@ -42,6 +42,8 @@ namespace OpenRA.Platforms.Null
 		public void SetSoundVolume(float volume, ISound music, ISound video) { }
 
 		public float Volume { get; set; }
+
+		public void Dispose() { }
 	}
 
 	class NullSoundSource : ISoundSource { }


### PR DESCRIPTION
Followup to #9274.  This unstatics the `Sound` class, and moves it to a static field in Game to make it consistent with how we access the renderer.
