### PR TITLE
Hitshape

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,9 @@ mod_common: $(mod_common_TARGET)
 test_dll_SRCS := $(shell find OpenRA.Test/ -iname '*.cs')
 test_dll_TARGET = OpenRA.Test.dll
 test_dll_KIND = library
-test_dll_DEPS = $(game_TARGET)
+test_dll_DEPS = $(game_TARGET) $(mod_common_TARGET)
 test_dll_FLAGS = -warn:1
-test_dll_LIBS = $(COMMON_LIBS) $(game_TARGET) $(NUNIT_LIBS)
+test_dll_LIBS = $(COMMON_LIBS) $(game_TARGET) $(mod_common_TARGET) $(NUNIT_LIBS)
 PROGRAMS += test_dll
 test_dll: $(test_dll_TARGET)
 

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -1,0 +1,93 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+
+namespace OpenRA.Mods.Common.HitShapes
+{
+	public class CapsuleShape : IHitShape
+	{
+		public WDist OuterRadius { get; private set; }
+
+		[FieldLoader.Require]
+		public readonly int2 PointA;
+
+		[FieldLoader.Require]
+		public readonly int2 PointB;
+
+		public readonly WDist Radius = new WDist(426);
+
+		int2 ab;
+		int abLenSq;
+
+		public CapsuleShape() { }
+
+		public CapsuleShape(int2 a, int2 b, WDist radius)
+		{
+			PointA = a;
+			PointB = b;
+			Radius = radius;
+		}
+
+		public void Initialize()
+		{
+			ab = PointB - PointA;
+			abLenSq = ab.LengthSquared / 1024;
+
+			if (abLenSq == 0)
+				throw new YamlException("This Capsule describes a circle. Use a Circle HitShape instead.");
+
+			OuterRadius = Radius + new WDist(Math.Max(PointA.Length, PointB.Length));
+		}
+
+		public WDist DistanceFromEdge(WVec v)
+		{
+			var p = new int2(v.X, v.Y);
+
+			var t = int2.Dot(p - PointA, ab) / abLenSq;
+
+			if (t < 0)
+				return new WDist(Math.Max(0, (PointA - p).Length - Radius.Length));
+			if (t > 1024)
+				return new WDist(Math.Max(0, (PointB - p).Length - Radius.Length));
+
+			var projection = PointA + new int2(
+				(ab.X * t) / 1024,
+				(ab.Y * t) / 1024);
+
+			var distance = (projection - p).Length;
+
+			return new WDist(Math.Max(0, distance - Radius.Length));
+		}
+
+		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		{
+			return DistanceFromEdge((pos - actor.CenterPosition).Rotate(-actor.Orientation));
+		}
+
+		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		{
+			var a = actor.CenterPosition + new WVec(PointA.X, PointA.Y, 0).Rotate(actor.Orientation);
+			var b = actor.CenterPosition + new WVec(PointB.X, PointB.Y, 0).Rotate(actor.Orientation);
+
+			var offset = new WVec(a.Y - b.Y, b.X - a.X, 0);
+			offset = offset * Radius.Length / offset.Length;
+
+			var c = Color.Yellow;
+			RangeCircleRenderable.DrawRangeCircle(wr, a, Radius, 1, c, 0, c);
+			RangeCircleRenderable.DrawRangeCircle(wr, b, Radius, 1, c, 0, c);
+			wcr.DrawLine(new[] { wr.ScreenPosition(a - offset), wr.ScreenPosition(b - offset) }, 1, c);
+			wcr.DrawLine(new[] { wr.ScreenPosition(a + offset), wr.ScreenPosition(b + offset) }, 1, c);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -1,0 +1,46 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+
+namespace OpenRA.Mods.Common.HitShapes
+{
+	public class CircleShape : IHitShape
+	{
+		public WDist OuterRadius { get { return Radius; } }
+
+		[FieldLoader.Require]
+		public readonly WDist Radius = new WDist(426);
+
+		public CircleShape() { }
+
+		public CircleShape(WDist radius) { Radius = radius; }
+
+		public void Initialize() { }
+
+		public WDist DistanceFromEdge(WVec v)
+		{
+			return new WDist(Math.Max(0, v.Length - Radius.Length));
+		}
+
+		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		{
+			return DistanceFromEdge(pos - actor.CenterPosition);
+		}
+
+		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		{
+			RangeCircleRenderable.DrawRangeCircle(wr, actor.CenterPosition, Radius, 1, Color.Yellow, 0, Color.Yellow);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/HitShapes/IHitShape.cs
+++ b/OpenRA.Mods.Common/HitShapes/IHitShape.cs
@@ -1,0 +1,25 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.HitShapes
+{
+	public interface IHitShape
+	{
+		WDist OuterRadius { get; }
+
+		WDist DistanceFromEdge(WVec v);
+		WDist DistanceFromEdge(WPos pos, Actor actor);
+
+		void Initialize();
+		void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor);
+	}
+}

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -1,0 +1,80 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.HitShapes
+{
+	public class RectangleShape : IHitShape
+	{
+		public WDist OuterRadius { get; private set; }
+
+		[FieldLoader.Require]
+		public readonly int2 TopLeft;
+
+		[FieldLoader.Require]
+		public readonly int2 BottomRight;
+
+		int2 quadrantSize;
+		int2 center;
+
+		WVec[] combatOverlayVerts;
+
+		public RectangleShape() { }
+
+		public RectangleShape(int2 tl, int2 br)
+		{
+			TopLeft = tl;
+			BottomRight = br;
+		}
+
+		public void Initialize()
+		{
+			if (TopLeft.X >= BottomRight.X || TopLeft.Y >= BottomRight.Y)
+				throw new YamlException("TopLeft and BottomRight points are invalid.");
+
+			quadrantSize = (BottomRight - TopLeft) / 2;
+			center = TopLeft + quadrantSize;
+
+			OuterRadius = new WDist(Math.Max(TopLeft.Length, BottomRight.Length));
+
+			combatOverlayVerts = new WVec[]
+			{
+				new WVec(TopLeft.X, TopLeft.Y, 0),
+				new WVec(BottomRight.X, TopLeft.Y, 0),
+				new WVec(BottomRight.X, BottomRight.Y, 0),
+				new WVec(TopLeft.X, BottomRight.Y, 0)
+			};
+		}
+
+		public WDist DistanceFromEdge(WVec v)
+		{
+			var r = new int2(
+				Math.Max(Math.Abs(v.X - center.X) - quadrantSize.X, 0),
+				Math.Max(Math.Abs(v.Y - center.Y) - quadrantSize.Y, 0));
+
+			return new WDist(r.Length);
+		}
+
+		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		{
+			return DistanceFromEdge((pos - actor.CenterPosition).Rotate(-actor.Orientation));
+		}
+
+		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		{
+			var verts = combatOverlayVerts.Select(v => wr.ScreenPosition(actor.CenterPosition + v.Rotate(actor.Orientation)));
+			wcr.DrawPolygon(verts.ToArray(), 1, Color.Yellow);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Lint
 						if (!warhead.ValidTargets.Overlaps(targetable))
 							continue;
 
-						if (healthTraits.Where(x => x.Radius.Length > warhead.TargetExtraSearchRadius.Length).Any())
+						if (healthTraits.Where(x => x.Shape.OuterRadius.Length > warhead.TargetExtraSearchRadius.Length).Any())
 							emitError("Actor type `{0}` has a health radius exceeding the victim scan radius of a warhead on `{1}`!"
 								.F(actorInfo.Key, weaponInfo.Key));
 					}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -177,6 +177,10 @@
     <Compile Include="Graphics\TextRenderable.cs" />
     <Compile Include="Graphics\VoxelActorPreview.cs" />
     <Compile Include="Graphics\VoxelRenderable.cs" />
+    <Compile Include="HitShapes\IHitShape.cs" />
+    <Compile Include="HitShapes\Rectangle.cs" />
+    <Compile Include="HitShapes\Capsule.cs" />
+    <Compile Include="HitShapes\Circle.cs" />
     <Compile Include="Lint\CheckSequences.cs" />
     <Compile Include="Lint\CheckPalettes.cs" />
     <Compile Include="Lint\CheckPlayers.cs" />

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -12,7 +12,6 @@ using System;
 using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -48,12 +47,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (devMode == null || !devMode.ShowCombatGeometry)
 				return;
 
-			if (healthInfo != null)
-				RangeCircleRenderable.DrawRangeCircle(wr, self.CenterPosition, healthInfo.Radius,
-					1, Color.Red, 0, Color.Red);
-
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
 			var iz = 1 / wr.Viewport.Zoom;
+
+			if (healthInfo != null)
+				healthInfo.Shape.DrawCombatOverlay(wr, wcr, self);
 
 			if (blockInfo != null)
 			{

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -8,7 +8,9 @@
  */
 #endregion
 
+using System;
 using System.Linq;
+using OpenRA.Mods.Common.HitShapes;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -17,12 +19,38 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("HitPoints")]
 		public readonly int HP = 0;
-
-		[Desc("Physical size of the unit used for damage calculations. Impacts within this radius apply full damage.")]
-		public readonly WDist Radius = new WDist(426);
-
 		[Desc("Trigger interfaces such as AnnounceOnKill?")]
 		public readonly bool NotifyAppliedDamage = true;
+
+		[FieldLoader.LoadUsing("LoadShape")]
+		public readonly IHitShape Shape;
+
+		static object LoadShape(MiniYaml yaml)
+		{
+			IHitShape ret;
+
+			var shapeNode = yaml.Nodes.Find(n => n.Key == "Shape");
+			var shape = shapeNode != null ? shapeNode.Value.Value : string.Empty;
+
+			if (!string.IsNullOrEmpty(shape))
+			{
+				ret = Game.CreateObject<IHitShape>(shape + "Shape");
+
+				try
+				{
+					FieldLoader.Load(ret, shapeNode.Value);
+				}
+				catch (YamlException e)
+				{
+					throw new YamlException("HitShape {0}: {1}".F(shape, e.Message));
+				}
+			}
+			else
+				ret = new CircleShape();
+
+			ret.Initialize();
+			return ret;
+		}
 
 		public virtual object Create(ActorInitializer init) { return new Health(init, this); }
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2788,6 +2788,25 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Refactored Health.Radius to HitShapes
+				if (engineVersion < 20151227)
+				{
+					if (node.Key.StartsWith("Health"))
+					{
+						var radius = node.Value.Nodes.FirstOrDefault(x => x.Key == "Radius");
+						if (radius != null)
+						{
+							var radiusValue = FieldLoader.GetValue<string>("Radius", radius.Value.Value);
+							node.Value.Nodes.Add(new MiniYamlNode("Shape", "Circle"));
+
+							var shape = node.Value.Nodes.First(x => x.Key == "Shape");
+							shape.Value.Nodes.Add(new MiniYamlNode("Radius", radiusValue));
+
+							node.Value.Nodes.Remove(radius);
+						}
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Warheads
 					continue;
 
 				// If the impact position is within any actor's health radius, we have a direct hit
-				if ((unit.CenterPosition - pos).LengthSquared <= healthInfo.Radius.LengthSquared)
+				if ((unit.CenterPosition - pos).LengthSquared <= healthInfo.Shape.OuterRadius.LengthSquared)
 					return true;
 			}
 

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -66,9 +66,8 @@ namespace OpenRA.Mods.Common.Warheads
 				if (healthInfo == null)
 					continue;
 
-				var localModifiers = damageModifiers;
-				var distance = Math.Max(0, (victim.CenterPosition - pos).Length - healthInfo.Radius.Length);
-				localModifiers = localModifiers.Append(GetDamageFalloff(distance));
+				var distance = healthInfo.Shape.DistanceFromEdge(pos, victim);
+				var localModifiers = damageModifiers.Append(GetDamageFalloff(distance.Length));
 
 				DoImpact(victim, firedBy, localModifiers);
 			}

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common
 				var actorWidth = 0;
 				var healthInfo = currActor.Info.TraitInfoOrDefault<HealthInfo>();
 				if (healthInfo != null)
-					actorWidth = healthInfo.Radius.Length;
+					actorWidth = healthInfo.Shape.OuterRadius.Length;
 
 				var projection = MinimumPointLineProjection(lineStart, lineEnd, currActor.CenterPosition);
 				var distance = (currActor.CenterPosition - projection).HorizontalLength;

--- a/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
@@ -1,0 +1,95 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using NUnit.Framework;
+using OpenRA.Mods.Common.HitShapes;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	public class ShapeTest
+	{
+		IHitShape shape;
+
+		[TestCase(TestName = "CircleShape reports accurate distance")]
+		public void Circle()
+		{
+			shape = new CircleShape(new WDist(1234));
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(100, 100, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(1000, 0, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(2000, 2000, 0)).Length,
+				Is.EqualTo(1594));
+
+			Assert.That(new CircleShape(new WDist(73))
+				.DistanceFromEdge(new WVec(150, -100, 0)).Length,
+				Is.EqualTo(107));
+
+			Assert.That(new CircleShape(new WDist(55))
+				.DistanceFromEdge(new WVec(30, -45, 0)).Length,
+				Is.EqualTo(0));
+		}
+
+		[TestCase(TestName = "CapsuleShape report accurate distance")]
+		public void Capsule()
+		{
+			shape = new CapsuleShape(new int2(-50, 0), new int2(500, 235), new WDist(50));
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(300, 100, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-50, 0, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(518, 451, 0)).Length,
+				Is.EqualTo(166));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-50, -50, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-41, 97, 0)).Length,
+				Is.EqualTo(35));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(339, 41, 0)).Length,
+				Is.EqualTo(64));
+		}
+
+		[TestCase(TestName = "RectangleShape report accurate distance")]
+		public void Rectangle()
+		{
+			shape = new RectangleShape(new int2(-123, -456), new int2(100, 100));
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, 50, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(0, 200, 0)).Length,
+				Is.EqualTo(100));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(123, 0, 0)).Length,
+				Is.EqualTo(24));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, -400, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1000, -400, 0)).Length,
+				Is.EqualTo(877));
+		}
+	}
+}

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -49,6 +49,7 @@
     <Compile Include="OpenRA.Game\MiniYamlTest.cs" />
     <Compile Include="OpenRA.Game\ActorInfoTest.cs" />
     <Compile Include="OpenRA.Game\CoordinateTest.cs" />
