### PR TITLE
TD Balance Patch Revised. 021616

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -94,7 +94,7 @@ APC:
 		ROT: 8
 		Speed: 128
 	Health:
-		HP: 200
+		HP: 210
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -301,7 +301,7 @@ JEEP:
 LTNK:
 	Inherits: ^Tank
 	Valued:
-		Cost: 600
+		Cost: 700
 	Tooltip:
 		Name: Light Tank
 		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
@@ -311,9 +311,9 @@ LTNK:
 		Queue: Vehicle.Nod
 	Mobile:
 		ROT: 7
-		Speed: 113
+		Speed: 110
 	Health:
-		HP: 350
+		HP: 340
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -19,7 +19,7 @@ Rockets:
 		Damage: 35
 		ValidTargets: Ground, Air
 		Versus:
-			None: 50
+			None: 30
 			Wood: 85
 			Light: 100
 			Heavy: 100
@@ -326,7 +326,7 @@ SAMMissile:
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		Damage: 30
+		Damage: 35
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -83,7 +83,7 @@ Grenade:
 		Versus:
 			None: 100
 			Wood: 50
-			Light: 75
+			Light: 80
 			Heavy: 35
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -25,7 +25,7 @@ HighV:
 			None: 100
 			Wood: 50
 			Light: 70
-			Heavy: 35
+			Heavy: 30
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs


### PR DESCRIPTION
Grenadier damage vs light increase to 80 from 75.

Increase APC HP to 210 from 200.

Guard Tower damage vs heavy reduced to 30 from 35.

SAM damage increase to 35 from 30.

Light Tank movement speed reduced to 110 from 113.

Light Tank Cost increased to 700 from 600. (Build time increase to 17
seconds from 15)

Light Tank HP Decreased to 340 from 350.

Rocket Infantry damage vs none decreased to 30 from 50.

(Revised from https://github.com/OpenRA/OpenRA/pull/10761)

forums will be updated once check made with the notes about GT.

http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=17430&postdays=0&postorder=asc&start=75
