### PR TITLE
Fix gps dot

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -165,7 +165,7 @@ namespace OpenRA
 			return CanViewActor(a);
 		}
 
-		public bool HasFogVisibility { get { return fogVisibilities.Any(f => f.HasFogVisibility(this)); } }
+		public bool HasFogVisibility { get { return fogVisibilities.Any(f => f.HasFogVisibility()); } }
 
 		#region Scripting interface
 

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -159,7 +159,7 @@ namespace OpenRA
 
 		public bool CanTargetActor(Actor a)
 		{
-			if (HasFogVisibility)
+			if (HasFogVisibility && fogVisibilities.Any(f => f.IsVisible(a)))
 				return true;
 
 			return CanViewActor(a);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -189,7 +189,12 @@ namespace OpenRA.Traits
 	public interface IDefaultVisibilityInfo : ITraitInfo { }
 	public interface IDefaultVisibility { bool IsVisible(Actor self, Player byPlayer); }
 	public interface IVisibilityModifier { bool IsVisible(Actor self, Player byPlayer); }
-	public interface IFogVisibilityModifier { bool HasFogVisibility(Player byPlayer); }
+
+	public interface IFogVisibilityModifier
+	{
+		bool IsVisible(Actor actor);
+		bool HasFogVisibility(Player byPlayer);
+	}
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self); }
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -193,7 +193,7 @@ namespace OpenRA.Traits
 	public interface IFogVisibilityModifier
 	{
 		bool IsVisible(Actor actor);
-		bool HasFogVisibility(Player byPlayer);
+		bool HasFogVisibility();
 	}
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self); }

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -79,7 +79,8 @@ namespace OpenRA.Mods.RA.Effects
 			if (disguise.Value != null && disguise.Value.Disguised)
 				return false;
 
-			if (huf.Value != null && !huf.Value.IsVisible(self, toPlayer))
+			if (huf.Value != null && !huf.Value.IsVisible(self, toPlayer)
+				&& toPlayer.Shroud.IsExplored(self.CenterPosition))
 				return true;
 
 			if (fuf.Value == null)
@@ -92,7 +93,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (f.HasRenderables || f.NeedRenderables)
 				return false;
 
-			return f.Visible;
+			return f.Visible && !f.Shrouded;
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -80,6 +80,15 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			return Granted || GrantedAllies;
 		}
+
+		public bool IsVisible(Actor actor)
+		{
+			var gpsDot = actor.TraitOrDefault<GpsDot>();
+			if (gpsDot == null)
+				return false;
+
+			return gpsDot.IsDotVisible(Owner);
+		}
 	}
 
 	class GpsPowerInfo : SupportPowerInfo

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.RA.Traits
 				Owner.Shroud.ExploreAll(Owner.World);
 		}
 
-		public bool HasFogVisibility(Player byPlayer)
+		public bool HasFogVisibility()
 		{
 			return Granted || GrantedAllies;
 		}


### PR DESCRIPTION
More hacks to fix GPS bogosity.
Should no longer enable auto targeting of actors under shroud.
