### PR TITLE
Fix paratroopers on heightmapped terrain

### DIFF
--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		Activity LastTick(Actor self)
 		{
-			pos.SetPosition(self, currentPosition - new WVec(0, 0, currentPosition.Z));
+			pos.SetPosition(self, currentPosition);
 
 			if (um != null)
 				foreach (var u in para.ParachuteUpgrade)
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Activities
 			currentPosition -= fallVector;
 
 			// If the unit has landed, this will be the last tick
-			if (currentPosition.Z <= 0)
+			if (self.World.Map.DistanceAboveTerrain(currentPosition).Length <= 0)
 				return LastTick(self);
 
 			pos.SetVisualPosition(self, currentPosition);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -422,7 +422,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var cell = self.World.Map.CellContaining(pos);
 			SetLocation(cell, FromSubCell, cell, FromSubCell);
-			SetVisualPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, pos.Z));
+			SetVisualPosition(self, self.World.Map.CenterOfSubCell(cell, FromSubCell) + new WVec(0, 0, self.World.Map.DistanceAboveTerrain(pos).Length));
 			FinishedMoving(self);
 		}
 


### PR DESCRIPTION
You can't see the effect in the default mods though (only ra2 will show one).
Anyway, all things that use `Mobile.SetPosition`\* seem to still work fine.

\* e.g. DeliverUnit, SwallowActor, Teleport and Cargo (EjectOnDeath there).
