### PR TITLE
Fix and improve lobby custom rules warning.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -392,7 +392,7 @@ namespace OpenRA.Server
 						SendOrderTo(newConn, "Message", motd);
 				}
 
-				if (Map.Rules != ModData.DefaultRules && !LobbyInfo.IsSinglePlayer)
+				if (!LobbyInfo.IsSinglePlayer && Map.DefinesUnsafeCustomRules)
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
 				if (Settings.DisableSinglePlayer)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -319,6 +319,7 @@ namespace OpenRA.Traits
 	public interface ITraitInfo : ITraitInfoInterface { object Create(ActorInitializer init); }
 
 	public class TraitInfo<T> : ITraitInfo where T : new() { public virtual object Create(ActorInitializer init) { return new T(); } }
+	public interface ILobbyCustomRulesIgnore { }
 
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfoInterface { }

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -398,7 +398,7 @@ namespace OpenRA.Mods.Common.Server
 
 							server.SendMessage("{0} changed the map to {1}.".F(client.Name, server.Map.Title));
 
-							if (server.Map.Rules.Actors != server.ModData.DefaultRules.Actors)
+							if (server.Map.DefinesUnsafeCustomRules)
 								server.SendMessage("This map contains custom rules. Game experience may change.");
 
 							if (server.Settings.DisableSinglePlayer)

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Used for day/night effects.")]
-	class GlobalLightingPaletteEffectInfo : ITraitInfo
+	class GlobalLightingPaletteEffectInfo : ITraitInfo, ILobbyCustomRulesIgnore
 	{
 		[Desc("Do not modify graphics that use any palette in this list.")]
 		public readonly HashSet<string> ExcludePalettes = new HashSet<string> { "cursor", "chrome", "colorpicker", "fog", "shroud", "alpha" };

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Adds a particle-based overlay.")]
-	public class WeatherOverlayInfo : ITraitInfo
+	public class WeatherOverlayInfo : ITraitInfo, ILobbyCustomRulesIgnore
 	{
 		[Desc("Factor for particle density. As higher as more particles will get spawned.")]
 		public readonly float ParticleDensityFactor = 0.0007625f;


### PR DESCRIPTION
Fixes #11068, and improves the check so that maps with custom lighting and/or weather effects don't trigger the warning.
