### PR TITLE
Load shaders relative to the game directory, rather than the CWD

### DIFF
--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Platforms.Default
 		protected int CompileShaderObject(ShaderType type, string name)
 		{
 			var ext = type == ShaderType.VertexShader ? "vert" : "frag";
-			var filename = "glsl{0}{1}.{2}".F(Path.DirectorySeparatorChar, name, ext);
+			var filename = Path.Combine(Platform.GameDir, "glsl", name + "." + ext);
 			var code = File.ReadAllText(filename);
 
 			var shader = GL.CreateShader(type);


### PR DESCRIPTION
If OpenRA is started with a current working directory that does not match the path to the game, then loading shaders will fail. By using a path relative to the game directory, we can successfully start the game with different working directories.

(I'm mostly scratching my own itch here - the memory profiler I use changes the working directory and thus gives me exceptions like `System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\Users\Roost\CLRProfiler\32\glsl\shp.vert'.`)
