### PR TITLE
Fix Map.Contains for maps with height

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -771,7 +771,12 @@ namespace OpenRA
 			if (Grid.MaximumTerrainHeight == 0)
 				return Contains((PPos)uv);
 
-			foreach (var puv in ProjectedCellsCovering(uv))
+			// If the cell has no valid projection, then we're off the map.
+			var projectedCells = ProjectedCellsCovering(uv);
+			if (projectedCells.Length == 0)
+				return false;
+
+			foreach (var puv in projectedCells)
 				if (!Contains(puv))
 					return false;
 			return true;

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -65,17 +65,15 @@ namespace OpenRA.Traits
 				.ToArray();
 
 			if (Footprint.Length == 0)
-				throw new ArgumentException(("This frozen actor has no footprint! Please report a bug!\n" +
+				throw new ArgumentException(("This frozen actor has no footprint.\n" +
 					"Actor Name: {0}\n" +
 					"Actor Location: {1}\n" +
 					"Input footprint: [{2}]\n" +
-					"Input footprint (shroud.Contains): [{3}]\n" +
-					"Input footprint (map.Contains): [{4}]")
+					"Input footprint (after shroud.Contains): [{3}]")
 					.F(actor.Info.Name,
 					actor.Location.ToString(),
 					footprint.Select(p => p.ToString()).JoinWith("|"),
-					footprint.Select(p => shroud.Contains(p).ToString()).JoinWith("|"),
-					footprint.Select(p => actor.World.Map.Contains(p).ToString()).JoinWith("|")));
+					footprint.Select(p => shroud.Contains(p).ToString()).JoinWith("|")));
 
 			CenterPosition = self.CenterPosition;
 			Bounds = self.Bounds;


### PR DESCRIPTION
Fixes #10460.
Fixes #10698.
Fixes OpenRA/ra2#85.

Changed the logic so a cell with no valid projected cells is now considered off the map - previously such a cell would be considered inside the map.

Also trimmed down the debug messaged introduced in #10592 a bit now we have a fix.
