### PR TITLE
Add depth buffer support for sprites.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -156,7 +156,7 @@ namespace OpenRA
 			using (new PerfTimer("NewWorld"))
 				OrderManager.World = new World(map, OrderManager, type);
 
-			worldRenderer = new WorldRenderer(OrderManager.World);
+			worldRenderer = new WorldRenderer(ModData, OrderManager.World);
 
 			using (new PerfTimer("LoadComplete"))
 				OrderManager.World.LoadComplete(worldRenderer);

--- a/OpenRA.Game/Graphics/IGraphicsDevice.cs
+++ b/OpenRA.Game/Graphics/IGraphicsDevice.cs
@@ -70,6 +70,7 @@ namespace OpenRA
 
 		void EnableDepthBuffer();
 		void DisableDepthBuffer();
+		void ClearDepthBuffer();
 
 		void SetBlendMode(BlendMode mode);
 

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Graphics
 		{
 			// Don't bother allocating empty sprites
 			if (size.Width == 0 || size.Height == 0)
-				return new Sprite(current, Rectangle.Empty, spriteOffset, channel, BlendMode.Alpha);
+				return new Sprite(current, Rectangle.Empty, 0, spriteOffset, channel, BlendMode.Alpha);
 
 			var rect = Allocate(size, spriteOffset);
 			Util.FastCopyIntoChannel(rect, src);
@@ -129,7 +129,7 @@ namespace OpenRA.Graphics
 				p = new Point(0, 0);
 			}
 
-			var rect = new Sprite(current, new Rectangle(p, imageSize), spriteOffset, channel, BlendMode.Alpha);
+			var rect = new Sprite(current, new Rectangle(p, imageSize), 0, spriteOffset, channel, BlendMode.Alpha);
 			p.X += imageSize.Width;
 
 			return rect;

--- a/OpenRA.Game/Graphics/SoftwareCursor.cs
+++ b/OpenRA.Game/Graphics/SoftwareCursor.cs
@@ -81,8 +81,8 @@ namespace OpenRA.Graphics
 			var cursorSize = CursorProvider.CursorViewportZoomed ? 2.0f * cursorSprite.Size : cursorSprite.Size;
 
 			var cursorOffset = CursorProvider.CursorViewportZoomed ?
-				(2 * cursorSequence.Hotspot) + cursorSprite.Size.ToInt2() :
-				cursorSequence.Hotspot + (0.5f * cursorSprite.Size).ToInt2();
+				(2 * cursorSequence.Hotspot) + cursorSprite.Size.XY.ToInt2() :
+				cursorSequence.Hotspot + (0.5f * cursorSprite.Size.XY).ToInt2();
 
 			renderer.SetPalette(palette);
 			renderer.SpriteRenderer.DrawSprite(cursorSprite,

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -20,24 +20,26 @@ namespace OpenRA.Graphics
 		public readonly Sheet Sheet;
 		public readonly BlendMode BlendMode;
 		public readonly TextureChannel Channel;
-		public readonly float2 Size;
-		public readonly float2 Offset;
-		public readonly float2 FractionalOffset;
+		public readonly float ZRamp;
+		public readonly float3 Size;
+		public readonly float3 Offset;
+		public readonly float3 FractionalOffset;
 		public readonly float Top, Left, Bottom, Right;
 
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel)
-			: this(sheet, bounds, float2.Zero, channel) { }
+			: this(sheet, bounds, 0, float2.Zero, channel) { }
 
