### PR TITLE
Makes hide-map and reveal-map crates affect allied players.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
@@ -14,7 +14,7 @@ namespace OpenRA.Mods.Common.Traits
 	class HideMapCrateActionInfo : CrateActionInfo
 	{
 		[Desc("Should the map also be hidden for the allies of the collector's owner?")]
-		public readonly bool IncludeAllies = false;
+		public readonly bool IncludeAllies = true;
 
 		public override object Create(ActorInitializer init) { return new HideMapCrateAction(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
@@ -14,7 +14,7 @@ namespace OpenRA.Mods.Common.Traits
 	class RevealMapCrateActionInfo : CrateActionInfo
 	{
 		[Desc("Should the map also be revealed for the allies of the collector's owner?")]
-		public readonly bool IncludeAllies = false;
+		public readonly bool IncludeAllies = true;
 
 		public override object Create(ActorInitializer init) { return new RevealMapCrateAction(init.Self, this); }
 	}


### PR DESCRIPTION
This way, allied players will have the same shroud visibility.
