### PR TITLE
Replace MiniTK.Graphics with custom OpenGL shim.

### DIFF
--- a/OpenRA.Platforms.Default/ErrorHandler.cs
+++ b/OpenRA.Platforms.Default/ErrorHandler.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Diagnostics;
-using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Platforms.Default
 {
@@ -18,7 +17,7 @@ namespace OpenRA.Platforms.Default
 	{
 		public static void CheckGlVersion()
 		{
-			var versionString = GL.GetString(StringName.Version);
+			var versionString = OpenGL.glGetString(OpenGL.GL_VERSION);
 			var version = versionString.Contains(" ") ? versionString.Split(' ')[0].Split('.') : versionString.Split('.');
 
 			var major = 0;
@@ -39,8 +38,8 @@ namespace OpenRA.Platforms.Default
 
 		public static void CheckGlError()
 		{
-			var n = GL.GetError();
-			if (n != ErrorCode.NoError)
+			var n = OpenGL.glGetError();
+			if (n != OpenGL.GL_NO_ERROR)
 			{
 				var error = "GL Error: {0}\n{1}".F(n, new StackTrace());
 				WriteGraphicsLog(error);
@@ -53,8 +52,9 @@ namespace OpenRA.Platforms.Default
 			Log.Write("graphics", message);
 			Log.Write("graphics", "");
 			Log.Write("graphics", "OpenGL Information:");
-			Log.Write("graphics", "Vendor: {0}", GL.GetString(StringName.Vendor));
-			if (GL.GetString(StringName.Vendor).Contains("Microsoft"))
+			var vendor = OpenGL.glGetString(OpenGL.GL_VENDOR);
+			Log.Write("graphics", "Vendor: {0}", vendor);
+			if (vendor.Contains("Microsoft"))
 			{
 				var msg = "";
 				msg += "Note:  The default driver provided by Microsoft does not include full OpenGL support.\n";
@@ -62,11 +62,11 @@ namespace OpenRA.Platforms.Default
 				Log.Write("graphics", msg);
 			}
 
-			Log.Write("graphics", "Renderer: {0}", GL.GetString(StringName.Renderer));
-			Log.Write("graphics", "GL Version: {0}", GL.GetString(StringName.Version));
-			Log.Write("graphics", "Shader Version: {0}", GL.GetString(StringName.ShadingLanguageVersion));
+			Log.Write("graphics", "Renderer: {0}", OpenGL.glGetString(OpenGL.GL_RENDERER));
+			Log.Write("graphics", "GL Version: {0}", OpenGL.glGetString(OpenGL.GL_VERSION));
+			Log.Write("graphics", "Shader Version: {0}", OpenGL.glGetString(OpenGL.GL_SHADING_LANGUAGE_VERSION));
 			Log.Write("graphics", "Available extensions:");
-			Log.Write("graphics", GL.GetString(StringName.Extensions));
+			Log.Write("graphics", OpenGL.glGetString(OpenGL.GL_EXTENSIONS));
 		}
 	}
 }

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -1,0 +1,413 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Text;
+using SDL2;
+
+namespace OpenRA.Platforms.Default
+{
+	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter",
+		Justification = "C-style naming is kept for consistency with the underlying native API.")]
+	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1310:FieldNamesMustNotContainUnderscore",
+		Justification = "C-style naming is kept for consistency with the underlying native API.")]
+	internal static class OpenGL
+	{
+		public const int GL_FALSE = 0;
+
+		// ClearBufferMask
+		public const int GL_COLOR_BUFFER_BIT = 0x4000;
+		public const int GL_DEPTH_BUFFER_BIT = 0x0100;
+		public const int GL_STENCIL_BUFFER_BIT = 0x0400;
+
+		// Data types
+		public const int GL_UNSIGNED_BYTE = 0x1401;
+		public const int GL_FLOAT = 0x1406;
+
+		// Errors
+		public const int GL_NO_ERROR = 0;
+
+		// BeginMode
+		public const int GL_POINTS = 0;
+		public const int GL_LINES = 0x0001;
+		public const int GL_TRIANGLES = 0x0004;
+
+		// EnableCap
+		public const int GL_ALPHA_TEST = 0x0BC0;
+		public const int GL_BLEND = 0x0BE2;
+		public const int GL_STENCIL_TEST = 0x0B90;
+		public const int GL_DEPTH_TEST = 0x0B71;
+		public const int GL_SCISSOR_TEST = 0x0C11;
+
+		// Texture mapping
+		public const int GL_TEXTURE_2D = 0x0DE1;
+		public const int GL_TEXTURE_WRAP_S = 0x2802;
+		public const int GL_TEXTURE_WRAP_T = 0x2803;
+		public const int GL_TEXTURE_MAG_FILTER = 0x2800;
+		public const int GL_TEXTURE_MIN_FILTER = 0x2801;
+		public const int GL_NEAREST = 0x2600;
+		public const int GL_LINEAR = 0x2601;
+
+		// Depth buffer
+		public const int GL_DEPTH_COMPONENT = 0x1902;
+
+		// BlendingFactorDest
+		public const int GL_ZERO = 0;
+		public const int GL_ONE = 1;
+		public const int GL_SRC_COLOR = 0x0300;
+		public const int GL_ONE_MINUS_SRC_COLOR = 0x0301;
+		public const int GL_SRC_ALPHA = 0x0302;
+		public const int GL_ONE_MINUS_SRC_ALPHA = 0x0303;
+		public const int GL_DST_ALPHA = 0x0304;
+		public const int GL_ONE_MINUS_DST_ALPHA = 0x0305;
+		public const int GL_DST_COLOR = 0x0306;
+		public const int GL_ONE_MINUS_DST_COLOR = 0x0307;
+
+		// GL_ARB_imaging
+		public const int GL_FUNC_ADD = 0x8006;
+		public const int GL_FUNC_SUBTRACT = 0x800A;
+		public const int GL_FUNC_REVERSE_SUBTRACT = 0x800B;
+		public const int GL_BLEND_COLOR = 0x8005;
+
+		// OpenGL 1.1 - 1.5
+		public const int GL_CLIENT_PIXEL_STORE_BIT = 0x0001;
+		public const int GL_BGRA = 0x80E1;
+		public const int GL_RGBA8 = 0x8058;
+		public const int GL_CLAMP_TO_EDGE = 0x812F;
+		public const int GL_TEXTURE_BASE_LEVEL = 0x813C;
+		public const int GL_TEXTURE_MAX_LEVEL = 0x813D;
+
+		public const int GL_ARRAY_BUFFER = 0x8892;
+		public const int GL_DYNAMIC_DRAW = 0x88E8;
+
+		public const int GL_TEXTURE0 = 0x84C0;
+
+		// OpenGL 2
+		public const int GL_FRAGMENT_SHADER = 0x8B30;
+		public const int GL_VERTEX_SHADER = 0x8B31;
+		public const int GL_SAMPLER_2D = 0x8B5E;
+		public const int GL_COMPILE_STATUS = 0x8B81;
+		public const int GL_LINK_STATUS = 0x8B82;
+		public const int GL_INFO_LOG_LENGTH = 0x8B84;
+		public const int GL_ACTIVE_UNIFORMS = 0x8B86;
+
+		// Pixel Mode / Transfer
+		public const int GL_PACK_ROW_LENGTH = 0x0D02;
+		public const int GL_PACK_ALIGNMENT = 0x0D05;
+
+		// Gets
+		public const int GL_VIEWPORT = 0x0BA2;
+
+		// Utility
+		public const int GL_VENDOR = 0x1F00;
+		public const int GL_RENDERER = 0x1F01;
+		public const int GL_VERSION = 0x1F02;
+		public const int GL_EXTENSIONS = 0x1F03;
+		public const int GL_SHADING_LANGUAGE_VERSION = 0x8B8C;
+
+		// Framebuffers
+		public const int FRAMEBUFFER_EXT = 0x8D40;
+		public const int RENDERBUFFER_EXT = 0x8D41;
+		public const int COLOR_ATTACHMENT0_EXT = 0x8CE0;
+		public const int DEPTH_ATTACHMENT_EXT = 0x8D00;
+		public const int FRAMEBUFFER_COMPLETE_EXT = 0x8CD5;
+
+		public delegate void Flush();
+		public static Flush glFlush { get; private set; }
+
+		public delegate void Viewport(int x, int y, int width, int height);
+		public static Viewport glViewport { get; private set; }
+
+		public delegate void Clear(int mask);
+		public static Clear glClear { get; private set; }
+
+		public delegate void ClearColor(float red, float green, float blue, float alpha);
+		public static ClearColor glClearColor { get; private set; }
+
+		public delegate int GetError();
+		public static GetError glGetError { get; private set; }
+
+		delegate IntPtr GetString(int name);
+		static GetString glGetStringInternal;
+
+		public static string glGetString(int name)
+		{
+			unsafe
+			{
+				return new string((sbyte*)glGetStringInternal(name));
+			}
+		}
+
+		public unsafe delegate int GetIntegerv(int pname, int* param);
+		public static GetIntegerv glGetIntegerv { get; private set; }
+
+		public delegate void Finish();
+		public static Finish glFinish { get; private set; }
+
+		public delegate uint CreateProgram();
+		public static CreateProgram glCreateProgram { get; private set; }
+
+		public delegate void UseProgram(uint program);
+		public static UseProgram glUseProgram { get; private set; }
+
+		public delegate void GetProgramiv(uint program, int pname, out int param);
+		public static GetProgramiv glGetProgramiv { get; private set; }
+
+		public delegate uint CreateShader(int shaderType);
+		public static CreateShader glCreateShader { get; private set; }
+
+		public delegate void ShaderSource(uint shader, int count, string[] str, IntPtr length);
+		public static ShaderSource glShaderSource { get; private set; }
+
+		public delegate void CompileShader(uint shader);
+		public static CompileShader glCompileShader { get; private set; }
+
+		public delegate int GetShaderiv(uint shader, int name, out int param);
+		public static GetShaderiv glGetShaderiv { get; private set; }
+
+		public delegate void AttachShader(uint program, uint shader);
+		public static AttachShader glAttachShader { get; private set; }
+
+		public delegate void GetShaderInfoLog(uint shader, int maxLength, out int length, StringBuilder infoLog);
+		public static GetShaderInfoLog glGetShaderInfoLog { get; private set; }
+
+		public delegate void LinkProgram(uint program);
+		public static LinkProgram glLinkProgram { get; private set; }
+
+		public delegate void GetProgramInfoLog(uint program, int maxLength, out int length, StringBuilder infoLog);
+		public static GetProgramInfoLog glGetProgramInfoLog { get; private set; }
+
+		public delegate int GetUniformLocation(uint program, string name);
+		public static GetUniformLocation glGetUniformLocation { get; private set; }
+
+		public delegate void GetActiveUniform(uint program, int index, int bufSize,
+			out int length, out int size, out int type, StringBuilder name);
+		public static GetActiveUniform glGetActiveUniform { get; private set; }
+
+		public delegate void Uniform1i(int location, int v0);
+		public static Uniform1i glUniform1i { get; private set; }
+
+		public delegate void Uniform1f(int location, float v0);
+		public static Uniform1f glUniform1f { get; private set; }
+
+		public delegate void Uniform2f(int location, float v0, float v1);
+		public static Uniform2f glUniform2f { get; private set; }
+
+		public delegate void Uniform1fv(int location, int count, IntPtr value);
+		public static Uniform1fv glUniform1fv { get; private set; }
+
+		public delegate void Uniform2fv(int location, int count, IntPtr value);
+		public static Uniform2fv glUniform2fv { get; private set; }
+
+		public delegate void Uniform3fv(int location, int count, IntPtr value);
+		public static Uniform3fv glUniform3fv { get; private set; }
+
+		public delegate void Uniform4fv(int location, int count, IntPtr value);
+		public static Uniform4fv glUniform4fv { get; private set; }
+
+		public delegate void UniformMatrix4fv(int location, int count, bool transpose, IntPtr value);
+		public static UniformMatrix4fv glUniformMatrix4fv { get; private set; }
+
+		public delegate void GenBuffers(int n, out uint buffers);
+		public static GenBuffers glGenBuffers { get; private set; }
+
+		public delegate void BindBuffer(int target, uint buffer);
+		public static BindBuffer glBindBuffer { get; private set; }
+
+		public delegate void BufferData(int target, IntPtr size, IntPtr data, int usage);
+		public static BufferData glBufferData { get; private set; }
+
+		public delegate void BufferSubData(int target, IntPtr offset, IntPtr size, IntPtr data);
+		public static BufferSubData glBufferSubData { get; private set; }
+
+		public delegate void DeleteBuffers(int n, ref uint buffers);
+		public static DeleteBuffers glDeleteBuffers { get; private set; }
+
+		public delegate void BindAttribLocation(uint program, int index, string name);
+		public static BindAttribLocation glBindAttribLocation { get; private set; }
+
+		public delegate void VertexAttribPointer(int index, int size, int type, bool normalized,
+			int stride, IntPtr pointer);
+		public static VertexAttribPointer glVertexAttribPointer { get; private set; }
+
+		public delegate void EnableVertexAttribArray(int index);
+		public static EnableVertexAttribArray glEnableVertexAttribArray { get; private set; }
+
+		public delegate void DisableVertexAttribArray(int index);
+		public static DisableVertexAttribArray glDisableVertexAttribArray { get; private set; }
+
+		public delegate void DrawArrays(int mode, int first, int count);
+		public static DrawArrays glDrawArrays { get; private set; }
+
+		public delegate void Enable(int cap);
+		public static Enable glEnable { get; private set; }
+
+		public delegate void Disable(int cap);
+		public static Disable glDisable { get; private set; }
+
+		public delegate void BlendEquation(int mode);
+		public static BlendEquation glBlendEquation { get; private set; }
+
+		public delegate void BlendFunc(int sfactor, int dfactor);
+		public static BlendFunc glBlendFunc { get; private set; }
+
+		public delegate void Scissor(int x, int y, int width, int height);
+		public static Scissor glScissor { get; private set; }
+
+		public delegate void PushClientAttrib(int mask);
+		public static PushClientAttrib glPushClientAttrib { get; private set; }
+
+		public delegate void PopClientAttrib();
+		public static PopClientAttrib glPopClientAttrib { get; private set; }
+
+		public delegate void PixelStoref(int param, float pname);
+		public static PixelStoref glPixelStoref { get; private set; }
+
+		public delegate void ReadPixels(int x, int y, int width, int height,
+			int format, int type, IntPtr data);
+		public static ReadPixels glReadPixels { get; private set; }
+
+		public delegate void GenTextures(int n, out uint textures);
+		public static GenTextures glGenTextures { get; private set; }
+
+		public delegate void DeleteTextures(int n, ref uint textures);
+		public static DeleteTextures glDeleteTextures { get; private set; }
+
+		public delegate void BindTexture(int target, uint texture);
+		public static BindTexture glBindTexture { get; private set; }
+
+		public delegate void ActiveTexture(int texture);
+		public static ActiveTexture glActiveTexture { get; private set; }
+
+		public delegate void TexImage2D(int target, int level, int internalFormat,
+			int width, int height, int border, int format, int type, IntPtr pixels);
+		public static TexImage2D glTexImage2D { get; private set; }
+
+		public delegate void GetTexImage(int target, int level,
+			int format, int type, IntPtr pixels);
+		public static GetTexImage glGetTexImage { get; private set; }
+
+		public delegate void TexParameteri(int target, int pname, int param);
+		public static TexParameteri glTexParameteri { get; private set; }
+
+		public delegate void TexParameterf(int target, int pname, float param);
+		public static TexParameterf glTexParameterf { get; private set; }
+
+		public delegate void GenFramebuffersEXT(int n, out uint framebuffers);
+		public static GenFramebuffersEXT glGenFramebuffersEXT { get; private set; }
+
+		public delegate void BindFramebufferEXT(int target, uint framebuffer);
+		public static BindFramebufferEXT glBindFramebufferEXT { get; private set; }
+
+		public delegate void FramebufferTexture2DEXT(int target, int attachment,
+			int textarget, uint texture, int level);
+		public static FramebufferTexture2DEXT glFramebufferTexture2DEXT { get; private set; }
+
+		public delegate void DeleteFramebuffersEXT(int n, ref uint framebuffers);
+		public static DeleteFramebuffersEXT glDeleteFramebuffersEXT { get; private set; }
+
+		public delegate void GenRenderbuffersEXT(int n, out uint renderbuffers);
+		public static GenRenderbuffersEXT glGenRenderbuffersEXT { get; private set; }
+
+		public delegate void BindRenderbufferEXT(int target, uint renderbuffer);
+		public static BindRenderbufferEXT glBindRenderbufferEXT { get; private set; }
+
+		public delegate void RenderbufferStorageEXT(int target, int internalformat,
+			int width, int height);
+		public static RenderbufferStorageEXT glRenderbufferStorageEXT { get; private set; }
+
+		public delegate void DeleteRenderbuffersEXT(int n, ref uint renderbuffers);
+		public static DeleteRenderbuffersEXT glDeleteRenderbuffersEXT { get; private set; }
+
+		public delegate void FramebufferRenderbufferEXT(int target, int attachment,
+			int renderbuffertarget, uint renderbuffer);
+		public static FramebufferRenderbufferEXT glFramebufferRenderbufferEXT { get; private set; }
+
+		public delegate int CheckFramebufferStatus(int target);
+		public static CheckFramebufferStatus glCheckFramebufferStatus { get; private set; }
+
+		public static void LoadDelegates()
+		{
+			glFlush = Bind<Flush>("glFlush");
+			glViewport = Bind<Viewport>("glViewport");
+			glClear = Bind<Clear>("glClear");
+			glClearColor = Bind<ClearColor>("glClearColor");
+			glGetError = Bind<GetError>("glGetError");
+			glGetStringInternal = Bind<GetString>("glGetString");
+			glGetIntegerv = Bind<GetIntegerv>("glGetIntegerv");
+			glFinish = Bind<Finish>("glFinish");
+			glCreateProgram = Bind<CreateProgram>("glCreateProgram");
+			glUseProgram = Bind<UseProgram>("glUseProgram");
+			glGetProgramiv = Bind<GetProgramiv>("glGetProgramiv");
+			glCreateShader = Bind<CreateShader>("glCreateShader");
+			glShaderSource = Bind<ShaderSource>("glShaderSource");
+			glCompileShader = Bind<CompileShader>("glCompileShader");
+			glGetShaderiv = Bind<GetShaderiv>("glGetShaderiv");
+			glAttachShader = Bind<AttachShader>("glAttachShader");
+			glGetShaderInfoLog = Bind<GetShaderInfoLog>("glGetShaderInfoLog");
+			glLinkProgram = Bind<LinkProgram>("glLinkProgram");
+			glGetProgramInfoLog = Bind<GetProgramInfoLog>("glGetProgramInfoLog");
+			glGetUniformLocation = Bind<GetUniformLocation>("glGetUniformLocation");
+			glGetActiveUniform = Bind<GetActiveUniform>("glGetActiveUniform");
+			glUniform1i = Bind<Uniform1i>("glUniform1i");
+			glUniform1f = Bind<Uniform1f>("glUniform1f");
+			glUniform2f = Bind<Uniform2f>("glUniform2f");
+			glUniform1fv = Bind<Uniform1fv>("glUniform1fv");
+			glUniform2fv = Bind<Uniform2fv>("glUniform2fv");
+			glUniform3fv = Bind<Uniform3fv>("glUniform3fv");
+			glUniform4fv = Bind<Uniform4fv>("glUniform4fv");
+			glUniformMatrix4fv = Bind<UniformMatrix4fv>("glUniformMatrix4fv");
+			glGenBuffers = Bind<GenBuffers>("glGenBuffers");
+			glBindBuffer = Bind<BindBuffer>("glBindBuffer");
+			glBufferData = Bind<BufferData>("glBufferData");
+			glBufferSubData = Bind<BufferSubData>("glBufferSubData");
+			glDeleteBuffers = Bind<DeleteBuffers>("glDeleteBuffers");
+			glBindAttribLocation = Bind<BindAttribLocation>("glBindAttribLocation");
+			glVertexAttribPointer = Bind<VertexAttribPointer>("glVertexAttribPointer");
+			glEnableVertexAttribArray = Bind<EnableVertexAttribArray>("glEnableVertexAttribArray");
+			glDisableVertexAttribArray = Bind<DisableVertexAttribArray>("glDisableVertexAttribArray");
+			glDrawArrays = Bind<DrawArrays>("glDrawArrays");
+			glEnable = Bind<Enable>("glEnable");
+			glDisable = Bind<Disable>("glDisable");
+			glBlendEquation = Bind<BlendEquation>("glBlendEquation");
+			glBlendFunc = Bind<BlendFunc>("glBlendFunc");
+			glScissor = Bind<Scissor>("glScissor");
+			glPushClientAttrib = Bind<PushClientAttrib>("glPushClientAttrib");
+			glPopClientAttrib = Bind<PopClientAttrib>("glPopClientAttrib");
+			glPixelStoref = Bind<PixelStoref>("glPixelStoref");
+			glReadPixels = Bind<ReadPixels>("glReadPixels");
+			glGenTextures = Bind<GenTextures>("glGenTextures");
+			glDeleteTextures = Bind<DeleteTextures>("glDeleteTextures");
+			glBindTexture = Bind<BindTexture>("glBindTexture");
+			glActiveTexture = Bind<ActiveTexture>("glActiveTexture");
+			glTexImage2D = Bind<TexImage2D>("glTexImage2D");
+			glGetTexImage = Bind<GetTexImage>("glGetTexImage");
+			glTexParameteri = Bind<TexParameteri>("glTexParameteri");
+			glTexParameterf = Bind<TexParameterf>("glTexParameterf");
+			glGenFramebuffersEXT = Bind<GenFramebuffersEXT>("glGenFramebuffersEXT");
+			glBindFramebufferEXT = Bind<BindFramebufferEXT>("glBindFramebufferEXT");
+			glFramebufferTexture2DEXT = Bind<FramebufferTexture2DEXT>("glFramebufferTexture2DEXT");
+			glDeleteFramebuffersEXT = Bind<DeleteFramebuffersEXT>("glDeleteFramebuffersEXT");
+			glGenRenderbuffersEXT = Bind<GenRenderbuffersEXT>("glGenRenderbuffersEXT");
+			glBindRenderbufferEXT = Bind<BindRenderbufferEXT>("glBindRenderbufferEXT");
+			glRenderbufferStorageEXT = Bind<RenderbufferStorageEXT>("glRenderbufferStorageEXT");
+			glDeleteRenderbuffersEXT = Bind<DeleteRenderbuffersEXT>("glDeleteRenderbuffersEXT");
+			glFramebufferRenderbufferEXT = Bind<FramebufferRenderbufferEXT>("glFramebufferRenderbufferEXT");
+			glCheckFramebufferStatus = Bind<CheckFramebufferStatus>("glCheckFramebufferStatus");
+		}
+
+		static T Bind<T>(string name)
+		{
+			return (T)(object)Marshal.GetDelegateForFunctionPointer(SDL.SDL_GL_GetProcAddress(name), typeof(T));
+		}
+	}
+}

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ThreadAffine.cs" />
     <Compile Include="VertexBuffer.cs" />
     <Compile Include="OpenAlSoundEngine.cs" />
