### PR TITLE
Support custom SupportDir overrides.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -238,7 +238,7 @@ namespace OpenRA
 		internal static void Initialize(Arguments args)
 		{
 			Console.WriteLine("Platform is {0}", Platform.CurrentPlatform);
-
+			Platform.Initialize(args);
 			InitializeSettings(args);
 
 			Log.AddChannel("perf", "perf.log");

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -63,11 +63,26 @@ namespace OpenRA
 			}
 		}
 
-		public static string SupportDir { get { return supportDir.Value; } }
-		static Lazy<string> supportDir = Exts.Lazy(GetSupportDir);
+		public static string SupportDir { get; private set; }
 
-		static string GetSupportDir()
+		public static void Initialize(Arguments args)
 		{
+			SupportDir = FindSupportDir(args);
+		}
+
+		static string FindSupportDir(Arguments args)
+		{
+			// Check for support directory overrides
+			if (args.Contains("SupportDir"))
+			{
+				var path = args.GetValue("SupportDir", "");
+				var separator = Path.DirectorySeparatorChar.ToString();
+				if (!path.EndsWith(separator))
+					path += separator;
+
+				return path;
+			}
+
 			// Use a local directory in the game root if it exists
 			if (Directory.Exists("Support"))
 				return "Support" + Path.DirectorySeparatorChar;

--- a/OpenRA.Test/OpenRA.Game/PlatformTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PlatformTest.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Test
 		[SetUp]
 		public void SetUp()
 		{
+			Platform.Initialize(Arguments.Empty);
 			supportDir = Platform.SupportDir;
 			gameDir = Platform.GameDir;
 		}

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -53,6 +53,7 @@ namespace OpenRA.Utility
 				return;
 			}
 
+			Platform.Initialize(Arguments.Empty);
 			Game.InitializeSettings(Arguments.Empty);
 			var modData = new ModData(modName);
 			args = args.Skip(1).ToArray();


### PR DESCRIPTION
This adds support for a `SupportDir=FooBar` commandline argument to force a specified support directory.  The main motivation is to simplify testing changes relating to map installation on dedicated servers, but this could also be used by mods that want to manage a self-contained engine distribution that is automatically versioned and upgraded.
