### PR TITLE
Fix some actors not being available for the neutral player in the map editor

### DIFF
--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -156,7 +156,7 @@ World:
 
 EditorWorld:
 	Inherits: ^BaseWorld
-	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:
+	LoadWidgetAtGameStart:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -157,7 +157,7 @@ World:
 
 EditorWorld:
 	Inherits: ^BaseWorld
-	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	D2kEditorResourceLayer:
 	EditorSelectionLayer:
+	LoadWidgetAtGameStart:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -173,7 +173,7 @@ World:
 
 EditorWorld:
 	Inherits: ^BaseWorld
-	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:
+	LoadWidgetAtGameStart:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -175,8 +175,8 @@ World:
 
 EditorWorld:
 	Inherits: ^BaseWorld
-	LoadWidgetAtGameStart:
 	EditorActorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:
 		Palette: placebuilding
+	LoadWidgetAtGameStart:


### PR DESCRIPTION
This is basically a follow-up from #10804, since both issues have the same cause, which just wasn't realized until now. For some reason I didn't put `LoadWidgetAtGameStart` at the end of the list for the `EditorWorld` in that PR, which would have already fixed the issue a while ago.

Fixes #10780.
