### PR TITLE
Tweaked D2k warhead falloffs

### DIFF
--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -9,13 +9,11 @@ LMG:
 		Falloff: 100, 50, 25, 0
 		Damage: 125
 		Versus:
-			none: 100
 			wall: 10
 			building: 25
 			wood: 75
 			light: 40
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -48,8 +46,6 @@ Bazooka:
 			building: 40
 			wood: 45
 			light: 70
-			heavy: 100
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -71,13 +67,11 @@ Fremen_S:
 		Falloff: 100, 50, 25, 0
 		Damage: 125
 		Versus:
-			none: 100
 			wall: 10
 			building: 25
 			wood: 75
 			light: 40
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -99,13 +93,11 @@ M_LMG:
 		Damage: 125
 		ValidTargets: Ground
 		Versus:
-			none: 100
 			wall: 10
 			building: 25
 			wood: 75
 			light: 40
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -125,12 +117,9 @@ M_HMG:
 		Damage: 250
 		Versus:
 			none: 25
-			wall: 100
 			building: 50
 			wood: 65
-			light: 100
 			heavy: 50
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -153,12 +142,9 @@ Fremen_L:
 		ValidTargets: Ground
 		Versus:
 			none: 25
-			wall: 100
 			building: 50
 			wood: 65
-			light: 100
 			heavy: 50
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -177,13 +163,11 @@ HMG:
 		Falloff: 100, 60, 30, 0
 		Damage: 180
 		Versus:
-			none: 100
 			wall: 10
 			building: 25
 			wood: 75
 			light: 40
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -202,13 +186,11 @@ HMGo:
 		Falloff: 100, 60, 30, 0
 		Damage: 180
 		Versus:
-			none: 100
 			wall: 10
 			building: 25
 			wood: 75
 			light: 40
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -249,12 +231,9 @@ Rocket:
 		ValidTargets: Ground
 		Versus:
 			none: 25
-			wall: 100
 			building: 50
 			wood: 65
-			light: 100
 			heavy: 50
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -285,9 +264,7 @@ Rocket:
 			wall: 50
 			building: 50
 			wood: 60
-			light: 100
 			heavy: 75
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -327,8 +304,6 @@ TowerMissile:
 			building: 60
 			wood: 65
 			light: 90
-			heavy: 100
-			concrete: 100
 			invulnerable: 0
 			cy: 30
 			harvester: 50
@@ -356,9 +331,7 @@ TowerMissile:
 			wall: 50
 			building: 50
 			wood: 60
-			light: 100
 			heavy: 75
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -385,9 +358,7 @@ TowerMissile:
 			wall: 50
 			building: 50
 			wood: 60
-			light: 100
 			heavy: 75
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -414,9 +385,7 @@ TowerMissile:
 			wall: 50
 			building: 50
 			wood: 60
-			light: 100
 			heavy: 75
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -440,15 +409,10 @@ DevBullet:
 		Damage: 650
 		Versus:
 			none: 50
-			wall: 100
 			building: 75
 			wood: 60
-			light: 100
-			heavy: 100
-			concrete: 100
 			invulnerable: 0
 			cy: 40
-			harvester: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
@@ -483,8 +447,6 @@ mtank_pri:
 			building: 60
 			wood: 65
 			light: 90
-			heavy: 100
-			concrete: 100
 			invulnerable: 0
 			cy: 30
 			harvester: 50
@@ -524,7 +486,6 @@ DeviatorMissile:
 			wood: 20
 			light: 20
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 10
 			harvester: 20
@@ -558,12 +519,9 @@ DeviatorMissile:
 		Damage: 450
 		Versus:
 			none: 125
-			wall: 100
-			building: 100
 			wood: 70
 			light: 30
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -587,13 +545,9 @@ Sound:
 		Falloff: 100, 100, 0
 		Damage: 500	#80 D2k but damages through all in path
 		Versus:
-			none: 100
 			wall: 50
 			building: 60
-			wood: 100
-			light: 100
 			heavy: 60
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -643,7 +597,6 @@ OrniBomb:
 			wood: 60
 			light: 60
 			heavy: 60
-			concrete: 100
 			invulnerable: 0
 			cy: 25
 			harvester: 60
@@ -680,7 +633,6 @@ Atomic:
 			wood: 60
 			light: 60
 			heavy: 60
-			concrete: 100
 			invulnerable: 0
 			cy: 25
 			harvester: 60