+    <Compile Include="OpenRA.Mods.Common\ShapeTest.cs" />
     <Compile Include="OpenRA.Game\OrderTest.cs" />
     <Compile Include="OpenRA.Game\PlatformTest.cs" />
   </ItemGroup>
@@ -56,6 +57,11 @@
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">
       <Project>{0dfb103f-2962-400f-8c6d-e2c28ccba633}</Project>
       <Name>OpenRA.Game</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\OpenRA.Mods.Common\OpenRA.Mods.Common.csproj">
+      <Project>{fe6c8cc0-2f07-442a-b29f-17617b3b7fc6}</Project>
+      <Name>OpenRA.Mods.Common</Name>
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -163,7 +163,8 @@
 	Inherits@2: ^GainsExperience
 	Inherits@3: ^SpriteActor
 	Health:
-		Radius: 128
+		Shape: Circle
+			Radius: 128
 	Armor:
 		Type: None
 	RevealsShroud:
@@ -286,8 +287,9 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Health:
-		Radius: 128
 		HP: 1000
+		Shape: Circle
+			Radius: 128
 	Armor:
 		Type: Wood
 	Buildable:
@@ -339,8 +341,9 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Health:
-		Radius: 427
 		HP: 300
+		Shape: Circle
+			Radius: 427
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -160,7 +160,8 @@
 	Inherits@2: ^GainsExperience
 	Inherits@3: ^SpriteActor
 	Health:
-		Radius: 96
+		Shape: Circle
+			Radius: 96
 	Armor:
 		Type: none
 	RevealsShroud:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -165,8 +165,9 @@
 	Inherits@3: ^SpriteActor
 	DrawLineToTarget:
 	Health:
-		Radius: 128
 		HP: 25
+		Shape: Circle
+			Radius: 128
 	Armor:
 		Type: None
 	RevealsShroud:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -591,7 +591,8 @@ Ant:
 		VisualBounds: 30,30,0,-2
 	Health:
 		HP: 750
-		Radius: 469
+		Shape: Circle
+			Radius: 469
 	Mobile:
 		Speed: 99
 		ROT: 12

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -211,8 +211,9 @@ DOGGIE:
 	Tooltip:
 		Name: Tiberian Fiend
 	Health:
-		Radius: 213
 		HP: 250
+		Shape: Circle
+			Radius: 213
 	PoisonedByTiberium:
 		Weapon: TiberiumHeal
 	Valued:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -231,8 +231,9 @@
 	Inherits@3: ^SpriteActor
 	DrawLineToTarget:
 	Health:
-		Radius: 128
 		HP: 50
+		Shape: Circle
+			Radius: 128
 	Armor:
 		Type: None
 	Valued:
@@ -518,7 +519,8 @@
 	Inherits@2: ^SpriteActor
 	DrawLineToTarget:
 	Health:
-		Radius: 256
+		Shape: Circle
+			Radius: 256
 	Armor:
 		Type: Light
 	Mobile:


### PR DESCRIPTION
Final part of https://github.com/OpenRA/OpenRA/issues/6820, new shapes added: Circle, Capsule, Rectangle.

demonstration with arbitrary values:

```
MCV:
    Health:
        HP: 600
        Shape: Capsule
            Radius: 426
            Vertices: 0, -512, 0, 512
```

![hit-a](https://cloud.githubusercontent.com/assets/1812087/10826815/731242ce-7e63-11e5-86be-14acc1f38463.jpg)
![hit-b](https://cloud.githubusercontent.com/assets/1812087/10826817/7528691c-7e63-11e5-9f1b-6187294ecad2.jpg)

```
4TNK:
    Health:
        HP: 900
        Shape: Rectangle
            Vertices: -512, -512, 512, 512
```

```
AFLD:
    Health:
        HP: 1000
        Shape: Rectangle
            Vertices: -1280,-384, 1280, 1024
```

![hit-c](https://cloud.githubusercontent.com/assets/1812087/10826822/7725fffe-7e63-11e5-94fa-6335382f45ea.jpg)
