### PR TITLE
Skip TD guard tower make anim frames containing yellow color

### DIFF
--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -491,8 +491,13 @@ gtwr:
 	dead:
 		Start: 2
 		Tick: 800
-	make: gtwrmake
-		Length: *
+	make: 
+		Combine:
+			gtwrmake:
+				Length: 17
+			gtwrmake:
+				Start: 19
+		Length: 18
 		Tick: 80
 	muzzle: minigun
 		Length: 6


### PR DESCRIPTION
Skipping the offening frames is easier than fixing the art. Besides, except for the color nothing changes between the last 3 frames anyway.

Closes #11239.
