### PR TITLE
Fixed NullReferenceExceptions if package opening fails.

### DIFF
--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -486,8 +486,13 @@ namespace OpenRA
 						Game.RunAfterTick(() =>
 						{
 							var package = modData.ModFiles.OpenPackage(mapFilename, mapInstallPackage);
-							UpdateFromMap(package, mapInstallPackage, MapClassification.User, null, GridType);
-							onSuccess();
+							if (package == null)
+								innerData.Status = MapStatus.DownloadError;
+							else
+							{
+								UpdateFromMap(package, mapInstallPackage, MapClassification.User, null, GridType);
+								onSuccess();
+							}
 						});
 					};
 


### PR DESCRIPTION
`OpenPackage` explicitly returns null if the file suffixes don't match .zip or .oramap, which I assume doesn't happen very often in practice, but Coverity is right, that this should not crash here.
