### PR TITLE
Temporary fix for missiles launched from zero height

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -284,7 +284,7 @@ namespace OpenRA.Mods.Common.Effects
 			var diffClfMslHgt = predClfHgt - pos.Z;
 
 			// Incline coming up
-			if (diffClfMslHgt >= 0)
+			if (diffClfMslHgt >= 0 && predClfDist > 0)
 				DetermineLaunchSpeedAndAngleForIncline(predClfDist, diffClfMslHgt, relTarHorDist, out speed, out vFacing);
 			else if (lastHt != 0)
 			{


### PR DESCRIPTION
Fixes choosing minimum launch speed for missiles launched at or below terrain height.

Takes care of #9645.
