### PR TITLE
Set yaml filename when loading from FileSystem.

### DIFF
--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -243,7 +243,7 @@ namespace OpenRA
 				{
 					var mapFiles = FieldLoader.GetValue<string[]>("value", mapRules.Value);
 					foreach (var f in mapFiles)
-						if (AnyFlaggedTraits(modData, MiniYaml.FromStream(fileSystem.Open(f))))
+						if (AnyFlaggedTraits(modData, MiniYaml.FromStream(fileSystem.Open(f), f)))
 							return true;
 				}
 			}

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Graphics
 			cachedSprites = new Dictionary<string, Dictionary<string, Sprite>>();
 
 			var chrome = MiniYaml.Merge(modData.Manifest.Chrome
-				.Select(s => MiniYaml.FromStream(fileSystem.Open(s))));
+				.Select(s => MiniYaml.FromStream(fileSystem.Open(s), s)));
 
 			foreach (var c in chrome)
 				LoadCollection(c.Key, c.Value);

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Graphics
 		{
 			var fileSystem = modData.DefaultFileSystem;
 			var sequenceYaml = MiniYaml.Merge(modData.Manifest.Cursors.Select(
-				s => MiniYaml.FromStream(fileSystem.Open(s))));
+				s => MiniYaml.FromStream(fileSystem.Open(s), s)));
 
 			var shadowIndex = new int[] { };
 

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -64,7 +64,7 @@ namespace OpenRA
 		{
 			var package = ModMetadata.AllMods[modId].Package;
 
-			yaml = new MiniYaml(null, MiniYaml.FromStream(package.GetStream("mod.yaml"))).ToDictionary();
+			yaml = new MiniYaml(null, MiniYaml.FromStream(package.GetStream("mod.yaml"), "mod.yaml")).ToDictionary();
 
 			Mod = FieldLoader.Load<ModMetadata>(yaml["Metadata"]);
 			Mod.Id = modId;

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -204,7 +204,7 @@ namespace OpenRA
 
 		public TileSet(IReadOnlyFileSystem fileSystem, string filepath)
 		{
-			var yaml = MiniYaml.DictFromStream(fileSystem.Open(filepath));
+			var yaml = MiniYaml.DictFromStream(fileSystem.Open(filepath), filepath);
 
 			// General info
 			FieldLoader.Load(this, yaml["General"]);

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -236,9 +236,9 @@ namespace OpenRA
 			return FromFile(path).ToDictionary(x => x.Key, x => x.Value);
 		}
 
-		public static Dictionary<string, MiniYaml> DictFromStream(Stream stream)
+		public static Dictionary<string, MiniYaml> DictFromStream(Stream stream, string fileName = "<no filename available>")
 		{
-			return FromStream(stream).ToDictionary(x => x.Key, x => x.Value);
+			return FromStream(stream, fileName).ToDictionary(x => x.Key, x => x.Value);
 		}
 
 		public static List<MiniYamlNode> FromFile(string path)
@@ -385,7 +385,7 @@ namespace OpenRA
 				files = files.Append(mapFiles);
 			}
 
-			var yaml = files.Select(s => MiniYaml.FromStream(fileSystem.Open(s)));
+			var yaml = files.Select(s => MiniYaml.FromStream(fileSystem.Open(s), s));
 			if (mapRules != null && mapRules.Nodes.Any())
 				yaml = yaml.Append(mapRules.Nodes);
 

--- a/OpenRA.Game/ModMetadata.cs
+++ b/OpenRA.Game/ModMetadata.cs
@@ -61,7 +61,7 @@ namespace OpenRA
 						continue;
 					}
 
