### PR TITLE
ra: buff minelayer's HP

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -405,7 +405,7 @@ MNLY.AP:
 		Name: Minelayer
 		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
 	Health:
-		HP: 100
+		HP: 150
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -440,7 +440,7 @@ MNLY.AT:
 		Name: Minelayer
 		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
 	Health:
-		HP: 100
+		HP: 150
 	Armor:
 		Type: Heavy
 	Mobile:


### PR DESCRIPTION
Currently 1 rocket soldier can kill a minelayer with 2 shots. With this
change a rocket soldier needs 5 rockets. This behaviour mimics the
light tank behaviour where a rocket soldier needs 5 rockets to kill it.
I think this buff is needed because light tank is a paper tank and
costs $700, but minelayer costs $800 and it's even less sturdy.