@@ -701,7 +653,6 @@ CrateNuke:
 			wood: 60
 			light: 60
 			heavy: 60
-			concrete: 100
 			invulnerable: 0
 			cy: 25
 			harvester: 60
@@ -723,7 +674,6 @@ CrateExplosion:
 			wood: 50
 			light: 40
 			heavy: 30
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -764,12 +714,9 @@ grenade:
 		Damage: 150
 		Versus:
 			none: 125
-			wall: 100
-			building: 100
 			wood: 70
 			light: 30
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -792,12 +739,9 @@ GrenDeath:
 		Damage: 150
 		Versus:
 			none: 125
-			wall: 100
-			building: 100
 			wood: 70
 			light: 30
 			heavy: 20
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25
@@ -819,8 +763,6 @@ SardDeath:
 			building: 60
 			wood: 65
 			light: 90
-			heavy: 100
-			concrete: 100
 			invulnerable: 0
 			cy: 30
 			harvester: 50
@@ -850,7 +792,6 @@ SpiceExplosion:
 			wood: 50
 			light: 40
 			heavy: 30
-			concrete: 100
 			invulnerable: 0
 			cy: 20
 			harvester: 25

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -25,7 +25,6 @@ Bazooka:
 	ReloadDelay: 40
 	Range: 3c0
 	Report: ROCKET1.WAV
-	ValidTargets: Ground
 	Projectile: Missile
 		MaximumLaunchSpeed: 281
 		Inaccuracy: 256
@@ -39,7 +38,6 @@ Bazooka:
 		Spread: 192
 		Falloff: 100, 50, 25, 0
 		Damage: 300
-		ValidTargets: Ground
 		Versus:
 			none: 8
 			wall: 75
@@ -84,14 +82,12 @@ M_LMG:
 	ReloadDelay: 40
 	Range: 2c512
 	Report: MGUN2.WAV
-	ValidTargets: Ground
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Falloff: 100, 50, 25, 0
 		Damage: 125
-		ValidTargets: Ground
 		Versus:
 			wall: 10
 			building: 25
@@ -132,14 +128,12 @@ Fremen_L:
 	Delay: 5
 	Range: 3c512
 	Report: BAZOOK2.WAV
-	ValidTargets: Ground
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
 		Damage: 250
-		ValidTargets: Ground
 		Versus:
 			none: 25
 			building: 50
@@ -214,7 +208,6 @@ Rocket:
 	ReloadDelay: 30
 	Range: 3c512
 	Report: ROCKET1.WAV
-	ValidTargets: Ground
 	Projectile: Missile
 		Inaccuracy: 256
 		Image: RPG
@@ -228,7 +221,6 @@ Rocket:
 		Spread: 160
 		Falloff: 100, 50, 25, 0
 		Damage: 250
-		ValidTargets: Ground
 		Versus:
 			none: 25
 			building: 50

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -677,18 +677,18 @@ CrateExplosion:
 
 UnitExplodeSmall:
 	Warhead@1Eff: CreateEffect
-		Explosion: building
-		ImpactSound: EXPLHG1.WAV, EXPLLG1.WAV, EXPLMD1.WAV, EXPLSML4.WAV
+		Explosion: self_destruct
+		ImpactSound: EXPLSML1.WAV
 
 UnitExplodeMed:
 	Warhead@1Eff: CreateEffect
-		Explosion: self_destruct
-		ImpactSound: EXPLMD2.WAV, EXPLSML1.WAV, EXPLSML2.WAV, EXPLSML3.WAV
+		Explosion: building
+		ImpactSound: EXPLSML2.WAV
 
 UnitExplodeLarge:
 	Warhead@1Eff: CreateEffect
 		Explosion: large_explosion
-		ImpactSound: EXPLLG2.WAV, EXPLLG3.WAV, EXPLLG5.WAV
+		ImpactSound: EXPLLG2.WAV
 
 grenade:
 	ReloadDelay: 50

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -30,7 +30,7 @@ Bazooka:
 	ValidTargets: Ground
 	Projectile: Missile
 		MaximumLaunchSpeed: 281
-		Inaccuracy: 64
+		Inaccuracy: 256
 		Image: RPG
 		HorizontalRateOfTurn: 1
 		TrailImage: bazooka_trail2
@@ -234,7 +234,7 @@ Rocket:
 	Report: ROCKET1.WAV
 	ValidTargets: Ground
 	Projectile: Missile
