### PR TITLE
Added a filter for repeated move orders

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -115,6 +115,8 @@ namespace OpenRA.Mods.Common.Traits
 		bool airborne;
 		bool cruising;
 
+		CPos currentDestination;
+
 		public Aircraft(ActorInitializer init, AircraftInfo info)
 		{
 			Info = info;
@@ -528,6 +530,11 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
+
+				if (order.TargetLocation == currentDestination)
+					return;
+
+				currentDestination = order.TargetLocation;
 
 				if (!order.Queued)
 					UnReserve();

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -64,7 +64,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (order.OrderString == "AttackMove")
 			{
-				TargetLocation = move.NearestMoveableCell(order.TargetLocation);
+				var newTargetLocation = move.NearestMoveableCell(order.TargetLocation);
+				if (newTargetLocation == TargetLocation)
+					return;
+				else
+					TargetLocation = newTargetLocation;
+
 				self.SetTargetLine(Target.FromCell(self.World, TargetLocation.Value), Color.Red);
 				Activate(self);
 			}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -332,6 +332,8 @@ namespace OpenRA.Mods.Common.Traits
 		CPos fromCell, toCell;
 		public SubCell FromSubCell, ToSubCell;
 
+		CPos currentDestination;
+
 		[Sync] public int Facing
 		{
 			get { return facing; }
@@ -523,6 +525,11 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(order.TargetLocation))
 					return;
+
+				if (order.TargetLocation == currentDestination)
+					return;
+
+				currentDestination = order.TargetLocation;
 
 				PerformMove(self, self.World.Map.Clamp(order.TargetLocation),
 					order.Queued && !self.IsIdle);


### PR DESCRIPTION
as suggested in https://github.com/OpenRA/OpenRA/issues/3923#issuecomment-34561991. You can see the benefit of units not halting for every click as this avoids https://github.com/OpenRA/OpenRA/issues/3288 at least when you click at the exact same tile.
