### PR TITLE
Fix GravityBomb crash when Image is null

### DIFF
--- a/OpenRA.Mods.Common/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Effects/GravityBomb.cs
@@ -31,6 +31,8 @@ namespace OpenRA.Mods.Common.Effects
 
 		public readonly bool Shadow = false;
 
+		[PaletteReference] public readonly string ShadowPalette = "shadow";
+
 		public readonly WDist Velocity = WDist.Zero;
 
 		[Desc("Value added to velocity every tick.")]
@@ -95,7 +97,7 @@ namespace OpenRA.Mods.Common.Effects
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);
 					var shadowPos = pos - new WVec(0, 0, dat.Length);
-					foreach (var r in anim.Render(shadowPos, wr.Palette("shadow")))
+					foreach (var r in anim.Render(shadowPos, wr.Palette(info.ShadowPalette)))
 						yield return r;
 				}
 

--- a/OpenRA.Mods.Common/Effects/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Effects/GravityBomb.cs
@@ -56,10 +56,10 @@ namespace OpenRA.Mods.Common.Effects
 			velocity = new WVec(WDist.Zero, WDist.Zero, -info.Velocity);
 			acceleration = new WVec(WDist.Zero, WDist.Zero, info.Acceleration);
 
-			anim = new Animation(args.SourceActor.World, info.Image);
-
 			if (!string.IsNullOrEmpty(info.Image))
 			{
+				anim = new Animation(args.SourceActor.World, info.Image);
+
 				if (!string.IsNullOrEmpty(info.OpenSequence))
 					anim.PlayThen(info.OpenSequence, () => anim.PlayRepeating(info.Sequence));
 				else
@@ -85,6 +85,9 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
+			if (anim == null)
+				yield break;
+
 			var world = args.SourceActor.World;
 			if (!world.FogObscures(pos))
 			{


### PR DESCRIPTION
Additionally,
- changed impact check to use `DistanceAboveTerrain` instead of `.Z`
- made shadow palette configurable

Closes  #10883.
