### PR TITLE
Increase Supply & Demo Truck vision from 3 to 4 cells

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -475,7 +475,7 @@ TRUK:
 	Mobile:
 		Speed: 128
 	RevealsShroud:
-		Range: 3c0
+		Range: 4c0
 	SupplyTruck:
 		Payload: 500
 	SpawnActorOnDeath:
@@ -627,7 +627,7 @@ DTRK:
 	Mobile:
 		Speed: 85
 	RevealsShroud:
-		Range: 3c0
+		Range: 4c0
 	Explodes:
 		Weapon: MiniNuke
 		EmptyWeapon: MiniNuke


### PR DESCRIPTION
Small buff that may help a demo truck out if on a solo mission. Since `TRUK`/`DTRK` are near identical I buffed both of their visions.
