### PR TITLE
Make launch-dedicated scripts consistent between platforms

### DIFF
--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -1,17 +1,18 @@
+:: example launch script, see https://github.com/OpenRA/OpenRA/wiki/Dedicated for details
+
 @echo on
 
 set Name="Dedicated Server"
 set Mod=ra
-set Dedicated=True
-set DedicatedLoop=True
 set ListenPort=1234
 set ExternalPort=1234
 set AdvertiseOnline=True
-set Map=
-set Password=
+set AllowPortForward=False
+set DisableSinglePlayer=True
+set Password=""
 
 :loop
 
-OpenRA.Game.exe Game.Mod=%Mod% Server.Dedicated=%Dedicated% Server.DedicatedLoop=%DedicatedLoop% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.Map=%Map% Server.Password=%Password% 
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.AllowPortForward=%AllowPortForward% Server.DisableSinglePlayer=%DisableSinglePlayer% Server.Password=%Password%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -12,9 +12,12 @@ ListenPort="${ListenPort:-"1234"}"
 ExternalPort="${ExternalPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
 AllowPortForward="${AllowPortForward:-"False"}"
+DisableSinglePlayer="${DisableSinglePlayer:-"True"}"
+Password="${Password:-""}"
 
 while true; do
      mono --debug OpenRA.Server.exe Game.Mod=$Mod \
      Server.Name="$Name" Server.ListenPort=$ListenPort Server.ExternalPort=$ExternalPort \
-     Server.AdvertiseOnline=$AdvertiseOnline Server.AllowPortForward=$AllowPortForward
+     Server.AdvertiseOnline=$AdvertiseOnline Server.AllowPortForward=$AllowPortForward \
+     Server.DisableSinglePlayer=$DisableSinglePlayer Server.Password=$Password
 done


### PR DESCRIPTION
Updates our launch-dedicated scripts to be consistent, and updates the windows script to properly use `OpenRA.Server.exe`.

I removed `Map` from both scripts. It only seems useful when your server disables resource center sync and has a limited map pool.
