### PR TITLE
Fix mobile checks

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -232,6 +232,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (otherActor == ignoreActor)
 				return false;
 
+			// If self is null, we don't have a real actor - we're just checking what would happen theoretically.
+			// In such a scenario - we'll just assume any other actor in the cell will block us by default.
+			// If we have a real actor, we can then perform the extra checks that allow us to avoid being blocked.
+			if (self == null)
+				return true;
+
 			// If the check allows: we are not blocked by allied units moving in our direction.
 			if (!check.HasCellCondition(CellConditions.BlockedByMovers) &&
 				self.Owner.Stances[otherActor.Owner] == Stance.Ally &&


### PR DESCRIPTION
Follow up to #10696 to allow us to do mobility checks without a real actor. SpawnMPUnits needs this so we do need the check after all (otherwise the game crashes) - this is the cleanest way I can see to do it.
