### PR TITLE
Fix TD SAM sites not closing after killing a target.

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -694,6 +694,7 @@ SAM:
 	Turreted:
 		ROT: 10
 		InitialFacing: 0
+		RealignDelay: -1
 	-WithSpriteBody:
 	WithTurretedSpriteBody:
 	AutoSelectionSize:


### PR DESCRIPTION
This will only work when the target was killed, or when you tell the SAM to stop.

This fix will not make the SAM close if the target is still alive and got out of range. There's a separate issue for that: #6185.

Fixes #7926.
