### PR TITLE
Fix the rushAI building spens/syrds without being able to build naval units

### DIFF
--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -9,7 +9,6 @@ Player:
 			Barracks: barr,tent
 			VehiclesFactory: weap
 			Production: barr,tent,weap,afld,hpad
-			NavalProduction: spen,syrd
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv


### PR DESCRIPTION
[This](https://github.com/OpenRA/OpenRA/blob/177d9837286c863221b9c1083072cbaf8c18666d/OpenRA.Mods.Common/AI/BaseBuilder.cs#L260) will make it build naval structures, but the Rush AI hasn't any naval units defined to build.
