### PR TITLE
Add a lint pass for map format/author/title.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -115,6 +115,8 @@ namespace OpenRA
 
 	public class Map
 	{
+		public const int MinimumSupportedMapFormat = 6;
+
 		static readonly int[][] CellCornerHalfHeights = new int[][]
 		{
 			// Flat
@@ -329,7 +331,7 @@ namespace OpenRA
 			// Use release-20110207 to convert older maps to format 4
 			// Use release-20110511 to convert older maps to format 5
 			// Use release-20141029 to convert older maps to format 6
-			if (MapFormat < 6)
+			if (MapFormat < MinimumSupportedMapFormat)
 				throw new InvalidDataException("Map format {0} is not supported.\n File: {1}".F(MapFormat, path));
 
 			var nd = yaml.ToDictionary();

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	public class CheckMapMetadata : ILintMapPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		{
+			if (map.MapFormat < Map.MinimumSupportedMapFormat)
+				emitError("Map format {0} is older than the minimum supported version {1}."
+					.F(map.MapFormat, Map.MinimumSupportedMapFormat));
+
+			if (map.Author == null)
+				emitError("Map does not define a valid author.");
+
+			if (map.Title == null)
+				emitError("Map does not define a valid title.");
+
+			if (map.Type == null)
+				emitError("Map does not define a valid type.");
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -705,6 +705,7 @@
     <Compile Include="Traits\SupportPowers\ProduceActorPower.cs" />
     <Compile Include="Widgets\Logic\GlobalChatLogic.cs" />
     <Compile Include="Lint\CheckChromeLogic.cs" />
+    <Compile Include="Lint\CheckMapMetadata.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Inspired by #9420 and others.  It doesn't make any sense for a map to not define a title or author, so this will flag the maps when they are uploaded to the resource center.
