### PR TITLE
Add map editor only tooltips

### DIFF
--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -12,12 +12,23 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Shown in the build palette widget.")]
-	public class TooltipInfo : ITraitInfo, ITooltipInfo
+	public abstract class TooltipInfoBase : ITraitInfo
 	{
 		[Translate] public readonly string Description = "";
 		[Translate] public readonly string Name = "";
 
+		public abstract object Create(ActorInitializer init);
+	}
+
+	[Desc("Shown in map editor.")]
+	public class EditorOnlyTooltipInfo : TooltipInfoBase
+	{
+		public override object Create(ActorInitializer init) { return this; }
+	}
+
+	[Desc("Shown in the build palette widget.")]
+	public class TooltipInfo : TooltipInfoBase, ITooltipInfo
+	{
 		[Desc("An optional generic name (i.e. \"Soldier\" or \"Structure\")" +
 			"to be shown to chosen players.")]
 		[Translate] public readonly string GenericName = null;
@@ -34,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence of the actor that contains the cameo.")]
 		public readonly string Icon = "icon";
 
-		public virtual object Create(ActorInitializer init) { return new Tooltip(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Tooltip(init.Self, this); }
 
 		public string TooltipForPlayerStance(Stance stance)
 		{

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 				Footprint = new ReadOnlyDictionary<CPos, SubCell>(footprint);
 			}
 
-			var tooltip = Info.TraitInfoOrDefault<TooltipInfo>();
+			var tooltip = Info.TraitInfoOrDefault<EditorOnlyTooltipInfo>() as TooltipInfoBase ?? Info.TraitInfoOrDefault<TooltipInfo>();
 			Tooltip = (tooltip == null ? " < " + Info.Name + " >" : tooltip.Name) + "\n" + owner.Name + " (" + owner.Faction + ")"
 				+ "\nID: " + ID + "\nType: " + Info.Name;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					item.Bounds.Height = preview.Bounds.Height + 2 * preview.Bounds.Y;
 					item.IsVisible = () => true;
 
-					var tooltip = actor.TraitInfoOrDefault<TooltipInfo>();
+					var tooltip = actor.TraitInfoOrDefault<EditorOnlyTooltipInfo>() as TooltipInfoBase ?? actor.TraitInfoOrDefault<TooltipInfo>();
 					item.GetTooltipText = () => (tooltip == null ? "Type: " : tooltip.Name + "\nType: ") + actor.Name;
 
 					panel.AddChild(item);

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -26,6 +26,8 @@ CRATE:
 		Units: mcv
 
 mpspawn:
+	EditorOnlyTooltip:
+		Name: (multiplayer player starting point)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -35,6 +37,8 @@ mpspawn:
 		QuantizedFacings: 1
 
 waypoint:
+	EditorOnlyTooltip:
+		Name: (waypoint for scripted behavior)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -50,6 +54,8 @@ waypoint:
 		Palette: colorpicker
 
 CAMERA:
+	EditorOnlyTooltip:
+		Name: (reveals area to owner)
 	AlwaysVisible:
 	WithSpriteBody:
 	RenderSpritesEditorOnly:
@@ -64,6 +70,8 @@ CAMERA:
 		Type: CenterPosition
 
 CAMERA.small:
+	EditorOnlyTooltip:
+		Name: (reveals small area to owner)
 	AlwaysVisible:
 	WithSpriteBody:
 	RenderSpritesEditorOnly:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -125,6 +125,8 @@ crate:
 		CustomBounds: 20,20
 
 mpspawn:
+	EditorOnlyTooltip:
+		Name: (multiplayer player starting point)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -134,6 +136,8 @@ mpspawn:
 		QuantizedFacings: 1
 
 waypoint:
+	EditorOnlyTooltip:
+		Name: (waypoint for scripted behavior)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -151,6 +155,8 @@ waypoint:
 		Palette: colorpicker
 
 camera:
+	EditorOnlyTooltip:
+		Name: (reveals area to owner)
 	AlwaysVisible:
 	RenderSpritesEditorOnly:
 	WithSpriteBody:
@@ -165,6 +171,8 @@ camera:
 		Type: CenterPosition
 
 wormspawner:
+	EditorOnlyTooltip:
+		Name: (worm spawning location)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -347,6 +347,8 @@ U2:
 	Inherits: ^Plane
 	Health:
 		HP: 2000
+	EditorOnlyTooltip:
+		Name: U2 Spy Plane
 	Armor:
 		Type: Heavy
 	Aircraft:

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -216,6 +216,8 @@ HIND.Husk:
 
 U2.Husk:
 	Inherits: ^PlaneHusk
+	EditorOnlyTooltip:
+		Name: Husk (U2 Spy Plane)
 	Aircraft:
 		ROT: 7
 		Speed: 373

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -118,6 +118,8 @@ HEALCRATE:
 		Effect: heal
 
 CAMERA:
+	EditorOnlyTooltip:
+		Name: (reveals area to owner)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -134,17 +136,23 @@ CAMERA:
 
 camera.paradrop:
 	Inherits: CAMERA
+	EditorOnlyTooltip:
+		Name: (support power proxy camera)
 	RevealsShroud:
 		Range: 6c0
 
 camera.spyplane:
 	Inherits: CAMERA
+	EditorOnlyTooltip:
+		Name: (support power proxy camera)
 	DetectCloaked:
 		Range: 10c0
 		CloakTypes: Cloak, Hijacker
 
 SONAR:
 	Inherits: camera.spyplane
+	EditorOnlyTooltip:
+		Name: (support power proxy camera)
 	-RevealsShroud:
 	DetectCloaked:
 		CloakTypes: Underwater
@@ -307,6 +315,8 @@ aircraft.upgraded:
 	ProvidesPrerequisite:
 
 mpspawn:
+	EditorOnlyTooltip:
+		Name: (multiplayer player starting point)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -316,6 +326,8 @@ mpspawn:
 		QuantizedFacings: 1
 
 waypoint:
+	EditorOnlyTooltip:
+		Name: (waypoint for scripted behavior)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -714,6 +714,8 @@
 		QuantizedFacings: 1
 
 ^Railway:
+	EditorOnlyTooltip:
+		Name: Railway
 	Inherits: ^TerrainOverlay
 
 ^Tunnel:

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -1,4 +1,6 @@
 mpspawn:
+	EditorOnlyTooltip:
+		Name: (multiplayer player starting point)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -8,6 +10,8 @@ mpspawn:
 		QuantizedFacings: 1
 
 waypoint:
+	EditorOnlyTooltip:
+		Name: (waypoint for scripted behavior)
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
@@ -32,6 +36,8 @@ waypoint:
 		Palette: colorpicker
 
 CAMERA:
+	EditorOnlyTooltip:
+		Name: (reveals area to owner)
 	AlwaysVisible:
 	RenderSpritesEditorOnly:
 	WithSpriteBody:


### PR DESCRIPTION
Polishes map editor with tooltips for actors that are not to show tooltips in game that should help those using the map editor (they don't have to figure out that the player starting points are `mpspawn`).
This is not meant as a partial fix for #9986.
