### PR TITLE
Halven CloseEnough on Stinger.

### DIFF
--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -295,6 +295,7 @@ Stinger:
 		HorizontalRateOfTurn: 20
 		RangeLimit: 50
 		Speed: 170
+		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -293,7 +293,7 @@ Stinger:
 		ContrailLength: 10
 		Image: DRAGON
 		HorizontalRateOfTurn: 20
-		RangeLimit: 50
+		RangeLimit: 65
 		Speed: 170
 		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
With 170 Speed, 298 CloseEnough, and 128 Spread, it will always act as a proximity weapon against the targets. Other missiles aren't affected because all the other missiles have a fair margin to satisfy the optimal Speed+Spread > CloseEnough condition.

(With this change, there is a ~26% chance (1-(128/149)²) to deliver 37% damage and all the other cases full damage due to the missile characteristics and since the Speed is 170, a unit must move at 128 speed to outrun the missile and trigger it turning back to hit it).

Fixes #10186.
