### PR TITLE
Add tileset depth metadata support.

### DIFF
--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -59,15 +59,15 @@ namespace OpenRA.Graphics
 			this.allocateSheet = allocateSheet;
 		}
 
-		public Sprite Add(ISpriteFrame frame) { return Add(frame.Data, frame.Size, frame.Offset); }
-		public Sprite Add(byte[] src, Size size) { return Add(src, size, float2.Zero); }
-		public Sprite Add(byte[] src, Size size, float2 spriteOffset)
+		public Sprite Add(ISpriteFrame frame) { return Add(frame.Data, frame.Size, 0, frame.Offset); }
+		public Sprite Add(byte[] src, Size size) { return Add(src, size, 0, float3.Zero); }
+		public Sprite Add(byte[] src, Size size, float zRamp, float3 spriteOffset)
 		{
 			// Don't bother allocating empty sprites
 			if (size.Width == 0 || size.Height == 0)
 				return new Sprite(current, Rectangle.Empty, 0, spriteOffset, channel, BlendMode.Alpha);
 
-			var rect = Allocate(size, spriteOffset);
+			var rect = Allocate(size, zRamp, spriteOffset);
 			Util.FastCopyIntoChannel(rect, src);
 			current.CommitBufferedData();
 			return rect;
@@ -99,8 +99,8 @@ namespace OpenRA.Graphics
 			return (TextureChannel)nextChannel;
 		}
 
-		public Sprite Allocate(Size imageSize) { return Allocate(imageSize, float2.Zero); }
-		public Sprite Allocate(Size imageSize, float2 spriteOffset)
+		public Sprite Allocate(Size imageSize) { return Allocate(imageSize, 0, float3.Zero); }
+		public Sprite Allocate(Size imageSize, float zRamp, float3 spriteOffset)
 		{
 			if (imageSize.Width + p.X > current.Size.Width)
 			{
@@ -128,7 +128,7 @@ namespace OpenRA.Graphics
 				p = new Point(0, 0);
 			}
 
-			var rect = new Sprite(current, new Rectangle(p, imageSize), 0, spriteOffset, channel, BlendMode.Alpha);
+			var rect = new Sprite(current, new Rectangle(p, imageSize), zRamp, spriteOffset, channel, BlendMode.Alpha);
 			p.X += imageSize.Width;
 
 			return rect;

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -68,12 +68,10 @@ namespace OpenRA.Graphics
 
 		public void Update(CPos cell, Sprite sprite)
 		{
-			var xy = sprite == null ? float2.Zero :
-				worldRenderer.ScreenPosition(map.CenterOfCell(cell)) + sprite.Offset - 0.5f * sprite.Size;
+			var xyz = sprite == null ? float3.Zero :
+				worldRenderer.Screen3DPosition(map.CenterOfCell(cell)) + sprite.Offset - 0.5f * sprite.Size;
 
-			// TODO: Deal with sprite z offsets
-			var z = worldRenderer.ScreenZPosition(map.CenterOfCell(cell), 0);
-			Update(cell.ToMPos(map.Grid.Type), sprite, new float3(xy.X, xy.Y, z));
+			Update(cell.ToMPos(map.Grid.Type), sprite, xyz);
 		}
 
 		public void Update(MPos uv, Sprite sprite, float3 pos)

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -69,12 +69,18 @@ namespace OpenRA.Graphics
 					variants.Add(indices.Select(j =>
 					{
 						var f = allFrames[j];
-						var s = sheetBuilder.Allocate(f.Size, f.Offset);
+						var tile = t.Value.Contains(j) ? t.Value[j] : null;
+
+						// The internal z axis is inverted from expectation (negative is closer)
+						var zOffset = tile != null ? -tile.ZOffset : 0;
+						var zRamp = tile != null ? tile.ZRamp : 1f;
+						var offset = new float3(f.Offset, zOffset);
+						var s = sheetBuilder.Allocate(f.Size, zRamp, offset);
 						Util.FastCopyIntoChannel(s, f.Data);
 
 						if (tileset.EnableDepth)
 						{
-							var ss = sheetBuilder.Allocate(f.Size, f.Offset);
+							var ss = sheetBuilder.Allocate(f.Size, zRamp, offset);
 							Util.FastCopyIntoChannel(ss, allFrames[j + frameCount].Data);
 
 							// s and ss are guaranteed to use the same sheet
@@ -90,7 +96,7 @@ namespace OpenRA.Graphics
 
 				// Ignore the offsets baked into R8 sprites
 				if (tileset.IgnoreTileSpriteOffsets)
-					allSprites = allSprites.Select(s => new Sprite(s.Sheet, s.Bounds, s.ZRamp, float2.Zero, s.Channel, s.BlendMode));
+					allSprites = allSprites.Select(s => new Sprite(s.Sheet, s.Bounds, s.ZRamp, new float3(float2.Zero, s.Offset.Z), s.Channel, s.BlendMode));
 
 				templates.Add(t.Value.Id, new TheaterTemplate(allSprites.ToArray(), variants.First().Count(), t.Value.Images.Length));
 			}

--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -161,8 +161,8 @@ namespace OpenRA.Graphics
 			CalculateSpriteGeometry(tl, br, 1, out spriteSize, out spriteOffset);
 			CalculateSpriteGeometry(stl, sbr, 2, out shadowSpriteSize, out shadowSpriteOffset);
 
-			var sprite = sheetBuilder.Allocate(spriteSize, spriteOffset);
-			var shadowSprite = sheetBuilder.Allocate(shadowSpriteSize, shadowSpriteOffset);
+			var sprite = sheetBuilder.Allocate(spriteSize, 0, spriteOffset);
+			var shadowSprite = sheetBuilder.Allocate(shadowSpriteSize, 0, shadowSpriteOffset);
 			var sb = sprite.Bounds;
 			var ssb = shadowSprite.Bounds;
 			var spriteCenter = new float2(sb.Left + sb.Width / 2, sb.Top + sb.Height / 2);

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -27,6 +27,9 @@ namespace OpenRA
 		public readonly Color LeftColor;
 		public readonly Color RightColor;
 
+		public readonly float ZOffset = 0.0f;
+		public readonly float ZRamp = 1.0f;
+
 		public MiniYaml Save(TileSet tileSet)
 		{
 			var root = new List<MiniYamlNode>();
@@ -41,6 +44,12 @@ namespace OpenRA
 
 			if (RightColor != tileSet.TerrainInfo[TerrainType].Color)
 				root.Add(FieldSaver.SaveField(this, "RightColor"));
+
+			if (ZOffset != 0.0f)
+				root.Add(FieldSaver.SaveField(this, "ZOffset"));
+
+			if (ZRamp != 1.0f)
+				root.Add(FieldSaver.SaveField(this, "ZRamp"));
 
 			return new MiniYaml(tileSet.TerrainInfo[TerrainType].Type, root);
 		}

--- a/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.TS/UtilityCommands/LegacyTilesetImporter.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.TS.UtilityCommands
 
 			var file = new IniFile(File.Open(args[1], FileMode.Open));
 			var extension = args[2];
+			var tileSize = modData.Manifest.Get<MapGrid>().TileSize;
 
 			var templateIndex = 0;
 
@@ -125,6 +126,8 @@ namespace OpenRA.Mods.TS.UtilityCommands
 
 								Console.WriteLine("\t\t\t\tLeftColor: {0:X2}{1:X2}{2:X2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
 								Console.WriteLine("\t\t\t\tRightColor: {0:X2}{1:X2}{2:X2}", s.ReadUInt8(), s.ReadUInt8(), s.ReadUInt8());
+								Console.WriteLine("\t\t\t\tZOffset: {0}", -tileSize.Height / 2.0f);
+								Console.WriteLine("\t\t\t\tZRamp: 0");
 							}
 						}
 					}

--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -80,6 +80,8 @@ Templates:
 			0: Clear
 				LeftColor: C0DBF2
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 	Template@1:
 		Category: Misc Buildings
 		Id: 1
@@ -89,6 +91,8 @@ Templates:
 			0: Rough
 				LeftColor: 76818C
 				RightColor: 5F686E
+				ZOffset: -12
+				ZRamp: 0
 	Template@2:
 		Category: Misc Buildings
 		Id: 2
@@ -98,15 +102,23 @@ Templates:
 			0: Rough
 				LeftColor: 7C8387
 				RightColor: 778087
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 6B7278
 				RightColor: 7D8C99
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 95A4AF
 				RightColor: 707880
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 8C9DAB
 				RightColor: 899BAA
+				ZOffset: -12
+				ZRamp: 0
 	Template@3:
 		Category: Misc Buildings
 		Id: 3
@@ -116,30 +128,48 @@ Templates:
 			0: Cliff
 				LeftColor: 627077
 				RightColor: 6C787E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 4E5558
 				RightColor: 5B666E
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: B1C9E3
 				RightColor: C0DBF2
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 757D83
 				RightColor: 747F85
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6A7175
 				RightColor: 545C66
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: B9D4F0
 				RightColor: B8D3EF
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: BCD7F1
 				RightColor: B7CEE3
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: B7CCE1
 				RightColor: A3B6CA
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: B8D0E9
 				RightColor: B5CFEC
+				ZOffset: -12
+				ZRamp: 0
 	Template@4:
 		Category: Clear
 		Id: 4
@@ -149,6 +179,8 @@ Templates:
 			0: Clear
 				LeftColor: B9D5F0
 				RightColor: B5D1EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@5:
 		Category: Clear
 		Id: 5
@@ -158,6 +190,8 @@ Templates:
 			0: Clear
 				LeftColor: BCD7F1
 				RightColor: C0DBF2
+				ZOffset: -12
+				ZRamp: 0
 	Template@6:
 		Category: Clear
 		Id: 6
@@ -167,6 +201,8 @@ Templates:
 			0: Clear
 				LeftColor: BBD6F1
 				RightColor: BCD8F1
+				ZOffset: -12
+				ZRamp: 0
 	Template@7:
 		Category: Clear
 		Id: 7
@@ -176,6 +212,8 @@ Templates:
 			0: Clear
 				LeftColor: C0DBF2
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 	Template@8:
 		Category: Cliff Pieces
 		Id: 8
@@ -185,6 +223,8 @@ Templates:
 			0: Rough
 				LeftColor: C0DBF2
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 	Template@9:
 		Category: Cliff Pieces
 		Id: 9
@@ -194,6 +234,8 @@ Templates:
 			0: Rough
 				LeftColor: C0DBF2
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 	Template@10:
 		Category: Ice Flow
 		Id: 10
@@ -203,111 +245,183 @@ Templates:
 			2: Rough
 				LeftColor: 7F858C
 				RightColor: 9DADBC
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 848B92
 				RightColor: A8BCCC
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 929CA7
 				RightColor: 8B959E
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: ADBFCD
 				RightColor: 98A8B5
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 9CAAB6
 				RightColor: A8B7C8
+				ZOffset: -12
+				ZRamp: 0
 			18: Rough
 				LeftColor: BCD2E5
 				RightColor: B6CBDC
+				ZOffset: -12
+				ZRamp: 0
 			19: Rough
 				LeftColor: 72787F
 				RightColor: 9CABB9
+				ZOffset: -12
+				ZRamp: 0
 			20: Rough
 				LeftColor: AABAC8
 				RightColor: 929AA3
+				ZOffset: -12
+				ZRamp: 0
 			21: Rough
 				LeftColor: 9FAEBD
 				RightColor: 818B96
+				ZOffset: -12
+				ZRamp: 0
 			22: Rough
 				LeftColor: 9FACBA
 				RightColor: ABBCCC
+				ZOffset: -12
+				ZRamp: 0
 			23: Rough
 				LeftColor: A6B9C9
 				RightColor: B9CEE2
+				ZOffset: -12
+				ZRamp: 0
 			24: Rough
 				LeftColor: 949FA9
 				RightColor: B4C8DB
+				ZOffset: -12
+				ZRamp: 0
 			25: Rough
 				LeftColor: 909CA7
 				RightColor: B4CEEA
+				ZOffset: -12
+				ZRamp: 0
 			26: Rough
 				LeftColor: A0AEBD
 				RightColor: B7CDE2
+				ZOffset: -12
+				ZRamp: 0
 			28: Rough
 				LeftColor: B5C9DD
 				RightColor: 8D97A1
+				ZOffset: -12
+				ZRamp: 0
 			29: Rough
 				LeftColor: ABBCCB
 				RightColor: A2B0C0
+				ZOffset: -12
+				ZRamp: 0
 			30: Rough
 				LeftColor: 80878E
 				RightColor: 929BA3
+				ZOffset: -12
+				ZRamp: 0
 			31: Rough
 				LeftColor: A7B6C2
 				RightColor: A8B9C7
+				ZOffset: -12
+				ZRamp: 0
 			32: Rough
 				LeftColor: B1C4D3
 				RightColor: A9BACA
+				ZOffset: -12
+				ZRamp: 0
 			33: Rough
 				LeftColor: 9AA6B1
 				RightColor: 9EA9B4
+				ZOffset: -12
+				ZRamp: 0
 			34: Rough
 				LeftColor: A1B0BE
 				RightColor: 919BA6
+				ZOffset: -12
+				ZRamp: 0
 			35: Rough
 				LeftColor: 98A2AE
 				RightColor: B0C3D4
+				ZOffset: -12
+				ZRamp: 0
 			38: Rough
 				LeftColor: 94A0AD
 				RightColor: 9FACB8
+				ZOffset: -12
+				ZRamp: 0
 			39: Rough
 				LeftColor: 9EADBD
 				RightColor: 98A3AE
+				ZOffset: -12
+				ZRamp: 0
 			40: Rough
 				LeftColor: 9BA6B2
 				RightColor: A6B6C3
+				ZOffset: -12
+				ZRamp: 0
 			41: Rough
 				LeftColor: 9CAAB6
 				RightColor: B5C6D4
+				ZOffset: -12
+				ZRamp: 0
 			42: Rough
 				LeftColor: B5CBDE
 				RightColor: BDD7EE
+				ZOffset: -12
+				ZRamp: 0
 			43: Rough
 				LeftColor: BBD3E9
 				RightColor: B2C8DE
+				ZOffset: -12
+				ZRamp: 0
 			44: Rough
 				LeftColor: 9FAEC0
 				RightColor: AEC0D0
+				ZOffset: -12
+				ZRamp: 0
 			49: Rough
 				LeftColor: A9BACA
 				RightColor: A3B5C7
+				ZOffset: -12
+				ZRamp: 0
 			50: Rough
 				LeftColor: B1C2D1
 				RightColor: A2ADB8
+				ZOffset: -12
+				ZRamp: 0
 			51: Rough
 				LeftColor: 98A3AF
 				RightColor: 9FADB8
+				ZOffset: -12
+				ZRamp: 0
 			52: Rough
 				LeftColor: A0ACB5
 				RightColor: A4B2BE
+				ZOffset: -12
+				ZRamp: 0
 			53: Rough
 				LeftColor: AABCCD
 				RightColor: 97A3AD
+				ZOffset: -12
+				ZRamp: 0
 			60: Rough
 				LeftColor: B6CBDF
 				RightColor: 9BA7B2
+				ZOffset: -12
+				ZRamp: 0
 			61: Rough
 				LeftColor: 9CACBE
 				RightColor: A1B0C0
+				ZOffset: -12
+				ZRamp: 0
 	Template@11:
 		Category: House
 		Id: 11
@@ -317,15 +431,23 @@ Templates:
 			0: Cliff
 				LeftColor: 8B8268
 				RightColor: 726D61
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 9EA1A5
 				RightColor: 7C7B7B
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: B6B9B6
 				RightColor: 948F7A
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B8BAB6
 				RightColor: 9DA0A5
+				ZOffset: -12
+				ZRamp: 0
 	Template@12:
 		Category: Blank
 		Id: 12
@@ -335,6 +457,8 @@ Templates:
 			0: Rough
 				LeftColor: 282828
 				RightColor: 282828
+				ZOffset: -12
+				ZRamp: 0
 	Template@40:
 		Category: Ice Ramps
 		Id: 40
@@ -345,6 +469,8 @@ Templates:
 				RampType: 1
 				LeftColor: D2E5F0
 				RightColor: CFE3EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@41:
 		Category: Ice Ramps
 		Id: 41
@@ -355,6 +481,8 @@ Templates:
 				RampType: 2
 				LeftColor: A0B8DD
 				RightColor: 9EB9DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@42:
 		Category: Ice Ramps
 		Id: 42
@@ -365,6 +493,8 @@ Templates:
 				RampType: 3
 				LeftColor: AAC5E3
 				RightColor: A2BDDD
+				ZOffset: -12
+				ZRamp: 0
 	Template@43:
 		Category: Ice Ramps
 		Id: 43
@@ -375,6 +505,8 @@ Templates:
 				RampType: 4
 				LeftColor: D6E8F2
 				RightColor: D1E3EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@44:
 		Category: Ice Ramps
 		Id: 44
@@ -385,6 +517,8 @@ Templates:
 				RampType: 5
 				LeftColor: C2DDF2
 				RightColor: ADC8EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@45:
 		Category: Ice Ramps
 		Id: 45
@@ -395,6 +529,8 @@ Templates:
 				RampType: 6
 				LeftColor: 96B2D8
 				RightColor: B6D0EC
+				ZOffset: -12
+				ZRamp: 0
 	Template@46:
 		Category: Ice Ramps
 		Id: 46
@@ -405,6 +541,8 @@ Templates:
 				RampType: 7
 				LeftColor: C7DEF0
 				RightColor: C1D9EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@47:
 		Category: Ice Ramps
 		Id: 47
@@ -415,6 +553,8 @@ Templates:
 				RampType: 8
 				LeftColor: C3DBEF
 				RightColor: DEEBF3
+				ZOffset: -12
+				ZRamp: 0
 	Template@48:
 		Category: Ice Ramps
 		Id: 48
@@ -425,6 +565,8 @@ Templates:
 				RampType: 9
 				LeftColor: BED9F0
 				RightColor: BFD9F0
+				ZOffset: -12
+				ZRamp: 0
 	Template@49:
 		Category: Ice Ramps
 		Id: 49
@@ -435,6 +577,8 @@ Templates:
 				RampType: 10
 				LeftColor: B8D3ED
 				RightColor: 91A9D0
+				ZOffset: -12
+				ZRamp: 0
 	Template@50:
 		Category: Ice Ramps
 		Id: 50
@@ -445,6 +589,8 @@ Templates:
 				RampType: 11
 				LeftColor: BFD8ED
 				RightColor: C4DCED
+				ZOffset: -12
+				ZRamp: 0
 	Template@51:
 		Category: Ice Ramps
 		Id: 51
@@ -455,6 +601,8 @@ Templates:
 				RampType: 12
 				LeftColor: DDEBF3
 				RightColor: BED9F2
+				ZOffset: -12
+				ZRamp: 0
 	Template@52:
 		Category: Ice Ramps
 		Id: 52
@@ -465,6 +613,8 @@ Templates:
 				RampType: 13
 				LeftColor: B0CCEC
 				RightColor: B0CCEC
+				ZOffset: -12
+				ZRamp: 0
 	Template@53:
 		Category: Ice Ramps
 		Id: 53
@@ -475,6 +625,8 @@ Templates:
 				RampType: 14
 				LeftColor: 9BB5D8
 				RightColor: 91A9D0
+				ZOffset: -12
+				ZRamp: 0
 	Template@54:
 		Category: Ice Ramps
 		Id: 54
@@ -485,6 +637,8 @@ Templates:
 				RampType: 15
 				LeftColor: C5DDEE
 				RightColor: C0D8EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@55:
 		Category: Ice Ramps
 		Id: 55
@@ -495,6 +649,8 @@ Templates:
 				RampType: 16
 				LeftColor: DDEBF3
 				RightColor: DEEBF3
+				ZOffset: -12
+				ZRamp: 0
 	Template@56:
 		Category: Ice Ramps
 		Id: 56
@@ -505,6 +661,8 @@ Templates:
 				RampType: 17
 				LeftColor: 9AB5D9
 				RightColor: DBE9F2
+				ZOffset: -12
+				ZRamp: 0
 	Template@57:
 		Category: Ice Ramps
 		Id: 57
@@ -515,6 +673,8 @@ Templates:
 				RampType: 18
 				LeftColor: D6E5F1
 				RightColor: 98B1D6
+				ZOffset: -12
+				ZRamp: 0
 	Template@58:
 		Category: Ice Ramps
 		Id: 58
@@ -525,6 +685,8 @@ Templates:
 				RampType: 17
 				LeftColor: 9AB5D9
 				RightColor: DBE9F2
+				ZOffset: -12
+				ZRamp: 0
 	Template@59:
 		Category: Ice Ramps
 		Id: 59
@@ -535,6 +697,8 @@ Templates:
 				RampType: 18
 				LeftColor: D6E5F1
 				RightColor: 98B1D6
+				ZOffset: -12
+				ZRamp: 0
 	Template@60:
 		Category: Cliff Set
 		Id: 60
@@ -545,16 +709,24 @@ Templates:
 				Height: 4
 				LeftColor: 6E808E
 				RightColor: 8393A0
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 9CB7CD
 				RightColor: 96ACBF
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 5A6C7A
 				RightColor: 7B8D9B
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B6CFE4
 				RightColor: 9DB4C8
+				ZOffset: -12
+				ZRamp: 0
 	Template@61:
 		Category: Cliff Set
 		Id: 61
@@ -565,9 +737,13 @@ Templates:
 				Height: 4
 				LeftColor: 8090A0
 				RightColor: 8B9FB2
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 9EB6D1
 				RightColor: 93ABC2
+				ZOffset: -12
+				ZRamp: 0
 	Template@62:
 		Category: Cliff Set
 		Id: 62
@@ -578,16 +754,24 @@ Templates:
 				Height: 4
 				LeftColor: 78899A
 				RightColor: 879AA9
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: B3C8DF
 				RightColor: 94A9C0
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 798795
 				RightColor: 7D8D9B
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C0DBF2
 				RightColor: 98AEC4
+				ZOffset: -12
+				ZRamp: 0
 	Template@63:
 		Category: Cliff Set
 		Id: 63
@@ -598,16 +782,24 @@ Templates:
 				Height: 4
 				LeftColor: 8798A6
 				RightColor: 8EA1B0
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: BBD3E6
 				RightColor: A9BECE
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 8B99A7
 				RightColor: 8698A8
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C0DBF2
 				RightColor: B3CBDF
+				ZOffset: -12
+				ZRamp: 0
 	Template@64:
 		Category: Cliff Set
 		Id: 64
@@ -618,16 +810,24 @@ Templates:
 				Height: 4
 				LeftColor: 7D8D9D
 				RightColor: 8296A8
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 7D8C9E
 				RightColor: 879CB1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: BAD5F0
 				RightColor: AAC0D5
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B6D0E9
 				RightColor: A9BED2
+				ZOffset: -12
+				ZRamp: 0
 	Template@65:
 		Category: Cliff Set
 		Id: 65
@@ -638,16 +838,24 @@ Templates:
 				Height: 4
 				LeftColor: 617487
 				RightColor: 8494A5
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 647586
 				RightColor: 7E91A3
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: BAD4ED
 				RightColor: 9EB4C7
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B4CDE6
 				RightColor: 97AEC4
+				ZOffset: -12
+				ZRamp: 0
 	Template@66:
 		Category: Cliff Set
 		Id: 66
@@ -658,16 +866,24 @@ Templates:
 				Height: 4
 				LeftColor: 8295A7
 				RightColor: 8D9EAF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 889AAA
 				RightColor: 8B9FB0
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: B9D4EF
 				RightColor: 91A8BB
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B3CDE4
 				RightColor: A6BACB
+				ZOffset: -12
+				ZRamp: 0
 	Template@67:
 		Category: Cliff Set
 		Id: 67
@@ -678,9 +894,13 @@ Templates:
 				Height: 4
 				LeftColor: 728497
 				RightColor: 8095A7
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: ACC4DB
 				RightColor: 8BA4BA
+				ZOffset: -12
+				ZRamp: 0
 	Template@68:
 		Category: Cliff Set
 		Id: 68
@@ -691,12 +911,18 @@ Templates:
 				Height: 4
 				LeftColor: 90A4B6
 				RightColor: 92A6B6
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 9AAEBE
 				RightColor: 99ADC0
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: A4B8CC
 				RightColor: A4B9CE
+				ZOffset: -12
+				ZRamp: 0
 	Template@69:
 		Category: Cliff Set
 		Id: 69
@@ -707,12 +933,18 @@ Templates:
 				Height: 4
 				LeftColor: 889BAF
 				RightColor: 889BAC
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: A1BCD5
 				RightColor: 9CB3CA
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 83A0BC
 				RightColor: 93ADCC
+				ZOffset: -12
+				ZRamp: 0
 	Template@70:
 		Category: Cliff Set
 		Id: 70
@@ -723,12 +955,18 @@ Templates:
 				Height: 4
 				LeftColor: 8CA1B4
 				RightColor: 8DA2B5
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 98B0C3
 				RightColor: 8FA9C4
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 8FA8C0
 				RightColor: A8C0D4
+				ZOffset: -12
+				ZRamp: 0
 	Template@71:
 		Category: Cliff Set
 		Id: 71
@@ -738,6 +976,8 @@ Templates:
 			0: Cliff
 				LeftColor: B2C6DB
 				RightColor: A3B9CE
+				ZOffset: -12
+				ZRamp: 0
 	Template@72:
 		Category: Cliff Set
 		Id: 72
@@ -747,6 +987,8 @@ Templates:
 			0: Cliff
 				LeftColor: 94ACC4
 				RightColor: A6BDD2
+				ZOffset: -12
+				ZRamp: 0
 	Template@73:
 		Category: Cliff Set
 		Id: 73
@@ -756,6 +998,8 @@ Templates:
 			0: Cliff
 				LeftColor: A8BED1
 				RightColor: 83A0B5
+				ZOffset: -12
+				ZRamp: 0
 	Template@74:
 		Category: Cliff Set
 		Id: 74
@@ -766,16 +1010,24 @@ Templates:
 				Height: 4
 				LeftColor: 879BAE
 				RightColor: 7B8D9D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 86A3C1
 				RightColor: 7997AE
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 899EB0
 				RightColor: 7F909F
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B0CAE5
 				RightColor: 819EB5
+				ZOffset: -12
+				ZRamp: 0
 	Template@75:
 		Category: Cliff Set
 		Id: 75
@@ -786,16 +1038,24 @@ Templates:
 				Height: 4
 				LeftColor: 778998
 				RightColor: 758692
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 98B2C7
 				RightColor: 7795AA
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8296A9
 				RightColor: 768898
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: AAC2DC
 				RightColor: 83A1BA
+				ZOffset: -12
+				ZRamp: 0
 	Template@76:
 		Category: Cliff Set
 		Id: 76
@@ -806,16 +1066,24 @@ Templates:
 				Height: 4
 				LeftColor: 7E92A4
 				RightColor: 7D8FA0
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 93AAC0
 				RightColor: 829CB4
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8BA0B4
 				RightColor: 708395
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 9AB1C5
 				RightColor: 7991A6
+				ZOffset: -12
+				ZRamp: 0
 	Template@77:
 		Category: Cliff Set
 		Id: 77
@@ -826,9 +1094,13 @@ Templates:
 				Height: 4
 				LeftColor: 8395A7
 				RightColor: 7B8D9E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 97B2CB
 				RightColor: 859EB1
+				ZOffset: -12
+				ZRamp: 0
 	Template@78:
 		Category: Cliff Set
 		Id: 78
@@ -839,16 +1111,24 @@ Templates:
 				Height: 4
 				LeftColor: 8A9EAF
 				RightColor: 8395A6
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 657E90
 				RightColor: 7F9AAE
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 889BAD
 				RightColor: 596C78
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: ADC6DE
 				RightColor: 8EA9C3
+				ZOffset: -12
+				ZRamp: 0
 	Template@79:
 		Category: Cliff Set
 		Id: 79
@@ -859,16 +1139,24 @@ Templates:
 				Height: 4
 				LeftColor: 8CA0B4
 				RightColor: 8699AB
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 768E9F
 				RightColor: 849EB0
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 8A9FB2
 				RightColor: 5B6F7D
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B4CEE5
 				RightColor: 9CB7D0
+				ZOffset: -12
+				ZRamp: 0
 	Template@80:
 		Category: Cliff Set
 		Id: 80
@@ -879,16 +1167,24 @@ Templates:
 				Height: 4
 				LeftColor: 8090A0
 				RightColor: 7F8C98
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 8399AD
 				RightColor: 94AABD
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 8DA0B2
 				RightColor: 778594
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: AABFD2
 				RightColor: A4BBD1
+				ZOffset: -12
+				ZRamp: 0
 	Template@81:
 		Category: Cliff Set
 		Id: 81
@@ -899,9 +1195,13 @@ Templates:
 				Height: 4
 				LeftColor: 879BAC
 				RightColor: 788794
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 90A8BC
 				RightColor: 88A0B4
+				ZOffset: -12
+				ZRamp: 0
 	Template@82:
 		Category: Cliff Set
 		Id: 82
@@ -912,10 +1212,14 @@ Templates:
 				Height: 4
 				LeftColor: 879BAE
 				RightColor: 7C8E9F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 8598A8
 				RightColor: 738394
+				ZOffset: -12
+				ZRamp: 0
 	Template@83:
 		Category: Cliff Set
 		Id: 83
@@ -926,10 +1230,14 @@ Templates:
 				Height: 4
 				LeftColor: 8999A8
 				RightColor: 707F8F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 8A9BAC
 				RightColor: 8393A3
+				ZOffset: -12
+				ZRamp: 0
 	Template@84:
 		Category: Cliff Set
 		Id: 84
@@ -940,10 +1248,14 @@ Templates:
 				Height: 4
 				LeftColor: 8A9EAF
 				RightColor: 758896
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 647581
 				RightColor: 5A7080
+				ZOffset: -12
+				ZRamp: 0
 	Template@85:
 		Category: Cliff Set
 		Id: 85
@@ -954,6 +1266,8 @@ Templates:
 				Height: 4
 				LeftColor: 8393A6
 				RightColor: 738295
+				ZOffset: -12
+				ZRamp: 0
 	Template@86:
 		Category: Cliff Set
 		Id: 86
@@ -964,14 +1278,20 @@ Templates:
 				Height: 4
 				LeftColor: 7B8B9D
 				RightColor: 78879B
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 879CB0
 				RightColor: 8295A9
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 78879D
 				RightColor: 90A3B4
+				ZOffset: -12
+				ZRamp: 0
 	Template@87:
 		Category: Cliff Set
 		Id: 87
@@ -982,14 +1302,20 @@ Templates:
 				Height: 4
 				LeftColor: 768A9C
 				RightColor: 708495
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 7E92A4
 				RightColor: 798B9B
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 8798A8
 				RightColor: 74879A
+				ZOffset: -12
+				ZRamp: 0
 	Template@88:
 		Category: Cliff Set
 		Id: 88
@@ -1000,6 +1326,8 @@ Templates:
 				Height: 4
 				LeftColor: 7D8C9E
 				RightColor: 8597A9
+				ZOffset: -12
+				ZRamp: 0
 	Template@89:
 		Category: Cliff Set
 		Id: 89
@@ -1010,6 +1338,8 @@ Templates:
 				Height: 4
 				LeftColor: 8495A4
 				RightColor: 738293
+				ZOffset: -12
+				ZRamp: 0
 	Template@90:
 		Category: Cliff Set
 		Id: 90
@@ -1020,14 +1350,20 @@ Templates:
 				Height: 4
 				LeftColor: 778696
 				RightColor: 758596
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 808FA0
 				RightColor: 7F8FA1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8293A4
 				RightColor: 798A9B
+				ZOffset: -12
+				ZRamp: 0
 	Template@91:
 		Category: Cliff Set
 		Id: 91
@@ -1038,14 +1374,20 @@ Templates:
 				Height: 4
 				LeftColor: 879BB0
 				RightColor: 788C9C
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8EA2B3
 				RightColor: 728492
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 889CB1
 				RightColor: 8397AC
+				ZOffset: -12
+				ZRamp: 0
 	Template@92:
 		Category: Cliff Set
 		Id: 92
@@ -1056,6 +1398,8 @@ Templates:
 				Height: 4
 				LeftColor: 8496AA
 				RightColor: 8293A7
+				ZOffset: -12
+				ZRamp: 0
 	Template@93:
 		Category: Cliff Set
 		Id: 93
@@ -1066,6 +1410,8 @@ Templates:
 				Height: 4
 				LeftColor: 899CAE
 				RightColor: 8C9FB0
+				ZOffset: -12
+				ZRamp: 0
 	Template@94:
 		Category: Cliff Set
 		Id: 94
@@ -1076,10 +1422,14 @@ Templates:
 				Height: 4
 				LeftColor: 899AAA
 				RightColor: 8596A6
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 788899
 				RightColor: 8798A9
+				ZOffset: -12
+				ZRamp: 0
 	Template@95:
 		Category: Cliff Set
 		Id: 95
@@ -1090,10 +1440,14 @@ Templates:
 				Height: 4
 				LeftColor: 8293A3
 				RightColor: 879AAE
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 798799
 				RightColor: 8697A4
+				ZOffset: -12
+				ZRamp: 0
 	Template@96:
 		Category: Cliff Set
 		Id: 96
@@ -1104,10 +1458,14 @@ Templates:
 				Height: 4
 				LeftColor: 7F91A4
 				RightColor: 8A9BAF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 7F93A8
 				RightColor: 8498A9
+				ZOffset: -12
+				ZRamp: 0
 	Template@97:
 		Category: Cliff Set
 		Id: 97
@@ -1118,6 +1476,8 @@ Templates:
 				Height: 4
 				LeftColor: 778799
 				RightColor: 7C8C9E
+				ZOffset: -12
+				ZRamp: 0
 	Template@98:
 		Category: Cliff Set
 		Id: 98
@@ -1128,6 +1488,8 @@ Templates:
 				Height: 4
 				LeftColor: 8A9BAB
 				RightColor: 869BB1
+				ZOffset: -12
+				ZRamp: 0
 	Template@99:
 		Category: Cliff Set
 		Id: 99
@@ -1138,6 +1500,8 @@ Templates:
 				Height: 4
 				LeftColor: 8BA0B4
 				RightColor: 8293A4
+				ZOffset: -12
+				ZRamp: 0
 	Template@100:
 		Category: Civilian Buildings
 		Id: 100
@@ -1147,30 +1511,48 @@ Templates:
 			0: Impassable
 				LeftColor: 627077
 				RightColor: 6D797F
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: 4E5558
 				RightColor: 5D6870
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B2CAE4
 				RightColor: C0DBF2
+				ZOffset: -12
+				ZRamp: 0
 			3: Impassable
 				LeftColor: 757D83
 				RightColor: 768187
+				ZOffset: -12
+				ZRamp: 0
 			4: Impassable
 				LeftColor: 6A7175
 				RightColor: 545C66
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B9D4F0
 				RightColor: B8D3EF
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: BCD7F1
 				RightColor: B8CFE4
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: B7CCE1
 				RightColor: A4B7CA
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: B8D0E9
 				RightColor: B5D0EC
+				ZOffset: -12
+				ZRamp: 0
 	Template@101:
 		Category: Civilian Buildings
 		Id: 101
@@ -1180,9 +1562,13 @@ Templates:
 			0: Impassable
 				LeftColor: A6B8DB
 				RightColor: AABAD6
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: ACBACE
 				RightColor: B0CAEC
+				ZOffset: -12
+				ZRamp: 0
 	Template@102:
 		Category: Civilian Buildings
 		Id: 102
@@ -1192,6 +1578,8 @@ Templates:
 			0: Impassable
 				LeftColor: 9AA1A1
 				RightColor: 868D90
+				ZOffset: -12
+				ZRamp: 0
 	Template@103:
 		Category: Civilian Buildings
 		Id: 103
@@ -1201,9 +1589,13 @@ Templates:
 			0: Impassable
 				LeftColor: ACBFDE
 				RightColor: ABBAD4
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: AFC3DB
 				RightColor: BCD6EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@104:
 		Category: Civilian Buildings
 		Id: 104
@@ -1213,12 +1605,18 @@ Templates:
 			1: Impassable
 				LeftColor: 77848C
 				RightColor: 656D73
+				ZOffset: -12
+				ZRamp: 0
 			2: Impassable
 				LeftColor: 768086
 				RightColor: 787E84
+				ZOffset: -12
+				ZRamp: 0
 			3: Impassable
 				LeftColor: 70767D
 				RightColor: 666E75
+				ZOffset: -12
+				ZRamp: 0
 	Template@105:
 		Category: Civilian Buildings
 		Id: 105
@@ -1228,21 +1626,33 @@ Templates:
 			1: Impassable
 				LeftColor: 70777C
 				RightColor: 788188
+				ZOffset: -12
+				ZRamp: 0
 			3: Impassable
 				LeftColor: 8B98A2
 				RightColor: 757C81
+				ZOffset: -12
+				ZRamp: 0
 			4: Impassable
 				LeftColor: 8FA0AD
 				RightColor: 97A5B2
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: AEB6BC
 				RightColor: B3C5D5
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: B1C6D8
 				RightColor: A8B0B1
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: B4C6D7
 				RightColor: A8B8C7
+				ZOffset: -12
+				ZRamp: 0
 	Template@106:
 		Category: Civilian Buildings
 		Id: 106
@@ -1252,6 +1662,8 @@ Templates:
 			0: Impassable
 				LeftColor: 6F777E
 				RightColor: 59626A
+				ZOffset: -12
+				ZRamp: 0
 	Template@107:
 		Category: Civilian Buildings
 		Id: 107
@@ -1261,9 +1673,13 @@ Templates:
 			0: Impassable
 				LeftColor: 666C6E
 				RightColor: 6F7981
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: 75828C
 				RightColor: 5A6977
+				ZOffset: -12
+				ZRamp: 0
 	Template@108:
 		Category: Shore Pieces
 		Id: 108
@@ -1273,15 +1689,23 @@ Templates:
 			0: Water
 				LeftColor: 73828D
 				RightColor: A0B1C0
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 6E7C87
 				RightColor: B1C4D6
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 34444E
 				RightColor: 8297A6
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 344249
 				RightColor: 3D4A52
+				ZOffset: -12
+				ZRamp: 0
 	Template@109:
 		Category: Shore Pieces
 		Id: 109
@@ -1291,15 +1715,23 @@ Templates:
 			0: Water
 				LeftColor: B2C5D6
 				RightColor: A9B9C9
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 68737E
 				RightColor: 95A9BA
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 394954
 				RightColor: 76828F
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 46545C
 				RightColor: 3F4F5A
+				ZOffset: -12
+				ZRamp: 0
 	Template@110:
 		Category: Shore Pieces
 		Id: 110
@@ -1309,15 +1741,23 @@ Templates:
 			0: Water
 				LeftColor: A4B7C8
 				RightColor: A0B1C2
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: A2B5C4
 				RightColor: B0C6DA
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 2D3D46
 				RightColor: 53636F
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 4B5A65
 				RightColor: 616F7B
+				ZOffset: -12
+				ZRamp: 0
 	Template@111:
 		Category: Shore Pieces
 		Id: 111
@@ -1327,9 +1767,13 @@ Templates:
 			0: Water
 				LeftColor: 717D87
 				RightColor: ADC1D5
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 2C3C45
 				RightColor: 384856
+				ZOffset: -12
+				ZRamp: 0
 	Template@112:
 		Category: Shore Pieces
 		Id: 112
@@ -1339,21 +1783,33 @@ Templates:
 			0: Water
 				LeftColor: 99AABB
 				RightColor: AABECF
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 72797F
 				RightColor: 9BABB7
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 687782
 				RightColor: 526877
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 4F5D65
 				RightColor: 899CA8
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 293941
 				RightColor: 5B6C78
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 2F3F48
 				RightColor: 35424B
+				ZOffset: -12
+				ZRamp: 0
 	Template@113:
 		Category: Shore Pieces
 		Id: 113
@@ -1363,21 +1819,33 @@ Templates:
 			0: Water
 				LeftColor: A6B5C0
 				RightColor: 95A1AB
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 828D96
 				RightColor: 99AABA
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 81909C
 				RightColor: 7E8C97
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 42525D
 				RightColor: 4D5E6C
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 324049
 				RightColor: 444F58
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 313F46
 				RightColor: 324048
+				ZOffset: -12
+				ZRamp: 0
 	Template@114:
 		Category: Shore Pieces
 		Id: 114
@@ -1387,15 +1855,23 @@ Templates:
 			0: Water
 				LeftColor: 8E9CAA
 				RightColor: 8695A3
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 415059
 				RightColor: 2E3E48
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 36424A
 				RightColor: 738089
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 3E4E57
 				RightColor: 2C3B42
+				ZOffset: -12
+				ZRamp: 0
 	Template@115:
 		Category: Shore Pieces
 		Id: 115
@@ -1405,15 +1881,23 @@ Templates:
 			0: Water
 				LeftColor: A0B1BF
 				RightColor: 9CADBC
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 5C656A
 				RightColor: 2D3C44
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 34444D
 				RightColor: 798C9D
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 576872
 				RightColor: 465662
+				ZOffset: -12
+				ZRamp: 0
 	Template@116:
 		Category: Shore Pieces
 		Id: 116
@@ -1423,15 +1907,23 @@ Templates:
 			0: Water
 				LeftColor: AEC1D4
 				RightColor: A6B6C4
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 6C7E8B
 				RightColor: 33424D
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: B3C7D9
 				RightColor: A1B2C1
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 4A555E
 				RightColor: 4C606E
+				ZOffset: -12
+				ZRamp: 0
 	Template@117:
 		Category: Shore Pieces
 		Id: 117
@@ -1441,15 +1933,23 @@ Templates:
 			0: Water
 				LeftColor: A2AFBA
 				RightColor: BBD0E1
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 7D8E9E
 				RightColor: 2F3E48
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: ADBBC7
 				RightColor: 95A0AA
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 576774
 				RightColor: 5A6B76
+				ZOffset: -12
+				ZRamp: 0
 	Template@118:
 		Category: Shore Pieces
 		Id: 118
@@ -1459,15 +1959,23 @@ Templates:
 			0: Water
 				LeftColor: B4CADF
 				RightColor: 9EACBB
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 6D7E8A
 				RightColor: 303D44
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: C0DBF2
 				RightColor: B6CDE4
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 768795
 				RightColor: 5B6972
+				ZOffset: -12
+				ZRamp: 0
 	Template@119:
 		Category: Shore Pieces
 		Id: 119
@@ -1477,9 +1985,13 @@ Templates:
 			0: Water
 				LeftColor: B2C4D6
 				RightColor: 9DADB9
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 566672
 				RightColor: 475765
+				ZOffset: -12
+				ZRamp: 0
 	Template@120:
 		Category: Shore Pieces
 		Id: 120
@@ -1489,21 +2001,33 @@ Templates:
 			0: Clear
 				LeftColor: B6CCE1
 				RightColor: B2C3D3
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: B1C2D1
 				RightColor: 9CADBD
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 6D7C86
 				RightColor: 35434B
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: A6B6C5
 				RightColor: AEBCC7
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 6C7B88
 				RightColor: 606972
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 45545E
 				RightColor: 404E56
+				ZOffset: -12
+				ZRamp: 0
 	Template@121:
 		Category: Shore Pieces
 		Id: 121
@@ -1513,21 +2037,33 @@ Templates:
 			0: Water
 				LeftColor: 929CA4
 				RightColor: 858F99
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: A1B1C0
 				RightColor: 657481
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 8194A5
 				RightColor: 445562
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: BCD4E9
 				RightColor: A2AFBB
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: A6B7C7
 				RightColor: 7C8B99
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 3C4C57
 				RightColor: 3F4C56
+				ZOffset: -12
+				ZRamp: 0
 	Template@122:
 		Category: Shore Pieces
 		Id: 122
@@ -1537,15 +2073,23 @@ Templates:
 			0: Water
 				LeftColor: 3A4A54
 				RightColor: 2C3B44
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 2D3C44
 				RightColor: 2A3A42
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: A5B4C2
 				RightColor: 7D92A1
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 3A4952
 				RightColor: 2F3F48
+				ZOffset: -12
+				ZRamp: 0
 	Template@123:
 		Category: Shore Pieces
 		Id: 123
@@ -1555,15 +2099,23 @@ Templates:
 			0: Water
 				LeftColor: 4C5961
 				RightColor: 2A3A43
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 435059
 				RightColor: 293941
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: ADBED0
 				RightColor: ACBBCC
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 3C4952
 				RightColor: 445059
+				ZOffset: -12
+				ZRamp: 0
 	Template@124:
 		Category: Shore Pieces
 		Id: 124
@@ -1573,15 +2125,23 @@ Templates:
 			0: Water
 				LeftColor: 75838E
 				RightColor: 495760
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 485963
 				RightColor: 323F47
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: ACBBC9
 				RightColor: B7C9D8
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: B6CEE3
 				RightColor: A5B4C0
+				ZOffset: -12
+				ZRamp: 0
 	Template@125:
 		Category: Shore Pieces
 		Id: 125
@@ -1591,15 +2151,23 @@ Templates:
 			0: Water
 				LeftColor: 5B6870
 				RightColor: 404D54
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 6E7C85
 				RightColor: 485760
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: BACCDC
 				RightColor: A7B3BE
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: B9D3EE
 				RightColor: A9BAC9
+				ZOffset: -12
+				ZRamp: 0
 	Template@126:
 		Category: Shore Pieces
 		Id: 126
@@ -1609,15 +2177,23 @@ Templates:
 			0: Water
 				LeftColor: 495860
 				RightColor: 2A3941
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 40515F
 				RightColor: 33454F
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 9FB0BF
 				RightColor: 748088
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 9CACB9
 				RightColor: A9BCCC
+				ZOffset: -12
+				ZRamp: 0
 	Template@127:
 		Category: Shore Pieces
 		Id: 127
@@ -1627,9 +2203,13 @@ Templates:
 			0: Water
 				LeftColor: 6E7D85
 				RightColor: 435057
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: B9CDDF
 				RightColor: A5B3BF
+				ZOffset: -12
+				ZRamp: 0
 	Template@128:
 		Category: Shore Pieces
 		Id: 128
@@ -1639,21 +2219,33 @@ Templates:
 			0: Water
 				LeftColor: 364248
 				RightColor: 334148
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 616D74
 				RightColor: 364750
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 57646A
 				RightColor: 58666E
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 99A6B0
 				RightColor: B0BECA
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: A4B0BC
 				RightColor: 607079
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: A3B3C1
 				RightColor: AFC4D6
+				ZOffset: -12
+				ZRamp: 0
 	Template@129:
 		Category: Shore Pieces
 		Id: 129
@@ -1663,21 +2255,33 @@ Templates:
 			0: Water
 				LeftColor: 394C55
 				RightColor: 3B4B54
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 8EA2B2
 				RightColor: 394953
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 8E9CA9
 				RightColor: 455058
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 626E77
 				RightColor: 60727E
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: A1AFBA
 				RightColor: 96A3AE
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: A6B5C3
 				RightColor: ACBCCA
+				ZOffset: -12
+				ZRamp: 0
 	Template@130:
 		Category: Shore Pieces
 		Id: 130
@@ -1687,15 +2291,23 @@ Templates:
 			0: Water
 				LeftColor: 303C42
 				RightColor: 2C3B42
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 656F77
 				RightColor: 51626C
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 354148
 				RightColor: 3C4A53
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 8F9CA8
 				RightColor: A8B9CA
+				ZOffset: -12
+				ZRamp: 0
 	Template@131:
 		Category: Shore Pieces
 		Id: 131
@@ -1705,15 +2317,23 @@ Templates:
 			0: Water
 				LeftColor: 4D5A62
 				RightColor: 55636D
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 889AA8
 				RightColor: 415159
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 31414C
 				RightColor: 8C9BA6
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: A6B5C3
 				RightColor: B7C9D7
+				ZOffset: -12
+				ZRamp: 0
 	Template@132:
 		Category: Shore Pieces
 		Id: 132
@@ -1723,15 +2343,23 @@ Templates:
 			0: Water
 				LeftColor: 5B6974
 				RightColor: 8799A5
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: A6B6C4
 				RightColor: ABBDCD
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 36454E
 				RightColor: 889BAA
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 9BA7B1
 				RightColor: AEBCCA
+				ZOffset: -12
+				ZRamp: 0
 	Template@133:
 		Category: Shore Pieces
 		Id: 133
@@ -1741,15 +2369,23 @@ Templates:
 			0: Water
 				LeftColor: 5E6C74
 				RightColor: 667582
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 9AA7B4
 				RightColor: B6C9DA
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 35434B
 				RightColor: 818E99
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: ABB8C5
 				RightColor: ADBECC
+				ZOffset: -12
+				ZRamp: 0
 	Template@134:
 		Category: Shore Pieces
 		Id: 134
@@ -1759,15 +2395,23 @@ Templates:
 			0: Water
 				LeftColor: 3F4D56
 				RightColor: 51616C
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 828990
 				RightColor: 9DABB8
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 38464E
 				RightColor: 82919D
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 98ABBA
 				RightColor: B3C9DE
+				ZOffset: -12
+				ZRamp: 0
 	Template@135:
 		Category: Shore Pieces
 		Id: 135
@@ -1777,9 +2421,13 @@ Templates:
 			0: Water
 				LeftColor: 36464F
 				RightColor: 616F76
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: A5B4C3
 				RightColor: B0C5DA
+				ZOffset: -12
+				ZRamp: 0
 	Template@136:
 		Category: Shore Pieces
 		Id: 136
@@ -1789,21 +2437,33 @@ Templates:
 			0: Water
 				LeftColor: 2F3E46
 				RightColor: 475863
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 858D94
 				RightColor: 9EACB9
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 94A3B3
 				RightColor: B0C5DB
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 2C3C45
 				RightColor: 35454F
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 53636D
 				RightColor: 78838D
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: A4B5C5
 				RightColor: A0B0C1
+				ZOffset: -12
+				ZRamp: 0
 	Template@137:
 		Category: Shore Pieces
 		Id: 137
@@ -1813,21 +2473,33 @@ Templates:
 			0: Water
 				LeftColor: 34424A
 				RightColor: 324048
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 6D7C86
 				RightColor: 7A8A95
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: B8C8D6
 				RightColor: B9CDDF
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 2E3F47
 				RightColor: 404A50
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 6F7C85
 				RightColor: 8A99A4
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: B2C4D3
 				RightColor: A9BBCC
+				ZOffset: -12
+				ZRamp: 0
 	Template@138:
 		Category: Shore Pieces
 		Id: 138
@@ -1837,15 +2509,23 @@ Templates:
 			0: Water
 				LeftColor: 506371
 				RightColor: 384953
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 606B76
 				RightColor: A7B4C0
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 2D3E47
 				RightColor: 4C5E6B
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 323D42
 				RightColor: 39474F
+				ZOffset: -12
+				ZRamp: 0
 	Template@139:
 		Category: Shore Pieces
 		Id: 139
@@ -1855,15 +2535,23 @@ Templates:
 			0: Water
 				LeftColor: 6B7D90
 				RightColor: 4C5963
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 6D7A86
 				RightColor: B5CADE
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 2C3D45
 				RightColor: 384852
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 2C3C45
 				RightColor: 3E4C59
+				ZOffset: -12
+				ZRamp: 0
 	Template@140:
 		Category: Shore Pieces
 		Id: 140
@@ -1873,15 +2561,23 @@ Templates:
 			0: Clear
 				LeftColor: C0D8EC
 				RightColor: C1D6E8
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 88929B
 				RightColor: ADBCC8
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 9EAEBE
 				RightColor: 9EAEBF
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 495665
 				RightColor: 576573
+				ZOffset: -12
+				ZRamp: 0
 	Template@141:
 		Category: Shore Pieces
 		Id: 141
@@ -1891,15 +2587,23 @@ Templates:
 			0: Clear
 				LeftColor: BAD0E2
 				RightColor: B0C5DC
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 798793
 				RightColor: 90A1B0
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: B4C8DB
 				RightColor: 9FAEBC
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 51616B
 				RightColor: 47565F
+				ZOffset: -12
+				ZRamp: 0
 	Template@142:
 		Category: Shore Pieces
 		Id: 142
@@ -1909,15 +2613,23 @@ Templates:
 			0: Water
 				LeftColor: B9CDDD
 				RightColor: 9EACBA
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 748490
 				RightColor: 354650
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: BED7EC
 				RightColor: ACBDCC
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: ADBDCC
 				RightColor: B2C8DB
+				ZOffset: -12
+				ZRamp: 0
 	Template@143:
 		Category: Shore Pieces
 		Id: 143
@@ -1927,15 +2639,23 @@ Templates:
 			0: Water
 				LeftColor: ACBED0
 				RightColor: 92A2B1
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 606F7B
 				RightColor: 5D6E7B
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: C0DBF2
 				RightColor: 929EA9
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 98A5B1
 				RightColor: AFC1D0
+				ZOffset: -12
+				ZRamp: 0
 	Template@144:
 		Category: Shore Pieces
 		Id: 144
@@ -1945,15 +2665,23 @@ Templates:
 			0: Water
 				LeftColor: 778691
 				RightColor: 76848E
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: A9B8C6
 				RightColor: BAD1E5
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: B1C4D5
 				RightColor: 97A1AA
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: B0C3D7
 				RightColor: ABBED2
+				ZOffset: -12
+				ZRamp: 0
 	Template@145:
 		Category: Shore Pieces
 		Id: 145
@@ -1963,15 +2691,23 @@ Templates:
 			0: Water
 				LeftColor: 728490
 				RightColor: 6C7B86
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 868E95
 				RightColor: A2B1BE
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 9DAAB7
 				RightColor: 9FADBA
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: A0B1BF
 				RightColor: 99A3AE
+				ZOffset: -12
+				ZRamp: 0
 	Template@146:
 		Category: Shore Pieces
 		Id: 146
@@ -1981,15 +2717,23 @@ Templates:
 			0: Water
 				LeftColor: A7B7C6
 				RightColor: A5B2BF
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: B7CEE4
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 435058
 				RightColor: AABCCB
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: B4C8DB
 				RightColor: BAD4ED
+				ZOffset: -12
+				ZRamp: 0
 	Template@147:
 		Category: Shore Pieces
 		Id: 147
@@ -1999,15 +2743,23 @@ Templates:
 			0: Water
 				LeftColor: 909BA5
 				RightColor: 929FAC
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 848D96
 				RightColor: 9DADBA
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 43525B
 				RightColor: 87929B
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: B2C8D9
 				RightColor: A7B9CC
+				ZOffset: -12
+				ZRamp: 0
 	Template@148:
 		Category: Shore Pieces
 		Id: 148
@@ -2017,66 +2769,108 @@ Templates:
 			1: Clear
 				LeftColor: A5B6C7
 				RightColor: B7CEE4
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: ADBAC7
 				RightColor: BBD0E1
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 8C96A0
 				RightColor: B5C9DE
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B8CDE0
 				RightColor: B7CEE4
+				ZOffset: -12
+				ZRamp: 0
 			7: Water
 				LeftColor: 9DAAB7
 				RightColor: 9EACBA
+				ZOffset: -12
+				ZRamp: 0
 			8: Water
 				LeftColor: 81929F
 				RightColor: 76808B
+				ZOffset: -12
+				ZRamp: 0
 			9: Water
 				LeftColor: 798692
 				RightColor: ACBECE
+				ZOffset: -12
+				ZRamp: 0
 			10: Water
 				LeftColor: 7E8C9E
 				RightColor: AFC1D0
+				ZOffset: -12
+				ZRamp: 0
 			11: Water
 				LeftColor: 8B9FAE
 				RightColor: 374752
+				ZOffset: -12
+				ZRamp: 0
 			12: Water
 				LeftColor: ABBCCC
 				RightColor: 99A4B0
+				ZOffset: -12
+				ZRamp: 0
 			13: Water
 				LeftColor: 9FAEBC
 				RightColor: 8F99A2
+				ZOffset: -12
+				ZRamp: 0
 			14: Water
 				LeftColor: 4E5A64
 				RightColor: 596773
+				ZOffset: -12
+				ZRamp: 0
 			15: Water
 				LeftColor: 344048
 				RightColor: 546975
+				ZOffset: -12
+				ZRamp: 0
 			16: Water
 				LeftColor: 41525D
 				RightColor: 4F5C65
+				ZOffset: -12
+				ZRamp: 0
 			17: Water
 				LeftColor: 39454D
 				RightColor: 374751
+				ZOffset: -12
+				ZRamp: 0
 			18: Water
 				LeftColor: B0C2D5
 				RightColor: 8B99A7
+				ZOffset: -12
+				ZRamp: 0
 			19: Water
 				LeftColor: 37444C
 				RightColor: 46545C
+				ZOffset: -12
+				ZRamp: 0
 			20: Water
 				LeftColor: 2D3B43
 				RightColor: 323F47
+				ZOffset: -12
+				ZRamp: 0
 			21: Water
 				LeftColor: 2B3A43
 				RightColor: 2D3C45
+				ZOffset: -12
+				ZRamp: 0
 			22: Water
 				LeftColor: 2A3A42
 				RightColor: 2E3C44
+				ZOffset: -12
+				ZRamp: 0
 			23: Water
 				LeftColor: 2C3C44
 				RightColor: 2A3941
+				ZOffset: -12
+				ZRamp: 0
 	Template@149:
 		Category: Shore Pieces
 		Id: 149
@@ -2086,93 +2880,153 @@ Templates:
 			2: Water
 				LeftColor: 7E848A
 				RightColor: 9BACBB
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 787F84
 				RightColor: A9BCCC
+				ZOffset: -12
+				ZRamp: 0
 			11: Water
 				LeftColor: 8A96A1
 				RightColor: 646C71
+				ZOffset: -12
+				ZRamp: 0
 			12: Water
 				LeftColor: 58646B
 				RightColor: 75818A
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 9EABB8
 				RightColor: AABACA
+				ZOffset: -12
+				ZRamp: 0
 			18: Clear
 				LeftColor: BED6EA
 				RightColor: B8CDDF
+				ZOffset: -12
+				ZRamp: 0
 			19: Water
 				LeftColor: 5D6368
 				RightColor: 8697A5
+				ZOffset: -12
+				ZRamp: 0
 			20: Water
 				LeftColor: 3F4F59
 				RightColor: 404C54
+				ZOffset: -12
+				ZRamp: 0
 			21: Water
 				LeftColor: 303F49
 				RightColor: 3C474E
+				ZOffset: -12
+				ZRamp: 0
 			22: Water
 				LeftColor: 5A6871
 				RightColor: 9EAEBC
+				ZOffset: -12
+				ZRamp: 0
 			23: Water
 				LeftColor: 63717B
 				RightColor: B1C6D9
+				ZOffset: -12
+				ZRamp: 0
 			24: Water
 				LeftColor: 66737C
 				RightColor: B6CADC
+				ZOffset: -12
+				ZRamp: 0
 			25: Water
 				LeftColor: 929EA8
 				RightColor: B4CFEA
+				ZOffset: -12
+				ZRamp: 0
 			26: Water
 				LeftColor: 495660
 				RightColor: 2C3B43
+				ZOffset: -12
+				ZRamp: 0
 			28: Water
 				LeftColor: AEC2D4
 				RightColor: 808B94
+				ZOffset: -12
+				ZRamp: 0
 			29: Water
 				LeftColor: 606F7A
 				RightColor: 4E5C65
+				ZOffset: -12
+				ZRamp: 0
 			30: Water
 				LeftColor: 2F3F48
 				RightColor: 2E3C44
+				ZOffset: -12
+				ZRamp: 0
 			31: Water
 				LeftColor: 2B3A42
 				RightColor: 313F49
+				ZOffset: -12
+				ZRamp: 0
 			32: Water
 				LeftColor: 303F49
 				RightColor: 33424C
+				ZOffset: -12
+				ZRamp: 0
 			33: Water
 				LeftColor: 2E3C44
 				RightColor: 324049
+				ZOffset: -12
+				ZRamp: 0
 			34: Water
 				LeftColor: 2E3D45
 				RightColor: 35434A
+				ZOffset: -12
+				ZRamp: 0
 			35: Water
 				LeftColor: 2F3F48
 				RightColor: 2F3F48
+				ZOffset: -12
+				ZRamp: 0
 			37: Water
 				LeftColor: B7CBDA
 				RightColor: A3B4C2
+				ZOffset: -12
+				ZRamp: 0
 			38: Water
 				LeftColor: 47525A
 				RightColor: 394750
+				ZOffset: -12
+				ZRamp: 0
 			39: Water
 				LeftColor: 2B3B43
 				RightColor: 2C3C44
+				ZOffset: -12
+				ZRamp: 0
 			40: Water
 				LeftColor: 2C3C45
 				RightColor: 2B3B44
+				ZOffset: -12
+				ZRamp: 0
 			41: Water
 				LeftColor: 2B3B43
 				RightColor: 2B3A42
+				ZOffset: -12
+				ZRamp: 0
 			42: Water
 				LeftColor: 2A3A42
 				RightColor: 2A3A42
+				ZOffset: -12
+				ZRamp: 0
 			43: Water
 				LeftColor: 2B3B43
 				RightColor: 2C3C44
+				ZOffset: -12
+				ZRamp: 0
 			44: Water
 				LeftColor: 2D3D46
 				RightColor: 2B3B43
+				ZOffset: -12
+				ZRamp: 0
 	Template@150:
 		Category: Rough lat
 		Id: 150
@@ -2182,6 +3036,8 @@ Templates:
 			0: Rough
 				LeftColor: BFCFDF
 				RightColor: AFC1D3
+				ZOffset: -12
+				ZRamp: 0
 	Template@151:
 		Category: Clear/Rough LAT
 		Id: 151
@@ -2191,6 +3047,8 @@ Templates:
 			0: Rough
 				LeftColor: C0D5E5
 				RightColor: BED1E4
+				ZOffset: -12
+				ZRamp: 0
 	Template@152:
 		Category: Clear/Rough LAT
 		Id: 152
@@ -2200,6 +3058,8 @@ Templates:
 			0: Rough
 				LeftColor: B9C9D8
 				RightColor: B8CEE3
+				ZOffset: -12
+				ZRamp: 0
 	Template@153:
 		Category: Clear/Rough LAT
 		Id: 153
@@ -2209,6 +3069,8 @@ Templates:
 			0: Rough
 				LeftColor: B1C5D9
 				RightColor: C3D8EC
+				ZOffset: -12
+				ZRamp: 0
 	Template@154:
 		Category: Clear/Rough LAT
 		Id: 154
@@ -2218,6 +3080,8 @@ Templates:
 			0: Rough
 				LeftColor: C0D1E2
 				RightColor: BDD7EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@155:
 		Category: Clear/Rough LAT
 		Id: 155
@@ -2227,6 +3091,8 @@ Templates:
 			0: Rough
 				LeftColor: BFD3E3
 				RightColor: B6C5D7
+				ZOffset: -12
+				ZRamp: 0
 	Template@156:
 		Category: Clear/Rough LAT
 		Id: 156
@@ -2236,6 +3102,8 @@ Templates:
 			0: Rough
 				LeftColor: BFD4E6
 				RightColor: BAD0E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@157:
 		Category: Clear/Rough LAT
 		Id: 157
@@ -2245,6 +3113,8 @@ Templates:
 			0: Rough
 				LeftColor: BED4E6
 				RightColor: B3CAE0
+				ZOffset: -12
+				ZRamp: 0
 	Template@158:
 		Category: Clear/Rough LAT
 		Id: 158
@@ -2254,6 +3124,8 @@ Templates:
 			0: Rough
 				LeftColor: B6CCE0
 				RightColor: BCD4EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@159:
 		Category: Clear/Rough LAT
 		Id: 159
@@ -2263,6 +3135,8 @@ Templates:
 			0: Rough
 				LeftColor: C3D6E7
 				RightColor: B0C3D4
+				ZOffset: -12
+				ZRamp: 0
 	Template@160:
 		Category: Clear/Rough LAT
 		Id: 160
@@ -2272,6 +3146,8 @@ Templates:
 			0: Rough
 				LeftColor: C3D6E7
 				RightColor: B8CEE3
+				ZOffset: -12
+				ZRamp: 0
 	Template@161:
 		Category: Clear/Rough LAT
 		Id: 161
@@ -2281,6 +3157,8 @@ Templates:
 			0: Rough
 				LeftColor: C0D5E7
 				RightColor: BCD2E7
+				ZOffset: -12
+				ZRamp: 0
 	Template@162:
 		Category: Clear/Rough LAT
 		Id: 162
@@ -2290,6 +3168,8 @@ Templates:
 			0: Rough
 				LeftColor: BDD1E5
 				RightColor: BAD3EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@163:
 		Category: Clear/Rough LAT
 		Id: 163
@@ -2299,6 +3179,8 @@ Templates:
 			0: Rough
 				LeftColor: BCD6EB
 				RightColor: ADC2D5
+				ZOffset: -12
+				ZRamp: 0
 	Template@164:
 		Category: Clear/Rough LAT
 		Id: 164
@@ -2308,6 +3190,8 @@ Templates:
 			0: Rough
 				LeftColor: BCD3E6
 				RightColor: B9CCDF
+				ZOffset: -12
+				ZRamp: 0
 	Template@165:
 		Category: Clear/Rough LAT
 		Id: 165
@@ -2317,6 +3201,8 @@ Templates:
 			0: Rough
 				LeftColor: C0DAEF
 				RightColor: C6D9EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@166:
 		Category: Clear/Rough LAT
 		Id: 166
@@ -2326,6 +3212,8 @@ Templates:
 			0: Rough
 				LeftColor: BBD1E8
 				RightColor: C1D5E8
+				ZOffset: -12
+				ZRamp: 0
 	Template@167:
 		Category: Cliff/Water pieces
 		Id: 167
@@ -2336,16 +3224,24 @@ Templates:
 				Height: 4
 				LeftColor: 798996
 				RightColor: 8B9AA7
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: A9BDD1
 				RightColor: A2B6C6
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 6A7B87
 				RightColor: 768894
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 879CBF
 				RightColor: 93A8BE
+				ZOffset: -12
+				ZRamp: 0
 	Template@168:
 		Category: Cliff/Water pieces
 		Id: 168
@@ -2356,9 +3252,13 @@ Templates:
 				Height: 4
 				LeftColor: 8091A1
 				RightColor: 8B9FB2
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 90A9C2
 				RightColor: 8BA3BB
+				ZOffset: -12
+				ZRamp: 0
 	Template@169:
 		Category: Cliff/Water pieces
 		Id: 169
@@ -2369,16 +3269,24 @@ Templates:
 				Height: 4
 				LeftColor: 8393A1
 				RightColor: 8C9FAE
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 8DA4C8
 				RightColor: 96AAC0
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 788695
 				RightColor: 8394A3
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 8095B6
 				RightColor: 8DA1BF
+				ZOffset: -12
+				ZRamp: 0
 	Template@170:
 		Category: Cliff/Water pieces
 		Id: 170
@@ -2389,16 +3297,24 @@ Templates:
 				Height: 4
 				LeftColor: 8998A7
 				RightColor: 8FA1B1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: AAC1E2
 				RightColor: A7BBCB
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 8997A4
 				RightColor: 8798A8
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 889FC4
 				RightColor: A1B7CC
+				ZOffset: -12
+				ZRamp: 0
 	Template@171:
 		Category: Cliff/Water pieces
 		Id: 171
@@ -2409,16 +3325,24 @@ Templates:
 				Height: 4
 				LeftColor: 7D8D9D
 				RightColor: 8296A8
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 7D8C9F
 				RightColor: 879CB1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 8297BF
 				RightColor: 8CA6B9
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 8A9FBB
 				RightColor: 93A8BE
+				ZOffset: -12
+				ZRamp: 0
 	Template@172:
 		Category: Cliff/Water pieces
 		Id: 172
@@ -2429,16 +3353,24 @@ Templates:
 				Height: 4
 				LeftColor: 798C9E
 				RightColor: 8596A7
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 627384
 				RightColor: 7E91A3
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 7E95B7
 				RightColor: A3B7C8
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 96ACC7
 				RightColor: A1B6CB
+				ZOffset: -12
+				ZRamp: 0
 	Template@173:
 		Category: Cliff/Water pieces
 		Id: 173
@@ -2449,16 +3381,24 @@ Templates:
 				Height: 4
 				LeftColor: 8295A7
 				RightColor: 8D9EAF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 8E9FAC
 				RightColor: 8B9FB0
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 879DC0
 				RightColor: 95A8B7
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B5C4D8
 				RightColor: 96ABBE
+				ZOffset: -12
+				ZRamp: 0
 	Template@174:
 		Category: Cliff/Water pieces
 		Id: 174
@@ -2469,9 +3409,13 @@ Templates:
 				Height: 4
 				LeftColor: 728497
 				RightColor: 8095A7
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 97ADC3
 				RightColor: 859CB3
+				ZOffset: -12
+				ZRamp: 0
 	Template@175:
 		Category: Cliff/Water pieces
 		Id: 175
@@ -2482,12 +3426,18 @@ Templates:
 				Height: 4
 				LeftColor: 92A0AD
 				RightColor: 8693A0
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 8196B0
 				RightColor: 92A8BC
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: A3B7CE
 				RightColor: 9AAFC5
+				ZOffset: -12
+				ZRamp: 0
 	Template@176:
 		Category: Cliff/Water pieces
 		Id: 176
@@ -2498,15 +3448,23 @@ Templates:
 				Height: 4
 				LeftColor: 8C9EB1
 				RightColor: 889BAC
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 7287A0
 				RightColor: 9EB7D0
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 8CA6C1
 				RightColor: 84A0BC
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 7F93B5
 				RightColor: 8095B8
+				ZOffset: -12
+				ZRamp: 0
 	Template@177:
 		Category: Cliff/Water pieces
 		Id: 177
@@ -2517,12 +3475,18 @@ Templates:
 				Height: 4
 				LeftColor: 92A1AD
 				RightColor: 8A9AAA
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 9FB4CD
 				RightColor: 94AEC7
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 94ABC3
 				RightColor: AEC4D9
+				ZOffset: -12
+				ZRamp: 0
 	Template@178:
 		Category: Cliff/Water pieces
 		Id: 178
@@ -2532,6 +3496,8 @@ Templates:
 			0: Cliff
 				LeftColor: ACC0D6
 				RightColor: 9DB2C7
+				ZOffset: -12
+				ZRamp: 0
 	Template@179:
 		Category: Cliff/Water pieces
 		Id: 179
@@ -2541,6 +3507,8 @@ Templates:
 			0: Cliff
 				LeftColor: 9CB3CA
 				RightColor: A4B9CF
+				ZOffset: -12
+				ZRamp: 0
 	Template@180:
 		Category: Cliff/Water pieces
 		Id: 180
@@ -2550,6 +3518,8 @@ Templates:
 			0: Cliff
 				LeftColor: ADC1D4
 				RightColor: 8AA3B6
+				ZOffset: -12
+				ZRamp: 0
 	Template@181:
 		Category: Cliff/Water pieces
 		Id: 181
@@ -2560,16 +3530,24 @@ Templates:
 				Height: 4
 				LeftColor: 879BAE
 				RightColor: 7B8D9D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6A7F95
 				RightColor: 7591AB
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 899EB0
 				RightColor: 7F909F
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 72869B
 				RightColor: 708BA0
+				ZOffset: -12
+				ZRamp: 0
 	Template@182:
 		Category: Cliff/Water pieces
 		Id: 182
@@ -2580,16 +3558,24 @@ Templates:
 				Height: 4
 				LeftColor: 778998
 				RightColor: 758692
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 94A9BF
 				RightColor: 738FA5
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8296A9
 				RightColor: 7C8D9C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 8498BC
 				RightColor: 859EB7
+				ZOffset: -12
+				ZRamp: 0
 	Template@183:
 		Category: Cliff/Water pieces
 		Id: 183
@@ -2600,16 +3586,24 @@ Templates:
 				Height: 4
 				LeftColor: 7E91A4
 				RightColor: 8596A6
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 93A6BB
 				RightColor: 7892AB
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8BA0B4
 				RightColor: 6C7F8F
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 768A9E
 				RightColor: 657E90
+				ZOffset: -12
+				ZRamp: 0
 	Template@184:
 		Category: Cliff/Water pieces
 		Id: 184
@@ -2620,9 +3614,13 @@ Templates:
 				Height: 4
 				LeftColor: 8395A7
 				RightColor: 7B8D9E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 7B90A9
 				RightColor: 7F98AC
+				ZOffset: -12
+				ZRamp: 0
 	Template@185:
 		Category: Cliff/Water pieces
 		Id: 185
@@ -2633,16 +3631,24 @@ Templates:
 				Height: 4
 				LeftColor: 8EA0B1
 				RightColor: 8898A9
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 647B8B
 				RightColor: 7991A6
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 899CAF
 				RightColor: 63747E
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 889DBD
 				RightColor: 889FBD
+				ZOffset: -12
+				ZRamp: 0
 	Template@186:
 		Category: Cliff/Water pieces
 		Id: 186
@@ -2653,16 +3659,24 @@ Templates:
 				Height: 4
 				LeftColor: 8CA1B4
 				RightColor: 8D9FAF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 8C9EAA
 				RightColor: 7C95AB
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 8BA0B3
 				RightColor: 677987
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 788CAF
 				RightColor: 7C94B4
+				ZOffset: -12
+				ZRamp: 0
 	Template@187:
 		Category: Cliff/Water pieces
 		Id: 187
@@ -2673,16 +3687,24 @@ Templates:
 				Height: 4
 				LeftColor: 7C8C9A
 				RightColor: 7A8793
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 899FB4
 				RightColor: 859BAE
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 8DA0B2
 				RightColor: 6F7D8A
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: A0B4CF
 				RightColor: 8EA4C4
+				ZOffset: -12
+				ZRamp: 0
 	Template@188:
 		Category: Cliff/Water pieces
 		Id: 188
@@ -2693,9 +3715,13 @@ Templates:
 				Height: 4
 				LeftColor: 8A9EB0
 				RightColor: 8091A2
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 8197AF
 				RightColor: 8BA2B6
+				ZOffset: -12
+				ZRamp: 0
 	Template@189:
 		Category: Cliff/Water pieces
 		Id: 189
@@ -2706,19 +3732,29 @@ Templates:
 				Height: 4
 				LeftColor: 8597A4
 				RightColor: 899BA9
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 93AEC0
 				RightColor: 92AABD
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 637683
 				RightColor: 778D9D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 9AABBE
 				RightColor: B5C2CD
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 8B9EB5
 				RightColor: 91A7BD
+				ZOffset: -12
+				ZRamp: 0
 	Template@190:
 		Category: Cliff/Water pieces
 		Id: 190
@@ -2728,9 +3764,13 @@ Templates:
 			0: Cliff
 				LeftColor: 96A8BF
 				RightColor: 92ABBE
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 8B9FBD
 				RightColor: ACBFD1
+				ZOffset: -12
+				ZRamp: 0
 	Template@191:
 		Category: Cliff/Water pieces
 		Id: 191
@@ -2740,9 +3780,13 @@ Templates:
 			0: Cliff
 				LeftColor: 96ACC3
 				RightColor: A4BACF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: B2C4D4
 				RightColor: 99ABC6
+				ZOffset: -12
+				ZRamp: 0
 	Template@192:
 		Category: Cliff/Water pieces
 		Id: 192
@@ -2752,9 +3796,13 @@ Templates:
 			0: Cliff
 				LeftColor: 9EB2C5
 				RightColor: 9FB5CA
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 9BACC4
 				RightColor: B2C7DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@193:
 		Category: Cliff/Water pieces
 		Id: 193
@@ -2764,9 +3812,13 @@ Templates:
 			0: Cliff
 				LeftColor: AABDD5
 				RightColor: 90A7BC
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: B6CADC
 				RightColor: 9BAEC7
+				ZOffset: -12
+				ZRamp: 0
 	Template@194:
 		Category: Cliff/Water pieces
 		Id: 194
@@ -2777,19 +3829,29 @@ Templates:
 				Height: 4
 				LeftColor: 8090A0
 				RightColor: 7F8C98
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 9BB0C3
 				RightColor: 95ABBF
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: A7BDD3
 				RightColor: 98A9BE
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 8DA0B2
 				RightColor: 778594
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 92A6BE
 				RightColor: 9DB5CE
+				ZOffset: -12
+				ZRamp: 0
 	Template@195:
 		Category: Bendy Dirt Roads
 		Id: 195
@@ -2799,18 +3861,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: C0DBF2
 				RightColor: A3B8C7
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 99ADBA
 				RightColor: 9AAEBB
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 97ABB8
 				RightColor: 86949B
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: C3DCF0
 				RightColor: A9BECE
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: ACC5D9
 				RightColor: 98B0C0
+				ZOffset: -12
+				ZRamp: 0
 	Template@196:
 		Category: Bendy Dirt Roads
 		Id: 196
@@ -2820,15 +3892,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: B3CBDF
 				RightColor: 97A8B4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9DADB7
 				RightColor: 98A9B5
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: C5DDF1
 				RightColor: BAD0E2
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: BCD2E4
 				RightColor: 95A5AF
+				ZOffset: -12
+				ZRamp: 0
 	Template@197:
 		Category: Bendy Dirt Roads
 		Id: 197
@@ -2838,15 +3918,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: B4CEE6
 				RightColor: 9BAEBA
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9CAEBB
 				RightColor: B5CDE0
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: C2DCF1
 				RightColor: B7CFE7
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9BADB9
 				RightColor: ABC0D3
+				ZOffset: -12
+				ZRamp: 0
 	Template@198:
 		Category: Bendy Dirt Roads
 		Id: 198
@@ -2856,12 +3944,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: A7BECF
 				RightColor: 98ADBC
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A4BACB
 				RightColor: B3CCE1
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: AAC3D6
 				RightColor: BBCFE0
+				ZOffset: -12
+				ZRamp: 0
 	Template@199:
 		Category: Bendy Dirt Roads
 		Id: 199
@@ -2871,15 +3965,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 94A3AC
 				RightColor: 9AA8B2
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A0B2C1
 				RightColor: B7CFE1
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: ADC4D7
 				RightColor: 98AAB5
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: BCD5E7
 				RightColor: BCD5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@200:
 		Category: Bendy Dirt Roads
 		Id: 200
@@ -2889,18 +3991,28 @@ Templates:
 			1: DirtRoad
 				LeftColor: 98ADBE
 				RightColor: 99AAB7
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9FB4C2
 				RightColor: B4CDE2
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: C2DDF2
 				RightColor: B1CADE
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: ACC5DB
 				RightColor: 92A8B7
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A3BCD0
 				RightColor: A2BCD2
+				ZOffset: -12
+				ZRamp: 0
 	Template@201:
 		Category: Bendy Dirt Roads
 		Id: 201
@@ -2910,18 +4022,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: B8CFE1
 				RightColor: B0C6DA
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9DB0BE
 				RightColor: 8A9CA6
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: C0D9ED
 				RightColor: B3CBDF
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 93A6B2
 				RightColor: 99ACBA
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: C4DDF1
 				RightColor: ABC0CE
+				ZOffset: -12
+				ZRamp: 0
 	Template@202:
 		Category: Bendy Dirt Roads
 		Id: 202
@@ -2931,15 +4053,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: BAD3E9
 				RightColor: B3CADD
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8D9EAA
 				RightColor: 83929A
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B9D4EE
 				RightColor: AEC6DA
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 97A8B4
 				RightColor: 8698A1
+				ZOffset: -12
+				ZRamp: 0
 	Template@203:
 		Category: Bendy Dirt Roads
 		Id: 203
@@ -2949,15 +4079,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: BAD3EA
 				RightColor: A9BFD3
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8C9DA7
 				RightColor: 89979F
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B5CCDE
 				RightColor: 9AAEBC
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9AABB6
 				RightColor: A0B3BF
+				ZOffset: -12
+				ZRamp: 0
 	Template@204:
 		Category: Bendy Dirt Roads
 		Id: 204
@@ -2967,15 +4105,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 99ABB7
 				RightColor: AABFD0
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 899BA5
 				RightColor: 859399
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: ABC4DA
 				RightColor: 9DB1BE
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: BAD3E6
 				RightColor: ABBFCD
+				ZOffset: -12
+				ZRamp: 0
 	Template@205:
 		Category: Bendy Dirt Roads
 		Id: 205
@@ -2985,18 +4131,28 @@ Templates:
 			1: DirtRoad
 				LeftColor: 9BAEBB
 				RightColor: A9BECE
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 8C99A0
 				RightColor: 849097
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B8D1EA
 				RightColor: ABBFD1
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B3CADB
 				RightColor: 9EB2C0
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B2C9DA
 				RightColor: A4BAC8
+				ZOffset: -12
+				ZRamp: 0
 	Template@206:
 		Category: Bendy Dirt Roads
 		Id: 206
@@ -3006,18 +4162,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: BCD6EE
 				RightColor: A1B4C4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A0B4C3
 				RightColor: 9CAEBC
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A6B7C5
 				RightColor: 8B99A1
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: C1DBEF
 				RightColor: ABC1D1
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: BCD5E9
 				RightColor: B2CADD
+				ZOffset: -12
+				ZRamp: 0
 	Template@207:
 		Category: Bendy Dirt Roads
 		Id: 207
@@ -3027,21 +4193,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: ADC7DE
 				RightColor: AEC6DA
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 99AEBD
 				RightColor: ADC5DA
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B4CBDC
 				RightColor: 95ABB8
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9BADB9
 				RightColor: 99ACB7
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: C3DDF1
 				RightColor: B3CADD
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9DB0BC
 				RightColor: 9EB1BE
+				ZOffset: -12
+				ZRamp: 0
 	Template@208:
 		Category: Bendy Dirt Roads
 		Id: 208
@@ -3051,15 +4229,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: B5CDE4
 				RightColor: B5CFE8
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9FB2BF
 				RightColor: ADC4D8
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: ADC4D5
 				RightColor: 94A7B5
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 98ACBB
 				RightColor: 94A8B5
+				ZOffset: -12
+				ZRamp: 0
 	Template@209:
 		Category: Bendy Dirt Roads
 		Id: 209
@@ -3069,12 +4255,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: 9EB2C1
 				RightColor: B1C9DB
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 90A3AF
 				RightColor: A4BDD3
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9CAFBB
 				RightColor: 9DAFBB
+				ZOffset: -12
+				ZRamp: 0
 	Template@210:
 		Category: Bendy Dirt Roads
 		Id: 210
@@ -3084,12 +4276,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: A2B6C6
 				RightColor: AEC6DA
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: BAD5EE
 				RightColor: B3CBDF
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B4CCDE
 				RightColor: 99ACB8
+				ZOffset: -12
+				ZRamp: 0
 	Template@211:
 		Category: Bendy Dirt Roads
 		Id: 211
@@ -3099,21 +4297,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: B4CCDF
 				RightColor: B0C8DD
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 97AAB9
 				RightColor: B3CBE2
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B6CBDD
 				RightColor: BDD6ED
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: ACC2D4
 				RightColor: 96A9B5
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A3B6C4
 				RightColor: 95A7B4
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 899BA4
 				RightColor: 98A9B6
+				ZOffset: -12
+				ZRamp: 0
 	Template@212:
 		Category: Bendy Dirt Roads
 		Id: 212
@@ -3123,12 +4333,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: A2B5C3
 				RightColor: B1C6D9
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: AABECF
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8D9BA4
 				RightColor: 98AAB8
+				ZOffset: -12
+				ZRamp: 0
 	Template@213:
 		Category: Bendy Dirt Roads
 		Id: 213
@@ -3138,15 +4354,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8898A3
 				RightColor: B1C9DE
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: B4CBE1
 				RightColor: BDD6ED
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: BECEDC
 				RightColor: 92A4AF
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 84939B
 				RightColor: 92A4B1
+				ZOffset: -12
+				ZRamp: 0
 	Template@214:
 		Category: Bendy Dirt Roads
 		Id: 214
@@ -3156,18 +4380,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: A7BDCE
 				RightColor: A9C1D4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 91A3B0
 				RightColor: ACC4D8
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B7CFE2
 				RightColor: BDD7EC
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 93A5B1
 				RightColor: 829199
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9FB3C1
 				RightColor: B6D0EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@215:
 		Category: Bendy Dirt Roads
 		Id: 215
@@ -3177,15 +4411,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 9FB2BF
 				RightColor: B6CDE0
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: BAD2E6
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A7BCCC
 				RightColor: 8C9BA4
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 94A7B2
 				RightColor: B5CCDD
+				ZOffset: -12
+				ZRamp: 0
 	Template@216:
 		Category: Bendy Dirt Roads
 		Id: 216
@@ -3195,12 +4437,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: A7BED1
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: BCD5E7
 				RightColor: 9DB0BD
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 96A7B2
 				RightColor: ADC4D6
+				ZOffset: -12
+				ZRamp: 0
 	Template@217:
 		Category: Bendy Dirt Roads
 		Id: 217
@@ -3210,15 +4458,23 @@ Templates:
 			1: DirtRoad
 				LeftColor: ABC1D5
 				RightColor: C0DBF2
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9EB4C4
 				RightColor: 9AADBA
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9CAEBB
 				RightColor: ABC1D1
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B1C6D7
 				RightColor: B3CADE
+				ZOffset: -12
+				ZRamp: 0
 	Template@218:
 		Category: Bendy Dirt Roads
 		Id: 218
@@ -3228,18 +4484,28 @@ Templates:
 			1: DirtRoad
 				LeftColor: AABFD1
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 97A9B6
 				RightColor: 98ACBA
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8C9FAB
 				RightColor: A4BCD2
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: AEC7DD
 				RightColor: 99ADBA
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B8D1E6
 				RightColor: B6D0E7
+				ZOffset: -12
+				ZRamp: 0
 	Template@219:
 		Category: Dirt Road Junctions
 		Id: 219
@@ -3249,15 +4515,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: A1B8CA
 				RightColor: 97AAB7
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 90A2AD
 				RightColor: 8EA1AE
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A9BED0
 				RightColor: 8B9EAA
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 98ABB7
 				RightColor: 8EA0AC
+				ZOffset: -12
+				ZRamp: 0
 	Template@220:
 		Category: Dirt Road Junctions
 		Id: 220
@@ -3267,15 +4541,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: AAC0D2
 				RightColor: BDD6EC
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A4BCD1
 				RightColor: AAC1D5
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9CB1BE
 				RightColor: A1B7C8
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B3C9DC
 				RightColor: A8BFD0
+				ZOffset: -12
+				ZRamp: 0
 	Template@221:
 		Category: Dirt Road Junctions
 		Id: 221
@@ -3285,15 +4567,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 99ACBA
 				RightColor: 9FB1BF
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A6B9C7
 				RightColor: B1C7DA
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9DAFBC
 				RightColor: 8D9CA4
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A2B6C4
 				RightColor: AEC5D7
+				ZOffset: -12
+				ZRamp: 0
 	Template@222:
 		Category: Dirt Road Junctions
 		Id: 222
@@ -3303,15 +4593,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 99A9B3
 				RightColor: 95A2AA
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 99A8B2
 				RightColor: 95A9B7
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B2C9DA
 				RightColor: 98AAB6
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: ABC0D2
 				RightColor: 95A7B2
+				ZOffset: -12
+				ZRamp: 0
 	Template@223:
 		Category: Dirt Road Junctions
 		Id: 223
@@ -3321,15 +4619,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 91A3AF
 				RightColor: 909FA8
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 889BA7
 				RightColor: 98ACBB
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9DB1BF
 				RightColor: 8699A4
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 93A8B7
 				RightColor: 8DA2AD
+				ZOffset: -12
+				ZRamp: 0
 	Template@224:
 		Category: Dirt Road Junctions
 		Id: 224
@@ -3339,24 +4645,38 @@ Templates:
 			1: DirtRoad
 				LeftColor: B2C8DA
 				RightColor: A6BCCE
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 879299
 				RightColor: 848F93
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 98ABB8
 				RightColor: A7BDCD
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8D9DA7
 				RightColor: 94A4AE
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 95A4AE
 				RightColor: 9AABB8
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 99AEBD
 				RightColor: 8E9FAA
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 8A9BA5
 				RightColor: 8F9EA7
+				ZOffset: -12
+				ZRamp: 0
 	Template@225:
 		Category: Dirt Road Junctions
 		Id: 225
@@ -3366,21 +4686,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: ACC3D7
 				RightColor: C0DBF2
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A2B7C5
 				RightColor: 92A6B4
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8499A5
 				RightColor: 8FA2AD
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B0C7D7
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A6BCCC
 				RightColor: 98ACB9
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 95A8B5
 				RightColor: 96A8B5
+				ZOffset: -12
+				ZRamp: 0
 	Template@226:
 		Category: Dirt Road Junctions
 		Id: 226
@@ -3390,21 +4722,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8FA3B1
 				RightColor: AAC3D6
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 99AAB5
 				RightColor: 8E9FA9
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9BAFBD
 				RightColor: 8C9CA6
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A1B5C3
 				RightColor: A4BBCB
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: BCD5E9
 				RightColor: B5CEE2
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A7BBCB
 				RightColor: AEC3D5
+				ZOffset: -12
+				ZRamp: 0
 	Template@227:
 		Category: Dirt Road Junctions
 		Id: 227
@@ -3414,24 +4758,38 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8B9EAB
 				RightColor: A5BDCF
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 98A9B4
 				RightColor: 8E9FA9
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: C2DDF2
 				RightColor: B9D1E5
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 9DB0BE
 				RightColor: 83959E
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 97ADBA
 				RightColor: B0C9DC
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: C0DBF2
 				RightColor: B6CEE1
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 8FA4B0
 				RightColor: 91A6B3
+				ZOffset: -12
+				ZRamp: 0
 	Template@228:
 		Category: Dirt Road Junctions
 		Id: 228
@@ -3441,24 +4799,38 @@ Templates:
 			1: DirtRoad
 				LeftColor: 93A8B6
 				RightColor: A4B9CA
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 88949B
 				RightColor: 86959C
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 98ABBA
 				RightColor: 96A8B4
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8A9BA4
 				RightColor: 7D8E97
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 90A0AA
 				RightColor: 95A5B0
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 98ACBA
 				RightColor: 8D9FAA
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 8C9FAA
 				RightColor: 8D9FAB
+				ZOffset: -12
+				ZRamp: 0
 	Template@229:
 		Category: Dirt Road Junctions
 		Id: 229
@@ -3468,42 +4840,68 @@ Templates:
 			2: DirtRoad
 				LeftColor: AFC5DA
 				RightColor: A4B9CB
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 92A2AD
 				RightColor: 93A3AD
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A1B6C3
 				RightColor: 99AFBF
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 88979F
 				RightColor: 8E9FAA
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A0B4C2
 				RightColor: A6BBC9
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 899CA8
 				RightColor: 9FB6C7
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 85939B
 				RightColor: 818F97
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 809099
 				RightColor: 909CA4
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 97A9B5
 				RightColor: 9EAFBD
+				ZOffset: -12
+				ZRamp: 0
 			12: DirtRoad
 				LeftColor: B4C9DA
 				RightColor: 95A7B4
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: A5BACB
 				RightColor: 899BA5
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: A8BED2
 				RightColor: 8C9CA6
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: A2B6C5
 				RightColor: 8F9FA8
+				ZOffset: -12
+				ZRamp: 0
 	Template@230:
 		Category: Straight Dirt Roads
 		Id: 230
@@ -3513,30 +4911,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: A1B8C9
 				RightColor: A8BDCE
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 89959C
 				RightColor: 87959C
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: ADC4D9
 				RightColor: A6BED4
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 929FA9
 				RightColor: 88959E
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: AEC2D3
 				RightColor: A5B8C7
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 9CAFBB
 				RightColor: A6BCCE
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 8FA0AB
 				RightColor: 849299
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: A5B7C3
 				RightColor: AABCC9
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 96ABBC
 				RightColor: 9BB1C5
+				ZOffset: -12
+				ZRamp: 0
 	Template@231:
 		Category: Straight Dirt Roads
 		Id: 231
@@ -3546,30 +4962,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: A2B7C7
 				RightColor: A7B9C8
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8697A0
 				RightColor: 8A979F
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A4B8C6
 				RightColor: 9BB0BF
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 909EA7
 				RightColor: 8A98A0
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 9DB3C1
 				RightColor: 9FB2BF
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 95A8B6
 				RightColor: A3B9CC
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 86949B
 				RightColor: 87949B
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 9BAFC0
 				RightColor: A3B7C3
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: A0B4C4
 				RightColor: A2B8CA
+				ZOffset: -12
+				ZRamp: 0
 	Template@232:
 		Category: Straight Dirt Roads
 		Id: 232
@@ -3579,30 +5013,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: B4CBE0
 				RightColor: A6BCCE
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 94A6B1
 				RightColor: 90A0AA
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B6CFE2
 				RightColor: B7D0E6
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: A6BBC9
 				RightColor: A8BECF
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: B1CAE0
 				RightColor: B0C8D9
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 9DB1BF
 				RightColor: ABC3D7
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: A7BCCC
 				RightColor: AFC6D9
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: AFC8DE
 				RightColor: AFC8DD
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 9DAFBC
 				RightColor: A6BCCB
+				ZOffset: -12
+				ZRamp: 0
 	Template@233:
 		Category: Straight Dirt Roads
 		Id: 233
@@ -3612,39 +5064,63 @@ Templates:
 			0: Clear
 				LeftColor: B8D1E8
 				RightColor: B9D2EB
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: A4BCD0
 				RightColor: A4BDD3
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 91A2AC
 				RightColor: 97ACBC
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8D9DA6
 				RightColor: 8C9AA1
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: B9D3E6
 				RightColor: B4CEE3
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 899BA6
 				RightColor: 8B9BA4
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 899AA4
 				RightColor: 8697A1
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A4BACC
 				RightColor: A6BACB
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 99AAB7
 				RightColor: 9FB2C0
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 89979E
 				RightColor: 81929A
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: A5BAC9
 				RightColor: B6CCDE
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 9BB0C1
 				RightColor: A3B8C6
+				ZOffset: -12
+				ZRamp: 0
 	Template@234:
 		Category: Straight Dirt Roads
 		Id: 234
@@ -3654,21 +5130,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: ADC4D8
 				RightColor: A7BDCF
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 8FA1AB
 				RightColor: 8D9DA5
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9DB0BE
 				RightColor: A9C1D4
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 9EB2C1
 				RightColor: 9FB3C3
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B0C7DC
 				RightColor: ACC2D3
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 9BAEBC
 				RightColor: A2B9CA
+				ZOffset: -12
+				ZRamp: 0
 	Template@235:
 		Category: Straight Dirt Roads
 		Id: 235
@@ -3678,12 +5166,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: A7B8C4
 				RightColor: AABDCC
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 91A0A9
 				RightColor: 879297
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9CAFBC
 				RightColor: A3B7C7
+				ZOffset: -12
+				ZRamp: 0
 	Template@236:
 		Category: Straight Dirt Roads
 		Id: 236
@@ -3693,12 +5187,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: A4B4C0
 				RightColor: AABDCE
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 96A3AB
 				RightColor: 838E93
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A0B2BE
 				RightColor: A6B9C8
+				ZOffset: -12
+				ZRamp: 0
 	Template@237:
 		Category: Straight Dirt Roads
 		Id: 237
@@ -3708,27 +5208,43 @@ Templates:
 			2: Clear
 				LeftColor: BFD6E9
 				RightColor: BED7ED
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B5CBDB
 				RightColor: BDD5EA
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: AFC7DC
 				RightColor: AFC6DA
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: A9C1D7
 				RightColor: B0CBE6
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 97ACBB
 				RightColor: A6BACB
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 93A1A9
 				RightColor: ACBECE
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: BFD5E8
 				RightColor: C0D4E5
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 9DAEB9
 				RightColor: A4B7C3
+				ZOffset: -12
+				ZRamp: 0
 	Template@238:
 		Category: Straight Dirt Roads
 		Id: 238
@@ -3738,30 +5254,48 @@ Templates:
 			1: Clear
 				LeftColor: C2DBEE
 				RightColor: C0DAF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: A5BCCF
 				RightColor: B3CCE2
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: ACC3D9
 				RightColor: ACC6E3
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: ADC1D1
 				RightColor: B5CEE2
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9FB1BE
 				RightColor: 9EB4C5
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: A0B1BE
 				RightColor: A6BBCE
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: ACC2D3
 				RightColor: B3C8D9
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 9FB3BF
 				RightColor: A1B2BE
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: BFD9ED
 				RightColor: B9D2EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@239:
 		Category: Straight Dirt Roads
 		Id: 239
@@ -3771,21 +5305,33 @@ Templates:
 			1: Clear
 				LeftColor: AEC5D6
 				RightColor: B5CEE4
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: AEC4D6
 				RightColor: B4CDE7
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 95A8B5
 				RightColor: A3BACB
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 92A4B0
 				RightColor: 9DB2C2
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B2C9DF
 				RightColor: C0D7E9
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 9CB1C2
 				RightColor: A3BCCF
+				ZOffset: -12
+				ZRamp: 0
 	Template@240:
 		Category: Straight Dirt Roads
 		Id: 240
@@ -3795,30 +5341,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: AEC4D8
 				RightColor: ABBFD1
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9DB0BF
 				RightColor: 90A0AB
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: BCD5E9
 				RightColor: B8D0E5
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: ABC2D5
 				RightColor: A8BDCD
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: ABC2D6
 				RightColor: A2B8CA
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: BBD4E9
 				RightColor: B4CCE1
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: A2B6C7
 				RightColor: ABBFCF
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: ADC3D4
 				RightColor: B4CDE0
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: B7D1E9
 				RightColor: B1C9DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@241:
 		Category: Straight Dirt Roads
 		Id: 241
@@ -3828,30 +5392,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: B3CBE3
 				RightColor: AFC5DA
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A4B5C2
 				RightColor: 94A1A9
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: BBD5EE
 				RightColor: BAD2E9
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: B1C7DA
 				RightColor: AFC4D6
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B3C9DD
 				RightColor: AEC3D5
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: BDD1E6
 				RightColor: B3C8DB
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: B8CEE2
 				RightColor: BAD0E5
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: C4DDF1
 				RightColor: BED6EA
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: C1DBF0
 				RightColor: BCD6ED
+				ZOffset: -12
+				ZRamp: 0
 	Template@242:
 		Category: Straight Dirt Roads
 		Id: 242
@@ -3861,21 +5443,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: B7CCDD
 				RightColor: B2C7D9
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A1AFBA
 				RightColor: 859095
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: BCD4E9
 				RightColor: B8CFE5
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: ADC1D4
 				RightColor: 9DADB8
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A2B6C7
 				RightColor: A5B8C9
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: B7D1EB
 				RightColor: B4CBDE
+				ZOffset: -12
+				ZRamp: 0
 	Template@243:
 		Category: Straight Dirt Roads
 		Id: 243
@@ -3885,33 +5479,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: AAC6DF
 				RightColor: B4CFE8
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 96ABBB
 				RightColor: ACC6DB
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 91A6B2
 				RightColor: 8CA1AE
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 85949C
 				RightColor: 88959D
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9FB1BF
 				RightColor: A9C2D4
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 8999A2
 				RightColor: 7D8E97
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A1B5C4
 				RightColor: 8D9FA9
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: A2BACA
 				RightColor: 9DAFBB
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: B6CEE5
 				RightColor: A2BACD
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 9CAFBB
 				RightColor: 9FAFB9
+				ZOffset: -12
+				ZRamp: 0
 	Template@244:
 		Category: Straight Dirt Roads
 		Id: 244
@@ -3921,33 +5535,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: A8BFD0
 				RightColor: A0B6C8
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 8C9BA4
 				RightColor: 869298
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: ADC6DC
 				RightColor: A7BED1
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 88979F
 				RightColor: 8C9BA3
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A7BCCB
 				RightColor: 9EB3BF
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B4CBE1
 				RightColor: A8B9C7
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A8B7C2
 				RightColor: AABCC9
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 9AADBA
 				RightColor: A6B7C4
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: B2C3D2
 				RightColor: BFD3E7
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: A3B8C6
 				RightColor: BCD3E7
+				ZOffset: -12
+				ZRamp: 0
 	Template@245:
 		Category: Straight Dirt Roads
 		Id: 245
@@ -3957,21 +5591,33 @@ Templates:
 			1: Clear
 				LeftColor: B9D0E4
 				RightColor: BCD5EA
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B8CEE1
 				RightColor: B6CCE0
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: ADC4DA
 				RightColor: B5CDE3
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: B5C7D7
 				RightColor: ACBECF
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B1C7DD
 				RightColor: B1CBE7
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B8D1E9
 				RightColor: BCD3E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@246:
 		Category: Straight Dirt Roads
 		Id: 246
@@ -3981,27 +5627,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 9AACB8
 				RightColor: B8CCDE
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: BBCFDF
 				RightColor: BBCFE1
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: C1D6E9
 				RightColor: B9D3EB
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A1B5C6
 				RightColor: A7C0D7
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A7BED2
 				RightColor: 98AAB5
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: AEC3D2
 				RightColor: 99AAB6
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: A7BCCD
 				RightColor: 95A5B1
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A7BBCC
 				RightColor: 92A2AD
+				ZOffset: -12
+				ZRamp: 0
 	Template@247:
 		Category: Straight Dirt Roads
 		Id: 247
@@ -4011,27 +5673,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 96A8B5
 				RightColor: A9BFCF
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 94A5B1
 				RightColor: 91A3AF
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 92A3AD
 				RightColor: A0B2C0
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 91A3AE
 				RightColor: A9C1D5
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: AEC5D6
 				RightColor: 9DAFBA
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B9D2EB
 				RightColor: A9BECD
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B7D1EA
 				RightColor: A8BDCD
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: B7CFE1
 				RightColor: 95A6B0
+				ZOffset: -12
+				ZRamp: 0
 	Template@248:
 		Category: Straight Dirt Roads
 		Id: 248
@@ -4041,27 +5719,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8FA1AE
 				RightColor: AEC7DE
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9CB2C2
 				RightColor: B1C9E0
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: AFC6DA
 				RightColor: B4CCE1
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 95A7B3
 				RightColor: A8BFD2
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A1B6C6
 				RightColor: 92A6B2
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: AFC6D9
 				RightColor: 9AAEBB
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B1C8DA
 				RightColor: 8EA4B1
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A4BCCE
 				RightColor: 92A3AE
+				ZOffset: -12
+				ZRamp: 0
 	Template@249:
 		Category: Straight Dirt Roads
 		Id: 249
@@ -4071,27 +5765,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8E9FA9
 				RightColor: A6BBCD
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 92A4AF
 				RightColor: 9DB3C5
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7C8E97
 				RightColor: A7BED1
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 95A6B3
 				RightColor: A8C0D3
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B0C5D4
 				RightColor: 8697A0
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A1B7C8
 				RightColor: 8699A3
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: ABC3DA
 				RightColor: 899BA6
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A7BDCF
 				RightColor: 8F9FA8
+				ZOffset: -12
+				ZRamp: 0
 	Template@250:
 		Category: Straight Dirt Roads
 		Id: 250
@@ -4101,21 +5811,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: 92A4B0
 				RightColor: A3B9CB
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 92A5B2
 				RightColor: 9DB3C4
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 93A4B1
 				RightColor: A7BED1
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: AEC3D2
 				RightColor: 92A4B0
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A6BCCD
 				RightColor: 98AEBC
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: ABC2D5
 				RightColor: 91A0A9
+				ZOffset: -12
+				ZRamp: 0
 	Template@251:
 		Category: Straight Dirt Roads
 		Id: 251
@@ -4125,15 +5847,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: A3B7C5
 				RightColor: B8CFE4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: ABBFCE
 				RightColor: B1C9DE
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B4CCE0
 				RightColor: 9EB2C0
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: ABC3D9
 				RightColor: A2B7C8
+				ZOffset: -12
+				ZRamp: 0
 	Template@252:
 		Category: Straight Dirt Roads
 		Id: 252
@@ -4143,9 +5873,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8D9FAB
 				RightColor: AAC2D5
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A7BCCF
 				RightColor: 8FA3B1
+				ZOffset: -12
+				ZRamp: 0
 	Template@253:
 		Category: Straight Dirt Roads
 		Id: 253
@@ -4155,9 +5889,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: 96A8B4
 				RightColor: ADC4D9
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A7BED1
 				RightColor: 98A9B4
+				ZOffset: -12
+				ZRamp: 0
 	Template@254:
 		Category: Straight Dirt Roads
 		Id: 254
@@ -4167,21 +5905,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: 94AABA
 				RightColor: B9D2EA
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: ABC1D4
 				RightColor: BAD1E8
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B5CCE2
 				RightColor: B9D3ED
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B2CBDE
 				RightColor: 94A9B7
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B1C9E2
 				RightColor: 9EB3C4
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B5CDE2
 				RightColor: BDD3E7
+				ZOffset: -12
+				ZRamp: 0
 	Template@255:
 		Category: Straight Dirt Roads
 		Id: 255
@@ -4191,15 +5941,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: A2B9CC
 				RightColor: BBD6EE
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: BBD1E4
 				RightColor: BFD8EE
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: AEC6D9
 				RightColor: A2B7C6
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: B0CAE1
 				RightColor: AFCAE4
+				ZOffset: -12
+				ZRamp: 0
 	Template@256:
 		Category: Straight Dirt Roads
 		Id: 256
@@ -4209,24 +5967,38 @@ Templates:
 			1: Clear
 				LeftColor: BBD2E4
 				RightColor: B9CBDB
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B7CADA
 				RightColor: BBD5EB
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 94A7B3
 				RightColor: B1C8DD
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B2C7D9
 				RightColor: B0C8DB
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B9D3ED
 				RightColor: B9D1E9
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: A9BECD
 				RightColor: 8999A2
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: AAC1D4
 				RightColor: B9CDE0
+				ZOffset: -12
+				ZRamp: 0
 	Template@257:
 		Category: Straight Dirt Roads
 		Id: 257
@@ -4236,21 +6008,33 @@ Templates:
 			0: Clear
 				LeftColor: B8D3EA
 				RightColor: B9D3EC
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A2B8CC
 				RightColor: B0CAE3
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9DB0BE
 				RightColor: B1C9DD
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: C1DCF2
 				RightColor: B7D0E6
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: BFD6E9
 				RightColor: ADC2D3
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: AFC7DB
 				RightColor: 95A8B3
+				ZOffset: -12
+				ZRamp: 0
 	Template@258:
 		Category: Straight Dirt Roads
 		Id: 258
@@ -4260,15 +6044,23 @@ Templates:
 			0: Clear
 				LeftColor: B7D1EB
 				RightColor: B8D3ED
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: AFC2D2
 				RightColor: B1C6D8
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B9D3E8
 				RightColor: B7D0E5
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: BCD4E8
 				RightColor: 9FB2BE
+				ZOffset: -12
+				ZRamp: 0
 	Template@259:
 		Category: Straight Dirt Roads
 		Id: 259
@@ -4278,15 +6070,23 @@ Templates:
 			0: Clear
 				LeftColor: C3D8EC
 				RightColor: B2C9E0
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 98AFBE
 				RightColor: AAC2D7
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: BFD5E9
 				RightColor: BDD0E3
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: BAD1E4
 				RightColor: 97ACB8
+				ZOffset: -12
+				ZRamp: 0
 	Template@260:
 		Category: Straight Dirt Roads
 		Id: 260
@@ -4296,27 +6096,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 9FB3C0
 				RightColor: B7CEE3
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: B0C7DB
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B4CCE0
 				RightColor: 9BB1C0
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A3B7C7
 				RightColor: 8F9EA6
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 9FB0BD
 				RightColor: B4CCDF
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A4B9C7
 				RightColor: B1C9DD
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: C2DCF2
 				RightColor: B6CEE3
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: B2CBE3
 				RightColor: 99AFC0
+				ZOffset: -12
+				ZRamp: 0
 	Template@261:
 		Category: Straight Dirt Roads
 		Id: 261
@@ -4326,27 +6142,43 @@ Templates:
 			2: Clear
 				LeftColor: B5CCE0
 				RightColor: BAD2E6
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9DB0BC
 				RightColor: B0C7DC
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 94A5B0
 				RightColor: ACC1D3
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 94A3AC
 				RightColor: A9BCCB
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: ABBECE
 				RightColor: 9FAEBA
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: ABC0D0
 				RightColor: 99AEBD
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: AFC6DA
 				RightColor: A2B5C4
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: B8D2EB
 				RightColor: B5CEE5
+				ZOffset: -12
+				ZRamp: 0
 	Template@262:
 		Category: Straight Dirt Roads
 		Id: 262
@@ -4356,27 +6188,43 @@ Templates:
 			0: Clear
 				LeftColor: BDD6EC
 				RightColor: BBD3E7
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: B0C5D9
 				RightColor: BBD5EC
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: BBD4E7
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: B9D3EC
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: B9D5F0
 				RightColor: B3CEE9
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: C1DAEE
 				RightColor: AEC3D4
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B4CADC
 				RightColor: B3C8DA
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: B6CFE8
 				RightColor: BBD6F0
+				ZOffset: -12
+				ZRamp: 0
 	Template@263:
 		Category: Straight Dirt Roads
 		Id: 263
@@ -4386,30 +6234,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: B7D0E3
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: BBD6F1
 				RightColor: AEC3D5
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 92A0A8
 				RightColor: 93A5B1
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: AFC6D9
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: C0DBF2
 				RightColor: A7BCCB
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 8B9AA4
 				RightColor: 8799A4
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: B0C7D7
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: BCD6EE
 				RightColor: A5BBCD
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 92A5B1
 				RightColor: 96A8B5
+				ZOffset: -12
+				ZRamp: 0
 	Template@264:
 		Category: Straight Dirt Roads
 		Id: 264
@@ -4419,30 +6285,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: AFC7DC
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: BAD5F0
 				RightColor: A6BCCE
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 93A3AD
 				RightColor: 9FB4C6
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: BAD3E8
 				RightColor: BDD8F0
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: BCD8F1
 				RightColor: ABC0D1
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 9DAFBB
 				RightColor: A4B9CA
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: B2C7D8
 				RightColor: C0DAF1
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: BFDBF2
 				RightColor: B1C7DA
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 94A6B2
 				RightColor: 9AAAB6
+				ZOffset: -12
+				ZRamp: 0
 	Template@265:
 		Category: Straight Dirt Roads
 		Id: 265
@@ -4452,30 +6336,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: B1C4D2
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: C2DCF2
 				RightColor: B3C9DB
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A6BCCF
 				RightColor: A6B9C9
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B0C9DE
 				RightColor: BAD5ED
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: BCD6EE
 				RightColor: B3C9DD
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: A8BDD0
 				RightColor: ACBFCF
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: B7CFE4
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: BAD5EF
 				RightColor: B2CADF
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: A5B8C7
 				RightColor: A7BCCD
+				ZOffset: -12
+				ZRamp: 0
 	Template@266:
 		Category: Straight Dirt Roads
 		Id: 266
@@ -4485,30 +6387,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: AABFD5
 				RightColor: C0DBF2
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B9D4ED
 				RightColor: AFC6D9
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A5B9C9
 				RightColor: 93A5B1
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: AAC0D0
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: C2DCF2
 				RightColor: B1C8DA
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: ABC0D0
 				RightColor: 97A8B4
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: B0C6D9
 				RightColor: B7D2EC
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: C2DDF2
 				RightColor: B8D1E5
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 97AAB8
 				RightColor: 9EB3C4
+				ZOffset: -12
+				ZRamp: 0
 	Template@267:
 		Category: Straight Dirt Roads
 		Id: 267
@@ -4518,21 +6438,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: ACC0CE
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B8D4EE
 				RightColor: A4BACC
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8FA1AB
 				RightColor: 9AAEBB
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A3B8CA
 				RightColor: BBD5EB
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: BED9F1
 				RightColor: ACC2D5
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 92A4B0
 				RightColor: 98A9B4
+				ZOffset: -12
+				ZRamp: 0
 	Template@268:
 		Category: Straight Dirt Roads
 		Id: 268
@@ -4542,12 +6474,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: B3CADF
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B8D3EF
 				RightColor: A4BAD2
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9CB1C7
 				RightColor: A1B7C9
+				ZOffset: -12
+				ZRamp: 0
 	Template@269:
 		Category: Straight Dirt Roads
 		Id: 269
@@ -4557,12 +6495,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: B4CBDE
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: C4DDF1
 				RightColor: B1C6D8
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9EB1BE
 				RightColor: 9AADBB
+				ZOffset: -12
+				ZRamp: 0
 	Template@270:
 		Category: Straight Dirt Roads
 		Id: 270
@@ -4572,30 +6516,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: ADC2D5
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: BFDAF2
 				RightColor: B0C6D7
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A6B7C4
 				RightColor: ADC0CF
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B5CDE5
 				RightColor: B6D1EE
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: C0D9EF
 				RightColor: B8CDE0
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: B1C7D9
 				RightColor: B3C8DB
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: B8D1E8
 				RightColor: BBD5EE
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: C0DAEF
 				RightColor: B5CEE5
+				ZOffset: -12
+				ZRamp: 0
 			15: Clear
 				LeftColor: B7D2ED
 				RightColor: BAD5EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@271:
 		Category: Straight Dirt Roads
 		Id: 271
@@ -4605,33 +6567,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: 97ADC0
 				RightColor: B4CFE9
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: BFDAF2
 				RightColor: ABC3D8
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A5BCD1
 				RightColor: A6BFD5
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B7CEE4
 				RightColor: B8D3EC
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: BFD8ED
 				RightColor: B4CBDE
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: B8CDE1
 				RightColor: B5CDE6
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: BBD3E8
 				RightColor: BDD8EF
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: BBD6EF
 				RightColor: B9D2EA
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: BED3E7
 				RightColor: BAD3E7
+				ZOffset: -12
+				ZRamp: 0
 			18: Clear
 				LeftColor: BFD9F0
 				RightColor: BFD9EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@272:
 		Category: Straight Dirt Roads
 		Id: 272
@@ -4641,21 +6623,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: ACC2D6
 				RightColor: B6D1EF
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: BAD5EE
 				RightColor: A1B5C3
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 91A2AC
 				RightColor: 9EB0BD
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B5CDE2
 				RightColor: BAD4EE
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: C2DCF2
 				RightColor: AFC4D6
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: BCD3E5
 				RightColor: BAD2E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@273:
 		Category: Straight Dirt Roads
 		Id: 273
@@ -4665,30 +6659,48 @@ Templates:
 			1: Clear
 				LeftColor: B6D1EA
 				RightColor: B9D4EF
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: BED9F1
 				RightColor: BED7ED
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B3CBE6
 				RightColor: ADC6DE
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B5CCE0
 				RightColor: C5DAED
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: C4DDF1
 				RightColor: B7CEE4
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 9FB2C1
 				RightColor: A6BCCF
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: B1C8DB
 				RightColor: C3DAEE
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: BCD5EE
 				RightColor: B2C5D5
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: A1B5C5
 				RightColor: 9AABB8
+				ZOffset: -12
+				ZRamp: 0
 	Template@274:
 		Category: Straight Dirt Roads
 		Id: 274
@@ -4698,21 +6710,33 @@ Templates:
 			0: Clear
 				LeftColor: C0DAF1
 				RightColor: C0DAF0
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: B8D3EE
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: BFD9ED
 				RightColor: B0C7DA
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: AEC4D5
 				RightColor: BBD4EC
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: BCD5EE
 				RightColor: B8D2EA
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9CB0BF
 				RightColor: 9BAFC0
+				ZOffset: -12
+				ZRamp: 0
 	Template@275:
 		Category: Straight Dirt Roads
 		Id: 275
@@ -4722,21 +6746,33 @@ Templates:
 			1: Clear
 				LeftColor: BFD9F0
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: C5DEF2
 				RightColor: B3CDE3
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: B1C9E1
 				RightColor: B7D1EA
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B3CDE6
 				RightColor: BCD7F0
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: BDD5EB
 				RightColor: BBD1E5
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 99AEBC
 				RightColor: A4BDD4
+				ZOffset: -12
+				ZRamp: 0
 	Template@276:
 		Category: Straight Dirt Roads
 		Id: 276
@@ -4746,36 +6782,58 @@ Templates:
 			1: DirtRoad
 				LeftColor: 9DB1C0
 				RightColor: BCD5EA
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B4CDE6
 				RightColor: B5D0ED
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: C4DDF1
 				RightColor: A8BDCE
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 97ABBA
 				RightColor: 8B9DA8
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 9BAEBB
 				RightColor: AAC1D3
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: B1C7DC
 				RightColor: B2CCE4
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: BBD3E8
 				RightColor: BCD7EF
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: B7D2EC
 				RightColor: AFCAE8
+				ZOffset: -12
+				ZRamp: 0
 			12: DirtRoad
 				LeftColor: C0DAEF
 				RightColor: AFC3D4
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: AFC6D7
 				RightColor: 9AACB9
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 909EA6
 				RightColor: A6BACA
+				ZOffset: -12
+				ZRamp: 0
 	Template@277:
 		Category: Straight Dirt Roads
 		Id: 277
@@ -4785,33 +6843,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: B0C9E3
 				RightColor: B4CFEE
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B8D0E7
 				RightColor: A0B1BF
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 98A7B2
 				RightColor: B5CDE4
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: C0D9EE
 				RightColor: B8CFE6
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A1B4C3
 				RightColor: 8D9FAB
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: B7D0E7
 				RightColor: BCD7F0
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: B5CCE2
 				RightColor: 9EB1BF
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 95A7B3
 				RightColor: BBD5ED
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: B9D4EE
 				RightColor: B0C8DD
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: A1B4C4
 				RightColor: 95AAB6
+				ZOffset: -12
+				ZRamp: 0
 	Template@278:
 		Category: Straight Dirt Roads
 		Id: 278
@@ -4821,30 +6899,48 @@ Templates:
 			1: Clear
 				LeftColor: BFD8ED
 				RightColor: BED9F1
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: C0DBF2
 				RightColor: BDD8F0
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: ABC2D7
 				RightColor: A9C1D6
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: BCD5EA
 				RightColor: C0D8EE
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: BAD5F0
 				RightColor: B1C9E0
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: B0C6D9
 				RightColor: A4B9CC
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: B3CBDE
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: BDD7EF
 				RightColor: C0D2E3
+				ZOffset: -12
+				ZRamp: 0
 			15: Clear
 				LeftColor: C1D5E6
 				RightColor: B2C9DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@279:
 		Category: Straight Dirt Roads
 		Id: 279
@@ -4854,27 +6950,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: A7BED2
 				RightColor: 95A3AD
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8FA1AE
 				RightColor: A8BED1
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: ADC4D8
 				RightColor: 95A6B2
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9DB0BE
 				RightColor: ABC3D7
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B6CDDF
 				RightColor: 9EB1BF
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9AB0C0
 				RightColor: B0C8DE
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B1C7D9
 				RightColor: 99ABB8
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A0B2BF
 				RightColor: BAD3E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@280:
 		Category: Straight Dirt Roads
 		Id: 280
@@ -4884,27 +6996,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: A6BDCF
 				RightColor: 95A7B3
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 96A8B3
 				RightColor: ABC2D9
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A9C0D2
 				RightColor: 95AAB9
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9DB3C2
 				RightColor: B3CDE1
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A6BFD3
 				RightColor: ABC2D5
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B0C7D7
 				RightColor: B2C9DB
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: AFC5D9
 				RightColor: 8FA2AD
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A6BCCC
 				RightColor: B9D1E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@281:
 		Category: Straight Dirt Roads
 		Id: 281
@@ -4914,27 +7042,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: B1CADC
 				RightColor: 91A6B3
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A0B4C3
 				RightColor: AFC7DD
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B0C7DA
 				RightColor: A1B5C4
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A1B6C7
 				RightColor: B4CEE8
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B1CADF
 				RightColor: A0B4C4
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: A6BAC8
 				RightColor: BCD5E9
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B1C7D9
 				RightColor: 90A5B4
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 9BAEB9
 				RightColor: B8D1E4
+				ZOffset: -12
+				ZRamp: 0
 	Template@282:
 		Category: Straight Dirt Roads
 		Id: 282
@@ -4944,27 +7088,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: ACC4DA
 				RightColor: 94A7B4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 98AAB7
 				RightColor: B8D0E3
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: AEC6DD
 				RightColor: 9AAFC1
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9DB0BD
 				RightColor: A5BACA
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B3C8D8
 				RightColor: A1B5C6
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 8D9EA9
 				RightColor: A4B8C9
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: ACC3D3
 				RightColor: 93A6B2
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A3B5C2
 				RightColor: B8CFE3
+				ZOffset: -12
+				ZRamp: 0
 	Template@283:
 		Category: Straight Dirt Roads
 		Id: 283
@@ -4974,21 +7134,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: ABC3D6
 				RightColor: 91A5B3
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9AACB9
 				RightColor: B2CADD
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: ACC3D7
 				RightColor: 97ABB9
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9FB3C0
 				RightColor: ABC3D6
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: AFC5D7
 				RightColor: 94A8B5
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9DAFBB
 				RightColor: B3CBDE
+				ZOffset: -12
+				ZRamp: 0
 	Template@284:
 		Category: Straight Dirt Roads
 		Id: 284
@@ -4998,15 +7170,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: AAC1D6
 				RightColor: A4B4C0
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 99ABB7
 				RightColor: B3CADD
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: AFC5D8
 				RightColor: 9DB1C0
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A8BBC9
 				RightColor: BBD1E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@285:
 		Category: Straight Dirt Roads
 		Id: 285
@@ -5016,9 +7196,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: AAC1D4
 				RightColor: 95A8B5
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9DAEBA
 				RightColor: B8D0E4
+				ZOffset: -12
+				ZRamp: 0
 	Template@286:
 		Category: Straight Dirt Roads
 		Id: 286
@@ -5028,9 +7212,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: ADC4D6
 				RightColor: 9AADBB
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A1B5C3
 				RightColor: AEC5D9
+				ZOffset: -12
+				ZRamp: 0
 	Template@287:
 		Category: Straight Dirt Roads
 		Id: 287
@@ -5040,27 +7228,43 @@ Templates:
 			0: Clear
 				LeftColor: B9D3ED
 				RightColor: BBD0E5
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: BBD3E9
 				RightColor: BAD5ED
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B9D3EB
 				RightColor: B9D1E6
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: B8D0E5
 				RightColor: B7D0E9
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B8CFE2
 				RightColor: AFC5D7
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: B5CBDD
 				RightColor: B7CFE5
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B0C7DA
 				RightColor: 9DAEBA
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: A9BFCF
 				RightColor: BED7EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@288:
 		Category: Straight Dirt Roads
 		Id: 288
@@ -5070,24 +7274,38 @@ Templates:
 			0: Clear
 				LeftColor: B4CEE5
 				RightColor: B4CEEA
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: BBD6EF
 				RightColor: C0DBF2
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B7CDE0
 				RightColor: A7BBCC
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: ADC3D7
 				RightColor: B9D4EC
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: BBD5EA
 				RightColor: BED8ED
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B4CBDE
 				RightColor: A3B8C8
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 8FA5B4
 				RightColor: A1B9CC
+				ZOffset: -12
+				ZRamp: 0
 	Template@289:
 		Category: Straight Dirt Roads
 		Id: 289
@@ -5097,18 +7315,28 @@ Templates:
 			0: Clear
 				LeftColor: BFD9ED
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B8D3ED
 				RightColor: AFC9E4
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B2CCE5
 				RightColor: BBD5EC
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: ADC7E2
 				RightColor: ADC4D9
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9BB0BF
 				RightColor: ADC6DB
+				ZOffset: -12
+				ZRamp: 0
 	Template@290:
 		Category: Straight Dirt Roads
 		Id: 290
@@ -5118,24 +7346,38 @@ Templates:
 			0: DirtRoad
 				LeftColor: B1CADF
 				RightColor: 97ABBA
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A2B6C5
 				RightColor: B7CFE2
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: BAD2E5
 				RightColor: ABBFD0
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: B1C6D9
 				RightColor: BAD2E8
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: B7D0E6
 				RightColor: B1C9DF
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: BCD6ED
 				RightColor: C0DAEF
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B8D3ED
 				RightColor: B2CCE7
+				ZOffset: -12
+				ZRamp: 0
 	Template@291:
 		Category: Straight Dirt Roads
 		Id: 291
@@ -5145,27 +7387,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: B6CFE3
 				RightColor: 95AAB8
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9CB2C5
 				RightColor: B0CAE5
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: B6CEE4
 				RightColor: A4B8C8
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A0B4C4
 				RightColor: B5CCDF
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: ADC5DB
 				RightColor: 9EB2C2
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B2C7DA
 				RightColor: B5CDE1
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B8D3EC
 				RightColor: A7BCCF
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: BED8ED
 				RightColor: BCD7EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@292:
 		Category: Straight Dirt Roads
 		Id: 292
@@ -5175,15 +7433,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: B7D0E6
 				RightColor: A0B4C4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: B2C5DA
 				RightColor: B7D0E6
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: BBD7F1
 				RightColor: B7D0E8
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: C2DAED
 				RightColor: BED6EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@293:
 		Category: Straight Dirt Roads
 		Id: 293
@@ -5193,27 +7459,43 @@ Templates:
 			1: DirtRoad
 				LeftColor: B8D2EB
 				RightColor: 9AACBB
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9BAFBC
 				RightColor: B0C8DE
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A0B5C7
 				RightColor: A4B6C4
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: ADC4D5
 				RightColor: B8D1E5
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B5CFE7
 				RightColor: B2CADF
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 9CAEBB
 				RightColor: A1B5C5
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: B2CADD
 				RightColor: A1B5C4
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: A0B4C5
 				RightColor: B9D1E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@294:
 		Category: Straight Dirt Roads
 		Id: 294
@@ -5223,27 +7505,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: B8D0E3
 				RightColor: 95A7B4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 96A9B7
 				RightColor: B6D0E5
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: BCD5EC
 				RightColor: BFD2E2
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 99ABB7
 				RightColor: A4BACF
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: B3CADD
 				RightColor: 8FA2AD
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: B0C8E0
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: AEC5D6
 				RightColor: 94A7B5
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: A4B7C9
 				RightColor: B3CDE9
+				ZOffset: -12
+				ZRamp: 0
 	Template@295:
 		Category: Straight Dirt Roads
 		Id: 295
@@ -5253,18 +7551,28 @@ Templates:
 			0: Clear
 				LeftColor: B4CDE5
 				RightColor: B1C9DF
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: B4CADF
 				RightColor: C4DDF1
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: C4DDF1
 				RightColor: B8D0E9
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: AFC4D8
 				RightColor: B7D0E7
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B6D1EA
 				RightColor: AAC4DD
+				ZOffset: -12
+				ZRamp: 0
 	Template@296:
 		Category: Bridges
 		Id: 296
@@ -5275,55 +7583,85 @@ Templates:
 				Height: 4
 				LeftColor: 81878D
 				RightColor: 7D8A96
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 716F6C
 				RightColor: 696B6A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: BFD4E6
 				RightColor: C0DAEF
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 484D4F
 				RightColor: 6B7074
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 454546
 				RightColor: 6C6F71
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B7CBDF
 				RightColor: 94A3AD
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 3E3E3C
 				RightColor: 3F3E3A
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 3F3E39
 				RightColor: 3F3D38
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C0D1E2
 				RightColor: 757A7E
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 697177
 				RightColor: 454748
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 626363
 				RightColor: 454545
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: BED4E6
 				RightColor: 6F7478
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 8694A2
 				RightColor: 797C7F
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: B0C2D1
 				RightColor: 999FA4
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: B7CDE1
 				RightColor: BCD4EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@297:
 		Category: Bridges
 		Id: 297
@@ -5334,55 +7672,85 @@ Templates:
 				Height: 4
 				LeftColor: 81878D
 				RightColor: 7D8A96
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 716F6C
 				RightColor: 67696A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 62758D
 				RightColor: 889DC2
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 484D4F
 				RightColor: 6B7074
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 454546
 				RightColor: 6C6F71
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 7489A8
 				RightColor: 68727F
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 3E3E3C
 				RightColor: 3F3E3A
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 3F3E39
 				RightColor: 3F3D38
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 62748D
 				RightColor: 686C73
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 697177
 				RightColor: 454748
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 626363
 				RightColor: 454545
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 5F7189
 				RightColor: 61656A
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 8593A0
 				RightColor: 7A7E81
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 9DABBD
 				RightColor: 989FA4
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 7A8EB4
 				RightColor: 6C7D9A
+				ZOffset: -12
+				ZRamp: 0
 	Template@298:
 		Category: Bridges
 		Id: 298
@@ -5392,41 +7760,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 81878B
 				RightColor: 7F8C9A
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 464646
 				RightColor: 6D6E6E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 484C4F
 				RightColor: 6C7379
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 3E3E3A
 				RightColor: 3F3F3B
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				Height: 4
 				LeftColor: 3F3E3B
 				RightColor: 3E3F3E
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 606061
 				RightColor: 454545
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 676C70
 				RightColor: 4A5055
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A9AEB1
 				RightColor: 9EA1A0
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 7F8A97
 				RightColor: 767A7F
+				ZOffset: -12
+				ZRamp: 0
 	Template@299:
 		Category: Bridges
 		Id: 299
@@ -5437,55 +7825,85 @@ Templates:
 				Height: 4
 				LeftColor: 73808D
 				RightColor: 71767A
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 747B82
 				RightColor: 505355
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3F3F3B
 				RightColor: 40413E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 45484C
 				RightColor: 6D7379
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 6D7074
 				RightColor: 808D98
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B3BCC3
 				RightColor: 9D9C97
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 5F6061
 				RightColor: 595C5E
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 3F3E3B
 				RightColor: 40403D
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 464646
 				RightColor: 616161
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 9BA8B3
 				RightColor: 949DA2
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: C0DAEF
 				RightColor: C6D9EB
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: BAD5EE
 				RightColor: B8C4CF
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: C4DEF1
 				RightColor: A0A4A5
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: BED4E6
 				RightColor: A0A5A8
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: C0DAEF
 				RightColor: C6D9EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@300:
 		Category: Bridges
 		Id: 300
@@ -5496,55 +7914,85 @@ Templates:
 				Height: 4
 				LeftColor: 73808D
 				RightColor: 71767A
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 747B82
 				RightColor: 505355
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3F3F3B
 				RightColor: 40413E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 45484C
 				RightColor: 6D7379
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 6D7074
 				RightColor: 808D98
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: A4ABB4
 				RightColor: 9D9C97
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 5F6061
 				RightColor: 595C5E
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 3F3E3B
 				RightColor: 40403D
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 464646
 				RightColor: 616161
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 909FAD
 				RightColor: 8D959C
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 7C91B8
 				RightColor: 677897
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 7489A9
 				RightColor: 9AA6B7
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 7689AE
 				RightColor: 919599
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 778AA9
 				RightColor: 969BA0
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 768AB0
 				RightColor: 7585A2
+				ZOffset: -12
+				ZRamp: 0
 	Template@301:
 		Category: Bridges
 		Id: 301
@@ -5554,41 +8002,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 606161
 				RightColor: 565657
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3F3D39
 				RightColor: 3F3D39
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 454545
 				RightColor: 606061
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 848C93
 				RightColor: 7A7D7F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 7F8E9C
 				RightColor: 71777D
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 767A7E
 				RightColor: 4A4B4C
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 42413E
 				RightColor: 42423F
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 4F5050
 				RightColor: 777B7E
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 6E7378
 				RightColor: 747C85
+				ZOffset: -12
+				ZRamp: 0
 	Template@302:
 		Category: Bridges
 		Id: 302
@@ -5598,36 +8066,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 696967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C3D2E0
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 454646
 				RightColor: 6C6E6E
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: C3D1DF
 				RightColor: 97A4AC
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 3F3D39
 				RightColor: 403D38
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BDD0E1
 				RightColor: 717679
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 626262
 				RightColor: 464646
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BFD0E1
 				RightColor: 707578
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B1B7BA
 				RightColor: 989896
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BCD2E6
 				RightColor: B6D1EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@303:
 		Category: Bridges
 		Id: 303
@@ -5637,36 +8125,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 696967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C3D2E0
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3F4141
 				RightColor: 656667
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: C3D1DF
 				RightColor: 97A4AC
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 393936
 				RightColor: 3E3C39
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BDD0E1
 				RightColor: 717679
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4A4A4A
 				RightColor: 414141
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BFD0E1
 				RightColor: 707578
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A3A8AB
 				RightColor: 929290
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: B6D1EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@304:
 		Category: Bridges
 		Id: 304
@@ -5676,36 +8184,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 696967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C0CEDC
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 404040
 				RightColor: 646566
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B2C0CD
 				RightColor: 889299
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 3D3C3A
 				RightColor: 383735
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: AEC1D0
 				RightColor: 6F7477
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 5B5B5B
 				RightColor: 404040
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B8C4D0
 				RightColor: 6B7073
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: AFB4B7
 				RightColor: 90918F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: A5BDD5
+				ZOffset: -12
+				ZRamp: 0
 	Template@305:
 		Category: Bridges
 		Id: 305
@@ -5715,36 +8243,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 686866
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C0CEDC
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 3C3C3D
 				RightColor: 5A5B5C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B2C0CD
 				RightColor: 889299
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				Height: 4
 				LeftColor: 393936
 				RightColor: 3A3835
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: AEC1D0
 				RightColor: 6F7477
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				Height: 4
 				LeftColor: 4B4B4B
 				RightColor: 3D3D3D
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B8C4D0
 				RightColor: 6B7073
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A3A8AB
 				RightColor: 90918F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: A5BDD5
+				ZOffset: -12
+				ZRamp: 0
 	Template@306:
 		Category: Bridges
 		Id: 306
@@ -5754,33 +8302,53 @@ Templates:
 			0: Cliff
 				LeftColor: 7A7977
 				RightColor: 8F9090
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: BCC7D2
 				RightColor: ACBCC8
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 656462
 				RightColor: 6C6C6B
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 798187
 				RightColor: A3B8C9
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6E6D6B
 				RightColor: 858481
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 91A0AC
 				RightColor: 7A868E
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 797875
 				RightColor: 979692
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B4BEC7
 				RightColor: ADC4DA
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: AEB6BB
 				RightColor: A5ABAE
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: A5BBD1
+				ZOffset: -12
+				ZRamp: 0
 	Template@307:
 		Category: Bridges
 		Id: 307
@@ -5790,36 +8358,56 @@ Templates:
 			0: Cliff
 				LeftColor: B8C0C6
 				RightColor: 9D9C98
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 606161
 				RightColor: 565657
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3F3D39
 				RightColor: 3F3D39
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 454545
 				RightColor: 606061
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8C9296
 				RightColor: 878989
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C4DEF1
 				RightColor: C3D4E4
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: BED4E6
 				RightColor: AFBCC7
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C0DAEF
 				RightColor: A3A6A6
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: BAD5EE
 				RightColor: A1A4A5
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD5EE
 				RightColor: BED5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@308:
 		Category: Bridges
 		Id: 308
@@ -5830,32 +8418,50 @@ Templates:
 				Height: 4
 				LeftColor: 585858
 				RightColor: 4E4E4E
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3C3B37
 				RightColor: 3B3A36
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 444444
 				RightColor: 535353
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8C9296
 				RightColor: 888989
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C4DEF1
 				RightColor: B6BDC2
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: BED4E6
 				RightColor: A0A4A5
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C0DAEF
 				RightColor: A3A6A6
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: BAD5EE
 				RightColor: A1A4A5
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD5EE
 				RightColor: BED5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@309:
 		Category: Bridges
 		Id: 309
@@ -5865,36 +8471,56 @@ Templates:
 			0: Cliff
 				LeftColor: 9FA6AA
 				RightColor: 8E8D89
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 565656
 				RightColor: 515151
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3C3A35
 				RightColor: 3E3D39
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 3F3F3F
 				RightColor: 5F6060
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8C9296
 				RightColor: 868888
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: C4DEF1
 				RightColor: B5C5D3
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: B5C9D8
 				RightColor: 9FA9B2
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: B9CFE0
 				RightColor: 949694
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: B7CDE1
 				RightColor: 9B9E9F
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: B9D3ED
 				RightColor: BED5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@310:
 		Category: Bridges
 		Id: 310
@@ -5905,32 +8531,50 @@ Templates:
 				Height: 4
 				LeftColor: 414242
 				RightColor: 4B4B4B
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 363430
 				RightColor: 35332F
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 313131
 				RightColor: 4D4D4D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 84888A
 				RightColor: 838484
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BAD1E3
 				RightColor: A6ACB0
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: B5C9D8
 				RightColor: 8E9192
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B6CBDC
 				RightColor: 929492
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B7CDE1
 				RightColor: A0A3A3
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: B6D0E9
 				RightColor: B0C1D1
+				ZOffset: -12
+				ZRamp: 0
 	Template@311:
 		Category: Bridges
 		Id: 311
@@ -5940,33 +8584,53 @@ Templates:
 			0: Cliff
 				LeftColor: 9EA5AA
 				RightColor: 898987
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 959898
 				RightColor: 969491
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 8F8E87
 				RightColor: 888783
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 959490
 				RightColor: 787776
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 828688
 				RightColor: 8D9499
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BAD1E3
 				RightColor: B4C0CA
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: AEBECA
 				RightColor: 9FAEBC
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: A9B4BD
 				RightColor: 71767D
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B6CCE1
 				RightColor: 9EA6AD
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: B2CBE5
 				RightColor: AEC0D1
+				ZOffset: -12
+				ZRamp: 0
 	Template@312:
 		Category: Paved Roads
 		Id: 312
@@ -5976,12 +8640,18 @@ Templates:
 			0: Road
 				LeftColor: 606970
 				RightColor: 929CA5
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 545959
 				RightColor: 5A5C5A
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 919AA3
 				RightColor: 6C747A
+				ZOffset: -12
+				ZRamp: 0
 	Template@313:
 		Category: Paved Roads
 		Id: 313
@@ -5991,12 +8661,18 @@ Templates:
 			0: Road
 				LeftColor: 9DA3A8
 				RightColor: 626466
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 585752
 				RightColor: 585854
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 6A6A6B
 				RightColor: 9FA4A8
+				ZOffset: -12
+				ZRamp: 0
 	Template@314:
 		Category: Paved Roads
 		Id: 314
@@ -6006,30 +8682,48 @@ Templates:
 			0: Road
 				LeftColor: 5B646C
 				RightColor: 595D60
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 4E5256
 				RightColor: 545454
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 505151
 				RightColor: 6F7780
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 545454
 				RightColor: 4F5050
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 515253
 				RightColor: 4D5358
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 4E5356
 				RightColor: 525659
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 757C81
 				RightColor: 505050
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 545454
 				RightColor: 4A5356
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 666C70
 				RightColor: 5E656A
+				ZOffset: -12
+				ZRamp: 0
 	Template@315:
 		Category: Paved Roads
 		Id: 315
@@ -6039,30 +8733,48 @@ Templates:
 			0: Road
 				LeftColor: 5C636B
 				RightColor: 5A5D61
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 55544F
 				RightColor: 545452
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565656
 				RightColor: 6C757D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 545454
 				RightColor: 545555
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 545652
 				RightColor: 555550
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 555656
 				RightColor: 545759
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 73797F
 				RightColor: 545454
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 585752
 				RightColor: 585854
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 686D70
 				RightColor: 5F656A
+				ZOffset: -12
+				ZRamp: 0
 	Template@316:
 		Category: Paved Roads
 		Id: 316
@@ -6072,30 +8784,48 @@ Templates:
 			0: Road
 				LeftColor: 5B636A
 				RightColor: 595D60
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 535456
 				RightColor: 545454
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 52575A
 				RightColor: 6C757E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 545959
 				RightColor: 5A5C5A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 535452
 				RightColor: 545553
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 535453
 				RightColor: 535553
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 747C82
 				RightColor: 54585B
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 545557
 				RightColor: 52575A
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 656C70
 				RightColor: 61686D
+				ZOffset: -12
+				ZRamp: 0
 	Template@317:
 		Category: Paved Roads
 		Id: 317
@@ -6105,30 +8835,48 @@ Templates:
 			0: Road
 				LeftColor: 606970
 				RightColor: 929CA5
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 798086
 				RightColor: 9CA7AF
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 60696F
 				RightColor: 919BA3
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 545959
 				RightColor: 5A5C5A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 535452
 				RightColor: 545553
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 535453
 				RightColor: 535553
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 747C82
 				RightColor: 54585B
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 545557
 				RightColor: 52575A
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 656C70
 				RightColor: 61686D
+				ZOffset: -12
+				ZRamp: 0
 	Template@318:
 		Category: Paved Roads
 		Id: 318
@@ -6138,30 +8886,48 @@ Templates:
 			0: Road
 				LeftColor: 5C636B
 				RightColor: 5A5D61
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 55544F
 				RightColor: 545452
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 656A6F
 				RightColor: 959FA8
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 545454
 				RightColor: 545555
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 545652
 				RightColor: 555550
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 646567
 				RightColor: A7ABAF
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 73797F
 				RightColor: 545454
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 585752
 				RightColor: 585854
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 676869
 				RightColor: 9B9FA2
+				ZOffset: -12
+				ZRamp: 0
 	Template@319:
 		Category: Paved Roads
 		Id: 319
@@ -6171,30 +8937,48 @@ Templates:
 			0: Road
 				LeftColor: 5B636A
 				RightColor: 595D60
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 535456
 				RightColor: 545454
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 52575A
 				RightColor: 6C757E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 545959
 				RightColor: 5A5C5A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 535452
 				RightColor: 545553
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 535453
 				RightColor: 535553
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 919AA3
 				RightColor: 6C747A
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 8E98A1
 				RightColor: 6B7176
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 8D98A1
 				RightColor: 626C73
+				ZOffset: -12
+				ZRamp: 0
 	Template@320:
 		Category: Paved Roads
 		Id: 320
@@ -6204,30 +8988,48 @@ Templates:
 			0: Road
 				LeftColor: 9EA6AB
 				RightColor: 646768
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 55544F
 				RightColor: 545452
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565656
 				RightColor: 6C757D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 999EA3
 				RightColor: 67696B
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 545652
 				RightColor: 555550
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 555656
 				RightColor: 545759
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 9DA3A8
 				RightColor: 626466
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 585752
 				RightColor: 585854
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 686D70
 				RightColor: 5F656A
+				ZOffset: -12
+				ZRamp: 0
 	Template@321:
 		Category: Paved Roads
 		Id: 321
@@ -6237,39 +9039,63 @@ Templates:
 			0: Clear
 				LeftColor: C4D7E5
 				RightColor: C3D5E4
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: B5C3D0
 				RightColor: C6D1DD
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B6C5D2
 				RightColor: B6C5D3
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 9FAEBA
 				RightColor: 93A2AD
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: BCD3E7
 				RightColor: BECEDD
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: BBCBD9
 				RightColor: BECDDC
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: B3BBC2
 				RightColor: 9DA8AD
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 71797B
 				RightColor: 777D7D
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: C2DAEC
 				RightColor: BBCCDB
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: C2D6E8
 				RightColor: C1CFDA
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: B5CADD
 				RightColor: BBC5D0
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: B0BCC7
 				RightColor: 727E85
+				ZOffset: -12
+				ZRamp: 0
 	Template@322:
 		Category: Paved Roads
 		Id: 322
@@ -6279,39 +9105,63 @@ Templates:
 			0: Road
 				LeftColor: 727B80
 				RightColor: A2AEB6
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A6ADB3
 				RightColor: B6C3CF
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: B7C5D1
 				RightColor: BFCFDF
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: C5D6E5
 				RightColor: C7DDEF
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 595E5E
 				RightColor: 73797B
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 969A9C
 				RightColor: A6A9AC
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: BCC3C9
 				RightColor: C0C7CE
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: C7D3E0
 				RightColor: C6DAEA
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 919AA3
 				RightColor: 848D93
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: B4C2CF
 				RightColor: B2BFC9
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: C0CFDD
 				RightColor: B7C7D6
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: BFD4E7
 				RightColor: C0D4E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@323:
 		Category: Paved Roads
 		Id: 323
@@ -6321,39 +9171,63 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7A858D
 				RightColor: BDCBD9
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 727E87
 				RightColor: 717980
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 535556
 				RightColor: 7F858B
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 73797E
 				RightColor: 929EA8
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 5A5F60
 				RightColor: 606361
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 585754
 				RightColor: 4F4E4B
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 4B4A46
 				RightColor: 4E4C4A
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 575652
 				RightColor: 575856
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 939FA8
 				RightColor: 96A5B2
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: ABBDCC
 				RightColor: 616364
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: 65696D
 				RightColor: 5B5C5C
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 8F989F
 				RightColor: 7B8389
+				ZOffset: -12
+				ZRamp: 0
 	Template@324:
 		Category: Paved Roads
 		Id: 324
@@ -6363,39 +9237,63 @@ Templates:
 			0: DirtRoad
 				LeftColor: B5C0C9
 				RightColor: 6B7073
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 585853
 				RightColor: 565652
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 6C7378
 				RightColor: 929DA6
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: B4C5D3
 				RightColor: 848E97
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 596364
 				RightColor: 697478
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: ABB5BD
 				RightColor: B2BCC2
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: ADB9C3
 				RightColor: 829099
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 737E81
 				RightColor: 717D87
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 82898E
 				RightColor: A8B6C2
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: C1D5E9
 				RightColor: B6C2CE
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: BCCCDA
 				RightColor: 9EAAB1
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: B5C2CE
 				RightColor: C1CDD8
+				ZOffset: -12
+				ZRamp: 0
 	Template@325:
 		Category: Paved Roads
 		Id: 325
@@ -6405,39 +9303,63 @@ Templates:
 			0: Clear
 				LeftColor: B7D1EA
 				RightColor: B6D1EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: BED4E6
 				RightColor: B5CCE2
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: ABC1D3
 				RightColor: B4CDE3
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: BCCFDE
 				RightColor: B1C3D3
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: B3C3D0
 				RightColor: B8C8D7
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: ACBECD
 				RightColor: BCCEE1
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: A9B6C1
 				RightColor: A7B5C0
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 879093
 				RightColor: 99A6AF
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 8E9497
 				RightColor: B7C9DA
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 9DA3A8
 				RightColor: 747576
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 585752
 				RightColor: 5D5D59
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 6E6F6F
 				RightColor: A1A6AA
+				ZOffset: -12
+				ZRamp: 0
 	Template@326:
 		Category: Paved Roads
 		Id: 326
@@ -6447,39 +9369,63 @@ Templates:
 			0: Clear
 				LeftColor: A8B3BB
 				RightColor: 727578
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 585855
 				RightColor: 54524C
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 788288
 				RightColor: A5AAAE
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: B2BBC5
 				RightColor: 6A7073
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 565956
 				RightColor: 4E4F4F
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 7C858A
 				RightColor: AEBBC4
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: B8C8D5
 				RightColor: 8F989E
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 72777A
 				RightColor: 535350
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 8C9499
 				RightColor: ADB8BF
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 9EADBA
 				RightColor: 8E979F
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 6D6F6F
 				RightColor: 747B7E
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 72787B
 				RightColor: 9EAEBD
+				ZOffset: -12
+				ZRamp: 0
 	Template@327:
 		Category: Paved Roads
 		Id: 327
@@ -6489,51 +9435,83 @@ Templates:
 			0: Road
 				LeftColor: 606970
 				RightColor: 929CA5
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 7A8287
 				RightColor: 9DA8B0
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 60696F
 				RightColor: 919BA3
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 717E86
 				RightColor: 92A0AC
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 555959
 				RightColor: 5B5E5B
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 5B5B59
 				RightColor: 565654
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 535453
 				RightColor: 535553
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 565B5C
 				RightColor: 535858
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 8F99A0
 				RightColor: 737C84
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 8E9BA3
 				RightColor: 7C848A
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 909CA5
 				RightColor: 6A747B
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 9EABB7
 				RightColor: 6A767E
+				ZOffset: -12
+				ZRamp: 0
 			12: DirtRoad
 				LeftColor: 96A8B5
 				RightColor: 9DB4C4
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 93A5B0
 				RightColor: 9EB2C1
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: B1C9DE
 				RightColor: BED4E6
+				ZOffset: -12
+				ZRamp: 0
 			17: DirtRoad
 				LeftColor: 9CB1C2
 				RightColor: A3BCCF
+				ZOffset: -12
+				ZRamp: 0
 	Template@328:
 		Category: Paved Roads
 		Id: 328
@@ -6543,45 +9521,73 @@ Templates:
 			1: DirtRoad
 				LeftColor: A1B6C6
 				RightColor: A6B9C7
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 84959E
 				RightColor: 89969E
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 626C72
 				RightColor: 97A1AB
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 848D92
 				RightColor: 9AA7AF
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 747E83
 				RightColor: 929EA5
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 79868D
 				RightColor: 92A0AC
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 545959
 				RightColor: 5D605D
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 696965
 				RightColor: 666663
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 555655
 				RightColor: 5F615F
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 5C6366
 				RightColor: 555A5A
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 919AA3
 				RightColor: 6C747A
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 8F9AA2
 				RightColor: 7A8185
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: 99A2A9
 				RightColor: 677077
+				ZOffset: -12
+				ZRamp: 0
 			15: Road
 				LeftColor: 9AA6B1
 				RightColor: 646E76
+				ZOffset: -12
+				ZRamp: 0
 	Template@329:
 		Category: Paved Roads
 		Id: 329
@@ -6591,51 +9597,83 @@ Templates:
 			1: DirtRoad
 				LeftColor: AFC7D9
 				RightColor: 91A5B2
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9AACBA
 				RightColor: B6D0E5
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 606970
 				RightColor: A3ADB8
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 9EA6AD
 				RightColor: B5BEC8
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 7A848F
 				RightColor: 949FA8
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 727F87
 				RightColor: 92A0AC
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 545959
 				RightColor: 5E615F
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 707375
 				RightColor: 808388
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 777A7F
 				RightColor: 6A6F71
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 585E60
 				RightColor: 535959
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 919AA3
 				RightColor: 737B82
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: A2ACB5
 				RightColor: 888F94
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: A9B4BE
 				RightColor: 818A95
+				ZOffset: -12
+				ZRamp: 0
 			15: Road
 				LeftColor: A8B4C1
 				RightColor: 69757D
+				ZOffset: -12
+				ZRamp: 0
 			17: DirtRoad
 				LeftColor: AEC5D6
 				RightColor: 92A6B3
+				ZOffset: -12
+				ZRamp: 0
 			18: DirtRoad
 				LeftColor: 9CAFBB
 				RightColor: B7D0E4
+				ZOffset: -12
+				ZRamp: 0
 	Template@330:
 		Category: Paved Roads
 		Id: 330
@@ -6645,51 +9683,83 @@ Templates:
 			2: Road
 				LeftColor: 9FA9B1
 				RightColor: 6D7174
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 5B5A56
 				RightColor: 565653
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 656A6F
 				RightColor: 959FA8
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: A4B4C0
 				RightColor: A5B9C9
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 9CA3A7
 				RightColor: 797B7C
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 595853
 				RightColor: 555653
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 646667
 				RightColor: A7ABAF
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: A7B8C4
 				RightColor: AABDCC
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 91A0A9
 				RightColor: 869197
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 94999C
 				RightColor: 747779
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 5C5E5A
 				RightColor: 5A5A56
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: 676969
 				RightColor: 9B9FA2
+				ZOffset: -12
+				ZRamp: 0
 			16: DirtRoad
 				LeftColor: 9BAEBB
 				RightColor: A1B4C4
+				ZOffset: -12
+				ZRamp: 0
 			17: Road
 				LeftColor: 9BA1A5
 				RightColor: 727475
+				ZOffset: -12
+				ZRamp: 0
 			18: Road
 				LeftColor: 5C5B56
 				RightColor: 595955
+				ZOffset: -12
+				ZRamp: 0
 			19: Road
 				LeftColor: 6A6A6B
 				RightColor: 9FA4A8
+				ZOffset: -12
+				ZRamp: 0
 	Template@331:
 		Category: Paved Roads
 		Id: 331
@@ -6699,45 +9769,73 @@ Templates:
 			0: Road
 				LeftColor: 9FA9B1
 				RightColor: 6B6F72
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 5A5955
 				RightColor: 575753
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 6C7175
 				RightColor: 959FA8
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 9EA6AB
 				RightColor: 646768
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 575651
 				RightColor: 575754
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 737576
 				RightColor: 9B9FA1
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 93A0A7
 				RightColor: 838D92
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 9BA0A4
 				RightColor: 696C6D
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 575954
 				RightColor: 5D5C57
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 737475
 				RightColor: 96999B
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: A0B2C0
 				RightColor: A5B8C8
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 9DA3A8
 				RightColor: 656768
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 585752
 				RightColor: 585854
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: 6C6D6D
 				RightColor: A0A5A8
+				ZOffset: -12
+				ZRamp: 0
 	Template@332:
 		Category: Paved Roads
 		Id: 332
@@ -6747,51 +9845,83 @@ Templates:
 			1: Road
 				LeftColor: B6C0C8
 				RightColor: 7A7E81
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 5D5C58
 				RightColor: 5B5B57
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 7A8187
 				RightColor: 959FA8
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 94A6B2
 				RightColor: ABC0D2
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 96A0A7
 				RightColor: 939799
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 6F6F6D
 				RightColor: 6B6D70
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 848687
 				RightColor: B7BFC5
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 9DB1BD
 				RightColor: B0C7DD
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: A6BDD0
 				RightColor: 94A5B0
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 8C9397
 				RightColor: 898E91
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 626564
 				RightColor: 6F7172
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 888B8D
 				RightColor: A0A5A9
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: A9BECE
 				RightColor: 99AEBE
+				ZOffset: -12
+				ZRamp: 0
 			16: Road
 				LeftColor: 9DA3A8
 				RightColor: 6A6C6E
+				ZOffset: -12
+				ZRamp: 0
 			17: Road
 				LeftColor: 5B5A55
 				RightColor: 5A5A56
+				ZOffset: -12
+				ZRamp: 0
 			18: Road
 				LeftColor: 737474
 				RightColor: B9BEC3
+				ZOffset: -12
+				ZRamp: 0
 	Template@333:
 		Category: Water
 		Id: 333
@@ -6801,15 +9931,23 @@ Templates:
 			0: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 29373F
 				RightColor: 29373F
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 28373F
 				RightColor: 293841
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 28373F
 				RightColor: 29373F
+				ZOffset: -12
+				ZRamp: 0
 	Template@334:
 		Category: Water
 		Id: 334
@@ -6819,15 +9957,23 @@ Templates:
 			0: Water
 				LeftColor: 293740
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 2B3A43
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 	Template@335:
 		Category: Water
 		Id: 335
@@ -6837,15 +9983,23 @@ Templates:
 			0: Water
 				LeftColor: 2B3B43
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 28373F
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 293840
 				RightColor: 2C3C44
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 2A3A42
 				RightColor: 28373F
+				ZOffset: -12
+				ZRamp: 0
 	Template@336:
 		Category: Water
 		Id: 336
@@ -6855,15 +10009,23 @@ Templates:
 			0: Water
 				LeftColor: 293840
 				RightColor: 28373F
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 28373F
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 	Template@337:
 		Category: Water
 		Id: 337
@@ -6873,15 +10035,23 @@ Templates:
 			0: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 293840
 				RightColor: 28373F
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 293740
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 	Template@338:
 		Category: Water
 		Id: 338
@@ -6891,15 +10061,23 @@ Templates:
 			0: Water
 				LeftColor: 28373F
 				RightColor: 29373F
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 28373F
 				RightColor: 293841
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 29373F
 				RightColor: 29373F
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 293840
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 	Template@339:
 		Category: Water
 		Id: 339
@@ -6909,15 +10087,23 @@ Templates:
 			0: Cliff
 				LeftColor: 4E5E68
 				RightColor: 495862
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 3D4D58
 				RightColor: 293941
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 29373F
 				RightColor: 2F3E47
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 2A3941
 				RightColor: 2A3941
+				ZOffset: -12
+				ZRamp: 0
 	Template@340:
 		Category: Water
 		Id: 340
@@ -6927,15 +10113,23 @@ Templates:
 			0: Cliff
 				LeftColor: 455763
 				RightColor: 475660
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 32414C
 				RightColor: 293941
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 293840
 				RightColor: 2D3C46
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 34444F
 				RightColor: 4A5A67
+				ZOffset: -12
+				ZRamp: 0
 	Template@341:
 		Category: Water
 		Id: 341
@@ -6945,6 +10139,8 @@ Templates:
 			0: Water
 				LeftColor: 2A3941
 				RightColor: 293841
+				ZOffset: -12
+				ZRamp: 0
 	Template@342:
 		Category: Water
 		Id: 342
@@ -6954,6 +10150,8 @@ Templates:
 			0: Water
 				LeftColor: 293841
 				RightColor: 293941
+				ZOffset: -12
+				ZRamp: 0
 	Template@343:
 		Category: Water
 		Id: 343
@@ -6963,6 +10161,8 @@ Templates:
 			0: Water
 				LeftColor: 2B3B44
 				RightColor: 2A3A42
+				ZOffset: -12
+				ZRamp: 0
 	Template@344:
 		Category: Water
 		Id: 344
@@ -6972,6 +10172,8 @@ Templates:
 			0: Water
 				LeftColor: 293840
 				RightColor: 28373F
+				ZOffset: -12
+				ZRamp: 0
 	Template@345:
 		Category: Water
 		Id: 345
@@ -6981,6 +10183,8 @@ Templates:
 			0: Water
 				LeftColor: 28373F
 				RightColor: 293840
+				ZOffset: -12
+				ZRamp: 0
 	Template@346:
 		Category: Water
 		Id: 346
@@ -6990,6 +10194,8 @@ Templates:
 			0: Cliff
 				LeftColor: 394954
 				RightColor: 3B4C59
+				ZOffset: -12
+				ZRamp: 0
 	Template@387:
 		Category: Dirt Road Slopes
 		Id: 387
@@ -7000,10 +10206,14 @@ Templates:
 				RampType: 1
 				LeftColor: AAB8C1
 				RightColor: BCCED8
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 1
 				LeftColor: C5D7E1
 				RightColor: C0D2DF
+				ZOffset: -12
+				ZRamp: 0
 	Template@388:
 		Category: Dirt Road Slopes
 		Id: 388
@@ -7014,10 +10224,14 @@ Templates:
 				RampType: 1
 				LeftColor: A5B5BF
 				RightColor: C1D5E1
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 1
 				LeftColor: C5D9E6
 				RightColor: B8CBD9
+				ZOffset: -12
+				ZRamp: 0
 	Template@389:
 		Category: Dirt Road Slopes
 		Id: 389
@@ -7028,10 +10242,14 @@ Templates:
 				RampType: 2
 				LeftColor: 9DB7D3
 				RightColor: 8BA3B4
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 2
 				LeftColor: 9AB2CC
 				RightColor: 9CB6D4
+				ZOffset: -12
+				ZRamp: 0
 	Template@390:
 		Category: Dirt Road Slopes
 		Id: 390
@@ -7042,10 +10260,14 @@ Templates:
 				RampType: 2
 				LeftColor: 9DB4D5
 				RightColor: 90A4B5
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 2
 				LeftColor: 97AFC4
 				RightColor: 9CB4D1
+				ZOffset: -12
+				ZRamp: 0
 	Template@391:
 		Category: Dirt Road Slopes
 		Id: 391
@@ -7056,10 +10278,14 @@ Templates:
 				RampType: 3
 				LeftColor: 9AB1C4
 				RightColor: A0B5C9
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 3
 				LeftColor: A5BCD5
 				RightColor: 93A9BD
+				ZOffset: -12
+				ZRamp: 0
 	Template@392:
 		Category: Dirt Road Slopes
 		Id: 392
@@ -7070,10 +10296,14 @@ Templates:
 				RampType: 3
 				LeftColor: 98ABB9
 				RightColor: A3B9CE
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 3
 				LeftColor: A8C0D6
 				RightColor: 93A8B7
+				ZOffset: -12
+				ZRamp: 0
 	Template@393:
 		Category: Dirt Road Slopes
 		Id: 393
@@ -7084,10 +10314,14 @@ Templates:
 				RampType: 4
 				LeftColor: C8D8E2
 				RightColor: A5B3BC
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 4
 				LeftColor: ACBDCA
 				RightColor: C3D5E2
+				ZOffset: -12
+				ZRamp: 0
 	Template@394:
 		Category: Dirt Road Slopes
 		Id: 394
@@ -7098,10 +10332,14 @@ Templates:
 				RampType: 4
 				LeftColor: CAD9E2
 				RightColor: B4C2CC
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 4
 				LeftColor: B7C9D5
 				RightColor: C5D8E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@403:
 		Category: Slope Set Pieces
 		Id: 403
@@ -7113,45 +10351,65 @@ Templates:
 				RampType: 11
 				LeftColor: B2CAE2
 				RightColor: C2D9EC
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 3
 				RampType: 4
 				LeftColor: CADBE8
 				RightColor: B9CFE2
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 8D9FAE
 				RightColor: 8497A6
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 3
 				RampType: 3
 				LeftColor: 99B0CF
 				RightColor: A7BEDD
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				Height: 2
 				RampType: 4
 				LeftColor: C9DDEB
 				RightColor: CADEEE
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: BCD7F0
 				RightColor: ACC1D5
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				RampType: 1
 				LeftColor: D9EAF3
 				RightColor: CDDFEB
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				Height: 1
 				RampType: 4
 				LeftColor: C5D7E2
 				RightColor: B8CBDA
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				RampType: 8
 				LeftColor: BED9F1
 				RightColor: E0EDF5
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				RampType: 4
 				LeftColor: CADFEF
 				RightColor: C7DAE8
+				ZOffset: -12
+				ZRamp: 0
 	Template@404:
 		Category: Slope Set Pieces
 		Id: 404
@@ -7163,45 +10421,65 @@ Templates:
 				RampType: 4
 				LeftColor: CBE0EE
 				RightColor: CCDEEB
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 3
 				RampType: 12
 				LeftColor: C7DCE9
 				RightColor: BFD8EE
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				Height: 2
 				RampType: 4
 				LeftColor: D1E4EF
 				RightColor: C1D5E3
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 3
 				RampType: 1
 				LeftColor: ADC3D4
 				RightColor: C6DAE9
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 8799A9
 				RightColor: 869AB1
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				Height: 1
 				RampType: 4
 				LeftColor: CCDFEB
 				RightColor: CEE0EC
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				RampType: 3
 				LeftColor: A6BED8
 				RightColor: 9FB6CC
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B3CCE5
 				RightColor: A5BACD
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				RampType: 4
 				LeftColor: CDE1EF
 				RightColor: C5D9E8
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				RampType: 7
 				LeftColor: C3DBEE
 				RightColor: BCD2E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@405:
 		Category: Slope Set Pieces
 		Id: 405
@@ -7213,45 +10491,65 @@ Templates:
 				RampType: 3
 				LeftColor: A2BBE0
 				RightColor: B1CCE8
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 2
 				RampType: 3
 				LeftColor: 9BB4CD
 				RightColor: A6BFD9
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 1
 				RampType: 3
 				LeftColor: ACC2D9
 				RightColor: A9C3E1
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				RampType: 3
 				LeftColor: AFCAE6
 				RightColor: A9C4E0
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				Height: 3
 				RampType: 10
 				LeftColor: BAD5EE
 				RightColor: A3BDE0
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 3
 				RampType: 2
 				LeftColor: 9FB9D4
 				RightColor: 9CB6D1
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				RampType: 4
 				LeftColor: D0E5F2
 				RightColor: A8BFD0
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				RampType: 7
 				LeftColor: C6E0F2
 				RightColor: BFD8EC
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 8DA1B4
 				RightColor: 8698A8
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: ADC5DD
 				RightColor: 8BA7C0
+				ZOffset: -12
+				ZRamp: 0
 	Template@406:
 		Category: Slope Set Pieces
 		Id: 406
@@ -7262,46 +10560,66 @@ Templates:
 				Height: 4
 				LeftColor: 899EB0
 				RightColor: 8696A4
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 86A2C1
 				RightColor: 87A2B8
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				Height: 3
 				RampType: 11
 				LeftColor: B5CEE7
 				RightColor: CCE2F2
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 3
 				RampType: 4
 				LeftColor: CFE2ED
 				RightColor: B7CDDC
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				RampType: 2
 				LeftColor: A4BEE1
 				RightColor: 9FB9DD
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				RampType: 6
 				LeftColor: A4BEE0
 				RightColor: BDD9F1
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				Height: 3
 				RampType: 3
 				LeftColor: AFCAE7
 				RightColor: A2BDDE
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				Height: 2
 				RampType: 3
 				LeftColor: A7C2E1
 				RightColor: B0C8E1
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				Height: 1
 				RampType: 3
 				LeftColor: ADC5DB
 				RightColor: 94AEC5
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				RampType: 3
 				LeftColor: A7C2E0
 				RightColor: ACC6E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@407:
 		Category: Slope Set Pieces
 		Id: 407
@@ -7312,45 +10630,65 @@ Templates:
 				RampType: 5
 				LeftColor: ABC4DF
 				RightColor: AAC4E3
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				RampType: 2
 				LeftColor: 9BB6D6
 				RightColor: A4C0E0
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 9FB7DC
 				RightColor: A1B7D3
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 9DB8D7
 				RightColor: 9FB9D9
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				Height: 1
 				RampType: 2
 				LeftColor: A3BEDF
 				RightColor: A2BCDD
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				Height: 4
 				LeftColor: 8393A6
 				RightColor: 748295
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				Height: 3
 				RampType: 3
 				LeftColor: 98AFC9
 				RightColor: A2BAD5
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				Height: 2
 				RampType: 2
 				LeftColor: 9DB8D7
 				RightColor: 9DB4D3
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				Height: 3
 				RampType: 10
 				LeftColor: BBD5ED
 				RightColor: 9EB6E0
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				Height: 3
 				RampType: 2
 				LeftColor: A0B9DC
 				RightColor: 9EB9DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@408:
 		Category: Slope Set Pieces
 		Id: 408
@@ -7361,32 +10699,46 @@ Templates:
 				RampType: 2
 				LeftColor: 95AFC9
 				RightColor: A3BCE0
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				RampType: 6
 				LeftColor: A3BDE2
 				RightColor: BCD7F0
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				Height: 1
 				RampType: 2
 				LeftColor: 9AB5D4
 				RightColor: 95B0CB
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				RampType: 3
 				LeftColor: A8C3E6
 				RightColor: A7C1E5
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BBD7F1
 				RightColor: C2DDF3
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				Height: 2
 				RampType: 2
 				LeftColor: 9EB7DB
 				RightColor: 9FB9DA
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				Height: 3
 				RampType: 2
 				LeftColor: ABC4E1
 				RightColor: A1B9DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@409:
 		Category: Slope Set Pieces
 		Id: 409
@@ -7398,15 +10750,21 @@ Templates:
 				RampType: 1
 				LeftColor: C4DBED
 				RightColor: B7CBDD
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 8899A8
 				RightColor: 8899AA
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 3
 				RampType: 9
 				LeftColor: BED9F0
 				RightColor: C3DEF2
+				ZOffset: -12
+				ZRamp: 0
 	Template@410:
 		Category: Slope Set Pieces
 		Id: 410
@@ -7416,46 +10774,66 @@ Templates:
 			1: Cliff
 				LeftColor: B2C5D3
 				RightColor: C4D7E5
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8797A5
 				RightColor: 8699AC
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				RampType: 5
 				LeftColor: C9E0EF
 				RightColor: BED5EA
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: D4E5EF
 				RightColor: CADEEB
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				Height: 3
 				RampType: 4
 				LeftColor: B6CBDA
 				RightColor: C7D7E2
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				Height: 3
 				RampType: 12
 				LeftColor: C7DAE7
 				RightColor: BDD8F0
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				RampType: 1
 				LeftColor: D2E5F1
 				RightColor: D1E5F1
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				Height: 1
 				RampType: 1
 				LeftColor: D2E5F0
 				RightColor: D2E4EE
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				Height: 2
 				RampType: 1
 				LeftColor: D4E5EF
 				RightColor: BACDDA
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				Height: 3
 				RampType: 1
 				LeftColor: CCE3F1
 				RightColor: BED5E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@411:
 		Category: Slope Set Pieces
 		Id: 411
@@ -7466,32 +10844,46 @@ Templates:
 				RampType: 1
 				LeftColor: D2E2EC
 				RightColor: C7D7E2
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 1
 				RampType: 1
 				LeftColor: C4D3DE
 				RightColor: CEE1ED
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 2
 				RampType: 1
 				LeftColor: D3E5F0
 				RightColor: CEE2EE
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				Height: 3
 				RampType: 1
 				LeftColor: D1E8F5
 				RightColor: CCE3F2
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				RampType: 8
 				LeftColor: BFD8ED
 				RightColor: DBE7EE
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				RampType: 4
 				LeftColor: BED2E7
 				RightColor: C9DCEA
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C4DDF1
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 	Template@412:
 		Category: Slope Set Pieces
 		Id: 412
@@ -7503,15 +10895,21 @@ Templates:
 				RampType: 2
 				LeftColor: B5CCE1
 				RightColor: ACC7E7
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 3
 				RampType: 9
 				LeftColor: B6D2EF
 				RightColor: B0CCE9
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 7C8D9F
 				RightColor: 8092A1
+				ZOffset: -12
+				ZRamp: 0
 	Template@423:
 		Category: Dead Oil Tanker
 		Id: 423
@@ -7521,81 +10919,131 @@ Templates:
 			0: Cliff
 				LeftColor: A1B2C2
 				RightColor: 778189
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 565C60
 				RightColor: B0C6DA
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				RampType: 4
 				LeftColor: A6B8C8
 				RightColor: B8CDE0
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				RampType: 12
 				LeftColor: 777E85
 				RightColor: 9BABB7
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 3E4E58
 				RightColor: 79858D
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 52575A
 				RightColor: 545556
+				ZOffset: -12
+				ZRamp: 0
 			7: Water
 				LeftColor: 717D8A
 				RightColor: 70818F
+				ZOffset: -12
+				ZRamp: 0
 			8: Water
 				RampType: 8
 				LeftColor: 4F5A63
 				RightColor: 8E9EAA
+				ZOffset: -12
+				ZRamp: 0
 			10: Water
 				LeftColor: 293840
 				RightColor: 314149
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 3B4950
 				RightColor: 525657
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 454D51
 				RightColor: 63737E
+				ZOffset: -12
+				ZRamp: 0
 			13: Water
 				LeftColor: 37454C
 				RightColor: 35434C
+				ZOffset: -12
+				ZRamp: 0
 			16: Water
 				LeftColor: 293840
 				RightColor: 2C3A42
+				ZOffset: -12
+				ZRamp: 0
 			17: Cliff
 				LeftColor: 354249
 				RightColor: 3B4951
+				ZOffset: -12
+				ZRamp: 0
 			18: Water
 				LeftColor: 303D44
 				RightColor: 2A3840
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: 303C43
 				RightColor: 3A444C
+				ZOffset: -12
+				ZRamp: 0
 			23: Cliff
 				LeftColor: 40484E
 				RightColor: 3B4951
+				ZOffset: -12
+				ZRamp: 0
 			27: Cliff
 				LeftColor: 37454D
 				RightColor: 323E44
+				ZOffset: -12
+				ZRamp: 0
 			28: Cliff
 				LeftColor: 4B4C4D
 				RightColor: 434649
+				ZOffset: -12
+				ZRamp: 0
 			29: Water
 				LeftColor: 2A373E
 				RightColor: 28373F
+				ZOffset: -12
+				ZRamp: 0
 			32: Cliff
 				LeftColor: 293840
 				RightColor: 4C5A64
+				ZOffset: -12
+				ZRamp: 0
 			33: Cliff
 				LeftColor: 454D53
 				RightColor: 515152
+				ZOffset: -12
+				ZRamp: 0
 			34: Cliff
 				LeftColor: 34373A
 				RightColor: 27333B
+				ZOffset: -12
+				ZRamp: 0
 			38: Cliff
 				LeftColor: 293840
 				RightColor: 464D50
+				ZOffset: -12
+				ZRamp: 0
 			39: Cliff
 				LeftColor: 313538
 				RightColor: 32363A
+				ZOffset: -12
+				ZRamp: 0
 	Template@424:
 		Category: Ruins
 		Id: 424
@@ -7605,24 +11053,38 @@ Templates:
 			1: Cliff
 				LeftColor: 747677
 				RightColor: 6C7680
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 788691
 				RightColor: 8392A0
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 707A82
 				RightColor: 666F77
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 75818D
 				RightColor: 828F9A
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: B1BDC8
 				RightColor: 878788
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B6C1C7
 				RightColor: B7BBBD
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C0CCD8
 				RightColor: 828D97
+				ZOffset: -12
+				ZRamp: 0
 	Template@435:
 		Category: Waterfalls
 		Id: 435
@@ -7633,30 +11095,46 @@ Templates:
 				Height: 4
 				LeftColor: 8593A0
 				RightColor: 77838C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 4E5860
 				RightColor: 3C4751
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 7A8B9C
 				RightColor: 7B8A9A
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 687B90
 				RightColor: 4E5C65
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: A9BFD3
 				RightColor: A1B5C7
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 455662
 				RightColor: 70879B
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: B3CADD
 				RightColor: 99A7B4
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 667580
 				RightColor: 38454E
+				ZOffset: -12
+				ZRamp: 0
 	Template@436:
 		Category: Waterfalls
 		Id: 436
@@ -7667,16 +11145,24 @@ Templates:
 				Height: 4
 				LeftColor: 2C373D
 				RightColor: 263138
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 656D72
 				RightColor: 576065
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: A9B8C2
 				RightColor: ABB8C2
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 485862
 				RightColor: 738690
+				ZOffset: -12
+				ZRamp: 0
 	Template@437:
 		Category: Waterfalls
 		Id: 437
@@ -7687,30 +11173,46 @@ Templates:
 				Height: 4
 				LeftColor: 333F46
 				RightColor: 28343A
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 424E55
 				RightColor: 253036
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 80868D
 				RightColor: 485258
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 70797E
 				RightColor: 505C63
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: A0B1BC
 				RightColor: CED7DF
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C1CCD5
 				RightColor: B6C3D0
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 445560
 				RightColor: 728691
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 62737E
 				RightColor: 798B96
+				ZOffset: -12
+				ZRamp: 0
 	Template@438:
 		Category: Waterfalls
 		Id: 438
@@ -7721,30 +11223,46 @@ Templates:
 				Height: 4
 				LeftColor: 2B3339
 				RightColor: 444D52
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 838E9A
 				RightColor: 8494A4
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 6C7378
 				RightColor: 38434A
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 79838B
 				RightColor: 94A2AF
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: B7C1C8
 				RightColor: A8B7C2
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B4C9DE
 				RightColor: 859BAC
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 475863
 				RightColor: 798A95
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: A1AFBB
 				RightColor: B0C2D3
+				ZOffset: -12
+				ZRamp: 0
 	Template@439:
 		Category: Ice 01
 		Id: 439
@@ -7754,6 +11272,8 @@ Templates:
 			0: Clear
 				LeftColor: AFCBED
 				RightColor: B0CCED
+				ZOffset: -12
+				ZRamp: 0
 	Template@440:
 		Category: Ice 01
 		Id: 440
@@ -7763,6 +11283,8 @@ Templates:
 			0: Clear
 				LeftColor: AAC4EA
 				RightColor: ABC6EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@441:
 		Category: Ice 01
 		Id: 441
@@ -7772,6 +11294,8 @@ Templates:
 			0: Clear
 				LeftColor: AECAEC
 				RightColor: A5BEE7
+				ZOffset: -12
+				ZRamp: 0
 	Template@442:
 		Category: Ice 01
 		Id: 442
@@ -7781,6 +11305,8 @@ Templates:
 			0: Clear
 				LeftColor: ADC8EC
 				RightColor: A7C1E8
+				ZOffset: -12
+				ZRamp: 0
 	Template@443:
 		Category: Ice 01
 		Id: 443
@@ -7790,6 +11316,8 @@ Templates:
 			0: Clear
 				LeftColor: ABC6EB
 				RightColor: 9EB5E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@444:
 		Category: Ice 01
 		Id: 444
@@ -7799,6 +11327,8 @@ Templates:
 			0: Clear
 				LeftColor: A2BBE6
 				RightColor: ACC7EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@445:
 		Category: Ice 01
 		Id: 445
@@ -7808,6 +11338,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BFE8
 				RightColor: A5BFE8
+				ZOffset: -12
+				ZRamp: 0
 	Template@446:
 		Category: Ice 01
 		Id: 446
@@ -7817,6 +11349,8 @@ Templates:
 			0: Clear
 				LeftColor: A2BBE6
 				RightColor: A6BFE7
+				ZOffset: -12
+				ZRamp: 0
 	Template@447:
 		Category: Ice 01
 		Id: 447
@@ -7826,6 +11360,8 @@ Templates:
 			0: Clear
 				LeftColor: A8C3EA
 				RightColor: 9EB5E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@448:
 		Category: Ice 01
 		Id: 448
@@ -7835,6 +11371,8 @@ Templates:
 			0: Clear
 				LeftColor: A4BEE8
 				RightColor: ADC9EC
+				ZOffset: -12
+				ZRamp: 0
 	Template@449:
 		Category: Ice 01
 		Id: 449
@@ -7844,6 +11382,8 @@ Templates:
 			0: Clear
 				LeftColor: A4BEE8
 				RightColor: A6C0E9
+				ZOffset: -12
+				ZRamp: 0
 	Template@450:
 		Category: Ice 01
 		Id: 450
@@ -7853,6 +11393,8 @@ Templates:
 			0: Clear
 				LeftColor: A3BDE7
 				RightColor: A6C0E8
+				ZOffset: -12
+				ZRamp: 0
 	Template@451:
 		Category: Ice 01
 		Id: 451
@@ -7862,6 +11404,8 @@ Templates:
 			0: Clear
 				LeftColor: A6C0E9
 				RightColor: 9DB4E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@452:
 		Category: Ice 01
 		Id: 452
@@ -7871,6 +11415,8 @@ Templates:
 			0: Clear
 				LeftColor: 9DB5E4
 				RightColor: AEC9EC
+				ZOffset: -12
+				ZRamp: 0
 	Template@453:
 		Category: Ice 01
 		Id: 453
@@ -7880,6 +11426,8 @@ Templates:
 			0: Clear
 				LeftColor: 9EB6E4
 				RightColor: A5BEE8
+				ZOffset: -12
+				ZRamp: 0
 	Template@454:
 		Category: Ice 01
 		Id: 454
@@ -7889,6 +11437,8 @@ Templates:
 			0: Clear
 				LeftColor: 9DB4E3
 				RightColor: A6BFE7
+				ZOffset: -12
+				ZRamp: 0
 	Template@455:
 		Category: Ice 01
 		Id: 455
@@ -7898,6 +11448,8 @@ Templates:
 			0: Clear
 				LeftColor: 9AB0E1
 				RightColor: 98AEE0
+				ZOffset: -12
+				ZRamp: 0
 	Template@456:
 		Category: Ice 01
 		Id: 456
@@ -7907,6 +11459,8 @@ Templates:
 			0: Clear
 				LeftColor: 415160
 				RightColor: 677895
+				ZOffset: -12
+				ZRamp: 0
 	Template@457:
 		Category: Ice 01
 		Id: 457
@@ -7916,6 +11470,8 @@ Templates:
 			0: Clear
 				LeftColor: 3E4F5F
 				RightColor: 637693
+				ZOffset: -12
+				ZRamp: 0
 	Template@458:
 		Category: Ice 01
 		Id: 458
@@ -7925,6 +11481,8 @@ Templates:
 			0: Clear
 				LeftColor: 475769
 				RightColor: 8195BB
+				ZOffset: -12
+				ZRamp: 0
 	Template@459:
 		Category: Ice 01
 		Id: 459
@@ -7934,6 +11492,8 @@ Templates:
 			0: Clear
 				LeftColor: 6B7D9F
 				RightColor: 3F505F
+				ZOffset: -12
+				ZRamp: 0
 	Template@460:
 		Category: Ice 01
 		Id: 460
@@ -7943,6 +11503,8 @@ Templates:
 			0: Clear
 				LeftColor: 7386A9
 				RightColor: 7384A6
+				ZOffset: -12
+				ZRamp: 0
 	Template@461:
 		Category: Ice 01
 		Id: 461
@@ -7952,6 +11514,8 @@ Templates:
 			0: Clear
 				LeftColor: 6B7D9F
 				RightColor: 677A99
+				ZOffset: -12
+				ZRamp: 0
 	Template@462:
 		Category: Ice 01
 		Id: 462
@@ -7961,6 +11525,8 @@ Templates:
 			0: Clear
 				LeftColor: 7385A8
 				RightColor: 8598C1
+				ZOffset: -12
+				ZRamp: 0
 	Template@463:
 		Category: Ice 01
 		Id: 463
@@ -7970,6 +11536,8 @@ Templates:
 			0: Clear
 				LeftColor: 596A80
 				RightColor: 3A4B57
+				ZOffset: -12
+				ZRamp: 0
 	Template@464:
 		Category: Ice 01
 		Id: 464
@@ -7979,6 +11547,8 @@ Templates:
 			0: Clear
 				LeftColor: 596B82
 				RightColor: 677895
+				ZOffset: -12
+				ZRamp: 0
 	Template@465:
 		Category: Ice 01
 		Id: 465
@@ -7988,6 +11558,8 @@ Templates:
 			0: Clear
 				LeftColor: 5F7189
 				RightColor: 6A7E9C
+				ZOffset: -12
+				ZRamp: 0
 	Template@466:
 		Category: Ice 01
 		Id: 466
@@ -7997,6 +11569,8 @@ Templates:
 			0: Clear
 				LeftColor: 60728B
 				RightColor: 8195BB
+				ZOffset: -12
+				ZRamp: 0
 	Template@467:
 		Category: Ice 01
 		Id: 467
@@ -8006,6 +11580,8 @@ Templates:
 			0: Clear
 				LeftColor: 7E91B9
 				RightColor: 465768
+				ZOffset: -12
+				ZRamp: 0
 	Template@468:
 		Category: Ice 01
 		Id: 468
@@ -8015,6 +11591,8 @@ Templates:
 			0: Clear
 				LeftColor: 7F93BB
 				RightColor: 7284A6
+				ZOffset: -12
+				ZRamp: 0
 	Template@469:
 		Category: Ice 01
 		Id: 469
@@ -8024,6 +11602,8 @@ Templates:
 			0: Clear
 				LeftColor: 7E91B9
 				RightColor: 6E82A2
+				ZOffset: -12
+				ZRamp: 0
 	Template@470:
 		Category: Ice 01
 		Id: 470
@@ -8033,6 +11613,8 @@ Templates:
 			0: Clear
 				LeftColor: 7F92BA
 				RightColor: 8397BF
+				ZOffset: -12
+				ZRamp: 0
 	Template@471:
 		Category: Ice 01
 		Id: 471
@@ -8042,6 +11624,8 @@ Templates:
 			0: Clear
 				LeftColor: 475769
 				RightColor: 7183A5
+				ZOffset: -12
+				ZRamp: 0
 	Template@472:
 		Category: Ice 01
 		Id: 472
@@ -8051,6 +11635,8 @@ Templates:
 			0: Clear
 				LeftColor: 475869
 				RightColor: 637693
+				ZOffset: -12
+				ZRamp: 0
 	Template@473:
 		Category: Ice 01
 		Id: 473
@@ -8060,6 +11646,8 @@ Templates:
 			0: Clear
 				LeftColor: 506073
 				RightColor: 8195BB
+				ZOffset: -12
+				ZRamp: 0
 	Template@474:
 		Category: Ice 01
 		Id: 474
@@ -8069,6 +11657,8 @@ Templates:
 			0: Clear
 				LeftColor: 7083A5
 				RightColor: 465667
+				ZOffset: -12
+				ZRamp: 0
 	Template@475:
 		Category: Ice 01
 		Id: 475
@@ -8078,6 +11668,8 @@ Templates:
 			0: Clear
 				LeftColor: 7183A6
 				RightColor: 6E81A1
+				ZOffset: -12
+				ZRamp: 0
 	Template@476:
 		Category: Ice 01
 		Id: 476
@@ -8087,6 +11679,8 @@ Templates:
 			0: Clear
 				LeftColor: 596A80
 				RightColor: 4F6074
+				ZOffset: -12
+				ZRamp: 0
 	Template@477:
 		Category: Ice 01
 		Id: 477
@@ -8096,6 +11690,8 @@ Templates:
 			0: Clear
 				LeftColor: 5F718B
 				RightColor: 7182A5
+				ZOffset: -12
+				ZRamp: 0
 	Template@478:
 		Category: Ice 01
 		Id: 478
@@ -8105,6 +11701,8 @@ Templates:
 			0: Clear
 				LeftColor: 7E91B9
 				RightColor: 5B6C85
+				ZOffset: -12
+				ZRamp: 0
 	Template@479:
 		Category: Ice 01
 		Id: 479
@@ -8114,6 +11712,8 @@ Templates:
 			0: Clear
 				LeftColor: 495A6A
 				RightColor: 677895
+				ZOffset: -12
+				ZRamp: 0
 	Template@480:
 		Category: Ice 01
 		Id: 480
@@ -8123,6 +11723,8 @@ Templates:
 			0: Clear
 				LeftColor: 445566
 				RightColor: 6A7D9B
+				ZOffset: -12
+				ZRamp: 0
 	Template@481:
 		Category: Ice 01
 		Id: 481
@@ -8132,6 +11734,8 @@ Templates:
 			0: Clear
 				LeftColor: 6B7D9F
 				RightColor: 54657C
+				ZOffset: -12
+				ZRamp: 0
 	Template@482:
 		Category: Ice 01
 		Id: 482
@@ -8141,6 +11745,8 @@ Templates:
 			0: Clear
 				LeftColor: 5F7189
 				RightColor: 455666
+				ZOffset: -12
+				ZRamp: 0
 	Template@483:
 		Category: Ice 01
 		Id: 483
@@ -8150,6 +11756,8 @@ Templates:
 			0: Clear
 				LeftColor: 506073
 				RightColor: 7183A5
+				ZOffset: -12
+				ZRamp: 0
 	Template@484:
 		Category: Ice 01
 		Id: 484
@@ -8159,6 +11767,8 @@ Templates:
 			0: Clear
 				LeftColor: 4D5D70
 				RightColor: 6A7D9B
+				ZOffset: -12
+				ZRamp: 0
 	Template@485:
 		Category: Ice 01
 		Id: 485
@@ -8168,6 +11778,8 @@ Templates:
 			0: Clear
 				LeftColor: 7083A5
 				RightColor: 5A6B84
+				ZOffset: -12
+				ZRamp: 0
 	Template@486:
 		Category: Ice 01
 		Id: 486
@@ -8177,6 +11789,8 @@ Templates:
 			0: Clear
 				LeftColor: 5F7189
 				RightColor: 596B83
+				ZOffset: -12
+				ZRamp: 0
 	Template@487:
 		Category: Ice 01
 		Id: 487
@@ -8186,6 +11800,8 @@ Templates:
 			0: Clear
 				LeftColor: 3E4E5D
 				RightColor: 3A4A56
+				ZOffset: -12
+				ZRamp: 0
 	Template@488:
 		Category: Ice 01
 		Id: 488
@@ -8195,6 +11811,8 @@ Templates:
 			0: Clear
 				LeftColor: 384856
 				RightColor: 48586B
+				ZOffset: -12
+				ZRamp: 0
 	Template@489:
 		Category: Ice 01
 		Id: 489
@@ -8204,6 +11822,8 @@ Templates:
 			0: Clear
 				LeftColor: 3E4F5F
 				RightColor: 3E4E5E
+				ZOffset: -12
+				ZRamp: 0
 	Template@490:
 		Category: Ice 01
 		Id: 490
@@ -8213,6 +11833,8 @@ Templates:
 			0: Clear
 				LeftColor: 415160
 				RightColor: 33444E
+				ZOffset: -12
+				ZRamp: 0
 	Template@491:
 		Category: Ice 01
 		Id: 491
@@ -8222,6 +11844,8 @@ Templates:
 			0: Clear
 				LeftColor: 3E4E5D
 				RightColor: 4E5F73
+				ZOffset: -12
+				ZRamp: 0
 	Template@492:
 		Category: Ice 01
 		Id: 492
@@ -8231,6 +11855,8 @@ Templates:
 			0: Clear
 				LeftColor: 3E4F5F
 				RightColor: 52637B
+				ZOffset: -12
+				ZRamp: 0
 	Template@493:
 		Category: Ice 01
 		Id: 493
@@ -8240,6 +11866,8 @@ Templates:
 			0: Clear
 				LeftColor: 475869
 				RightColor: 3E4E5E
+				ZOffset: -12
+				ZRamp: 0
 	Template@494:
 		Category: Ice 01
 		Id: 494
@@ -8249,6 +11877,8 @@ Templates:
 			0: Clear
 				LeftColor: 475767
 				RightColor: 3A4A56
+				ZOffset: -12
+				ZRamp: 0
 	Template@495:
 		Category: Ice 01
 		Id: 495
@@ -8258,6 +11888,8 @@ Templates:
 			0: Clear
 				LeftColor: 445566
 				RightColor: 596A82
+				ZOffset: -12
+				ZRamp: 0
 	Template@496:
 		Category: Ice 01
 		Id: 496
@@ -8267,6 +11899,8 @@ Templates:
 			0: Clear
 				LeftColor: 475869
 				RightColor: 52637B
+				ZOffset: -12
+				ZRamp: 0
 	Template@497:
 		Category: Ice 01
 		Id: 497
@@ -8276,6 +11910,8 @@ Templates:
 			0: Clear
 				LeftColor: 4D5D70
 				RightColor: 445565
+				ZOffset: -12
+				ZRamp: 0
 	Template@498:
 		Category: Ice 01
 		Id: 498
@@ -8285,6 +11921,8 @@ Templates:
 			0: Clear
 				LeftColor: 475767
 				RightColor: 4E5F73
+				ZOffset: -12
+				ZRamp: 0
 	Template@499:
 		Category: Ice 01
 		Id: 499
@@ -8294,6 +11932,8 @@ Templates:
 			0: Clear
 				LeftColor: 445566
 				RightColor: 445565
+				ZOffset: -12
+				ZRamp: 0
 	Template@500:
 		Category: Ice 01
 		Id: 500
@@ -8303,6 +11943,8 @@ Templates:
 			0: Clear
 				LeftColor: 415160
 				RightColor: 48586B
+				ZOffset: -12
+				ZRamp: 0
 	Template@501:
 		Category: Ice 01
 		Id: 501
@@ -8312,6 +11954,8 @@ Templates:
 			0: Clear
 				LeftColor: 4D5D70
 				RightColor: 596A82
+				ZOffset: -12
+				ZRamp: 0
 	Template@502:
 		Category: Ice 01
 		Id: 502
@@ -8321,6 +11965,8 @@ Templates:
 			0: Clear
 				LeftColor: 2B3B43
 				RightColor: 2A3A42
+				ZOffset: -12
+				ZRamp: 0
 	Template@503:
 		Category: Ice 02
 		Id: 503
@@ -8330,6 +11976,8 @@ Templates:
 			0: Clear
 				LeftColor: B2CEEE
 				RightColor: B5D0EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@504:
 		Category: Ice 02
 		Id: 504
@@ -8339,6 +11987,8 @@ Templates:
 			0: Clear
 				LeftColor: ADC8EB
 				RightColor: ADC7EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@505:
 		Category: Ice 02
 		Id: 505
@@ -8348,6 +11998,8 @@ Templates:
 			0: Clear
 				LeftColor: AFCAEC
 				RightColor: A7C0E8
+				ZOffset: -12
+				ZRamp: 0
 	Template@506:
 		Category: Ice 02
 		Id: 506
@@ -8357,6 +12009,8 @@ Templates:
 			0: Clear
 				LeftColor: B0CBED
 				RightColor: A5BFE8
+				ZOffset: -12
+				ZRamp: 0
 	Template@507:
 		Category: Ice 02
 		Id: 507
@@ -8366,6 +12020,8 @@ Templates:
 			0: Clear
 				LeftColor: ADC8EC
 				RightColor: 9EB6E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@508:
 		Category: Ice 02
 		Id: 508
@@ -8375,6 +12031,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BEE8
 				RightColor: B0CBED
+				ZOffset: -12
+				ZRamp: 0
 	Template@509:
 		Category: Ice 02
 		Id: 509
@@ -8384,6 +12042,8 @@ Templates:
 			0: Clear
 				LeftColor: A6C0E9
 				RightColor: A9C3EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@510:
 		Category: Ice 02
 		Id: 510
@@ -8393,6 +12053,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BEE8
 				RightColor: A5BFE8
+				ZOffset: -12
+				ZRamp: 0
 	Template@511:
 		Category: Ice 02
 		Id: 511
@@ -8402,6 +12064,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BEE7
 				RightColor: 9CB4E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@512:
 		Category: Ice 02
 		Id: 512
@@ -8411,6 +12075,8 @@ Templates:
 			0: Clear
 				LeftColor: A4BDE7
 				RightColor: B0CBED
+				ZOffset: -12
+				ZRamp: 0
 	Template@513:
 		Category: Ice 02
 		Id: 513
@@ -8420,6 +12086,8 @@ Templates:
 			0: Clear
 				LeftColor: A4BDE7
 				RightColor: A7C0E8
+				ZOffset: -12
+				ZRamp: 0
 	Template@514:
 		Category: Ice 02
 		Id: 514
@@ -8429,6 +12097,8 @@ Templates:
 			0: Clear
 				LeftColor: A6C0E8
 				RightColor: A6C0E9
+				ZOffset: -12
+				ZRamp: 0
 	Template@515:
 		Category: Ice 02
 		Id: 515
@@ -8438,6 +12108,8 @@ Templates:
 			0: Clear
 				LeftColor: A6C0E8
 				RightColor: A0B8E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@516:
 		Category: Ice 02
 		Id: 516
@@ -8447,6 +12119,8 @@ Templates:
 			0: Clear
 				LeftColor: 9EB6E4
 				RightColor: ADC8EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@517:
 		Category: Ice 02
 		Id: 517
@@ -8456,6 +12130,8 @@ Templates:
 			0: Clear
 				LeftColor: 9FB7E5
 				RightColor: A9C3EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@518:
 		Category: Ice 02
 		Id: 518
@@ -8465,6 +12141,8 @@ Templates:
 			0: Clear
 				LeftColor: 9FB7E5
 				RightColor: A6C0E9
+				ZOffset: -12
+				ZRamp: 0
 	Template@519:
 		Category: Ice 02
 		Id: 519
@@ -8474,6 +12152,8 @@ Templates:
 			0: Clear
 				LeftColor: 99B0E0
 				RightColor: 99B0E0
+				ZOffset: -12
+				ZRamp: 0
 	Template@520:
 		Category: Ice 02
 		Id: 520
@@ -8483,6 +12163,8 @@ Templates:
 			0: Clear
 				LeftColor: 404F61
 				RightColor: 697B9E
+				ZOffset: -12
+				ZRamp: 0
 	Template@521:
 		Category: Ice 02
 		Id: 521
@@ -8492,6 +12174,8 @@ Templates:
 			0: Clear
 				LeftColor: 3B4C58
 				RightColor: 647896
+				ZOffset: -12
+				ZRamp: 0
 	Template@522:
 		Category: Ice 02
 		Id: 522
@@ -8501,6 +12185,8 @@ Templates:
 			0: Clear
 				LeftColor: 4E5F74
 				RightColor: 8A9FCD
+				ZOffset: -12
+				ZRamp: 0
 	Template@523:
 		Category: Ice 02
 		Id: 523
@@ -8510,6 +12196,8 @@ Templates:
 			0: Clear
 				LeftColor: 697C9D
 				RightColor: 344450
+				ZOffset: -12
+				ZRamp: 0
 	Template@524:
 		Category: Ice 02
 		Id: 524
@@ -8519,6 +12207,8 @@ Templates:
 			0: Clear
 				LeftColor: 798DB5
 				RightColor: 7386AD
+				ZOffset: -12
+				ZRamp: 0
 	Template@525:
 		Category: Ice 02
 		Id: 525
@@ -8528,6 +12218,8 @@ Templates:
 			0: Clear
 				LeftColor: 6A7E9E
 				RightColor: 647795
+				ZOffset: -12
+				ZRamp: 0
 	Template@526:
 		Category: Ice 02
 		Id: 526
@@ -8537,6 +12229,8 @@ Templates:
 			0: Clear
 				LeftColor: 7B8FB7
 				RightColor: 8A9FCD
+				ZOffset: -12
+				ZRamp: 0
 	Template@527:
 		Category: Ice 02
 		Id: 527
@@ -8546,6 +12240,8 @@ Templates:
 			0: Clear
 				LeftColor: 516379
 				RightColor: 2B3B44
+				ZOffset: -12
+				ZRamp: 0
 	Template@528:
 		Category: Ice 02
 		Id: 528
@@ -8555,6 +12251,8 @@ Templates:
 			0: Clear
 				LeftColor: 54677E
 				RightColor: 697B9E
+				ZOffset: -12
+				ZRamp: 0
 	Template@529:
 		Category: Ice 02
 		Id: 529
@@ -8564,6 +12262,8 @@ Templates:
 			0: Clear
 				LeftColor: 5D7089
 				RightColor: 667998
+				ZOffset: -12
+				ZRamp: 0
 	Template@530:
 		Category: Ice 02
 		Id: 530
@@ -8573,6 +12273,8 @@ Templates:
 			0: Clear
 				LeftColor: 5F738D
 				RightColor: 8A9FCD
+				ZOffset: -12
+				ZRamp: 0
 	Template@531:
 		Category: Ice 02
 		Id: 531
@@ -8582,6 +12284,8 @@ Templates:
 			0: Clear
 				LeftColor: 7D92B8
 				RightColor: 364754
+				ZOffset: -12
+				ZRamp: 0
 	Template@532:
 		Category: Ice 02
 		Id: 532
@@ -8591,6 +12295,8 @@ Templates:
 			0: Clear
 				LeftColor: 7E93BB
 				RightColor: 7386AD
+				ZOffset: -12
+				ZRamp: 0
 	Template@533:
 		Category: Ice 02
 		Id: 533
@@ -8600,6 +12306,8 @@ Templates:
 			0: Clear
 				LeftColor: 7D92B9
 				RightColor: 667998
+				ZOffset: -12
+				ZRamp: 0
 	Template@534:
 		Category: Ice 02
 		Id: 534
@@ -8609,6 +12317,8 @@ Templates:
 			0: Clear
 				LeftColor: 7F94BC
 				RightColor: 8A9FCD
+				ZOffset: -12
+				ZRamp: 0
 	Template@535:
 		Category: Ice 02
 		Id: 535
@@ -8618,6 +12328,8 @@ Templates:
 			0: Clear
 				LeftColor: 4A5A6E
 				RightColor: 7487AE
+				ZOffset: -12
+				ZRamp: 0
 	Template@536:
 		Category: Ice 02
 		Id: 536
@@ -8627,6 +12339,8 @@ Templates:
 			0: Clear
 				LeftColor: 425463
 				RightColor: 647896
+				ZOffset: -12
+				ZRamp: 0
 	Template@537:
 		Category: Ice 02
 		Id: 537
@@ -8636,6 +12350,8 @@ Templates:
 			0: Clear
 				LeftColor: 566780
 				RightColor: 8A9FCD
+				ZOffset: -12
+				ZRamp: 0
 	Template@538:
 		Category: Ice 02
 		Id: 538
@@ -8645,6 +12361,8 @@ Templates:
 			0: Clear
 				LeftColor: 7589AE
 				RightColor: 364754
+				ZOffset: -12
+				ZRamp: 0
 	Template@539:
 		Category: Ice 02
 		Id: 539
@@ -8654,6 +12372,8 @@ Templates:
 			0: Clear
 				LeftColor: 768AB0
 				RightColor: 667A99
+				ZOffset: -12
+				ZRamp: 0
 	Template@540:
 		Category: Ice 02
 		Id: 540
@@ -8663,6 +12383,8 @@ Templates:
 			0: Clear
 				LeftColor: 516379
 				RightColor: 3A4B5A
+				ZOffset: -12
+				ZRamp: 0
 	Template@541:
 		Category: Ice 02
 		Id: 541
@@ -8672,6 +12394,8 @@ Templates:
 			0: Clear
 				LeftColor: 5E718B
 				RightColor: 7487AE
+				ZOffset: -12
+				ZRamp: 0
 	Template@542:
 		Category: Ice 02
 		Id: 542
@@ -8681,6 +12405,8 @@ Templates:
 			0: Clear
 				LeftColor: 7D92B8
 				RightColor: 45566A
+				ZOffset: -12
+				ZRamp: 0
 	Template@543:
 		Category: Ice 02
 		Id: 543
@@ -8690,6 +12416,8 @@ Templates:
 			0: Clear
 				LeftColor: 4A5B70
 				RightColor: 697B9E
+				ZOffset: -12
+				ZRamp: 0
 	Template@544:
 		Category: Ice 02
 		Id: 544
@@ -8699,6 +12427,8 @@ Templates:
 			0: Clear
 				LeftColor: 47596B
 				RightColor: 667A99
+				ZOffset: -12
+				ZRamp: 0
 	Template@545:
 		Category: Ice 02
 		Id: 545
@@ -8708,6 +12438,8 @@ Templates:
 			0: Clear
 				LeftColor: 697C9D
 				RightColor: 435467
+				ZOffset: -12
+				ZRamp: 0
 	Template@546:
 		Category: Ice 02
 		Id: 546
@@ -8717,6 +12449,8 @@ Templates:
 			0: Clear
 				LeftColor: 5B6F87
 				RightColor: 374855
+				ZOffset: -12
+				ZRamp: 0
 	Template@547:
 		Category: Ice 02
 		Id: 547
@@ -8726,6 +12460,8 @@ Templates:
 			0: Clear
 				LeftColor: 54657D
 				RightColor: 7487AE
+				ZOffset: -12
+				ZRamp: 0
 	Template@548:
 		Category: Ice 02
 		Id: 548
@@ -8735,6 +12471,8 @@ Templates:
 			0: Clear
 				LeftColor: 4F6176
 				RightColor: 667A99
+				ZOffset: -12
+				ZRamp: 0
 	Template@549:
 		Category: Ice 02
 		Id: 549
@@ -8744,6 +12482,8 @@ Templates:
 			0: Clear
 				LeftColor: 7589AE
 				RightColor: 45576A
+				ZOffset: -12
+				ZRamp: 0
 	Template@550:
 		Category: Ice 02
 		Id: 550
@@ -8753,6 +12493,8 @@ Templates:
 			0: Clear
 				LeftColor: 5B6F87
 				RightColor: 46586B
+				ZOffset: -12
+				ZRamp: 0
 	Template@551:
 		Category: Ice 02
 		Id: 551
@@ -8762,6 +12504,8 @@ Templates:
 			0: Clear
 				LeftColor: 354653
 				RightColor: 2B3B44
+				ZOffset: -12
+				ZRamp: 0
 	Template@552:
 		Category: Ice 02
 		Id: 552
@@ -8771,6 +12515,8 @@ Templates:
 			0: Clear
 				LeftColor: 293941
 				RightColor: 384856
+				ZOffset: -12
+				ZRamp: 0
 	Template@553:
 		Category: Ice 02
 		Id: 553
@@ -8780,6 +12526,8 @@ Templates:
 			0: Clear
 				LeftColor: 33444F
 				RightColor: 354552
+				ZOffset: -12
+				ZRamp: 0
 	Template@554:
 		Category: Ice 02
 		Id: 554
@@ -8789,6 +12537,8 @@ Templates:
 			0: Clear
 				LeftColor: 364753
 				RightColor: 283840
+				ZOffset: -12
+				ZRamp: 0
 	Template@555:
 		Category: Ice 02
 		Id: 555
@@ -8798,6 +12548,8 @@ Templates:
 			0: Clear
 				LeftColor: 354653
 				RightColor: 3A4B5A
+				ZOffset: -12
+				ZRamp: 0
 	Template@556:
 		Category: Ice 02
 		Id: 556
@@ -8807,6 +12559,8 @@ Templates:
 			0: Clear
 				LeftColor: 33444F
 				RightColor: 445568
+				ZOffset: -12
+				ZRamp: 0
 	Template@557:
 		Category: Ice 02
 		Id: 557
@@ -8816,6 +12570,8 @@ Templates:
 			0: Clear
 				LeftColor: 405261
 				RightColor: 354552
+				ZOffset: -12
+				ZRamp: 0
 	Template@558:
 		Category: Ice 02
 		Id: 558
@@ -8825,6 +12581,8 @@ Templates:
 			0: Clear
 				LeftColor: 425365
 				RightColor: 2B3B44
+				ZOffset: -12
+				ZRamp: 0
 	Template@559:
 		Category: Ice 02
 		Id: 559
@@ -8834,6 +12592,8 @@ Templates:
 			0: Clear
 				LeftColor: 405161
 				RightColor: 46586B
+				ZOffset: -12
+				ZRamp: 0
 	Template@560:
 		Category: Ice 02
 		Id: 560
@@ -8843,6 +12603,8 @@ Templates:
 			0: Clear
 				LeftColor: 405261
 				RightColor: 445568
+				ZOffset: -12
+				ZRamp: 0
 	Template@561:
 		Category: Ice 02
 		Id: 561
@@ -8852,6 +12614,8 @@ Templates:
 			0: Clear
 				LeftColor: 4D5F73
 				RightColor: 374855
+				ZOffset: -12
+				ZRamp: 0
 	Template@562:
 		Category: Ice 02
 		Id: 562
@@ -8861,6 +12625,8 @@ Templates:
 			0: Clear
 				LeftColor: 425365
 				RightColor: 3A4B5A
+				ZOffset: -12
+				ZRamp: 0
 	Template@563:
 		Category: Ice 02
 		Id: 563
@@ -8870,6 +12636,8 @@ Templates:
 			0: Clear
 				LeftColor: 405161
 				RightColor: 374855
+				ZOffset: -12
+				ZRamp: 0
 	Template@564:
 		Category: Ice 02
 		Id: 564
@@ -8879,6 +12647,8 @@ Templates:
 			0: Clear
 				LeftColor: 364653
 				RightColor: 384856
+				ZOffset: -12
+				ZRamp: 0
 	Template@565:
 		Category: Ice 02
 		Id: 565
@@ -8888,6 +12658,8 @@ Templates:
 			0: Clear
 				LeftColor: 4D5F73
 				RightColor: 46586B
+				ZOffset: -12
+				ZRamp: 0
 	Template@566:
 		Category: Ice 02
 		Id: 566
@@ -8897,6 +12669,8 @@ Templates:
 			0: Clear
 				LeftColor: 293941
 				RightColor: 283840
+				ZOffset: -12
+				ZRamp: 0
 	Template@567:
 		Category: Ice 03
 		Id: 567
@@ -8906,6 +12680,8 @@ Templates:
 			0: Clear
 				LeftColor: B0CCED
 				RightColor: AECAEC
+				ZOffset: -12
+				ZRamp: 0
 	Template@568:
 		Category: Ice 03
 		Id: 568
@@ -8915,6 +12691,8 @@ Templates:
 			0: Clear
 				LeftColor: ABC5EA
 				RightColor: AAC5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@569:
 		Category: Ice 03
 		Id: 569
@@ -8924,6 +12702,8 @@ Templates:
 			0: Clear
 				LeftColor: ACC6EB
 				RightColor: A2BAE6
+				ZOffset: -12
+				ZRamp: 0
 	Template@570:
 		Category: Ice 03
 		Id: 570
@@ -8933,6 +12713,8 @@ Templates:
 			0: Clear
 				LeftColor: AEC9EC
 				RightColor: A1BAE5
+				ZOffset: -12
+				ZRamp: 0
 	Template@571:
 		Category: Ice 03
 		Id: 571
@@ -8942,6 +12724,8 @@ Templates:
 			0: Clear
 				LeftColor: ABC6EB
 				RightColor: 9BB1E2
+				ZOffset: -12
+				ZRamp: 0
 	Template@572:
 		Category: Ice 03
 		Id: 572
@@ -8951,6 +12735,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BEE8
 				RightColor: ACC7EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@573:
 		Category: Ice 03
 		Id: 573
@@ -8960,6 +12746,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BFE8
 				RightColor: A3BBE7
+				ZOffset: -12
+				ZRamp: 0
 	Template@574:
 		Category: Ice 03
 		Id: 574
@@ -8969,6 +12757,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BEE8
 				RightColor: A1BAE5
+				ZOffset: -12
+				ZRamp: 0
 	Template@575:
 		Category: Ice 03
 		Id: 575
@@ -8978,6 +12768,8 @@ Templates:
 			0: Clear
 				LeftColor: A5BFE8
 				RightColor: 9BB1E2
+				ZOffset: -12
+				ZRamp: 0
 	Template@576:
 		Category: Ice 03
 		Id: 576
@@ -8987,6 +12779,8 @@ Templates:
 			0: Clear
 				LeftColor: A3BCE7
 				RightColor: AAC4EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@577:
 		Category: Ice 03
 		Id: 577
@@ -8996,6 +12790,8 @@ Templates:
 			0: Clear
 				LeftColor: A3BCE7
 				RightColor: A2BAE6
+				ZOffset: -12
+				ZRamp: 0
 	Template@578:
 		Category: Ice 03
 		Id: 578
@@ -9005,6 +12801,8 @@ Templates:
 			0: Clear
 				LeftColor: A4BDE7
 				RightColor: A2BAE6
+				ZOffset: -12
+				ZRamp: 0
 	Template@579:
 		Category: Ice 03
 		Id: 579
@@ -9014,6 +12812,8 @@ Templates:
 			0: Clear
 				LeftColor: A4BDE7
 				RightColor: 9BB1E2
+				ZOffset: -12
+				ZRamp: 0
 	Template@580:
 		Category: Ice 03
 		Id: 580
@@ -9023,6 +12823,8 @@ Templates:
 			0: Clear
 				LeftColor: 9FB7E4
 				RightColor: A8C2EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@581:
 		Category: Ice 03
 		Id: 581
@@ -9032,6 +12834,8 @@ Templates:
 			0: Clear
 				LeftColor: 9FB7E4
 				RightColor: A1B9E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@582:
 		Category: Ice 03
 		Id: 582
@@ -9041,6 +12845,8 @@ Templates:
 			0: Clear
 				LeftColor: 9FB7E4
 				RightColor: A0B8E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@583:
 		Category: Ice 03
 		Id: 583
@@ -9050,6 +12856,8 @@ Templates:
 			0: Clear
 				LeftColor: 9AB0DF
 				RightColor: 9AAFE0
+				ZOffset: -12
+				ZRamp: 0
 	Template@584:
 		Category: Ice 03
 		Id: 584
@@ -9059,6 +12867,8 @@ Templates:
 			0: Clear
 				LeftColor: 405261
 				RightColor: 7084A1
+				ZOffset: -12
+				ZRamp: 0
 	Template@585:
 		Category: Ice 03
 		Id: 585
@@ -9068,6 +12878,8 @@ Templates:
 			0: Clear
 				LeftColor: 415262
 				RightColor: 61738D
+				ZOffset: -12
+				ZRamp: 0
 	Template@586:
 		Category: Ice 03
 		Id: 586
@@ -9077,6 +12889,8 @@ Templates:
 			0: Clear
 				LeftColor: 516378
 				RightColor: 889DC2
+				ZOffset: -12
+				ZRamp: 0
 	Template@587:
 		Category: Ice 03
 		Id: 587
@@ -9086,6 +12900,8 @@ Templates:
 			0: Clear
 				LeftColor: 677B96
 				RightColor: 3F505F
+				ZOffset: -12
+				ZRamp: 0
 	Template@588:
 		Category: Ice 03
 		Id: 588
@@ -9095,6 +12911,8 @@ Templates:
 			0: Clear
 				LeftColor: 7589A9
 				RightColor: 7E94B6
+				ZOffset: -12
+				ZRamp: 0
 	Template@589:
 		Category: Ice 03
 		Id: 589
@@ -9104,6 +12922,8 @@ Templates:
 			0: Clear
 				LeftColor: 677B96
 				RightColor: 60738C
+				ZOffset: -12
+				ZRamp: 0
 	Template@590:
 		Category: Ice 03
 		Id: 590
@@ -9113,6 +12933,8 @@ Templates:
 			0: Clear
 				LeftColor: 7589A9
 				RightColor: 889DC2
+				ZOffset: -12
+				ZRamp: 0
 	Template@591:
 		Category: Ice 03
 		Id: 591
@@ -9122,6 +12944,8 @@ Templates:
 			0: Clear
 				LeftColor: 657A94
 				RightColor: 31414B
+				ZOffset: -12
+				ZRamp: 0
 	Template@592:
 		Category: Ice 03
 		Id: 592
@@ -9131,6 +12955,8 @@ Templates:
 			0: Clear
 				LeftColor: 657A94
 				RightColor: 7084A1
+				ZOffset: -12
+				ZRamp: 0
 	Template@593:
 		Category: Ice 03
 		Id: 593
@@ -9140,6 +12966,8 @@ Templates:
 			0: Clear
 				LeftColor: 768BAB
 				RightColor: 647792
+				ZOffset: -12
+				ZRamp: 0
 	Template@594:
 		Category: Ice 03
 		Id: 594
@@ -9149,6 +12977,8 @@ Templates:
 			0: Clear
 				LeftColor: 768BAB
 				RightColor: 889DC2
+				ZOffset: -12
+				ZRamp: 0
 	Template@595:
 		Category: Ice 03
 		Id: 595
@@ -9158,6 +12988,8 @@ Templates:
 			0: Clear
 				LeftColor: 859BBF
 				RightColor: 435464
+				ZOffset: -12
+				ZRamp: 0
 	Template@596:
 		Category: Ice 03
 		Id: 596
@@ -9167,6 +12999,8 @@ Templates:
 			0: Clear
 				LeftColor: 859BBF
 				RightColor: 7E94B6
+				ZOffset: -12
+				ZRamp: 0
 	Template@597:
 		Category: Ice 03
 		Id: 597
@@ -9176,6 +13010,8 @@ Templates:
 			0: Clear
 				LeftColor: 859BBF
 				RightColor: 647792
+				ZOffset: -12
+				ZRamp: 0
 	Template@598:
 		Category: Ice 03
 		Id: 598
@@ -9185,6 +13021,8 @@ Templates:
 			0: Clear
 				LeftColor: 859BBF
 				RightColor: 889DC2
+				ZOffset: -12
+				ZRamp: 0
 	Template@599:
 		Category: Ice 03
 		Id: 599
@@ -9194,6 +13032,8 @@ Templates:
 			0: Clear
 				LeftColor: 4C5F71
 				RightColor: 7A8FB0
+				ZOffset: -12
+				ZRamp: 0
 	Template@600:
 		Category: Ice 03
 		Id: 600
@@ -9203,6 +13043,8 @@ Templates:
 			0: Clear
 				LeftColor: 4D6072
 				RightColor: 61738D
+				ZOffset: -12
+				ZRamp: 0
 	Template@601:
 		Category: Ice 03
 		Id: 601
@@ -9212,6 +13054,8 @@ Templates:
 			0: Clear
 				LeftColor: 5D7188
 				RightColor: 889DC2
+				ZOffset: -12
+				ZRamp: 0
 	Template@602:
 		Category: Ice 03
 		Id: 602
@@ -9221,6 +13065,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D829F
 				RightColor: 425362
+				ZOffset: -12
+				ZRamp: 0
 	Template@603:
 		Category: Ice 03
 		Id: 603
@@ -9230,6 +13076,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D829F
 				RightColor: 62758F
+				ZOffset: -12
+				ZRamp: 0
 	Template@604:
 		Category: Ice 03
 		Id: 604
@@ -9239,6 +13087,8 @@ Templates:
 			0: Clear
 				LeftColor: 657A94
 				RightColor: 415363
+				ZOffset: -12
+				ZRamp: 0
 	Template@605:
 		Category: Ice 03
 		Id: 605
@@ -9248,6 +13098,8 @@ Templates:
 			0: Clear
 				LeftColor: 7288A5
 				RightColor: 7A8FB0
+				ZOffset: -12
+				ZRamp: 0
 	Template@606:
 		Category: Ice 03
 		Id: 606
@@ -9257,6 +13109,8 @@ Templates:
 			0: Clear
 				LeftColor: 859BBF
 				RightColor: 54677C
+				ZOffset: -12
+				ZRamp: 0
 	Template@607:
 		Category: Ice 03
 		Id: 607
@@ -9266,6 +13120,8 @@ Templates:
 			0: Clear
 				LeftColor: 4C5F72
 				RightColor: 7084A1
+				ZOffset: -12
+				ZRamp: 0
 	Template@608:
 		Category: Ice 03
 		Id: 608
@@ -9275,6 +13131,8 @@ Templates:
 			0: Clear
 				LeftColor: 47596B
 				RightColor: 637690
+				ZOffset: -12
+				ZRamp: 0
 	Template@609:
 		Category: Ice 03
 		Id: 609
@@ -9284,6 +13142,8 @@ Templates:
 			0: Clear
 				LeftColor: 677B96
 				RightColor: 506277
+				ZOffset: -12
+				ZRamp: 0
 	Template@610:
 		Category: Ice 03
 		Id: 610
@@ -9293,6 +13153,8 @@ Templates:
 			0: Clear
 				LeftColor: 7187A3
 				RightColor: 3D4F5C
+				ZOffset: -12
+				ZRamp: 0
 	Template@611:
 		Category: Ice 03
 		Id: 611
@@ -9302,6 +13164,8 @@ Templates:
 			0: Clear
 				LeftColor: 586D82
 				RightColor: 7A8FB0
+				ZOffset: -12
+				ZRamp: 0
 	Template@612:
 		Category: Ice 03
 		Id: 612
@@ -9311,6 +13175,8 @@ Templates:
 			0: Clear
 				LeftColor: 53677B
 				RightColor: 637690
+				ZOffset: -12
+				ZRamp: 0
 	Template@613:
 		Category: Ice 03
 		Id: 613
@@ -9320,6 +13186,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D829F
 				RightColor: 52657A
+				ZOffset: -12
+				ZRamp: 0
 	Template@614:
 		Category: Ice 03
 		Id: 614
@@ -9329,6 +13197,8 @@ Templates:
 			0: Clear
 				LeftColor: 7187A3
 				RightColor: 4E6174
+				ZOffset: -12
+				ZRamp: 0
 	Template@615:
 		Category: Ice 03
 		Id: 615
@@ -9338,6 +13208,8 @@ Templates:
 			0: Clear
 				LeftColor: 344550
 				RightColor: 2F3F48
+				ZOffset: -12
+				ZRamp: 0
 	Template@616:
 		Category: Ice 03
 		Id: 616
@@ -9347,6 +13219,8 @@ Templates:
 			0: Clear
 				LeftColor: 2E3E47
 				RightColor: 3D4E5C
+				ZOffset: -12
+				ZRamp: 0
 	Template@617:
 		Category: Ice 03
 		Id: 617
@@ -9356,6 +13230,8 @@ Templates:
 			0: Clear
 				LeftColor: 3C4D5A
 				RightColor: 394A57
+				ZOffset: -12
+				ZRamp: 0
 	Template@618:
 		Category: Ice 03
 		Id: 618
@@ -9365,6 +13241,8 @@ Templates:
 			0: Clear
 				LeftColor: 3A4B58
 				RightColor: 2C3C45
+				ZOffset: -12
+				ZRamp: 0
 	Template@619:
 		Category: Ice 03
 		Id: 619
@@ -9374,6 +13252,8 @@ Templates:
 			0: Clear
 				LeftColor: 344550
 				RightColor: 405160
+				ZOffset: -12
+				ZRamp: 0
 	Template@620:
 		Category: Ice 03
 		Id: 620
@@ -9383,6 +13263,8 @@ Templates:
 			0: Clear
 				LeftColor: 3C4D5A
 				RightColor: 4A5D6F
+				ZOffset: -12
+				ZRamp: 0
 	Template@621:
 		Category: Ice 03
 		Id: 621
@@ -9392,6 +13274,8 @@ Templates:
 			0: Clear
 				LeftColor: 475B6B
 				RightColor: 394A57
+				ZOffset: -12
+				ZRamp: 0
 	Template@622:
 		Category: Ice 03
 		Id: 622
@@ -9401,6 +13285,8 @@ Templates:
 			0: Clear
 				LeftColor: 405361
 				RightColor: 2F3F48
+				ZOffset: -12
+				ZRamp: 0
 	Template@623:
 		Category: Ice 03
 		Id: 623
@@ -9410,6 +13296,8 @@ Templates:
 			0: Clear
 				LeftColor: 425563
 				RightColor: 4D6072
+				ZOffset: -12
+				ZRamp: 0
 	Template@624:
 		Category: Ice 03
 		Id: 624
@@ -9419,6 +13307,8 @@ Templates:
 			0: Clear
 				LeftColor: 475B6B
 				RightColor: 4A5D6F
+				ZOffset: -12
+				ZRamp: 0
 	Template@625:
 		Category: Ice 03
 		Id: 625
@@ -9428,6 +13318,8 @@ Templates:
 			0: Clear
 				LeftColor: 4E6274
 				RightColor: 3C4D5A
+				ZOffset: -12
+				ZRamp: 0
 	Template@626:
 		Category: Ice 03
 		Id: 626
@@ -9437,6 +13329,8 @@ Templates:
 			0: Clear
 				LeftColor: 405361
 				RightColor: 405160
+				ZOffset: -12
+				ZRamp: 0
 	Template@627:
 		Category: Ice 03
 		Id: 627
@@ -9446,6 +13340,8 @@ Templates:
 			0: Clear
 				LeftColor: 425563
 				RightColor: 3C4D5A
+				ZOffset: -12
+				ZRamp: 0
 	Template@628:
 		Category: Ice 03
 		Id: 628
@@ -9455,6 +13351,8 @@ Templates:
 			0: Clear
 				LeftColor: 3A4B58
 				RightColor: 3D4E5C
+				ZOffset: -12
+				ZRamp: 0
 	Template@629:
 		Category: Ice 03
 		Id: 629
@@ -9464,6 +13362,8 @@ Templates:
 			0: Clear
 				LeftColor: 4E6274
 				RightColor: 4D6072
+				ZOffset: -12
+				ZRamp: 0
 	Template@630:
 		Category: Ice 03
 		Id: 630
@@ -9473,6 +13373,8 @@ Templates:
 			0: Clear
 				LeftColor: 2B3B43
 				RightColor: 2B3A42
+				ZOffset: -12
+				ZRamp: 0
 	Template@631:
 		Category: Ice shore
 		Id: 631
@@ -9482,6 +13384,8 @@ Templates:
 			0: Clear
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 	Template@632:
 		Category: Ice shore
 		Id: 632
@@ -9491,6 +13395,8 @@ Templates:
 			0: Clear
 				LeftColor: ACBFD3
 				RightColor: A5B4C9
+				ZOffset: -12
+				ZRamp: 0
 	Template@633:
 		Category: Ice shore
 		Id: 633
@@ -9500,6 +13406,8 @@ Templates:
 			0: Clear
 				LeftColor: B8D0E8
 				RightColor: 98A9BE
+				ZOffset: -12
+				ZRamp: 0
 	Template@634:
 		Category: Ice shore
 		Id: 634
@@ -9509,6 +13417,8 @@ Templates:
 			0: Clear
 				LeftColor: AFC0D0
 				RightColor: 99ABC6
+				ZOffset: -12
+				ZRamp: 0
 	Template@635:
 		Category: Ice shore
 		Id: 635
@@ -9518,6 +13428,8 @@ Templates:
 			0: Clear
 				LeftColor: 9BAEC4
 				RightColor: B5C9DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@636:
 		Category: Ice shore
 		Id: 636
@@ -9527,6 +13439,8 @@ Templates:
 			0: Clear
 				LeftColor: 97A7C0
 				RightColor: A9BBD3
+				ZOffset: -12
+				ZRamp: 0
 	Template@637:
 		Category: Ice shore
 		Id: 637
@@ -9536,6 +13450,8 @@ Templates:
 			0: Clear
 				LeftColor: 9AACC1
 				RightColor: 97A9C1
+				ZOffset: -12
+				ZRamp: 0
 	Template@638:
 		Category: Ice shore
 		Id: 638
@@ -9545,6 +13461,8 @@ Templates:
 			0: Clear
 				LeftColor: 96A6BE
 				RightColor: 99ACC7
+				ZOffset: -12
+				ZRamp: 0
 	Template@639:
 		Category: Ice shore
 		Id: 639
@@ -9554,6 +13472,8 @@ Templates:
 			0: Clear
 				LeftColor: 9CABC3
 				RightColor: 98A6B4
+				ZOffset: -12
+				ZRamp: 0
 	Template@640:
 		Category: Ice shore
 		Id: 640
@@ -9563,6 +13483,8 @@ Templates:
 			0: Clear
 				LeftColor: 9CADC5
 				RightColor: ACBFD9
+				ZOffset: -12
+				ZRamp: 0
 	Template@641:
 		Category: Ice shore
 		Id: 641
@@ -9572,6 +13494,8 @@ Templates:
 			0: Clear
 				LeftColor: 9EB1C7
 				RightColor: 98ADC4
+				ZOffset: -12
+				ZRamp: 0
 	Template@642:
 		Category: Ice shore
 		Id: 642
@@ -9581,6 +13505,8 @@ Templates:
 			0: Clear
 				LeftColor: 9BACC3
 				RightColor: 99ABC6
+				ZOffset: -12
+				ZRamp: 0
 	Template@643:
 		Category: Ice shore
 		Id: 643
@@ -9590,6 +13516,8 @@ Templates:
 			0: Clear
 				LeftColor: 8F9EB7
 				RightColor: A9BCCF
+				ZOffset: -12
+				ZRamp: 0
 	Template@644:
 		Category: Ice shore
 		Id: 644
@@ -9599,6 +13527,8 @@ Templates:
 			0: Clear
 				LeftColor: 93A2BD
 				RightColor: A8BAD4
+				ZOffset: -12
+				ZRamp: 0
 	Template@645:
 		Category: Ice shore
 		Id: 645
@@ -9608,6 +13538,8 @@ Templates:
 			0: Clear
 				LeftColor: 8C9CB4
 				RightColor: 99AABE
+				ZOffset: -12
+				ZRamp: 0
 	Template@646:
 		Category: Ice shore
 		Id: 646
@@ -9617,6 +13549,8 @@ Templates:
 			0: Clear
 				LeftColor: 93A4C0
 				RightColor: 99AECC
+				ZOffset: -12
+				ZRamp: 0
 	Template@647:
 		Category: Ice shore
 		Id: 647
@@ -9626,6 +13560,8 @@ Templates:
 			0: Clear
 				LeftColor: B3C6D8
 				RightColor: A2B2C8
+				ZOffset: -12
+				ZRamp: 0
 	Template@648:
 		Category: Ice shore
 		Id: 648
@@ -9635,6 +13571,8 @@ Templates:
 			0: Clear
 				LeftColor: BAC8D5
 				RightColor: 98A9BD
+				ZOffset: -12
+				ZRamp: 0
 	Template@649:
 		Category: Ice shore
 		Id: 649
@@ -9644,6 +13582,8 @@ Templates:
 			0: Clear
 				LeftColor: A8B5C1
 				RightColor: 99ABC6
+				ZOffset: -12
+				ZRamp: 0
 	Template@650:
 		Category: Ice shore
 		Id: 650
@@ -9653,6 +13593,8 @@ Templates:
 			0: Clear
 				LeftColor: 99AABF
 				RightColor: ABBCCC
+				ZOffset: -12
+				ZRamp: 0
 	Template@651:
 		Category: Ice shore
 		Id: 651
@@ -9662,6 +13604,8 @@ Templates:
 			0: Clear
 				LeftColor: 97A8BD
 				RightColor: 92A2B7
+				ZOffset: -12
+				ZRamp: 0
 	Template@652:
 		Category: Ice shore
 		Id: 652
@@ -9671,6 +13615,8 @@ Templates:
 			0: Clear
 				LeftColor: 97A6BB
 				RightColor: 9DABB6
+				ZOffset: -12
+				ZRamp: 0
 	Template@653:
 		Category: Ice shore
 		Id: 653
@@ -9680,6 +13626,8 @@ Templates:
 			0: Clear
 				LeftColor: 98A6BB
 				RightColor: A9BAD2
+				ZOffset: -12
+				ZRamp: 0
 	Template@654:
 		Category: Ice shore
 		Id: 654
@@ -9689,6 +13637,8 @@ Templates:
 			0: Clear
 				LeftColor: 8F9EB7
 				RightColor: 9EABB7
+				ZOffset: -12
+				ZRamp: 0
 	Template@655:
 		Category: Ice shore
 		Id: 655
@@ -9698,6 +13648,8 @@ Templates:
 			0: Clear
 				LeftColor: A6B1BC
 				RightColor: A5B3C9
+				ZOffset: -12
+				ZRamp: 0
 	Template@656:
 		Category: Ice shore
 		Id: 656
@@ -9707,6 +13659,8 @@ Templates:
 			0: Clear
 				LeftColor: B2C8DE
 				RightColor: 919FB1
+				ZOffset: -12
+				ZRamp: 0
 	Template@657:
 		Category: Ice shore
 		Id: 657
@@ -9716,6 +13670,8 @@ Templates:
 			0: Clear
 				LeftColor: 9BAEC4
 				RightColor: ADBECD
+				ZOffset: -12
+				ZRamp: 0
 	Template@658:
 		Category: Ice shore
 		Id: 658
@@ -9725,6 +13681,8 @@ Templates:
 			0: Clear
 				LeftColor: 99A6BA
 				RightColor: B1C3D3
+				ZOffset: -12
+				ZRamp: 0
 	Template@659:
 		Category: Ice shore
 		Id: 659
@@ -9734,6 +13692,8 @@ Templates:
 			0: Clear
 				LeftColor: A7B5C3
 				RightColor: ADBCD0
+				ZOffset: -12
+				ZRamp: 0
 	Template@660:
 		Category: Ice shore
 		Id: 660
@@ -9743,6 +13703,8 @@ Templates:
 			0: Clear
 				LeftColor: ACBBCA
 				RightColor: 92A2B5
+				ZOffset: -12
+				ZRamp: 0
 	Template@661:
 		Category: Ice shore
 		Id: 661
@@ -9752,6 +13714,8 @@ Templates:
 			0: Clear
 				LeftColor: 95A6BA
 				RightColor: A4B3BF
+				ZOffset: -12
+				ZRamp: 0
 	Template@662:
 		Category: Ice shore
 		Id: 662
@@ -9761,6 +13725,8 @@ Templates:
 			0: Clear
 				LeftColor: A0AAB8
 				RightColor: 9DA8B0
+				ZOffset: -12
+				ZRamp: 0
 	Template@663:
 		Category: Ice shore
 		Id: 663
@@ -9770,6 +13736,8 @@ Templates:
 			0: Clear
 				LeftColor: AEC4DB
 				RightColor: AABED4
+				ZOffset: -12
+				ZRamp: 0
 	Template@664:
 		Category: Ice shore
 		Id: 664
@@ -9779,6 +13747,8 @@ Templates:
 			0: Clear
 				LeftColor: BCD5ED
 				RightColor: A6B3BE
+				ZOffset: -12
+				ZRamp: 0
 	Template@665:
 		Category: Ice shore
 		Id: 665
@@ -9788,6 +13758,8 @@ Templates:
 			0: Clear
 				LeftColor: B9C8D6
 				RightColor: BFD4E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@666:
 		Category: Ice shore
 		Id: 666
@@ -9797,6 +13769,8 @@ Templates:
 			0: Clear
 				LeftColor: ADB9C5
 				RightColor: BDD8F0
+				ZOffset: -12
+				ZRamp: 0
 	Template@667:
 		Category: Ice shore
 		Id: 667
@@ -9806,6 +13780,8 @@ Templates:
 			0: Clear
 				LeftColor: B5CDE5
 				RightColor: AEBFCC
+				ZOffset: -12
+				ZRamp: 0
 	Template@668:
 		Category: Ice shore
 		Id: 668
@@ -9815,6 +13791,8 @@ Templates:
 			0: Clear
 				LeftColor: B8C7D5
 				RightColor: A2ADB5
+				ZOffset: -12
+				ZRamp: 0
 	Template@669:
 		Category: Ice shore
 		Id: 669
@@ -9824,6 +13802,8 @@ Templates:
 			0: Clear
 				LeftColor: ACBDCC
 				RightColor: BFD4E5
+				ZOffset: -12
+				ZRamp: 0
 	Template@670:
 		Category: Ice shore
 		Id: 670
@@ -9833,6 +13813,8 @@ Templates:
 			0: Clear
 				LeftColor: AEBDCA
 				RightColor: AEC6DE
+				ZOffset: -12
+				ZRamp: 0
 	Template@671:
 		Category: Ice shore
 		Id: 671
@@ -9842,6 +13824,8 @@ Templates:
 			0: Clear
 				LeftColor: B0C1D0
 				RightColor: A8B6C1
+				ZOffset: -12
+				ZRamp: 0
 	Template@672:
 		Category: Ice shore
 		Id: 672
@@ -9851,6 +13835,8 @@ Templates:
 			0: Clear
 				LeftColor: ADBBC9
 				RightColor: A2ADB5
+				ZOffset: -12
+				ZRamp: 0
 	Template@673:
 		Category: Ice shore
 		Id: 673
@@ -9860,6 +13846,8 @@ Templates:
 			0: Clear
 				LeftColor: AAB6C2
 				RightColor: B5C8D9
+				ZOffset: -12
+				ZRamp: 0
 	Template@674:
 		Category: Ice shore
 		Id: 674
@@ -9869,6 +13857,8 @@ Templates:
 			0: Clear
 				LeftColor: AEBDCA
 				RightColor: AEBFCC
+				ZOffset: -12
+				ZRamp: 0
 	Template@675:
 		Category: Ice shore
 		Id: 675
@@ -9878,6 +13868,8 @@ Templates:
 			0: Clear
 				LeftColor: AFBFCE
 				RightColor: AEC3D8
+				ZOffset: -12
+				ZRamp: 0
 	Template@676:
 		Category: Ice shore
 		Id: 676
@@ -9887,6 +13879,8 @@ Templates:
 			0: Clear
 				LeftColor: AEC2D5
 				RightColor: ADBECE
+				ZOffset: -12
+				ZRamp: 0
 	Template@677:
 		Category: Ice shore
 		Id: 677
@@ -9896,6 +13890,8 @@ Templates:
 			0: Clear
 				LeftColor: AAB6C2
 				RightColor: A8B6C1
+				ZOffset: -12
+				ZRamp: 0
 	Template@678:
 		Category: Ice shore
 		Id: 678
@@ -9905,6 +13901,8 @@ Templates:
 			0: Clear
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 	Template@679:
 		Category: Waterfalls-B
 		Id: 679
@@ -9915,30 +13913,46 @@ Templates:
 				Height: 4
 				LeftColor: 525D63
 				RightColor: 353F47
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 394853
 				RightColor: 53646D
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 7F94A2
 				RightColor: 7D909D
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 8695A1
 				RightColor: 647681
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 8B9AA7
 				RightColor: 7A848D
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 8296AA
 				RightColor: 647587
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: A0B6CC
 				RightColor: 7D96AC
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: A6B3BF
 				RightColor: AAB9C4
+				ZOffset: -12
+				ZRamp: 0
 	Template@680:
 		Category: Waterfalls-B
 		Id: 680
@@ -9949,16 +13963,24 @@ Templates:
 				Height: 4
 				LeftColor: 2B3840
 				RightColor: 3E4950
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 414B54
 				RightColor: 68757D
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: BECBD8
 				RightColor: B1C1CE
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 778992
 				RightColor: 50626C
+				ZOffset: -12
+				ZRamp: 0
 	Template@681:
 		Category: Waterfalls-B
 		Id: 681
@@ -9969,30 +13991,46 @@ Templates:
 				Height: 4
 				LeftColor: 243038
 				RightColor: 28353E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 39454F
 				RightColor: 5F6A72
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 9FB2C0
 				RightColor: 9DAFBD
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 667680
 				RightColor: 566269
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 26333B
 				RightColor: 2C3842
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 3F4B53
 				RightColor: 5F6A72
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: BDCAD7
 				RightColor: AABAC8
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 8C979E
 				RightColor: 52626B
+				ZOffset: -12
+				ZRamp: 0
 	Template@682:
 		Category: Waterfalls-B
 		Id: 682
@@ -10003,30 +14041,46 @@ Templates:
 				Height: 4
 				LeftColor: 555E65
 				RightColor: 81909E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 7D8FA2
 				RightColor: 758697
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: AAC3DC
 				RightColor: 7F9CB5
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 788EA5
 				RightColor: B4C9DC
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 28343C
 				RightColor: 2D3843
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 424F58
 				RightColor: 53667A
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 99ACB9
 				RightColor: 748EA1
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 6D7F8B
 				RightColor: 435764
+				ZOffset: -12
+				ZRamp: 0
 	Template@683:
 		Category: Waterfalls-C
 		Id: 683
@@ -10037,14 +14091,20 @@ Templates:
 				Height: 4
 				LeftColor: 8798A8
 				RightColor: 6B7C8C
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 8897A7
 				RightColor: 78848E
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 414C55
 				RightColor: 495763
+				ZOffset: -12
+				ZRamp: 0
 	Template@684:
 		Category: Waterfalls-C
 		Id: 684
@@ -10055,6 +14115,8 @@ Templates:
 				Height: 4
 				LeftColor: 212D34
 				RightColor: 34414A
+				ZOffset: -12
+				ZRamp: 0
 	Template@685:
 		Category: Waterfalls-C
 		Id: 685
@@ -10065,10 +14127,14 @@ Templates:
 				Height: 4
 				LeftColor: 243037
 				RightColor: 404F59
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 2A383F
 				RightColor: 313F47
+				ZOffset: -12
+				ZRamp: 0
 	Template@686:
 		Category: Waterfalls-C
 		Id: 686
@@ -10079,14 +14145,20 @@ Templates:
 				Height: 4
 				LeftColor: 7C8C9C
 				RightColor: 728191
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 253037
 				RightColor: 3C474F
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 7B8692
 				RightColor: 82919E
+				ZOffset: -12
+				ZRamp: 0
 	Template@687:
 		Category: Waterfalls-D
 		Id: 687
@@ -10097,14 +14169,20 @@ Templates:
 				Height: 4
 				LeftColor: 67757E
 				RightColor: 515F69
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 8E9DAB
 				RightColor: 8C9DAB
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 8C9BA9
 				RightColor: 7B868F
+				ZOffset: -12
+				ZRamp: 0
 	Template@688:
 		Category: Waterfalls-D
 		Id: 688
@@ -10115,6 +14193,8 @@ Templates:
 				Height: 4
 				LeftColor: 32414B
 				RightColor: 222E35
+				ZOffset: -12
+				ZRamp: 0
 	Template@689:
 		Category: Waterfalls-D
 		Id: 689
@@ -10125,10 +14205,14 @@ Templates:
 				Height: 4
 				LeftColor: 2E3C45
 				RightColor: 2E3B44
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 34424C
 				RightColor: 26333A
+				ZOffset: -12
+				ZRamp: 0
 	Template@690:
 		Category: Waterfalls-D
 		Id: 690
@@ -10139,14 +14223,20 @@ Templates:
 				Height: 4
 				LeftColor: 8191A3
 				RightColor: 8192A4
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				Height: 4
 				LeftColor: 5A646B
 				RightColor: 81919F
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 415160
 				RightColor: 2F3C48
+				ZOffset: -12
+				ZRamp: 0
 	Template@691:
 		Category: Paved Road Ends
 		Id: 691
@@ -10156,12 +14246,18 @@ Templates:
 			0: Rough
 				LeftColor: 5E666C
 				RightColor: 88949F
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 56595B
 				RightColor: 666E72
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 8E9BA6
 				RightColor: 859098
+				ZOffset: -12
+				ZRamp: 0
 	Template@692:
 		Category: Paved Road Ends
 		Id: 692
@@ -10171,12 +14267,18 @@ Templates:
 			0: Rough
 				LeftColor: A4ADB4
 				RightColor: 656C70
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 595B58
 				RightColor: 5D6265
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 636769
 				RightColor: 919BA4
+				ZOffset: -12
+				ZRamp: 0
 	Template@693:
 		Category: Paved Road Ends
 		Id: 693
@@ -10186,12 +14288,18 @@ Templates:
 			0: Rough
 				LeftColor: 707579
 				RightColor: 8A9298
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 595C5D
 				RightColor: 545755
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 94A1AD
 				RightColor: 52575B
+				ZOffset: -12
+				ZRamp: 0
 	Template@694:
 		Category: Paved Road Ends
 		Id: 694
@@ -10201,12 +14309,18 @@ Templates:
 			0: Rough
 				LeftColor: A7BBCC
 				RightColor: 767C81
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 717B81
 				RightColor: 565652
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 7B868F
 				RightColor: 98A4AC
+				ZOffset: -12
+				ZRamp: 0
 	Template@695:
 		Category: TrainBridges
 		Id: 695
@@ -10217,55 +14331,85 @@ Templates:
 				Height: 4
 				LeftColor: 81878D
 				RightColor: 7D8A96
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 716F6C
 				RightColor: 696B6A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: BFD4E6
 				RightColor: C0DAEF
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 484D4F
 				RightColor: 6B7074
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 454546
 				RightColor: 6C6F71
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B7CBDF
 				RightColor: 94A3AD
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				Height: 4
 				LeftColor: 393C3F
 				RightColor: 3D3F41
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 3A3B3D
 				RightColor: 3D3E40
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C0D1E2
 				RightColor: 757A7E
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 697177
 				RightColor: 454748
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 626363
 				RightColor: 454545
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: BED4E6
 				RightColor: 6F7478
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 8694A2
 				RightColor: 797C7F
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: B0C2D1
 				RightColor: 999FA4
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: B7CDE1
 				RightColor: BCD4EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@696:
 		Category: TrainBridges
 		Id: 696
@@ -10276,55 +14420,85 @@ Templates:
 				Height: 4
 				LeftColor: 81878D
 				RightColor: 7D8A96
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 716F6C
 				RightColor: 67696A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 62758D
 				RightColor: 889DC2
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 484D4F
 				RightColor: 6B7074
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 454546
 				RightColor: 6C6F71
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 7489A8
 				RightColor: 68727F
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				Height: 4
 				LeftColor: 393C3F
 				RightColor: 3D3F41
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 3A3B3D
 				RightColor: 3D3E40
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 62748D
 				RightColor: 686C73
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 697177
 				RightColor: 454748
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 626363
 				RightColor: 454545
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 5F7189
 				RightColor: 61656A
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 8593A0
 				RightColor: 7A7E81
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 9DABBD
 				RightColor: 989FA4
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 7A8EB4
 				RightColor: 6C7D9A
+				ZOffset: -12
+				ZRamp: 0
 	Template@697:
 		Category: TrainBridges
 		Id: 697
@@ -10334,41 +14508,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 81878B
 				RightColor: 7F8C9A
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 464646
 				RightColor: 6D6E6E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 484C4F
 				RightColor: 6C7379
+				ZOffset: -12
+				ZRamp: 0
 			4: Rail
 				Height: 4
 				LeftColor: 3A3B3D
 				RightColor: 3D3F41
+				ZOffset: -12
+				ZRamp: 0
 			5: Rail
 				Height: 4
 				LeftColor: 3A3C3E
 				RightColor: 3C3F42
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 606061
 				RightColor: 454545
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 676C70
 				RightColor: 4A5055
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A9AEB1
 				RightColor: 9EA1A0
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 7F8A97
 				RightColor: 767A7F
+				ZOffset: -12
+				ZRamp: 0
 	Template@698:
 		Category: TrainBridges
 		Id: 698
@@ -10379,55 +14573,85 @@ Templates:
 				Height: 4
 				LeftColor: 73808D
 				RightColor: 71767A
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 747B82
 				RightColor: 505355
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 3B3C3E
 				RightColor: 393C3F
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 45484C
 				RightColor: 6D7379
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 6D7074
 				RightColor: 808D98
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B3BCC3
 				RightColor: 9D9C97
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 5F6061
 				RightColor: 595C5E
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 3A3C3F
 				RightColor: 393B3E
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 464646
 				RightColor: 616161
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 9BA8B3
 				RightColor: 949DA2
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: C0DAEF
 				RightColor: C6D9EB
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: BAD5EE
 				RightColor: B8C4CF
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: C4DEF1
 				RightColor: A0A4A5
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: BED4E6
 				RightColor: A0A5A8
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: C0DAEF
 				RightColor: C6D9EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@699:
 		Category: TrainBridges
 		Id: 699
@@ -10438,55 +14662,85 @@ Templates:
 				Height: 4
 				LeftColor: 73808D
 				RightColor: 71767A
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 747B82
 				RightColor: 505355
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 3B3C3E
 				RightColor: 393C3F
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 45484C
 				RightColor: 6D7379
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 6D7074
 				RightColor: 808D98
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: A4ABB4
 				RightColor: 9D9C97
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 5F6061
 				RightColor: 595C5E
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 3A3C3F
 				RightColor: 393B3E
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 464646
 				RightColor: 616161
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 909FAD
 				RightColor: 8D959C
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 7C91B8
 				RightColor: 677897
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 7489A9
 				RightColor: 9AA6B7
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 7689AE
 				RightColor: 919599
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 778AA9
 				RightColor: 969BA0
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 768AB0
 				RightColor: 7585A2
+				ZOffset: -12
+				ZRamp: 0
 	Template@700:
 		Category: TrainBridges
 		Id: 700
@@ -10496,41 +14750,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 606161
 				RightColor: 565657
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 3A3C3D
 				RightColor: 393B3D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 454545
 				RightColor: 606061
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 848C93
 				RightColor: 7A7D7F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 7F8E9C
 				RightColor: 71777D
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 767A7E
 				RightColor: 4A4B4C
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 3B3D3F
 				RightColor: 3A3C3E
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 4F5050
 				RightColor: 777B7E
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 6E7378
 				RightColor: 747C85
+				ZOffset: -12
+				ZRamp: 0
 	Template@701:
 		Category: TrainBridges
 		Id: 701
@@ -10540,36 +14814,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 696967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C3D2E0
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 454646
 				RightColor: 6C6E6E
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: C3D1DF
 				RightColor: 97A4AC
+				ZOffset: -12
+				ZRamp: 0
 			4: Rail
 				Height: 4
 				LeftColor: 373633
 				RightColor: 373632
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BDD0E1
 				RightColor: 717679
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 626262
 				RightColor: 464646
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BFD0E1
 				RightColor: 707578
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B1B7BA
 				RightColor: 989896
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BCD2E6
 				RightColor: B6D1EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@702:
 		Category: TrainBridges
 		Id: 702
@@ -10579,36 +14873,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 696967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C3D2E0
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3F4141
 				RightColor: 656667
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: C3D1DF
 				RightColor: 97A4AC
+				ZOffset: -12
+				ZRamp: 0
 			4: Rail
 				Height: 4
 				LeftColor: 343331
 				RightColor: 383734
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BDD0E1
 				RightColor: 717679
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4A4A4A
 				RightColor: 414141
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BFD0E1
 				RightColor: 707578
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A3A8AB
 				RightColor: 929290
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: B6D1EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@703:
 		Category: TrainBridges
 		Id: 703
@@ -10618,36 +14932,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 696967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C0CEDC
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 404040
 				RightColor: 646566
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B2C0CD
 				RightColor: 889299
+				ZOffset: -12
+				ZRamp: 0
 			4: Rail
 				Height: 4
 				LeftColor: 363533
 				RightColor: 31312F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: AEC1D0
 				RightColor: 6F7477
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 5B5B5B
 				RightColor: 404040
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B8C4D0
 				RightColor: 6B7073
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: AFB4B7
 				RightColor: 90918F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: A5BDD5
+				ZOffset: -12
+				ZRamp: 0
 	Template@704:
 		Category: TrainBridges
 		Id: 704
@@ -10657,36 +14991,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 686866
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C0CEDC
 				RightColor: C2DBF0
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 3C3C3D
 				RightColor: 5A5B5C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B2C0CD
 				RightColor: 889299
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				Height: 4
 				LeftColor: 353533
 				RightColor: 343330
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: AEC1D0
 				RightColor: 6F7477
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				Height: 4
 				LeftColor: 4B4B4B
 				RightColor: 3D3D3D
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B8C4D0
 				RightColor: 6B7073
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A3A8AB
 				RightColor: 90918F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: A5BDD5
+				ZOffset: -12
+				ZRamp: 0
 	Template@705:
 		Category: TrainBridges
 		Id: 705
@@ -10696,33 +15050,53 @@ Templates:
 			0: Cliff
 				LeftColor: 7A7977
 				RightColor: 8F9090
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: BCC7D2
 				RightColor: ACBCC8
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 636260
 				RightColor: 6C6C6B
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 777F85
 				RightColor: A3B8C9
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6E6D6B
 				RightColor: 838380
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 8F9EAA
 				RightColor: 76828B
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 797875
 				RightColor: 979692
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B4BEC7
 				RightColor: ADC4DA
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: AEB6BB
 				RightColor: A5ABAE
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD0E3
 				RightColor: A5BBD1
+				ZOffset: -12
+				ZRamp: 0
 	Template@706:
 		Category: TrainBridges
 		Id: 706
@@ -10732,36 +15106,56 @@ Templates:
 			0: Cliff
 				LeftColor: B8C0C6
 				RightColor: 9D9C98
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 606161
 				RightColor: 565657
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 363531
 				RightColor: 373632
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 454545
 				RightColor: 606061
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8C9296
 				RightColor: 878989
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C4DEF1
 				RightColor: C3D4E4
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: BED4E6
 				RightColor: AFBCC7
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C0DAEF
 				RightColor: A3A6A6
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: BAD5EE
 				RightColor: A1A4A5
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD5EE
 				RightColor: BED5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@707:
 		Category: TrainBridges
 		Id: 707
@@ -10772,32 +15166,50 @@ Templates:
 				Height: 4
 				LeftColor: 585858
 				RightColor: 4E4E4E
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 33322F
 				RightColor: 343330
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 444444
 				RightColor: 535353
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8C9296
 				RightColor: 888989
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C4DEF1
 				RightColor: B6BDC2
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: BED4E6
 				RightColor: A0A4A5
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C0DAEF
 				RightColor: A3A6A6
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: BAD5EE
 				RightColor: A1A4A5
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BAD5EE
 				RightColor: BED5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@708:
 		Category: TrainBridges
 		Id: 708
@@ -10807,36 +15219,56 @@ Templates:
 			0: Cliff
 				LeftColor: 9FA6AA
 				RightColor: 8E8D89
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 565656
 				RightColor: 515151
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 33322E
 				RightColor: 373633
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 3F3F3F
 				RightColor: 5F6060
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8C9296
 				RightColor: 868888
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C4DEF1
 				RightColor: B5C5D3
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: B5C9D8
 				RightColor: 9FA9B2
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B9CFE0
 				RightColor: 949594
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B7CDE1
 				RightColor: 9B9E9F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: B9D3ED
 				RightColor: BED5EA
+				ZOffset: -12
+				ZRamp: 0
 	Template@709:
 		Category: TrainBridges
 		Id: 709
@@ -10847,32 +15279,50 @@ Templates:
 				Height: 4
 				LeftColor: 414242
 				RightColor: 4B4B4B
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 2E2D2B
 				RightColor: 2D2B28
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 313131
 				RightColor: 4D4D4D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 84888A
 				RightColor: 838484
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BAD1E3
 				RightColor: A6ACB0
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: B5C9D8
 				RightColor: 8E9192
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B6CBDC
 				RightColor: 929492
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B7CDE1
 				RightColor: A0A3A3
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: B6D0E9
 				RightColor: B0C1D1
+				ZOffset: -12
+				ZRamp: 0
 	Template@710:
 		Category: TrainBridges
 		Id: 710
@@ -10882,33 +15332,53 @@ Templates:
 			0: Cliff
 				LeftColor: 9EA5AA
 				RightColor: 898987
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 959898
 				RightColor: 969491
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 898883
 				RightColor: 888783
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 949390
 				RightColor: 787776
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 828688
 				RightColor: 8D9499
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: BAD1E3
 				RightColor: B4C0CA
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: AEBECA
 				RightColor: 9FAEBC
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: A9B4BD
 				RightColor: 6D737A
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B6CCE1
 				RightColor: 9EA6AD
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: B2CBE5
 				RightColor: AEC0D1
+				ZOffset: -12
+				ZRamp: 0
 	Template@711:
 		Category: Rough ground
 		Id: 711
@@ -10918,111 +15388,183 @@ Templates:
 			2: Rough
 				LeftColor: 7F858C
 				RightColor: 9DADBC
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 848B92
 				RightColor: A8BCCC
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 929CA7
 				RightColor: 8B959E
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: ADBFCD
 				RightColor: 98A8B5
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 9CAAB6
 				RightColor: A8B7C8
+				ZOffset: -12
+				ZRamp: 0
 			18: Rough
 				LeftColor: BCD2E5
 				RightColor: B6CBDC
+				ZOffset: -12
+				ZRamp: 0
 			19: Rough
 				LeftColor: 72787F
 				RightColor: 9AA8B5
+				ZOffset: -12
+				ZRamp: 0
 			20: Rough
 				LeftColor: AABAC8
 				RightColor: 929AA3
+				ZOffset: -12
+				ZRamp: 0
 			21: Rough
 				LeftColor: 9FAEBD
 				RightColor: 818B96
+				ZOffset: -12
+				ZRamp: 0
 			22: Rough
 				LeftColor: 9FACBA
 				RightColor: ABBCCC
+				ZOffset: -12
+				ZRamp: 0
 			23: Rough
 				LeftColor: A6B9C9
 				RightColor: B6CBDD
+				ZOffset: -12
+				ZRamp: 0
 			24: Rough
 				LeftColor: 858F98
 				RightColor: B0C3D4
+				ZOffset: -12
+				ZRamp: 0
 			25: Rough
 				LeftColor: 909CA6
 				RightColor: B4CEEA
+				ZOffset: -12
+				ZRamp: 0
 			26: Rough
 				LeftColor: A0AEBD
 				RightColor: B7CDE2
+				ZOffset: -12
+				ZRamp: 0
 			28: Rough
 				LeftColor: B5C9DD
 				RightColor: 8D97A1
+				ZOffset: -12
+				ZRamp: 0
 			29: Rough
 				LeftColor: ABBCCB
 				RightColor: A2B0C0
+				ZOffset: -12
+				ZRamp: 0
 			30: Rough
 				LeftColor: 80878E
 				RightColor: 929BA3
+				ZOffset: -12
+				ZRamp: 0
 			31: Rough
 				LeftColor: A7B6C2
 				RightColor: A8B9C7
+				ZOffset: -12
+				ZRamp: 0
 			32: Rough
 				LeftColor: B1C4D3
 				RightColor: A9BACA
+				ZOffset: -12
+				ZRamp: 0
 			33: Rough
 				LeftColor: 9AA6B1
 				RightColor: 9EA9B4
+				ZOffset: -12
+				ZRamp: 0
 			34: Rough
 				LeftColor: A1B0BE
 				RightColor: 919BA6
+				ZOffset: -12
+				ZRamp: 0
 			35: Rough
 				LeftColor: 98A2AE
 				RightColor: B0C3D4
+				ZOffset: -12
+				ZRamp: 0
 			38: Rough
 				LeftColor: 94A0AD
 				RightColor: 9FACB8
+				ZOffset: -12
+				ZRamp: 0
 			39: Rough
 				LeftColor: 9EADBD
 				RightColor: 98A3AE
+				ZOffset: -12
+				ZRamp: 0
 			40: Rough
 				LeftColor: 9BA6B2
 				RightColor: A6B6C3
+				ZOffset: -12
+				ZRamp: 0
 			41: Rough
 				LeftColor: 9CAAB6
 				RightColor: B5C6D4
+				ZOffset: -12
+				ZRamp: 0
 			42: Rough
 				LeftColor: B5CBDE
 				RightColor: BDD7EE
+				ZOffset: -12
+				ZRamp: 0
 			43: Rough
 				LeftColor: BBD3E9
 				RightColor: B2C8DE
+				ZOffset: -12
+				ZRamp: 0
 			44: Rough
 				LeftColor: 9FAEC0
 				RightColor: AEC0D0
+				ZOffset: -12
+				ZRamp: 0
 			49: Rough
 				LeftColor: A9BACA
 				RightColor: A3B5C7
+				ZOffset: -12
+				ZRamp: 0
 			50: Rough
 				LeftColor: B1C2D1
 				RightColor: A2ADB8
+				ZOffset: -12
+				ZRamp: 0
 			51: Rough
 				LeftColor: 98A3AF
 				RightColor: 9FADB8
+				ZOffset: -12
+				ZRamp: 0
 			52: Rough
 				LeftColor: A0ACB5
 				RightColor: A4B2BE
+				ZOffset: -12
+				ZRamp: 0
 			53: Rough
 				LeftColor: AABCCD
 				RightColor: 97A3AD
+				ZOffset: -12
+				ZRamp: 0
 			60: Rough
 				LeftColor: B6CBDF
 				RightColor: 9BA7B2
+				ZOffset: -12
+				ZRamp: 0
 			61: Rough
 				LeftColor: 9CACBE
 				RightColor: A1B0C0
+				ZOffset: -12
+				ZRamp: 0
 	Template@712:
 		Category: Rough ground
 		Id: 712
@@ -11032,33 +15574,53 @@ Templates:
 			1: Rough
 				LeftColor: 9AAABA
 				RightColor: A5B8C9
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 848C94
 				RightColor: A5B8C9
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 94A0AC
 				RightColor: 949FAA
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 858B93
 				RightColor: 8E9AA5
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 8D959E
 				RightColor: 8C939C
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 99A9B8
 				RightColor: AFC5DC
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 9DAEBD
 				RightColor: 9EABB8
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: 828B94
 				RightColor: 99A5AF
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: A7B8C8
 				RightColor: 9BACBC
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: B1C5D8
 				RightColor: ABBAC8
+				ZOffset: -12
+				ZRamp: 0
 	Template@713:
 		Category: Rough ground
 		Id: 713
@@ -11068,36 +15630,58 @@ Templates:
 			0: Rough
 				LeftColor: B4CCE2
 				RightColor: 9CA8B5
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 95A1B0
 				RightColor: 8C97A2
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: B0C2D2
 				RightColor: B7CEE2
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 929DA8
 				RightColor: ADC2D4
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: BDD3E5
 				RightColor: B3C7D8
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 909BA6
 				RightColor: 9CA4AA
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: A8B8C6
 				RightColor: 929AA3
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: A0B0BE
 				RightColor: 99A8B6
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: B9CDDE
 				RightColor: 8D97A0
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: B2C6D9
 				RightColor: B0C3D6
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 8A949D
 				RightColor: 94A0A9
+				ZOffset: -12
+				ZRamp: 0
 	Template@714:
 		Category: Rough ground
 		Id: 714
@@ -11107,27 +15691,43 @@ Templates:
 			0: Rough
 				LeftColor: A1B0BD
 				RightColor: 9BA8B4
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: A6B7C8
 				RightColor: 919DA9
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 929DA9
 				RightColor: A8BBCC
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: B5C9DB
 				RightColor: C2D6E4
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 8F9BA7
 				RightColor: A7B7C5
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 929DA6
 				RightColor: B4CADB
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: A4B5C3
 				RightColor: 9EA9B4
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: A5B6C7
 				RightColor: 97A3B0
+				ZOffset: -12
+				ZRamp: 0
 	Template@715:
 		Category: Rough ground
 		Id: 715
@@ -11137,39 +15737,63 @@ Templates:
 			1: Rough
 				LeftColor: 939BA2
 				RightColor: A4B4C2
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 8F99A2
 				RightColor: 8D959E
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 7D8289
 				RightColor: 899097
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 86919D
 				RightColor: B1C5D8
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 99A8B8
 				RightColor: 94A1AC
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: BBD1E3
 				RightColor: 8F9BA9
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 939FA9
 				RightColor: ADC0D1
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: B7CCDE
 				RightColor: 97A6B5
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: A2ADB7
 				RightColor: A6B1BA
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: A7B5C3
 				RightColor: 94A0AC
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: A1B1C0
 				RightColor: AABBCC
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: ADBDCC
 				RightColor: BBCEDC
+				ZOffset: -12
+				ZRamp: 0
 	Template@716:
 		Category: Rough ground
 		Id: 716
@@ -11179,42 +15803,68 @@ Templates:
 			1: Clear
 				LeftColor: B3CADF
 				RightColor: A9BED3
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: BACFE0
 				RightColor: B8CFE5
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: B8CFE1
 				RightColor: AEC3D4
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 838D96
 				RightColor: 8F9BA7
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: A5B3C1
 				RightColor: B3C7DB
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 9DAAB5
 				RightColor: A5B9CB
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: B9D3EC
 				RightColor: A3B3C4
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: 99A4AF
 				RightColor: 9CAAB6
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: A2AEB9
 				RightColor: A4B0BA
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 7E858C
 				RightColor: 88949E
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: A0AEBD
 				RightColor: 7D868E
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: ADBCCB
 				RightColor: A1AEB8
+				ZOffset: -12
+				ZRamp: 0
 			15: Rough
 				LeftColor: A9B8C7
 				RightColor: A5B7C8
+				ZOffset: -12
+				ZRamp: 0
 	Template@717:
 		Category: Rough ground
 		Id: 717
@@ -11224,27 +15874,43 @@ Templates:
 			0: Rough
 				LeftColor: A0B0C1
 				RightColor: A4B4C3
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: ACBFD2
 				RightColor: A7B8C8
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: A6B5C2
 				RightColor: ADC1D1
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 9EACB9
 				RightColor: A5B4C3
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: AEBECD
 				RightColor: ABBAC7
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: BAC9D5
 				RightColor: A6B5C5
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: B5C9DC
 				RightColor: A5B3BF
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: B7CCDE
 				RightColor: A3B3C1
+				ZOffset: -12
+				ZRamp: 0
 	Template@718:
 		Category: Rough ground
 		Id: 718
@@ -11254,69 +15920,113 @@ Templates:
 			1: Rough
 				LeftColor: AABECF
 				RightColor: ACC1D4
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 99A6B4
 				RightColor: 95A1AD
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 848B92
 				RightColor: 919DAA
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: ABBECF
 				RightColor: 99A8B6
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 8F99A3
 				RightColor: 939DA5
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 858C94
 				RightColor: 94A4B1
+				ZOffset: -12
+				ZRamp: 0
 			15: Rough
 				LeftColor: A1B2C1
 				RightColor: B3C7D8
+				ZOffset: -12
+				ZRamp: 0
 			20: Rough
 				LeftColor: 9FAEBD
 				RightColor: 959FAC
+				ZOffset: -12
+				ZRamp: 0
 			21: Rough
 				LeftColor: A4B4C4
 				RightColor: 7D838A
+				ZOffset: -12
+				ZRamp: 0
 			22: Rough
 				LeftColor: 939EAA
 				RightColor: A9BCCD
+				ZOffset: -12
+				ZRamp: 0
 			26: Rough
 				LeftColor: B2C6D9
 				RightColor: A6B7C7
+				ZOffset: -12
+				ZRamp: 0
 			27: Rough
 				LeftColor: 9EADBA
 				RightColor: C2D7E4
+				ZOffset: -12
+				ZRamp: 0
 			28: Rough
 				LeftColor: 99A6B1
 				RightColor: B0C3D2
+				ZOffset: -12
+				ZRamp: 0
 			33: Rough
 				LeftColor: B7CCDC
 				RightColor: A9BACA
+				ZOffset: -12
+				ZRamp: 0
 			34: Rough
 				LeftColor: 98A4AF
 				RightColor: 9EA9B4
+				ZOffset: -12
+				ZRamp: 0
 			35: Rough
 				LeftColor: A6B7C6
 				RightColor: B4C9DB
+				ZOffset: -12
+				ZRamp: 0
 			40: Rough
 				LeftColor: ABBCCA
 				RightColor: C1DBEE
+				ZOffset: -12
+				ZRamp: 0
 			45: Rough
 				LeftColor: AEBFCF
 				RightColor: A8B6C2
+				ZOffset: -12
+				ZRamp: 0
 			46: Rough
 				LeftColor: A0AEBC
 				RightColor: AEC0D0
+				ZOffset: -12
+				ZRamp: 0
 			51: Rough
 				LeftColor: BBD0E2
 				RightColor: B8C9D6
+				ZOffset: -12
+				ZRamp: 0
 			52: Rough
 				LeftColor: A8B8C5
 				RightColor: A9B9CA
+				ZOffset: -12
+				ZRamp: 0
 			57: Rough
 				LeftColor: B0C2D3
 				RightColor: ADBECE
+				ZOffset: -12
+				ZRamp: 0
 	Template@719:
 		Category: Rough ground
 		Id: 719
@@ -11326,51 +16036,83 @@ Templates:
 			0: Clear
 				LeftColor: C5DBED
 				RightColor: CAE2F4
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: B2C1CA
 				RightColor: A1B0BD
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 7F878D
 				RightColor: 8A959F
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 939EA6
 				RightColor: 9AA9B5
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: A5B5C3
 				RightColor: 8E99A3
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: B6CADA
 				RightColor: BBD7F1
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: B3C9DD
 				RightColor: 96A0AA
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: AFC2D4
 				RightColor: 98A3AD
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: BED6EA
 				RightColor: AFC0D2
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: AFC1D4
 				RightColor: 8E99A5
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: 97A5B5
 				RightColor: A4B2BC
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 939CA6
 				RightColor: 9AA7B2
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 9CAAB5
 				RightColor: B3C6D4
+				ZOffset: -12
+				ZRamp: 0
 			15: Rough
 				LeftColor: A8BCCE
 				RightColor: AABED0
+				ZOffset: -12
+				ZRamp: 0
 			21: Clear
 				LeftColor: C1DCF3
 				RightColor: B6CBDD
+				ZOffset: -12
+				ZRamp: 0
 			22: Clear
 				LeftColor: B1C5D6
 				RightColor: BDD4E7
+				ZOffset: -12
+				ZRamp: 0
 	Template@720:
 		Category: Rough ground
 		Id: 720
@@ -11380,27 +16122,43 @@ Templates:
 			0: Rough
 				LeftColor: A8BBCC
 				RightColor: 99A9B8
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 9FAEBB
 				RightColor: B5CDE4
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 9CACB9
 				RightColor: 98A4AE
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: A7B5C2
 				RightColor: A8B9C6
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: ADBECC
 				RightColor: B0C6D9
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: A3B2C1
 				RightColor: A7B7C4
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: A9BBCA
 				RightColor: BBCFDF
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: A4B4C3
 				RightColor: B2C7DA
+				ZOffset: -12
+				ZRamp: 0
 	Template@721:
 		Category: Ramp edge fixup
 		Id: 721
@@ -11411,6 +16169,8 @@ Templates:
 				RampType: 1
 				LeftColor: D0E4F0
 				RightColor: CEE2EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@722:
 		Category: Ramp edge fixup
 		Id: 722
@@ -11421,6 +16181,8 @@ Templates:
 				RampType: 1
 				LeftColor: D2E5F0
 				RightColor: CDE0EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@723:
 		Category: Ramp edge fixup
 		Id: 723
@@ -11431,6 +16193,8 @@ Templates:
 				RampType: 1
 				LeftColor: D0E4F0
 				RightColor: CCE0EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@724:
 		Category: Ramp edge fixup
 		Id: 724
@@ -11441,6 +16205,8 @@ Templates:
 				RampType: 2
 				LeftColor: A0B9DD
 				RightColor: A1BCDE
+				ZOffset: -12
+				ZRamp: 0
 	Template@725:
 		Category: Ramp edge fixup
 		Id: 725
@@ -11451,6 +16217,8 @@ Templates:
 				RampType: 2
 				LeftColor: A6BFE2
 				RightColor: 9EB9DC
+				ZOffset: -12
+				ZRamp: 0
 	Template@726:
 		Category: Ramp edge fixup
 		Id: 726
@@ -11461,6 +16229,8 @@ Templates:
 				RampType: 2
 				LeftColor: A6C0E2
 				RightColor: A1BCDE
+				ZOffset: -12
+				ZRamp: 0
 	Template@727:
 		Category: Ramp edge fixup
 		Id: 727
@@ -11471,6 +16241,8 @@ Templates:
 				RampType: 3
 				LeftColor: AAC5E3
 				RightColor: A7C3E1
+				ZOffset: -12
+				ZRamp: 0
 	Template@728:
 		Category: Ramp edge fixup
 		Id: 728
@@ -11481,6 +16253,8 @@ Templates:
 				RampType: 3
 				LeftColor: AFCAE6
 				RightColor: A2BDDD
+				ZOffset: -12
+				ZRamp: 0
 	Template@729:
 		Category: Ramp edge fixup
 		Id: 729
@@ -11491,6 +16265,8 @@ Templates:
 				RampType: 3
 				LeftColor: AFCAE6
 				RightColor: A7C3E1
+				ZOffset: -12
+				ZRamp: 0
 	Template@730:
 		Category: Ramp edge fixup
 		Id: 730
@@ -11501,6 +16277,8 @@ Templates:
 				RampType: 4
 				LeftColor: D2E5F2
 				RightColor: D1E3EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@731:
 		Category: Ramp edge fixup
 		Id: 731
@@ -11511,6 +16289,8 @@ Templates:
 				RampType: 4
 				LeftColor: D6E8F2
 				RightColor: CBDFED
+				ZOffset: -12
+				ZRamp: 0
 	Template@732:
 		Category: Ramp edge fixup
 		Id: 732
@@ -11521,6 +16301,8 @@ Templates:
 				RampType: 4
 				LeftColor: D2E5F2
 				RightColor: CBDFED
+				ZOffset: -12
+				ZRamp: 0
 	Template@745:
 		Category: Water slopes
 		Id: 745
@@ -11531,18 +16313,26 @@ Templates:
 				RampType: 1
 				LeftColor: 738691
 				RightColor: CCE1F0
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 1
 				LeftColor: 465865
 				RightColor: 495C6B
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 1
 				LeftColor: 7D8F9A
 				RightColor: 5A6F7D
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 1
 				LeftColor: C9DAE4
 				RightColor: C7D9E6
+				ZOffset: -12
+				ZRamp: 0
 	Template@746:
 		Category: Water slopes
 		Id: 746
@@ -11553,18 +16343,26 @@ Templates:
 				RampType: 2
 				LeftColor: A0B8DC
 				RightColor: 879EB3
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 2
 				LeftColor: 596E7A
 				RightColor: 465966
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 2
 				LeftColor: 3B4D5B
 				RightColor: 728699
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 2
 				LeftColor: 93AEC8
 				RightColor: 93ADCC
+				ZOffset: -12
+				ZRamp: 0
 	Template@747:
 		Category: Water slopes
 		Id: 747
@@ -11575,18 +16373,26 @@ Templates:
 				RampType: 3
 				LeftColor: 8DA2B5
 				RightColor: A4BCD4
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 3
 				LeftColor: 4B5E6E
 				RightColor: 51636F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 3
 				LeftColor: 657887
 				RightColor: 516270
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 3
 				LeftColor: B9D2E7
 				RightColor: A7BBCE
+				ZOffset: -12
+				ZRamp: 0
 	Template@748:
 		Category: Water slopes
 		Id: 748
@@ -11597,18 +16403,26 @@ Templates:
 				RampType: 4
 				LeftColor: D4E5EF
 				RightColor: 91A1AA
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 4
 				LeftColor: 5E6E79
 				RightColor: 67767F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 4
 				LeftColor: 6B7D88
 				RightColor: 75868F
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 4
 				LeftColor: C5D8E5
 				RightColor: C5D7E3
+				ZOffset: -12
+				ZRamp: 0
 	Template@749:
 		Category: Paved Road Slopes
 		Id: 749
@@ -11619,14 +16433,20 @@ Templates:
 				RampType: 1
 				LeftColor: 6A7279
 				RightColor: A2AEB6
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				RampType: 1
 				LeftColor: 616161
 				RightColor: 686558
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				RampType: 1
 				LeftColor: 9AA7B0
 				RightColor: 7A838B
+				ZOffset: -12
+				ZRamp: 0
 	Template@750:
 		Category: Paved Road Slopes
 		Id: 750
@@ -11637,14 +16457,20 @@ Templates:
 				RampType: 2
 				LeftColor: 8494AA
 				RightColor: 596069
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				RampType: 2
 				LeftColor: 535146
 				RightColor: 4E4F4F
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				RampType: 2
 				LeftColor: 697682
 				RightColor: 7F92A7
+				ZOffset: -12
+				ZRamp: 0
 	Template@751:
 		Category: Paved Road Slopes
 		Id: 751
@@ -11655,14 +16481,20 @@ Templates:
 				RampType: 3
 				LeftColor: 4D4E4F
 				RightColor: 7E868E
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				RampType: 3
 				LeftColor: 4D4E4F
 				RightColor: 4F4F4E
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				RampType: 3
 				LeftColor: 7F8991
 				RightColor: 5B6165
+				ZOffset: -12
+				ZRamp: 0
 	Template@752:
 		Category: Paved Road Slopes
 		Id: 752
@@ -11673,14 +16505,20 @@ Templates:
 				RampType: 4
 				LeftColor: A2A9AE
 				RightColor: 5F6265
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 4
 				LeftColor: 575855
 				RightColor: 575858
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				RampType: 4
 				LeftColor: 64696D
 				RightColor: 8B949A
+				ZOffset: -12
+				ZRamp: 0
 	Template@753:
 		Category: Monorail Slopes
 		Id: 753
@@ -11691,6 +16529,8 @@ Templates:
 				RampType: 1
 				LeftColor: 4C4D4C
 				RightColor: 4D4C46
+				ZOffset: -12
+				ZRamp: 0
 	Template@754:
 		Category: Monorail Slopes
 		Id: 754
@@ -11701,6 +16541,8 @@ Templates:
 				RampType: 2
 				LeftColor: 3E434A
 				RightColor: 454645
+				ZOffset: -12
+				ZRamp: 0
 	Template@755:
 		Category: Monorail Slopes
 		Id: 755
@@ -11711,6 +16553,8 @@ Templates:
 				RampType: 3
 				LeftColor: 4A4942
 				RightColor: 474847
+				ZOffset: -12
+				ZRamp: 0
 	Template@756:
 		Category: Monorail Slopes
 		Id: 756
@@ -11721,6 +16565,8 @@ Templates:
 				RampType: 4
 				LeftColor: 373A3B
 				RightColor: 4B483F
+				ZOffset: -12
+				ZRamp: 0
 	Template@772:
 		Category: Tunnels
 		Id: 772
@@ -11730,48 +16576,78 @@ Templates:
 			0: Cliff
 				LeftColor: BAD5F0
 				RightColor: B6D1EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: BBD7F1
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 89A1AC
 				RightColor: 8AA2AD
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 606970
 				RightColor: 929CA5
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 798086
 				RightColor: 9CA7AF
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 4A5157
 				RightColor: 697479
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 545959
 				RightColor: 5A5C5A
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 535452
 				RightColor: 545553
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 424342
 				RightColor: 424442
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 919AA3
 				RightColor: 6C747A
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 8E98A1
 				RightColor: 6B7176
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 667279
 				RightColor: 4B5459
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 	Template@773:
 		Category: Tunnels
 		Id: 773
@@ -11781,48 +16657,78 @@ Templates:
 			0: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 9FA9B1
 				RightColor: 6B6F72
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 585753
 				RightColor: 565652
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 656A6F
 				RightColor: 959FA8
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: C2DCF2
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 9EA6AB
 				RightColor: 646768
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 55544F
 				RightColor: 545452
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 646567
 				RightColor: A7ABAF
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C4DDF1
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 8BA1AD
 				RightColor: 89A0AC
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 71777A
 				RightColor: 525556
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 454747
 				RightColor: 464746
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 525454
 				RightColor: 747779
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 859DA9
 				RightColor: 819BA8
+				ZOffset: -12
+				ZRamp: 0
 	Template@774:
 		Category: Tunnels
 		Id: 774
@@ -11832,39 +16738,63 @@ Templates:
 			0: Cliff
 				LeftColor: 0F1011
 				RightColor: 48525C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5F6467
 				RightColor: 686E77
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 9BAEC1
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 26292A
 				RightColor: 101213
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 475055
 				RightColor: 75828C
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 798085
 				RightColor: 9CA7AF
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 1B1C1B
 				RightColor: 080909
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 3B3D3C
 				RightColor: 434644
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 535451
 				RightColor: 545553
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 0B0C0C
 				RightColor: 353B3E
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 68747B
 				RightColor: 515B60
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 8D98A0
 				RightColor: 6B7176
+				ZOffset: -12
+				ZRamp: 0
 	Template@775:
 		Category: Tunnels
 		Id: 775
@@ -11874,39 +16804,63 @@ Templates:
 			0: Cliff
 				LeftColor: 232526
 				RightColor: 525B63
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 495155
 				RightColor: 0A0A0B
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 2A2D2D
 				RightColor: 050505
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 353B3E
 				RightColor: 0B0C0C
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 606B77
 				RightColor: 606870
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 75828C
 				RightColor: 475055
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 434644
 				RightColor: 3B3D3C
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 515B60
 				RightColor: 68747B
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C2DDF2
 				RightColor: 9DB0C3
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 9CA7B0
 				RightColor: 798085
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 545553
 				RightColor: 535451
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 6B7176
 				RightColor: 8D98A0
+				ZOffset: -12
+				ZRamp: 0
 	Template@776:
 		Category: Tunnel Side
 		Id: 776
@@ -11917,12 +16871,18 @@ Templates:
 				Height: 4
 				LeftColor: 8395A7
 				RightColor: 798895
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 95AFCA
 				RightColor: 959DA2
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: C0D8EB
 				RightColor: 99A0A4
+				ZOffset: -12
+				ZRamp: 0
 	Template@777:
 		Category: Tunnel Side
 		Id: 777
@@ -11932,12 +16892,18 @@ Templates:
 			0: Cliff
 				LeftColor: 85A0B5
 				RightColor: 8EA2B5
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 8E99A5
 				RightColor: 6E7780
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 9EA9B2
 				RightColor: B6C8D9
+				ZOffset: -12
+				ZRamp: 0
 	Template@778:
 		Category: TrackTunnel Floor
 		Id: 778
@@ -11947,48 +16913,78 @@ Templates:
 			0: Cliff
 				LeftColor: BAD5F0
 				RightColor: B6D1EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: BBD7F1
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 89A1AC
 				RightColor: 8AA2AD
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 606970
 				RightColor: 929CA5
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 798086
 				RightColor: 9CA7AF
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 4A5157
 				RightColor: 697479
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 4D5155
 				RightColor: 525558
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 4D4F52
 				RightColor: 515356
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 494C50
 				RightColor: 4D5154
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 919AA3
 				RightColor: 6C747A
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 8E98A1
 				RightColor: 6B7176
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 667279
 				RightColor: 4B5459
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 	Template@779:
 		Category: TrackTunnel Floor
 		Id: 779
@@ -11998,48 +16994,78 @@ Templates:
 			0: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 9FA9B1
 				RightColor: 6B6F72
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 4F5154
 				RightColor: 4D4F53
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 656A6F
 				RightColor: 959FA8
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: C2DCF2
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 9EA6AB
 				RightColor: 646768
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 4F5154
 				RightColor: 4D4F52
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 646567
 				RightColor: A7ABAF
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C4DDF1
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 8BA1AD
 				RightColor: 89A0AC
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 71777A
 				RightColor: 525556
+				ZOffset: -12
+				ZRamp: 0
 			12: Rail
 				LeftColor: 4C4E50
 				RightColor: 494C50
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 525454
 				RightColor: 747779
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 859DA9
 				RightColor: 819BA8
+				ZOffset: -12
+				ZRamp: 0
 	Template@780:
 		Category: TrackTunnel Floor
 		Id: 780
@@ -12049,39 +17075,63 @@ Templates:
 			0: Cliff
 				LeftColor: 0F1011
 				RightColor: 48525C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5F6467
 				RightColor: 686E77
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 9BAEC1
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 26292A
 				RightColor: 101213
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 475055
 				RightColor: 75828C
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 798085
 				RightColor: 9CA7AF
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 232425
 				RightColor: 090A0A
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 3C4043
 				RightColor: 484C50
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 4D4F52
 				RightColor: 515356
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 0B0C0C
 				RightColor: 353B3E
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 68747B
 				RightColor: 515B60
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 8D98A0
 				RightColor: 6B7176
+				ZOffset: -12
+				ZRamp: 0
 	Template@781:
 		Category: TrackTunnel Floor
 		Id: 781
@@ -12091,39 +17141,63 @@ Templates:
 			0: Cliff
 				LeftColor: 232526
 				RightColor: 525B63
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 495155
 				RightColor: 0A0A0B
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 292C2D
 				RightColor: 060606
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 353B3E
 				RightColor: 0B0C0C
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 606B77
 				RightColor: 606870
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 75828C
 				RightColor: 475055
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				LeftColor: 44494C
 				RightColor: 383C3F
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 515B60
 				RightColor: 68747B
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C2DDF2
 				RightColor: 9DB0C3
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 9CA7B0
 				RightColor: 798085
+				ZOffset: -12
+				ZRamp: 0
 			10: Rail
 				LeftColor: 4E5053
 				RightColor: 4C4F52
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 6B7176
 				RightColor: 8D98A0
+				ZOffset: -12
+				ZRamp: 0
 	Template@987:
 		Category: Destroyable Cliffs
 		Id: 987
@@ -12134,72 +17208,112 @@ Templates:
 				Height: 4
 				LeftColor: 889CAE
 				RightColor: 8FA2B1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 9DA9B1
 				RightColor: 8A9AA8
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 9CA8B2
 				RightColor: 99A7B3
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 9FABB4
 				RightColor: 93A6B4
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				Height: 4
 				LeftColor: 8C9DAE
 				RightColor: 7E90A0
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				Height: 4
 				LeftColor: 7C8DA2
 				RightColor: 879CB1
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				Height: 4
 				LeftColor: 84919F
 				RightColor: 8E9CAA
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 6D8092
 				RightColor: 8697A8
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				Height: 4
 				LeftColor: 8194A5
 				RightColor: 8F9FAD
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				Height: 4
 				LeftColor: 8597A9
 				RightColor: 869AB1
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: BCD7F0
 				RightColor: ACC1D5
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: D9E9F4
 				RightColor: B1C3D3
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: C6D8E5
 				RightColor: AABED1
+				ZOffset: -12
+				ZRamp: 0
 			15: Cliff
 				LeftColor: BED1E1
 				RightColor: 9CB3C8
+				ZOffset: -12
+				ZRamp: 0
 			16: Cliff
 				LeftColor: B7CDE1
 				RightColor: 94AABD
+				ZOffset: -12
+				ZRamp: 0
 			17: Cliff
 				LeftColor: B3CDE7
 				RightColor: A6BCCF
+				ZOffset: -12
+				ZRamp: 0
 			19: Cliff
 				LeftColor: BCD8F1
 				RightColor: C5DDF2
+				ZOffset: -12
+				ZRamp: 0
 			20: Cliff
 				LeftColor: C8E1F3
 				RightColor: C6DDEF
+				ZOffset: -12
+				ZRamp: 0
 			21: Cliff
 				LeftColor: BAD5EF
 				RightColor: C2DBEF
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: BDD7EE
 				RightColor: C2DBEF
+				ZOffset: -12
+				ZRamp: 0
 	Template@988:
 		Category: Destroyable Cliffs
 		Id: 988
@@ -12210,72 +17324,112 @@ Templates:
 				Height: 4
 				LeftColor: 899EB0
 				RightColor: 8696A4
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 87A3C2
 				RightColor: 87A2B8
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 96A7B5
 				RightColor: 98A9B6
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 899EB0
 				RightColor: 7F909F
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: A1BBDB
 				RightColor: 7E9BB4
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BBD5ED
 				RightColor: C2DCF2
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				Height: 4
 				LeftColor: 8A9EB1
 				RightColor: 8B9EB0
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 7F92A4
 				RightColor: 7D8FA0
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 9BB5D0
 				RightColor: 839EB8
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: ADC8E6
 				RightColor: BCD6EF
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 94A7B6
 				RightColor: 8DA0B0
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				Height: 4
 				LeftColor: 879CB0
 				RightColor: 738799
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: B7D1E5
 				RightColor: 94ADC7
+				ZOffset: -12
+				ZRamp: 0
 			15: Cliff
 				LeftColor: ADC8E7
 				RightColor: B8D3EE
+				ZOffset: -12
+				ZRamp: 0
 			16: Cliff
 				Height: 4
 				LeftColor: 8CA0B2
 				RightColor: 8295AC
+				ZOffset: -12
+				ZRamp: 0
 			17: Cliff
 				Height: 4
 				LeftColor: 778998
 				RightColor: 738493
+				ZOffset: -12
+				ZRamp: 0
 			18: Cliff
 				LeftColor: CAE0EE
 				RightColor: 88A3B6
+				ZOffset: -12
+				ZRamp: 0
 			19: Cliff
 				LeftColor: C3DCF0
 				RightColor: BFDAF0
+				ZOffset: -12
+				ZRamp: 0
 			21: Cliff
 				Height: 4
 				LeftColor: 8DA1B4
 				RightColor: 8698A8
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: ADC5DD
 				RightColor: 8AA7BF
+				ZOffset: -12
+				ZRamp: 0
 	Template@989:
 		Category: Rock LAT
 		Id: 989
@@ -12285,6 +17439,8 @@ Templates:
 			0: Rough
 				LeftColor: 54564F
 				RightColor: 565750
+				ZOffset: -12
+				ZRamp: 0
 	Template@990:
 		Category: Rock/Clear LAT
 		Id: 990
@@ -12294,6 +17450,8 @@ Templates:
 			0: Rough
 				LeftColor: 6B7576
 				RightColor: 646F70
+				ZOffset: -12
+				ZRamp: 0
 	Template@991:
 		Category: Rock/Clear LAT
 		Id: 991
@@ -12303,6 +17461,8 @@ Templates:
 			0: Rough
 				LeftColor: 747F84
 				RightColor: 7E8D96
+				ZOffset: -12
+				ZRamp: 0
 	Template@992:
 		Category: Rock/Clear LAT
 		Id: 992
@@ -12312,6 +17472,8 @@ Templates:
 			0: Rough
 				LeftColor: 5D605A
 				RightColor: 85939A
+				ZOffset: -12
+				ZRamp: 0
 	Template@993:
 		Category: Rock/Clear LAT
 		Id: 993
@@ -12321,6 +17483,8 @@ Templates:
 			0: Rough
 				LeftColor: 687071
 				RightColor: A2B6C9
+				ZOffset: -12
+				ZRamp: 0
 	Template@994:
 		Category: Rock/Clear LAT
 		Id: 994
@@ -12330,6 +17494,8 @@ Templates:
 			0: Rough
 				LeftColor: 7B8B95
 				RightColor: 595B55
+				ZOffset: -12
+				ZRamp: 0
 	Template@995:
 		Category: Rock/Clear LAT
 		Id: 995
@@ -12339,6 +17505,8 @@ Templates:
 			0: Rough
 				LeftColor: 9AAAB8
 				RightColor: 919FAA
+				ZOffset: -12
+				ZRamp: 0
 	Template@996:
 		Category: Rock/Clear LAT
 		Id: 996
@@ -12348,6 +17516,8 @@ Templates:
 			0: Rough
 				LeftColor: 85929A
 				RightColor: 8B98A0
+				ZOffset: -12
+				ZRamp: 0
 	Template@997:
 		Category: Rock/Clear LAT
 		Id: 997
@@ -12357,6 +17527,8 @@ Templates:
 			0: Rough
 				LeftColor: 919FAB
 				RightColor: AEC5DB
+				ZOffset: -12
+				ZRamp: 0
 	Template@998:
 		Category: Rock/Clear LAT
 		Id: 998
@@ -12366,6 +17538,8 @@ Templates:
 			0: Rough
 				LeftColor: 7B8487
 				RightColor: 5C5E58
+				ZOffset: -12
+				ZRamp: 0
 	Template@999:
 		Category: Rock/Clear LAT
 		Id: 999
@@ -12375,6 +17549,8 @@ Templates:
 			0: Rough
 				LeftColor: 93A4AF
 				RightColor: 8C98A1
+				ZOffset: -12
+				ZRamp: 0
 	Template@1000:
 		Category: Rock/Clear LAT
 		Id: 1000
@@ -12384,6 +17560,8 @@ Templates:
 			0: Rough
 				LeftColor: 8597A4
 				RightColor: 7F8E98
+				ZOffset: -12
+				ZRamp: 0
 	Template@1001:
 		Category: Rock/Clear LAT
 		Id: 1001
@@ -12393,6 +17571,8 @@ Templates:
 			0: Rough
 				LeftColor: A4B3C0
 				RightColor: BDD6EB
+				ZOffset: -12
+				ZRamp: 0
 	Template@1002:
 		Category: Rock/Clear LAT
 		Id: 1002
@@ -12402,6 +17582,8 @@ Templates:
 			0: Rough
 				LeftColor: A3B5C4
 				RightColor: 616460
+				ZOffset: -12
+				ZRamp: 0
 	Template@1003:
 		Category: Rock/Clear LAT
 		Id: 1003
@@ -12411,6 +17593,8 @@ Templates:
 			0: Rough
 				LeftColor: B1C7D9
 				RightColor: 8E9DAA
+				ZOffset: -12
+				ZRamp: 0
 	Template@1004:
 		Category: Rock/Clear LAT
 		Id: 1004
@@ -12420,6 +17604,8 @@ Templates:
 			0: Rough
 				LeftColor: BCD5EE
 				RightColor: A3B6C6
+				ZOffset: -12
+				ZRamp: 0
 	Template@1005:
 		Category: Rock/Clear LAT
 		Id: 1005
@@ -12429,6 +17615,8 @@ Templates:
 			0: Rough
 				LeftColor: 8F9DA7
 				RightColor: 90A3B3
+				ZOffset: -12
+				ZRamp: 0
 	Template@1006:
 		Category: Grey
 		Id: 1006
@@ -12438,6 +17626,8 @@ Templates:
 			0: Clear
 				LeftColor: 757D81
 				RightColor: A0A4A7
+				ZOffset: -12
+				ZRamp: 0
 	Template@1007:
 		Category: Grey/Clear LAT
 		Id: 1007
@@ -12447,6 +17637,8 @@ Templates:
 			0: Road
 				LeftColor: B9CDDE
 				RightColor: B6C9DB
+				ZOffset: -12
+				ZRamp: 0
 	Template@1008:
 		Category: Grey/Clear LAT
 		Id: 1008
@@ -12456,6 +17648,8 @@ Templates:
 			0: Road
 				LeftColor: 929EA5
 				RightColor: A7BACB
+				ZOffset: -12
+				ZRamp: 0
 	Template@1009:
 		Category: Grey/Clear LAT
 		Id: 1009
@@ -12465,6 +17659,8 @@ Templates:
 			0: Road
 				LeftColor: A3A9AE
 				RightColor: B9C7D6
+				ZOffset: -12
+				ZRamp: 0
 	Template@1010:
 		Category: Grey/Clear LAT
 		Id: 1010
@@ -12474,6 +17670,8 @@ Templates:
 			0: Road
 				LeftColor: A6A9AB
 				RightColor: BFD0E0
+				ZOffset: -12
+				ZRamp: 0
 	Template@1011:
 		Category: Grey/Clear LAT
 		Id: 1011
@@ -12483,6 +17681,8 @@ Templates:
 			0: Road
 				LeftColor: B2C0CE
 				RightColor: A7A9AB
+				ZOffset: -12
+				ZRamp: 0
 	Template@1012:
 		Category: Grey/Clear LAT
 		Id: 1012
@@ -12492,6 +17692,8 @@ Templates:
 			0: Road
 				LeftColor: A6B7C5
 				RightColor: A0B2C0
+				ZOffset: -12
+				ZRamp: 0
 	Template@1013:
 		Category: Grey/Clear LAT
 		Id: 1013
@@ -12501,6 +17703,8 @@ Templates:
 			0: Road
 				LeftColor: B6C6D4
 				RightColor: A1B1BE
+				ZOffset: -12
+				ZRamp: 0
 	Template@1014:
 		Category: Grey/Clear LAT
 		Id: 1014
@@ -12510,6 +17714,8 @@ Templates:
 			0: Road
 				LeftColor: AEB9C2
 				RightColor: B4CBDE
+				ZOffset: -12
+				ZRamp: 0
 	Template@1015:
 		Category: Grey/Clear LAT
 		Id: 1015
@@ -12519,6 +17725,8 @@ Templates:
 			0: Road
 				LeftColor: A4B8C8
 				RightColor: 8F999F
+				ZOffset: -12
+				ZRamp: 0
 	Template@1016:
 		Category: Grey/Clear LAT
 		Id: 1016
@@ -12528,6 +17736,8 @@ Templates:
 			0: Road
 				LeftColor: 93A4B0
 				RightColor: AAB9C6
+				ZOffset: -12
+				ZRamp: 0
 	Template@1017:
 		Category: Grey/Clear LAT
 		Id: 1017
@@ -12537,6 +17747,8 @@ Templates:
 			0: Road
 				LeftColor: A7B3BD
 				RightColor: A8B3BC
+				ZOffset: -12
+				ZRamp: 0
 	Template@1018:
 		Category: Grey/Clear LAT
 		Id: 1018
@@ -12546,6 +17758,8 @@ Templates:
 			0: Road
 				LeftColor: ADBBC6
 				RightColor: C0D9EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@1019:
 		Category: Grey/Clear LAT
 		Id: 1019
@@ -12555,6 +17769,8 @@ Templates:
 			0: Road
 				LeftColor: B3C7D9
 				RightColor: 95989A
+				ZOffset: -12
+				ZRamp: 0
 	Template@1020:
 		Category: Grey/Clear LAT
 		Id: 1020
@@ -12564,6 +17780,8 @@ Templates:
 			0: Road
 				LeftColor: BED5E7
 				RightColor: A2AFBA
+				ZOffset: -12
+				ZRamp: 0
 	Template@1021:
 		Category: Grey/Clear LAT
 		Id: 1021
@@ -12573,6 +17791,8 @@ Templates:
 			0: Road
 				LeftColor: BFD8EB
 				RightColor: ACB9C4
+				ZOffset: -12
+				ZRamp: 0
 	Template@1022:
 		Category: Grey/Clear LAT
 		Id: 1022
@@ -12582,6 +17802,8 @@ Templates:
 			0: Road
 				LeftColor: B1C0CD
 				RightColor: B2C0CC
+				ZOffset: -12
+				ZRamp: 0
 	Template@1023:
 		Category: DirtTrackTunnel Floor
 		Id: 1023
@@ -12591,48 +17813,78 @@ Templates:
 			0: Cliff
 				LeftColor: BAD5F0
 				RightColor: B6D1EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: BBD7F1
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 89A1AC
 				RightColor: 8AA2AD
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 68717A
 				RightColor: 687078
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 69727A
 				RightColor: 687078
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 5B6369
 				RightColor: 5D6469
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 	Template@1024:
 		Category: DirtTrackTunnel Floor
 		Id: 1024
@@ -12642,48 +17894,78 @@ Templates:
 			0: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 656D75
 				RightColor: 677079
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: C2DCF2
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 656D75
 				RightColor: 68717A
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C4DDF1
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 8BA1AD
 				RightColor: 89A0AC
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 879FAC
 				RightColor: 89A1AD
+				ZOffset: -12
+				ZRamp: 0
 			12: Rail
 				LeftColor: 5A6166
 				RightColor: 5A6268
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 879FAC
 				RightColor: 89A1AD
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 859DA9
 				RightColor: 819BA8
+				ZOffset: -12
+				ZRamp: 0
 	Template@1025:
 		Category: DirtTrackTunnel Floor
 		Id: 1025
@@ -12693,39 +17975,63 @@ Templates:
 			0: Cliff
 				LeftColor: 0F1011
 				RightColor: 48525C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5F6467
 				RightColor: 686E77
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 9BAEC1
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 879FAC
 				RightColor: 1D2225
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 5A6268
 				RightColor: 121415
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 68717A
 				RightColor: 697178
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 677079
 				RightColor: 687078
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 1B1F22
 				RightColor: 89A1AD
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@1026:
 		Category: DirtTrackTunnel Floor
 		Id: 1026
@@ -12735,39 +18041,63 @@ Templates:
 			0: Cliff
 				LeftColor: 232526
 				RightColor: 525B63
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 89A1AD
 				RightColor: 1D2224
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 5A6166
 				RightColor: 111314
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 89A1AD
 				RightColor: 1B1F22
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 606B77
 				RightColor: 606870
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				LeftColor: 666E75
 				RightColor: 677079
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C2DDF2
 				RightColor: 9DB0C3
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			10: Rail
 				LeftColor: 656D75
 				RightColor: 667079
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@1027:
 		Category: DirtTunnel Floor
 		Id: 1027
@@ -12777,48 +18107,78 @@ Templates:
 			0: Cliff
 				LeftColor: BAD5F0
 				RightColor: B6D1EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: BBD7F1
 				RightColor: BDD8F1
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 89A1AC
 				RightColor: 8AA2AD
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 89A1AD
 				RightColor: 879FAC
+				ZOffset: -12
+				ZRamp: 0
 	Template@1028:
 		Category: DirtTunnel Floor
 		Id: 1028
@@ -12828,48 +18188,78 @@ Templates:
 			0: Cliff
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: C2DCF2
 				RightColor: BFDAF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C4DDF1
 				RightColor: C1DBF1
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 8BA1AD
 				RightColor: 89A0AC
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 879FAC
 				RightColor: 89A1AD
+				ZOffset: -12
+				ZRamp: 0
 			12: Clear
 				LeftColor: 879FAC
 				RightColor: 89A1AD
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 879FAC
 				RightColor: 89A1AD
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 859DA9
 				RightColor: 819BA8
+				ZOffset: -12
+				ZRamp: 0
 	Template@1029:
 		Category: DirtTunnel Floor
 		Id: 1029
@@ -12879,39 +18269,63 @@ Templates:
 			0: Cliff
 				LeftColor: 0F1011
 				RightColor: 48525C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5F6467
 				RightColor: 686E77
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 9BAEC1
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 879FAC
 				RightColor: 1D2225
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 879FAC
 				RightColor: 1B2022
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 1B1F22
 				RightColor: 89A1AD
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: C1DBF2
 				RightColor: C2DDF2
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: BBD6EF
 				RightColor: BCD6EE
+				ZOffset: -12
+				ZRamp: 0
 	Template@1030:
 		Category: DirtTunnel Floor
 		Id: 1030
@@ -12921,39 +18335,63 @@ Templates:
 			0: Cliff
 				LeftColor: 232526
 				RightColor: 525B63
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 89A1AD
 				RightColor: 1D2224
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 89A1AD
 				RightColor: 1B1F22
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 89A1AD
 				RightColor: 1B1F22
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 606B77
 				RightColor: 606870
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: C2DDF2
 				RightColor: C1DBF2
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C2DDF2
 				RightColor: 9DB0C3
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: BCD6EE
 				RightColor: BBD6EF
+				ZOffset: -12
+				ZRamp: 0
 	Template@1031:
 		Category: Pavement (Use for LAT)
 		Id: 1031
@@ -12963,6 +18401,8 @@ Templates:
 			0: Road
 				LeftColor: 6C7275
 				RightColor: 6E6F70
+				ZOffset: -12
+				ZRamp: 0
 	Template@1032:
 		Category: Pavement
 		Id: 1032
@@ -12972,6 +18412,8 @@ Templates:
 			0: Road
 				LeftColor: 686A6E
 				RightColor: 656768
+				ZOffset: -12
+				ZRamp: 0
 	Template@1033:
 		Category: Pavement
 		Id: 1033
@@ -12981,6 +18423,8 @@ Templates:
 			0: Road
 				LeftColor: 6A6C6F
 				RightColor: 65676A
+				ZOffset: -12
+				ZRamp: 0
 	Template@1034:
 		Category: Pavement
 		Id: 1034
@@ -12990,6 +18434,8 @@ Templates:
 			0: Road
 				LeftColor: 666A6A
 				RightColor: 646564
+				ZOffset: -12
+				ZRamp: 0
 	Template@1035:
 		Category: Pavement
 		Id: 1035
@@ -12999,6 +18445,8 @@ Templates:
 			0: Road
 				LeftColor: 626668
 				RightColor: 5F6062
+				ZOffset: -12
+				ZRamp: 0
 	Template@1036:
 		Category: Pavement
 		Id: 1036
@@ -13008,15 +18456,23 @@ Templates:
 			0: Road
 				LeftColor: 666865
 				RightColor: 666867
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 666764
 				RightColor: 666868
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 646666
 				RightColor: 646765
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 656768
 				RightColor: 686A68
+				ZOffset: -12
+				ZRamp: 0
 	Template@1037:
 		Category: Pavement
 		Id: 1037
@@ -13026,15 +18482,23 @@ Templates:
 			0: Road
 				LeftColor: 676968
 				RightColor: 656664
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 656564
 				RightColor: 646565
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 676969
 				RightColor: 646666
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 676A6A
 				RightColor: 696A6A
+				ZOffset: -12
+				ZRamp: 0
 	Template@1038:
 		Category: Pavement
 		Id: 1038
@@ -13044,15 +18508,23 @@ Templates:
 			0: Road
 				LeftColor: 646665
 				RightColor: 606060
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 656869
 				RightColor: 686C6D
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 686C6E
 				RightColor: 67696B
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 616366
 				RightColor: 636567
+				ZOffset: -12
+				ZRamp: 0
 	Template@1039:
 		Category: Pavement
 		Id: 1039
@@ -13062,15 +18534,23 @@ Templates:
 			0: Road
 				LeftColor: 6B6C6C
 				RightColor: 676868
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6C6D6C
 				RightColor: 6C6D6D
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 686969
 				RightColor: 686969
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6A6C6E
 				RightColor: 6C6D6D
+				ZOffset: -12
+				ZRamp: 0
 	Template@1040:
 		Category: Pavement
 		Id: 1040
@@ -13080,15 +18560,23 @@ Templates:
 			0: Road
 				LeftColor: 6D7275
 				RightColor: 6B6E6E
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6D6F6F
 				RightColor: 6B6E6E
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 656768
 				RightColor: 676A6C
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 666969
 				RightColor: 6B6F74
+				ZOffset: -12
+				ZRamp: 0
 	Template@1041:
 		Category: Pavement
 		Id: 1041
@@ -13098,15 +18586,23 @@ Templates:
 			0: Road
 				LeftColor: 686B6E
 				RightColor: 656668
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 686968
 				RightColor: 676A6B
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 676A6D
 				RightColor: 67696B
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 676B6D
 				RightColor: 66676A
+				ZOffset: -12
+				ZRamp: 0
 	Template@1042:
 		Category: Pavement
 		Id: 1042
@@ -13116,15 +18612,23 @@ Templates:
 			0: Road
 				LeftColor: 656764
 				RightColor: 6A6B66
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6C6F6A
 				RightColor: 696C6C
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 656765
 				RightColor: 686A65
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6A6E6D
 				RightColor: 6B6D6C
+				ZOffset: -12
+				ZRamp: 0
 	Template@1043:
 		Category: Pavement
 		Id: 1043
@@ -13134,15 +18638,23 @@ Templates:
 			0: Road
 				LeftColor: 676A68
 				RightColor: 6B6E69
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6D6F6A
 				RightColor: 686D6C
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 686C6B
 				RightColor: 6F6F68
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6A6A64
 				RightColor: 666867
+				ZOffset: -12
+				ZRamp: 0
 	Template@1044:
 		Category: Pavement
 		Id: 1044
@@ -13152,15 +18664,23 @@ Templates:
 			0: Road
 				LeftColor: 656868
 				RightColor: 676864
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6A6A66
 				RightColor: 666A69
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 676967
 				RightColor: 696861
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6A6B65
 				RightColor: 666765
+				ZOffset: -12
+				ZRamp: 0
 	Template@1045:
 		Category: Pavement
 		Id: 1045
@@ -13170,15 +18690,23 @@ Templates:
 			0: Road
 				LeftColor: 656868
 				RightColor: 676864
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6A6A66
 				RightColor: 666A69
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 676967
 				RightColor: 696861
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6A6B65
 				RightColor: 666765
+				ZOffset: -12
+				ZRamp: 0
 	Template@1046:
 		Category: Pavement/Clear LAT
 		Id: 1046
@@ -13188,6 +18716,8 @@ Templates:
 			0: Road
 				LeftColor: 88959F
 				RightColor: 909DA8
+				ZOffset: -12
+				ZRamp: 0
 	Template@1047:
 		Category: Pavement/Clear LAT
 		Id: 1047
@@ -13197,6 +18727,8 @@ Templates:
 			0: Road
 				LeftColor: 7C858B
 				RightColor: 93A3AF
+				ZOffset: -12
+				ZRamp: 0
 	Template@1048:
 		Category: Pavement/Clear LAT
 		Id: 1048
@@ -13206,6 +18738,8 @@ Templates:
 			0: Road
 				LeftColor: 727C81
 				RightColor: 97A8B2
+				ZOffset: -12
+				ZRamp: 0
 	Template@1049:
 		Category: Pavement/Clear LAT
 		Id: 1049
@@ -13215,6 +18749,8 @@ Templates:
 			0: Road
 				LeftColor: 828E96
 				RightColor: AFCAE3
+				ZOffset: -12
+				ZRamp: 0
 	Template@1050:
 		Category: Pavement/Clear LAT
 		Id: 1050
@@ -13224,6 +18760,8 @@ Templates:
 			0: Road
 				LeftColor: 95A6B1
 				RightColor: 7A8288
+				ZOffset: -12
+				ZRamp: 0
 	Template@1051:
 		Category: Pavement/Clear LAT
 		Id: 1051
@@ -13233,6 +18771,8 @@ Templates:
 			0: Road
 				LeftColor: 9CAEBC
 				RightColor: 9EAFBD
+				ZOffset: -12
+				ZRamp: 0
 	Template@1052:
 		Category: Pavement/Clear LAT
 		Id: 1052
@@ -13242,6 +18782,8 @@ Templates:
 			0: Road
 				LeftColor: A2B3C0
 				RightColor: A2B6C4
+				ZOffset: -12
+				ZRamp: 0
 	Template@1053:
 		Category: Pavement/Clear LAT
 		Id: 1053
@@ -13251,6 +18793,8 @@ Templates:
 			0: Road
 				LeftColor: 848F96
 				RightColor: A0B4C4
+				ZOffset: -12
+				ZRamp: 0
 	Template@1054:
 		Category: Pavement/Clear LAT
 		Id: 1054
@@ -13260,6 +18804,8 @@ Templates:
 			0: Road
 				LeftColor: 8E9FAA
 				RightColor: 7F868B
+				ZOffset: -12
+				ZRamp: 0
 	Template@1055:
 		Category: Pavement/Clear LAT
 		Id: 1055
@@ -13269,6 +18815,8 @@ Templates:
 			0: Road
 				LeftColor: 93A4B3
 				RightColor: 92A0AB
+				ZOffset: -12
+				ZRamp: 0
 	Template@1056:
 		Category: Pavement/Clear LAT
 		Id: 1056
@@ -13278,6 +18826,8 @@ Templates:
 			0: Road
 				LeftColor: 94A4B0
 				RightColor: 96A6B0
+				ZOffset: -12
+				ZRamp: 0
 	Template@1057:
 		Category: Pavement/Clear LAT
 		Id: 1057
@@ -13287,6 +18837,8 @@ Templates:
 			0: Road
 				LeftColor: 8E9CA6
 				RightColor: A7C0D6
+				ZOffset: -12
+				ZRamp: 0
 	Template@1058:
 		Category: Pavement/Clear LAT
 		Id: 1058
@@ -13296,6 +18848,8 @@ Templates:
 			0: Road
 				LeftColor: B1C9DB
 				RightColor: 798187
+				ZOffset: -12
+				ZRamp: 0
 	Template@1059:
 		Category: Pavement/Clear LAT
 		Id: 1059
@@ -13305,6 +18859,8 @@ Templates:
 			0: Road
 				LeftColor: B3CADD
 				RightColor: 91A0AC
+				ZOffset: -12
+				ZRamp: 0
 	Template@1060:
 		Category: Pavement/Clear LAT
 		Id: 1060
@@ -13314,6 +18870,8 @@ Templates:
 			0: Road
 				LeftColor: A6BCCB
 				RightColor: 88969F
+				ZOffset: -12
+				ZRamp: 0
 	Template@1061:
 		Category: Pavement/Clear LAT
 		Id: 1061
@@ -13323,3 +18881,5 @@ Templates:
 			0: Road
 				LeftColor: 97A8B7
 				RightColor: 99AAB8
+				ZOffset: -12
+				ZRamp: 0

--- a/mods/ts/tilesets/temperate.yaml
+++ b/mods/ts/tilesets/temperate.yaml
@@ -80,6 +80,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D573D
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@1:
 		Category: Misc Buildings
 		Id: 1
@@ -89,6 +91,8 @@ Templates:
 			0: Rough
 				LeftColor: 7A7E8B
 				RightColor: 61666D
+				ZOffset: -12
+				ZRamp: 0
 	Template@2:
 		Category: Misc Buildings
 		Id: 2
@@ -98,15 +102,23 @@ Templates:
 			0: Rough
 				LeftColor: 808285
 				RightColor: 7A7E86
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 6E7176
 				RightColor: 83879A
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 9C9EB1
 				RightColor: 73777E
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 9297AD
 				RightColor: 9195AC
+				ZOffset: -12
+				ZRamp: 0
 	Template@3:
 		Category: Misc Buildings
 		Id: 3
@@ -116,30 +128,48 @@ Templates:
 			0: Cliff
 				LeftColor: 676E76
 				RightColor: 70767C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 505458
 				RightColor: 5F636D
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: BEC0EC
 				RightColor: CECFF6
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 787B82
 				RightColor: 797E84
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6D7075
 				RightColor: 575A66
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: C7C8F6
 				RightColor: C6C8F8
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: CBCCF7
 				RightColor: C4C6E6
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: C2C4E6
 				RightColor: ADB0CE
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: C4C6F0
 				RightColor: C2C4F6
+				ZOffset: -12
+				ZRamp: 0
 	Template@4:
 		Category: Clear
 		Id: 4
@@ -149,6 +179,8 @@ Templates:
 			0: Clear
 				LeftColor: C7C9FA
 				RightColor: C3C5FA
+				ZOffset: -12
+				ZRamp: 0
 	Template@5:
 		Category: Clear
 		Id: 5
@@ -158,6 +190,8 @@ Templates:
 			0: Clear
 				LeftColor: CBCCF7
 				RightColor: CFD0F5
+				ZOffset: -12
+				ZRamp: 0
 	Template@6:
 		Category: Clear
 		Id: 6
@@ -167,6 +201,8 @@ Templates:
 			0: Clear
 				LeftColor: C8CAF9
 				RightColor: CBCCF7
+				ZOffset: -12
+				ZRamp: 0
 	Template@7:
 		Category: Clear
 		Id: 7
@@ -176,6 +212,8 @@ Templates:
 			0: Clear
 				LeftColor: CFD0F6
 				RightColor: D1D2F5
+				ZOffset: -12
+				ZRamp: 0
 	Template@8:
 		Category: Cliff Pieces
 		Id: 8
@@ -185,6 +223,8 @@ Templates:
 			0: Rough
 				LeftColor: CFD0F6
 				RightColor: D1D2F5
+				ZOffset: -12
+				ZRamp: 0
 	Template@9:
 		Category: Cliff Pieces
 		Id: 9
@@ -194,6 +234,8 @@ Templates:
 			0: Rough
 				LeftColor: CFD0F6
 				RightColor: D1D2F5
+				ZOffset: -12
+				ZRamp: 0
 	Template@10:
 		Category: Ice Flow
 		Id: 10
@@ -203,111 +245,183 @@ Templates:
 			2: Rough
 				LeftColor: 81828D
 				RightColor: A5A6BE
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 878893
 				RightColor: B3B4CD
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 9798AA
 				RightColor: 8F919E
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: B8B9CB
 				RightColor: A0A1B6
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: A4A4B8
 				RightColor: AFB0CE
+				ZOffset: -12
+				ZRamp: 0
 			18: Rough
 				LeftColor: C9CAE7
 				RightColor: C3C4DD
+				ZOffset: -12
+				ZRamp: 0
 			19: Rough
 				LeftColor: 737582
 				RightColor: A3A4BB
+				ZOffset: -12
+				ZRamp: 0
 			20: Rough
 				LeftColor: B3B4CA
 				RightColor: 9596A5
+				ZOffset: -12
+				ZRamp: 0
 			21: Rough
 				LeftColor: A7A8C0
 				RightColor: 858699
+				ZOffset: -12
+				ZRamp: 0
 			22: Rough
 				LeftColor: A6A7BD
 				RightColor: B4B5CF
+				ZOffset: -12
+				ZRamp: 0
 			23: Rough
 				LeftColor: B0B1CB
 				RightColor: C4C5E4
+				ZOffset: -12
+				ZRamp: 0
 			24: Rough
 				LeftColor: 999AAA
 				RightColor: BFC0DD
+				ZOffset: -12
+				ZRamp: 0
 			25: Rough
 				LeftColor: 9697A8
 				RightColor: C1C3F3
+				ZOffset: -12
+				ZRamp: 0
 			26: Rough
 				LeftColor: A7A8C1
 				RightColor: C3C4E6
+				ZOffset: -12
+				ZRamp: 0
 			28: Rough
 				LeftColor: BFC1E3
 				RightColor: 9192A4
+				ZOffset: -12
+				ZRamp: 0
 			29: Rough
 				LeftColor: B4B5CE
 				RightColor: AAAAC4
+				ZOffset: -12
+				ZRamp: 0
 			30: Rough
 				LeftColor: 82838F
 				RightColor: 9697A2
+				ZOffset: -12
+				ZRamp: 0
 			31: Rough
 				LeftColor: AFB0C3
 				RightColor: B2B2C8
+				ZOffset: -12
+				ZRamp: 0
 			32: Rough
 				LeftColor: BDBDD2
 				RightColor: B3B3CD
+				ZOffset: -12
+				ZRamp: 0
 			33: Rough
 				LeftColor: A0A1B2
 				RightColor: A4A4B6
+				ZOffset: -12
+				ZRamp: 0
 			34: Rough
 				LeftColor: A9AAC1
 				RightColor: 9696A9
+				ZOffset: -12
+				ZRamp: 0
 			35: Rough
 				LeftColor: 9D9EB0
 				RightColor: BBBCD6
+				ZOffset: -12
+				ZRamp: 0
 			38: Rough
 				LeftColor: 9A9BB0
 				RightColor: A6A6B9
+				ZOffset: -12
+				ZRamp: 0
 			39: Rough
 				LeftColor: A6A7C2
 				RightColor: 9D9EB1
+				ZOffset: -12
+				ZRamp: 0
 			40: Rough
 				LeftColor: A1A1B5
 				RightColor: AFAFC5
+				ZOffset: -12
+				ZRamp: 0
 			41: Rough
 				LeftColor: A3A4B6
 				RightColor: BFC0D3
+				ZOffset: -12
+				ZRamp: 0
 			42: Rough
 				LeftColor: C0C1E2
 				RightColor: CBCCF3
+				ZOffset: -12
+				ZRamp: 0
 			43: Rough
 				LeftColor: C9CAEA
 				RightColor: BEBFE5
+				ZOffset: -12
+				ZRamp: 0
 			44: Rough
 				LeftColor: A6A8C6
 				RightColor: B8B9D0
+				ZOffset: -12
+				ZRamp: 0
 			49: Rough
 				LeftColor: B1B3CE
 				RightColor: ADAECB
+				ZOffset: -12
+				ZRamp: 0
 			50: Rough
 				LeftColor: BBBBD3
 				RightColor: A8A9BA
+				ZOffset: -12
+				ZRamp: 0
 			51: Rough
 				LeftColor: 9D9EB1
 				RightColor: A6A7B7
+				ZOffset: -12
+				ZRamp: 0
 			52: Rough
 				LeftColor: A7A7B5
 				RightColor: ACADBD
+				ZOffset: -12
+				ZRamp: 0
 			53: Rough
 				LeftColor: B3B4D1
 				RightColor: 9D9EAE
+				ZOffset: -12
+				ZRamp: 0
 			60: Rough
 				LeftColor: C1C2E4
 				RightColor: A1A2B5
+				ZOffset: -12
+				ZRamp: 0
 			61: Rough
 				LeftColor: A3A5C4
 				RightColor: A9AAC4
+				ZOffset: -12
+				ZRamp: 0
 	Template@11:
 		Category: House
 		Id: 11
@@ -317,15 +431,23 @@ Templates:
 			0: Cliff
 				LeftColor: 8D806A
 				RightColor: 736C61
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 9FA0A5
 				RightColor: 7E7A7B
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: B9B6B8
 				RightColor: 968C7B
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: BCB8B6
 				RightColor: 9F9FA4
+				ZOffset: -12
+				ZRamp: 0
 	Template@12:
 		Category: Blank
 		Id: 12
@@ -335,6 +457,8 @@ Templates:
 			0: Rough
 				LeftColor: 282828
 				RightColor: 282828
+				ZOffset: -12
+				ZRamp: 0
 	Template@40:
 		Category: Ice Ramps
 		Id: 40
@@ -345,6 +469,8 @@ Templates:
 				RampType: 1
 				LeftColor: 746046
 				RightColor: 6F5D44
+				ZOffset: -12
+				ZRamp: 0
 	Template@41:
 		Category: Ice Ramps
 		Id: 41
@@ -355,6 +481,8 @@ Templates:
 				RampType: 2
 				LeftColor: 4B4439
 				RightColor: 443F34
+				ZOffset: -12
+				ZRamp: 0
 	Template@42:
 		Category: Ice Ramps
 		Id: 42
@@ -365,6 +493,8 @@ Templates:
 				RampType: 3
 				LeftColor: 584D3E
 				RightColor: 584D3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@43:
 		Category: Ice Ramps
 		Id: 43
@@ -375,6 +505,8 @@ Templates:
 				RampType: 4
 				LeftColor: 60523F
 				RightColor: 5D4E3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@44:
 		Category: Ice Ramps
 		Id: 44
@@ -385,6 +517,8 @@ Templates:
 				RampType: 5
 				LeftColor: 715D44
 				RightColor: 473F33
+				ZOffset: -12
+				ZRamp: 0
 	Template@45:
 		Category: Ice Ramps
 		Id: 45
@@ -395,6 +529,8 @@ Templates:
 				RampType: 6
 				LeftColor: 433D33
 				RightColor: 5B4D3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@46:
 		Category: Ice Ramps
 		Id: 46
@@ -405,6 +541,8 @@ Templates:
 				RampType: 7
 				LeftColor: 655643
 				RightColor: 5B4E3D
+				ZOffset: -12
+				ZRamp: 0
 	Template@47:
 		Category: Ice Ramps
 		Id: 47
@@ -415,6 +553,8 @@ Templates:
 				RampType: 8
 				LeftColor: 695740
 				RightColor: 6C5942
+				ZOffset: -12
+				ZRamp: 0
 	Template@48:
 		Category: Ice Ramps
 		Id: 48
@@ -425,6 +565,8 @@ Templates:
 				RampType: 9
 				LeftColor: 655641
 				RightColor: 655745
+				ZOffset: -12
+				ZRamp: 0
 	Template@49:
 		Category: Ice Ramps
 		Id: 49
@@ -435,6 +577,8 @@ Templates:
 				RampType: 10
 				LeftColor: 63533F
 				RightColor: 423C32
+				ZOffset: -12
+				ZRamp: 0
 	Template@50:
 		Category: Ice Ramps
 		Id: 50
@@ -445,6 +589,8 @@ Templates:
 				RampType: 11
 				LeftColor: 5D4F3C
 				RightColor: 5F503C
+				ZOffset: -12
+				ZRamp: 0
 	Template@51:
 		Category: Ice Ramps
 		Id: 51
@@ -455,6 +601,8 @@ Templates:
 				RampType: 12
 				LeftColor: 756147
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 	Template@52:
 		Category: Ice Ramps
 		Id: 52
@@ -465,6 +613,8 @@ Templates:
 				RampType: 13
 				LeftColor: 584838
 				RightColor: 584838
+				ZOffset: -12
+				ZRamp: 0
 	Template@53:
 		Category: Ice Ramps
 		Id: 53
@@ -475,6 +625,8 @@ Templates:
 				RampType: 14
 				LeftColor: 443D31
 				RightColor: 463E32
+				ZOffset: -12
+				ZRamp: 0
 	Template@54:
 		Category: Ice Ramps
 		Id: 54
@@ -485,6 +637,8 @@ Templates:
 				RampType: 15
 				LeftColor: 645540
 				RightColor: 594B37
+				ZOffset: -12
+				ZRamp: 0
 	Template@55:
 		Category: Ice Ramps
 		Id: 55
@@ -495,6 +649,8 @@ Templates:
 				RampType: 16
 				LeftColor: 7C6344
 				RightColor: 7E6548
+				ZOffset: -12
+				ZRamp: 0
 	Template@56:
 		Category: Ice Ramps
 		Id: 56
@@ -505,6 +661,8 @@ Templates:
 				RampType: 17
 				LeftColor: 463E32
 				RightColor: 796145
+				ZOffset: -12
+				ZRamp: 0
 	Template@57:
 		Category: Ice Ramps
 		Id: 57
@@ -515,6 +673,8 @@ Templates:
 				RampType: 18
 				LeftColor: 755F42
 				RightColor: 443D32
+				ZOffset: -12
+				ZRamp: 0
 	Template@58:
 		Category: Ice Ramps
 		Id: 58
@@ -525,6 +685,8 @@ Templates:
 				RampType: 19
 				LeftColor: 777758
 				RightColor: 804F52
+				ZOffset: -12
+				ZRamp: 0
 	Template@59:
 		Category: Ice Ramps
 		Id: 59
@@ -535,6 +697,8 @@ Templates:
 				RampType: 20
 				LeftColor: 9B6876
 				RightColor: 6B5643
+				ZOffset: -12
+				ZRamp: 0
 	Template@60:
 		Category: Cliff Set
 		Id: 60
@@ -545,16 +709,24 @@ Templates:
 				Height: 4
 				LeftColor: 3F3B34
 				RightColor: 504537
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 514638
 				RightColor: 413D36
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 2D2B27
 				RightColor: 413C35
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 67533B
 				RightColor: 483E30
+				ZOffset: -12
+				ZRamp: 0
 	Template@61:
 		Category: Cliff Set
 		Id: 61
@@ -565,9 +737,13 @@ Templates:
 				Height: 4
 				LeftColor: 3C3831
 				RightColor: 494134
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 615B51
 				RightColor: 47423B
+				ZOffset: -12
+				ZRamp: 0
 	Template@62:
 		Category: Cliff Set
 		Id: 62
@@ -578,16 +754,24 @@ Templates:
 				Height: 4
 				LeftColor: 433D34
 				RightColor: 483E32
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 5F513E
 				RightColor: 3F3B34
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 2D2C28
 				RightColor: 37322B
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 685945
 				RightColor: 4A4134
+				ZOffset: -12
+				ZRamp: 0
 	Template@63:
 		Category: Cliff Set
 		Id: 63
@@ -598,16 +782,24 @@ Templates:
 				Height: 4
 				LeftColor: 524637
 				RightColor: 594B38
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 5B503F
 				RightColor: 4F4A41
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 49463F
 				RightColor: 494338
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 695A45
 				RightColor: 574D3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@64:
 		Category: Cliff Set
 		Id: 64
@@ -618,16 +810,24 @@ Templates:
 				Height: 4
 				LeftColor: 4D463A
 				RightColor: 4C4234
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 4A4235
 				RightColor: 4F4436
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 695B49
 				RightColor: 484339
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 5B4F3E
 				RightColor: 534C40
+				ZOffset: -12
+				ZRamp: 0
 	Template@65:
 		Category: Cliff Set
 		Id: 65
@@ -638,16 +838,24 @@ Templates:
 				Height: 4
 				LeftColor: 2B2824
 				RightColor: 4E4437
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 353028
 				RightColor: 473F34
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6D5B43
 				RightColor: 51483C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 544737
 				RightColor: 4A4034
+				ZOffset: -12
+				ZRamp: 0
 	Template@66:
 		Category: Cliff Set
 		Id: 66
@@ -658,16 +866,24 @@ Templates:
 				Height: 4
 				LeftColor: 4A4338
 				RightColor: 4F4436
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 484136
 				RightColor: 4D4233
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 615443
 				RightColor: 47443D
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 5A4D3C
 				RightColor: 4E473D
+				ZOffset: -12
+				ZRamp: 0
 	Template@67:
 		Category: Cliff Set
 		Id: 67
@@ -678,9 +894,13 @@ Templates:
 				Height: 4
 				LeftColor: 39352E
 				RightColor: 453B2D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5A5346
 				RightColor: 47433C
+				ZOffset: -12
+				ZRamp: 0
 	Template@68:
 		Category: Cliff Set
 		Id: 68
@@ -691,12 +911,18 @@ Templates:
 				Height: 4
 				LeftColor: 494034
 				RightColor: 4E4436
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5A4F3F
 				RightColor: 524C42
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 544C3F
 				RightColor: 4E473C
+				ZOffset: -12
+				ZRamp: 0
 	Template@69:
 		Category: Cliff Set
 		Id: 69
@@ -707,12 +933,18 @@ Templates:
 				Height: 4
 				LeftColor: 4E4437
 				RightColor: 514434
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 4F4639
 				RightColor: 51493D
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 464035
 				RightColor: 554E42
+				ZOffset: -12
+				ZRamp: 0
 	Template@70:
 		Category: Cliff Set
 		Id: 70
@@ -723,12 +955,18 @@ Templates:
 				Height: 4
 				LeftColor: 4F4334
 				RightColor: 494135
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 564D3F
 				RightColor: 48443B
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 555046
 				RightColor: 5E564A
+				ZOffset: -12
+				ZRamp: 0
 	Template@71:
 		Category: Cliff Set
 		Id: 71
@@ -738,6 +976,8 @@ Templates:
 			0: Cliff
 				LeftColor: 524D43
 				RightColor: 534D42
+				ZOffset: -12
+				ZRamp: 0
 	Template@72:
 		Category: Cliff Set
 		Id: 72
@@ -747,6 +987,8 @@ Templates:
 			0: Cliff
 				LeftColor: 443F37
 				RightColor: 524B3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@73:
 		Category: Cliff Set
 		Id: 73
@@ -756,6 +998,8 @@ Templates:
 			0: Cliff
 				LeftColor: 544E43
 				RightColor: 3D3830
+				ZOffset: -12
+				ZRamp: 0
 	Template@74:
 		Category: Cliff Set
 		Id: 74
@@ -766,16 +1010,24 @@ Templates:
 				Height: 4
 				LeftColor: 453C30
 				RightColor: 42392D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 4B4135
 				RightColor: 3E3931
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 4D4334
 				RightColor: 403A31
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 5C4F3F
 				RightColor: 3D3931
+				ZOffset: -12
+				ZRamp: 0
 	Template@75:
 		Category: Cliff Set
 		Id: 75
@@ -786,16 +1038,24 @@ Templates:
 				Height: 4
 				LeftColor: 4B4032
 				RightColor: 413A31
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 453C31
 				RightColor: 39342D
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 453B2F
 				RightColor: 443D34
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 584C3C
 				RightColor: 454038
+				ZOffset: -12
+				ZRamp: 0
 	Template@76:
 		Category: Cliff Set
 		Id: 76
@@ -806,16 +1066,24 @@ Templates:
 				Height: 4
 				LeftColor: 443C30
 				RightColor: 453C30
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 36322C
 				RightColor: 3A3731
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 4F4231
 				RightColor: 443D34
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 4B4338
 				RightColor: 3F3C37
+				ZOffset: -12
+				ZRamp: 0
 	Template@77:
 		Category: Cliff Set
 		Id: 77
@@ -826,9 +1094,13 @@ Templates:
 				Height: 4
 				LeftColor: 4A3F2F
 				RightColor: 4A4338
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 484137
 				RightColor: 3E3A34
+				ZOffset: -12
+				ZRamp: 0
 	Template@78:
 		Category: Cliff Set
 		Id: 78
@@ -839,16 +1111,24 @@ Templates:
 				Height: 4
 				LeftColor: 4B4031
 				RightColor: 403C33
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 323230
 				RightColor: 46413A
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 4A4236
 				RightColor: 2B2A27
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 5E5446
 				RightColor: 4E4538
+				ZOffset: -12
+				ZRamp: 0
 	Template@79:
 		Category: Cliff Set
 		Id: 79
@@ -859,16 +1139,24 @@ Templates:
 				Height: 4
 				LeftColor: 514637
 				RightColor: 4A4134
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2D2C29
 				RightColor: 423E36
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 4D4132
 				RightColor: 302E2B
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 5A4F41
 				RightColor: 483F33
+				ZOffset: -12
+				ZRamp: 0
 	Template@80:
 		Category: Cliff Set
 		Id: 80
@@ -879,16 +1167,24 @@ Templates:
 				Height: 4
 				LeftColor: 42392C
 				RightColor: 3B362E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2A2826
 				RightColor: 37342E
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 484034
 				RightColor: 2A2926
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 574E41
 				RightColor: 4A4237
+				ZOffset: -12
+				ZRamp: 0
 	Template@81:
 		Category: Cliff Set
 		Id: 81
@@ -899,9 +1195,13 @@ Templates:
 				Height: 4
 				LeftColor: 3F382E
 				RightColor: 433C33
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 42392C
 				RightColor: 383530
+				ZOffset: -12
+				ZRamp: 0
 	Template@82:
 		Category: Cliff Set
 		Id: 82
@@ -912,10 +1212,14 @@ Templates:
 				Height: 4
 				LeftColor: 504332
 				RightColor: 494033
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 4A3F31
 				RightColor: 3D3830
+				ZOffset: -12
+				ZRamp: 0
 	Template@83:
 		Category: Cliff Set
 		Id: 83
@@ -926,10 +1230,14 @@ Templates:
 				Height: 4
 				LeftColor: 4F4334
 				RightColor: 413B31
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 504434
 				RightColor: 423A2F
+				ZOffset: -12
+				ZRamp: 0
 	Template@84:
 		Category: Cliff Set
 		Id: 84
@@ -940,10 +1248,14 @@ Templates:
 				Height: 4
 				LeftColor: 4D4234
 				RightColor: 423D35
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 433C32
 				RightColor: 4A443B
+				ZOffset: -12
+				ZRamp: 0
 	Template@85:
 		Category: Cliff Set
 		Id: 85
@@ -954,6 +1266,8 @@ Templates:
 				Height: 4
 				LeftColor: 4E4233
 				RightColor: 3A3329
+				ZOffset: -12
+				ZRamp: 0
 	Template@86:
 		Category: Cliff Set
 		Id: 86
@@ -964,14 +1278,20 @@ Templates:
 				Height: 4
 				LeftColor: 4F473B
 				RightColor: 443F36
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 4E4232
 				RightColor: 463F35
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 403B33
 				RightColor: 50473A
+				ZOffset: -12
+				ZRamp: 0
 	Template@87:
 		Category: Cliff Set
 		Id: 87
@@ -982,14 +1302,20 @@ Templates:
 				Height: 4
 				LeftColor: 3D372E
 				RightColor: 3B362D
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 433D33
 				RightColor: 3C372F
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 50483B
 				RightColor: 443A2D
+				ZOffset: -12
+				ZRamp: 0
 	Template@88:
 		Category: Cliff Set
 		Id: 88
@@ -1000,6 +1326,8 @@ Templates:
 				Height: 4
 				LeftColor: 413B32
 				RightColor: 474136
+				ZOffset: -12
+				ZRamp: 0
 	Template@89:
 		Category: Cliff Set
 		Id: 89
@@ -1010,6 +1338,8 @@ Templates:
 				Height: 4
 				LeftColor: 474036
 				RightColor: 3C3730
+				ZOffset: -12
+				ZRamp: 0
 	Template@90:
 		Category: Cliff Set
 		Id: 90
@@ -1020,14 +1350,20 @@ Templates:
 				Height: 4
 				LeftColor: 31302B
 				RightColor: 39352F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 4D453A
 				RightColor: 4C4337
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 4C4235
 				RightColor: 473F32
+				ZOffset: -12
+				ZRamp: 0
 	Template@91:
 		Category: Cliff Set
 		Id: 91
@@ -1038,14 +1374,20 @@ Templates:
 				Height: 4
 				LeftColor: 454038
 				RightColor: 3F3931
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 4E4334
 				RightColor: 3C3730
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 544A3C
 				RightColor: 4E4335
+				ZOffset: -12
+				ZRamp: 0
 	Template@92:
 		Category: Cliff Set
 		Id: 92
@@ -1056,6 +1398,8 @@ Templates:
 				Height: 4
 				LeftColor: 4C4234
 				RightColor: 453E33
+				ZOffset: -12
+				ZRamp: 0
 	Template@93:
 		Category: Cliff Set
 		Id: 93
@@ -1066,6 +1410,8 @@ Templates:
 				Height: 4
 				LeftColor: 4A4032
 				RightColor: 4F4231
+				ZOffset: -12
+				ZRamp: 0
 	Template@94:
 		Category: Cliff Set
 		Id: 94
@@ -1076,10 +1422,14 @@ Templates:
 				Height: 4
 				LeftColor: 4B453A
 				RightColor: 473F34
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 444039
 				RightColor: 52483B
+				ZOffset: -12
+				ZRamp: 0
 	Template@95:
 		Category: Cliff Set
 		Id: 95
@@ -1090,10 +1440,14 @@ Templates:
 				Height: 4
 				LeftColor: 49443B
 				RightColor: 4B4032
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 46413A
 				RightColor: 504638
+				ZOffset: -12
+				ZRamp: 0
 	Template@96:
 		Category: Cliff Set
 		Id: 96
@@ -1104,10 +1458,14 @@ Templates:
 				Height: 4
 				LeftColor: 474138
 				RightColor: 474036
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 484239
 				RightColor: 595042
+				ZOffset: -12
+				ZRamp: 0
 	Template@97:
 		Category: Cliff Set
 		Id: 97
@@ -1118,6 +1476,8 @@ Templates:
 				Height: 4
 				LeftColor: 35322C
 				RightColor: 39332B
+				ZOffset: -12
+				ZRamp: 0
 	Template@98:
 		Category: Cliff Set
 		Id: 98
@@ -1128,6 +1488,8 @@ Templates:
 				Height: 4
 				LeftColor: 4B4337
 				RightColor: 4B4030
+				ZOffset: -12
+				ZRamp: 0
 	Template@99:
 		Category: Cliff Set
 		Id: 99
@@ -1138,6 +1500,8 @@ Templates:
 				Height: 4
 				LeftColor: 4D4233
 				RightColor: 453E34
+				ZOffset: -12
+				ZRamp: 0
 	Template@100:
 		Category: Civilian Buildings
 		Id: 100
@@ -1147,30 +1511,48 @@ Templates:
 			0: Impassable
 				LeftColor: 666D76
 				RightColor: 71777D
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: 505457
 				RightColor: 61656F
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: BFC0ED
 				RightColor: CECFF6
+				ZOffset: -12
+				ZRamp: 0
 			3: Impassable
 				LeftColor: 797B82
 				RightColor: 7B7F86
+				ZOffset: -12
+				ZRamp: 0
 			4: Impassable
 				LeftColor: 6D6F74
 				RightColor: 585A66
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: C7C8F6
 				RightColor: C6C8F8
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: CBCCF7
 				RightColor: C5C6E6
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: C2C4E6
 				RightColor: ADB0CE
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: C4C6F0
 				RightColor: C2C4F6
+				ZOffset: -12
+				ZRamp: 0
 	Template@101:
 		Category: Civilian Buildings
 		Id: 101
@@ -1180,9 +1562,13 @@ Templates:
 			0: Impassable
 				LeftColor: B1B1E7
 				RightColor: B3B5D9
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: B4B5D2
 				RightColor: BEBFF7
+				ZOffset: -12
+				ZRamp: 0
 	Template@102:
 		Category: Civilian Buildings
 		Id: 102
@@ -1192,6 +1578,8 @@ Templates:
 			0: Impassable
 				LeftColor: 9D9EA0
 				RightColor: 898B8F
+				ZOffset: -12
+				ZRamp: 0
 	Template@103:
 		Category: Civilian Buildings
 		Id: 103
@@ -1201,9 +1589,13 @@ Templates:
 			0: Impassable
 				LeftColor: B7B8E6
 				RightColor: B4B6D6
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: BABBE1
 				RightColor: CACBF6
+				ZOffset: -12
+				ZRamp: 0
 	Template@104:
 		Category: Civilian Buildings
 		Id: 104
@@ -1213,12 +1605,18 @@ Templates:
 			1: Impassable
 				LeftColor: 7C818A
 				RightColor: 676B72
+				ZOffset: -12
+				ZRamp: 0
 			2: Impassable
 				LeftColor: 7B7F83
 				RightColor: 7A7E82
+				ZOffset: -12
+				ZRamp: 0
 			3: Impassable
 				LeftColor: 72757C
 				RightColor: 6A6D73
+				ZOffset: -12
+				ZRamp: 0
 	Template@105:
 		Category: Civilian Buildings
 		Id: 105
@@ -1228,21 +1626,33 @@ Templates:
 			1: Impassable
 				LeftColor: 73757B
 				RightColor: 7D7F88
+				ZOffset: -12
+				ZRamp: 0
 			3: Impassable
 				LeftColor: 9294A2
 				RightColor: 777A80
+				ZOffset: -12
+				ZRamp: 0
 			4: Impassable
 				LeftColor: 979BAC
 				RightColor: 9DA0B2
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: B3B3BD
 				RightColor: BDBDD7
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: BCBEDB
 				RightColor: AEADAF
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: BDBFD8
 				RightColor: B0B2CA
+				ZOffset: -12
+				ZRamp: 0
 	Template@106:
 		Category: Civilian Buildings
 		Id: 106
@@ -1252,6 +1662,8 @@ Templates:
 			0: Impassable
 				LeftColor: 72757D
 				RightColor: 5C6169
+				ZOffset: -12
+				ZRamp: 0
 	Template@107:
 		Category: Civilian Buildings
 		Id: 107
@@ -1261,9 +1673,13 @@ Templates:
 			0: Impassable
 				LeftColor: 686B6E
 				RightColor: 727681
+				ZOffset: -12
+				ZRamp: 0
 			1: Impassable
 				LeftColor: 797F8D
 				RightColor: 5E6678
+				ZOffset: -12
+				ZRamp: 0
 	Template@108:
 		Category: Shore Pieces
 		Id: 108
@@ -1273,15 +1689,23 @@ Templates:
 			0: Water
 				LeftColor: 3D4148
 				RightColor: 504C48
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 484948
 				RightColor: 5D5040
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 1A2D47
 				RightColor: 2E3B4F
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 1C2F4A
 				RightColor: 2C394A
+				ZOffset: -12
+				ZRamp: 0
 	Template@109:
 		Category: Shore Pieces
 		Id: 109
@@ -1291,15 +1715,23 @@ Templates:
 			0: Water
 				LeftColor: 414447
 				RightColor: 534D46
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 3E4347
 				RightColor: 5E5347
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 18283A
 				RightColor: 232F3C
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 172B48
 				RightColor: 253854
+				ZOffset: -12
+				ZRamp: 0
 	Template@110:
 		Category: Shore Pieces
 		Id: 110
@@ -1309,15 +1741,23 @@ Templates:
 			0: Water
 				LeftColor: 424448
 				RightColor: 584D40
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 2F3947
 				RightColor: 5C4F40
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 172A43
 				RightColor: 24344B
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 18283D
 				RightColor: 1E314E
+				ZOffset: -12
+				ZRamp: 0
 	Template@111:
 		Category: Shore Pieces
 		Id: 111
@@ -1327,9 +1767,13 @@ Templates:
 			0: Water
 				LeftColor: 504A43
 				RightColor: 5D4F3F
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 162943
 				RightColor: 2F3844
+				ZOffset: -12
+				ZRamp: 0
 	Template@112:
 		Category: Shore Pieces
 		Id: 112
@@ -1339,21 +1783,33 @@ Templates:
 			0: Water
 				LeftColor: 4F4942
 				RightColor: 5E5243
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 4A4B49
 				RightColor: 6A563E
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 263444
 				RightColor: 293541
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 283B55
 				RightColor: 4C4E50
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 142842
 				RightColor: 27374D
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 273447
 				RightColor: 243246
+				ZOffset: -12
+				ZRamp: 0
 	Template@113:
 		Category: Shore Pieces
 		Id: 113
@@ -1363,21 +1819,33 @@ Templates:
 			0: Water
 				LeftColor: 44484C
 				RightColor: 564F46
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 545757
 				RightColor: 645440
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 42464F
 				RightColor: 383F49
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 26354C
 				RightColor: 38424F
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 162944
 				RightColor: 182C48
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 102238
 				RightColor: 172A45
+				ZOffset: -12
+				ZRamp: 0
 	Template@114:
 		Category: Shore Pieces
 		Id: 114
@@ -1387,15 +1855,23 @@ Templates:
 			0: Water
 				LeftColor: 3C434F
 				RightColor: 464747
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 25364E
 				RightColor: 182A43
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 162943
 				RightColor: 203452
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 12253F
 				RightColor: 1A2E4B
+				ZOffset: -12
+				ZRamp: 0
 	Template@115:
 		Category: Shore Pieces
 		Id: 115
@@ -1405,15 +1881,23 @@ Templates:
 			0: Water
 				LeftColor: 4F5051
 				RightColor: 4F4F4D
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 26374E
 				RightColor: 14253B
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 1C2F47
 				RightColor: 243957
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 102237
 				RightColor: 152842
+				ZOffset: -12
+				ZRamp: 0
 	Template@116:
 		Category: Shore Pieces
 		Id: 116
@@ -1423,15 +1907,23 @@ Templates:
 			0: Water
 				LeftColor: 544E48
 				RightColor: 514D48
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 354153
 				RightColor: 1F2F46
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 5D4E3B
 				RightColor: 2F3B4D
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 223551
 				RightColor: 1A2D4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@117:
 		Category: Shore Pieces
 		Id: 117
@@ -1441,15 +1933,23 @@ Templates:
 			0: Water
 				LeftColor: 4C4F54
 				RightColor: 544D44
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 273B5B
 				RightColor: 16283D
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 574E44
 				RightColor: 364558
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 1C2E49
 				RightColor: 182D4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@118:
 		Category: Shore Pieces
 		Id: 118
@@ -1459,15 +1959,23 @@ Templates:
 			0: Water
 				LeftColor: 434850
 				RightColor: 5A544D
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 283C59
 				RightColor: 162A41
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 625241
 				RightColor: 504F4E
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 1F324D
 				RightColor: 1D304F
+				ZOffset: -12
+				ZRamp: 0
 	Template@119:
 		Category: Shore Pieces
 		Id: 119
@@ -1477,9 +1985,13 @@ Templates:
 			0: Water
 				LeftColor: 605445
 				RightColor: 42464D
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 203046
 				RightColor: 16283F
+				ZOffset: -12
+				ZRamp: 0
 	Template@120:
 		Category: Shore Pieces
 		Id: 120
@@ -1489,21 +2001,33 @@ Templates:
 			0: Clear
 				LeftColor: 605549
 				RightColor: 645645
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 3F4958
 				RightColor: 4B4A4A
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 283850
 				RightColor: 14273D
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 52504D
 				RightColor: 3B4759
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 273548
 				RightColor: 1D2D46
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 1A2F4D
 				RightColor: 162A45
+				ZOffset: -12
+				ZRamp: 0
 	Template@121:
 		Category: Shore Pieces
 		Id: 121
@@ -1513,21 +2037,33 @@ Templates:
 			0: Water
 				LeftColor: 554D43
 				RightColor: 554F48
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 334155
 				RightColor: 1A2B40
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 23354D
 				RightColor: 26364D
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 6B563D
 				RightColor: 494C51
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 4C4A47
 				RightColor: 374150
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 182C49
 				RightColor: 182B46
+				ZOffset: -12
+				ZRamp: 0
 	Template@122:
 		Category: Shore Pieces
 		Id: 122
@@ -1537,15 +2073,23 @@ Templates:
 			0: Water
 				LeftColor: 203148
 				RightColor: 152943
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 162A46
 				RightColor: 0E2136
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 635545
 				RightColor: 434749
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 233449
 				RightColor: 192C47
+				ZOffset: -12
+				ZRamp: 0
 	Template@123:
 		Category: Shore Pieces
 		Id: 123
@@ -1555,15 +2099,23 @@ Templates:
 			0: Water
 				LeftColor: 1B2F4D
 				RightColor: 142841
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 1C3051
 				RightColor: 10243B
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 55504A
 				RightColor: 354254
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 24364F
 				RightColor: 192D4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@124:
 		Category: Shore Pieces
 		Id: 124
@@ -1573,15 +2125,23 @@ Templates:
 			0: Water
 				LeftColor: 26354B
 				RightColor: 203145
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 2C3B50
 				RightColor: 10243B
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 5A5247
 				RightColor: 3D454E
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 45484D
 				RightColor: 494A4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@125:
 		Category: Shore Pieces
 		Id: 125
@@ -1591,15 +2151,23 @@ Templates:
 			0: Water
 				LeftColor: 172A44
 				RightColor: 1C2E47
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 1C2F4B
 				RightColor: 13273F
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 55514D
 				RightColor: 2F3E52
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 514F4D
 				RightColor: 484746
+				ZOffset: -12
+				ZRamp: 0
 	Template@126:
 		Category: Shore Pieces
 		Id: 126
@@ -1609,15 +2177,23 @@ Templates:
 			0: Water
 				LeftColor: 24354B
 				RightColor: 1E2F46
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 1B2F4C
 				RightColor: 142842
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 615241
 				RightColor: 414751
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 4E4E4E
 				RightColor: 3C4451
+				ZOffset: -12
+				ZRamp: 0
 	Template@127:
 		Category: Shore Pieces
 		Id: 127
@@ -1627,9 +2203,13 @@ Templates:
 			0: Water
 				LeftColor: 1F3149
 				RightColor: 162A46
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 5D5142
 				RightColor: 534C45
+				ZOffset: -12
+				ZRamp: 0
 	Template@128:
 		Category: Shore Pieces
 		Id: 128
@@ -1639,21 +2219,33 @@ Templates:
 			0: Water
 				LeftColor: 152841
 				RightColor: 152840
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 253348
 				RightColor: 11253D
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 243245
 				RightColor: 353C44
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 3A3F46
 				RightColor: 4E4B48
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 605242
 				RightColor: 484847
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 5B5144
 				RightColor: 524E4B
+				ZOffset: -12
+				ZRamp: 0
 	Template@129:
 		Category: Shore Pieces
 		Id: 129
@@ -1663,21 +2255,33 @@ Templates:
 			0: Water
 				LeftColor: 323A43
 				RightColor: 1B2D46
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 283340
 				RightColor: 112339
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 4C4E52
 				RightColor: 303A47
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 283446
 				RightColor: 20324E
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 64533E
 				RightColor: 4E4E4C
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 5A5145
 				RightColor: 564D42
+				ZOffset: -12
+				ZRamp: 0
 	Template@130:
 		Category: Shore Pieces
 		Id: 130
@@ -1687,15 +2291,23 @@ Templates:
 			0: Water
 				LeftColor: 182D49
 				RightColor: 182B47
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 283648
 				RightColor: 182B44
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 1D2E43
 				RightColor: 223654
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 3B4149
 				RightColor: 454648
+				ZOffset: -12
+				ZRamp: 0
 	Template@131:
 		Category: Shore Pieces
 		Id: 131
@@ -1705,15 +2317,23 @@ Templates:
 			0: Water
 				LeftColor: 253346
 				RightColor: 1E2D41
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 303A45
 				RightColor: 1E314D
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 263241
 				RightColor: 3D434A
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 5B5043
 				RightColor: 524E4B
+				ZOffset: -12
+				ZRamp: 0
 	Template@132:
 		Category: Shore Pieces
 		Id: 132
@@ -1723,15 +2343,23 @@ Templates:
 			0: Water
 				LeftColor: 1F314A
 				RightColor: 2A3545
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 4B4A49
 				RightColor: 5D5244
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 213145
 				RightColor: 283749
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 50504D
 				RightColor: 55524C
+				ZOffset: -12
+				ZRamp: 0
 	Template@133:
 		Category: Shore Pieces
 		Id: 133
@@ -1741,15 +2369,23 @@ Templates:
 			0: Water
 				LeftColor: 1D3046
 				RightColor: 353F48
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 4A4B49
 				RightColor: 615546
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 1E2E41
 				RightColor: 373E47
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 524C45
 				RightColor: 5D5141
+				ZOffset: -12
+				ZRamp: 0
 	Template@134:
 		Category: Shore Pieces
 		Id: 134
@@ -1759,15 +2395,23 @@ Templates:
 			0: Water
 				LeftColor: 2A394C
 				RightColor: 39424E
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 47494B
 				RightColor: 5C5248
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 212F40
 				RightColor: 263750
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 534D44
 				RightColor: 595044
+				ZOffset: -12
+				ZRamp: 0
 	Template@135:
 		Category: Shore Pieces
 		Id: 135
@@ -1777,9 +2421,13 @@ Templates:
 			0: Water
 				LeftColor: 243246
 				RightColor: 363E47
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 544E47
 				RightColor: 5F5547
+				ZOffset: -12
+				ZRamp: 0
 	Template@136:
 		Category: Shore Pieces
 		Id: 136
@@ -1789,21 +2437,33 @@ Templates:
 			0: Water
 				LeftColor: 15273E
 				RightColor: 40444B
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 494C50
 				RightColor: 4E4C4B
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 4E463B
 				RightColor: 66543E
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 0E2036
 				RightColor: 11233A
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 213042
 				RightColor: 3B444E
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 524E46
 				RightColor: 585043
+				ZOffset: -12
+				ZRamp: 0
 	Template@137:
 		Category: Shore Pieces
 		Id: 137
@@ -1813,21 +2473,33 @@ Templates:
 			0: Water
 				LeftColor: 13253D
 				RightColor: 162B46
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 2E405A
 				RightColor: 353F4A
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 565148
 				RightColor: 61503B
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 1D2A3B
 				RightColor: 2E3845
+				ZOffset: -12
+				ZRamp: 0
 			4: Water
 				LeftColor: 60513D
 				RightColor: 3B434C
+				ZOffset: -12
+				ZRamp: 0
 			5: Water
 				LeftColor: 5B5041
 				RightColor: 5C5143
+				ZOffset: -12
+				ZRamp: 0
 	Template@138:
 		Category: Shore Pieces
 		Id: 138
@@ -1837,15 +2509,23 @@ Templates:
 			0: Water
 				LeftColor: 1F3047
 				RightColor: 393C40
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 4A4743
 				RightColor: 62523E
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 0F2137
 				RightColor: 152842
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 172B45
 				RightColor: 223045
+				ZOffset: -12
+				ZRamp: 0
 	Template@139:
 		Category: Shore Pieces
 		Id: 139
@@ -1855,15 +2535,23 @@ Templates:
 			0: Water
 				LeftColor: 162943
 				RightColor: 353C46
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 57524C
 				RightColor: 67553F
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 12253D
 				RightColor: 182D49
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 172B46
 				RightColor: 313D4B
+				ZOffset: -12
+				ZRamp: 0
 	Template@140:
 		Category: Shore Pieces
 		Id: 140
@@ -1873,15 +2561,23 @@ Templates:
 			0: Clear
 				LeftColor: 635645
 				RightColor: 5E5446
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 434B53
 				RightColor: 5E5243
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 655541
 				RightColor: 374250
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 1A2D46
 				RightColor: 273A56
+				ZOffset: -12
+				ZRamp: 0
 	Template@141:
 		Category: Shore Pieces
 		Id: 141
@@ -1891,15 +2587,23 @@ Templates:
 			0: Clear
 				LeftColor: 5E5040
 				RightColor: 645442
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 4A4948
 				RightColor: 5B5041
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 605343
 				RightColor: 484A4C
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 343E4C
 				RightColor: 343E4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@142:
 		Category: Shore Pieces
 		Id: 142
@@ -1909,15 +2613,23 @@ Templates:
 			0: Water
 				LeftColor: 564D43
 				RightColor: 564E43
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 22354F
 				RightColor: 13273D
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 6E583E
 				RightColor: 58534E
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 4A4949
 				RightColor: 4C4B49
+				ZOffset: -12
+				ZRamp: 0
 	Template@143:
 		Category: Shore Pieces
 		Id: 143
@@ -1927,15 +2639,23 @@ Templates:
 			0: Water
 				LeftColor: 514E49
 				RightColor: 534E4A
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 28384D
 				RightColor: 152941
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 705A3E
 				RightColor: 5B5041
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 524F4B
 				RightColor: 474949
+				ZOffset: -12
+				ZRamp: 0
 	Template@144:
 		Category: Shore Pieces
 		Id: 144
@@ -1945,15 +2665,23 @@ Templates:
 			0: Water
 				LeftColor: 1D304A
 				RightColor: 303C4D
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 4D4F52
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 554F47
 				RightColor: 464B4F
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 5F5447
 				RightColor: 665541
+				ZOffset: -12
+				ZRamp: 0
 	Template@145:
 		Category: Shore Pieces
 		Id: 145
@@ -1963,15 +2691,23 @@ Templates:
 			0: Water
 				LeftColor: 22344D
 				RightColor: 303A47
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 494D53
 				RightColor: 655440
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 5E5244
 				RightColor: 44474B
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 5D5245
 				RightColor: 5D5143
+				ZOffset: -12
+				ZRamp: 0
 	Template@146:
 		Category: Shore Pieces
 		Id: 146
@@ -1981,15 +2717,23 @@ Templates:
 			0: Water
 				LeftColor: 534F49
 				RightColor: 5B5248
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 625442
 				RightColor: 6B573E
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 25313F
 				RightColor: 37424F
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 585248
 				RightColor: 524F4B
+				ZOffset: -12
+				ZRamp: 0
 	Template@147:
 		Category: Shore Pieces
 		Id: 147
@@ -1999,15 +2743,23 @@ Templates:
 			0: Water
 				LeftColor: 494B4E
 				RightColor: 5C544A
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 4C4B4A
 				RightColor: 625240
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 283649
 				RightColor: 253855
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 4E4C4A
 				RightColor: 544F4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@148:
 		Category: Shore Pieces
 		Id: 148
@@ -2017,66 +2769,108 @@ Templates:
 			1: Clear
 				LeftColor: 63523D
 				RightColor: 60513D
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 5D503F
 				RightColor: 63523E
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 625340
 				RightColor: 66543F
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 645440
 				RightColor: 60513D
+				ZOffset: -12
+				ZRamp: 0
 			7: Water
 				LeftColor: 48443F
 				RightColor: 55493B
+				ZOffset: -12
+				ZRamp: 0
 			8: Water
 				LeftColor: 43413D
 				RightColor: 45423C
+				ZOffset: -12
+				ZRamp: 0
 			9: Water
 				LeftColor: 44403B
 				RightColor: 514739
+				ZOffset: -12
+				ZRamp: 0
 			10: Water
 				LeftColor: 393D40
 				RightColor: 534A3F
+				ZOffset: -12
+				ZRamp: 0
 			11: Water
 				LeftColor: 272E38
 				RightColor: 1B2839
+				ZOffset: -12
+				ZRamp: 0
 			12: Water
 				LeftColor: 554D42
 				RightColor: 4D463C
+				ZOffset: -12
+				ZRamp: 0
 			13: Water
 				LeftColor: 45484A
 				RightColor: 343E4A
+				ZOffset: -12
+				ZRamp: 0
 			14: Water
 				LeftColor: 3A4045
 				RightColor: 3D4041
+				ZOffset: -12
+				ZRamp: 0
 			15: Water
 				LeftColor: 232F3D
 				RightColor: 2B343D
+				ZOffset: -12
+				ZRamp: 0
 			16: Water
 				LeftColor: 1F3048
 				RightColor: 1E3048
+				ZOffset: -12
+				ZRamp: 0
 			17: Water
 				LeftColor: 1E3456
 				RightColor: 152842
+				ZOffset: -12
+				ZRamp: 0
 			18: Water
 				LeftColor: 584C3E
 				RightColor: 44423E
+				ZOffset: -12
+				ZRamp: 0
 			19: Water
 				LeftColor: 1F304A
 				RightColor: 223552
+				ZOffset: -12
+				ZRamp: 0
 			20: Water
 				LeftColor: 162A46
 				RightColor: 1B2D45
+				ZOffset: -12
+				ZRamp: 0
 			21: Water
 				LeftColor: 102238
 				RightColor: 192E4B
+				ZOffset: -12
+				ZRamp: 0
 			22: Water
 				LeftColor: 182C49
 				RightColor: 1F3557
+				ZOffset: -12
+				ZRamp: 0
 			23: Water
 				LeftColor: 11243C
 				RightColor: 12253E
+				ZOffset: -12
+				ZRamp: 0
 	Template@149:
 		Category: Shore Pieces
 		Id: 149
@@ -2086,93 +2880,153 @@ Templates:
 			2: Water
 				LeftColor: 584E3F
 				RightColor: 5F513D
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 524A3E
 				RightColor: 645541
+				ZOffset: -12
+				ZRamp: 0
 			11: Water
 				LeftColor: 4F4A43
 				RightColor: 3B4046
+				ZOffset: -12
+				ZRamp: 0
 			12: Water
 				LeftColor: 383F47
 				RightColor: 4E4D49
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 65543F
 				RightColor: 6E5C44
+				ZOffset: -12
+				ZRamp: 0
 			18: Clear
 				LeftColor: 6C5A42
 				RightColor: 665641
+				ZOffset: -12
+				ZRamp: 0
 			19: Water
 				LeftColor: 574A3A
 				RightColor: 5B4D3C
+				ZOffset: -12
+				ZRamp: 0
 			20: Water
 				LeftColor: 383C3E
 				RightColor: 30373F
+				ZOffset: -12
+				ZRamp: 0
 			21: Water
 				LeftColor: 28364E
 				RightColor: 273340
+				ZOffset: -12
+				ZRamp: 0
 			22: Water
 				LeftColor: 25313F
 				RightColor: 4C4840
+				ZOffset: -12
+				ZRamp: 0
 			23: Water
 				LeftColor: 333738
 				RightColor: 574F44
+				ZOffset: -12
+				ZRamp: 0
 			24: Water
 				LeftColor: 28323C
 				RightColor: 4F473C
+				ZOffset: -12
+				ZRamp: 0
 			25: Water
 				LeftColor: 404140
 				RightColor: 4C4842
+				ZOffset: -12
+				ZRamp: 0
 			26: Water
 				LeftColor: 21324D
 				RightColor: 16283D
+				ZOffset: -12
+				ZRamp: 0
 			28: Water
 				LeftColor: 5D503E
 				RightColor: 615444
+				ZOffset: -12
+				ZRamp: 0
 			29: Water
 				LeftColor: 5A5246
 				RightColor: 363737
+				ZOffset: -12
+				ZRamp: 0
 			30: Water
 				LeftColor: 1E3252
 				RightColor: 1A2B41
+				ZOffset: -12
+				ZRamp: 0
 			31: Water
 				LeftColor: 1B3050
 				RightColor: 192D4B
+				ZOffset: -12
+				ZRamp: 0
 			32: Water
 				LeftColor: 1C3151
 				RightColor: 1B3151
+				ZOffset: -12
+				ZRamp: 0
 			33: Water
 				LeftColor: 152944
 				RightColor: 172B45
+				ZOffset: -12
+				ZRamp: 0
 			34: Water
 				LeftColor: 14273F
 				RightColor: 192E4B
+				ZOffset: -12
+				ZRamp: 0
 			35: Water
 				LeftColor: 152842
 				RightColor: 132640
+				ZOffset: -12
+				ZRamp: 0
 			37: Water
 				LeftColor: 695741
 				RightColor: 5D4E3B
+				ZOffset: -12
+				ZRamp: 0
 			38: Water
 				LeftColor: 373938
 				RightColor: 3D3F3F
+				ZOffset: -12
+				ZRamp: 0
 			39: Water
 				LeftColor: 162944
 				RightColor: 162A47
+				ZOffset: -12
+				ZRamp: 0
 			40: Water
 				LeftColor: 11233B
 				RightColor: 182C49
+				ZOffset: -12
+				ZRamp: 0
 			41: Water
 				LeftColor: 12253D
 				RightColor: 11253D
+				ZOffset: -12
+				ZRamp: 0
 			42: Water
 				LeftColor: 0F2136
 				RightColor: 10233C
+				ZOffset: -12
+				ZRamp: 0
 			43: Water
 				LeftColor: 0E2036
 				RightColor: 12253F
+				ZOffset: -12
+				ZRamp: 0
 			44: Water
 				LeftColor: 152843
 				RightColor: 142842
+				ZOffset: -12
+				ZRamp: 0
 	Template@150:
 		Category: Rough LAT tile
 		Id: 150
@@ -2182,6 +3036,8 @@ Templates:
 			0: Rough
 				LeftColor: 464036
 				RightColor: 474137
+				ZOffset: -12
+				ZRamp: 0
 	Template@151:
 		Category: Clear/Rough LAT
 		Id: 151
@@ -2191,6 +3047,8 @@ Templates:
 			0: Rough
 				LeftColor: 534839
 				RightColor: 544939
+				ZOffset: -12
+				ZRamp: 0
 	Template@152:
 		Category: Clear/Rough LAT
 		Id: 152
@@ -2200,6 +3058,8 @@ Templates:
 			0: Rough
 				LeftColor: 4A4439
 				RightColor: 584A38
+				ZOffset: -12
+				ZRamp: 0
 	Template@153:
 		Category: Clear/Rough LAT
 		Id: 153
@@ -2209,6 +3069,8 @@ Templates:
 			0: Rough
 				LeftColor: 464036
 				RightColor: 574A39
+				ZOffset: -12
+				ZRamp: 0
 	Template@154:
 		Category: Clear/Rough LAT
 		Id: 154
@@ -2218,6 +3080,8 @@ Templates:
 			0: Rough
 				LeftColor: 4C463B
 				RightColor: 5E4F3C
+				ZOffset: -12
+				ZRamp: 0
 	Template@155:
 		Category: Clear/Rough LAT
 		Id: 155
@@ -2227,6 +3091,8 @@ Templates:
 			0: Rough
 				LeftColor: 554939
 				RightColor: 494338
+				ZOffset: -12
+				ZRamp: 0
 	Template@156:
 		Category: Clear/Rough LAT
 		Id: 156
@@ -2236,6 +3102,8 @@ Templates:
 			0: Rough
 				LeftColor: 554938
 				RightColor: 574A3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@157:
 		Category: Clear/Rough LAT
 		Id: 157
@@ -2245,6 +3113,8 @@ Templates:
 			0: Rough
 				LeftColor: 584C3C
 				RightColor: 584A39
+				ZOffset: -12
+				ZRamp: 0
 	Template@158:
 		Category: Clear/Rough LAT
 		Id: 158
@@ -2254,6 +3124,8 @@ Templates:
 			0: Rough
 				LeftColor: 564B3B
 				RightColor: 61523F
+				ZOffset: -12
+				ZRamp: 0
 	Template@159:
 		Category: Clear/Rough LAT
 		Id: 159
@@ -2263,6 +3135,8 @@ Templates:
 			0: Rough
 				LeftColor: 564939
 				RightColor: 494338
+				ZOffset: -12
+				ZRamp: 0
 	Template@160:
 		Category: Clear/Rough LAT
 		Id: 160
@@ -2272,6 +3146,8 @@ Templates:
 			0: Rough
 				LeftColor: 544939
 				RightColor: 564937
+				ZOffset: -12
+				ZRamp: 0
 	Template@161:
 		Category: Clear/Rough LAT
 		Id: 161
@@ -2281,6 +3157,8 @@ Templates:
 			0: Rough
 				LeftColor: 5A4E3D
 				RightColor: 5B4C39
+				ZOffset: -12
+				ZRamp: 0
 	Template@162:
 		Category: Clear/Rough LAT
 		Id: 162
@@ -2290,6 +3168,8 @@ Templates:
 			0: Rough
 				LeftColor: 574C3C
 				RightColor: 60503D
+				ZOffset: -12
+				ZRamp: 0
 	Template@163:
 		Category: Clear/Rough LAT
 		Id: 163
@@ -2299,6 +3179,8 @@ Templates:
 			0: Rough
 				LeftColor: 64533D
 				RightColor: 4A4438
+				ZOffset: -12
+				ZRamp: 0
 	Template@164:
 		Category: Clear/Rough LAT
 		Id: 164
@@ -2308,6 +3190,8 @@ Templates:
 			0: Rough
 				LeftColor: 67533B
 				RightColor: 584B3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@165:
 		Category: Clear/Rough LAT
 		Id: 165
@@ -2317,6 +3201,8 @@ Templates:
 			0: Rough
 				LeftColor: 635440
 				RightColor: 554939
+				ZOffset: -12
+				ZRamp: 0
 	Template@166:
 		Category: Clear/Rough LAT
 		Id: 166
@@ -2326,6 +3212,8 @@ Templates:
 			0: Rough
 				LeftColor: 5B4D3A
 				RightColor: 5D4F3D
+				ZOffset: -12
+				ZRamp: 0
 	Template@167:
 		Category: Cliff/Water pieces
 		Id: 167
@@ -2336,16 +3224,24 @@ Templates:
 				Height: 4
 				LeftColor: 3D3325
 				RightColor: 52432F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 423B33
 				RightColor: 493F30
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 31281B
 				RightColor: 463827
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 2B333B
 				RightColor: 3C372D
+				ZOffset: -12
+				ZRamp: 0
 	Template@168:
 		Category: Cliff/Water pieces
 		Id: 168
@@ -2356,9 +3252,13 @@ Templates:
 				Height: 4
 				LeftColor: 463F33
 				RightColor: 524738
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 464138
 				RightColor: 3E382E
+				ZOffset: -12
+				ZRamp: 0
 	Template@169:
 		Category: Cliff/Water pieces
 		Id: 169
@@ -2369,16 +3269,24 @@ Templates:
 				Height: 4
 				LeftColor: 3E372C
 				RightColor: 4C402F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 313842
 				RightColor: 3F3930
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 353027
 				RightColor: 3A342A
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 242D3A
 				RightColor: 302E2A
+				ZOffset: -12
+				ZRamp: 0
 	Template@170:
 		Category: Cliff/Water pieces
 		Id: 170
@@ -2389,16 +3297,24 @@ Templates:
 				Height: 4
 				LeftColor: 504637
 				RightColor: 514433
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 26313F
 				RightColor: 4D4436
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 403A2D
 				RightColor: 4C4234
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 2D353F
 				RightColor: 453F33
+				ZOffset: -12
+				ZRamp: 0
 	Template@171:
 		Category: Cliff/Water pieces
 		Id: 171
@@ -2409,16 +3325,24 @@ Templates:
 				Height: 4
 				LeftColor: 3E362A
 				RightColor: 463C2E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 3F3A32
 				RightColor: 504434
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 2A3137
 				RightColor: 423C32
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 2E3640
 				RightColor: 4D463B
+				ZOffset: -12
+				ZRamp: 0
 	Template@172:
 		Category: Cliff/Water pieces
 		Id: 172
@@ -2429,16 +3353,24 @@ Templates:
 				Height: 4
 				LeftColor: 41392D
 				RightColor: 4D4334
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 3A3429
 				RightColor: 4A3E2E
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 363737
 				RightColor: 4D4538
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 323436
 				RightColor: 4D4436
+				ZOffset: -12
+				ZRamp: 0
 	Template@173:
 		Category: Cliff/Water pieces
 		Id: 173
@@ -2449,16 +3381,24 @@ Templates:
 				Height: 4
 				LeftColor: 483E30
 				RightColor: 504332
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 483F33
 				RightColor: 4E4130
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 2B323B
 				RightColor: 3E3931
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 353B42
 				RightColor: 484238
+				ZOffset: -12
+				ZRamp: 0
 	Template@174:
 		Category: Cliff/Water pieces
 		Id: 174
@@ -2469,9 +3409,13 @@ Templates:
 				Height: 4
 				LeftColor: 3E362C
 				RightColor: 4D4233
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 484744
 				RightColor: 444038
+				ZOffset: -12
+				ZRamp: 0
 	Template@175:
 		Category: Cliff/Water pieces
 		Id: 175
@@ -2482,12 +3426,18 @@ Templates:
 				Height: 4
 				LeftColor: 473E32
 				RightColor: 524535
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 34373A
 				RightColor: 4E473C
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 4A453B
 				RightColor: 454139
+				ZOffset: -12
+				ZRamp: 0
 	Template@176:
 		Category: Cliff/Water pieces
 		Id: 176
@@ -2498,15 +3448,23 @@ Templates:
 				Height: 4
 				LeftColor: 494032
 				RightColor: 4C4032
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 212932
 				RightColor: 494339
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 3E3B35
 				RightColor: 484237
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 313740
 				RightColor: 1E2B3C
+				ZOffset: -12
+				ZRamp: 0
 	Template@177:
 		Category: Cliff/Water pieces
 		Id: 177
@@ -2517,12 +3475,18 @@ Templates:
 				Height: 4
 				LeftColor: 483D2F
 				RightColor: 3F3629
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2C333A
 				RightColor: 3C382F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 46433D
 				RightColor: 48443E
+				ZOffset: -12
+				ZRamp: 0
 	Template@178:
 		Category: Cliff/Water pieces
 		Id: 178
@@ -2532,6 +3496,8 @@ Templates:
 			0: Cliff
 				LeftColor: 47433C
 				RightColor: 3E3C37
+				ZOffset: -12
+				ZRamp: 0
 	Template@179:
 		Category: Cliff/Water pieces
 		Id: 179
@@ -2541,6 +3507,8 @@ Templates:
 			0: Cliff
 				LeftColor: 423F39
 				RightColor: 4E473D
+				ZOffset: -12
+				ZRamp: 0
 	Template@180:
 		Category: Cliff/Water pieces
 		Id: 180
@@ -2550,6 +3518,8 @@ Templates:
 			0: Cliff
 				LeftColor: 4A453C
 				RightColor: 3B372F
+				ZOffset: -12
+				ZRamp: 0
 	Template@181:
 		Category: Cliff/Water pieces
 		Id: 181
@@ -2560,16 +3530,24 @@ Templates:
 				Height: 4
 				LeftColor: 4E4233
 				RightColor: 42382C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2E2E2D
 				RightColor: 32302C
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 483D30
 				RightColor: 3D3830
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 30353C
 				RightColor: 2F3030
+				ZOffset: -12
+				ZRamp: 0
 	Template@182:
 		Category: Cliff/Water pieces
 		Id: 182
@@ -2580,16 +3558,24 @@ Templates:
 				Height: 4
 				LeftColor: 443E34
 				RightColor: 423B30
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 363531
 				RightColor: 27292A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 473F33
 				RightColor: 302E29
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 383837
 				RightColor: 373632
+				ZOffset: -12
+				ZRamp: 0
 	Template@183:
 		Category: Cliff/Water pieces
 		Id: 183
@@ -2600,16 +3586,24 @@ Templates:
 				Height: 4
 				LeftColor: 453B2D
 				RightColor: 463E32
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 302B22
 				RightColor: 2F2E2B
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 504434
 				RightColor: 463F34
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 282C30
 				RightColor: 3A3732
+				ZOffset: -12
+				ZRamp: 0
 	Template@184:
 		Category: Cliff/Water pieces
 		Id: 184
@@ -2620,9 +3614,13 @@ Templates:
 				Height: 4
 				LeftColor: 4F412F
 				RightColor: 4A4033
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2C2E2D
 				RightColor: 363531
+				ZOffset: -12
+				ZRamp: 0
 	Template@185:
 		Category: Cliff/Water pieces
 		Id: 185
@@ -2633,16 +3631,24 @@ Templates:
 				Height: 4
 				LeftColor: 514434
 				RightColor: 3D372F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2C2A25
 				RightColor: 2B2E31
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 443B2D
 				RightColor: 242320
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 303942
 				RightColor: 2F3336
+				ZOffset: -12
+				ZRamp: 0
 	Template@186:
 		Category: Cliff/Water pieces
 		Id: 186
@@ -2653,16 +3659,24 @@ Templates:
 				Height: 4
 				LeftColor: 4E4232
 				RightColor: 453E32
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2D2C2A
 				RightColor: 23272D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 514231
 				RightColor: 2B2925
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 29313A
 				RightColor: 252C34
+				ZOffset: -12
+				ZRamp: 0
 	Template@187:
 		Category: Cliff/Water pieces
 		Id: 187
@@ -2673,16 +3687,24 @@ Templates:
 				Height: 4
 				LeftColor: 463D30
 				RightColor: 302F2B
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2B2C2B
 				RightColor: 343431
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 504434
 				RightColor: 24221F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 3C3E40
 				RightColor: 2E343B
+				ZOffset: -12
+				ZRamp: 0
 	Template@188:
 		Category: Cliff/Water pieces
 		Id: 188
@@ -2693,9 +3715,13 @@ Templates:
 				Height: 4
 				LeftColor: 4A3E2F
 				RightColor: 444038
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2B2D2F
 				RightColor: 30302E
+				ZOffset: -12
+				ZRamp: 0
 	Template@189:
 		Category: Cliff/Water pieces
 		Id: 189
@@ -2706,19 +3732,29 @@ Templates:
 				Height: 4
 				LeftColor: 463E32
 				RightColor: 4D4031
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 4A463C
 				RightColor: 3E3C36
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 2B2824
 				RightColor: 37322A
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 202D40
 				RightColor: 3B3B3B
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 25303F
 				RightColor: 373634
+				ZOffset: -12
+				ZRamp: 0
 	Template@190:
 		Category: Cliff/Water pieces
 		Id: 190
@@ -2728,9 +3764,13 @@ Templates:
 			0: Cliff
 				LeftColor: 474239
 				RightColor: 3F3B35
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 202C3B
 				RightColor: 373C41
+				ZOffset: -12
+				ZRamp: 0
 	Template@191:
 		Category: Cliff/Water pieces
 		Id: 191
@@ -2740,9 +3780,13 @@ Templates:
 			0: Cliff
 				LeftColor: 48433B
 				RightColor: 4C463C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 383C41
 				RightColor: 202D3D
+				ZOffset: -12
+				ZRamp: 0
 	Template@192:
 		Category: Cliff/Water pieces
 		Id: 192
@@ -2752,9 +3796,13 @@ Templates:
 			0: Cliff
 				LeftColor: 403C33
 				RightColor: 4E473B
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2D3540
 				RightColor: 443F3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@193:
 		Category: Cliff/Water pieces
 		Id: 193
@@ -2764,9 +3812,13 @@ Templates:
 			0: Cliff
 				LeftColor: 544B3D
 				RightColor: 423F38
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 383D47
 				RightColor: 2F3947
+				ZOffset: -12
+				ZRamp: 0
 	Template@194:
 		Category: Cliff/Water pieces
 		Id: 194
@@ -2777,19 +3829,29 @@ Templates:
 				Height: 4
 				LeftColor: 4B3F2E
 				RightColor: 423B31
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 312F2B
 				RightColor: 35332E
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 42413F
 				RightColor: 16283E
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 4E4132
 				RightColor: 282724
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 31373E
 				RightColor: 303439
+				ZOffset: -12
+				ZRamp: 0
 	Template@195:
 		Category: Bendy Dirt Roads
 		Id: 195
@@ -2799,18 +3861,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: 70593E
 				RightColor: 886946
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 906F49
 				RightColor: 8E6E49
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 92704A
 				RightColor: 9A754A
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 70593E
 				RightColor: 856745
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7F6444
 				RightColor: 8B6D48
+				ZOffset: -12
+				ZRamp: 0
 	Template@196:
 		Category: Bendy Dirt Roads
 		Id: 196
@@ -2820,15 +3892,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7C6243
 				RightColor: 8D6C46
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 916E47
 				RightColor: 8F6E48
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 6F583D
 				RightColor: 7A6143
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 7A6143
 				RightColor: 927048
+				ZOffset: -12
+				ZRamp: 0
 	Template@197:
 		Category: Bendy Dirt Roads
 		Id: 197
@@ -2838,15 +3918,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7C6345
 				RightColor: 927049
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 97744B
 				RightColor: 806545
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 6F583D
 				RightColor: 816646
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8B6C48
 				RightColor: 8A6C49
+				ZOffset: -12
+				ZRamp: 0
 	Template@198:
 		Category: Bendy Dirt Roads
 		Id: 198
@@ -2856,12 +3944,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: 896A47
 				RightColor: 8E6D47
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8A6943
 				RightColor: 7F6443
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 816544
 				RightColor: 7E6342
+				ZOffset: -12
+				ZRamp: 0
 	Template@199:
 		Category: Bendy Dirt Roads
 		Id: 199
@@ -2871,15 +3965,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8F6E47
 				RightColor: 8A6A45
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8B6A45
 				RightColor: 7D6344
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 826543
 				RightColor: 866743
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 765E42
 				RightColor: 765E40
+				ZOffset: -12
+				ZRamp: 0
 	Template@200:
 		Category: Bendy Dirt Roads
 		Id: 200
@@ -2889,18 +3991,28 @@ Templates:
 			1: DirtRoad
 				LeftColor: 95734B
 				RightColor: 957249
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 937048
 				RightColor: 7C6141
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 6D583E
 				RightColor: 7C6242
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7E6343
 				RightColor: 947149
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 896A46
 				RightColor: 846744
+				ZOffset: -12
+				ZRamp: 0
 	Template@201:
 		Category: Bendy Dirt Roads
 		Id: 201
@@ -2910,18 +4022,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7B6243
 				RightColor: 7D6344
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8F6D46
 				RightColor: 99744A
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 6D563C
 				RightColor: 7C6142
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9C774D
 				RightColor: 916E46
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 71593E
 				RightColor: 8A6B46
+				ZOffset: -12
+				ZRamp: 0
 	Template@202:
 		Category: Bendy Dirt Roads
 		Id: 202
@@ -2931,15 +4053,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 755D41
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 957249
 				RightColor: 9D774C
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 725D42
 				RightColor: 7E6445
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 906E49
 				RightColor: 8F6E49
+				ZOffset: -12
+				ZRamp: 0
 	Template@203:
 		Category: Bendy Dirt Roads
 		Id: 203
@@ -2949,15 +4079,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 765F43
 				RightColor: 7D6344
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9B764B
 				RightColor: 9D784D
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7F6444
 				RightColor: 886A46
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 876946
+				ZOffset: -12
+				ZRamp: 0
 	Template@204:
 		Category: Bendy Dirt Roads
 		Id: 204
@@ -2967,15 +4105,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 99754B
 				RightColor: 846745
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A07A4D
 				RightColor: 9E784D
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 846744
 				RightColor: 927049
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 7A6244
 				RightColor: 886A46
+				ZOffset: -12
+				ZRamp: 0
 	Template@205:
 		Category: Bendy Dirt Roads
 		Id: 205
@@ -2985,18 +4131,28 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8E6D47
 				RightColor: 836542
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9F784C
 				RightColor: 9E784D
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 765F43
 				RightColor: 836440
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7B5F3F
 				RightColor: 916E46
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 836644
 				RightColor: 886944
+				ZOffset: -12
+				ZRamp: 0
 	Template@206:
 		Category: Bendy Dirt Roads
 		Id: 206
@@ -3006,18 +4162,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: 715A3E
 				RightColor: 896B48
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8D6D49
 				RightColor: 9E784D
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9E794E
 				RightColor: 9D774C
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 70593F
 				RightColor: 866A48
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7E6345
 				RightColor: 7F6547
+				ZOffset: -12
+				ZRamp: 0
 	Template@207:
 		Category: Bendy Dirt Roads
 		Id: 207
@@ -3027,21 +4193,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7E6445
 				RightColor: 775E41
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 816443
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7C6142
 				RightColor: 8E6D47
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8E6F4B
 				RightColor: 98754B
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 705A40
 				RightColor: 7E6343
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 95734B
 				RightColor: 8E6E49
+				ZOffset: -12
+				ZRamp: 0
 	Template@208:
 		Category: Bendy Dirt Roads
 		Id: 208
@@ -3051,15 +4229,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7D6343
 				RightColor: 785F40
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8C6C47
 				RightColor: 816443
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 826644
 				RightColor: 8B6B45
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 926F48
 				RightColor: 95724A
+				ZOffset: -12
+				ZRamp: 0
 	Template@209:
 		Category: Bendy Dirt Roads
 		Id: 209
@@ -3069,12 +4255,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: 896A47
 				RightColor: 7A5F40
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 937048
 				RightColor: 816543
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 937049
+				ZOffset: -12
+				ZRamp: 0
 	Template@210:
 		Category: Bendy Dirt Roads
 		Id: 210
@@ -3084,12 +4276,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: 906F4A
 				RightColor: 806443
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 70593E
 				RightColor: 7D6344
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 7C6243
 				RightColor: 94714A
+				ZOffset: -12
+				ZRamp: 0
 	Template@211:
 		Category: Bendy Dirt Roads
 		Id: 211
@@ -3099,21 +4297,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7E6344
 				RightColor: 7D6344
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 896A46
 				RightColor: 785E40
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 765D40
 				RightColor: 6E5A40
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 7D6142
 				RightColor: 8B6B46
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8C6D49
 				RightColor: 906F49
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 93704A
 				RightColor: 896A46
+				ZOffset: -12
+				ZRamp: 0
 	Template@212:
 		Category: Bendy Dirt Roads
 		Id: 212
@@ -3123,12 +4333,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8C6C48
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 866846
 				RightColor: 745D40
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 94724C
 				RightColor: 8A6A45
+				ZOffset: -12
+				ZRamp: 0
 	Template@213:
 		Category: Bendy Dirt Roads
 		Id: 213
@@ -3138,15 +4354,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 886A46
 				RightColor: 7A6042
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 775D3E
 				RightColor: 735B3E
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 836644
 				RightColor: 8D6C46
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8E6D46
 				RightColor: 8B6B46
+				ZOffset: -12
+				ZRamp: 0
 	Template@214:
 		Category: Bendy Dirt Roads
 		Id: 214
@@ -3156,18 +4380,28 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8C6C48
 				RightColor: 7E6343
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8A6D4A
 				RightColor: 7A6144
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7A6042
 				RightColor: 735C3F
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 916F48
 				RightColor: 96724A
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 8C6D49
 				RightColor: 775F42
+				ZOffset: -12
+				ZRamp: 0
 	Template@215:
 		Category: Bendy Dirt Roads
 		Id: 215
@@ -3177,15 +4411,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8B6C48
 				RightColor: 7A6142
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 806444
 				RightColor: 715A3E
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 93714A
 				RightColor: 96744C
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 947149
 				RightColor: 816544
+				ZOffset: -12
+				ZRamp: 0
 	Template@216:
 		Category: Bendy Dirt Roads
 		Id: 216
@@ -3195,12 +4437,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8D6E4A
 				RightColor: 705B41
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7D6343
 				RightColor: 8E6D47
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6F49
 				RightColor: 876A47
+				ZOffset: -12
+				ZRamp: 0
 	Template@217:
 		Category: Bendy Dirt Roads
 		Id: 217
@@ -3210,15 +4458,23 @@ Templates:
 			1: DirtRoad
 				LeftColor: 856847
 				RightColor: 705A3F
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 8A6C47
 				RightColor: 8D6D47
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8B6A44
 				RightColor: 816442
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 816544
 				RightColor: 7C6242
+				ZOffset: -12
+				ZRamp: 0
 	Template@218:
 		Category: Bendy Dirt Roads
 		Id: 218
@@ -3228,18 +4484,28 @@ Templates:
 			1: DirtRoad
 				LeftColor: 7D6343
 				RightColor: 6E5A40
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 98744B
 				RightColor: 9E784D
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 95734A
 				RightColor: 826644
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 846644
 				RightColor: 93724B
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7B6243
 				RightColor: 826644
+				ZOffset: -12
+				ZRamp: 0
 	Template@219:
 		Category: Dirt Road Junctions
 		Id: 219
@@ -3249,15 +4515,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7C6142
 				RightColor: 8E6D47
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9A764D
 				RightColor: 8F6F4B
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7E6444
 				RightColor: 886A47
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 91714B
 				RightColor: 99754C
+				ZOffset: -12
+				ZRamp: 0
 	Template@220:
 		Category: Dirt Road Junctions
 		Id: 220
@@ -3267,15 +4541,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 806444
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8F6E49
 				RightColor: 816443
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 947149
 				RightColor: 916F48
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 927049
 				RightColor: 9A754C
+				ZOffset: -12
+				ZRamp: 0
 	Template@221:
 		Category: Dirt Road Junctions
 		Id: 221
@@ -3285,15 +4567,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 96734B
 				RightColor: 99764D
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 96734A
 				RightColor: 7F6545
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 937048
 				RightColor: 957148
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 906F47
 				RightColor: 7B6041
+				ZOffset: -12
+				ZRamp: 0
 	Template@222:
 		Category: Dirt Road Junctions
 		Id: 222
@@ -3303,15 +4593,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8E6E49
 				RightColor: 896B48
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9C774D
 				RightColor: 90704B
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 866845
 				RightColor: 8D6D48
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8A6B47
 				RightColor: 9A764C
+				ZOffset: -12
+				ZRamp: 0
 	Template@223:
 		Category: Dirt Road Junctions
 		Id: 223
@@ -3321,15 +4619,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8B6C48
 				RightColor: 96744C
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9B784E
 				RightColor: 91714B
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 8C6C47
 				RightColor: 8C6C48
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F704A
 				RightColor: 96734B
+				ZOffset: -12
+				ZRamp: 0
 	Template@224:
 		Category: Dirt Road Junctions
 		Id: 224
@@ -3339,24 +4645,38 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8A6E4C
 				RightColor: 836746
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9F794D
 				RightColor: 9E784C
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6E49
 				RightColor: 886946
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 96744D
 				RightColor: A47E52
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 91704A
 				RightColor: 8C6D47
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 856745
 				RightColor: 91704B
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 97744C
 				RightColor: 8E6E49
+				ZOffset: -12
+				ZRamp: 0
 	Template@225:
 		Category: Dirt Road Junctions
 		Id: 225
@@ -3366,21 +4686,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: 775E41
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8E6E48
 				RightColor: 8B6B46
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 9B754B
 				RightColor: 866743
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 806342
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 876845
 				RightColor: 937049
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 97744C
 				RightColor: 8F6F49
+				ZOffset: -12
+				ZRamp: 0
 	Template@226:
 		Category: Dirt Road Junctions
 		Id: 226
@@ -3390,21 +4722,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: 91704A
 				RightColor: 7F6343
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 99744A
 				RightColor: 9D784C
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8D6D48
 				RightColor: 96734A
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8D6D47
 				RightColor: 95724A
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 816646
 				RightColor: 846745
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 846745
 				RightColor: 816545
+				ZOffset: -12
+				ZRamp: 0
 	Template@227:
 		Category: Dirt Road Junctions
 		Id: 227
@@ -3414,24 +4758,38 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8C6B47
 				RightColor: 856745
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9F794D
 				RightColor: 9E784D
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 715B40
 				RightColor: 876946
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 906E47
 				RightColor: 9D784D
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 967249
 				RightColor: 896A46
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 6E573D
 				RightColor: 826644
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 95734B
 				RightColor: 8F6F49
+				ZOffset: -12
+				ZRamp: 0
 	Template@228:
 		Category: Dirt Road Junctions
 		Id: 228
@@ -3441,24 +4799,38 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8A6C4A
 				RightColor: 856745
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A07A4E
 				RightColor: 9E794D
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8D6D48
 				RightColor: 947149
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 916E47
 				RightColor: 99754B
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 937148
 				RightColor: 896A46
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 846745
 				RightColor: 8F6D47
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 98744B
 				RightColor: 906F49
+				ZOffset: -12
+				ZRamp: 0
 	Template@229:
 		Category: Dirt Road Junctions
 		Id: 229
@@ -3468,42 +4840,68 @@ Templates:
 			2: DirtRoad
 				LeftColor: 876C4B
 				RightColor: 896A46
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9C774B
 				RightColor: 9F784C
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7F6446
 				RightColor: 7B6143
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 9C784E
 				RightColor: 9D794F
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 856644
 				RightColor: 806443
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 98744B
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 92714B
 				RightColor: 9E794F
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 987853
 				RightColor: 977751
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 96754E
 				RightColor: 876946
+				ZOffset: -12
+				ZRamp: 0
 			12: DirtRoad
 				LeftColor: 896A46
 				RightColor: 99754C
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 846949
 				RightColor: 96744D
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 8A6B48
 				RightColor: 91724F
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 866845
 				RightColor: 95734C
+				ZOffset: -12
+				ZRamp: 0
 	Template@230:
 		Category: Straight Dirt Roads
 		Id: 230
@@ -3513,30 +4911,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: 876B4B
 				RightColor: 816544
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A07A4D
 				RightColor: 9E784D
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7E6548
 				RightColor: 7B6143
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: A17B4E
 				RightColor: 9F7A4E
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 846745
 				RightColor: 886A46
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 8D6D48
 				RightColor: 866744
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 876845
 				RightColor: 93714A
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 806545
 				RightColor: 866743
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 846745
 				RightColor: 816544
+				ZOffset: -12
+				ZRamp: 0
 	Template@231:
 		Category: Straight Dirt Roads
 		Id: 231
@@ -3546,30 +4962,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: 856A4A
 				RightColor: 876845
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9B764B
 				RightColor: 9F784C
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7E6446
 				RightColor: 7A6042
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 9B784F
 				RightColor: 99764E
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 795F40
 				RightColor: 7F6443
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 866948
 				RightColor: 7F6546
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 947048
 				RightColor: 99764C
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 876B4A
 				RightColor: 856A4B
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 8A6A45
 				RightColor: 896B47
+				ZOffset: -12
+				ZRamp: 0
 	Template@232:
 		Category: Straight Dirt Roads
 		Id: 232
@@ -3579,30 +5013,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: 816443
 				RightColor: 826441
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6D47
 				RightColor: 967248
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 795E3F
 				RightColor: 725B3F
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7C6346
 				RightColor: 856845
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 836542
 				RightColor: 795E3F
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 876947
 				RightColor: 876946
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 947148
 				RightColor: 896741
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 7C6141
 				RightColor: 7A6142
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 8B6B46
 				RightColor: 866846
+				ZOffset: -12
+				ZRamp: 0
 	Template@233:
 		Category: Straight Dirt Roads
 		Id: 233
@@ -3612,39 +5064,63 @@ Templates:
 			0: Clear
 				LeftColor: 775E40
 				RightColor: 755C3F
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 8E6D47
 				RightColor: 7D6243
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9C774C
 				RightColor: 93714A
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 9C764A
 				RightColor: 9D764A
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 7C6344
 				RightColor: 886945
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9E784D
 				RightColor: A27C4F
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 856643
 				RightColor: 8C6B44
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 765D41
 				RightColor: 7A5F3F
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 8E6E4A
 				RightColor: 916F48
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 9D774B
 				RightColor: 916F48
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 755D40
 				RightColor: 6F593D
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 8A6B46
 				RightColor: 886A46
+				ZOffset: -12
+				ZRamp: 0
 	Template@234:
 		Category: Straight Dirt Roads
 		Id: 234
@@ -3654,21 +5130,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8C6B45
 				RightColor: 8D6B45
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 9E784D
 				RightColor: 9B764B
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 896C48
 				RightColor: 886945
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A27B4E
 				RightColor: 9B764B
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7D6141
 				RightColor: 806240
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 866946
 				RightColor: 866946
+				ZOffset: -12
+				ZRamp: 0
 	Template@235:
 		Category: Straight Dirt Roads
 		Id: 235
@@ -3678,12 +5166,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: 876B4B
 				RightColor: 907049
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: A07A4E
 				RightColor: 9F794D
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6C44
 				RightColor: 8B6B46
+				ZOffset: -12
+				ZRamp: 0
 	Template@236:
 		Category: Straight Dirt Roads
 		Id: 236
@@ -3693,12 +5187,18 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8F6D47
 				RightColor: 886844
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 9D774B
 				RightColor: 9D774B
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 876845
 				RightColor: 836543
+				ZOffset: -12
+				ZRamp: 0
 	Template@237:
 		Category: Straight Dirt Roads
 		Id: 237
@@ -3708,27 +5208,43 @@ Templates:
 			2: Clear
 				LeftColor: 715A3F
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7C6143
 				RightColor: 755E41
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 796144
 				RightColor: 745D43
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 775E42
 				RightColor: 735B3F
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 896C49
 				RightColor: 775D3F
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 926E46
 				RightColor: 876742
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 765D40
 				RightColor: 765E41
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 836644
 				RightColor: 856846
+				ZOffset: -12
+				ZRamp: 0
 	Template@238:
 		Category: Straight Dirt Roads
 		Id: 238
@@ -3738,30 +5254,48 @@ Templates:
 			1: Clear
 				LeftColor: 745D42
 				RightColor: 725B41
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 7B6345
 				RightColor: 796144
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 735B40
 				RightColor: 70593F
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 886B49
 				RightColor: 836949
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 9A7851
 				RightColor: 896D4E
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 856C4E
 				RightColor: 7E6548
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 755D42
 				RightColor: 715A3F
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 8B6C47
 				RightColor: 92714C
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 766046
 				RightColor: 765F44
+				ZOffset: -12
+				ZRamp: 0
 	Template@239:
 		Category: Straight Dirt Roads
 		Id: 239
@@ -3771,21 +5305,33 @@ Templates:
 			1: Clear
 				LeftColor: 7B6244
 				RightColor: 775F43
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 816647
 				RightColor: 725B3F
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 876947
 				RightColor: 876947
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 906E47
 				RightColor: 866846
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 755D41
 				RightColor: 775E40
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 8A6A45
 				RightColor: 846745
+				ZOffset: -12
+				ZRamp: 0
 	Template@240:
 		Category: Straight Dirt Roads
 		Id: 240
@@ -3795,30 +5341,48 @@ Templates:
 			2: DirtRoad
 				LeftColor: 806341
 				RightColor: 846643
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8E6D47
 				RightColor: 916F47
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 735B3E
 				RightColor: 745B3E
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7B6142
 				RightColor: 8A6943
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 846541
 				RightColor: 836542
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 71593D
 				RightColor: 765B3D
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 7E6140
 				RightColor: 82633F
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 7A5E3E
 				RightColor: 775D3E
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 735B40
 				RightColor: 775D3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@241:
 		Category: Straight Dirt Roads
 		Id: 241
@@ -3828,30 +5392,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: 795F3F
 				RightColor: 856643
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7E6141
 				RightColor: 957249
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 705A3F
 				RightColor: 826443
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 937048
 				RightColor: 8C6A43
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 775D40
 				RightColor: 7E6240
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 796044
 				RightColor: 846849
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 866743
 				RightColor: 836543
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 725D43
 				RightColor: 786043
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 735C41
 				RightColor: 7A6041
+				ZOffset: -12
+				ZRamp: 0
 	Template@242:
 		Category: Straight Dirt Roads
 		Id: 242
@@ -3861,21 +5443,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: 796144
 				RightColor: 7D6344
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 896A46
 				RightColor: 9C774C
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 766045
 				RightColor: 745D41
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 816545
 				RightColor: 896B47
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 816443
 				RightColor: 7F6443
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 6F593F
 				RightColor: 7C6345
+				ZOffset: -12
+				ZRamp: 0
 	Template@243:
 		Category: Straight Dirt Roads
 		Id: 243
@@ -3885,33 +5479,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: 7D6242
 				RightColor: 7A6142
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 977349
 				RightColor: 856541
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: A0794D
 				RightColor: 96724A
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: A17B4F
 				RightColor: A37C4F
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 856845
 				RightColor: 836643
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 9D774B
 				RightColor: 997449
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 8A6B46
 				RightColor: 977349
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 846644
 				RightColor: 8D6D47
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 755D40
 				RightColor: 7D6343
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 8A6B47
 				RightColor: 866744
+				ZOffset: -12
+				ZRamp: 0
 	Template@244:
 		Category: Straight Dirt Roads
 		Id: 244
@@ -3921,33 +5535,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: 795F40
 				RightColor: 7B6041
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 906F48
 				RightColor: 9F7B50
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 796143
 				RightColor: 775F42
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8C6C47
 				RightColor: 8F6F49
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7F6546
 				RightColor: 866946
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 795F41
 				RightColor: 8C6C48
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 7E6343
 				RightColor: 7A6041
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 8E6F4A
 				RightColor: 846745
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 826442
 				RightColor: 7B6142
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 856845
 				RightColor: 796143
+				ZOffset: -12
+				ZRamp: 0
 	Template@245:
 		Category: Straight Dirt Roads
 		Id: 245
@@ -3957,21 +5591,33 @@ Templates:
 			1: Clear
 				LeftColor: 7B6143
 				RightColor: 765E41
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 786144
 				RightColor: 7A6243
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 7D6447
 				RightColor: 796245
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 826747
 				RightColor: 846847
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 755D41
 				RightColor: 725B3F
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 71593E
 				RightColor: 775F42
+				ZOffset: -12
+				ZRamp: 0
 	Template@246:
 		Category: Straight Dirt Roads
 		Id: 246
@@ -3981,27 +5627,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 896B47
 				RightColor: 7A6041
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 7B6243
 				RightColor: 796043
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 775E40
 				RightColor: 755D3F
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8A6B47
 				RightColor: 816443
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 846745
 				RightColor: 8B6C47
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7E6344
 				RightColor: 8F6E48
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 846643
 				RightColor: 906F48
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 836644
 				RightColor: 98744B
+				ZOffset: -12
+				ZRamp: 0
 	Template@247:
 		Category: Straight Dirt Roads
 		Id: 247
@@ -4011,27 +5673,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 7E6242
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 92704A
 				RightColor: 8E6E49
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 917049
 				RightColor: 856846
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 96734A
 				RightColor: 806444
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 816544
 				RightColor: 896A45
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 796143
 				RightColor: 896B47
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 765F43
 				RightColor: 856947
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 785E41
 				RightColor: 94724A
+				ZOffset: -12
+				ZRamp: 0
 	Template@248:
 		Category: Straight Dirt Roads
 		Id: 248
@@ -4041,27 +5719,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 97744B
 				RightColor: 7E6444
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8C6D49
 				RightColor: 816544
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7D6446
 				RightColor: 776043
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 92714C
 				RightColor: 7D6243
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 896A46
 				RightColor: 93714C
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7F6648
 				RightColor: 90704B
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 836847
 				RightColor: 91724F
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 866845
 				RightColor: 95734C
+				ZOffset: -12
+				ZRamp: 0
 	Template@249:
 		Category: Straight Dirt Roads
 		Id: 249
@@ -4071,27 +5765,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8C6A44
 				RightColor: 7E6140
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8B6B46
 				RightColor: 896944
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 927049
 				RightColor: 7E6343
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8B6B46
 				RightColor: 7E6343
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7E6445
 				RightColor: 947046
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 806444
 				RightColor: 8E6E48
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7C6140
 				RightColor: 927048
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 7C6141
 				RightColor: 916F47
+				ZOffset: -12
+				ZRamp: 0
 	Template@250:
 		Category: Straight Dirt Roads
 		Id: 250
@@ -4101,21 +5811,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8A6B47
 				RightColor: 7D6242
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 886945
 				RightColor: 826544
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 8D6C46
 				RightColor: 826543
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 846745
 				RightColor: 8C6C46
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7E6242
 				RightColor: 8E6D47
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7A5F40
 				RightColor: 947047
+				ZOffset: -12
+				ZRamp: 0
 	Template@251:
 		Category: Straight Dirt Roads
 		Id: 251
@@ -4125,15 +5847,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 7C6143
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 866949
 				RightColor: 7E6344
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7F6342
 				RightColor: 8E6E49
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 856947
 				RightColor: 90704A
+				ZOffset: -12
+				ZRamp: 0
 	Template@252:
 		Category: Straight Dirt Roads
 		Id: 252
@@ -4143,9 +5873,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 7E6344
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 866846
 				RightColor: 927048
+				ZOffset: -12
+				ZRamp: 0
 	Template@253:
 		Category: Straight Dirt Roads
 		Id: 253
@@ -4155,9 +5889,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8F6D47
 				RightColor: 7C6142
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 7F6240
 				RightColor: 8B6B46
+				ZOffset: -12
+				ZRamp: 0
 	Template@254:
 		Category: Straight Dirt Roads
 		Id: 254
@@ -4167,21 +5905,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: 8C6C47
 				RightColor: 7D6141
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 856745
 				RightColor: 765D3F
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 785F41
 				RightColor: 6F5A40
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 816544
 				RightColor: 916F48
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 806443
 				RightColor: 856642
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 745C41
 				RightColor: 735B3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@255:
 		Category: Straight Dirt Roads
 		Id: 255
@@ -4191,15 +5941,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 97744B
 				RightColor: 715B3F
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 755E42
 				RightColor: 6E5941
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 816544
 				RightColor: 8C6D49
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 745D42
 				RightColor: 745D42
+				ZOffset: -12
+				ZRamp: 0
 	Template@256:
 		Category: Straight Dirt Roads
 		Id: 256
@@ -4209,24 +5967,38 @@ Templates:
 			1: Clear
 				LeftColor: 715C42
 				RightColor: 6F5A42
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 755E44
 				RightColor: 6D5941
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 886A47
 				RightColor: 7A6143
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8A6B48
 				RightColor: 806749
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 735D44
 				RightColor: 755F44
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 846847
 				RightColor: 876A48
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 755E43
 				RightColor: 775F42
+				ZOffset: -12
+				ZRamp: 0
 	Template@257:
 		Category: Straight Dirt Roads
 		Id: 257
@@ -4236,21 +6008,33 @@ Templates:
 			0: Clear
 				LeftColor: 795E40
 				RightColor: 775E40
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 886B49
 				RightColor: 785F43
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 8D6E49
 				RightColor: 816544
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 755D41
 				RightColor: 836643
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 796143
 				RightColor: 8B6B47
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 846847
 				RightColor: 9A764B
+				ZOffset: -12
+				ZRamp: 0
 	Template@258:
 		Category: Straight Dirt Roads
 		Id: 258
@@ -4260,15 +6044,23 @@ Templates:
 			0: Clear
 				LeftColor: 786145
 				RightColor: 725B3F
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 846745
 				RightColor: 806545
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 775F43
 				RightColor: 7E6242
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 715A3F
 				RightColor: 8D6E49
+				ZOffset: -12
+				ZRamp: 0
 	Template@259:
 		Category: Straight Dirt Roads
 		Id: 259
@@ -4278,15 +6070,23 @@ Templates:
 			0: Clear
 				LeftColor: 785E3F
 				RightColor: 7C6141
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8F6C45
 				RightColor: 7C6243
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 775F41
 				RightColor: 785F41
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 7B6142
 				RightColor: 927049
+				ZOffset: -12
+				ZRamp: 0
 	Template@260:
 		Category: Straight Dirt Roads
 		Id: 260
@@ -4296,27 +6096,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 906F48
 				RightColor: 7C6142
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 846847
 				RightColor: 735D40
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7F6444
 				RightColor: 8A6944
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 816341
 				RightColor: 967249
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 886946
 				RightColor: 7A6041
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 896B48
 				RightColor: 7E6344
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 735D43
 				RightColor: 7B6143
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 785F41
 				RightColor: 8B6C48
+				ZOffset: -12
+				ZRamp: 0
 	Template@261:
 		Category: Straight Dirt Roads
 		Id: 261
@@ -4326,27 +6142,43 @@ Templates:
 			2: Clear
 				LeftColor: 7C6141
 				RightColor: 775E42
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 937149
 				RightColor: 7D6242
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 917049
 				RightColor: 7F6344
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 8B6B46
 				RightColor: 856642
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7B6040
 				RightColor: 846745
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 816443
 				RightColor: 906E46
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 7A5F40
 				RightColor: 826543
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 765E41
 				RightColor: 796042
+				ZOffset: -12
+				ZRamp: 0
 	Template@262:
 		Category: Straight Dirt Roads
 		Id: 262
@@ -4356,27 +6188,43 @@ Templates:
 			0: Clear
 				LeftColor: 755D40
 				RightColor: 785E3F
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 886946
 				RightColor: 7D6342
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 866745
 				RightColor: 735D41
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 7A5F40
 				RightColor: 70593F
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 705A40
 				RightColor: 765D40
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 735B3F
 				RightColor: 92704A
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 846643
 				RightColor: 896843
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 796144
 				RightColor: 755D40
+				ZOffset: -12
+				ZRamp: 0
 	Template@263:
 		Category: Straight Dirt Roads
 		Id: 263
@@ -4386,30 +6234,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: 775F41
 				RightColor: 6E5A40
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 715B40
 				RightColor: 876946
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 906E48
 				RightColor: 856846
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7B6243
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 725C41
 				RightColor: 866845
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 916F48
 				RightColor: 8D6D47
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 816443
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 6E573D
 				RightColor: 826644
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 95734B
 				RightColor: 8E6E49
+				ZOffset: -12
+				ZRamp: 0
 	Template@264:
 		Category: Straight Dirt Roads
 		Id: 264
@@ -4419,30 +6285,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: 7F6545
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 715C43
 				RightColor: 866946
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 906D46
 				RightColor: 866844
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7A6041
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 70593E
 				RightColor: 836745
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 8B6B46
 				RightColor: 896A45
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 7F6342
 				RightColor: 6E5A40
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 715C43
 				RightColor: 7D6343
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 876845
 				RightColor: 94714A
+				ZOffset: -12
+				ZRamp: 0
 	Template@265:
 		Category: Straight Dirt Roads
 		Id: 265
@@ -4452,30 +6336,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: 886B47
 				RightColor: 725B3F
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 735E44
 				RightColor: 866947
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 856947
 				RightColor: 876946
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 846947
 				RightColor: 786042
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 725A3E
 				RightColor: 866945
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 8C6D49
 				RightColor: 846847
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 826645
 				RightColor: 715A3E
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 725B40
 				RightColor: 816645
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 8B6C48
 				RightColor: 866845
+				ZOffset: -12
+				ZRamp: 0
 	Template@266:
 		Category: Straight Dirt Roads
 		Id: 266
@@ -4485,30 +6387,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: 7A6041
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 735D41
 				RightColor: 876A47
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 886A47
 				RightColor: 846745
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 816645
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 715B40
 				RightColor: 836745
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 806442
 				RightColor: 92714A
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 816646
 				RightColor: 735D42
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 735D42
 				RightColor: 7C6344
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 906F4A
 				RightColor: 896B47
+				ZOffset: -12
+				ZRamp: 0
 	Template@267:
 		Category: Straight Dirt Roads
 		Id: 267
@@ -4518,21 +6438,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: 816544
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 715A3E
 				RightColor: 816544
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8A6B47
 				RightColor: 8A6B47
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 876A47
 				RightColor: 765E41
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 725B3F
 				RightColor: 816443
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 93714A
 				RightColor: 91704A
+				ZOffset: -12
+				ZRamp: 0
 	Template@268:
 		Category: Straight Dirt Roads
 		Id: 268
@@ -4542,12 +6474,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: 826644
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 735C40
 				RightColor: 866947
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8E6D48
 				RightColor: 91714B
+				ZOffset: -12
+				ZRamp: 0
 	Template@269:
 		Category: Straight Dirt Roads
 		Id: 269
@@ -4557,12 +6495,18 @@ Templates:
 			1: DirtRoad
 				LeftColor: 7B6040
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 725B3F
 				RightColor: 856846
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8B6C47
 				RightColor: 8C6C48
+				ZOffset: -12
+				ZRamp: 0
 	Template@270:
 		Category: Straight Dirt Roads
 		Id: 270
@@ -4572,30 +6516,48 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8B6C48
 				RightColor: 735C3F
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 6E583F
 				RightColor: 856947
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 92704A
 				RightColor: 906F49
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7D6243
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 705B41
 				RightColor: 816646
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 816545
 				RightColor: 826645
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 755C40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: 70583D
 				RightColor: 7A6042
+				ZOffset: -12
+				ZRamp: 0
 			15: Clear
 				LeftColor: 755E42
 				RightColor: 775F42
+				ZOffset: -12
+				ZRamp: 0
 	Template@271:
 		Category: Straight Dirt Roads
 		Id: 271
@@ -4605,33 +6567,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: 94724B
 				RightColor: 745C41
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 6E583F
 				RightColor: 866A48
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 92714B
 				RightColor: 91704A
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 7B6042
 				RightColor: 6F5A40
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 796043
 				RightColor: 816545
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 7D6142
 				RightColor: 7B6041
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 725A3E
 				RightColor: 715A3F
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 725B40
 				RightColor: 765D40
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: 735B3F
 				RightColor: 735B3F
+				ZOffset: -12
+				ZRamp: 0
 			18: Clear
 				LeftColor: 725C42
 				RightColor: 755D41
+				ZOffset: -12
+				ZRamp: 0
 	Template@272:
 		Category: Straight Dirt Roads
 		Id: 272
@@ -4641,21 +6623,33 @@ Templates:
 			1: DirtRoad
 				LeftColor: 806444
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 705B41
 				RightColor: 866948
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8B6B47
 				RightColor: 836645
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 755D40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 6E573D
 				RightColor: 7A6042
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 796144
 				RightColor: 7B6143
+				ZOffset: -12
+				ZRamp: 0
 	Template@273:
 		Category: Straight Dirt Roads
 		Id: 273
@@ -4665,30 +6659,48 @@ Templates:
 			1: Clear
 				LeftColor: 765F42
 				RightColor: 765E41
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 725B40
 				RightColor: 765D41
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 785E41
 				RightColor: 7D6243
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 7C6346
 				RightColor: 705A3F
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 725C41
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 896C4A
 				RightColor: 806546
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 836745
 				RightColor: 725C41
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 735C3F
 				RightColor: 7E6343
+				ZOffset: -12
+				ZRamp: 0
 			15: DirtRoad
 				LeftColor: 886945
 				RightColor: 8D6D48
+				ZOffset: -12
+				ZRamp: 0
 	Template@274:
 		Category: Straight Dirt Roads
 		Id: 274
@@ -4698,21 +6710,33 @@ Templates:
 			0: Clear
 				LeftColor: 725B41
 				RightColor: 725B3F
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 745C3F
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 70583D
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 886A48
 				RightColor: 755E41
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 70593F
 				RightColor: 745C41
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 8C6D48
 				RightColor: 906E48
+				ZOffset: -12
+				ZRamp: 0
 	Template@275:
 		Category: Straight Dirt Roads
 		Id: 275
@@ -4722,21 +6746,33 @@ Templates:
 			1: Clear
 				LeftColor: 735A3D
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 6E573D
 				RightColor: 6F583C
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 795F40
 				RightColor: 7C6041
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7C603F
 				RightColor: 725A3E
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 755D41
 				RightColor: 81633F
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 876946
 				RightColor: 8C6C48
+				ZOffset: -12
+				ZRamp: 0
 	Template@276:
 		Category: Straight Dirt Roads
 		Id: 276
@@ -4746,36 +6782,58 @@ Templates:
 			1: DirtRoad
 				LeftColor: 8D6D47
 				RightColor: 785E41
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 7D6141
 				RightColor: 735B3F
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 715A40
 				RightColor: 8B6C47
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 8E6D47
 				RightColor: 8D6B44
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 8C6B44
 				RightColor: 856744
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 836645
 				RightColor: 7D6242
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 826646
 				RightColor: 6F5A40
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 786042
 				RightColor: 7F6443
+				ZOffset: -12
+				ZRamp: 0
 			12: DirtRoad
 				LeftColor: 735C40
 				RightColor: 836644
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 816443
 				RightColor: 8D6B45
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 93724C
 				RightColor: 8E6E48
+				ZOffset: -12
+				ZRamp: 0
 	Template@277:
 		Category: Straight Dirt Roads
 		Id: 277
@@ -4785,33 +6843,53 @@ Templates:
 			1: DirtRoad
 				LeftColor: 785F41
 				RightColor: 735B3E
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 796043
 				RightColor: 8B6C47
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 8F704C
 				RightColor: 7E6343
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 725B3F
 				RightColor: 7A6143
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 8F704B
 				RightColor: 96754E
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 7F6647
 				RightColor: 6F5A3F
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 7D6447
 				RightColor: 8B6D49
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 92714A
 				RightColor: 775E41
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 6F5A40
 				RightColor: 7E6547
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 866948
 				RightColor: 8C6D4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@278:
 		Category: Straight Dirt Roads
 		Id: 278
@@ -4821,30 +6899,48 @@ Templates:
 			1: Clear
 				LeftColor: 735C40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 70593F
 				RightColor: 715B40
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 816747
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 735C40
 				RightColor: 6F5A41
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 6F5A40
 				RightColor: 765F44
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 806545
 				RightColor: 7F6445
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 7A6043
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: 6E573D
 				RightColor: 775F41
+				ZOffset: -12
+				ZRamp: 0
 			15: Clear
 				LeftColor: 786042
 				RightColor: 7B6143
+				ZOffset: -12
+				ZRamp: 0
 	Template@279:
 		Category: Straight Dirt Roads
 		Id: 279
@@ -4854,27 +6950,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7D6243
 				RightColor: 916F48
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 96734A
 				RightColor: 7F6545
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7D6547
 				RightColor: 896B48
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F704B
 				RightColor: 836745
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7A6142
 				RightColor: 896B48
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 866A48
 				RightColor: 796144
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7F6444
 				RightColor: 876946
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 8F6F48
 				RightColor: 775E40
+				ZOffset: -12
+				ZRamp: 0
 	Template@280:
 		Category: Straight Dirt Roads
 		Id: 280
@@ -4884,27 +6996,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 876A48
 				RightColor: 92714B
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 866845
 				RightColor: 7B6142
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7F6445
 				RightColor: 91714B
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 876A47
 				RightColor: 765E41
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7C6447
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 816746
 				RightColor: 816645
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 806443
 				RightColor: 93714A
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 886A47
 				RightColor: 796042
+				ZOffset: -12
+				ZRamp: 0
 	Template@281:
 		Category: Straight Dirt Roads
 		Id: 281
@@ -4914,27 +7042,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7C6243
 				RightColor: 957148
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8F6F49
 				RightColor: 7B6141
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7F6444
 				RightColor: 8E6F4A
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 90714C
 				RightColor: 786042
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 806545
 				RightColor: 8A6D49
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 91714B
 				RightColor: 786144
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 816645
 				RightColor: 906F48
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 92704A
 				RightColor: 7C6242
+				ZOffset: -12
+				ZRamp: 0
 	Template@282:
 		Category: Straight Dirt Roads
 		Id: 282
@@ -4944,27 +7088,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7D6345
 				RightColor: 8F6E48
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 896B47
 				RightColor: 775E40
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 816747
 				RightColor: 8E6F4A
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F704B
 				RightColor: 7E6445
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 866947
 				RightColor: 8C6E49
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 94734D
 				RightColor: 886A46
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 836745
 				RightColor: 95744D
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 896C49
 				RightColor: 745D40
+				ZOffset: -12
+				ZRamp: 0
 	Template@283:
 		Category: Straight Dirt Roads
 		Id: 283
@@ -4974,21 +7134,33 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7B6143
 				RightColor: 92714B
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8F6E48
 				RightColor: 7D6242
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7E6548
 				RightColor: 896B48
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8E6E49
 				RightColor: 806545
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 816543
 				RightColor: 957249
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 8A6B47
 				RightColor: 7A6244
+				ZOffset: -12
+				ZRamp: 0
 	Template@284:
 		Category: Straight Dirt Roads
 		Id: 284
@@ -4998,15 +7170,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 816544
 				RightColor: 8F6E48
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 93714A
 				RightColor: 7D6343
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7E6446
 				RightColor: 8D6E49
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6F49
 				RightColor: 7D6444
+				ZOffset: -12
+				ZRamp: 0
 	Template@285:
 		Category: Straight Dirt Roads
 		Id: 285
@@ -5016,9 +7196,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7E6444
 				RightColor: 94714A
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 886A46
 				RightColor: 745D41
+				ZOffset: -12
+				ZRamp: 0
 	Template@286:
 		Category: Straight Dirt Roads
 		Id: 286
@@ -5028,9 +7212,13 @@ Templates:
 			0: DirtRoad
 				LeftColor: 836745
 				RightColor: 917049
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8D6D48
 				RightColor: 826747
+				ZOffset: -12
+				ZRamp: 0
 	Template@287:
 		Category: Straight Dirt Roads
 		Id: 287
@@ -5040,27 +7228,43 @@ Templates:
 			0: Clear
 				LeftColor: 725C41
 				RightColor: 725B40
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 70593F
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 725B41
 				RightColor: 765F44
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 7A644A
 				RightColor: 6F5B42
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 846A4C
 				RightColor: 846A4B
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 8B6F4E
 				RightColor: 786044
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 806444
 				RightColor: 96744C
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 8D6F4B
 				RightColor: 816748
+				ZOffset: -12
+				ZRamp: 0
 	Template@288:
 		Category: Straight Dirt Roads
 		Id: 288
@@ -5070,24 +7274,38 @@ Templates:
 			0: Clear
 				LeftColor: 725B40
 				RightColor: 705B41
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 70593E
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 765D40
 				RightColor: 846644
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7D6447
 				RightColor: 705A3F
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 765F43
 				RightColor: 765E41
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7F6546
 				RightColor: 886A48
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 93714A
 				RightColor: 866946
+				ZOffset: -12
+				ZRamp: 0
 	Template@289:
 		Category: Straight Dirt Roads
 		Id: 289
@@ -5097,18 +7315,28 @@ Templates:
 			0: Clear
 				LeftColor: 735B3F
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 7C6345
 				RightColor: 775F42
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 786043
 				RightColor: 755E42
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7B6142
 				RightColor: 876945
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 906F49
 				RightColor: 7E6445
+				ZOffset: -12
+				ZRamp: 0
 	Template@290:
 		Category: Straight Dirt Roads
 		Id: 290
@@ -5118,24 +7346,38 @@ Templates:
 			0: DirtRoad
 				LeftColor: 816646
 				RightColor: 937048
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8E6F4A
 				RightColor: 806646
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 7E6547
 				RightColor: 8B6D4C
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 866845
 				RightColor: 806444
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 765D40
 				RightColor: 7B6244
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 765E42
 				RightColor: 775E41
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 725D43
 				RightColor: 725B40
+				ZOffset: -12
+				ZRamp: 0
 	Template@291:
 		Category: Straight Dirt Roads
 		Id: 291
@@ -5145,27 +7387,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7A6143
 				RightColor: 92714A
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 927049
 				RightColor: 7E6342
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 785E40
 				RightColor: 8D6C47
+				ZOffset: -12
+				ZRamp: 0
 			3: DirtRoad
 				LeftColor: 8F6E49
 				RightColor: 7F6444
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 7C6447
 				RightColor: 876846
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 7D6345
 				RightColor: 7A6143
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 6F593D
 				RightColor: 7A6143
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 6F593F
 				RightColor: 6F5A40
+				ZOffset: -12
+				ZRamp: 0
 	Template@292:
 		Category: Straight Dirt Roads
 		Id: 292
@@ -5175,15 +7433,23 @@ Templates:
 			0: DirtRoad
 				LeftColor: 7B6245
 				RightColor: 90714D
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 836849
 				RightColor: 796043
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 725D41
 				RightColor: 7D6445
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 745C41
 				RightColor: 765E40
+				ZOffset: -12
+				ZRamp: 0
 	Template@293:
 		Category: Straight Dirt Roads
 		Id: 293
@@ -5193,27 +7459,43 @@ Templates:
 			1: DirtRoad
 				LeftColor: 7A6143
 				RightColor: 8F6D47
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 916F48
 				RightColor: 7C6142
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 886A47
 				RightColor: 8F6F4A
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 7B6142
 				RightColor: 745E43
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 7A6043
 				RightColor: 836746
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 906E49
 				RightColor: 896A46
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 7E6547
 				RightColor: 896A47
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 8E6D48
 				RightColor: 7F6545
+				ZOffset: -12
+				ZRamp: 0
 	Template@294:
 		Category: Straight Dirt Roads
 		Id: 294
@@ -5223,27 +7505,43 @@ Templates:
 			0: DirtRoad
 				LeftColor: 775E41
 				RightColor: 906F4A
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 90714D
 				RightColor: 7A6144
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 735D42
 				RightColor: 785F43
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 92714B
 				RightColor: 826645
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 836644
 				RightColor: 9B774D
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 806546
 				RightColor: 715A3E
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 826747
 				RightColor: 90704A
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 896B48
 				RightColor: 786042
+				ZOffset: -12
+				ZRamp: 0
 	Template@295:
 		Category: Straight Dirt Roads
 		Id: 295
@@ -5253,18 +7551,28 @@ Templates:
 			0: Clear
 				LeftColor: 755D41
 				RightColor: 7A6144
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 866A4B
 				RightColor: 725C41
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 70593E
 				RightColor: 7A6143
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 8A6C49
 				RightColor: 7E6445
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 725A3E
 				RightColor: 7C6243
+				ZOffset: -12
+				ZRamp: 0
 	Template@296:
 		Category: Bridges
 		Id: 296
@@ -5275,55 +7583,85 @@ Templates:
 				Height: 4
 				LeftColor: 6F6B66
 				RightColor: 554F46
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6E6A61
 				RightColor: 635E57
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6E5A41
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 33312F
 				RightColor: 4B4A48
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 313131
 				RightColor: 585855
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6C573F
 				RightColor: 6B5E4D
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 302D27
 				RightColor: 2D2B27
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 2C2B28
 				RightColor: 2D2B27
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 705C44
 				RightColor: 625D55
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 4C4A48
 				RightColor: 35322F
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 4D4C4A
 				RightColor: 32312F
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 6F583E
 				RightColor: 5F584F
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 5B564E
 				RightColor: 777571
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6E6150
 				RightColor: 858279
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 705A40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@297:
 		Category: Bridges
 		Id: 297
@@ -5334,55 +7672,85 @@ Templates:
 				Height: 4
 				LeftColor: 6F6B66
 				RightColor: 554F47
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6F6C66
 				RightColor: 5E5C58
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 15273B
 				RightColor: 0F2339
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 33312F
 				RightColor: 4B4A48
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 313131
 				RightColor: 585855
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 1E2933
 				RightColor: 3E454B
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 302D27
 				RightColor: 2D2B27
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 2C2B28
 				RightColor: 2D2B27
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 1F2C39
 				RightColor: 515355
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 4C4A48
 				RightColor: 35322F
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 4D4C4A
 				RightColor: 32312F
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 233344
 				RightColor: 4D4F4F
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 5B564E
 				RightColor: 777571
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 504F4B
 				RightColor: 84827A
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 243341
 				RightColor: 16273C
+				ZOffset: -12
+				ZRamp: 0
 	Template@298:
 		Category: Bridges
 		Id: 298
@@ -5392,41 +7760,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 726F6A
 				RightColor: 585147
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 33312F
 				RightColor: 605E5A
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 313131
 				RightColor: 494846
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 302D27
 				RightColor: 2D2B27
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				Height: 4
 				LeftColor: 2C2B28
 				RightColor: 2D2B27
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4C4C4B
 				RightColor: 35322F
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 4B4945
 				RightColor: 323130
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 8C8579
 				RightColor: 8A857A
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 534D43
 				RightColor: 6A6865
+				ZOffset: -12
+				ZRamp: 0
 	Template@299:
 		Category: Bridges
 		Id: 299
@@ -5437,55 +7825,85 @@ Templates:
 				Height: 4
 				LeftColor: 4F4940
 				RightColor: 63605B
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 4B4A48
 				RightColor: 33312F
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 2D2B27
 				RightColor: 302D27
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 34322F
 				RightColor: 494844
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 5B5955
 				RightColor: 564D42
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 998E7D
 				RightColor: 98958D
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 494845
 				RightColor: 484745
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 2D2B28
 				RightColor: 2D2C2A
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 32312E
 				RightColor: 4B4945
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 645A4C
 				RightColor: 6A655B
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 6D573D
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 6E583D
 				RightColor: 887A68
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 725C41
 				RightColor: 8D867A
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6F5A40
 				RightColor: 8B8478
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 705C43
 				RightColor: 6C573E
+				ZOffset: -12
+				ZRamp: 0
 	Template@300:
 		Category: Bridges
 		Id: 300
@@ -5496,55 +7914,85 @@ Templates:
 				Height: 4
 				LeftColor: 4F4940
 				RightColor: 63605B
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 4B4A48
 				RightColor: 33312F
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 2D2B27
 				RightColor: 302D27
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 34322F
 				RightColor: 494844
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 5B5955
 				RightColor: 564D43
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 888989
 				RightColor: 98958D
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 494845
 				RightColor: 484745
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 2D2B28
 				RightColor: 2D2C2A
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 32312E
 				RightColor: 4B4945
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 5D584F
 				RightColor: 67635B
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 0E2036
 				RightColor: 192A3E
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 102135
 				RightColor: 666B6E
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 122439
 				RightColor: 7F7F7C
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 112337
 				RightColor: 80817E
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 112135
 				RightColor: 223041
+				ZOffset: -12
+				ZRamp: 0
 	Template@301:
 		Category: Bridges
 		Id: 301
@@ -5554,41 +8002,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 4C4C4C
 				RightColor: 4C4B4A
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 2D2B27
 				RightColor: 302D27
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 35332F
 				RightColor: 4D4C4B
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 685F55
 				RightColor: 6B665F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 564D40
 				RightColor: 605E5B
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4D4D4C
 				RightColor: 333230
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 2D2B27
 				RightColor: 2C2B28
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 313130
 				RightColor: 4B4C4C
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 5E5B57
 				RightColor: 56534E
+				ZOffset: -12
+				ZRamp: 0
 	Template@302:
 		Category: Bridges
 		Id: 302
@@ -5598,36 +8066,56 @@ Templates:
 			0: Cliff
 				LeftColor: 706E6A
 				RightColor: 64625D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6E5A41
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 313131
 				RightColor: 626262
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 6C573F
 				RightColor: 6B5F50
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 2C2B28
 				RightColor: 2D2B27
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 705C44
 				RightColor: 625D56
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4E4D4B
 				RightColor: 323130
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 6F583E
 				RightColor: 5F5A52
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 9B958B
 				RightColor: 918F8A
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 705A40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@303:
 		Category: Bridges
 		Id: 303
@@ -5637,36 +8125,56 @@ Templates:
 			0: Cliff
 				LeftColor: 706E6A
 				RightColor: 64625D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6E5A41
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3B3B3A
 				RightColor: 646364
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 6C573F
 				RightColor: 6B5F50
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 343432
 				RightColor: 363430
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 705C44
 				RightColor: 625D56
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 464645
 				RightColor: 363635
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 6F583E
 				RightColor: 5F5A52
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 8F8981
 				RightColor: 8C8A85
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 715C42
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@304:
 		Category: Bridges
 		Id: 304
@@ -5676,36 +8184,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706C
 				RightColor: 64625E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 746552
 				RightColor: 6B5740
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 333230
 				RightColor: 656565
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 6C6357
 				RightColor: 6F6559
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 333230
 				RightColor: 343330
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 665643
 				RightColor: 5F5B54
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 525252
 				RightColor: 3A3A3A
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 6B5840
 				RightColor: 5A554E
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 989289
 				RightColor: 8A8884
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 705A40
 				RightColor: 705A3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@305:
 		Category: Bridges
 		Id: 305
@@ -5715,36 +8243,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706C
 				RightColor: 63615C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 786958
 				RightColor: 73614D
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 3B3B3B
 				RightColor: 5B5B5C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 6C6357
 				RightColor: 6F6559
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				Height: 4
 				LeftColor: 3B3B39
 				RightColor: 373634
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 5C5245
 				RightColor: 5F5B54
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				Height: 4
 				LeftColor: 4B4B4B
 				RightColor: 3C3C3C
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 6B5840
 				RightColor: 59544E
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 8F8981
 				RightColor: 8B8884
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 715C42
 				RightColor: 705A3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@306:
 		Category: Bridges
 		Id: 306
@@ -5754,33 +8302,53 @@ Templates:
 			0: Cliff
 				LeftColor: 7B7A77
 				RightColor: 878580
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 786958
 				RightColor: 73614D
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 656562
 				RightColor: 72716F
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 6A6358
 				RightColor: 685743
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6C6B6A
 				RightColor: 84837F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 575147
 				RightColor: 5F513F
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 747371
 				RightColor: 8F8E89
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 61584B
 				RightColor: 62533F
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 90877C
 				RightColor: 747068
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 5D5040
 				RightColor: 63533F
+				ZOffset: -12
+				ZRamp: 0
 	Template@307:
 		Category: Bridges
 		Id: 307
@@ -5791,32 +8359,50 @@ Templates:
 				Height: 4
 				LeftColor: 4C4C4C
 				RightColor: 4C4B4A
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 2D2B28
 				RightColor: 2D2C2A
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 32312F
 				RightColor: 4E4D4C
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 756D63
 				RightColor: 807D78
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6D573D
 				RightColor: 988F83
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 6E583D
 				RightColor: 928C83
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 725C41
 				RightColor: 918A80
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6F5A40
 				RightColor: 908A81
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 	Template@308:
 		Category: Bridges
 		Id: 308
@@ -5827,32 +8413,50 @@ Templates:
 				Height: 4
 				LeftColor: 4E4E4E
 				RightColor: 4E4E4D
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 32302D
 				RightColor: 353430
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 363736
 				RightColor: 606061
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 756D63
 				RightColor: 807D78
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6D573D
 				RightColor: 988F83
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 6E583D
 				RightColor: 928C83
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 725C41
 				RightColor: 918A80
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6F5A40
 				RightColor: 908A81
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 	Template@309:
 		Category: Bridges
 		Id: 309
@@ -5863,32 +8467,50 @@ Templates:
 				Height: 4
 				LeftColor: 545454
 				RightColor: 4B4A49
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3A3833
 				RightColor: 312E29
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 333231
 				RightColor: 4D4C4C
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 756E63
 				RightColor: 7F7C77
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6D573E
 				RightColor: 90887D
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 6E593F
 				RightColor: 827D75
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 705E48
 				RightColor: 878178
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6D5940
 				RightColor: 87847D
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 705D46
 				RightColor: 6A563E
+				ZOffset: -12
+				ZRamp: 0
 	Template@310:
 		Category: Bridges
 		Id: 310
@@ -5899,32 +8521,50 @@ Templates:
 				Height: 4
 				LeftColor: 414142
 				RightColor: 4C4C4C
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 363430
 				RightColor: 32302D
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 313131
 				RightColor: 555555
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 757068
 				RightColor: 7B7872
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6E593F
 				RightColor: 8F877D
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 695843
 				RightColor: 827E78
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 6E5E49
 				RightColor: 878178
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6D5940
 				RightColor: 8C8882
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 705D46
 				RightColor: 726351
+				ZOffset: -12
+				ZRamp: 0
 	Template@311:
 		Category: Bridges
 		Id: 311
@@ -5935,32 +8575,50 @@ Templates:
 				Height: 4
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 757068
 				RightColor: 76726D
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6E5A42
 				RightColor: 817567
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 695843
 				RightColor: 827D76
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 6E5E49
 				RightColor: 8F8B84
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 61584C
 				RightColor: 85837D
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 756C62
 				RightColor: 706353
+				ZOffset: -12
+				ZRamp: 0
 	Template@312:
 		Category: Paved Roads
 		Id: 312
@@ -5970,12 +8628,18 @@ Templates:
 			0: Road
 				LeftColor: 42403C
 				RightColor: 4D4D4B
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 403C34
 				RightColor: 3C3934
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 4D4B46
 				RightColor: 44413C
+				ZOffset: -12
+				ZRamp: 0
 	Template@313:
 		Category: Paved Roads
 		Id: 313
@@ -5985,12 +8649,18 @@ Templates:
 			0: Road
 				LeftColor: 4D4D4B
 				RightColor: 42403C
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 3C3934
 				RightColor: 403C34
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 44413C
 				RightColor: 4D4B46
+				ZOffset: -12
+				ZRamp: 0
 	Template@314:
 		Category: Paved Roads
 		Id: 314
@@ -6000,30 +8670,48 @@ Templates:
 			0: Road
 				LeftColor: 3E3E3C
 				RightColor: 3E3E3C
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 383838
 				RightColor: 3A3B3B
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 383838
 				RightColor: 444443
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 3B3B3B
 				RightColor: 3A3A3A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 363636
 				RightColor: 383838
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 3A3A3A
 				RightColor: 3B3B3B
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 454443
 				RightColor: 393939
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 3B3C3C
 				RightColor: 393939
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 3F3E3D
 				RightColor: 3F3E3C
+				ZOffset: -12
+				ZRamp: 0
 	Template@315:
 		Category: Paved Roads
 		Id: 315
@@ -6033,30 +8721,48 @@ Templates:
 			0: Road
 				LeftColor: 3F3F3D
 				RightColor: 42403D
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 3C3934
 				RightColor: 403C34
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 3E3C39
 				RightColor: 424240
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 3B3B3B
 				RightColor: 3E3D3A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 3C3A35
 				RightColor: 3B3935
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 3C3B3B
 				RightColor: 3A3A3A
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 424241
 				RightColor: 3D3C39
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 3C3A36
 				RightColor: 3C3B38
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 41403D
 				RightColor: 3F3E3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@316:
 		Category: Paved Roads
 		Id: 316
@@ -6066,30 +8772,48 @@ Templates:
 			0: Road
 				LeftColor: 43403D
 				RightColor: 403F3D
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 3E3C3A
 				RightColor: 3C3D3C
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 3D3D3D
 				RightColor: 424241
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 3B3935
 				RightColor: 3C3A35
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 403C34
 				RightColor: 3C3934
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 3B3A35
 				RightColor: 3C3934
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 424242
 				RightColor: 3C3C3B
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 3C3C3C
 				RightColor: 3E3D3B
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 3F3E3B
 				RightColor: 413F3C
+				ZOffset: -12
+				ZRamp: 0
 	Template@317:
 		Category: Paved Roads
 		Id: 317
@@ -6099,30 +8823,48 @@ Templates:
 			0: Road
 				LeftColor: 42403C
 				RightColor: 4D4D4B
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 41403D
 				RightColor: 4C4B48
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 404040
 				RightColor: 4C4C4A
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 3C3A36
 				RightColor: 3C3A34
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 3F3C35
 				RightColor: 3C3934
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 3B3A35
 				RightColor: 3C3934
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 424242
 				RightColor: 3C3C3B
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 3C3C3C
 				RightColor: 3E3D3B
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 3F3E3B
 				RightColor: 413F3C
+				ZOffset: -12
+				ZRamp: 0
 	Template@318:
 		Category: Paved Roads
 		Id: 318
@@ -6132,30 +8874,48 @@ Templates:
 			0: Road
 				LeftColor: 3F3F3D
 				RightColor: 42403D
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 3C3A36
 				RightColor: 3D3B37
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 413F3D
 				RightColor: 504F4B
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 3B3B3B
 				RightColor: 3E3D3A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 3C3A35
 				RightColor: 3B3935
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 403F3E
 				RightColor: 4F4D4A
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 424241
 				RightColor: 3D3C39
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 3C3934
 				RightColor: 3C3A36
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 403F3D
 				RightColor: 4C4D4C
+				ZOffset: -12
+				ZRamp: 0
 	Template@319:
 		Category: Paved Roads
 		Id: 319
@@ -6165,30 +8925,48 @@ Templates:
 			0: Road
 				LeftColor: 43403D
 				RightColor: 403F3D
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 3E3C3A
 				RightColor: 3C3D3C
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 3D3D3D
 				RightColor: 424241
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 3B3935
 				RightColor: 3C3A35
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 3C3A36
 				RightColor: 3C3A34
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 3C3B37
 				RightColor: 3B3A35
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 4F4D4A
 				RightColor: 403F3E
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 4C4D4C
 				RightColor: 403F3D
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 504F4B
 				RightColor: 413F3D
+				ZOffset: -12
+				ZRamp: 0
 	Template@320:
 		Category: Paved Roads
 		Id: 320
@@ -6198,30 +8976,48 @@ Templates:
 			0: Road
 				LeftColor: 4C4B48
 				RightColor: 41403D
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 3C3934
 				RightColor: 3F3C35
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 3E3C39
 				RightColor: 424240
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 4E4D4A
 				RightColor: 42413E
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 3C3A35
 				RightColor: 3B3935
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 3C3B3B
 				RightColor: 3A3A3A
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 4D4D4B
 				RightColor: 42403C
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 3C3A36
 				RightColor: 3D3B37
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 41403D
 				RightColor: 3F3E3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@321:
 		Category: Paved Roads
 		Id: 321
@@ -6231,39 +9027,63 @@ Templates:
 			0: Clear
 				LeftColor: 6C5940
 				RightColor: 6C5A42
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 4C4439
 				RightColor: 534D44
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 62513F
 				RightColor: 5E503F
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 45403B
 				RightColor: 4F4C47
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 68543C
 				RightColor: 5E4F3D
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 695741
 				RightColor: 64523D
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 5D4E3C
 				RightColor: 50473D
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 453F35
 				RightColor: 3D3A34
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 615546
 				RightColor: 4F463C
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 655746
 				RightColor: 67553F
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 655544
 				RightColor: 62513E
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 554B3F
 				RightColor: 45413C
+				ZOffset: -12
+				ZRamp: 0
 	Template@322:
 		Category: Paved Roads
 		Id: 322
@@ -6273,39 +9093,63 @@ Templates:
 			0: Road
 				LeftColor: 42403C
 				RightColor: 544C43
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 4B453C
 				RightColor: 63523D
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 5C4E3D
 				RightColor: 655643
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 63503B
 				RightColor: 6E573D
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 403C34
 				RightColor: 3C3934
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 454038
 				RightColor: 403C35
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 443F36
 				RightColor: 524739
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 544A3E
 				RightColor: 6D573D
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 4E4A44
 				RightColor: 48423B
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 61503D
 				RightColor: 5D5040
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 695D4F
 				RightColor: 5C4F3F
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 65543F
 				RightColor: 68553E
+				ZOffset: -12
+				ZRamp: 0
 	Template@323:
 		Category: Paved Roads
 		Id: 323
@@ -6315,39 +9159,63 @@ Templates:
 			0: DirtRoad
 				LeftColor: 47423B
 				RightColor: 63523D
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 423E37
 				RightColor: 544A3D
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 4F4A43
 				RightColor: 565047
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 534D45
 				RightColor: 564E43
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 423C34
 				RightColor: 413B32
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 484339
 				RightColor: 433E37
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 49453D
 				RightColor: 44433F
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 4F483F
 				RightColor: 45413B
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 504B43
 				RightColor: 53493C
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 605342
 				RightColor: 45423E
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: 544D45
 				RightColor: 4C4843
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 524F4A
 				RightColor: 403E3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@324:
 		Category: Paved Roads
 		Id: 324
@@ -6357,39 +9225,63 @@ Templates:
 			0: DirtRoad
 				LeftColor: 4E4D4A
 				RightColor: 42413E
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 403C34
 				RightColor: 3C3A35
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 403F3D
 				RightColor: 4C4D4C
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 574C3F
 				RightColor: 4A443C
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 484034
 				RightColor: 433E34
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 4B443B
 				RightColor: 504E49
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 6C5942
 				RightColor: 63513E
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 5E4F3C
 				RightColor: 51483D
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 63523E
 				RightColor: 645441
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 6D583E
 				RightColor: 6D5940
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 6F5A40
 				RightColor: 6B573E
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 705B41
 				RightColor: 67553E
+				ZOffset: -12
+				ZRamp: 0
 	Template@325:
 		Category: Paved Roads
 		Id: 325
@@ -6399,39 +9291,63 @@ Templates:
 			0: Clear
 				LeftColor: 615341
 				RightColor: 66543E
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				LeftColor: 67533C
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 6F583E
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 5D5040
 				RightColor: 62523F
+				ZOffset: -12
+				ZRamp: 0
 			4: DirtRoad
 				LeftColor: 50473D
 				RightColor: 5C4E3D
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 62503E
 				RightColor: 6C583F
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 5E5449
 				RightColor: 53493E
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 433E35
 				RightColor: 494135
+				ZOffset: -12
+				ZRamp: 0
 			8: DirtRoad
 				LeftColor: 46423C
 				RightColor: 554B3E
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 4C4C4A
 				RightColor: 484440
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 474036
 				RightColor: 453F36
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 41403E
 				RightColor: 4F4D4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@326:
 		Category: Paved Roads
 		Id: 326
@@ -6441,39 +9357,63 @@ Templates:
 			0: DirtRoad
 				LeftColor: 4D4C4A
 				RightColor: 404040
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 373631
 				RightColor: 373531
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 3E3A33
 				RightColor: 4D4C49
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 4C4C49
 				RightColor: 3E3D3B
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 2D2C2A
 				RightColor: 2F2C26
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 4F4336
 				RightColor: 5E5345
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 524B42
 				RightColor: 3C3935
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 363532
 				RightColor: 36332E
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 403E39
 				RightColor: 4D4A44
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 494845
 				RightColor: 3E3C3A
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 3C3A36
 				RightColor: 373632
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 41403D
 				RightColor: 514F4C
+				ZOffset: -12
+				ZRamp: 0
 	Template@327:
 		Category: Paved Roads
 		Id: 327
@@ -6483,51 +9423,83 @@ Templates:
 			0: Road
 				LeftColor: 43403C
 				RightColor: 4E4D4B
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 41403F
 				RightColor: 4C4C4A
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 43413E
 				RightColor: 4E4D4A
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 42403D
 				RightColor: 4C4B48
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 474035
 				RightColor: 413C34
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 453F36
 				RightColor: 413C34
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 50473B
 				RightColor: 4B4337
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 51493E
 				RightColor: 413D37
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 544E46
 				RightColor: 52493E
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 756047
 				RightColor: 62513F
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 7F684C
 				RightColor: 665643
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 57534D
 				RightColor: 44423D
+				ZOffset: -12
+				ZRamp: 0
 			12: DirtRoad
 				LeftColor: 866948
 				RightColor: 826747
+				ZOffset: -12
+				ZRamp: 0
 			13: DirtRoad
 				LeftColor: 957148
 				RightColor: 9A764D
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 886B4A
 				RightColor: 856B4B
+				ZOffset: -12
+				ZRamp: 0
 			17: DirtRoad
 				LeftColor: 8A6A46
 				RightColor: 8A6B48
+				ZOffset: -12
+				ZRamp: 0
 	Template@328:
 		Category: Paved Roads
 		Id: 328
@@ -6537,45 +9509,73 @@ Templates:
 			1: DirtRoad
 				LeftColor: 876B4B
 				RightColor: 806443
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: A0794D
 				RightColor: 9E784D
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 45423D
 				RightColor: 574F44
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 625341
 				RightColor: 80674B
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 755F46
 				RightColor: 7F674B
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 55493C
 				RightColor: 5A4F40
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 3C3A35
 				RightColor: 453F35
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 494237
 				RightColor: 514738
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 4C4337
 				RightColor: 504638
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 474137
 				RightColor: 413C33
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 4F4D4A
 				RightColor: 42403C
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 52504B
 				RightColor: 44413C
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: 4F4F4D
 				RightColor: 47433E
+				ZOffset: -12
+				ZRamp: 0
 			15: Road
 				LeftColor: 514E47
 				RightColor: 46423D
+				ZOffset: -12
+				ZRamp: 0
 	Template@329:
 		Category: Paved Roads
 		Id: 329
@@ -6585,51 +9585,83 @@ Templates:
 			1: DirtRoad
 				LeftColor: 816545
 				RightColor: 94714A
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 98754B
 				RightColor: 7F6545
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 46433F
 				RightColor: 514E49
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 5C5041
 				RightColor: 826B4F
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 7B6447
 				RightColor: 73614A
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 4D463E
 				RightColor: 4F4C48
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 3E3B36
 				RightColor: 433E36
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 53493D
 				RightColor: 5F513E
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 6B5841
 				RightColor: 5D4D39
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 443E36
 				RightColor: 3E3B34
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 4C4D4C
 				RightColor: 43413D
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 6B5D4B
 				RightColor: 715D45
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: 7F694E
 				RightColor: 625442
+				ZOffset: -12
+				ZRamp: 0
 			15: Road
 				LeftColor: 59544C
 				RightColor: 44423E
+				ZOffset: -12
+				ZRamp: 0
 			17: DirtRoad
 				LeftColor: 7E6444
 				RightColor: 896A46
+				ZOffset: -12
+				ZRamp: 0
 			18: DirtRoad
 				LeftColor: 8F6F48
 				RightColor: 785F40
+				ZOffset: -12
+				ZRamp: 0
 	Template@330:
 		Category: Paved Roads
 		Id: 330
@@ -6639,51 +9671,83 @@ Templates:
 			2: Road
 				LeftColor: 60584E
 				RightColor: 4E473F
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 554B3D
 				RightColor: 423D35
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 44413C
 				RightColor: 4D4B46
+				ZOffset: -12
+				ZRamp: 0
 			6: DirtRoad
 				LeftColor: 7D6548
 				RightColor: 7B6143
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 937450
 				RightColor: 846A4C
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 5F513F
 				RightColor: 51483C
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 46433F
 				RightColor: 514F4A
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 8D6D47
 				RightColor: 866744
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 876946
 				RightColor: 93714A
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 7C6446
 				RightColor: 7E6446
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 61523F
 				RightColor: 534A3D
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: 42413E
 				RightColor: 4D4D4C
+				ZOffset: -12
+				ZRamp: 0
 			16: DirtRoad
 				LeftColor: 846745
 				RightColor: 836745
+				ZOffset: -12
+				ZRamp: 0
 			17: Road
 				LeftColor: 534D44
 				RightColor: 584E41
+				ZOffset: -12
+				ZRamp: 0
 			18: Road
 				LeftColor: 433F38
 				RightColor: 51493D
+				ZOffset: -12
+				ZRamp: 0
 			19: Road
 				LeftColor: 44423D
 				RightColor: 53514C
+				ZOffset: -12
+				ZRamp: 0
 	Template@331:
 		Category: Paved Roads
 		Id: 331
@@ -6693,45 +9757,73 @@ Templates:
 			0: Road
 				LeftColor: 4E4D4A
 				RightColor: 424240
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 403C35
 				RightColor: 3D3B36
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 4C463F
 				RightColor: 574D40
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 4C4B48
 				RightColor: 43413E
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 423E37
 				RightColor: 48443C
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 78634A
 				RightColor: 766249
+				ZOffset: -12
+				ZRamp: 0
 			7: DirtRoad
 				LeftColor: 9C764B
 				RightColor: 9D774C
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 4F4E4B
 				RightColor: 44413E
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 4B4439
 				RightColor: 5D503E
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 846A4C
 				RightColor: 8A6F4F
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 795F40
 				RightColor: 7F6343
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 4D4D4B
 				RightColor: 44413D
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 3E3B35
 				RightColor: 554A3C
+				ZOffset: -12
+				ZRamp: 0
 			14: Road
 				LeftColor: 574E42
 				RightColor: 655B4C
+				ZOffset: -12
+				ZRamp: 0
 	Template@332:
 		Category: Paved Roads
 		Id: 332
@@ -6741,51 +9833,83 @@ Templates:
 			1: Road
 				LeftColor: 4D4D4B
 				RightColor: 42403C
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 3C3A35
 				RightColor: 403C34
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 45413C
 				RightColor: 4D4B46
+				ZOffset: -12
+				ZRamp: 0
 			5: DirtRoad
 				LeftColor: 8B6C48
 				RightColor: 806545
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 766550
 				RightColor: 574E44
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 574C3D
 				RightColor: 51473B
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 5F5243
 				RightColor: 635747
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 8B6C48
 				RightColor: 816443
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 846745
 				RightColor: 8D6D48
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 776148
 				RightColor: 846A4D
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 6B5A45
 				RightColor: 6F5C47
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 72604A
 				RightColor: 7F684D
+				ZOffset: -12
+				ZRamp: 0
 			14: DirtRoad
 				LeftColor: 836644
 				RightColor: 99754B
+				ZOffset: -12
+				ZRamp: 0
 			16: Road
 				LeftColor: 4D4B48
 				RightColor: 47433E
+				ZOffset: -12
+				ZRamp: 0
 			17: Road
 				LeftColor: 3C3A34
 				RightColor: 4B443A
+				ZOffset: -12
+				ZRamp: 0
 			18: Road
 				LeftColor: 49443F
 				RightColor: 5F564B
+				ZOffset: -12
+				ZRamp: 0
 	Template@333:
 		Category: Water
 		Id: 333
@@ -6795,15 +9919,23 @@ Templates:
 			0: Water
 				LeftColor: 12253D
 				RightColor: 152944
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 1B2F50
 				RightColor: 10243B
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 0F2237
 				RightColor: 132640
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 142842
 				RightColor: 132640
+				ZOffset: -12
+				ZRamp: 0
 	Template@334:
 		Category: Water
 		Id: 334
@@ -6813,15 +9945,23 @@ Templates:
 			0: Water
 				LeftColor: 0D1F33
 				RightColor: 0E2035
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 0F2137
 				RightColor: 0F2338
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 0E2136
 				RightColor: 0B1B2E
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 0F2238
 				RightColor: 0F2137
+				ZOffset: -12
+				ZRamp: 0
 	Template@335:
 		Category: Water
 		Id: 335
@@ -6831,15 +9971,23 @@ Templates:
 			0: Water
 				LeftColor: 10233A
 				RightColor: 12253E
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 132741
 				RightColor: 10233A
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 0F2138
 				RightColor: 0E2136
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 0F2138
 				RightColor: 0F2237
+				ZOffset: -12
+				ZRamp: 0
 	Template@336:
 		Category: Water
 		Id: 336
@@ -6849,15 +9997,23 @@ Templates:
 			0: Water
 				LeftColor: 0E2136
 				RightColor: 0F2137
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 11233B
 				RightColor: 112339
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 13263F
 				RightColor: 112338
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 142742
 				RightColor: 142843
+				ZOffset: -12
+				ZRamp: 0
 	Template@337:
 		Category: Water
 		Id: 337
@@ -6867,15 +10023,23 @@ Templates:
 			0: Water
 				LeftColor: 0D2035
 				RightColor: 0A1B2D
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 10233A
 				RightColor: 12243E
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 0F2137
 				RightColor: 10233A
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 0F2136
 				RightColor: 10233C
+				ZOffset: -12
+				ZRamp: 0
 	Template@338:
 		Category: Water
 		Id: 338
@@ -6885,15 +10049,23 @@ Templates:
 			0: Water
 				LeftColor: 0F2239
 				RightColor: 102238
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 12253D
 				RightColor: 0F2137
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 0E2036
 				RightColor: 11243C
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 0E1E33
 				RightColor: 102239
+				ZOffset: -12
+				ZRamp: 0
 	Template@339:
 		Category: Water
 		Id: 339
@@ -6903,15 +10075,23 @@ Templates:
 			0: Cliff
 				LeftColor: 30373E
 				RightColor: 293340
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 1F3352
 				RightColor: 12243C
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				LeftColor: 102339
 				RightColor: 12243A
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				LeftColor: 11243B
 				RightColor: 142842
+				ZOffset: -12
+				ZRamp: 0
 	Template@340:
 		Category: Water
 		Id: 340
@@ -6921,15 +10101,23 @@ Templates:
 			0: Cliff
 				LeftColor: 404A55
 				RightColor: 28313A
+				ZOffset: -12
+				ZRamp: 0
 			1: Water
 				LeftColor: 15273D
 				RightColor: 10243C
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 162B44
 				RightColor: 253348
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 2C3748
 				RightColor: 2C3744
+				ZOffset: -12
+				ZRamp: 0
 	Template@341:
 		Category: Water
 		Id: 341
@@ -6939,6 +10127,8 @@ Templates:
 			0: Water
 				LeftColor: 0E1F34
 				RightColor: 11243B
+				ZOffset: -12
+				ZRamp: 0
 	Template@342:
 		Category: Water
 		Id: 342
@@ -6948,6 +10138,8 @@ Templates:
 			0: Water
 				LeftColor: 11233B
 				RightColor: 11243C
+				ZOffset: -12
+				ZRamp: 0
 	Template@343:
 		Category: Water
 		Id: 343
@@ -6957,6 +10149,8 @@ Templates:
 			0: Water
 				LeftColor: 0F2136
 				RightColor: 102238
+				ZOffset: -12
+				ZRamp: 0
 	Template@344:
 		Category: Water
 		Id: 344
@@ -6966,6 +10160,8 @@ Templates:
 			0: Water
 				LeftColor: 0D1E33
 				RightColor: 102239
+				ZOffset: -12
+				ZRamp: 0
 	Template@345:
 		Category: Water
 		Id: 345
@@ -6975,6 +10171,8 @@ Templates:
 			0: Water
 				LeftColor: 102238
 				RightColor: 102238
+				ZOffset: -12
+				ZRamp: 0
 	Template@346:
 		Category: Water
 		Id: 346
@@ -6984,6 +10182,8 @@ Templates:
 			0: Cliff
 				LeftColor: 2C3642
 				RightColor: 27313A
+				ZOffset: -12
+				ZRamp: 0
 	Template@387:
 		Category: Dirt Road Slopes
 		Id: 387
@@ -6994,10 +10194,14 @@ Templates:
 				RampType: 1
 				LeftColor: 8C6C47
 				RightColor: 7C6345
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 1
 				LeftColor: 7F674A
 				RightColor: 785D3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@388:
 		Category: Dirt Road Slopes
 		Id: 388
@@ -7008,10 +10212,14 @@ Templates:
 				RampType: 1
 				LeftColor: 977349
 				RightColor: 82694A
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 1
 				LeftColor: 826A4B
 				RightColor: 826644
+				ZOffset: -12
+				ZRamp: 0
 	Template@389:
 		Category: Dirt Road Slopes
 		Id: 389
@@ -7022,10 +10230,14 @@ Templates:
 				RampType: 2
 				LeftColor: 6C5840
 				RightColor: 8E6C46
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 2
 				LeftColor: 755E42
 				RightColor: 63533E
+				ZOffset: -12
+				ZRamp: 0
 	Template@390:
 		Category: Dirt Road Slopes
 		Id: 390
@@ -7036,10 +10248,14 @@ Templates:
 				RampType: 2
 				LeftColor: 6D5941
 				RightColor: 906D47
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 2
 				LeftColor: 765D41
 				RightColor: 64533F
+				ZOffset: -12
+				ZRamp: 0
 	Template@391:
 		Category: Dirt Road Slopes
 		Id: 391
@@ -7050,10 +10266,14 @@ Templates:
 				RampType: 3
 				LeftColor: 806544
 				RightColor: 6E5B43
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 3
 				LeftColor: 675641
 				RightColor: 7B674D
+				ZOffset: -12
+				ZRamp: 0
 	Template@392:
 		Category: Dirt Road Slopes
 		Id: 392
@@ -7064,10 +10284,14 @@ Templates:
 				RampType: 3
 				LeftColor: 7C6141
 				RightColor: 6B5842
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 3
 				LeftColor: 685641
 				RightColor: 725C41
+				ZOffset: -12
+				ZRamp: 0
 	Template@393:
 		Category: Dirt Road Slopes
 		Id: 393
@@ -7078,10 +10302,14 @@ Templates:
 				RampType: 4
 				LeftColor: 7A6144
 				RightColor: 94724A
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 4
 				LeftColor: 7D6243
 				RightColor: 6E593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@394:
 		Category: Dirt Road Slopes
 		Id: 394
@@ -7092,10 +10320,14 @@ Templates:
 				RampType: 4
 				LeftColor: 755C3F
 				RightColor: 8C6C46
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 4
 				LeftColor: 8C6B44
 				RightColor: 735C40
+				ZOffset: -12
+				ZRamp: 0
 	Template@403:
 		Category: Slope Set Pieces
 		Id: 403
@@ -7107,45 +10339,65 @@ Templates:
 				RampType: 11
 				LeftColor: 524637
 				RightColor: 60503D
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 3
 				RampType: 4
 				LeftColor: 5D4E3B
 				RightColor: 67533A
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 4E4539
 				RightColor: 3F372B
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 3
 				RampType: 3
 				LeftColor: 514636
 				RightColor: 574C3D
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				Height: 2
 				RampType: 4
 				LeftColor: 554938
 				RightColor: 5F513E
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 695742
 				RightColor: 50483C
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				RampType: 1
 				LeftColor: 695A46
 				RightColor: 61523E
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				Height: 1
 				RampType: 4
 				LeftColor: 5A4B38
 				RightColor: 544837
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				RampType: 8
 				LeftColor: 6C5941
 				RightColor: 685741
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				RampType: 4
 				LeftColor: 69543C
 				RightColor: 65533D
+				ZOffset: -12
+				ZRamp: 0
 	Template@404:
 		Category: Slope Set Pieces
 		Id: 404
@@ -7157,45 +10409,65 @@ Templates:
 				RampType: 4
 				LeftColor: 574B3A
 				RightColor: 5F513F
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 3
 				RampType: 12
 				LeftColor: 6A5C48
 				RightColor: 68553E
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				Height: 2
 				RampType: 4
 				LeftColor: 5A4D3C
 				RightColor: 574C3D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 3
 				RampType: 1
 				LeftColor: 4E463A
 				RightColor: 625543
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 504537
 				RightColor: 42392C
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				Height: 1
 				RampType: 4
 				LeftColor: 5D5040
 				RightColor: 584C3C
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				RampType: 3
 				LeftColor: 564D41
 				RightColor: 4D4438
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 675845
 				RightColor: 3F3A31
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				RampType: 4
 				LeftColor: 6A563E
 				RightColor: 5C4E3A
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				RampType: 7
 				LeftColor: 665640
 				RightColor: 594C3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@405:
 		Category: Slope Set Pieces
 		Id: 405
@@ -7207,45 +10479,65 @@ Templates:
 				RampType: 3
 				LeftColor: 605444
 				RightColor: 625442
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 2
 				RampType: 3
 				LeftColor: 554D41
 				RightColor: 584E3F
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 1
 				RampType: 3
 				LeftColor: 544D43
 				RightColor: 605445
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				RampType: 3
 				LeftColor: 50483D
 				RightColor: 625544
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				Height: 3
 				RampType: 10
 				LeftColor: 6C5841
 				RightColor: 4F473C
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 3
 				RampType: 2
 				LeftColor: 4E4537
 				RightColor: 4D463A
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				RampType: 4
 				LeftColor: 665846
 				RightColor: 5D5244
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				RampType: 7
 				LeftColor: 6C5B45
 				RightColor: 62523D
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 4B4033
 				RightColor: 413A2F
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 564D40
 				RightColor: 3F3B33
+				ZOffset: -12
+				ZRamp: 0
 	Template@406:
 		Category: Slope Set Pieces
 		Id: 406
@@ -7256,46 +10548,66 @@ Templates:
 				Height: 4
 				LeftColor: 473E33
 				RightColor: 403A32
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 3B3831
 				RightColor: 35332E
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				Height: 3
 				RampType: 11
 				LeftColor: 605648
 				RightColor: 63594A
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 3
 				RampType: 4
 				LeftColor: 655B4B
 				RightColor: 5D5447
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				RampType: 2
 				LeftColor: 4E4537
 				RightColor: 4A4236
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				RampType: 6
 				LeftColor: 4C4337
 				RightColor: 5F5240
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				Height: 3
 				RampType: 3
 				LeftColor: 645645
 				RightColor: 5A5042
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				Height: 2
 				RampType: 3
 				LeftColor: 584D3D
 				RightColor: 574E42
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				Height: 1
 				RampType: 3
 				LeftColor: 5A5041
 				RightColor: 423C33
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				RampType: 3
 				LeftColor: 5C4E3D
 				RightColor: 61523F
+				ZOffset: -12
+				ZRamp: 0
 	Template@407:
 		Category: Slope Set Pieces
 		Id: 407
@@ -7306,45 +10618,65 @@ Templates:
 				RampType: 5
 				LeftColor: 544A3C
 				RightColor: 4F463A
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				RampType: 2
 				LeftColor: 443D31
 				RightColor: 504535
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 544C40
 				RightColor: 544C3F
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 4A4338
 				RightColor: 443D33
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				Height: 1
 				RampType: 2
 				LeftColor: 474238
 				RightColor: 474035
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				Height: 4
 				LeftColor: 504535
 				RightColor: 4D463B
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				Height: 3
 				RampType: 3
 				LeftColor: 4E4A41
 				RightColor: 554E42
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				Height: 2
 				RampType: 2
 				LeftColor: 4A4338
 				RightColor: 50473A
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				Height: 3
 				RampType: 10
 				LeftColor: 665947
 				RightColor: 4E473B
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				Height: 3
 				RampType: 2
 				LeftColor: 5A5348
 				RightColor: 4A443A
+				ZOffset: -12
+				ZRamp: 0
 	Template@408:
 		Category: Slope Set Pieces
 		Id: 408
@@ -7355,32 +10687,46 @@ Templates:
 				RampType: 2
 				LeftColor: 544C40
 				RightColor: 4F483D
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				RampType: 6
 				LeftColor: 4E463A
 				RightColor: 5D503F
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				Height: 1
 				RampType: 2
 				LeftColor: 453F34
 				RightColor: 4E473A
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				RampType: 3
 				LeftColor: 5A4F3F
 				RightColor: 605647
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6B5A45
 				RightColor: 6D5A41
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				Height: 2
 				RampType: 2
 				LeftColor: 413C32
 				RightColor: 484137
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				Height: 3
 				RampType: 2
 				LeftColor: 453E32
 				RightColor: 433E34
+				ZOffset: -12
+				ZRamp: 0
 	Template@409:
 		Category: Slope Set Pieces
 		Id: 409
@@ -7392,15 +10738,21 @@ Templates:
 				RampType: 1
 				LeftColor: 74634D
 				RightColor: 74654F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 524636
 				RightColor: 494034
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 3
 				RampType: 9
 				LeftColor: 625544
 				RightColor: 6A5842
+				ZOffset: -12
+				ZRamp: 0
 	Template@410:
 		Category: Slope Set Pieces
 		Id: 410
@@ -7410,46 +10762,66 @@ Templates:
 			1: Cliff
 				LeftColor: 685C4B
 				RightColor: 645B4C
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 4C453A
 				RightColor: 4C4234
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				RampType: 5
 				LeftColor: 70604A
 				RightColor: 615545
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 746149
 				RightColor: 706049
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				Height: 3
 				RampType: 4
 				LeftColor: 665D4F
 				RightColor: 61594D
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				Height: 3
 				RampType: 12
 				LeftColor: 6C5F4C
 				RightColor: 73634D
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				RampType: 1
 				LeftColor: 715F47
 				RightColor: 72624C
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				Height: 1
 				RampType: 1
 				LeftColor: 77654D
 				RightColor: 746149
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				Height: 2
 				RampType: 1
 				LeftColor: 746149
 				RightColor: 6A5D4B
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				Height: 3
 				RampType: 1
 				LeftColor: 72624C
 				RightColor: 695D4D
+				ZOffset: -12
+				ZRamp: 0
 	Template@411:
 		Category: Slope Set Pieces
 		Id: 411
@@ -7460,32 +10832,46 @@ Templates:
 				RampType: 1
 				LeftColor: 6A5C49
 				RightColor: 6D6353
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 1
 				RampType: 1
 				LeftColor: 695F4F
 				RightColor: 6F614C
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				Height: 2
 				RampType: 1
 				LeftColor: 73624B
 				RightColor: 716049
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				Height: 3
 				RampType: 1
 				LeftColor: 756249
 				RightColor: 715F48
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				RampType: 8
 				LeftColor: 6B5943
 				RightColor: 655947
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				RampType: 4
 				LeftColor: 695F50
 				RightColor: 5C5244
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 705D45
 				RightColor: 6E5C46
+				ZOffset: -12
+				ZRamp: 0
 	Template@412:
 		Category: Slope Set Pieces
 		Id: 412
@@ -7497,15 +10883,21 @@ Templates:
 				RampType: 2
 				LeftColor: 655B4B
 				RightColor: 524A3D
+				ZOffset: -12
+				ZRamp: 0
 			1: Clear
 				Height: 3
 				RampType: 9
 				LeftColor: 6A5A44
 				RightColor: 665B4A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 464037
 				RightColor: 484137
+				ZOffset: -12
+				ZRamp: 0
 	Template@423:
 		Category: Dead Oil Tanker
 		Id: 423
@@ -7515,81 +10907,131 @@ Templates:
 			0: Cliff
 				LeftColor: ABADC2
 				RightColor: 7C7E89
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 585A5F
 				RightColor: BCBDDD
+				ZOffset: -12
+				ZRamp: 0
 			2: Water
 				RampType: 4
 				LeftColor: B0B2C8
 				RightColor: C4C5E2
+				ZOffset: -12
+				ZRamp: 0
 			3: Water
 				RampType: 12
 				LeftColor: 7B7D85
 				RightColor: A4A5B5
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 3F4D58
 				RightColor: 7D828C
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 53565A
 				RightColor: 545556
+				ZOffset: -12
+				ZRamp: 0
 			7: Water
 				LeftColor: 757B8A
 				RightColor: 747C8E
+				ZOffset: -12
+				ZRamp: 0
 			8: Water
 				RampType: 8
 				LeftColor: 515862
 				RightColor: 979AA8
+				ZOffset: -12
+				ZRamp: 0
 			10: Water
 				LeftColor: 293840
 				RightColor: 324049
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 3C4850
 				RightColor: 535557
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 454D51
 				RightColor: 67707D
+				ZOffset: -12
+				ZRamp: 0
 			13: Water
 				LeftColor: 38444C
 				RightColor: 35424C
+				ZOffset: -12
+				ZRamp: 0
 			16: Water
 				LeftColor: 293840
 				RightColor: 2C3A42
+				ZOffset: -12
+				ZRamp: 0
 			17: Cliff
 				LeftColor: 354249
 				RightColor: 3C4951
+				ZOffset: -12
+				ZRamp: 0
 			18: Water
 				LeftColor: 303D44
 				RightColor: 2A3840
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: 303C43
 				RightColor: 3A444C
+				ZOffset: -12
+				ZRamp: 0
 			23: Cliff
 				LeftColor: 40484E
 				RightColor: 3B4852
+				ZOffset: -12
+				ZRamp: 0
 			27: Cliff
 				LeftColor: 38444D
 				RightColor: 323E44
+				ZOffset: -12
+				ZRamp: 0
 			28: Cliff
 				LeftColor: 4B4C4D
 				RightColor: 434649
+				ZOffset: -12
+				ZRamp: 0
 			29: Water
 				LeftColor: 2A373E
 				RightColor: 28373F
+				ZOffset: -12
+				ZRamp: 0
 			32: Cliff
 				LeftColor: 293840
 				RightColor: 4E5864
+				ZOffset: -12
+				ZRamp: 0
 			33: Cliff
 				LeftColor: 454D53
 				RightColor: 515152
+				ZOffset: -12
+				ZRamp: 0
 			34: Cliff
 				LeftColor: 34373A
 				RightColor: 27333B
+				ZOffset: -12
+				ZRamp: 0
 			38: Cliff
 				LeftColor: 293840
 				RightColor: 464D50
+				ZOffset: -12
+				ZRamp: 0
 			39: Cliff
 				LeftColor: 313538
 				RightColor: 31363A
+				ZOffset: -12
+				ZRamp: 0
 	Template@424:
 		Category: Ruins
 		Id: 424
@@ -7599,24 +11041,38 @@ Templates:
 			1: Cliff
 				LeftColor: 757677
 				RightColor: 707380
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 7E8291
 				RightColor: 8A8DA1
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 757880
 				RightColor: 6A6D75
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 7B7E8B
 				RightColor: 898C9A
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: B7B8CA
 				RightColor: 878787
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BDBCC7
 				RightColor: B9B9BD
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C6C7DA
 				RightColor: 888998
+				ZOffset: -12
+				ZRamp: 0
 	Template@435:
 		Category: Waterfalls
 		Id: 435
@@ -7627,30 +11083,46 @@ Templates:
 				Height: 4
 				LeftColor: 3F362A
 				RightColor: 423A2F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 172231
 				RightColor: 101C2B
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 433C31
 				RightColor: 453E34
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 41434A
 				RightColor: 313D51
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 66543C
 				RightColor: 4C463B
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 475261
 				RightColor: 626769
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 604F3B
 				RightColor: 373F4A
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 253650
 				RightColor: 1F314D
+				ZOffset: -12
+				ZRamp: 0
 	Template@436:
 		Category: Waterfalls
 		Id: 436
@@ -7661,16 +11133,24 @@ Templates:
 				Height: 4
 				LeftColor: 142238
 				RightColor: 0D1C2E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 545D6D
 				RightColor: 343F50
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6F7B8D
 				RightColor: 93989E
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 152841
 				RightColor: 283F63
+				ZOffset: -12
+				ZRamp: 0
 	Template@437:
 		Category: Waterfalls
 		Id: 437
@@ -7681,30 +11161,46 @@ Templates:
 				Height: 4
 				LeftColor: 0C1A2C
 				RightColor: 0D1B2C
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 182331
 				RightColor: 0E1B2C
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 565E6A
 				RightColor: 27364E
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 4D586D
 				RightColor: 2E394C
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 616D7D
 				RightColor: A4A8AD
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 8E95A2
 				RightColor: B6B8BF
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 152943
 				RightColor: 23395C
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 182C49
 				RightColor: 354A6F
+				ZOffset: -12
+				ZRamp: 0
 	Template@438:
 		Category: Waterfalls
 		Id: 438
@@ -7715,30 +11211,46 @@ Templates:
 				Height: 4
 				LeftColor: 151F2A
 				RightColor: 1F252D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 443B2F
 				RightColor: 50412F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 525A68
 				RightColor: 32363C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 524635
 				RightColor: 483E31
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 7F8690
 				RightColor: A09E9E
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 544B3D
 				RightColor: 4F4638
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 2A3647
 				RightColor: 474A4E
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 5F503D
 				RightColor: 605341
+				ZOffset: -12
+				ZRamp: 0
 	Template@439:
 		Category: Ground 01
 		Id: 439
@@ -7748,6 +11260,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D573D
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@440:
 		Category: Ground 01
 		Id: 440
@@ -7757,6 +11271,8 @@ Templates:
 			0: Clear
 				LeftColor: 6E583D
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 	Template@441:
 		Category: Ground 01
 		Id: 441
@@ -7766,6 +11282,8 @@ Templates:
 			0: Clear
 				LeftColor: 725C41
 				RightColor: 735C40
+				ZOffset: -12
+				ZRamp: 0
 	Template@442:
 		Category: Ground 01
 		Id: 442
@@ -7775,6 +11293,8 @@ Templates:
 			0: Clear
 				LeftColor: 6F5A40
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 	Template@443:
 		Category: Ground 01
 		Id: 443
@@ -7784,6 +11304,8 @@ Templates:
 			0: Clear
 				LeftColor: 705A40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@444:
 		Category: Ground 01
 		Id: 444
@@ -7793,6 +11315,8 @@ Templates:
 			0: Clear
 				LeftColor: 6F583D
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 	Template@445:
 		Category: Ground 01
 		Id: 445
@@ -7802,6 +11326,8 @@ Templates:
 			0: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 	Template@446:
 		Category: Ground 01
 		Id: 446
@@ -7811,6 +11337,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 	Template@447:
 		Category: Ground 01
 		Id: 447
@@ -7820,6 +11348,8 @@ Templates:
 			0: Clear
 				LeftColor: 464036
 				RightColor: 474137
+				ZOffset: -12
+				ZRamp: 0
 	Template@448:
 		Category: Ground 01
 		Id: 448
@@ -7829,6 +11359,8 @@ Templates:
 			0: Clear
 				LeftColor: 484338
 				RightColor: 423D33
+				ZOffset: -12
+				ZRamp: 0
 	Template@449:
 		Category: Ground 01
 		Id: 449
@@ -7838,6 +11370,8 @@ Templates:
 			0: Clear
 				LeftColor: 443F36
 				RightColor: 474237
+				ZOffset: -12
+				ZRamp: 0
 	Template@450:
 		Category: Ground 01
 		Id: 450
@@ -7847,6 +11381,8 @@ Templates:
 			0: Clear
 				LeftColor: 4A443A
 				RightColor: 454036
+				ZOffset: -12
+				ZRamp: 0
 	Template@451:
 		Category: Ground 01
 		Id: 451
@@ -7856,6 +11392,8 @@ Templates:
 			0: Clear
 				LeftColor: 474137
 				RightColor: 484238
+				ZOffset: -12
+				ZRamp: 0
 	Template@452:
 		Category: Ground 01
 		Id: 452
@@ -7865,6 +11403,8 @@ Templates:
 			0: Clear
 				LeftColor: 454036
 				RightColor: 484237
+				ZOffset: -12
+				ZRamp: 0
 	Template@453:
 		Category: Ground 01
 		Id: 453
@@ -7874,6 +11414,8 @@ Templates:
 			0: Clear
 				LeftColor: 484339
 				RightColor: 474136
+				ZOffset: -12
+				ZRamp: 0
 	Template@454:
 		Category: Ground 01
 		Id: 454
@@ -7883,6 +11425,8 @@ Templates:
 			0: Clear
 				LeftColor: 474137
 				RightColor: 484238
+				ZOffset: -12
+				ZRamp: 0
 	Template@455:
 		Category: Ground 01
 		Id: 455
@@ -7892,6 +11436,8 @@ Templates:
 			0: Clear
 				LeftColor: 534839
 				RightColor: 544939
+				ZOffset: -12
+				ZRamp: 0
 	Template@456:
 		Category: Ground 01
 		Id: 456
@@ -7901,6 +11447,8 @@ Templates:
 			0: Clear
 				LeftColor: 4A4439
 				RightColor: 584A38
+				ZOffset: -12
+				ZRamp: 0
 	Template@457:
 		Category: Ground 01
 		Id: 457
@@ -7910,6 +11458,8 @@ Templates:
 			0: Clear
 				LeftColor: 464036
 				RightColor: 574A39
+				ZOffset: -12
+				ZRamp: 0
 	Template@458:
 		Category: Ground 01
 		Id: 458
@@ -7919,6 +11469,8 @@ Templates:
 			0: Clear
 				LeftColor: 4C463B
 				RightColor: 5E4F3C
+				ZOffset: -12
+				ZRamp: 0
 	Template@459:
 		Category: Ground 01
 		Id: 459
@@ -7928,6 +11480,8 @@ Templates:
 			0: Clear
 				LeftColor: 554939
 				RightColor: 494338
+				ZOffset: -12
+				ZRamp: 0
 	Template@460:
 		Category: Ground 01
 		Id: 460
@@ -7937,6 +11491,8 @@ Templates:
 			0: Clear
 				LeftColor: 554938
 				RightColor: 574A3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@461:
 		Category: Ground 01
 		Id: 461
@@ -7946,6 +11502,8 @@ Templates:
 			0: Clear
 				LeftColor: 584C3C
 				RightColor: 584A39
+				ZOffset: -12
+				ZRamp: 0
 	Template@462:
 		Category: Ground 01
 		Id: 462
@@ -7955,6 +11513,8 @@ Templates:
 			0: Clear
 				LeftColor: 564B3B
 				RightColor: 61523F
+				ZOffset: -12
+				ZRamp: 0
 	Template@463:
 		Category: Ground 01
 		Id: 463
@@ -7964,6 +11524,8 @@ Templates:
 			0: Clear
 				LeftColor: 564939
 				RightColor: 494338
+				ZOffset: -12
+				ZRamp: 0
 	Template@464:
 		Category: Ground 01
 		Id: 464
@@ -7973,6 +11535,8 @@ Templates:
 			0: Clear
 				LeftColor: 544939
 				RightColor: 564937
+				ZOffset: -12
+				ZRamp: 0
 	Template@465:
 		Category: Ground 01
 		Id: 465
@@ -7982,6 +11546,8 @@ Templates:
 			0: Clear
 				LeftColor: 5A4E3D
 				RightColor: 5B4C39
+				ZOffset: -12
+				ZRamp: 0
 	Template@466:
 		Category: Ground 01
 		Id: 466
@@ -7991,6 +11557,8 @@ Templates:
 			0: Clear
 				LeftColor: 574C3C
 				RightColor: 60503D
+				ZOffset: -12
+				ZRamp: 0
 	Template@467:
 		Category: Ground 01
 		Id: 467
@@ -8000,6 +11568,8 @@ Templates:
 			0: Clear
 				LeftColor: 64533D
 				RightColor: 4A4438
+				ZOffset: -12
+				ZRamp: 0
 	Template@468:
 		Category: Ground 01
 		Id: 468
@@ -8009,6 +11579,8 @@ Templates:
 			0: Clear
 				LeftColor: 67533B
 				RightColor: 584B3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@469:
 		Category: Ground 01
 		Id: 469
@@ -8018,6 +11590,8 @@ Templates:
 			0: Clear
 				LeftColor: 635440
 				RightColor: 554939
+				ZOffset: -12
+				ZRamp: 0
 	Template@470:
 		Category: Ground 01
 		Id: 470
@@ -8027,6 +11601,8 @@ Templates:
 			0: Clear
 				LeftColor: 5B4D3A
 				RightColor: 5D4F3D
+				ZOffset: -12
+				ZRamp: 0
 	Template@471:
 		Category: Ground 01
 		Id: 471
@@ -8036,6 +11612,8 @@ Templates:
 			0: Clear
 				LeftColor: 55493A
 				RightColor: 514739
+				ZOffset: -12
+				ZRamp: 0
 	Template@472:
 		Category: Ground 01
 		Id: 472
@@ -8045,6 +11623,8 @@ Templates:
 			0: Clear
 				LeftColor: 504638
 				RightColor: 5E4E3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@473:
 		Category: Ground 01
 		Id: 473
@@ -8054,6 +11634,8 @@ Templates:
 			0: Clear
 				LeftColor: 51483A
 				RightColor: 594B39
+				ZOffset: -12
+				ZRamp: 0
 	Template@474:
 		Category: Ground 01
 		Id: 474
@@ -8063,6 +11645,8 @@ Templates:
 			0: Clear
 				LeftColor: 544B3D
 				RightColor: 64523E
+				ZOffset: -12
+				ZRamp: 0
 	Template@475:
 		Category: Ground 01
 		Id: 475
@@ -8072,6 +11656,8 @@ Templates:
 			0: Clear
 				LeftColor: 5E4F3B
 				RightColor: 50473A
+				ZOffset: -12
+				ZRamp: 0
 	Template@476:
 		Category: Ground 01
 		Id: 476
@@ -8081,6 +11667,8 @@ Templates:
 			0: Clear
 				LeftColor: 5E4D39
 				RightColor: 5C4D3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@477:
 		Category: Ground 01
 		Id: 477
@@ -8090,6 +11678,8 @@ Templates:
 			0: Clear
 				LeftColor: 594C3B
 				RightColor: 5C4D3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@478:
 		Category: Ground 01
 		Id: 478
@@ -8099,6 +11689,8 @@ Templates:
 			0: Clear
 				LeftColor: 5D4E3C
 				RightColor: 655440
+				ZOffset: -12
+				ZRamp: 0
 	Template@479:
 		Category: Ground 01
 		Id: 479
@@ -8108,6 +11700,8 @@ Templates:
 			0: Clear
 				LeftColor: 564A3A
 				RightColor: 4E4639
+				ZOffset: -12
+				ZRamp: 0
 	Template@480:
 		Category: Ground 01
 		Id: 480
@@ -8117,6 +11711,8 @@ Templates:
 			0: Clear
 				LeftColor: 584B39
 				RightColor: 62513B
+				ZOffset: -12
+				ZRamp: 0
 	Template@481:
 		Category: Ground 01
 		Id: 481
@@ -8126,6 +11722,8 @@ Templates:
 			0: Clear
 				LeftColor: 5A4D3D
 				RightColor: 574A38
+				ZOffset: -12
+				ZRamp: 0
 	Template@482:
 		Category: Ground 01
 		Id: 482
@@ -8135,6 +11733,8 @@ Templates:
 			0: Clear
 				LeftColor: 5D503E
 				RightColor: 63523E
+				ZOffset: -12
+				ZRamp: 0
 	Template@483:
 		Category: Ground 01
 		Id: 483
@@ -8144,6 +11744,8 @@ Templates:
 			0: Clear
 				LeftColor: 68543C
 				RightColor: 574A39
+				ZOffset: -12
+				ZRamp: 0
 	Template@484:
 		Category: Ground 01
 		Id: 484
@@ -8153,6 +11755,8 @@ Templates:
 			0: Clear
 				LeftColor: 61503B
 				RightColor: 5C4D3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@485:
 		Category: Ground 01
 		Id: 485
@@ -8162,6 +11766,8 @@ Templates:
 			0: Clear
 				LeftColor: 67553F
 				RightColor: 5B4D3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@486:
 		Category: Ground 01
 		Id: 486
@@ -8171,6 +11777,8 @@ Templates:
 			0: Clear
 				LeftColor: 62513D
 				RightColor: 5F503D
+				ZOffset: -12
+				ZRamp: 0
 	Template@487:
 		Category: Ground 02
 		Id: 487
@@ -8180,6 +11788,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D573D
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@488:
 		Category: Ground 02
 		Id: 488
@@ -8189,6 +11799,8 @@ Templates:
 			0: Clear
 				LeftColor: 6E583D
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 	Template@489:
 		Category: Ground 02
 		Id: 489
@@ -8198,6 +11810,8 @@ Templates:
 			0: Clear
 				LeftColor: 725C41
 				RightColor: 735C40
+				ZOffset: -12
+				ZRamp: 0
 	Template@490:
 		Category: Ground 02
 		Id: 490
@@ -8207,6 +11821,8 @@ Templates:
 			0: Clear
 				LeftColor: 6F5A40
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 	Template@491:
 		Category: Ground 02
 		Id: 491
@@ -8216,6 +11832,8 @@ Templates:
 			0: Clear
 				LeftColor: 705A40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@492:
 		Category: Ground 02
 		Id: 492
@@ -8225,6 +11843,8 @@ Templates:
 			0: Clear
 				LeftColor: 6F583D
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 	Template@493:
 		Category: Ground 02
 		Id: 493
@@ -8234,6 +11854,8 @@ Templates:
 			0: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 	Template@494:
 		Category: Ground 02
 		Id: 494
@@ -8243,6 +11865,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 	Template@495:
 		Category: Ground 02
 		Id: 495
@@ -8252,6 +11876,8 @@ Templates:
 			0: Clear
 				LeftColor: 8B6D48
 				RightColor: 8A6D48
+				ZOffset: -12
+				ZRamp: 0
 	Template@496:
 		Category: Ground 02
 		Id: 496
@@ -8261,6 +11887,8 @@ Templates:
 			0: Clear
 				LeftColor: 8C6F49
 				RightColor: 896D48
+				ZOffset: -12
+				ZRamp: 0
 	Template@497:
 		Category: Ground 02
 		Id: 497
@@ -8270,6 +11898,8 @@ Templates:
 			0: Clear
 				LeftColor: 8A6D48
 				RightColor: 896C47
+				ZOffset: -12
+				ZRamp: 0
 	Template@498:
 		Category: Ground 02
 		Id: 498
@@ -8279,6 +11909,8 @@ Templates:
 			0: Clear
 				LeftColor: 8D704A
 				RightColor: 8C6E49
+				ZOffset: -12
+				ZRamp: 0
 	Template@499:
 		Category: Ground 02
 		Id: 499
@@ -8288,6 +11920,8 @@ Templates:
 			0: Clear
 				LeftColor: 896D47
 				RightColor: 876A46
+				ZOffset: -12
+				ZRamp: 0
 	Template@500:
 		Category: Ground 02
 		Id: 500
@@ -8297,6 +11931,8 @@ Templates:
 			0: Clear
 				LeftColor: 8A6D48
 				RightColor: 8C6F49
+				ZOffset: -12
+				ZRamp: 0
 	Template@501:
 		Category: Ground 02
 		Id: 501
@@ -8306,6 +11942,8 @@ Templates:
 			0: Clear
 				LeftColor: 8B6D48
 				RightColor: 876B47
+				ZOffset: -12
+				ZRamp: 0
 	Template@502:
 		Category: Ground 02
 		Id: 502
@@ -8315,6 +11953,8 @@ Templates:
 			0: Clear
 				LeftColor: 896C48
 				RightColor: 876B46
+				ZOffset: -12
+				ZRamp: 0
 	Template@503:
 		Category: Ground 02
 		Id: 503
@@ -8324,6 +11964,8 @@ Templates:
 			0: Clear
 				LeftColor: 7C6243
 				RightColor: 816645
+				ZOffset: -12
+				ZRamp: 0
 	Template@504:
 		Category: Ground 02
 		Id: 504
@@ -8333,6 +11975,8 @@ Templates:
 			0: Clear
 				LeftColor: 745C3F
 				RightColor: 806543
+				ZOffset: -12
+				ZRamp: 0
 	Template@505:
 		Category: Ground 02
 		Id: 505
@@ -8342,6 +11986,8 @@ Templates:
 			0: Clear
 				LeftColor: 725B40
 				RightColor: 7D6342
+				ZOffset: -12
+				ZRamp: 0
 	Template@506:
 		Category: Ground 02
 		Id: 506
@@ -8351,6 +11997,8 @@ Templates:
 			0: Clear
 				LeftColor: 6D583E
 				RightColor: 836845
+				ZOffset: -12
+				ZRamp: 0
 	Template@507:
 		Category: Ground 02
 		Id: 507
@@ -8360,6 +12008,8 @@ Templates:
 			0: Clear
 				LeftColor: 745D41
 				RightColor: 6B553C
+				ZOffset: -12
+				ZRamp: 0
 	Template@508:
 		Category: Ground 02
 		Id: 508
@@ -8369,6 +12019,8 @@ Templates:
 			0: Clear
 				LeftColor: 806644
 				RightColor: 7C6343
+				ZOffset: -12
+				ZRamp: 0
 	Template@509:
 		Category: Ground 02
 		Id: 509
@@ -8378,6 +12030,8 @@ Templates:
 			0: Clear
 				LeftColor: 765E41
 				RightColor: 755D40
+				ZOffset: -12
+				ZRamp: 0
 	Template@510:
 		Category: Ground 02
 		Id: 510
@@ -8387,6 +12041,8 @@ Templates:
 			0: Clear
 				LeftColor: 755E41
 				RightColor: 7F6544
+				ZOffset: -12
+				ZRamp: 0
 	Template@511:
 		Category: Ground 02
 		Id: 511
@@ -8396,6 +12052,8 @@ Templates:
 			0: Clear
 				LeftColor: 7B6141
 				RightColor: 6C573D
+				ZOffset: -12
+				ZRamp: 0
 	Template@512:
 		Category: Ground 02
 		Id: 512
@@ -8405,6 +12063,8 @@ Templates:
 			0: Clear
 				LeftColor: 775E40
 				RightColor: 735C3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@513:
 		Category: Ground 02
 		Id: 513
@@ -8414,6 +12074,8 @@ Templates:
 			0: Clear
 				LeftColor: 7E6343
 				RightColor: 7C6242
+				ZOffset: -12
+				ZRamp: 0
 	Template@514:
 		Category: Ground 02
 		Id: 514
@@ -8423,6 +12085,8 @@ Templates:
 			0: Clear
 				LeftColor: 7B6142
 				RightColor: 886C48
+				ZOffset: -12
+				ZRamp: 0
 	Template@515:
 		Category: Ground 02
 		Id: 515
@@ -8432,6 +12096,8 @@ Templates:
 			0: Clear
 				LeftColor: 866A47
 				RightColor: 6C573D
+				ZOffset: -12
+				ZRamp: 0
 	Template@516:
 		Category: Ground 02
 		Id: 516
@@ -8441,6 +12107,8 @@ Templates:
 			0: Clear
 				LeftColor: 836845
 				RightColor: 796042
+				ZOffset: -12
+				ZRamp: 0
 	Template@517:
 		Category: Ground 02
 		Id: 517
@@ -8450,6 +12118,8 @@ Templates:
 			0: Clear
 				LeftColor: 886B47
 				RightColor: 785F41
+				ZOffset: -12
+				ZRamp: 0
 	Template@518:
 		Category: Ground 02
 		Id: 518
@@ -8459,6 +12129,8 @@ Templates:
 			0: Clear
 				LeftColor: 745C3F
 				RightColor: 775F40
+				ZOffset: -12
+				ZRamp: 0
 	Template@519:
 		Category: Ground 02
 		Id: 519
@@ -8468,6 +12140,8 @@ Templates:
 			0: Clear
 				LeftColor: 826745
 				RightColor: 7A6143
+				ZOffset: -12
+				ZRamp: 0
 	Template@520:
 		Category: Ground 02
 		Id: 520
@@ -8477,6 +12151,8 @@ Templates:
 			0: Clear
 				LeftColor: 765E40
 				RightColor: 7E6443
+				ZOffset: -12
+				ZRamp: 0
 	Template@521:
 		Category: Ground 02
 		Id: 521
@@ -8486,6 +12162,8 @@ Templates:
 			0: Clear
 				LeftColor: 735D41
 				RightColor: 816644
+				ZOffset: -12
+				ZRamp: 0
 	Template@522:
 		Category: Ground 02
 		Id: 522
@@ -8495,6 +12173,8 @@ Templates:
 			0: Clear
 				LeftColor: 725B3E
 				RightColor: 886C47
+				ZOffset: -12
+				ZRamp: 0
 	Template@523:
 		Category: Ground 02
 		Id: 523
@@ -8504,6 +12184,8 @@ Templates:
 			0: Clear
 				LeftColor: 816745
 				RightColor: 715B40
+				ZOffset: -12
+				ZRamp: 0
 	Template@524:
 		Category: Ground 02
 		Id: 524
@@ -8513,6 +12195,8 @@ Templates:
 			0: Clear
 				LeftColor: 765E41
 				RightColor: 715C42
+				ZOffset: -12
+				ZRamp: 0
 	Template@525:
 		Category: Ground 02
 		Id: 525
@@ -8522,6 +12206,8 @@ Templates:
 			0: Clear
 				LeftColor: 796041
 				RightColor: 7F6543
+				ZOffset: -12
+				ZRamp: 0
 	Template@526:
 		Category: Ground 02
 		Id: 526
@@ -8531,6 +12217,8 @@ Templates:
 			0: Clear
 				LeftColor: 806645
 				RightColor: 8C6F49
+				ZOffset: -12
+				ZRamp: 0
 	Template@527:
 		Category: Ground 02
 		Id: 527
@@ -8540,6 +12228,8 @@ Templates:
 			0: Clear
 				LeftColor: 806544
 				RightColor: 735C3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@528:
 		Category: Ground 02
 		Id: 528
@@ -8549,6 +12239,8 @@ Templates:
 			0: Clear
 				LeftColor: 765F42
 				RightColor: 786144
+				ZOffset: -12
+				ZRamp: 0
 	Template@529:
 		Category: Ground 02
 		Id: 529
@@ -8558,6 +12250,8 @@ Templates:
 			0: Clear
 				LeftColor: 836845
 				RightColor: 796041
+				ZOffset: -12
+				ZRamp: 0
 	Template@530:
 		Category: Ground 02
 		Id: 530
@@ -8567,6 +12261,8 @@ Templates:
 			0: Clear
 				LeftColor: 765D3F
 				RightColor: 7D6242
+				ZOffset: -12
+				ZRamp: 0
 	Template@531:
 		Category: Ground 02
 		Id: 531
@@ -8576,6 +12272,8 @@ Templates:
 			0: Clear
 				LeftColor: 8A6D48
 				RightColor: 735C3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@532:
 		Category: Ground 02
 		Id: 532
@@ -8585,6 +12283,8 @@ Templates:
 			0: Clear
 				LeftColor: 876A46
 				RightColor: 775D40
+				ZOffset: -12
+				ZRamp: 0
 	Template@533:
 		Category: Ground 02
 		Id: 533
@@ -8594,6 +12294,8 @@ Templates:
 			0: Clear
 				LeftColor: 886C47
 				RightColor: 765E40
+				ZOffset: -12
+				ZRamp: 0
 	Template@534:
 		Category: Ground 02
 		Id: 534
@@ -8603,6 +12305,8 @@ Templates:
 			0: Clear
 				LeftColor: 765E40
 				RightColor: 755D3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@535:
 		Category: Sand
 		Id: 535
@@ -8612,6 +12316,8 @@ Templates:
 			0: Rough
 				LeftColor: 8B6D48
 				RightColor: 8A6D48
+				ZOffset: -12
+				ZRamp: 0
 	Template@536:
 		Category: Sand/Clear LAT
 		Id: 536
@@ -8621,6 +12327,8 @@ Templates:
 			0: Rough
 				LeftColor: 7C6243
 				RightColor: 816645
+				ZOffset: -12
+				ZRamp: 0
 	Template@537:
 		Category: Sand/Clear LAT
 		Id: 537
@@ -8630,6 +12338,8 @@ Templates:
 			0: Rough
 				LeftColor: 886B47
 				RightColor: 785F41
+				ZOffset: -12
+				ZRamp: 0
 	Template@538:
 		Category: Sand/Clear LAT
 		Id: 538
@@ -8639,6 +12349,8 @@ Templates:
 			0: Rough
 				LeftColor: 836845
 				RightColor: 796042
+				ZOffset: -12
+				ZRamp: 0
 	Template@539:
 		Category: Sand/Clear LAT
 		Id: 539
@@ -8648,6 +12360,8 @@ Templates:
 			0: Rough
 				LeftColor: 866A47
 				RightColor: 6C573D
+				ZOffset: -12
+				ZRamp: 0
 	Template@540:
 		Category: Sand/Clear LAT
 		Id: 540
@@ -8657,6 +12371,8 @@ Templates:
 			0: Rough
 				LeftColor: 7B6142
 				RightColor: 886C48
+				ZOffset: -12
+				ZRamp: 0
 	Template@541:
 		Category: Sand/Clear LAT
 		Id: 541
@@ -8666,6 +12382,8 @@ Templates:
 			0: Rough
 				LeftColor: 7E6343
 				RightColor: 7C6242
+				ZOffset: -12
+				ZRamp: 0
 	Template@542:
 		Category: Sand/Clear LAT
 		Id: 542
@@ -8675,6 +12393,8 @@ Templates:
 			0: Rough
 				LeftColor: 775E40
 				RightColor: 735C3F
+				ZOffset: -12
+				ZRamp: 0
 	Template@543:
 		Category: Sand/Clear LAT
 		Id: 543
@@ -8684,6 +12404,8 @@ Templates:
 			0: Rough
 				LeftColor: 7B6141
 				RightColor: 6C573D
+				ZOffset: -12
+				ZRamp: 0
 	Template@544:
 		Category: Sand/Clear LAT
 		Id: 544
@@ -8693,6 +12415,8 @@ Templates:
 			0: Rough
 				LeftColor: 755E41
 				RightColor: 7F6544
+				ZOffset: -12
+				ZRamp: 0
 	Template@545:
 		Category: Sand/Clear LAT
 		Id: 545
@@ -8702,6 +12426,8 @@ Templates:
 			0: Rough
 				LeftColor: 765E41
 				RightColor: 755D40
+				ZOffset: -12
+				ZRamp: 0
 	Template@546:
 		Category: Sand/Clear LAT
 		Id: 546
@@ -8711,6 +12437,8 @@ Templates:
 			0: Rough
 				LeftColor: 806644
 				RightColor: 7C6343
+				ZOffset: -12
+				ZRamp: 0
 	Template@547:
 		Category: Sand/Clear LAT
 		Id: 547
@@ -8720,6 +12448,8 @@ Templates:
 			0: Rough
 				LeftColor: 745D41
 				RightColor: 6B553C
+				ZOffset: -12
+				ZRamp: 0
 	Template@548:
 		Category: Sand/Clear LAT
 		Id: 548
@@ -8729,6 +12459,8 @@ Templates:
 			0: Rough
 				LeftColor: 6D583E
 				RightColor: 836845
+				ZOffset: -12
+				ZRamp: 0
 	Template@549:
 		Category: Sand/Clear LAT
 		Id: 549
@@ -8738,6 +12470,8 @@ Templates:
 			0: Rough
 				LeftColor: 725B40
 				RightColor: 7D6342
+				ZOffset: -12
+				ZRamp: 0
 	Template@550:
 		Category: Sand/Clear LAT
 		Id: 550
@@ -8747,6 +12481,8 @@ Templates:
 			0: Rough
 				LeftColor: 745C3F
 				RightColor: 806543
+				ZOffset: -12
+				ZRamp: 0
 	Template@551:
 		Category: Sand/Clear LAT
 		Id: 551
@@ -8756,6 +12492,8 @@ Templates:
 			0: Rough
 				LeftColor: 745C3F
 				RightColor: 775F40
+				ZOffset: -12
+				ZRamp: 0
 	Template@552:
 		Category: Rough ground
 		Id: 552
@@ -8765,111 +12503,183 @@ Templates:
 			2: Rough
 				LeftColor: 6A5740
 				RightColor: 5B4A35
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 4E4231
 				RightColor: 64523C
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 63523C
 				RightColor: 5E4F3B
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: 524636
 				RightColor: 4B3D2B
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 604F3A
 				RightColor: 67553E
+				ZOffset: -12
+				ZRamp: 0
 			18: Rough
 				LeftColor: 6D5A43
 				RightColor: 68563F
+				ZOffset: -12
+				ZRamp: 0
 			19: Rough
 				LeftColor: 5A4B38
 				RightColor: 6A5943
+				ZOffset: -12
+				ZRamp: 0
 			20: Rough
 				LeftColor: 5D4D37
 				RightColor: 5D4E39
+				ZOffset: -12
+				ZRamp: 0
 			21: Rough
 				LeftColor: 514331
 				RightColor: 5A4D3C
+				ZOffset: -12
+				ZRamp: 0
 			22: Rough
 				LeftColor: 3E3427
 				RightColor: 5D4C38
+				ZOffset: -12
+				ZRamp: 0
 			23: Rough
 				LeftColor: 574C3E
 				RightColor: 66533B
+				ZOffset: -12
+				ZRamp: 0
 			24: Rough
 				LeftColor: 62513C
 				RightColor: 604F3A
+				ZOffset: -12
+				ZRamp: 0
 			25: Rough
 				LeftColor: 4E4232
 				RightColor: 62513C
+				ZOffset: -12
+				ZRamp: 0
 			26: Rough
 				LeftColor: 6A5A45
 				RightColor: 66533C
+				ZOffset: -12
+				ZRamp: 0
 			28: Rough
 				LeftColor: 6D5941
 				RightColor: 635340
+				ZOffset: -12
+				ZRamp: 0
 			29: Rough
 				LeftColor: 5D4D39
 				RightColor: 60523F
+				ZOffset: -12
+				ZRamp: 0
 			30: Rough
 				LeftColor: 594A36
 				RightColor: 60513D
+				ZOffset: -12
+				ZRamp: 0
 			31: Rough
 				LeftColor: 564938
 				RightColor: 574835
+				ZOffset: -12
+				ZRamp: 0
 			32: Rough
 				LeftColor: 3A3226
 				RightColor: 4F4537
+				ZOffset: -12
+				ZRamp: 0
 			33: Rough
 				LeftColor: 574B3B
 				RightColor: 5B4E3D
+				ZOffset: -12
+				ZRamp: 0
 			34: Rough
 				LeftColor: 41382A
 				RightColor: 4D4132
+				ZOffset: -12
+				ZRamp: 0
 			35: Rough
 				LeftColor: 504434
 				RightColor: 61513C
+				ZOffset: -12
+				ZRamp: 0
 			38: Rough
 				LeftColor: 6F593F
 				RightColor: 60503D
+				ZOffset: -12
+				ZRamp: 0
 			39: Rough
 				LeftColor: 6A563E
 				RightColor: 66543E
+				ZOffset: -12
+				ZRamp: 0
 			40: Rough
 				LeftColor: 655541
 				RightColor: 514635
+				ZOffset: -12
+				ZRamp: 0
 			41: Rough
 				LeftColor: 3C3324
 				RightColor: 463C2E
+				ZOffset: -12
+				ZRamp: 0
 			42: Rough
 				LeftColor: 504434
 				RightColor: 514638
+				ZOffset: -12
+				ZRamp: 0
 			43: Rough
 				LeftColor: 544C40
 				RightColor: 564A3A
+				ZOffset: -12
+				ZRamp: 0
 			44: Rough
 				LeftColor: 594B3B
 				RightColor: 62523E
+				ZOffset: -12
+				ZRamp: 0
 			49: Rough
 				LeftColor: 6E5B44
 				RightColor: 615341
+				ZOffset: -12
+				ZRamp: 0
 			50: Rough
 				LeftColor: 5A4D3B
 				RightColor: 524635
+				ZOffset: -12
+				ZRamp: 0
 			51: Rough
 				LeftColor: 594C3A
 				RightColor: 574B3B
+				ZOffset: -12
+				ZRamp: 0
 			52: Rough
 				LeftColor: 5B4B36
 				RightColor: 5E4E3A
+				ZOffset: -12
+				ZRamp: 0
 			53: Rough
 				LeftColor: 695841
 				RightColor: 62513D
+				ZOffset: -12
+				ZRamp: 0
 			60: Rough
 				LeftColor: 6D5940
 				RightColor: 5E4D37
+				ZOffset: -12
+				ZRamp: 0
 			61: Rough
 				LeftColor: 6C5840
 				RightColor: 635440
+				ZOffset: -12
+				ZRamp: 0
 	Template@553:
 		Category: Rough ground
 		Id: 553
@@ -8879,33 +12689,53 @@ Templates:
 			1: Rough
 				LeftColor: 635340
 				RightColor: 62523E
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 534533
 				RightColor: 685742
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 64523B
 				RightColor: 6B5B46
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 5F5342
 				RightColor: 554A39
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 574937
 				RightColor: 564939
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 5A4A36
 				RightColor: 64513B
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 725F47
 				RightColor: 5F503E
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: 60523F
 				RightColor: 5B4E3B
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: 695945
 				RightColor: 6A5A46
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 6B5841
 				RightColor: 60513C
+				ZOffset: -12
+				ZRamp: 0
 	Template@554:
 		Category: Rough ground
 		Id: 554
@@ -8915,36 +12745,58 @@ Templates:
 			0: Rough
 				LeftColor: 6B5942
 				RightColor: 61523F
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 605342
 				RightColor: 645644
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 5B4F3F
 				RightColor: 6B5A43
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 5E4F3C
 				RightColor: 6F5C44
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 695844
 				RightColor: 54493A
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 544635
 				RightColor: 534738
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 50473A
 				RightColor: 5C4D3A
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: 51483A
 				RightColor: 6B5942
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: 69573F
 				RightColor: 5D503F
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 65543F
 				RightColor: 5E5243
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 635341
 				RightColor: 554836
+				ZOffset: -12
+				ZRamp: 0
 	Template@555:
 		Category: Rough ground
 		Id: 555
@@ -8954,27 +12806,43 @@ Templates:
 			0: Rough
 				LeftColor: 6C5944
 				RightColor: 5F503C
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 67553F
 				RightColor: 5B4E3D
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 493F30
 				RightColor: 6B5942
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 675643
 				RightColor: 504537
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 3F3B33
 				RightColor: 3E3529
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 4C4031
 				RightColor: 62523D
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: 64543F
 				RightColor: 4B4336
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 60513E
 				RightColor: 625545
+				ZOffset: -12
+				ZRamp: 0
 	Template@556:
 		Category: Rough ground
 		Id: 556
@@ -8984,39 +12852,63 @@ Templates:
 			1: Rough
 				LeftColor: 62523E
 				RightColor: 6C5B45
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 645440
 				RightColor: 65533E
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 564F45
 				RightColor: 504434
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 534839
 				RightColor: 685845
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 605343
 				RightColor: 5C4E3B
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 453B2D
 				RightColor: 5C4E3C
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 5D4F3F
 				RightColor: 625341
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: 64543F
 				RightColor: 5F513E
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: 4A4134
 				RightColor: 484136
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 493F32
 				RightColor: 584937
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 6C5941
 				RightColor: 60513D
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 615443
 				RightColor: 5A4C3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@557:
 		Category: Rough ground
 		Id: 557
@@ -9026,42 +12918,68 @@ Templates:
 			1: Clear
 				LeftColor: 65533D
 				RightColor: 64523D
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				LeftColor: 685846
 				RightColor: 6B573F
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 6C5841
 				RightColor: 6E5C45
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 4D4435
 				RightColor: 5B4D3B
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 4F4536
 				RightColor: 443C30
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 55493A
 				RightColor: 6E583F
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 715E46
 				RightColor: 675845
+				ZOffset: -12
+				ZRamp: 0
 			9: Rough
 				LeftColor: 514738
 				RightColor: 494134
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: 4F4436
 				RightColor: 4C4337
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 554939
 				RightColor: 635440
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 6D583E
 				RightColor: 62513C
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 63533F
 				RightColor: 625340
+				ZOffset: -12
+				ZRamp: 0
 			15: Rough
 				LeftColor: 564A3A
 				RightColor: 584B3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@558:
 		Category: Rough ground
 		Id: 558
@@ -9071,27 +12989,43 @@ Templates:
 			0: Rough
 				LeftColor: 61513E
 				RightColor: 5D4C38
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 554A39
 				RightColor: 64533D
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 5E4E39
 				RightColor: 705D47
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 6D5C47
 				RightColor: 5F5242
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 63523D
 				RightColor: 484035
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 554939
 				RightColor: 665541
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 68553D
 				RightColor: 524635
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 62533F
 				RightColor: 554735
+				ZOffset: -12
+				ZRamp: 0
 	Template@559:
 		Category: Rough ground
 		Id: 559
@@ -9101,69 +13035,113 @@ Templates:
 			1: Rough
 				LeftColor: 68553E
 				RightColor: 655440
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				LeftColor: 6E5C46
 				RightColor: 5C4C38
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 5B4D3A
 				RightColor: 5D5142
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: 6C5942
 				RightColor: 514636
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 544838
 				RightColor: 5A4C3A
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 514737
 				RightColor: 625039
+				ZOffset: -12
+				ZRamp: 0
 			15: Rough
 				LeftColor: 5B4D39
 				RightColor: 6B5740
+				ZOffset: -12
+				ZRamp: 0
 			20: Rough
 				LeftColor: 655540
 				RightColor: 5C4C37
+				ZOffset: -12
+				ZRamp: 0
 			21: Rough
 				LeftColor: 4D4131
 				RightColor: 604F38
+				ZOffset: -12
+				ZRamp: 0
 			22: Rough
 				LeftColor: 423728
 				RightColor: 6A5741
+				ZOffset: -12
+				ZRamp: 0
 			26: Rough
 				LeftColor: 68563F
 				RightColor: 63533E
+				ZOffset: -12
+				ZRamp: 0
 			27: Rough
 				LeftColor: 544737
 				RightColor: 494135
+				ZOffset: -12
+				ZRamp: 0
 			28: Rough
 				LeftColor: 4D3F2D
 				RightColor: 544531
+				ZOffset: -12
+				ZRamp: 0
 			33: Rough
 				LeftColor: 685640
 				RightColor: 594B39
+				ZOffset: -12
+				ZRamp: 0
 			34: Rough
 				LeftColor: 564A3A
 				RightColor: 574834
+				ZOffset: -12
+				ZRamp: 0
 			35: Rough
 				LeftColor: 695740
 				RightColor: 6F5B42
+				ZOffset: -12
+				ZRamp: 0
 			40: Rough
 				LeftColor: 625546
 				RightColor: 5F513F
+				ZOffset: -12
+				ZRamp: 0
 			45: Rough
 				LeftColor: 5C4E3B
 				RightColor: 61523E
+				ZOffset: -12
+				ZRamp: 0
 			46: Rough
 				LeftColor: 67553F
 				RightColor: 61513D
+				ZOffset: -12
+				ZRamp: 0
 			51: Rough
 				LeftColor: 5A4C39
 				RightColor: 4F4332
+				ZOffset: -12
+				ZRamp: 0
 			52: Rough
 				LeftColor: 65523C
 				RightColor: 67543D
+				ZOffset: -12
+				ZRamp: 0
 			57: Rough
 				LeftColor: 6C5942
 				RightColor: 594B39
+				ZOffset: -12
+				ZRamp: 0
 	Template@560:
 		Category: Rough ground
 		Id: 560
@@ -9173,51 +13151,83 @@ Templates:
 			0: Clear
 				LeftColor: 624F36
 				RightColor: 715B40
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 5C4E3B
 				RightColor: 5F4F3A
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 544938
 				RightColor: 5F4E39
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 4D4131
 				RightColor: 6C583F
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 544837
 				RightColor: 675641
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 5F5241
 				RightColor: 6B5841
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 645440
 				RightColor: 544939
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 6F5B42
 				RightColor: 6F5D47
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 705B42
 				RightColor: 685947
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 705D45
 				RightColor: 5F5240
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: 5E503C
 				RightColor: 524533
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 524636
 				RightColor: 53483A
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 574D3E
 				RightColor: 665743
+				ZOffset: -12
+				ZRamp: 0
 			15: Rough
 				LeftColor: 60523F
 				RightColor: 655541
+				ZOffset: -12
+				ZRamp: 0
 			21: Clear
 				LeftColor: 6E5A42
 				RightColor: 665947
+				ZOffset: -12
+				ZRamp: 0
 			22: Clear
 				LeftColor: 665540
 				RightColor: 725D44
+				ZOffset: -12
+				ZRamp: 0
 	Template@561:
 		Category: Rough ground
 		Id: 561
@@ -9227,27 +13237,43 @@ Templates:
 			0: Rough
 				LeftColor: 65533D
 				RightColor: 5F4E39
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 615546
 				RightColor: 6A573F
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 60513E
 				RightColor: 554B3E
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				LeftColor: 5A4B38
 				RightColor: 50463A
+				ZOffset: -12
+				ZRamp: 0
 			5: Rough
 				LeftColor: 5E4F3B
 				RightColor: 695842
+				ZOffset: -12
+				ZRamp: 0
 			7: Rough
 				LeftColor: 65543E
 				RightColor: 4F4538
+				ZOffset: -12
+				ZRamp: 0
 			8: Rough
 				LeftColor: 5A4A36
 				RightColor: 60513C
+				ZOffset: -12
+				ZRamp: 0
 			10: Rough
 				LeftColor: 695741
 				RightColor: 64543F
+				ZOffset: -12
+				ZRamp: 0
 	Template@562:
 		Category: Paved Road Ends
 		Id: 562
@@ -9257,12 +13283,18 @@ Templates:
 			0: Rough
 				LeftColor: 393734
 				RightColor: 4D483F
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 3B3730
 				RightColor: 423C33
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 4D4A45
 				RightColor: 453F36
+				ZOffset: -12
+				ZRamp: 0
 	Template@563:
 		Category: Paved Road Ends
 		Id: 563
@@ -9272,12 +13304,18 @@ Templates:
 			0: Rough
 				LeftColor: 504E4A
 				RightColor: 3E3A34
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 3E3B34
 				RightColor: 403B36
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 3F3C38
 				RightColor: 625441
+				ZOffset: -12
+				ZRamp: 0
 	Template@564:
 		Category: Paved Road Ends
 		Id: 564
@@ -9287,12 +13325,18 @@ Templates:
 			0: Rough
 				LeftColor: 3F3A33
 				RightColor: 4A4641
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 4F4436
 				RightColor: 37332D
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 4A4339
 				RightColor: 423C33
+				ZOffset: -12
+				ZRamp: 0
 	Template@565:
 		Category: Paved Road Ends
 		Id: 565
@@ -9302,12 +13346,18 @@ Templates:
 			0: Rough
 				LeftColor: 5B4E3E
 				RightColor: 3B3936
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				LeftColor: 463D2F
 				RightColor: 3E3B34
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				LeftColor: 453E34
 				RightColor: 4A453E
+				ZOffset: -12
+				ZRamp: 0
 	Template@566:
 		Category: TrainBridges
 		Id: 566
@@ -9318,55 +13368,85 @@ Templates:
 				Height: 4
 				LeftColor: 6F6B66
 				RightColor: 554F46
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6E6A61
 				RightColor: 635E57
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6E5A41
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 33312F
 				RightColor: 4B4A48
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 313131
 				RightColor: 585855
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 6C573F
 				RightColor: 6B5E4D
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				Height: 4
 				LeftColor: 363739
 				RightColor: 393A3C
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 353739
 				RightColor: 393A3C
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 705C44
 				RightColor: 625D55
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 4C4A48
 				RightColor: 35322F
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 4D4C4A
 				RightColor: 32312F
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 6F583E
 				RightColor: 5F584F
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 5B564E
 				RightColor: 777571
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6E6150
 				RightColor: 858279
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 705A40
 				RightColor: 70593E
+				ZOffset: -12
+				ZRamp: 0
 	Template@567:
 		Category: TrainBridges
 		Id: 567
@@ -9377,55 +13457,85 @@ Templates:
 				Height: 4
 				LeftColor: 6F6B66
 				RightColor: 554F46
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6F6C66
 				RightColor: 5E5C58
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 15273B
 				RightColor: 0F2339
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 33312F
 				RightColor: 4B4A48
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				Height: 4
 				LeftColor: 313131
 				RightColor: 585855
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 1E2933
 				RightColor: 3E454B
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				Height: 4
 				LeftColor: 363739
 				RightColor: 393A3C
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 353739
 				RightColor: 393A3C
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 1F2C39
 				RightColor: 515355
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				Height: 4
 				LeftColor: 4C4A48
 				RightColor: 35322F
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				Height: 4
 				LeftColor: 4D4C4A
 				RightColor: 32312F
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 233344
 				RightColor: 4D4F4F
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 5B564E
 				RightColor: 777571
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 504F4B
 				RightColor: 84827A
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 243341
 				RightColor: 16273C
+				ZOffset: -12
+				ZRamp: 0
 	Template@568:
 		Category: TrainBridges
 		Id: 568
@@ -9435,41 +13545,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 726F6A
 				RightColor: 585147
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 33312F
 				RightColor: 605E5A
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 313131
 				RightColor: 494846
+				ZOffset: -12
+				ZRamp: 0
 			4: Rail
 				Height: 4
 				LeftColor: 363739
 				RightColor: 393A3C
+				ZOffset: -12
+				ZRamp: 0
 			5: Rail
 				Height: 4
 				LeftColor: 353739
 				RightColor: 393A3C
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4C4C4B
 				RightColor: 35322F
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				Height: 4
 				LeftColor: 4B4945
 				RightColor: 323130
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 8C8579
 				RightColor: 8A857A
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 534D43
 				RightColor: 6A6865
+				ZOffset: -12
+				ZRamp: 0
 	Template@569:
 		Category: TrainBridges
 		Id: 569
@@ -9480,55 +13610,85 @@ Templates:
 				Height: 4
 				LeftColor: 4F4940
 				RightColor: 63605B
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 4B4A48
 				RightColor: 33312F
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 37383A
 				RightColor: 353738
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 34322F
 				RightColor: 494844
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 5B5955
 				RightColor: 564D42
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 998E7D
 				RightColor: 98958D
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 494845
 				RightColor: 484745
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 37383A
 				RightColor: 353639
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 32312E
 				RightColor: 4B4945
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 645A4C
 				RightColor: 6A655B
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 6D573D
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 6E583D
 				RightColor: 887A68
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 725C41
 				RightColor: 8D867A
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6F5A40
 				RightColor: 8B8478
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 705C43
 				RightColor: 6C573E
+				ZOffset: -12
+				ZRamp: 0
 	Template@570:
 		Category: TrainBridges
 		Id: 570
@@ -9539,55 +13699,85 @@ Templates:
 				Height: 4
 				LeftColor: 4F4940
 				RightColor: 63605B
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 4B4A48
 				RightColor: 33312F
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 37383A
 				RightColor: 353738
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 34322F
 				RightColor: 494844
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 5B5955
 				RightColor: 564D42
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 888989
 				RightColor: 98958D
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 494845
 				RightColor: 484745
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 37383A
 				RightColor: 353639
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 32312E
 				RightColor: 4B4945
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 5D584F
 				RightColor: 67635B
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 0E2036
 				RightColor: 192A3E
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 102135
 				RightColor: 666B6E
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 122439
 				RightColor: 7F7F7C
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 112337
 				RightColor: 80817E
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 112135
 				RightColor: 223041
+				ZOffset: -12
+				ZRamp: 0
 	Template@571:
 		Category: TrainBridges
 		Id: 571
@@ -9597,41 +13787,61 @@ Templates:
 			0: Cliff
 				LeftColor: 000000
 				RightColor: 000000
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 4C4C4C
 				RightColor: 4C4B4A
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 37383A
 				RightColor: 353738
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 35332F
 				RightColor: 4D4C4B
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 685F55
 				RightColor: 6B665F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 564D40
 				RightColor: 605E5B
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4D4D4C
 				RightColor: 333230
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				Height: 4
 				LeftColor: 373839
 				RightColor: 353639
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				Height: 4
 				LeftColor: 313130
 				RightColor: 4B4C4C
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 5E5B57
 				RightColor: 56534E
+				ZOffset: -12
+				ZRamp: 0
 	Template@572:
 		Category: TrainBridges
 		Id: 572
@@ -9641,36 +13851,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 6A6967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: CCCDDD
 				RightColor: D1D2EE
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 454646
 				RightColor: 6D6D6E
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: CCCDDD
 				RightColor: 9F9FAB
+				ZOffset: -12
+				ZRamp: 0
 			4: Rail
 				Height: 4
 				LeftColor: 373633
 				RightColor: 373632
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C8CADE
 				RightColor: 747478
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 626262
 				RightColor: 464646
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C8CADF
 				RightColor: 737379
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B5B5B9
 				RightColor: 999896
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C8CBE6
 				RightColor: C3C5F7
+				ZOffset: -12
+				ZRamp: 0
 	Template@573:
 		Category: TrainBridges
 		Id: 573
@@ -9680,36 +13910,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 696867
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: CCCDDD
 				RightColor: D1D2EE
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 3F4041
 				RightColor: 666667
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: CCCDDD
 				RightColor: 9F9FAB
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				Height: 4
 				LeftColor: 343331
 				RightColor: 383734
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C8CADE
 				RightColor: 747478
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 4A4A4A
 				RightColor: 414141
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C8CADF
 				RightColor: 737379
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A6A6AA
 				RightColor: 939290
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C6C8E3
 				RightColor: C3C5F7
+				ZOffset: -12
+				ZRamp: 0
 	Template@574:
 		Category: TrainBridges
 		Id: 574
@@ -9719,36 +13969,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 6A6967
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C8CAD9
 				RightColor: D1D2EE
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				Height: 4
 				LeftColor: 404040
 				RightColor: 656565
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B9BBCA
 				RightColor: 8E8F97
+				ZOffset: -12
+				ZRamp: 0
 			4: Rail
 				Height: 4
 				LeftColor: 363533
 				RightColor: 31312F
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B8BBCB
 				RightColor: 727276
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				Height: 4
 				LeftColor: 5B5B5B
 				RightColor: 404040
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BFC0CE
 				RightColor: 6E6E73
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B3B2B6
 				RightColor: 91908F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C6C8E3
 				RightColor: B1B3DA
+				ZOffset: -12
+				ZRamp: 0
 	Template@575:
 		Category: TrainBridges
 		Id: 575
@@ -9758,36 +14028,56 @@ Templates:
 			0: Cliff
 				LeftColor: 71706D
 				RightColor: 686765
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C8CAD9
 				RightColor: D1D2EE
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 3C3C3D
 				RightColor: 5B5B5B
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: B9BBCA
 				RightColor: 8E8F97
+				ZOffset: -12
+				ZRamp: 0
 			4: Rough
 				Height: 4
 				LeftColor: 353533
 				RightColor: 343330
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: B8BBCB
 				RightColor: 727276
+				ZOffset: -12
+				ZRamp: 0
 			6: Rough
 				Height: 4
 				LeftColor: 4B4B4B
 				RightColor: 3D3D3D
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BFC0CE
 				RightColor: 6E6E73
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: A6A6AA
 				RightColor: 91918F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C6C8E3
 				RightColor: B1B3DA
+				ZOffset: -12
+				ZRamp: 0
 	Template@576:
 		Category: TrainBridges
 		Id: 576
@@ -9797,33 +14087,53 @@ Templates:
 			0: Cliff
 				LeftColor: 7A7977
 				RightColor: 90908F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: C3C4D0
 				RightColor: B5B6C7
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 636260
 				RightColor: 6C6C6A
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 7A7C84
 				RightColor: B0B1C6
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6E6D6B
 				RightColor: 848380
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 979AA7
 				RightColor: 7D7F89
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 797875
 				RightColor: 979692
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: BABBC6
 				RightColor: B9BBDD
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: B3B3BA
 				RightColor: A9A9AD
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C6C8E3
 				RightColor: B0B2D6
+				ZOffset: -12
+				ZRamp: 0
 	Template@577:
 		Category: TrainBridges
 		Id: 577
@@ -9833,36 +14143,56 @@ Templates:
 			0: Cliff
 				LeftColor: BDBDC5
 				RightColor: 9D9C98
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 616161
 				RightColor: 565657
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 363531
 				RightColor: 373632
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 454545
 				RightColor: 606061
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8F8F97
 				RightColor: 898889
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: D3D3F1
 				RightColor: CDCEE4
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: CBCDE2
 				RightColor: B7B8C4
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: CFD0EF
 				RightColor: A6A4A6
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C8CAF5
 				RightColor: A3A3A5
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C8CAF5
 				RightColor: CBCDEC
+				ZOffset: -12
+				ZRamp: 0
 	Template@578:
 		Category: TrainBridges
 		Id: 578
@@ -9873,32 +14203,50 @@ Templates:
 				Height: 4
 				LeftColor: 585858
 				RightColor: 4E4E4E
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 33322F
 				RightColor: 343330
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 444444
 				RightColor: 535353
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8F8F97
 				RightColor: 898989
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: D3D3F1
 				RightColor: BABAC2
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: CBCDE2
 				RightColor: A3A3A4
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: CFD0EF
 				RightColor: A6A4A6
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C8CAF5
 				RightColor: A3A3A5
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C8CAF5
 				RightColor: CBCDEC
+				ZOffset: -12
+				ZRamp: 0
 	Template@579:
 		Category: TrainBridges
 		Id: 579
@@ -9908,36 +14256,56 @@ Templates:
 			0: Cliff
 				LeftColor: A3A3AA
 				RightColor: 8E8D89
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				Height: 4
 				LeftColor: 565656
 				RightColor: 515151
+				ZOffset: -12
+				ZRamp: 0
 			2: Rail
 				Height: 4
 				LeftColor: 33322E
 				RightColor: 373633
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				Height: 4
 				LeftColor: 3F3F3F
 				RightColor: 5F6060
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 8F8F97
 				RightColor: 888788
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: D3D3F1
 				RightColor: BEBFD3
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: C0C2D5
 				RightColor: A5A6B0
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C5C7DF
 				RightColor: 969494
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C3C5E4
 				RightColor: 9E9D9F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C7C9F3
 				RightColor: CBCDEC
+				ZOffset: -12
+				ZRamp: 0
 	Template@580:
 		Category: TrainBridges
 		Id: 580
@@ -9948,32 +14316,50 @@ Templates:
 				Height: 4
 				LeftColor: 414242
 				RightColor: 4B4B4B
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 2E2D2B
 				RightColor: 2D2B28
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 313131
 				RightColor: 4D4D4D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 86868A
 				RightColor: 848384
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C7C8E2
 				RightColor: AAAAB0
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: C0C2D5
 				RightColor: 909091
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: C2C3DB
 				RightColor: 949392
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C3C5E4
 				RightColor: A2A1A3
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: C3C5F0
 				RightColor: B9BAD4
+				ZOffset: -12
+				ZRamp: 0
 	Template@581:
 		Category: TrainBridges
 		Id: 581
@@ -9983,33 +14369,53 @@ Templates:
 			0: Cliff
 				LeftColor: A2A3AA
 				RightColor: 8A8987
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 979797
 				RightColor: 969491
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 8A8883
 				RightColor: 888783
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 959390
 				RightColor: 787776
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 848489
 				RightColor: 919199
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: C7C8E2
 				RightColor: BBBCC9
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: B7B9C7
 				RightColor: A7A9BA
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: B0B0BC
 				RightColor: 707178
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: C2C4E4
 				RightColor: A2A3AD
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: BFC1EB
 				RightColor: B7B9D3
+				ZOffset: -12
+				ZRamp: 0
 	Template@582:
 		Category: Pavement
 		Id: 582
@@ -10019,6 +14425,8 @@ Templates:
 			0: Road
 				LeftColor: 565553
 				RightColor: 535250
+				ZOffset: -12
+				ZRamp: 0
 	Template@583:
 		Category: Pavement
 		Id: 583
@@ -10028,6 +14436,8 @@ Templates:
 			0: Road
 				LeftColor: 585754
 				RightColor: 545250
+				ZOffset: -12
+				ZRamp: 0
 	Template@584:
 		Category: Pavement
 		Id: 584
@@ -10037,6 +14447,8 @@ Templates:
 			0: Road
 				LeftColor: 545350
 				RightColor: 525251
+				ZOffset: -12
+				ZRamp: 0
 	Template@585:
 		Category: Pavement
 		Id: 585
@@ -10046,6 +14458,8 @@ Templates:
 			0: Road
 				LeftColor: 504F4D
 				RightColor: 4D4D4C
+				ZOffset: -12
+				ZRamp: 0
 	Template@586:
 		Category: Pavement
 		Id: 586
@@ -10055,15 +14469,23 @@ Templates:
 			0: Road
 				LeftColor: 57534E
 				RightColor: 55524E
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 55514D
 				RightColor: 54524F
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 52514F
 				RightColor: 54514C
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 53524F
 				RightColor: 59544F
+				ZOffset: -12
+				ZRamp: 0
 	Template@587:
 		Category: Pavement
 		Id: 587
@@ -10073,15 +14495,23 @@ Templates:
 			0: Road
 				LeftColor: 565553
 				RightColor: 535250
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 535251
 				RightColor: 525251
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565452
 				RightColor: 545251
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 565554
 				RightColor: 575756
+				ZOffset: -12
+				ZRamp: 0
 	Template@588:
 		Category: Pavement
 		Id: 588
@@ -10091,15 +14521,23 @@ Templates:
 			0: Road
 				LeftColor: 52514F
 				RightColor: 4E4D4D
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 545352
 				RightColor: 565552
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565553
 				RightColor: 565552
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 4F4E4C
 				RightColor: 51504E
+				ZOffset: -12
+				ZRamp: 0
 	Template@589:
 		Category: Pavement
 		Id: 589
@@ -10109,15 +14547,23 @@ Templates:
 			0: Road
 				LeftColor: 595855
 				RightColor: 555451
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 5A5956
 				RightColor: 5A5855
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565452
 				RightColor: 565553
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 575653
 				RightColor: 5A5854
+				ZOffset: -12
+				ZRamp: 0
 	Template@590:
 		Category: Pavement
 		Id: 590
@@ -10127,15 +14573,23 @@ Templates:
 			0: Road
 				LeftColor: 5B5A58
 				RightColor: 5B5855
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 5B5B58
 				RightColor: 595855
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 53524F
 				RightColor: 545351
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 555350
 				RightColor: 585654
+				ZOffset: -12
+				ZRamp: 0
 	Template@591:
 		Category: Pavement
 		Id: 591
@@ -10145,15 +14599,23 @@ Templates:
 			0: Road
 				LeftColor: 585552
 				RightColor: 535252
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 565553
 				RightColor: 555451
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 555351
 				RightColor: 545452
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 57534F
 				RightColor: 545353
+				ZOffset: -12
+				ZRamp: 0
 	Template@592:
 		Category: Pavement
 		Id: 592
@@ -10163,15 +14625,23 @@ Templates:
 			0: Road
 				LeftColor: 57534D
 				RightColor: 5B5651
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 5D5952
 				RightColor: 5A5753
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 55524F
 				RightColor: 5B554D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 5B5751
 				RightColor: 5B5955
+				ZOffset: -12
+				ZRamp: 0
 	Template@593:
 		Category: Pavement
 		Id: 593
@@ -10181,15 +14651,23 @@ Templates:
 			0: Road
 				LeftColor: 58544F
 				RightColor: 5F584F
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 5F5A53
 				RightColor: 5A5651
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 5A5652
 				RightColor: 615B53
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 5B554E
 				RightColor: 55534F
+				ZOffset: -12
+				ZRamp: 0
 	Template@594:
 		Category: Pavement
 		Id: 594
@@ -10199,15 +14677,23 @@ Templates:
 			0: Road
 				LeftColor: 56534E
 				RightColor: 59554F
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 5C5750
 				RightColor: 575551
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565450
 				RightColor: 5A5650
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 5C5750
 				RightColor: 555452
+				ZOffset: -12
+				ZRamp: 0
 	Template@595:
 		Category: Pavement
 		Id: 595
@@ -10217,15 +14703,23 @@ Templates:
 			0: Road
 				LeftColor: 56534E
 				RightColor: 59554F
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 5C5750
 				RightColor: 575551
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565450
 				RightColor: 5A5650
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 5C5750
 				RightColor: 555452
+				ZOffset: -12
+				ZRamp: 0
 	Template@596:
 		Category: Pavement/Clear LAT
 		Id: 596
@@ -10235,6 +14729,8 @@ Templates:
 			0: Road
 				LeftColor: 5E554A
 				RightColor: 615548
+				ZOffset: -12
+				ZRamp: 0
 	Template@597:
 		Category: Pavement/Clear LAT
 		Id: 597
@@ -10244,6 +14740,8 @@ Templates:
 			0: Road
 				LeftColor: 58544C
 				RightColor: 615546
+				ZOffset: -12
+				ZRamp: 0
 	Template@598:
 		Category: Pavement/Clear LAT
 		Id: 598
@@ -10253,6 +14751,8 @@ Templates:
 			0: Road
 				LeftColor: 58544E
 				RightColor: 635747
+				ZOffset: -12
+				ZRamp: 0
 	Template@599:
 		Category: Pavement/Clear LAT
 		Id: 599
@@ -10262,6 +14762,8 @@ Templates:
 			0: Road
 				LeftColor: 5F574D
 				RightColor: 705A3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@600:
 		Category: Pavement/Clear LAT
 		Id: 600
@@ -10271,6 +14773,8 @@ Templates:
 			0: Road
 				LeftColor: 625546
 				RightColor: 56524D
+				ZOffset: -12
+				ZRamp: 0
 	Template@601:
 		Category: Pavement/Clear LAT
 		Id: 601
@@ -10280,6 +14784,8 @@ Templates:
 			0: Road
 				LeftColor: 655644
 				RightColor: 645644
+				ZOffset: -12
+				ZRamp: 0
 	Template@602:
 		Category: Pavement/Clear LAT
 		Id: 602
@@ -10289,6 +14795,8 @@ Templates:
 			0: Road
 				LeftColor: 675642
 				RightColor: 695844
+				ZOffset: -12
+				ZRamp: 0
 	Template@603:
 		Category: Pavement/Clear LAT
 		Id: 603
@@ -10298,6 +14806,8 @@ Templates:
 			0: Road
 				LeftColor: 5B5348
 				RightColor: 675540
+				ZOffset: -12
+				ZRamp: 0
 	Template@604:
 		Category: Pavement/Clear LAT
 		Id: 604
@@ -10307,6 +14817,8 @@ Templates:
 			0: Road
 				LeftColor: 665A49
 				RightColor: 5C574E
+				ZOffset: -12
+				ZRamp: 0
 	Template@605:
 		Category: Pavement/Clear LAT
 		Id: 605
@@ -10316,6 +14828,8 @@ Templates:
 			0: Road
 				LeftColor: 695C49
 				RightColor: 63594A
+				ZOffset: -12
+				ZRamp: 0
 	Template@606:
 		Category: Pavement/Clear LAT
 		Id: 606
@@ -10325,6 +14839,8 @@ Templates:
 			0: Road
 				LeftColor: 64594B
 				RightColor: 645849
+				ZOffset: -12
+				ZRamp: 0
 	Template@607:
 		Category: Pavement/Clear LAT
 		Id: 607
@@ -10334,6 +14850,8 @@ Templates:
 			0: Road
 				LeftColor: 625547
 				RightColor: 6C573E
+				ZOffset: -12
+				ZRamp: 0
 	Template@608:
 		Category: Pavement/Clear LAT
 		Id: 608
@@ -10343,6 +14861,8 @@ Templates:
 			0: Road
 				LeftColor: 6D5941
 				RightColor: 56544E
+				ZOffset: -12
+				ZRamp: 0
 	Template@609:
 		Category: Pavement/Clear LAT
 		Id: 609
@@ -10352,6 +14872,8 @@ Templates:
 			0: Road
 				LeftColor: 6F5A3F
 				RightColor: 64584A
+				ZOffset: -12
+				ZRamp: 0
 	Template@610:
 		Category: Pavement/Clear LAT
 		Id: 610
@@ -10361,6 +14883,8 @@ Templates:
 			0: Road
 				LeftColor: 6C5943
 				RightColor: 635747
+				ZOffset: -12
+				ZRamp: 0
 	Template@611:
 		Category: Pavement/Clear LAT
 		Id: 611
@@ -10370,6 +14894,8 @@ Templates:
 			0: Road
 				LeftColor: 645645
 				RightColor: 655745
+				ZOffset: -12
+				ZRamp: 0
 	Template@612:
 		Category: Paved road bits
 		Id: 612
@@ -10379,6 +14905,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 3E3B38
 				RightColor: 443F3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@613:
 		Category: Paved road bits
 		Id: 613
@@ -10388,6 +14916,8 @@ Templates:
 			0: Clear
 				LeftColor: 494139
 				RightColor: 4B433A
+				ZOffset: -12
+				ZRamp: 0
 	Template@614:
 		Category: Paved road bits
 		Id: 614
@@ -10397,6 +14927,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 413D38
 				RightColor: 3F3D39
+				ZOffset: -12
+				ZRamp: 0
 	Template@615:
 		Category: Paved road bits
 		Id: 615
@@ -10406,6 +14938,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 3A3937
 				RightColor: 453F37
+				ZOffset: -12
+				ZRamp: 0
 	Template@616:
 		Category: Paved road bits
 		Id: 616
@@ -10415,6 +14949,8 @@ Templates:
 			0: Clear
 				LeftColor: 4B433A
 				RightColor: 494139
+				ZOffset: -12
+				ZRamp: 0
 	Template@617:
 		Category: Paved road bits
 		Id: 617
@@ -10424,6 +14960,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 464038
 				RightColor: 393838
+				ZOffset: -12
+				ZRamp: 0
 	Template@618:
 		Category: Paved road bits
 		Id: 618
@@ -10433,6 +14971,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 403E3B
 				RightColor: 49443F
+				ZOffset: -12
+				ZRamp: 0
 	Template@619:
 		Category: Paved road bits
 		Id: 619
@@ -10442,6 +14982,8 @@ Templates:
 			0: Clear
 				LeftColor: 4A423A
 				RightColor: 4D453B
+				ZOffset: -12
+				ZRamp: 0
 	Template@620:
 		Category: Paved road bits
 		Id: 620
@@ -10451,6 +14993,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 47433F
 				RightColor: 43413D
+				ZOffset: -12
+				ZRamp: 0
 	Template@621:
 		Category: Paved road bits
 		Id: 621
@@ -10460,6 +15004,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 403F3D
 				RightColor: 474139
+				ZOffset: -12
+				ZRamp: 0
 	Template@622:
 		Category: Paved road bits
 		Id: 622
@@ -10469,6 +15015,8 @@ Templates:
 			0: Clear
 				LeftColor: 4D453B
 				RightColor: 4A423A
+				ZOffset: -12
+				ZRamp: 0
 	Template@623:
 		Category: Paved road bits
 		Id: 623
@@ -10478,6 +15026,8 @@ Templates:
 			0: DirtRoad
 				LeftColor: 48423A
 				RightColor: 40403F
+				ZOffset: -12
+				ZRamp: 0
 	Template@624:
 		Category: Paved road bits
 		Id: 624
@@ -10487,12 +15037,18 @@ Templates:
 			0: Road
 				LeftColor: 494846
 				RightColor: 52504E
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 464542
 				RightColor: 454340
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 565552
 				RightColor: 484745
+				ZOffset: -12
+				ZRamp: 0
 	Template@625:
 		Category: Paved road bits
 		Id: 625
@@ -10502,12 +15058,18 @@ Templates:
 			0: Road
 				LeftColor: 52504E
 				RightColor: 494846
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 454340
 				RightColor: 464542
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 484745
 				RightColor: 565552
+				ZOffset: -12
+				ZRamp: 0
 	Template@626:
 		Category: Green
 		Id: 626
@@ -10517,6 +15079,8 @@ Templates:
 			0: Rough
 				LeftColor: 2B300C
 				RightColor: 2B330C
+				ZOffset: -12
+				ZRamp: 0
 	Template@627:
 		Category: Green/Clear LAT
 		Id: 627
@@ -10526,6 +15090,8 @@ Templates:
 			0: Rough
 				LeftColor: 4D452C
 				RightColor: 494328
+				ZOffset: -12
+				ZRamp: 0
 	Template@628:
 		Category: Green/Clear LAT
 		Id: 628
@@ -10535,6 +15101,8 @@ Templates:
 			0: Rough
 				LeftColor: 363518
 				RightColor: 5A4C34
+				ZOffset: -12
+				ZRamp: 0
 	Template@629:
 		Category: Green/Clear LAT
 		Id: 629
@@ -10544,6 +15112,8 @@ Templates:
 			0: Rough
 				LeftColor: 3D3A21
 				RightColor: 4D432A
+				ZOffset: -12
+				ZRamp: 0
 	Template@630:
 		Category: Green/Clear LAT
 		Id: 630
@@ -10553,6 +15123,8 @@ Templates:
 			0: Rough
 				LeftColor: 484426
 				RightColor: 62513C
+				ZOffset: -12
+				ZRamp: 0
 	Template@631:
 		Category: Green/Clear LAT
 		Id: 631
@@ -10562,6 +15134,8 @@ Templates:
 			0: Rough
 				LeftColor: 594C34
 				RightColor: 444220
+				ZOffset: -12
+				ZRamp: 0
 	Template@632:
 		Category: Green/Clear LAT
 		Id: 632
@@ -10571,6 +15145,8 @@ Templates:
 			0: Rough
 				LeftColor: 57492E
 				RightColor: 54492F
+				ZOffset: -12
+				ZRamp: 0
 	Template@633:
 		Category: Green/Clear LAT
 		Id: 633
@@ -10580,6 +15156,8 @@ Templates:
 			0: Rough
 				LeftColor: 4D4529
 				RightColor: 564931
+				ZOffset: -12
+				ZRamp: 0
 	Template@634:
 		Category: Green/Clear LAT
 		Id: 634
@@ -10589,6 +15167,8 @@ Templates:
 			0: Rough
 				LeftColor: 504629
 				RightColor: 64533F
+				ZOffset: -12
+				ZRamp: 0
 	Template@635:
 		Category: Green/Clear LAT
 		Id: 635
@@ -10598,6 +15178,8 @@ Templates:
 			0: Rough
 				LeftColor: 50472D
 				RightColor: 454125
+				ZOffset: -12
+				ZRamp: 0
 	Template@636:
 		Category: Green/Clear LAT
 		Id: 636
@@ -10607,6 +15189,8 @@ Templates:
 			0: Rough
 				LeftColor: 4C422B
 				RightColor: 594C31
+				ZOffset: -12
+				ZRamp: 0
 	Template@637:
 		Category: Green/Clear LAT
 		Id: 637
@@ -10616,6 +15200,8 @@ Templates:
 			0: Rough
 				LeftColor: 50482E
 				RightColor: 4F4728
+				ZOffset: -12
+				ZRamp: 0
 	Template@638:
 		Category: Green/Clear LAT
 		Id: 638
@@ -10625,6 +15211,8 @@ Templates:
 			0: Rough
 				LeftColor: 544A30
 				RightColor: 60503B
+				ZOffset: -12
+				ZRamp: 0
 	Template@639:
 		Category: Green/Clear LAT
 		Id: 639
@@ -10634,6 +15222,8 @@ Templates:
 			0: Rough
 				LeftColor: 66533B
 				RightColor: 4D4528
+				ZOffset: -12
+				ZRamp: 0
 	Template@640:
 		Category: Green/Clear LAT
 		Id: 640
@@ -10643,6 +15233,8 @@ Templates:
 			0: Rough
 				LeftColor: 5F4F38
 				RightColor: 574A31
+				ZOffset: -12
+				ZRamp: 0
 	Template@641:
 		Category: Green/Clear LAT
 		Id: 641
@@ -10652,6 +15244,8 @@ Templates:
 			0: Rough
 				LeftColor: 64533B
 				RightColor: 51472E
+				ZOffset: -12
+				ZRamp: 0
 	Template@642:
 		Category: Green/Clear LAT
 		Id: 642
@@ -10661,6 +15255,8 @@ Templates:
 			0: Rough
 				LeftColor: 5D4E36
 				RightColor: 5B4D37
+				ZOffset: -12
+				ZRamp: 0
 	Template@643:
 		Category: Ramp edge fixup
 		Id: 643
@@ -10671,6 +15267,8 @@ Templates:
 				RampType: 1
 				LeftColor: 705A3F
 				RightColor: 705E46
+				ZOffset: -12
+				ZRamp: 0
 	Template@644:
 		Category: Ramp edge fixup
 		Id: 644
@@ -10681,6 +15279,8 @@ Templates:
 				RampType: 1
 				LeftColor: 746148
 				RightColor: 705B41
+				ZOffset: -12
+				ZRamp: 0
 	Template@645:
 		Category: Ramp edge fixup
 		Id: 645
@@ -10691,6 +15291,8 @@ Templates:
 				RampType: 1
 				LeftColor: 726047
 				RightColor: 705B41
+				ZOffset: -12
+				ZRamp: 0
 	Template@646:
 		Category: Ramp edge fixup
 		Id: 646
@@ -10701,6 +15303,8 @@ Templates:
 				RampType: 2
 				LeftColor: 4C4539
 				RightColor: 564939
+				ZOffset: -12
+				ZRamp: 0
 	Template@647:
 		Category: Ramp edge fixup
 		Id: 647
@@ -10711,6 +15315,8 @@ Templates:
 				RampType: 2
 				LeftColor: 574A39
 				RightColor: 464034
+				ZOffset: -12
+				ZRamp: 0
 	Template@648:
 		Category: Ramp edge fixup
 		Id: 648
@@ -10721,6 +15327,8 @@ Templates:
 				RampType: 2
 				LeftColor: 594C3B
 				RightColor: 564A39
+				ZOffset: -12
+				ZRamp: 0
 	Template@649:
 		Category: Ramp edge fixup
 		Id: 649
@@ -10731,6 +15339,8 @@ Templates:
 				RampType: 3
 				LeftColor: 594D3D
 				RightColor: 61523F
+				ZOffset: -12
+				ZRamp: 0
 	Template@650:
 		Category: Ramp edge fixup
 		Id: 650
@@ -10741,6 +15351,8 @@ Templates:
 				RampType: 3
 				LeftColor: 5B4E3C
 				RightColor: 584D3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@651:
 		Category: Ramp edge fixup
 		Id: 651
@@ -10751,6 +15363,8 @@ Templates:
 				RampType: 3
 				LeftColor: 5B4E3C
 				RightColor: 61523F
+				ZOffset: -12
+				ZRamp: 0
 	Template@652:
 		Category: Ramp edge fixup
 		Id: 652
@@ -10761,6 +15375,8 @@ Templates:
 				RampType: 4
 				LeftColor: 66543E
 				RightColor: 5D4E3A
+				ZOffset: -12
+				ZRamp: 0
 	Template@653:
 		Category: Ramp edge fixup
 		Id: 653
@@ -10771,6 +15387,8 @@ Templates:
 				RampType: 4
 				LeftColor: 60523E
 				RightColor: 604F3B
+				ZOffset: -12
+				ZRamp: 0
 	Template@654:
 		Category: Ramp edge fixup
 		Id: 654
@@ -10781,6 +15399,8 @@ Templates:
 				RampType: 4
 				LeftColor: 67553F
 				RightColor: 62513C
+				ZOffset: -12
+				ZRamp: 0
 	Template@667:
 		Category: Water slopes
 		Id: 667
@@ -10791,18 +15411,26 @@ Templates:
 				RampType: 1
 				LeftColor: 686159
 				RightColor: 6E5B43
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 1
 				LeftColor: 445064
 				RightColor: 505E79
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 1
 				LeftColor: 56565A
 				RightColor: 425269
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 1
 				LeftColor: 765E41
 				RightColor: 725D42
+				ZOffset: -12
+				ZRamp: 0
 	Template@668:
 		Category: Water slopes
 		Id: 668
@@ -10813,18 +15441,26 @@ Templates:
 				RampType: 2
 				LeftColor: 544A3B
 				RightColor: 5B5856
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 2
 				LeftColor: 495771
 				RightColor: 404F6A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 2
 				LeftColor: 4D586D
 				RightColor: 544E46
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 2
 				LeftColor: 544A3A
 				RightColor: 443D30
+				ZOffset: -12
+				ZRamp: 0
 	Template@669:
 		Category: Water slopes
 		Id: 669
@@ -10835,18 +15471,26 @@ Templates:
 				RampType: 3
 				LeftColor: 635A4F
 				RightColor: 5B5041
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 3
 				LeftColor: 6C7995
 				RightColor: 57657F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 3
 				LeftColor: 6B6C71
 				RightColor: 616C83
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 3
 				LeftColor: 5A4E3D
 				RightColor: 5C4F3E
+				ZOffset: -12
+				ZRamp: 0
 	Template@670:
 		Category: Water slopes
 		Id: 670
@@ -10857,18 +15501,26 @@ Templates:
 				RampType: 4
 				LeftColor: 604F3A
 				RightColor: 564E45
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				RampType: 4
 				LeftColor: 697389
 				RightColor: 4E5B72
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				RampType: 4
 				LeftColor: 4C5665
 				RightColor: 616368
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				RampType: 4
 				LeftColor: 5F513E
 				RightColor: 60503B
+				ZOffset: -12
+				ZRamp: 0
 	Template@671:
 		Category: Pavement (Use for LAT)
 		Id: 671
@@ -10878,6 +15530,8 @@ Templates:
 			0: Road
 				LeftColor: 545350
 				RightColor: 525252
+				ZOffset: -12
+				ZRamp: 0
 	Template@672:
 		Category: Paved Road Slopes
 		Id: 672
@@ -10888,14 +15542,20 @@ Templates:
 				RampType: 1
 				LeftColor: 484744
 				RightColor: 5A5A5A
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				RampType: 1
 				LeftColor: 45443F
 				RightColor: 4B4537
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				RampType: 1
 				LeftColor: 565553
 				RightColor: 4B4B4A
+				ZOffset: -12
+				ZRamp: 0
 	Template@673:
 		Category: Paved Road Slopes
 		Id: 673
@@ -10906,14 +15566,20 @@ Templates:
 				RampType: 2
 				LeftColor: 484847
 				RightColor: 383734
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				RampType: 2
 				LeftColor: 3C362B
 				RightColor: 353430
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				RampType: 2
 				LeftColor: 3B3B3A
 				RightColor: 444340
+				ZOffset: -12
+				ZRamp: 0
 	Template@674:
 		Category: Paved Road Slopes
 		Id: 674
@@ -10924,14 +15590,20 @@ Templates:
 				RampType: 3
 				LeftColor: 363430
 				RightColor: 3D3C38
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				RampType: 3
 				LeftColor: 323130
 				RightColor: 36332E
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				RampType: 3
 				LeftColor: 42403B
 				RightColor: 363635
+				ZOffset: -12
+				ZRamp: 0
 	Template@675:
 		Category: Paved Road Slopes
 		Id: 675
@@ -10942,14 +15614,20 @@ Templates:
 				RampType: 4
 				LeftColor: 4F4B45
 				RightColor: 3E3D3B
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				RampType: 4
 				LeftColor: 3E3B34
 				RightColor: 3C3B38
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				RampType: 4
 				LeftColor: 3F3F3D
 				RightColor: 4D4A45
+				ZOffset: -12
+				ZRamp: 0
 	Template@676:
 		Category: Monorail Slopes
 		Id: 676
@@ -10960,6 +15638,8 @@ Templates:
 				RampType: 1
 				LeftColor: 4D4D4E
 				RightColor: 4E4B48
+				ZOffset: -12
+				ZRamp: 0
 	Template@677:
 		Category: Monorail Slopes
 		Id: 677
@@ -10970,6 +15650,8 @@ Templates:
 				RampType: 2
 				LeftColor: 3E434A
 				RightColor: 454646
+				ZOffset: -12
+				ZRamp: 0
 	Template@678:
 		Category: Monorail Slopes
 		Id: 678
@@ -10980,6 +15662,8 @@ Templates:
 				RampType: 3
 				LeftColor: 4B4843
 				RightColor: 484848
+				ZOffset: -12
+				ZRamp: 0
 	Template@679:
 		Category: Monorail Slopes
 		Id: 679
@@ -10990,6 +15674,8 @@ Templates:
 				RampType: 4
 				LeftColor: 383A3C
 				RightColor: 4C4842
+				ZOffset: -12
+				ZRamp: 0
 	Template@680:
 		Category: Waterfalls-B
 		Id: 680
@@ -11000,30 +15686,46 @@ Templates:
 				Height: 4
 				LeftColor: 111F32
 				RightColor: 162335
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 1E2E47
 				RightColor: 33405A
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 808695
 				RightColor: 848890
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 1D3253
 				RightColor: 132840
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 413D39
 				RightColor: 29313A
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 3C3B3A
 				RightColor: 433C32
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 41382B
 				RightColor: 3F3B32
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 4E4D4D
 				RightColor: 3B4350
+				ZOffset: -12
+				ZRamp: 0
 	Template@681:
 		Category: Waterfalls-B
 		Id: 681
@@ -11034,16 +15736,24 @@ Templates:
 				Height: 4
 				LeftColor: 0B192A
 				RightColor: 0E1C2E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 142339
 				RightColor: 465167
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 959BAB
 				RightColor: 9EA3AD
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 142640
 				RightColor: 11243B
+				ZOffset: -12
+				ZRamp: 0
 	Template@682:
 		Category: Waterfalls-B
 		Id: 682
@@ -11054,30 +15764,46 @@ Templates:
 				Height: 4
 				LeftColor: 0D1C2F
 				RightColor: 0E1C2E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 202F46
 				RightColor: 5F6776
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 8E95A3
 				RightColor: 8E949C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 1B2F4F
 				RightColor: 12253D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 0B192A
 				RightColor: 111F34
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 212E42
 				RightColor: 575E6A
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 9AA0B1
 				RightColor: A7ABB5
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 152843
 				RightColor: 10243A
+				ZOffset: -12
+				ZRamp: 0
 	Template@683:
 		Category: Waterfalls-B
 		Id: 683
@@ -11088,30 +15814,46 @@ Templates:
 				Height: 4
 				LeftColor: 313336
 				RightColor: 423A30
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 423C32
 				RightColor: 393229
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 403A31
 				RightColor: 3A352C
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				LeftColor: 3D4044
 				RightColor: 5E503F
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 112032
 				RightColor: 1A2532
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 25344B
 				RightColor: 514E4A
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 6C747D
 				RightColor: 626261
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 1A2B43
 				RightColor: 1E314E
+				ZOffset: -12
+				ZRamp: 0
 	Template@684:
 		Category: Waterfalls-C
 		Id: 684
@@ -11122,14 +15864,20 @@ Templates:
 				Height: 4
 				LeftColor: 4A3F31
 				RightColor: 443F36
+				ZOffset: -12
+				ZRamp: 0
 			2: Rough
 				Height: 4
 				LeftColor: 453C32
 				RightColor: 2F333B
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 1A283E
 				RightColor: 39404D
+				ZOffset: -12
+				ZRamp: 0
 	Template@685:
 		Category: Waterfalls-C
 		Id: 685
@@ -11140,6 +15888,8 @@ Templates:
 				Height: 4
 				LeftColor: 112034
 				RightColor: 374257
+				ZOffset: -12
+				ZRamp: 0
 	Template@686:
 		Category: Waterfalls-C
 		Id: 686
@@ -11150,10 +15900,14 @@ Templates:
 				Height: 4
 				LeftColor: 112035
 				RightColor: 3A455A
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 16253D
 				RightColor: 334057
+				ZOffset: -12
+				ZRamp: 0
 	Template@687:
 		Category: Waterfalls-C
 		Id: 687
@@ -11164,14 +15918,20 @@ Templates:
 				Height: 4
 				LeftColor: 322F29
 				RightColor: 413D35
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 192637
 				RightColor: 3D4553
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 3D3933
 				RightColor: 463F34
+				ZOffset: -12
+				ZRamp: 0
 	Template@688:
 		Category: Waterfalls-D
 		Id: 688
@@ -11182,14 +15942,20 @@ Templates:
 				Height: 4
 				LeftColor: 212E42
 				RightColor: 1D2C43
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 433C31
 				RightColor: 373531
+				ZOffset: -12
+				ZRamp: 0
 			3: Rough
 				Height: 4
 				LeftColor: 3E372E
 				RightColor: 353636
+				ZOffset: -12
+				ZRamp: 0
 	Template@689:
 		Category: Waterfalls-D
 		Id: 689
@@ -11200,6 +15966,8 @@ Templates:
 				Height: 4
 				LeftColor: 253349
 				RightColor: 0F1E31
+				ZOffset: -12
+				ZRamp: 0
 	Template@690:
 		Category: Waterfalls-D
 		Id: 690
@@ -11210,10 +15978,14 @@ Templates:
 				Height: 4
 				LeftColor: 17263E
 				RightColor: 233043
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 2A3850
 				RightColor: 16263E
+				ZOffset: -12
+				ZRamp: 0
 	Template@691:
 		Category: Waterfalls-D
 		Id: 691
@@ -11224,14 +15996,20 @@ Templates:
 				Height: 4
 				LeftColor: 322F2A
 				RightColor: 453D31
+				ZOffset: -12
+				ZRamp: 0
 			1: Rough
 				Height: 4
 				LeftColor: 363636
 				RightColor: 463C30
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 28303E
 				RightColor: 212B37
+				ZOffset: -12
+				ZRamp: 0
 	Template@707:
 		Category: Tunnel Floor
 		Id: 707
@@ -11241,48 +16019,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 453625
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 42413E
 				RightColor: 4E4D4A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 383939
 				RightColor: 3B3A37
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 20201E
 				RightColor: 1C1B1A
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 3B3935
 				RightColor: 3C3A35
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 36332F
 				RightColor: 2D2B28
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 1F1E1B
 				RightColor: 1A1918
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 4C4D4C
 				RightColor: 403F3D
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 474541
 				RightColor: 2F2F2F
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 252523
 				RightColor: 1C1C1C
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6F5A41
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 463525
 				RightColor: 453525
+				ZOffset: -12
+				ZRamp: 0
 	Template@708:
 		Category: Tunnel Floor
 		Id: 708
@@ -11292,48 +16100,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 4E4D4A
 				RightColor: 42413E
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 3C3A35
 				RightColor: 3B3935
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 403F3D
 				RightColor: 4C4D4C
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6D5A42
 				RightColor: 6C583E
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 3B3A37
 				RightColor: 383939
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 2D2B28
 				RightColor: 36332F
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 2F2F2F
 				RightColor: 474541
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 6D583E
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 1C1B1A
 				RightColor: 20201E
+				ZOffset: -12
+				ZRamp: 0
 			12: Road
 				LeftColor: 1A1918
 				RightColor: 1F1E1B
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 1C1C1C
 				RightColor: 252523
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 453525
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 	Template@709:
 		Category: Tunnel Floor
 		Id: 709
@@ -11343,39 +16181,63 @@ Templates:
 			0: Cliff
 				LeftColor: 070707
 				RightColor: 2F2A24
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5B574F
 				RightColor: 5C5954
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6D6354
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 1C1C1C
 				RightColor: 090909
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 2F2F2F
 				RightColor: 474541
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 42413E
 				RightColor: 4E4C49
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 1A1918
 				RightColor: 060605
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 2D2B28
 				RightColor: 36332F
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 3B3935
 				RightColor: 3C3A35
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 050505
 				RightColor: 20201E
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 3B3A37
 				RightColor: 383939
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 4F4E4C
 				RightColor: 403F3D
+				ZOffset: -12
+				ZRamp: 0
 	Template@710:
 		Category: Tunnel Floor
 		Id: 710
@@ -11385,39 +16247,63 @@ Templates:
 			0: Cliff
 				LeftColor: 161616
 				RightColor: 2A2620
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 252523
 				RightColor: 070707
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 1F1E1B
 				RightColor: 050504
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 20201E
 				RightColor: 050505
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 58544C
 				RightColor: 4D4B47
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 474541
 				RightColor: 2F2F2F
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 36332F
 				RightColor: 2D2B28
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 383939
 				RightColor: 3B3A37
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6F583D
 				RightColor: 706659
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 4E4C49
 				RightColor: 42413E
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 3C3A35
 				RightColor: 3B3935
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 403F3D
 				RightColor: 4F4E4C
+				ZOffset: -12
+				ZRamp: 0
 	Template@711:
 		Category: Tunnel Side
 		Id: 711
@@ -11428,12 +16314,18 @@ Templates:
 				Height: 4
 				LeftColor: 51422F
 				RightColor: 534839
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 544633
 				RightColor: 807B72
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6F5C44
 				RightColor: 736C61
+				ZOffset: -12
+				ZRamp: 0
 	Template@712:
 		Category: Tunnel Side
 		Id: 712
@@ -11444,12 +16336,18 @@ Templates:
 				Height: 4
 				LeftColor: 54493A
 				RightColor: 50422F
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 413B33
 				RightColor: 5E564B
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 7E7870
 				RightColor: 5A4B38
+				ZOffset: -12
+				ZRamp: 0
 	Template@713:
 		Category: TrackTunnel Floor
 		Id: 713
@@ -11459,48 +16357,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 453625
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 42413E
 				RightColor: 4E4D4A
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 383939
 				RightColor: 3B3A37
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 20201E
 				RightColor: 1C1B1A
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 47494C
 				RightColor: 4C4E50
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 444649
 				RightColor: 4A4C4E
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 32312F
 				RightColor: 363531
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 4C4D4C
 				RightColor: 403F3D
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 474541
 				RightColor: 2F2F2F
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 252523
 				RightColor: 1C1C1C
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6F5A41
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 463525
 				RightColor: 453525
+				ZOffset: -12
+				ZRamp: 0
 	Template@714:
 		Category: TrackTunnel Floor
 		Id: 714
@@ -11510,48 +16438,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 4E4D4A
 				RightColor: 42413E
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 494B4D
 				RightColor: 46494C
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 403F3D
 				RightColor: 4C4D4C
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6D5A42
 				RightColor: 6C583E
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 3B3A37
 				RightColor: 383939
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 47494B
 				RightColor: 444649
+				ZOffset: -12
+				ZRamp: 0
 			8: Road
 				LeftColor: 2F2F2F
 				RightColor: 474541
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 6D583E
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 1C1B1A
 				RightColor: 20201E
+				ZOffset: -12
+				ZRamp: 0
 			12: Rail
 				LeftColor: 33322F
 				RightColor: 31302E
+				ZOffset: -12
+				ZRamp: 0
 			13: Road
 				LeftColor: 1C1C1C
 				RightColor: 252523
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 453525
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 	Template@715:
 		Category: TrackTunnel Floor
 		Id: 715
@@ -11561,39 +16519,63 @@ Templates:
 			0: Cliff
 				LeftColor: 070707
 				RightColor: 2F2B25
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5B574F
 				RightColor: 5C5954
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6D6354
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 1C1C1C
 				RightColor: 090909
+				ZOffset: -12
+				ZRamp: 0
 			4: Road
 				LeftColor: 2F2F2F
 				RightColor: 474541
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 42413E
 				RightColor: 4E4C49
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 292620
 				RightColor: 080806
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 363533
 				RightColor: 3A3935
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 47494C
 				RightColor: 4C4E50
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 050505
 				RightColor: 20201E
+				ZOffset: -12
+				ZRamp: 0
 			10: Road
 				LeftColor: 3B3A37
 				RightColor: 383939
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 4F4E4C
 				RightColor: 403F3D
+				ZOffset: -12
+				ZRamp: 0
 	Template@716:
 		Category: TrackTunnel Floor
 		Id: 716
@@ -11603,39 +16585,63 @@ Templates:
 			0: Cliff
 				LeftColor: 161616
 				RightColor: 2A2621
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 252523
 				RightColor: 070707
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 2B2721
 				RightColor: 080706
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 20201E
 				RightColor: 050505
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 58544C
 				RightColor: 4D4B47
+				ZOffset: -12
+				ZRamp: 0
 			5: Road
 				LeftColor: 474541
 				RightColor: 2F2F2F
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				LeftColor: 373634
 				RightColor: 353533
+				ZOffset: -12
+				ZRamp: 0
 			7: Road
 				LeftColor: 383939
 				RightColor: 3B3A37
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6F583D
 				RightColor: 706659
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 4E4C49
 				RightColor: 42413E
+				ZOffset: -12
+				ZRamp: 0
 			10: Rail
 				LeftColor: 494B4D
 				RightColor: 46494C
+				ZOffset: -12
+				ZRamp: 0
 			11: Road
 				LeftColor: 403F3D
 				RightColor: 4F4E4C
+				ZOffset: -12
+				ZRamp: 0
 	Template@717:
 		Category: Destroyable Cliffs
 		Id: 717
@@ -11646,72 +16652,112 @@ Templates:
 				Height: 4
 				LeftColor: 453C2F
 				RightColor: 433A2D
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 4E3F2C
 				RightColor: 473B2B
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				Height: 4
 				LeftColor: 52422F
 				RightColor: 4B3E2E
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 4F4333
 				RightColor: 4C3E2E
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				Height: 4
 				LeftColor: 4E4539
 				RightColor: 3F372C
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				Height: 4
 				LeftColor: 504435
 				RightColor: 453B2F
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				Height: 4
 				LeftColor: 50412F
 				RightColor: 584732
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 574530
 				RightColor: 614E37
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				Height: 4
 				LeftColor: 493E30
 				RightColor: 524738
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				Height: 4
 				LeftColor: 504537
 				RightColor: 42392E
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 615341
 				RightColor: 564C3F
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 715A40
 				RightColor: 65533C
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 725A3F
 				RightColor: 604D35
+				ZOffset: -12
+				ZRamp: 0
 			15: Cliff
 				LeftColor: 7A6144
 				RightColor: 6F583E
+				ZOffset: -12
+				ZRamp: 0
 			16: Cliff
 				LeftColor: 745C40
 				RightColor: 594F41
+				ZOffset: -12
+				ZRamp: 0
 			17: Cliff
 				LeftColor: 6B5B46
 				RightColor: 403B32
+				ZOffset: -12
+				ZRamp: 0
 			19: Cliff
 				LeftColor: 6B553C
 				RightColor: 69543B
+				ZOffset: -12
+				ZRamp: 0
 			20: Cliff
 				LeftColor: 745D42
 				RightColor: 725A3F
+				ZOffset: -12
+				ZRamp: 0
 			21: Cliff
 				LeftColor: 765F43
 				RightColor: 70583D
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: 6A553B
 				RightColor: 6C563D
+				ZOffset: -12
+				ZRamp: 0
 	Template@718:
 		Category: Destroyable Cliffs
 		Id: 718
@@ -11722,72 +16768,112 @@ Templates:
 				Height: 4
 				LeftColor: 473E33
 				RightColor: 403A32
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 3A3731
 				RightColor: 34322D
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				Height: 4
 				LeftColor: 41392E
 				RightColor: 4F4639
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				Height: 4
 				LeftColor: 4C4337
 				RightColor: 4D463B
+				ZOffset: -12
+				ZRamp: 0
 			6: Cliff
 				LeftColor: 4F402D
 				RightColor: 473C2D
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 69533B
 				RightColor: 6B563E
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				Height: 4
 				LeftColor: 413930
 				RightColor: 483E31
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				Height: 4
 				LeftColor: 5B4A35
 				RightColor: 524433
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 645038
 				RightColor: 69553D
+				ZOffset: -12
+				ZRamp: 0
 			11: Cliff
 				LeftColor: 6C563D
 				RightColor: 6C553B
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				Height: 4
 				LeftColor: 514433
 				RightColor: 493E31
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				Height: 4
 				LeftColor: 614F38
 				RightColor: 554735
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 70583C
 				RightColor: 725B40
+				ZOffset: -12
+				ZRamp: 0
 			15: Cliff
 				LeftColor: 69543C
 				RightColor: 725A40
+				ZOffset: -12
+				ZRamp: 0
 			16: Cliff
 				Height: 4
 				LeftColor: 4D402F
 				RightColor: 493D2E
+				ZOffset: -12
+				ZRamp: 0
 			17: Cliff
 				Height: 4
 				LeftColor: 433B2F
 				RightColor: 493D2F
+				ZOffset: -12
+				ZRamp: 0
 			18: Cliff
 				LeftColor: 504232
 				RightColor: 5B4C3A
+				ZOffset: -12
+				ZRamp: 0
 			19: Cliff
 				LeftColor: 634E36
 				RightColor: 6F593E
+				ZOffset: -12
+				ZRamp: 0
 			21: Cliff
 				Height: 4
 				LeftColor: 4B4033
 				RightColor: 413A2F
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: 564D40
 				RightColor: 3E3A33
+				ZOffset: -12
+				ZRamp: 0
 	Template@719:
 		Category: Water Caves
 		Id: 719
@@ -11798,16 +16884,24 @@ Templates:
 				Height: 4
 				LeftColor: 41382B
 				RightColor: 4D4030
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 3A3226
 				RightColor: 4A3F2F
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 323639
 				RightColor: 4D4233
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 212C39
 				RightColor: 2A2B2B
+				ZOffset: -12
+				ZRamp: 0
 	Template@720:
 		Category: Water Caves
 		Id: 720
@@ -11818,16 +16912,24 @@ Templates:
 				Height: 4
 				LeftColor: 423A2E
 				RightColor: 473C2D
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 3E362B
 				RightColor: 504333
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 20344E
 				RightColor: 1A1F23
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 2B333B
 				RightColor: 272521
+				ZOffset: -12
+				ZRamp: 0
 	Template@721:
 		Category: Water Caves
 		Id: 721
@@ -11838,9 +16940,13 @@ Templates:
 				Height: 4
 				LeftColor: 383127
 				RightColor: 4D4131
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 24354B
 				RightColor: 161A1E
+				ZOffset: -12
+				ZRamp: 0
 	Template@722:
 		Category: Water Caves
 		Id: 722
@@ -11851,16 +16957,24 @@ Templates:
 				Height: 4
 				LeftColor: 483E30
 				RightColor: 504130
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				Height: 4
 				LeftColor: 484034
 				RightColor: 4E4130
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 223553
 				RightColor: 161A1E
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 383B3E
 				RightColor: 474137
+				ZOffset: -12
+				ZRamp: 0
 	Template@723:
 		Category: Water Caves
 		Id: 723
@@ -11871,16 +16985,24 @@ Templates:
 				Height: 4
 				LeftColor: 4D4131
 				RightColor: 3A3227
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 213046
 				RightColor: 1B2129
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 483E30
 				RightColor: 3D362C
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 31353B
 				RightColor: 2F2F2D
+				ZOffset: -12
+				ZRamp: 0
 	Template@724:
 		Category: Water Caves
 		Id: 724
@@ -11891,16 +17013,24 @@ Templates:
 				Height: 4
 				LeftColor: 443C30
 				RightColor: 423B30
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 253249
 				RightColor: 171E28
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 473E31
 				RightColor: 302C24
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 1D3151
 				RightColor: 1C232D
+				ZOffset: -12
+				ZRamp: 0
 	Template@725:
 		Category: Water Caves
 		Id: 725
@@ -11911,9 +17041,13 @@ Templates:
 				Height: 4
 				LeftColor: 463E32
 				RightColor: 3F382E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 1D3252
 				RightColor: 17202A
+				ZOffset: -12
+				ZRamp: 0
 	Template@726:
 		Category: Water Caves
 		Id: 726
@@ -11924,16 +17058,24 @@ Templates:
 				Height: 4
 				LeftColor: 463B2E
 				RightColor: 463E32
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 2F2F2B
 				RightColor: 2E2E2C
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				Height: 4
 				LeftColor: 504232
 				RightColor: 463E33
+				ZOffset: -12
+				ZRamp: 0
 			3: Cliff
 				LeftColor: 223553
 				RightColor: 282C2E
+				ZOffset: -12
+				ZRamp: 0
 	Template@940:
 		Category: Scrin Wreckage
 		Id: 940
@@ -11944,100 +17086,158 @@ Templates:
 				RampType: 15
 				LeftColor: 5E503E
 				RightColor: 62523D
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				RampType: 12
 				LeftColor: 756046
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				RampType: 15
 				LeftColor: 392F1B
 				RightColor: 604E38
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				RampType: 4
 				LeftColor: 453927
 				RightColor: 614F38
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				RampType: 7
 				LeftColor: 423524
 				RightColor: 5B4C38
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				RampType: 8
 				LeftColor: 564732
 				RightColor: 6E5A40
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				RampType: 12
 				LeftColor: 705A3F
 				RightColor: 6F5B43
+				ZOffset: -12
+				ZRamp: 0
 			12: Clear
 				RampType: 3
 				LeftColor: 2A2414
 				RightColor: 2A2413
+				ZOffset: -12
+				ZRamp: 0
 			13: Rough
 				LeftColor: 342B1C
 				RightColor: 2F2716
+				ZOffset: -12
+				ZRamp: 0
 			14: Rough
 				LeftColor: 2F2717
 				RightColor: 2E2313
+				ZOffset: -12
+				ZRamp: 0
 			15: Rough
 				LeftColor: 423321
 				RightColor: 52412D
+				ZOffset: -12
+				ZRamp: 0
 			16: Clear
 				RampType: 1
 				LeftColor: 594531
 				RightColor: 423626
+				ZOffset: -12
+				ZRamp: 0
 			18: Clear
 				RampType: 3
 				LeftColor: 2C2617
 				RightColor: 2A2617
+				ZOffset: -12
+				ZRamp: 0
 			19: Rough
 				LeftColor: 3C3323
 				RightColor: 332B1C
+				ZOffset: -12
+				ZRamp: 0
 			20: Rough
 				LeftColor: 2E281B
 				RightColor: 493B2B
+				ZOffset: -12
+				ZRamp: 0
 			21: Rough
 				LeftColor: 433928
 				RightColor: 453928
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: 312B1E
 				RightColor: 2A2415
+				ZOffset: -12
+				ZRamp: 0
 			24: Cliff
 				RampType: 14
 				LeftColor: 332B1B
 				RightColor: 251F10
+				ZOffset: -12
+				ZRamp: 0
 			25: Cliff
 				LeftColor: 1B170B
 				RightColor: 332D1D
+				ZOffset: -12
+				ZRamp: 0
 			26: Rough
 				LeftColor: 2D2818
 				RightColor: 4C3F2D
+				ZOffset: -12
+				ZRamp: 0
 			27: Rough
 				LeftColor: 493D2C
 				RightColor: 3B3425
+				ZOffset: -12
+				ZRamp: 0
 			28: Cliff
 				LeftColor: 322C23
 				RightColor: 171613
+				ZOffset: -12
+				ZRamp: 0
 			32: Cliff
 				LeftColor: 1C190B
 				RightColor: 1D1A0D
+				ZOffset: -12
+				ZRamp: 0
 			33: Cliff
 				LeftColor: 1E1A0D
 				RightColor: 282515
+				ZOffset: -12
+				ZRamp: 0
 			34: Cliff
 				LeftColor: 2B2518
 				RightColor: 2A251F
+				ZOffset: -12
+				ZRamp: 0
 			35: Cliff
 				LeftColor: 1A1815
 				RightColor: 2D2820
+				ZOffset: -12
+				ZRamp: 0
 			39: Cliff
 				LeftColor: 493E2E
 				RightColor: 29271A
+				ZOffset: -12
+				ZRamp: 0
 			40: Cliff
 				LeftColor: 2B281C
 				RightColor: 222017
+				ZOffset: -12
+				ZRamp: 0
 			41: Cliff
 				LeftColor: 29271F
 				RightColor: 222019
+				ZOffset: -12
+				ZRamp: 0
 	Template@941:
 		Category: Scrin Wreckage
 		Id: 941
@@ -12048,56 +17248,84 @@ Templates:
 				RampType: 11
 				LeftColor: 5E4D39
 				RightColor: 675640
+				ZOffset: -12
+				ZRamp: 0
 			2: Clear
 				RampType: 12
 				LeftColor: 705E47
 				RightColor: 705B42
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				RampType: 11
 				LeftColor: 5A4B38
 				RightColor: 6A5740
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				RampType: 4
 				LeftColor: 574835
 				RightColor: 685640
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				RampType: 11
 				LeftColor: 504332
 				RightColor: 5E4E3B
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				RampType: 7
 				LeftColor: 69553F
 				RightColor: 6D5740
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				RampType: 8
 				LeftColor: 64533D
 				RightColor: 68563F
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				RampType: 3
 				LeftColor: 3E3321
 				RightColor: 483B29
+				ZOffset: -12
+				ZRamp: 0
 			11: Rough
 				LeftColor: 342D1B
 				RightColor: 423725
+				ZOffset: -12
+				ZRamp: 0
 			12: Rough
 				LeftColor: 362F1E
 				RightColor: 3F3524
+				ZOffset: -12
+				ZRamp: 0
 			15: Clear
 				RampType: 10
 				LeftColor: 69543C
 				RightColor: 5A4833
+				ZOffset: -12
+				ZRamp: 0
 			16: Clear
 				RampType: 2
 				LeftColor: 584732
 				RightColor: 292314
+				ZOffset: -12
+				ZRamp: 0
 			17: Clear
 				RampType: 6
 				LeftColor: 272217
 				RightColor: 252113
+				ZOffset: -12
+				ZRamp: 0
 			22: Clear
 				RampType: 10
 				LeftColor: 675843
 				RightColor: 504330
+				ZOffset: -12
+				ZRamp: 0
 	Template@942:
 		Category: Scrin Wreckage
 		Id: 942
@@ -12107,147 +17335,239 @@ Templates:
 			0: DirtRoad
 				LeftColor: 906F48
 				RightColor: 7E6342
+				ZOffset: -12
+				ZRamp: 0
 			1: DirtRoad
 				LeftColor: 8B6D4A
 				RightColor: 79644E
+				ZOffset: -12
+				ZRamp: 0
 			2: DirtRoad
 				LeftColor: 816F5E
 				RightColor: 564A3A
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 554734
 				RightColor: 675642
+				ZOffset: -12
+				ZRamp: 0
 			9: DirtRoad
 				LeftColor: 7F6444
 				RightColor: 8A6944
+				ZOffset: -12
+				ZRamp: 0
 			10: DirtRoad
 				LeftColor: 886945
 				RightColor: 977349
+				ZOffset: -12
+				ZRamp: 0
 			11: DirtRoad
 				LeftColor: 927049
 				RightColor: 98744A
+				ZOffset: -12
+				ZRamp: 0
 			12: Clear
 				LeftColor: 5E4C37
 				RightColor: 4D3F2F
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 463C2F
 				RightColor: 5D4C38
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: 625443
 				RightColor: 6E583D
+				ZOffset: -12
+				ZRamp: 0
 			19: DirtRoad
 				LeftColor: 5F5240
 				RightColor: 7F6A50
+				ZOffset: -12
+				ZRamp: 0
 			20: Clear
 				LeftColor: 675946
 				RightColor: 96734B
+				ZOffset: -12
+				ZRamp: 0
 			21: DirtRoad
 				LeftColor: 97744C
 				RightColor: 7B6144
+				ZOffset: -12
+				ZRamp: 0
 			22: Clear
 				LeftColor: 886D4D
 				RightColor: 856B4D
+				ZOffset: -12
+				ZRamp: 0
 			23: Clear
 				LeftColor: 846D51
 				RightColor: 6C563B
+				ZOffset: -12
+				ZRamp: 0
 			24: Clear
 				LeftColor: 574935
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			28: DirtRoad
 				LeftColor: 70593E
 				RightColor: 5D5242
+				ZOffset: -12
+				ZRamp: 0
 			29: DirtRoad
 				LeftColor: 77654D
 				RightColor: 5D5344
+				ZOffset: -12
+				ZRamp: 0
 			30: Clear
 				LeftColor: 98764E
 				RightColor: 9E7B50
+				ZOffset: -12
+				ZRamp: 0
 			31: DirtRoad
 				LeftColor: 9C7B52
 				RightColor: 98784E
+				ZOffset: -12
+				ZRamp: 0
 			32: Clear
 				LeftColor: 8B765B
 				RightColor: 806C53
+				ZOffset: -12
+				ZRamp: 0
 			33: Clear
 				LeftColor: 856E55
 				RightColor: 715E49
+				ZOffset: -12
+				ZRamp: 0
 			38: Clear
 				LeftColor: 765E42
 				RightColor: 82694C
+				ZOffset: -12
+				ZRamp: 0
 			39: DirtRoad
 				LeftColor: 92704A
 				RightColor: 97754D
+				ZOffset: -12
+				ZRamp: 0
 			40: DirtRoad
 				LeftColor: 9D794F
 				RightColor: 9E7C54
+				ZOffset: -12
+				ZRamp: 0
 			41: DirtRoad
 				LeftColor: 99754B
 				RightColor: 8D6F4E
+				ZOffset: -12
+				ZRamp: 0
 			42: Clear
 				LeftColor: 917451
 				RightColor: 796247
+				ZOffset: -12
+				ZRamp: 0
 			47: Clear
 				LeftColor: 604C35
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			48: DirtRoad
 				LeftColor: 745D41
 				RightColor: 8C6D4A
+				ZOffset: -12
+				ZRamp: 0
 			49: DirtRoad
 				LeftColor: 92714A
 				RightColor: 997750
+				ZOffset: -12
+				ZRamp: 0
 			50: DirtRoad
 				LeftColor: 856B4C
 				RightColor: 8F704C
+				ZOffset: -12
+				ZRamp: 0
 			51: Rough
 				LeftColor: 433829
 				RightColor: 7F6C4B
+				ZOffset: -12
+				ZRamp: 0
 			52: Cliff
 				LeftColor: 705E49
 				RightColor: 68553D
+				ZOffset: -12
+				ZRamp: 0
 			56: Cliff
 				LeftColor: 332A19
 				RightColor: 453828
+				ZOffset: -12
+				ZRamp: 0
 			57: Clear
 				LeftColor: 70593D
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			58: Clear
 				LeftColor: 6F593E
 				RightColor: 836644
+				ZOffset: -12
+				ZRamp: 0
 			59: Clear
 				LeftColor: 7F6343
 				RightColor: 685B4D
+				ZOffset: -12
+				ZRamp: 0
 			60: Cliff
 				LeftColor: 735E44
 				RightColor: 8C775B
+				ZOffset: -12
+				ZRamp: 0
 			61: Cliff
 				LeftColor: 7B6C57
 				RightColor: 675846
+				ZOffset: -12
+				ZRamp: 0
 			65: Cliff
 				LeftColor: 161411
 				RightColor: 221F15
+				ZOffset: -12
+				ZRamp: 0
 			66: Clear
 				RampType: 2
 				LeftColor: 27241C
 				RightColor: 1A1A18
+				ZOffset: -12
+				ZRamp: 0
 			67: Clear
 				RampType: 2
 				LeftColor: 6F583D
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			68: Clear
 				RampType: 2
 				LeftColor: 6F583D
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			69: Cliff
 				RampType: 2
 				LeftColor: 6F583D
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			70: Cliff
 				RampType: 2
 				LeftColor: 6F583D
 				RightColor: 604E36
+				ZOffset: -12
+				ZRamp: 0
 			71: Cliff
 				RampType: 9
 				LeftColor: 3D3426
 				RightColor: 5F4D38
+				ZOffset: -12
+				ZRamp: 0
 	Template@943:
 		Category: Scrin Wreckage
 		Id: 943
@@ -12257,27 +17577,43 @@ Templates:
 			0: Rough
 				LeftColor: 6C563D
 				RightColor: 574734
+				ZOffset: -12
+				ZRamp: 0
 			18: Rough
 				LeftColor: 705A40
 				RightColor: 645440
+				ZOffset: -12
+				ZRamp: 0
 			28: Cliff
 				LeftColor: 6E5A42
 				RightColor: 594934
+				ZOffset: -12
+				ZRamp: 0
 			29: Cliff
 				LeftColor: 413726
 				RightColor: 251F10
+				ZOffset: -12
+				ZRamp: 0
 			37: Cliff
 				LeftColor: 715A3F
 				RightColor: 473C2C
+				ZOffset: -12
+				ZRamp: 0
 			38: Cliff
 				LeftColor: 483E2E
 				RightColor: 252111
+				ZOffset: -12
+				ZRamp: 0
 			46: Clear
 				LeftColor: 745F46
 				RightColor: 765F44
+				ZOffset: -12
+				ZRamp: 0
 			47: Cliff
 				LeftColor: 6F5A41
 				RightColor: 514534
+				ZOffset: -12
+				ZRamp: 0
 	Template@944:
 		Category: Scrin Wreckage
 		Id: 944
@@ -12287,114 +17623,188 @@ Templates:
 			2: Clear
 				LeftColor: 2C271F
 				RightColor: 1D1A16
+				ZOffset: -12
+				ZRamp: 0
 			3: Clear
 				LeftColor: 141513
 				RightColor: 1C1A15
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 1B1E21
 				RightColor: 24231D
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 27251D
 				RightColor: 1F1C14
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 272319
 				RightColor: 20201D
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 26231E
 				RightColor: 353024
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 1A1815
 				RightColor: 29251F
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 1E1C17
 				RightColor: 171513
+				ZOffset: -12
+				ZRamp: 0
 			12: Clear
 				LeftColor: 262420
 				RightColor: 1B1B1A
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 161513
 				RightColor: 1E2224
+				ZOffset: -12
+				ZRamp: 0
 			14: Clear
 				LeftColor: 242624
 				RightColor: 343738
+				ZOffset: -12
+				ZRamp: 0
 			15: Clear
 				LeftColor: 3E4C5C
 				RightColor: 1D2022
+				ZOffset: -12
+				ZRamp: 0
 			16: Cliff
 				LeftColor: 493E2E
 				RightColor: 2B271B
+				ZOffset: -12
+				ZRamp: 0
 			17: Cliff
 				LeftColor: 2B281C
 				RightColor: 27241B
+				ZOffset: -12
+				ZRamp: 0
 			18: Cliff
 				LeftColor: 29271F
 				RightColor: 222019
+				ZOffset: -12
+				ZRamp: 0
 			19: Clear
 				LeftColor: 2A2823
 				RightColor: 1E1C18
+				ZOffset: -12
+				ZRamp: 0
 			20: Clear
 				LeftColor: 1A1916
 				RightColor: 302C25
+				ZOffset: -12
+				ZRamp: 0
 			21: Clear
 				LeftColor: 352F26
 				RightColor: 1B1811
+				ZOffset: -12
+				ZRamp: 0
 			22: Clear
 				LeftColor: 544838
 				RightColor: 464037
+				ZOffset: -12
+				ZRamp: 0
 			23: Clear
 				LeftColor: 514D46
 				RightColor: 3E3D3A
+				ZOffset: -12
+				ZRamp: 0
 			24: Clear
 				LeftColor: 715C42
 				RightColor: 745E43
+				ZOffset: -12
+				ZRamp: 0
 			25: Clear
 				LeftColor: 755E43
 				RightColor: 5A4933
+				ZOffset: -12
+				ZRamp: 0
 			26: Cliff
 				LeftColor: 655139
 				RightColor: 2D2A1F
+				ZOffset: -12
+				ZRamp: 0
 			27: Cliff
 				LeftColor: 26251E
 				RightColor: 2C2C28
+				ZOffset: -12
+				ZRamp: 0
 			28: Clear
 				LeftColor: 33322E
 				RightColor: 31302C
+				ZOffset: -12
+				ZRamp: 0
 			29: Clear
 				LeftColor: 2D2B24
 				RightColor: 181915
+				ZOffset: -12
+				ZRamp: 0
 			30: Cliff
 				LeftColor: 2A3039
 				RightColor: 262523
+				ZOffset: -12
+				ZRamp: 0
 			31: Cliff
 				LeftColor: 1B180F
 				RightColor: 393227
+				ZOffset: -12
+				ZRamp: 0
 			34: Clear
 				LeftColor: 6F5A40
 				RightColor: 6B563D
+				ZOffset: -12
+				ZRamp: 0
 			35: Cliff
 				LeftColor: 6F5A3F
 				RightColor: 473D2E
+				ZOffset: -12
+				ZRamp: 0
 			36: Cliff
 				LeftColor: 584A3A
 				RightColor: 4E4537
+				ZOffset: -12
+				ZRamp: 0
 			37: Cliff
 				LeftColor: 484034
 				RightColor: 55524D
+				ZOffset: -12
+				ZRamp: 0
 			38: Cliff
 				LeftColor: 73706F
 				RightColor: 454646
+				ZOffset: -12
+				ZRamp: 0
 			39: Cliff
 				LeftColor: 463A26
 				RightColor: 2E2614
+				ZOffset: -12
+				ZRamp: 0
 			45: Cliff
 				LeftColor: 715A3F
 				RightColor: 544530
+				ZOffset: -12
+				ZRamp: 0
 			46: Cliff
 				LeftColor: 5B4B36
 				RightColor: 635543
+				ZOffset: -12
+				ZRamp: 0
 			47: Cliff
 				LeftColor: 5B554C
 				RightColor: 544F48
+				ZOffset: -12
+				ZRamp: 0
 	Template@945:
 		Category: Scrin Wreckage
 		Id: 945
@@ -12404,144 +17814,238 @@ Templates:
 			0: Cliff
 				LeftColor: 61503C
 				RightColor: 614F3A
+				ZOffset: -12
+				ZRamp: 0
 			7: Cliff
 				LeftColor: 463E2F
 				RightColor: 453B2C
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 4B4336
 				RightColor: 745E43
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 111314
 				RightColor: 2A271F
+				ZOffset: -12
+				ZRamp: 0
 			15: Cliff
 				LeftColor: 4F412E
 				RightColor: 4E4230
+				ZOffset: -12
+				ZRamp: 0
 			16: Cliff
 				LeftColor: 53442F
 				RightColor: 65533B
+				ZOffset: -12
+				ZRamp: 0
 			17: Rough
 				LeftColor: 5A4C3A
 				RightColor: 5F4E39
+				ZOffset: -12
+				ZRamp: 0
 			21: Cliff
 				LeftColor: 2D3748
 				RightColor: 393C3C
+				ZOffset: -12
+				ZRamp: 0
 			22: Cliff
 				LeftColor: 4C4334
 				RightColor: 4F402E
+				ZOffset: -12
+				ZRamp: 0
 			23: Cliff
 				LeftColor: 5F4E39
 				RightColor: 55452F
+				ZOffset: -12
+				ZRamp: 0
 			24: Cliff
 				LeftColor: 564631
 				RightColor: 372F20
+				ZOffset: -12
+				ZRamp: 0
 			25: Rough
 				LeftColor: 473A27
 				RightColor: 6B573F
+				ZOffset: -12
+				ZRamp: 0
 			28: Cliff
 				LeftColor: 484133
 				RightColor: 635C58
+				ZOffset: -12
+				ZRamp: 0
 			29: Cliff
 				LeftColor: 80684E
 				RightColor: 65523E
+				ZOffset: -12
+				ZRamp: 0
 			30: Cliff
 				LeftColor: 65513A
 				RightColor: 63513C
+				ZOffset: -12
+				ZRamp: 0
 			31: Cliff
 				LeftColor: 6F5B44
 				RightColor: 584733
+				ZOffset: -12
+				ZRamp: 0
 			32: Cliff
 				LeftColor: 453724
 				RightColor: 3B301F
+				ZOffset: -12
+				ZRamp: 0
 			33: Rough
 				LeftColor: 544533
 				RightColor: 6F5B43
+				ZOffset: -12
+				ZRamp: 0
 			34: Clear
 				LeftColor: 6D5A42
 				RightColor: 6A553D
+				ZOffset: -12
+				ZRamp: 0
 			35: Cliff
 				LeftColor: 2E2818
 				RightColor: 262214
+				ZOffset: -12
+				ZRamp: 0
 			36: Cliff
 				LeftColor: 312A17
 				RightColor: 483C2B
+				ZOffset: -12
+				ZRamp: 0
 			37: Cliff
 				LeftColor: 453A28
 				RightColor: 5D4C38
+				ZOffset: -12
+				ZRamp: 0
 			38: Cliff
 				LeftColor: 634F38
 				RightColor: 624F38
+				ZOffset: -12
+				ZRamp: 0
 			39: Cliff
 				LeftColor: 493B29
 				RightColor: 443828
+				ZOffset: -12
+				ZRamp: 0
 			40: Rough
 				LeftColor: 3B3221
 				RightColor: 514332
+				ZOffset: -12
+				ZRamp: 0
 			41: Clear
 				LeftColor: 64533D
 				RightColor: 6D5A42
+				ZOffset: -12
+				ZRamp: 0
 			42: Cliff
 				LeftColor: 443F34
 				RightColor: 4F4637
+				ZOffset: -12
+				ZRamp: 0
 			43: Cliff
 				LeftColor: 51483A
 				RightColor: 393120
+				ZOffset: -12
+				ZRamp: 0
 			44: Cliff
 				LeftColor: 534836
 				RightColor: 2B2615
+				ZOffset: -12
+				ZRamp: 0
 			45: Cliff
 				LeftColor: 2F2917
 				RightColor: 4D3D2B
+				ZOffset: -12
+				ZRamp: 0
 			46: Cliff
 				LeftColor: 473928
 				RightColor: 453827
+				ZOffset: -12
+				ZRamp: 0
 			47: Rough
 				LeftColor: 3E3425
 				RightColor: 483D2D
+				ZOffset: -12
+				ZRamp: 0
 			48: Clear
 				LeftColor: 60503C
 				RightColor: 574935
+				ZOffset: -12
+				ZRamp: 0
 			49: Clear
 				LeftColor: 6E5A42
 				RightColor: 78644C
+				ZOffset: -12
+				ZRamp: 0
 			50: Clear
 				LeftColor: 7F6649
 				RightColor: 7D664C
+				ZOffset: -12
+				ZRamp: 0
 			51: Cliff
 				LeftColor: 6C5943
 				RightColor: 453A29
+				ZOffset: -12
+				ZRamp: 0
 			52: Cliff
 				LeftColor: 443A2A
 				RightColor: 514430
+				ZOffset: -12
+				ZRamp: 0
 			53: Cliff
 				LeftColor: 614F38
 				RightColor: 433724
+				ZOffset: -12
+				ZRamp: 0
 			54: Cliff
 				LeftColor: 53432E
 				RightColor: 5D4A35
+				ZOffset: -12
+				ZRamp: 0
 			55: Clear
 				LeftColor: 594B3A
 				RightColor: 65523C
+				ZOffset: -12
+				ZRamp: 0
 			57: Clear
 				LeftColor: 534535
 				RightColor: 61503D
+				ZOffset: -12
+				ZRamp: 0
 			58: Clear
 				LeftColor: 4D4130
 				RightColor: 4E4130
+				ZOffset: -12
+				ZRamp: 0
 			59: Clear
 				LeftColor: 473D2B
 				RightColor: 604F39
+				ZOffset: -12
+				ZRamp: 0
 			62: Clear
 				LeftColor: 69563F
 				RightColor: 5E5447
+				ZOffset: -12
+				ZRamp: 0
 			64: Clear
 				LeftColor: 6F583D
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			65: Clear
 				LeftColor: 665641
 				RightColor: 524533
+				ZOffset: -12
+				ZRamp: 0
 			66: Clear
 				LeftColor: 5B4A34
 				RightColor: 5E4C35
+				ZOffset: -12
+				ZRamp: 0
 	Template@952:
 		Category: DirtTrackTunnel Floor
 		Id: 952
@@ -12551,48 +18055,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 453625
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 453625
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 54514E
 				RightColor: 585552
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 54514D
 				RightColor: 585653
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 4A4847
 				RightColor: 4F4E4D
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 453625
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6F5A41
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 463525
 				RightColor: 453525
+				ZOffset: -12
+				ZRamp: 0
 	Template@953:
 		Category: DirtTrackTunnel Floor
 		Id: 953
@@ -12602,48 +18136,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 55524F
 				RightColor: 53514E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6D5A42
 				RightColor: 6C583E
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 555350
 				RightColor: 54514D
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 6D583E
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			12: Rail
 				LeftColor: 4C4B4A
 				RightColor: 494847
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 453525
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 	Template@954:
 		Category: DirtTrackTunnel Floor
 		Id: 954
@@ -12653,39 +18217,63 @@ Templates:
 			0: Cliff
 				LeftColor: 070707
 				RightColor: 2F2B25
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5B574F
 				RightColor: 5C5954
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6D6354
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 463525
 				RightColor: 100C09
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 4B4847
 				RightColor: 0F0F0F
+				ZOffset: -12
+				ZRamp: 0
 			7: Rail
 				LeftColor: 55524F
 				RightColor: 585552
+				ZOffset: -12
+				ZRamp: 0
 			8: Rail
 				LeftColor: 55514E
 				RightColor: 585552
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 0E0A07
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 	Template@955:
 		Category: DirtTrackTunnel Floor
 		Id: 955
@@ -12695,39 +18283,63 @@ Templates:
 			0: Cliff
 				LeftColor: 161616
 				RightColor: 2A2621
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 453625
 				RightColor: 100C09
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 4C4B4A
 				RightColor: 0E0E0E
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 453625
 				RightColor: 0E0A07
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 58544C
 				RightColor: 4D4B47
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			6: Rail
 				LeftColor: 55524F
 				RightColor: 54524F
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6F583D
 				RightColor: 706659
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			10: Rail
 				LeftColor: 54524F
 				RightColor: 54514E
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 	Template@956:
 		Category: DirtTunnel Floor
 		Id: 956
@@ -12737,48 +18349,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 453625
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 6F5A41
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 463525
 				RightColor: 453525
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 6F5A41
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 463525
 				RightColor: 453525
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 6F5A41
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 463525
 				RightColor: 453525
+				ZOffset: -12
+				ZRamp: 0
 			12: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			13: Cliff
 				LeftColor: 6F5A41
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 463525
 				RightColor: 453525
+				ZOffset: -12
+				ZRamp: 0
 	Template@957:
 		Category: DirtTunnel Floor
 		Id: 957
@@ -12788,48 +18430,78 @@ Templates:
 			0: Cliff
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 6D5A42
 				RightColor: 6C583E
+				ZOffset: -12
+				ZRamp: 0
 			5: Cliff
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			9: Cliff
 				LeftColor: 6D583E
 				RightColor: 6C5840
+				ZOffset: -12
+				ZRamp: 0
 			10: Cliff
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			12: Clear
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			13: Clear
 				LeftColor: 463525
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			14: Cliff
 				LeftColor: 453525
 				RightColor: 463525
+				ZOffset: -12
+				ZRamp: 0
 	Template@958:
 		Category: DirtTunnel Floor
 		Id: 958
@@ -12839,39 +18511,63 @@ Templates:
 			0: Cliff
 				LeftColor: 070707
 				RightColor: 2F2A24
+				ZOffset: -12
+				ZRamp: 0
 			1: Cliff
 				LeftColor: 5B574F
 				RightColor: 5C5954
+				ZOffset: -12
+				ZRamp: 0
 			2: Cliff
 				LeftColor: 6D6354
 				RightColor: 6F583D
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 463525
 				RightColor: 100C09
+				ZOffset: -12
+				ZRamp: 0
 			4: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			6: Road
 				LeftColor: 463525
 				RightColor: 0D0A07
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			8: Clear
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 			9: Road
 				LeftColor: 0E0A07
 				RightColor: 453625
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 705C43
 				RightColor: 6D583F
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 6D583E
 				RightColor: 6E5940
+				ZOffset: -12
+				ZRamp: 0
 	Template@959:
 		Category: DirtTunnel Floor
 		Id: 959
@@ -12881,36 +18577,60 @@ Templates:
 			0: Cliff
 				LeftColor: 161616
 				RightColor: 2A2620
+				ZOffset: -12
+				ZRamp: 0
 			1: Road
 				LeftColor: 453625
 				RightColor: 100C09
+				ZOffset: -12
+				ZRamp: 0
 			2: Road
 				LeftColor: 453625
 				RightColor: 0E0A07
+				ZOffset: -12
+				ZRamp: 0
 			3: Road
 				LeftColor: 453625
 				RightColor: 0E0A07
+				ZOffset: -12
+				ZRamp: 0
 			4: Cliff
 				LeftColor: 58544C
 				RightColor: 4D4B47
+				ZOffset: -12
+				ZRamp: 0
 			5: Clear
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			6: Clear
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			7: Clear
 				LeftColor: 6D583F
 				RightColor: 705C43
+				ZOffset: -12
+				ZRamp: 0
 			8: Cliff
 				LeftColor: 6F583D
 				RightColor: 706659
+				ZOffset: -12
+				ZRamp: 0
 			9: Clear
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			10: Clear
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0
 			11: Clear
 				LeftColor: 6E5940
 				RightColor: 6D583E
+				ZOffset: -12
+				ZRamp: 0


### PR DESCRIPTION
This adds support for per-tile Z-ramp and Z-offsets to the tileset code and gen2 tileset importer.  The TS tilesets are reimported with proper values.

The defaults are set up so that tiles without any extra depth metadata will be "flat" at ground level – the test commit enables this in RA for illustration.  The TS tilesets are set up so that tile tile depths are correctly zeroed at the middle of the tile.

The expected behaviour is (for mods with `EnableDepth: true`) for sprite data to be cut off for all y < CenterPosition.Y, because for flat sprites with Z = CenterPosition.Z anything lower is rendered behind the terrain.  A future PR that adds support for sprite depth maps will fix that.  This puts the ground work in place by setting the correct terrain depth.
