### PR TITLE
Fix a wrong string.Format index in the Map ctor

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -310,7 +310,7 @@ namespace OpenRA
 			Package = package;
 
 			if (!Package.Contains("map.yaml") || !Package.Contains("map.bin"))
-				throw new InvalidDataException("Not a valid map\n File: {1}".F(package.Name));
+				throw new InvalidDataException("Not a valid map\n File: {0}".F(package.Name));
 
 			var yaml = new MiniYaml(null, MiniYaml.FromStream(Package.GetStream("map.yaml"), package.Name));
 			foreach (var field in YamlFields)


### PR DESCRIPTION
Before throwing the exception caused a crash...
