### PR TITLE
Undo lowering selection priority of medics and mechanics

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -322,8 +322,6 @@ MEDI:
 		AttackSequence: heal
 	Voiced:
 		VoiceSet: MedicVoice
-	Selectable:
-		Priority: 5
 
 MECH:
 	Inherits: ^Soldier
@@ -361,8 +359,6 @@ MECH:
 		StandSequences: stand
 	Voiced:
 		VoiceSet: MechanicVoice
-	Selectable:
-		Priority: 5
 
 EINSTEIN:
 	Inherits: ^CivInfantry

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -56,8 +56,6 @@ MEDIC:
 		Ticks: 60
 	Passenger:
 		PipType: Red
-	Selectable:
-		Priority: 5
 
 JUMPJET:
 	Inherits: ^Soldier

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -162,8 +162,6 @@ REPAIR:
 		ForceTargetStances: None
 	AttackFrontal:
 		Voice: Attack
-	Selectable:
-		Priority: 5
 
 WEED:
 	Inherits: ^VoxelTank


### PR DESCRIPTION
This undoes parts of #10519.

That PR made using medics and mechanics really cumbersome to use because you always have to manually select them after selecting the rest of your attack force if you want to issue attack move commands.
#8768 mostly fixed the problem of medics and mechanics running in front of the other units they are escorting, so it's safe to tell them to attack-move along with others. They will stop to repair/heal damaged units and not run head-on into the enemy.

The change from #10519 does make sense for engineers, though, so they keep the lower selection priority.
