### PR TITLE
Unify filesystem package syntax.

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -81,10 +81,16 @@ namespace OpenRA.FileSystem
 			if (optional)
 				name = name.Substring(1);
 
-			Action a = () => Mount(OpenPackage(name), explicitName);
+			var modPackage = name.StartsWith("$");
+			if (modPackage)
+				name = name.Substring(1);
+
+			Action a = () => Mount(modPackage ? ModMetadata.AllMods[name].Package : OpenPackage(name), explicitName);
 			if (optional)
+			{
 				try { a(); }
 				catch { }
+			}
 			else
 				a();
 		}

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -35,11 +35,12 @@ namespace OpenRA
 	{
 		public readonly ModMetadata Mod;
 		public readonly string[]
-			Packages, Rules, ServerTraits,
+			Rules, ServerTraits,
 			Sequences, VoxelSequences, Cursors, Chrome, Assemblies, ChromeLayout,
 			Weapons, Voices, Notifications, Music, Translations, TileSets,
 			ChromeMetrics, MapCompatibility, Missions;
 
+		public readonly IReadOnlyDictionary<string, string> Packages;
 		public readonly IReadOnlyDictionary<string, string> MapFolders;
 		public readonly MiniYaml LoadScreen;
 		public readonly MiniYaml LobbyDefaults;
@@ -70,7 +71,11 @@ namespace OpenRA
 
 			// TODO: Use fieldloader
 			MapFolders = YamlDictionary(yaml, "MapFolders", true);
-			Packages = YamlList(yaml, "Packages", true);
+
+			MiniYaml packages;
+			if (yaml.TryGetValue("Packages", out packages))
+				Packages = packages.ToDictionary(x => Platform.ResolvePath(x), x => x.Value).AsReadOnly();
+
 			Rules = YamlList(yaml, "Rules", true);
 			Sequences = YamlList(yaml, "Sequences", true);
 			VoxelSequences = YamlList(yaml, "VoxelSequences", true);

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -74,23 +74,23 @@ namespace OpenRA
 
 			MiniYaml packages;
 			if (yaml.TryGetValue("Packages", out packages))
-				Packages = packages.ToDictionary(x => Platform.ResolvePath(x), x => x.Value).AsReadOnly();
+				Packages = packages.ToDictionary(x => x.Value).AsReadOnly();
 
-			Rules = YamlList(yaml, "Rules", true);
-			Sequences = YamlList(yaml, "Sequences", true);
-			VoxelSequences = YamlList(yaml, "VoxelSequences", true);
-			Cursors = YamlList(yaml, "Cursors", true);
-			Chrome = YamlList(yaml, "Chrome", true);
-			Assemblies = YamlList(yaml, "Assemblies", true);
-			ChromeLayout = YamlList(yaml, "ChromeLayout", true);
-			Weapons = YamlList(yaml, "Weapons", true);
-			Voices = YamlList(yaml, "Voices", true);
-			Notifications = YamlList(yaml, "Notifications", true);
-			Music = YamlList(yaml, "Music", true);
-			Translations = YamlList(yaml, "Translations", true);
-			TileSets = YamlList(yaml, "TileSets", true);
-			ChromeMetrics = YamlList(yaml, "ChromeMetrics", true);
-			Missions = YamlList(yaml, "Missions", true);
+			Rules = YamlList(yaml, "Rules");
+			Sequences = YamlList(yaml, "Sequences");
+			VoxelSequences = YamlList(yaml, "VoxelSequences");
+			Cursors = YamlList(yaml, "Cursors");
+			Chrome = YamlList(yaml, "Chrome");
+			Assemblies = YamlList(yaml, "Assemblies");
+			ChromeLayout = YamlList(yaml, "ChromeLayout");
+			Weapons = YamlList(yaml, "Weapons");
+			Voices = YamlList(yaml, "Voices");
+			Notifications = YamlList(yaml, "Notifications");
+			Music = YamlList(yaml, "Music");
+			Translations = YamlList(yaml, "Translations");
+			TileSets = YamlList(yaml, "TileSets");
+			ChromeMetrics = YamlList(yaml, "ChromeMetrics");
+			Missions = YamlList(yaml, "Missions");
 
 			ServerTraits = YamlList(yaml, "ServerTraits");
 
@@ -101,10 +101,10 @@ namespace OpenRA
 				throw new InvalidDataException("`LobbyDefaults` section is not defined.");
 
 			Fonts = yaml["Fonts"].ToDictionary(my =>
-				{
-					var nd = my.ToDictionary();
-					return Pair.New(nd["Font"].Value, Exts.ParseIntegerInvariant(nd["Size"].Value));
-				});
+			{
+				var nd = my.ToDictionary();
+				return Pair.New(nd["Font"].Value, Exts.ParseIntegerInvariant(nd["Size"].Value));
+			});
 
 			RequiresMods = yaml["RequiresMods"].ToDictionary(my => my.Value);
 
@@ -156,9 +156,6 @@ namespace OpenRA
 		{
 			if (!yaml.ContainsKey(key))
 				return new string[] { };
-
-			if (parsePaths)
-				return yaml[key].Nodes.Select(node => Platform.ResolvePath(node.Key, node.Value.Value ?? string.Empty)).ToArray();
 
 			return yaml[key].ToDictionary().Keys.ToArray();
 		}

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -70,7 +70,7 @@ namespace OpenRA
 			Mod.Id = modId;
 
 			// TODO: Use fieldloader
-			MapFolders = YamlDictionary(yaml, "MapFolders", true);
+			MapFolders = YamlDictionary(yaml, "MapFolders");
 
 			MiniYaml packages;
 			if (yaml.TryGetValue("Packages", out packages))
@@ -160,29 +160,12 @@ namespace OpenRA
 			return yaml[key].ToDictionary().Keys.ToArray();
 		}
 
-		static IReadOnlyDictionary<string, string> YamlDictionary(Dictionary<string, MiniYaml> yaml, string key, bool parsePaths = false)
+		static IReadOnlyDictionary<string, string> YamlDictionary(Dictionary<string, MiniYaml> yaml, string key)
 		{
 			if (!yaml.ContainsKey(key))
 				return new ReadOnlyDictionary<string, string>();
 
-			var inner = new Dictionary<string, string>();
-			foreach (var node in yaml[key].Nodes)
-			{
-				var line = node.Key;
-				if (node.Value.Value != null)
-					line += ":" + node.Value.Value;
-
-				// '@' may be used in mod.yaml to indicate extra information (similar to trait @ tags).
-				// Applies to MapFolders (to indicate System and User directories) and Packages (to indicate package annotation).
-				if (line.Contains('@'))
-				{
-					var split = line.Split('@');
-					inner.Add(parsePaths ? Platform.ResolvePath(split[0]) : split[0], split[1]);
-				}
-				else
-					inner.Add(line, null);
-			}
-
+			var inner = yaml[key].ToDictionary(my => my.Value);
 			return new ReadOnlyDictionary<string, string>(inner);
 		}
 

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -100,14 +100,6 @@ namespace OpenRA
 		{
 			path = path.TrimEnd(new char[] { ' ', '\t' });
 
-			// If the path contains ':', chances are it is a package path.
-			// If it isn't, someone passed an already resolved path, which is wrong.
-			if (path.IndexOf(":", StringComparison.Ordinal) > 1)
-			{
-				var split = path.Split(':');
-				return ResolvePath(split[0], split[1]);
-			}
-
 			// paths starting with ^ are relative to the support dir
 			if (path.StartsWith("^"))
 				path = SupportDir + path.Substring(1);
@@ -117,16 +109,6 @@ namespace OpenRA
 				path = GameDir + path.Substring(2);
 
 			return path;
-		}
-
-		/// <summary>Replaces package names with full paths. Avoid using this for non-package paths.</summary>
-		public static string ResolvePath(string package, string target)
-		{
-			// Resolve mod package paths.
-			if (ModMetadata.AllMods.ContainsKey(package))
-				package = ModMetadata.AllMods[package].Package.Name;
-
-			return ResolvePath(Path.Combine(package, target));
 		}
 
 		/// <summary>Replace special character prefixes with full paths.</summary>

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -33,8 +33,8 @@ Packages:
 	cnc|uibits
 
 MapFolders:
-	./mods/cnc/maps@System
-	~^maps/cnc/{DEV_VERSION}@User
+	cnc|maps: System
+	~^maps/cnc/{DEV_VERSION}: User
 
 Rules:
 	cnc|rules/misc.yaml

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -10,7 +10,8 @@ RequiresMods:
 Packages:
 	~^Content/cnc
 	.
-	./mods/cnc
+	$cnc: cnc
+	./mods/common: common
 	speech.mix
 	conquer.mix
 	sounds.mix
@@ -24,122 +25,122 @@ Packages:
 	~scores.mix
 	~scores2.mix
 	~transit.mix
-	./mods/cnc/bits/snow.mix
-	./mods/cnc/bits
-	./mods/cnc/bits/jungle
-	./mods/cnc/bits/desert
-	./mods/cnc/bits/ss
-	./mods/cnc/uibits
+	cnc|bits/snow.mix
+	cnc|bits
+	cnc|bits/jungle
+	cnc|bits/desert
+	cnc|bits/ss
+	cnc|uibits
 
 MapFolders:
 	./mods/cnc/maps@System
 	~^maps/cnc/{DEV_VERSION}@User
 
 Rules:
-	./mods/cnc/rules/misc.yaml
-	./mods/cnc/rules/ai.yaml
-	./mods/cnc/rules/player.yaml
-	./mods/cnc/rules/world.yaml
-	./mods/cnc/rules/palettes.yaml
-	./mods/cnc/rules/defaults.yaml
-	./mods/cnc/rules/structures.yaml
-	./mods/cnc/rules/infantry.yaml
-	./mods/cnc/rules/vehicles.yaml
-	./mods/cnc/rules/trees.yaml
-	./mods/cnc/rules/civilian.yaml
-	./mods/cnc/rules/civilian-desert.yaml
-	./mods/cnc/rules/tech.yaml
-	./mods/cnc/rules/ships.yaml
-	./mods/cnc/rules/aircraft.yaml
-	./mods/cnc/rules/husks.yaml
+	cnc|rules/misc.yaml
+	cnc|rules/ai.yaml
+	cnc|rules/player.yaml
+	cnc|rules/world.yaml
+	cnc|rules/palettes.yaml
+	cnc|rules/defaults.yaml
+	cnc|rules/structures.yaml
+	cnc|rules/infantry.yaml
+	cnc|rules/vehicles.yaml
+	cnc|rules/trees.yaml
+	cnc|rules/civilian.yaml
+	cnc|rules/civilian-desert.yaml
+	cnc|rules/tech.yaml
+	cnc|rules/ships.yaml
+	cnc|rules/aircraft.yaml
+	cnc|rules/husks.yaml
 
 Sequences:
-	./mods/cnc/sequences/structures.yaml
-	./mods/cnc/sequences/vehicles.yaml
-	./mods/cnc/sequences/infantry.yaml
-	./mods/cnc/sequences/aircraft.yaml
-	./mods/cnc/sequences/decorations.yaml
-	./mods/cnc/sequences/misc.yaml
-	./mods/cnc/sequences/funpark.yaml
-	./mods/cnc/sequences/civilian.yaml
-	./mods/cnc/sequences/campaign.yaml
+	cnc|sequences/structures.yaml
+	cnc|sequences/vehicles.yaml
+	cnc|sequences/infantry.yaml
+	cnc|sequences/aircraft.yaml
+	cnc|sequences/decorations.yaml
+	cnc|sequences/misc.yaml
+	cnc|sequences/funpark.yaml
+	cnc|sequences/civilian.yaml
+	cnc|sequences/campaign.yaml
 
 TileSets:
-	./mods/cnc/tilesets/desert.yaml
-	./mods/cnc/tilesets/winter.yaml
-	./mods/cnc/tilesets/snow.yaml
-	./mods/cnc/tilesets/temperat.yaml
-	./mods/cnc/tilesets/jungle.yaml
+	cnc|tilesets/desert.yaml
+	cnc|tilesets/winter.yaml
+	cnc|tilesets/snow.yaml
+	cnc|tilesets/temperat.yaml
+	cnc|tilesets/jungle.yaml
 
 Weapons:
-	./mods/cnc/weapons/explosions.yaml
-	./mods/cnc/weapons/largecaliber.yaml
-	./mods/cnc/weapons/missiles.yaml
-	./mods/cnc/weapons/other.yaml
-	./mods/cnc/weapons/smallcaliber.yaml
-	./mods/cnc/weapons/superweapons.yaml
+	cnc|weapons/explosions.yaml
+	cnc|weapons/largecaliber.yaml
+	cnc|weapons/missiles.yaml
+	cnc|weapons/other.yaml
+	cnc|weapons/smallcaliber.yaml
+	cnc|weapons/superweapons.yaml
 
 Cursors:
-	./mods/cnc/cursors.yaml
+	cnc|cursors.yaml
 
 Chrome:
-	./mods/cnc/chrome.yaml
+	cnc|chrome.yaml
 
 Assemblies:
-	./mods/common/OpenRA.Mods.Common.dll
-	./mods/cnc/OpenRA.Mods.Cnc.dll
+	common|OpenRA.Mods.Common.dll
+	cnc|OpenRA.Mods.Cnc.dll
 
 ChromeLayout:
