### PR TITLE
Fixed crashes when saving maps in folders without write access.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -56,6 +56,26 @@ namespace OpenRA.Mods.Common.Widgets
 			};
 		}
 
+		public static void ErrorPrompt(string title, Exception e, Action onCancel = null, string cancelText = null)
+		{
+			var prompt = Ui.OpenWindow("ERROR_PROMPT");
+			prompt.Get<LabelWidget>("PROMPT_TITLE").GetText = () => title;
+
+			var textPrompt = prompt.Get<LabelWidget>("PROMPT_TEXT");
+			var font = Game.Renderer.Fonts[textPrompt.Font];
+			textPrompt.GetText = () => WidgetUtils.WrapText(e.Message, textPrompt.Bounds.Width, font);
+
+			if (!string.IsNullOrEmpty(cancelText))
+				prompt.Get<ButtonWidget>("CANCEL_BUTTON").GetText = () => cancelText;
+
+			prompt.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () =>
+			{
+				Ui.CloseWindow();
+				if (onCancel != null)
+					onCancel();
+			};
+		}
+
 		public static void TextInputPrompt(
 			string title, string prompt, string initialText,
 			Action<string> onAccept, Action onCancel = null,

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -135,22 +135,31 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				map.RequiresMod = Game.ModData.Manifest.Mod.Id;
 
-				// Create the map directory if required
-				Directory.CreateDirectory(Platform.ResolvePath(directoryDropdown.Text));
+				try
+				{
+					// Create the map directory if required
+					Directory.CreateDirectory(Platform.ResolvePath(directoryDropdown.Text));
 
-				var combinedPath = Platform.ResolvePath(Path.Combine(directoryDropdown.Text, filename.Text + fileTypes[typeDropdown.Text]));
+					var combinedPath = Platform.ResolvePath(Path.Combine(directoryDropdown.Text, filename.Text + fileTypes[typeDropdown.Text]));
 
-				// Invalidate the old map metadata
-				if (map.Uid != null && combinedPath == map.Path)
-					Game.ModData.MapCache[map.Uid].Invalidate();
+					// Invalidate the old map metadata
+					if (map.Uid != null && combinedPath == map.Path)
+						Game.ModData.MapCache[map.Uid].Invalidate();
 
-				map.Save(combinedPath);
+					map.Save(combinedPath);
 
-				// Update the map cache so it can be loaded without restarting the game
-				var classification = mapDirectories[directoryDropdown.Text];
-				Game.ModData.MapCache[map.Uid].UpdateFromMap(map, classification);
+					// Update the map cache so it can be loaded without restarting the game
+					var classification = mapDirectories[directoryDropdown.Text];
+					Game.ModData.MapCache[map.Uid].UpdateFromMap(map, classification);
 
-				Console.WriteLine("Saved current map at {0}", combinedPath);
+					Console.WriteLine("Saved current map at {0}", combinedPath);
+				}
+				catch (Exception e)
+				{
+					ConfirmationDialogs.ErrorPrompt("Map Save Failed", e);
+					return;
+				}
+
 				Ui.CloseWindow();
 
 				onSave(map.Uid);

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -200,6 +200,38 @@ Container@CANCEL_PROMPT:
 			Height: 35
 			Text: Cancel
 
+Container@ERROR_PROMPT:
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - 90)/2
+	Width: 640
+	Height: 90
+	Children:
+		Label@PROMPT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 0-25
+			Font: BigBold
+			Contrast: true
+			Align: Center
+		Background@bg:
+			Width: 640
+			Height: 60
+			Background: panel-black
+			Children:
+				Label@PROMPT_TEXT:
+					X: 10
+					Y: (PARENT_BOTTOM-HEIGHT)/2
+					Width: PARENT_RIGHT-15
+					Height: 15
+					Font: Bold
+					Align: Center
+					WordWrap: true
+		Button@CANCEL_BUTTON:
+			Key: escape
+			Y: 59
+			Width: 140
+			Height: 35
+			Text: Cancel
+
 Container@TEXT_INPUT_PROMPT:
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - HEIGHT)/2

--- a/mods/ra/chrome/confirmation-dialogs.yaml
+++ b/mods/ra/chrome/confirmation-dialogs.yaml
@@ -50,7 +50,34 @@ Background@CANCEL_PROMPT:
 			Y: 50
 			Width: PARENT_RIGHT - 30
 			Height: 65
+		Button@CANCEL_BUTTON:
+			X: PARENT_RIGHT/2 - WIDTH/2
+			Y: PARENT_BOTTOM - 45
+			Width: 160
+			Height: 25
+			Text: Cancel
+			Font: Bold
+			Key: escape
+
+Background@ERROR_PROMPT:
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - 90)/2
+	Width: 640
+	Height: 145
+	Children:
+		Label@PROMPT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
 			Align: Center
+		Label@PROMPT_TEXT:
+			X: 15
+			Y: 35
+			Width: PARENT_RIGHT - 30
+			Height: 65
+			Align: Center
+			WordWrap: true
 		Button@CANCEL_BUTTON:
 			X: PARENT_RIGHT/2 - WIDTH/2
 			Y: PARENT_BOTTOM - 45


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/9430. To test add something invalid to `MapFolders:` in your `mod.yaml` file.

Our current CancelPrompt didn't really scale well with error messages longer than a few hard-coded words. I gave my best to fix text box overflow issues, but I am not really an expert with those chrome.yaml definitions and I guess this will be the major focus of the reviewers. Suggestions for improvement are very welcome.

![image](https://cloud.githubusercontent.com/assets/756669/11322663/863d0a00-90f6-11e5-8284-bf35351ebb6f.png)

![image](https://cloud.githubusercontent.com/assets/756669/11322669/a6b37238-90f6-11e5-8a6d-4e75385fcbf2.png)
