### PR TITLE
Query lobby checkbox state via their owning traits.

### DIFF
--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -129,9 +129,7 @@ namespace OpenRA.Traits
 						self.Trait<PlayerResources>().GiveCash(amount);
 					}
 					else
-					{
 						self.Owner.Shroud.ResetExploration();
-					}
 
 					self.Owner.Shroud.Disabled = DisableShroud;
 					if (self.World.LocalPlayer == self.Owner)
@@ -168,10 +166,8 @@ namespace OpenRA.Traits
 				case "DevGrowResources":
 				{
 					foreach (var a in self.World.ActorsWithTrait<ISeedableResource>())
-					{
 						for (var i = 0; i < info.ResourceGrowth; i++)
 							a.Trait.Seed(a.Actor);
-					}
 
 					break;
 				}
@@ -182,6 +178,7 @@ namespace OpenRA.Traits
 					self.Owner.Shroud.Disabled = DisableShroud;
 					if (self.World.LocalPlayer == self.Owner)
 						self.World.RenderPlayer = DisableShroud ? null : self.Owner;
+
 					break;
 				}
 

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Traits
 
 						if (EnableAll)
 						{
-							self.Owner.Shroud.ExploreAll(self.World);
+							self.Owner.Shroud.ExploreAll();
 
 							var amount = order.ExtraData != 0 ? (int)order.ExtraData : info.Cash;
 							self.Trait<PlayerResources>().GiveCash(amount);
@@ -177,7 +177,7 @@ namespace OpenRA.Traits
 
 				case "DevGiveExploration":
 					{
-						self.Owner.Shroud.ExploreAll(self.World);
+						self.Owner.Shroud.ExploreAll();
 						break;
 					}
 

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -59,16 +59,26 @@ namespace OpenRA.Traits
 		public object Create(ActorInitializer init) { return new DeveloperMode(this); }
 	}
 
