### PR TITLE
Support content installation from "C&C The Ultimate Collection" (Origin versions).

### DIFF
--- a/OpenRA.Game/ModContent.cs
+++ b/OpenRA.Game/ModContent.cs
@@ -17,6 +17,7 @@ namespace OpenRA
 {
 	public class ModContent : IGlobalModData
 	{
+		public enum SourceType { Disc, Install }
 		public class ModPackage
 		{
 			public readonly string Title;
@@ -39,6 +40,12 @@ namespace OpenRA
 
 		public class ModSource
 		{
+			public readonly SourceType Type = SourceType.Disc;
+
+			// Used to find installation locations for SourceType.Install
+			public readonly string RegistryKey;
+			public readonly string RegistryValue;
+
 			public readonly string Title;
 			public readonly Dictionary<string, string> IDFiles;
 

--- a/OpenRA.Game/ModContent.cs
+++ b/OpenRA.Game/ModContent.cs
@@ -21,7 +21,7 @@ namespace OpenRA
 		{
 			public readonly string Title;
 			public readonly string[] TestFiles = { };
-			public readonly string[] Discs = { };
+			public readonly string[] Sources = { };
 			public readonly bool Required;
 			public readonly string Download;
 
@@ -37,14 +37,14 @@ namespace OpenRA
 			}
 		}
 
-		public class ModDisc
+		public class ModSource
 		{
 			public readonly string Title;
 			public readonly Dictionary<string, string> IDFiles;
 
 			[FieldLoader.Ignore] public readonly List<MiniYamlNode> Install;
 
-			public ModDisc(MiniYaml yaml)
+			public ModSource(MiniYaml yaml)
 			{
 				Title = yaml.Value;
 				var installNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Install");
@@ -101,18 +101,18 @@ namespace OpenRA
 			return downloads;
 		}
 
-		[FieldLoader.LoadUsing("LoadDiscs")]
-		public readonly Dictionary<string, ModDisc> Discs;
+		[FieldLoader.LoadUsing("LoadSources")]
+		public readonly Dictionary<string, ModSource> Sources;
 
-		static object LoadDiscs(MiniYaml yaml)
+		static object LoadSources(MiniYaml yaml)
 		{
-			var discs = new Dictionary<string, ModDisc>();
-			var discNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Discs");
-			if (discNode != null)
-				foreach (var node in discNode.Value.Nodes)
-					discs.Add(node.Key, new ModDisc(node.Value));
+			var sources = new Dictionary<string, ModSource>();
+			var sourceNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Sources");
+			if (sourceNode != null)
+				foreach (var node in sourceNode.Value.Nodes)
+					sources.Add(node.Key, new ModSource(node.Value));
 
-			return discs;
+			return sources;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -235,7 +235,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							}
 
 							default:
-								Game.Debug("debug", "Unknown installation command {0} - ignoring", i.Key);
+								Log.Write("debug", "Unknown installation command {0} - ignoring", i.Key);
 								break;
 						}
 					}

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					.Where(v => v.DriveType == DriveType.CDRom && v.IsReady)
 					.Select(v => v.RootDirectory.FullName);
 
-				foreach (var kv in content.Discs)
+				foreach (var kv in content.Sources)
 				{
 					message = "Searching for " + kv.Value.Title;
 
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (PathIsDiscMount(volume, kv.Value))
 						{
 							var packages = content.Packages.Values
-								.Where(p => p.Discs.Contains(kv.Key) && !p.IsInstalled())
+								.Where(p => p.Sources.Contains(kv.Key) && !p.IsInstalled())
 								.Select(p => p.Title);
 
 							// Ignore disc if content is already installed
@@ -133,8 +133,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var discTitles = content.Packages.Values
 					.Where(p => !p.IsInstalled())
-					.SelectMany(p => p.Discs)
-					.Select(d => content.Discs[d].Title)
+					.SelectMany(p => p.Sources)
+					.Select(d => content.Sources[d].Title)
 					.Distinct();
 
 				Game.RunAfterTick(() =>
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}).Start();
 		}
 
-		void InstallFromDisc(string path, ModContent.ModDisc disc)
+		void InstallFromDisc(string path, ModContent.ModSource modSource)
 		{
 			var message = "";
 			ShowProgressbar("Installing Content", () => message);
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				try
 				{
-					foreach (var i in disc.Install)
+					foreach (var i in modSource.Install)
 					{
 						switch (i.Key)
 						{
@@ -236,7 +236,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.RunAfterTick(() =>
 					{
 						ShowMessage("Installation Failed", "Refer to install.log in the logs directory for details.");
-						ShowBackRetry(() => InstallFromDisc(path, disc));
+						ShowBackRetry(() => InstallFromDisc(path, modSource));
 					});
 				}
 			}).Start();
@@ -351,11 +351,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		bool PathIsDiscMount(string path, ModContent.ModDisc disc)
+		bool PathIsDiscMount(string path, ModContent.ModSource source)
 		{
 			try
 			{
-				foreach (var kv in disc.IDFiles)
+				foreach (var kv in source.IDFiles)
 				{
 					var filePath = Path.Combine(path, kv.Key);
 					if (!File.Exists(filePath))

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		// List Panel
 		readonly Widget listContainer;
 		readonly ScrollPanelWidget listPanel;
+		readonly Widget listHeaderTemplate;
 		readonly LabelWidget listTemplate;
 		readonly LabelWidget listLabel;
 
@@ -84,6 +85,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			listContainer.IsVisible = () => visible == Mode.List;
 
 			listPanel = listContainer.Get<ScrollPanelWidget>("LIST_PANEL");
+			listHeaderTemplate = listPanel.Get("LIST_HEADER_TEMPLATE");
 			listTemplate = listPanel.Get<LabelWidget>("LIST_TEMPLATE");
 			listPanel.RemoveChildren();
 
@@ -108,38 +110,55 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					message = "Searching for " + kv.Value.Title;
 
-					foreach (var volume in volumes)
+					var path = FindSourcePath(kv.Value, volumes);
+					if (path != null)
 					{
-						if (PathIsDiscMount(volume, kv.Value))
+						var packages = content.Packages.Values
+							.Where(p => p.Sources.Contains(kv.Key) && !p.IsInstalled())
+							.Select(p => p.Title);
+
+						// Ignore disc if content is already installed
+						if (packages.Any())
 						{
-							var packages = content.Packages.Values
-								.Where(p => p.Sources.Contains(kv.Key) && !p.IsInstalled())
-								.Select(p => p.Title);
-
-							// Ignore disc if content is already installed
-							if (packages.Any())
+							Game.RunAfterTick(() =>
 							{
-								Game.RunAfterTick(() =>
-								{
-									ShowList(kv.Value.Title, "The following content packages will be installed:", packages);
-									ShowContinueCancel(() => InstallFromDisc(volume, kv.Value));
-								});
+								ShowList(kv.Value.Title, "The following content packages will be installed:", packages);
+								ShowContinueCancel(() => InstallFromDisc(path, kv.Value));
+							});
 
-								return;
-							}
+							return;
 						}
 					}
 				}
 
-				var discTitles = content.Packages.Values
+				var sources = content.Packages.Values
 					.Where(p => !p.IsInstalled())
 					.SelectMany(p => p.Sources)
-					.Select(d => content.Sources[d].Title)
+					.Select(d => content.Sources[d]);
+
+				var discs = sources
+					.Where(s => s.Type == ModContent.SourceType.Disc)
+					.Select(s => s.Title)
 					.Distinct();
+
+				var options = new Dictionary<string, IEnumerable<string>>()
+				{
+					{ "Game Discs", discs },
+				};
+
+				if (Platform.CurrentPlatform == PlatformType.Windows)
+				{
+					var installations = sources
+						.Where(s => s.Type == ModContent.SourceType.Install)
+						.Select(s => s.Title)
+						.Distinct();
+
+					options.Add("Digital Installs", installations);
+				}
 
 				Game.RunAfterTick(() =>
 				{
-					ShowList("Disc Content Not Found", "Please insert or mount one of the following discs and try again", discTitles);
+					ShowList("Game Content Not Found", "Please insert or install one of the following content sources:", options);
 					ShowBackRetry(DetectContentDisks);
 				});
 			}).Start();
@@ -351,7 +370,32 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		bool PathIsDiscMount(string path, ModContent.ModSource source)
+		string FindSourcePath(ModContent.ModSource source, IEnumerable<string> volumes)
+		{
+			if (source.Type == ModContent.SourceType.Install)
+			{
+				if (source.RegistryKey == null)
+					return null;
+
+				if (Platform.CurrentPlatform != PlatformType.Windows)
+					return null;
+
+				var path = Microsoft.Win32.Registry.GetValue(source.RegistryKey, source.RegistryValue, null) as string;
+				if (path == null)
+					return null;
+
+				return IsValidSourcePath(path, source) ? path : null;
+			}
+
+			if (source.Type == ModContent.SourceType.Disc)
+				foreach (var volume in volumes)
+					if (IsValidSourcePath(volume, source))
+						return volume;
+
+			return null;
+		}
+
+		bool IsValidSourcePath(string path, ModContent.ModSource source)
 		{
 			try
 			{
@@ -419,6 +463,40 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var labelWidget = (LabelWidget)listTemplate.Clone();
 				labelWidget.GetText = () => item;
 				listPanel.AddChild(labelWidget);
+			}
+
+			primaryButton.Bounds.Y += listContainer.Bounds.Height - panel.Bounds.Height;
+			secondaryButton.Bounds.Y += listContainer.Bounds.Height - panel.Bounds.Height;
+			panel.Bounds.Y -= (listContainer.Bounds.Height - panel.Bounds.Height) / 2;
+			panel.Bounds.Height = listContainer.Bounds.Height;
+		}
+
+		void ShowList(string title, string message, Dictionary<string, IEnumerable<string>> groups)
+		{
+			visible = Mode.List;
+			titleLabel.Text = title;
+			listLabel.Text = message;
+
+			listPanel.RemoveChildren();
+
+			foreach (var kv in groups)
+			{
+				if (kv.Value.Any())
+				{
+					var groupTitle = kv.Key;
+					var headerWidget = listHeaderTemplate.Clone();
+					var headerTitleWidget = headerWidget.Get<LabelWidget>("LABEL");
+					headerTitleWidget.GetText = () => groupTitle;
+					listPanel.AddChild(headerWidget);
+				}
+
+				foreach (var i in kv.Value)
+				{
+					var item = i;
+					var labelWidget = (LabelWidget)listTemplate.Clone();
+					labelWidget.GetText = () => item;
+					listPanel.AddChild(labelWidget);
+				}
 			}
 
 			primaryButton.Bounds.Y += listContainer.Bounds.Height - panel.Bounds.Height;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -86,12 +86,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var requiredWidget = container.Get<LabelWidget>("REQUIRED");
 				requiredWidget.IsVisible = () => p.Value.Required;
 
-				var discWidget = container.Get<ImageWidget>("DISC");
-				var discs = p.Value.Discs.Select(s => content.Discs[s].Title).Distinct();
-				var discList = discs.JoinWith("\n");
-				var isDiscAvailable = discs.Any();
-				discWidget.GetTooltipText = () => discList;
-				discWidget.IsVisible = () => isDiscAvailable;
+				var sourceWidget = container.Get<ImageWidget>("DISC");
+				var sources = p.Value.Sources.Select(s => content.Sources[s].Title).Distinct();
+				var sourceList = sources.JoinWith("\n");
+				var isSourceAvailable = sources.Any();
+				sourceWidget.GetTooltipText = () => sourceList;
+				sourceWidget.IsVisible = () => isSourceAvailable;
 
 				var installed = p.Value.IsInstalled();
 				var downloadButton = container.Get<ButtonWidget>("DOWNLOAD");
@@ -115,13 +115,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var requiresDiscWidget = container.Get<LabelWidget>("REQUIRES_DISC");
 				requiresDiscWidget.IsVisible = () => !installed && !downloadEnabled;
-				if (!isDiscAvailable)
+				if (!isSourceAvailable)
 					requiresDiscWidget.GetText = () => "Manual Install";
 
 				scrollPanel.AddChild(container);
 			}
 
-			discAvailable = content.Packages.Values.Any(p => p.Discs.Any() && !p.IsInstalled());
+			discAvailable = content.Packages.Values.Any(p => p.Sources.Any() && !p.IsInstalled());
 		}
 	}
 }

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -228,22 +228,22 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/cnc/conquer.mix, ^Content/cnc/desert.mix, ^Content/cnc/sounds.mix, ^Content/cnc/speech.mix, ^Content/cnc/temperat.mix, ^Content/cnc/tempicnh.mix, ^Content/cnc/winter.mix
-			Discs: gdi95, gdi95-linux, nod95, nod95-linux
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/cnc/scores.mix
-			Discs: gdi95, gdi95-linux, nod95, nod95-linux
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux
 			Download: music
 		movies-gdi: GDI Campaign Briefings
 			TestFiles: ^Content/cnc/movies-gdi.mix
