### PR TITLE
Increase ambient light level in Fort Lonestar and GDI06.

### DIFF
--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -23,7 +23,7 @@ World:
 		Red: 0.75
 		Green: 0.85
 		Blue: 1.5
-		Ambient: 0.35
+		Ambient: 0.45
 	MissionData:
 		Briefing: Use a GDI Commando to infiltrate the Nod base. **** ** destroy the ******** so that the base is incapacitated. Get in, hit it, and get the **** out.
 		BriefingVideo: gdi6.vqa

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -21,7 +21,7 @@ World:
 		Red: 0.75
 		Green: 0.85
 		Blue: 1.5
-		Ambient: 0.35
+		Ambient: 0.45
 	MusicPlaylist:
 		BackgroundMusic: rain
 	FlashPaletteEffect@LIGHTNINGSTRIKE:


### PR DESCRIPTION
Fort Lonestar being too dark is a common complaint that i've seen in game streams and other channels.  This bumps the light levels a bit in Lonestar and GDI06 to help improve this situation without affecting the ambient feeling _too_ much.

Fixes #9939.
