### PR TITLE
Remove map lazyness.

### DIFF
--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -20,15 +20,11 @@ namespace OpenRA.Graphics
 		readonly Map map;
 		readonly Dictionary<string, TerrainSpriteLayer> spriteLayers = new Dictionary<string, TerrainSpriteLayer>();
 		readonly Theater theater;
-		readonly CellLayer<TerrainTile> mapTiles;
-		readonly CellLayer<byte> mapHeight;
 
 		public TerrainRenderer(World world, WorldRenderer wr)
 		{
 			map = world.Map;
 			theater = wr.Theater;
-			mapTiles = map.MapTiles.Value;
-			mapHeight = map.MapHeight.Value;
 
 			foreach (var template in map.Rules.TileSet.Templates)
 			{
@@ -40,13 +36,13 @@ namespace OpenRA.Graphics
 			foreach (var cell in map.AllCells)
 				UpdateCell(cell);
 
-			mapTiles.CellEntryChanged += UpdateCell;
-			mapHeight.CellEntryChanged += UpdateCell;
+			map.Tiles.CellEntryChanged += UpdateCell;
+			map.Height.CellEntryChanged += UpdateCell;
 		}
 
 		public void UpdateCell(CPos cell)
 		{
-			var tile = mapTiles[cell];
+			var tile = map.Tiles[cell];
 			var palette = TileSet.TerrainPaletteInternalName;
 			if (map.Rules.TileSet.Templates.ContainsKey(tile.Type))
 				palette = map.Rules.TileSet.Templates[tile.Type].Palette ?? palette;
@@ -67,8 +63,8 @@ namespace OpenRA.Graphics
 
 		public void Dispose()
 		{
-			mapTiles.CellEntryChanged -= UpdateCell;
-			mapHeight.CellEntryChanged -= UpdateCell;
+			map.Tiles.CellEntryChanged -= UpdateCell;
+			map.Height.CellEntryChanged -= UpdateCell;
 
 			foreach (var kv in spriteLayers.Values)
 				kv.Dispose();

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -161,8 +161,7 @@ namespace OpenRA.Graphics
 					var ramp = 0;
 					if (map.Contains(uv))
 					{
-						var tile = map.MapTiles.Value[uv];
-						var ti = tileSet.GetTileInfo(tile);
+						var ti = tileSet.GetTileInfo(map.Tiles[uv]);
 						if (ti != null)
 							ramp = ti.RampType;
 					}

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -161,13 +161,6 @@ namespace OpenRA
 		[FieldLoader.Ignore] public CellRegion AllCells;
 		public List<CPos> AllEdgeCells { get; private set; }
 
-		void AssertExists(string filename)
-		{
-			using (var s = Package.GetStream(filename))
-				if (s == null)
-					throw new InvalidOperationException("Required file {0} not present in this map".F(filename));
-		}
-
 		/// <summary>
 		/// Initializes a new map created by the editor or importer.
 		/// The map will not receive a valid UID until after it has been saved and reloaded.
@@ -208,8 +201,8 @@ namespace OpenRA
 			this.modData = modData;
 			Package = package;
 
-			AssertExists("map.yaml");
-			AssertExists("map.bin");
+			if (!Package.Contains("map.yaml") || !Package.Contains("map.bin"))
+				throw new InvalidDataException("Not a valid map\n File: {1}".F(package.Name));
 
 			var yaml = new MiniYaml(null, MiniYaml.FromStream(Package.GetStream("map.yaml"), package.Name));
 			FieldLoader.Load(this, yaml);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -126,8 +126,6 @@ namespace OpenRA
 		/// </summary>
 		public WPos ProjectedBottomRight;
 
-		public Lazy<CPos[]> SpawnPoints;
-
 		// Yaml map data
 		[FieldLoader.Ignore] public readonly MiniYaml RuleDefinitions;
 		[FieldLoader.Ignore] public readonly MiniYaml SequenceDefinitions;
@@ -203,8 +201,6 @@ namespace OpenRA
 
 			Tiles.Clear(tileRef);
 
-			SpawnPoints = Exts.Lazy(() => new CPos[0]);
-
 			PostInit();
 		}
 
@@ -221,19 +217,6 @@ namespace OpenRA
 
 			if (MapFormat != SupportedMapFormat)
 				throw new InvalidDataException("Map format {0} is not supported.\n File: {1}".F(MapFormat, package.Name));
-
-			SpawnPoints = Exts.Lazy(() =>
-			{
-				var spawns = new List<CPos>();
-				foreach (var kv in ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
-				{
-					var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
-
-					spawns.Add(s.InitDict.Get<LocationInit>().Value(null));
-				}
-
-				return spawns.ToArray();
-			});
 
 			RuleDefinitions = LoadRuleSection(yaml, "Rules");
 			SequenceDefinitions = LoadRuleSection(yaml, "Sequences");

--- a/OpenRA.Game/Map/ProjectedCellRegion.cs
+++ b/OpenRA.Game/Map/ProjectedCellRegion.cs
@@ -44,8 +44,8 @@ namespace OpenRA
 			var maxHeight = map.Grid.MaximumTerrainHeight;
 			var heightOffset = map.Grid.Type == MapGridType.RectangularIsometric ? maxHeight : maxHeight / 2;
 
-			// Use the MapHeight data array to clamp the bottom coordinate so it doesn't overflow the map
-			mapBottomRight = map.MapHeight.Value.Clamp(new MPos(bottomRight.U, bottomRight.V + heightOffset));
+			// Use the map Height data array to clamp the bottom coordinate so it doesn't overflow the map
+			mapBottomRight = map.Height.Clamp(new MPos(bottomRight.U, bottomRight.V + heightOffset));
 		}
 
 		public bool Contains(PPos puv)

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -186,18 +186,14 @@ namespace OpenRA
 			if (MapCache[uid].Status != MapStatus.Available)
 				throw new InvalidDataException("Invalid map uid: {0}".F(uid));
 
-			// Operate on a copy of the map to avoid gameplay state leaking into the cache
-			var map = new Map(this, MapCache[uid].Package);
+			Map map;
+			using (new Support.PerfTimer("Map"))
+				map = new Map(this, MapCache[uid].Package);
 
 			LoadTranslations(map);
 
 			// Reinitialize all our assets
 			InitializeLoaders(map);
-
-			using (new Support.PerfTimer("Map.PreloadRules"))
-				map.PreloadRules();
-			using (new Support.PerfTimer("Map.SequenceProvider.Preload"))
-				map.Rules.Sequences.Preload();
 
 			// Load music with map assets mounted
 			using (new Support.PerfTimer("Map.Music"))

--- a/OpenRA.Mods.Cnc/ImportTiberianDawnLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/ImportTiberianDawnLegacyMapCommand.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				{
 					var type = ms.ReadUInt8();
 					var index = ms.ReadUInt8();
-					Map.MapTiles.Value[new CPos(i, j)] = new TerrainTile(type, index);
+					Map.Tiles[new CPos(i, j)] = new TerrainTile(type, index);
 				}
 			}
 		}
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				if (overlayResourceMapping.ContainsKey(type))
 					res = overlayResourceMapping[type];
 
