### PR TITLE
Fix the length of the idle2 sequence of tanya

### DIFF
--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -725,7 +725,7 @@ e7:
 		Tick: 120
 	idle2:
 		Start: 248
-		Length: 15
+		Length: 14
 		Tick: 120
 	die1:
 		Start: 262


### PR DESCRIPTION
Had a wrong frame in the end (tanya held her hands up 🙌 ):
![tanyaidle](https://cloud.githubusercontent.com/assets/7704140/14650775/5fa9d638-066d-11e6-8d42-3cedd40ef102.gif)
