### PR TITLE
Unhardcode the lobby options backend.

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -193,9 +193,6 @@ namespace OpenRA.Network
 			public int RandomSeed = 0;
 			public bool AllowSpectators = true;
 			public string Difficulty;
-			public int StartingCash = 5000;
-			public string TechLevel;
-			public string StartingUnitsClass;
 			public string GameSpeedType = "default";
 			public bool AllowVersionMismatch;
 			public string GameUid;

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -191,20 +191,12 @@ namespace OpenRA.Network
 			public int Timestep = 40;
 			public int OrderLatency = 3; // net tick frames (x 120 = ms)
 			public int RandomSeed = 0;
-			public bool AllowCheats = false;
 			public bool AllowSpectators = true;
-			public bool Dedicated;
 			public string Difficulty;
-			public bool Crates = true;
-			public bool Creeps = true;
-			public bool Shroud = true;
-			public bool Fog = true;
-			public bool AllyBuildRadius = true;
 			public int StartingCash = 5000;
 			public string TechLevel;
 			public string StartingUnitsClass;
 			public string GameSpeedType = "default";
-			public bool ShortGame = true;
 			public bool AllowVersionMismatch;
 			public string GameUid;
 			public bool DisableSingleplayer;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -149,7 +149,6 @@ namespace OpenRA.Server
 					RandomSeed = randomSeed,
 					Map = settings.Map,
 					ServerName = settings.Name,
-					Dedicated = dedicated,
 					DisableSingleplayer = settings.DisableSinglePlayer,
 				}
 			};

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -9,10 +9,12 @@
  */
 #endregion
 
+using System.Collections.Generic;
+
 namespace OpenRA.Traits
 {
 	[Desc("Attach this to the player actor.")]
-	public class DeveloperModeInfo : ITraitInfo
+	public class DeveloperModeInfo : ITraitInfo, ILobbyOptions
 	{
 		[Desc("Default value of the developer mode checkbox in the lobby.")]
 		public bool Enabled = false;
@@ -55,6 +57,11 @@ namespace OpenRA.Traits
 
 		[Desc("Enable the actor tags overlay by default.")]
 		public bool ShowActorTags;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyBooleanOption("cheats", "Debug Menu", Enabled, Locked);
+		}
 
 		public object Create(ActorInitializer init) { return new DeveloperMode(this); }
 	}
@@ -106,7 +113,8 @@ namespace OpenRA.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			Enabled = self.World.LobbyInfo.GlobalSettings.AllowCheats || self.World.LobbyInfo.IsSinglePlayer;
+			Enabled = self.World.LobbyInfo.IsSinglePlayer || self.World.LobbyInfo.GlobalSettings
+				.OptionOrDefault("cheats", info.Enabled);
 		}
 
 		public void ResolveOrder(Actor self, Order order)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -412,4 +412,50 @@ namespace OpenRA.Traits
 
 	public interface IRulesetLoaded<TInfo> { void RulesetLoaded(Ruleset rules, TInfo info); }
 	public interface IRulesetLoaded : IRulesetLoaded<ActorInfo>, ITraitInfoInterface { }
+
+	[RequireExplicitImplementation]
+	public interface ILobbyOptions : ITraitInfoInterface
+	{
+		IEnumerable<LobbyOption> LobbyOptions(Ruleset rules);
+	}
+
+	public class LobbyOption
+	{
+		public readonly string Id;
+		public readonly string Name;
+		public readonly IReadOnlyDictionary<string, string> Values;
+		public readonly string DefaultValue;
+		public readonly bool Locked;
+
+		public LobbyOption(string id, string name, IReadOnlyDictionary<string, string> values, string defaultValue, bool locked)
+		{
+			Id = id;
+			Name = name;
+			Values = values;
+			DefaultValue = defaultValue;
+			Locked = locked;
+		}
+
+		public virtual string ValueChangedMessage(string playerName, string newValue)
+		{
+			return playerName + " changed " + Name + " to " + Values[newValue] + ".";
+		}
+	}
+
+	public class LobbyBooleanOption : LobbyOption
+	{
+		static readonly Dictionary<string, string> BoolValues = new Dictionary<string, string>()
+		{
+			{ true.ToString(), "enabled" },
+			{ false.ToString(), "disabled" }
+		};
+
+		public LobbyBooleanOption(string id, string name, bool defaultValue, bool locked)
+			: base(id, name, new ReadOnlyDictionary<string, string>(BoolValues), defaultValue.ToString(), locked) { }
+
+		public override string ValueChangedMessage(string playerName, string newValue)
+		{
+			return playerName + " " + BoolValues[newValue] + " " + Name + ".";
+		}
+	}
 }

