### PR TITLE
Add a dynamically generated bordercolor for supportpower timers

### DIFF
--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -9,9 +9,11 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
@@ -26,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		readonly int timestep;
 		readonly IEnumerable<SupportPowerInstance> powers;
-		Pair<string, Color>[] texts;
+		Tuple<string, Color, Color>[] texts;
 
 		[ObjectCreator.UseCtor]
 		public SupportPowerTimerWidget(World world)
@@ -56,7 +58,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var color = !p.Ready || Game.LocalTick % 50 < 25 ? playerColor : Color.White;
 
-				return Pair.New(text, color);
+				var inversedColor = self.Owner.Color;
+				var inversedL = color == Color.White || inversedColor.L > 128 ? (byte)0 : (byte)255;
+				inversedColor = new HSLColor(inversedColor.H, 0, inversedL);
+
+				return Tuple.Create(text, color, inversedColor.RGB);
 			}).ToArray();
 		}
 
@@ -69,8 +75,8 @@ namespace OpenRA.Mods.Common.Widgets
 			foreach (var t in texts)
 			{
 				var font = Game.Renderer.Fonts[Font];
-				font.DrawTextWithContrast(t.First, new float2(Bounds.Location) + new float2(0, y), t.Second, Color.Black, 1);
-				y += (font.Measure(t.First).Y + 5) * (int)Order;
+				font.DrawTextWithContrast(t.Item1, new float2(Bounds.Location) + new float2(0, y), t.Item2, t.Item3, 1);
+				y += (font.Measure(t.Item1).Y + 5) * (int)Order;
 			}
 		}
 


### PR DESCRIPTION
Fixes #11590.

Once you got used to it, it looks quite ok/good, imho.
![timerbordera](https://cloud.githubusercontent.com/assets/7704140/16810705/537685dc-4925-11e6-9cf9-03b30e57cbfc.png)
![timerborderb](https://cloud.githubusercontent.com/assets/7704140/16810710/54f70346-4925-11e6-8ff7-d63c5872799f.png)
