### PR TITLE
Add a 'Voice' field to RepairableNearInfo

### DIFF
--- a/OpenRA.Game/VoiceExts.cs
+++ b/OpenRA.Game/VoiceExts.cs
@@ -63,12 +63,14 @@ namespace OpenRA
 					continue;
 
 				foreach (var voice in orderSubject.TraitsImplementing<IVoiced>())
+				{
 					foreach (var v in orderSubject.TraitsImplementing<IOrderVoice>())
 					{
 						if (voice.PlayVoice(orderSubject, v.VoicePhraseForOrder(orderSubject, o),
 							orderSubject.Owner.Faction.InternalName))
 							return;
 					}
+				}
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	class RepairableNearInfo : ITraitInfo, Requires<HealthInfo>, Requires<IMoveInfo>
 	{
 		[ActorReference] public readonly HashSet<string> Buildings = new HashSet<string> { "spen", "syrd" };
-		public readonly int CloseEnough = 4;
+		public readonly WDist CloseEnough = WDist.FromCells(4);
 		[VoiceReference] public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 				var target = Target.FromOrder(self.World, order);
 
 				self.CancelActivity();
-				self.QueueActivity(movement.MoveWithinRange(target, new WDist(1024 * info.CloseEnough)));
+				self.QueueActivity(movement.MoveWithinRange(target, info.CloseEnough));
 				self.QueueActivity(new Repair(order.TargetActor));
 
 				self.SetTargetLine(target, Color.Green, false);

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -20,12 +20,13 @@ namespace OpenRA.Mods.Common.Traits
 	class RepairableNearInfo : ITraitInfo, Requires<HealthInfo>, Requires<IMoveInfo>
 	{
 		[ActorReference] public readonly HashSet<string> Buildings = new HashSet<string> { "spen", "syrd" };
-		public readonly int CloseEnough = 4;	/* cells */
+		public readonly int CloseEnough = 4;
+		[VoiceReference] public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
 	}
 
-	class RepairableNear : IIssueOrder, IResolveOrder
+	class RepairableNear : IIssueOrder, IResolveOrder, IOrderVoice
 	{
 		readonly Actor self;
 		readonly RepairableNearInfo info;
@@ -63,6 +64,11 @@ namespace OpenRA.Mods.Common.Traits
 		bool ShouldRepair()
 		{
 			return self.GetDamageState() > DamageState.Undamaged;
+		}
+
+		public string VoicePhraseForOrder(Actor self, Order order)
+		{
+			return (order.OrderString == "RepairNear" && ShouldRepair()) ? info.Voice : null;
 		}
 
 		public void ResolveOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -2683,6 +2683,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// 'CloseEnough' on 'RepairableNear' uses WDist now
+				if (engineVersion < 20151214)
+				{
+					if (node.Key == "RepairableNear")
+					{
+						var ce = node.Value.Nodes.FirstOrDefault(n => n.Key == "CloseEnough");
+						if (ce != null && !ce.Value.Value.Contains("c"))
+							ce.Value.Value = ce.Value.Value + "c0";
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}


### PR DESCRIPTION
Before naval units in the RA mod didn't play voices when ordered to be repaired.
