### PR TITLE
Remove a redundant check

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -867,8 +867,6 @@ namespace OpenRA.Mods.Common.AI
 			// HACK: This needs to query against MCVs directly
 			var mcvs = self.World.Actors
 				.Where(a => a.Owner == Player && a.Info.HasTraitInfo<BaseBuildingInfo>() && a.Info.HasTraitInfo<MobileInfo>());
-			if (!mcvs.Any())
-				return;
 
 			foreach (var mcv in mcvs)
 			{


### PR DESCRIPTION
This avoids enumerating the `mcvs` twice in `FindAndDeployBackupMcv` for no reason.
