### PR TITLE
Add *.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ mods/*/*.mdb
 /*.pdb
 /*.mdb
 /*.exe
+/*.xml
 thirdparty/download/*
 *.mmdb.gz
 


### PR DESCRIPTION
`SmarIrc4net.xml` shows up as new file all the time, which is quite annoying.

The only other .xml in the main folder is the StyleCop one, so this shouldn't cause any problems.
