### PR TITLE
Minor trait caching tweaks

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/PoisonedByTiberium.cs
+++ b/OpenRA.Mods.Cnc/Traits/PoisonedByTiberium.cs
@@ -24,16 +24,20 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public WeaponInfo WeaponInfo { get; private set; }
 
-		public override object Create(ActorInitializer init) { return new PoisonedByTiberium(this); }
+		public override object Create(ActorInitializer init) { return new PoisonedByTiberium(init, this); }
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai) { WeaponInfo = rules.Weapons[Weapon.ToLowerInvariant()]; }
 	}
 
 	class PoisonedByTiberium : UpgradableTrait<PoisonedByTiberiumInfo>, ITick, ISync
 	{
+		readonly ResourceLayer rl;
 		[Sync] int poisonTicks;
 
-		public PoisonedByTiberium(PoisonedByTiberiumInfo info)
-			: base(info) { }
+		public PoisonedByTiberium(ActorInitializer init, PoisonedByTiberiumInfo info)
+			: base(info)
+		{
+			rl = init.Self.World.WorldActor.Trait<ResourceLayer>();
+		}
 
 		public void Tick(Actor self)
 		{
@@ -44,7 +48,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!self.IsInWorld)
 				return;
 
-			var rl = self.World.WorldActor.Trait<ResourceLayer>();
 			var r = rl.GetResource(self.Location);
 			if (r == null || !Info.Resources.Contains(r.Info.Name))
 				return;

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Leave the current position in a random direction.")]
 		public void Scatter()
 		{
-			Self.Trait<Mobile>().Nudge(Self, Self, true);
+			mobile.Nudge(Self, Self, true);
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be sent to a structure for repairs.")]
-	class RepairableInfo : ITraitInfo, Requires<HealthInfo>
+	class RepairableInfo : ITraitInfo, Requires<HealthInfo>, Requires<IMoveInfo>
 	{
 		public readonly HashSet<string> RepairBuildings = new HashSet<string> { "fix" };
 
@@ -33,12 +33,14 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly RepairableInfo info;
 		readonly Health health;
+		readonly IMove movement;
 		readonly AmmoPool[] ammoPools;
 
 		public Repairable(Actor self, RepairableInfo info)
 		{
 			this.info = info;
 			health = self.Trait<Health>();
+			movement = self.Trait<IMove>();
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 		}
 
@@ -90,7 +92,6 @@ namespace OpenRA.Mods.Common.Traits
 				if (!CanRepairAt(order.TargetActor) || (!CanRepair() && !CanRearm()))
 					return;
 
-				var movement = self.Trait<IMove>();
 				var target = Target.FromOrder(self.World, order);
 				self.SetTargetLine(target, Color.Green);
 


### PR DESCRIPTION
I couldn't find any noteworthy low-hanging fruits, though the `ResourceLayer` caching in `PoisonedByTiberium` might be worthwhile with lots of actors on the map.
