### PR TITLE
Rename WithTurret, WithBarrel and WithReloadingTurret to include 'Sprite' in trait name

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -84,7 +84,7 @@
     <Compile Include="Traits\Render\WithGunboatBody.cs" />
     <Compile Include="Traits\Render\WithCargo.cs" />
     <Compile Include="Traits\Render\WithDeliveryAnimation.cs" />
-    <Compile Include="Traits\Render\WithReloadingTurret.cs" />
+    <Compile Include="Traits\Render\WithReloadingSpriteTurret.cs" />
     <Compile Include="Traits\Render\WithRoof.cs" />
     <Compile Include="Traits\SupportPowers\IonCannonPower.cs" />
     <Compile Include="Widgets\Logic\CncMainMenuLogic.cs" />

--- a/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Renders ammo-dependent turret graphics for units with the Turreted trait.")]
-	public class WithReloadingTurretInfo : WithTurretInfo, Requires<AmmoPoolInfo>, Requires<ArmamentInfo>
+	public class WithReloadingSpriteTurretInfo : WithSpriteTurretInfo, Requires<AmmoPoolInfo>, Requires<ArmamentInfo>
 	{
 		[Desc("AmmoPool to use for ammo-dependent sequences.")]
 		public readonly string AmmoPoolName = null;
@@ -27,17 +27,17 @@ namespace OpenRA.Mods.Cnc.Traits
 			"Adds current reload stage to Sequence as suffix when a matching AmmoPool is present.")]
 		public readonly int ReloadStages = -1;
 
-		public override object Create(ActorInitializer init) { return new WithReloadingTurret(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithReloadingSpriteTurret(init.Self, this); }
 	}
 
-	public class WithReloadingTurret : WithTurret
+	public class WithReloadingSpriteTurret : WithSpriteTurret
 	{
 		readonly int reloadStages;
 		readonly AmmoPool ammoPool;
 		string sequence;
 		string ammoSuffix;
 
-		public WithReloadingTurret(Actor self, WithReloadingTurretInfo info)
+		public WithReloadingSpriteTurret(Actor self, WithReloadingSpriteTurretInfo info)
 			: base(self, info)
 		{
 			ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault(a => a.Info.Name == info.AmmoPoolName);

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -412,7 +412,7 @@
     <Compile Include="Traits\Render\ProductionBar.cs" />
     <Compile Include="Traits\Render\SupportPowerChargeBar.cs" />
     <Compile Include="Traits\Render\TimedUpgradeBar.cs" />
-    <Compile Include="Traits\Render\WithBarrel.cs" />
+    <Compile Include="Traits\Render\WithSpriteBarrel.cs" />
     <Compile Include="Traits\Render\WithBuildingExplosion.cs" />
     <Compile Include="Traits\Render\WithActiveAnimation.cs" />
     <Compile Include="Traits\Render\WithAttackAnimation.cs" />
@@ -441,7 +441,7 @@
     <Compile Include="Traits\Render\WithShadow.cs" />
     <Compile Include="Traits\Render\WithSmoke.cs" />
     <Compile Include="Traits\Render\WithSpriteBody.cs" />
-    <Compile Include="Traits\Render\WithTurret.cs" />
+    <Compile Include="Traits\Render\WithSpriteTurret.cs" />
     <Compile Include="Traits\Render\WithFacingSpriteBody.cs" />
     <Compile Include="Traits\Render\WithBuildingPlacedOverlay.cs" />
     <Compile Include="Traits\Render\WithProductionDoorOverlay.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -402,6 +402,7 @@
     <Compile Include="Traits\Render\LeavesTrails.cs" />
     <Compile Include="Traits\Render\RenderSpritesEditorOnly.cs" />
     <Compile Include="Traits\Render\WithTurretedSpriteBody.cs" />
+    <Compile Include="Traits\Render\RenderUtils.cs" />
     <Compile Include="Traits\Render\RenderNameTag.cs" />
     <Compile Include="Traits\Render\RenderSprites.cs" />
     <Compile Include="Traits\Render\WithWallSpriteBody.cs" />

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Traits
 						() => PortOffset(self, port),
 						() => false,
 						() => false,
-						p => WithTurret.ZOffsetFromCenter(self, p, 1024));
+						p => RenderUtils.ZOffsetFromCenter(self, p, 1024));
 
 					muzzles.Add(muzzleFlash);
 					muzzleAnim.PlayThen(sequence, () => muzzles.Remove(muzzleFlash));

