### PR TITLE
Fixed Passenger missing UpgradeGrantedReference

### DIFF
--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WDist AlternateTransportScanRange = WDist.FromCells(11) / 2;
 
 		[Desc("Upgrade types to grant to transport.")]
-		public readonly string[] GrantUpgrades = { };
+		[UpgradeGrantedReference] public readonly string[] GrantUpgrades = { };
 
 		[VoiceReference] public readonly string Voice = "Action";
 


### PR DESCRIPTION
which cause the linter to run amok if you actually use it.
