### PR TITLE
Add an actor name overlay debug option

### DIFF
--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Traits
 		public bool ShowCombatGeometry;
 		public bool ShowDebugGeometry;
 		public bool ShowDepthPreview;
+		public bool ShowActorTags;
 
 		public object Create(ActorInitializer init) { return new DeveloperMode(this); }
 	}
@@ -43,6 +44,7 @@ namespace OpenRA.Traits
 		public bool ShowCombatGeometry;
 		public bool ShowDebugGeometry;
 		public bool ShowDepthPreview;
+		public bool ShowActorTags;
 
 		public bool EnableAll;
 
@@ -58,6 +60,7 @@ namespace OpenRA.Traits
 			ShowCombatGeometry = info.ShowCombatGeometry;
 			ShowDebugGeometry = info.ShowDebugGeometry;
 			ShowDepthPreview = info.ShowDepthPreview;
+			ShowActorTags = info.ShowActorTags;
 		}
 
 		public void ResolveOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -178,6 +178,8 @@ namespace OpenRA.Mods.Common.AI
 			return randomBaseBuilding != null ? randomBaseBuilding.Location : initialBaseCenter;
 		}
 
+		public bool IsEnabled;
+		public List<Squad> Squads = new List<Squad>();
 		public Player Player { get; private set; }
 
 		readonly DomainIndex domainIndex;
@@ -194,7 +196,6 @@ namespace OpenRA.Mods.Common.AI
 		PowerManager playerPower;
 		SupportPowerManager supportPowerMngr;
 		PlayerResources playerResource;
-		bool enabled;
 		int ticks;
 
 		BitArray resourceTypeIndices;
@@ -204,7 +205,6 @@ namespace OpenRA.Mods.Common.AI
 		Cache<Player, Enemy> aggro = new Cache<Player, Enemy>(_ => new Enemy());
 		List<BaseBuilder> builders = new List<BaseBuilder>();
 
-		List<Squad> squads = new List<Squad>();
 		List<Actor> unitsHangingAroundTheBase = new List<Actor>();
 
 		// Units that the ai already knows about. Any unit not on this list needs to be given a role.
