### PR TITLE
Restore targeting cursor when mousing over a disguised enemy spy.

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Orders
 						modifiers |= TargetModifiers.ForceMove;
 
 					string cursor = null;
-					if (o.Order.CanTarget(self, target, actorsAt, modifiers, ref cursor))
+					if (o.Order.CanTarget(self, target, actorsAt, ref modifiers, ref cursor))
 						return new UnitOrderResult(self, o.Order, o.Trait, cursor, target);
 				}
 			}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Traits
 	{
 		string OrderID { get; }
 		int OrderPriority { get; }
-		bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor);
+		bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor);
 		bool IsQueued { get; }
 		bool OverrideSelection { get; }
 	}

--- a/OpenRA.Mods.Common/Orders/AircraftMoveOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/AircraftMoveOrderTargeter.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		public AircraftMoveOrderTargeter(AircraftInfo info) { this.info = info; }
 
-		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
 			if (target.Type != TargetType.Terrain)
 				return false;

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Orders
 		public int OrderPriority { get; private set; }
 		public bool OverrideSelection { get { return true; } }
 
-		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
 			if (target.Type != TargetType.Actor)
 				return false;

--- a/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Orders
 		public abstract bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor);
 		public abstract bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor);
 
-		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
 			var type = target.Type;
 			if (type != TargetType.Actor && type != TargetType.FrozenActor)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -279,7 +279,7 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority { get; private set; }
 			public bool OverrideSelection { get { return true; } }
 
-			bool CanTargetActor(Actor self, Target target, TargetModifiers modifiers, ref string cursor)
+			bool CanTargetActor(Actor self, Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
@@ -326,13 +326,13 @@ namespace OpenRA.Mods.Common.Traits
 				return true;
 			}
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				switch (target.Type)
 				{
 					case TargetType.Actor:
 					case TargetType.FrozenActor:
-						return CanTargetActor(self, target, modifiers, ref cursor);
+						return CanTargetActor(self, target, ref modifiers, ref cursor);
 					case TargetType.Terrain:
 						return CanTargetLocation(self, self.World.Map.CellContaining(target.CenterPosition), othersAtTarget, modifiers, ref cursor);
 					default:

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -286,6 +286,14 @@ namespace OpenRA.Mods.Common.Traits
 				if (modifiers.HasModifier(TargetModifiers.ForceMove))
 					return false;
 
+				// Disguised actors are revealed by the attack cursor
+				// HACK: works around limitations in the targeting code that force the
+				// targeting and attacking logic (which should be logically separate)
+				// to use the same code
+				if (target.Type == TargetType.Actor && target.Actor.EffectiveOwner != null &&
+						target.Actor.EffectiveOwner.Disguised && self.Owner.Stances[target.Actor.Owner] == Stance.Enemy)
+					modifiers |= TargetModifiers.ForceAttack;
+
 				var forceAttack = modifiers.HasModifier(TargetModifiers.ForceAttack);
 				var a = ab.ChooseArmamentsForTarget(target, forceAttack).FirstOrDefault();
 				if (a == null)

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority { get { return 0; } }
 			public bool OverrideSelection { get { return true; } }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain)
 					return false;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -453,7 +453,7 @@ namespace OpenRA.Mods.Common.Traits
 			public bool IsQueued { get; protected set; }
 			public bool OverrideSelection { get { return true; } }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain)
 					return false;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -707,7 +707,7 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority { get { return 4; } }
 			public bool IsQueued { get; protected set; }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (rejectMove || !target.IsValidFor(self))
 					return false;

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.RA.Traits
 			public int OrderPriority { get { return 5; } }
 			public bool OverrideSelection { get { return true; } }
 
-			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain)
 					return false;

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.RA.Traits
 		public bool IsQueued { get; protected set; }
 		public bool OverrideSelection { get { return true; } }
 
-		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, TargetModifiers modifiers, ref string cursor)
+		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
 			// TODO: When target modifiers are configurable this needs to be revisited
 			if (modifiers.HasModifier(TargetModifiers.ForceMove) || modifiers.HasModifier(TargetModifiers.ForceQueue))


### PR DESCRIPTION
Fixes #10012.

This unfortunately requires a hack. A much cleaner fix (which I tried originally) would have been to make the manual targeting check against the original owner, ignoring EffectiveOwner.  Unfortunately the EffectiveOwner check is enforced for both manual and automatic orders on the ResolveOrder side, so these manual orders are ignored.  The only way to make this work without rewriting the attack logic again is to force a force attack.

On the plus side, at least this approach is easy to review and doesn't risk regressions...
