### PR TITLE
FileSystem.Mount: Use TryGetValue instead of directly accessing a value

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -109,7 +109,12 @@ namespace OpenRA.FileSystem
 				if (name.StartsWith("$"))
 				{
 					name = name.Substring(1);
-					package = ModMetadata.AllMods[name].Package;
+
+					ModMetadata mod;
+					if (!ModMetadata.AllMods.TryGetValue(name, out mod))
+						throw new InvalidOperationException("Could not load mod '{0}'. Available mods: {1}".F(name, ModMetadata.AllMods.Keys.JoinWith(", ")));
+
+					package = mod.Package;
 					modPackages.Add(package);
 				}
 				else


### PR DESCRIPTION
```
Exception of type `System.InvalidOperationException`: Could not load mod 'foo'. Available mods: all, cnc, d2k, modchooser, ra, ts, ra2, pc
  at OpenRA.FileSystem.FileSystem.Mount (System.String name, System.String explicitName) [0x00074] in /Users/thill/projects/play/openra/OpenRA.Game//FileSystem/FileSystem.cs:115
```

This will help to speed up diagnosing issues like https://github.com/OpenRA/ra2/issues/243#issuecomment-230131995 in the future.
