### PR TITLE
Add a common ChromeLogic base class and lint verification.

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -140,6 +140,12 @@ namespace OpenRA.Widgets
 		}
 	}
 
+	public class ChromeLogic : IDisposable
+	{
+		public void Dispose() { Dispose(true); GC.SuppressFinalize(this); }
+		protected virtual void Dispose(bool disposing) { }
+	}
+
 	public abstract class Widget
 	{
 		public readonly List<Widget> Children = new List<Widget>();
@@ -151,7 +157,7 @@ namespace OpenRA.Widgets
 		public string Width = "0";
 		public string Height = "0";
 		public string[] Logic = { };
-		public object[] LogicObjects { get; private set; }
+		public ChromeLogic[] LogicObjects { get; private set; }
 		public bool Visible = true;
 		public bool IgnoreMouseOver;
 		public bool IgnoreChildMouseOver;
@@ -244,7 +250,7 @@ namespace OpenRA.Widgets
 
 			args["widget"] = this;
 
-			LogicObjects = Logic.Select(l => Game.ModData.ObjectCreator.CreateObject<object>(l, args))
+			LogicObjects = Logic.Select(l => Game.ModData.ObjectCreator.CreateObject<ChromeLogic>(l, args))
 				.ToArray();
 
 			args.Remove("widget");
@@ -486,8 +492,7 @@ namespace OpenRA.Widgets
 
 			if (LogicObjects != null)
 				foreach (var l in LogicObjects)
-					if (l is IDisposable)
-						((IDisposable)l).Dispose();
+					l.Dispose();
 		}
 
 		public Widget GetOrNull(string id)

