### PR TITLE
DeployToUpgrade: Deploy Animations processed before starting deploy

### DIFF
--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly UpgradeManager manager;
 		readonly bool checkTerrainType;
 		readonly bool canTurn;
-		readonly Lazy<ISpriteBody> body;
+		readonly Lazy<WithSpriteBody> body;
 
 		DeployState deployState;
 
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			manager = self.Trait<UpgradeManager>();
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
 			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
-			body = Exts.Lazy(self.TraitOrDefault<ISpriteBody>);
+			body = Exts.Lazy(self.TraitOrDefault<WithSpriteBody>);
 			if (init.Contains<DeployStateInit>())
 				deployState = init.Get<DeployStateInit, DeployState>();
 		}
@@ -110,8 +110,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
-			get { yield return new DeployOrderTargeter("DeployToUpgrade", 5,
-				() => IsOnValidTerrain() ? info.DeployCursor : info.DeployBlockedCursor); }
+			get
+			{
+				yield return new DeployOrderTargeter("DeployToUpgrade", 5,
+					() => IsOnValidTerrain() ? info.DeployCursor : info.DeployBlockedCursor);
+			}
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
@@ -194,17 +197,15 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!string.IsNullOrEmpty(info.DeploySound))
 				Game.Sound.Play(info.DeploySound, self.CenterPosition);
-
+			if (!string.IsNullOrEmpty(info.DeployAnimation))
+				body.Value.PlayCustomAnimation(self, info.DeployAnimation);
 			// Revoke upgrades that are used while undeployed.
 			if (!init)
 				OnDeployStarted();
 
 			// If there is no animation to play just grant the upgrades that are used while deployed.
 			// Alternatively, play the deploy animation and then grant the upgrades.
-			if (string.IsNullOrEmpty(info.DeployAnimation) || body.Value == null)
-				OnDeployCompleted();
-			else
-				body.Value.PlayCustomAnimation(self, info.DeployAnimation, OnDeployCompleted);
+			OnDeployCompleted();
 		}
 
 		/// <summary>Play undeploy sound and animation and after that revoke the upgrades.</summary>
@@ -217,16 +218,14 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!string.IsNullOrEmpty(info.UndeploySound))
 				Game.Sound.Play(info.UndeploySound, self.CenterPosition);
-
+			if (!string.IsNullOrEmpty(info.DeployAnimation))
+				body.Value.PlayCustomAnimationBackwards(self, info.DeployAnimation);
 			if (!init)
 				OnUndeployStarted();
 
 			// If there is no animation to play just grant the upgrades that are used while undeployed.
 			// Alternatively, play the undeploy animation and then grant the upgrades.
-			if (string.IsNullOrEmpty(info.DeployAnimation) || body.Value == null)
-				OnUndeployCompleted();
-			else
-				body.Value.PlayCustomAnimationBackwards(self, info.DeployAnimation, OnUndeployCompleted);
+			OnUndeployCompleted();
 		}
 
 		void OnDeployStarted()


### PR DESCRIPTION
When trying to implement the Allied G.I.'s Deploy function at this PR:
https://github.com/OpenRA/ra2/pull/3
I noticed that DeployToUpgrade wasn't wanting to render the DeployAnimation.

This fixes that issue, by causing the DeployAnimation to render before the rest of the effects of the Deploy/Undeploy.

The only other unit in the entire project to use DeployToUpgrade is the Dune 2000 Thumper unit, and they do not have a DeployAnimation, and are therefore unaffected.
