### PR TITLE
Fix voxel rendering with EnableDepthBuffer: True

### DIFF
--- a/OpenRA.Game/Graphics/VoxelRenderer.cs
+++ b/OpenRA.Game/Graphics/VoxelRenderer.cs
@@ -22,9 +22,9 @@ namespace OpenRA.Graphics
 		public readonly Sprite Sprite;
 		public readonly Sprite ShadowSprite;
 		public readonly float ShadowDirection;
-		public readonly float2[] ProjectedShadowBounds;
+		public readonly float3[] ProjectedShadowBounds;
 
-		public VoxelRenderProxy(Sprite sprite, Sprite shadowSprite, float2[] projectedShadowBounds, float shadowDirection)
+		public VoxelRenderProxy(Sprite sprite, Sprite shadowSprite, float3[] projectedShadowBounds, float shadowDirection)
 		{
 			Sprite = sprite;
 			ShadowSprite = shadowSprite;
@@ -145,7 +145,7 @@ namespace OpenRA.Graphics
 
 			var shadowScreenTransform = Util.MatrixMultiply(cameraTransform, invShadowTransform);
 			var shadowGroundNormal = Util.MatrixVectorMultiply(shadowTransform, groundNormal);
-			var screenCorners = new float2[4];
+			var screenCorners = new float3[4];
 			for (var j = 0; j < 4; j++)
 			{
 				// Project to ground plane
@@ -154,7 +154,7 @@ namespace OpenRA.Graphics
 
 				// Rotate to camera-space
 				corners[j] = Util.MatrixVectorMultiply(shadowScreenTransform, corners[j]);
-				screenCorners[j] = new float2(corners[j][0], corners[j][1]);
+				screenCorners[j] = new float3(corners[j][0], corners[j][1], 0);
 			}
 
 			// Shadows are rendered at twice the resolution to reduce artifacts

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -126,7 +126,10 @@ namespace OpenRA.Graphics
 				return;
 
 			if (devTrait.Value != null)
+			{
 				Game.Renderer.WorldSpriteRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
+				Game.Renderer.WorldRgbaSpriteRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
+			}
 
 			RefreshPalette();
 

--- a/glsl/rgba.frag
+++ b/glsl/rgba.frag
@@ -1,7 +1,25 @@
 uniform sampler2D DiffuseTexture;
+uniform bool EnableDepthPreview;
+
 varying vec4 vTexCoord;
 
 void main()
 {
-	gl_FragColor = texture2D(DiffuseTexture, vTexCoord.st);
+	vec4 c = texture2D(DiffuseTexture, vTexCoord.st);
+	// Discard any transparent fragments (both color and depth)
+	if (c.a == 0.0)
+		discard;
+
+	float depth = gl_FragCoord.z;
+
+	// Convert to window coords
+	gl_FragDepth = 0.5 * depth + 0.5;
+
+	if (EnableDepthPreview)
+	{
+		// Front of the depth buffer is at 0, but we want to render it as bright
+		gl_FragColor = vec4(vec3(1.0 - gl_FragDepth), 1.0);
+	}
+	else
+		gl_FragColor = c;
 }


### PR DESCRIPTION
This gets us another step closer towards being able to enable the depth buffer rendering in the gen2 mods (nearly there!) by rendering voxels with an approximately correct z coordinate so that they are composited at (nearly) the right place in the world.

The "approximately" and "(nearly)" are because we throw away the per-pixel depth information associated with the model and for now can only render a flat billboard.  As commented in the code, this is because we have at most four colour channels to store 5 sets of data (RGB, alpha, and depth).  For now hacking the depth gives a good-enough result that we can improve further down the line when the voxel renderer is rewritten.

You'll notice when testing that the voxels clip beneath the ground when moving over slopes.  This isn't the renderer's fault: the heightmap-unaware movement code really is making the actors move partially underground, in addition to not being able to rotate them to match the slope.
