### PR TITLE
Disable single-player games by default on dedicated servers

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -196,7 +196,7 @@ namespace OpenRA.Network
 			public string GameSpeedType = "default";
 			public bool AllowVersionMismatch;
 			public string GameUid;
-			public bool DisableSingleplayer;
+			public bool EnableSingleplayer;
 
 			[FieldLoader.Ignore]
 			public Dictionary<string, LobbyOptionState> LobbyOptions = new Dictionary<string, LobbyOptionState>();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Server
 					RandomSeed = randomSeed,
 					Map = settings.Map,
 					ServerName = settings.Name,
-					DisableSingleplayer = settings.DisableSinglePlayer,
+					EnableSingleplayer = settings.EnableSingleplayer || !dedicated,
 				}
 			};
 
@@ -394,8 +394,8 @@ namespace OpenRA.Server
 				if (!LobbyInfo.IsSinglePlayer && Map.DefinesUnsafeCustomRules)
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
-				if (Settings.DisableSinglePlayer)
-					SendOrderTo(newConn, "Message", "Singleplayer games have been disabled on this server.");
+				if (!LobbyInfo.GlobalSettings.EnableSingleplayer)
+					SendOrderTo(newConn, "Message", "This server requires at least two human players to start a match.");
 				else if (Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 					SendOrderTo(newConn, "Message", "Bots have been disabled on this map.");
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -76,8 +76,8 @@ namespace OpenRA
 		[Desc("Value in milliseconds when to terminate the game. Needs to be at least 10000 (10 s) to enable the timer.")]
 		public int TimeOut = 0;
 
-		[Desc("Disallow games where only one player plays with bots.")]
-		public bool DisableSinglePlayer = false;
+		[Desc("For dedicated servers only, controls whether a game can be started with just one human player in the lobby.")]
+		public bool EnableSingleplayer = false;
 
 		[Desc("Query map information from the Resource Center if they are not available locally.")]
 		public bool QueryMapRepository = true;

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Server
 				return;
 
 			// Does server have only one player?
-			if (server.Settings.DisableSinglePlayer && playerClients.Count() == 1)
+			if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer && playerClients.Count() == 1)
 				return;
 
 			server.StartGame();
@@ -122,10 +122,10 @@ namespace OpenRA.Mods.Common.Server
 							return true;
 						}
 
-						if (server.Settings.DisableSinglePlayer &&
+						if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer &&
 							server.LobbyInfo.Clients.Where(c => c.Bot == null && c.Slot != null).Count() == 1)
 						{
-							server.SendOrderTo(conn, "Message", "Unable to start the game until another player joins.");
+							server.SendOrderTo(conn, "Message", "This server requires at least two human players to start match.");
 							return true;
 						}
 
@@ -401,8 +401,8 @@ namespace OpenRA.Mods.Common.Server
 							if (server.Map.DefinesUnsafeCustomRules)
 								server.SendMessage("This map contains custom rules. Game experience may change.");
 
-							if (server.Settings.DisableSinglePlayer)
-								server.SendMessage("Singleplayer games have been disabled on this server.");
+							if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer)
+								server.SendMessage("This server requires at least two human players to start match.");
 							else if (server.Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 								server.SendMessage("Bots have been disabled on this map.");
 						};

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -317,7 +317,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				startGameButton.IsDisabled = () => configurationDisabled() || Map.Status != MapStatus.Available ||
 					orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
-					(orderManager.LobbyInfo.GlobalSettings.DisableSingleplayer && orderManager.LobbyInfo.IsSinglePlayer);
+					(!orderManager.LobbyInfo.GlobalSettings.EnableSingleplayer && orderManager.LobbyInfo.IsSinglePlayer);
 
 				startGameButton.OnClick = () =>
 				{

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -8,11 +8,11 @@ set ListenPort=1234
 set ExternalPort=1234
 set AdvertiseOnline=True
 set AllowPortForward=False
-set DisableSinglePlayer=True
+set EnableSingleplayer=False
 set Password=""
 
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.AllowPortForward=%AllowPortForward% Server.DisableSinglePlayer=%DisableSinglePlayer% Server.Password=%Password%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.AllowPortForward=%AllowPortForward% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -12,12 +12,12 @@ ListenPort="${ListenPort:-"1234"}"
 ExternalPort="${ExternalPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
 AllowPortForward="${AllowPortForward:-"False"}"
-DisableSinglePlayer="${DisableSinglePlayer:-"True"}"
+EnableSingleplayer="${EnableSingleplayer:-"False"}"
 Password="${Password:-""}"
 
 while true; do
      mono --debug OpenRA.Server.exe Game.Mod=$Mod \
      Server.Name="$Name" Server.ListenPort=$ListenPort Server.ExternalPort=$ExternalPort \
      Server.AdvertiseOnline=$AdvertiseOnline Server.AllowPortForward=$AllowPortForward \
-     Server.DisableSinglePlayer=$DisableSinglePlayer Server.Password=$Password
+     Server.EnableSingleplayer=$EnableSingleplayer Server.Password=$Password
 done


### PR DESCRIPTION
Rationale: it's stupid to allow single players to hog someone else's server by themselves by default. This change would force them to use the single-player lobby instead.
