### PR TITLE
Fix upgrades in d2k not being producible

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -61,6 +61,7 @@ construction_yard:
 		Range: 5c768
 	Production:
 		Produces: Building, Upgrade
+	Exit:
 	Valued:
 		Cost: 2000
 	Tooltip:


### PR DESCRIPTION
On current bleed, it stops at `READY` and never finishes.
