### PR TITLE
Remove aircraft defaults

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -31,9 +31,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RepulsionSpeed = -1;
 
 		[ActorReference]
-		public readonly HashSet<string> RepairBuildings = new HashSet<string> { "fix" };
+		public readonly HashSet<string> RepairBuildings = new HashSet<string> { };
 		[ActorReference]
-		public readonly HashSet<string> RearmBuildings = new HashSet<string> { "hpad", "afld" };
+		public readonly HashSet<string> RearmBuildings = new HashSet<string> { };
 		public readonly int InitialFacing = 0;
 		public readonly int ROT = 255;
 		public readonly int Speed = 1;

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -134,7 +134,6 @@
 		Bounds: 24,24
 	Aircraft:
 		RepairBuildings: hpad
-		RearmBuildings:
 		LandWhenIdle: false
 		AirborneUpgrades: airborne
 		CanHover: True

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -18,7 +18,6 @@ carryall.reinforce:
 		Speed: 144 # 112 * ~1.3 for balance reasons
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune
 		RepairBuildings: repair_pad
-		RearmBuildings:
 		Repulsable: False
 		LandAltitude: 100
 		LandWhenIdle: False
@@ -61,8 +60,6 @@ frigate:
 	Aircraft:
 		ROT: 1
 		Speed: 189 # 126 * ~1.5 for balance reasons
-		RepairBuildings:
-		RearmBuildings:
 		Repulsable: False
 		MaximumPitch: 20
 	-AppearsOnRadar:
@@ -85,8 +82,6 @@ ornithopter:
 	Aircraft:
 		ROT: 2
 		Speed: 224 # 189 * ~1.2 for balance reasons
-		RepairBuildings:
-		RearmBuildings:
 		Repulsable: False
 		CanHover: True
 	AmmoPool:
@@ -104,8 +99,6 @@ ornithopter.husk:
 	Aircraft:
 		ROT: 5
 		Speed: 224
-		RepairBuildings:
-		RearmBuildings:
 	RenderSprites:
 		Image: ornithopter
 
@@ -116,8 +109,6 @@ carryall.husk:
 	Aircraft:
 		ROT: 4
 		Speed: 144
-		RepairBuildings:
-		RearmBuildings:
 		CanHover: True
 	RenderSprites:
 		Image: carryall

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -105,7 +105,6 @@ MIG:
 		InitialFacing: 192
 		ROT: 4
 		Speed: 223
-		RearmBuildings: afld
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 		AirborneUpgrades: airborne
@@ -164,7 +163,6 @@ YAK:
 		FacingTolerance: 20
 	Aircraft:
 		CruiseAltitude: 2560
-		RearmBuildings: afld
 		InitialFacing: 192
 		ROT: 4
 		Speed: 178
@@ -213,7 +211,6 @@ TRAN:
 		Range: 10c0
 		Type: CenterPosition
 	Aircraft:
-		RearmBuildings: hpad
 		InitialFacing: 0
 		ROT: 5
 		Speed: 112
@@ -264,7 +261,6 @@ HELI:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
-		RearmBuildings: hpad
 		LandWhenIdle: false
 		InitialFacing: 20
 		ROT: 4
@@ -318,7 +314,6 @@ HIND:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
-		RearmBuildings: hpad
 		LandWhenIdle: false
 		InitialFacing: 20
 		ROT: 4

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -12,7 +12,6 @@ BADR:
 		Speed: 149
 		Repulsable: False
 		MaximumPitch: 56
-		AirborneUpgrades: airborne
 	Cargo:
 		MaxWeight: 10
 	-Selectable:
@@ -50,7 +49,6 @@ BADR.Bomber:
 		Speed: 149
 		Repulsable: False
 		MaximumPitch: 56
-		AirborneUpgrades: airborne
 	AmmoPool:
 		Ammo: 7
 	-Selectable:
@@ -107,7 +105,6 @@ MIG:
 		Speed: 223
 		RepulsionSpeed: 40
 		MaximumPitch: 56
-		AirborneUpgrades: airborne
 	AutoTarget:
 		TargetWhenIdle: false
 		TargetWhenDamaged: false
@@ -168,7 +165,6 @@ YAK:
 		Speed: 178
 		RepulsionSpeed: 40
 		MaximumPitch: 56
-		AirborneUpgrades: airborne
 	AutoTarget:
 		TargetWhenIdle: false
 		TargetWhenDamaged: false
@@ -216,8 +212,6 @@ TRAN:
 		Speed: 112
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach
 		AltitudeVelocity: 0c100
-		AirborneUpgrades: airborne
-		CanHover: True
 	WithSpriteRotorOverlay@PRIMARY:
 		Offset: -597,0,341
 		Sequence: rotor2
@@ -265,8 +259,6 @@ HELI:
 		InitialFacing: 20
 		ROT: 4
 		Speed: 149
