### PR TITLE
Updated music.yaml files (RA/TD/D2k)

### DIFF
--- a/mods/cnc/audio/music.yaml
+++ b/mods/cnc/audio/music.yaml
@@ -1,68 +1,72 @@
-aoi: Act on Instinct
-aoi2: Act on Instinct (Voiced)
-	Filename: aoi
-	Extension: var
+aoi: Act On Instinct
 airstrik: Air Strike
-befeared: To be Feared
-befeared2: To be Feared (Voiced)
-	Filename: befeared
-	Extension: var
-80mx226m: C&C 80's mix
 ccthang: C&C Thang
-ind2: Canyon Chase
-chrg226m: Depth Charge
-crep226m: Creeping Upon
-stopthem: Deception (Stop Them)
-deception: Deception (Stop Them) (Voiced)
-	Filename: stopthem
-	Extension: var
+ind2: Canyon Chase (Industrial 2)
 heavyg: Demolition (Heavy Gear)
-die: Die
-dril225m: Drill
-dron226m: Drone
 fwp: Fight Win Prevail
-fist226m: Iron Fist
-warfare: Warfare (Full Stop)
+warfare: Full Stop (Warfare)
 win1: Great Shot!
 	Hidden: true
-win2: Great Shot! (Voiced)
-	Filename: win2
+win2: Great Shot! (SFX)
+	Filename: win1
 	Extension: var
-heart: Heartbreak (Voiced)
-	Extension: var
-iam: I Am - Destructible Times (Voiced)
+	Hidden: true
+iam: I Am - Times (Credits)
 ind: Industrial
-linefire: In the Line of Fire
+linefire: In The Line Of Fire
 trouble: In Trouble
-trouble2: In Trouble (Voiced)
-	Filename: trouble
-	Extension: var
-justdoit: Just Do it Up
-justdoit2: Just Do it Up (Voiced)
+justdoit: Just Do It Up
+justdoit2: Just Do It Up (SFX)
 	Filename: justdoit
 	Extension: var
