### PR TITLE
Fix Wanders always triggering move at first game tick

### DIFF
--- a/OpenRA.Mods.Common/Traits/Wanders.cs
+++ b/OpenRA.Mods.Common/Traits/Wanders.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			countdown = self.World.SharedRandom.Next(info.MinMoveDelay, info.MaxMoveDelay);
 		}
 
-		public void TickIdle(Actor self)
+		public virtual void TickIdle(Actor self)
 		{
 			// The countdown has not have been set at this point, so don't check yet
 			if (firstTick)

--- a/OpenRA.Mods.Common/Traits/Wanders.cs
+++ b/OpenRA.Mods.Common/Traits/Wanders.cs
@@ -39,6 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		int countdown;
 		int ticksIdle;
 		int effectiveMoveRadius;
+		bool firstTick = true;
 
 		public Wanders(Actor self, WandersInfo info)
 		{
@@ -54,6 +55,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void TickIdle(Actor self)
 		{
+			// The countdown has not have been set at this point, so don't check yet
+			if (firstTick)
+			{
+				firstTick = false;
+				return;
+			}
+
 			if (--countdown > 0)
 				return;
 


### PR DESCRIPTION
Currently, all actors with `AttackWander` or some other `Wanders`-derivative wander at the first tick because `countdown` has not yet been set to a random value when the first `TickIdle` runs.

I added a `firstTick` check so `TickIdle` won't do anything before the 2nd tick, ensuring `countdown` has been set properly by that time.

Additionally made `TickIdle` virtual so traits like `AttackWander` can override it, if necessary.
