### PR TITLE
Added WithExitOverlay rendered when the actor is leaving production

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -453,6 +453,7 @@
     <Compile Include="Traits\Render\WithSpriteTurret.cs" />
     <Compile Include="Traits\Render\WithFacingSpriteBody.cs" />
     <Compile Include="Traits\Render\WithBuildingPlacedOverlay.cs" />
+    <Compile Include="Traits\Render\WithExitOverlay.cs" />
     <Compile Include="Traits\Render\WithProductionDoorOverlay.cs" />
     <Compile Include="Traits\Render\WithProductionOverlay.cs" />
     <Compile Include="Traits\Render\WithVoxelBarrel.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithExitOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithExitOverlay.cs
@@ -1,0 +1,87 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2015 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Renders an animation when when the actor is leaving from a production building.")]
+	public class WithExitOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	{
+		[Desc("Sequence name to use")]
+		[SequenceReference] public readonly string Sequence = "exit-overlay";
+
+		[Desc("Position relative to body")]
+		public readonly WVec Offset = WVec.Zero;
+
+		[Desc("Custom palette name")]
+		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+
+		[Desc("Custom palette is a player palette BaseName")]
+		public readonly bool IsPlayerPalette = false;
+
+		public object Create(ActorInitializer init) { return new WithExitOverlay(init.Self, this); }
+	}
+
+	public class WithExitOverlay : INotifyDamageStateChanged, INotifyBuildComplete, INotifySold, INotifyProduction
+	{
+		readonly Actor self;
+		readonly Animation overlay;
+		bool buildComplete;
+		CPos exit;
+
+		bool IsExitBlocked
+		{
+			get { return self.World.ActorMap.GetActorsAt(exit).Any(a => a != self); }
+		}
+
+		public WithExitOverlay(Actor self, WithExitOverlayInfo info)
+		{
+			this.self = self;
+			var rs = self.Trait<RenderSprites>();
+			var body = self.Trait<BodyOrientation>();
+
+			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
+
+			overlay = new Animation(self.World, rs.GetImage(self));
+			overlay.PlayRepeating(info.Sequence);
+
+			var anim = new AnimationWithOffset(overlay,
+				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => !buildComplete || !IsExitBlocked);
+
+			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+		}
+
+		public void BuildingComplete(Actor self)
+		{
+			buildComplete = true;
+		}
+
+		public void Sold(Actor self) { }
+		public void Selling(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		public void DamageStateChanged(Actor self, AttackInfo e)
+		{
+			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, overlay.CurrentSequence.Name));
+		}
+
+		public void UnitProduced(Actor self, Actor other, CPos exit)
+		{
+			this.exit = exit;
+		}
+	}
+}


### PR DESCRIPTION
Red Alert 2 has a different approach to war factory rendering. Instead of door opening/closing animations it simply draws overlays which a) hide the produced vehicle with a roof and b) add open door overlays. This was a bit weird to understand, but it is quite controllable when playing around with Z offsets. In followup pull requests this will differentiate per queue to allow the roof opening overlays for helicopters and airships.