@@ -257,7 +257,7 @@ namespace OpenRA.Mods.Common.AI
 		public void Activate(Player p)
 		{
 			Player = p;
-			enabled = true;
+			IsEnabled = true;
 			playerPower = p.PlayerActor.Trait<PowerManager>();
 			supportPowerMngr = p.PlayerActor.Trait<SupportPowerManager>();
 			playerResource = p.PlayerActor.Trait<PlayerResources>();
@@ -523,7 +523,7 @@ namespace OpenRA.Mods.Common.AI
 
 		public void Tick(Actor self)
 		{
-			if (!enabled)
+			if (!IsEnabled)
 				return;
 
 			ticks++;
@@ -603,21 +603,21 @@ namespace OpenRA.Mods.Common.AI
 
 		void CleanSquads()
 		{
-			squads.RemoveAll(s => !s.IsValid);
-			foreach (var s in squads)
+			Squads.RemoveAll(s => !s.IsValid);
+			foreach (var s in Squads)
 				s.Units.RemoveAll(unitCannotBeOrdered);
 		}
 
 		// Use of this function requires that one squad of this type. Hence it is a piece of shit
 		Squad GetSquadOfType(SquadType type)
 		{
-			return squads.FirstOrDefault(s => s.Type == type);
+			return Squads.FirstOrDefault(s => s.Type == type);
 		}
 
 		Squad RegisterNewSquad(SquadType type, Actor target = null)
 		{
 			var ret = new Squad(this, type, target);
-			squads.Add(ret);
+			Squads.Add(ret);
 			return ret;
 		}
 
@@ -637,7 +637,7 @@ namespace OpenRA.Mods.Common.AI
 			if (--attackForceTicks <= 0)
 			{
 				attackForceTicks = Info.AttackForceInterval;
-				foreach (var s in squads)
+				foreach (var s in Squads)
 					s.Update();
 			}
 
@@ -1059,7 +1059,7 @@ namespace OpenRA.Mods.Common.AI
 
 		public void Damaged(Actor self, AttackInfo e)
 		{
-			if (!enabled || e.Attacker == null)
+			if (!IsEnabled || e.Attacker == null)
 				return;
 
 			if (e.Attacker.Owner.Stances[self.Owner] == Stance.Neutral)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -404,6 +404,7 @@
     <Compile Include="Traits\Render\RenderSpritesEditorOnly.cs" />
     <Compile Include="Traits\Render\WithTurretedSpriteBody.cs" />
     <Compile Include="Traits\Render\RenderUtils.cs" />
+    <Compile Include="Traits\Render\RenderDebugState.cs" />
     <Compile Include="Traits\Render\RenderNameTag.cs" />
     <Compile Include="Traits\Render\RenderSprites.cs" />
     <Compile Include="Traits\Render\WithWallSpriteBody.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -1,0 +1,101 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.AI;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Displays the actor's type and ID above the actor.")]
+	class RenderDebugStateInfo : ITraitInfo
+	{
+		public readonly string Font = "TinyBold";
+
+		public object Create(ActorInitializer init) { return new RenderDebugState(init.Self, this); }
+	}
+
+	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, IPostRenderSelection
+	{
+		readonly DeveloperMode devMode;
+		readonly SpriteFont font;
+		readonly Actor self;
+		readonly WVec offset;
+		readonly HackyAI ai;
+
+		Color color;
+		string tagString;
+
+		public RenderDebugState(Actor self, RenderDebugStateInfo info)
+		{
+			var buildingInfo = self.Info.TraitInfoOrDefault<BuildingInfo>();
+			var yOffset = buildingInfo == null ? 1 : buildingInfo.Dimensions.Y;
+			offset = new WVec(0, 512 * yOffset, 0);
+
+			this.self = self;
+			color = GetColor();
+			font = Game.Renderer.Fonts[info.Font];
+
+			var localPlayer = self.World.LocalPlayer;
+			devMode = localPlayer != null ? localPlayer.PlayerActor.Trait<DeveloperMode>() : null;
+			ai = self.Owner.PlayerActor.TraitsImplementing<HackyAI>().FirstOrDefault(x => x.IsEnabled);
+		}
+
+		public void AddedToWorld(Actor self)
+		{
+			tagString = self.ToString();
+		}
+
+		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			color = GetColor();
+		}
+
+		Color GetColor()
+		{
+			return self.EffectiveOwner != null ? self.EffectiveOwner.Owner.Color.RGB : self.Owner.Color.RGB;
+		}
+
+		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		{
+			if (devMode == null || !devMode.ShowActorTags)
+				yield break;
+
+			yield return new TextRenderable(font, self.CenterPosition - offset, 0, color, tagString);
+
+			// Get the actor's activity.
+			var activity = self.GetCurrentActivity();
+			if (activity != null)
+			{
+				var activityName = activity.GetType().ToString().Split('.').Last();
+				yield return new TextRenderable(font, self.CenterPosition, 0, color, activityName);
+			}
+
+			// Get the AI squad that this actor belongs to.
+			if (!self.Owner.IsBot)
+				yield break;
+
+			if (ai == null)
+				yield break;
+
+			var squads = ai.Squads;
+			var squad = squads.FirstOrDefault(x => x.Units.Contains(self));
+			if (squad == null)
+				yield break;
+
+			var aiSquadInfo = "{0}, {1}".F(squad.Type, squad.TargetActor);
+			yield return new TextRenderable(font, self.CenterPosition + offset, 0, color, aiSquadInfo);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -126,6 +126,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				showAstarCostCheckbox.IsChecked = () => dbgOverlay != null ? dbgOverlay.Visible : false;
 				showAstarCostCheckbox.OnClick = () => { if (dbgOverlay != null) dbgOverlay.Visible ^= true; };
 			}
+
+			var showActorTagsCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_ACTOR_TAGS");
+			if (showActorTagsCheckbox != null)
+			{
+				showActorTagsCheckbox.IsChecked = () => devTrait.ShowActorTags;
+				showActorTagsCheckbox.OnClick = () => devTrait.ShowActorTags ^= true;
+			}
 		}
 
 		public void Order(World world, string order)

