### PR TITLE
Change AllowInvalidPlacement rules

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -39,13 +39,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public static bool CanPlaceBuilding(this World world, string name, BuildingInfo building, CPos topLeft, Actor toIgnore)
 		{
+			var footprint = FootprintUtils.Tiles(world.Map.Rules, name, building, topLeft);
 			if (building.AllowInvalidPlacement)
-				return true;
+				return footprint.Any(world.Map.AllCells.Contains);
 
 			var res = world.WorldActor.Trait<ResourceLayer>();
-			return FootprintUtils.Tiles(world.Map.Rules, name, building, topLeft).All(
-				t => world.Map.Contains(t) && res.GetResource(t) == null &&
-					world.IsCellBuildable(t, building, toIgnore));
+			return footprint.All(t => world.Map.Contains(t)
+				&& res.GetResource(t) == null
+				&& world.IsCellBuildable(t, building, toIgnore));
 		}
 
 		public static IEnumerable<CPos> GetLineBuildCells(World world, CPos location, string name, BuildingInfo bi)


### PR DESCRIPTION
Instead of allowing placement of a building literally anywhere (including miles off the map area), we now ensure at least one cell of the footprint is on the map.

Currently, only concrete in Dune makes use of `AllowInvalidPlacement` and is the only thing that will be affected in the default mods. This change means you can no longer accidentally place concrete off the map where it has no use.