--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -12,11 +12,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Network;
 
 namespace OpenRA.Traits
 {
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
-	public class ShroudInfo : ITraitInfo
+	public class ShroudInfo : ITraitInfo, ILobbyOptions
 	{
 		[Desc("Default value of the fog checkbox in the lobby.")]
 		public bool FogEnabled = true;
@@ -30,7 +31,13 @@ namespace OpenRA.Traits
 		[Desc("Prevent the explore map enabled state from being changed in the lobby.")]
 		public bool ExploredMapLocked = false;
 
-		public object Create(ActorInitializer init) { return new Shroud(init.Self); }
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyBooleanOption("explored", "Explored Map", ExploredMapEnabled, ExploredMapLocked);
+			yield return new LobbyBooleanOption("fog", "Fog of War", FogEnabled, FogLocked);
+		}
+
+		public object Create(ActorInitializer init) { return new Shroud(init.Self, this); }
 	}
 
 	public class Shroud : ISync, INotifyCreated
@@ -38,6 +45,7 @@ namespace OpenRA.Traits
 		public event Action<IEnumerable<PPos>> CellsChanged;
 
 		readonly Actor self;
+		readonly ShroudInfo info;
 		readonly Map map;
 
 		readonly CellLayer<short> visibleCount;
@@ -72,9 +80,10 @@ namespace OpenRA.Traits
 
 		public int Hash { get; private set; }
 
-		public Shroud(Actor self)
+		public Shroud(Actor self, ShroudInfo info)
 		{
 			this.self = self;
+			this.info = info;
 			map = self.World.Map;
 
 			visibleCount = new CellLayer<short>(map);
@@ -84,9 +93,11 @@ namespace OpenRA.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			fogEnabled = self.World.LobbyInfo.GlobalSettings.Fog;
-			var shroudEnabled = self.World.LobbyInfo.GlobalSettings.Shroud;
-			if (!shroudEnabled)
+			var gs = self.World.LobbyInfo.GlobalSettings;
+			fogEnabled = gs.OptionOrDefault("fog", info.FogEnabled);
+
+			var exploreMap = gs.OptionOrDefault("explored", info.ExploredMapEnabled);
+			if (exploreMap)
 				self.World.AddFrameEndTask(w => ExploreAll());
 		}
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -465,78 +465,6 @@ namespace OpenRA.Mods.Common.Server
 						return true;
 					}
 				},
-				{ "allowcheats",
-					s =>
-					{
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var devMode = server.Map.Rules.Actors["player"].TraitInfo<DeveloperModeInfo>();
-						if (devMode.Locked)
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled cheat configuration.");
-							return true;
-						}
-
-						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.AllowCheats);
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} the Debug Menu."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.AllowCheats ? "enabled" : "disabled"));
-
-						return true;
-					}
-				},
-				{ "shroud",
-					s =>
-					{
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var shroud = server.Map.Rules.Actors["player"].TraitInfo<ShroudInfo>();
-						if (shroud.ExploredMapLocked)
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled shroud configuration.");
-							return true;
-						}
-
-						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.Shroud);
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} Explored map."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.Shroud ? "disabled" : "enabled"));
-
-						return true;
-					}
-				},
-				{ "fog",
-					s =>
-					{
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var shroud = server.Map.Rules.Actors["player"].TraitInfo<ShroudInfo>();
-						if (shroud.FogLocked)
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled fog configuration.");
-							return true;
-						}
-
-						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.Fog);
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} Fog of War."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.Fog ? "enabled" : "disabled"));
-
-						return true;
-					}
-				},
 				{ "assignteams",
 					s =>
 					{
@@ -575,78 +503,6 @@ namespace OpenRA.Mods.Common.Server
 						}
 
 						server.SyncLobbyClients();
-						return true;
-					}
-				},
-				{ "crates",
-					s =>
-					{
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var crateSpawner = server.Map.Rules.Actors["world"].TraitInfoOrDefault<CrateSpawnerInfo>();
-						if (crateSpawner == null || crateSpawner.Locked)
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled crate configuration.");
-							return true;
-						}
-
-						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.Crates);
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} Crates."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.Crates ? "enabled" : "disabled"));
-
-						return true;
-					}
-				},
-				{ "creeps",
-					s =>
-					{
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var mapCreeps = server.Map.Rules.Actors["world"].TraitInfoOrDefault<MapCreepsInfo>();
-						if (mapCreeps == null || mapCreeps.Locked)
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled Creeps spawning configuration.");
-							return true;
-						}
-
-						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.Creeps);
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} Creeps spawning."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.Creeps ? "enabled" : "disabled"));
-
-						return true;
-					}
-				},
-				{ "allybuildradius",
-					s =>
-					{
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var mapBuildRadius = server.Map.Rules.Actors["world"].TraitInfoOrDefault<MapBuildRadiusInfo>();
-						if (mapBuildRadius == null || mapBuildRadius.AllyBuildRadiusLocked)
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled ally build radius configuration.");
-							return true;
-						}
-
-						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.AllyBuildRadius);
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} Build off Allies' ConYards."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.AllyBuildRadius ? "enabled" : "disabled"));
-
 						return true;
 					}
 				},
