### PR TITLE
Removed the unused jeep unload sequence

### DIFF
--- a/mods/cnc/sequences/campaign.yaml
+++ b/mods/cnc/sequences/campaign.yaml
@@ -2,9 +2,6 @@ lst:
 	idle: lstnew
 		UseClassicFacingFudge: True
 		Facings: 32
-	unload: lstnew
-		UseClassicFacingFudge: True
-		Facings: 32
 	roof: lstnew2
 		UseClassicFacingFudge: True
 		Facings: 32

--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -2,13 +2,9 @@ carryall:
 	idle: DATA.R8
 		Start: 1923
 		Facings: -32
-	unload: DATA.R8
-		Start: 1923
-		Facings: -32
 	icon: DATA.R8
 		Start: 4029
 		Offset: -30,-24
-
 
 ornithopter:
 	idle: DATA.R8

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -42,9 +42,6 @@ trike:
 	idle: DATA.R8
 		Start: 1635
 		Facings: -32
-	unload: DATA.R8
-		Start: 1635
-		Facings: -32
 	muzzle: DATA.R8
 		Start: 3839
 		Tick: 50
@@ -56,9 +53,6 @@ trike:
 
 quad:
 	idle: DATA.R8
-		Start: 1667
-		Facings: -32
-	unload: DATA.R8
 		Start: 1667
 		Facings: -32
 	icon: DATA.R8
@@ -219,9 +213,6 @@ raider:
 	idle: DATA.R8
 		Start: 2421
 		Facings: -32
-	unload: DATA.R8
-		Start: 2421
-		Facings: -32
 	muzzle: DATA.R8
 		Start: 3743
 		Tick: 50
@@ -233,9 +224,6 @@ raider:
 
 stealth_raider:
 	idle: DATA.R8
-		Start: 2421
-		Facings: -32
-	unload: DATA.R8
 		Start: 2421
 		Facings: -32
 	muzzle: DATA.R8

--- a/mods/ra/sequences/vehicles.yaml
+++ b/mods/ra/sequences/vehicles.yaml
@@ -193,9 +193,6 @@ jeep:
 	muzzle: minigun
 		Length: 6
 		Facings: 8
-	unload:
-		Facings: 32
-		UseClassicFacingFudge: True
 	icon: jeepicon
 
 apc:


### PR DESCRIPTION
We don't use the unload animations (anymore) so this workaround isn't required. Redundant to idle anyway so that sequence can be referenced when it makes a return. Might save a small amount of space on the sprite map. PS: This applies to a few other occasions as well. Updated accordingly.
