### PR TITLE
Fix desync when removing smudges

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -165,18 +165,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void RemoveSmudge(CPos loc)
 		{
-			if (dirty.ContainsKey(loc))
-			{
-				var tile = dirty[loc];
-				tile.Depth = 0;
-				tile.Sprite = null;
-				dirty[loc] = tile;
-			}
-			else
-			{
-				var st = smudges.Keys.Random(world.SharedRandom);
-				dirty[loc] = new Smudge { Type = st, Depth = 0, Sprite = null };
-			}
+			var tile = dirty.ContainsKey(loc) ? dirty[loc] : new Smudge();
+
+			tile.Sprite = null;
+			dirty[loc] = tile;
 		}
 
 		public void TickRender(WorldRenderer wr, Actor self)


### PR DESCRIPTION
The cause of the crash was that the `RemoveSmudge` method only invokes `SharedRandom` in the else-branch of an if condition that is only taken when the `RenderPlayer` has fog visibility on the location (locations the `RenderPlayer` can see get removed from `dirty` in `TickRender`).

To add insult to injury, the `Type` field does not even need to get set since [we are only using the `Sprite` field's null value as a marker to be picked up by the `TickRender` method](https://github.com/OpenRA/OpenRA/blob/e13fa2d474a963d4148ab1db7407fb84b0f90016/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs#L189). [The `Type` field is only ever used twice in `AddSmudge`](https://github.com/OpenRA/OpenRA/blob/e13fa2d474a963d4148ab1db7407fb84b0f90016/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs#L155-L159), in a branch of an if-condition [that will not be taken when the `Sprite` field is null](https://github.com/OpenRA/OpenRA/blob/e13fa2d474a963d4148ab1db7407fb84b0f90016/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs#L145), which we set explicitly. The same holds true for the `Depth` field.

Fixes #11660.
