### PR TITLE
Add support for a FallbackSequence in WithDeathAnimation

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -301,6 +301,7 @@ namespace OpenRA.Traits
 
 	public interface IFacingInfo : ITraitInfoInterface { int GetInitialFacing(); }
 
+	[RequireExplicitImplementation]
 	public interface ICrushable
 	{
 		bool CrushableBy(HashSet<string> crushClasses, Player owner);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -303,9 +303,14 @@ namespace OpenRA.Traits
 
 	public interface ICrushable
 	{
-		void OnCrush(Actor crusher);
-		void WarnCrush(Actor crusher);
 		bool CrushableBy(HashSet<string> crushClasses, Player owner);
+	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyCrushed
+	{
+		void OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses);
+		void WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses);
 	}
 
 	public interface ITraitInfoInterface { }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -304,7 +304,7 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface ICrushable
 	{
-		bool CrushableBy(HashSet<string> crushClasses, Player owner);
+		bool CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses);
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -178,8 +178,8 @@ namespace OpenRA.Mods.Common.Traits
 				return SubCell.FullCell;
 
 			return !self.World.ActorMap.GetActorsAt(cell)
-				.Where(x => x != ignoreActor)
-				.Any() ? SubCell.FullCell : SubCell.Invalid;
+				.Any(x => x != ignoreActor)
+				? SubCell.FullCell : SubCell.Invalid;
 		}
 
 		public bool CanEnterCell(CPos a, Actor ignoreActor = null, bool checkTransientActors = true)

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.Common.Traits
 			return GetAvailableSubCell(a, SubCell.Any, ignoreActor, checkTransientActors) != SubCell.Invalid;
 		}
 
-		bool ICrushable.CrushableBy(HashSet<string> crushClasses, Player owner)
+		bool ICrushable.CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
 			// Crate can only be crushed if it is not in the air.
 			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass);

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -61,7 +61,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
-			if (!CrushableBy(crushClasses, crusher.Owner))
+			// Crate can only be crushed if it is not in the air.
+			if (!self.IsAtGroundLevel() || !crushClasses.Contains(info.CrushClass))
 				return;
 
 			OnCrushInner(crusher);
@@ -84,7 +85,8 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				// Make sure that the actor can collect this crate type
-				return CrushableBy(mi.Crushes, a.Owner);
+				// Crate can only be crushed if it is not in the air.
+				return self.IsAtGroundLevel() && mi.Crushes.Contains(info.CrushClass);
 			});
 
 			// Destroy the crate if none of the units in the cell are valid collectors
@@ -196,7 +198,7 @@ namespace OpenRA.Mods.Common.Traits
 			return GetAvailableSubCell(a, SubCell.Any, ignoreActor, checkTransientActors) != SubCell.Invalid;
 		}
 
-		public bool CrushableBy(HashSet<string> crushClasses, Player owner)
+		bool ICrushable.CrushableBy(HashSet<string> crushClasses, Player owner)
 		{
 			// Crate can only be crushed if it is not in the air.
 			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass);

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -71,9 +71,9 @@ namespace OpenRA.Mods.Common.Traits
 			self.Kill(crusher);
 		}
 
-		bool ICrushable.CrushableBy(HashSet<string> crushClasses, Player crushOwner)
+		bool ICrushable.CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
-			return CrushableInner(crushClasses, crushOwner);
+			return CrushableInner(crushClasses, crusher.Owner);
 		}
 
 		bool CrushableInner(HashSet<string> crushClasses, Player crushOwner)

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
-			if (!CrushableBy(crushClasses, crusher.Owner))
+			if (!CrushableInner(crushClasses, crusher.Owner))
 				return;
 
 			var mobile = self.TraitOrDefault<Mobile>();
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
-			if (!CrushableBy(crushClasses, crusher.Owner))
+			if (!CrushableInner(crushClasses, crusher.Owner))
 				return;
 
 			Game.Sound.Play(info.CrushSound, crusher.CenterPosition);
@@ -71,7 +71,12 @@ namespace OpenRA.Mods.Common.Traits
 			self.Kill(crusher);
 		}
 