--- a/OpenRA.Mods.Common/Traits/Render/RenderUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderUtils.cs
@@ -1,0 +1,23 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class RenderUtils
+	{
+		public static int ZOffsetFromCenter(Actor self, WPos pos, int offset)
+		{
+			var delta = self.CenterPosition - pos;
+			return delta.Y + delta.Z + offset;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBarrel.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => turreted.TurretFacing);
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
 			rs.Add(new AnimationWithOffset(
-				DefaultAnimation, () => BarrelOffset(), () => IsTraitDisabled, () => false, p => WithTurret.ZOffsetFromCenter(self, p, 0)));
+				DefaultAnimation, () => BarrelOffset(), () => IsTraitDisabled, () => false, p => RenderUtils.ZOffsetFromCenter(self, p, 0)));
 
 			// Restrict turret facings to match the sprite
 			turreted.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => IsTraitDisabled || !buildComplete,
 				() => (info.PauseOnLowPower && self.IsDisabled()) || !buildComplete,
-				p => WithTurret.ZOffsetFromCenter(self, p, 1));
+				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 							() => info.IgnoreOffset ? WVec.Zero : armClosure.MuzzleOffset(self, barrel),
 							() => IsTraitDisabled || !visible[barrel],
 							() => false,
-							p => WithTurret.ZOffsetFromCenter(self, p, 2)));
+							p => RenderUtils.ZOffsetFromCenter(self, p, 2)));
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Traits
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => IsTraitDisabled && !renderProlonged,
 				() => false,
-				p => WithTurret.ZOffsetFromCenter(self, p, 1));
+				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			var rs = self.Trait<RenderSprites>();
 			rs.Add(anim, info.Palette);

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => !visible || !buildComplete,
 				() => info.PauseOnLowPower && self.IsDisabled(),
-				p => WithTurret.ZOffsetFromCenter(self, p, 1));
+				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders barrels for units with the Turreted trait.")]
-	public class WithBarrelInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<TurretedInfo>,
+	public class WithSpriteBarrelInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<TurretedInfo>,
 		Requires<ArmamentInfo>, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use.")]
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Visual offset.")]
 		public readonly WVec LocalOffset = WVec.Zero;
 
