### PR TITLE
Reduce effectiveness of demo truck against air targets

### DIFF
--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -104,7 +104,7 @@ MiniNuke:
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: Ground, Water, Underwater, Air
+		ValidTargets: Ground, Water, Underwater
 		Versus:
 			Concrete: 25
 		AffectsParent: true
@@ -117,7 +117,7 @@ MiniNuke:
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
-		ValidTargets: Ground, Water, Underwater, Air
+		ValidTargets: Ground, Water, Underwater
 		Versus:
 			Concrete: 25
 		AffectsParent: true


### PR DESCRIPTION
I did the nerf by removing the ValidTarget: Air from some of the warheads. Now it roughly seems that any unit in the scorched-earth area will be instantly killed, others are only damaged
![openra-2016-05-10t184901z](https://cloud.githubusercontent.com/assets/12610736/15158793/c15b8784-16f1-11e6-93c1-f32647c42a9a.png)

This is VERY open to discussion, which already partly happened in #10799 but got sidetracked. This is response to both #10799 and #10865.