-		public Sprite(Sheet sheet, Rectangle bounds, float2 offset, TextureChannel channel, BlendMode blendMode = BlendMode.Alpha)
+		public Sprite(Sheet sheet, Rectangle bounds, float zRamp, float3 offset, TextureChannel channel, BlendMode blendMode = BlendMode.Alpha)
 		{
 			Sheet = sheet;
 			Bounds = bounds;
 			Offset = offset;
+			ZRamp = zRamp;
 			Channel = channel;
-			Size = new float2(bounds.Size);
+			Size = new float3(bounds.Size.Width, bounds.Size.Height, bounds.Size.Height * zRamp);
 			BlendMode = blendMode;
-
-			FractionalOffset = offset / Size;
+			FractionalOffset = Size.Z != 0 ? offset / Size :
+				new float3(offset.X / Size.X, offset.Y / Size.Y, 0);
 
 			Left = (float)Math.Min(bounds.Left, bounds.Right) / sheet.Size.Width;
 			Top = (float)Math.Min(bounds.Top, bounds.Bottom) / sheet.Size.Height;

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -49,21 +49,22 @@ namespace OpenRA.Graphics
 		public IRenderable OffsetBy(WVec vec) { return new SpriteRenderable(sprite, pos + vec, offset, zOffset, palette, scale, isDecoration); }
 		public IRenderable AsDecoration() { return new SpriteRenderable(sprite, pos, offset, zOffset, palette, scale, true); }
 
-		float2 ScreenPosition(WorldRenderer wr)
+		float3 ScreenPosition(WorldRenderer wr)
 		{
-			return wr.ScreenPxPosition(pos) + wr.ScreenPxOffset(offset) - (0.5f * scale * sprite.Size).ToInt2();
+			var xy = wr.ScreenPxPosition(pos) + wr.ScreenPxOffset(offset) - (0.5f * scale * sprite.Size.XY).ToInt2();
+			return new float3(xy, wr.ScreenZPosition(pos, 0) - 0.5f * scale * sprite.Size.Z);
 		}
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.WorldSpriteRenderer.DrawSprite(sprite, ScreenPosition(wr), palette, sprite.Size * scale);
+			Game.Renderer.WorldSpriteRenderer.DrawSprite(sprite, ScreenPosition(wr), palette, scale * sprite.Size);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
-			var offset = ScreenPosition(wr) + sprite.Offset;
-			Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset, offset + sprite.Size, 1 / wr.Viewport.Zoom, Color.Red);
+			var offset = ScreenPosition(wr) + sprite.Offset.XY;
+			Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset.XY, (offset + sprite.Size).XY, 1 / wr.Viewport.Zoom, Color.Red);
 		}
 
 		public Rectangle ScreenBounds(WorldRenderer wr)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -59,17 +59,17 @@ namespace OpenRA.Graphics
 			currentSheet = s.Sheet;
 		}
 
-		public void DrawSprite(Sprite s, float2 location, PaletteReference pal)
+		public void DrawSprite(Sprite s, float3 location, PaletteReference pal)
 		{
 			DrawSprite(s, location, pal.TextureIndex, s.Size);
 		}
 
-		public void DrawSprite(Sprite s, float2 location, PaletteReference pal, float2 size)
+		public void DrawSprite(Sprite s, float3 location, PaletteReference pal, float3 size)
 		{
 			DrawSprite(s, location, pal.TextureIndex, size);
 		}
 
-		void DrawSprite(Sprite s, float2 location, float paletteTextureIndex, float2 size)
+		void DrawSprite(Sprite s, float3 location, float paletteTextureIndex, float3 size)
 		{
 			SetRenderStateForSprite(s);
 			Util.FastCreateQuad(vertices, location + s.FractionalOffset * size, s, paletteTextureIndex, nv, size);
@@ -77,17 +77,17 @@ namespace OpenRA.Graphics
 		}
 
 		// For RGBASpriteRenderer, which doesn't use palettes
-		public void DrawSprite(Sprite s, float2 location)
+		public void DrawSprite(Sprite s, float3 location)
 		{
 			DrawSprite(s, location, 0, s.Size);
 		}
 
-		public void DrawSprite(Sprite s, float2 location, float2 size)
+		public void DrawSprite(Sprite s, float3 location, float3 size)
 		{
 			DrawSprite(s, location, 0, size);
 		}
 
-		public void DrawSprite(Sprite s, float2 a, float2 b, float2 c, float2 d)
+		public void DrawSprite(Sprite s, float3 a, float3 b, float3 c, float3 d)
 		{
 			SetRenderStateForSprite(s);
 			Util.FastCreateQuad(vertices, a, b, c, d, s, 0, nv);

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Graphics
 
 				// Ignore the offsets baked into R8 sprites
 				if (tileset.IgnoreTileSpriteOffsets)
-					allSprites = allSprites.Select(s => new Sprite(s.Sheet, s.Bounds, float2.Zero, s.Channel, s.BlendMode));
+					allSprites = allSprites.Select(s => new Sprite(s.Sheet, s.Bounds, s.ZRamp, float2.Zero, s.Channel, s.BlendMode));
 
 				templates.Add(t.Value.Id, new TheaterTemplate(allSprites.ToArray(), variants.First().Count(), t.Value.Images.Length));
 			}

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -48,13 +48,13 @@ namespace OpenRA.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.SpriteRenderer.DrawSprite(sprite, screenPos, palette, sprite.Size * scale);
+			Game.Renderer.SpriteRenderer.DrawSprite(sprite, screenPos, palette, scale * sprite.Size);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
-			var offset = screenPos + sprite.Offset;
-			Game.Renderer.RgbaColorRenderer.DrawRect(offset, offset + sprite.Size, 1, Color.Red);
+			var offset = screenPos + sprite.Offset.XY;
+			Game.Renderer.RgbaColorRenderer.DrawRect(offset, offset + sprite.Size.XY, 1, Color.Red);
 		}
 
 		public Rectangle ScreenBounds(WorldRenderer wr)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -255,6 +255,12 @@ namespace OpenRA
 			Device.DisableDepthBuffer();
 		}
 
