### PR TITLE
Fixed AppVeyor after_test depending on a Unix cp command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ after_test:
   - make docs
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o DOCUMENTATION.html DOCUMENTATION.md'
   - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o Lua-API.html Lua-API.md'
-  - cp OpenRA.Game/OpenRA.ico .
+  - ps: cp OpenRA.Game/OpenRA.ico .
   - if not exist nsissetup.exe appveyor DownloadFile "http://downloads.sourceforge.net/project/nsis/NSIS 2/2.46/nsis-2.46-setup.exe" -FileName nsissetup.exe
   - nsissetup /S /D=%NSIS_ROOT%
   - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\download\windows" /V3 packaging/windows/OpenRA.nsi'


### PR DESCRIPTION
Apparently without it the `cp` command relies on a Unix `cp.exe` available from an arbitrary depdendency we were not aware of and it vanishing was the reason for yesterdays failed builds.  Source: http://help.appveyor.com/discussions/problems/4291-cp-fails-on-every-build
