### PR TITLE
Fix the idle animation of the host in WithRepairAnimation.cs

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var spriteBody = host.TraitOrDefault<WithSpriteBody>();
 			if (spriteBody != null && !(info.PauseOnLowPower && self.IsDisabled()))
-				spriteBody.PlayCustomAnimation(host, info.Sequence, () => spriteBody.CancelCustomAnimation(self));
+				spriteBody.PlayCustomAnimation(host, info.Sequence, () => spriteBody.CancelCustomAnimation(host));
 		}
 	}
 }


### PR DESCRIPTION
using the damage state of the repaired actor.

Follow-up of #10211.
See https://github.com/OpenRA/OpenRA/pull/10141#discussion_r47689848.
