### PR TITLE
Polished the Dune 2000 low power graphics

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool PauseOnLowPower = false;
 
+		[Desc("Optional decoration element which doesn't cast shadows and won't get overlayed.")]
+		public readonly bool IsDecoration = false;
+
 		public override object Create(ActorInitializer init) { return new WithIdleOverlay(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
@@ -71,6 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self),
 				() => (info.PauseOnLowPower && self.IsDisabled()) || !buildComplete);
+			overlay.IsDecoration = info.IsDecoration;
 			if (info.StartSequence != null)
 				overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.StartSequence),
 					() => overlay.PlayRepeating(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence)));

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -558,6 +558,7 @@ starport:
 			corrino: starport.corrino
 	WithDeliveryOverlay:
 		Palette: starportlights
+		PauseOnLowPower: true
 	ProductionBar:
 	PrimaryBuilding:
 	RequiresPower:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -511,6 +511,7 @@ outpost:
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
 		PauseOnLowPower: yes
+		IsDecoration: true
 	Power:
 		Amount: -125
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -228,14 +228,14 @@ starport.atreides:
 	active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
 	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
@@ -723,14 +723,14 @@ starport.harkonnen:
 	active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
 	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
@@ -1127,14 +1127,14 @@ starport.ordos:
 	active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
 	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
@@ -1509,14 +1509,14 @@ starport.corrino:
 	active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200
 	damaged-active: DATA.R8
 		Start: 4723
 		Length: 23
-		ZOffset: -1c511
+		ZOffset: -0c511
 		Offset: -48,48
 		BlendMode: Additive
 		Tick: 200


### PR DESCRIPTION
~~The dish not spinning should be enough.~~ Our disabled overlay clashes with other overlays.

![image](https://cloud.githubusercontent.com/assets/756669/12077976/04df0318-b1fe-11e5-9152-9f1446170013.png)

I also fixed the Starport lights not showing up at all. Probably a regression from https://github.com/OpenRA/OpenRA/pull/10119.
Made them not blink when on low power. It is a bit unlogical that the starport is powered down and non-operational, but the lights are still there. Our `WithProductionOverlay` was missing that switch.
