### PR TITLE
Remove Map usage from the server and mission browser.

### DIFF
--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -148,7 +148,9 @@ namespace OpenRA
 			return new Ruleset(dr.Actors, dr.Weapons, dr.Voices, dr.Notifications, dr.Music, ts, sequences);
 		}
 
-		public static Ruleset LoadFromMap(ModData modData, Map map)
+		public static Ruleset Load(ModData modData, IReadOnlyFileSystem fileSystem, string tileSet,
+			MiniYaml mapRules, MiniYaml mapWeapons, MiniYaml mapVoices, MiniYaml mapNotifications,
+			MiniYaml mapMusic, MiniYaml mapSequences)
 		{
 			var m = modData.Manifest;
 			var dr = modData.DefaultRules;
@@ -156,27 +158,27 @@ namespace OpenRA
 			Ruleset ruleset = null;
 			Action f = () =>
 			{
-				var actors = MergeOrDefault("Manifest,Rules", map, m.Rules, map.RuleDefinitions, dr.Actors,
+				var actors = MergeOrDefault("Rules", fileSystem, m.Rules, mapRules, dr.Actors,
 					k => new ActorInfo(modData.ObjectCreator, k.Key.ToLowerInvariant(), k.Value));
 
-				var weapons = MergeOrDefault("Manifest,Weapons", map, m.Weapons, map.WeaponDefinitions, dr.Weapons,
+				var weapons = MergeOrDefault("Weapons", fileSystem, m.Weapons, mapWeapons, dr.Weapons,
 					k => new WeaponInfo(k.Key.ToLowerInvariant(), k.Value));
 
-				var voices = MergeOrDefault("Manifest,Voices", map, m.Voices, map.VoiceDefinitions, dr.Voices,
+				var voices = MergeOrDefault("Voices", fileSystem, m.Voices, mapVoices, dr.Voices,
 					k => new SoundInfo(k.Value));
 
-				var notifications = MergeOrDefault("Manifest,Notifications", map, m.Notifications, map.NotificationDefinitions, dr.Notifications,
+				var notifications = MergeOrDefault("Notifications", fileSystem, m.Notifications, mapNotifications, dr.Notifications,
 					k => new SoundInfo(k.Value));
 
-				var music = MergeOrDefault("Manifest,Music", map, m.Music, map.NotificationDefinitions, dr.Music,
+				var music = MergeOrDefault("Music", fileSystem, m.Music, mapMusic, dr.Music,
 					k => new MusicInfo(k.Key, k.Value));
 
 				// TODO: Add support for merging custom tileset modifications
-				var ts = modData.DefaultTileSets[map.Tileset];
+				var ts = modData.DefaultTileSets[tileSet];
 
 				// TODO: Top-level dictionary should be moved into the Ruleset instead of in its own object
-				var sequences = map.SequenceDefinitions == null ? modData.DefaultSequences[map.Tileset] :
-					new SequenceProvider(map, modData, ts, map.SequenceDefinitions);
+				var sequences = mapSequences == null ? modData.DefaultSequences[tileSet] :
+					new SequenceProvider(fileSystem, modData, ts, mapSequences);
 
 				// TODO: Add support for custom voxel sequences
 				ruleset = new Ruleset(actors, weapons, voices, notifications, music, ts, sequences);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1192,7 +1192,6 @@ namespace OpenRA
 			return FindTilesInAnnulus(center, 0, maxRange, allowOutsideBounds);
 		}
 
-		// Placeholders for future implementation
 		public Stream Open(string filename)
 		{
 			// Explicit package paths never refer to a map

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -296,7 +296,8 @@ namespace OpenRA
 			{
 				try
 				{
-					return Ruleset.LoadFromMap(modData, this);
+					return Ruleset.Load(modData, this, Tileset, RuleDefinitions, WeaponDefinitions,
+						VoiceDefinitions, NotificationDefinitions, MusicDefinitions, SequenceDefinitions);
 				}
 				catch (Exception e)
 				{

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -25,7 +25,7 @@ namespace OpenRA
 {
 	public sealed class MapCache : IEnumerable<MapPreview>, IDisposable
 	{
-		public static readonly MapPreview UnknownMap = new MapPreview(null, MapGridType.Rectangular, null);
+		public static readonly MapPreview UnknownMap = new MapPreview(null, null, MapGridType.Rectangular, null);
 		public readonly IReadOnlyDictionary<IReadOnlyPackage, MapClassification> MapLocations;
 
 		readonly Cache<string, MapPreview> previews;
@@ -41,7 +41,7 @@ namespace OpenRA
 			this.modData = modData;
 
 			var gridType = Exts.Lazy(() => modData.Manifest.Get<MapGrid>().Type);
-			previews = new Cache<string, MapPreview>(uid => new MapPreview(uid, gridType.Value, this));
+			previews = new Cache<string, MapPreview>(uid => new MapPreview(modData, uid, gridType.Value, this));
 			sheetBuilder = new SheetBuilder(SheetType.BGRA);
 
 			// Enumerate map directories

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -51,8 +51,7 @@ namespace OpenRA.Server
 		public List<string> TempBans = new List<string>();
 
 		// Managed by LobbyCommands
-		public Map Map;
-		public MapPlayers MapPlayers;
+		public MapPreview Map;
 
 		readonly int randomSeed;
 		readonly TcpListener listener;
@@ -323,7 +322,7 @@ namespace OpenRA.Server
 				}
 
 				if (client.Slot != null)
-					SyncClientToPlayerReference(client, MapPlayers.Players[client.Slot]);
+					SyncClientToPlayerReference(client, Map.Players.Players[client.Slot]);
 				else
 					client.Color = HSLColor.FromRGB(255, 255, 255);
 
@@ -392,12 +391,12 @@ namespace OpenRA.Server
 						SendOrderTo(newConn, "Message", motd);
 				}
 
-				if (Map.RuleDefinitions != null && !LobbyInfo.IsSinglePlayer)
+				if (Map.Rules != ModData.DefaultRules && !LobbyInfo.IsSinglePlayer)
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
 				if (Settings.DisableSinglePlayer)
 					SendOrderTo(newConn, "Message", "Singleplayer games have been disabled on this server.");
-				else if (MapPlayers.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
+				else if (Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 					SendOrderTo(newConn, "Message", "Bots have been disabled on this map.");
 
 				if (handshake.Mod == "{DEV_VERSION}")

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Server
 							client.SpawnPoint = 0;
 
 						client.Slot = s;
-						S.SyncClientToPlayerReference(client, server.MapPlayers.Players[s]);
+						S.SyncClientToPlayerReference(client, server.Map.Players.Players[s]);
 
 						if (!slot.LockColor)
 							client.PreferredColor = client.Color = SanitizePlayerColor(server, client.Color, client.Index, conn);
@@ -311,7 +311,7 @@ namespace OpenRA.Mods.Common.Server
 							var tileset = server.Map.Rules.TileSet;
 							var terrainColors = tileset.TerrainInfo.Where(ti => ti.RestrictPlayerColor).Select(ti => ti.Color);
 							var playerColors = server.LobbyInfo.Clients.Select(c => c.Color.RGB)
-								.Concat(server.MapPlayers.Players.Values.Select(p => p.Color.RGB));
+								.Concat(server.Map.Players.Players.Values.Select(p => p.Color.RGB));
 							bot.Color = bot.PreferredColor = validator.RandomValidColor(server.Random, terrainColors, playerColors);
 
 							server.LobbyInfo.Clients.Add(bot);
@@ -323,7 +323,7 @@ namespace OpenRA.Mods.Common.Server
 							bot.Bot = botType;
 						}
 
-						S.SyncClientToPlayerReference(bot, server.MapPlayers.Players[parts[0]]);
+						S.SyncClientToPlayerReference(bot, server.Map.Players.Players[parts[0]]);
 						server.SyncLobbyClients();
 						server.SyncLobbySlots();
 						return true;
@@ -370,9 +370,9 @@ namespace OpenRA.Mods.Common.Server
 							if (c.Slot != null)
 							{
 								// Remove Bot from slot if slot forbids bots
-								if (c.Bot != null && !server.MapPlayers.Players[c.Slot].AllowBots)
+								if (c.Bot != null && !server.Map.Players.Players[c.Slot].AllowBots)
 									server.LobbyInfo.Clients.Remove(c);
-								S.SyncClientToPlayerReference(c, server.MapPlayers.Players[c.Slot]);
+								S.SyncClientToPlayerReference(c, server.Map.Players.Players[c.Slot]);
 							}
 							else if (c.Bot != null)
 								server.LobbyInfo.Clients.Remove(c);
@@ -387,12 +387,12 @@ namespace OpenRA.Mods.Common.Server
 
 						server.SendMessage("{0} changed the map to {1}.".F(client.Name, server.Map.Title));
 
-						if (server.Map.RuleDefinitions != null)
+						if (server.Map.Rules.Actors != server.ModData.DefaultRules.Actors)
 							server.SendMessage("This map contains custom rules. Game experience may change.");
 
 						if (server.Settings.DisableSinglePlayer)
 							server.SendMessage("Singleplayer games have been disabled on this server.");
-						else if (server.MapPlayers.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
+						else if (server.Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 							server.SendMessage("Bots have been disabled on this map.");
 
 						return true;
@@ -875,7 +875,7 @@ namespace OpenRA.Mods.Common.Server
 
 						int spawnPoint;
 						if (!Exts.TryParseIntegerInvariant(parts[1], out spawnPoint)
-							|| spawnPoint < 0 || spawnPoint > server.Map.SpawnPoints.Value.Length)
+							|| spawnPoint < 0 || spawnPoint > server.Map.SpawnPoints.Length)
 						{
 							Log.Write("server", "Invalid spawn point: {0}", parts[1]);
 							return true;
@@ -1042,10 +1042,9 @@ namespace OpenRA.Mods.Common.Server
 
 		static void LoadMap(S server)
 		{
-			server.Map = new Map(server.ModData, server.ModData.MapCache[server.LobbyInfo.GlobalSettings.Map].Package);
+			server.Map = server.ModData.MapCache[server.LobbyInfo.GlobalSettings.Map];
 
-			server.MapPlayers = new MapPlayers(server.Map.PlayerDefinitions);
-			server.LobbyInfo.Slots = server.MapPlayers.Players
+			server.LobbyInfo.Slots = server.Map.Players.Players
 				.Select(p => MakeSlotFromPlayerReference(p.Value))
 				.Where(s => s != null)
 				.ToDictionary(s => s.PlayerReference, s => s);
@@ -1067,7 +1066,7 @@ namespace OpenRA.Mods.Common.Server
 			var tileset = server.Map.Rules.TileSet;
 			var terrainColors = tileset.TerrainInfo.Where(ti => ti.RestrictPlayerColor).Select(ti => ti.Color).ToList();
 			var playerColors = server.LobbyInfo.Clients.Where(c => c.Index != playerIndex).Select(c => c.Color.RGB)
-				.Concat(server.MapPlayers.Players.Values.Select(p => p.Color.RGB)).ToList();
+				.Concat(server.Map.Players.Players.Values.Select(p => p.Color.RGB)).ToList();
 
 			return validator.MakeValid(askColor.RGB, server.Random, terrainColors, playerColors, onError);
 		}
@@ -1086,7 +1085,7 @@ namespace OpenRA.Mods.Common.Server
 			if (slot == null)
 				return null;
 
-			return server.MapPlayers.Players[slot.PlayerReference];
+			return server.Map.Players.Players[slot.PlayerReference];
 		}
 	}
 }

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -1013,28 +1013,28 @@ namespace OpenRA.Mods.Common.Server
 			};
 		}
 
-		public static void LoadMapSettings(Session.Global gs, Map map)
+		public static void LoadMapSettings(Session.Global gs, Ruleset rules)
 		{
-			var devMode = map.Rules.Actors["player"].TraitInfo<DeveloperModeInfo>();
+			var devMode = rules.Actors["player"].TraitInfo<DeveloperModeInfo>();
 			gs.AllowCheats = devMode.Enabled;
 
-			var crateSpawner = map.Rules.Actors["world"].TraitInfoOrDefault<CrateSpawnerInfo>();
+			var crateSpawner = rules.Actors["world"].TraitInfoOrDefault<CrateSpawnerInfo>();
 			gs.Crates = crateSpawner != null && crateSpawner.Enabled;
 
-			var shroud = map.Rules.Actors["player"].TraitInfo<ShroudInfo>();
+			var shroud = rules.Actors["player"].TraitInfo<ShroudInfo>();
 			gs.Fog = shroud.FogEnabled;
 			gs.Shroud = !shroud.ExploredMapEnabled;
 
-			var resources = map.Rules.Actors["player"].TraitInfo<PlayerResourcesInfo>();
+			var resources = rules.Actors["player"].TraitInfo<PlayerResourcesInfo>();
 			gs.StartingCash = resources.DefaultCash;
 
-			var startingUnits = map.Rules.Actors["world"].TraitInfoOrDefault<SpawnMPUnitsInfo>();
+			var startingUnits = rules.Actors["world"].TraitInfoOrDefault<SpawnMPUnitsInfo>();
 			gs.StartingUnitsClass = startingUnits == null ? "none" : startingUnits.StartingUnitsClass;
 
-			var mapBuildRadius = map.Rules.Actors["world"].TraitInfoOrDefault<MapBuildRadiusInfo>();
+			var mapBuildRadius = rules.Actors["world"].TraitInfoOrDefault<MapBuildRadiusInfo>();
 			gs.AllyBuildRadius = mapBuildRadius != null && mapBuildRadius.AllyBuildRadiusEnabled;
 
-			var mapOptions = map.Rules.Actors["world"].TraitInfo<MapOptionsInfo>();
+			var mapOptions = rules.Actors["world"].TraitInfo<MapOptionsInfo>();
 			gs.ShortGame = mapOptions.ShortGameEnabled;
 			gs.TechLevel = mapOptions.TechLevel;
 			gs.Difficulty = mapOptions.Difficulty ?? mapOptions.Difficulties.FirstOrDefault();
@@ -1050,7 +1050,7 @@ namespace OpenRA.Mods.Common.Server
 				.Where(s => s != null)
 				.ToDictionary(s => s.PlayerReference, s => s);
 
-			LoadMapSettings(server.LobbyInfo.GlobalSettings, server.Map);
+			LoadMapSettings(server.LobbyInfo.GlobalSettings, server.Map.Rules);
 		}
 
 		static HSLColor SanitizePlayerColor(S server, HSLColor askedColor, int playerIndex, Connection connectionToEcho = null)

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Server
 				return;
 
 			var defaults = new Session.Global();
-			LobbyCommands.LoadMapSettings(defaults, server.Map);
+			LobbyCommands.LoadMapSettings(defaults, server.Map.Rules);
 
 			if (server.LobbyInfo.GlobalSettings.AllowCheats != defaults.AllowCheats)
 				server.SendOrderTo(conn, "Message", "Allow Cheats: {0}".F(server.LobbyInfo.GlobalSettings.AllowCheats));


### PR DESCRIPTION
This adds support for loading map rules from a `MapPreview`, and removes the last uses of `Map` from places that don't actually want a full map object.  This makes the mission browser a bit smoother (the video button and description are now available instantly), and, once support is added to the resource center, give servers access to all the maps available on the resource center without having to manually sync.

This also checks off another major point in #10717, and means that we can now streamline Map initialization by dropping all the `Lazy`ness.
