### PR TITLE
Use vertex depths for rendering terrain depth preview.

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -508,6 +508,26 @@ namespace OpenRA
 
 				return InvalidValueAction(value, fieldType, fieldName);
 			}
+			else if (fieldType == typeof(float3))
+			{
+				if (value != null)
+				{
+					var parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+					float x = 0;
+					float y = 0;
+					float z = 0;
+					float.TryParse(parts[0], NumberStyles.Float, NumberFormatInfo.InvariantInfo, out x);
+					float.TryParse(parts[1], NumberStyles.Float, NumberFormatInfo.InvariantInfo, out y);
+
+					// z component is optional for compatibility with older float2 definitions
+					if (parts.Length > 2)
+						float.TryParse(parts[2], NumberStyles.Float, NumberFormatInfo.InvariantInfo, out z);
+
+					return new float3(x, y, z);
+				}
+
+				return InvalidValueAction(value, fieldType, fieldName);
+			}
 			else if (fieldType == typeof(Rectangle))
 			{
 				if (value != null)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -359,6 +359,9 @@ namespace OpenRA
 			ModData.InitializeLoaders(ModData.DefaultFileSystem);
 			Renderer.InitializeFonts(ModData);
 
+			var grid = ModData.Manifest.Contains<MapGrid>() ? ModData.Manifest.Get<MapGrid>() : null;
+			Renderer.InitializeDepthBuffer(grid);
+
 			if (Cursor != null)
 				Cursor.Dispose();
 

--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -95,6 +95,7 @@ namespace OpenRA
 		void SetBool(string name, bool value);
 		void SetVec(string name, float x);
 		void SetVec(string name, float x, float y);
+		void SetVec(string name, float x, float y, float z);
 		void SetVec(string name, float[] vec, int length);
 		void SetTexture(string param, ITexture texture);
 		void SetMatrix(string param, float[] mtx);

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -114,11 +114,17 @@ namespace OpenRA.Graphics
 			shader.SetTexture("Palette", palette);
 		}
 
-		public void SetViewportParams(Size screen, float zoom, int2 scroll)
+		public void SetViewportParams(Size screen, float depthScale, float depthOffset, float zoom, int2 scroll)
 		{
-			shader.SetVec("Scroll", scroll.X, scroll.Y);
-			shader.SetVec("r1", zoom * 2f / screen.Width, -zoom * 2f / screen.Height);
-			shader.SetVec("r2", -1, 1);
+			shader.SetVec("Scroll", scroll.X, scroll.Y, scroll.Y);
+			shader.SetVec("r1",
+				zoom * 2f / screen.Width,
+				-zoom * 2f / screen.Height,
+				-depthScale * zoom / screen.Height);
+			shader.SetVec("r2", -1, 1, 1 - depthOffset);
+
+			// Texture index is sampled as a float, so convert to pixels then scale
+			shader.SetVec("DepthTextureScale", 128 * depthScale * zoom / screen.Height);
 		}
 
 		public void SetDepthPreviewEnabled(bool enabled)

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -68,12 +68,15 @@ namespace OpenRA.Graphics
 
 		public void Update(CPos cell, Sprite sprite)
 		{
-			var pos = sprite == null ? float2.Zero :
+			var xy = sprite == null ? float2.Zero :
 				worldRenderer.ScreenPosition(map.CenterOfCell(cell)) + sprite.Offset - 0.5f * sprite.Size;
-			Update(cell.ToMPos(map.Grid.Type), sprite, pos);
+
+			// TODO: Deal with sprite z offsets
+			var z = worldRenderer.ScreenZPosition(map.CenterOfCell(cell), 0);
+			Update(cell.ToMPos(map.Grid.Type), sprite, new float3(xy.X, xy.Y, z));
 		}
 