-		Inaccuracy: 64
+		Inaccuracy: 256
 		Image: RPG
 		HorizontalRateOfTurn: 0
 		TrailImage: bazooka_trail2

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -506,8 +506,8 @@ DeviatorMissile:
 		ContrailLength: 20
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 384
-		Falloff: 100, 60, 30, 15, 0
+		Spread: 416
+		Falloff: 100, 65, 35, 20, 0
 		Damage: 450
 		Versus:
 			none: 125
@@ -702,7 +702,7 @@ grenade:
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
+		Falloff: 100, 65, 35, 20, 0
 		Damage: 150
 		Versus:
 			none: 125

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -794,5 +794,4 @@ SpiceExplosion:
 		Size: 2,2
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
-		ImpactSound: EXPLLG5.WAV
 

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -5,8 +5,8 @@ LMG:
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 48
-		Falloff: 100, 100, 65, 30, 0
+		Spread: 128
+		Falloff: 100, 50, 25, 0
 		Damage: 125
 		Versus:
 			none: 100
@@ -38,8 +38,8 @@ Bazooka:
 		TrailInterval: 1
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage
-		Spread: 250
-		Falloff: 100, 95, 70, 50, 25, 5, 0
+		Spread: 192
+		Falloff: 100, 50, 25, 0
 		Damage: 300
 		ValidTargets: Ground
 		Versus:
@@ -67,8 +67,8 @@ Fremen_S:
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 48
-		Falloff: 100, 100, 65, 30, 0
+		Spread: 128
+		Falloff: 100, 50, 25, 0
 		Damage: 125
 		Versus:
 			none: 100
@@ -94,8 +94,8 @@ M_LMG:
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 48
-		Falloff: 100, 100, 65, 30, 0
+		Spread: 128
+		Falloff: 100, 50, 25, 0
 		Damage: 125
 		ValidTargets: Ground
 		Versus:
@@ -120,8 +120,8 @@ M_HMG:
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 48
-		Falloff: 100, 100, 65, 30, 0
+		Spread: 192
+		Falloff: 100, 50, 25, 0
 		Damage: 250
 		Versus:
 			none: 25
@@ -147,8 +147,8 @@ Fremen_L:
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 64
-		Falloff: 100, 100, 65, 30, 0
+		Spread: 192
+		Falloff: 100, 50, 25, 0
 		Damage: 250
 		ValidTargets: Ground
 		Versus:
@@ -173,8 +173,8 @@ HMG:
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Falloff: 100, 100, 65, 30, 0
+		Spread: 160
+		Falloff: 100, 60, 30, 0
 		Damage: 180
 		Versus:
 			none: 100
@@ -198,8 +198,8 @@ HMGo:
 	Projectile: Bullet
 		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Falloff: 100, 100, 65, 30, 0
+		Spread: 160
+		Falloff: 100, 60, 30, 0
 		Damage: 180
 		Versus:
 			none: 100
@@ -243,8 +243,8 @@ Rocket:
 		MaximumLaunchSpeed: 343
 		RangeLimit: 40
 	Warhead@1Dam: SpreadDamage
-		Spread: 250
-		Falloff: 100, 95, 70, 50, 25, 5, 0
+		Spread: 160
+		Falloff: 100, 50, 25, 0
 		Damage: 250
 		ValidTargets: Ground
 		Versus:
@@ -277,8 +277,8 @@ Rocket:
 		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 160
-		Falloff: 100, 100, 85, 50, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 290
 		Versus:
 			none: 20
@@ -310,14 +310,15 @@ TowerMissile:
 		Blockable: false
 		Shadow: true
 		HorizontalRateOfTurn: 1
+		RangeLimit: 50
 		Inaccuracy: 384
 		Image: MISSILE2
 		TrailImage: large_trail
 		TrailInterval: 1
 		MaximumLaunchSpeed: 320
 	Warhead@1Dam: SpreadDamage
-		Spread: 280
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 480
 		ValidTargets: Ground, Air
 		Versus:
@@ -347,8 +348,8 @@ TowerMissile:
 		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 180
-		Falloff: 100, 100, 85, 50, 15, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 270
 		Versus:
 			none: 20
@@ -376,8 +377,8 @@ TowerMissile:
 		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 180
-		Falloff: 100, 100, 85, 50, 15, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 270
 		Versus:
 			none: 20
@@ -405,8 +406,8 @@ TowerMissile:
 		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 180
