### PR TITLE
Use UTF8 instead of system locale code page

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -25,7 +25,7 @@ namespace OpenRA.FileSystem
 
 		static ZipFile()
 		{
-			ZipConstants.DefaultCodePage = Encoding.Default.CodePage;
+			ZipConstants.DefaultCodePage = Encoding.UTF8.CodePage;
 		}
 
 		public ZipFile(FileSystem context, string filename, int priority)


### PR DESCRIPTION
as recommended by https://msdn.microsoft.com/en-us/library/windows/desktop/dd317756

Closes https://github.com/OpenRA/OpenRA/issues/10332 in a cleaner way.
Probably fixes https://github.com/OpenRA/OpenRA/issues/10308.
