### PR TITLE
Improve AI MCV deployment

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -825,8 +825,7 @@ namespace OpenRA.Mods.Common.AI
 
 			foreach (var mcv in mcvs)
 			{
-				var mover = mcv.TraitOrDefault<IMove>();
-				if (mover != null && mover.IsMoving)
+				if (!mcv.IsIdle)
 					continue;
 
 				var factType = mcv.Info.TraitInfo<TransformsInfo>().IntoActor;

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -125,6 +125,9 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Radius in cells around the center of the base to expand.")]
 		public readonly int MaxBaseRadius = 20;
 
+		[Desc("Should deployment of additional MCVs be restricted to MaxBaseRadius if explicit deploy locations are missing or occupied?")]
+		public readonly bool RestrictMCVDeploymentFallbackToBase = true;
+
 		[Desc("Radius in cells around each building with ProvideBuildableArea",
 			"to check for a 3x3 area of water where naval structures can be built.",
 			"Should match maximum adjacency of naval structures.")]
@@ -817,7 +820,7 @@ namespace OpenRA.Mods.Common.AI
 		}
 
 		// Find any newly constructed MCVs and deploy them at a sensible
-		// backup location within the main base.
+		// backup location.
 		void FindAndDeployBackupMcv(Actor self)
 		{
 			var mcvs = self.World.Actors.Where(a => a.Owner == Player &&
@@ -829,7 +832,7 @@ namespace OpenRA.Mods.Common.AI
 					continue;
 
 				var factType = mcv.Info.TraitInfo<TransformsInfo>().IntoActor;
-				var desiredLocation = ChooseBuildLocation(factType, true, BuildingType.Building);
+				var desiredLocation = ChooseBuildLocation(factType, Info.RestrictMCVDeploymentFallbackToBase, BuildingType.Building);
 				if (desiredLocation == null)
 					continue;
 

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -829,7 +829,7 @@ namespace OpenRA.Mods.Common.AI
 					continue;
 
 				var factType = mcv.Info.TraitInfo<TransformsInfo>().IntoActor;
-				var desiredLocation = ChooseBuildLocation(factType, false, BuildingType.Building);
+				var desiredLocation = ChooseBuildLocation(factType, true, BuildingType.Building);
 				if (desiredLocation == null)
 					continue;
 


### PR DESCRIPTION
While #11308 has merit of its own, it doesn't really solve #11305.

Instead, I took a closer look at the AI MCV deployment code. This PR fixes the two more problematic out of three issues I could find:
- The first is that the AI was spamming orders even to MCVs that were already on the move.
- The second is that the AI often chose locations near the enemy base, usually resulting in the MCV's destruction before it's even deployed.

The third is that `ChooseBuildLocation` works rather poorly in practice, sometimes choosing locations where some obstacle doesn't allow deployment, but fixing that will be harder and is therefore left for some other time.

The commits should be descriptive enough, so I won't repeat the details here.
