### PR TITLE
Cache self.ToLuaValue in ScriptTriggers

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"only contain alive actors.")]
 		public bool Build(string[] actorTypes, LuaFunction actionFunc = null)
 		{
-			if (triggers.Triggers[Trigger.OnProduction].Any())
+			if (triggers.HasAnyCallbacksFor(Trigger.OnProduction))
 				return false;
 
 			var queue = queues.Where(q => actorTypes.All(t => GetBuildableInfo(t).Queue.Contains(q.Info.Type)))
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"Note: it does not check whether this particular type of actor is being produced.")]
 		public bool IsProducing(string actorType)
 		{
-			if (triggers.Triggers[Trigger.OnProduction].Any())
+			if (triggers.HasAnyCallbacksFor(Trigger.OnProduction))
 				return true;
 
 			return queues.Where(q => GetBuildableInfo(actorType).Queue.Contains(q.Info.Type))


### PR DESCRIPTION
(This explanation is probably going to be terrible, so tl;dr: This improves performance.)

When making an Lua function call, any LuaCustomClrObject must be introspected via reflection in order to determine what to expose in Lua code. In OpenRA, we use these for any types that implement IScriptBindable, such as Actor.

Previously, we would need to pay the cost of this reflection for every individual Lua call an Actor used in its ScriptTriggers trait where it passed `self` as a parameter. This would be repeated every time. For performance, we now cache self.ToLuaValue in the trait and use that for all calls so we only pay the reflection cost once on trait construction. This removes a significant overhead in the Lua bridging code.

This requires OpenRA/Eluant#1 in order to realize the performance benefits - but this PR doesn't strictly depend on it and can be merged on its own merits as desired.

Alternatively, in pseudocode:

Calling an Lua function and passing an actor looks like this:

``` csharp
void DoSomeLua()
{
    using (var a = actor.ToLuaValue(context))
        luaFunction.Call(a);
}
```

This is morally equivalent to:

``` csharp
void DoSomeLua()
{
    using (var a = actor.ToLuaValue(context))
        luaFunction.Call(a.ExpensiveReflectionHere());
}
```

The linked PR changes this to:

``` csharp
void DoSomeLua()
{
    using (var a = actor.ToLuaValue(context).ExpensiveReflectionHere())
        luaFunction.Call(a);
}
```

This PR then changes this to:

``` csharp
// This is a field which we reuse, so we don't have to pay for reflection every time.
LuaValue a = actor.ToLuaValue(context).ExpensiveReflectionHere();

void DoSomeLua()
{
    luaFunction.Call(a);
}
```

On the RA shellmap, this reduces the reflection overhead in calling Lua functions from 4.9% of CPU to 0.9%. This is mainly due to `ScriptTriggers.TickIdle` since that passes an actor parameter.
