### PR TITLE
Fixed the AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,13 +54,13 @@ test_script:
 
 after_test:
   - choco install pandoc -y
-  - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o README.html README.md'
-  - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o CONTRIBUTING.html CONTRIBUTING.md'
+  - '"%ProgramFiles(x86)%\Pandoc\pandoc.exe" -o README.html README.md'
+  - '"%ProgramFiles(x86)%\Pandoc\pandoc.exe" -o CONTRIBUTING.html CONTRIBUTING.md'
   - appveyor DownloadFile "https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md" -FileName Changelog.md
-  - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o Changelog.html CHANGELOG.md'
+  - '"%ProgramFiles(x86)%\Pandoc\pandoc.exe" -o Changelog.html CHANGELOG.md'
   - make docs
-  - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o DOCUMENTATION.html DOCUMENTATION.md'
-  - '%LOCALAPPDATA%\Pandoc\pandoc.exe -o Lua-API.html Lua-API.md'
+  - '"%ProgramFiles(x86)%\Pandoc\pandoc.exe" -o DOCUMENTATION.html DOCUMENTATION.md'
+  - '"%ProgramFiles(x86)%\Pandoc\pandoc.exe" -o Lua-API.html Lua-API.md'
   - ps: cp OpenRA.Game/OpenRA.ico .
   - if not exist nsissetup.exe appveyor DownloadFile "http://downloads.sourceforge.net/project/nsis/NSIS 2/2.46/nsis-2.46-setup.exe" -FileName nsissetup.exe
   - nsissetup /S /D=%NSIS_ROOT%


### PR DESCRIPTION
Looks like the https://chocolatey.org/packages/pandoc changed towards a more sane install.

```
pandoc has been installed.
pandoc installed to 'C:\Program Files (x86)\Pandoc'
Adding pandoc to the PATH if needed
```

Adjusting our build scripts to fix the systematically failing builds.
