### PR TITLE
Allow loading of ChromeLogic properties from YAML

### DIFF
--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -67,7 +67,14 @@ namespace OpenRA
 					foreach (var c in child.Value.Nodes)
 						LoadWidget(args, widget, c);
 
+			var logicNode = node.Value.Nodes.FirstOrDefault(n => n.Key == "Logic");
+			var logic = logicNode == null ? null : logicNode.Value.ToDictionary();
+			args.Add("logicArgs", logic);
+
 			widget.PostInit(args);
+
+			args.Remove("logicArgs");
+
 			return widget;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class AssetBrowserLogic : ChromeLogic
 	{
-		static readonly string[] AllowedExtensions = { ".shp", ".r8", "tmp", ".tem", ".des", ".sno", ".int", ".jun", ".vqa" };
+		static string[] allowedExtensions;
 
 		readonly World world;
 
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		int currentFrame;
 
 		[ObjectCreator.UseCtor]
-		public AssetBrowserLogic(Widget widget, Action onExit, World world)
+		public AssetBrowserLogic(Widget widget, Action onExit, World world, Dictionary<string, MiniYaml> logicArgs)
 		{
 			this.world = world;
 
@@ -212,6 +212,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				prevButton.IsVisible = () => !isVideoLoaded;
 			}
 
+			if (logicArgs.ContainsKey("SupportedFormats"))
+				allowedExtensions = FieldLoader.GetValue<string[]>("SupportedFormats", logicArgs["SupportedFormats"].Value);
+			else
+				allowedExtensions = new string[0];
+
 			assetList = panel.Get<ScrollPanelWidget>("ASSET_LIST");
 			template = panel.Get<ScrollItemWidget>("ASSET_TEMPLATE");
 			PopulateAssetList();
@@ -359,7 +364,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var files = assetSource.AllFileNames().OrderBy(s => s);
 			foreach (var file in files)
 			{
-				if (AllowedExtensions.Any(ext => file.EndsWith(ext, true, CultureInfo.InvariantCulture)))
+				if (allowedExtensions.Any(ext => file.EndsWith(ext, true, CultureInfo.InvariantCulture)))
 				{
 					AddAsset(assetList, file, template);
 					availableShps.Add(file);

--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -1,5 +1,6 @@
 Container@ASSETBROWSER_PANEL:
 	Logic: AssetBrowserLogic
+		SupportedFormats: .shp, .tem, .des, .sno, .jun, .vqa
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - HEIGHT)/2
 	Width: 695

--- a/mods/ra/chrome/assetbrowser.yaml
+++ b/mods/ra/chrome/assetbrowser.yaml
@@ -1,5 +1,6 @@
 Background@ASSETBROWSER_PANEL:
 	Logic: AssetBrowserLogic
+		SupportedFormats: .shp, .r8, .tmp, .tem, .des, .sno, .int, .vqa
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - HEIGHT)/2
 	Width: 700


### PR DESCRIPTION
As opposed to having to add new properties to the widget and loading the values into those, then later having the `ChromeLogic` query the widget to get those.

Also allow mods to override the asset browser's supported file formats least so they can add their own file extensions.
