### PR TITLE
Avoid importing spawn points with the same location

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Text;
 
@@ -49,6 +51,16 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			result.AppendLine();
 
 			return result.ToString();
+		}
+
+		public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+		{
+			var knownKeys = new HashSet<TKey>();
+			foreach (TSource element in source)
+			{
+				if (knownKeys.Add(keySelector(element)))
+					yield return element;
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -255,8 +255,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				.Select(kv => Pair.New(Exts.ParseIntegerInvariant(kv.Key),
 					LocationFromMapOffset(Exts.ParseIntegerInvariant(kv.Value), MapSize)));
 
-			// Add waypoint actors
-			foreach (var kv in wps)
+			// Add waypoint actors skipping duplicate entries
+			foreach (var kv in wps.DistinctBy(location => location.Second))
 			{
 				if (!singlePlayer && kv.First <= 7)
 				{


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/8115.

You can use http://ra.afraid.org/maps/index.php?size=&theater=&players=&rules=&trigs=&units=&name=stalingrad&author=&sort_by=name&order=asc as a test case which has one duplicated player spawn location.
