### PR TITLE
Map editor tooltips rework

### DIFF
--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -9,10 +9,11 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Traits;
 
 namespace OpenRA
 {
-	public class PlayerReference
+	public class PlayerReference : IPlayerSummary
 	{
 		public string Name;
 		public string Palette;
@@ -44,5 +45,10 @@ namespace OpenRA
 		public PlayerReference(MiniYaml my) { FieldLoader.Load(this, my); }
 
 		public override string ToString() { return Name; }
+
+		public string GetPlayerName() { return Name; }
+		public string GetInternalFactionName() { return Faction; }
+		public HSLColor GetColor() { return Color; }
+		public bool IsNonCombatant() { return NonCombatant; }
 	}
 }

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -24,7 +24,15 @@ namespace OpenRA
 	public enum PowerState { Normal, Low, Critical }
 	public enum WinState { Undefined, Won, Lost }
 
-	public class Player : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
+	public interface IPlayerSummary
+	{
+		string GetPlayerName();
+		string GetInternalFactionName();
+		HSLColor GetColor();
+		bool IsNonCombatant();
+	}
+
+	public class Player : IPlayerSummary, IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
 	{
 		public readonly Actor PlayerActor;
 		public readonly HSLColor Color;
@@ -50,6 +58,11 @@ namespace OpenRA
 		public World World { get; private set; }
 
 		readonly IFogVisibilityModifier[] fogVisibilities;
+
+		public string GetPlayerName() { return PlayerName; }
+		public string GetInternalFactionName() { return Faction.InternalName; }
+		public HSLColor GetColor() { return Color; }
+		public bool IsNonCombatant() { return NonCombatant; }
 
 		static FactionInfo ChooseFaction(World world, string name, bool requireSelectable = true)
 		{

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -67,11 +67,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var mapResources = world.Map.MapResources.Value;
 			ResourceType type;
 			if (underCursor != null)
-				editorWidget.SetTooltip(underCursor.Tooltip);
+				editorWidget.SetTooltip(underCursor);
 			else if (mapResources.Contains(cell) && resources.TryGetValue(mapResources[cell].Type, out type))
 				editorWidget.SetTooltip(type.Info.Name);
 			else
-				editorWidget.SetTooltip(null);
+				editorWidget.RemoveTooltip();
 
 			// Finished with mouse move events, so let them bubble up the widget tree
 			if (mi.Event == MouseInputEvent.Move)
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button == MouseButton.Right)
 			{
-				editorWidget.SetTooltip(null);
+				editorWidget.RemoveTooltip();
 
 				if (underCursor != null)
 					editorLayer.Remove(underCursor);

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -209,7 +209,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			TooltipContainer: TOOLTIP_CONTAINER
-			TooltipTemplate: SIMPLE_TOOLTIP
+			TooltipTemplate: WORLD_TOOLTIP
 			Children:
 				TerrainTemplatePreview@DRAG_TILE_PREVIEW:
 					Visible: false

--- a/mods/ra/chrome/editor.yaml
+++ b/mods/ra/chrome/editor.yaml
@@ -202,7 +202,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			TooltipContainer: TOOLTIP_CONTAINER
-			TooltipTemplate: SIMPLE_TOOLTIP
+			TooltipTemplate: WORLD_TOOLTIP
 			Children:
 				ActorPreview@DRAG_ACTOR_PREVIEW:
 					Visible: false


### PR DESCRIPTION
Makes the actor tooltips in the map editors look like the in game version with extra information lines for manual editing. This should be friendlier to map authors who do not go into the MiniYaml or Lua.

Closes #9883 but if a smaller temporary 2 line tooltip fix is preferred, I can do that (in another PR dropping "PR: For stable" and Next from this PR).
