### PR TITLE
Add slow selfealing to the harvester (RA mod)

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -275,6 +275,11 @@ HARV:
 	HarvesterHuskModifier:
 		FullActor: HARV.FullHusk
 		FullnessThreshold: 50
+	SelfHealing:
+		Step: 1
+		Delay: 25
+		HealIfBelow: 50
+		DamageCooldown: 500
 	Explodes:
 		Weapon: OreExplosion
 


### PR DESCRIPTION
Realization of #11224 due general acceptance, for RA mod atm, if people agree I can push commits for other mods.

While most people argued that heal should be at Mamooth Tank rate, I found that to be stupidly high (harv is attacked by group of infantry, goes back to ref and is healed almost to 50% when it gets back). I set it to quite slow, feeling that while it decreases unnecessary macro, it also motivates player to play safe and reapir it to full health fast (for cash).
