### PR TITLE
Add support for inter-mod dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,8 @@ all-dependencies: cli-dependencies windows-dependencies osx-dependencies
 version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/ts/mod.yaml mods/modchooser/mod.yaml mods/all/mod.yaml
 	@for i in $? ; do \
 		awk '{sub("Version:.*$$","Version: $(VERSION)"); print $0}' $${i} > $${i}.tmp && \
-		mv -f $${i}.tmp $${i} ; \
+		awk '{sub("\tmodchooser:.*$$","\tmodchooser: $(VERSION)"); print $0}' $${i}.tmp > $${i} && \
+		rm $${i}.tmp ; \
 	done
 
 docs: utility mods version

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -253,6 +253,13 @@ namespace OpenRA
 				RunAfterDelay(Settings.Server.NatDiscoveryTimeout, UPnP.StoppingNatDiscovery);
 		}
 
+		public static bool IsModInstalled(string modId)
+		{
+			return Manifest.AllMods[modId].RequiresMods.All(mod => ModMetadata.AllMods.ContainsKey(mod.Key)
+				&& ModMetadata.AllMods[mod.Key].Version == mod.Value
+				&& IsModInstalled(mod.Key));
+		}
+
 		public static void InitializeMod(string mod, Arguments args)
 		{
 			// Clear static state if we have switched mods
@@ -276,8 +283,8 @@ namespace OpenRA
 				ModData.Dispose();
 			ModData = null;
 
-			// Fall back to default if the mod doesn't exist
-			if (!ModMetadata.AllMods.ContainsKey(mod))
+			// Fall back to default if the mod doesn't exist or has missing prerequisites.
+			if (!ModMetadata.AllMods.ContainsKey(mod) || !IsModInstalled(mod))
 				mod = new GameSettings().Mod;
 
 			Console.WriteLine("Loading mod: {0}", mod);

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -596,6 +596,7 @@
     <Compile Include="Widgets\Logic\Ingame\WorldTooltipLogic.cs" />
     <Compile Include="Widgets\Logic\Installation\InstallFromCDLogic.cs" />
     <Compile Include="Widgets\Logic\Installation\DownloadPackagesLogic.cs" />
+    <Compile Include="Widgets\Logic\Installation\InstallModLogic.cs" />
     <Compile Include="Widgets\Logic\Installation\InstallLogic.cs" />
     <Compile Include="Widgets\Logic\Installation\InstallMusicLogic.cs" />
     <Compile Include="Widgets\Logic\Lobby\ClientTooltipLogic.cs" />

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallModLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallModLogic.cs
@@ -1,0 +1,30 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class InstallModLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public InstallModLogic(Widget widget, string modId)
+		{
+			var panel = widget.Get("INSTALL_MOD_PANEL");
+
+			var mods = Manifest.AllMods[modId].RequiresMods.Select(x => "{0} ({1})".F(x.Key, x.Value));
+			var text = string.Join(", ", mods);
+			panel.Get<LabelWidget>("MOD_LIST").Text = text;
+
+			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = Ui.CloseWindow;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Dictionary<string, Sprite> previews = new Dictionary<string, Sprite>();
 		readonly Dictionary<string, Sprite> logos = new Dictionary<string, Sprite>();
 		readonly Cache<ModMetadata, bool> modInstallStatus;
+		readonly Cache<string, bool> modPrerequisitesFulfilled;
 		readonly Widget modChooserPanel;
 		readonly ButtonWidget loadButton;
 		readonly SheetBuilder sheetBuilder;
@@ -38,6 +39,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public ModBrowserLogic(Widget widget)
 		{
+			modInstallStatus = new Cache<ModMetadata, bool>(IsModInstalled);
+			modPrerequisitesFulfilled = new Cache<string, bool>(Game.IsModInstalled);
+
 			modChooserPanel = widget;
 			loadButton = modChooserPanel.Get<ButtonWidget>("LOAD_BUTTON");
 			loadButton.OnClick = () => LoadMod(selectedMod);
@@ -92,8 +96,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 				catch (Exception) { }
 			}
-
-			modInstallStatus = new Cache<ModMetadata, bool>(IsModInstalled);
 
 			ModMetadata initialMod;
 			ModMetadata.AllMods.TryGetValue(Game.Settings.Game.PreviousMod, out initialMod);
@@ -157,6 +159,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				modOffset = selectedIndex - 4;
 
 			loadButton.Text = modInstallStatus[mod] ? "Load Mod" : "Install Assets";
+
+			loadButton.Text = modPrerequisitesFulfilled[mod.Id] ? loadButton.Text : "Prerequisites missing!";
 		}
 
 		void LoadMod(ModMetadata mod)

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -158,13 +158,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (selectedIndex - modOffset > 4)
 				modOffset = selectedIndex - 4;
 
-			loadButton.Text = modInstallStatus[mod] ? "Load Mod" : "Install Assets";
-
-			loadButton.Text = modPrerequisitesFulfilled[mod.Id] ? loadButton.Text : "Prerequisites missing!";
+			loadButton.Text = !modPrerequisitesFulfilled[mod.Id] ? "Install mod" :
+				modInstallStatus[mod] ? "Load Mod" : "Install Assets";
 		}
 
 		void LoadMod(ModMetadata mod)
 		{
+			if (!modPrerequisitesFulfilled[mod.Id])
+			{
+				var widgetArgs = new WidgetArgs
+				{
+					{ "modId", mod.Id }
+				};
+
+				Ui.OpenWindow("INSTALL_MOD_PANEL", widgetArgs);
+				return;
+			}
+
 			if (!modInstallStatus[mod])
 			{
 				var widgetArgs = new WidgetArgs

--- a/make.ps1
+++ b/make.ps1
@@ -113,6 +113,8 @@ elseif ($command -eq "version")
 		{
 			$replacement = (gc $mod) -Replace "Version:.*", ("Version: {0}" -f $version)
 			sc $mod $replacement
+			$replacement = (gc $mod) -Replace "modchooser:.*", ("modchooser: {0}" -f $version)
+			sc $mod $replacement
 		}
 		echo ("Version strings set to '{0}'." -f $version)
 	}

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -4,6 +4,9 @@ Metadata:
 	Version: {DEV_VERSION}
 	Author: the OpenRA Developers
 
+RequiresMods:
+	modchooser: {DEV_VERSION}
+
 Folders:
 	.
 	./mods/cnc

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -4,6 +4,9 @@ Metadata:
 	Version: {DEV_VERSION}
 	Author: the OpenRA Developers
 
+RequiresMods:
+	modchooser: {DEV_VERSION}
+
 Folders:
 	.
 	./mods/d2k

--- a/mods/modchooser/install.yaml
+++ b/mods/modchooser/install.yaml
@@ -260,3 +260,50 @@ Container@INSTALL_MUSIC_PANEL:
 			Text: Back
 			Font: Bold
 			Key: escape
+Container@INSTALL_MOD_PANEL:
+	Logic: InstallModLogic
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - HEIGHT)/2
+	Width: 500
+	Height: 177
+	Children:
+		Background:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-bg
+		Background@RULE:
+			X: 30
+			Y: 50
+			Width: 440
+			Height: 150
+			Background: panel-rule
+		Label@TITLE:
+			X: 0
+			Y: 12
+			Width: PARENT_RIGHT
+			Height: 25
+			Text: Missing dependencies
+			Align: Center
+			Font: MediumBold
+		Label@DESC:
+			X: 0
+			Y: 65
+			Width: PARENT_RIGHT
+			Height: 25
+			Align: Center
+			Text: Please fully install the following mods then try again:
+		Label@MOD_LIST:
+			X: 0
+			Y: 85
+			Width: PARENT_RIGHT
+			Height: 25
+			Align: Center
+		Button@BACK_BUTTON:
+			X: PARENT_RIGHT - 130
+			Y: PARENT_BOTTOM - 52
+			Background: button-highlighted
+			Width: 110
+			Height: 32
+			Text: Back
+			Font: Bold
+			Key: escape

