### PR TITLE
Increased default range of angles that missiles can launch at

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -35,10 +35,10 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly bool Shadow = false;
 
 		[Desc("Minimum vertical launch angle (pitch).")]
-		public readonly WAngle MinimumLaunchAngle = WAngle.Zero;
+		public readonly WAngle MinimumLaunchAngle = new WAngle(-64);
 
 		[Desc("Maximum vertical launch angle (pitch).")]
-		public readonly WAngle MaximumLaunchAngle = new WAngle(64);
+		public readonly WAngle MaximumLaunchAngle = new WAngle(128);
 
 		[Desc("Minimum launch speed in WDist / tick")]
 		public readonly WDist MinimumLaunchSpeed = new WDist(75);


### PR DESCRIPTION
This changes the default values so missiles without custom angles can launch at up to 90° downwards (enough for Orcas, Longbows and so on) and 180° upwards (basically straight up, for SAM sites and Adv. Guard Towers).

Closes #10024.
