### PR TITLE
Fix a theoretical null reference in UpgradeWeaponRules.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -650,7 +650,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 					else
 					{
-						if (node.Key == "MaximumLaunchSpeed" && parent.Value.Value == "Missile")
+						if (node.Key == "MaximumLaunchSpeed" && parent != null && parent.Value.Value == "Missile")
 							node.Key = "Speed";
 					}
 				}


### PR DESCRIPTION
Parent is null at the root level, so we should ensure we don't explode on that.

Discovered by Coverity.