+    <Compile Include="OpenGL.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -12,16 +12,15 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using OpenTK.Graphics.OpenGL;
 
 namespace OpenRA.Platforms.Default
 {
 	sealed class Texture : ThreadAffine, ITexture
 	{
-		int texture;
+		uint texture;
 		TextureScaleFilter scaleFilter;
 
-		public int ID { get { return texture; } }
+		public uint ID { get { return texture; } }
 		public Size Size { get; private set; }
 
 		bool disposed;
@@ -46,13 +45,13 @@ namespace OpenRA.Platforms.Default
 
 		public Texture()
 		{
-			GL.GenTextures(1, out texture);
+			OpenGL.glGenTextures(1, out texture);
 			ErrorHandler.CheckGlError();
 		}
 
 		public Texture(Bitmap bitmap)
 		{
-			GL.GenTextures(1, out texture);
+			OpenGL.glGenTextures(1, out texture);
 			ErrorHandler.CheckGlError();
 			SetData(bitmap);
 		}
@@ -60,23 +59,23 @@ namespace OpenRA.Platforms.Default
 		void PrepareTexture()
 		{
 			ErrorHandler.CheckGlError();
-			GL.BindTexture(TextureTarget.Texture2D, texture);
+			OpenGL.glBindTexture(OpenGL.GL_TEXTURE_2D, texture);
 			ErrorHandler.CheckGlError();
 
-			var filter = scaleFilter == TextureScaleFilter.Linear ? (int)TextureMinFilter.Linear : (int)TextureMinFilter.Nearest;
-			GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, filter);
+			var filter = scaleFilter == TextureScaleFilter.Linear ? OpenGL.GL_LINEAR : OpenGL.GL_NEAREST;
+			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_MAG_FILTER, (int)filter);
 			ErrorHandler.CheckGlError();
-			GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, filter);
-			ErrorHandler.CheckGlError();
-
-			GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (float)TextureWrapMode.ClampToEdge);
-			ErrorHandler.CheckGlError();
-			GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (float)TextureWrapMode.ClampToEdge);
+			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_MIN_FILTER, (int)filter);
 			ErrorHandler.CheckGlError();
 