-		AirborneUpgrades: airborne
-		CanHover: True
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
@@ -318,8 +310,6 @@ HIND:
 		InitialFacing: 20
 		ROT: 4
 		Speed: 112
-		AirborneUpgrades: airborne
-		CanHover: True
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
@@ -350,7 +340,6 @@ U2:
 		Speed: 373
 		Repulsable: False
 		MaximumPitch: 56
-		AirborneUpgrades: airborne
 	AttackBomber:
 	-Selectable:
 	-Voiced:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -350,6 +350,9 @@
 	SelectionDecorations:
 	Selectable:
 		Bounds: 24,24
+	Aircraft:
+		RepairBuildings: fix
+		RearmBuildings: afld
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
 		UpgradeTypes: airborne
@@ -388,6 +391,8 @@
 	Inherits: ^Plane
 	Tooltip:
 		GenericName: Helicopter
+	Aircraft:
+		RearmBuildings: hpad
 	GpsDot:
 		String: Helicopter
 	Hovers:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -353,6 +353,7 @@
 	Aircraft:
 		RepairBuildings: fix
 		RearmBuildings: afld
+		AirborneUpgrades: airborne
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
 		UpgradeTypes: airborne
@@ -393,6 +394,7 @@
 		GenericName: Helicopter
 	Aircraft:
 		RearmBuildings: hpad
+		CanHover: True
 	GpsDot:
 		String: Helicopter
 	Hovers:
@@ -617,6 +619,8 @@
 	WithShadow:
 	Tooltip:
 		GenericName: Destroyed Plane
+	Aircraft:
+		AirborneUpgrades: airborne
 	FallsToEarth:
 		Spins: False
 		Moves: True
@@ -627,6 +631,9 @@
 	WithShadow:
 	Tooltip:
 		GenericName: Destroyed Helicopter
+	Aircraft:
+		AirborneUpgrades: airborne
+		CanHover: True
 	FallsToEarth:
 
 ^Bridge:

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -88,8 +88,6 @@ TRAN.Husk:
 	Aircraft:
 		ROT: 4
 		Speed: 149
-		AirborneUpgrades: airborne
-		CanHover: True
 	WithSpriteRotorOverlay@PRIMARY:
 		Offset: -597,0,341
 	WithSpriteRotorOverlay@SECONDARY:
@@ -121,7 +119,6 @@ BADR.Husk:
 	Aircraft:
 		ROT: 5
 		Speed: 149
-		AirborneUpgrades: airborne
 	SmokeTrailWhenDamaged@0:
 		Offset: -432,560,0
 		Interval: 2
@@ -144,7 +141,6 @@ MIG.Husk:
 	Aircraft:
 		ROT: 5
 		Speed: 186
-		AirborneUpgrades: airborne
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,171
 		Interval: 2
@@ -164,7 +160,6 @@ YAK.Husk:
 	Aircraft:
 		ROT: 5
 		Speed: 149
-		AirborneUpgrades: airborne
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,0
 		Interval: 2
@@ -182,8 +177,6 @@ HELI.Husk:
 	Aircraft:
 		ROT: 4
 		Speed: 149
-		AirborneUpgrades: airborne
-		CanHover: True
 	WithSpriteRotorOverlay:
 		Offset: 0,0,85
 	SmokeTrailWhenDamaged:
@@ -202,8 +195,6 @@ HIND.Husk:
 	Aircraft:
 		ROT: 4
 		Speed: 112
-		AirborneUpgrades: airborne
-		CanHover: True
 	WithSpriteRotorOverlay:
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
@@ -219,7 +210,6 @@ U2.Husk:
 	Aircraft:
 		ROT: 7
 		Speed: 373
-		AirborneUpgrades: airborne
 	Contrail@1:
 		Offset: -725,683,0
 	Contrail@2:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -75,7 +75,6 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		RearmBuildings: gahpad, nahpad
 		ROT: 5
 		Speed: 186
 		TakeoffSound: orcaup1.aud
@@ -275,7 +274,6 @@ APACHE:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		RearmBuildings: gahpad, nahpad
 		ROT: 5
 		Speed: 130
 	Health:
@@ -319,8 +317,6 @@ HUNTER:
 		Weapon: SuicideBomb
 		EmptyWeapon: SuicideBomb
 	Aircraft:
-		RearmBuildings:
-		RepairBuildings:
 		ROT: 16
 		Speed: 355
 		CruiseAltitude: 256

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -497,7 +497,7 @@
 	Inherits: ^Aircraft
 	Aircraft:
 		RepairBuildings: gadept
-		RearmBuildings:
+		RearmBuildings: gahpad, nahpad
 		LandWhenIdle: no
 		CruiseAltitude: 2048
 		Voice: Move


### PR DESCRIPTION
- Removed those pesky aircraft defaults for `RepairBuildings` and `RearmBuildings` that were only ever useful in ra
- Merged common ra aircraft definitons 
