### PR TITLE
Don't force SmarIrc4net to be copied to output

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -86,6 +86,7 @@
     </Reference>
     <Reference Include="SmarIrc4net">
       <HintPath>..\thirdparty\download\SmarIrc4net.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Instead, it will be implicitly included since it is a reference. This avoids pulling in the documentary .xml file.

Supersedes #9683.
