### PR TITLE
Split D2K shroud/fog rendering and fix shroud blending.

### DIFF
--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -60,7 +60,6 @@
 		Name: shroud
 		Filename: DATA.R8
 		Offset: 12007
-		InvertColor: true
 	FogPaletteFromR8@fog:
 		Name: fog
 		Filename: DATA.R8

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -8,11 +8,11 @@
 		DefeatMusic: score
 	TerrainGeometryOverlay:
 	ShroudRenderer:
-		ShroudVariants: typea, typeb, typec, typed
-		FogVariants: typea, typeb, typec, typed
+		ShroudVariants: shrouda, shroudb, shroudc, shroudd
+		FogVariants: foga, fogb, fogc, fogd
 		Index: 11, 3, 7, 9, 6, 13, 12, 14, 4, 8, 2, 1, 5, 10
-		OverrideFullShroud: full
-		OverrideFullFog: full
+		OverrideFullShroud: shroudfull
+		OverrideFullFog: fogfull
 		ShroudBlend: Multiply
 	Faction@Random:
 		Name: Any

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -362,28 +362,37 @@ resources:
 		Offset: -16,-16
 
 shroud:
-	typea: DATA.R8
+	Defaults:
+		BlendMode: Subtractive
+		Offset: -16,-16
+		Length: 14
+	shrouda: DATA.R8
 		Start: 40
-		Length: 14
-		Offset: -16,-16
-		BlendMode: Multiply
-	typeb: DATA.R8
+	shroudb: DATA.R8
 		Start: 56
-		Length: 14
-		Offset: -16,-16
-		BlendMode: Multiply
-	typec: DATA.R8
+	shroudc: DATA.R8
 		Start: 72
-		Length: 14
-		Offset: -16,-16
-		BlendMode: Multiply
-	typed: DATA.R8
+	shroudd: DATA.R8
 		Start: 88
-		Length: 14
-		Offset: -16,-16
+	shroudfull: fullshroud.shp
+		Offset: 0,0
+		Length: 1
+	foga: DATA.R8
 		BlendMode: Multiply
-	full: fullshroud.shp
+		Start: 40
+	fogb: DATA.R8
 		BlendMode: Multiply
+		Start: 56
+	fogc: DATA.R8
+		BlendMode: Multiply
+		Start: 72
+	fogd: DATA.R8
+		BlendMode: Multiply
+		Start: 88
+	fogfull: fullshroud.shp
+		BlendMode: Multiply
+		Offset: 0,0
+		Length: 1
 
 rockcraters:
 	rockcrater1: DATA.R8


### PR DESCRIPTION
Fixes #8981.

This is a simple and easily tested polish improvement for d2k, so I'd like to see this be merged to prep.
