### PR TITLE
Fix the debris spawned when walls are destroyed in d2k

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -652,9 +652,9 @@ wall:
 		SellSounds: CHUNG.WAV
 	Guardable:
 	ThrowsShrapnel:
-		Weapons: Debris, Debris2, Debris3, Debris4
-		Pieces: 3, 7
-		Range: 2c0, 5c0
+		Weapons: Debris, Debris3
+		Pieces: 2, 2
+		Range: 2c0, 4c0
 
 medium_gun_turret:
 	Inherits: ^Defense


### PR DESCRIPTION
Looks like this on bleed:
https://www.dropbox.com/s/790kwftd2x4mfcv/d2kwalls.gif?dl=0 (File too big to upload it on github).

The debris configuration I added is taken from `^Defense`.

(Discovered by my brother, btw. ;))
