### PR TITLE
Fixed musicTab = null return value from GetOrNull<ButtonWidget>

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -296,7 +296,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			playersTab.IsDisabled = () => panel == PanelType.Kick || panel == PanelType.ForceStart;
 			playersTab.OnClick = () => panel = PanelType.Players;
 
-			var musicTab = lobby.GetOrNull<ButtonWidget>("MUSIC_TAB");
+			var musicTab = lobby.Get<ButtonWidget>("MUSIC_TAB");
 			musicTab.IsHighlighted = () => panel == PanelType.Music;
 			musicTab.IsDisabled = () => panel == PanelType.Kick || panel == PanelType.ForceStart;
 			musicTab.OnClick = () => panel = PanelType.Music;


### PR DESCRIPTION
Same as https://github.com/OpenRA/OpenRA/pull/9772 essentially to silence Coverity. This tab/button isn't really optional at all just like the others. Introduced by https://github.com/OpenRA/OpenRA/pull/9549.
