### PR TITLE
Change aircraft's maximum pitch in TD to match the increased cruise altitude

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -401,6 +401,7 @@
 	RejectsOrders:
 	Aircraft:
 		CruiseAltitude: 2560
+		MaximumPitch: 56
 
 ^Ship:
 	Inherits@1: ^ExistsInWorld


### PR DESCRIPTION
Without this change, the C17 would not manage to get all the way down to the airfield's level, leading to a sudden drop in height, seemingly teleporting down to ground level.
