### PR TITLE
Move carryall code to Mods.Common.

### DIFF
--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -10,13 +10,10 @@
 #endregion
 
 using OpenRA.Activities;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.D2k.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.D2k.Activities
+namespace OpenRA.Mods.Common.Activities
 {
 	public class DeliverUnit : Activity
 	{

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -10,13 +10,10 @@
 #endregion
 
 using OpenRA.Activities;
-using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.D2k.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.D2k.Activities
+namespace OpenRA.Mods.Common.Activities
 {
 	public class PickupUnit : Activity
 	{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -758,6 +758,11 @@
     <Compile Include="FileFormats\MSCabCompression.cs" />
     <Compile Include="UtilityCommands\OutputActorMiniYamlCommand.cs" />
     <Compile Include="Traits\World\ScriptLobbyDropdown.cs" />
+    <Compile Include="Activities\DeliverUnit.cs" />
+    <Compile Include="Activities\PickupUnit.cs" />
+    <Compile Include="Traits\Carryable.cs" />
+    <Compile Include="Traits\Carryall.cs" />
+    <Compile Include="Traits\Buildings\FreeActorWithDelivery.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
@@ -9,14 +9,11 @@
  */
 #endregion
 
-using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.D2k.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.D2k.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Player receives a unit for free once the building is placed.",
 		"If you want more than one unit to be delivered, copy this section and assign IDs like FreeActorWithDelivery@2, ...")]

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -12,10 +12,9 @@
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.D2k.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Can be carried by units with the trait `Carryall`.")]
 	public class CarryableInfo : ITraitInfo, Requires<UpgradeManagerInfo>

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -13,12 +13,10 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
-using OpenRA.Mods.D2k.Activities;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.D2k.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Automatically transports harvesters with the Carryable trait between resource fields and refineries.")]
 	public class CarryallInfo : ITraitInfo, Requires<BodyOrientationInfo>

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -76,16 +76,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Activities\PickupUnit.cs" />
-    <Compile Include="Activities\DeliverUnit.cs" />
     <Compile Include="Activities\SwallowActor.cs" />
     <Compile Include="SpriteLoaders\R8Loader.cs" />
     <Compile Include="Traits\AttackSwallow.cs" />
-    <Compile Include="Traits\Carryall.cs" />
-    <Compile Include="Traits\Buildings\FreeActorWithDelivery.cs" />
     <Compile Include="Traits\Buildings\DamagedWithoutFoundation.cs" />
     <Compile Include="Traits\Buildings\LaysTerrain.cs" />
-    <Compile Include="Traits\Carryable.cs" />
     <Compile Include="Traits\Player\HarvesterInsurance.cs" />
     <Compile Include="Traits\Render\WithCrumbleOverlay.cs" />
     <Compile Include="Traits\Render\WithDeliveryOverlay.cs" />


### PR DESCRIPTION
In preparation for user-controllable carryalls.  This is done now to improve the readability of the next pr – git otherwise detects those changes as unrelated file deletions and additions.
