### PR TITLE
Fix DamagedWithoutFoundation causing more damage than it should

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
@@ -64,6 +64,8 @@ namespace OpenRA.Mods.D2k.Traits
 			var delta = health.HP - damageThreshold;
 			if (delta > 0)
 				health.InflictDamage(self, self.World.WorldActor, delta, null, false);
+
+			damageTicks = info.WeaponInfo.ReloadDelay;
 		}
 
 		public void Tick(Actor self)

--- a/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/DamagedWithoutFoundation.cs
@@ -19,9 +19,13 @@ namespace OpenRA.Mods.D2k.Traits
 	[Desc("Reduces health points over time when the actor is placed on unsafe terrain.")]
 	class DamagedWithoutFoundationInfo : ITraitInfo, IRulesetLoaded, Requires<HealthInfo>
 	{
-		[WeaponReference]
+		[WeaponReference, Desc("The weapon to use for causing damage.")]
 		public readonly string Weapon = "weathering";
+
+		[Desc("Terrain types on which no damage is caused.")]
 		public readonly HashSet<string> SafeTerrain = new HashSet<string> { "Concrete" };
+
+		[Desc("The percentage of health the actor should keep.")]
 		public readonly int DamageThreshold = 50;
 
 		public WeaponInfo WeaponInfo { get; private set; }


### PR DESCRIPTION
to its damaged animation.

~~Unfortunately I didn't find a better way to fix the issue than two `RunAfterTick`s.
If we don't want to use that, I can remove the first commit, as the second one will hide the issue.~~

EDIT: Outdated description.
