### PR TITLE
Hide the owner row of FCOM

### DIFF
--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1376,6 +1376,9 @@ Rules:
 	^Crate:
 		Tooltip:
 			ShowOwnerRow: false
+	FCOM:
+		Tooltip:
+			ShowOwnerRow: false
 	powerproxy.paratroopers:
 		ParatroopersPower:
 			DropItems: E1,E1,E1,E2,E2

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -1271,6 +1271,9 @@ Rules:
 	^Crate:
 		Tooltip:
 			ShowOwnerRow: false
+	FCOM:
+		Tooltip:
+			ShowOwnerRow: false
 	powerproxy.paratroopers:
 		ParatroopersPower:
 			DropItems: E1,E1,E1,E2,E2

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1763,6 +1763,8 @@ Rules:
 			Prerequisites: ~disabled
 	FCOM:
 		MustBeDestroyed:
+		Tooltip:
+			ShowOwnerRow: false
 	4TNK:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-02a/map.yaml
+++ b/mods/ra/maps/soviet-02a/map.yaml
@@ -623,6 +623,9 @@ Rules:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+	FCOM:
+		Tooltip:
+			ShowOwnerRow: false
 	SPEN:
 		Buildable:
 			Prerequisites: ~disabled


### PR DESCRIPTION
Follow up of #9448.
Fixes #9565.
