### PR TITLE
Fix Mobile using legacy CenterPosition.Z check

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -587,7 +587,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void EnteringCell(Actor self)
 		{
 			// Only make actor crush if it is on the ground
-			if (self.CenterPosition.Z != 0)
+			if (!self.IsAtGroundLevel())
 				return;
 
 			var crushables = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self)


### PR DESCRIPTION
This check would fail if actor is on elevated terrain.
