### PR TITLE
Fix blank video heuristic for legacy map import to include upper-case 'X'

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var videos = new List<MiniYamlNode>();
 			foreach (var s in file.GetSection(section))
 			{
-				if (s.Value != "x" && s.Value != "<none>")
+				if (s.Value != "x" && s.Value != "X" && s.Value != "<none>")
 				{
 					switch (s.Key)
 					{


### PR DESCRIPTION
Fixes #11472.

There are actually seven instances of an upper-case X being used (vs. 66 lower-case ones).
