### PR TITLE
Some D2k polishing

### DIFF
--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -27,7 +27,7 @@ spicebloom:
 	AutoSelectionSize:
 	RenderSprites:
 	AppearsOnRadar:
-		UseLocation: yes
+		UseLocation: true
 	Tooltip:
 		Name: Spice Bloom
 	SpiceBloom:
@@ -46,7 +46,7 @@ spicebloom:
 		Radius: 512
 	Targetable:
 		TargetTypes: Ground
-		RequiresForceFire: yes
+		RequiresForceFire: true
 	Armor:
 		Type: none
 
@@ -86,7 +86,7 @@ sandworm:
 		Sequence: sand
 	HiddenUnderFog:
 	AppearsOnRadar:
-		UseLocation: yes
+		UseLocation: true
 	AttackSwallow:
 		AttackRequiresEnteringCell: true
 		IgnoresVisibility: true

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -127,7 +127,7 @@
 		Interval: 4
 	Targetable:
 		TargetTypes: Ground, Vehicle
-		RequiresForceFire: yes
+		RequiresForceFire: true
 	DisabledOverlay:
 	Explodes:
 		Weapon: UnitExplodeMed
@@ -226,7 +226,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	AppearsOnRadar:
-		UseLocation: yes
+		UseLocation: true
 	HiddenUnderFog:
 		Type: CenterPosition
 		AlwaysVisibleStances: None

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -8,15 +8,15 @@ crate:
 	GiveCashCrateAction@1:
 		Amount: 750
 		SelectionShares: 25
-		UseCashTick: yes
+		UseCashTick: true
 	GiveCashCrateAction@2:
 		Amount: 1000
 		SelectionShares: 50
-		UseCashTick: yes
+		UseCashTick: true
 	GiveCashCrateAction@3:
 		Amount: 1500
 		SelectionShares: 25
-		UseCashTick: yes
+		UseCashTick: true
 	ExplodeCrateAction@1:
 		Weapon: CrateExplosion
 		SelectionShares: 5

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -525,7 +525,7 @@ outpost:
 			mercenary: outpost.ordos
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
-		PauseOnLowPower: yes
+		PauseOnLowPower: true
 	Power:
 		Amount: -125
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -423,7 +423,7 @@ grenadier: # 2502 - 2749 in 1.06 DATA.R8
 	Defaults:
 		Offset: 1,-4
 	stand: grenadier.shp
-		Facings: 8
+		Facings: -8
 	idle: grenadier.shp
 		Start: 203
 		Length: 16

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -115,7 +115,7 @@ mtank_pri:
 		RangeLimit: 7c204
 		HorizontalRateOfTurn: 3
 		Blockable: false
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 96
 		Image: MISSILE2
 		TrailImage: large_trail
@@ -150,7 +150,7 @@ DeviatorMissile:
 		RangeLimit: 6c0
 		HorizontalRateOfTurn: 3
 		Blockable: false
-		Shadow: yes
+		Shadow: true
 		Inaccuracy: 384
 		Image: MISSILE
 		TrailImage: deviator_trail

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -78,6 +78,9 @@ TowerMissile:
 		HorizontalRateOfTurn: 1
 		RangeLimit: 6c614
 		Inaccuracy: 384
+		CruiseAltitude: 1c0
+		MinimumLaunchAngle: 64
+		VerticalRateOfTurn: 10
 		Image: MISSILE2
 		TrailImage: large_trail
 		TrailInterval: 1
@@ -116,6 +119,9 @@ mtank_pri:
 		HorizontalRateOfTurn: 3
 		Blockable: false
 		Shadow: true
+		CruiseAltitude: 1c0
+		MinimumLaunchAngle: 64
+		VerticalRateOfTurn: 10
 		Inaccuracy: 96
 		Image: MISSILE2
 		TrailImage: large_trail
@@ -152,6 +158,9 @@ DeviatorMissile:
 		Blockable: false
 		Shadow: true
 		Inaccuracy: 384
+		CruiseAltitude: 1c0
+		MinimumLaunchAngle: 64
+		VerticalRateOfTurn: 10
 		Image: MISSILE
 		TrailImage: deviator_trail
 		TrailPalette: deviatorgas


### PR DESCRIPTION
Fixed d2k grenadier stand sequence facings (other sequences are not affected), gave larger missiles a ballistic flight curve and changed `yes` to `true` on all boolean properties for consistency.

Fixes #9516.
Closes #10137.
