### PR TITLE
Removed unused SDL2-CS code paths

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -130,7 +130,7 @@ if (!(Test-Path "SDL2-CS.dll"))
 {
 	echo "Fetching SDL2-CS from GitHub."
 	$target = Join-Path $pwd.ToString() "SDL2-CS.dll"
-	(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/SDL2-CS/releases/download/20151227/SDL2-CS.dll", $target)
+	(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/SDL2-CS/releases/download/20160807/SDL2-CS.dll", $target)
 }
 
 if (!(Test-Path "OpenAL-CS.dll"))

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -99,8 +99,8 @@ fi
 
 if [ ! -f SDL2-CS.dll -o ! -f SDL2-CS.dll.config ]; then
 	echo "Fetching SDL2-CS from GitHub."
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20151227/SDL2-CS.dll
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20151227/SDL2-CS.dll.config
+	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20160807/SDL2-CS.dll
+	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20160807/SDL2-CS.dll.config
 fi
 
 if [ ! -f OpenAL-CS.dll -o ! -f OpenAL-CS.dll.config ]; then


### PR DESCRIPTION
The real change can be inspected at https://github.com/OpenRA/SDL2-CS/pull/1. It shouldn't cause any changes except us shipping a slightly smaller DLL.
