### PR TITLE
Further improve D2k spiceblooms

### DIFF
--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -23,6 +23,9 @@ namespace OpenRA.Mods.D2k.Traits
 	[Desc("Seeds resources by explosive eruptions after accumulation times.")]
 	public class SpiceBloomInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
+		[ActorReference]
+		public readonly string SpawnActor = "spicebloom.spawnpoint";
+
 		[SequenceReference]
 		public readonly string[] GrowthSequences = { "grow1", "grow2", "grow3" };
 
@@ -159,7 +162,7 @@ namespace OpenRA.Mods.D2k.Traits
 					new FactionInit(self.Owner.Faction.InternalName),
 					new SkipMakeAnimsInit()
 				};
-				self.World.CreateActor(self.Info.Name, td);
+				self.World.CreateActor(info.SpawnActor, td);
 			})));
 		}
 	}

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public readonly string ResourceType = "Spice";
 
+		[Desc("Spice blooms only grow on these terrain types.")]
+		public readonly HashSet<string> GrowthTerrainTypes = new HashSet<string>();
+
 		[Desc("The weapon to use for spice creation.")]
 		[WeaponReference]
 		public readonly string Weapon = "SpiceExplosion";
@@ -78,6 +81,12 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public void Tick(Actor self)
 		{
+			if (!self.World.Map.Contains(self.Location))
+				return;
+
+			if (info.GrowthTerrainTypes.Count > 0 && !info.GrowthTerrainTypes.Contains(self.World.Map.GetTerrainInfo(self.Location).Type))
+				return;
+
 			ticks++;
 
 			if (ticks >= growTicks)

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -1,3 +1,25 @@
+spicebloom.spawnpoint:
+	HiddenUnderShroud:
+		Type: CenterPosition
+	BodyOrientation:
+		QuantizedFacings: 1
+	RenderSprites:
+		Image: spicebloom
+	SpiceBloom:
+		GrowthTerrainTypes: Sand
+		SpawnActor: spicebloom
+		GrowthSequences: grow0
+		GrowthDelay: 250, 750
+		RespawnDelay: 1, 2
+	Explodes:
+		Weapon: BloomSpawn
+		EmptyWeapon: BloomSpawn
+	Health:
+		HP: 9999
+		Radius: 1
+	Immobile:
+		OccupiesSpace: false
+
 spicebloom:
 	HiddenUnderShroud:
 	BodyOrientation:

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -46,6 +46,11 @@ explosion:
 		BlendMode: Alpha
 		Offset: 12, -10
 		Tick: 120
+	bloomspawn: DATA.R8
+		Start: 3980
+		Length: 8
+		Tick: 120
+		Offset: 0, -16
 	corpse: DATA.R8
 		Start: 430
 		Length: 12
@@ -328,6 +333,11 @@ crate:
 		Offset: -16,-16
 
 spicebloom:
+	grow0: DATA.R8
+		Start: 106
+		Length: 1
+		ZOffset: -1023
+		Offset: -16,-16
 	grow1: DATA.R8
 		Start: 107
 		Length: 1

--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -820,3 +820,12 @@ BloomExplosion:
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 		AffectsParent: true
 
+BloomSpawn:
+	Range: 0c1
+	Projectile: Bullet
+		Speed: 1c0
+		Blockable: false
+		Image: null
+	Warhead@1Eff: CreateEffect
+		Explosion: bloomspawn
+


### PR DESCRIPTION
This implements the last missing aspects of spiceblooms, namely only growing/'spawning' on spice-free sand (unless pre-placed in map editor) and displaying the animation of blowing spice into the air when spawned.

Additionally, spice particles now properly target cells free of spice when possible.

Closes https://github.com/OpenRA/OpenRA/issues/9866.
