### PR TITLE
Unhardcode Explosion "Image"

### DIFF
--- a/OpenRA.Mods.Common/Effects/Explosion.cs
+++ b/OpenRA.Mods.Common/Effects/Explosion.cs
@@ -22,12 +22,12 @@ namespace OpenRA.Mods.Common.Effects
 		readonly Animation anim;
 		WPos pos;
 
-		public Explosion(World world, WPos pos, string sequence, string palette)
+		public Explosion(World world, WPos pos, string image, string sequence, string palette)
 		{
 			this.world = world;
 			this.pos = pos;
 			this.palette = palette;
-			anim = new Animation(world, "explosion");
+			anim = new Animation(world, image);
 			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -20,15 +20,15 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("If we land on invalid terrain for my actor type should we be killed?")]
 		public readonly bool KilledOnImpassableTerrain = true;
 
-		[Desc("Group where Ground/WaterCorpseSequence is looked up.")]
-		public readonly string CorpseSequenceCollection = "explosion";
+		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
+		public readonly string Image = "explosion";
 
 		public readonly string GroundImpactSound = null;
-		[SequenceReference("CorpseSequenceCollection")] public readonly string GroundCorpseSequence = "corpse";
+		[SequenceReference("Image")] public readonly string GroundCorpseSequence = "corpse";
 		[PaletteReference] public readonly string GroundCorpsePalette = "effect";
 
 		public readonly string WaterImpactSound = null;
-		[SequenceReference("CorpseSequenceCollection")] public readonly string WaterCorpseSequence = null;
+		[SequenceReference("Image")] public readonly string WaterCorpseSequence = null;
 		[PaletteReference] public readonly string WaterCorpsePalette = "effect";
 
 		public readonly int FallRate = 13;
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			var sequence = terrain.IsWater ? info.WaterCorpseSequence : info.GroundCorpseSequence;
 			var palette = terrain.IsWater ? info.WaterCorpsePalette : info.GroundCorpsePalette;
 			if (sequence != null && palette != null)
-				self.World.AddFrameEndTask(w => w.Add(new Explosion(w, self.OccupiesSpace.CenterPosition, sequence, palette)));
+				self.World.AddFrameEndTask(w => w.Add(new Explosion(w, self.OccupiesSpace.CenterPosition, info.Image, sequence, palette)));
 
 			self.Kill(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingExplosion.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingExplosion.cs
@@ -19,16 +19,16 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Display explosions over the building footprint when it is destroyed.")]
 	class WithBuildingExplosionInfo : ITraitInfo, Requires<BuildingInfo>
 	{
-		[Desc("Group where Sequences are looked up.")]
-		public readonly string SequenceCollection = "explosion";
+		[Desc("'Image' where Sequences are looked up.")]
+		public readonly string Image = "explosion";
 
-		[Desc("Explosion sequence names to use")]
-		[SequenceReference("SequenceCollection")] public readonly string[] Sequences = { "building" };
+		[Desc("Explosion sequence names to use.")]
+		[SequenceReference("Image")] public readonly string[] Sequences = { "building" };
 
 		[Desc("Delay the explosions by this many ticks.")]
 		public readonly int Delay = 0;
 
-		[Desc("Custom palette name")]
+		[Desc("Custom palette name.")]
 		[PaletteReference] public readonly string Palette = "effect";
 
 		public object Create(ActorInitializer init) { return new WithBuildingExplosion(init.Self, this); }
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 		void SpawnExplosions(World world, IEnumerable<CPos> cells)
 		{
 			foreach (var c in cells)
-				world.AddFrameEndTask(w => w.Add(new Explosion(w, w.Map.CenterOfCell(c), info.Sequences.Random(w.SharedRandom), info.Palette)));
+				world.AddFrameEndTask(w => w.Add(new Explosion(w, w.Map.CenterOfCell(c), info.Image, info.Sequences.Random(w.SharedRandom), info.Palette)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -606,6 +606,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "TurnSpeed";
 				}
 
+				if (engineVersion < 20160320)
+				{
+					// Renamed Parachutable.CorpseSequenceCollection to Image
+					if (node.Key == "CorpseSequenceCollection")
+						node.Key = "Image";
+
+					// Renamed WithBuildingExplosion.SequenceCollection to Image
+					if (node.Key == "SequenceCollection")
+						node.Key = "Image";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -18,8 +18,11 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class CreateEffectWarhead : Warhead
 	{
-		[Desc("List of explosion effects that can be used.")]
-		public readonly string[] Explosions = new string[0];
+		[Desc("List of explosion sequences that can be used.")]
+		[SequenceReference("Image")] public readonly string[] Explosions = new string[0];
+
+		[Desc("Image containing explosion effect sequence.")]
+		public readonly string Image = "explosion";
 
 		[Desc("Palette to use for explosion effect."), PaletteReference("UsePlayerPalette")]
 		public readonly string ExplosionPalette = "effect";
@@ -101,8 +104,8 @@ namespace OpenRA.Mods.Common.Warheads
 				palette += firedBy.Owner.InternalName;
 
 			var explosion = Explosions.RandomOrDefault(Game.CosmeticRandom);
-			if (explosion != null)
-				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, explosion, palette)));
+			if (Image != null && explosion != null)
+				world.AddFrameEndTask(w => w.Add(new Explosion(w, pos, Image, explosion, palette)));
 
 			var impactSound = ImpactSounds.RandomOrDefault(Game.CosmeticRandom);
 			if (impactSound != null)


### PR DESCRIPTION
Adds `ExplosionCollection` property to `CreateEffectWarhead`.

Additionally - although I didn't test it - going by the code I believe that before my fix, `Explodes`, `Parachutable`, `WithBuildingExplosion` would only pass lint tests but NOT work in-game with anything other than "explosion", because that image string was still hardcoded on the effect itself.

Should make life easier for 3rd-party mods.
