### PR TITLE
Increase D2k aircraft speed

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -15,7 +15,7 @@ carryall.reinforce:
 		CruiseAltitude: 2100
 		InitialFacing: 0
 		ROT: 4
-		Speed: 112
+		Speed: 144 # 112 * ~1.3 for balance reasons
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, Dune
 		RepairBuildings: repair_pad
 		RearmBuildings:
@@ -60,8 +60,8 @@ frigate:
 		Description: Supply spacecraft
 	Aircraft:
 		ROT: 1
-		Speed: 126
-		RepairBuildings: repair_pad
+		Speed: 189 # 126 * ~1.5 for balance reasons
+		RepairBuildings:
 		RearmBuildings:
 		Repulsable: False
 	-AppearsOnRadar:
@@ -83,7 +83,7 @@ ornithopter:
 		Type: light
 	Aircraft:
 		ROT: 2
-		Speed: 189
+		Speed: 224 # 189 * ~1.2 for balance reasons
 		RepairBuildings:
 		RearmBuildings:
 		Repulsable: False
@@ -102,7 +102,7 @@ ornithopter.husk:
 		Name: Ornithopter
 	Aircraft:
 		ROT: 5
-		Speed: 189
+		Speed: 224
 		RepairBuildings:
 		RearmBuildings:
 	RenderSprites:
@@ -114,7 +114,7 @@ carryall.husk:
 		Name: Carryall
 	Aircraft:
 		ROT: 4
-		Speed: 112
+		Speed: 144
 		RepairBuildings:
 		RearmBuildings:
 		CanHover: True


### PR DESCRIPTION
While I'm relatively sure that the current values are correctly or at least closely replicating the original speeds (normalized to our gamespeed), I agree with #9680 that they somewhat hamper gameplay.

I tried to chose values that don't make carryalls and ornithopters too hard to hit by missiles. The frigate's speed can be reverted once we can make them appear from the closest map border cell.
