### PR TITLE
Fix TD aircraft being visible through fog.

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -398,6 +398,7 @@
 		UseLocation: yes
 	HiddenUnderFog:
 		Type: CenterPosition
+		AlwaysVisibleStances: None
 	ActorLostNotification:
 	AttackMove:
 	WithShadow:


### PR DESCRIPTION
The fog represents the lack of visibility, so seeing things move under it does not make sense (this is the same logic we use for the Carryalls in D2K).  This also looks glitchy, as the contrail rendering is disabled under the fog.
