### PR TITLE
Fix the idle animation of the hostBuilding in Rearm.cs

### DIFF
--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				var wsb = hostBuilding.Trait<WithSpriteBody>();
 				if (wsb.DefaultAnimation.HasSequence("active"))
-					wsb.PlayCustomAnimation(hostBuilding, "active", () => wsb.CancelCustomAnimation(self));
+					wsb.PlayCustomAnimation(hostBuilding, "active", () => wsb.CancelCustomAnimation(hostBuilding));
 
 				var sound = pool.Info.RearmSound;
 				if (sound != null)


### PR DESCRIPTION
using the damage state of the reloaded actor.

Fixes #10209.
See https://github.com/OpenRA/OpenRA/pull/10141#issuecomment-164237863.
