### PR TITLE
Fix a crash when producing an actor without OccupiesSpace...

### DIFF
--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -106,6 +106,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)
 		{
+			// If the produced Actor doesn't occupy space, it can't be in range
+			if (produced.OccupiesSpace == null)
+				return;
+
 			// Work around for actors produced within the region not triggering until the second tick
 			if ((produced.CenterPosition - self.CenterPosition).HorizontalLengthSquared <= info.Range.LengthSquared)
 			{


### PR DESCRIPTION
...in combination with UpgradeActorsNear.

Fixes #10167.
