### PR TITLE
Added an error message when setting up upgrades without UpgradeManager

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var actorInfo in rules.Actors)
 			{
+				if (actorInfo.Key.StartsWith("^"))
+					continue;
+
 				foreach (var trait in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = trait.GetType().GetFields();
@@ -51,6 +54,9 @@ namespace OpenRA.Mods.Common.Lint
 			// Check all upgrades granted by traits.
 			foreach (var actorInfo in rules.Actors)
 			{
+				if (actorInfo.Key.StartsWith("^"))
+					continue;
+
 				foreach (var trait in actorInfo.Value.TraitInfos<ITraitInfo>())
 				{
 					var fields = trait.GetType().GetFields();

--- a/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUpgrades.cs
@@ -40,8 +40,14 @@ namespace OpenRA.Mods.Common.Lint
 					foreach (var field in fields.Where(x => x.HasAttribute<UpgradeUsedReferenceAttribute>()))
 					{
 						var values = LintExts.GetFieldValues(trait, field, emitError);
-						foreach (var value in values.Where(x => !upgradesGranted.Contains(x)))
-							emitError("Actor type `{0}` uses upgrade `{1}` that is not granted by anything!".F(actorInfo.Key, value));
+						foreach (var value in values)
+						{
+							if (!upgradesGranted.Contains(value))
+								emitError("Actor type `{0}` uses upgrade `{1}` that is not granted by anything!".F(actorInfo.Key, value));
+
+							if (actorInfo.Value.TraitInfoOrDefault<UpgradeManagerInfo>() == null)
+								emitError("Actor type `{0}` uses upgrade `{1}`, but doesn't have the UpgradeManager trait.".F(actorInfo.Key, value));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
A major downside from actor upgrades is that they can be setup in ways where nothing happens and you don't get any feedback why. This should help reduce the annoyance. Split from https://github.com/OpenRA/OpenRA/pull/11405.
