### PR TITLE
MiniYaml.cs cleanups

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -174,7 +174,7 @@ namespace OpenRA
 					currChar = line[charPosition];
 					switch (currChar)
 					{
-					    case ' ':
+						case ' ':
 							spaces++;
 							if (spaces >= SpacesPerLevel)
 							{

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -160,15 +160,15 @@ namespace OpenRA
 					line = line.Substring(0, commentIndex).TrimEnd(' ', '\t');
 				if (line.Length == 0)
 					continue;
-				var cp = 0;
+				var charPosition = 0;
 				var level = 0;
 				var spaces = 0;
 				var textStart = false;
-				var c = line[cp];
-				while (!(c == '\n' || c == '\r') && cp < line.Length && !textStart)
+				var currChar = line[charPosition];
+				while (!(currChar == '\n' || currChar == '\r') && charPosition < line.Length && !textStart)
 				{
-					c = line[cp];
-					switch (c)
+					currChar = line[charPosition];
+					switch (currChar)
 					{
 					    case ' ':
 							spaces++;
@@ -178,11 +178,11 @@ namespace OpenRA
 								level++;
 							}
 
-							cp++;
+							charPosition++;
 							break;
 						case '\t':
 							level++;
-							cp++;
+							charPosition++;
 							break;
 						default:
 							textStart = true;
@@ -190,8 +190,8 @@ namespace OpenRA
 					}
 				}
 
-				var t = line.Substring(cp);
-				if (t.Length == 0)
+				var realText = line.Substring(charPosition);
+				if (realText.Length == 0)
 					continue;
 				var location = new MiniYamlNode.SourceLocation { Filename = filename, Line = lineNo };
 
@@ -201,8 +201,8 @@ namespace OpenRA
 					levels.RemoveAt(levels.Count - 1);
 
 				var d = new List<MiniYamlNode>();
-				var rhs = SplitAtColon(ref t);
-				levels[level].Add(new MiniYamlNode(t, rhs, d, location));
+				var rhs = SplitAtColon(ref realText);
+				levels[level].Add(new MiniYamlNode(realText, rhs, d, location));
 
 				levels.Add(d);
 			}
@@ -210,15 +210,15 @@ namespace OpenRA
 			return levels[0];
 		}
 
-		static string SplitAtColon(ref string t)
+		static string SplitAtColon(ref string realText)
 		{
-			var colon = t.IndexOf(':');
+			var colon = realText.IndexOf(':');
 			if (colon == -1)
 				return null;
-			var ret = t.Substring(colon + 1).Trim();
+			var ret = realText.Substring(colon + 1).Trim();
 			if (ret.Length == 0)
 				ret = null;
-			t = t.Substring(0, colon).Trim();
+			realText = realText.Substring(0, colon).Trim();
 			return ret;
 		}
 

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -36,6 +36,7 @@ namespace OpenRA
 			{
 				foreach (var line in kv.Value.ToLines(kv.Key))
 					yield return line;
+
 				if (lowest)
 					yield return "";
 			}
@@ -158,13 +159,16 @@ namespace OpenRA
 				var commentIndex = line.IndexOf('#');
 				if (commentIndex != -1)
 					line = line.Substring(0, commentIndex).TrimEnd(' ', '\t');
+
 				if (line.Length == 0)
 					continue;
+
 				var charPosition = 0;
 				var level = 0;
 				var spaces = 0;
 				var textStart = false;
 				var currChar = line[charPosition];
+
 				while (!(currChar == '\n' || currChar == '\r') && charPosition < line.Length && !textStart)
 				{
 					currChar = line[charPosition];
@@ -193,10 +197,12 @@ namespace OpenRA
 				var realText = line.Substring(charPosition);
 				if (realText.Length == 0)
 					continue;
+
 				var location = new MiniYamlNode.SourceLocation { Filename = filename, Line = lineNo };
 
 				if (levels.Count <= level)
 					throw new YamlException("Bad indent in miniyaml at {0}".F(location));
+
 				while (levels.Count > level + 1)
 					levels.RemoveAt(levels.Count - 1);
 
@@ -215,9 +221,11 @@ namespace OpenRA
 			var colon = realText.IndexOf(':');
 			if (colon == -1)
 				return null;
+
 			var ret = realText.Substring(colon + 1).Trim();
 			if (ret.Length == 0)
 				ret = null;
+
 			realText = realText.Substring(0, colon).Trim();
 			return ret;
 		}
@@ -268,6 +276,7 @@ namespace OpenRA
 		{
 			if (a.Count == 0)
 				return b;
+
 			if (b.Count == 0)
 				return a;
 
@@ -332,6 +341,7 @@ namespace OpenRA
 		{
 			if (a == null)
 				return b;
+
 			if (b == null)
 				return a;
 
@@ -341,6 +351,7 @@ namespace OpenRA
 		public IEnumerable<string> ToLines(string name)
 		{
 			yield return name + ": " + Value;
+
 			if (Nodes != null)
 				foreach (var line in Nodes.ToLines(false))
 					yield return "\t" + line;


### PR DESCRIPTION
Fix/add some whitespace.
Rename some variables.

I'm working on _not_ trashing comments when we parse yaml files but this proved more difficult than I originally thought and I didn't want these cleanup commits to just sit and go to waste.
