### PR TITLE
TD Balance Changes 22142016.

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -778,6 +778,8 @@ GTWR:
 	Building:
 	Health:
 		HP: 400
+	Armor:
+		Type: Wood
 	RevealsShroud:
 		Range: 7c0
 	Bib:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -94,7 +94,7 @@ APC:
 		ROT: 8
 		Speed: 128
 	Health:
-		HP: 200
+		HP: 210
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -301,7 +301,7 @@ JEEP:
 LTNK:
 	Inherits: ^Tank
 	Valued:
-		Cost: 600
+		Cost: 700
 	Tooltip:
 		Name: Light Tank
 		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
@@ -311,9 +311,9 @@ LTNK:
 		Queue: Vehicle.Nod
 	Mobile:
 		ROT: 7
-		Speed: 113
+		Speed: 110
 	Health:
-		HP: 350
+		HP: 340
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/weapons/largecaliber.yaml
+++ b/mods/cnc/weapons/largecaliber.yaml
@@ -103,7 +103,7 @@ TurretGun:
 		Damage: 40
 		Versus:
 			None: 20
-			Wood: 25
+			Wood: 100
 			Light: 100
 			Heavy: 100
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -19,7 +19,7 @@ Rockets:
 		Damage: 35
 		ValidTargets: Ground, Air
 		Versus:
-			None: 50
+			None: 30
 			Wood: 85
 			Light: 100
 			Heavy: 100
@@ -227,7 +227,7 @@ MammothMissiles:
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
-			Wood: 75
+			Wood: 100
 			Light: 100
 			Heavy: 90
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
@@ -294,7 +294,7 @@ TowerMissle:
 		ValidTargets: Ground
 		Versus:
 			None: 50
-			Wood: 25
+			Wood: 100
 			Light: 100
 			Heavy: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
@@ -326,7 +326,7 @@ SAMMissile:
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		Damage: 30
+		Damage: 35
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -83,7 +83,7 @@ Grenade:
 		Versus:
 			None: 100
 			Wood: 50
-			Light: 75
+			Light: 80
 			Heavy: 35
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
@@ -129,7 +129,7 @@ Laser:
 		Spread: 42
 		Damage: 360
 		Versus:
-			Wood: 50
+			Wood: 100
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -25,7 +25,7 @@ HighV:
 			None: 100
 			Wood: 50
 			Light: 70
-			Heavy: 35
+			Heavy: 30
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
@@ -47,7 +47,7 @@ HeliAGGun:
 		ValidTargets: Ground
 		Versus:
 			None: 100
-			Wood: 50
+			Wood: 80
 			Light: 75
 			Heavy: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath


### PR DESCRIPTION
TD Balance Changes 22142016.

Grenadier damage vs light increase to 80 from 75.

Increase APC HP to 210 from 200.

Guard Tower damage vs heavy reduced to 30 from 35.

Guard Tower gains armor type Wood.

SAM damage increase to 35 from 30.

Light Tank movement speed reduced to 110 from 113.

Light Tank Cost increased to 700 from 600. (Build time increase to 17
seconds from 15)

Light Tank HP Decreased to 340 from 350.

Rocket Infantry damage vs none decreased to 30 from 50.

Increase Apache damage vs wood to 80 from 50.

Stealth Tank damage vs wood increased to 100 from 75

AGT Damage vs wood increased to 100 from 25.

Obelisk damage vs wood increased to 100 from 50.

Gun Turret damage vs wood increased to 100 from 25.

The changes made to E3 is something I forgot about when testing. They
won't kill infantry like they were in testing.

The light tanks have been balanced to prevent en massing and adding a
higher price makes them more valuable instead of suicide tanks.

The armor type wood added to the guard tower made me realize how much of
a damage problem it was vs weapon types. (Gun turrets did only 25
damage?!) It has been calibrated and fixed.

An updated forum post of all the information will be here:
http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=17430&postdays=0&postorder=asc&start=75
