### PR TITLE
Fix CellRegion.BoundingRegion behaviour.

### DIFF
--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -53,23 +53,24 @@ namespace OpenRA
 			if (cells == null || !cells.Any())
 				throw new ArgumentException("cells must not be null or empty.", "cells");
 
-			var minX = int.MaxValue;
-			var minY = int.MaxValue;
-			var maxX = int.MinValue;
-			var maxY = int.MinValue;
+			var minU = int.MaxValue;
+			var minV = int.MaxValue;
+			var maxU = int.MinValue;
+			var maxV = int.MinValue;
 			foreach (var cell in cells)
 			{
-				if (minX > cell.X)
-					minX = cell.X;
-				if (maxX < cell.X)
-					maxX = cell.X;
-				if (minY > cell.Y)
-					minY = cell.Y;
-				if (maxY < cell.Y)
-					maxY = cell.Y;
+				var uv = cell.ToMPos(shape);
+				if (minU > uv.U)
+					minU = uv.U;
+				if (maxU < uv.U)
+					maxU = uv.U;
+				if (minV > uv.V)
+					minV = uv.V;
+				if (maxV < uv.V)
+					maxV = uv.V;
 			}
 
-			return new CellRegion(shape, new CPos(minX, minY), new CPos(maxX, maxY));
+			return new CellRegion(shape, new MPos(minU, minV).ToCPos(shape), new MPos(maxU, maxV).ToCPos(shape));
 		}
 
 		public bool Contains(CellRegion region)


### PR DESCRIPTION
CellRegions use MPos internally, and so the bounding area must be calculated in these coordinates in order for it to behave properly in the isometric mods.  This fixes the wonky copy/paste selection area in the TS map editor.
