### PR TITLE
Add xmldoc to some ISpriteFrame members

### DIFF
--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -24,8 +24,17 @@ namespace OpenRA.Graphics
 
 	public interface ISpriteFrame
 	{
+		/// <summary>
+		/// Size of the frame's `Data`.
+		/// </summary>
 		Size Size { get; }
+
+		/// <summary>
+		/// Size of the entire frame including the frame's `Size`.
+		/// Think of this like a picture frame.
+		/// </summary>
 		Size FrameSize { get; }
+
 		float2 Offset { get; }
 		byte[] Data { get; }
 		bool DisableExportPadding { get; }


### PR DESCRIPTION
ref http://logs.openra.net/?year=2016&month=03&day=12#19:27:49

```
[19:27:49]  <Phrohdoh> I'm a bit confused on the terminology in shptsloader
[19:28:26]  <Phrohdoh> We have a Size and a FrameSize
[19:28:33]  <pchote> yes
[19:28:38]  <Phrohdoh> But it looks like FrameSize isn't really that
[19:28:50]  <Phrohdoh> it may be the entire shp's max width/height
[19:29:00]  <Phrohdoh> but https://github.com/OpenRA/OpenRA/blob/f3c8dd0397723b15beb0d4b5455d4ff05556a8e4/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs#L36 is actually the frame's size
[19:29:19]  <pchote> terminology failure there
[19:29:30]  <pchote> frame as in the frame around it (like a picture frame) vs individual frame in an animation
```