-				Map.MapResources.Value[cell] = new ResourceTile(res.First, res.Second);
+				Map.Resources[cell] = new ResourceTile(res.First, res.Second);
 				if (overlayActors.Contains(type))
 				{
 					var ar = new ActorReference(type)

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down)
 			{
 				// Check the actor is inside the map
-				if (!footprint.All(c => world.Map.MapTiles.Value.Contains(cell + locationOffset + c)))
+				if (!footprint.All(c => world.Map.Tiles.Contains(cell + locationOffset + c)))
 					return true;
 
 				var newActorReference = new ActorReference(Actor.Name);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -94,9 +94,9 @@ namespace OpenRA.Mods.Common.Widgets
 		void Copy(CellRegion source, CVec offset)
 		{
 			var gridType = worldRenderer.World.Map.Grid.Type;
-			var mapTiles = worldRenderer.World.Map.MapTiles.Value;
-			var mapHeight = worldRenderer.World.Map.MapHeight.Value;
-			var mapResources = worldRenderer.World.Map.MapResources.Value;
+			var mapTiles = worldRenderer.World.Map.Tiles;
+			var mapHeight = worldRenderer.World.Map.Height;
+			var mapResources = worldRenderer.World.Map.Resources;
 
 			var dest = new CellRegion(gridType, source.TopLeft + offset, source.BottomRight + offset);
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var underCursor = editorLayer.PreviewsAt(worldPixel).MinByOrDefault(CalculateActorSelectionPriority);
 
-			var mapResources = world.Map.MapResources.Value;
+			var mapResources = world.Map.Resources;
 			ResourceType type;
 			if (underCursor != null)
 				editorWidget.SetTooltip(underCursor.Tooltip);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				var type = (byte)ResourceType.ResourceType;
 				var index = (byte)ResourceType.MaxDensity;
-				world.Map.MapResources.Value[cell] = new ResourceTile(type, index);
+				world.Map.Resources[cell] = new ResourceTile(type, index);
 			}
 
 			return true;
@@ -77,11 +77,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public bool AllowResourceAt(CPos cell)
 		{
-			var mapResources = world.Map.MapResources.Value;
+			var mapResources = world.Map.Resources;
 			if (!mapResources.Contains(cell))
 				return false;
 
-			var tile = world.Map.MapTiles.Value[cell];
+			var tile = world.Map.Tiles[cell];
 			var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
 			if (tileInfo == null)
 				return false;

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -97,8 +97,8 @@ namespace OpenRA.Mods.Common.Widgets
 		void PaintCell(CPos cell, bool isMoving)
 		{
 			var map = world.Map;
-			var mapTiles = map.MapTiles.Value;
-			var mapHeight = map.MapHeight.Value;
+			var mapTiles = map.Tiles;
+			var mapHeight = map.Height;
 
 			var tileset = map.Rules.TileSet;
 			var template = tileset.Templates[Template];
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Widgets
 		void FloodFillWithBrush(CPos cell, bool isMoving)
 		{
 			var map = world.Map;
-			var mapTiles = map.MapTiles.Value;
+			var mapTiles = map.Tiles;
 			var replace = mapTiles[cell];
 
 			if (replace.Type == Template)
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PlacementOverlapsSameTemplate(TerrainTemplateInfo template, CPos cell)
 		{
 			var map = world.Map;
-			var mapTiles = map.MapTiles.Value;
+			var mapTiles = map.Tiles;
 			var i = 0;
 			for (var y = 0; y < template.Size.Y; y++)
 			{

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -447,7 +447,7 @@ namespace OpenRA.Mods.Common.Effects
 				if (!world.Map.Contains(world.Map.CellContaining(posProbe)))
 					break;
 
-				var ht = world.Map.MapHeight.Value[world.Map.CellContaining(posProbe)] * 512;
+				var ht = world.Map.Height[world.Map.CellContaining(posProbe)] * 512;
 
 				curDist += stepSize;
 				if (ht > predClfHgt)

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!bi.AllowInvalidPlacement && world.ActorMap.GetActorsAt(cell).Any(a => a != toIgnore))
 				return false;
 
-			var tile = world.Map.MapTiles.Value[cell];
+			var tile = world.Map.Tiles[cell];
 			var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
 
 			// TODO: This is bandaiding over bogus tilesets.

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -49,7 +49,6 @@ namespace OpenRA.Mods.Common.Traits
 			var world = self.World;
 			var map = world.Map;
 
-			var tiles = map.MapTiles.Value;
 			var pos = map.CellContaining(self.CenterPosition);
 			var terrainType = map.GetTerrainInfo(pos).Type;
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/DeployToUpgrade.cs
@@ -158,7 +158,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (!checkTerrainType)
 				return true;
 
-			var tiles = self.World.Map.MapTiles.Value;
 			var terrainType = self.World.Map.GetTerrainInfo(self.Location).Type;
 
 			return info.AllowedTerrainTypes.Contains(terrainType);
@@ -172,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 			var ramp = 0;
 			if (self.World.Map.Contains(self.Location))
 			{
-				var tile = self.World.Map.MapTiles.Value[self.Location];
+				var tile = self.World.Map.Tiles[self.Location];
 				var ti = self.World.Map.Rules.TileSet.GetTileInfo(tile);
 				if (ti != null)
 					ramp = ti.RampType;

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Take all templates to overlay from the map
-			foreach (var cell in w.Map.AllCells.Where(cell => bridgeTypes.ContainsKey(w.Map.MapTiles.Value[cell].Type)))
+			foreach (var cell in w.Map.AllCells.Where(cell => bridgeTypes.ContainsKey(w.Map.Tiles[cell].Type)))
 				ConvertBridgeToActor(w, cell);
 
 			// Link adjacent (long)-bridges so that artwork is updated correctly
@@ -65,8 +65,8 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// Correlate the tile "image" aka subtile with its position to find the template origin
-			var tile = w.Map.MapTiles.Value[cell].Type;
-			var index = w.Map.MapTiles.Value[cell].Index;
+			var tile = w.Map.Tiles[cell].Type;
+			var index = w.Map.Tiles[cell].Index;
 			var template = w.Map.Rules.TileSet.Templates[tile];
 			var ni = cell.X - index % template.Size.X;
 			var nj = cell.Y - index / template.Size.X;
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			}).Trait<Bridge>();
 
 			var subTiles = new Dictionary<CPos, byte>();
-			var mapTiles = w.Map.MapTiles.Value;
+			var mapTiles = w.Map.Tiles;
 
 			// For each subtile in the template
 			for (byte ind = 0; ind < template.Size.X * template.Size.Y; ind++)

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			Resources = self.TraitsImplementing<ResourceType>()
 				.ToDictionary(r => r.Info.ResourceType, r => r);
 
-			Map.MapResources.Value.CellEntryChanged += UpdateCell;
+			Map.Resources.CellEntryChanged += UpdateCell;
 		}
 
 		public void WorldLoaded(World w, WorldRenderer wr)
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void UpdateCell(CPos cell)
 		{
 			var uv = cell.ToMPos(Map);
-			var tile = Map.MapResources.Value[uv];
+			var tile = Map.Resources[uv];
 
 			var t = Tiles[cell];
 			if (t.Density > 0)
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Set density based on the number of neighboring resources
 			var adjacent = 0;
 			var type = Tiles[c].Type;
-			var resources = Map.MapResources.Value;
+			var resources = Map.Resources;
 			for (var u = -1; u < 2; u++)
 			{
 				for (var v = -1; v < 2; v++)
@@ -205,7 +205,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var kv in spriteLayers.Values)
 				kv.Dispose();
 
-			Map.MapResources.Value.CellEntryChanged -= UpdateCell;
+			Map.Resources.CellEntryChanged -= UpdateCell;
 
 			disposed = true;
 		}

--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -38,7 +38,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
-			var spawns = world.Map.SpawnPoints.Value;
+			var spawns = world.Actors.Where(a => a.Info.Name == "mpspawn")
+				.Select(a => a.Location)
+				.ToArray();
+
 			var taken = world.LobbyInfo.Clients.Where(c => c.SpawnPoint != 0 && c.Slot != null)
 					.Select(c => spawns[c.SpawnPoint - 1]).ToList();
 			var available = spawns.Except(taken).ToList();

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var cell in w.Map.AllCells)
 			{
 				ResourceType t;
-				if (!resources.TryGetValue(w.Map.MapResources.Value[cell].Type, out t))
+				if (!resources.TryGetValue(w.Map.Resources[cell].Type, out t))
 					continue;
 
 				if (!AllowResourceAt(t, cell))
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!rt.Info.AllowOnRamps)
 			{
-				var tile = world.Map.MapTiles.Value[cell];
+				var tile = world.Map.Tiles[cell];
 				var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
 				if (tileInfo != null && tileInfo.RampType > 0)
 					return false;

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -57,11 +57,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var uv in wr.Viewport.AllVisibleCells.CandidateMapCoords)
 			{
-				if (!map.MapHeight.Value.Contains(uv))
+				if (!map.Height.Contains(uv))
 					continue;
 
-				var height = (int)map.MapHeight.Value[uv];
-				var tile = map.MapTiles.Value[uv];
+				var height = (int)map.Height[uv];
+				var tile = map.Tiles[uv];
 				var ti = tileSet.GetTileInfo(tile);
 				var ramp = ti != null ? ti.RampType : 0;
 

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -87,7 +87,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				foreach (var testMap in maps)
 				{
 					Console.WriteLine("Testing map: {0}".F(testMap.Title));
-					testMap.PreloadRules();
 
 					// Run all rule checks on the map if it defines custom rules.
 					if (testMap.RuleDefinitions != null || testMap.VoiceDefinitions != null || testMap.WeaponDefinitions != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var br = new PPos(width, height + maxTerrainHeight);
 				map.SetBounds(tl, br);
 
-				map.PlayerDefinitions = new MapPlayers(map.Rules, map.SpawnPoints.Value.Length).ToMiniYaml();
+				map.PlayerDefinitions = new MapPlayers(map.Rules, 0).ToMiniYaml();
 				map.FixOpenAreas();
 
 				Action<string> afterSave = uid =>

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Widgets
 			foreach (var cell in world.Map.AllCells)
 				UpdateTerrainCell(cell);
 
-			world.Map.MapTiles.Value.CellEntryChanged += UpdateTerrainCell;
+			world.Map.Tiles.CellEntryChanged += UpdateTerrainCell;
 			world.Map.CustomTerrain.CellEntryChanged += UpdateTerrainCell;
 		}
 
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Widgets
 			int leftColor, rightColor;
 			if (custom == byte.MaxValue)
 			{
-				var type = world.Map.Rules.TileSet.GetTileInfo(world.Map.MapTiles.Value[uv]);
+				var type = world.Map.Rules.TileSet.GetTileInfo(world.Map.Tiles[uv]);
 				leftColor = type != null ? type.LeftColor.ToArgb() : Color.Black.ToArgb();
 				rightColor = type != null ? type.RightColor.ToArgb() : Color.Black.ToArgb();
 			}
@@ -444,7 +444,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public override void Removed()
 		{
 			base.Removed();
-			world.Map.MapTiles.Value.CellEntryChanged -= UpdateTerrainCell;
+			world.Map.Tiles.CellEntryChanged -= UpdateTerrainCell;
 			world.Map.CustomTerrain.CellEntryChanged -= UpdateTerrainCell;
 			Dispose();
 		}

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -263,6 +263,7 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 		Size mapSize;
 		TileSet tileSet;
 		List<TerrainTemplateInfo> tileSetsFromYaml;
+		int playerCount;
 
 		D2kMapImporter(string filename, string tileset, Ruleset rules)
 		{
@@ -293,13 +294,12 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 
 		public static Map Import(string filename, string mod, string tileset, Ruleset rules)
 		{
-			var map = new D2kMapImporter(filename, tileset, rules).map;
+			var importer = new D2kMapImporter(filename, tileset, rules);
+			var map = importer.map;
 			if (map == null)
 				return null;
 
 			map.RequiresMod = mod;
-			var players = new MapPlayers(map.Rules, map.SpawnPoints.Value.Length);
-			map.PlayerDefinitions = players.ToMiniYaml();
 
 			return map;
 		}
@@ -324,6 +324,9 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 			// Each frame is a tile from the Dune 2000 tileset files, with the Frame ID being the index of the tile in the original file
 			tileSetsFromYaml = tileSet.Templates.Where(t => t.Value.Frames != null
 				&& t.Value.Images[0].ToLower() == tilesetName.ToLower()).Select(ts => ts.Value).ToList();
+
+			var players = new MapPlayers(map.Rules, playerCount);
+			map.PlayerDefinitions = players.ToMiniYaml();
 		}
 
 		void FillMap()
@@ -356,7 +359,11 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 						new LocationInit(locationOnMap),
 						new OwnerInit(kvp.Second)
 					};
+
 					map.ActorDefinitions.Add(new MiniYamlNode("Actor" + map.ActorDefinitions.Count, a.Save()));
+
+					if (kvp.First == "mpspawn")
+						playerCount++;
 				}
 			}
 		}

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -336,13 +336,13 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 
 				var locationOnMap = GetCurrentTilePositionOnMap();
 
