### PR TITLE
MAD tank balance changes/overhall

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -129,7 +129,7 @@ NUK2:
 	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Buildable:
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 80
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Building.GDI, Building.Nod
 	Building:
@@ -236,7 +236,7 @@ PYLE:
 	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Buildable:
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 30
 		Prerequisites: anypower
 		Queue: Building.GDI
 	Building:
@@ -277,7 +277,7 @@ HAND:
 	ProvidesPrerequisite:
 		Prerequisite: barracks
 	Buildable:
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 30
 		Prerequisites: anypower
 		Queue: Building.Nod
 	Building:
@@ -317,7 +317,7 @@ AFLD:
 	ProvidesPrerequisite:
 		Prerequisite: vehicleproduction
 	Buildable:
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 40
 		Prerequisites: proc
 		Queue: Building.Nod
 	Building:
@@ -360,7 +360,7 @@ WEAP:
 	ProvidesPrerequisite:
 		Prerequisite: vehicleproduction
 	Buildable:
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 40
 		Prerequisites: proc
 		Queue: Building.GDI
 	Building:
@@ -402,7 +402,7 @@ HPAD:
 		Name: Helipad
 		Description: Produces, rearms and\nrepairs helicopters
 	Buildable:
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 50
 		Prerequisites: proc
 		Queue: Building.GDI, Building.Nod
 	Building:
@@ -502,7 +502,7 @@ FIX:
 		Name: Repair Facility
 		Description: Repairs vehicles
 	Buildable:
-		BuildPaletteOrder: 80
+		BuildPaletteOrder: 60
 		Prerequisites: vehicleproduction
 		Queue: Building.GDI, Building.Nod
 	Building:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -695,7 +695,7 @@ QTNK:
 		BuildPaletteOrder: 200
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
 	Valued:
-		Cost: 2000
+		Cost: 2500
 	Tooltip:
 		Name: MAD Tank
 		Description: Deals seismic damage to nearby vehicles\nand structures.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
@@ -714,6 +714,8 @@ QTNK:
 	-EjectOnDeath:
 	Targetable:
 		TargetTypes: Ground, MADTank, Repair
+	-Chronoshiftable:
+	-DamageMultiplier@IRONCURTAIN:
 
 STNK:
 	Inherits: ^Vehicle

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -263,10 +263,69 @@ Mandible:
 MADTankThump:
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
-		Spread: 7c0
-		Damage: 1
+		Spread: 1c0
+		damage: 2
+			Delay: 8
 		InvalidTargets: MADTank, Infantry
-
+	Warhead@26mu: LeaveSmudge
+		Delay: 8
+		SmudgeType: Crater
+		Size: 1
+	Warhead@2Dam: HealthPercentageDamage
+		Spread: 2c0
+		Damage: 2
+			Delay: 16
+		InvalidTargets: MADTank, Infantry
+	Warhead@27mu: LeaveSmudge
+		Delay: 16
+		SmudgeType: Crater
+		Size: 2
+	Warhead@3Dam: HealthPercentageDamage
+		Spread: 3c0
+		Damage: 2
+			Delay: 24
+		InvalidTargets: MADTank, Infantry
+	Warhead@28mu: LeaveSmudge
+		Delay: 24
+		SmudgeType: Crater
+		Size: 3
+	Warhead@4Dam: HealthPercentageDamage
+		Spread: 4c0
+		Damage: 2
+			Delay: 32
+		InvalidTargets: MADTank, Infantry
+	Warhead@29mu: LeaveSmudge
+		Delay: 32
+		SmudgeType: Crater
+		Size: 4
+	Warhead@5Dam: HealthPercentageDamage
+		Spread: 5c0
+		Damage: 2
+			Delay: 40
+		InvalidTargets: MADTank, Infantry
+	Warhead@30mu: LeaveSmudge
+		Delay: 40
+		SmudgeType: Crater
+		Size: 5
+	Warhead@6Dam: HealthPercentageDamage
+		Spread: 6c0
+		Damage: 2
+			Delay: 48
+		InvalidTargets: MADTank, Infantry
+	Warhead@31mu: LeaveSmudge
+		Delay: 48
+		SmudgeType: Crater
+		Size: 6
+	Warhead@7Dam: HealthPercentageDamage
+		Spread: 7c0
+		Damage: 2
+			Delay: 56
+		InvalidTargets: MADTank, Infantry
+	Warhead@32mu: LeaveSmudge
+		Delay: 56
+		SmudgeType: Crater
+		Size: 7
+		
 MADTankDetonate:
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
@@ -279,4 +338,5 @@ MADTankDetonate:
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: mineblo1.aud
+
 


### PR DESCRIPTION
the Mad tank has been changed so that it is more useful as a support infantry unit that still causes devastation
video: https://vid.me/CXgI
