### PR TITLE
Re-enabled All Packages which seems to be fast enough now.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -22,7 +22,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class AssetBrowserLogic : ChromeLogic
 	{
-		static string[] allowedExtensions;
+		readonly string[] allowedExtensions;
+		readonly IEnumerable<IReadOnlyPackage> acceptablePackages;
 
 		readonly World world;
 
@@ -216,6 +217,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			else
 				allowedExtensions = new string[0];
 
+			acceptablePackages = Game.ModData.ModFiles.MountedPackages.Where(p =>
+				p.Contents.Any(c => allowedExtensions.Contains(Path.GetExtension(c).ToLowerInvariant())));
+
 			assetList = panel.Get<ScrollPanelWidget>("ASSET_LIST");
 			template = panel.Get<ScrollItemWidget>("ASSET_TEMPLATE");
 			PopulateAssetList();
@@ -342,7 +346,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			var sources = new[] { (IReadOnlyPackage)null }.Concat(Game.ModData.ModFiles.MountedPackages);
+			var sources = new[] { (IReadOnlyPackage)null }.Concat(acceptablePackages);
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 280, sources, setupItem);
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -50,7 +50,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.world = world;
 
 			panel = widget;
-			assetSource = Game.ModData.ModFiles.MountedPackages.First();
 
 			var ticker = panel.GetOrNull<LogicTickerWidget>("ANIMATION_TICKER");
 			if (ticker != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -343,9 +343,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			// TODO: Re-enable "All Packages" once list generation is done in a background thread
-			// var sources = new[] { (IPackage)null }.Concat(GlobalFileSystem.MountedFolders);
-			var sources = Game.ModData.ModFiles.MountedPackages;
+			var sources = new[] { (IReadOnlyPackage)null }.Concat(Game.ModData.ModFiles.MountedPackages);
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 280, sources, setupItem);
 			return true;
 		}
@@ -355,14 +353,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			assetList.RemoveChildren();
 			availableShps.Clear();
 
-			// TODO: This is too slow to run in the main thread
-			// var files = AssetSource != null ? AssetSource.AllFileNames() :
-			// GlobalFileSystem.MountedFolders.SelectMany(f => f.AllFileNames());
-			if (assetSource == null)
-				return;
-
-			var files = assetSource.Contents.OrderBy(s => s);
-			foreach (var file in files)
+			var files = assetSource != null ? assetSource.Contents : Game.ModData.ModFiles.MountedPackages.SelectMany(f => f.Contents).Distinct();
+			foreach (var file in files.OrderBy(s => s))
 			{
 				if (allowedExtensions.Any(ext => file.EndsWith(ext, true, CultureInfo.InvariantCulture)))
 				{


### PR DESCRIPTION
It pops up instantly even for Red Alert 2. Not sure what kind of performance problems we were suffering in the past, they seem to be gone now. This is way more practical if you are setting up sequences with sprites scattered around in tileset specific MIX files.
