### PR TITLE
Remove cnc mission boilerplate

### DIFF
--- a/mods/cnc/maps/cnc64gdi01/map.yaml
+++ b/mods/cnc/maps/cnc64gdi01/map.yaml
@@ -712,6 +712,6 @@ Actors:
 		Owner: Nod
 		Location: 26,14
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Sequences: sequences.yaml

--- a/mods/cnc/maps/cnc64gdi01/rules.yaml
+++ b/mods/cnc/maps/cnc64gdi01/rules.yaml
@@ -1,29 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: cnc64gdi01.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: aoi
 	MissionData:
@@ -31,83 +8,10 @@ World:
 		StartVideo: obel.vqa
 		WinVideo: orcabomb.vqa
 		LossVideo: cutout.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
 Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
 		DefaultCash: 10000
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 BIO.Husk:
 	Tooltip:
@@ -140,22 +44,6 @@ OLDLST:
 	RejectsOrders:
 	Cargo:
 		Types: disabled
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 airstrike.proxy:
 	AlwaysVisible:

--- a/mods/cnc/maps/funpark01/map.yaml
+++ b/mods/cnc/maps/funpark01/map.yaml
@@ -409,7 +409,7 @@ Actors:
 		Location: 16,50
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Sequences: sequences.yaml
 

--- a/mods/cnc/maps/funpark01/rules.yaml
+++ b/mods/cnc/maps/funpark01/rules.yaml
@@ -1,111 +1,35 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Civilian: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Dinosaur: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	EnemyWatcher:
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 0
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
 	LuaScript:
 		Scripts: scj01ea.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: j1
 	MissionData:
 		Briefing: There have been some reports of strange animals in this area. \n\nTake your units to investigate, and report back your findings.
 		BriefingVideo: generic.vqa
 		StartVideo: dino.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
 	MapOptions:
 		Difficulties: Easy, Normal
 		ShortGameLocked: True
 		ShortGameEnabled: False
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
+Player:
+	EnemyWatcher:
+	PlayerResources:
+		DefaultCash: 0
 
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			Dinosaur: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			Dinosaur: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 
 ^CivInfantry:
 	-ActorLostNotification:
 
 ^CivBuilding:
 	AnnounceOnSeen:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
 
 OLDLST:
 	Inherits: LST
@@ -138,6 +62,4 @@ STEG:
 		Speed: 32
 
 ^DINO:
-	Tooltip:
-		ShowOwnerRow: false
 	MustBeDestroyed:

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -394,7 +394,7 @@ Actors:
 		Location: 54,53
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Sequences: sequences.yaml
 

--- a/mods/cnc/maps/gdi01/rules.yaml
+++ b/mods/cnc/maps/gdi01/rules.yaml
@@ -1,29 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi01.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: aoi
 	MissionData:
@@ -33,83 +10,6 @@ World:
 		StartVideo: landing.vqa
 		WinVideo: consyard.vqa
 		LossVideo: gameover.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 5000
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 NUKE:
 	-Sellable:
@@ -203,19 +103,3 @@ OLDLST:
 	RejectsOrders:
 	Cargo:
 		Types: disabled
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -623,6 +623,6 @@ Actors:
 		Location: 54,55
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Sequences: sequences.yaml

--- a/mods/cnc/maps/gdi02/rules.yaml
+++ b/mods/cnc/maps/gdi02/rules.yaml
@@ -1,29 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi02.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: befeared
 	MissionData:
@@ -31,97 +8,14 @@ World:
 		BriefingVideo: gdi2.vqa
 		WinVideo: flag.vqa
 		LossVideo: gameover.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 5000
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
 
 SBAG:
 	-Crushable:
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 HARV:
 	Harvester:
 		SearchFromProcRadius: 32
 		SearchFromOrderRadius: 20
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 PROC:
 	Buildable:
@@ -218,11 +112,3 @@ OLDLST:
 	RejectsOrders:
 	Cargo:
 		Types: disabled
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -697,4 +697,4 @@ Actors:
 		Location: 37,51
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/gdi03/rules.yaml
+++ b/mods/cnc/maps/gdi03/rules.yaml
@@ -1,29 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi03.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: crep226m
 	MissionData:
@@ -32,94 +9,9 @@ World:
 		StartVideo: samdie.vqa
 		WinVideo: bombaway.vqa
 		LossVideo: gameover.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 5000
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
 
 SBAG:
 	-Crushable:
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 WEAP:
 	Buildable:
@@ -209,19 +101,3 @@ airstrike.proxy:
 		BeaconPoster: airstrike
 		DisplayRadarPing: True
 		CameraActor: camera
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -455,6 +455,6 @@ Actors:
 		Location: 27,58
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/mods/cnc/maps/gdi04a/rules.yaml
+++ b/mods/cnc/maps/gdi04a/rules.yaml
@@ -1,29 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi04a.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: fist226m
 	MissionData:
@@ -33,96 +10,7 @@ World:
 		StartVideo: nitejump.vqa
 		WinVideo: burdet1.vqa
 		LossVideo: gameover.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
 Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
 		DefaultCash: 0
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -526,6 +526,6 @@ Actors:
 		Location: 50,45
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/mods/cnc/maps/gdi04b/rules.yaml
+++ b/mods/cnc/maps/gdi04b/rules.yaml
@@ -1,29 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi04b.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: fist226m
 	MissionData:
@@ -33,100 +10,11 @@ World:
 		StartVideo: nitejump.vqa
 		WinVideo: burdet1.vqa
 		LossVideo: gameover.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
 Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
 		DefaultCash: 0
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 E3:
 	AutoTarget:
 		ScanRadius: 5
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -29,7 +29,7 @@ Players:
 		Faction: nod
 		Color: FE1100
 		Allies: Nod
-		Enemies: GDI, Civillians
+		Enemies: GDI, Civilians
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True
@@ -43,8 +43,8 @@ Players:
 		LockTeam: True
 		Allies: GDI
 		Enemies: Nod
-	PlayerReference@Civillians:
-		Name: Civillians
+	PlayerReference@Civilians:
+		Name: Civilians
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
@@ -418,19 +418,19 @@ Actors:
 		Owner: Neutral
 	Actor124: v05
 		Location: 25,55
-		Owner: Civillians
+		Owner: Civilians
 	Actor125: v03
 		Location: 21,50
-		Owner: Civillians
+		Owner: Civilians
 	Actor128: v05
 		Location: 21,52
-		Owner: Civillians
+		Owner: Civilians
 	Actor130: v07
 		Location: 19,52
-		Owner: Civillians
+		Owner: Civilians
 	Actor131: v06
 		Location: 17,52
-		Owner: Civillians
+		Owner: Civilians
 	Actor136: bggy
 		Location: 58,35
 		Owner: Nod
@@ -504,7 +504,7 @@ Actors:
 		SubCell: 0
 	Actor154: c2
 		Location: 23,56
-		Owner: Civillians
+		Owner: Civilians
 		SubCell: 0
 	Actor155: e1
 		Location: 55,29
@@ -518,15 +518,15 @@ Actors:
 		SubCell: 3
 	Actor157: c4
 		Location: 24,48
-		Owner: Civillians
+		Owner: Civilians
 		SubCell: 3
 	Actor158: c6
 		Location: 27,55
-		Owner: Civillians
+		Owner: Civilians
 		SubCell: 3
 	Actor159: c9
 		Location: 22,54
-		Owner: Civillians
+		Owner: Civilians
 		Facing: 128
 		SubCell: 1
 	Actor160: e3
@@ -646,38 +646,38 @@ Actors:
 		SubCell: 0
 	TrigHuntFarm1: v06
 		Location: 45,43
-		Owner: Civillians
+		Owner: Civilians
 	TrigRNF1Farm1: v07
 		Location: 31,53
-		Owner: Civillians
+		Owner: Civilians
 	TrigRNF1Farm2: v09
 		Location: 31,50
-		Owner: Civillians
+		Owner: Civilians
 	TrigRNF2Farm1: v08
 		Location: 30,53
-		Owner: Civillians
+		Owner: Civilians
 	TrigRNF2Farm2: v11
 		Location: 29,50
-		Owner: Civillians
+		Owner: Civilians
 	TrigLos2Farm1: v04
 		Location: 25,53
