### PR TITLE
Adjust the (visual) selection bounds of the Windmill and the Lighthouse

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -641,9 +641,7 @@ LHUS:
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERAT
 	Selectable:
-		Bounds: 24,24,0,16
-	SelectionDecorations:
-		VisualBounds: 24,48
+		Bounds: 24,48,0,-16
 	Tooltip:
 		Name: Lighthouse
 	Building:
@@ -655,9 +653,9 @@ WINDMILL:
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERAT
 	Selectable:
-		Bounds: 24,24,0,8
+		Bounds: 24,24,0,-14
 	SelectionDecorations:
-		VisualBounds: 36,36
+		VisualBounds: 36,36,0,-14
 	Tooltip:
 		Name: Windmill
 	Building:


### PR DESCRIPTION
Removed `SelectionDecorations` entirely from the `LHUS` definition as that trait gets inherited and uses the `Bounds` values of `Selectable` by default.

Before:
![boundsmillhusformer](https://cloud.githubusercontent.com/assets/7704140/13293046/64e78f70-db1e-11e5-83e7-fcb94686bc22.png)
After:
![boundsmillhus](https://cloud.githubusercontent.com/assets/7704140/13293043/632f0942-db1e-11e5-84ec-7fc1b8daaa16.png)
(Note: The windmill has smaller "selection-bounds" than "visible bounds".)
