### PR TITLE
Disable hide map crate if explored map is enabled.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -77,6 +77,7 @@ namespace OpenRA.Traits
 
 		bool fogEnabled;
 		public bool FogEnabled { get { return !Disabled && fogEnabled; } }
+		public bool ExploreMapEnabled { get; private set; }
 
 		public int Hash { get; private set; }
 
@@ -96,8 +97,8 @@ namespace OpenRA.Traits
 			var gs = self.World.LobbyInfo.GlobalSettings;
 			fogEnabled = gs.OptionOrDefault("fog", info.FogEnabled);
 
-			var exploreMap = gs.OptionOrDefault("explored", info.ExploredMapEnabled);
-			if (exploreMap)
+			ExploreMapEnabled = gs.OptionOrDefault("explored", info.ExploredMapEnabled);
+			if (ExploreMapEnabled)
 				self.World.AddFrameEndTask(w => ExploreAll());
 		}
 

--- a/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
@@ -32,8 +32,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override int GetSelectionShares(Actor collector)
 		{
-			// Don't ever hide the map for people who have GPS.
-			if (collector.Owner.HasFogVisibility)
+			// Don't hide the map if the shroud is force-revealed
+			if (collector.Owner.HasFogVisibility || collector.Owner.Shroud.ExploreMapEnabled)
 				return 0;
 
 			return base.GetSelectionShares(collector);


### PR DESCRIPTION
Suggested by lucassss in http://www.sleipnirstuff.com/forum/viewtopic.php?t=19622.

While it could certainly be argued that the hide map penalty remains valid, I think it is reasonable to treat the player's choice to explore the map as a request to disable the shroud completely.  This is also consistent with our original disabled-shroud behavior.
