### PR TITLE
Make turning-while-moving actors follow curved paths.

### DIFF
--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -64,6 +64,20 @@ namespace OpenRA
 			return new WAngle(Angle - 512).Tan();
 		}
 
+		public static WAngle Lerp(WAngle a, WAngle b, int mul, int div)
+		{
+			// Map 1024 <-> 0 wrapping into linear space
+			var aa = a.Angle;
+			var bb = b.Angle;
+			if (aa > bb && aa - bb > 512)
+				aa -= 1024;
+
+			if (bb > aa && bb - aa > 512)
+				bb -= 1024;
+
+			return new WAngle(aa + (bb - aa) * mul / div);
+		}
+
 		public static WAngle ArcTan(int y, int x) { return ArcTan(y, x, 1); }
 		public static WAngle ArcTan(int y, int x, int stride)
 		{


### PR DESCRIPTION
The code for moving units through cells independently lerps actor positions along disjoint straight-lines between cell edges while smoothly varying the facing.  This leads to subtly wrong-looking moves when units turn corners (actors move in a different direction to their facing).

The effect is small, but extremely irritating when you know what to look for... or even when you don't: this is the main cause of the often-repeated "OpenRA's turning is too smooth" complaint.

This PR replaces the linear position lerping with arcs.  It still ignores the unit's ROT because incorporating that would (a) be much more complicated and (b) break balance (fast units wouldn't be able to turn sharply enough to move without stopping).

Before and after videos:
- [before](https://www.dropbox.com/s/qp5u64egxgsdb5h/before.mov?dl=0)
- [after](https://www.dropbox.com/s/ziio8vbzldgwnn2/after.mov?dl=0)

Fixes #11212.
