### PR TITLE
Restore the ability for maps to include inline rules.

### DIFF
--- a/OpenRA.Game/Graphics/VoxelProvider.cs
+++ b/OpenRA.Game/Graphics/VoxelProvider.cs
@@ -21,13 +21,9 @@ namespace OpenRA.Graphics
 	{
 		static Dictionary<string, Dictionary<string, Voxel>> units;
 
-		public static void Initialize(VoxelLoader loader, IReadOnlyFileSystem fileSystem, IEnumerable<string> voxelFiles)
+		public static void Initialize(VoxelLoader loader, IReadOnlyFileSystem fileSystem, List<MiniYamlNode> sequences)
 		{
 			units = new Dictionary<string, Dictionary<string, Voxel>>();
-
-			var sequences = MiniYaml.Merge(voxelFiles.Select(
-				s => MiniYaml.FromStream(fileSystem.Open(s))));
-
 			foreach (var s in sequences)
 				LoadVoxelsForUnit(loader, s.Key, s.Value);
 

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -201,6 +201,10 @@ namespace OpenRA
 			MapSize = new int2(size);
 			Tileset = tileset.Id;
 
+			// Empty rules that can be added to by the importers.
+			// Will be dropped on save if nothing is added to it
+			RuleDefinitions = new MiniYaml("");
+
 			MapResources = Exts.Lazy(() => new CellLayer<ResourceTile>(Grid.Type, size));
 
 			MapTiles = Exts.Lazy(() =>

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenRA.FileSystem;
 
 namespace OpenRA
 {
@@ -374,6 +375,21 @@ namespace OpenRA
 			if (Nodes != null)
 				foreach (var line in Nodes.ToLines(false))
 					yield return "\t" + line;
+		}
+
+		public static List<MiniYamlNode> Load(IReadOnlyFileSystem fileSystem, IEnumerable<string> files, MiniYaml mapRules)
+		{
+			if (mapRules != null && mapRules.Value != null)
+			{
+				var mapFiles = FieldLoader.GetValue<string[]>("value", mapRules.Value);
+				files = files.Append(mapFiles);
+			}
+
+			var yaml = files.Select(s => MiniYaml.FromStream(fileSystem.Open(s)));
+			if (mapRules != null && mapRules.Nodes.Any())
+				yaml = yaml.Append(mapRules.Nodes);
+
+			return MiniYaml.Merge(yaml);
 		}
 	}
 

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -130,8 +130,7 @@ namespace OpenRA
 				return;
 			}
 
-			var yaml = MiniYaml.Merge(Manifest.Translations.Append(map.TranslationDefinitions)
-				.Select(t => MiniYaml.FromStream(map.Open(t))));
+			var yaml = MiniYaml.Load(map, Manifest.Translations, map.TranslationDefinitions);
 			Languages = yaml.Select(t => t.Key).ToArray();
 
 			foreach (var y in yaml)
@@ -182,7 +181,7 @@ namespace OpenRA
 				foreach (var entry in map.Rules.Music)
 					entry.Value.Load(map);
 
-			VoxelProvider.Initialize(VoxelLoader, map, Manifest.VoxelSequences.Append(map.VoxelSequenceDefinitions));
+			VoxelProvider.Initialize(VoxelLoader, map, MiniYaml.Load(map, Manifest.VoxelSequences, map.VoxelSequenceDefinitions));
 			VoxelLoader.Finish();
 
 			return map;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -392,7 +392,7 @@ namespace OpenRA.Server
 						SendOrderTo(newConn, "Message", motd);
 				}
 
-				if (Map.RuleDefinitions.Any() && !LobbyInfo.IsSinglePlayer)
+				if (Map.RuleDefinitions != null && !LobbyInfo.IsSinglePlayer)
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
 				if (Settings.DisableSinglePlayer)

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -26,18 +26,17 @@ namespace OpenRA.Mods.Common.Lint
 
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
-			if (map != null && !map.SequenceDefinitions.Any())
+			if (map.SequenceDefinitions == null)
 				return;
 
 			var modData = Game.ModData;
 			this.emitError = emitError;
 
-			var mapSequences = map != null ? map.SequenceDefinitions : new string[0];
-			sequenceDefinitions = MiniYaml.Merge(modData.Manifest.Sequences.Append(mapSequences).Select(s => MiniYaml.FromStream(map.Open(s))));
+			sequenceDefinitions = MiniYaml.Load(map, modData.Manifest.Sequences, map.SequenceDefinitions);
 
