### PR TITLE
Fix aircraft husk crash velocity

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -612,6 +612,7 @@
 	FallsToEarth:
 		Spins: False
 		Moves: True
+		Velocity: 86
 
 ^HelicopterHusk:
 	Inherits: ^BasicHusk


### PR DESCRIPTION
This fixes the long glide time aircraft husks had when they were shot down. They are falling down to earth much faster now and the distance covered matches that from release-20150614.

This has been a common complaint with the current release (e.g. [1](http://logs.openra.net/?year=2015&month=09&day=22#20:57:46), [2](http://logs.openra.net/?year=2015&month=09&day=25#00:00:32))
