### PR TITLE
Fix Missile projectile crashing with NRE if it has no Image

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -841,6 +841,9 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.ContrailLength > 0)
 				yield return contrail;
 
+			if (anim == null)
+				yield break;
+
 			var world = args.SourceActor.World;
 			if (!world.FogObscures(pos))
 			{


### PR DESCRIPTION
Closes #10739.
