### PR TITLE
Fixed highest density sprite frame never being rendered

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 			NetWorth += t.Density * type.Info.ValuePerUnit;
 
 			var sprites = type.Variants[t.Variant];
-			var frame = int2.Lerp(0, sprites.Length - 1, t.Density - 1, type.Info.MaxDensity);
+			var frame = int2.Lerp(0, sprites.Length - 1, t.Density, type.Info.MaxDensity);
 			t.Sprite = sprites[frame];
 
 			return t;

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (t.Density > 0)
 			{
 				var sprites = t.Type.Variants[t.Variant];
-				var frame = int2.Lerp(0, sprites.Length - 1, t.Density - 1, t.Type.Info.MaxDensity);
+				var frame = int2.Lerp(0, sprites.Length - 1, t.Density, t.Type.Info.MaxDensity);
 				t.Sprite = sprites[frame];
 			}
 			else


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/9795. In fact this changes the whole rendering. Not sure if my math is correct, but we now see the last gem frame and I believe single ore patches are also rendered in a thin manner.