-		Owner: Civillians
+		Owner: Civilians
 	TrigLos2Farm2: v06
 		Location: 24,50
-		Owner: Civillians
+		Owner: Civilians
 	TrigLos2Farm3: v07
 		Location: 19,46
-		Owner: Civillians
+		Owner: Civilians
 	TrigLos2Farm4: v01
 		Location: 18,44
-		Owner: Civillians
+		Owner: Civilians
 	civvie1: c8
 		Location: 26,22
-		Owner: Civillians
+		Owner: Civilians
 		SubCell: 4
 	civvie2: c3
 		Location: 26,22
-		Owner: Civillians
+		Owner: Civilians
 		SubCell: 3
 	CivvieWpts1: waypoint
 		Location: 32,14

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -740,6 +740,6 @@ Actors:
 		Location: 28,47
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/mods/cnc/maps/gdi04c/rules.yaml
+++ b/mods/cnc/maps/gdi04c/rules.yaml
@@ -1,31 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi04c.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: ind
 	MissionData:
@@ -35,15 +10,6 @@ World:
 		StartVideo: nodsweep.vqa
 		WinVideo: burdet1.vqa
 		LossVideo: gameover.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 	SmudgeLayer@SCORCH:
 		InitialSmudges:
 			58,38: sc5,0
@@ -61,103 +27,21 @@ World:
 			23,32: cr1,0
 
 Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
 		DefaultCash: 0
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 
 ^CivInfantry:
 	Health:
 		HP: 125
 
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
 ^Bridge:
 	DamageMultiplier@INVULNERABLE:
 		Modifier: 0
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/gdi04c/rules.yaml
+++ b/mods/cnc/maps/gdi04c/rules.yaml
@@ -33,10 +33,10 @@ Player:
 ^Palettes:
 	IndexedPlayerPalette:
 		PlayerIndex:
-			Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 	IndexedPlayerPalette@units:
 		PlayerIndex:
-			Civillians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 
 ^CivInfantry:
 	Health:

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -754,6 +754,6 @@ Actors:
 		Location: 44,40
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Weapons: weapons.yaml

--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -1,31 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi05a.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: rain
 	MissionData:
@@ -35,12 +10,6 @@ World:
 		StartVideo: seige.vqa
 		WinVideo: nodlose.vqa
 		LossVideo: gdilose.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
 	MapOptions:
 		Difficulties: Easy, Normal, Hard
 		ShortGameLocked: True
@@ -60,74 +29,20 @@ World:
 			11,51: cr1,0
 
 Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
 	EnemyWatcher:
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
 		DefaultCash: 2000
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
 
 ^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
 	AnnounceOnSeen:
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 E2:
 	Buildable:
@@ -154,12 +69,6 @@ HARV:
 		SearchFromOrderRadius: 24
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 LTNK:
 	Buildable:
@@ -168,12 +77,6 @@ LTNK:
 MCV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 MTNK:
 	Buildable:

--- a/mods/cnc/maps/gdi05b/map.yaml
+++ b/mods/cnc/maps/gdi05b/map.yaml
@@ -607,4 +607,4 @@ Actors:
 		Location: 26,37
 		Owner: Nod
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/gdi05b/rules.yaml
+++ b/mods/cnc/maps/gdi05b/rules.yaml
@@ -1,47 +1,8 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	EnemyWatcher:
-	MusicPlaylist:
-		StartingMusic: rain
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 4000
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: gdi05b.lua
+	MusicPlaylist:
+		StartingMusic: rain
 	MissionData:
 		Briefing: A GDI field base is under attack. They have fended off one attack but will not survive another.\n\nMove to the base, repair the structures and then launch a strike force to destroy the Nod base in the area.\n\nDestroy all Nod units and structures.
 		BackgroundVideo: podium.vqa
@@ -49,15 +10,6 @@ World:
 		StartVideo: seige.vqa
 		WinVideo: nodlose.vqa
 		LossVideo: gdilose.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 	SmudgeLayer@SCORCH:
 		InitialSmudges:
 			15,56: sc3,0
