### PR TITLE
Misc Missile and CreateEffectWarhead tweaks

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -76,6 +76,9 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("Vertical rate of turn.")]
 		public readonly int VerticalRateOfTurn = 6;
 
+		[Desc("Gravity applied while in free fall.")]
+		public readonly int Gravity = 10;
+
 		[Desc("Run out of fuel after being activated this many ticks. Zero for unlimited fuel.")]
 		public readonly int RangeLimit = 0;
 
@@ -152,8 +155,7 @@ namespace OpenRA.Mods.Common.Effects
 		readonly ProjectileArgs args;
 		readonly Animation anim;
 
-		// NOTE: Might be desirable to unhardcode the number -10
-		readonly WVec gravity = new WVec(0, 0, -10);
+		readonly WVec gravity;
 
 		int ticks;
 
@@ -191,6 +193,7 @@ namespace OpenRA.Mods.Common.Effects
 
 			pos = args.Source;
 			hFacing = args.Facing;
+			gravity = new WVec(0, 0, -info.Gravity);
 			targetPosition = args.PassiveTarget;
 
 			var world = args.SourceActor.World;

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Warheads
 			if (dat.Length > airMargin.Length)
 				return isDirectHit ? ImpactType.AirHit : ImpactType.Air;
 
-			if (dat.Length <= 0 && world.Map.GetTerrainInfo(cell).IsWater)
+			if (dat.Length <= airMargin.Length && world.Map.GetTerrainInfo(cell).IsWater)
 				return isDirectHit ? ImpactType.WaterHit : ImpactType.Water;
 
 			if (isDirectHit)

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -77,8 +77,8 @@ namespace OpenRA.Mods.Common.Warheads
 				if (healthInfo == null)
 					continue;
 
-				// If the impact position is within any actor's health radius, we have a direct hit
-				if ((unit.CenterPosition - pos).LengthSquared <= healthInfo.Shape.OuterRadius.LengthSquared)
+				// If the impact position is within any actor's HitShape, we have a direct hit
+				if ((unit.CenterPosition - pos).LengthSquared <= healthInfo.Shape.DistanceFromEdge(pos, unit).LengthSquared)
 					return true;
 			}
 


### PR DESCRIPTION
- Fixes #10350 by using `airMargin` in CEWH water check
- unhardcodes `Missile` freefall gravity
- Make `CreateEffectWarhead` check for `HitShape.DistanceFromEdge` instead of `.OuterRadius` (to match `SpreadDamageWarhead`)
