### PR TITLE
Fix Giant Ants and Zombies not being able to attack diagonally

### DIFF
--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -228,7 +228,7 @@ Demolish:
 
 Claw:
 	ReloadDelay: 30
-	Range: 1c0
+	Range: 1c512
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
@@ -244,7 +244,7 @@ Claw:
 
 Mandible:
 	ReloadDelay: 10
-	Range: 1c0
+	Range: 1c512
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
As described in #9331, melee ants and zombies couldn't attack diagonal directions. This was fixed by setting their attack range to 1 cell and a half.
