### PR TITLE
Fixed AI bots trying to assign orders to units not in the world

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.AI
 		readonly IPathFinder pathfinder;
 
 		readonly Func<Actor, bool> isEnemyUnit;
-		readonly Predicate<Actor> unitIsDeadOrHasNewOwner;
+		readonly Predicate<Actor> unitCannotBeOrdered;
 		Dictionary<SupportPowerInstance, int> waitingPowers = new Dictionary<SupportPowerInstance, int>();
 		Dictionary<string, SupportPowerDecision> powerDecisions = new Dictionary<string, SupportPowerDecision>();
 
@@ -236,7 +236,8 @@ namespace OpenRA.Mods.Common.AI
 				Player.Stances[unit.Owner] == Stance.Enemy
 					&& !unit.Info.HasTraitInfo<HuskInfo>()
 					&& unit.Info.HasTraitInfo<ITargetableInfo>();
-			unitIsDeadOrHasNewOwner = a => a.Owner != Player || a.IsDead;
+
+			unitCannotBeOrdered = a => a.Owner != Player || a.IsDead || !a.IsInWorld;
 
 			foreach (var decision in info.PowerDecisions)
 				powerDecisions.Add(decision.OrderName, decision);
@@ -606,7 +607,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			squads.RemoveAll(s => !s.IsValid);
 			foreach (var s in squads)
-				s.Units.RemoveAll(unitIsDeadOrHasNewOwner);
+				s.Units.RemoveAll(unitCannotBeOrdered);
 		}
 
 		// Use of this function requires that one squad of this type. Hence it is a piece of shit
@@ -625,8 +626,9 @@ namespace OpenRA.Mods.Common.AI
 		void AssignRolesToIdleUnits(Actor self)
 		{
 			CleanSquads();
-			activeUnits.RemoveAll(unitIsDeadOrHasNewOwner);
-			unitsHangingAroundTheBase.RemoveAll(unitIsDeadOrHasNewOwner);
+
+			activeUnits.RemoveAll(unitCannotBeOrdered);
+			unitsHangingAroundTheBase.RemoveAll(unitCannotBeOrdered);
 
 			if (--rushTicks <= 0)
 			{


### PR DESCRIPTION
The AI was ordering units around which are not in the world. This is futile and probably responsible for some performance regressions whenever units are airlifted in. Fixes https://github.com/OpenRA/OpenRA/issues/9385.
