### PR TITLE
Fix possible instant repairs by spamming Repair activities

### DIFF
--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -32,11 +32,20 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled) return NextActivity;
-			if (host == null || !host.IsInWorld) return NextActivity;
+			if (IsCanceled)
+			{
+				if (remainingTicks-- == 0)
+					return NextActivity;
+
+				return this;
+			}
+
+			if (host == null || !host.IsInWorld)
+				return NextActivity;
 
 			health = self.TraitOrDefault<Health>();
-			if (health == null) return NextActivity;
+			if (health == null)
+				return NextActivity;
 
 			if (health.DamageState == DamageState.Undamaged)
 			{


### PR DESCRIPTION
Noticeable when spam-clicking on a naval yard/sub pen.
