### PR TITLE
Implement a utility command to check for explicit interface implementation violations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,9 @@ check: utility mods
 	@echo
 	@echo "Checking for code style violations in OpenRA.Test..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Test
+	@echo
+	@echo "Checking for explicit interface violations..."
+	@mono --debug OpenRA.Utility.exe all --check-explicit-interfaces
 
 NUNIT_CONSOLE := $(shell test -f thirdparty/download/nunit3-console.exe && echo mono thirdparty/download/nunit3-console.exe || \
 	which nunit3-console 2>/dev/null || which nunit2-console 2>/dev/null || which nunit-console 2>/dev/null)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -19,6 +19,8 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Traits
 {
+	public sealed class RequireExplicitImplementationAttribute : Attribute { }
+
 	public enum DamageState { Undamaged, Light, Medium, Heavy, Critical, Dead }
 
 	public interface IHealth
@@ -249,6 +251,8 @@ namespace OpenRA.Traits
 	public interface ILoadsPlayerPalettes { void LoadPlayerPalettes(WorldRenderer wr, string playerName, HSLColor playerColor, bool replaceExisting); }
 	public interface IPaletteModifier { void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> b); }
 	public interface IPips { IEnumerable<PipType> GetPips(Actor self); }
+
+	[RequireExplicitImplementation]
 	public interface ISelectionBar { float GetValue(); Color GetColor(); }
 
 	public interface IPositionableInfo : ITraitInfoInterface { }

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -726,6 +726,7 @@
     <Compile Include="FileFormats\RLEZerosCompression.cs" />
     <Compile Include="FileFormats\IniFile.cs" />
     <Compile Include="Orders\GuardOrderGenerator.cs" />
+    <Compile Include="UtilityCommands\CheckExplicitInterfacesCommand.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -78,8 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 				Color.FromArgb(96, Color.Black));
 		}
 
-		// Selection bar
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			// Visible to player and allies
 			if (!ValidRenderPlayer())
@@ -92,6 +91,6 @@ namespace OpenRA.Mods.Common.Traits
 			return (float)progress / total;
 		}
 
-		public Color GetColor() { return Color.Purple; }
+		Color ISelectionBar.GetColor() { return Color.Purple; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 			capturable = self.Trait<ExternalCapturable>();
 		}
 
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			// only show when building is being captured
 			if (!capturable.CaptureInProgress)
@@ -37,6 +37,6 @@ namespace OpenRA.Mods.Common.Traits
 			return (float)capturable.CaptureProgressTime / (capturable.Info.CaptureCompleteTime * 25);
 		}
 
-		public Color GetColor() { return Color.Orange; }
+		Color ISelectionBar.GetColor() { return Color.Orange; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 			playerPower = self.Owner.PlayerActor.Trait<PowerManager>();
 		}
 
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			if (playerPower.PowerOutageRemainingTicks <= 0)
 				return 0;
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 			return (float)playerPower.PowerOutageRemainingTicks / playerPower.PowerOutageTotalTicks;
 		}
 
-		public Color GetColor()
+		Color ISelectionBar.GetColor()
 		{
 			return Color.Yellow;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			value = current != null ? 1 - (float)current.RemainingCost / current.TotalCost : 0;
 		}
 
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			// only people we like should see our production status.
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			return value;
 		}
 
-		public Color GetColor() { return info.Color; }
+		Color ISelectionBar.GetColor() { return info.Color; }
 
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				return 0;
@@ -46,6 +46,6 @@ namespace OpenRA.Mods.Common.Traits
 			return 1 - (float)power.RemainingTime / power.TotalTime;
 		}
 
-		public Color GetColor() { return info.Color; }
+		Color ISelectionBar.GetColor() { return info.Color; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			value = remaining * 1f / duration;
 		}
 
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				return 0;
@@ -57,6 +57,6 @@ namespace OpenRA.Mods.Common.Traits
 			return value;
 		}
 
