### PR TITLE
Wrap OpenRA.exe arguments in quotes

### DIFF
--- a/OpenRA.GameMonitor/GameMonitor.cs
+++ b/OpenRA.GameMonitor/GameMonitor.cs
@@ -12,6 +12,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Media;
 using System.Reflection;
 using System.Windows.Forms;
@@ -30,7 +31,7 @@ namespace OpenRA
 
 			Directory.SetCurrentDirectory(executableDirectory);
 
-			var psi = new ProcessStartInfo(processName, string.Join(" ", args));
+			var psi = new ProcessStartInfo(processName, string.Join(" ", args.Select(arg => "\"" + arg + "\"")));
 
 			try
 			{

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -59,7 +59,7 @@ Section "-Reg" Reg
 	; Replay file association
 	WriteRegStr HKLM "Software\Classes\.orarep" "" "OpenRA_replay"
 	WriteRegStr HKLM "Software\Classes\OpenRA_replay\DefaultIcon" "" "$INSTDIR\OpenRA.ico,0"
-	WriteRegStr HKLM "Software\Classes\OpenRA_replay\Shell\Open\Command" "" "$INSTDIR\OpenRA.exe Launch.Replay=%1"
+	WriteRegStr HKLM "Software\Classes\OpenRA_replay\Shell\Open\Command" "" "$INSTDIR\OpenRA.exe Launch.Replay=$\"%1$\""
 	
 	; OpenRA URL Scheme
 	WriteRegStr HKLM "Software\Classes\openra" "" "URL:OpenRA scheme"


### PR DESCRIPTION
On Windows, if the path to the replay contains spaces, it wouldn't be parsed correctly and would crash the game.

Fixes #10572
