### PR TITLE
Fix the documentation of Explodes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Health level at which actor will explode.")]
 		public readonly int DamageThreshold = 0;
 
-		[Desc("DeathType(s) to apply upon explosion.")]
+		[Desc("DeathType(s) that trigger the explosion. Leave empty to always trigger an explosion.")]
 		public readonly HashSet<string> DeathType = new HashSet<string>();
 
 		public WeaponInfo WeaponInfo { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int DamageThreshold = 0;
 
 		[Desc("DeathType(s) that trigger the explosion. Leave empty to always trigger an explosion.")]
-		public readonly HashSet<string> DeathType = new HashSet<string>();
+		public readonly HashSet<string> DeathTypes = new HashSet<string>();
 
 		public WeaponInfo WeaponInfo { get; private set; }
 		public WeaponInfo EmptyWeaponInfo { get; private set; }
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var warhead = e.Warhead as DamageWarhead;
-			if (info.DeathType.Count > 0 && warhead != null && !warhead.DamageTypes.Overlaps(info.DeathType))
+			if (info.DeathTypes.Count > 0 && warhead != null && !warhead.DamageTypes.Overlaps(info.DeathTypes))
 				return;
 
 			var weapon = ChooseWeaponForExplosion(self);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2377,6 +2377,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "ParticleSize";
 				}
 
+				// DeathType on Explodes was renamed to DeathTypes
+				if (engineVersion < 20151110)
+				{
+					if (node.Key == "Explodes")
+					{
+						var dt = node.Value.Nodes.FirstOrDefault(n => n.Key == "DeathType");
+						if (dt != null)
+							dt.Key = "DeathTypes";
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}


### PR DESCRIPTION
The `DeathType` defines which weapon(s) trigger an explosion.
Also renamed it to plural, as we use it elsewhere (it was already a `HashSet<string>`, too).
