### PR TITLE
Allow HealthInit to be used with Actor.Create in Lua scripts

### DIFF
--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -209,7 +209,10 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldFromYamlKey] readonly int value = 100;
 		readonly bool allowZero;
 		public HealthInit() { }
-		public HealthInit(int init, bool allowZero = false)
+		public HealthInit(int init)
+			: this(init, false) { }
+
+		public HealthInit(int init, bool allowZero)
 		{
 			this.allowZero = allowZero;
 			value = init;


### PR DESCRIPTION
BTW, I checked all the other `ActorInit`s, `HealthInit` was the only one without a single-argument ctor.
