### PR TITLE
Added a benchmark mode

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -45,6 +45,8 @@ namespace OpenRA
 		public static Sound Sound;
 		public static bool HasInputFocus = false;
 
+		public static bool BenchmarkMode = false;
+
 		public static GlobalChat GlobalChat;
 
 		public static OrderManager JoinServer(string host, int port, string password, bool recordReplay = true)
@@ -493,6 +495,9 @@ namespace OpenRA
 
 							Log.Write("debug", "--Tick: {0} ({1})", LocalTick, isNetTick ? "net" : "local");
 
+							if (BenchmarkMode)
+								Log.Write("cpu", "{0};{1}".F(LocalTick, PerfHistory.Items["tick_time"].LastValue));
+
 							if (isNetTick)
 								orderManager.Tick();
 
@@ -578,6 +583,9 @@ namespace OpenRA
 			PerfHistory.Items["batches"].Tick();
 			PerfHistory.Items["render_widgets"].Tick();
 			PerfHistory.Items["render_flip"].Tick();
+
+			if (BenchmarkMode)
+				Log.Write("render", "{0};{1}".F(RenderFrame, PerfHistory.Items["render"].LastValue));
 		}
 
 		static void Loop()

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -96,13 +96,25 @@ namespace OpenRA
 	public class GraphicSettings
 	{
 		public string Renderer = "Default";
+
+		[Desc("This can be set to Windowed, Fullscreen or PseudoFullscreen.")]
 		public WindowMode Mode = WindowMode.PseudoFullscreen;
+
+		[Desc("Screen resolution in fullscreen mode.")]
 		public int2 FullscreenSize = new int2(0, 0);
+
+		[Desc("Screen resolution in windowed mode.")]
 		public int2 WindowedSize = new int2(1024, 768);
+
 		public bool HardwareCursors = true;
+
 		public bool PixelDouble = false;
 		public bool CursorDouble = false;
+
+		[Desc("Add a frame rate limiter. It is recommended to not disable this.")]
 		public bool CapFramerate = true;
+
+		[Desc("At which frames per second to cap the framerate.")]
 		public int MaxFramerate = 60;
 
 		public int BatchSize = 8192;

--- a/OpenRA.Game/Support/LaunchArguments.cs
+++ b/OpenRA.Game/Support/LaunchArguments.cs
@@ -21,6 +21,9 @@ namespace OpenRA
 		[Desc("Automatically start playing the given replay file.")]
 		public string Replay;
 
+		[Desc("Dump performance data into cpu.csv and render.csv in the logs folder.")]
+		public bool Benchmark;
+
 		public LaunchArguments(Arguments args)
 		{
 			if (args == null)

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -8,6 +8,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -38,6 +39,19 @@ namespace OpenRA.Mods.Common.LoadScreens
 			Launch = new LaunchArguments(args);
 			Ui.ResetAll();
 			Game.Settings.Save();
+
+			if (Launch.Benchmark)
+			{
+				Log.AddChannel("cpu", "cpu.csv");
+				Log.Write("cpu", "tick;time [ms]");
+
+				Log.AddChannel("render", "render.csv");
+				Log.Write("render", "frame;time [ms]");
+
+				Console.WriteLine("Saving benchmark data into {0}".F(Path.Combine(Platform.SupportDir, "Logs")));
+
+				Game.BenchmarkMode = true;
+			}
 
 			// Join a server directly
 			var connect = Launch.GetConnectAddress();


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/8673.

If you start the game with ~~`Debug.Benchmark=true`~~  `Launch.Benchmark=true` this adds two new files into the Log folder:

![image](https://cloud.githubusercontent.com/assets/756669/11451951/fff827a0-95d6-11e5-98af-82192b4d4d3f.png)

which record CPU and rendering performance over time in character separated values with `;` as separator to avoid confusion with localized floating point separators. 

You can create graphs, calculate average FPS like values or maybe even do live data analysis with tools like https://kst-plot.kde.org/ This shouldn't limit anyone's freedom.

The Red Alert desert shellmap is a good performance benchmark in itself, but you probably get the most reproducible results by starting a replay directly either from the command line or by double clicking on it.