-	public class DeveloperMode : IResolveOrder, ISync
+	public class DeveloperMode : IResolveOrder, ISync, INotifyCreated
 	{
-		DeveloperModeInfo info;
-		[Sync] public bool FastCharge;
-		[Sync] public bool AllTech;
-		[Sync] public bool FastBuild;
-		[Sync] public bool DisableShroud;
-		[Sync] public bool PathDebug;
-		[Sync] public bool UnlimitedPower;
-		[Sync] public bool BuildAnywhere;
+		readonly DeveloperModeInfo info;
+		public bool Enabled { get; private set; }
+
+		[Sync] bool fastCharge;
+		[Sync] bool allTech;
+		[Sync] bool fastBuild;
+		[Sync] bool disableShroud;
+		[Sync] bool pathDebug;
+		[Sync] bool unlimitedPower;
+		[Sync] bool buildAnywhere;
+
+		public bool FastCharge { get { return Enabled && fastCharge; } }
+		public bool AllTech { get { return Enabled && allTech; } }
+		public bool FastBuild { get { return Enabled && fastBuild; } }
+		public bool DisableShroud { get { return Enabled && disableShroud; } }
+		public bool PathDebug { get { return Enabled && pathDebug; } }
+		public bool UnlimitedPower { get { return Enabled && unlimitedPower; } }
+		public bool BuildAnywhere { get { return Enabled && buildAnywhere; } }
 
 		// Client side only
 		public bool ShowCombatGeometry;
@@ -76,128 +86,134 @@ namespace OpenRA.Traits
 		public bool ShowDepthPreview;
 		public bool ShowActorTags;
 
-		public bool EnableAll;
+		bool enableAll;
 
 		public DeveloperMode(DeveloperModeInfo info)
 		{
 			this.info = info;
-			FastBuild = info.FastBuild;
-			FastCharge = info.FastCharge;
-			DisableShroud = info.DisableShroud;
-			PathDebug = info.PathDebug;
-			UnlimitedPower = info.UnlimitedPower;
-			BuildAnywhere = info.BuildAnywhere;
+			fastBuild = info.FastBuild;
+			fastCharge = info.FastCharge;
+			disableShroud = info.DisableShroud;
+			pathDebug = info.PathDebug;
+			unlimitedPower = info.UnlimitedPower;
+			buildAnywhere = info.BuildAnywhere;
+
 			ShowCombatGeometry = info.ShowCombatGeometry;
 			ShowDebugGeometry = info.ShowDebugGeometry;
 			ShowDepthPreview = info.ShowDepthPreview;
 			ShowActorTags = info.ShowActorTags;
 		}
 
+		void INotifyCreated.Created(Actor self)
+		{
+			Enabled = self.World.LobbyInfo.GlobalSettings.AllowCheats || self.World.LobbyInfo.IsSinglePlayer;
+		}
+
 		public void ResolveOrder(Actor self, Order order)
 		{
-			if (!self.World.AllowDevCommands)
+			if (!Enabled)
 				return;
 
 			switch (order.OrderString)
 			{
 				case "DevAll":
-					{
-						EnableAll ^= true;
-						AllTech = FastCharge = FastBuild = DisableShroud = UnlimitedPower = BuildAnywhere = EnableAll;
+				{
+					enableAll ^= true;
+					allTech = fastCharge = fastBuild = disableShroud = unlimitedPower = buildAnywhere = enableAll;
 
-						if (EnableAll)
-						{
-							self.Owner.Shroud.ExploreAll();
-
-							var amount = order.ExtraData != 0 ? (int)order.ExtraData : info.Cash;
-							self.Trait<PlayerResources>().GiveCash(amount);
-						}
-						else
-						{
-							self.Owner.Shroud.ResetExploration();
-						}
-
-						self.Owner.Shroud.Disabled = DisableShroud;
-						if (self.World.LocalPlayer == self.Owner)
-							self.World.RenderPlayer = DisableShroud ? null : self.Owner;
-
-						break;
-					}
-
-				case "DevEnableTech":
-					{
-						AllTech ^= true;
-						break;
-					}
-
-				case "DevFastCharge":
-					{
-						FastCharge ^= true;
-						break;
-					}
-
-				case "DevFastBuild":
-					{
-						FastBuild ^= true;
-						break;
-					}
-
-				case "DevGiveCash":
-					{
-						var amount = order.ExtraData != 0 ? (int)order.ExtraData : info.Cash;
-						self.Trait<PlayerResources>().GiveCash(amount);
-						break;
-					}
-
-				case "DevGrowResources":
-					{
-						foreach (var a in self.World.ActorsWithTrait<ISeedableResource>())
-						{
-							for (var i = 0; i < info.ResourceGrowth; i++)
-								a.Trait.Seed(a.Actor);
-						}
-
-						break;
-					}
-
-				case "DevVisibility":
-					{
-						DisableShroud ^= true;
-						self.Owner.Shroud.Disabled = DisableShroud;
-						if (self.World.LocalPlayer == self.Owner)
-							self.World.RenderPlayer = DisableShroud ? null : self.Owner;
-						break;
-					}
-
-				case "DevPathDebug":
-					{
-						PathDebug ^= true;
-						break;
-					}
-
-				case "DevGiveExploration":
+					if (enableAll)
 					{
 						self.Owner.Shroud.ExploreAll();
-						break;
-					}
 
-				case "DevResetExploration":
+						var amount = order.ExtraData != 0 ? (int)order.ExtraData : info.Cash;
+						self.Trait<PlayerResources>().GiveCash(amount);
+					}
+					else
 					{
 						self.Owner.Shroud.ResetExploration();
-						break;
 					}
+
+					self.Owner.Shroud.Disabled = DisableShroud;
+					if (self.World.LocalPlayer == self.Owner)
+						self.World.RenderPlayer = DisableShroud ? null : self.Owner;
+
+					break;
+				}
+
+				case "DevEnableTech":
+				{
+					allTech ^= true;
+					break;
+				}
+
+				case "DevFastCharge":
+				{
+					fastCharge ^= true;
+					break;
+				}
+
+				case "DevFastBuild":
+				{
+					fastBuild ^= true;
+					break;
+				}
+
+				case "DevGiveCash":
+				{
+					var amount = order.ExtraData != 0 ? (int)order.ExtraData : info.Cash;
+					self.Trait<PlayerResources>().GiveCash(amount);
+					break;
+				}
+
+				case "DevGrowResources":
+				{
+					foreach (var a in self.World.ActorsWithTrait<ISeedableResource>())
+					{
+						for (var i = 0; i < info.ResourceGrowth; i++)
+							a.Trait.Seed(a.Actor);
+					}
+
+					break;
+				}
+
+				case "DevVisibility":
+				{
+					disableShroud ^= true;
+					self.Owner.Shroud.Disabled = DisableShroud;
+					if (self.World.LocalPlayer == self.Owner)
+						self.World.RenderPlayer = DisableShroud ? null : self.Owner;
+					break;
+				}
+
+				case "DevPathDebug":
+				{
+					pathDebug ^= true;
+					break;
+				}
+
+				case "DevGiveExploration":
+				{
+					self.Owner.Shroud.ExploreAll();
+					break;
+				}
+
+				case "DevResetExploration":
+				{
+					self.Owner.Shroud.ResetExploration();
+					break;
+				}
 
 				case "DevUnlimitedPower":
-					{
-						UnlimitedPower ^= true;
-						break;
-					}
+				{
+					unlimitedPower ^= true;
+					break;
+				}
 
 				case "DevBuildAnywhere":
-					{
-						BuildAnywhere ^= true;
-						break;
-					}
+				{
+					buildAnywhere ^= true;
+					break;
+				}
 
 				default:
 					return;

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Traits
 		public object Create(ActorInitializer init) { return new Shroud(init.Self); }
 	}
 
-	public class Shroud : ISync
+	public class Shroud : ISync, INotifyCreated
 	{
 		public event Action<IEnumerable<PPos>> CellsChanged;
 
@@ -77,6 +77,12 @@ namespace OpenRA.Traits
 			visibleCount = new CellLayer<short>(map);
 			generatedShroudCount = new CellLayer<short>(map);
 			explored = new CellLayer<bool>(map);
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			if (!self.World.LobbyInfo.GlobalSettings.Shroud)
+				self.World.AddFrameEndTask(w => ExploreAll());
 		}
 
 		void Invalidate(IEnumerable<PPos> changed)
@@ -241,7 +247,7 @@ namespace OpenRA.Traits
 			Invalidate(changed);
 		}
 