@@ -67,61 +19,21 @@ World:
 			24,52: sc1,0
 			39,51: sc4,0
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+Player:
+	EnemyWatcher:
+	PlayerResources:
+		DefaultCash: 4000
 
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			AbandonedBase: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
 
 ^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
 	AnnounceOnSeen:
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 SBAG:
 	Buildable:
@@ -186,12 +98,6 @@ E3:
 HARV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 MTNK:
 	Buildable:
@@ -212,12 +118,6 @@ MSAM:
 MCV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 FTNK:
 	Buildable:

--- a/mods/cnc/maps/gdi06/map.yaml
+++ b/mods/cnc/maps/gdi06/map.yaml
@@ -1016,7 +1016,7 @@ Actors:
 		Owner: GDI
 		Location: 55,61
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
 Sequences: sequences.yaml
 

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -1,29 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 World:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	-CrateSpawner:
 	LuaScript:
 		Scripts: gdi06.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		BackgroundMusic: rain-ambient
 		StartingMusic: rain
@@ -53,84 +30,14 @@ World:
 		StartVideo: nitejump.vqa
 		WinVideo: sabotage.vqa
 		LossVideo: gdilose.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
 	MapOptions:
 		Difficulties: Easy, Normal, Hard
 		ShortGameLocked: True
 		ShortGameEnabled: True
 
 Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
 		DefaultCash: 0
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 FLARE:
 	RevealsShroud:
@@ -181,19 +88,3 @@ E3.sticky:
 		AllowMovement: false
 	RenderSprites:
 		Image: E3
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod01/map.yaml
+++ b/mods/cnc/maps/nod01/map.yaml
@@ -253,4 +253,4 @@ Actors:
 		Location: 24,17
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod01/rules.yaml
+++ b/mods/cnc/maps/nod01/rules.yaml
@@ -1,44 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Villagers: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Villagers: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 0
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
 	LuaScript:
 		Scripts: nod01.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: nomercy
 		VictoryMusic: nod_win1
@@ -47,15 +9,18 @@ World:
 		BackgroundVideo: intro2.vqa
 		BriefingVideo: nod1.vqa
 		LossVideo: nodlose.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
+
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			Villagers: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			Villagers: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+
+Player:
+	PlayerResources:
+		DefaultCash: 0
 
 C10:
 	Tooltip:
@@ -67,85 +32,6 @@ C10:
 
 ^CivBuilding:
 	MustBeDestroyed:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
 
 ^CivInfantry:
 	MustBeDestroyed:
-
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod02a/map.yaml
+++ b/mods/cnc/maps/nod02a/map.yaml
@@ -194,4 +194,4 @@ Actors:
 		Location: 56,38
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod02b/map.yaml
+++ b/mods/cnc/maps/nod02b/map.yaml
@@ -236,4 +236,4 @@ Actors:
 		Location: 30,44
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod02b/rules.yaml
+++ b/mods/cnc/maps/nod02b/rules.yaml
@@ -1,40 +1,4 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 4000
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: nod02b.lua
 	MusicPlaylist:
@@ -46,70 +10,10 @@ World:
 		StartVideo: seige.vqa
 		WinVideo: airstrk.vqa
 		LossVideo: deskill.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+Player:
+	PlayerResources:
+		DefaultCash: 4000
 
 NUK2:
 	Buildable:
@@ -170,12 +74,6 @@ MLRS:
 MCV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 LST:
 	Buildable:
@@ -228,11 +126,3 @@ EYE:
 ATWR:
 	Buildable:
 		Prerequisites: ~disabled
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -430,4 +430,4 @@ Actors:
 		Location: 32,47
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod03a/rules.yaml
+++ b/mods/cnc/maps/nod03a/rules.yaml
@@ -1,42 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 4000
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
 	LuaScript:
 		Scripts: nod03a.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: chrg226m
 		VictoryMusic: nod_win1
@@ -46,80 +10,10 @@ World:
 		StartVideo: dessweep.vqa
 		WinVideo: desflees.vqa
 		LossVideo: flag.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+Player:
+	PlayerResources:
+		DefaultCash: 4000
 
 HQ:
 	AirstrikePower:
@@ -196,19 +90,3 @@ MISS:
 		Name: Prison
 	Capturable:
 		CaptureThreshold: 1
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -474,4 +474,4 @@ Actors:
 		Location: 23,20
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod03b/rules.yaml
+++ b/mods/cnc/maps/nod03b/rules.yaml
@@ -1,42 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 4000
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
 	LuaScript:
 		Scripts: nod03b.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: chrg226m
 		VictoryMusic: nod_win1
@@ -46,80 +10,10 @@ World:
 		StartVideo: dessweep.vqa
 		WinVideo: desflees.vqa
 		LossVideo: flag.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+Player:
+	PlayerResources:
+		DefaultCash: 4000
 
 HQ:
 	AirstrikePower:
@@ -196,19 +90,3 @@ MISS:
 		Name: Prison
 	Capturable:
 		CaptureThreshold: 1
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod04a/map.yaml
+++ b/mods/cnc/maps/nod04a/map.yaml
@@ -534,4 +534,4 @@ Actors:
 		Facing: 160
 		SubCell: 2
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod04a/rules.yaml
+++ b/mods/cnc/maps/nod04a/rules.yaml
@@ -1,45 +1,6 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			NodSupporter: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			NodSupporter: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	EnemyWatcher:
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 0
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
 	LuaScript:
 		Scripts: nod04a.lua
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	MusicPlaylist:
 		StartingMusic: valkyrie
 		VictoryMusic: nod_win1
@@ -48,87 +9,31 @@ World:
 		BriefingVideo: nod4b.vqa
 		StartVideo: retro.vqa
 		LossVideo: deskill.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 	SmudgeLayer@SCORCH:
 		InitialSmudges:
 			37,24: sc6,0
 			36,18: sc6,0
+Player:
+	EnemyWatcher:
+	PlayerResources:
+		DefaultCash: 0
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			NodSupporter: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			NodSupporter: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 
 ^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
 	AnnounceOnSeen:
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
 
 ^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
 	AnnounceOnSeen:
 
 ^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
 	AnnounceOnSeen:
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 NUK2:
 	Buildable:
@@ -189,12 +94,6 @@ MLRS:
 MCV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 LST:
 	Buildable:
@@ -235,11 +134,3 @@ EYE:
 ATWR:
 	Buildable:
 		Prerequisites: ~disabled
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod04b/map.yaml
+++ b/mods/cnc/maps/nod04b/map.yaml
@@ -476,4 +476,4 @@ Actors:
 		Location: 32,22
 		Owner: Neutral
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod04b/rules.yaml
+++ b/mods/cnc/maps/nod04b/rules.yaml
@@ -1,41 +1,4 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	EnemyWatcher:
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 0
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: nod04b.lua
 	MusicPlaylist:
@@ -45,91 +8,20 @@ World:
 		Briefing: A small village friendly to our cause has been increasingly harassed by GDI, and the Brotherhood wishes you to assist them in their efforts.\n\nSeek out the enemy village and destroy it. The event will be disguised as a GDI attack.
 		BriefingVideo: nod4b.vqa
 		LossVideo: nodlose.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
+
+Player:
+	EnemyWatcher:
+	PlayerResources:
+		DefaultCash: 0
 
 ^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
 	AnnounceOnSeen:
-	RenderSprites:
-		PlayerPalette: player-units
 
 ^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
 	AnnounceOnSeen:
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
 
 TRAN:
 	RejectsOrders:
 	-Selectable:
 	RevealsShroud:
 		Range: 5c0
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -373,4 +373,4 @@ Actors:
 		Location: 26,13
 		Owner: GDI
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod05/rules.yaml
+++ b/mods/cnc/maps/nod05/rules.yaml
@@ -1,42 +1,4 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 5000
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: nod05.lua
 	MusicPlaylist:
@@ -49,78 +11,17 @@ World:
 		StartVideo: samsite.vqa
 		WinVideo: insites.vqa
 		LossVideo: flag.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 	SmudgeLayer@CRATER:
 		InitialSmudges:
 			46,48: cr1,0
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^Wall:
-	Tooltip:
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy, Ally, Neutral
-		GenericStancePrefix: false
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 
 NUK2:
 	Buildable:
@@ -169,12 +70,6 @@ MLRS:
 MCV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 LST:
 	Buildable:
