### PR TITLE
Enable original TD campaign colors.

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -252,6 +252,7 @@
     <Compile Include="GlobalChat.cs" />
     <Compile Include="Primitives\ObservableList.cs" />
     <Compile Include="Graphics\RgbaColorRenderer.cs" />
+    <Compile Include="Traits\Player\IndexedPlayerPalette.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
+++ b/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
@@ -1,0 +1,91 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using OpenRA.Graphics;
+
+namespace OpenRA.Traits
+{
+	[Desc("Define a player palette by swapping palette indices.")]
+	public class IndexedPlayerPaletteInfo : ITraitInfo, IRulesetLoaded
+	{
+		[Desc("The name of the palette to base off.")]
+		[PaletteReference] public readonly string BasePalette = null;
+
+		[Desc("The prefix for the resulting player palettes")]
+		[PaletteDefinition(true)] public readonly string BaseName = "player";
+
+		[Desc("Remap these indices to player colors.")]
+		public readonly int[] RemapIndex = { };
+
+		[Desc("Allow palette modifiers to change the palette.")]
+		public readonly bool AllowModifiers = true;
+
+		public readonly Dictionary<string, int[]> PlayerIndex;
+
+		public object Create(ActorInitializer init) { return new IndexedPlayerPalette(this); }
+
+		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			foreach (var p in PlayerIndex)
+				if (p.Value.Length != RemapIndex.Length)
+					throw new YamlException("PlayerIndex for player `{0}` length does not match RemapIndex!".F(p.Key));
+		}
+	}
+
+	public class IndexedPlayerPalette : ILoadsPlayerPalettes
+	{
+		readonly IndexedPlayerPaletteInfo info;
+
+		public IndexedPlayerPalette(IndexedPlayerPaletteInfo info)
+		{
+			this.info = info;
+		}
+
+		public void LoadPlayerPalettes(WorldRenderer wr, string playerName, HSLColor color, bool replaceExisting)
+		{
+			var basePalette = wr.Palette(info.BasePalette).Palette;
+			ImmutablePalette pal;
+			int[] remap;
+
+			if (info.PlayerIndex.TryGetValue(playerName, out remap))
+				pal = new ImmutablePalette(basePalette, new IndexedColorRemap(basePalette, info.RemapIndex, remap));
+			else
+				pal = new ImmutablePalette(basePalette);
+
+			wr.AddPalette(info.BaseName + playerName, pal, info.AllowModifiers, replaceExisting);
+		}
+	}
+
+	public class IndexedColorRemap : IPaletteRemap
+	{
+		Dictionary<int, int> replacements = new Dictionary<int, int>();
+		IPalette basePalette;
+
+		public IndexedColorRemap(IPalette basePalette, int[] ramp, int[] remap)
+		{
+			this.basePalette = basePalette;
+			if (ramp.Length != remap.Length)
+				throw new InvalidDataException("ramp and remap lengths do no match.");
+
+			for (var i = 0; i < ramp.Length; i++)
+				replacements[ramp[i]] = remap[i];
+		}
+
+		public Color GetRemappedColor(Color original, int index)
+		{
+			int c;
+			return replacements.TryGetValue(index, out c)
+				? basePalette.GetColor(c) : original;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -29,16 +29,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly DropDownButtonWidget ownersDropDown;
 		readonly ScrollPanelWidget panel;
 		readonly ScrollItemWidget itemTemplate;
-		readonly Ruleset modRules;
+		readonly Ruleset mapRules;
 		readonly World world;
 		readonly WorldRenderer worldRenderer;
 
 		PlayerReference selectedOwner;
 
 		[ObjectCreator.UseCtor]
-		public ActorSelectorLogic(Widget widget, World world, WorldRenderer worldRenderer, Ruleset modRules)
+		public ActorSelectorLogic(Widget widget, World world, WorldRenderer worldRenderer)
 		{
-			this.modRules = modRules;
+			this.mapRules = world.Map.Rules;
 			this.world = world;
 			this.worldRenderer = worldRenderer;
 
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			panel.RemoveChildren();
 
-			var actors = modRules.Actors.Where(a => !a.Value.Name.Contains('^'))
+			var actors = mapRules.Actors.Where(a => !a.Value.Name.Contains('^'))
 				.Select(a => a.Value);
 
 			foreach (var a in actors)

--- a/mods/cnc/maps/cnc64gdi01/map.yaml
+++ b/mods/cnc/maps/cnc64gdi01/map.yaml
@@ -731,6 +731,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -749,18 +766,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -776,11 +801,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	BIO.Husk:
 		Tooltip:
 			ShowOwnerRow: false
@@ -806,6 +833,18 @@ Rules:
 		RejectsOrders:
 		Cargo:
 			Types: disabled
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	airstrike.proxy:
 		AlwaysVisible:
 		AirstrikePower:

--- a/mods/cnc/maps/funpark01/map.yaml
+++ b/mods/cnc/maps/funpark01/map.yaml
@@ -428,6 +428,16 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Civilian: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Dinosaur: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -474,7 +484,7 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -415,6 +415,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -433,18 +450,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -460,11 +485,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	NUKE:
 		-Sellable:
 		Buildable:
@@ -537,6 +564,18 @@ Rules:
 		RejectsOrders:
 		Cargo:
 			Types: disabled
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 	oldlst:

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -642,6 +642,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -660,18 +677,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -689,15 +714,22 @@ Rules:
 			ShowOwnerRow: false
 	SBAG:
 		-Crushable:
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	HARV:
 		Harvester:
 			SearchFromProcRadius: 32
 			SearchFromOrderRadius: 20
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	PROC:
 		Buildable:
 			Prerequisites: ~disabled
@@ -771,6 +803,12 @@ Rules:
 		RejectsOrders:
 		Cargo:
 			Types: disabled
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 	oldlst:

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -717,6 +717,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -735,6 +752,8 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -743,10 +762,14 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -764,11 +787,13 @@ Rules:
 			ShowOwnerRow: false
 	SBAG:
 		-Crushable:
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	WEAP:
 		Buildable:
 			Prerequisites: ~disabled
@@ -841,6 +866,18 @@ Rules:
 			BeaconPoster: airstrike
 			DisplayRadarPing: True
 			CameraActor: camera
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -476,6 +476,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -494,18 +511,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -521,11 +546,25 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -547,6 +547,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -565,18 +582,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -592,14 +617,28 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	E3:
 		AutoTarget:
 			ScanRadius: 5
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -772,6 +772,25 @@ Smudges:
 	sc2 47,31 0:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -790,18 +809,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -817,17 +844,31 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^CivInfantry:
 		Health:
 			HP: 125
 	^Bridge:
 		DamageMultiplier@INVULNERABLE:
 			Modifier: 0
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -785,6 +785,25 @@ Smudges:
 	sc6 49,48 0:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -804,18 +823,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -832,11 +859,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	E2:
 		Buildable:
 			Prerequisites: ~pyle
@@ -857,12 +886,22 @@ Rules:
 			SearchFromOrderRadius: 24
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	LTNK:
 		Buildable:
 			Prerequisites: ~afld
 	MCV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	MTNK:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/maps/gdi05b/map.yaml
+++ b/mods/cnc/maps/gdi05b/map.yaml
@@ -634,6 +634,25 @@ Smudges:
 	sc4 39,51 0:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -653,18 +672,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -681,11 +708,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	SBAG:
 		Buildable:
 			Prerequisites: ~disabled
@@ -734,6 +763,11 @@ Rules:
 	HARV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	MTNK:
 		Buildable:
 			Prerequisites: ~disabled
@@ -749,6 +783,11 @@ Rules:
 	MCV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	FTNK:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/maps/gdi06/map.yaml
+++ b/mods/cnc/maps/gdi06/map.yaml
@@ -1037,6 +1037,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	World:
 		-SpawnMPUnits:
 		-MPStartLocations:
@@ -1076,18 +1093,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -1103,6 +1128,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
+	^CommonHuskDefaults:
+		Tooltip:
+			GenericVisibility: Enemy, Ally, Neutral
+			GenericStancePrefix: false
+			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	FLARE:
 		RevealsShroud:
 			Range: 5c0
@@ -1146,6 +1178,18 @@ Rules:
 			AllowMovement: false
 		RenderSprites:
 			Image: E3
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 	oldlst:

--- a/mods/cnc/maps/nod01/map.yaml
+++ b/mods/cnc/maps/nod01/map.yaml
@@ -272,6 +272,25 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Villagers: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Villagers: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -301,18 +320,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -328,11 +355,25 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod02a/map.yaml
+++ b/mods/cnc/maps/nod02a/map.yaml
@@ -214,6 +214,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -233,18 +250,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -260,11 +285,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled
@@ -310,6 +337,17 @@ Rules:
 	MCV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	LST:
 		Buildable:
 			Prerequisites: ~disabled
@@ -349,7 +387,6 @@ Rules:
 	ATWR:
 		Buildable:
 			Prerequisites: ~disabled
-
 Sequences:
 
 VoxelSequences:

--- a/mods/cnc/maps/nod02b/map.yaml
+++ b/mods/cnc/maps/nod02b/map.yaml
@@ -256,6 +256,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -275,18 +292,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -302,11 +327,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled
@@ -352,6 +379,11 @@ Rules:
 	MCV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	LST:
 		Buildable:
 			Prerequisites: ~disabled
@@ -391,6 +423,12 @@ Rules:
 	ATWR:
 		Buildable:
 			Prerequisites: ~disabled
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -450,6 +450,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -469,18 +486,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -496,11 +521,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	HQ:
 		AirstrikePower:
 			Prerequisites: ~disabled
@@ -559,6 +586,18 @@ Rules:
 			Name: Prison
 		Capturable:
 			CaptureThreshold: 1
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -494,6 +494,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -513,18 +530,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -540,11 +565,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	HQ:
 		AirstrikePower:
 			Prerequisites: ~disabled
@@ -603,6 +630,18 @@ Rules:
 			Name: Prison
 		Capturable:
 			CaptureThreshold: 1
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod04a/map.yaml
+++ b/mods/cnc/maps/nod04a/map.yaml
@@ -555,6 +555,25 @@ Smudges:
 	sc6 36,18 0:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				NodSupporter: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				NodSupporter: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -575,19 +594,27 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
 		AnnounceOnSeen:
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -611,11 +638,13 @@ Rules:
 		Tooltip:
 			ShowOwnerRow: false
 		AnnounceOnSeen:
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled
@@ -661,6 +690,11 @@ Rules:
 	MCV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	LST:
 		Buildable:
 			Prerequisites: ~disabled
@@ -691,6 +725,12 @@ Rules:
 	ATWR:
 		Buildable:
 			Prerequisites: ~disabled
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod04b/map.yaml
+++ b/mods/cnc/maps/nod04b/map.yaml
@@ -494,6 +494,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -515,19 +532,27 @@ Rules:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
 		AnnounceOnSeen:
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
 		AnnounceOnSeen:
+		RenderSprites:
+			PlayerPalette: player-units
 	^Helicopter:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Building:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -541,16 +566,30 @@ Rules:
 	^CivBuildingHusk:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	TRAN:
 		RejectsOrders:
 		-Selectable:
 		RevealsShroud:
 			Range: 5c0
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -395,6 +395,25 @@ Smudges:
 	cr1 46,48 0:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -414,18 +433,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Ship:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -437,11 +464,13 @@ Rules:
 	^Wall:
 		Tooltip:
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy, Ally, Neutral
 			GenericStancePrefix: false
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	NUK2:
 		Buildable:
 			Prerequisites: ~disabled
@@ -478,6 +507,11 @@ Rules:
 	MCV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	LST:
 		Buildable:
 			Prerequisites: ~disabled
@@ -501,6 +535,11 @@ Rules:
 			Prerequisites: ~disabled
 		Harvester:
 			SearchFromOrderRadius: 24
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	FTNK:
 		Buildable:
 			Prerequisites: ~disabled

--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -662,6 +662,23 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -682,15 +699,27 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
 		AnnounceOnSeen:
+		RenderSprites:
+			PlayerPalette: player-units
+	^Helicopter:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -703,21 +732,34 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^CivBuildingHusk:
 		Tooltip:
 			ShowOwnerRow: false
 	HARV:
 		Harvester:
 			SearchFromProcRadius: 64
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	FLARE:
 		Tooltip:
 			ShowOwnerRow: false
 	TRAN:
 		-Selectable:
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod06b/map.yaml
+++ b/mods/cnc/maps/nod06b/map.yaml
@@ -605,6 +605,25 @@ Actors:
 Smudges:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+				Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -624,14 +643,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
+	^Helicopter:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -644,10 +675,12 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
-	^Husk:
+	^CommonHuskDefaults:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^CivBuildingHusk:
 		Tooltip:
 			ShowOwnerRow: false
@@ -656,6 +689,18 @@ Rules:
 			ShowOwnerRow: false
 	TRAN:
 		-Selectable:
+	HARV:
+		RenderSprites:
+			PlayerPalette: player
+	MCV:
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 
 Sequences:
 

--- a/mods/cnc/maps/nod06c/map.yaml
+++ b/mods/cnc/maps/nod06c/map.yaml
@@ -491,6 +491,23 @@ Smudges:
 	sc5 32,20 0:
 
 Rules:
+	^Palettes:
+		-PlayerColorPalette:
+		IndexedPlayerPalette:
+			BasePalette: terrain
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+		IndexedPlayerPalette@units:
+			BasePalette: terrain
+			BaseName: player-units
+			RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			PlayerIndex:
+				GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+				Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+				Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	Player:
 		-ConquestVictoryConditions:
 		MissionObjectives:
@@ -510,14 +527,26 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Tank:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Infantry:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
+	^Helicopter:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Plane:
 		Tooltip:
 			GenericVisibility: Enemy
@@ -530,6 +559,12 @@ Rules:
 		Tooltip:
 			GenericVisibility: Enemy
 			ShowOwnerRow: false
+	^CommonHuskDefaults:
+		Tooltip:
+			GenericVisibility: Enemy
+			ShowOwnerRow: false
+		RenderSprites:
+			PlayerPalette: player-units
 	^Bridge:
 		DamageMultiplier@INVULNERABLE:
 			Modifier: 0
@@ -581,6 +616,11 @@ Rules:
 	MCV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	MCV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	LST:
 		Buildable:
 			Prerequisites: ~disabled
@@ -605,6 +645,11 @@ Rules:
 	HARV:
 		Buildable:
 			Prerequisites: ~disabled
+		RenderSprites:
+			PlayerPalette: player
+	HARV.Husk:
+		RenderSprites:
+			PlayerPalette: player
 	MTNK:
 		Buildable:
 			Prerequisites: ~disabled


### PR DESCRIPTION
Closes #8517 and fixes some generic tooltip issues caused by missing default overrides.

Fixes https://github.com/OpenRA/OpenRA/issues/10268.
