### PR TITLE
Rework map loading and saving.

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -34,17 +34,6 @@ namespace OpenRA.FileSystem
 
 		Cache<string, List<IReadOnlyPackage>> fileIndex = new Cache<string, List<IReadOnlyPackage>>(_ => new List<IReadOnlyPackage>());
 
-		public IReadWritePackage CreatePackage(string filename)
-		{
-			var content = new Dictionary<string, byte[]>();
-			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, content);
-			if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))
-				return new ZipFile(this, filename, content);
-
-			return new Folder(filename, content);
-		}
-
 		public IReadOnlyPackage OpenPackage(string filename)
 		{
 			if (filename.EndsWith(".mix", StringComparison.InvariantCultureIgnoreCase))

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -64,6 +64,32 @@ namespace OpenRA.FileSystem
 			return new Folder(Platform.ResolvePath(filename));
 		}
 
+		public IReadOnlyPackage OpenPackage(string filename, IReadOnlyPackage parent)
+		{
+			// HACK: limit support to zip and folder until we generalize the PackageLoader support
+			if (parent is Folder)
+			{
+				var path = Path.Combine(parent.Name, filename);
+
+				// HACK: work around SharpZipLib's lack of support for writing to in-memory files
+				if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
+					return new ZipFile(this, path);
+				if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))
+					return new ZipFile(this, path);
+
+				var subFolder = Platform.ResolvePath(path);
+				if (Directory.Exists(subFolder))
+					return new Folder(subFolder);
+			}
+
+			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
+				return new ZipFile(this, filename, parent.GetStream(filename));
+			if (filename.EndsWith(".oramap", StringComparison.InvariantCultureIgnoreCase))
+				return new ZipFile(this, filename, parent.GetStream(filename));
+
+			return null;
+		}
+
 		public IReadWritePackage OpenWritablePackage(string filename)
 		{
 			if (filename.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -144,7 +144,13 @@ namespace OpenRA.FileSystem
 					packagesForFile.RemoveAll(p => p == package);
 
 				mountedPackages.Remove(package);
-				explicitMounts.Remove(package.Name);
+				var explicitKeys = explicitMounts.Where(kv => kv.Value == package)
+					.Select(kv => kv.Key)
+					.ToList();
+
+				foreach (var key in explicitKeys)
+					explicitMounts.Remove(key);
+
 				package.Dispose();
 			}
 			else

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -18,16 +18,6 @@ namespace OpenRA.FileSystem
 	{
 		readonly string path;
 
-		// Create a new folder package
-		public Folder(string path, Dictionary<string, byte[]> contents)
-		{
-			this.path = path;
-			if (Directory.Exists(path))
-				Directory.Delete(path, true);
-
-			Write(contents);
-		}
-
 		public Folder(string path)
 		{
 			this.path = path;
@@ -57,15 +47,22 @@ namespace OpenRA.FileSystem
 			return File.Exists(Path.Combine(path, filename));
 		}
 
-		public void Write(Dictionary<string, byte[]> contents)
+		public void Update(string filename, byte[] contents)
 		{
 			if (!Directory.Exists(path))
 				Directory.CreateDirectory(path);
 
-			foreach (var file in contents)
-				using (var dataStream = File.Create(Path.Combine(path, file.Key)))
-				using (var writer = new BinaryWriter(dataStream))
-					writer.Write(file.Value);
+			using (var s = File.Create(Path.Combine(path, filename)))
+				s.Write(contents, 0, contents.Length);
+		}
+
+		public void Delete(string filename)
+		{
+			var filePath = Path.Combine(path, filename);
+			if (Directory.Exists(filePath))
+				Directory.Delete(filePath, true);
+			else if (File.Exists(filePath))
+				File.Delete(filePath);
 		}
 
 		public void Dispose() { }

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -33,6 +33,8 @@ namespace OpenRA.FileSystem
 			{
 				foreach (var filename in Directory.GetFiles(path, "*", SearchOption.TopDirectoryOnly))
 					yield return Path.GetFileName(filename);
+				foreach (var filename in Directory.GetDirectories(path))
+					yield return Path.GetFileName(filename);
 			}
 		}
 
@@ -59,7 +61,12 @@ namespace OpenRA.FileSystem
 
 		public void Delete(string filename)
 		{
-			var filePath = Path.Combine(path, filename);
+			// HACK: ZipFiles can't be loaded as read-write from a stream, so we are
+			// forced to bypass the parent package and load them with their full path
+			// in FileSystem.OpenPackage.  Their internal name therefore contains the
+			// full parent path too.  We need to be careful to not add a second path
+			// prefix to these hacked packages.
+			var filePath = filename.StartsWith(path) ? filename : Path.Combine(path, filename);
 			if (Directory.Exists(filePath))
 				Directory.Delete(filePath, true);
 			else if (File.Exists(filePath))

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -44,7 +44,8 @@ namespace OpenRA.FileSystem
 
 		public bool Contains(string filename)
 		{
-			return File.Exists(Path.Combine(path, filename));
+			var combined = Path.Combine(path, filename);
+			return combined.StartsWith(path) && File.Exists(combined);
 		}
 
 		public void Update(string filename, byte[] contents)

--- a/OpenRA.Game/FileSystem/IPackage.cs
+++ b/OpenRA.Game/FileSystem/IPackage.cs
@@ -25,6 +25,7 @@ namespace OpenRA.FileSystem
 
 	public interface IReadWritePackage : IReadOnlyPackage
 	{
-		void Write(Dictionary<string, byte[]> contents);
+		void Update(string filename, byte[] contents);
+		void Delete(string filename);
 	}
 }

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -27,6 +27,16 @@ namespace OpenRA.FileSystem
 			ZipConstants.DefaultCodePage = Encoding.UTF8.CodePage;
 		}
 
