### PR TITLE
Set the default map location to the support dir.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -76,8 +76,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var mapDirectory = map.Path != null ? Platform.UnresolvePath(Path.GetDirectoryName(map.Path)) : null;
 				var initialDirectory = mapDirectories.Keys.FirstOrDefault(f => f == mapDirectory);
 
+				// Prioritize MapClassification.User directories over system directories
 				if (initialDirectory == null)
-					initialDirectory = mapDirectories.Keys.First();
+					initialDirectory = mapDirectories.OrderByDescending(kv => kv.Value).First().Key;
 
 				directoryDropdown.Text = initialDirectory;
 				directoryDropdown.OnClick = () =>


### PR DESCRIPTION
Fixes the worst part of #9430 so that it does not block the next release.

That ticket will not be properly resolved until we catch other errors during map save, but that is out of scope for this PR.
