### PR TITLE
Fix max view distance check.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1151,7 +1151,7 @@ namespace OpenRA
 			if (maxRange < minRange)
 				throw new ArgumentOutOfRangeException("maxRange", "Maximum range is less than the minimum range.");
 
-			if (maxRange > TilesByDistance.Length)
+			if (maxRange >= TilesByDistance.Length)
 				throw new ArgumentOutOfRangeException("maxRange", "The requested range ({0}) exceeds the maximum allowed ({1})".F(maxRange, MaxTilesInCircleRange));
 
 			Func<CPos, bool> valid = Contains;


### PR DESCRIPTION
A range of 51 wasn't stopped by the original statement.  It triggered an out of bounds exception from TilesByDistance a few lines later.

This is my first pull request.  Let me know if I did something wrong.
