### PR TITLE
Add ScriptTags trait

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -736,6 +736,7 @@
     <Compile Include="Traits\World\MapOptions.cs" />
     <Compile Include="Traits\World\MissionData.cs" />
     <Compile Include="UtilityCommands\ExtractMapRules.cs" />
+    <Compile Include="Traits\ScriptTags.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Traits;
@@ -112,6 +113,12 @@ namespace OpenRA.Mods.Common.Scripting
 		public bool IsNamedActor(Actor actor)
 		{
 			return actor.ActorID <= sma.LastMapActorID && actor.ActorID > sma.LastMapActorID - sma.Actors.Count;
+		}
+
+		[Desc("Returns a table of all actors tagged with the given string.")]
+		public Actor[] ActorsWithTag(string tag)
+		{
+			return Context.World.ActorsHavingTrait<ScriptTags>(t => t.HasTag(tag)).ToArray();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -79,12 +79,14 @@ namespace OpenRA.Mods.Common.Scripting
 	{
 		readonly IFacing facing;
 		readonly AutoTarget autotarget;
+		readonly ScriptTags scriptTags;
 
 		public GeneralProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
 			facing = self.TraitOrDefault<IFacing>();
 			autotarget = self.TraitOrDefault<AutoTarget>();
+			scriptTags = self.TraitOrDefault<ScriptTags>();
 		}
 
 		[Desc("The actor position in cell coordinates.")]
@@ -161,6 +163,27 @@ namespace OpenRA.Mods.Common.Scripting
 
 				autotarget.Stance = stance;
 			}
+		}
+
+		[Desc("Specifies whether or not the actor supports 'tags'.")]
+		public bool IsTaggable { get { return scriptTags != null; } }
+
+		[Desc("Add a tag to the actor. Returns true on success, false otherwise (for example the actor may already have the given tag).")]
+		public bool AddTag(string tag)
+		{
+			return IsTaggable && scriptTags.AddTag(tag);
+		}
+
+		[Desc("Remove a tag from the actor. Returns true on success, false otherwise (tag was not present).")]
+		public bool RemoveTag(string tag)
+		{
+			return IsTaggable && scriptTags.RemoveTag(tag);
+		}
+
+		[Desc("Specifies whether or not the actor has a particular tag.")]
+		public bool HasTag(string tag)
+		{
+			return IsTaggable && scriptTags.HasTag(tag);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ScriptTags.cs
+++ b/OpenRA.Mods.Common/Traits/ScriptTags.cs
@@ -1,0 +1,58 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Allows this actor to be 'tagged' with arbitrary strings. Tags must be unique or they will be rejected.")]
+	public class ScriptTagsInfo : UsesInit<ScriptTagsInit>
+	{
+		object ITraitInfo.Create(ActorInitializer init) { return new ScriptTags(init, this); }
+	}
+
+	public class ScriptTags
+	{
+		readonly HashSet<string> tags = new HashSet<string>();
+
+		public ScriptTags(ActorInitializer init, ScriptTagsInfo info)
+		{
+			if (init.Contains<ScriptTagsInit>())
+				foreach (var tag in init.Get<ScriptTagsInit, string[]>())
+					tags.Add(tag);
+		}
+
+		public bool AddTag(string tag)
+		{
+			return tags.Add(tag);
+		}
+
+		public bool RemoveTag(string tag)
+		{
+			return tags.Remove(tag);
+		}
+
+		public bool HasTag(string tag)
+		{
+			return tags.Contains(tag);
+		}
+	}
+
+	/// <summary>Allows mappers to 'tag' actors with arbitrary strings that may have meaning in their scripts.</summary>
+	public class ScriptTagsInit : IActorInit<string[]>
+	{
+		[FieldFromYamlKey] readonly string[] value = new string[0];
+		public ScriptTagsInit() { }
+		public ScriptTagsInit(string[] init) { value = init; }
+		public string[] Value(World world) { return value; }
+	}
+}


### PR DESCRIPTION
This allows actors to be tagged with arbitrary strings.
Also includes `ScriptTagsInit` and `MapGlobal.ActorsWithTag`
  which expose this functionality to map scripters.

I am using this like such:

``` lua
_paradrop_wps = {
    ['a'] = Map.ActorsWithTag('paradrop_a'),
    ['b'] = Map.ActorsWithTag('paradrop_b'),
    ['c'] = Map.ActorsWithTag('paradrop_c'),
    ['d'] = Map.ActorsWithTag('paradrop_d')
}

...

SetupStartingForces = function(player)
    local spawn2alpha = { 'a', 'b', 'c', 'd' }
    for _, actor in ipairs(Map.NamedActors) do
        local tag = 'owner_' .. spawn2alpha[player.Spawn]
        if actor.HasTag(tag) then
            actor.Owner = player
        end
    end
end
```

ref #10956