-		public Color GetColor() { return info.Color; }
+		Color ISelectionBar.GetColor() { return info.Color; }
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
@@ -1,0 +1,122 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using System.Reflection;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.UtilityCommands
+{
+	public class CheckExplicitInterfacesCommand : IUtilityCommand
+	{
+		string IUtilityCommand.Name { get { return "--check-explicit-interfaces"; } }
+
+		bool IUtilityCommand.ValidateArguments(string[] args)
+		{
+			return args.Length == 1;
+		}
+
+		int violationCount;
+
+		[Desc("Check for explicit interface implementation violations in all assemblies referenced by the specified mod.")]
+		void IUtilityCommand.Run(ModData modData, string[] args)
+		{
+			var types = modData.ObjectCreator.GetTypes();
+
+			foreach (var implementingType in types.Where(t => !t.IsInterface))
+			{
+				if (implementingType.IsEnum)
+					continue;
+
+				var interfaces = implementingType.GetInterfaces();
+				foreach (var interfaceType in interfaces)
+				{
+					if (!interfaceType.HasAttribute<RequireExplicitImplementationAttribute>())
+						continue;
+
+					var interfaceMembers = interfaceType.GetMembers();
+					foreach (var interfaceMember in interfaceMembers)
+					{
+						if (interfaceMember.Name.StartsWith("get_") || interfaceMember.Name.StartsWith("set_"))
+							continue;
+
+						var interfaceMethod = interfaceMember as MethodInfo;
+						if (interfaceMethod != null)
+						{
+							var interfaceMethodParams = interfaceMethod.GetParameters();
+							foreach (var implementingMethod in implementingType.GetMethods())
+							{
+								if (implementingMethod.Name != interfaceMethod.Name
+									|| implementingMethod.ReturnType != interfaceMethod.ReturnType)
+									continue;
+
+								var implementingMethodParams = implementingMethod.GetParameters();
+								var lenImpl = implementingMethodParams.Length;
+								if (lenImpl != interfaceMethodParams.Length)
+									continue;
+
+								var allMatch = true;
+								for (var i = 0; i < lenImpl; i++)
+								{
+								    var implementingParam = implementingMethodParams[i];
+								    var interfaceParam = interfaceMethodParams[i];
+								    if (implementingParam.ParameterType != interfaceParam.ParameterType
+										|| implementingParam.Name != interfaceParam.Name
+										|| implementingParam.IsOut != interfaceParam.IsOut)
+								    {
+										allMatch = false;
+										break;
+								    }
+								}
+
+								// Explicitly implemented methods are never public in C#.
+								if (allMatch && implementingMethod.IsPublic)
+									OnViolation(implementingType, interfaceType, implementingMethod);
+							}
+						}
+
+						var interfaceProperty = interfaceMember as PropertyInfo;
+						if (interfaceProperty != null)
+						{
+							var implementingProperties = implementingType.GetProperties();
+							foreach (var implementingProperty in implementingProperties)
+							{
+								if (implementingProperty.PropertyType != interfaceProperty.PropertyType
+									|| implementingProperty.Name != interfaceProperty.Name)
+									continue;
+
+								if (!IsExplicitInterfaceProperty(implementingProperty))
+									OnViolation(implementingType, interfaceType, implementingProperty);
+							}
+						}
+					}
+				}
+			}
+
+			if (violationCount > 0)
+			{
+				Console.WriteLine("Explicit interface violations: {0}", violationCount);
+				Environment.Exit(1);
+			}
+		}
+
+		static bool IsExplicitInterfaceProperty(PropertyInfo pi)
+		{
+			return pi.Name.Contains(".");
+		}
+
+		void OnViolation(Type implementor, Type interfaceType, MemberInfo violator)
+		{
+			Console.WriteLine("{0} must explicitly implement the interface member {1}.{2}", implementor.Name, interfaceType.Name, violator.Name);
+			violationCount++;
+		}
+	}
+}

--- a/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
+++ b/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.D2k.Traits
 				changingOwner = null; // It was triggered by this trait: reset
 		}
 
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			if (remaining <= 0)
 				return 0;
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.D2k.Traits
 			return (float)remaining / duration;
 		}
 
-		public Color GetColor()
+		Color ISelectionBar.GetColor()
 		{
 			return info.BarColor;
 		}

--- a/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.RA.Traits
 		}
 
 		// Show the remaining time as a bar
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			if (!info.ReturnToOrigin)
 				return 0f;
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.RA.Traits
 			return (float)ReturnTicks / duration;
 		}
 
-		public Color GetColor() { return info.TimeBarColor; }
+		Color ISelectionBar.GetColor() { return info.TimeBarColor; }
 
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
 		{

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -105,12 +105,12 @@ namespace OpenRA.Mods.RA.Traits
 			get { return chargeTick <= 0; }
 		}
 
-		public float GetValue()
+		float ISelectionBar.GetValue()
 		{
 			return (float)(Info.ChargeDelay - chargeTick) / Info.ChargeDelay;
 		}
 
-		public Color GetColor() { return Color.Magenta; }
+		Color ISelectionBar.GetColor() { return Color.Magenta; }
 	}
 
 	class PortableChronoOrderTargeter : IOrderTargeter

