### PR TITLE
Speed up AutoTarget.ChooseTarget among groups of allied units.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -287,6 +287,17 @@ namespace OpenRA.Mods.Common.Traits
 				&& (target.IsInRange(self.CenterPosition, GetMaximumRange()) || (allowMove && self.Info.HasTraitInfo<IMoveInfo>()));
 		}
 
+		public Stance UnforcedAttackTargetStances()
+		{
+			// PERF: Avoid LINQ.
+			var stances = Stance.None;
+			foreach (var armament in Armaments)
+				if (!armament.IsTraitDisabled)
+					stances |= armament.Info.TargetStances;
+
+			return stances;
+		}
+
 		class AttackOrderTargeter : IOrderTargeter
 		{
 			readonly AttackBase ab;


### PR DESCRIPTION
Most auto target scans will be conducted among groups of allied units unable to target each other because they are allied and their weapons only target enemies. Since they cannot target each other, the scan will be repeated constantly. Realising this, we can significantly reduce the performance impact of auto target scanning by bailing early in this scenario to avoid carrying out expensive targeting checks on friendly units which we know will fail anyway.

On the RA shellmap, this reduces total CPU usage of `ChooseTarget` from 2.47% to 1.54%. I watched a replay from release-20151224 earlier that had large standing armies for a fair bit that clocked in at like 10%. That will probably get significantly reduced too.
