### PR TITLE
Update the UID stored in the map file after saving.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -603,6 +603,9 @@ namespace OpenRA
 
 			// Update existing package
 			Container.Write(entries);
+
+			// Update UID to match the newly saved data
+			Uid = ComputeHash();
 		}
 
 		public CellLayer<TerrainTile> LoadMapTiles()

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -145,9 +145,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				map.Save(combinedPath);
 
-				// Reload map to calculate new UID
-				map = new Map(combinedPath);
-
 				// Update the map cache so it can be loaded without restarting the game
 				var classification = mapDirectories[directoryDropdown.Text];
 				Game.ModData.MapCache[map.Uid].UpdateFromMap(map, classification);


### PR DESCRIPTION
Fixes #9617.

That error occurred when saving a map more than two times.  Because the UID was not being updated, it would always invalidate the first loaded preview, instead of the currently active one.
