### PR TITLE
Change display-mode without restart

### DIFF
--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -55,6 +55,8 @@ namespace OpenRA
 		IShader CreateShader(string name);
 
 		Size WindowSize { get; }
+		WindowMode WindowMode { get; }
+		void SetWindowSize(Size size, WindowMode windowMode);
 
 		void Clear();
 		void Present();
@@ -135,6 +137,6 @@ namespace OpenRA
 	{
 		Windowed,
 		Fullscreen,
-		PseudoFullscreen,
+		NativeFullscreen,
 	}
 }

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -116,6 +116,12 @@ namespace OpenRA.Graphics
 
 			Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
 			tileSize = grid.TileSize;
+
+			Game.Renderer.OnResolutionChange += (windowSize) =>
+			{
+				screenClip = new Rectangle(Point.Empty, windowSize);
+				Zoom = zoom;
+			};
 		}
 
 		public CPos ViewToWorld(int2 view)
@@ -214,7 +220,7 @@ namespace OpenRA.Graphics
 		}
 
 		// Rectangle (in viewport coords) that contains things to be drawn
-		static readonly Rectangle ScreenClip = Rectangle.FromLTRB(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
+		Rectangle screenClip = Rectangle.FromLTRB(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
 		public Rectangle GetScissorBounds(bool insideBounds)
 		{
 			// Visible rectangle in world coordinates (expanded to the corners of the cells)
@@ -224,8 +230,8 @@ namespace OpenRA.Graphics
 			var cbr = map.CenterOfCell(((MPos)bounds.BottomRight).ToCPos(map)) + new WVec(512, 512, 0);
 
 			// Convert to screen coordinates
-			var tl = WorldToViewPx(worldRenderer.ScreenPxPosition(ctl - new WVec(0, 0, ctl.Z))).Clamp(ScreenClip);
-			var br = WorldToViewPx(worldRenderer.ScreenPxPosition(cbr - new WVec(0, 0, cbr.Z))).Clamp(ScreenClip);
+			var tl = WorldToViewPx(worldRenderer.ScreenPxPosition(ctl - new WVec(0, 0, ctl.Z))).Clamp(screenClip);
+			var br = WorldToViewPx(worldRenderer.ScreenPxPosition(cbr - new WVec(0, 0, cbr.Z))).Clamp(screenClip);
 
 			// Add an extra one cell fudge in each direction for safety
 			return Rectangle.FromLTRB(tl.X - tileSize.Width, tl.Y - tileSize.Height,

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -112,8 +112,7 @@ namespace OpenRA
 	public class GraphicSettings
 	{
 		public string Renderer = "Default";
-		public WindowMode Mode = WindowMode.PseudoFullscreen;
-		public int2 FullscreenSize = new int2(0, 0);
+		public WindowMode Mode = WindowMode.NativeFullscreen;
 		public int2 WindowedSize = new int2(1024, 768);
 		public bool HardwareCursors = true;
 		public bool PixelDouble = false;

--- a/OpenRA.Game/Widgets/RootWidget.cs
+++ b/OpenRA.Game/Widgets/RootWidget.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Graphics;
 
 namespace OpenRA.Widgets
@@ -17,6 +18,12 @@ namespace OpenRA.Widgets
 		public RootWidget()
 		{
 			IgnoreMouseOver = true;
+			Game.Renderer.OnResolutionChange += (windowSize) => OnResolutionChange();
+		}
+
+		public override void Initialize(WidgetArgs args)
+		{
+			this.Bounds = new Rectangle(Point.Empty, Game.Renderer.Resolution);
 		}
 
 		public override bool HandleKeyPress(KeyInput e)

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -208,8 +208,12 @@ namespace OpenRA.Widgets
 			}
 		}
 
+		WidgetArgs widgetArgs;
+
 		public virtual void Initialize(WidgetArgs args)
 		{
+			this.widgetArgs = args;
+
 			// Parse the YAML equations to find the widget bounds
 			var parentBounds = (Parent == null)
 				? new Rectangle(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height)
@@ -235,6 +239,15 @@ namespace OpenRA.Widgets
 								   Evaluator.Evaluate(Y, substitutions),
 								   width,
 								   height);
+		}
+
+		protected void OnResolutionChange()
+		{
+			if (widgetArgs != null)
+				Initialize(widgetArgs);
+
+			foreach (var child in Children)
+				child.OnResolutionChange();
 		}
 
 		public void PostInit(WidgetArgs args)

--- a/OpenRA.Platforms.Null/NullGraphicsDevice.cs
+++ b/OpenRA.Platforms.Null/NullGraphicsDevice.cs
@@ -17,12 +17,16 @@ namespace OpenRA.Platforms.Null
 	public sealed class NullGraphicsDevice : IGraphicsDevice
 	{
 		public Size WindowSize { get; private set; }
+		public WindowMode WindowMode { get; private set; }
 
-		public NullGraphicsDevice(Size size, WindowMode window)
+		public NullGraphicsDevice(Size size, WindowMode windowMode)
 		{
 			Console.WriteLine("Using Null renderer");
 			WindowSize = size;
+			WindowMode = windowMode;
 		}
+
+		public void SetWindowSize(Size size, WindowMode windowMode) { }
 
 		public void Dispose() { }
 

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -63,21 +63,21 @@ Background@SETTINGS_PANEL:
 			Height: PARENT_BOTTOM
 			Children:
 				Label@MODE_LABEL:
-					X: 110
+					X: 40
 					Y: 39
 					Width: 45
 					Height: 25
 					Align: Right
 					Text: Mode:
 				DropDownButton@MODE_DROPDOWN:
-					X: 160
+					X: 90
 					Y: 40
 					Width: 170
 					Height: 25
 					Font: Regular
 					Text: Windowed
 				Container@WINDOW_RESOLUTION:
-					X: 330
+					X: 260
 					Y: 40
 					Children:
 						Label@At:
@@ -105,6 +105,10 @@ Background@SETTINGS_PANEL:
 							Width: 45
 							Height: 25
 							MaxLength: 5
+						DropDownButton@WINDOW_SIZE_DROPDOWN:
+							X: 135
+							Width: 120
+							Height: 25
 				Checkbox@HARDWARECURSORS_CHECKBOX:
 					X: 310
 					Y: 75
@@ -118,7 +122,7 @@ Background@SETTINGS_PANEL:
 					Height: 25
 					Font: Tiny
 					Align: Center
-					Text: Mode, resolution, and cursor changes will be applied after the game is restarted
+					Text: Hardware cursor changes will be applied after the game is restarted
 				Checkbox@FRAME_LIMIT_CHECKBOX:
 					X: 15
 					Y: 125


### PR DESCRIPTION
Working prototype of display mode change without restarting. (Live display adjustments https://github.com/OpenRA/OpenRA/issues/3774) Type the new res in the display settings and go back/to another settings tab.

Need help to finish:
Not all ingame widgets are initialized properly
Nitpicking the display settings UI - I think a dropdown resolution changer would be better
Probably don't need help with but haven't included yet: fullscreen switching, hardware cursor switching
