### PR TITLE
Renamed ROT to TurnSpeed

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -296,7 +296,7 @@ namespace OpenRA.Traits
 
 	public interface IFacing
 	{
-		int ROT { get; }
+		int TurnSpeed { get; }
 		int Facing { get; set; }
 	}
 

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 			var move = plane.FlyStep(plane.Facing);
 			var altitude = plane.CenterPosition.Z;
 
-			plane.Facing = Util.TickFacing(plane.Facing, desiredFacing, plane.ROT);
+			plane.Facing = Util.TickFacing(plane.Facing, desiredFacing, plane.TurnSpeed);
 
 			if (altitude != desiredAltitude.Length)
 			{

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Can rotate facing while ascending
 			var desiredFacing = dist.HorizontalLengthSquared != 0 ? dist.Yaw.Facing : helicopter.Facing;
-			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.ROT);
+			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.TurnSpeed);
 
 			if (HeliFly.AdjustAltitude(self, helicopter, helicopter.Info.CruiseAltitude))
 				return this;

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Rotate towards the target
 			var dist = pos - self.CenterPosition;
 			var desiredFacing = dist.HorizontalLengthSquared != 0 ? dist.Yaw.Facing : helicopter.Facing;
-			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.ROT);
+			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.TurnSpeed);
 			var move = helicopter.FlyStep(desiredFacing);
 
 			// Inside the minimum range, so reverse

--- a/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 			helicopter.SetPosition(self, helicopter.CenterPosition + move);
 
 			var desiredFacing = helicopter.Facing + 64;
-			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.ROT / 3);
+			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.TurnSpeed / 3);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		int CalculateTurnRadius(int speed)
 		{
-			return (int)(141 * speed / planeInfo.ROT / (float)Math.PI);
+			return (int)(141 * speed / planeInfo.TurnSpeed / (float)Math.PI);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (desiredFacing == facing.Facing)
 				return NextActivity;
-			facing.Facing = Util.TickFacing(facing.Facing, desiredFacing, facing.ROT);
+			facing.Facing = Util.TickFacing(facing.Facing, desiredFacing, facing.TurnSpeed);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference]
 		public readonly HashSet<string> RearmBuildings = new HashSet<string> { };
 		public readonly int InitialFacing = 0;
-		public readonly int ROT = 255;
+		public readonly int TurnSpeed = 255;
 		public readonly int Speed = 1;
 
 		[Desc("Minimum altitude where this aircraft is considered airborne")]
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync] public int Facing { get; set; }
 		[Sync] public WPos CenterPosition { get; private set; }
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
-		public int ROT { get { return Info.ROT; } }
+		public int TurnSpeed { get { return Info.TurnSpeed; } }
 
 		bool airborne;
 		bool cruising;

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync] public WPos CenterPosition { get; private set; }
 		[Sync] public int Facing { get; set; }
 
-		public int ROT { get { return 0; } }
+		public int TurnSpeed { get { return 0; } }
 
 		public Husk(ActorInitializer init, HuskInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -55,8 +55,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int InitialFacing = 0;
 
-		[Desc("Rate of Turning")]
-		public readonly int ROT = 255;
+		[Desc("Speed at which the actor turns.")]
+		public readonly int TurnSpeed = 255;
 
 		public readonly int Speed = 1;
 
@@ -339,7 +339,7 @@ namespace OpenRA.Mods.Common.Traits
 			set { facing = value; }
 		}
 
-		public int ROT { get { return Info.ROT; } }
+		public int TurnSpeed { get { return Info.TurnSpeed; } }
 
 		[Sync] public WPos CenterPosition { get; private set; }
 		[Sync] public CPos FromCell { get { return fromCell; } }

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -37,8 +37,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speed to throw the particle (horizontal WPos/tick)")]
 		public readonly int Velocity = 75;
 
-		[Desc("Maximum rotation rate")]
-		public readonly float ROT = 15;
+		[Desc("Speed at which the particle turns.")]
+		public readonly float TurnSpeed = 15;
 
 		public object Create(ActorInitializer init) { return new ThrowsParticle(init, this); }
 	}
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			length = (finalPos - initialPos).Length / info.Velocity;
 
 			// Facing rotation
