### PR TITLE
Support loading multiple turret facings

### DIFF
--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -14,7 +14,15 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
-	public class ActorInitializer
+	public interface IActorInitializer
+	{
+		World World { get; }
+		T Get<T>() where T : IActorInit;
+		U Get<T, U>() where T : IActorInit<U>;
+		bool Contains<T>() where T : IActorInit;
+	}
+
+	public class ActorInitializer : IActorInitializer
 	{
 		public readonly Actor Self;
 		public World World { get { return Self.World; } }
@@ -44,14 +52,6 @@ namespace OpenRA
 		[FieldFromYamlKey] readonly int value = 128;
 		public FacingInit() { }
 		public FacingInit(int init) { value = init; }
-		public int Value(World world) { return value; }
-	}
-
-	public class TurretFacingInit : IActorInit<int>
-	{
-		[FieldFromYamlKey] readonly int value = 128;
-		public TurretFacingInit() { }
-		public TurretFacingInit(int init) { value = init; }
 		public int Value(World world) { return value; }
 	}
 

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Graphics
 		IEnumerable<IRenderable> Render(WorldRenderer wr, WPos pos);
 	}
 
-	public class ActorPreviewInitializer
+	public class ActorPreviewInitializer : IActorInitializer
 	{
 		public readonly ActorInfo Actor;
 		public readonly WorldRenderer WorldRenderer;

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var ifacing = init.Actor.TraitInfoOrDefault<IFacingInfo>();
 			var bodyFacing = ifacing != null ? init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : ifacing.GetInitialFacing() : 0;
-			var turretFacing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit, int>() : t.InitialFacing;
+			var turretFacing = Turreted.GetInitialTurretFacing(init, t.InitialFacing, Turret);
 
 			var anim = new Animation(init.World, image, () => turretFacing);
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var voxel = VoxelProvider.GetVoxel(image, Sequence);
 
-			var turretFacing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit, int>() : t.InitialFacing;
+			var turretFacing = Turreted.GetInitialTurretFacing(init, t.InitialFacing, t.Turret);
 			var turretOrientation = body.QuantizeOrientation(new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(turretFacing) - orientation.Yaw), facings);
 			var turretOffset = body.LocalToWorld(t.Offset.Rotate(orientation));
 

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 			var voxel = VoxelProvider.GetVoxel(image, Sequence);
 			var turretOffset = body.LocalToWorld(t.Offset.Rotate(orientation));
 
-			var turretFacing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit, int>() : t.InitialFacing;
+			var turretFacing = Turreted.GetInitialTurretFacing(init, t.InitialFacing, Turret);
 			var turretBodyOrientation = new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(turretFacing) - orientation.Yaw);
 			var turretOrientation = new[] { turretBodyOrientation, body.QuantizeOrientation(orientation, facings) };
 			yield return new VoxelAnimation(voxel, () => turretOffset, () => turretOrientation, () => false, () => 0);

--- a/OpenRA.Mods.RA/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.RA/Traits/SpawnActorOnDeath.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Warheads;
@@ -107,11 +108,14 @@ namespace OpenRA.Mods.RA.Traits
 				if (facing != null)
 					td.Add(new FacingInit(facing.Facing));
 
-				// TODO: This will only take the first turret if there are multiple
-				// This isn't a problem with the current units, but may be a problem for mods
-				var turreted = self.TraitsImplementing<Turreted>().FirstOrDefault();
-				if (turreted != null)
-					td.Add(new TurretFacingInit(turreted.TurretFacing));
+				var turreted = self.TraitsImplementing<Turreted>();
+				if (turreted.Any())
+				{
+					var turretFacings = new Dictionary<string, int>();
+					foreach (var t in turreted)
+						turretFacings.Add(t.Name, t.TurretFacing);
+					td.Add(new TurretFacingsInit(turretFacings));
+				}
 
 				// TODO: untie this and move to Mods.Common
 				var chronoshiftable = self.TraitOrDefault<Chronoshiftable>();


### PR DESCRIPTION
Adds `TurretFacingsInit` to support loading/saving the turret facing of each turret.
Moved `TurretFacingInit` since it should have been in `OpenRA.Mods.Common/Traits/Turreted.cs` all along.
Added `IActorInitializer` so that `Turreted.TurretFacingsInit` can use `ActorPreviewInitializer`s instead of `ActorInitializer`s when called from `RenderPreview*`.