-			Discs: gdi95, gdi95-linux
+			Sources: gdi95, gdi95-linux
 		movies-nod: Nod Campaign Briefings
 			TestFiles: ^Content/cnc/movies-nod.mix
-			Discs: nod95, nod95-linux
+			Sources: nod95, nod95-linux
 		music-covertops: Covert Operations Music
 			TestFiles: ^Content/cnc/scores-covertops.mix
-			Discs: covertops, covertops-linux
+			Sources: covertops, covertops-linux
 	Downloads:
 		basefiles: Base Freeware Content
 			MirrorList: http://www.openra.net/packages/cnc-mirrors.txt
@@ -261,7 +261,7 @@ ModContent:
 			MirrorList: http://www.openra.net/packages/cnc-music-mirrors.txt
 			Extract:
 				^Content/cnc/scores.mix: scores.mix
-	Discs:
+	Sources:
 		gdi95: C&C Gold (GDI Disc, English)
 			IDFiles:
 				DISK.WAV: 8bef9a6687c0fe0afd57c6561df58fa6e64f145d

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -224,16 +224,16 @@ ColorValidator:
 ModContent:
 	InstallPromptMessage: Tiberian Dawn requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2007 C&C Gold freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.
 	QuickDownload: basefiles
-	HeaderMessage: The original game content may be copied from an original game disc,\nor downloaded from an online mirror of the 2007 freeware release.
+	HeaderMessage: Game content may be extracted from the original game discs or an\nexisting digital install. OpenRA can also download the base game\nfiles from an online mirror of the 2007 freeware release of C&C.
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/cnc/conquer.mix, ^Content/cnc/desert.mix, ^Content/cnc/sounds.mix, ^Content/cnc/speech.mix, ^Content/cnc/temperat.mix, ^Content/cnc/tempicnh.mix, ^Content/cnc/winter.mix
-			Sources: gdi95, gdi95-linux, nod95, nod95-linux
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux, origin
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/cnc/scores.mix
-			Sources: gdi95, gdi95-linux, nod95, nod95-linux
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux, origin
 			Download: music
 		movies-gdi: GDI Campaign Briefings
 			TestFiles: ^Content/cnc/movies-gdi.mix
@@ -243,7 +243,7 @@ ModContent:
 			Sources: nod95, nod95-linux
 		music-covertops: Covert Operations Music
 			TestFiles: ^Content/cnc/scores-covertops.mix
-			Sources: covertops, covertops-linux
+			Sources: covertops, covertops-linux, origin
 	Downloads:
 		basefiles: Base Freeware Content
 			MirrorList: http://www.openra.net/packages/cnc-mirrors.txt
@@ -372,3 +372,23 @@ ModContent:
 			Install:
 				copy: .
 					^Content/cnc/scores-covertops.mix: scores.mix
+		origin: C&C The Ultimate Collection (Origin version, English)
+			Type: Install
+			RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\CNC and The Covert Operations
+			RegistryValue: Install Dir
+			IDFiles:
+				CNC95Launcher.exe: 1d711adf09ac08738b2599b3092a1b448169b32a
+				CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
+			Install:
+				copy: .
+					^Content/cnc/conquer.mix: CONQUER.MIX
+					^Content/cnc/desert.mix: DESERT.MIX
+					^Content/cnc/general.mix: GENERAL.MIX
+					^Content/cnc/scores.mix: SCORES.MIX
+					^Content/cnc/sounds.mix: SOUNDS.MIX
+					^Content/cnc/temperat.mix: TEMPERAT.MIX
+					^Content/cnc/winter.mix: WINTER.MIX
+					^Content/cnc/speech.mix: SPEECH.MIX
+					^Content/cnc/tempicnh.mix: TEMPICNH.MIX
+					^Content/cnc/transit.mix: TRANSIT.MIX
+					^Content/cnc/scores-covertops.mix: covert/SCORES.MIX

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -9,6 +9,7 @@ RequiresMods:
 
 Packages:
 	~^Content/cnc
+	~^Content/cnc/movies
 	.
 	$cnc: cnc
 	./mods/common: common
@@ -19,8 +20,6 @@ Packages:
 	~temperat.mix
 	~winter.mix
 	~desert.mix
-	~movies-gdi.mix
-	~movies-nod.mix
 	~movies.mix
 	~scores.mix
 	~scores2.mix
@@ -236,11 +235,11 @@ ModContent:
 			Sources: gdi95, gdi95-linux, nod95, nod95-linux, origin
 			Download: music
 		movies-gdi: GDI Campaign Briefings
-			TestFiles: ^Content/cnc/movies-gdi.mix
-			Sources: gdi95, gdi95-linux
+			TestFiles: ^Content/cnc/movies/visor.vqa, ^Content/cnc/movies/turtkill.vqa, ^Content/cnc/movies/trailer.vqa, ^Content/cnc/movies/tbrinfo3.vqa, ^Content/cnc/movies/tbrinfo2.vqa, ^Content/cnc/movies/tbrinfo1.vqa, ^Content/cnc/movies/seige.vqa, ^Content/cnc/movies/samsite.vqa, ^Content/cnc/movies/samdie.vqa, ^Content/cnc/movies/sabotage.vqa, ^Content/cnc/movies/retro.vqa, ^Content/cnc/movies/podium.vqa, ^Content/cnc/movies/planecra.vqa, ^Content/cnc/movies/pintle.vqa, ^Content/cnc/movies/paratrop.vqa, ^Content/cnc/movies/nodsweep.vqa, ^Content/cnc/movies/nodlose.vqa, ^Content/cnc/movies/nodflees.vqa, ^Content/cnc/movies/nod1.vqa, ^Content/cnc/movies/nitejump.vqa, ^Content/cnc/movies/napalm.vqa, ^Content/cnc/movies/logo.vqa, ^Content/cnc/movies/landing.vqa, ^Content/cnc/movies/intro2.vqa, ^Content/cnc/movies/hellvaly.vqa, ^Content/cnc/movies/gunboat.vqa, ^Content/cnc/movies/generic.vqa, ^Content/cnc/movies/gdilose.vqa, ^Content/cnc/movies/gdifinb.vqa, ^Content/cnc/movies/gdifina.vqa, ^Content/cnc/movies/gdiend2.vqa, ^Content/cnc/movies/gdiend1.vqa, ^Content/cnc/movies/gdi9.vqa, ^Content/cnc/movies/gdi8b.vqa, ^Content/cnc/movies/gdi8a.vqa, ^Content/cnc/movies/gdi7.vqa, ^Content/cnc/movies/gdi6.vqa, ^Content/cnc/movies/gdi5.vqa, ^Content/cnc/movies/gdi4b.vqa, ^Content/cnc/movies/gdi4a.vqa, ^Content/cnc/movies/gdi3lose.vqa, ^Content/cnc/movies/gdi3.vqa, ^Content/cnc/movies/gdi2.vqa, ^Content/cnc/movies/gdi15.vqa, ^Content/cnc/movies/gdi14.vqa, ^Content/cnc/movies/gdi13.vqa, ^Content/cnc/movies/gdi12.vqa, ^Content/cnc/movies/gdi11.vqa, ^Content/cnc/movies/gdi10.vqa, ^Content/cnc/movies/gdi1.vqa, ^Content/cnc/movies/gameover.vqa, ^Content/cnc/movies/forestkl.vqa, ^Content/cnc/movies/flyy.vqa, ^Content/cnc/movies/flag.vqa, ^Content/cnc/movies/dino.vqa, ^Content/cnc/movies/desolat.vqa, ^Content/cnc/movies/consyard.vqa, ^Content/cnc/movies/cc2tease.vqa, ^Content/cnc/movies/burdet2.vqa, ^Content/cnc/movies/burdet1.vqa, ^Content/cnc/movies/bombflee.vqa, ^Content/cnc/movies/bombaway.vqa, ^Content/cnc/movies/bkground.vqa, ^Content/cnc/movies/bcanyon.vqa, ^Content/cnc/movies/banner.vqa
+			Sources: gdi95, gdi95-linux, origin
 		movies-nod: Nod Campaign Briefings
