### PR TITLE
Do not render trails under fog by default.

### DIFF
--- a/OpenRA.Game/Effects/SpriteEffect.cs
+++ b/OpenRA.Game/Effects/SpriteEffect.cs
@@ -15,16 +15,20 @@ namespace OpenRA.Effects
 {
 	public class SpriteEffect : IEffect
 	{
+		readonly World world;
 		readonly string palette;
 		readonly Animation anim;
 		readonly WPos pos;
+		readonly bool visibleThroughFog;
 		readonly bool scaleSizeWithZoom;
 
-		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette, bool scaleSizeWithZoom = false)
+		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette, bool visibleThroughFog = false, bool scaleSizeWithZoom = false)
 		{
+			this.world = world;
 			this.pos = pos;
 			this.palette = palette;
 			this.scaleSizeWithZoom = scaleSizeWithZoom;
+			this.visibleThroughFog = visibleThroughFog;
 			anim = new Animation(world, image);
 			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
 		}
@@ -36,6 +40,9 @@ namespace OpenRA.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
+			if (world.FogObscures(pos) && !visibleThroughFog)
+				return SpriteRenderable.None;
+
 			var zoom = scaleSizeWithZoom ? 1f / wr.Viewport.Zoom : 1f;
 			return anim.Render(pos, WVec.Zero, 0, wr.Palette(palette), zoom);
 		}

--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -196,7 +196,7 @@ namespace OpenRA.Widgets
 					else if (o.TargetLocation != CPos.Zero)
 					{
 						var pos = world.Map.CenterOfCell(cell);
-						world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, world, "moveflsh", "idle", "moveflash", true)));
+						world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, world, "moveflsh", "idle", "moveflash", true, true)));
 						flashed = true;
 					}
 				}

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 			"CenterPosition to draw the trail sprite at the current position.")]
 		public readonly TrailType Type = TrailType.Cell;
 
+		[Desc("Should the trail be visible through fog.")]
+		public readonly bool VisibleThroughFog = false;
+
 		[Desc("Display a trail while stationary.")]
 		public readonly bool TrailWhileStationary = false;
 
@@ -76,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (Info.TerrainTypes.Contains(type) && !string.IsNullOrEmpty(Info.Image))
 					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, self.World, Info.Image,
-						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette)));
+						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog)));
 
 				cachedPosition = self.CenterPosition;
 				ticks = 0;


### PR DESCRIPTION
Exposed a boolean for rendering a `SpriteEffect` under fog. Exposed a setting in `LeavesTrails` for this boolean. Sandworm trails in D2k remains visible under fog thanks to this.

There's a usecase of `SpriteEffect` in `SpawnActorPower` as well, but I'll assume there that the spawned actor will reveal the fog for the animation if intended to be seen.
