### PR TITLE
Prevent projectiles from overshooting blocking actors

### DIFF
--- a/OpenRA.Mods.Common/Effects/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Effects/AreaBeam.cs
@@ -169,7 +169,7 @@ namespace OpenRA.Mods.Common.Effects
 
 			// Check for blocking actors
 			WPos blockedPos;
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, tailPos, headPos,
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, tailPos, headPos,
 				info.Width, info.TargetExtraSearchRadius, out blockedPos))
 			{
 				headPos = blockedPos;

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -92,6 +92,7 @@ namespace OpenRA.Mods.Common.Effects
 		ContrailRenderable contrail;
 		string trailPalette;
 
+		WPos lastPos;
 		[Sync] WPos pos, target;
 		[Sync] int length;
 		[Sync] int facing;
@@ -104,6 +105,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.info = info;
 			this.args = args;
 			pos = args.Source;
+			lastPos = pos;
 
 			var world = args.SourceActor.World;
 
@@ -166,13 +168,14 @@ namespace OpenRA.Mods.Common.Effects
 			if (anim != null)
 				anim.Tick();
 
-			var lastPos = pos;
+			var lastBeforeLastPos = lastPos;
+			lastPos = pos;
 			pos = WPos.LerpQuadratic(args.Source, target, angle, ticks, length);
 
 			// Check for walls or other blocking obstacles
 			var shouldExplode = false;
 			WPos blockedPos;
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, lastPos, pos, info.Width,
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, lastBeforeLastPos, lastPos, pos, info.Width,
 				info.TargetExtraSearchRadius, out blockedPos))
 			{
 				pos = blockedPos;

--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Effects
 			// Check for walls or other blocking obstacles
 			var shouldExplode = false;
 			WPos blockedPos;
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, lastPos, pos, info.Width,
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, lastPos, pos, info.Width,
 				info.TargetExtraSearchRadius, out blockedPos))
 			{
 				pos = blockedPos;

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -177,6 +177,7 @@ namespace OpenRA.Mods.Common.Effects
 		WVec tarVel;
 		WVec predVel;
 
+		WPos lastPos;
 		[Sync] WPos pos;
 		WVec velocity;
 		int speed;
@@ -197,6 +198,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.args = args;
 
 			pos = args.Source;
+			lastPos = pos;
 			hFacing = args.Facing;
 			gravity = new WVec(0, 0, -info.Gravity);
 			targetPosition = args.PassiveTarget;
@@ -804,13 +806,14 @@ namespace OpenRA.Mods.Common.Effects
 			renderFacing = new WVec(move.X, move.Y - move.Z, 0).Yaw.Facing;
 
 			// Move the missile
-			var lastPos = pos;
+			var lastBeforeLastPos = lastPos;
+			lastPos = pos;
 			pos += move;
 
 			// Check for walls or other blocking obstacles
 			var shouldExplode = false;
 			WPos blockedPos;
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, lastPos, pos, info.Width,
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, lastBeforeLastPos, lastPos, pos, info.Width,
 				info.TargetExtraSearchRadius, out blockedPos))
 			{
 				pos = blockedPos;

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -810,7 +810,7 @@ namespace OpenRA.Mods.Common.Effects
 			// Check for walls or other blocking obstacles
 			var shouldExplode = false;
 			WPos blockedPos;
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, lastPos, pos, info.Width,
+			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, lastPos, pos, info.Width,
 				info.TargetExtraSearchRadius, out blockedPos))
 			{
 				pos = blockedPos;

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.HitShapes
 	public class CapsuleShape : IHitShape
 	{
 		public WDist OuterRadius { get; private set; }
+		public WDist InnerRadius { get { return Radius; } }
 
 		[FieldLoader.Require]
 		public readonly int2 PointA;

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.HitShapes
 	public class CircleShape : IHitShape
 	{
 		public WDist OuterRadius { get { return Radius; } }
+		public WDist InnerRadius { get { return Radius; } }
 
 		[FieldLoader.Require]
 		public readonly WDist Radius = new WDist(426);

--- a/OpenRA.Mods.Common/HitShapes/IHitShape.cs
+++ b/OpenRA.Mods.Common/HitShapes/IHitShape.cs
@@ -16,6 +16,7 @@ namespace OpenRA.Mods.Common.HitShapes
 	public interface IHitShape
 	{
 		WDist OuterRadius { get; }
+		WDist InnerRadius { get; }
 
 		WDist DistanceFromEdge(WVec v);
 		WDist DistanceFromEdge(WPos pos, Actor actor);

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.HitShapes
 	public class RectangleShape : IHitShape
 	{
 		public WDist OuterRadius { get; private set; }
+		public WDist InnerRadius { get; private set; }
 
 		[FieldLoader.Require]
 		public readonly int2 TopLeft;
@@ -59,6 +60,7 @@ namespace OpenRA.Mods.Common.HitShapes
 			center = TopLeft + quadrantSize;
 
 			OuterRadius = new WDist(Math.Max(TopLeft.Length, BottomRight.Length));
+			InnerRadius = new WDist(Math.Max(TopLeft.X, BottomRight.X));
 
 			combatOverlayVertsTop = new WVec[]
 			{

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -58,7 +58,12 @@ namespace OpenRA.Mods.Common.Traits
 				if (!blockers.Any())
 					continue;
 
-				var hitPos = WorldExtensions.MinimumPointLineProjection(start, end, a.CenterPosition);
+				// FindActorsOnLine only finds actors with health trait, so this actor is guaranteed to have it
+				var healthInfo = a.Info.TraitInfo<HealthInfo>();
+				var vector = (a.CenterPosition - source) * healthInfo.Shape.InnerRadius.Length / (a.CenterPosition - source).Length;
+				var hitShapeEdgePos = a.CenterPosition - vector;
+				var hitPos = WorldExtensions.MinimumPointLineProjection(source, a.CenterPosition, hitShapeEdgePos);
+
 				var dat = world.Map.DistanceAboveTerrain(hitPos);
 				if ((hitPos - start).Length < length && blockers.Any(t => t.BlockingHeight > dat))
 				{

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 					.Any(Exts.IsTraitEnabled));
 		}
 
-		public static bool AnyBlockingActorsBetween(World world, WPos start, WPos end, WDist width, WDist overscan, out WPos hit)
+		public static bool AnyBlockingActorsBetween(World world, WPos source, WPos start, WPos end, WDist width, WDist overscan, out WPos hit)
 		{
 			var actors = world.FindActorsOnLine(start, end, width, overscan);
 			var length = (end - start).Length;


### PR DESCRIPTION
One of the prerequisites for directional armor and explosion effects.

While the issue with blockable projectiles passing through walls was fixed a while ago, they still quite often explode on the 'wrong side' of the blocking actor.

This PR calculates the direction the projectile came from and enforces the explosion to happen on the side facing the source (or at least previous position of the projectile).

The concrete walls in our shipping mods already provide a good test case for this.
