### PR TITLE
Fix UpgradeOnDamage to apply if initial DamageState is valid

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -507,7 +507,7 @@
     <Compile Include="Traits\Upgrades\DisableOnUpgrade.cs" />
     <Compile Include="Traits\Upgrades\UpgradableTrait.cs" />
     <Compile Include="Traits\Upgrades\UpgradeActorsNear.cs" />
-    <Compile Include="Traits\Upgrades\UpgradeOnDamage.cs" />
+    <Compile Include="Traits\Upgrades\UpgradeOnDamageState.cs" />
     <Compile Include="Traits\Upgrades\UpgradeOnTerrain.cs" />
     <Compile Include="Traits\Upgrades\UpgradeManager.cs" />
     <Compile Include="Traits\Valued.cs" />

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnDamage.cs
@@ -44,14 +44,11 @@ namespace OpenRA.Mods.Common.Traits
 		public UpgradeOnDamage(Actor self, UpgradeOnDamageInfo info)
 		{
 			this.info = info;
-			um = self.TraitOrDefault<UpgradeManager>();
+			um = self.Trait<UpgradeManager>();
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
-			if (um == null)
-				return;
-
 			if (granted && info.GrantPermanently)
 				return;
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnDamageState.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeOnDamageState.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Applies an upgrade to the actor at specified damage states.")]
-	public class UpgradeOnDamageInfo : ITraitInfo, Requires<UpgradeManagerInfo>, Requires<HealthInfo>
+	public class UpgradeOnDamageStateInfo : ITraitInfo, Requires<UpgradeManagerInfo>, Requires<HealthInfo>
 	{
 		[UpgradeGrantedReference, FieldLoader.Require]
 		[Desc("The upgrades to grant.")]
@@ -32,17 +32,17 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Are upgrades irrevocable once the conditions have been met?")]
 		public readonly bool GrantPermanently = false;
 
-		public object Create(ActorInitializer init) { return new UpgradeOnDamage(init.Self, this); }
+		public object Create(ActorInitializer init) { return new UpgradeOnDamageState(init.Self, this); }
 	}
 
-	public class UpgradeOnDamage : INotifyDamageStateChanged, INotifyCreated
+	public class UpgradeOnDamageState : INotifyDamageStateChanged, INotifyCreated
 	{
-		readonly UpgradeOnDamageInfo info;
+		readonly UpgradeOnDamageStateInfo info;
 		readonly UpgradeManager um;
 		readonly Health health;
 		bool granted;
 
-		public UpgradeOnDamage(Actor self, UpgradeOnDamageInfo info)
+		public UpgradeOnDamageState(Actor self, UpgradeOnDamageStateInfo info)
 		{
 			this.info = info;
 			um = self.Trait<UpgradeManager>();

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -280,6 +280,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20160818)
+				{
+					if (depth == 1 && node.Key.StartsWith("UpgradeOnDamage"))
+					{
+						var parts = node.Key.Split('@');
+						node.Key = "UpgradeOnDamageState";
+						if (parts.Length > 1)
+							node.Key += "@" + parts[1];
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -397,7 +397,7 @@
 	WithInfantryBody:
 		AttackSequence: attack
 		IdleSequences: idle1,idle2
-	UpgradeOnDamage@CRITICAL:
+	UpgradeOnDamageState@CRITICAL:
 		Upgrades: criticalspeed
 		ValidDamageStates: Critical
 		GrantPermanently: true
@@ -476,10 +476,10 @@
 		Weapons: SmallDebris
 		Pieces: 3, 7
 		Range: 2c0, 5c0
-	UpgradeOnDamage@DAMAGED:
+	UpgradeOnDamageState@DAMAGED:
 		Upgrades: damagedspeed
 		ValidDamageStates: Heavy
-	UpgradeOnDamage@CRITICAL:
+	UpgradeOnDamageState@CRITICAL:
 		Upgrades: criticalspeed
 		ValidDamageStates: Critical
 	SpeedMultiplier@DAMAGED:


### PR DESCRIPTION
As pointed out by Nolt on IRC, on bleed upgrades don't work even if the initial `DamageState` is valid, until the actor's damage state changes.
However, modders might want to use the trait to apply upgrades while the actor is undamaged, and there might be maps with actors starting at valid damage states, too.

This PR makes the trait perform an additional check for a valid `DamageState` at creation.
