### PR TITLE
Turrets actively track targets

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				return false;
 			}
 
-			return turret.FaceTarget(self, target);
+			return true;
 		}
 
 		public void TickIdle(Actor self)

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -186,6 +186,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (ammoPool != null && !ammoPool.HasAmmo())
 				return null;
 
+			if (turret != null && !turret.HasAchievedDesiredFacing)
+				return null;
+
 			if (!target.IsInRange(self.CenterPosition, MaxRange()))
 				return null;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -32,14 +32,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override bool CanAttack(Actor self, Target target)
 		{
-			if (!base.CanAttack(self, target))
+			if (target.Type == TargetType.Invalid)
 				return false;
 
+			// Don't break early from this loop - we want to bring all turrets to bear!
+			var turretReady = false;
 			foreach (var t in turrets)
 				if (t.FaceTarget(self, target))
-					return true;
+					turretReady = true;
 
-			return false;
+			return turretReady && base.CanAttack(self, target);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -113,7 +113,12 @@ namespace OpenRA.Mods.Common.Traits
 			var delta = target.CenterPosition - self.CenterPosition;
 			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();
-			return TurretFacing == DesiredFacing.Value;
+			return HasAchievedDesiredFacing;
+		}
+
+		public bool HasAchievedDesiredFacing
+		{
+			get { return DesiredFacing != null && TurretFacing == DesiredFacing.Value; }
 		}
 
 		// Turret offset in world-space


### PR DESCRIPTION
Whilst a turreted unit has a valid target, all turrets will be made to track the target even if it is not ready to attack yet. This means once it becomes ready (e.g. enters range, reloads, etc) it will already be lined up.

Fixes #5203.
