### PR TITLE
Fix crash when launching the game directly into a mod with missing assets

### DIFF
--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -41,16 +41,6 @@ namespace OpenRA.Mods.Common.LoadScreens
 			Ui.ResetAll();
 			Game.Settings.Save();
 
-			var installData = Game.ModData.Manifest.Get<ContentInstaller>();
-			var isModContentInstalled = installData.TestFiles.All(f => GlobalFileSystem.Exists(Path.GetFileName(f)));
-
-			// Mod assets are missing!
-			if (!isModContentInstalled)
-			{
-				Game.InitializeMod("modchooser", new Arguments());
-				return;
-			}
-
 			// Join a server directly
 			var connect = Launch.GetConnectAddress();
 			if (!string.IsNullOrEmpty(connect))


### PR DESCRIPTION
From the commit description:

> This fixes a crash that happens when you try to launch a mod directly while its assets aren't installed.
> Additionally should reduce the overhead for dedicated servers (in theory).

This only moves things around.
- The asset validation check was moved to an earlier point, because on bleed the game crashes because it tries to load the assets before checking whether they are available.
- The asset validation check now uses `File.Exists()` instead of `GlobalFileSystem.Exists()` because at that point in time the files aren't loaded yet.
- All asset loading and initializing is moved _after_ the dedicated server check. In theory that should save some unnecessary loading for those.

**Note:** I am unsure whether removing this from the dedicated server loading will have any unwanted effects, so someone more familiar with that should take a look:

```
                PerfHistory.Items["render"].HasNormalTick = false;
                PerfHistory.Items["batches"].HasNormalTick = false;
                PerfHistory.Items["render_widgets"].HasNormalTick = false;
                PerfHistory.Items["render_flip"].HasNormalTick = false;

                JoinLocal();
```

I did try setting up a dedicated server and joining it (jaZz_KCS set it up) and it all worked fine.
