### PR TITLE
Strengthen trait ordering rules

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -100,7 +100,7 @@ namespace OpenRA
 			var unresolved = source.Except(resolved);
 
 			var testResolve = new Func<Type, Type, bool>((a, b) => a == b || a.IsAssignableFrom(b));
-			var more = unresolved.Where(u => u.Dependencies.All(d => resolved.Exists(r => testResolve(d, r.Type))));
+			var more = unresolved.Where(u => u.Dependencies.All(d => resolved.Exists(r => testResolve(d, r.Type)) && !unresolved.Any(u1 => testResolve(d, u1.Type))));
 
 			// Re-evaluate the vars above until sorted
 			while (more.Any())
@@ -122,14 +122,14 @@ namespace OpenRA
 					exceptionString += u.Type + ": { " + string.Join(", ", deps) + " }\r\n";
 				}
 
-				throw new Exception(exceptionString);
+				throw new YamlException(exceptionString);
 			}
 
 			constructOrderCache = resolved.Select(r => r.Trait).ToList();
 			return constructOrderCache;
 		}
 
-		static IEnumerable<Type> PrerequisitesOf(ITraitInfo info)
+		public static IEnumerable<Type> PrerequisitesOf(ITraitInfo info)
 		{
 			return info
 				.GetType()

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -77,8 +77,11 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			upgradeManager = self.TraitOrDefault<UpgradeManager>();
+
+			// The upgrade manager exists, but may not have finished being created yet.
+			// We'll defer the upgrades until the end of the tick, at which point it will be ready.
 			if (Cloaked)
-				GrantUpgrades(self);
+				self.World.AddFrameEndTask(_ => GrantUpgrades(self));
 		}
 
 		public bool Cloaked { get { return !IsTraitDisabled && remainingTime <= 0; } }

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeManager.cs
@@ -17,12 +17,18 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to a unit to enable dynamic upgrades by warheads, experience, crates, support powers, etc.")]
-	public class UpgradeManagerInfo : ITraitInfo, Requires<IUpgradableInfo>
+	public class UpgradeManagerInfo : TraitInfo<UpgradeManager>, IRulesetLoaded
 	{
-		public object Create(ActorInitializer init) { return new UpgradeManager(init); }
+		public void RulesetLoaded(Ruleset rules, ActorInfo info)
+		{
+			if (!info.Name.StartsWith("^") && !info.TraitInfos<IUpgradableInfo>().Any())
+				throw new YamlException(
+					"There are no upgrades to be managed for actor '{0}'. You are either missing some upgradeable traits, or this UpgradeManager trait is not required.".F(
+						info.Name));
+		}
 	}
 
