### PR TITLE
Fix input reset crash

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -450,21 +450,34 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "CycleStatusBarsKey", "Cycle status bars display" },
 					{ "TogglePixelDoubleKey", "Toggle pixel doubling" },
 					{ "ToggleMuteKey", "Toggle audio mute" },
-					{ "TogglePlayerStanceColorsKey", "Toggle player stance colors" },
-
-					{ "MapScrollUp", "Map scroll up" },
-					{ "MapScrollDown", "Map scroll down" },
-					{ "MapScrollLeft", "Map scroll left" },
-					{ "MapScrollRight", "Map scroll right" },
-
-					{ "MapPushTop", "Map push to top" },
-					{ "MapPushBottom", "Map push to bottom" },
-					{ "MapPushLeftEdge", "Map push to left edge" },
-					{ "MapPushRightEdge", "Map push to right edge" }
+					{ "TogglePlayerStanceColorsKey", "Toggle player stance colors" }
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);
 				header.Get<LabelWidget>("LABEL").GetText = () => "Game Commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
+			}
+
+			// Viewport
+			{
+				var hotkeys = new Dictionary<string, string>()
+				{
+					{ "MapScrollUp", "Scroll up" },
+					{ "MapScrollDown", "Scroll down" },
+					{ "MapScrollLeft", "Scroll left" },
+					{ "MapScrollRight", "Scroll right" },
+
+					{ "MapPushTop", "Jump to top edge" },
+					{ "MapPushBottom", "Jump to bottom edge" },
+					{ "MapPushLeftEdge", "Jump to left edge" },
+					{ "MapPushRightEdge", "Jump to right edge" }
+				};
+
+				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);
+				header.Get<LabelWidget>("LABEL").GetText = () => "Viewport Commands";
 				hotkeyList.AddChild(header);
 
 				foreach (var kv in hotkeys)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -473,7 +473,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "MapPushTop", "Jump to top edge" },
 					{ "MapPushBottom", "Jump to bottom edge" },
 					{ "MapPushLeftEdge", "Jump to left edge" },
-					{ "MapPushRightEdge", "Jump to right edge" }
+					{ "MapPushRightEdge", "Jump to right edge" },
+
+					{ "ViewPortBookmarkSaveSlot1", "Record bookmark #1" },
+					{ "ViewPortBookmarkUseSlot1", "Jump to bookmark #1" },
+					{ "ViewPortBookmarkSaveSlot2", "Record bookmark #2" },
+					{ "ViewPortBookmarkUseSlot2", "Jump to bookmark #2" },
+					{ "ViewPortBookmarkSaveSlot3", "Record bookmark #3" },
+					{ "ViewPortBookmarkUseSlot3", "Jump to bookmark #3" },
+					{ "ViewPortBookmarkSaveSlot4", "Record bookmark #4" },
+					{ "ViewPortBookmarkUseSlot4", "Jump to bookmark #4" }
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);


### PR DESCRIPTION
#11130 introduced a crash when pressing the reset button in the input settings tab.

This fixes the crash by adding UI bindings for those keys and splits out a new hotkey section to help with organization.
