### PR TITLE
Remove the last relicts of InitialActivity

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -48,7 +48,6 @@ HARV:
 		BuildPaletteOrder: 10
 		Prerequisites: proc
 		Queue: Vehicle.GDI, Vehicle.Nod
-		InitialActivity: FindResources
 	Selectable:
 		Priority: 7
 	Harvester:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -52,7 +52,6 @@ harvester:
 		Queue: Armor
 		Prerequisites: refinery
 		BuildPaletteOrder: 10
-		InitialActivity: FindResources
 	Valued:
 		Cost: 1200
 	CustomBuildTimeValue:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -239,7 +239,6 @@ HARV:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Prerequisites: proc, ~techlevel.infonly
-		InitialActivity: FindResources
 	Valued:
 		Cost: 1100
 	Tooltip:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -48,7 +48,6 @@ HARV:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Prerequisites: ~factory, proc
-		InitialActivity: FindResources
 	Selectable:
 		Priority: 7
 		Bounds: 36,36


### PR DESCRIPTION
Seems like this was forgotten in #8674. The upgrade rule looks fine though.
Reported by `The_madd` on IRC.
