### PR TITLE
Add a "no superweapons" tech level to RA.

### DIFF
--- a/mods/ra/chrome/lobby-options.yaml
+++ b/mods/ra/chrome/lobby-options.yaml
@@ -54,16 +54,16 @@ Background@LOBBY_OPTIONS_BIN:
 					Height: 20
 					Text: Debug Menu
 				Label@DIFFICULTY_DESC:
-					X: PARENT_RIGHT - WIDTH - 145
+					X: PARENT_RIGHT - WIDTH - 165
 					Y: 70
-					Width: 120
+					Width: 160
 					Height: 25
 					Text: Mission Difficulty:
 					Align: Right
 				DropDownButton@DIFFICULTY_DROPDOWNBUTTON:
 					X: PARENT_RIGHT - WIDTH
 					Y: 70
-					Width: 140
+					Width: 160
 					Height: 25
 					Font: Regular
 				Label@STARTINGCASH_DESC:
@@ -75,12 +75,12 @@ Background@LOBBY_OPTIONS_BIN:
 				DropDownButton@STARTINGCASH_DROPDOWNBUTTON:
 					X: 85
 					Y: 110
-					Width: 130
+					Width: 160
 					Height: 25
 					Font: Regular
 					Text: $5000
 				Label@STARTINGUNITS_DESC:
-					X: PARENT_RIGHT - WIDTH - 145
+					X: PARENT_RIGHT - WIDTH - 165
 					Y: 110
 					Width: 120
 					Height: 25
@@ -89,13 +89,13 @@ Background@LOBBY_OPTIONS_BIN:
 				DropDownButton@STARTINGUNITS_DROPDOWNBUTTON:
 					X: PARENT_RIGHT - WIDTH
 					Y: 110
-					Width: 140
+					Width: 160
 					Height: 25
 					Font: Regular
 				DropDownButton@TECHLEVEL_DROPDOWNBUTTON:
 					X: 85
 					Y: 150
-					Width: 130
+					Width: 160
 					Height: 25
 					Font: Regular
 					Text: 10
@@ -106,7 +106,7 @@ Background@LOBBY_OPTIONS_BIN:
 					Text: Tech Level:
 					Align: Right
 				Label@GAMESPEED_DESC:
-					X: PARENT_RIGHT - WIDTH - 145
+					X: PARENT_RIGHT - WIDTH - 165
 					Y: 150
 					Width: 120
 					Height: 25
@@ -115,6 +115,6 @@ Background@LOBBY_OPTIONS_BIN:
 				DropDownButton@GAMESPEED_DROPDOWNBUTTON:
 					X: PARENT_RIGHT - WIDTH
 					Y: 150
-					Width: 140
+					Width: 160
 					Height: 25
 					Font: Regular

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -79,7 +79,7 @@ MIG:
 		Queue: Aircraft
 		BuildAtProductionType: Plane
 		BuildPaletteOrder: 50
-		Prerequisites: ~afld, stek, ~techlevel.unrestricted
+		Prerequisites: ~afld, stek, ~techlevel.high
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -233,7 +233,7 @@ HELI:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 40
-		Prerequisites: ~hpad, atek, ~techlevel.unrestricted
+		Prerequisites: ~hpad, atek, ~techlevel.high
 	Valued:
 		Cost: 2000
 	Tooltip:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -154,7 +154,7 @@ ATEF:
 	Buildable:
 		BuildPaletteOrder: 940
 		Queue: Defense
-		Prerequisites: ~structures.france, ~techlevel.unrestricted
+		Prerequisites: ~structures.france, ~techlevel.high
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -251,7 +251,7 @@ E7:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 120
-		Prerequisites: ~tent, atek, ~techlevel.unrestricted
+		Prerequisites: ~tent, atek, ~techlevel.high
 		BuildLimit: 1
 	Valued:
 		Cost: 1200
@@ -476,7 +476,7 @@ SHOK:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 130
-		Prerequisites: ~barr, stek, tsla, ~infantry.russia, ~techlevel.unrestricted
+		Prerequisites: ~barr, stek, tsla, ~infantry.russia, ~techlevel.high
 	Valued:
 		Cost: 400
 	Tooltip:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -75,7 +75,7 @@ CRATE:
 		SelectionShares: 3
 		Units: 4tnk
 		ValidFactions: soviet, russia, ukraine
