### PR TITLE
Implement suicide bomb for D2K Saboteur

### DIFF
--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Actor target;
 		readonly IDemolishable[] demolishables;
+		readonly EnterBehaviour enterBehaviour;
 		readonly int delay;
 		readonly int flashes;
 		readonly int flashesDelay;
@@ -28,11 +29,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		readonly Cloak cloak;
 
-		public Demolish(Actor self, Actor target, int delay, int flashes, int flashesDelay, int flashInterval, int flashDuration)
+		public Demolish(Actor self, Actor target, EnterBehaviour enterBehaviour, int delay,
+			int flashes, int flashesDelay, int flashInterval, int flashDuration)
 			: base(self, target)
 		{
 			this.target = target;
 			demolishables = target.TraitsImplementing<IDemolishable>().ToArray();
+			this.enterBehaviour = enterBehaviour;
 			this.delay = delay;
 			this.flashes = flashes;
 			this.flashesDelay = flashesDelay;
@@ -72,6 +75,11 @@ namespace OpenRA.Mods.Common.Activities
 					if (Util.ApplyPercentageModifiers(100, modifiers) > 0)
 						demolishables.Do(d => d.Demolish(target, self));
 				}));
+
+				if (enterBehaviour == EnterBehaviour.Suicide)
+					self.Kill(self);
+				else if (enterBehaviour == EnterBehaviour.Dispose)
+					self.Dispose();
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -15,6 +15,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
+	public enum EnterBehaviour { Exit, Suicide, Dispose }
+
 	public abstract class Enter : Activity
 	{
 		public enum ReserveStatus { None, TooFar, Pending, Ready }

--- a/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
@@ -34,8 +34,8 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Demolish the target actor.")]
 		public void Demolish(Actor target)
 		{
-			Self.QueueActivity(new Demolish(Self, target, info.C4Delay, info.Flashes,
-				info.FlashesDelay, info.FlashInterval, info.FlashDuration));
+			Self.QueueActivity(new Demolish(Self, target, info.EnterBehaviour, info.C4Delay,
+				info.Flashes, info.FlashesDelay, info.FlashInterval, info.FlashDuration));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/C4Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/C4Demolition.cs
@@ -35,6 +35,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Duration of each flash")]
 		public readonly int FlashDuration = 3;
 
+		[Desc("Behaviour when entering the structure.",
+			"Possible values are Exit, Suicide, Dispose.")]
+		public readonly EnterBehaviour EnterBehaviour = EnterBehaviour.Exit;
+
 		[Desc("Voice string when planting explosive charges.")]
 		[VoiceReference] public readonly string Voice = "Action";
 
@@ -83,8 +87,8 @@ namespace OpenRA.Mods.Common.Traits
 				self.CancelActivity();
 
 			self.SetTargetLine(target, Color.Red);
-			self.QueueActivity(new Demolish(self,
-				target.Actor, info.C4Delay, info.Flashes, info.FlashesDelay, info.FlashInterval, info.FlashDuration));
+			self.QueueActivity(new Demolish(self, target.Actor, info.EnterBehaviour, info.C4Delay,
+				info.Flashes, info.FlashesDelay, info.FlashInterval, info.FlashDuration));
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/C4Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/C4Demolition.cs
@@ -23,16 +23,16 @@ namespace OpenRA.Mods.Common.Traits
 			"Measured in game ticks. Default is 1.8 seconds.")]
 		public readonly int C4Delay = 45;
 
-		[Desc("Number of times to flash the target")]
+		[Desc("Number of times to flash the target.")]
 		public readonly int Flashes = 3;
 
-		[Desc("Delay before the flashing starts")]
+		[Desc("Delay before the flashing starts.")]
 		public readonly int FlashesDelay = 4;
 
-		[Desc("Interval between each flash")]
+		[Desc("Interval between each flash.")]
 		public readonly int FlashInterval = 4;
 
-		[Desc("Duration of each flash")]
+		[Desc("Duration of each flash.")]
 		public readonly int FlashDuration = 3;
 
 		[Desc("Behaviour when entering the structure.",

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -243,7 +243,9 @@ saboteur:
 	Mobile:
 		Speed: 43
 	C4Demolition:
-		C4Delay: 45
+		C4Delay: 0
+		Flashes: 0
+		EnterBehaviour: Suicide
 	-AutoTarget:
 	Cloak:
 		InitialDelay: 85


### PR DESCRIPTION
Another aspect of the original d2k balance (see [video](https://youtu.be/dmflM70vtZI?t=232)).
This introduces a yaml option for specifying what should happen when the demolisher enters its target:
- Temporary: Unit leaves again once it is done (existing behaviour).
- Suicide: Unit kills itself, increasing the kill and death counters of the owner (used for saboteur).
- Dispose: Unit is disposed without adjusting the kill/death count (engineer/spy behaviour).

I think it would be useful to take this on to prep since it is part of the overall d2k balance, so I have limited this pr to only change C4Demolition.  I have a [followup branch](https://github.com/pchote/OpenRA/commits/other-enter-traits) for bleed that adds the same flexibility to Infiltrates and the repairing traits.