+		public ZipFile(FileSystem context, string filename, Stream stream, bool createOrClearContents = false)
+		{
+			Name = filename;
+
+			if (createOrClearContents)
+				pkg = SZipFile.Create(stream);
+			else
+				pkg = new SZipFile(stream);
+		}
+
 		public ZipFile(IReadOnlyFileSystem context, string filename, bool createOrClearContents = false)
 		{
 			Name = filename;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -492,7 +492,7 @@ namespace OpenRA
 
 		public void Save(IReadWritePackage toPackage)
 		{
-			MapFormat = 8;
+			MapFormat = SupportedMapFormat;
 
 			var root = new List<MiniYamlNode>();
 			var fields = new[]
@@ -534,10 +534,12 @@ namespace OpenRA
 			root.Add(new MiniYamlNode("Notifications", null, NotificationDefinitions));
 			root.Add(new MiniYamlNode("Translations", null, TranslationDefinitions));
 
+			// Saving to a new package: copy over all the content from the map
 			if (Package != null && toPackage != Package)
 				foreach (var file in Package.Contents)
 					toPackage.Update(file, Package.GetStream(file).ReadAllBytes());
 
+			// Update the package with the new map data
 			var s = root.WriteToString();
 			toPackage.Update("map.yaml", Encoding.UTF8.GetBytes(s));
 			toPackage.Update("map.bin", SaveBinaryData());

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -57,17 +57,21 @@ namespace OpenRA
 			var mapGrid = modData.Manifest.Get<MapGrid>();
 			foreach (var path in mapPaths)
 			{
+				IReadOnlyPackage package;
 				try
 				{
 					using (new Support.PerfTimer(path.Key))
 					{
-						var package = modData.ModFiles.OpenPackage(path.Key);
+						package = modData.ModFiles.OpenPackage(path.Key);
 						var uid = Map.ComputeUID(package);
 						previews[uid].UpdateFromMap(package, path.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
 					}
 				}
 				catch (Exception e)
 				{
+					if (package != null)
+						package.Dispose();
+
 					Console.WriteLine("Failed to load map: {0}", path);
 					Console.WriteLine("Details: {0}", e);
 					Log.Write("debug", "Failed to load map: {0}", path);

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -269,6 +269,9 @@ namespace OpenRA
 				return;
 			}
 
+			foreach (var p in previews.Values)
+				p.Dispose();
+
 			// We need to let the loader thread exit before we can dispose our sheet builder.
 			// Ideally we should dispose our resources before returning, but we don't to block waiting on the loader thread to exit.
 			// Instead, we'll queue disposal to be run once it has exited.

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -26,6 +26,8 @@ namespace OpenRA
 	public sealed class MapCache : IEnumerable<MapPreview>, IDisposable
 	{
 		public static readonly MapPreview UnknownMap = new MapPreview(null, MapGridType.Rectangular, null);
+		public readonly IReadOnlyDictionary<IReadOnlyPackage, MapClassification> MapLocations;
+
 		readonly Cache<string, MapPreview> previews;
 		readonly ModData modData;
 		readonly SheetBuilder sheetBuilder;
@@ -41,6 +43,36 @@ namespace OpenRA
 			var gridType = Exts.Lazy(() => modData.Manifest.Get<MapGrid>().Type);
 			previews = new Cache<string, MapPreview>(uid => new MapPreview(uid, gridType.Value, this));
 			sheetBuilder = new SheetBuilder(SheetType.BGRA);
+
+			// Enumerate map directories
+			var mapLocations = new Dictionary<IReadOnlyPackage, MapClassification>();
+			foreach (var kv in modData.Manifest.MapFolders)
+			{
+				var name = kv.Key;
+				var classification = string.IsNullOrEmpty(kv.Value)
+					? MapClassification.Unknown : Enum<MapClassification>.Parse(kv.Value);
+
+				IReadOnlyPackage package;
+				var optional = name.StartsWith("~");
+				if (optional)
+					name = name.Substring(1);
+
+				try
+				{
+					package = modData.ModFiles.OpenPackage(name);
+				}
+				catch
+				{
+					if (optional)
+						continue;
+
+					throw;
+				}
+
+				mapLocations.Add(package, classification);
+			}
+
+			MapLocations = new ReadOnlyDictionary<IReadOnlyPackage, MapClassification>(mapLocations);
 		}
 
 		public void LoadMaps()
@@ -49,33 +81,33 @@ namespace OpenRA
 			if (!modData.Manifest.Contains<MapGrid>())
 				return;
 
-			// Expand the dictionary (dir path, dir type) to a dictionary of (map path, dir type)
-			var mapPaths = modData.Manifest.MapFolders.SelectMany(kv =>
-				FindMapsIn(modData.ModFiles, kv.Key).ToDictionary(p => p, p => string.IsNullOrEmpty(kv.Value)
-					? MapClassification.Unknown : Enum<MapClassification>.Parse(kv.Value)));
-
-			var mapGrid = modData.Manifest.Get<MapGrid>();
-			foreach (var path in mapPaths)
+			var mapGrid = Game.ModData.Manifest.Get<MapGrid>();
+			foreach (var kv in MapLocations)
 			{
-				IReadOnlyPackage package;
-				try
+				foreach (var map in kv.Key.Contents)
 				{
-					using (new Support.PerfTimer(path.Key))
+					IReadOnlyPackage mapPackage = null;
+					try
 					{
-						package = modData.ModFiles.OpenPackage(path.Key);
-						var uid = Map.ComputeUID(package);
-						previews[uid].UpdateFromMap(package, path.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
-					}
-				}
-				catch (Exception e)
-				{
-					if (package != null)
-						package.Dispose();
+						using (new Support.PerfTimer(map))
+						{
+							mapPackage = modData.ModFiles.OpenPackage(map, kv.Key);
+							if (mapPackage == null)
+								continue;
 
-					Console.WriteLine("Failed to load map: {0}", path);
-					Console.WriteLine("Details: {0}", e);
-					Log.Write("debug", "Failed to load map: {0}", path);
-					Log.Write("debug", "Details: {0}", e);
+							var uid = Map.ComputeUID(mapPackage);
+							previews[uid].UpdateFromMap(mapPackage, kv.Key, kv.Value, modData.Manifest.MapCompatibility, mapGrid.Type);
+						}
+					}
+					catch (Exception e)
+					{
+						if (mapPackage != null)
+							mapPackage.Dispose();
+						Console.WriteLine("Failed to load map: {0}", map);
+						Console.WriteLine("Details: {0}", e);
+						Log.Write("debug", "Failed to load map: {0}", map);
+						Log.Write("debug", "Details: {0}", e);
+					}
 				}
 			}
 		}
@@ -121,31 +153,6 @@ namespace OpenRA
 			};
 
 			new Download(url, _ => { }, onInfoComplete);
-		}
-
-		public static IEnumerable<string> FindMapsIn(FileSystem.FileSystem context, string dir)
-		{
-			string[] noMaps = { };
-
-			// Ignore optional flag
-			if (dir.StartsWith("~"))
-				dir = dir.Substring(1);
-
-			// HACK: We currently only support maps loaded from Folders
-			// This is a temporary workaround that resolves the filesystem paths to a system directory
-			IReadOnlyPackage package;
-			string filename;
-			if (context.TryGetPackageContaining(dir, out package, out filename))
-				dir = Path.Combine(package.Name, filename);
-			else if (Directory.Exists(Platform.ResolvePath(dir)))
-				dir = Platform.ResolvePath(dir);
-			else
-				return noMaps;
-
-			var dirsWithMaps = Directory.GetDirectories(dir)
-				.Where(d => Directory.GetFiles(d, "map.yaml").Any() && Directory.GetFiles(d, "map.bin").Any());
-
-			return dirsWithMaps.Concat(Directory.GetFiles(dir, "*.oramap"));
 		}
 
 		void LoadAsyncInternal()

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -53,7 +53,7 @@ namespace OpenRA
 		public readonly bool downloading;
 	}
 
