### PR TITLE
Added autoqueue feature.

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -152,6 +152,11 @@ namespace OpenRA
 			return new Order("StartProduction", subject, false) { ExtraData = (uint)count, TargetString = item };
 		}
 
+		public static Order ToggleAutoQueue(Actor subject, string item, bool on)
+		{
+			return new Order("ToggleAutoQueue", subject, false) { ExtraData = on ? 1u : 0u, TargetString = item };
+		}
+
 		public static Order PauseProduction(Actor subject, string item, bool pause)
 		{
 			return new Order("PauseProduction", subject, false) { ExtraData = pause ? 1u : 0u, TargetString = item };

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -90,6 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync] public bool Enabled { get; private set; }
 
 		public string Faction { get; private set; }
+		public bool AutoQueue { get; private set; }
 
 		public ProductionQueue(ActorInitializer init, Actor playerActor, ProductionQueueInfo info)
 		{
@@ -98,6 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 			playerResources = playerActor.Trait<PlayerResources>();
 			playerPower = playerActor.Trait<PowerManager>();
 			developerMode = playerActor.Trait<DeveloperMode>();
+			AutoQueue = false;
 
 			Faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
 			Enabled = !info.Factions.Any() || info.Factions.Contains(Faction);
@@ -230,10 +232,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual void Tick(Actor self)
 		{
+			// Disable AutoQueue when nothing is building
+			if (queue.Count == 0)
+				AutoQueue = false;
+
 			while (queue.Count > 0 && BuildableItems().All(b => b.Name != queue[0].Item))
 			{
 				playerResources.GiveCash(queue[0].TotalCost - queue[0].RemainingCost); // refund what's been paid so far.
-				FinishProduction();
+				RemoveProduction();
 			}
 
 			if (queue.Count > 0)
@@ -245,54 +251,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Enabled)
 				return;
 
-			var rules = self.World.Map.Rules;
 			switch (order.OrderString)
 			{
 				case "StartProduction":
 					{
-						var unit = rules.Actors[order.TargetString];
-						var bi = unit.TraitInfo<BuildableInfo>();
-						if (!bi.Queue.Contains(Info.Type))
-							return; /* Not built by this queue */
-
-						var cost = unit.HasTraitInfo<ValuedInfo>() ? unit.TraitInfo<ValuedInfo>().Cost : 0;
-						var time = GetBuildTime(order.TargetString);
-
-						if (BuildableItems().All(b => b.Name != order.TargetString))
-							return;	/* you can't build that!! */
-
-						// Check if the player is trying to build more units that they are allowed
-						var fromLimit = int.MaxValue;
-						if (!developerMode.AllTech && bi.BuildLimit > 0)
-						{
-							var inQueue = queue.Count(pi => pi.Item == order.TargetString);
-							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner);
-							fromLimit = bi.BuildLimit - (inQueue + owned);
-
-							if (fromLimit <= 0)
-								return;
-						}
-
-						var amountToBuild = Math.Min(fromLimit, order.ExtraData);
-						for (var n = 0; n < amountToBuild; n++)
-						{
-							var hasPlayedSound = false;
-							BeginProduction(new ProductionItem(this, order.TargetString, cost, playerPower, () => self.World.AddFrameEndTask(_ =>
-							{
-								var isBuilding = unit.HasTraitInfo<BuildingInfo>();
-
-								if (isBuilding && !hasPlayedSound)
-									hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
-								else if (!isBuilding)
-								{
-									if (BuildUnit(order.TargetString))
-										Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
-									else if (!hasPlayedSound && time > 0)
-										hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
-								}
-							})));
-						}
-
+						StartProduction(order.TargetString, order.ExtraData);
 						break;
 					}
 
@@ -307,6 +270,16 @@ namespace OpenRA.Mods.Common.Traits
 				case "CancelProduction":
 					{
 						CancelProduction(order.TargetString, order.ExtraData);
+						break;
+					}
+
+				case "ToggleAutoQueue":
+					{
+						// Toggle it for right queue only
+						if (BuildableItems().All(b => b.Name != order.TargetString))
+							return;
+
+						AutoQueue = order.ExtraData == 1;
 						break;
 					}
 			}
@@ -326,6 +299,53 @@ namespace OpenRA.Mods.Common.Traits
 			return (int)time;
 		}
 
