### PR TITLE
Make FlipX/FlipY flip respective embedded offsets as well

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Graphics
 					{
 						var sd = sub.Value.ToDictionary();
 
-						// Allow per-sprite offset, start, and length
+						// Allow per-sprite offset, flipping, start, and length
 						var subStart = LoadField(sd, "Start", 0);
 						var subOffset = LoadField(sd, "Offset", float2.Zero);
 						var subFlipX = LoadField(sd, "FlipX", false);
@@ -158,7 +158,10 @@ namespace OpenRA.Mods.Common.Graphics
 
 						var subSrc = GetSpriteSrc(modData, tileSet, sequence, animation, sub.Key, sd);
 						var subSprites = cache[subSrc].Select(
-							s => new Sprite(s.Sheet, FlipRectangle(s.Bounds, subFlipX, subFlipY), s.Offset + subOffset + offset, s.Channel, blendMode));
+							s => new Sprite(s.Sheet,
+								FlipRectangle(s.Bounds, subFlipX, subFlipY),
+								new float2(subFlipX ? -s.Offset.X : s.Offset.X, subFlipY ? -s.Offset.Y : s.Offset.Y) + subOffset + offset,
+								s.Channel, blendMode));
 
 						var subLength = 0;
 						MiniYaml subLengthYaml;
@@ -178,7 +181,10 @@ namespace OpenRA.Mods.Common.Graphics
 					// Different sequences may apply different offsets to the same frame
 					var src = GetSpriteSrc(modData, tileSet, sequence, animation, info.Value, d);
 					sprites = cache[src].Select(
-						s => new Sprite(s.Sheet, FlipRectangle(s.Bounds, flipX, flipY), s.Offset + offset, s.Channel, blendMode)).ToArray();
+						s => new Sprite(s.Sheet,
+							FlipRectangle(s.Bounds, flipX, flipY),
+							new float2(flipX ? -s.Offset.X : s.Offset.X, flipY ? -s.Offset.Y : s.Offset.Y) + offset,
+							s.Channel, blendMode)).ToArray();
 				}
 
 				MiniYaml length;


### PR DESCRIPTION
When a sequence is flipped along an axis, flip embedded offsets for that axis as well.
