### PR TITLE
Check HVA files validity at load time

### DIFF
--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -220,7 +220,7 @@ namespace OpenRA.Graphics
 			using (var s = GlobalFileSystem.Open(files.First + ".vxl"))
 				vxl = new VxlReader(s);
 			using (var s = GlobalFileSystem.Open(files.Second + ".hva"))
-				hva = new HvaReader(s);
+				hva = new HvaReader(s, files.Second + ".hva");
 			return new Voxel(this, vxl, hva);
 		}
 


### PR DESCRIPTION
Currently if you provide the game with a voxel with bogus HVA file, the game will crash [here](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/Graphics/VoxelRenderer.cs#L203) after `Util.MatrixInverse(t)` returns `null` and `Util.MatrixMultiply()` chokes on it.
That, of course, happens ingame when you create the actor, which is far from ideal.

The reason in the case I debugged ( reported by @ABrandau ) was a bogus transformation matrix.
The exception, of course, was an NRE with no information whatsoever.

This throws at load time (as soon as you start up the game), and it gives a proper exception, which will hopefully help modders find their mistake.
