### PR TITLE
Normalize InsufficientFundsWarning header.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/InsufficientFundsWarning.cs
+++ b/OpenRA.Mods.Common/Traits/Player/InsufficientFundsWarning.cs
@@ -3,8 +3,9 @@
  * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
- * as published by the Free Software Foundation. For more information,
- * see COPYING.
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
  */
 #endregion
 


### PR DESCRIPTION
It got merged with the old, now outdated header.
