### PR TITLE
Prevent invalid cells checks in SeedsResource

### DIFF
--- a/OpenRA.Mods.Common/Traits/SeedsResource.cs
+++ b/OpenRA.Mods.Common/Traits/SeedsResource.cs
@@ -65,7 +65,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var cell = Util.RandomWalk(self.Location, self.World.SharedRandom)
 				.Take(info.MaxRange)
-				.SkipWhile(p => resLayer.GetResource(p) == resourceType && resLayer.IsFull(p))
+				.SkipWhile(p => !self.World.Map.Contains(p) ||
+					(resLayer.GetResource(p) == resourceType && resLayer.IsFull(p)))
 				.Cast<CPos?>().FirstOrDefault();
 
 			if (cell != null && resLayer.CanSpawnResourceAt(resourceType, cell.Value))


### PR DESCRIPTION
Fixes the seeding crash from #10039. Untested, but matches with the stack trace.
