### PR TITLE
Dump Mono.NAT in favor of Open.Nat 2.0.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ SDK         ?=
 CSC         = mcs $(SDK)
 CSFLAGS     = -nologo -warn:4 -codepage:utf8 -unsafe -warnaserror
 DEFINE      = TRACE
-COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/Mono.Nat.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/MaxMind.GeoIP2.dll thirdparty/download/Eluant.dll thirdparty/download/SmarIrc4net.dll
+COMMON_LIBS = System.dll System.Core.dll System.Data.dll System.Data.DataSetExtensions.dll System.Drawing.dll System.Xml.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/MaxMind.GeoIP2.dll thirdparty/download/Eluant.dll thirdparty/download/SmarIrc4net.dll
 NUNIT_LIBS_PATH :=
 NUNIT_LIBS  := $(NUNIT_LIBS_PATH)nunit.framework.dll
 
@@ -108,7 +108,7 @@ endif
 game_SRCS := $(shell find OpenRA.Game/ -iname '*.cs')
 game_TARGET = OpenRA.Game.exe
 game_KIND = winexe
-game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SharpFont.dll
+game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SharpFont.dll thirdparty/download/Open.Nat.dll
 game_FLAGS = -win32icon:OpenRA.Game/OpenRA.ico
 PROGRAMS += game
 game: $(game_TARGET)
@@ -409,7 +409,7 @@ install-core: default
 	@$(INSTALL_PROGRAM) FuzzyLogicLibrary.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) SharpFont.dll "$(DATA_INSTALL_DIR)"
 	@$(CP) SharpFont.dll.config "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) Mono.Nat.dll "$(DATA_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) Open.Nat.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) MaxMind.Db.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) MaxMind.GeoIP2.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) Newtonsoft.Json.dll "$(DATA_INSTALL_DIR)"

