### PR TITLE
Speed up checks for IOccupySpace trait

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -574,7 +574,7 @@ namespace OpenRA.Mods.Common.AI
 
 			// Pick something worth attacking owned by that player
 			var target = World.Actors
-				.Where(a => a.Owner == enemy && a.Info.HasTraitInfo<IOccupySpaceInfo>())
+				.Where(a => a.Owner == enemy && a.OccupiesSpace != null)
 				.ClosestTo(World.Map.CenterOfCell(GetRandomBaseCenter()));
 
 			if (target == null)

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common
 			if (self.IsDead)
 				return false;
 
-			if (!self.Info.HasTraitInfo<IOccupySpaceInfo>())
+			if (self.OccupiesSpace == null)
 				return false;
 
 			if (!self.IsInWorld)

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -35,12 +35,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly ProductionInfo Info;
 		public string Faction { get; private set; }
 
-		readonly bool occupiesSpace;
-
 		public Production(ActorInitializer init, ProductionInfo info)
 		{
 			Info = info;
-			occupiesSpace = init.Self.Info.HasTraitInfo<IOccupySpaceInfo>();
 			rp = Exts.Lazy(() => init.Self.IsDead ? null : init.Self.TraitOrDefault<RallyPoint>());
 			Faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}
@@ -60,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 				new OwnerInit(self.Owner),
 			};
 
-			if (occupiesSpace)
+			if (self.OccupiesSpace != null)
 			{
 				exit = self.Location + exitinfo.ExitCell;
 				var spawn = self.CenterPosition + exitinfo.SpawnOffset;
@@ -122,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			var exit = self.Info.TraitInfos<ExitInfo>().Shuffle(self.World.SharedRandom)
 				.FirstOrDefault(e => CanUseExit(self, producee, e));
 
-			if (exit != null || !occupiesSpace)
+			if (exit != null || self.OccupiesSpace == null)
 			{
 				DoProduction(self, producee, exit, factionVariant);
 				return true;

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public AmbientSound(Actor self, AmbientSoundInfo info)
 		{
-			if (self.Info.HasTraitInfo<IOccupySpaceInfo>())
+			if (self.OccupiesSpace != null)
 				Game.Sound.PlayLooped(info.SoundFile, self.CenterPosition);
 			else
 				Game.Sound.PlayLooped(info.SoundFile);


### PR DESCRIPTION
Eagerly load the trait (if it exists) in Actor, and use this reference to avoid having to perform `self.Info.HasTraitInfo<IOccupySpaceInfo>()` checks.

The main benefit is for `IsAtGroundLevel`, which is used during pathfinding for crushability checks. Therefore this saves us a lookup for every actor we need to check for crushability on our path.
