### PR TITLE
Add hotkeys for moving viewport to map edge

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -209,6 +209,11 @@ namespace OpenRA
 		public Hotkey MapScrollLeft = new Hotkey(Keycode.LEFT, Modifiers.None);
 		public Hotkey MapScrollRight = new Hotkey(Keycode.RIGHT, Modifiers.None);
 
+		public Hotkey MapPushTop = new Hotkey(Keycode.UP, Modifiers.Alt);
+		public Hotkey MapPushBottom = new Hotkey(Keycode.DOWN, Modifiers.Alt);
+		public Hotkey MapPushLeftEdge = new Hotkey(Keycode.LEFT, Modifiers.Alt);
+		public Hotkey MapPushRightEdge = new Hotkey(Keycode.RIGHT, Modifiers.Alt);
+
 		public Hotkey ViewPortBookmarkSaveSlot1 = new Hotkey(Keycode.Q, Modifiers.Ctrl);
 		public Hotkey ViewPortBookmarkSaveSlot2 = new Hotkey(Keycode.W, Modifiers.Ctrl);
 		public Hotkey ViewPortBookmarkSaveSlot3 = new Hotkey(Keycode.E, Modifiers.Ctrl);

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -455,7 +455,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "MapScrollUp", "Map scroll up" },
 					{ "MapScrollDown", "Map scroll down" },
 					{ "MapScrollLeft", "Map scroll left" },
-					{ "MapScrollRight", "Map scroll right" }
+					{ "MapScrollRight", "Map scroll right" },
+
+					{ "MapPushTop", "Map push to top" },
+					{ "MapPushBottom", "Map push to bottom" },
+					{ "MapPushLeftEdge", "Map push to left edge" },
+					{ "MapPushRightEdge", "Map push to right edge" }
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -331,6 +331,29 @@ namespace OpenRA.Mods.Common.Widgets
 				return true;
 			}
 
+			if (key == ks.MapPushTop)
+			{
+				worldRenderer.Viewport.Center(new WPos(worldRenderer.Viewport.CenterPosition.X, 0, 0));
+				return false;
+			}
+
+			if (key == ks.MapPushBottom)
+			{
+				worldRenderer.Viewport.Center(new WPos(worldRenderer.Viewport.CenterPosition.X, worldRenderer.World.Map.ProjectedBottomRight.Y, 0));
+				return false;
+			}
+
+			if (key == ks.MapPushLeftEdge)
+			{
+				worldRenderer.Viewport.Center(new WPos(0, worldRenderer.Viewport.CenterPosition.Y, 0));
+				return false;
+			}
+
+			if (key == ks.MapPushRightEdge)
+			{
+				worldRenderer.Viewport.Center(new WPos(worldRenderer.World.Map.ProjectedBottomRight.X, worldRenderer.Viewport.CenterPosition.Y, 0));
+			}
+
 			if (key == ks.ViewPortBookmarkSaveSlot1)
 			{
 				SaveCurrentPositionToBookmark(0);


### PR DESCRIPTION
Closes #10644 hotkeys added for moving viewport to map edge. Basically you can use ctrl+arrow keys, but in options menu you can modify, anytime you want it.
