### PR TITLE
Use player name as default for global chat

### DIFF
--- a/OpenRA.Game/GlobalChat.cs
+++ b/OpenRA.Game/GlobalChat.cs
@@ -105,6 +105,8 @@ namespace OpenRA.Chat
 			client.OnDevoice += (_, e) => SetUserVoiced(e.Whom, false);
 			client.OnPart += OnPart;
 			client.OnQuit += OnQuit;
+
+			TrySetNickname(Game.Settings.Player.Name);
 		}
 
 		void SetUserOp(string whom, bool isOp)


### PR DESCRIPTION
Sets the nickname for the global chat to the same as the player name by default. Closes #9728.
