### PR TITLE
Made attackable positions customizable

### DIFF
--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -165,6 +165,35 @@ namespace OpenRA.Traits
 			}
 		}
 
+		public IEnumerable<WPos> AttackablePositions
+		{
+			get
+			{
+				switch (Type)
+				{
+					case TargetType.Actor:
+						if (!actor.Targetables.Any(Exts.IsTraitEnabled))
+							return new[] { actor.CenterPosition };
+
+						var attackablePositions = actor.TraitsImplementing<IAttackablePositions>();
+						if (attackablePositions.Any())
+						{
+							var target = this;
+							return attackablePositions.SelectMany(ap => ap.AttackablePositions(target.actor));
+						}
+
+						return new[] { actor.CenterPosition };
+					case TargetType.FrozenActor:
+						return new[] { frozen.CenterPosition };
+					case TargetType.Terrain:
+						return new[] { pos };
+					default:
+					case TargetType.Invalid:
+						return NoPositions;
+				}
+			}
+		}
+
 		public bool IsInRange(WPos origin, WDist range)
 		{
 			if (Type == TargetType.Invalid)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -381,6 +381,11 @@ namespace OpenRA.Traits
 		IEnumerable<WPos> TargetablePositions(Actor self);
 	}
 
+	public interface IAttackablePositions
+	{
+		IEnumerable<WPos> AttackablePositions(Actor self);
+	}
+
 	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData); }
 	public interface ILintMapPass { void Run(Action<string> emitError, Action<string> emitWarning, Map map); }
 	public interface ILintRulesPass { void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules); }

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -30,6 +30,11 @@ namespace OpenRA
 			return actors.MinByOrDefault(a => (a.CenterPosition - pos).LengthSquared);
 		}
 
