### PR TITLE
Add naive capturing to HackyAI

### DIFF
--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -46,7 +46,12 @@ Player:
 			silo: 0%
 			fix: 1%
 			hpad: 2%
+		CapturingActorTypes: e6
+		CapturableActorTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, obli, v19
+		CheckCaptureTargetsForVisibility: false
+		MaximumCaptureTargetOptions: 15
 		UnitsToBuild:
+			e6: 5%
 			e1: 14%
 			e3: 7%
 			e2: 10%

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -42,7 +42,12 @@ Player:
 			stek: 1%
 			fix: 0.1%
 			dome: 10%
+		CapturingActorTypes: e6
+		CapturableActorTypes: mslo, gap, iron, pdox, atek, weap, fact, proc, silo, hpad, afld, powr, apwr, stek, barr, kenn, tent, fix, oilb
+		CheckCaptureTargetsForVisibility: false
+		MaximumCaptureTargetOptions: 15
 		UnitsToBuild:
+			e6: 5%
 			e1: 50%
 			e2: 20%
 			e3: 10%


### PR DESCRIPTION
Currently only RA's Rush AI is setup in a testable manner.

This PR adds these fields to `HackyAIInfo`:

``` csharp
[Desc("Actor types that can capture other actors (via `Captures` or `ExternalCaptures`).",
    "Leave this empty to disable capturing.")]
public HashSet<string> CapturingActorTypes = new HashSet<string>();

[Desc("Actor types that can be targeted for capturing.",
      "Leave this empty to include all actors.")]
public HashSet<string> CapturableActorTypes = new HashSet<string>();

[Desc("Minimum delay (in ticks) between trying to capture with CapturingActorTypes.")]
public readonly int MinimumCaptureDelay = 50;

[Desc("Maximum number of options to consider for capturing.")]
public readonly int MaximumCaptureTargetOptions = 5;

[Desc("Should visibility (Shroud, Fog, Cloak, etc) be considered when searching for capturable targets?")]
public readonly bool CheckCaptureTargetsForVisibility = true;
```

`CheckCaptureTargetsForVisibility` defaulting to `true` means exploration must happen before any of this new code has any noticeable effect, should `false` be a better default value I have no objections to changing it.

@obrakmann made the statement:

>  instead of the *CaptureTargetOptions, I'd have a list of actor types that are suitable for capturing

This is fair, I can implement this once this PR gets some initial review going.

Here is a series of images from a test game where the orange AI captured a conyard and built off of it before the original owner captured it back:

![screen shot 2016-06-07 at 1 35 53 pm](https://cloud.githubusercontent.com/assets/4861023/15877011/b9fc5d42-2cd6-11e6-9eef-19e7e375568e.png)
![screen shot 2016-06-07 at 1 35 58 pm](https://cloud.githubusercontent.com/assets/4861023/15877012/b9fce550-2cd6-11e6-9a63-049693eb94e0.png)
![screen shot 2016-06-07 at 1 36 11 pm](https://cloud.githubusercontent.com/assets/4861023/15877010/b9fb92fe-2cd6-11e6-8027-84e75991eb03.png)

I am leaving the commits as they are for the initial reviews, they will be squashed and fixed up as necessary if this goes anywhere.
