### PR TITLE
Enable Chrono Tank at "No Superweapons"

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -656,7 +656,7 @@ CTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 210
-		Prerequisites: atek, pdox, ~vehicles.germany, ~techlevel.unrestricted
+		Prerequisites: atek, ~vehicles.germany, ~techlevel.high
 	Valued:
 		Cost: 1350
 	Tooltip:


### PR DESCRIPTION
Enables Germany's Chrono Tank at "No Superweapons" by removing Chronosphere from prerequisites and lowering tech-level requirement to 'high'.
