### PR TITLE
Reference SubCells directly from MapGrid.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -74,10 +74,6 @@ namespace OpenRA
 		public readonly MapGrid Grid;
 		readonly ModData modData;
 
-		[FieldLoader.Ignore] public readonly WVec[] SubCellOffsets;
-		public readonly SubCell DefaultSubCell;
-		public readonly SubCell LastSubCell;
-
 		public IReadOnlyPackage Package { get; private set; }
 
 		// Yaml map data
@@ -92,14 +88,6 @@ namespace OpenRA
 		public string Tileset;
 		public bool LockPreview;
 		public bool InvalidCustomRules { get; private set; }
-
-		public WVec OffsetOfSubCell(SubCell subCell)
-		{
-			if (subCell == SubCell.Invalid || subCell == SubCell.Any)
-				return WVec.Zero;
-
-			return SubCellOffsets[(int)subCell];
-		}
 
 		public static string ComputeUID(IReadOnlyPackage package)
 		{
@@ -273,10 +261,6 @@ namespace OpenRA
 			MapHeight = Exts.Lazy(LoadMapHeight);
 
 			Grid = modData.Manifest.Get<MapGrid>();
-
-			SubCellOffsets = Grid.SubCellOffsets;
-			LastSubCell = (SubCell)(SubCellOffsets.Length - 1);
-			DefaultSubCell = (SubCell)Grid.SubCellDefaultIndex;
 
 			PostInit();
 
@@ -760,8 +744,8 @@ namespace OpenRA
 		public WPos CenterOfSubCell(CPos cell, SubCell subCell)
 		{
 			var index = (int)subCell;
-			if (index >= 0 && index <= SubCellOffsets.Length)
-				return CenterOfCell(cell) + SubCellOffsets[index];
+			if (index >= 0 && index <= Grid.SubCellOffsets.Length)
+				return CenterOfCell(cell) + Grid.SubCellOffsets[index];
 			return CenterOfCell(cell);
 		}
 

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -12,6 +12,7 @@
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using OpenRA.Traits;
 
 namespace OpenRA
 {
@@ -22,7 +23,8 @@ namespace OpenRA
 		public readonly MapGridType Type = MapGridType.Rectangular;
 		public readonly Size TileSize = new Size(24, 24);
 		public readonly byte MaximumTerrainHeight = 0;
-		public readonly byte SubCellDefaultIndex = byte.MaxValue;
+		public readonly SubCell DefaultSubCell = (SubCell)byte.MaxValue;
+
 		public readonly WVec[] SubCellOffsets =
 		{
 			new WVec(0, 0, 0),       // full cell - index 0
@@ -76,9 +78,10 @@ namespace OpenRA
 			FieldLoader.Load(this, yaml);
 
 			// The default subcell index defaults to the middle entry
-			if (SubCellDefaultIndex == byte.MaxValue)
-				SubCellDefaultIndex = (byte)(SubCellOffsets.Length / 2);
-			else if (SubCellDefaultIndex < (SubCellOffsets.Length > 1 ? 1 : 0) || SubCellDefaultIndex >= SubCellOffsets.Length)
+			var defaultSubCellIndex = (byte)DefaultSubCell;
+			if (defaultSubCellIndex == byte.MaxValue)
+				DefaultSubCell = (SubCell)(SubCellOffsets.Length / 2);
+			else if (defaultSubCellIndex < (SubCellOffsets.Length > 1 ? 1 : 0) || defaultSubCellIndex >= SubCellOffsets.Length)
 				throw new InvalidDataException("Subcell default index must be a valid index into the offset triples and must be greater than 0 for mods with subcells");
 
 			var leftDelta = Type == MapGridType.RectangularIsometric ? new WVec(-512, 0, 0) : new WVec(-512, -512, 0);
@@ -92,6 +95,14 @@ namespace OpenRA
 				rightDelta + new WVec(0, 0, 512 * ramp[2]),
 				bottomDelta + new WVec(0, 0, 512 * ramp[3])
 			}).ToArray();
+		}
+
+		public WVec OffsetOfSubCell(SubCell subCell)
+		{
+			if (subCell == SubCell.Invalid || subCell == SubCell.Any)
+				return WVec.Zero;
+
+			return SubCellOffsets[(int)subCell];
 		}
 	}
 }

--- a/OpenRA.Game/Traits/World/ActorMap.cs
+++ b/OpenRA.Game/Traits/World/ActorMap.cs
@@ -249,9 +249,9 @@ namespace OpenRA.Traits
 				return preferredSubCell;
 
 			if (!AnyActorsAt(cell))
-				return map.DefaultSubCell;
+				return map.Grid.DefaultSubCell;
 
-			for (var i = (int)SubCell.First; i < map.SubCellOffsets.Length; i++)
+			for (var i = (int)SubCell.First; i < map.Grid.SubCellOffsets.Length; i++)
 				if (i != (int)preferredSubCell && !AnyActorsAt(cell, (SubCell)i, checkTransient))
 					return (SubCell)i;
 
@@ -264,9 +264,9 @@ namespace OpenRA.Traits
 				return preferredSubCell;
 
 			if (!AnyActorsAt(cell))
-				return map.DefaultSubCell;
+				return map.Grid.DefaultSubCell;
 