-		public void Update(MPos uv, Sprite sprite, float2 pos)
+		public void Update(MPos uv, Sprite sprite, float3 pos)
 		{
 			if (sprite != null)
 			{

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -21,15 +21,15 @@ namespace OpenRA.Graphics
 		static readonly int[] ChannelMasks = { 2, 1, 0, 3 };
 		static readonly float[] ChannelSelect = { 0.2f, 0.4f, 0.6f, 0.8f };
 
-		public static void FastCreateQuad(Vertex[] vertices, float2 o, Sprite r, float paletteTextureIndex, int nv, float2 size)
+		public static void FastCreateQuad(Vertex[] vertices, float3 o, Sprite r, float paletteTextureIndex, int nv, float3 size)
 		{
-			var b = new float2(o.X + size.X, o.Y);
-			var c = new float2(o.X + size.X, o.Y + size.Y);
-			var d = new float2(o.X, o.Y + size.Y);
+			var b = new float3(o.X + size.X, o.Y, o.Z);
+			var c = new float3(o.X + size.X, o.Y + size.Y, o.Z + size.Z);
+			var d = new float3(o.X, o.Y + size.Y, o.Z + size.Z);
 			FastCreateQuad(vertices, o, b, c, d, r, paletteTextureIndex, nv);
 		}
 
-		public static void FastCreateQuad(Vertex[] vertices, float2 a, float2 b, float2 c, float2 d, Sprite r, float paletteTextureIndex, int nv)
+		public static void FastCreateQuad(Vertex[] vertices, float3 a, float3 b, float3 c, float3 d, Sprite r, float paletteTextureIndex, int nv)
 		{
 			var attribC = ChannelSelect[(int)r.Channel];
 			if (r.Sheet.Type == SheetType.DualIndexed)

--- a/OpenRA.Game/Graphics/Vertex.cs
+++ b/OpenRA.Game/Graphics/Vertex.cs
@@ -18,8 +18,8 @@ namespace OpenRA.Graphics
 	{
 		public readonly float X, Y, Z, U, V, P, C;
 
-		public Vertex(float2 xy, float u, float v, float p, float c)
-			: this(xy.X, xy.Y, 0, u, v, p, c) { }
+		public Vertex(float3 xyz, float u, float v, float p, float c)
+			: this(xyz.X, xyz.Y, xyz.Z, u, v, p, c) { }
 
 		public Vertex(float[] xyz, float u, float v, float p, float c)
 			: this(xyz[0], xyz[1], xyz[2], u, v, p, c) { }

--- a/OpenRA.Game/Graphics/Vertex.cs
+++ b/OpenRA.Game/Graphics/Vertex.cs
@@ -21,9 +21,6 @@ namespace OpenRA.Graphics
 		public Vertex(float3 xyz, float u, float v, float p, float c)
 			: this(xyz.X, xyz.Y, xyz.Z, u, v, p, c) { }
 
-		public Vertex(float[] xyz, float u, float v, float p, float c)
-			: this(xyz[0], xyz[1], xyz[2], u, v, p, c) { }
-
 		public Vertex(float x, float y, float z, float u, float v, float p, float c)
 		{
 			X = x; Y = y; Z = z;

--- a/OpenRA.Game/Graphics/VoxelLoader.cs
+++ b/OpenRA.Game/Graphics/VoxelLoader.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Graphics
 			sheetBuilder = CreateSheetBuilder();
 		}
 
-		Vertex[] GenerateSlicePlane(int su, int sv, Func<int, int, VxlElement> first, Func<int, int, VxlElement> second, Func<int, int, float[]> coord)
+		Vertex[] GenerateSlicePlane(int su, int sv, Func<int, int, VxlElement> first, Func<int, int, VxlElement> second, Func<int, int, float3> coord)
 		{
 			var colors = new byte[su * sv];
 			var normals = new byte[su * sv];
@@ -158,21 +158,21 @@ namespace OpenRA.Graphics
 					yield return GenerateSlicePlane(l.Size[1], l.Size[2],
 						(u, v) => get(x, u, v),
 						(u, v) => get(x - 1, u, v),
-						(u, v) => new float[] { x, u, v });
+						(u, v) => new float3(x, u, v));
 
 			for (var y = 0; y <= l.Size[1]; y++)
 				if (yPlanes[y])
 					yield return GenerateSlicePlane(l.Size[0], l.Size[2],
 						(u, v) => get(u, y, v),
 						(u, v) => get(u, y - 1, v),
-						(u, v) => new float[] { u, y, v });
+						(u, v) => new float3(u, y, v));
 
 			for (var z = 0; z <= l.Size[2]; z++)
 				if (zPlanes[z])
 					yield return GenerateSlicePlane(l.Size[0], l.Size[1],
 						(u, v) => get(u, v, z),
 						(u, v) => get(u, v, z - 1),
-						(u, v) => new float[] { u, v, z });
+						(u, v) => new float3(u, v, z));
 		}
 
 		public VoxelRenderData GenerateRenderData(VxlLimb l)

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -28,6 +28,8 @@ namespace OpenRA
 
 		public readonly int MaximumTileSearchRange = 50;
 
+		public readonly bool EnableDepthBuffer = false;
+
 		public readonly WVec[] SubCellOffsets =
 		{
 			new WVec(0, 0, 0),       // full cell - index 0

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -254,6 +254,7 @@
     <Compile Include="Traits\Player\IndexedPlayerPalette.cs" />
     <Compile Include="Traits\ActivityUtils.cs" />
     <Compile Include="FileSystem\ZipFolder.cs" />
+    <Compile Include="Primitives\float3.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Game/Primitives/float3.cs
+++ b/OpenRA.Game/Primitives/float3.cs
@@ -1,0 +1,54 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace OpenRA
+{
+	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Mimic a built-in type alias.")]
+	[StructLayout(LayoutKind.Sequential)]
+	public struct float3
+	{
+		public readonly float X, Y, Z;
+		public float2 XY { get { return new float2(X, Y); } }
+
+		public float3(float x, float y, float z) { X = x; Y = y; Z = z; }
+		public float3(float2 xy, float z) { X = xy.X; Y = xy.Y; Z = z; }
+
+		public static implicit operator float3(int2 src) { return new float3(src.X, src.Y, 0); }
+		public static implicit operator float3(float2 src) { return new float3(src.X, src.Y, 0); }
+
+		public static float3 operator +(float3 a, float3 b) { return new float3(a.X + b.X, a.Y + b.Y, a.Z + b.Z); }
+		public static float3 operator -(float3 a, float3 b) { return new float3(a.X - b.X, a.Y - b.Y, a.Z - b.Z); }
+		public static float3 operator -(float3 a) { return new float3(-a.X, -a.Y, -a.Z); }
+		public static float3 operator *(float3 a, float3 b) { return new float3(a.X * b.X, a.Y * b.Y, a.Z * b.Z); }
+		public static float3 operator *(float a, float3 b) { return new float3(a * b.X, a * b.Y, a * b.Z); }
+		public static float3 operator /(float3 a, float3 b) { return new float3(a.X / b.X, a.Y / b.Y, a.Z / b.Z); }
+		public static float3 operator /(float3 a, float b) { return new float3(a.X / b, a.Y / b, a.Z / b); }
+
+		public static bool operator ==(float3 me, float3 other) { return me.X == other.X && me.Y == other.Y && me.Z == other.Z; }
+		public static bool operator !=(float3 me, float3 other) { return !(me == other); }
+		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
+
+		public override bool Equals(object obj)
+		{
+			var o = obj as float3?;
+			return o != null && o == this;
+		}
+
+		public override string ToString() { return "{0},{1},{2}".F(X, Y, Z); }
+
+		public static readonly float3 Zero = new float3(0, 0, 0);
+	}
+}

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -40,6 +40,9 @@ namespace OpenRA
 
 		SheetBuilder fontSheetBuilder;
 
+		float depthScale;
+		float depthOffset;
+
 		Size? lastResolution;
 		int2? lastScroll;
 		float? lastZoom;
@@ -102,6 +105,20 @@ namespace OpenRA
 			}
 		}
 
