### PR TITLE
Interleave renderables for effects and actors

### DIFF
--- a/OpenRA.Mods.Common/Effects/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Effects/AreaBeam.cs
@@ -59,6 +59,9 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("Should the beam be visuall rendered? False = Beam is invisible.")]
 		public readonly bool RenderBeam = true;
 
+		[Desc("Equivalent to sequence ZOffset. Controls Z sorting.")]
+		public readonly int ZOffset = 0;
+
 		[Desc("Color of the beam.")]
 		public readonly Color Color = Color.Red;
 
@@ -193,7 +196,7 @@ namespace OpenRA.Mods.Common.Effects
 		{
 			if (!IsBeamComplete && info.RenderBeam && !(wr.World.FogObscures(tailPos) && wr.World.FogObscures(headPos)))
 			{
-				var beamRender = new BeamRenderable(headPos, 0, tailPos - headPos, info.Shape, info.Width, color);
+				var beamRender = new BeamRenderable(headPos, info.ZOffset, tailPos - headPos, info.Shape, info.Width, color);
 				return new[] { (IRenderable)beamRender };
 			}
 

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -63,6 +63,7 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly bool TrailUsePlayerPalette = false;
 
 		public readonly int ContrailLength = 0;
+		public readonly int ContrailZOffset = 2047;
 		public readonly Color ContrailColor = Color.White;
 		public readonly bool ContrailUsePlayerColor = false;
 		public readonly int ContrailDelay = 1;
@@ -128,7 +129,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, 0);
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -23,6 +23,9 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[Desc("Offset for Z sorting.")]
+		public readonly int ZOffset = 0;
+
 		[Desc("Length of the trail (in ticks).")]
 		public readonly int TrailLength = 25;
 
@@ -51,7 +54,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.info = info;
 
 			var color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
-			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, 0);
+			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
 
 			body = self.Trait<BodyOrientation>();
 		}

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -49,7 +49,8 @@ namespace OpenRA.Mods.Common.Effects
 			if (wr.World.FogObscures(pos))
 				yield break;
 
-			yield return new TextRenderable(font, pos, 0, color, text);
+			// Arbitrary large value used for the z-offset to try and ensure the text displays above everything else.
+			yield return new TextRenderable(font, pos, 4096, color, text);
 		}
 
 		public static string FormatCashTick(int cashAmount)

--- a/OpenRA.Mods.Common/Effects/LaserZap.cs
+++ b/OpenRA.Mods.Common/Effects/LaserZap.cs
@@ -27,6 +27,9 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("The shape of the beam.  Accepts values Cylindrical or Flat.")]
 		public readonly BeamRenderableShape Shape = BeamRenderableShape.Cylindrical;
 
+		[Desc("Equivalent to sequence ZOffset. Controls Z sorting.")]
+		public readonly int ZOffset = 0;
+
 		public readonly int BeamDuration = 10;
 
 		public readonly bool UsePlayerColor = false;
@@ -102,7 +105,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (ticks < info.BeamDuration)
 			{
 				var rc = Color.FromArgb((info.BeamDuration - ticks) * 255 / info.BeamDuration, color);
-				yield return new BeamRenderable(args.Source, 0, target - args.Source, info.Shape, info.Width, rc);
+				yield return new BeamRenderable(args.Source, info.ZOffset, target - args.Source, info.Shape, info.Width, rc);
 			}
 
 			if (hitanim != null)

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -105,6 +105,8 @@ namespace OpenRA.Mods.Common.Effects
 
 		public readonly int ContrailLength = 0;
 
+		public readonly int ContrailZOffset = 2047;
+
 		public readonly WDist ContrailWidth = new WDist(64);
 
 		public readonly Color ContrailColor = Color.White;
@@ -211,7 +213,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, 0);
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -256,6 +256,7 @@ moveflsh:
 	idle:
 		Length: *
 		Tick: 80