+		public void ClearDepthBuffer()
+		{
+			Flush();
+			Device.ClearDepthBuffer();
+		}
+
 		public void GrabWindowMouseFocus()
 		{
 			Device.GrabWindowMouseFocus();

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -79,6 +79,7 @@ namespace OpenRA.Mods.Common.Graphics
 		public int Facings { get; private set; }
 		public int Tick { get; private set; }
 		public int ZOffset { get; private set; }
+		public float ZRamp { get; private set; }
 		public int ShadowStart { get; private set; }
 		public int ShadowZOffset { get; private set; }
 		public int[] Frames { get; private set; }
@@ -119,6 +120,7 @@ namespace OpenRA.Mods.Common.Graphics
 				ShadowStart = LoadField(d, "ShadowStart", -1);
 				ShadowZOffset = LoadField(d, "ShadowZOffset", DefaultShadowSpriteZOffset).Length;
 				ZOffset = LoadField(d, "ZOffset", WDist.Zero).Length;
+				ZRamp = LoadField(d, "ZRamp", 0);
 				Tick = LoadField(d, "Tick", 40);
 				transpose = LoadField(d, "Transpose", false);
 				Frames = LoadField<int[]>(d, "Frames", null);
@@ -139,7 +141,7 @@ namespace OpenRA.Mods.Common.Graphics
 						"{0}: Sequence {1}.{2}: UseClassicFacingFudge is only valid for 32 facings"
 						.F(info.Nodes[0].Location, sequence, animation));
 
-				var offset = LoadField(d, "Offset", float2.Zero);
+				var offset = LoadField(d, "Offset", float3.Zero);
 				var blendMode = LoadField(d, "BlendMode", BlendMode.Alpha);
 
 				MiniYaml combine;
@@ -159,7 +161,7 @@ namespace OpenRA.Mods.Common.Graphics
 						var subSrc = GetSpriteSrc(modData, tileSet, sequence, animation, sub.Key, sd);
 						var subSprites = cache[subSrc].Select(
 							s => new Sprite(s.Sheet,
-								FlipRectangle(s.Bounds, subFlipX, subFlipY),
+								FlipRectangle(s.Bounds, subFlipX, subFlipY), ZRamp,
 								new float2(subFlipX ? -s.Offset.X : s.Offset.X, subFlipY ? -s.Offset.Y : s.Offset.Y) + subOffset + offset,
 								s.Channel, blendMode));
 
@@ -182,7 +184,7 @@ namespace OpenRA.Mods.Common.Graphics
 					var src = GetSpriteSrc(modData, tileSet, sequence, animation, info.Value, d);
 					sprites = cache[src].Select(
 						s => new Sprite(s.Sheet,
-							FlipRectangle(s.Bounds, flipX, flipY),
+							FlipRectangle(s.Bounds, flipX, flipY), ZRamp,
 							new float2(flipX ? -s.Offset.X : s.Offset.X, flipY ? -s.Offset.Y : s.Offset.Y) + offset,
 							s.Channel, blendMode)).ToArray();
 				}

--- a/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 				// Draw sprite rect
 				var offset = pxOrigin + renderProxy.Sprite.Offset - 0.5f * renderProxy.Sprite.Size;
-				Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset, offset + renderProxy.Sprite.Size, iz, Color.Red);
+				Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset.XY, (offset + renderProxy.Sprite.Size).XY, iz, Color.Red);
 
 				// Draw transformed shadow sprite rect
 				var c = Color.Purple;

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -228,7 +228,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return anims.Where(b => b.IsVisible
 				&& b.Animation.Animation.CurrentSequence != null)
