### PR TITLE
Auto-detect mix hash type.

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -36,7 +36,7 @@ namespace OpenRA.FileSystem
 			return new Folder(filename, order, content);
 		}
 
-		public IReadOnlyPackage OpenPackage(string filename, string annotation, int order)
+		public IReadOnlyPackage OpenPackage(string filename, int order)
 		{
 			if (filename.EndsWith(".mix", StringComparison.InvariantCultureIgnoreCase))
 				return new MixFile(this, filename, order);
@@ -76,7 +76,7 @@ namespace OpenRA.FileSystem
 				MountedPackages.Add(mount);
 		}
 
-		public void Mount(string name, string annotation = null)
+		public void Mount(string name)
 		{
 			var optional = name.StartsWith("~");
 			if (optional)
@@ -84,7 +84,7 @@ namespace OpenRA.FileSystem
 
 			name = Platform.ResolvePath(name);
 
-			Action a = () => MountInner(OpenPackage(name, annotation, order++));
+			Action a = () => MountInner(OpenPackage(name, order++));
 
 			if (optional)
 				try { a(); }
@@ -132,7 +132,7 @@ namespace OpenRA.FileSystem
 				Mount(dir);
 
 			foreach (var pkg in manifest.Packages)
-				Mount(pkg.Key, pkg.Value);
+				Mount(pkg);
 		}
 
 		Stream GetFromCache(string filename)

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -39,14 +39,7 @@ namespace OpenRA.FileSystem
 		public IReadOnlyPackage OpenPackage(string filename, string annotation, int order)
 		{
 			if (filename.EndsWith(".mix", StringComparison.InvariantCultureIgnoreCase))
-			{
-				var type = string.IsNullOrEmpty(annotation)
-					? PackageHashType.Classic
-					: FieldLoader.GetValue<PackageHashType>("(value)", annotation);
-
-				return new MixFile(this, filename, type, order);
-			}
-
+				return new MixFile(this, filename, order);
 			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
 				return new ZipFile(this, filename, order);
 			if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -36,12 +36,11 @@ namespace OpenRA
 
 		public readonly ModMetadata Mod;
 		public readonly string[]
-			Folders, Rules, ServerTraits,
+			Packages, Folders, Rules, ServerTraits,
 			Sequences, VoxelSequences, Cursors, Chrome, Assemblies, ChromeLayout,
 			Weapons, Voices, Notifications, Music, Translations, TileSets,
 			ChromeMetrics, MapCompatibility, Missions;
 
-		public readonly IReadOnlyDictionary<string, string> Packages;
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
 		public readonly MiniYaml LoadScreen;
 		public readonly MiniYaml LobbyDefaults;
@@ -75,7 +74,7 @@ namespace OpenRA
 			// TODO: Use fieldloader
 			Folders = YamlList(yaml, "Folders", true);
 			MapFolders = YamlDictionary(yaml, "MapFolders", true);
-			Packages = YamlDictionary(yaml, "Packages", true);
+			Packages = YamlList(yaml, "Packages", true);
 			Rules = YamlList(yaml, "Rules", true);
 			Sequences = YamlList(yaml, "Sequences", true);
 			VoxelSequences = YamlList(yaml, "VoxelSequences", true);

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -177,7 +177,7 @@ namespace OpenRA
 			ModFiles.LoadFromManifest(Manifest);
 
 			// Mount map package so custom assets can be used. TODO: check priority.
-			ModFiles.Mount(ModFiles.OpenPackage(map.Path, null, int.MaxValue));
+			ModFiles.Mount(ModFiles.OpenPackage(map.Path, int.MaxValue));
 
 			using (new Support.PerfTimer("Map.PreloadRules"))
 				map.PreloadRules();

--- a/OpenRA.Mods.Common/InstallUtils.cs
+++ b/OpenRA.Mods.Common/InstallUtils.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common
 		}
 
 		// TODO: The package should be mounted into its own context to avoid name collisions with installed files
-		public static bool ExtractFromPackage(string srcPath, string package, string annotation, Dictionary<string, string[]> filesByDirectory,
+		public static bool ExtractFromPackage(string srcPath, string package, Dictionary<string, string[]> filesByDirectory,
 			string destPath, bool overwrite, ContentInstaller.FilenameCase caseModifier, Action<string> onProgress, Action<string> onError)
 		{
 			Directory.CreateDirectory(destPath);
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common
 			Log.Write("debug", "Mounting {0}".F(srcPath));
 			Game.ModData.ModFiles.Mount(srcPath);
 			Log.Write("debug", "Mounting {0}".F(package));
-			Game.ModData.ModFiles.Mount(package, annotation);
+			Game.ModData.ModFiles.Mount(package);
 
 			foreach (var directory in filesByDirectory)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
@@ -131,8 +131,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						statusLabel.GetText = () => "Extracting {0}".F(filename);
 						var destFile = Platform.ResolvePath("^", "Content", modId, filename.ToLowerInvariant());
 						cabExtractor.ExtractFile(uint.Parse(archive[0]), destFile);
-						var annotation = archive.Length > 1 ? archive[1] : null;
-						InstallUtils.ExtractFromPackage(source, destFile, annotation, extractFiles, destDir, overwrite, installData.OutputFilenameCase, onProgress, onError);
+						InstallUtils.ExtractFromPackage(source, destFile, extractFiles, destDir, overwrite, installData.OutputFilenameCase, onProgress, onError);
 						progressBar.Percentage += installPercent;
 					}
 				}
