### PR TITLE
Fix "Team colors" affecting (superweapon) countdown timers

### DIFF
--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -54,12 +54,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var time = WidgetUtils.FormatTime(p.RemainingTime, false, timestep);
 				var text = Format.F(p.Info.Description, time);
 				var self = p.Instances[0].Self;
-				var playerColor = self.Owner.Color.RGB;
-
-				if (Game.Settings.Game.UsePlayerStanceColors)
-					playerColor = self.Owner.PlayerStanceColor(self);
-
-				var color = !p.Ready || Game.LocalTick % 50 < 25 ? playerColor : Color.White;
+				var color = !p.Ready || Game.LocalTick % 50 < 25 ? self.Owner.Color.RGB : Color.White;
 
 				return Pair.New(text, color);
 			}).ToArray();


### PR DESCRIPTION
Fixes #11048.

This just drops the entire `PlayerStanceColor` thing from the `SupportPowerTimerWidget`.
If we still want to display some information, we could add some kind of `(Enemy)`/`(Ally)` pre-/suffixes?
