### PR TITLE
Mines will no longer kill players own units.

### DIFF
--- a/OpenRA.Mods.RA/Traits/Mine.cs
+++ b/OpenRA.Mods.RA/Traits/Mine.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public void OnCrush(Actor crusher)
 		{
-			if (crusher.Info.HasTraitInfo<MineImmuneInfo>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly))
+			if (crusher.Info.HasTraitInfo<MineImmuneInfo>() || (self.Owner.Stances[crusher.Owner] == Stance.Ally && info.AvoidFriendly) || crusher.Owner == self.Owner)
 				return;
 
 			var mobile = crusher.TraitOrDefault<Mobile>();


### PR DESCRIPTION
In current bleed, Mines will kill owner units of any kind - regardless of type.
I've added a simple or condition to the trigger that checks if the crushing unit's owner is the same as it's own and returns with no action if this passes.

Otherwise, blow up as normal :)

This can be repeated in current head by simply laying a field of mines in skirmish and making any unit cross them.
