### PR TITLE
Fix harvesters teleporting through doors

### DIFF
--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (exitinfo.MoveIntoWorld)
 					{
 						if (exitinfo.ExitDelay > 0)
-							newUnit.QueueActivity(new Wait(exitinfo.ExitDelay));
+							newUnit.QueueActivity(new Wait(exitinfo.ExitDelay, false));
 
 						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
 						newUnit.QueueActivity(new AttackMoveActivity(


### PR DESCRIPTION
The `Harvester` trait has an `INotifyBlockingMove` implementation that cancels the activity queue if the current activity is `Wait`.  This interacts badly with the weapons factories in TD and TS, which make the units wait while the door opens.  On current bleed cancelling the wait and queued MoveIntoWorld makes the units instantly teleport to the exit cell, before continuing on.  This isn't visible in RA or D2K because they don't define production waits.

This works around the issue by making the production wait uncancellable.
