### PR TITLE
Fix case sensitivity issue in d2k sequence definitions

### DIFF
--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -161,7 +161,7 @@ rallypoint:
 		Length: *
 
 beacon:
-	arrow: mouse.r8
+	arrow: MOUSE.R8
 		Start: 148
 		Offset: -24,-24
 	circles: fpls.shp


### PR DESCRIPTION
Game would crash on systems with case-sensitive filesystems when a support-power beacon appeared.
