### PR TITLE
Fix the prerequisite of the supply truck being displayed

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -468,7 +468,7 @@ TRUK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 20
-		Prerequisites: weap, ~techlevel.low
+		Prerequisites: ~techlevel.low
 	Valued:
 		Cost: 500
 	Tooltip:


### PR DESCRIPTION
We don't do this for other units that only require a war factory (like the light tank or ranger) either.
Reported by `theKalash` [on Reddit](https://www.reddit.com/r/openra/comments/4hgzd3/a_couple_of_minor_bugs/d2qx505).
