### PR TITLE
Several fixes for cloak behavior

### DIFF
--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (target.IsDead)
 					return;
 
-				if (cloak != null && cloak.Info.UncloakOnDemolish)
+				if (cloak != null && cloak.Info.UncloakOn.HasFlag(UncloakType.Demolish))
 					cloak.Uncloak();
 
 				for (var f = 0; f < flashes; f++)

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled || cargo.IsEmpty(self))
 				return NextActivity;
 
-			if (cloak != null && cloak.Info.UncloakOnUnload)
+			if (cloak != null && cloak.Info.UncloakOn.HasFlag(UncloakType.Unload))
 				cloak.Uncloak();
 
 			var actor = cargo.Peek(self);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2830,6 +2830,52 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20160701 && depth == 1 && node.Key.StartsWith("Cloak"))
+				{
+					var defaultCloakType = Traits.UncloakType.Attack
+						| Traits.UncloakType.Unload | Traits.UncloakType.Infiltrate | Traits.UncloakType.Demolish;
+
+					// Merge Uncloak types
+					var t = defaultCloakType;
+					for (var i = node.Value.Nodes.Count - 1; i >= 0; i--)
+					{
+						var n = node.Value.Nodes[i];
+						var v = string.Compare(n.Value.Value, "true", true) == 0;
+						Traits.UncloakType flag;
+						if (n.Key == "UncloakOnAttack")
+							flag = Traits.UncloakType.Attack;
+						else if (n.Key == "UncloakOnMove")
+							flag = Traits.UncloakType.Move;
+						else if (n.Key == "UncloakOnUnload")
+							flag = Traits.UncloakType.Unload;
+						else if (n.Key == "UncloakOnInfiltrate")
+							flag = Traits.UncloakType.Infiltrate;
+						else if (n.Key == "UncloakOnDemolish")
+							flag = Traits.UncloakType.Demolish;
+						else
+							continue;
+						t = v ? t | flag : t & ~flag;
+						node.Value.Nodes.Remove(n);
+					}
+
+					if (t != defaultCloakType)
+					{
+						Console.WriteLine("\t\tCloak type: " + t.ToString());
+						var ts = new List<string>();
+						if (t.HasFlag(Traits.UncloakType.Attack))
+							ts.Add("Attack");
+						if (t.HasFlag(Traits.UncloakType.Unload))
+							ts.Add("Unload");
+						if (t.HasFlag(Traits.UncloakType.Infiltrate))
+							ts.Add("Infiltrate");
+						if (t.HasFlag(Traits.UncloakType.Demolish))
+							ts.Add("Demolish");
+						if (t.HasFlag(Traits.UncloakType.Move))
+							ts.Add("Move");
+						node.Value.Nodes.Add(new MiniYamlNode("UncloakOn", ts.JoinWith(", ")));
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.RA.Activities
 			if (!validStances.HasStance(stance))
 				return;
 
-			if (cloak != null && cloak.Info.UncloakOnInfiltrate)
+			if (cloak != null && cloak.Info.UncloakOn.HasFlag(UncloakType.Infiltrate))
 				cloak.Uncloak();
 
 			foreach (var t in target.TraitsImplementing<INotifyInfiltrated>())

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -251,7 +251,7 @@ saboteur:
 		CloakDelay: 85
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
-		UncloakOnMove: true
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
 		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: SaboteurVoice

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -458,7 +458,7 @@ HIJACKER:
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 120
-		UncloakOnMove: true
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
 		CloakTypes: Cloak, Hijacker
 		IsPlayerPalette: true
 	Mobile:
@@ -538,7 +538,7 @@ SNIPER:
 		CloakDelay: 120
 		CloakSound:
 		UncloakSound:
-		UncloakOnMove: true
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
 		IsPlayerPalette: true
 	DetectCloaked:
 		CloakTypes: Cloak, Hijacker

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -111,6 +111,9 @@
 		InitialDelay: 0
 		CloakDelay: 90
 		IsPlayerPalette: true
+		CloakSound: cloak5.aud
+		UncloakSound: cloak5.aud
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
 
 ^Building:
 	Inherits@1: ^BasicBuilding
@@ -216,6 +219,9 @@
 		InitialDelay: 0
 		CloakDelay: 90
 		IsPlayerPalette: true
+		CloakSound: cloak5.aud
+		UncloakSound: cloak5.aud
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
 	Health:
 		Shape: Circle
 			Radius: 363
@@ -319,6 +325,9 @@
 		InitialDelay: 0
 		CloakDelay: 90
 		IsPlayerPalette: true
+		CloakSound: cloak5.aud
+		UncloakSound: cloak5.aud
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
 
 ^Soldier:
 	Inherits: ^Infantry
@@ -420,6 +429,9 @@
 		InitialDelay: 0
 		CloakDelay: 90
 		IsPlayerPalette: true
+		CloakSound: cloak5.aud
+		UncloakSound: cloak5.aud
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
 	MustBeDestroyed:
 	RenderSprites:
 	ThrowsShrapnel:
@@ -499,6 +511,15 @@
 	MustBeDestroyed:
 	RenderVoxels:
 	WithVoxelBody:
+	Cloak@CLOAKGENERATOR:
+		UpgradeTypes: cloakgenerator
+		UpgradeMinEnabledLevel: 1
+		InitialDelay: 0
+		CloakDelay: 90
+		IsPlayerPalette: true
+		CloakSound: cloak5.aud
+		UncloakSound: cloak5.aud
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
 
 ^Helicopter:
 	Inherits: ^Aircraft
@@ -712,6 +733,9 @@
 		InitialDelay: 0
 		CloakDelay: 90
 		IsPlayerPalette: true
+		CloakSound: cloak5.aud
+		UncloakSound: cloak5.aud
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
 	ThrowsShrapnel:
 		Weapons: SmallDebris
 		Pieces: 3, 7

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -282,6 +282,7 @@ STNK:
 		CloakSound: cloak5.aud
 		UncloakSound: cloak5.aud
 		IsPlayerPalette: true
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
 	Armament:
 		Weapon: Dragon
 		LocalOffset: 213,43,128, 213,-43,128


### PR DESCRIPTION
- Reworked the cloak class
  - Removed code duplication when granting upgrades
  - Use explicit interface implementations where possible
  - Added optional `UncloakOnDamage` which uncloaks actors when at least one tick damage taken
  - Play sound when being cloaked by an upgrade
  - Don't play sounds when cloaked by another cloaking trait
  - Uncloak actors when `UncloakOnAttack==true` and they are charging
  - Refactored all loose `UncloakOn*` booleans and merged them into one enum
- Extended/Reworked TS cloaking behavior
  - Cloak Aircraft via cloaking generator
  - Uncloak actors and buildings on damage taken
  - Added Sounds for cloaking
