### PR TITLE
Improve sync performance

### DIFF
--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -63,31 +63,29 @@ namespace OpenRA.Network
 			report.SyncedRandom = orderManager.World.SharedRandom.Last;
 			report.TotalCount = orderManager.World.SharedRandom.TotalCount;
 			report.Traits.Clear();
-			foreach (var a in orderManager.World.ActorsWithTrait<ISync>())
-			{
-				var sync = Sync.CalculateSyncHash(a.Trait);
-				if (sync != 0)
-					report.Traits.Add(new TraitReport()
-					{
-						ActorID = a.Actor.ActorID,
-						Type = a.Actor.Info.Name,
-						Owner = (a.Actor.Owner == null) ? "null" : a.Actor.Owner.PlayerName,
-						Trait = a.Trait.GetType().Name,
-						Hash = sync,
-						NamesValues = DumpSyncTrait(a.Trait)
-					});
-			}
+			foreach (var actor in orderManager.World.ActorsHavingTrait<ISync>())
+				foreach (var syncHash in actor.SyncHashes)
+					if (syncHash.Hash != 0)
+						report.Traits.Add(new TraitReport()
+						{
+							ActorID = actor.ActorID,
+							Type = actor.Info.Name,
+							Owner = (actor.Owner == null) ? "null" : actor.Owner.PlayerName,
+							Trait = syncHash.Trait.GetType().Name,
+							Hash = syncHash.Hash,
+							NamesValues = DumpSyncTrait(syncHash.Trait)
+						});
 
 			foreach (var e in orderManager.World.Effects)
 			{
 				var sync = e as ISync;
 				if (sync != null)
 				{
-					var hash = Sync.CalculateSyncHash(sync);
+					var hash = Sync.Hash(sync);
 					if (hash != 0)
 						report.Effects.Add(new EffectReport()
 						{
-							Name = sync.ToString().Split('.').Last(),
+							Name = sync.GetType().Name,
 							Hash = hash,
 							NamesValues = DumpSyncTrait(sync)
 						});

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -341,18 +341,19 @@ namespace OpenRA
 
 				// hash all the actors
 				foreach (var a in Actors)
-					ret += n++ * (int)(1 + a.ActorID) * Sync.CalculateSyncHash(a);
+					ret += n++ * (int)(1 + a.ActorID) * Sync.HashActor(a);
 
 				// hash all the traits that tick
-				foreach (var x in ActorsWithTrait<ISync>())
-					ret += n++ * (int)(1 + x.Actor.ActorID) * Sync.CalculateSyncHash(x.Trait);
+				foreach (var actor in ActorsHavingTrait<ISync>())
+					foreach (var syncHash in actor.SyncHashes)
+						ret += n++ * (int)(1 + actor.ActorID) * syncHash.Hash;
 
 				// TODO: don't go over all effects
 				foreach (var e in Effects)
 				{
 					var sync = e as ISync;
 					if (sync != null)
-						ret += n++ * Sync.CalculateSyncHash(sync);
+						ret += n++ * Sync.Hash(sync);
 				}
 
 				// Hash the shared rng

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var hash = 0;
 				foreach (var objective in objectives)
-					hash ^= Sync.Hash(objective.State);
+					hash ^= Sync.HashUsingHashCode(objective.State);
 				return hash;
 			}
 		}


### PR DESCRIPTION
Previously, generating the sync hash for each syncable trait required a lookup to find the hash function every tick, as well as lookups for the syncable traits.

Instead, we now cache these lookups on actor creation as they do not change. This means we avoid repeated lookups for the traits and the hash functions.

On the RA shellmap, this reduces time spent syncing the world state from 9.65% of total CPU to 6.88%.
