### PR TITLE
Refactor naming of Missile's speed-related properties

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -3451,6 +3451,25 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Rename some speed-related Missile properties
+				if (engineVersion < 20160205)
+				{
+					var mod = Game.ModData.Manifest.Mod.Id;
+					if (mod == "ts")
+					{
+						if (node.Key == "Projectile" && node.Value.Value == "Missile")
+						{
+							node.Value.Nodes.Add(new MiniYamlNode("MinimumLaunchSpeed", "75"));
+							node.Value.Nodes.Add(new MiniYamlNode("Speed", "384"));
+						}
+					}
+					else
+					{
+						if (node.Key == "MaximumLaunchSpeed" && parent.Value.Value == "Missile")
+							node.Key = "Speed";
+					}
+				}
+
 				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -12,7 +12,7 @@ Rockets:
 		HorizontalRateOfTurn: 15
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 298
+		Speed: 298
 		RangeLimit: 20
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -46,7 +46,7 @@ BikeRockets:
 		HorizontalRateOfTurn: 10
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 213
+		Speed: 213
 		RangeLimit: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -81,7 +81,7 @@ OrcaAGMissiles:
 		HorizontalRateOfTurn: 20
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 256
+		Speed: 256
 		RangeLimit: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -115,7 +115,7 @@ OrcaAAMissiles:
 		HorizontalRateOfTurn: 20
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 298
+		Speed: 298
 		RangeLimit: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -146,7 +146,7 @@ MammothMissiles:
 		HorizontalRateOfTurn: 20
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 341
+		Speed: 341
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
@@ -219,7 +219,7 @@ MammothMissiles:
 		HorizontalRateOfTurn: 10
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 213
+		Speed: 213
 		RangeLimit: 40
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -251,7 +251,7 @@ BoatMissile:
 		HorizontalRateOfTurn: 10
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 170
+		Speed: 170
 		RangeLimit: 60
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
@@ -286,7 +286,7 @@ TowerMissle:
 		HorizontalRateOfTurn: 20
 		TrailImage: smokey
 		ContrailLength: 8
-		MaximumLaunchSpeed: 298
+		Speed: 298
 		RangeLimit: 40
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
@@ -314,7 +314,7 @@ SAMMissile:
 		Blockable: false
 		Image: MISSILE
 		HorizontalRateOfTurn: 20
-		MaximumLaunchSpeed: 426
+		Speed: 426
 		RangeLimit: 35
 		TrailImage: smokey
 		ContrailLength: 8
@@ -375,7 +375,7 @@ Patriot:
 		TrailImage: smokey
 		ContrailLength: 8
 		HorizontalRateOfTurn: 20
-		MaximumLaunchSpeed: 300
+		Speed: 300
 		RangeLimit: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 682

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -3,7 +3,7 @@ Bazooka:
 	Range: 3c0
 	Report: ROCKET1.WAV
 	Projectile: Missile
-		MaximumLaunchSpeed: 281
+		Speed: 281
 		Inaccuracy: 256
 		Image: RPG
 		HorizontalRateOfTurn: 1
@@ -42,7 +42,7 @@ Rocket:
 		TrailImage: bazooka_trail2
 		TrailPalette: effect75alpha
 		TrailInterval: 1
-		MaximumLaunchSpeed: 343
+		Speed: 343
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
@@ -81,7 +81,7 @@ TowerMissile:
 		Image: MISSILE2
 		TrailImage: large_trail
 		TrailInterval: 1
-		MaximumLaunchSpeed: 320
+		Speed: 320
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
@@ -111,7 +111,7 @@ mtank_pri:
 	Report: ROCKET1.WAV
 	ValidTargets: Ground, Air
 	Projectile: Missile
-		MaximumLaunchSpeed: 281
+		Speed: 281
 		RangeLimit: 50
 		HorizontalRateOfTurn: 3
 		Blockable: false
@@ -146,7 +146,7 @@ DeviatorMissile:
 	Range: 5c0
 	Report: MISSLE1.WAV
 	Projectile: Missile
-		MaximumLaunchSpeed: 281
+		Speed: 281
 		RangeLimit: 40
 		HorizontalRateOfTurn: 3
 		Blockable: false

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -841,8 +841,8 @@ Weapons:
 		Range: 10c0
 		ValidTargets: Ground, Air
 		Projectile: Missile
-			MaximumLaunchSpeed: 128
 			Blockable: false
+			Speed: 128
 			TrailImage: smokey
 			ContrailLength: 150
 			Inaccuracy: 0c853

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -7,7 +7,7 @@ Maverick:
 	BurstDelay: 7
 	ValidTargets: Ground, Water
 	Projectile: Missile