@@ -205,12 +100,6 @@ HARV:
 		Prerequisites: ~disabled
 	Harvester:
 		SearchFromOrderRadius: 24
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 FTNK:
 	Buildable:

--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -643,4 +643,4 @@ Actors:
 		Location: 57,32
 		Owner: GDI
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod06a/rules.yaml
+++ b/mods/cnc/maps/nod06a/rules.yaml
@@ -1,41 +1,4 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	EnemyWatcher:
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 0
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: nod06a.lua
 	MusicPlaylist:
@@ -46,86 +9,18 @@ World:
 		BriefingVideo: nod6.vqa
 		StartVideo: sundial.vqa
 		LossVideo: banner.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+Player:
+	EnemyWatcher:
+	PlayerResources:
+		DefaultCash: 0
 
 ^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
 	AnnounceOnSeen:
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
 
 HARV:
 	Harvester:
 		SearchFromProcRadius: 64
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 FLARE:
 	Tooltip:
@@ -133,11 +28,3 @@ FLARE:
 
 TRAN:
 	-Selectable:
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod06b/map.yaml
+++ b/mods/cnc/maps/nod06b/map.yaml
@@ -586,4 +586,4 @@ Actors:
 		Owner: GDI
 		SubCell: 1
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod06b/rules.yaml
+++ b/mods/cnc/maps/nod06b/rules.yaml
@@ -1,42 +1,4 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 0
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: nod06b.lua
 	MusicPlaylist:
@@ -47,75 +9,18 @@ World:
 		BriefingVideo: nod6.vqa
 		StartVideo: sundial.vqa
 		LossVideo: banner.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
+Player:
+	PlayerResources:
+		DefaultCash: 0
 
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
+^Palettes:
+	IndexedPlayerPalette:
+		PlayerIndex:
+			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+	IndexedPlayerPalette@units:
+		PlayerIndex:
+			Civilians: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
 
 FLARE:
 	Tooltip:
@@ -123,19 +28,3 @@ FLARE:
 
 TRAN:
 	-Selectable:
-
-HARV:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV:
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/maps/nod06c/map.yaml
+++ b/mods/cnc/maps/nod06c/map.yaml
@@ -463,4 +463,4 @@ Actors:
 		Location: 20,21
 		Owner: GDI
 
-Rules: rules.yaml
+Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod06c/rules.yaml
+++ b/mods/cnc/maps/nod06c/rules.yaml
@@ -1,40 +1,4 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
-Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogLocked: True
-		FogEnabled: True
-		ExploredMapLocked: True
-		ExploredMapEnabled: False
-	PlayerResources:
-		DefaultCashLocked: True
-		DefaultCash: 4000
-
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: nod06c.lua
 	MusicPlaylist:
@@ -45,15 +9,6 @@ World:
 		BriefingVideo: nod6.vqa
 		StartVideo: sundial.vqa
 		LossVideo: banner.vqa
-	MapCreeps:
-		Locked: True
-		Enabled: False
-	MapBuildRadius:
-		AllyBuildRadiusLocked: True
-		AllyBuildRadiusEnabled: False
-	MapOptions:
-		ShortGameLocked: True
-		ShortGameEnabled: False
 	SmudgeLayer@SCORCH:
 		InitialSmudges:
 			41,40: sc2,0
@@ -68,65 +23,9 @@ World:
 			42,39: cr1,0
 			43,36: cr1,0
 
-^Vehicle:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Infantry:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Helicopter:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^Plane:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Ship:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
-^Building:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CivBuilding:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
-
-^CommonHuskDefaults:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-	RenderSprites:
-		PlayerPalette: player-units
-
-^CivBuildingHusk:
-	Tooltip:
-		GenericVisibility: Enemy, Neutral
-		ShowOwnerRow: false
+Player:
+	PlayerResources:
+		DefaultCash: 4000
 
 ^Bridge:
 	DamageMultiplier@INVULNERABLE:
@@ -195,12 +94,6 @@ MLRS:
 MCV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-MCV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 LST:
 	Buildable:
@@ -233,12 +126,6 @@ E3:
 HARV:
 	Buildable:
 		Prerequisites: ~disabled
