### PR TITLE
D2k fixed armour & AI typos

### DIFF
--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -5,7 +5,7 @@ Player:
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
-			ConstructionYard: conyard
+			ConstructionYard: construction_yard
 			Refinery: refinery
 			Power: wind_trap
 			VehiclesFactory: light_factory, heavy_factory, starport
@@ -23,6 +23,7 @@ Player:
 			outpost: 1
 			high_tech_factory: 1
 			palace: 1
+			upgrade.conyard: 1
 			upgrade.barracks: 1
 			upgrade.light: 1
 			upgrade.heavy: 1
@@ -40,6 +41,7 @@ Player:
 			medium_gun_turret: 8%
 			large_gun_turret: 6%
 			wind_trap: 10%
+			upgrade.conyard: 0.1%
 			upgrade.barracks: 0.1%
 			upgrade.light: 0.1%
 			upgrade.heavy: 0.1%
@@ -119,7 +121,7 @@ Player:
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
-			ConstructionYard: conyard
+			ConstructionYard: construction_yard
 			Refinery: refinery
 			Power: wind_trap
 			VehiclesFactory: light_factory, heavy_factory, starport
@@ -137,6 +139,7 @@ Player:
 			outpost: 1
 			high_tech_factory: 1
 			palace: 1
+			upgrade.conyard: 1
 			upgrade.barracks: 1
 			upgrade.light: 1
 			upgrade.heavy: 1
@@ -154,6 +157,7 @@ Player:
 			medium_gun_turret: 5%
 			large_gun_turret: 10%
 			wind_trap: 12%
+			upgrade.conyard: 0.1%
 			upgrade.barracks: 0.1%
 			upgrade.light: 0.1%
 			upgrade.heavy: 0.1%
@@ -233,7 +237,7 @@ Player:
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport
 		BuildingCommonNames:
-			ConstructionYard: conyard
+			ConstructionYard: construction_yard
 			Refinery: refinery
 			Power: wind_trap
 			VehiclesFactory: light_factory, heavy_factory, starport
@@ -251,6 +255,7 @@ Player:
 			outpost: 1
 			high_tech_factory: 1
 			palace: 1
+			upgrade.conyard: 1
 			upgrade.barracks: 1
 			upgrade.light: 1
 			upgrade.heavy: 1
@@ -268,6 +273,7 @@ Player:
 			medium_gun_turret: 4%
 			large_gun_turret: 12%
 			wind_trap: 10%
+			upgrade.conyard: 0.1%
 			upgrade.barracks: 0.1%
 			upgrade.light: 0.1%
 			upgrade.heavy: 0.1%

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -26,7 +26,7 @@ spicebloom:
 		TargetTypes: Ground
 		RequiresForceFire: yes
 	Armor:
-		Type: None
+		Type: none
 
 sandworm:
 	Inherits@1: ^SpriteActor
@@ -37,7 +37,7 @@ sandworm:
 		HP: 9990
 		Radius: 256
 	Armor:
-		Type: None
+		Type: heavy
 	Mobile:
 		Speed: 42
 		TerrainSpeeds:
@@ -73,9 +73,9 @@ sietch:
 		Dimensions: 2,2
 		TerrainTypes: Cliff
 	Health:
-		HP: 400
+		HP: 6000
 	Armor:
-		Type: Concrete
+		Type: wood
 	RevealsShroud:
 		Range: 10c0
 	-DamagedWithoutFoundation:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -106,7 +106,7 @@
 	Health:
 		HP: 75
 	Armor:
-		Type: Light
+		Type: light
 	HiddenUnderFog:
 		Type: CenterPosition
 	Tooltip:
@@ -141,7 +141,7 @@
 	Health:
 		HP: 125
 	Armor:
-		Type: Concrete
+		Type: concrete
 	Husk:
 	AppearsOnRadar:
 	HiddenUnderFog:
@@ -158,7 +158,7 @@
 	Health:
 		Radius: 96
 	Armor:
-		Type: None
+		Type: none
 	RevealsShroud:
 		Range: 3c768
 	Mobile:


### PR DESCRIPTION
This fixes some armour typos, that meant all infantry & sandworms were being treated with 100% weapon damage. Corrected sietch armour and health.

Also noticed the AI had an issue with a typo, as well not having the ability to build the construction yard upgrade.
