### PR TITLE
Add support for playing a "LoseNotification" to the old owner through CaptureNotification

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
@@ -15,7 +15,10 @@ namespace OpenRA.Mods.Common.Traits.Sound
 {
 	public class CaptureNotificationInfo : ITraitInfo
 	{
+		[Desc("The speech notification to play to the new owner.")]
 		public readonly string Notification = "BuildingCaptured";
+
+		[Desc("Specifies if Notification is played with the voice of the new owners faction.")]
 		public readonly bool NewOwnerVoice = true;
 
 		public object Create(ActorInitializer init) { return new CaptureNotification(this); }

--- a/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
@@ -21,6 +21,12 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Specifies if Notification is played with the voice of the new owners faction.")]
 		public readonly bool NewOwnerVoice = true;
 
+		[Desc("The speech notification to play to the old owner.")]
+		public readonly string LoseNotification = null;
+
+		[Desc("Specifies if LoseNotification is played with the voice of the new owners faction.")]
+		public readonly bool LoseNewOwnerVoice = false;
+
 		public object Create(ActorInitializer init) { return new CaptureNotification(this); }
 	}
 
@@ -36,6 +42,9 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		{
 			var faction = info.NewOwnerVoice ? newOwner.Faction.InternalName : oldOwner.Faction.InternalName;
 			Game.Sound.PlayNotification(self.World.Map.Rules, newOwner, "Speech", info.Notification, faction);
+
+			var loseFaction = info.LoseNewOwnerVoice ? newOwner.Faction.InternalName : oldOwner.Faction.InternalName;
+			Game.Sound.PlayNotification(self.World.Map.Rules, oldOwner, "Speech", info.LoseNotification, loseFaction);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 	public class CaptureNotification : INotifyCapture
 	{
-		CaptureNotificationInfo info;
+		readonly CaptureNotificationInfo info;
 		public CaptureNotification(CaptureNotificationInfo info)
 		{
 			this.info = info;
@@ -31,11 +31,8 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
 		{
-			if (captor.World.LocalPlayer != captor.Owner)
-				return;
-
 			var faction = info.NewOwnerVoice ? newOwner.Faction.InternalName : oldOwner.Faction.InternalName;
-			Game.Sound.PlayNotification(self.World.Map.Rules, captor.World.LocalPlayer, "Speech", info.Notification, faction);
+			Game.Sound.PlayNotification(self.World.Map.Rules, newOwner, "Speech", info.Notification, faction);
 		}
 	}
 }


### PR DESCRIPTION
We want this for at least ra2: https://github.com/OpenRA/ra2/pull/187#discussion_r59159963

The default being `null` won't cause trouble as `PlayNotification` already catches that.
