### PR TITLE
Remove Game.ModData references from Widget code.

### DIFF
--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -46,9 +46,6 @@ namespace OpenRA
 
 		public Widget LoadWidget(WidgetArgs args, Widget parent, MiniYamlNode node)
 		{
-			if (!args.ContainsKey("modRules"))
-				args = new WidgetArgs(args) { { "modRules", modData.DefaultRules } };
-
 			if (!args.ContainsKey("modData"))
 				args = new WidgetArgs(args) { { "modData", modData } };
 

--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -49,6 +49,9 @@ namespace OpenRA
 			if (!args.ContainsKey("modRules"))
 				args = new WidgetArgs(args) { { "modRules", modData.DefaultRules } };
 
+			if (!args.ContainsKey("modData"))
+				args = new WidgetArgs(args) { { "modData", modData } };
+
 			var widget = NewWidget(node.Key, args);
 
 			if (parent != null)

--- a/OpenRA.Mods.Cnc/Widgets/Logic/CncMainMenuLogic.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/CncMainMenuLogic.cs
@@ -18,8 +18,8 @@ namespace OpenRA.Mods.Cnc.Widgets.Logic
 	public class CncMainMenuLogic : MainMenuLogic
 	{
 		[ObjectCreator.UseCtor]
-		public CncMainMenuLogic(Widget widget, World world)
-			: base(widget, world)
+		public CncMainMenuLogic(Widget widget, World world, ModData modData)
+			: base(widget, world, modData)
 		{
 			var shellmapDecorations = widget.Get("SHELLMAP_DECORATIONS");
 			shellmapDecorations.IsVisible = () => menuType != MenuType.None && Game.Settings.Game.ShowShellmap;

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -60,9 +60,9 @@ namespace OpenRA.Mods.Common.Widgets
 		protected readonly Ruleset ModRules;
 
 		[ObjectCreator.UseCtor]
-		public ButtonWidget(Ruleset modRules)
+		public ButtonWidget(ModData modData)
 		{
-			ModRules = modRules;
+			ModRules = modData.DefaultRules;
 
 			GetText = () => Text;
 			GetColor = () => TextColor;

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -25,8 +25,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public bool HasPressedState = ChromeMetrics.Get<bool>("CheckboxPressedState");
 
 		[ObjectCreator.UseCtor]
-		public CheckboxWidget(Ruleset modRules)
-			: base(modRules)
+		public CheckboxWidget(ModData modData)
+			: base(modData)
 		{
 			GetCheckType = () => CheckType;
 		}

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -29,8 +29,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public string PanelRoot;
 
 		[ObjectCreator.UseCtor]
-		public DropDownButtonWidget(Ruleset modRules)
-			: base(modRules) { }
+		public DropDownButtonWidget(ModData modData)
+			: base(modData) { }
 
 		protected DropDownButtonWidget(DropDownButtonWidget widget)
 			: base(widget)

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -48,11 +48,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		int currentFrame;
 
 		[ObjectCreator.UseCtor]
-		public AssetBrowserLogic(Widget widget, Action onExit, World world, Dictionary<string, MiniYaml> logicArgs)
+		public AssetBrowserLogic(Widget widget, Action onExit, ModData modData, World world, Dictionary<string, MiniYaml> logicArgs)
 		{
 			this.world = world;
-			modData = Game.ModData;
-
+			this.modData = modData;
 			panel = widget;
 
 			var ticker = panel.GetOrNull<LogicTickerWidget>("ANIMATION_TICKER");

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ColorPickerLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public ColorPickerLogic(Widget widget, World world, HSLColor initialColor, Action<HSLColor> onChange, WorldRenderer worldRenderer)
+		public ColorPickerLogic(Widget widget, ModData modData, World world, HSLColor initialColor, Action<HSLColor> onChange, WorldRenderer worldRenderer)
 		{
 			string actorType;
 			if (!ChromeMetrics.TryGet("ColorPickerActorType", out actorType))
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 			// Set the initial state
-			var validator = Game.ModData.Manifest.Get<ColorValidator>();
+			var validator = modData.Manifest.Get<ColorValidator>();
 			mixer.SetPaletteRange(validator.HsvSaturationRange[0], validator.HsvSaturationRange[1], validator.HsvValueRange[0], validator.HsvValueRange[1]);
 			mixer.Set(initialColor);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -18,10 +18,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class CreditsLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public CreditsLogic(Widget widget, Action onExit)
+		public CreditsLogic(Widget widget, ModData modData, Action onExit)
 		{
 			var panel = widget.Get("CREDITS_PANEL");
-			var modData = Game.ModData;
 
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -19,7 +19,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class LayerSelectorLogic : ChromeLogic
 	{
 		readonly EditorViewportControllerWidget editor;
-		readonly Ruleset modRules;
 		readonly World world;
 		readonly WorldRenderer worldRenderer;
 
@@ -27,9 +26,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ScrollItemWidget layerPreviewTemplate;
 
 		[ObjectCreator.UseCtor]
-		public LayerSelectorLogic(Widget widget, WorldRenderer worldRenderer, Ruleset modRules)
+		public LayerSelectorLogic(Widget widget, WorldRenderer worldRenderer)
 		{
-			this.modRules = modRules;
 			this.worldRenderer = worldRenderer;
 			world = worldRenderer.World;
 
@@ -45,8 +43,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void IntializeLayerPreview(Widget widget)
 		{
 			layerTemplateList.RemoveChildren();
-
-			var resources = modRules.Actors["world"].TraitInfos<ResourceTypeInfo>();
+			var rules = worldRenderer.World.Map.Rules;
+			var resources = rules.Actors["world"].TraitInfos<ResourceTypeInfo>();
+			var tileSize = worldRenderer.World.Map.Grid.TileSize;
 			foreach (var resource in resources)
 			{
 				var newResourcePreviewTemplate = ScrollItemWidget.Setup(layerPreviewTemplate,
@@ -61,12 +60,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				layerPreview.GetPalette = () => resource.Palette;
 
 				var variant = resource.Variants.FirstOrDefault();
-				var sequenceProvider = modRules.Sequences[world.TileSet.Id];
+				var sequenceProvider = rules.Sequences[world.TileSet.Id];
 				var sequence = sequenceProvider.GetSequence("resources", variant);
 				var frame = sequence.Frames != null ? sequence.Frames.Last() : resource.MaxDensity - 1;
 				layerPreview.GetSprite = () => sequence.GetSprite(frame);
 
-				var tileSize = Game.ModData.Manifest.Get<MapGrid>().TileSize;
 				layerPreview.Bounds.Width = tileSize.Width;
 				layerPreview.Bounds.Height = tileSize.Height;
 				newResourcePreviewTemplate.Bounds.Width = tileSize.Width + (layerPreview.Bounds.X * 2);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -20,14 +20,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Widget panel;
 
 		[ObjectCreator.UseCtor]
-		public NewMapLogic(Action onExit, Action<string> onSelect, Ruleset modRules, Widget widget, World world)
+		public NewMapLogic(Action onExit, Action<string> onSelect, Widget widget, World world)
 		{
 			panel = widget;
 
 			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
 
 			var tilesetDropDown = panel.Get<DropDownButtonWidget>("TILESET");
-			var tilesets = modRules.TileSets.Select(t => t.Key).ToList();
+			var tilesets = world.Map.Rules.TileSets.Select(t => t.Key).ToList();
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
 			{
 				var item = ScrollItemWidget.Setup(template,
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				height = Math.Max(2, height);
 
 				var maxTerrainHeight = world.Map.Grid.MaximumTerrainHeight;
-				var tileset = modRules.TileSets[tilesetDropDown.Text];
+				var tileset = world.Map.Rules.TileSets[tilesetDropDown.Text];
 				var map = new Map(Game.ModData, tileset, width + 2, height + maxTerrainHeight + 2);
 
 				var tl = new PPos(1, 1);
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				map.SetBounds(tl, br);
 
 				map.PlayerDefinitions = new MapPlayers(map.Rules, map.SpawnPoints.Value.Length).ToMiniYaml();
-				map.FixOpenAreas(modRules);
+				map.FixOpenAreas(world.Map.Rules);
 
 				Action<string> afterSave = uid =>
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -29,9 +29,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public SaveMapLogic(Widget widget, Action<string> onSave, Action onExit, Map map, List<MiniYamlNode> playerDefinitions, List<MiniYamlNode> actorDefinitions)
+		public SaveMapLogic(Widget widget, ModData modData, Action<string> onSave, Action onExit,
+			Map map, List<MiniYamlNode> playerDefinitions, List<MiniYamlNode> actorDefinitions)
 		{
-			var modData = Game.ModData;
 			var title = widget.Get<TextFieldWidget>("TITLE");
 			title.Text = map.Title;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -23,9 +23,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ScrollItemWidget itemTemplate;
 
 		[ObjectCreator.UseCtor]
-		public TileSelectorLogic(Widget widget, WorldRenderer worldRenderer, Ruleset modRules)
+		public TileSelectorLogic(Widget widget, WorldRenderer worldRenderer)
 		{
-			var tileset = modRules.TileSets[worldRenderer.World.Map.Tileset];
+			var rules = worldRenderer.World.Map.Rules;
+			var tileset = rules.TileSets[worldRenderer.World.Map.Tileset];
 
 			editor = widget.Parent.Get<EditorViewportControllerWidget>("MAP_EDITOR");
 			panel = widget.Get<ScrollPanelWidget>("TILETEMPLATE_LIST");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -16,10 +16,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	class GameInfoBriefingLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public GameInfoBriefingLogic(Widget widget, World world)
+		public GameInfoBriefingLogic(Widget widget, ModData modData, World world)
 		{
 			var previewWidget = widget.Get<MapPreviewWidget>("MAP_PREVIEW");
-			previewWidget.Preview = () => Game.ModData.MapCache[world.Map.Uid];
+			previewWidget.Preview = () => modData.MapCache[world.Map.Uid];
 
 			var mapDescriptionPanel = widget.Get<ScrollPanelWidget>("MAP_DESCRIPTION_PANEL");
 			var mapDescription = widget.Get<LabelWidget>("MAP_DESCRIPTION");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -39,10 +39,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool teamChat;
 
 		[ObjectCreator.UseCtor]
-		public IngameChatLogic(Widget widget, OrderManager orderManager, World world, Ruleset modRules)
+		public IngameChatLogic(Widget widget, OrderManager orderManager, World world, ModData modData)
 		{
 			this.orderManager = orderManager;
-			this.modRules = modRules;
+			this.modRules = modData.DefaultRules;
 
 			chatTraits = world.WorldActor.TraitsImplementing<INotifyChat>().ToArray();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Widget menu;
 
 		[ObjectCreator.UseCtor]
-		public IngameMenuLogic(Widget widget, World world, Action onExit, WorldRenderer worldRenderer, IngameInfoPanel activePanel)
+		public IngameMenuLogic(Widget widget, ModData modData, World world, Action onExit, WorldRenderer worldRenderer, IngameInfoPanel activePanel)
 		{
 			var leaving = false;
 			menu = widget.Get("INGAME_MENU");
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (mpe != null)
 				mpe.Fade(mpe.Info.MenuEffect);
 
-			menu.Get<LabelWidget>("VERSION_LABEL").Text = Game.ModData.Manifest.Mod.Version;
+			menu.Get<LabelWidget>("VERSION_LABEL").Text = modData.Manifest.Mod.Version;
 
 			var hideMenu = false;
 			menu.Get("MENU_BUTTONS").IsVisible = () => !hideMenu;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromCDLogic.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class InstallFromCDLogic : ChromeLogic
 	{
+		readonly ModData modData;
 		readonly string modId;
 		readonly Widget panel;
 		readonly ProgressBarWidget progressBar;
@@ -30,8 +31,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ContentInstaller installData;
 
 		[ObjectCreator.UseCtor]
-		public InstallFromCDLogic(Widget widget, Action afterInstall, string modId)
+		public InstallFromCDLogic(Widget widget, ModData modData, Action afterInstall, string modId)
 		{
+			this.modData = modData;
 			this.modId = modId;
 			installData = ModMetadata.AllMods[modId].Content;
 			this.afterInstall = afterInstall;
@@ -92,11 +94,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
 			progressBar.Percentage = 0;
-			var modData = Game.ModData;
 
 			new Thread(() =>
 			{
-				using (var cabExtractor = new InstallShieldCABExtractor(Game.ModData.ModFiles, source))
+				using (var cabExtractor = new InstallShieldCABExtractor(modData.ModFiles, source))
 				{
 					var denom = installData.InstallShieldCABFileIds.Count;
 					var extractFiles = installData.ExtractFilesFromCD;
@@ -152,7 +153,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			retryButton.IsDisabled = () => true;
 			insertDiskContainer.IsVisible = () => false;
 			installingContainer.IsVisible = () => true;
-			var modData = Game.ModData;
 			var dest = Platform.ResolvePath("^", "Content", modId);
 			var copyFiles = installData.CopyFilesFromCD;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		[ObjectCreator.UseCtor]
 		internal LobbyLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, OrderManager orderManager,
-			Action onExit, Action onStart, bool skirmishMode, Ruleset modRules)
+			Action onExit, Action onStart, bool skirmishMode)
 		{
 			MapPreview = MapCache.UnknownMap;
 			lobby = widget;
@@ -121,7 +121,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.onStart = onStart;
 			this.onExit = onExit;
 			this.skirmishMode = skirmishMode;
-			this.modRules = modRules;
+
+			// TODO: This needs to be reworked to support per-map tech levels, bots, etc.
+			this.modRules = modData.DefaultRules;
 			shellmapWorld = worldRenderer.World;
 
 			orderManager.AddChatLine += AddChatLine;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public MapPreview MapPreview { get; private set; }
 		public Map Map { get; private set; }
 
+		readonly ModData modData;
 		readonly Action onStart;
 		readonly Action onExit;
 		readonly OrderManager orderManager;
@@ -110,11 +111,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		internal LobbyLogic(Widget widget, WorldRenderer worldRenderer, OrderManager orderManager,
+		internal LobbyLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, OrderManager orderManager,
 			Action onExit, Action onStart, bool skirmishMode, Ruleset modRules)
 		{
 			MapPreview = MapCache.UnknownMap;
 			lobby = widget;
+			this.modData = modData;
 			this.orderManager = orderManager;
 			this.onStart = onStart;
 			this.onExit = onExit;
@@ -511,7 +513,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var gameSpeed = optionsBin.GetOrNull<DropDownButtonWidget>("GAMESPEED_DROPDOWNBUTTON");
 			if (gameSpeed != null)
 			{
-				var speeds = Game.ModData.Manifest.Get<GameSpeeds>().Speeds;
+				var speeds = modData.Manifest.Get<GameSpeeds>().Speeds;
 
 				gameSpeed.IsDisabled = configurationDisabled;
 				gameSpeed.GetText = () =>
@@ -738,7 +740,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (MapPreview.Uid == uid)
 				return;
 
-			var modData = Game.ModData;
 			MapPreview = modData.MapCache[uid];
 			Map = null;
 			if (MapPreview.Status == MapStatus.Available)
@@ -768,7 +769,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}).Start();
 			}
 			else if (Game.Settings.Game.AllowDownloading)
-				Game.ModData.MapCache.QueryRemoteMapDetails(new[] { uid });
+				modData.MapCache.QueryRemoteMapDetails(new[] { uid });
 		}
 
 		void UpdatePlayerList()

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		int blinkTick;
 
 		[ObjectCreator.UseCtor]
-		internal LobbyMapPreviewLogic(Widget widget, OrderManager orderManager, LobbyLogic lobby)
+		internal LobbyMapPreviewLogic(Widget widget, ModData modData, OrderManager orderManager, LobbyLogic lobby)
 		{
 			var available = widget.GetOrNull("MAP_AVAILABLE");
 			if (available != null)
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (lobby.MapPreview.Status == MapStatus.DownloadError)
 							lobby.MapPreview.Install();
 						else if (lobby.MapPreview.Status == MapStatus.Unavailable)
-							Game.ModData.MapCache.QueryRemoteMapDetails(new[] { lobby.MapPreview.Uid });
+							modData.MapCache.QueryRemoteMapDetails(new[] { lobby.MapPreview.Uid });
 					};
 
 					retry.GetText = () => lobby.MapPreview.Status == MapStatus.DownloadError ? "Retry Install" : "Retry Search";

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -41,10 +41,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public MainMenuLogic(Widget widget, World world)
+		public MainMenuLogic(Widget widget, World world, ModData modData)
 		{
 			rootMenu = widget;
-			rootMenu.Get<LabelWidget>("VERSION_LABEL").Text = Game.ModData.Manifest.Mod.Version;
+			rootMenu.Get<LabelWidget>("VERSION_LABEL").Text = modData.Manifest.Mod.Version;
 
 			// Menu buttons
 			var mainMenu = widget.Get("MAIN_MENU");
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// so we can't do this inside the input handler.
 				Game.RunAfterTick(() =>
 				{
-					Game.Settings.Game.PreviousMod = Game.ModData.Manifest.Mod.Id;
+					Game.Settings.Game.PreviousMod = modData.Manifest.Mod.Id;
 					Game.InitializeMod("modchooser", null);
 				});
 			};
@@ -103,8 +103,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			};
 
-			var hasCampaign = Game.ModData.Manifest.Missions.Any();
-			var hasMissions = Game.ModData.MapCache
+			var hasCampaign = modData.Manifest.Missions.Any();
+			var hasMissions = modData.MapCache
 				.Any(p => p.Status == MapStatus.Available && p.Visibility.HasFlag(MapVisibility.MissionSelector));
 
 			missionsButton.Disabled = !hasCampaign && !hasMissions;
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var onSelect = new Action<string>(uid =>
 			{
 				RemoveShellmapUI();
-				LoadMapIntoEditor(Game.ModData.MapCache[uid].Uid);
+				LoadMapIntoEditor(modData.MapCache[uid].Uid);
 			});
 
 			var newMapButton = widget.Get<ButtonWidget>("NEW_MAP_BUTTON");

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -53,10 +53,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		string gameSpeed;
 
 		[ObjectCreator.UseCtor]
-		public MissionBrowserLogic(Widget widget, World world, Action onStart, Action onExit)
+		public MissionBrowserLogic(Widget widget, ModData modData, World world, Action onStart, Action onExit)
 		{
-			modData = Game.ModData;
 			mapCache = new Cache<MapPreview, Map>(p => new Map(modData, p.Package));
+			this.modData = modData;
 			this.onStart = onStart;
 
 			missionList = widget.Get<ScrollPanelWidget>("MISSION_LIST");
@@ -230,7 +230,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (gameSpeedButton != null)
 			{
-				var speeds = Game.ModData.Manifest.Get<GameSpeeds>().Speeds;
+				var speeds = modData.Manifest.Get<GameSpeeds>().Speeds;
 				gameSpeed = "default";
 
 				gameSpeedButton.GetText = () => speeds[gameSpeed].Name;

--- a/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ModBrowserLogic.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		int modOffset = 0;
 
 		[ObjectCreator.UseCtor]
-		public ModBrowserLogic(Widget widget)
+		public ModBrowserLogic(Widget widget, ModData modData)
 		{
 			modInstallStatus = new Cache<ModMetadata, bool>(IsModInstalled);
 			modPrerequisitesFulfilled = new Cache<string, bool>(Game.IsModInstalled);
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			modChooserPanel = widget;
 			loadButton = modChooserPanel.Get<ButtonWidget>("LOAD_BUTTON");
 			loadButton.OnClick = () => LoadMod(selectedMod);
-			loadButton.IsDisabled = () => selectedMod.Id == Game.ModData.Manifest.Mod.Id;
+			loadButton.IsDisabled = () => selectedMod.Id == modData.Manifest.Mod.Id;
 
 			modChooserPanel.Get<ButtonWidget>("QUIT_BUTTON").OnClick = Game.Exit;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Color incompatibleGameStartedColor;
 		readonly Color gameStartedColor;
 		readonly Color incompatibleGameColor;
+		readonly ModData modData;
 
 		GameServer currentServer;
 		MapPreview currentMap;
@@ -68,8 +69,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public MultiplayerLogic(Widget widget, Action onStart, Action onExit, string directConnectHost, int directConnectPort)
+		public MultiplayerLogic(Widget widget, ModData modData, Action onStart, Action onExit, string directConnectHost, int directConnectPort)
 		{
+			this.modData = modData;
 			this.onStart = onStart;
 			this.onExit = onExit;
 
@@ -321,7 +323,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return 0;
 
 			// Games for the current mod+version are sorted first
-			if (testEntry.ModId == Game.ModData.Manifest.Mod.Id)
+			if (testEntry.ModId == modData.Manifest.Mod.Id)
 				return 2;
 
 			// Followed by games for different mods that are joinable
@@ -331,7 +333,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void SelectServer(GameServer server)
 		{
 			currentServer = server;
-			currentMap = server != null ? Game.ModData.MapCache[server.Map] : null;
+			currentMap = server != null ? modData.MapCache[server.Map] : null;
 		}
 
 		void RefreshServerListInner(IEnumerable<GameServer> games)
@@ -438,7 +440,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				// Search for any unknown maps
 				if (Game.Settings.Game.AllowDownloading)
-					Game.ModData.MapCache.QueryRemoteMapDetails(games.Where(g => !Filtered(g)).Select(g => g.Map));
+					modData.MapCache.QueryRemoteMapDetails(games.Where(g => !Filtered(g)).Select(g => g.Map));
 
 				foreach (var row in rows)
 					serverList.AddChild(row);

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		MusicInfo currentSong = null;
 
 		[ObjectCreator.UseCtor]
-		public MusicPlayerLogic(Widget widget, Ruleset modRules, World world, Action onExit)
+		public MusicPlayerLogic(Widget widget, ModData modData, Ruleset modRules, World world, Action onExit)
 		{
 			var panel = widget;
 
@@ -107,11 +107,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (installButton != null)
 			{
 				installButton.IsDisabled = () => world.Type != WorldType.Shellmap;
-				var args = new[] { "installMusic={0}".F(Game.ModData.Manifest.Mod.Id) };
+				var args = new[] { "installMusic={0}".F(modData.Manifest.Mod.Id) };
 				installButton.OnClick = () =>
 					Game.RunAfterTick(() => Game.InitializeMod("modchooser", new Arguments(args)));
 
-				var installData = Game.ModData.Manifest.Get<ContentInstaller>();
+				var installData = modData.Manifest.Get<ContentInstaller>();
 				installButton.IsVisible = () => modRules.InstalledMusic.ToArray().Length <= installData.ShippedSoundtracks;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		MusicInfo currentSong = null;
 
 		[ObjectCreator.UseCtor]
-		public MusicPlayerLogic(Widget widget, ModData modData, Ruleset modRules, World world, Action onExit)
+		public MusicPlayerLogic(Widget widget, ModData modData, World world, Action onExit)
 		{
 			var panel = widget;
 
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.RunAfterTick(() => Game.InitializeMod("modchooser", new Arguments(args)));
 
 				var installData = modData.Manifest.Get<ContentInstaller>();
-				installButton.IsVisible = () => modRules.InstalledMusic.ToArray().Length <= installData.ShippedSoundtracks;
+				installButton.IsVisible = () => modData.DefaultRules.InstalledMusic.ToArray().Length <= installData.ShippedSoundtracks;
 			}
 
 			var songWatcher = widget.GetOrNull<LogicTickerWidget>("SONG_WATCHER");

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		volatile bool cancelLoadingReplays;
 
 		[ObjectCreator.UseCtor]
-		public ReplayBrowserLogic(Widget widget, Action onExit, Action onStart)
+		public ReplayBrowserLogic(Widget widget, ModData modData, Action onExit, Action onStart)
 		{
 			panel = widget;
 
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			replayList = panel.Get<ScrollPanelWidget>("REPLAY_LIST");
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
-			var mod = Game.ModData.Manifest.Mod;
+			var mod = modData.Manifest.Mod;
 			var dir = Platform.ResolvePath("^", "Replays", mod.Id, mod.Version);
 
 			if (Directory.Exists(dir))

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -25,14 +25,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool allowPortForward;
 
 		[ObjectCreator.UseCtor]
-		public ServerCreationLogic(Widget widget, Action onExit, Action openLobby)
+		public ServerCreationLogic(Widget widget, ModData modData, Action onExit, Action openLobby)
 		{
 			panel = widget;
 			onCreate = openLobby;
 			this.onExit = onExit;
 
 			var settings = Game.Settings;
-			preview = Game.ModData.MapCache[WidgetUtils.ChooseInitialMap(Game.Settings.Server.Map)];
+			preview = modData.MapCache[WidgetUtils.ChooseInitialMap(Game.Settings.Server.Map)];
 
 			panel.Get<ButtonWidget>("CREATE_BUTTON").OnClick = CreateAndJoin;
 
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{ "initialMap", preview.Uid },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", () => { } },
-						{ "onSelect", (Action<string>)(uid => preview = Game.ModData.MapCache[uid]) },
+						{ "onSelect", (Action<string>)(uid => preview = modData.MapCache[uid]) },
 						{ "filter", MapVisibility.Lobby },
 						{ "onStart", () => { } }
 					});

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -21,13 +21,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SettingsLogic : ChromeLogic
 	{
 		enum PanelType { Display, Audio, Input, Advanced }
-		Dictionary<PanelType, Action> leavePanelActions = new Dictionary<PanelType, Action>();
-		Dictionary<PanelType, Action> resetPanelActions = new Dictionary<PanelType, Action>();
-		PanelType settingsPanel = PanelType.Display;
-		Widget panelContainer, tabContainer;
-
-		WorldRenderer worldRenderer;
-		SoundDevice soundDevice;
 
 		static readonly string OriginalSoundDevice;
 		static readonly string OriginalSoundEngine;
@@ -35,6 +28,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		static readonly string OriginalGraphicsRenderer;
 		static readonly int2 OriginalGraphicsWindowedSize;
 		static readonly int2 OriginalGraphicsFullscreenSize;
+
+		readonly Dictionary<PanelType, Action> leavePanelActions = new Dictionary<PanelType, Action>();
+		readonly Dictionary<PanelType, Action> resetPanelActions = new Dictionary<PanelType, Action>();
+		readonly Widget panelContainer, tabContainer;
+
+		readonly ModData modData;
+		readonly WorldRenderer worldRenderer;
+
+		SoundDevice soundDevice;
+		PanelType settingsPanel = PanelType.Display;
 
 		static SettingsLogic()
 		{
@@ -48,9 +51,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public SettingsLogic(Widget widget, Action onExit, WorldRenderer worldRenderer)
+		public SettingsLogic(Widget widget, Action onExit, ModData modData, WorldRenderer worldRenderer)
 		{
 			this.worldRenderer = worldRenderer;
+			this.modData = modData;
 
 			panelContainer = widget.Get("SETTINGS_PANEL");
 			tabContainer = widget.Get("TAB_CONTAINER");
@@ -158,7 +162,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "PLAYER_STANCE_COLORS_CHECKBOX", gs, "UsePlayerStanceColors");
 
 			var languageDropDownButton = panel.Get<DropDownButtonWidget>("LANGUAGE_DROPDOWNBUTTON");
-			languageDropDownButton.OnMouseDown = _ => ShowLanguageDropdown(languageDropDownButton);
+			languageDropDownButton.OnMouseDown = _ => ShowLanguageDropdown(languageDropDownButton, modData.Languages);
 			languageDropDownButton.GetText = () => FieldLoader.Translate(ds.Language);
 
 			var windowModeDropdown = panel.Get<DropDownButtonWidget>("MODE_DROPDOWN");
@@ -684,7 +688,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			return true;
 		}
 
-		static bool ShowLanguageDropdown(DropDownButtonWidget dropdown)
+		static bool ShowLanguageDropdown(DropDownButtonWidget dropdown, IEnumerable<string> languages)
 		{
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{
@@ -696,7 +700,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, Game.ModData.Languages, setupItem);
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, languages, setupItem);
 			return true;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
@@ -18,8 +18,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly bool HideIngameUI = true;
 
 		[ObjectCreator.UseCtor]
-		public MenuButtonWidget(Ruleset modRules)
-			: base(modRules) { }
+		public MenuButtonWidget(ModData modData)
+			: base(modData) { }
 
 		protected MenuButtonWidget(MenuButtonWidget other)
 			: base(other)

--- a/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
@@ -17,8 +17,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string HotkeyName;
 
 		[ObjectCreator.UseCtor]
-		public ProductionTypeButtonWidget(Ruleset modRules)
-			: base(modRules) { }
+		public ProductionTypeButtonWidget(ModData modData)
+			: base(modData) { }
 
 		protected ProductionTypeButtonWidget(ProductionTypeButtonWidget other)
 			: base(other)

--- a/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
@@ -20,8 +20,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public string BaseName = "scrollitem";
 
 		[ObjectCreator.UseCtor]
-		public ScrollItemWidget(Ruleset modRules)
-			: base(modRules)
+		public ScrollItemWidget(ModData modData)
+			: base(modData)
 		{
 			IsVisible = () => false;
 			VisualHeight = 0;

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -86,9 +86,9 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 
 		[ObjectCreator.UseCtor]
-		public ScrollPanelWidget(Ruleset modRules)
+		public ScrollPanelWidget(ModData modData)
 		{
-			this.modRules = modRules;
+			this.modRules = modData.DefaultRules;
 
 			Layout = new ListLayout(this);
 		}


### PR DESCRIPTION
The main focus of this change is code hygiene (relying on a static reference for something which may change isn't nice), but has a side-effect of adding support for map-defined resources in the editor.
