### PR TITLE
Fixed massive AI base builder performance issue

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -500,11 +500,11 @@ namespace OpenRA.Mods.Common.AI
 					// Try and place the refinery near a resource field
 					var nearbyResources = Map.FindTilesInCircle(baseCenter, Info.MaxBaseRadius)
 						.Where(a => resourceTypeIndices.Get(Map.GetTerrainIndex(a)))
-						.Shuffle(Random);
+						.Shuffle(Random).ToList();
 
-					foreach (var c in nearbyResources)
+					if (nearbyResources.Count > 0)
 					{
-						var found = findPos(c, baseCenter, 0, Info.MaxBaseRadius);
+						var found = findPos(nearbyResources.First(), baseCenter, 0, Info.MaxBaseRadius);
 						if (found != null)
 							return found;
 					}

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -101,6 +101,9 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Radius in cells around a factory scanned for rally points by the AI.")]
 		public readonly int RallyPointScanRadius = 8;
 
+		[Desc("Minimum distance in cells from center of the base when checking for building placement.")]
+		public readonly int MinBaseRadius = 2;
+
 		[Desc("Radius in cells around the center of the base to expand.")]
 		public readonly int MaxBaseRadius = 20;
 
@@ -501,22 +504,22 @@ namespace OpenRA.Mods.Common.AI
 				case BuildingType.Refinery:
 
 					// Try and place the refinery near a resource field
-					var nearbyResources = Map.FindTilesInCircle(baseCenter, Info.MaxBaseRadius)
+					var nearbyResources = Map.FindTilesInAnnulus(baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius)
 						.Where(a => resourceTypeIndices.Get(Map.GetTerrainIndex(a)))
 						.Shuffle(Random).Take(Info.MaxResourceCellsToCheck);
 
 					foreach (var r in nearbyResources)
 					{
-						var found = findPos(r, baseCenter, 0, Info.MaxBaseRadius);
+						var found = findPos(r, baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius);
 						if (found != null)
 							return found;
 					}
 
 					// Try and find a free spot somewhere else in the base
-					return findPos(baseCenter, baseCenter, 0, Info.MaxBaseRadius);
+					return findPos(baseCenter, baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius);
 
 				case BuildingType.Building:
-					return findPos(baseCenter, baseCenter, 0, distanceToBaseIsImportant ? Info.MaxBaseRadius : Map.MaxTilesInCircleRange);
+					return findPos(baseCenter, baseCenter, Info.MinBaseRadius, distanceToBaseIsImportant ? Info.MaxBaseRadius : Map.MaxTilesInCircleRange);
 			}
 
 			// Can't find a build location

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -74,6 +74,9 @@ namespace OpenRA.Mods.Common.AI
 			"for StructureProductionResumeDelay before retrying.")]
 		public readonly int MaximumFailedPlacementAttempts = 3;
 
+		[Desc("How many randomly chosen cells with resources to check when deciding refinery placement.")]
+		public readonly int MaxResourceCellsToCheck = 3;
+
 		[Desc("Delay (in ticks) until rechecking for new BaseProviders.")]
 		public readonly int CheckForNewBasesDelay = 1500;
 
@@ -500,11 +503,11 @@ namespace OpenRA.Mods.Common.AI
 					// Try and place the refinery near a resource field
 					var nearbyResources = Map.FindTilesInCircle(baseCenter, Info.MaxBaseRadius)
 						.Where(a => resourceTypeIndices.Get(Map.GetTerrainIndex(a)))
-						.Shuffle(Random).ToList();
+						.Shuffle(Random).Take(Info.MaxResourceCellsToCheck);
 
-					if (nearbyResources.Count > 0)
+					foreach (var r in nearbyResources)
 					{
-						var found = findPos(nearbyResources.First(), baseCenter, 0, Info.MaxBaseRadius);
+						var found = findPos(r, baseCenter, 0, Info.MaxBaseRadius);
 						if (found != null)
 							return found;
 					}


### PR DESCRIPTION
HackyAI causes occasional BaseBuilder-related lag spikes of anywhere between 200 and 1200(!) milliseconds.

After throwing around with PerfTimers, I narrowed it down to the refinery placement.
In worst-case scenarios, the AI would iterate through all cells with resources inside MaxBaseRadius and perform a full findPos check for each of them.

Now it simply takes the first randomly chosen cell with resources inside MaxBaseRadius and places the refinery in that direction, if possible, and otherwise falls back to a normal placement check.

Closes #4717.
