### PR TITLE
Move MiniYaml into its own OpenRA.Markup project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,19 @@ endif
 #
 # Core binaries
 
+# OpenRA.Markup
+markup_SRCS := $(shell find OpenRA.Markup/ -iname '*.cs')
+markup_TARGET = OpenRA.Markup.dll
+markup_KIND = library
+#markup_DEPS = none
+markup_LIBS = $(COMMON_LIBS)
+PROGRAMS += markup
+markup: $(markup_TARGET)
+
 game_SRCS := $(shell find OpenRA.Game/ -iname '*.cs')
 game_TARGET = OpenRA.Game.exe
 game_KIND = winexe
+game_DEPS = $(markup_TARGET)
 game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SharpFont.dll
 game_FLAGS = -win32icon:OpenRA.Game/OpenRA.ico
 PROGRAMS += game
@@ -131,7 +141,7 @@ platforms: $(pdefault_TARGET) $(pnull_TARGET)
 mod_common_SRCS := $(shell find OpenRA.Mods.Common/ -iname '*.cs')
 mod_common_TARGET = mods/common/OpenRA.Mods.Common.dll
 mod_common_KIND = library
-mod_common_DEPS = $(game_TARGET)
+mod_common_DEPS = $(markup_TARGET) $(game_TARGET)
 mod_common_LIBS = $(COMMON_LIBS) $(STD_MOD_LIBS) thirdparty/download/StyleCop.dll thirdparty/download/StyleCop.CSharp.dll thirdparty/download/StyleCop.CSharp.Rules.dll
 PROGRAMS += mod_common
 mod_common: $(mod_common_TARGET)
@@ -140,7 +150,7 @@ mod_common: $(mod_common_TARGET)
 test_dll_SRCS := $(shell find OpenRA.Test/ -iname '*.cs')
 test_dll_TARGET = OpenRA.Test.dll
 test_dll_KIND = library
-test_dll_DEPS = $(game_TARGET) $(mod_common_TARGET)
+test_dll_DEPS = $(markup_TARGET) $(game_TARGET) $(mod_common_TARGET)
 test_dll_FLAGS = -warn:1
 test_dll_LIBS = $(COMMON_LIBS) $(game_TARGET) $(mod_common_TARGET) $(NUNIT_LIBS)
 PROGRAMS += test_dll
@@ -148,7 +158,7 @@ test_dll: $(test_dll_TARGET)
 
 ##### Official Mods #####
 
-STD_MOD_LIBS	= $(game_TARGET)
+STD_MOD_LIBS	= $(markup_TARGET) $(game_TARGET)
 STD_MOD_DEPS	= $(STD_MOD_LIBS)
 
 # Red Alert