-	./mods/cnc/chrome/mainmenu.yaml
-	./mods/cnc/chrome/multiplayer.yaml
-	./mods/cnc/chrome/multiplayer-browser.yaml
-	./mods/cnc/chrome/multiplayer-createserver.yaml
-	./mods/cnc/chrome/multiplayer-directconnect.yaml
-	./mods/cnc/chrome/multiplayer-globalchat.yaml
-	./mods/cnc/chrome/lobby.yaml
-	./mods/cnc/chrome/lobby-mappreview.yaml
-	./mods/cnc/chrome/lobby-players.yaml
-	./mods/cnc/chrome/lobby-options.yaml
-	./mods/cnc/chrome/lobby-music.yaml
-	./mods/cnc/chrome/lobby-kickdialogs.yaml
-	./mods/cnc/chrome/lobby-globalchat.yaml
-	./mods/cnc/chrome/connection.yaml
-	./mods/cnc/chrome/color-picker.yaml
-	./mods/cnc/chrome/mapchooser.yaml
-	./mods/cnc/chrome/replaybrowser.yaml
-	./mods/cnc/chrome/ingame.yaml
-	./mods/cnc/chrome/ingame-chat.yaml
-	./mods/cnc/chrome/ingame-menu.yaml
-	./mods/cnc/chrome/ingame-debug.yaml
-	./mods/cnc/chrome/ingame-info.yaml
-	./mods/cnc/chrome/ingame-infobriefing.yaml
-	./mods/cnc/chrome/ingame-infoscripterror.yaml
-	./mods/cnc/chrome/ingame-infoobjectives.yaml
-	./mods/cnc/chrome/ingame-infostats.yaml
-	./mods/cnc/chrome/ingame-observerstats.yaml
-	./mods/cnc/chrome/music.yaml
-	./mods/cnc/chrome/settings.yaml
-	./mods/cnc/chrome/credits.yaml
-	./mods/cnc/chrome/dialogs.yaml
-	./mods/cnc/chrome/tooltips.yaml
-	./mods/cnc/chrome/assetbrowser.yaml
-	./mods/cnc/chrome/missionbrowser.yaml
-	./mods/cnc/chrome/editor.yaml
+	cnc|chrome/mainmenu.yaml
+	cnc|chrome/multiplayer.yaml
+	cnc|chrome/multiplayer-browser.yaml
+	cnc|chrome/multiplayer-createserver.yaml
+	cnc|chrome/multiplayer-directconnect.yaml
+	cnc|chrome/multiplayer-globalchat.yaml
+	cnc|chrome/lobby.yaml
+	cnc|chrome/lobby-mappreview.yaml
+	cnc|chrome/lobby-players.yaml
+	cnc|chrome/lobby-options.yaml
+	cnc|chrome/lobby-music.yaml
+	cnc|chrome/lobby-kickdialogs.yaml
+	cnc|chrome/lobby-globalchat.yaml
+	cnc|chrome/connection.yaml
+	cnc|chrome/color-picker.yaml
+	cnc|chrome/mapchooser.yaml
+	cnc|chrome/replaybrowser.yaml
+	cnc|chrome/ingame.yaml
+	cnc|chrome/ingame-chat.yaml
+	cnc|chrome/ingame-menu.yaml
+	cnc|chrome/ingame-debug.yaml
+	cnc|chrome/ingame-info.yaml
+	cnc|chrome/ingame-infobriefing.yaml
+	cnc|chrome/ingame-infoscripterror.yaml
+	cnc|chrome/ingame-infoobjectives.yaml
+	cnc|chrome/ingame-infostats.yaml
+	cnc|chrome/ingame-observerstats.yaml
+	cnc|chrome/music.yaml
+	cnc|chrome/settings.yaml
+	cnc|chrome/credits.yaml
+	cnc|chrome/dialogs.yaml
+	cnc|chrome/tooltips.yaml
+	cnc|chrome/assetbrowser.yaml
+	cnc|chrome/missionbrowser.yaml
+	cnc|chrome/editor.yaml
 
 Voices:
-	./mods/cnc/audio/voices.yaml
+	cnc|audio/voices.yaml
 
 Notifications:
-	./mods/cnc/audio/notifications.yaml
+	cnc|audio/notifications.yaml
 
 Music:
-	./mods/cnc/audio/music.yaml
+	cnc|audio/music.yaml
 
 Translations:
-	./mods/cnc/languages/english.yaml
+	cnc|languages/english.yaml
 
 LoadScreen: CncLoadScreen
-	Image: ./mods/cnc/uibits/chrome.png
+	Image: cnc|uibits/chrome.png
 	Text: Loading
 
 ContentInstaller:
@@ -171,33 +172,33 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
-	./mods/common/metrics.yaml
-	./mods/cnc/metrics.yaml
+	common|metrics.yaml
+	cnc|metrics.yaml
 
 Fonts:
 	Small:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:12
 	Regular:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:14
 	Bold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:32
 	MediumBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:18
 	BigBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:24
 	Tiny:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:10
 
 Missions:

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -13,120 +13,124 @@ Packages:
 	~^Content/d2k/Movies
 	~^Content/d2k/Music
 	.
-	d2k:
+	$d2k: d2k
+	$ra: ra
+	$cnc: cnc
+	./mods/common: common
+
 	SOUND.RS
-	d2k:bits
-	d2k:bits/tex
-	d2k:bits/xmas
-	d2k:uibits
+	d2k|bits
+	d2k|bits/tex
+	d2k|bits/xmas
+	d2k|uibits
 
 MapFolders:
-	d2k:maps@System
+	./mods/d2k/maps@System
 	~^maps/d2k/{DEV_VERSION}@User
 
 Rules:
-	d2k:rules/misc.yaml
-	d2k:rules/ai.yaml
-	d2k:rules/player.yaml
-	d2k:rules/world.yaml
-	d2k:rules/palettes.yaml
-	d2k:rules/defaults.yaml
-	d2k:rules/vehicles.yaml
-	d2k:rules/starport.yaml
-	d2k:rules/husks.yaml
-	d2k:rules/structures.yaml
-	d2k:rules/aircraft.yaml
-	d2k:rules/infantry.yaml
-	d2k:rules/arrakis.yaml
+	d2k|rules/misc.yaml
+	d2k|rules/ai.yaml
+	d2k|rules/player.yaml
+	d2k|rules/world.yaml
+	d2k|rules/palettes.yaml
+	d2k|rules/defaults.yaml
+	d2k|rules/vehicles.yaml
+	d2k|rules/starport.yaml
+	d2k|rules/husks.yaml
+	d2k|rules/structures.yaml
+	d2k|rules/aircraft.yaml
+	d2k|rules/infantry.yaml
+	d2k|rules/arrakis.yaml
 
 Sequences:
-	d2k:sequences/aircraft.yaml
-	d2k:sequences/vehicles.yaml
-	d2k:sequences/infantry.yaml
-	d2k:sequences/structures.yaml
-	d2k:sequences/misc.yaml
+	d2k|sequences/aircraft.yaml
+	d2k|sequences/vehicles.yaml
+	d2k|sequences/infantry.yaml
+	d2k|sequences/structures.yaml
+	d2k|sequences/misc.yaml
 
 TileSets:
-	d2k:tilesets/arrakis.yaml
+	d2k|tilesets/arrakis.yaml
 
 MapGrid:
 	TileSize: 32,32
 	Type: Rectangular
 
 Cursors:
-	d2k:cursors.yaml
+	d2k|cursors.yaml
 
 Chrome:
-	d2k:chrome.yaml
+	d2k|chrome.yaml
 
 Assemblies:
-	./mods/common/OpenRA.Mods.Common.dll
-	./mods/cnc/OpenRA.Mods.Cnc.dll
-	./mods/d2k/OpenRA.Mods.D2k.dll
+	common|OpenRA.Mods.Common.dll
+	cnc|OpenRA.Mods.Cnc.dll
+	d2k|OpenRA.Mods.D2k.dll
 
 ChromeLayout:
-	d2k:chrome/ingame.yaml
-	./mods/ra/chrome/ingame-chat.yaml
-	./mods/ra/chrome/ingame-fmvplayer.yaml
-	d2k:chrome/ingame-menu.yaml
-	./mods/ra/chrome/ingame-info.yaml
-	./mods/ra/chrome/ingame-infoscripterror.yaml
-	./mods/ra/chrome/ingame-infobriefing.yaml
-	./mods/ra/chrome/ingame-infoobjectives.yaml
-	d2k:chrome/ingame-infostats.yaml
-	d2k:chrome/ingame-observer.yaml
-	./mods/ra/chrome/ingame-observerstats.yaml
-	d2k:chrome/ingame-player.yaml
-	./mods/ra/chrome/ingame-perf.yaml
-	./mods/ra/chrome/ingame-debug.yaml
-	d2k:chrome/mainmenu.yaml
-	./mods/ra/chrome/settings.yaml
-	./mods/ra/chrome/credits.yaml
-	./mods/ra/chrome/lobby.yaml
-	./mods/ra/chrome/lobby-mappreview.yaml
-	d2k:chrome/lobby-players.yaml
-	d2k:chrome/lobby-options.yaml
-	./mods/ra/chrome/lobby-music.yaml
-	./mods/ra/chrome/lobby-kickdialogs.yaml
-	./mods/ra/chrome/lobby-globalchat.yaml
-	d2k:chrome/color-picker.yaml
-	./mods/ra/chrome/map-chooser.yaml
-	./mods/ra/chrome/multiplayer.yaml
-	./mods/ra/chrome/multiplayer-browser.yaml
-	./mods/ra/chrome/multiplayer-createserver.yaml
-	./mods/ra/chrome/multiplayer-directconnect.yaml
-	./mods/ra/chrome/multiplayer-globalchat.yaml
-	./mods/ra/chrome/connection.yaml
-	d2k:chrome/dropdowns.yaml
-	./mods/ra/chrome/musicplayer.yaml
-	d2k:chrome/tooltips.yaml
-	./mods/ra/chrome/assetbrowser.yaml
-	d2k:chrome/missionbrowser.yaml
-	./mods/ra/chrome/confirmation-dialogs.yaml
-	./mods/ra/chrome/editor.yaml
-	./mods/ra/chrome/replaybrowser.yaml
+	d2k|chrome/ingame.yaml
+	ra|chrome/ingame-chat.yaml
+	ra|chrome/ingame-fmvplayer.yaml
+	d2k|chrome/ingame-menu.yaml
+	ra|chrome/ingame-info.yaml
+	ra|chrome/ingame-infoscripterror.yaml
+	ra|chrome/ingame-infobriefing.yaml
+	ra|chrome/ingame-infoobjectives.yaml
+	d2k|chrome/ingame-infostats.yaml
+	d2k|chrome/ingame-observer.yaml
+	ra|chrome/ingame-observerstats.yaml
+	d2k|chrome/ingame-player.yaml
+	ra|chrome/ingame-perf.yaml
+	ra|chrome/ingame-debug.yaml
+	d2k|chrome/mainmenu.yaml
+	ra|chrome/settings.yaml
+	ra|chrome/credits.yaml
+	ra|chrome/lobby.yaml
+	ra|chrome/lobby-mappreview.yaml
+	d2k|chrome/lobby-players.yaml
+	d2k|chrome/lobby-options.yaml
+	ra|chrome/lobby-music.yaml
+	ra|chrome/lobby-kickdialogs.yaml
+	ra|chrome/lobby-globalchat.yaml
+	d2k|chrome/color-picker.yaml
+	ra|chrome/map-chooser.yaml
+	ra|chrome/multiplayer.yaml
+	ra|chrome/multiplayer-browser.yaml
+	ra|chrome/multiplayer-createserver.yaml
+	ra|chrome/multiplayer-directconnect.yaml
+	ra|chrome/multiplayer-globalchat.yaml
+	ra|chrome/connection.yaml
+	d2k|chrome/dropdowns.yaml
+	ra|chrome/musicplayer.yaml
+	d2k|chrome/tooltips.yaml
+	ra|chrome/assetbrowser.yaml
+	d2k|chrome/missionbrowser.yaml
+	ra|chrome/confirmation-dialogs.yaml
+	ra|chrome/editor.yaml
+	ra|chrome/replaybrowser.yaml
 
 Weapons:
-	d2k:weapons/debris.yaml
-	d2k:weapons/smallguns.yaml
-	d2k:weapons/largeguns.yaml
-	d2k:weapons/missiles.yaml
-	d2k:weapons/other.yaml
+	d2k|weapons/debris.yaml
+	d2k|weapons/smallguns.yaml
+	d2k|weapons/largeguns.yaml
+	d2k|weapons/missiles.yaml
+	d2k|weapons/other.yaml
 
 Voices:
-	d2k:audio/voices.yaml
+	d2k|audio/voices.yaml
 
 Notifications:
-	d2k:audio/notifications.yaml
+	d2k|audio/notifications.yaml
 
 Music:
-	d2k:audio/music.yaml
+	d2k|audio/music.yaml
 
 Translations:
-	d2k:languages/english.yaml
+	d2k|languages/english.yaml
 
 LoadScreen: LogoStripeLoadScreen
-	Image: ./mods/d2k/uibits/loadscreen.png
+	Image: d2k|uibits/loadscreen.png
 	Text: Filling Crates..., Breeding Sandworms..., Fuelling carryalls..., Deploying harvesters..., Preparing 'thopters..., Summoning mentats...
 
 ContentInstaller:
@@ -161,37 +165,37 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
-	./mods/common/metrics.yaml
-	d2k:metrics.yaml
+	common|metrics.yaml
+	d2k|metrics.yaml
 
 Fonts:
 	Regular:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:14
 	Bold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:./mods/d2k/Dune2k.ttf
+		Font: d2k|Dune2k.ttf
 		Size:32
 	MediumBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:18
 	BigBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:24
 	Small:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:12
 	Tiny:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:10
 
 Missions:
-	d2k:missions.yaml
+	d2k|missions.yaml
 
 SupportsMapsFrom: d2k
 

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -25,8 +25,8 @@ Packages:
 	d2k|uibits
 
 MapFolders:
-	./mods/d2k/maps@System
-	~^maps/d2k/{DEV_VERSION}@User
+	d2k|maps: System
+	~^maps/d2k/{DEV_VERSION}: User
 
 Rules:
 	d2k|rules/misc.yaml

--- a/mods/modchooser/mod.yaml
+++ b/mods/modchooser/mod.yaml
@@ -8,48 +8,49 @@ RequiresMods:
 
 Packages:
 	.
-	./mods/modchooser
+	./mods/modchooser: modchooser
+	./mods/common: common
 
 Cursors:
-	./mods/modchooser/cursors.yaml
+	modchooser|cursors.yaml
 
 Chrome:
-	./mods/modchooser/chrome.yaml
+	modchooser|chrome.yaml
 
 Assemblies:
-	./mods/common/OpenRA.Mods.Common.dll
+	common|OpenRA.Mods.Common.dll
 
 ChromeLayout:
-	./mods/modchooser/modchooser.yaml
-	./mods/modchooser/install.yaml
+	modchooser|modchooser.yaml
+	modchooser|install.yaml
 
 Notifications:
-	./mods/modchooser/notifications.yaml
+	modchooser|notifications.yaml
 
 LoadScreen: ModChooserLoadScreen
 	Image: ./mods/modchooser/chrome.png
 
 ChromeMetrics:
-	./mods/modchooser/metrics.yaml
+	modchooser|metrics.yaml
 
 Fonts:
 	Regular:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:14
 	Bold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:14
 	BigBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:24
 	MediumBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:18
 	Tiny:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:10
 
 LobbyDefaults:

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -10,7 +10,9 @@ RequiresMods:
 Packages:
 	~^Content/ra
 	.
