### PR TITLE
Switch WithSpriteRotorOverlay to WithRotorSpriteOverlay

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -436,7 +436,7 @@
     <Compile Include="Traits\Render\WithRepairAnimation.cs" />
     <Compile Include="Traits\Render\WithRepairOverlay.cs" />
     <Compile Include="Traits\Render\WithResources.cs" />
-    <Compile Include="Traits\Render\WithSpriteRotorOverlay.cs" />
+    <Compile Include="Traits\Render\WithRotorSpriteOverlay.cs" />
     <Compile Include="Traits\Render\WithShadow.cs" />
     <Compile Include="Traits\Render\WithSmoke.cs" />
     <Compile Include="Traits\Render\WithSpriteBody.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithRotorSpriteOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRotorSpriteOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays a helicopter rotor overlay.")]
-	public class WithSpriteRotorOverlayInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	public class WithRotorSpriteOverlayInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use when flying")]
 		[SequenceReference] public readonly string Sequence = "rotor";
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		public object Create(ActorInitializer init) { return new WithSpriteRotorOverlay(init.Self, this); }
+		public object Create(ActorInitializer init) { return new WithRotorSpriteOverlay(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
@@ -43,13 +43,13 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithSpriteRotorOverlay : ITick
+	public class WithRotorSpriteOverlay : ITick
 	{
-		readonly WithSpriteRotorOverlayInfo info;
+		readonly WithRotorSpriteOverlayInfo info;
 		readonly Animation rotorAnim;
 		readonly IMove movement;
 
-		public WithSpriteRotorOverlay(Actor self, WithSpriteRotorOverlayInfo info)
+		public WithRotorSpriteOverlay(Actor self, WithRotorSpriteOverlayInfo info)
 		{
 			this.info = info;
 			var rs = self.Trait<RenderSprites>();

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -23,11 +23,11 @@ TRAN:
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
-	WithSpriteRotorOverlay@PRIMARY:
+	WithRotorSpriteOverlay@PRIMARY:
 		Offset: -597,0,171
 		Sequence: rotor2
 		GroundSequence: slow-rotor2
-	WithSpriteRotorOverlay@SECONDARY:
+	WithRotorSpriteOverlay@SECONDARY:
 		Offset: 597,0,85
 	Cargo:
 		Types: Infantry
@@ -80,7 +80,7 @@ HELI:
 		SelfReloads: true
 		ReloadCount: 10
 		SelfReloadTicks: 200
-	WithSpriteRotorOverlay:
+	WithRotorSpriteOverlay:
 		Offset: 0,0,85
 	WithMuzzleOverlay:
 	SpawnActorOnDeath:
@@ -225,9 +225,9 @@ TRAN.Husk:
 	RevealsShroud:
 		Range: 8c0
 		Type: CenterPosition
-	WithSpriteRotorOverlay@PRIMARY:
+	WithRotorSpriteOverlay@PRIMARY:
 		Offset: -597,0,171
-	WithSpriteRotorOverlay@SECONDARY:
+	WithRotorSpriteOverlay@SECONDARY:
 		Offset: 597,0,85
 	RenderSprites:
 		Image: tran
@@ -242,7 +242,7 @@ HELI.Husk:
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
-	WithSpriteRotorOverlay:
+	WithRotorSpriteOverlay:
 		Offset: 0,0,85
 	RenderSprites:
 		Image: heli

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -221,11 +221,11 @@ TRAN:
 		AltitudeVelocity: 0c100
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithSpriteRotorOverlay@PRIMARY:
+	WithRotorSpriteOverlay@PRIMARY:
 		Offset: -597,0,341
 		Sequence: rotor2
 		GroundSequence: slow-rotor2
-	WithSpriteRotorOverlay@SECONDARY:
+	WithRotorSpriteOverlay@SECONDARY:
 		Offset: 597,0,213
 	Cargo:
 		Types: Infantry
@@ -274,7 +274,7 @@ HELI:
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
-	WithSpriteRotorOverlay:
+	WithRotorSpriteOverlay:
 		Offset: 0,0,85
 	AmmoPool:
 		Ammo: 8
@@ -328,7 +328,7 @@ HIND:
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
-	WithSpriteRotorOverlay:
+	WithRotorSpriteOverlay:
 	AmmoPool:
 		Ammo: 24
 		PipCount: 6

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -90,9 +90,9 @@ TRAN.Husk:
 		Speed: 149
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithSpriteRotorOverlay@PRIMARY:
+	WithRotorSpriteOverlay@PRIMARY:
 		Offset: -597,0,341
-	WithSpriteRotorOverlay@SECONDARY:
+	WithRotorSpriteOverlay@SECONDARY:
 		Offset: 597,0,213
 	RevealsShroud:
 		Range: 12c0
@@ -184,7 +184,7 @@ HELI.Husk:
 		Speed: 149
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithSpriteRotorOverlay:
+	WithRotorSpriteOverlay:
 		Offset: 0,0,85
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
@@ -204,7 +204,7 @@ HIND.Husk:
 		Speed: 112
 		AirborneUpgrades: airborne
 		CanHover: True
-	WithSpriteRotorOverlay:
+	WithRotorSpriteOverlay:
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
 		MinDamage: Undamaged

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -290,7 +290,7 @@ APACHE:
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:
-	WithSpriteRotorOverlay:
+	WithRotorSpriteOverlay:
 		Offset: 85,0,384
 	RenderSprites:
 	Hovers@AIRBORNE:


### PR DESCRIPTION
In accordance with other render traits and suggestion in #9541.

Note: While not strictly necessary for this release, it would spare modders from another rename with Next+1 if this went into prep-1512.