--- a/OpenRA.Game/Network/UPnP.cs
+++ b/OpenRA.Game/Network/UPnP.cs
@@ -10,127 +10,67 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
-using Mono.Nat;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Open.Nat;
 
 namespace OpenRA.Network
 {
-	public static class UPnP
+	public class UPnP
 	{
-		static INatDevice natDevice;
+		static NatDevice natDevice;
+		static Mapping mapping;
 
-		public static void TryNatDiscovery()
+		public static IPAddress ExternalIP { get; private set; }
+
+		public static async Task DiscoverNatDevices(int timeout)
 		{
+			NatDiscoverer.TraceSource.Switch.Level = SourceLevels.Verbose;
+			var logChannel = Log.Channel("nat");
+			NatDiscoverer.TraceSource.Listeners.Add(new TextWriterTraceListener(logChannel.Writer));
+
+			var natDiscoverer = new NatDiscoverer();
+			var token = new CancellationTokenSource(timeout);
+			natDevice = await natDiscoverer.DiscoverDeviceAsync(PortMapper.Upnp, token);
 			try
 			{
-				NatUtility.Logger = Log.Channel("server").Writer;
-				NatUtility.Verbose = Game.Settings.Server.VerboseNatDiscovery;
-				NatUtility.DeviceFound += DeviceFound;
-				Game.Settings.Server.NatDeviceAvailable = false;
-				NatUtility.StartDiscovery();
-				Log.Write("server", "NAT discovery started.");
+				ExternalIP = await natDevice.GetExternalIPAsync();
 			}
 			catch (Exception e)
 			{
-				Log.Write("server", "Can't discover UPnP-enabled device: {0}", e);
-				Game.Settings.Server.NatDeviceAvailable = false;
-				Game.Settings.Server.AllowPortForward = false;
+				Console.WriteLine("Getting the external IP from NAT device failed: {0}", e.Message);
+				Log.Write("nat", e.StackTrace);
 			}
 		}
 
-		public static void StoppingNatDiscovery()
+		public static async Task ForwardPort(int listen, int external)
 		{
-			Log.Write("server", "Stopping NAT discovery.");
-			NatUtility.StopDiscovery();
-
-			if (natDevice == null || natDevice.GetType() != typeof(Mono.Nat.Upnp.UpnpNatDevice))
-			{
-				Log.Write("server",
-					"No NAT devices with UPnP enabled found within {0} ms deadline. Disabling automatic port forwarding.".F(Game.Settings.Server.NatDiscoveryTimeout));
-				Game.Settings.Server.NatDeviceAvailable = false;
-				Game.Settings.Server.AllowPortForward = false;
-			}
-		}
-
-		public static void DeviceFound(object sender, DeviceEventArgs args)
-		{
-			Log.Write("server", "NAT device discovered.");
-
-			Game.Settings.Server.NatDeviceAvailable = true;
-			Game.Settings.Server.AllowPortForward = true;
-
+			mapping = new Mapping(Protocol.Tcp, listen, external, "OpenRA");
 			try
 			{
-				natDevice = args.Device;
-				Log.Write("server", "Type: {0}", natDevice.GetType());
-				Log.Write("server", "Your external IP is: {0}", natDevice.GetExternalIP());
-
-				foreach (var mp in natDevice.GetAllMappings())
-					Log.Write("server", "Existing port mapping: protocol={0}, public={1}, private={2}",
-						mp.Protocol, mp.PublicPort, mp.PrivatePort);
+				await natDevice.CreatePortMapAsync(mapping);
 			}
 			catch (Exception e)
 			{
-				Log.Write("server", "Can't fetch information from NAT device: {0}", e);
-
-				Game.Settings.Server.NatDeviceAvailable = false;
-				Game.Settings.Server.AllowPortForward = false;
+				Console.WriteLine("Port forwarding failed: {0}", e.Message);
+				Log.Write("nat", e.StackTrace);
 			}
 		}
 
-		public static void ForwardPort(int lifetime)
+		public static async Task RemovePortForward()
 		{
 			try
 			{
-				var mapping = new Mapping(Protocol.Tcp, Game.Settings.Server.ExternalPort, Game.Settings.Server.ListenPort, lifetime);
-				natDevice.CreatePortMap(mapping);
-				Log.Write("server", "Create port mapping: protocol = {0}, public = {1}, private = {2}, lifetime = {3} s",
-					mapping.Protocol, mapping.PublicPort, mapping.PrivatePort, mapping.Lifetime);
-			}
-			catch (MappingException e)
-			{
-				if (e.ErrorCode == 725 && lifetime != 0)
-				{
-					Log.Write("server", "NAT device answered with OnlyPermanentLeasesSupported. Retrying...");
-					ForwardPort(0);
-				}
-				else
-				{
-					Log.Write("server", "Can not forward ports via UPnP: {0}", e);
-					Game.Settings.Server.AllowPortForward = false;
-				}
-			}
-		}
-
-		public static void RemovePortforward()
-		{
-			try
-			{
-				var mapping = new Mapping(Protocol.Tcp, Game.Settings.Server.ExternalPort, Game.Settings.Server.ListenPort);
-				natDevice.DeletePortMap(mapping);
-				Log.Write("server", "Remove port mapping: protocol = {0}, public = {1}, private = {2}, expiration = {3}",
-					mapping.Protocol, mapping.PublicPort, mapping.PrivatePort, mapping.Expiration);
+				await natDevice.DeletePortMapAsync(mapping);
 			}
 			catch (Exception e)
 			{
-				Log.Write("server", "Can not remove UPnP portforwarding rules: {0}", e);
-				Game.Settings.Server.AllowPortForward = false;
-			}
-		}
-
-		public static IPAddress GetExternalIP()
-		{
-			if (natDevice == null)
-				return null;
-
-			try
-			{
-				return natDevice.GetExternalIP();
-			}
-			catch (Exception e)
-			{
-				Log.Write("server", "Failed to get the external IP from NAT device: {0}", e);
-				return null;
+				Console.WriteLine("Port removal failed: {0}", e.Message);
+				Log.Write("nat", e.StackTrace);
 			}
 		}
 	}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -63,11 +63,8 @@
       <HintPath>..\thirdparty\download\SharpFont.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Nat">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-      <Package>mono.nat</Package>
-      <HintPath>..\thirdparty\download\Mono.Nat.dll</HintPath>
+    <Reference Include="Open.Nat">
+      <HintPath>..\thirdparty\download\Open.Nat.dll</HintPath>
     </Reference>
     <Reference Include="Eluant">
       <HintPath>..\thirdparty\download\Eluant.dll</HintPath>

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -137,7 +137,7 @@ namespace OpenRA.Server
 			randomSeed = (int)DateTime.Now.ToBinary();
 
 			if (Settings.AllowPortForward)
-				UPnP.ForwardPort(3600);
+				UPnP.ForwardPort(Settings.ListenPort, Settings.ExternalPort).Wait();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
 				serverTraits.Add(modData.ObjectCreator.CreateObject<ServerTrait>(trait));
@@ -202,7 +202,8 @@ namespace OpenRA.Server
 					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();
-						if (Settings.AllowPortForward) UPnP.RemovePortforward();
+						if (Settings.AllowPortForward)
+							UPnP.RemovePortForward().Wait();
 						break;
 					}
 				}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -59,13 +59,8 @@ namespace OpenRA
 		[Desc("Set this to false to disable UPnP even if compatible devices are found.")]
 		public bool AllowPortForward = true;
 
