### PR TITLE
TD Additional Balance Changes Revamped

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -209,7 +209,7 @@
 		DeathType: TiberiumDeath
 		RequiresLobbyCreeps: true
 	Crushable:
-		WarnProbability: 67
+		WarnProbability: 75
 		CrushSound: squish2.aud
 	Guardable:
 	SelfHealing@HOSPITAL:
@@ -223,7 +223,7 @@
 		Upgrades: hospitalheal
 		Prerequisites: hosp
 	DetectCloaked:
-		Range: 1c0
+		Range: 2c0
 	DeathSounds@NORMAL:
 		DeathTypes: DefaultDeath, BulletDeath, SmallExplosionDeath, ExplosionDeath
 	DeathSounds@BURNED:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -475,7 +475,7 @@ HQ:
 	AirstrikePower:
 		Prerequisites: ~techlevel.superweapons
 		Icon: airstrike
-		ChargeTime: 180
+		ChargeTime: 210
 		SquadSize: 3
 		QuantizedFacings: 8
 		Description: Air Strike
@@ -520,6 +520,7 @@ FIX:
 		HasMinibib: Yes
 	Reservable:
 	RepairsUnits:
+		Interval: 15
 	RallyPoint:
 	WithRepairAnimation:
 	Power:
@@ -669,9 +670,9 @@ GUN:
 SAM:
 	Inherits: ^Defense
 	Valued:
-		Cost: 750
+		Cost: 700
 	CustomBuildTimeValue:
-		Value: 2160
+		Value: 2000
 	Tooltip:
 		Name: SAM Site
 		Description: Anti-Aircraft base defense.\n  Strong vs Aircraft\n  Cannot target Ground units.

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -420,7 +420,7 @@ HTNK:
 MSAM:
 	Inherits: ^Tank
 	Valued:
-		Cost: 1200
+		Cost: 1000
 	Tooltip:
 		Name: Rocket Launcher
 		Description: Long range rocket artillery.\n  Strong vs all Ground units.

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -42,7 +42,7 @@
 		TerrainType: BlueTiberium
 		Variants: bti1,bti2,bti3,bti4,bti5,bti6,bti7,bti8,bti9,bti10,bti11,bti12
 		MaxDensity: 12
-		ValuePerUnit: 75
+		ValuePerUnit: 60
 		Name: BlueTiberium
 		PipColor: Blue
 		AllowedTerrainTypes: Clear,Road


### PR DESCRIPTION
Forums link: http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&p=292265#292265

Infantry stealth detection: Increase sight range of stealth detection to
2 from 1.

MLRS: Reduce price to 1000 from 1200

Repair pad: Power remains at 30. Repair speed increased. (Interval 15
from 0)

Blue Tiberium: Reduce the value income to 75-90% from 110% (60 from 75)

Infantry evade chance: 75 from 67

Samsites: cost reduced to 700 from 750. Reduced build time (2000 from
2160)

Airstrikes: Increase cool down timer to 3:30 from 3:00.

---

From the old messy pull request which is closed/deleted. Updated with cleaner slate and less mistakes. Updated additions. Finalized.

https://github.com/OpenRA/OpenRA/pull/9454
