### PR TITLE
Fixed a division through zero in DamagedByTerrain.

### DIFF
--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -62,6 +62,9 @@ namespace OpenRA.Mods.Common.Traits
 					safeTiles++;
 			}
 
+			if (totalTiles == 0)
+				return;
+
 			damageThreshold = (Info.DamageThreshold * health.MaxHP + (100 - Info.DamageThreshold) * safeTiles * health.MaxHP / totalTiles) / 100;
 
 			// Actors start with maximum damage applied


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/11499 after Coverity complained about it.
