### PR TITLE
Polished the Windows installer

### DIFF
--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -128,13 +128,11 @@ Section "Game" GAME
 	File "${SRCDIR}\glsl\*.vert"
 SectionEnd
 
-SectionGroup /e "Settings"
-	Section "Desktop Shortcut" DESKTOPSHORTCUT
-		SetOutPath "$INSTDIR"
-		CreateShortCut "$DESKTOP\OpenRA.lnk" $INSTDIR\OpenRA.exe "" \
-			"$INSTDIR\OpenRA.exe" "" "" "" ""
-	SectionEnd
-SectionGroupEnd
+Section "Desktop Shortcut" DESKTOPSHORTCUT
+	SetOutPath "$INSTDIR"
+	CreateShortCut "$DESKTOP\OpenRA.lnk" $INSTDIR\OpenRA.exe "" \
+		"$INSTDIR\OpenRA.exe" "" "" "" ""
+SectionEnd
 
 ;***************************
 ;Dependency Sections

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -70,6 +70,8 @@ Section "-Reg" Reg
 SectionEnd
 
 Section "Game" GAME
+	SectionIn RO
+
 	RMDir /r "$INSTDIR\mods"
 	SetOutPath "$INSTDIR\mods"
 	File /r "${SRCDIR}\mods\common"


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/10102.

You now can't de-select "Game" and I got rid of the unnecessary sub-section to avoid a horizontal scroll bar on modern Windows themes as depicted in the screenshot as well.
