### PR TITLE
Fixed undisposed file and memory streams in ZipFile and surroundings

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -137,6 +137,9 @@ namespace OpenRA.FileSystem
 		{
 			if (pkg != null)
 				pkg.Close();
+
+			if (pkgStream != null)
+				pkgStream.Dispose();
 		}
 	}
 

--- a/OpenRA.Game/ModMetadata.cs
+++ b/OpenRA.Game/ModMetadata.cs
@@ -47,7 +47,8 @@ namespace OpenRA
 					{
 						try
 						{
-							package = new ZipFile(File.OpenRead(pair.Second), pair.Second);
+							using (var fileStream = File.OpenRead(pair.Second))
+								package = new ZipFile(fileStream, pair.Second);
 						}
 						catch
 						{


### PR DESCRIPTION
This tries to fix the defects from https://github.com/OpenRA/OpenRA/pull/11482, which were detected by Coverity.