-			var rules = map == null ? modData.DefaultRules : map.Rules;
+			var rules = map.Rules;
 			var factions = rules.Actors["world"].TraitInfos<FactionInfo>().Select(f => f.InternalName).ToArray();
-			var sequenceProviders = map == null ? rules.Sequences.Values : new[] { rules.Sequences[map.Tileset] };
+			var sequenceProviders = new[] { rules.Sequences[map.Tileset] };
 
 			foreach (var actorInfo in rules.Actors)
 			{

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -387,7 +387,7 @@ namespace OpenRA.Mods.Common.Server
 
 						server.SendMessage("{0} changed the map to {1}.".F(client.Name, server.Map.Title));
 
-						if (server.Map.RuleDefinitions.Any())
+						if (server.Map.RuleDefinitions != null)
 							server.SendMessage("This map contains custom rules. Game experience may change.");
 
 						if (server.Settings.DisableSinglePlayer)

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					testMap.PreloadRules();
 
 					// Run all rule checks on the map if it defines custom rules.
-					if (testMap.RuleDefinitions.Any() || testMap.VoiceDefinitions.Any() || testMap.WeaponDefinitions.Any())
+					if (testMap.RuleDefinitions != null || testMap.VoiceDefinitions != null || testMap.WeaponDefinitions != null)
 						CheckRules(modData, testMap.Rules, testMap);
 
 					// Run all map-level checks here.

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -948,20 +948,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					rules.Value.Nodes.Add(playerNode);
 			}
 
-			// Format 9 -> 10 extracted map rules, sequences, voxelsequences, weapons, voices, music, notifications,
-			// and translations to external files, moved smudges to SmudgeLayer, and uses map.png for all maps
+			// Format 9 -> 10 moved smudges to SmudgeLayer, and uses map.png for all maps
 			if (mapFormat < 10)
 			{
 				ExtractSmudges(yaml);
-				ExtractOrRemoveRules(package, yaml, "Rules", "rules.yaml");
-				ExtractOrRemoveRules(package, yaml, "Sequences", "sequences.yaml");
-				ExtractOrRemoveRules(package, yaml, "VoxelSequences", "voxels.yaml");
-				ExtractOrRemoveRules(package, yaml, "Weapons", "weapons.yaml");
-				ExtractOrRemoveRules(package, yaml, "Voices", "voices.yaml");
-				ExtractOrRemoveRules(package, yaml, "Music", "music.yaml");
-				ExtractOrRemoveRules(package, yaml, "Notifications", "notifications.yaml");
-				ExtractOrRemoveRules(package, yaml, "Translations", "translations.yaml");
-
 				if (package.Contains("map.png"))
 					yaml.Nodes.Add(new MiniYamlNode("LockPreview", new MiniYaml("True")));
 			}
@@ -1022,23 +1012,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var smudgeLayer = new MiniYamlNode("SmudgeLayer@CRATER", new MiniYaml("", new List<MiniYamlNode>() { initialCraters }));
 				worldNode.Value.Nodes.Add(smudgeLayer);
 			}
-		}
-
-		static void ExtractOrRemoveRules(IReadWritePackage package, MiniYaml yaml, string key, string filename)
-		{
-			var node = yaml.Nodes.FirstOrDefault(n => n.Key == key);
-			if (node == null)
-				return;
-
-			if (node.Value.Nodes.Any())
-			{
-				var rulesText = node.Value.Nodes.ToLines(false).JoinWith("\n");
-				package.Update(filename, System.Text.Encoding.ASCII.GetBytes(rulesText));
-				node.Value.Value = filename;
-				node.Value.Nodes.Clear();
-			}
-			else
-				yaml.Nodes.Remove(node);
 		}
 	}
 }

--- a/mods/ts/maps/arivruns/map.yaml
+++ b/mods/ts/maps/arivruns/map.yaml
@@ -1293,4 +1293,7 @@ Actors:
 		Owner: Neutral
 		Location: 115,-15
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.72

--- a/mods/ts/maps/arivruns/rules.yaml
+++ b/mods/ts/maps/arivruns/rules.yaml
@@ -1,3 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Ambient: 0.72

--- a/mods/ts/maps/cliffsin/map.yaml
+++ b/mods/ts/maps/cliffsin/map.yaml
@@ -1499,4 +1499,7 @@ Actors:
 		Location: 123,87
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.68

--- a/mods/ts/maps/cliffsin/rules.yaml
+++ b/mods/ts/maps/cliffsin/rules.yaml
@@ -1,3 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Ambient: 0.68

