### PR TITLE
Clean up map tileset references.

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Graphics
 
 		public Animation(World world, string name, Func<int> facingFunc, Func<bool> paused)
 		{
-			sequenceProvider = world.Map.SequenceProvider;
+			sequenceProvider = world.Map.Rules.Sequences;
 			Name = name.ToLowerInvariant();
 			this.facingFunc = facingFunc;
 			this.paused = paused;

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Graphics
 {
 	sealed class TerrainRenderer : IDisposable
 	{
-		readonly World world;
+		readonly Map map;
 		readonly Dictionary<string, TerrainSpriteLayer> spriteLayers = new Dictionary<string, TerrainSpriteLayer>();
 		readonly Theater theater;
 		readonly CellLayer<TerrainTile> mapTiles;
@@ -25,19 +25,19 @@ namespace OpenRA.Graphics
 
 		public TerrainRenderer(World world, WorldRenderer wr)
 		{
-			this.world = world;
+			map = world.Map;
 			theater = wr.Theater;
-			mapTiles = world.Map.MapTiles.Value;
-			mapHeight = world.Map.MapHeight.Value;
+			mapTiles = map.MapTiles.Value;
+			mapHeight = map.MapHeight.Value;
 
-			foreach (var template in world.TileSet.Templates)
+			foreach (var template in map.Rules.TileSet.Templates)
 			{
 				var palette = template.Value.Palette ?? TileSet.TerrainPaletteInternalName;
 				spriteLayers.GetOrAdd(palette, pal =>
-					new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(palette), wr.World.Type != WorldType.Editor));
+					new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(palette), world.Type != WorldType.Editor));
 			}
 
-			foreach (var cell in world.Map.AllCells)
+			foreach (var cell in map.AllCells)
 				UpdateCell(cell);
 
 			mapTiles.CellEntryChanged += UpdateCell;
@@ -47,7 +47,7 @@ namespace OpenRA.Graphics
 		public void UpdateCell(CPos cell)
 		{
 			var tile = mapTiles[cell];
-			var palette = world.TileSet.Templates[tile.Type].Palette ?? TileSet.TerrainPaletteInternalName;
+			var palette = map.Rules.TileSet.Templates[tile.Type].Palette ?? TileSet.TerrainPaletteInternalName;
 			var sprite = theater.TileSprite(tile);
 			foreach (var kv in spriteLayers)
 				kv.Value.Update(cell, palette == kv.Key ? sprite : null);

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -47,7 +47,10 @@ namespace OpenRA.Graphics
 		public void UpdateCell(CPos cell)
 		{
 			var tile = mapTiles[cell];
-			var palette = map.Rules.TileSet.Templates[tile.Type].Palette ?? TileSet.TerrainPaletteInternalName;
+			var palette = TileSet.TerrainPaletteInternalName;
+			if (map.Rules.TileSet.Templates.ContainsKey(tile.Type))
+				palette = map.Rules.TileSet.Templates[tile.Type].Palette ?? palette;
+
 			var sprite = theater.TileSprite(tile);
 			foreach (var kv in spriteLayers)
 				kv.Value.Update(cell, palette == kv.Key ? sprite : null);

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Graphics
 			var world = worldRenderer.Viewport.ViewToWorldPx(view);
 			var map = worldRenderer.World.Map;
 			var candidates = CandidateMouseoverCells(world).ToList();
-			var tileSet = worldRenderer.World.TileSet;
+			var tileSet = worldRenderer.World.Map.Rules.TileSet;
 
 			foreach (var uv in candidates)
 			{

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Graphics
 
 			palette.Initialize();
 
-			Theater = new Theater(world.TileSet);
+			Theater = new Theater(world.Map.Rules.TileSet);
 			terrainRenderer = new TerrainRenderer(world, this);
 
 			devTrait = Exts.Lazy(() => world.LocalPlayer != null ? world.LocalPlayer.PlayerActor.Trait<DeveloperMode>() : null);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -171,7 +171,6 @@ namespace OpenRA
 
 		[FieldLoader.Ignore] Lazy<Ruleset> rules;
 		public Ruleset Rules { get { return rules != null ? rules.Value : null; } }
-		public SequenceProvider SequenceProvider { get { return Rules.Sequences; } }
 
 		[FieldLoader.Ignore] public ProjectedCellRegion ProjectedCellBounds;
 		[FieldLoader.Ignore] public CellRegion AllCells;

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -197,7 +197,7 @@ namespace OpenRA
 			using (new Support.PerfTimer("Map.PreloadRules"))
 				map.PreloadRules();
 			using (new Support.PerfTimer("Map.SequenceProvider.Preload"))
-				map.SequenceProvider.Preload();
+				map.Rules.Sequences.Preload();
 
 			// Load music with map assets mounted
 			using (new Support.PerfTimer("Map.Music"))

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Traits
 			Variants = new Dictionary<string, Sprite[]>();
 			foreach (var v in info.Variants)
 			{
-				var seq = world.Map.SequenceProvider.GetSequence(Info.Sequence, v);
+				var seq = world.Map.Rules.Sequences.GetSequence(Info.Sequence, v);
 				var sprites = Exts.MakeArray(seq.Length, x => seq.GetSprite(x));
 				Variants.Add(v, sprites);
 			}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -109,8 +109,6 @@ namespace OpenRA
 
 		public readonly Map Map;
 
-		public readonly TileSet TileSet;
-
 		public readonly ActorMap ActorMap;
 		public readonly ScreenMap ScreenMap;
 		public readonly WorldType Type;
@@ -159,8 +157,6 @@ namespace OpenRA
 			orderGenerator = new UnitOrderGenerator();
 			Map = map;
 			Timestep = orderManager.LobbyInfo.GlobalSettings.Timestep;
-
-			TileSet = map.Rules.TileSet;
 			SharedRandom = new MersenneTwister(orderManager.LobbyInfo.GlobalSettings.RandomSeed);
 
 			var worldActorType = type == WorldType.Editor ? "EditorWorld" : "World";

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -308,9 +308,10 @@ namespace OpenRA.Mods.Common.AI
 			attackForceTicks = Random.Next(0, Info.AttackForceInterval);
 			minAttackForceDelayTicks = Random.Next(0, Info.MinimumAttackForceDelay);
 
-			resourceTypeIndices = new BitArray(World.TileSet.TerrainInfo.Length); // Big enough
+			var tileset = World.Map.Rules.TileSet;
+			resourceTypeIndices = new BitArray(tileset.TerrainInfo.Length); // Big enough
 			foreach (var t in Map.Rules.Actors["world"].TraitInfos<ResourceTypeInfo>())
-				resourceTypeIndices.Set(World.TileSet.GetTerrainIndex(t.TerrainType), true);
+				resourceTypeIndices.Set(tileset.GetTerrainIndex(t.TerrainType), true);
 		}
 
 		// TODO: Possibly give this a more generic name when terrain type is unhardcoded
@@ -672,7 +673,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var harvInfo = harvester.Info.TraitInfo<HarvesterInfo>();
 			var mobileInfo = harvester.Info.TraitInfo<MobileInfo>();
-			var passable = (uint)mobileInfo.GetMovementClass(World.TileSet);
+			var passable = (uint)mobileInfo.GetMovementClass(World.Map.Rules.TileSet);
 
 			var path = pathfinder.FindPath(
 				PathSearch.Search(World, mobileInfo, harvester, true,

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Activities
 			var searchRadiusSquared = searchRadius * searchRadius;
 
 			// Find any harvestable resources:
-			var passable = (uint)mobileInfo.GetMovementClass(self.World.TileSet);
+			var passable = (uint)mobileInfo.GetMovementClass(self.World.Map.Rules.TileSet);
 			List<CPos> path;
 			using (var search = PathSearch.Search(self.World, mobileInfo, self, true,
 				loc => domainIndex.IsPassable(self.Location, loc, passable) && self.CanHarvestAt(loc, resLayer, harvInfo, territory))

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 			mobile = self.Trait<Mobile>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
-			movementClass = (uint)mobile.Info.GetMovementClass(self.World.TileSet);
+			movementClass = (uint)mobile.Info.GetMovementClass(self.World.Map.Rules.TileSet);
 
 			if (target.IsValidFor(self))
 				targetPosition = self.World.Map.CellContaining(target.CenterPosition);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -37,8 +37,7 @@ namespace OpenRA.Mods.Common.Widgets
 			preview.IsVisible = () => editorWidget.CurrentBrush == this;
 
 			var variant = resource.Variants.FirstOrDefault();
-			var sequenceProvider = wr.World.Map.Rules.Sequences;
-			var sequence = sequenceProvider.GetSequence("resources", variant);
+			var sequence = wr.World.Map.Rules.Sequences.GetSequence("resources", variant);
 			var sprite = sequence.GetSprite(resource.MaxDensity - 1);
 			preview.GetSprite = () => sprite;
 
@@ -83,11 +82,11 @@ namespace OpenRA.Mods.Common.Widgets
 				return false;
 
 			var tile = world.Map.MapTiles.Value[cell];
-			var tileInfo = world.TileSet.GetTileInfo(tile);
+			var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
 			if (tileInfo == null)
 				return false;
 
-			var terrainType = world.TileSet.TerrainInfo[tileInfo.TerrainType];
+			var terrainType = world.Map.Rules.TileSet.TerrainInfo[tileInfo.TerrainType];
 
 			if (mapResources[cell].Type == ResourceType.ResourceType)
 				return false;

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 			preview.GetScale = () => worldRenderer.Viewport.Zoom;
 			preview.IsVisible = () => editorWidget.CurrentBrush == this;
 
-			preview.Template = world.TileSet.Templates.First(t => t.Value.Id == template).Value;
+			preview.Template = world.Map.Rules.TileSet.Templates.First(t => t.Value.Id == template).Value;
 			var grid = world.Map.Grid;
 			bounds = worldRenderer.Theater.TemplateBounds(preview.Template, grid.TileSize, grid.Type);
 

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -56,8 +56,8 @@ namespace OpenRA.Mods.Common.Orders
 			faction = buildableInfo.ForceFaction
 				?? (mostLikelyProducer.Trait != null ? mostLikelyProducer.Trait.Faction : queue.Actor.Owner.Faction.InternalName);
 
-			buildOk = map.SequenceProvider.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
-			buildBlocked = map.SequenceProvider.GetSequence("overlay", "build-invalid").GetSprite(0);
+			buildOk = map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
+			buildBlocked = map.Rules.Sequences.GetSequence("overlay", "build-invalid").GetSprite(0);
 
 			buildingInfluence = world.WorldActor.Trait<BuildingInfluence>();
 		}

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Orders
 				world.Selection.Clear();
 
 			var map = world.Map;
-			var tileset = world.TileSet.Id.ToLowerInvariant();
+			var tileset = world.Map.Tileset.ToLowerInvariant();
 
 			var info = map.Rules.Actors[building];
 			buildingInfo = info.TraitInfo<BuildingInfo>();

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 						throw new InvalidOperationException("Actor type '" + self.Info.Name + "' does not define a quantized body orientation.");
 				}
 
-				return qboi.QuantizedBodyFacings(self.Info, self.World.Map.SequenceProvider, faction);
+				return qboi.QuantizedBodyFacings(self.Info, self.World.Map.Rules.Sequences, faction);
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -130,8 +130,9 @@ namespace OpenRA.Mods.Common.Traits
 		byte GetTerrainType(CPos cell)
 		{
 			var dx = cell - self.Location;
-			var index = dx.X + self.World.TileSet.Templates[template].Size.X * dx.Y;
-			return self.World.TileSet.GetTerrainIndex(new TerrainTile(template, (byte)index));
+			var tileSet = self.World.Map.Rules.TileSet;
+			var index = dx.X + tileSet.Templates[template].Size.X * dx.Y;
+			return tileSet.GetTerrainIndex(new TerrainTile(template, (byte)index));
 		}
 
 		public void LinkNeighbouringBridges(World world, BridgeLayer bridges)

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var tile = world.Map.MapTiles.Value[cell];
-			var tileInfo = world.TileSet.GetTileInfo(tile);
+			var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
 
 			// TODO: This is bandaiding over bogus tilesets.
 			if (tileInfo != null && tileInfo.RampType > 0)

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -48,11 +48,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			var world = self.World;
 			var map = world.Map;
-			var tileSet = world.TileSet;
 
 			var tiles = map.MapTiles.Value;
 			var pos = map.CellContaining(self.CenterPosition);
-			var terrainType = tileSet[tileSet.GetTerrainIndex(tiles[pos])].Type;
+			var terrainType = map.GetTerrainInfo(pos).Type;
 
 			if (!Info.TerrainModifier.ContainsKey(terrainType))
 				return FullDamage;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Traits
 				// PERF: This struct allows us to cache the terrain info for the tileset used by the world.
 				// This allows us to speed up some performance-sensitive pathfinding calculations.
 				World = world;
-				TerrainInfos = info.TilesetTerrainInfo[world.TileSet];
+				TerrainInfos = info.TilesetTerrainInfo[world.Map.Rules.TileSet];
 			}
 		}
 
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public int MovementCostForCell(World world, CPos cell)
 		{
-			return MovementCostForCell(world.Map, TilesetTerrainInfo[world.TileSet], cell);
+			return MovementCostForCell(world.Map, TilesetTerrainInfo[world.Map.Rules.TileSet], cell);
 		}
 
 		int MovementCostForCell(Map map, TerrainInfo[] terrainInfos, CPos cell)
@@ -630,7 +630,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (index == byte.MaxValue)
 				return 0;
 
-			var terrainSpeed = Info.TilesetTerrainInfo[self.World.TileSet][index].Speed;
+			var terrainSpeed = Info.TilesetTerrainInfo[self.World.Map.Rules.TileSet][index].Speed;
 			if (terrainSpeed == 0)
 				return 0;
 

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			rotationBuffer = new uint[info.RotationRange];
-			tilesetId = world.TileSet.Id;
+			tilesetId = world.Map.Rules.TileSet.Id;
 
 			validTileset = IsValidTileset();
 		}

--- a/OpenRA.Mods.Common/Traits/RadarColorFromTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/RadarColorFromTerrain.cs
@@ -26,7 +26,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public RadarColorFromTerrain(Actor self, string terrain)
 		{
-			c = self.World.TileSet[self.World.TileSet.GetTerrainIndex(terrain)].Color;
+			var tileSet = self.World.Map.Rules.TileSet;
+			c = tileSet[tileSet.GetTerrainIndex(terrain)].Color;
 		}
 
 		public bool VisibleOnRadar(Actor self) { return true; }

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
-			var sequenceProvider = init.World.Map.SequenceProvider;
+			var sequenceProvider = init.World.Map.Rules.Sequences;
 			var faction = init.Get<FactionInit, string>();
 			var ownerName = init.Get<OwnerInit>().PlayerName;
 			var image = GetImage(init.Actor, sequenceProvider, faction);
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (cachedImage != null)
 				return cachedImage;
 
-			return cachedImage = info.GetImage(self.Info, self.World.Map.SequenceProvider, faction);
+			return cachedImage = info.GetImage(self.Info, self.World.Map.Rules.Sequences, faction);
 		}
 
 		public void UpdatePalette()

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var faction = init.Get<FactionInit, string>();
 			var ownerName = init.Get<OwnerInit>().PlayerName;
