### PR TITLE
General Cleanup

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -288,7 +288,7 @@ namespace OpenRA
 				if (wasInWorld)
 					w.Add(this);
 
-				foreach (var t in this.TraitsImplementing<INotifyOwnerChanged>())
+				foreach (var t in TraitsImplementing<INotifyOwnerChanged>())
 					t.OnOwnerChanged(this, oldOwner, newOwner);
 			});
 		}
@@ -381,7 +381,7 @@ namespace OpenRA
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			Actor a, b;
-			if (!left.TryGetClrValue<Actor>(out a) || !right.TryGetClrValue<Actor>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				return false;
 
 			return a == b;

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -73,7 +73,7 @@ namespace OpenRA
 		{
 			CPos a;
 			CVec b;
-			if (!left.TryGetClrValue<CPos>(out a) || !right.TryGetClrValue<CVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call CPos.Add(CPos, CVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
 
 			return new LuaCustomClrObject(a + b);
@@ -83,7 +83,7 @@ namespace OpenRA
 		{
 			CPos a;
 			CVec b;
-			if (!left.TryGetClrValue<CPos>(out a) || !right.TryGetClrValue<CVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call CPos.Subtract(CPos, CVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
 
 			return new LuaCustomClrObject(a - b);
@@ -92,7 +92,7 @@ namespace OpenRA
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			CPos a, b;
-			if (!left.TryGetClrValue<CPos>(out a) || !right.TryGetClrValue<CPos>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				return false;
 
 			return a == b;

--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -75,7 +75,7 @@ namespace OpenRA
 		public LuaValue Add(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			CVec a, b;
-			if (!left.TryGetClrValue<CVec>(out a) || !right.TryGetClrValue<CVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call CVec.Add(CVec, CVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
 
 			return new LuaCustomClrObject(a + b);
@@ -84,7 +84,7 @@ namespace OpenRA
 		public LuaValue Subtract(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			CVec a, b;
-			if (!left.TryGetClrValue<CVec>(out a) || !right.TryGetClrValue<CVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call CVec.Subtract(CVec, CVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
 
 			return new LuaCustomClrObject(a - b);
@@ -98,7 +98,7 @@ namespace OpenRA
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			CVec a, b;
-			if (!left.TryGetClrValue<CVec>(out a) || !right.TryGetClrValue<CVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				return false;
 
 			return a == b;

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -126,7 +126,7 @@ namespace OpenRA
 				return result;
 			}
 
-			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(OpenRA.Primitives.Cache<,>))
+			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Primitives.Cache<,>))
 				return ""; // TODO
 
 			if (t == typeof(DateTime))

--- a/OpenRA.Game/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Game/FileFormats/BlowfishKeyProvider.cs
@@ -55,7 +55,7 @@ namespace OpenRA.FileFormats
 				{
 					var pn = (byte*)tempPn;
 					var i = blen * 4;
-					for (; i > klen; i--) pn[i - 1] = (byte)sign;
+					for (; i > klen; i--) pn[i - 1] = sign;
 					for (; i > 0; i--) pn[i - 1] = key[klen - i];
 				}
 			}

--- a/OpenRA.Game/FileFormats/HvaReader.cs
+++ b/OpenRA.Game/FileFormats/HvaReader.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using OpenRA.Graphics;
 
 namespace OpenRA.FileFormats

--- a/OpenRA.Game/FileFormats/ImaAdpcmLoader.cs
+++ b/OpenRA.Game/FileFormats/ImaAdpcmLoader.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.IO;
 
 namespace OpenRA.FileFormats

--- a/OpenRA.Game/FileFormats/XccLocalDatabase.cs
+++ b/OpenRA.Game/FileFormats/XccLocalDatabase.cs
@@ -49,11 +49,11 @@ namespace OpenRA.FileFormats
 				writer.Write(Encoding.ASCII.GetBytes("XCC by Olaf van der Spek"));
 				writer.Write(new byte[] { 0x1A, 0x04, 0x17, 0x27, 0x10, 0x19, 0x80, 0x00 });
 
-				writer.Write((int)(Entries.Aggregate(Entries.Length, (a, b) => a + b.Length) + 52)); // Size
-				writer.Write((int)0); // Type
-				writer.Write((int)0); // Version
-				writer.Write((int)0); // Game/Format (0 == TD)
-				writer.Write((int)Entries.Length); // Entries
+				writer.Write(Entries.Aggregate(Entries.Length, (a, b) => a + b.Length) + 52); // Size
+				writer.Write(0); // Type
+				writer.Write(0); // Version
+				writer.Write(0); // Game/Format (0 == TD)
+				writer.Write(Entries.Length); // Entries
 				foreach (var e in Entries)
 				{
 					writer.Write(Encoding.ASCII.GetBytes(e));

--- a/OpenRA.Game/FileSystem/D2kSoundResources.cs
+++ b/OpenRA.Game/FileSystem/D2kSoundResources.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 

--- a/OpenRA.Game/FileSystem/InstallShieldCABExtractor.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldCABExtractor.cs
@@ -43,7 +43,7 @@ namespace OpenRA.FileSystem
 				FirstFile = reader.ReadUInt32();
 				LastFile = reader.ReadUInt32();
 
-				reader.Seek(offset + (long)nameOffset, SeekOrigin.Begin);
+				reader.Seek(offset + nameOffset, SeekOrigin.Begin);
 				Name = reader.ReadASCIIZ();
 			}
 		}
@@ -107,7 +107,7 @@ namespace OpenRA.FileSystem
 			{
 				Version = reader.ReadUInt32();
 				VolumeInfo = reader.ReadUInt32();
-				CabDescriptorOffset = (long)reader.ReadUInt32();
+				CabDescriptorOffset = reader.ReadUInt32();
 				CabDescriptorSize = reader.ReadUInt32();
 			}
 		}
@@ -125,7 +125,7 @@ namespace OpenRA.FileSystem
 			public CabDescriptor(Stream reader, CommonHeader commonHeader)
 			{
 				reader.Seek(commonHeader.CabDescriptorOffset + 12, SeekOrigin.Begin);
-				FileTableOffset = (long)reader.ReadUInt32();
+				FileTableOffset = reader.ReadUInt32();
 				/*    unknown  */ reader.ReadUInt32();
 				FileTableSize = reader.ReadUInt32();
 
@@ -134,7 +134,7 @@ namespace OpenRA.FileSystem
 				/*   unknown  */ reader.ReadBytes(8);
 				FileCount = reader.ReadUInt32();
 
-				FileTableOffset2 = (long)reader.ReadUInt32();
+				FileTableOffset2 = reader.ReadUInt32();
 			}
 		}
 
@@ -201,7 +201,7 @@ namespace OpenRA.FileSystem
 				this.index = index;
 				this.commonName = commonName;
 				this.context = context;
-				volumeNumber = (ushort)((uint)fileDes.Volume - 1u);
+				volumeNumber = (ushort)(fileDes.Volume - 1u);
 				RemainingArchiveStream = 0;
 				if ((fileDes.Flags & FileCompressed) > 0)
 					RemainingFileStream = fileDes.CompressedSize;
@@ -374,7 +374,7 @@ namespace OpenRA.FileSystem
 					hdrFile.Seek((long)nextOffset + 4 + commonHeader.CabDescriptorOffset, SeekOrigin.Begin);
 					var descriptorOffset = hdrFile.ReadUInt32();
 					nextOffset = hdrFile.ReadUInt32();
-					hdrFile.Seek((long)descriptorOffset + commonHeader.CabDescriptorOffset, SeekOrigin.Begin);
+					hdrFile.Seek(descriptorOffset + commonHeader.CabDescriptorOffset, SeekOrigin.Begin);
 
 					fileGroups.Add(new FileGroup(hdrFile, commonHeader.CabDescriptorOffset));
 				}
@@ -387,7 +387,7 @@ namespace OpenRA.FileSystem
 				{
 					AddFileDescriptorToList(index);
 					var fileDescriptor = fileDescriptors[index];
-					var fullFilePath   = "{0}\\{1}\\{2}".F(fileGroup.Name, DirectoryName((uint)fileDescriptor.DirectoryIndex), fileDescriptor.Filename);
+					var fullFilePath   = "{0}\\{1}\\{2}".F(fileGroup.Name, DirectoryName(fileDescriptor.DirectoryIndex), fileDescriptor.Filename);
 					fileLookup.Add(fullFilePath, index);
 				}
 			}

--- a/OpenRA.Game/FileSystem/Pak.cs
+++ b/OpenRA.Game/FileSystem/Pak.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -86,7 +86,7 @@ namespace OpenRA
 
 		// More accurate replacement for Environment.TickCount
 		static Stopwatch stopwatch = Stopwatch.StartNew();
-		public static int RunTime { get { return (int)Game.stopwatch.ElapsedMilliseconds; } }
+		public static int RunTime { get { return (int)stopwatch.ElapsedMilliseconds; } }
 
 		public static int RenderFrame = 0;
 		public static int NetFrameNumber { get { return OrderManager.NetFrameNumber; } }
@@ -461,8 +461,8 @@ namespace OpenRA
 		// Note: These delayed actions should only be used by widgets or disposing objects
 		// - things that depend on a particular world should be queuing them on the world actor.
 		static volatile ActionQueue delayedActions = new ActionQueue();
-		public static void RunAfterTick(Action a) { delayedActions.Add(a, Game.RunTime); }
-		public static void RunAfterDelay(int delayMilliseconds, Action a) { delayedActions.Add(a, Game.RunTime + delayMilliseconds); }
+		public static void RunAfterTick(Action a) { delayedActions.Add(a, RunTime); }
+		public static void RunAfterDelay(int delayMilliseconds, Action a) { delayedActions.Add(a, RunTime + delayMilliseconds); }
 
 		static void TakeScreenshotInner()
 		{
@@ -489,7 +489,7 @@ namespace OpenRA
 
 				bitmap.Dispose();
 
-				Game.RunAfterTick(() => Debug("Saved screenshot " + filename));
+				RunAfterTick(() => Debug("Saved screenshot " + filename));
 			});
 		}
 
@@ -571,7 +571,7 @@ namespace OpenRA
 
 		static void LogicTick()
 		{
-			delayedActions.PerformActions(Game.RunTime);
+			delayedActions.PerformActions(RunTime);
 
 			if (OrderManager.Connection.ConnectionState != lastConnectionState)
 			{
@@ -604,9 +604,9 @@ namespace OpenRA
 
 				using (new PerfSample("render_widgets"))
 				{
-					Game.Renderer.WorldVoxelRenderer.BeginFrame();
+					Renderer.WorldVoxelRenderer.BeginFrame();
 					Ui.PrepareRenderables();
-					Game.Renderer.WorldVoxelRenderer.EndFrame();
+					Renderer.WorldVoxelRenderer.EndFrame();
 
 					Ui.Draw();
 
@@ -684,7 +684,7 @@ namespace OpenRA
 			{
 				// Ideal time between logic updates. Timestep = 0 means the game is paused
 				// but we still call LogicTick() because it handles pausing internally.
-				var logicInterval = worldRenderer != null && worldRenderer.World.Timestep != 0 ? worldRenderer.World.Timestep : Game.Timestep;
+				var logicInterval = worldRenderer != null && worldRenderer.World.Timestep != 0 ? worldRenderer.World.Timestep : Timestep;
 
 				// Ideal time between screen updates
 				var maxFramerate = Settings.Graphics.CapFramerate ? Settings.Graphics.MaxFramerate.Clamp(1, 1000) : 1000;

--- a/OpenRA.Game/GameSpeed.cs
+++ b/OpenRA.Game/GameSpeed.cs
@@ -8,10 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Graphics;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/GlobalChat.cs
+++ b/OpenRA.Game/GlobalChat.cs
@@ -10,11 +10,9 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Meebey.SmartIrc4net;
-using OpenRA;
 using OpenRA.Primitives;
 
 namespace OpenRA.Chat

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace OpenRA.Graphics

--- a/OpenRA.Game/Graphics/HardwareCursor.cs
+++ b/OpenRA.Game/Graphics/HardwareCursor.cs
@@ -12,8 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
-using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/MappedImage.cs
+++ b/OpenRA.Game/Graphics/MappedImage.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Graphics
 			if (defaultSrc != Src)
 				root.Add(new MiniYamlNode("Src", Src));
 
-			return new MiniYaml(FieldSaver.FormatValue(this, this.GetType().GetField("rect")), root);
+			return new MiniYaml(FieldSaver.FormatValue(this, GetType().GetField("rect")), root);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Graphics
 			var b = new Bitmap(Size, 1, PixelFormat.Format32bppArgb);
 			var data = b.LockBits(new Rectangle(0, 0, b.Width, b.Height),
 								  ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
-			var temp = new uint[Palette.Size];
+			var temp = new uint[Size];
 			palette.CopyToArray(temp, 0);
 			Marshal.Copy((int[])(object)temp, 0, data.Scan0, Size);
 			b.UnlockBits(data);

--- a/OpenRA.Game/Graphics/PaletteReference.cs
+++ b/OpenRA.Game/Graphics/PaletteReference.cs
@@ -8,12 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using OpenRA.Traits;
-
 namespace OpenRA.Graphics
 {
 	public sealed class PaletteReference

--- a/OpenRA.Game/Graphics/PlayerColorRemap.cs
+++ b/OpenRA.Game/Graphics/PlayerColorRemap.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Graphics
 		{
 			// Increase luminosity if required to represent the full ramp
 			var rampRange = (byte)((1 - rampFraction) * c.L);
-			var c1 = new HSLColor(c.H, c.S, (byte)Math.Max(rampRange, c.L)).RGB;
+			var c1 = new HSLColor(c.H, c.S, Math.Max(rampRange, c.L)).RGB;
 			var c2 = new HSLColor(c.H, c.S, (byte)Math.Max(0, c.L - rampRange)).RGB;
 			var baseIndex = ramp[0];
 			var remapRamp = ramp.Select(r => r - ramp[0]);

--- a/OpenRA.Game/Graphics/Renderable.cs
+++ b/OpenRA.Game/Graphics/Renderable.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Drawing;
-using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Graphics

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -10,9 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 
 namespace OpenRA.Graphics
 {
@@ -50,8 +48,8 @@ namespace OpenRA.Graphics
 
 		public SequenceProvider(SequenceCache cache, Map map)
 		{
-			this.sequences = Exts.Lazy(() => cache.LoadSequences(map));
-			this.SpriteCache = cache.SpriteCache;
+			sequences = Exts.Lazy(() => cache.LoadSequences(map));
+			SpriteCache = cache.SpriteCache;
 		}
 
 		public ISpriteSequence GetSequence(string unitName, string sequenceName)

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -12,7 +12,6 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace OpenRA.Graphics

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/SoftwareCursor.cs
+++ b/OpenRA.Game/Graphics/SoftwareCursor.cs
@@ -10,9 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Primitives;
 
 namespace OpenRA.Graphics

--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -11,8 +11,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
-using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -12,8 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.FileSystem;
 using OpenRA.Support;
 
 namespace OpenRA.Graphics

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Runtime.InteropServices;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Graphics
 
 		public VoxelRenderProxy(Sprite sprite, Sprite shadowSprite, float2[] projectedShadowBounds, float shadowDirection)
 		{
-			this.Sprite = sprite;
+			Sprite = sprite;
 			ShadowSprite = shadowSprite;
 			ProjectedShadowBounds = projectedShadowBounds;
 			ShadowDirection = shadowDirection;

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -86,12 +86,12 @@ namespace OpenRA
 		Player player;
 
 		public OwnerInit() { }
-		public OwnerInit(string playerName) { this.PlayerName = playerName; }
+		public OwnerInit(string playerName) { PlayerName = playerName; }
 
 		public OwnerInit(Player player)
 		{
 			this.player = player;
-			this.PlayerName = player.InternalName;
+			PlayerName = player.InternalName;
 		}
 
 		public Player Value(World world)

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -74,7 +74,7 @@ namespace OpenRA
 			return uv.V * Size.Width + uv.U;
 		}
 
-		/// <summary>Gets or sets the <see cref="OpenRA.CellLayer"/> using cell coordinates</summary>
+		/// <summary>Gets or sets the <see cref="CellLayer"/> using cell coordinates</summary>
 		public T this[CPos cell]
 		{
 			get

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -16,7 +16,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using OpenRA.FileSystem;
-using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Support;
@@ -277,7 +276,7 @@ namespace OpenRA
 		{
 			var size = new Size(width, height);
 			Grid = Game.ModData.Manifest.Get<MapGrid>();
-			var tileRef = new TerrainTile(tileset.Templates.First().Key, (byte)0);
+			var tileRef = new TerrainTile(tileset.Templates.First().Key, 0);
 
 			Title = "Name your map here";
 			Description = "Describe your map here";
@@ -604,7 +603,7 @@ namespace OpenRA
 
 			foreach (var field in fields)
 			{
-				var f = this.GetType().GetField(field);
+				var f = GetType().GetField(field);
 				if (f.GetValue(this) == null)
 					continue;
 				root.Add(new MiniYamlNode(field, FieldSaver.FormatValue(this, f)));

--- a/OpenRA.Game/Map/MapCoordsRegion.cs
+++ b/OpenRA.Game/Map/MapCoordsRegion.cs
@@ -8,10 +8,8 @@
  */
 #endregion
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA
 {
@@ -64,8 +62,8 @@ namespace OpenRA
 
 		public MapCoordsRegion(MPos mapTopLeft, MPos mapBottomRight)
 		{
-			this.topLeft = mapTopLeft;
-			this.bottomRight = mapBottomRight;
+			topLeft = mapTopLeft;
+			bottomRight = mapBottomRight;
 		}
 
 		public MapCoordsEnumerator GetEnumerator()

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -79,9 +79,9 @@ namespace OpenRA
 
 		public TerrainTemplateInfo(ushort id, string[] images, int2 size, byte[] tiles)
 		{
-			this.Id = id;
-			this.Images = images;
-			this.Size = size;
+			Id = id;
+			Images = images;
+			Size = size;
 		}
 
 		public TerrainTemplateInfo(TileSet tileSet, MiniYaml my)

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Network
 		public virtual void SendImmediate(List<byte[]> orders)
 		{
 			var ms = new MemoryStream();
-			ms.Write(BitConverter.GetBytes((int)0));
+			ms.Write(BitConverter.GetBytes(0));
 			foreach (var o in orders)
 				ms.Write(o);
 			Send(ms.ToArray());
@@ -196,12 +196,12 @@ namespace OpenRA.Network
 			try
 			{
 				var ms = new MemoryStream();
-				ms.Write(BitConverter.GetBytes((int)packet.Length));
+				ms.Write(BitConverter.GetBytes(packet.Length));
 				ms.Write(packet);
 
 				foreach (var q in queuedSyncPackets)
 				{
-					ms.Write(BitConverter.GetBytes((int)q.Length));
+					ms.Write(BitConverter.GetBytes(q.Length));
 					ms.Write(q);
 					base.Send(q);
 				}

--- a/OpenRA.Game/Network/GeoIP.cs
+++ b/OpenRA.Game/Network/GeoIP.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.IO;
-using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.GZip;
 using MaxMind.GeoIP2;
 

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using OpenRA.Network;
 
 namespace OpenRA
@@ -52,14 +51,14 @@ namespace OpenRA
 		Order(string orderString, Actor subject,
 			Actor targetActor, CPos targetLocation, string targetString, bool queued, CPos extraLocation, uint extraData)
 		{
-			this.OrderString = orderString;
-			this.Subject = subject;
-			this.TargetActor = targetActor;
-			this.TargetLocation = targetLocation;
-			this.TargetString = targetString;
-			this.Queued = queued;
-			this.ExtraLocation = extraLocation;
-			this.ExtraData = extraData;
+			OrderString = orderString;
+			Subject = subject;
+			TargetActor = targetActor;
+			TargetLocation = targetLocation;
+			TargetString = targetString;
+			Queued = queued;
+			ExtraLocation = extraLocation;
+			ExtraData = extraData;
 		}
 
 		public static Order Deserialize(World world, BinaryReader r)

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
@@ -64,7 +63,7 @@ namespace OpenRA.Network
 			}
 
 			file.Write(initialContent);
-			this.writer = new BinaryWriter(file);
+			writer = new BinaryWriter(file);
 		}
 
 		public void Receive(int clientID, byte[] data)

--- a/OpenRA.Game/Orders/GenericSelectTarget.cs
+++ b/OpenRA.Game/Orders/GenericSelectTarget.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Graphics;
 
 namespace OpenRA.Orders
 {

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -167,11 +167,11 @@ namespace OpenRA.Orders
 
 			public UnitOrderResult(Actor actor, IOrderTargeter order, IIssueOrder trait, string cursor, Target target)
 			{
-				this.Actor = actor;
-				this.Order = order;
-				this.Trait = trait;
-				this.Cursor = cursor;
-				this.Target = target;
+				Actor = actor;
+				Order = order;
+				Trait = trait;
+				Cursor = cursor;
+				Target = target;
 			}
 		}
 	}

--- a/OpenRA.Game/Primitives/int2.cs
+++ b/OpenRA.Game/Primitives/int2.cs
@@ -18,7 +18,7 @@ namespace OpenRA
 	public struct int2 : IEquatable<int2>
 	{
 		public readonly int X, Y;
-		public int2(int x, int y) { this.X = x; this.Y = y; }
+		public int2(int x, int y) { X = x; Y = y; }
 		public int2(Point p) { X = p.X; Y = p.Y; }
 		public int2(Size p) { X = p.Width; Y = p.Height; }
 
@@ -66,7 +66,7 @@ namespace OpenRA
 		// Change endianness of a uint32
 		public static uint Swap(uint orig)
 		{
-			return (uint)((orig & 0xff000000) >> 24) | ((orig & 0x00ff0000) >> 8) | ((orig & 0x0000ff00) << 8) | ((orig & 0x000000ff) << 24);
+			return ((orig & 0xff000000) >> 24) | ((orig & 0x00ff0000) >> 8) | ((orig & 0x0000ff00) << 8) | ((orig & 0x000000ff) << 24);
 		}
 
 		public static int Lerp(int a, int b, int mul, int div)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -95,7 +95,7 @@ namespace OpenRA
 			if (Fonts != null)
 				foreach (var font in Fonts.Values)
 					font.Dispose();
-			using (new Support.PerfTimer("SpriteFonts"))
+			using (new PerfTimer("SpriteFonts"))
 			{
 				if (fontSheetBuilder != null)
 					fontSheetBuilder.Dispose();

--- a/OpenRA.Game/Scripting/ScriptActorInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptActorInterface.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace OpenRA.Scripting

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -86,8 +86,8 @@ namespace OpenRA.Scripting
 		public ScriptGlobal(ScriptContext context)
 			: base(context)
 		{
-			// The 'this.' resolves the actual (subclass) type
-			var type = this.GetType();
+			// GetType resolves the actual (subclass) type
+			var type = GetType();
 			var names = type.GetCustomAttributes<ScriptGlobalAttribute>(true);
 			if (names.Length != 1)
 				throw new InvalidOperationException("[ScriptGlobal] attribute not found for global table '{0}'".F(type));

--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections;
 using Eluant;
 
 namespace OpenRA.Scripting
@@ -145,16 +144,16 @@ namespace OpenRA.Scripting
 				return LuaNil.Instance;
 
 			if (obj is double)
-				return (LuaValue)(double)obj;
+				return (double)obj;
 
 			if (obj is int)
-				return (LuaValue)(int)obj;
+				return (int)obj;
 
 			if (obj is bool)
-				return (LuaValue)(bool)obj;
+				return (bool)obj;
 
 			if (obj is string)
-				return (LuaValue)(string)obj;
+				return (string)obj;
 
 			if (obj is IScriptBindable)
 			{

--- a/OpenRA.Game/Support/LaunchArguments.cs
+++ b/OpenRA.Game/Support/LaunchArguments.cs
@@ -29,7 +29,7 @@ namespace OpenRA
 			if (args == null)
 				return;
 
-			foreach (var f in this.GetType().GetFields())
+			foreach (var f in GetType().GetFields())
 				if (args.Contains("Launch" + "." + f.Name))
 					FieldLoader.LoadField(this, f.Name, args.GetValue("Launch" + "." + f.Name, ""));
 		}

--- a/OpenRA.Game/Support/PerfHistory.cs
+++ b/OpenRA.Game/Support/PerfHistory.cs
@@ -8,9 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using OpenRA.Primitives;
 

--- a/OpenRA.Game/Support/PerfItem.cs
+++ b/OpenRA.Game/Support/PerfItem.cs
@@ -8,11 +8,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
-using OpenRA.Primitives;
 
 namespace OpenRA.Support
 {

--- a/OpenRA.Game/Support/PerfSample.cs
+++ b/OpenRA.Game/Support/PerfSample.cs
@@ -9,10 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
-using OpenRA.Primitives;
 
 namespace OpenRA.Support
 {

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -38,11 +38,11 @@ namespace OpenRA
 			{ typeof(int2), ((Func<int2, int>)HashInt2).Method },
 			{ typeof(CPos), ((Func<CPos, int>)HashCPos).Method },
 			{ typeof(CVec), ((Func<CVec, int>)HashCVec).Method },
-			{ typeof(WDist), ((Func<WDist, int>)Hash<WDist>).Method },
-			{ typeof(WPos), ((Func<WPos, int>)Hash<WPos>).Method },
-			{ typeof(WVec), ((Func<WVec, int>)Hash<WVec>).Method },
-			{ typeof(WAngle), ((Func<WAngle, int>)Hash<WAngle>).Method },
-			{ typeof(WRot), ((Func<WRot, int>)Hash<WRot>).Method },
+			{ typeof(WDist), ((Func<WDist, int>)Hash).Method },
+			{ typeof(WPos), ((Func<WPos, int>)Hash).Method },
+			{ typeof(WVec), ((Func<WVec, int>)Hash).Method },
+			{ typeof(WAngle), ((Func<WAngle, int>)Hash).Method },
+			{ typeof(WRot), ((Func<WRot, int>)Hash).Method },
 			{ typeof(TypeDictionary), ((Func<TypeDictionary, int>)HashTDict).Method },
 			{ typeof(Actor), ((Func<Actor, int>)HashActor).Method },
 			{ typeof(Player), ((Func<Player, int>)HashPlayer).Method },
@@ -152,7 +152,7 @@ namespace OpenRA
 					return (int)(t.FrozenActor.Actor.ActorID << 16) * 0x567;
 
 				case TargetType.Terrain:
-					return Hash<WPos>(t.CenterPosition);
+					return Hash(t.CenterPosition);
 
 				default:
 				case TargetType.Invalid:

--- a/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Graphics;
 
 namespace OpenRA.Traits

--- a/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Game/Traits/RejectsOrders.cs
+++ b/OpenRA.Game/Traits/RejectsOrders.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA.Traits
 {

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Traits
 
 		public ResourceType(ResourceTypeInfo info, World world)
 		{
-			this.Info = info;
+			Info = info;
 			Variants = new Dictionary<string, Sprite[]>();
 			foreach (var v in info.Variants)
 			{

--- a/OpenRA.Game/VoiceExts.cs
+++ b/OpenRA.Game/VoiceExts.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;
 

--- a/OpenRA.Game/WDist.cs
+++ b/OpenRA.Game/WDist.cs
@@ -23,7 +23,7 @@ namespace OpenRA
 	public struct WDist : IComparable, IComparable<WDist>, IEquatable<WDist>, IScriptBindable, ILuaAdditionBinding, ILuaSubtractionBinding, ILuaEqualityBinding, ILuaTableBinding
 	{
 		public readonly int Length;
-		public long LengthSquared { get { return (long)Length * (long)Length; } }
+		public long LengthSquared { get { return (long)Length * Length; } }
 
 		public WDist(int r) { Length = r; }
 		public static readonly WDist Zero = new WDist(0);
@@ -57,7 +57,7 @@ namespace OpenRA
 
 		public static bool TryParse(string s, out WDist result)
 		{
-			result = WDist.Zero;
+			result = Zero;
 
 			if (string.IsNullOrEmpty(s))
 				return false;
@@ -115,7 +115,7 @@ namespace OpenRA
 		{
 			WDist a;
 			WDist b;
-			if (!left.TryGetClrValue<WDist>(out a) || !right.TryGetClrValue<WDist>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call WDist.Add(WDist, WDist) with invalid arguments.");
 
 			return new LuaCustomClrObject(a + b);
@@ -125,7 +125,7 @@ namespace OpenRA
 		{
 			WDist a;
 			WDist b;
-			if (!left.TryGetClrValue<WDist>(out a) || !right.TryGetClrValue<WDist>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call WDist.Subtract(WDist, WDist) with invalid arguments.");
 
 			return new LuaCustomClrObject(a - b);
@@ -135,7 +135,7 @@ namespace OpenRA
 		{
 			WDist a;
 			WDist b;
-			if (!left.TryGetClrValue<WDist>(out a) || !right.TryGetClrValue<WDist>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call WDist.Equals(WDist, WDist) with invalid arguments.");
 
 			return a == b;

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -81,7 +81,7 @@ namespace OpenRA
 		{
 			WPos a;
 			WVec b;
-			if (!left.TryGetClrValue<WPos>(out a) || !right.TryGetClrValue<WVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call WPos.Add(WPos, WVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
 
 			return new LuaCustomClrObject(a + b);
@@ -91,19 +91,19 @@ namespace OpenRA
 		{
 			WPos a;
 			var rightType = right.WrappedClrType();
-			if (!left.TryGetClrValue<WPos>(out a))
+			if (!left.TryGetClrValue(out a))
 				throw new LuaException("Attempted to call WPos.Subtract(WPos, WVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, rightType));
 
 			if (rightType == typeof(WPos))
 			{
 				WPos b;
-				right.TryGetClrValue<WPos>(out b);
+				right.TryGetClrValue(out b);
 				return new LuaCustomClrObject(a - b);
 			}
 			else if (rightType == typeof(WVec))
 			{
 				WVec b;
-				right.TryGetClrValue<WVec>(out b);
+				right.TryGetClrValue(out b);
 				return new LuaCustomClrObject(a - b);
 			}
 
@@ -113,7 +113,7 @@ namespace OpenRA
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			WPos a, b;
-			if (!left.TryGetClrValue<WPos>(out a) || !right.TryGetClrValue<WPos>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				return false;
 
 			return a == b;

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -82,7 +82,7 @@ namespace OpenRA
 
 			// Add an additional quadratic variation to height
 			// Uses fp to avoid integer overflow
-			var offset = (int)((float)((float)(b - a).Length * pitch.Tan() * mul * (div - mul)) / (float)(1024 * div * div));
+			var offset = (int)((float)(b - a).Length * pitch.Tan() * mul * (div - mul) / (1024 * div * div));
 			return new WVec(ret.X, ret.Y, ret.Z + offset);
 		}
 
@@ -108,7 +108,7 @@ namespace OpenRA
 		public LuaValue Add(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			WVec a, b;
-			if (!left.TryGetClrValue<WVec>(out a) || !right.TryGetClrValue<WVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call WVec.Add(WVec, WVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
 
 			return new LuaCustomClrObject(a + b);
@@ -117,7 +117,7 @@ namespace OpenRA
 		public LuaValue Subtract(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			WVec a, b;
-			if (!left.TryGetClrValue<WVec>(out a) || !right.TryGetClrValue<WVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				throw new LuaException("Attempted to call WVec.Subtract(WVec, WVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
 
 			return new LuaCustomClrObject(a - b);
@@ -131,7 +131,7 @@ namespace OpenRA
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			WVec a, b;
-			if (!left.TryGetClrValue<WVec>(out a) || !right.TryGetClrValue<WVec>(out b))
+			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
 				return false;
 
 			return a == b;

--- a/OpenRA.Game/Widgets/RootWidget.cs
+++ b/OpenRA.Game/Widgets/RootWidget.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Widgets
 
 				if (hk == Game.Settings.Keys.HideUserInterfaceKey)
 				{
-					foreach (var child in this.Children)
+					foreach (var child in Children)
 						child.Visible ^= true;
 
 					return true;

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -503,7 +503,7 @@ namespace OpenRA.Widgets
 
 		public Widget GetOrNull(string id)
 		{
-			if (this.Id == id)
+			if (Id == id)
 				return this;
 
 			foreach (var child in Children)

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -14,7 +14,6 @@ using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Orders;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Widgets
@@ -37,7 +36,7 @@ namespace OpenRA.Widgets
 		[ObjectCreator.UseCtor]
 		public WorldInteractionControllerWidget(World world, WorldRenderer worldRenderer)
 		{
-			this.World = world;
+			World = world;
 			this.worldRenderer = worldRenderer;
 		}
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -196,7 +196,7 @@ namespace OpenRA
 		public void LoadComplete(WorldRenderer wr)
 		{
 			// ScreenMap must be initialized before anything else
-			using (new Support.PerfTimer("ScreenMap.WorldLoaded"))
+			using (new PerfTimer("ScreenMap.WorldLoaded"))
 				ScreenMap.WorldLoaded(this, wr);
 
 			foreach (var wlh in WorldActor.TraitsImplementing<IWorldLoaded>())
@@ -205,7 +205,7 @@ namespace OpenRA
 				if (wlh == ScreenMap)
 					continue;
 
-				using (new Support.PerfTimer(wlh.GetType().Name + ".WorldLoaded"))
+				using (new PerfTimer(wlh.GetType().Name + ".WorldLoaded"))
 					wlh.WorldLoaded(this, wr);
 			}
 
@@ -374,7 +374,7 @@ namespace OpenRA
 
 		public IEnumerable<Actor> ActorsHavingTrait<T>(Func<T, bool> predicate)
 		{
-			return TraitDict.ActorsHavingTrait<T>(predicate);
+			return TraitDict.ActorsHavingTrait(predicate);
 		}
 
 		public void OnPlayerWinStateChanged(Player player)

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Support;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
@@ -9,9 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -160,10 +160,10 @@ namespace OpenRA.Mods.Common.AI
 		public bool CanAttack(IEnumerable<Actor> ownUnits, IEnumerable<Actor> enemyUnits)
 		{
 			var inputValues = new Dictionary<FuzzyVariable, double>();
-			inputValues.Add(fuzzyEngine.InputByName("OwnHealth"), (double)NormalizedHealth(ownUnits, 100));
-			inputValues.Add(fuzzyEngine.InputByName("EnemyHealth"), (double)NormalizedHealth(enemyUnits, 100));
-			inputValues.Add(fuzzyEngine.InputByName("RelativeAttackPower"), (double)RelativePower(ownUnits, enemyUnits));
-			inputValues.Add(fuzzyEngine.InputByName("RelativeSpeed"), (double)RelativeSpeed(ownUnits, enemyUnits));
+			inputValues.Add(fuzzyEngine.InputByName("OwnHealth"), NormalizedHealth(ownUnits, 100));
+			inputValues.Add(fuzzyEngine.InputByName("EnemyHealth"), NormalizedHealth(enemyUnits, 100));
+			inputValues.Add(fuzzyEngine.InputByName("RelativeAttackPower"), RelativePower(ownUnits, enemyUnits));
+			inputValues.Add(fuzzyEngine.InputByName("RelativeSpeed"), RelativeSpeed(ownUnits, enemyUnits));
 
 			var result = fuzzyEngine.Calculate(inputValues);
 			var attackChance = result[fuzzyEngine.OutputByName("AttackOrFlee")];

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Should the AI repair its buildings if damaged?")]
 		public readonly bool ShouldRepairBuildings = true;
 
-		string IBotInfo.Name { get { return this.Name; } }
+		string IBotInfo.Name { get { return Name; } }
 
 		[Desc("What units to the AI should build.", "What % of the total army must be this type of unit.")]
 		public readonly Dictionary<string, float> UnitsToBuild = null;
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.Common.AI
 
 		public readonly World World;
 		public Map Map { get { return World.Map; } }
-		IBotInfo IBot.Info { get { return this.Info; } }
+		IBotInfo IBot.Info { get { return Info; } }
 
 		int rushTicks;
 		int assignRolesTicks;

--- a/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -10,7 +10,6 @@
 
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -8,12 +8,9 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected Enter(Actor self, Actor target, EnterBehaviour enterBehaviour, int maxTries = 1, bool targetCenter = false)
 		{
-			this.move = self.Trait<IMove>();
+			move = self.Trait<IMove>();
 			this.target = Target.FromActor(target);
 			this.maxTries = maxTries;
 			this.enterBehaviour = enterBehaviour;

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -10,7 +10,6 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Activities
 				return path;
 			};
 			this.destination = destination;
-			this.nearEnough = WDist.Zero;
+			nearEnough = WDist.Zero;
 		}
 
 		// HACK: for legacy code
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Activities
 			};
 
 			this.destination = destination;
-			this.nearEnough = WDist.Zero;
+			nearEnough = WDist.Zero;
 			this.ignoredActor = ignoredActor;
 		}
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -10,8 +10,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -8,10 +8,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -8,19 +8,11 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
 using OpenRA.Primitives;
 using OpenRA.Traits;
-using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -10,17 +10,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
-using OpenRA.Primitives;
-using OpenRA.Traits;
-using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -10,17 +10,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
-using OpenRA.Primitives;
 using OpenRA.Traits;
-using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -8,19 +8,9 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Graphics;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
-using OpenRA.Primitives;
 using OpenRA.Traits;
-using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -8,19 +8,9 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Graphics;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
-using OpenRA.Primitives;
-using OpenRA.Traits;
-using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {

--- a/OpenRA.Mods.Common/Effects/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Effects/AreaBeam.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -100,7 +99,7 @@ namespace OpenRA.Mods.Common.Effects
 		{
 			this.info = info;
 			this.args = args;
-			this.pos = args.Source;
+			pos = args.Source;
 
 			var world = args.SourceActor.World;
 

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -29,11 +29,11 @@ namespace OpenRA.Mods.Common.Effects
 
 		public FloatingText(WPos pos, Color color, string text, int duration)
 		{
-			this.font = Game.Renderer.Fonts["TinyBold"];
+			font = Game.Renderer.Fonts["TinyBold"];
 			this.pos = pos;
 			this.color = color;
 			this.text = text;
-			this.remaining = duration;
+			remaining = duration;
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Effects/LaserZap.cs
+++ b/OpenRA.Mods.Common/Effects/LaserZap.cs
@@ -68,10 +68,10 @@ namespace OpenRA.Mods.Common.Effects
 			this.args = args;
 			this.info = info;
 			this.color = color;
-			this.target = args.PassiveTarget;
+			target = args.PassiveTarget;
 
 			if (!string.IsNullOrEmpty(info.HitAnim))
-				this.hitanim = new Animation(args.SourceActor.World, info.HitAnim);
+				hitanim = new Animation(args.SourceActor.World, info.HitAnim);
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Effects/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Effects/NukeLaunch.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.firedBy = firedBy;
 			this.weapon = weapon;
 			this.delay = delay;
-			this.turn = delay / 2;
+			turn = delay / 2;
 			this.flashType = flashType;
 
 			var offset = new WVec(WDist.Zero, WDist.Zero, velocity * turn);

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -122,25 +122,25 @@ namespace OpenRA.Mods.Common.Graphics
 
 			try
 			{
-				Start = LoadField<int>(d, "Start", 0);
-				ShadowStart = LoadField<int>(d, "ShadowStart", -1);
-				ShadowZOffset = LoadField<WDist>(d, "ShadowZOffset", DefaultShadowSpriteZOffset).Length;
-				ZOffset = LoadField<WDist>(d, "ZOffset", WDist.Zero).Length;
-				Tick = LoadField<int>(d, "Tick", 40);
-				transpose = LoadField<bool>(d, "Transpose", false);
+				Start = LoadField(d, "Start", 0);
+				ShadowStart = LoadField(d, "ShadowStart", -1);
+				ShadowZOffset = LoadField(d, "ShadowZOffset", DefaultShadowSpriteZOffset).Length;
+				ZOffset = LoadField(d, "ZOffset", WDist.Zero).Length;
+				Tick = LoadField(d, "Tick", 40);
+				transpose = LoadField(d, "Transpose", false);
 				Frames = LoadField<int[]>(d, "Frames", null);
-				var flipX = LoadField<bool>(d, "FlipX", false);
-				var flipY = LoadField<bool>(d, "FlipY", false);
+				var flipX = LoadField(d, "FlipX", false);
+				var flipY = LoadField(d, "FlipY", false);
 
-				Facings = LoadField<int>(d, "Facings", 1);
+				Facings = LoadField(d, "Facings", 1);
 				if (Facings < 0)
 				{
 					reverseFacings = true;
 					Facings = -Facings;
 				}
 
-				var offset = LoadField<float2>(d, "Offset", float2.Zero);
-				var blendMode = LoadField<BlendMode>(d, "BlendMode", BlendMode.Alpha);
+				var offset = LoadField(d, "Offset", float2.Zero);
+				var blendMode = LoadField(d, "BlendMode", BlendMode.Alpha);
 
 				MiniYaml combine;
 				if (d.TryGetValue("Combine", out combine))
@@ -151,10 +151,10 @@ namespace OpenRA.Mods.Common.Graphics
 						var sd = sub.Value.ToDictionary();
 
 						// Allow per-sprite offset, start, and length
-						var subStart = LoadField<int>(sd, "Start", 0);
-						var subOffset = LoadField<float2>(sd, "Offset", float2.Zero);
-						var subFlipX = LoadField<bool>(sd, "FlipX", false);
-						var subFlipY = LoadField<bool>(sd, "FlipY", false);
+						var subStart = LoadField(sd, "Start", 0);
+						var subOffset = LoadField(sd, "Offset", float2.Zero);
+						var subFlipX = LoadField(sd, "FlipX", false);
+						var subFlipY = LoadField(sd, "FlipY", false);
 
 						var subSrc = GetSpriteSrc(modData, tileSet, sequence, animation, sub.Key, sd);
 						var subSprites = cache[subSrc].Select(
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Graphics
 						if (sd.TryGetValue("Length", out subLengthYaml) && subLengthYaml.Value == "*")
 							subLength = subSprites.Count() - subStart;
 						else
-							subLength = LoadField<int>(sd, "Length", 1);
+							subLength = LoadField(sd, "Length", 1);
 
 						combined = combined.Concat(subSprites.Skip(subStart).Take(subLength));
 					}
@@ -185,17 +185,17 @@ namespace OpenRA.Mods.Common.Graphics
 				if (d.TryGetValue("Length", out length) && length.Value == "*")
 					Length = sprites.Length - Start;
 				else
-					Length = LoadField<int>(d, "Length", 1);
+					Length = LoadField(d, "Length", 1);
 
 				// Plays the animation forwards, and then in reverse
-				if (LoadField<bool>(d, "Reverses", false))
+				if (LoadField(d, "Reverses", false))
 				{
 					var frames = Frames ?? Exts.MakeArray(Length, i => Start + i);
 					Frames = frames.Concat(frames.Skip(1).Take(frames.Length - 2).Reverse()).ToArray();
 					Length = 2 * Length - 2;
 				}
 
-				Stride = LoadField<int>(d, "Stride", Length);
+				Stride = LoadField(d, "Stride", Length);
 
 				if (Length > Stride)
 					throw new InvalidOperationException(

--- a/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Graphics
 			this.centerPosition = centerPosition;
 			this.radius = radius;
 			this.zOffset = zOffset;
-			this.trailCount = lineTrails;
+			trailCount = lineTrails;
 			this.trailSeparation = trailSeparation;
 			this.trailAngle = trailAngle;
 			this.color = color;

--- a/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
@@ -55,10 +55,10 @@ namespace OpenRA.Mods.Common.Graphics
 		{
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
 			var offset = new WVec(radius.Length, 0, 0);
-			for (var i = 0; i < RangeCircleRenderable.RangeCircleSegments; i++)
+			for (var i = 0; i < RangeCircleSegments; i++)
 			{
-				var a = wr.ScreenPosition(centerPosition + offset.Rotate(RangeCircleRenderable.RangeCircleStartRotations[i]));
-				var b = wr.ScreenPosition(centerPosition + offset.Rotate(RangeCircleRenderable.RangeCircleEndRotations[i]));
+				var a = wr.ScreenPosition(centerPosition + offset.Rotate(RangeCircleStartRotations[i]));
+				var b = wr.ScreenPosition(centerPosition + offset.Rotate(RangeCircleEndRotations[i]));
 
 				if (contrastWidth > 0)
 					wcr.DrawLine(a, b, contrastWidth / wr.Viewport.Zoom, contrastColor);

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
@@ -10,7 +10,6 @@
 
 using System.Drawing;
 using OpenRA.Graphics;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Graphics
 {

--- a/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
@@ -8,10 +8,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
-using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Graphics
 {

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
 
@@ -69,16 +67,16 @@ namespace OpenRA.Mods.Common.Graphics
 
 			var spriteName = sprite ?? sequence;
 
-			if (LoadField<bool>(d, "UseTilesetCode", false))
+			if (LoadField(d, "UseTilesetCode", false))
 			{
 				string code;
 				if (loader.TilesetCodes.TryGetValue(ResolveTilesetId(tileSet, d), out code))
 					spriteName = spriteName.Substring(0, 1) + code + spriteName.Substring(2, spriteName.Length - 2);
 			}
 
-			if (LoadField<bool>(d, "AddExtension", true))
+			if (LoadField(d, "AddExtension", true))
 			{
-				var useTilesetExtension = LoadField<bool>(d, "UseTilesetExtension", false);
+				var useTilesetExtension = LoadField(d, "UseTilesetExtension", false);
 
 				string tilesetExtension;
 				if (useTilesetExtension && loader.TilesetExtensions.TryGetValue(ResolveTilesetId(tileSet, d), out tilesetExtension))

--- a/OpenRA.Mods.Common/Graphics/VoxelActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/VoxelActorPreview.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 
@@ -52,8 +51,8 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, WPos pos)
 		{
-			yield return new VoxelRenderable(components, pos + offset, zOffset, camera, this.scale,
-				lightSource, this.lightAmbientColor, this.lightDiffuseColor,
+			yield return new VoxelRenderable(components, pos + offset, zOffset, camera, scale,
+				lightSource, lightAmbientColor, lightDiffuseColor,
 				colorPalette, normalsPalette, shadowPalette);
 		}
 	}

--- a/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
@@ -43,9 +43,9 @@ namespace OpenRA.Mods.Common.Graphics
 			this.lightSource = lightSource;
 			this.lightAmbientColor = lightAmbientColor;
 			this.lightDiffuseColor = lightDiffuseColor;
-			this.palette = color;
-			this.normalsPalette = normals;
-			this.shadowPalette = shadow;
+			palette = color;
+			normalsPalette = normals;
+			shadowPalette = shadow;
 		}
 
 		public WPos Pos { get { return pos; } }
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Graphics
 				var draw = voxel.voxels.Where(v => v.DisableFunc == null || !v.DisableFunc());
 
 				renderProxy = Game.Renderer.WorldVoxelRenderer.RenderAsync(
-					wr, draw, voxel.camera, voxel.scale, VoxelRenderable.GroundNormal, voxel.lightSource,
+					wr, draw, voxel.camera, voxel.scale, GroundNormal, voxel.lightSource,
 					voxel.lightAmbientColor, voxel.lightDiffuseColor,
 					voxel.palette, voxel.normalsPalette, voxel.shadowPalette);
 			}

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -10,8 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Warheads;

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Linq;
-using System.Reflection;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using OpenRA.FileFormats;
 using OpenRA.Mods.Common.Widgets.Logic;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -25,8 +25,8 @@ namespace OpenRA.Mods.Common.Orders
 
 		public DeployOrderTargeter(string order, int priority, Func<string> cursor)
 		{
-			this.OrderID = order;
-			this.OrderPriority = priority;
+			OrderID = order;
+			OrderPriority = priority;
 			this.cursor = cursor;
 		}
 

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -12,11 +12,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
-using OpenRA.Traits;
 using Util = OpenRA.Traits.Util;
 
 namespace OpenRA.Mods.Common.Orders

--- a/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
@@ -21,8 +20,8 @@ namespace OpenRA.Mods.Common.Orders
 
 		public UnitOrderTargeter(string order, int priority, string cursor, bool targetEnemyUnits, bool targetAllyUnits)
 		{
-			this.OrderID = order;
-			this.OrderPriority = priority;
+			OrderID = order;
+			OrderPriority = priority;
 			this.cursor = cursor;
 			this.targetEnemyUnits = targetEnemyUnits;
 			this.targetAllyUnits = targetAllyUnits;

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder

--- a/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
@@ -8,9 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-
 namespace OpenRA.Mods.Common.Pathfinder
 {
 	/// <summary>

--- a/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
+++ b/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
@@ -12,7 +12,6 @@ using System;
 using Eluant;
 using OpenRA.Activities;
 using OpenRA.Scripting;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;

--- a/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using Eluant;
 using OpenRA.Scripting;
 
 namespace OpenRA.Mods.Common.Scripting

--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Eluant;
 using OpenRA.Effects;

--- a/OpenRA.Mods.Common/Scripting/LuaScript.cs
+++ b/OpenRA.Mods.Common/Scripting/LuaScript.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Linq;
-using Eluant;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using Eluant;
 using OpenRA.Activities;

--- a/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
@@ -8,10 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Linq;
-using Eluant;
-using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;

--- a/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
@@ -8,9 +8,6 @@
  */
 #endregion
 
-using System;
-using Eluant;
-using OpenRA.Network;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
@@ -8,11 +8,9 @@
  */
 #endregion
 
-using System;
 using Eluant;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Scripting
 {

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Eluant;

--- a/OpenRA.Mods.Common/Scripting/Properties/PowerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PowerProperties.cs
@@ -8,10 +8,7 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using Eluant;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Scripting;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Scripting/Properties/UpgradeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/UpgradeProperties.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/ServerTraits/ColorValidator.cs
+++ b/OpenRA.Mods.Common/ServerTraits/ColorValidator.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Network;
 using OpenRA.Server;
 using S = OpenRA.Server.Server;
 
@@ -199,7 +198,7 @@ namespace OpenRA.Mods.Common.Server
 
 			// Validate whether color is allowed and get an alternative if it isn't
 			if (client.Slot == null || !server.LobbyInfo.Slots[client.Slot].LockColor)
-				client.Color = ColorValidator.ValidatePlayerColorAndGetAlternative(server, client.Color, client.Index);
+				client.Color = ValidatePlayerColorAndGetAlternative(server, client.Color, client.Index);
 		}
 
 		#endregion

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
@@ -760,7 +759,7 @@ namespace OpenRA.Mods.Common.Server
 				{ "name",
 					s =>
 					{
-						var sanitizedName = OpenRA.Settings.SanitizedPlayerName(s);
+						var sanitizedName = Settings.SanitizedPlayerName(s);
 						if (sanitizedName == client.Name)
 							return true;
 

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Server;
 using S = OpenRA.Server.Server;

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Armor.cs
+++ b/OpenRA.Mods.Common/Traits/Armor.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Used to define weapon efficiency modifiers with different percentages per Type.")]

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -305,8 +305,8 @@ namespace OpenRA.Mods.Common.Traits
 			public AttackOrderTargeter(AttackBase ab, int priority, bool negativeDamage)
 			{
 				this.ab = ab;
-				this.OrderID = ab.attackOrderName;
-				this.OrderPriority = priority;
+				OrderID = ab.attackOrderName;
+				OrderPriority = priority;
 			}
 
 			public string OrderID { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
@@ -82,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackGarrisoned(Actor self, AttackGarrisonedInfo info)
 			: base(self, info)
 		{
-			this.Info = info;
+			Info = info;
 			coords = Exts.Lazy(() => self.Trait<BodyOrientation>());
 			armaments = new List<Armament>();
 			muzzles = new List<AnimationWithOffset>();

--- a/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
@@ -11,8 +11,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Activities;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -9,8 +9,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -154,9 +154,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Building(ActorInitializer init, BuildingInfo info)
 		{
-			this.self = init.Self;
-			this.topLeft = init.Get<LocationInit, CPos>();
-			this.Info = info;
+			self = init.Self;
+			topLeft = init.Get<LocationInit, CPos>();
+			Info = info;
 
 			occupiedCells = FootprintUtils.UnpathableTiles(self.Info.Name, Info, TopLeft)
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -10,7 +10,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Buildings/FootprintUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FootprintUtils.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static IEnumerable<CPos> Tiles(Ruleset rules, string name, BuildingInfo buildingInfo, CPos topLeft)
 		{
-			var dim = (CVec)buildingInfo.Dimensions;
+			var dim = buildingInfo.Dimensions;
 
 			var footprint = buildingInfo.Footprint.Where(x => !char.IsWhiteSpace(x));
 
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public static IEnumerable<CPos> UnpathableTiles(string name, BuildingInfo buildingInfo, CPos position)
 		{
 			var footprint = buildingInfo.Footprint.Where(x => !char.IsWhiteSpace(x)).ToArray();
-			foreach (var tile in TilesWhere(name, (CVec)buildingInfo.Dimensions, footprint, a => a == 'x'))
+			foreach (var tile in TilesWhere(name, buildingInfo.Dimensions, footprint, a => a == 'x'))
 				yield return tile + position;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Capturable.cs
+++ b/OpenRA.Mods.Common/Traits/Capturable.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Crate(ActorInitializer init, CrateInfo info)
 		{
-			this.self = init.Self;
+			self = init.Self;
 			this.info = info;
 
 			if (init.Contains<LocationInit>())

--- a/OpenRA.Mods.Common/Traits/Crates/HealUnitsCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HealUnitsCrateAction.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var gainsExperience = recipient.TraitOrDefault<GainsExperience>();
 					if (gainsExperience != null)
-						gainsExperience.GiveLevels(((LevelUpCrateActionInfo)info).Levels);
+						gainsExperience.GiveLevels(info.Levels);
 				});
 			}
 

--- a/OpenRA.Mods.Common/Traits/CustomSelectionSize.cs
+++ b/OpenRA.Mods.Common/Traits/CustomSelectionSize.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -10,7 +10,6 @@
 
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -8,13 +8,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using OpenRA.Graphics;
-using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Mods.Common.HitShapes;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Husk(ActorInitializer init, HuskInfo info)
 		{
 			this.info = info;
-			this.self = init.Self;
+			self = init.Self;
 
 			TopLeft = init.Get<LocationInit, CPos>();
 			CenterPosition = init.Contains<CenterPositionInit>() ? init.Get<CenterPositionInit, WPos>() : init.World.Map.CenterOfCell(TopLeft);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -84,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 				var nodesDict = t.Value.ToDictionary();
 				var cost = nodesDict.ContainsKey("PathingCost")
 					? FieldLoader.GetValue<int>("cost", nodesDict["PathingCost"].Value)
-					: (int)(10000 / speed);
+					: 10000 / speed;
 				ret.Add(t.Key, new TerrainInfo(speed, cost));
 			}
 
@@ -369,7 +368,7 @@ namespace OpenRA.Mods.Common.Traits
 				SetVisualPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
 			}
 
-			this.Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : info.InitialFacing;
+			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : info.InitialFacing;
 
 			// Sets the visual position to WPos accuracy
 			// Use LocationInit if you want to insert the actor into the ActorMap!
@@ -704,7 +703,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public MoveOrderTargeter(Actor self, Mobile unit)
 			{
-				this.mobile = unit;
+				mobile = unit;
 				rejectMove = !self.AcceptsOrder("Move");
 			}
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
@@ -8,11 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Graphics;
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The actor stays invisible under fog of war.")]

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Multipliers/DamageMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/DamageMultiplier.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
@@ -8,10 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Linq;
-using OpenRA;
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/CloakPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/CloakPaletteEffect.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Parachutable(ActorInitializer init, ParachutableInfo info)
 		{
-			this.self = init.Self;
+			self = init.Self;
 			this.info = info;
 
 			positionable = self.TraitOrDefault<IPositionable>();

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public ClassicProductionQueue(ActorInitializer init, ClassicProductionQueueInfo info)
 			: base(init, init.Self, info)
 		{
-			this.self = init.Self;
+			self = init.Self;
 			this.info = info;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -41,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			var tech = init.World.Map.Options.TechLevel ?? init.World.LobbyInfo.GlobalSettings.TechLevel;
-			this.enabled = info.Name == tech;
+			enabled = info.Name == tech;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool HasPrerequisites(IEnumerable<string> prerequisites)
 		{
-			var ownedPrereqs = TechTree.GatherOwnedPrerequisites(player);
+			var ownedPrereqs = GatherOwnedPrerequisites(player);
 			return prerequisites.All(p => !(p.Replace("~", "").StartsWith("!")
 					^ !ownedPrereqs.ContainsKey(p.Replace("!", "").Replace("~", ""))));
 		}
@@ -119,12 +119,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			public Watcher(string key, string[] prerequisites, int limit, ITechTreeElement watcher)
 			{
-				this.Key = key;
+				Key = key;
 				this.prerequisites = prerequisites;
 				this.watcher = watcher;
-				this.hasPrerequisites = false;
+				hasPrerequisites = false;
 				this.limit = limit;
-				this.hidden = false;
+				hidden = false;
 			}
 
 			bool HasPrerequisites(Cache<string, List<Actor>> ownedPrerequisites)

--- a/OpenRA.Mods.Common/Traits/Plug.cs
+++ b/OpenRA.Mods.Common/Traits/Plug.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
+++ b/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
@@ -9,10 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/AutoSelectionSize.cs
+++ b/OpenRA.Mods.Common/Traits/Render/AutoSelectionSize.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderUtils.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	public class RenderUtils

--- a/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -8,9 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -8,11 +8,7 @@
  */
 #endregion
 
-using System;
-using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Graphics;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (turreted != null)
 						getFacing = () => turreted.TurretFacing;
 					else if (facing != null)
-						getFacing = (Func<int>)(() => facing.Facing);
+						getFacing = () => facing.Facing;
 					else
 						getFacing = () => 0;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
@@ -8,9 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using OpenRA.Graphics;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteRotorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteRotorOverlay.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -10,7 +10,6 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/SeedsResource.cs
+++ b/OpenRA.Mods.Common/Traits/SeedsResource.cs
@@ -9,9 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/SelfHealing.cs
+++ b/OpenRA.Mods.Common/Traits/SelfHealing.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 				this.manager = manager;
 				this.order = order;
 				this.power = power;
-				this.range = power.info.Range;
+				range = power.info.Range;
 				tile = world.Map.SequenceProvider.GetSequence("overlay", "target-select").GetSprite(0);
 			}
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -10,7 +10,6 @@
 
 using OpenRA.Effects;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public DeployToUpgrade(ActorInitializer init, DeployToUpgradeInfo info)
 		{
-			this.self = init.Self;
+			self = init.Self;
 			this.info = info;
 			manager = self.Trait<UpgradeManager>();
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -8,9 +8,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
@@ -10,10 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Voiced.cs
+++ b/OpenRA.Mods.Common/Traits/Voiced.cs
@@ -8,9 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -11,10 +11,8 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			ID = id;
 			this.actor = actor;
-			this.Owner = owner;
+			Owner = owner;
 			this.worldRenderer = worldRenderer;
 
 			if (!actor.InitDict.Contains<FactionInit>())

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -10,12 +10,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Graphics;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -8,14 +8,7 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Graphics;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
+++ b/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
@@ -11,7 +11,6 @@
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
@@ -8,10 +8,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Drawing;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -10,12 +10,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -8,8 +8,6 @@
   */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
@@ -65,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 				var height = (int)map.MapHeight.Value[uv];
 				var tile = map.MapTiles.Value[uv];
 				var ti = tileSet.GetTileInfo(tile);
-				var ramp = ti != null ? (int)ti.RampType : 0;
+				var ramp = ti != null ? ti.RampType : 0;
 
 				var corners = map.CellCorners[ramp];
 				var color = corners.Select(c => colors[height + c.Z / 512]).ToArray();

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -8,10 +8,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
@@ -11,7 +11,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				Console.WriteLine("# {0}:", filename);
 				var yaml = MiniYaml.FromFile(filename);
-				ExtractLanguageStringsCommand.FromChromeLayout(ref yaml, null,
+				FromChromeLayout(ref yaml, null,
 					translatableFields.Select(t => t.Name).Distinct(), null);
 				using (var file = new StreamWriter(filename))
 					file.WriteLine(yaml.WriteToString());

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -9,9 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			if (t.IsSubclassOf(typeof(Array)))
 				return "Multiple {0}".F(FriendlyTypeName(t.GetElementType()));
 
-			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(OpenRA.Primitives.Cache<,>))
+			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Primitives.Cache<,>))
 				return "Cached<{0},{1}>".F(t.GetGenericArguments().Select(FriendlyTypeName).ToArray());
 
 			if (t == typeof(int) || t == typeof(uint))

--- a/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LegacyMapImporter.cs
@@ -266,7 +266,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				for (var i = 0; i < mapSize; i++)
 				{
 					var tileID = ms.ReadUInt16();
-					types[i, j] = tileID == (ushort)0 ? (ushort)255 : tileID; // RAED weirdness
+					types[i, j] = tileID == 0 ? (ushort)255 : tileID; // RAED weirdness
 				}
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
@@ -82,9 +82,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var ca = Color.FromArgb((int)a);
 			var cb = Color.FromArgb((int)b);
 
-			return Math.Abs((int)ca.R - (int)cb.R) +
-				Math.Abs((int)ca.G - (int)cb.G) +
-				Math.Abs((int)ca.B - (int)cb.B);
+			return Math.Abs(ca.R - cb.R) +
+				Math.Abs(ca.G - cb.G) +
+				Math.Abs(ca.B - cb.B);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -10,8 +10,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -9,9 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Effects;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantUpgradeWarhead.cs
@@ -10,9 +10,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
-using OpenRA.GameRules;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -11,8 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -10,7 +10,6 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Widgets
 			// Mask to prevent any clicks from being sent to other widgets
 			fullscreenMask = new MaskWidget();
 			fullscreenMask.Bounds = new Rectangle(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
-			fullscreenMask.OnMouseDown += mi => { Game.Sound.PlayNotification(this.ModRules, null, "Sounds", "ClickSound", null); RemovePanel(); };
+			fullscreenMask.OnMouseDown += mi => { Game.Sound.PlayNotification(ModRules, null, "Sounds", "ClickSound", null); RemovePanel(); };
 			if (onCancel != null)
 				fullscreenMask.OnMouseDown += _ => onCancel();
 

--- a/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
@@ -9,17 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Graphics;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Orders;
-using OpenRA.Primitives;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public ColorPickerLogic(Widget widget, World world, HSLColor initialColor, Action<HSLColor> onChange, WorldRenderer worldRenderer)
 		{
 			string actorType;
-			if (!ChromeMetrics.TryGet<string>("ColorPickerActorType", out actorType))
+			if (!ChromeMetrics.TryGet("ColorPickerActorType", out actorType))
 				actorType = "mcv";
 
 			var preview = widget.GetOrNull<ActorPreviewWidget>("PREVIEW");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -9,14 +9,9 @@
 #endregion
 
 using System;
-using System.Drawing;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 using OpenRA.Widgets;
@@ -38,7 +33,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public ActorSelectorLogic(Widget widget, World world, WorldRenderer worldRenderer)
 		{
-			this.mapRules = world.Map.Rules;
+			mapRules = world.Map.Rules;
 			this.world = world;
 			this.worldRenderer = worldRenderer;
 
@@ -126,7 +121,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					// Scale templates to fit within the panel
 					var scale = 1f;
 					if (scale * preview.IdealPreviewSize.X > itemTemplate.Bounds.Width)
-						scale = (float)(itemTemplate.Bounds.Width - panel.ItemSpacing) / (float)preview.IdealPreviewSize.X;
+						scale = (itemTemplate.Bounds.Width - panel.ItemSpacing) / (float)preview.IdealPreviewSize.X;
 
 					preview.GetScale = () => scale;
 					preview.Bounds.Width = (int)(scale * preview.IdealPreviewSize.X);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 using OpenRA.Widgets;
@@ -32,7 +30,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			this.modRules = modRules;
 			this.worldRenderer = worldRenderer;
-			this.world = worldRenderer.World;
+			world = worldRenderer.World;
 
 			editor = widget.Parent.Get<EditorViewportControllerWidget>("MAP_EDITOR");
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
@@ -9,10 +9,6 @@
 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -9,14 +9,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using OpenRA;
-using OpenRA.FileFormats;
-using OpenRA.Mods.Common.Widgets;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/GlobalChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GlobalChatLogic.cs
@@ -8,12 +8,7 @@
  */
 #endregion
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Threading;
 using OpenRA.Chat;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Network;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ControlGroupLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ControlGroupLogic.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Mods.Common.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -12,7 +12,6 @@ using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -10,7 +10,6 @@
 
 using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -63,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				nameLabel.GetText = () =>
 				{
 					var suffix = pp.WinState == WinState.Undefined ? "" : " (" + pp.WinState + ")";
-					if (client != null && client.State == Network.Session.ClientState.Disconnected)
+					if (client != null && client.State == Session.ClientState.Disconnected)
 						suffix = " (Gone)";
 
 					var sl = suffixLength.Update(suffix);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Commands;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -10,9 +10,7 @@
 
 using System;
 using System.Linq;
-using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -8,11 +8,7 @@
  */
 #endregion
 
-using System;
-using System.Linq;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Traits;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Net;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Network;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			dropdown.ShowDropDown<SlotDropDownOption>("LABEL_DROPDOWN_TEMPLATE", 167, options, setupItem);
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 167, options, setupItem);
 		}
 
 		public static void ShowTeamDropDown(DropDownButtonWidget dropdown, Session.Client client,
@@ -490,7 +490,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			playerName.GetText = () =>
 			{
 				var suffix = player.WinState == WinState.Undefined ? "" : " (" + player.WinState + ")";
-				if (client != null && client.State == Network.Session.ClientState.Disconnected)
+				if (client != null && client.State == Session.ClientState.Disconnected)
 					suffix = " (Gone)";
 
 				var sl = suffixLength.Update(suffix);

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -244,7 +244,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void LoadMapIntoEditor(Map map)
 		{
-			ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
+			ConnectionLogic.Connect(IPAddress.Loopback.ToString(),
 				Game.CreateLocalServer(map.Uid),
 				"",
 				() => { Game.LoadEditor(map.Uid); },

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -12,10 +12,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using OpenRA.Graphics;
-using OpenRA.Network;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -16,7 +16,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenRA.FileFormats;
-using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using OpenRA.Widgets;
-
 namespace OpenRA.Mods.Common.Widgets
 {
 	public class MenuButtonWidget : ButtonWidget

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public ProductionPaletteWidget(OrderManager orderManager, World world, WorldRenderer worldRenderer)
 		{
 			this.orderManager = orderManager;
-			this.World = world;
+			World = world;
 			this.worldRenderer = worldRenderer;
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));

--- a/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using OpenRA.Widgets;
-
 namespace OpenRA.Mods.Common.Widgets
 {
 	public class ProductionTypeButtonWidget : ButtonWidget

--- a/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			GetPalette = () => Palette;
 
-			this.WorldRenderer = worldRenderer;
+			WorldRenderer = worldRenderer;
 		}
 
 		protected SpriteWidget(SpriteWidget other)

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;

--- a/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
+++ b/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {

--- a/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/FreeActorWithDelivery.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using System.IO;
-using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.D2k.Activities;

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Drawing;
-using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.D2k/Traits/Carryall.cs
+++ b/OpenRA.Mods.D2k/Traits/Carryall.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.D2k/Traits/Render/WithDecorationCarryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDecorationCarryable.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;

--- a/OpenRA.Mods.RA/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.RA/Activities/Infiltrate.cs
@@ -10,7 +10,6 @@
 
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.RA.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Activities

--- a/OpenRA.Mods.RA/Activities/LayMines.cs
+++ b/OpenRA.Mods.RA/Activities/LayMines.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;

--- a/OpenRA.Mods.RA/Activities/Teleport.cs
+++ b/OpenRA.Mods.RA/Activities/Teleport.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.RA/Scripting/Properties/DisguiseProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/DisguiseProperties.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Scripting/Properties/InfiltrateProperties.cs
+++ b/OpenRA.Mods.RA/Scripting/Properties/InfiltrateProperties.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Mods.RA.Traits;
 using OpenRA.Scripting;

--- a/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.RA/Traits/Buildings/ClonesProducedUnits.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
+++ b/OpenRA.Mods.RA/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.RA/Traits/PaletteEffects/LightPaletteRotator.cs
+++ b/OpenRA.Mods.RA/Traits/PaletteEffects/LightPaletteRotator.cs
@@ -9,7 +9,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.RA.Traits
 				this.manager = manager;
 				this.order = order;
 				this.power = power;
-				this.range = ((ChronoshiftPowerInfo)power.Info).Range;
+				range = ((ChronoshiftPowerInfo)power.Info).Range;
 				tile = world.Map.SequenceProvider.GetSequence("overlay", "target-select").GetSprite(0);
 			}
 
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.RA.Traits
 				this.order = order;
 				this.power = power;
 				this.sourceLocation = sourceLocation;
-				this.range = ((ChronoshiftPowerInfo)power.Info).Range;
+				range = ((ChronoshiftPowerInfo)power.Info).Range;
 
 				var tileset = manager.Self.World.TileSet.Id.ToLowerInvariant();
 				validTile = world.Map.SequenceProvider.GetSequence("overlay", "target-valid-{0}".F(tileset)).GetSprite(0);

--- a/OpenRA.Mods.TS/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.TS/Activities/VoxelHarvesterDockSequence.cs
@@ -10,7 +10,6 @@
 
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.TS.Traits;
 
 namespace OpenRA.Mods.TS.Activities

--- a/OpenRA.Mods.TS/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.TS/SpriteLoaders/TmpTSLoader.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Drawing;
 using System.IO;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.TS/Traits/Render/WithPermanentInjury.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithPermanentInjury.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.TS.Traits

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -8,9 +8,7 @@
  */
 #endregion
 
-using System;
 using System.Drawing;
-using System.Reflection;
 using OpenRA;
 
 [assembly: Platform(typeof(OpenRA.Platforms.Default.DeviceFactory))]

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -13,11 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using OpenAL;
-using OpenRA.FileFormats;
-using OpenRA.FileSystem;
-using OpenRA.GameRules;
-using OpenRA.Primitives;
-using OpenRA.Traits;
 
 namespace OpenRA.Platforms.Default
 {
@@ -106,7 +101,7 @@ namespace OpenRA.Platforms.Default
 					throw new InvalidOperationException("Can't create OpenAL device");
 			}
 
-			var ctx = ALC10.alcCreateContext(device, (int[])null);
+			var ctx = ALC10.alcCreateContext(device, null);
 			if (ctx == IntPtr.Zero)
 				throw new InvalidOperationException("Can't create OpenAL context");
 			ALC10.alcMakeContextCurrent(ctx);

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -362,11 +362,11 @@ namespace OpenRA.Platforms.Default
 			DetectGLFeatures();
 			if (!Features.HasFlag(GLFeatures.GL2OrGreater) || !Features.HasFlag(GLFeatures.FramebufferExt))
 			{
-				WriteGraphicsLog("Unsupported OpenGL version: " + glGetString(OpenGL.GL_VERSION));
+				WriteGraphicsLog("Unsupported OpenGL version: " + glGetString(GL_VERSION));
 				throw new InvalidProgramException("OpenGL Version Error: See graphics.log for details.");
 			}
 			else
-				Console.WriteLine("OpenGL version: " + glGetString(OpenGL.GL_VERSION));
+				Console.WriteLine("OpenGL version: " + glGetString(GL_VERSION));
 
 			try
 			{
@@ -437,7 +437,7 @@ namespace OpenRA.Platforms.Default
 			}
 			catch (Exception e)
 			{
-				OpenGL.WriteGraphicsLog("Failed to initialize OpenGL bindings.\nInner exception was: {0}".F(e));
+				WriteGraphicsLog("Failed to initialize OpenGL bindings.\nInner exception was: {0}".F(e));
 				throw new InvalidProgramException("Failed to initialize OpenGL. See graphics.log for details.");
 			}
 		}
@@ -451,7 +451,7 @@ namespace OpenRA.Platforms.Default
 		{
 			try
 			{
-				var versionString = glGetString(OpenGL.GL_VERSION);
+				var versionString = glGetString(GL_VERSION);
 				var version = versionString.Contains(" ") ? versionString.Split(' ')[0].Split('.') : versionString.Split('.');
 
 				var major = 0;
@@ -474,8 +474,8 @@ namespace OpenRA.Platforms.Default
 
 		public static void CheckGLError()
 		{
-			var n = OpenGL.glGetError();
-			if (n != OpenGL.GL_NO_ERROR)
+			var n = glGetError();
+			if (n != GL_NO_ERROR)
 			{
 				var error = "GL Error: {0}\n{1}".F(n, new StackTrace());
 				WriteGraphicsLog(error);
@@ -488,7 +488,7 @@ namespace OpenRA.Platforms.Default
 			Log.Write("graphics", message);
 			Log.Write("graphics", "");
 			Log.Write("graphics", "OpenGL Information:");
-			var vendor = OpenGL.glGetString(OpenGL.GL_VENDOR);
+			var vendor = glGetString(GL_VENDOR);
 			Log.Write("graphics", "Vendor: {0}", vendor);
 			if (vendor.Contains("Microsoft"))
 			{
@@ -498,11 +498,11 @@ namespace OpenRA.Platforms.Default
 				Log.Write("graphics", msg);
 			}
 
-			Log.Write("graphics", "Renderer: {0}", OpenGL.glGetString(OpenGL.GL_RENDERER));
-			Log.Write("graphics", "GL Version: {0}", OpenGL.glGetString(OpenGL.GL_VERSION));
-			Log.Write("graphics", "Shader Version: {0}", OpenGL.glGetString(OpenGL.GL_SHADING_LANGUAGE_VERSION));
+			Log.Write("graphics", "Renderer: {0}", glGetString(GL_RENDERER));
+			Log.Write("graphics", "GL Version: {0}", glGetString(GL_VERSION));
+			Log.Write("graphics", "Shader Version: {0}", glGetString(GL_SHADING_LANGUAGE_VERSION));
 			Log.Write("graphics", "Available extensions:");
-			Log.Write("graphics", OpenGL.glGetString(OpenGL.GL_EXTENSIONS));
+			Log.Write("graphics", glGetString(GL_EXTENSIONS));
 		}
 	}
 }

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -12,8 +12,6 @@ using System;
 using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Threading;
-using OpenRA;
 using OpenRA.Graphics;
 using SDL2;
 

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Platforms.Default
 {
 	class Sdl2Input
 	{
-		MouseButton lastButtonBits = (MouseButton)0;
+		MouseButton lastButtonBits = MouseButton.None;
 
 		public string GetClipboardText() { return SDL.SDL_GetClipboardText(); }
 		public bool SetClipboardText(string text) { return SDL.SDL_SetClipboardText(text) == 0; }

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Platforms.Default
 			int success;
 			OpenGL.glGetShaderiv(shader, OpenGL.GL_COMPILE_STATUS, out success);
 			OpenGL.CheckGLError();
-			if (success == (int)OpenGL.GL_FALSE)
+			if (success == OpenGL.GL_FALSE)
 			{
 				int len;
 				OpenGL.glGetShaderiv(shader, OpenGL.GL_INFO_LOG_LENGTH, out len);
@@ -83,7 +83,7 @@ namespace OpenRA.Platforms.Default
 			int success;
 			OpenGL.glGetProgramiv(program, OpenGL.GL_LINK_STATUS, out success);
 			OpenGL.CheckGLError();
-			if (success == (int)OpenGL.GL_FALSE)
+			if (success == OpenGL.GL_FALSE)
 			{
 				int len;
 				OpenGL.glGetProgramiv(program, OpenGL.GL_INFO_LOG_LENGTH, out len);

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -63,14 +63,14 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 
 			var filter = scaleFilter == TextureScaleFilter.Linear ? OpenGL.GL_LINEAR : OpenGL.GL_NEAREST;
-			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_MAG_FILTER, (int)filter);
+			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_MAG_FILTER, filter);
 			OpenGL.CheckGLError();
-			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_MIN_FILTER, (int)filter);
+			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_MIN_FILTER, filter);
 			OpenGL.CheckGLError();
 
-			OpenGL.glTexParameterf(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_WRAP_S, (float)OpenGL.GL_CLAMP_TO_EDGE);
+			OpenGL.glTexParameterf(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_WRAP_S, OpenGL.GL_CLAMP_TO_EDGE);
 			OpenGL.CheckGLError();
-			OpenGL.glTexParameterf(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_WRAP_T, (float)OpenGL.GL_CLAMP_TO_EDGE);
+			OpenGL.glTexParameterf(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_WRAP_T, OpenGL.GL_CLAMP_TO_EDGE);
 			OpenGL.CheckGLError();
 
 			OpenGL.glTexParameteri(OpenGL.GL_TEXTURE_2D, OpenGL.GL_TEXTURE_BASE_LEVEL, 0);
@@ -137,7 +137,7 @@ namespace OpenRA.Platforms.Default
 			{
 				Size = new Size(bitmap.Width, bitmap.Height);
 				var bits = bitmap.LockBits(bitmap.Bounds(),
-					ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+					ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
 
 				PrepareTexture();
 				OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, bits.Width, bits.Height,

--- a/OpenRA.Platforms.Null/NullPlatform.cs
+++ b/OpenRA.Platforms.Null/NullPlatform.cs
@@ -8,7 +8,6 @@
  */
 #endregion
 
-using System;
 using System.Drawing;
 using OpenRA;
 

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
-using OpenRA.GameRules;
 using OpenRA.Traits;
 
 namespace OpenRA.Test

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -9,12 +9,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using NUnit.Framework;
-using OpenRA.GameRules;
-using OpenRA.Traits;
 
 namespace OpenRA.Test
 {


### PR DESCRIPTION
Run automated fixes from VS to simplify names, remove unused usings and remove redundant casts.

I have made inline comments against minor tweaks where I intervened - fixes are otherwise automated so should be pretty safe to take despite the diff size.
