### PR TITLE
Disable 1 human versus bots games

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -196,6 +196,7 @@ namespace OpenRA.Network
 			public bool ShortGame = true;
 			public bool AllowVersionMismatch;
 			public string GameUid;
+			public bool DisableSingleplayer;
 
 			public static Global Deserialize(MiniYaml data)
 			{

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -148,7 +148,8 @@ namespace OpenRA.Server
 					RandomSeed = randomSeed,
 					Map = settings.Map,
 					ServerName = settings.Name,
-					Dedicated = settings.Dedicated
+					Dedicated = settings.Dedicated,
+					DisableSingleplayer = settings.DisableSinglePlayer,
 				}
 			};
 
@@ -395,8 +396,8 @@ namespace OpenRA.Server
 				if (Map.RuleDefinitions.Any() && !LobbyInfo.IsSinglePlayer)
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
-				if (Settings.LockBots)
-					SendOrderTo(newConn, "Message", "Bots have been disabled on this server.");
+				if (Settings.DisableSinglePlayer)
+					SendOrderTo(newConn, "Message", "Singleplayer games have been disabled on this server.");
 				else if (MapPlayers.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 					SendOrderTo(newConn, "Message", "Bots have been disabled on this map.");
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -70,8 +70,8 @@ namespace OpenRA
 		[Desc("Automatically restart when a game ends. Disable this when something else already takes care about it.")]
 		public bool DedicatedLoop = true;
 
-		[Desc("Disallow AI bots.")]
-		public bool LockBots = false;
+		[Desc("Disallow games where only one player plays with bots.")]
+		public bool DisableSinglePlayer = false;
 
 		public string TimestampFormat = "s";
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -318,7 +318,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (startGameButton != null)
 			{
 				startGameButton.IsDisabled = () => configurationDisabled() || Map.RuleStatus != MapRuleStatus.Cached ||
-					orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null);
+					orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
+					(orderManager.LobbyInfo.GlobalSettings.DisableSingleplayer && orderManager.LobbyInfo.IsSinglePlayer);
 				startGameButton.OnClick = () =>
 				{
 					// Bots and admins don't count


### PR DESCRIPTION
Changed the Server.LockBots setting to Server.DisableSinglePlayer.

If the setting is enabled, and there is only one client in the server,
the game won't start.

Fixes #10660 
