### PR TITLE
Allow building on tiles 107 and 108

### DIFF
--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -3116,12 +3116,12 @@ Templates:
 		Category: Debris
 		Tiles:
 			0: Rough
-			1: Rough
-			2: Rough
-			3: Rough
-			4: Rough
-			5: Rough
-			6: Rough
+			1: Clear
+			2: Clear
+			3: Clear
+			4: Clear
+			5: Clear
+			6: Clear
 			7: Clear
 	Template@108:
 		Id: 108
@@ -3130,11 +3130,11 @@ Templates:
 		Category: Debris
 		Tiles:
 			0: Clear
-			1: Rough
-			2: Rough
-			3: Rough
-			4: Rough
-			5: Rough
+			1: Clear
+			2: Clear
+			3: Clear
+			4: Clear
+			5: Clear
 	Template@109:
 		Id: 109
 		Images: p13.sno

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -3110,12 +3110,12 @@ Templates:
 		Category: Debris
 		Tiles:
 			0: Rough
-			1: Rough
-			2: Rough
-			3: Rough
-			4: Rough
-			5: Rough
-			6: Rough
+			1: Clear
+			2: Clear
+			3: Clear
+			4: Clear
+			5: Clear
+			6: Clear
 			7: Clear
 	Template@108:
 		Id: 108
@@ -3124,11 +3124,11 @@ Templates:
 		Category: Debris
 		Tiles:
 			0: Clear
-			1: Rough
-			2: Rough
-			3: Rough
-			4: Rough
-			5: Rough
+			1: Clear
+			2: Clear
+			3: Clear
+			4: Clear
+			5: Clear
 	Template@109:
 		Id: 109
 		Images: p13.tem


### PR DESCRIPTION
in the snow and temperat tilesets.
![debris](https://cloud.githubusercontent.com/assets/7704140/10890071/28172f1a-8196-11e5-9137-0a5538e0f88f.png)

Note: I left the top right corner as `Rough`, as there are stones:
![debris_marked](https://cloud.githubusercontent.com/assets/7704140/10890100/5f86ad36-8196-11e5-85a2-0ba7634debf8.png)

Fixes #9847 .
