### PR TITLE
Disable color validation for locked colors.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -136,8 +136,11 @@ namespace OpenRA.Mods.Common.Server
 						client.Slot = s;
 						S.SyncClientToPlayerReference(client, server.MapPlayers.Players[s]);
 
-						var validatedColor = ColorValidator.ValidatePlayerColorAndGetAlternative(server, client.Color, client.Index, conn);
-						client.PreferredColor = client.Color = validatedColor;
+						if (!slot.LockColor)
+						{
+							var validatedColor = ColorValidator.ValidatePlayerColorAndGetAlternative(server, client.Color, client.Index, conn);
+							client.PreferredColor = client.Color = validatedColor;
+						}
 
 						server.SyncLobbyClients();
 						CheckAutoStart(server);
@@ -368,7 +371,8 @@ namespace OpenRA.Mods.Common.Server
 						foreach (var c in server.LobbyInfo.Clients)
 						{
 							// Validate if color is allowed and get an alternative it isn't
-							c.Color = c.PreferredColor = ColorValidator.ValidatePlayerColorAndGetAlternative(server, c.Color, c.Index, conn);
+							if (c.Slot == null || (c.Slot != null && !server.LobbyInfo.Slots[c.Slot].LockColor))
+								c.Color = c.PreferredColor = ColorValidator.ValidatePlayerColorAndGetAlternative(server, c.Color, c.Index, conn);
 						}
 
 						server.SyncLobbyInfo();


### PR DESCRIPTION
Fixes #7899.

Testcase: set `Visibility: Lobby` on "Storm the Beachhead" or another GDI campaign mission and select it in the skirmish lobby.
