### PR TITLE
Fix base range circle not being shown during building placement

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -20,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class GivesBuildableAreaInfo : TraitInfo<GivesBuildableArea> { }
 	public class GivesBuildableArea { }
 
-	public class BuildingInfo : ITraitInfo, IOccupySpaceInfo, UsesInit<LocationInit>
+	public class BuildingInfo : ITraitInfo, IOccupySpaceInfo, IPlaceBuildingDecorationInfo, UsesInit<LocationInit>
 	{
 		[Desc("Where you are allowed to place the building (Water, Clear, ...)")]
 		public readonly HashSet<string> TerrainTypes = new HashSet<string>();
@@ -114,6 +115,16 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		{
+			if (!RequiresBaseProvider)
+				yield break;
+
+			foreach (var a in w.ActorsWithTrait<BaseProvider>())
+				foreach (var r in a.Trait.RenderAfterWorld(wr))
+					yield return r;
+		}
 	}
 
 	public class Building : IOccupySpace, INotifySold, INotifyTransform, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, ITargetablePositions

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -11,14 +11,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
-using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows the player to execute build orders.", " Attach this to the player actor.")]
-	public class PlaceBuildingInfo : ITraitInfo, IPlaceBuildingDecorationInfo
+	public class PlaceBuildingInfo : ITraitInfo
 	{
 		[Desc("Palette to use for rendering the placement sprite.")]
 		[PaletteReference] public readonly string Palette = "terrain";
@@ -30,16 +29,6 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string NewOptionsNotification = "NewOptions";
 
 		public object Create(ActorInitializer init) { return new PlaceBuilding(this); }
-
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
-		{
-			if (!ai.TraitInfo<BuildingInfo>().RequiresBaseProvider)
-				yield break;
-
-			foreach (var a in w.ActorsWithTrait<BaseProvider>())
-				foreach (var r in a.Trait.RenderAfterWorld(wr))
-					yield return r;
-		}
 	}
 
 	public class PlaceBuilding : IResolveOrder


### PR DESCRIPTION
Note that the range circle is drawn below the shroud, so be sure to explore a bit before testing. This matches the behaviour as seen in release-20150614.

Fixes #9784.
