### PR TITLE
D2k thumper worm attraction balance change

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -116,6 +116,7 @@ thumper:
 		UpgradeMinEnabledLevel: 1
 	AttractsWorms:
 		Intensity: 1000
+		Falloff: 0, 0, 0, 100, 100, 100, 25, 11, 6, 4, 3, 2, 1, 0
 		UpgradeTypes: deployed
 		UpgradeMinEnabledLevel: 1
 	DisableOnUpgrade:


### PR DESCRIPTION
Originally suggested by pchote, this gives the Thumper an inner ring where the worm is allowed to move freely around the Thumper. Makes them much more useful, as you can essentially "trap" a worm in an area but still allow them to attack other objects like enemy Harvesters etc.

By default it AttractWorm should have a Spread of 3072, making the inner circle 9 cells in total. (?)

The exact range of this effect could be argued about, but for now this is a big improvement.
