### PR TITLE
Fix trait lookup of destroyed actor in SpawnActorOnDeath

### DIFF
--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -77,6 +77,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
+				// Actor has been disposed by something else before its death (for example `Enter`).
+				if (self.Disposed)
+					return;
+
 				var td = new TypeDictionary
 				{
 					new ParentActorInit(self),


### PR DESCRIPTION
The sequence of events leading to that crash looks like this:
1. Truk enters a building.
2. `Enter.FindAndTransitionToNextState()` is running, and since `DonateSupplies` uses `EnterBehaviour.Dispose`, `Actor.Dispose()` runs for the actor, queueing a FrameEndTask.
3. Truk is then killed:
   - `Health.InflictDamage()` first calls `SpawnActorOnDeath.Killed()`, which queues a FrameEndTask during which some trait lookups happen.
   - `Health.InflictDamage()` then calls `Actor.Dispose()` as well, queueing another FrameEndTask (which will never run, the game crashes before).
4. After the tick, the first FrameEndTask disposes of the actor. The second FrameEndTask would spawn the crate from the truk, but the trait lookups then fail and throw an exception.
