### PR TITLE
Rewrite yaml merger

### DIFF
--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -33,12 +33,7 @@ namespace OpenRA.Graphics
 			cachedSheets = new Dictionary<string, Sheet>();
 			cachedSprites = new Dictionary<string, Dictionary<string, Sprite>>();
 
-			var partial = chromeFiles
-				.Select(s => MiniYaml.FromFile(s))
-				.Aggregate(MiniYaml.MergePartial);
-
-			var chrome = MiniYaml.ApplyRemovals(partial);
-
+			var chrome = MiniYaml.Merge(chromeFiles.Select(MiniYaml.FromFile));
 			foreach (var c in chrome)
 				LoadCollection(c.Key, c.Value);
 		}

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -21,12 +21,8 @@ namespace OpenRA.Graphics
 
 		public CursorProvider(ModData modData)
 		{
-			var sequenceFiles = modData.Manifest.Cursors;
-			var partial = sequenceFiles
-				.Select(s => MiniYaml.FromFile(s))
-				.Aggregate(MiniYaml.MergePartial);
+			var sequences = new MiniYaml(null, MiniYaml.Merge(modData.Manifest.Cursors.Select(MiniYaml.FromFile)));
 
-			var sequences = new MiniYaml(null, MiniYaml.ApplyRemovals(partial));
 			var shadowIndex = new int[] { };
 
 			var nodesDict = sequences.ToDictionary();

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -123,13 +123,7 @@ namespace OpenRA.Graphics
 
 		Sequences Load(List<MiniYamlNode> sequenceNodes)
 		{
-			var sequenceFiles = modData.Manifest.Sequences;
-
-			var partial = sequenceFiles
-				.Select(s => MiniYaml.FromFile(s))
-				.Aggregate(sequenceNodes, MiniYaml.MergePartial);
-
-			var nodes = MiniYaml.ApplyRemovals(partial);
+			var nodes = MiniYaml.Merge(modData.Manifest.Sequences.Select(MiniYaml.FromFile).Append(sequenceNodes));
 			var items = new Dictionary<string, UnitSequences>();
 			foreach (var n in nodes)
 			{

--- a/OpenRA.Game/Graphics/VoxelProvider.cs
+++ b/OpenRA.Game/Graphics/VoxelProvider.cs
@@ -23,11 +23,7 @@ namespace OpenRA.Graphics
 		{
 			units = new Dictionary<string, Dictionary<string, Voxel>>();
 
-			var partial = voxelFiles
-				.Select(s => MiniYaml.FromFile(s))
-				.Aggregate(voxelNodes, MiniYaml.MergePartial);
-
-			var sequences = MiniYaml.ApplyRemovals(partial);
+			var sequences = MiniYaml.Merge(voxelFiles.Select(MiniYaml.FromFile));
 			foreach (var s in sequences)
 				LoadVoxelsForUnit(s.Key, s.Value);
 

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -133,10 +133,9 @@ namespace OpenRA
 				return;
 			}
 
-			var partial = Manifest.Translations.Select(MiniYaml.FromFile).Aggregate(MiniYaml.MergePartial);
-			Languages = partial.Select(t => t.Key).ToArray();
+			var yaml = MiniYaml.Merge(Manifest.Translations.Select(MiniYaml.FromFile).Append(map.TranslationDefinitions));
+			Languages = yaml.Select(t => t.Key).ToArray();
 
-			var yaml = MiniYaml.Merge(map.TranslationDefinitions, partial);
 			foreach (var y in yaml)
 			{
 				if (y.Key == Game.Settings.Graphics.Language)

--- a/OpenRA.Game/Widgets/ChromeMetrics.cs
+++ b/OpenRA.Game/Widgets/ChromeMetrics.cs
@@ -20,11 +20,8 @@ namespace OpenRA.Widgets
 		public static void Initialize(IEnumerable<string> yaml)
 		{
 			data = new Dictionary<string, string>();
-			var partial = yaml
-				.Select(y => MiniYaml.FromFile(y))
-				.Aggregate(MiniYaml.MergePartial);
 
-			var metrics = MiniYaml.ApplyRemovals(partial);
+			var metrics = MiniYaml.Merge(yaml.Select(MiniYaml.FromFile));
 			foreach (var m in metrics)
 				foreach (var n in m.Value.Nodes)
 					data[n.Key] = n.Value.Value;

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -36,19 +36,11 @@ namespace OpenRA.Mods.Common.Graphics
 			if (nodes.TryGetValue("Defaults", out defaults))
 			{
 				nodes.Remove("Defaults");
-				nodes = nodes.ToDictionary(kv => kv.Key, kv => MiniYaml.Merge(kv.Value, defaults));
-
-				// Merge 'Defaults' animation image value. An example follows.
-				//
-				// - Before -
-				// stand:
-				// 	Facings: 8
-				//
-				// - After -
-				// stand: e1
-				// 	Facings: 8
 				foreach (var n in nodes)
+				{
+					n.Value.Nodes = MiniYaml.Merge(new[] { defaults.Nodes, n.Value.Nodes });
 					n.Value.Value = n.Value.Value ?? defaults.Value;
+				}
 			}
 
 			foreach (var kvp in nodes)

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -31,10 +31,7 @@ namespace OpenRA.Mods.Common.Lint
 			this.emitError = emitError;
 
 			var sequenceSource = map != null ? map.SequenceDefinitions : new List<MiniYamlNode>();
-			var partial = Game.ModData.Manifest.Sequences
-				.Select(MiniYaml.FromFile)
-				.Aggregate(MiniYaml.MergePartial);
-			sequenceDefinitions = MiniYaml.Merge(sequenceSource, partial);
+			sequenceDefinitions = MiniYaml.Merge(Game.ModData.Manifest.Sequences.Select(MiniYaml.FromFile).Append(sequenceSource));
 
 			var rules = map == null ? Game.ModData.DefaultRules : map.Rules;
 			var factions = rules.Actors["world"].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();

--- a/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
@@ -36,13 +36,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var ts = new TileSet(Game.ModData, t);
 				Console.WriteLine("Tileset: " + ts.Name);
 				var sc = new SpriteCache(modData.SpriteLoaders, new SheetBuilder(SheetType.Indexed));
-				var sequenceFiles = modData.Manifest.Sequences;
-
-				var partial = sequenceFiles
-					.Select(s => MiniYaml.FromFile(s))
-					.Aggregate(MiniYaml.MergePartial);
-
-				var nodes = MiniYaml.ApplyRemovals(partial);
+				var nodes = MiniYaml.Merge(modData.Manifest.Sequences.Select(MiniYaml.FromFile));
 				foreach (var n in nodes)
 					Game.ModData.SpriteSequenceLoader.ParseSequences(Game.ModData, ts, sc, n);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -49,6 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public MissionBrowserLogic(Widget widget, World world, Action onStart, Action onExit)
 		{
+			var modData = Game.ModData;
 			this.onStart = onStart;
 
 			missionList = widget.Get<ScrollPanelWidget>("MISSION_LIST");
@@ -92,18 +93,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			missionList.RemoveChildren();
 
 			// Add a group for each campaign
-			if (Game.ModData.Manifest.Missions.Any())
+			if (modData.Manifest.Missions.Any())
 			{
-				var partial = Game.ModData.Manifest.Missions
-					.Select(MiniYaml.FromFile)
-					.Aggregate(MiniYaml.MergePartial);
-
-				var yaml = MiniYaml.ApplyRemovals(partial);
+				var yaml = MiniYaml.Merge(modData.Manifest.Missions.Select(MiniYaml.FromFile));
 				foreach (var kv in yaml)
 				{
 					var missionMapPaths = kv.Value.Nodes.Select(n => Path.GetFullPath(n.Key)).ToList();
 
-					var maps = Game.ModData.MapCache
+					var maps = modData.MapCache
 						.Where(p => p.Status == MapStatus.Available && missionMapPaths.Contains(Path.GetFullPath(p.Map.Path)))
 						.Select(p => p.Map)
 						.OrderBy(m => missionMapPaths.IndexOf(Path.GetFullPath(m.Path)));
@@ -114,7 +111,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			// Add an additional group for loose missions
-			var looseMissions = Game.ModData.MapCache
+			var looseMissions = modData.MapCache
 				.Where(p => p.Status == MapStatus.Available && p.Map.Visibility.HasFlag(MapVisibility.MissionSelector) && !allMaps.Contains(p.Map))
 				.Select(p => p.Map);
 

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -31,6 +31,8 @@ namespace OpenRA.Test
 	class MockB2Info : MockTraitInfo { }
 	class MockC2Info : MockTraitInfo { }
 
+	class MockStringInfo : MockTraitInfo { public string AString = null; }
+
 	[TestFixture]
 	public class ActorInfoTest
 	{
@@ -140,6 +142,29 @@ Actor:
 
 			var actorInfo = CreateActorInfoFromYaml("Actor", null, baseYaml, overrideYaml);
 			Assert.IsFalse(actorInfo.HasTraitInfo<MockA2Info>(), "Actor should not have the MockA2 trait, but does.");
+		}
+
+		[TestCase(TestName = "Trait can be removed and later overridden")]
+		public void TraitCanBeRemovedAndLaterOverridden()
+		{
+			var baseYaml = @"
+^BaseA:
+    MockString:
+        AString: ""Base""
+Actor:
+    Inherits: ^BaseA
+    -MockString:
+";
+			var overrideYaml = @"
+Actor:
+    MockString:
+        AString: ""Override""
+";
+
+			var actorInfo = CreateActorInfoFromYaml("Actor", null, baseYaml, overrideYaml);
+			Assert.IsTrue(actorInfo.HasTraitInfo<MockStringInfo>(), "Actor should have the MockStringInfo trait, but does not.");
+			Assert.IsTrue(actorInfo.TraitInfo<MockStringInfo>().AString == "\"Override\"",
+				"MockStringInfo trait has not been set with the correct override value for AString.");
 		}
 
 		// This needs to match the logic used in RulesetCache.LoadYamlRules

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -97,87 +97,19 @@ namespace OpenRA.Test
 			}
 		}
 
-		[TestCase(TestName = "Trait inheritance and removal can be composed")]
-		public void TraitInheritanceAndRemovalCanBeComposed()
-		{
-			var baseYaml = @"
-^BaseA:
-	MockA2:
-^BaseB:
-	Inherits@a: ^BaseA
-	MockB2:
-";
-			var extendedYaml = @"
-Actor:
-	Inherits@b: ^BaseB
-	-MockA2:
-";
-			var mapYaml = @"
-^BaseC:
-	MockC2:
-Actor:
-	Inherits@c: ^BaseC
-";
-
-			var actorInfo = CreateActorInfoFromYaml("Actor", mapYaml, baseYaml, extendedYaml);
-			Assert.IsFalse(actorInfo.HasTraitInfo<MockA2Info>(), "Actor should not have the MockA2 trait, but does.");
-			Assert.IsTrue(actorInfo.HasTraitInfo<MockB2Info>(), "Actor should have the MockB2 trait, but does not.");
-			Assert.IsTrue(actorInfo.HasTraitInfo<MockC2Info>(), "Actor should have the MockC2 trait, but does not.");
-		}
-
-		[TestCase(TestName = "Trait can be removed after multiple inheritance")]
-		public void TraitCanBeRemovedAfterMultipleInheritance()
-		{
-			var baseYaml = @"
-^BaseA:
-	MockA2:
-Actor:
-	Inherits: ^BaseA
-	MockA2:
-";
-			var overrideYaml = @"
-Actor:
-	-MockA2
-";
-
-			var actorInfo = CreateActorInfoFromYaml("Actor", null, baseYaml, overrideYaml);
-			Assert.IsFalse(actorInfo.HasTraitInfo<MockA2Info>(), "Actor should not have the MockA2 trait, but does.");
-		}
-
-		[TestCase(TestName = "Trait can be removed and later overridden")]
-		public void TraitCanBeRemovedAndLaterOverridden()
-		{
-			var baseYaml = @"
-^BaseA:
-    MockString:
-        AString: ""Base""
-Actor:
-    Inherits: ^BaseA
-    -MockString:
-";
-			var overrideYaml = @"
-Actor:
-    MockString:
-        AString: ""Override""
-";
-
-			var actorInfo = CreateActorInfoFromYaml("Actor", null, baseYaml, overrideYaml);
-			Assert.IsTrue(actorInfo.HasTraitInfo<MockStringInfo>(), "Actor should have the MockStringInfo trait, but does not.");
-			Assert.IsTrue(actorInfo.TraitInfo<MockStringInfo>().AString == "\"Override\"",
-				"MockStringInfo trait has not been set with the correct override value for AString.");
-		}
-
 		// This needs to match the logic used in RulesetCache.LoadYamlRules
 		ActorInfo CreateActorInfoFromYaml(string name, string mapYaml, params string[] yamls)
 		{
-			var initialNodes = mapYaml == null ? new List<MiniYamlNode>() : MiniYaml.FromString(mapYaml);
-			var yaml = yamls
-				.Select(s => MiniYaml.FromString(s))
-				.Aggregate(initialNodes, MiniYaml.MergePartial);
+			var nodes = mapYaml == null ? new List<MiniYamlNode>() : MiniYaml.FromString(mapYaml);
+			var sources = yamls.ToList();
+			if (mapYaml != null)
+				sources.Add(mapYaml);
+
+			var yaml = MiniYaml.Merge(sources.Select(s => MiniYaml.FromString(s)));
 			var allUnits = yaml.ToDictionary(node => node.Key, node => node.Value);
 			var unit = allUnits[name];
 			var creator = new ObjectCreator(new[] { typeof(ActorInfoTest).Assembly });
-			return new ActorInfo(creator, name, unit, allUnits);
+			return new ActorInfo(creator, name, unit);
 		}
 	}
 }

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -32,37 +32,7 @@ vice:
 	icon: viceicnh
 
 pvice:
-	idle:
-		Length: *
-	muzzle:
-		Combine:
-			chem-n:
-				Length: *
-				Offset: 1,2
-			chem-nw:
-				Length: *
-				Offset: 8,2
-			chem-w:
-				Length: *
-				Offset: 8,-3
-			chem-sw:
-				Length: *
-				Offset: 7,-6
-			chem-s:
-				Length: *
-				Offset: 1,-6
-			chem-se:
-				Length: *
-				Offset: -5,-6
-			chem-e:
-				Length: *
-				Offset: -7,-3
-			chem-ne:
-				Length: *
-				Offset: -3,2
-		Facings: 8
-		Length: 13
-	icon: viceicnh
+	Inherits: vice
 
 e1:
 	stand:

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1710,9 +1710,8 @@ Rules:
 		RenderSprites:
 			Image: E7
 	Colt:
-		-Huntable:
-		AutoTargetIgnore:
 		Inherits: ^Defense
+		AutoTargetIgnore:
 		Valued:
 			Cost: 800
 		Building:
@@ -1736,6 +1735,7 @@ Rules:
 		AttackTurreted:
 		AutoTarget:
 		-Selectable:
+		-Huntable:
 	E1.Autotarget:
 		Inherits: E1
 		Buildable:


### PR DESCRIPTION
Fixes #10207
Fixes #7556
Fixes #8890
Fixes #8086
Fixes #8185

As I explained in #10207 all these bugs exist because the code tried to treat yaml merging and inheritance as separable steps (which is completely bogus). This moves the inheritance logic into the yaml parser and fixes the merge and removal logic to behave in the logical way.