-			GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
+			OpenGL.glTexParameterf(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_WRAP_S, (float)OpenGL.GL_CLAMP_TO_EDGE);
 			ErrorHandler.CheckGlError();
-			GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 0);
+			OpenGL.glTexParameterf(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_WRAP_T, (float)OpenGL.GL_CLAMP_TO_EDGE);
+			ErrorHandler.CheckGlError();
+
+			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_BASE_LEVEL, 0);
+			ErrorHandler.CheckGlError();
+			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_MAX_LEVEL, 0);
 			ErrorHandler.CheckGlError();
 		}
 
@@ -93,8 +92,8 @@ namespace OpenRA.Platforms.Default
 				{
 					var intPtr = new IntPtr((void*)ptr);
 					PrepareTexture();
-					GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, width, height,
-						0, OpenTK.Graphics.OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, intPtr);
+					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, width, height,
+						0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
 					ErrorHandler.CheckGlError();
 				}
 			}
@@ -117,8 +116,8 @@ namespace OpenRA.Platforms.Default
 				{
 					var intPtr = new IntPtr((void*)ptr);
 					PrepareTexture();
-					GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, width, height,
-						0, OpenTK.Graphics.OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, intPtr);
+					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, width, height,
+						0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
 					ErrorHandler.CheckGlError();
 				}
 			}
