### PR TITLE
Revert missile explosion condition to strictly less than zero

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -788,7 +788,7 @@ namespace OpenRA.Mods.Common.Effects
 			// NOTE: High speeds might cause the missile to miss the target or fly through obstacles
 			//       In that case, big moves should probably be decomposed into multiple smaller ones with hit checks
 			var height = world.Map.DistanceAboveTerrain(pos);
-			var shouldExplode = (height.Length <= 0) // Hit the ground
+			var shouldExplode = (height.Length < 0) // Hit the ground
 				|| (relTarDist < info.CloseEnough.Length) // Within range
 				|| (info.ExplodeWhenEmpty && info.RangeLimit != 0 && ticks > info.RangeLimit) // Ran out of fuel
 				|| (info.Blockable && BlocksProjectiles.AnyBlockingActorAt(world, pos)) // Hit a wall or other blocking obstacle

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -818,7 +818,7 @@ ATWR:
 		HasMinibib: Yes
 	Turreted:
 		ROT: 255
-		Offset: 128,128,-85
+		Offset: 128,128,0
 	Armament@PRIMARY:
 		Weapon: TowerMissle
 		LocalOffset: 256,128,0, 256,-128,0


### PR DESCRIPTION
Makes broken submarine torpedos work again.

https://github.com/OpenRA/OpenRA/pull/9646#issuecomment-150830239
