### PR TITLE
Fix a spurious NRE in GlobalChat

### DIFF
--- a/OpenRA.Game/GlobalChat.cs
+++ b/OpenRA.Game/GlobalChat.cs
@@ -241,7 +241,7 @@ namespace OpenRA.Chat
 
 		void OnJoin(object sender, JoinEventArgs e)
 		{
-			if (e.Who == client.Nickname || e.Channel != channel.Name)
+			if (e.Who == client.Nickname || channel == null || e.Channel != channel.Name)
 				return;
 
 			AddNotification("{0} joined the chat.".F(e.Who));
@@ -284,7 +284,7 @@ namespace OpenRA.Chat
 
 		void OnPart(object sender, PartEventArgs e)
 		{
-			if (e.Data.Channel != channel.Name)
+			if (channel == null || e.Data.Channel != channel.Name)
 				return;
 
 			AddNotification("{0} left the chat.".F(e.Who));


### PR DESCRIPTION
Fixes an NRE reported by xanax`:

```
Red Alert Mod at Version git-bd7e53b
on map 1b896bb92014607fc1d9c3c1feff5f2a22f902ea (Desert Shellmap by Scott_NZ).
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.NullReferenceException`: La référence d'objet n'est pas définie à une instance d'un objet.
   à OpenRA.Chat.GlobalChat.OnJoin(Object sender, JoinEventArgs e) dans f:\JEUX\OpenRA source code built (SmartGit)\x-a-n-a-x-OpenRA\OpenRA.Game\GlobalChat.cs:ligne 244
   à Meebey.SmartIrc4net.IrcClient._Event_JOIN(IrcMessageData ircdata)
   à Meebey.SmartIrc4net.IrcClient._HandleEvents(IrcMessageData ircdata)
```
