### PR TITLE
Revert Nuke Truck Damage nerf vs Air

### DIFF
--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -112,7 +112,7 @@ MiniNuke:
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: Ground, Trees, Water, Underwater
+		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
 			Concrete: 25
 		AffectsParent: true


### PR DESCRIPTION
#11253 overshot the issue raised by #10865 and #10799 by reducing the guarantee kill zone for YAKs/Hinds from 10 to 3(!). The original issue argued for a slight nerf in order to allow nearby aircrafts get away.

By adding Air as a valid target back to one of the Warheads the guaranteed killzone vs Hinds/YAKs is measured to 6.