+		protected void StartProduction(string itemName, uint numberToBuild)
+		{
+			var rules = self.World.Map.Rules;
+			var unit = rules.Actors[itemName];
+			var bi = unit.TraitInfo<BuildableInfo>();
+			if (!bi.Queue.Contains(Info.Type))
+				return; /* Not built by this queue */
+
+			var cost = unit.HasTraitInfo<ValuedInfo>() ? unit.TraitInfo<ValuedInfo>().Cost : 0;
+			var time = GetBuildTime(itemName);
+
+			if (BuildableItems().All(b => b.Name != itemName))
+				return; /* you can't build that!! */
+
+			// Check if the player is trying to build more units that they are allowed
+			var fromLimit = int.MaxValue;
+			if (!developerMode.AllTech && bi.BuildLimit > 0)
+			{
+				var inQueue = queue.Count(pi => pi.Item == itemName);
+				var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == itemName && a.Owner == self.Owner);
+				fromLimit = bi.BuildLimit - (inQueue + owned);
+
+				if (fromLimit <= 0)
+					return;
+			}
+
+			var amountToBuild = Math.Min(fromLimit, numberToBuild);
+			for (var n = 0; n < amountToBuild; n++)
+			{
+				var hasPlayedSound = false;
+				BeginProduction(new ProductionItem(this, itemName, cost, playerPower, () => self.World.AddFrameEndTask(_ =>
+				{
+					var isBuilding = unit.HasTraitInfo<BuildingInfo>();
+
+					if (isBuilding && !hasPlayedSound)
+						hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+					else if (!isBuilding)
+					{
+						if (BuildUnit(itemName))
+							Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
+						else if (!hasPlayedSound && time > 0)
+							hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
+					}
+				})));
+			}
+		}
+
 		protected void CancelProduction(string itemName, uint numberToCancel)
 		{
 			for (var i = 0; i < numberToCancel; i++)
@@ -342,14 +362,23 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var item = queue[0];
 				playerResources.GiveCash(item.TotalCost - item.RemainingCost);	// refund what has been paid
-				FinishProduction();
+				RemoveProduction();
 			}
+		}
+
+		protected void RemoveProduction()
+		{
+			if (queue.Count != 0)
+				queue.RemoveAt(0);
 		}
 
 		public void FinishProduction()
 		{
-			if (queue.Count != 0)
-				queue.RemoveAt(0);
+			var item = queue[0].Item;
+			RemoveProduction();
+
+			if (AutoQueue)
+				StartProduction(item, 1);
 		}
 
 		protected void BeginProduction(ProductionItem item)

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -285,7 +285,7 @@ namespace OpenRA.Mods.Common.Traits
 				case "ToggleAutoQueue":
 					{
 						// Toggle it for right queue only
-						if (BuildableItems().All(b => b.Name != order.TargetString))
+						if (AllItems().All(b => b.Name != order.TargetString))
 							return;
 
 						if (AutoQueue == true && order.ExtraData == 0)
@@ -371,9 +371,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (lastIndex > 0)
 			{
 				queue.RemoveAt(lastIndex);
-
-				if (AutoQueue)
-				    autoQueueList.Remove(itemName);
+				AutoQueueRemove(itemName);
 			}
 			else if (lastIndex == 0)
 			{
@@ -385,11 +383,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected void RemoveProduction()
 		{
-			if (AutoQueue)
-			    autoQueueList.Remove(queue[0].Item);
-
+			var item = queue[0].Item;
 			if (queue.Count != 0)
 				queue.RemoveAt(0);
+
+			AutoQueueRemove(item);
 		}
 
 		public void FinishProduction()
@@ -411,6 +409,17 @@ namespace OpenRA.Mods.Common.Traits
 		protected void BeginProduction(ProductionItem item, int queuePos)
 		{
 			queue.Insert(queuePos, item);
+		}
+
+		protected void AutoQueueRemove(string itemName)
+		{
+			if (AutoQueue)
+			{
+				autoQueueList.Remove(itemName);
+
+				if (queue.Count <= autoQueueList.Count)
+					autoQueueList.Clear();
+			}
 		}
 
 		public long CountItemsAutoQueue(string itemName)

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public PaletteReference IconDarkenPalette;
 		public float2 Pos;
 		public List<ProductionItem> Queued;
+		public long AutoQueueCount;
 	}
 
 	public class ProductionPaletteWidget : Widget
@@ -341,7 +342,8 @@ namespace OpenRA.Mods.Common.Widgets
 					IconClockPalette = worldRenderer.Palette(ClockPalette),
 					IconDarkenPalette = worldRenderer.Palette(NotBuildablePalette),
 					Pos = new float2(rect.Location),
-					Queued = CurrentQueue.AllQueued().Where(a => a.Item == item.Name).ToList()
+					Queued = CurrentQueue.AllQueued().Where(a => a.Item == item.Name).ToList(),
+					AutoQueueCount = CurrentQueue.CountItemsAutoQueue(item.Name)
 				};
 
 				icons.Add(rect, pi);
