### PR TITLE
Fix cancellation of downloads.

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -128,11 +128,11 @@ namespace OpenRA
 
 			var url = Game.Settings.Game.MapRepository + "hash/" + string.Join(",", maps.Keys) + "/yaml";
 
-			Action<DownloadDataCompletedEventArgs, bool> onInfoComplete = (i, cancelled) =>
+			Action<DownloadDataCompletedEventArgs> onInfoComplete = i =>
 			{
-				if (cancelled || i.Error != null)
+				if (i.Error != null)
 				{
-					Log.Write("debug", "Remote map query failed with error: {0}", i.Error != null ? i.Error.Message : "cancelled");
+					Log.Write("debug", "Remote map query failed with error: {0}", Download.FormatErrorMessage(i.Error));
 					Log.Write("debug", "URL was: {0}", url);
 					foreach (var p in maps.Values)
 						p.UpdateRemoteSearch(MapStatus.Unavailable, null);

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -444,13 +444,13 @@ namespace OpenRA
 					}
 
 					Action<DownloadProgressChangedEventArgs> onDownloadProgress = i => { DownloadBytes = i.BytesReceived; DownloadPercentage = i.ProgressPercentage; };
-					Action<DownloadDataCompletedEventArgs, bool> onDownloadComplete = (i, cancelled) =>
+					Action<DownloadDataCompletedEventArgs> onDownloadComplete = i =>
 					{
 						download = null;
 
-						if (cancelled || i.Error != null)
+						if (i.Error != null)
 						{
-							Log.Write("debug", "Remote map download failed with error: {0}", i.Error != null ? i.Error.Message : "cancelled");
+							Log.Write("debug", "Remote map download failed with error: {0}", Download.FormatErrorMessage(i.Error));
 							Log.Write("debug", "URL was: {0}", mapUrl);
 
 							innerData.Status = MapStatus.DownloadError;
@@ -487,7 +487,7 @@ namespace OpenRA
 			if (download == null)
 				return;
 
-			download.Cancel();
+			download.CancelAsync();
 			download = null;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -294,8 +294,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								.JoinWith("&");
 
 						new Download(newsURL, cacheFile, e => { },
-							(e, c) => NewsDownloadComplete(e, cacheFile, currentNews,
-							() => newsButton.AttachPanel(newsPanel)));
+							e => NewsDownloadComplete(e, cacheFile, currentNews,
+								() => newsButton.AttachPanel(newsPanel)));
 					}
 
 					newsButton.OnClick = () => newsButton.AttachPanel(newsPanel);

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -296,11 +296,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			searchStatus = SearchStatus.Fetching;
 
-			Action<DownloadDataCompletedEventArgs, bool> onComplete = (i, cancelled) =>
+			Action<DownloadDataCompletedEventArgs> onComplete = i =>
 			{
 				currentQuery = null;
 
-				if (i.Error != null || cancelled)
+				if (i.Error != null)
 				{
 					RefreshServerListInner(null);
 					return;


### PR DESCRIPTION
The Download class cancels asynchronously, which means callers must handle cancellation inside the completion event, and not after requesting cancellation.

Fixes #11739.

When a download is cancelled, the `Cancelled` flag is set, and `Error` contains an exception with a `RequestCanceled` Status. This means if you want to check for either cancellation or an error, simply checking for `Error != null` is sufficient. It also means if you want to handle cancellation differently from an error, you must handle cancellation first.
