### PR TITLE
Added missing CRAT0C rule

### DIFF
--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -144,6 +144,9 @@ CRAT0A:
 CRAT0B:
 	Inherits: ^Box
 
+CRAT0C:
+	Inherits: ^Box
+
 DRUM01:
 	Inherits: ^Drum
 


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/8957.