+		public static WPos PositionClosestTo(this IEnumerable<WPos> positions, WPos pos)
+		{
+			return positions.MinByOrDefault(p => (p - pos).LengthSquared);
+		}
+
 		public static IEnumerable<Actor> FindActorsInCircle(this World world, WPos origin, WDist r)
 		{
 			// Target ranges are calculated in 2D, so ignore height differences

--- a/OpenRA.Mods.Common/Effects/LaserZap.cs
+++ b/OpenRA.Mods.Common/Effects/LaserZap.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -79,7 +80,7 @@ namespace OpenRA.Mods.Common.Effects
 		{
 			// Beam tracks target
 			if (args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = args.GuidedTarget.CenterPosition;
+				target = args.GuidedTarget.AttackablePositions.PositionClosestTo(args.Source);
 
 			if (!doneDamage)
 			{

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -780,7 +780,7 @@ namespace OpenRA.Mods.Common.Effects
 			// Check if target position should be updated (actor visible & locked on)
 			var newTarPos = targetPosition;
 			if (args.GuidedTarget.IsValidFor(args.SourceActor) && lockOn)
-				newTarPos = args.GuidedTarget.CenterPosition
+				newTarPos = args.GuidedTarget.AttackablePositions.PositionClosestTo(args.Source)
 					+ new WVec(WDist.Zero, WDist.Zero, info.AirburstAltitude);
 
 			// Compute target's predicted velocity vector (assuming uniform circular motion)

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -85,6 +85,12 @@ namespace OpenRA.Mods.Common.HitShapes
 		public WDist DistanceFromEdge(WPos pos, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var attackablePositions = actor.TraitsImplementing<IAttackablePositions>();
+			if (attackablePositions.Any())
+			{
+				var positions = attackablePositions.SelectMany(ap => ap.AttackablePositions(actor));
+				actorPos = positions.PositionClosestTo(actorPos);
+			}
 
 			if (pos.Z > actorPos.Z + VerticalTopOffset)
 				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-actor.Orientation));
@@ -98,6 +104,12 @@ namespace OpenRA.Mods.Common.HitShapes
 		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var attackablePositions = actor.TraitsImplementing<IAttackablePositions>();
+			if (attackablePositions.Any())
+			{
+				var positions = attackablePositions.SelectMany(ap => ap.AttackablePositions(actor));
+				actorPos = positions.PositionClosestTo(actorPos);
+			}
 
 			var a = actorPos + new WVec(PointA.X, PointA.Y, VerticalTopOffset).Rotate(actor.Orientation);
 			var b = actorPos + new WVec(PointB.X, PointB.Y, VerticalTopOffset).Rotate(actor.Orientation);

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -49,6 +49,12 @@ namespace OpenRA.Mods.Common.HitShapes
 		public WDist DistanceFromEdge(WPos pos, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var attackablePositions = actor.TraitsImplementing<IAttackablePositions>();
+			if (attackablePositions.Any())
+			{
+				var positions = attackablePositions.SelectMany(ap => ap.AttackablePositions(actor));
+				actorPos = positions.PositionClosestTo(actorPos);
+			}
 
 			if (pos.Z > actorPos.Z + VerticalTopOffset)
 				return DistanceFromEdge(pos - (actorPos + new WVec(0, 0, VerticalTopOffset)));
@@ -62,6 +68,12 @@ namespace OpenRA.Mods.Common.HitShapes
 		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var attackablePositions = actor.TraitsImplementing<IAttackablePositions>();
+			if (attackablePositions.Any())
+			{
+				var positions = attackablePositions.SelectMany(ap => ap.AttackablePositions(actor));
+				actorPos = positions.PositionClosestTo(actorPos);
+			}
 
 			RangeCircleRenderable.DrawRangeCircle(
 				wr, actorPos + new WVec(0, 0, VerticalTopOffset), Radius, 1, Color.Yellow, 0, Color.Yellow);

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -89,6 +89,12 @@ namespace OpenRA.Mods.Common.HitShapes
 		public WDist DistanceFromEdge(WPos pos, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var attackablePositions = actor.TraitsImplementing<IAttackablePositions>();
+			if (attackablePositions.Any())
+			{
+				var positions = attackablePositions.SelectMany(ap => ap.AttackablePositions(actor));
+				actorPos = positions.PositionClosestTo(actorPos);
+			}
 
 			if (pos.Z > actorPos.Z + VerticalTopOffset)
 				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-actor.Orientation));
@@ -102,6 +108,12 @@ namespace OpenRA.Mods.Common.HitShapes
 		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var attackablePositions = actor.TraitsImplementing<IAttackablePositions>();
+			if (attackablePositions.Any())
+			{
+				var positions = attackablePositions.SelectMany(ap => ap.AttackablePositions(actor));
+				actorPos = positions.PositionClosestTo(actorPos);
+			}
 
 			var vertsTop = combatOverlayVertsTop.Select(v => wr.ScreenPosition(actorPos + v.Rotate(actor.Orientation)));
 			var vertsBottom = combatOverlayVertsBottom.Select(v => wr.ScreenPosition(actorPos + v.Rotate(actor.Orientation)));

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 				Source = muzzlePosition(),
 				CurrentSource = muzzlePosition,
 				SourceActor = self,
-				PassiveTarget = target.CenterPosition,
+				PassiveTarget = target.AttackablePositions.First(),
 				GuidedTarget = target
 			};
 

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Has to be defined in weapons.yaml as well.")]
 		public readonly string Weapon = null;
 
+		[Desc("Ignore any custom attackable positions and always aim at the targets' CenterPosition.")]
+		public readonly bool IgnoreAttackablePositionOffset = false;
+
 		[Desc("Which limited ammo pool (if present) should this armament be assigned to.")]
 		public readonly string AmmoPoolName = "primary";
 
@@ -219,7 +222,7 @@ namespace OpenRA.Mods.Common.Traits
 				Source = muzzlePosition(),
 				CurrentSource = muzzlePosition,
 				SourceActor = self,
-				PassiveTarget = target.AttackablePositions.First(),
+				PassiveTarget = Info.IgnoreAttackablePositionOffset ? target.CenterPosition : target.AttackablePositions.PositionClosestTo(muzzlePosition()),
 				GuidedTarget = target
 			};
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var f = facing.Value.Facing;
-			var delta = target.CenterPosition - self.CenterPosition;
+			var delta = target.AttackablePositions.PositionClosestTo(self.CenterPosition) - self.CenterPosition;
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 
 			if (Math.Abs(facingToTarget - f) % 256 > info.FacingTolerance)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -20,6 +20,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly int FacingTolerance = 1;
 
+		[Desc("Should the actor face target's center instead of any custom AttackPositions?")]
+		public readonly bool IgnoreAttackablePositions = false;
+
 		public override object Create(ActorInitializer init) { return new AttackFrontal(init.Self, this); }
 	}
 
