### PR TITLE
Added a warning when bots have been disabled

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -395,6 +395,11 @@ namespace OpenRA.Server
 				if (Map.RuleDefinitions.Any() && !LobbyInfo.IsSinglePlayer)
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
+				if (Settings.LockBots)
+					SendOrderTo(newConn, "Message", "Bots have been disabled on this server.");
+				else if (MapPlayers.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
+					SendOrderTo(newConn, "Message", "Bots have been disabled on this map.");
+
 				if (handshake.Mod == "{DEV_VERSION}")
 					SendMessage("{0} is running an unversioned development build, ".F(client.Name) +
 						"and may desynchronize the game state if they have incompatible rules.");

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -378,6 +378,11 @@ namespace OpenRA.Mods.Common.Server
 						if (server.Map.RuleDefinitions.Any())
 							server.SendMessage("This map contains custom rules. Game experience may change.");
 
+						if (server.Settings.LockBots)
+							server.SendMessage("Bots have been disabled on this server.");
+						else if (server.MapPlayers.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
+							server.SendMessage("Bots have been disabled on this map.");
+
 						return true;
 					}
 				},


### PR DESCRIPTION
If people click skirmish and choose an island map, they get a wrong illusion that we don't support AI. See https://www.facebook.com/openra/posts/993082560747961?comment_id=993237267399157&comment_tracking=%7B%22tn%22%3A%22R0%22%7D