-	RenderSprites:
-		PlayerPalette: player
-
-HARV.Husk:
-	RenderSprites:
-		PlayerPalette: player
 
 MTNK:
 	Buildable:

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -1,0 +1,28 @@
+World:
+	-SpawnMPUnits:
+	-MPStartLocations:
+	-CrateSpawner:
+	ObjectivesPanel:
+		PanelName: MISSION_OBJECTIVES
+	MapCreeps:
+		Locked: True
+		Enabled: False
+	MapBuildRadius:
+		AllyBuildRadiusLocked: True
+		AllyBuildRadiusEnabled: False
+	MapOptions:
+		ShortGameLocked: True
+		ShortGameEnabled: False
+
+Player:
+	-ConquestVictoryConditions:
+	MissionObjectives:
+		EarlyGameOver: true
+	Shroud:
+		FogLocked: True
+		FogEnabled: True
+		ExploredMapLocked: True
+		ExploredMapEnabled: False
+	PlayerResources:
+		DefaultCashLocked: True
+		DefaultCash: 5000

--- a/mods/cnc/rules/campaign-palettes.yaml
+++ b/mods/cnc/rules/campaign-palettes.yaml
@@ -1,0 +1,53 @@
+^Palettes:
+	-PlayerColorPalette:
+	IndexedPlayerPalette:
+		BasePalette: terrain
+		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+		PlayerIndex:
+			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
+			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+	IndexedPlayerPalette@units:
+		BasePalette: terrain
+		BaseName: player-units
+		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+		PlayerIndex:
+			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
+			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
+			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
+
+^Vehicle:
+	RenderSprites:
+		PlayerPalette: player-units
+
+^Tank:
+	RenderSprites:
+		PlayerPalette: player-units
+
+^Helicopter:
+	RenderSprites:
+		PlayerPalette: player-units
+
+^Infantry:
+	RenderSprites:
+		PlayerPalette: player-units
+
+^CommonHuskDefaults:
+	RenderSprites:
+		PlayerPalette: player-units
+
+HARV:
+	RenderSprites:
+		PlayerPalette: player
+
+MCV:
+	RenderSprites:
+		PlayerPalette: player
+
+HARV.Husk:
+	RenderSprites:
+		PlayerPalette: player
+
+MCV.Husk:
+	RenderSprites:
+		PlayerPalette: player

--- a/mods/cnc/rules/campaign-tooltips.yaml
+++ b/mods/cnc/rules/campaign-tooltips.yaml
@@ -1,0 +1,59 @@
+
+^Vehicle:
+	Tooltip:
+		GenericVisibility: Enemy
+		ShowOwnerRow: false
+
+^Tank:
+	Tooltip:
+		GenericVisibility: Enemy
+		ShowOwnerRow: false
+
+^Helicopter:
+	Tooltip:
+		GenericVisibility: Enemy
+		ShowOwnerRow: false
+
+^Infantry:
+	Tooltip:
+		GenericVisibility: Enemy
+		ShowOwnerRow: false
+
+^Plane:
+	Tooltip:
+		GenericVisibility: Enemy
+		ShowOwnerRow: false
+
+^Ship:
+	Tooltip:
+		GenericVisibility: Enemy
+		ShowOwnerRow: false
+
+^Building:
+	Tooltip:
+		GenericVisibility: Enemy
+		ShowOwnerRow: false
+
+^Wall:
+	Tooltip:
+		ShowOwnerRow: false
+
+^CivBuilding:
+	Tooltip:
+		GenericVisibility: Enemy, Neutral
+		ShowOwnerRow: false
+
+^CivBuildingHusk:
+	Tooltip:
+		GenericVisibility: Enemy, Neutral
+		ShowOwnerRow: false
+
+^CommonHuskDefaults:
+	Tooltip:
+		GenericVisibility: Enemy, Ally, Neutral
+		GenericStancePrefix: false
+		ShowOwnerRow: false
+
+^DINO:
+	Tooltip:
+		ShowOwnerRow: false


### PR DESCRIPTION
This makes use of the new feature allowing maps to include mod files to remove most of the boilerplate definitions from the cnc campaign.

Also fixes the starting music on gdi05b (was defined on Player instead of World), and fixes the spelling of the civilian player on gdi04c.
