### PR TITLE
Fix Mobile.IsMovingInMyDirection check.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -179,18 +179,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		static bool IsMovingInMyDirection(Actor self, Actor other)
 		{
-			var selfMobile = self.TraitOrDefault<Mobile>();
-			if (selfMobile == null)
-				return false;
-
 			var otherMobile = other.TraitOrDefault<Mobile>();
 			if (otherMobile == null || !otherMobile.IsMoving)
 				return false;
 
-			// Sign of dot-product indicates (roughly) if vectors are facing in same or opposite directions:
-			var dp = CVec.Dot(selfMobile.ToCell - self.Location, otherMobile.ToCell - other.Location);
+			var selfMobile = self.TraitOrDefault<Mobile>();
+			if (selfMobile == null)
+				return false;
 
-			return dp > 0;
+			// Moving in the same direction if the facing delta is between +/- 90 degrees
+			var delta = Util.NormalizeFacing(otherMobile.Facing - selfMobile.Facing);
+			return delta < 64 || delta > 192;
 		}
 
 		public int TileSetMovementHash(TileSet tileSet)


### PR DESCRIPTION
The old code would always return false (because `selfMobile.ToCell == self.Location` by definition), so check has effectively been a no-op for years.

My tests indicate a huge improvement to unit behavior across bridges as long as you issue move orders far enough past the bridge that you are outside the 8-cell `nearEnough` radius that will cause units to give up and stop on/in front of the bridge.
