### PR TITLE
Added burning trees to Tiberian Sun

### DIFF
--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradableTrait.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 	/// Requires basing *Info on UpgradableTraitInfo and using base(info) constructor.
 	/// Note that EnabledByUpgrade is not called at creation even if this starts as enabled.
 	/// </summary>
-	public abstract class UpgradableTrait<InfoType> : IUpgradable, IDisabledTrait, ISync where InfoType : UpgradableTraitInfo
+	public abstract class UpgradableTrait<InfoType> : IUpgradable, INotifyCreated, IDisabledTrait, ISync where InfoType : UpgradableTraitInfo
 	{
 		public readonly InfoType Info;
 		public IEnumerable<string> UpgradeTypes { get { return Info.UpgradeTypes; } }
@@ -51,6 +51,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Info = info;
 			IsTraitDisabled = info.UpgradeTypes != null && info.UpgradeTypes.Count > 0 && info.UpgradeMinEnabledLevel > 0;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			if (Info.UpgradeTypes.Count > 0 && self.TraitOrDefault<UpgradeManager>() == null)
+				throw new YamlException("Actor {0} references UpgradeTypes, but doesn't have the UpgradeManager trait.".F(self));
 		}
 
 		public bool AcceptsUpgradeLevel(Actor self, string type, int level)

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -653,6 +653,16 @@
 		Terrain: Tree
 	Tooltip:
 		Name: Tree
+	Targetable:
+		TargetTypes: flammable
+	UpgradeManager:
+	WithIdleOverlay@FORESTFIRE:
+		Sequence: burn
+		Palette: effect
+		UpgradeTypes: incendiary
+		ShowToEnemies: true
+		ZOffset: 1024
+		UpgradeMinEnabledLevel: 1
 
 ^Rock:
 	Inherits@1: ^SpriteActor

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -50,150 +50,250 @@ tree01:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree02:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree03:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree04:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree05:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree06:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree07:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree08:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree09:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree10:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree11:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree12:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree13:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree14:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree15:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree16:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree17:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree18:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree19:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree20:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree21:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree22:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree23:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree24:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 tree25:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0, -12
+	burn: burn-l
+		Start: 16
+		Length: 44
+		ZOffset: 512
 
 veinhole:
 	idle:

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -20,6 +20,11 @@ FireballLauncher:
 		DamageTypes: Prone100Percent, TriggerProne, FireDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SmallScorch
+	Warhead@INCENDIARY: GrantUpgrade
+		Range: 3c0
+		Duration: 600
+		Upgrades: incendiary
+		ValidTargets: flammable
 
 FiendShard:
 	ReloadDelay: 30


### PR DESCRIPTION
I went a different direction compared to Red Alert and Tiberian Dawn, because Tiberian Sun doesn't seem to have tree husks. So here nothing is really damaged or killed. Instead a decorational overlay is enabled via the upgrade system that wears off after some time. The benefit is that this allows per tree offsets and sequences.

It turned out to be very fiddly and I was very annoyed that it didn't work. I finally found out that `UpgradeManager` is missing for trees when I added a `TimedUpgradeBar` for debugging purposes which requires `UpgradeManager` and added a violent, but helpful crash. Added something similar to all optionally upgradeable traits.
