### PR TITLE
Fix the TargetTypes of the Mad Tank

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -713,7 +713,7 @@ QTNK:
 	MadTank:
 	-EjectOnDeath:
 	Targetable:
-		TargetTypes: Ground, MADTank, Repair
+		TargetTypes: Ground, MADTank, Repair, Vehicle
 
 STNK:
 	Inherits: ^Vehicle


### PR DESCRIPTION
"Vehicle" was missing, which lead to tanya shooting at it.
Tanya's weapon (Colt45) has InvalidTargets: Vehicle defined,
so adding just "Vehicle" to the TargetTypes fixed the bug.

Fixes #10545.
