### PR TITLE
Added option to show team colors on radar map

### DIFF
--- a/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
@@ -85,29 +85,8 @@ namespace OpenRA.Graphics
 
 		Color GetHealthColor(IHealth health)
 		{
-			var player = actor.World.RenderPlayer ?? actor.World.LocalPlayer;
-
-			if (Game.Settings.Game.TeamHealthColors && player != null && !player.Spectating)
-			{
-				var apparentOwner = actor.EffectiveOwner != null && actor.EffectiveOwner.Disguised
-					? actor.EffectiveOwner.Owner
-					: actor.Owner;
-
-				// For friendly spies, treat the unit's owner as the actual owner
-				if (actor.Owner.IsAlliedWith(actor.World.RenderPlayer))
-					apparentOwner = actor.Owner;
-
-				if (apparentOwner == player)
-					return Color.LimeGreen;
-
-				if (apparentOwner.IsAlliedWith(player))
-					return Color.Yellow;
-
-				if (apparentOwner.NonCombatant)
-					return Color.Tan;
-
-				return Color.Red;
-			}
+			if (Game.Settings.Game.UsePlayerStanceColors)
+				return actor.Owner.PlayerStanceColor(actor);
 			else
 				return health.DamageState == DamageState.Critical ? Color.Red :
 					health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -168,7 +168,7 @@ namespace OpenRA
 
 		public bool UseClassicMouseStyle = false;
 		public StatusBarsType StatusBars = StatusBarsType.Standard;
-		public bool TeamHealthColors = false;
+		public bool UsePlayerStanceColors = false;
 		public bool DrawTargetLine = true;
 
 		public bool AllowDownloading = true;
@@ -213,6 +213,7 @@ namespace OpenRA
 
 		public Hotkey CycleStatusBarsKey = new Hotkey(Keycode.COMMA, Modifiers.None);
 		public Hotkey TogglePixelDoubleKey = new Hotkey(Keycode.PERIOD, Modifiers.None);
+		public Hotkey TogglePlayerStanceColorsKey = new Hotkey(Keycode.COMMA, Modifiers.Ctrl);
 
 		public Hotkey DevReloadChromeKey = new Hotkey(Keycode.C, Modifiers.Ctrl | Modifiers.Shift);
 		public Hotkey HideUserInterfaceKey = new Hotkey(Keycode.H, Modifiers.Ctrl | Modifiers.Shift);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Traits
 		bool HasFogVisibility();
 	}
 
-	public interface IRadarColorModifier { Color RadarColorOverride(Actor self); }
+	public interface IRadarColorModifier { Color RadarColorOverride(Actor self, Color color); }
 
 	public interface IOccupySpaceInfo : ITraitInfoInterface
 	{

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -286,6 +286,8 @@ namespace OpenRA.Widgets
 					return TogglePixelDouble();
 				else if (key == Game.Settings.Keys.ToggleMuteKey)
 					return ToggleMute();
+				else if (key == Game.Settings.Keys.TogglePlayerStanceColorsKey)
+					return TogglePlayerStanceColors();
 			}
 
 			return false;
@@ -342,6 +344,7 @@ namespace OpenRA.Widgets
 		{
 			Game.Settings.Graphics.PixelDouble ^= true;
 			worldRenderer.Viewport.Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
+
 			return true;
 		}
 
@@ -359,6 +362,13 @@ namespace OpenRA.Widgets
 				Game.Sound.UnmuteAudio();
 				Game.Debug("Audio unmuted");
 			}
+
+			return true;
+		}
+
+		bool TogglePlayerStanceColors()
+		{
+			Game.Settings.Game.UsePlayerStanceColors ^= true;
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnRadar.cs
@@ -40,7 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self)
 		{
-			var color = modifier != null ? modifier.RadarColorOverride(self) : self.Owner.Color.RGB;
+			var color = Game.Settings.Game.UsePlayerStanceColors ? self.Owner.PlayerStanceColor(self) : self.Owner.Color.RGB;
+			if (modifier != null)
+				color = modifier.RadarColorOverride(self, color);
 
 			if (info.UseLocation)
 				return new[] { Pair.New(self.Location, color) };

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -156,12 +156,12 @@ namespace OpenRA.Mods.Common.Traits
 				&& (self.CenterPosition - a.Actor.CenterPosition).LengthSquared <= a.Trait.Info.Range.LengthSquared);
 		}
 
-		Color IRadarColorModifier.RadarColorOverride(Actor self)
+		Color IRadarColorModifier.RadarColorOverride(Actor self, Color color)
 		{
-			var c = self.Owner.Color.RGB;
 			if (self.Owner == self.World.LocalPlayer && Cloaked)
-				c = Color.FromArgb(128, c);
-			return c;
+				color = Color.FromArgb(128, color);
+
+			return color;
 		}
 
 		void GrantUpgrades(Actor self)

--- a/OpenRA.Mods.Common/Traits/RadarColorFromTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/RadarColorFromTerrain.cs
@@ -29,6 +29,6 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public bool VisibleOnRadar(Actor self) { return true; }
-		public Color RadarColorOverride(Actor self) { return c; }
+		public Color RadarColorOverride(Actor self, Color color) { return c; }
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
 			BindCheckboxPref(panel, "SHOW_SHELLMAP", gs, "ShowShellmap");
 			BindCheckboxPref(panel, "DISPLAY_TARGET_LINES_CHECKBOX", gs, "DrawTargetLine");
-			BindCheckboxPref(panel, "TEAM_HEALTH_COLORS_CHECKBOX", gs, "TeamHealthColors");
+			BindCheckboxPref(panel, "PLAYER_STANCE_COLORS_CHECKBOX", gs, "UsePlayerStanceColors");
 
 			var languageDropDownButton = panel.Get<DropDownButtonWidget>("LANGUAGE_DROPDOWNBUTTON");
 			languageDropDownButton.OnMouseDown = _ => ShowLanguageDropdown(languageDropDownButton);
