### PR TITLE
Added support for the Kate text editor

### DIFF
--- a/.kateproject
+++ b/.kateproject
@@ -1,0 +1,9 @@
+{
+  "name": "OpenRA"
+, "files": [ { "git": 1 } ]
+, "build": {
+  "directory": "."
+  , "build": "make all"
+  , "clean": "make clean"
+  }
+}


### PR DESCRIPTION
See http://kate-editor.org/2012/11/02/using-the-projects-plugin-in-kate/ for reference. I should have set this up way earlier. It supports project wide search (and replace) which is now quite necessary after the rules have been split up into many different files and adds other convenient features such as build commands. Not sure if this is helpful for anyone else. I may be the only user, but on the other hand this JSON file is hidden, small and won't need any maintenance.

![image](https://cloud.githubusercontent.com/assets/756669/12535624/838f5ff0-c289-11e5-8f0c-379fe4075c74.png)
