### PR TITLE
Add an option to AnnounceOnBuild/AnnounceOnKill to only announce their activity to it's owner.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnBuild.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Voice to use when built/trained.")]
 		[VoiceReference] public readonly string Voice = "Build";
 
+		[Desc("Should the voice be played for the owner alone?")]
+		public readonly bool OnlyToOwner = false;
+
 		public object Create(ActorInitializer init) { return new AnnounceOnBuild(init.Self, this); }
 	}
 
@@ -33,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void BuildingComplete(Actor self)
 		{
+			if (info.OnlyToOwner && self.Owner != self.World.RenderPlayer)
+				return;
+
 			self.PlayVoice(info.Voice);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
@@ -22,6 +22,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Voice to use when killing something.")]
 		[VoiceReference] public readonly string Voice = "Kill";
 
+		[Desc("Should the voice be played for the owner alone?")]
+		public readonly bool OnlyToOwner = false;
+
 		public object Create(ActorInitializer init) { return new AnnounceOnKill(init.Self, this); }
 	}
 
@@ -42,6 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 			// Don't notify suicides
 			if (e.DamageState == DamageState.Dead && damaged != e.Attacker)
 			{
+				if (info.OnlyToOwner && self.Owner != self.World.RenderPlayer)
+					return;
+
 				if (self.World.WorldTick - lastAnnounce > info.Interval * 25)
 					self.PlayVoice(info.Voice);
 


### PR DESCRIPTION
Requested by @ABrandau and SchismNavigator.
