### PR TITLE
Fixed lobby self-kicking when clicking start game quickly

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -320,7 +320,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var startGameButton = lobby.GetOrNull<ButtonWidget>("START_GAME_BUTTON");
 			if (startGameButton != null)
 			{
-				startGameButton.IsDisabled = () => configurationDisabled() ||
+				startGameButton.IsDisabled = () => configurationDisabled() || Map == null ||
 					orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
 					(orderManager.LobbyInfo.GlobalSettings.DisableSingleplayer && orderManager.LobbyInfo.IsSinglePlayer);
 


### PR DESCRIPTION
https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs#L742 sets the map to null so I can easily check against that. The problems appears when you click skirmish and immediately the start game button. If a debugger is attached and the map check is slowed down this will frequently happen. The game will even kick you in skirmish games which are technically a local server with one client.
