### PR TITLE
Fix the misleading wording of the confirm dialogs

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -317,7 +317,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (after != null)
 						after(newUid);
 				},
-				confirmText: "Delete");
+				confirmText: "Delete",
+				onCancel: () => { });
 		}
 
 		void DeleteAllMaps(string[] maps, Action<string> after)
@@ -331,7 +332,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (after != null)
 						after(WidgetUtils.ChooseInitialMap(null));
 				},
-				confirmText: "Delete");
+				confirmText: "Delete",
+				onCancel: () => { });
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -410,7 +410,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (after != null)
 							after.Invoke();
 					},
-					confirmText: "Delete");
+					confirmText: "Delete",
+					onCancel: () => { });
 			};
 
 			{
@@ -450,7 +451,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							if (selectedReplay == null)
 								SelectFirstVisibleReplay();
 						},
-						confirmText: "Delete All");
+						confirmText: "Delete All",
+						onCancel: () => { });
 				};
 			}
 		}

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -162,7 +162,7 @@ Container@CONFIRM_PROMPT:
 			Y: 89
 			Width: 140
 			Height: 35
-			Text: Abort
+			Text: Confirm
 		Button@OTHER_BUTTON:
 			Key: r
 			X: 210

--- a/mods/ra/chrome/confirmation-dialogs.yaml
+++ b/mods/ra/chrome/confirmation-dialogs.yaml
@@ -21,7 +21,7 @@ Background@CONFIRM_PROMPT:
 			Y: PARENT_BOTTOM - 45
 			Width: 160
 			Height: 25
-			Text: Abort
+			Text: Confirm
 			Font: Bold
 			Key: return
 		Button@OTHER_BUTTON:


### PR DESCRIPTION
Noticeable when leaving the map editor. Previously it asked you "Exit and lose all unsaved changes" and gave you `[Cancel]` and `[Abort]` which might be confusing (which one is the correct button?).