-			var sequenceProvider = init.World.Map.SequenceProvider;
+			var sequenceProvider = init.World.Map.Rules.Sequences;
 			var image = Image ?? init.Actor.Name;
 			var facings = body.QuantizedFacings == -1 ?
 				init.Actor.TraitInfo<IQuantizeBodyOrientationInfo>().QuantizedBodyFacings(init.Actor, sequenceProvider, faction) :

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 				this.order = order;
 				this.power = power;
 				range = power.info.Range;
-				tile = world.Map.SequenceProvider.GetSequence("overlay", "target-select").GetSprite(0);
+				tile = world.Map.Rules.Sequences.GetSequence("overlay", "target-select").GetSprite(0);
 			}
 
 			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -158,9 +158,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!checkTerrainType)
 				return true;
 
-			var tileSet = self.World.TileSet;
 			var tiles = self.World.Map.MapTiles.Value;
-			var terrainType = tileSet[tileSet.GetTerrainIndex(tiles[self.Location])].Type;
+			var terrainType = self.World.Map.GetTerrainInfo(self.Location).Type;
 
 			return info.AllowedTerrainTypes.Contains(terrainType);
 		}
@@ -174,7 +173,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.World.Map.Contains(self.Location))
 			{
 				var tile = self.World.Map.MapTiles.Value[self.Location];
-				var ti = self.World.TileSet.GetTileInfo(tile);
+				var ti = self.World.Map.Rules.TileSet.GetTileInfo(tile);
 				if (ti != null)
 					ramp = ti.RampType;
 			}

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Correlate the tile "image" aka subtile with its position to find the template origin
 			var tile = w.Map.MapTiles.Value[cell].Type;
 			var index = w.Map.MapTiles.Value[cell].Index;
