### PR TITLE
drop target which was created from autotarget if targeted actor now p…

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Orders
 			if (self.World.IsGameOver)
 				return null;
 
-			if (self.Disposed || !target.IsValidFor(self))
+			if (self.Disposed || !target.IsValidForIgnoringMethod(self))
 				return null;
 
 			var modifiers = TargetModifiers.None;

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -16,12 +16,14 @@ using System.Linq;
 namespace OpenRA.Traits
 {
 	public enum TargetType { Invalid, Actor, Terrain, FrozenActor }
+	public enum TargetMethod { Manual, Automatic }
 	public struct Target
 	{
 		public static readonly Target[] None = { };
 		public static readonly Target Invalid = new Target { type = TargetType.Invalid };
 
 		TargetType type;
+		public TargetMethod TargetMethod { get; private set; }
 		Actor actor;
 		FrozenActor frozen;
 		WPos pos;
@@ -40,7 +42,7 @@ namespace OpenRA.Traits
 				: FromCell(w, o.TargetLocation);
 		}
 
-		public static Target FromActor(Actor a)
+		public static Target FromActor(Actor a, TargetMethod targetMethod = TargetMethod.Manual)
 		{
 			if (a == null)
 				return Invalid;
@@ -50,6 +52,7 @@ namespace OpenRA.Traits
 				actor = a,
 				type = TargetType.Actor,
 				generation = a.Generation,
+				TargetMethod = targetMethod,
 			};
 		}
 
@@ -77,7 +80,7 @@ namespace OpenRA.Traits
 			}
 		}
 
-		public bool IsValidFor(Actor targeter)
+		public bool IsValidForIgnoringMethod(Actor targeter)
 		{
 			if (targeter == null || Type == TargetType.Invalid)
 				return false;

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -145,5 +145,14 @@ namespace OpenRA.Mods.Common
 		{
 			return cells.MinByOrDefault(c => (self.Location - c).LengthSquared);
 		}
+
+		public static bool PreventsAutoTarget(this Actor target, Actor attacker)
+		{
+			foreach (var pat in target.TraitsImplementing<IPreventsAutoTarget>())
+				if (pat.PreventsAutoTarget(target, attacker))
+					return true;
+
+			return false;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Effects/LaserZap.cs
+++ b/OpenRA.Mods.Common/Effects/LaserZap.cs
@@ -15,6 +15,7 @@ using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Effects

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -164,7 +164,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Attack(Actor self, Actor targetActor, bool allowMove)
 		{
 			TargetedActor = targetActor;
-			var target = Target.FromActor(targetActor);
+			var target = Target.FromActor(targetActor, TargetMethod.Automatic);
 			self.SetTargetLine(target, Color.Red, false);
 			attack.AttackTarget(target, false, allowMove);
 		}
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (attackStances == OpenRA.Traits.Stance.Enemy && !actor.AppearsHostileTo(self))
 					continue;
 
-				if (PreventsAutoTarget(self, actor) || !self.Owner.CanTargetActor(actor))
+				if (self.PreventsAutoTarget(actor) || !self.Owner.CanTargetActor(actor))
 					continue;
 
 				// Select only the first compatible armament for each actor: if this actor is selected
@@ -220,14 +220,18 @@ namespace OpenRA.Mods.Common.Traits
 
 			return null;
 		}
+	}
 
-		bool PreventsAutoTarget(Actor attacker, Actor target)
+	public static class TargetExts
+	{
+		public static bool MethodIsValidFor(this Target target, Actor targeter)
 		{
-			foreach (var pat in target.TraitsImplementing<IPreventsAutoTarget>())
-				if (pat.PreventsAutoTarget(target, attacker))
-					return true;
+			return !(target.Actor != null && target.TargetMethod == TargetMethod.Automatic && target.Actor.PreventsAutoTarget(targeter));
+		}
 
-			return false;
+		public static bool IsValidFor(this Target target, Actor targeter)
+		{
+			return target.IsValidForIgnoringMethod(targeter) && target.MethodIsValidFor(targeter);
 		}
 	}
 

--- a/OpenRA.Mods.RA/Effects/TeslaZap.cs
+++ b/OpenRA.Mods.RA/Effects/TeslaZap.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Graphics;
 using OpenRA.Traits;
 


### PR DESCRIPTION
…revents autotarget. This is an improvement on the changes made with PR #9854 to resolve issue #6170.

This addresses the scenarios described by @r34ch 4 days ago:

> 1. If a unit is attacking a building and then a friendly engineer starts capturing it, that unit will not stop attacking until ordered to move; with the exception of
> 2. turreted units will continue to attack the building being captured even when moved, including moving out of range and back into range.
