### PR TITLE
Fixed the OpenAL device not being properly closed

### DIFF
--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -97,6 +97,8 @@ namespace OpenRA.Platforms.Default
 					throw new InvalidOperationException("Can't create OpenAL device");
 			}
 
+			Game.OnQuit += () => { Alc.CloseDevice(dev); };
+
 			var ctx = Alc.CreateContext(dev, (int[])null);
 			if (ctx == ContextHandle.Zero)
 				throw new InvalidOperationException("Can't create OpenAL context");


### PR DESCRIPTION
I always get reminded in the command line when closing the game.

> AL lib: (EE) alc_cleanup: 1 device not closed
