### PR TITLE
Fix shroud not updating when disabled

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -22,8 +22,6 @@ namespace OpenRA.Traits
 
 	public class Shroud : ISync
 	{
-		[Sync] public bool Disabled;
-
 		public event Action<IEnumerable<PPos>> CellsChanged;
 
 		readonly Actor self;
@@ -37,6 +35,24 @@ namespace OpenRA.Traits
 		// can't make us invalid.
 		readonly Dictionary<Actor, PPos[]> visibility = new Dictionary<Actor, PPos[]>();
 		readonly Dictionary<Actor, PPos[]> generation = new Dictionary<Actor, PPos[]>();
+
+		[Sync] bool disabled;
+		public bool Disabled
+		{
+			get
+			{
+				return disabled;
+			}
+
+			set
+			{
+				if (disabled == value)
+					return;
+
+				disabled = value;
+				Invalidate(map.ProjectedCellBounds);
+			}
+		}
 
 		public int Hash { get; private set; }
 
@@ -270,7 +286,7 @@ namespace OpenRA.Traits
 		public bool IsExplored(PPos puv)
 		{
 			if (!ShroudEnabled)
-				return true;
+				return map.Contains(puv);
 
 			var uv = (MPos)puv;
 			return explored.Contains(uv) && explored[uv] && (generatedShroudCount[uv] == 0 || visibleCount[uv] > 0);
@@ -304,7 +320,7 @@ namespace OpenRA.Traits
 		public bool IsVisible(PPos puv)
 		{
 			if (!FogEnabled)
-				return true;
+				return map.Contains(puv);
 
 			var uv = (MPos)puv;
 			return visibleCount.Contains(uv) && visibleCount[uv] > 0;

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -242,12 +242,12 @@ namespace OpenRA.Mods.Common.Traits
 					shroud.CellsChanged += DirtyCells;
 
 				// Needs the anonymous function to ensure the correct overload is chosen
-				if (shroud != null && shroud.ShroudEnabled)
+				if (shroud != null)
 					visibleUnderShroud = puv => currentShroud.IsExplored(puv);
 				else
 					visibleUnderShroud = puv => map.Contains(puv);
 
-				if (shroud != null && shroud.FogEnabled)
+				if (shroud != null)
 					visibleUnderFog = puv => currentShroud.IsVisible(puv);
 				else
 					visibleUnderFog = puv => map.Contains(puv);


### PR DESCRIPTION
If you disable visibility checks using the debug options, the affected areas of the shroud are not refreshed.

This can be most easily seen during a replay if you spectate a player who used this option, as your view of the shroud remains outdated until units move through it.

![](http://imgur.com/sEfyiEY.png)

Suggested changelog: Fix shroud not updating when "Disable Visibility Checks" is used.
