### PR TITLE
Only check for and render selection bars for actors on screen

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -190,9 +190,12 @@ namespace OpenRA.Graphics
 
 			if (World.Type == WorldType.Regular)
 			{
-				foreach (var g in World.ActorsHavingTrait<Selectable>().Where(a => !a.Disposed
-					&& !World.FogObscures(a)
-					&& !World.Selection.Contains(a)))
+				foreach (var g in World.ScreenMap.ActorsInBox(Viewport.TopLeft, Viewport.BottomRight)
+					.Where(a =>
+						!a.Disposed &&
+						!World.Selection.Contains(a) &&
+						a.Info.HasTraitInfo<SelectableInfo>() &&
+						!World.FogObscures(a)))
 				{
 					if (Game.Settings.Game.StatusBars == StatusBarsType.Standard)
 						new SelectionBarsRenderable(g, false, false).Render(this);


### PR DESCRIPTION
This avoids expensive `FogObscures` checks and saves drawing selections bars for actors that are offscreen anyway.

In a 6 player TS game with a bunch of AI, the large number of units meant 4.3% of total CPU time was spent checking if actors were obscured by fog when deciding to render selection bars or not. (Our visibility checks are quite expensive on non-flat maps).

By changing this to limit to the visible screen, we only have to check actors onscreen at any time which scales much better - it also means we avoid rendering bars for offscreen stuff as a bonus.

This reduces the checks to about 0.6% of total CPU.
