### PR TITLE
Fix button positions on TD connection dialog.

### DIFF
--- a/mods/cnc/chrome/connection.yaml
+++ b/mods/cnc/chrome/connection.yaml
@@ -26,7 +26,6 @@ Container@CONNECTING_PANEL:
 					Align: Center
 		Button@ABORT_BUTTON:
 			Key: escape
-			X: 230
 			Y: 89
 			Width: 140
 			Height: 35
@@ -79,16 +78,16 @@ Container@CONNECTIONFAILED_PANEL:
 					Width: 155
 					MaxLength: 20
 					Height: 25
-		Button@RETRY_BUTTON:
-			Key: return
-			Y: 84
-			Width: 140
-			Height: 35
-			Text: Retry
 		Button@ABORT_BUTTON:
 			Key: escape
-			X: 230
 			Y: 84
 			Width: 140
 			Height: 35
 			Text: Abort
+		Button@RETRY_BUTTON:
+			Key: return
+			X: 230
+			Y: 84
+			Width: 140
+			Height: 35
+			Text: Retry


### PR DESCRIPTION
"forward" acting buttons go on the right.
"back" acting buttons go on the left.
