### PR TITLE
Fixes passability/buildability of several TD cliff tiles

### DIFF
--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -264,9 +264,9 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rock
 			1: Rock
-			2: Clear
+			2: Rock
 			3: Rock
 			4: Rock
 			5: Clear
@@ -362,7 +362,7 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rough
 			1: Rock
 			2: Rock
 			3: Rock

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -408,9 +408,9 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rock
 			1: Rock
-			2: Clear
+			2: Rock
 			3: Rock
 			4: Rock
 			5: Clear
@@ -449,8 +449,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@30:
@@ -459,8 +459,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@31:
@@ -469,8 +469,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@32:
@@ -506,7 +506,7 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rough
 			1: Rock
 			2: Rock
 			3: Rock
@@ -589,8 +589,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@44:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -420,9 +420,9 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rock
 			1: Rock
-			2: Clear
+			2: Rock
 			3: Rock
 			4: Rock
 			5: Clear
@@ -461,8 +461,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@30:
@@ -471,8 +471,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@31:
@@ -481,8 +481,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@32:
@@ -518,7 +518,7 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rough
 			1: Rock
 			2: Rock
 			3: Rock
@@ -601,8 +601,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@44:

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -408,9 +408,9 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rock
 			1: Rock
-			2: Clear
+			2: Rock
 			3: Rock
 			4: Rock
 			5: Clear
@@ -449,8 +449,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@30:
@@ -459,8 +459,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@31:
@@ -469,8 +469,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@32:
@@ -506,7 +506,7 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rough
 			1: Rock
 			2: Rock
 			3: Rock
@@ -589,8 +589,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@44:

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -408,9 +408,9 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rock
 			1: Rock
-			2: Clear
+			2: Rock
 			3: Rock
 			4: Rock
 			5: Clear
@@ -449,8 +449,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@30:
@@ -459,8 +459,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@31:
@@ -469,8 +469,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@32:
@@ -506,7 +506,7 @@ Templates:
 		Size: 3,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
+			0: Rough
 			1: Rock
 			2: Rock
 			3: Rock
@@ -589,8 +589,8 @@ Templates:
 		Size: 2,2
 		Category: Cliffs
 		Tiles:
-			0: Clear
-			1: Clear
+			0: Rock
+			1: Rock
 			2: Rock
 			3: Rock
 	Template@44:


### PR DESCRIPTION
These definitely could not be moved/built on in the original (in fact, templates 29, 30, 31 and 43 have already been fixed before on desert tileset).

Note: There are a few more debatable cases that were of "Clear" terrain type in the original, but probably shouldn't have been (going by visuals/consistency), but I left those out for now.
