### PR TITLE
Lower the case of the TechLevel in all rules.yaml files

### DIFF
--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -8,7 +8,6 @@ World:
 		Briefing: GDI is attempting to retake Egypt.\n\nUse every available resource in your efforts to stop them.\n\nThe populace has once again swayed in support of GDI forces, so show no mercy in dealing with the villagers.
 		LossVideo: banner.vqa
 		BriefingVideo: nod9.vqa
-	MapOptions:
 	SmudgeLayer@SCORCH:
 		InitialSmudges:
 			20,55: sc2,0

--- a/mods/cnc/maps/the-hot-box/rules.yaml
+++ b/mods/cnc/maps/the-hot-box/rules.yaml
@@ -11,7 +11,7 @@ World:
 		AllyBuildRadiusEnabled: False
 	MapOptions:
 		TechLevelLocked: True
-		TechLevel: Unrestricted
+		TechLevel: unrestricted
 
 UNITCRATE:
 	Inherits: ^Crate

--- a/mods/d2k/maps/atreides-01a/rules.yaml
+++ b/mods/d2k/maps/atreides-01a/rules.yaml
@@ -9,7 +9,7 @@ World:
 		Briefing: Harvest Spice from the Imperial Basin. Construct a Spice Refinery and defend it against the Harkonnen troops scattered throughout the basin. You have been assigned only limited offensive forces - use them wisely.\n\nYou will have to learn the subtleties of mining as you go, but remember to build Silos to store the Spice. When you run out of storage space you can not gather more Spice. Also, any building without adequate concrete foundation will need immediate repair and be vulnerable to erosive damage from the harsh environment. Your greatest adversary may be the elements.\n\nGood luck.\n
 		BriefingVideo: A_BR01_E.VQA
 	MapOptions:
-		TechLevel: Low
+		TechLevel: low
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/d2k/maps/atreides-01b/rules.yaml
+++ b/mods/d2k/maps/atreides-01b/rules.yaml
@@ -9,7 +9,7 @@ World:
 		Briefing: Harvest Spice from the Imperial Basin. Construct a Spice Refinery and defend it against the Harkonnen troops scattered throughout the basin. You have been assigned only limited offensive forces - use them wisely.\n\nYou will have to learn the subtleties of mining as you go, but remember to build Silos to store the Spice. When you run out of storage space you can not gather more Spice. Also, any building without adequate concrete foundation will need immediate repair and be vulnerable to erosive damage from the harsh environment. Your greatest adversary may be the elements.\n\nGood luck.\n
 		BriefingVideo: A_BR01_E.VQA
 	MapOptions:
-		TechLevel: Low
+		TechLevel: low
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/d2k/maps/atreides-02a/rules.yaml
+++ b/mods/d2k/maps/atreides-02a/rules.yaml
@@ -9,7 +9,7 @@ World:
 		Briefing: Infiltrate the Imperial Basin and build up our forces until they are strong enough to eradicate the local Harkonnen presence.\n\nThe Harkonnen are reinforcing their troops by air, so be on your guard. Use the Outpost's radar to detect attacks from unexpected quarters.\n\nBe careful when mining the Spice. Spice mounds grow out of the sand. While a vital source of Spice, Spice mounds can damage or destroy any unit that blunders into them.\n\nGood luck.\n
 		BriefingVideo: A_BR02_E.VQA
 	MapOptions:
-		TechLevel: Low
+		TechLevel: low
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/d2k/maps/atreides-02b/rules.yaml
+++ b/mods/d2k/maps/atreides-02b/rules.yaml
@@ -9,7 +9,7 @@ World:
 		Briefing: Infiltrate the Imperial Basin and build up our forces until they are strong enough to eradicate the local Harkonnen presence.\n\nThe Harkonnen are reinforcing their troops by air, so be on your guard. Use the Outpost's radar to detect attacks from unexpected quarters.\n\nBe careful when mining the Spice. Spice mounds grow out of the sand. While a vital source of Spice, Spice mounds can damage or destroy any unit that blunders into them.\n\nGood luck.\n
 		BriefingVideo: A_BR02_E.VQA
 	MapOptions:
-		TechLevel: Low
+		TechLevel: low
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/d2k/maps/atreides-03a/rules.yaml
+++ b/mods/d2k/maps/atreides-03a/rules.yaml
@@ -9,7 +9,7 @@ World:
 		Briefing: Bring the Atreides forces up to combat strength - quickly. Guard against surprise attacks and ensure Spice production.\n\nThe Ordos forces are light but numerous. To combat the Ordos, you have been granted license to produce Quads, which have a greater anti-vehicle capability than Trikes. Upgrade your Light Factories to allow production of these units.\n\nMeet any agression with overwhelming force.\n\nGood luck.\n
 		BriefingVideo: A_BR03_E.VQA
 	MapOptions:
-		TechLevel: Low
+		TechLevel: low
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/allies-02/rules.yaml
+++ b/mods/ra/maps/allies-02/rules.yaml
@@ -11,7 +11,6 @@ World:
 		StartVideo: mcv.vqa
 		WinVideo: montpass.vqa
 		LossVideo: frozen.vqa
-	MapOptions:
 	SmudgeLayer@CRATER:
 		InitialSmudges:
 			60,79: cr1,0

