### PR TITLE
Fix parameters sent to DetectionCircleRenderable.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
@@ -45,19 +45,19 @@ namespace OpenRA.Mods.Common.Graphics
 		public IRenderable WithPalette(PaletteReference newPalette)
 		{
 			return new DetectionCircleRenderable(centerPosition, radius, zOffset,
-				trailCount, trailAngle, trailSeparation, color, contrastColor);
+				trailCount, trailSeparation, trailAngle, color, contrastColor);
 		}
 
 		public IRenderable WithZOffset(int newOffset)
 		{
 			return new DetectionCircleRenderable(centerPosition, radius, newOffset,
-				trailCount, trailAngle, trailSeparation, color, contrastColor);
+				trailCount, trailSeparation, trailAngle, color, contrastColor);
 		}
 
 		public IRenderable OffsetBy(WVec vec)
 		{
 			return new DetectionCircleRenderable(centerPosition + vec, radius, zOffset,
-				trailCount, trailAngle, trailSeparation, color, contrastColor);
+				trailCount, trailSeparation, trailAngle, color, contrastColor);
 		}
 
 		public IRenderable AsDecoration() { return this; }


### PR DESCRIPTION
The parameters had been accidentally reversed in the builder methods.

Discovered by Coverity.