-					.Select(a => (a.Animation.Animation.Image.Size * info.Scale).ToInt2())
+					.Select(a => (a.Animation.Animation.Image.Size.XY * info.Scale).ToInt2())
 					.FirstOrDefault();
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 			pipImages.PlayFetchIndex("groups", () => (int)group);
 			pipImages.Tick();
 
-			var pos = basePosition - (0.5f * pipImages.Image.Size).ToInt2() + new int2(9, 5);
+			var pos = basePosition - (0.5f * pipImages.Image.Size.XY).ToInt2() + new int2(9, 5);
 			yield return new UISpriteRenderable(pipImages.Image, self.CenterPosition, pos, 0, pal, 1f);
 		}
 
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 			var pipImages = new Animation(self.World, "pips");
 			pipImages.PlayRepeating(PipStrings[0]);
 
-			var pipSize = pipImages.Image.Size.ToInt2();
+			var pipSize = pipImages.Image.Size.XY.ToInt2();
 			var pipxyBase = basePosition + new int2(1 - pipSize.X / 2, -(3 + pipSize.Y / 2));
 			var pipxyOffset = new int2(0, 0);
 			var pal = wr.Palette(Info.Palette);

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 				return Enumerable.Empty<IRenderable>();
 
 			var bounds = self.VisualBounds;
-			var halfSize = (0.5f * Anim.Image.Size).ToInt2();
+			var halfSize = (0.5f * Anim.Image.Size.XY).ToInt2();
 
 			var boundsOffset = new int2(bounds.Left + bounds.Right, bounds.Top + bounds.Bottom) / 2;
 			var sizeOffset = -halfSize;

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var uv in w.Map.AllCells.MapCoords)
 			{
 				var pos = w.Map.CenterOfCell(uv.ToCPos(map));
-				var screen = wr.ScreenPosition(pos - new WVec(0, 0, pos.Z));
+				var screen = wr.Screen3DPosition(pos - new WVec(0, 0, pos.Z));
 				var variant = (byte)Game.CosmeticRandom.Next(info.ShroudVariants.Length);
 				tileInfos[uv] = new TileInfo(screen, variant);
 			}

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -71,10 +71,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		struct TileInfo
 		{
-			public readonly float2 ScreenPosition;
+			public readonly float3 ScreenPosition;
 			public readonly byte Variant;
 
-			public TileInfo(float2 screenPosition, byte variant)
+			public TileInfo(float3 screenPosition, byte variant)
 			{
 				ScreenPosition = screenPosition;
 				Variant = variant;

--- a/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (sprite != cachedSprite)
 			{
-				offset = 0.5f * (new float2(RenderBounds.Size) - sprite.Size);
+				offset = 0.5f * (new float2(RenderBounds.Size) - sprite.Size.XY);
 				cachedSprite = sprite;
 			}
 

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			// Terrain tiles define their origin at the topleft
 			var s = theater.TileSprite(tile);
-			dirty[cell] = new Sprite(s.Sheet, s.Bounds, float2.Zero, s.Channel, s.BlendMode);
+			dirty[cell] = new Sprite(s.Sheet, s.Bounds, s.ZRamp, float2.Zero, s.Channel, s.BlendMode);
 		}
 
 		public void TickRender(WorldRenderer wr, Actor self)

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -72,6 +72,7 @@ namespace OpenRA.Platforms.Default
 
 		// Depth buffer
 		public const int GL_DEPTH_COMPONENT = 0x1902;
+		public const int GL_LEQUAL = 0x0203;
 
 		// BlendingFactorDest
 		public const int GL_ZERO = 0;
@@ -276,6 +277,9 @@ namespace OpenRA.Platforms.Default
 		public delegate void BlendFunc(int sfactor, int dfactor);
 		public static BlendFunc glBlendFunc { get; private set; }
 
+		public delegate void DepthFunc(int func);
+		public static DepthFunc glDepthFunc { get; private set; }
+
 		public delegate void Scissor(int x, int y, int width, int height);
 		public static Scissor glScissor { get; private set; }
 
@@ -418,6 +422,7 @@ namespace OpenRA.Platforms.Default
 				glDisable = Bind<Disable>("glDisable");
 				glBlendEquation = Bind<BlendEquation>("glBlendEquation");
 				glBlendFunc = Bind<BlendFunc>("glBlendFunc");
+				glDepthFunc = Bind<DepthFunc>("glDepthFunc");
 				glScissor = Bind<Scissor>("glScissor");
 				glPushClientAttrib = Bind<PushClientAttrib>("glPushClientAttrib");
 				glPopClientAttrib = Bind<PopClientAttrib>("glPopClientAttrib");

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -213,7 +213,7 @@ namespace OpenRA.Platforms.Default
 			VerifyThreadAffinity();
 			OpenGL.glClearColor(0, 0, 0, 1);
 			OpenGL.CheckGLError();
-			OpenGL.glClear(OpenGL.GL_COLOR_BUFFER_BIT);
+			OpenGL.glClear(OpenGL.GL_COLOR_BUFFER_BIT | OpenGL.GL_DEPTH_BUFFER_BIT);
 			OpenGL.CheckGLError();
 		}
 
