### PR TITLE
Fix the attack-move cursor appearing for units which can't attack-move

### DIFF
--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -100,10 +100,10 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformAttackMove()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<AttackMoveInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>())
+				.Where(a => a.Owner == world.LocalPlayer)
 				.ToArray();
 
-			if (actors.Any())
+			if (actors.Any(a => a.Info.HasTraitInfo<AttackMoveInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>()))
 				world.OrderGenerator = new GenericSelectTarget(actors,
 					"AttackMove", "attackmove", Game.Settings.Game.MouseButtonPreference.Action);
 
@@ -183,9 +183,9 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformGuard()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<GuardInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());
+				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer);
 
-			if (actors.Any())
+			if (actors.Any(a => a.Info.HasTraitInfo<GuardInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>()))
 				world.OrderGenerator = new GuardOrderGenerator(actors,
 					"Guard", "guard", Game.Settings.Game.MouseButtonPreference.Action);
 

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformAttackMove()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer)
+				.Where(a => a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<AttackMoveInfo>())
 				.ToArray();
 
 			if (actors.Any())

--- a/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldCommandWidget.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformAttackMove()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<AttackMoveInfo>())
+				.Where(a => a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<AttackMoveInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>())
 				.ToArray();
 
 			if (actors.Any())
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.Widgets
 		bool PerformGuard()
 		{
 			var actors = world.Selection.Actors
-				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<GuardInfo>());
+				.Where(a => !a.Disposed && a.Owner == world.LocalPlayer && a.Info.HasTraitInfo<GuardInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());
 
 			if (actors.Any())
 				world.OrderGenerator = new GuardOrderGenerator(actors,


### PR DESCRIPTION
Easily noticeable with tanya on the higher difficulties.
Fixes #9383.