--- a/mods/modchooser/mod.yaml
+++ b/mods/modchooser/mod.yaml
@@ -4,6 +4,8 @@ Metadata:
 	Author: The OpenRA Developers
 	Hidden: true
 
+RequiresMods:
+
 Folders:
 	.
 	./mods/modchooser

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -4,6 +4,9 @@ Metadata:
 	Version: {DEV_VERSION}
 	Author: the OpenRA Developers
 
+RequiresMods:
+	modchooser: {DEV_VERSION}
+
 Folders:
 	.
 	./mods/ra

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -4,6 +4,9 @@ Metadata:
 	Version: {DEV_VERSION}
 	Author: the OpenRA Developers
 
+RequiresMods:
+	modchooser: {DEV_VERSION}
+
 Folders:
 	.
 # Tiberian Sun


### PR DESCRIPTION
Adds support for mods requiring specific versions of other mods in order to run.
The "engine version" will be represented by `modchooser`'s mod version, which will allow mods to target a specific engine version.
Closes  #8991.

The UI can be bikeshed at length, but I decided to open this now as the prerequisite was merged earlier today so the approach and underlying code can be discussed (to hopefully save some time).

Note: One thing left to be done is have the packaging scripts update the mods' required versions from `{DEV_VERSION}` to the release/playtest version. Help with that would be nice.