-		public bool CrushableBy(HashSet<string> crushClasses, Player crushOwner)
+		bool ICrushable.CrushableBy(HashSet<string> crushClasses, Player crushOwner)
+		{
+			return CrushableInner(crushClasses, crushOwner);
+		}
+
+		bool CrushableInner(HashSet<string> crushClasses, Player crushOwner)
 		{
 			// Only make actor crushable if it is on the ground.
 			if (!self.IsAtGroundLevel())

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -57,17 +57,6 @@ namespace OpenRA.Mods.Common.Traits
 
 			Game.Sound.Play(info.CrushSound, crusher.CenterPosition);
 
-			var wda = self.TraitsImplementing<WithDeathAnimation>()
-				.FirstOrDefault(s => s.Info.CrushedSequence != null);
-			if (wda != null)
-			{
-				var palette = wda.Info.CrushedSequencePalette;
-				if (wda.Info.CrushedPaletteIsPlayerPalette)
-					palette += self.Owner.InternalName;
-
-				wda.SpawnDeathAnimation(self, wda.Info.CrushedSequence, palette);
-			}
-
 			self.Kill(crusher);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -594,10 +594,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsAtGroundLevel())
 				return;
 
-			var crushables = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self)
-				.SelectMany(a => a.TraitsImplementing<ICrushable>().Where(b => b.CrushableBy(Info.Crushes, self.Owner)));
-			foreach (var crushable in crushables)
-				crushable.WarnCrush(self);
+			var notifiers = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self)
+				.SelectMany(a => a.TraitsImplementing<INotifyCrushed>().Select(t => new TraitPair<INotifyCrushed>(a, t)));
+			foreach (var notifyCrushed in notifiers)
+				notifyCrushed.Trait.WarnCrush(notifyCrushed.Actor, self, Info.Crushes);
 		}
 
 		public void FinishedMoving(Actor self)
@@ -606,10 +606,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsAtGroundLevel())
 				return;
 
-			var crushables = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self)
-				.SelectMany(a => a.TraitsImplementing<ICrushable>().Where(c => c.CrushableBy(Info.Crushes, self.Owner)));
-			foreach (var crushable in crushables)
-				crushable.OnCrush(self);
+			var notifiers = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self)
+				.SelectMany(a => a.TraitsImplementing<INotifyCrushed>().Select(t => new TraitPair<INotifyCrushed>(a, t)));
+			foreach (var notifyCrushed in notifiers)
+				notifyCrushed.Trait.OnCrush(notifyCrushed.Actor, self, Info.Crushes);
 		}
 
 		public int MovementSpeedForCell(Actor self, CPos cell)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -260,7 +260,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var crushable in crushables)
 			{
 				lacksCrushability = false;
-				if (!crushable.CrushableBy(Crushes, self.Owner))
+				if (!crushable.CrushableBy(otherActor, self, Crushes))
 					return true;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (e.Warhead == null || !(e.Warhead is DamageWarhead))
 			{
 				if (Info.FallbackSequence != null)
-					SpawnDeathAnimation(self, Info.FallbackSequence, palette);
+					SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.FallbackSequence, palette);
 
 				return;
 			}
@@ -102,16 +102,12 @@ namespace OpenRA.Mods.Common.Traits
 				sequence += Info.DeathTypes[damageType];
 			}
 
-			SpawnDeathAnimation(self, sequence, palette);
+			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), sequence, palette);
 		}
 
-		public void SpawnDeathAnimation(Actor self, string sequence, string palette)
+		public void SpawnDeathAnimation(Actor self, WPos pos, string image, string sequence, string palette)
 		{
-			self.World.AddFrameEndTask(w =>
-			{
-				if (!self.Disposed)
-					w.Add(new Corpse(w, self.CenterPosition, rs.GetImage(self), sequence, palette));
-			});
+			self.World.AddFrameEndTask(w => w.Add(new Corpse(w, pos, image, sequence, palette)));
 		}
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
@@ -125,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.CrushedPaletteIsPlayerPalette)
 				crushPalette += self.Owner.InternalName;
 
-			SpawnDeathAnimation(self, Info.CrushedSequence, crushPalette);
+			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.CrushedSequence, crushPalette);
 		}
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -45,6 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 			"Is only used if UseDeathTypeSuffix is `True`.")]
 		public readonly Dictionary<string, int> DeathTypes = new Dictionary<string, int>();
 
+		[Desc("Sequence to use when the actor is killed by some non-standard means (e.g. suicide).")]
+		[SequenceReference] public readonly string FallbackSequence = null;
+
 		public static object LoadDeathTypes(MiniYaml yaml)
 		{
 			var md = yaml.ToDictionary();
@@ -57,10 +60,11 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new WithDeathAnimation(init.Self, this); }
 	}
 
