### PR TITLE
Don't render WithSpriteBody if it is disabled

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
+			if (UpgradeMinEnabledLevel > 0)
+				yield break;
+
 			var anim = new Animation(init.World, image);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 


### PR DESCRIPTION
Fixes https://github.com/OpenRA/ra2/pull/167#issuecomment-199066996