-				map.MapTiles.Value[locationOnMap] = tile;
+				map.Tiles[locationOnMap] = tile;
 
 				// Spice
 				if (tileSpecialInfo == 1)
-					map.MapResources.Value[locationOnMap] = new ResourceTile(1, 1);
+					map.Resources[locationOnMap] = new ResourceTile(1, 1);
 				if (tileSpecialInfo == 2)
-					map.MapResources.Value[locationOnMap] = new ResourceTile(1, 2);
+					map.Resources[locationOnMap] = new ResourceTile(1, 2);
 
 				// Actors
 				if (ActorDataByActorCode.ContainsKey(tileSpecialInfo))

--- a/OpenRA.Mods.RA/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.RA/ImportRedAlertLegacyMapCommand.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.RA.UtilityCommands
 
 			for (var j = 0; j < MapSize; j++)
 				for (var i = 0; i < MapSize; i++)
-					Map.MapTiles.Value[new CPos(i, j)] = new TerrainTile(types[i, j], ms.ReadUInt8());
+					Map.Tiles[new CPos(i, j)] = new TerrainTile(types[i, j], ms.ReadUInt8());
 		}
 
 		static string[] overlayActors = new string[]
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.RA.UtilityCommands
 						res = overlayResourceMapping[redAlertOverlayNames[o]];
 
 					var cell = new CPos(i, j);
