### PR TITLE
Move CellCorners to MapGrid.

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Graphics
 							ramp = ti.RampType;
 					}
 
-					var corners = map.CellCorners[ramp];
+					var corners = map.Grid.CellCorners[ramp];
 					var pos = map.CenterOfCell(uv.ToCPos(map));
 					var screen = corners.Select(c => worldRenderer.ScreenPxPosition(pos + c)).ToArray();
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -114,42 +114,6 @@ namespace OpenRA
 	{
 		public const int MinimumSupportedMapFormat = 6;
 
-		static readonly int[][] CellCornerHalfHeights = new int[][]
-		{
-			// Flat
-			new[] { 0, 0, 0, 0 },
-
-			// Slopes (two corners high)
-			new[] { 0, 0, 1, 1 },
-			new[] { 1, 0, 0, 1 },
-			new[] { 1, 1, 0, 0 },
-			new[] { 0, 1, 1, 0 },
-
-			// Slopes (one corner high)
-			new[] { 0, 0, 0, 1 },
-			new[] { 1, 0, 0, 0 },
-			new[] { 0, 1, 0, 0 },
-			new[] { 0, 0, 1, 0 },
-
-			// Slopes (three corners high)
-			new[] { 1, 0, 1, 1 },
-			new[] { 1, 1, 0, 1 },
-			new[] { 1, 1, 1, 0 },
-			new[] { 0, 1, 1, 1 },
-
-			// Slopes (two corners high, one corner double high)
-			new[] { 1, 0, 1, 2 },
-			new[] { 2, 1, 0, 1 },
-			new[] { 1, 2, 1, 0 },
-			new[] { 0, 1, 2, 1 },
-
-			// Slopes (two corners high, alternating)
-			new[] { 1, 0, 1, 0 },
-			new[] { 0, 1, 0, 1 },
-			new[] { 1, 0, 1, 0 },
-			new[] { 0, 1, 0, 1 }
-		};
-
 		public const int MaxTilesInCircleRange = 50;
 		public readonly MapGrid Grid;
 
@@ -257,7 +221,6 @@ namespace OpenRA
 		public Ruleset Rules { get { return rules != null ? rules.Value : null; } }
 		public SequenceProvider SequenceProvider { get { return Rules.Sequences[Tileset]; } }
 
-		public WVec[][] CellCorners { get; private set; }
 		[FieldLoader.Ignore] public ProjectedCellRegion ProjectedCellBounds;
 		[FieldLoader.Ignore] public CellRegion AllCells;
 
@@ -472,18 +435,6 @@ namespace OpenRA
 			CustomTerrain = new CellLayer<byte>(this);
 			foreach (var uv in AllCells.MapCoords)
 				CustomTerrain[uv] = byte.MaxValue;
-
-			var leftDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
-			var topDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(0, -512, 0) : new WVec(512, -512, 0);
-			var rightDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
-			var bottomDelta = Grid.Type == MapGridType.RectangularIsometric ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
-			CellCorners = CellCornerHalfHeights.Select(ramp => new WVec[]
-			{
-				leftDelta + new WVec(0, 0, 512 * ramp[0]),
-				topDelta + new WVec(0, 0, 512 * ramp[1]),
-				rightDelta + new WVec(0, 0, 512 * ramp[2]),
-				bottomDelta + new WVec(0, 0, 512 * ramp[3])
-			}).ToArray();
 		}
 
 		void InitializeCellProjection()

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -10,6 +10,7 @@
 
 using System.Drawing;
 using System.IO;
+using System.Linq;
 
 namespace OpenRA
 {
@@ -31,6 +32,44 @@ namespace OpenRA
 			new WVec(256, 256, 0),   // bottom right - index 5
 		};
 
+		public WVec[][] CellCorners { get; private set; }
+
+		readonly int[][] cellCornerHalfHeights = new int[][]
+		{
+			// Flat
+			new[] { 0, 0, 0, 0 },
+
+			// Slopes (two corners high)
+			new[] { 0, 0, 1, 1 },
+			new[] { 1, 0, 0, 1 },
+			new[] { 1, 1, 0, 0 },
+			new[] { 0, 1, 1, 0 },
+
+			// Slopes (one corner high)
+			new[] { 0, 0, 0, 1 },
+			new[] { 1, 0, 0, 0 },
+			new[] { 0, 1, 0, 0 },
+			new[] { 0, 0, 1, 0 },
+
+			// Slopes (three corners high)
+			new[] { 1, 0, 1, 1 },
+			new[] { 1, 1, 0, 1 },
+			new[] { 1, 1, 1, 0 },
+			new[] { 0, 1, 1, 1 },
+
+			// Slopes (two corners high, one corner double high)
+			new[] { 1, 0, 1, 2 },
+			new[] { 2, 1, 0, 1 },
+			new[] { 1, 2, 1, 0 },
+			new[] { 0, 1, 2, 1 },
+
+			// Slopes (two corners high, alternating)
+			new[] { 1, 0, 1, 0 },
+			new[] { 0, 1, 0, 1 },
+			new[] { 1, 0, 1, 0 },
+			new[] { 0, 1, 0, 1 }
+		};
+
 		public MapGrid(MiniYaml yaml)
 		{
 			FieldLoader.Load(this, yaml);
@@ -40,6 +79,18 @@ namespace OpenRA
 				SubCellDefaultIndex = (byte)(SubCellOffsets.Length / 2);
 			else if (SubCellDefaultIndex < (SubCellOffsets.Length > 1 ? 1 : 0) || SubCellDefaultIndex >= SubCellOffsets.Length)
 				throw new InvalidDataException("Subcell default index must be a valid index into the offset triples and must be greater than 0 for mods with subcells");
+
+			var leftDelta = Type == MapGridType.RectangularIsometric ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
+			var topDelta = Type == MapGridType.RectangularIsometric ? new WVec(0, -512, 0) : new WVec(512, -512, 0);
+			var rightDelta = Type == MapGridType.RectangularIsometric ? new WVec(512, 0, 0) : new WVec(512, 512, 0);
+			var bottomDelta = Type == MapGridType.RectangularIsometric ? new WVec(0, 512, 0) : new WVec(-512, 512, 0);
+			CellCorners = cellCornerHalfHeights.Select(ramp => new WVec[]
+			{
+				leftDelta + new WVec(0, 0, 512 * ramp[0]),
+				topDelta + new WVec(0, 0, 512 * ramp[1]),
+				rightDelta + new WVec(0, 0, 512 * ramp[2]),
+				bottomDelta + new WVec(0, 0, 512 * ramp[3])
+			}).ToArray();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 				var ti = tileSet.GetTileInfo(tile);
 				var ramp = ti != null ? ti.RampType : 0;
 
-				var corners = map.CellCorners[ramp];
+				var corners = map.Grid.CellCorners[ramp];
 				var color = corners.Select(c => colors[height + c.Z / 512]).ToArray();
 				var pos = map.CenterOfCell(uv.ToCPos(map));
 				var screen = corners.Select(c => wr.ScreenPxPosition(pos + c).ToFloat2()).ToArray();
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Projected cell coordinates for the current cell
-			var projectedCorners = map.CellCorners[0];
+			var projectedCorners = map.Grid.CellCorners[0];
 			foreach (var puv in map.ProjectedCellsCovering(mouseCell))
 			{
 				var pos = map.CenterOfCell(((MPos)puv).ToCPos(map));


### PR DESCRIPTION
We no longer need to store this per-map.  Moving it to MapGrid saves a small amount of memory and performance per map.
