### PR TITLE
Adjust the description of allies05a

### DIFF
--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -213,6 +213,10 @@ SendSpy = function()
 		SpyCameraA = Actor.Create("camera", true, { Owner = greece, Location = SpyCamera1.Location })
 		SpyCameraB = Actor.Create("camera", true, { Owner = greece, Location = SpyCamera2.Location })
 	end
+
+	Trigger.AfterDelay(DateTime.Seconds(3), function()
+		Media.DisplayMessage("Commander! You have to disguise me in order to get through the enemy patrols.", "Spy")
+	end)
 end
 
 ActivatePatrols = function()

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -4,7 +4,7 @@ RequiresMod: ra
 
 Title: 05a: Tanya's Tale
 
-Description: Rescue Tanya.\n\nYour spy can move past any enemy unit, except dogs, without being detected. Direct him into the weapons factory located at a nearby Soviet Base where he will hijack a truck and free Tanya.\n\nWith Tanya's help, take out the air defenses on the island and a Chinook will arrive to rescue her.\n\nThen destroy all remaining Soviet buildings and units.
+Description: Rescue Tanya.\n\nOnce disguised, your spy can move past any enemy unit, except dogs, without being detected. Direct him into the weapons factory located at a nearby Soviet Base where he will hijack a truck and free Tanya.\n\nWith Tanya's help, take out the air defenses on the island and a Chinook will arrive to rescue her.\n\nThen destroy all remaining Soviet buildings and units.
 
 Author: Westwood Studios
 


### PR DESCRIPTION
To prevent issues like #10226 and #10265.
-> Fixes #10265.

In addition we could disguise the spy automatically at mission start, if you feel like this change in the description is not enough.