@@ -1016,30 +872,6 @@ namespace OpenRA.Mods.Common.Server
 						return true;
 					}
 				},
-				{ "shortgame",
-					s =>
-					{
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var mapOptions = server.Map.Rules.Actors["world"].TraitInfo<MapOptionsInfo>();
-						if (mapOptions.ShortGameLocked)
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled short game configuration.");
-							return true;
-						}
-
-						bool.TryParse(s, out server.LobbyInfo.GlobalSettings.ShortGame);
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} {1} Short Game."
-							.F(client.Name, server.LobbyInfo.GlobalSettings.ShortGame ? "enabled" : "disabled"));
-
-						return true;
-					}
-				},
 				{ "sync_lobby",
 					s =>
 					{
@@ -1139,30 +971,13 @@ namespace OpenRA.Mods.Common.Server
 				gs.LobbyOptions[o.Id] = state;
 			}
 
-			var devMode = rules.Actors["player"].TraitInfo<DeveloperModeInfo>();
-			gs.AllowCheats = devMode.Enabled;
-
-			var crateSpawner = rules.Actors["world"].TraitInfoOrDefault<CrateSpawnerInfo>();
-			gs.Crates = crateSpawner != null && crateSpawner.Enabled;
-
-			var shroud = rules.Actors["player"].TraitInfo<ShroudInfo>();
-			gs.Fog = shroud.FogEnabled;
-			gs.Shroud = !shroud.ExploredMapEnabled;
-
 			var resources = rules.Actors["player"].TraitInfo<PlayerResourcesInfo>();
 			gs.StartingCash = resources.DefaultCash;
 
 			var startingUnits = rules.Actors["world"].TraitInfoOrDefault<SpawnMPUnitsInfo>();
 			gs.StartingUnitsClass = startingUnits == null ? "none" : startingUnits.StartingUnitsClass;
 
-			var mapBuildRadius = rules.Actors["world"].TraitInfoOrDefault<MapBuildRadiusInfo>();
-			gs.AllyBuildRadius = mapBuildRadius != null && mapBuildRadius.AllyBuildRadiusEnabled;
-
-			var mapCreeps = rules.Actors["world"].TraitInfoOrDefault<MapCreepsInfo>();
-			gs.Creeps = mapCreeps != null && mapCreeps.Enabled;
-
 			var mapOptions = rules.Actors["world"].TraitInfo<MapOptionsInfo>();
-			gs.ShortGame = mapOptions.ShortGameEnabled;
 			gs.TechLevel = mapOptions.TechLevel;
 			gs.Difficulty = mapOptions.Difficulty ?? mapOptions.Difficulties.FirstOrDefault();
 		}

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -38,20 +38,6 @@ namespace OpenRA.Mods.Common.Server
 				if (!defaults.LobbyOptions.TryGetValue(kv.Key, out def) || kv.Value.Value != def.Value)
 					server.SendOrderTo(conn, "Message", options[kv.Key].Name + ": " + kv.Value.Value);
 			}
