### PR TITLE
Ensure some structs implement IEquatable<T>.

### DIFF
--- a/OpenRA.Game/Primitives/Pair.cs
+++ b/OpenRA.Game/Primitives/Pair.cs
@@ -8,12 +8,13 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 
 namespace OpenRA.Primitives
 {
-	public struct Pair<T, U>
+	public struct Pair<T, U> : IEquatable<Pair<T, U>>
 	{
 		public T First;
 		public U Second;
@@ -37,16 +38,10 @@ namespace OpenRA.Primitives
 			return !(a == b);
 		}
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as Pair<T, U>?;
-			return o != null && o == this;
-		}
+		public override int GetHashCode() { return First.GetHashCode() ^ Second.GetHashCode(); }
 
-		public override int GetHashCode()
-		{
-			return First.GetHashCode() ^ Second.GetHashCode();
-		}
+		public bool Equals(Pair<T, U> other) { return this == other; }
+		public override bool Equals(object obj) { return obj is Pair<T, U> && Equals((Pair<T, U>)obj); }
 
 		public Pair<T, U> WithFirst(T t) { return new Pair<T, U>(t, Second); }
 		public Pair<T, U> WithSecond(U u) { return new Pair<T, U>(First, u); }

--- a/OpenRA.Game/Primitives/float2.cs
+++ b/OpenRA.Game/Primitives/float2.cs
@@ -17,7 +17,7 @@ namespace OpenRA
 {
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Mimic a built-in type alias.")]
 	[StructLayout(LayoutKind.Sequential)]
-	public struct float2
+	public struct float2 : IEquatable<float2>
 	{
 		public float X, Y;
 
@@ -72,13 +72,13 @@ namespace OpenRA
 
 		public static bool operator ==(float2 me, float2 other) { return me.X == other.X && me.Y == other.Y; }
 		public static bool operator !=(float2 me, float2 other) { return !(me == other); }
+
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as float2?;
-			return o != null && o == this;
-		}
+		public bool Equals(float2 other) { return this == other; }
+		public override bool Equals(object obj) { return obj is float2 && Equals((float2)obj); }
+
+		public override string ToString() { return X + "," + Y; }
 
 		public static readonly float2 Zero = new float2(0, 0);
 
@@ -92,7 +92,6 @@ namespace OpenRA
 		public static float Dot(float2 a, float2 b) { return a.X * b.X + a.Y * b.Y; }
 		public float2 Round() { return new float2((float)Math.Round(X), (float)Math.Round(Y)); }
 
-		public override string ToString() { return "{0},{1}".F(X, Y); }
 		public int2 ToInt2() { return new int2((int)X, (int)Y); }
 
 		public static float2 Max(float2 a, float2 b) { return new float2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)); }

--- a/OpenRA.Game/Primitives/int2.cs
+++ b/OpenRA.Game/Primitives/int2.cs
@@ -15,7 +15,7 @@ using System.Drawing;
 namespace OpenRA
 {
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Mimic a built-in type alias.")]
-	public struct int2
+	public struct int2 : IEquatable<int2>
 	{
 		public readonly int X, Y;
 		public int2(int x, int y) { this.X = x; this.Y = y; }
@@ -33,11 +33,17 @@ namespace OpenRA
 		public static bool operator ==(int2 me, int2 other) { return me.X == other.X && me.Y == other.Y; }
 		public static bool operator !=(int2 me, int2 other) { return !(me == other); }
 
+		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
+
+		public bool Equals(int2 other) { return this == other; }
+		public override bool Equals(object obj) { return obj is int2 && Equals((int2)obj); }
+
+		public override string ToString() { return X + "," + Y; }
+
 		public int2 Sign() { return new int2(Math.Sign(X), Math.Sign(Y)); }
 		public int2 Abs() { return new int2(Math.Abs(X), Math.Abs(Y)); }
 		public int LengthSquared { get { return X * X + Y * Y; } }
 		public int Length { get { return Exts.ISqrt(LengthSquared); } }
-		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode(); }
 
 		public int2 WithX(int newX)
 		{
@@ -52,18 +58,10 @@ namespace OpenRA
 		public static int2 Max(int2 a, int2 b) { return new int2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)); }
 		public static int2 Min(int2 a, int2 b) { return new int2(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y)); }
 
-		public override bool Equals(object obj)
-		{
-			var o = obj as int2?;
-			return o != null && o == this;
-		}
-
 		public static readonly int2 Zero = new int2(0, 0);
 		public Point ToPoint() { return new Point(X, Y); }
 		public PointF ToPointF() { return new PointF(X, Y); }
 		public float2 ToFloat2() { return new float2(X, Y); }
-
-		public override string ToString() { return "{0},{1}".F(X, Y); }
 
 		// Change endianness of a uint32
 		public static uint Swap(uint orig)


### PR DESCRIPTION
I have moved around some of the code to make it consistent with existing overrides in other vectors such as `CPos`, `WVec`, etc.

Implementating `IEquatable<T>` is important for structs as this is used as the default equality comparer (when available) for inbuilt collections that need a definition of equality (like `Dictionary`). Implementing it allows them to avoid boxing costs if such a struct is the key.