-			TestFiles: ^Content/cnc/movies-nod.mix
-			Sources: nod95, nod95-linux
+			TestFiles: ^Content/cnc/movies/visor.vqa, ^Content/cnc/movies/trtkil_d.vqa, ^Content/cnc/movies/trailer.vqa, ^Content/cnc/movies/tiberfx.vqa, ^Content/cnc/movies/tankkill.vqa, ^Content/cnc/movies/tankgo.vqa, ^Content/cnc/movies/sundial.vqa, ^Content/cnc/movies/stealth.vqa, ^Content/cnc/movies/spycrash.vqa, ^Content/cnc/movies/sethpre.vqa, ^Content/cnc/movies/seige.vqa, ^Content/cnc/movies/samsite.vqa, ^Content/cnc/movies/retro.vqa, ^Content/cnc/movies/refint.vqa, ^Content/cnc/movies/obel.vqa, ^Content/cnc/movies/nuke.vqa, ^Content/cnc/movies/nodlose.vqa, ^Content/cnc/movies/nodfinal.vqa, ^Content/cnc/movies/nodend4.vqa, ^Content/cnc/movies/nodend3.vqa, ^Content/cnc/movies/nodend2.vqa, ^Content/cnc/movies/nodend1.vqa, ^Content/cnc/movies/nod9.vqa, ^Content/cnc/movies/nod8.vqa, ^Content/cnc/movies/nod7b.vqa, ^Content/cnc/movies/nod7a.vqa, ^Content/cnc/movies/nod6.vqa, ^Content/cnc/movies/nod5.vqa, ^Content/cnc/movies/nod4b.vqa, ^Content/cnc/movies/nod4a.vqa, ^Content/cnc/movies/nod3.vqa, ^Content/cnc/movies/nod2.vqa, ^Content/cnc/movies/nod1pre.vqa, ^Content/cnc/movies/nod13.vqa, ^Content/cnc/movies/nod12.vqa, ^Content/cnc/movies/nod11.vqa, ^Content/cnc/movies/nod10b.vqa, ^Content/cnc/movies/nod10a.vqa, ^Content/cnc/movies/nod1.vqa, ^Content/cnc/movies/logo.vqa, ^Content/cnc/movies/landing.vqa, ^Content/cnc/movies/kanepre.vqa, ^Content/cnc/movies/intro2.vqa, ^Content/cnc/movies/insites.vqa, ^Content/cnc/movies/generic.vqa, ^Content/cnc/movies/gdi1.vqa, ^Content/cnc/movies/gameover.vqa, ^Content/cnc/movies/forestkl.vqa, ^Content/cnc/movies/flag.vqa, ^Content/cnc/movies/dino.vqa, ^Content/cnc/movies/dessweep.vqa, ^Content/cnc/movies/deskill.vqa, ^Content/cnc/movies/desflees.vqa, ^Content/cnc/movies/consyard.vqa, ^Content/cnc/movies/cc2tease.vqa, ^Content/cnc/movies/bombflee.vqa, ^Content/cnc/movies/bombaway.vqa, ^Content/cnc/movies/bcanyon.vqa, ^Content/cnc/movies/banner.vqa, ^Content/cnc/movies/akira.vqa, ^Content/cnc/movies/airstrk.vqa
+			Sources: nod95, nod95-linux, origin
 		music-covertops: Covert Operations Music
 			TestFiles: ^Content/cnc/scores-covertops.mix
 			Sources: covertops, covertops-linux, origin
@@ -275,7 +274,6 @@ ModContent:
 					^Content/cnc/sounds.mix: SOUNDS.MIX
 					^Content/cnc/temperat.mix: TEMPERAT.MIX
 					^Content/cnc/winter.mix: WINTER.MIX
-					^Content/cnc/movies-gdi.mix: MOVIES.MIX
 				extract-blast: INSTALL/SETUP.Z
 					^Content/cnc/speech.mix:
 						Offset: 10203213
@@ -286,6 +284,202 @@ ModContent:
 					^Content/cnc/transit.mix:
 						Offset: 11078017
 						Length: 3724462
+				extract-raw: MOVIES.MIX
+					^Content/cnc/movies/visor.vqa:
+						Offset: 786
+						Length: 4407162
+					^Content/cnc/movies/turtkill.vqa:
+						Offset: 4407948
+						Length: 3323444
+					^Content/cnc/movies/trailer.vqa:
+						Offset: 7731392
+						Length: 23163930
+					^Content/cnc/movies/tbrinfo3.vqa:
+						Offset: 30895322
+						Length: 14972046
+					^Content/cnc/movies/tbrinfo2.vqa:
+						Offset: 45867368
+						Length: 16195290
+					^Content/cnc/movies/tbrinfo1.vqa:
+						Offset: 62062658
+						Length: 23479052
+					^Content/cnc/movies/seige.vqa:
+						Offset: 85541710
+						Length: 2705978
+					^Content/cnc/movies/samsite.vqa:
+						Offset: 88247688
+						Length: 1410418
+					^Content/cnc/movies/samdie.vqa:
+						Offset: 89658106
+						Length: 3741942
+					^Content/cnc/movies/sabotage.vqa:
+						Offset: 93400048
+						Length: 1386202
+					^Content/cnc/movies/retro.vqa:
+						Offset: 94786250
+						Length: 6434382
+					^Content/cnc/movies/podium.vqa:
+						Offset: 101220632
+						Length: 2790664
+					^Content/cnc/movies/planecra.vqa:
+						Offset: 104011296
+						Length: 5085426
+					^Content/cnc/movies/pintle.vqa:
+						Offset: 109096722
+						Length: 2757536
+					^Content/cnc/movies/paratrop.vqa:
+						Offset: 111854258
+						Length: 3180272
+					^Content/cnc/movies/nodsweep.vqa:
+						Offset: 115034530
+						Length: 3642174
+					^Content/cnc/movies/nodlose.vqa:
+						Offset: 118676704
+						Length: 5148924
+					^Content/cnc/movies/nodflees.vqa:
+						Offset: 123825628
+						Length: 3056426
+					^Content/cnc/movies/nod1.vqa:
+						Offset: 126882054
+						Length: 4663258
+					^Content/cnc/movies/nitejump.vqa:
+						Offset: 131545312
+						Length: 3702838
+					^Content/cnc/movies/napalm.vqa:
+						Offset: 135248150
+						Length: 4004146
+					^Content/cnc/movies/logo.vqa:
+						Offset: 139252296
+						Length: 3562630
+					^Content/cnc/movies/landing.vqa:
+						Offset: 142814926
+						Length: 1617094
+					^Content/cnc/movies/intro2.vqa:
+						Offset: 144432020
+						Length: 21058732
+					^Content/cnc/movies/hellvaly.vqa:
+						Offset: 165490752
+						Length: 6658950
+					^Content/cnc/movies/gunboat.vqa:
+						Offset: 172149702
+						Length: 3203706
+					^Content/cnc/movies/generic.vqa:
+						Offset: 175353408
+						Length: 1452820
+					^Content/cnc/movies/gdilose.vqa:
+						Offset: 176806228
+						Length: 2097912
+					^Content/cnc/movies/gdifinb.vqa:
+						Offset: 178904140
+						Length: 17769978
+					^Content/cnc/movies/gdifina.vqa:
+						Offset: 196674118
+						Length: 12888650
+					^Content/cnc/movies/gdiend2.vqa:
+						Offset: 209562768
+						Length: 25242946
+					^Content/cnc/movies/gdiend1.vqa:
+						Offset: 234805714
+						Length: 25311636
+					^Content/cnc/movies/gdi9.vqa:
+						Offset: 260117350
+						Length: 11806994
+					^Content/cnc/movies/gdi8b.vqa:
+						Offset: 271924344
+						Length: 5324410
+					^Content/cnc/movies/gdi8a.vqa:
+						Offset: 277248754
+						Length: 4672548
+					^Content/cnc/movies/gdi7.vqa:
+						Offset: 281921302
+						Length: 4241952
+					^Content/cnc/movies/gdi6.vqa:
+						Offset: 286163254
+						Length: 3959650
+					^Content/cnc/movies/gdi5.vqa:
+						Offset: 290122904
+						Length: 3818244
+					^Content/cnc/movies/gdi4b.vqa:
+						Offset: 293941148
+						Length: 6603530
+					^Content/cnc/movies/gdi4a.vqa:
+						Offset: 300544678
+						Length: 4450582
+					^Content/cnc/movies/gdi3lose.vqa:
+						Offset: 304995260
+						Length: 2265770
+					^Content/cnc/movies/gdi3.vqa:
+						Offset: 307261030
+						Length: 5443848
+					^Content/cnc/movies/gdi2.vqa:
+						Offset: 312704878
+						Length: 7883500
+					^Content/cnc/movies/gdi15.vqa:
+						Offset: 320588378
+						Length: 11684610
+					^Content/cnc/movies/gdi14.vqa:
+						Offset: 332272988
+						Length: 5282770
+					^Content/cnc/movies/gdi13.vqa:
+						Offset: 337555758
+						Length: 6900914
+					^Content/cnc/movies/gdi12.vqa:
+						Offset: 344456672
+						Length: 3669404
+					^Content/cnc/movies/gdi11.vqa:
+						Offset: 348126076
+						Length: 5895754
+					^Content/cnc/movies/gdi10.vqa:
+						Offset: 354021830
+						Length: 5761514
+					^Content/cnc/movies/gdi1.vqa:
+						Offset: 359783344
+						Length: 6341298
+					^Content/cnc/movies/gameover.vqa:
+						Offset: 366124642
+						Length: 2087322
+					^Content/cnc/movies/forestkl.vqa:
+						Offset: 368211964
+						Length: 1500986
+					^Content/cnc/movies/flyy.vqa:
+						Offset: 369712950
+						Length: 1373532
+					^Content/cnc/movies/flag.vqa:
+						Offset: 371086482
+						Length: 4308680
+					^Content/cnc/movies/dino.vqa:
+						Offset: 375395162
+						Length: 1347896
+					^Content/cnc/movies/desolat.vqa:
+						Offset: 376743058
+						Length: 8385122
+					^Content/cnc/movies/consyard.vqa:
+						Offset: 385128180
+						Length: 7864652
+					^Content/cnc/movies/cc2tease.vqa:
+						Offset: 392992832
+						Length: 12506712
+					^Content/cnc/movies/burdet2.vqa:
+						Offset: 405499544
+						Length: 2062190
+					^Content/cnc/movies/burdet1.vqa:
+						Offset: 407561734
+						Length: 10410614
+					^Content/cnc/movies/bombflee.vqa:
+						Offset: 417972348
+						Length: 2859726
+					^Content/cnc/movies/bombaway.vqa:
+						Offset: 420832074
+						Length: 5579588
+					^Content/cnc/movies/bkground.vqa:
+						Offset: 426411662
+						Length: 15267052
+					^Content/cnc/movies/bcanyon.vqa:
+						Offset: 441678714
+						Length: 5172288
+					^Content/cnc/movies/banner.vqa:
+						Offset: 446851002
+						Length: 2229408
 		gdi95-linux: C&C Gold (GDI Disc, English)
 			IDFiles:
 				disk.wav: 8bef9a6687c0fe0afd57c6561df58fa6e64f145d
@@ -299,7 +493,6 @@ ModContent:
 					^Content/cnc/sounds.mix: sounds.mix
 					^Content/cnc/temperat.mix: temperat.mix
 					^Content/cnc/winter.mix: winter.mix
-					^Content/cnc/movies-gdi.mix: movies.mix
 				extract-blast: install/setup.z
 					^Content/cnc/speech.mix:
 						Offset: 10203213
@@ -310,6 +503,202 @@ ModContent:
 					^Content/cnc/transit.mix:
 						Offset: 11078017
 						Length: 3724462
