### PR TITLE
Add IsDead checks to gdi06

### DIFF
--- a/mods/cnc/maps/gdi06/gdi06.lua
+++ b/mods/cnc/maps/gdi06/gdi06.lua
@@ -125,14 +125,18 @@ WorldLoaded = function()
 
 	Trigger.OnKilled(AttackTrigger2, function()
 		Utils.Do(FlameSquad, function(unit)
-			unit.Patrol(FlameSquadRoute, false)
+			if not unit.IsDead then
+				unit.Patrol(FlameSquadRoute, false)
+			end
 		end)
 	end)
 
 	Trigger.OnEnteredFootprint(AttackCellTriggerActivator, function(a, id)
 		if a.Owner == player then
 			Utils.Do(AttackUnits, function(unit)
-				unit.AttackMove(waypoint10.Location)
+				if not unit.IsDead then
+					unit.AttackMove(waypoint10.Location)
+				end
 			end)
 			Trigger.RemoveFootprintTrigger(id)
 		end


### PR DESCRIPTION
Fixes a crash reported by @Snurre86 on IRC:

```
Exception has been thrown by the target of an invocation. ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> Eluant.LuaException: [string "BindingSupport.lua"]:30: Actor 'e4 (dead)' does not define a property 'Patrol'
   at Eluant.LuaRuntime.Call(IList`1 args)
   at Eluant.LuaRuntime.Call(LuaFunction fn, IList`1 args)
   at OpenRA.Mods.Common.Scripting.UtilsGlobal.Do(LuaValue[] collection, LuaFunction func)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at OpenRA.Scripting.ScriptMemberWrapper.Invoke(LuaVararg args)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at Eluant.LuaRuntime.MethodWrapper.Invoke(Object[] parms)
   at Eluant.LuaRuntime.MakeManagedCall(IntPtr state, MethodWrapper wrapper)
   at OpenRA.Scripting.ScriptContext.FatalError(String message)
   at OpenRA.Mods.Common.Scripting.ScriptTriggers.Killed(Actor self, AttackInfo e)
   at OpenRA.Mods.Common.Traits.Health.InflictDamage(Actor self, Actor attacker, Int32 damage, IWarhead warhead, Boolean ignoreModifiers)
   at OpenRA.Actor.InflictDamage(Actor attacker, Int32 damage, IWarhead warhead)
   at OpenRA.Mods.Common.Warheads.DamageWarhead.DoImpact(Actor victim, Actor firedBy, IEnumerable`1 damageModifiers)
   at OpenRA.Mods.Common.Warheads.SpreadDamageWarhead.DoImpact(WPos pos, Actor firedBy, IEnumerable`1 damageModifiers)
   at OpenRA.Mods.Common.Warheads.DamageWarhead.DoImpact(Target target, Actor firedBy, IEnumerable`1 damageModifiers)
   at OpenRA.GameRules.WeaponInfo.<Impact>c__AnonStorey2.<>m__0()
   at OpenRA.GameRules.WeaponInfo.Impact(Target target, Actor firedBy, IEnumerable`1 damageModifiers)
   at OpenRA.Mods.Common.Effects.Bullet.Explode(World world)
   at OpenRA.Mods.Common.Effects.Bullet.Tick(World world)
   at OpenRA.World.<Tick>m__4(IEffect e)
   at OpenRA.WorldUtils.DoTimed[T](IEnumerable`1 e, Action`1 a, String text)
   at OpenRA.World.Tick()
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager)
   at OpenRA.Game.LogicTick()
   at OpenRA.Game.Loop()
   at OpenRA.Game.Run()
   at OpenRA.Program.Run(String[] args)
   at OpenRA.Program.Main(String[] args)
```

It happens when you kill the flame throwers before killing the rifle man patroling at the entrance.
