### PR TITLE
Fix a crash when using the chronoshift power on the map bomber john

### DIFF
--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.RA.Activities
 			if (teleporter != null && self != teleporter && !teleporter.Disposed)
 			{
 				var building = teleporter.TraitOrDefault<WithSpriteBody>();
-				if (building != null)
+				if (building != null && building.DefaultAnimation.HasSequence("active"))
 					building.PlayCustomAnimation(teleporter, "active");
 			}
 


### PR DESCRIPTION
Fixes the issue discovered by @obrakmann here: https://github.com/OpenRA/OpenRA/issues/10005#issuecomment-156841805.

~~Just a workaround at the moment, as `Teleport` has an [hardcoded sequence](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.RA/Activities/Teleport.cs#L97).~~
