### PR TITLE
Fixed footprints of several RA and TD base structures

### DIFF
--- a/OpenRA.Mods.Cnc/ImportTiberianDawnLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/ImportTiberianDawnLegacyMapCommand.cs
@@ -116,6 +116,17 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			return input.Split(',')[0].ToLowerInvariant();
 		}
 
+		public override CPos ParseActorLocation(string input, int loc)
+		{
+			var newLoc = new CPos(loc % MapSize, loc / MapSize);
+			var vectorDown = new CVec(0, 1);
+
+			if (input == "obli" || input == "atwr" || input == "weap" || input == "hand" || input == "tmpl" || input == "split2" || input == "split3")
+				newLoc += vectorDown;
+
+			return newLoc;
+		}
+
 		public override void LoadPlayer(IniFile file, string section)
 		{
 			string color;

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -365,7 +365,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				mapPlayers.Players[section] = pr;
 		}
 
-		public static void LoadActors(IniFile file, string section, List<string> players, int mapSize, Map map)
+		public virtual CPos ParseActorLocation(string input, int loc)
+		{
+			return new CPos(loc % MapSize, loc / MapSize);
+		}
+
+		public void LoadActors(IniFile file, string section, List<string> players, int mapSize, Map map)
 		{
 			foreach (var s in file.GetSection(section, true))
 			{
@@ -385,8 +390,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					var health = Exts.ParseIntegerInvariant(parts[2]) * 100 / 256;
 					var facing = (section == "INFANTRY") ? Exts.ParseIntegerInvariant(parts[6]) : Exts.ParseIntegerInvariant(parts[4]);
 
-					var actor = new ActorReference(parts[1].ToLowerInvariant()) {
-						new LocationInit(new CPos(loc % mapSize, loc / mapSize)),
+					var actorType = parts[1].ToLowerInvariant();
+
+					var actor = new ActorReference(actorType) {
+						new LocationInit(ParseActorLocation(actorType, loc)),
 						new OwnerInit(parts[0]),
 					};
 
@@ -424,9 +431,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			foreach (var kv in terrain)
 			{
 				var loc = Exts.ParseIntegerInvariant(kv.Key);
-				var ar = new ActorReference(ParseTreeActor(kv.Value))
+				var treeActor = ParseTreeActor(kv.Value);
+
+				var ar = new ActorReference(treeActor)
 				{
-					new LocationInit(new CPos(loc % MapSize, loc / MapSize)),
+					new LocationInit(ParseActorLocation(treeActor, loc)),
 					new OwnerInit("Neutral")
 				};
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -25,9 +25,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return args.Length >= 3;
 		}
 
-		delegate void UpgradeAction(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth);
+		delegate void UpgradeAction(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth);
 
-		static void ProcessYaml(Map map, MiniYaml yaml, int engineDate, UpgradeAction processYaml)
+		static void ProcessYaml(ModData modData, Map map, MiniYaml yaml, int engineDate, UpgradeAction processYaml)
 		{
 			if (yaml == null)
 				return;
@@ -38,12 +38,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			    foreach (var filename in files)
 			    {
 			        var fileNodes = MiniYaml.FromStream(map.Package.GetStream(filename), filename);
-					processYaml(engineDate, ref fileNodes, null, 0);
+					processYaml(modData, engineDate, ref fileNodes, null, 0);
 			        ((IReadWritePackage)map.Package).Update(filename, Encoding.ASCII.GetBytes(fileNodes.WriteToString()));
 			    }
 			}
 
-			processYaml(engineDate, ref yaml.Nodes, null, 1);
+			processYaml(modData, engineDate, ref yaml.Nodes, null, 1);
 		}
 
 		public static void UpgradeMap(ModData modData, IReadWritePackage package, int engineDate)
@@ -58,10 +58,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 
 			var map = new Map(modData, package);
-			ProcessYaml(map, map.WeaponDefinitions, engineDate, UpgradeRules.UpgradeWeaponRules);
-			ProcessYaml(map, map.RuleDefinitions, engineDate, UpgradeRules.UpgradeActorRules);
-			UpgradeRules.UpgradePlayers(engineDate, ref map.PlayerDefinitions, null, 0);
-			UpgradeRules.UpgradeActors(engineDate, ref map.ActorDefinitions, null, 0);
+			ProcessYaml(modData, map, map.WeaponDefinitions, engineDate, UpgradeRules.UpgradeWeaponRules);
+			ProcessYaml(modData, map, map.RuleDefinitions, engineDate, UpgradeRules.UpgradeActorRules);
+			UpgradeRules.UpgradePlayers(modData, engineDate, ref map.PlayerDefinitions, null, 0);
+			UpgradeRules.UpgradeActors(modData, engineDate, ref map.ActorDefinitions, null, 0);
 			map.Save(package);
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return args.Length >= 2;
 		}
 
-		delegate void UpgradeAction(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth);
+		delegate void UpgradeAction(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth);
 
 		void ProcessYaml(string type, IEnumerable<string> files, ModData modData, int engineDate, UpgradeAction processFile)
 		{
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				var yaml = MiniYaml.FromStream(package.GetStream(name), name);
-				processFile(engineDate, ref yaml, null, 0);
+				processFile(modData, engineDate, ref yaml, null, 0);
 
 				// Generate the on-disk path
 				var path = Path.Combine(package.Name, name);

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			catch { }
 		}
 
-		internal static void UpgradeActorRules(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradeActorRules(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			var addNodes = new List<MiniYamlNode>();
 
@@ -185,14 +185,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
-				UpgradeActorRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 
 			foreach (var a in addNodes)
 				nodes.Add(a);
 		}
 
-		internal static void UpgradeWeaponRules(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradeWeaponRules(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
@@ -240,61 +240,61 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "Speed";
 				}
 
-				UpgradeWeaponRules(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradeWeaponRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
 
-		internal static void UpgradeTileset(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradeTileset(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
 				// Add rules here
-				UpgradeTileset(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradeTileset(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
 
-		internal static void UpgradeCursors(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradeCursors(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
 				// Add rules here
-				UpgradeCursors(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradeCursors(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
 
-		internal static void UpgradePlayers(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradePlayers(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
 				// Add rules here
-				UpgradePlayers(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradePlayers(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
 
-		internal static void UpgradeChromeMetrics(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradeChromeMetrics(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
 				// Add rules here
-				UpgradeChromeMetrics(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradeChromeMetrics(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
 
-		internal static void UpgradeChromeLayout(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradeChromeLayout(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
 				// Add rules here
-				UpgradeChromeLayout(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradeChromeLayout(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
 
-		internal static void UpgradeActors(int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
+		internal static void UpgradeActors(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
 				// Add rules here
-				UpgradeActors(engineVersion, ref node.Value.Nodes, node, depth + 1);
+				UpgradeActors(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -289,11 +289,33 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 		}
 
+		internal static void ModifyCPos(ref string input, CVec vector)
+		{
+			var oldCPos = FieldLoader.GetValue<CPos>("(value)", input);
+			var newCPos = oldCPos + vector;
+			input = newCPos.ToString();
+		}
+
 		internal static void UpgradeActors(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			foreach (var node in nodes)
 			{
-				// Add rules here
+				// Fix RA building footprints to not use _ when it's not necessary
+				if (engineVersion < 20160619 && modData.Manifest.Mod.Id == "ra" && depth == 1)
+				{
+					var buildings = new List<string>() { "tsla", "gap", "agun", "apwr", "fapw" };
+					if (buildings.Contains(parent.Value.Value) && node.Key == "Location")
+						ModifyCPos(ref node.Value.Value, new CVec(0, 1));
+				}
+
+				// Fix TD building footprints to not use _ when it's not necessary
+				if (engineVersion < 20160619 && modData.Manifest.Mod.Id == "cnc" && depth == 1)
+				{
+					var buildings = new List<string>() { "atwr", "obli", "tmpl", "weap", "hand" };
+					if (buildings.Contains(parent.Value.Value) && node.Key == "Location")
+						ModifyCPos(ref node.Value.Value, new CVec(0, 1));
+				}
+
 				UpgradeActors(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.RA/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.RA/ImportRedAlertLegacyMapCommand.cs
@@ -126,6 +126,17 @@ namespace OpenRA.Mods.RA.UtilityCommands
 			return input.ToLowerInvariant();
 		}
 
+		public override CPos ParseActorLocation(string input, int loc)
+		{
+			var newLoc = new CPos(loc % MapSize, loc / MapSize);
+			var vectorDown = new CVec(0, 1);
+
+			if (input == "tsla" || input == "agun" || input == "gap" || input == "apwr" || input == "iron")
+				newLoc += vectorDown;
+
+			return newLoc;
+		}
+
 		public override void LoadPlayer(IniFile file, string section)
 		{
 			string color;

--- a/mods/cnc/maps/cnc64gdi01/map.yaml
+++ b/mods/cnc/maps/cnc64gdi01/map.yaml
@@ -474,10 +474,10 @@ Actors:
 		Location: 20,49
 		Owner: Nod
 	Actor142: obli
-		Location: 20,30
+		Location: 20,31
 		Owner: Nod
 	AttackTrigger4: obli
-		Location: 24,29
+		Location: 24,30
 		Owner: Nod
 	NodHQ: hq
 		Location: 47,46
@@ -533,13 +533,13 @@ Actors:
 		Location: 18,42
 		Owner: Nod
 	Obelisk01: obli
-		Location: 15,52
+		Location: 15,53
 		Owner: Nod
 	HandOfNod: hand
-		Location: 42,44
+		Location: 42,45
 		Owner: Nod
 	Actor163: obli
-		Location: 16,16
+		Location: 16,17
 		Owner: Nod
 	Actor164: nuk2
 		Location: 4,9

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -379,7 +379,7 @@ Actors:
 		Location: 29,26
 		Owner: Nod
 	NodBarracks: hand
-		Location: 24,26
+		Location: 24,27
 		Owner: Nod
 	Actor112: silo
 		Location: 33,26

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -414,7 +414,7 @@ Actors:
 		Facing: 192
 		SubCell: 3
 	HandOfNod: hand
-		Location: 30,52
+		Location: 30,53
 		Owner: Nod
 	Hunter1: bggy
 		Location: 35,43

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -474,7 +474,7 @@ Actors:
 		Owner: Nod
 		Facing: 96
 	HandOfNod: hand
-		Location: 15,14
+		Location: 15,15
 		Owner: Nod
 	Hunter1: bggy
 		Location: 27,37

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -674,7 +674,7 @@ Actors:
 		Owner: AbandonedBase
 		Facing: 64
 	GdiWeap: weap
-		Location: 50,54
+		Location: 50,55
 		Owner: AbandonedBase
 		Health: 27
 	GdiNuke1: nuke
@@ -705,7 +705,7 @@ Actors:
 		Owner: Nod
 		FreeActor: False
 	HandOfNod: hand
-		Location: 15,22
+		Location: 15,23
 		Owner: Nod
 	Airfield: afld
 		Location: 9,25

--- a/mods/cnc/maps/gdi05b/map.yaml
+++ b/mods/cnc/maps/gdi05b/map.yaml
@@ -551,7 +551,7 @@ Actors:
 		Location: 40,18
 		Owner: Nod
 	Hand1: hand
-		Location: 41,21
+		Location: 41,22
 		Owner: Nod
 	Nuke2: nuke
 		Location: 47,18
@@ -576,7 +576,7 @@ Actors:
 		Owner: AbandonedBase
 		Facing: 64
 	GdiWeap1: weap
-		Location: 35,51
+		Location: 35,52
 		Owner: AbandonedBase
 		Health: 41
 	GdiNuke2: nuke

--- a/mods/cnc/maps/gdi06/map.yaml
+++ b/mods/cnc/maps/gdi06/map.yaml
@@ -754,7 +754,7 @@ Actors:
 		Location: 51,14
 		Owner: Nod
 	HandOfNod: hand
-		Location: 44,12
+		Location: 44,13
 		Owner: Nod
 	Silo4: silo
 		Location: 44,16

--- a/mods/cnc/maps/gdi07/map.yaml
+++ b/mods/cnc/maps/gdi07/map.yaml
@@ -701,7 +701,7 @@ Actors:
 		Location: 46,20
 		Owner: Nod
 	handofnod: hand
-		Location: 44,12
+		Location: 44,13
 		Owner: Nod
 	Actor219: silo
 		Location: 44,16

--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -370,7 +370,7 @@ Actors:
 		Location: 18,14
 		Owner: GDI
 	Factory: weap
-		Location: 26,13
+		Location: 26,14
 		Owner: GDI
 
 Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod06b/map.yaml
+++ b/mods/cnc/maps/nod06b/map.yaml
@@ -569,7 +569,7 @@ Actors:
 		Location: 51,18
 		Owner: GDI
 	Chn2Actor1: weap
-		Location: 51,21
+		Location: 51,22
 		Owner: GDI
 	Atk1Actor1: gtwr
 		Location: 39,25

--- a/mods/cnc/maps/nod06c/map.yaml
+++ b/mods/cnc/maps/nod06c/map.yaml
@@ -454,7 +454,7 @@ Actors:
 		Location: 24, 22
 		Owner: GDI
 	Factory: weap
-		Location: 20,23
+		Location: 20,24
 		Owner: GDI
 	Barracks: pyle
 		Location: 26,20

--- a/mods/cnc/maps/nod07a/map.yaml
+++ b/mods/cnc/maps/nod07a/map.yaml
@@ -542,7 +542,7 @@ Actors:
 		Owner: Neutral
 		Location: 30,60
 	GDIWeap: weap
-		Location: 27,54
+		Location: 27,55
 		Owner: GDI
 	NodBuilding1: fact
 		Location: 54,11

--- a/mods/cnc/maps/nod07a/nod07a-AI.lua
+++ b/mods/cnc/maps/nod07a/nod07a-AI.lua
@@ -16,7 +16,7 @@ BaseNuke1 = { type = "nuke", pos = CPos.New(16, 56), cost = 500, exists = true }
 BaseNuke2 = { type = "nuke", pos = CPos.New(18, 57), cost = 500, exists = true }
 BaseNuke3 = { type = "nuke", pos = CPos.New(27, 51), cost = 500, exists = true }
 InfantryProduction = { type = "pyle", pos = CPos.New(18, 54), cost = 500, exists = true }
-VehicleProduction = { type = "weap", pos = CPos.New(27, 54), cost = 2000, exists = true }
+VehicleProduction = { type = "weap", pos = CPos.New(27, 55), cost = 2000, exists = true }
 
 BaseBuildings = { BaseProc, BaseNuke1, BaseNuke2, BaseNuke3, InfantryProduction, VehicleProduction }
 

--- a/mods/cnc/maps/nod07b/map.yaml
+++ b/mods/cnc/maps/nod07b/map.yaml
@@ -920,7 +920,7 @@ Actors:
 		Location: 52,39
 		Owner: GDI
 	GDIWeap: weap
-		Location: 55,38
+		Location: 55,39
 		Owner: GDI
 	ReinforcementsBikesRally: waypoint
 		Owner: Neutral

--- a/mods/cnc/maps/nod07b/nod07b-AI.lua
+++ b/mods/cnc/maps/nod07b/nod07b-AI.lua
@@ -16,7 +16,7 @@ BaseNuke1 = { type = "nuke", pos = CPos.New(52, 36), cost = 500, exists = true }
 BaseNuke2 = { type = "nuke", pos = CPos.New(54, 36), cost = 500, exists = true }
 BaseNuke3 = { type = "nuke", pos = CPos.New(56, 36), cost = 500, exists = true }
 InfantryProduction = { type = "pyle", pos = CPos.New(52, 39), cost = 500, exists = true }
-VehicleProduction = { type = "weap", pos = CPos.New(55, 38), cost = 2000, exists = true }
+VehicleProduction = { type = "weap", pos = CPos.New(55, 39), cost = 2000, exists = true }
 
 BaseBuildings = { BaseProc, BaseNuke1, BaseNuke2, BaseNuke3, InfantryProduction, VehicleProduction }
 

--- a/mods/cnc/maps/nod07c/map.yaml
+++ b/mods/cnc/maps/nod07c/map.yaml
@@ -721,7 +721,7 @@ Actors:
 		Owner: GDI
 		ScriptTags: GDIBuilding
 	GDIBuilding8: weap
-		Location: 48,53
+		Location: 48,54
 		Owner: GDI
 		ScriptTags: GDIBuilding
 	GDIBuilding9: gtwr

--- a/mods/cnc/maps/nod08a/map.yaml
+++ b/mods/cnc/maps/nod08a/map.yaml
@@ -529,7 +529,7 @@ Actors:
 		Owner: GDI
 	GDIBuilding9: atwr
 		Owner: GDI
-		Location: 47,19
+		Location: 47,20
 		TurretFacing: 92
 	GDICYard: fact
 		Location: 59,13
@@ -569,7 +569,7 @@ Actors:
 		Location: 53,14
 		Owner: GDI
 	GDIWeap: weap
-		Location: 48,12
+		Location: 48,13
 		Owner: GDI
 	MoneyCrate: MoneyCrate
 		Owner: Neutral
@@ -579,7 +579,7 @@ Actors:
 		Owner: NodBase
 		Health: 37
 	NodHand: hand
-		Location: 59,55
+		Location: 59,56
 		Owner: NodBase
 		Health: 45
 	NodNuke: nuke

--- a/mods/cnc/maps/nod08a/nod08a-AI.lua
+++ b/mods/cnc/maps/nod08a/nod08a-AI.lua
@@ -18,7 +18,7 @@ BaseNuke2 = { type = "nuke", pos = CPos.New(59, 19), cost = 500, exists = true }
 BaseNuke3 = { type = "nuke", pos = CPos.New(57, 18), cost = 500, exists = true }
 BaseNuke4 = { type = "nuke", pos = CPos.New(58, 16), cost = 500, exists = true }
 InfantryProduction = { type = "pyle", pos = CPos.New(53, 14), cost = 500, exists = true }
-VehicleProduction = { type = "weap", pos = CPos.New(48, 12), cost = 2000, exists = true }
+VehicleProduction = { type = "weap", pos = CPos.New(48, 13), cost = 2000, exists = true }
 
 BaseBuildings = { BaseProc, BaseNuke1, BaseNuke2, BaseNuke3, BaseNuke4, InfantryProduction, VehicleProduction }
 

--- a/mods/cnc/maps/nod08b/map.yaml
+++ b/mods/cnc/maps/nod08b/map.yaml
@@ -644,7 +644,7 @@ Actors:
 		Owner: Neutral
 		Location: 48,27
 	GDIBuilding1: atwr
-		Location: 11,47
+		Location: 11,48
 		Owner: GDI
 	GDIBuilding2: gtwr
 		Location: 31,49
@@ -719,7 +719,7 @@ Actors:
 		Location: 12,52
 		Facing: 92
 	GDIWeap: weap
-		Location: 8,47
+		Location: 8,48
 		Owner: GDI
 	Gunboat1: boat
 		Location: 31,59
@@ -749,7 +749,7 @@ Actors:
 		Owner: NodBase
 		Health: 39
 	NodHand: hand
-		Location: 58,2
+		Location: 58,3
 		Owner: NodBase
 		Health: 31
 	NodNuke: nuke

--- a/mods/cnc/maps/nod08b/nod08b-AI.lua
+++ b/mods/cnc/maps/nod08b/nod08b-AI.lua
@@ -18,7 +18,7 @@ BaseNuke2 = { type = "nuke", pos = CPos.New(7, 52), cost = 500, exists = true }
 BaseNuke3 = { type = "nuke", pos = CPos.New(11, 53), cost = 500, exists = true }
 BaseNuke4 = { type = "nuke", pos = CPos.New(13, 52), cost = 500, exists = true }
 InfantryProduction = { type = "pyle", pos = CPos.New(15, 52), cost = 500, exists = true }
-VehicleProduction = { type = "weap", pos = CPos.New(8, 47), cost = 2000, exists = true }
+VehicleProduction = { type = "weap", pos = CPos.New(8, 48), cost = 2000, exists = true }
 
 BaseBuildings = { BaseProc, BaseNuke1, BaseNuke2, BaseNuke3, BaseNuke4, InfantryProduction, VehicleProduction }
 

--- a/mods/cnc/maps/nod09/map.yaml
+++ b/mods/cnc/maps/nod09/map.yaml
@@ -771,11 +771,11 @@ Actors:
 		Owner: GDI
 	GDIBuilding4: atwr
 		Owner: GDI
-		Location: 45,6
+		Location: 45,7
 		TurretFacing: 92
 	GDIBuilding5: atwr
 		Owner: GDI
-		Location: 45,10
+		Location: 45,11
 		TurretFacing: 92
 	GDIBuilding6: silo
 		Location: 59,13
@@ -836,7 +836,7 @@ Actors:
 		Location: 49,4
 		Owner: GDI
 	GDIWeap: weap
-		Location: 51,6
+		Location: 51,7
 		Owner: GDI
 	Gunboat: boat
 		Location: 60,58

--- a/mods/cnc/maps/nod09/nod09-AI.lua
+++ b/mods/cnc/maps/nod09/nod09-AI.lua
@@ -18,7 +18,7 @@ BaseNuke2 = { type = "nuke", pos = CPos.New(55, 7), cost = 500, exists = true }
 BaseNuke3 = { type = "nuke", pos = CPos.New(59, 7), cost = 500, exists = true }
 BaseNuke4 = { type = "nuke", pos = CPos.New(59, 10), cost = 500, exists = true }
 InfantryProduction = { type = "pyle", pos = CPos.New(49, 4), cost = 500, exists = true }
-VehicleProduction = { type = "weap", pos = CPos.New(51, 6), cost = 2000, exists = true }
+VehicleProduction = { type = "weap", pos = CPos.New(51, 7), cost = 2000, exists = true }
 
 BaseBuildings = { BaseProc, BaseNuke1, BaseNuke2, BaseNuke3, BaseNuke4, InfantryProduction, VehicleProduction }
 

--- a/mods/cnc/maps/shellmap/map.yaml
+++ b/mods/cnc/maps/shellmap/map.yaml
@@ -81,7 +81,7 @@ Actors:
 		Location: 56,44
 		Owner: GDI
 	Actor17: atwr
-		Location: 55,41
+		Location: 55,42
 		Owner: GDI
 	Actor18: nuke
 		Location: 70,45
@@ -108,7 +108,7 @@ Actors:
 		Location: 64,45
 		Owner: GDI
 	Actor26: atwr
-		Location: 66,41
+		Location: 66,42
 		Owner: GDI
 	Actor27: tc02
 		Location: 65,42
@@ -165,7 +165,7 @@ Actors:
 		Location: 79,5
 		Owner: Nod
 	Actor49: hand
-		Location: 15,7
+		Location: 15,8
 		Owner: Nod
 	Actor50: cycl
 		Location: 13,11

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -283,14 +283,15 @@ HAND:
 		Prerequisites: anypower
 		Queue: Building.Nod
 	Building:
-		Footprint: __ xx xx
-		Dimensions: 2,3
+		Footprint: xx xx
+		Dimensions: 2,2
 	Health:
 		HP: 500
 	RevealsShroud:
 		Range: 5c0
 	Bib:
 	RallyPoint:
+		Offset: 1,2
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
@@ -366,8 +367,8 @@ WEAP:
 		Prerequisites: proc
 		Queue: Building.GDI
 	Building:
-		Footprint: ___ xxx ===
-		Dimensions: 3,3
+		Footprint: xxx ===
+		Dimensions: 3,2
 	Selectable:
 		Bounds: 72,54,0,5
 	SelectionDecorations:
@@ -380,10 +381,10 @@ WEAP:
 	WithProductionDoorOverlay:
 		Sequence: build-top
 	RallyPoint:
-		Offset: 0,3
+		Offset: 0,2
 	Exit@1:
-		SpawnOffset: -341,-341,0
-		ExitCell: 0,2
+		SpawnOffset: -512,-512,0
+		ExitCell: 0,1
 		ExitDelay: 3
 	Production:
 		Produces: Vehicle.GDI
@@ -604,8 +605,8 @@ TMPL:
 		Prerequisites: anyhq, ~techlevel.high
 		Queue: Building.Nod
 	Building:
-		Footprint: ___ xxx xxx
-		Dimensions: 3,3
+		Footprint: xxx xxx
+		Dimensions: 3,2
 	Selectable:
 		Bounds: 72,60,0,9
 	SelectionDecorations:
@@ -740,13 +741,10 @@ OBLI:
 		BuildPaletteOrder: 60
 		Prerequisites: tmpl, ~techlevel.high
 		Queue: Defence.Nod
-	Building:
-		Footprint: _ x
-		Dimensions: 1,2
 	Selectable:
-		Bounds: 24,24,0,12
+		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 22,42
+		VisualBounds: 22,42,0,-9
 	RequiresPower:
 	DisabledOverlay:
 	Health:
@@ -760,7 +758,7 @@ OBLI:
 	WithChargeAnimation:
 	Armament:
 		Weapon: Laser
-		LocalOffset: 0,0,725
+		LocalOffset: 0,-85,1280
 		FireDelay: 0
 	AttackCharge:
 		ChargeAudio: obelpowr.aud
@@ -820,13 +818,10 @@ ATWR:
 		BuildPaletteOrder: 60
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Defence.GDI
-	Building:
-		Footprint: _ x
-		Dimensions: 1,2
 	Selectable:
-		Bounds: 24,24,0,12
+		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 24,48,0,-3
+		VisualBounds: 22,42,0,-9
 	RequiresPower:
 	DisabledOverlay:
 	Health:
@@ -839,7 +834,7 @@ ATWR:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 255
-		Offset: 128,128,0
+		Offset: 128,128,384
 	Armament@PRIMARY:
 		Weapon: TowerMissle
 		LocalOffset: 256,128,0, 256,-128,0

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -308,7 +308,9 @@ HAND:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
 	Selectable:
-		Bounds: 48,60,0,-3
+		Bounds: 48,48
+	SelectionDecorations:
+		VisualBounds: 48,68,0,-10
 
 AFLD:
 	Inherits: ^BaseBuilding
@@ -370,9 +372,9 @@ WEAP:
 		Footprint: xxx ===
 		Dimensions: 3,2
 	Selectable:
-		Bounds: 72,54,0,5
+		Bounds: 72,48
 	SelectionDecorations:
-		VisualBounds: 72,64,0,-5
+		VisualBounds: 72,64,0,-16
 	Health:
 		HP: 1000
 	RevealsShroud:
@@ -608,9 +610,9 @@ TMPL:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Selectable:
-		Bounds: 72,60,0,9
+		Bounds: 72,48
 	SelectionDecorations:
-		VisualBounds: 72,72,0,-3
+		VisualBounds: 72,68,0,-12
 	RequiresPower:
 	CanPowerDown:
 		PowerupSound: EnablePower
@@ -744,7 +746,7 @@ OBLI:
 	Selectable:
 		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 22,42,0,-9
+		VisualBounds: 22,44,0,-10
 	RequiresPower:
 	DisabledOverlay:
 	Health:
@@ -821,7 +823,7 @@ ATWR:
 	Selectable:
 		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 22,42,0,-9
+		VisualBounds: 22,48,0,-12
 	RequiresPower:
 	DisabledOverlay:
 	Health:

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -109,6 +109,8 @@ silo:
 		AddExtension: False
 
 hand:
+	Defaults:
+		Offset: 0,-8
 	idle:
 	damaged-idle:
 		Start: 1
@@ -121,8 +123,10 @@ hand:
 	bib: bib3
 		UseTilesetExtension: true
 		Length: *
+		Offset: 0,0
 	icon: handicnh.tem
 		AddExtension: False
+		Offset: 0,0
 
 pyle:
 	idle:
@@ -145,9 +149,13 @@ pyle:
 		AddExtension: False
 
 weap:
+	Defaults:
+		Offset: 0,-12
 	idle:
+		ZOffset: -511
 	damaged-idle:
 		Start: 1
+		ZOffset: -511
 	dead:
 		Start: 2
 		Tick: 800
@@ -164,8 +172,10 @@ weap:
 	bib: bib2
 		UseTilesetExtension: true
 		Length: *
+		Offset: 0,0
 	icon: weapicnh.tem
 		AddExtension: False
+		Offset: 0,0
 
 afld:
 	idle:
@@ -322,6 +332,8 @@ eye:
 		AddExtension: False
 
 tmpl:
+	Defaults:
+		Offset: 0,-12
 	idle:
 	damaged-idle:
 		Start: 5
@@ -339,10 +351,14 @@ tmpl:
 	bib: bib2
 		UseTilesetExtension: true
 		Length: *
+		Offset: 0,0
 	icon: tmplicnh.tem
 		AddExtension: False
+		Offset: 0,0
 
 obli:
+	Defaults:
+		Offset: 0,-12
 	idle:
 	damaged-idle:
 		Start: 4
@@ -369,6 +385,7 @@ obli:
 		Offset: -1,-3
 	icon: obliicnh.tem
 		AddExtension: False
+		Offset: 0,0
 
 brik:
 	idle:
@@ -514,22 +531,19 @@ gtwr:
 		AddExtension: False
 
 atwr:
+	Defaults:
+		Offset: 0,-13
 	idle:
-		Offset: 0,-1
 	damaged-idle:
 		Start: 1
-		Offset: 0,-1
 	dead:
 		Start: 2
-		Offset: 0,-1
 		Tick: 800
 	make: atwrmake
 		Length: *
 		Tick: 80
-		Offset: 0,-1
 	muzzle: gunfire2
 		Length: *
-		Offset: 0,-1
 	bib: mbGTWR
 		UseTilesetExtension: true
 		TilesetOverrides:
@@ -540,6 +554,7 @@ atwr:
 		Offset: -3,0
 	icon: atwricnh.tem
 		AddExtension: False
+		Offset: 0,0
 
 hosp:
 	idle:

--- a/mods/ra/maps/allies-01/map.yaml
+++ b/mods/ra/maps/allies-01/map.yaml
@@ -117,7 +117,7 @@ Actors:
 		Location: 54,45
 		Owner: Neutral
 	Actor22: tsla
-		Location: 71,59
+		Location: 71,60
 		Owner: USSR
 	Actor23: powr
 		Location: 75,64
@@ -138,10 +138,10 @@ Actors:
 		Location: 61,64
 		Owner: USSR
 	Actor30: tsla
-		Location: 67,67
+		Location: 67,68
 		Owner: USSR
 	Actor31: tsla
-		Location: 60,66
+		Location: 60,67
 		Owner: USSR
 	Actor32: weap
 		Location: 65,62

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1133,7 +1133,7 @@ Actors:
 		Location: 81,77
 		Owner: USSR
 	USSRAdvancedPowerPlant: apwr
-		Location: 81,80
+		Location: 81,81
 		Owner: USSR
 	USSRRadarDome: dome
 		Location: 78,80

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -968,10 +968,10 @@ Actors:
 		Location: 83,79
 		Owner: USSR
 	Actor302: apwr
-		Location: 5,5
+		Location: 5,6
 		Owner: USSR
 	Actor304: apwr
-		Location: 5,5
+		Location: 5,6
 		Owner: USSR
 	ExplosiveBarrel: brl3
 		Location: 55,40

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -938,10 +938,10 @@ Actors:
 		Location: 53,85
 		Owner: USSR
 	Actor314: tsla
-		Location: 40,73
+		Location: 40,74
 		Owner: USSR
 	Actor315: tsla
-		Location: 48,73
+		Location: 48,74
 		Owner: USSR
 	Actor317: powr
 		Location: 46,49

--- a/mods/ra/maps/center-of-attention-redux-2/map.yaml
+++ b/mods/ra/maps/center-of-attention-redux-2/map.yaml
@@ -571,7 +571,7 @@ Actors:
 		Location: 65,66
 		Owner: Creeps
 	Actor178: agun
-		Location: 67,69
+		Location: 67,70
 		Owner: Creeps
 	Actor180: v2rl
 		Location: 73,65
@@ -778,7 +778,7 @@ Actors:
 		Location: 64,62
 		Owner: Neutral
 	Actor174: agun
-		Location: 67,61
+		Location: 67,62
 		Owner: Creeps
 	Actor248: brl3
 		Location: 71,63
@@ -874,10 +874,10 @@ Actors:
 		Location: 67,60
 		Owner: Creeps
 	Actor233: apwr
-		Location: 121,91
+		Location: 121,92
 		Owner: Creeps
 	Actor232: apwr
-		Location: 121,96
+		Location: 121,97
 		Owner: Creeps
 
 Rules: rules.yaml

--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -132,7 +132,7 @@ Actors:
 		Location: 64,63
 		Owner: Allies
 	Actor153: apwr
-		Location: 93,87
+		Location: 93,88
 		Owner: Allies
 	Actor49: brik
 		Location: 71,63
@@ -156,10 +156,10 @@ Actors:
 		Location: 74,67
 		Owner: Allies
 	Actor50: apwr
-		Location: 51,14
+		Location: 51,15
 		Owner: Soviets
 	Actor63: tsla
-		Location: 48,31
+		Location: 48,32
 		Owner: Soviets
 	Actor56: v23
 		Location: 24,36
@@ -231,7 +231,7 @@ Actors:
 		Location: 14,56
 		Owner: Neutral
 	Actor62: apwr
-		Location: 38,17
+		Location: 38,18
 		Owner: Soviets
 	Actor72: brik
 		Location: 87,70
@@ -287,10 +287,10 @@ Actors:
 		Location: 94,28
 		Owner: Soviets
 	Actor103: apwr
-		Location: 118,36
+		Location: 118,37
 		Owner: Soviets
 	Actor101: apwr
-		Location: 115,38
+		Location: 115,39
 		Owner: Soviets
 	Actor110: fcom
 		Location: 106,44
@@ -299,13 +299,13 @@ Actors:
 		Location: 114,43
 		Owner: Soviets
 	Actor104: apwr
-		Location: 115,35
+		Location: 115,36
 		Owner: Soviets
 	Actor91: apwr
-		Location: 118,39
+		Location: 118,40
 		Owner: Soviets
 	Actor108: tsla
-		Location: 95,33
+		Location: 95,34
 		Owner: Soviets
 	Actor112: ftur
 		Location: 93,29
@@ -317,7 +317,7 @@ Actors:
 		Location: 37,28
 		Owner: Soviets
 	Actor115: tsla
-		Location: 40,24
+		Location: 40,25
 		Owner: Soviets
 	Actor117: fix
 		Location: 106,34
@@ -333,13 +333,13 @@ Actors:
 		Location: 112,49
 		Owner: Soviets
 	Actor126: tsla
-		Location: 110,27
+		Location: 110,28
 		Owner: Soviets
 	Actor124: dome
 		Location: 118,46
 		Owner: Soviets
 	Actor125: tsla
-		Location: 111,43
+		Location: 111,44
 		Owner: Soviets
 	Actor127: rock2
 		Location: 103,54
@@ -351,13 +351,13 @@ Actors:
 		Location: 99,28
 		Owner: Soviets
 	Actor130: apwr
-		Location: 119,33
+		Location: 119,34
 		Owner: Soviets
 	Actor131: t08
 		Location: 121,43
 		Owner: Neutral
 	Actor132: apwr
-		Location: 116,32
+		Location: 116,33
 		Owner: Soviets
 	Actor133: oilb
 		Location: 76,37
@@ -418,7 +418,7 @@ Actors:
 		Owner: Allies
 		Facing: 110
 	Actor150: apwr
-		Location: 94,90
+		Location: 94,91
 		Owner: Allies
 	Actor35: pbox
 		Location: 68,85
@@ -476,11 +476,11 @@ Actors:
 		Location: 107,52
 		Owner: Soviets
 	Actor54: agun
-		Location: 76,92
+		Location: 76,93
 		Owner: Allies
 		Facing: 150
 	Actor155: apwr
-		Location: 90,87
+		Location: 90,88
 		Owner: Allies
 	Actor213: brik
 		Location: 60,80
@@ -503,34 +503,34 @@ Actors:
 		Location: 72,83
 		Owner: Allies
 	Actor89: apwr
-		Location: 93,84
+		Location: 93,85
 		Owner: Allies
 	Actor161: powr
 		Location: 89,90
 		Owner: Allies
 	Actor84: apwr
-		Location: 38,9
+		Location: 38,10
 		Owner: Soviets
 	Actor96: apwr
-		Location: 38,12
+		Location: 38,13
 		Owner: Soviets
 	Actor98: apwr
-		Location: 34,12
+		Location: 34,13
 		Owner: Soviets
 	Actor99: apwr
-		Location: 34,9
+		Location: 34,10
 		Owner: Soviets
 	Actor100: apwr
-		Location: 30,12
+		Location: 30,13
 		Owner: Soviets
 	Actor189: apwr
-		Location: 30,9
+		Location: 30,10
 		Owner: Soviets
 	Actor190: apwr
-		Location: 26,12
+		Location: 26,13
 		Owner: Soviets
 	Actor191: apwr
-		Location: 26,9
+		Location: 26,10
 		Owner: Soviets
 	Actor120: brik
 		Location: 95,70
@@ -551,7 +551,7 @@ Actors:
 		Location: 59,80
 		Owner: Allies
 	Actor149: apwr
-		Location: 92,93
+		Location: 92,94
 		Owner: Allies
 	Actor38: brik
 		Location: 72,67
@@ -610,7 +610,7 @@ Actors:
 		Location: 53,62
 		Owner: Allies
 	Actor151: apwr
-		Location: 91,90
+		Location: 91,91
 		Owner: Allies
 	Actor31: t08
 		Location: 56,58
@@ -665,7 +665,7 @@ Actors:
 		Location: 44,67
 		Owner: Allies
 	Actor66: gap
-		Location: 62,70
+		Location: 62,71
 		Owner: Allies
 	Actor218: sbag
 		Location: 43,68
@@ -858,7 +858,7 @@ Actors:
 		Location: 49,77
 		Owner: Allies
 	Actor256: gap
-		Location: 74,75
+		Location: 74,76
 		Owner: Allies
 	Actor313: brik
 		Location: 37,70
@@ -921,7 +921,7 @@ Actors:
 		Location: 63,81
 		Owner: Allies
 	Actor148: apwr
-		Location: 95,93
+		Location: 95,94
 		Owner: Allies
 	Actor324: e3
 		Location: 73,68
@@ -1065,7 +1065,7 @@ Actors:
 		Location: 81,91
 		Owner: Allies
 	Actor364: gap
-		Location: 77,90
+		Location: 77,91
 		Owner: Allies
 	Actor366: brik
 		Location: 59,60
@@ -1134,10 +1134,10 @@ Actors:
 		Location: 96,79
 		Owner: Allies
 	Actor79: agun
-		Location: 70,65
+		Location: 70,66
 		Owner: Allies
 	Actor118: agun
-		Location: 47,69
+		Location: 47,70
 		Owner: Allies
 		Facing: 64
 	SovietWarFactory1: weap

--- a/mods/ra/maps/evacuation/map.yaml
+++ b/mods/ra/maps/evacuation/map.yaml
@@ -392,7 +392,7 @@ Actors:
 		Location: 74,36
 		Owner: Soviets
 	Actor306: apwr
-		Location: 54,65
+		Location: 54,67
 		Owner: Soviets
 	Actor134: tc03
 		Location: 110,107
@@ -717,7 +717,7 @@ Actors:
 		Location: 93,18
 		Owner: Soviets
 	Actor489: apwr
-		Location: 76,19
+		Location: 76,20
 		Owner: Soviets
 	Actor517: sbag
 		Location: 96,17
@@ -726,7 +726,7 @@ Actors:
 		Location: 93,19
 		Owner: Soviets
 	Actor488: apwr
-		Location: 80,19
+		Location: 80,20
 		Owner: Soviets
 	Actor116: cycl
 		Location: 74,20
@@ -744,7 +744,7 @@ Actors:
 		Location: 101,35
 		Owner: Soviets
 	Actor487: apwr
-		Location: 80,16
+		Location: 80,17
 		Owner: Soviets
 	Actor523: t17
 		Location: 85,20
@@ -786,13 +786,13 @@ Actors:
 		Location: 96,18
 		Owner: Soviets
 	Actor486: apwr
-		Location: 76,16
+		Location: 76,17
 		Owner: Soviets
 	Actor514: tc03
 		Location: 104,20
 		Owner: Neutral
 	Actor307: apwr
-		Location: 54,59
+		Location: 54,60
 		Owner: Soviets
 	Actor91: cycl
 		Location: 74,17
@@ -861,7 +861,7 @@ Actors:
 		Location: 35,99
 		Owner: Allies
 	Actor204: apwr
-		Location: 37,107
+		Location: 37,108
 		Owner: Allies
 	Actor92: powr
 		Location: 101,46
@@ -870,7 +870,7 @@ Actors:
 		Location: 110,93
 		Owner: Soviets
 	Actor83: apwr
-		Location: 37,104
+		Location: 37,105
 		Owner: Allies
 	Actor162: mine
 		Location: 20,91
@@ -923,7 +923,7 @@ Actors:
 		Location: 45,79
 		Owner: Neutral
 	Actor171: tsla
-		Location: 41,56
+		Location: 41,57
 		Owner: Soviets
 	Actor570: oilb
 		Location: 43,80
@@ -1010,7 +1010,7 @@ Actors:
 		Location: 102,78
 		Owner: Soviets
 	Actor283: apwr
-		Location: 51,58
+		Location: 51,59
 		Owner: Soviets
 	Actor72: dog
 		Location: 81,71
@@ -1079,7 +1079,7 @@ Actors:
 		Location: 64,63
 		Owner: Neutral
 	Actor265: tsla
-		Location: 61,64
+		Location: 61,65
 		Owner: Soviets
 	Actor257: proc
 		Location: 35,28
@@ -1124,7 +1124,7 @@ Actors:
 		Location: 81,97
 		Owner: Neutral
 	Actor176: tsla
-		Location: 56,36
+		Location: 56,37
 		Owner: Soviets
 	Actor681: wood
 		Location: 70,100
@@ -1133,7 +1133,7 @@ Actors:
 		Location: 69,100
 		Owner: Neutral
 	Actor308: apwr
-		Location: 54,62
+		Location: 54,63
 		Owner: Soviets
 	Actor262: t06
 		Location: 20,51
@@ -1175,13 +1175,13 @@ Actors:
 		Location: 45,44
 		Owner: Soviets
 	Actor179: tsla
-		Location: 25,52
+		Location: 25,53
 		Owner: Soviets
 	Actor180: ftur
 		Location: 32,25
 		Owner: Soviets
 	Actor700: tsla
-		Location: 55,17
+		Location: 55,18
 		Owner: Soviets
 	Actor183: ftur
 		Location: 22,40
@@ -1283,7 +1283,7 @@ Actors:
 		Location: 102,68
 		Owner: Soviets
 	Actor309: apwr
-		Location: 51,64
+		Location: 51,65
 		Owner: Soviets
 	Actor316: fact
 		Location: 59,61
@@ -1295,7 +1295,7 @@ Actors:
 		Location: 67,52
 		Owner: Neutral
 	Actor763: tsla
-		Location: 79,24
+		Location: 79,25
 		Owner: Soviets
 	Actor764: e1
 		Location: 95,59
@@ -1349,7 +1349,7 @@ Actors:
 		Location: 40,24
 		Owner: Neutral
 	Actor322: tsla
-		Location: 48,64
+		Location: 48,65
 		Owner: Soviets
 	Actor255: gun
 		Location: 42,91
@@ -1418,13 +1418,13 @@ Actors:
 		Location: 65,44
 		Owner: Soviets
 	Actor197: tsla
-		Location: 55,44
+		Location: 55,45
 		Owner: Soviets
 	Actor277: fenc
 		Location: 57,39
 		Owner: Soviets
 	Actor288: apwr
-		Location: 51,61
+		Location: 51,62
 		Owner: Soviets
 	Actor278: fenc
 		Location: 56,39

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -485,22 +485,22 @@ Actors:
 		Location: 23,30
 		Owner: Neutral
 	Actor160: apwr
-		Location: 32,88
+		Location: 32,89
 		Owner: Soviets
 	Actor162: apwr
-		Location: 41,92
+		Location: 41,93
 		Owner: Soviets
 	Actor161: apwr
-		Location: 24,96
+		Location: 24,97
 		Owner: Soviets
 	Actor128: apwr
-		Location: 37,90
+		Location: 37,91
 		Owner: Soviets
 	Actor159: apwr
-		Location: 28,92
+		Location: 28,93
 		Owner: Soviets
 	Actor127: apwr
-		Location: 34,94
+		Location: 34,95
 		Owner: Soviets
 	Actor174: brik
 		Location: 47,85
@@ -522,10 +522,10 @@ Actors:
 		Location: 37,84
 		Owner: Soviets
 	Actor172: tsla
-		Location: 46,84
+		Location: 46,85
 		Owner: Soviets
 	Actor176: tsla
-		Location: 37,84
+		Location: 37,85
 		Owner: Soviets
 	Actor178: brik
 		Location: 38,84
@@ -792,7 +792,7 @@ Actors:
 		Location: 66,80
 		Owner: Soviets
 	Actor261: tsla
-		Location: 72,79
+		Location: 72,80
 		Owner: Soviets
 	Actor360: brik
 		Location: 57,62
@@ -894,7 +894,7 @@ Actors:
 		Location: 21,57
 		Owner: Neutral
 	Actor299: tsla
-		Location: 78,64
+		Location: 78,65
 		Owner: Soviets
 	Actor302: wood
 		Location: 18,58
@@ -1040,7 +1040,7 @@ Actors:
 		Owner: Soviets
 		FreeActor: False
 	Actor343: tsla
-		Location: 65,79
+		Location: 65,80
 		Owner: Soviets
 	Actor344: fact
 		Location: 64,68
@@ -1206,22 +1206,22 @@ Actors:
 		Location: 34,100
 		Owner: Soviets
 	Actor400: apwr
-		Location: 24,104
+		Location: 24,105
 		Owner: Soviets
 	Actor399: apwr
-		Location: 24,100
+		Location: 24,101
 		Owner: Soviets
 	Actor398: apwr
-		Location: 24,92
+		Location: 24,93
 		Owner: Soviets
 	Actor406: apwr
-		Location: 59,69
+		Location: 59,70
 		Owner: Soviets
 	Actor405: apwr
-		Location: 59,65
+		Location: 59,66
 		Owner: Soviets
 	Actor404: apwr
-		Location: 59,61
+		Location: 59,62
 		Owner: Soviets
 	Actor407: sam
 		Location: 77,61

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -1403,10 +1403,10 @@ Actors:
 		Location: 76,37
 		Owner: BadGuy
 	Actor439: apwr
-		Location: 98,32
+		Location: 98,33
 		Owner: BadGuy
 	Actor440: apwr
-		Location: 94,34
+		Location: 94,35
 		Owner: BadGuy
 	Actor441: barr
 		Location: 97,40
@@ -1424,13 +1424,13 @@ Actors:
 		Location: 86,31
 		Owner: BadGuy
 	Actor447: tsla
-		Location: 93,44
+		Location: 93,45
 		Owner: BadGuy
 	Actor448: tsla
-		Location: 80,44
+		Location: 80,45
 		Owner: BadGuy
 	Actor449: apwr
-		Location: 95,31
+		Location: 95,32
 		Owner: BadGuy
 	Actor450: spen
 		Location: 102,47
@@ -1461,16 +1461,16 @@ Actors:
 		Location: 80,74
 		Owner: USSR
 	Actor459: apwr
-		Location: 73,84
+		Location: 73,85
 		Owner: USSR
 	Actor460: apwr
-		Location: 89,75
+		Location: 89,76
 		Owner: USSR
 	Actor461: apwr
-		Location: 69,86
+		Location: 69,87
 		Owner: USSR
 	Actor462: apwr
-		Location: 86,76
+		Location: 86,77
 		Owner: USSR
 	Actor463: barr
 		Location: 66,76
@@ -1479,16 +1479,16 @@ Actors:
 		Location: 91,86
 		Owner: USSR
 	Actor465: tsla
-		Location: 78,73
+		Location: 78,74
 		Owner: USSR
 	Actor466: tsla
-		Location: 83,73
+		Location: 83,74
 		Owner: USSR
 	Actor467: tsla
-		Location: 62,75
+		Location: 62,76
 		Owner: USSR
 	Actor468: tsla
-		Location: 62,86
+		Location: 62,87
 		Owner: USSR
 	Actor469: weap
 		Location: 81,82
@@ -1515,7 +1515,7 @@ Actors:
 		Location: 78,87
 		Owner: USSR
 	Actor477: apwr
-		Location: 89,78
+		Location: 89,79
 		Owner: USSR
 	Actor480: powr
 		Location: 34,61
@@ -1599,11 +1599,11 @@ Actors:
 		Owner: Outpost
 		Health: 33
 	Actor511: apwr
-		Location: 26,20
+		Location: 26,21
 		Owner: Outpost
 		Health: 25
 	Actor512: apwr
-		Location: 23,23
+		Location: 23,24
 		Owner: Outpost
 		Health: 14
 	Actor515: v02
@@ -1628,7 +1628,7 @@ Actors:
 		Location: 21,99
 		Owner: Neutral
 	Actor522: apwr
-		Location: 72,87
+		Location: 72,88
 		Owner: USSR
 	Actor523: v02
 		Location: 42,47

--- a/mods/ra/maps/soviet-03/map.yaml
+++ b/mods/ra/maps/soviet-03/map.yaml
@@ -967,10 +967,10 @@ Actors:
 		Location: 79,32
 		Owner: Soviet
 	BaseBuilding3: apwr
-		Location: 71,22
+		Location: 71,23
 		Owner: Soviet
 	BaseBuilding4: apwr
-		Location: 86,26
+		Location: 86,27
 		Owner: Soviet
 	BaseBuilding5: barl
 		Location: 74,24

--- a/mods/ra/maps/soviet-04a/map.yaml
+++ b/mods/ra/maps/soviet-04a/map.yaml
@@ -501,10 +501,10 @@ Actors:
 		Location: 67,45
 		Owner: Greece
 	Gap1: gap
-		Location: 83,51
+		Location: 83,52
 		Owner: Greece
 	Gap2: gap
-		Location: 59,65
+		Location: 59,66
 		Owner: Greece
 	Powr1: powr
 		Location: 47,47
@@ -516,7 +516,7 @@ Actors:
 		Location: 96,45
 		Owner: Greece
 	APwr: apwr
-		Location: 49,56
+		Location: 49,57
 		Owner: Greece
 	Fix1: fix
 		Location: 56,55

--- a/mods/ra/maps/soviet-04b/map.yaml
+++ b/mods/ra/maps/soviet-04b/map.yaml
@@ -535,10 +535,10 @@ Actors:
 		Location: 96,54
 		Owner: Greece
 	Gap1: gap
-		Location: 86,50
+		Location: 86,51
 		Owner: Greece
 	Gap2: gap
-		Location: 90,62
+		Location: 90,63
 		Owner: Greece
 	Weap: weap
 		Location: 92,50

--- a/mods/ra/maps/soviet-05/map.yaml
+++ b/mods/ra/maps/soviet-05/map.yaml
@@ -213,7 +213,7 @@ Actors:
 		Location: 78,61
 		Owner: Neutral
 	Actor54: agun
-		Location: 73,45
+		Location: 73,46
 		Owner: Greece
 	Actor55: gun
 		Location: 69,49
@@ -261,7 +261,7 @@ Actors:
 		Owner: Greece
 		Facing: 160
 	Actor69: agun
-		Location: 68,46
+		Location: 68,47
 		Owner: Greece
 	Actor70: proc
 		Location: 63,42

--- a/mods/ra/maps/soviet-06a/map.yaml
+++ b/mods/ra/maps/soviet-06a/map.yaml
@@ -526,7 +526,7 @@ Actors:
 		Owner: Greece
 		Facing: 128
 	Actor163: gap
-		Location: 24,21
+		Location: 24,22
 		Owner: Greece
 	Actor164: syrd
 		Location: 35,14
@@ -716,7 +716,7 @@ Actors:
 		Owner: Neutral
 	AGun: agun
 		Owner: Greece
-		Location: 25,4
+		Location: 25,5
 		TurretFacing: 92
 	APCWaypoint1: waypoint
 		Location: 52,50
@@ -725,11 +725,11 @@ Actors:
 		Location: 58,51
 		Owner: Neutral
 	Apwr: apwr
-		Location: 18,11
+		Location: 18,12
 		Owner: Greece
 	Apwr2: apwr
 		Owner: Greece
-		Location: 27,5
+		Location: 27,6
 	AttackWaypoint1: waypoint
 		Owner: Neutral
 		Location: 24,30

--- a/mods/ra/maps/soviet-06b/map.yaml
+++ b/mods/ra/maps/soviet-06b/map.yaml
@@ -433,7 +433,7 @@ Actors:
 		Owner: Neutral
 	AGun: agun
 		Owner: Greece
-		Location: 69,48
+		Location: 69,49
 		TurretFacing: 92
 	APCWaypoint1: waypoint
 		Location: 39,62
@@ -442,10 +442,10 @@ Actors:
 		Location: 46,66
 		Owner: Neutral
 	Apwr: apwr
-		Location: 76,40
+		Location: 76,41
 		Owner: Greece
 	Apwr2: apwr
-		Location: 77,44
+		Location: 77,45
 		Owner: Greece
 	AttackWaypoint1: waypoint
 		Owner: Neutral

--- a/mods/ra/maps/survival01/map.yaml
+++ b/mods/ra/maps/survival01/map.yaml
@@ -254,7 +254,7 @@ Actors:
 		Location: 65,57
 		Owner: Allies
 	Actor80: apwr
-		Location: 68,53
+		Location: 68,54
 		Owner: Allies
 	Actor81: powr
 		Location: 65,53
@@ -356,7 +356,7 @@ Actors:
 		Location: 58,41
 		Owner: Allies
 	Actor104: apwr
-		Location: 71,47
+		Location: 71,48
 		Owner: Allies
 	Actor105: fact
 		Location: 59,51
@@ -1040,7 +1040,7 @@ Actors:
 		Location: 78,17
 		Owner: Soviets
 	AdvancedPowerPlant3: apwr
-		Location: 88,12
+		Location: 88,13
 		Owner: Soviets
 	Silo1: silo
 		Location: 84,13
@@ -1091,10 +1091,10 @@ Actors:
 		Location: 22,12
 		Owner: Soviets
 	AdvancedPowerPlant1: apwr
-		Location: 24,5
+		Location: 24,6
 		Owner: Soviets
 	AdvancedPowerPlant2: apwr
-		Location: 16,13
+		Location: 16,14
 		Owner: Soviets
 	BadgerEntryPoint1: waypoint
 		Location: 1,54

--- a/mods/ra/maps/survival02/map.yaml
+++ b/mods/ra/maps/survival02/map.yaml
@@ -215,10 +215,10 @@ Actors:
 		Location: 14,17
 		Owner: Soviets
 	Actor69: apwr
-		Location: 75,6
+		Location: 75,7
 		Owner: Soviets
 	Actor73: tsla
-		Location: 16,12
+		Location: 16,13
 		Owner: Soviets
 	Actor67: barb
 		Location: 19,11
@@ -413,7 +413,7 @@ Actors:
 		Location: 34,47
 		Owner: Neutral
 	Actor134: agun
-		Location: 35,42
+		Location: 35,43
 		Owner: Allies
 		Health: 40
 	Actor135: gun
@@ -437,7 +437,7 @@ Actors:
 		Owner: Allies
 		Health: 50
 	Actor141: agun
-		Location: 32,31
+		Location: 32,32
 		Owner: Allies
 		Health: 40
 	Actor143: fenc
@@ -518,7 +518,7 @@ Actors:
 		Location: 45,32
 		Owner: Allies
 	Actor166: agun
-		Location: 46,37
+		Location: 46,38
 		Owner: Allies
 		Health: 50
 	Actor167: e1
@@ -576,7 +576,7 @@ Actors:
 		Location: 29,15
 		Owner: Neutral
 	Actor182: apwr
-		Location: 22,2
+		Location: 22,3
 		Owner: Soviets
 	Actor77: v2rl
 		Location: 40,23
@@ -632,7 +632,7 @@ Actors:
 		Location: 62,75
 		Owner: Soviets
 	Actor196: tsla
-		Location: 60,8
+		Location: 60,9
 		Owner: Soviets
 	Actor235: barl
 		Location: 64,70
@@ -728,7 +728,7 @@ Actors:
 		Location: 23,6
 		Owner: Neutral
 	Actor190: apwr
-		Location: 25,4
+		Location: 25,5
 		Owner: Soviets
 	Actor83: barl
 		Location: 63,69
@@ -908,7 +908,7 @@ Actors:
 		Location: 58,71
 		Owner: Soviets
 	boom1: apwr
-		Location: 56,72
+		Location: 56,73
 		Owner: Soviets
 	boom2: barr
 		Location: 65,69

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -183,8 +183,8 @@ FAPW:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Building:
-		Footprint: ___ xxx xxx
-		Dimensions: 3,3
+		Footprint: xxx xxx
+		Dimensions: 3,2
 	Health:
 		HP: 700
 	Armor:
@@ -192,6 +192,10 @@ FAPW:
 	Bib:
 	RenderSprites:
 		Image: APWR
+	Selectable:
+		Bounds: 72,48
+	SelectionDecorations:
+		VisualBounds: 72,60,0,-6
 	Valued:
 		Cost: 60
 

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -195,7 +195,7 @@ FAPW:
 	Selectable:
 		Bounds: 72,48
 	SelectionDecorations:
-		VisualBounds: 72,60,0,-6
+		VisualBounds: 72,68,0,-10
 	Valued:
 		Cost: 60
 

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -61,13 +61,10 @@ GAP:
 		Queue: Defense
 		BuildPaletteOrder: 110
 		Prerequisites: atek, ~structures.allies, ~techlevel.high
-	Building:
-		Footprint: _ x
-		Dimensions: 1,2
 	Selectable:
-		Bounds: 24,28,0,12
+		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 24,40,0,0
+		VisualBounds: 24,40,0,-8
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
@@ -407,14 +404,11 @@ TSLA:
 	Tooltip:
 		Name: Tesla Coil
 		Description: Advanced base defense.\nRequires power to operate.\nCan detect cloaked units.\n  Strong vs Vehicles, Infantry\n  Weak vs Aircraft
-	Building:
-		Footprint: _ x
-		Dimensions: 1,2
 	RequiresPower:
 	Selectable:
-		Bounds: 24,24,0,16
+		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 24,36,0,4
+		VisualBounds: 24,36,0,-6
 	CanPowerDown:
 		PowerupSound: EnablePower
 		PowerdownSound: DisablePower
@@ -430,7 +424,7 @@ TSLA:
 	WithChargeAnimation:
 	Armament:
 		Weapon: TeslaZap
-		LocalOffset: 0,0,427
+		LocalOffset: 0,0,896
 	AttackCharge:
 		ChargeAudio: tslachg2.aud
 		MaxCharges: 3
@@ -454,13 +448,10 @@ AGUN:
 	Tooltip:
 		Name: AA Gun
 		Description: Anti-Air base defense.\nRequires power to operate.\nCan detect cloaked units.\n  Strong vs Aircraft\n  Weak vs Ground units
-	Building:
-		Footprint: _ x
-		Dimensions: 1,2
 	Selectable:
-		Bounds: 24,28,0,16
+		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 24,36,0,12
+		VisualBounds: 24,32,0,-4
 	RequiresPower:
 	CanPowerDown:
 		PowerupSound: EnablePower
@@ -1293,12 +1284,12 @@ APWR:
 	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
-		Footprint: ___ xxx xxx
-		Dimensions: 3,3
+		Footprint: xxx xxx
+		Dimensions: 3,2
 	Selectable:
-		Bounds: 72,48,0,12
+		Bounds: 72,48
 	SelectionDecorations:
-		VisualBounds: 72,64,0,-2
+		VisualBounds: 72,60,0,-6
 	Health:
 		HP: 700
 	Armor:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1137,7 +1137,6 @@ AFLD:
 	RevealsShroud:
 		Range: 7c0
 	Exit@1:
-		SpawnOffset: 0,170,0
 		ExitCell: 1,1
 		Facing: 192
 		MoveIntoWorld: false

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -64,7 +64,7 @@ GAP:
 	Selectable:
 		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 24,40,0,-8
+		VisualBounds: 24,48,0,-12
 	RequiresPower:
 	CanPowerDown:
 	DisabledOverlay:
@@ -408,7 +408,7 @@ TSLA:
 	Selectable:
 		Bounds: 24,24
 	SelectionDecorations:
-		VisualBounds: 24,36,0,-6
+		VisualBounds: 24,40,0,-8
 	CanPowerDown:
 		PowerupSound: EnablePower
 		PowerdownSound: DisablePower
@@ -1288,7 +1288,7 @@ APWR:
 	Selectable:
 		Bounds: 72,48
 	SelectionDecorations:
-		VisualBounds: 72,60,0,-6
+		VisualBounds: 72,68,0,-10
 	Health:
 		HP: 700
 	Armor:

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -131,12 +131,16 @@ powr:
 
 apwr:
 	idle:
+		Offset: 0,-10
 	damaged-idle:
 		Start: 1
+		Offset: 0,-10
 	make: apwrmake
 		Length: *
+		Offset: 0,-10
 	dead: apwrdead
 		Tick: 800
+		Offset: 0,-10
 	bib: bib2
 		Length: *
 		UseTilesetExtension: true
@@ -374,29 +378,29 @@ agun:
 	idle:
 		Facings: 32
 		UseClassicFacingFudge: True
-		Offset: 0,-1
+		Offset: 0,-13
 	recoil:
 		Start: 32
 		Facings: 32
 		UseClassicFacingFudge: True
-		Offset: 0,-1
+		Offset: 0,-13
 	make: agunmake
 		Length: *
-		Offset: 0,-1
+		Offset: 0,-13
 	damaged-idle:
 		Start: 64
 		Facings: 32
 		UseClassicFacingFudge: True
-		Offset: 0,-1
+		Offset: 0,-13
 	damaged-recoil:
 		Start: 96
 		Facings: 32
 		UseClassicFacingFudge: True
-		Offset: 0,-1
+		Offset: 0,-13
 	muzzle: gunfire2
 		Start: 1
 		Length: 4
-		Offset: 0,-1
+		Offset: 0,-13
 	bib: mbAGUN
 		Length: *
 		UseTilesetExtension: true
@@ -441,23 +445,23 @@ ftur:
 
 tsla:
 	idle:
-		Offset: 0,-1
+		Offset: 0,-13
 	damaged-idle:
 		Start: 10
-		Offset: 0,-1
+		Offset: 0,-13
 	make: tslamake
 		Length: *
-		Offset: 0,-1
+		Offset: 0,-13
 	active:
 		Start: 1
 		Length: 9
 		Tick: 100
-		Offset: 0,-1
+		Offset: 0,-13
 	damaged-active:
 		Start: 11
 		Length: 9
 		Tick: 100
-		Offset: 0,-1
+		Offset: 0,-13
 	bib: mbTSLA
 		Length: *
 		UseTilesetExtension: true
@@ -498,14 +502,14 @@ hbox:
 gap:
 	idle:
 		Length: 32
-		Offset: 0,-2
+		Offset: 0,-14
 	damaged-idle:
 		Start: 32
 		Length: 32
-		Offset: 0,-2
+		Offset: 0,-14
 	make: gapmake
 		Length: *
-		Offset: 0,-2
+		Offset: 0,-14
 	bib: mbGAP
 		Length: *
 		UseTilesetExtension: true

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -152,11 +152,14 @@ apwr:
 barr:
 	idle:
 		Length: 10
+		Offset: 0,-6
 	damaged-idle:
 		Start: 10
 		Length: 10
+		Offset: 0,-6
 	make: barrmake
 		Length: *
+		Offset: 0,-6
 	bib: bib3
 		Length: *
 		UseTilesetExtension: true
@@ -283,22 +286,27 @@ afld:
 		Length: 8
 		Tick: 160
 		ZOffset: -1023
+		Offset: 0,-4
 	damaged-idle: afldidle
 		Start: 8
 		Length: 8
 		Tick: 160
 		ZOffset: -1023
+		Offset: 0,-4
 	active:
 		Length: 8
 		Tick: 160
 		ZOffset: -1023
+		Offset: 0,-4
 	damaged-active:
 		Start: 8
 		Length: 8
 		Tick: 160
 		ZOffset: -1023
+		Offset: 0,-4
 	make: afldmake
 		Length: *
+		Offset: 0,-4
 	icon: afldicon
 
 spen:


### PR DESCRIPTION
There were several cases of base buildings in RA and TD with the top row of the footprint only consisting of `_` cells, namely

RA:
- Advanced Power Plant
- Fake Advanced Power Plant
- Tesla Coil
- Gap Generator
- Flak Cannon

TD:
- Weapons Factory
- Temple of Nod
- Hand of Nod
- Obelisk
- Advanced Guard Tower

In the case of defenses, this meant that the `CenterPosition` was located between the empty cell and the occupied cell, rather than centered on the occupied cell, which - while consistent with TD - was not consistent with original RA and made placing, attacking or C4'ing these structures look a bit dodgy.

To make placement, attacking, C4'ing and later on HitShape setup easier and more consistent, I've removed all those empty top rows and adjusted the art offsets instead.

_Note_: Due to the sheer amount of actors that would be affected, I've refrained from doing the same for trees and rocks (fortunately civilian structures are not affected), since they are indestructible in RA/TD and therefore wouldn't really benefit from similar fixes. And, of course, the diff and risk of regressions would go up considerably.

_Note2_: The upgrade rule did work on two maps, but then I ran into a bug in our map upgrading so I had to use a slightly modified version of my previous MapFormat upgrade rule to apply it to all maps.
Additionally, I ran into a zlib error when trying to upgrade the `.oramap` packages, so I could only fix the unzipped maps (though I'm not sure we ship any packaged maps which have these specific actors pre-placed.)
