### PR TITLE
Speed up FrozenUnderFog.Tick

### DIFF
--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -38,9 +38,14 @@ namespace OpenRA
 
 		public readonly MersenneTwister SharedRandom;
 
-		public readonly List<Player> Players = new List<Player>();
+		public Player[] Players = new Player[0];
 
-		public void AddPlayer(Player p) { Players.Add(p); }
+		public void SetPlayers(IEnumerable<Player> players, Player localPlayer)
+		{
+			Players = players.ToArray();
+			SetLocalPlayer(localPlayer);
+		}
+
 		public Player LocalPlayer { get; private set; }
 
 		public event Action GameOver = () => { };
@@ -82,12 +87,18 @@ namespace OpenRA
 			get { return LobbyInfo.GlobalSettings.AllowCheats || LobbyInfo.IsSinglePlayer; }
 		}
 
-		public void SetLocalPlayer(string pr)
+		void SetLocalPlayer(Player localPlayer)
 		{
+			if (localPlayer == null)
+				return;
+
+			if (!Players.Contains(localPlayer))
+				throw new ArgumentException("The local player must be one of the players in the world.", "localPlayer");
+
 			if (IsReplay)
 				return;
 
-			LocalPlayer = Players.FirstOrDefault(p => p.InternalName == pr);
+			LocalPlayer = localPlayer;
 			RenderPlayer = LocalPlayer;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -35,11 +35,10 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool startsRevealed;
 		readonly PPos[] footprint;
 
-		readonly Lazy<ITooltip> tooltip;
-		readonly Lazy<Health> health;
-
 		readonly Dictionary<Player, FrozenState> stateByPlayer = new Dictionary<Player, FrozenState>();
 
+		ITooltip tooltip;
+		Health health;
 		bool initialized;
 
 		class FrozenState
@@ -62,8 +61,6 @@ namespace OpenRA.Mods.Common.Traits
 			startsRevealed = info.StartsRevealed && !init.Contains<ParentActorInit>();
 			var footprintCells = FootprintUtils.Tiles(init.Self).ToList();
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
-			tooltip = Exts.Lazy(() => init.Self.TraitsImplementing<ITooltip>().FirstOrDefault());
-			health = Exts.Lazy(() => init.Self.TraitOrDefault<Health>());
 		}
 
 		bool IsVisibleInner(Actor self, Player byPlayer)
@@ -90,6 +87,13 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			VisibilityHash = 0;
+
+			if (!initialized)
+			{
+				tooltip = self.TraitsImplementing<ITooltip>().FirstOrDefault();
+				health = self.TraitOrDefault<Health>();
+			}
+
 			foreach (var player in self.World.Players)
 			{
 				FrozenActor frozenActor;
@@ -116,16 +120,16 @@ namespace OpenRA.Mods.Common.Traits
 
 				frozenActor.Owner = self.Owner;
 
-				if (health.Value != null)
+				if (health != null)
 				{
-					frozenActor.HP = health.Value.HP;
-					frozenActor.DamageState = health.Value.DamageState;
+					frozenActor.HP = health.HP;
+					frozenActor.DamageState = health.DamageState;
 				}
 
-				if (tooltip.Value != null)
+				if (tooltip != null)
 				{
-					frozenActor.TooltipInfo = tooltip.Value.TooltipInfo;
-					frozenActor.TooltipOwner = tooltip.Value.Owner;
+					frozenActor.TooltipInfo = tooltip.TooltipInfo;
+					frozenActor.TooltipOwner = tooltip.Owner;
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -164,10 +164,7 @@ namespace OpenRA.Mods.Common.Traits
 				var index = int.Parse(name.Substring(5));
 
 				if (index >= newCount)
-				{
 					Players.Players.Remove(name);
-					worldRenderer.World.Players.RemoveAll(pp => pp.InternalName == name);
-				}
 			}
 
 			for (var index = 0; index < newCount; index++)


### PR DESCRIPTION
Two speedups here:
- Avoid the perf impact of accessing Lazy<T>.Value for the traits.
- Store states for each player in an array rather than a dictionary for much faster lookups. This relies on the players in the world never changing (they don't once the world is created) - however I have applied a small refactoring to firm this up a bit.

On the RA shellmap, this reduces total CPU time spent in FrozenUnderFog.Tick from 1.40% to 0.51%.
