### PR TITLE
Refactored Missile.RangeLimit to be a WDist value

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckRangeLimit : ILintRulesPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		{
+			foreach (var weaponInfo in rules.Weapons)
+			{
+				var range = weaponInfo.Value.Range;
+				var missile = weaponInfo.Value.Projectile as MissileInfo;
+
+				if (missile != null && missile.RangeLimit > WDist.Zero && missile.RangeLimit < range)
+					emitError("Weapon `{0}`: projectile RangeLimit lower than weapon range!"
+						.F(weaponInfo.Key));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Lint\CheckSyncAnnotations.cs" />
     <Compile Include="Lint\CheckTraitPrerequisites.cs" />
     <Compile Include="Lint\CheckDeathTypes.cs" />
+    <Compile Include="Lint\CheckRangeLimit.cs" />
     <Compile Include="Lint\CheckVoiceReferences.cs" />
     <Compile Include="Lint\CheckUpgrades.cs" />
     <Compile Include="Lint\CheckTargetHealthRadius.cs" />

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -13,7 +13,7 @@ Rockets:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 298
-		RangeLimit: 20
+		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 35
@@ -46,7 +46,7 @@ BikeRockets:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 213
-		RangeLimit: 30
+		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30
@@ -80,7 +80,7 @@ OrcaAGMissiles:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 256
-		RangeLimit: 30
+		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
@@ -114,7 +114,7 @@ OrcaAAMissiles:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 298
-		RangeLimit: 30
+		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25
@@ -145,7 +145,7 @@ MammothMissiles:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 341
-		RangeLimit: 35
+		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
 		Damage: 45
@@ -218,7 +218,7 @@ MammothMissiles:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 213
-		RangeLimit: 40
+		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
@@ -250,7 +250,7 @@ BoatMissile:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 170
-		RangeLimit: 60
+		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 60
@@ -285,7 +285,7 @@ TowerMissle:
 		TrailImage: smokey
 		ContrailLength: 8
 		Speed: 298
-		RangeLimit: 40
+		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
 		Damage: 25
@@ -313,7 +313,7 @@ SAMMissile:
 		Image: MISSILE
 		HorizontalRateOfTurn: 20
 		Speed: 426
-		RangeLimit: 35
+		RangeLimit: 9c614
 		TrailImage: smokey
 		ContrailLength: 8
 	Warhead@1Dam: SpreadDamage
@@ -374,7 +374,7 @@ Patriot:
 		ContrailLength: 8
 		HorizontalRateOfTurn: 20
 		Speed: 300
-		RangeLimit: 30
+		RangeLimit: 10c819
 	Warhead@1Dam: SpreadDamage
 		Spread: 682
 		ValidTargets: Air

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -10,7 +10,7 @@ Bazooka:
 		TrailImage: bazooka_trail2
 		TrailPalette: effect75alpha
 		TrailInterval: 1
-		RangeLimit: 35
+		RangeLimit: 3c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
@@ -43,7 +43,7 @@ Rocket:
 		TrailPalette: effect75alpha
 		TrailInterval: 1
 		Speed: 343
-		RangeLimit: 35
+		RangeLimit: 4c204
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 50, 25, 0
@@ -76,7 +76,7 @@ TowerMissile:
 		Blockable: false
 		Shadow: true
 		HorizontalRateOfTurn: 1
-		RangeLimit: 50
+		RangeLimit: 6c614
 		Inaccuracy: 384
 		Image: MISSILE2
 		TrailImage: large_trail
@@ -112,7 +112,7 @@ mtank_pri:
 	ValidTargets: Ground, Air
 	Projectile: Missile
 		Speed: 281
-		RangeLimit: 50
+		RangeLimit: 7c204
 		HorizontalRateOfTurn: 3
 		Blockable: false
 		Shadow: yes
@@ -147,7 +147,7 @@ DeviatorMissile:
 	Report: MISSLE1.WAV
 	Projectile: Missile
 		Speed: 281
-		RangeLimit: 40
+		RangeLimit: 6c0
 		HorizontalRateOfTurn: 3
 		Blockable: false
 		Shadow: yes

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -28,7 +28,7 @@ MammothTusk:
 		ContrailLength: 150
 		Inaccuracy: 0c853
 		ROT: 10
-		RangeLimit: 80
+		RangeLimit: 12c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 640
 		ValidTargets: Ground, Air

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -15,7 +15,7 @@ Maverick:
 		Image: DRAGON
 		HorizontalRateOfTurn: 5
 		CruiseAltitude: 2c0
-		RangeLimit: 60
+		RangeLimit: 10c819
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 70
@@ -52,7 +52,7 @@ Dragon:
 		Inaccuracy: 128
 		Image: DRAGON
 		HorizontalRateOfTurn: 5
-		RangeLimit: 35
+		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 50
@@ -90,7 +90,7 @@ HellfireAG:
 		Inaccuracy: 128
 		Image: DRAGON
 		HorizontalRateOfTurn: 10
-		RangeLimit: 20
+		RangeLimit: 4c819
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 60
@@ -128,7 +128,7 @@ HellfireAA:
 		Inaccuracy: 128
 		Image: DRAGON
 		HorizontalRateOfTurn: 10
-		RangeLimit: 20
+		RangeLimit: 4c819
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40
@@ -164,7 +164,7 @@ MammothTusk:
 		Inaccuracy: 128
 		Image: DRAGON
 		HorizontalRateOfTurn: 15
-		RangeLimit: 40
+		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 50
@@ -201,7 +201,7 @@ Nike:
 		ContrailLength: 10
 		Image: MISSILE
 		HorizontalRateOfTurn: 25
-		RangeLimit: 50
+		RangeLimit: 9c0
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -229,7 +229,7 @@ RedEye:
 		ContrailLength: 10
 		Image: MISSILE
 		HorizontalRateOfTurn: 20
-		RangeLimit: 30
+		RangeLimit: 9c0
 		Speed: 298
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -293,7 +293,7 @@ Stinger:
 		ContrailLength: 10
 		Image: DRAGON
 		HorizontalRateOfTurn: 20
-		RangeLimit: 65
+		RangeLimit: 10c819
 		Speed: 170
 		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage
@@ -334,7 +334,7 @@ StingerAA:
 		ContrailLength: 10
 		Image: DRAGON
 		HorizontalRateOfTurn: 20
-		RangeLimit: 50
+		RangeLimit: 10c819
 		Speed: 255
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
@@ -374,7 +374,7 @@ TorpTube:
 		Speed: 85
 		TrailImage: bubbles
 		HorizontalRateOfTurn: 1
-		RangeLimit: 160
+		RangeLimit: 10c819
 		BoundToTerrainType: Water
 		Palette: shadow
 	Warhead@1Dam: SpreadDamage
@@ -451,7 +451,7 @@ APTusk:
 		Inaccuracy: 128
 		Image: DRAGON
 		HorizontalRateOfTurn: 10
-		RangeLimit: 22
+		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 30

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -12,7 +12,7 @@ Bazooka:
 		Image: DRAGON
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 8
-		RangeLimit: 50
+		RangeLimit: 7c204
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384
@@ -58,7 +58,7 @@ HoverMissile:
 		Image: DRAGON
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 8
-		RangeLimit: 35
+		RangeLimit: 9c614
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384
@@ -103,7 +103,7 @@ MammothTusk:
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 10
 		MaximumLaunchSpeed: 213
-		RangeLimit: 50
+		RangeLimit: 7c204
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384
@@ -144,7 +144,7 @@ BikeMissile:
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 8
 		MaximumLaunchSpeed: 213
-		RangeLimit: 50
+		RangeLimit: 6c0
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384
@@ -186,7 +186,7 @@ Dragon:
 		Image: DRAGON
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 8
-		RangeLimit: 50
+		RangeLimit: 7c204
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384
@@ -232,7 +232,7 @@ Hellfire:
 		Image: DRAGON
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 8
-		RangeLimit: 35
+		RangeLimit: 7c204
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384
@@ -277,7 +277,7 @@ RedEye2:
 		Image: DRAGON
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 5
-		RangeLimit: 100
+		RangeLimit: 18c0
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -11,7 +11,7 @@ MultiCluster:
 		Inaccuracy: 128
 		Image: DRAGON
 		HorizontalRateOfTurn: 8
-		RangeLimit: 35
+		RangeLimit: 7c204
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384


### PR DESCRIPTION
Tick-based `RangeLimit` is tedious to get right (you need to divide weapon Range by projectile speed, and that doesn't even cover any kind of acceleration), and many values throughout the shipping mods + TS are rough or even arbitrary guesses.

This refactor gives much more accurate control over maximum flight distance, especially in mods like TS which use acceleration.

All yaml updates were done automatically via the provided upgrade rules.
