### PR TITLE
Fix ProvidesPrerequisite not refreshing the tech tree (on owner change)

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -301,11 +301,11 @@ namespace OpenRA
 				Owner = newOwner;
 				Generation++;
 
-				if (wasInWorld)
-					w.Add(this);
-
 				foreach (var t in TraitsImplementing<INotifyOwnerChanged>())
 					t.OnOwnerChanged(this, oldOwner, newOwner);
+
+				if (wasInWorld)
+					w.Add(this);
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			skipTriggerUpdate = false;
+			Game.RunAfterTick(() => skipTriggerUpdate = false);
 		}
 	}
 }


### PR DESCRIPTION
Not sure if this is the correct approach. Context (see also https://github.com/OpenRA/ra2/pull/191):

> 21:44:08 (abcdefg30) ok, so I might need some advice here
> 21:44:22 (abcdefg30) it works how I want it too, but not sure if that's the right thing to do
> 21:44:38 (abcdefg30) case: we have a neutral airport, when you capture it you get faction specific paradrops
> 21:45:03 (abcdefg30) unfortunately, we need different prerequisites for the different faction specific paradrops
> 21:45:15 (abcdefg30) so I just let the building itself provide a faction specific prereq
> 21:45:42 (abcdefg30) now the thing: the building just grants the prereq of the first owner (which would be neutral with its faction)
> 21:46:17 (abcdefg30) when I capture the neutral building then, I still somehow get the old factions prereq / paratroopers power :s

I'll investigate a bit more tomorrow, if noone has a good idea.
