### PR TITLE
Fix FrozenActorLayer.FootprintBounds.

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -209,7 +209,7 @@ namespace OpenRA.Traits
 					maxV = p.V;
 			}
 
-			return Rectangle.FromLTRB(minU, minV, maxU, maxV);
+			return Rectangle.FromLTRB(minU, minV, maxU + 1, maxV + 1);
 		}
 
 		public void Tick(Actor self)


### PR DESCRIPTION
The size of the bounds was too small (as rectangle has exclusive edges on the right and bottom). This meant some intersection tests would fail and thus the frozen actor was not found when searching the partition bins.

Fixes #10403.