-					Map.MapResources.Value[cell] = new ResourceTile(res.First, res.Second);
+					Map.Resources[cell] = new ResourceTile(res.First, res.Second);
 
 					if (o != 255 && overlayActors.Contains(redAlertOverlayNames[o]))
 					{

--- a/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/ImportTSMapCommand.cs
@@ -232,9 +232,9 @@ namespace OpenRA.Mods.TS.UtilityCommands
 			map.Title = basic.GetValue("Name", Path.GetFileNameWithoutExtension(filename));
 			map.Author = "Westwood Studios";
 			map.Bounds = new Rectangle(iniBounds[0], iniBounds[1], iniBounds[2], 2 * iniBounds[3] + 2 * iniBounds[1]);
-			map.MapResources = Exts.Lazy(() => new CellLayer<ResourceTile>(map.Grid.Type, size));
-			map.MapTiles = Exts.Lazy(() => new CellLayer<TerrainTile>(map.Grid.Type, size));
-			map.MapHeight = Exts.Lazy(() => new CellLayer<byte>(map.Grid.Type, size));
+			map.Resources = new CellLayer<ResourceTile>(map.Grid.Type, size);
+			map.Tiles = new CellLayer<TerrainTile>(map.Grid.Type, size);
+			map.Height = new CellLayer<byte>(map.Grid.Type, size);
 
 			map.RequiresMod = modData.Manifest.Mod.Id;
 
@@ -268,13 +268,13 @@ namespace OpenRA.Mods.TS.UtilityCommands
 				var mapCell = new MPos(dx / 2, dy);
 				var cell = mapCell.ToCPos(map);
 
-				if (map.MapTiles.Value.Contains(cell))
+				if (map.Tiles.Contains(cell))
 				{
 					if (!tileset.Templates.ContainsKey(tilenum))
 						tilenum = subtile = 0;
 
-					map.MapTiles.Value[cell] = new TerrainTile(tilenum, subtile);
-					map.MapHeight.Value[cell] = z;
+					map.Tiles[cell] = new TerrainTile(tilenum, subtile);
+					map.Height[cell] = z;
 				}
 			}
 		}
@@ -303,7 +303,7 @@ namespace OpenRA.Mods.TS.UtilityCommands
 					var rx = (ushort)((dx + dy) / 2 + 1);
 					var ry = (ushort)(dy - rx + fullSize.X + 1);
 
-					if (!map.MapResources.Value.Contains(uv))
+					if (!map.Resources.Contains(uv))
 						continue;
 
 					var idx = rx + 512 * ry;
@@ -331,7 +331,7 @@ namespace OpenRA.Mods.TS.UtilityCommands
 
 					if (resourceType != 0)
 					{
-						map.MapResources.Value[uv] = new ResourceTile(resourceType, overlayDataPack[idx]);
+						map.Resources[uv] = new ResourceTile(resourceType, overlayDataPack[idx]);
 						continue;
 					}
 


### PR DESCRIPTION
`Map` objects are now only initialized when we need access to the full map object.  This removes a layer of indirection that is no longer necessary, cleaning up the public interface and making the performance and memory usage more predictable.
