### PR TITLE
D2k, fixed infantry moving too slow on dunes

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -171,7 +171,7 @@
 			Concrete: 100
 			Spice: 100
 			SpiceBlobs: 100
-			Dune: 50
+			Dune: 80
 			Rough: 80
 	SelectionDecorations:
 	Selectable:


### PR DESCRIPTION
This isn't a 'scientific' fix because I don't believe we know the exact terrain movement stats, but playing the original, infantry definitely seem to move faster on dunes than vehicles and don't have as a slow a speed reduction as there is here.

Adding to that, it does IMO make sense that infantry wouldn't slow down as much and it gives them another nice boost to usability on the battlefield.
