### PR TITLE
TD Balance Changes v1192016

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -1,7 +1,7 @@
 FACT:
 	Inherits: ^BaseBuilding
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	Tooltip:
 		Name: Construction Yard
 		Description: Builds structures
@@ -9,7 +9,7 @@ FACT:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 1400
+		HP: 2000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -515,7 +515,7 @@ FIX:
 	SelectionDecorations:
 		VisualBounds: 72,48
 	Health:
-		HP: 400
+		HP: 600
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -840,7 +840,7 @@ ATWR:
 	DetectCloaked:
 		Range: 5c0
 	Power:
-		Amount: -40
+		Amount: -50
 
 SBAG:
 	Inherits: ^Wall

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -1,13 +1,13 @@
 MCV:
 	Inherits: ^Vehicle
 	Valued:
-		Cost: 2000
+		Cost: 4000
 	Tooltip:
 		Name: Mobile Construction Vehicle
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Buildable:
 		BuildPaletteOrder: 100
-		Prerequisites: anyhq, ~techlevel.medium
+		Prerequisites: anyhq, ~techlevel.medium, fix
 		Queue: Vehicle.GDI, Vehicle.Nod
 	Selectable:
 		Priority: 4
@@ -15,9 +15,9 @@ MCV:
 		Speed: 71
 		Crushes: crate, infantry
 	Health:
-		HP: 750
+		HP: 950
 	Armor:
-		Type: Light
+		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
 	Transforms:
@@ -486,7 +486,7 @@ MLRS:
 		PipCount: 0
 		SelfReloads: true
 		ReloadCount: 1
-		SelfReloadTicks: 100
+		SelfReloadTicks: 45
 	AttackTurreted:
 	WithReloadingSpriteTurret:
 		AmmoPoolName: primary

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -16,7 +16,7 @@ Rockets:
 		RangeLimit: 20
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 35
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
@@ -170,7 +170,7 @@ MammothMissiles:
 		ValidImpactTypes: Air, AirHit
 
 227mm:
-	ReloadDelay: 140
+	ReloadDelay: 100
 	Range: 12c0
 	MinRange: 3c0
 	Burst: 4

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -174,7 +174,7 @@ APCGun:
 		Versus:
 			None: 50
 			Wood: 50
-			Light: 100
+			Light: 105
 			Heavy: 50
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect


### PR DESCRIPTION
Balance changes are as followed:

Increase power of AGT to 50 from 40.

MSAM faster reload to 45 from 100.

Increase APC damage vs light target to 105 from 100.

MLRS attack speed increase to 100 from 140.

Rocket Infantry damage increase to 35 from 30.

MCV Price increase to 4000 from 2000. Build time increase from 0:48 to
1:36.

MCV unit HP increase to 950 from 750. armor type Heavy from Light.

MCV now requires both Command Center and Repair Pad to produce.

Construction yard HP increase to 2000 from 1400.

Repair pad HP increase to 600 from 400.

Link discussion at:
http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&p=294421#294421
