### PR TITLE
Fix UpgradeActorsNear revoking upgrades after the actor dies

### DIFF
--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ActorEntered(Actor a)
 		{
-			if (a.Disposed)
+			if (a.Disposed || self.Disposed)
 				return;
 
 			if (a == self && !info.AffectsParent)
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ActorExited(Actor a)
 		{
-			if (a == self || a.Disposed)
+			if (a == self || a.Disposed || self.Disposed)
 				return;
 
 			var stance = self.Owner.Stances[a.Owner];


### PR DESCRIPTION
Very hard bug to reproduce: if you can power down a stealth generator just as it is dieing you can hit a race condition that leads to ActorExited() being called to revoke the upgrades after they have already been revoked once.

It helps if you have 100000 actors so the performance is bad enough for the race condition to be more likely to happen. If people want I can upload a couple of replays where I eventually managed to reproduce the crash.

Related to #9242 - exception is the same, with just the source being `UpgradeActorsNear` instead of `DeployToUpgrade`.
