### PR TITLE
If PipCount < 0, then use max / -PipCount

### DIFF
--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			var pips = Info.PipCount >= 0 ? Info.PipCount : Info.Ammo;
+			var pips = Info.PipCount >= 0 ? Info.PipCount : Info.Ammo / -Info.PipCount;
 
 			return Enumerable.Range(0, pips).Select(i =>
 				(CurrentAmmo * pips) / Info.Ammo > i ?

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Initial ammo the actor is created with. Defaults to Ammo.")]
 		public readonly int InitialAmmo = -1;
 
-		[Desc("Defaults to value in Ammo. 0 means no visible pips.")]
+		[Desc("Defaults to value in Ammo.", "0 means no visible pips.", "-1 means same amount as Ammo.")]
 		public readonly int PipCount = -1;
 
 		[Desc("PipType to use for loaded ammo.")]

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -24,7 +24,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The maximum sum of Passenger.Weight that this actor can support.")]
 		public readonly int MaxWeight = 0;
 
-		[Desc("Number of pips to display when this actor is selected.", "0 means no visible pips.", "-1 means same amount as MaxWeight.")]
+		[Desc("Number of pips to display when this actor is selected.", "0 means no visible pips.", "-1 means same amount as MaxWeight.",
+			"< -1 means Capacity / -PipCount pips.")]
 		public readonly int PipCount = 0;
 
 		[Desc("`Passenger.CargoType`s that can be loaded into this actor.")]
@@ -256,7 +257,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			var numPips = Info.PipCount >= 0 ? Info.PipCount : Info.MaxWeight;
+			var numPips = Info.PipCount >= 0 ? Info.PipCount : Info.MaxWeight / -Info.PipCount;
 
 			for (var i = 0; i < numPips; i++)
 				yield return GetPipAt(i);
@@ -264,7 +265,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		PipType GetPipAt(int i)
 		{
-			var n = Info.PipCount >= 0 ? i * Info.MaxWeight / Info.PipCount : i;
+			var n = Info.PipCount >= 0 ? i * Info.MaxWeight / Info.PipCount : i / -Info.PipCount;
 
 			foreach (var c in cargo)
 			{

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The maximum sum of Passenger.Weight that this actor can support.")]
 		public readonly int MaxWeight = 0;
 
-		[Desc("Number of pips to display when this actor is selected.")]
+		[Desc("Number of pips to display when this actor is selected.", "0 means no visible pips.", "-1 means same amount as MaxWeight.")]
 		public readonly int PipCount = 0;
 
 		[Desc("`Passenger.CargoType`s that can be loaded into this actor.")]
@@ -256,7 +256,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			var numPips = Info.PipCount;
+			var numPips = Info.PipCount >= 0 ? Info.PipCount : Info.MaxWeight;
 
 			for (var i = 0; i < numPips; i++)
 				yield return GetPipAt(i);
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		PipType GetPipAt(int i)
 		{
-			var n = i * Info.MaxWeight / Info.PipCount;
+			var n = Info.PipCount >= 0 ? i * Info.MaxWeight / Info.PipCount : i;
 
 			foreach (var c in cargo)
 			{

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -37,7 +37,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("How fast it can dump it's carryage.")]
 		public readonly int UnloadTicksPerBale = 4;
 
-		[Desc("How many squares to show the fill level.", "0 means no visible pips.", "-1 means same amount as Capacity.")]
+		[Desc("How many squares to show the fill level.", "0 means no visible pips.", "-1 means same amount as Capacity.",
+			"< -1 means Capacity / -PipCount pips.")]
 		public readonly int PipCount = 7;
 
 		public readonly int HarvestFacings = 0;
@@ -420,7 +421,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		PipType GetPipAt(int i)
 		{
-			var n = Info.PipCount >= 0 ? i * Info.Capacity / Info.PipCount : i;
+			var n = Info.PipCount >= 0 ? i * Info.Capacity / Info.PipCount : i / -Info.PipCount;
 
 			foreach (var rt in contents)
 				if (n < rt.Value)
@@ -433,7 +434,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			var numPips = Info.PipCount >= 0 ? Info.PipCount : Info.Capacity;
+			var numPips = Info.PipCount >= 0 ? Info.PipCount : Info.Capacity / -Info.PipCount;
 
 			for (var i = 0; i < numPips; i++)
 				yield return GetPipAt(i);

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("How fast it can dump it's carryage.")]
 		public readonly int UnloadTicksPerBale = 4;
 
-		[Desc("How many squares to show the fill level.")]
+		[Desc("How many squares to show the fill level.", "0 means no visible pips.", "-1 means same amount as Capacity.")]
 		public readonly int PipCount = 7;
 
 		public readonly int HarvestFacings = 0;
@@ -420,7 +420,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		PipType GetPipAt(int i)
 		{
-			var n = i * Info.Capacity / Info.PipCount;
+			var n = Info.PipCount >= 0 ? i * Info.Capacity / Info.PipCount : i;
 
 			foreach (var rt in contents)
 				if (n < rt.Value)
@@ -433,7 +433,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			var numPips = Info.PipCount;
+			var numPips = Info.PipCount >= 0 ? Info.PipCount : Info.Capacity;
 
 			for (var i = 0; i < numPips; i++)
 				yield return GetPipAt(i);

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Traits
 	class StoresResourcesInfo : ITraitInfo
 	{
 		[FieldLoader.Require]
-		[Desc("Number of little squares used to display how filled unit is.", "0 means no visible pips.", "-1 means same amount as Capacity")]
+		[Desc("Number of little squares used to display how filled unit is.", "0 means no visible pips.", "-1 means same amount as Capacity",
+			"< -1 means Capacity / -PipCount pips.")]
 		public readonly int PipCount = 0;
 		public readonly PipType PipColor = PipType.Yellow;
 		[FieldLoader.Require]
@@ -66,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			var numPips = info.PipCount >= 0 ? info.PipCount : info.Capacity;
+			var numPips = info.PipCount >= 0 ? info.PipCount : info.Capacity / -info.PipCount;
 			return Enumerable.Range(0, numPips).Select(i =>
 				player.Resources * numPips > i * player.ResourceCapacity
 				? info.PipColor : PipType.Transparent);

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	class StoresResourcesInfo : ITraitInfo
 	{
 		[FieldLoader.Require]
-		[Desc("Number of little squares used to display how filled unit is.")]
+		[Desc("Number of little squares used to display how filled unit is.", "0 means no visible pips.", "-1 means same amount as Capacity")]
 		public readonly int PipCount = 0;
 		public readonly PipType PipColor = PipType.Yellow;
 		[FieldLoader.Require]
@@ -66,8 +66,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<PipType> GetPips(Actor self)
 		{
-			return Enumerable.Range(0, info.PipCount).Select(i =>
-				player.Resources * info.PipCount > i * player.ResourceCapacity
+			var numPips = info.PipCount >= 0 ? info.PipCount : info.Capacity;
+			return Enumerable.Range(0, numPips).Select(i =>
+				player.Resources * numPips > i * player.ResourceCapacity
 				? info.PipColor : PipType.Transparent);
 		}
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -76,7 +76,7 @@ HELI:
 		FacingTolerance: 20
 	AmmoPool:
 		Ammo: 10
-		PipCount: 5
+		PipCount: -2
 		SelfReloads: true
 		ReloadCount: 10
 		SelfReloadTicks: 200

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -32,7 +32,7 @@ TRAN:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 10
-		PipCount: 10
+		PipCount: -1
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	Explodes:
@@ -124,7 +124,7 @@ ORCA:
 		FacingTolerance: 20
 	AmmoPool:
 		Ammo: 6
-		PipCount: 6
+		PipCount: -1
 		SelfReloads: true
 		ReloadCount: 2
 		SelfReloadTicks: 100
@@ -163,7 +163,7 @@ C17:
 		Type: CenterPosition
 	Cargo:
 		MaxWeight: 10
-		PipCount: 10
+		PipCount: -1
 	DamageMultiplier@INVULNERABLE:
 		Modifier: 0
 	Contrail@1:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -74,6 +74,6 @@ LST:
 	Cargo:
 		Types: Infantry, Vehicle
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 		PassengerFacing: 0
 

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -119,7 +119,7 @@ APC:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 	SpawnActorOnDeath:
 		Actor: APC.Husk
 

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -177,7 +177,7 @@ YAK:
 		EnableStances: false
 	AmmoPool:
 		Ammo: 18
-		PipCount: 6
+		PipCount: -3
 		ReloadTicks: 11
 	ReturnOnIdle:
 	SelectionDecorations:
@@ -331,7 +331,7 @@ HIND:
 	WithSpriteRotorOverlay:
 	AmmoPool:
 		Ammo: 24
-		PipCount: 6
+		PipCount: -4
 		ReloadTicks: 8
 	SelectionDecorations:
 		VisualBounds: 38,32

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -230,7 +230,7 @@ TRAN:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 8
-		PipCount: 8
+		PipCount: -1
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	SelectionDecorations:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -237,7 +237,7 @@ LST:
 	Cargo:
 		Types: Infantry, Vehicle
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 		PassengerFacing: 0
 	-Chronoshiftable:
 

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -531,7 +531,7 @@ PBOX:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
-		PipCount: 1
+		PipCount: -1
 		InitialUnits: e1
 	-EmitInfantryOnSell:
 	AttackGarrisoned:
@@ -578,7 +578,7 @@ HBOX:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
-		PipCount: 1
+		PipCount: -1
 		InitialUnits: e1
 	-EmitInfantryOnSell:
 	DetectCloaked:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -349,7 +349,7 @@ JEEP:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
-		PipCount: 1
+		PipCount: -1
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -383,7 +383,7 @@ APC:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -742,7 +742,7 @@ STNK:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 4
-		PipCount: 4
+		PipCount: -1
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 250

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -138,7 +138,7 @@ ORCAB:
 		FacingTolerance: 20
 	AmmoPool:
 		Ammo: 10
-		PipCount: 2
+		PipCount: -5
 		ReloadCount: 5
 		ReloadTicks: 200
 		PipType: Ammo
@@ -254,7 +254,7 @@ SCRIN:
 		FacingTolerance: 20
 	AmmoPool:
 		Ammo: 15
-		PipCount: 3
+		PipCount: -5
 		ReloadCount: 5
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
@@ -292,7 +292,7 @@ APACHE:
 		Voice: Attack
 	AmmoPool:
 		Ammo: 12
-		PipCount: 4
+		PipCount: -3
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -20,7 +20,7 @@ DPOD:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
-		PipCount: 1
+		PipCount: -1
 		UnloadVoice: Move
 	Armament:
 		Weapon: Vulcan2
@@ -28,7 +28,7 @@ DPOD:
 		Voice: Attack
 	AmmoPool:
 		Ammo: 5
-		PipCount: 5
+		PipCount: -1
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:
@@ -57,7 +57,7 @@ DSHP:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 		UnloadVoice: Move
 	Hovers:
 
@@ -94,7 +94,7 @@ ORCA:
 		Voice: Attack
 	AmmoPool:
 		Ammo: 5
-		PipCount: 5
+		PipCount: -1
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
 	AutoTarget:
@@ -178,7 +178,7 @@ ORCATRAN:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 		UnloadVoice: Move
 	Hovers@AIRBORNE:
 		UpgradeTypes: airborne

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -138,7 +138,7 @@ CAR:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 4
-		PipCount: 5
+		PipCount: -1
 		UnloadVoice: Unload
 
 WINI:
@@ -159,7 +159,7 @@ WINI:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 		UnloadVoice: Unload
 
 LOCOMOTIVE:
@@ -171,7 +171,7 @@ LOCOMOTIVE:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 2
-		PipCount: 2
+		PipCount: -1
 		UnloadVoice: Unload
 
 TRAINCAR:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -96,7 +96,7 @@ BUS:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 20
-		PipCount: 5
+		PipCount: -4
 		UnloadVoice: Unload
 
 PICK:
@@ -117,7 +117,7 @@ PICK:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 2
-		PipCount: 5
+		PipCount: -1
 		UnloadVoice: Unload
 
 CAR:
@@ -183,7 +183,7 @@ TRAINCAR:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 10
-		PipCount: 5
+		PipCount: -2
 		UnloadVoice: Unload
 
 CARGOCAR:
@@ -195,6 +195,6 @@ CARGOCAR:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 10
-		PipCount: 5
+		PipCount: -2
 		UnloadVoice: Unload
 

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -25,7 +25,7 @@ APC:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 		UnloadVoice: Unload
 	-WithVoxelBody:
 	WithVoxelWaterBody:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -224,7 +224,7 @@ SAPC:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
-		PipCount: 5
+		PipCount: -1
 		UnloadVoice: Unload
 
 SUBTANK:


### PR DESCRIPTION
Applies to:
- `AmmoPool` : `Ammo / -PipCount`
- `Cargo` : `MaxWeight / -PipCount`
- `Harvester` : `Capacity / -PipCount`
- `StoresResources` : `Capacity / -PipCount`
