### PR TITLE
Gave veins an orange minimap color

### DIFF
--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -58,7 +58,7 @@ Terrain:
 		RestrictPlayerColor: true
 	TerrainType@Veins:
 		Type: Veins
-		Color: 000000
+		Color: CD6600
 		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree

--- a/mods/ts/tilesets/temperate.yaml
+++ b/mods/ts/tilesets/temperate.yaml
@@ -58,7 +58,7 @@ Terrain:
 		RestrictPlayerColor: true
 	TerrainType@Veins:
 		Type: Veins
-		Color: 000000
+		Color: CD6600
 		TargetTypes: Ground
 	TerrainType@Tree:
 		Type: Tree


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/10407. The original black is confusing. I chose DarkOrange3 which fits to the terrain sprites.
