### PR TITLE
TD mission yaml fixes

### DIFF
--- a/mods/cnc/maps/funpark01/map.yaml
+++ b/mods/cnc/maps/funpark01/map.yaml
@@ -518,6 +518,8 @@ Sequences:
 			Start: 0
 			Facings: 1
 			ZOffset: -1024
+		icon: lsticnh.tem
+			AddExtension: False
 
 VoxelSequences:
 

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -42,7 +42,7 @@ Players:
 		Faction: nod
 		ColorRamp: 3,255,127
 		Allies: Nod
-		Enemies: GDI, Creeps
+		Enemies: GDI
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True
@@ -55,17 +55,12 @@ Players:
 		LockSpawn: True
 		LockTeam: True
 		Allies: GDI
-		Enemies: Nod, Creeps
+		Enemies: Nod
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
 		NonCombatant: True
 		Faction: gdi
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: sbag
@@ -547,6 +542,8 @@ Sequences:
 			Start: 0
 			Facings: 1
 			ZOffset: -1024
+		icon: lsticnh.tem
+			AddExtension: False
 
 VoxelSequences:
 

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -59,11 +59,6 @@ Players:
 		OwnsWorld: True
 		NonCombatant: True
 		Faction: gdi
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: sbag
@@ -781,6 +776,8 @@ Sequences:
 			Start: 0
 			Facings: 1
 			ZOffset: -1024
+		icon: lsticnh.tem
+			AddExtension: False
 
 VoxelSequences:
 

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -60,11 +60,6 @@ Players:
 		LockTeam: True
 		Allies: GDI
 		Enemies: Nod
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: wood

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -61,11 +61,6 @@ Players:
 		OwnsWorld: True
 		NonCombatant: True
 		Faction: gdi
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: cycl

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -61,11 +61,6 @@ Players:
 		OwnsWorld: True
 		NonCombatant: True
 		Faction: gdi
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: sbag

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -66,11 +66,6 @@ Players:
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: v17

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -67,11 +67,6 @@ Players:
 		OwnsWorld: True
 		NonCombatant: True
 		Faction: gdi
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: sbag

--- a/mods/cnc/maps/nod01/map.yaml
+++ b/mods/cnc/maps/nod01/map.yaml
@@ -62,11 +62,6 @@ Players:
 		LockSpawn: True
 		LockTeam: True
 		Enemies: GDI, Villagers
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor46: e1

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -60,11 +60,6 @@ Players:
 		LockTeam: True
 		Allies: Nod
 		Enemies: GDI
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor0: sbag

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -60,11 +60,6 @@ Players:
 		LockTeam: True
 		Allies: Nod
 		Enemies: GDI
-	PlayerReference@Creeps:
-		Name: Creeps
-		NonCombatant: True
-		Faction: Random
-		Enemies: Nod, GDI
 
 Actors:
 	Actor117: e1


### PR DESCRIPTION
- fixes #9466 (thanks @obrakmann!)
- removes Creeps faction from TD singleplayer missions (as pointed out by @obrakmann in  #9118)
