### PR TITLE
Per-warhead WarheadDebugOverlay colors

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			public readonly WPos CenterPosition;
 			public readonly WDist[] Range;
+			public readonly Color Color;
 			public int Time;
 
 			public WDist OuterRange
@@ -36,10 +37,11 @@ namespace OpenRA.Mods.Common.Traits
 				get { return Range[Range.Length - 1]; }
 			}
 
-			public WHImpact(WPos pos, WDist[] range, int time)
+			public WHImpact(WPos pos, WDist[] range, int time, Color color)
 			{
 				CenterPosition = pos;
 				Range = range;
+				Color = color;
 				Time = time;
 			}
 		}
@@ -52,9 +54,9 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public void AddImpact(WPos pos, WDist[] range)
+		public void AddImpact(WPos pos, WDist[] range, Color color)
 		{
-			impacts.Add(new WHImpact(pos, range, info.DisplayDuration));
+			impacts.Add(new WHImpact(pos, range, info.DisplayDuration, color));
 		}
 
 		public void RenderAfterWorld(WorldRenderer wr, Actor self)
@@ -64,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 				var alpha = 255.0f * i.Time / info.DisplayDuration;
 				var rangeStep = alpha / i.Range.Length;
 
-				wr.DrawRangeCircle(i.CenterPosition, i.OuterRange, Color.FromArgb((int)alpha, Color.Red));
+				wr.DrawRangeCircle(i.CenterPosition, i.OuterRange, Color.FromArgb((int)alpha, i.Color));
 
 				foreach (var r in i.Range)
 				{
@@ -72,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 					var br = wr.ScreenPosition(i.CenterPosition + new WVec(r.Length, r.Length, 0));
 					var rect = RectangleF.FromLTRB(tl.X, tl.Y, br.X, br.Y);
 
-					Game.Renderer.WorldLineRenderer.FillEllipse(rect, Color.FromArgb((int)alpha, Color.Red));
+					Game.Renderer.WorldLineRenderer.FillEllipse(rect, Color.FromArgb((int)alpha, i.Color));
 
 					alpha -= rangeStep;
 				}

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Warheads
 			{
 				var devMode = world.LocalPlayer.PlayerActor.TraitOrDefault<DeveloperMode>();
 				if (devMode != null && devMode.ShowCombatGeometry)
-					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Spread);
+					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Spread, DebugOverlayColor);
 			}
 
 			var range = Spread[0];

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Warheads
 			{
 				var devMode = world.LocalPlayer.PlayerActor.TraitOrDefault<DeveloperMode>();
 				if (devMode != null && devMode.ShowCombatGeometry)
-					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Range);
+					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Range, DebugOverlayColor);
 			}
 
 			// This only finds actors where the center is within the search radius,

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -32,6 +33,9 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Delay in ticks before applying the warhead effect.", "0 = instant (old model).")]
 		public readonly int Delay = 0;
 		int IWarhead.Delay { get { return Delay; } }
+
+		[Desc("The color used for this warhead's visualization in the world's `WarheadDebugOverlay` trait.")]
+		public readonly Color DebugOverlayColor = Color.Red;
 
 		public bool IsValidTarget(IEnumerable<string> targetTypes)
 		{

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -581,6 +581,7 @@ Heal:
 		Falloff: 100, 100, 0
 		Damage: -200
 		ValidTargets: Infantry
+		DebugOverlayColor: 00FF00
 
 WormJaw:
 	ReloadDelay: 10

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -199,6 +199,7 @@ Heal:
 		Spread: 213
 		Damage: -50
 		ValidTargets: Infantry
+		DebugOverlayColor: 00FF00
 
 Repair:
 	ReloadDelay: 80
@@ -211,6 +212,7 @@ Repair:
 		Spread: 213
 		Damage: -20
 		ValidTargets: Repair
+		DebugOverlayColor: 00FF00
 
 Crush:
 	Warhead@1Dam: SpreadDamage

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -6,6 +6,7 @@ Heal:
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
+		DebugOverlayColor: 00FF00
 		Spread: 213
 		Damage: -50
 		ValidTargets: Infantry
@@ -18,6 +19,7 @@ Repair:
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
+		DebugOverlayColor: 00FF00
 		Spread: 213
 		Damage: -50
 		ValidTargets: Repair


### PR DESCRIPTION
This allows any warhead to provide its own color, such as healing warheads being green.
The test commit changes the E1 in TS to use a cyan-ish color.

Inspired by @deniz1a's comment [here](https://github.com/OpenRA/OpenRA/pull/9465#issuecomment-148508283).

![Outdated gif](http://i.imgur.com/OlwlFVA.gif)
![newer](http://i.imgur.com/x6OyVao.gif)
