### PR TITLE
Loads mod assemblies via the virtual filesystem.

### DIFF
--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -41,11 +41,12 @@ namespace OpenRA
 		{
 			Languages = new string[0];
 			Manifest = new Manifest(mod);
+			ModFiles.LoadFromManifest(Manifest);
 
 			// Allow mods to load types from the core Game assembly, and any additional assemblies they specify.
-			var assemblies =
-				new[] { typeof(Game).Assembly }.Concat(
-					Manifest.Assemblies.Select(path => Assembly.LoadFrom(Platform.ResolvePath(path))));
+			var assemblies = new[] { typeof(Game).Assembly }
+					.Concat(Manifest.Assemblies.Select(path => Assembly.Load(ModFiles.Open(path).ReadAllBytes())))
+					.ToList();
 			ObjectCreator = new ObjectCreator(assemblies);
 			Manifest.LoadCustomData(ObjectCreator);
 
@@ -55,8 +56,6 @@ namespace OpenRA
 				LoadScreen.Init(Manifest, Manifest.LoadScreen.ToDictionary(my => my.Value));
 				LoadScreen.Display();
 			}
-
-			ModFiles.LoadFromManifest(Manifest);
 
 			WidgetLoader = new WidgetLoader(this);
 			RulesetCache = new RulesetCache(this);

--- a/mods/all/mod.yaml
+++ b/mods/all/mod.yaml
@@ -7,7 +7,7 @@ Metadata:
 
 RequiresMods:
 
-Folders:
+Packages:
 	.
 
 Cursors:
@@ -17,7 +17,7 @@ Chrome:
 Assemblies:
 	./mods/common/OpenRA.Mods.Common.dll
 	./mods/ra/OpenRA.Mods.RA.dll
-	d2k:OpenRA.Mods.D2k.dll
+	./mods/d2k/OpenRA.Mods.D2k.dll
 	./mods/cnc/OpenRA.Mods.Cnc.dll
 	./mods/ts/OpenRA.Mods.TS.dll
 


### PR DESCRIPTION
Prerequisite to #10703 and oramods.

Unfortunately this delays the time to first loadscreen render, but I don't see any alternatives.
