### PR TITLE
Middle click to cancel directly (skips onhold) & ctrl+cancel to cancel entire queue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Also thanks to:
     * Joppy Furr
     * Kanar
     * Kenny Hoxworth (hoxworth)
+    * Kevin Azzam (ChaoticMind)
     * Krishnakanth Mallik
     * Kyrre Soerensen (zypres)
     * Lawrence Wang
@@ -159,4 +160,3 @@ distributed under the LGPL version 2.1 or later.
 Finally, special thanks goes to the original teams
 at Westwood Studios and EA for creating the classic
 games which OpenRA aims to reimagine.
-


### PR DESCRIPTION
Implemented a fix to a pet peeve which is having to go through "onhold" before cancelling an item. Especially frustrating during lag spikes (and misclicks of adding extra units/structures). If we middle click instead of right click, we can now directly cancel an item without interrupting the currently building/training item. This also gives us a lot more versatility in fixing up the queue for long term construction projects. 

I also implemented `ctrl + click` to cancel an entire queue, resolving #6082.
- `Ctrl + leftclick` doesn't do anything (trains one unit, except if it's `ctrl + shift + leftclick` which behaves as `shift + leftclick`.
- `Ctrl + middleclick`: immediately cancels the whole queue (without going to "onhold")
- `Ctrl + rightclick`: goes to onhold if not already there. If already in onhold, cancels the entire queue.

Just a note: If someone gets the bright idea of implementing modifiers for keyboard hotkeys (like shift+f1 to train 5 items, or ctrl+f1 to cancel an item or something, then it's an exercise in futility since ctrl+f1 won't match the hotkey for the building at all, since it could be binded to something else anyway :p). It's debatable if we care enough to look for some solution to this.