-		public void ExploreAll(World world)
+		public void ExploreAll()
 		{
 			var changed = new List<PPos>();
 			foreach (var puv in map.ProjectedCellBounds)

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -67,6 +67,9 @@ namespace OpenRA.Traits
 			}
 		}
 
+		bool fogEnabled;
+		public bool FogEnabled { get { return !Disabled && fogEnabled; } }
+
 		public int Hash { get; private set; }
 
 		public Shroud(Actor self)
@@ -81,7 +84,9 @@ namespace OpenRA.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			if (!self.World.LobbyInfo.GlobalSettings.Shroud)
+			fogEnabled = self.World.LobbyInfo.GlobalSettings.Fog;
+			var shroudEnabled = self.World.LobbyInfo.GlobalSettings.Shroud;
+			if (!shroudEnabled)
 				self.World.AddFrameEndTask(w => ExploreAll());
 		}
 
@@ -304,14 +309,12 @@ namespace OpenRA.Traits
 
 		public bool IsExplored(PPos puv)
 		{
-			if (!ShroudEnabled)
+			if (Disabled)
 				return map.Contains(puv);
 
 			var uv = (MPos)puv;
 			return explored.Contains(uv) && explored[uv] && (generatedShroudCount[uv] == 0 || visibleCount[uv] > 0);
 		}
-
-		public bool ShroudEnabled { get { return !Disabled; } }
 
 		public bool IsVisible(WPos pos)
 		{
@@ -344,8 +347,6 @@ namespace OpenRA.Traits
 			var uv = (MPos)puv;
 			return visibleCount.Contains(uv) && visibleCount[uv] > 0;
 		}
