### PR TITLE
Removed redundant targetPassedBy check.

### DIFF
--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -642,7 +642,7 @@ namespace OpenRA.Mods.Common.Effects
 							else
 							{
 								// Aim for the target
-								var vDist = new WVec(-relTarHgt, -relTarHorDist * (targetPassedBy ? -1 : 1), 0);
+								var vDist = new WVec(-relTarHgt, -relTarHorDist, 0);
 								desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
 								if (desiredVFacing < 0 && info.VerticalRateOfTurn < (sbyte)vFacing)
 									desiredVFacing = 0;


### PR DESCRIPTION
This is probably a copy & paste mistake as you can see the identical block a few lines below in another conditional. In line 599 the whole block is already checking against `targetPassedBy` so Coverity is right that it can never be true and therefore only introduces dead code.