-			rotation = WDist.FromPDF(Game.CosmeticRandom, 2).Length * info.ROT / 1024;
+			rotation = WDist.FromPDF(Game.CosmeticRandom, 2).Length * info.TurnSpeed / 1024;
 
 			var anim = new Animation(init.World, rs.GetImage(self), () => (int)facing);
 			anim.PlayRepeating(info.Anim);

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -18,8 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 	public class TurretedInfo : ITraitInfo, UsesInit<TurretFacingInit>, Requires<BodyOrientationInfo>
 	{
 		public readonly string Turret = "primary";
-		[Desc("Rate of Turning")]
-		public readonly int ROT = 255;
+		[Desc("Speed at which the turret turns.")]
+		public readonly int TurnSpeed = 255;
 		public readonly int InitialFacing = 128;
 
 		[Desc("Number of ticks before turret is realigned. (-1 turns off realignment)")]
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 		void MoveTurret()
 		{
 			var df = DesiredFacing ?? (facing != null ? facing.Facing : TurretFacing);
-			TurretFacing = Util.TickFacing(TurretFacing, df, info.ROT);
+			TurretFacing = Util.TickFacing(TurretFacing, df, info.TurnSpeed);
 		}
 
 		public bool FaceTarget(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Turret = "primary";
 		[Desc("Speed at which the turret turns.")]
 		public readonly int TurnSpeed = 255;
-		public readonly int InitialFacing = 128;
+		public readonly int InitialFacing = 0;
 
 		[Desc("Number of ticks before turret is realigned. (-1 turns off realignment)")]
 		public readonly int RealignDelay = 40;

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -599,6 +599,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20160301)
+				{
+					// Renamed ROT -> TurnSpeed
+					if (node.Key == "ROT")
+						node.Key = "TurnSpeed";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -11,7 +11,7 @@ TRAN:
 		Queue: Aircraft.GDI, Aircraft.Nod
 	Aircraft:
 		LandWhenIdle: true
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 140
 		InitialFacing: 224
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Tiberium,BlueTiberium
@@ -55,7 +55,7 @@ HELI:
 	Aircraft:
 		RearmBuildings: hpad
 		InitialFacing: 224
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 186
 	Health:
 		HP: 125
@@ -107,7 +107,7 @@ ORCA:
 	Aircraft:
 		RearmBuildings: hpad
 		InitialFacing: 224
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 186
 	Health:
 		HP: 90
@@ -151,7 +151,7 @@ C17:
 	Valued:
 		Cost: 2000
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 326
 		Repulsable: False
 		AirborneUpgrades: airborne
@@ -189,7 +189,7 @@ A10:
 	Valued:
 		Cost: 2000
 	Aircraft:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 373
 		Repulsable: False
 		AirborneUpgrades: airborne
@@ -222,7 +222,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Chinook Transport
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 140
 	RevealsShroud:
 		Range: 8c0
@@ -239,7 +239,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Apache Longbow
 	Aircraft:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
@@ -254,7 +254,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca
 	Aircraft:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -66,7 +66,7 @@
 			Tiberium: 50
 			BlueTiberium: 50
 			Beach: 50
-		ROT: 5
+		TurnSpeed: 5
 	SelectionDecorations:
 	Selectable:
 		Bounds: 24,24
@@ -112,7 +112,7 @@
 			Tiberium: 70
 			BlueTiberium: 70
 			Beach: 70
-		ROT: 5
+		TurnSpeed: 5
 	Tooltip:
 		GenericName: Tank
 

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -10,13 +10,13 @@ BOAT:
 		Type: Heavy
 	Mobile:
 		InitialFacing: 64
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 28
 		OnRails: true
 	RevealsShroud:
 		Range: 7c0
 	Turreted:
-		ROT: 7
+		TurnSpeed: 7
 		Offset: 0,896,171
 	Armament:
 		Weapon: BoatMissile
@@ -60,7 +60,7 @@ LST:
 			Beach: 100
 			River: 100
 		InitialFacing: 0
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 142
 	Health:
 		HP: 400

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -667,7 +667,7 @@ GUN:
 	Bib:
 		HasMinibib: Yes
 	Turreted:
-		ROT: 12
+		TurnSpeed: 12
 		InitialFacing: 56
 	-WithSpriteBody:
 	WithTurretedSpriteBody:
@@ -710,7 +710,7 @@ SAM:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		InitialFacing: 0
 		RealignDelay: -1
 	-WithSpriteBody:
@@ -803,7 +803,7 @@ GTWR:
 		Range: 3c0
 	WithMuzzleOverlay:
 	Turreted:
-		ROT: 255
+		TurnSpeed: 255
 	Power:
 		Amount: -10
 
@@ -838,7 +838,7 @@ ATWR:
 	Bib:
 		HasMinibib: Yes
 	Turreted:
-		ROT: 255
+		TurnSpeed: 255
 		Offset: 128,128,0
 	Armament@PRIMARY:
 		Weapon: TowerMissle

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -91,7 +91,7 @@ APC:
 	Mobile:
 		UpgradeTypes: notmobile
 		UpgradeMaxEnabledLevel: 0
-		ROT: 8
+		TurnSpeed: 8
 		Speed: 128
 	Health:
 		HP: 210
@@ -100,7 +100,7 @@ APC:
 	RevealsShroud:
 		Range: 7c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 	Armament@PRIMARY:
 		Weapon: APCGun
 		Recoil: 96
@@ -138,7 +138,7 @@ ARTY:
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.Nod
 	Mobile:
-		ROT: 2
+		TurnSpeed: 2
 		Speed: 85
 	Health:
 		HP: 75
@@ -173,7 +173,7 @@ FTNK:
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.Nod
 	Mobile:
-		ROT: 7
+		TurnSpeed: 7
 		Speed: 99
 	Health:
 		HP: 270
@@ -206,7 +206,7 @@ BGGY:
 		Prerequisites: afld
 		Queue: Vehicle.Nod
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 170
 	Health:
 		HP: 120
@@ -215,7 +215,7 @@ BGGY:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		Offset: -43,0,128
 	Armament:
 		Weapon: MachineGun
@@ -240,7 +240,7 @@ BIKE:
 		Prerequisites: afld
 		Queue: Vehicle.Nod
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 213
 		TerrainSpeeds:
 			Clear: 70
@@ -276,7 +276,7 @@ JEEP:
 		Prerequisites: weap
 		Queue: Vehicle.GDI
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 156
 	Health:
 		HP: 160
@@ -285,7 +285,7 @@ JEEP:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		Offset: -85,0,128
 	Armament:
 		Weapon: MachineGun
@@ -310,7 +310,7 @@ LTNK:
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.Nod
 	Mobile:
-		ROT: 7
+		TurnSpeed: 7
 		Speed: 110
 	Health:
 		HP: 340
@@ -319,7 +319,7 @@ LTNK:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		ROT: 7
+		TurnSpeed: 7
 	Armament:
 		Weapon: 70mm
 		Recoil: 85
@@ -353,7 +353,7 @@ MTNK:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 	Armament:
 		Weapon: 120mm
 		Recoil: 128
@@ -383,7 +383,7 @@ HTNK:
 	Mobile:
 		Crushes: wall, heavywall, crate, infantry
 		Speed: 56
-		ROT: 3
+		TurnSpeed: 3
 	Health:
 		HP: 800
 	Armor:
@@ -392,7 +392,7 @@ HTNK:
 		Range: 6c0
 	WithSpriteTurret:
 	Turreted:
-		ROT: 3
+		TurnSpeed: 3
 	Armament@PRIMARY:
 		Weapon: 120mmDual
 		LocalOffset: 900,180,340, 900,-180,340
@@ -431,7 +431,7 @@ MSAM:
 		Queue: Vehicle.GDI
 	Mobile:
 		Speed: 85
-		ROT: 4
+		TurnSpeed: 4
 	Health:
 		HP: 120
 	Armor:
@@ -439,7 +439,7 @@ MSAM:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		ROT: 255
+		TurnSpeed: 255
 		Offset: -256,0,128
 	Armament@PRIMARY:
 		Weapon: 227mm
@@ -467,7 +467,7 @@ MLRS:
 		Queue: Vehicle.Nod
 	Mobile:
 		Speed: 99
-		ROT: 7
+		TurnSpeed: 7
 	Health:
 		HP: 120
 	Armor:
@@ -475,7 +475,7 @@ MLRS:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		ROT: 8
+		TurnSpeed: 8
 		Offset: -128,0,128
 		RealignDelay: 0
 	Armament:
@@ -508,7 +508,7 @@ STNK:
 		Prerequisites: tmpl, ~techlevel.high
 		Queue: Vehicle.Nod
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 142
 		Crushes: crate, infantry
 	Health:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -14,8 +14,8 @@ carryall.reinforce:
 	Aircraft:
 		CruiseAltitude: 2100
 		InitialFacing: 0
-		ROT: 4
 		Speed: 144 # 112 * ~1.3 for balance reasons
+		TurnSpeed: 4
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune
 		Repulsable: False
 		LandAltitude: 100
@@ -57,8 +57,8 @@ frigate:
 		Name: Frigate
 		Description: Supply spacecraft
 	Aircraft:
-		ROT: 1
 		Speed: 189 # 126 * ~1.5 for balance reasons
+		TurnSpeed: 1
 		Repulsable: False
 		MaximumPitch: 20
 	-AppearsOnRadar:
@@ -79,8 +79,8 @@ ornithopter:
 	Armor:
 		Type: light
 	Aircraft:
-		ROT: 2
 		Speed: 224 # 189 * ~1.2 for balance reasons
+		TurnSpeed: 2
 		Repulsable: False
 		CanHover: True
 	AmmoPool:
@@ -96,7 +96,7 @@ ornithopter.husk:
 	Tooltip:
 		Name: Ornithopter
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 224
 	RenderSprites:
 		Image: ornithopter
@@ -106,7 +106,7 @@ carryall.husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 144
 		CanHover: True
 	RenderSprites:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -70,7 +70,7 @@
 			Spice: 100
 			SpiceBlobs: 100
 			Dune: 50
-		ROT: 5
+		TurnSpeed: 5
 	SelectionDecorations:
 	Selectable:
 		Bounds: 32,32

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -687,7 +687,7 @@ medium_gun_turret:
 		QuantizedFacings: 32
 	WithMuzzleOverlay:
 	Turreted:
-		ROT: 6
+		TurnSpeed: 6
 		InitialFacing: 128
 	Armament:
 		Weapon: 110mm_Gun
@@ -731,7 +731,7 @@ large_gun_turret:
 		Weapon: TowerMissile
 		LocalOffset: 256,384,768, 256,-384,768
 	Turreted:
-		ROT: 8
+		TurnSpeed: 8
 		InitialFacing: 128
 	RequiresPower:
 	CanPowerDown:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -117,7 +117,7 @@ trike:
 	Armor:
 		Type: wood
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 128
 	RevealsShroud:
 		Range: 4c768
@@ -155,7 +155,7 @@ quad:
 	Armor:
 		Type: light
 	Mobile:
-		ROT: 8
+		TurnSpeed: 8
 		Speed: 96
 	RevealsShroud:
 		Range: 4c768
@@ -191,11 +191,11 @@ siege_tank:
 		Type: light
 	Mobile:
 		Speed: 43
-		ROT: 3
+		TurnSpeed: 3
 	RevealsShroud:
 		Range: 6c768
 	Turreted:
-		ROT: 3
+		TurnSpeed: 3
 		Offset: 0,0,-32
 	Armament:
 		Weapon: 155mm
@@ -233,7 +233,7 @@ missile_tank:
 		Value: 441
 	Mobile:
 		Speed: 64
-		ROT: 5
+		TurnSpeed: 5
 	Health:
 		HP: 1300
 	Armor:
@@ -274,7 +274,7 @@ sonic_tank:
 	Armor:
 		Type: light
 	Mobile:
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 31
 	RevealsShroud:
 		Range: 5c768
@@ -311,7 +311,7 @@ devastator:
 	Armor:
 		Type: heavy
 	Mobile:
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 31
 		Crushes: crate, infantry, spicebloom, wall
 	RevealsShroud:
@@ -356,7 +356,7 @@ raider:
 	Armor:
 		Type: wood
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 149
 	RevealsShroud:
 		Range: 4c768
@@ -413,7 +413,7 @@ deviator:
 		BuildPaletteOrder: 50
 		Prerequisites: ~heavy.ordos, research_centre, ~techlevel.high
 	Mobile:
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 53
 	Health:
 		HP: 1100
@@ -453,11 +453,11 @@ deviator:
 		Type: heavy
 	Mobile:
 		Speed: 75
-		ROT: 5
+		TurnSpeed: 5
 	RevealsShroud:
 		Range: 5c768
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 		RealignDelay: 0
 	Armament:
 		Weapon: 80mm_A
@@ -504,7 +504,7 @@ combat_tank_o:
 	Buildable:
 		Prerequisites: ~heavy.ordos
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 	Armament:
 		Weapon: 80mm_O
 	Mobile:

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -1724,7 +1724,7 @@ Rules:
 		RevealsShroud:
 			Range: 0c0
 		Turreted:
-			ROT: 15
+			TurnSpeed: 15
 			InitialFacing: 224
 		RenderSprites:
 			Image: AGUN

--- a/mods/ra/maps/bomber-john/map.yaml
+++ b/mods/ra/maps/bomber-john/map.yaml
@@ -827,7 +827,7 @@ Rules:
 			Speed: 128
 			WaitAverage: 1
 			WaitSpread: 1
-			ROT: 900
+			TurnSpeed: 900
 		RevealsShroud:
 			Range: 40c0
 		MustBeDestroyed:

--- a/mods/ra/maps/fort-lonestar/map.yaml
+++ b/mods/ra/maps/fort-lonestar/map.yaml
@@ -736,7 +736,7 @@ Rules:
 		RevealsShroud:
 			Range: 14c0
 		Turreted:
-			ROT: 1
+			TurnSpeed: 1
 		Armament@PRIMARY:
 			Recoil: 8
 			RecoilRecovery: 0c7

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -2204,7 +2204,7 @@ Rules:
 		RevealsShroud:
 			Range: 6c0
 		Turreted:
-			ROT: 1
+			TurnSpeed: 1
 		Armament@PRIMARY:
 			Weapon: SuperTankPrimary
 			LocalOffset: 900,180,340, 900,-180,340

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -8,7 +8,7 @@ BADR:
 		Type: Light
 	Aircraft:
 		CruiseAltitude: 2560
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 149
 		Repulsable: False
 		MaximumPitch: 56
@@ -45,7 +45,7 @@ BADR.Bomber:
 		Type: Light
 	Aircraft:
 		CruiseAltitude: 2560
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 149
 		Repulsable: False
 		MaximumPitch: 56
@@ -101,7 +101,7 @@ MIG:
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 223
 		RepulsionSpeed: 40
 		MaximumPitch: 56
@@ -161,7 +161,7 @@ YAK:
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 178
 		RepulsionSpeed: 40
 		MaximumPitch: 56
@@ -208,7 +208,7 @@ TRAN:
 		Type: CenterPosition
 	Aircraft:
 		InitialFacing: 224
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 112
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach
 		AltitudeVelocity: 0c100
@@ -257,7 +257,7 @@ HELI:
 	Aircraft:
 		LandWhenIdle: false
 		InitialFacing: 224
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 149
 	AutoTarget:
 		InitialStance: HoldFire
@@ -308,7 +308,7 @@ HIND:
 	Aircraft:
 		LandWhenIdle: false
 		InitialFacing: 224
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 112
 	AutoTarget:
 		InitialStance: HoldFire
@@ -338,7 +338,7 @@ U2:
 		Type: Heavy
 	Aircraft:
 		CruiseAltitude: 2560
-		ROT: 7
+		TurnSpeed: 7
 		Speed: 373
 		Repulsable: False
 		MaximumPitch: 56

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -79,7 +79,7 @@
 			Ore: 70
 			Gems: 70
 			Beach: 40
-		ROT: 5
+		TurnSpeed: 5
 	SelectionDecorations:
 	Selectable:
 		Bounds: 24, 24

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -86,7 +86,7 @@ TRAN.Husk:
 	Tooltip:
 		Name: Transport Helicopter
 	Aircraft:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 149
 	WithSpriteRotorOverlay@PRIMARY:
 		Offset: -597,0,341
@@ -117,7 +117,7 @@ BADR.Husk:
 	Tooltip:
 		Name: Badger
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 149
 	SmokeTrailWhenDamaged@0:
 		Offset: -432,560,0
@@ -139,7 +139,7 @@ MIG.Husk:
 	Contrail@2:
 		Offset: -598,683,0
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 186
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,171
@@ -158,7 +158,7 @@ YAK.Husk:
 	Contrail:
 		Offset: -853,0,0
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 149
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,0
@@ -175,7 +175,7 @@ HELI.Husk:
 	Tooltip:
 		Name: Longbow
 	Aircraft:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 149
 	WithSpriteRotorOverlay:
 		Offset: 0,0,85
@@ -193,7 +193,7 @@ HIND.Husk:
 	Tooltip:
 		Name: Hind
 	Aircraft:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 112
 	WithSpriteRotorOverlay:
 	SmokeTrailWhenDamaged:
@@ -210,7 +210,7 @@ U2.Husk:
 	EditorOnlyTooltip:
 		Name: Husk (U2 Spy Plane)
 	Aircraft:
-		ROT: 7
+		TurnSpeed: 7
 		Speed: 373
 	Contrail@1:
 		Offset: -725,683,0

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -597,7 +597,7 @@ Ant:
 			Radius: 469
 	Mobile:
 		Speed: 99
-		ROT: 12
+		TurnSpeed: 12
 		SharesCell: no
 	AutoTarget:
 		ScanRadius: 5

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -15,7 +15,7 @@ SS:
 	Armor:
 		Type: Light
 	Mobile:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 71
 	RevealsShroud:
 		Range: 6c0
@@ -71,7 +71,7 @@ MSUB:
 	Armor:
 		Type: Light
 	Mobile:
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 42
 	RevealsShroud:
 		Range: 6c0
@@ -127,12 +127,12 @@ DD:
 	Armor:
 		Type: Heavy
 	Mobile:
-		ROT: 7
+		TurnSpeed: 7
 		Speed: 85
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		ROT: 7
+		TurnSpeed: 7
 		Offset: 341,0,128
 	Armament@PRIMARY:
 		Weapon: Stinger
@@ -173,18 +173,18 @@ CA:
 	Armor:
 		Type: Heavy
 	Mobile:
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 42
 	RevealsShroud:
 		Range: 7c0
 	Turreted@PRIMARY:
 		Turret: primary
 		Offset: -864,0,128
-		ROT: 3
+		TurnSpeed: 3
 	Turreted@SECONDARY:
 		Turret: secondary
 		Offset: 768,0,128
-		ROT: 3
+		TurnSpeed: 3
 	Armament@PRIMARY:
 		Turret: primary
 		Weapon: 8Inch
@@ -228,7 +228,7 @@ LST:
 	Mobile:
 		UpgradeTypes: notmobile
 		UpgradeMaxEnabledLevel: 0
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 113
 	RevealsShroud:
 		Range: 6c0
@@ -261,12 +261,12 @@ PT:
 	Armor:
 		Type: Heavy
 	Mobile:
-		ROT: 7
+		TurnSpeed: 7
 		Speed: 128
 	RevealsShroud:
 		Range: 7c0
 	Turreted:
-		ROT: 7
+		TurnSpeed: 7
 		Offset: 512,0,0
 	Armament@PRIMARY:
 		Weapon: 2Inch

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -475,7 +475,7 @@ AGUN:
 	Bib:
 		HasMinibib: Yes
 	Turreted:
-		ROT: 15
+		TurnSpeed: 15
 		InitialFacing: 224
 	-WithSpriteBody:
 	WithTurretedSpriteBody:
@@ -554,7 +554,7 @@ PBOX:
 	Bib:
 		HasMinibib: Yes
 	Turreted:
-		ROT: 255
+		TurnSpeed: 255
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
@@ -601,7 +601,7 @@ HBOX:
 		CloakDelay: 60
 		IsPlayerPalette: true
 	Turreted:
-		ROT: 255
+		TurnSpeed: 255
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
@@ -647,7 +647,7 @@ GUN:
 	Bib:
 		HasMinibib: Yes
 	Turreted:
-		ROT: 12
+		TurnSpeed: 12
 		InitialFacing: 56
 	-WithSpriteBody:
 	WithTurretedSpriteBody:
@@ -687,7 +687,7 @@ FTUR:
 	Bib:
 		HasMinibib: Yes
 	Turreted:
-		ROT: 255
+		TurnSpeed: 255
 		Offset: 0,0,112
 	Armament:
 		Weapon: FireballLauncher
@@ -730,7 +730,7 @@ SAM:
 	Bib:
 		HasMinibib: Yes
 	Turreted:
-		ROT: 30
+		TurnSpeed: 30
 		InitialFacing: 0
 	-WithSpriteBody:
 	WithTurretedSpriteBody:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -52,7 +52,7 @@ V2RL:
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
-		ROT: 7
+		TurnSpeed: 7
 	Armament:
 		Weapon: 25mm
 		Recoil: 85
@@ -89,7 +89,7 @@ V2RL:
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 	Armament:
 		Weapon: 90mm
 		Recoil: 128
@@ -128,7 +128,7 @@ V2RL:
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 	Armament:
 		Weapon: 105mm
 		Recoil: 128
@@ -169,7 +169,7 @@ V2RL:
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		ROT: 2
+		TurnSpeed: 2
 	Armament@PRIMARY:
 		Weapon: 120mm
 		LocalOffset: 900,180,340, 900,-180,340
@@ -215,7 +215,7 @@ ARTY:
 	Armor:
 		Type: Light
 	Mobile:
-		ROT: 2
+		TurnSpeed: 2
 		Speed: 85
 	RevealsShroud:
 		Range: 5c0
@@ -332,14 +332,14 @@ JEEP:
 	Armor:
 		Type: Light
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 170
 		UpgradeTypes: notmobile
 		UpgradeMaxEnabledLevel: 0
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		Offset: 0,0,85
 	Armament:
 		Weapon: M60mg
@@ -595,12 +595,12 @@ FTRK:
 	Armor:
 		Type: Light
 	Mobile:
-		ROT: 10
+		TurnSpeed: 10
 		Speed: 128
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		Offset: -298,0,298
 	Armament@AA:
 		Weapon: FLAK-23-AA
@@ -744,7 +744,7 @@ STNK:
 		Weapon: APTusk
 		LocalOffset: 400,0,0
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 	AttackTurreted:
 	WithSpriteTurret:
 	Cargo:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -6,7 +6,7 @@ DPOD:
 		Name: Drop Pod
 	Aircraft:
 		LandWhenIdle: yes
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
 		LandableTerrainTypes: Clear
@@ -42,7 +42,7 @@ DSHP:
 		Name: Dropship
 	Aircraft:
 		LandWhenIdle: yes
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 168
 		InitialFacing: 0
 		LandableTerrainTypes: Clear
@@ -79,7 +79,7 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 186
 		MoveIntoShroud: false
 		TakeoffSound: orcaup1.aud
@@ -122,7 +122,7 @@ ORCAB:
 	Aircraft:
 		CruiseAltitude: 3072
 		MaximumPitch: 120
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 96
 		AirborneUpgrades: airborne
 		MoveIntoShroud: false
@@ -168,7 +168,7 @@ ORCATRAN:
 	RenderSprites:
 	Aircraft:
 		LandWhenIdle: yes
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 84
 		InitialFacing: 0
 		LandableTerrainTypes: Clear
@@ -204,7 +204,7 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 	Aircraft:
 		LandWhenIdle: yes
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
 		LandableTerrainTypes: Clear
@@ -242,7 +242,7 @@ SCRIN:
 		VoiceSet: Scrin
 	Aircraft:
 		MaximumPitch: 90
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 168
 		AirborneUpgrades: airborne
 		MoveIntoShroud: false
@@ -286,7 +286,7 @@ APACHE:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 130
 		MoveIntoShroud: false
 	Health:
@@ -329,7 +329,7 @@ HUNTER:
 		Weapon: SuicideBomb
 		EmptyWeapon: SuicideBomb
 	Aircraft:
-		ROT: 16
+		TurnSpeed: 16
 		Speed: 355
 		CruiseAltitude: 256
 		CanHover: True

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -6,7 +6,7 @@
 		Name: Mammoth Tank
 	Mobile:
 		Speed: 56
-		ROT: 5
+		TurnSpeed: 5
 		Crushes: wall, crate, infantry
 	Health:
 		HP: 600
@@ -15,7 +15,7 @@
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
-		ROT: 3
+		TurnSpeed: 3
 	Armament@PRIMARY:
 		Weapon: 120mmx
 		LocalOffset: 500,60,360, 500,-85,360
@@ -67,7 +67,7 @@ ICBM:
 		Type: Light
 	Mobile:
 		Speed: 85
-		ROT: 5
+		TurnSpeed: 5
 	RevealsShroud:
 		Range: 7c0
 	Transforms:
@@ -85,7 +85,7 @@ BUS:
 	Tooltip:
 		Name: School Bus
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 113
 	Health:
 		HP: 100
@@ -108,7 +108,7 @@ PICK:
 	Tooltip:
 		Name: Pickup
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 113
 	Health:
 		HP: 100
@@ -131,7 +131,7 @@ CAR:
 	Tooltip:
 		Name: Automobile
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 113
 	Health:
 		HP: 100
@@ -154,7 +154,7 @@ WINI:
 	Tooltip:
 		Name: Recreational Vehicle
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 113
 	Health:
 		HP: 200

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -396,7 +396,7 @@
 			Tiberium: 50
 			BlueTiberium: 50
 			Veins: 50
-		ROT: 5
+		TurnSpeed: 5
 		Voice: Move
 	Selectable:
 		Bounds: 40,24
@@ -568,7 +568,7 @@
 		Type: Light
 	Mobile:
 		Speed: 113
-		ROT: 16
+		TurnSpeed: 16
 		Crushes: crate
 		SharesCell: no
 		TerrainSpeeds:
@@ -717,7 +717,7 @@
 		TerrainSpeeds:
 			Rail: 100
 		Crushes: wall, crate, infantry
-		ROT: 5
+		TurnSpeed: 5
 		Voice: Move
 		Speed: 113
 	Cargo:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -73,7 +73,7 @@ GACTWR:
 		UpgradeTypes: tower
 		UpgradeMinEnabledLevel: 1
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		InitialFacing: 50
 	AttackTurreted:
 		UpgradeTypes: tower

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -10,7 +10,7 @@ APC:
 		BuildPaletteOrder: 30
 		Prerequisites: ~gaweap, gapile
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 113
 		TerrainSpeeds:
 			Water: 80
@@ -21,7 +21,7 @@ APC:
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
@@ -71,7 +71,7 @@ HVR:
 		Weapon: HoverMissile
 		LocalOffset: 0,171,384, 0,-171,384
 	Turreted:
-		ROT: 7
+		TurnSpeed: 7
 		Offset: -128,0,85
 	AttackTurreted:
 		Voice: Attack
@@ -98,7 +98,7 @@ SMECH:
 		BuildPaletteOrder: 10
 		Prerequisites: ~gaweap
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 99
 	Health:
 		HP: 175
@@ -136,7 +136,7 @@ MMCH:
 		BuildPaletteOrder: 30
 		Prerequisites: ~gaweap
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 56
 		Crushes: wall, crate, infantry
 	Health:
@@ -149,7 +149,7 @@ MMCH:
 		QuantizedFacings: 32
 	WithInfantryBody:
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 	AttackTurreted:
 		Voice: Attack
 	WithSpriteTurret:
@@ -178,7 +178,7 @@ HMEC:
 		Prerequisites: ~gaweap, gatech
 		BuildLimit: 1
 	Mobile:
-		ROT: 3
+		TurnSpeed: 3
 		Speed: 42
 		Crushes: wall, crate, infantry
 	Health:
@@ -217,7 +217,7 @@ SONIC:
 	Targetable:
 		TargetTypes: Ground, Vehicle, Repair, Disruptor
 	Mobile:
-		ROT: 4
+		TurnSpeed: 4
 		Speed: 56
 		Crushes: wall, crate, infantry
 	Health:
@@ -232,7 +232,7 @@ SONIC:
 	AttackTurreted:
 		Voice: Attack
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 		Offset: -170,0,0
 	AutoTarget:
 	WithVoxelTurret:

--- a/mods/ts/rules/husks.yaml
+++ b/mods/ts/rules/husks.yaml
@@ -3,7 +3,7 @@ DSHP.Husk:
 	Tooltip:
 		Name: Dropship
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 168
 	RenderSprites:
 		Image: dshp
@@ -15,7 +15,7 @@ ORCA.Husk:
 	Tooltip:
 		Name: Orca Fighter
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 186
 	RenderSprites:
 		Image: orca
@@ -27,7 +27,7 @@ ORCAB.Husk:
 	Tooltip:
 		Name: Orca Bomber
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 96
 	RenderSprites:
 		Image: orcab
@@ -39,7 +39,7 @@ ORCATRAN.Husk:
 	Tooltip:
 		Name: Orca Transport
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 84
 	RenderSprites:
 		Image: orcatran
@@ -51,7 +51,7 @@ TRNSPORT.Husk:
 	Tooltip:
 		Name: Carryall
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 149
 	RenderSprites:
 		Image: trnsport
@@ -63,7 +63,7 @@ SCRIN.Husk:
 	Tooltip:
 		Name: Banshee Fighter
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 168
 	RenderSprites:
 		Image: scrin
@@ -75,7 +75,7 @@ APACHE.Husk:
 	Tooltip:
 		Name: Harpy
 	Aircraft:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 130
 	WithSpriteRotorOverlay:
 		Offset: 85,0,384

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -68,7 +68,7 @@ NALASR:
 	DetectCloaked:
 		Range: 3c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		InitialFacing: 300
 		Offset: 298,-171,288
 	AttackTurreted:
@@ -150,7 +150,7 @@ NASAM:
 	RenderRangeCircle:
 		RangeCircleType: aa
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		InitialFacing: 50
 	AttackTurreted:
 	WithSpriteTurret:
@@ -176,7 +176,7 @@ GAARTY:
 	RevealsShroud:
 		Range: 9c0
 	Turreted:
-		ROT: 5
+		TurnSpeed: 5
 		InitialFacing: 128
 		Offset: 0,0,171
 	Armament:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -10,7 +10,7 @@ BGGY:
 		BuildPaletteOrder: 40
 		Prerequisites: ~naweap
 	Mobile:
-		ROT: 8
+		TurnSpeed: 8
 		Speed: 142
 	Health:
 		HP: 220
@@ -40,7 +40,7 @@ BIKE:
 		BuildPaletteOrder: 30
 		Prerequisites: ~naweap
 	Mobile:
-		ROT: 8
+		TurnSpeed: 8
 		Speed: 170
 	Health:
 		HP: 150
@@ -75,7 +75,7 @@ TTNK:
 		BuildPaletteOrder: 60
 		Prerequisites: ~naweap
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 85
 		Crushes: wall, crate, infantry
 	Health:
@@ -122,7 +122,7 @@ TTNK:
 		UpgradeMinEnabledLevel: 1
 		UpgradeMaxAcceptedLevel: 1
 	Turreted:
-		ROT: 6
+		TurnSpeed: 6
 		Turret: deployed
 		InitialFacing: 128
 		Offset: -20, -130, 180
@@ -179,7 +179,7 @@ ART2:
 		Type: Light
 	Mobile:
 		Speed: 71
-		ROT: 2
+		TurnSpeed: 2
 	RevealsShroud:
 		Range: 9c0
 	RenderVoxels:
@@ -206,7 +206,7 @@ REPAIR:
 		HP: 200
 	Mobile:
 		Speed: 85
-		ROT: 5
+		TurnSpeed: 5
 	RevealsShroud:
 		Range: 5c0
 	Armament:
@@ -241,7 +241,7 @@ WEED:
 		DeliverVoice: Move
 	Mobile:
 		Speed: 71
-		ROT: 5
+		TurnSpeed: 5
 	Health:
 		HP: 600
 	SelfHealing:
@@ -268,7 +268,7 @@ SAPC:
 		BuildPaletteOrder: 30
 		Prerequisites: ~naweap, natech
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 71
 	Health:
 		HP: 175
@@ -296,7 +296,7 @@ SUBTANK:
 		BuildPaletteOrder: 40
 		Prerequisites: ~naweap, natech
 	Mobile:
-		ROT: 6
+		TurnSpeed: 6
 		Speed: 71
 		Crushes: wall, crate, infantry
 	Health:
@@ -323,7 +323,7 @@ STNK:
 		Prerequisites: ~naweap, natech
 		Queue: Vehicle
 	Mobile:
-		ROT: 5
+		TurnSpeed: 5
 		Speed: 85
 		Crushes: wall, crate, infantry
 	Health:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -23,7 +23,7 @@ NAPULS:
 	RevealsShroud:
 		Range: 8c0
 	Turreted:
-		ROT: 10
+		TurnSpeed: 10
 		InitialFacing: 300
 	AttackTurreted:
 	Armament:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -117,7 +117,7 @@ LPST:
 		Type: Wood
 	Mobile:
 		Speed: 85
-		ROT: 5
+		TurnSpeed: 5
 	RevealsShroud:
 		Range: 7c0
 	RenderSprites:


### PR DESCRIPTION
...on `Mobile`, `Aircraft`, `Turreted` and `ThrowsParticle`.

It was mentioned long time ago that we should get rid of abbreviations.

For the record: `TurnSpeed` got the most agreement on IRC (because it matches `Speed`), so I will not rename it again.