-		public bool NatDeviceAvailable = false; // internal check if discovery succeeded
-
 		[Desc("Time in milliseconds to search for UPnP enabled NAT devices.")]
 		public int NatDiscoveryTimeout = 1000;
-
-		[Desc("Print very detailed logs for debugging issues with routers.")]
-		public bool VerboseNatDiscovery = false;
 
 		[Desc("Starts the game with a default map. Input as hash that can be obtained by the utility.")]
 		public string Map = null;

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -70,10 +70,6 @@
       <HintPath>..\thirdparty\download\MaxMind.GeoIP2.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Nat">
-      <HintPath>..\thirdparty\download\Mono.Nat.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>..\thirdparty\download\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>False</Private>

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -509,7 +509,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var lc = orderManager.LocalClient;
 			if (lc != null && lc.Index == clientIndex && address == IPAddress.Loopback.ToString())
 			{
-				var externalIP = UPnP.GetExternalIP();
+				var externalIP = UPnP.ExternalIP;
 				if (externalIP != null)
 					address = externalIP.ToString();
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var checkboxUPnP = panel.Get<CheckboxWidget>("UPNP_CHECKBOX");
 			checkboxUPnP.IsChecked = () => allowPortForward;
 			checkboxUPnP.OnClick = () => allowPortForward ^= true;
-			checkboxUPnP.IsDisabled = () => !Game.Settings.Server.NatDeviceAvailable;
+			checkboxUPnP.IsDisabled = () => !Game.Settings.Server.AllowPortForward;
 
 			var passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");
 			if (passwordField != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -630,7 +630,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var gs = Game.Settings.Game;
 
 			BindCheckboxPref(panel, "NAT_DISCOVERY", ss, "DiscoverNatDevices");
-			BindCheckboxPref(panel, "VERBOSE_NAT_CHECKBOX", ss, "VerboseNatDiscovery");
 			BindCheckboxPref(panel, "PERFTEXT_CHECKBOX", ds, "PerfText");
 			BindCheckboxPref(panel, "PERFGRAPH_CHECKBOX", ds, "PerfGraph");
 			BindCheckboxPref(panel, "CHECKUNSYNCED_CHECKBOX", ds, "SanityCheckUnsyncedCode");
@@ -652,7 +651,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			return () =>
 			{
 				ss.DiscoverNatDevices = dss.DiscoverNatDevices;
-				ss.VerboseNatDiscovery = dss.VerboseNatDiscovery;
 				ds.PerfText = dds.PerfText;
 				ds.PerfGraph = dds.PerfGraph;
 				ds.SanityCheckUnsyncedCode = dds.SanityCheckUnsyncedCode;

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -578,13 +578,6 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Show Bot Debug Messages
-						Checkbox@VERBOSE_NAT_CHECKBOX:
-							X: 310
-							Y: 190
-							Width: 300
-							Height: 20
-							Font: Regular
-							Text: Detailed NAT logging
 						Checkbox@CHECKUNSYNCED_CHECKBOX:
 							X: 15
 							Y: 220
@@ -594,7 +587,7 @@ Container@SETTINGS_PANEL:
 							Text: Check Sync around Unsynced Code
 						Checkbox@LUADEBUG_CHECKBOX:
 							X: 310
-							Y: 220
+							Y: 190
 							Width: 300
 							Height: 20
 							Font: Regular

--- a/mods/ra/chrome/settings.yaml
+++ b/mods/ra/chrome/settings.yaml
@@ -579,13 +579,6 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Show Bot Debug Messages
-				Checkbox@VERBOSE_NAT_CHECKBOX:
-					X: 310
-					Y: 190
-					Width: 300
-					Height: 20
-					Font: Regular
-					Text: Detailed NAT logging
 				Checkbox@CHECKUNSYNCED_CHECKBOX:
 					X: 15
 					Y: 220
@@ -595,7 +588,7 @@ Background@SETTINGS_PANEL:
 					Text: Check Sync around Unsynced Code
 				Checkbox@LUADEBUG_CHECKBOX:
 					X: 310
-					Y: 220
+					Y: 190
 					Width: 300
 					Height: 20
 					Font: Regular

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -89,7 +89,7 @@ Section "Game" GAME
 	File "${SRCDIR}\OpenRA.Platforms.Default.dll"
 	File "${SRCDIR}\ICSharpCode.SharpZipLib.dll"
 	File "${SRCDIR}\FuzzyLogicLibrary.dll"
-	File "${SRCDIR}\Mono.Nat.dll"
+	File "${SRCDIR}\Open.Nat.dll"
 	File "${SRCDIR}\AUTHORS"
 	File "${SRCDIR}\COPYING"
 	File "${SRCDIR}\README.html"
@@ -193,7 +193,7 @@ Function ${UN}Clean
 	Delete $INSTDIR\OpenRA.Platforms.Default.dll
 	Delete $INSTDIR\ICSharpCode.SharpZipLib.dll
 	Delete $INSTDIR\FuzzyLogicLibrary.dll
-	Delete $INSTDIR\Mono.Nat.dll
+	Delete $INSTDIR\Open.Nat.dll
 	Delete $INSTDIR\SharpFont.dll
 	Delete $INSTDIR\AUTHORS
 	Delete $INSTDIR\COPYING

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -86,12 +86,12 @@ if (!(Test-Path "windows/SDL2.dll"))
 	rm -path "$currentPath\windows\README-SDL.txt"
 }
 
-if (!(Test-Path "Mono.Nat.dll"))
+if (!(Test-Path "Open.Nat.dll"))
 {
-	echo "Fetching Mono.Nat from NuGet."
-	./nuget.exe install Mono.Nat -Version 1.2.24 -ExcludeVersion
-	cp Mono.Nat/lib/net40/Mono.Nat.dll .
-	rmdir Mono.Nat -Recurse
+	echo "Fetching Open.Nat from NuGet."
+	./nuget.exe install Open.Nat -Version 2.0.16 -ExcludeVersion
+	cp Open.Nat/lib/net45/Open.Nat.dll .
+	rmdir Open.Nat -Recurse
 }
 
 if (!(Test-Path "windows/lua51.dll"))

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -83,11 +83,11 @@ if [ ! -f nunit3-console.exe ]; then
 	rm -rf NUnit.Console
 fi
 
-if [ ! -f Mono.Nat.dll ]; then
-	echo "Fetching Mono.Nat from NuGet"
-	get Mono.Nat 1.2.24
-	cp ./Mono.Nat/lib/net40/Mono.Nat.dll .
-	rm -rf Mono.Nat
+if [ ! -f Open.Nat.dll ]; then
+	echo "Fetching Open.Nat from NuGet"
+	get Open.Nat 2.0.16
+	cp ./Open.Nat/lib/net45/Open.Nat.dll .
+	rm -rf Open.Nat
 fi
 
 if [ ! -f FuzzyLogicLibrary.dll ]; then


### PR DESCRIPTION
Closes #7140.
Fixes #8794.

Depends on #11284. I can try the .NET 3.5 variant, but I don't want to as we will then need to ship our own version of `System.Threading` DLLs, which will cause a lot of unnecessary bloat.
