### PR TITLE
Rework order targeting crazyness.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -709,7 +709,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
-				if (rejectMove || !target.IsValidFor(self))
+				if (rejectMove || target.Type != TargetType.Terrain)
 					return false;
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);


### PR DESCRIPTION
Reduces some duplication in UnitOrderGenerator and fixes #10070.  As a side effect, this adds the other half of the plumbing we need to fix #7546 (#9800 adds the first half), and gets us a small step closer to #8917.
#10070 was introduced by #9327 which gave them a finite selection size.  This meant that the ScreenMap query for actors under the cursor now returned the bridge actor instead of null, and meant that the move cursor and order queries checked against the actor's center position instead of the moused over cell.

This fix comes in two parts:
1. Adding a second pass to `UnitOrderGenerator.OrderForUnit` that checks for orders against the cell if there are no valid orders against the actor.
2. Making move orders invalid for any non-cell targets.

This fixes the cursor, and allows us to again order actors to any cell in the bridge footprint.  It also fixes the inconsistency where you got a move cursor when mousing over trees, but not over barrels.

This may have unexpected consequences, so it shouldn't be merged to prep:
- If there are any cases that relied on move orders against actors being valid when the moused-over cell was invalid but the actor's center position was valid (I don't think we have any code _this_ bogus... although it might affect crushing)
- If there are any other where we want to prevent orders against cells when there is an un-targetable actor on top.
