### PR TITLE
AttackBase and Armament optimizations

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public abstract class AttackBaseInfo : UpgradableTraitInfo, ITraitInfo
+	public abstract class AttackBaseInfo : UpgradableTraitInfo
 	{
 		[Desc("Armament names")]
 		public readonly string[] Armaments = { "primary", "secondary" };

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -70,7 +70,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual bool CanAttack(Actor self, Target target)
 		{
-			if (!self.IsInWorld || IsTraitDisabled)
+			if (!self.IsInWorld || IsTraitDisabled || self.IsDisabled())
+				return false;
+
+			if (!target.IsValidFor(self))
 				return false;
 
 			if (!HasAnyValidWeapons(target))
@@ -80,13 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (building.Value != null && !building.Value.BuildComplete)
 				return false;
 
-			if (!target.IsValidFor(self))
-				return false;
-
 			if (Armaments.All(a => a.IsReloading))
-				return false;
-
-			if (self.IsDisabled())
 				return false;
 
 			if (target.Type == TargetType.Actor && !self.Owner.CanTargetActor(target.Actor))


### PR DESCRIPTION
- Removes redundant ITraitInfo from `AttackBase`.
- Moves `self.IsDisabled()` check in `AttackBase.CanAttack` up to first check, so later checks are skipped for disabled actors.
- Caches the assigned turret and `AmmoPool` as well als `BodyOrientation` and `rangeModifier` directly in `Armament` via `INotifyCreated` instead of using Lazy.

Note: Please review at least the 3rd commit very carefully, I'm not sure the performance impact is worth it and I'm not sure whether this might cause any regressions.
The approach of the last commit was simply copied from one of @RoosterDragon's PRs.
