### PR TITLE
Ra mad tank balance/overhall

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -695,7 +695,7 @@ QTNK:
 		BuildPaletteOrder: 200
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
 	Valued:
-		Cost: 2000
+		Cost: 2500
 	Tooltip:
 		Name: MAD Tank
 		Description: Deals seismic damage to nearby vehicles\nand structures.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
@@ -714,6 +714,8 @@ QTNK:
 	-EjectOnDeath:
 	Targetable:
 		TargetTypes: Ground, MADTank, Repair
+	-Chronoshiftable:
+	-DamageMultiplier@IRONCURTAIN:
 
 STNK:
 	Inherits: ^Vehicle

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -265,6 +265,8 @@ MADTankThump:
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 1c0
 		Damage: 3
+		Versus:
+			wood: 1
 		Delay: 8
 		InvalidTargets: MADTank, Infantry
 	Warhead@26mu: LeaveSmudge
@@ -274,11 +276,15 @@ MADTankThump:
 	Warhead@2Dam: HealthPercentageDamage
 		Spread: 2c0
 		Damage: 3
+		Versus:
+			wood: 1
 		Delay: 16
 		InvalidTargets: MADTank, Infantry
 	Warhead@3Dam: HealthPercentageDamage
 		Spread: 3c0
 		Damage: 3
+		Versus:
+			wood: 1
 		Delay: 24
 		InvalidTargets: MADTank, Infantry
 	Warhead@28mu: LeaveSmudge
@@ -288,11 +294,15 @@ MADTankThump:
 	Warhead@4Dam: HealthPercentageDamage
 		Spread: 4c0
 		Damage: 3
+		Versus:
+			wood: 1
 		Delay: 32
 		InvalidTargets: MADTank, Infantry
 	Warhead@5Dam: HealthPercentageDamage
 		Spread: 5c0
 		Damage: 3
+		Versus:
+			wood: 1
 		Delay: 40
 		InvalidTargets: MADTank, Infantry
 	Warhead@30mu: LeaveSmudge
@@ -302,11 +312,15 @@ MADTankThump:
 	Warhead@6Dam: HealthPercentageDamage
 		Spread: 6c0
 		Damage: 3
+		Versus:
+			wood: 1
 		Delay: 48
 		InvalidTargets: MADTank, Infantry
 	Warhead@7Dam: HealthPercentageDamage
 		Spread: 7c0
 		Damage: 3
+		Versus:
+			wood: 1
 		Delay: 56
 		InvalidTargets: MADTank, Infantry
 	Warhead@32mu: LeaveSmudge

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -264,9 +264,7 @@ MADTankThump:
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 1c0
-		Damage: 3
-		Versus:
-			wood: 1
+		Damage: 1
 		Delay: 8
 		InvalidTargets: MADTank, Infantry
 	Warhead@26mu: LeaveSmudge
@@ -275,16 +273,12 @@ MADTankThump:
 		Size: 1
 	Warhead@2Dam: HealthPercentageDamage
 		Spread: 2c0
-		Damage: 3
-		Versus:
-			wood: 1
+		Damage: 1
 		Delay: 16
 		InvalidTargets: MADTank, Infantry
 	Warhead@3Dam: HealthPercentageDamage
 		Spread: 3c0
-		Damage: 3
-		Versus:
-			wood: 1
+		Damage: 1
 		Delay: 24
 		InvalidTargets: MADTank, Infantry
 	Warhead@28mu: LeaveSmudge
@@ -293,16 +287,12 @@ MADTankThump:
 		Size: 3
 	Warhead@4Dam: HealthPercentageDamage
 		Spread: 4c0
-		Damage: 3
-		Versus:
-			wood: 1
+		Damage: 1
 		Delay: 32
 		InvalidTargets: MADTank, Infantry
 	Warhead@5Dam: HealthPercentageDamage
 		Spread: 5c0
-		Damage: 3
-		Versus:
-			wood: 1
+		Damage: 1
 		Delay: 40
 		InvalidTargets: MADTank, Infantry
 	Warhead@30mu: LeaveSmudge
@@ -311,25 +301,39 @@ MADTankThump:
 		Size: 5
 	Warhead@6Dam: HealthPercentageDamage
 		Spread: 6c0
-		Damage: 3
-		Versus:
-			wood: 1
+		Damage: 1
 		Delay: 48
 		InvalidTargets: MADTank, Infantry
 	Warhead@7Dam: HealthPercentageDamage
 		Spread: 7c0
-		Damage: 3
-		Versus:
-			wood: 1
+		Damage: 1
 		Delay: 56
 		InvalidTargets: MADTank, Infantry
-	Warhead@32mu: LeaveSmudge
+	Warhead@31mu: LeaveSmudge
 		Delay: 56
 		SmudgeType: Crater
 		Size: 7
+	Warhead@8Dam: HealthPercentageDamage
+		Spread: 8c0
+		Damage: 1
+		Delay: 64
+		InvalidTargets: MADTank, Infantry
+	Warhead@9Dam: HealthPercentageDamage
+		Spread: 9c0
+		Damage: 1
+		Delay: 72
+		InvalidTargets: MADTank, Infantry
+	Warhead@33mu: LeaveSmudge
+		Delay: 72
+		SmudgeType: Crater
+		Size: 9
 	
 MADTankDetonate:
 	InvalidTargets: MADTank, Infantry
+	Warhead@1Dam: HealthPercentageDamage
+		Spread: 9c0
+		Damage: 40
+		InvalidTargets: MADTank, Infantry, Structure
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: mineblo1.aud

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -263,10 +263,69 @@ Mandible:
 MADTankThump:
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
-		Spread: 7c0
-		Damage: 1
+		Spread: 1c0
+		damage: 2
+			Delay: 8
 		InvalidTargets: MADTank, Infantry