--- a/mods/cnc/chrome/ingame-debug.yaml
+++ b/mods/cnc/chrome/ingame-debug.yaml
@@ -116,3 +116,10 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
+		Checkbox@SHOW_ACTOR_TAGS:
+			X: 45
+			Y: 335
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Actor Tags

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -6,6 +6,7 @@
 	ScriptTriggers:
 	UpgradeManager:
 	Huntable:
+	RenderDebugState:
 
 ^SpriteActor:
 	BodyOrientation:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -6,6 +6,7 @@
 	ScriptTriggers:
 	UpgradeManager:
 	Huntable:
+	RenderDebugState:
 
 ^SpriteActor:
 	BodyOrientation:

--- a/mods/ra/chrome/ingame-debug.yaml
+++ b/mods/ra/chrome/ingame-debug.yaml
@@ -121,3 +121,10 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
+		Checkbox@SHOW_ACTOR_TAGS:
+			X: 45
+			Y: 335
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Actor Tags

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -5,6 +5,7 @@
 	ScriptTriggers:
 	UpgradeManager:
 	Huntable:
+	RenderDebugState:
 
 ^SpriteActor:
 	BodyOrientation:

--- a/mods/ts/chrome/ingame-debug.yaml
+++ b/mods/ts/chrome/ingame-debug.yaml
@@ -128,3 +128,10 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
+		Checkbox@SHOW_ACTOR_TAGS:
+			X: 45
+			Y: 365
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Actor Tags

--- a/mods/ts/chrome/ingame-info.yaml
+++ b/mods/ts/chrome/ingame-info.yaml
@@ -1,0 +1,65 @@
+Container@GAME_INFO_PANEL:
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 522
+	Height: 455
+	Logic: GameInfoLogic
+	Visible: False
+	Children:
+		Background@BACKGROUND:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+		Background@BACKGROUND_NO_TABS:
+			Y: 25
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM - 25
+		Label@TITLE:
+			Y: 20
+			Width: PARENT_RIGHT
+			Height: 25
+			Align: Center
+			Font: Bold
+		Label@TITLE_NO_TABS:
+			Y: 45
+			Width: PARENT_RIGHT
+			Height: 25
+			Align: Center
+			Font: Bold
+		Container@TAB_CONTAINER:
+			X: (PARENT_RIGHT - WIDTH) / 2
+			Width: 360
+			Height: 25
+			Children:
+				Button@BUTTON1:
+					Y: 50
+					Width: 120
+					Height: 25
+					Font: Bold
+					Visible: False
+				Button@BUTTON2:
+					X: 120
+					Y: 50
+					Width: 120
+					Height: 25
+					Font: Bold
+					Visible: False
+				Button@BUTTON3:
+					X: 240
+					Y: 50
+					Width: 120
+					Height: 25
+					Font: Bold
+					Visible: False
+		Container@STATS_PANEL:
+			Y: 65
+		Container@MAP_PANEL:
+			Y: 65
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+		Container@OBJECTIVES_PANEL:
+			Y: 65
+			Width: PARENT_RIGHT
+		Container@DEBUG_PANEL:
+			Y: 65
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM

--- a/mods/ts/chrome/ingame-info.yaml
+++ b/mods/ts/chrome/ingame-info.yaml
@@ -2,7 +2,7 @@ Container@GAME_INFO_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 522
-	Height: 455
+	Height: 485
 	Logic: GameInfoLogic
 	Visible: False
 	Children:

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -136,7 +136,7 @@ ChromeLayout:
 	./mods/ra/chrome/ingame-diplomacy.yaml
 	./mods/ra/chrome/ingame-fmvplayer.yaml
 	./mods/ra/chrome/ingame-menu.yaml
-	./mods/ra/chrome/ingame-info.yaml
+	./mods/ts/chrome/ingame-info.yaml
 	./mods/ra/chrome/ingame-infoscripterror.yaml
 	./mods/ra/chrome/ingame-infobriefing.yaml
 	./mods/ra/chrome/ingame-infoobjectives.yaml

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -6,6 +6,7 @@
 	ScriptTriggers:
 	UpgradeManager:
 	Huntable:
+	RenderDebugState:
 
 ^SpriteActor:
 	BodyOrientation:


### PR DESCRIPTION
Inspired by, and very similar to the screenshots on #8670.
Displays the actor type and ID over selected actors when enabled.
