### PR TITLE
Disable modifiers on the d2k move flash palette.

### DIFF
--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -37,6 +37,7 @@
 		Filename: DATA.R8
 		Offset: 2572352
 		InvertColor: true
+		AllowModifiers: false
 	PaletteFromRGBA@disabled:
 		Name: disabled
 		R: 0


### PR DESCRIPTION
Fixes #9045.
