### PR TITLE
Lower Spy's InfiltrateForPowerOutage time from 30->20sec

### DIFF
--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -15,7 +15,7 @@ namespace OpenRA.Mods.RA.Traits
 {
 	class InfiltrateForPowerOutageInfo : ITraitInfo
 	{
-		public readonly int Duration = 25 * 30;
+		public readonly int Duration = 25 * 20;
 
 		public object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.Self, this); }
 	}


### PR DESCRIPTION
As 30 seconds is quite punishing right now