-
-			if (server.LobbyInfo.GlobalSettings.StartingUnitsClass != defaults.StartingUnitsClass)
-			{
-				var startUnitsInfo = server.Map.Rules.Actors["world"].TraitInfos<MPStartUnitsInfo>();
-				var selectedClass = startUnitsInfo.Where(u => u.Class == server.LobbyInfo.GlobalSettings.StartingUnitsClass).Select(u => u.ClassName).FirstOrDefault();
-				var className = selectedClass != null ? selectedClass : server.LobbyInfo.GlobalSettings.StartingUnitsClass;
-				server.SendOrderTo(conn, "Message", "Starting Units: {0}".F(className));
-			}
-
-			if (server.LobbyInfo.GlobalSettings.StartingCash != defaults.StartingCash)
-				server.SendOrderTo(conn, "Message", "Starting Cash: ${0}".F(server.LobbyInfo.GlobalSettings.StartingCash));
-
-			if (server.LobbyInfo.GlobalSettings.TechLevel != defaults.TechLevel)
-				server.SendOrderTo(conn, "Message", "Tech Level: {0}".F(server.LobbyInfo.GlobalSettings.TechLevel));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -39,24 +39,6 @@ namespace OpenRA.Mods.Common.Server
 					server.SendOrderTo(conn, "Message", options[kv.Key].Name + ": " + kv.Value.Value);
 			}
 
