### PR TITLE
Reduce gliding effect on smooth turns while moving

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -387,7 +387,11 @@ namespace OpenRA.Mods.Common.Activities
 				var nextCell = parent.PopPath(self);
 				if (nextCell != null)
 				{
-					if (IsTurn(mobile, nextCell.Value.First))
+					// HACK: small U-turns currently look crap, because the actor will just shift on the edge between cells.
+					// Therefore we disable smooth turning for them until we have a better turning logic.
+					var distanceFromNext = (self.World.Map.CenterOfCell(nextCell.Value.First) - self.World.Map.CenterOfCell(mobile.FromCell)).Length;
+					var smallUTurn = distanceFromNext == 2048;
+					if (IsTurn(mobile, nextCell.Value.First) && !smallUTurn)
 					{
 						var nextSubcellOffset = self.World.Map.Grid.OffsetOfSubCell(nextCell.Value.Second);
 						var ret = new MoveFirstHalf(


### PR DESCRIPTION
The worst offender is the turn around a single cell obstacle, because the turning actor will just shift straight from one cell corner to the other. Therefore, until we have a better turning logic, we disable smooth turning for these specific turns.
