### PR TITLE
Fix map editor crash

### DIFF
--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -19,7 +19,7 @@ Background@TWO_LINE_TOOLTIP:
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			TextColor: FFFF00
+			TextColor: 255,255,0
 			Height: 23
 			Font: Bold
 

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -23,7 +23,7 @@ Background@TWO_LINE_TOOLTIP:
 			Visible: false
 			Y: 3
 			Height: 23
-			TextColor: FFFF00
+			TextColor: 255,255,0
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -23,7 +23,7 @@ Background@TWO_LINE_TOOLTIP:
 			Visible: false
 			Y: 2
 			Height: 23
-			TextColor: FFFF00
+			TextColor: 255,255,0
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:


### PR DESCRIPTION
This is a prep-specific fix, because that branch doesn't have the color syntax change yet.
