### PR TITLE
Added a minimal debug text overlay for UI without chat

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -109,6 +109,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (e.Event == KeyInputEvent.Up)
 					return false;
 
+				if (world.Type != WorldType.Regular)
+					return false;
+
 				if (!chatChrome.IsVisible() && (e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER))
 				{
 					OpenChat();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var editorRoot = widget.Get("WORLD_ROOT");
 			Game.LoadWidget(world, "EDITOR_WORLD_ROOT", editorRoot, new WidgetArgs());
+			Game.LoadWidget(world, "CHAT_PANEL", editorRoot, new WidgetArgs());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -37,6 +37,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			rootMenu = widget;
 			rootMenu.Get<LabelWidget>("VERSION_LABEL").Text = Game.ModData.Manifest.Mod.Version;
 
+			// TODO: This will disapear when navigating into sub menus.
+			Game.LoadWidget(world, "CHAT_PANEL", rootMenu, new WidgetArgs());
+
 			// Menu buttons
 			var mainMenu = widget.Get("MAIN_MENU");
 			mainMenu.IsVisible = () => menuType == MenuType.Main;


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/9508.

Background: actually there is a way to take a screenshot. The hotkey `CTRL` + `P` works, but there was no debug text giving feedback. This adds the missing debug text to the main menu and map editor.
