### PR TITLE
Fix TS Obelisk charge overlay Z offset

### DIFF
--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -606,6 +606,7 @@ naobel:
 	active: ntobel_b
 		Length: 12
 		Tick: 200
+		ZOffset: 2
 	idle-lights: ntobel_a
 		Length: 12
 		Tick: 80


### PR DESCRIPTION
To make sure it is played on top of the 'body'.

Closes #10108.
