### PR TITLE
Changed grid in map editor to darker red

### DIFF
--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -3,6 +3,7 @@ General:
 	Id: DESERT
 	Palette: desert.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
+	HeightDebugColors: 880000
 
 Terrain:
 	TerrainType@Beach:

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -3,6 +3,7 @@ General:
 	Id: JUNGLE
 	Palette: jungle.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
+	HeightDebugColors: AA0000
 
 Terrain:
 	TerrainType@Beach:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -3,6 +3,7 @@ General:
 	Id: SNOW
 	Palette: snow.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
+	HeightDebugColors: 880000
 
 Terrain:
 	TerrainType@Beach:

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -3,6 +3,7 @@ General:
 	Id: TEMPERAT
 	Palette: temperat.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
+	HeightDebugColors: AA0000
 
 Terrain:
 	TerrainType@Beach:

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -3,6 +3,7 @@ General:
 	Id: WINTER
 	Palette: winter.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
+	HeightDebugColors: 880000
 
 Terrain:
 	TerrainType@Beach:

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -5,6 +5,7 @@ General:
 	Palette: PALETTE.BIN
 	EditorTemplateOrder: Basic, Dune, Sand-Detail, Brick, Sand-Cliff, Sand-Smooth, Cliff-Type-Changer, Rock-Sand-Smooth, Rock-Detail, Rock-Cliff, Rock-Cliff-Rock, Rotten-Base, Dead-Worm, Ice, Ice-Detail, Rock-Cliff-Sand, Sand-Platform, Unidentified
 	IgnoreTileSpriteOffsets: True
+	HeightDebugColors: 880000
 
 Terrain:
 	TerrainType@Clear:

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -4,6 +4,7 @@ General:
 	Palette: desert.pal
 	PlayerPalette: temperat.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
+	HeightDebugColors: 880000
 
 Terrain:
 	TerrainType@Beach:

--- a/mods/ra/tilesets/interior.yaml
+++ b/mods/ra/tilesets/interior.yaml
@@ -3,6 +3,7 @@ General:
 	Id: INTERIOR
 	Palette: interior.pal
 	EditorTemplateOrder: Floor, Wall
+	HeightDebugColors: 880000
 
 Terrain:
 	TerrainType@Clear:

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -3,6 +3,7 @@ General:
 	Id: SNOW
 	Palette: snow.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
+	HeightDebugColors: 880000
 
 Terrain:
 	TerrainType@Beach:

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -3,6 +3,7 @@ General:
 	Id: TEMPERAT
 	Palette: temperat.pal
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
+	HeightDebugColors: AA0000
 
 Terrain:
 	TerrainType@Beach:


### PR DESCRIPTION
Related to #10753. Added parameter General.HeightDebugColors for each terrain type in \mods\ra\tilesets. I changed the color from #FF0000 to #880000 with the exception of Temperate terrain, where it's only down to #AA0000 as too dark color blends with the terrain and can't be seen.

Changes can be seen on screenshots under this link:
http://imgur.com/a/1NNeX

I appologize for any possible fuckups I may have caused as this is my first pull request ever... but I hope it's all okay. :)
