### PR TITLE
Fixed a NullReferenceException in OpenAL QueryDevices

### DIFF
--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Platforms.Default
 
 			do
 			{
-				var str = Marshal.PtrToStringAnsi(next);
+				var str = Marshal.PtrToStringAuto(next);
 				next += str.Length + 1;
 				devices.Add(str);
 			} while (Marshal.ReadByte(next) != 0);

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using OpenAL;
 
 namespace OpenRA.Platforms.Default
@@ -65,7 +66,7 @@ namespace OpenRA.Platforms.Default
 			do
 			{
 				var str = Marshal.PtrToStringAuto(next);
-				next += str.Length + 1;
+				next += UnicodeEncoding.Default.GetByteCount(str) + 1;
 				devices.Add(str);
 			} while (Marshal.ReadByte(next) != 0);
 

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -56,18 +56,18 @@ namespace OpenRA.Platforms.Default
 
 			var devices = new List<string>();
 			var next = ALC10.alcGetString(IntPtr.Zero, type);
+			if (next == IntPtr.Zero || AL10.alGetError() != AL10.AL_NO_ERROR)
+			{
+				Log.Write("sound", "Failed to query OpenAL device list using {0}", label);
+				return new string[] { };
+			}
+
 			do
 			{
 				var str = Marshal.PtrToStringAnsi(next);
 				next += str.Length + 1;
 				devices.Add(str);
 			} while (Marshal.ReadByte(next) != 0);
-
-			if (AL10.alGetError() != AL10.AL_NO_ERROR)
-			{
-				Log.Write("sound", "Failed to query OpenAL device list using {0}", label);
-				return new string[] { };
-			}
 
 			return devices.ToArray();
 		}


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/7b620dhe(v=vs.110).aspx Marshal.PtrToStringAnsi can return null so I assume this fixes https://github.com/OpenRA/OpenRA/issues/11181.
