### PR TITLE
Don't add duplicate facing entries when modifying the DeathActorInit in Turreted.cs

### DIFF
--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -172,7 +172,8 @@ namespace OpenRA.Mods.Common.Traits
 				init.Add(facings);
 			}
 
-			facings.Value(self.World).Add(Name, TurretFacing);
+			if (!facings.Value(self.World).ContainsKey(Name))
+				facings.Value(self.World).Add(Name, TurretFacing);
 		}
 
 		void IActorPreviewInitModifier.ModifyActorPreviewInit(Actor self, TypeDictionary inits)


### PR DESCRIPTION
Causes a crash when having multiple `SpawnActorOnDeath` traits on a single turreted actor.
