### PR TITLE
Change CONNECTIONFAILED_PANEL title if server requires password

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -106,6 +106,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
 			connectionError.GetText = () => orderManager.ServerError;
 
+			var panelTitle = widget.Get<LabelWidget>("TITLE");
+			panelTitle.GetText = () => orderManager.AuthenticationFailed ? "Password Required" : "Connection Failed";
+
 			passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");
 			if (passwordField != null)
 			{

--- a/mods/cnc/chrome/connection.yaml
+++ b/mods/cnc/chrome/connection.yaml
@@ -46,7 +46,6 @@ Container@CONNECTIONFAILED_PANEL:
 			Font: BigBold
 			Contrast: true
 			Align: Center
-			Text: Connection Failed
 		Background@CONNECTION_BACKGROUND:
 			Width: 370
 			Height: 85

--- a/mods/ra/chrome/connection.yaml
+++ b/mods/ra/chrome/connection.yaml
@@ -6,12 +6,11 @@ Background@CONNECTIONFAILED_PANEL:
 	Height: 160
 	Children:
 		LogicTicker@CONNECTION_FAILED_TICKER:
-		Label@CONNECTION_FAILED_TITLE:
+		Label@TITLE:
 			X: 0
 			Y: 20
 			Width: 450
 			Height: 25
-			Text: Connection Failed
 			Align: Center
 			Font: Bold
 		Label@CONNECTING_DESC:

--- a/mods/ra/chrome/connection.yaml
+++ b/mods/ra/chrome/connection.yaml
@@ -43,7 +43,7 @@ Background@CONNECTIONFAILED_PANEL:
 			MaxLength: 20
 			Height: 25
 		Button@RETRY_BUTTON:
-			X: PARENT_RIGHT - 360
+			X: PARENT_RIGHT - 430
 			Y: PARENT_BOTTOM - 45
 			Width: 160
 			Height: 25


### PR DESCRIPTION
I've also fixed the alignment of the Retry button on the `CONNECTIONFAILED_PANEL`.

This is how the panel looks now:
![](http://i.imgur.com/fGXtzWG.png)

Fixes #7160
