### PR TITLE
RA - Some fixes about Giant Ants

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -583,6 +583,7 @@ Ant:
 	Tooltip:
 		Name: Giant Ant
 		Description: Irradiated insect that grew oversize.
+		GenericName: Ant
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 1954
@@ -599,6 +600,7 @@ Ant:
 		Speed: 99
 		TurnSpeed: 12
 		SharesCell: no
+	-Crushable:
 	AutoTarget:
 		ScanRadius: 5
 	AttackFrontal:


### PR DESCRIPTION
I recently realised they were crushable when playing my map. This doesn't makes sense and they are not in original game too. Also it had `GenericName:` of `Soldier` i made it `Ant` as we changed it for dogs too.
