### PR TITLE
Add tests for PriorityQueue

### DIFF
--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -76,17 +76,19 @@ namespace OpenRA.Primitives
 			return At(lastLevel, lastIndex);
 		}
 
-		public T Peek() { return At(0, 0); }
+		public T Peek()
+		{
+			if (level <= 0 && index <= 0)
+				throw new InvalidOperationException("PriorityQueue empty.");
+			return At(0, 0);
+		}
+
 		public T Pop()
 		{
-			if (level == 0 && index == 0)
-				throw new InvalidOperationException("Attempting to pop empty PriorityQueue");
-
-			var ret = At(0, 0);
+			var ret = Peek();
 			BubbleInto(0, 0, Last());
 			if (--index < 0)
 				index = (1 << --level) - 1;
-
 			return ret;
 		}
 

--- a/OpenRA.Test/OpenRA.Game/ActionQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActionQueueTest.cs
@@ -14,7 +14,7 @@ using System.Linq;
 using NUnit.Framework;
 using OpenRA.Primitives;
 
-namespace OpenRA.Test.OpenRA.Game
+namespace OpenRA.Test
 {
 	[TestFixture]
 	class ActionQueueTest

--- a/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
@@ -1,0 +1,48 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using NUnit.Framework;
+using OpenRA.Primitives;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	class PriorityQueueTest
+	{
+		[TestCase(TestName = "PriorityQueue maintains invariants when adding and removing items.")]
+		public void PriorityQueueGeneralTest()
+		{
+			var queue = new PriorityQueue<int>();
+
+			Assert.IsTrue(queue.Empty, "New queue should start out empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+
+			foreach (var value in new[] { 4, 3, 5, 1, 2 })
+			{
+				queue.Add(value);
+				Assert.IsFalse(queue.Empty, "Queue should not be empty - items have been added.");
+			}
+
+			foreach (var value in new[] { 1, 2, 3, 4, 5 })
+			{
+				Assert.AreEqual(value, queue.Peek(), "Peek returned the wrong item - should be in order.");
+				Assert.IsFalse(queue.Empty, "Queue should not be empty yet.");
+				Assert.AreEqual(value, queue.Pop(), "Pop returned the wrong item - should be in order.");
+			}
+
+			Assert.IsTrue(queue.Empty, "Queue should now be empty.");
+			Assert.Throws<InvalidOperationException>(() => queue.Peek(), "Peeking at an empty queue should throw.");
+			Assert.Throws<InvalidOperationException>(() => queue.Pop(), "Popping an empty queue should throw.");
+		}
+	}
+}

--- a/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
+++ b/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
@@ -13,7 +13,7 @@ using System.Drawing;
 using NUnit.Framework;
 using OpenRA.Primitives;
 
-namespace OpenRA.Test.OpenRA.Game
+namespace OpenRA.Test
 {
 	[TestFixture]
 	class SpatiallyPartitionedTest

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -50,6 +50,7 @@
     <Compile Include="OpenRA.Game\MiniYamlTest.cs" />
     <Compile Include="OpenRA.Game\ActorInfoTest.cs" />
     <Compile Include="OpenRA.Game\CoordinateTest.cs" />
+    <Compile Include="OpenRA.Game\PriorityQueueTest.cs" />
     <Compile Include="OpenRA.Game\SpatiallyPartitionedTest.cs" />
     <Compile Include="OpenRA.Mods.Common\ShapeTest.cs" />
     <Compile Include="OpenRA.Game\OrderTest.cs" />


### PR DESCRIPTION
- Added some tests to verify the queue does the right things.
- Fixed `Peek` to throw when the queue is empty.
- Adjusted the exception message to be consistent with the mesage from the BCL `Queue` & `Stack` when peeking/popping empty collections.
- Changed `if (level == 0 && index == 0)` to `if (level <= 0 && index <= 0)` to hopefully fix a false positive from static analysis via Coverity (this should provide a hint to the analysis that `level` and `index` cannot be negative in normal code paths)