@@ -232,6 +232,13 @@ namespace OpenRA.Platforms.Default
 		{
 			VerifyThreadAffinity();
 			OpenGL.glDisable(OpenGL.GL_DEPTH_TEST);
+			OpenGL.CheckGLError();
+		}
+
+		public void ClearDepthBuffer()
+		{
+			VerifyThreadAffinity();
+			OpenGL.glClear(OpenGL.GL_DEPTH_BUFFER_BIT);
 			OpenGL.CheckGLError();
 		}
 

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -224,6 +224,8 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 			OpenGL.glEnable(OpenGL.GL_DEPTH_TEST);
 			OpenGL.CheckGLError();
+			OpenGL.glDepthFunc(OpenGL.GL_LEQUAL);
+			OpenGL.CheckGLError();
 		}
 
 		public void DisableDepthBuffer()

--- a/glsl/shp.frag
+++ b/glsl/shp.frag
@@ -17,25 +17,20 @@ void main()
 	if (c.a == 0.0)
 		discard;
 
-	if (EnableDepthPreview && length(vDepthMask) > 0.0)
-	{		
-		if (abs(DepthTextureScale) > 0.0)
-		{
-			// Preview vertex aware depth
-			float depth = gl_FragCoord.z + DepthTextureScale * dot(x, vDepthMask);
+	float depth = gl_FragCoord.z;
+	if (length(vDepthMask) > 0.0)
+	{
+		// Preview vertex aware depth
+		depth = depth + DepthTextureScale * dot(x, vDepthMask);
+	}
 
-			// Convert to window coords
-			depth = 0.5 * depth + 0.5;
+	// Convert to window coords
+	gl_FragDepth = 0.5 * depth + 0.5;
 
-			// Front of the depth buffer is at 0, but we want to render it as bright
-			gl_FragColor = vec4(vec3(1.0 - depth), 1.0);
-		}
-		else
-		{
-			// Preview boring sprite-only depth
-			float depth = dot(x, vDepthMask);
-			gl_FragColor = vec4(depth, depth, depth, 1.0);
-		}
+	if (EnableDepthPreview)
+	{
+		// Front of the depth buffer is at 0, but we want to render it as bright
+		gl_FragColor = vec4(vec3(1.0 - gl_FragDepth), 1.0);
 	}
 	else
 		gl_FragColor = c;

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -274,6 +274,7 @@ resources:
 		Length: 12
 		ShadowStart: 12
 		Offset: 0, -12
+		ZRamp: 1
 	tib01: tib01
 	tib02: tib02
 	tib03: tib03
@@ -302,6 +303,7 @@ resources:
 shroud:
 	Defaults:
 		Offset: 0, -1
+		ZRamp: 1
 	shroud:
 		Length: *
 	fog: fog


### PR DESCRIPTION
The next step towards #7520.

This enables the depth buffer properly for mods that define `EnableDepthBuffer` in their mod.yaml, and writes sensible data into the sprite z coordinates.  This fixes most of the "scroll the map and X disappears" issues from #11058 (but not for voxels or color effects), and gives the desired clipping behaviour for sprite based actors behind cliffs.

Large sprite actors (buildings) are partly clipped below the terrain: this is expected, and will be fixed in a future PR that adds support for per-sprite depth maps.  The clip level is not actually ground level because of the way the terrain depth is defined.  That will be fixed in the next PR.  It also disables the old per-sprite depth preview (with `EnableDepthBuffer` disabled), because that is no longer useful and it would be a pain to maintain support for it.

Github has also buggered up the commit order in their preview, as usual.  The "TEST COMMIT" is the head commit, and should be removed before merging.
