### PR TITLE
Fix the StartsRevealed option of FrozenUnderFog being ignored

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Traits
 					Shrouded = false;
 			}
 
-			NeedRenderables = Visible && !wasVisible;
+			NeedRenderables |= Visible && !wasVisible;
 		}
 
 		public void Flash()


### PR DESCRIPTION
Fixes #10228.

In `FrozenActor`'s ctor, the `NeedsRenderables` property is effectively being set to the value of the actor's `FrozenUnderFogInfo.StartsRevealed` field. Later in the ctor, the `UpdateVisibility` method is called, which ignores and overwrites the previous value. This change ensures that `NeedsRenderables` won't be unset by `UpdateVisibility` if it was already set. It will be reset to false by [this line in `FrozenUnderFog.TickRender`](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs#L167) eventually.
