### PR TITLE
Fixed crashes with Red Alert 2 wav files

### DIFF
--- a/OpenRA.Game/FileFormats/AudLoader.cs
+++ b/OpenRA.Game/FileFormats/AudLoader.cs
@@ -170,6 +170,7 @@ namespace OpenRA.FileFormats
 			out int sampleRate)
 		{
 			channels = sampleBits = sampleRate = 0;
+			var position = stream.Position;
 
 			try
 			{
@@ -186,6 +187,10 @@ namespace OpenRA.FileFormats
 				Log.Write("sound", e.ToString());
 				rawData = null;
 				return false;
+			}
+			finally
+			{
+				stream.Position = position;
 			}
 
 			channels = 1;

--- a/OpenRA.Game/FileFormats/AudLoader.cs
+++ b/OpenRA.Game/FileFormats/AudLoader.cs
@@ -182,8 +182,8 @@ namespace OpenRA.FileFormats
 				// If not, it will simply return false so we know we can't use it. If it is, it will start
 				// parsing the data without any further failsafes, which means that it will crash on corrupted files
 				// (that end prematurely or otherwise don't conform to the specifications despite the headers being OK).
-				Log.Write("debug", "Failed to parse AUD file {0}. Error message:".F(fileName));
-				Log.Write("debug", e.ToString());
+				Log.Write("sound", "Failed to parse AUD file {0}. Error message:".F(fileName));
+				Log.Write("sound", e.ToString());
 				rawData = null;
 				return false;
 			}

--- a/OpenRA.Game/FileFormats/AudLoader.cs
+++ b/OpenRA.Game/FileFormats/AudLoader.cs
@@ -125,12 +125,12 @@ namespace OpenRA.FileFormats
 			sampleRate = s.ReadUInt16();
 			var dataSize = s.ReadInt32();
 			var outputSize = s.ReadInt32();
-			var readFlag = s.ReadByte();
-			var readFormat = s.ReadByte();
 
+			var readFlag = s.ReadByte();
 			if (!Enum.IsDefined(typeof(SoundFlags), readFlag))
 				return false;
 
+			var readFormat = s.ReadByte();
 			if (!Enum.IsDefined(typeof(SoundFormat), readFormat))
 				return false;
 

--- a/OpenRA.Game/FileFormats/VocLoader.cs
+++ b/OpenRA.Game/FileFormats/VocLoader.cs
@@ -19,6 +19,8 @@ namespace OpenRA.FileFormats
 	{
 		bool ISoundLoader.TryParseSound(Stream stream, string fileName, out byte[] rawData, out int channels, out int sampleBits, out int sampleRate)
 		{
+			var position = stream.Position;
+
 			try
 			{
 				var vocStream = new VocStream(stream);
@@ -32,6 +34,10 @@ namespace OpenRA.FileFormats
 				rawData = null;
 				channels = sampleBits = sampleRate = 0;
 				return false;
+			}
+			finally
+			{
+				stream.Position = position;
 			}
 
 			return true;

--- a/OpenRA.Game/FileFormats/WavLoader.cs
+++ b/OpenRA.Game/FileFormats/WavLoader.cs
@@ -181,6 +181,7 @@ namespace OpenRA.FileFormats
 		{
 			rawData = null;
 			channels = sampleBits = sampleRate = 0;
+			var position = stream.Position;
 
 			try
 			{
@@ -196,6 +197,10 @@ namespace OpenRA.FileFormats
 				Log.Write("sound", "Failed to parse WAV file {0}. Error message:".F(fileName));
 				Log.Write("sound", e.ToString());
 				return false;
+			}
+			finally
+			{
+				stream.Position = position;
 			}
 
 			rawData = RawOutput;

--- a/OpenRA.Game/FileFormats/WavLoader.cs
+++ b/OpenRA.Game/FileFormats/WavLoader.cs
@@ -68,24 +68,17 @@ namespace OpenRA.FileFormats
 						s.ReadBytes(FmtChunkSize - 16);
 						break;
 					case "fact":
-						{
-							var chunkSize = s.ReadInt32();
-							UncompressedSize = s.ReadInt32();
-							s.ReadBytes(chunkSize - 4);
-						}
-
+						var chunkSize = s.ReadInt32();
+						UncompressedSize = s.ReadInt32();
+						s.ReadBytes(chunkSize - 4);
 						break;
 					case "data":
 						DataSize = s.ReadInt32();
 						RawOutput = s.ReadBytes(DataSize);
 						break;
 					default:
-						// Ignore unknown chunks
-						{
-							var chunkSize = s.ReadInt32();
-							s.ReadBytes(chunkSize);
-						}
-
+						var unknownChunkSize = s.ReadInt32();
+						s.ReadBytes(unknownChunkSize);
 						break;
 				}
 			}

--- a/OpenRA.Game/FileFormats/WavLoader.cs
+++ b/OpenRA.Game/FileFormats/WavLoader.cs
@@ -201,8 +201,8 @@ namespace OpenRA.FileFormats
 				// If not, it will simply return false so we know we can't use it. If it is, it will start
 				// parsing the data without any further failsafes, which means that it will crash on corrupted files
 				// (that end prematurely or otherwise don't conform to the specifications despite the headers being OK).
-				Log.Write("debug", "Failed to parse WAV file {0}. Error message:".F(fileName));
-				Log.Write("debug", e.ToString());
+				Log.Write("sound", "Failed to parse WAV file {0}. Error message:".F(fileName));
+				Log.Write("sound", e.ToString());
 				return false;
 			}
 

--- a/OpenRA.Game/FileFormats/WavLoader.cs
+++ b/OpenRA.Game/FileFormats/WavLoader.cs
@@ -43,7 +43,6 @@ namespace OpenRA.FileFormats
 			Format = s.ReadASCII(4);
 			if (Format != "WAVE")
 				return false;
-
 			while (s.Position < s.Length)
 			{
 				if ((s.Position & 1) == 1)
@@ -57,8 +56,8 @@ namespace OpenRA.FileFormats
 						AudioFormat = s.ReadInt16();
 						Type = (WaveType)AudioFormat;
 
-						if (Type != WaveType.Pcm && Type != WaveType.ImaAdpcm)
-							throw new NotSupportedException("Compression type is not supported.");
+						if (!Enum.IsDefined(typeof(WaveType), Type))
+							throw new NotSupportedException("Compression type {0} is not supported.".F(AudioFormat));
 
 						Channels = s.ReadInt16();
 						SampleRate = s.ReadInt32();

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -63,11 +63,8 @@ namespace OpenRA
 				int sampleBits;
 				int sampleRate;
 				foreach (var loader in Game.ModData.SoundLoaders)
-				{
-					stream.Position = 0;
 					if (loader.TryParseSound(stream, filename, out rawData, out channels, out sampleBits, out sampleRate))
 						return soundEngine.AddSoundSourceFromMemory(rawData, channels, sampleBits, sampleRate);
-				}
 
 				throw new InvalidDataException(filename + " is not a valid sound file!");
 			}


### PR DESCRIPTION
The recent changes made the https://github.com/OpenRA/ra2 mod unplayable. Even clicking a button crashes the whole game. This reverts parts of https://github.com/OpenRA/OpenRA/commit/5063e56786c7aa47dda640df6a8acf3d6a941c3a to aid debugging. I stumbled upon some `if (Format != "WAVE")` cases with `Format = "fmt"` so this rejected valid *.wav files without reason. ~~It won't fix it completely though. Something else is still bogus.~~ The generic exceptions "not a valid sound file" are far from useful so I put it into the appropriate log files.
