### PR TITLE
Dump Mono.NAT in favor of Open.NAT 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@
 
 ############################## TOOLCHAIN ###############################
 #
-CSC         = dmcs
+CSC         = mcs -sdk:4.5
 CSFLAGS     = -nologo -warn:4 -codepage:utf8 -unsafe -warnaserror
 DEFINE      = TRACE
 COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/Mono.Nat.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/MaxMind.GeoIP2.dll thirdparty/download/Eluant.dll thirdparty/download/SmarIrc4net.dll

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@
 CSC         = mcs -sdk:4.5
 CSFLAGS     = -nologo -warn:4 -codepage:utf8 -unsafe -warnaserror
 DEFINE      = TRACE
-COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/Mono.Nat.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/MaxMind.GeoIP2.dll thirdparty/download/Eluant.dll thirdparty/download/SmarIrc4net.dll
+COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/MaxMind.GeoIP2.dll thirdparty/download/Eluant.dll thirdparty/download/SmarIrc4net.dll
 NUNIT_LIBS_PATH :=
 NUNIT_LIBS  := $(NUNIT_LIBS_PATH)nunit.framework.dll
 
@@ -107,7 +107,7 @@ endif
 game_SRCS := $(shell find OpenRA.Game/ -iname '*.cs')
 game_TARGET = OpenRA.Game.exe
 game_KIND = winexe
-game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SharpFont.dll
+game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SharpFont.dll thirdparty/download/Open.Nat.dll
 game_FLAGS = -win32icon:OpenRA.Game/OpenRA.ico
 PROGRAMS += game
 game: $(game_TARGET)
@@ -399,7 +399,7 @@ install-core: default
 	@$(INSTALL_PROGRAM) FuzzyLogicLibrary.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) SharpFont.dll "$(DATA_INSTALL_DIR)"
 	@$(CP) SharpFont.dll.config "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) Mono.Nat.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) Open.Nat.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) MaxMind.Db.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) MaxMind.GeoIP2.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -208,14 +208,6 @@ namespace OpenRA
 			Log.AddChannel("geoip", "geoip.log");
 			Log.AddChannel("irc", "irc.log");
 
-			if (Settings.Server.DiscoverNatDevices)
-				UPnP.TryNatDiscovery();
-			else
-			{
-				Settings.Server.NatDeviceAvailable = false;
-				Settings.Server.AllowPortForward = false;
-			}
-
 			GeoIP.Initialize();
 
 			var renderers = new[] { Settings.Graphics.Renderer, "Default", null };
@@ -239,6 +231,8 @@ namespace OpenRA
 
 			Sound = new Sound(Settings.Server.Dedicated ? "Null" : Settings.Sound.Engine);
 
+			UPnP.TryNatDiscovery().Wait();
+
 			GlobalChat = new GlobalChat();
 
 			Console.WriteLine("Available mods:");
@@ -246,9 +240,6 @@ namespace OpenRA
 				Console.WriteLine("\t{0}: {1} ({2})", mod.Key, mod.Value.Title, mod.Value.Version);
 
 			InitializeMod(Settings.Game.Mod, args);
-
-			if (Settings.Server.DiscoverNatDevices)
-				RunAfterDelay(Settings.Server.NatDiscoveryTimeout, UPnP.StoppingNatDiscovery);
 		}
 
 		public static bool IsModInstalled(string modId)

