### PR TITLE
Make "select all units" work across screen/map again

### DIFF
--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -235,11 +235,25 @@ namespace OpenRA.Widgets
 				else if (key == Game.Settings.Keys.SelectAllUnitsKey && !World.IsGameOver)
 				{
 					// Select actors on the screen which belong to the current player
-					var ownUnitsOnScreen = SelectActorsOnScreen(World, worldRenderer, null, player).SubsetWithHighestSelectionPriority();
+					var ownUnitsOnScreen = SelectActorsOnScreen(World, worldRenderer, null, player).SubsetWithHighestSelectionPriority().ToList();
+
+					// Check if selecting actors on the screen has selected new units
+					if (ownUnitsOnScreen.Count > World.Selection.Actors.Count())
+						Game.Debug("Selected across screen");
+					else
+					{
+						// Select actors in the world that have highest selection priority
+						ownUnitsOnScreen = SelectActorsInWorld(World, null, player).SubsetWithHighestSelectionPriority().ToList();
+						Game.Debug("Selected across map");
+					}
+
 					World.Selection.Combine(World, ownUnitsOnScreen, false, false);
 				}
 				else if (key == Game.Settings.Keys.SelectUnitsByTypeKey && !World.IsGameOver)
 				{
+					if (!World.Selection.Actors.Any())
+						return false;
+
 					// Get all the selected actors' selection classes
 					var selectedClasses = World.Selection.Actors
 						.Where(x => !x.IsDead && x.Owner == player)
@@ -250,7 +264,7 @@ namespace OpenRA.Widgets
 					var newSelection = SelectActorsOnScreen(World, worldRenderer, selectedClasses, player).ToList();
 
 					// Check if selecting actors on the screen has selected new units
-					if (newSelection.Count() > World.Selection.Actors.Count())
+					if (newSelection.Count > World.Selection.Actors.Count())
 						Game.Debug("Selected across screen");
 					else
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -394,7 +394,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "CycleBaseKey", "Jump to base" },
 					{ "ToLastEventKey", "Jump to last radar event" },
 					{ "ToSelectionKey", "Jump to selection" },
-					{ "SelectAllUnitsKey", "Select all units on screen" },
+					{ "SelectAllUnitsKey", "Select all combat units" },
 					{ "SelectUnitsByTypeKey", "Select units by type" },
 
 					{ "PlaceBeaconKey", "Place beacon" },


### PR DESCRIPTION
I noticed in the new release that 'q' no longer selects all units across the map (only across the screen). I couldn't find the commit that was responsible for this regression, but this PR addresses that.

I also made 'w' do less work if no units/classes are selected (no debug msg appears either)

The behavior now adheres to what's stated in the [wiki](https://github.com/OpenRA/OpenRA/wiki/Hotkeys). Updated the line in settings to better represent what 'q' does.

Although I incorrectly stated that it selects "military units" instead of "highest priority".

Do you think 'q' should instead select "military units" ie a specific priority instead of simply the highest one?

Note: this makes use of "Game.debug()" which might not be desirable. I could remove that or replace it with some placeholder (e.g. Game.WriteLine()) that calls Game.debug() until a better solution is available. I'm personally OK with leaving it as is (using Game.debug()).
