### PR TITLE
Fix ready checkbox in the lobby being unusable after installing a map

### DIFF
--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -355,6 +355,11 @@ namespace OpenRA
 			return true;
 		}
 
+		public void PreloadRules()
+		{
+			var unused = Rules;
+		}
+
 		public void UpdateRemoteSearch(MapStatus status, MiniYaml yaml, Action<MapPreview> parseMetadata = null)
 		{
 			var newData = innerData.Clone();

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -781,7 +781,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			new Task(() =>
 			{
 				// Force map rules to be loaded on this background thread
-				var unused = map.Rules;
+				map.PreloadRules();
 			}).Start();
 		}
 
@@ -799,7 +799,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				new Task(() =>
 				{
 					// Force map rules to be loaded on this background thread
-					var unused = currentMap.Rules;
+					currentMap.PreloadRules();
 					Game.RunAfterTick(() =>
 					{
 						// Map may have changed in the meantime

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
@@ -109,8 +109,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var install = download.GetOrNull<ButtonWidget>("MAP_INSTALL");
 				if (install != null)
 				{
-					install.OnClick = () => lobby.Map.Install(
-						() => orderManager.IssueOrder(Order.Command("state {0}".F(Session.ClientState.NotReady))));
+					install.OnClick = () => lobby.Map.Install(() =>
+					{
+						lobby.Map.PreloadRules();
+						Game.RunAfterTick(() => orderManager.IssueOrder(Order.Command("state {0}".F(Session.ClientState.NotReady))));
+					});
 					install.IsHighlighted = () => installHighlighted;
 				}
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				foreach (var p in allPreviews)
 				{
 					p.GetMinimap();
-					var unused = p.Rules;
+					p.PreloadRules();
 				}
 			}).Start();
 


### PR DESCRIPTION
Fixes #11074.

Cause of the bug was that the `RulesLoaded` flag in the `MapPreview` was false after installing the map, so we needed to trigger loading the rules manually.
