### PR TITLE
Same unit command sounds wont overlap anymore

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using OpenRA.FileSystem;
 using OpenRA.GameRules;
@@ -39,6 +40,7 @@ namespace OpenRA
 		ISound music;
 		ISound video;
 		MusicInfo currentMusic;
+		Dictionary<uint, ISound> currentSounds = new Dictionary<uint, ISound>();
 
 		public Sound(IPlatform platform, SoundSettings soundSettings)
 		{
@@ -348,9 +350,18 @@ namespace OpenRA
 			var name = prefix + clip + suffix;
 
 			if (!string.IsNullOrEmpty(name) && (p == null || p == p.World.LocalPlayer))
-				soundEngine.Play2D(sounds[name],
+			{
+				var sound = soundEngine.Play2D(sounds[name],
 					false, relative, pos,
 					InternalSoundVolume * volumeModifier, attenuateVolume);
+				if (id != 0)
+				{
+					if (currentSounds.ContainsKey(id))
+						soundEngine.StopSound(currentSounds[id]);
+
+					currentSounds[id] = sound;
+				}
+			}
 
 			return true;
 		}


### PR DESCRIPTION
When the player submits an order to a unit, it will now stop the previous sound before playing the new one.
This will prevent ventriloquists units.

I made a [short video](https://youtu.be/4uljtQ3zRjU) that shows the results.

Sorry for the graphics lag, I haven't got a proper screen recording setup right now.
