### PR TITLE
Add a debug setting to draw the RenderBounds of Widgets.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -91,6 +91,7 @@ namespace OpenRA
 		public bool SanityCheckUnsyncedCode = false;
 		public int Samples = 25;
 		public bool IgnoreVersionMismatch = false;
+		public bool WidgetRenderBoundsLines = false;
 	}
 
 	public class GraphicSettings

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -587,6 +587,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "BOTDEBUG_CHECKBOX", ds, "BotDebug");
 			BindCheckboxPref(panel, "FETCH_NEWS_CHECKBOX", gs, "FetchNews");
 			BindCheckboxPref(panel, "LUADEBUG_CHECKBOX", ds, "LuaDebug");
+			BindCheckboxPref(panel, "WIDGETDEBUG_CHECKBOX", ds, "WidgetRenderBoundsLines");
 
 			return () => { };
 		}

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -549,6 +549,14 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Show Map Debug Messages
+						Checkbox@WIDGETDEBUG_CHECKBOX:
+							X: 15
+							Y: 220
+							Width: 300
+							Height: 20
+							Font: Regular
+							Text: Draw Widget RenderBounds
+
 		Button@BACK_BUTTON:
 			Key: escape
 			Y: 393

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -543,6 +543,13 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Check Sync around Unsynced Code
+				Checkbox@WIDGETDEBUG_CHECKBOX:
+					X: 15
+					Y: 220
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Draw Widget RenderBounds
 				Checkbox@LUADEBUG_CHECKBOX:
 					X: 310
 					Y: 190


### PR DESCRIPTION
![screen shot 2016-01-12 at 1 09 27 pm](https://cloud.githubusercontent.com/assets/4861023/12274114/ebf65d32-b92e-11e5-9547-1be6fb8ce7d8.png)

![screen shot 2016-01-12 at 1 22 48 pm](https://cloud.githubusercontent.com/assets/4861023/12274249/a35bfea0-b92f-11e5-827c-15fcfda1af94.png)

Useful for debugging position and size of widgets.
Hopefully more to come.
