### PR TITLE
Attempt to reduce SpreadDamageWarhead CPU overhead

### DIFF
--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly WDist Spread = new WDist(43);
 
 		[Desc("Extra search radius beyond maximum spread. Required to ensure damage to actors with large health radius.")]
-		public readonly WDist TargetExtraSearchRadius = new WDist(2048);
+		public readonly WDist TargetExtraSearchRadius = new WDist(1536);
 
 		[Desc("Damage percentage at each range step")]
 		public readonly int[] Falloff = { 100, 37, 14, 5, 0 };

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly WDist TargetExtraSearchRadius = new WDist(2048);
 
 		[Desc("Damage percentage at each range step")]
-		public readonly int[] Falloff = { 100, 37, 14, 5, 2, 1, 0 };
+		public readonly int[] Falloff = { 100, 37, 14, 5, 0 };
 
 		[Desc("Ranges at which each Falloff step is defined. Overrides Spread.")]
 		public WDist[] Range = null;

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -65,13 +65,13 @@ namespace OpenRA.Mods.Common.Warheads
 				if (!IsValidAgainst(victim, firedBy))
 					continue;
 
-				var localModifiers = damageModifiers;
 				var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
-				if (healthInfo != null)
-				{
-					var distance = Math.Max(0, (victim.CenterPosition - pos).Length - healthInfo.Radius.Length);
-					localModifiers = localModifiers.Append(GetDamageFalloff(distance));
-				}
+				if (healthInfo == null)
+					continue;
+
+				var localModifiers = damageModifiers;
+				var distance = Math.Max(0, (victim.CenterPosition - pos).Length - healthInfo.Radius.Length);
+				localModifiers = localModifiers.Append(GetDamageFalloff(distance));
 
 				DoImpact(victim, firedBy, localModifiers);
 			}


### PR DESCRIPTION
I'm not sure how large the total positive effect on performance is (assuming there is any), but I think this is worth testing.

This basically does ~two~ three things:
- removes the 2% and 1% stages from default `Falloff`. For the majority of weapons in RA, TD and TS these stages resulted in zero damage or 1 damage point against most actors anyway, while D2k now gets its own, custom Falloffs. This reduces situations where infantry would go prone due to a single damage point, and effectively reduces the default radius that is scanned for victims from 6x to 4x `Spread`, reducing the average number of iterated actors and number of 1-damage-point `Health.InflictDamage` ops.
- `hitActors` now only enumerates actors with `HealthInfo`, which avoids iterating over and performing a pointless `DoImpact` on invulnerable actors without `Health` trait (which might actually yield significant savings when weapons with large area of effect - like nukes - are fired into an area with lots of rocks or invulnerable trees etc., but for now that's just a guess).
- reduces default `TargetExtraSearchRadius` to largest feasible health radius on any shipping mod (1c512). A larger scan radius will only be needed when we increase health radii / health boxes, and only on weapons with relatively low area of effect.
