### PR TITLE
Added Keyboard input filter to only register first key press.

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -161,7 +161,11 @@ namespace OpenRA.Platforms.Default
 								Platform.CurrentPlatform == PlatformType.Windows)
 								Game.Exit();
 							else
-								inputHandler.OnKeyInput(keyEvent);
+							{
+								// Only register initial key press
+								if (e.key.repeat == 0)
+									inputHandler.OnKeyInput(keyEvent);
+							}
 
 							break;
 						}


### PR DESCRIPTION
Fix for #9737 to prevent key repeats triggering command keys multiple times.

Currently holding keyboard short cut keys triggers every key repeat, this changes to only register on physical key press.

Closes #9737.
