### PR TITLE
Remove Util.GetFacing.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -915,7 +915,11 @@ namespace OpenRA
 
 		public int FacingBetween(CPos cell, CPos towards, int fallbackfacing)
 		{
-			return Traits.Util.GetFacing(CenterOfCell(towards) - CenterOfCell(cell), fallbackfacing);
+			var delta = CenterOfCell(towards) - CenterOfCell(cell);
+			if (delta.HorizontalLengthSquared == 0)
+				return fallbackfacing;
+
+			return delta.Yaw.Facing;
 		}
 
 		public void Resize(int width, int height)		// editor magic.

--- a/OpenRA.Game/Traits/Util.cs
+++ b/OpenRA.Game/Traits/Util.cs
@@ -31,18 +31,6 @@ namespace OpenRA.Traits
 				return (facing - rot) & 0xFF;
 		}
 
-		public static int GetFacing(WVec d, int currentFacing)
-		{
-			if (d.LengthSquared == 0)
-				return currentFacing;
-
-			// OpenRA defines north as -y, so invert
-			var angle = WAngle.ArcTan(-d.Y, d.X, 4).Angle;
-
-			// Convert back to a facing
-			return (angle / 4 - 0x40) & 0xFF;
-		}
-
 		public static int GetNearestFacing(int facing, int desiredFacing)
 		{
 			var turn = desiredFacing - facing;

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -41,6 +41,8 @@ namespace OpenRA
 		public bool Equals(WAngle other) { return other == this; }
 		public override bool Equals(object obj) { return obj is WAngle && Equals((WAngle)obj); }
 
+		public int Facing { get { return Angle / 4; } }
+
 		public int Sin() { return new WAngle(Angle - 256).Cos(); }
 
 		public int Cos()

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -58,6 +58,18 @@ namespace OpenRA
 				(int)((lx * mtx[2] + ly * mtx[6] + lz * mtx[10]) / mtx[15]));
 		}
 
+		public WAngle Yaw
+		{
+			get
+			{
+				if (LengthSquared == 0)
+					return WAngle.Zero;
+
+				// OpenRA defines north as -y
+				return WAngle.ArcTan(-Y, X) - new WAngle(256);
+			}
+		}
+
 		public static WVec Lerp(WVec a, WVec b, int mul, int div) { return a + (b - a) * mul / div; }
 
 		public static WVec LerpQuadratic(WVec a, WVec b, WAngle pitch, int mul, int div)
@@ -134,7 +146,7 @@ namespace OpenRA
 					case "X": return X;
 					case "Y": return Y;
 					case "Z": return Z;
-					case "Facing": return Traits.Util.GetFacing(this, 0);
+					case "Facing": return Yaw.Facing;
 					default: throw new LuaException("WVec does not define a member '{0}'".F(key));
 				}
 			}

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -70,9 +70,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (d.HorizontalLengthSquared < 91022)
 				return NextActivity;
 
-			var desiredFacing = Util.GetFacing(d, plane.Facing);
-
 			// Don't turn until we've reached the cruise altitude
+			var desiredFacing = d.Yaw.Facing;
 			var targetAltitude = plane.CenterPosition.Z + plane.Info.CruiseAltitude.Length - self.World.Map.DistanceAboveTerrain(plane.CenterPosition).Length;
 			if (plane.CenterPosition.Z < targetAltitude)
 				desiredFacing = plane.Facing;

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Activities
 			var dist = target.CenterPosition - self.CenterPosition;
 
 			// Can rotate facing while ascending
-			var desiredFacing = Util.GetFacing(dist, helicopter.Facing);
+			var desiredFacing = dist.HorizontalLengthSquared != 0 ? dist.Yaw.Facing : helicopter.Facing;
 			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.ROT);
 
 			if (HeliFly.AdjustAltitude(self, helicopter, helicopter.Info.CruiseAltitude))

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Rotate towards the target
 			var dist = pos - self.CenterPosition;
-			var desiredFacing = Util.GetFacing(dist, helicopter.Facing);
+			var desiredFacing = dist.HorizontalLengthSquared != 0 ? dist.Yaw.Facing : helicopter.Facing;
 			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.ROT);
 			var move = helicopter.FlyStep(desiredFacing);
 

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -43,8 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			var desiredFacing = Util.GetFacing(d, plane.Facing);
-			Fly.FlyToward(self, plane, desiredFacing, WDist.Zero);
+			Fly.FlyToward(self, plane, d.Yaw.Facing, WDist.Zero);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (move != null && (!Target.IsInRange(self.CenterPosition, maxRange) || Target.IsInRange(self.CenterPosition, minRange)))
 				return Util.SequenceActivities(move.MoveWithinRange(Target, minRange, maxRange), this);
 
-			var desiredFacing = Util.GetFacing(Target.CenterPosition - self.CenterPosition, 0);
+			var desiredFacing = (Target.CenterPosition - self.CenterPosition).Yaw.Facing;
 			if (facing.Facing != desiredFacing)
 				return Util.SequenceActivities(new Turn(self, desiredFacing), this);
 

