### PR TITLE
Refactor animation classes

### DIFF
--- a/OpenRA.Game/Graphics/AnimationWithOffset.cs
+++ b/OpenRA.Game/Graphics/AnimationWithOffset.cs
@@ -18,22 +18,20 @@ namespace OpenRA.Graphics
 		public readonly Animation Animation;
 		public readonly Func<WVec> OffsetFunc;
 		public readonly Func<bool> DisableFunc;
-		public readonly Func<bool> Paused;
 		public readonly Func<WPos, int> ZOffset;
 
 		public AnimationWithOffset(Animation a, Func<WVec> offset, Func<bool> disable)
-			: this(a, offset, disable, () => false, null) { }
+			: this(a, offset, disable, null) { }
 
 		public AnimationWithOffset(Animation a, Func<WVec> offset, Func<bool> disable, int zOffset)
-			: this(a, offset, disable, () => false, _ => zOffset) { }
+			: this(a, offset, disable, _ => zOffset) { }
 
-		public AnimationWithOffset(Animation a, Func<WVec> offset, Func<bool> disable, Func<bool> pause, Func<WPos, int> zOffset)
+		public AnimationWithOffset(Animation a, Func<WVec> offset, Func<bool> disable, Func<WPos, int> zOffset)
 		{
-			this.Animation = a;
-			this.Animation.Paused = pause;
-			this.OffsetFunc = offset;
-			this.DisableFunc = disable;
-			this.ZOffset = zOffset;
+			Animation = a;
+			OffsetFunc = offset;
+			DisableFunc = disable;
+			ZOffset = zOffset;
 		}
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr, PaletteReference pal, float scale)
@@ -47,7 +45,7 @@ namespace OpenRA.Graphics
 
 		public static implicit operator AnimationWithOffset(Animation a)
 		{
-			return new AnimationWithOffset(a, null, null, null, null);
+			return new AnimationWithOffset(a, null, null, null);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Effects
 
 			if (!string.IsNullOrEmpty(info.Image))
 			{
-				anim = new Animation(world, info.Image, GetEffectiveFacing);
+				anim = new Animation(world, info.Image, new Func<int>(GetEffectiveFacing));
 				anim.PlayRepeating(info.Sequences.Random(world.SharedRandom));
 			}
 

--- a/OpenRA.Mods.Common/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RepairIndicator.cs
@@ -29,8 +29,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.building = building;
 
 			rb = building.Trait<RepairableBuilding>();
-			anim = new Animation(building.World, rb.Info.IndicatorImage);
-			anim.Paused = () => !rb.RepairActive || rb.IsTraitDisabled;
+			anim = new Animation(building.World, rb.Info.IndicatorImage, () => !rb.RepairActive || rb.IsTraitDisabled);
 
 			CycleRepairer();
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -165,7 +165,6 @@ namespace OpenRA.Mods.Common.Traits
 					var muzzleFlash = new AnimationWithOffset(muzzleAnim,
 						() => PortOffset(self, port),
 						() => false,
-						() => false,
 						p => RenderUtils.ZOffsetFromCenter(self, p, 1024));
 
 					muzzles.Add(muzzleFlash);

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -79,8 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			this.self = self;
 			image = info.Image ?? self.Info.Name;
-			anim = new Animation(self.World, image);
-			anim.Paused = () => self.World.Paused;
+			anim = new Animation(self.World, image, () => self.World.Paused);
 			anim.PlayRepeating(info.Sequence);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -46,7 +46,6 @@ namespace OpenRA.Mods.Common.Traits
 			rs.Add(new AnimationWithOffset(anim,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => !visible,
-				() => false,
 				p => ZOffsetFromCenter(self, p, 0)), info.Palette);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -69,7 +69,8 @@ namespace OpenRA.Mods.Common.Traits
 			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
-			overlay = new Animation(self.World, rs.GetImage(self));
+			overlay = new Animation(self.World, rs.GetImage(self),
+				() => (info.PauseOnLowPower && self.IsDisabled()) || !buildComplete);
 			if (info.StartSequence != null)
 				overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.StartSequence),
 					() => overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence)));