-	public class MapPreview
+	public class MapPreview : IDisposable
 	{
 		static readonly CPos[] NoSpawns = new CPos[] { };
 		MapCache cache;
@@ -343,6 +343,15 @@ namespace OpenRA
 		public void Invalidate()
 		{
 			Status = MapStatus.Unavailable;
+		}
+
+		public void Dispose()
+		{
+			if (Package != null)
+			{
+				Package.Dispose();
+				Package = null;
+			}
 		}
 	}
 }

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -272,8 +272,15 @@ namespace OpenRA
 				return;
 
 			Status = MapStatus.Downloading;
-			var mapInstallPackage = new Folder(Platform.ResolvePath("^", "maps", Game.ModData.Manifest.Mod.Id));
+			var installLocation = cache.MapLocations.FirstOrDefault(p => p.Value == MapClassification.User);
+			if (installLocation.Key == null || !(installLocation.Key is IReadWritePackage))
+			{
+				Log.Write("debug", "Map install directory not found");
+				Status = MapStatus.DownloadError;
+				return;
+			}
 
+			var mapInstallPackage = installLocation.Key as IReadWritePackage;
 			var modData = Game.ModData;
 			new Thread(() =>
 			{

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.Traits;
@@ -95,7 +96,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Map.FixOpenAreas(Rules);
 
 			var dest = Path.GetFileNameWithoutExtension(args[1]) + ".oramap";
-			var package = modData.ModFiles.CreatePackage(dest);
+			var package = new ZipFile(modData.ModFiles, dest, true);
 			Map.Save(package);
 			Console.WriteLine(dest + " saved.");
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -785,17 +785,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			yaml.Nodes.First(n => n.Key == "MapFormat").Value = new MiniYaml(Map.SupportedMapFormat.ToString());
 
-			var entries = new Dictionary<string, byte[]>();
-			entries.Add("map.yaml", Encoding.UTF8.GetBytes(yaml.Nodes.WriteToString()));
-			foreach (var file in package.Contents)
-			{
-				if (file == "map.yaml")
-					continue;
-
-				entries.Add(file, package.GetStream(file).ReadAllBytes());
-			}
-
-			package.Write(entries);
+			package.Update("map.yaml", Encoding.UTF8.GetBytes(yaml.Nodes.WriteToString()));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -169,8 +169,32 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (map.Uid != null && combinedPath == mapPath)
 					modData.MapCache[map.Uid].Invalidate();
 
-				var package = modData.ModFiles.CreatePackage(combinedPath);
-				map.Save(package);
+				var package = map.Package as IReadWritePackage;
+				if (package == null || package.Name != combinedPath)
+				{
+					try
+					{
+						if (fileType == MapFileType.OraMap)
+						{
+							if (File.Exists(combinedPath))
+								File.Delete(combinedPath);
+
+							package = new ZipFile(modData.DefaultFileSystem, combinedPath, true);
+						}
+						else
+						{
+							if (Directory.Exists(combinedPath))
+								Directory.Delete(combinedPath, true);
+							package = new Folder(combinedPath);
+						}
+
+						map.Save(package);
+					}
+					catch
+					{
+						Console.WriteLine("Failed to save map at {0}", combinedPath);
+					}
+				}
 
 				// Update the map cache so it can be loaded without restarting the game
 				var classification = mapDirectories[directoryDropdown.Text];

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -288,22 +288,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		string DeleteMap(string map)
 		{
-			var path = modData.MapCache[map].Package.Name;
 			try
 			{
-				if (File.Exists(path))
-					File.Delete(path);
-				else if (Directory.Exists(path))
-					Directory.Delete(path, true);
-
-				modData.MapCache[map].Invalidate();
-
+				modData.MapCache[map].Delete();
 				if (selectedUid == map)
 					selectedUid = WidgetUtils.ChooseInitialMap(tabMaps[currentTab].Select(mp => mp.Uid).FirstOrDefault());
 			}
 			catch (Exception ex)
 			{
-				Game.Debug("Failed to delete map '{0}'. See the debug.log file for details.", path);
+				Game.Debug("Failed to delete map '{0}'. See the debug.log file for details.", map);
 				Log.Write("debug", ex.ToString());
 			}
 

--- a/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.IO;
+using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.D2k.UtilityCommands
 {
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 				return;
 
 			var dest = Path.GetFileNameWithoutExtension(args[1]) + ".oramap";
-			var package = modData.ModFiles.CreatePackage(dest);
+			var package = new ZipFile(modData.DefaultFileSystem, dest, true);
 			map.Save(package);
 			Console.WriteLine(dest + " saved.");
 		}

--- a/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.TS.UtilityCommands
 			map.PlayerDefinitions = mapPlayers.ToMiniYaml();
 
 			var dest = Path.GetFileNameWithoutExtension(args[1]) + ".oramap";
-			var package = modData.ModFiles.CreatePackage(dest);
+			var package = new ZipFile(modData.DefaultFileSystem, dest, true);
 			map.Save(package);
 			Console.WriteLine(dest + " saved.");
 		}


### PR DESCRIPTION
- Fixes bogosity with `MapPreview` disposing
- Cleans the last nastyness from the `IReadWritePackage` interface.
- Prevents saving maps to non-writable directories (Fixes #9430).
- Final prerequisites for `.oramod` support.
