### PR TITLE
Add replaybrowser yaml file back to d2k manifest.

### DIFF
--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -106,6 +106,7 @@ ChromeLayout:
 	./mods/d2k/chrome/missionbrowser.yaml
 	./mods/ra/chrome/confirmation-dialogs.yaml
 	./mods/ra/chrome/editor.yaml
+	./mods/ra/chrome/replaybrowser.yaml
 
 Weapons:
 	./mods/d2k/weapons.yaml


### PR DESCRIPTION
#9744 was removing stuff from d2k's mod.yaml a little too enthusiastically.
