### PR TITLE
Add DeployStateInit for Pre-deployment and Clean Up after #9124

### DIFF
--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -1,29 +1,3 @@
-GADPSA:
-	Inherits: ^DeployedVehicle
-	Valued:
-		Cost: 950
-	Tooltip:
-		Name: Deployed Sensor Array
-	Health:
-		HP: 600
-	Armor:
-		Type: Wood
-	RevealsShroud:
-		Range: 8c0
-	Transforms:
-		IntoActor: lpst
-		Facing: 159
-		TransformSounds: place2.aud
-		NoTransformSounds:
-		Voice: Move
-	-AutoTarget:
-	-DrawLineToTarget:
-	-AttackTurreted:
-	-RenderRangeCircle:
-	RenderDetectionCircle:
-	DetectCloaked:
-		Range: 6c0
-
 NAPULS:
 	Inherits: ^Defense
 	Valued:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -138,7 +138,6 @@ LPST:
 		UpgradeTypes: undeployed
 		UpgradeMinEnabledLevel: 1
 	WithSpriteBody@deployed:
-		StartSequence: make
 		UpgradeTypes: undeployed
 		UpgradeMaxEnabledLevel: 0
 	DisableOnUpgrade:

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -573,19 +573,6 @@ gaicbm:
 		Length: 30
 		ShadowStart: 30
 
-gadpsa:
-	Defaults:
-		Offset: 0, -12
-		UseTilesetCode: true
-	idle:
-		ShadowStart: 3
-	damaged-idle:
-		Start: 1
-		ShadowStart: 4
-	make: gadpsamk
-		Length: 36
-		ShadowStart: 36
-
 gaarty:
 	Defaults:
 		Offset: 0, -12


### PR DESCRIPTION
Allows map makers to put deployed actors by adding `DeployState: Deployed` in `map.yaml` for the actor.
Includes a clean up after #9124 (closes #9497), because there is an unnecessary `StartSequence` for `WithSpriteBody@deployed` under `LPST`.
