### PR TITLE
Update VS version in solution file

### DIFF
--- a/OpenRA.sln
+++ b/OpenRA.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.Game", "OpenRA.Game\OpenRA.Game.csproj", "{0DFB103F-2962-400F-8C6D-E2C28CCBA633}"
 EndProject


### PR DESCRIPTION
VS 2015 Update 1 changed the version number slightly. Committing this stops people on an up-to-date Visual Studio from having to reset this change whenever VS paves over the solution file with changes.
