### PR TITLE
Restart skirmish matches

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -889,6 +889,28 @@ namespace OpenRA.Mods.Common.Server
 
 						return true;
 					}
+				},
+				{ "sync_lobby",
+					s =>
+					{
+						if (!client.IsAdmin)
+						{
+							server.SendOrderTo(conn, "Message", "Only the host can set lobby info");
+							return true;
+						}
+
+						var lobbyInfo = Session.Deserialize(s);
+						if (lobbyInfo == null)
+						{
+							server.SendOrderTo(conn, "Message", "Invalid Lobby Info Sent");
+							return true;
+						}
+
+						server.LobbyInfo = lobbyInfo;
+
+						server.SyncLobbyInfo();
+						return true;
+					}
 				}
 			};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -90,14 +90,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				hideMenu = true;
 
-				if (world.LocalPlayer == null || (world.LocalPlayer.WinState != WinState.Won &&
-					(!world.IsGameOver || world.Map.Visibility == MapVisibility.MissionSelector)))
+				if (world.LocalPlayer == null || world.LocalPlayer.WinState != WinState.Won)
 				{
 					Action restartAction = null;
-					if (world.IsReplay || world.Map.Visibility == MapVisibility.MissionSelector)
+					var iop = world.WorldActor.TraitsImplementing<IObjectivesPanel>().FirstOrDefault();
+					var exitDelay = iop != null ? iop.ExitDelay : 0;
+
+					if (world.LobbyInfo.IsSinglePlayer)
 					{
-						var iop = world.WorldActor.TraitsImplementing<IObjectivesPanel>().FirstOrDefault();
-						var exitDelay = iop != null ? iop.ExitDelay : 0;
 						restartAction = () =>
 						{
 							Ui.CloseWindow();
@@ -145,7 +145,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 			var surrenderButton = menu.Get<ButtonWidget>("SURRENDER");
 			surrenderButton.IsVisible = () => world.Type == WorldType.Regular;
-			surrenderButton.IsDisabled = () => (world.LocalPlayer == null || world.LocalPlayer.WinState != WinState.Undefined) || hasError;
+			surrenderButton.IsDisabled = () =>
+				world.LocalPlayer == null || world.LocalPlayer.WinState != WinState.Undefined ||
+				world.Map.Visibility.HasFlag(MapVisibility.MissionSelector) || hasError;
 			surrenderButton.OnClick = () =>
 			{
 				hideMenu = true;
@@ -153,7 +155,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					title: "Surrender",
 					text: "Are you sure you want to surrender?",
 					onConfirm: onSurrender,
-					onCancel: showMenu);
+					onCancel: showMenu,
+					confirmText: "Surrender",
+					cancelText: "Stay");
 			};
 
 			var saveMapButton = menu.Get<ButtonWidget>("SAVE_MAP");

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using OpenRA.Graphics;
+using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 
@@ -301,6 +302,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return;
 
 			var gameStartVideo = selectedMap.Videos.GameStart;
+			var orders = new[] {
+				Order.Command("gamespeed {0}".F(gameSpeed)),
+				Order.Command("difficulty {0}".F(difficulty)),
+				Order.Command("state {0}".F(Session.ClientState.Ready))
+			};
+
 			if (gameStartVideo != null && Game.ModData.ModFiles.Exists(gameStartVideo))
 			{
 				var fsPlayer = fullscreenVideoPlayer.Get<VqaPlayerWidget>("PLAYER");
@@ -308,11 +315,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				PlayVideo(fsPlayer, gameStartVideo, PlayingVideo.GameStart, () =>
 				{
 					StopVideo(fsPlayer);
-					Game.StartMission(selectedMapPreview.Uid, gameSpeed, difficulty, onStart);
+					Game.CreateAndStartLocalServer(selectedMapPreview.Uid, orders, onStart);
 				});
 			}
 			else
-				Game.StartMission(selectedMapPreview.Uid, gameSpeed, difficulty, onStart);
+				Game.CreateAndStartLocalServer(selectedMapPreview.Uid, orders, onStart);
 		}
 
 		class DropDownOption


### PR DESCRIPTION
This allows one to return to the skirmish lobby with the same settings and bots as one had in a previous match. Tested while in the middle of a match with another bot, could go back to lobby and then hit start again with no problems and all settings and bots stayed the same

Should handle the skirmish part of #10533
