### PR TITLE
Remove sdk flag from default makefile.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
 # Run the NUnit tests
 script:
  - travis_retry make all-dependencies
- - make all
+ - make all SDK="-sdk:4.0"
  - make check
  - make check-scripts
  - make test

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@
 
 ############################## TOOLCHAIN ###############################
 #
-CSC         = mcs -sdk:4.0
+SDK         ?=
+CSC         = mcs $(SDK)
 CSFLAGS     = -nologo -warn:4 -codepage:utf8 -unsafe -warnaserror
 DEFINE      = TRACE
 COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/Mono.Nat.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/MaxMind.GeoIP2.dll thirdparty/download/Eluant.dll thirdparty/download/SmarIrc4net.dll


### PR DESCRIPTION
Linux distros are slowly migrating to mono >= 4, and most of them don't seem to be including support for the 4.0 SDK (probably because, as far as I understand, this relies on shipping binaries that can no longer be compiled from source).  This then leads to issues like #10248 and #10726.

This removes the forced SDK from the default makefile, but keeps it for our travis builds (which use the Xamarin mono builds that _do_ have 4.0 support) to retain compatibility with .NET 4 on windows.
