### PR TITLE
Improved the Red Alert dog behavior

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -123,6 +124,11 @@ namespace OpenRA.Mods.Common.Activities
 			attack.DoAttack(self, Target, armaments);
 
 			return this;
+		}
+
+		public override IEnumerable<Target> GetTargets(Actor self)
+		{
+			yield return Target;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		int length;
 		int ticks = 0;
 
+		/// <summary> Decorational move that doesn't change actor position. </summary>
 		public Drag(Actor self, WPos start, WPos end, int length)
 		{
 			positionable = self.Trait<IPositionable>();

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -53,5 +53,10 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			return Target.IsInRange(origin, maxRange) && !Target.IsInRange(origin, minRange);
 		}
+
+		public override IEnumerable<Target> GetTargets(Actor self)
+		{
+			yield return Target;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Projectiles\AreaBeam.cs" />
     <Compile Include="Projectiles\Bullet.cs" />
     <Compile Include="Projectiles\GravityBomb.cs" />
+    <Compile Include="Projectiles\InstantHit.cs" />
     <Compile Include="Projectiles\LaserZap.cs" />
     <Compile Include="Projectiles\Missile.cs" />
     <Compile Include="Projectiles\NukeLaunch.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -573,6 +573,7 @@
     <Compile Include="UtilityCommands\UpgradeModCommand.cs" />
     <Compile Include="UtilityCommands\UpgradeRules.cs" />
     <Compile Include="UtilityCommands\Rgba2Hex.cs" />
+    <Compile Include="Warheads\ActorDamageWarhead.cs" />
     <Compile Include="Warheads\CreateEffectWarhead.cs" />
     <Compile Include="Warheads\CreateResourceWarhead.cs" />
     <Compile Include="Warheads\DamageWarhead.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -508,6 +508,7 @@
     <Compile Include="Traits\Upgrades\UpgradableTrait.cs" />
     <Compile Include="Traits\Upgrades\UpgradeActorsNear.cs" />
     <Compile Include="Traits\Upgrades\UpgradeOnDamageState.cs" />
+    <Compile Include="Traits\Upgrades\UpgradeOnTarget.cs" />
     <Compile Include="Traits\Upgrades\UpgradeOnTerrain.cs" />
     <Compile Include="Traits\Upgrades\UpgradeManager.cs" />
     <Compile Include="Traits\Valued.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -508,6 +508,7 @@
     <Compile Include="Traits\Upgrades\UpgradableTrait.cs" />
     <Compile Include="Traits\Upgrades\UpgradeActorsNear.cs" />
     <Compile Include="Traits\Upgrades\UpgradeOnDamageState.cs" />
+    <Compile Include="Traits\Upgrades\UpgradeOnAttack.cs" />
     <Compile Include="Traits\Upgrades\UpgradeOnTarget.cs" />
     <Compile Include="Traits\Upgrades\UpgradeOnTerrain.cs" />
     <Compile Include="Traits\Upgrades\UpgradeManager.cs" />

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -1,0 +1,50 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.GameRules;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Projectiles
+{
+	[Desc("Simple invisible direct on target actor fake projectile.")]
+	public class MeleeAttackInfo : IProjectileInfo
+	{
+		public IProjectile Create(ProjectileArgs args) { return new MeleeAttack(this, args); }
+	}
+
+	public class MeleeAttack : IProjectile
+	{
+		readonly ProjectileArgs args;
+
+		bool doneDamage;
+
+		public MeleeAttack(MeleeAttackInfo info, ProjectileArgs args)
+		{
+			this.args = args;
+		}
+
+		public void Tick(World world)
+		{
+			if (!doneDamage)
+			{
+				args.Weapon.Impact(args.GuidedTarget, args.SourceActor, args.DamageModifiers);
+				world.AddFrameEndTask(w => w.Remove(this));
+				doneDamage = true;
+			}
+		}
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		{
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -16,18 +16,18 @@ using OpenRA.Graphics;
 namespace OpenRA.Mods.Common.Projectiles
 {
 	[Desc("Simple invisible direct on target actor fake projectile.")]
-	public class MeleeAttackInfo : IProjectileInfo
+	public class InstantHitInfo : IProjectileInfo
 	{
-		public IProjectile Create(ProjectileArgs args) { return new MeleeAttack(this, args); }
+		public IProjectile Create(ProjectileArgs args) { return new InstantHit(this, args); }
 	}
 
-	public class MeleeAttack : IProjectile
+	public class InstantHit : IProjectile
 	{
 		readonly ProjectileArgs args;
 
 		bool doneDamage;
 
-		public MeleeAttack(MeleeAttackInfo info, ProjectileArgs args)
+		public InstantHit(InstantHitInfo info, ProjectileArgs args)
 		{
 			this.args = args;
 		}

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnAttack.cs
@@ -1,0 +1,59 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Trigger upgrades during Attack trait activities.")]
+	public class UpgradeOnAttackInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	{
+		[Desc("Lasts until the attack is executed.")]
+		[UpgradeGrantedReference] public readonly string[] PreparingAttackUpgrades = { };
+
+		[Desc("Timed upgrade for the duration of the fire delay.")]
+		[UpgradeGrantedReference] public readonly string[] AttackingUpgrades = { };
+
+		[Desc("How long the timed attacking upgrade should last.")]
+		public readonly int AttackingDelay = 0;
+
+		public object Create(ActorInitializer init) { return new UpgradeOnAttack(init, this); }
+	}
+
+	public class UpgradeOnAttack : INotifyAttack
+	{
+		readonly Actor self;
+		readonly UpgradeOnAttackInfo info;
+		readonly UpgradeManager manager;
+
+		public UpgradeOnAttack(ActorInitializer init, UpgradeOnAttackInfo info)
+		{
+			self = init.Self;
+			this.info = info;
+			manager = self.Trait<UpgradeManager>();
+		}
+
+		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
+		{
+			foreach (var up in info.PreparingAttackUpgrades)
+				manager.GrantUpgrade(self, up, this);
+		}
+
+		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		{
+			foreach (var up in info.PreparingAttackUpgrades)
+				manager.RevokeUpgrade(self, up, this);
+
+			foreach (var up in info.AttackingUpgrades)
+				manager.GrantTimedUpgrade(self, up, info.AttackingDelay, this);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnTarget.cs
@@ -1,0 +1,61 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Trigger upgrades when an actor is targeted.")]
+	public class UpgradeOnTargetInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	{
+		[UpgradeGrantedReference] public readonly string[] Upgrades = { };
+
+		public object Create(ActorInitializer init) { return new UpgradeOnTarget(init, this); }
+	}
+
+	public class UpgradeOnTarget : ITick
+	{
+		readonly Actor self;
+		readonly UpgradeOnTargetInfo info;
+		readonly UpgradeManager manager;
+
+		bool granted;
+
+		public UpgradeOnTarget(ActorInitializer init, UpgradeOnTargetInfo info)
+		{
+			self = init.Self;
+			this.info = info;
+			manager = self.Trait<UpgradeManager>();
+		}
+
+		public void Tick(Actor self)
+		{
+			var activity = self.GetCurrentActivity();
+			var wantsGranted = activity != null && activity.GetTargets(self).Any(t => t.Type == TargetType.Actor);
+			if (wantsGranted && !granted)
+			{
+				foreach (var up in info.Upgrades)
+					manager.GrantUpgrade(self, up, this);
+
+				granted = true;
+			}
+			else if (!wantsGranted && granted)
+			{
+				foreach (var up in info.Upgrades)
+					manager.RevokeUpgrade(self, up, this);
+
+				granted = false;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Warheads/ActorDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ActorDamageWarhead.cs
@@ -1,0 +1,38 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Warheads
+{
+	[Desc("Only hits when an actor is targeted directly.")]
+	public class ActorDamageWarhead : DamageWarhead
+	{
+		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		{
+			if (target.Type != TargetType.Actor)
+				return;
+
+			var victim = target.Actor;
+			if (!IsValidAgainst(victim, firedBy))
+				return;
+
+			var damage = Util.ApplyPercentageModifiers(Damage, damageModifiers.Append(DamageVersus(victim)));
+			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
+		}
+
+		public override void DoImpact(WPos pos, Actor firedBy, IEnumerable<int> damageModifiers)
+		{
+			// missed the target
+		}
+	}
+}

--- a/OpenRA.Mods.RA/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.RA/Traits/Attack/AttackLeap.cs
@@ -9,49 +9,62 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
+using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.RA.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	[Desc("Dogs use this attack model.")]
-	class AttackLeapInfo : AttackFrontalInfo
+	[Desc("Move onto the target then execute the attack.")]
+	public class AttackLeapInfo : AttackFrontalInfo, Requires<MobileInfo>, Requires<UpgradeManagerInfo>
 	{
 		[Desc("Leap speed (in units/tick).")]
 		public readonly WDist Speed = new WDist(426);
 
-		public readonly WAngle Angle = WAngle.FromDegrees(20);
+		[Desc("Upgrades that last from start of leap till attack.")]
+		[UpgradeGrantedReference] public readonly string[] LeapUpgrades = { };
 
 		public override object Create(ActorInitializer init) { return new AttackLeap(init.Self, this); }
 	}
 
-	class AttackLeap : AttackFrontal
+	public class AttackLeap : AttackFrontal
 	{
 		readonly AttackLeapInfo info;
+		readonly Mobile mobile;
+		readonly UpgradeManager manager;
 
 		public AttackLeap(Actor self, AttackLeapInfo info)
 			: base(self, info)
 		{
 			this.info = info;
+			mobile = self.Trait<Mobile>();
+			manager = self.Trait<UpgradeManager>();
 		}
 
 		public override void DoAttack(Actor self, Target target, IEnumerable<Armament> armaments = null)
 		{
-			if (target.Type != TargetType.Actor || !CanAttack(self, target))
+			if (IsAttacking || !mobile.CanMoveFreelyInto(target.Actor.Location))
 				return;
 
-			var a = ChooseArmamentsForTarget(target, true).FirstOrDefault();
-			if (a == null)
-				return;
+			var origin = self.World.Map.CenterOfSubCell(self.Location, mobile.FromSubCell);
+			var targetMobile = self.TraitOrDefault<Mobile>();
+			var targetSubcell = targetMobile != null ? targetMobile.FromSubCell : SubCell.Any;
+			var destination = self.World.Map.CenterOfSubCell(target.Actor.Location, targetSubcell);
+			var length = Math.Max((origin - destination).Length / info.Speed.Length, 1);
+			self.QueueActivity(new Leap(self, origin, destination, length, mobile));
+			foreach (var up in info.LeapUpgrades)
+				manager.GrantUpgrade(self, up, this);
 
-			if (!target.IsInRange(self.CenterPosition, a.MaxRange()))
-				return;
+			Game.RunAfterDelay(length, () => {
+				foreach (var up in info.LeapUpgrades)
+					manager.RevokeUpgrade(self, up, this);
 
-			self.CancelActivity();
-			self.QueueActivity(new Leap(self, target.Actor, a.Weapon, info.Speed, info.Angle));
+				if (!self.IsDead)
+					base.DoAttack(self, target, armaments);
+			});
 		}
 	}
 }

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -20,6 +20,8 @@ DOG:
 	Mobile:
 		Speed: 99
 		Voice: Move
+		UpgradeTypes: rip
+		UpgradeMaxEnabledLevel: 0
 	Guard:
 		Voice: Move
 	Passenger:
@@ -30,15 +32,44 @@ DOG:
 		Weapon: DogJaw
 	AttackLeap:
 		Voice: Attack
+		LeapUpgrades: leap
 	AttackMove:
 		Voice: Move
+	UpgradeOnAttack:
+		AttackingUpgrades: rip
+		AttackingDelay: 30
+	UpgradeOnTarget:
+		Upgrades: rush
 	AutoTarget:
 		InitialStance: AttackAnything
 	Targetable:
 		TargetTypes: Ground, Infantry
 	WithInfantryBody:
-		AttackSequence: shoot
+		MoveSequence: walk
 		StandSequences: stand
+		AttackSequence: eat
+		UpgradeTypes: leap, rush, rip
+		UpgradeMaxEnabledLevel: 0
+	WithInfantryBody@RUSH:
+		MoveSequence: run
+		AttackSequence: run
+		UpgradeTypes: rush
+		UpgradeMinEnabledLevel: 1
+	WithInfantryBody@LEAP:
+		MoveSequence: jump
+		AttackSequence: jump
+		UpgradeTypes: leap
+		UpgradeMinEnabledLevel: 1
+	WithInfantryBody@EAT:
+		MoveSequence: eat
+		AttackSequence: eat
+		StandSequences: eat
+		IdleSequences: eat
+		UpgradeTypes: rip
+		UpgradeMinEnabledLevel: 1
+	SpeedMultiplier@HUNGER:
+		Modifier: 150
+		UpgradeTypes: rush
 	IgnoresDisguise:
 	DetectCloaked:
 		CloakTypes: Cloak, Hijacker

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -497,9 +497,19 @@ e2:
 dog:
 	stand:
 		Facings: 8
-	run:
+	walk:
 		Start: 8
 		Length: 6
+		Facings: 8
+		Tick: 80
+	run:
+		Start: 56
+		Length: 6
+		Facings: 8
+		Tick: 80
+	eat:
+		Start: 104
+		Length: 14
 		Facings: 8
 		Tick: 80
 	idle1:
@@ -535,7 +545,7 @@ dog:
 		TilesetOverrides:
 			DESERT: TEMPERAT
 			INTERIOR: TEMPERAT
-	shoot: dogbullt
+	jump: dogbullt
 		Length: 4
 		Facings: 8
 	icon: dogicon

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -188,8 +188,8 @@ DogJaw:
 	ReloadDelay: 10
 	Range: 3c0
 	Report: dogg5p.aud
-	Warhead@1Dam: SpreadDamage
-		Spread: 213
+	Projectile: InstantHit
+	Warhead: ActorDamage
 		Damage: 100
 		ValidTargets: Infantry
 		DamageTypes: DefaultDeath


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/7506. I redid this from scratch and tried to match RA95 behavior taking https://youtu.be/4ZyAlXOY0aM?t=2m for reference still avoiding legacy limitations.

Instead of leaping onto a targetable actor and killing everything in that cell, I separate leap movement and attack execution. This means the path finder now makes sure that an attack can be executed so jumping over cliffs and other glitches are gone.

The insta-kill is also not a hard-coded hack, but using the regular weapon system. This means we can also armor soldiers accordingly so they only take damage from a hit for a more fine grained balancing. For now the weapon is a high speed bullet like all the other melee attacks, but we can change this into a close combat "projectile" later on to avoid the overhead.

I also tried to adhere to our modular https://github.com/OpenRA/OpenRA/wiki/Actor-Upgrades system instead of putting everything into a monolithic one-purpose trait. The `UpgradeOnTarget` trait can be used to recreate http://cnc.wikia.com/wiki/Terrorist_(Generals) style units and I guess creative modders will find a lot of uses for `UpgradeOnAttack` I didn't even think of yet.