-					var yaml = new MiniYaml(null, MiniYaml.FromStream(package.GetStream("mod.yaml")));
+					var yaml = new MiniYaml(null, MiniYaml.FromStream(package.GetStream("mod.yaml"), "mod.yaml"));
 					var nd = yaml.ToDictionary();
 					if (!nd.ContainsKey("Metadata"))
 					{

--- a/OpenRA.Game/Widgets/ChromeMetrics.cs
+++ b/OpenRA.Game/Widgets/ChromeMetrics.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Widgets
 		{
 			data = new Dictionary<string, string>();
 			var metrics = MiniYaml.Merge(modData.Manifest.ChromeMetrics.Select(
-				y => MiniYaml.FromStream(modData.DefaultFileSystem.Open(y))));
+				y => MiniYaml.FromStream(modData.DefaultFileSystem.Open(y), y)));
 			foreach (var m in metrics)
 				foreach (var n in m.Value.Nodes)
 					data[n.Key] = n.Value.Value;

--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -25,7 +25,7 @@ namespace OpenRA
 		{
 			this.modData = modData;
 
-			foreach (var file in modData.Manifest.ChromeLayout.Select(a => MiniYaml.FromStream(modData.DefaultFileSystem.Open(a))))
+			foreach (var file in modData.Manifest.ChromeLayout.Select(a => MiniYaml.FromStream(modData.DefaultFileSystem.Open(a), a)))
 				foreach (var w in file)
 				{
 					var key = w.Key.Substring(w.Key.IndexOf('@') + 1);

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Lint
 		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
 		{
 			foreach (var filename in modData.Manifest.ChromeLayout)
-				CheckInner(MiniYaml.FromStream(modData.DefaultFileSystem.Open(filename)), filename, emitError);
+				CheckInner(MiniYaml.FromStream(modData.DefaultFileSystem.Open(filename), filename), filename, emitError);
 		}
 
 		void CheckInner(List<MiniYamlNode> nodes, string filename, Action<string> emitError)

--- a/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var ts = new TileSet(modData.DefaultFileSystem, t);
 				Console.WriteLine("Tileset: " + ts.Name);
 				var sc = new SpriteCache(modData.DefaultFileSystem, modData.SpriteLoaders, new SheetBuilder(SheetType.Indexed));
-				var nodes = MiniYaml.Merge(modData.Manifest.Sequences.Select(s => MiniYaml.FromStream(modData.DefaultFileSystem.Open(s))));
+				var nodes = MiniYaml.Merge(modData.Manifest.Sequences.Select(s => MiniYaml.FromStream(modData.DefaultFileSystem.Open(s), s)));
 				foreach (var n in nodes)
 					modData.SpriteSequenceLoader.ParseSequences(modData, ts, sc, n);
 			}

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					include |= map.Package.Contains(f);
 					if (include)
-						nodes.AddRange(MiniYaml.FromStream(map.Open(f)));
+						nodes.AddRange(MiniYaml.FromStream(map.Open(f), f));
 					else
 						includes.Add(f);
 				}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var files = FieldLoader.GetValue<string[]>("value", yaml.Value);
 			    foreach (var filename in files)
 			    {
-			        var fileNodes = MiniYaml.FromStream(map.Package.GetStream(filename));
+			        var fileNodes = MiniYaml.FromStream(map.Package.GetStream(filename), filename);
 					processYaml(engineDate, ref fileNodes, null, 0);
 			        ((IReadWritePackage)map.Package).Update(filename, Encoding.ASCII.GetBytes(fileNodes.WriteToString()));
 			    }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					continue;
 				}
 
-				var yaml = MiniYaml.FromStream(package.GetStream(name));
+				var yaml = MiniYaml.FromStream(package.GetStream(name), name);
 				processFile(engineDate, ref yaml, null, 0);
 
 				// Generate the on-disk path

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (modData.Manifest.Missions.Any())
 			{
 				var yaml = MiniYaml.Merge(modData.Manifest.Missions.Select(
-					m => MiniYaml.FromStream(modData.DefaultFileSystem.Open(m))));
+					m => MiniYaml.FromStream(modData.DefaultFileSystem.Open(m), m)));
 
 				foreach (var kv in yaml)
 				{


### PR DESCRIPTION
This fixes the generally unhelpful `OpenRA.YamlException: <no filename available>` exception messages that I accidentally broke with the filesystem rework.
