### PR TITLE
Added facings support to sprite trails

### DIFF
--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -47,6 +47,9 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("Trail animation.")]
 		public readonly string Trail = null;
 
+		[Desc("Loop these sequences of Trail while this projectile is moving.")]
+		[SequenceReference("Trail")] public readonly string[] TrailSequences = { "idle" };
+
 		[Desc("Is this blocked by actors with BlocksProjectiles trait.")]
 		public readonly bool Blockable = true;
 
@@ -179,7 +182,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!string.IsNullOrEmpty(info.Trail) && --smokeTicks < 0)
 			{
 				var delayedPos = WPos.LerpQuadratic(args.Source, target, angle, ticks - info.TrailDelay, length);
-				world.AddFrameEndTask(w => w.Add(new Smoke(w, delayedPos, info.Trail, trailPalette, info.Sequences.Random(world.SharedRandom))));
+				world.AddFrameEndTask(w => w.Add(new Smoke(w, delayedPos, info.Trail, trailPalette, info.TrailSequences.Random(world.SharedRandom))));
 				smokeTicks = info.TrailInterval;
 			}
 

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!string.IsNullOrEmpty(info.Trail) && --smokeTicks < 0)
 			{
 				var delayedPos = WPos.LerpQuadratic(args.Source, target, angle, ticks - info.TrailDelay, length);
-				world.AddFrameEndTask(w => w.Add(new Smoke(w, delayedPos, info.Trail, trailPalette, info.TrailSequences.Random(world.SharedRandom))));
+				world.AddFrameEndTask(w => w.Add(new Smoke(w, delayedPos, () => GetEffectiveFacing(), info.Trail, trailPalette, info.TrailSequences.Random(world.SharedRandom))));
 				smokeTicks = info.TrailInterval;
 			}
 

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -805,7 +805,7 @@ namespace OpenRA.Mods.Common.Effects
 			// Create the smoke trail effect
 			if (!string.IsNullOrEmpty(info.TrailImage) && --ticksToNextSmoke < 0 && (state != States.Freefall || info.TrailWhenDeactivated))
 			{
-				world.AddFrameEndTask(w => w.Add(new Smoke(w, pos - 3 * move / 2, info.TrailImage, trailPalette, info.TrailSequence)));
+				world.AddFrameEndTask(w => w.Add(new Smoke(w, pos - 3 * move / 2, () => renderFacing, info.TrailImage, trailPalette, info.TrailSequence)));
 				ticksToNextSmoke = info.TrailInterval;
 			}
 

--- a/OpenRA.Mods.Common/Effects/Smoke.cs
+++ b/OpenRA.Mods.Common/Effects/Smoke.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Effects;
 using OpenRA.Graphics;
@@ -23,12 +24,15 @@ namespace OpenRA.Mods.Common.Effects
 		readonly string palette;
 
 		public Smoke(World world, WPos pos, string trail, string palette, string sequence)
+			: this(world, pos, () => 0, trail, palette, sequence) { }
+
+		public Smoke(World world, WPos pos, Func<int> facingFunc, string trail, string palette, string sequence)
 		{
 			this.world = world;
 			this.pos = pos;
 			this.palette = palette;
 
-			anim = new Animation(world, trail);
+			anim = new Animation(world, trail, facingFunc);
 			anim.PlayThen(sequence,
 				() => world.AddFrameEndTask(w => w.Remove(this)));
 		}

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -31,12 +32,19 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly SmokeTrailWhenDamagedInfo info;
 		readonly BodyOrientation body;
+		readonly Func<int> getFacing;
 		int ticks;
 
 		public SmokeTrailWhenDamaged(Actor self, SmokeTrailWhenDamagedInfo info)
 		{
 			this.info = info;
 			body = self.Trait<BodyOrientation>();
+			var facing = self.TraitOrDefault<IFacing>();
+
+			if (facing != null)
+				getFacing = () => facing.Facing;
+			else
+				getFacing = () => 0;
 		}
 
 		public void Tick(Actor self)
@@ -48,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 					var pos = position + body.LocalToWorld(offset);
-					self.World.AddFrameEndTask(w => w.Add(new Smoke(w, pos, info.Sprite, info.Palette, info.Sequence)));
+					self.World.AddFrameEndTask(w => w.Add(new Smoke(w, pos, getFacing, info.Sprite, info.Palette, info.Sequence)));
 				}
 
 				ticks = info.Interval;


### PR DESCRIPTION
`Bullet`, `Missile` and `SmokeTrailWhenDamaged`.

Closes #10823.

Test case can be found at https://github.com/reaperrr/OpenRA/tree/smoke-facings-test
