### PR TITLE
Change mouse cursors while joystick scrolling

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -48,6 +48,18 @@ namespace OpenRA.Mods.Common.Widgets
 			{ ScrollDirection.Right, "scroll-r" },
 		};
 
+		static readonly Dictionary<ScrollDirection, string> JoystickCursors = new Dictionary<ScrollDirection, string>
+		{
+			{ ScrollDirection.Up | ScrollDirection.Left, "joystick-tl-blocked" },
+			{ ScrollDirection.Up | ScrollDirection.Right, "joystick-tr-blocked" },
+			{ ScrollDirection.Down | ScrollDirection.Left, "joystick-bl-blocked" },
+			{ ScrollDirection.Down | ScrollDirection.Right, "joystick-br-blocked" },
+			{ ScrollDirection.Up, "joystick-t-blocked" },
+			{ ScrollDirection.Down, "joystick-b-blocked" },
+			{ ScrollDirection.Left, "joystick-l-blocked" },
+			{ ScrollDirection.Right, "joystick-r-blocked" },
+		};
+
 		static readonly Dictionary<ScrollDirection, float2> ScrollOffsets = new Dictionary<ScrollDirection, float2>
 		{
 			{ ScrollDirection.Up, new float2(0, -1) },
@@ -147,10 +159,20 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override string GetCursor(int2 pos)
 		{
-			if (!Game.Settings.Game.ViewportEdgeScroll || Ui.MouseOverWidget != this)
+			if (!IsJoystickScrolling &&
+			    (!Game.Settings.Game.ViewportEdgeScroll || Ui.MouseOverWidget != this))
 				return null;
 
 			var blockedDirections = worldRenderer.Viewport.GetBlockedDirections();
+
+			if (IsJoystickScrolling)
+			{
+				foreach (var dir in JoystickCursors)
+					if (blockedDirections.Includes(dir.Key))
+						return dir.Value;
+				return "joystick-all";
+			}
+
 			foreach (var dir in ScrollCursors)
 				if (edgeDirections.Includes(dir.Key))
 					return dir.Value + (blockedDirections.Includes(dir.Key) ? "-blocked" : "");

--- a/mods/cnc/cursors.yaml
+++ b/mods/cnc/cursors.yaml
@@ -71,6 +71,22 @@ Cursors:
 		c4-minimap:
 			Start: 127
 			Length: 3
+		joystick-t-blocked:
+			Start: 130
+		joystick-tr-blocked:
+			Start: 131
+		joystick-r-blocked:
+			Start: 132
+		joystick-br-blocked:
+			Start: 133
+		joystick-b-blocked:
+			Start: 134
+		joystick-bl-blocked:
+			Start: 135
+		joystick-l-blocked:
+			Start: 136
+		joystick-tl-blocked:
+			Start: 137
 
 # Cursors that need minimap variants
 		deploy:
@@ -102,6 +118,10 @@ Cursors:
 			Length: 24
 	mouse3.shp: cursor
 		default:
+			Start: 0
+			X: -16
+			Y: -12
+		joystick-all:
 			Start: 0
 			X: -16
 			Y: -12

--- a/mods/d2k/cursors.yaml
+++ b/mods/d2k/cursors.yaml
@@ -207,6 +207,42 @@ Cursors:
 			Length: 8
 			X: 24
 			Y: 24
+		joystick-all:
+			Start: 0
+			X: 24
+			Y: 24
+		joystick-t-blocked:
+			Start: 180
+			X: 24
+			Y: 24
+		joystick-tr-blocked:
+			Start: 188
+			X: 24
+			Y: 24
+		joystick-r-blocked:
+			Start: 196
+			X: 24
+			Y: 24
+		joystick-br-blocked:
+			Start: 204
+			X: 24
+			Y: 24
+		joystick-b-blocked:
+			Start: 212
+			X: 24
+			Y: 24
+		joystick-bl-blocked:
+			Start: 220
+			X: 24
+			Y: 24
+		joystick-l-blocked:
+			Start: 228
+			X: 24
+			Y: 24
+		joystick-tl-blocked:
+			Start: 236
+			X: 24
+			Y: 24
 
 # Cursors that need minimap variants
 		deploy:

--- a/mods/ra/cursors.yaml
+++ b/mods/ra/cursors.yaml
@@ -122,6 +122,26 @@ Cursors:
 		ability-minimap:
 			Start: 214
 			Length: 8
+		joystick-all:
+			Start: 0
+			X: -16
+			Y: -12
+		joystick-t-blocked:
+			Start: 124
+		joystick-tr-blocked:
+			Start: 125
+		joystick-r-blocked:
+			Start: 126
+		joystick-br-blocked:
+			Start: 127
+		joystick-b-blocked:
+			Start: 128
+		joystick-bl-blocked:
+			Start: 129
+		joystick-l-blocked:
+			Start: 130
+		joystick-tl-blocked:
+			Start: 131
 
 # Cursors that need minimap variants
 		deploy:

--- a/mods/ts/cursors.yaml
+++ b/mods/ts/cursors.yaml
@@ -176,4 +176,22 @@ Cursors:
 		powerdown:
 			Start: 329
 			Length: 15
+		joystick-all:
+			Start: 378
+		joystick-t-blocked:
+			Start: 379
+		joystick-tr-blocked:
+			Start: 380
+		joystick-r-blocked:
+			Start: 381
+		joystick-br-blocked:
+			Start: 382
+		joystick-b-blocked:
+			Start: 383
+		joystick-bl-blocked:
+			Start: 384
+		joystick-l-blocked:
+			Start: 385
+		joystick-tl-blocked:
+			Start: 386
 


### PR DESCRIPTION
This patch adds mouse cursors to the joystick scrolling feature.

On Tiberian Sun, which itself had joystick scrolling, the same cursors are
used as in the original game.

As the older games did not have joystick scrolling, I've had to make a
best-effort guess as to what were suitable cursors.
  -> When scrolling in all directions is available, the default arrow
     cursor is used.
  -> When a direction is blocked, the edge-scrolling blocked direction
     cursor is used.