--- a/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTabsLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/ProductionTabsLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Cnc.Widgets.Logic
 {
-	public class ProductionTabsLogic
+	public class ProductionTabsLogic : ChromeLogic
 	{
 		readonly ProductionTabsWidget tabs;
 		readonly World world;

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -1,0 +1,53 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using OpenRA.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckChromeLogic : ILintPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning)
+		{
+			foreach (var filename in Game.ModData.Manifest.ChromeLayout)
+				CheckInner(MiniYaml.FromFile(filename), filename, emitError);
+		}
+
+		void CheckInner(List<MiniYamlNode> nodes, string filename, Action<string> emitError)
+		{
+			foreach (var node in nodes)
+			{
+				if (node.Value == null)
+					continue;
+
+				if (node.Key == "Logic")
+				{
+					var typeNames = FieldLoader.GetValue<string[]>(node.Key, node.Value.Value);
+					foreach (var typeName in typeNames)
+					{
+						var type = Game.ModData.ObjectCreator.FindType(typeName);
+						if (type == null)
+							emitError("{0} refers to a logic object `{1}` that does not exist".F(filename, typeName));
+						else if (!typeof(ChromeLogic).IsAssignableFrom(type))
+							emitError("{0} refers to a logic object `{1}` that does not inherit from ChromeLogic".F(filename, typeName));
+					}
+				}
+
+				if (node.Value.Nodes != null)
+					CheckInner(node.Value.Nodes, filename, emitError);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -704,6 +704,7 @@
     <Compile Include="Scripting\Global\LightingGlobal.cs" />
     <Compile Include="Traits\SupportPowers\ProduceActorPower.cs" />
     <Compile Include="Widgets\Logic\GlobalChatLogic.cs" />
+    <Compile Include="Lint\CheckChromeLogic.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -20,7 +20,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class AssetBrowserLogic
+	public class AssetBrowserLogic : ChromeLogic
 	{
 		static readonly string[] AllowedExtensions = { ".shp", ".r8", "tmp", ".tem", ".des", ".sno", ".int", ".jun", ".vqa" };
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -12,7 +12,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ButtonTooltipLogic
+	public class ButtonTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public ButtonTooltipLogic(Widget widget, ButtonWidget button)

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ColorPickerLogic
+	public class ColorPickerLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public ColorPickerLogic(Widget widget, World world, HSLColor initialColor, Action<HSLColor> onChange, WorldRenderer worldRenderer)

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ConnectionLogic
+	public class ConnectionLogic : ChromeLogic
 	{
 		Action onConnect, onAbort;
 		Action<string> onRetry;
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 	}
 
-	public class ConnectionFailedLogic
+	public class ConnectionFailedLogic : ChromeLogic
 	{
 		PasswordFieldWidget passwordField;
 		bool passwordOffsetAdjusted;

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -15,7 +15,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class CreditsLogic
+	public class CreditsLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public CreditsLogic(Widget widget, Action onExit)

--- a/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class DirectConnectLogic
+	public class DirectConnectLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public DirectConnectLogic(Widget widget, Action onExit, Action openLobby)

--- a/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class DisconnectWatcherLogic
+	public class DisconnectWatcherLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public DisconnectWatcherLogic(Widget widget, OrderManager orderManager)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -23,7 +23,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ActorSelectorLogic
+	public class ActorSelectorLogic : ChromeLogic
 	{
 		readonly EditorViewportControllerWidget editor;
 		readonly DropDownButtonWidget ownersDropDown;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class LayerSelectorLogic
+	public class LayerSelectorLogic : ChromeLogic
 	{
 		readonly EditorViewportControllerWidget editor;
 		readonly Ruleset modRules;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class MapEditorLogic
+	public class MapEditorLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public MapEditorLogic(Widget widget, World world, WorldRenderer worldRenderer)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class MapEditorTabsLogic
+	public class MapEditorTabsLogic : ChromeLogic
 	{
 		protected enum MenuType { Tiles, Layers, Actors }
 		protected MenuType menuType = MenuType.Tiles;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -21,7 +21,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class NewMapLogic
+	public class NewMapLogic : ChromeLogic
 	{
 		Widget panel;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SaveMapLogic
+	public class SaveMapLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public SaveMapLogic(Widget widget, Action<string> onSave, Action onExit, Map map, List<MiniYamlNode> playerDefinitions, List<MiniYamlNode> actorDefinitions)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class TileSelectorLogic
+	public class TileSelectorLogic : ChromeLogic
 	{
 		readonly EditorViewportControllerWidget editor;
 		readonly ScrollPanelWidget panel;

--- a/OpenRA.Mods.Common/Widgets/Logic/FactionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/FactionTooltipLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class FactionTooltipLogic
+	public class FactionTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public FactionTooltipLogic(Widget widget, ButtonWidget button)

--- a/OpenRA.Mods.Common/Widgets/Logic/GlobalChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GlobalChatLogic.cs
@@ -19,7 +19,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class GlobalChatLogic : IDisposable
+	class GlobalChatLogic : ChromeLogic
 	{
 		readonly ScrollPanelWidget historyPanel;
 		readonly LabelWidget historyTemplate;
@@ -149,8 +149,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		bool disposed;
-		public void Dispose()
+		protected override void Dispose(bool disposing)
 		{
+			base.Dispose(disposing);
+
 			if (disposed)
 				return;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class AddFactionSuffixLogic
+	public class AddFactionSuffixLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public AddFactionSuffixLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ClassicProductionLogic
+	public class ClassicProductionLogic : ChromeLogic
 	{
 		readonly ProductionPaletteWidget palette;
 		readonly World world;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ControlGroupLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ControlGroupLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ControlGroupLogic
+	public class ControlGroupLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public ControlGroupLogic(Widget widget, World world, WorldRenderer worldRenderer)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class DebugMenuLogic
+	public class DebugMenuLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public DebugMenuLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DiplomacyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DiplomacyLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class DiplomacyLogic
+	public class DiplomacyLogic : ChromeLogic
 	{
 		readonly World world;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -12,7 +12,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class GameInfoBriefingLogic
+	class GameInfoBriefingLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public GameInfoBriefingLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public enum IngameInfoPanel { AutoSelect, Map, Objectives, Debug }
 
-	class GameInfoLogic
+	class GameInfoLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public GameInfoLogic(Widget widget, World world, IngameInfoPanel activePanel)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class GameInfoObjectivesLogic
+	class GameInfoObjectivesLogic : ChromeLogic
 	{
 		readonly ContainerWidget template;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class GameInfoStatsLogic
+	class GameInfoStatsLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public GameInfoStatsLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class GameTimerLogic
+	public class GameTimerLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public GameTimerLogic(Widget widget, OrderManager orderManager, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class IngameCashCounterLogic
+	public class IngameCashCounterLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public IngameCashCounterLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class IngameChatLogic
+	public class IngameChatLogic : ChromeLogic
 	{
 		readonly OrderManager orderManager;
 		readonly Ruleset modRules;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class IngameMenuLogic
+	public class IngameMenuLogic : ChromeLogic
 	{
 		Widget menu;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class IngamePowerBarLogic
+	public class IngamePowerBarLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public IngamePowerBarLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class IngamePowerCounterLogic
+	public class IngamePowerCounterLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public IngamePowerCounterLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class IngameRadarDisplayLogic
+	public class IngameRadarDisplayLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public IngameRadarDisplayLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class IngameSiloBarLogic
+	public class IngameSiloBarLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public IngameSiloBarLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
@@ -12,7 +12,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class LoadIngamePerfLogic
+	public class LoadIngamePerfLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public LoadIngamePerfLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class LoadIngamePlayerOrObserverUILogic
+	public class LoadIngamePlayerOrObserverUILogic : ChromeLogic
 	{
 		bool loadingObserverWidgets = false;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
@@ -12,7 +12,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class LoadMapEditorLogic
+	public class LoadMapEditorLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public LoadMapEditorLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class MenuButtonsChromeLogic
+	public class MenuButtonsChromeLogic : ChromeLogic
 	{
 		readonly World world;
 		readonly Widget worldRoot;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ObserverShroudSelectorLogic
+	public class ObserverShroudSelectorLogic : ChromeLogic
 	{
 		readonly CameraOption combined, disableShroud;
 		readonly IOrderedEnumerable<IGrouping<int, CameraOption>> teams;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -20,7 +20,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ObserverStatsLogic
+	public class ObserverStatsLogic : ChromeLogic
 	{
 		ContainerWidget basicStatsHeaders;
 		ContainerWidget economyStatsHeaders;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SellOrderButtonLogic
+	public class SellOrderButtonLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public SellOrderButtonLogic(Widget widget, World world)
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 	}
 
-	public class RepairOrderButtonLogic
+	public class RepairOrderButtonLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public RepairOrderButtonLogic(Widget widget, World world)
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 	}
 
-	public class PowerdownOrderButtonLogic
+	public class PowerdownOrderButtonLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public PowerdownOrderButtonLogic(Widget widget, World world)
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 	}
 
-	public class BeaconOrderButtonLogic
+	public class BeaconOrderButtonLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public BeaconOrderButtonLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ProductionTooltipLogic
+	public class ProductionTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public ProductionTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, ProductionPaletteWidget palette, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
@@ -15,7 +15,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ReplayControlBarLogic
+	public class ReplayControlBarLogic : ChromeLogic
 	{
 		enum PlaybackSpeed { Regular, Slow, Fast, Maximum }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerBinLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerBinLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SupportPowerBinLogic
+	public class SupportPowerBinLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public SupportPowerBinLogic(Widget widget, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SupportPowerTooltipLogic
+	public class SupportPowerTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public SupportPowerTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, SupportPowersWidget palette, World world)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class WorldTooltipLogic
+	public class WorldTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public WorldTooltipLogic(Widget widget, World world, TooltipContainerWidget tooltipContainer, ViewportControllerWidget viewport)

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackagesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackagesLogic.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class DownloadPackagesLogic
+	public class DownloadPackagesLogic : ChromeLogic
 	{
 		static readonly string[] SizeSuffixes = { "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
 		readonly Widget panel;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class InstallFromCDLogic
+	public class InstallFromCDLogic : ChromeLogic
 	{
 		readonly string modId;
 		readonly Widget panel;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallLogic.cs
@@ -12,7 +12,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class InstallLogic : Widget
+	public class InstallLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public InstallLogic(Widget widget, string mirrorListUrl, string modId)

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallMusicLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallMusicLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class InstallMusicLogic
+	public class InstallMusicLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public InstallMusicLogic(Widget widget, string modId)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
@@ -15,7 +15,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ClientTooltipLogic
+	public class ClientTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public ClientTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, OrderManager orderManager, int clientIndex)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class KickClientLogic
+	class KickClientLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public KickClientLogic(Widget widget, string clientName, Action<bool> okPressed, Action cancelPressed)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	class KickSpectatorsLogic
+	class KickSpectatorsLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public KickSpectatorsLogic(Widget widget, string clientCount, Action okPressed, Action cancelPressed)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -21,7 +21,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class LobbyLogic
+	public class LobbyLogic : ChromeLogic
 	{
 		static readonly Action DoNothing = () => { };
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class LobbyMapPreviewLogic
+	public class LobbyMapPreviewLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		internal LobbyMapPreviewLogic(Widget widget, OrderManager orderManager, LobbyLogic lobby)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SpawnSelectorTooltipLogic
+	public class SpawnSelectorTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public SpawnSelectorTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, MapPreviewWidget preview)

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class MainMenuLogic
+	public class MainMenuLogic : ChromeLogic
 	{
 		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, None }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -18,7 +18,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class MapChooserLogic
+	public class MapChooserLogic : ChromeLogic
 	{
 		readonly Widget widget;
 		readonly DropDownButtonWidget gameModeDropdown;

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -21,7 +21,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class MissionBrowserLogic
+	public class MissionBrowserLogic : ChromeLogic
 	{
 		enum PlayingVideo { None, Info, Briefing, GameStart }
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -19,7 +19,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ModBrowserLogic
+	public class ModBrowserLogic : ChromeLogic
 	{
 		readonly Widget modList;
 		readonly ButtonWidget modTemplate;

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class MusicPlayerLogic
+	public class MusicPlayerLogic : ChromeLogic
 	{
 		readonly ScrollPanelWidget musicList;
 		readonly ScrollItemWidget itemTemplate;

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class PerfDebugLogic
+	public class PerfDebugLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public PerfDebugLogic(Widget widget)

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -22,7 +22,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ReplayBrowserLogic
+	public class ReplayBrowserLogic : ChromeLogic
 	{
 		static Filter filter = new Filter();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerBrowserLogic.cs
@@ -20,7 +20,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ServerBrowserLogic
+	public class ServerBrowserLogic : ChromeLogic
 	{
 		static readonly Action DoNothing = () => { };
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -14,7 +14,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class ServerCreationLogic
+	public class ServerCreationLogic : ChromeLogic
 	{
 		Widget panel;
 		Action onCreate;

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SettingsLogic
+	public class SettingsLogic : ChromeLogic
 	{
 		enum PanelType { Display, Audio, Input, Advanced }
 		Dictionary<PanelType, Action> leavePanelActions = new Dictionary<PanelType, Action>();

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -13,7 +13,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SimpleTooltipLogic
+	public class SimpleTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
 		public SimpleTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, Func<string> getText)

--- a/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
@@ -11,10 +11,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class TabCompletionLogic
+	public class TabCompletionLogic : ChromeLogic
 	{
 		IList<string> candidates = new List<string>();
 		int currentCandidateIndex = 0;


### PR DESCRIPTION
This makes all of our chrome logic classes inherit from a new `ChromeLogic`, and adds a lint pass that checks that all the referenced logics exist and are of the correct type.

This puts the foundations in place for the next PR, which will replace the conceptually ugly `LogicTickerWidget` with a `Tick` function on the chrome logic classes themselves.
