### PR TITLE
Improve Rectangle HitShape customizability

### DIFF
--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -30,6 +30,11 @@ namespace OpenRA
 			return actors.MinByOrDefault(a => (a.CenterPosition - pos).LengthSquared);
 		}
 
+		public static WPos PositionClosestTo(this IEnumerable<WPos> positions, WPos pos)
+		{
+			return positions.MinByOrDefault(p => (p - pos).LengthSquared);
+		}
+
 		public static IEnumerable<Actor> FindActorsInCircle(this World world, WPos origin, WDist r)
 		{
 			// Target ranges are calculated in 2D, so ignore height differences

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -33,6 +33,11 @@ namespace OpenRA.Mods.Common.HitShapes
 		[Desc("Defines the bottom offset relative to the actor's target point.")]
 		public readonly int VerticalBottomOffset = 0;
 
+		// This is just a temporary work-around until we have a customizable PolygonShape
+		[Desc("Rotates shape by 90 degree relative to actor facing. Mostly required for buildings on isometric terrain.",
+			"Mobile actors do NOT need this!")]
+		public readonly bool RotateToIsometry = false;
+
 		int2 quadrantSize;
 		int2 center;
 
@@ -89,22 +94,26 @@ namespace OpenRA.Mods.Common.HitShapes
 		public WDist DistanceFromEdge(WPos pos, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var orientation = new WRot(actor.Orientation.Roll, actor.Orientation.Pitch,
+				new WAngle(actor.Orientation.Yaw.Angle + (RotateToIsometry ? 128 : 0)));
 
 			if (pos.Z > actorPos.Z + VerticalTopOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-actor.Orientation));
+				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
 
 			if (pos.Z < actorPos.Z + VerticalBottomOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalBottomOffset))).Rotate(-actor.Orientation));
+				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalBottomOffset))).Rotate(-orientation));
 
-			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-actor.Orientation));
+			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-orientation));
 		}
 
 		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
+			var orientation = new WRot(actor.Orientation.Roll, actor.Orientation.Pitch,
+				new WAngle(actor.Orientation.Yaw.Angle + (RotateToIsometry ? 128 : 0)));
 
-			var vertsTop = combatOverlayVertsTop.Select(v => wr.ScreenPosition(actorPos + v.Rotate(actor.Orientation)));
-			var vertsBottom = combatOverlayVertsBottom.Select(v => wr.ScreenPosition(actorPos + v.Rotate(actor.Orientation)));
+			var vertsTop = combatOverlayVertsTop.Select(v => wr.ScreenPosition(actorPos + v.Rotate(orientation)));
+			var vertsBottom = combatOverlayVertsBottom.Select(v => wr.ScreenPosition(actorPos + v.Rotate(orientation)));
 			wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
 			wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
 		}

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -218,8 +218,10 @@
 	ScriptTriggers:
 	UpgradeManager:
 	Health:
-		Shape: Circle
-			Radius: 363
+		Shape: Rectangle
+			RotateToIsometry: true
+			TopLeft: -384, -384
+			BottomRight: 384, 384
 			VerticalTopOffset: 512
 
 ^BuildingPlug:


### PR DESCRIPTION
As temporary solution until someone adds a more customizable PolygonShape, I've added support for 
- applying the shape to all `TargetablePositions` (effectively implementing footprint shapes)
- rotating the shape by 90 degree (necessary for isometric perspective)

As example for the rotation, I'm using this to give TS walls an isometric, rectangular hitshape.

If you need a testcase for the functionality of applying the shape to all `TargetablePositions`, you can find that here: https://github.com/reaperrr/OpenRA/tree/hitshape-test
