### PR TITLE
Fix a NRE when destroying SAM Sites in GDI06.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 				init.Add(facings);
 			}
 
-			facings.Value(self.World).Add(Name, facing.Facing);
+			facings.Value(self.World).Add(Name, TurretFacing);
 		}
 	}
 


### PR DESCRIPTION
Fixes a regression from #9414.
`facing` is null for turreted structures, and in any case body facing != turret facing.