-		Prerequisites: techlevel.unrestricted, fix, techcenter
+		Prerequisites: techlevel.high, fix, techcenter
 	GiveUnitCrateAction@squadlight:
 		SelectionShares: 7
 		Units: e1,e1,e1,e3,e3

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -60,9 +60,12 @@ Player:
 	ProvidesTechPrerequisite@medium:
 		Name: Medium
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium
+	ProvidesTechPrerequisite@high:
+		Name: No Superweapons
+		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.high
 	ProvidesTechPrerequisite@unrestricted:
 		Name: Unrestricted
-		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.unrestricted
+		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.high, techlevel.unrestricted
 	GlobalUpgradeManager:
 	EnemyWatcher:
 	VeteranProductionIconOverlay:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -60,7 +60,7 @@ MSUB:
 		Queue: Ship
 		BuildAtProductionType: Submarine
 		BuildPaletteOrder: 60
-		Prerequisites: ~spen, stek, ~techlevel.unrestricted
+		Prerequisites: ~spen, stek, ~techlevel.high
 	Valued:
 		Cost: 2400
 	Tooltip:
@@ -162,7 +162,7 @@ CA:
 		Queue: Ship
 		BuildAtProductionType: Boat
 		BuildPaletteOrder: 50
-		Prerequisites: ~syrd, atek, ~techlevel.unrestricted
+		Prerequisites: ~syrd, atek, ~techlevel.high
 	Valued:
 		Cost: 2400
 	Tooltip:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -60,7 +60,7 @@ GAP:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 110
-		Prerequisites: atek, ~structures.allies, ~techlevel.unrestricted
+		Prerequisites: atek, ~structures.allies, ~techlevel.high
 	Building:
 		Footprint: _ x
 		Dimensions: 1,2
@@ -747,7 +747,7 @@ ATEK:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 140
-		Prerequisites: weap, dome, ~structures.allies, ~techlevel.unrestricted
+		Prerequisites: weap, dome, ~structures.allies, ~techlevel.high
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -1318,7 +1318,7 @@ STEK:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 150
-		Prerequisites: weap, dome, ~structures.soviet, ~techlevel.unrestricted
+		Prerequisites: weap, dome, ~structures.soviet, ~techlevel.high
 	Valued:
 		Cost: 1500
 	Tooltip:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -151,7 +151,7 @@ V2RL:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 190
-		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
+		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.high
 	Valued:
 		Cost: 2000
 	CustomBuildTimeValue:
@@ -492,7 +492,7 @@ MGG:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 160
-		Prerequisites: atek, ~vehicles.france, ~techlevel.unrestricted
+		Prerequisites: atek, ~vehicles.france, ~techlevel.high
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -525,7 +525,7 @@ MRJ:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 150
-		Prerequisites: atek, ~vehicles.allies, ~techlevel.unrestricted
+		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
 	Health:
 		HP: 220
 	Armor:
@@ -551,7 +551,7 @@ TTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 180
-		Prerequisites: tsla, stek, ~vehicles.russia, ~techlevel.unrestricted
+		Prerequisites: tsla, stek, ~vehicles.russia, ~techlevel.high
 	Valued:
 		Cost: 1350
 	Tooltip:
@@ -626,7 +626,7 @@ DTRK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 170
-		Prerequisites: stek, ~vehicles.ukraine, ~techlevel.unrestricted
+		Prerequisites: stek, ~vehicles.ukraine, ~techlevel.high
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -693,7 +693,7 @@ QTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 200
-		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.unrestricted
+		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.high
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -720,7 +720,7 @@ STNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 140
-		Prerequisites: atek, ~vehicles.england, ~techlevel.unrestricted
+		Prerequisites: atek, ~vehicles.england, ~techlevel.high
 	Valued:
 		Cost: 1350
 	Tooltip:


### PR DESCRIPTION
This addresses one of the biggest remaining complaints/requests that we see from casual players scattered over our various feedback channels.

The new "No Superweapons" options disables the three superweapon structures in the game: Missile Silo, Iron Curtain, Chronosphere.  It does _not_ remove any of the support powers (GPS, parabombs, etc), nor does it attempt to address the balance of the chrono tank (which is implicitly removed) or the demo truck (which isn't).