--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -6,7 +6,6 @@ World:
 		StartVideo: brdgtilt.vqa
 		WinVideo: toofar.vqa
 		LossVideo: sovtstar.vqa
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -6,7 +6,6 @@ World:
 		StartVideo: brdgtilt.vqa
 		WinVideo: toofar.vqa
 		LossVideo: sovtstar.vqa
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -8,7 +8,7 @@ World:
 		WinVideo: tanya2.vqa
 		LossVideo: grvestne.vqa
 	MapOptions:
-		TechLevel: Medium
+		TechLevel: medium
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -6,7 +6,7 @@ World:
 		AllyBuildRadiusEnabled: False
 	MapOptions:
 		TechLevelLocked: True
-		TechLevel: Unrestricted
+		TechLevel: unrestricted
 
 APWR:
 	Buildable:

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -11,7 +11,7 @@ World:
 		AllyBuildRadiusEnabled: False
 	MapOptions:
 		TechLevelLocked: True
-		TechLevel: Unrestricted
+		TechLevel: unrestricted
 
 UNITCRATE:
 	Inherits: ^Crate

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -12,7 +12,7 @@ World:
 		AllyBuildRadiusEnabled: False
 	MapOptions:
 		TechLevelLocked: True
-		TechLevel: Unrestricted
+		TechLevel: unrestricted
 
 UNITCRATE:
 	Inherits: ^Crate

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -11,7 +11,7 @@ World:
 		AllyBuildRadiusEnabled: False
 	MapOptions:
 		TechLevelLocked: True
-		TechLevel: Unrestricted
+		TechLevel: unrestricted
 
 UNITCRATE:
 	Inherits: ^Crate

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -37,7 +37,7 @@ World:
 		Locked: True
 	MapOptions:
 		TechLevelLocked: True
-		TechLevel: Unrestricted
+		TechLevel: unrestricted
 		ShortGameLocked: True
 		ShortGameEnabled: False
 	ScriptLobbyDropdown@difficulty:

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -7,7 +7,6 @@ World:
 		Scripts: intervention.lua
 	MissionData:
 		Briefing: The Soviet Air Force is flying air raids against a civilian village.\n\nWe have to do everything in our power to stop them!\n\nYour job is to establish a base on the mainland ASAP. We can prevent the village's destruction by capturing the enemy's Air Force Headquarters building. The enemy base is heavily guarded, though.  You will not have enough time to build a force big enough to overpower the Soviet defences. You will have to find a way to sneak in!\n\nGood luck, Commander!\n
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/soviet-03/rules.yaml
+++ b/mods/ra/maps/soviet-03/rules.yaml
@@ -7,7 +7,6 @@ World:
 		StartVideo: search.vqa
 		WinVideo: execute.vqa
 		LossVideo: take_off.vqa
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/soviet-04a/rules.yaml
+++ b/mods/ra/maps/soviet-04a/rules.yaml
@@ -12,7 +12,7 @@ World:
 		WinVideo: radrraid.vqa
 		LossVideo: allymorf.vqa
 	MapOptions:
-		TechLevel: Medium
+		TechLevel: medium
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/soviet-04b/rules.yaml
+++ b/mods/ra/maps/soviet-04b/rules.yaml
@@ -12,7 +12,7 @@ World:
 		WinVideo: radrraid.vqa
 		LossVideo: allymorf.vqa
 	MapOptions:
-		TechLevel: Medium
+		TechLevel: medium
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/soviet-05/rules.yaml
+++ b/mods/ra/maps/soviet-05/rules.yaml
@@ -12,7 +12,7 @@ World:
 		WinVideo: strafe.vqa
 		LossVideo: sovbatl.vqa
 	MapOptions:
-		TechLevel: Medium
+		TechLevel: medium
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -11,7 +11,6 @@ World:
 		StartVideo: onthprwl.vqa
 		WinVideo: sitduck.vqa
 		LossVideo: dpthchrg.vqa
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -11,7 +11,6 @@ World:
 		StartVideo: onthprwl.vqa
 		WinVideo: sitduck.vqa
 		LossVideo: dpthchrg.vqa
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -7,7 +7,6 @@ World:
 		StartVideo: countdwn.vqa
 		WinVideo: averted.vqa
 		LossVideo: nukestok.vqa
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/survival01/rules.yaml
+++ b/mods/ra/maps/survival01/rules.yaml
@@ -7,7 +7,6 @@ World:
 		Scripts: survival01.lua
 	MissionData:
 		Briefing: LANDCOM 66 HQS.\nTOP SECRET.\nTO: FIELD COMMANDER A34\n\nTHE SOVIETS STARTED HEAVY ATTACKS AT OUR POSITION.\n SURVIVE AND HOLD THE BASE UNTIL OUR FRENCH ALLIES ARRIVE.\n\nCONFIRMATION CODE 5593.\n\nTRANSMISSION ENDS.
-	MapOptions:
 	ScriptLobbyDropdown@difficulty:
 		ID: difficulty
 		Label: Difficulty

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -7,7 +7,7 @@ World:
 		AllyBuildRadiusEnabled: False
 	MapOptions:
 		TechLevelLocked: True
-		TechLevel: Unrestricted
+		TechLevel: unrestricted
 
 Player:
 	ClassicProductionQueue@Infantry:


### PR DESCRIPTION
Since #11364 the case of the `TechLevel`s is lower-case.
This prohibited building in several missions.

Also cleaned a bit up: Removed the `MapOptions` trait where it's not needed.
