### PR TITLE
Expose the rest of the SupportPowers to lua

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -78,6 +78,7 @@
   <ItemGroup>
     <Compile Include="CncLoadScreen.cs" />
     <Compile Include="Effects\IonCannon.cs" />
+    <Compile Include="Scripting\Properties\IonCannonProperties.cs" />
     <Compile Include="Traits\AttackPopupTurreted.cs" />
     <Compile Include="Traits\Buildings\ProductionAirdrop.cs" />
     <Compile Include="Traits\PoisonedByTiberium.cs" />
@@ -119,6 +120,10 @@
       <ProductName>Windows Installer 3.1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Scripting" />
+    <Folder Include="Scripting\Properties" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/OpenRA.Mods.Cnc/Scripting/Properties/IonCannonProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/IonCannonProperties.cs
@@ -1,0 +1,37 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using Eluant;
+using OpenRA.Mods.Cnc.Traits;
+using OpenRA.Scripting;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Scripting
+{
+	[ScriptPropertyGroup("Support Powers")]
+	public class IonCannonProperties : ScriptActorProperties, Requires<IonCannonPowerInfo>
+	{
+		readonly Actor self;
+		readonly IonCannonPower power;
+
+		public IonCannonProperties(ScriptContext context, Actor self)
+			: base(context, self)
+		{
+			this.self = self;
+			power = self.Trait<IonCannonPower>();
+		}
+
+		[Desc("Activates the IonCannonPower of the actor, launching the ion cannon on the given 'targetLocation'.")]
+		public void IonCannon(CPos targetLocation)
+		{
+			power.ActivateIonCannon(self, targetLocation);
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -57,17 +57,22 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			base.Activate(self, order, manager);
 
+			ActivateIonCannon(self, order.TargetLocation);
+		}
+
+		public void ActivateIonCannon(Actor self, CPos targetLocation)
+		{
 			self.World.AddFrameEndTask(w =>
 			{
-				Game.Sound.Play(Info.LaunchSound, self.World.Map.CenterOfCell(order.TargetLocation));
-				w.Add(new IonCannon(self.Owner, info.WeaponInfo, w, order.TargetLocation, info.Effect, info.EffectPalette, info.WeaponDelay));
+				Game.Sound.Play(Info.LaunchSound, self.World.Map.CenterOfCell(targetLocation));
+				w.Add(new IonCannon(self.Owner, info.WeaponInfo, w, targetLocation, info.Effect, info.EffectPalette, info.WeaponDelay));
 
 				if (info.CameraActor == null)
 					return;
 
 				var camera = w.CreateActor(info.CameraActor, new TypeDictionary
 				{
-					new LocationInit(order.TargetLocation),
+					new LocationInit(targetLocation),
 					new OwnerInit(self.Owner),
 				});
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Lint\LintBuildablePrerequisites.cs" />
     <Compile Include="Lint\LintExts.cs" />
     <Compile Include="LoadScreens\ModChooserLoadScreen.cs" />
+    <Compile Include="Scripting\Properties\NukeProperties.cs" />
     <Compile Include="ShroudExts.cs" />
     <Compile Include="Orders\BeaconOrderGenerator.cs" />
     <Compile Include="Orders\DeployOrderTargeter.cs" />

--- a/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
@@ -1,0 +1,38 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using Eluant;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Scripting;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[ScriptPropertyGroup("Support Powers")]
+	public class NukeProperties : ScriptActorProperties, Requires<NukePowerInfo>
+	{
+		readonly Actor self;
+		readonly NukePower power;
+
+		public NukeProperties(ScriptContext context, Actor self)
+			: base(context, self)
+		{
+			this.self = self;
+			power = self.Trait<NukePower>();
+		}
+
+		[Desc("Activates the NukePower of the actor, launching the nuke on the given 'targetLocation'.",
+			"'beaconOwner' specifies which player owns the beacon display on the target location.")]
+		public void Nuke(CPos targetLocation, Player beaconOwner)
+		{
+			power.ActivateNuke(self, targetLocation, beaconOwner);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	class GrantUpgradePower : SupportPower
 	{
-		GrantUpgradePowerInfo info;
+		readonly GrantUpgradePowerInfo info;
 
 		public GrantUpgradePower(Actor self, GrantUpgradePowerInfo info)
 			: base(self, info)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -92,6 +92,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.Activate(self, order, manager);
 
+			ActivateNuke(self, order.TargetLocation, order.Player);
+		}
+
+		public void ActivateNuke(Actor self, CPos targetLocation, Player beaconOwner)
+		{
 			if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				Game.Sound.Play(Info.LaunchSound);
 			else
@@ -103,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 				wsb.PlayCustomAnimation(self, info.ActivationSequence, () => wsb.CancelCustomAnimation(self));
 			}
 
-			var targetPosition = self.World.Map.CenterOfCell(order.TargetLocation);
+			var targetPosition = self.World.Map.CenterOfCell(targetLocation);
 			var palette = info.IsPlayerPalette ? info.MissilePalette + self.Owner.InternalName : info.MissilePalette;
 			var missile = new NukeLaunch(self.Owner, info.MissileWeapon, info.WeaponInfo, palette, info.MissileUp, info.MissileDown,
 				self.CenterPosition + body.LocalToWorld(info.SpawnOffset),
@@ -117,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var camera = self.World.CreateActor(false, info.CameraActor, new TypeDictionary
 				{
-					new LocationInit(order.TargetLocation),
+					new LocationInit(targetLocation),
 					new OwnerInit(self.Owner),
 				});
 
@@ -131,7 +136,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.DisplayBeacon)
 			{
 				var beacon = new Beacon(
-					order.Player,
+					beaconOwner,
 					targetPosition,
 					Info.BeaconPalettePrefix,
 					Info.BeaconPoster,

--- a/mods/cnc/maps/gdi03/gdi03.lua
+++ b/mods/cnc/maps/gdi03/gdi03.lua
@@ -100,6 +100,14 @@ WorldLoaded = function()
 	Camera.Position = MCVwaypoint.CenterPosition
 
 	Trigger.AfterDelay(DateTime.Seconds(15), AttackPlayer)
+
+	Actor.Create("nuk2", true, { Owner = player, Location = CPos.New(16, 56) })
+	local eye = Actor.Create("eye", true, { Owner = player, Location = CPos.New(20, 56) })
+
+	local targetLoc = CPos.New(20, 30)
+	Actor.Create("camera", true, { Owner = player, Location = targetLoc })
+	Beacon.New(player, Map.CenterOfCell(targetLoc))
+	Trigger.AfterDelay(DateTime.Seconds(6), function() eye.IonCannon(targetLoc) end)
 end
 
 Tick = function()

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -428,4 +428,12 @@ WorldLoaded = function()
 	InitObjectives()
 	InitMission()
 	SetupSoviets()
+	NukePowerTest()
+end
+
+NukePowerTest = function()
+	Actor.Create("apwr", true, { Owner = allies, Location = CPos.New(60, 40) })
+	local nk = Actor.Create("mslo", true, { Owner = allies, Location = CPos.New(60, 42) })
+
+	Trigger.AfterDelay(DateTime.Seconds(2), function() nk.Nuke(CPos.New(60, 60), allies) end)
 end


### PR DESCRIPTION
Exposes the `NukePower` and the `IonCannonPower`.

`Iron Curtain` (`GrantUpgradePower`), `GpsPower`,  `ProduceActorPower` and `SpawnActorPower` can already be done by manually granting upgrades etc., while `AirstrikePower`, `ParatroopersPower` and `ChronoshiftPower` already are exposed.

Fixes #11011.