--- a/mods/ts/maps/gdi4a/map.yaml
+++ b/mods/ts/maps/gdi4a/map.yaml
@@ -1737,3 +1737,9 @@ Actors:
 		Location: 111,13
 
 Rules: rules.yaml
+	World:
+		GlobalLightingPaletteEffect:
+			Red: 1.1
+			Green: 1.1
+			Blue: 1
+			Ambient: 0.55

--- a/mods/ts/maps/gdi4a/rules.yaml
+++ b/mods/ts/maps/gdi4a/rules.yaml
@@ -4,10 +4,5 @@ World:
 	-MPStartLocations:
 	MusicPlaylist:
 		BackgroundMusic: intro
-	GlobalLightingPaletteEffect:
-		Red: 1.1
-		Green: 1.1
-		Blue: 1
-		Ambient: 0.55
 	LuaScript:
 		Scripts: map.lua

--- a/mods/ts/maps/karasjok/map.yaml
+++ b/mods/ts/maps/karasjok/map.yaml
@@ -1554,4 +1554,10 @@ Actors:
 		Location: 134,73
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Red: 0.5
+			Green: 0.7
+			Blue: 0.7
+			Ambient: 0.78

--- a/mods/ts/maps/karasjok/rules.yaml
+++ b/mods/ts/maps/karasjok/rules.yaml
@@ -1,6 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Red: 0.5
-		Blue: 0.7
-		Green: 0.7
-		Ambient: 0.78

--- a/mods/ts/maps/rivrrad4/map.yaml
+++ b/mods/ts/maps/rivrrad4/map.yaml
@@ -868,4 +868,7 @@ Actors:
 		Location: 254,39
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.85

--- a/mods/ts/maps/rivrrad4/rules.yaml
+++ b/mods/ts/maps/rivrrad4/rules.yaml
@@ -1,3 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Ambient: 0.85

--- a/mods/ts/maps/springs/map.yaml
+++ b/mods/ts/maps/springs/map.yaml
@@ -853,4 +853,7 @@ Actors:
 		Owner: Neutral
 		Location: 95,3
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.62

--- a/mods/ts/maps/springs/rules.yaml
+++ b/mods/ts/maps/springs/rules.yaml
@@ -1,3 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Ambient: 0.62

--- a/mods/ts/maps/t_garden/map.yaml
+++ b/mods/ts/maps/t_garden/map.yaml
@@ -830,4 +830,7 @@ Actors:
 		Location: 99,74
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.79

--- a/mods/ts/maps/t_garden/rules.yaml
+++ b/mods/ts/maps/t_garden/rules.yaml
@@ -1,6 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Red: 1
-		Blue: 1
-		Green: 1
-		Ambient: 0.79

--- a/mods/ts/maps/tactical/map.yaml
+++ b/mods/ts/maps/tactical/map.yaml
@@ -800,4 +800,7 @@ Actors:
 		Location: 167,83
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.85

--- a/mods/ts/maps/tactical/rules.yaml
+++ b/mods/ts/maps/tactical/rules.yaml
@@ -1,3 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Ambient: 0.85

--- a/mods/ts/maps/terrace/map.yaml
+++ b/mods/ts/maps/terrace/map.yaml
@@ -509,4 +509,7 @@ Actors:
 		Location: 84,60
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.63

--- a/mods/ts/maps/terrace/rules.yaml
+++ b/mods/ts/maps/terrace/rules.yaml
@@ -1,3 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Ambient: 0.63

--- a/mods/ts/maps/tread_l/map.yaml
+++ b/mods/ts/maps/tread_l/map.yaml
@@ -1213,4 +1213,7 @@ Actors:
 		Location: 123,20
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules:
+	World:
+		GlobalLightingPaletteEffect:
+			Ambient: 0.75

--- a/mods/ts/maps/tread_l/rules.yaml
+++ b/mods/ts/maps/tread_l/rules.yaml
@@ -1,3 +1,0 @@
-World:
-	GlobalLightingPaletteEffect:
-		Ambient: 0.75


### PR DESCRIPTION
Removing support for inline yaml rules etc was a little premature: we need this feature for the server-resource center integration.  It therefore makes sense to bring this back for regular maps too.

This mostly reverts the changes to the importers and format upgrader to keep the custom rules in map.yaml.  The TS lighting definitions have been moved back as a testcase because it was a little silly to have a 3-4 line single-trait override in its own file.