-		Falloff: 100, 100, 85, 50, 15, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 270
 		Versus:
 			none: 20
@@ -434,8 +435,8 @@ DevBullet:
 		Blockable: true
 		Image: doubleblastbullet
 	Warhead@1Dam: SpreadDamage
-		Spread: 192
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 384
+		Falloff: 100, 50, 25, 0
 		Damage: 650
 		Versus:
 			none: 50
@@ -472,8 +473,8 @@ mtank_pri:
 		TrailImage: large_trail
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
-		Spread: 280
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 600
 		ValidTargets: Ground, Air
 		Versus:
@@ -501,6 +502,7 @@ DeviatorMissile:
 	InvalidTargets: Infantry, Structure
 	Projectile: Missile
 		MaximumLaunchSpeed: 281
+		RangeLimit: 40
 		Blockable: false
 		Shadow: yes
 		RateofTurn: 1
@@ -512,8 +514,8 @@ DeviatorMissile:
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		InvalidTargets: Infantry, Structure
-		Spread: 280
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 5
 		Versus:
 			none: 20
@@ -551,8 +553,8 @@ DeviatorMissile:
 		ContrailLength: 20
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 280
-		Falloff: 100, 100, 85, 65, 40, 25, 0
+		Spread: 384
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 450
 		Versus:
 			none: 125
@@ -581,8 +583,8 @@ Sound:
 		BeamDuration: 8
 		UsePlayerColor: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 96
-		Falloff: 100, 100, 100, 50, 25, 0
+		Spread: 256
+		Falloff: 100, 100, 0
 		Damage: 500	#80 D2k but damages through all in path
 		Versus:
 			none: 100
@@ -631,8 +633,8 @@ OrniBomb:
 	Projectile: GravityBomb
 		Image: BOMBS
 	Warhead@1Dam: SpreadDamage
-		Spread: 276
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 320
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 400
 		Versus:
 			none: 90
@@ -669,7 +671,7 @@ Demolish:
 Atomic:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
-		Falloff: 200, 120, 80, 60, 40, 20, 10, 0
+		Falloff: 200, 100, 50, 25, 12, 0
 		Damage: 2700	##225 in vanilla but of course is a cluster bomb instead, so damage spread out
 		Versus:
 			none: 90
@@ -690,6 +692,7 @@ Atomic:
 CrateNuke:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 500
 		Versus:
 			none: 90
@@ -710,8 +713,8 @@ CrateNuke:
 
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage
-		Spread: 276
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 320
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 200
 		Versus:
 			none: 90
@@ -756,8 +759,8 @@ grenade:
 		Image: grenade
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 200
-		Falloff: 100, 100, 100, 95, 60, 0
+		Spread: 320
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 150
 		Versus:
 			none: 125
@@ -784,8 +787,8 @@ Weathering:
 
 GrenDeath:
 	Warhead@1Dam: SpreadDamage
-		Spread: 280
-		Falloff: 100, 100, 100, 95, 60, 0
+		Spread: 320
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 150
 		Versus:
 			none: 125
@@ -807,8 +810,8 @@ GrenDeath:
 
 SardDeath:
 	Warhead@1Dam: SpreadDamage
-		Spread: 280
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 256
+		Falloff: 100, 50, 25, 0
 		Damage: 300
 		Versus:
 			none: 15
@@ -837,8 +840,8 @@ SpiceExplosion:
 		Trail: large_trail
 		Image: null
 	Warhead@1Dam: SpreadDamage
-		Spread: 480
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Spread: 320
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 75
 		Versus:
 			none: 90

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -9,7 +9,7 @@ Debris:
 		Image: shrapnel
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 150
 		Versus:
 			none: 20
@@ -43,7 +43,7 @@ Debris2:
 		TrailInterval: 2
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 250
 		Versus:
 			none: 90
@@ -77,7 +77,7 @@ Debris3:
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 150
 		Versus:
 			none: 90
@@ -111,7 +111,7 @@ Debris4:
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 100, 100, 95, 60, 25, 0
+		Falloff: 100, 60, 30, 15, 0
 		Damage: 250
 		Versus:
 			none: 90


### PR DESCRIPTION
I recently played the original quite a bit and I think our area of effect on several weapons is over the top even compared to the original, which is one of the reasons why debris are too powerful on bleed (they are being dealt with in #9615).

I tried to keep things as simple and consistent as possible, but this might need more testing and fine-tuning.
