### PR TITLE
Port map difficulties to new lobby options backend.

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -192,7 +192,6 @@ namespace OpenRA.Network
 			public int OrderLatency = 3; // net tick frames (x 120 = ms)
 			public int RandomSeed = 0;
 			public bool AllowSpectators = true;
-			public string Difficulty;
 			public string GameSpeedType = "default";
 			public bool AllowVersionMismatch;
 			public string GameUid;

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -756,6 +756,7 @@
     <Compile Include="UtilityCommands\ListMSCabContentsCommand.cs" />
     <Compile Include="FileFormats\MSCabCompression.cs" />
     <Compile Include="UtilityCommands\OutputActorMiniYamlCommand.cs" />
+    <Compile Include="Traits\World\ScriptLobbyDropdown.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -105,7 +105,18 @@ namespace OpenRA.Mods.Common.Scripting
 		public bool IsSinglePlayer { get { return Context.World.LobbyInfo.IsSinglePlayer; } }
 
 		[Desc("Returns the difficulty selected by the player before starting the mission.")]
-		public string Difficulty { get { return Context.World.LobbyInfo.GlobalSettings.Difficulty; } }
+		public string Difficulty
+		{
+			get
+			{
+				Game.Debug("Map script is using deprecated Map.Difficulty API. This should be changed to Map.LobbyOption(\"difficulty\").");
+				Log.Write("lua", "Map script is using deprecated Map.Difficulty API. This should be changed to Map.LobbyOption(\"difficulty\").");
+				var option = Context.World.WorldActor.TraitsImplementing<ScriptLobbyDropdown>()
+					.FirstOrDefault(sld => sld.Info.ID == "difficulty");
+
+				return option != null ? option.Info.Values[option.Value] : null;
+			}
+		}
 
 		[Desc("Returns the value of a `ScriptLobbyDropdown` selected in the game lobby.")]
 		public LuaValue LobbyOption(string id)

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -107,6 +107,18 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Returns the difficulty selected by the player before starting the mission.")]
 		public string Difficulty { get { return Context.World.LobbyInfo.GlobalSettings.Difficulty; } }
 
+		[Desc("Returns the value of a `ScriptLobbyDropdown` selected in the game lobby.")]
+		public LuaValue LobbyOption(string id)
+		{
+			var option = Context.World.WorldActor.TraitsImplementing<ScriptLobbyDropdown>()
+				.FirstOrDefault(sld => sld.Info.ID == id);
+
+			if (option == null)
+				throw new YamlException("A ScriptLobbyDropdown with ID `" + id + "` was not found.");
+
+			return option.Value;
+		}
+
 		[Desc("Returns a table of all the actors that were specified in the map file.")]
 		public Actor[] NamedActors { get { return sma.Actors.Values.ToArray(); } }
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -433,10 +433,14 @@ namespace OpenRA.Mods.Common.Server
 							return true;
 						}
 
-						var options = server.Map.Rules.Actors["player"].TraitInfos<ILobbyOptions>()
+						var allOptions = server.Map.Rules.Actors["player"].TraitInfos<ILobbyOptions>()
 							.Concat(server.Map.Rules.Actors["world"].TraitInfos<ILobbyOptions>())
-							.SelectMany(t => t.LobbyOptions(server.Map.Rules))
-							.ToDictionary(o => o.Id, o => o);
+							.SelectMany(t => t.LobbyOptions(server.Map.Rules));
+
+						// Overwrite keys with duplicate ids
+						var options = new Dictionary<string, LobbyOption>();
+						foreach (var o in allOptions)
+							options[o.Id] = o;
 
 						var split = s.Split(' ');
 						LobbyOption option;

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -506,39 +506,6 @@ namespace OpenRA.Mods.Common.Server
 						return true;
 					}
 				},
