### PR TITLE
Expand SelfHealing.

### DIFF
--- a/OpenRA.Mods.Common/Traits/SelfHealing.cs
+++ b/OpenRA.Mods.Common/Traits/SelfHealing.cs
@@ -16,10 +16,18 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to actors which should be able to regenerate their health points.")]
 	class SelfHealingInfo : UpgradableTraitInfo, Requires<HealthInfo>
 	{
+		[Desc("Absolute amount of health points added in each step.")]
 		public readonly int Step = 5;
+
+		[Desc("Relative percentages of health added in each step.",
+			"When both values are defined, their summary will be applied.")]
+		public readonly int PercentageStep = 0;
+
 		public readonly int Delay = 5;
+
 		[Desc("Heal if current health is below this percentage of full health.")]
 		public readonly int HealIfBelow = 50;
+
 		public readonly int DamageCooldown = 0;
 
 		public override object Create(ActorInitializer init) { return new SelfHealing(init.Self, this); }
@@ -55,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (--ticks <= 0)
 			{
 				ticks = Info.Delay;
-				self.InflictDamage(self, new Damage(-Info.Step));
+				self.InflictDamage(self, new Damage(-(Info.Step + Info.PercentageStep * health.MaxHP / 100)));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/SelfHealing.cs
+++ b/OpenRA.Mods.Common/Traits/SelfHealing.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -29,6 +30,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int HealIfBelow = 50;
 
 		public readonly int DamageCooldown = 0;
+
+		[Desc("Apply the selfhealing using these damagetypes.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
 
 		public override object Create(ActorInitializer init) { return new SelfHealing(init.Self, this); }
 	}
@@ -63,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (--ticks <= 0)
 			{
 				ticks = Info.Delay;
-				self.InflictDamage(self, new Damage(-(Info.Step + Info.PercentageStep * health.MaxHP / 100)));
+				self.InflictDamage(self, new Damage(-(Info.Step + Info.PercentageStep * health.MaxHP / 100), Info.DamageTypes));
 			}
 		}
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -38,7 +38,8 @@
 		UpgradeTypes: inaccuracy
 		Modifier: 90, 80, 70, 50
 	SelfHealing@ELITE:
-		Step: 2
+		Step: 0
+		PercentageStep: 4
 		Delay: 125
 		HealIfBelow: 100
 		DamageCooldown: 125


### PR DESCRIPTION
Adds a percentage healing option and damagetypes.
Depends on #11513 (also can be used as a justification of that PR).

Includes testcase.
