### PR TITLE
Remove editor actor selection tooltip blank line

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					item.IsVisible = () => true;
 
 					var tooltip = actor.TraitInfoOrDefault<TooltipInfo>();
-					item.GetTooltipText = () => (tooltip == null ? "\nType: " : tooltip.Name + "\nType: ") + actor.Name;
+					item.GetTooltipText = () => (tooltip == null ? "Type: " : tooltip.Name + "\nType: ") + actor.Name;
 
 					panel.AddChild(item);
 				}


### PR DESCRIPTION
Removes the blank line for actors lacking tooltips as mentioned in #9986. With #10026, this provides a solution to #9986.
