### PR TITLE
Fixed palettes in the assets browser when the shellmap is disabled

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -545,11 +545,11 @@ namespace OpenRA
 						}
 						else if (orderManager.NetFrameNumber == 0)
 							orderManager.LastTickTime = RunTime;
-
-						Sync.CheckSyncUnchanged(world, () => world.TickRender(worldRenderer));
 					}
 					else
 						PerfHistory.Tick();
+
+					Sync.CheckSyncUnchanged(world, () => world.TickRender(worldRenderer));
 				}
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/10762.
