### PR TITLE
Do not remove empty entries in MiniYaml.FromString

### DIFF
--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -254,7 +254,7 @@ namespace OpenRA
 
 		public static List<MiniYamlNode> FromString(string text, string fileName = "<no filename available>")
 		{
-			return FromLines(text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries), fileName);
+			return FromLines(text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None), fileName);
 		}
 
 		public static List<MiniYamlNode> Merge(IEnumerable<List<MiniYamlNode>> sources)

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -154,5 +154,20 @@ Test:
 			Assert.IsFalse(result.First(n => n.Key == "MockString").Value.Nodes.Any(n => n.Key == "AString"),
 				"MockString value should have been removed, but was not.");
 		}
+
+		[TestCase(TestName = "Empty lines should count toward line numbers")]
+		public void EmptyLinesShouldCountTowardLineNumbers()
+		{
+			var yaml = @"
+TestA:
+	Nothing:
+
+TestB:
+	Nothing:
+";
+
+			var result = MiniYaml.FromString(yaml).First(n => n.Key == "TestB");
+			Assert.AreEqual(5, result.Location.Line);
+		}
 	}
 }


### PR DESCRIPTION
This will fix cases of incorrect line numbers being reported.

http://logs.openra.net/?year=2016&month=06&day=17#15:34:02

> [15:34:02]  [Phrohdoh] Oh, duh. Empty lines are stripped before the IEnumerable<string> is passed to FromLines, so that is why my line numbers are off.
> [15:34:29]  [Phrohdoh] Outside of not removing those, that isn't fixable.
> [15:34:40]  [pchote] is this in your code, or ours?
> [15:34:43]  [Phrohdoh] upstream
> [15:34:53]  [Phrohdoh] return FromLines(text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries), fileName);
> [15:35:00]  [Phrohdoh] MiniYaml:257
> [15:35:01]  [pchote] lets not do that, then
> [15:35:17]  [pchote] discard them at parse time, incrementing the line counter to mathc
> [15:35:19]  [pchote] *match
> [15:35:23]  [Phrohdoh] ok 
