### PR TITLE
Fix AA-only missiles not damaging landed aircraft

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -121,11 +121,11 @@
 	AppearsOnRadar:
 		UseLocation: yes
 	Targetable@GROUND:
-		TargetTypes: Ground, Vehicle
+		TargetTypes: Ground, Vehicle, Aircraft
 		UpgradeTypes: airborne
 		UpgradeMaxEnabledLevel: 0
 	Targetable@AIRBORNE:
-		TargetTypes: Air
+		TargetTypes: Air, Aircraft
 		UpgradeTypes: airborne
 		UpgradeMinEnabledLevel: 1
 	SelectionDecorations:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -120,7 +120,7 @@ OrcaAAMissiles:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		Versus:
 			Light: 75
 			Heavy: 50
@@ -320,11 +320,8 @@ SAMMissile:
 		ContrailLength: 8
 	Warhead@1Dam: SpreadDamage
 		Spread: 682
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		Versus:
-			None: 100
-			Wood: 100
-			Light: 100
 			Heavy: 75
 		Damage: 30
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
@@ -379,7 +376,7 @@ Patriot:
 		RangeLimit: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 682
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		Versus:
 			Heavy: 75
 		Damage: 50

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -243,6 +243,7 @@ BoatMissile:
 	Burst: 2
 	BurstDelay: 7
 	Report: ROCKET2.AUD
+	ValidTargets: Ground, Air
 	Projectile: Missile
 		Arm: 0
 		Blockable: false
@@ -256,6 +257,7 @@ BoatMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 60
+		ValidTargets: Ground, Air
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -350,11 +350,11 @@
 	Selectable:
 		Bounds: 24,24
 	Targetable@GROUND:
-		TargetTypes: Ground, Repair, Vehicle
+		TargetTypes: Ground, Repair, Vehicle, Aircraft
 		UpgradeTypes: airborne
 		UpgradeMaxEnabledLevel: 0
 	Targetable@AIRBORNE:
-		TargetTypes: Air
+		TargetTypes: Air, Aircraft
 		UpgradeTypes: airborne
 		UpgradeMinEnabledLevel: 1
 	HiddenUnderFog:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -131,7 +131,7 @@ HellfireAA:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		Versus:
 			None: 30
 			Wood: 75
@@ -167,7 +167,7 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 50
-		ValidTargets: Air, Infantry
+		ValidTargets: Air, Aircraft, Infantry
 		Versus:
 			None: 100
 			Wood: 75
@@ -205,7 +205,7 @@ Nike:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		Versus:
 			None: 90
 			Light: 90
@@ -233,7 +233,7 @@ RedEye:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -459,11 +459,11 @@
 	AppearsOnRadar:
 		UseLocation: yes
 	Targetable@GROUND:
-		TargetTypes: Ground
+		TargetTypes: Ground, Aircraft
 		UpgradeTypes: airborne
 		UpgradeMaxEnabledLevel: 0
 	Targetable@AIRBORNE:
-		TargetTypes: Air
+		TargetTypes: Air, Aircraft
 		UpgradeTypes: airborne
 		UpgradeMinEnabledLevel: 1
 	Selectable:

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -104,7 +104,7 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
 		Damage: 40
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		Versus:
 			None: 100
 			Wood: 85
@@ -270,7 +270,7 @@ RedEye2:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 33
-		ValidTargets: Air
+		ValidTargets: Air, Aircraft
 		DamageTypes: SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosion: tiny_twlt


### PR DESCRIPTION
This adresses the edge case where an AA-only missile is fired while the aircraft is in the air, but hits after the aircraft landed and then deals no damage, because the target type is no longer `Air`.

Fixes #9911.
