### PR TITLE
Fix the creeps actor on the Dune 2000 shellmap being in low power mode

### DIFF
--- a/mods/d2k/maps/shellmap/rules.yaml
+++ b/mods/d2k/maps/shellmap/rules.yaml
@@ -12,4 +12,4 @@ World:
 
 large_gun_turret:
 	Power:
-		Amount: 100
+		Amount: 300


### PR DESCRIPTION
This is even visible in the menu on large screens.
