### PR TITLE
Added lint testing to SpawnActorPower effect sprite and palette

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -28,8 +28,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string DeploySound = null;
 
-		public readonly string EffectSequence = null;
-		public readonly string EffectPalette = null;
+		public readonly string EffectImage = null;
+		[SequenceReference("EffectImage")] public readonly string EffectSequence = "idle";
+		[PaletteReference] public readonly string EffectPalette = null;
 
 		public override object Create(ActorInitializer init) { return new SpawnActorPower(init.Self, this); }
 	}
@@ -52,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 					Game.Sound.Play(info.DeploySound, location);
 
 					if (!string.IsNullOrEmpty(info.EffectSequence) && !string.IsNullOrEmpty(info.EffectPalette))
-						w.Add(new SpriteEffect(location, w, info.EffectSequence, "idle", info.EffectPalette));
+						w.Add(new SpriteEffect(location, w, info.EffectImage, info.EffectSequence, info.EffectPalette));
 
 					var actor = w.CreateActor(info.Actor, new TypeDictionary
 					{

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -750,6 +750,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20160402)
+				{
+					// Fix misleading property naming.
+					if (node.Key == "EffectSequence" && parent.Key == "SpawnActorPower")
+						node.Key = "EffectImage";
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -298,7 +298,7 @@ powerproxy.sonarpulse:
 		Actor: sonar
 		LifeTime: 250
 		DeploySound: sonpulse.aud
-		EffectSequence: moveflsh
+		EffectImage: moveflsh
 		EffectPalette: moveflash
 
 powerproxy.paratroopers:


### PR DESCRIPTION
The property namings were also exactly swapped violating our current standards.
