### PR TITLE
Getting rid of float in simulation code Part 2

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
 				return 0;
 
-			var time = (int)(unit.GetBuildTime() * Info.BuildSpeed);
+			var time = unit.GetBuildTime() * Info.BuildSpeed / 100;
 
 			if (info.SpeedUp)
 			{

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -34,8 +34,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Should the prerequisite remain enabled if the owner changes?")]
 		public readonly bool Sticky = true;
 
-		[Desc("This value is used to translate the unit cost into build time.")]
-		public readonly float BuildSpeed = 0.4f;
+		[Desc("This percentage value is multiplied with actor cost to translate into build time (lower means faster).")]
+		public readonly int BuildSpeed = 40;
 
 		[Desc("The build time is multiplied with this value on low power.")]
 		public readonly int LowPowerSlowdown = 3;
@@ -319,8 +319,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
 				return 0;
 
-			var time = unit.GetBuildTime() * Info.BuildSpeed;
-			return (int)time;
+			var time = unit.GetBuildTime() * Info.BuildSpeed / 100;
+			return time;
 		}
 
 		protected void CancelProduction(string itemName, uint numberToCancel)

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool ResetOnHoldLost = true;
 
 		[Desc("Percentage of all strategic points the player has to hold to win.")]
-		public readonly float RatioRequired = 0.5f;
+		public readonly int RatioRequired = 50;
 
 		[Desc("Delay for the end game notification in milliseconds.")]
 		public readonly int NotificationDelay = 1500;
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 		public int Total { get { return AllPoints.Count(); } }
 		int Owned { get { return AllPoints.Count(a => WorldUtils.AreMutualAllies(player, a.Owner)); } }
 
-		public bool Holding { get { return Owned >= info.RatioRequired * Total; } }
+		public bool Holding { get { return Owned >= info.RatioRequired * Total / 100; } }
 
 		public void Tick(Actor self)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -660,6 +660,22 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Migrated StrategicVictoryConditions RatioRequired to use int percentage instead of float
