### PR TITLE
Set missile default acceleration to 0 (prep only)

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly WDist MaximumSpeed = new WDist(384);
 
 		[Desc("Projectile acceleration when propulsion activated.")]
-		public readonly WDist Acceleration = new WDist(5);
+		public readonly WDist Acceleration = WDist.Zero;
 
 		[Desc("How many ticks before this missile is armed and can explode.")]
 		public readonly int Arm = 0;


### PR DESCRIPTION
Needed to remake, this patch specifically targets the prep branch only. Previous discussion on #10142.

As discussed on IRC and proven out in #10129. We have to make another ticket regardless for `Next+1` to fix this properly in bleed. This is probably the least-invasive band-aid opposed to setting yaml values.
