### PR TITLE
Generate frozen actor renderables for all map-placed actors.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -20,8 +20,6 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This actor will remain visible (but not updated visually) under fog, once discovered.")]
 	public class FrozenUnderFogInfo : ITraitInfo, Requires<BuildingInfo>, IDefaultVisibilityInfo
 	{
-		public readonly bool StartsRevealed = false;
-
 		[Desc("Players with these stances can always see the actor.")]
 		public readonly Stance AlwaysVisibleStances = Stance.Ally;
 
@@ -55,8 +53,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			var map = init.World.Map;
 
-			// Spawned actors (e.g. building husks) shouldn't be revealed
-			startsRevealed = info.StartsRevealed && !init.Contains<ParentActorInit>();
+			// Explore map-placed actors if the "Explore Map" option is enabled
+			var exploredMap = !init.World.LobbyInfo.GlobalSettings.Shroud;
+			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>() && !init.Contains<HiddenUnderFogInit>();
 			var footprintCells = FootprintUtils.Tiles(init.Self).ToList();
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
 		}
@@ -142,4 +141,6 @@ namespace OpenRA.Mods.Common.Traits
 			return IsVisible(self, self.World.RenderPlayer) || isRendering ? r : SpriteRenderable.None;
 		}
 	}
+
+	public class HiddenUnderFogInit : IActorInit { }
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -140,6 +140,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), () => adjacent);
 			UpdateNeighbours(self);
+
+			// Set the initial animation frame before the render tick (for frozen actor previews)
+			self.World.AddFrameEndTask(_ => DefaultAnimation.Tick());
 		}
 
 		static void UpdateNeighbours(Actor self)

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -37,6 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var initDict = actorReference.InitDict;
 				initDict.Add(new SkipMakeAnimsInit());
+				initDict.Add(new SpawnedByMapInit(kv.Key));
 				var actor = world.CreateActor(actorReference.Type, initDict);
 				Actors[kv.Key] = actor;
 				LastMapActorID = actor.ActorID;
@@ -45,4 +46,14 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class SkipMakeAnimsInit : IActorInit, ISuppressInitExport { }
+	public class SpawnedByMapInit : IActorInit<string>, ISuppressInitExport
+	{
+		public readonly string Name;
+		public SpawnedByMapInit(string name) { Name = name; }
+
+		public string Value(World world)
+		{
+			return Name;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -770,6 +770,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20160418)
+				{
+					// Removed FrozenUnderFog.StartsRevealed
+					if (node.Key == "FrozenUnderFog")
+						node.Value.Nodes.RemoveAll(x => x.Key == "StartsRevealed");
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -518,7 +518,6 @@
 		GenericStancePrefix: false
 		ShowOwnerRow: false
 	FrozenUnderFog:
-		StartsRevealed: true
 
 ^CivBuildingHusk:
 	Inherits@1: ^SpriteActor
@@ -532,7 +531,6 @@
 		GenericStancePrefix: false
 		ShowOwnerRow: false
 	FrozenUnderFog:
-		StartsRevealed: true
 	ScriptTriggers:
 
 ^TechBuilding:
@@ -571,7 +569,6 @@
 		Palette: terrain
 	WithSpriteBody:
 	FrozenUnderFog:
-		StartsRevealed: true
 	ScriptTriggers:
 
 ^Wall:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -521,7 +521,6 @@
 		Name: Civilian Building
 		GenericVisibility: None
 	FrozenUnderFog:
-		StartsRevealed: true
 
 ^FakeBuilding:
 	Inherits: ^Building

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -607,7 +607,6 @@
 	RadarColorFromTerrain:
 		Terrain: Tiberium
 	FrozenUnderFog:
-		StartsRevealed: true
 	SeedsResource:
 		ResourceType: Tiberium
 		Interval: 55


### PR DESCRIPTION
Fixes #11080.  This is a rather obvious polish bug in the current playtest, so if there are no objections I would like to see this included in the next playtest.