-	./mods/ra
+	$ra: ra
+	$cnc: cnc
+	./mods/common: common
 	~main.mix
 	redalert.mix
 	conquer.mix
@@ -26,121 +28,121 @@ Packages:
 	~scores.mix
 	~movies1.mix
 	~movies2.mix
-	./mods/ra/bits
-	./mods/ra/bits/desert
-	./mods/ra/uibits
+	ra|bits
+	ra|bits/desert
+	ra|uibits
 
 MapFolders:
 	./mods/ra/maps@System
 	~^maps/ra/{DEV_VERSION}@User
 
 Rules:
-	./mods/ra/rules/misc.yaml
-	./mods/ra/rules/ai.yaml
-	./mods/ra/rules/player.yaml
-	./mods/ra/rules/palettes.yaml
-	./mods/ra/rules/world.yaml
-	./mods/ra/rules/defaults.yaml
-	./mods/ra/rules/vehicles.yaml
-	./mods/ra/rules/husks.yaml
-	./mods/ra/rules/structures.yaml
-	./mods/ra/rules/infantry.yaml
-	./mods/ra/rules/civilian.yaml
-	./mods/ra/rules/decoration.yaml
-	./mods/ra/rules/aircraft.yaml
-	./mods/ra/rules/ships.yaml
-	./mods/ra/rules/fakes.yaml
+	ra|rules/misc.yaml
+	ra|rules/ai.yaml
+	ra|rules/player.yaml
+	ra|rules/palettes.yaml
+	ra|rules/world.yaml
+	ra|rules/defaults.yaml
+	ra|rules/vehicles.yaml
+	ra|rules/husks.yaml
+	ra|rules/structures.yaml
+	ra|rules/infantry.yaml
+	ra|rules/civilian.yaml
+	ra|rules/decoration.yaml
+	ra|rules/aircraft.yaml
+	ra|rules/ships.yaml
+	ra|rules/fakes.yaml
 
 Sequences:
-	./mods/ra/sequences/ships.yaml
-	./mods/ra/sequences/vehicles.yaml
-	./mods/ra/sequences/structures.yaml
-	./mods/ra/sequences/infantry.yaml
-	./mods/ra/sequences/aircraft.yaml
-	./mods/ra/sequences/misc.yaml
-	./mods/ra/sequences/decorations.yaml
+	ra|sequences/ships.yaml
+	ra|sequences/vehicles.yaml
+	ra|sequences/structures.yaml
+	ra|sequences/infantry.yaml
+	ra|sequences/aircraft.yaml
+	ra|sequences/misc.yaml
+	ra|sequences/decorations.yaml
 
 TileSets:
-	./mods/ra/tilesets/snow.yaml
-	./mods/ra/tilesets/interior.yaml
-	./mods/ra/tilesets/temperat.yaml
-	./mods/ra/tilesets/desert.yaml
+	ra|tilesets/snow.yaml
+	ra|tilesets/interior.yaml
+	ra|tilesets/temperat.yaml
+	ra|tilesets/desert.yaml
 
 Cursors:
-	./mods/ra/cursors.yaml
+	ra|cursors.yaml
 
 Chrome:
-	./mods/ra/chrome.yaml
+	ra|chrome.yaml
 
 Assemblies:
-	./mods/common/OpenRA.Mods.Common.dll
-	./mods/ra/OpenRA.Mods.RA.dll
-	./mods/cnc/OpenRA.Mods.Cnc.dll
+	common|OpenRA.Mods.Common.dll
+	ra|OpenRA.Mods.RA.dll
+	cnc|OpenRA.Mods.Cnc.dll
 
 ChromeLayout:
-	./mods/ra/chrome/ingame.yaml
-	./mods/ra/chrome/ingame-chat.yaml
-	./mods/ra/chrome/ingame-fmvplayer.yaml
-	./mods/ra/chrome/ingame-info.yaml
-	./mods/ra/chrome/ingame-infoscripterror.yaml
-	./mods/ra/chrome/ingame-infobriefing.yaml
-	./mods/ra/chrome/ingame-infoobjectives.yaml
-	./mods/ra/chrome/ingame-infostats.yaml
-	./mods/ra/chrome/ingame-menu.yaml
-	./mods/ra/chrome/ingame-observer.yaml
-	./mods/ra/chrome/ingame-observerstats.yaml
-	./mods/ra/chrome/ingame-player.yaml
-	./mods/ra/chrome/ingame-perf.yaml
-	./mods/ra/chrome/ingame-debug.yaml
-	./mods/ra/chrome/mainmenu.yaml
-	./mods/ra/chrome/settings.yaml
-	./mods/ra/chrome/credits.yaml
-	./mods/ra/chrome/lobby.yaml
-	./mods/ra/chrome/lobby-mappreview.yaml
-	./mods/ra/chrome/lobby-players.yaml
-	./mods/ra/chrome/lobby-options.yaml
-	./mods/ra/chrome/lobby-music.yaml
-	./mods/ra/chrome/lobby-kickdialogs.yaml
-	./mods/ra/chrome/lobby-globalchat.yaml
-	./mods/ra/chrome/color-picker.yaml
-	./mods/ra/chrome/map-chooser.yaml
-	./mods/ra/chrome/multiplayer.yaml
-	./mods/ra/chrome/multiplayer-browser.yaml
-	./mods/ra/chrome/multiplayer-createserver.yaml
-	./mods/ra/chrome/multiplayer-directconnect.yaml
-	./mods/ra/chrome/multiplayer-globalchat.yaml
-	./mods/ra/chrome/connection.yaml
-	./mods/ra/chrome/replaybrowser.yaml
-	./mods/ra/chrome/dropdowns.yaml
-	./mods/ra/chrome/musicplayer.yaml
-	./mods/ra/chrome/tooltips.yaml
-	./mods/ra/chrome/assetbrowser.yaml
-	./mods/ra/chrome/missionbrowser.yaml
-	./mods/ra/chrome/confirmation-dialogs.yaml
-	./mods/ra/chrome/editor.yaml
+	ra|chrome/ingame.yaml
+	ra|chrome/ingame-chat.yaml
+	ra|chrome/ingame-fmvplayer.yaml
+	ra|chrome/ingame-info.yaml
+	ra|chrome/ingame-infoscripterror.yaml
+	ra|chrome/ingame-infobriefing.yaml
+	ra|chrome/ingame-infoobjectives.yaml
+	ra|chrome/ingame-infostats.yaml
+	ra|chrome/ingame-menu.yaml
+	ra|chrome/ingame-observer.yaml
+	ra|chrome/ingame-observerstats.yaml
+	ra|chrome/ingame-player.yaml
+	ra|chrome/ingame-perf.yaml
+	ra|chrome/ingame-debug.yaml
+	ra|chrome/mainmenu.yaml
+	ra|chrome/settings.yaml
+	ra|chrome/credits.yaml
+	ra|chrome/lobby.yaml
+	ra|chrome/lobby-mappreview.yaml
+	ra|chrome/lobby-players.yaml
+	ra|chrome/lobby-options.yaml
+	ra|chrome/lobby-music.yaml
+	ra|chrome/lobby-kickdialogs.yaml
+	ra|chrome/lobby-globalchat.yaml
+	ra|chrome/color-picker.yaml
+	ra|chrome/map-chooser.yaml
+	ra|chrome/multiplayer.yaml
+	ra|chrome/multiplayer-browser.yaml
+	ra|chrome/multiplayer-createserver.yaml
+	ra|chrome/multiplayer-directconnect.yaml
+	ra|chrome/multiplayer-globalchat.yaml
+	ra|chrome/connection.yaml
+	ra|chrome/replaybrowser.yaml
+	ra|chrome/dropdowns.yaml
+	ra|chrome/musicplayer.yaml
+	ra|chrome/tooltips.yaml
+	ra|chrome/assetbrowser.yaml
+	ra|chrome/missionbrowser.yaml
+	ra|chrome/confirmation-dialogs.yaml
+	ra|chrome/editor.yaml
 
 Weapons:
