### PR TITLE
Remove the OwnerRow on tooltips of flare in the TD campaign

### DIFF
--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -110,6 +110,7 @@ FLARE:
 		Type: CenterPosition
 	Tooltip:
 		Name: Flare
+		ShowOwnerRow: false
 	BodyOrientation:
 		QuantizedFacings: 1
 	AutoSelectionSize:


### PR DESCRIPTION
Fixes the first point of #11034.
