### PR TITLE
Prevent locked spawns from being selected by other players.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -146,6 +146,11 @@ namespace OpenRA.Mods.Common.Server
 						if (slot.Closed || server.LobbyInfo.ClientInSlot(s) != null)
 							return false;
 
+						// If the previous slot had a locked spawn then we must not carry that to the new slot
+						var oldSlot = client.Slot != null ? server.LobbyInfo.Slots[client.Slot] : null;
+						if (oldSlot != null && oldSlot.LockSpawn)
+							client.SpawnPoint = 0;
+
 						client.Slot = s;
 						S.SyncClientToPlayerReference(client, server.MapPlayers.Players[s]);
 


### PR DESCRIPTION
Fixes #10230.

A future PR (which depends on the ongoing map format cleanups) will be able to hide these invalid spawns from the lobby GUI.  For now, the error message will have to do.
