### PR TITLE
Fixes Obelisk not attacking again after a forced attack command

### DIFF
--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -95,8 +95,7 @@ NAOBEL:
 		LocalOffset: 1400,210,800
 	AttackCharge:
 		ChargeAudio: obelpowr.aud
-		ReloadTime: 50
-		InitialChargeDelay: 50
+		InitialChargeDelay: 120
 	WithChargeOverlay:
 		Sequence: active
 		Palette: player

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -171,7 +171,7 @@ Proton:
 		ValidImpactTypes: Water
 
 ObeliskLaserFire:
-	ReloadDelay: 120
+	ReloadDelay: 1
 	Range: 10c512
 	Charges: true
 	Report: obelray1.aud


### PR DESCRIPTION
This PR should fix #10165,
Reload delay was set to 120 so the obelisk would wait that long before charging again. Another attack move would overwrite this request explaining the behavior
