### PR TITLE
Check that noiseDirection is not a zero

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -111,6 +111,13 @@ namespace OpenRA.Mods.D2k.Traits
 
 			while (!self.World.Map.Contains(moveTo) || !mobile.CanEnterCell(moveTo, null, false))
 			{
+				// without this check, this while can be infinity loop
+				if (moveTo == self.Location)
+				{
+					self.CancelActivity();
+					return;
+				}
+
 				noiseDirection /= 2;
 				moveTo = self.World.Map.CellContaining(self.CenterPosition + noiseDirection);
 			}


### PR DESCRIPTION
fix unexpected freezes that can happen because of infinity loop in RescanForTargets
