### PR TITLE
Refine the support power speech notifications setup

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -127,10 +127,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				var notification = self.Owner.IsAlliedWith(self.World.RenderPlayer) ? Info.LaunchSound : Info.IncomingSound;
-				Game.Sound.Play(notification);
-				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
-					Info.IncomingSpeechNotification, self.Owner.Faction.InternalName);
+				var isAllied = self.Owner.IsAlliedWith(self.World.RenderPlayer);
+				Game.Sound.Play(isAllied ? Info.LaunchSound : Info.IncomingSound);
+
+				var speech = isAllied ? Info.LaunchSpeechNotification : Info.IncomingSpeechNotification;
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", speech, self.Owner.Faction.InternalName);
 
 				Actor distanceTestActor = null;
 				for (var i = -info.SquadSize / 2; i <= info.SquadSize / 2; i++)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -94,7 +94,11 @@ namespace OpenRA.Mods.Common.Traits
 			base.Activate(self, order, manager);
 
 			if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
+			{
 				Game.Sound.Play(Info.LaunchSound);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
+					Info.LaunchSpeechNotification, self.Owner.Faction.InternalName);
+			}
 			else
 			{
 				Game.Sound.Play(Info.IncomingSound);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -38,7 +38,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string SelectTargetSound = null;
 		public readonly string SelectTargetSpeechNotification = null;
 		public readonly string InsufficientPowerSound = null;
+		public readonly string InsufficientPowerSpeechNotification = null;
 		public readonly string LaunchSound = null;
+		public readonly string LaunchSpeechNotification = null;
 		public readonly string IncomingSound = null;
 		public readonly string IncomingSpeechNotification = null;
 

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -114,7 +114,11 @@ namespace OpenRA.Mods.Common.Widgets
 		protected void ClickIcon(SupportPowerIcon clicked)
 		{
 			if (!clicked.Power.Active)
+			{
 				Game.Sound.PlayToPlayer(spm.Self.Owner, clicked.Power.Info.InsufficientPowerSound);
+				Game.Sound.PlayNotification(spm.Self.World.Map.Rules, spm.Self.Owner, "Speech",
+					clicked.Power.Info.InsufficientPowerSpeechNotification, spm.Self.Owner.Faction.InternalName);
+			}
 			else
 				clicked.Power.Target();
 		}

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -75,6 +75,8 @@ namespace OpenRA.Mods.RA.Traits
 			self.World.AddFrameEndTask(w =>
 			{
 				Game.Sound.PlayToPlayer(self.Owner, Info.LaunchSound);
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
+					Info.LaunchSpeechNotification, self.Owner.Faction.InternalName);
 
 				w.Add(new SatelliteLaunch(self, info));
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/ParatroopersPower.cs
@@ -153,8 +153,11 @@ namespace OpenRA.Mods.RA.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				var notification = self.Owner.IsAlliedWith(self.World.RenderPlayer) ? Info.LaunchSound : Info.IncomingSound;
-				Game.Sound.Play(notification);
+				var isAllied = self.Owner.IsAlliedWith(self.World.RenderPlayer);
+				Game.Sound.Play(isAllied ? Info.LaunchSound : Info.IncomingSound);
+
+				var speech = isAllied ? Info.LaunchSpeechNotification : Info.IncomingSpeechNotification;
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", speech, self.Owner.Faction.InternalName);
 
 				Actor distanceTestActor = null;
 

--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -49,20 +49,38 @@ Speech:
 
 Sounds:
 	Notifications:
+		Appear: appear1
 		Beacon: bleep2
-		CashTickDown:tone16
-		CashTickUp:tone15
+		Beepy2: beepy2
+		Beepy3: beepy3
+		Beepy6: beepy6
+		CashTickDown: tone16
+		CashTickUp: tone15
 		ChatLine: scold1
 		ClickDisabledSound: scold2
 		ClickSound: button
+		Cloak: trans1
+		Clock: clock1
+		Construction: constru2
+		Country1: country1
+		Country4: country4
 		DisablePower: bleep11
 		EnablePower: bleep12
+		HeavyDoor: hvydoor1
+		Keystroke: keystrok
 		LevelUp: text2
+		NewTarget: newtarg1
 		RadarDown: powrdn1
 		RadarUp: comcntr1
+		Sell: cashturn
 		SignalFlare: flare1
 		SignalFlareEast: flaree1
 		SignalFlareNorth: flaren1
 		SignalFlareSouth: flares1
 		SignalFlareWest: flarew1
 		TabClick: button
+		Target1: target1
+		Target2: target2
+		Target3: target3
+		Text: text2
+		World: world2

--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -3,49 +3,49 @@ Speech:
 		gdi: gdi
 		nod: nod
 	Notifications:
-		Repairing: repair1
-		LowPower: lopower1
-		SilosNeeded: silos1
-		PrimaryBuildingSelected: pribldg1
-		BuildingCannotPlaceAudio: deploy1
-		NewOptions: newopt1
-		Win: accom1
-		Lose: fail1
 		BaseAttack: baseatk1
+		Building: bldging1
+		BuildingCannotPlaceAudio: deploy1
+		BuildingCaptured: capt1
+		BuildingLost: strclost
+		Cancelled: cancel1
+		CivilianBuildingCaptured: civcapt1
+		CivilianKilled: civdead1
+		ConstructionComplete: constru1
 		HarvesterAttack:
 		Leave: batlcon1
-		StartGame:
-		UnitReady: unitredy
+		Lose: fail1
+		LowPower: lopower1
+		NewOptions: newopt1
 		NoBuild: nobuild1
-		Training: bldging1
 		OnHold: onhold1
-		Cancelled: cancel1
-		Building: bldging1
-		ConstructionComplete: constru1
+		PrimaryBuildingSelected: pribldg1
 		Reinforce: reinfor1
+		Repairing: repair1
+		SilosNeeded: silos1
+		StartGame:
+		Training: bldging1
 		UnitLost: unitlost
-		BuildingLost: strclost
-		CivilianKilled: civdead1
-		BuildingCaptured: capt1
-		CivilianBuildingCaptured: civcapt1
-	DisablePrefixes: Repairing, LowPower, SilosNeeded, PrimaryBuildingSelected, BuildingCannotPlaceAudio, NewOptions, AbilityInsufficientPower, Win, Lose, BaseAttack, HarvesterAttack, Leave, UnitReady, NoBuild, Training, OnHold, Cancelled, Building, ConstructionComplete, Reinforce, UnitLost, BuildingLost, CivilianKilled, CivilianBuildingCaptured
+		UnitReady: unitredy
+		Win: accom1
+	DisablePrefixes: AbilityInsufficientPower, BaseAttack, Building, BuildingCannotPlaceAudio, BuildingLost, Cancelled, CivilianBuildingCaptured, CivilianKilled, ConstructionComplete, HarvesterAttack, Leave, Lose, LowPower, NewOptions, NoBuild, OnHold, PrimaryBuildingSelected, Reinforce, Repairing, SilosNeeded, Training, UnitLost, UnitReady, Win
 
 Sounds:
 	Notifications:
-		RadarUp: comcntr1
-		RadarDown: powrdn1
-		CashTickUp:tone15
+		Beacon: bleep2
 		CashTickDown:tone16
-		LevelUp: text2
+		CashTickUp:tone15
+		ChatLine: scold1
+		ClickDisabledSound: scold2
+		ClickSound: button
 		DisablePower: bleep11
 		EnablePower: bleep12
-		ChatLine: scold1
-		TabClick: button
-		ClickSound: button
-		ClickDisabledSound: scold2
-		Beacon: bleep2
+		LevelUp: text2
+		RadarDown: powrdn1
+		RadarUp: comcntr1
 		SignalFlare: flare1
 		SignalFlareEast: flaree1
 		SignalFlareNorth: flaren1
 		SignalFlareSouth: flares1
 		SignalFlareWest: flarew1
+		TabClick: button

--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -3,32 +3,49 @@ Speech:
 		gdi: gdi
 		nod: nod
 	Notifications:
+		AirstrikeReady: airredy1
 		BaseAttack: baseatk1
 		Building: bldging1
 		BuildingCannotPlaceAudio: deploy1
 		BuildingCaptured: capt1
+		BuildingInProgress: bldg1
 		BuildingLost: strclost
 		Cancelled: cancel1
 		CivilianBuildingCaptured: civcapt1
 		CivilianKilled: civdead1
 		ConstructionComplete: constru1
+		EnemyUnitsApproaching: enmyunit
+		EnemyStructureDestroyed: estrucx
+		EnemyPlanesApproaching: enemya
 		HarvesterAttack:
+		InsufficientPower: nopower1
+		IonCannonCharging: ionchrg1
+		IonCannonReady: ionredy1
 		Leave: batlcon1
 		Lose: fail1
 		LowPower: lopower1
+		MissionAccomplished: accom1
+		MissionFailed: fail1
 		NewOptions: newopt1
 		NoBuild: nobuild1
+		NodStructureDestroyed: nstruc1
+		NotReady: noredy1
+		NuclearWarheadApproaching: nuke1
+		NuclearWeaponAvailable: nukavail
+		NuclearWeaponLaunched: nuklnch1
 		OnHold: onhold1
 		PrimaryBuildingSelected: pribldg1
 		Reinforce: reinfor1
 		Repairing: repair1
+		SelectTarget: select1
 		SilosNeeded: silos1
 		StartGame:
 		Training: bldging1
+		UnitDestroyed: dead1
 		UnitLost: unitlost
 		UnitReady: unitredy
 		Win: accom1
-	DisablePrefixes: AbilityInsufficientPower, BaseAttack, Building, BuildingCannotPlaceAudio, BuildingLost, Cancelled, CivilianBuildingCaptured, CivilianKilled, ConstructionComplete, HarvesterAttack, Leave, Lose, LowPower, NewOptions, NoBuild, OnHold, PrimaryBuildingSelected, Reinforce, Repairing, SilosNeeded, Training, UnitLost, UnitReady, Win
+	DisablePrefixes: AbilityInsufficientPower, BaseAttack, Building, BuildingCannotPlaceAudio, BuildingInProgress, BuildingLost, Cancelled, CivilianBuildingCaptured, CivilianKilled, ConstructionComplete, EnemyUnitsApproaching, EnemyStructureDestroyed, EnemyPlanesApproaching, HarvesterAttack, InsufficientPower, IonCannonCharging, IonCannonReady, Leave, Lose, LowPower, MissionAccomplished, MissionFailed, NewOptions, NoBuild, NodStructureDestroyed, NotReady, NuclearWarheadApproaching, NuclearWeaponAvailable, NuclearWeaponLaunched, OnHold, PrimaryBuildingSelected, Reinforce, Repairing, SelectTarget, SilosNeeded, Training, UnitLost, UnitReady, Win
 
 Sounds:
 	Notifications:

--- a/mods/cnc/maps/cnc64gdi01/rules.yaml
+++ b/mods/cnc/maps/cnc64gdi01/rules.yaml
@@ -57,7 +57,7 @@ airstrike.proxy:
 		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
 		EndChargeSpeechNotification: AirstrikeReady
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopower1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
 		IncomingSpeechNotification: EnemyPlanesApproaching
 		UnitType: a10
 		DisplayBeacon: True

--- a/mods/cnc/maps/cnc64gdi01/rules.yaml
+++ b/mods/cnc/maps/cnc64gdi01/rules.yaml
@@ -55,10 +55,10 @@ airstrike.proxy:
 		QuantizedFacings: 8
 		Description: Air Strike
 		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
-		EndChargeSound: airredy1.aud
-		SelectTargetSound: select1.aud
+		EndChargeSpeechNotification: AirstrikeReady
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopower1.aud
-		IncomingSound: enemya.aud
+		IncomingSpeechNotification: EnemyPlanesApproaching
 		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -493,7 +493,7 @@ HQ:
 		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
 		EndChargeSpeechNotification: AirstrikeReady
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopower1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
 		IncomingSpeechNotification: EnemyPlanesApproaching
 		UnitType: a10
 		DisplayBeacon: True
@@ -585,7 +585,7 @@ EYE:
 		EndChargeSpeechNotification: IonCannonReady
 		LaunchSound: ion1.aud
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopower1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
 		DisplayRadarPing: True
 		CameraActor: camera.small
 	SupportPowerChargeBar:
@@ -632,8 +632,8 @@ TMPL:
 		LongDesc: Launch a tactical nuclear warhead.\nApplies heavy damage over a large area.
 		EndChargeSpeechNotification: NuclearWeaponAvailable
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopower1.aud
-		LaunchSound: nuklnch1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
+		LaunchSpeechNotification: NuclearWeaponLaunched
 		IncomingSpeechNotification: NuclearWarheadApproaching
 		MissileWeapon: atomic
 		DisplayBeacon: True

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -491,10 +491,10 @@ HQ:
 		QuantizedFacings: 8
 		Description: Air Strike
 		LongDesc: Deploy an aerial napalm strike.\nBurns buildings and infantry along a line.
-		EndChargeSound: airredy1.aud
-		SelectTargetSound: select1.aud
+		EndChargeSpeechNotification: AirstrikeReady
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopower1.aud
-		IncomingSound: enemya.aud
+		IncomingSpeechNotification: EnemyPlanesApproaching
 		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
@@ -581,10 +581,10 @@ EYE:
 		ChargeTime: 180
 		Description: Ion Cannon
 		LongDesc: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
-		BeginChargeSound: ionchrg1.aud
-		EndChargeSound: ionredy1.aud
+		BeginChargeSpeechNotification: IonCannonCharging
+		EndChargeSpeechNotification: IonCannonReady
 		LaunchSound: ion1.aud
-		SelectTargetSound: select1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopower1.aud
 		DisplayRadarPing: True
 		CameraActor: camera.small
@@ -631,11 +631,11 @@ TMPL:
 		Description: Nuclear Strike
 		LongDesc: Launch a tactical nuclear warhead.\nApplies heavy damage over a large area.
 		BeginChargeSound:
-		EndChargeSound: nukavail.aud
-		SelectTargetSound: select1.aud
+		EndChargeSpeechNotification: NuclearWeaponAvailable
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopower1.aud
 		LaunchSound: nuklnch1.aud
-		IncomingSound: nuke1.aud
+		IncomingSpeechNotification: NuclearWarheadApproaching
 		MissileWeapon: atomic
 		DisplayBeacon: True
 		BeaconPoster: atomic

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -630,7 +630,6 @@ TMPL:
 		ChargeTime: 300
 		Description: Nuclear Strike
 		LongDesc: Launch a tactical nuclear warhead.\nApplies heavy damage over a large area.
-		BeginChargeSound:
 		EndChargeSpeechNotification: NuclearWeaponAvailable
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopower1.aud

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -280,7 +280,7 @@ powerproxy.parabombs:
 		OneShot: true
 		AllowMultiple: true
 		UnitType: badr.bomber
-		SelectTargetSound: slcttgt1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		QuantizedFacings: 8
 		DisplayBeacon: True
 		BeaconPoster: pbmbicon
@@ -293,8 +293,8 @@ powerproxy.sonarpulse:
 		Description: Sonar Pulse
 		LongDesc: Reveals all submarines in the vicinity for a \nshort time.
 		ChargeTime: 30
-		EndChargeSound: pulse1.aud
-		SelectTargetSound: slcttgt1.aud
+		EndChargeSpeechNotification: SonarPulseReady
+		SelectTargetSpeechNotification: SelectTarget
 		Actor: sonar
 		LifeTime: 250
 		DeploySound: sonpulse.aud
@@ -308,7 +308,7 @@ powerproxy.paratroopers:
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
 		DropItems: E1,E1,E1,E3,E3
-		SelectTargetSound: slcttgt1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		AllowImpassableCells: false
 		QuantizedFacings: 8
 		CameraActor: camera.paradrop

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -28,7 +28,7 @@ MSLO:
 		BeginChargeSpeechNotification: AbombPrepping
 		EndChargeSpeechNotification: AbombReady
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopowr1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
 		IncomingSpeechNotification: AbombLaunchDetected
 		MissileWeapon: atomic
 		SpawnOffset: 0,427,0
@@ -310,7 +310,7 @@ IRON:
 		LongDesc: Makes a group of units invulnerable\nfor 20 seconds.
 		Duration: 500
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopowr1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: IronCurtainCharging
 		EndChargeSpeechNotification: IronCurtainReady
 		DisplayRadarPing: True
@@ -363,7 +363,7 @@ PDOX:
 		Description: Chronoshift
 		LongDesc: Teleports a group of units across\nthe map for 20 seconds.
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopowr1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
 		EndChargeSpeechNotification: ChronosphereReady
 		Duration: 20
@@ -377,7 +377,7 @@ PDOX:
 		Description: Advanced Chronoshift
 		LongDesc: Teleports a large group of units across\nthe map for 20 seconds.
 		SelectTargetSpeechNotification: SelectTarget
-		InsufficientPowerSound: nopowr1.aud
+		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
 		EndChargeSpeechNotification: ChronosphereReady
 		Duration: 20
@@ -768,7 +768,7 @@ ATEK:
 		Description: GPS Satellite
 		LongDesc: Reveals map terrain and provides tactical\ninformation. Requires power and active radar.
 		RevealDelay: 15
-		LaunchSound: satlnch1.aud
+		LaunchSpeechNotification: SatelliteLaunched
 		DisplayTimer: True
 	SupportPowerChargeBar:
 	RequiresPower:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -30,7 +30,6 @@ MSLO:
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopowr1.aud
 		IncomingSpeechNotification: AbombLaunchDetected
-		LaunchSound:
 		MissileWeapon: atomic
 		SpawnOffset: 0,427,0
 		DisplayTimer: True

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -25,11 +25,11 @@ MSLO:
 		ChargeTime: 540
 		Description: Atom Bomb
 		LongDesc: Launches a devastating atomic bomb\nat a target location.
-		BeginChargeSound: aprep1.aud
-		EndChargeSound: aready1.aud
-		SelectTargetSound: slcttgt1.aud
+		BeginChargeSpeechNotification: AbombPrepping
+		EndChargeSpeechNotification: AbombReady
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopowr1.aud
-		IncomingSound: alaunch1.aud
+		IncomingSpeechNotification: AbombLaunchDetected
 		LaunchSound:
 		MissileWeapon: atomic
 		SpawnOffset: 0,427,0
@@ -310,10 +310,10 @@ IRON:
 		Description: Invulnerability
 		LongDesc: Makes a group of units invulnerable\nfor 20 seconds.
 		Duration: 500
-		SelectTargetSound: slcttgt1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopowr1.aud
-		BeginChargeSound: ironchg1.aud
-		EndChargeSound: ironrdy1.aud
+		BeginChargeSpeechNotification: IronCurtainCharging
+		EndChargeSpeechNotification: IronCurtainReady
 		DisplayRadarPing: True
 		Upgrades: invulnerability
 	SupportPowerChargeBar:
@@ -363,10 +363,10 @@ PDOX:
 		ChargeTime: 120
 		Description: Chronoshift
 		LongDesc: Teleports a group of units across\nthe map for 20 seconds.
-		SelectTargetSound: slcttgt1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopowr1.aud
-		BeginChargeSound: chrochr1.aud
-		EndChargeSound: chrordy1.aud
+		BeginChargeSpeechNotification: ChronosphereCharging
+		EndChargeSpeechNotification: ChronosphereReady
 		Duration: 20
 		KillCargo: yes
 		DisplayRadarPing: True
@@ -377,10 +377,10 @@ PDOX:
 		ChargeTime: 120
 		Description: Advanced Chronoshift
 		LongDesc: Teleports a large group of units across\nthe map for 20 seconds.
-		SelectTargetSound: slcttgt1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSound: nopowr1.aud
-		BeginChargeSound: chrochr1.aud
-		EndChargeSound: chrordy1.aud
+		BeginChargeSpeechNotification: ChronosphereCharging
+		EndChargeSpeechNotification: ChronosphereReady
 		Duration: 20
 		KillCargo: yes
 		DisplayRadarPing: True
@@ -1175,8 +1175,8 @@ AFLD:
 		ChargeTime: 180
 		Description: Spy Plane
 		LongDesc: Reveals an area of the map\nand cloaked enemy units.
-		SelectTargetSound: slcttgt1.aud
-		EndChargeSound: spypln1.aud
+		SelectTargetSpeechNotification: SelectTarget
+		EndChargeSpeechNotification: SpyPlaneReady
 		CameraActor: camera.spyplane
 		CameraRemoveDelay: 150
 		UnitType: u2
@@ -1191,7 +1191,7 @@ AFLD:
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
 		DropItems: E1,E1,E1,E3,E3
-		SelectTargetSound: slcttgt1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		AllowImpassableCells: false
 		QuantizedFacings: 8
 		CameraActor: camera.paradrop
@@ -1204,7 +1204,7 @@ AFLD:
 		ChargeTime: 360
 		Description: Parabombs
 		LongDesc: A squad of Badgers drops parachuted\nbombs on your target.
-		SelectTargetSound: slcttgt1.aud
+		SelectTargetSpeechNotification: SelectTarget
 		CameraActor: camera
 		CameraRemoveDelay: 150
 		UnitType: badr.bomber


### PR DESCRIPTION
- Cleans and completes the `notifications.yaml` file of cnc
- Removes empty fields (which default to `null` anyway)
- Adds support for `InsufficientPower`\- and `LaunchSpeechNotifications`
- Replaces references to filenames by references to the speech notifications

Followup of #11483.
