### PR TITLE
Added the movement classes of the domain index to the debug logs

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			domains = new CellLayer<int>(world.Map);
 			transientConnections = new Dictionary<int, HashSet<int>>();
 
-			using (new PerfTimer("BuildDomains: {0}".F(world.Map.Title)))
+			using (new PerfTimer("BuildDomains: {0} for movement class {1}".F(world.Map.Title, movementClass)))
 				BuildDomains(world);
 		}
 
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Common.Traits
 				domain += 1;
 			}
 
-			Log.Write("debug", "Found {0} domains on map {1}.", domain - 1, map.Title);
+			Log.Write("debug", "Found {0} domains for movement class {1} on map {2}.", domain - 1, movementClass, map.Title);
 		}
 	}
 }


### PR DESCRIPTION
I was just told that the domain indices are calculated per movement class and wanted to share that insight somehow.
