### PR TITLE
D2k repair pad

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -80,7 +80,7 @@
 	HiddenUnderFog:
 	ActorLostNotification:
 	Repairable:
-		RepairBuildings: repair
+		RepairBuildings: repair_pad
 	Guard:
 		Voice: Guard
 	Guardable:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -662,8 +662,8 @@ repair_pad:
 		VisualBounds: 96,80
 	Reservable:
 	RepairsUnits:
-		Interval: 15
-		ValuePercentage: 50
+		Interval: 10
+		HpPerStep: 80
 		FinishRepairingNotification: UnitRepaired
 	RallyPoint:
 		Offset: 1,3


### PR DESCRIPTION
First commit fixes  #9889
Second makes the repair pad not laughably useless.
