### PR TITLE
Fix D2K outpost artwork offsets and selection box.

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -406,7 +406,7 @@ outpost:
 		Queue: Building
 		BuildPaletteOrder: 50
 	Selectable:
-		Bounds: 96,64
+		Bounds: 96,72,0,-8
 	Valued:
 		Cost: 750
 	CustomBuildTimeValue:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -313,23 +313,23 @@ barracks.atreides:
 outpost.atreides:
 	idle: DATA.R8
 		Start: 2521
-		Offset: -48,80
+		Offset: -48,64
 	make: DATA.R8
 		Start: 4254
 		Length: 9
-		Offset: -48,80
+		Offset: -48,64
 	crumble-overlay: DATA.R8
 		Start: 4263
 		Length: 10
-		Offset: -48,80
+		Offset: -48,64
 		Tick: 100
 	damaged-idle: DATA.R8
 		Start: 2522
-		Offset: -48,80
+		Offset: -48,64
 	idle-dish: DATA.R8
 		Start: 4522
 		Length: 30
-		Offset: -48,80
+		Offset: -48,64
 	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -808,23 +808,23 @@ barracks.harkonnen:
 outpost.harkonnen:
 	idle: DATA.R8
 		Start: 2681
-		Offset: -48,80
+		Offset: -48,64
 	make: DATA.R8
 		Start: 4254
 		Length: 9
-		Offset: -48,80
+		Offset: -48,64
 	crumble-overlay: DATA.R8
 		Start: 4263
 		Length: 10
-		Offset: -48,80
+		Offset: -48,64
 		Tick: 100
 	damaged-idle: DATA.R8
 		Start: 2682
-		Offset: -48,80
+		Offset: -48,64
 	idle-dish: DATA.R8
 		Start: 4553
 		Length: 30
-		Offset: -48,80
+		Offset: -48,64
 	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
@@ -1212,23 +1212,23 @@ barracks.ordos:
 outpost.ordos:
 	idle: DATA.R8
 		Start: 2841
-		Offset: -48,80
+		Offset: -48,64
 	make: DATA.R8
 		Start: 4254
 		Length: 9
-		Offset: -48,80
+		Offset: -48,64
 	crumble-overlay: DATA.R8
 		Start: 4263
 		Length: 10
-		Offset: -48,80
+		Offset: -48,64
 		Tick: 100
 	damaged-idle: DATA.R8
 		Start: 2842
-		Offset: -48,80
+		Offset: -48,64
 	idle-dish: DATA.R8
 		Start: 4583
 		Length: 30
-		Offset: -48,80
+		Offset: -48,64
 	bib: BLOXBASE.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6


### PR DESCRIPTION
Fixes #8504.  Another simple fix to make the overhauled D2K mod extra polished for the nit-picky original game fans.