-				{ "difficulty",
-					s =>
-					{
-						if (server.LobbyInfo.GlobalSettings.Difficulty == s)
-							return true;
-
-						if (!client.IsAdmin)
-						{
-							server.SendOrderTo(conn, "Message", "Only the host can set that option.");
-							return true;
-						}
-
-						var mapOptions = server.Map.Rules.Actors["world"].TraitInfo<MapOptionsInfo>();
-						if (mapOptions.DifficultyLocked || !mapOptions.Difficulties.Any())
-						{
-							server.SendOrderTo(conn, "Message", "Map has disabled difficulty configuration.");
-							return true;
-						}
-
-						if (s != null && !mapOptions.Difficulties.Contains(s))
-						{
-							server.SendOrderTo(conn, "Message", "Invalid difficulty selected: {0}".F(s));
-							server.SendOrderTo(conn, "Message", "Supported values: {0}".F(mapOptions.Difficulties.JoinWith(", ")));
-							return true;
-						}
-
-						server.LobbyInfo.GlobalSettings.Difficulty = s;
-						server.SyncLobbyGlobalSettings();
-						server.SendMessage("{0} changed difficulty to {1}.".F(client.Name, s));
-
-						return true;
-					}
-				},
 				{ "gamespeed",
 					s =>
 					{

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -30,15 +30,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Prevent the tech level from being changed in the lobby.")]
 		public readonly bool TechLevelLocked = false;
 
-		[Desc("Difficulty levels supported by the map.")]
-		public readonly string[] Difficulties = { };
-
-		[Desc("Default difficulty level.")]
-		public readonly string Difficulty = null;
-
-		[Desc("Prevent the difficulty from being changed in the lobby.")]
-		public readonly bool DifficultyLocked = false;
-
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
 		{
 			yield return new LobbyBooleanOption("shortgame", "Short Game", ShortGameEnabled, ShortGameLocked);

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -1,0 +1,66 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Controls the map difficulty, tech level, and short game lobby options.")]
+	public class ScriptLobbyDropdownInfo : ITraitInfo, ILobbyOptions
+	{
+		[FieldLoader.Require]
+		[Desc("Internal id for this option.")]
+		public readonly string ID = null;
+
+		[FieldLoader.Require]
+		[Desc("Display name for this option.")]
+		public readonly string Label = null;
+
+		[FieldLoader.Require]
+		[Desc("Default option key in the `Values` list.")]
+		public readonly string Default = null;
+
+		[FieldLoader.Require]
+		[Desc("Difficulty levels supported by the map.")]
+		public readonly Dictionary<string, string> Values = null;
+
+		[Desc("Prevent the option from being changed from its default value.")]
+		public readonly bool Locked = false;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
+		{
+			yield return new LobbyOption(ID, Label,
+				new ReadOnlyDictionary<string, string>(Values),
+					Default, Locked);
+		}
+
+		public object Create(ActorInitializer init) { return new ScriptLobbyDropdown(this); }
+	}
+
+	public class ScriptLobbyDropdown : INotifyCreated
+	{
+		public readonly ScriptLobbyDropdownInfo Info;
+
+		public string Value { get; private set; }
+
+		public ScriptLobbyDropdown(ScriptLobbyDropdownInfo info)
+		{
+			Info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			Value = self.World.LobbyInfo.GlobalSettings.OptionOrDefault(Info.ID, Info.Default);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -355,6 +355,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var option = new CachedTransform<Session.Global, Session.LobbyOptionState>(
 						gs => gs.LobbyOptions[kv.Value]);
 
+					var visible = new CachedTransform<Session.Global, bool>(
+						gs => gs.LobbyOptions.ContainsKey(kv.Value));
+
+					checkbox.IsVisible = () => visible.Update(orderManager.LobbyInfo.GlobalSettings);
 					checkbox.IsChecked = () => option.Update(orderManager.LobbyInfo.GlobalSettings).Enabled;
 					checkbox.IsDisabled = () => configurationDisabled() ||
 						option.Update(orderManager.LobbyInfo.GlobalSettings).Locked;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -368,6 +368,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "TECHLEVEL", "techlevel" },
 				{ "STARTINGUNITS", "startingunits" },
 				{ "STARTINGCASH", "startingcash" },
+				{ "DIFFICULTY", "difficulty" }
 			};
 
 			var allOptions = new CachedTransform<MapPreview, LobbyOption[]>(
@@ -421,35 +422,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (label != null)
 						label.IsVisible = () => option.Update(Map) != null;
 				}
-			}
-
-			var difficulty = optionsBin.GetOrNull<DropDownButtonWidget>("DIFFICULTY_DROPDOWNBUTTON");
-			if (difficulty != null)
-			{
-				var mapOptions = new CachedTransform<MapPreview, MapOptionsInfo>(
-					map => map.Rules.Actors["world"].TraitInfo<MapOptionsInfo>());
-
-				difficulty.IsVisible = () => Map.RulesLoaded && mapOptions.Update(Map).Difficulties.Any();
-				difficulty.IsDisabled = () => configurationDisabled() || mapOptions.Update(Map).DifficultyLocked;
-				difficulty.GetText = () => orderManager.LobbyInfo.GlobalSettings.Difficulty;
-				difficulty.OnMouseDown = _ =>
-				{
-					var options = mapOptions.Update(Map).Difficulties.Select(d => new DropDownOption
-					{
-						Title = d,
-						IsSelected = () => orderManager.LobbyInfo.GlobalSettings.Difficulty == d,
-						OnClick = () => orderManager.IssueOrder(Order.Command("difficulty {0}".F(d)))
-					});
-					Func<DropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
-					{
-						var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
-						item.Get<LabelWidget>("LABEL").GetText = () => option.Title;
-						return item;
-					};
-					difficulty.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", options.Count() * 30, options, setupItem);
-				};
-
-				optionsBin.Get<LabelWidget>("DIFFICULTY_DESC").IsVisible = difficulty.IsVisible;
 			}
 
 			var gameSpeed = optionsBin.GetOrNull<DropDownButtonWidget>("GAMESPEED_DROPDOWNBUTTON");

--- a/mods/cnc/maps/funpark01/rules.yaml
+++ b/mods/cnc/maps/funpark01/rules.yaml
@@ -8,9 +8,15 @@ World:
 		BriefingVideo: generic.vqa
 		StartVideo: dino.vqa
 	MapOptions:
-		Difficulties: Easy, Normal
 		ShortGameLocked: True
 		ShortGameEnabled: False
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+		Default: easy
 
 Player:
 	EnemyWatcher:

--- a/mods/cnc/maps/funpark01/scj01ea.lua
+++ b/mods/cnc/maps/funpark01/scj01ea.lua
@@ -79,7 +79,7 @@ WorldLoaded = function()
 	Trigger.AfterDelay(DateTime.Seconds(1), function() InitialUnitsArrived = true end)
 
 	Trigger.AfterDelay(DateTime.Seconds(15), function() ReinforceWithLandingCraft(BazookaReinforcments, SeaEntryB.Location, BeachReinforceB.Location, BeachReinforceB.Location) end)
-	if Map.Difficulty == "Easy" then
+	if Map.LobbyOption("difficulty") == "easy" then
 		Trigger.AfterDelay(DateTime.Seconds(25), function() ReinforceWithLandingCraft(BikeReinforcments, SeaEntryA.Location, BeachReinforceA.Location, BeachReinforceA.Location) end)
 		Trigger.AfterDelay(DateTime.Seconds(30), function() ReinforceWithLandingCraft(BikeReinforcments, SeaEntryB.Location, BeachReinforceB.Location, BeachReinforceB.Location) end)
 	end

--- a/mods/cnc/maps/gdi05a/gdi05a.lua
+++ b/mods/cnc/maps/gdi05a/gdi05a.lua
@@ -1,10 +1,10 @@
-RepairThreshold = { Easy = 0.3, Normal = 0.6, Hard = 0.9 }
+RepairThreshold = { easy = 0.3, normal = 0.6, hard = 0.9 }
 
 ActorRemovals =
 {
-	Easy = { Actor167, Actor168, Actor190, Actor191, Actor193, Actor194, Actor196, Actor198, Actor200 },
-	Normal = { Actor167, Actor194, Actor196, Actor197 },
-	Hard = { },
+	easy = { Actor167, Actor168, Actor190, Actor191, Actor193, Actor194, Actor196, Actor198, Actor200 },
+	normal = { Actor167, Actor194, Actor196, Actor197 },
+	hard = { },
 }
 
 GdiTanks = { "mtnk", "mtnk" }
@@ -16,31 +16,31 @@ CoreNodBase = { NodConYard, NodRefinery, HandOfNod, Airfield }
 
 Grd1UnitTypes = { "bggy" }
 Grd1Path = { waypoint4.Location, waypoint5.Location, waypoint10.Location }
-Grd1Delay = { Easy = DateTime.Minutes(2), Normal = DateTime.Minutes(1), Hard = DateTime.Seconds(30) }
+Grd1Delay = { easy = DateTime.Minutes(2), normal = DateTime.Minutes(1), hard = DateTime.Seconds(30) }
 Grd2UnitTypes = { "bggy" }
 Grd2Path = { waypoint0.Location, waypoint1.Location, waypoint2.Location }
 Grd3Units = { GuardTank1, GuardTank2 }
 Grd3Path = { waypoint4.Location, waypoint5.Location, waypoint9.Location }
 
-AttackDelayMin = { Easy = DateTime.Minutes(1), Normal = DateTime.Seconds(45), Hard = DateTime.Seconds(30) }
-AttackDelayMax = { Easy = DateTime.Minutes(2), Normal = DateTime.Seconds(90), Hard = DateTime.Minutes(1) }
+AttackDelayMin = { easy = DateTime.Minutes(1), normal = DateTime.Seconds(45), hard = DateTime.Seconds(30) }
+AttackDelayMax = { easy = DateTime.Minutes(2), normal = DateTime.Seconds(90), hard = DateTime.Minutes(1) }
 AttackUnitTypes =
 {
-	Easy =
+	easy =
 	{
 		{ factory = HandOfNod, types = { "e1", "e1" } },
 		{ factory = HandOfNod, types = { "e1", "e3" } },
 		{ factory = HandOfNod, types = { "e1", "e1", "e3" } },
 		{ factory = HandOfNod, types = { "e1", "e3", "e3" } },
 	},
-	Normal =
+	normal =
 	{
 		{ factory = HandOfNod, types = { "e1", "e1", "e3" } },
 		{ factory = HandOfNod, types = { "e1", "e3", "e3" } },
 		{ factory = HandOfNod, types = { "e1", "e1", "e3", "e3" } },
 		{ factory = Airfield, types = { "bggy" } },
 	},
-	Hard =
+	hard =
 	{
 		{ factory = HandOfNod, types = { "e1", "e1", "e3", "e3" } },
 		{ factory = HandOfNod, types = { "e1", "e1", "e1", "e3", "e3" } },
@@ -68,7 +68,7 @@ Build = function(factory, units, action)
 end
 
 Attack = function()
-	local production = Utils.Random(AttackUnitTypes[Map.Difficulty])
+	local production = Utils.Random(AttackUnitTypes[Map.LobbyOption("difficulty")])
 	local path = Utils.Random(AttackPaths)
 	Build(production.factory, production.types, function(units)
 		Utils.Do(units, function(unit)
@@ -78,7 +78,7 @@ Attack = function()
 		end)
 	end)
 
-	Trigger.AfterDelay(Utils.RandomInteger(AttackDelayMin[Map.Difficulty], AttackDelayMax[Map.Difficulty]), Attack)
+	Trigger.AfterDelay(Utils.RandomInteger(AttackDelayMin[Map.LobbyOption("difficulty")], AttackDelayMax[Map.LobbyOption("difficulty")]), Attack)
 end
 
 Grd1Action = function()
@@ -86,7 +86,7 @@ Grd1Action = function()
 		Utils.Do(units, function(unit)
 			if unit.Owner ~= enemy then return end
 			Trigger.OnKilled(unit, function()
-				Trigger.AfterDelay(Grd1Delay[Map.Difficulty], Grd1Action)
+				Trigger.AfterDelay(Grd1Delay[Map.LobbyOption("difficulty")], Grd1Action)
 			end)
 			unit.Patrol(Grd1Path, true, DateTime.Seconds(7))
 		end)
@@ -138,7 +138,7 @@ DiscoverGdiBase = function(actor, discoverer)
 end
 
 SetupWorld = function()
-	Utils.Do(ActorRemovals[Map.Difficulty], function(unit)
+	Utils.Do(ActorRemovals[Map.LobbyOption("difficulty")], function(unit)
 		unit.Destroy()
 	end)
 
@@ -152,7 +152,7 @@ SetupWorld = function()
 	Utils.Do(Map.NamedActors, function(actor)
 		if actor.Owner == enemy and actor.HasProperty("StartBuildingRepairs") then
 			Trigger.OnDamaged(actor, function(building)
-				if building.Owner == enemy and building.Health < RepairThreshold[Map.Difficulty] * building.MaxHealth then
+				if building.Owner == enemy and building.Health < RepairThreshold[Map.LobbyOption("difficulty")] * building.MaxHealth then
 					building.StartBuildingRepairs()
 				end
 			end)
@@ -166,11 +166,11 @@ SetupWorld = function()
 
 	GdiHarv.Stop()
 	NodHarv.FindResources()
-	if Map.Difficulty ~= "Easy" then
+	if Map.LobbyOption("difficulty") ~= "easy" then
 		Trigger.OnDamaged(NodHarv, function()
 			Utils.Do(enemy.GetGroundAttackers(), function(unit)
 				unit.AttackMove(NodHarv.Location)
-				if Map.Difficulty == "Hard" then
+				if Map.LobbyOption("difficulty") == "hard" then
 					unit.Hunt()
 				end
 			end)

--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -11,7 +11,6 @@ World:
 		WinVideo: nodlose.vqa
 		LossVideo: gdilose.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard
 		ShortGameLocked: True
 		ShortGameEnabled: False
 	SmudgeLayer@SCORCH:
@@ -27,6 +26,14 @@ World:
 			41,54: cr1,0
 			13,52: cr1,0
 			11,51: cr1,0
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 Player:
 	EnemyWatcher:

--- a/mods/cnc/maps/gdi06/gdi06.lua
+++ b/mods/cnc/maps/gdi06/gdi06.lua
@@ -89,10 +89,10 @@ WorldLoaded = function()
 		Media.PlaySpeechNotification(player, "Lose")
 	end)
 
-	if Map.Difficulty == "Easy" then
+	if Map.LobbyOption("difficulty") == "easy" then
 		CommandoType = "rmbo.easy"
 		KillCounterHuntThreshold = 30
-	elseif Map.Difficulty == "Hard" then
+	elseif Map.LobbyOption("difficulty") == "hard" then
 		CommandoType = "rmbo.hard"
 		KillCounterHuntThreshold = 15
 	else

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -31,9 +31,16 @@ World:
 		WinVideo: sabotage.vqa
 		LossVideo: gdilose.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard
 		ShortGameLocked: True
 		ShortGameEnabled: True
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 Player:
 	PlayerResources:

--- a/mods/cnc/maps/nod09/nod09.lua
+++ b/mods/cnc/maps/nod09/nod09.lua
@@ -1,6 +1,6 @@
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	Rambo = "rmbo.easy"
-elseif Map.Difficulty == "Hard" then
+elseif Map.LobbyOption("difficulty") == "hard" then
 	Rambo = "rmbo.hard"
 else
 	Rambo = "rmbo"

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -9,7 +9,6 @@ World:
 		LossVideo: banner.vqa
 		BriefingVideo: nod9.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard
 	SmudgeLayer@SCORCH:
 		InitialSmudges:
 			20,55: sc2,0
@@ -29,6 +28,14 @@ World:
 			8,55: cr1,0
 			8,54: cr1,0
 			7,54: cr1,0
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 Player:
 	PlayerResources:

--- a/mods/d2k/maps/atreides-01a/atreides01a.lua
+++ b/mods/d2k/maps/atreides-01a/atreides01a.lua
@@ -1,18 +1,18 @@
 
 HarkonnenReinforcements = { }
-HarkonnenReinforcements["Easy"] =
+HarkonnenReinforcements["easy"] =
 {
 	{ "light_inf", "light_inf" }
 }
 
-HarkonnenReinforcements["Normal"] =
+HarkonnenReinforcements["normal"] =
 {
 	{ "light_inf", "light_inf" },
 	{ "light_inf", "light_inf", "light_inf" },
 	{ "light_inf", "trike" },
 }
 
-HarkonnenReinforcements["Hard"] =
+HarkonnenReinforcements["hard"] =
 {
 	{ "light_inf", "light_inf" },
 	{ "trike", "trike" },
@@ -25,14 +25,14 @@ HarkonnenEntryWaypoints = { HarkonnenWaypoint1.Location, HarkonnenWaypoint2.Loca
 HarkonnenAttackDelay = DateTime.Seconds(30)
 
 HarkonnenAttackWaves = { }
-HarkonnenAttackWaves["Easy"] = 1
-HarkonnenAttackWaves["Normal"] = 5
-HarkonnenAttackWaves["Hard"] = 12
+HarkonnenAttackWaves["easy"] = 1
+HarkonnenAttackWaves["normal"] = 5
+HarkonnenAttackWaves["hard"] = 12
 
 ToHarvest = { }
-ToHarvest["Easy"] = 2500
-ToHarvest["Normal"] = 3000
-ToHarvest["Hard"] = 3500
+ToHarvest["easy"] = 2500
+ToHarvest["normal"] = 3000
+ToHarvest["hard"] = 3500
 
 AtreidesReinforcements = { "light_inf", "light_inf", "light_inf" }
 AtreidesEntryPath = { AtreidesWaypoint.Location, AtreidesRally.Location }
@@ -57,7 +57,7 @@ Tick = function()
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 
-	if player.Resources > ToHarvest[Map.Difficulty] - 1 then
+	if player.Resources > ToHarvest[Map.LobbyOption("difficulty")] - 1 then
 		player.MarkCompletedObjective(GatherSpice)
 	end
 
@@ -78,7 +78,7 @@ Tick = function()
 		Media.DisplayMessage(Messages[4], "Mentat")
 	end
 
-	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. ToHarvest[Map.Difficulty], player.Color)
+	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. ToHarvest[Map.LobbyOption("difficulty")], player.Color)
 end
 
 WorldLoaded = function()
@@ -106,12 +106,12 @@ WorldLoaded = function()
 		Reinforcements.Reinforce(player, AtreidesReinforcements, AtreidesEntryPath)
 	end)
 
-	WavesLeft = HarkonnenAttackWaves[Map.Difficulty]
+	WavesLeft = HarkonnenAttackWaves[Map.LobbyOption("difficulty")]
 	SendReinforcements()
 end
 
 SendReinforcements = function()
-	local units = HarkonnenReinforcements[Map.Difficulty]
+	local units = HarkonnenReinforcements[Map.LobbyOption("difficulty")]
 	local delay = Utils.RandomInteger(HarkonnenAttackDelay - DateTime.Seconds(2), HarkonnenAttackDelay)
 	HarkonnenAttackDelay = HarkonnenAttackDelay - (#units * 3 - 3 - WavesLeft) * DateTime.Seconds(1)
 	if HarkonnenAttackDelay < 0 then HarkonnenAttackDelay = 0 end
@@ -134,7 +134,7 @@ InitObjectives = function()
 	end)
 
 	KillAtreides = harkonnen.AddPrimaryObjective("Kill all Atreides units.")
-	GatherSpice = player.AddPrimaryObjective("Harvest " .. tostring(ToHarvest[Map.Difficulty]) .. " Solaris worth of Spice.")
+	GatherSpice = player.AddPrimaryObjective("Harvest " .. tostring(ToHarvest[Map.LobbyOption("difficulty")]) .. " Solaris worth of Spice.")
 	KillHarkonnen = player.AddSecondaryObjective("Eliminate all Harkonnen units and reinforcements\nin the area.")
 
 	Trigger.OnObjectiveCompleted(player, function(p, id)

--- a/mods/d2k/maps/atreides-01a/rules.yaml
+++ b/mods/d2k/maps/atreides-01a/rules.yaml
@@ -10,7 +10,14 @@ World:
 		BriefingVideo: A_BR01_E.VQA
 	MapOptions:
 		TechLevel: Low
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 construction_yard:
 	Production:

--- a/mods/d2k/maps/atreides-01b/atreides01b.lua
+++ b/mods/d2k/maps/atreides-01b/atreides01b.lua
@@ -1,18 +1,18 @@
 
 HarkonnenReinforcements = { }
-HarkonnenReinforcements["Easy"] =
+HarkonnenReinforcements["easy"] =
 {
 	{ "light_inf", "light_inf" }
 }
 
-HarkonnenReinforcements["Normal"] =
+HarkonnenReinforcements["normal"] =
 {
 	{ "light_inf", "light_inf" },
 	{ "light_inf", "light_inf", "light_inf" },
 	{ "light_inf", "trike" },
 }
 
-HarkonnenReinforcements["Hard"] =
+HarkonnenReinforcements["hard"] =
 {
 	{ "light_inf", "light_inf" },
 	{ "trike", "trike" },
@@ -25,14 +25,14 @@ HarkonnenEntryWaypoints = { HarkonnenWaypoint1.Location, HarkonnenWaypoint2.Loca
 HarkonnenAttackDelay = DateTime.Seconds(30)
 
 HarkonnenAttackWaves = { }
-HarkonnenAttackWaves["Easy"] = 1
-HarkonnenAttackWaves["Normal"] = 5
-HarkonnenAttackWaves["Hard"] = 12
+HarkonnenAttackWaves["easy"] = 1
+HarkonnenAttackWaves["normal"] = 5
+HarkonnenAttackWaves["hard"] = 12
 
 ToHarvest = { }
-ToHarvest["Easy"] = 2500
-ToHarvest["Normal"] = 3000
-ToHarvest["Hard"] = 3500
+ToHarvest["easy"] = 2500
+ToHarvest["normal"] = 3000
+ToHarvest["hard"] = 3500
 
 AtreidesReinforcements = { "light_inf", "light_inf", "light_inf", "light_inf" }
 AtreidesEntryPath = { AtreidesWaypoint.Location, AtreidesRally.Location }
@@ -57,7 +57,7 @@ Tick = function()
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 
-	if player.Resources > ToHarvest[Map.Difficulty] - 1 then
+	if player.Resources > ToHarvest[Map.LobbyOption("difficulty")] - 1 then
 		player.MarkCompletedObjective(GatherSpice)
 	end
 
@@ -78,7 +78,7 @@ Tick = function()
 		Media.DisplayMessage(Messages[4], "Mentat")
 	end
 
-	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. ToHarvest[Map.Difficulty], player.Color)
+	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. ToHarvest[Map.LobbyOption("difficulty")], player.Color)
 end
 
 WorldLoaded = function()
@@ -106,12 +106,12 @@ WorldLoaded = function()
 		Reinforcements.Reinforce(player, AtreidesReinforcements, AtreidesEntryPath)
 	end)
 
-	WavesLeft = HarkonnenAttackWaves[Map.Difficulty]
+	WavesLeft = HarkonnenAttackWaves[Map.LobbyOption("difficulty")]
 	SendReinforcements()
 end
 
 SendReinforcements = function()
-	local units = HarkonnenReinforcements[Map.Difficulty]
+	local units = HarkonnenReinforcements[Map.LobbyOption("difficulty")]
 	local delay = Utils.RandomInteger(HarkonnenAttackDelay - DateTime.Seconds(2), HarkonnenAttackDelay)
 	HarkonnenAttackDelay = HarkonnenAttackDelay - (#units * 3 - 3 - WavesLeft) * DateTime.Seconds(1)
 	if HarkonnenAttackDelay < 0 then HarkonnenAttackDelay = 0 end
@@ -134,7 +134,7 @@ InitObjectives = function()
 	end)
 
 	KillAtreides = harkonnen.AddPrimaryObjective("Kill all Atreides units.")
-	GatherSpice = player.AddPrimaryObjective("Harvest " .. tostring(ToHarvest[Map.Difficulty]) .. " Solaris worth of Spice.")
+	GatherSpice = player.AddPrimaryObjective("Harvest " .. tostring(ToHarvest[Map.LobbyOption("difficulty")]) .. " Solaris worth of Spice.")
 	KillHarkonnen = player.AddSecondaryObjective("Eliminate all Harkonnen units and reinforcements\nin the area.")
 
 	Trigger.OnObjectiveCompleted(player, function(p, id)

--- a/mods/d2k/maps/atreides-01b/rules.yaml
+++ b/mods/d2k/maps/atreides-01b/rules.yaml
@@ -10,7 +10,14 @@ World:
 		BriefingVideo: A_BR01_E.VQA
 	MapOptions:
 		TechLevel: Low
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 construction_yard:
 	Production:

--- a/mods/d2k/maps/atreides-02a/atreides02a.lua
+++ b/mods/d2k/maps/atreides-02a/atreides02a.lua
@@ -2,14 +2,14 @@
 HarkonnenBase = { HConyard, HPower1, HPower2, HBarracks }
 
 HarkonnenReinforcements = { }
-HarkonnenReinforcements["Easy"] =
+HarkonnenReinforcements["easy"] =
 {
 	{ "light_inf", "trike" },
 	{ "light_inf", "trike" },
 	{ "light_inf", "light_inf", "light_inf", "trike", "trike" }
 }
 
-HarkonnenReinforcements["Normal"] =
+HarkonnenReinforcements["normal"] =
 {
 	{ "light_inf", "trike" },
 	{ "light_inf", "trike" },
@@ -19,7 +19,7 @@ HarkonnenReinforcements["Normal"] =
 	{ "light_inf", "trike" },
 }
 
-HarkonnenReinforcements["Hard"] =
+HarkonnenReinforcements["hard"] =
 {
 	{ "trike", "trike" },
 	{ "light_inf", "trike" },
@@ -41,25 +41,25 @@ HarkonnenAttackPaths =
 }
 
 HarkonnenAttackDelay = { }
-HarkonnenAttackDelay["Easy"] = DateTime.Minutes(5)
-HarkonnenAttackDelay["Normal"] = DateTime.Minutes(2) + DateTime.Seconds(40)
-HarkonnenAttackDelay["Hard"] = DateTime.Minutes(1) + DateTime.Seconds(20)
+HarkonnenAttackDelay["easy"] = DateTime.Minutes(5)
+HarkonnenAttackDelay["normal"] = DateTime.Minutes(2) + DateTime.Seconds(40)
+HarkonnenAttackDelay["hard"] = DateTime.Minutes(1) + DateTime.Seconds(20)
 
 HarkonnenAttackWaves = { }
-HarkonnenAttackWaves["Easy"] = 3
-HarkonnenAttackWaves["Normal"] = 6
-HarkonnenAttackWaves["Hard"] = 9
+HarkonnenAttackWaves["easy"] = 3
+HarkonnenAttackWaves["normal"] = 6
+HarkonnenAttackWaves["hard"] = 9
 
 wave = 0
 SendHarkonnen = function()
-	Trigger.AfterDelay(HarkonnenAttackDelay[Map.Difficulty], function()
+	Trigger.AfterDelay(HarkonnenAttackDelay[Map.LobbyOption("difficulty")], function()
 		wave = wave + 1
-		if wave > HarkonnenAttackWaves[Map.Difficulty] then
+		if wave > HarkonnenAttackWaves[Map.LobbyOption("difficulty")] then
 			return
 		end
 
 		local path = Utils.Random(HarkonnenAttackPaths)
-		local units = Reinforcements.ReinforceWithTransport(harkonnen, "carryall.reinforce", HarkonnenReinforcements[Map.Difficulty][wave], path, { path[1] })[2]
+		local units = Reinforcements.ReinforceWithTransport(harkonnen, "carryall.reinforce", HarkonnenReinforcements[Map.LobbyOption("difficulty")][wave], path, { path[1] })[2]
 		Utils.Do(units, IdleHunt)
 
 		SendHarkonnen()

--- a/mods/d2k/maps/atreides-02a/rules.yaml
+++ b/mods/d2k/maps/atreides-02a/rules.yaml
@@ -10,7 +10,14 @@ World:
 		BriefingVideo: A_BR02_E.VQA
 	MapOptions:
 		TechLevel: Low
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 carryall.reinforce:
 	Cargo:

--- a/mods/d2k/maps/atreides-02b/atreides02b.lua
+++ b/mods/d2k/maps/atreides-02b/atreides02b.lua
@@ -2,14 +2,14 @@
 HarkonnenBase = { HConyard, HOutpost, HBarracks }
 
 HarkonnenReinforcements = { }
-HarkonnenReinforcements["Easy"] =
+HarkonnenReinforcements["easy"] =
 {
 	{ "light_inf", "trike" },
 	{ "light_inf", "trike" },
 	{ "light_inf", "light_inf", "light_inf", "trike", "trike" }
 }
 
-HarkonnenReinforcements["Normal"] =
+HarkonnenReinforcements["normal"] =
 {
 	{ "light_inf", "trike" },
 	{ "light_inf", "trike" },
@@ -19,7 +19,7 @@ HarkonnenReinforcements["Normal"] =
 	{ "light_inf", "trike" },
 }
 
-HarkonnenReinforcements["Hard"] =
+HarkonnenReinforcements["hard"] =
 {
 	{ "trike", "trike" },
 	{ "light_inf", "trike" },
@@ -42,28 +42,28 @@ HarkonnenAttackPaths =
 
 HarkonnenAttackDelay =
 {
-	Easy = DateTime.Minutes(5),
-	Normal = DateTime.Minutes(2) + DateTime.Seconds(40),
-	Hard = DateTime.Minutes(1) + DateTime.Seconds(20)
+	easy = DateTime.Minutes(5),
+	normal = DateTime.Minutes(2) + DateTime.Seconds(40),
+	hard = DateTime.Minutes(1) + DateTime.Seconds(20)
 }
 
 HarkonnenAttackWaves =
 {
-	Easy = 3,
-	Normal = 6,
-	Hard = 9
+	easy = 3,
+	normal = 6,
+	hard = 9
 }
 
 wave = 0
 SendHarkonnen = function()
-	Trigger.AfterDelay(HarkonnenAttackDelay[Map.Difficulty], function()
+	Trigger.AfterDelay(HarkonnenAttackDelay[Map.LobbyOption("difficulty")], function()
 		wave = wave + 1
-		if wave > HarkonnenAttackWaves[Map.Difficulty] then
+		if wave > HarkonnenAttackWaves[Map.LobbyOption("difficulty")] then
 			return
 		end
 
 		local path = Utils.Random(HarkonnenAttackPaths)
-		local units = Reinforcements.ReinforceWithTransport(harkonnen, "carryall.reinforce", HarkonnenReinforcements[Map.Difficulty][wave], path, { path[1] })[2]
+		local units = Reinforcements.ReinforceWithTransport(harkonnen, "carryall.reinforce", HarkonnenReinforcements[Map.LobbyOption("difficulty")][wave], path, { path[1] })[2]
 		Utils.Do(units, IdleHunt)
 
 		SendHarkonnen()

--- a/mods/d2k/maps/atreides-02b/rules.yaml
+++ b/mods/d2k/maps/atreides-02b/rules.yaml
@@ -10,7 +10,14 @@ World:
 		BriefingVideo: A_BR02_E.VQA
 	MapOptions:
 		TechLevel: Low
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 carryall.reinforce:
 	Cargo:

--- a/mods/d2k/maps/atreides-03a/atreides03a-AI.lua
+++ b/mods/d2k/maps/atreides-03a/atreides03a-AI.lua
@@ -2,15 +2,15 @@ IdlingUnits = { }
 
 AttackGroupSize =
 {
-	Easy = 6,
-	Normal = 8,
-	Hard = 10
+	easy = 6,
+	normal = 8,
+	hard = 10
 }
 AttackDelays =
 {
-	Easy = { DateTime.Seconds(4), DateTime.Seconds(9) },
-	Normal = { DateTime.Seconds(2), DateTime.Seconds(7) },
-	Hard = { DateTime.Seconds(1), DateTime.Seconds(5) }
+	easy = { DateTime.Seconds(4), DateTime.Seconds(9) },
+	normal = { DateTime.Seconds(2), DateTime.Seconds(7) },
+	hard = { DateTime.Seconds(1), DateTime.Seconds(5) }
 }
 
 OrdosInfantryTypes = { "light_inf", "light_inf", "light_inf", "trooper", "trooper" }
@@ -25,7 +25,7 @@ IdleHunt = function(unit) if not unit.IsDead then Trigger.OnIdle(unit, unit.Hunt
 SetupAttackGroup = function()
 	local units = { }
 
-	for i = 0, AttackGroupSize[Map.Difficulty], 1 do
+	for i = 0, AttackGroupSize[Map.LobbyOption("difficulty")], 1 do
 		if #IdlingUnits == 0 then
 			return units
 		end
@@ -115,13 +115,13 @@ ProduceInfantry = function()
 		return
 	end
 
-	local delay = Utils.RandomInteger(AttackDelays[Map.Difficulty][1], AttackDelays[Map.Difficulty][2] + 1)
+	local delay = Utils.RandomInteger(AttackDelays[Map.LobbyOption("difficulty")][1], AttackDelays[Map.LobbyOption("difficulty")][2] + 1)
 	local toBuild = { Utils.Random(OrdosInfantryTypes) }
 	ordos.Build(toBuild, function(unit)
 		IdlingUnits[#IdlingUnits + 1] = unit[1]
 		Trigger.AfterDelay(delay, ProduceInfantry)
 
-		if #IdlingUnits >= (AttackGroupSize[Map.Difficulty] * 2.5) then
+		if #IdlingUnits >= (AttackGroupSize[Map.LobbyOption("difficulty")] * 2.5) then
 			SendAttack()
 		end
 	end)
@@ -137,13 +137,13 @@ ProduceVehicles = function()
 		return
 	end
 
-	local delay = Utils.RandomInteger(AttackDelays[Map.Difficulty][1], AttackDelays[Map.Difficulty][2] + 1)
+	local delay = Utils.RandomInteger(AttackDelays[Map.LobbyOption("difficulty")][1], AttackDelays[Map.LobbyOption("difficulty")][2] + 1)
 	local toBuild = { Utils.Random(OrdosVehicleTypes) }
 	ordos.Build(toBuild, function(unit)
 		IdlingUnits[#IdlingUnits + 1] = unit[1]
 		Trigger.AfterDelay(delay, ProduceVehicles)
 
-		if #IdlingUnits >= (AttackGroupSize[Map.Difficulty] * 2.5) then
+		if #IdlingUnits >= (AttackGroupSize[Map.LobbyOption("difficulty")] * 2.5) then
 			SendAttack()
 		end
 	end)

--- a/mods/d2k/maps/atreides-03a/atreides03a.lua
+++ b/mods/d2k/maps/atreides-03a/atreides03a.lua
@@ -2,14 +2,14 @@ OrdosBase = { OBarracks, OWindTrap1, OWindTrap2, OWindTrap3, OWindTrap4, OLightF
 
 OrdosReinforcements =
 {
-	Easy =
+	easy =
 	{
 		{ "light_inf", "raider", "trooper" },
 		{ "light_inf", "raider", "quad" },
 		{ "light_inf", "light_inf", "trooper", "raider", "raider", "quad" }
 	},
 
-	Normal =
+	normal =
 	{
 		{ "light_inf", "raider", "trooper" },
 		{ "light_inf", "raider", "raider" },
@@ -19,7 +19,7 @@ OrdosReinforcements =
 		{ "light_inf", "raider", "quad", "quad" }
 	},
 
-	Hard =
+	hard =
 	{
 		{ "raider", "raider", "quad" },
 		{ "light_inf", "raider", "raider" },
@@ -35,23 +35,23 @@ OrdosReinforcements =
 
 OrdosAttackDelay =
 {
-	Easy = DateTime.Minutes(5),
-	Normal = DateTime.Minutes(2) + DateTime.Seconds(40),
-	Hard = DateTime.Minutes(1) + DateTime.Seconds(20)
+	easy = DateTime.Minutes(5),
+	normal = DateTime.Minutes(2) + DateTime.Seconds(40),
+	hard = DateTime.Minutes(1) + DateTime.Seconds(20)
 }
 
 OrdosAttackWaves =
 {
-	Easy = 3,
-	Normal = 6,
-	Hard = 9
+	easy = 3,
+	normal = 6,
+	hard = 9
 }
 
 ToHarvest =
 {
-	Easy = 5000,
-	Normal = 6000,
-	Hard = 7000
+	easy = 5000,
+	normal = 6000,
+	hard = 7000
 }
 
 InitialOrdosReinforcements = { "light_inf", "light_inf", "quad", "quad", "raider", "raider", "trooper", "trooper" }
@@ -70,17 +70,17 @@ AtreidesUpgrades = { "upgrade.barracks", "upgrade.light" }
 
 wave = 0
 SendOrdos = function()
-	Trigger.AfterDelay(OrdosAttackDelay[Map.Difficulty], function()
+	Trigger.AfterDelay(OrdosAttackDelay[Map.LobbyOption("difficulty")], function()
 		if player.IsObjectiveCompleted(KillOrdos) then
 			return
 		end
 
 		wave = wave + 1
-		if wave > OrdosAttackWaves[Map.Difficulty] then
+		if wave > OrdosAttackWaves[Map.LobbyOption("difficulty")] then
 			return
 		end
 
-		local units = Reinforcements.ReinforceWithTransport(ordos, "carryall.reinforce", OrdosReinforcements[Map.Difficulty][wave], OrdosPaths[1], { OrdosPaths[1][1] })[2]
+		local units = Reinforcements.ReinforceWithTransport(ordos, "carryall.reinforce", OrdosReinforcements[Map.LobbyOption("difficulty")][wave], OrdosPaths[1], { OrdosPaths[1][1] })[2]
 		Utils.Do(units, IdleHunt)
 
 		SendOrdos()
@@ -110,7 +110,7 @@ Tick = function()
 		end
 	end
 
-	if player.Resources > ToHarvest[Map.Difficulty] - 1 then
+	if player.Resources > ToHarvest[Map.LobbyOption("difficulty")] - 1 then
 		player.MarkCompletedObjective(GatherSpice)
 	end
 
@@ -118,7 +118,7 @@ Tick = function()
 		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.", "Mentat")
 	end
 
-	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. ToHarvest[Map.Difficulty], player.Color)
+	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. ToHarvest[Map.LobbyOption("difficulty")], player.Color)
 end
 
 WorldLoaded = function()
@@ -147,7 +147,7 @@ InitObjectives = function()
 	end)
 
 	KillAtreides = ordos.AddPrimaryObjective("Kill all Atreides units.")
-	GatherSpice = player.AddPrimaryObjective("Harvest " .. tostring(ToHarvest[Map.Difficulty]) .. " Solaris worth of Spice.")
+	GatherSpice = player.AddPrimaryObjective("Harvest " .. tostring(ToHarvest[Map.LobbyOption("difficulty")]) .. " Solaris worth of Spice.")
 	KillOrdos = player.AddSecondaryObjective("Eliminate all Ordos units and reinforcements\nin the area.")
 
 	Trigger.OnObjectiveCompleted(player, function(p, id)

--- a/mods/d2k/maps/atreides-03a/rules.yaml
+++ b/mods/d2k/maps/atreides-03a/rules.yaml
@@ -10,7 +10,14 @@ World:
 		BriefingVideo: A_BR03_E.VQA
 	MapOptions:
 		TechLevel: Low
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 carryall.reinforce:
 	Cargo:

--- a/mods/ra/maps/allies-02/allies02.lua
+++ b/mods/ra/maps/allies-02/allies02.lua
@@ -11,7 +11,7 @@ PathGuards = { PathGuard1, PathGuard2, PathGuard3, PathGuard4, PathGuard5, PathG
 
 IdlingUnits = { }
 
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	TimerTicks = DateTime.Minutes(10)
 	Announcements =
 	{
@@ -23,7 +23,7 @@ if Map.Difficulty == "Easy" then
 		{ speech = "WarningOneMinuteRemaining", delay = DateTime.Minutes(9) }
 	}
 
-elseif Map.Difficulty == "Normal" then
+elseif Map.LobbyOption("difficulty") == "normal" then
 	TimerTicks = DateTime.Minutes(5)
 	Announcements =
 	{
@@ -38,7 +38,7 @@ elseif Map.Difficulty == "Normal" then
 	InfantryDelay = DateTime.Seconds(18)
 	AttackGroupSize = 5
 
-elseif Map.Difficulty == "Hard" then
+elseif Map.LobbyOption("difficulty") == "hard" then
 	TimerTicks = DateTime.Minutes(3)
 	Announcements =
 	{
@@ -146,7 +146,7 @@ SendAttack = function()
 	end
 
 	Utils.Do(units, function(unit)
-		if Map.Difficulty ~= "Real tough guy" then
+		if Map.LobbyOption("difficulty") ~= "tough" then
 			unit.AttackMove(DeployPoint.Location)
 		end
 		Trigger.OnIdle(unit, unit.Hunt)

--- a/mods/ra/maps/allies-02/rules.yaml
+++ b/mods/ra/maps/allies-02/rules.yaml
@@ -22,7 +22,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-			realtoughguy: Real tough guy
+			tough: Real tough guy
 		Default: easy
 
 HARV:

--- a/mods/ra/maps/allies-02/rules.yaml
+++ b/mods/ra/maps/allies-02/rules.yaml
@@ -12,11 +12,18 @@ World:
 		WinVideo: montpass.vqa
 		LossVideo: frozen.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard, Real tough guy
 	SmudgeLayer@CRATER:
 		InitialSmudges:
 			60,79: cr1,0
-
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+			realtoughguy: Real tough guy
+		Default: easy
 
 HARV:
 	Buildable:

--- a/mods/ra/maps/allies-03a/allies03a.lua
+++ b/mods/ra/maps/allies-03a/allies03a.lua
@@ -9,7 +9,7 @@ WaterTransportTriggerArea = { CPos.New(39, 54), CPos.New(40, 54), CPos.New(41, 5
 ParadropTriggerArea = { CPos.New(81, 60), CPos.New(82, 60), CPos.New(83, 60), CPos.New(63, 63), CPos.New(64, 63), CPos.New(65, 63), CPos.New(66, 63), CPos.New(67, 63), CPos.New(68, 63), CPos.New(69, 63), CPos.New(70, 63), CPos.New(71, 63), CPos.New(72, 63) }
 ReinforcementsTriggerArea = { CPos.New(96, 55), CPos.New(97, 55), CPos.New(97, 56), CPos.New(98, 56) }
 
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	TanyaType = "e7"
 else
 	TanyaType = "e7.noautotarget"

--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -7,7 +7,13 @@ World:
 		WinVideo: toofar.vqa
 		LossVideo: sovtstar.vqa
 	MapOptions:
-		Difficulties: Easy, Normal
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+		Default: easy
 
 ^Building:
 	Capturable:

--- a/mods/ra/maps/allies-03b/allies03b.lua
+++ b/mods/ra/maps/allies-03b/allies03b.lua
@@ -20,7 +20,7 @@ GuardTanks = { Heavy1, Heavy2, Heavy3 }
 CheckpointGuards = { USSRCheckpointGuard1, USSRCheckpointGuard2 }
 CheckpointGuardWaypoints = { CheckpointGuardWaypoint1, CheckpointGuardWaypoint2 }
 
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	TanyaType = "e7"
 else
 	TanyaType = "e7.noautotarget"

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -7,7 +7,13 @@ World:
 		WinVideo: toofar.vqa
 		LossVideo: sovtstar.vqa
 	MapOptions:
-		Difficulties: Easy, Normal
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+		Default: easy
 
 ^Building:
 	Capturable:

--- a/mods/ra/maps/allies-05a/allies05a-AI.lua
+++ b/mods/ra/maps/allies-05a/allies05a-AI.lua
@@ -158,7 +158,7 @@ InitProductionBuildings = function()
 		end)
 	end
 
-	if Map.Difficulty ~= "Easy" then
+	if Map.LobbyOption("difficulty") ~= "easy" then
 
 		if not Airfield1.IsDead then
 			Trigger.OnKilled(Airfield1, function()

--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -1,9 +1,9 @@
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	TanyaType = "e7"
 	ReinforceCash = 5000
 	HoldAITime = DateTime.Minutes(3)
 	SpecialCameras = true
-elseif Map.Difficulty == "Normal" then
+elseif Map.LobbyOption("difficulty") == "normal" then
 	TanyaType = "e7.noautotarget"
 	ChangeStance = true
 	ReinforceCash = 2250
@@ -83,7 +83,7 @@ Tick = function()
 	end
 
 	if ussr.HasNoRequiredUnits() then
-		if not greece.IsObjectiveCompleted(KillAll) and Map.Difficulty == "Real tough guy" then
+		if not greece.IsObjectiveCompleted(KillAll) and Map.LobbyOption("difficulty") == "tough" then
 			SendWaterExtraction()
 		end
 		greece.MarkCompletedObjective(KillAll)
@@ -186,7 +186,7 @@ FreeTanya = function()
 
 	Trigger.OnKilled(Tanya, function() ussr.MarkCompletedObjective(ussrObj) end)
 
-	if Map.Difficulty == "Real tough guy" then
+	if Map.LobbyOption("difficulty") == "tough" then
 		KillSams = greece.AddPrimaryObjective("Destroy all four SAM Sites that block\nour reinforcements' helicopter.")
 
 		greece.MarkCompletedObjective(mainObj)
@@ -272,7 +272,7 @@ InitTriggers = function()
 		end
 	end)
 
-	if Map.Difficulty ~= "Real tough guy" then
+	if Map.LobbyOption("difficulty") ~= "tough" then
 		Trigger.OnKilled(Mammoth, function()
 			Trigger.AfterDelay(HoldAITime - DateTime.Seconds(45), function() HoldProduction = false end)
 			Trigger.AfterDelay(HoldAITime, function() Attacking = true end)
@@ -294,7 +294,7 @@ InitTriggers = function()
 		Trigger.AfterDelay(DateTime.Seconds(7), flare.Destroy)
 		Media.PlaySpeechNotification(greece, "SignalFlare")
 
-		if Map.Difficulty == "Real tough guy" then
+		if Map.LobbyOption("difficulty") == "tough" then
 			Reinforcements.ReinforceWithTransport(greece, InsertionHeliType, HeliReinforcements, ExtractionPath, { ExtractionPath[1] })
 			if not Harvester.IsDead then
 				Harvester.FindResources()

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -9,7 +9,15 @@ World:
 		LossVideo: grvestne.vqa
 	MapOptions:
 		TechLevel: Medium
-		Difficulties: Easy, Normal, Hard, Real tough guy
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+			realtoughguy: Real tough guy
+		Default: easy
 
 Camera.Truk:
 	AlwaysVisible:

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -16,7 +16,7 @@ World:
 			easy: Easy
 			normal: Normal
 			hard: Hard
-			realtoughguy: Real tough guy
+			tough: Real tough guy
 		Default: easy
 
 Camera.Truk:

--- a/mods/ra/maps/evacuation/evacuation.lua
+++ b/mods/ra/maps/evacuation/evacuation.lua
@@ -1,20 +1,20 @@
 DeathThreshold =
 {
-	Easy = 200,
-	Normal = 100,
+	easy = 200,
+	normal = 100,
 }
 
 TanyaType = "e7"
 TanyaStance = "AttackAnything"
-if Map.Difficulty ~= "Easy" then
+if Map.LobbyOption("difficulty") ~= "easy" then
 	TanyaType = "e7.noautotarget"
 	TanyaStance = "HoldFire"
 end
 
 RepairTriggerThreshold =
 {
-	Easy = 50,
-	Normal = 75,
+	easy = 50,
+	normal = 75,
 }
 
 Sams = { Sam1, Sam2, Sam3, Sam4 }
@@ -58,8 +58,8 @@ SovietVehicles =
 }
 ProductionInterval =
 {
-	Easy = DateTime.Seconds(10),
-	Normal = DateTime.Seconds(2),
+	easy = DateTime.Seconds(10),
+	normal = DateTime.Seconds(2),
 }
 
 ReinforcementsDelay = DateTime.Minutes(16)
@@ -144,7 +144,7 @@ ProduceInfantry = function()
 	soviets.Build({ Utils.Random(SovietInfantry) }, function(units)
 		table.insert(AttackGroup, units[1])
 		SendAttackGroup()
-		Trigger.AfterDelay(ProductionInterval[Map.Difficulty], ProduceInfantry)
+		Trigger.AfterDelay(ProductionInterval[Map.LobbyOption("difficulty")], ProduceInfantry)
 	end)
 end
 
@@ -156,7 +156,7 @@ ProduceVehicles = function()
 	soviets.Build({ Utils.Random(SovietVehicles[SovietVehicleType]) }, function(units)
 		table.insert(AttackGroup, units[1])
 		SendAttackGroup()
-		Trigger.AfterDelay(ProductionInterval[Map.Difficulty], ProduceVehicles)
+		Trigger.AfterDelay(ProductionInterval[Map.LobbyOption("difficulty")], ProduceVehicles)
 	end)
 end
 
@@ -177,7 +177,7 @@ Tick = function()
 		allies2.MarkCompletedObjective(objCutSovietPower)
 	end
 
-	if not allies2.IsObjectiveCompleted(objLimitLosses) and allies2.UnitsLost > DeathThreshold[Map.Difficulty] then
+	if not allies2.IsObjectiveCompleted(objLimitLosses) and allies2.UnitsLost > DeathThreshold[Map.LobbyOption("difficulty")] then
 		allies2.MarkFailedObjective(objLimitLosses)
 	end
 
@@ -191,7 +191,7 @@ end
 SetupSoviets = function()
 	soviets.Cash = 1000
 
-	if Map.Difficulty == "Easy" then
+	if Map.LobbyOption("difficulty") == "easy" then
 		Utils.Do(Sams, function(sam)
 			local camera = Actor.Create("Camera.SAM", true, { Owner = allies1, Location = sam.Location })
 			Trigger.OnKilledOrCaptured(sam, function()
@@ -203,7 +203,7 @@ SetupSoviets = function()
 	local buildings = Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == soviets and self.HasProperty("StartBuildingRepairs") end)
 	Utils.Do(buildings, function(actor)
 		Trigger.OnDamaged(actor, function(building)
-			if building.Owner == soviets and building.Health < (building.MaxHealth * RepairTriggerThreshold[Map.Difficulty] / 100) then
+			if building.Owner == soviets and building.Health < (building.MaxHealth * RepairTriggerThreshold[Map.LobbyOption("difficulty")] / 100) then
 				building.StartBuildingRepairs()
 			end
 		end)
@@ -283,7 +283,7 @@ SpawnTanya = function()
 	Tanya = Actor.Create(TanyaType, true, { Owner = allies1, Location = TanyaLocation.Location })
 	Tanya.Stance = TanyaStance
 
-	if Map.Difficulty ~= "Easy" and allies1.IsLocalPlayer then
+	if Map.LobbyOption("difficulty") ~= "easy" and allies1.IsLocalPlayer then
 		Trigger.AfterDelay(DateTime.Seconds(2), function()
 			Media.DisplayMessage("According to the rules of engagement I need your explicit orders to fire, Commander!", "Tanya")
 		end)
@@ -355,7 +355,7 @@ WorldLoaded = function()
 	objDestroySamSites = allies1.AddPrimaryObjective("Destroy the SAM sites.")
 
 	objHoldPosition = allies2.AddPrimaryObjective("Hold your position and protect the base.")
-	objLimitLosses = allies2.AddSecondaryObjective("Do not lose more than " .. DeathThreshold[Map.Difficulty] .. " units.")
+	objLimitLosses = allies2.AddSecondaryObjective("Do not lose more than " .. DeathThreshold[Map.LobbyOption("difficulty")] .. " units.")
 	objCutSovietPower = allies2.AddSecondaryObjective("Take out the Soviet power grid.")
 
 	SetupTriggers()

--- a/mods/ra/maps/evacuation/rules.yaml
+++ b/mods/ra/maps/evacuation/rules.yaml
@@ -13,8 +13,13 @@ World:
 		Scripts: evacuation.lua
 	MapOptions:
 		TechLevelLocked: True
-		Difficulties: Easy, Normal
-		Difficulty: Normal
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+		Default: normal
 
 ^Tanks:
 	Demolishable:
@@ -214,4 +219,3 @@ powerproxy.paras2:
 	AlwaysVisible:
 	ParatroopersPower:
 		DropItems: E1,E1,E1,E2,E2
-

--- a/mods/ra/maps/fort-lonestar/fort-lonestar.lua
+++ b/mods/ra/maps/fort-lonestar/fort-lonestar.lua
@@ -13,7 +13,7 @@ Walls =
 	{ WallBottomRight1, WallBottomRight2, WallBottomRight3, WallBottomRight4, WallBottomRight5, WallBottomRight6, WallBottomRight7, WallBottomRight8, WallBottomRight9 }
 }
 
-if Map.Difficulty == "Very Easy (1P)" then
+if Map.LobbyOption("difficulty") == "veryeasy" then
 	ParaChance = 20
 	Patrol = { "e1", "e2", "e1" }
 	Infantry = { "e4", "e1", "e1", "e2", "e2" }
@@ -22,7 +22,7 @@ if Map.Difficulty == "Very Easy (1P)" then
 	LongRange = { "arty" }
 	Boss = { "v2rl" }
 	Swarm = { "shok", "shok", "shok" }
-elseif Map.Difficulty == "Easy (2P)" then
+elseif Map.LobbyOption("difficulty") == "easy" then
 	ParaChance = 25
 	Patrol = { "e1", "e2", "e1" }
 	Infantry = { "e4", "e1", "e1", "e2", "e1", "e2", "e1" }
@@ -31,7 +31,7 @@ elseif Map.Difficulty == "Easy (2P)" then
 	LongRange = { "v2rl" }
 	Boss = { "4tnk" }
 	Swarm = { "shok", "shok", "shok", "shok", "ttnk" }
-elseif Map.Difficulty == "Normal (3P)" then
+elseif Map.LobbyOption("difficulty") == "normal" then
 	ParaChance = 30
 	Patrol = { "e1", "e2", "e1", "e1" }
 	Infantry = { "e4", "e1", "e1", "e2", "e1", "e2", "e1" }
@@ -40,7 +40,7 @@ elseif Map.Difficulty == "Normal (3P)" then
 	LongRange = { "v2rl" }
 	Boss = { "4tnk" }
 	Swarm = { "shok", "shok", "shok", "shok", "ttnk", "ttnk", "ttnk" }
-elseif Map.Difficulty == "Hard (4P)" then
+elseif Map.LobbyOption("difficulty") == "hard" then
 	ParaChance = 35
 	Patrol = { "e1", "e2", "e1", "e1", "e4" }
 	Infantry = { "e4", "e1", "e1", "e2", "e1", "e2", "e1" }
@@ -77,7 +77,7 @@ Waves =
 }
 
 -- Now do some adjustments to the waves
-if Map.Difficulty == "Real tough guy" or Map.Difficulty == "Endless mode" then
+if Map.LobbyOption("difficulty") == "tough" or Map.LobbyOption("difficulty") == "endless" then
 	Waves[8] = { delay = 1500, units = { Infantry, Infantry, Patrol, Infantry, Infantry, Infantry }, ironUnits = { LongRange } }
 	Waves[9] = { delay = 1500, units = { Infantry, Infantry, Patrol, Infantry, Infantry, Infantry, Infantry, Infantry, LongRange, LongRange, Vehicles, Tank }, ironUnits = { Tank } }
 	Waves[11] = { delay = 1500, units = { Vehicles, Infantry, Patrol, Patrol, Patrol, Infantry, LongRange, Tank, Boss, Infantry, Infantry, Patrol } }
@@ -145,7 +145,7 @@ SendWave = function()
 				SendWave()
 			end
 		else
-			if Map.Difficulty == "Endless mode" then
+			if Map.LobbyOption("difficulty") == "endless" then
 				Wave = 0
 				IncreaseDifficulty()
 				SendWave()

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -38,9 +38,19 @@ World:
 	MapOptions:
 		TechLevelLocked: True
 		TechLevel: Unrestricted
-		Difficulties: Hard (4P), Normal (3P), Easy (2P), Very Easy (1P), Real tough guy, Endless mode
 		ShortGameLocked: True
 		ShortGameEnabled: False
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			hard(4p): Hard (4P)
+			normal(3p): Normal (3P)
+			easy(2p): Easy (2P)
+			veryeasy(1p): Very Easy (1P)
+			realtoughguy: Real tough guy
+			endlessmode: Endless mode
+		Default: hard(4p)
 
 FORTCRATE:
 	Inherits: ^Crate

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -44,13 +44,13 @@ World:
 		ID: difficulty
 		Label: Difficulty
 		Values:
-			hard(4p): Hard (4P)
-			normal(3p): Normal (3P)
-			easy(2p): Easy (2P)
-			veryeasy(1p): Very Easy (1P)
-			realtoughguy: Real tough guy
-			endlessmode: Endless mode
-		Default: hard(4p)
+			hard: Hard (4P)
+			normal: Normal (3P)
+			easy: Easy (2P)
+			veryeasy: Very Easy (1P)
+			tough: Real tough guy
+			endless: Endless mode
+		Default: hard
 
 FORTCRATE:
 	Inherits: ^Crate

--- a/mods/ra/maps/intervention/intervention.lua
+++ b/mods/ra/maps/intervention/intervention.lua
@@ -9,9 +9,9 @@ BeachheadTrigger =
 	CPos.New(137, 104), CPos.New(137, 105), CPos.New(137, 106), CPos.New(136, 106), CPos.New(136, 107)
 }
 
-Difficulty = Map.Difficulty
+Difficulty = Map.LobbyOption("difficulty")
 
-if Difficulty == "Medium" then
+if Difficulty == "medium" then
 	BaseRaidInterval = DateTime.Minutes(3)
 	BaseFrontAttackInterval = DateTime.Minutes(3) + DateTime.Seconds(30)
 	BaseRearAttackInterval = DateTime.Minutes(8)

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -8,7 +8,13 @@ World:
 	MissionData:
 		Briefing: The Soviet Air Force is flying air raids against a civilian village.\n\nWe have to do everything in our power to stop them!\n\nYour job is to establish a base on the mainland ASAP. We can prevent the village's destruction by capturing the enemy's Air Force Headquarters building. The enemy base is heavily guarded, though.  You will not have enough time to build a force big enough to overpower the Soviet defences. You will have to find a way to sneak in!\n\nGood luck, Commander!\n
 	MapOptions:
-		Difficulties: Medium, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			medium: Medium
+			hard: Hard
+		Default: medium
 
 CAMERA:
 	RevealsShroud:

--- a/mods/ra/maps/soviet-03/rules.yaml
+++ b/mods/ra/maps/soviet-03/rules.yaml
@@ -8,7 +8,14 @@ World:
 		WinVideo: execute.vqa
 		LossVideo: take_off.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 ^TechBuilding:
 	AutoTargetIgnore:

--- a/mods/ra/maps/soviet-03/soviet03.lua
+++ b/mods/ra/maps/soviet-03/soviet03.lua
@@ -1,8 +1,8 @@
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	remainingTime = DateTime.Minutes(7)
-elseif Map.Difficulty == "Normal" then
+elseif Map.LobbyOption("difficulty") == "normal" then
 	remainingTime = DateTime.Minutes(6)
-elseif Map.Difficulty == "Hard" then
+elseif Map.LobbyOption("difficulty") == "hard" then
 	remainingTime = DateTime.Minutes(5)
 end
 
@@ -256,7 +256,7 @@ end)
 Trigger.OnEnteredFootprint(SpyHideout3Trigger, function(a, id)
 	if not spyHideout3Trigger and a.Owner == player then
 		spyHideout3Trigger = true
-		if Map.Difficulty ~= "Hard" then
+		if Map.LobbyOption("difficulty") ~= "hard" then
 			Reinforcements.Reinforce(player, USSRReinforcements2, { ReinforcementSpawn.Location, CameraSpyHideout33.Location }, 0)
 			Media.PlaySpeechNotification(player, "ReinforcementsArrived")
 		end
@@ -363,7 +363,7 @@ Tick = function()
 	if not SpyHideout4.IsDead and SpyHideout4.HasPassengers then
 		spyReachedHideout4 = true
 	end
-	if remainingTime == DateTime.Minutes(5) and Map.Difficulty ~= "Hard" then
+	if remainingTime == DateTime.Minutes(5) and Map.LobbyOption("difficulty") ~= "hard" then
 		Media.PlaySpeechNotification(player, "WarningFiveMinutesRemaining")
 	elseif remainingTime == DateTime.Minutes(4) then
 		Media.PlaySpeechNotification(player, "WarningFourMinutesRemaining")

--- a/mods/ra/maps/soviet-04a/rules.yaml
+++ b/mods/ra/maps/soviet-04a/rules.yaml
@@ -13,7 +13,14 @@ World:
 		LossVideo: allymorf.vqa
 	MapOptions:
 		TechLevel: Medium
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 AFLD:
 	ParatroopersPower@paratroopers:

--- a/mods/ra/maps/soviet-04a/soviet04a-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-04a/soviet04a-reinforcements_teams.lua
@@ -18,7 +18,7 @@ Patrol2Path = { BridgeEntrancePoint.Location, NERoadTurnPoint.Location, Crossroa
 
 VillageCamArea = { CPos.New(68, 75),CPos.New(68, 76),CPos.New(68, 77),CPos.New(68, 78),CPos.New(68, 79), CPos.New(68, 80), CPos.New(68, 81), CPos.New(68, 82) }
 
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	ArmorReinfGreece = { "jeep", "1tnk", "1tnk" }
 else
 	ArmorReinfGreece = { "jeep", "jeep", "1tnk", "1tnk", "1tnk" }
@@ -60,7 +60,7 @@ BringPatrol1 = function()
 	end)
 
 	Trigger.OnAllKilled(units, function()
-		if Map.Difficulty == "Hard" then
+		if Map.LobbyOption("difficulty") == "hard" then
 			Trigger.AfterDelay(DateTime.Minutes(4), BringPatrol1)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(7), BringPatrol1)
@@ -79,7 +79,7 @@ BringPatrol2 = function()
 	end)
 
 	Trigger.OnAllKilled(units, function()
-		if Map.Difficulty == "Hard" then
+		if Map.LobbyOption("difficulty") == "hard" then
 			Trigger.AfterDelay(DateTime.Minutes(4), BringPatrol2)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(7), BringPatrol2)

--- a/mods/ra/maps/soviet-04a/soviet04a.lua
+++ b/mods/ra/maps/soviet-04a/soviet04a.lua
@@ -83,7 +83,7 @@ RunInitialActivities = function()
 	Trigger.AfterDelay(DateTime.Minutes(1), ProduceInfantry)
 	Trigger.AfterDelay(DateTime.Minutes(2), ProduceArmor)
 
-	if Map.Difficulty == "Hard" or Map.Difficulty == "Medium" then
+	if Map.LobbyOption("difficulty") == "hard" or Map.LobbyOption("difficulty") == "normal" then
 		Trigger.AfterDelay(DateTime.Seconds(15), ReinfInf)
 	end
 	Trigger.AfterDelay(DateTime.Minutes(1), ReinfInf)
@@ -108,9 +108,9 @@ Tick = function()
 
 	if RCheck then
 		RCheck = false
-		if Map.Difficulty == "Hard" then
+		if Map.LobbyOption("difficulty") == "hard" then
 			Trigger.AfterDelay(DateTime.Seconds(150), ReinfArmor)
-		elseif Map.Difficulty == "Medium" then
+		elseif Map.LobbyOption("difficulty") == "normal" then
 			Trigger.AfterDelay(DateTime.Minutes(5), ReinfArmor)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(8), ReinfArmor)

--- a/mods/ra/maps/soviet-04b/rules.yaml
+++ b/mods/ra/maps/soviet-04b/rules.yaml
@@ -13,7 +13,14 @@ World:
 		LossVideo: allymorf.vqa
 	MapOptions:
 		TechLevel: Medium
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 AFLD:
 	ParatroopersPower@paratroopers:

--- a/mods/ra/maps/soviet-04b/soviet04b-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b-reinforcements_teams.lua
@@ -17,7 +17,7 @@ Patrol2Path = { EntranceSouthPoint.Location, ToRadarBridgePoint.Location, Island
 
 VillageCamArea = { CPos.New(37, 58),CPos.New(37, 59),CPos.New(37, 60),CPos.New(38, 60),CPos.New(39, 60), CPos.New(40, 60), CPos.New(41, 60), CPos.New(35, 57), CPos.New(34, 57), CPos.New(33, 57), CPos.New(32, 57) }
 
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	ArmorReinfGreece = { "jeep", "1tnk", "1tnk" }
 else
 	ArmorReinfGreece = { "jeep", "jeep", "1tnk", "1tnk", "1tnk" }
@@ -60,7 +60,7 @@ BringPatrol1 = function()
 	end)
 
 	Trigger.OnAllKilled(units, function()
-		if Map.Difficulty == "Hard" then
+		if Map.LobbyOption("difficulty") == "hard" then
 			Trigger.AfterDelay(DateTime.Minutes(4), BringPatrol1)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(7), BringPatrol1)
@@ -79,7 +79,7 @@ BringPatrol2 = function()
 	end)
 
 	Trigger.OnAllKilled(units, function()
-		if Map.Difficulty == "Hard" then
+		if Map.LobbyOption("difficulty") == "hard" then
 			Trigger.AfterDelay(DateTime.Minutes(4), BringPatrol2)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(7), BringPatrol2)

--- a/mods/ra/maps/soviet-04b/soviet04b.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b.lua
@@ -68,7 +68,7 @@ RunInitialActivities = function()
 	Trigger.AfterDelay(DateTime.Minutes(1), ProduceInfantry)
 	Trigger.AfterDelay(DateTime.Minutes(2), ProduceArmor)
 
-	if Map.Difficulty == "Hard" or Map.Difficulty == "Medium" then
+	if Map.LobbyOption("difficulty") == "hard" or Map.LobbyOption("difficulty") == "medium" then
 		Trigger.AfterDelay(DateTime.Seconds(5), ReinfInf)
 	end
 	Trigger.AfterDelay(DateTime.Minutes(1), ReinfInf)
@@ -93,9 +93,9 @@ Tick = function()
 
 	if RCheck then
 		RCheck = false
-		if Map.Difficulty == "Hard" then
+		if Map.LobbyOption("difficulty") == "hard" then
 			Trigger.AfterDelay(DateTime.Seconds(150), ReinfArmor)
-		elseif Map.Difficulty == "Medium" then
+		elseif Map.LobbyOption("difficulty") == "medium" then
 			Trigger.AfterDelay(DateTime.Minutes(5), ReinfArmor)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(8), ReinfArmor)

--- a/mods/ra/maps/soviet-05/rules.yaml
+++ b/mods/ra/maps/soviet-05/rules.yaml
@@ -13,7 +13,14 @@ World:
 		LossVideo: sovbatl.vqa
 	MapOptions:
 		TechLevel: Medium
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 AFLD:
 	ParatroopersPower@paratroopers:

--- a/mods/ra/maps/soviet-05/soviet05-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-05/soviet05-reinforcements_teams.lua
@@ -3,7 +3,7 @@ SovietStartToBasePath = { StartPoint.Location, SovietBasePoint.Location }
 SovietMCVReinf = { "mcv", "3tnk", "3tnk", "e1", "e1" }
 SovExpansionPointGuard = { "2tnk", "2tnk", "e3", "e3", "e3" }
 
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	ArmorReinfGreece = { "jeep", "1tnk", "1tnk" }
 else
 	ArmorReinfGreece = { "jeep", "jeep", "1tnk", "1tnk", "1tnk" }
@@ -70,11 +70,11 @@ IslandTroops1 = function()
 	end)
 	if not CheckForCYard() then
 		return
-	elseif Map.Difficulty == "Easy" then
+	elseif Map.LobbyOption("difficulty") == "easy" then
 		return
 	else
 		Trigger.OnAllKilled(units, function()
-			if Map.Difficulty == "Hard" then
+			if Map.LobbyOption("difficulty") == "hard" then
 				Trigger.AfterDelay(DateTime.Minutes(3), IslandTroops1)
 			else
 				Trigger.AfterDelay(DateTime.Minutes(5), IslandTroops1)
@@ -92,11 +92,11 @@ IslandTroops2 = function()
 	end)
 	if not CheckForCYard() then
 		return
-	elseif Map.Difficulty == "Easy" then
+	elseif Map.LobbyOption("difficulty") == "easy" then
 		return
 	else
 		Trigger.OnAllKilled(units, function()
-			if Map.Difficulty == "Hard" then
+			if Map.LobbyOption("difficulty") == "hard" then
 				Trigger.AfterDelay(DateTime.Minutes(3), IslandTroops2)
 			else
 				Trigger.AfterDelay(DateTime.Minutes(5), IslandTroops2)
@@ -114,11 +114,11 @@ IslandTroops3 = function()
 	end)
 	if not CheckForCYard() then
 		return
-	elseif Map.Difficulty == "Easy" then
+	elseif Map.LobbyOption("difficulty") == "easy" then
 		return
 	else
 		Trigger.OnAllKilled(units, function()
-			if Map.Difficulty == "Hard" then
+			if Map.LobbyOption("difficulty") == "hard" then
 				Trigger.AfterDelay(DateTime.Minutes(3), IslandTroops3)
 			else
 				Trigger.AfterDelay(DateTime.Minutes(5), IslandTroops3)
@@ -138,7 +138,7 @@ BringDDPatrol1 = function()
 		return
 	else
 		Trigger.OnAllKilled(units, function()
-			if Map.Difficulty == "Hard" then
+			if Map.LobbyOption("difficulty") == "hard" then
 				Trigger.AfterDelay(DateTime.Minutes(4), BringDDPatrol1)
 			else
 				Trigger.AfterDelay(DateTime.Minutes(7), BringDDPatrol1)
@@ -158,7 +158,7 @@ BringDDPatrol2 = function()
 		return
 	else
 		Trigger.OnAllKilled(units, function()
-			if Map.Difficulty == "Hard" then
+			if Map.LobbyOption("difficulty") == "hard" then
 				Trigger.AfterDelay(DateTime.Minutes(4), BringDDPatrol2)
 			else
 				Trigger.AfterDelay(DateTime.Minutes(7), BringDDPatrol2)

--- a/mods/ra/maps/soviet-05/soviet05.lua
+++ b/mods/ra/maps/soviet-05/soviet05.lua
@@ -19,7 +19,7 @@ CheckForSPen = function()
 end
 
 RunInitialActivities = function()
-	if Map.Difficulty == "Hard" then
+	if Map.LobbyOption("difficulty") == "hard" then
 		Expand()
 		ExpansionCheck = true
 	else
@@ -57,7 +57,7 @@ RunInitialActivities = function()
 	ProduceInfantry()
 	Trigger.AfterDelay(DateTime.Minutes(2), ProduceShips)
 
-	if Map.Difficulty == "Hard" or Map.Difficulty == "Medium" then
+	if Map.LobbyOption("difficulty") == "hard" or Map.LobbyOption("difficulty") == "medium" then
 		Trigger.AfterDelay(DateTime.Seconds(25), ReinfInf)
 	end
 	Trigger.AfterDelay(DateTime.Minutes(2), ReinfInf)
@@ -170,9 +170,9 @@ Tick = function()
 
 	if not RCheck then
 		RCheck = true
-		if Map.Difficulty == "Easy" and ReinfCheck then
+		if Map.LobbyOption("difficulty") == "easy" and ReinfCheck then
 			Trigger.AfterDelay(DateTime.Minutes(6), ReinfArmor)
-		elseif Map.Difficulty == "Medium" then
+		elseif Map.LobbyOption("difficulty") == "medium" then
 			Trigger.AfterDelay(DateTime.Minutes(4), ReinfArmor)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(3), ReinfArmor)

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -12,7 +12,14 @@ World:
 		WinVideo: sitduck.vqa
 		LossVideo: dpthchrg.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 APWR:
 	Buildable:

--- a/mods/ra/maps/soviet-06a/soviet06a-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-06a/soviet06a-reinforcements_teams.lua
@@ -1,20 +1,20 @@
 EnemyReinforcements =
 {
-	Easy =
+	easy =
 	{
 		{ "e1", "e1", "e3" },
 		{ "e1", "e3", "jeep" },
 		{ "e1", "jeep", "1tnk" }
 	},
 
-	Normal =
+	normal =
 	{
 		{ "e1", "e1", "e3", "e3" },
 		{ "e1", "e3", "jeep", "jeep" },
 		{ "e1", "jeep", "1tnk", "2tnk" }
 	},
 
-	Hard =
+	hard =
 	{
 		{ "e1", "e1", "e3", "e3", "e1" },
 		{ "e1", "e3", "jeep", "jeep", "1tnk" },
@@ -24,9 +24,9 @@ EnemyReinforcements =
 
 EnemyAttackDelay =
 {
-	Easy = DateTime.Minutes(5),
-	Normal = DateTime.Minutes(2) + DateTime.Seconds(40),
-	Hard = DateTime.Minutes(1) + DateTime.Seconds(30)
+	easy = DateTime.Minutes(5),
+	normal = DateTime.Minutes(2) + DateTime.Seconds(40),
+	hard = DateTime.Minutes(1) + DateTime.Seconds(30)
 }
 
 EnemyPaths =
@@ -37,7 +37,7 @@ EnemyPaths =
 
 wave = 0
 SendEnemies = function()
-	Trigger.AfterDelay(EnemyAttackDelay[Map.Difficulty], function()
+	Trigger.AfterDelay(EnemyAttackDelay[Map.LobbyOption("difficulty")], function()
 
 		wave = wave + 1
 		if wave > 3 then
@@ -45,10 +45,10 @@ SendEnemies = function()
 		end
 
 		if wave == 1 then
-			local units = Reinforcements.ReinforceWithTransport(enemy, "tran", EnemyReinforcements[Map.Difficulty][wave], EnemyPaths[1], { EnemyPaths[1][1] })[2]
+			local units = Reinforcements.ReinforceWithTransport(enemy, "tran", EnemyReinforcements[Map.LobbyOption("difficulty")][wave], EnemyPaths[1], { EnemyPaths[1][1] })[2]
 			Utils.Do(units, IdleHunt)
 		else
-			local units = Reinforcements.ReinforceWithTransport(enemy, "lst", EnemyReinforcements[Map.Difficulty][wave], EnemyPaths[2], { EnemyPaths[2][1] })[2]
+			local units = Reinforcements.ReinforceWithTransport(enemy, "lst", EnemyReinforcements[Map.LobbyOption("difficulty")][wave], EnemyPaths[2], { EnemyPaths[2][1] })[2]
 			Utils.Do(units, IdleHunt)
 		end
 

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -12,7 +12,14 @@ World:
 		WinVideo: sitduck.vqa
 		LossVideo: dpthchrg.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 APWR:
 	Buildable:

--- a/mods/ra/maps/soviet-06b/soviet06b-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-06b/soviet06b-reinforcements_teams.lua
@@ -1,20 +1,20 @@
 EnemyReinforcements =
 {
-	Easy =
+	easy =
 	{
 		{ "e1", "e1", "e3" },
 		{ "e1", "e3", "jeep" },
 		{ "e1", "jeep", "1tnk" }
 	},
 
-	Normal =
+	normal =
 	{
 		{ "e1", "e1", "e3", "e3" },
 		{ "e1", "e3", "jeep", "jeep" },
 		{ "e1", "jeep", "1tnk", "2tnk" }
 	},
 
-	Hard =
+	hard =
 	{
 		{ "e1", "e1", "e3", "e3", "e1" },
 		{ "e1", "e3", "jeep", "jeep", "1tnk" },
@@ -24,9 +24,9 @@ EnemyReinforcements =
 
 EnemyAttackDelay =
 {
-	Easy = DateTime.Minutes(5),
-	Normal = DateTime.Minutes(2) + DateTime.Seconds(40),
-	Hard = DateTime.Minutes(1) + DateTime.Seconds(30)
+	easy = DateTime.Minutes(5),
+	normal = DateTime.Minutes(2) + DateTime.Seconds(40),
+	hard = DateTime.Minutes(1) + DateTime.Seconds(30)
 }
 
 EnemyPaths =
@@ -37,7 +37,7 @@ EnemyPaths =
 
 wave = 0
 SendEnemies = function()
-	Trigger.AfterDelay(EnemyAttackDelay[Map.Difficulty], function()
+	Trigger.AfterDelay(EnemyAttackDelay[Map.LobbyOption("difficulty")], function()
 
 		wave = wave + 1
 		if wave > 3 then
@@ -45,10 +45,10 @@ SendEnemies = function()
 		end
 
 		if wave == 1 then
-			local units = Reinforcements.ReinforceWithTransport(enemy, "tran", EnemyReinforcements[Map.Difficulty][wave], EnemyPaths[1], { EnemyPaths[1][1] })[2]
+			local units = Reinforcements.ReinforceWithTransport(enemy, "tran", EnemyReinforcements[Map.LobbyOption("difficulty")][wave], EnemyPaths[1], { EnemyPaths[1][1] })[2]
 			Utils.Do(units, IdleHunt)
 		else
-			local units = Reinforcements.ReinforceWithTransport(enemy, "lst", EnemyReinforcements[Map.Difficulty][wave], EnemyPaths[2], { EnemyPaths[2][1] })[2]
+			local units = Reinforcements.ReinforceWithTransport(enemy, "lst", EnemyReinforcements[Map.LobbyOption("difficulty")][wave], EnemyPaths[2], { EnemyPaths[2][1] })[2]
 			Utils.Do(units, IdleHunt)
 		end
 

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -8,7 +8,14 @@ World:
 		WinVideo: averted.vqa
 		LossVideo: nukestok.vqa
 	MapOptions:
-		Difficulties: Easy, Normal, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			normal: Normal
+			hard: Hard
+		Default: easy
 
 ^Infantry:
 	-GivesBounty:

--- a/mods/ra/maps/soviet-07/soviet07.lua
+++ b/mods/ra/maps/soviet-07/soviet07.lua
@@ -1,8 +1,8 @@
-if Map.Difficulty == "Easy" then
+if Map.LobbyOption("difficulty") == "easy" then
 	remainingTime = DateTime.Minutes(7)
-elseif Map.Difficulty == "Normal" then
+elseif Map.LobbyOption("difficulty") == "normal" then
 	remainingTime = DateTime.Minutes(6)
-elseif Map.Difficulty == "Hard" then
+elseif Map.LobbyOption("difficulty") == "hard" then
 	remainingTime = DateTime.Minutes(5)
 end
 
@@ -299,7 +299,7 @@ Tick = function()
 		enemy.MarkCompletedObjective(alliedObjective)
 	end
 
-	if remainingTime == DateTime.Minutes(5) and Map.Difficulty ~= "Hard" then
+	if remainingTime == DateTime.Minutes(5) and Map.LobbyOption("difficulty") ~= "hard" then
 		Media.PlaySpeechNotification(player, "WarningFiveMinutesRemaining")
 	elseif remainingTime == DateTime.Minutes(4) then
 		Media.PlaySpeechNotification(player, "WarningFourMinutesRemaining")

--- a/mods/ra/maps/survival01/rules.yaml
+++ b/mods/ra/maps/survival01/rules.yaml
@@ -8,7 +8,14 @@ World:
 	MissionData:
 		Briefing: LANDCOM 66 HQS.\nTOP SECRET.\nTO: FIELD COMMANDER A34\n\nTHE SOVIETS STARTED HEAVY ATTACKS AT OUR POSITION.\n SURVIVE AND HOLD THE BASE UNTIL OUR FRENCH ALLIES ARRIVE.\n\nCONFIRMATION CODE 5593.\n\nTRANSMISSION ENDS.
 	MapOptions:
-		Difficulties: Easy, Medium, Hard
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			easy: Easy
+			medium: Medium
+			hard: Hard
+		Default: easy
 
 powerproxy.paratroopers:
 	ParatroopersPower:

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -1,6 +1,6 @@
-Difficulty = Map.Difficulty
+Difficulty = Map.LobbyOption("difficulty")
 
-if Difficulty == "Easy" then
+if Difficulty == "easy" then
 	AttackAtFrameIncrement = DateTime.Seconds(22)
 	AttackAtFrameIncrementInf = DateTime.Seconds(16)
 	TimerTicks = DateTime.Minutes(15)
@@ -8,7 +8,7 @@ if Difficulty == "Easy" then
 	DamageModifier = 0.5
 	LongBowReinforcements = { "heli", "heli" }
 	ParadropArtillery = true
-elseif Difficulty == "Medium" then
+elseif Difficulty == "medium" then
 	AttackAtFrameIncrement = DateTime.Seconds(18)
 	AttackAtFrameIncrementInf = DateTime.Seconds(12)
 	TimerTicks = DateTime.Minutes(20)
@@ -16,7 +16,7 @@ elseif Difficulty == "Medium" then
 	MoreParas = true
 	DamageModifier = 0.75
 	LongBowReinforcements = { "heli", "heli" }
-else --Difficulty == "Hard"
+else --Difficulty == "hard"
 	AttackAtFrameIncrement = DateTime.Seconds(14)
 	AttackAtFrameIncrementInf = DateTime.Seconds(8)
 	TimerTicks = DateTime.Minutes(25)

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -10,10 +10,6 @@ Player:
 	PlayerResources:
 		DefaultCashLocked: True
 		DefaultCash: 0
-	MapOptions:
-		TechLevelLocked: True
-		ShortGameLocked: True
-		ShortGameEnabled: False
 
 World:
 	-CrateSpawner:
@@ -25,6 +21,7 @@ World:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
 	MapOptions:
+		TechLevelLocked: True
 		ShortGameLocked: True
 		ShortGameEnabled: False
 


### PR DESCRIPTION
This introduces a new `ScriptLobbyDropdown` trait that, in the future (along with a `ScriptLobbyCheckbox`) will let mappers define arbitrary lobby options that can be queried from lua.

This new trait duplicates exactly the behaviour that we want from the map difficulty selector, so that is now reimplemented using this trait.

This gets us another step closer to unhardcoding the lobby options UI.
