### PR TITLE
Use height offset when rendering voxels.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -219,7 +219,7 @@ namespace OpenRA.Graphics
 		public void ScreenVectorComponents(WVec vec, out float x, out float y, out float z)
 		{
 			x = TileSize.Width * vec.X / 1024f;
-			y = TileSize.Height * vec.Y / 1024f;
+			y = TileSize.Height * (vec.Y - vec.Z) / 1024f;
 			z = TileSize.Height * vec.Z / 1024f;
 		}
 
@@ -236,7 +236,7 @@ namespace OpenRA.Graphics
 			// Round to nearest pixel
 			float x, y, z;
 			ScreenVectorComponents(vec, out x, out y, out z);
-			return new int2((int)Math.Round(x), (int)Math.Round(y - z));
+			return new int2((int)Math.Round(x), (int)Math.Round(y));
 		}
 
 		public float ScreenZPosition(WPos pos, int offset)

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -44,19 +44,25 @@ namespace OpenRA.Mods.Common.Traits
 
 			var turretFacing = Turreted.GetInitialTurretFacing(init, t.InitialFacing, t.Turret);
 			var turretOrientation = body.QuantizeOrientation(new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(turretFacing) - orientation.Yaw), facings);
-			var turretOffset = body.LocalToWorld(t.Offset.Rotate(orientation));
 
-			yield return new VoxelAnimation(voxel, () => turretOffset, () => new[] { turretOrientation, orientation },
+			var quantizedTurret = body.QuantizeOrientation(turretOrientation, facings);
+			var quantizedBody = body.QuantizeOrientation(orientation, facings);
+			var barrelOffset = body.LocalToWorld((t.Offset + LocalOffset.Rotate(quantizedTurret)).Rotate(quantizedBody));
+
+			yield return new VoxelAnimation(voxel, () => barrelOffset, () => new[] { turretOrientation, orientation },
 				() => false, () => 0);
 		}
 	}
 
-	public class WithVoxelBarrel : UpgradableTrait<WithVoxelBarrelInfo>
+	public class WithVoxelBarrel : UpgradableTrait<WithVoxelBarrelInfo>, INotifyBuildComplete, INotifySold, INotifyTransform
 	{
 		readonly Actor self;
 		readonly Armament armament;
 		readonly Turreted turreted;
 		readonly BodyOrientation body;
+
+		// TODO: This should go away once https://github.com/OpenRA/OpenRA/issues/7035 is implemented
+		bool buildComplete;
 
 		public WithVoxelBarrel(Actor self, WithVoxelBarrelInfo info)
 			: base(info)
@@ -68,21 +74,23 @@ namespace OpenRA.Mods.Common.Traits
 			turreted = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == armament.Info.Turret);
 
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
+
 			var rv = self.Trait<RenderVoxels>();
 			rv.Add(new VoxelAnimation(VoxelProvider.GetVoxel(rv.Image, Info.Sequence),
 				BarrelOffset, BarrelRotation,
-				() => IsTraitDisabled, () => 0));
+				() => IsTraitDisabled || !buildComplete, () => 0));
 		}
 
 		WVec BarrelOffset()
 		{
 			var localOffset = Info.LocalOffset + new WVec(-armament.Recoil, WDist.Zero, WDist.Zero);
-			var turretOffset = turreted != null ? turreted.Position(self) : WVec.Zero;
+			var turretLocalOffset = turreted != null ? turreted.Offset : WVec.Zero;
 			var turretOrientation = turreted != null ? turreted.LocalOrientation(self) : WRot.Zero;
 
 			var quantizedBody = body.QuantizeOrientation(self, self.Orientation);
 			var quantizedTurret = body.QuantizeOrientation(self, turretOrientation);
-			return turretOffset + body.LocalToWorld(localOffset.Rotate(quantizedTurret).Rotate(quantizedBody));
+			return body.LocalToWorld((turretLocalOffset + localOffset.Rotate(quantizedTurret)).Rotate(quantizedBody));
 		}
 
 		IEnumerable<WRot> BarrelRotation()
@@ -92,5 +100,12 @@ namespace OpenRA.Mods.Common.Traits
 			yield return turreted.LocalOrientation(self) + WRot.FromYaw(b.Yaw - qb.Yaw);
 			yield return qb;
 		}
+
+		void INotifyBuildComplete.BuildingComplete(Actor self) { buildComplete = true; }
+		void INotifySold.Selling(Actor self) { buildComplete = false; }
+		void INotifySold.Sold(Actor self) { }
+		void INotifyTransform.BeforeTransform(Actor self) { buildComplete = false; }
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor toActor) { }
 	}
 }

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -52,17 +52,19 @@ NALASR:
 	Turreted:
 		ROT: 10
 		InitialFacing: 300
-		Offset: 298,-171,0
+		Offset: 298,-171,288
 	AttackTurreted:
 	Armament:
 		Weapon: TurretLaserFire
-		LocalOffset: 0, 0, 200
+		LocalOffset: 352, 0, 224
 	RenderVoxels:
 	WithVoxelTurret:
 	Power:
 		Amount: -40
 	SelectionDecorations:
 		VisualBounds: 40, 36, -8, -8
+	BodyOrientation:
+		QuantizedFacings: 0
 
 NAOBEL:
 	Inherits: ^Defense

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -151,7 +151,7 @@ GATICK:
 	Valued:
 		Cost: 800
 	Tooltip:
-		Name: Deployed Tick Tank
+		Name: Tick Tank
 	Health:
 		HP: 350
 	Armor:
@@ -160,18 +160,18 @@ GATICK:
 		Range: 5c0
 	Turreted:
 		ROT: 6
-		InitialFacing: 128
-		Offset: 170,0,213
+		InitialFacing: 224
+		Offset: 0,96,224
 	Armament@PRIMARY:
 		Weapon: 90mm
-		LocalOffset: 384,0,128
+		LocalOffset: 448,0,348
 		UpgradeTypes: eliteweapon
 		UpgradeMaxEnabledLevel: 0
 		UpgradeMaxAcceptedLevel: 1
 		MuzzleSequence: muzzle
 	Armament@ELITE:
 		Weapon: 120mmx
-		LocalOffset: 384,0,128
+		LocalOffset: 448,0,348
 		UpgradeTypes: eliteweapon
 		UpgradeMinEnabledLevel: 1
 		MuzzleSequence: muzzle
@@ -179,7 +179,7 @@ GATICK:
 		QuantizedFacings: 32
 	RenderVoxels:
 	WithVoxelBarrel:
-		LocalOffset: 170,0,0
+		LocalOffset: 128,0,348
 	WithVoxelTurret:
 	Transforms:
 		IntoActor: ttnk


### PR DESCRIPTION
Fixes #9522 and improves the offsets for the laser turret and deployed tick tank as testcases.

This is one of N immediate prereqs for fixing #4823.
