### PR TITLE
Add NUnit configuration with correct binpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ nunit: test_dll
 		echo 'NUnit version >= 2.6 required'>&2; \
 		exit 1; \
 	fi
-	@$(NUNIT_CONSOLE) --noresult $(test_dll_TARGET)
+	@$(NUNIT_CONSOLE) --noresult OpenRA.Test.nunit
 
 test: utility mods
 	@echo

--- a/OpenRA.Test.nunit
+++ b/OpenRA.Test.nunit
@@ -1,0 +1,6 @@
+<NUnitProject>
+  <Settings activeconfig="Debug"/>
+  <Config name="Debug" binpath="mods/common">
+    <assembly path="OpenRA.Test.dll"/>
+  </Config>
+</NUnitProject>


### PR DESCRIPTION
This allows the tests to find and load OpenRA.Mods.Common.dll correctly under Linux / Mono.

This should fix #10325.
