### PR TITLE
Rename TileShape to fit its role better

### DIFF
--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -47,9 +47,9 @@ namespace OpenRA
 			return ToMPos(map.Grid.Type);
 		}
 
-		public MPos ToMPos(TileShape shape)
+		public MPos ToMPos(MapGridType gridType)
 		{
-			if (shape == TileShape.Rectangle)
+			if (gridType == MapGridType.Rectangle)
 				return new MPos(X, Y);
 
 			// Convert from diamond cell (x, y) position to rectangular map position (u, v)

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -49,7 +49,7 @@ namespace OpenRA
 
 		public MPos ToMPos(MapGridType gridType)
 		{
-			if (gridType == MapGridType.Rectangle)
+			if (gridType == MapGridType.Rectangular)
 				return new MPos(X, Y);
 
 			// Convert from diamond cell (x, y) position to rectangular map position (u, v)

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -52,7 +52,7 @@ namespace OpenRA
 			if (gridType == MapGridType.Rectangular)
 				return new MPos(X, Y);
 
-			// Convert from diamond cell (x, y) position to rectangular map position (u, v)
+			// Convert from RectangularIsometric cell (x, y) position to rectangular map position (u, v)
 			//  - The staggered rows make this fiddly (hint: draw a diagram!)
 			// (a) Consider the relationships:
 			//  - +1x (even -> odd) adds (0, 1) to (u, v)

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Graphics
 	{
 		public static Bitmap TerrainBitmap(TileSet tileset, Map map, bool actualSize = false)
 		{
-			var isDiamond = map.Grid.Type == MapGridType.Diamond;
+			var isRectangularIsometric = map.Grid.Type == MapGridType.RectangularIsometric;
 			var b = map.Bounds;
 
 			// Fudge the heightmap offset by adding as much extra as we need / can.
@@ -30,7 +30,7 @@ namespace OpenRA.Graphics
 			var height = b.Height + heightOffset;
 
 			var bitmapWidth = width;
-			if (isDiamond)
+			if (isRectangularIsometric)
 				bitmapWidth = 2 * bitmapWidth - 1;
 
 			if (!actualSize)
@@ -55,7 +55,7 @@ namespace OpenRA.Graphics
 						var type = tileset.GetTileInfo(mapTiles[uv]);
 						var leftColor = type != null ? type.LeftColor : Color.Black;
 
-						if (isDiamond)
+						if (isRectangularIsometric)
 						{
 							// Odd rows are shifted right by 1px
 							var dx = uv.V & 1;
@@ -81,7 +81,7 @@ namespace OpenRA.Graphics
 		static Bitmap AddStaticResources(TileSet tileset, Map map, Ruleset resourceRules, Bitmap terrainBitmap)
 		{
 			var terrain = new Bitmap(terrainBitmap);
-			var isDiamond = map.Grid.Type == MapGridType.Diamond;
+			var isRectangularIsometric = map.Grid.Type == MapGridType.RectangularIsometric;
 			var b = map.Bounds;
 
 			// Fudge the heightmap offset by adding as much extra as we need / can
@@ -113,7 +113,7 @@ namespace OpenRA.Graphics
 							continue;
 
 						var color = tileset[tileset.GetTerrainIndex(res)].Color.ToArgb();
-						if (isDiamond)
+						if (isRectangularIsometric)
 						{
 							// Odd rows are shifted right by 1px
 							var dx = uv.V & 1;

--- a/OpenRA.Game/Graphics/Minimap.cs
+++ b/OpenRA.Game/Graphics/Minimap.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Graphics
 	{
 		public static Bitmap TerrainBitmap(TileSet tileset, Map map, bool actualSize = false)
 		{
-			var isDiamond = map.Grid.Type == TileShape.Diamond;
+			var isDiamond = map.Grid.Type == MapGridType.Diamond;
 			var b = map.Bounds;
 
 			// Fudge the heightmap offset by adding as much extra as we need / can.
@@ -81,7 +81,7 @@ namespace OpenRA.Graphics
 		static Bitmap AddStaticResources(TileSet tileset, Map map, Ruleset resourceRules, Bitmap terrainBitmap)
 		{
 			var terrain = new Bitmap(terrainBitmap);
-			var isDiamond = map.Grid.Type == TileShape.Diamond;
+			var isDiamond = map.Grid.Type == MapGridType.Diamond;
 			var b = map.Bounds;
 
 			// Fudge the heightmap offset by adding as much extra as we need / can

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Graphics
 			return template.Sprites[start * template.Stride + r.Index];
 		}
 
-		public Rectangle TemplateBounds(TerrainTemplateInfo template, Size tileSize, TileShape tileShape)
+		public Rectangle TemplateBounds(TerrainTemplateInfo template, Size tileSize, MapGridType mapGrid)
 		{
 			Rectangle? templateRect = null;
 
@@ -125,8 +125,8 @@ namespace OpenRA.Graphics
 						continue;
 
 					var sprite = TileSprite(tile);
-					var u = tileShape == TileShape.Rectangle ? x : (x - y) / 2f;
-					var v = tileShape == TileShape.Rectangle ? y : (x + y) / 2f;
+					var u = mapGrid == MapGridType.Rectangle ? x : (x - y) / 2f;
+					var v = mapGrid == MapGridType.Rectangle ? y : (x + y) / 2f;
 
 					var tl = new float2(u * tileSize.Width, (v - 0.5f * tileInfo.Height) * tileSize.Height) - 0.5f * sprite.Size;
 					var rect = new Rectangle((int)(tl.X + sprite.Offset.X), (int)(tl.Y + sprite.Offset.Y), (int)sprite.Size.X, (int)sprite.Size.Y);

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -125,8 +125,8 @@ namespace OpenRA.Graphics
 						continue;
 
 					var sprite = TileSprite(tile);
-					var u = mapGrid == MapGridType.Rectangle ? x : (x - y) / 2f;
-					var v = mapGrid == MapGridType.Rectangle ? y : (x + y) / 2f;
+					var u = mapGrid == MapGridType.Rectangular ? x : (x - y) / 2f;
+					var v = mapGrid == MapGridType.Rectangular ? y : (x + y) / 2f;
 
 					var tl = new float2(u * tileSize.Width, (v - 0.5f * tileInfo.Height) * tileSize.Height) - 0.5f * sprite.Size;
 					var rect = new Rectangle((int)(tl.X + sprite.Offset.X), (int)(tl.Y + sprite.Offset.Y), (int)sprite.Size.X, (int)sprite.Size.Y);

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Graphics
 				// The full map is visible in the editor
 				var width = map.MapSize.X * grid.TileSize.Width;
 				var height = map.MapSize.Y * grid.TileSize.Height;
-				if (wr.World.Map.Grid.Type == TileShape.Diamond)
+				if (wr.World.Map.Grid.Type == MapGridType.Diamond)
 					height /= 2;
 
 				mapBounds = new Rectangle(0, 0, width, height);
@@ -243,7 +243,7 @@ namespace OpenRA.Graphics
 			// Diamond tile shapes don't have straight edges, and so we need
 			// an additional cell margin to include the cells that are half
 			// visible on each edge.
-			if (map.Grid.Type == TileShape.Diamond)
+			if (map.Grid.Type == MapGridType.Diamond)
 			{
 				tl = new PPos(tl.U - 1, tl.V - 1);
 				br = new PPos(br.U + 1, br.V + 1);

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -100,7 +99,7 @@ namespace OpenRA.Graphics
 				// The full map is visible in the editor
 				var width = map.MapSize.X * grid.TileSize.Width;
 				var height = map.MapSize.Y * grid.TileSize.Height;
-				if (wr.World.Map.Grid.Type == MapGridType.Diamond)
+				if (wr.World.Map.Grid.Type == MapGridType.RectangularIsometric)
 					height /= 2;
 
 				mapBounds = new Rectangle(0, 0, width, height);
@@ -240,10 +239,9 @@ namespace OpenRA.Graphics
 			var tl = (PPos)map.CellContaining(worldRenderer.ProjectedPosition(TopLeft)).ToMPos(map);
 			var br = (PPos)map.CellContaining(worldRenderer.ProjectedPosition(BottomRight)).ToMPos(map);
 
-			// Diamond tile shapes don't have straight edges, and so we need
-			// an additional cell margin to include the cells that are half
-			// visible on each edge.
-			if (map.Grid.Type == MapGridType.Diamond)
+			// RectangularIsometric maps don't have straight edges, and so we need an additional
+			// cell margin to include the cells that are half visible on each edge.
+			if (map.Grid.Type == MapGridType.RectangularIsometric)
 			{
 				tl = new PPos(tl.U - 1, tl.V - 1);
 				br = new PPos(br.U + 1, br.V + 1);

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -41,9 +41,9 @@ namespace OpenRA
 			return ToCPos(map.Grid.Type);
 		}
 
-		public CPos ToCPos(TileShape shape)
+		public CPos ToCPos(MapGridType gridType)
 		{
-			if (shape == TileShape.Rectangle)
+			if (gridType == MapGridType.Rectangle)
 				return new CPos(U, V);
 
 			// Convert from rectangular map position to diamond cell position

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -46,7 +46,7 @@ namespace OpenRA
 			if (gridType == MapGridType.Rectangular)
 				return new CPos(U, V);
 
-			// Convert from rectangular map position to diamond cell position
+			// Convert from rectangular map position to RectangularIsometric cell position
 			//  - The staggered rows make this fiddly (hint: draw a diagram!)
 			// (a) Consider the relationships:
 			//  - +1u (even -> odd) adds (1, -1) to (x, y)

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -43,7 +43,7 @@ namespace OpenRA
 
 		public CPos ToCPos(MapGridType gridType)
 		{
-			if (gridType == MapGridType.Rectangle)
+			if (gridType == MapGridType.Rectangular)
 				return new CPos(U, V);
 
 			// Convert from rectangular map position to diamond cell position

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -128,9 +128,9 @@ namespace OpenRA
 		public bool Contains(CPos cell)
 		{
 			// .ToMPos() returns the same result if the X and Y coordinates
-			// are switched. X < Y is invalid in the Diamond coordinate system,
+			// are switched. X < Y is invalid in the RectangularIsometric coordinate system,
 			// so we pre-filter these to avoid returning the wrong result
-			if (GridType == MapGridType.Diamond && cell.X < cell.Y)
+			if (GridType == MapGridType.RectangularIsometric && cell.X < cell.Y)
 				return false;
 
 			return Contains(cell.ToMPos(GridType));

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -22,33 +22,33 @@ namespace OpenRA
 		// Corners of the region
 		public readonly CPos TopLeft;
 		public readonly CPos BottomRight;
-		readonly TileShape shape;
+		readonly MapGridType gridType;
 
 		// Corners in map coordinates
-		// These will only equal TopLeft and BottomRight for TileShape.Rectangular
+		// These will only equal TopLeft and BottomRight for MapGridType.Rectangular
 		readonly MPos mapTopLeft;
 		readonly MPos mapBottomRight;
 
-		public CellRegion(TileShape shape, CPos topLeft, CPos bottomRight)
+		public CellRegion(MapGridType gridType, CPos topLeft, CPos bottomRight)
 		{
-			this.shape = shape;
+			this.gridType = gridType;
 			TopLeft = topLeft;
 			BottomRight = bottomRight;
 
-			mapTopLeft = TopLeft.ToMPos(shape);
-			mapBottomRight = BottomRight.ToMPos(shape);
+			mapTopLeft = TopLeft.ToMPos(gridType);
+			mapBottomRight = BottomRight.ToMPos(gridType);
 		}
 
 		/// <summary>Expand the specified region with an additional cordon. This may expand the region outside the map borders.</summary>
 		public static CellRegion Expand(CellRegion region, int cordon)
 		{
-			var tl = new MPos(region.mapTopLeft.U - cordon, region.mapTopLeft.V - cordon).ToCPos(region.shape);
-			var br = new MPos(region.mapBottomRight.U + cordon, region.mapBottomRight.V + cordon).ToCPos(region.shape);
-			return new CellRegion(region.shape, tl, br);
+			var tl = new MPos(region.mapTopLeft.U - cordon, region.mapTopLeft.V - cordon).ToCPos(region.gridType);
+			var br = new MPos(region.mapBottomRight.U + cordon, region.mapBottomRight.V + cordon).ToCPos(region.gridType);
+			return new CellRegion(region.gridType, tl, br);
 		}
 
 		/// <summary>Returns the minimal region that covers at least the specified cells.</summary>
-		public static CellRegion BoundingRegion(TileShape shape, IEnumerable<CPos> cells)
+		public static CellRegion BoundingRegion(MapGridType shape, IEnumerable<CPos> cells)
 		{
 			if (cells == null || !cells.Any())
 				throw new ArgumentException("cells must not be null or empty.", "cells");
@@ -81,7 +81,7 @@ namespace OpenRA
 
 		public bool Contains(CPos cell)
 		{
-			var uv = cell.ToMPos(shape);
+			var uv = cell.ToMPos(gridType);
 			return uv.U >= mapTopLeft.U && uv.U <= mapBottomRight.U && uv.V >= mapTopLeft.V && uv.V <= mapBottomRight.V;
 		}
 
@@ -136,7 +136,7 @@ namespace OpenRA
 						return false;
 				}
 
-				current = new MPos(u, v).ToCPos(r.shape);
+				current = new MPos(u, v).ToCPos(r.gridType);
 				return true;
 			}
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -786,7 +786,7 @@ namespace OpenRA
 
 		public WPos CenterOfCell(CPos cell)
 		{
-			if (Grid.Type == MapGridType.Rectangle)
+			if (Grid.Type == MapGridType.Rectangular)
 				return new WPos(1024 * cell.X + 512, 1024 * cell.Y + 512, 0);
 
 			// Convert from diamond cell position (x, y) to world position (u, v):
@@ -818,7 +818,7 @@ namespace OpenRA
 
 		public CPos CellContaining(WPos pos)
 		{
-			if (Grid.Type == MapGridType.Rectangle)
+			if (Grid.Type == MapGridType.Rectangular)
 				return new CPos(pos.X / 1024, pos.Y / 1024);
 
 			// Convert from world position to diamond cell position:

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -9,10 +9,8 @@
 #endregion
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -428,10 +426,10 @@ namespace OpenRA
 			foreach (var uv in AllCells.MapCoords)
 				CustomTerrain[uv] = byte.MaxValue;
 
-			var leftDelta = Grid.Type == TileShape.Diamond ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
-			var topDelta = Grid.Type == TileShape.Diamond ? new WVec(0, -512, 0) : new WVec(512, -512, 0);
-			var rightDelta = Grid.Type == TileShape.Diamond ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
-			var bottomDelta = Grid.Type == TileShape.Diamond ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
+			var leftDelta = Grid.Type == MapGridType.Diamond ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
+			var topDelta = Grid.Type == MapGridType.Diamond ? new WVec(0, -512, 0) : new WVec(512, -512, 0);
+			var rightDelta = Grid.Type == MapGridType.Diamond ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
+			var bottomDelta = Grid.Type == MapGridType.Diamond ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
 			CellCorners = CellCornerHalfHeights.Select(ramp => new WVec[]
 			{
 				leftDelta + new WVec(0, 0, 512 * ramp[0]),
@@ -756,7 +754,7 @@ namespace OpenRA
 			// .ToMPos() returns the same result if the X and Y coordinates
 			// are switched. X < Y is invalid in the Diamond coordinate system,
 			// so we pre-filter these to avoid returning the wrong result
-			if (Grid.Type == TileShape.Diamond && cell.X < cell.Y)
+			if (Grid.Type == MapGridType.Diamond && cell.X < cell.Y)
 				return false;
 
 			return Contains(cell.ToMPos(this));
@@ -788,7 +786,7 @@ namespace OpenRA
 
 		public WPos CenterOfCell(CPos cell)
 		{
-			if (Grid.Type == TileShape.Rectangle)
+			if (Grid.Type == MapGridType.Rectangle)
 				return new WPos(1024 * cell.X + 512, 1024 * cell.Y + 512, 0);
 
 			// Convert from diamond cell position (x, y) to world position (u, v):
@@ -820,7 +818,7 @@ namespace OpenRA
 
 		public CPos CellContaining(WPos pos)
 		{
-			if (Grid.Type == TileShape.Rectangle)
+			if (Grid.Type == MapGridType.Rectangle)
 				return new CPos(pos.X / 1024, pos.Y / 1024);
 
 			// Convert from world position to diamond cell position:
@@ -901,7 +899,7 @@ namespace OpenRA
 			// for diamond cells.
 			var wtop = tl.V * 1024;
 			var wbottom = (br.V + 1) * 1024;
-			if (Grid.Type == TileShape.Diamond)
+			if (Grid.Type == MapGridType.Diamond)
 			{
 				wtop /= 2;
 				wbottom /= 2;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -426,10 +426,10 @@ namespace OpenRA
 			foreach (var uv in AllCells.MapCoords)
 				CustomTerrain[uv] = byte.MaxValue;
 
-			var leftDelta = Grid.Type == MapGridType.Diamond ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
-			var topDelta = Grid.Type == MapGridType.Diamond ? new WVec(0, -512, 0) : new WVec(512, -512, 0);
-			var rightDelta = Grid.Type == MapGridType.Diamond ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
-			var bottomDelta = Grid.Type == MapGridType.Diamond ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
+			var leftDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
+			var topDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(0, -512, 0) : new WVec(512, -512, 0);
+			var rightDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
+			var bottomDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
 			CellCorners = CellCornerHalfHeights.Select(ramp => new WVec[]
 			{
 				leftDelta + new WVec(0, 0, 512 * ramp[0]),
@@ -752,9 +752,9 @@ namespace OpenRA
 		public bool Contains(CPos cell)
 		{
 			// .ToMPos() returns the same result if the X and Y coordinates
-			// are switched. X < Y is invalid in the Diamond coordinate system,
+			// are switched. X < Y is invalid in the RectangularIsometric coordinate system,
 			// so we pre-filter these to avoid returning the wrong result
-			if (Grid.Type == MapGridType.Diamond && cell.X < cell.Y)
+			if (Grid.Type == MapGridType.RectangularIsometric && cell.X < cell.Y)
 				return false;
 
 			return Contains(cell.ToMPos(this));
@@ -789,7 +789,7 @@ namespace OpenRA
 			if (Grid.Type == MapGridType.Rectangular)
 				return new WPos(1024 * cell.X + 512, 1024 * cell.Y + 512, 0);
 
-			// Convert from diamond cell position (x, y) to world position (u, v):
+			// Convert from isometric cell position (x, y) to world position (u, v):
 			// (a) Consider the relationships:
 			//  - Center of origin cell is (512, 512)
 			//  - +x adds (512, 512) to world pos
@@ -821,7 +821,7 @@ namespace OpenRA
 			if (Grid.Type == MapGridType.Rectangular)
 				return new CPos(pos.X / 1024, pos.Y / 1024);
 
-			// Convert from world position to diamond cell position:
+			// Convert from world position to isometric cell position:
 			// (a) Subtract (512, 512) to move the rotation center to the middle of the corner cell
 			// (b) Rotate axes by -pi/4
 			// (c) Divide through by sqrt(2) to bring us to an equivalent world pos aligned with u,v axes
@@ -896,10 +896,10 @@ namespace OpenRA
 			// Directly calculate the projected map corners in world units avoiding unnecessary
 			// conversions.  This abuses the definition that the width of the cell is always
 			// 1024 units, and that the height of two rows is 2048 for classic cells and 1024
-			// for diamond cells.
+			// for isometric cells.
 			var wtop = tl.V * 1024;
 			var wbottom = (br.V + 1) * 1024;
-			if (Grid.Type == MapGridType.Diamond)
+			if (Grid.Type == MapGridType.RectangularIsometric)
 			{
 				wtop /= 2;
 				wbottom /= 2;

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -23,7 +23,7 @@ namespace OpenRA
 {
 	public sealed class MapCache : IEnumerable<MapPreview>, IDisposable
 	{
-		public static readonly MapPreview UnknownMap = new MapPreview(null, TileShape.Rectangle, null);
+		public static readonly MapPreview UnknownMap = new MapPreview(null, MapGridType.Rectangle, null);
 		readonly Cache<string, MapPreview> previews;
 		readonly ModData modData;
 		readonly SheetBuilder sheetBuilder;

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -23,7 +23,7 @@ namespace OpenRA
 {
 	public sealed class MapCache : IEnumerable<MapPreview>, IDisposable
 	{
-		public static readonly MapPreview UnknownMap = new MapPreview(null, MapGridType.Rectangle, null);
+		public static readonly MapPreview UnknownMap = new MapPreview(null, MapGridType.Rectangular, null);
 		readonly Cache<string, MapPreview> previews;
 		readonly ModData modData;
 		readonly SheetBuilder sheetBuilder;

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -13,11 +13,11 @@ using System.IO;
 
 namespace OpenRA
 {
-	public enum MapGridType { Rectangle, Diamond }
+	public enum MapGridType { Rectangular, Diamond }
 
 	public class MapGrid : IGlobalModData
 	{
-		public readonly MapGridType Type = MapGridType.Rectangle;
+		public readonly MapGridType Type = MapGridType.Rectangular;
 		public readonly Size TileSize = new Size(24, 24);
 		public readonly byte MaximumTerrainHeight = 0;
 		public readonly byte SubCellDefaultIndex = byte.MaxValue;

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -13,7 +13,7 @@ using System.IO;
 
 namespace OpenRA
 {
-	public enum MapGridType { Rectangular, Diamond }
+	public enum MapGridType { Rectangular, RectangularIsometric }
 
 	public class MapGrid : IGlobalModData
 	{

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -13,11 +13,11 @@ using System.IO;
 
 namespace OpenRA
 {
-	public enum TileShape { Rectangle, Diamond }
+	public enum MapGridType { Rectangle, Diamond }
 
 	public class MapGrid : IGlobalModData
 	{
-		public readonly TileShape Type = TileShape.Rectangle;
+		public readonly MapGridType Type = MapGridType.Rectangle;
 		public readonly Size TileSize = new Size(24, 24);
 		public readonly byte MaximumTerrainHeight = 0;
 		public readonly byte SubCellDefaultIndex = byte.MaxValue;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -47,7 +47,7 @@ namespace OpenRA
 		public readonly int players;
 		public readonly Rectangle bounds;
 		public readonly int[] spawnpoints = { };
-		public readonly TileShape map_grid_type;
+		public readonly MapGridType map_grid_type;
 		public readonly string minimap;
 		public readonly bool downloading;
 	}
@@ -63,7 +63,7 @@ namespace OpenRA
 		public string Author { get; private set; }
 		public int PlayerCount { get; private set; }
 		public CPos[] SpawnPoints { get; private set; }
-		public TileShape GridType { get; private set; }
+		public MapGridType GridType { get; private set; }
 		public Rectangle Bounds { get; private set; }
 		public Bitmap CustomPreview { get; private set; }
 		public Map Map { get; private set; }
@@ -99,7 +99,7 @@ namespace OpenRA
 			generatingMinimap = false;
 		}
 
-		public MapPreview(string uid, TileShape gridType, MapCache cache)
+		public MapPreview(string uid, MapGridType gridType, MapCache cache)
 		{
 			this.cache = cache;
 			Uid = uid;

--- a/OpenRA.Game/Map/ProjectedCellRegion.cs
+++ b/OpenRA.Game/Map/ProjectedCellRegion.cs
@@ -8,10 +8,8 @@
  */
 #endregion
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA
 {
@@ -43,7 +41,7 @@ namespace OpenRA
 			// Each height step is equivalent to 512 WRange units, which is one MPos
 			// step for diamond cells, but only half a MPos step for classic cells. Doh!
 			var maxHeight = map.Grid.MaximumTerrainHeight;
-			var heightOffset = map.Grid.Type == TileShape.Diamond ? maxHeight : maxHeight / 2;
+			var heightOffset = map.Grid.Type == MapGridType.Diamond ? maxHeight : maxHeight / 2;
 
 			// Use the MapHeight data array to clamp the bottom coordinate so it doesn't overflow the map
 			mapBottomRight = map.MapHeight.Value.Clamp(new MPos(bottomRight.U, bottomRight.V + heightOffset));

--- a/OpenRA.Game/Map/ProjectedCellRegion.cs
+++ b/OpenRA.Game/Map/ProjectedCellRegion.cs
@@ -39,9 +39,9 @@ namespace OpenRA
 			// The bottom edge is trickier: cells at MPos.V > bottomRight.V may have
 			// been projected into this region if they have height > 0.
 			// Each height step is equivalent to 512 WRange units, which is one MPos
-			// step for diamond cells, but only half a MPos step for classic cells. Doh!
+			// step for isometric cells, but only half a MPos step for classic cells. Doh!
 			var maxHeight = map.Grid.MaximumTerrainHeight;
-			var heightOffset = map.Grid.Type == MapGridType.Diamond ? maxHeight : maxHeight / 2;
+			var heightOffset = map.Grid.Type == MapGridType.RectangularIsometric ? maxHeight : maxHeight / 2;
 
 			// Use the MapHeight data array to clamp the bottom coordinate so it doesn't overflow the map
 			mapBottomRight = map.MapHeight.Value.Clamp(new MPos(bottomRight.U, bottomRight.V + heightOffset));

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 					layer = pool.Pop();
 
 			if (layer == null)
-				layer = new CellLayer<CellInfo>(defaultLayer.Shape, defaultLayer.Size);
+				layer = new CellLayer<CellInfo>(defaultLayer.GridType, defaultLayer.Size);
 			layer.CopyValuesFrom(defaultLayer);
 			return layer;
 		}

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -130,11 +130,11 @@ namespace OpenRA.Mods.Common.Widgets
 				tooltipContainer.Value.RemoveTooltip();
 		}
 
-		public int2 ConvertToPreview(CPos cell, TileShape gridType)
+		public int2 ConvertToPreview(CPos cell, MapGridType gridType)
 		{
 			var preview = Preview();
 			var point = cell.ToMPos(gridType);
-			var cellWidth = gridType == TileShape.Diamond ? 2 : 1;
+			var cellWidth = gridType == MapGridType.Diamond ? 2 : 1;
 			var dx = (int)(previewScale * cellWidth * (point.U - preview.Bounds.Left));
 			var dy = (int)(previewScale * (point.V - preview.Bounds.Top));
 

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var preview = Preview();
 			var point = cell.ToMPos(gridType);
-			var cellWidth = gridType == MapGridType.Diamond ? 2 : 1;
+			var cellWidth = gridType == MapGridType.RectangularIsometric ? 2 : 1;
 			var dx = (int)(previewScale * cellWidth * (point.U - preview.Bounds.Left));
 			var dy = (int)(previewScale * (point.V - preview.Bounds.Top));
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Widgets
 			this.worldRenderer = worldRenderer;
 			radarPings = world.WorldActor.TraitOrDefault<RadarPings>();
 
-			isDiamond = world.Map.Grid.Type == TileShape.Diamond;
+			isDiamond = world.Map.Grid.Type == MapGridType.Diamond;
 			cellWidth = isDiamond ? 2 : 1;
 			previewWidth = world.Map.MapSize.X;
 			previewHeight = world.Map.MapSize.Y;

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly World world;
 		readonly WorldRenderer worldRenderer;
 		readonly RadarPings radarPings;
-		readonly bool isDiamond;
+		readonly bool isRectangularIsometric;
 		readonly int cellWidth;
 		readonly int previewWidth;
 		readonly int previewHeight;
@@ -64,11 +64,11 @@ namespace OpenRA.Mods.Common.Widgets
 			this.worldRenderer = worldRenderer;
 			radarPings = world.WorldActor.TraitOrDefault<RadarPings>();
 
-			isDiamond = world.Map.Grid.Type == MapGridType.Diamond;
-			cellWidth = isDiamond ? 2 : 1;
+			isRectangularIsometric = world.Map.Grid.Type == MapGridType.RectangularIsometric;
+			cellWidth = isRectangularIsometric ? 2 : 1;
 			previewWidth = world.Map.MapSize.X;
 			previewHeight = world.Map.MapSize.Y;
-			if (isDiamond)
+			if (isRectangularIsometric)
 				previewWidth = 2 * previewWidth - 1;
 		}
 
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Widgets
 				fixed (byte* colorBytes = &radarData[0])
 				{
 					var colors = (int*)colorBytes;
-					if (isDiamond)
+					if (isRectangularIsometric)
 					{
 						// Odd rows are shifted right by 1px
 						var dx = uv.V & 1;
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.Widgets
 					var colors = (int*)colorBytes;
 					foreach (var uv in world.Map.Unproject(puv))
 					{
-						if (isDiamond)
+						if (isRectangularIsometric)
 						{
 							// Odd rows are shifted right by 1px
 							var dx = uv.V & 1;
@@ -381,7 +381,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 								var uv = cell.First.ToMPos(world.Map.Grid.Type);
 								var color = cell.Second.ToArgb();
-								if (isDiamond)
+								if (isRectangularIsometric)
 								{
 									// Odd rows are shifted right by 1px
 									var dx = uv.V & 1;
@@ -430,7 +430,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var dy = (int)(previewScale * (uv.V - world.Map.Bounds.Top));
 
 			// Odd rows are shifted right by 1px
-			if (isDiamond && (uv.V & 1) == 1)
+			if (isRectangularIsometric && (uv.V & 1) == 1)
 				dx += 1;
 
 			return new int2(mapRect.X + dx, mapRect.Y + dy);

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -10,8 +10,6 @@
 
 using System;
 using System.Drawing;
-using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 
@@ -42,9 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 					return;
 
 				var grid = Game.ModData.Manifest.Get<MapGrid>();
-				var ts = grid.TileSize;
-				var shape = grid.Type;
-				bounds = worldRenderer.Theater.TemplateBounds(template, ts, shape);
+				bounds = worldRenderer.Theater.TemplateBounds(template, grid.TileSize, grid.Type);
 			}
 		}
 
@@ -73,7 +69,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var grid = Game.ModData.Manifest.Get<MapGrid>();
 			var ts = grid.TileSize;
-			var shape = grid.Type;
+			var gridType = grid.Type;
 			var scale = GetScale();
 
 			var sb = new Rectangle((int)(scale * bounds.X), (int)(scale * bounds.Y), (int)(scale * bounds.Width), (int)(scale * bounds.Height));
@@ -94,8 +90,8 @@ namespace OpenRA.Mods.Common.Widgets
 					var sprite = worldRenderer.Theater.TileSprite(tile, 0);
 					var size = new float2(sprite.Size.X * scale, sprite.Size.Y * scale);
 
-					var u = shape == TileShape.Rectangle ? x : (x - y) / 2f;
-					var v = shape == TileShape.Rectangle ? y : (x + y) / 2f;
+					var u = gridType == MapGridType.Rectangle ? x : (x - y) / 2f;
+					var v = gridType == MapGridType.Rectangle ? y : (x + y) / 2f;
 					var pos = origin + scale * (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.Size);
 					Game.Renderer.SpriteRenderer.DrawSprite(sprite, pos, worldRenderer.Palette(Palette), size);
 				}

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -90,8 +90,8 @@ namespace OpenRA.Mods.Common.Widgets
 					var sprite = worldRenderer.Theater.TileSprite(tile, 0);
 					var size = new float2(sprite.Size.X * scale, sprite.Size.Y * scale);
 
-					var u = gridType == MapGridType.Rectangle ? x : (x - y) / 2f;
-					var v = gridType == MapGridType.Rectangle ? y : (x + y) / 2f;
+					var u = gridType == MapGridType.Rectangular ? x : (x - y) / 2f;
+					var v = gridType == MapGridType.Rectangular ? y : (x + y) / 2f;
 					var pos = origin + scale * (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.Size);
 					Game.Renderer.SpriteRenderer.DrawSprite(sprite, pos, worldRenderer.Palette(Palette), size);
 				}

--- a/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Test
 						catch (Exception e)
 						{
 							// Known problem on isometric mods that shouldn't be visible to players as these are outside the map.
-							if (gridType == MapGridType.Diamond && y > x)
+							if (gridType == MapGridType.RectangularIsometric && y > x)
 								continue;
 
 							Console.WriteLine("Coordinate {0} on grid type {1} failed to convert back.".F(cell, gridType));

--- a/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Test
 		[TestCase(TestName = "Test CPos and MPos conversion and back again.")]
 		public void CoarseToMapProjection()
 		{
-			foreach (var shape in Enum.GetValues(typeof(TileShape)).Cast<TileShape>())
+			foreach (var gridType in Enum.GetValues(typeof(MapGridType)).Cast<MapGridType>())
 			{
 				for (var x = 0; x < 12; x++)
 				{
@@ -29,15 +29,15 @@ namespace OpenRA.Test
 						var cell = new CPos(x, y);
 						try
 						{
-							Assert.That(cell, Is.EqualTo(cell.ToMPos(shape).ToCPos(shape)));
+							Assert.That(cell, Is.EqualTo(cell.ToMPos(gridType).ToCPos(gridType)));
 						}
 						catch (Exception e)
 						{
 							// Known problem on isometric mods that shouldn't be visible to players as these are outside the map.
-							if (shape == TileShape.Diamond && y > x)
+							if (gridType == MapGridType.Diamond && y > x)
 								continue;
 
-							Console.WriteLine("Coordinate {0} on shape {1} failed to convert back.".F(cell, shape));
+							Console.WriteLine("Coordinate {0} on grid type {1} failed to convert back.".F(cell, gridType));
 							throw e;
 						}
 					}

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -207,7 +207,7 @@ Missions:
 
 MapGrid:
 	TileSize: 24,24
-	Type: Rectangle
+	Type: Rectangular
 
 SupportsMapsFrom: cnc
 

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -51,7 +51,7 @@ TileSets:
 
 MapGrid:
 	TileSize: 32,32
-	Type: Rectangle
+	Type: Rectangular
 
 Cursors:
 	./mods/d2k/cursors.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -207,7 +207,7 @@ Missions:
 
 MapGrid:
 	TileSize: 24,24
-	Type: Rectangle
+	Type: Rectangular
 
 SupportsMapsFrom: ra
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -113,7 +113,7 @@ TileSets:
 
 MapGrid:
 	TileSize: 48,24
-	Type: Diamond
+	Type: RectangularIsometric
 	MaximumTerrainHeight: 16
 	SubCellOffsets: 0,0,0, -256,128,0, 0,-128,0, 256,128,0
 	SubCellDefaultIndex: 2


### PR DESCRIPTION
This is the second small step toward "diamond" maps.
It just does some renaming to enable the addition of an _Isometric_ grid type.
Also `TileShape` isn't exactly proper, as it's used for much more than that.
