### PR TITLE
Fix the bogus getAirstrikeTarget methods of the nod08 missions

### DIFF
--- a/mods/cnc/maps/nod08a/nod08a.lua
+++ b/mods/cnc/maps/nod08a/nod08a.lua
@@ -50,12 +50,18 @@ getAirstrikeTarget = function()
 
 	local target = list[DateTime.GameTime % #list + 1].CenterPosition
 
-	if searches < 6 then
+	local sams = Map.ActorsInCircle(target, WDist.New(8 * 1024), function(actor)
+		return actor.Type == "sam" end)
+
+	if #sams == 0 then
+		searches = 0
+		return target
+	elseif searches < 6 then
 		searches = searches + 1
 		return getAirstrikeTarget()
 	else
 		searches = 0
-		return target
+		return nil
 	end
 end
 

--- a/mods/cnc/maps/nod08b/nod08b.lua
+++ b/mods/cnc/maps/nod08b/nod08b.lua
@@ -51,12 +51,18 @@ getAirstrikeTarget = function()
 
 	local target = list[DateTime.GameTime % #list + 1].CenterPosition
 
-	if searches < 6 then
+	local sams = Map.ActorsInCircle(target, WDist.New(8 * 1024), function(actor)
+		return actor.Type == "sam" end)
+
+	if #sams == 0 then
+		searches = 0
+		return target
+	elseif searches < 6 then
 		searches = searches + 1
 		return getAirstrikeTarget()
 	else
 		searches = 0
-		return target
+		return nil
 	end
 end
 


### PR DESCRIPTION
They always searched 6 times even after finding a target.
Now they also account for SAM sites (like in the previous missions).

And yes, you can indeed get SAM sites in those missions, it isn't too easy though and thus I'd like the player to be rewarded for getting them.