-			var template = w.TileSet.Templates[tile];
+			var template = w.Map.Rules.TileSet.Templates[tile];
 			var ni = cell.X - index % template.Size.X;
 			var nj = cell.Y - index / template.Size.X;
 

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -28,9 +28,10 @@ namespace OpenRA.Mods.Common.Traits
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
+			var tileSet = world.Map.Rules.TileSet;
 			var movementClasses =
 				world.Map.Rules.Actors.Where(ai => ai.Value.HasTraitInfo<MobileInfo>())
-				.Select(ai => (uint)ai.Value.TraitInfo<MobileInfo>().GetMovementClass(world.TileSet)).Distinct();
+					.Select(ai => (uint)ai.Value.TraitInfo<MobileInfo>().GetMovementClass(tileSet)).Distinct();
 
 			foreach (var mc in movementClasses)
 				domainIndexes[mc] = new MovementClassDomainIndex(world, mc);

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			Map = self.World.Map;
-			Tileset = self.World.TileSet;
+			Tileset = self.World.Map.Rules.TileSet;
 
 			Tiles = new CellLayer<CellContents>(Map);
 			Resources = self.TraitsImplementing<ResourceType>()

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -53,8 +53,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			this.info = info;
 			map = self.World.Map;
-			copySprite = map.SequenceProvider.GetSequence(info.Image, info.CopySequence).GetSprite(0);
-			pasteSprite = map.SequenceProvider.GetSequence(info.Image, info.PasteSequence).GetSprite(0);
+			copySprite = map.Rules.Sequences.GetSequence(info.Image, info.CopySequence).GetSprite(0);
+			pasteSprite = map.Rules.Sequences.GetSequence(info.Image, info.PasteSequence).GetSprite(0);
 		}
 
 		public void WorldLoaded(World w, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void LoadPalettes(WorldRenderer wr)
 		{
-			wr.AddPalette(info.Name, new ImmutablePalette(wr.World.Map.Open(world.TileSet.Palette), info.ShadowIndex), info.AllowModifiers);
+			wr.AddPalette(info.Name, new ImmutablePalette(wr.World.Map.Open(world.Map.Rules.TileSet.Palette), info.ShadowIndex), info.AllowModifiers);
 		}
 
 		public IEnumerable<string> PaletteNames { get { yield return info.Name; } }

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				// Only expose the palette if it is available for the shellmap's tileset (which is a requirement for its use).
-				if (info.Tileset == null || info.Tileset == world.TileSet.Id)
+				if (info.Tileset == null || info.Tileset == world.Map.Rules.TileSet.Id)
 					yield return info.Name;
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			var domainIndex = world.WorldActor.TraitOrDefault<DomainIndex>();
 			if (domainIndex != null)
 			{
-				var passable = mi.GetMovementClass(world.TileSet);
+				var passable = mi.GetMovementClass(world.Map.Rules.TileSet);
 				if (!domainIndex.IsPassable(source, target, (uint)passable))
 					return EmptyPath;
 			}
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 			var domainIndex = world.WorldActor.TraitOrDefault<DomainIndex>();
 			if (domainIndex != null)
 			{
-				var passable = mi.GetMovementClass(world.TileSet);
+				var passable = mi.GetMovementClass(world.Map.Rules.TileSet);
 				tilesInRange = new List<CPos>(tilesInRange.Where(t => domainIndex.IsPassable(source, t, (uint)passable)));
 				if (!tilesInRange.Any())
 					return EmptyPath;

--- a/OpenRA.Mods.Common/Traits/World/PlayerPaletteFromCurrentTileset.cs
+++ b/OpenRA.Mods.Common/Traits/World/PlayerPaletteFromCurrentTileset.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void LoadPalettes(WorldRenderer wr)
 		{
-			var filename = world.TileSet.PlayerPalette ?? world.TileSet.Palette;
+			var filename = world.Map.Rules.TileSet.PlayerPalette ?? world.Map.Rules.TileSet.Palette;
 			wr.AddPalette(info.Name, new ImmutablePalette(wr.World.Map.Open(filename), info.ShadowIndex), info.AllowModifiers);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!rt.Info.AllowOnRamps)
 			{
 				var tile = world.Map.MapTiles.Value[cell];
-				var tileInfo = world.TileSet.GetTileInfo(tile);
+				var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
 				if (tileInfo != null && tileInfo.RampType > 0)
 					return false;
 			}
@@ -214,7 +214,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		CellContents CreateResourceCell(ResourceType t, CPos cell)
 		{
-			world.Map.CustomTerrain[cell] = world.TileSet.GetTerrainIndex(t.Info.TerrainType);
+			world.Map.CustomTerrain[cell] = world.Map.Rules.TileSet.GetTerrainIndex(t.Info.TerrainType);
 
 			return new CellContents
 			{

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -121,10 +121,11 @@ namespace OpenRA.Mods.Common.Traits
 			shroudSprites = new Sprite[variantCount * variantStride];
 			fogSprites = new Sprite[variantCount * variantStride];
 
+			var sequenceProvider = map.Rules.Sequences;
 			for (var j = 0; j < variantCount; j++)
 			{
-				var shroud = map.SequenceProvider.GetSequence(info.Sequence, info.ShroudVariants[j]);
-				var fog = map.SequenceProvider.GetSequence(info.Sequence, info.FogVariants[j]);
+				var shroud = sequenceProvider.GetSequence(info.Sequence, info.ShroudVariants[j]);
+				var fog = sequenceProvider.GetSequence(info.Sequence, info.FogVariants[j]);
 				for (var i = 0; i < info.Index.Length; i++)
 				{
 					shroudSprites[j * variantStride + i] = shroud.GetSprite(i);
@@ -134,8 +135,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (info.OverrideFullShroud != null)
 				{
 					var i = (j + 1) * variantStride - 1;
-					shroudSprites[i] = map.SequenceProvider.GetSequence(info.Sequence, info.OverrideFullShroud).GetSprite(0);
-					fogSprites[i] = map.SequenceProvider.GetSequence(info.Sequence, info.OverrideFullFog).GetSprite(0);
+					shroudSprites[i] = sequenceProvider.GetSequence(info.Sequence, info.OverrideFullShroud).GetSprite(0);
+					fogSprites[i] = sequenceProvider.GetSequence(info.Sequence, info.OverrideFullFog).GetSprite(0);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -94,10 +94,11 @@ namespace OpenRA.Mods.Common.Traits
 			Info = info;
 			world = self.World;
 
-			var types = world.Map.SequenceProvider.Sequences(Info.Sequence);
+			var sequenceProvider = world.Map.Rules.Sequences;
+			var types = sequenceProvider.Sequences(Info.Sequence);
 			foreach (var t in types)
 			{
-				var seq = world.Map.SequenceProvider.GetSequence(Info.Sequence, t);
+				var seq = sequenceProvider.GetSequence(Info.Sequence, t);
 				var sprites = Exts.MakeArray(seq.Length, x => seq.GetSprite(x));
 				smudges.Add(t, sprites);
 			}

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -50,9 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var map = wr.World.Map;
-			var tileSet = wr.World.TileSet;
+			var tileSet = wr.World.Map.Rules.TileSet;
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
-			var colors = wr.World.TileSet.HeightDebugColors;
+			var colors = tileSet.HeightDebugColors;
 			var mouseCell = wr.Viewport.ViewToWorld(Viewport.LastMousePos).ToMPos(wr.World.Map);
 
 			foreach (var uv in wr.Viewport.AllVisibleCells.CandidateMapCoords)

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -328,7 +328,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			else
 			{
 				currentFilename = filename;
-				currentSprites = world.Map.SequenceProvider.SpriteCache[filename];
+				currentSprites = world.Map.Rules.Sequences.SpriteCache[filename];
 				currentFrame = 0;
 				frameSlider.MaximumValue = (float)currentSprites.Length - 1;
 				frameSlider.Ticks = currentSprites.Length;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -97,9 +97,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var filter = actor.TraitInfoOrDefault<EditorTilesetFilterInfo>();
 				if (filter != null)
 				{
-					if (filter.ExcludeTilesets != null && filter.ExcludeTilesets.Contains(world.TileSet.Id))
+					if (filter.ExcludeTilesets != null && filter.ExcludeTilesets.Contains(world.Map.Rules.TileSet.Id))
 						continue;
-					if (filter.RequireTilesets != null && !filter.RequireTilesets.Contains(world.TileSet.Id))
+					if (filter.RequireTilesets != null && !filter.RequireTilesets.Contains(world.Map.Rules.TileSet.Id))
 						continue;
 				}
 
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				catch
 				{
 					Log.Write("debug", "Map editor ignoring actor {0}, because of missing sprites for tileset {1}.",
-						actor.Name, world.TileSet.Id);
+						actor.Name, world.Map.Rules.TileSet.Id);
 					continue;
 				}
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -57,8 +57,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				layerPreview.GetPalette = () => resource.Palette;
 
 				var variant = resource.Variants.FirstOrDefault();
-				var sequenceProvider = rules.Sequences;
-				var sequence = sequenceProvider.GetSequence("resources", variant);
+				var sequence = rules.Sequences.GetSequence("resources", variant);
 				var frame = sequence.Frames != null ? sequence.Frames.Last() : resource.MaxDensity - 1;
 				layerPreview.GetSprite = () => sequence.GetSprite(frame);
 

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Widgets
 					continue;
 
 				var rsi = actor.TraitInfo<RenderSpritesInfo>();
-				var icon = new Animation(world, rsi.GetImage(actor, world.Map.SequenceProvider, faction));
+				var icon = new Animation(world, rsi.GetImage(actor, world.Map.Rules.Sequences, faction));
 				icon.Play(actor.TraitInfo<TooltipInfo>().Icon);
 				var bi = actor.TraitInfo<BuildableInfo>();
 				var location = new float2(RenderBounds.Location) + new float2(queue.i * (IconWidth + IconSpacing), 0);

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -331,7 +331,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var rect = new Rectangle(rb.X + x * (IconSize.X + IconMargin.X), rb.Y + y * (IconSize.Y + IconMargin.Y), IconSize.X, IconSize.Y);
 
 				var rsi = item.TraitInfo<RenderSpritesInfo>();
-				var icon = new Animation(World, rsi.GetImage(item, World.Map.SequenceProvider, faction));
+				var icon = new Animation(World, rsi.GetImage(item, World.Map.Rules.Sequences, faction));
 				icon.Play(item.TraitInfo<TooltipInfo>().Icon);
 
 				var bi = item.TraitInfo<BuildableInfo>();

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -140,12 +140,12 @@ namespace OpenRA.Mods.Common.Widgets
 			int leftColor, rightColor;
 			if (custom == byte.MaxValue)
 			{
-				var type = world.TileSet.GetTileInfo(world.Map.MapTiles.Value[uv]);
+				var type = world.Map.Rules.TileSet.GetTileInfo(world.Map.MapTiles.Value[uv]);
 				leftColor = type != null ? type.LeftColor.ToArgb() : Color.Black.ToArgb();
 				rightColor = type != null ? type.RightColor.ToArgb() : Color.Black.ToArgb();
 			}
 			else
-				leftColor = rightColor = world.TileSet[custom].Color.ToArgb();
+				leftColor = rightColor = world.Map.Rules.TileSet[custom].Color.ToArgb();
 
 			var stride = radarSheet.Size.Width;
 

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.D2k.Traits
 			this.info = info;
 			layer = self.World.WorldActor.Trait<BuildableTerrainLayer>();
 			bi = self.World.WorldActor.Trait<BuildingInfluence>();
-			template = self.World.TileSet.Templates[info.Template];
+			template = self.World.Map.Rules.TileSet.Templates[info.Template];
 		}
 
 		public void AddedToWorld(Actor self)

--- a/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/ProductionFromMapEdge.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.D2k.Traits
 			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
 
-			var passable = mobileInfo != null ? (uint)mobileInfo.GetMovementClass(self.World.TileSet) : 0;
+			var passable = mobileInfo != null ? (uint)mobileInfo.GetMovementClass(self.World.Map.Rules.TileSet) : 0;
 			var destination = rp != null ? rp.Location : self.Location;
 
 			var location = spawnLocation;

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -28,7 +28,6 @@ namespace OpenRA.Mods.D2k.Traits
 	{
 		readonly BuildableTerrainLayerInfo info;
 		readonly Dictionary<CPos, Sprite> dirty = new Dictionary<CPos, Sprite>();
-		readonly TileSet tileset;
 		readonly Map map;
 
 		TerrainSpriteLayer render;
@@ -37,7 +36,6 @@ namespace OpenRA.Mods.D2k.Traits
 		public BuildableTerrainLayer(Actor self, BuildableTerrainLayerInfo info)
 		{
 			this.info = info;
-			tileset = self.World.TileSet;
 			map = self.World.Map;
 		}
 
@@ -49,7 +47,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public void AddTile(CPos cell, TerrainTile tile)
 		{
-			map.CustomTerrain[cell] = tileset.GetTerrainIndex(tile);
+			map.CustomTerrain[cell] = map.Rules.TileSet.GetTerrainIndex(tile);
 
 			// Terrain tiles define their origin at the topleft
 			var s = theater.TileSprite(tile);

--- a/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.RA/Graphics/TeslaZapRenderable.cs
@@ -92,8 +92,8 @@ namespace OpenRA.Mods.RA.Graphics
 
 		public IEnumerable<IFinalizedRenderable> GenerateRenderables(WorldRenderer wr)
 		{
-			var bright = wr.World.Map.SequenceProvider.GetSequence(image, brightSequence);
-			var dim = wr.World.Map.SequenceProvider.GetSequence(image, dimSequence);
+			var bright = wr.World.Map.Rules.Sequences.GetSequence(image, brightSequence);
+			var dim = wr.World.Map.Rules.Sequences.GetSequence(image, dimSequence);
 
 			var source = wr.ScreenPosition(pos);
 			var target = wr.ScreenPosition(pos + length);

--- a/OpenRA.Mods.RA/Traits/Disguise.cs
+++ b/OpenRA.Mods.RA/Traits/Disguise.cs
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.RA.Traits
 			var oldEffectiveOwner = AsPlayer;
 
 			var renderSprites = actorInfo.TraitInfoOrDefault<RenderSpritesInfo>();
-			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.SequenceProvider, newOwner.Faction.InternalName);
+			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.Rules.Sequences, newOwner.Faction.InternalName);
 			AsPlayer = newOwner;
 			AsTooltipInfo = actorInfo.TraitInfos<TooltipInfo>().FirstOrDefault();
 

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA.Traits
 		{
 			this.self = self;
 
-			var tileset = self.World.TileSet.Id.ToLowerInvariant();
+			var tileset = self.World.Map.Tileset.ToLowerInvariant();
 			tile = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
 		}
 
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.RA.Traits
 				minelayer = self;
 				minefieldStart = xy;
 
-				var tileset = self.World.TileSet.Id.ToLowerInvariant();
+				var tileset = self.World.Map.Tileset.ToLowerInvariant();
 				tileOk = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
 				tileBlocked = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-invalid").GetSprite(0);
 			}

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.RA.Traits
 			this.self = self;
 
 			var tileset = self.World.TileSet.Id.ToLowerInvariant();
-			tile = self.World.Map.SequenceProvider.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
+			tile = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
 		}
 
 		public IEnumerable<IOrderTargeter> Orders
@@ -141,8 +141,8 @@ namespace OpenRA.Mods.RA.Traits
 				minefieldStart = xy;
 
 				var tileset = self.World.TileSet.Id.ToLowerInvariant();
-				tileOk = self.World.Map.SequenceProvider.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
-				tileBlocked = self.World.Map.SequenceProvider.GetSequence("overlay", "build-invalid").GetSprite(0);
+				tileOk = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
+				tileBlocked = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-invalid").GetSprite(0);
 			}
 
 			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.RA.Traits
 
 				var info = (ChronoshiftPowerInfo)power.Info;
 				range = info.Range;
-				tile = world.Map.SequenceProvider.GetSequence(info.OverlaySpriteGroup, info.SourceTileSequence).GetSprite(0);
+				tile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.SourceTileSequence).GetSprite(0);
 			}
 
 			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -196,9 +196,9 @@ namespace OpenRA.Mods.RA.Traits
 				range = info.Range;
 
 				var tileset = manager.Self.World.TileSet.Id.ToLowerInvariant();
-				validTile = world.Map.SequenceProvider.GetSequence(info.OverlaySpriteGroup, info.ValidTileSequencePrefix + tileset).GetSprite(0);
-				invalidTile = world.Map.SequenceProvider.GetSequence(info.OverlaySpriteGroup, info.InvalidTileSequence).GetSprite(0);
-				sourceTile = world.Map.SequenceProvider.GetSequence(info.OverlaySpriteGroup, info.SourceTileSequence).GetSprite(0);
+				validTile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.ValidTileSequencePrefix + tileset).GetSprite(0);
+				invalidTile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.InvalidTileSequence).GetSprite(0);
+				sourceTile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.SourceTileSequence).GetSprite(0);
 			}
 
 			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ChronoshiftPower.cs
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.RA.Traits
 				var info = (ChronoshiftPowerInfo)power.Info;
 				range = info.Range;
 
-				var tileset = manager.Self.World.TileSet.Id.ToLowerInvariant();
+				var tileset = world.Map.Tileset.ToLowerInvariant();
 				validTile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.ValidTileSequencePrefix + tileset).GetSprite(0);
 				invalidTile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.InvalidTileSequence).GetSprite(0);
 				sourceTile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.SourceTileSequence).GetSprite(0);


### PR DESCRIPTION
The last few PRs have untangled the map format to the point that we can now start dropping the ugly workarounds that were in place for perf or sanity reasons.  This PR makes a start by unifying the tileset references into a single Map.Tileset property.

Depends on #10839.  Only the last two commits are new.
