### PR TITLE
Fix missiles not moving to CruiseAltitude if launched above it

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -664,6 +664,11 @@ namespace OpenRA.Mods.Common.Effects
 					// of vertical facing bound by the maximum vertical rate of turn
 					var vDist = new WVec(-diffClfMslHgt - info.CruiseAltitude.Length, -speed, 0);
 					desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
+
+					// If the missile is launched above CruiseAltitude, it has to descend instead of climbing
+					if (-diffClfMslHgt > info.CruiseAltitude.Length)
+						desiredVFacing = -desiredVFacing;
+
 					desiredVFacing = desiredVFacing.Clamp(-info.VerticalRateOfTurn, info.VerticalRateOfTurn);
 
 					ChangeSpeed();
@@ -675,6 +680,11 @@ namespace OpenRA.Mods.Common.Effects
 				// of vertical facing bound by the maximum vertical rate of turn
 				var vDist = new WVec(-diffClfMslHgt - info.CruiseAltitude.Length, -speed, 0);
 				desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
+
+				// If the missile is launched above CruiseAltitude, it has to descend instead of climbing
+				if (-diffClfMslHgt > info.CruiseAltitude.Length)
+					desiredVFacing = -desiredVFacing;
+
 				desiredVFacing = desiredVFacing.Clamp(-info.VerticalRateOfTurn, info.VerticalRateOfTurn);
 
 				ChangeSpeed();

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -14,6 +14,7 @@ Maverick:
 		Inaccuracy: 512
 		Image: DRAGON
 		HorizontalRateOfTurn: 5
+		CruiseAltitude: 2c0
 		RangeLimit: 60
 	Warhead@1Dam: SpreadDamage
 		Spread: 128


### PR DESCRIPTION
Closes #10741.

Missiles can now descend towards CruiseAltitude as well.
