### PR TITLE
Fix (HealthPercentage)DamageWarheads ignoring stances.

### DIFF
--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -65,6 +65,9 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public virtual void DoImpact(Actor victim, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
+			if (!IsValidAgainst(victim, firedBy))
+				return;
+
 			var damage = Util.ApplyPercentageModifiers(Damage, damageModifiers.Append(DamageVersus(victim)));
 			victim.InflictDamage(firedBy, damage, this);
 		}

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -42,6 +42,9 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public override void DoImpact(Actor victim, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
+			if (!IsValidAgainst(victim, firedBy))
+				return;
+
 			var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
 			if (healthInfo == null)
 				return;

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -62,9 +62,6 @@ namespace OpenRA.Mods.Common.Warheads
 
 			foreach (var victim in hitActors)
 			{
-				if (!IsValidAgainst(victim, firedBy))
-					continue;
-
 				var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
 				if (healthInfo == null)
 					continue;


### PR DESCRIPTION
How come noone noticed this before, I wonder... target validity was never checked at these two compared to `SpreadDamageWarhead`.

Fixes  #9107.
