### PR TITLE
Use Contains method on Selection when possible.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -192,7 +192,7 @@ namespace OpenRA.Graphics
 			{
 				foreach (var g in World.ActorsHavingTrait<Selectable>().Where(a => !a.Disposed
 					&& !World.FogObscures(a)
-					&& !World.Selection.Actors.Contains(a)))
+					&& !World.Selection.Contains(a)))
 				{
 					if (Game.Settings.Game.StatusBars == StatusBarsType.Standard)
 						new SelectionBarsRenderable(g, false, false).Render(this);

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!building.IsInWorld || !building.Owner.IsAlliedWith(building.World.LocalPlayer))
 				return SpriteRenderable.None;
 
-			if (!building.World.Selection.Actors.Contains(building))
+			if (!building.World.Selection.Contains(building))
 				return SpriteRenderable.None;
 
 			return RenderInner(wr);

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			var next = bases
-				.SkipWhile(b => !world.Selection.Actors.Contains(b))
+				.SkipWhile(b => !world.Selection.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 
@@ -240,7 +240,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return true;
 
 			var next = facilities
-				.SkipWhile(b => !world.Selection.Actors.Contains(b))
+				.SkipWhile(b => !world.Selection.Contains(b))
 				.Skip(1)
 				.FirstOrDefault();
 


### PR DESCRIPTION
This allows the set to be utilized for a fast check, rather than degrading to a linear search via LINQ.
