### PR TITLE
Implement some keyboard hotkeys for chat (TextFieldWidget)

### DIFF
--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -61,6 +61,7 @@ namespace OpenRA
 		Bitmap TakeScreenshot();
 		void PumpInput(IInputHandler inputHandler);
 		string GetClipboardText();
+		bool SetClipboardText(string text);
 		void DrawPrimitives(PrimitiveType type, int firstVertex, int numVertices);
 
 		void SetLineWidth(float width);

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -267,5 +267,10 @@ namespace OpenRA
 		{
 			return Device.GetClipboardText();
 		}
+
+		public bool SetClipboardText(string text)
+		{
+			return Device.SetClipboardText(text);
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -123,15 +123,15 @@ namespace OpenRA.Mods.Common.Widgets
 			Func<int> getPrevWhitespaceIndex = () =>
 				Text.Substring(0, CursorPosition).TrimEnd().LastIndexOf(' ') + 1;
 
-			Func<int> getNextWhitespaceIndex = () => {
+			Func<int> getNextWhitespaceIndex = () =>
+			{
 				var substr = Text.Substring(CursorPosition);
 				var substrTrimmed = substr.TrimStart();
 				var trimmedSpaces = substr.Length - substrTrimmed.Length;
 				var nextWhitespace = substrTrimmed.IndexOf(' ');
 				if (nextWhitespace == -1)
 					return Text.Length;
-				else
-					return CursorPosition + trimmedSpaces + nextWhitespace;
+				return CursorPosition + trimmedSpaces + nextWhitespace;
 			};
 
 			var isOSX = Platform.CurrentPlatform == PlatformType.OSX;
@@ -161,21 +161,24 @@ namespace OpenRA.Mods.Common.Widgets
 				case Keycode.LEFT:
 					ResetBlinkCycle();
 					if (CursorPosition > 0)
-						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-						(isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
+					{
+						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) || (isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
 							CursorPosition = getPrevWhitespaceIndex();
 						else
 							CursorPosition--;
+					}
+
 					break;
 
 				case Keycode.RIGHT:
 					ResetBlinkCycle();
 					if (CursorPosition <= Text.Length - 1)
-						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-						(isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
+					{
+						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) || (isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
 							CursorPosition = getNextWhitespaceIndex();
 						else
 							CursorPosition++;
+					}
 
 					break;
 
@@ -214,10 +217,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 				case Keycode.X:
 					ResetBlinkCycle();
-					if (((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-						 (isOSX && e.Modifiers.HasModifier(Modifiers.Meta))) &&
-						 (!string.IsNullOrEmpty(Text)))
+					if (((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) || (isOSX && e.Modifiers.HasModifier(Modifiers.Meta))) &&
+						!string.IsNullOrEmpty(Text))
 					{
+						Game.Renderer.SetClipboardText(Text);
 						Text = Text.Remove(0);
 						CursorPosition = 0;
 						OnTextEdited();
@@ -230,8 +233,7 @@ namespace OpenRA.Mods.Common.Widgets
 					ResetBlinkCycle();
 					if (CursorPosition < Text.Length)
 					{
-						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-						(isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
+						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) || (isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
 							Text = Text.Substring(0, CursorPosition) + Text.Substring(getNextWhitespaceIndex());
 						else if (isOSX && e.Modifiers.HasModifier(Modifiers.Meta))
 							Text = Text.Remove(CursorPosition);
@@ -248,8 +250,7 @@ namespace OpenRA.Mods.Common.Widgets
 					ResetBlinkCycle();
 					if (CursorPosition > 0)
 					{
-						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-						(isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
+						if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) || (isOSX && e.Modifiers.HasModifier(Modifiers.Alt)))
 						{
 							var prev_whitespace = getPrevWhitespaceIndex();
 							Text = Text.Substring(0, prev_whitespace) + Text.Substring(CursorPosition);
@@ -273,8 +274,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				case Keycode.V:
 					ResetBlinkCycle();
-					if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-						 (isOSX && e.Modifiers.HasModifier(Modifiers.Meta)))
+					if ((!isOSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) || (isOSX && e.Modifiers.HasModifier(Modifiers.Meta)))
 					{
 						var clipboardText = Game.Renderer.GetClipboardText();
 

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -115,18 +115,6 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!HasKeyboardFocus)
 				return false;
 
-			if ((e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER) && OnEnterKey())
-				return true;
-
-			if (e.Key == Keycode.TAB && OnTabKey())
-				return true;
-
-			if (e.Key == Keycode.ESCAPE && OnEscKey())
-				return true;
-
-			if (e.Key == Keycode.LALT && OnAltKey())
-				return true;
-
 			Func<int> getPrevWhitespaceIndex = () =>
 				Text.Substring(0, CursorPosition).TrimEnd().LastIndexOf(' ') + 1;
 
@@ -141,156 +129,155 @@ namespace OpenRA.Mods.Common.Widgets
 					return CursorPosition + trimmed_spaces + next_whitespace;
 			};
 
-			if (e.Key == Keycode.LEFT)
-			{
-				if (CursorPosition > 0)
-				{
-					if ((Platform.CurrentPlatform != PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-					(Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Alt)))
-					{
-						CursorPosition = getPrevWhitespaceIndex();
-					}
-					else
-					{
-						CursorPosition--;
-					}
-				}
+			Func<bool> isOSX = () => Platform.CurrentPlatform == PlatformType.OSX;
 
-				return true;
-			}
+			switch (e.Key) {
+				case Keycode.RETURN:
+				case Keycode.KP_ENTER:
+					if (OnEnterKey())
+						return true;
+					break;
 
-			if (e.Key == Keycode.RIGHT)
-			{
-				if (CursorPosition <= Text.Length - 1) {
-					if ((Platform.CurrentPlatform != PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-					(Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Alt)))
-					{
-						CursorPosition = getNextWhitespaceIndex();
-					}
-					else
-					{
-						CursorPosition++;
-					}
-				}
+				case Keycode.TAB:
+					if (OnTabKey())
+						return true;
+					break;
 
-				return true;
-			}
+				case Keycode.ESCAPE:
+					if (OnEscKey())
+						return true;
+					break;
 
-			if (e.Key == Keycode.HOME)
-			{
-				CursorPosition = 0;
-				return true;
-			}
+				case Keycode.LALT:
+					if (OnAltKey())
+						return true;
+					break;
 
-			if (e.Key == Keycode.END)
-			{
-				CursorPosition = Text.Length;
-				return true;
-			}
+				case Keycode.LEFT:
+					if (CursorPosition > 0)
+						if ((!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
+						(isOSX() && e.Modifiers.HasModifier(Modifiers.Alt)))
+							CursorPosition = getPrevWhitespaceIndex();
+						else
+							CursorPosition--;
+					break;
 
-			if (e.Key == Keycode.K && e.Modifiers.HasModifier(Modifiers.Ctrl) &&
-				(Platform.CurrentPlatform != PlatformType.OSX))
-			{
-				// equivalent to cmd+delete on osx
-				if (CursorPosition < Text.Length)
-				{
-					Text = Text.Remove(CursorPosition);
-					OnTextEdited();
-				}
+				case Keycode.RIGHT:
+					if (CursorPosition <= Text.Length - 1)
+						if ((!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
+						(isOSX() && e.Modifiers.HasModifier(Modifiers.Alt)))
+							CursorPosition = getNextWhitespaceIndex();
+						else
+							CursorPosition++;
 
-				return true;
-			}
+					break;
 
-			if (e.Key == Keycode.U && e.Modifiers.HasModifier(Modifiers.Ctrl) &&
-				(Platform.CurrentPlatform != PlatformType.OSX))
-			{
-				// equivalent to cmd+backspace on osx
-				Text = Text.Substring(CursorPosition);
-				CursorPosition = 0;
-				OnTextEdited();
-				return true;
-			}
-
-			if (e.Key == Keycode.X &&
-				((Platform.CurrentPlatform != PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-				 (Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Meta))))
-			{
-				if (!string.IsNullOrEmpty(Text))
-				{
-					Text = Text.Remove(0);
+				case Keycode.HOME:
 					CursorPosition = 0;
-					OnTextEdited();
-					return true;
-				}
-			}
+					break;
 
-			if (e.Key == Keycode.DELETE)
-			{
-				if (CursorPosition < Text.Length)
-				{
-					if ((Platform.CurrentPlatform != PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-					(Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Alt)))
+				case Keycode.END:
+					CursorPosition = Text.Length;
+					break;
+
+				case Keycode.K:
+					// ctrl+k is equivalent to cmd+delete on osx
+					if (!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl) && CursorPosition < Text.Length)
 					{
-						Text = Text.Substring(0, CursorPosition) + Text.Substring(getNextWhitespaceIndex());
-					}
-					else if (Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Meta))
-					{
-						// equivalent to ctrl+k on non-osx
 						Text = Text.Remove(CursorPosition);
+						OnTextEdited();
 					}
-					else
+
+					break;
+
+				case Keycode.U:
+					// ctrl+u is equivalent to cmd+backspace on osx
+					if (!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl) && CursorPosition > 0)
 					{
-						Text = Text.Remove(CursorPosition, 1);
+						Text = Text.Substring(CursorPosition);
+						CursorPosition = 0;
+						OnTextEdited();
 					}
 
-					OnTextEdited();
+					break;
+
+				case Keycode.X:
+					if (((!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
+						 (isOSX() && e.Modifiers.HasModifier(Modifiers.Meta))) &&
+						 (!string.IsNullOrEmpty(Text)))
+					{
+						Text = Text.Remove(0);
+						CursorPosition = 0;
+						OnTextEdited();
+					}
+
+					break;
+
+				case Keycode.DELETE:
+					// cmd+delete is equivalent to ctrl+k on non-osx
+					if (CursorPosition < Text.Length)
+					{
+						if ((!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
+						(isOSX() && e.Modifiers.HasModifier(Modifiers.Alt)))
+							Text = Text.Substring(0, CursorPosition) + Text.Substring(getNextWhitespaceIndex());
+						else if (isOSX() && e.Modifiers.HasModifier(Modifiers.Meta))
+							Text = Text.Remove(CursorPosition);
+						else
+							Text = Text.Remove(CursorPosition, 1);
+
+						OnTextEdited();
+					}
+
+					break;
+
+				case Keycode.BACKSPACE:
+					// cmd+backspace is equivalent to ctrl+u on non-osx
+					if (CursorPosition > 0)
+					{
+						if ((!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
+						(isOSX() && e.Modifiers.HasModifier(Modifiers.Alt)))
+						{
+							var prev_whitespace = getPrevWhitespaceIndex();
+							Text = Text.Substring(0, prev_whitespace) + Text.Substring(CursorPosition);
+							CursorPosition = prev_whitespace;
+						}
+						else if (isOSX() && e.Modifiers.HasModifier(Modifiers.Meta))
+						{
+							Text = Text.Substring(CursorPosition);
+							CursorPosition = 0;
+						}
+						else
+						{
+							CursorPosition--;
+							Text = Text.Remove(CursorPosition, 1);
+						}
+
+						OnTextEdited();
+					}
+
+					break;
+
+				case Keycode.V:
+					if ((!isOSX() && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
+						 (isOSX() && e.Modifiers.HasModifier(Modifiers.Meta)))
+					{
+						var clipboardText = Game.Renderer.GetClipboardText();
+
+						// Take only the first line of the clipboard contents
+						var nl = clipboardText.IndexOf('\n');
+						if (nl > 0)
+							clipboardText = clipboardText.Substring(0, nl);
+
+						clipboardText = clipboardText.Trim();
+						if (clipboardText.Length > 0)
+							HandleTextInput(clipboardText);
+					}
+
+					break;
+
+				default:
+					break;
 				}
-
-				return true;
-			}
-
-			if (e.Key == Keycode.BACKSPACE && CursorPosition > 0)
-			{
-				if ((Platform.CurrentPlatform != PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-				(Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Alt)))
-				{
-					var prev_whitespace = getPrevWhitespaceIndex();
-					Text = Text.Substring(0, prev_whitespace) + Text.Substring(CursorPosition);
-					CursorPosition = prev_whitespace;
-				}
-				else if (Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Meta))
-				{
-					// equivalent to ctrl+u on non-osx
-					Text = Text.Substring(CursorPosition);
-					CursorPosition = 0;
-				}
-				else
-				{
-					CursorPosition--;
-					Text = Text.Remove(CursorPosition, 1);
-				}
-
-				OnTextEdited();
-				return true;
-			}
-
-			if (e.Key == Keycode.V &&
-				((Platform.CurrentPlatform != PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Ctrl)) ||
-				 (Platform.CurrentPlatform == PlatformType.OSX && e.Modifiers.HasModifier(Modifiers.Meta))))
-			{
-				var clipboardText = Game.Renderer.GetClipboardText();
-
-				// Take only the first line of the clipboard contents
-				var nl = clipboardText.IndexOf('\n');
-				if (nl > 0)
-					clipboardText = clipboardText.Substring(0, nl);
-
-				clipboardText = clipboardText.Trim();
-				if (clipboardText.Length > 0)
-					HandleTextInput(clipboardText);
-
-				return true;
-			}
 
 			return true;
 		}

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -382,6 +382,12 @@ namespace OpenRA.Platforms.Default
 			return input.GetClipboardText();
 		}
 
+		public bool SetClipboardText(string text)
+		{
+			VerifyThreadAffinity();
+			return input.SetClipboardText(text);
+		}
+
 		public IVertexBuffer<Vertex> CreateVertexBuffer(int size)
 		{
 			VerifyThreadAffinity();

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Platforms.Default
 		MouseButton lastButtonBits = (MouseButton)0;
 
 		public string GetClipboardText() { return SDL.SDL_GetClipboardText(); }
+		public bool SetClipboardText(string text) { return SDL.SDL_SetClipboardText(text) == 0; }
 
 		static MouseButton MakeButton(byte b)
 		{

--- a/OpenRA.Platforms.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Platforms.Null/NullGraphicsDevice.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Platforms.Null
 		public Bitmap TakeScreenshot() { return new Bitmap(1, 1); }
 
 		public string GetClipboardText() { return ""; }
+		public bool SetClipboardText(string text) { return false; }
 		public void PumpInput(IInputHandler ih)
 		{
 			Game.HasInputFocus = false;


### PR DESCRIPTION
This implements #8301 and parts of #2794.

The first commits implements the features, the second is a refactor to clarify the code, remove redundancies and make it easier to modify/add to in the future. It's also more explicit in its behavior, especially with regards to some functions that were being called from conditionals.
Because of the refactor, I recommend reviewing the commits separately.

The implemented keyboard hotkeys in the text areas are:
- ctrl + left/right (navigate words) (cmd + left/right on osx)
- ctrl + backspace/delete (backspaces/deletes words) (alt + backspace/delete on osx)
- ctrl + u / ctrl + k (removes rest of line from cursor) (cmd backspace/delete on osx)
- ctrl + x (clears the whole line) (cmd + x on osx) (this is optional but I often use it, especially in text editors)

I don't have access to OSX, so someone has to test that it's working fine on OSX, and that the hotkeys are sane/expected behavior (coherent with how interface usually behaves in other apps/in the os)

Also, does home/end exist on OSX? should cmd + left/cmd + right behave like home/end instead? (edit: did the latter)

A third commit resets the cursor blinking which I think makes the UX much better
A fourth commit makes ctrl+x cut to clipboard instead of cutting to the ether.