+				extract-raw: movies.mix
+					^Content/cnc/movies/visor.vqa:
+						Offset: 786
+						Length: 4407162
+					^Content/cnc/movies/turtkill.vqa:
+						Offset: 4407948
+						Length: 3323444
+					^Content/cnc/movies/trailer.vqa:
+						Offset: 7731392
+						Length: 23163930
+					^Content/cnc/movies/tbrinfo3.vqa:
+						Offset: 30895322
+						Length: 14972046
+					^Content/cnc/movies/tbrinfo2.vqa:
+						Offset: 45867368
+						Length: 16195290
+					^Content/cnc/movies/tbrinfo1.vqa:
+						Offset: 62062658
+						Length: 23479052
+					^Content/cnc/movies/seige.vqa:
+						Offset: 85541710
+						Length: 2705978
+					^Content/cnc/movies/samsite.vqa:
+						Offset: 88247688
+						Length: 1410418
+					^Content/cnc/movies/samdie.vqa:
+						Offset: 89658106
+						Length: 3741942
+					^Content/cnc/movies/sabotage.vqa:
+						Offset: 93400048
+						Length: 1386202
+					^Content/cnc/movies/retro.vqa:
+						Offset: 94786250
+						Length: 6434382
+					^Content/cnc/movies/podium.vqa:
+						Offset: 101220632
+						Length: 2790664
+					^Content/cnc/movies/planecra.vqa:
+						Offset: 104011296
+						Length: 5085426
+					^Content/cnc/movies/pintle.vqa:
+						Offset: 109096722
+						Length: 2757536
+					^Content/cnc/movies/paratrop.vqa:
+						Offset: 111854258
+						Length: 3180272
+					^Content/cnc/movies/nodsweep.vqa:
+						Offset: 115034530
+						Length: 3642174
+					^Content/cnc/movies/nodlose.vqa:
+						Offset: 118676704
+						Length: 5148924
+					^Content/cnc/movies/nodflees.vqa:
+						Offset: 123825628
+						Length: 3056426
+					^Content/cnc/movies/nod1.vqa:
+						Offset: 126882054
+						Length: 4663258
+					^Content/cnc/movies/nitejump.vqa:
+						Offset: 131545312
+						Length: 3702838
+					^Content/cnc/movies/napalm.vqa:
+						Offset: 135248150
+						Length: 4004146
+					^Content/cnc/movies/logo.vqa:
+						Offset: 139252296
+						Length: 3562630
+					^Content/cnc/movies/landing.vqa:
+						Offset: 142814926
+						Length: 1617094
+					^Content/cnc/movies/intro2.vqa:
+						Offset: 144432020
+						Length: 21058732
+					^Content/cnc/movies/hellvaly.vqa:
+						Offset: 165490752
+						Length: 6658950
+					^Content/cnc/movies/gunboat.vqa:
+						Offset: 172149702
+						Length: 3203706
+					^Content/cnc/movies/generic.vqa:
+						Offset: 175353408
+						Length: 1452820
+					^Content/cnc/movies/gdilose.vqa:
+						Offset: 176806228
+						Length: 2097912
+					^Content/cnc/movies/gdifinb.vqa:
+						Offset: 178904140
+						Length: 17769978
+					^Content/cnc/movies/gdifina.vqa:
+						Offset: 196674118
+						Length: 12888650
+					^Content/cnc/movies/gdiend2.vqa:
+						Offset: 209562768
+						Length: 25242946
+					^Content/cnc/movies/gdiend1.vqa:
+						Offset: 234805714
+						Length: 25311636
+					^Content/cnc/movies/gdi9.vqa:
+						Offset: 260117350
+						Length: 11806994
+					^Content/cnc/movies/gdi8b.vqa:
+						Offset: 271924344
+						Length: 5324410
+					^Content/cnc/movies/gdi8a.vqa:
+						Offset: 277248754
+						Length: 4672548
+					^Content/cnc/movies/gdi7.vqa:
+						Offset: 281921302
+						Length: 4241952
+					^Content/cnc/movies/gdi6.vqa:
+						Offset: 286163254
+						Length: 3959650
+					^Content/cnc/movies/gdi5.vqa:
+						Offset: 290122904
+						Length: 3818244
+					^Content/cnc/movies/gdi4b.vqa:
+						Offset: 293941148
+						Length: 6603530
+					^Content/cnc/movies/gdi4a.vqa:
+						Offset: 300544678
+						Length: 4450582
+					^Content/cnc/movies/gdi3lose.vqa:
+						Offset: 304995260
+						Length: 2265770
+					^Content/cnc/movies/gdi3.vqa:
+						Offset: 307261030
+						Length: 5443848
+					^Content/cnc/movies/gdi2.vqa:
+						Offset: 312704878
+						Length: 7883500
+					^Content/cnc/movies/gdi15.vqa:
+						Offset: 320588378
+						Length: 11684610
+					^Content/cnc/movies/gdi14.vqa:
+						Offset: 332272988
+						Length: 5282770
+					^Content/cnc/movies/gdi13.vqa:
+						Offset: 337555758
+						Length: 6900914
+					^Content/cnc/movies/gdi12.vqa:
+						Offset: 344456672
+						Length: 3669404
+					^Content/cnc/movies/gdi11.vqa:
+						Offset: 348126076
+						Length: 5895754
+					^Content/cnc/movies/gdi10.vqa:
+						Offset: 354021830
+						Length: 5761514
+					^Content/cnc/movies/gdi1.vqa:
+						Offset: 359783344
+						Length: 6341298
+					^Content/cnc/movies/gameover.vqa:
+						Offset: 366124642
+						Length: 2087322
+					^Content/cnc/movies/forestkl.vqa:
+						Offset: 368211964
+						Length: 1500986
+					^Content/cnc/movies/flyy.vqa:
+						Offset: 369712950
+						Length: 1373532
+					^Content/cnc/movies/flag.vqa:
+						Offset: 371086482
+						Length: 4308680
+					^Content/cnc/movies/dino.vqa:
+						Offset: 375395162
+						Length: 1347896
+					^Content/cnc/movies/desolat.vqa:
+						Offset: 376743058
+						Length: 8385122
+					^Content/cnc/movies/consyard.vqa:
+						Offset: 385128180
+						Length: 7864652
+					^Content/cnc/movies/cc2tease.vqa:
+						Offset: 392992832
+						Length: 12506712
+					^Content/cnc/movies/burdet2.vqa:
+						Offset: 405499544
+						Length: 2062190
+					^Content/cnc/movies/burdet1.vqa:
+						Offset: 407561734
+						Length: 10410614
+					^Content/cnc/movies/bombflee.vqa:
+						Offset: 417972348
+						Length: 2859726
+					^Content/cnc/movies/bombaway.vqa:
+						Offset: 420832074
+						Length: 5579588
+					^Content/cnc/movies/bkground.vqa:
+						Offset: 426411662
+						Length: 15267052
+					^Content/cnc/movies/bcanyon.vqa:
+						Offset: 441678714
+						Length: 5172288
+					^Content/cnc/movies/banner.vqa:
+						Offset: 446851002
+						Length: 2229408
 		nod95: C&C Gold (Nod Disc, English)
 			IDFiles:
 				DISK.WAV: 83a0235525afa5cd6096f2967e3eae032996e38c
@@ -323,7 +712,6 @@ ModContent:
 					^Content/cnc/sounds.mix: SOUNDS.MIX
 					^Content/cnc/temperat.mix: TEMPERAT.MIX
 					^Content/cnc/winter.mix: WINTER.MIX
-					^Content/cnc/movies-nod.mix: MOVIES.MIX
 				extract-blast: INSTALL/SETUP.Z
 					^Content/cnc/speech.mix:
 						Offset: 10203213
@@ -334,6 +722,190 @@ ModContent:
 					^Content/cnc/transit.mix:
 						Offset: 11078017
 						Length: 3724462
+				extract-raw: MOVIES.MIX
+					^Content/cnc/movies/visor.vqa:
+						Offset: 738
+						Length: 4407162
+					^Content/cnc/movies/trtkil_d.vqa:
+						Offset: 4407900
+						Length: 3511836
+					^Content/cnc/movies/trailer.vqa:
+						Offset: 7919736
+						Length: 23163930
+					^Content/cnc/movies/tiberfx.vqa:
+						Offset: 31083666
+						Length: 8735102
+					^Content/cnc/movies/tankkill.vqa:
+						Offset: 39818768
+						Length: 3298978
+					^Content/cnc/movies/tankgo.vqa:
+						Offset: 43117746
+						Length: 1403876
+					^Content/cnc/movies/sundial.vqa:
+						Offset: 44521622
+						Length: 3653636
+					^Content/cnc/movies/stealth.vqa:
+						Offset: 48175258
+						Length: 4521860
+					^Content/cnc/movies/spycrash.vqa:
+						Offset: 52697118
+						Length: 1886288
+					^Content/cnc/movies/sethpre.vqa:
+						Offset: 54583406
+						Length: 10914610
+					^Content/cnc/movies/seige.vqa:
+						Offset: 65498016
+						Length: 2705978
+					^Content/cnc/movies/samsite.vqa:
+						Offset: 68203994
+						Length: 1410418
+					^Content/cnc/movies/retro.vqa:
+						Offset: 69614412
+						Length: 6434382
+					^Content/cnc/movies/refint.vqa:
+						Offset: 76048794
+						Length: 5090040
+					^Content/cnc/movies/obel.vqa:
+						Offset: 81138834
+						Length: 3851370
+					^Content/cnc/movies/nuke.vqa:
+						Offset: 84990204
+						Length: 3126662
+					^Content/cnc/movies/nodlose.vqa:
+						Offset: 88116866
+						Length: 5148924
+					^Content/cnc/movies/nodfinal.vqa:
+						Offset: 93265790
+						Length: 23326586
+					^Content/cnc/movies/nodend4.vqa:
+						Offset: 116592376
+						Length: 25535232
+					^Content/cnc/movies/nodend3.vqa:
+						Offset: 142127608
+						Length: 25725824
+					^Content/cnc/movies/nodend2.vqa:
+						Offset: 167853432
+						Length: 27214048
+					^Content/cnc/movies/nodend1.vqa:
+						Offset: 195067480
+						Length: 27172272
+					^Content/cnc/movies/nod9.vqa:
+						Offset: 222239752
+						Length: 9357980
+					^Content/cnc/movies/nod8.vqa:
+						Offset: 231597732
+						Length: 11597940
+					^Content/cnc/movies/nod7b.vqa:
+						Offset: 243195672
+						Length: 4671402
+					^Content/cnc/movies/nod7a.vqa:
+						Offset: 247867074
+						Length: 4740470
+					^Content/cnc/movies/nod6.vqa:
+						Offset: 252607544
+						Length: 5007744
+					^Content/cnc/movies/nod5.vqa:
+						Offset: 257615288
+						Length: 6641700
+					^Content/cnc/movies/nod4b.vqa:
+						Offset: 264256988
+						Length: 3867618
+					^Content/cnc/movies/nod4a.vqa:
+						Offset: 268124606
+						Length: 3838924
+					^Content/cnc/movies/nod3.vqa:
+						Offset: 271963530
+						Length: 3603314
+					^Content/cnc/movies/nod2.vqa:
+						Offset: 275566844
+						Length: 7200720
+					^Content/cnc/movies/nod1pre.vqa:
+						Offset: 282767564
+						Length: 395720
+					^Content/cnc/movies/nod13.vqa:
+						Offset: 283163284
+						Length: 2746626
+					^Content/cnc/movies/nod12.vqa:
+						Offset: 285909910
+						Length: 6576562
+					^Content/cnc/movies/nod11.vqa:
+						Offset: 292486472
+						Length: 4629270
+					^Content/cnc/movies/nod10b.vqa:
+						Offset: 297115742
+						Length: 6386444
+					^Content/cnc/movies/nod10a.vqa:
+						Offset: 303502186
+						Length: 7205632
+					^Content/cnc/movies/nod1.vqa:
+						Offset: 310707818
+						Length: 4663258
+					^Content/cnc/movies/logo.vqa:
+						Offset: 315371076
+						Length: 3562630
+					^Content/cnc/movies/landing.vqa:
+						Offset: 318933706
+						Length: 1617094
+					^Content/cnc/movies/kanepre.vqa:
+						Offset: 320550800
+						Length: 17220712
+					^Content/cnc/movies/intro2.vqa:
+						Offset: 337771512
+						Length: 21058732
+					^Content/cnc/movies/insites.vqa:
+						Offset: 358830244
+						Length: 460482
+					^Content/cnc/movies/generic.vqa:
+						Offset: 359290726
+						Length: 1452820
+					^Content/cnc/movies/gdi1.vqa:
+						Offset: 360743546
+						Length: 6341298
+					^Content/cnc/movies/gameover.vqa:
+						Offset: 367084844
+						Length: 2087322
+					^Content/cnc/movies/forestkl.vqa:
+						Offset: 369172166
+						Length: 1500986
+					^Content/cnc/movies/flag.vqa:
+						Offset: 370673152
+						Length: 4308680
+					^Content/cnc/movies/dino.vqa:
+						Offset: 374981832
+						Length: 1347896
+					^Content/cnc/movies/dessweep.vqa:
+						Offset: 376329728
+						Length: 3563646
+					^Content/cnc/movies/deskill.vqa:
+						Offset: 379893374
+						Length: 1483634
+					^Content/cnc/movies/desflees.vqa:
+						Offset: 381377008
+						Length: 2698426
+					^Content/cnc/movies/consyard.vqa:
+						Offset: 384075434
+						Length: 7864652
+					^Content/cnc/movies/cc2tease.vqa:
+						Offset: 391940086
+						Length: 12506712
+					^Content/cnc/movies/bombflee.vqa:
+						Offset: 404446798
+						Length: 2859726
+					^Content/cnc/movies/bombaway.vqa:
+						Offset: 407306524
+						Length: 5579588
+					^Content/cnc/movies/bcanyon.vqa:
+						Offset: 412886112
+						Length: 5172288
+					^Content/cnc/movies/banner.vqa:
+						Offset: 418058400
+						Length: 2229408
+					^Content/cnc/movies/akira.vqa:
+						Offset: 420287808
+						Length: 7803444
+					^Content/cnc/movies/airstrk.vqa:
+						Offset: 428091252
+						Length: 4444442
 		nod95-linux: C&C Gold (Nod Disc, English)
 			IDFiles:
 				disk.wav: 83a0235525afa5cd6096f2967e3eae032996e38c