@@ -79,7 +80,6 @@ namespace OpenRA.Mods.Common.Traits
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => IsTraitDisabled || !buildComplete,
-				() => (info.PauseOnLowPower && self.IsDisabled()) || !buildComplete,
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -69,7 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 						new AnimationWithOffset(muzzleFlash,
 							() => info.IgnoreOffset ? WVec.Zero : armClosure.MuzzleOffset(self, barrel),
 							() => IsTraitDisabled || !visible[barrel],
-							() => false,
 							p => RenderUtils.ZOffsetFromCenter(self, p, 2)));
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -105,7 +105,6 @@ namespace OpenRA.Mods.Common.Traits
 			anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => IsTraitDisabled && !renderProlonged,
-				() => false,
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			var rs = self.Trait<RenderSprites>();

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -47,13 +47,13 @@ namespace OpenRA.Mods.Common.Traits
 			var body = self.Trait<BodyOrientation>();
 
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
-			overlay = new Animation(self.World, rs.GetImage(self));
+			overlay = new Animation(self.World, rs.GetImage(self),
+				() => info.PauseOnLowPower && self.IsDisabled());
 			overlay.PlayThen(info.Sequence, () => visible = false);
 
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => !visible || !buildComplete,
-				() => info.PauseOnLowPower && self.IsDisabled(),
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => turreted.TurretFacing);
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
 			rs.Add(new AnimationWithOffset(
-				DefaultAnimation, () => BarrelOffset(), () => IsTraitDisabled, () => false, p => RenderUtils.ZOffsetFromCenter(self, p, 0)));
+				DefaultAnimation, () => BarrelOffset(), () => IsTraitDisabled, p => RenderUtils.ZOffsetFromCenter(self, p, 0)));
 
 			// Restrict turret facings to match the sprite
 			turreted.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -51,7 +51,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var rs = init.Self.Trait<RenderSprites>();
 
-			DefaultAnimation = new Animation(init.World, rs.GetImage(init.Self), baseFacing);
+			Func<bool> paused = null;
+			if (info.PauseAnimationWhenDisabled)
+				paused = () => init.Self.IsDisabled() &&
+				DefaultAnimation.CurrentSequence.Name == NormalizeSequence(init.Self, Info.Sequence);
+
+			DefaultAnimation = new Animation(init.World, rs.GetImage(init.Self), baseFacing, paused);
 			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled));
 
 			if (info.StartSequence != null)
@@ -59,10 +64,6 @@ namespace OpenRA.Mods.Common.Traits
 					() => PlayCustomAnimationRepeating(init.Self, info.Sequence));
 			else
 				DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence));
-
-			if (info.PauseAnimationWhenDisabled)
-				DefaultAnimation.Paused = () =>
-					init.Self.IsDisabled() && DefaultAnimation.CurrentSequence.Name == NormalizeSequence(init.Self, Info.Sequence);
 		}
 
 		public string NormalizeSequence(Actor self, string sequence)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteRotorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteRotorOverlay.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			rotorAnim.PlayRepeating(info.Sequence);
 			rs.Add(new AnimationWithOffset(rotorAnim,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-				null, () => false, p => ZOffsetFromCenter(self, p, 1)));
+				null, p => ZOffsetFromCenter(self, p, 1)));
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => t.TurretFacing);
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 			rs.Add(new AnimationWithOffset(
-				DefaultAnimation, () => TurretOffset(self), () => IsTraitDisabled, () => false, p => RenderUtils.ZOffsetFromCenter(self, p, 1)));
+				DefaultAnimation, () => TurretOffset(self), () => IsTraitDisabled, p => RenderUtils.ZOffsetFromCenter(self, p, 1)));
 
 			// Restrict turret facings to match the sprite
 			t.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;


### PR DESCRIPTION
Specify pause function in constructors of Animation if required, and remove the unused pause function from AnimationWithOffset.

Cleanup Animation.cs and reduce code duplication.
