### PR TITLE
Changed Basic and Combat observer stats to include Assets Destroyed/L…

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -200,8 +200,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
 			if (stats == null) return template;
-			template.Get<LabelWidget>("KILLS_COST").GetText = () => "$" + stats.KillsCost;
-			template.Get<LabelWidget>("DEATHS_COST").GetText = () => "$" + stats.DeathsCost;
+			template.Get<LabelWidget>("ASSETS_DESTROYED").GetText = () => "$" + stats.KillsCost;
+			template.Get<LabelWidget>("ASSETS_LOST").GetText = () => "$" + stats.DeathsCost;
 			template.Get<LabelWidget>("UNITS_KILLED").GetText = () => stats.UnitsKilled.ToString();
 			template.Get<LabelWidget>("UNITS_DEAD").GetText = () => stats.UnitsDead.ToString();
 			template.Get<LabelWidget>("BUILDINGS_KILLED").GetText = () => stats.BuildingsKilled.ToString();
@@ -271,7 +271,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (stats == null) return template;
 			template.Get<LabelWidget>("KILLS").GetText = () => (stats.UnitsKilled + stats.BuildingsKilled).ToString();
 			template.Get<LabelWidget>("DEATHS").GetText = () => (stats.UnitsDead + stats.BuildingsDead).ToString();
-			template.Get<LabelWidget>("KD_RATIO").GetText = () => KillDeathRatio(stats.UnitsKilled + stats.BuildingsKilled, stats.UnitsDead + stats.BuildingsDead);
+			template.Get<LabelWidget>("ASSETS_DESTROYED").GetText = () => "$" + stats.KillsCost;
+			template.Get<LabelWidget>("ASSETS_LOST").GetText = () => "$" + stats.DeathsCost;
 			template.Get<LabelWidget>("ACTIONS_MIN").GetText = () => AverageOrdersPerMinute(stats.OrderCount);
 
 			return template;

--- a/mods/cnc/chrome/ingame-observerstats.yaml
+++ b/mods/cnc/chrome/ingame-observerstats.yaml
@@ -74,16 +74,24 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Deaths
 							Align: Right
-						Label@KD_RATIO_HEADER:
-							X: 615
+						Label@ASSETS_DESTROYED_HEADER:
+							X: 625
 							Y: 40
-							Width: 80
+							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Kills/Deaths
+							Text: Destroyed
+							Align: Right
+						Label@ASSETS_LOST_HEADER:
+							X: 685
+							Y: 40
+							Width: 60
+							Height: 25
+							Font: Bold
+							Text: Lost
 							Align: Right
 						Label@ACTIONS_MIN_HEADER:
-							X: 745
+							X: 805
 							Y: 40
 							Width: 40
 							Height: 25
@@ -193,20 +201,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Height: 25
 							Font: Bold
 							Text: Player
-						Label@KILLS_COST_HEADER:
-							X: 235
+						Label@ASSETS_DESTROYED_HEADER:
+							X: 230
 							Y: 40
 							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Kills
-						Label@DEATHS_COST_HEADER:
-							X: 315
+							Text: Destroyed
+						Label@ASSETS_LOST_HEADER:
+							X: 325
 							Y: 40
 							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Deaths
+							Text: Lost
 						Label@UNITS_KILLED_HEADER:
 							X: 415
 							Y: 40
@@ -319,14 +327,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Width: 40
 									Height: PARENT_BOTTOM
 									Align: Right
-								Label@KD_RATIO:
+								Label@ASSETS_DESTROYED:
 									X: 595
 									Y: 0
-									Width: 80
+									Width: 60
+									Height: PARENT_BOTTOM
+									Align: Right
+								Label@ASSETS_LOST:
+									X: 660
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 								Label@ACTIONS_MIN:
-									X: 725
+									X: 775
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
@@ -434,12 +448,12 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Width: 160
 									Height: PARENT_BOTTOM
 									Font: Bold
-								Label@KILLS_COST:
+								Label@ASSETS_DESTROYED:
 									X: 215
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
-								Label@DEATHS_COST:
+								Label@ASSETS_LOST:
 									X: 295
 									Y: 0
 									Width: 60

--- a/mods/ra/chrome/ingame-observerstats.yaml
+++ b/mods/ra/chrome/ingame-observerstats.yaml
@@ -74,16 +74,24 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Deaths
 							Align: Right
-						Label@KD_RATIO_HEADER:
+						Label@ASSETS_DESTROYED_HEADER:
 							X: 625
 							Y: 40
