### PR TITLE
Added ready checkbox for spectating admins

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -60,7 +60,8 @@ namespace OpenRA.Mods.Common.Server
 
 		static void CheckAutoStart(S server)
 		{
-			var playerClients = server.LobbyInfo.Clients.Where(c => c.Bot == null && c.Slot != null);
+			// A spectating admin is included for checking these rules
+			var playerClients = server.LobbyInfo.Clients.Where(c => (c.Bot == null && c.Slot != null) || c.IsAdmin);
 
 			// Are all players ready?
 			if (!playerClients.Any() || playerClients.Any(c => c.State != Session.ClientState.Ready))
@@ -188,6 +189,7 @@ namespace OpenRA.Mods.Common.Server
 							client.SpawnPoint = 0;
 							client.Color = HSLColor.FromRGB(255, 255, 255);
 							server.SyncLobbyClients();
+							CheckAutoStart(server);
 							return true;
 						}
 						else

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -745,7 +745,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupEditableFactionWidget(template, slot, client, orderManager, factions);
 					LobbyUtils.SetupEditableTeamWidget(template, slot, client, orderManager, Map);
 					LobbyUtils.SetupEditableSpawnWidget(template, slot, client, orderManager, Map);
-					LobbyUtils.SetupEditableReadyWidget(template, slot, client, orderManager, Map, !Map.RulesLoaded || Map.InvalidCustomRules);
+					LobbyUtils.SetupEditableReadyWidget(template, slot, client, orderManager, Map);
 				}
 				else
 				{
@@ -791,6 +791,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						template = editableSpectatorTemplate.Clone();
 
 					LobbyUtils.SetupEditableNameWidget(template, null, c, orderManager);
+
+					if (client.IsAdmin)
+						LobbyUtils.SetupEditableReadyWidget(template, null, client, orderManager, Map);
 				}
 				else
 				{
@@ -801,6 +804,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupNameWidget(template, null, client);
 					LobbyUtils.SetupKickWidget(template, null, client, orderManager, lobby,
 						() => panel = PanelType.Kick, () => panel = PanelType.Players);
+
+					if (client.IsAdmin)
+						LobbyUtils.SetupReadyWidget(template, null, client);
 				}
 
 				LobbyUtils.SetupClientWidget(template, c, orderManager, true);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -457,12 +457,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			parent.Get<LabelWidget>("SPAWN").GetText = () => (c.SpawnPoint == 0) ? "-" : Convert.ToChar('A' - 1 + c.SpawnPoint).ToString();
 		}
 
-		public static void SetupEditableReadyWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map, bool forceDisable)
+		public static void SetupEditableReadyWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)
 		{
 			var status = parent.Get<CheckboxWidget>("STATUS_CHECKBOX");
 			status.IsChecked = () => orderManager.LocalClient.IsReady || c.Bot != null;
 			status.IsVisible = () => true;
-			status.IsDisabled = () => c.Bot != null || map.Status != MapStatus.Available || forceDisable;
+			status.IsDisabled = () => c.Bot != null || map.Status != MapStatus.Available ||
+				!map.RulesLoaded || map.InvalidCustomRules;
 
 			var state = orderManager.LocalClient.IsReady ? Session.ClientState.NotReady : Session.ClientState.Ready;
 			status.OnClick = () => orderManager.IssueOrder(Order.Command("state {0}".F(state)));

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -300,6 +300,20 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Spectator
 							Align: Center
 							Font: Bold
+						Image@STATUS_IMAGE:
+							X: 521
+							Y: 4
+							Width: 20
+							Height: 20
+							ImageCollection: checkbox-bits
+							ImageName: checked
+							Visible: false
+						Checkbox@STATUS_CHECKBOX:
+							X: 527
+							Y: 2
+							Width: 20
+							Height: 20
+							Visible: false
 				Container@TEMPLATE_NONEDITABLE_SPECTATOR:
 					X: 5
 					Width: 530
@@ -350,6 +364,14 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Spectator
 							Align: Center
 							Font: Bold
+						Image@STATUS_IMAGE:
+							X: 527
+							Y: 4
+							Width: 20
+							Height: 20
+							ImageCollection: checkbox-bits
+							ImageName: checked
+							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:
 					X: 5
 					Width: 529

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -291,6 +291,20 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Spectator
 							Align: Center
 							Font: Bold
+						Checkbox@STATUS_CHECKBOX:
+							X: 525
+							Y: 2
+							Width: 20
+							Height: 20
+							Visible: false
+						Image@STATUS_IMAGE:
+							X: 527
+							Y: 4
+							Width: 20
+							Height: 20
+							ImageCollection: checkbox-bits
+							ImageName: checked
+							Visible: false
 				Container@TEMPLATE_NONEDITABLE_SPECTATOR:
 					X: 5
 					Width: 475
@@ -338,6 +352,14 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Spectator
 							Align: Center
 							Font: Bold
+						Image@STATUS_IMAGE:
+							X: 527
+							Y: 4
+							Width: 20
+							Height: 20
+							ImageCollection: checkbox-bits
+							ImageName: checked
+							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:
 					X: 5
 					Width: 475

--- a/mods/ra/chrome/lobby-players.yaml
+++ b/mods/ra/chrome/lobby-players.yaml
@@ -291,6 +291,20 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Spectator
 							Align: Center
 							Font: Bold
+						Checkbox@STATUS_CHECKBOX:
+							X: 525
+							Y: 2
+							Width: 20
+							Height: 20
+							Visible: false
+						Image@STATUS_IMAGE:
+							X: 527
+							Y: 4
+							Width: 20
+							Height: 20
+							ImageCollection: checkbox-bits
+							ImageName: checked
+							Visible: false
 				Container@TEMPLATE_NONEDITABLE_SPECTATOR:
 					X: 5
 					Width: 475
@@ -338,6 +352,14 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Spectator
 							Align: Center
 							Font: Bold
+						Image@STATUS_IMAGE:
+							X: 527
+							Y: 4
+							Width: 20
+							Height: 20
+							ImageCollection: checkbox-bits
+							ImageName: checked
+							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:
 					X: 5
 					Width: 475


### PR DESCRIPTION
Feature #10416

An admin is now able to spectate a game and is provided with a ready checkbox.
![ra](https://cloud.githubusercontent.com/assets/2963387/16540205/fc82fbc2-4053-11e6-8d19-64a44798b561.png)

Game does not start until the spectating admin is ready.
![spec_admin_not_ready](https://cloud.githubusercontent.com/assets/2963387/16540204/fade3e94-4053-11e6-9ca2-2f4329ac30ce.png)

An admin spectating still has the start game option.
![two_spectators](https://cloud.githubusercontent.com/assets/2963387/16540206/fe09b4ea-4053-11e6-8485-4009549c0d56.png)

![cnc](https://cloud.githubusercontent.com/assets/2963387/16540211/21c6033e-4054-11e6-8af1-2cf1e4d1aaae.png)
