### PR TITLE
Fix incorrect "In progress" time shown in server browser

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
@@ -363,15 +363,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (game.State == (int)ServerState.GameStarted)
 			{
-				var label = "";
-				try
+				var label = "In progress";
+
+				DateTime startTime;
+				if (DateTime.TryParse(game.Started, out startTime))
 				{
-					var runTime = DateTime.Now - System.DateTime.Parse(game.Started);
-					label = "In progress for {0} minute{1}".F(runTime.Minutes, runTime.Minutes > 1 ? "s" : "");
-				}
-				catch (Exception)
-				{
-					label = "In progress";
+					var totalMinutes = Math.Ceiling((DateTime.UtcNow - startTime).TotalMinutes);
+					label += " for {0} minute{1}".F(totalMinutes, totalMinutes > 1 ? "s" : "");
 				}
 
 				return game.Protected ? label + " (Password protected)" : label;


### PR DESCRIPTION
This fixes a couple problems. The in progress time should be using `TotalMinutes`, and we should be treating the local machine's current time as UTC to match the master server.
