### PR TITLE
Support sending sequences of points when drawing lines

### DIFF
--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace OpenRA.Graphics
 {
@@ -109,6 +110,23 @@ namespace OpenRA.Graphics
 			return new float2(x, y) / d;
 		}
 
+		void DrawDisconnectedLine(IEnumerable<float2> points, float width, Color color)
+		{
+			using (var e = points.GetEnumerator())
+			{
+				if (!e.MoveNext())
+					return;
+
+				var lastPoint = e.Current;
+				while (e.MoveNext())
+				{
+					var point = e.Current;
+					DrawLine(lastPoint, point, width, color);
+					lastPoint = point;
+				}
+			}
+		}
+
 		void DrawConnectedLine(float2[] points, float width, Color color, bool closed)
 		{
 			// Not a line
@@ -178,18 +196,12 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public void DrawLine(float2[] points, float width, Color color, bool connectSegments = false)
+		public void DrawLine(IEnumerable<float2> points, float width, Color color, bool connectSegments = false)
 		{
 			if (!connectSegments)
-			{
-				if (points.Length < 2)
-					return;
-
-				for (var i = 1; i < points.Length; i++)
-					DrawLine(points[i - 1], points[i], width, color);
-			}
+				DrawDisconnectedLine(points, width, color);
 			else
-				DrawConnectedLine(points, width, color, false);
+				DrawConnectedLine(points as float2[] ?? points.ToArray(), width, color, false);
 		}
 
 		public void DrawPolygon(float2[] vertices, float width, Color color)

--- a/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Widgets
 							lastX = x;
 							lastPoint = point;
 							return origin + new float2(x * xStep, -point * scale);
-						}).ToArray(), 1, color);
+						}), 1, color);
 
 					if (lastPoint != 0f)
 						tiny.DrawText(GetValueFormat().F(lastPoint), origin + new float2(lastX * xStep, -lastPoint * scale - 2), color);

--- a/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Widgets
 			foreach (var item in PerfHistory.Items.Values)
 			{
 				cr.DrawLine(item.Samples()
-					.Select((sample, i) => origin + new float2(i, (float)sample) * basis).ToArray(),
+					.Select((sample, i) => origin + new float2(i, (float)sample) * basis),
 					1, item.C);
 
 				var u = new float2(rect.Left, rect.Top);


### PR DESCRIPTION
This allows the graph widgets to avoid having to create temporary arrays just to draw these lines, which reduces GC pressure.

On the RA shellmap with the perf graph active, this reduces ongoing allocations by about 9%.