@@ -157,7 +156,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var packageToExtract = installData.PackageToExtractFromCD.Split(':');
 			var extractPackage = packageToExtract.First();
-			var annotation = packageToExtract.Length > 1 ? packageToExtract.Last() : null;
 
 			var extractFiles = installData.ExtractFilesFromCD;
 
@@ -191,7 +189,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					if (!string.IsNullOrEmpty(extractPackage))
 					{
-						if (!InstallUtils.ExtractFromPackage(source, extractPackage, annotation, extractFiles, dest,
+						if (!InstallUtils.ExtractFromPackage(source, extractPackage, extractFiles, dest,
 							overwrite, installData.OutputFilenameCase, onProgress, onError))
 						{
 							onError("Extracting files from CD failed.");

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -20,44 +20,44 @@ MapFolders:
 
 Packages:
 # Tiberian Sun
-	~scores.mix@CRC32
-	~sidenc01.mix@CRC32
-	~sidenc02.mix@CRC32
-	~gmenu.mix@CRC32
-	~e01scd01.mix@CRC32
-	~e01scd02.mix@CRC32
-	~maps01.mix@CRC32
-	~maps02.mix@CRC32
-	~movies01.mix@CRC32
-	~movies02.mix@CRC32
-	~multi.mix@CRC32
-	~patch.mix@CRC32
-	~sidecd01.mix@CRC32
-	~sidecd02.mix@CRC32
-	~tibsun.mix@CRC32
-	cache.mix@CRC32
-	conquer.mix@CRC32
-	isosnow.mix@CRC32
-	isotemp.mix@CRC32
-	local.mix@CRC32
-	sidec01.mix@CRC32
-	sidec02.mix@CRC32
-	sno.mix@CRC32
-	snow.mix@CRC32
-	sounds.mix@CRC32
-	speech01.mix@CRC32 # EVA
-	speech02.mix@CRC32 # Cabal
-	tem.mix@CRC32
-	temperat.mix@CRC32
+	~scores.mix
+	~sidenc01.mix
+	~sidenc02.mix
+	~gmenu.mix
+	~e01scd01.mix
+	~e01scd02.mix
+	~maps01.mix
+	~maps02.mix
+	~movies01.mix
+	~movies02.mix
+	~multi.mix
+	~patch.mix
+	~sidecd01.mix
+	~sidecd02.mix
+	~tibsun.mix
+	cache.mix
+	conquer.mix
+	isosnow.mix
+	isotemp.mix
+	local.mix
+	sidec01.mix
+	sidec02.mix
+	sno.mix
+	snow.mix
+	sounds.mix
+	speech01.mix # EVA
+	speech02.mix # Cabal
+	tem.mix
+	temperat.mix
 # Firestorm
-	~scores01.mix@CRC32
-	~expand01.mix@CRC32
-	~sounds01.mix@CRC32
-	~e01sc01.mix@CRC32
-	~e01sc02.mix@CRC32
-	~e01vox01.mix@CRC32
-	~e01vox02.mix@CRC32
-	~ecache01.mix@CRC32
+	~scores01.mix
+	~expand01.mix
+	~sounds01.mix
+	~e01sc01.mix
+	~e01sc02.mix
+	~e01vox01.mix
+	~e01vox02.mix
+	~ecache01.mix
 
 Rules:
 	./mods/ts/rules/ai.yaml
@@ -198,12 +198,12 @@ ContentInstaller:
 	DiskTestFiles: MULTI.MIX, INSTALL/TIBSUN.MIX
 	CopyFilesFromCD:
 		.: INSTALL/TIBSUN.MIX, SCORES.MIX, MULTI.MIX
-	PackageToExtractFromCD: INSTALL/TIBSUN.MIX:CRC32
+	PackageToExtractFromCD: INSTALL/TIBSUN.MIX
 	ExtractFilesFromCD:
 		.: cache.mix, conquer.mix, isosnow.mix, isotemp.mix, local.mix, sidec01.mix, sidec02.mix, sno.mix, snow.mix, sounds.mix, speech01.mix, tem.mix, temperat.mix
 	ShippedSoundtracks: 2
 	MusicPackageMirrorList: http://www.openra.net/packages/ts-music-mirrors.txt
-	InstallShieldCABFilePackageIds: 332:CRC32
+	InstallShieldCABFilePackageIds: 332
 	InstallShieldCABFileIds: 323, 364
 
 ServerTraits:


### PR DESCRIPTION
This rewrites the mix file parser to be guess whether it is uses classic or CRC style hashes, and removes the last direct workarounds for mix file uglyness from the rest of the engine.

This can impact/regress mods in two ways:
1. A valid local and/or global mix database containing the filenames is now required to load files from the package.  This shouldn't be a problem unless somebody went out of their way to make their mix files unusable by XCC mixer.
2.  Filenames inside mixes are now case sensitive, and must be queried using the exact case written in the local or global mix database (usually all lower case).

I've tested that TD/RA/TS still successfully install from CD (except for #10529) and can launch a skirmish. 
