### PR TITLE
Update gdi-vehicles.yaml

### DIFF
--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -94,7 +94,7 @@ SMECH:
 		ROT: 5
 		Speed: 99
 	Health:
-		HP: 800
+		HP: 175
 	Armor:
 		Type: Light
 	RevealsShroud:


### PR DESCRIPTION
Changed because the thing was stronger than a Mammoth Mk 2

Previously set to 800.

Tiberian Sun value was set to 175

Changed to 175 to match Tiberian Sun. Verified other values matched Rules.ini
