### PR TITLE
Do not try to tick undefined parachute shadows.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -135,7 +135,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public void Tick(Actor self)
 		{
-			shadow.Tick();
+			if (shadow != null)
+				shadow.Tick();
 		}
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)


### PR DESCRIPTION
Regression introduced by #11291. It broke the RA2 infantry.
