### PR TITLE
Remove bogus height check from Bullet explosion check

### DIFF
--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -167,10 +167,8 @@ namespace OpenRA.Mods.Common.Effects
 				contrail.Update(pos);
 
 			var cell = world.Map.CellContaining(pos);
-			var height = world.Map.DistanceAboveTerrain(pos);
 
-			var shouldExplode = height.Length <= 0 // Hit the ground
-				|| ticks++ >= length // Flight length reached/exceeded
+			var shouldExplode = ticks++ >= length // Flight length reached/exceeded
 				|| (info.Blockable && world.ActorMap.GetUnitsAt(cell).Any(a => a.Info.HasTraitInfo<IBlocksProjectilesInfo>())); // Hit a wall or other blocking obstacle
 
 			if (shouldExplode)


### PR DESCRIPTION
Bullets have a fixed length anyway (unless they are blocked), so this copy-paste from the missile's check doesn't work as intended here.

Closes #9495.
