### PR TITLE
Added Squad Exclusion to HackyAI

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.AI
 		public class UnitCategories
 		{
 			public readonly HashSet<string> Mcv = new HashSet<string>();
+			public readonly HashSet<string> ExcludeFromSquads = new HashSet<string>();
 		}
 
 		public class BuildingCategories
@@ -150,7 +151,7 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("What buildings to the AI should build.", "What % of the total base must be this type of building.")]
 		public readonly Dictionary<string, float> BuildingFractions = null;
 
-		[Desc("Tells the AI what unit types fall under the same common name. Only supported entry is Mcv.")]
+		[Desc("Tells the AI what unit types fall under the same common name. Supported entries are Mcv and ExcludeFromSquads.")]
 		[FieldLoader.LoadUsing("LoadUnitCategories", true)]
 		public readonly UnitCategories UnitsCommonNames;
 
@@ -678,7 +679,8 @@ namespace OpenRA.Mods.Common.AI
 		void FindNewUnits(Actor self)
 		{
 			var newUnits = self.World.ActorsHavingTrait<IPositionable>()
-				.Where(a => a.Owner == Player && !Info.UnitsCommonNames.Mcv.Contains(a.Info.Name) && !activeUnits.Contains(a));
+				.Where(a => a.Owner == Player && !Info.UnitsCommonNames.Mcv.Contains(a.Info.Name) &&
+					!Info.UnitsCommonNames.ExcludeFromSquads.Contains(a.Info.Name) && !activeUnits.Contains(a));
 
 			foreach (var a in newUnits)
 			{


### PR DESCRIPTION
Thanks to GraionDilach for pointing this out to me but HackyAI will exclude MCVs and harvesters from squads but otherwise will add any available units to squads including possibility unarmed utility units like the Manticore faction in my mod, Phoenix Chronicles, has. So I have an AI that will send power-generating unarmed trucks and it's HQ among other base-units into battle. This gives a modder a way to make units with the sole purpose of being around the base. Could be useful for the mobile repair vehicle for Nod in TS.

No test case included, but I did test it before pushing by adding like 90% of the unit roster to the exclusion list. Nothing included appeared to be put into a squad.
