### PR TITLE
Don't update player list when lobby doesn't have our client yet

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -776,6 +776,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void UpdatePlayerList()
 		{
+			if (orderManager.LocalClient == null)
+				return;
+
 			var idx = 0;
 			foreach (var kv in orderManager.LobbyInfo.Slots)
 			{


### PR DESCRIPTION
Fixes #10450.

I was actually only able to reproduce this once (on the first try, too), never again after that. But with the crash happening on [this line](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs#L895), it's pretty clear what's going on. Since quite a few more things are referencing that, I decided to move the check up to the top of the method. It's probably fair to assume that both the loops running before the check in line 895 would have iterated over empty collections anyway, so they wouldn't have done anything useful, so we might just as well bail out early.
