### PR TITLE
Unhardcode music file types [Superseded]

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -19,7 +19,9 @@ namespace OpenRA
 {
 	public interface ISoundLoader
 	{
+		bool CanParse(Stream stream);
 		bool TryParseSound(Stream stream, string fileName, out byte[] rawData, out int channels, out int sampleBits, out int sampleRate);
+		float GetLength(Stream stream);
 	}
 
 	public sealed class Sound : IDisposable


### PR DESCRIPTION
Use the code from  #10069 to unhardcode music file types like that PR unhardcoded sound (effects, speech, and such) file types.
#10032 would have to take this into account as well, sorry @teees . At least it looks like it should be pretty simple.
