### PR TITLE
Detach some event handlers

### DIFF
--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -18,11 +18,13 @@ namespace OpenRA.Graphics
 		readonly TerrainSpriteLayer terrain;
 		readonly Theater theater;
 		readonly CellLayer<TerrainTile> mapTiles;
+		readonly CellLayer<byte> mapHeight;
 
 		public TerrainRenderer(World world, WorldRenderer wr)
 		{
 			theater = wr.Theater;
 			mapTiles = world.Map.MapTiles.Value;
+			mapHeight = world.Map.MapHeight.Value;
 
 			terrain = new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha,
 				wr.Palette("terrain"), wr.World.Type != WorldType.Editor);
@@ -30,8 +32,8 @@ namespace OpenRA.Graphics
 			foreach (var cell in world.Map.AllCells)
 				UpdateCell(cell);
 
-			world.Map.MapTiles.Value.CellEntryChanged += UpdateCell;
-			world.Map.MapHeight.Value.CellEntryChanged += UpdateCell;
+			mapTiles.CellEntryChanged += UpdateCell;
+			mapHeight.CellEntryChanged += UpdateCell;
 		}
 
 		public void UpdateCell(CPos cell)
@@ -48,6 +50,8 @@ namespace OpenRA.Graphics
 
 		public void Dispose()
 		{
+			mapTiles.CellEntryChanged -= UpdateCell;
+			mapHeight.CellEntryChanged -= UpdateCell;
 			terrain.Dispose();
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -207,6 +207,8 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var kv in spriteLayers.Values)
 				kv.Dispose();
 
+			Map.MapResources.Value.CellEntryChanged -= UpdateCell;
+
 			disposed = true;
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -294,6 +294,8 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var kv in spriteLayers.Values)
 				kv.Dispose();
 
+			RenderContent.CellEntryChanged -= UpdateSpriteLayers;
+
 			disposed = true;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -217,17 +217,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 			}
 
-			Game.OnRemoteDirectConnect += (host, port) =>
+			Game.OnRemoteDirectConnect += OnRemoteDirectConnect;
+		}
+
+		void OnRemoteDirectConnect(string host, int port)
+		{
+			menuType = MenuType.None;
+			Ui.OpenWindow("MULTIPLAYER_PANEL", new WidgetArgs
 			{
-				menuType = MenuType.None;
-				Ui.OpenWindow("MULTIPLAYER_PANEL", new WidgetArgs
-				{
-					{ "onStart", RemoveShellmapUI },
-					{ "onExit", () => menuType = MenuType.Main },
-					{ "directConnectHost", host },
-					{ "directConnectPort", port },
-				});
-			};
+				{ "onStart", RemoveShellmapUI },
+				{ "onExit", () => menuType = MenuType.Main },
+				{ "directConnectHost", host },
+				{ "directConnectPort", port },
+			});
 		}
 
 		void LoadMapIntoEditor(Map map)
@@ -361,6 +363,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				"",
 				OpenSkirmishLobbyPanel,
 				() => { Game.CloseServer(); menuType = MenuType.Main; });
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+				Game.OnRemoteDirectConnect -= OnRemoteDirectConnect;
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -442,5 +442,12 @@ namespace OpenRA.Mods.Common.Widgets
 			var v = (int)((p.Y - mapRect.Y) / previewScale) + world.Map.Bounds.Top;
 			return new MPos(u, v).ToCPos(world.Map);
 		}
+
+		public override void Removed()
+		{
+			base.Removed();
+			world.Map.MapTiles.Value.CellEntryChanged -= UpdateTerrainCell;
+			world.Map.CustomTerrain.CellEntryChanged -= UpdateTerrainCell;
+		}
 	}
 }


### PR DESCRIPTION
Some classes attach event handlers to classes that live longer than they do, thus they end up extending their lifetime beyond what we normally expect because the event handler reference keeps them alive.

This leads to a few "memory leak" style scenarios where we don't reclaim memory because it still has references. Explicitly removing the event handlers when these classes are done with prevents this problem.

Fixes #9841.
