### PR TITLE
Add NamedActorNames to MapGlobal

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -93,6 +93,20 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns a table of all the actors that were specified in the map file.")]
 		public Actor[] NamedActors { get { return sma.Actors.Values.ToArray(); } }
 
+		[Desc("Returns a table of key,value pairs which are name,Actor (where 'Actor' is an actor instance).")]
+		public LuaTable NameToActorKeyValues
+		{
+			get
+			{
+				var ret = Context.CreateTable();
+				foreach (var k in sma.Actors.Keys)
+					using (LuaValue v = sma.Actors[k].ToLuaValue(Context))
+						ret.Add(k, v);
+
+				return ret;
+			}
+		}
+
 		[Desc("Returns the actor that was specified with a given name in " +
 			"the map file (or nil, if the actor is dead or not found).")]
 		public Actor NamedActor(string actorName)


### PR DESCRIPTION
This allows a script author to do something like:

``` lua
    for name, actor in pairs(Map.NameToActorKeyValues) do
        -- do something with `name` and `actor`
    end
```

Real-world example:
I am assigning owners based on the actor's name in yaml (which corresponds to player spawn points).

``` lua
spawn2alpha = { }
spawn2alpha[1] = 'a'
spawn2alpha[2] = 'b'
spawn2alpha[3] = 'c'
spawn2alpha[4] = 'd'

SetupStartingForces = function(player)
    for name, actor in pairs(Map.NameToActorKeyValues) do
        local prefix = name:sub(0, 1):lower()
        if prefix == spawn2alpha[player.Spawn] then
            actor.Owner = player
        end
    end
end
```

Where the `Actors` section of the `map.yaml` contains entries like this:

``` yaml
    a_caoild_1: caoild
        Location: 49,12
        Owner: Neutral
    a_caoild_2: caoild
        Location: 50,15
        Owner: Neutral
    b_caoild_1: caoild
        Location: 85,-45
        Owner: Neutral
    b_caoild_2: caoild
        Location: 83,-42
        Owner: Neutral
    c_caoild_1: caoild
        Owner: Neutral
        Location: 142,-1
    c_caoild_2: caoild
        Owner: Neutral
        Location: 144,2
    d_gapile_1: gapile
        Owner: Neutral
        Location: 102,43
    d_e1_1: e1
        Owner: Neutral
        Location: 81,44
    d_e1_2: e1
        Owner: Neutral
        Location: 100,53
```
