### PR TITLE
Set default missile acceleration to 0

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly WDist MaximumSpeed = new WDist(384);
 
 		[Desc("Projectile acceleration when propulsion activated.")]
-		public readonly WDist Acceleration = new WDist(5);
+		public readonly WDist Acceleration = new WDist(0);
 
 		[Desc("How many ticks before this missile is armed and can explode.")]
 		public readonly int Arm = 0;


### PR DESCRIPTION
As discussed on IRC and proven out in #10129. If merged, we should make a ticket for `next+1` on the topic of re-adding acceleration, since we're short on time.
