### PR TITLE
Replace INotifyBuildComplete with upgrade system (part 1)

### DIFF
--- a/OpenRA.Mods.Common/Traits/Modifiers/DisabledOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/DisabledOverlay.cs
@@ -15,13 +15,19 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Use together with CanPowerDown/RequiresPower on buildings or Husk for vehicles.")]
-	public class DisabledOverlayInfo : TraitInfo<DisabledOverlay> { }
-
-	public class DisabledOverlay : IRenderModifier
+	public class DisabledOverlayInfo : UpgradableTraitInfo
 	{
+		public override object Create(ActorInitializer init) { return new DisabledOverlay(init, this); }
+	}
+
+	public class DisabledOverlay : UpgradableTrait<DisabledOverlayInfo>, IRenderModifier
+	{
+		public DisabledOverlay(ActorInitializer init, DisabledOverlayInfo info)
+			: base(info) { }
+
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			if (!self.IsDisabled())
+			if (IsTraitDisabled || !self.IsDisabled())
 				return r;
 
 			return ModifiedRender(self, wr, r);

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -13,35 +13,29 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Changes the animation when the actor constructed a building.")]
-	public class WithBuildingPlacedAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
+	public class WithBuildingPlacedAnimationInfo : UpgradableTraitInfo, Requires<WithSpriteBodyInfo>
 	{
 		[Desc("Sequence name to use"), SequenceReference]
 		public readonly string Sequence = "build";
 
-		public object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.Self, this); }
 	}
 
