### PR TITLE
Add support for custom vertical HitShape offsets

### DIFF
--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -220,6 +220,7 @@
 	Health:
 		Shape: Circle
 			Radius: 363
+			VerticalTopOffset: 512
 
 ^BuildingPlug:
 	AlwaysVisible:
@@ -239,6 +240,7 @@
 		HP: 50
 		Shape: Circle
 			Radius: 128
+			VerticalTopOffset: 512
 	Armor:
 		Type: None
 	Valued:
@@ -564,6 +566,7 @@
 	Health:
 		Shape: Circle
 			Radius: 256
+			VerticalTopOffset: 512
 	Armor:
 		Type: Light
 	Mobile:


### PR DESCRIPTION
Makes it possible to define custom vertical top and bottom offsets for `HitShapes` relative to actor `CenterPosition`.

Split from #10383 (minus the `TargetPositions` adaption, obviously) to reduce its diff.
