### PR TITLE
Updated NSIS to version 2.51

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ install:
 
 cache:
   - nsissetup.exe -> appveyor.yaml
-  - NsProcess.zip -> appveyor.yaml
   - thirdparty\download -> thirdparty\fetch-thirdparty-deps.ps1
 
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 1.0.{build}
 
 environment:
-  NSIS_ROOT: C:\nsis
   CoverityProjectToken:
     secure: BYP5qnptMazSCwTwgiFHlfqZd7BM3bwTRq2Cbs++ofg=
   CoverityNotificationEmail:
@@ -10,7 +9,6 @@ environment:
 install:
 
 cache:
-  - nsissetup.exe -> appveyor.yaml
   - thirdparty\download -> thirdparty\fetch-thirdparty-deps.ps1
 
 before_build:
@@ -61,9 +59,8 @@ after_test:
   - '"%ProgramFiles(x86)%\Pandoc\pandoc.exe" -o DOCUMENTATION.html DOCUMENTATION.md'
   - '"%ProgramFiles(x86)%\Pandoc\pandoc.exe" -o Lua-API.html Lua-API.md'
   - ps: cp OpenRA.Game/OpenRA.ico .
-  - if not exist nsissetup.exe appveyor DownloadFile "http://downloads.sourceforge.net/project/nsis/NSIS 2/2.46/nsis-2.46-setup.exe" -FileName nsissetup.exe
-  - nsissetup /S /D=%NSIS_ROOT%
-  - '%NSIS_ROOT%\makensis /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\download\windows" /V3 packaging/windows/OpenRA.nsi'
+  - choco install nsis.install -version 2.51 -y
+  - '"%ProgramFiles(x86)%\NSIS\makensis.exe" /DSRCDIR="%APPVEYOR_BUILD_FOLDER%" /DDEPSDIR="%APPVEYOR_BUILD_FOLDER%\thirdparty\download\windows" /V3 packaging/windows/OpenRA.nsi'
   - if defined APPVEYOR_REPO_TAG_NAME set VERSION=%APPVEYOR_REPO_TAG_NAME%
   - if not defined APPVEYOR_REPO_TAG_NAME set VERSION=%APPVEYOR_REPO_COMMIT:~0,7%
   - move /Y %APPVEYOR_BUILD_FOLDER%\packaging\windows\OpenRA.Setup.exe %APPVEYOR_BUILD_FOLDER%\OpenRA-%VERSION%.exe

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -44,7 +44,3 @@ if [ ! -f soft_oal.dll ]; then
 	cp ./OpenAL-Soft/bin/Win32/soft_oal.dll ./soft_oal.dll
 	rm -rf OpenAL-Soft
 fi
-
-if [ ! -f ../NsProcess.zip ]; then
-	curl -s -L -o ../NsProcess.zip http://nsis.sourceforge.net/mediawiki/images/archive/1/18/20140806212030!NsProcess.zip
-fi


### PR DESCRIPTION
also removed some bit rot since https://github.com/OpenRA/OpenRA/pull/8796/commits/03ace480314a4d373db13da45fd65e217e391c68.

Changelog see: http://nsis.sourceforge.net/Docs/AppendixF.html#v2.51 It is mostly security updates. The OpenRA setup is currently exposing a security vulnerability during installation.
