### PR TITLE
Fix ProductionFromMapEdge to work properly with ground units

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 					var move = newUnit.TraitOrDefault<IMove>();
 					if (move != null)
-						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, destination));
+						newUnit.QueueActivity(move.MoveTo(destination, 2));
 
 					newUnit.SetTargetLine(Target.FromCell(self.World, destination), Color.Green, false);
 

--- a/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
@@ -74,37 +74,37 @@ namespace OpenRA.Mods.D2k.Traits
 			var initialFacing = self.World.Map.FacingBetween(location.Value, destination, 0);
 
 			self.World.AddFrameEndTask(w =>
+			{
+				var td = new TypeDictionary
 				{
-					var td = new TypeDictionary
-					{
-						new OwnerInit(self.Owner),
-						new LocationInit(location.Value),
-						new CenterPositionInit(pos),
-						new FacingInit(initialFacing)
-					};
+					new OwnerInit(self.Owner),
+					new LocationInit(location.Value),
+					new CenterPositionInit(pos),
+					new FacingInit(initialFacing)
+				};
 
-					if (factionVariant != null)
-						td.Add(new FactionInit(factionVariant));
+				if (factionVariant != null)
+					td.Add(new FactionInit(factionVariant));
 
-					var newUnit = self.World.CreateActor(producee.Name, td);
+				var newUnit = self.World.CreateActor(producee.Name, td);
 
-					var move = newUnit.TraitOrDefault<IMove>();
-					if (move != null)
-						newUnit.QueueActivity(move.MoveTo(destination, 2));
+				var move = newUnit.TraitOrDefault<IMove>();
+				if (move != null)
+					newUnit.QueueActivity(move.MoveTo(destination, 2));
 
-					newUnit.SetTargetLine(Target.FromCell(self.World, destination), Color.Green, false);
+				newUnit.SetTargetLine(Target.FromCell(self.World, destination), Color.Green, false);
 
-					if (!self.IsDead)
-						foreach (var t in self.TraitsImplementing<INotifyProduction>())
-							t.UnitProduced(self, newUnit, destination);
+				if (!self.IsDead)
+					foreach (var t in self.TraitsImplementing<INotifyProduction>())
+						t.UnitProduced(self, newUnit, destination);
 
-					var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
-					foreach (var notify in notifyOthers)
-						notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
+				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
+				foreach (var notify in notifyOthers)
+					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
 
-					foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
-						t.BuildingComplete(newUnit);
-				});
+				foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
+					t.BuildingComplete(newUnit);
+			});
 
 			return true;
 		}


### PR DESCRIPTION
`ProductionFromMapEdge` has several limitations when it comes to working with ground units:
1. It doesn't respect rally points, and units are always ordered to the factory's location.
2. `Mobile.MoveIntoWorld` ends up using the `VisualMove` activity, which basically just moves a sprite across the screen but does not do any pathfinding or collision detection at all. Units will happily drive through other units and across rivers, cliffs etc.
3. As a consequence of both (1) and (2) units end up driving right into the middle of their production building.

This PR fixes all of that.

Testcase included :)
