### PR TITLE
Silence unused field warning in DamagedByTerrainInfo

### DIFF
--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	class DamagedByTerrainInfo : UpgradableTraitInfo, IRulesetLoaded, Requires<HealthInfo>
 	{
 		[Desc("The weapon which is used to damage the actor.")]
-		[WeaponReference, FieldLoader.Require] public readonly string Weapon;
+		[WeaponReference, FieldLoader.Require] public readonly string Weapon = null;
 
 		[Desc("Terrain types where the actor will take damage.")]
 		[FieldLoader.Require] public readonly string[] Terrain = { };


### PR DESCRIPTION
This produces a warning in VS2015 Update 3. Explicit assignment silences the warning.