@@ -347,7 +919,6 @@ ModContent:
 					^Content/cnc/sounds.mix: sounds.mix
 					^Content/cnc/temperat.mix: temperat.mix
 					^Content/cnc/winter.mix: winter.mix
-					^Content/cnc/movies-nod.mix: movies.mix
 				extract-blast: install/setup.z
 					^Content/cnc/speech.mix:
 						Offset: 10203213
@@ -358,6 +929,190 @@ ModContent:
 					^Content/cnc/transit.mix:
 						Offset: 11078017
 						Length: 3724462
+				extract-raw: movies.mix
+					^Content/cnc/movies/visor.vqa:
+						Offset: 738
+						Length: 4407162
+					^Content/cnc/movies/trtkil_d.vqa:
+						Offset: 4407900
+						Length: 3511836
+					^Content/cnc/movies/trailer.vqa:
+						Offset: 7919736
+						Length: 23163930
+					^Content/cnc/movies/tiberfx.vqa:
+						Offset: 31083666
+						Length: 8735102
+					^Content/cnc/movies/tankkill.vqa:
+						Offset: 39818768
+						Length: 3298978
+					^Content/cnc/movies/tankgo.vqa:
+						Offset: 43117746
+						Length: 1403876
+					^Content/cnc/movies/sundial.vqa:
+						Offset: 44521622
+						Length: 3653636
+					^Content/cnc/movies/stealth.vqa:
+						Offset: 48175258
+						Length: 4521860
+					^Content/cnc/movies/spycrash.vqa:
+						Offset: 52697118
+						Length: 1886288
+					^Content/cnc/movies/sethpre.vqa:
+						Offset: 54583406
+						Length: 10914610
+					^Content/cnc/movies/seige.vqa:
+						Offset: 65498016
+						Length: 2705978
+					^Content/cnc/movies/samsite.vqa:
+						Offset: 68203994
+						Length: 1410418
+					^Content/cnc/movies/retro.vqa:
+						Offset: 69614412
+						Length: 6434382
+					^Content/cnc/movies/refint.vqa:
+						Offset: 76048794
+						Length: 5090040
+					^Content/cnc/movies/obel.vqa:
+						Offset: 81138834
+						Length: 3851370
+					^Content/cnc/movies/nuke.vqa:
+						Offset: 84990204
+						Length: 3126662
+					^Content/cnc/movies/nodlose.vqa:
+						Offset: 88116866
+						Length: 5148924
+					^Content/cnc/movies/nodfinal.vqa:
+						Offset: 93265790
+						Length: 23326586
+					^Content/cnc/movies/nodend4.vqa:
+						Offset: 116592376
+						Length: 25535232
+					^Content/cnc/movies/nodend3.vqa:
+						Offset: 142127608
+						Length: 25725824
+					^Content/cnc/movies/nodend2.vqa:
+						Offset: 167853432
+						Length: 27214048
+					^Content/cnc/movies/nodend1.vqa:
+						Offset: 195067480
+						Length: 27172272
+					^Content/cnc/movies/nod9.vqa:
+						Offset: 222239752
+						Length: 9357980
+					^Content/cnc/movies/nod8.vqa:
+						Offset: 231597732
+						Length: 11597940
+					^Content/cnc/movies/nod7b.vqa:
+						Offset: 243195672
+						Length: 4671402
+					^Content/cnc/movies/nod7a.vqa:
+						Offset: 247867074
+						Length: 4740470
+					^Content/cnc/movies/nod6.vqa:
+						Offset: 252607544
+						Length: 5007744
+					^Content/cnc/movies/nod5.vqa:
+						Offset: 257615288
+						Length: 6641700
+					^Content/cnc/movies/nod4b.vqa:
+						Offset: 264256988
+						Length: 3867618
+					^Content/cnc/movies/nod4a.vqa:
+						Offset: 268124606
+						Length: 3838924
+					^Content/cnc/movies/nod3.vqa:
+						Offset: 271963530
+						Length: 3603314
+					^Content/cnc/movies/nod2.vqa:
+						Offset: 275566844
+						Length: 7200720
+					^Content/cnc/movies/nod1pre.vqa:
+						Offset: 282767564
+						Length: 395720
+					^Content/cnc/movies/nod13.vqa:
+						Offset: 283163284
+						Length: 2746626
+					^Content/cnc/movies/nod12.vqa:
+						Offset: 285909910
+						Length: 6576562
+					^Content/cnc/movies/nod11.vqa:
+						Offset: 292486472
+						Length: 4629270
+					^Content/cnc/movies/nod10b.vqa:
+						Offset: 297115742
+						Length: 6386444
+					^Content/cnc/movies/nod10a.vqa:
+						Offset: 303502186
+						Length: 7205632
+					^Content/cnc/movies/nod1.vqa:
+						Offset: 310707818
+						Length: 4663258
+					^Content/cnc/movies/logo.vqa:
+						Offset: 315371076
+						Length: 3562630
+					^Content/cnc/movies/landing.vqa:
+						Offset: 318933706
+						Length: 1617094
+					^Content/cnc/movies/kanepre.vqa:
+						Offset: 320550800
+						Length: 17220712
+					^Content/cnc/movies/intro2.vqa:
+						Offset: 337771512
+						Length: 21058732
+					^Content/cnc/movies/insites.vqa:
+						Offset: 358830244
+						Length: 460482
+					^Content/cnc/movies/generic.vqa:
+						Offset: 359290726
+						Length: 1452820
+					^Content/cnc/movies/gdi1.vqa:
+						Offset: 360743546
+						Length: 6341298
+					^Content/cnc/movies/gameover.vqa:
+						Offset: 367084844
+						Length: 2087322
+					^Content/cnc/movies/forestkl.vqa:
+						Offset: 369172166
+						Length: 1500986
+					^Content/cnc/movies/flag.vqa:
+						Offset: 370673152
+						Length: 4308680
+					^Content/cnc/movies/dino.vqa:
+						Offset: 374981832
+						Length: 1347896
+					^Content/cnc/movies/dessweep.vqa:
+						Offset: 376329728
+						Length: 3563646
+					^Content/cnc/movies/deskill.vqa:
+						Offset: 379893374
+						Length: 1483634
+					^Content/cnc/movies/desflees.vqa:
+						Offset: 381377008
+						Length: 2698426
+					^Content/cnc/movies/consyard.vqa:
+						Offset: 384075434
+						Length: 7864652
+					^Content/cnc/movies/cc2tease.vqa:
+						Offset: 391940086
+						Length: 12506712
+					^Content/cnc/movies/bombflee.vqa:
+						Offset: 404446798
+						Length: 2859726
+					^Content/cnc/movies/bombaway.vqa:
+						Offset: 407306524
+						Length: 5579588
+					^Content/cnc/movies/bcanyon.vqa:
+						Offset: 412886112
+						Length: 5172288
+					^Content/cnc/movies/banner.vqa:
+						Offset: 418058400
+						Length: 2229408
+					^Content/cnc/movies/akira.vqa:
+						Offset: 420287808
+						Length: 7803444
+					^Content/cnc/movies/airstrk.vqa:
+						Offset: 428091252
+						Length: 4444442
 		covertops: Covert Operations Expansion (English)
 			IDFiles:
 				GAME/GAME.DAT: be5a6c4c0a581da09e8f34a3bbf7bd17e525085c
@@ -392,3 +1147,316 @@ ModContent:
 					^Content/cnc/tempicnh.mix: TEMPICNH.MIX
 					^Content/cnc/transit.mix: TRANSIT.MIX
 					^Content/cnc/scores-covertops.mix: covert/SCORES.MIX
