### PR TITLE
Added a new checkbox to settings, where you can turn off the silo war…

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -150,6 +150,7 @@ namespace OpenRA
 		public string Device = null;
 
 		public bool CashTicks = true;
+		public bool SiloWarnings = true;
 		public bool Mute = false;
 	}
 

--- a/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ResourceStorageWarningInfo : ITraitInfo, Requires<PlayerResourcesInfo>
 	{
 		[Desc("Interval, in seconds, at which to check if more storage is needed.")]
-		public readonly int AdviceInterval = 10;
+		public readonly int AdviceInterval = 30;
 
 		[Desc("The percentage threshold above which a warning is played.")]
 		public readonly int Threshold = 80;
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Tick(Actor self)
 		{
-			if (--nextSiloAdviceTime <= 0)
+			if (Game.Settings.Sound.SiloWarnings && --nextSiloAdviceTime <= 0)
 			{
 				var owner = self.Owner;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -310,6 +310,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var ss = Game.Settings.Sound;
 
 			BindCheckboxPref(panel, "CASH_TICKS", ss, "CashTicks");
+			BindCheckboxPref(panel, "SILO_WARNINGS", ss, "SiloWarnings");
 			BindCheckboxPref(panel, "MUTE_SOUND", ss, "Mute");
 
 			BindSliderPref(panel, "SOUND_VOLUME", ss, "SoundVolume");
@@ -363,6 +364,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ss.MusicVolume = dss.MusicVolume;
 				ss.VideoVolume = dss.VideoVolume;
 				ss.CashTicks = dss.CashTicks;
+				ss.SiloWarnings = dss.SiloWarnings;
 				ss.Mute = dss.Mute;
 				ss.Device = dss.Device;
 				ss.Engine = dss.Engine;

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -269,9 +269,16 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Cash Ticks
-						Checkbox@MUTE_SOUND:
+						Checkbox@SILO_WARNINGS:
 							X: 15
 							Y: 70
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Cash Ticks
+						Checkbox@MUTE_SOUND:
+							X: 15
+							Y: 100
 							Width: 200
 							Height: 20
 							Font: Regular

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -277,9 +277,16 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Cash Ticks
-				Checkbox@MUTE_SOUND:
+				Checkbox@SILO_WARNINGS:
 					X: 15
 					Y: 70
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Silo Warnings
+				Checkbox@MUTE_SOUND:
+					X: 15
+					Y: 100
 					Width: 200
 					Height: 20
 					Font: Regular


### PR DESCRIPTION
Added a new checkbox to settings, where you can turn off the silo warnings, also changed the default silo warning time to 30s
Did the following request: #6955
