### PR TITLE
D2k, upgrades without conyard

### DIFF
--- a/mods/d2k/maps/atreides-01a/map.yaml
+++ b/mods/d2k/maps/atreides-01a/map.yaml
@@ -145,9 +145,9 @@ Rules:
 		WormManager:
 			Minimum: 1
 			Maximum: 1
-	construction_yard:
-		Production:
-			Produces: Building
+	upgrade.conyard:
+		Buildable:
+			Prerequisites: ~disabled
 	concreteb:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/d2k/maps/atreides-01b/map.yaml
+++ b/mods/d2k/maps/atreides-01b/map.yaml
@@ -144,9 +144,9 @@ Rules:
 		WormManager:
 			Minimum: 1
 			Maximum: 1
-	construction_yard:
-		Production:
-			Produces: Building
+	upgrade.conyard:
+		Buildable:
+			Prerequisites: ~disabled
 	concreteb:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/d2k/maps/atreides-02a/map.yaml
+++ b/mods/d2k/maps/atreides-02a/map.yaml
@@ -205,9 +205,9 @@ Rules:
 	carryall.reinforce:
 		Cargo:
 			MaxWeight: 10
-	construction_yard:
-		Production:
-			Produces: Building
+	upgrade.conyard:
+		Buildable:
+			Prerequisites: ~disabled
 	concreteb:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/d2k/maps/atreides-02b/map.yaml
+++ b/mods/d2k/maps/atreides-02b/map.yaml
@@ -175,9 +175,9 @@ Rules:
 	carryall.reinforce:
 		Cargo:
 			MaxWeight: 10
-	construction_yard:
-		Production:
-			Produces: Building
+	upgrade.conyard:
+		Buildable:
+			Prerequisites: ~disabled
 	concreteb:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/d2k/maps/atreides-03a/map.yaml
+++ b/mods/d2k/maps/atreides-03a/map.yaml
@@ -182,7 +182,7 @@ Rules:
 			Prerequisites: ~disabled
 	outpost:
 		Buildable:
-			Prerequisites: barracks
+			Prerequisites: construction_yard, barracks
 	quad:
 		Buildable:
 			Prerequisites: upgrade.light

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -1,6 +1,8 @@
 Player:
 	AlwaysVisible:
 	TechTree:
+	Production:
+		Produces: Building, Upgrade
 	ClassicProductionQueue@Building:
 		Type: Building
 		BuildSpeed: 1.0
@@ -16,7 +18,6 @@ Player:
 		QueuedAudio: Upgrading
 		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom
-		SpeedUp: true
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildSpeed: 1.0

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -60,8 +60,7 @@ construction_yard:
 	RevealsShroud:
 		Range: 5c768
 	Production:
-		Produces: Building, Upgrade
-	Exit:
+		Produces: Building
 	Valued:
 		Cost: 2000
 	Tooltip:


### PR DESCRIPTION
This enables upgrades to be purchased without the presence of a Con Yard, as is possible in vanilla.

There was some discussion on the IRC that apparently this was tried earlier with issues, although I'm not sure if the whole thing was actually PR'd separately from #9106. I'd like to get this in as it is fairly annoying that you can't upgrade without a Con Yard, even if you have the upgradable building, but this should be properly tested to see if any issues do exist (no one apparently remembers what the issues were...). From my testing I don't see anything immediately noticable.

Also check the missions to make sure all the available tech is correct, I tried updating them to keep it the same.

The reason the player is also given the building queue is because if it isn't the case then the upgrade tab gets shown to you when deploying your first MCV. This is because the queue appears to activate once the buildup is finished, while the prerequisite is activated immediately. This simply means all buildings should have the construction_yard as a prerequisite, which was already made the case. Just a note for anyone doing any mapping.
