### PR TITLE
Suppress warning about Is.StringContaining on NUnit 3

### DIFF
--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -64,11 +64,14 @@ namespace OpenRA.Test
 			}
 			catch (Exception e)
 			{
+				// Is.StringContaining is deprecated in NUnit 3, but we need to support NUnit 2 so we ignore the warning.
+				#pragma warning disable CS0618
 				Assert.That(e.Message, Is.StringContaining("MockA"));
 				Assert.That(e.Message, Is.StringContaining("MockB"));
 				Assert.That(e.Message, Is.StringContaining("MockC"));
 				Assert.That(e.Message, Is.StringContaining("MockInherit"), "Should recognize base classes");
 				Assert.That(e.Message, Is.StringContaining("IMock"), "Should recognize interfaces");
+				#pragma warning restore CS0618
 			}
 		}
 


### PR DESCRIPTION
A side effect of moving to NUnit 3, I believe.
