### PR TITLE
More graceful hardware cursor failing

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -336,7 +336,6 @@ namespace OpenRA
 					Console.WriteLine("Error was: " + e.Message);
 
 					Cursor = new SoftwareCursor(ModData.CursorProvider);
-					Settings.Graphics.HardwareCursors = false;
 				}
 			}
 			else

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Platforms.Default
 			}
 			catch (Exception ex)
 			{
-				throw new InvalidDataException("Failed to create hardware cursor `{0}`".F(name), ex);
+				throw new InvalidDataException("Failed to create hardware cursor `{0}` - {1}".F(name, ex.Message), ex);
 			}
 		}
 


### PR DESCRIPTION
- Ensure we grab enough of the error message so it shows up in the debug log (https://github.com/OpenRA/OpenRA/issues/10172#issuecomment-162100039)
- If hardware cursors fail, don't change the settings. This disables them for the session rather than forever. (https://github.com/OpenRA/OpenRA/issues/10172#issuecomment-162560939)
