### PR TITLE
Cancel tooltips when opening the ingame menu.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -117,6 +117,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			});
 
 			currentWidget = Game.LoadWidget(world, button.MenuContainer, menuRoot, widgetArgs);
+			Game.RunAfterTick(Ui.ResetTooltips);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #6936.

Testcase: hover the cursor over an actor until the tooltip shows, then press escape to open the menu.