+		ZOffset: 2047
 
 resources:
 	Defaults:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -238,6 +238,7 @@ poweroff:
 	offline:
 		Length: *
 		Tick: 160
+		ZOffset: 2047
 
 icon:
 	Defaults:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -88,10 +88,10 @@ rank:
 		Length: *
 
 rallypoint:
-	flag:flagfly
+	flag: flagfly
 		Length: *
 		Offset: 10,-5
-	circles:fpls
+	circles: fpls
 		Length: *
 
 beacon:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -1,6 +1,7 @@
 fb4:
 	idle:
 		Length: 4
+		ZOffset: 1023
 
 fire:
 	1: fire1
@@ -14,6 +15,7 @@ fire:
 
 120mm:
 	idle:
+		ZOffset: 1023
 
 smoke_m:
 	idle:
@@ -37,22 +39,27 @@ laserfire:
 dragon:
 	idle:
 		Facings: 32
+		ZOffset: 1023
 
 smokey:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 bomb:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 missile:
 	idle:
 		Facings: 32
+		ZOffset: 1023
 
 patriot:
 	idle:
 		Facings: 32
+		ZOffset: 1023
 
 explosion:
 	Defaults:
@@ -149,17 +156,10 @@ crate-effects:
 	armorup: armorcrate
 	speedup: speedcrate
 
-atomicup:
-	idle:
-		Length: *
-
-atomicdn:
-	idle:
-		Length: *
-
 atomic:
 	Defaults:
 		Length: *
+		ZOffset: 1023
 	up: atomicup
 	down: atomicdn
 
@@ -167,11 +167,12 @@ ionsfx:
 	idle:
 		Length: *
 		Offset: 0, -78
-		ZOffset: 1
+		ZOffset: 1023
 
 bomblet:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 mpspawn:
 	idle:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -143,6 +143,7 @@ xcrated:
 crate-effects:
 	Defaults:
 		Length: *
+		ZOffset: 2047
 	airstrike: deviator
 	nuke: missile2
 	dollar: dollar

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -35,6 +35,7 @@ smoke_m:
 laserfire:
 	idle:veh-hit3
 		Length: *
+		ZOffset: 511
 
 dragon:
 	idle:
@@ -64,6 +65,7 @@ patriot:
 explosion:
 	Defaults:
 		Length: *
+		ZOffset: 511
 	nuke_explosion: atomsfx
 	piff: piff
 	piffs: piffpiff

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -116,6 +116,7 @@ allyrepair:
 	repair:
 		Length: *
 		Tick: 160
+		ZOffset: 2047
 
 crate:
 	idle:

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -91,15 +91,20 @@ rallypoint:
 	flag: flagfly
 		Length: *
 		Offset: 10,-5
+		ZOffset: 2535
 	circles: fpls
 		Length: *
+		ZOffset: 2047
 
 beacon:
+	Defaults:
+		ZOffset: 2535
 	arrow: mouse2
 		Start: 5
 		Offset: 1,-12
 	circles: fpls
 		Length: *
+		ZOffset: 2047
 	airstrike: bombicon
 		Offset: 0,-42
 	atomic: atomicon

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -125,6 +125,7 @@ Laser:
 	Projectile: LaserZap
 		Width: 85
 		HitAnim: laserfire
+		ZOffset: 2047
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 360

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -179,6 +179,7 @@ rpg:
 	idle: DATA.R8
 		Start: 3015
 		Facings: -32
+		ZOffset: 1023
 
 120mm:
 	idle: DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -404,6 +404,7 @@ moveflsh:
 		Length: 5
 		Tick: 80
 		BlendMode: Multiply
+		ZOffset: 2047
 
 resources:
 	spice: BLOXBASE.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -132,11 +132,13 @@ clock:
 powerdown:
 	disabled: speed.shp
 		Start: 3
+		ZOffset: 2047
 
 poweroff:
 	offline: poweroff.shp
 		Length: *
 		Tick: 160
