### PR TITLE
Fix calling OnOwnerChange with wrong player in ProximityCapturable

### DIFF
--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.Traits
 					w.Add(new FlashTarget(self));
 
 				foreach (var t in self.TraitsImplementing<INotifyCapture>())
-					t.OnCapture(self, captor, previousOwner, self.Owner);
+					t.OnCapture(self, captor, previousOwner, captor.Owner);
 			});
 		}
 


### PR DESCRIPTION
The actor's owner only gets changed in an end frame task queued by `Actor.ChangeOwner`. So during this frame end task, `self.Owner` still points to the old owner, whereas we want the new one, represented by `captor.Owner`.

This bug lead to the capture notification being played when _losing_ a building, but not when actually capturing it.
