### PR TITLE
Added burning trees to the Tiberian Dawn mod

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckBuildingFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckBuildingFootprint.cs
@@ -1,0 +1,36 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckBuildingFootprint : ILintRulesPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		{
+			foreach (var actorInfo in rules.Actors)
+			{
+				var building = actorInfo.Value.TraitInfoOrDefault<BuildingInfo>();
+				if (building == null)
+					continue;
+
+				var footprint = building.Footprint.Where(x => !char.IsWhiteSpace(x)).ToArray();
+				var dimension = building.Dimensions;
+				if (footprint.Length != dimension.X * dimension.Y)
+					emitError("Invalid building footprint/dimension for " + actorInfo.Key);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -179,6 +179,7 @@
     <Compile Include="HitShapes\Rectangle.cs" />
     <Compile Include="HitShapes\Capsule.cs" />
     <Compile Include="HitShapes\Circle.cs" />
+    <Compile Include="Lint\CheckBuildingFootprint.cs" />
     <Compile Include="Lint\CheckSequences.cs" />
     <Compile Include="Lint\CheckPalettes.cs" />
     <Compile Include="Lint\CheckPlayers.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -431,6 +431,7 @@
     <Compile Include="Traits\Render\WithChargeAnimation.cs" />
     <Compile Include="Traits\Render\WithChargeOverlay.cs" />
     <Compile Include="Traits\Render\WithCrateBody.cs" />
+    <Compile Include="Traits\Render\WithDamageOverlay.cs" />
     <Compile Include="Traits\Render\WithDeathAnimation.cs" />
     <Compile Include="Traits\Render\WithDecoration.cs" />
     <Compile Include="Traits\Render\WithDockingAnimation.cs" />
@@ -447,7 +448,6 @@
     <Compile Include="Traits\Render\WithResources.cs" />
     <Compile Include="Traits\Render\WithSpriteRotorOverlay.cs" />
     <Compile Include="Traits\Render\WithShadow.cs" />
-    <Compile Include="Traits\Render\WithSmoke.cs" />
     <Compile Include="Traits\Render\WithSpriteBody.cs" />
     <Compile Include="Traits\Render\WithSpriteTurret.cs" />
     <Compile Include="Traits\Render\WithFacingSpriteBody.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			isSmoking = true;
 			anim.PlayThen(info.IdleSequence,
 				() => anim.PlayThen(info.LoopSequence,
-					() => anim.PlayBackwardsThen(info.EndSequence,
+					() => anim.PlayThen(info.EndSequence,
 						() => isSmoking = false)));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -17,13 +17,13 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders an overlay when the actor is taking heavy damage.")]
-	public class WithSmokeInfo : ITraitInfo, Requires<RenderSpritesInfo> // TODO: rename to WithDamageOverlay
+	public class WithDamageOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
-		public readonly string Sequence = "smoke_m"; // TODO: rename to image
+		public readonly string Image = "smoke_m";
 
-		[SequenceReference("Sequence")] public readonly string IdleSequence = "idle";
-		[SequenceReference("Sequence")] public readonly string LoopSequence = "loop";
-		[SequenceReference("Sequence")] public readonly string EndSequence = "end";
+		[SequenceReference("Image")] public readonly string IdleSequence = "idle";
+		[SequenceReference("Image")] public readonly string LoopSequence = "loop";
+		[SequenceReference("Image")] public readonly string EndSequence = "end";
 
 		[Desc("Damage types that this should be used for (defined on the warheads).",
 			"Leave empty to disable all filtering.")]
@@ -33,23 +33,23 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly DamageState MinimumDamageState = DamageState.Heavy;
 		public readonly DamageState MaximumDamageState = DamageState.Dead;
 
-		public object Create(ActorInitializer init) { return new WithSmoke(init.Self, this); }
+		public object Create(ActorInitializer init) { return new WithDamageOverlay(init.Self, this); }
 	}
 
-	public class WithSmoke : INotifyDamage
+	public class WithDamageOverlay : INotifyDamage
 	{
-		readonly WithSmokeInfo info;
+		readonly WithDamageOverlayInfo info;
 		readonly Animation anim;
 
 		bool isSmoking;
 
-		public WithSmoke(Actor self, WithSmokeInfo info)
+		public WithDamageOverlay(Actor self, WithDamageOverlayInfo info)
 		{
 			this.info = info;
 
 			var rs = self.Trait<RenderSprites>();
 
-			anim = new Animation(self.World, info.Sequence);
+			anim = new Animation(self.World, info.Image);
 			rs.Add(new AnimationWithOffset(anim, null, () => !isSmoking));
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -788,6 +788,22 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							n.Key = "DetonationDelay";
 				}
 
+				// WithSmoke was refactored to become more generic and Sequence/Image notation has been unified.
+				if (engineVersion < 20160528)
+				{
+					if (depth == 1 && node.Key.StartsWith("WithSmoke"))
+					{
+						var s = node.Value.Nodes.FirstOrDefault(n => n.Key == "Sequence");
+						if (s != null)
+							s.Key = "Image";
+
+						var parts = node.Key.Split('@');
+						node.Key = "WithDamageOverlay";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -79,7 +79,7 @@
 	HiddenUnderFog:
 	AttackMove:
 	DrawLineToTarget:
-	WithSmoke:
+	WithDamageOverlay:
 	WithFacingSpriteBody:
 	Explodes:
 		Weapon: UnitExplodeSmall
@@ -446,7 +446,7 @@
 	ActorLostNotification:
 	AttackMove:
 	DrawLineToTarget:
-	WithSmoke:
+	WithDamageOverlay:
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip
@@ -636,19 +636,19 @@
 		Type: Wood
 	Targetable:
 		TargetTypes: Trees
-	WithSmoke@SmallBurn:
+	WithDamageOverlay@SmallBurn:
 		DamageType: Incendiary
-		Sequence: burn-s
+		Image: burn-s
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
-	WithSmoke@MediumBurn:
+	WithDamageOverlay@MediumBurn:
 		DamageType: Incendiary
-		Sequence: burn-m
+		Image: burn-m
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
-	WithSmoke@LargeBurn:
+	WithDamageOverlay@LargeBurn:
 		DamageType: Incendiary
-		Sequence: burn-l
+		Image: burn-l
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 	AutoTargetIgnore:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -634,8 +634,38 @@
 		HP: 500
 	Armor:
 		Type: Wood
+	Targetable:
+		TargetTypes: Trees
+	WithSmoke@SmallBurn:
+		DamageType: Incendiary
+		Sequence: burn-s
+		MinimumDamageState: Light
+		MaximumDamageState: Medium
+	WithSmoke@MediumBurn:
+		DamageType: Incendiary
+		Sequence: burn-m
+		MinimumDamageState: Medium
+		MaximumDamageState: Heavy
+	WithSmoke@LargeBurn:
+		DamageType: Incendiary
+		Sequence: burn-l
+		MinimumDamageState: Heavy
+		MaximumDamageState: Dead
 	AutoTargetIgnore:
 	HiddenUnderShroud:
+	ScriptTriggers:
+
+^TreeHusk:
+	Inherits@1: ^SpriteActor
+	AppearsOnRadar:
+	Building:
+		Footprint: __ x_
+		Dimensions: 2,2
+	WithSpriteBody:
+	Tooltip:
+		Name: Tree (Burnt)
+		ShowOwnerRow: false
+	FrozenUnderFog:
 	ScriptTriggers:
 
 ^TibTree:

--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -69,9 +69,23 @@ T01:
 	Inherits: ^Tree
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T01.Husk
+
+T01.Husk:
+	Inherits: ^TreeHusk
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T02:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T02.Husk
+
+T02.Husk:
+	Inherits: ^TreeHusk
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
 
@@ -79,9 +93,23 @@ T03:
 	Inherits: ^Tree
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T03.Husk
+
+T03.Husk:
+	Inherits: ^TreeHusk
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T04:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T04.Husk
+
+T04.Husk:
+	Inherits: ^TreeHusk
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
 
@@ -89,9 +117,23 @@ T05:
 	Inherits: ^Tree
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T05.Husk
+
+T05.Husk:
+	Inherits: ^TreeHusk
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T06:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T06.Husk
+
+T06.Husk:
+	Inherits: ^TreeHusk
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
 
@@ -99,9 +141,24 @@ T07:
 	Inherits: ^Tree
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T07.Husk
+
+T07.Husk:
+	Inherits: ^TreeHusk
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T08:
 	Inherits: ^Tree
+	Building:
+		Footprint: x_
+		Dimensions: 2,1
+	SpawnActorOnDeath:
+		Actor: T08.Husk
+
+T08.Husk:
+	Inherits: ^TreeHusk
 	Building:
 		Footprint: x_
 		Dimensions: 2,1
@@ -113,9 +170,28 @@ T09:
 		Dimensions: 2,1
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T09.Husk
+
+T09.Husk:
+	Inherits: ^TreeHusk
+	Building:
+		Footprint: x_
+		Dimensions: 2,1
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T10:
 	Inherits: ^Tree
+	Building:
+		Footprint: __ xx
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T10.Husk
+
+T10.Husk:
+	Inherits: ^TreeHusk
 	Building:
 		Footprint: __ xx
 	EditorTilesetFilter:
@@ -127,9 +203,26 @@ T11:
 		Footprint: __ xx
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T11.Husk
+
+T11.Husk:
+	Inherits: ^TreeHusk
+	Building:
+		Footprint: __ xx
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T12:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T12.Husk
+
+T12.Husk:
+	Inherits: ^TreeHusk
+	Building:
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
 
@@ -137,9 +230,24 @@ T13:
 	Inherits: ^Tree
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T13.Husk
+
+T13.Husk:
+	Inherits: ^TreeHusk
+	Building:
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T14:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T14.Husk
+
+T14.Husk:
+	Inherits: ^TreeHusk
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
 
@@ -150,9 +258,26 @@ T15:
 		Dimensions: 3,2
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T15.Husk
+
+T15.Husk:
+	Inherits: ^TreeHusk
+	Building:
+		Footprint: ___ xx_
+		Dimensions: 3,2
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T16:
 	Inherits: ^Tree
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T16.Husk
+
+T16.Husk:
+	Inherits: ^TreeHusk
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
 
@@ -160,14 +285,38 @@ T17:
 	Inherits: ^Tree
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T17.Husk
+
+T17.Husk:
+	Inherits: ^TreeHusk
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 T18:
 	Inherits: ^Tree
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: T18.Husk
+
+T18.Husk:
+	Inherits: ^TreeHusk
+	EditorTilesetFilter:
+		RequireTilesets: DESERT
 
 TC01:
 	Inherits: ^Tree
+	Building:
+		Footprint: ___ xx_
+		Dimensions: 3,2
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: TC01.Husk
+
+TC01.Husk:
+	Inherits: ^TreeHusk
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
@@ -181,9 +330,29 @@ TC02:
 		Dimensions: 3,2
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: TC02.Husk
+
+TC02.Husk:
+	Inherits: ^TreeHusk
+	Building:
+		Footprint: _x_ xx_
+		Dimensions: 3,2
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 TC03:
 	Inherits: ^Tree
+	Building:
+		Footprint: _x_ xx_
+		Dimensions: 3,2
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: TC03.Husk
+
+TC03.Husk:
+	Inherits: ^TreeHusk
 	Building:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
@@ -197,9 +366,29 @@ TC04:
 		Dimensions: 4,3
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: TC04.Husk
+
+TC04.Husk:
+	Inherits: ^TreeHusk
+	Building:
+		Footprint: ____ xxx_ x___
+		Dimensions: 4,3
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
 
 TC05:
 	Inherits: ^Tree
+	Building:
+		Footprint: __x_ xxx_ _xx_
+		Dimensions: 4,3
+	EditorTilesetFilter:
+		ExcludeTilesets: DESERT
+	SpawnActorOnDeath:
+		Actor: TC05.Husk
+
+TC05.Husk:
+	Inherits: ^TreeHusk
 	Building:
 		Footprint: __x_ xxx_ _xx_
 		Dimensions: 4,3

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -60,6 +60,14 @@ tc04:
 	idle:
 	damaged-idle:
 		Start: 1
+
+tc04.husk:
+	Defaults: tc04
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
+		Start: 2
 	dead:
 		Start: 2
 		Length: 8
@@ -73,6 +81,14 @@ tc05:
 	idle:
 	damaged-idle:
 		Start: 1
+
+tc05.husk:
+	Defaults: tc05
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
+		Start: 2
 	dead:
 		Start: 2
 		Length: 8
@@ -84,7 +100,13 @@ tc03:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+tc03.husk:
+	Defaults: tc03
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -97,7 +119,13 @@ tc02:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+tc02.husk:
+	Defaults: tc02
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -110,7 +138,13 @@ tc01:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+tc01.husk:
+	Defaults: tc01
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -121,7 +155,11 @@ t18:
 	Defaults:
 		AddExtension: false
 	idle: t18.des
-	damaged-idle: t18.des
+
+t18.husk:
+	Defaults: t18
+		AddExtension: false
+	idle: t18.des
 		Start: 1
 	dead: t18.des
 		Start: 2
@@ -134,7 +172,13 @@ t17:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t17.husk:
+	Defaults: t17
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -147,7 +191,13 @@ t16:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t16.husk:
+	Defaults: t16
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -160,7 +210,13 @@ t15:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t15.husk:
+	Defaults: t15
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -173,7 +229,13 @@ t14:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t14.husk:
+	Defaults: t14
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -186,7 +248,13 @@ t13:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t13.husk:
+	Defaults: t13
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -199,7 +267,13 @@ t12:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t12.husk:
+	Defaults: t12
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -212,7 +286,13 @@ t11:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t11.husk:
+	Defaults: t11
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -225,7 +305,13 @@ t10:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t10.husk:
+	Defaults: t10
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -236,7 +322,11 @@ t09:
 	Defaults:
 		AddExtension: false
 	idle: t09.des
-	damaged-idle: t09.des
+
+t09.husk:
+	Defaults: t09
+		AddExtension: false
+	idle: t09.des
 		Start: 1
 	dead: t09.des
 		Start: 2
@@ -247,7 +337,13 @@ t08:
 	Defaults:
 		UseTilesetExtension: true
 	idle:
-	damaged-idle:
+
+t08.husk:
+	Defaults: t08
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -260,7 +356,13 @@ t07:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t07.husk:
+	Defaults: t07
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -273,7 +375,13 @@ t06:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t06.husk:
+	Defaults: t06
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -286,7 +394,13 @@ t05:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t05.husk:
+	Defaults: t05
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -297,7 +411,11 @@ t04:
 	Defaults:
 		AddExtension: false
 	idle: t04.des
-	damaged-idle: t04.des
+
+t04.husk:
+	Defaults: t04
+		AddExtension: false
+	idle: t04.des
 		Start: 1
 	dead: t04.des
 		Start: 2
@@ -310,7 +428,13 @@ t03:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t03.husk:
+	Defaults: t03
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -323,7 +447,13 @@ t02:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t02.husk:
+	Defaults: t02
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2
@@ -336,7 +466,13 @@ t01:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 	idle:
-	damaged-idle:
+
+t01.husk:
+	Defaults: t01
+		UseTilesetExtension: true
+		TilesetOverrides:
+			DESERT: TEMPERAT
+	idle:
 		Start: 1
 	dead:
 		Start: 2

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -13,6 +13,45 @@ fire:
 		Offset: 0,-3
 		ZOffset: 1023
 
+burn-l:
+	idle:
+		Length: *
+		ZOffset: 512
+	loop:
+		Start: 16
+		Length: 44
+		ZOffset: 512
+	end:
+		Start: 60
+		Length: 6
+		ZOffset: 512
+
+burn-m:
+	idle:
+		Length: *
+		ZOffset: 512
+	loop:
+		Start: 16
+		Length: 44
+		ZOffset: 512
+	end:
+		Start: 60
+		Length: 6
+		ZOffset: 512
+
+burn-s:
+	idle:
+		Length: *
+		ZOffset: 512
+	loop:
+		Start: 12
+		Length: 46
+		ZOffset: 512
+	end:
+		Start: 59
+		Length: 5
+		ZOffset: 512
+
 120mm:
 	idle:
 		ZOffset: 1023

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -67,7 +67,8 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 	end:
-		Length: 26
+		Start: 26
+		Length: -26
 		Offset: 2, -5
 		ZOffset: 512
 

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -1,4 +1,5 @@
 Flamethrower:
+	ValidTargets: Ground, Trees
 	ReloadDelay: 55
 	Range: 2c512
 	InvalidTargets: Wall
@@ -8,13 +9,14 @@ Flamethrower:
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
 		Damage: 40
+		ValidTargets: Ground, Trees
 		InvalidTargets: Wall
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 100
 			Heavy: 20
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -22,6 +24,7 @@ Flamethrower:
 		ImpactSounds: flamer2.aud
 
 BigFlamer:
+	ValidTargets: Ground, Trees
 	ReloadDelay: 50
 	Range: 3c512
 	InvalidTargets: Wall
@@ -34,12 +37,13 @@ BigFlamer:
 		Spread: 341
 		Damage: 75
 		InvalidTargets: Wall
+		ValidTargets: Ground, Trees
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 67
 			Heavy: 25
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect
@@ -93,7 +97,7 @@ Grenade:
 		ImpactSounds: xplos.aud
 
 Napalm:
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, Trees
 	ReloadDelay: 4
 	Range: 2c0
 	Burst: 2
@@ -104,13 +108,13 @@ Napalm:
 		Spread: 341
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		ValidTargets: Ground, Water
+		ValidTargets: Ground, Water, Trees
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 100
 			Heavy: 80
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Eff: CreateEffect

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -1,17 +1,17 @@
 Atomic:
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Trees
 	Report: nukemisl.aud
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		ValidTargets: Ground, Air
+		ValidTargets: Ground, Air, Trees
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Eff_impact: CreateEffect
 		Explosions: nuke_explosion
 		ImpactSounds: nukexplo.aud
@@ -26,7 +26,7 @@ Atomic:
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@4Res_areanukea: DestroyResource
 		Size: 3
 		Delay: 3
@@ -42,13 +42,13 @@ Atomic:
 		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 6
-		ValidTargets: Ground, Air
+		ValidTargets: Ground, Air, Trees
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@8Res_areanukeb: DestroyResource
 		Size: 4
 		Delay: 6
@@ -61,13 +61,13 @@ Atomic:
 		Damage: 20
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 9
-		ValidTargets: Ground, Air
+		ValidTargets: Ground, Air, Trees
 		Versus:
 			None: 100
 			Wood: 100
 			Light: 60
 			Heavy: 50
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@11Res_areanukec: DestroyResource
 		Size: 5
 		Delay: 9
@@ -77,13 +77,13 @@ Atomic:
 		Delay: 9
 
 IonCannon:
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, Air, Trees
 	Warhead@1Dam_impact: SpreadDamage
 		Range: 0, 1c1, 2c1, 2c512
 		Damage: 100
 		Falloff: 1000, 1000, 250, 100
-		ValidTargets: Ground, Air
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath
+		ValidTargets: Ground, Air, Trees
+		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
 	Warhead@3Smu_area: LeaveSmudge

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -99,7 +99,7 @@
 	GivesBounty:
 	GpsDot:
 		String: Vehicle
-	WithSmoke:
+	WithDamageOverlay:
 	Guard:
 	Guardable:
 	Tooltip:
@@ -325,7 +325,7 @@
 	RepairableNear:
 	GpsDot:
 		String: Ship
-	WithSmoke:
+	WithDamageOverlay:
 	Explodes:
 		Weapon: UnitExplodeShip
 		EmptyWeapon: UnitExplodeShip

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -132,7 +132,8 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 	end:
-		Length: 26
+		Start: 26
+		Length: -26
 		Offset: 2, -5
 		ZOffset: 512
 


### PR DESCRIPTION
:evergreen_tree: can catch :fire: but only with flame inducing weaponry. They leave a scorched charcoaled tree, but can't be chopped down completely. Artwork for destructible fauna is available, but I fear the balancing shit storm as maps have been designed with trees as indestructible barriers in mind. Closes https://github.com/OpenRA/OpenRA/issues/6403. I can set up RA :deciduous_tree: as well if this gets positive feedback.

PS: Added an additional lint test to catch my own copy & paste mistakes which will crash later on: https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Buildings/FootprintUtils.cs#L51
