### PR TITLE
Added INotifyBurstComplete interface

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -249,6 +249,9 @@ namespace OpenRA.Mods.Common.Traits
 					.Select(m => m.GetReloadModifier());
 				FireDelay = Util.ApplyPercentageModifiers(Weapon.ReloadDelay, modifiers);
 				Burst = Weapon.Burst;
+
+				foreach (var nbc in self.TraitsImplementing<INotifyBurstComplete>())
+					nbc.FiredBurst(self, target, this);
 			}
 
 			return barrel;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public interface INotifyAttack { void Attacking(Actor self, Target target, Armament a, Barrel barrel); }
+	public interface INotifyBurstComplete { void FiredBurst(Actor self, Target target, Armament a); }
 	public interface INotifyCharging { void Charging(Actor self, Target target); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
 	public interface INotifyParachuteLanded { void OnLanded(Actor ignore); }


### PR DESCRIPTION
Resurrected version of #11158, with the requested rename included. The original PR already had three :+1:s, so I'm gonna carry the +2 label over.
