### PR TITLE
Fixed domain index updates for bridges

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -98,13 +98,15 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						var neighborDomain = domains[n];
 						if (CanTraverseTile(world, n))
+						{
 							neighborDomains.Add(neighborDomain);
 
-						// Set ourselves to the first non-dirty neighbor we find.
-						if (!found)
-						{
-							domains[cell] = neighborDomain;
-							found = true;
+							// Set ourselves to the first non-dirty neighbor we find.
+							if (!found)
+							{
+								domains[cell] = neighborDomain;
+								found = true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
When the bridge damage state changes, the domain cells of the bridge
would pull in the first neighbors domain which may be untraversable.
This change only pulls the domain of traversable neighbor tiles.

Fixes #7539.
Fixes #6684.
