### PR TITLE
Moved Kennel in Soviet buildings tab as per issue 8973

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1418,7 +1418,7 @@ KENN:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 25
+		BuildPaletteOrder: 175
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.infonly
 	Valued:
 		Cost: 100


### PR DESCRIPTION
Moves the Kennel to the end of the Soviet buildings tab to align all the other buildings so that hotkeys match across factions. Closes #8973.
