### PR TITLE
use right cursor for ion and nuke

### DIFF
--- a/mods/ts/cursors.yaml
+++ b/mods/ts/cursors.yaml
@@ -146,10 +146,10 @@ Cursors:
 		goldwrench-blocked: #TODO
 			Start: 213
 			Length: 1
-		nuke:
+		ioncannon:
 			Start: 279
 			Length: 20
-		ioncannon:
+		nuke:
 			Start: 319
 			Length: 9
 		sell:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -361,6 +361,7 @@ GAPLUG:
 	RevealsShroud:
 		Range: 6c0
 	IonCannonPower:
+		Cursor: ioncannon
 		UpgradeTypes: plug.ioncannon
 		UpgradeMinEnabledLevel: 1
 		Icon: ioncannon


### PR DESCRIPTION
nuke and ion cursors where switched;
ion cannon was using default cursor
