### PR TITLE
Add timestamp to exception.log

### DIFF
--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -62,6 +62,7 @@ namespace OpenRA
 				Log.Write("exception", "on map {0} ({1} by {2}).", map.Uid, map.Title, map.Author);
 			}
 
+			Log.Write("exception", "Date: {0:u}", DateTime.UtcNow);
 			Log.Write("exception", "Operating System: {0} ({1})", Platform.CurrentPlatform, Environment.OSVersion);
 			Log.Write("exception", "Runtime Version: {0}", Platform.RuntimeVersion);
 			var rpt = BuildExceptionReport(e).ToString();


### PR DESCRIPTION
Came up after questioning if a pasted crash log was dated or not. We're almost always able to look at the file write time but this hopefully doesn't hurt.

Sample:

```
Red Alert Mod at Version {DEV_VERSION}
on map 065791667982ccb50a4c3acdd6c752430db9a4a8 (Behind The Veil by Kyrylo Silin).
Date: 2016-07-06 19:48:15Z
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `OpenRA.Mods.Common.Commands.DevCommands+DevException`: Exception of type 'OpenRA.Mods.Common.Commands.DevCommands+DevException' was thrown.
   at OpenRA.Mods.Common.Commands.DevCommands.InvokeCommand(String name, String arg)
   at OpenRA.Mods.Common.Commands.ChatCommands.OnChat(String playername, String message)
...
```
