### PR TITLE
Add an explicit YamlException to ArmamentInfo

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -80,7 +80,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			WeaponInfo = rules.Weapons[Weapon.ToLowerInvariant()];
+			WeaponInfo weaponInfo;
+
+			var weaponToLower = Weapon.ToLowerInvariant();
+			if (!rules.Weapons.TryGetValue(weaponToLower, out weaponInfo))
+				throw new YamlException("Weapons Ruleset does not contain an entry '{0}'".F(weaponToLower));
+
+			WeaponInfo = weaponInfo;
 			ModifiedRange = new WDist(Util.ApplyPercentageModifiers(
 				WeaponInfo.Range.Length,
 				ai.TraitInfos<IRangeModifierInfo>().Select(m => m.GetRangeModifierDefault())));


### PR DESCRIPTION
Throw a more descriptive exception when the current weapon ruleset
doesn't contain an entry for the referenced weapon.

``` yaml
Armament@pew:
    Weapon: PewPew
    ...
```

```
Exception of type `OpenRA.YamlException`: Actor type e1: Weapons Ruleset does not contain the entry 'pewpew'
  at OpenRA.Ruleset..ctor (IDictionary`2 actors, IDictionary`2 weapons, IDictionary`2 voices, IDictionary`2 notifications, IDictionary`2 music, IDictionary`2 tileSets, IDictionary`2 sequences) [0x000cd] in /Users/thill/projects/play/openra/OpenRA.Game//GameRules/Ruleset.cs:56
  at OpenRA.RulesetCache.Load (OpenRA.Map map) [0x002e7] in /Users/thill/projects/play/openra/OpenRA.Game//GameRules/RulesetCache.cs:90
  at OpenRA.ModData.<ModData>m__3 () [0x00007] in /Users/thill/projects/play/openra/OpenRA.Game//ModData.cs:77
  at System.Lazy`1[T].CreateValue () <0x17957a0 + 0x0018f> in <filename unknown>:0
```