-		public override object Create(ActorInitializer init) { return new WithBarrel(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithSpriteBarrel(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithBarrel : UpgradableTrait<WithBarrelInfo>
+	public class WithSpriteBarrel : UpgradableTrait<WithSpriteBarrelInfo>
 	{
 		public readonly Animation DefaultAnimation;
 		readonly RenderSprites rs;
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Turreted turreted;
 		readonly BodyOrientation body;
 
-		public WithBarrel(Actor self, WithBarrelInfo info)
+		public WithSpriteBarrel(Actor self, WithSpriteBarrelInfo info)
 			: base(info)
 		{
 			this.self = self;

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders turrets for units with the Turreted trait.")]
-	public class WithTurretInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo,
+	public class WithSpriteTurretInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo,
 		Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<BodyOrientationInfo>, Requires<ArmamentInfo>
 	{
 		[Desc("Sequence name to use")]
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Render recoil")]
 		public readonly bool Recoils = true;
 
-		public override object Create(ActorInitializer init) { return new WithTurret(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithSpriteTurret(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithTurret : UpgradableTrait<WithTurretInfo>, ITick, INotifyDamageStateChanged
+	public class WithSpriteTurret : UpgradableTrait<WithSpriteTurretInfo>, ITick, INotifyDamageStateChanged
 	{
 		public readonly Animation DefaultAnimation;
 		protected readonly AttackBase Attack;
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Turreted t;
 		readonly Armament[] arms;
 
-		public WithTurret(Actor self, WithTurretInfo info)
+		public WithSpriteTurret(Actor self, WithSpriteTurretInfo info)
 			: base(info)
 		{
 			rs = self.Trait<RenderSprites>();

--- a/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurret.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => t.TurretFacing);
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 			rs.Add(new AnimationWithOffset(
-				DefaultAnimation, () => TurretOffset(self), () => IsTraitDisabled, () => false, p => ZOffsetFromCenter(self, p, 1)));
+				DefaultAnimation, () => TurretOffset(self), () => IsTraitDisabled, () => false, p => RenderUtils.ZOffsetFromCenter(self, p, 1)));
 
 			// Restrict turret facings to match the sprite
 			t.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
@@ -115,12 +115,6 @@ namespace OpenRA.Mods.Common.Traits
 
 			var sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;
 			DefaultAnimation.ReplaceAnim(sequence);
-		}
-
-		public static int ZOffsetFromCenter(Actor self, WPos pos, int offset)
-		{
-			var delta = self.CenterPosition - pos;
-			return delta.Y + delta.Z + offset;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2399,6 +2399,60 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20151127)
+				{
+					// Rename WithTurret to WithSpriteTurret
+					if (depth == 1 && node.Key.StartsWith("WithTurret"))
+					{
+						var parts = node.Key.Split('@');
+						node.Key = "WithSpriteTurret";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+
+					if (depth == 1 && node.Key.StartsWith("-WithTurret"))
+					{
+						var parts = node.Key.Split('@');
+						node.Key = "-WithSpriteTurret";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+
+					// Rename WithBarrel to WithSpriteBarrel
+					if (depth == 1 && node.Key.StartsWith("WithBarrel"))
+					{
+						var parts = node.Key.Split('@');
+						node.Key = "WithSpriteBarrel";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+
+					if (depth == 1 && node.Key.StartsWith("-WithBarrel"))
+					{
+						var parts = node.Key.Split('@');
+						node.Key = "-WithSpriteBarrel";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+
+					// Rename WithReloadingTurret to WithReloadingSpriteTurret
+					if (depth == 1 && node.Key.StartsWith("WithReloadingTurret"))
+					{
+						var parts = node.Key.Split('@');
+						node.Key = "WithReloadingSpriteTurret";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+
+					if (depth == 1 && node.Key.StartsWith("-WithReloadingTurret"))
+					{
+						var parts = node.Key.Split('@');
+						node.Key = "-WithReloadingSpriteTurret";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -114,7 +114,7 @@ APC:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	Cargo:
 		Types: Infantry
@@ -220,7 +220,7 @@ BGGY:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: BGGY.Husk
@@ -290,7 +290,7 @@ JEEP:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: JEEP.Husk
@@ -325,7 +325,7 @@ LTNK:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: LTNK.Husk
@@ -359,7 +359,7 @@ MTNK:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: MTNK.Husk
@@ -387,7 +387,7 @@ HTNK:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
-	WithTurret:
+	WithSpriteTurret:
 	Turreted:
 		ROT: 3
 	Armament@PRIMARY:
@@ -445,7 +445,7 @@ MSAM:
 		Weapon: 227mm
 		LocalOffset: 213,-128,0, 213,128,0
 	AttackFrontal:
-	WithTurret:
+	WithSpriteTurret:
 		AimSequence: aim
 	AutoTarget:
 	SpawnActorOnDeath:
@@ -485,7 +485,7 @@ MLRS:
 		ReloadCount: 1
 		SelfReloadTicks: 100
 	AttackTurreted:
-	WithReloadingTurret:
+	WithReloadingSpriteTurret:
 		AmmoPoolName: primary
 	AutoTarget:
 		InitialStanceAI: Defend

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -283,7 +283,7 @@
 
 ^Defense:
 	Inherits: ^Building
-	WithTurret:
+	WithSpriteTurret:
 	AttackTurreted:
 	AutoTarget:
 	RenderRangeCircle:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -205,7 +205,7 @@ siege_tank:
 		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	Explodes:
 		Weapon: UnitExplodeMed
 		EmptyWeapon: UnitExplodeMed
@@ -465,7 +465,7 @@ deviator:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	Explodes:
 		Weapon: UnitExplodeMed

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -1388,7 +1388,7 @@ Rules:
 		-Huntable:
 		-Targetable:
 		-Armament:
-		-WithTurret:
+		-WithSpriteTurret:
 		-WithMuzzleOverlay:
 		Cargo:
 			Types: ~disabled

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2209,7 +2209,7 @@ Rules:
 			MuzzleSequence: muzzle
 		AttackTurreted:
 		WithMuzzleOverlay:
-		WithTurret:
+		WithSpriteTurret:
 		AutoTarget:
 		Explodes:
 			Weapon: MiniNuke

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -149,7 +149,7 @@ DD:
 	AttackTurreted:
 	SelectionDecorations:
 		VisualBounds: 38,38
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	DetectCloaked:
 		CloakTypes: Underwater
@@ -204,9 +204,9 @@ CA:
 	WithMuzzleOverlay:
 	SelectionDecorations:
 		VisualBounds: 44,44
-	WithTurret@PRIMARY:
+	WithSpriteTurret@PRIMARY:
 		Turret: primary
-	WithTurret@SECONDARY:
+	WithSpriteTurret@SECONDARY:
 		Turret: secondary
 	AutoTarget:
 
@@ -277,7 +277,7 @@ PT:
 	WithMuzzleOverlay:
 	SelectionDecorations:
 		VisualBounds: 36,36
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	DetectCloaked:
 		CloakTypes: Underwater

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -61,7 +61,7 @@ V2RL:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 1TNK.Husk
@@ -98,7 +98,7 @@ V2RL:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 2TNK.Husk
@@ -137,7 +137,7 @@ V2RL:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 3TNK.Husk
@@ -185,7 +185,7 @@ V2RL:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 4TNK.Husk
@@ -344,7 +344,7 @@ JEEP:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	Cargo:
 		Types: Infantry
@@ -608,7 +608,7 @@ FTRK:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	WithTurret:
+	WithSpriteTurret:
 	AutoTarget:
 	SelectionDecorations:
 		VisualBounds: 28,28
@@ -738,7 +738,7 @@ STNK:
 	Turreted:
 		ROT: 5
 	AttackTurreted:
-	WithTurret:
+	WithSpriteTurret:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 4

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -62,17 +62,17 @@ GACTWR:
 		UpgradeMinEnabledLevel: 1
 	CanPowerDown:
 		IndicatorPalette: mouse
-	WithTurret@VULC:
+	WithSpriteTurret@VULC:
 		UpgradeTypes: tower.vulcan
 		UpgradeMinEnabledLevel: 1
 		Recoils: no
 		Sequence: turret-vulcan
-	WithTurret@ROCKET:
+	WithSpriteTurret@ROCKET:
 		UpgradeTypes: tower.rocket
 		UpgradeMinEnabledLevel: 1
 		Recoils: no
 		Sequence: turret-rocket
-	WithTurret@SAM:
+	WithSpriteTurret@SAM:
 		UpgradeTypes: tower.sam
 		UpgradeMinEnabledLevel: 1
 		Recoils: no

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -145,7 +145,7 @@ MMCH:
 		ROT: 5
 	AttackTurreted:
 		Voice: Attack
-	WithTurret:
+	WithSpriteTurret:
 		Recoils: no
 	Armament:
 		Weapon: 120mm

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -134,7 +134,7 @@ NASAM:
 		ROT: 10
 		InitialFacing: 50
 	AttackTurreted:
-	WithTurret:
+	WithSpriteTurret:
 		Recoils: no
 	Armament:
 		Weapon: RedEye2

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -28,7 +28,7 @@ NAPULS:
 	AttackTurreted:
 	Armament:
 		Weapon: EMPulseCannon
-	WithTurret:
+	WithSpriteTurret:
 		Sequence: turret
 	Power:
 		Amount: -150


### PR DESCRIPTION
To make 100% clear to any modder that these are render traits (not to be confused with `Turreted`, for example) as well as for more consistent naming.

Additionally pulled out `ZOffsetFromCenter` from former `WithTurret` into a new `RenderUtils`, since there's quite a number of traits using it by now.
