### PR TITLE
Added cruising upgrade to aircraft

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -136,6 +136,7 @@
 		RepairBuildings: hpad
 		LandWhenIdle: false
 		AirborneUpgrades: airborne
+		CruisingUpgrades: cruising
 		CanHover: True
 	HiddenUnderFog:
 		Type: CenterPosition
@@ -151,7 +152,9 @@
 		GenericName: Helicopter
 	WithFacingSpriteBody:
 	WithShadow:
-	Hovers:
+	Hovers@CRUISING:
+		UpgradeTypes: cruising
+		UpgradeMinEnabledLevel: 1
 	MustBeDestroyed:
 	Voiced:
 		VoiceSet: VehicleVoice

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -354,6 +354,7 @@
 		RepairBuildings: fix
 		RearmBuildings: afld
 		AirborneUpgrades: airborne
+		CruisingUpgrades: cruising
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
 		UpgradeTypes: airborne
@@ -397,7 +398,9 @@
 		CanHover: True
 	GpsDot:
 		String: Helicopter
-	Hovers:
+	Hovers@CRUISING:
+		UpgradeTypes: cruising
+		UpgradeMinEnabledLevel: 1
 
 ^BasicBuilding:
 	Inherits@1: ^ExistsInWorld
@@ -621,6 +624,7 @@
 		GenericName: Destroyed Plane
 	Aircraft:
 		AirborneUpgrades: airborne
+		CruisingUpgrades: cruising
 	FallsToEarth:
 		Spins: False
 		Moves: True
@@ -633,6 +637,7 @@
 		GenericName: Destroyed Helicopter
 	Aircraft:
 		AirborneUpgrades: airborne
+		CruisingUpgrades: cruising
 		CanHover: True
 	FallsToEarth:
 

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -59,7 +59,6 @@ DSHP:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Move
-	Hovers:
 
 ORCA:
 	Inherits: ^Helicopter
@@ -98,9 +97,6 @@ ORCA:
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:
 	RenderSprites:
-	Hovers@AIRBORNE:
-		UpgradeTypes: airborne
-		UpgradeMinEnabledLevel: 1
 
 ORCAB:
 	Inherits: ^Plane
@@ -144,8 +140,8 @@ ORCAB:
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:
 	RenderSprites:
-	Hovers@AIRBORNE:
-		UpgradeTypes: airborne
+	Hovers@CRUISING:
+		UpgradeTypes: cruising
 		UpgradeMinEnabledLevel: 1
 
 ORCATRAN:
@@ -179,9 +175,6 @@ ORCATRAN:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Move
-	Hovers@AIRBORNE:
-		UpgradeTypes: airborne
-		UpgradeMinEnabledLevel: 1
 
 TRNSPORT:
 	Inherits: ^Helicopter
@@ -211,9 +204,6 @@ TRNSPORT:
 		Range: 2c0
 		Type: CenterPosition
 	RenderSprites:
-	Hovers@AIRBORNE:
-		UpgradeTypes: airborne
-		UpgradeMinEnabledLevel: 1
 	Selectable:
 		Bounds: 44,32,0,-8
 
@@ -297,9 +287,6 @@ APACHE:
 	WithSpriteRotorOverlay:
 		Offset: 85,0,384
 	RenderSprites:
-	Hovers@AIRBORNE:
-		UpgradeTypes: airborne
-		UpgradeMinEnabledLevel: 1
 
 HUNTER:
 	Inherits@1: ^GainsExperience
@@ -330,7 +317,9 @@ HUNTER:
 	RenderSprites:
 		Image: GGHUNT
 	WithFacingSpriteBody:
-	Hovers:
+	Hovers@CRUISING:
+		UpgradeTypes: cruising
+		UpgradeMinEnabledLevel: 1
 	QuantizeFacingsFromSequence:
 	AutoSelectionSize:
 	DrawLineToTarget:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -476,6 +476,13 @@
 	Selectable:
 	SelectionDecorations:
 		Palette: pips
+	Aircraft:
+		AirborneUpgrades: airborne
+		CruisingUpgrades: cruising
+		RepairBuildings: gadept
+		RearmBuildings: gahpad, nahpad
+		LandWhenIdle: no
+		Voice: Move
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:
@@ -496,23 +503,18 @@
 ^Helicopter:
 	Inherits: ^Aircraft
 	Aircraft:
-		RepairBuildings: gadept
-		RearmBuildings: gahpad, nahpad
 		LandWhenIdle: no
 		CruiseAltitude: 2048
-		Voice: Move
-		AirborneUpgrades: airborne
 		CanHover: True
+	Hovers@CRUISING:
+		UpgradeTypes: cruising
+		UpgradeMinEnabledLevel: 1
 
 ^Plane:
 	Inherits: ^Aircraft
 	Aircraft:
-		RepairBuildings: gadept
-		RearmBuildings: gahpad, nahpad
 		LandWhenIdle: no
 		CruiseAltitude: 2560
-		Voice: Move
-		AirborneUpgrades: airborne
 	ReturnOnIdle:
 
 ^Viceroid:


### PR DESCRIPTION
Allows mods to toggle traits when reaching / leaving cruise altitude (e.g. hovering)

http://gfycat.com/FaithfulUnimportantAssassinbug

Fixes #9721 for all mods, makes the aircraft check in `Hovers.cs` redundant (see #10162)
