### PR TITLE
Unload passengers / cargo on death

### DIFF
--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -273,6 +273,11 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Run inner activity/InsideTick
 			inner = inner == this ? InsideTick(self) : Util.RunActivity(self, inner);
+
+			// If we are finished, move on to next activity
+			if (inner == null && nextState == State.Done)
+				return NextActivity;
+
 			return this;
 		}
 	}

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -22,6 +22,7 @@ DPOD:
 		MaxWeight: 1
 		PipCount: 1
 		UnloadVoice: Move
+		EjectOnDeath: true
 	Armament:
 		Weapon: Vulcan2
 	AttackHeli:
@@ -59,6 +60,7 @@ DSHP:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Move
+		EjectOnDeath: true
 	SpawnActorOnDeath:
 		Actor: DSHP.Husk
 
@@ -183,6 +185,7 @@ ORCATRAN:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Move
+		EjectOnDeath: true
 	SpawnActorOnDeath:
 		Actor: ORCATRAN.Husk
 

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -28,6 +28,7 @@ APC:
 		PipCount: 5
 		UnloadVoice: Unload
 		LoadingUpgrades: notmobile
+		EjectOnDeath: true
 	-WithVoxelBody:
 	WithVoxelWaterBody:
 	LeavesTrails:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -227,6 +227,7 @@ SAPC:
 		PipCount: 5
 		UnloadVoice: Unload
 		LoadingUpgrades: notmobile
+		EjectOnDeath: true
 
 SUBTANK:
 	Inherits: ^VoxelTank


### PR DESCRIPTION
Bit hacky approach, works by nudging passengers on exit so they don't bunch up.

The changes in EnterTransport will cancel any of the passengers activity, since mobile will discard nudges if not idle.

Kills any cargo it can't unload (when in water etc)

Edit:
No changes in EnterTransport, added a check in Enter to move on to the next activity and don't wait for the next tick. Also use Mobile.Nudge instead of INotifyBlockingMove.OnNotifyBlockingMove

http://gfycat.com/ImpishImaginativeFlea

https://gfycat.com/BoilingLimpAfricanjacana
