### PR TITLE
Fix-up NUnit 2 & 3 use in Unix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #
 # to check unit tests (requires NUnit version >= 2.6), run:
 #  make nunit [NUNIT_CONSOLE=<path-to/nunit[2]-console>] [NUNIT_LIBS_PATH=<path-to-libs-dir>] [NUNIT_LIBS=<nunit-libs>]
-#      Use NUNIT_CONSOLE if nunit[2|3]-console was not downloaded by `make dependencies` nor is it not in bin search paths
+#      Use NUNIT_CONSOLE if nunit[3|2]-console was not downloaded by `make dependencies` nor is it in bin search paths
 #      Use NUNIT_LIBS_PATH if NUnit libs are not in search paths. Include trailing /
 #      Use NUNIT_LIBS if NUnit libs have different names (such as including a prefix or suffix)
 # to check the official mods for erroneous yaml files, run:
@@ -229,18 +229,20 @@ check: utility mods
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Test
 
 NUNIT_CONSOLE := $(shell test -f thirdparty/download/nunit3-console.exe && echo mono thirdparty/download/nunit3-console.exe || \
-	which nunit2-console 2>/dev/null || which nunit3-console 2>/dev/null || which nunit-console 2>/dev/null)
+	which nunit3-console 2>/dev/null || which nunit2-console 2>/dev/null || which nunit-console 2>/dev/null)
 nunit: test_dll
 	@echo
 	@echo "Checking unit tests..."
 	@if [ "$(NUNIT_CONSOLE)" = "" ] ; then \
-		echo 'nunit[2|3]-console not found!'; \
+		echo 'nunit[3|2]-console not found!'; \
 		echo 'Was "make dependencies" called or is NUnit installed?'>&2; \
-		echo 'see "make help"'; \
+		echo 'See "make help".'; \
 		exit 1; \
 	fi
 	@if $(NUNIT_CONSOLE) --help | head -n 1 | grep -E "NUnit version (1|2\.[0-5])";then \
 		echo 'NUnit version >= 2.6 required'>&2; \
+		echo 'Try "make dependencies" first to use NUnit from NuGet.'>&2; \
+		echo 'See "make help".'; \
 		exit 1; \
 	fi
 	@$(NUNIT_CONSOLE) --noresult OpenRA.Test.nunit
@@ -479,8 +481,8 @@ help:
 	@echo '  make all [DEBUG=false]'
 	@echo
 	@echo 'to check unit tests (requires NUnit version >= 2.6), run:'
-	@echo '  make nunit [NUNIT_CONSOLE=<path-to/nunit[2]-console>] [NUNIT_LIBS_PATH=<path-to-libs-dir>] [NUNIT_LIBS=<nunit-libs>]'
-	@echo '     Use NUNIT_CONSOLE if nunit[2|3]-console was not downloaded by `make dependencies` nor is it not in bin search paths'
+	@echo '  make nunit [NUNIT_CONSOLE=<path-to/nunit[3|2]-console>] [NUNIT_LIBS_PATH=<path-to-libs-dir>] [NUNIT_LIBS=<nunit-libs>]'
+	@echo '     Use NUNIT_CONSOLE if nunit[3|2]-console was not downloaded by `make dependencies` nor is it in bin search paths'
 	@echo '     Use NUNIT_LIBS_PATH if NUnit libs are not in search paths. Include trailing /'
 	@echo '     Use NUNIT_LIBS if NUnit libs have different names (such as including a prefix or suffix)'
 	@echo


### PR DESCRIPTION
Cleans up NUint 2 & 3 after #10309 and #10327.
