### PR TITLE
Multi-line map editor tooltips

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -70,7 +70,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var tooltip = Info.TraitInfoOrDefault<TooltipInfo>();
-			Tooltip = tooltip == null ? ID + ": " + Info.Name : ID + ": " + tooltip.Name + " (" + Info.Name + ")" + "\n" + owner.Name + " (" + owner.Faction + ")";
+			Tooltip = (tooltip == null ? " < " + Info.Name + " >" : tooltip.Name) + "\n" + owner.Name + " (" + owner.Faction + ")"
+				+ "\nID: " + ID + "\nType: " + Info.Name;
 
 			GeneratePreviews();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					item.IsVisible = () => true;
 
 					var tooltip = actor.TraitInfoOrDefault<TooltipInfo>();
-					item.GetTooltipText = () => tooltip == null ? actor.Name : tooltip.Name + " (" + actor.Name + ")";
+					item.GetTooltipText = () => (tooltip == null ? "\nType: " : tooltip.Name + "\nType: ") + actor.Name;
 
 					panel.AddChild(item);
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -22,17 +22,26 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var font = Game.Renderer.Fonts[label.Font];
 			var cachedWidth = 0;
+			var cachedHeight = 0;
+			var horizontalPadding = label.Bounds.Width - widget.Bounds.Width;
+			if (horizontalPadding <= 0)
+				horizontalPadding = 2 * label.Bounds.X;
+			var vertcalPadding = widget.Bounds.Height - label.Bounds.Height;
+			if (vertcalPadding <= 0)
+				vertcalPadding = 2 * label.Bounds.Y;
 			var labelText = "";
 			tooltipContainer.BeforeRender = () =>
 			{
 				labelText = getText();
 				var textDim = font.Measure(labelText);
-				if (textDim.X != cachedWidth)
+				if (textDim.X != cachedWidth || textDim.Y != cachedHeight)
 				{
 					label.Bounds.Width = textDim.X;
-					widget.Bounds.Width = 2 * label.Bounds.X + textDim.X;
+					widget.Bounds.Width = horizontalPadding + textDim.X;
 					label.Bounds.Height = textDim.Y;
-					widget.Bounds.Height = 4 * label.Bounds.Y + textDim.Y;
+					widget.Bounds.Height = vertcalPadding + textDim.Y;
+					cachedWidth = textDim.X;
+					cachedHeight = textDim.Y;
 				}
 			};
 

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -329,6 +329,7 @@ Container@EDITOR_WORLD_ROOT:
 									Visible: false
 									Width: PARENT_RIGHT - 35
 									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: TWO_LINE_TOOLTIP
 									IgnoreChildMouseOver: true
 									Children:
 										ActorPreview@ACTOR_PREVIEW:

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -1,7 +1,7 @@
 Background@SIMPLE_TOOLTIP:
 	Logic: SimpleTooltipLogic
 	Background: panel-black
-	Height: 25
+	Height: 27
 	Children:
 		Label@LABEL:
 			X: 5

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -8,6 +8,21 @@ Background@SIMPLE_TOOLTIP:
 			Height: 23
 			Font: Bold
 
+Background@TWO_LINE_TOOLTIP:
+	Logic: ButtonTooltipLogic
+	Background: panel-black
+	Height: 48
+	Children:
+		Label@LABEL:
+			X: 5
+			Height: 46
+			Font: Bold
+		Label@HOTKEY:
+			Visible: false
+			TextColor: FFFF00
+			Height: 23
+			Font: Bold
+
 Background@BUTTON_TOOLTIP:
 	Logic: ButtonTooltipLogic
 	Background: panel-black

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -1,7 +1,7 @@
 Background@SIMPLE_TOOLTIP:
 	Logic: SimpleTooltipLogic
 	Background: dialog3
-	Height: 31
+	Height: 34
 	Children:
 		Label@LABEL:
 			X: 5

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -9,6 +9,23 @@ Background@SIMPLE_TOOLTIP:
 			Height: 23
 			Font: Bold
 
+Background@TWO_LINE_TOOLTIP:
+	Logic: ButtonTooltipLogic
+	Background: dialog3
+	Height: 54
+	Children:
+		Label@LABEL:
+			X: 5
+			Y: 3
+			Height: 46
+			Font: Bold
+		Label@HOTKEY:
+			Visible: false
+			Y: 3
+			Height: 23
+			TextColor: FFFF00
+			Font: Bold
+
 Background@BUTTON_TOOLTIP:
 	Logic: ButtonTooltipLogic
 	Background: dialog3

--- a/mods/ra/chrome/editor.yaml
+++ b/mods/ra/chrome/editor.yaml
@@ -307,6 +307,7 @@ Container@EDITOR_WORLD_ROOT:
 									Visible: false
 									Width: PARENT_RIGHT - 35
 									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: TWO_LINE_TOOLTIP
 									IgnoreChildMouseOver: true
 									Children:
 										ActorPreview@ACTOR_PREVIEW:

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -9,6 +9,23 @@ Background@SIMPLE_TOOLTIP:
 			Height: 23
 			Font: Bold
 
+Background@TWO_LINE_TOOLTIP:
+	Logic: ButtonTooltipLogic
+	Background: dialog4
+	Height: 52
+	Children:
+		Label@LABEL:
+			X: 7
+			Y: 2
+			Height: 46
+			Font: Bold
+		Label@HOTKEY:
+			Visible: false
+			Y: 2
+			Height: 23
+			TextColor: FFFF00
+			Font: Bold
+
 Background@BUTTON_TOOLTIP:
 	Logic: ButtonTooltipLogic
 	Background: dialog4

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -1,7 +1,7 @@
 Background@SIMPLE_TOOLTIP:
 	Logic: SimpleTooltipLogic
 	Background: dialog4
-	Height: 29
+	Height: 32
 	Children:
 		Label@LABEL:
 			X: 7


### PR DESCRIPTION
Makes the actor tooltips in the map editors look similar to the in game version (listing faction in parentheses instead of using a flag) with information lines below for manual editing. This should be friendlier to map authors who do not go into the MiniYaml or Lua.

Closes #9883 and provides a stepping stone to #9904 tooltip layout.

This actually adds multi-line support to simple tooltips.
