### PR TITLE
Fix broken GPS and frozen actor behaviour

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -42,8 +42,11 @@ namespace OpenRA.Traits
 
 		public bool Visible = true;
 		public bool Shrouded { get; private set; }
-		public bool NeedRenderables { get; private set; }
-		public bool IsRendering { get; private set; }
+		public bool NeedRenderables { get; set; }
+		public IRenderable[] Renderables = NoRenderables;
+		static readonly IRenderable[] NoRenderables = new IRenderable[0];
+
+		int flashTicks;
 
 		public FrozenActor(Actor self, PPos[] footprint, Shroud shroud, bool startsRevealed)
 		{
@@ -68,11 +71,6 @@ namespace OpenRA.Traits
 		public bool IsValid { get { return Owner != null; } }
 		public ActorInfo Info { get { return actor.Info; } }
 		public Actor Actor { get { return !actor.IsDead ? actor : null; } }
-
-		static readonly IRenderable[] NoRenderables = new IRenderable[0];
-
-		int flashTicks;
-		IRenderable[] renderables = NoRenderables;
 
 		public void Tick()
 		{
@@ -103,8 +101,7 @@ namespace OpenRA.Traits
 					Shrouded = false;
 			}
 
-			if (Visible && !wasVisible)
-				NeedRenderables = true;
+			NeedRenderables = Visible && !wasVisible;
 		}
 
 		public void Flash()
@@ -114,31 +111,20 @@ namespace OpenRA.Traits
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (NeedRenderables)
-			{
-				NeedRenderables = false;
-				if (!actor.Disposed)
-				{
-					IsRendering = true;
-					renderables = actor.Render(wr).ToArray();
-					IsRendering = false;
-				}
-			}
-
 			if (Shrouded)
 				return NoRenderables;
 
 			if (flashTicks > 0 && flashTicks % 2 == 0)
 			{
 				var highlight = wr.Palette("highlight");
-				return renderables.Concat(renderables.Where(r => !r.IsDecoration)
+				return Renderables.Concat(Renderables.Where(r => !r.IsDecoration)
 					.Select(r => r.WithPalette(highlight)));
 			}
 
-			return renderables;
+			return Renderables;
 		}
 
-		public bool HasRenderables { get { return !Shrouded && renderables.Any(); } }
+		public bool HasRenderables { get { return !Shrouded && Renderables.Any(); } }
 
 		public bool ShouldBeRemoved(Player owner)
 		{

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
 	}
 
-	public class FrozenUnderFog : IRenderModifier, IDefaultVisibility, ITick, ISync
+	public class FrozenUnderFog : IRenderModifier, IDefaultVisibility, ITick, ITickRender, ISync
 	{
 		[Sync] public int VisibilityHash;
 
@@ -41,6 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		ITooltip tooltip;
 		Health health;
 		bool initialized;
+		bool isRendering;
 
 		class FrozenState
 		{
@@ -143,11 +144,35 @@ namespace OpenRA.Mods.Common.Traits
 			initialized = true;
 		}
 
+		public void TickRender(WorldRenderer wr, Actor self)
+		{
+			if (!initialized)
+				return;
+
+			IRenderable[] renderables = null;
+			foreach (var player in self.World.Players)
+			{
+				var frozen = stateByPlayer[player].FrozenActor;
+				if (!frozen.NeedRenderables)
+					continue;
+
+				if (renderables == null)
+				{
+					isRendering = true;
+					renderables = self.Render(wr).ToArray();
+					isRendering = false;
+				}
+
+				frozen.NeedRenderables = false;
+				frozen.Renderables = renderables;
+			}
+		}
+
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
 			return
 				IsVisible(self, self.World.RenderPlayer) ||
-				(initialized && stateByPlayer[self.World.RenderPlayer].FrozenActor.IsRendering) ?
+				(initialized && isRendering) ?
 				r : SpriteRenderable.None;
 		}
 	}

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.RA.Traits
 			foreach (var i in atek.World.ActorsWithTrait<GpsWatcher>())
 				i.Trait.RefreshGranted();
 
-			if ((Granted || GrantedAllies) && atek.Owner.IsAlliedWith(atek.World.RenderPlayer))
+			if ((Granted || GrantedAllies) && atek.Owner.IsAlliedWith(Owner))
 				atek.Owner.Shroud.ExploreAll(atek.World);
 		}
 


### PR DESCRIPTION
## Merge dictionaries in GpsDot

This speeds up GpsDot.Tick as it requires only one dictionary lookup per player rather than two. This change also provides useful infrastructure for later commits.

On the RA shellmap, this reduces total CPU time spent in GpsDot.Tick from 1.3% to 0.6%.
## Ensure frozen actors are rendered on the first tick they become visible

Fixes a regression from #7734. If we don't render the snapshot for the frozen actor straight away, the actor can continue ticking and we'll take a much newer than intended snapshot and display that instead. This doesn't tend to have bad effects in practise but nonetheless we revert back to using TickRender to get a snapshot at the correct time.

We still manage to keep the perf benefit of #7734, by only rendering the snapshot once and not again until we need to.
## Fix GPS dot relying on frozen actor render state

Fixes #10155. See the linked issue for more details. Ultimately I have seperated the simulation and render state of the GPS dot from the frozen actor rendering. I have attempted to maintain other behaviour, such as not rendering a GPS dot if there is already a visible frozen actor for it.
## Fix GPS refreshing for incorrect player

This was just noticed during the debugging for #10155 as clearly broken behaviour (relying on the render player in simulation code). I'm including a fix here, although we haven't seen this manifest any issues of its own as yet.
## Please review carefully

So far, every PR I have ever submitted or reviewed dealing with the frozen actor code has contained major regressions which I did not catch. Anything I've written here has a high chance of being super broken and you should treat it with due scepticism.
