### PR TITLE
Make SupportPowerChargeBar and the SupportPowerTimer customizable with stances

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -26,22 +26,22 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new SupportPowerChargeBar(init.Self, this); }
 	}
 
-	class SupportPowerChargeBar : ISelectionBar
+	class SupportPowerChargeBar : ISelectionBar, INotifyOwnerChanged
 	{
 		readonly Actor self;
 		readonly SupportPowerChargeBarInfo info;
+		SupportPowerManager spm;
 
 		public SupportPowerChargeBar(Actor self, SupportPowerChargeBarInfo info)
 		{
 			this.self = self;
 			this.info = info;
+			spm = self.Owner.PlayerActor.Trait<SupportPowerManager>();
 		}
 
 		float ISelectionBar.GetValue()
 		{
-			var spm = self.Owner.PlayerActor.Trait<SupportPowerManager>();
 			var power = spm.GetPowersForActor(self).FirstOrDefault(sp => !sp.Disabled);
-
 			if (power == null)
 				return 0;
 
@@ -53,5 +53,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		Color ISelectionBar.GetColor() { return info.Color; }
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			spm = newOwner.PlayerActor.Trait<SupportPowerManager>();
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -15,9 +15,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	[Desc("Display the time remaining until the super weapon attached to the actor is ready to the player and his allies.")]
+	[Desc("Display the time remaining until the super weapon attached to the actor is ready.")]
 	class SupportPowerChargeBarInfo : ITraitInfo
 	{
+		[Desc("Defines to which players the bar is to be shown.")]
+		public readonly Stance DisplayStances = Stance.Ally;
+
 		public readonly Color Color = Color.Magenta;
 
 		public object Create(ActorInitializer init) { return new SupportPowerChargeBar(init.Self, this); }
@@ -36,13 +39,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		float ISelectionBar.GetValue()
 		{
-			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
-				return 0;
-
 			var spm = self.Owner.PlayerActor.Trait<SupportPowerManager>();
 			var power = spm.GetPowersForActor(self).FirstOrDefault(sp => !sp.Disabled);
 
-			if (power == null) return 0;
+			if (power == null)
+				return 0;
+
+			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
+			if (viewer != null && info.DisplayStances.HasStance(self.Owner.Stances[viewer]))
+				return 0;
 
 			return 1 - (float)power.RemainingTime / power.TotalTime;
 		}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -44,7 +44,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string IncomingSound = null;
 		public readonly string IncomingSpeechNotification = null;
 
-		public readonly bool DisplayTimer = false;
+		[Desc("Defines to which players the timer is shown.")]
+		public readonly Stance DisplayTimerStances = Stance.None;
 
 		[Desc("Palette used for the icon.")]
 		[PaletteReference] public readonly string IconPalette = "chrome";

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -291,6 +291,20 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// DisplayTimer was replaced by DisplayTimerStances
+				if (engineVersion < 20160710)
+				{
+					if (node.Key == "DisplayTimer")
+					{
+						node.Key = "DisplayTimerStances";
+
+						if (node.Value.Value.ToLower() == "false")
+							node.Value.Value = "None";
+						else
+							node.Value.Value = "Ally, Neutral, Enemy";
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -32,7 +32,7 @@ MSLO:
 		IncomingSpeechNotification: AbombLaunchDetected
 		MissileWeapon: atomic
 		SpawnOffset: 0,427,0
-		DisplayTimer: True
+		DisplayTimerStances: Ally, Neutral, Enemy
 		DisplayBeacon: True
 		DisplayRadarPing: True
 		BeaconPoster: atomicon
@@ -771,7 +771,7 @@ ATEK:
 		LongDesc: Reveals map terrain and provides tactical\ninformation. Requires power and active radar.
 		RevealDelay: 15
 		LaunchSpeechNotification: SatelliteLaunched
-		DisplayTimer: True
+		DisplayTimerStances: Ally, Neutral, Enemy
 	SupportPowerChargeBar:
 	RequiresPower:
 	DisabledOverlay:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -243,7 +243,7 @@ NAMISL:
 		LaunchSound: icbm1.aud
 		MissileWeapon: ClusterMissile
 		SpawnOffset: 0,427,0
-		DisplayTimer: False
+		DisplayTimerStances: None
 		DisplayBeacon: False
 		DisplayRadarPing: True
 		BeaconPoster:


### PR DESCRIPTION
~~As a workaround for #11048.~~

~~If we show the timer, we now also show the charge bar (both is customizable with a stances field now).~~

~~(If this is merged before the next release, I'd like to get it into `stable`. It's not compulsory though.)~~

EDIT:

> This now only adds support to switch the charge bars and timers on/off based on stances.