-		MaximumLaunchSpeed: 256
+		Speed: 256
 		Arm: 2
 		Blockable: false
 		ContrailLength: 10
@@ -43,7 +43,7 @@ Dragon:
 	Report: missile6.aud
 	ValidTargets: Ground, Water
 	Projectile: Missile
-		MaximumLaunchSpeed: 213
+		Speed: 213
 		Arm: 2
 		Blockable: false
 		TrailImage: smokey
@@ -82,7 +82,7 @@ HellfireAG:
 	BurstDelay: 10
 	ValidTargets: Ground, Water
 	Projectile: Missile
-		MaximumLaunchSpeed: 256
+		Speed: 256
 		Arm: 2
 		Blockable: false
 		ContrailLength: 10
@@ -120,7 +120,7 @@ HellfireAA:
 	BurstDelay: 10
 	ValidTargets: Air
 	Projectile: Missile
-		MaximumLaunchSpeed: 384
+		Speed: 384
 		Arm: 2
 		Blockable: false
 		ContrailLength: 10
@@ -156,7 +156,7 @@ MammothTusk:
 	Burst: 2
 	ValidTargets: Air, Infantry
 	Projectile: Missile
-		MaximumLaunchSpeed: 341
+		Speed: 341
 		Arm: 2
 		Blockable: false
 		ContrailLength: 10
@@ -201,7 +201,7 @@ Nike:
 		Image: MISSILE
 		HorizontalRateOfTurn: 25
 		RangeLimit: 50
-		MaximumLaunchSpeed: 341
+		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
@@ -229,7 +229,7 @@ RedEye:
 		Image: MISSILE
 		HorizontalRateOfTurn: 20
 		RangeLimit: 30
-		MaximumLaunchSpeed: 298
+		Speed: 298
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
@@ -293,7 +293,7 @@ Stinger:
 		Image: DRAGON
 		HorizontalRateOfTurn: 20
 		RangeLimit: 50
-		MaximumLaunchSpeed: 170
+		Speed: 170
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
@@ -333,7 +333,7 @@ StingerAA:
 		Image: DRAGON
 		HorizontalRateOfTurn: 20
 		RangeLimit: 50
-		MaximumLaunchSpeed: 255
+		Speed: 255
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
@@ -369,7 +369,7 @@ TorpTube:
 	Projectile: Missile
 		Image: torpedo
 		Arm: 3
-		MaximumLaunchSpeed: 85
+		Speed: 85
 		TrailImage: bubbles
 		HorizontalRateOfTurn: 1
 		RangeLimit: 160
@@ -441,7 +441,7 @@ APTusk:
 	Report: missile6.aud
 	ValidTargets: Ground, Water
 	Projectile: Missile
-		MaximumLaunchSpeed: 298
+		Speed: 298
 		Arm: 2
 		Blockable: false
 		TrailImage: smokey

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -111,6 +111,8 @@ CyCannon:
 		HorizontalRateOfTurn: 2
 		Shadow: true
 		Image: TORPEDO
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 43
 		Damage: 120

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -14,6 +14,8 @@ Bazooka:
 		HorizontalRateOfTurn: 8
 		RangeLimit: 50
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
@@ -58,6 +60,8 @@ HoverMissile:
 		HorizontalRateOfTurn: 8
 		RangeLimit: 35
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
@@ -101,6 +105,8 @@ MammothTusk:
 		MaximumLaunchSpeed: 213
 		RangeLimit: 50
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
 		Damage: 40
@@ -140,6 +146,8 @@ BikeMissile:
 		MaximumLaunchSpeed: 213
 		RangeLimit: 50
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40
@@ -180,6 +188,8 @@ Dragon:
 		HorizontalRateOfTurn: 8
 		RangeLimit: 50
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
@@ -224,6 +234,8 @@ Hellfire:
 		HorizontalRateOfTurn: 8
 		RangeLimit: 35
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 85
 		Damage: 30
@@ -267,6 +279,8 @@ RedEye2:
 		HorizontalRateOfTurn: 5
 		RangeLimit: 100
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 33

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -13,6 +13,8 @@ MultiCluster:
 		HorizontalRateOfTurn: 8
 		RangeLimit: 35
 		Palette: ra
+		MinimumLaunchSpeed: 75
+		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 65


### PR DESCRIPTION
`MaximumSpeed` renamed to just `Speed`.

`MinimumLaunchSpeed` and `MaximumLaunchSpeed` now default to `Speed`.

Note: To solve #10129, additional yaml adjustments might be necessary.
