### PR TITLE
[AI] [TD] Enable Repair Pad build for AI --> needed for MCV replacement 

### DIFF
--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -25,7 +25,7 @@ Player:
 			hpad: 0
 			eye: 1
 			tmpl: 1
-			fix: 0
+			fix: 1
 			silo: 1
 		BuildingFractions:
 			proc: 20%
@@ -146,7 +146,7 @@ Player:
 			hpad: 2
 			eye: 1
 			tmpl: 1
-			fix: 0
+			fix: 1
 			silo: 1
 		BuildingFractions:
 			proc: 17%
@@ -267,7 +267,7 @@ Player:
 			hpad: 2
 			eye: 1
 			tmpl: 1
-			fix: 0
+			fix: 1
 			silo: 1
 		BuildingFractions:
 			proc: 17%


### PR DESCRIPTION
Currently, the AI in TD does not build repair pads (set to 0 in yaml). These are now [since playtest 20160403] required to build MCVs. Ergo the AI is not able to replace destroyed Construction Yards

Issue --> https://github.com/OpenRA/OpenRA/issues/11057