+				extract-raw: movies.mix
+					^Content/cnc/movies/akira.vqa:
+						Offset: 4445708
+						Length: 7803444
+					^Content/cnc/movies/bkground.vqa:
+						Offset: 12249152
+						Length: 15267052
+					^Content/cnc/movies/burdet1.vqa:
+						Offset: 27516204
+						Length: 10410614
+					^Content/cnc/movies/burdet2.vqa:
+						Offset: 37926818
+						Length: 2062190
+					^Content/cnc/movies/gdi4a.vqa:
+						Offset: 39989008
+						Length: 4450582
+					^Content/cnc/movies/gdi4b.vqa:
+						Offset: 44439590
+						Length: 6603530
+					^Content/cnc/movies/gdifina.vqa:
+						Offset: 51043120
+						Length: 12888650
+					^Content/cnc/movies/gdifinb.vqa:
+						Offset: 63931770
+						Length: 17769978
+					^Content/cnc/movies/nod7a.vqa:
+						Offset: 81701748
+						Length: 4740470
+					^Content/cnc/movies/nod7b.vqa:
+						Offset: 86442218
+						Length: 4671402
+					^Content/cnc/movies/visor.vqa:
+						Offset: 91113620
+						Length: 4407162
+					^Content/cnc/movies/turtkill.vqa:
+						Offset: 95520782
+						Length: 3323444
+					^Content/cnc/movies/trtkil_d.vqa:
+						Offset: 98844226
+						Length: 3511836
+					^Content/cnc/movies/trailer.vqa:
+						Offset: 102356062
+						Length: 23163930
+					^Content/cnc/movies/tiberfx.vqa:
+						Offset: 125519992
+						Length: 8735102
+					^Content/cnc/movies/tbrinfo3.vqa:
+						Offset: 134255094
+						Length: 14972046
+					^Content/cnc/movies/tbrinfo2.vqa:
+						Offset: 149227140
+						Length: 16195290
+					^Content/cnc/movies/tbrinfo1.vqa:
+						Offset: 165422430
+						Length: 23479052
+					^Content/cnc/movies/tankkill.vqa:
+						Offset: 188901482
+						Length: 3298978
+					^Content/cnc/movies/tankgo.vqa:
+						Offset: 192200460
+						Length: 1403876
+					^Content/cnc/movies/sundial.vqa:
+						Offset: 193604336
+						Length: 3653636
+					^Content/cnc/movies/stealth.vqa:
+						Offset: 197257972
+						Length: 4521860
+					^Content/cnc/movies/spycrash.vqa:
+						Offset: 201779832
+						Length: 1886288
+					^Content/cnc/movies/sethpre.vqa:
+						Offset: 203666120
+						Length: 10914610
+					^Content/cnc/movies/seige.vqa:
+						Offset: 214580730
+						Length: 2705978
+					^Content/cnc/movies/samsite.vqa:
+						Offset: 217286708
+						Length: 1410418
+					^Content/cnc/movies/samdie.vqa:
+						Offset: 218697126
+						Length: 3741942
+					^Content/cnc/movies/sabotage.vqa:
+						Offset: 222439068
+						Length: 1386202
+					^Content/cnc/movies/retro.vqa:
+						Offset: 223825270
+						Length: 6434382
+					^Content/cnc/movies/refint.vqa:
+						Offset: 230259652
+						Length: 5090040
+					^Content/cnc/movies/podium.vqa:
+						Offset: 235349692
+						Length: 2790664
+					^Content/cnc/movies/planecra.vqa:
+						Offset: 238140356
+						Length: 5085426
+					^Content/cnc/movies/pintle.vqa:
+						Offset: 243225782
+						Length: 2757536
+					^Content/cnc/movies/paratrop.vqa:
+						Offset: 245983318
+						Length: 3180272
+					^Content/cnc/movies/obel.vqa:
+						Offset: 249163590
+						Length: 3851370
+					^Content/cnc/movies/nuke.vqa:
+						Offset: 253014960
+						Length: 3126662
+					^Content/cnc/movies/nodsweep.vqa:
+						Offset: 256141622
+						Length: 3642174
+					^Content/cnc/movies/nodlose.vqa:
+						Offset: 259783796
+						Length: 5148924
+					^Content/cnc/movies/nodflees.vqa:
+						Offset: 264932720
+						Length: 3056426
+					^Content/cnc/movies/nodfinal.vqa:
+						Offset: 267989146
+						Length: 23326586
+					^Content/cnc/movies/nod9.vqa:
+						Offset: 396963108
+						Length: 9357980
+					^Content/cnc/movies/nod8.vqa:
+						Offset: 406321088
+						Length: 11597940
+					^Content/cnc/movies/nod6.vqa:
+						Offset: 417919028
+						Length: 5007744
+					^Content/cnc/movies/nod5.vqa:
+						Offset: 422926772
+						Length: 6641700
+					^Content/cnc/movies/nod4b.vqa:
+						Offset: 429568472
+						Length: 3867618
+					^Content/cnc/movies/nod4a.vqa:
+						Offset: 433436090
+						Length: 3838924
+					^Content/cnc/movies/nod3.vqa:
+						Offset: 437275014
+						Length: 3603314
+					^Content/cnc/movies/nod2.vqa:
+						Offset: 440878328
+						Length: 7200720
+					^Content/cnc/movies/nod1pre.vqa:
+						Offset: 448079048
+						Length: 395720
+					^Content/cnc/movies/nod13.vqa:
+						Offset: 448474768
+						Length: 2746626
+					^Content/cnc/movies/nod12.vqa:
+						Offset: 451221394
+						Length: 6576562
+					^Content/cnc/movies/nod11.vqa:
+						Offset: 457797956
+						Length: 4629270
+					^Content/cnc/movies/nod10b.vqa:
+						Offset: 462427226
+						Length: 6386444
+					^Content/cnc/movies/nod10a.vqa:
+						Offset: 468813670
+						Length: 7205632
+					^Content/cnc/movies/nod1.vqa:
+						Offset: 476019302
+						Length: 4663258
+					^Content/cnc/movies/nitejump.vqa:
+						Offset: 480682560
+						Length: 3702838
+					^Content/cnc/movies/napalm.vqa:
+						Offset: 484385398
+						Length: 4004146
+					^Content/cnc/movies/logo.vqa:
+						Offset: 488389544
+						Length: 3562630
+					^Content/cnc/movies/landing.vqa:
+						Offset: 491952174
+						Length: 1617094
+					^Content/cnc/movies/kanepre.vqa:
+						Offset: 493569268
+						Length: 17220712
+					^Content/cnc/movies/intro2.vqa:
+						Offset: 510789980
+						Length: 21058732
+					^Content/cnc/movies/insites.vqa:
+						Offset: 531848712
+						Length: 460482
+					^Content/cnc/movies/hellvaly.vqa:
+						Offset: 532309194
+						Length: 6658950
+					^Content/cnc/movies/gunboat.vqa:
+						Offset: 538968144
+						Length: 3203706
+					^Content/cnc/movies/generic.vqa:
+						Offset: 542171850
+						Length: 1452820
+					^Content/cnc/movies/gdilose.vqa:
+						Offset: 543624670
+						Length: 2097912
+					^Content/cnc/movies/gdiend2.vqa:
+						Offset: 545722582
+						Length: 25242946
+					^Content/cnc/movies/gdiend1.vqa:
+						Offset: 570965528
+						Length: 25311636
+					^Content/cnc/movies/gdi9.vqa:
+						Offset: 596277164
+						Length: 11806994
+					^Content/cnc/movies/gdi8b.vqa:
+						Offset: 608084158
+						Length: 5324410
+					^Content/cnc/movies/gdi8a.vqa:
+						Offset: 613408568
+						Length: 4672548
+					^Content/cnc/movies/gdi7.vqa:
+						Offset: 618081116
+						Length: 4241952
+					^Content/cnc/movies/gdi6.vqa:
+						Offset: 622323068
+						Length: 3959650
+					^Content/cnc/movies/gdi5.vqa:
+						Offset: 626282718
+						Length: 3818244
+					^Content/cnc/movies/gdi3lose.vqa:
+						Offset: 630100962
+						Length: 2265770
+					^Content/cnc/movies/gdi3.vqa:
+						Offset: 632366732
+						Length: 5443848
+					^Content/cnc/movies/gdi2.vqa:
+						Offset: 637810580
+						Length: 7883500
+					^Content/cnc/movies/gdi15.vqa:
+						Offset: 645694080
+						Length: 11684610
+					^Content/cnc/movies/gdi14.vqa:
+						Offset: 657378690
+						Length: 5282770
+					^Content/cnc/movies/gdi13.vqa:
+						Offset: 662661460
+						Length: 6900914
+					^Content/cnc/movies/gdi12.vqa:
+						Offset: 669562374
+						Length: 3669404
+					^Content/cnc/movies/gdi11.vqa:
+						Offset: 673231778
+						Length: 5895754
+					^Content/cnc/movies/gdi10.vqa:
+						Offset: 679127532
+						Length: 5761514
+					^Content/cnc/movies/gdi1.vqa:
+						Offset: 684889046
+						Length: 6341298
+					^Content/cnc/movies/gameover.vqa:
+						Offset: 691230344
+						Length: 2087322
+					^Content/cnc/movies/forestkl.vqa:
+						Offset: 693317666
+						Length: 1500986
+					^Content/cnc/movies/flyy.vqa:
+						Offset: 694818652
+						Length: 1373532
+					^Content/cnc/movies/flag.vqa:
+						Offset: 696192184
+						Length: 4308680
+					^Content/cnc/movies/dino.vqa:
+						Offset: 700500864
+						Length: 1347896
+					^Content/cnc/movies/dessweep.vqa:
+						Offset: 701848760
+						Length: 3563646
+					^Content/cnc/movies/desolat.vqa:
+						Offset: 705412406
+						Length: 8385122
+					^Content/cnc/movies/deskill.vqa:
+						Offset: 713797528
+						Length: 1483634
+					^Content/cnc/movies/desflees.vqa:
+						Offset: 715281162
+						Length: 2698426
+					^Content/cnc/movies/consyard.vqa:
+						Offset: 717979588
+						Length: 7864652
+					^Content/cnc/movies/cc2tease.vqa:
+						Offset: 725844240
+						Length: 12506712
+					^Content/cnc/movies/bombflee.vqa:
+						Offset: 738350952
+						Length: 2859726
+					^Content/cnc/movies/bombaway.vqa:
+						Offset: 741210678
+						Length: 5579588
+					^Content/cnc/movies/bcanyon.vqa:
+						Offset: 746790266
+						Length: 5172288
+					^Content/cnc/movies/banner.vqa:
+						Offset: 751962554
+						Length: 2229408
+					^Content/cnc/movies/airstrk.vqa:
+						Offset: 754191962
+						Length: 4444442
+					^Content/cnc/movies/nodend1.vqa:
+						Offset: 758637638
+						Length: 24708735
+					^Content/cnc/movies/nodend2.vqa:
+						Offset: 783346373
+						Length: 24700467
+					^Content/cnc/movies/nodend3.vqa:
+						Offset: 808046840
+						Length: 23323681
+					^Content/cnc/movies/nodend4.vqa:
+						Offset: 831370521
+						Length: 23346753

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -207,15 +207,15 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/d2k/BLOXBASE.R8, ^Content/d2k/BLOXBAT.R8, ^Content/d2k/BLOXBGBS.R8, ^Content/d2k/BLOXICE.R8, ^Content/d2k/BLOXTREE.R8, ^Content/d2k/BLOXWAST.R8, ^Content/d2k/DATA.R8, ^Content/d2k/SOUND.RS, ^Content/d2k/PALETTE.BIN
-			Discs: d2k, d2k-linux
+			Sources: d2k, d2k-linux
 			Required: true
 			Download: basefiles
 		music: Game Music
 			TestFiles: ^Content/d2k/Music/AMBUSH.AUD
-			Discs: d2k, d2k-linux
+			Sources: d2k, d2k-linux
 		movies: Campaign Briefings
 			TestFiles: ^Content/d2k/Movies/A_BR01_E.VQA
-			Discs: d2k, d2k-linux
+			Sources: d2k, d2k-linux
 	Downloads:
 		basefiles: Base Content
 			MirrorList: http://www.openra.net/packages/d2k-103-mirrors.txt
