### PR TITLE
Tiberian Sun style right-click-and-drag scrolling implementation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ Also thanks to:
     * Jeff Harris (jeff_1amstudios)
     * Jes
     * Joakim Lindberg (booom3)
+    * Joppy Furr
     * Kanar
     * Kenny Hoxworth (hoxworth)
     * Krishnakanth Mallik

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA
 {
-	public enum MouseScrollType { Disabled, Standard, Inverted }
+	public enum MouseScrollType { Disabled, Standard, Inverted, Joystick }
 
 	public class ServerSettings
 	{
@@ -167,6 +167,7 @@ namespace OpenRA
 		public float ViewportEdgeScrollStep = 10f;
 		public float UIScrollSpeed = 50f;
 		public int SelectionDeadzone = 24;
+		public int JoystickScrollDeadzone = 8;
 
 		public bool UseClassicMouseStyle = false;
 		public bool AlwaysShowStatusBars = false;

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Widgets
 				YieldMouseFocus(mi);
 			}
 
-			if (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Down)
+			if (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Up)
 			{
 				// Don't do anything while selecting
 				if (!hasBox)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -588,6 +588,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "Disabled", MouseScrollType.Disabled },
 				{ "Standard", MouseScrollType.Standard },
 				{ "Inverted", MouseScrollType.Inverted },
+				{ "Joystick", MouseScrollType.Joystick },
 			};
 
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -333,7 +333,7 @@ Container@SETTINGS_PANEL:
 							Width: 160
 							Height: 20
 							Font: Regular
-							Text: Middle-Mouse Scrolling:
+							Text: Mouse Scrolling Method:
 							Align: Right
 						DropDownButton@MOUSE_SCROLL:
 							X: PARENT_RIGHT - WIDTH - 15

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -337,7 +337,7 @@ Background@SETTINGS_PANEL:
 					Width: 160
 					Height: 20
 					Font: Regular
-					Text: Middle-Mouse Scrolling:
+					Text: Mouse Scrolling Method:
 					Align: Right
 				DropDownButton@MOUSE_SCROLL:
 					X: PARENT_RIGHT - WIDTH - 15


### PR DESCRIPTION
Rarr :3

```
This patch introduces support for the right-click-and-drag scrolling that
is available in Tiberian Sun and Red Alert 2. It can be enabled by
selecting "TS" scrolling in the Input settings.

A side-effect of this is that events previously tied to right clicks on
the world are now based on the release of the click rather than the press.

"Middle-Mouse Scrolling:" in the menu is also changed to "Scrolling Method:"
```
