### PR TITLE
Remove obsolete and performance costly RevealsShroud definitions

### DIFF
--- a/mods/cnc/maps/the-hot-box/map.yaml
+++ b/mods/cnc/maps/the-hot-box/map.yaml
@@ -238,8 +238,6 @@ Rules:
 	APC:
 		Health:
 			HP: 1000
-		RevealsShroud:
-			Range: 40c0
 		MustBeDestroyed:
 			RequiredForShortGame: true
 		-AttackMove:

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/map.yaml
@@ -330,8 +330,6 @@ Rules:
 	APC:
 		Health:
 			HP: 1000
-		RevealsShroud:
-			Range: 40c0
 		MustBeDestroyed:
 			RequiredForShortGame: true
 		-AttackMove:

--- a/mods/ra/maps/drop-zone/map.yaml
+++ b/mods/ra/maps/drop-zone/map.yaml
@@ -225,8 +225,6 @@ Rules:
 	APC:
 		Health:
 			HP: 1000
-		RevealsShroud:
-			Range: 40c0
 		MustBeDestroyed:
 			RequiredForShortGame: true
 		-AttackMove:


### PR DESCRIPTION
from the APC on the dropzone maps. It caused a lot of lag when moving the apc (enable the perf graph, it's quite visible there).