+		ZOffset: 2047
 
 rank:
 	rank: rank.shp

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -167,15 +167,19 @@ rallypoint:
 	flag: flagfly.shp
 		Length: *
 		Offset: 11,-5
+		ZOffset: 2535
 	circles: fpls.shp
 		Length: *
+		ZOffset: 2047
 
 beacon:
 	arrow: MOUSE.R8
 		Start: 148
 		Offset: -24,-24
+		ZOffset: 2535
 	circles: fpls.shp
 		Length: *
+		ZOffset: 2047
 
 rpg:
 	idle: DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -217,6 +217,7 @@ allyrepair:
 		Length: 2
 		Tick: 300
 		Offset: -11,-10
+		ZOffset: 2047
 
 missile:
 	idle: DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -62,36 +62,42 @@ large_trail:
 		Length: 4
 		Tick: 80
 		BlendMode: Additive
+		ZOffset: 1023
 
 small_trail:
 	idle: DATA.R8
 		Start: 3735
 		Length: 4
 		Tick: 80
+		ZOffset: 1023
 
 small_trail2:
 	idle: DATA.R8
 		Start: 3540
 		Length: 4
 		Tick: 80
+		ZOffset: 1023
 
 bazooka_trail:
 	idle: DATA.R8
 		Start: 3381
 		Length: 4
 		Tick: 80
+		ZOffset: 1023
 
 bazooka_trail2:
 	idle: DATA.R8
 		Start: 3544
 		Length: 4
 		Tick: 80
+		ZOffset: 1023
 
 deviator_trail:
 	idle: DATA.R8
 		Start: 3535
 		Length: 5
 		Tick: 80
+		ZOffset: 1023
 
 laserfire:
 	idle: DATA.R8
@@ -175,10 +181,12 @@ rpg:
 	idle: DATA.R8
 		Start: 3014
 		BlendMode: Additive
+		ZOffset: 1023
 
 155mm:
 	idle: DATA.R8
 		Start: 3081
+		ZOffset: 1023
 
 crate-effects:
 	dollar: DATA.R8
@@ -208,17 +216,21 @@ missile:
 	idle: DATA.R8
 		Start: 3088
 		Facings: -32
+		ZOffset: 1023
 
 missile2:
 	idle: DATA.R8
 		Start: 3306
 		Facings: -32
+		ZOffset: 1023
 
 atomic:
 	up: DATA.R8
 		Start: 2147
+		ZOffset: 1023
 	down: DATA.R8
 		Start: 2148
+		ZOffset: 1023
 
 fire:
 	1: DATA.R8
@@ -264,31 +276,37 @@ bombs:
 	idle: DATA.R8
 		Start: 3280
 		Length: 4
+		ZOffset: 1023
 
 grenade:
 	idle: grenade.shp	# frames 3618-3621 from patch 1.06 DATA.R8
 		Length: 4
 		Tick: 80
+		ZOffset: 1023
 
 shrapnel:
 	idle: DATA.R8
 		Start: 3290
 		Length: 4
+		ZOffset: 1023
 
 shrapnel2:
 	idle: DATA.R8
 		Start: 3294
 		Length: 1
+		ZOffset: 1023
 
 shrapnel3:
 	idle: DATA.R8
 		Start: 3295
 		Length: 8
+		ZOffset: 1023
 
 shrapnel4:
 	idle: DATA.R8
 		Start: 3303
 		Length: 1
+		ZOffset: 1023
 		
 mpspawn:
 	idle: mpspawn.shp
@@ -322,6 +340,7 @@ doubleblastbullet:
 		Start: 3248
 		Facings: -16
 		BlendMode: Additive
+		ZOffset: 1023
 
 icon:
 	ornistrike: DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -272,6 +272,8 @@ fire:
 		BlendMode: Additive
 
 smoke_m:
+	Defaults:
+		ZOffset: 511
 	idle: DATA.R8
 		Start: 3418
 		Length: 2

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -2,6 +2,7 @@ explosion:
 	Defaults:
 		BlendMode: Additive
 		Tick: 80
+		ZOffset: 511
 	piff: DATA.R8
 		Start: 3626
 		Length: 5
@@ -52,6 +53,7 @@ explosion:
 		Tick: 120
 		Offset: 0, -16
 	corpse: DATA.R8
+		ZOffset: -511
 		Start: 430
 		Length: 12
 		Tick: 1600
@@ -105,6 +107,7 @@ laserfire:
 		Length: 4
 		Tick: 80
 		BlendMode: Additive
+		ZOffset: 511
 
 pips:
 	groups: DATA.R8
@@ -334,6 +337,7 @@ doubleblast:
 		Start: 3279
 		Facings: -16
 		BlendMode: Additive
+		ZOffset: 511
 
 doubleblastbullet:
 	idle: DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -193,6 +193,8 @@ rpg:
 		ZOffset: 1023
 
 crate-effects:
+	Defaults:
+		ZOffset: 2047
 	dollar: DATA.R8
 		Start: 3679
 		Length: 8

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -179,6 +179,7 @@ moveflsh:
 	idle:
 		Length: *
 		Tick: 80
+		ZOffset: 2047
 		UseTilesetExtension: true
 		TilesetOverrides:
 			DESERT: TEMPERAT

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -8,9 +8,11 @@ powerdown:
 
 120mm:
 	idle:
+		ZOffset: 1023
 
 50cal:
 	idle:
+		ZOffset: 1023
 
 explosion:
 	Defaults:
@@ -80,6 +82,7 @@ pips:
 v2:
 	idle:
 		Facings: 32
+		ZOffset: 1023
 
 rallypoint:
 	flag:flagfly
@@ -128,6 +131,7 @@ smoke_m:
 dragon:
 	idle:
 		Facings: 32
+		ZOffset: 1023
 
 smokey:
 	idle:
@@ -137,21 +141,31 @@ smokey:
 bomb:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 missile:
 	idle:
 		Facings: 32
+		ZOffset: 1023
+
+torpedo:
+	idle: missile
+		Facings: 32
+		ZOffset: -1023
 
 litning:
 	bright:
 		Length: 4
+		ZOffset: 1023
 	dim:
 		Start: 4
 		Length: 4
+		ZOffset: 1023
 
 fb1:
 	idle: 
 		Length: *
+		ZOffset: 1023
 
 moveflsh:
 	idle:
@@ -184,6 +198,7 @@ sputnik:
 	idle:
 		Length: *
 		Offset: -4,0
+		ZOffset: 1023
 
 dd-crnr:
 	idle:
@@ -199,13 +214,17 @@ dd-crnr:
 fb2:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 fb3:
 	idle:
 		Facings: 32
+		ZOffset: 1023
+
 fb4:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 scrate:
 	idle:
@@ -319,24 +338,19 @@ parach-shadow:
 	idle:
 		Length: *
 
-atomicup:
-	idle:
-		Length: *
-
-atomicdn:
-	idle:
-		Length: *
-
 bomblet:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 parabomb:
 	open:
 		Length: 8
+		ZOffset: 1023
 	idle:
 		Start: 8
 		Length: 5
+		ZOffset: 1023
 
 smokland:
 	open: playersmoke
@@ -378,8 +392,10 @@ iconchevrons:
 atomic:
 	up: atomicup
 		Length: *
+		ZOffset: 1023
 	down: atomicdn
 		Length: *
+		ZOffset: 1023
 
 bubbles:
 	idle:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -190,6 +190,7 @@ allyrepair:
 	repair:
 		Length: *
 		Tick: 160
+		ZOffset: 2047
 
 tabs:
 	left-normal:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -293,40 +293,26 @@ xcrated:
 		ZOffset: -511
 
 crate-effects:
