### PR TITLE
Fix actors not going back to idle animation after custom animation

### DIFF
--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				var wsb = hostBuilding.Trait<WithSpriteBody>();
 				if (wsb.DefaultAnimation.HasSequence("active"))
-					wsb.PlayCustomAnimation(hostBuilding, "active");
+					wsb.PlayCustomAnimation(hostBuilding, "active", () => wsb.CancelCustomAnimation(self));
 
 				var sound = pool.Info.RearmSound;
 				if (sound != null)

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Harvester was killed while unloading
 			if (dockedHarv != null && dockedHarv.IsDead)
 			{
-				wsb.PlayCustomAnimation(self, wsb.Info.Sequence);
+				wsb.CancelCustomAnimation(self);
 				dockedHarv = null;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithActiveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithActiveAnimation.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (--ticks <= 0)
 			{
 				if (!(info.PauseOnLowPower && self.IsDisabled()))
-					wsb.PlayCustomAnimation(self, info.Sequence);
+					wsb.PlayCustomAnimation(self, info.Sequence, () => wsb.CancelCustomAnimation(self));
 				ticks = info.Interval;
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Charging(Actor self, Target target)
 		{
-			wsb.PlayCustomAnimation(self, info.ChargeSequence);
+			wsb.PlayCustomAnimation(self, info.ChargeSequence, () => wsb.CancelCustomAnimation(self));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var spriteBody = host.TraitOrDefault<WithSpriteBody>();
 			if (spriteBody != null && !(info.PauseOnLowPower && self.IsDisabled()))
-				spriteBody.PlayCustomAnimation(host, info.Sequence);
+				spriteBody.PlayCustomAnimation(host, info.Sequence, () => spriteBody.CancelCustomAnimation(self));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var wsb = self.TraitOrDefault<WithSpriteBody>();
 			if (wsb != null && wsb.DefaultAnimation.HasSequence(info.GrantUpgradeSequence))
-				wsb.PlayCustomAnimation(self, info.GrantUpgradeSequence);
+				wsb.PlayCustomAnimation(self, info.GrantUpgradeSequence, () => wsb.CancelCustomAnimation(self));
 
 			Game.Sound.Play(info.GrantUpgradeSound, self.World.Map.CenterOfCell(order.TargetLocation));
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!string.IsNullOrEmpty(info.ActivationSequence))
 			{
 				var wsb = self.Trait<WithSpriteBody>();
-				wsb.PlayCustomAnimation(self, info.ActivationSequence);
+				wsb.PlayCustomAnimation(self, info.ActivationSequence, () => wsb.CancelCustomAnimation(self));
 			}
 
 			var targetPosition = self.World.Map.CenterOfCell(order.TargetLocation);


### PR DESCRIPTION
Before this fix, actors which had an idle animation (not an overlay, but a looping `idle` sequence with more than 1 frame) as well as an `active` animation of some kind would get stuck at the last frame of the active animation once it played, because the latter was basically never cancelled.
A few cases have already been fixed in the past (`WithBuildingPlacedAnimation`, `WithAttackAnimation`), but not all of them.

This has gone unnoticed because there are only very few actors in the shipping mods with more than 1 idle frame (RA airfields are the only case I can think of), while TS uses overlays.
