### PR TITLE
Fixed game end when admin leaves on dedicated server

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -167,6 +167,11 @@ namespace OpenRA
 			return new Order("CancelProduction", subject, false) { ExtraData = (uint)count, TargetString = item };
 		}
 
+		public static Order NewAdmin(int nextAdminIndex)
+		{
+			return new Order("NewAdmin", null, false) { ExtraData = (uint)nextAdminIndex };
+		}
+
 		// For scripting special powers
 		public Order()
 			: this(null, null, null, CPos.Zero, null, false, CPos.Zero, 0) { }

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -138,19 +138,28 @@ namespace OpenRA
 
 			// Enable the bot logic on the host
 			IsBot = BotType != null;
-			if (IsBot && Game.IsHost)
-			{
-				var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Type == BotType);
-				if (logic == null)
-					Log.Write("debug", "Invalid bot type: {0}", BotType);
-				else
-					logic.Activate(this);
-			}
+			if (IsBot)
+				ActivateBot();
 
 			stanceColors.Self = ChromeMetrics.Get<Color>("PlayerStanceColorSelf");
 			stanceColors.Allies = ChromeMetrics.Get<Color>("PlayerStanceColorAllies");
 			stanceColors.Enemies = ChromeMetrics.Get<Color>("PlayerStanceColorEnemies");
 			stanceColors.Neutrals = ChromeMetrics.Get<Color>("PlayerStanceColorNeutrals");
+		}
+
+		public void ActivateBot()
+		{
+			if (string.IsNullOrEmpty(BotType) || !Game.IsHost)
+				return;
+
+			var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Type == BotType);
+			if (logic == null)
+				Log.Write("debug", "Invalid bot type: {0}", BotType);
+			else
+			{
+				logic.Activate(this);
+				Log.Write("debug", "Activated bot {0} on player {1}".F(BotType, InternalName));
+			}
 		}
 
 		public override string ToString()

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -559,24 +559,32 @@ namespace OpenRA.Server
 				// Send disconnected order, even if still in the lobby
 				DispatchOrdersToClients(toDrop, 0, new ServerOrder("Disconnected", "").Serialize());
 
-				LobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
-				LobbyInfo.ClientPings.RemoveAll(p => p.Index == toDrop.PlayerIndex);
-
-				// Client was the server admin
-				// TODO: Reassign admin for game in progress via an order
-				if (Dedicated && dropClient.IsAdmin && State == ServerState.WaitingPlayers)
+				// Client was the server admin, but the game isn't over yet.
+				if (Dedicated && dropClient.IsAdmin)
 				{
-					// Remove any bots controlled by the admin
-					LobbyInfo.Clients.RemoveAll(c => c.Bot != null && c.BotControllerClientIndex == toDrop.PlayerIndex);
+					// Pick the human player who joined right after the previous admin.
+					var nextAdmin = LobbyInfo.Clients.Where(c => c.Bot == null && c != dropClient).MinByOrDefault(c => c.Index);
 
-					var nextAdmin = LobbyInfo.Clients.Where(c1 => c1.Bot == null)
-						.MinByOrDefault(c => c.Index);
-
-					if (nextAdmin != null)
+					// Still in the lobby so handle things directly.
+					if (State == ServerState.WaitingPlayers)
 					{
-						nextAdmin.IsAdmin = true;
-						SendMessage("{0} is now the admin.".F(nextAdmin.Name));
+						// Remove the previous admin.
+						LobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
+
+						// Stop pinging when a player drops from the server.
+						LobbyInfo.ClientPings.RemoveAll(p => p.Index == toDrop.PlayerIndex);
+
+						// Remove any bots controlled by the previous admin.
+						LobbyInfo.Clients.RemoveAll(c => c.Bot != null && c.BotControllerClientIndex == toDrop.PlayerIndex);
+
+						if (nextAdmin != null)
+						{
+							nextAdmin.IsAdmin = true;
+							SendMessage("{0} is now the admin.".F(nextAdmin.Name));
+						}
 					}
+					else if (nextAdmin != null)
+						DispatchOrdersToClients(toDrop, 0, Order.NewAdmin(nextAdmin.Index).Serialize());
 				}
 
 				DispatchOrders(toDrop, toDrop.MostRecentFrame, new byte[] { 0xbf });


### PR DESCRIPTION
Instead a new admin is found and all bots are handed over. You can use `launch-dedicated.sh` and `launch-game.sh` to quickly setup a test environment with 1 dedicated server and 2 clients.

Closes https://github.com/OpenRA/OpenRA/issues/10515.
