### PR TITLE
Remove CAMERA.Large from Evacuation and Survival01

### DIFF
--- a/mods/ra/maps/evacuation/rules.yaml
+++ b/mods/ra/maps/evacuation/rules.yaml
@@ -200,11 +200,6 @@ MSUB:
 	Buildable:
 		Prerequisites: ~disabled
 
-CAMERA.Large:
-	Inherits: CAMERA
-	RevealsShroud:
-		Range: 1000c0
-
 Camera.SAM:
 	Inherits: CAMERA
 	RevealsShroud:

--- a/mods/ra/maps/survival01/map.yaml
+++ b/mods/ra/maps/survival01/map.yaml
@@ -1033,9 +1033,6 @@ Actors:
 	Actor346: t15
 		Location: 57,24
 		Owner: Neutral
-	Actor1000: camera.large
-		Location: 1,1
-		Owner: Soviets
 	FlameTower3: ftur
 		Location: 78,17
 		Owner: Soviets

--- a/mods/ra/maps/survival01/rules.yaml
+++ b/mods/ra/maps/survival01/rules.yaml
@@ -30,11 +30,6 @@ CAMERA.sam:
 	RevealsShroud:
 		Range: 4c0
 
-CAMERA.Large:
-	Inherits: CAMERA
-	RevealsShroud:
-		Range: 1000
-
 AFLD.mission:
 	Inherits: AFLD
 	-AirstrikePower@spyplane:


### PR DESCRIPTION
Resolves https://github.com/OpenRA/OpenRA/pull/11316#discussion_r71973766.
