### PR TITLE
Fix the C17 delivery plane doing a steep dive when trying to land

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					new FacingInit(64)
 				});
 
-				actor.QueueActivity(new Fly(actor, Target.FromCell(w, self.Location + new CVec(9, 0))));
+				actor.QueueActivity(new Fly(actor, Target.FromCell(w, self.Location + new CVec(12, 0))));
 				actor.QueueActivity(new Land(actor, Target.FromActor(self)));
 				actor.QueueActivity(new CallFunc(() =>
 				{

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -153,6 +153,7 @@ C17:
 		Speed: 326
 		Repulsable: False
 		AirborneUpgrades: airborne
+		MaximumPitch: 36
 	Health:
 		HP: 25
 	Armor:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -401,7 +401,6 @@
 	RejectsOrders:
 	Aircraft:
 		CruiseAltitude: 2560
-		MaximumPitch: 56
 
 ^Ship:
 	Inherits@1: ^ExistsInWorld

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -64,6 +64,7 @@ frigate:
 		RepairBuildings:
 		RearmBuildings:
 		Repulsable: False
+		MaximumPitch: 20
 	-AppearsOnRadar:
 	Cargo:
 		MaxWeight: 20


### PR DESCRIPTION
Yes, it sucks that the land range is hardcoded. Yes, I will unhardcode it. No, not in this PR. It will be in my PR that completely rewrites this trait to enable proper Starport logic (or it already is, I don't remember; if it isn't request in on that PR next time I reopen it).

The frigate's MaximumPitch is of no consequence.
`MaximumPitch: 56` was removed from the TD `^Plane` because only C17 lands anyway.
