### PR TITLE
Fix players being able to command allied units to the service depot

### DIFF
--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -45,6 +45,10 @@ namespace OpenRA.Mods.Common.Orders
 			if (underCursor.Info.HasTraitInfo<RepairableBuildingInfo>())
 				yield return new Order("RepairBuilding", world.LocalPlayer.PlayerActor, false) { TargetActor = underCursor };
 
+			// Don't command allied units
+			if (underCursor.Owner != world.LocalPlayer)
+				yield break;
+
 			// Test for generic Repairable (used on units).
 			var repairable = underCursor.TraitOrDefault<Repairable>();
 			if (repairable == null)

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
 				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
-					&& a.Actor.Owner == self.Owner &&
+					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
 					info.RepairBuildings.Contains(a.Actor.Info.Name))
 				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
 


### PR DESCRIPTION
Fixes #10888.

You can also now use the repair cursor to order your units to allied repair pads, when you don't have one yourself (it'll drain your cash anyway).
