### PR TITLE
Do not crash during importing a TS map if a waypoint ID isn't an integer.

### DIFF
--- a/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
@@ -347,7 +347,8 @@ namespace OpenRA.Mods.TS.UtilityCommands
 				var dy = rx + ry - fullSize.X - 1;
 				var cell = new MPos(dx / 2, dy).ToCPos(map);
 
-				var ar = new ActorReference(int.Parse(kv.Key) <= 7 ? "mpspawn" : "waypoint");
+				int wpindex;
+				var ar = new ActorReference((!int.TryParse(kv.Key, out wpindex) || wpindex > 7) ? "waypoint" : "mpspawn");
 				ar.Add(new LocationInit(cell));
 				ar.Add(new OwnerInit("Neutral"));
 


### PR DESCRIPTION
While FinalAlert itself does not insert waypoints with IDs having alpabetical characters, mappers could manually place waypoints where the IDs could contain such.
