### PR TITLE
Updated to use the unified Mono compiler suite

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,6 @@ Type `sudo make install-all` for system wide installation. Run `make install-lin
 Debian/Ubuntu
 -------------
 
-* mono-mcs
 * libmono-system-windows-forms4.0-cil
 * nuget
 * mono-devel

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,6 @@ Type `sudo make install-all` for system wide installation. Run `make install-lin
 Debian/Ubuntu
 -------------
 
-* libmono-system-windows-forms4.0-cil
 * nuget
 * mono-devel
 * libfreetype6

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ Debian/Ubuntu
 * mono-mcs
 * libmono-system-windows-forms4.0-cil
 * nuget
-* cli-common-dev (>= 2.10)
+* mono-devel
 * libfreetype6
 * libopenal1
 * liblua5.1-0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ Type `sudo make install-all` for system wide installation. Run `make install-lin
 Debian/Ubuntu
 -------------
 
-* mono-dmcs
+* mono-mcs
 * libmono-system-windows-forms4.0-cil
 * nuget
 * cli-common-dev (>= 2.10)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@
 
 ############################## TOOLCHAIN ###############################
 #
-CSC         = dmcs
+CSC         = mcs -sdk:4.0
 CSFLAGS     = -nologo -warn:4 -codepage:utf8 -unsafe -warnaserror
 DEFINE      = TRACE
 COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/Mono.Nat.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/MaxMind.GeoIP2.dll thirdparty/download/Eluant.dll thirdparty/download/SmarIrc4net.dll


### PR DESCRIPTION
> http://www.mono-project.com/docs/about-mono/languages/csharp/:
> Starting with Mono version 2.11 a new unified compiler mcs is available.

Time to update our `Makefile` as well. We are a bit late actually. Updated the build documentation, too. The only dependency from http://packages.ubuntu.com/trusty/cli-common-dev we need is mono-devel so I reference that directly.
