### PR TITLE
Avoid creating throwaway map objects at startup.

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -169,6 +169,11 @@ namespace OpenRA
 			return new ReadOnlyDictionary<string, string>(inner);
 		}
 
+		public bool Contains<T>() where T : IGlobalModData
+		{
+			return modules.Contains<T>();
+		}
+
 		public T Get<T>() where T : IGlobalModData
 		{
 			var module = modules.GetOrDefault<T>();

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				// Update the map cache so it can be loaded without restarting the game
 				var classification = mapDirectories[directoryDropdown.Text];
-				modData.MapCache[map.Uid].UpdateFromMap(map, classification);
+				modData.MapCache[map.Uid].UpdateFromMap(map.Container, classification, null, map.Grid.Type);
 
 				Console.WriteLine("Saved current map at {0}", combinedPath);
 				Ui.CloseWindow();


### PR DESCRIPTION
This parses MapPreview objects instead of going to the effort of constructing a full map and then throwing it away.  Saves ~30% on map load time and is another step towards #10717.

Depends on #10765.  Only the last two commits are part of this PR.
