### PR TITLE
Changed ServerSettings cloning to a more reliable approach

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -358,7 +358,7 @@ namespace OpenRA
 			{
 				Settings.Server.Map = WidgetUtils.ChooseInitialMap(Settings.Server.Map);
 				Settings.Save();
-				CreateServer(new ServerSettings(Settings.Server));
+				CreateServer(Settings.Server.Clone());
 
 				while (true)
 				{

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -74,27 +74,9 @@ namespace OpenRA
 
 		public string TimestampFormat = "s";
 
-		public ServerSettings() { }
-
-		public ServerSettings(ServerSettings other)
+		public ServerSettings Clone()
 		{
-			Name = other.Name;
-			ListenPort = other.ListenPort;
-			ExternalPort = other.ExternalPort;
-			AdvertiseOnline = other.AdvertiseOnline;
-			Password = other.Password;
-			MasterServer = other.MasterServer;
-			DiscoverNatDevices = other.DiscoverNatDevices;
-			AllowPortForward = other.AllowPortForward;
-			NatDeviceAvailable = other.NatDeviceAvailable;
-			NatDiscoveryTimeout = other.NatDiscoveryTimeout;
-			VerboseNatDiscovery = other.VerboseNatDiscovery;
-			Map = other.Map;
-			Ban = other.Ban;
-			TimeOut = other.TimeOut;
-			Dedicated = other.Dedicated;
-			DedicatedLoop = other.DedicatedLoop;
-			LockBots = other.LockBots;
+			return (ServerSettings)MemberwiseClone();
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.Settings.Save();
 
 			// Take a copy so that subsequent changes don't affect the server
-			var settings = new ServerSettings(Game.Settings.Server);
+			var settings = Game.Settings.Server.Clone();
 
 			// Create and join the server
 			try


### PR DESCRIPTION
Using your own copying constructor in classes without proper maps (e.g. ObjectToObject in BLToolkit) is a dangerous practice. As shown in this commit, one might easily forget to update the copying constructor with recently added fields (for example, TimestampFormat was not copied before this commit).

The more general solution (for simple cases like this one) is a call to a protected System.Object method MemberwiseClone(), which does exactly what its name says.

Actually, you may consider using a struct for cases like this. Structs are always copied on assignment; it takes a lot of trickery to actually modify (not replace) someone else's struct, and it is virtually impossible if it is published via a readonly property. But, since structs are all ValueTypes (which implies they are allocated on stack), it is not recommended to use them without fully understanding their nature.