@@ -436,6 +436,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "CycleStatusBarsKey", "Cycle status bars display" },
 					{ "TogglePixelDoubleKey", "Toggle pixel doubling" },
 					{ "ToggleMuteKey", "Toggle audio mute" },
+					{ "TogglePlayerStanceColorsKey", "Toggle player stance colors" },
 
 					{ "MapScrollUp", "Map scroll up" },
 					{ "MapScrollDown", "Map scroll down" },

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -52,7 +52,14 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var time = WidgetUtils.FormatTime(p.RemainingTime, false, timestep);
 				var text = Format.F(p.Info.Description, time);
-				var color = !p.Ready || Game.LocalTick % 50 < 25 ? p.Instances[0].Self.Owner.Color.RGB : Color.White;
+				var self = p.Instances[0].Self;
+				var playerColor = self.Owner.Color.RGB;
+
+				if (Game.Settings.Game.UsePlayerStanceColors)
+					playerColor = self.Owner.PlayerStanceColor(self);
+
+				var color = !p.Ready || Game.LocalTick % 50 < 25 ? playerColor : Color.White;
+
 				return Pair.New(text, color);
 			}).ToArray();
 		}

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -120,12 +120,12 @@ namespace OpenRA.Mods.RA.Traits
 			return order.OrderString == "Disguise" ? info.Voice : null;
 		}
 
-		public Color RadarColorOverride(Actor self)
+		public Color RadarColorOverride(Actor self, Color color)
 		{
 			if (!Disguised || self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				return self.Owner.Color.RGB;
+				return color;
 
-			return AsPlayer.Color.RGB;
+			return color = Game.Settings.Game.UsePlayerStanceColors ? AsPlayer.PlayerStanceColor(self) : AsPlayer.Color.RGB;
 		}
 
 		public void DisguiseAs(Actor target)

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -145,13 +145,13 @@ Container@SETTINGS_PANEL:
 							Y: 152
 							Height: 25
 							Text: FPS
-						Checkbox@TEAM_HEALTH_COLORS_CHECKBOX:
+						Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
 							X: 310
 							Y: 185
 							Width: 200
 							Height: 20
 							Font: Regular
-							Text: Team Health Colors
+							Text: Player Stance Colors
 						Checkbox@SHOW_SHELLMAP:
 							X: 15
 							Y: 185

--- a/mods/cnc/metrics.yaml
+++ b/mods/cnc/metrics.yaml
@@ -36,3 +36,7 @@ Metrics:
 	IncompatibleGameStartedColor: D2691E
 	GlobalChatTextColor: FFFFFF
 	GlobalChatNotificationColor: D3D3D3
+	PlayerStanceColorSelf: 32CD32
+	PlayerStanceColorAllies: FFFF00
+	PlayerStanceColorEnemies: FF0000
+	PlayerStanceColorNeutrals: D2B48C

--- a/mods/d2k/metrics.yaml
+++ b/mods/d2k/metrics.yaml
@@ -35,3 +35,7 @@ Metrics:
 	IncompatibleGameStartedColor: D2691E
 	GlobalChatTextColor: FFFFFF
 	GlobalChatNotificationColor: D3D3D3
+	PlayerStanceColorSelf: 32CD32
+	PlayerStanceColorAllies: FFFF00
+	PlayerStanceColorEnemies: FF0000
+	PlayerStanceColorNeutrals: D2B48C

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -158,13 +158,13 @@ Background@SETTINGS_PANEL:
 					Y: 157
 					Height: 25
 					Text: FPS
-				Checkbox@TEAM_HEALTH_COLORS_CHECKBOX:
+				Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
 					X: 310
 					Y: 195
 					Width: 200
 					Height: 20
 					Font: Regular
-					Text: Team Health Colors
+					Text: Player Stance Colors
 				Checkbox@SHOW_SHELLMAP:
 					X: 15
 					Y: 195

--- a/mods/ra/metrics.yaml
+++ b/mods/ra/metrics.yaml
@@ -43,3 +43,7 @@ Metrics:
 	IncompatibleGameStartedColor: D2691E
 	GlobalChatTextColor: FFFFFF
 	GlobalChatNotificationColor: D3D3D3
+	PlayerStanceColorSelf: 32CD32
+	PlayerStanceColorAllies: FFFF00
+	PlayerStanceColorEnemies: FF0000
+	PlayerStanceColorNeutrals: D2B48C

--- a/mods/ts/metrics.yaml
+++ b/mods/ts/metrics.yaml
@@ -35,3 +35,7 @@ Metrics:
 	IncompatibleGameStartedColor: D2691E
 	GlobalChatTextColor: FFFFFF
 	GlobalChatNotificationColor: D3D3D3
+	PlayerStanceColorSelf: 32CD32
+	PlayerStanceColorAllies: FFFF00
+	PlayerStanceColorEnemies: FF0000
+	PlayerStanceColorNeutrals: D2B48C


### PR DESCRIPTION
Revived #9801.

Changes compared to #9801:
- Added the requested chrome metrics entries for those colours.
- Fixed spies showing the wrong colour when disguised.
- Removed the distinction between radar map and selection bar colours for neutrals.

Text from original PR:

> Adds an option to display actors on radar in colors denoting their diplomatic stance toward the player. ![team-radar](https://cloud.githubusercontent.com/assets/3636652/10833737/1e8e19ca-7e8c-11e5-92b9-b60cef6d0a86.png)
> 
> This means players who use colors similar to the terrain are on equal terms with players who opt for bright contrasting colours
