### PR TITLE
Fixed a potential NRE in DownloadPackageLogic.ShowDownloadDialog

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						foreach (var kv in download.Extract)
 						{
 							var entry = z.GetEntry(kv.Value);
-							if (!entry.IsFile)
+							if (entry == null || !entry.IsFile)
 								continue;
 
 							onExtractProgress("Extracting " + entry.Name);


### PR DESCRIPTION
This fixes a possible crash introduced in https://github.com/OpenRA/OpenRA/pull/11375 which was detected by Coverity.
