### PR TITLE
Delete legacy downloaded scores.mix on first run

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -344,6 +344,13 @@ namespace OpenRA
 			using (new PerfTimer("LoadMaps"))
 				ModData.MapCache.LoadMaps();
 
+			if (ModData.Manifest.Contains<Migrations>())
+			{
+				var reload = ModData.Manifest.Get<Migrations>().Run();
+				if (reload)
+					InitializeMod(mod, args);
+			}
+
 			var content = ModData.Manifest.Get<ModContent>();
 			var isModContentInstalled = content.Packages
 				.Where(p => p.Value.Required)

--- a/OpenRA.Game/Migrations.cs
+++ b/OpenRA.Game/Migrations.cs
@@ -1,0 +1,65 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenRA
+{
+	public class Migrations : IGlobalModData
+	{
+		[FieldLoader.Ignore]
+		readonly List<MiniYamlNode> rules;
+
+		public Migrations(MiniYaml yaml)
+		{
+			rules = yaml.Nodes;
+		}
+
+		public bool Run()
+		{
+			var appliedRule = false;
+			foreach (var rule in rules)
+			{
+				var path = Platform.ResolvePath(rule.Value.Value);
+				if (!File.Exists(path))
+					continue;
+
+				var lengthNode = rule.Value.Nodes.FirstOrDefault(n => n.Key == "Length");
+				if (lengthNode != null)
+				{
+					var matchLength = FieldLoader.GetValue<int>("Length", lengthNode.Value.Value);
+					var actualLength = new FileInfo(path).Length;
+					if (matchLength != actualLength)
+						continue;
+				}
+
+				switch (rule.Key)
+				{
+					case "delete":
+						Log.Write("debug", "Migration: Deleting file {0}", path);
+						Console.WriteLine("Migration: Deleting file {0}", path);
+
+						File.Delete(path);
+						appliedRule = true;
+						break;
+					default:
+						Log.Write("debug", "Unknown migration command {0} - ignoring", rule.Value.Value);
+						break;
+				}
+			}
+
+			return appliedRule;
+		}
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -248,6 +248,7 @@
     <Compile Include="FileSystem\ZipFolder.cs" />
     <Compile Include="Primitives\float3.cs" />
     <Compile Include="ModContent.cs" />
+    <Compile Include="Migrations.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -222,6 +222,10 @@ GameSpeeds:
 
 ColorValidator:
 
+Migrations:
+	delete: ^Content/ra/scores.mix
+		Length: 4271443
+
 ModContent:
 	InstallPromptMessage: Red Alert requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2008 Red Alert freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.
 	QuickDownload: basefiles


### PR DESCRIPTION
The asset download ships a mangled scores.mix that only has Hell March.  This causes problems for the music player (#11375 ripped out the special place hacks it used to have) and content manager.

This implements a new "Migrations" block that, for now, lets us match files based on name and length and delete them.  I have implemented this in a general enough way that we can expand it later as needs arise for moving content, migrating maps to newer releases, cleaning up older content (replays, maps – with a confirmation prompt), etc.

Closes #11525.
