### PR TITLE
Return a Target.FrozenActor in Actor.ResolveFrozenActorOrder

### DIFF
--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common
 
 			// Target is still alive - resolve the real order
 			if (frozen.Actor != null && frozen.Actor.IsInWorld)
-				return Target.FromActor(frozen.Actor);
+				return Target.FromFrozenActor(frozen);
 
 			if (!order.Queued)
 				self.CancelActivity();

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -80,21 +80,8 @@ namespace OpenRA.Mods.Common
 			self.SetTargetLine(frozen, targetLine, true);
 
 			// Target is still alive - resolve the real order
-			if (frozen.Actor != null && frozen.Actor.IsInWorld)
+			if (frozen.Actor != null)
 				return Target.FromFrozenActor(frozen);
-
-			if (!order.Queued)
-				self.CancelActivity();
-
-			var move = self.TraitOrDefault<IMove>();
-			if (move != null)
-			{
-				// Move within sight range of the frozen actor
-				var sight = self.TraitOrDefault<RevealsShroud>();
-				var range = sight != null ? sight.Range : WDist.FromCells(2);
-
-				self.QueueActivity(move.MoveWithinRange(Target.FromPos(frozen.CenterPosition), range));
-			}
 
 			return Target.Invalid;
 		}


### PR DESCRIPTION
...instead of a Target.Actor, which would make code dealing with the order work with false assumptions.

Fixes #10361.

Here's a list of things that need fixing before this can be merged:
- [ ] `ExternalCaptures` + `ExternalCaptureActivity`.
- [ ] `MoveAdjacentTo`.
- [ ] `Attack*` (non-turreted).
- [ ] `Enter` and friends.

...
