### PR TITLE
Added 3 Lua player API properties

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Scripting
 		public PlayerProperties(ScriptContext context, Player player)
 			: base(context, player) { }
 
+		[Desc("The player's internal name.")]
+		public string InternalName { get { return Player.InternalName; } }
+
 		[Desc("The player's name.")]
 		public string Name { get { return Player.PlayerName; } }
 
@@ -51,6 +54,12 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[Desc("Returns true if the player is a bot.")]
 		public bool IsBot { get { return Player.IsBot; } }
+
+		[Desc("Returns true if the player is non combatant.")]
+		public bool IsNonCombatant { get { return Player.NonCombatant; } }
+
+		[Desc("Returns true if the player is the local player.")]
+		public bool IsLocalPlayer { get { return Player == (Player.World.RenderPlayer ?? Player.World.LocalPlayer); }	}
 
 		[Desc("Returns an array of actors representing all ground attack units of this player.")]
 		public Actor[] GetGroundAttackers()


### PR DESCRIPTION
Added 3 Lua player API properties:
- `InternalName`
- `IsNonCombantant` for use with GetPlayers() to get only combatant players back (no Creeps/Neutral)
- `IsLocalPlayer` for individualized player code (such as setting camera position, or future Lua UI stuff)

Test sole survivor map/branch: https://github.com/cjshmyr/OpenRA/commit/e76cc7729e9895359149357f652c847cadbfa2fb
