### PR TITLE
Fix parachutes in non-heightmapped mods.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -56,7 +56,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		Activity LastTick(Actor self)
 		{
-			pos.SetPosition(self, currentPosition);
+			var dat = self.World.Map.DistanceAboveTerrain(currentPosition);
+			pos.SetPosition(self, currentPosition - new WVec(WDist.Zero, WDist.Zero, dat));
 
 			if (um != null)
 				foreach (var u in para.ParachuteUpgrade)


### PR DESCRIPTION
#11015 put the actors at the wrong height, which stops them from being crushable.  This broke crates in RA.
