### PR TITLE
Removed GpsWatcher from Tiberian Sun

### DIFF
--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -41,7 +41,6 @@ Player:
 	PlayerResources:
 	ActorGroupProxy:
 	DeveloperMode:
-	GpsWatcher:
 	Shroud:
 	FrozenActorLayer:
 	BaseAttackNotifier:


### PR DESCRIPTION
This will just waste resources.
