### PR TITLE
Add Height property to BlocksProjectiles

### DIFF
--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -13,10 +13,11 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	// TODO: Add functionality like a customizable Height that is compared to projectile altitude
 	[Desc("This actor blocks bullets and missiles with 'Blockable' property.")]
 	public class BlocksProjectilesInfo : UpgradableTraitInfo
 	{
+		public readonly WDist Height = WDist.FromCells(1);
+
 		public override object Create(ActorInitializer init) { return new BlocksProjectiles(init.Self, this); }
 	}
 
@@ -27,8 +28,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public static bool AnyBlockingActorAt(World world, WPos pos)
 		{
+			var dat = world.Map.DistanceAboveTerrain(pos);
 			return world.ActorMap.GetActorsAt(world.Map.CellContaining(pos))
-				.Any(a => a.TraitsImplementing<BlocksProjectiles>().Any(Exts.IsTraitEnabled));
+				.Any(a => a.TraitsImplementing<BlocksProjectiles>()
+					.Where(t => t.Info.Height.Length >= dat.Length)
+					.Any(Exts.IsTraitEnabled));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -27,12 +27,14 @@ namespace OpenRA.Mods.Common.Traits
 		readonly DeveloperMode devMode;
 
 		readonly HealthInfo healthInfo;
+		readonly BlocksProjectilesInfo blockInfo;
 		Lazy<AttackBase> attack;
 		Lazy<BodyOrientation> coords;
 
 		public CombatDebugOverlay(Actor self)
 		{
 			healthInfo = self.Info.TraitInfoOrDefault<HealthInfo>();
+			blockInfo = self.Info.TraitInfoOrDefault<BlocksProjectilesInfo>();
 			attack = Exts.Lazy(() => self.TraitOrDefault<AttackBase>());
 			coords = Exts.Lazy(() => self.Trait<BodyOrientation>());
 
@@ -48,11 +50,23 @@ namespace OpenRA.Mods.Common.Traits
 			if (healthInfo != null)
 				wr.DrawRangeCircle(self.CenterPosition, healthInfo.Radius, Color.Red);
 
+			var wlr = Game.Renderer.WorldLineRenderer;
+
+			if (blockInfo != null)
+			{
+				var hc = Color.Orange;
+				var height = new WVec(0, 0, blockInfo.Height.Length);
+				var ha = wr.ScreenPosition(self.CenterPosition);
+				var hb = wr.ScreenPosition(self.CenterPosition + height);
+				wlr.DrawLine(ha, hb, hc);
+				wr.DrawTargetMarker(hc, ha);
+				wr.DrawTargetMarker(hc, hb);
+			}
+
 			// No armaments to draw
 			if (attack.Value == null)
 				return;
 
-			var wlr = Game.Renderer.WorldLineRenderer;
 			var c = Color.White;
 
 			// Fire ports on garrisonable structures

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -545,6 +545,7 @@
 
 ^Wall:
 	Inherits@1: ^SpriteActor
+	CombatDebugOverlay:
 	AppearsOnRadar:
 	Building:
 		Dimensions: 1,1

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -500,6 +500,7 @@ starport:
 
 wall:
 	Inherits@1: ^SpriteActor
+	CombatDebugOverlay:
 	HiddenUnderShroud:
 	Buildable:
 		Queue: Building

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -173,6 +173,7 @@
 
 ^Wall:
 	Inherits@1: ^SpriteActor
+	CombatDebugOverlay:
 	HiddenUnderShroud:
 	AppearsOnRadar:
 	Building:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -19,6 +19,7 @@ GAWALL:
 	Armor:
 		Type: Concrete
 	BlocksProjectiles:
+		Height: 640
 	Crushable:
 		CrushClasses: heavywall
 	LineBuild:
@@ -46,6 +47,8 @@ GACTWR:
 		HP: 500
 	Armor:
 		Type: Light
+	BlocksProjectiles:
+		Height: 768
 	BodyOrientation:
 		QuantizedFacings: 32
 	DetectCloaked:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -19,6 +19,7 @@ NAWALL:
 	Armor:
 		Type: Concrete
 	BlocksProjectiles:
+		Height: 640
 	Crushable:
 		CrushClasses: heavywall
 	LineBuild:

--- a/mods/ts/weapons/largeguns.yaml
+++ b/mods/ts/weapons/largeguns.yaml
@@ -6,7 +6,7 @@
 		Speed: 682
 		Image: 120mm
 		Shadow: true
-		Angle: 62
+		Angle: 75
 		Palette: ra
 	Warhead@1Dam: SpreadDamage
 		Spread: 128


### PR DESCRIPTION
`Blockable` projectiles now compare the height of potential blockers with their own distance above ground.

Default `Height` is intentionally high so the shipping mods (or mods based on them) won't be affected, unless modders consciously make use of this.
Used to give the Tick Tank the ability to shoot over walls from certain positions (reproduces original behavior).

Possible TODO (might need help with that): Visualize height in `CombatDebugOverlay`.