@@ -481,7 +481,7 @@ ModContent:
 				^Content/d2k/GAMESFX/O_VSEL1.AUD: GAMESFX/O_VSEL1.AUD
 				^Content/d2k/GAMESFX/O_VSEL2.AUD: GAMESFX/O_VSEL2.AUD
 				^Content/d2k/GAMESFX/O_VSEL3.AUD: GAMESFX/O_VSEL3.AUD
-	Discs:
+	Sources:
 		d2k: Dune 2000 (English)
 			IDFiles:
 				MUSIC/AMBUSH.AUD: bd5926a56a83bc0e49f96037e1f909014ac0772a

--- a/mods/modchooser/content.yaml
+++ b/mods/modchooser/content.yaml
@@ -3,7 +3,7 @@ Background@CONTENT_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 500
-	Height: 268
+	Height: 290
 	Background: panel-bg
 	Children:
 		Background@RULE:
@@ -29,7 +29,7 @@ Background@CONTENT_PANEL:
 			X: 30
 			Y: 84
 			Width: PARENT_RIGHT - 60
-			Height: 115
+			Height: 137
 			TopBottomSpacing: 4
 			ItemSpacing: 2
 			BorderWidth: 2
@@ -89,9 +89,9 @@ Background@CONTENT_PANEL:
 			X: 30
 			Y: PARENT_BOTTOM - 52
 			Background: button-highlighted
-			Width: 110
+			Width: 200
 			Height: 32
-			Text: Detect Disc
+			Text: Detect Disc or Installation
 			Font: Bold
 		Button@BACK_BUTTON:
 			X: PARENT_RIGHT - 140
@@ -230,7 +230,7 @@ Background@DISC_INSTALL_PANEL:
 					Align: Center
 		Container@LIST:
 			Width: PARENT_RIGHT
-			Height: 268
+			Height: 338
 			Visible: false
 			Children:
 				Label@LIST_MESSAGE:
@@ -242,11 +242,31 @@ Background@DISC_INSTALL_PANEL:
 					X: 30
 					Y: 99
 					Width: PARENT_RIGHT - 60
-					Height: 100
+					Height: 170
 					TopBottomSpacing: 4
 					ItemSpacing: 2
 					BorderWidth: 2
 					Children:
+						Container@LIST_HEADER_TEMPLATE:
+							X: 6
+							Width: PARENT_RIGHT - 12 - 24
+							Height: 14
+							Children:
+								Background@TOP_RULE:
+									Width: PARENT_RIGHT
+									Height: 1
+									Background: panel-rule
+								Label@LABEL:
+									Y: 3
+									Width: PARENT_RIGHT
+									Height: 10
+									Font: TinyBold
+									Align: Center
+								Background@BOTTOM_RULE:
+									Y: 16
+									Width: PARENT_RIGHT
+									Height: 1
+									Background: panel-rule
 						Label@LIST_TEMPLATE:
 							X: 6
 							Width: PARENT_RIGHT - 16

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -229,24 +229,24 @@ Migrations:
 ModContent:
 	InstallPromptMessage: Red Alert requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2008 Red Alert freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.
 	QuickDownload: basefiles
-	HeaderMessage: The original game content may be copied from an original game disc,\nor downloaded from an online mirror of the 2008 freeware release.
+	HeaderMessage: Game content may be extracted from the original game discs or an\nexisting digital install. OpenRA can also download the base game\nfiles from an online mirror of the 2008 freeware release of RA.
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/ra/allies.mix, ^Content/ra/conquer.mix, ^Content/ra/interior.mix, ^Content/ra/redalert.mix, ^Content/ra/russian.mix, ^Content/ra/snow.mix, ^Content/ra/sounds.mix, ^Content/ra/temperat.mix
-			Sources: allied, allied-linux, soviet, soviet-linux
+			Sources: allied, allied-linux, soviet, soviet-linux, origin
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/ra/scores.mix
-			Sources: allied, allied-linux, soviet, soviet-linux
+			Sources: allied, allied-linux, soviet, soviet-linux, origin
 			Download: music
 		movies-allied: Allied Campaign Briefings
 			TestFiles: ^Content/ra/movies1.mix
-			Sources: allied, allied-linux
+			Sources: allied, allied-linux, origin
 		movies-soviet: Soviet Campaign Briefings
 			TestFiles: ^Content/ra/movies2.mix
-			Sources: soviet, soviet-linux
-		music-covertops: Counterstrike Music
+			Sources: soviet, soviet-linux, origin
+		music-counterstrike: Counterstrike Music
 			TestFiles: ^Content/ra/scores-counterstrike.mix
 			Sources: counterstrike, counterstrike-linux
 	Downloads:
@@ -425,3 +425,44 @@ ModContent:
 					^Content/ra/scores-counterstrike.mix:
 						Offset: 144899491
 						Length: 87483135
+		origin: C&C The Ultimate Collection (Origin version, English)
+			Type: Install
+			RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\Command and Conquer Red Alert
+			RegistryValue: Install Dir
+			IDFiles:
+				RA95Launcher.exe: 22bf7a1f9f1c2498823e3216541e6012f291c2c0
+				REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
+			Install:
+				copy: .
+					^Content/ra/redalert.mix: REDALERT.MIX
+				extract-raw: MAIN.MIX
+					^Content/ra/movies1.mix:
+						Offset: 417051805
+						Length: 404691306
+					^Content/ra/interior.mix:
+						Offset: 821743111
+						Length: 249490
+					^Content/ra/conquer.mix:
+						Offset: 840028549
+						Length: 2192279
+					^Content/ra/allies.mix:
+						Offset: 842220828
+						Length: 319181
+					^Content/ra/temperat.mix:
+						Offset: 842540009
+						Length: 1043672
+					^Content/ra/sounds.mix:
+						Offset: 843583681
+						Length: 1385637
+					^Content/ra/snow.mix:
+						Offset: 844969318
+						Length: 1035716
+					^Content/ra/scores.mix:
+						Offset: 846005034
+						Length: 67742203
+					^Content/ra/russian.mix:
+						Offset: 913747237
+						Length: 274732
+					^Content/ra/movies2.mix:
+						Offset: 914022190
+						Length: 417051731

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -9,6 +9,7 @@ RequiresMods:
 
 Packages:
 	~^Content/ra
+	~^Content/ra/music
 	.
 	$ra: ra
 	$cnc: cnc
@@ -26,7 +27,6 @@ Packages:
 	~snow.mix
 	~interior.mix
 	~scores.mix
-	~scores-counterstrike.mix
 	~movies1.mix
 	~movies2.mix
 	ra|bits
@@ -247,8 +247,11 @@ ModContent:
 			TestFiles: ^Content/ra/movies2.mix
 			Sources: soviet, soviet-linux, origin
 		music-counterstrike: Counterstrike Music
-			TestFiles: ^Content/ra/scores-counterstrike.mix
-			Sources: counterstrike, counterstrike-linux
+			TestFiles: ^Content/ra/music/araziod.aud, ^Content/ra/music/backstab.aud, ^Content/ra/music/chaos2.aud, ^Content/ra/music/shut_it.aud, ^Content/ra/music/2nd_hand.aud, ^Content/ra/music/twinmix1.aud, ^Content/ra/music/under3.aud, ^Content/ra/music/vr2.aud, 
+			Sources: counterstrike, counterstrike-linux, origin
+		music-aftermath: Aftermath Music
+			TestFiles: ^Content/ra/music/await.aud, ^Content/ra/music/bog.aud, ^Content/ra/music/float_v2.aud, ^Content/ra/music/gloom.aud, ^Content/ra/music/grndwire.aud, ^Content/ra/music/rpt.aud, ^Content/ra/music/search.aud, ^Content/ra/music/traction.aud, ^Content/ra/music/wastelnd.aud
+			Sources: origin
 	Downloads:
 		basefiles: Base Freeware Content
 			MirrorList: http://www.openra.net/packages/ra-mirrors.txt
@@ -407,24 +410,66 @@ ModContent:
 					^Content/ra/temperat.mix:
 						Offset: 499538555
 						Length: 1038859
-		counterstrike: Counterstrike Expansion (English)
+		counterstrike: Counterstrike Expansion Disc (English)
 			IDFiles:
 				README.TXT: 0efe8087383f0b159a9633f891fb5f53c6097cd4
 				SETUP/INSTALL/CSTRIKE.RTP: fae8ba82db71574f6ecd8fb4ff4026fcb65d2adc
 			Install:
 				extract-raw: MAIN.MIX
-					^Content/ra/scores-counterstrike.mix:
-						Offset: 144899491
-						Length: 87483135
-		counterstrike-linux: Counterstrike Expansion (English)
+					^Content/ra/music/2nd_hand.aud:
+						Offset: 209070947
+						Length: 3070092
+					^Content/ra/music/araziod.aud:
+						Offset: 212141039
+						Length: 2941132
+					^Content/ra/music/backstab.aud:
+						Offset: 215082171
+						Length: 3178252
+					^Content/ra/music/chaos2.aud:
+						Offset: 218260423
+						Length: 2860068
+					^Content/ra/music/shut_it.aud:
+						Offset: 221120491
+						Length: 2991979
+					^Content/ra/music/twinmix1.aud:
+						Offset: 224112470
+						Length: 2536972
+					^Content/ra/music/under3.aud:
+						Offset: 226649442
+						Length: 2812788
+					^Content/ra/music/vr2.aud:
+						Offset: 229462230
+						Length: 2920396
+		counterstrike-linux: Counterstrike Expansion Disc (English)
 			IDFiles:
 				readme.txt: 0efe8087383f0b159a9633f891fb5f53c6097cd4
 				setup/install/cstrike.rtp: fae8ba82db71574f6ecd8fb4ff4026fcb65d2adc
 			Install:
 				extract-raw: main.mix
-					^Content/ra/scores-counterstrike.mix:
-						Offset: 144899491
-						Length: 87483135
+					^Content/ra/music/2nd_hand.aud:
+						Offset: 209070947
+						Length: 3070092
+					^Content/ra/music/araziod.aud:
+						Offset: 212141039
+						Length: 2941132
+					^Content/ra/music/backstab.aud:
+						Offset: 215082171
+						Length: 3178252
+					^Content/ra/music/chaos2.aud:
+						Offset: 218260423
+						Length: 2860068
+					^Content/ra/music/shut_it.aud:
+						Offset: 221120491
+						Length: 2991979
+					^Content/ra/music/twinmix1.aud:
+						Offset: 224112470
+						Length: 2536972
+					^Content/ra/music/under3.aud:
+						Offset: 226649442
+						Length: 2812788
+					^Content/ra/music/vr2.aud:
+						Offset: 229462230
+						Length: 2920396
 		origin: C&C The Ultimate Collection (Origin version, English)
 			Type: Install
 			RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\Command and Conquer Red Alert
@@ -435,6 +480,23 @@ ModContent:
 			Install:
 				copy: .
 					^Content/ra/redalert.mix: REDALERT.MIX
