### PR TITLE
Remove spurious space in TS' mod.yaml

### DIFF
--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -1,4 +1,4 @@
- Metadata:
+Metadata:
 	Title: Tiberian Sun
 	Description: Developer stub, not yet ready for release!
 	Version: {DEV_VERSION}


### PR DESCRIPTION
Introduced in 27699ce3d732ff448a15dde771c5aab5c38542b3 for seemingly no reason.

As far as I am aware we shouldn't be parsing this properly, but apparently we are.
