### PR TITLE
Handle mouse up event in default editor brush (instead of mouse down)

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -89,8 +89,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button == MouseButton.Right)
 			{
-				editorWidget.ClearBrush();
-				return true;
+				if (mi.Event == MouseInputEvent.Up)
+				{
+					editorWidget.ClearBrush();
+					return true;
+				}
+
+				return false;
 			}
 
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -55,12 +55,11 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			// Exclusively uses mouse wheel and right mouse buttons, but nothing else
 			// Mouse move events are important for tooltips, so we always allow these through
-			if (mi.Button != MouseButton.Right && mi.Event != MouseInputEvent.Move && mi.Event != MouseInputEvent.Scroll)
+			if ((mi.Button != MouseButton.Right && mi.Event != MouseInputEvent.Move && mi.Event != MouseInputEvent.Scroll) ||
+				mi.Event == MouseInputEvent.Down)
 				return false;
 
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
-			if (mi.Event == MouseInputEvent.Up)
-				return true;
 
 			var underCursor = editorLayer.PreviewsAt(worldRenderer.Viewport.ViewToWorldPx(mi.Location))
 				.FirstOrDefault();

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -64,8 +64,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button == MouseButton.Right)
 			{
-				editorWidget.ClearBrush();
-				return true;
+				if (mi.Event == MouseInputEvent.Up)
+				{
+					editorWidget.ClearBrush();
+					return true;
+				}
+
+				return false;
 			}
 
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -64,8 +64,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button == MouseButton.Right)
 			{
-				editorWidget.ClearBrush();
-				return true;
+				if (mi.Event == MouseInputEvent.Up)
+				{
+					editorWidget.ClearBrush();
+					return true;
+				}
+
+				return false;
 			}
 
 			if (mi.Button == MouseButton.Left)


### PR DESCRIPTION
Let the mouse down event bubble up, fixes #9836
EDIT:
- applied this behaviour to all brushes (only affects right clicks), so you can also joystick scroll with with all other brushes
