### PR TITLE
Fixup DeployToUpgrade

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2388,6 +2388,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Upgrades on DeployToUpgrade were renamed to DeployedUpgrades
+				if (engineVersion < 20151122)
+				{
+					if (node.Key == "DeployToUpgrade")
+					{
+						var u = node.Value.Nodes.FirstOrDefault(n => n.Key == "Upgrades");
+						if (u != null)
+							u.Key = "DeployedUpgrades";
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -95,7 +95,7 @@ thumper:
 	Mobile:
 		Speed: 43
 	DeployToUpgrade:
-		Upgrades: deployed
+		DeployedUpgrades: deployed
 		Facing: 128
 		AllowedTerrainTypes: Sand, Spice, Dune
 	WithInfantryBody:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -126,7 +126,8 @@ LPST:
 			gdi: lpst.gdi
 			nod: lpst.nod
 	DeployToUpgrade:
-		Upgrades: deployed
+		DeployedUpgrades: deployed
+		UndeployedUpgrades: undeployed
 		DeployAnimation: make
 		Facing: 160
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
@@ -134,15 +135,15 @@ LPST:
 		UndeploySound: clicky1.aud
 	WithVoxelBody:
 		Image: lpst
-		UpgradeTypes: deployed
-		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: undeployed
+		UpgradeMinEnabledLevel: 1
 	WithSpriteBody@deployed:
 		StartSequence: make
-		UpgradeTypes: deployed
-		UpgradeMinEnabledLevel: 1
+		UpgradeTypes: undeployed
+		UpgradeMaxEnabledLevel: 0
 	DisableOnUpgrade:
-		UpgradeTypes: deployed
-		UpgradeMinEnabledLevel: 1
+		UpgradeTypes: undeployed
+		UpgradeMaxEnabledLevel: 0
 	DetectCloaked:
 		UpgradeTypes: deployed
 		UpgradeMinEnabledLevel: 1


### PR DESCRIPTION
This fixes issues with `DeployToUpgrade` that lead to crashes, as well as adding support for having 3 separate actor states - `Undeployed, Deploying, Deployed`, with the ability to have 3 different sets of traits enabled according to the state (needed for more complex transformations like Tick Tanks).

Fixes #9242.
Fixes #9996.
