### PR TITLE
TD Balance Changes 06302016

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -524,7 +524,7 @@ FIX:
 	SelectionDecorations:
 		VisualBounds: 72,48
 	Health:
-		HP: 600
+		HP: 700
 	RevealsShroud:
 		Range: 5c0
 	Bib:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -15,7 +15,7 @@ MCV:
 		Speed: 71
 		Crushes: crate, infantry
 	Health:
-		HP: 950
+		HP: 1200
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -137,7 +137,7 @@ ARTY:
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.Nod
 	Mobile:
-		TurnSpeed: 2
+		TurnSpeed: 4
 		Speed: 85
 	Health:
 		HP: 75

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -1,7 +1,7 @@
 FlametankExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
-		Damage: 100
+		Damage: 115
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: big_napalm

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -34,14 +34,14 @@ BigFlamer:
 	Burst: 2
 	BurstDelay: 25
 	Warhead@1Dam: SpreadDamage
-		Spread: 341
+		Spread: 400
 		Damage: 75
 		InvalidTargets: Wall
 		ValidTargets: Ground, Trees
 		Versus:
 			None: 100
 			Wood: 100
-			Light: 67
+			Light: 100
 			Heavy: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -185,7 +185,7 @@ APCGun.AA:
 	Report: gun20.aud
 	ValidTargets: Air
 	Projectile: Bullet
-		Speed: 1c682
+		Speed: 2c0
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 128


### PR DESCRIPTION
These are the following changes for TD:

APC AA Gun projectile speed increase from 1c6 to 2c0.

Flame Tank damage vs light increase from 67 to 100.

Flame Tank explosion damage increase from 100 to 115.

Flame Tank damage spread increase from 341 to 400.

Repair Pad HP increase from 600 to 700.

Artillery Turn Speed increased from 2 to 4.

MCV HP increase from 950 to 1200. 
