### PR TITLE
Mouse wheel zooming

### DIFF
--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -144,7 +144,35 @@ namespace OpenRA.Widgets
 				}
 			}
 
-			lastMousePosition = xy;
+            if (mi.Event == MouseInputEvent.Scroll && mi.ScrollDelta == +1)
+            {
+                var zoomLevel = worldRenderer.Viewport.Zoom + 0.5f;
+
+                //maximum level = 4
+                if (zoomLevel > 4f)
+                {
+                    zoomLevel = 4f;
+                }
+
+                worldRenderer.Viewport.Zoom = zoomLevel;
+                Game.Settings.Graphics.PixelDouble = true;
+            }
+
+            if (mi.Event == MouseInputEvent.Scroll && mi.ScrollDelta == -1)
+            {
+                var zoomLevel = worldRenderer.Viewport.Zoom - 0.5f;
+
+                //minimum level = 0.5
+                if (zoomLevel < 0.5f)
+                {
+                    zoomLevel = 0.5f;
+                }
+
+                worldRenderer.Viewport.Zoom = zoomLevel;
+                Game.Settings.Graphics.PixelDouble = false;
+            }
+
+            lastMousePosition = xy;
 
 			return true;
 		}

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Widgets
             {
                 var zoomLevel = worldRenderer.Viewport.Zoom + 0.5f;
 
-                //maximum level = 4
+                // Maximum level = 4
                 if (zoomLevel > 4f)
                 {
                     zoomLevel = 4f;
@@ -161,7 +161,7 @@ namespace OpenRA.Widgets
             {
                 var zoomLevel = worldRenderer.Viewport.Zoom - 0.5f;
 
-                //minimum level = 0.5
+                // Minimum level = 0.5
                 if (zoomLevel < 0.5f)
                 {
                     zoomLevel = 0.5f;

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -155,7 +155,6 @@ namespace OpenRA.Widgets
                 }
 
                 worldRenderer.Viewport.Zoom = zoomLevel;
-                Game.Settings.Graphics.PixelDouble = true;
             }
 
             if (mi.Event == MouseInputEvent.Scroll && mi.ScrollDelta == -1)
@@ -169,7 +168,6 @@ namespace OpenRA.Widgets
                 }
 
                 worldRenderer.Viewport.Zoom = zoomLevel;
-                Game.Settings.Graphics.PixelDouble = false;
             }
 
             lastMousePosition = xy;


### PR DESCRIPTION
This change adds support for mousewheel zooming, with a minimum zoom level of 0.5 (half of the current) and a maximum of 4.0 (double the current).