-	./mods/ra/weapons/explosions.yaml
-	./mods/ra/weapons/largecaliber.yaml
-	./mods/ra/weapons/missiles.yaml
-	./mods/ra/weapons/other.yaml
-	./mods/ra/weapons/smallcaliber.yaml
-	./mods/ra/weapons/superweapons.yaml
+	ra|weapons/explosions.yaml
+	ra|weapons/largecaliber.yaml
+	ra|weapons/missiles.yaml
+	ra|weapons/other.yaml
+	ra|weapons/smallcaliber.yaml
+	ra|weapons/superweapons.yaml
 	
 Voices:
-	./mods/ra/audio/voices.yaml
+	ra|audio/voices.yaml
 
 Notifications:
-	./mods/ra/audio/notifications.yaml
+	ra|audio/notifications.yaml
 
 Music:
-	./mods/ra/audio/music.yaml
+	ra|audio/music.yaml
 
 Translations:
-	./mods/ra/languages/english.yaml
+	ra|languages/english.yaml
 
 LoadScreen: LogoStripeLoadScreen
-	Image: ./mods/ra/uibits/loadscreen.png
+	Image: ra|uibits/loadscreen.png
 	Text: Filling Crates..., Charging Capacitors..., Reticulating Splines..., Planting Trees..., Building Bridges..., Aging Empires..., Compiling EVA..., Constructing Pylons..., Activating Skynet..., Splitting Atoms...
 
 ContentInstaller:
@@ -173,37 +175,37 @@ LobbyDefaults:
 	TechLevel: Unrestricted
 
 ChromeMetrics:
-	./mods/common/metrics.yaml
-	./mods/ra/metrics.yaml
+	common|metrics.yaml
+	ra|metrics.yaml
 
 Fonts:
 	Regular:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:14
 	Bold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:./mods/ra/ZoodRangmah.ttf
+		Font: ra|ZoodRangmah.ttf
 		Size:48
 	MediumBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:18
 	BigBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:24
 	Small:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:12
 	Tiny:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:10
 
 Missions:
-	./mods/ra/missions.yaml
+	ra|missions.yaml
 
 MapGrid:
 	TileSize: 24,24

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -33,8 +33,8 @@ Packages:
 	ra|uibits
 
 MapFolders:
-	./mods/ra/maps@System
-	~^maps/ra/{DEV_VERSION}@User
+	ra|maps: System
+	~^maps/ra/{DEV_VERSION}: User
 
 Rules:
 	ra|rules/misc.yaml

--- a/mods/ts/audio/speech-generic.yaml
+++ b/mods/ts/audio/speech-generic.yaml
@@ -1,7 +1,7 @@
 Speech:
 	Prefixes:
-		gdi: speech01.mix:
-		nod: speech02.mix:
+		gdi: speech-gdi|
+		nod: speech-nod|
 	Notifications:
 		AirUnitLost: 00-i074
 		AirstrikeReady: 00-n160

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -32,13 +32,13 @@ Packages:
 	isosnow.mix
 	isotemp.mix
 	local.mix
-	sidec01.mix
-	sidec02.mix
+	sidec01.mix: sidebar-gdi
+	sidec02.mix: sidebar-nod
 	sno.mix
 	snow.mix
 	sounds.mix
-	speech01.mix # EVA
-	speech02.mix # Cabal
+	speech01.mix: speech-gdi
+	speech02.mix: speech-nod
 	tem.mix
 	temperat.mix
 # Firestorm

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -10,7 +10,12 @@ RequiresMods:
 Packages:
 	~^Content/ts
 	.
-	./mods/ts
+	$ts: ts
+	./mods/common: common
+	$ra: ra
+	$cnc: cnc
+	$d2k: d2k
+
 # Tiberian Sun
 	~scores.mix
 	~sidenc01.mix
@@ -50,65 +55,65 @@ Packages:
 	~e01vox01.mix
 	~e01vox02.mix
 	~ecache01.mix
-	./mods/ts/bits
-	./mods/ts/uibits
+	ts|bits
+	ts|uibits
 
 MapFolders:
 	./mods/ts/maps@System
 	~^maps/ts/{DEV_VERSION}@User
 
 Rules:
-	./mods/ts/rules/ai.yaml
-	./mods/ts/rules/misc.yaml
-	./mods/ts/rules/player.yaml
-	./mods/ts/rules/world.yaml
-	./mods/ts/rules/palettes.yaml
-	./mods/ts/rules/defaults.yaml
-	./mods/ts/rules/aircraft.yaml
-	./mods/ts/rules/husks.yaml
-	./mods/ts/rules/civilian-infantry.yaml
-	./mods/ts/rules/civilian-structures.yaml
-	./mods/ts/rules/civilian-vehicles.yaml
-	./mods/ts/rules/gdi-infantry.yaml
-	./mods/ts/rules/gdi-structures.yaml
-	./mods/ts/rules/gdi-support.yaml
-	./mods/ts/rules/gdi-vehicles.yaml
-	./mods/ts/rules/nod-infantry.yaml
-	./mods/ts/rules/nod-structures.yaml
-	./mods/ts/rules/nod-support.yaml
-	./mods/ts/rules/nod-vehicles.yaml
-	./mods/ts/rules/shared-infantry.yaml
-	./mods/ts/rules/shared-structures.yaml
-	./mods/ts/rules/shared-support.yaml
-	./mods/ts/rules/shared-vehicles.yaml
-	./mods/ts/rules/trees.yaml
+	ts|rules/ai.yaml
+	ts|rules/misc.yaml
+	ts|rules/player.yaml
+	ts|rules/world.yaml
+	ts|rules/palettes.yaml
+	ts|rules/defaults.yaml
+	ts|rules/aircraft.yaml
+	ts|rules/husks.yaml
+	ts|rules/civilian-infantry.yaml
+	ts|rules/civilian-structures.yaml
+	ts|rules/civilian-vehicles.yaml
+	ts|rules/gdi-infantry.yaml
+	ts|rules/gdi-structures.yaml
+	ts|rules/gdi-support.yaml
+	ts|rules/gdi-vehicles.yaml
+	ts|rules/nod-infantry.yaml
+	ts|rules/nod-structures.yaml
+	ts|rules/nod-support.yaml
+	ts|rules/nod-vehicles.yaml
+	ts|rules/shared-infantry.yaml
+	ts|rules/shared-structures.yaml
+	ts|rules/shared-support.yaml
+	ts|rules/shared-vehicles.yaml
+	ts|rules/trees.yaml
 
 Weapons:
-	./mods/ts/weapons/bombsandgrenades.yaml
-	./mods/ts/weapons/energyweapons.yaml
-	./mods/ts/weapons/explosions.yaml
-	./mods/ts/weapons/healweapons.yaml
-	./mods/ts/weapons/largeguns.yaml
-	./mods/ts/weapons/missiles.yaml
-	./mods/ts/weapons/otherweapons.yaml
-	./mods/ts/weapons/smallguns.yaml
-	./mods/ts/weapons/superweapons.yaml
+	ts|weapons/bombsandgrenades.yaml
+	ts|weapons/energyweapons.yaml
+	ts|weapons/explosions.yaml
+	ts|weapons/healweapons.yaml
+	ts|weapons/largeguns.yaml
+	ts|weapons/missiles.yaml
+	ts|weapons/otherweapons.yaml
+	ts|weapons/smallguns.yaml
+	ts|weapons/superweapons.yaml
 
 Sequences:
-	./mods/ts/sequences/aircraft.yaml
-	./mods/ts/sequences/infantry.yaml
-	./mods/ts/sequences/misc.yaml
-	./mods/ts/sequences/civilian.yaml
-	./mods/ts/sequences/structures.yaml
-	./mods/ts/sequences/vehicles.yaml
-	./mods/ts/sequences/trees.yaml
+	ts|sequences/aircraft.yaml
+	ts|sequences/infantry.yaml
+	ts|sequences/misc.yaml
+	ts|sequences/civilian.yaml
+	ts|sequences/structures.yaml
+	ts|sequences/vehicles.yaml
+	ts|sequences/trees.yaml
 
 VoxelSequences:
-	./mods/ts/sequences/voxels.yaml
+	ts|sequences/voxels.yaml
 
 TileSets:
-	./mods/ts/tilesets/temperate.yaml
-	./mods/ts/tilesets/snow.yaml
+	ts|tilesets/temperate.yaml
+	ts|tilesets/snow.yaml
 
 MapGrid:
 	TileSize: 48,24
@@ -118,75 +123,75 @@ MapGrid:
 	SubCellDefaultIndex: 2
 
 Cursors:
-	./mods/ts/cursors.yaml
+	ts|cursors.yaml
 
 Chrome:
-	./mods/ts/chrome.yaml
+	ts|chrome.yaml
 
 Assemblies:
-	./mods/common/OpenRA.Mods.Common.dll
-	./mods/ra/OpenRA.Mods.RA.dll
-	./mods/cnc/OpenRA.Mods.Cnc.dll
-	./mods/ts/OpenRA.Mods.TS.dll
+	common|OpenRA.Mods.Common.dll
+	ra|OpenRA.Mods.RA.dll
+	cnc|OpenRA.Mods.Cnc.dll
+	ts|OpenRA.Mods.TS.dll
 
 ChromeLayout:
-	./mods/ra/chrome/ingame.yaml
-	./mods/ra/chrome/ingame-chat.yaml
-	./mods/ra/chrome/ingame-fmvplayer.yaml
-	./mods/ra/chrome/ingame-menu.yaml
-	./mods/ts/chrome/ingame-info.yaml
-	./mods/ra/chrome/ingame-infoscripterror.yaml
-	./mods/ra/chrome/ingame-infobriefing.yaml
-	./mods/ra/chrome/ingame-infoobjectives.yaml
-	./mods/ra/chrome/ingame-infostats.yaml
-	d2k:chrome/ingame-observer.yaml
-	./mods/ts/chrome/ingame-observerstats.yaml
-	./mods/ts/chrome/ingame-player.yaml
-	./mods/ra/chrome/ingame-perf.yaml
-	./mods/ts/chrome/ingame-debug.yaml
-	./mods/ra/chrome/mainmenu.yaml
-	./mods/ra/chrome/settings.yaml
-	./mods/ra/chrome/credits.yaml
-	./mods/ra/chrome/lobby.yaml
-	./mods/ra/chrome/lobby-mappreview.yaml
-	./mods/ra/chrome/lobby-players.yaml
-	./mods/ra/chrome/lobby-options.yaml
-	./mods/ra/chrome/lobby-music.yaml
-	./mods/ra/chrome/lobby-kickdialogs.yaml
-	./mods/ra/chrome/lobby-globalchat.yaml
-	./mods/ts/chrome/color-picker.yaml
-	./mods/ra/chrome/map-chooser.yaml
-	./mods/ra/chrome/multiplayer.yaml
-	./mods/ra/chrome/multiplayer-browser.yaml
-	./mods/ra/chrome/multiplayer-createserver.yaml
-	./mods/ra/chrome/multiplayer-directconnect.yaml
-	./mods/ra/chrome/multiplayer-globalchat.yaml
-	./mods/ra/chrome/connection.yaml
-	./mods/ra/chrome/replaybrowser.yaml
-	./mods/ts/chrome/dropdowns.yaml
-	./mods/ra/chrome/musicplayer.yaml
-	./mods/ra/chrome/tooltips.yaml
-	./mods/ra/chrome/assetbrowser.yaml
-	./mods/ra/chrome/missionbrowser.yaml
-	./mods/ra/chrome/confirmation-dialogs.yaml
-	./mods/ra/chrome/editor.yaml
+	ra|chrome/ingame.yaml
+	ra|chrome/ingame-chat.yaml
+	ra|chrome/ingame-fmvplayer.yaml
+	ra|chrome/ingame-menu.yaml
+	ts|chrome/ingame-info.yaml
+	ra|chrome/ingame-infoscripterror.yaml
+	ra|chrome/ingame-infobriefing.yaml
+	ra|chrome/ingame-infoobjectives.yaml
+	ra|chrome/ingame-infostats.yaml
+	d2k|chrome/ingame-observer.yaml
+	ts|chrome/ingame-observerstats.yaml
+	ts|chrome/ingame-player.yaml
+	ra|chrome/ingame-perf.yaml
+	ts|chrome/ingame-debug.yaml
+	ra|chrome/mainmenu.yaml
+	ra|chrome/settings.yaml
+	ra|chrome/credits.yaml
+	ra|chrome/lobby.yaml
+	ra|chrome/lobby-mappreview.yaml
+	ra|chrome/lobby-players.yaml
+	ra|chrome/lobby-options.yaml
+	ra|chrome/lobby-music.yaml
+	ra|chrome/lobby-kickdialogs.yaml
+	ra|chrome/lobby-globalchat.yaml
+	ts|chrome/color-picker.yaml
+	ra|chrome/map-chooser.yaml
+	ra|chrome/multiplayer.yaml
+	ra|chrome/multiplayer-browser.yaml
+	ra|chrome/multiplayer-createserver.yaml
+	ra|chrome/multiplayer-directconnect.yaml
+	ra|chrome/multiplayer-globalchat.yaml
+	ra|chrome/connection.yaml
+	ra|chrome/replaybrowser.yaml
+	ts|chrome/dropdowns.yaml
+	ra|chrome/musicplayer.yaml
+	ra|chrome/tooltips.yaml
+	ra|chrome/assetbrowser.yaml
+	ra|chrome/missionbrowser.yaml
+	ra|chrome/confirmation-dialogs.yaml
+	ra|chrome/editor.yaml
 
 Voices:
-	./mods/ts/audio/voices.yaml
+	ts|audio/voices.yaml
 
 Notifications:
