### PR TITLE
Don't grant upgrades to newly built units while disabled

### DIFF
--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -107,6 +107,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (produced.OccupiesSpace == null)
 				return;
 
+			// We don't grant upgrades when disabled
+			if (self.IsDisabled())
+				return;
+
 			// Work around for actors produced within the region not triggering until the second tick
 			if ((produced.CenterPosition - self.CenterPosition).HorizontalLengthSquared <= info.Range.LengthSquared)
 			{


### PR DESCRIPTION
before:
https://streamable.com/2rl4
after:
https://streamable.com/ygw5

(you need sound to hear it)

What happened is that UpgradeActorsNear would grant upgrades on newly built actors and revoke it in the next tick when disabled.