+jdi_v2: Just Do It Up 2 (Take 'Em out)
 map1: Map Theme
 	Hidden: true
-march: March to Doom
-nomercy: No Mercy
-nomercy2: No Mercy (Voiced)
-	Filename: nomercy
-	Extension: var
-otp: On the Prowl
-prp: Prepare for Battle
-radio: Radio
-rain: Rain in the Night
-rout: Reaching out (Voiced)
-	Extension: var
-recn226m: Recon
-jdi_v2: Just Do it Up 2 (Take em' out)
-target: Target (Mechanical Man)
-j1: Untamed Land
-valkyrie: Ride of the Valkyries
-voic226m: Voice Rhythm
-outtakes: Outtakes
-	Hidden: true
+march: March To Doom
 nod_map1: Nod Map Theme
 	Hidden: true
 nod_win1: Nod Win Theme
 	Hidden: true
+nomercy: No Mercy
+nomercy2: No Mercy (SFX)
+	Filename: nomercy
+	Extension: var
+otp: On The Prowl
+outtakes: Outtakes (Censored)
+	Hidden: true
+prp: Prepare For Battle
+radio: Radio
+rain: Rain In The Night
+target: Target (Mechanical Man)
+j1: Untamed Land (Jungle)
+valkyrie: Ride Of The Valkyries
+	Hidden: true
+stopthem: We Will Stop Them (Deception)
+deception: We Will Stop Them (SFX)
+	Filename: stopthem
+	Extension: var
+
+# Covert Operations tracks
+aoi2: Act On Instinct (SFX)
+	Filename: aoi
+	Extension: var
+befeared: To Be Feared
+befeared2: To Be Feared (SFX)
+	Filename: befeared
+	Extension: var
+80mx226m: C&C 80's Mix
+crep226m: Creeping Upon
+chrg226m: Depth Charge
+die: Die
+dril225m: Drill
+dron226m: Drone
+fist226m: Iron Fist
+heart: Heartbreak
+	Extension: var
+trouble2: In Trouble (SFX)
+	Filename: trouble
+	Extension: var
+rout: Reaching Out
+	Extension: var
+recn226m: Recon
+voic226m: Voice Rhythm

--- a/mods/d2k/audio/music.yaml
+++ b/mods/d2k/audio/music.yaml
@@ -1,15 +1,9 @@
-# requires Dune 2000/DATA/Music copied to OpenRA/Content/d2k
-AMBUSH: The Ambush
-	Extension: AUD
+# requires Dune 2000/DATA/Music copied to OpenRA/Content/d2k/Music
 ARAKATAK: Attack on Arrakis
-	Extension: AUD
-ATREGAIN: The Atreides Gain
 	Extension: AUD
 ENTORDOS: Enter the Ordos
 	Extension: AUD
 FIGHTPWR: Fight for Power
-	Extension: AUD
-FREMEN: The Fremen
 	Extension: AUD
 HARK_BAT: Harkonnen Battle
 	Extension: AUD
@@ -27,11 +21,17 @@ ROBOTIX: Robotix
 SCORE: Score
 	Extension: AUD
 	Hidden: true
-SOLDAPPR: The Soldiers Approach
-	Extension: AUD
 SPICESCT: Spice Scouting
 	Extension: AUD
-UNDERCON: Under Construction
+AMBUSH: The Ambush
+	Extension: AUD
+ATREGAIN: The Atreides Gain
+	Extension: AUD
+FREMEN: The Fremen
+	Extension: AUD
+SOLDAPPR: The Soldiers Approach
 	Extension: AUD
 WAITGAME: The Waiting Game
+	Extension: AUD
+UNDERCON: Under Construction
 	Extension: AUD

--- a/mods/ra/audio/music.yaml
+++ b/mods/ra/audio/music.yaml
@@ -1,22 +1,22 @@
-intro: Intro
-	Hidden: true
-map: Map
-	Hidden: true
-score: Militant Force
-	Hidden: true
-await_r: Await
+await_r: Afterlife (Await)
 bigf226m: Bigfoot
-credits: Reload Fire
 crus226m: Crush
 dense_r: Dense
 fac1226m: Face to the Enemy 1
 fac2226m: Face to the Enemy 2
 fogger1a: Fogger
 hell226m: Hell March
+intro: Intro
+	Hidden: true
+map: Map
+	Hidden: true
 mud1a: Mud
 radio2: Radio 2
+credits: Reload Fire (Credits)
 rollout: Roll Out
-run1226m: Run for your Life
+run1226m: Run (For Your Life)
+score: Militant Force (Scores)
+	Hidden: true
 smsh226m: Smash
 snake: Snake
 terminat: Terminate
@@ -26,21 +26,22 @@ vector1a: Vector
 work226m: Workmen
 
 # Counterstrike tracks
-2nd_hand: The Second Hand
-backstab: Backstab
-shut_it: Shut It
-under3: Underlying Thoughts
-chaos2: Chaos
-twinmix1: Twin Cannon Remix
-vr2: Voice Rhythm 2
 araziod: Arazoid
+backstab: Backstab
+chaos2: Chaos
+shut_it: Shut It
+2nd_hand: The Second Hand
+twinmix1: Twin Cannon (Remix)
+under3: Underlying Thoughts
+vr2: Voice Rhythm 2
 
 # Aftermath tracks
+await: Afterlife (Await)
 bog: Bog
-gloom: Gloom
-rpt: Running through Pipes (Mech Man 2)
-traction: Traction
 float_v2: Floating
-grndwire: Ground Wire
+gloom: Gloom
+grndwire: Groundwire
+rpt: Running Through Pipes
 search: The Search
+traction: Traction
 wastelnd: Wasteland


### PR DESCRIPTION
_Update: All three mod files have now been updated, made sure the correct names appear, made sure that regardless of what version you use (vanilla/expansion/content mirror) you have all files correctly listed, alphabetized and put into corresponding expansion section of the files, if applicable._

Added a one-liner to make sure the song "Afterlife" (await_r.aud) is loaded in both content data alternatives (Aftermath scores.mix from DL mirror / Base game scores.mix file from Game CD.)

Depending of which scores.mix file is used (the DL mirror one including the Aftermath expansion tracks or the vanilla one from "Install from CD"-option)
the naming of the file is slightly different. This results in missing out this song when using the bigger scores.mix file with the bonus tracks, since OpenRA can't find the file "await_r.aud", because in the expansion mix files, it is actually called "await.aud".

Closes #10160.
