### PR TITLE
Fix Turreted units not dropping cancelled targets.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -66,6 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			readonly Target target;
 			readonly bool forceAttack;
 			readonly bool onRailsHack;
+			bool hasTicked;
 
 			public AttackActivity(Actor self, Target target, bool allowMove, bool forceAttack)
 			{
@@ -103,7 +104,13 @@ namespace OpenRA.Mods.Common.Traits
 					var maxRange = targetIsMobile ? new WDist(Math.Max(weapon.Weapon.MinRange.Length, modifiedRange.Length - 1024))
 						: modifiedRange;
 
+					// Check that AttackFollow hasn't cancelled the target by modifying attack.Target
+					// Having both this and AttackFollow modify that field is a horrible hack.
+					if (hasTicked && attack.Target.Type == TargetType.Invalid)
+						return NextActivity;
+
 					attack.Target = target;
+					hasTicked = true;
 
 					if (move != null)
 						return ActivityUtils.SequenceActivities(move.MoveFollow(self, target, weapon.Weapon.MinRange, maxRange), this);


### PR DESCRIPTION
Fixes #11027.

I don't see a cleaner way to work around this without doing a major rewrite.
The attack code is so horrible :disappointed: 
