### PR TITLE
Fix a crash in d2k caused by empty bounds

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -183,14 +183,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self.World.ActorMap.AddInfluence(self, this);
 			self.World.ActorMap.AddPosition(self, this);
-			self.World.ScreenMap.Add(self);
+
+			if (!self.Bounds.Size.IsEmpty)
+				self.World.ScreenMap.Add(self);
 		}
 
 		public void RemovedFromWorld(Actor self)
 		{
 			self.World.ActorMap.RemoveInfluence(self, this);
 			self.World.ActorMap.RemovePosition(self, this);
-			self.World.ScreenMap.Remove(self);
+
+			if (!self.Bounds.Size.IsEmpty)
+				self.World.ScreenMap.Remove(self);
 		}
 
 		public void NotifyBuildingComplete(Actor self)


### PR DESCRIPTION
~~I'm using `CustomSelectionSize`, because somehow `AutoSelectionSize` didn't work.~~

EDIT: While looking at #10462 I just noticed that we are allowing empty bounds, so I just added respective checks to prevent the crash.

The crash is easy to reproduce: Just launch the d2k mod.

```
System.ArgumentException: bounds must be non-empty.
   at OpenRA.Primitives.SpatiallyPartitioned`1.ValidateBounds(Rectangle bounds) in OpenRA\OpenRA.Game\Primitives\SpatiallyPartitioned.cs:Line 36.
   at OpenRA.Primitives.SpatiallyPartitioned`1.Add(T item, Rectangle bounds) in OpenRA\OpenRA.Game\Primitives\SpatiallyPartitioned.cs:Line 41.
   at OpenRA.Traits.ScreenMap.Add(Actor a) in OpenRA\OpenRA.Game\Traits\World\ScreenMap.cs:Line 77.
   at OpenRA.Mods.Common.Traits.Building.AddedToWorld(Actor self)
   at OpenRA.World.Add(Actor a) in OpenRA\OpenRA.Game\World.cs:Line 245.
   at OpenRA.World.CreateActor(Boolean addToWorld, String name, TypeDictionary initDict) in OpenRA\OpenRA.Game\World.cs:Line 234.
   at OpenRA.World.CreateActor(String name, TypeDictionary initDict) in OpenRA\OpenRA.Game\World.cs:Line 225.
   at OpenRA.Mods.Common.Traits.SpawnMapActors.WorldLoaded(World world, WorldRenderer wr)
   at OpenRA.World.LoadComplete(WorldRenderer wr) in OpenRA\OpenRA.Game\World.cs:Line 209.
   at OpenRA.Game.StartGame(String mapUID, WorldType type) in OpenRA\OpenRA.Game\Game.cs:Line 161.
   at OpenRA.Game.LoadShellMap() in OpenRA\OpenRA.Game\Game.cs:Line 443.
   at OpenRA.Mods.Common.LoadScreens.BlankLoadScreen.StartGame(Arguments args)
   at OpenRA.Game.InitializeMod(String mod, Arguments args) in OpenRA\OpenRA.Game\Game.cs:Line 399.
   at OpenRA.Game.Initialize(Arguments args) in OpenRA\OpenRA.Game\Game.cs:Line 288.
   at OpenRA.Program.Run(String[] args) in OpenRA\OpenRA.Game\Support\Program.cs:Line 115.
   at OpenRA.Program.Main(String[] args) in OpenRA\OpenRA.Game\Support\Program.cs:Line 33.
```
