### PR TITLE
Added missing Requires<AircraftInfo> to FallsToEarthInfo.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Causes aircraft husks that are spawned in the air to crash to the ground.")]
-	public class FallsToEarthInfo : ITraitInfo, IRulesetLoaded
+	public class FallsToEarthInfo : ITraitInfo, IRulesetLoaded, Requires<AircraftInfo>
 	{
 		[WeaponReference]
 		public readonly string Explosion = "UnitExplode";


### PR DESCRIPTION
I hope this fixes https://github.com/OpenRA/OpenRA/issues/10743, but either way the requires is necessary.
