### PR TITLE
Fix shellmap UI disappearing prematurely when starting a mission or replay.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -197,7 +197,7 @@ namespace OpenRA
 				CreateAndStartLocalServer(lobbyInfo.GlobalSettings.Map, orders);
 		}
 
-		public static void CreateAndStartLocalServer(string mapUID, IEnumerable<Order> setupOrders, Action onStart = null)
+		public static void CreateAndStartLocalServer(string mapUID, IEnumerable<Order> setupOrders)
 		{
 			OrderManager om = null;
 
@@ -207,10 +207,8 @@ namespace OpenRA
 				LobbyInfoChanged -= lobbyReady;
 				foreach (var o in setupOrders)
 					om.IssueOrder(o);
-
-				if (onStart != null)
-					onStart();
 			};
+
 			LobbyInfoChanged += lobbyReady;
 
 			om = JoinServer(IPAddress.Loopback.ToString(), CreateLocalServer(mapUID), "");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (om.Connection.ConnectionState == ConnectionState.NotConnected)
 			{
 				// Show connection failed dialog
-				CloseWindow();
+				Ui.CloseWindow();
 
 				Action onConnect = () =>
 				{
@@ -98,17 +98,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "onRetry", onRetry }
 				});
 			}
-		}
-
-		void CloseWindow()
-		{
-			orderManager.AddChatLine -= AddChatLine;
-			Game.LobbyInfoChanged -= UpdateCurrentMap;
-			Game.LobbyInfoChanged -= UpdatePlayerList;
-			Game.BeforeGameStart -= OnGameStart;
-			Game.ConnectionStateChanged -= ConnectionStateChanged;
-
-			Ui.CloseWindow();
 		}
 
 		[ObjectCreator.UseCtor]
@@ -618,7 +607,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var disconnectButton = lobby.Get<ButtonWidget>("DISCONNECT_BUTTON");
-			disconnectButton.OnClick = () => { CloseWindow(); onExit(); };
+			disconnectButton.OnClick = () => { Ui.CloseWindow(); onExit(); };
 
 			if (skirmishMode)
 				disconnectButton.Text = "Back";
@@ -714,6 +703,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// Add a bot on the first lobbyinfo update
 			if (skirmishMode)
 				addBotOnMapLoad = true;
+		}
+
+		bool disposed;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !disposed)
+			{
+				disposed = true;
+				orderManager.AddChatLine -= AddChatLine;
+				Game.LobbyInfoChanged -= UpdateCurrentMap;
+				Game.LobbyInfoChanged -= UpdatePlayerList;
+				Game.BeforeGameStart -= OnGameStart;
+				Game.ConnectionStateChanged -= ConnectionStateChanged;
+			}
+
+			base.Dispose(disposing);
 		}
 
 		public override void Tick()
@@ -985,7 +990,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void OnGameStart()
 		{
-			CloseWindow();
+			Ui.CloseWindow();
 			onStart();
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -55,6 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			this.modData = modData;
 			this.onStart = onStart;
+			Game.BeforeGameStart += OnGameStart;
 
 			missionList = widget.Get<ScrollPanelWidget>("MISSION_LIST");
 
@@ -149,6 +150,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Ui.CloseWindow();
 				onExit();
 			};
+		}
+
+		void OnGameStart()
+		{
+			Ui.CloseWindow();
+			onStart();
+		}
+
+		bool disposed;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !disposed)
+			{
+				disposed = true;
+				Game.BeforeGameStart -= OnGameStart;
+			}
+
+			base.Dispose(disposing);
 		}
 
 		void CreateMissionGroup(string title, IEnumerable<MapPreview> previews)
@@ -344,11 +363,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				PlayVideo(fsPlayer, missionData.StartVideo, PlayingVideo.GameStart, () =>
 				{
 					StopVideo(fsPlayer);
-					Game.CreateAndStartLocalServer(selectedMap.Uid, orders, onStart);
+					Game.CreateAndStartLocalServer(selectedMap.Uid, orders);
 				});
 			}
 			else
-				Game.CreateAndStartLocalServer(selectedMap.Uid, orders, onStart);
+				Game.CreateAndStartLocalServer(selectedMap.Uid, orders);
 		}
 
 		class DropDownOption

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			panel = widget;
 
 			this.onStart = onStart;
+			Game.BeforeGameStart += OnGameStart;
 
 			playerList = panel.Get<ScrollPanelWidget>("PLAYER_LIST");
 			playerHeader = playerList.Get<ScrollItemWidget>("HEADER");
@@ -664,16 +665,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void WatchReplay()
 		{
-			Action startReplay = () =>
+			if (selectedReplay != null && ReplayUtils.PromptConfirmReplayCompatibility(selectedReplay))
 			{
 				cancelLoadingReplays = true;
 				Game.JoinReplay(selectedReplay.FilePath);
-				Ui.CloseWindow();
-				onStart();
-			};
-
-			if (selectedReplay != null && ReplayUtils.PromptConfirmReplayCompatibility(selectedReplay))
-				startReplay();
+			}
 		}
 
 		void AddReplay(ReplayMetadata replay, ScrollItemWidget template)
@@ -695,6 +691,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			item.Get<LabelWidget>("TITLE").GetText = () => item.Text;
 			item.IsVisible = () => replayState[replay].Visible;
 			replayList.AddChild(item);
+		}
+
+		void OnGameStart()
+		{
+			Ui.CloseWindow();
+			onStart();
+		}
+
+		bool disposed;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !disposed)
+			{
+				disposed = true;
+				Game.BeforeGameStart -= OnGameStart;
+			}
+
+			base.Dispose(disposing);
 		}
 
 		class ReplayState


### PR DESCRIPTION
The mission and replay browsers now bind their UI cleanup to the `BeforeGameStart` event, matching what the Lobby UI has always done.  This fixes their UI being removed a tick too early.
