### PR TITLE
Fixed selectable crash sites

### DIFF
--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -659,64 +659,25 @@ CABHUT:
 		Palette: player
 
 CACRSH01:
-	Inherits: ^CivBuilding
+	Inherits: ^Decoration
 	Tooltip:
-		Name: Crash 1
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
+		Name: Crash Site
 	Armor:
 		Type: concrete
 	Health:
 		HP: 400
 
 CACRSH02:
-	Inherits: ^CivBuilding
-	Tooltip:
-		Name: Crash 2
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: concrete
-	Health:
-		HP: 400
+	Inherits: CACRSH01
 
 CACRSH03:
-	Inherits: ^CivBuilding
-	Tooltip:
-		Name: Crash 3
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: concrete
-	Health:
-		HP: 400
+	Inherits: CACRSH01
 
 CACRSH04:
-	Inherits: ^CivBuilding
-	Tooltip:
-		Name: Crash 4
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: concrete
-	Health:
-		HP: 400
+	Inherits: CACRSH01
 
 CACRSH05:
-	Inherits: ^CivBuilding
-	Tooltip:
-		Name: Crash 5
-	Building:
-		Footprint: x
-		Dimensions: 1, 1
-	Armor:
-		Type: concrete
-	Health:
-		HP: 400
+	Inherits: CACRSH01
 
 CAHOSP:
 	Inherits: ^CivBuilding


### PR DESCRIPTION
These are decorational actors like rocks which shouldn't have a health bar. They also still contained internal developer tooltips which aren't really atmospheric.