--- a/OpenRA.Mods.Common/Effects/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Effects/AreaBeam.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Effects
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
 
-			towardsTargetFacing = OpenRA.Traits.Util.GetFacing(target - headPos, 0);
+			towardsTargetFacing = (target - headPos).Yaw.Facing;
 
 			// Update the target position with the range we shoot beyond the target by
 			// I.e. we can deliberately overshoot, so aim for that position

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Effects
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
 
-			facing = OpenRA.Traits.Util.GetFacing(target - pos, 0);
+			facing = (target - pos).Yaw.Facing;
 			length = Math.Max((target - pos).Length / speed.Length, 1);
 
 			if (!string.IsNullOrEmpty(info.Image))

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -169,13 +169,11 @@ namespace OpenRA.Mods.Common.Traits
 		public void Repulse()
 		{
 			var repulsionForce = GetRepulsionForce();
-
-			var repulsionFacing = Util.GetFacing(repulsionForce, -1);
-			if (repulsionFacing == -1)
+			if (repulsionForce.HorizontalLengthSquared == 0)
 				return;
 
 			var speed = Info.RepulsionSpeed != -1 ? Info.RepulsionSpeed : MovementSpeed;
-			SetPosition(self, CenterPosition + FlyStep(speed, repulsionFacing));
+			SetPosition(self, CenterPosition + FlyStep(speed, repulsionForce.Yaw.Facing));
 		}
 
 		public virtual WVec GetRepulsionForce()

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -54,7 +54,8 @@ namespace OpenRA.Mods.Common.Traits
 			inAttackRange = false;
 
 			var f = facing.Value.Facing;
-			var facingToTarget = Util.GetFacing(target.CenterPosition - self.CenterPosition, f);
+			var delta = target.CenterPosition - self.CenterPosition;
+			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 			facingTarget = Math.Abs(facingToTarget - f) % 256 <= info.FacingTolerance;
 
 			// Bombs drop anywhere in range

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var f = facing.Value.Facing;
-			var facingToTarget = Util.GetFacing(target.CenterPosition - self.CenterPosition, f);
+			var delta = target.CenterPosition - self.CenterPosition;
+			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 
 			if (Math.Abs(facingToTarget - f) % 256 > info.FacingTolerance)
 				return false;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var pos = self.CenterPosition;
-			var targetYaw = WAngle.FromFacing(OpenRA.Traits.Util.GetFacing(target.CenterPosition - self.CenterPosition, 0));
+			var targetYaw = (target.CenterPosition - self.CenterPosition).Yaw;
 
 			foreach (var a in Armaments)
 			{

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -796,7 +796,8 @@ namespace OpenRA.Mods.Common.Traits
 			var speed = MovementSpeedForCell(self, cell);
 			var length = speed > 0 ? (toPos - fromPos).Length / speed : 0;
 
-			var facing = Util.GetFacing(toPos - fromPos, Facing);
+			var delta = toPos - fromPos;
+			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : Facing;
 			return Util.SequenceActivities(new Turn(self, facing), new Drag(self, fromPos, toPos, length));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -63,8 +63,18 @@ namespace OpenRA.Mods.Common.Traits
 				var spawn = self.CenterPosition + exitinfo.SpawnOffset;
 				var to = self.World.Map.CenterOfCell(exit);
 
-				var fi = producee.TraitInfoOrDefault<IFacingInfo>();
-				var initialFacing = exitinfo.Facing < 0 ? Util.GetFacing(to - spawn, fi == null ? 0 : fi.GetInitialFacing()) : exitinfo.Facing;
+				var initialFacing = exitinfo.Facing;
+				if (exitinfo.Facing < 0)
+				{
+					var delta = to - spawn;
+					if (delta.HorizontalLengthSquared == 0)
+					{
+						var fi = producee.TraitInfoOrDefault<IFacingInfo>();
+						initialFacing = fi != null ? fi.GetInitialFacing() : 0;
+					}
+					else
+						initialFacing = delta.Yaw.Facing;
+				}
 
 				exitLocation = rp.Value != null ? rp.Value.Location : exit;
 				target = Target.FromCell(self.World, exitLocation);

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -110,7 +110,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool FaceTarget(Actor self, Target target)
 		{
-			DesiredFacing = Util.GetFacing(target.CenterPosition - self.CenterPosition, TurretFacing);
+			var delta = target.CenterPosition - self.CenterPosition;
+			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();
 			return TurretFacing == DesiredFacing.Value;
 		}


### PR DESCRIPTION
This introduces WVec.Yaw and WAngle.Facing primitives, and uses them instead of Util.GetFacing.
This is another small step towards fixing our horrible facing code (which is required for proper handling of TS slopes), and is an immediate blocker to fixing #4823.
