### PR TITLE
Use BeforeGameStart to remove shellmap UI on editor start.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -185,11 +185,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var mapEditorMenu = widget.Get("MAP_EDITOR_MENU");
 			mapEditorMenu.IsVisible = () => menuType == MenuType.MapEditor;
 
-			var onSelect = new Action<string>(uid =>
-			{
-				RemoveShellmapUI();
-				LoadMapIntoEditor(modData.MapCache[uid].Uid);
-			});
+			// Loading into the map editor
+			Game.BeforeGameStart += RemoveShellmapUI;
+
+			var onSelect = new Action<string>(uid => LoadMapIntoEditor(modData.MapCache[uid].Uid));
 
 			var newMapButton = widget.Get<ButtonWidget>("NEW_MAP_BUTTON");
 			newMapButton.OnClick = () =>
@@ -450,7 +449,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
+			{
 				Game.OnRemoteDirectConnect -= OnRemoteDirectConnect;
+				Game.BeforeGameStart -= RemoveShellmapUI;
+			}
+
 			base.Dispose(disposing);
 		}
 	}


### PR DESCRIPTION
This extends #11370 to also fix the menu -> editor transition.