+					^Content/ra/music/2nd_hand.aud: 2nd_hand.aud
+					^Content/ra/music/araziod.aud: araziod.aud
+					^Content/ra/music/await.aud: await.aud
+					^Content/ra/music/backstab.aud: backstab.aud
+					^Content/ra/music/bog.aud: bog.aud
+					^Content/ra/music/chaos2.aud: chaos2.aud
+					^Content/ra/music/float_v2.aud: float_v2.aud
+					^Content/ra/music/gloom.aud: gloom.aud
+					^Content/ra/music/grndwire.aud: grndwire.aud
+					^Content/ra/music/rpt.aud: rpt.aud
+					^Content/ra/music/search.aud: search.aud
+					^Content/ra/music/shut_it.aud: shut_it.aud
+					^Content/ra/music/traction.aud: traction.aud
+					^Content/ra/music/twinmix1.aud: twinmix1.aud
+					^Content/ra/music/under3.aud: under3.aud
+					^Content/ra/music/vr2.aud: vr2.aud
+					^Content/ra/music/wastelnd.aud: wastelnd.aud
 				extract-raw: MAIN.MIX
 					^Content/ra/movies1.mix:
 						Offset: 417051805

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -251,7 +251,7 @@ ModContent:
 			Sources: counterstrike, counterstrike-linux, origin
 		music-aftermath: Aftermath Music
 			TestFiles: ^Content/ra/music/await.aud, ^Content/ra/music/bog.aud, ^Content/ra/music/float_v2.aud, ^Content/ra/music/gloom.aud, ^Content/ra/music/grndwire.aud, ^Content/ra/music/rpt.aud, ^Content/ra/music/search.aud, ^Content/ra/music/traction.aud, ^Content/ra/music/wastelnd.aud
-			Sources: origin
+			Sources: aftermath, aftermath-linux, origin
 	Downloads:
 		basefiles: Base Freeware Content
 			MirrorList: http://www.openra.net/packages/ra-mirrors.txt
@@ -470,6 +470,72 @@ ModContent:
 					^Content/ra/music/vr2.aud:
 						Offset: 229462230
 						Length: 2920396
+		aftermath: Aftermath Expansion Disc (English)
+			IDFiles:
+				README.TXT: 9902fb74c019df1b76ff5634e68f0371d790b5e0
+				SETUP/INSTALL/PATCH.RTP: 5bce93f834f9322ddaa7233242e5b6c7fea0bf17
+			Install:
+				extract-raw: MAIN.MIX
+					^Content/ra/music/await.aud:
+						Offset: 158698809
+						Length: 2972788
+					^Content/ra/music/bog.aud:
+						Offset: 244351833
+						Length: 2386955
+					^Content/ra/music/float_v2.aud:
+						Offset: 246738788
+						Length: 3090115
+					^Content/ra/music/gloom.aud:
+						Offset: 249828903
+						Length: 2662851
+					^Content/ra/music/grndwire.aud:
+						Offset: 252491754
+						Length: 2573611
+					^Content/ra/music/rpt.aud:
+						Offset: 255065365
+						Length: 3092259
+					^Content/ra/music/search.aud:
+						Offset: 258157624
+						Length: 3104091
+					^Content/ra/music/traction.aud:
+						Offset: 261261715
+						Length: 2668003
+					^Content/ra/music/wastelnd.aud:
+						Offset: 263929718
+						Length: 2721563
+		aftermath-linux: Aftermath Expansion Disc (English)
+			IDFiles:
+				readme.txt: 9902fb74c019df1b76ff5634e68f0371d790b5e0
+				setup/install/patch.rtp: 5bce93f834f9322ddaa7233242e5b6c7fea0bf17
+			Install:
+				extract-raw: main.mix
+					^Content/ra/music/await.aud:
+						Offset: 158698809
+						Length: 2972788
+					^Content/ra/music/bog.aud:
+						Offset: 244351833
+						Length: 2386955
+					^Content/ra/music/float_v2.aud:
+						Offset: 246738788
+						Length: 3090115
+					^Content/ra/music/gloom.aud:
+						Offset: 249828903
+						Length: 2662851
+					^Content/ra/music/grndwire.aud:
+						Offset: 252491754
+						Length: 2573611
+					^Content/ra/music/rpt.aud:
+						Offset: 255065365
+						Length: 3092259
+					^Content/ra/music/search.aud:
+						Offset: 258157624
+						Length: 3104091
+					^Content/ra/music/traction.aud:
+						Offset: 261261715
+						Length: 2668003
+					^Content/ra/music/wastelnd.aud:
+						Offset: 263929718
+						Length: 2721563
 		origin: C&C The Ultimate Collection (Origin version, English)
 			Type: Install
 			RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\Command and Conquer Red Alert

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -233,22 +233,22 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/ra/allies.mix, ^Content/ra/conquer.mix, ^Content/ra/interior.mix, ^Content/ra/redalert.mix, ^Content/ra/russian.mix, ^Content/ra/snow.mix, ^Content/ra/sounds.mix, ^Content/ra/temperat.mix
-			Discs: allied, allied-linux, soviet, soviet-linux
+			Sources: allied, allied-linux, soviet, soviet-linux
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/ra/scores.mix
-			Discs: allied, allied-linux, soviet, soviet-linux
+			Sources: allied, allied-linux, soviet, soviet-linux
 			Download: music
 		movies-allied: Allied Campaign Briefings
 			TestFiles: ^Content/ra/movies1.mix
-			Discs: allied, allied-linux
+			Sources: allied, allied-linux
 		movies-soviet: Soviet Campaign Briefings
 			TestFiles: ^Content/ra/movies2.mix
-			Discs: soviet, soviet-linux
+			Sources: soviet, soviet-linux
 		music-covertops: Counterstrike Music
 			TestFiles: ^Content/ra/scores-counterstrike.mix
-			Discs: counterstrike, counterstrike-linux
+			Sources: counterstrike, counterstrike-linux
 	Downloads:
 		basefiles: Base Freeware Content
 			MirrorList: http://www.openra.net/packages/ra-mirrors.txt
@@ -266,7 +266,7 @@ ModContent:
 			MirrorList: http://www.openra.net/packages/ra-music-mirrors.txt
 			Extract:
 				^Content/ra/scores.mix: scores.mix
-	Discs:
+	Sources:
 		allied: Red Alert 95 (Allied Disc, English)
 			IDFiles:
 				eahelp.GID: 13a8a4a1e7d9d6d893c38df5a39262c4689aeba5

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -266,12 +266,12 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/ts/cache.mix, ^Content/ts/conquer.mix, ^Content/ts/isosnow.mix, ^Content/ts/isotemp.mix, ^Content/ts/local.mix, ^Content/ts/sidec01.mix, ^Content/ts/sidec02.mix, ^Content/ts/sno.mix, ^Content/ts/snow.mix, ^Content/ts/sounds.mix, ^Content/ts/speech01.mix, ^Content/ts/tem.mix, ^Content/ts/temperat.mix
-			Discs: tibsun, tibsun-linux
+			Sources: tibsun, tibsun-linux
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/ts/scores.mix
-			Discs: tibsun, tibsun-linux
+			Sources: tibsun, tibsun-linux
 			Download: music
 	Downloads:
 		basefiles: Base Freeware Content
@@ -295,7 +295,7 @@ ModContent:
 			MirrorList: http://www.openra.net/packages/ts-music-mirrors.txt
 			Extract:
 				^Content/ts/scores.mix: scores.mix
-	Discs:
+	Sources:
 		tibsun: Tiberan Sun (GDI or Nod Disc, English)
 			IDFiles:
 				README.TXT: 45745c4a0c888317ec900208a426472779c42bf7

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -26,7 +26,6 @@ Packages:
 	~movies02.mix
 	~sidecd01.mix
 	~sidecd02.mix
-	~tibsun.mix
 	~cache.mix
 	~conquer.mix
 	~isosnow.mix
@@ -262,16 +261,16 @@ ColorValidator:
 ModContent:
 	InstallPromptMessage: Tiberian Sun requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2012 Tiberian Sun freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.
 	QuickDownload: basefiles
-	HeaderMessage: The original game content may be copied from an original game disc,\nor downloaded from an online mirror of the 2012 freeware release.
+	HeaderMessage: Game content may be extracted from the original game discs or an\nexisting digital install. OpenRA can also download the base game\nfiles from an online mirror of the 2012 freeware release of TS.
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/ts/cache.mix, ^Content/ts/conquer.mix, ^Content/ts/isosnow.mix, ^Content/ts/isotemp.mix, ^Content/ts/local.mix, ^Content/ts/sidec01.mix, ^Content/ts/sidec02.mix, ^Content/ts/sno.mix, ^Content/ts/snow.mix, ^Content/ts/sounds.mix, ^Content/ts/speech01.mix, ^Content/ts/tem.mix, ^Content/ts/temperat.mix
-			Sources: tibsun, tibsun-linux
+			Sources: tibsun, tibsun-linux, origin
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/ts/scores.mix
-			Sources: tibsun, tibsun-linux
+			Sources: tibsun, tibsun-linux, origin
 			Download: music
 	Downloads:
 		basefiles: Base Freeware Content
@@ -354,6 +353,59 @@ ModContent:
 				copy: .
 					^Content/ts/scores.mix: scores.mix
 				extract-raw: install/tibsun.mix
+					^Content/ts/cache.mix:
+						Offset: 300
+						Length: 169176
+					^Content/ts/conquer.mix:
+						Offset: 169484
+						Length: 5700088
+					^Content/ts/isosnow.mix:
+						Offset: 5869580
+						Length: 7624750
+					^Content/ts/isotemp.mix:
+						Offset: 13494332
+						Length: 8617646
+					^Content/ts/local.mix:
+						Offset: 22111980
+						Length: 18044736
+					^Content/ts/sidec01.mix:
+						Offset: 40156716
+						Length: 998476
+					^Content/ts/sidec02.mix:
+						Offset: 41155196
+						Length: 1039996
+					^Content/ts/snow.mix:
+						Offset: 56104508
+						Length: 2087806
+					^Content/ts/sno.mix:
+						Offset: 58192316
+						Length: 7826
+					^Content/ts/sounds.mix:
+						Offset: 58200156
+						Length: 3224136
+					^Content/ts/speech01.mix:
+						Offset: 61424300
+						Length: 6028236
+					^Content/ts/speech02.mix:
+						Offset: 67452540
+						Length: 5596628
+					^Content/ts/tem.mix:
+						Offset: 73049180
+						Length: 7746
+					^Content/ts/temperat.mix:
+						Offset: 73056940
+						Length: 2037606
+		origin: C&C The Ultimate Collection (Origin version, English)
+			Type: Install
+			RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\Command and Conquer Tiberian Sun
+			RegistryValue: Install Dir
+			IDFiles:
+				TSLauncher.exe: 0b3e8dfd7cb701868eccef3ba3717a1ced802707
+				GDFBinary_en_US.dll: 4bb56a449bd0003e7ae67625d90a11ae169319d6
+			Install:
+				copy: .
+					^Content/ts/scores.mix: SCORES.MIX
+				extract-raw: TIBSUN.MIX
 					^Content/ts/cache.mix:
 						Offset: 300
 						Length: 169176


### PR DESCRIPTION
This adds support for querying the Windows registry to find an install location that is used as an asset source, and then tweaks the content and installation UI to distinguish between external and internal media.

TD, RA, and TS have been updated to support installation fro TUC.  This required a few minor tweaks to the file layout, which we will be able to clean up as part of the future file-migrations PR.

I have [another branch](https://github.com/pchote/OpenRA/tree/gruntmods) that adds support for installing D2K assets from the gruntmods edition, but that's blocked on #2344.
