### PR TITLE
Split IPackage into IReadOnlyPackage and IReadWritePackage

### DIFF
--- a/OpenRA.Game/FileSystem/BagFile.cs
+++ b/OpenRA.Game/FileSystem/BagFile.cs
@@ -19,7 +19,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class BagFile : IPackage
+	public sealed class BagFile : IReadOnlyPackage
 	{
 		static readonly uint[] Nothing = { };
 
@@ -173,12 +173,6 @@ namespace OpenRA.FileSystem
 			}
 
 			return index.Keys.Select(k => lookup.ContainsKey(k) ? lookup[k] : "{0:X}".F(k));
-		}
-
-		public void Write(Dictionary<string, byte[]> contents)
-		{
-			context.Unmount(this);
-			throw new NotImplementedException("Updating bag files unsupported");
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/FileSystem/BigFile.cs
+++ b/OpenRA.Game/FileSystem/BigFile.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class BigFile : IPackage
+	public sealed class BigFile : IReadOnlyPackage
 	{
 		public string Name { get; private set; }
 		public int Priority { get; private set; }
@@ -109,11 +109,6 @@ namespace OpenRA.FileSystem
 		public IEnumerable<string> AllFileNames()
 		{
 			return entries.Keys;
-		}
-
-		public void Write(Dictionary<string, byte[]> contents)
-		{
-			throw new NotImplementedException();
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/FileSystem/D2kSoundResources.cs
+++ b/OpenRA.Game/FileSystem/D2kSoundResources.cs
@@ -14,7 +14,7 @@ using System.IO;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class D2kSoundResources : IPackage
+	public sealed class D2kSoundResources : IReadOnlyPackage
 	{
 		readonly Stream s;
 
@@ -92,11 +92,6 @@ namespace OpenRA.FileSystem
 		public IEnumerable<uint> CrcHashes()
 		{
 			yield break;
-		}
-
-		public void Write(Dictionary<string, byte[]> contents)
-		{
-			throw new NotImplementedException("Cannot save Dune 2000 Sound Resources.");
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -30,22 +30,10 @@ namespace OpenRA.FileSystem
 
 		public IReadWritePackage CreatePackage(string filename, int order, Dictionary<string, byte[]> content)
 		{
-			if (filename.EndsWith(".mix", StringComparison.InvariantCultureIgnoreCase))
-				return new MixFile(this, filename, order, content);
 			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
 				return new ZipFile(this, filename, order, content);
 			if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))
 				return new ZipFile(this, filename, order, content);
-			if (filename.EndsWith(".RS", StringComparison.InvariantCultureIgnoreCase))
-				throw new NotImplementedException("The creation of .RS archives is unimplemented");
-			if (filename.EndsWith(".Z", StringComparison.InvariantCultureIgnoreCase))
-				throw new NotImplementedException("The creation of .Z archives is unimplemented");
-			if (filename.EndsWith(".PAK", StringComparison.InvariantCultureIgnoreCase))
-				throw new NotImplementedException("The creation of .PAK archives is unimplemented");
-			if (filename.EndsWith(".big", StringComparison.InvariantCultureIgnoreCase))
-				throw new NotImplementedException("The creation of .big archives is unimplemented");
-			if (filename.EndsWith(".cab", StringComparison.InvariantCultureIgnoreCase))
-				throw new NotImplementedException("The creation of .cab archives is unimplemented");
 
 			return new Folder(filename, order, content);
 		}

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -13,7 +13,7 @@ using System.IO;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class Folder : IPackage
+	public sealed class Folder : IReadWritePackage
 	{
 		readonly string path;
 		readonly int priority;

--- a/OpenRA.Game/FileSystem/IPackage.cs
+++ b/OpenRA.Game/FileSystem/IPackage.cs
@@ -14,15 +14,19 @@ using System.IO;
 
 namespace OpenRA.FileSystem
 {
-	public interface IPackage : IDisposable
+	public interface IReadOnlyPackage : IDisposable
 	{
 		Stream GetContent(string filename);
 		bool Exists(string filename);
 		IEnumerable<uint> ClassicHashes();
 		IEnumerable<uint> CrcHashes();
 		IEnumerable<string> AllFileNames();
-		void Write(Dictionary<string, byte[]> contents);
 		int Priority { get; }
 		string Name { get; }
+	}
+
+	public interface IReadWritePackage : IReadOnlyPackage
+	{
+		void Write(Dictionary<string, byte[]> contents);
 	}
 }

--- a/OpenRA.Game/FileSystem/InstallShieldCABExtractor.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldCABExtractor.cs
@@ -17,7 +17,7 @@ using ICSharpCode.SharpZipLib.Zip.Compression;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class InstallShieldCABExtractor : IPackage
+	public sealed class InstallShieldCABExtractor : IReadOnlyPackage
 	{
 		const uint FileSplit = 0x1;
 		const uint FileObfuscated = 0x2;
@@ -449,11 +449,6 @@ namespace OpenRA.FileSystem
 			Directory.CreateDirectory(Path.GetDirectoryName(fileName));
 			using (var destfile = File.Open(fileName, FileMode.Create))
 				GetContentById(index, destfile);
-		}
-
-		public void Write(Dictionary<string, byte[]> input)
-		{
-			throw new NotImplementedException("Cannot Add Files To Cab");
 		}
 
 		public IEnumerable<uint> ClassicHashes()

--- a/OpenRA.Game/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldPackage.cs
@@ -15,7 +15,7 @@ using OpenRA.FileFormats;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class InstallShieldPackage : IPackage
+	public sealed class InstallShieldPackage : IReadOnlyPackage
 	{
 		readonly Dictionary<uint, PackageEntry> index = new Dictionary<uint, PackageEntry>();
 		readonly List<string> filenames;

--- a/OpenRA.Game/FileSystem/MixFile.cs
+++ b/OpenRA.Game/FileSystem/MixFile.cs
@@ -18,7 +18,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class MixFile : IPackage
+	public sealed class MixFile : IReadWritePackage
 	{
 		readonly Dictionary<uint, PackageEntry> index;
 		readonly long dataStart;

--- a/OpenRA.Game/FileSystem/Pak.cs
+++ b/OpenRA.Game/FileSystem/Pak.cs
@@ -21,7 +21,7 @@ namespace OpenRA.FileSystem
 		public string Filename;
 	}
 
-	public sealed class PakFile : IPackage
+	public sealed class PakFile : IReadOnlyPackage
 	{
 		readonly string filename;
 		readonly int priority;
@@ -91,11 +91,6 @@ namespace OpenRA.FileSystem
 		public bool Exists(string filename)
 		{
 			return index.ContainsKey(filename);
-		}
-
-		public void Write(Dictionary<string, byte[]> contents)
-		{
-			throw new NotImplementedException("Cannot save Pak archives.");
 		}
 
 		public int Priority { get { return 1000 + priority; } }

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -17,7 +17,7 @@ using SZipFile = ICSharpCode.SharpZipLib.Zip.ZipFile;
 
 namespace OpenRA.FileSystem
 {
-	public sealed class ZipFile : IPackage
+	public sealed class ZipFile : IReadWritePackage
 	{
 		readonly string filename;
 		readonly int priority;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -157,7 +157,7 @@ namespace OpenRA
 		[FieldLoader.Ignore] public readonly WVec[] SubCellOffsets;
 		public readonly SubCell DefaultSubCell;
 		public readonly SubCell LastSubCell;
-		[FieldLoader.Ignore] public IPackage Container;
+		[FieldLoader.Ignore] public IReadWritePackage Container;
 		public string Path { get; private set; }
 
 		// Yaml map data
@@ -317,7 +317,7 @@ namespace OpenRA
 		public Map(string path)
 		{
 			Path = path;
-			Container = Game.ModData.ModFiles.OpenPackage(path, null, int.MaxValue);
+			Container = Game.ModData.ModFiles.OpenWritablePackage(path, int.MaxValue);
 
 			AssertExists("map.yaml");
 			AssertExists("map.bin");

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		ScrollPanelWidget assetList;
 		ScrollItemWidget template;
 
-		IPackage assetSource = null;
+		IReadOnlyPackage assetSource = null;
 		List<string> availableShps = new List<string>();
 		bool animateFrames = false;
 
@@ -334,7 +334,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool ShowSourceDropdown(DropDownButtonWidget dropdown)
 		{
-			Func<IPackage, ScrollItemWidget, ScrollItemWidget> setupItem = (source, itemTemplate) =>
+			Func<IReadOnlyPackage, ScrollItemWidget, ScrollItemWidget> setupItem = (source, itemTemplate) =>
 			{
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => assetSource == source,


### PR DESCRIPTION
Another small step towards mod-defined package parsers.  This also removes the ability to package maps as a mix file (which was the only place where we used the mix file writer).
