### PR TITLE
Fix D2k deviator not taking effect

### DIFF
--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -151,7 +151,7 @@ DeviatorMissile:
 		HorizontalRateOfTurn: 3
 		Blockable: false
 		Shadow: yes
-		Inaccuracy: 768
+		Inaccuracy: 384
 		Image: MISSILE
 		TrailImage: deviator_trail
 		TrailPalette: deviatorgas
@@ -180,6 +180,6 @@ DeviatorMissile:
 		UsePlayerPalette: true
 		ImpactSounds: EXPLSML1.WAV
 	Warhead@4OwnerChange: ChangeOwner
-		Range: 256
+		Range: 512
 		Duration: 375
 		InvalidTargets: Infantry, Structure


### PR DESCRIPTION
The warhead's scan range was lower than both the missile inaccuracy as well as the Missile CloseEnough value of 298, so it almost never "hit" the target.

Closes #10278.