+				if (engineVersion < 20160325)
+				{
+					if (node.Key.StartsWith("StrategicVictoryConditions"))
+					{
+						var ratioNode = node.Value.Nodes.FirstOrDefault(x => x.Key == "RatioRequired");
+						if (ratioNode != null)
+						{
+							// The RatioRequired value is now an int percentage, so multiply the float with 100.
+							var oldValue = FieldLoader.GetValue<float>("RatioRequired", ratioNode.Value.Value);
+							var newValue = (int)(oldValue * 100);
+							ratioNode.Value.Value = newValue.ToString();
+						}
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -644,6 +644,22 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "ReloadDelay";
 				}
 
+				// Migrated ProductionQueue BuildSpeed to use int percentage instead of float
+				if (engineVersion < 20160325)
+				{
+					if (node.Key.StartsWith("ProductionQueue") || node.Key.StartsWith("ClassicProductionQueue"))
+					{
+						var buildSpeedNode = node.Value.Nodes.FirstOrDefault(x => x.Key == "BuildSpeed");
+						if (buildSpeedNode != null)
+						{
+							// The BuildSpeed value is now an int percentage, so multiply the float with 100.
+							var oldValue = FieldLoader.GetValue<float>("BuildSpeed", buildSpeedNode.Value.Value);
+							var newValue = (int)(oldValue * 100);
+							buildSpeedNode.Value.Value = newValue.ToString();
+						}
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -676,6 +676,22 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Migrated Minelayer.MinefieldDepth to use WDist instead of float
+				if (engineVersion < 20160325)
+				{
+					if (node.Key.StartsWith("Minelayer"))
+					{
+						var depthNode = node.Value.Nodes.FirstOrDefault(x => x.Key == "MinefieldDepth");
+						if (depthNode != null)
+						{
+							// The MinefieldDepth value is now a WDist, so multiply the float value with 1024.
+							var oldValue = FieldLoader.GetValue<float>("MinefieldDepth", depthNode.Value.Value);
+							var newValue = (int)(oldValue * 1024);
+							depthNode.Value.Value = newValue.ToString();
+						}
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public readonly string AmmoPoolName = "primary";
 
-		public readonly float MinefieldDepth = 1.5f;
+		public readonly WDist MinefieldDepth = new WDist(1536);
 
 		public object Create(ActorInitializer init) { return new Minelayer(init.Self); }
 	}
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.RA.Traits
 			}
 		}
 
-		static IEnumerable<CPos> GetMinefieldCells(CPos start, CPos end, float depth)
+		static IEnumerable<CPos> GetMinefieldCells(CPos start, CPos end, WDist depth)
 		{
 			var mins = CPos.Min(start, end);
 			var maxs = CPos.Max(start, end);
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.RA.Traits
 
 			for (var i = mins.X; i <= maxs.X; i++)
 				for (var j = mins.Y; j <= maxs.Y; j++)
-					if (Math.Abs(q.X * i + q.Y * j + c) < depth)
+					if (Math.Abs(q.X * i + q.Y * j + c) * 1024 < depth.Length)
 						yield return new CPos(i, j);
 		}
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -25,7 +25,7 @@ FACT:
 		Type: Building.GDI
 		Factions: gdi
 		Group: Building
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 2
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
@@ -33,7 +33,7 @@ FACT:
 		Type: Building.Nod
 		Factions: nod
 		Group: Building
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 2
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
@@ -41,7 +41,7 @@ FACT:
 		Type: Defence.GDI
 		Factions: gdi
 		Group: Defence
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
@@ -49,7 +49,7 @@ FACT:
 		Type: Defence.Nod
 		Factions: nod
 		Group: Defence
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
@@ -260,7 +260,7 @@ PYLE:
 		Type: Infantry.GDI
 		Group: Infantry
 		RequireOwner: false
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 	ProductionBar:
 	Power:
@@ -300,7 +300,7 @@ HAND:
 		Type: Infantry.Nod
 		Group: Infantry
 		RequireOwner: false
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 	ProductionBar:
 	Power:
@@ -344,7 +344,7 @@ AFLD:
 		Type: Vehicle.Nod
 		Group: Vehicle
 		RequireOwner: false
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		ReadyAudio:
 	ProductionBar:
@@ -391,7 +391,7 @@ WEAP:
 		Type: Vehicle.GDI
 		RequireOwner: false
 		Group: Vehicle
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 	ProductionBar:
 	Power:
@@ -428,13 +428,13 @@ HPAD:
 		Type: Aircraft.GDI
 		Factions: gdi
 		Group: Aircraft
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 	ProductionQueue@Nod:
 		Type: Aircraft.Nod
 		Factions: nod
 		Group: Aircraft
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 	ProductionBar@GDI:
 		ProductionType: Aircraft.GDI

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -65,7 +65,7 @@ BIO:
 		Type: Biolab
 		Group: Infantry
 		RequireOwner: false
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 	ProductionBar:
 	RallyPoint:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -3,7 +3,7 @@ Player:
 	TechTree:
 	ClassicProductionQueue@Building:
 		Type: Building
-		BuildSpeed: 1.0
+		BuildSpeed: 100
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: BuildingReady
@@ -11,7 +11,7 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Upgrade:
 		Type: Upgrade
-		BuildSpeed: 1.0
+		BuildSpeed: 100
 		LowPowerSlowdown: 0
 		QueuedAudio: Upgrading
 		ReadyAudio: NewOptions
@@ -19,34 +19,34 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
-		BuildSpeed: 1.0
+		BuildSpeed: 100
 		LowPowerSlowdown: 3
 		BlockedAudio: NoRoom
 		SpeedUp: true
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
-		BuildSpeed: 1.0
+		BuildSpeed: 100
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		BlockedAudio: NoRoom
 		SpeedUp: true
 	ClassicProductionQueue@Armor:
 		Type: Armor
-		BuildSpeed: 1.0
+		BuildSpeed: 100
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		BlockedAudio: NoRoom
 		SpeedUp: true
 	ClassicProductionQueue@Starport:
 		Type: Starport
-		BuildSpeed: 0.85
+		BuildSpeed: 85
 		LowPowerSlowdown: 0
 		BlockedAudio: NoRoom
 		QueuedAudio: OrderPlaced
 		ReadyAudio:
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
-		BuildSpeed: 1.25
+		BuildSpeed: 125
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		BlockedAudio: NoRoom

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -54,7 +54,7 @@ SILO:
 
 Player:
 	ClassicProductionQueue@Building:
-		BuildSpeed: 0.4
+		BuildSpeed: 40
 	Shroud:
 		FogLocked: True
 		FogEnabled: True

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -76,7 +76,7 @@ FORTCRATE:
 
 Player:
 	ClassicProductionQueue@Infantry:
-		BuildSpeed: 1
+		BuildSpeed: 100
 	-EnemyWatcher:
 	Shroud:
 		FogLocked: True

--- a/mods/ra/maps/koth-hopes-anchor/rules.yaml
+++ b/mods/ra/maps/koth-hopes-anchor/rules.yaml
@@ -18,6 +18,5 @@ Player:
 	StrategicVictoryConditions:
 		HoldDuration: 3000
 		ResetOnHoldLost: true
-		RatioRequired: 0.65
-		CriticalRatioRequired: 0.65
+		RatioRequired: 65
 	-ConquestVictoryConditions:

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -11,9 +11,9 @@ World:
 
 Player:
 	ClassicProductionQueue@Infantry:
-		BuildSpeed: 1
+		BuildSpeed: 100
 	ClassicProductionQueue@Vehicle:
-		BuildSpeed: 1
+		BuildSpeed: 100
 	Shroud:
 		FogLocked: True
 		FogEnabled: True

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -3,36 +3,36 @@ Player:
 	TechTree:
 	ClassicProductionQueue@Building:
 		Type: Building
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	ClassicProductionQueue@Ship:
 		Type: Ship
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	PlaceBuilding:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -4,31 +4,31 @@ Player:
 	GlobalUpgradeManager:
 	ClassicProductionQueue@Building:
 		Type: Building
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	ClassicProductionQueue@Air:
 		Type: Air
-		BuildSpeed: .4
+		BuildSpeed: 40
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	PlaceBuilding:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -4,31 +4,31 @@ Player:
 	GlobalUpgradeManager:
 	ClassicProductionQueue@Building:
 		Type: Building
-		BuildSpeed: 40
+		BuildSpeed: 48
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
-		BuildSpeed: 40
+		BuildSpeed: 48
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
-		BuildSpeed: 40
+		BuildSpeed: 48
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
-		BuildSpeed: 40
+		BuildSpeed: 48
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	ClassicProductionQueue@Air:
 		Type: Air
-		BuildSpeed: 40
+		BuildSpeed: 48
 		LowPowerSlowdown: 3
 		SpeedUp: True
 	PlaceBuilding:


### PR DESCRIPTION
Covers the rest of examples listed in #10845 + `ThrowsParticle`.
