### PR TITLE
Rename WithRotor to WithSpriteRotorOverlay

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -441,7 +441,7 @@
     <Compile Include="Traits\Render\WithRepairAnimation.cs" />
     <Compile Include="Traits\Render\WithRepairOverlay.cs" />
     <Compile Include="Traits\Render\WithResources.cs" />
-    <Compile Include="Traits\Render\WithRotor.cs" />
+    <Compile Include="Traits\Render\WithSpriteRotorOverlay.cs" />
     <Compile Include="Traits\Render\WithShadow.cs" />
     <Compile Include="Traits\Render\WithSmoke.cs" />
     <Compile Include="Traits\Render\WithSpriteBody.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteRotorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteRotorOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays a helicopter rotor overlay.")]
-	public class WithRotorInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	public class WithSpriteRotorOverlayInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use when flying")]
 		[SequenceReference] public readonly string Sequence = "rotor";
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		public object Create(ActorInitializer init) { return new WithRotor(init.Self, this); }
+		public object Create(ActorInitializer init) { return new WithSpriteRotorOverlay(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
@@ -43,13 +43,13 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithRotor : ITick
+	public class WithSpriteRotorOverlay : ITick
 	{
-		readonly WithRotorInfo info;
+		readonly WithSpriteRotorOverlayInfo info;
 		readonly Animation rotorAnim;
 		readonly IMove movement;
 
-		public WithRotor(Actor self, WithRotorInfo info)
+		public WithSpriteRotorOverlay(Actor self, WithSpriteRotorOverlayInfo info)
 		{
 			this.info = info;
 			var rs = self.Trait<RenderSprites>();

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2189,6 +2189,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20151004)
+				{
+					if (depth == 1 && node.Key == "WithRotor")
+						node.Key = "WithSpriteRotorOverlay";
+
+					if (depth == 1 && node.Key == "-WithRotor")
+						node.Key = "-WithSpriteRotorOverlay";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -23,11 +23,11 @@ TRAN:
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
-	WithRotor@PRIMARY:
+	WithSpriteRotorOverlay@PRIMARY:
 		Offset: -597,0,171
 		Sequence: rotor2
 		GroundSequence: slow-rotor2
-	WithRotor@SECONDARY:
+	WithSpriteRotorOverlay@SECONDARY:
 		Offset: 597,0,85
 	Cargo:
 		Types: Infantry
@@ -80,7 +80,7 @@ HELI:
 		SelfReloads: true
 		ReloadCount: 10
 		SelfReloadTicks: 200
-	WithRotor:
+	WithSpriteRotorOverlay:
 		Offset: 0,0,85
 	WithMuzzleOverlay:
 	SpawnActorOnDeath:
@@ -224,9 +224,9 @@ TRAN.Husk:
 	RevealsShroud:
 		Range: 8c0
 		Type: CenterPosition
-	WithRotor@PRIMARY:
+	WithSpriteRotorOverlay@PRIMARY:
 		Offset: -597,0,171
-	WithRotor@SECONDARY:
+	WithSpriteRotorOverlay@SECONDARY:
 		Offset: 597,0,85
 	RenderSprites:
 		Image: tran
@@ -241,7 +241,7 @@ HELI.Husk:
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
-	WithRotor:
+	WithSpriteRotorOverlay:
 		Offset: 0,0,85
 	RenderSprites:
 		Image: heli

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -221,11 +221,11 @@ TRAN:
 		AltitudeVelocity: 0c100
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithRotor@PRIMARY:
+	WithSpriteRotorOverlay@PRIMARY:
 		Offset: -597,0,341
 		Sequence: rotor2
 		GroundSequence: slow-rotor2
-	WithRotor@SECONDARY:
+	WithSpriteRotorOverlay@SECONDARY:
 		Offset: 597,0,213
 	Cargo:
 		Types: Infantry
@@ -271,7 +271,7 @@ HELI:
 		CanHover: True
 	AutoTarget:
 		InitialStance: HoldFire
-	WithRotor:
+	WithSpriteRotorOverlay:
 		Offset: 0,0,85
 	AmmoPool:
 		Ammo: 8
@@ -324,7 +324,7 @@ HIND:
 		CanHover: True
 	AutoTarget:
 		InitialStance: HoldFire
-	WithRotor:
+	WithSpriteRotorOverlay:
 	AmmoPool:
 		Ammo: 24
 		PipCount: 6

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -90,9 +90,9 @@ TRAN.Husk:
 		Speed: 149
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithRotor@PRIMARY:
+	WithSpriteRotorOverlay@PRIMARY:
 		Offset: -597,0,341
-	WithRotor@SECONDARY:
+	WithSpriteRotorOverlay@SECONDARY:
 		Offset: 597,0,213
 	RevealsShroud:
 		Range: 12c0
@@ -184,7 +184,7 @@ HELI.Husk:
 		Speed: 149
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithRotor:
+	WithSpriteRotorOverlay:
 		Offset: 0,0,85
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
@@ -204,7 +204,7 @@ HIND.Husk:
 		Speed: 112
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithRotor:
+	WithSpriteRotorOverlay:
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
 		MinDamage: Undamaged

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -282,7 +282,7 @@ APACHE:
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:
-	WithRotor:
+	WithSpriteRotorOverlay:
 		Offset: 85,0,384
 	RenderSprites:
 	Hovers:


### PR DESCRIPTION
For more consistency, clarification and differentiation (there might be a `WithVoxelRotorOverlay` in the future).
