### PR TITLE
Revert "add custom selection sizes to aid the renderer" on prep-1512

### DIFF
--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -314,8 +314,6 @@ BRIDGE1:
 	Building:
 		Footprint: ____ ____ ____ ____
 		Dimensions: 4,4
-	CustomSelectionSize:
-		CustomBounds: 96,96
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 2,0
@@ -331,8 +329,6 @@ BRIDGE2:
 	Building:
 		Footprint: _____ _____ _____ _____ _____
 		Dimensions: 5,5
-	CustomSelectionSize:
-		CustomBounds: 120,120
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 0,0
@@ -348,8 +344,6 @@ BRIDGE3:
 	Building:
 		Footprint: ______ ______ ______ ______ ______
 		Dimensions: 6,5
-	CustomSelectionSize:
-		CustomBounds: 144,120
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 3,0
@@ -365,8 +359,6 @@ BRIDGE4:
 	Building:
 		Footprint: ______ ______ ______ ______
 		Dimensions: 6,4
-	CustomSelectionSize:
-		CustomBounds: 144,96
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 1,0

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -400,8 +400,6 @@ BRIDGE1:
 	Building:
 		Footprint: _____ _____ _____
 		Dimensions: 5,3
-	CustomSelectionSize:
-		CustomBounds: 120,72
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 2,-1
@@ -418,8 +416,6 @@ BRIDGE2:
 	Building:
 		Footprint: _____ _____
 		Dimensions: 5,2
-	CustomSelectionSize:
-		CustomBounds: 120,48
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 0,-1
@@ -436,8 +432,6 @@ SBRIDGE1:
 	Building:
 		Footprint: ___ ___
 		Dimensions: 3,2
-	CustomSelectionSize:
-		CustomBounds: 72,48
 	FreeActor@north:
 		Actor: bridgehut.small
 		SpawnOffset: 1,0
@@ -454,8 +448,6 @@ SBRIDGE2:
 	Building:
 		Footprint: __ __ __
 		Dimensions: 2,3
-	CustomSelectionSize:
-		CustomBounds: 48,72
 	FreeActor@west:
 		Actor: bridgehut.small
 		SpawnOffset: 0,1
@@ -469,6 +461,9 @@ SBRIDGE3:
 		Template: 523
 		DamagedTemplate: 524
 		DestroyedTemplate: 525
+	Building:
+		Footprint: ____ ____
+		Dimensions: 4,2
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 2,-1
@@ -482,6 +477,9 @@ SBRIDGE4:
 		Template: 527
 		DamagedTemplate: 528
 		DestroyedTemplate: 529
+	Building:
+		Footprint: ____ ____
+		Dimensions: 4,2
 	FreeActor@north:
 		Actor: bridgehut
 		SpawnOffset: 0,-1

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -637,8 +637,6 @@
 	Building:
 		Footprint: ____ ____
 		Dimensions: 4,2
-	CustomSelectionSize:
-		CustomBounds: 96,48
 	Health:
 		HP: 1000
 	ProximityCaptor:


### PR DESCRIPTION
This reverts commit c3dce785a54637301b941206fadbcd28271b499b.

Works around #10070 on the prep branch only, bringing this back to how it was in the last few releases (yes - we did always show the move-blocked cursor over the bridge ends!).  The proper fix for Next + 1 is #10118.
