### PR TITLE
Improve Harvester-related code

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -702,9 +702,7 @@ namespace OpenRA.Mods.Common.AI
 				{
 					var act = harvester.GetCurrentActivity();
 
-					// A Wait activity is technically idle:
-					if ((act.GetType() != typeof(Wait)) &&
-						(act.NextActivity == null || act.NextActivity.GetType() != typeof(FindResources)))
+					if (act.NextActivity == null || act.NextActivity.GetType() != typeof(FindResources))
 						continue;
 				}
 

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -67,17 +67,10 @@ namespace OpenRA.Mods.Common.Activities
 				if (!harv.IsEmpty)
 					return deliver;
 
-				var cachedPosition = self.Location;
-				harv.UnblockRefinery(self);
-
-				// Only do this if UnblockRefinery did nothing.
-				if (self.Location == cachedPosition)
-				{
-					var unblockCell = harv.LastHarvestedCell ?? (self.Location + harvInfo.UnblockCell);
-					var moveTo = mobile.NearestMoveableCell(unblockCell, 2, 5);
-					self.QueueActivity(mobile.MoveTo(moveTo, 1));
-					self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
-				}
+				var unblockCell = harv.LastHarvestedCell ?? (self.Location + harvInfo.UnblockCell);
+				var moveTo = mobile.NearestMoveableCell(unblockCell, 2, 5);
+				self.QueueActivity(mobile.MoveTo(moveTo, 1));
+				self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
 
 				var randFrames = self.World.SharedRandom.Next(100, 175);
 				return ActivityUtils.SequenceActivities(NextActivity, new Wait(randFrames), this);

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -57,6 +57,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Search radius (in cells) from the last harvest order location to find more resources.")]
 		public readonly int SearchFromOrderRadius = 12;
 
+		[Desc("Maximum duration of being idle before queueing a Wait activity.")]
+		public readonly int MaxIdleDuration = 25;
+
+		[Desc("Duration to wait before becoming idle again.")]
+		public readonly int WaitDuration = 25;
+
 		[VoiceReference] public readonly string HarvestVoice = "Action";
 		[VoiceReference] public readonly string DeliverVoice = "Action";
 
@@ -239,6 +245,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
+		int idleDuration;
 		public void TickIdle(Actor self)
 		{
 			// Should we be intelligent while idle?
@@ -252,9 +259,16 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			UnblockRefinery(self);
+			idleDuration += 1;
 
-			// Wait for a bit before becoming idle again:
-			self.QueueActivity(new Wait(10));
+			// Wait a bit before queueing Wait activity
+			if (idleDuration > Info.MaxIdleDuration)
+			{
+				idleDuration = 0;
+
+				// Wait for a bit before becoming idle again:
+				self.QueueActivity(new Wait(Info.WaitDuration));
+			}
 		}
 
 		// Returns true when unloading is complete

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -215,17 +215,6 @@ namespace OpenRA.Mods.Common.Traits
 					var moveTo = mobile.NearestMoveableCell(unblockCell, 1, 5);
 					self.QueueActivity(mobile.MoveTo(moveTo, 1));
 					self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Gray, false);
-
-					var territory = self.World.WorldActor.TraitOrDefault<ResourceClaimLayer>();
-					if (territory != null)
-						territory.ClaimResource(self, moveTo);
-
-					var notify = self.TraitsImplementing<INotifyHarvesterAction>();
-					var next = new FindResources(self);
-					foreach (var n in notify)
-						n.MovingToResources(self, moveTo, next);
-
-					self.QueueActivity(next);
 				}
 			}
 		}


### PR DESCRIPTION
This removes some duplication and should improve AI performance by reducing frequency of the more expensive AI resource search.

Issues fixed by this PR:
- `Harvester.UnblockRefinery` was not just unblocking, but also performing a resource claim and queueing a `FindResources` activity (which would then perform another resource claim). 
- The `ContinueHarvesting` method would queue another `FindResources` after `UnblockRefinery`, resulting in potentially queueing `FindResources` twice.
- In `FindResources`, if no harvestable position was found, it would perform `harv.UnblockRefinery` and its own unblock at the same tick due to a bogus if check.
- the AI was making the assumption that a `Wait`ing harvester is idle. That is plain wrong, as `Wait` activities are intentionally queued by all harvester-related activities. This resulted in far too many expensive AI resource searches.