+	Defaults:
+		ZOffset: 2047
+		Length: *
 	speed: speed
-		Length: *
 	dollar: dollar
-		Length: *
 	reveal-map: earth
-		Length: *
 	hide-map: empulse
-		Length: *
 	fpower: fpower
-		Length: *
 	gps: gpsbox
-		Length: *
 	invuln: invulbox
-		Length: *
 	heal: invun
-		Length: *
 	nuke: missile2
-		Length: *
 	parabombs: parabox
-		Length: *
 	sonar: sonarbox
-		Length: *
 	stealth: stealth2
-		Length: *
 	timequake: tquake
-		Length: *
 	armor: armor
-		Length: *
 	chrono: chronbox
-		Length: *
 	airstrike: deviator
-		Length: *
 	levelup: levelup
-		Length: *
 		Tick: 200
 
 parach:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -5,6 +5,7 @@ clock:
 powerdown:
 	disabled: speed
 		Start: 3
+		ZOffset: 2047
 
 120mm:
 	idle:
@@ -185,6 +186,7 @@ poweroff:
 	offline:
 		Length: *
 		Tick: 160
+		ZOffset: 2047
 
 allyrepair:
 	repair:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -91,15 +91,20 @@ rallypoint:
 	flag:flagfly
 		Length: *
 		Offset: 11,-5
+		ZOffset: 2535
 	circles:fpls
 		Length: *
+		ZOffset: 2047
 
 beacon:
+	Defaults:
+		ZOffset: 2535
 	arrow: mouse
 		Start: 5
 		Offset: 1,-12
 	circles: fpls
 		Length: *
+		ZOffset: 2047
 	atomicon: lores-atomicon
 		Length: *
 		Offset: 0,-42

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -17,6 +17,7 @@ powerdown:
 explosion:
 	Defaults:
 		Length: *
+		ZOffset: 511
 	piff: piff
 	piffs: piffpiff
 	water_piff: wpiff
@@ -41,6 +42,7 @@ explosion:
 	small_napalm: napalm1
 	large_napalm: napalm3
 	corpse: corpse1
+		ZOffset: -512
 		Tick: 1600
 		UseTilesetExtension: true
 		TilesetOverrides:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -367,7 +367,7 @@ TorpTube:
 	Burst: 2
 	BurstDelay: 20
 	Projectile: Missile
-		Image: MISSILE
+		Image: torpedo
 		Arm: 3
 		MaximumLaunchSpeed: 85
 		TrailImage: bubbles

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -47,6 +47,7 @@ crate:
 crate-effects:
 	Defaults:
 		Length: *
+		ZOffset: 2047
 	dollar: money
 	reveal-map: reveal
 	hide-map: shroudx

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -23,6 +23,7 @@ allyrepair:
 	repair: wrench
 		Length: *
 		Tick: 160
+		ZOffset: 2047
 
 rallypoint:
 	flag: mouse

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -266,6 +266,7 @@ wake:
 	idle: wake2
 		Length: *
 		Tick: 180
+		ZOffset: 2047
 
 resources:
 	Defaults:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -30,15 +30,18 @@ rallypoint:
 	flag: mouse
 		Start: 221
 		Length: 8
+		ZOffset: 3072
 	circles: null
 
 beacon:
 	arrow: mouse
 		Start: 6
 		Offset: 1,-12
+		ZOffset: 2535
 	circles: ring
 		Length: 12
 		BlendMode: Additive
+		ZOffset: 2047
 
 crate:
 	idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -172,54 +172,66 @@ explosion:
 discus:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 canister:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 pulsball:
 	idle:
 		Length: *
 		BlendMode: Additive
+		ZOffset: 1023
 
 dragon:
 	idle:
 		Facings: 32
+		ZOffset: 1023
 
 crystal4:
 	idle:
 		Length: 15
 		ShadowStart: 15
 		UseTilesetExtension: true
+		ZOffset: 1023
 
 120mm:
 	idle:
+		ZOffset: 1023
 
 torpedo:
 	idle:
 		Length: *
+		ZOffset: 1023
 
 flameall:
 	idle:
 		Length: 19
 		Facings: -8
 		Tick: 160
+		ZOffset: 1023
 
 largesmoke:
 	idle: lgrysmk1
 		Length: *
+		ZOffset: 1023
 
 smallsmoke:
 	idle: sgrysmk1
 		Length: *
+		ZOffset: 1023
 
 large_smoke_trail:
 	idle: smokey
 		Length: *
+		ZOffset: 1023
 
 small_smoke_trail:
 	idle: smokey2
 		Length: *
+		ZOffset: 1023
 
 largefire:
 	idle: fire1
@@ -354,7 +366,7 @@ ionbeam:
 	idle:
 		Length: *
 		Offset: 0, -78
-		ZOffset: 1
+		ZOffset: 1023
 
 trock01:
 	idle:
@@ -417,48 +429,34 @@ srock05:
 		Offset: 0, -12
 
 dbrissm:
+	Defaults:
+		ZOffset: 1023
+		Length:*
 	1: dbris1sm
-		Length:*
 	2: dbris2sm
-		Length:*
 	3: dbris3sm
-		Length:*
 	4: dbris4sm
-		Length:*
 	5: dbris5sm
-		Length:*
 	6: dbris6sm
-		Length:*
 	7: dbris7sm
-		Length:*
 	8: dbris8sm
-		Length:*
 	9: dbris9sm
-		Length:*
 	10: dbrs10sm
-		Length:*
 
 dbrislg:
+	Defaults:
+		ZOffset: 1023
+		Length:*
 	1: dbris1lg
-		Length:*
 	2: dbris2lg
-		Length:*
 	3: dbris3lg
-		Length:*
 	4: dbris4lg
-		Length:*
 	5: dbris5lg
-		Length:*
 	6: dbris6lg
-		Length:*
 	7: dbris7lg
-		Length:*
 	8: dbris8lg
-		Length:*
 	9: dbris9lg
-		Length:*
 	10: dbrs10lg
-		Length:*
 
 crat01:
 	idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -126,6 +126,7 @@ pips:
 explosion:
 	Defaults:
 		Length: *
+		ZOffset: 511
 	building: twlt070
 	ionring: ring1
 		BlendMode: Additive

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -260,6 +260,7 @@ moveflsh:
 	idle: ring
 		Length: *
 		Tick: 30
+		ZOffset: 2047
 
 wake:
 	idle: wake2

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -18,6 +18,7 @@ poweroff:
 	offline:
 		Length: *
 		Tick: 160
+		ZOffset: 2047
 
 allyrepair:
 	repair: wrench

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -75,6 +75,7 @@ SonicZap:
 		DamageInterval: 5 # Roughly 18 impacts.
 		Width: 0c384
 		Shape: Flat
+		ZOffset: 2047
 		BeyondTargetRange: 0c256
 		Blockable: true
 		Color: 00FFFFC8
@@ -176,6 +177,7 @@ ObeliskLaserFire:
 	Report: OBELRAY1.AUD
 	Projectile: LaserZap
 		Width: 170
+		ZOffset: 2047
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 250
@@ -188,6 +190,7 @@ TurretLaserFire:
 	Projectile: LaserZap
 		Width: 85
 		BeamDuration: 5
+		ZOffset: 2047
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 30


### PR DESCRIPTION
Previously, renderables from actors were z-ordered, but effects were excluded and not ordered. Now we order them all as a whole.

For reference, the RA shellmap uses ~450 actors and ~330 effects at a given moment. Sorting just the actors alone costs 1.4% CPU, whilst sorting both actors and effects raises it to 1.8%. So the performance impact isn't too bad.

According to https://github.com/OpenRA/OpenRA/issues/9443#issue-108459573, this will hopefully fix some polish issues.
