### PR TITLE
Improved ProductionParadrop plane targeting

### DIFF
--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -53,9 +53,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Start a fixed distance away: the width of the map.
 			// This makes the production timing independent of spawnpoint
-			var dropPos = self.Location + exit.ExitCell;
-			var startPos = dropPos + new CVec(owner.World.Map.Bounds.Width, 0);
-			var endPos = new CPos(owner.World.Map.Bounds.Left - 5, dropPos.Y);
+			var startPos = self.Location + new CVec(owner.World.Map.Bounds.Width, 0);
+			var endPos = new CPos(owner.World.Map.Bounds.Left - 5, self.Location.Y);
 
 			foreach (var notify in self.TraitsImplementing<INotifyDelivery>())
 				notify.IncomingDelivery(self);
@@ -76,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 					new FacingInit(64)
 				});
 
-				actor.QueueActivity(new Fly(actor, Target.FromCell(w, dropPos)));
+				actor.QueueActivity(new Fly(actor, Target.FromActor(self)));
 				actor.QueueActivity(new CallFunc(() =>
 				{
 					if (!self.IsInWorld || self.IsDead)


### PR DESCRIPTION
Fixes issues with ProductionParadrop by making the producer actor the target instead of it's location when production is finished. This allows it to handle mobile actors far better. Only trading off somewhat questionable logic involving aligning the plane with the exit location.

Fixes the primary issue raised in #11503.

EDIT: As pchote pointed out. The exit really needs to be taken into proper account instead of how it's handled here.