@@ -141,8 +140,8 @@ namespace OpenRA.Platforms.Default
 					ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
 				PrepareTexture();
-				GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, bits.Width, bits.Height,
-					0, OpenTK.Graphics.OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, bits.Scan0); // TODO: weird strides
+				OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, bits.Width, bits.Height,
+					0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, bits.Scan0); // TODO: weird strides
 				ErrorHandler.CheckGlError();
 				bitmap.UnlockBits(bits);
 			}
@@ -159,13 +158,14 @@ namespace OpenRA.Platforms.Default
 			var data = new byte[4 * Size.Width * Size.Height];
 
 			ErrorHandler.CheckGlError();
-			GL.BindTexture(TextureTarget.Texture2D, texture);
+			OpenGL.glBindTexture(OpenGL.GL_TEXTURE_2D, texture);
 			unsafe
 			{
 				fixed (byte* ptr = &data[0])
 				{
 					var intPtr = new IntPtr((void*)ptr);
-					GL.GetTexImage(TextureTarget.Texture2D, 0, OpenTK.Graphics.OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, intPtr);
+					OpenGL.glGetTexImage(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_BGRA,
+						OpenGL.GL_UNSIGNED_BYTE, intPtr);
 				}
 			}
 
@@ -181,8 +181,8 @@ namespace OpenRA.Platforms.Default
 
 			Size = new Size(width, height);
 			PrepareTexture();
-			GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, width, height,
-				0, OpenTK.Graphics.OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, IntPtr.Zero);
+			OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, width, height,
+				0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, IntPtr.Zero);
 			ErrorHandler.CheckGlError();
 		}
 
@@ -202,7 +202,7 @@ namespace OpenRA.Platforms.Default
 			if (disposed)
 				return;
 			disposed = true;
-			GL.DeleteTextures(1, ref texture);
+			OpenGL.glDeleteTextures(1, ref texture);
 		}
 	}
 }


### PR DESCRIPTION
This replaces the ~30k line monster that's hidden in our custom sdl2-cs.dll with a minimal shim that only exposes the functionality that we actually need and uses the proper c-style conventions.  This removes the relatively long delay (at least on my machine) between window creation and first render, and gets us a step closer to being able to use the "official" sdl2-cs library.

Depends on #10249 which currently makes up the first 6 commits in this pr (don't review these here!).
