### PR TITLE
Fixed filtersButton = null return value from GetOrNull<DropDownButtonWidget>

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var refreshButton = widget.Get<ButtonWidget>("REFRESH_BUTTON");
 			refreshButton.IsDisabled = () => searchStatus == SearchStatus.Fetching || panel != PanelType.Browser;
 
-			var filtersButton = widget.GetOrNull<DropDownButtonWidget>("FILTERS_DROPDOWNBUTTON");
+			var filtersButton = widget.Get<DropDownButtonWidget>("FILTERS_DROPDOWNBUTTON");
 			filtersButton.IsDisabled = () => searchStatus == SearchStatus.Fetching || panel != PanelType.Browser;
 
 			var browserTab = widget.Get<ButtonWidget>("BROWSER_TAB");


### PR DESCRIPTION
Another inconsistency from https://github.com/OpenRA/OpenRA/pull/9744. Not really a regression, but Coverity detects it, so I made this non-optional for a clearer crash if the chrome.yaml isn't adapted.
