### PR TITLE
Fix Lua API returning wrong player info

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -39,18 +39,25 @@ namespace OpenRA.Mods.Common.Scripting
 			get
 			{
 				Game.Debug("The property `PlayerProperties.Race` is deprecated! Use `PlayerProperties.Faction` instead!");
-				return Player.PlayerReference.Faction;
+				return Player.Faction.InternalName;
 			}
 		}
 
 		[Desc("The player's faction.")]
-		public string Faction { get { return Player.PlayerReference.Faction; } }
+		public string Faction { get { return Player.Faction.InternalName; } }
 
 		[Desc("The player's spawnpoint ID.")]
 		public int Spawn { get { return Player.SpawnPoint; } }
 
 		[Desc("The player's team ID.")]
-		public int Team { get { return Player.PlayerReference.Team; } }
+		public int Team
+		{
+			get
+			{
+				var c = Player.World.LobbyInfo.Clients[Player.ClientIndex];
+				return c != null ? c.Team : 0;
+			}
+		}
 
 		[Desc("Returns true if the player is a bot.")]
 		public bool IsBot { get { return Player.IsBot; } }


### PR DESCRIPTION
The Lua API would return wrong information on player fields such as the team or faction when it was changed in the lobby. It referenced fields on the PlayerReference, which are pretty much read-only and don't get changed by the lobby.

![screenshot from 2016-08-11 20 21 51](https://cloud.githubusercontent.com/assets/4331210/17600038/1a007a94-6002-11e6-935a-1f92bbeb647b.png)

Fixes #11808.