-	./mods/ts/audio/speech-generic.yaml
-	./mods/ts/audio/speech-singleplayer.yaml
-	./mods/ts/audio/sounds-generic.yaml
+	ts|audio/speech-generic.yaml
+	ts|audio/speech-singleplayer.yaml
+	ts|audio/sounds-generic.yaml
 
 Music:
-	./mods/ts/audio/music.yaml
+	ts|audio/music.yaml
 
 Translations:
-	./mods/ts/languages/english.yaml
+	ts|languages/english.yaml
 
 LoadScreen: LogoStripeLoadScreen
-	Image: ./mods/ts/uibits/loadscreen.png
+	Image: ts|uibits/loadscreen.png
 	Text: Updating EVA installation..., Changing perspective...
 
 ContentInstaller:
@@ -218,33 +223,33 @@ LobbyDefaults:
 	Fog: true
 
 ChromeMetrics:
-	./mods/common/metrics.yaml
-	./mods/ts/metrics.yaml
+	common|metrics.yaml
+	ts|metrics.yaml
 
 Fonts:
 	Regular:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:14
 	Bold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:14
 	Title:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:32
 	MediumBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:18
 	BigBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:24
 	Small:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:12
 	Tiny:
-		Font:./mods/common/FreeSans.ttf
+		Font: common|FreeSans.ttf
 		Size:10
 	TinyBold:
-		Font:./mods/common/FreeSansBold.ttf
+		Font: common|FreeSansBold.ttf
 		Size:10
 
 SupportsMapsFrom: ts

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -59,8 +59,8 @@ Packages:
 	ts|uibits
 
 MapFolders:
-	./mods/ts/maps@System
-	~^maps/ts/{DEV_VERSION}@User
+	ts|maps: System
+	~^maps/ts/{DEV_VERSION}: User
 
 Rules:
 	ts|rules/ai.yaml

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -43,7 +43,7 @@
 		Filename: anim.pal
 	PaletteFromFile@sidebar:
 		Name: sidebar
-		Filename: sidec02.mix:sidebar.pal
+		Filename: sidebar-nod|sidebar.pal
 	PaletteFromPaletteWithAlpha@clock:
 		Name: iconclock
 		BasePalette: sidebar

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -66,7 +66,7 @@ e1.gdi:
 		ShadowStart: 190
 	die6: electro
 		Length: *
-	icon: sidec01.mix:e1icon
+	icon: sidebar-gdi|e1icon
 
 e1.nod:
 	Defaults: e1
@@ -136,7 +136,7 @@ e1.nod:
 		ShadowStart: 190
 	die6: electro
 		Length: *
-	icon: sidec02.mix:e1icon
+	icon: sidebar-nod|e1icon
 
 e2:
 	Defaults:
@@ -477,7 +477,7 @@ engineer.gdi:
 		ShadowStart: 190
 	die6: electro
 		Length: *
-	icon: sidec01.mix:engnicon
+	icon: sidebar-gdi|engnicon
 
 engineer.nod:
 	Defaults: engineer
@@ -539,7 +539,7 @@ engineer.nod:
 		ShadowStart: 190
 	die6: electro
 		Length: *
-	icon: sidec02.mix:engnicon
+	icon: sidebar-nod|engnicon
 
 umagon:
 	Defaults:

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -912,7 +912,7 @@ napuls.gdi:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec01.mix:empicon
+	icon: sidebar-gdi|empicon
 		Offset: 0, 0
 		UseTilesetCode: false
 
@@ -940,7 +940,7 @@ napuls.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec02.mix:empicon
+	icon: sidebar-nod|empicon
 		Offset: 0, 0
 		UseTilesetCode: false
 
@@ -1190,7 +1190,7 @@ proc.gdi:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec01.mix:reficon
+	icon: sidebar-gdi|reficon
 		Offset: 0, 0
 		UseTilesetCode: false
 
@@ -1232,7 +1232,7 @@ proc.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec02.mix:reficon
+	icon: sidebar-nod|reficon
 		Offset: 0, 0
 		UseTilesetCode: false
 
@@ -1323,7 +1323,7 @@ gasilo.gdi:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec01.mix:siloicon
+	icon: sidebar-gdi|siloicon
 		Offset: 0, 0
 		UseTilesetCode: false
 
@@ -1367,7 +1367,7 @@ gasilo.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec02.mix:siloicon
+	icon: sidebar-nod|siloicon
 		Offset: 0, 0
 		UseTilesetCode: false
 
@@ -1431,7 +1431,7 @@ gadept.gdi:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec01.mix:fixicon
+	icon: sidebar-gdi|fixicon
 		Offset: 0, 0
 		UseTilesetCode: false
 
@@ -1495,7 +1495,7 @@ gadept.nod:
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
-	icon: sidec02.mix:fixicon
+	icon: sidebar-nod|fixicon
 		Offset: 76, 66
 		UseTilesetCode: false
 

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -2,13 +2,13 @@ mcv.gdi:
 	emp-overlay: emp_fx01
 		Length: *
 		BlendMode: Additive
-	icon: sidec01.mix:mcvicon
+	icon: sidebar-gdi|mcvicon
 
 mcv.nod:
 	emp-overlay: emp_fx01
 		Length: *
 		BlendMode: Additive
-	icon: sidec02.mix:mcvicon
+	icon: sidebar-nod|mcvicon
 
 apc:
 	emp-overlay: emp_fx01
@@ -22,7 +22,7 @@ harv.gdi:
 		BlendMode: Additive
 	harvest: harvestr
 		Length: *
-	icon: sidec01.mix:harvicon
+	icon: sidebar-gdi|harvicon
 
 harv.nod:
 	emp-overlay: emp_fx01
@@ -30,7 +30,7 @@ harv.nod:
 		BlendMode: Additive
 	harvest: harvestr
 		Length: *
-	icon: sidec02.mix:harvicon
+	icon: sidebar-nod|harvicon
 
 hvr:
 	emp-overlay: emp_fx01
@@ -56,7 +56,7 @@ lpst.gdi:
 	emp-overlay: emp_fx01
 		Length: *
 		BlendMode: Additive
-	icon: sidec01.mix:lpsticon
+	icon: sidebar-gdi|lpsticon
 
 lpst.nod:
 	idle: gadpsa
@@ -69,7 +69,7 @@ lpst.nod:
 	emp-overlay: emp_fx01
 		Length: *
 		BlendMode: Additive
-	icon: sidec02.mix:lpsticon
+	icon: sidebar-nod|lpsticon
 
 repair:
 	emp-overlay: emp_fx01


### PR DESCRIPTION
This unifies our handling of mod/package specific files with common code in the virtual file system.

There are three new/changed syntax elements for use in yaml:
1. `explicit-name|file` specifies that `file` should be loaded from the package that has been explicitly named `explicit-name`.
2. `package: explicit-name` in the `Packages:` section of `mod.yaml` defines an explicitly named package that can be referenced using the `|` syntax.
3. `$mod` in the `Packages:` section of `mod.yaml` defines that the mod named `mod` should be mounted as a package.  Mods may be loaded from either the system or support dirs, and will eventually support both unpacked and oramods.

As a compromise based on the earlier discussions/arguments I have changed the explicit package operator from `:` to `|` and reverted the change for `MapFolders`.

This has the side-effect of making all our default mods portable between the system and support directories.

Supersedes #10487.