--- a/make.ps1
+++ b/make.ps1
@@ -174,6 +174,8 @@ elseif ($command -eq "check")
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Utility
 		echo "Checking for code style violations in OpenRA.Test..."
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Test
+		echo "Checking for explicit interface violations..."
+		./OpenRA.Utility.exe all --check-explicit-interfaces
 	}
 	else
 	{


### PR DESCRIPTION
cc @OpenRA/engine-hackers

`[PR: Help wanted]` is because I don't know how to add this as a required-passing step to Travis.

It would be of great help if all PRs now and forthcoming implemented their interfaces explicitly, at least until the above-noted Travis step is completed and we can check for it in each PR.

I could add this to `make check` but that is already incredibly slow.
Would that be the proper place to run this?

Currently this produces:

``` bash
tmba:openra thill\ $ orautil all --check-explicit-interfaces

Actor.OnScriptBind (from IScriptNotifyBind) is not explicit!
AsyncAction.Tick (from IEffect) is not explicit!
AsyncAction.Render (from IEffect) is not explicit!
DelayedAction.Tick (from IEffect) is not explicit!
DelayedAction.Render (from IEffect) is not explicit!
FlashTarget.Tick (from IEffect) is not explicit!
FlashTarget.Render (from IEffect) is not explicit!
SpriteEffect.Tick (from IEffect) is not explicit!
SpriteEffect.Render (from IEffect) is not explicit!
BagFile.GetContent (from IFolder) is not explicit!
BagFile.Exists (from IFolder) is not explicit!
BagFile.Write (from IFolder) is not explicit!
BagFile.Priority (from IFolder) is not explicit!
BagFile.Name (from IFolder) is not explicit!
[...snip...]
WithPermanentInjury.SequencePrefix (from IRenderInfantrySequenceModifier) is not explicit!
WithPermanentInjury.Damaged (from INotifyDamage) is not explicit!
WithVoxelUnloadBody.SelectionSize (from IAutoSelectionSize) is not explicit!
WithVoxelWalkerBody.Tick (from ITick) is not explicit!
WithVoxelWalkerBody.SelectionSize (from IAutoSelectionSize) is not explicit!
WithVoxelWaterBody.SelectionSize (from IAutoSelectionSize) is not explicit!
TSShroudPalette.PaletteNames (from IProvidesAssetBrowserPalettes) is not explicit!
TSShroudPalette.LoadPalettes (from ILoadsPalettes) is not explicit!
ImportLegacyTilesetCommand.ValidateArguments (from IUtilityCommand) is not explicit!
ImportLegacyTilesetCommand.Run (from IUtilityCommand) is not explicit!
ImportLegacyTilesetCommand.Name (from IUtilityCommand) is not explicit!

Explicit interface violations: 1983
```

To be less ambiguous I could add method params to the output but this gets ugly when generic types/params are introduced.

**Edit**:
This _still_ doesn't actually work:

``` bash
tmba:openra thill\ $ orautil all --check-explicit-interfaces | head

BigFile.GetContent (from IFolder) is not explicit!
BigFile.Exists (from IFolder) is not explicit!
BigFile.Write (from IFolder) is not explicit!
BigFile.Priority (from IFolder) is not explicit!
BigFile.Name (from IFolder) is not explicit!
D2kSoundResources.GetContent (from IFolder) is not explicit!
D2kSoundResources.Exists (from IFolder) is not explicit!
D2kSoundResources.Write (from IFolder) is not explicit!
D2kSoundResources.Priority (from IFolder) is not explicit!
D2kSoundResources.Name (from IFolder) is not explicit!

tmba:openra thill\ $ make
make: Nothing to be done for 'default'.
```

``` diff
@@ -135,13 +135,13 @@ public Stream GetContent(uint hash)
                        return null;
                }

-               public Stream GetContent(string filename)
+               Stream IFolder.GetContent(string filename)
                {
                        var hash = FindMatchingHash(filename);
                        return hash.HasValue ? GetContent(hash.Value) : null;
                }

-               public bool Exists(string filename)
+               bool IFolder.Exists(string filename)
                {
                        return FindMatchingHash(filename).HasValue;
                }
```

``` csharp
    public interface IFolder : IDisposable
    {
        Stream GetContent(string filename);
        bool Exists(string filename);
        IEnumerable<uint> ClassicHashes();
        IEnumerable<uint> CrcHashes();
        IEnumerable<string> AllFileNames();
        void Write(Dictionary<string, byte[]> contents);
        int Priority { get; }
        string Name { get; }
    }
```

I don't know why the code still sees IFolder as implicit in the above example/diff.
