### PR TITLE
Remove IReadOnlyPackage.Priority

### DIFF
--- a/OpenRA.Game/FileSystem/BagFile.cs
+++ b/OpenRA.Game/FileSystem/BagFile.cs
@@ -23,13 +23,11 @@ namespace OpenRA.FileSystem
 	{
 		readonly string bagFilename;
 		readonly Stream s;
-		readonly int bagFilePriority;
 		readonly Dictionary<string, IdxEntry> index;
 
-		public BagFile(FileSystem context, string filename, int priority)
+		public BagFile(FileSystem context, string filename)
 		{
 			bagFilename = filename;
-			bagFilePriority = priority;
 
 			// A bag file is always accompanied with an .idx counterpart
 			// For example: audio.bag requires the audio.idx file
@@ -47,7 +45,6 @@ namespace OpenRA.FileSystem
 			s = context.Open(filename);
 		}
 
-		public int Priority { get { return 1000 + bagFilePriority; } }
 		public string Name { get { return bagFilename; } }
 
 		public Stream GetContent(string filename)

--- a/OpenRA.Game/FileSystem/BagFile.cs
+++ b/OpenRA.Game/FileSystem/BagFile.cs
@@ -21,13 +21,15 @@ namespace OpenRA.FileSystem
 {
 	public sealed class BagFile : IReadOnlyPackage
 	{
-		readonly string bagFilename;
+		public string Name { get; private set; }
+		public IEnumerable<string> Contents { get { return index.Keys; } }
+
 		readonly Stream s;
 		readonly Dictionary<string, IdxEntry> index;
 
 		public BagFile(FileSystem context, string filename)
 		{
-			bagFilename = filename;
+			Name = filename;
 
 			// A bag file is always accompanied with an .idx counterpart
 			// For example: audio.bag requires the audio.idx file
@@ -45,9 +47,7 @@ namespace OpenRA.FileSystem
 			s = context.Open(filename);
 		}
 
-		public string Name { get { return bagFilename; } }
-
-		public Stream GetContent(string filename)
+		public Stream GetStream(string filename)
 		{
 			IdxEntry entry;
 			if (!index.TryGetValue(filename, out entry))
@@ -113,14 +113,9 @@ namespace OpenRA.FileSystem
 			return mergedStream;
 		}
 
-		public bool Exists(string filename)
+		public bool Contains(string filename)
 		{
 			return index.ContainsKey(filename);
-		}
-
-		public IEnumerable<string> AllFileNames()
-		{
-			return index.Keys;
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/FileSystem/BigFile.cs
+++ b/OpenRA.Game/FileSystem/BigFile.cs
@@ -18,14 +18,12 @@ namespace OpenRA.FileSystem
 	public sealed class BigFile : IReadOnlyPackage
 	{
 		public string Name { get; private set; }
-		public int Priority { get; private set; }
 		readonly Dictionary<string, Entry> entries = new Dictionary<string, Entry>();
 		readonly Stream s;
 
-		public BigFile(FileSystem context, string filename, int priority)
+		public BigFile(FileSystem context, string filename)
 		{
 			Name = filename;
-			Priority = priority;
 
 			s = context.Open(filename);
 			try

--- a/OpenRA.Game/FileSystem/BigFile.cs
+++ b/OpenRA.Game/FileSystem/BigFile.cs
@@ -18,7 +18,9 @@ namespace OpenRA.FileSystem
 	public sealed class BigFile : IReadOnlyPackage
 	{
 		public string Name { get; private set; }
-		readonly Dictionary<string, Entry> entries = new Dictionary<string, Entry>();
+		public IEnumerable<string> Contents { get { return index.Keys; } }
+
+		readonly Dictionary<string, Entry> index = new Dictionary<string, Entry>();
 		readonly Stream s;
 
 		public BigFile(FileSystem context, string filename)
@@ -45,7 +47,7 @@ namespace OpenRA.FileSystem
 				for (var i = 0; i < entryCount; i++)
 				{
 					var entry = new Entry(s);
-					entries.Add(entry.Path, entry);
+					index.Add(entry.Path, entry);
 				}
 			}
 			catch
@@ -84,19 +86,14 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		public Stream GetContent(string filename)
+		public Stream GetStream(string filename)
 		{
-			return entries[filename].GetData();
+			return index[filename].GetData();
 		}
 
-		public bool Exists(string filename)
+		public bool Contains(string filename)
 		{
-			return entries.ContainsKey(filename);
-		}
-
-		public IEnumerable<string> AllFileNames()
-		{
-			return entries.Keys;
+			return index.ContainsKey(filename);
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/FileSystem/D2kSoundResources.cs
+++ b/OpenRA.Game/FileSystem/D2kSoundResources.cs
@@ -31,13 +31,11 @@ namespace OpenRA.FileSystem
 		readonly Stream s;
 
 		readonly string filename;
-		readonly int priority;
 		readonly Dictionary<string, Entry> index = new Dictionary<string, Entry>();
 
-		public D2kSoundResources(FileSystem context, string filename, int priority)
+		public D2kSoundResources(FileSystem context, string filename)
 		{
 			this.filename = filename;
-			this.priority = priority;
 
 			s = context.Open(filename);
 			try
@@ -79,8 +77,6 @@ namespace OpenRA.FileSystem
 		}
 
 		public string Name { get { return filename; } }
-
-		public int Priority { get { return 1000 + priority; } }
 
 		public void Dispose()
 		{

--- a/OpenRA.Game/FileSystem/D2kSoundResources.cs
+++ b/OpenRA.Game/FileSystem/D2kSoundResources.cs
@@ -28,14 +28,15 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		readonly Stream s;
+		public string Name { get; private set; }
+		public IEnumerable<string> Contents { get { return index.Keys; } }
 
-		readonly string filename;
+		readonly Stream s;
 		readonly Dictionary<string, Entry> index = new Dictionary<string, Entry>();
 
 		public D2kSoundResources(FileSystem context, string filename)
 		{
-			this.filename = filename;
+			Name = filename;
 
 			s = context.Open(filename);
 			try
@@ -56,7 +57,7 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		public Stream GetContent(string filename)
+		public Stream GetStream(string filename)
 		{
 			Entry e;
 			if (!index.TryGetValue(filename, out e))
@@ -66,17 +67,10 @@ namespace OpenRA.FileSystem
 			return new MemoryStream(s.ReadBytes((int)e.Length));
 		}
 
-		public bool Exists(string filename)
+		public bool Contains(string filename)
 		{
 			return index.ContainsKey(filename);
 		}
-
-		public IEnumerable<string> AllFileNames()
-		{
-			return index.Keys;
-		}
-
-		public string Name { get { return filename; } }
 
 		public void Dispose()
 		{

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -23,52 +23,50 @@ namespace OpenRA.FileSystem
 		readonly Dictionary<IReadOnlyPackage, int> mountedPackages = new Dictionary<IReadOnlyPackage, int>();
 
 		static readonly Dictionary<string, Assembly> AssemblyCache = new Dictionary<string, Assembly>();
-
-		int order;
 		Cache<string, List<IReadOnlyPackage>> fileIndex = new Cache<string, List<IReadOnlyPackage>>(_ => new List<IReadOnlyPackage>());
 
-		public IReadWritePackage CreatePackage(string filename, int order, Dictionary<string, byte[]> content)
+		public IReadWritePackage CreatePackage(string filename, Dictionary<string, byte[]> content)
 		{
 			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, order, content);
+				return new ZipFile(this, filename, content);
 			if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, order, content);
+				return new ZipFile(this, filename, content);
 
-			return new Folder(filename, order, content);
+			return new Folder(filename, content);
 		}
 
-		public IReadOnlyPackage OpenPackage(string filename, int order)
+		public IReadOnlyPackage OpenPackage(string filename)
 		{
 			if (filename.EndsWith(".mix", StringComparison.InvariantCultureIgnoreCase))
-				return new MixFile(this, filename, order);
+				return new MixFile(this, filename);
 			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, order);
+				return new ZipFile(this, filename);
 			if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, order);
+				return new ZipFile(this, filename);
 			if (filename.EndsWith(".RS", StringComparison.InvariantCultureIgnoreCase))
-				return new D2kSoundResources(this, filename, order);
+				return new D2kSoundResources(this, filename);
 			if (filename.EndsWith(".Z", StringComparison.InvariantCultureIgnoreCase))
-				return new InstallShieldPackage(this, filename, order);
+				return new InstallShieldPackage(this, filename);
 			if (filename.EndsWith(".PAK", StringComparison.InvariantCultureIgnoreCase))
-				return new PakFile(this, filename, order);
+				return new PakFile(this, filename);
 			if (filename.EndsWith(".big", StringComparison.InvariantCultureIgnoreCase))
-				return new BigFile(this, filename, order);
+				return new BigFile(this, filename);
 			if (filename.EndsWith(".bag", StringComparison.InvariantCultureIgnoreCase))
-				return new BagFile(this, filename, order);
+				return new BagFile(this, filename);
 			if (filename.EndsWith(".hdr", StringComparison.InvariantCultureIgnoreCase))
-				return new InstallShieldCABExtractor(this, filename, order);
+				return new InstallShieldCABExtractor(this, filename);
 
-			return new Folder(filename, order);
+			return new Folder(filename);
 		}
 
-		public IReadWritePackage OpenWritablePackage(string filename, int order)
+		public IReadWritePackage OpenWritablePackage(string filename)
 		{
 			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, order);
+				return new ZipFile(this, filename);
 			if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, order);
+				return new ZipFile(this, filename);
 
-			return new Folder(filename, order);
+			return new Folder(filename);
 		}
 
 		public void Mount(string name)
@@ -79,7 +77,7 @@ namespace OpenRA.FileSystem
 
 			name = Platform.ResolvePath(name);
 
-			Action a = () => Mount(OpenPackage(name, order++));
+			Action a = () => Mount(OpenPackage(name));
 			if (optional)
 				try { a(); }
 				catch { }
@@ -149,8 +147,7 @@ namespace OpenRA.FileSystem
 		Stream GetFromCache(string filename)
 		{
 			var package = fileIndex[filename]
-				.Where(x => x.Exists(filename))
-				.MinByOrDefault(x => x.Priority);
+				.LastOrDefault(x => x.Exists(filename));
 
 			if (package != null)
 				return package.GetContent(filename);
@@ -193,9 +190,9 @@ namespace OpenRA.FileSystem
 			// Ask each package individually
 			IReadOnlyPackage package;
 			if (explicitPackage && !string.IsNullOrEmpty(packageName))
-				package = mountedPackages.Keys.Where(x => x.Name == packageName).MaxByOrDefault(x => x.Priority);
+				package = mountedPackages.Keys.LastOrDefault(x => x.Name == packageName);
 			else
-				package = mountedPackages.Keys.Where(x => x.Exists(filename)).MaxByOrDefault(x => x.Priority);
+				package = mountedPackages.Keys.LastOrDefault(x => x.Exists(filename));
 
 			if (package != null)
 			{

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -128,9 +128,6 @@ namespace OpenRA.FileSystem
 		public void LoadFromManifest(Manifest manifest)
 		{
 			UnmountAll();
-			foreach (var dir in manifest.Folders)
-				Mount(dir);
-
 			foreach (var pkg in manifest.Packages)
 				Mount(pkg);
 		}

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -93,7 +93,7 @@ namespace OpenRA.FileSystem
 				// Package is already mounted
 				// Increment the mount count and bump up the file loading priority
 				mountedPackages[package] = mountCount + 1;
-				foreach (var filename in package.AllFileNames())
+				foreach (var filename in package.Contents)
 				{
 					fileIndex[filename].Remove(package);
 					fileIndex[filename].Add(package);
@@ -103,7 +103,7 @@ namespace OpenRA.FileSystem
 			{
 				// Mounting the package for the first time
 				mountedPackages.Add(package, 1);
-				foreach (var filename in package.AllFileNames())
+				foreach (var filename in package.Contents)
 					fileIndex[filename].Add(package);
 			}
 		}
@@ -147,10 +147,10 @@ namespace OpenRA.FileSystem
 		Stream GetFromCache(string filename)
 		{
 			var package = fileIndex[filename]
-				.LastOrDefault(x => x.Exists(filename));
+				.LastOrDefault(x => x.Contains(filename));
 
 			if (package != null)
-				return package.GetContent(filename);
+				return package.GetStream(filename);
 
 			return null;
 		}
@@ -192,11 +192,11 @@ namespace OpenRA.FileSystem
 			if (explicitPackage && !string.IsNullOrEmpty(packageName))
 				package = mountedPackages.Keys.LastOrDefault(x => x.Name == packageName);
 			else
-				package = mountedPackages.Keys.LastOrDefault(x => x.Exists(filename));
+				package = mountedPackages.Keys.LastOrDefault(x => x.Contains(filename));
 
 			if (package != null)
 			{
-				s = package.GetContent(filename);
+				s = package.GetStream(filename);
 				return true;
 			}
 
@@ -212,10 +212,10 @@ namespace OpenRA.FileSystem
 				var divide = name.Split(':');
 				var packageName = divide.First();
 				var filename = divide.Last();
-				return mountedPackages.Keys.Where(n => n.Name == packageName).Any(f => f.Exists(filename));
+				return mountedPackages.Keys.Where(n => n.Name == packageName).Any(f => f.Contains(filename));
 			}
 			else
-				return mountedPackages.Keys.Any(f => f.Exists(name));
+				return mountedPackages.Keys.Any(f => f.Contains(name));
 		}
 
 		public static Assembly ResolveAssembly(object sender, ResolveEventArgs e)

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -16,23 +16,20 @@ namespace OpenRA.FileSystem
 	public sealed class Folder : IReadWritePackage
 	{
 		readonly string path;
-		readonly int priority;
 
 		// Create a new folder package
-		public Folder(string path, int priority, Dictionary<string, byte[]> contents)
+		public Folder(string path, Dictionary<string, byte[]> contents)
 		{
 			this.path = path;
-			this.priority = priority;
 			if (Directory.Exists(path))
 				Directory.Delete(path, true);
 
 			Write(contents);
 		}
 
-		public Folder(string path, int priority)
+		public Folder(string path)
 		{
 			this.path = path;
-			this.priority = priority;
 			if (!Directory.Exists(path))
 				Directory.CreateDirectory(path);
 		}
@@ -54,7 +51,6 @@ namespace OpenRA.FileSystem
 			return File.Exists(Path.Combine(path, filename));
 		}
 
-		public int Priority { get { return priority; } }
 		public string Name { get { return path; } }
 
 		public void Write(Dictionary<string, byte[]> contents)

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -34,24 +34,27 @@ namespace OpenRA.FileSystem
 				Directory.CreateDirectory(path);
 		}
 
-		public Stream GetContent(string filename)
+		public string Name { get { return path; } }
+
+		public IEnumerable<string> Contents
+		{
+			get
+			{
+				foreach (var filename in Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly))
+					yield return Path.GetFileName(filename);
+			}
+		}
+
+		public Stream GetStream(string filename)
 		{
 			try { return File.OpenRead(Path.Combine(path, filename)); }
 			catch { return null; }
 		}
 
-		public IEnumerable<string> AllFileNames()
-		{
-			foreach (var filename in Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly))
-				yield return Path.GetFileName(filename);
-		}
-
-		public bool Exists(string filename)
+		public bool Contains(string filename)
 		{
 			return File.Exists(Path.Combine(path, filename));
 		}
-
-		public string Name { get { return path; } }
 
 		public void Write(Dictionary<string, byte[]> contents)
 		{

--- a/OpenRA.Game/FileSystem/IPackage.cs
+++ b/OpenRA.Game/FileSystem/IPackage.cs
@@ -19,7 +19,6 @@ namespace OpenRA.FileSystem
 		Stream GetContent(string filename);
 		bool Exists(string filename);
 		IEnumerable<string> AllFileNames();
-		int Priority { get; }
 		string Name { get; }
 	}
 

--- a/OpenRA.Game/FileSystem/IPackage.cs
+++ b/OpenRA.Game/FileSystem/IPackage.cs
@@ -16,10 +16,10 @@ namespace OpenRA.FileSystem
 {
 	public interface IReadOnlyPackage : IDisposable
 	{
-		Stream GetContent(string filename);
-		bool Exists(string filename);
-		IEnumerable<string> AllFileNames();
 		string Name { get; }
+		IEnumerable<string> Contents { get; }
+		Stream GetStream(string filename);
+		bool Contains(string filename);
 	}
 
 	public interface IReadWritePackage : IReadOnlyPackage

--- a/OpenRA.Game/FileSystem/InstallShieldCABExtractor.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldCABExtractor.cs
@@ -331,19 +331,16 @@ namespace OpenRA.FileSystem
 		readonly Dictionary<uint, FileDescriptor> fileDescriptors = new Dictionary<uint, FileDescriptor>();
 		readonly Dictionary<string, uint> fileLookup = new Dictionary<string, uint>();
 		readonly FileSystem context;
-		int priority;
 		string commonName;
-		public int Priority { get { return priority; } }
 
 		public string Name { get { return commonName; } }
 
-		public InstallShieldCABExtractor(FileSystem context, string hdrFilename, int priority = -1)
+		public InstallShieldCABExtractor(FileSystem context, string hdrFilename)
 		{
 			var fileGroups = new List<FileGroup>();
 			var fileGroupOffsets = new List<uint>();
 
 			hdrFile = context.Open(hdrFilename);
-			this.priority = priority;
 			this.context = context;
 
 			// Strips archive number AND file extension

--- a/OpenRA.Game/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldPackage.cs
@@ -29,14 +29,16 @@ namespace OpenRA.FileSystem
 			}
 		}
 
+		public string Name { get; private set; }
+		public IEnumerable<string> Contents { get { return index.Keys; } }
+
 		readonly Dictionary<string, Entry> index = new Dictionary<string, Entry>();
 		readonly Stream s;
 		readonly long dataStart = 255;
-		readonly string filename;
 
 		public InstallShieldPackage(FileSystem context, string filename)
 		{
-			this.filename = filename;
+			Name = filename;
 
 			s = context.Open(filename);
 			try
@@ -104,7 +106,7 @@ namespace OpenRA.FileSystem
 			s.Position += chunkSize - nameLength - 30;
 		}
 
-		public Stream GetContent(string filename)
+		public Stream GetStream(string filename)
 		{
 			Entry e;
 			if (!index.TryGetValue(filename, out e))
@@ -116,17 +118,10 @@ namespace OpenRA.FileSystem
 			return new MemoryStream(Blast.Decompress(data));
 		}
 
-		public IEnumerable<string> AllFileNames()
-		{
-			return index.Keys;
-		}
-
-		public bool Exists(string filename)
+		public bool Contains(string filename)
 		{
 			return index.ContainsKey(filename);
 		}
-
-		public string Name { get { return filename; } }
 
 		public void Dispose()
 		{

--- a/OpenRA.Game/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldPackage.cs
@@ -32,13 +32,11 @@ namespace OpenRA.FileSystem
 		readonly Dictionary<string, Entry> index = new Dictionary<string, Entry>();
 		readonly Stream s;
 		readonly long dataStart = 255;
-		readonly int priority;
 		readonly string filename;
 
-		public InstallShieldPackage(FileSystem context, string filename, int priority)
+		public InstallShieldPackage(FileSystem context, string filename)
 		{
 			this.filename = filename;
-			this.priority = priority;
 
 			s = context.Open(filename);
 			try
@@ -128,7 +126,6 @@ namespace OpenRA.FileSystem
 			return index.ContainsKey(filename);
 		}
 
-		public int Priority { get { return 2000 + priority; } }
 		public string Name { get { return filename; } }
 
 		public void Dispose()

--- a/OpenRA.Game/FileSystem/MixFile.cs
+++ b/OpenRA.Game/FileSystem/MixFile.cs
@@ -21,6 +21,7 @@ namespace OpenRA.FileSystem
 	public sealed class MixFile : IReadOnlyPackage
 	{
 		public string Name { get; private set; }
+		public IEnumerable<string> Contents { get { return index.Keys; } }
 
 		readonly Dictionary<string, PackageEntry> index;
 		readonly long dataStart;
@@ -192,7 +193,7 @@ namespace OpenRA.FileSystem
 			return new SegmentStream(File.OpenRead(path), offset, entry.Length);
 		}
 
-		public Stream GetContent(string filename)
+		public Stream GetStream(string filename)
 		{
 			PackageEntry e;
 			if (!index.TryGetValue(filename, out e))
@@ -201,12 +202,7 @@ namespace OpenRA.FileSystem
 			return GetContent(e);
 		}
 
-		public IEnumerable<string> AllFileNames()
-		{
-			return index.Keys;
-		}
-
-		public bool Exists(string filename)
+		public bool Contains(string filename)
 		{
 			return index.ContainsKey(filename);
 		}

--- a/OpenRA.Game/FileSystem/MixFile.cs
+++ b/OpenRA.Game/FileSystem/MixFile.cs
@@ -25,13 +25,11 @@ namespace OpenRA.FileSystem
 		readonly Dictionary<string, PackageEntry> index;
 		readonly long dataStart;
 		readonly Stream s;
-		readonly int priority;
 		readonly FileSystem context;
 
-		public MixFile(FileSystem context, string filename, int priority)
+		public MixFile(FileSystem context, string filename)
 		{
 			Name = filename;
-			this.priority = priority;
 			this.context = context;
 
 			s = context.Open(filename);
@@ -212,8 +210,6 @@ namespace OpenRA.FileSystem
 		{
 			return index.ContainsKey(filename);
 		}
-
-		public int Priority { get { return 1000 + priority; } }
 
 		public void Dispose()
 		{

--- a/OpenRA.Game/FileSystem/Pak.cs
+++ b/OpenRA.Game/FileSystem/Pak.cs
@@ -22,13 +22,15 @@ namespace OpenRA.FileSystem
 
 	public sealed class PakFile : IReadOnlyPackage
 	{
-		readonly string filename;
+		public string Name { get; private set; }
+		public IEnumerable<string> Contents { get { return index.Keys; } }
+
 		readonly Dictionary<string, Entry> index;
 		readonly Stream stream;
 
 		public PakFile(FileSystem context, string filename)
 		{
-			this.filename = filename;
+			Name = filename;
 			index = new Dictionary<string, Entry>();
 
 			stream = context.Open(filename);
@@ -57,7 +59,7 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		public Stream GetContent(string filename)
+		public Stream GetStream(string filename)
 		{
 			Entry entry;
 			if (!index.TryGetValue(filename, out entry))
@@ -68,18 +70,10 @@ namespace OpenRA.FileSystem
 			return new MemoryStream(data);
 		}
 
-		public IEnumerable<string> AllFileNames()
-		{
-			foreach (var filename in index.Keys)
-				yield return filename;
-		}
-
-		public bool Exists(string filename)
+		public bool Contains(string filename)
 		{
 			return index.ContainsKey(filename);
 		}
-
-		public string Name { get { return filename; } }
 
 		public void Dispose()
 		{

--- a/OpenRA.Game/FileSystem/Pak.cs
+++ b/OpenRA.Game/FileSystem/Pak.cs
@@ -23,14 +23,12 @@ namespace OpenRA.FileSystem
 	public sealed class PakFile : IReadOnlyPackage
 	{
 		readonly string filename;
-		readonly int priority;
 		readonly Dictionary<string, Entry> index;
 		readonly Stream stream;
 
-		public PakFile(FileSystem context, string filename, int priority)
+		public PakFile(FileSystem context, string filename)
 		{
 			this.filename = filename;
-			this.priority = priority;
 			index = new Dictionary<string, Entry>();
 
 			stream = context.Open(filename);
@@ -81,7 +79,6 @@ namespace OpenRA.FileSystem
 			return index.ContainsKey(filename);
 		}
 
-		public int Priority { get { return 1000 + priority; } }
 		public string Name { get { return filename; } }
 
 		public void Dispose()

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -19,7 +19,6 @@ namespace OpenRA.FileSystem
 	public sealed class ZipFile : IReadWritePackage
 	{
 		readonly string filename;
-		readonly int priority;
 		SZipFile pkg;
 
 		static ZipFile()
@@ -27,10 +26,9 @@ namespace OpenRA.FileSystem
 			ZipConstants.DefaultCodePage = Encoding.UTF8.CodePage;
 		}
 
-		public ZipFile(FileSystem context, string filename, int priority)
+		public ZipFile(FileSystem context, string filename)
 		{
 			this.filename = filename;
-			this.priority = priority;
 
 			try
 			{
@@ -44,9 +42,8 @@ namespace OpenRA.FileSystem
 		}
 
 		// Create a new zip with the specified contents.
-		public ZipFile(FileSystem context, string filename, int priority, Dictionary<string, byte[]> contents)
+		public ZipFile(FileSystem context, string filename, Dictionary<string, byte[]> contents)
 		{
-			this.priority = priority;
 			this.filename = filename;
 
 			if (File.Exists(filename))
@@ -82,7 +79,6 @@ namespace OpenRA.FileSystem
 			return pkg.GetEntry(filename) != null;
 		}
 
-		public int Priority { get { return 500 + priority; } }
 		public string Name { get { return filename; } }
 
 		public void Write(Dictionary<string, byte[]> contents)

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -36,7 +36,7 @@ namespace OpenRA
 
 		public readonly ModMetadata Mod;
 		public readonly string[]
-			Packages, Folders, Rules, ServerTraits,
+			Packages, Rules, ServerTraits,
 			Sequences, VoxelSequences, Cursors, Chrome, Assemblies, ChromeLayout,
 			Weapons, Voices, Notifications, Music, Translations, TileSets,
 			ChromeMetrics, MapCompatibility, Missions;
@@ -72,7 +72,6 @@ namespace OpenRA
 			Mod.Id = modId;
 
 			// TODO: Use fieldloader
-			Folders = YamlList(yaml, "Folders", true);
 			MapFolders = YamlDictionary(yaml, "MapFolders", true);
 			Packages = YamlList(yaml, "Packages", true);
 			Rules = YamlList(yaml, "Rules", true);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -316,7 +316,7 @@ namespace OpenRA
 		public Map(string path)
 		{
 			Path = path;
-			Container = Game.ModData.ModFiles.OpenWritablePackage(path, int.MaxValue);
+			Container = Game.ModData.ModFiles.OpenWritablePackage(path);
 
 			AssertExists("map.yaml");
 			AssertExists("map.bin");
@@ -649,7 +649,7 @@ namespace OpenRA
 				Path = toPath;
 
 				// Create a new map package
-				Container = Game.ModData.ModFiles.CreatePackage(Path, int.MaxValue, entries);
+				Container = Game.ModData.ModFiles.CreatePackage(Path, entries);
 			}
 
 			// Update existing package

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -263,7 +263,7 @@ namespace OpenRA
 
 		void AssertExists(string filename)
 		{
-			using (var s = Container.GetContent(filename))
+			using (var s = Container.GetStream(filename))
 				if (s == null)
 					throw new InvalidOperationException("Required file {0} not present in this map".F(filename));
 		}
@@ -321,7 +321,7 @@ namespace OpenRA
 			AssertExists("map.yaml");
 			AssertExists("map.bin");
 
-			var yaml = new MiniYaml(null, MiniYaml.FromStream(Container.GetContent("map.yaml"), path));
+			var yaml = new MiniYaml(null, MiniYaml.FromStream(Container.GetStream("map.yaml"), path));
 			FieldLoader.Load(this, yaml);
 
 			// Support for formats 1-3 dropped 2011-02-11.
@@ -427,8 +427,8 @@ namespace OpenRA
 			LastSubCell = (SubCell)(SubCellOffsets.Length - 1);
 			DefaultSubCell = (SubCell)Grid.SubCellDefaultIndex;
 
-			if (Container.Exists("map.png"))
-				using (var dataStream = Container.GetContent("map.png"))
+			if (Container.Contains("map.png"))
+				using (var dataStream = Container.GetStream("map.png"))
 					CustomPreview = new Bitmap(dataStream);
 
 			PostInit();
@@ -634,12 +634,12 @@ namespace OpenRA
 			// Add any custom assets
 			if (Container != null)
 			{
-				foreach (var file in Container.AllFileNames())
+				foreach (var file in Container.Contents)
 				{
 					if (file == "map.bin" || file == "map.yaml")
 						continue;
 
-					entries.Add(file, Container.GetContent(file).ReadAllBytes());
+					entries.Add(file, Container.GetStream(file).ReadAllBytes());
 				}
 			}
 
@@ -662,7 +662,7 @@ namespace OpenRA
 		public CellLayer<TerrainTile> LoadMapTiles()
 		{
 			var tiles = new CellLayer<TerrainTile>(this);
-			using (var s = Container.GetContent("map.bin"))
+			using (var s = Container.GetStream("map.bin"))
 			{
 				var header = new BinaryDataHeader(s, MapSize);
 				if (header.TilesOffset > 0)
@@ -694,7 +694,7 @@ namespace OpenRA
 		public CellLayer<byte> LoadMapHeight()
 		{
 			var tiles = new CellLayer<byte>(this);
-			using (var s = Container.GetContent("map.bin"))
+			using (var s = Container.GetStream("map.bin"))
 			{
 				var header = new BinaryDataHeader(s, MapSize);
 				if (header.HeightsOffset > 0)
@@ -716,7 +716,7 @@ namespace OpenRA
 		{
 			var resources = new CellLayer<ResourceTile>(this);
 
-			using (var s = Container.GetContent("map.bin"))
+			using (var s = Container.GetStream("map.bin"))
 			{
 				var header = new BinaryDataHeader(s, MapSize);
 				if (header.ResourcesOffset > 0)
@@ -968,9 +968,9 @@ namespace OpenRA
 			using (var ms = new MemoryStream())
 			{
 				// Read the relevant data into the buffer
-				using (var s = Container.GetContent("map.yaml"))
+				using (var s = Container.GetStream("map.yaml"))
 					s.CopyTo(ms);
-				using (var s = Container.GetContent("map.bin"))
+				using (var s = Container.GetStream("map.bin"))
 					s.CopyTo(ms);
 
 				// Take the SHA1

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -175,8 +175,8 @@ namespace OpenRA
 			InitializeLoaders();
 			ModFiles.LoadFromManifest(Manifest);
 
-			// Mount map package so custom assets can be used. TODO: check priority.
-			ModFiles.Mount(ModFiles.OpenPackage(map.Path, int.MaxValue));
+			// Mount map package so custom assets can be used.
+			ModFiles.Mount(ModFiles.OpenPackage(map.Path));
 
 			using (new Support.PerfTimer("Map.PreloadRules"))
 				map.PreloadRules();

--- a/OpenRA.Mods.Common/UtilityCommands/GenerateMinimapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GenerateMinimapCommand.cs
@@ -27,12 +27,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		public void Run(ModData modData, string[] args)
 		{
 			Game.ModData = modData;
+			modData.MountFiles();
+
 			var map = new Map(args[1]);
-
-			modData.ModFiles.UnmountAll();
-			foreach (var dir in Game.ModData.Manifest.Folders)
-				modData.ModFiles.Mount(dir);
-
 			var minimap = Minimap.RenderMapPreview(map.Rules.TileSets[map.Tileset], map, true);
 
 			var dest = Path.GetFileNameWithoutExtension(args[1]) + ".png";

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -361,7 +361,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (assetSource == null)
 				return;
 
-			var files = assetSource.AllFileNames().OrderBy(s => s);
+			var files = assetSource.Contents.OrderBy(s => s);
 			foreach (var file in files)
 			{
 				if (allowedExtensions.Any(ext => file.EndsWith(ext, true, CultureInfo.InvariantCulture)))

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -7,21 +7,10 @@ Metadata:
 RequiresMods:
 	modchooser: {DEV_VERSION}
 
-Folders:
+Packages:
+	~^Content/cnc
 	.
 	./mods/cnc
-	./mods/cnc/bits
-	./mods/cnc/bits/jungle
-	./mods/cnc/bits/desert
-	./mods/cnc/bits/ss
-	./mods/cnc/uibits
-	~^Content/cnc
-
-MapFolders:
-	./mods/cnc/maps@System
-	~^maps/cnc@User
-
-Packages:
 	speech.mix
 	conquer.mix
 	sounds.mix
@@ -29,13 +18,22 @@ Packages:
 	temperat.mix
 	winter.mix
 	desert.mix
-	snow.mix
 	~movies-gdi.mix
 	~movies-nod.mix
 	~movies.mix
 	~scores.mix
 	~scores2.mix
 	~transit.mix
+	./mods/cnc/bits/snow.mix
+	./mods/cnc/bits
+	./mods/cnc/bits/jungle
+	./mods/cnc/bits/desert
+	./mods/cnc/bits/ss
+	./mods/cnc/uibits
+
+MapFolders:
+	./mods/cnc/maps@System
+	~^maps/cnc@User
 
 Rules:
 	./mods/cnc/rules/misc.yaml

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -7,24 +7,22 @@ Metadata:
 RequiresMods:
 	modchooser: {DEV_VERSION}
 
-Folders:
-	.
-	d2k:
-	d2k:bits
-	d2k:bits/tex
-	d2k:bits/xmas
-	d2k:uibits
+Packages:
 	~^Content/d2k
 	~^Content/d2k/GAMESFX
 	~^Content/d2k/Movies
 	~^Content/d2k/Music
+	.
+	d2k:
+	SOUND.RS
+	d2k:bits
+	d2k:bits/tex
+	d2k:bits/xmas
+	d2k:uibits
 
 MapFolders:
 	d2k:maps@System
 	~^maps/d2k@User
-
-Packages:
-	SOUND.RS
 
 Rules:
 	d2k:rules/misc.yaml

--- a/mods/modchooser/mod.yaml
+++ b/mods/modchooser/mod.yaml
@@ -6,7 +6,7 @@ Metadata:
 
 RequiresMods:
 
-Folders:
+Packages:
 	.
 	./mods/modchooser
 

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -7,19 +7,10 @@ Metadata:
 RequiresMods:
 	modchooser: {DEV_VERSION}
 
-Folders:
+Packages:
+	~^Content/ra
 	.
 	./mods/ra
-	./mods/ra/bits
-	./mods/ra/bits/desert
-	./mods/ra/uibits
-	~^Content/ra
-
-MapFolders:
-	./mods/ra/maps@System
-	~^maps/ra@User
-
-Packages:
 	~main.mix
 	redalert.mix
 	conquer.mix
@@ -35,6 +26,13 @@ Packages:
 	~scores.mix
 	~movies1.mix
 	~movies2.mix
+	./mods/ra/bits
+	./mods/ra/bits/desert
+	./mods/ra/uibits
+
+MapFolders:
+	./mods/ra/maps@System
+	~^maps/ra@User
 
 Rules:
 	./mods/ra/rules/misc.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -7,18 +7,10 @@ Metadata:
 RequiresMods:
 	modchooser: {DEV_VERSION}
 
-Folders:
+Packages:
+	~^Content/ts
 	.
 	./mods/ts
-	./mods/ts/bits
-	./mods/ts/uibits
-	~^Content/ts
-
-MapFolders:
-	./mods/ts/maps@System
-	~^maps/ts@User
-
-Packages:
 # Tiberian Sun
 	~scores.mix
 	~sidenc01.mix
@@ -58,6 +50,12 @@ Packages:
 	~e01vox01.mix
 	~e01vox02.mix
 	~ecache01.mix
+	./mods/ts/bits
+	./mods/ts/uibits
+
+MapFolders:
+	./mods/ts/maps@System
+	~^maps/ts@User
 
 Rules:
 	./mods/ts/rules/ai.yaml


### PR DESCRIPTION
This removes the last of the legacy crap from the `IReadOnlyPackage` interface by replacing the hardcoded package priorities with mod-defined priority via the package order in mod.yaml.