@@ -194,6 +204,9 @@ check-scripts:
 	@luac -p $(shell find lua/* -iname '*.lua')
 
 check: utility mods
+	@echo
+	@echo "Checking for code style violations in OpenRA.Markup..."
+	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Markup
 	@echo
 	@echo "Checking for code style violations in OpenRA.Game..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Game
@@ -280,7 +293,7 @@ gamemonitor: $(gamemonitor_TARGET)
 utility_SRCS := $(shell find OpenRA.Utility/ -iname '*.cs')
 utility_TARGET = OpenRA.Utility.exe
 utility_KIND = exe
-utility_DEPS = $(game_TARGET)
+utility_DEPS = $(markup_TARGET) $(game_TARGET)
 utility_LIBS = $(COMMON_LIBS) $(utility_DEPS) thirdparty/download/ICSharpCode.SharpZipLib.dll
 PROGRAMS += utility
 utility: $(utility_TARGET)

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -19,6 +19,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 
 namespace OpenRA

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/FileFormats/ReplayMetadata.cs
+++ b/OpenRA.Game/FileFormats/ReplayMetadata.cs
@@ -11,6 +11,7 @@
 using System;
 using System.IO;
 using System.Text;
+using OpenRA.Markup;
 
 namespace OpenRA.FileFormats
 {

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Network;
 
 namespace OpenRA

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using OpenRA.FileFormats;
+using OpenRA.Markup;
 
 namespace OpenRA.GameRules
 {

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA

--- a/OpenRA.Game/GameRules/RulesetCache.cs
+++ b/OpenRA.Game/GameRules/RulesetCache.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Support;
 
 namespace OpenRA

--- a/OpenRA.Game/GameRules/SoundInfo.cs
+++ b/OpenRA.Game/GameRules/SoundInfo.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.GameRules
 {

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Effects;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA.GameRules

--- a/OpenRA.Game/GameSpeed.cs
+++ b/OpenRA.Game/GameSpeed.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Markup;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/CursorSequence.cs
+++ b/OpenRA.Game/Graphics/CursorSequence.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/MappedImage.cs
+++ b/OpenRA.Game/Graphics/MappedImage.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using OpenRA.Markup;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/VoxelProvider.cs
+++ b/OpenRA.Game/Graphics/VoxelProvider.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 
 namespace OpenRA

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 
 namespace OpenRA

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -17,6 +17,7 @@ using System.Security.Cryptography;
 using System.Text;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Network;
 using OpenRA.Support;
 using OpenRA.Traits;

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -17,6 +17,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 
 namespace OpenRA

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -10,6 +10,7 @@
 
 using System.Drawing;
 using System.IO;
+using OpenRA.Markup;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 
 namespace OpenRA

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Widgets;
 using FS = OpenRA.FileSystem.FileSystem;
 

--- a/OpenRA.Game/ModMetadata.cs
+++ b/OpenRA.Game/ModMetadata.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -8,6 +8,8 @@
  */
 #endregion
 
+using OpenRA.Markup;
+
 namespace OpenRA.Network
 {
 	public class GameServer

--- a/OpenRA.Game/Network/Handshake.cs
+++ b/OpenRA.Game/Network/Handshake.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Network
 {

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA.Network
 {

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA.Network

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -298,7 +298,6 @@
     <Compile Include="Support\Log.cs" />
     <Compile Include="Support\PerfTimer.cs" />
     <Compile Include="Exts.cs" />
-    <Compile Include="MiniYaml.cs" />
     <Compile Include="StreamExts.cs" />
     <Compile Include="Map\Map.cs" />
     <Compile Include="Map\MapCache.cs" />
@@ -361,4 +360,10 @@
   </Target>
   -->
   <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\OpenRA.Markup\OpenRA.Markup.csproj">
+      <Project>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</Project>
+      <Name>OpenRA.Markup</Name>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using Eluant;
 using Eluant.ObjectBinding;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Scripting;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -17,6 +17,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Support;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA

--- a/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
+++ b/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA.Traits
 {

--- a/OpenRA.Game/Widgets/ChromeMetrics.cs
+++ b/OpenRA.Game/Widgets/ChromeMetrics.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Widgets
 {

--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Widgets;
 
 namespace OpenRA

--- a/OpenRA.Markup/Exts.cs
+++ b/OpenRA.Markup/Exts.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Markup
+{
+	internal static class Exts
+	{
+		public static string JoinWith<T>(this IEnumerable<T> ts, string j)
+		{
+			return string.Join(j, ts);
+		}
+
+		public static string F(this string str, params object[] fmt)
+		{
+			return string.Format(str, fmt);
+		}
+
+		public static Dictionary<TKey, TSource> ToDictionaryWithConflictLog<TSource, TKey>(
+			this IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
+			string debugName, Func<TKey, string> logKey, Func<TSource, string> logValue)
+		{
+			return ToDictionaryWithConflictLog(source, keySelector, x => x, debugName, logKey, logValue);
+		}
+
+		public static Dictionary<TKey, TElement> ToDictionaryWithConflictLog<TSource, TKey, TElement>(
+			this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector,
+			string debugName, Func<TKey, string> logKey, Func<TElement, string> logValue)
+		{
+			// Fall back on ToString() if null functions are provided:
+			logKey = logKey ?? (s => s.ToString());
+			logValue = logValue ?? (s => s.ToString());
+
+			// Try to build a dictionary and log all duplicates found (if any):
+			var dupKeys = new Dictionary<TKey, List<string>>();
+			var d = new Dictionary<TKey, TElement>();
+			foreach (var item in source)
+			{
+				var key = keySelector(item);
+				var element = elementSelector(item);
+
+				// Check for a key conflict:
+				if (d.ContainsKey(key))
+				{
+					List<string> dupKeyMessages;
+					if (!dupKeys.TryGetValue(key, out dupKeyMessages))
+					{
+						// Log the initial conflicting value already inserted:
+						dupKeyMessages = new List<string>();
+						dupKeyMessages.Add(logValue(d[key]));
+						dupKeys.Add(key, dupKeyMessages);
+					}
+
+					// Log this conflicting value:
+					dupKeyMessages.Add(logValue(element));
+					continue;
+				}
+
+				d.Add(key, element);
+			}
+
+			// If any duplicates were found, throw a descriptive error
+			if (dupKeys.Count > 0)
+			{
+				var badKeysFormatted = string.Join(", ", dupKeys.Select(p => "{0}: [{1}]".F(logKey(p.Key), string.Join(",", p.Value))));
+				var msg = "{0}, duplicate values found for the following keys: {1}".F(debugName, badKeysFormatted);
+				throw new ArgumentException(msg);
+			}
+
+			// Return the dictionary we built:
+			return d;
+		}
+	}
+}

--- a/OpenRA.Markup/MiniYaml.cs
+++ b/OpenRA.Markup/MiniYaml.cs
@@ -1,4 +1,4 @@
-#region Copyright & License Information
+﻿#region Copyright & License Information
 /*
  * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace OpenRA
+namespace OpenRA.Markup
 {
 	using MiniYamlNodes = List<MiniYamlNode>;
 

--- a/OpenRA.Markup/OpenRA.Markup.csproj
+++ b/OpenRA.Markup/OpenRA.Markup.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>OpenRA.Markup</RootNamespace>
+    <AssemblyName>OpenRA.Markup</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MiniYaml.cs" />
+    <Compile Include="Exts.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/OpenRA.Mods.Cnc/ImportTiberianDawnLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/ImportTiberianDawnLegacyMapCommand.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.UtilityCommands;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -102,6 +102,10 @@
       <Name>OpenRA.Mods.Common</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\OpenRA.Markup\OpenRA.Markup.csproj">
+      <Project>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</Project>
+      <Name>OpenRA.Markup</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA.Mods.Common.Graphics
 {

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -11,6 +11,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA.Mods.Common.Graphics
 {

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Drawing;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Graphics;
 
 namespace OpenRA.Mods.Common.HitShapes

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -12,6 +12,7 @@ using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA.Mods.Common.HitShapes
 {

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Markup;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -85,6 +85,10 @@
       <Name>OpenRA.Game</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\OpenRA.Markup\OpenRA.Markup.csproj">
+      <Project>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</Project>
+      <Name>OpenRA.Markup</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activities\Air\FallToEarth.cs" />

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -9,6 +9,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.HitShapes;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -11,6 +11,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using OpenRA.GameRules;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -14,6 +14,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net;
+using OpenRA.Markup;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using OpenRA.Graphics;
+using OpenRA.Markup;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.Linq;
 using System.Net;
 using System.Text;
+using OpenRA.Markup;
 using OpenRA.Network;
 using OpenRA.Server;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -127,6 +127,10 @@ cd "$(SolutionDir)"</PostBuildEvent>
       <Name>OpenRA.Mods.Common</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\OpenRA.Markup\OpenRA.Markup.csproj">
+      <Project>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</Project>
+      <Name>OpenRA.Markup</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using OpenRA.Markup;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.D2k.UtilityCommands

--- a/OpenRA.Mods.RA/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.RA/ImportRedAlertLegacyMapCommand.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.UtilityCommands;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -126,6 +126,10 @@
       <Name>OpenRA.Mods.Common</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\OpenRA.Markup\OpenRA.Markup.csproj">
+      <Project>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</Project>
+      <Name>OpenRA.Markup</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -64,6 +64,10 @@
       <Name>OpenRA.Mods.Common</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\OpenRA.Markup\OpenRA.Markup.csproj">
+      <Project>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</Project>
+      <Name>OpenRA.Markup</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activities\VoxelHarvesterDockSequence.cs" />

--- a/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
+using OpenRA.Markup;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
+using OpenRA.Markup;
 using OpenRA.Traits;
 
 namespace OpenRA.Test

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using OpenRA.Markup;
 
 namespace OpenRA.Test
 {

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -66,6 +66,10 @@
       <Name>OpenRA.Mods.Common</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\OpenRA.Markup\OpenRA.Markup.csproj">
+      <Project>{382F64EF-9D04-4DB8-B193-43E05249E2E7}</Project>
+      <Name>OpenRA.Markup</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/OpenRA.sln
+++ b/OpenRA.sln
@@ -105,6 +105,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.GameMonitor", "OpenR
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Test", "OpenRA.Test\OpenRA.Test.csproj", "{6CB8E1B7-6B36-4D93-8633-7C573E194AC4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Markup", "OpenRA.Markup\OpenRA.Markup.csproj", "{382F64EF-9D04-4DB8-B193-43E05249E2E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86
@@ -155,6 +157,10 @@ Global
 		{6CB8E1B7-6B36-4D93-8633-7C573E194AC4}.Debug|x86.Build.0 = Debug|x86
 		{6CB8E1B7-6B36-4D93-8633-7C573E194AC4}.Release|x86.ActiveCfg = Release|x86
 		{6CB8E1B7-6B36-4D93-8633-7C573E194AC4}.Release|x86.Build.0 = Release|x86
+		{382F64EF-9D04-4DB8-B193-43E05249E2E7}.Debug|x86.ActiveCfg = Debug|x86
+		{382F64EF-9D04-4DB8-B193-43E05249E2E7}.Debug|x86.Build.0 = Debug|x86
+		{382F64EF-9D04-4DB8-B193-43E05249E2E7}.Release|x86.ActiveCfg = Release|x86
+		{382F64EF-9D04-4DB8-B193-43E05249E2E7}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This will allow other projects/tools to depend on miniyaml structures and parsing without needing the entirety of the engine.
