### PR TITLE
Replay hotkeys for pause/play/change of speed

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -269,6 +269,11 @@ namespace OpenRA
 		public Hotkey SupportPower05Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
 		public Hotkey SupportPower06Key = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
 
+		public Hotkey ReplaySpeedSlowKey = new Hotkey(Keycode.F5, Modifiers.None);
+		public Hotkey ReplaySpeedRegularKey = new Hotkey(Keycode.F6, Modifiers.None);
+		public Hotkey ReplaySpeedFastKey = new Hotkey(Keycode.F7, Modifiers.None);
+		public Hotkey ReplaySpeedMaxKey = new Hotkey(Keycode.F8, Modifiers.None);
+
 		static readonly Func<KeySettings, Hotkey>[] ProductionKeys = GetKeys(24, "Production");
 		static readonly Func<KeySettings, Hotkey>[] SupportPowerKeys = GetKeys(6, "SupportPower");
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
@@ -46,15 +46,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var originalTimestep = world.Timestep;
 
 				var pauseButton = widget.Get<ButtonWidget>("BUTTON_PAUSE");
+				pauseButton.GetKey = _ => Game.Settings.Keys.PauseKey;
 				pauseButton.IsVisible = () => world.Timestep != 0 && orderManager.NetFrameNumber < replayNetTicks;
 				pauseButton.OnClick = () => world.Timestep = 0;
 
 				var playButton = widget.Get<ButtonWidget>("BUTTON_PLAY");
+				playButton.GetKey = _ => Game.Settings.Keys.PauseKey;
 				playButton.IsVisible = () => world.Timestep == 0 || orderManager.NetFrameNumber >= replayNetTicks;
 				playButton.OnClick = () => world.Timestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
 				playButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 
 				var slowButton = widget.Get<ButtonWidget>("BUTTON_SLOW");
+				slowButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedSlowKey;
 				slowButton.IsHighlighted = () => speed == PlaybackSpeed.Slow;
 				slowButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				slowButton.OnClick = () =>
@@ -65,6 +68,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var normalSpeedButton = widget.Get<ButtonWidget>("BUTTON_REGULAR");
+				normalSpeedButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedRegularKey;
 				normalSpeedButton.IsHighlighted = () => speed == PlaybackSpeed.Regular;
 				normalSpeedButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				normalSpeedButton.OnClick = () =>
@@ -75,6 +79,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var fastButton = widget.Get<ButtonWidget>("BUTTON_FAST");
+				fastButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedFastKey;
 				fastButton.IsHighlighted = () => speed == PlaybackSpeed.Fast;
 				fastButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				fastButton.OnClick = () =>
@@ -85,6 +90,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var maximumButton = widget.Get<ButtonWidget>("BUTTON_MAXIMUM");
+				maximumButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedMaxKey;
 				maximumButton.IsHighlighted = () => speed == PlaybackSpeed.Maximum;
 				maximumButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				maximumButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -467,7 +467,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var hotkeys = new Dictionary<string, string>()
 				{
 					{ "ObserverCombinedView", "All Players" },
-					{ "ObserverWorldView", "Disable Shroud" }
+					{ "ObserverWorldView", "Disable Shroud" },
+					{ "PauseKey", "Pause/Play" },
+					{ "ReplaySpeedSlowKey", "Slow speed" },
+					{ "ReplaySpeedRegularKey", "Regular speed" },
+					{ "ReplaySpeedFastKey", "Fast speed" },
+					{ "ReplaySpeedMaxKey", "Maximum speed" }
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);


### PR DESCRIPTION
Related to #8972. I also added hint to button tooltips via edditing {mod}/chrome/ingame-observer.yaml or in case of cnc ingame.yaml. You can see the result here: http://imgur.com/a/kk64J

I added the hotkeys to OpenRA.Game/Settings.cs and added this functionality to OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs. Hopefully that is the correct place for that.

Keys are mapped to:
Pause/Play: Spacebar
Slow speed: F5
Regular speed: F6
Fast speed: F7
Max speed: F8
