### PR TITLE
Fix showing unread messages count on active lobby chat button

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -590,7 +590,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var globalChatLabel = globalChatTab.Text;
 			globalChatTab.GetText = () =>
 			{
-				if (globalChatUnreadMessages == 0)
+				if (globalChatUnreadMessages == 0 || chatPanel == ChatPanelType.Global)
 					return globalChatLabel;
 
 				return globalChatLabel + " ({0})".F(globalChatUnreadMessages);
@@ -642,7 +642,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var lobbyChatLabel = lobbyChatTab.Text;
 			lobbyChatTab.GetText = () =>
 			{
-				if (lobbyChatUnreadMessages == 0)
+				if (lobbyChatUnreadMessages == 0 || chatPanel == ChatPanelType.Lobby)
 					return lobbyChatLabel;
 
 				return lobbyChatLabel + " ({0})".F(lobbyChatUnreadMessages);


### PR DESCRIPTION
The lobby chat button text would change to include the unread messages count for a split second, even when the lobby chat was the current panel, leading to the button text sort of 'blinking' in an ugly way.

This is simple enough and provides better polish for a new feature that I think it's warranted to be added to the milestone.