--- a/OpenRA.Game/Network/UPnP.cs
+++ b/OpenRA.Game/Network/UPnP.cs
@@ -9,127 +9,84 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
-using Mono.Nat;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Open.Nat;
 
 namespace OpenRA.Network
 {
-	public static class UPnP
+	public class UPnP
 	{
-		static INatDevice natDevice;
+		static IEnumerable<NatDevice> natDevices;
+		static Mapping mapping;
 
-		public static void TryNatDiscovery()
+		public static IPAddress ExternalIP;
+
+		public static async Task TryNatDiscovery()
 		{
+			if (Game.Settings.Server.DiscoverNatDevices == false)
+				Game.Settings.Server.AllowPortForward = false;
+
 			try
 			{
-				NatUtility.Logger = Log.Channels["server"].Writer;
-				NatUtility.Verbose = Game.Settings.Server.VerboseNatDiscovery;
-				NatUtility.DeviceFound += DeviceFound;
-				Game.Settings.Server.NatDeviceAvailable = false;
-				NatUtility.StartDiscovery();
-				Log.Write("server", "NAT discovery started.");
+				NatDiscoverer.TraceSource.Switch.Level = SourceLevels.Verbose;
+				Log.AddChannel("nat", "nat.log");
+				NatDiscoverer.TraceSource.Listeners.Add(new TextWriterTraceListener(Log.Channels["nat"].Writer));
+
+				var natDiscoverer = new NatDiscoverer();
+				var token = new CancellationTokenSource(Game.Settings.Server.NatDiscoveryTimeout);
+				natDevices = await natDiscoverer.DiscoverDevicesAsync(PortMapper.Upnp, token);
+				foreach (var natDevice in natDevices)
+				{
+					try
+					{
+						ExternalIP = natDevice.GetExternalIPAsync().Result;
+					}
+					catch { }
+				}
 			}
 			catch (Exception e)
 			{
-				Log.Write("server", "Can't discover UPnP-enabled device: {0}", e);
-				Game.Settings.Server.NatDeviceAvailable = false;
+				Console.WriteLine("NAT discovery failed: {0}", e.Message);
+				Log.Write("nat", e.StackTrace);
 				Game.Settings.Server.AllowPortForward = false;
 			}
-		}
 
-		public static void StoppingNatDiscovery()
-		{
-			Log.Write("server", "Stopping NAT discovery.");
-			NatUtility.StopDiscovery();
-
-			if (natDevice == null || natDevice.GetType() != typeof(Mono.Nat.Upnp.UpnpNatDevice))
-			{
-				Log.Write("server",
-					"No NAT devices with UPnP enabled found within {0} ms deadline. Disabling automatic port forwarding.".F(Game.Settings.Server.NatDiscoveryTimeout));
-				Game.Settings.Server.NatDeviceAvailable = false;
-				Game.Settings.Server.AllowPortForward = false;
-			}
-		}
-
-		public static void DeviceFound(object sender, DeviceEventArgs args)
-		{
-			Log.Write("server", "NAT device discovered.");
-
-			Game.Settings.Server.NatDeviceAvailable = true;
 			Game.Settings.Server.AllowPortForward = true;
-
-			try
-			{
-				natDevice = args.Device;
-				Log.Write("server", "Type: {0}", natDevice.GetType());
-				Log.Write("server", "Your external IP is: {0}", natDevice.GetExternalIP());
-
-				foreach (var mp in natDevice.GetAllMappings())
-					Log.Write("server", "Existing port mapping: protocol={0}, public={1}, private={2}",
-						mp.Protocol, mp.PublicPort, mp.PrivatePort);
-			}
-			catch (Exception e)
-			{
-				Log.Write("server", "Can't fetch information from NAT device: {0}", e);
-
-				Game.Settings.Server.NatDeviceAvailable = false;
-				Game.Settings.Server.AllowPortForward = false;
-			}
 		}
 
-		public static void ForwardPort(int lifetime)
+		public static async void ForwardPort()
 		{
-			try
+			mapping = new Mapping(Protocol.Tcp, Game.Settings.Server.ListenPort, Game.Settings.Server.ExternalPort, "OpenRA");
+			foreach (var natDevice in natDevices)
 			{
-				var mapping = new Mapping(Protocol.Tcp, Game.Settings.Server.ExternalPort, Game.Settings.Server.ListenPort, lifetime);
-				natDevice.CreatePortMap(mapping);
-				Log.Write("server", "Create port mapping: protocol = {0}, public = {1}, private = {2}, lifetime = {3} s",
-					mapping.Protocol, mapping.PublicPort, mapping.PrivatePort, mapping.Lifetime);
-			}
-			catch (MappingException e)
-			{
-				if (e.ErrorCode == 725 && lifetime != 0)
+				try
 				{
-					Log.Write("server", "NAT device answered with OnlyPermanentLeasesSupported. Retrying...");
-					ForwardPort(0);
+					await natDevice.CreatePortMapAsync(mapping);
 				}
-				else
+				catch (Exception e)
 				{
-					Log.Write("server", "Can not forward ports via UPnP: {0}", e);
-					Game.Settings.Server.AllowPortForward = false;
+					Console.WriteLine("Port forwarding failed: {0}", e.Message);
 				}
 			}
 		}
 
-		public static void RemovePortforward()
+		public static async void RemovePortforward()
 		{
-			try
+			foreach (var natDevice in natDevices)
 			{
-				var mapping = new Mapping(Protocol.Tcp, Game.Settings.Server.ExternalPort, Game.Settings.Server.ListenPort);
-				natDevice.DeletePortMap(mapping);
-				Log.Write("server", "Remove port mapping: protocol = {0}, public = {1}, private = {2}, expiration = {3}",
-					mapping.Protocol, mapping.PublicPort, mapping.PrivatePort, mapping.Expiration);
-			}
-			catch (Exception e)
-			{
-				Log.Write("server", "Can not remove UPnP portforwarding rules: {0}", e);
-				Game.Settings.Server.AllowPortForward = false;
-			}
-		}
-
-		public static IPAddress GetExternalIP()
-		{
-			if (natDevice == null)
-				return null;
-
-			try
-			{
-				return natDevice.GetExternalIP();
-			}
-			catch (Exception e)
-			{
-				Log.Write("server", "Failed to get the external IP from NAT device: {0}", e);
-				return null;
+				try
+				{
+					await natDevice.DeletePortMapAsync(mapping);
+				}
+				catch (Exception e)
+				{
+					Console.WriteLine("Port removal failed: {0}", e.Message);
+				}
 			}
 		}
 	}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -31,6 +31,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -63,12 +63,6 @@
       <HintPath>..\thirdparty\download\SharpFont.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Nat">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-      <Package>mono.nat</Package>
-      <HintPath>..\thirdparty\download\Mono.Nat.dll</HintPath>
-    </Reference>
     <Reference Include="Eluant">
       <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
       <Private>False</Private>
@@ -88,6 +82,9 @@
     <Reference Include="SmarIrc4net">
       <HintPath>..\thirdparty\download\SmarIrc4net.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Open.Nat">
+      <HintPath>..\thirdparty\download\Open.Nat.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Server
 			randomSeed = (int)DateTime.Now.ToBinary();
 
 			if (Settings.AllowPortForward)
-				UPnP.ForwardPort(3600);
+				UPnP.ForwardPort();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
 				serverTraits.Add(modData.ObjectCreator.CreateObject<ServerTrait>(trait));

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -47,13 +47,8 @@ namespace OpenRA
 		[Desc("Set this to false to disable UPnP even if compatible devices are found.")]
 		public bool AllowPortForward = true;
 
-		public bool NatDeviceAvailable = false; // internal check if discovery succeeded
-
 		[Desc("Time in milliseconds to search for UPnP enabled NAT devices.")]
 		public int NatDiscoveryTimeout = 1000;
-
-		[Desc("Print very detailed logs for debugging issues with routers.")]
-		public bool VerboseNatDiscovery = false;
 
 		[Desc("Starts the game with a default map. Input as hash that can be obtained by the utility.")]
 		public string Map = null;

--- a/OpenRA.GameMonitor/OpenRA.GameMonitor.csproj
+++ b/OpenRA.GameMonitor/OpenRA.GameMonitor.csproj
@@ -7,6 +7,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>OpenRA</RootNamespace>
     <AssemblyName>OpenRA</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -30,6 +30,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -66,9 +67,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="Eluant">
       <HintPath>..\thirdparty\download\Eluant.dll</HintPath>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenRA.Mods.Common</RootNamespace>
     <AssemblyName>OpenRA.Mods.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -505,7 +505,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var address = orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
 			if (clientIndex == orderManager.LocalClient.Index && address == IPAddress.Loopback.ToString())
 			{
-				var externalIP = UPnP.GetExternalIP();
+				var externalIP = UPnP.ExternalIP;
 				if (externalIP != null)
 					address = externalIP.ToString();
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var checkboxUPnP = panel.Get<CheckboxWidget>("UPNP_CHECKBOX");
 			checkboxUPnP.IsChecked = () => allowPortForward;
 			checkboxUPnP.OnClick = () => allowPortForward ^= true;
-			checkboxUPnP.IsDisabled = () => !Game.Settings.Server.NatDeviceAvailable;
+			checkboxUPnP.IsDisabled = () => !Game.Settings.Server.AllowPortForward;
 
 			var passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");
 			if (passwordField != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -580,7 +580,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var gs = Game.Settings.Game;
 
 			BindCheckboxPref(panel, "NAT_DISCOVERY", ss, "DiscoverNatDevices");
-			BindCheckboxPref(panel, "VERBOSE_NAT_CHECKBOX", ss, "VerboseNatDiscovery");
 			BindCheckboxPref(panel, "PERFTEXT_CHECKBOX", ds, "PerfText");
 			BindCheckboxPref(panel, "PERFGRAPH_CHECKBOX", ds, "PerfGraph");
 			BindCheckboxPref(panel, "CHECKUNSYNCED_CHECKBOX", ds, "SanityCheckUnsyncedCode");
@@ -601,7 +600,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			return () =>
 			{
 				ss.DiscoverNatDevices = dss.DiscoverNatDevices;
-				ss.VerboseNatDiscovery = dss.VerboseNatDiscovery;
 				ds.PerfText = dds.PerfText;
 				ds.PerfGraph = dds.PerfGraph;
 				ds.SanityCheckUnsyncedCode = dds.SanityCheckUnsyncedCode;

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -30,6 +30,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -67,9 +68,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="Eluant">
       <HintPath>..\thirdparty\download\Eluant.dll</HintPath>

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -30,6 +30,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>OpenRA.Mods.TS</RootNamespace>
     <AssemblyName>OpenRA.Mods.TS</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>OpenRA.Platforms.Default</RootNamespace>
     <AssemblyName>OpenRA.Platforms.Default</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenRA.Platforms.Null/OpenRA.Platforms.Null.csproj
+++ b/OpenRA.Platforms.Null/OpenRA.Platforms.Null.csproj
@@ -29,6 +29,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenRA.Test</RootNamespace>
     <AssemblyName>OpenRA.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/OpenRA.Utility/OpenRA.Utility.csproj
+++ b/OpenRA.Utility/OpenRA.Utility.csproj
@@ -30,6 +30,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -56,9 +57,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -528,13 +528,6 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Show Bot Debug Messages
-						Checkbox@VERBOSE_NAT_CHECKBOX:
-							X: 310
-							Y: 160
-							Width: 300
-							Height: 20
-							Font: Regular
-							Text: Detailed NAT logging
 						Checkbox@CHECKUNSYNCED_CHECKBOX:
 							X: 15
 							Y: 190
@@ -544,7 +537,7 @@ Container@SETTINGS_PANEL:
 							Text: Check Sync around Unsynced Code
 						Checkbox@LUADEBUG_CHECKBOX:
 							X: 310
-							Y: 190
+							Y: 160
 							Width: 300
 							Height: 20
 							Font: Regular

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -529,13 +529,6 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Show Bot Debug Messages
-				Checkbox@VERBOSE_NAT_CHECKBOX:
-					X: 310
-					Y: 160
-					Width: 300
-					Height: 20
-					Font: Regular
-					Text: Detailed NAT logging
 				Checkbox@CHECKUNSYNCED_CHECKBOX:
 					X: 15
 					Y: 190
@@ -545,7 +538,7 @@ Background@SETTINGS_PANEL:
 					Text: Check Sync around Unsynced Code
 				Checkbox@LUADEBUG_CHECKBOX:
 					X: 310
-					Y: 190
+					Y: 160
 					Width: 300
 					Height: 20
 					Font: Regular

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -89,7 +89,7 @@ Section "Game" GAME
 	File "${SRCDIR}\OpenRA.Platforms.Default.dll"
 	File "${SRCDIR}\ICSharpCode.SharpZipLib.dll"
 	File "${SRCDIR}\FuzzyLogicLibrary.dll"
-	File "${SRCDIR}\Mono.Nat.dll"
+	File "${SRCDIR}\Open.Nat.dll"
 	File "${SRCDIR}\AUTHORS"
 	File "${SRCDIR}\COPYING"
 	File "${SRCDIR}\README.html"
@@ -194,7 +194,7 @@ Function ${UN}Clean
 	Delete $INSTDIR\OpenRA.Platforms.Default.dll
 	Delete $INSTDIR\ICSharpCode.SharpZipLib.dll
 	Delete $INSTDIR\FuzzyLogicLibrary.dll
-	Delete $INSTDIR\Mono.Nat.dll
+	Delete $INSTDIR\Open.Nat.dll
 	Delete $INSTDIR\SharpFont.dll
 	Delete $INSTDIR\AUTHORS
 	Delete $INSTDIR\COPYING

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -148,14 +148,14 @@ Section "-DotNet" DotNet
 	IfErrors error 0
 	IntCmp $0 1 done error done
 	error:
-		MessageBox MB_YESNO ".NET Framework v4.0 or later is required to run OpenRA. $\n \
+		MessageBox MB_YESNO ".NET Framework v4.5.2 or later is required to run OpenRA. $\n \
 		Do you wish for the installer to launch your web browser in order to download and install it?" \
 		IDYES download IDNO error2
 	download:
-		ExecShell "open" "http://www.microsoft.com/en-us/download/details.aspx?id=17113"
+		ExecShell "open" "http://www.microsoft.com/en-us/download/details.aspx?id=42643"
 		Goto done
 	error2:
-		MessageBox MB_OK "Installation will continue, but be aware that OpenRA will not run unless .NET v4.0 \
+		MessageBox MB_OK "Installation will continue, but be aware that OpenRA will not run unless .NET v4.5.2 \
 		or later is installed."
 	done:
 SectionEnd

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -76,12 +76,12 @@ if (!(Test-Path "windows/SDL2.dll"))
 	rmdir sdl2.redist -Recurse
 }
 
-if (!(Test-Path "Mono.Nat.dll"))
+if (!(Test-Path "Open.Nat.dll"))
 {
-	echo "Fetching Mono.Nat from NuGet."
-	./nuget.exe install Mono.Nat -Version 1.2.21 -ExcludeVersion
-	cp Mono.Nat/lib/net40/Mono.Nat.dll .
-	rmdir Mono.Nat -Recurse
+	echo "Fetching Open.Nat from NuGet."
+	./nuget.exe install Open.Nat -Version 2.0.14 -ExcludeVersion
+	cp Open.NAT/lib/net45/Open.Nat.dll .
+	rmdir Open.Nat -Recurse
 }
 
 if (!(Test-Path "windows/lua51.dll"))

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -88,11 +88,11 @@ if [ ! -f nunit-console.exe ]; then
 	rm -rf NUnit.Runners
 fi
 
-if [ ! -f Mono.Nat.dll ]; then
-	echo "Fetching Mono.Nat from NuGet"
-	get Mono.Nat 1.2.21
-	cp ./Mono.Nat/lib/net40/Mono.Nat.dll .
-	rm -rf Mono.Nat
+if [ ! -f Open.Nat.dll ]; then
+	echo "Fetching Open.Nat from NuGet"
+	get Open.Nat 2.0.14
+	cp ./Open.NAT/lib/net45/Open.Nat.dll .
+	rm -rf Open.Nat
 fi
 
 if [ ! -f FuzzyLogicLibrary.dll ]; then


### PR DESCRIPTION
https://github.com/lontivero/Open.NAT/wiki/Why-Open.NAT

Closes https://github.com/OpenRA/OpenRA/issues/7140.
Fixes https://github.com/OpenRA/OpenRA/issues/8794.
Depends on https://github.com/OpenRA/OpenRA/pull/10279.

It also deprecates the `Settings.Server.NatDeviceAvailable` helper variable and always logs into `nat.log` (so we can get rid of `Settings.Server.VerboseNatDiscovery` as well) as even in verbose mode it is now pretty readable as Open.NAT only searches for NAT devices, not every other UPnP enabled device in the network.