-
-		public bool FogEnabled { get { return !Disabled && self.World.LobbyInfo.GlobalSettings.Fog; } }
 
 		public bool Contains(PPos uv)
 		{

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -85,11 +85,6 @@ namespace OpenRA
 			get { return OrderManager.Connection is ReplayConnection; }
 		}
 
-		public bool AllowDevCommands
-		{
-			get { return LobbyInfo.GlobalSettings.AllowCheats || LobbyInfo.IsSinglePlayer; }
-		}
-
 		void SetLocalPlayer(Player localPlayer)
 		{
 			if (localPlayer == null)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -184,10 +184,6 @@ namespace OpenRA
 				MapUid = Map.Uid,
 				MapTitle = Map.Title
 			};
-
-			if (!LobbyInfo.GlobalSettings.Shroud)
-				foreach (var player in Players)
-					player.Shroud.ExploreAll(this);
 		}
 
 		public void AddToMaps(Actor self, IOccupySpace ios)

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -24,10 +24,15 @@ namespace OpenRA.Mods.Common.Commands
 	public class DevCommands : IChatCommand, IWorldLoaded
 	{
 		World world;
+		DeveloperMode developerMode;
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			world = w;
+
+			if (world.LocalPlayer != null)
+				developerMode = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
+
 			var console = world.WorldActor.Trait<ChatCommands>();
 			var help = world.WorldActor.Trait<HelpCommand>();
 
@@ -55,7 +60,7 @@ namespace OpenRA.Mods.Common.Commands
 			if (world.LocalPlayer == null)
 				return;
 
-			if (!world.AllowDevCommands)
+			if (!developerMode.Enabled)
 			{
 				Game.Debug("Cheats are disabled.");
 				return;

--- a/OpenRA.Mods.Common/PlayerExtensions.cs
+++ b/OpenRA.Mods.Common/PlayerExtensions.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Common
 	{
 		public static bool HasNoRequiredUnits(this Player player)
 		{
-			if (player.World.LobbyInfo.GlobalSettings.ShortGame)
+			var mapOptions = player.World.WorldActor.Trait<MapOptions>();
+			if (mapOptions.ShortGame)
 				return !player.World.ActorsHavingTrait<MustBeDestroyed>(t => t.Info.RequiredForShortGame).Any(a => a.Owner == player);
 			return !player.World.ActorsHavingTrait<MustBeDestroyed>().Any(a => a.Owner == player && a.IsInWorld);
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -30,10 +30,12 @@ namespace OpenRA.Mods.Common.Traits
 	public class BaseProvider : ITick, IPostRenderSelection, ISelectionBar
 	{
 		public readonly BaseProviderInfo Info;
-		DeveloperMode devMode;
-		Actor self;
+		readonly DeveloperMode devMode;
+		readonly Actor self;
+
 		int total;
 		int progress;
+		bool allyBuildEnabled;
 
 		public BaseProvider(Actor self, BaseProviderInfo info)
 		{
@@ -41,6 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 			devMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
 			progress = total = info.InitialDelay;
+			allyBuildEnabled = self.World.WorldActor.Trait<MapBuildRadius>().AllyBuildRadiusEnabled;
 		}
 
 		public void Tick(Actor self)
@@ -61,8 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ValidRenderPlayer()
 		{
-			var allyBuildRadius = self.World.LobbyInfo.GlobalSettings.AllyBuildRadius;
-			return self.Owner == self.World.RenderPlayer || (allyBuildRadius && self.Owner.IsAlliedWith(self.World.RenderPlayer));
+			return self.Owner == self.World.RenderPlayer || (allyBuildEnabled && self.Owner.IsAlliedWith(self.World.RenderPlayer));
 		}
 
 		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -43,9 +43,11 @@ namespace OpenRA.Mods.Common.Traits
 		public Actor FindBaseProvider(World world, Player p, CPos topLeft)
 		{
 			var center = world.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(world, this);
+			var allyBuildEnabled = world.WorldActor.Trait<MapBuildRadius>().AllyBuildRadiusEnabled;
+
 			foreach (var bp in world.ActorsWithTrait<BaseProvider>())
 			{
-				var validOwner = bp.Actor.Owner == p || (world.LobbyInfo.GlobalSettings.AllyBuildRadius && bp.Actor.Owner.Stances[p] == Stance.Ally);
+				var validOwner = bp.Actor.Owner == p || (allyBuildEnabled && bp.Actor.Owner.Stances[p] == Stance.Ally);
 				if (!validOwner || !bp.Trait.Ready())
 					continue;
 
@@ -76,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var nearnessCandidates = new List<CPos>();
 			var bi = world.WorldActor.Trait<BuildingInfluence>();
-			var allyBuildRadius = world.LobbyInfo.GlobalSettings.AllyBuildRadius;
+			var allyBuildEnabled = world.WorldActor.Trait<MapBuildRadius>().AllyBuildRadiusEnabled;
 
 			for (var y = scanStart.Y; y < scanEnd.Y; y++)
 			{
@@ -89,14 +91,14 @@ namespace OpenRA.Mods.Common.Traits
 					if (buildingAtPos == null)
 					{
 						var unitsAtPos = world.ActorMap.GetActorsAt(pos).Where(a => a.IsInWorld
-							&& (a.Owner == p || (allyBuildRadius && a.Owner.Stances[p] == Stance.Ally))
+							&& (a.Owner == p || (allyBuildEnabled && a.Owner.Stances[p] == Stance.Ally))
 							&& a.Info.HasTraitInfo<GivesBuildableAreaInfo>());
 
 						if (unitsAtPos.Any())
 							nearnessCandidates.Add(pos);
 					}
 					else if (buildingAtPos.IsInWorld && buildingAtPos.Info.HasTraitInfo<GivesBuildableAreaInfo>()
-						&& (buildingAtPos.Owner == p || (allyBuildRadius && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
+						&& (buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
 						nearnessCandidates.Add(pos);
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
@@ -36,10 +36,10 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				foreach (var player in collector.World.Players)
 					if (collector.Owner.IsAlliedWith(player))
-						player.Shroud.ExploreAll(player.World);
+						player.Shroud.ExploreAll();
 			}
 			else
-				collector.Owner.Shroud.ExploreAll(collector.World);
+				collector.Owner.Shroud.ExploreAll();
 
 			base.Activate(collector);
 		}

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -97,11 +97,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResolveOrder(Actor self, Order order)
 		{
-			if (!self.World.AllowDevCommands)
-				return;
-
 			if (order.OrderString == "DevLevelUp")
 			{
+				var developerMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
+				if (!developerMode.Enabled)
+					return;
+
 				if ((int)order.ExtraData > 0)
 					GiveLevels((int)order.ExtraData);
 				else

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override int GetBuildTime(ActorInfo unit, BuildableInfo bi = null)
 		{
-			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
+			if (developerMode.FastBuild)
 				return 0;
 
 			var time = unit.GetBuildTime() * Info.BuildSpeed / 100;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -204,7 +204,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<ActorInfo> AllItems()
 		{
-			if (self.World.AllowDevCommands && developerMode.AllTech)
+			if (developerMode.AllTech)
 				return producible.Keys;
 
 			return allProducibles;
@@ -214,7 +214,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!Enabled)
 				return Enumerable.Empty<ActorInfo>();
-			if (self.World.AllowDevCommands && developerMode.AllTech)
+			if (developerMode.AllTech)
 				return producible.Keys;
 
 			return buildableProducibles;
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!producible.TryGetValue(actor, out ps))
 				return false;
 
-			return ps.Buildable || (self.World.AllowDevCommands && developerMode.AllTech);
+			return ps.Buildable || developerMode.AllTech;
 		}
 
 		public virtual void Tick(Actor self)
@@ -316,7 +316,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual int GetBuildTime(ActorInfo unit, BuildableInfo bi = null)
 		{
-			if (self.World.AllowDevCommands && self.Owner.PlayerActor.Trait<DeveloperMode>().FastBuild)
+			if (developerMode.FastBuild)
 				return 0;
 
 			var time = unit.GetBuildTime() * Info.BuildSpeed / 100;

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -52,17 +52,18 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly SpawnActorOnDeathInfo info;
 		readonly string faction;
+		readonly bool enabled;
 
 		public SpawnActorOnDeath(ActorInitializer init, SpawnActorOnDeathInfo info)
 		{
 			this.info = info;
-
+			enabled = !info.RequiresLobbyCreeps || init.Self.World.WorldActor.Trait<MapCreeps>().Enabled;
 			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}
 
 		public void Killed(Actor self, AttackInfo e)
 		{
-			if (info.RequiresLobbyCreeps && !self.World.LobbyInfo.GlobalSettings.Creeps)
+			if (!enabled)
 				return;
 
 			if (!self.IsInWorld)

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -24,5 +24,13 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool AllyBuildRadiusLocked = false;
 	}
 
-	public class MapBuildRadius { }
+	public class MapBuildRadius : INotifyCreated
+	{
+		public bool AllyBuildRadiusEnabled { get; private set; }
+
+		void INotifyCreated.Created(Actor self)
+		{
+			AllyBuildRadiusEnabled = self.World.LobbyInfo.GlobalSettings.AllyBuildRadius;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -24,5 +24,13 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool Locked = false;
 	}
 
-	public class MapCreeps { }
+	public class MapCreeps : INotifyCreated
+	{
+		public bool Enabled { get; private set; }
+
+		void INotifyCreated.Created(Actor self)
+		{
+			Enabled = self.World.LobbyInfo.GlobalSettings.Creeps;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -39,5 +39,13 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool DifficultyLocked = false;
 	}
 
-	public class MapOptions { }
+	public class MapOptions : INotifyCreated
+	{
+		public bool ShortGame { get; private set; }
+
+		void INotifyCreated.Created(Actor self)
+		{
+			ShortGame = self.World.LobbyInfo.GlobalSettings.ShortGame;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -64,14 +64,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 			}
 
-			var diplomacy = widget.GetOrNull<MenuButtonWidget>("DIPLOMACY_BUTTON");
-			if (diplomacy != null)
-			{
-				diplomacy.Visible = !world.Map.Visibility.HasFlag(MapVisibility.MissionSelector) && world.Players.Any(a => a != world.LocalPlayer && !a.NonCombatant);
-				diplomacy.IsDisabled = () => disableSystemButtons;
-				diplomacy.OnClick = () => OpenMenuPanel(diplomacy);
-			}
-
 			var debug = widget.GetOrNull<MenuButtonWidget>("DEBUG_BUTTON");
 			if (debug != null)
 			{

--- a/OpenRA.Mods.RA/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.RA/Traits/GpsWatcher.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.RA.Traits
 				i.Trait.RefreshGranted();
 
 			if ((Granted || GrantedAllies) && atek.Owner.IsAlliedWith(owner))
-				atek.Owner.Shroud.ExploreAll(atek.World);
+				atek.Owner.Shroud.ExploreAll();
 		}
 
 		void RefreshGranted()
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.RA.Traits
 			GrantedAllies = owner.World.ActorsHavingTrait<GpsWatcher>(g => g.Granted).Any(p => p.Owner.IsAlliedWith(owner));
 
 			if (Granted || GrantedAllies)
-				owner.Shroud.ExploreAll(owner.World);
+				owner.Shroud.ExploreAll();
 
 			if (wasGranted != Granted || wasGrantedAllies != GrantedAllies)
 				foreach (var tp in notifyOnRefresh.ToList())


### PR DESCRIPTION
This continues the work started by #10857 to migrate from hardcoded lobby options to a more flexible trait-driven system.

The direct checks against the boolean `World.LobbyInfo.GlobalSettings.*` values are replaced with checks against the respective checkbox-owning traits.  A future PR (see [pchote:lobby-trait-options](https://github.com/pchote/OpenRA/commits/lobby-trait-options) for a WIP preview) will then be able to swap out the `INotifyCreated.Created` implementations without having to deal with all of these outside references.
