### PR TITLE
Add curl as dependency for linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,7 @@ Debian/Ubuntu
 * libsdl2-2.0-0
 * xdg-utils
 * zenity
+* curl
 
 openSUSE
 --------
@@ -54,6 +55,7 @@ openSUSE
 * lua51
 * xdg-utils
 * zenity
+* curl
 
 Gentoo
 ------
@@ -69,3 +71,4 @@ Gentoo
 * dev-lang/lua-5.1.5
 * x11-misc/xdg-utils
 * gnome-extra/zenity
+* net-misc/curl


### PR DESCRIPTION
`make dependencies` fails if you don't have curl installed:
`./thirdparty/fetch-thirdparty-deps.sh: 105: ./thirdparty/fetch-thirdparty-deps.sh: curl: not found`

So I guess curl is a dependency. I already added it to the list on [the Compiling page on the wiki.](https://github.com/OpenRA/OpenRA/wiki/Compiling). This adds the package names to INSTALL.md as well.
