### PR TITLE
Add basic arguments validation

### DIFF
--- a/OpenRA.Game/IUtilityCommand.cs
+++ b/OpenRA.Game/IUtilityCommand.cs
@@ -17,6 +17,8 @@ namespace OpenRA
 		/// </summary>
 		string Name { get; }
 
+		bool ValidateArguments(string[] args);
+
 		void Run(ModData modData, string[] args);
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/CheckCodeStyle.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckCodeStyle.cs
@@ -9,12 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using OpenRA.FileSystem;
-using OpenRA.Traits;
 using StyleCop;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -23,6 +18,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		public string Name { get { return "--check-code-style"; } }
 		int violationCount;
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
 
 		[Desc("DIRECTORY", "Check the *.cs source code files in a directory for code style violations.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
@@ -9,20 +9,20 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
-using OpenRA.Traits;
-using StyleCop;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	class CheckSquenceSprites : IUtilityCommand
 	{
 		public string Name { get { return "--check-sequence-sprites"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return true;
+		}
 
 		[Desc("Check the sequence definitions for missing sprite files.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.FileSystem;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -32,6 +31,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		static void EmitWarning(string e)
 		{
 			Console.WriteLine("OpenRA.Utility(1,1): Warning: {0}", e);
+		}
+
+		public bool ValidateArguments(string[] args)
+		{
+			return true;
 		}
 
 		[Desc("[MAPFILE]", "Check a mod or map for certain yaml errors.")]

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertPngToShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertPngToShpCommand.cs
@@ -15,7 +15,6 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using OpenRA.FileFormats;
 using OpenRA.Mods.Common.SpriteLoaders;
 
@@ -24,6 +23,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	class ConvertPngToShpCommand : IUtilityCommand
 	{
 		public string Name { get { return "--shp"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
 
 		[Desc("PNGFILE [PNGFILE ...]", "Combine a list of PNG images into a SHP")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -9,14 +9,11 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -24,6 +21,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	class ConvertSpriteToPngCommand : IUtilityCommand
 	{
 		public string Name { get { return "--png"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 3;
+		}
 
 		[Desc("SPRITEFILE PALETTE [--noshadow] [--nopadding]",
 			  "Convert a shp/tmp/R8 to a series of PNGs, optionally removing shadow")]

--- a/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
@@ -17,6 +17,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		public string Name { get { return "--man-page"; } }
 
+		public bool ValidateArguments(string[] args)
+		{
+			return true;
+		}
+
 		[Desc("Create a man page in troff format.")]
 		public void Run(ModData modData, string[] args)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Data;
 using System.Text;
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
@@ -9,10 +9,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -20,6 +18,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	class ExtractFilesCommand : IUtilityCommand
 	{
 		public string Name { get { return "--extract"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
 
 		[Desc("Extract files from mod packages to the current directory")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -12,13 +12,17 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	class ExtractLanguageStringsCommand : IUtilityCommand
 	{
 		public string Name { get { return "--extract-language-strings"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return true;
+		}
 
 		[Desc("Extract translatable strings that are not yet localized and update chrome layout.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -21,6 +21,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		public string Name { get { return "--lua-docs"; } }
 
+		public bool ValidateArguments(string[] args)
+		{
+			return true;
+		}
+
 		[Desc("Generate Lua API documentation in MarkDown format.")]
 		public void Run(ModData modData, string[] args)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -20,6 +20,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		public string Name { get { return "--docs"; } }
 
+		public bool ValidateArguments(string[] args)
+		{
+			return true;
+		}
+
 		[Desc("Generate trait documentation in MarkDown format.")]
 		public void Run(ModData modData, string[] args)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/FixClassicTilesets.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FixClassicTilesets.cs
@@ -9,21 +9,23 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
-using OpenRA.Traits;
-using StyleCop;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	class FixClassicTilesets : IUtilityCommand
 	{
 		public string Name { get { return "--fix-classic-tilesets"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
 
 		[Desc("EXTENSIONS", "Fixes missing template tile definitions and adds filename extensions.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/GenerateMinimapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GenerateMinimapCommand.cs
@@ -9,10 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 
@@ -21,6 +18,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	class GenerateMinimapCommand : IUtilityCommand
 	{
 		public string Name { get { return "--map-preview"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
 
 		[Desc("MAPFILE", "Render PNG minimap of specified oramap file.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
@@ -9,15 +9,17 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	public class GetMapHashCommand : IUtilityCommand
 	{
 		public string Name { get { return "--map-hash"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
 
 		[Desc("MAPFILE", "Generate hash of specified oramap file.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -17,6 +17,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		public string Name { get { return "--map-import"; } }
 
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
+
 		[Desc("FILENAME", "Convert a legacy INI/MPR map to the OpenRA format.")]
 		public void Run(ModData modData, string[] args)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
@@ -10,8 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
@@ -13,8 +13,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Text;
-using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.SpriteLoaders;
@@ -25,6 +23,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	class RemapShpCommand : IUtilityCommand
 	{
 		public string Name { get { return "--remap"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 5;
+		}
 
 		[Desc("SRCMOD:PAL DESTMOD:PAL SRCSHP DESTSHP", "Remap SHPs to another palette")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
@@ -18,6 +18,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	{
 		public string Name { get { return "--replay-metadata"; } }
 
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
+
 		[Desc("REPLAYFILE", "Print the game metadata from a replay file.")]
 		public void Run(ModData modData, string[] args)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -8,16 +8,16 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	class UpgradeMapCommand : IUtilityCommand
 	{
 		public string Name { get { return "--upgrade-map"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 3;
+		}
 
 		[Desc("MAP", "CURRENTENGINE", "Upgrade map rules to the latest engine version.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -9,16 +9,19 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
 	class UpgradeModCommand : IUtilityCommand
 	{
 		public string Name { get { return "--upgrade-mod"; } }
+
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 2;
+		}
 
 		[Desc("CURRENTENGINE", "Upgrade mod rules to the latest engine version.")]
 		public void Run(ModData modData, string[] args)

--- a/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
@@ -17,6 +17,11 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 	{
 		public string Name { get { return "--import-d2k-map"; } }
 
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 3;
+		}
+
 		[Desc("FILENAME", "TILESET", "Convert a legacy Dune 2000 MAP file to the OpenRA format.")]
 		public void Run(ModData modData, string[] args)
 		{

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -20,6 +20,11 @@ namespace OpenRA.Mods.TS.UtilityCommands
 	{
 		public string Name { get { return "--tileset-import"; } }
 
+		public bool ValidateArguments(string[] args)
+		{
+			return args.Length >= 3;
+		}
+
 		[Desc("FILENAME", "TEMPLATEEXTENSION", "Convert a legacy tileset to the OpenRA format.")]
 		public void Run(ModData modData, string[] args)
 		{


### PR DESCRIPTION
This PR is the first step of validation of argument(s) passed through OpenRA.Utility. Target issue #8442
- Add a method [IUtilityCommand](https://github.com/Herve-M/OpenRA/blob/feat-utility-polish/OpenRA.Game/IUtilityCommand.cs#L20)
- Test Argument before calling command [OpenRA.Utility/Program.cs](https://github.com/Herve-M/OpenRA/blob/feat-utility-polish/OpenRA.Utility/Program.cs#L59-L72)
- Impl. basic validation (on args.Length) on all [Utility.Commands](https://github.com/Herve-M/OpenRA/commit/ff82276c2103ab2c06e5926f37170346a7ee8795?diff=unified)

If a command is called without validating, the description is showed.

```
λ OpenRA.Utility.exe ra --shp
Invalid arguments for '--shp'
  --shp PNGFILE [PNGFILE ...]
  Combine a list of PNG images into a SHP
```

If a inexisting command is used, a System.ArgumentException is thrown without crashing / showing it. 

```
λ OpenRA.Utility.exe ra --sh
No such command '--sh'
```

**Special attention for validation** : see if UnityCommands:ValidateArguments are just.
