### PR TITLE
Make UpgradeActorsNear vertical range customizable

### DIFF
--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -41,6 +41,8 @@ namespace OpenRA
 		public int Length { get { return (int)Exts.ISqrt(LengthSquared); } }
 		public long HorizontalLengthSquared { get { return (long)X * X + (long)Y * Y; } }
 		public int HorizontalLength { get { return (int)Exts.ISqrt(HorizontalLengthSquared); } }
+		public long VerticalLengthSquared { get { return (long)Z * Z; } }
+		public int VerticalLength { get { return (int)Exts.ISqrt(VerticalLengthSquared); } }
 
 		public WVec Rotate(WRot rot)
 		{

--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -373,7 +373,7 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 			};
 
-			triggerId = Context.World.ActorMap.AddProximityTrigger(pos, range, invokeEntry, null);
+			triggerId = Context.World.ActorMap.AddProximityTrigger(pos, range, WDist.Zero, invokeEntry, null);
 
 			return triggerId;
 		}
@@ -400,7 +400,7 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 			};
 
-			triggerId = Context.World.ActorMap.AddProximityTrigger(pos, range, null, invokeExit);
+			triggerId = Context.World.ActorMap.AddProximityTrigger(pos, range, WDist.Zero, null, invokeExit);
 
 			return triggerId;
 		}

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// TODO: Eventually support CellTriggers as well
-			proximityTrigger = self.World.ActorMap.AddProximityTrigger(self.CenterPosition, Info.Range, ActorEntered, ActorLeft);
+			proximityTrigger = self.World.ActorMap.AddProximityTrigger(self.CenterPosition, Info.Range, WDist.Zero, ActorEntered, ActorLeft);
 		}
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsInWorld || self.CenterPosition == prevPosition)
 				return;
 
-			self.World.ActorMap.UpdateProximityTrigger(proximityTrigger, self.CenterPosition, Info.Range);
+			self.World.ActorMap.UpdateProximityTrigger(proximityTrigger, self.CenterPosition, Info.Range, WDist.Zero);
 			prevPosition = self.CenterPosition;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void AddedToWorld(Actor self)
 		{
 			cachedPosition = self.CenterPosition;
-			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, ActorEntered, ActorExited);
+			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, WDist.Zero, ActorEntered, ActorExited);
 		}
 
 		public void RemovedFromWorld(Actor self)
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				cachedPosition = self.CenterPosition;
 				cachedRange = desiredRange;
-				self.World.ActorMap.UpdateProximityTrigger(proximityTrigger, cachedPosition, cachedRange);
+				self.World.ActorMap.UpdateProximityTrigger(proximityTrigger, cachedPosition, cachedRange, WDist.Zero);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -23,6 +23,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The range to search for actors to upgrade.")]
 		public readonly WDist Range = WDist.FromCells(3);
 
+		[Desc("The maximum vertical range above terrain to search for actors to upgrade.",
+		"Ignored if 0 (actors are upgraded regardless of vertical distance).")]
+		public readonly WDist MaximumVerticalOffset = WDist.Zero;
+
 		[Desc("What diplomatic stances are affected.")]
 		public readonly Stance ValidStances = Stance.Ally;
 
@@ -44,6 +48,8 @@ namespace OpenRA.Mods.Common.Traits
 		WPos cachedPosition;
 		WDist cachedRange;
 		WDist desiredRange;
+		WDist cachedVRange;
+		WDist desiredVRange;
 
 		bool cachedDisabled = true;
 
@@ -52,12 +58,13 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			this.self = self;
 			cachedRange = info.Range;
+			cachedVRange = info.MaximumVerticalOffset;
 		}
 
 		public void AddedToWorld(Actor self)
 		{
 			cachedPosition = self.CenterPosition;
-			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, WDist.Zero, ActorEntered, ActorExited);
+			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, cachedVRange, ActorEntered, ActorExited);
 		}
 
 		public void RemovedFromWorld(Actor self)
@@ -73,14 +80,16 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				Game.Sound.Play(disabled ? info.DisableSound : info.EnableSound, self.CenterPosition);
 				desiredRange = disabled ? WDist.Zero : info.Range;
+				desiredVRange = disabled ? WDist.Zero : info.MaximumVerticalOffset;
 				cachedDisabled = disabled;
 			}
 
-			if (self.CenterPosition != cachedPosition || desiredRange != cachedRange)
+			if (self.CenterPosition != cachedPosition || desiredRange != cachedRange || desiredVRange != cachedVRange)
 			{
 				cachedPosition = self.CenterPosition;
 				cachedRange = desiredRange;
-				self.World.ActorMap.UpdateProximityTrigger(proximityTrigger, cachedPosition, cachedRange, WDist.Zero);
+				cachedVRange = desiredVRange;
+				self.World.ActorMap.UpdateProximityTrigger(proximityTrigger, cachedPosition, cachedRange, cachedVRange);
 			}
 		}
 


### PR DESCRIPTION
Includes plumbing to do the same for other ProximityTrigger-based features, but the focus of this PR is UpgradeActorsNear.

Makes it more flexible and a requirement to implement #10590 properly (otherwise aircraft would start reloading while still in the air).