@@ -39,7 +42,10 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var f = facing.Value.Facing;
-			var delta = target.AttackablePositions.PositionClosestTo(self.CenterPosition) - self.CenterPosition;
+			var aimPos = info.IgnoreAttackablePositions ? target.CenterPosition
+				: target.AttackablePositions.PositionClosestTo(self.CenterPosition);
+
+			var delta = aimPos - self.CenterPosition;
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 
 			if (Math.Abs(facingToTarget - f) % 256 > info.FacingTolerance)

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -58,6 +58,25 @@ namespace OpenRA.Mods.Common.Traits
 			if (healthInfo != null)
 				healthInfo.Shape.DrawCombatOverlay(wr, wcr, self);
 
+			var attackablePositions = self.TraitsImplementing<IAttackablePositions>();
+			foreach (var ap in attackablePositions)
+			{
+				var attackPos = self.CenterPosition;
+				var positions = ap.AttackablePositions(self);
+				if (positions.Any())
+					attackPos = positions.First();
+
+				var attackPosColor = Color.Magenta;
+				var apx = new WVec(96, 0, 0);
+				var apy = new WVec(0, 96, 0);
+				var apa = wr.ScreenPosition(attackPos + apx);
+				var apb = wr.ScreenPosition(attackPos - apx);
+				var apc = wr.ScreenPosition(attackPos + apy);
+				var apd = wr.ScreenPosition(attackPos - apy);
+				wcr.DrawLine(apa, apb, iz, attackPosColor);
+				wcr.DrawLine(apc, apd, iz, attackPosColor);
+			}
+
 			var blockers = allBlockers.Where(Exts.IsTraitEnabled).ToList();
 			if (blockers.Count > 0)
 			{

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool FaceTarget(Actor self, Target target)
 		{
-			var delta = target.CenterPosition - self.CenterPosition;
+			var delta = target.AttackablePositions.PositionClosestTo(self.CenterPosition) - self.CenterPosition;
 			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();
 			return HasAchievedDesiredFacing;

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -25,6 +25,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Number of ticks before turret is realigned. (-1 turns off realignment)")]
 		public readonly int RealignDelay = 40;
 
+		[Desc("Should the turret face the target's center instead of any custom AttackPositions?")]
+		public readonly bool IgnoreAttackablePositions = false;
+
 		[Desc("Muzzle position relative to turret or body. (forward, right, up) triples")]
 		public readonly WVec Offset = WVec.Zero;
 
@@ -110,7 +113,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool FaceTarget(Actor self, Target target)
 		{
-			var delta = target.AttackablePositions.PositionClosestTo(self.CenterPosition) - self.CenterPosition;
+			var aimPos = info.IgnoreAttackablePositions ? target.CenterPosition
+				: target.AttackablePositions.PositionClosestTo(self.CenterPosition);
+
+			var delta = aimPos - self.CenterPosition;
 			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();
 			return HasAchievedDesiredFacing;


### PR DESCRIPTION
This allows modders to define custom offsets relative to `Actor.CenterPosition` that will be targeted instead of `CenterPosition`, which is extremely useful for tall units like mechs.

~~Also adds custom HitShapes to all TS units (not buildings for now, no point in that until we have footprint/custom shape support).~~ split to #11169.

Closes #7717.
