### PR TITLE
Remove CanPowerDown from gates.

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -524,8 +524,6 @@
 	-Building:
 	-WithSpriteBody:
 	WithGateSpriteBody:
-	Power:
-	CanPowerDown:
 	Tooltip:
 		Name: Gate
 		Description: Automated barrier that opens for allied units.

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -816,9 +816,6 @@
 	-MustBeDestroyed:
 	-WithSpriteBody:
 	WithGateSpriteBody:
-	Power:
-	CanPowerDown:
-		IndicatorPalette: mouse
 	Tooltip:
 		Description: Automated barrier that opens for allied units.
 	Gate:


### PR DESCRIPTION
Gates are not powered, so it is bogus from a UI/UX perspective to allow them to be disabled using the powerdown cursor.
