### PR TITLE
Improve WithShadow

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -21,6 +21,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		[PaletteReference] public readonly string Palette = "shadow";
 
+		[Desc("Shadow position offset relative to actor position (ground level).")]
+		public readonly WVec Offset = WVec.Zero;
+
+		[Desc("Shadow Z offset relative to actor sprite.")]
+		public readonly int ZOffset = -5;
+
 		public override object Create(ActorInitializer init) { return new WithShadow(this); }
 	}
 
@@ -46,8 +52,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var height = self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length;
 			var shadowSprites = r.Where(s => !s.IsDecoration)
 				.Select(a => a.WithPalette(wr.Palette(info.Palette))
-					.OffsetBy(new WVec(0, 0, -height))
-					.WithZOffset(a.ZOffset + height)
+					.OffsetBy(info.Offset - new WVec(0, 0, height))
+					.WithZOffset(a.ZOffset + (height + info.ZOffset))
 					.AsDecoration());
 
 			return shadowSprites.Concat(r);

--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -16,25 +16,32 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	[Desc("Clones the aircraft sprite with another palette below it.")]
-	class WithShadowInfo : ITraitInfo
+	[Desc("Clones the actor sprite with another palette below it.")]
+	public class WithShadowInfo : UpgradableTraitInfo
 	{
 		[PaletteReference] public readonly string Palette = "shadow";
 
-		public object Create(ActorInitializer init) { return new WithShadow(this); }
+		public override object Create(ActorInitializer init) { return new WithShadow(this); }
 	}
 
-	class WithShadow : IRenderModifier
+	public class WithShadow : UpgradableTrait<WithShadowInfo>, IRenderModifier
 	{
-		WithShadowInfo info;
+		readonly WithShadowInfo info;
 
 		public WithShadow(WithShadowInfo info)
+			: base(info)
 		{
 			this.info = info;
 		}
 
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
+			if (IsTraitDisabled)
+				return Enumerable.Empty<IRenderable>();
+
+			if (self.IsDead || !self.IsInWorld)
+				return Enumerable.Empty<IRenderable>();
+
 			// Contrails shouldn't cast shadows
 			var height = self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length;
 			var shadowSprites = r.Where(s => !s.IsDecoration)

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -153,6 +153,8 @@
 		GenericName: Helicopter
 	WithFacingSpriteBody:
 	WithShadow:
+		Offset: 43, 128, 0
+		ZOffset: -129
 	Hovers@CRUISING:
 		UpgradeTypes: cruising
 		UpgradeMinEnabledLevel: 1
@@ -427,6 +429,8 @@
 	ActorLostNotification:
 	AttackMove:
 	WithShadow:
+		Offset: 43, 128, 0
+		ZOffset: -129
 	WithFacingSpriteBody:
 	FlyAwayOnIdle:
 	RejectsOrders:
@@ -746,6 +750,8 @@
 ^HelicopterHusk:
 	Inherits: ^CommonHuskDefaults
 	WithShadow:
+		Offset: 43, 128, 0
+		ZOffset: -129
 	Aircraft:
 		AirborneUpgrades: airborne
 		CanHover: True

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -386,6 +386,8 @@
 	Tooltip:
 		GenericName: Plane
 	WithShadow:
+		Offset: 43, 128, 0
+		ZOffset: -129
 	WithFacingSpriteBody:
 	MustBeDestroyed:
 	Voiced:
@@ -690,6 +692,8 @@
 ^PlaneHusk:
 	Inherits: ^BasicHusk
 	WithShadow:
+		Offset: 43, 128, 0
+		ZOffset: -129
 	Tooltip:
 		GenericName: Destroyed Plane
 	Aircraft:
@@ -703,6 +707,8 @@
 ^HelicopterHusk:
 	Inherits: ^BasicHusk
 	WithShadow:
+		Offset: 43, 128, 0
+		ZOffset: -129
 	Tooltip:
 		GenericName: Destroyed Helicopter
 	Aircraft:


### PR DESCRIPTION
Makes the trait public, upgradable and the offset customizable.

Uses the customizable offset to tweak shadow position of TD and RA aircraft, which looks a little better especially for landed aircraft (they no longer completely hide the shadow).
