### PR TITLE
Added a welding overlay to the Nod repair vehicle

### DIFF
--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -216,8 +216,11 @@ REPAIR:
 		OutsideRangeCursor: repair
 		TargetStances: Ally
 		ForceTargetStances: None
+		LocalOffset: 300,0,500
+		MuzzleSequence: emp-overlay
 	AttackFrontal:
 		Voice: Attack
+	WithMuzzleOverlay:
 
 WEED:
 	Inherits: ^VoxelTank


### PR DESCRIPTION
In Marn's Tiberian Sun mod the Nod repair tank does not only the welding sounds, but also has a nice visual overlay which makes it way easier to understand for the player what is going on.
