### PR TITLE
Add OS X build instructions to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,3 +72,12 @@ Gentoo
 * x11-misc/xdg-utils
 * gnome-extra/zenity
 * net-misc/curl
+
+OSX
+=====
+
+Use `make dependencies` to map the native libraries to your system.
+
+To compile OpenRA, run `make` from the command line.
+
+Run with `mono --debug OpenRA.Game.exe`.


### PR DESCRIPTION
This is resurrected from #11750, only with the commits squashed as requested.

The original PR already had two :+1:s, so I'm going to merge it right away. 