@@ -410,7 +412,7 @@ namespace OpenRA.Mods.Common.Widgets
 					if (CurrentQueue.AutoQueue)
 					{
 						textColor = Color.Green;
-						totalString = "[" + totalString + "] " + (total - CurrentQueue.CountItemsAutoQueue(icon.Name)).ToString();
+						totalString = "[" + totalString + "] " + (total - icon.AutoQueueCount).ToString();
 					}
 
 					if (first.Done)

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -216,8 +216,14 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		bool HandleLeftClick(ProductionItem item, ProductionIcon icon, bool handleMultiple)
+		bool HandleLeftClick(ProductionItem item, ProductionIcon icon, bool handleMultiple, bool toggleAutoQueue)
 		{
+			if (toggleAutoQueue)
+			{
+				World.IssueOrder(Order.ToggleAutoQueue(CurrentQueue.Actor, icon.Name, !CurrentQueue.AutoQueue));
+				return true;
+			}
+
 			if (PickUpCompletedBuildingIcon(icon, item))
 			{
 				Game.Sound.Play(TabClick);
@@ -245,16 +251,10 @@ namespace OpenRA.Mods.Common.Widgets
 			return false;
 		}
 
-		bool HandleRightClick(ProductionItem item, ProductionIcon icon, bool handleMultiple, bool toggleAutoQueue)
+		bool HandleRightClick(ProductionItem item, ProductionIcon icon, bool handleMultiple)
 		{
 			if (item == null)
 				return false;
-
-			if (toggleAutoQueue)
-			{
-				World.IssueOrder(Order.ToggleAutoQueue(CurrentQueue.Actor, icon.Name, !CurrentQueue.AutoQueue));
-				return true;
-			}
 
 			Game.Sound.Play(TabClick);
 
@@ -278,8 +278,8 @@ namespace OpenRA.Mods.Common.Widgets
 		bool HandleEvent(ProductionIcon icon, bool isLeftClick, bool handleMultiple, bool toggleAutoQueue)
 		{
 			var item = icon.Queued.FirstOrDefault();
-			var handled = isLeftClick ? HandleLeftClick(item, icon, handleMultiple)
-				: HandleRightClick(item, icon, handleMultiple, toggleAutoQueue);
+			var handled = isLeftClick ? HandleLeftClick(item, icon, handleMultiple, toggleAutoQueue)
+				: HandleRightClick(item, icon, handleMultiple);
 
 			if (!handled)
 				Game.Sound.Play(DisabledTabClick);

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -405,9 +405,13 @@ namespace OpenRA.Mods.Common.Widgets
 					var first = icon.Queued[0];
 					var waiting = first != CurrentQueue.CurrentItem() && !first.Done;
 					var textColor = Color.White;
+					var totalString = total.ToString();
 
 					if (CurrentQueue.AutoQueue)
+					{
 						textColor = Color.Green;
+						totalString = "[" + totalString + "] " + (total - CurrentQueue.CountItemsAutoQueue(icon.Name)).ToString();
+					}
 
 					if (first.Done)
 					{
@@ -427,8 +431,8 @@ namespace OpenRA.Mods.Common.Widgets
 														 textColor, Color.Black, 1);
 					}
 
-					if (total > 1 || waiting)
-						overlayFont.DrawTextWithContrast(total.ToString(),
+					if (total > 1 || waiting || CurrentQueue.AutoQueue)
+						overlayFont.DrawTextWithContrast(totalString,
 														 icon.Pos + queuedOffset,
 														 textColor, Color.Black, 1);
 				}


### PR DESCRIPTION
CTRL-~~Right~~ Left click on the queue to enable/disable auto queue.

Autoqueue makes the queue repeat itself infinitely until it's disabled or the items are removed which is very useful as it means you don't need to requeue units manually. Age of mythology has it.

I made the text color change to green to indicate when it is enabled.
