### PR TITLE
Fix the supply truck in allies03b not being targetable by tanya

### DIFF
--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -116,6 +116,8 @@ DOG:
 
 TRUK:
 	-Demolishable:
+	Targetable:
+		TargetTypes: Ground, Truk
 	Armor:
 		Type: Truk
 

--- a/mods/ra/maps/allies-03b/weapons.yaml
+++ b/mods/ra/maps/allies-03b/weapons.yaml
@@ -1,5 +1,7 @@
 Colt45:
+	ValidTargets: Ground, Infantry, Truk
 	Warhead@1Dam: SpreadDamage
+		ValidTargets: Barrel, Infantry, Truk
 		Versus:
 			Truk: 50
 


### PR DESCRIPTION
You need to be able to target it with her colt as the truck is moving away (thus you won't be able to C4 it).
