### PR TITLE
ProvidesPrerequisiteFromAllies

### DIFF
--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -29,7 +29,11 @@ namespace OpenRA.Mods.Common.Lint
 			var techPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ProvidesTechPrerequisiteInfo>())
 				.SelectMany(p => p.Prerequisites);
 
-			var providedPrereqs = customPrereqs.Concat(techPrereqs);
+			// ProvidesPrerequisiteFromAllies allows arbitrary prereq definitions
+			var prereqsFromAllies = rules.Actors.SelectMany(a => a.Value.TraitInfos<ProvidesPrerequisiteFromAlliesInfo>())
+				.Select(p => p.Prerequisite);
+
+			var providedPrereqs = customPrereqs.Concat(techPrereqs).Concat(prereqsFromAllies);
 
 			// TODO: this check is case insensitive while the real check in-game is not
 			foreach (var i in rules.Actors)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -769,6 +769,7 @@
     <Compile Include="Traits\Carryable.cs" />
     <Compile Include="Traits\Carryall.cs" />
     <Compile Include="Traits\Buildings\FreeActorWithDelivery.cs" />
+    <Compile Include="Traits\Player\ProvidesPrerequisiteFromAllies.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisiteFromAllies.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisiteFromAllies.cs
@@ -1,0 +1,71 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Provides a prerequisite based on the factions of allied players, if any.")]
+	public class ProvidesPrerequisiteFromAlliesInfo : ITechTreePrerequisiteInfo
+	{
+		[Desc("The prerequisite type that this provides."), FieldLoader.Require]
+		public readonly string Prerequisite = null;
+
+		[Desc("Only grant this prerequisite when this player is one of certain factions.")]
+		public readonly HashSet<string> Factions = new HashSet<string>();
+
+		[Desc("Only grant this prerequisite when the allied player is one of certain factions."), FieldLoader.Require]
+		public readonly HashSet<string> AlliedFactions = new HashSet<string>();
+
+		public object Create(ActorInitializer init) { return new ProvidesPrerequisiteFromAllies(init, this); }
+	}
+
+	public class ProvidesPrerequisiteFromAllies : ITechTreePrerequisite, INotifyCreated
+	{
+		readonly ProvidesPrerequisiteFromAlliesInfo info;
+		readonly string prerequisite;
+
+		bool enabled;
+
+		public ProvidesPrerequisiteFromAllies(ActorInitializer init, ProvidesPrerequisiteFromAlliesInfo info)
+		{
+			this.info = info;
+			prerequisite = info.Prerequisite;
+		}
+
+		public IEnumerable<string> ProvidesPrerequisites
+		{
+			get
+			{
+				if (!enabled)
+					yield break;
+
+				yield return prerequisite;
+			}
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			self.World.AddFrameEndTask(world =>
+			{
+				if (info.Factions.Count > 0 && !info.Factions.Contains(self.Owner.Faction.InternalName))
+					return;
+
+				enabled = self.World.Players.Any(p =>
+					p != self.Owner
+					&& self.Owner.Stances[p] == Stance.Ally
+					&& info.AlliedFactions.Contains(p.Faction.InternalName));
+			});
+		}
+	}
+}

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -73,6 +73,9 @@ Player:
 		Prerequisites: techlevel.infonly, techlevel.low, techlevel.medium, techlevel.high, techlevel.unrestricted
 		Id: unrestricted
 	GlobalUpgradeManager:
+	ProvidesPrerequisiteFromAllies@ally.england:
+		AlliedFactions: england
+		Prerequisite: ally.england
 	EnemyWatcher:
 	VeteranProductionIconOverlay:
 		Image: iconchevrons

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1416,7 +1416,7 @@ KENN:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 175
-		Prerequisites: anypower, ~structures.soviet, ~techlevel.infonly
+		Prerequisites: ally.england, anypower, ~structures.soviet, ~techlevel.infonly
 	Valued:
 		Cost: 100
 	Tooltip:


### PR DESCRIPTION
Inspired by [0AD](http://www.play0ad.com)'s [planned feature](https://github.com/0ad/0ad/blob/92bb12a56552429476bd6e2955cc6cf53e4cb51c/binaries/data/mods/public/simulation/data/civs/spart.json#L81-L85) (which will go by the name `Peloponnesian League` for their Spartan faction's "team bonus").

This allows providing a prereq to a player based of the faction of allied players.