-			if (server.LobbyInfo.GlobalSettings.AllowCheats != defaults.AllowCheats)
-				server.SendOrderTo(conn, "Message", "Allow Cheats: {0}".F(server.LobbyInfo.GlobalSettings.AllowCheats));
-
-			if (server.LobbyInfo.GlobalSettings.Shroud != defaults.Shroud)
-				server.SendOrderTo(conn, "Message", "Explored map: {0}".F(!server.LobbyInfo.GlobalSettings.Shroud));
-
-			if (server.LobbyInfo.GlobalSettings.Fog != defaults.Fog)
-				server.SendOrderTo(conn, "Message", "Fog of war: {0}".F(server.LobbyInfo.GlobalSettings.Fog));
-
-			if (server.LobbyInfo.GlobalSettings.Crates != defaults.Crates)
-				server.SendOrderTo(conn, "Message", "Crates Appear: {0}".F(server.LobbyInfo.GlobalSettings.Crates));
-
-			if (server.LobbyInfo.GlobalSettings.Creeps != defaults.Creeps)
-				server.SendOrderTo(conn, "Message", "Creeps Spawn: {0}".F(server.LobbyInfo.GlobalSettings.Creeps));
-
-			if (server.LobbyInfo.GlobalSettings.AllyBuildRadius != defaults.AllyBuildRadius)
-				server.SendOrderTo(conn, "Message", "Build off Ally ConYards: {0}".F(server.LobbyInfo.GlobalSettings.AllyBuildRadius));
-
 			if (server.LobbyInfo.GlobalSettings.StartingUnitsClass != defaults.StartingUnitsClass)
 			{
 				var startUnitsInfo = server.Map.Rules.Actors["world"].TraitInfos<MPStartUnitsInfo>();
@@ -70,9 +52,6 @@ namespace OpenRA.Mods.Common.Server
 
 			if (server.LobbyInfo.GlobalSettings.TechLevel != defaults.TechLevel)
 				server.SendOrderTo(conn, "Message", "Tech Level: {0}".F(server.LobbyInfo.GlobalSettings.TechLevel));
-
-			if (server.LobbyInfo.GlobalSettings.ShortGame != defaults.ShortGame)
-				server.SendOrderTo(conn, "Message", "Short Game: {0}".F(server.LobbyInfo.GlobalSettings.ShortGame));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -54,7 +54,8 @@ namespace OpenRA.Mods.Common.Traits
 			var map = init.World.Map;
 
 			// Explore map-placed actors if the "Explore Map" option is enabled
-			var exploredMap = !init.World.LobbyInfo.GlobalSettings.Shroud;
+			var shroudInfo = init.World.Map.Rules.Actors["player"].TraitInfo<ShroudInfo>();
+			var exploredMap = init.World.LobbyInfo.GlobalSettings.OptionOrDefault("explored", shroudInfo.ExploredMapEnabled);
 			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>() && !init.Contains<HiddenUnderFogInit>();
 			var footprintCells = FootprintUtils.FrozenUnderFogTiles(init.Self).ToList();
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -48,7 +48,8 @@ namespace OpenRA.Mods.Common.Traits
 		public ProvidesTechPrerequisite(ProvidesTechPrerequisiteInfo info, ActorInitializer init)
 		{
 			this.info = info;
-			enabled = info.Name == init.World.LobbyInfo.GlobalSettings.TechLevel;
+			var mapOptions = init.World.WorldActor.TraitOrDefault<MapOptions>();
+			enabled = mapOptions != null && mapOptions.TechLevel == info.Id;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -15,7 +15,14 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class ProvidesTechPrerequisiteInfo : ITechTreePrerequisiteInfo
 	{
+		[Desc("Internal id for this tech level.")]
+		public readonly string Id;
+
+		[Translate]
+		[Desc("Name shown in the lobby options.")]
 		public readonly string Name;
+
+		[Desc("Prerequisites to grant when this tech level is active.")]
 		public readonly string[] Prerequisites = { };
 
 		public object Create(ActorInitializer init) { return new ProvidesTechPrerequisite(this, init); }
@@ -23,8 +30,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class ProvidesTechPrerequisite : ITechTreePrerequisite
 	{
-		ProvidesTechPrerequisiteInfo info;
+		readonly ProvidesTechPrerequisiteInfo info;
 		bool enabled;
+
 		static readonly string[] NoPrerequisites = new string[0];
 
 		public string Name { get { return info.Name; } }

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -15,22 +15,36 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the build radius checkboxes in the lobby options.")]
-	public class MapBuildRadiusInfo : TraitInfo<MapBuildRadius>
+	public class MapBuildRadiusInfo : ITraitInfo, ILobbyOptions
 	{
 		[Desc("Default value of the ally build radius checkbox in the lobby.")]
 		public readonly bool AllyBuildRadiusEnabled = true;
 
 		[Desc("Prevent the ally build radius state from being changed in the lobby.")]
 		public readonly bool AllyBuildRadiusLocked = false;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyBooleanOption("allybuild", "Build off Allies' ConYards", AllyBuildRadiusEnabled, AllyBuildRadiusLocked);
+		}
+
+		public object Create(ActorInitializer init) { return new MapBuildRadius(this); }
 	}
 
 	public class MapBuildRadius : INotifyCreated
 	{
+		readonly MapBuildRadiusInfo info;
 		public bool AllyBuildRadiusEnabled { get; private set; }
+
+		public MapBuildRadius(MapBuildRadiusInfo info)
+		{
+			this.info = info;
+		}
 
 		void INotifyCreated.Created(Actor self)
 		{
-			AllyBuildRadiusEnabled = self.World.LobbyInfo.GlobalSettings.AllyBuildRadius;
+			AllyBuildRadiusEnabled = self.World.LobbyInfo.GlobalSettings
+				.OptionOrDefault("allybuild", info.AllyBuildRadiusEnabled);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -15,22 +15,36 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the 'Creeps' checkbox in the lobby options.")]
-	public class MapCreepsInfo : TraitInfo<MapCreeps>
+	public class MapCreepsInfo : ITraitInfo, ILobbyOptions
 	{
 		[Desc("Default value of the creeps checkbox in the lobby.")]
 		public readonly bool Enabled = true;
 
 		[Desc("Prevent the creeps state from being changed in the lobby.")]
 		public readonly bool Locked = false;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyBooleanOption("creeps", "Worms", Enabled, Locked);
+		}
+
+		public object Create(ActorInitializer init) { return new MapCreeps(this); }
 	}
 
 	public class MapCreeps : INotifyCreated
 	{
+		readonly MapCreepsInfo info;
 		public bool Enabled { get; private set; }
+
+		public MapCreeps(MapCreepsInfo info)
+		{
+			this.info = info;
+		}
 
 		void INotifyCreated.Created(Actor self)
 		{
-			Enabled = self.World.LobbyInfo.GlobalSettings.Creeps;
+			Enabled = self.World.LobbyInfo.GlobalSettings
+				.OptionOrDefault("creeps", info.Enabled);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the map difficulty, tech level, and short game lobby options.")]
-	public class MapOptionsInfo : TraitInfo<MapOptions>
+	public class MapOptionsInfo : ITraitInfo, ILobbyOptions
 	{
 		[Desc("Default value of the short game checkbox in the lobby.")]
 		public readonly bool ShortGameEnabled = true;
@@ -37,15 +37,30 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Prevent the difficulty from being changed in the lobby.")]
 		public readonly bool DifficultyLocked = false;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyBooleanOption("shortgame", "Short Game", ShortGameEnabled, ShortGameLocked);
+		}
+
+		public object Create(ActorInitializer init) { return new MapOptions(this); }
 	}
 
 	public class MapOptions : INotifyCreated
 	{
+		readonly MapOptionsInfo info;
+
 		public bool ShortGame { get; private set; }
+
+		public MapOptions(MapOptionsInfo info)
+		{
+			this.info = info;
+		}
 
 		void INotifyCreated.Created(Actor self)
 		{
-			ShortGame = self.World.LobbyInfo.GlobalSettings.ShortGame;
+			ShortGame = self.World.LobbyInfo.GlobalSettings
+				.OptionOrDefault("shortgame", info.ShortGameEnabled);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -18,25 +19,48 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Spawn base actor at the spawnpoint and support units in an annulus around the base actor. Both are defined at MPStartUnits. Attach this to the world actor.")]
-	public class SpawnMPUnitsInfo : TraitInfo<SpawnMPUnits>, Requires<MPStartLocationsInfo>, Requires<MPStartUnitsInfo>
+	public class SpawnMPUnitsInfo : ITraitInfo, Requires<MPStartLocationsInfo>, Requires<MPStartUnitsInfo>, ILobbyOptions
 	{
 		public readonly string StartingUnitsClass = "none";
 
 		[Desc("Prevent the starting units option from being changed in the lobby.")]
 		public bool Locked = false;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			var startingUnits = new Dictionary<string, string>();
+
+			// Duplicate classes are defined for different race variants
+			foreach (var t in rules.Actors["world"].TraitInfos<MPStartUnitsInfo>())
+				startingUnits[t.Class] = t.ClassName;
+
+			if (startingUnits.Any())
+				yield return new LobbyOption("startingunits", "Starting Units", new ReadOnlyDictionary<string, string>(startingUnits), StartingUnitsClass, Locked);
+		}
+
+		public object Create(ActorInitializer init) { return new SpawnMPUnits(this); }
 	}
 
 	public class SpawnMPUnits : IWorldLoaded
 	{
+		readonly SpawnMPUnitsInfo info;
+
+		public SpawnMPUnits(SpawnMPUnitsInfo info)
+		{
+			this.info = info;
+		}
+
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
 			foreach (var s in world.WorldActor.Trait<MPStartLocations>().Start)
 				SpawnUnitsForPlayer(world, s.Key, s.Value);
 		}
 
-		static void SpawnUnitsForPlayer(World w, Player p, CPos sp)
+		void SpawnUnitsForPlayer(World w, Player p, CPos sp)
 		{
-			var spawnClass = p.PlayerReference.StartingUnitsClass ?? w.LobbyInfo.GlobalSettings.StartingUnitsClass;
+			var spawnClass = p.PlayerReference.StartingUnitsClass ?? w.LobbyInfo.GlobalSettings
+				.OptionOrDefault("startingunits", info.StartingUnitsClass);
+
 			var unitGroup = w.Map.Rules.Actors["world"].TraitInfos<MPStartUnitsInfo>()
 				.Where(g => g.Class == spawnClass && g.Factions != null && g.Factions.Contains(p.Faction.InternalName))
 				.RandomOrDefault(w.SharedRandom);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -804,6 +804,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20160604 && node.Key.StartsWith("ProvidesTechPrerequisite"))
+				{
+					var name = node.Value.Nodes.First(n => n.Key == "Name");
+					var id = name.Value.Value.ToLowerInvariant().Replace(" ", "");
+					node.Value.Nodes.Add(new MiniYamlNode("Id", id));
+				}
+
 				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -75,12 +75,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			// Debug/Cheats tab
-			if (lp != null && world.LobbyInfo.GlobalSettings.AllowCheats)
+			// Can't use DeveloperMode.Enabled because there is a hardcoded hack to *always*
+			// enable developer mode for singleplayer games, but we only want to show the button
+			// if it has been explicitly enabled
+			var def = world.Map.Rules.Actors["player"].TraitInfo<DeveloperModeInfo>().Enabled;
+			var developerEnabled = world.LobbyInfo.GlobalSettings.OptionOrDefault("cheats", def);
+			if (lp != null && developerEnabled)
 			{
 				numTabs++;
 				var debugTabButton = widget.Get<ButtonWidget>(string.Concat("BUTTON", numTabs.ToString()));
 				debugTabButton.Text = "Debug";
-				debugTabButton.IsVisible = () => lp != null && world.LobbyInfo.GlobalSettings.AllowCheats && numTabs > 1 && !hasError;
+				debugTabButton.IsVisible = () => lp != null && numTabs > 1 && !hasError;
 				debugTabButton.IsDisabled = () => world.IsGameOver;
 				debugTabButton.OnClick = () => activePanel = IngameInfoPanel.Debug;
 				debugTabButton.IsHighlighted = () => activePanel == IngameInfoPanel.Debug;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -67,7 +68,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var debug = widget.GetOrNull<MenuButtonWidget>("DEBUG_BUTTON");
 			if (debug != null)
 			{
-				debug.IsVisible = () => world.LobbyInfo.GlobalSettings.AllowCheats;
+				// Can't use DeveloperMode.Enabled because there is a hardcoded hack to *always*
+				// enable developer mode for singleplayer games, but we only want to show the button
+				// if it has been explicitly enabled
+				var def = world.Map.Rules.Actors["player"].TraitInfo<DeveloperModeInfo>().Enabled;
+				var enabled = world.LobbyInfo.GlobalSettings.OptionOrDefault("cheats", def);
+				debug.IsVisible = () => enabled;
 				debug.IsDisabled = () => disableSystemButtons;
 				debug.OnClick = () => OpenMenuPanel(debug, new WidgetArgs()
 				{

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -19,14 +19,18 @@ Player:
 	ProvidesTechPrerequisite@low:
 		Name: Low
 		Prerequisites: techlevel.low
+		Id: low
 	ProvidesTechPrerequisite@medium:
 		Name: Medium
 		Prerequisites: techlevel.low, techlevel.medium
+		Id: medium
 	ProvidesTechPrerequisite@nosuper:
 		Name: No Powers
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high
+		Id: nopowers
 	ProvidesTechPrerequisite@all:
 		Name: Unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
+		Id: unrestricted
 	GlobalUpgradeManager:
 	ResourceStorageWarning:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -73,15 +73,19 @@ Player:
 	ProvidesTechPrerequisite@low:
 		Name: Low
 		Prerequisites: techlevel.low
+		Id: low
 	ProvidesTechPrerequisite@medium:
 		Name: Medium
 		Prerequisites: techlevel.low, techlevel.medium
+		Id: medium
 	ProvidesTechPrerequisite@nosuper:
 		Name: No Powers
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high
+		Id: nopowers
 	ProvidesTechPrerequisite@all:
 		Name: Unrestricted
 		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
+		Id: unrestricted
 	EnemyWatcher:
 	HarvesterInsurance:
 	GlobalUpgradeManager:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -55,18 +55,23 @@ Player:
 	ProvidesTechPrerequisite@infonly:
 		Name: Infantry Only
 		Prerequisites: techlevel.infonly
+		Id: infantryonly
 	ProvidesTechPrerequisite@low:
 		Name: Low
 		Prerequisites: techlevel.infonly, techlevel.low
+		Id: low
 	ProvidesTechPrerequisite@medium:
 		Name: Medium
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium
+		Id: medium
 	ProvidesTechPrerequisite@high:
 		Name: No Superweapons
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.high
+		Id: nosuperweapons
 	ProvidesTechPrerequisite@unrestricted:
 		Name: Unrestricted
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.high, techlevel.unrestricted
+		Id: unrestricted
 	GlobalUpgradeManager:
 	EnemyWatcher:
 	VeteranProductionIconOverlay:


### PR DESCRIPTION
This follows on from #11176 and #10857, taking us another step towards mod/map defined lobby options.

All of the options except for map difficulty and game speed are migrated to a new mod-level options order, and the traits are set up to use these.  Difficulty and game speed require nontrivial changes to integrate with the new system, so these will be done with their own followup PRs.  After those are complete we can implmement the dynamically generated options bin UI.
