### PR TITLE
Extract installer data using direct stream-stream copies

### DIFF
--- a/OpenRA.Game/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Game/FileSystem/InstallShieldPackage.cs
@@ -114,9 +114,12 @@ namespace OpenRA.FileSystem
 				return null;
 
 			s.Seek(dataStart + e.Offset, SeekOrigin.Begin);
-			var data = s.ReadBytes((int)e.Length);
 
-			return new MemoryStream(Blast.Decompress(data));
+			var ret = new MemoryStream();
+			Blast.Decompress(s, ret);
+			ret.Seek(0, SeekOrigin.Begin);
+
+			return ret;
 		}
 
 		public bool Contains(string filename)

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -304,12 +304,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
 					using (var target = File.OpenWrite(targetPath))
 					{
-						// This is a bit dumb memory-wise, but we load the whole thing when running the game anyway
 						Log.Write("install", "Extracting {0} -> {1}".F(sourcePath, targetPath));
-
 						var displayFilename = Path.GetFileName(Path.GetFileName(targetPath));
 						Action<int> onProgress = percent => updateMessage("Extracting {0} ({1}%)".F(displayFilename, percent));
-						target.Write(reader.ExtractFile(node.Value.Value, onProgress));
+						reader.ExtractFile(node.Value.Value, target, onProgress);
 					}
 				}
 			}


### PR DESCRIPTION
The old implementation would read all the data into a memory buffer and then dump that buffer to disk as two separate options.  This is bad for the UI (no way to measure progress) and for memory (because we need to load entire files into memory – potentially twice).

This removes the intermediate memory buffers and adds (XX%) indicators to the installation progress UI.
