### PR TITLE
Fix PixelDoubling not working properly after zooming with mousewheel

### DIFF
--- a/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Game/Widgets/WorldInteractionControllerWidget.cs
@@ -345,8 +345,16 @@ namespace OpenRA.Widgets
 
 		bool TogglePixelDouble()
 		{
-			Game.Settings.Graphics.PixelDouble ^= true;
-			worldRenderer.Viewport.Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
+			if (worldRenderer.Viewport.Zoom == 1f)
+				worldRenderer.Viewport.Zoom = 2f;
+			else
+			{
+				// Reset zoom to regular view if it was anything else before
+				// (like a zoom level only reachable by using the scroll wheel).
+				worldRenderer.Viewport.Zoom = 1f;
+			}
+
+			Game.Settings.Graphics.PixelDouble = worldRenderer.Viewport.Zoom == 2f;
 
 			return true;
 		}


### PR DESCRIPTION
I decided to write it this way (instead of setting `Game.Settings.Graphics.PixelDouble` in `Viewport.Zoom` appropriately) because I see the double pixel setting as the user's preference that the game uses at the start of a match and which should not be changed only because the user decided to zoom in a bit.
