### PR TITLE
Tab completion improvement/rewrite

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		readonly ColorPreviewManagerWidget colorPreview;
 
-		readonly TabCompletionLogic tabCompletion = new TabCompletionLogic();
+		readonly TabCompletionLogic tabCompletionNames = new TabCompletionLogic();
 
 		readonly LabelWidget chatLabel;
 		bool teamChat;
@@ -620,7 +620,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatTextField.OnTabKey = () =>
 			{
 				var previousText = chatTextField.Text;
-				chatTextField.Text = tabCompletion.Complete(chatTextField.Text);
+				chatTextField.Text = tabCompletionNames.Complete(chatTextField.Text);
 				chatTextField.CursorPosition = chatTextField.Text.Length;
 
 				if (chatTextField.Text == previousText)
@@ -921,7 +921,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			while (players.Children.Count > idx)
 				players.RemoveChild(players.Children[idx]);
 
-			tabCompletion.Names = orderManager.LobbyInfo.Clients.Select(c => c.Name).Distinct().ToList();
+			tabCompletionNames.Completions = orderManager.LobbyInfo.Clients.Select(c => c.Name).Distinct().ToList();
 		}
 
 		void OnGameStart()


### PR DESCRIPTION
Tab completion can now properly handle elements (most likely usernames) with whitespace. Previously, if someone had a nickname "I like lamp", and one types "I li+tab", it wouldn't work. Another pet peeve tackled!

I'm not super satisfied with it because I would have liked to avoid rebuilding `relevantSubstrings`, but I didn't really find a more elegant solution. (Suggestions welcome). It might be impossible though because of the immutability of strings and the not-worthiness of having a "startsWith()" helper function that works on char arrays.
It's O(n*m) (worst case) where m is the average length of the possible elements (nicknames).

I rewrote a good section of the class to increasing modularity and reduce the need to handle corner cases (although some remnants linger). Commands and Names are now in different `TabCompletionLogic` objects.
