### PR TITLE
Reworking ReplayRecorderConnection to be not be a Connection

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -49,9 +49,9 @@ namespace OpenRA
 
 		public static OrderManager JoinServer(string host, int port, string password, bool recordReplay = true)
 		{
-			IConnection connection = new NetworkConnection(host, port);
+			var connection = new NetworkConnection(host, port);
 			if (recordReplay)
-				connection = new ReplayRecorderConnection(connection, TimestampedFilename);
+				connection.StartRecording(TimestampedFilename);
 
 			var om = new OrderManager(host, port, password, connection);
 			JoinInner(om);

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Network
 		}
 
 		protected List<ReceivedPacket> receivedPackets = new List<ReceivedPacket>();
+		public ReplayRecorder Recorder { get; private set; }
 
 		public virtual int LocalClientId
 		{
@@ -99,10 +100,26 @@ namespace OpenRA.Network
 			}
 
 			foreach (var p in packets)
+			{
 				packetFn(p.FromClient, p.Data);
+				if (Recorder != null)
+					Recorder.Receive(p.FromClient, p.Data);
+			}
 		}
 
-		protected virtual void Dispose(bool disposing) { }
+		public void StartRecording(Func<string> chooseFilename)
+		{
+			// If we have a previous recording then save/dispose it and start a new one.
+			if (Recorder != null)
+				Recorder.Dispose();
+			Recorder = new ReplayRecorder(chooseFilename);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (disposing && Recorder != null)
+				Recorder.Dispose();
+		}
 
 		public void Dispose()
 		{

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -188,7 +188,7 @@
     <Compile Include="World.cs" />
     <Compile Include="WorldUtils.cs" />
     <Compile Include="VoiceExts.cs" />
-    <Compile Include="Network\ReplayRecorderConnection.cs" />
+    <Compile Include="Network\ReplayRecorder.cs" />
     <Compile Include="Traits\DebugPauseState.cs" />
     <Compile Include="Network\UPnP.cs" />
     <Compile Include="Graphics\Renderable.cs" />

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -211,7 +211,9 @@ namespace OpenRA
 			foreach (var player in Players)
 				gameInfo.AddPlayer(player, OrderManager.LobbyInfo);
 
-			var rc = OrderManager.Connection as ReplayRecorderConnection;
+			var echo = OrderManager.Connection as EchoConnection;
+			var rc = echo != null ? echo.Recorder : null;
+
 			if (rc != null)
 				rc.Metadata = new ReplayMetadata(gameInfo);
 		}


### PR DESCRIPTION
I made it so that the ReplayRecorder is no longer a connection itself but a component of certain connections. This allows one to keep a connection but create a new Replay by disposing of the old one and then starting a new one. 

This also removes a large amount of complexity from the recorder which was mostly forwarding to an actual connection and modifying some functions