+		public void InitializeDepthBuffer(MapGrid mapGrid)
+		{
+			// The depth buffer needs to be initialized with enough range to cover:
+			//  - the height of the screen
+			//  - the z-offset of tiles from MaxTerrainHeight below the bottom of the screen (pushed into view)
+			//  - additional z-offset from actors on top of MaxTerrainHeight terrain
+			//  - a small margin so that tiles rendered partially above the top edge of the screen aren't pushed behind the clip plane
+			// We need an offset of mapGrid.MaximumTerrainHeight * mapGrid.TileSize.Height / 2 to cover the terrain height
+			// and choose to use mapGrid.MaximumTerrainHeight * mapGrid.TileSize.Height / 4 for each of the actor and top-edge cases
+			this.depthScale = mapGrid == null || !mapGrid.EnableDepthBuffer ? 0 :
+				(float)Resolution.Height / (Resolution.Height + mapGrid.TileSize.Height * mapGrid.MaximumTerrainHeight);
+			this.depthOffset = this.depthScale / 2;
+		}
+
 		public void BeginFrame(int2 scroll, float zoom)
 		{
 			Device.Clear();
@@ -115,8 +132,8 @@ namespace OpenRA
 			if (resolutionChanged)
 			{
 				lastResolution = Resolution;
-				RgbaSpriteRenderer.SetViewportParams(Resolution, 1f, int2.Zero);
-				SpriteRenderer.SetViewportParams(Resolution, 1f, int2.Zero);
+				RgbaSpriteRenderer.SetViewportParams(Resolution, 0f, 0f, 1f, int2.Zero);
+				SpriteRenderer.SetViewportParams(Resolution, 0f, 0f, 1f, int2.Zero);
 				RgbaColorRenderer.SetViewportParams(Resolution, 1f, int2.Zero);
 			}
 
@@ -125,8 +142,8 @@ namespace OpenRA
 			{
 				lastScroll = scroll;
 				lastZoom = zoom;
-				WorldRgbaSpriteRenderer.SetViewportParams(Resolution, zoom, scroll);
-				WorldSpriteRenderer.SetViewportParams(Resolution, zoom, scroll);
+				WorldRgbaSpriteRenderer.SetViewportParams(Resolution, depthScale, depthOffset, zoom, scroll);
+				WorldSpriteRenderer.SetViewportParams(Resolution, depthScale, depthOffset, zoom, scroll);
 				WorldVoxelRenderer.SetViewportParams(Resolution, zoom, scroll);
 				WorldRgbaColorRenderer.SetViewportParams(Resolution, zoom, scroll);
 			}

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -215,6 +215,9 @@ namespace OpenRA.Platforms.Default
 		public delegate void Uniform2f(int location, float v0, float v1);
 		public static Uniform2f glUniform2f { get; private set; }
 
+		public delegate void Uniform3f(int location, float v0, float v1, float v2);
+		public static Uniform3f glUniform3f { get; private set; }
+
 		public delegate void Uniform1fv(int location, int count, IntPtr value);
 		public static Uniform1fv glUniform1fv { get; private set; }
 
@@ -395,6 +398,7 @@ namespace OpenRA.Platforms.Default
 				glUniform1i = Bind<Uniform1i>("glUniform1i");
 				glUniform1f = Bind<Uniform1f>("glUniform1f");
 				glUniform2f = Bind<Uniform2f>("glUniform2f");
+				glUniform3f = Bind<Uniform3f>("glUniform3f");
 				glUniform1fv = Bind<Uniform1fv>("glUniform1fv");
 				glUniform2fv = Bind<Uniform2fv>("glUniform2fv");
 				glUniform3fv = Bind<Uniform3fv>("glUniform3fv");

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -189,6 +189,17 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
+		public void SetVec(string name, float x, float y, float z)
+		{
+			VerifyThreadAffinity();
+			OpenGL.glUseProgram(program);
+			OpenGL.CheckGLError();
+			var param = OpenGL.glGetUniformLocation(program, name);
+			OpenGL.CheckGLError();
+			OpenGL.glUniform3f(param, x, y, z);
+			OpenGL.CheckGLError();
+		}
+
 		public void SetVec(string name, float[] vec, int length)
 		{
 			VerifyThreadAffinity();

--- a/glsl/rgba.vert
+++ b/glsl/rgba.vert
@@ -1,5 +1,5 @@
-uniform vec2 Scroll;
-uniform vec2 r1, r2;
+uniform vec3 Scroll;
+uniform vec3 r1, r2;
 
 attribute vec4 aVertexPosition;
 attribute vec4 aVertexTexCoord;
@@ -7,7 +7,6 @@ varying vec4 vTexCoord;
 
 void main()
 {
-	vec2 p = (aVertexPosition.xy - Scroll.xy)*r1 + r2;
-	gl_Position = vec4(p.x,p.y,0,1);
+	gl_Position = vec4((aVertexPosition.xyz - Scroll.xyz) * r1 + r2, 1);
 	vTexCoord = aVertexTexCoord;
 } 

--- a/glsl/shp.frag
+++ b/glsl/shp.frag
@@ -1,6 +1,7 @@
 uniform sampler2D DiffuseTexture, Palette;
 
 uniform bool EnableDepthPreview;
+uniform float DepthTextureScale;
 
 varying vec4 vTexCoord;
 varying vec4 vChannelMask;
@@ -17,9 +18,24 @@ void main()
 		discard;
 
 	if (EnableDepthPreview && length(vDepthMask) > 0.0)
-	{
-		float depth = dot(x, vDepthMask);
-		gl_FragColor = vec4(depth, depth, depth, 1);
+	{		
+		if (abs(DepthTextureScale) > 0.0)
+		{
+			// Preview vertex aware depth
+			float depth = gl_FragCoord.z + DepthTextureScale * dot(x, vDepthMask);
+
+			// Convert to window coords
+			depth = 0.5 * depth + 0.5;
+
+			// Front of the depth buffer is at 0, but we want to render it as bright
+			gl_FragColor = vec4(vec3(1.0 - depth), 1.0);
+		}
+		else
+		{
+			// Preview boring sprite-only depth
+			float depth = dot(x, vDepthMask);
+			gl_FragColor = vec4(depth, depth, depth, 1.0);
+		}
 	}
 	else
 		gl_FragColor = c;

--- a/glsl/shp.vert
+++ b/glsl/shp.vert
@@ -1,5 +1,5 @@
-uniform vec2 Scroll;
-uniform vec2 r1,r2;		// matrix elements
+uniform vec3 Scroll;
+uniform vec3 r1, r2;
 
 attribute vec4 aVertexPosition;
 attribute vec4 aVertexTexCoord;
@@ -36,8 +36,7 @@ vec4 DecodeDepthChannelMask(float x)
 
 void main()
 {
-	vec2 p = (aVertexPosition.xy - Scroll.xy) * r1 + r2;
-	gl_Position = vec4(p.x,p.y,0,1);
+	gl_Position = vec4((aVertexPosition.xyz - Scroll.xyz) * r1 + r2, 1);
 	vTexCoord = aVertexTexCoord;
 	vChannelMask = DecodeChannelMask(aVertexTexCoord.w);
 	vDepthMask = DecodeDepthChannelMask(aVertexTexCoord.w);


### PR DESCRIPTION
This implements the second and one of the most fiddly steps towards #7520.

Initial support for defining 3d positions is added, and `TerrainSpriteLayer` is set up to give each tile a z coordinate evaluated at the center of the tile.  The projection matrix is expanded to transform the raw z coordinates into normalized device coordinates... this was tricky to solve and is the most likely place to find bugs because any vertex mapped outside the range -1...1 it will be discarded, leaving a hole in the map.  Finally, the depth preview is adjusted to combine the vertex depth with the depth sprite to produce the final depth image that is drawn into the color buffer.  It will eventually be written into the depth buffer, but we don't need that yet so it's not included here.

The feature must be explicitly enabled by defining `EnableDepthBuffer` on the MapGrid so it shouldn't affect the classic mods (but this should be tested) or ts once the test commit is dropped.  Because actors etc don't write sensible vertex z coordinates they end up being discarded for most map scroll positions (reason explained above).  My [depthbuffer-part-two](https://github.com/pchote/OpenRA/tree/depthbuffer-part-two) branch prototypes that support, which shows off the almost-proper depth sorting that this pr is working towards.

Things to look out for / be aware of when testing:
- If the projection is wrong then holes will appear in the map, probably at the top or bottom of the screen or where the terrain is very high.
- The depth image should look consistent with the map everywhere (no sudden jumps in shade that aren't explained by the map tiles).
- I've included the test map that I uses for tweaking and debugging the depth transformations.
- Loading the "Town of Karasjok" map into the editor is a good way of getting a feeling for this.  You can enable depth rendering in the editor by starting a skirmish, enabling depth rendering, returning to the shellmap, then starting the editor.

Good luck!