-	public class WithDeathAnimation : INotifyKilled
+	public class WithDeathAnimation : INotifyKilled, INotifyCrushed
 	{
 		public readonly WithDeathAnimationInfo Info;
 		readonly RenderSprites rs;
+		bool crushed;
 
 		public WithDeathAnimation(Actor self, WithDeathAnimationInfo info)
 		{
@@ -70,10 +74,22 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			// Killed by some non-standard means. This includes being crushed
-			// by a vehicle (Actors with Crushable trait will spawn CrushedSequence instead).
-			if (e.Warhead == null || !(e.Warhead is DamageWarhead))
+			// Actors with Crushable trait will spawn CrushedSequence.
+			if (crushed)
 				return;
+
+			var palette = Info.DeathSequencePalette;
+			if (Info.DeathPaletteIsPlayerPalette)
+				palette += self.Owner.InternalName;
+
+			// Killed by some non-standard means
+			if (e.Warhead == null || !(e.Warhead is DamageWarhead))
+			{
+				if (Info.FallbackSequence != null)
+					SpawnDeathAnimation(self, Info.FallbackSequence, palette);
+
+				return;
+			}
 
 			var sequence = Info.DeathSequence;
 			if (Info.UseDeathTypeSuffix)
@@ -86,10 +102,6 @@ namespace OpenRA.Mods.Common.Traits
 				sequence += Info.DeathTypes[damageType];
 			}
 
-			var palette = Info.DeathSequencePalette;
-			if (Info.DeathPaletteIsPlayerPalette)
-				palette += self.Owner.InternalName;
-
 			SpawnDeathAnimation(self, sequence, palette);
 		}
 
@@ -101,5 +113,12 @@ namespace OpenRA.Mods.Common.Traits
 					w.Add(new Corpse(w, self.CenterPosition, rs.GetImage(self), sequence, palette));
 			});
 		}
+
+		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
+		{
+			crushed = true;
+		}
+
+		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -117,6 +117,15 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
 			crushed = true;
+
+			if (Info.CrushedSequence == null)
+				return;
+
+			var crushPalette = Info.CrushedSequencePalette;
+			if (Info.CrushedPaletteIsPlayerPalette)
+				crushPalette += self.Owner.InternalName;
+
+			SpawnDeathAnimation(self, Info.CrushedSequence, crushPalette);
 		}
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses) { }

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -20,24 +20,25 @@ namespace OpenRA.Mods.RA.Traits
 		public readonly bool AvoidFriendly = true;
 		public readonly HashSet<string> DetonateClasses = new HashSet<string>();
 
-		public object Create(ActorInitializer init) { return new Mine(init, this); }
+		public object Create(ActorInitializer init) { return new Mine(this); }
 	}
 
-	class Mine : ICrushable
+	class Mine : ICrushable, INotifyCrushed
 	{
-		readonly Actor self;
 		readonly MineInfo info;
 
-		public Mine(ActorInitializer init, MineInfo info)
+		public Mine(MineInfo info)
 		{
-			self = init.Self;
 			this.info = info;
 		}
 
-		public void WarnCrush(Actor crusher) { }
+		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses) { }
 
-		public void OnCrush(Actor crusher)
+		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
+			if (!CrushableBy(crushClasses, crusher.Owner))
+				return;
+
 			if (crusher.Info.HasTraitInfo<MineImmuneInfo>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly))
 				return;
 

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA.Traits
 			self.Kill(crusher);
 		}
 
-		bool ICrushable.CrushableBy(HashSet<string> crushClasses, Player owner)
+		bool ICrushable.CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
 			return info.CrushClasses.Overlaps(crushClasses);
 		}

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
 		{
-			if (!CrushableBy(crushClasses, crusher.Owner))
+			if (!info.CrushClasses.Overlaps(crushClasses))
 				return;
 
 			if (crusher.Info.HasTraitInfo<MineImmuneInfo>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly))
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.RA.Traits
 			self.Kill(crusher);
 		}
 
-		public bool CrushableBy(HashSet<string> crushClasses, Player owner)
+		bool ICrushable.CrushableBy(HashSet<string> crushClasses, Player owner)
 		{
 			return info.CrushClasses.Overlaps(crushClasses);
 		}


### PR DESCRIPTION
Used when the actor is killed by non-standard means, like suicide.
Split from #9350.
