### PR TITLE
Remove null checks against self

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -179,7 +179,6 @@ namespace OpenRA.Mods.Common.Traits
 		static bool IsMovingInMyDirection(Actor self, Actor other)
 		{
 			if (!other.IsMoving()) return false;
-			if (self == null) return true;
 
 			var selfMobile = self.TraitOrDefault<Mobile>();
 			if (selfMobile == null) return false;
@@ -235,7 +234,6 @@ namespace OpenRA.Mods.Common.Traits
 
 			// If the check allows: we are not blocked by allied units moving in our direction.
 			if (!check.HasCellCondition(CellConditions.BlockedByMovers) &&
-				self != null &&
 				self.Owner.Stances[otherActor.Owner] == Stance.Ally &&
 				IsMovingInMyDirection(self, otherActor))
 				return false;
@@ -246,7 +244,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			// If we cannot crush the other actor in our way, we are blocked.
-			if (self == null || Crushes == null || Crushes.Count == 0)
+			if (Crushes == null || Crushes.Count == 0)
 				return true;
 
 			// If the other actor in our way cannot be crushed, we are blocked.


### PR DESCRIPTION
Remove checks for self being null in Mobile.cs.

Picked up by a Coverity check which detected that self was dereferenced inside a call to `CanRemoveBlockage` without a null check - but the other code around it has such null checks.

In OpenRA, 'self' should never be null by convention (if it is - a NRE is probably the least of your problems).
