### PR TITLE
Update the default NUnit from 2.6.4 to 3.0.1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Also thanks to:
     * Paul Dovydaitis (pdovy)
     * Pavlos Touboulidis (pav)
     * Pizzaoverhead
+    * Piët Delport (pjdelport)
     * Psydev
     * Raymond Bedrossian (Squiggles211)
     * Raymond Martineau (mart0258)

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ check: utility mods
 	@echo "Checking for code style violations in OpenRA.Test..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Test
 
-NUNIT_CONSOLE := $(shell test -f thirdparty/download/nunit-console.exe && echo mono thirdparty/download/nunit-console.exe || \
+NUNIT_CONSOLE := $(shell test -f thirdparty/download/nunit3-console.exe && echo mono thirdparty/download/nunit3-console.exe || \
 	which nunit2-console 2>/dev/null || which nunit3-console 2>/dev/null || which nunit-console 2>/dev/null)
 nunit: test_dll
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ nunit: test_dll
 		echo 'NUnit version >= 2.6 required'>&2; \
 		exit 1; \
 	fi
-	@$(NUNIT_CONSOLE) $(test_dll_TARGET)
+	@$(NUNIT_CONSOLE) --noresult $(test_dll_TARGET)
 
 test: utility mods
 	@echo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ before_test:
     }
 
 test_script:
-  - nunit-console-x86.exe OpenRA.Test.dll
+  - nunit3-console OpenRA.Test.dll --result=myresults.xml;format=AppVeyor
 
 after_test:
   - choco install pandoc -y

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -63,7 +63,7 @@ if (!(Test-Path "nunit.framework.dll"))
 {
 	echo "Fetching NUnit from NuGet."
 	./nuget.exe install NUnit -Version 3.0.1 -ExcludeVersion
-	cp NUnit/lib/nunit.framework* .
+	cp NUnit/lib/net40/nunit.framework* .
 	rmdir NUnit -Recurse
 }
 

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -62,7 +62,7 @@ if (!(Test-Path "SharpFont.dll"))
 if (!(Test-Path "nunit.framework.dll"))
 {
 	echo "Fetching NUnit from NuGet."
-	./nuget.exe install NUnit -Version 2.6.4 -ExcludeVersion
+	./nuget.exe install NUnit -Version 3.0.1 -ExcludeVersion
 	cp NUnit/lib/nunit.framework* .
 	rmdir NUnit -Recurse
 }

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -73,19 +73,17 @@ fi
 
 if [ ! -f nunit.framework.dll ]; then
 	echo "Fetching NUnit from NuGet"
-	get NUnit 2.6.4
-	cp ./NUnit/lib/nunit.framework* .
+	get NUnit 3.0.1
+	cp ./NUnit/lib/net40/nunit.framework* .
 	rm -rf NUnit
 fi
 
-if [ ! -f nunit-console.exe ]; then
-	echo "Fetching NUnit.Runners from NuGet"
-	get NUnit.Runners 2.6.4
-	cp ./NUnit.Runners/tools/nunit-console.exe .
-	chmod +x nunit-console.exe
-	cp ./NUnit.Runners/tools/nunit-console.exe.config .
-	cp -R ./NUnit.Runners/tools/lib .
-	rm -rf NUnit.Runners
+if [ ! -f nunit3-console.exe ]; then
+	echo "Fetching NUnit.Console from NuGet"
+	get NUnit.Console 3.0.1
+	cp -R ./NUnit.Console/tools/* .
+	chmod +x nunit3-console.exe
+	rm -rf NUnit.Console
 fi
 
 if [ ! -f Mono.Nat.dll ]; then


### PR DESCRIPTION
The older version of NUnit seems to have trouble running, at least on Ubuntu 15.10 and recent versions of Mono.

With this update, `make dependencies` followed by `make nunit` works out of the box for me.
