### PR TITLE
Added more support for multiple Mobile

### DIFF
--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		static bool CanUseExit(Actor self, ActorInfo producee, ExitInfo s)
 		{
-			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
+			var mobileInfo = producee.TraitInfos<MobileInfo>().FirstOrDefault(Exts.IsTraitEnabled);
 
 			self.NotifyBlocker(self.Location + s.ExitCell);
 

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -29,9 +29,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
 			var tileSet = world.Map.Rules.TileSet;
-			var movementClasses =
-				world.Map.Rules.Actors.Where(ai => ai.Value.HasTraitInfo<MobileInfo>())
-					.Select(ai => (uint)ai.Value.TraitInfo<MobileInfo>().GetMovementClass(tileSet)).Distinct();
+
+			var movementClasses = world.Map.Rules.Actors.Values.SelectMany(a => a.TraitInfos<MobileInfo>())
+				.Select(m => (uint)m.GetMovementClass(tileSet)).Distinct();
 
 			foreach (var mc in movementClasses)
 				domainIndexes[mc] = new MovementClassDomainIndex(world, mc);


### PR DESCRIPTION
Actor upgrades are in theory a good idea, but they completely fail with simple things like replacing mobile properties. The engine doesn't like multiple `Mobile` on one actor. Fixed it as far as I could. It will now crash later with "Actor has multiple traits of type `OpenRA.Traits.IOccupySpace`", but I am not able to resolve that.
