### PR TITLE
Remove ISpriteBody

### DIFF
--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				// If a sprite actor has neither custom QuantizedFacings nor a trait implementing IQuantizeBodyOrientationInfo, throw
 				if (qboi == null)
 				{
-					if (self.Info.HasTraitInfo<ISpriteBodyInfo>())
+					if (self.Info.HasTraitInfo<WithSpriteBodyInfo>())
 						throw new InvalidOperationException("Actor '" + self.Info.Name + "' has a sprite body but no facing quantization."
 							+ " Either add the QuantizeFacingsFromSequence trait or set custom QuantizedFacings on BodyOrientation.");
 					else

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Default trait for rendering sprite-based actors.")]
-	public class WithSpriteBodyInfo : UpgradableTraitInfo, ISpriteBodyInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
+	public class WithSpriteBodyInfo : UpgradableTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Animation to play when the actor is created."), SequenceReference]
 		public readonly string StartSequence = null;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class WithSpriteBody : UpgradableTrait<WithSpriteBodyInfo>, ISpriteBody, INotifyDamageStateChanged, INotifyBuildComplete
+	public class WithSpriteBody : UpgradableTrait<WithSpriteBodyInfo>, INotifyDamageStateChanged, INotifyBuildComplete
 	{
 		public readonly Animation DefaultAnimation;
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly UpgradeManager manager;
 		readonly bool checkTerrainType;
 		readonly bool canTurn;
-		readonly Lazy<ISpriteBody> body;
+		readonly Lazy<WithSpriteBody> body;
 
 		DeployState deployState;
 
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			manager = self.Trait<UpgradeManager>();
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
 			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
-			body = Exts.Lazy(self.TraitOrDefault<ISpriteBody>);
+			body = Exts.Lazy(self.TraitOrDefault<WithSpriteBody>);
 			if (init.Contains<DeployStateInit>())
 				deployState = init.Get<DeployStateInit, DeployState>();
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -19,14 +19,6 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public interface ISpriteBodyInfo : ITraitInfo { }
-	public interface ISpriteBody
-	{
-		void PlayCustomAnimation(Actor self, string newAnimation, Action after);
-		void PlayCustomAnimationRepeating(Actor self, string name);
-		void PlayCustomAnimationBackwards(Actor self, string name, Action after);
-	}
-
 	public interface IQuantizeBodyOrientationInfo : ITraitInfo
 	{
 		int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race);


### PR DESCRIPTION
> 16:19:51 (abcdefg30) why do we even have ISpriteBody when it's only implemented by WithSpriteBody ?
> 16:20:08 (pchote) it was there while we were transitioning to WithSpriteBody
> 16:20:18 (pchote) the old Render*'s used to implement it too
> 16:20:23 (abcdefg30) ah, so basically i can remove it?
> 16:20:31 (pchote) should be able to