-							Width: 80
+							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Kills/Deaths
+							Text: Destroyed
+							Align: Right
+						Label@ASSETS_LOST_HEADER:
+							X: 685
+							Y: 40
+							Width: 60
+							Height: 25
+							Font: Bold
+							Text: Lost
 							Align: Right
 						Label@ACTIONS_MIN_HEADER:
-							X: 755
+							X: 805
 							Y: 40
 							Width: 40
 							Height: 25
@@ -193,20 +201,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Height: 25
 							Font: Bold
 							Text: Player
-						Label@KILLS_COST_HEADER:
-							X: 245
+						Label@ASSETS_DESTROYED_HEADER:
+							X: 230
 							Y: 40
 							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Kills
-						Label@DEATHS_COST_HEADER:
+							Text: Destroyed
+						Label@ASSETS_LOST_HEADER:
 							X: 325
 							Y: 40
 							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Deaths
+							Text: Lost
 						Label@UNITS_KILLED_HEADER:
 							X: 425
 							Y: 40
@@ -319,14 +327,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Width: 40
 									Height: PARENT_BOTTOM
 									Align: Right
-								Label@KD_RATIO:
+								Label@ASSETS_DESTROYED:
 									X: 595
 									Y: 0
-									Width: 80
+									Width: 60
+									Height: PARENT_BOTTOM
+									Align: Right
+								Label@ASSETS_LOST:
+									X: 660
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 								Label@ACTIONS_MIN:
-									X: 725
+									X: 775
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
@@ -434,12 +448,12 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Width: 160
 									Height: PARENT_BOTTOM
 									Font: Bold
-								Label@KILLS_COST:
+								Label@ASSETS_DESTROYED:
 									X: 215
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
-								Label@DEATHS_COST:
+								Label@ASSETS_LOST:
 									X: 295
 									Y: 0
 									Width: 60

--- a/mods/ts/chrome/ingame-observerstats.yaml
+++ b/mods/ts/chrome/ingame-observerstats.yaml
@@ -74,16 +74,24 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Deaths
 							Align: Right
-						Label@KD_RATIO_HEADER:
+						Label@ASSETS_DESTROYED_HEADER:
 							X: 625
 							Y: 40
-							Width: 80
+							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Kills/Deaths
+							Text: Destroyed
+							Align: Right
+						Label@ASSETS_LOST_HEADER:
+							X: 685
+							Y: 40
+							Width: 60
+							Height: 25
+							Font: Bold
+							Text: Lost
 							Align: Right
 						Label@ACTIONS_MIN_HEADER:
-							X: 755
+							X: 805
 							Y: 40
 							Width: 40
 							Height: 25
@@ -193,20 +201,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Height: 25
 							Font: Bold
 							Text: Player
-						Label@KILLS_COST_HEADER:
-							X: 245
+						Label@ASSETS_DESTROYED_HEADER:
+							X: 230
 							Y: 40
 							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Kills
-						Label@DEATHS_COST_HEADER:
+							Text: Destroyed
+						Label@ASSETS_LOST_HEADER:
 							X: 325
 							Y: 40
 							Width: 60
 							Height: 25
 							Font: Bold
-							Text: Deaths
+							Text: Lost
 						Label@UNITS_KILLED_HEADER:
 							X: 425
 							Y: 40
@@ -319,14 +327,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Width: 40
 									Height: PARENT_BOTTOM
 									Align: Right
-								Label@KD_RATIO:
+								Label@ASSETS_DESTROYED:
 									X: 595
 									Y: 0
-									Width: 80
+									Width: 60
+									Height: PARENT_BOTTOM
+									Align: Right
+								Label@ASSETS_LOST:
+									X: 660
+									Y: 0
+									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 								Label@ACTIONS_MIN:
-									X: 725
+									X: 775
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
@@ -436,12 +450,12 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Width: 160
 									Height: PARENT_BOTTOM
 									Font: Bold
-								Label@KILLS_COST:
+								Label@ASSETS_DESTROYED:
 									X: 215
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
-								Label@DEATHS_COST:
+								Label@ASSETS_LOST:
 									X: 295
 									Y: 0
 									Width: 60


### PR DESCRIPTION
…ost instead of K/D ratio

Addressing #11628 and following @Mailaender 's suggestion

Since there was already a kill/death cost stat implemented, I relabeled it in the combat stats and replaced the K/D ratio in the basic stats with it.
This is what it shows now:
![assets](https://cloud.githubusercontent.com/assets/7117676/16793516/72a43b7e-4886-11e6-8ed0-d18eab0760bc.png)
