### PR TITLE
Couple "Warning: Server ports are not forwarded." with the UPnP feature

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -96,7 +96,10 @@ namespace OpenRA.Mods.Common.Server
 								if (masterResponseText.Contains("[001]"))  // Server does not respond code
 								{
 									Log.Write("server", masterResponseText);
-									masterServerMessages.Enqueue("Warning: Server ports are not forwarded.");
+
+									if (!server.Settings.AllowPortForward)
+										masterServerMessages.Enqueue("Warning: Server ports are not forwarded.");
+
 									masterServerMessages.Enqueue("Game has not been advertised online.");
 								}
 							}


### PR DESCRIPTION
I found it a bit confusing this message is printed always.
