### PR TITLE
Provide an early exit in RunActivity when there is no activity

### DIFF
--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -74,6 +74,9 @@ namespace OpenRA.Traits
 
 		public static Activity RunActivity(Actor self, Activity act)
 		{
+			if (act == null)
+				return act;
+
 			// Note - manual iteration here for performance due to high call volume.
 			var longTickThresholdInStopwatchTicks = PerfTimer.LongTickThresholdInStopwatchTicks;
 			var start = Stopwatch.GetTimestamp();


### PR DESCRIPTION
Provides a tiny speedup for actors that are idle, as we can avoid calling `Stopwatch.GetTimestamp()`.
