### PR TITLE
Prompt FMV installation when trying to play a missing video.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						};
 					}
 
-					ConfirmationDialogs.PromptConfirmAction(
+					ConfirmationDialogs.ButtonPrompt(
 						title: "Leave Mission",
 						text: "Leave this game and return to the menu?",
 						onConfirm: onQuit,
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			exitEditorButton.OnClick = () =>
 			{
 				hideMenu = true;
-				ConfirmationDialogs.PromptConfirmAction(
+				ConfirmationDialogs.ButtonPrompt(
 					title: "Exit Map Editor",
 					text: "Exit and lose all unsaved changes?",
 					onConfirm: onQuit,
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			surrenderButton.OnClick = () =>
 			{
 				hideMenu = true;
-				ConfirmationDialogs.PromptConfirmAction(
+				ConfirmationDialogs.ButtonPrompt(
 					title: "Surrender",
 					text: "Are you sure you want to surrender?",
 					onConfirm: onSurrender,

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -328,7 +328,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void DeleteOneMap(string map, Action<string> after)
 		{
-			ConfirmationDialogs.PromptConfirmAction(
+			ConfirmationDialogs.ButtonPrompt(
 				title: "Delete map",
 				text: "Delete the map '{0}'?".F(modData.MapCache[map].Title),
 				onConfirm: () =>
@@ -343,7 +343,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void DeleteAllMaps(string[] maps, Action<string> after)
 		{
-			ConfirmationDialogs.PromptConfirmAction(
+			ConfirmationDialogs.ButtonPrompt(
 				title: "Delete maps",
 				text: "Delete all maps on this page?",
 				onConfirm: () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -409,7 +409,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			Action<ReplayMetadata, Action> onDeleteReplay = (r, after) =>
 			{
-				ConfirmationDialogs.PromptConfirmAction(
+				ConfirmationDialogs.ButtonPrompt(
 					title: "Delete selected replay?",
 					text: "Delete replay '{0}'?".F(Path.GetFileNameWithoutExtension(r.FilePath)),
 					onConfirm: () =>
@@ -450,7 +450,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						return;
 					}
 
-					ConfirmationDialogs.PromptConfirmAction(
+					ConfirmationDialogs.ButtonPrompt(
 						title: "Delete all selected replays?",
 						text: "Delete {0} replays?".F(list.Count),
 						onConfirm: () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var error = "It was recorded with an " + type;
 			error += string.IsNullOrEmpty(name) ? "." : ":\n{0}".F(name);
 
-			ConfirmationDialogs.CancelPrompt("Incompatible Replay", error, onCancel);
+			ConfirmationDialogs.ButtonPrompt("Incompatible Replay", error, onCancel: onCancel);
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -128,14 +128,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (System.Net.Sockets.SocketException e)
 			{
-				var err_msg = "Could not listen on port {0}.".F(Game.Settings.Server.ListenPort);
+				var message = "Could not listen on port {0}.".F(Game.Settings.Server.ListenPort);
 				if (e.ErrorCode == 10048) { // AddressAlreadyInUse (WSAEADDRINUSE)
-					err_msg += "\n\nCheck if the port is already being used.";
+					message += "\nCheck if the port is already being used.";
 				} else {
-					err_msg += "\n\nError is: \"{0}\" ({1})".F(e.Message, e.ErrorCode);
+					message += "\nError is: \"{0}\" ({1})".F(e.Message, e.ErrorCode);
 				}
 
-				ConfirmationDialogs.CancelPrompt("Server Creation Failed", err_msg, cancelText: "OK");
+				ConfirmationDialogs.ButtonPrompt("Server Creation Failed", message, onCancel: () => { }, cancelText: "Back");
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					OriginalGraphicsRenderer != current.Graphics.Renderer ||
 					OriginalGraphicsWindowedSize != current.Graphics.WindowedSize ||
 					OriginalGraphicsFullscreenSize != current.Graphics.FullscreenSize)
-					ConfirmationDialogs.PromptConfirmAction(
+					ConfirmationDialogs.ButtonPrompt(
 						title: "Restart Now?",
 						text: "Some changes will not be applied until\nthe game is restarted. Restart now?",
 						onConfirm: Game.Restart,

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -133,11 +133,12 @@ ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 					Width: PARENT_RIGHT
 					Height: 25
 
-Container@CONFIRM_PROMPT_THREEBUTTON:
+Background@THREEBUTTON_PROMPT:
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - 90)/2
 	Width: 500
-	Height: 125
+	Height: 41
+	Background: panel-black
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
@@ -145,44 +146,42 @@ Container@CONFIRM_PROMPT_THREEBUTTON:
 			Font: BigBold
 			Contrast: true
 			Align: Center
-		Background@bg:
-			Width: 500
-			Height: 90
-			Background: panel-black
-			Children:
-				Label@PROMPT_TEXT:
-					Y: (PARENT_BOTTOM-HEIGHT)/2
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
+		Label@PROMPT_TEXT:
+			Y: 20
+			Width: PARENT_RIGHT
+			Height: 20
+			Font: Bold
+			Align: Center
 		Button@CONFIRM_BUTTON:
 			Key: return
 			X: 360
-			Y: 89
+			Y: 40
 			Width: 140
 			Height: 35
 			Text: Confirm
+			Visible: false
 		Button@OTHER_BUTTON:
 			Key: r
 			X: 210
-			Y: 89
+			Y: 40
 			Width: 140
 			Height: 35
 			Text: Restart
+			Visible: false
 		Button@CANCEL_BUTTON:
 			Key: escape
-			Y: 89
+			Y: 40
 			Width: 140
 			Height: 35
 			Text: Cancel
+			Visible: false
 
-
-Container@CONFIRM_PROMPT_TWOBUTTON:
+Background@TWOBUTTON_PROMPT:
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - 90)/2
 	Width: 370
-	Height: 125
+	Height: 31
+	Background: panel-black
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
@@ -190,60 +189,27 @@ Container@CONFIRM_PROMPT_TWOBUTTON:
 			Font: BigBold
 			Contrast: true
 			Align: Center
-		Background@bg:
-			Width: 370
-			Height: 90
-			Background: panel-black
-			Children:
-				Label@PROMPT_TEXT:
-					Y: (PARENT_BOTTOM-HEIGHT)/2
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
+		Label@PROMPT_TEXT:
+			Y: 15
+			Width: PARENT_RIGHT
+			Height: 20
+			Font: Bold
+			Align: Center
 		Button@CANCEL_BUTTON:
 			Key: escape
-			Y: 89
+			Y: 30
 			Width: 140
 			Height: 35
 			Text: Cancel
+			Visible: false
 		Button@CONFIRM_BUTTON:
 			Key: return
 			X: 230
-			Y: 89
+			Y: 30
 			Width: 140
 			Height: 35
 			Text: Confirm
-
-Container@CANCEL_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH)/2
-	Y: (WINDOW_BOTTOM - 90)/2
-	Width: 370
-	Height: 125
-	Children:
-		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
-			Y: 0-25
-			Font: BigBold
-			Contrast: true
-			Align: Center
-		Background@bg:
-			Width: 370
-			Height: 90
-			Background: panel-black
-			Children:
-				Label@PROMPT_TEXT:
-					Y: (PARENT_BOTTOM-HEIGHT)/2
-					Width: PARENT_RIGHT
-					Height: 25
-					Font: Bold
-					Align: Center
-		Button@CANCEL_BUTTON:
-			Key: escape
-			Y: 89
-			Width: 140
-			Height: 35
-			Text: Cancel
+			Visible: false
 
 Container@TEXT_INPUT_PROMPT:
 	X: (WINDOW_RIGHT - WIDTH)/2

--- a/mods/ra/chrome/confirmation-dialogs.yaml
+++ b/mods/ra/chrome/confirmation-dialogs.yaml
@@ -1,8 +1,8 @@
-Background@CONFIRM_PROMPT_THREEBUTTON:
+Background@THREEBUTTON_PROMPT:
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - 90)/2
 	Width: 600
-	Height: 175
+	Height: 110
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
@@ -14,7 +14,7 @@ Background@CONFIRM_PROMPT_THREEBUTTON:
 			X: 15
 			Y: 50
 			Width: PARENT_RIGHT - 30
-			Height: 65
+			Height: 20
 			Align: Center
 		Button@CONFIRM_BUTTON:
 			X: 20
@@ -24,6 +24,7 @@ Background@CONFIRM_PROMPT_THREEBUTTON:
 			Text: Confirm
 			Font: Bold
 			Key: return
+			Visible: false
 		Button@OTHER_BUTTON:
 			X: PARENT_RIGHT - 380
 			Y: PARENT_BOTTOM - 45
@@ -31,6 +32,7 @@ Background@CONFIRM_PROMPT_THREEBUTTON:
 			Height: 25
 			Text: Restart
 			Font: Bold
+			Visible: false
 		Button@CANCEL_BUTTON:
 			X: PARENT_RIGHT - 180
 			Y: PARENT_BOTTOM - 45
@@ -39,12 +41,13 @@ Background@CONFIRM_PROMPT_THREEBUTTON:
 			Text: Cancel
 			Font: Bold
 			Key: escape
+			Visible: false
 
-Background@CONFIRM_PROMPT_TWOBUTTON:
+Background@TWOBUTTON_PROMPT:
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - 90)/2
 	Width: 370
-	Height: 175
+	Height: 110
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
@@ -56,7 +59,7 @@ Background@CONFIRM_PROMPT_TWOBUTTON:
 			X: 15
 			Y: 50
 			Width: PARENT_RIGHT - 30
-			Height: 65
+			Height: 20
 			Align: Center
 		Button@CONFIRM_BUTTON:
 			X: 20
@@ -66,6 +69,7 @@ Background@CONFIRM_PROMPT_TWOBUTTON:
 			Text: Confirm
 			Font: Bold
 			Key: return
+			Visible: false
 		Button@CANCEL_BUTTON:
 			X: PARENT_RIGHT - 180
 			Y: PARENT_BOTTOM - 45
@@ -74,33 +78,7 @@ Background@CONFIRM_PROMPT_TWOBUTTON:
 			Text: Cancel
 			Font: Bold
 			Key: escape
-
-Background@CANCEL_PROMPT:
-	X: (WINDOW_RIGHT - WIDTH)/2
-	Y: (WINDOW_BOTTOM - 90)/2
-	Width: 370
-	Height: 175
-	Children:
-		Label@PROMPT_TITLE:
-			Width: PARENT_RIGHT
-			Y: 20
-			Height: 25
-			Font: Bold
-			Align: Center
-		Label@PROMPT_TEXT:
-			X: 15
-			Y: 50
-			Width: PARENT_RIGHT - 30
-			Height: 65
-			Align: Center
-		Button@CANCEL_BUTTON:
-			X: PARENT_RIGHT/2 - WIDTH/2
-			Y: PARENT_BOTTOM - 45
-			Width: 160
-			Height: 25
-			Text: Cancel
-			Font: Bold
-			Key: escape
+			Visible: false
 
 Background@TEXT_INPUT_PROMPT:
 	X: (WINDOW_RIGHT - WIDTH)/2


### PR DESCRIPTION
This adds multi-line support and reduces duplication in our dialog prompts, and then uses this to display an information dialog when trying to play a video that isn't installed.