-			for (var i = (int)SubCell.First; i < map.SubCellOffsets.Length; i++)
+			for (var i = (int)SubCell.First; i < map.Grid.SubCellOffsets.Length; i++)
 				if (i != (int)preferredSubCell && !AnyActorsAt(cell, (SubCell)i, checkIfBlocker))
 					return (SubCell)i;
 			return SubCell.Invalid;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -190,8 +190,8 @@ namespace OpenRA.Mods.Common.Activities
 				mobile.SetLocation(mobile.FromCell, mobile.FromSubCell, nextCell.Value.First, nextCell.Value.Second);
 				var from = self.World.Map.CenterOfSubCell(mobile.FromCell, mobile.FromSubCell);
 				var to = Util.BetweenCells(self.World, mobile.FromCell, mobile.ToCell) +
-					(self.World.Map.OffsetOfSubCell(mobile.FromSubCell) +
-					self.World.Map.OffsetOfSubCell(mobile.ToSubCell)) / 2;
+					(self.World.Map.Grid.OffsetOfSubCell(mobile.FromSubCell) +
+					self.World.Map.Grid.OffsetOfSubCell(mobile.ToSubCell)) / 2;
 				var move = new MoveFirstHalf(
 					this,
 					from,
@@ -381,15 +381,15 @@ namespace OpenRA.Mods.Common.Activities
 
 			protected override MovePart OnComplete(Actor self, Mobile mobile, Move parent)
 			{
-				var fromSubcellOffset = self.World.Map.OffsetOfSubCell(mobile.FromSubCell);
-				var toSubcellOffset = self.World.Map.OffsetOfSubCell(mobile.ToSubCell);
+				var fromSubcellOffset = self.World.Map.Grid.OffsetOfSubCell(mobile.FromSubCell);
+				var toSubcellOffset = self.World.Map.Grid.OffsetOfSubCell(mobile.ToSubCell);
 
 				var nextCell = parent.PopPath(self);
 				if (nextCell != null)
 				{
 					if (IsTurn(mobile, nextCell.Value.First))
 					{
-						var nextSubcellOffset = self.World.Map.OffsetOfSubCell(nextCell.Value.Second);
+						var nextSubcellOffset = self.World.Map.Grid.OffsetOfSubCell(nextCell.Value.Second);
 						var ret = new MoveFirstHalf(
 							Move,
 							Util.BetweenCells(self.World, mobile.FromCell, mobile.ToCell) + (fromSubcellOffset + toSubcellOffset) / 2,

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -368,7 +368,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			speedModifiers = Exts.Lazy(() => self.TraitsImplementing<ISpeedModifier>().ToArray().Select(x => x.GetSpeedModifier()));
 
-			ToSubCell = FromSubCell = info.SharesCell ? init.World.Map.DefaultSubCell : SubCell.FullCell;
+			ToSubCell = FromSubCell = info.SharesCell ? init.World.Map.Grid.DefaultSubCell : SubCell.FullCell;
 			if (init.Contains<SubCellInit>())
 				FromSubCell = ToSubCell = init.Get<SubCellInit, SubCell>();
 
@@ -397,7 +397,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.SharesCell)
 			{
 				if (preferred <= SubCell.FullCell)
-					return self.World.Map.DefaultSubCell;
+					return self.World.Map.Grid.DefaultSubCell;
 			}
 			else
 			{
@@ -776,7 +776,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// TODO: solve/reduce cell is full problem
 			if (subCell == SubCell.Invalid)
-				subCell = self.World.Map.DefaultSubCell;
+				subCell = self.World.Map.Grid.DefaultSubCell;
 
 			// Reserve the exit cell
 			SetPosition(self, cell, subCell);

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -226,9 +226,9 @@ namespace OpenRA.Mods.Common.Traits
 			var map = worldRenderer.World.Map;
 			var previews = PreviewsAt(cell).ToList();
 			if (!previews.Any())
-				return map.DefaultSubCell;
+				return map.Grid.DefaultSubCell;
 
-			for (var i = (int)SubCell.First; i < map.SubCellOffsets.Length; i++)
+			for (var i = (int)SubCell.First; i < map.Grid.SubCellOffsets.Length; i++)
 				if (!previews.Any(p => p.Footprint[cell] == (SubCell)i))
 					return (SubCell)i;
 

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 			var targetCell = world.Map.CellContaining(target);
 
 			// Correct for SubCell offset
-			target -= world.Map.OffsetOfSubCell(srcSub);
+			target -= world.Map.Grid.OffsetOfSubCell(srcSub);
 
 			// Select only the tiles that are within range from the requested SubCell
 			// This assumes that the SubCell does not change during the path traversal

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -120,7 +120,7 @@ MapGrid:
 	Type: RectangularIsometric
 	MaximumTerrainHeight: 16
 	SubCellOffsets: 0,0,0, -256,128,0, 0,-128,0, 256,128,0
-	SubCellDefaultIndex: 2
+	DefaultSubCell: 2
 
 Cursors:
 	ts|cursors.yaml


### PR DESCRIPTION
The SubCell data was moved outside `Map` a while ago, but the references were kept.  This changes the higher level code to reference the `MapGrid` directly.
