### PR TITLE
Add 'bool instantiateLogicObjects' to widget loading methods

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -56,18 +56,18 @@ namespace OpenRA.Widgets
 			return WindowList.Count > 0 ? WindowList.Peek() : null;
 		}
 
-		public static T LoadWidget<T>(string id, Widget parent, WidgetArgs args) where T : Widget
+		public static T LoadWidget<T>(string id, Widget parent, WidgetArgs args, bool instantiateLogicObjects = true) where T : Widget
 		{
-			var widget = LoadWidget(id, parent, args) as T;
+			var widget = LoadWidget(id, parent, args, instantiateLogicObjects) as T;
 			if (widget == null)
 				throw new InvalidOperationException(
 					"Widget {0} is not of type {1}".F(id, typeof(T).Name));
 			return widget;
 		}
 
-		public static Widget LoadWidget(string id, Widget parent, WidgetArgs args)
+		public static Widget LoadWidget(string id, Widget parent, WidgetArgs args, bool instantiateLogicObjects = true)
 		{
-			return Game.ModData.WidgetLoader.LoadWidget(args, parent, id);
+			return Game.ModData.WidgetLoader.LoadWidget(args, parent, id, instantiateLogicObjects);
 		}
 
 		public static void Tick() { Root.TickOuter(); }
@@ -247,15 +247,16 @@ namespace OpenRA.Widgets
 								   height);
 		}
 
-		public void PostInit(WidgetArgs args)
+		public void PostInit(WidgetArgs args, bool instantiateLogicObjects = true)
 		{
 			if (!Logic.Any())
 				return;
 
 			args["widget"] = this;
 
-			LogicObjects = Logic.Select(l => Game.ModData.ObjectCreator.CreateObject<ChromeLogic>(l, args))
-				.ToArray();
+			if (instantiateLogicObjects)
+				LogicObjects = Logic.Select(l => Game.ModData.ObjectCreator.CreateObject<ChromeLogic>(l, args))
+					.ToArray();
 
 			args.Remove("widget");
 		}

--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -34,16 +34,16 @@ namespace OpenRA
 				}
 		}
 
-		public Widget LoadWidget(WidgetArgs args, Widget parent, string w)
+		public Widget LoadWidget(WidgetArgs args, Widget parent, string w, bool instantiateLogicObjects = true)
 		{
 			MiniYamlNode ret;
 			if (!widgets.TryGetValue(w, out ret))
 				throw new InvalidDataException("Cannot find widget with Id `{0}`".F(w));
 
-			return LoadWidget(args, parent, ret);
+			return LoadWidget(args, parent, ret, instantiateLogicObjects);
 		}
 
-		public Widget LoadWidget(WidgetArgs args, Widget parent, MiniYamlNode node)
+		public Widget LoadWidget(WidgetArgs args, Widget parent, MiniYamlNode node, bool instantiateLogicObjects = true)
 		{
 			if (!args.ContainsKey("modRules"))
 				args = new WidgetArgs(args) { { "modRules", modData.DefaultRules } };


### PR DESCRIPTION
This allows one to open a widget (possibly root) without instantiating their logic objects which may change the UI's layout and interaction with the user.

I use this in my WIP designer branch.
