### PR TITLE
Fix exploding V2RL sound

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -24,7 +24,7 @@ V2RL:
 		VisualBounds: 28,28
 	AutoTarget:
 	Explodes:
-		Weapon: SCUD
+		Weapon: V2Explode
 	WithAttackAnimation:
 		AimSequence: aim
 		ReloadPrefix: empty-

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -216,6 +216,10 @@ ArtilleryExplode:
 		ImpactSounds: splash9.aud
 		ValidImpactTypes: Water
 
+V2Explode:
+	Inherits: SCUD
+	-Report:
+
 BarrelExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426


### PR DESCRIPTION
You could here the 'Report' of the V2 weapon when the launcher exploded. Added V2-exclusive explosion weapon to fix that.

Closes #8367.
