### PR TITLE
Add foundation for player experience tracking

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Scripting\Properties\MissionObjectiveProperties.cs" />
     <Compile Include="Scripting\Properties\MobileProperties.cs" />
     <Compile Include="Scripting\Properties\DemolitionProperties.cs" />
+    <Compile Include="Scripting\Properties\PlayerExperienceProperties.cs" />
     <Compile Include="Scripting\Properties\PlayerProperties.cs" />
     <Compile Include="Scripting\Properties\PlayerStatsProperties.cs" />
     <Compile Include="Scripting\Properties\PowerProperties.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -388,6 +388,7 @@
     <Compile Include="Traits\Player\MissionObjectives.cs" />
     <Compile Include="Traits\Player\PlaceBeacon.cs" />
     <Compile Include="Traits\Player\PlaceBuilding.cs" />
+    <Compile Include="Traits\Player\PlayerExperience.cs" />
     <Compile Include="Traits\Player\PlayerStatistics.cs" />
     <Compile Include="Traits\Player\ProductionQueue.cs" />
     <Compile Include="Traits\Player\ProvidesPrerequisite.cs" />

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
@@ -1,0 +1,43 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using Eluant;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Scripting;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[ScriptPropertyGroup("Player")]
+	public class PlayerExperienceProperties : ScriptPlayerProperties, Requires<PlayerExperienceInfo>
+	{
+		readonly PlayerExperience exp;
+
+		public PlayerExperienceProperties(ScriptContext context, Player player)
+			: base(context, player)
+		{
+			exp = player.PlayerActor.Trait<PlayerExperience>();
+		}
+
+		public int Experience
+		{
+			get
+			{
+				return exp.Experience;
+			}
+
+			set
+			{
+				exp.GiveExperience(value - exp.Experience);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("This trait can be used to track player experience based on units killed with the `GivesExperience` trait.",
+		"It can also be used as a point score system in scripted maps, for example.",
+		"Attach this to the player actor.")]
+	public class PlayerExperienceInfo : ITraitInfo
+	{
+		public object Create(ActorInitializer init) { return new PlayerExperience(); }
+	}
+
+	public class PlayerExperience : ISync
+	{
+		[Sync] public int Experience { get; private set; }
+
+		public void GiveExperience(int num)
+		{
+			Experience += num;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class PlayerStatistics : ITick, IResolveOrder, INotifyCreated
 	{
 		PlayerResources resources;
+		PlayerExperience experience;
 
 		public int OrderCount;
 
@@ -31,6 +32,14 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				return resources != null ? resources.Earned - earnedAtBeginningOfMinute : 0;
+			}
+		}
+
+		public int Experience
+		{
+			get
+			{
+				return experience != null ? experience.Experience : 0;
 			}
 		}
 
@@ -51,6 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			resources = self.TraitOrDefault<PlayerResources>();
+			experience = self.TraitOrDefault<PlayerExperience>();
 		}
 
 		void UpdateEarnedThisMinute()


### PR DESCRIPTION
Adds a `PlayerExperience` trait, first and foremost. The experience is added to by killing units with the `GivesExperience` trait. That behaviour can be removed by setting the `GivesExperienceInfo.PlayerExperienceModifier` to 0 (the default). The trait can otherwise be used to simply track a score, for example in Lua scripts.

The original PR enabled the feature in the existing mods, both in the rules and the UI. I'm not sure if we should actually do that. I added the rules changes as a test case, and split off the UI changes into a separate commit so that they can be easily removed, if we decide that way.

Supersedes #10358.

//cc: @Phoib 
