### PR TITLE
Fix a crash if an order generator is active when a game ends.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var optionsButton = playerRoot.GetOrNull<MenuButtonWidget>("OPTIONS_BUTTON");
 				if (optionsButton != null)
-					optionsButton.OnClick();
+					Sync.CheckSyncUnchanged(world, optionsButton.OnClick);
 			};
 		}
 	}


### PR DESCRIPTION
The UI code expects to be run from an unsynced context, and as of #10509 it asserts this requirement with an exception (via the world.OrderGenerator setter).  This leads to a crash if you have PBOG or another order generator active when the GameOver event fires and the options button click handler cancels the OG.

Repro case: Destroy your last base building while having the building placement order generator active.
