### PR TITLE
Fix possible NREs in RenderAsync in VoxelRenderer.cs

### DIFF
--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -94,6 +94,8 @@ namespace OpenRA.Graphics
 			var invShadowTransform = Util.MatrixInverse(shadowTransform);
 			var cameraTransform = Util.MakeFloatMatrix(camera.AsMatrix());
 			var invCameraTransform = Util.MatrixInverse(cameraTransform);
+			if (invCameraTransform == null)
+				throw new InvalidOperationException("Failed to invert the cameraTransform matrix during RenderAsync.");
 
 			// Sprite rectangle
 			var tl = new float2(float.MaxValue, float.MaxValue);
@@ -199,9 +201,12 @@ namespace OpenRA.Graphics
 					{
 						var rd = v.Voxel.RenderData(i);
 						var t = v.Voxel.TransformationMatrix(i, frame);
+						var it = Util.MatrixInverse(t);
+						if (it == null)
+							throw new InvalidOperationException("Failed to invert the transformed matrix of frame {0} during RenderAsync.".F(i));
 
 						// Transform light vector from shadow -> world -> limb coords
-						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(Util.MatrixInverse(t), lightTransform));
+						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(it, lightTransform));
 
 						Render(rd, Util.MatrixMultiply(transform, t), lightDirection,
 							lightAmbientColor, lightDiffuseColor, color.TextureMidIndex, normals.TextureMidIndex);


### PR DESCRIPTION
Detected by Coverity.

[`MatrixInverse`](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/Graphics/Util.cs#L318) might return `null` for `invCameraTransform` which will then crash in [`MatrixVectorMultiply`](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/Graphics/Util.cs#L194).
