### PR TITLE
Fix the legacy map importer not working

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = modData;
+			Game.ModData.MountFiles();
 
 			var rules = Game.ModData.RulesetCache.Load();
 			var map = LegacyMapImporter.Import(args[1], modData.Manifest.Mod.Id, rules, Console.WriteLine);


### PR DESCRIPTION
On current bleed, I can't import red alert maps anymore.
The bad commit seems to be 95709f11578747dfc9e1869f074b8d686e645336.

(Not sure if this is the correct fix tho.)
