### PR TITLE
Ensure HackyAI tries to attack and capture as frequently as it should.

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -659,20 +659,19 @@ namespace OpenRA.Mods.Common.AI
 					s.Update();
 			}
 
-			if (--assignRolesTicks > 0)
-				return;
+			if (--assignRolesTicks <= 0)
+			{
+				assignRolesTicks = Info.AssignRolesInterval;
+				GiveOrdersToIdleHarvesters();
+				FindNewUnits(self);
+				FindAndDeployBackupMcv(self);
+			}
 
-			assignRolesTicks = Info.AssignRolesInterval;
-
-			GiveOrdersToIdleHarvesters();
-			FindNewUnits(self);
 			if (--minAttackForceDelayTicks <= 0)
 			{
 				minAttackForceDelayTicks = Info.MinimumAttackForceDelay;
 				CreateAttackForce();
 			}
-
-			FindAndDeployBackupMcv(self);
 
 			if (--minCaptureDelayTicks <= 0)
 			{


### PR DESCRIPTION
Returning early in AssignRolesToIdleUnits would skip ticking down the counters that trigger new attack and capture attempts. This means they would be attempted far less often than intended.

Fixes https://github.com/OpenRA/OpenRA/pull/11417#discussion_r72907137.
