### PR TITLE
Password UI improvements

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -113,6 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");
 			if (passwordField != null)
 			{
+				passwordField.TakeKeyboardFocus();
 				passwordField.Text = orderManager.Password;
 				passwordField.IsVisible = () => orderManager.AuthenticationFailed;
 				var passwordLabel = widget.Get<LabelWidget>("PASSWORD_LABEL");

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -114,7 +114,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (passwordField != null)
 			{
 				passwordField.TakeKeyboardFocus();
-				passwordField.Text = orderManager.Password;
 				passwordField.IsVisible = () => orderManager.AuthenticationFailed;
 				var passwordLabel = widget.Get<LabelWidget>("PASSWORD_LABEL");
 				passwordLabel.IsVisible = passwordField.IsVisible;


### PR DESCRIPTION
Solves my #11527 (thanks for help @Phrohdoh :tada: )
Split into 2 commits. Fair warning, if we use only first commit, the cursor will be at the start of the field in front of the password.
