### PR TITLE
ra: decrease RevealsShroud for artillery

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -218,7 +218,7 @@ ARTY:
 		ROT: 2
 		Speed: 85
 	RevealsShroud:
-		Range: 5c0
+		Range: 3c0
 	Armament:
 		Weapon: 155mm
 		LocalOffset: 624,0,208


### PR DESCRIPTION
Artillery is meant to be a support unit, so usually something else
(Hinds) provides vision to it. With reduced RevealsShroud riflers can
now at least have a slight chance approach artillery without being
killed.
