### PR TITLE
Fix broken dev commands

### DIFF
--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -47,8 +47,6 @@
 		PipColor: Blue
 		AllowedTerrainTypes: Clear,Road
 		AllowUnderActors: true
-	LoadWidgetAtGameStart:
-		ShellmapRoot: MENU_BACKGROUND
 
 World:
 	Inherits: ^BaseWorld
@@ -149,9 +147,12 @@ World:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
 	RadarPings:
+	LoadWidgetAtGameStart:
+		ShellmapRoot: MENU_BACKGROUND
 
 EditorWorld:
 	Inherits: ^BaseWorld
+	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -54,7 +54,6 @@
 		PipColor: green
 		AllowedTerrainTypes: SpiceSand
 		AllowUnderActors: true
-	LoadWidgetAtGameStart:
 
 World:
 	Inherits: ^BaseWorld
@@ -151,9 +150,11 @@ World:
 	RadarPings:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
+	LoadWidgetAtGameStart:
 
 EditorWorld:
 	Inherits: ^BaseWorld
+	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	D2kEditorResourceLayer:
 	EditorSelectionLayer:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -7,7 +7,6 @@
 		VictoryMusic: score
 		DefeatMusic: map
 	TerrainGeometryOverlay:
-	LoadWidgetAtGameStart:
 	ShroudRenderer:
 		FogVariants: shroud
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255
@@ -168,9 +167,11 @@ World:
 	StartGameNotification:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
+	LoadWidgetAtGameStart:
 
 EditorWorld:
 	Inherits: ^BaseWorld
+	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -6,7 +6,6 @@
 	MusicPlaylist:
 		VictoryMusic: score
 		DefeatMusic: maps
-	LoadWidgetAtGameStart:
 	ShroudRenderer:
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255
 		UseExtendedIndex: true
@@ -170,9 +169,11 @@ World:
 	StartGameNotification:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
+	LoadWidgetAtGameStart:
 
 EditorWorld:
 	Inherits: ^BaseWorld
+	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:


### PR DESCRIPTION
Fixes #10683.

Not sure if that's really the way we should be going to solve this, but it does the job with minimal impact. A proper solution would likely require heavy surgery to the way we instantiate the widget tree.

I explained the problem itself in https://github.com/OpenRA/OpenRA/issues/10683#issuecomment-179478285:

> So all the *Commands do their thing in WorldLoaded. IngameChatLogic gathers all the commands in its constructor.
> 
> As it turns out, the widgets themselves are created during LoadWidgetAtGameStart's WorldLoaded method, which, as LoadWidgetAtGameStart is declared as one of the first traits in world.yaml, runs before the WorldLoaded method of the *Commands traits.