-
+	Warhead@26mu: LeaveSmudge
+		Delay: 8
+		SmudgeType: Crater
+		Size: 1
+	Warhead@2Dam: HealthPercentageDamage
+		Spread: 2c0
+		Damage: 2
+			Delay: 16
+		InvalidTargets: MADTank, Infantry
+	Warhead@27mu: LeaveSmudge
+		Delay: 16
+		SmudgeType: Crater
+		Size: 2
+	Warhead@3Dam: HealthPercentageDamage
+		Spread: 3c0
+		Damage: 2
+			Delay: 24
+		InvalidTargets: MADTank, Infantry
+	Warhead@28mu: LeaveSmudge
+		Delay: 24
+		SmudgeType: Crater
+		Size: 3
+	Warhead@4Dam: HealthPercentageDamage
+		Spread: 4c0
+		Damage: 2
+			Delay: 32
+		InvalidTargets: MADTank, Infantry
+	Warhead@29mu: LeaveSmudge
+		Delay: 32
+		SmudgeType: Crater
+		Size: 4
+	Warhead@5Dam: HealthPercentageDamage
+		Spread: 5c0
+		Damage: 2
+			Delay: 40
+		InvalidTargets: MADTank, Infantry
+	Warhead@30mu: LeaveSmudge
+		Delay: 40
+		SmudgeType: Crater
+		Size: 5
+	Warhead@6Dam: HealthPercentageDamage
+		Spread: 6c0
+		Damage: 2
+			Delay: 48
+		InvalidTargets: MADTank, Infantry
+	Warhead@31mu: LeaveSmudge
+		Delay: 48
+		SmudgeType: Crater
+		Size: 6
+	Warhead@7Dam: HealthPercentageDamage
+		Spread: 7c0
+		Damage: 2
+			Delay: 56
+		InvalidTargets: MADTank, Infantry
+	Warhead@32mu: LeaveSmudge
+		Delay: 56
+		SmudgeType: Crater
+		Size: 7
+		
 MADTankDetonate:
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
@@ -279,4 +338,5 @@ MADTankDetonate:
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: mineblo1.aud
+
 

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -264,8 +264,8 @@ MADTankThump:
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 1c0
-		Damage: 2
-			Delay: 8
+		Damage: 3
+		Delay: 8
 		InvalidTargets: MADTank, Infantry
 	Warhead@26mu: LeaveSmudge
 		Delay: 8
@@ -273,17 +273,13 @@ MADTankThump:
 		Size: 1
 	Warhead@2Dam: HealthPercentageDamage
 		Spread: 2c0
-		Damage: 2
-			Delay: 16
-		InvalidTargets: MADTank, Infantry
-	Warhead@27mu: LeaveSmudge
+		Damage: 3
 		Delay: 16
-		SmudgeType: Crater
-		Size: 2
+		InvalidTargets: MADTank, Infantry
 	Warhead@3Dam: HealthPercentageDamage
 		Spread: 3c0
-		Damage: 2
-			Delay: 24
+		Damage: 3
+		Delay: 24
 		InvalidTargets: MADTank, Infantry
 	Warhead@28mu: LeaveSmudge
 		Delay: 24
@@ -291,17 +287,13 @@ MADTankThump:
 		Size: 3
 	Warhead@4Dam: HealthPercentageDamage
 		Spread: 4c0
-		Damage: 2
-			Delay: 32
-		InvalidTargets: MADTank, Infantry
-	Warhead@29mu: LeaveSmudge
+		Damage: 3
 		Delay: 32
-		SmudgeType: Crater
-		Size: 4
+		InvalidTargets: MADTank, Infantry
 	Warhead@5Dam: HealthPercentageDamage
 		Spread: 5c0
-		Damage: 2
-			Delay: 40
+		Damage: 3
+		Delay: 40
 		InvalidTargets: MADTank, Infantry
 	Warhead@30mu: LeaveSmudge
 		Delay: 40
@@ -309,34 +301,21 @@ MADTankThump:
 		Size: 5
 	Warhead@6Dam: HealthPercentageDamage
 		Spread: 6c0
-		Damage: 2
-			Delay: 48
-		InvalidTargets: MADTank, Infantry
-	Warhead@31mu: LeaveSmudge
+		Damage: 3
 		Delay: 48
-		SmudgeType: Crater
-		Size: 6
+		InvalidTargets: MADTank, Infantry
 	Warhead@7Dam: HealthPercentageDamage
 		Spread: 7c0
-		Damage: 2
-			Delay: 56
+		Damage: 3
+		Delay: 56
 		InvalidTargets: MADTank, Infantry
 	Warhead@32mu: LeaveSmudge
 		Delay: 56
 		SmudgeType: Crater
 		Size: 7
-		
+	
 MADTankDetonate:
 	InvalidTargets: MADTank, Infantry
-	Warhead@1Dam: HealthPercentageDamage
-		Spread: 7c0
-		Damage: 19
-		InvalidTargets: MADTank, Infantry
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: Crater
-		Size: 7,6
 	Warhead@3Eff: CreateEffect
 		Explosion: med_explosion
 		ImpactSound: mineblo1.aud
-
-

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -264,7 +264,7 @@ MADTankThump:
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 1c0
-		damage: 2
+		Damage: 2
 			Delay: 8
 		InvalidTargets: MADTank, Infantry
 	Warhead@26mu: LeaveSmudge


### PR DESCRIPTION
the Mad tank has been changed so that it is more useful as a support infantry unit that still causes devastation
video: https://vid.me/CXgI

p.s forget about the other PR of this.... it was a grave mistake 
on the up side I spell checked it! now Damage is spelt with a capital :dancer: 
