### PR TITLE
Fix #9751 - Replace Selectable with CustomSelectionSize on RA barrels

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -244,8 +244,9 @@ V19.Husk:
 
 BARL:
 	Inherits: ^TechBuilding
-	Selectable:
-		Priority: 0
+	-Selectable:
+	CustomSelectionSize:
+		CustomBounds: 24,24
 	Health:
 		HP: 10
 	Explodes:
@@ -264,8 +265,9 @@ BARL:
 
 BRL3:
 	Inherits: ^TechBuilding
-	Selectable:
-		Priority: 0
+	-Selectable:
+	CustomSelectionSize:
+		CustomBounds: 24,24
 	Health:
 		HP: 10
 	Explodes:


### PR DESCRIPTION
This still allows targeting them, but you neither see their health bar on mouse-over, nor can you select them (effectively making their health bar and selection box invisible).

Fixes #9751.
