### PR TITLE
Clearup mod AIs.

### DIFF
--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -51,12 +51,12 @@ Player:
 		CheckCaptureTargetsForVisibility: false
 		MaximumCaptureTargetOptions: 15
 		UnitsToBuild:
+			e1: 65%
+			e2: 25%
+			e3: 40%
+			e4: 15%
+			e5: 15%
 			e6: 5%
-			e1: 14%
-			e3: 7%
-			e2: 10%
-			e4: 7%
-			e5: 5%
 			harv: 10%
 			bggy: 5%
 			bike: 40%
@@ -72,6 +72,7 @@ Player:
 			orca: 5%
 		UnitLimits:
 			harv: 8
+			e6: 3
 		SquadSize: 15
 		SupportPowerDecision@Airstrike:
 			OrderName: AirstrikePowerInfoOrder
@@ -173,9 +174,9 @@ Player:
 			silo: 0%
 			fix: 1%
 		UnitsToBuild:
-			e1: 30%
+			e1: 65%
 			e2: 30%
-			e3: 30%
+			e3: 40%
 			e4: 30%
 			e5: 30%
 			harv: 10%
@@ -294,9 +295,9 @@ Player:
 			silo: 0%
 			fix: 1%
 		UnitsToBuild:
-			e1: 30%
+			e1: 65%
 			e2: 30%
-			e3: 30%
+			e3: 40%
 			e4: 50%
 			e5: 50%
 			harv: 16%

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -48,14 +48,11 @@ Player:
 			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
-			light_inf: 6%
-			trooper: 5%
-			medic: 1%
-			fremen: 0.5%
-			sardaukar: 1.5%
-			saboteur: 0.5%
+			light_inf: 65%
+			trooper: 40%
+			sardaukar: 20%
 			harvester: 1%
-			grenadier: 1%
+			grenadier: 20%
 			trike.starport: 5%
 			quad.starport: 7.5%
 			siege_tank.starport: 5%
@@ -165,13 +162,10 @@ Player:
 			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
-			light_inf: 2%
-			trooper: 2%
-			medic: 0.5%
-			fremen: 0.25%
-			sardaukar: 1%
-			saboteur: 0.5%
-			grenadier: 1%
+			light_inf: 65%
+			trooper: 40%
+			sardaukar: 20%
+			grenadier: 20%
 			harvester: 1%
 			trike.starport: 7.5%
 			quad.starport: 12.5%
@@ -282,13 +276,10 @@ Player:
 			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
-			light_inf: 15%
-			trooper: 13%
-			medic: 2%
-			fremen: 1%
-			sardaukar: 3%
-			saboteur: 1%
-			grenadier: 2%
+			light_inf: 65%
+			trooper: 40%
+			sardaukar: 20%
+			grenadier: 20%
 			harvester: 1%
 			trike.starport: 5%
 			quad.starport: 7.5%

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -47,13 +47,13 @@ Player:
 		CheckCaptureTargetsForVisibility: false
 		MaximumCaptureTargetOptions: 15
 		UnitsToBuild:
+			e1: 65%
+			e2: 25%
+			e3: 40%
+			e4: 15%
 			e6: 5%
-			e1: 50%
-			e2: 20%
-			e3: 10%
-			e4: 2%
-			dog: 2%
-			shok: 2%
+			dog: 15%
+			shok: 15%
 			harv: 10%
 			apc: 30%
 			jeep: 40%
@@ -68,6 +68,7 @@ Player:
 			stnk: 5%
 		UnitLimits:
 			dog: 4
+			e6: 3
 			harv: 8
 		SquadSize: 20
 		SupportPowerDecision@spyplane:
@@ -169,12 +170,14 @@ Player:
 			stek: 1%
 			mslo: 1%
 		UnitsToBuild:
-			e1: 50%
-			e2: 10%
-			e3: 10%
-			e4: 5%
-			dog: 3%
-			shok: 5%
+			e1: 65%
+			e2: 25%
+			e3: 40%
+			e4: 15%
+			medi: 3%
+			mech: 3%
+			dog: 15%
+			shok: 15%
 			harv: 10%
 			apc: 30%
 			jeep: 40%
@@ -198,6 +201,8 @@ Player:
 			pt: 10%
 		UnitLimits:
 			dog: 4
+			medi: 3
+			mech: 3
 			harv: 8
 		SquadSize: 40
 		SupportPowerDecision@spyplane:
@@ -299,12 +304,14 @@ Player:
 			stek: 1%
 			mslo: 1%
 		UnitsToBuild:
-			e1: 50%
-			e2: 10%
-			e3: 10%
-			e4: 8%
-			dog: 4%
-			shok: 8%
+			e1: 65%
+			e2: 25%
+			e3: 40%
+			e4: 15%
+			medi: 5%
+			mech: 5%
+			dog: 15%
+			shok: 15%
 			harv: 10%
 			apc: 30%
 			jeep: 40%
@@ -328,6 +335,8 @@ Player:
 			pt: 10%
 		UnitLimits:
 			dog: 4
+			medi: 4
+			mech: 4
 			harv: 8
 		SquadSize: 10
 		SupportPowerDecision@spyplane:

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -52,8 +52,8 @@ Player:
 			naobel: 3%
 		UnitsToBuild:
 			e1: 80%
-			e2: 8%
-			e3: 8%
+			e2: 25%
+			e3: 25%
 			cyborg: 15%
 			jumpjet: 15%
 			repair: 2%
@@ -70,4 +70,6 @@ Player:
 			stnk: 8%
 		UnitLimits:
 			harv: 12
+			medic: 3
+			repair: 3
 		SquadSize: 20


### PR DESCRIPTION
The percentages might sound lame but having the summary of the riflemen and rocket infantry above 100 will make sure no techlevel gets stuck - excluding the RA Naval AI, which doesn't even use infantry at all (notsure if it should be allowed to spam those two).

Fixes #11797.
