### PR TITLE
Make TS not load unnecessary mix files

### DIFF
--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -20,15 +20,10 @@ Packages:
 	~scores.mix
 	~sidenc01.mix
 	~sidenc02.mix
-	~gmenu.mix
 	~e01scd01.mix
 	~e01scd02.mix
-	~maps01.mix
-	~maps02.mix
 	~movies01.mix
 	~movies02.mix
-	~multi.mix
-	~patch.mix
 	~sidecd01.mix
 	~sidecd02.mix
 	~tibsun.mix


### PR DESCRIPTION
- gmenu.mix only contains the menu orverride from Patch 2.0/Firestorm
- maps0*.mix only contain singleplayer maps 
- multi.mix only contains multiplayer maps
- patch.mix only contains ini files.

None of these are used or even usable directly by OpenRA as-is, so it's pointless to load them.
