### PR TITLE
Create disable movement trait

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -485,7 +485,8 @@
     <Compile Include="Traits\Turreted.cs" />
     <Compile Include="Traits\ProducibleWithLevel.cs" />
     <Compile Include="Traits\Upgrades\DeployToUpgrade.cs" />
-    <Compile Include="Traits\Upgrades\DisableUpgrade.cs" />
+    <Compile Include="Traits\Upgrades\DisableOnUpgrade.cs" />
+    <Compile Include="Traits\Upgrades\DisableMovementOnUpgrade.cs" />
     <Compile Include="Traits\Upgrades\UpgradableTrait.cs" />
     <Compile Include="Traits\Upgrades\UpgradeActorsNear.cs" />
     <Compile Include="Traits\Upgrades\UpgradeManager.cs" />

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -692,12 +692,14 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly MobileInfo unitType;
 			readonly bool rejectMove;
+			readonly IDisableMove[] moveDisablers;
 			public bool OverrideSelection { get { return false; } }
 
 			public MoveOrderTargeter(Actor self, MobileInfo unitType)
 			{
 				this.unitType = unitType;
 				rejectMove = !self.AcceptsOrder("Move");
+				moveDisablers = self.TraitsImplementing<IDisableMove>().ToArray();
 			}
 
 			public string OrderID { get { return "Move"; } }
@@ -716,7 +718,9 @@ namespace OpenRA.Mods.Common.Traits
 				cursor = self.World.Map.Contains(location) ?
 					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? unitType.Cursor) : unitType.BlockedCursor;
 
-				if ((!explored && !unitType.MoveIntoShroud) || (explored && unitType.MovementCostForCell(self.World, location) == int.MaxValue))
+				if ((!explored && !unitType.MoveIntoShroud)
+					|| (explored && unitType.MovementCostForCell(self.World, location) == int.MaxValue)
+					|| moveDisablers.Any(d => d.MoveDisabled(self)))
 					cursor = unitType.BlockedCursor;
 
 				return true;

--- a/OpenRA.Mods.Common/Traits/Upgrades/DisableMovementOnUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DisableMovementOnUpgrade.cs
@@ -12,18 +12,17 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Disable the actor when this trait is enabled by an upgrade.")]
-	public class DisableUpgradeInfo : UpgradableTraitInfo
+	[Desc("Disable the ability to move and turn of the actor when this trait is enabled by an upgrade.")]
+	public class DisableMovementInfo : UpgradableTraitInfo
 	{
-		public override object Create(ActorInitializer init) { return new DisableUpgrade(this); }
+		public override object Create(ActorInitializer init) { return new DisableMovementOnUpgrade(this); }
 	}
 
-	public class DisableUpgrade : UpgradableTrait<DisableUpgradeInfo>, IDisable, IDisableMove
+	public class DisableMovementOnUpgrade : UpgradableTrait<DisableMovementInfo>, IDisableMove
 	{
-		public DisableUpgrade(DisableUpgradeInfo info)
+		public DisableMovementOnUpgrade(DisableMovementInfo info)
 			: base(info) { }
 
-		public bool Disabled { get { return !IsTraitDisabled; } }
 		public bool MoveDisabled(Actor self) { return !IsTraitDisabled; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Upgrades/DisableOnUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DisableOnUpgrade.cs
@@ -1,0 +1,29 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Disable the actor when this trait is enabled by an upgrade.")]
+	public class DisableOnUpgradeInfo : UpgradableTraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new DisableOnUpgrade(this); }
+	}
+
+	public class DisableOnUpgrade : UpgradableTrait<DisableOnUpgradeInfo>, IDisable, IDisableMove
+	{
+		public DisableOnUpgrade(DisableOnUpgradeInfo info)
+			: base(info) { }
+
+		public bool Disabled { get { return !IsTraitDisabled; } }
+		public bool MoveDisabled(Actor self) { return !IsTraitDisabled; }
+	}
+}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2724,6 +2724,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					node.Value.Value = RenameD2kActors(node.Value.Value);
 				}
 
+				if (engineVersion < 20150925)
+				{
+					if (node.Key == "DisableUpgrade")
+						node.Key = "DisableOnUpgrade";
+				}
+
 				UpgradeActors(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -54,7 +54,7 @@
 		UpgradeTypes: empdisable
 		UpgradeMinEnabledLevel: 1
 		Palette: disabled
-	DisableUpgrade@EMPDISABLE:
+	DisableOnUpgrade@EMPDISABLE:
 		UpgradeTypes: empdisable
 		UpgradeMinEnabledLevel: 1
 	TimedUpgradeBar@EMPDISABLE:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -140,7 +140,7 @@ LPST:
 		StartSequence: make
 		UpgradeTypes: deployed
 		UpgradeMinEnabledLevel: 1
-	DisableUpgrade:
+	DisableOnUpgrade:
 		UpgradeTypes: deployed
 		UpgradeMinEnabledLevel: 1
 	DetectCloaked:


### PR DESCRIPTION
This trait is a clone of the `DisableUpgrade` trait, the only difference is that it only disables movement. It's needed for units that transform into static variants using deploy to upgrade, as those depend on the "disableupgrade" trait to keep them from moving, that obviously makes them unable to fire.
![deploytoupgrade](https://cloud.githubusercontent.com/assets/11763228/10106311/536d8274-638a-11e5-90d0-3f5fc7ffcc26.gif)
This image is just a test, where I changed the EMP upgrade for this new one.
![titan](https://cloud.githubusercontent.com/assets/11763228/10106314/559a47ee-638a-11e5-88f6-61748bd452ad.gif)
