### PR TITLE
Line spacing support in font engine & multi-line tooltip fix-ups

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Graphics
 	{
 		static readonly Library Library = new Library();
 
-		readonly int size;
+		public readonly int Size;
 		readonly SheetBuilder builder;
 		readonly Func<string, float> lineWidth;
 		readonly Face face;
@@ -32,7 +32,7 @@ namespace OpenRA.Graphics
 			if (builder.Type != SheetType.BGRA)
 				throw new ArgumentException("The sheet builder must create BGRA sheets.", "builder");
 
-			this.size = size;
+			this.Size = size;
 			this.builder = builder;
 
 			face = new Face(Library, name);
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 
 		void PrecacheColor(Color c, string name)
 		{
-			using (new PerfTimer("PrecacheColor {0} {1}px {2}".F(name, size, c.Name)))
+			using (new PerfTimer("PrecacheColor {0} {1}px {2}".F(name, Size, c.Name)))
 				for (var n = (char)0x20; n < (char)0x7f; n++)
 					if (glyphs[Pair.New(n, c)] == null)
 						throw new InvalidOperationException();
@@ -58,14 +58,14 @@ namespace OpenRA.Graphics
 
 		public void DrawText(string text, float2 location, Color c, int lineSpacing = 0)
 		{
-			location.Y += size;	// baseline vs top
+			location.Y += Size;	// baseline vs top
 
 			var p = location;
 			foreach (var s in text)
 			{
 				if (s == '\n')
 				{
-					location.Y += size + lineSpacing;
+					location.Y += Size + lineSpacing;
 					p = location;
 					continue;
 				}
@@ -95,10 +95,10 @@ namespace OpenRA.Graphics
 		public int2 Measure(string text, int lineSpacing = 0)
 		{
 			if (string.IsNullOrEmpty(text))
-				return new int2(0, size);
+				return new int2(0, Size);
 
 			var lines = text.Split('\n');
-			return new int2((int)Math.Ceiling(lines.Max(lineWidth)), lines.Length * (size + lineSpacing) - lineSpacing);
+			return new int2((int)Math.Ceiling(lines.Max(lineWidth)), lines.Length * (Size + lineSpacing) - lineSpacing);
 		}
 
 		GlyphInfo CreateGlyph(Pair<char, Color> c)

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Graphics
 						throw new InvalidOperationException();
 		}
 
-		public void DrawText(string text, float2 location, Color c)
+		public void DrawText(string text, float2 location, Color c, int lineSpacing = 0)
 		{
 			location.Y += size;	// baseline vs top
 
@@ -65,7 +65,7 @@ namespace OpenRA.Graphics
 			{
 				if (s == '\n')
 				{
-					location.Y += size;
+					location.Y += size + lineSpacing;
 					p = location;
 					continue;
 				}
@@ -79,26 +79,26 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public void DrawTextWithContrast(string text, float2 location, Color fg, Color bg, int offset)
+		public void DrawTextWithContrast(string text, float2 location, Color fg, Color bg, int offset, int lineSpacing = 0)
 		{
 			if (offset > 0)
 			{
-				DrawText(text, location + new float2(-offset, 0), bg);
-				DrawText(text, location + new float2(offset, 0), bg);
-				DrawText(text, location + new float2(0, -offset), bg);
-				DrawText(text, location + new float2(0, offset), bg);
+				DrawText(text, location + new float2(-offset, 0), bg, lineSpacing);
+				DrawText(text, location + new float2(offset, 0), bg, lineSpacing);
+				DrawText(text, location + new float2(0, -offset), bg, lineSpacing);
+				DrawText(text, location + new float2(0, offset), bg, lineSpacing);
 			}
 
-			DrawText(text, location, fg);
+			DrawText(text, location, fg, lineSpacing);
 		}
 
-		public int2 Measure(string text)
+		public int2 Measure(string text, int lineSpacing = 0)
 		{
 			if (string.IsNullOrEmpty(text))
 				return new int2(0, size);
 
 			var lines = text.Split('\n');
-			return new int2((int)Math.Ceiling(lines.Max(lineWidth)), lines.Length * size);
+			return new int2((int)Math.Ceiling(lines.Max(lineWidth)), lines.Length * (size + lineSpacing) - lineSpacing);
 		}
 
 		GlyphInfo CreateGlyph(Pair<char, Color> c)

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<Color> GetContrastColor;
 		public int FontSize { get { return font.Value.Size; } }
 		public int LinePixelSpacing { get { return linePixelSpacing.Value; } }
+		public SpriteFont SpriteFont { get { return font.Value; } }
 		Lazy<int> linePixelSpacing;
 		Lazy<SpriteFont> font;
 
@@ -101,6 +102,16 @@ namespace OpenRA.Mods.Common.Widgets
 			if (LineVAlign != LineVAlign.Collapsed)
 				textSize += new int2(0, linePixelSpacing.Value);
 			return textSize;
+		}
+
+		public string WrapText(string text)
+		{
+			return WidgetUtils.WrapText(text, Bounds.Width, font.Value);
+		}
+
+		public string TruncateText(string text)
+		{
+			return WidgetUtils.TruncateText(text, Bounds.Width, font.Value);
 		}
 
 		public int2 ResizeToText(string text)

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public bool Contrast = ChromeMetrics.Get<bool>("TextContrast");
 		public Color ContrastColor = ChromeMetrics.Get<Color>("TextContrastColor");
 		public bool WordWrap = false;
+		public int LineSpacing = 3;
 		public Func<string> GetText;
 		public Func<Color> GetColor;
 		public Func<Color> GetContrastColor;
@@ -64,7 +65,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (text == null)
 				return;
 
-			var textSize = font.Measure(text);
+			var textSize = font.Measure(text, LineSpacing);
 			var position = RenderOrigin;
 
 			if (VAlign == TextVAlign.Middle)
@@ -85,9 +86,9 @@ namespace OpenRA.Mods.Common.Widgets
 			var color = GetColor();
 			var contrast = GetContrastColor();
 			if (Contrast)
-				font.DrawTextWithContrast(text, position, color, contrast, 2);
+				font.DrawTextWithContrast(text, position, color, contrast, 2, LineSpacing);
 			else
-				font.DrawText(text, position, color);
+				font.DrawText(text, position, color, LineSpacing);
 		}
 
 		public override Widget Clone() { return new LabelWidget(this); }

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -18,21 +18,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public ButtonTooltipLogic(Widget widget, ButtonWidget button)
 		{
 			var label = widget.Get<LabelWidget>("LABEL");
-			var font = Game.Renderer.Fonts[label.Font];
 			var text = button.GetTooltipText();
-			var textDims = font.Measure(text, label.LineSpacing);
+			var textSize = label.MeasureText(text);
 
 			label.GetText = () => text;
-			label.Bounds.Width = textDims.X;
-			label.Bounds.Height = textDims.Y;
+			label.Bounds.Width = textSize.X;
+			label.Bounds.Height = textSize.Y;
 			var horizontalPadding = widget.Bounds.Width - label.Bounds.Width;
 			if (horizontalPadding <= 0 || label.Bounds.Width <= 0)
 				horizontalPadding = 2 * label.Bounds.X;
 			var verticalPadding = widget.Bounds.Height - label.Bounds.Height;
 			if (verticalPadding <= 0 || label.Bounds.Height <= 0)
-				verticalPadding = 2 * label.Bounds.Y + 2 * font.Size / 5; // With hang space
-			widget.Bounds.Width = textDims.X + horizontalPadding;
-			widget.Bounds.Height = textDims.Y + verticalPadding;
+				verticalPadding = 2 * label.Bounds.Y
+					+ System.Math.Max(label.LineSpacing, 2 * label.FontSize / 5); // With hang space
+			widget.Bounds.Width = textSize.X + horizontalPadding;
+			widget.Bounds.Height = textSize.Y + verticalPadding;
 
 			if (button.Key.IsValid())
 			{
@@ -42,9 +42,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var hotkeyLabel = "({0})".F(button.Key.DisplayString());
 				hotkey.GetText = () => hotkeyLabel;
 				hotkey.Bounds.X = widget.Bounds.Width;
-				var hotkeyTextDims = font.Measure(hotkeyLabel, hotkey.LineSpacing);
-				hotkey.Bounds.Height = hotkeyTextDims.Y;
-				hotkey.Bounds.Width = hotkeyTextDims.X;
+				var hotkeyTextSize = hotkey.MeasureText(hotkeyLabel);
+				hotkey.Bounds.Height = hotkeyTextSize.Y;
+				hotkey.Bounds.Width = hotkeyTextSize.X;
 
 				widget.Bounds.Width = hotkey.Bounds.X + label.Bounds.X + hotkey.Bounds.Width;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -19,18 +19,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var label = widget.Get<LabelWidget>("LABEL");
 			var text = button.GetTooltipText();
-			var textSize = label.MeasureText(text);
 
 			label.GetText = () => text;
-			label.Bounds.Width = textSize.X;
-			label.Bounds.Height = textSize.Y;
 			var horizontalPadding = widget.Bounds.Width - label.Bounds.Width;
 			if (horizontalPadding <= 0 || label.Bounds.Width <= 0)
 				horizontalPadding = 2 * label.Bounds.X;
 			var verticalPadding = widget.Bounds.Height - label.Bounds.Height;
 			if (verticalPadding <= 0 || label.Bounds.Height <= 0)
-				verticalPadding = 2 * label.Bounds.Y
-					+ System.Math.Max(label.LineSpacing, 2 * label.FontSize / 5); // With hang space
+				verticalPadding = 2 * label.Bounds.Y + label.LinePixelSpacing; // With hang space
+
+			var textSize = label.ResizeToText(text);
 			widget.Bounds.Width = textSize.X + horizontalPadding;
 			widget.Bounds.Height = textSize.Y + verticalPadding;
 
@@ -42,9 +40,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var hotkeyLabel = "({0})".F(button.Key.DisplayString());
 				hotkey.GetText = () => hotkeyLabel;
 				hotkey.Bounds.X = widget.Bounds.Width;
-				var hotkeyTextSize = hotkey.MeasureText(hotkeyLabel);
-				hotkey.Bounds.Height = hotkeyTextSize.Y;
-				hotkey.Bounds.Width = hotkeyTextSize.X;
+				hotkey.ResizeToText(hotkeyLabel);
 
 				widget.Bounds.Width = hotkey.Bounds.X + label.Bounds.X + hotkey.Bounds.Width;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -20,11 +20,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var label = widget.Get<LabelWidget>("LABEL");
 			var font = Game.Renderer.Fonts[label.Font];
 			var text = button.GetTooltipText();
-			var labelWidth = font.Measure(text).X;
+			var textDims = font.Measure(text, label.LineSpacing);
 
 			label.GetText = () => text;
-			label.Bounds.Width = labelWidth;
-			widget.Bounds.Width = 2 * label.Bounds.X + labelWidth;
+			label.Bounds.Width = textDims.X;
+			label.Bounds.Height = textDims.Y;
+			var horizontalPadding = widget.Bounds.Width - label.Bounds.Width;
+			if (horizontalPadding <= 0 || label.Bounds.Width <= 0)
+				horizontalPadding = 2 * label.Bounds.X;
+			var verticalPadding = widget.Bounds.Height - label.Bounds.Height;
+			if (verticalPadding <= 0 || label.Bounds.Height <= 0)
+				verticalPadding = 2 * label.Bounds.Y + 2 * font.Size / 5; // With hang space
+			widget.Bounds.Width = textDims.X + horizontalPadding;
+			widget.Bounds.Height = textDims.Y + verticalPadding;
 
 			if (button.Key.IsValid())
 			{
@@ -33,9 +41,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var hotkeyLabel = "({0})".F(button.Key.DisplayString());
 				hotkey.GetText = () => hotkeyLabel;
-				hotkey.Bounds.X = labelWidth + 2 * label.Bounds.X;
+				hotkey.Bounds.X = widget.Bounds.Width;
+				var hotkeyTextDims = font.Measure(hotkeyLabel, hotkey.LineSpacing);
+				hotkey.Bounds.Height = hotkeyTextDims.Y;
+				hotkey.Bounds.Width = hotkeyTextDims.X;
 
-				widget.Bounds.Width = hotkey.Bounds.X + label.Bounds.X + font.Measure(hotkeyLabel).X;
+				widget.Bounds.Width = hotkey.Bounds.X + label.Bounds.X + hotkey.Bounds.Width;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/FactionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/FactionTooltipLogic.cs
@@ -23,8 +23,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var header = widget.Get<LabelWidget>("HEADER");
 			var headerLine = lines[0];
-			var headerFont = Game.Renderer.Fonts[header.Font];
-			var headerSize = headerFont.Measure(headerLine);
+			var headerSize = header.MeasureText(headerLine);
 			header.Bounds.Width += headerSize.X;
 			header.Bounds.Height += headerSize.Y;
 			header.GetText = () => headerLine;
@@ -33,11 +32,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var description = widget.Get<LabelWidget>("DESCRIPTION");
 				var descriptionLines = lines.Skip(1).ToArray();
-				var descriptionFont = Game.Renderer.Fonts[description.Font];
 				description.Bounds.Y += header.Bounds.Y + header.Bounds.Height;
-				description.Bounds.Width += descriptionLines.Select(l => descriptionFont.Measure(l).X).Max();
-				description.Bounds.Height += descriptionFont.Measure(descriptionLines.First()).Y * descriptionLines.Length;
-				description.GetText = () => string.Join("\n", descriptionLines);
+				description.Text = string.Join("\n", descriptionLines);
+				var descriptionSize = description.MeasureText(description.Text);
+				description.Bounds.Width += descriptionSize.X;
+				description.Bounds.Height += descriptionSize.Y;
 
 				widget.Bounds.Width = Math.Max(header.Bounds.X + header.Bounds.Width, description.Bounds.X + description.Bounds.Width);
 				widget.Bounds.Height = description.Bounds.Y + description.Bounds.Height;

--- a/OpenRA.Mods.Common/Widgets/Logic/FactionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/FactionTooltipLogic.cs
@@ -23,28 +23,44 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var header = widget.Get<LabelWidget>("HEADER");
 			var headerLine = lines[0];
-			var headerSize = header.MeasureText(headerLine);
-			header.Bounds.Width += headerSize.X;
-			header.Bounds.Height += headerSize.Y;
 			header.GetText = () => headerLine;
+
+			var verticalPadding = widget.Bounds.Height - header.Bounds.Height;
+			if (verticalPadding <= 0)
+				verticalPadding = 2 * header.Bounds.Y + header.LinePixelSpacing; // With hang space
+
+			header.ResizeToText(headerLine);
 
 			if (lines.Length > 1)
 			{
 				var description = widget.Get<LabelWidget>("DESCRIPTION");
-				var descriptionLines = lines.Skip(1).ToArray();
-				description.Bounds.Y += header.Bounds.Y + header.Bounds.Height;
-				description.Text = string.Join("\n", descriptionLines);
-				var descriptionSize = description.MeasureText(description.Text);
-				description.Bounds.Width += descriptionSize.X;
-				description.Bounds.Height += descriptionSize.Y;
+				var maxRight = Math.Max(header.Bounds.Right, description.Bounds.Right);
+				var minLeft = Math.Min(header.Bounds.Left, description.Bounds.Left);
+				var horizontalPadding = widget.Bounds.Width  + minLeft - maxRight;
+				if (horizontalPadding <= 0)
+					horizontalPadding = 2 * Math.Min(header.Bounds.X, description.Bounds.X);
+				var separatorPadding = description.Bounds.Y - header.Bounds.Bottom;
+				if (separatorPadding <= 0)
+					separatorPadding = header.LinePixelSpacing;
 
-				widget.Bounds.Width = Math.Max(header.Bounds.X + header.Bounds.Width, description.Bounds.X + description.Bounds.Width);
-				widget.Bounds.Height = description.Bounds.Y + description.Bounds.Height;
+				var descriptionLines = lines.Skip(1).ToArray();
+				description.Bounds.Y = header.Bounds.Bottom + separatorPadding;
+				description.Text = string.Join("\n", descriptionLines);
+				description.ResizeToText(description.Text);
+
+				maxRight = Math.Max(header.Bounds.Right, description.Bounds.Right);
+				minLeft = Math.Min(header.Bounds.Left, description.Bounds.Left);
+				widget.Bounds.Width = maxRight - minLeft + horizontalPadding;
+				widget.Bounds.Height = description.Bounds.Bottom + verticalPadding - header.Bounds.Y;
 			}
 			else
 			{
-				widget.Bounds.Width = header.Bounds.X + header.Bounds.Width;
-				widget.Bounds.Height = header.Bounds.Y + header.Bounds.Height;
+				var horizontalPadding = widget.Bounds.Width - header.Bounds.Width;
+				if (horizontalPadding <= 0)
+					horizontalPadding = 2 * header.Bounds.X;
+
+				widget.Bounds.Width = header.Bounds.Right + horizontalPadding;
+				widget.Bounds.Height = header.Bounds.Bottom + verticalPadding - header.Bounds.Y;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -179,8 +179,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (!string.IsNullOrEmpty(from))
 				name = from + ":";
 
-			var font = Game.Renderer.Fonts[nameLabel.Font];
-			var nameSize = font.Measure(from);
+			var nameSize = nameLabel.MeasureText(from);
 
 			nameLabel.GetColor = () => c;
 			nameLabel.GetText = () => name;
@@ -189,9 +188,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			textLabel.Bounds.Width -= nameSize.X;
 
 			// Hack around our hacky wordwrap behavior: need to resize the widget to fit the text
-			text = WidgetUtils.WrapText(text, textLabel.Bounds.Width, font);
+			text = textLabel.WrapText(text);
 			textLabel.GetText = () => text;
-			var dh = font.Measure(text).Y - textLabel.Bounds.Height;
+			var dh = textLabel.MeasureText(text).Y - textLabel.Bounds.Height;
 			if (dh > 0)
 			{
 				textLabel.Bounds.Height += dh;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -40,9 +40,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var iconMargin = timeIcon.Bounds.X;
 
-			var font = Game.Renderer.Fonts[nameLabel.Font];
-			var descFont = Game.Renderer.Fonts[descLabel.Font];
-			var requiresFont = Game.Renderer.Fonts[requiresLabel.Font];
 			ActorInfo lastActor = null;
 
 			tooltipContainer.BeforeRender = () =>
@@ -61,9 +58,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				nameLabel.GetText = () => tooltip.Name;
 
 				var hotkey = palette.TooltipIcon.Hotkey;
-				var nameWidth = font.Measure(tooltip.Name).X;
+				var nameWidth = nameLabel.MeasureText(tooltip.Name).X;
 				var hotkeyText = "({0})".F(hotkey.DisplayString());
-				var hotkeyWidth = hotkey.IsValid() ? font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
+				var hotkeyWidth = hotkey.IsValid() ? hotkeyLabel.MeasureText(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
 				hotkeyLabel.GetText = () => hotkeyText;
 				hotkeyLabel.Bounds.X = nameWidth + 2 * nameLabel.Bounds.X;
 				hotkeyLabel.Visible = hotkey.IsValid();
@@ -95,15 +92,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var descString = tooltip.Description.Replace("\\n", "\n");
 				descLabel.GetText = () => descString;
 
-				var leftWidth = new[] { nameWidth + hotkeyWidth, requiresFont.Measure(requiresString).X, descFont.Measure(descString).X }.Aggregate(Math.Max);
-				var rightWidth = new[] { font.Measure(powerString).X, font.Measure(timeString).X, font.Measure(costString).X }.Aggregate(Math.Max);
+				var leftWidth = new[] { nameWidth + hotkeyWidth, requiresLabel.MeasureText(requiresString).X, descLabel.MeasureText(descString).X }.Aggregate(Math.Max);
+				var rightWidth = new[] { powerLabel.MeasureText(powerString).X, timeLabel.MeasureText(timeString).X, costLabel.MeasureText(costString).X }.Aggregate(Math.Max);
 
 				timeIcon.Bounds.X = powerIcon.Bounds.X = costIcon.Bounds.X = leftWidth + 2 * nameLabel.Bounds.X;
 				timeLabel.Bounds.X = powerLabel.Bounds.X = costLabel.Bounds.X = timeIcon.Bounds.Right + iconMargin;
 				widget.Bounds.Width = leftWidth + rightWidth + 3 * nameLabel.Bounds.X + timeIcon.Bounds.Width + iconMargin;
 
-				var leftHeight = font.Measure(tooltip.Name).Y + requiresFont.Measure(requiresString).Y + descFont.Measure(descString).Y;
-				var rightHeight = font.Measure(powerString).Y + font.Measure(timeString).Y + font.Measure(costString).Y;
+				var leftHeight = nameLabel.MeasureText(tooltip.Name).Y + requiresLabel.MeasureText(requiresString).Y + descLabel.MeasureText(descString).Y;
+				var rightHeight = powerLabel.MeasureText(powerString).Y + timeLabel.MeasureText(timeString).Y + costLabel.MeasureText(costString).Y;
 				widget.Bounds.Height = Math.Max(leftHeight, rightHeight) * 3 / 2 + 3 * nameLabel.Bounds.Y;
 
 				lastActor = actor;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var hotkey = palette.TooltipIcon.Hotkey;
 				var nameWidth = nameLabel.MeasureText(tooltip.Name).X;
 				var hotkeyText = "({0})".F(hotkey.DisplayString());
-				var hotkeyWidth = hotkey.IsValid() ? hotkeyLabel.MeasureText(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
+				var hotkeyWidth = hotkey.IsValid() ? hotkeyLabel.ResizeToText(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
 				hotkeyLabel.GetText = () => hotkeyText;
 				hotkeyLabel.Bounds.X = nameWidth + 2 * nameLabel.Bounds.X;
 				hotkeyLabel.Visible = hotkey.IsValid();
@@ -92,19 +92,33 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var descString = tooltip.Description.Replace("\\n", "\n");
 				descLabel.GetText = () => descString;
 
-				var leftWidth = new[] { nameWidth + hotkeyWidth, requiresLabel.MeasureText(requiresString).X, descLabel.MeasureText(descString).X }.Aggregate(Math.Max);
-				var rightWidth = new[] { powerLabel.MeasureText(powerString).X, timeLabel.MeasureText(timeString).X, costLabel.MeasureText(costString).X }.Aggregate(Math.Max);
+				var leftWidth = new[] { nameWidth + hotkeyWidth, requiresLabel.ResizeToText(requiresString).X, descLabel.ResizeToText(descString).X }.Aggregate(Math.Max);
+				var rightWidth = new[] { powerLabel.ResizeToText(powerString).X, timeLabel.ResizeToText(timeString).X, costLabel.ResizeToText(costString).X }.Aggregate(Math.Max);
 
 				timeIcon.Bounds.X = powerIcon.Bounds.X = costIcon.Bounds.X = leftWidth + 2 * nameLabel.Bounds.X;
 				timeLabel.Bounds.X = powerLabel.Bounds.X = costLabel.Bounds.X = timeIcon.Bounds.Right + iconMargin;
 				widget.Bounds.Width = leftWidth + rightWidth + 3 * nameLabel.Bounds.X + timeIcon.Bounds.Width + iconMargin;
 
-				var leftHeight = nameLabel.MeasureText(tooltip.Name).Y + requiresLabel.MeasureText(requiresString).Y + descLabel.MeasureText(descString).Y;
-				var rightHeight = powerLabel.MeasureText(powerString).Y + timeLabel.MeasureText(timeString).Y + costLabel.MeasureText(costString).Y;
-				widget.Bounds.Height = Math.Max(leftHeight, rightHeight) * 3 / 2 + 3 * nameLabel.Bounds.Y;
+				var nameBottom = nameLabel.Bounds.Bottom + nameLabel.LinePixelSpacing;
+				var requiresBottom = requiresLabel.Bounds.Bottom + requiresLabel.LinePixelSpacing;
+				var descBottom = descLabel.Bounds.Bottom + descLabel.LinePixelSpacing;
+				var leftBottom = Math.Max(Math.Max(nameBottom, requiresBottom), descBottom);
+
+				var costBottom = IconLabelPairBottom(costIcon, costLabel);
+				var timeBottom = IconLabelPairBottom(timeIcon, timeLabel);
+				var powerBottom = powerIcon.IsVisible() ? IconLabelPairBottom(powerIcon, powerLabel) : 0;
+				var rightBottom = Math.Max(Math.Max(costBottom, timeBottom), powerBottom);
+
+				widget.Bounds.Height = Math.Max(leftBottom, rightBottom) + 2 * nameLabel.Bounds.Y;
 
 				lastActor = actor;
 			};
+		}
+
+		static int IconLabelPairBottom(ImageWidget icon, LabelWidget label)
+		{
+			var iconBottom = icon.Bounds.Height != 0 ? icon.Bounds.Bottom : icon.Bounds.Y + icon.Bounds.Width;
+			return Math.Max(iconBottom + label.LinePixelSpacing, label.Bounds.Bottom);
 		}
 
 		static string ActorName(Ruleset rules, string a)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -24,9 +24,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var hotkeyLabel = widget.Get<LabelWidget>("HOTKEY");
 			var timeLabel = widget.Get<LabelWidget>("TIME");
 			var descLabel = widget.Get<LabelWidget>("DESC");
-			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
-			var timeFont = Game.Renderer.Fonts[timeLabel.Font];
-			var descFont = Game.Renderer.Fonts[descLabel.Font];
 			var name = "";
 			var time = "";
 			var desc = "";
@@ -58,14 +55,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var hotkey = icon.Hotkey;
 				var hotkeyText = "({0})".F(hotkey.DisplayString());
-				var hotkeyWidth = hotkey.IsValid() ? nameFont.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
+				var hotkeyWidth = hotkey.IsValid() ? hotkeyLabel.MeasureText(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
 				hotkeyLabel.GetText = () => hotkeyText;
-				hotkeyLabel.Bounds.X = nameFont.Measure(name).X + 2 * nameLabel.Bounds.X;
+				hotkeyLabel.Bounds.X = nameLabel.MeasureText(name).X + 2 * nameLabel.Bounds.X;
 				hotkeyLabel.Visible = hotkey.IsValid();
 
-				var timeWidth = timeFont.Measure(time).X;
-				var topWidth = nameFont.Measure(name).X + hotkeyWidth + timeWidth + timeOffset;
-				var descSize = descFont.Measure(desc);
+				var timeWidth = timeLabel.MeasureText(time).X;
+				var topWidth = nameLabel.MeasureText(name).X + hotkeyWidth + timeWidth + timeOffset;
+				var descSize = descLabel.MeasureText(desc);
 				widget.Bounds.Width = 2 * nameLabel.Bounds.X + Math.Max(topWidth, descSize.X);
 				widget.Bounds.Height = baseHeight + descSize.Y;
 				timeLabel.Bounds.X = widget.Bounds.Width - nameLabel.Bounds.X - timeWidth;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -27,8 +27,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var owner = widget.Get<LabelWidget>("OWNER");
 			var extras = widget.Get<LabelWidget>("EXTRA");
 
-			var font = Game.Renderer.Fonts[label.Font];
-			var ownerFont = Game.Renderer.Fonts[owner.Font];
 			var cachedWidth = 0;
 			var labelText = "";
 			var showOwner = false;
@@ -92,7 +90,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 				}
 
-				var textWidth = Math.Max(font.Measure(labelText).X, font.Measure(extraText).X);
+				var textWidth = Math.Max(label.MeasureText(labelText).X, extras.MeasureText(extraText).X);
 
 				if (textWidth != cachedWidth)
 				{
@@ -107,7 +105,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ownerColor = o.Color.RGB;
 					widget.Bounds.Height = doubleHeight;
 					widget.Bounds.Width = Math.Max(widget.Bounds.Width,
-						owner.Bounds.X + ownerFont.Measure(ownerName).X + label.Bounds.X);
+						owner.Bounds.X + owner.MeasureText(ownerName).X + label.Bounds.X);
 					index++;
 				}
 				else
@@ -115,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (extraText != "")
 				{
-					widget.Bounds.Height += font.Measure(extraText).Y + extras.Bounds.Height;
+					widget.Bounds.Height += extras.MeasureText(extraText).Y + extras.Bounds.Height;
 					if (showOwner)
 						extras.Bounds.Y = extraHeightOnDouble;
 					else

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
@@ -18,28 +18,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class ClientTooltipLogic : ChromeLogic
 	{
-		SpriteFont latencyFont;
-		SpriteFont latencyPrefixFont;
-
 		[ObjectCreator.UseCtor]
 		public ClientTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, OrderManager orderManager, int clientIndex)
 		{
 			var admin = widget.Get<LabelWidget>("ADMIN");
-			var adminFont = Game.Renderer.Fonts[admin.Font];
-
 			var latency = widget.GetOrNull<LabelWidget>("LATENCY");
-			if (latency != null)
-				latencyFont = Game.Renderer.Fonts[latency.Font];
-
 			var latencyPrefix = widget.GetOrNull<LabelWidget>("LATENCY_PREFIX");
-			if (latencyPrefix != null)
-				latencyPrefixFont = Game.Renderer.Fonts[latencyPrefix.Font];
-
 			var ip = widget.Get<LabelWidget>("IP");
-			var addressFont = Game.Renderer.Fonts[ip.Font];
-
 			var location = widget.Get<LabelWidget>("LOCATION");
-			var locationFont = Game.Renderer.Fonts[location.Font];
 
 			var locationOffset = location.Bounds.Y;
 			var addressOffset = ip.Bounds.Y;
@@ -51,12 +37,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			tooltipContainer.IsVisible = () => (orderManager.LobbyInfo.ClientWithIndex(clientIndex) != null);
 			tooltipContainer.BeforeRender = () =>
 			{
-				var latencyPrefixSize = latencyPrefix == null ? 0 : latencyPrefix.Bounds.X + latencyPrefixFont.Measure(latencyPrefix.GetText() + " ").X;
-				var locationWidth = locationFont.Measure(location.GetText()).X;
-				var adminWidth = adminFont.Measure(admin.GetText()).X;
-				var addressWidth = addressFont.Measure(ip.GetText()).X;
-				var latencyWidth = latencyFont == null ? 0 : latencyPrefixSize + latencyFont.Measure(latency.GetText()).X;
-				var width = Math.Max(locationWidth, Math.Max(adminWidth, Math.Max(addressWidth, latencyWidth)));
+				var latencyPrefixSize = latencyPrefix == null ? 0 : latencyPrefix.Bounds.X + latencyPrefix.MeasureText(latencyPrefix.GetText() + " ").X;
+				var locationWidth = location.MeasureText(location.GetText()).X;
+				var adminWidth = admin.MeasureText(admin.GetText()).X;
+				var ipWidth = ip.MeasureText(ip.GetText()).X;
+				var latencyWidth = latency == null ? 0 : latencyPrefixSize + latency.MeasureText(latency.GetText()).X;
+				var width = Math.Max(locationWidth, Math.Max(adminWidth, Math.Max(ipWidth, latencyWidth)));
 				widget.Bounds.Width = width + 2 * margin;
 				if (latency != null)
 					latency.Bounds.Width = widget.Bounds.Width;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -700,8 +700,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var textLabel = template.Get<LabelWidget>("TEXT");
 
 			var name = from + ":";
-			var font = Game.Renderer.Fonts[nameLabel.Font];
-			var nameSize = font.Measure(from);
+			var nameSize = nameLabel.MeasureText(from);
 
 			var time = DateTime.Now;
 			timeLabel.GetText = () => "{0:D2}:{1:D2}".F(time.Hour, time.Minute);
@@ -713,9 +712,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			textLabel.Bounds.Width -= nameSize.X;
 
 			// Hack around our hacky wordwrap behavior: need to resize the widget to fit the text
-			text = WidgetUtils.WrapText(text, textLabel.Bounds.Width, font);
+			text = textLabel.WrapText(text);
 			textLabel.GetText = () => text;
-			var dh = font.Measure(text).Y - textLabel.Bounds.Height;
+			var dh = textLabel.MeasureText(text).Y - textLabel.Bounds.Height;
 			if (dh > 0)
 			{
 				textLabel.Bounds.Height += dh;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -482,10 +482,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var client = player.World.LobbyInfo.ClientWithIndex(player.ClientIndex);
 			var playerName = template.Get<LabelWidget>("PLAYER");
-			var playerNameFont = Game.Renderer.Fonts[playerName.Font];
-			var suffixLength = new CachedTransform<string, int>(s => playerNameFont.Measure(s).X);
+			var suffixLength = new CachedTransform<string, int>(s => playerName.MeasureText(s).X);
 			var name = new CachedTransform<Pair<string, int>, string>(c =>
-				WidgetUtils.TruncateText(c.First, playerName.Bounds.Width - c.Second, playerNameFont));
+				WidgetUtils.TruncateText(c.First, playerName.Bounds.Width - c.Second, playerName.SpriteFont));
 
 			playerName.GetText = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -25,8 +25,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var team = widget.Get<LabelWidget>("TEAM");
 			var singleHeight = widget.Get("SINGLE_HEIGHT").Bounds.Height;
 			var doubleHeight = widget.Get("DOUBLE_HEIGHT").Bounds.Height;
-			var ownerFont = Game.Renderer.Fonts[label.Font];
-			var teamFont = Game.Renderer.Fonts[team.Font];
 
 			// Width specified in YAML is used as the margin between flag / label and label / border
 			var labelMargin = widget.Bounds.Width;
@@ -54,12 +52,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					playerFaction = occupant.Faction;
 					playerTeam = occupant.Team;
 					widget.Bounds.Height = playerTeam > 0 ? doubleHeight : singleHeight;
-					teamWidth = teamFont.Measure(team.GetText()).X;
+					teamWidth = team.MeasureText(team.GetText()).X;
 				}
 
 				label.Bounds.X = playerFaction != null ? flag.Bounds.Right + labelMargin : labelMargin;
 
-				var textWidth = ownerFont.Measure(labelText).X;
+				var textWidth = label.MeasureText(labelText).X;
 				if (textWidth != cachedWidth)
 				{
 					label.Bounds.Width = textWidth;

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -328,7 +328,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var content = item.Content.Replace("\\n", "\n");
 				content = WidgetUtils.WrapText(content, contentLabel.Bounds.Width, Game.Renderer.Fonts[contentLabel.Font]);
 				contentLabel.GetText = () => content;
-				contentLabel.Bounds.Height = Game.Renderer.Fonts[contentLabel.Font].Measure(content).Y;
+				contentLabel.Bounds.Height = contentLabel.MeasureText(content).Y;
 				newsItem.Bounds.Height += contentLabel.Bounds.Height;
 
 				newsPanel.AddChild(newsItem);

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var text = map.Description != null ? map.Description.Replace("\\n", "\n") : "";
 			text = WidgetUtils.WrapText(text, description.Bounds.Width, descriptionFont);
 			description.Text = text;
-			description.Bounds.Height = descriptionFont.Measure(text).Y;
+			description.Bounds.Height = description.MeasureText(text).Y;
 			descriptionPanel.ScrollToTop();
 			descriptionPanel.Layout.AdjustChildren();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -27,21 +27,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				horizontalPadding = 2 * label.Bounds.X;
 			var verticalPadding = widget.Bounds.Height - label.Bounds.Height;
 			if (verticalPadding <= 0 || label.Bounds.Height <= 0)
-				verticalPadding = 2 * label.Bounds.Y
-					+ System.Math.Max(label.LineSpacing, 2 * label.FontSize / 5); // With hang space
+				verticalPadding = 2 * label.Bounds.Y + label.LinePixelSpacing; // With hang space
 			var labelText = "";
 			tooltipContainer.BeforeRender = () =>
 			{
 				labelText = getText();
-				var textSize = label.MeasureText(labelText);
-				if (label.LineVAlign != LineVAlign.Collapsed)
-					textSize += new int2(0, label.LineSpacing);
+				var textSize = label.ResizeToText(labelText);
 
 				if (textSize.X != cachedWidth || textSize.Y != cachedHeight)
 				{
-					label.Bounds.Width = textSize.X;
 					widget.Bounds.Width = horizontalPadding + textSize.X;
-					label.Bounds.Height = textSize.Y;
 					widget.Bounds.Height = verticalPadding + textSize.Y;
 					cachedWidth = textSize.X;
 					cachedHeight = textSize.Y;

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -23,12 +23,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var font = Game.Renderer.Fonts[label.Font];
 			var cachedWidth = 0;
 			var cachedHeight = 0;
-			var horizontalPadding = label.Bounds.Width - widget.Bounds.Width;
-			if (horizontalPadding <= 0)
+			var horizontalPadding = widget.Bounds.Width - label.Bounds.Width;
+			if (horizontalPadding <= 0 || label.Bounds.Width <= 0)
 				horizontalPadding = 2 * label.Bounds.X;
-			var vertcalPadding = widget.Bounds.Height - label.Bounds.Height;
-			if (vertcalPadding <= 0)
-				vertcalPadding = 2 * label.Bounds.Y;
+			var verticalPadding = widget.Bounds.Height - label.Bounds.Height;
+			if (verticalPadding <= 0 || label.Bounds.Height <= 0)
+				verticalPadding = 2 * label.Bounds.Y + 2 * font.Size / 5; // With hang space
 			var labelText = "";
 			tooltipContainer.BeforeRender = () =>
 			{
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					label.Bounds.Width = textDim.X;
 					widget.Bounds.Width = horizontalPadding + textDim.X;
 					label.Bounds.Height = textDim.Y;
-					widget.Bounds.Height = vertcalPadding + textDim.Y;
+					widget.Bounds.Height = verticalPadding + textDim.Y;
 					cachedWidth = textDim.X;
 					cachedHeight = textDim.Y;
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			tooltipContainer.BeforeRender = () =>
 			{
 				labelText = getText();
-				var textDim = font.Measure(labelText);
+				var textDim = font.Measure(labelText, label.LineSpacing);
 				if (textDim.X != cachedWidth || textDim.Y != cachedHeight)
 				{
 					label.Bounds.Width = textDim.X;

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -20,7 +20,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var label = widget.Get<LabelWidget>("LABEL");
 
-			var font = Game.Renderer.Fonts[label.Font];
 			var cachedWidth = 0;
 			var cachedHeight = 0;
 			var horizontalPadding = widget.Bounds.Width - label.Bounds.Width;
@@ -28,20 +27,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				horizontalPadding = 2 * label.Bounds.X;
 			var verticalPadding = widget.Bounds.Height - label.Bounds.Height;
 			if (verticalPadding <= 0 || label.Bounds.Height <= 0)
-				verticalPadding = 2 * label.Bounds.Y + 2 * font.Size / 5; // With hang space
+				verticalPadding = 2 * label.Bounds.Y
+					+ System.Math.Max(label.LineSpacing, 2 * label.FontSize / 5); // With hang space
 			var labelText = "";
 			tooltipContainer.BeforeRender = () =>
 			{
 				labelText = getText();
-				var textDim = font.Measure(labelText, label.LineSpacing);
-				if (textDim.X != cachedWidth || textDim.Y != cachedHeight)
+				var textSize = label.MeasureText(labelText);
+				if (label.LineVAlign != LineVAlign.Collapsed)
+					textSize += new int2(0, label.LineSpacing);
+
+				if (textSize.X != cachedWidth || textSize.Y != cachedHeight)
 				{
-					label.Bounds.Width = textDim.X;
-					widget.Bounds.Width = horizontalPadding + textDim.X;
-					label.Bounds.Height = textDim.Y;
-					widget.Bounds.Height = verticalPadding + textDim.Y;
-					cachedWidth = textDim.X;
-					cachedHeight = textDim.Y;
+					label.Bounds.Width = textSize.X;
+					widget.Bounds.Width = horizontalPadding + textSize.X;
+					label.Bounds.Height = textSize.Y;
+					widget.Bounds.Height = verticalPadding + textSize.Y;
+					cachedWidth = textSize.X;
+					cachedHeight = textSize.Y;
 				}
 			};
 

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -328,7 +328,7 @@ Container@EDITOR_WORLD_ROOT:
 									Visible: false
 									Width: PARENT_RIGHT - 35
 									TooltipContainer: TOOLTIP_CONTAINER
-									TooltipTemplate: TWO_LINE_TOOLTIP
+									TooltipTemplate: BUTTON_TOOLTIP
 									IgnoreChildMouseOver: true
 									Children:
 										ActorPreview@ACTOR_PREVIEW:

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -5,22 +5,8 @@ Background@SIMPLE_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Height: 23
-			Font: Bold
-
-Background@TWO_LINE_TOOLTIP:
-	Logic: ButtonTooltipLogic
-	Background: panel-black
-	Height: 48
-	Children:
-		Label@LABEL:
-			X: 5
-			Height: 46
-			Font: Bold
-		Label@HOTKEY:
-			Visible: false
-			TextColor: FFFF00
-			Height: 23
+			Y: 4
+			Height: 14
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:
@@ -30,12 +16,14 @@ Background@BUTTON_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Height: 23
+			Y: 4
+			Height: 14
 			Font: Bold
 		Label@HOTKEY:
+			Y: 4
 			Visible: false
 			TextColor: FFFF00
-			Height: 23
+			Height: 14
 			Font: Bold
 
 Background@WORLD_TOOLTIP:

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -219,6 +219,7 @@ Background@INGAME_CLIENT_TOOLTIP:
 Background@FACTION_DESCRIPTION_TOOLTIP:
 	Logic: FactionTooltipLogic
 	Background: panel-black
+	Height: 26
 	Children:
 		Label@HEADER:
 			X: 7
@@ -226,12 +227,10 @@ Background@FACTION_DESCRIPTION_TOOLTIP:
 			Width: 8
 			Height: 12
 			Font: Bold
-			VAlign: Top
 		Label@DESCRIPTION:
 			X: 14
-			Y: 0
+			Y: 24
 			Width: 15
-			Height: 14
+			Height: 8
 			Font: TinyBold
-			VAlign: Top
 

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -5,8 +5,8 @@ Background@SIMPLE_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Y: 4
-			Height: 14
+			Y: 2
+			Height: 18
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:
@@ -16,14 +16,14 @@ Background@BUTTON_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Y: 4
-			Height: 14
+			Y: 2
+			Height: 18
 			Font: Bold
 		Label@HOTKEY:
-			Y: 4
+			Y: 2
 			Visible: false
 			TextColor: FFFF00
-			Height: 14
+			Height: 18
 			Font: Bold
 
 Background@WORLD_TOOLTIP:

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -5,25 +5,8 @@ Background@SIMPLE_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Y: 3
-			Height: 23
-			Font: Bold
-
-Background@TWO_LINE_TOOLTIP:
-	Logic: ButtonTooltipLogic
-	Background: dialog3
-	Height: 54
-	Children:
-		Label@LABEL:
-			X: 5
-			Y: 3
-			Height: 46
-			Font: Bold
-		Label@HOTKEY:
-			Visible: false
-			Y: 3
-			Height: 23
-			TextColor: FFFF00
+			Y: 5
+			Height: 14
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:
@@ -33,13 +16,13 @@ Background@BUTTON_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Y: 3
-			Height: 23
+			Y: 5
+			Height: 14
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			Y: 3
-			Height: 23
+			Y: 5
+			Height: 14
 			TextColor: FFFF00
 			Font: Bold
 

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -224,6 +224,7 @@ Background@SUPPORT_POWER_TOOLTIP:
 Background@FACTION_DESCRIPTION_TOOLTIP:
 	Logic: FactionTooltipLogic
 	Background: dialog3
+	Height: 28
 	Children:
 		Label@HEADER:
 			X: 7
@@ -231,12 +232,10 @@ Background@FACTION_DESCRIPTION_TOOLTIP:
 			Width: 8
 			Height: 10
 			Font: Bold
-			VAlign: Top
 		Label@DESCRIPTION:
 			X: 14
-			Y: 0
+			Y: 21
 			Width: 15
 			Height: 14
 			Font: TinyBold
-			VAlign: Top
 

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -1,7 +1,7 @@
 Background@SIMPLE_TOOLTIP:
 	Logic: SimpleTooltipLogic
 	Background: dialog3
-	Height: 34
+	Height: 32
 	Children:
 		Label@LABEL:
 			X: 5
@@ -12,7 +12,7 @@ Background@SIMPLE_TOOLTIP:
 Background@BUTTON_TOOLTIP:
 	Logic: ButtonTooltipLogic
 	Background: dialog3
-	Height: 31
+	Height: 29
 	Children:
 		Label@LABEL:
 			X: 5

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -5,8 +5,8 @@ Background@SIMPLE_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Y: 5
-			Height: 14
+			Y: 3
+			Height: 18
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:
@@ -16,13 +16,13 @@ Background@BUTTON_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 5
-			Y: 5
-			Height: 14
+			Y: 3
+			Height: 18
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			Y: 5
-			Height: 14
+			Y: 3
+			Height: 18
 			TextColor: FFFF00
 			Font: Bold
 

--- a/mods/ra/chrome/editor.yaml
+++ b/mods/ra/chrome/editor.yaml
@@ -307,7 +307,7 @@ Container@EDITOR_WORLD_ROOT:
 									Visible: false
 									Width: PARENT_RIGHT - 35
 									TooltipContainer: TOOLTIP_CONTAINER
-									TooltipTemplate: TWO_LINE_TOOLTIP
+									TooltipTemplate: BUTTON_TOOLTIP
 									IgnoreChildMouseOver: true
 									Children:
 										ActorPreview@ACTOR_PREVIEW:

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -141,28 +141,28 @@ Background@PRODUCTION_TOOLTIP:
 	Logic: ProductionTooltipLogic
 	Background: dialog4
 	Width: 200
-	Height: 10
+	Height: 65
 	Children:
 		Label@NAME:
 			X: 7
-			Y: 0
+			Y: 2
 			Height: 23
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			Y: 0
+			Y: 2
 			Height: 23
 			TextColor: FFFF00
 			Font: Bold
 		Label@REQUIRES:
 			X: 7
-			Y: 19
+			Y: 21
 			Height: 23
 			Font: TinyBold
 			Text: Requires {0}
 		Label@DESC:
 			X: 7
-			Y: 39
+			Y: 41
 			Height: 23
 			Font: TinyBold
 			VAlign: Top
@@ -181,16 +181,16 @@ Background@PRODUCTION_TOOLTIP:
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-time
 		Label@TIME:
-			Y: 19
+			Y: 21
 			Height: 23
 			Font: Bold
 		Image@POWER_ICON:
-			Y: 46
+			Y: 48
 			Width: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-power
 		Label@POWER:
-			Y: 39
+			Y: 41
 			Height: 23
 			Font: Bold
 

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -1,12 +1,12 @@
 Background@SIMPLE_TOOLTIP:
 	Logic: SimpleTooltipLogic
 	Background: dialog4
-	Height: 32
+	Height: 29
 	Children:
 		Label@LABEL:
 			X: 7
-			Y: 6
-			Height: 14
+			Y: 3
+			Height: 18
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:
@@ -16,13 +16,13 @@ Background@BUTTON_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 7
-			Y: 6
-			Height: 14
+			Y: 3
+			Height: 18
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			Y: 6
-			Height: 14
+			Y: 3
+			Height: 18
 			TextColor: FFFF00
 			Font: Bold
 

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -5,25 +5,8 @@ Background@SIMPLE_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 7
-			Y: 2
-			Height: 23
-			Font: Bold
-
-Background@TWO_LINE_TOOLTIP:
-	Logic: ButtonTooltipLogic
-	Background: dialog4
-	Height: 52
-	Children:
-		Label@LABEL:
-			X: 7
-			Y: 2
-			Height: 46
-			Font: Bold
-		Label@HOTKEY:
-			Visible: false
-			Y: 2
-			Height: 23
-			TextColor: FFFF00
+			Y: 6
+			Height: 14
 			Font: Bold
 
 Background@BUTTON_TOOLTIP:
@@ -33,13 +16,13 @@ Background@BUTTON_TOOLTIP:
 	Children:
 		Label@LABEL:
 			X: 7
-			Y: 2
-			Height: 23
+			Y: 6
+			Height: 14
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			Y: 2
-			Height: 23
+			Y: 6
+			Height: 14
 			TextColor: FFFF00
 			Font: Bold
 

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -224,6 +224,7 @@ Background@SUPPORT_POWER_TOOLTIP:
 Background@FACTION_DESCRIPTION_TOOLTIP:
 	Logic: FactionTooltipLogic
 	Background: dialog4
+	Height: 26
 	Children:
 		Label@HEADER:
 			X: 7
@@ -231,12 +232,10 @@ Background@FACTION_DESCRIPTION_TOOLTIP:
 			Width: 8
 			Height: 12
 			Font: Bold
-			VAlign: Top
 		Label@DESCRIPTION:
 			X: 14
-			Y: 0
+			Y: 20
 			Width: 15
 			Height: 18
 			Font: TinyBold
-			VAlign: Top
 

--- a/mods/ra/chrome/tooltips.yaml
+++ b/mods/ra/chrome/tooltips.yaml
@@ -37,21 +37,21 @@ Background@WORLD_TOOLTIP:
 		Label@LABEL:
 			X: 7
 			Y: 2
-			Height: 23
+			Height: 19
 			Font: Bold
 		Image@FLAG:
 			X: 7
-			Y: 27
+			Y: 25
 			Width: 32
 			Height: 16
 		Label@OWNER:
 			X: 45
 			Y: 22
-			Height: 23
+			Height: 19
 			Font: Bold
 		Label@EXTRA:
 			X: 7
-			Y: 50
+			Y: 48
 			Height: 5
 			Font: Bold
 
@@ -61,12 +61,12 @@ Background@SPAWN_TOOLTIP:
 	Width: 7
 	Children:
 		Container@SINGLE_HEIGHT:
-			Height: 29
+			Height: 31
 		Container@DOUBLE_HEIGHT:
-			Height: 44
+			Height: 46
 		Label@LABEL:
-			Y: 2
-			Height: 23
+			Y: 0
+			Height: 19
 			Font: Bold
 		Image@FLAG:
 			X: 7
@@ -74,7 +74,7 @@ Background@SPAWN_TOOLTIP:
 			Width: 32
 			Height: 16
 		Label@TEAM:
-			Y: 23
+			Y: 21
 			Height: 15
 			Font: TinyBold
 			Align: center
@@ -86,30 +86,30 @@ Background@CLIENT_TOOLTIP:
 	Width: 7
 	Children:
 		Label@ADMIN:
-			Y: 4
+			Y: 2
 			Height: 18
 			Font: Bold
 			Text: Game Admin
 			Align: Center
 		Label@IP:
-			Y: 7
+			Y: 2
 			Width: 5
 			Height: 10
 			Font: TinyBold
 			Align: Center
 		Label@LOCATION:
-			Y: 19
+			Y: 17
 			Height: 10
 			Font: TinyBold
 			Align: Center
 		Label@LATENCY_PREFIX:
 			X: 10
-			Y: 31
+			Y: 29
 			Height: 10
 			Font: TinyBold
 			Text: Latency:
 		Label@LATENCY:
-			Y: 31
+			Y: 29
 			Height: 10
 			Font: TinyBold
 
@@ -141,28 +141,28 @@ Background@PRODUCTION_TOOLTIP:
 	Logic: ProductionTooltipLogic
 	Background: dialog4
 	Width: 200
-	Height: 65
+	Height: 10
 	Children:
 		Label@NAME:
 			X: 7
-			Y: 2
+			Y: 0
 			Height: 23
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			Y: 2
+			Y: 0
 			Height: 23
 			TextColor: FFFF00
 			Font: Bold
 		Label@REQUIRES:
 			X: 7
-			Y: 21
+			Y: 19
 			Height: 23
 			Font: TinyBold
 			Text: Requires {0}
 		Label@DESC:
 			X: 7
-			Y: 41
+			Y: 39
 			Height: 23
 			Font: TinyBold
 			VAlign: Top
@@ -181,7 +181,7 @@ Background@PRODUCTION_TOOLTIP:
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-time
 		Label@TIME:
-			Y: 21
+			Y: 19
 			Height: 23
 			Font: Bold
 		Image@POWER_ICON:
@@ -190,7 +190,7 @@ Background@PRODUCTION_TOOLTIP:
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-power
 		Label@POWER:
-			Y: 41
+			Y: 39
 			Height: 23
 			Font: Bold
 
@@ -202,22 +202,22 @@ Background@SUPPORT_POWER_TOOLTIP:
 	Children:
 		Label@NAME:
 			X: 7
-			Y: 2
+			Y: 0
 			Height: 20
 			Font: Bold
 		Label@HOTKEY:
 			Visible: false
-			Y: 2
+			Y: 0
 			Height: 20
 			TextColor: FFFF00
 			Font: Bold
 		Label@TIME:
-			Y: 8
+			Y: 6
 			Font: TinyBold
 			VAlign: Top
 		Label@DESC:
 			X: 7
-			Y: 22
+			Y: 20
 			Font: TinyBold
 			VAlign: Top
 
@@ -227,7 +227,7 @@ Background@FACTION_DESCRIPTION_TOOLTIP:
 	Children:
 		Label@HEADER:
 			X: 7
-			Y: 6
+			Y: 4
 			Width: 8
 			Height: 12
 			Font: Bold
@@ -236,7 +236,7 @@ Background@FACTION_DESCRIPTION_TOOLTIP:
 			X: 14
 			Y: 0
 			Width: 15
-			Height: 14
+			Height: 18
 			Font: TinyBold
 			VAlign: Top
 


### PR DESCRIPTION
Adds supports for line spacing to the font engine and fixes vertical spacing as requested in #9986, but does not remove empty lines.

Use the `label`'s `Y` property (& the tooltip's `Height` property) to adjust the top padding, `label`'s `LineSpacing` property to adjust the line spacing, and the tooltip's `Height` property to adjust the bottom padding.
