### PR TITLE
Unify static mod metadata collections.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -293,7 +293,7 @@ namespace OpenRA
 
 		public static bool IsModInstalled(string modId)
 		{
-			return Manifest.AllMods[modId].RequiresMods.All(IsModInstalled);
+			return ModMetadata.AllMods[modId].RequiresMods.All(IsModInstalled);
 		}
 
 		public static bool IsModInstalled(KeyValuePair<string, string> mod)

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -124,7 +124,7 @@ namespace OpenRA
 		{
 			// Resolve mod package paths.
 			if (ModMetadata.AllMods.ContainsKey(package))
-				package = ModMetadata.CandidateModPaths[package];
+				package = ModMetadata.AllMods[package].Package.Name;
 
 			return ResolvePath(Path.Combine(package, target));
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallModLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallModLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var panel = widget.Get("INSTALL_MOD_PANEL");
 
-			var mods = Manifest.AllMods[modId].RequiresMods.Where(m => !Game.IsModInstalled(m)).Select(m => "{0} ({1})".F(m.Key, m.Value));
+			var mods = ModMetadata.AllMods[modId].RequiresMods.Where(m => !Game.IsModInstalled(m)).Select(m => "{0} ({1})".F(m.Key, m.Value));
 			var text = string.Join(", ", mods);
 			panel.Get<LabelWidget>("MOD_LIST").Text = text;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -82,17 +82,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				try
 				{
-					using (var preview = new Bitmap(Platform.ResolvePath(ModMetadata.CandidateModPaths[mod.Id], "preview.png")))
-						if (preview.Width == 296 && preview.Height == 196)
-							previews.Add(mod.Id, sheetBuilder.Add(preview));
+					using (var stream = ModMetadata.AllMods[mod.Id].Package.GetStream("preview.png"))
+						using (var preview = new Bitmap(stream))
+							if (preview.Width == 296 && preview.Height == 196)
+								previews.Add(mod.Id, sheetBuilder.Add(preview));
 				}
 				catch (Exception) { }
 
 				try
 				{
-					using (var logo = new Bitmap(Platform.ResolvePath(ModMetadata.CandidateModPaths[mod.Id], "logo.png")))
-						if (logo.Width == 96 && logo.Height == 96)
-							logos.Add(mod.Id, sheetBuilder.Add(logo));
+					using (var stream = ModMetadata.AllMods[mod.Id].Package.GetStream("logo.png"))
+						using (var logo = new Bitmap(stream))
+							if (logo.Width == 96 && logo.Height == 96)
+								logos.Add(mod.Id, sheetBuilder.Add(logo));
 				}
 				catch (Exception) { }
 			}

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -62,7 +62,7 @@ Chrome:
 Assemblies:
 	./mods/common/OpenRA.Mods.Common.dll
 	./mods/cnc/OpenRA.Mods.Cnc.dll
-	d2k:OpenRA.Mods.D2k.dll
+	./mods/d2k/OpenRA.Mods.D2k.dll
 
 ChromeLayout:
 	d2k:chrome/ingame.yaml


### PR DESCRIPTION
This merges the static Manifest collection into the static ModMetadata collection and replaces the path reference with a Package reference.

This is one of the last pieces of plumbing for supporting oramod packages: once the rest of the engine is using the virtual filesystem properly (#10704, #10706, #10703) it's as simple as adding an `else` case to `ModMetadata.ValidateMods` to return the oramod container instead of a folder.
