### PR TITLE
Fix viceroids being spawned by crushed infantry

### DIFF
--- a/OpenRA.Mods.RA/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.RA/Traits/SpawnActorOnDeath.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.RA.Traits
 				return;
 
 			var warhead = e.Warhead as DamageWarhead;
-			if (info.DeathType != null && warhead != null && !warhead.DamageTypes.Contains(info.DeathType))
+			if (info.DeathType != null && (warhead == null || !warhead.DamageTypes.Contains(info.DeathType)))
 				return;
 
 			self.World.AddFrameEndTask(w =>


### PR DESCRIPTION
Fixes #9831.

The bug was triggered when infantry was killed without a warhead, [as crushing does](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Crushable.cs#L64).
