### PR TITLE
Fix DeathSounds not working without DeathTypes defined

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -41,11 +41,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var warhead = e.Warhead as DamageWarhead;
 
-			// Killed by some non-standard means
-			if (warhead == null)
-				return;
-
-			if (warhead.DamageTypes.Overlaps(info.DeathTypes))
+			// If the warhead is null, the actor was killed by some non-standard means
+			if (info.DeathTypes.Count == 0 || (warhead != null && warhead.DamageTypes.Overlaps(info.DeathTypes)))
 				self.PlayVoiceLocal(info.Voice, info.VolumeMultiplier);
 		}
 	}


### PR DESCRIPTION
Needed for #10154.
