### PR TITLE
Fix a wrong check in LeavesTrails.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -98,8 +98,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if ((isMoving && !Info.TrailWhileMoving) || (!isMoving && !Info.TrailWhileStationary))
 				return;
 
-			if (isMoving && wasStationary)
+			if (isMoving == wasStationary)
+			{
 				cachedInterval = Info.StartDelay;
+				ticks = 0;
+			}
 
 			if (++ticks >= cachedInterval)
 			{
@@ -125,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				cachedFacing = facing != null ? facing.Facing : 0;
 				ticks = 0;
 
-				cachedInterval = isMoving && !wasStationary ? Info.MovingInterval : Info.StationaryInterval;
+				cachedInterval = isMoving ? Info.MovingInterval : Info.StationaryInterval;
 			}
 		}
 


### PR DESCRIPTION
![dfj](https://cloud.githubusercontent.com/assets/1136302/16673045/f0ed4492-44aa-11e6-9395-214524cf8ecb.gif)

Fixes #11595.

Checking for WasStationary there was redundant.

The bug is caused by the WasStationary check - if StartDelay is 0 then it will imminently spawn a new trail in the starting position and will load the stationary delay for moving actors.
