### PR TITLE
Fix RA Grenadier damage versus Heavy armor

### DIFF
--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -101,6 +101,7 @@ Grenade:
 			Wood: 100
 			Light: 25
 			Heavy: 25
+			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -100,7 +100,7 @@ Grenade:
 			None: 50
 			Wood: 100
 			Light: 25
-			Heavy: 5
+			Heavy: 25
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater


### PR DESCRIPTION
By increasing it by a factor of 5 (from a measly 5% to still-rather-low 25%).

Closes #11103.
