### PR TITLE
Order landed aircraft to take off if their reservation is cancelled.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -271,6 +271,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			reservation.Dispose();
 			reservation = null;
+			if (self.World.Map.DistanceAboveTerrain(CenterPosition).Length <= Info.LandAltitude.Length)
+				self.QueueActivity(new TakeOff(self));
 		}
 
 		public bool AircraftCanEnter(Actor a)


### PR DESCRIPTION
Aircraft will now take off when their airfield/helipad is sold or destroyed from under them.

Fixes #11610.
