### PR TITLE
Reference the Map Scripting page from the Lua API page

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -53,6 +53,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				"* Individual players expose a collection of properties and commands that query information or modify their state.\n" +
 				"The properties and commands available on each actor depends on the traits that the actor specifies in its rule definitions.\n");
 			Console.WriteLine();
+			Console.WriteLine("For a basic guide about map scripts see the [`Map Scripting` wiki page](https://github.com/OpenRA/OpenRA/wiki/Map-scripting).");
+			Console.WriteLine();
 
 			var tables = Game.ModData.ObjectCreator.GetTypesImplementing<ScriptGlobal>()
 				.OrderBy(t => t.Name);


### PR DESCRIPTION
Kind of closes https://github.com/OpenRA/OpenRA-Resources/issues/270, as a link to the learning guide is on the `Map Scripting` page now (https://github.com/OpenRA/OpenRA-Resources/issues/270#issuecomment-168691868).

When/If this is merged, I'll manually update the `Lua API` page.

Image:
![mapscripting](https://cloud.githubusercontent.com/assets/7704140/12093735/f02d516a-b304-11e5-89a4-35bc6c32545b.png)
