### PR TITLE
Fix 'make dependencies' choking on Open.NAT directory name

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -85,9 +85,9 @@ fi
 
 if [ ! -f Open.Nat.dll ]; then
 	echo "Fetching Open.Nat from NuGet"
-	get Open.Nat 2.1.0
-	cp ./Open.Nat/lib/net45/Open.Nat.dll .
-	rm -rf Open.Nat
+	get Open.NAT 2.1.0
+	cp ./Open.NAT/lib/net45/Open.Nat.dll .
+	rm -rf Open.NAT
 fi
 
 if [ ! -f FuzzyLogicLibrary.dll ]; then


### PR DESCRIPTION
The directory name appears to have changed in the package for 2.1.0.
