### PR TITLE
Truncate SoundDevice label at the UI level.

### DIFF
--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -37,10 +37,6 @@ namespace OpenRA
 			Engine = engine;
 			Device = device;
 			Label = label;
-
-			// Limit label to 32 characters
-			if (Label.Length > 32)
-				Label = "..." + Label.Substring(Label.Length - 32);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -335,7 +335,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var audioDeviceDropdown = panel.Get<DropDownButtonWidget>("AUDIO_DEVICE");
 			audioDeviceDropdown.OnMouseDown = _ => ShowAudioDeviceDropdown(audioDeviceDropdown, devices);
-			audioDeviceDropdown.GetText = () => soundDevice.Label;
+
+			var deviceFont = Game.Renderer.Fonts[audioDeviceDropdown.Font];
+			var deviceLabel = new CachedTransform<SoundDevice, string>(
+				s => WidgetUtils.TruncateText(s.Label, audioDeviceDropdown.UsableWidth, deviceFont));
+			audioDeviceDropdown.GetText = () => deviceLabel.Update(soundDevice);
 
 			return () =>
 			{
@@ -644,7 +648,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() => soundDevice == options[o],
 					() => soundDevice = options[o]);
 
-				item.Get<LabelWidget>("LABEL").GetText = () => options[o].Label;
+				var deviceLabel = item.Get<LabelWidget>("LABEL");
+				var font = Game.Renderer.Fonts[deviceLabel.Font];
+				var label = WidgetUtils.TruncateText(options[o].Label, deviceLabel.Bounds.Width, font);
+				deviceLabel.GetText = () => label;
 				return item;
 			};
 


### PR DESCRIPTION
For consistency with the rest of our UI code. Closes #5723.
