### PR TITLE
Fixed mod chooser spamming sound.log with file not found messages

### DIFF
--- a/mods/modchooser/notifications.yaml
+++ b/mods/modchooser/notifications.yaml
@@ -1,5 +1,5 @@
 Sounds:
 	Notifications:
-		TabClick: button
-		ClickSound: button
-		ClickDisabledSound: scold2
+		TabClick:
+		ClickSound:
+		ClickDisabledSound:


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/8138.
