### PR TITLE
Fix submarines not being attackable when surfaced

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -84,7 +84,10 @@ namespace OpenRA.Mods.Common.Traits
 			// The upgrade manager exists, but may not have finished being created yet.
 			// We'll defer the upgrades until the end of the tick, at which point it will be ready.
 			if (Cloaked)
+			{
+				wasCloaked = true;
 				self.World.AddFrameEndTask(_ => GrantUpgrades(self));
+			}
 		}
 
 		public bool Cloaked { get { return !IsTraitDisabled && remainingTime <= 0; } }


### PR DESCRIPTION
This will also fix the issue of all pre-placed subs playing the submerging sound during the start of a map.

Fixes #11046.
