### PR TITLE
Add a Lua wrapper to display debug messages (shows if setting enabled)

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -101,6 +101,7 @@ namespace OpenRA
 	public class DebugSettings
 	{
 		public bool BotDebug = false;
+		public bool LuaDebug = false;
 		public bool PerfText = false;
 		public bool PerfGraph = false;
 		public float LongTickThresholdMs = 1;

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -177,6 +177,15 @@ namespace OpenRA.Mods.Common.Scripting
 			Game.AddChatLine(c, prefix, text);
 		}
 
+		[Desc("Displays a debug message to the player, if \"Show Map Debug Messages\" is checked in the settings.")]
+		public void Debug(string text)
+		{
+			if (string.IsNullOrEmpty(text) || !Game.Settings.Debug.LuaDebug)
+				return;
+
+			Game.Debug(text);
+		}
+
 		[Desc("Display a text message at the specified location.")]
 		public void FloatingText(string text, WPos position, int duration = 30, HSLColor? color = null)
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -564,6 +564,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "CHECKUNSYNCED_CHECKBOX", ds, "SanityCheckUnsyncedCode");
 			BindCheckboxPref(panel, "BOTDEBUG_CHECKBOX", ds, "BotDebug");
 			BindCheckboxPref(panel, "FETCH_NEWS_CHECKBOX", gs, "FetchNews");
+			BindCheckboxPref(panel, "LUADEBUG_CHECKBOX", ds, "LuaDebug");
 
 			return () => { };
 		}
@@ -583,6 +584,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ds.PerfGraph = dds.PerfGraph;
 				ds.SanityCheckUnsyncedCode = dds.SanityCheckUnsyncedCode;
 				ds.BotDebug = dds.BotDebug;
+				ds.LuaDebug = dds.LuaDebug;
 			};
 		}
 

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -531,6 +531,13 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Check Sync around Unsynced Code
+						Checkbox@LUADEBUG_CHECKBOX:
+							X: 310
+							Y: 190
+							Width: 300
+							Height: 20
+							Font: Regular
+							Text: Show Map Debug Messages
 		Button@BACK_BUTTON:
 			Key: escape
 			Y: 393
@@ -543,4 +550,3 @@ Container@SETTINGS_PANEL:
 			Width: 140
 			Height: 35
 			Text: Reset
-

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -532,4 +532,10 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Check Sync around Unsynced Code
-
+				Checkbox@LUADEBUG_CHECKBOX:
+					X: 310
+					Y: 190
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Show Map Debug Messages


### PR DESCRIPTION
Addresses #9598.

Can be tested in lua with `Media.Debug()`
