### PR TITLE
Lower GDI medic self heal speed

### DIFF
--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -51,6 +51,7 @@ MEDIC:
 	WithInfantryBody:
 		AttackSequence: heal
 	SelfHealing:
+		Ticks: 60
 	Passenger:
 		PipType: Red
 


### PR DESCRIPTION
Current self heal speed is way too fast (you need >3 e1 to kill one selfhealing medic)