-	public class WithBuildingPlacedAnimation : INotifyBuildingPlaced, INotifyBuildComplete
+	public class WithBuildingPlacedAnimation : UpgradableTrait<WithBuildingPlacedAnimationInfo>, INotifyBuildingPlaced
 	{
 		readonly WithBuildingPlacedAnimationInfo info;
 		readonly WithSpriteBody wsb;
-		bool buildComplete;
 
 		public WithBuildingPlacedAnimation(Actor self, WithBuildingPlacedAnimationInfo info)
+			: base(info)
 		{
 			this.info = info;
 			wsb = self.Trait<WithSpriteBody>();
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>();
-		}
-
-		public void BuildingComplete(Actor self)
-		{
-			buildComplete = true;
 		}
 
 		public void BuildingPlaced(Actor self)
 		{
-			if (buildComplete)
+			if (!IsTraitDisabled)
 				wsb.PlayCustomAnimation(self, info.Sequence, () => wsb.CancelCustomAnimation(self));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -18,39 +18,70 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Replaces the sprite during construction.")]
-	public class WithMakeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
+	public class WithMakeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<UpgradeManagerInfo>
 	{
-		[Desc("Sequence name to use")]
+		[Desc("Sequence name to use.")]
 		[SequenceReference] public readonly string Sequence = "make";
+
+		[UpgradeGrantedReference]
+		[Desc("The upgrades to grant while the make animation runs.")]
+		public readonly string[] MakeUpgrades = { };
 
 		public object Create(ActorInitializer init) { return new WithMakeAnimation(init, this); }
 	}
 
-	public class WithMakeAnimation
+	public class WithMakeAnimation : INotifyCreated
 	{
 		readonly WithMakeAnimationInfo info;
 		readonly WithSpriteBody wsb;
+		readonly UpgradeManager manager;
 
 		public WithMakeAnimation(ActorInitializer init, WithMakeAnimationInfo info)
 		{
 			this.info = info;
 			var self = init.Self;
 			wsb = self.Trait<WithSpriteBody>();
+			manager = self.Trait<UpgradeManager>();
+		}
 
+		public void Created(Actor self)
+		{
 			var building = self.TraitOrDefault<Building>();
 			if (building != null && !building.SkipMakeAnimation)
 			{
+				foreach (var up in info.MakeUpgrades)
+					manager.GrantUpgrade(self, up, this);
+
 				wsb.PlayCustomAnimation(self, info.Sequence, () =>
 				{
 					building.NotifyBuildingComplete(self);
+					foreach (var up in info.MakeUpgrades)
+						manager.RevokeUpgrade(self, up, this);
+				});
+			}
+			else if (building == null)
+			{
+				foreach (var up in info.MakeUpgrades)
+					manager.GrantUpgrade(self, up, this);
+
+				wsb.PlayCustomAnimation(self, info.Sequence, () =>
+				{
+					foreach (var up in info.MakeUpgrades)
+						manager.RevokeUpgrade(self, up, this);
 				});
 			}
 		}
 
 		public void Reverse(Actor self, Activity activity, bool queued = true)
 		{
+			foreach (var up in info.MakeUpgrades)
+				manager.GrantUpgrade(self, up, this);
+
 			wsb.PlayCustomAnimationBackwards(self, info.Sequence, () =>
 			{
+				foreach (var up in info.MakeUpgrades)
+					manager.RevokeUpgrade(self, up, this);
+
 				// avoids visual glitches as we wait for the actor to get destroyed
 				wsb.DefaultAnimation.PlayFetchIndex(info.Sequence, () => 0);
 				self.QueueActivity(queued, activity);

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -480,10 +480,13 @@
 		SellSounds: cashturn.aud
 	Capturable:
 	WithMakeAnimation:
+		MakeUpgrades: underConstruction
+	DisableOnUpgrade:
+		UpgradeTypes: underConstruction
+		UpgradeMinEnabledLevel: 1
 
 ^CivBuilding:
 	Inherits: ^Building
-	-UpgradeManager:
 	Health:
 		HP: 400
 	Tooltip:
@@ -599,6 +602,7 @@
 
 ^TibTree:
 	Inherits@1: ^SpriteActor
+	UpgradeManager:
 	Tooltip:
 		Name: Blossom Tree
 	RenderSprites:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -212,10 +212,9 @@ SILO:
 		Range: 4c0
 	Bib:
 		HasMinibib: Yes
-	RenderSprites:
-	WithSpriteBody:
-	AutoSelectionSize:
 	WithSiloAnimation:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	StoresResources:
 		PipCount: 10
 		PipColor: Green

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -462,6 +462,8 @@ HQ:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
@@ -549,6 +551,8 @@ EYE:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
@@ -600,6 +604,8 @@ TMPL:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 2000
 	RevealsShroud:
@@ -686,6 +692,8 @@ SAM:
 		Dimensions: 2,1
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 400
 	Armor:
@@ -730,6 +738,8 @@ OBLI:
 		VisualBounds: 22,42
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 600
 	Armor:
@@ -810,6 +820,8 @@ ATWR:
 		VisualBounds: 22,40,0,4
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 600
 	Armor:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -66,6 +66,8 @@ FACT:
 		Cooldown: 75
 		Range: 14c0
 	WithBuildingPlacedAnimation:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Power:
 		Amount: 0
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -285,6 +285,10 @@
 		Pieces: 2, 5
 		Range: 1c512, 4c0
 	WithMakeAnimation:
+		MakeUpgrades: underConstruction
+	DisableOnUpgrade:
+		UpgradeTypes: underConstruction
+		UpgradeMinEnabledLevel: 1
 
 ^Defense:
 	Inherits: ^Building

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -447,6 +447,8 @@ outpost:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Buildable:
 		Prerequisites: construction_yard, barracks, ~techlevel.medium
 		Queue: Building
@@ -531,6 +533,8 @@ starport:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	ProvidesPrerequisite@atreides:
 		Prerequisite: starport.atreides
 		Factions: atreides
@@ -675,6 +679,8 @@ large_gun_turret:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Power:
 		Amount: -60
 	SelectionDecorations:
@@ -926,6 +932,8 @@ palace:
 		Produces: Palace
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	RequiresPower:
 	SupportPowerChargeBar:
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -283,6 +283,8 @@ silo:
 			ordos: silo.ordos
 	WithSpriteBody:
 	WithSiloAnimation:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	StoresResources:
 		PipColor: green
 		PipCount: 5

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -433,6 +433,10 @@
 	EngineerRepairable:
 	AcceptsSupplies:
 	WithMakeAnimation:
+		MakeUpgrades: underConstruction
+	DisableOnUpgrade:
+		UpgradeTypes: underConstruction
+		UpgradeMinEnabledLevel: 1
 	ExternalCapturable:
 	ExternalCapturableBar:
 	EmitInfantryOnSell:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -42,6 +42,8 @@ MSLO:
 	CanPowerDown:
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	SupportPowerChargeBar:
 	Power:
 		Amount: -150
@@ -69,6 +71,8 @@ GAP:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
@@ -275,6 +279,8 @@ IRON:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Selectable:
 		Bounds: 48,28,0,2
 	SelectionDecorations:
@@ -323,6 +329,8 @@ PDOX:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 1000
 	Armor:
@@ -395,6 +403,8 @@ TSLA:
 		VisualBounds: 24,36,0,4
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 400
 	Armor:
@@ -440,6 +450,8 @@ AGUN:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 400
 	Armor:
@@ -487,6 +499,8 @@ DOME:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 1000
 	Armor:
@@ -689,6 +703,8 @@ SAM:
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 400
 	Armor:
@@ -749,6 +765,8 @@ ATEK:
 	SupportPowerChargeBar:
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Power:
 		Amount: -200
 	ProvidesPrerequisite@buildingname:
@@ -1219,6 +1237,8 @@ POWR:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
@@ -1260,6 +1280,8 @@ APWR:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -999,6 +999,8 @@ SILO:
 	Bib:
 		HasMinibib: Yes
 	WithSiloAnimation:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	StoresResources:
 		PipCount: 5
 		Capacity: 1500

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -911,6 +911,8 @@ FACT:
 	BaseProvider:
 		Range: 16c0
 	WithBuildingPlacedAnimation:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Power:
 		Amount: 0
 	WithDeathAnimation:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -137,6 +137,10 @@
 	Sellable:
 		SellSounds: cashturn.aud
 	WithMakeAnimation:
+		MakeUpgrades: underConstruction
+	DisableOnUpgrade:
+		UpgradeTypes: underConstruction
+		UpgradeMinEnabledLevel: 1
 	ThrowsShrapnel:
 		Weapons: LargeDebris
 		Pieces: 3, 7

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -34,6 +34,8 @@ GAPOWR:
 		TargetTypes: Ground, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Pluggable@pluga:
 		Offset: 0,1
 		Upgrades:
@@ -348,6 +350,8 @@ GAPLUG:
 	CanPowerDown:
 		IndicatorPalette: mouse
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
 	WithIdleOverlay@LIGHTS:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -43,6 +43,8 @@ GACTWR:
 	Selectable:
 		Bounds: 48, 36, 0, -6
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 500
 	Armor:

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -32,6 +32,8 @@ NAPOWR:
 		TargetTypes: Ground, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	SelectionDecorations:
 		VisualBounds: 88, 80, 2, -12
 
@@ -69,6 +71,8 @@ NAAPWR:
 		TargetTypes: Ground, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	SelectionDecorations:
 		VisualBounds: 100, 74, 0, -12
 

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -41,6 +41,8 @@ NALASR:
 		Bounds: 40, 30, -8, -6
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 400
 	Armor:
@@ -82,6 +84,8 @@ NAOBEL:
 		Bounds: 88, 42, 0, -6
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 600
 	Armor:
@@ -122,6 +126,8 @@ NASAM:
 		Bounds: 40, 30, -3, -8
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 500
 	Armor:
@@ -255,6 +261,8 @@ NAMISL:
 		IndicatorPalette: mouse
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	ProvidesPrerequisite@buildingname:
 	SupportPowerChargeBar:
 	NukePower:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -134,6 +134,8 @@ GASILO:
 			nod: gasilo.nod
 	WithSpriteBody:
 	WithSiloAnimation:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	WithIdleOverlay@UNDERLAY:
 		Sequence: idle-underlay
 	WithIdleOverlay@LIGHTS:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -16,6 +16,8 @@ NAPULS:
 		Bounds: 78, 54, 0, -12
 	RequiresPower:
 	DisabledOverlay:
+		UpgradeMaxEnabledLevel: 0
+		UpgradeTypes: underConstruction
 	Health:
 		HP: 500
 	Armor:


### PR DESCRIPTION
Provided the general approach gets approved, this PR will be the first of two or more to get rid of the (hacky) `INotifyBuildComplete` interface, disabling actors/traits during make animation via upgrades instead.

This PR gives `WithMakeAnimation` the ability to provide upgrades, migrates `WithBuildingPlacedAnimation` (playing when TD and RA construction yards place a structure) and `WithSiloAnimation` from `INotifyBuildComplete` to upgrades, and makes the `DisabledOverlay` trait upgradable itself, because we don't want it to be enabled while the make animation runs.

I intentionally kept the number of migrated traits small in this PR, for easier reviewing of the general approach.
