### PR TITLE
Fix CanBeViewedByPlayer query in HackyAI.GetVisibleActorsBelongingToPlayer

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -683,7 +683,7 @@ namespace OpenRA.Mods.Common.AI
 		IEnumerable<Actor> GetVisibleActorsBelongingToPlayer(Player owner)
 		{
 			foreach (var actor in GetActorsThatCanBeOrderedByPlayer(owner))
-				if (actor.CanBeViewedByPlayer(owner))
+				if (actor.CanBeViewedByPlayer(Player))
 					yield return actor;
 		}
 


### PR DESCRIPTION
I was checking the wrong player's visibility status.
