### PR TITLE
MSAM Trajectory change.

### DIFF
--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -375,7 +375,7 @@ Patriot:
 		TrailImage: smokey
 		ContrailLength: 8
 		HorizontalRateOfTurn: 20
-		MaximumLaunchSpeed: 341
+		MaximumLaunchSpeed: 300
 		RangeLimit: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 682


### PR DESCRIPTION
changes from 341 to 300.

This allows aircraft to escape the MSAM with the same mechanics as
current release. In https://github.com/OpenRA/OpenRA/pull/10552 the
reload speed was changed to prevent stand still. This allows them to
keep fire rates up rather then wasted fire.

The missile mechanic change is a great buff addition. Thank you very
much!
