### PR TITLE
Improve D2k spiceblooms

### DIFF
--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -91,21 +91,6 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			var args = new ProjectileArgs
-			{
-				Weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()],
-				Facing = 0,
-
-				DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
-					.Select(a => a.GetFirepowerModifier()).ToArray(),
-
-				InaccuracyModifiers = self.TraitsImplementing<IInaccuracyModifier>()
-					.Select(a => a.GetInaccuracyModifier()).ToArray(),
-
-				Source = self.CenterPosition,
-				SourceActor = self,
-			};
-
 			var pieces = self.World.SharedRandom.Next(info.Pieces[0], info.Pieces[1]) * ticks / growTicks;
 			for (var i = 0; pieces > i; i++)
 			{
@@ -114,7 +99,21 @@ namespace OpenRA.Mods.D2k.Traits
 				if (cell == null)
 					cell = cells.Take(info.Range).Random(self.World.SharedRandom);
 
-				args.PassiveTarget = self.World.Map.CenterOfCell(cell.Value);
+				var args = new ProjectileArgs
+				{
+					Weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()],
+					Facing = 0,
+
+					DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
+						.Select(a => a.GetFirepowerModifier()).ToArray(),
+
+					InaccuracyModifiers = self.TraitsImplementing<IInaccuracyModifier>()
+						.Select(a => a.GetInaccuracyModifier()).ToArray(),
+
+					Source = self.CenterPosition,
+					SourceActor = self,
+					PassiveTarget = self.World.Map.CenterOfCell(cell.Value)
+				};
 
 				self.World.AddFrameEndTask(_ =>
 				{

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public readonly string Weapon = "SpiceExplosion";
 
 		[Desc("The amount of spice to expel.")]
-		public readonly int[] Pieces = { 3, 10 };
+		public readonly int[] Pieces = { 2, 12 };
 
 		[Desc("The maximum distance in cells that spice may be expelled.")]
 		public readonly int Range = 5;
@@ -92,6 +92,9 @@ namespace OpenRA.Mods.D2k.Traits
 		public void Killed(Actor self, AttackInfo e)
 		{
 			var pieces = self.World.SharedRandom.Next(info.Pieces[0], info.Pieces[1]) * ticks / growTicks;
+			if (pieces < info.Pieces[0])
+				pieces = info.Pieces[0];
+
 			for (var i = 0; pieces > i; i++)
 			{
 				var cells = OpenRA.Traits.Util.RandomWalk(self.Location, self.World.SharedRandom);

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public readonly int[] RespawnDelay = { 1500, 2500 };
 
 		[Desc("The range of time (in ticks) that the spicebloom will take to grow.")]
-		public readonly int[] GrowthDelay = { 1000, 1500 };
+		public readonly int[] GrowthDelay = { 1000, 3000 };
 
 		public readonly string ResourceType = "Spice";
 

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -10,6 +10,9 @@ spicebloom:
 		Name: Spice Bloom
 	SpiceBloom:
 		Weapon: SpiceExplosion
+	Explodes:
+		Weapon: BloomExplosion
+		EmptyWeapon: BloomExplosion
 	Crushable:
 		CrushClasses: spicebloom
 		CrushedByFriendlies: true

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -766,13 +766,12 @@ SardDeath:
 		ImpactSound: EXPLSML2.WAV
 
 SpiceExplosion:
-	Report: EXPLMD1.WAV
 	Projectile: Bullet
 		Speed: 50, 75
-		High: true
-		Angle: 91, 264
+		Blockable: false
+		Angle: 60, 90
 		Trail: large_trail
-		Image: null
+		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
@@ -794,4 +793,28 @@ SpiceExplosion:
 		Size: 2,2
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
+
+BloomExplosion:
+	Report: EXPLMD1.WAV
+	Range: 0c8
+	Projectile: Bullet
+		Speed: 1c0
+		Blockable: false
+		Image: null
+	Warhead@1Dam: SpreadDamage
+		Spread: 320
+		Falloff: 100, 60, 30, 15, 0
+		Damage: 750
+		Versus:
+			none: 90
+			wall: 5
+			building: 65
+			wood: 50
+			light: 40
+			heavy: 30
+			invulnerable: 0
+			cy: 20
+			harvester: 25
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		AffectsParent: true
 

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -790,7 +790,7 @@ SpiceExplosion:
 		AffectsParent: true
 	Warhead@2Res: CreateResource
 		AddsResourceType: Spice
-		Size: 2,2
+		Size: 1
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
 


### PR DESCRIPTION
This adresses most remaining issues left by #8987.
- slower and more random growth rate
- spice 'debris' no longer fly to the same cell
- much more sane projectile angles
- crushing actors are now damaged properly
- `SpiceExplosion` now has a visible projectile. It had a darker one in the original, but I haven't found the image yet, so I'm using `120mm` for now
- make sure that at least the minimum of pieces is spawned and slightly tweak defaults
