### PR TITLE
Make Log thread-safe.

### DIFF
--- a/OpenRA.Game/Network/UPnP.cs
+++ b/OpenRA.Game/Network/UPnP.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Network
 		{
 			try
 			{
-				NatUtility.Logger = Log.Channels["server"].Writer;
+				NatUtility.Logger = Log.Channel("server").Writer;
 				NatUtility.Verbose = Game.Settings.Server.VerboseNatDiscovery;
 				NatUtility.DeviceFound += DeviceFound;
 				Game.Settings.Server.NatDeviceAvailable = false;


### PR DESCRIPTION
Since logging is exposed via static methods, it need to be thread-safe or multiple threads trying to log at the same time will cause bad things to happen.

[Diff ignoring whitespace](https://github.com/OpenRA/OpenRA/pull/10417/files?w=1)
