### PR TITLE
Fix NREs in LobbyUtils.GetExternalIP

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -504,8 +504,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public static string GetExternalIP(int clientIndex, OrderManager orderManager)
 		{
-			var address = orderManager.LobbyInfo.ClientWithIndex(clientIndex).IpAddress;
-			if (clientIndex == orderManager.LocalClient.Index && address == IPAddress.Loopback.ToString())
+			var client = orderManager.LobbyInfo.ClientWithIndex(clientIndex);
+			var address = client != null ? client.IpAddress : "";
+			var lc = orderManager.LocalClient;
+			if (lc != null && lc.Index == clientIndex && address == IPAddress.Loopback.ToString())
 			{
 				var externalIP = UPnP.GetExternalIP();
 				if (externalIP != null)


### PR DESCRIPTION
Fixes #11246.

You can verify this by applying this commit directly on top of the last release and watching [this replay](http://www.gamereplays.org/openra/replays.php?game=92&show=details&id=311903). The crash happens when you mouse over a player name in the score screen.

The actual cause is that `orderManager.LocalClient` was null. The other check is just for safety's sake.
