### PR TITLE
Tweak the multiplayer server listing.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -23,6 +23,17 @@ namespace OpenRA
 	public enum MouseScrollType { Disabled, Standard, Inverted, Joystick }
 	public enum StatusBarsType { Standard, DamageShow, AlwaysShow }
 
+	[Flags]
+	public enum MPGameFilters
+	{
+		None = 0,
+		Waiting = 1,
+		Empty = 2,
+		Protected = 4,
+		Started = 8,
+		Incompatible = 16
+	}
+
 	public class ServerSettings
 	{
 		[Desc("Sets the server name.")]
@@ -182,6 +193,8 @@ namespace OpenRA
 
 		public bool FetchNews = true;
 		public string NewsUrl = "http://master.openra.net/gamenews";
+
+		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected;
 	}
 
 	public class KeySettings

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -194,7 +194,7 @@ namespace OpenRA
 		public bool FetchNews = true;
 		public string NewsUrl = "http://master.openra.net/gamenews";
 
-		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected;
+		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected | MPGameFilters.Started;
 	}
 
 	public class KeySettings

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -52,12 +52,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Download currentQuery;
 		Widget serverList;
 
-		bool showWaiting = true;
-		bool showEmpty = true;
-		bool showStarted = false;
-		bool showProtected = true;
-		bool showIncompatible = false;
-
 		public string ProgressLabelText()
 		{
 			switch (searchStatus)
@@ -145,40 +139,48 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			progressText.IsVisible = () => searchStatus != SearchStatus.Hidden;
 			progressText.GetText = ProgressLabelText;
 
+			var gs = Game.Settings.Game;
+			Action<MPGameFilters> toggleFilterFlag = f =>
+			{
+				gs.MPGameFilters ^= f;
+				Game.Settings.Save();
+				RefreshServerList();
+			};
+
 			var filtersPanel = Ui.LoadWidget("MULTIPLAYER_FILTER_PANEL", null, new WidgetArgs());
 			var showWaitingCheckbox = filtersPanel.GetOrNull<CheckboxWidget>("WAITING_FOR_PLAYERS");
 			if (showWaitingCheckbox != null)
 			{
-				showWaitingCheckbox.IsChecked = () => showWaiting;
-				showWaitingCheckbox.OnClick = () => { showWaiting ^= true; RefreshServerList(); };
+				showWaitingCheckbox.IsChecked = () => gs.MPGameFilters.HasFlag(MPGameFilters.Waiting);
+				showWaitingCheckbox.OnClick = () => toggleFilterFlag(MPGameFilters.Waiting);
 			}
 
 			var showEmptyCheckbox = filtersPanel.GetOrNull<CheckboxWidget>("EMPTY");
 			if (showEmptyCheckbox != null)
 			{
-				showEmptyCheckbox.IsChecked = () => showEmpty;
-				showEmptyCheckbox.OnClick = () => { showEmpty ^= true; RefreshServerList(); };
+				showEmptyCheckbox.IsChecked = () => gs.MPGameFilters.HasFlag(MPGameFilters.Empty);
+				showEmptyCheckbox.OnClick = () => toggleFilterFlag(MPGameFilters.Empty);
 			}
 
 			var showAlreadyStartedCheckbox = filtersPanel.GetOrNull<CheckboxWidget>("ALREADY_STARTED");
 			if (showAlreadyStartedCheckbox != null)
 			{
-				showAlreadyStartedCheckbox.IsChecked = () => showStarted;
-				showAlreadyStartedCheckbox.OnClick = () => { showStarted ^= true; RefreshServerList(); };
+				showAlreadyStartedCheckbox.IsChecked = () => gs.MPGameFilters.HasFlag(MPGameFilters.Started);
+				showAlreadyStartedCheckbox.OnClick = () => toggleFilterFlag(MPGameFilters.Started);
 			}
 
 			var showProtectedCheckbox = filtersPanel.GetOrNull<CheckboxWidget>("PASSWORD_PROTECTED");
 			if (showProtectedCheckbox != null)
 			{
-				showProtectedCheckbox.IsChecked = () => showProtected;
-				showProtectedCheckbox.OnClick = () => { showProtected ^= true; RefreshServerList(); };
+				showProtectedCheckbox.IsChecked = () => gs.MPGameFilters.HasFlag(MPGameFilters.Protected);
+				showProtectedCheckbox.OnClick = () => toggleFilterFlag(MPGameFilters.Protected);
 			}
 
 			var showIncompatibleCheckbox = filtersPanel.GetOrNull<CheckboxWidget>("INCOMPATIBLE_VERSION");
 			if (showIncompatibleCheckbox != null)
 			{
-				showIncompatibleCheckbox.IsChecked = () => showIncompatible;
-				showIncompatibleCheckbox.OnClick = () => { showIncompatible ^= true; RefreshServerList(); };
+				showIncompatibleCheckbox.IsChecked = () => gs.MPGameFilters.HasFlag(MPGameFilters.Incompatible);
+				showIncompatibleCheckbox.OnClick = () => toggleFilterFlag(MPGameFilters.Incompatible);
 			}
 
 			var filtersButton = widget.GetOrNull<DropDownButtonWidget>("FILTERS_DROPDOWNBUTTON");
@@ -541,19 +543,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool Filtered(GameServer game)
 		{
-			if (game.State == (int)ServerState.GameStarted && !showStarted)
+			var filters = Game.Settings.Game.MPGameFilters;
+			if (game.State == (int)ServerState.GameStarted && !filters.HasFlag(MPGameFilters.Started))
 				return true;
 
-			if (game.State == (int)ServerState.WaitingPlayers && !showWaiting && game.Players != 0)
+			if (game.State == (int)ServerState.WaitingPlayers && !filters.HasFlag(MPGameFilters.Waiting) && game.Players != 0)
 				return true;
 
-			if (game.Players == 0 && !showEmpty)
+			if (game.Players == 0 && !filters.HasFlag(MPGameFilters.Empty))
 				return true;
 
-			if (!game.IsCompatible && !showIncompatible)
+			if (!game.IsCompatible && !filters.HasFlag(MPGameFilters.Incompatible))
 				return true;
 
-			if (game.Protected && !showProtected)
+			if (game.Protected && !filters.HasFlag(MPGameFilters.Protected))
 				return true;
 
 			return false;

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -360,7 +360,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				header.Get<LabelWidget>("LABEL").GetText = () => headerTitle;
 				rows.Add(header);
 
-				foreach (var loop in modGames.OrderByDescending(g => g.IsJoinable).ThenByDescending(g => g.Players))
+				Func<GameServer, int> listOrder = g =>
+				{
+					// Servers waiting for players are always first
+					if (g.State == (int)ServerState.WaitingPlayers && g.Players > 0)
+						return 0;
+
+					// Then active games
+					if (g.State >= (int)ServerState.GameStarted)
+						return 1;
+
+					// Empty servers are shown at the end because a flood of empty servers
+					// at the top of the game list make the community look dead
+					return 2;
+				};
+
+				foreach (var loop in modGames.OrderBy(listOrder).ThenByDescending(g => g.Players))
 				{
 					var game = loop;
 					if (game == null || Filtered(game))


### PR DESCRIPTION
- Filter options are now persisted.
- Started games are now listed by default, and are listed before empty servers.

Closes #10276 and makes our community look a little less dead for new players who haven't yet discovered the filter options.
