### PR TITLE
Move SpawnActorOnDeath to OpenRA.Mods.Common

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -701,6 +701,7 @@
     <Compile Include="Lint\CheckRevealFootprint.cs" />
     <Compile Include="Traits\ThrowsShrapnel.cs" />
     <Compile Include="Traits\World\MusicPlaylist.cs" />
+    <Compile Include="Traits\SpawnActorOnDeath.cs" />
     <Compile Include="Scripting\Global\LightingGlobal.cs" />
     <Compile Include="Traits\SupportPowers\ProduceActorPower.cs" />
     <Compile Include="Widgets\Logic\GlobalChatLogic.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 	}
 
-	public class Aircraft : ITick, ISync, IFacing, IPositionable, IMove, IIssueOrder, IResolveOrder, IOrderVoice,
+	public class Aircraft : ITick, ISync, IFacing, IPositionable, IMove, IIssueOrder, IResolveOrder, IOrderVoice, IDeathActorInitModifier,
 		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing
 	{
 		static readonly Pair<CPos, SubCell>[] NoCells = { };
@@ -326,6 +326,11 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new Rearm(self);
 			if (Info.RepairBuildings.Contains(name))
 				yield return new Repair(a);
+		}
+
+		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
+		{
+			init.Add(new FacingInit(Facing));
 		}
 
 		#region Implement IPositionable

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 	}
 
-	public class Husk : IPositionable, IFacing, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, IDisable
+	public class Husk : IPositionable, IFacing, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, IDisable, IDeathActorInitModifier
 	{
 		readonly HuskInfo info;
 		readonly Actor self;
@@ -126,6 +126,11 @@ namespace OpenRA.Mods.Common.Traits
 		public bool Disabled
 		{
 			get { return true; }
+		}
+
+		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
+		{
+			init.Add(new FacingInit(Facing));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -304,7 +304,8 @@ namespace OpenRA.Mods.Common.Traits
 		bool IOccupySpaceInfo.SharesCell { get { return SharesCell; } }
 	}
 
-	public class Mobile : IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove, IFacing, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove
+	public class Mobile : IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove, IFacing, ISync, IDeathActorInitModifier,
+		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove
 	{
 		const int AverageTicksBeforePathing = 5;
 		const int SpreadTicksBeforePathing = 5;
@@ -792,6 +793,15 @@ namespace OpenRA.Mods.Common.Traits
 
 			var facing = Util.GetFacing(toPos - fromPos, Facing);
 			return Util.SequenceActivities(new Turn(self, facing), new Drag(self, fromPos, toPos, length));
+		}
+
+		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
+		{
+			init.Add(new FacingInit(facing));
+
+			// Allows the husk to drag to its final position
+			if (CanEnterCell(self.Location, self, false))
+				init.Add(new HuskSpeedInit(MovementSpeedForCell(self, self.Location)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -30,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new Turreted(init, this); }
 	}
 
-	public class Turreted : ITick, ISync, INotifyCreated
+	public class Turreted : ITick, ISync, INotifyCreated, IDeathActorInitModifier
 	{
 		readonly TurretedInfo info;
 		AttackTurreted attack;
@@ -134,6 +135,18 @@ namespace OpenRA.Mods.Common.Traits
 			// Implies no pitch or yaw
 			var facing = Util.QuantizeFacing(local.Yaw.Angle / 4, QuantizedFacings) * (256 / QuantizedFacings);
 			return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing));
+		}
+
+		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
+		{
+			var facings = init.GetOrDefault<TurretFacingsInit>();
+			if (facings == null)
+			{
+				facings = new TurretFacingsInit();
+				init.Add(facings);
+			}
+
+			facings.Value(self.World).Add(Name, facing.Facing);
 		}
 	}
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -14,6 +14,7 @@ using OpenRA.Activities;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -114,5 +115,10 @@ namespace OpenRA.Mods.Common.Traits
 		bool WantsTransport { get; set; }
 		void MovementCancelled(Actor self);
 		void RequestTransport(CPos destination, Activity afterLandActivity);
+	}
+
+	public interface IDeathActorInitModifier
+	{
+		void ModifyDeathActorInit(Actor self, TypeDictionary init);
 	}
 }

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -111,7 +111,6 @@
     <Compile Include="Traits\SupportPowers\ChronoshiftPower.cs" />
     <Compile Include="Traits\SupportPowers\GpsPower.cs" />
     <Compile Include="Traits\SupportPowers\ParatroopersPower.cs" />
-    <Compile Include="Traits\SpawnActorOnDeath.cs" />
     <Compile Include="Scripting\Properties\ChronosphereProperties.cs" />
     <Compile Include="Scripting\Properties\ParadropProperties.cs" />
     <Compile Include="Scripting\Properties\ParatroopersProperties.cs" />

--- a/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
@@ -11,6 +11,7 @@
 using System.Drawing;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Activities;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
@@ -24,7 +25,7 @@ namespace OpenRA.Mods.RA.Traits
 		public object Create(ActorInitializer init) { return new Chronoshiftable(init, this); }
 	}
 
-	public class Chronoshiftable : ITick, ISync, ISelectionBar
+	public class Chronoshiftable : ITick, ISync, ISelectionBar, IDeathActorInitModifier
 	{
 		readonly ChronoshiftableInfo info;
 		readonly Actor self;
@@ -46,6 +47,9 @@ namespace OpenRA.Mods.RA.Traits
 
 			if (init.Contains<ChronoshiftOriginInit>())
 				Origin = init.Get<ChronoshiftOriginInit, CPos>();
+
+			if (init.Contains<ChronoshiftChronosphereInit>())
+				chronosphere = init.Get<ChronoshiftChronosphereInit, Actor>();
 		}
 
 		public void Tick(Actor self)
@@ -107,6 +111,16 @@ namespace OpenRA.Mods.RA.Traits
 		}
 
 		public Color GetColor() { return Color.White; }
+
+		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
+		{
+			if (ReturnTicks <= 0)
+				return;
+			init.Add(new ChronoshiftOriginInit(Origin));
+			init.Add(new ChronoshiftReturnInit(ReturnTicks));
+			if (chronosphere != self)
+				init.Add(new ChronoshiftChronosphereInit(chronosphere));
+		}
 	}
 
 	public class ChronoshiftReturnInit : IActorInit<int>
@@ -122,5 +136,12 @@ namespace OpenRA.Mods.RA.Traits
 		[FieldFromYamlKey] readonly CPos value;
 		public ChronoshiftOriginInit(CPos init) { value = init; }
 		public CPos Value(World world) { return value; }
+	}
+
+	public class ChronoshiftChronosphereInit : IActorInit<Actor>
+	{
+		readonly Actor value;
+		public ChronoshiftChronosphereInit(Actor init) { value = init; }
+		public Actor Value(World world) { return value; }
 	}
 }


### PR DESCRIPTION
Move `SpawnActorOnDeath` to `OpenRA.Mods.Common` & fix spawned death actor teleportation.
Requires #9414 since loading turret facing(s) would require an ugly hack that would need to be replaced anyways.

Closes #9349.
