### PR TITLE
D2k Ornithopter bomb damage increase

### DIFF
--- a/mods/d2k/weapons.yaml
+++ b/mods/d2k/weapons.yaml
@@ -583,7 +583,7 @@ OrniBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 400
+		Damage: 1000 #400 in original, reduce when bombers can do multiple passes
 		Versus:
 			none: 90
 			wall: 50


### PR DESCRIPTION
Currently the ornithopter strike is useless, takes a quarter off the windtrap. In the original game there were 5 bombers in a line that did 3 strafes over the target, but since I believe that isn't possible, we should just up the damage a bit.

With 1000 damage it takes a windtrap down to about a quarter health, but can also damage surrounding buldings too, compared to the Death Hand which takes out a single windtrap but not much spread damage. This might seem useless but I believe that because the Atreides gets the Fremen power too, they're both intended as two support weapons. You can use them both together to take out a target, or use the 'thopters to finish something off after an attack etc.

And Atreides get more special stuff compared to the other factions, and more spread weapons with the Sonic Tank and Grenadiers...

Either way, this is a boost that makes it more useful, even if its not a free kill.
