### PR TITLE
Cancel custom input modes when opening the menu.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -98,7 +98,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var cachedPause = world.PredictedPaused;
 
 			if (button.HideIngameUI)
+			{
+				// Cancel custom input modes (guard, building placement, etc)
+				world.CancelInputMode();
+
 				worldRoot.IsVisible = () => false;
+			}
 
 			if (button.Pause && world.LobbyInfo.IsSinglePlayer)
 				world.SetPauseState(true);


### PR DESCRIPTION
Fixes #3277.

Testcase: Enter the building placement mode and then press escape to open the menu.
