### PR TITLE
Add infantry stealth detection to D2k

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -205,6 +205,8 @@
 	Guard:
 		Voice: Guard
 	Guardable:
+	DetectCloaked:
+		Range: 1c384
 	DeathSounds:
 		DeathTypes: ExplosionDeath, SoundDeath, SmallExplosionDeath, BulletDeath
 	MustBeDestroyed:


### PR DESCRIPTION
So they can detect fremen, saboteurs and stealth raiders.

Note:
- the radius needs to be a bit larger than 1 cell to make sure the subcell doesn't matter that much
