### PR TITLE
Fix a possible crash in ResourceLayer

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -203,6 +203,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanSpawnResourceAt(ResourceType newResourceType, CPos cell)
 		{
+			if (!world.Map.Contains(cell))
+				return false;
+
 			var currentResourceType = GetResource(cell);
 			return (currentResourceType == newResourceType && !IsFull(cell))
 				|| (currentResourceType == null && AllowResourceAt(newResourceType, cell));


### PR DESCRIPTION
Fixes following crash:

```
Tiberian Sun Mod at Version {DEV_VERSION}
on map 88cead46c1e5f57c7a6307bdcd8d27fefe7b805a (Name your map here by Your name here).
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.34209
Exception of type `System.IndexOutOfRangeException`: Index out of bounds. (Der Index war außerhalb des Arraybereichs.)
   at OpenRA.CellLayer`1.get_Item(CPos cell) in \OpenRA\OpenRA.Game\Map\CellLayer.cs:Line 82.
   at OpenRA.Mods.Common.Traits.ResourceLayer.GetResource(CPos cell)
   at OpenRA.Mods.Common.Traits.SeedsResource.<Seed>b__4(CPos p)
   at System.Linq.Enumerable.<SkipWhileIterator>d__52`1.MoveNext()
   at System.Linq.Enumerable.<CastIterator>d__b1`1.MoveNext()
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source)
   at OpenRA.Mods.Common.Traits.SeedsResource.Seed(Actor self)
   at OpenRA.Mods.Common.Traits.SeedsResource.Tick(Actor self)
   at OpenRA.World.<Tick>b__a(TraitPair`1 x) in \OpenRA\OpenRA.Game\World.cs:Line 287.
   at OpenRA.WorldUtils.DoTimed[T](IEnumerable`1 e, Action`1 a, String text) in \OpenRA\OpenRA.Game\WorldUtils.cs:Line 53.
   at OpenRA.World.Tick() in \OpenRA\OpenRA.Game\World.cs:Line 0.
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in \OpenRA\OpenRA.Game\Game.cs:Line 475.
   at OpenRA.Game.LogicTick() in \OpenRA\OpenRA.Game\Game.cs:Line 499.
   at OpenRA.Game.Loop() in \OpenRA\OpenRA.Game\Game.cs:Line 623.
   at OpenRA.Game.Run() in \OpenRA\OpenRA.Game\Game.cs:Line 663.
   at OpenRA.Program.Run(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 117.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 39.
```

I'm not sure how I got it, probably due to placing blossom trees near/at the map cordon.
