### PR TITLE
Moved shared metrics to mods/commons.

### DIFF
--- a/mods/cnc/metrics.yaml
+++ b/mods/cnc/metrics.yaml
@@ -22,21 +22,3 @@ Metrics:
 	TextContrastColor: 000000
 	ColorPickerRemapIndices: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
 	ColorPickerActorType: ^fact.colorpicker
-	SpawnFont: TinyBold
-	SpawnColor: FFFFFF
-	SpawnContrastColor: 000000
-	SpawnLabelOffset: 0,1
-	IncompatibleVersionColor: FF0000
-	IncompatibleGameColor: A9A9A9
-	ProtectedGameColor: FF0000
-	IncompatibleProtectedGameColor: 8B0000
-	WaitingGameColor: 00FF00
-	IncompatibleWaitingGameColor: 32CD32
-	GameStartedColor: FFA500
-	IncompatibleGameStartedColor: D2691E
-	GlobalChatTextColor: FFFFFF
-	GlobalChatNotificationColor: D3D3D3
-	PlayerStanceColorSelf: 32CD32
-	PlayerStanceColorAllies: FFFF00
-	PlayerStanceColorEnemies: FF0000
-	PlayerStanceColorNeutrals: D2B48C

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -173,6 +173,7 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
+	./mods/common/metrics.yaml
 	./mods/cnc/metrics.yaml
 
 Fonts:

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -1,0 +1,19 @@
+Metrics:
+	SpawnFont: TinyBold
+	SpawnColor: FFFFFF
+	SpawnContrastColor: 000000
+	SpawnLabelOffset: 0,1
+	IncompatibleVersionColor: FF0000
+	IncompatibleGameColor: A9A9A9
+	ProtectedGameColor: FF0000
+	IncompatibleProtectedGameColor: 8B0000
+	WaitingGameColor: 00FF00
+	IncompatibleWaitingGameColor: 32CD32
+	GameStartedColor: FFA500
+	IncompatibleGameStartedColor: D2691E
+	GlobalChatTextColor: FFFFFF
+	GlobalChatNotificationColor: D3D3D3
+	PlayerStanceColorSelf: 32CD32
+	PlayerStanceColorAllies: FFFF00
+	PlayerStanceColorEnemies: FF0000
+	PlayerStanceColorNeutrals: D2B48C

--- a/mods/d2k/metrics.yaml
+++ b/mods/d2k/metrics.yaml
@@ -21,21 +21,3 @@ Metrics:
 	TextContrastColor: 000000
 	ColorPickerRemapIndices: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
 	ColorPickerActorType: ^carryall.colorpicker
-	SpawnFont: TinyBold
-	SpawnColor: FFFFFF
-	SpawnContrastColor: 000000
-	SpawnLabelOffset: 0,1
-	IncompatibleVersionColor: FF0000
-	IncompatibleGameColor: A9A9A9
-	ProtectedGameColor: FF0000
-	IncompatibleProtectedGameColor: 8B0000
-	WaitingGameColor: 00FF00
-	IncompatibleWaitingGameColor: 32CD32
-	GameStartedColor: FFA500
-	IncompatibleGameStartedColor: D2691E
-	GlobalChatTextColor: FFFFFF
-	GlobalChatNotificationColor: D3D3D3
-	PlayerStanceColorSelf: 32CD32
-	PlayerStanceColorAllies: FFFF00
-	PlayerStanceColorEnemies: FF0000
-	PlayerStanceColorNeutrals: D2B48C

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -164,6 +164,7 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
+	./mods/common/metrics.yaml
 	d2k:metrics.yaml
 
 Fonts:

--- a/mods/ra/metrics.yaml
+++ b/mods/ra/metrics.yaml
@@ -22,10 +22,6 @@ Metrics:
 	TextContrastColor: 000000
 	ColorPickerRemapIndices: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
 	ColorPickerActorType: ^fact.colorpicker
-	SpawnFont: TinyBold
-	SpawnColor: FFFFFF
-	SpawnContrastColor: 000000
-	SpawnLabelOffset: 0,1
 	FactionSuffix-allies: allies
 	FactionSuffix-england: allies
 	FactionSuffix-france: allies
@@ -34,16 +30,4 @@ Metrics:
 	FactionSuffix-russia: soviet
 	FactionSuffix-ukraine: soviet
 	IncompatibleVersionColor: D3D3D3
-	IncompatibleGameColor: A9A9A9
-	ProtectedGameColor: FF0000
 	IncompatibleProtectedGameColor: B22222
-	WaitingGameColor: 00FF00
-	IncompatibleWaitingGameColor: 32CD32
-	GameStartedColor: FFA500
-	IncompatibleGameStartedColor: D2691E
-	GlobalChatTextColor: FFFFFF
-	GlobalChatNotificationColor: D3D3D3
-	PlayerStanceColorSelf: 32CD32
-	PlayerStanceColorAllies: FFFF00
-	PlayerStanceColorEnemies: FF0000
-	PlayerStanceColorNeutrals: D2B48C

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -176,6 +176,7 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
+	./mods/common/metrics.yaml
 	./mods/ra/metrics.yaml
 
 Fonts:

--- a/mods/ts/metrics.yaml
+++ b/mods/ts/metrics.yaml
@@ -21,21 +21,3 @@ Metrics:
 	TextContrastColor: 000000
 	ColorPickerRemapIndices: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 	ColorPickerActorType: ^mmch.colorpicker
-	SpawnFont: TinyBold
-	SpawnColor: FFFFFF
-	SpawnContrastColor: 000000
-	SpawnLabelOffset: 0,1
-	IncompatibleVersionColor: FF0000
-	IncompatibleGameColor: A9A9A9
-	ProtectedGameColor: FF0000
-	IncompatibleProtectedGameColor: 8B0000
-	WaitingGameColor: 00FF00
-	IncompatibleWaitingGameColor: 32CD32
-	GameStartedColor: FFA500
-	IncompatibleGameStartedColor: D2691E
-	GlobalChatTextColor: FFFFFF
-	GlobalChatNotificationColor: D3D3D3
-	PlayerStanceColorSelf: 32CD32
-	PlayerStanceColorAllies: FFFF00
-	PlayerStanceColorEnemies: FF0000
-	PlayerStanceColorNeutrals: D2B48C

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -221,6 +221,7 @@ LobbyDefaults:
 	Fog: true
 
 ChromeMetrics:
+	./mods/common/metrics.yaml
 	./mods/ts/metrics.yaml
 
 Fonts:


### PR DESCRIPTION
Avoids redundancy and bit rot in mods which are not maintained in this repository as missing metrics definitions always result in crashes in the startup sequence. https://github.com/OpenRA/ra2/issues/96
