### PR TITLE
Fix bridge destruction and repair.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -152,6 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		internal void AddHut(BridgeHut hut)
 		{
+			// TODO: This method is incomprehensible and fragile, and should be rewritten.
 			if (huts[0] == huts[1])
 				huts[1] = hut;
 			if (Hut == null)
@@ -161,7 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 					huts[0] = hut; // Set only first time
 				for (var d = 0; d <= 1; d++)
 					for (var b = neighbours[d]; b != null; b = b.Hut == null ? b.neighbours[d] : null)
-						b.huts[1 - d] = hut;
+						b.huts[d] = hut;
 			}
 			else
 				Hut = null;

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -493,8 +493,9 @@ BRIDGEHUT:
 	Building:
 		Footprint: __ __
 		Dimensions: 2,2
-	CustomSelectionSize:
-		CustomBounds: 48,48
+	Selectable:
+		Bounds: 48,48
+		Priority: 2
 	BridgeHut:
 	Targetable:
 		TargetTypes: BridgeHut, C4
@@ -504,8 +505,9 @@ BRIDGEHUT.small:
 	Building:
 		Footprint: _
 		Dimensions: 1,1
-	CustomSelectionSize:
-		CustomBounds: 24,24
+	Selectable:
+		Bounds: 24,24
+		Priority: 2
 	BridgeHut:
 	Targetable:
 		TargetTypes: BridgeHut, C4


### PR DESCRIPTION
The bridge hut spawning is sensitive to the order that the bridges were spawned on the map: it assumes that southern bridges were spawned before northern bridges, which only worked because we used to index the map in the bridge spawner in a non-standard way (column-major instead of row-major).  When 26ce7b5e1c3e6f8c7eaf359e14faaedf9954e470 fixed the map enumeration the code ended attaching bridges to the wrong ends of eachother, and this flowed on to the bridge huts being connected wrong.

This fix inverts the assumption above so that bridges are assumed to spawn north-to-south (which matches what we do), but the whole method is bogus and really should be rewritten at some point.

Fixes #9592.
Fixes #9192.