-	public class UpgradeManager : ITick
+	public class UpgradeManager : INotifyCreated, ITick
 	{
 		class TimedUpgrade
 		{
@@ -67,20 +73,21 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		readonly List<TimedUpgrade> timedUpgrades = new List<TimedUpgrade>();
-		readonly Lazy<Dictionary<string, UpgradeState>> upgrades;
 		readonly Dictionary<IUpgradable, int> levels = new Dictionary<IUpgradable, int>();
+		Dictionary<string, UpgradeState> upgrades;
 
-		public UpgradeManager(ActorInitializer init)
+		void INotifyCreated.Created(Actor self)
 		{
-			upgrades = Exts.Lazy(() =>
-			{
-				var ret = new Dictionary<string, UpgradeState>();
-				foreach (var up in init.Self.TraitsImplementing<IUpgradable>())
-					foreach (var t in up.UpgradeTypes)
-						ret.GetOrAdd(t).Traits.Add(up);
+			upgrades = new Dictionary<string, UpgradeState>();
+			foreach (var up in self.TraitsImplementing<IUpgradable>())
+				foreach (var t in up.UpgradeTypes)
+					upgrades.GetOrAdd(t).Traits.Add(up);
+		}
 
-				return ret;
-			});
+		void CheckCanManageUpgrades()
+		{
+			if (upgrades == null)
+				throw new InvalidOperationException("Upgrades cannot be managed until the actor has been fully created.");
 		}
 
 		/// <summary>Upgrade level increments are limited to dupesAllowed per source, i.e., if a single
@@ -139,8 +146,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void GrantUpgrade(Actor self, string upgrade, object source)
 		{
+			CheckCanManageUpgrades();
+
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return;
 
 			// Track the upgrade source so that the upgrade can be removed without conflicts
@@ -151,8 +160,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RevokeUpgrade(Actor self, string upgrade, object source)
 		{
+			CheckCanManageUpgrades();
+
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return;
 
 			if (!s.Sources.Remove(source))
@@ -164,14 +175,17 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>Returns true if the actor uses the given upgrade. Does not check the actual level of the upgrade.</summary>
 		public bool AcknowledgesUpgrade(Actor self, string upgrade)
 		{
-			return upgrades.Value.ContainsKey(upgrade);
+			CheckCanManageUpgrades();
+			return upgrades.ContainsKey(upgrade);
 		}
 
 		/// <summary>Returns true only if the actor can accept another level of the upgrade.</summary>
 		public bool AcceptsUpgrade(Actor self, string upgrade)
 		{
+			CheckCanManageUpgrades();
+
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return false;
 
 			return s.Traits.Any(up => up.AcceptsUpgradeLevel(self, upgrade, GetOverallLevel(up) + 1));
@@ -179,8 +193,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RegisterWatcher(string upgrade, Action<int, int> action)
 		{
+			CheckCanManageUpgrades();
+
 			UpgradeState s;
-			if (!upgrades.Value.TryGetValue(upgrade, out s))
+			if (!upgrades.TryGetValue(upgrade, out s))
 				return;
 
 			s.Watchers.Add(action);
@@ -192,6 +208,8 @@ namespace OpenRA.Mods.Common.Traits
 		/// GrantTimedUpgrade).</summary>
 		public void Tick(Actor self)
 		{
+			CheckCanManageUpgrades();
+
 			foreach (var u in timedUpgrades)
 			{
 				u.Tick();
@@ -201,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				u.Sources.RemoveWhere(source => source.Remaining <= 0);
 
-				foreach (var a in upgrades.Value[u.Upgrade].Watchers)
+				foreach (var a in upgrades[u.Upgrade].Watchers)
 					a(u.Duration, u.Remaining);
 			}
 

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -28,20 +28,9 @@ namespace OpenRA.Test
 	class MockEInfo : MockTraitInfo, Requires<MockFInfo> { }
 	class MockFInfo : MockTraitInfo, Requires<MockDInfo> { }
 
-	class MockA2Info : MockTraitInfo { }
-	class MockB2Info : MockTraitInfo { }
-	class MockC2Info : MockTraitInfo { }
-
-	class MockStringInfo : MockTraitInfo { public string AString = null; }
-
 	[TestFixture]
 	public class ActorInfoTest
 	{
-		[SetUp]
-		public void SetUp()
-		{
-		}
-
 		[TestCase(TestName = "Sort traits in order of dependency")]
 		public void TraitsInConstructOrderA()
 		{
@@ -96,21 +85,6 @@ namespace OpenRA.Test
 
 				Assert.That(count, Is.EqualTo(Math.Floor(count)), "Should be symmetrical");
 			}
-		}
-
-		// This needs to match the logic used in RulesetCache.LoadYamlRules
-		ActorInfo CreateActorInfoFromYaml(string name, string mapYaml, params string[] yamls)
-		{
-			var nodes = mapYaml == null ? new List<MiniYamlNode>() : MiniYaml.FromString(mapYaml);
-			var sources = yamls.ToList();
-			if (mapYaml != null)
-				sources.Add(mapYaml);
-
-			var yaml = MiniYaml.Merge(sources.Select(s => MiniYaml.FromString(s)));
-			var allUnits = yaml.ToDictionary(node => node.Key, node => node.Value);
-			var unit = allUnits[name];
-			var creator = new ObjectCreator(typeof(ActorInfoTest).Assembly);
-			return new ActorInfo(creator, name, unit);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #10907.

Currently, if you have multiple dependencies for a trait, as long as one of them is created first then the ordering is satisfied. This means the others might be created after the thing that requires them!

Now, we strengthen the rules to require all of the dependencies to be created up front. This means the dependent can now guarantee all its dependencies are ready, rather than just at least one.

I have adjusted the tests to verify this.

This created some circular dependency chains on `UpgradeManager` in the default mods which I have resolved by doing the trait lookups after the actor is created. Without this RA and D2k fail to load.
