### PR TITLE
Fix direct hit check in CreateEffectWarhead

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
@@ -47,7 +47,20 @@ namespace OpenRA.Mods.Common.Lint
 							continue;
 
 						if (healthTraits.Where(x => x.Shape.OuterRadius.Length > warhead.TargetExtraSearchRadius.Length).Any())
-							emitError("Actor type `{0}` has a health radius exceeding the victim scan radius of a warhead on `{1}`!"
+							emitError("Actor type `{0}` has a health radius exceeding the victim scan radius of a SpreadDamageWarhead on `{1}`!"
+								.F(actorInfo.Key, weaponInfo.Key));
+					}
+
+					var effectWarheads = weaponInfo.Value.Warheads.OfType<CreateEffectWarhead>();
+
+					foreach (var warhead in effectWarheads)
+					{
+						// This warhead cannot affect this actor.
+						if (!warhead.ValidTargets.Overlaps(targetable))
+							continue;
+
+						if (healthTraits.Where(x => x.Shape.OuterRadius.Length > warhead.TargetSearchRadius.Length).Any())
+							emitError("Actor type `{0}` has a health radius exceeding the victim scan radius of a CreateEffectWarhead on `{1}`!"
 								.F(actorInfo.Key, weaponInfo.Key));
 					}
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Remap explosion effect to player color, if art supports it.")]
 		public readonly bool UsePlayerPalette = false;
 
+		[Desc("Search radius around impact for 'direct hit' check.")]
+		public readonly WDist TargetSearchRadius = new WDist(2048);
+
 		[Desc("List of sounds that can be played on impact.")]
 		public readonly string[] ImpactSounds = new string[0];
 
@@ -72,7 +75,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public bool GetDirectHit(World world, CPos cell, WPos pos, Actor firedBy, bool checkTargetType = false)
 		{
-			foreach (var unit in world.ActorMap.GetActorsAt(cell))
+			foreach (var unit in world.FindActorsInCircle(pos, TargetSearchRadius))
 			{
 				if (checkTargetType && !IsValidAgainst(unit, firedBy))
 					continue;

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Warheads
 					continue;
 
 				// If the impact position is within any actor's HitShape, we have a direct hit
-				if ((unit.CenterPosition - pos).LengthSquared <= healthInfo.Shape.DistanceFromEdge(pos, unit).LengthSquared)
+				if (healthInfo.Shape.DistanceFromEdge(pos, unit).Length <= 0)
 					return true;
 			}
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -75,17 +75,17 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public bool GetDirectHit(World world, CPos cell, WPos pos, Actor firedBy, bool checkTargetType = false)
 		{
-			foreach (var unit in world.FindActorsInCircle(pos, TargetSearchRadius))
+			foreach (var victim in world.FindActorsInCircle(pos, TargetSearchRadius))
 			{
-				if (checkTargetType && !IsValidAgainst(unit, firedBy))
+				if (checkTargetType && !IsValidAgainst(victim, firedBy))
 					continue;
 
-				var healthInfo = unit.Info.TraitInfoOrDefault<HealthInfo>();
+				var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
 				if (healthInfo == null)
 					continue;
 
 				// If the impact position is within any actor's HitShape, we have a direct hit
-				if (healthInfo.Shape.DistanceFromEdge(pos, unit).Length <= 0)
+				if (healthInfo.Shape.DistanceFromEdge(pos, victim).Length <= 0)
 					return true;
 			}
 


### PR DESCRIPTION
Closes #11184.

Originally, this was comparing distance beween `pos` and `unit.CenterPosition` with `HitShape`'s `OuterRadius`. However, the `OuterRadius` can exceed the shape for `Capsule` and `Rectangular` shapes, so I tried to adress that a few months ago by using the `DistanceFromEdge` check instead. The approach was bogus, though. `DistanceFromEdge` just calculates the distance of a position to the edge, so by comparing it with the distance between `pos` and `victim.CenterPosition` in combination with using `LengthSquared`, it was entirely possible the explosion would be within the `HitShape`, but closer to the edge than the `victim.CenterPosition` and the check would return `false`, despite the explosion happening inside the shape.

Now we simply check if `DistanceFromEdge` is `0` or negative.
